### PR TITLE
[codex] add agent operations infrastructure

### DIFF
--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import Link from 'next/link'
+import type { ReactNode } from 'react'
+import { Activity, ArrowRight, Bot, CheckCircle2, Clock, DollarSign, XCircle } from 'lucide-react'
+import ProtectedRoute from '@/components/ProtectedRoute'
+import Breadcrumbs from '@/components/admin/Breadcrumbs'
+
+export default function AgentOperationsPage() {
+  return (
+    <ProtectedRoute requireAdmin>
+      <div className="min-h-screen bg-background text-foreground p-6 lg:p-8">
+        <div className="max-w-6xl mx-auto">
+          <Breadcrumbs items={[{ label: 'Admin Dashboard', href: '/admin' }, { label: 'Agent Operations' }]} />
+          <div className="mb-8">
+            <h1 className="text-3xl font-bold mb-1">Agent Operations</h1>
+            <p className="text-muted-foreground text-sm">
+              Shared control plane for Codex, n8n, Hermes, OpenCode, and manual agent work.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-5 mb-8">
+            <Link
+              href="/admin/agents/runs"
+              className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/30 p-5 hover:border-radiant-gold/60 transition-colors"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <div className="flex items-center gap-2 text-radiant-gold mb-2">
+                    <Activity size={20} />
+                    <h2 className="text-lg font-semibold">Run Console</h2>
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    View active and recent agent runs, current steps, runtime, costs, errors, and approvals.
+                  </p>
+                </div>
+                <ArrowRight size={20} className="text-muted-foreground shrink-0" />
+              </div>
+            </Link>
+
+            <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/30 p-5">
+              <div className="flex items-center gap-2 text-cyan-300 mb-2">
+                <Bot size={20} />
+                <h2 className="text-lg font-semibold">Runtime Strategy</h2>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                Codex and n8n are the primary backbone. Hermes is supported as a secondary runtime. OpenCode stays
+                deferred until traces prove safe.
+              </p>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            <SignalCard icon={<Clock size={18} />} label="Active states" value="Queued, running, approval" />
+            <SignalCard icon={<CheckCircle2 size={18} />} label="Completion" value="Completed, cancelled" />
+            <SignalCard icon={<XCircle size={18} />} label="Failure modes" value="Failed, stale" />
+            <SignalCard icon={<DollarSign size={18} />} label="Cost linkage" value="cost_events.agent_run_id" />
+          </div>
+        </div>
+      </div>
+    </ProtectedRoute>
+  )
+}
+
+function SignalCard({ icon, label, value }: { icon: ReactNode; label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-silicon-slate/60 bg-black/10 p-4">
+      <div className="flex items-center gap-2 text-muted-foreground mb-1">
+        {icon}
+        <span className="text-xs font-semibold uppercase tracking-wider">{label}</span>
+      </div>
+      <p className="text-sm font-medium">{value}</p>
+    </div>
+  )
+}

--- a/app/admin/agents/runs/[runId]/page.tsx
+++ b/app/admin/agents/runs/[runId]/page.tsx
@@ -1,0 +1,188 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import type { ReactNode } from 'react'
+import Link from 'next/link'
+import { AlertTriangle, ArrowLeft, Bot, DollarSign, FileText, RefreshCw } from 'lucide-react'
+import ProtectedRoute from '@/components/ProtectedRoute'
+import Breadcrumbs from '@/components/admin/Breadcrumbs'
+import { getCurrentSession } from '@/lib/auth'
+
+type AnyRow = Record<string, unknown>
+
+type RunDetail = {
+  run: AnyRow
+  steps: AnyRow[]
+  events: AnyRow[]
+  artifacts: AnyRow[]
+  approvals: AnyRow[]
+  handoffs: AnyRow[]
+  costs: AnyRow[]
+  cost_total: number
+}
+
+export default function AgentRunDetailPage({ params }: { params: { runId: string } }) {
+  return (
+    <ProtectedRoute requireAdmin>
+      <AgentRunDetailContent runId={params.runId} />
+    </ProtectedRoute>
+  )
+}
+
+function AgentRunDetailContent({ runId }: { runId: string }) {
+  const [data, setData] = useState<RunDetail | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchDetail = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Missing admin session')
+      const res = await fetch(`/api/admin/agents/runs/${runId}`, {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body.error || `HTTP ${res.status}`)
+      }
+      setData(await res.json())
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load run')
+      setData(null)
+    } finally {
+      setLoading(false)
+    }
+  }, [runId])
+
+  useEffect(() => {
+    fetchDetail()
+  }, [fetchDetail])
+
+  return (
+    <div className="min-h-screen bg-background text-foreground p-6 lg:p-8">
+      <div className="max-w-6xl mx-auto">
+        <Breadcrumbs items={[
+          { label: 'Admin Dashboard', href: '/admin' },
+          { label: 'Agent Operations', href: '/admin/agents' },
+          { label: 'Runs', href: '/admin/agents/runs' },
+          { label: 'Run Detail' },
+        ]} />
+        <Link href="/admin/agents/runs" className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground mb-5">
+          <ArrowLeft size={16} />
+          Back to runs
+        </Link>
+
+        {loading ? (
+          <div className="py-16 text-center text-muted-foreground">Loading run detail...</div>
+        ) : error ? (
+          <div className="rounded-lg border border-red-500/50 bg-red-500/10 p-5 text-red-300">
+            <div className="flex items-center gap-2 font-medium"><AlertTriangle size={18} /> Failed to load run</div>
+            <p className="text-sm mt-1">{error}</p>
+          </div>
+        ) : data ? (
+          <>
+            <div className="mb-6 flex items-start justify-between gap-4 flex-wrap">
+              <div>
+                <h1 className="text-3xl font-bold mb-1">{String(data.run.title ?? 'Agent run')}</h1>
+                <p className="text-sm text-muted-foreground">{String(data.run.kind ?? 'run')} · {String(data.run.id)}</p>
+              </div>
+              <button
+                onClick={fetchDetail}
+                className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 bg-silicon-slate/30 px-3 py-2 text-sm hover:border-radiant-gold/60"
+              >
+                <RefreshCw size={16} />
+                Refresh
+              </button>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+              <Metric icon={<Bot size={18} />} label="Runtime" value={String(data.run.runtime ?? '-')} />
+              <Metric icon={<RefreshCw size={18} />} label="Status" value={String(data.run.status ?? '-')} />
+              <Metric icon={<DollarSign size={18} />} label="Cost" value={`$${data.cost_total.toFixed(4)}`} />
+              <Metric icon={<FileText size={18} />} label="Artifacts" value={String(data.artifacts.length)} />
+            </div>
+
+            <section className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-5 mb-6">
+              <h2 className="text-lg font-semibold mb-4">Steps</h2>
+              <Timeline rows={data.steps} timeKey="started_at" titleKey="name" detailKey="output_summary" fallback="No steps recorded yet." />
+            </section>
+
+            <section className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-5 mb-6">
+              <h2 className="text-lg font-semibold mb-4">Events</h2>
+              <Timeline rows={data.events} timeKey="occurred_at" titleKey="event_type" detailKey="message" fallback="No events recorded yet." />
+            </section>
+
+            <section className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-5">
+              <h2 className="text-lg font-semibold mb-4">Artifacts & Approvals</h2>
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                <List rows={data.artifacts} titleKey="title" fallbackTitle="Artifact" detailKey="artifact_type" empty="No artifacts attached." />
+                <List rows={data.approvals} titleKey="approval_type" fallbackTitle="Approval" detailKey="status" empty="No approvals recorded." />
+              </div>
+            </section>
+          </>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function Metric({ icon, label, value }: { icon: ReactNode; label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-silicon-slate/60 bg-black/10 p-4">
+      <div className="flex items-center gap-2 text-muted-foreground text-xs font-semibold uppercase tracking-wider mb-1">
+        {icon}
+        {label}
+      </div>
+      <p className="font-semibold">{value}</p>
+    </div>
+  )
+}
+
+function Timeline({ rows, timeKey, titleKey, detailKey, fallback }: { rows: AnyRow[]; timeKey: string; titleKey: string; detailKey: string; fallback: string }) {
+  if (rows.length === 0) return <p className="text-sm text-muted-foreground">{fallback}</p>
+  return (
+    <div className="space-y-3">
+      {rows.map((row) => (
+        <div key={String(row.id)} className="rounded-lg border border-silicon-slate/50 bg-background/40 p-3">
+          <div className="flex items-center justify-between gap-3">
+            <p className="font-medium">{String(row[titleKey] ?? '-')}</p>
+            <p className="text-xs text-muted-foreground">{formatDate(asString(row[timeKey]))}</p>
+          </div>
+          {row[detailKey] ? <p className="text-sm text-muted-foreground mt-1">{String(row[detailKey])}</p> : null}
+          {row.status ? <p className="text-xs text-muted-foreground mt-1">Status: {String(row.status)}</p> : null}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function List({ rows, titleKey, fallbackTitle, detailKey, empty }: { rows: AnyRow[]; titleKey: string; fallbackTitle: string; detailKey: string; empty: string }) {
+  if (rows.length === 0) return <p className="text-sm text-muted-foreground">{empty}</p>
+  return (
+    <div className="space-y-2">
+      {rows.map((row) => (
+        <div key={String(row.id)} className="rounded-lg border border-silicon-slate/50 bg-background/40 p-3">
+          <p className="font-medium">{String(row[titleKey] || fallbackTitle)}</p>
+          <p className="text-sm text-muted-foreground">{String(row[detailKey] ?? '')}</p>
+          {row.url ? <a className="text-sm text-radiant-gold hover:underline" href={String(row.url)}>Open</a> : null}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function formatDate(value?: string) {
+  if (!value) return '-'
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(new Date(value))
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined
+}

--- a/app/admin/agents/runs/page.tsx
+++ b/app/admin/agents/runs/page.tsx
@@ -1,0 +1,192 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import Link from 'next/link'
+import { AlertTriangle, Bot, RefreshCw } from 'lucide-react'
+import ProtectedRoute from '@/components/ProtectedRoute'
+import Breadcrumbs from '@/components/admin/Breadcrumbs'
+import { getCurrentSession } from '@/lib/auth'
+import type { AgentRuntime, AgentRunStatus } from '@/lib/agent-run'
+
+type RunRow = {
+  id: string
+  agent_key: string | null
+  runtime: AgentRuntime
+  kind: string
+  title: string
+  status: AgentRunStatus
+  subject_type: string | null
+  subject_id: string | null
+  subject_label: string | null
+  current_step: string | null
+  started_at: string
+  completed_at: string | null
+  error_message: string | null
+  stale: boolean
+  cost_total: number
+  approvals: { pending: number; approved: number; rejected: number }
+}
+
+const RUNTIMES = ['all', 'codex', 'n8n', 'hermes', 'opencode', 'manual'] as const
+const STATUSES = ['all', 'queued', 'running', 'waiting_for_approval', 'completed', 'failed', 'cancelled', 'stale'] as const
+
+export default function AgentRunsPage() {
+  return (
+    <ProtectedRoute requireAdmin>
+      <AgentRunsContent />
+    </ProtectedRoute>
+  )
+}
+
+function AgentRunsContent() {
+  const [runs, setRuns] = useState<RunRow[]>([])
+  const [runtime, setRuntime] = useState<(typeof RUNTIMES)[number]>('all')
+  const [status, setStatus] = useState<(typeof STATUSES)[number]>('all')
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchRuns = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Missing admin session')
+      const qs = new URLSearchParams({ limit: '75' })
+      if (runtime !== 'all') qs.set('runtime', runtime)
+      if (status !== 'all') qs.set('status', status)
+      const res = await fetch(`/api/admin/agents/runs?${qs.toString()}`, {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body.error || `HTTP ${res.status}`)
+      }
+      const body = await res.json()
+      setRuns(body.runs || [])
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load runs')
+      setRuns([])
+    } finally {
+      setLoading(false)
+    }
+  }, [runtime, status])
+
+  useEffect(() => {
+    fetchRuns()
+  }, [fetchRuns])
+
+  return (
+    <div className="min-h-screen bg-background text-foreground p-6 lg:p-8">
+      <div className="max-w-7xl mx-auto">
+        <Breadcrumbs items={[
+          { label: 'Admin Dashboard', href: '/admin' },
+          { label: 'Agent Operations', href: '/admin/agents' },
+          { label: 'Runs' },
+        ]} />
+
+        <div className="mb-6 flex items-start justify-between gap-4 flex-wrap">
+          <div>
+            <h1 className="text-3xl font-bold mb-1">Agent Runs</h1>
+            <p className="text-muted-foreground text-sm">Live and historical traces across supported runtimes.</p>
+          </div>
+          <button
+            onClick={fetchRuns}
+            className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 bg-silicon-slate/30 px-3 py-2 text-sm hover:border-radiant-gold/60"
+          >
+            <RefreshCw size={16} />
+            Refresh
+          </button>
+        </div>
+
+        <div className="mb-5 flex gap-3 flex-wrap">
+          <select
+            value={runtime}
+            onChange={(e) => setRuntime(e.target.value as (typeof RUNTIMES)[number])}
+            className="rounded-lg border border-silicon-slate/70 bg-background px-3 py-2 text-sm"
+          >
+            {RUNTIMES.map((value) => (
+              <option key={value} value={value}>{value === 'all' ? 'All runtimes' : value}</option>
+            ))}
+          </select>
+          <select
+            value={status}
+            onChange={(e) => setStatus(e.target.value as (typeof STATUSES)[number])}
+            className="rounded-lg border border-silicon-slate/70 bg-background px-3 py-2 text-sm"
+          >
+            {STATUSES.map((value) => (
+              <option key={value} value={value}>{value === 'all' ? 'All statuses' : value}</option>
+            ))}
+          </select>
+        </div>
+
+        {loading ? (
+          <div className="py-16 text-center text-muted-foreground">Loading agent runs...</div>
+        ) : error ? (
+          <div className="rounded-lg border border-red-500/50 bg-red-500/10 p-5 text-red-300">
+            <div className="flex items-center gap-2 font-medium"><AlertTriangle size={18} /> Failed to load runs</div>
+            <p className="text-sm mt-1">{error}</p>
+          </div>
+        ) : runs.length === 0 ? (
+          <div className="rounded-lg border border-silicon-slate/60 bg-silicon-slate/20 p-8 text-center text-muted-foreground">
+            No agent runs match the current filters.
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-lg border border-silicon-slate/70">
+            <table className="w-full text-sm">
+              <thead className="bg-silicon-slate/40 text-muted-foreground">
+                <tr>
+                  <th className="text-left px-4 py-3 font-medium">Run</th>
+                  <th className="text-left px-4 py-3 font-medium">Runtime</th>
+                  <th className="text-left px-4 py-3 font-medium">Status</th>
+                  <th className="text-left px-4 py-3 font-medium">Current step</th>
+                  <th className="text-left px-4 py-3 font-medium">Subject</th>
+                  <th className="text-right px-4 py-3 font-medium">Cost</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-silicon-slate/60">
+                {runs.map((run) => (
+                  <tr key={run.id} className="hover:bg-silicon-slate/20">
+                    <td className="px-4 py-3">
+                      <Link href={`/admin/agents/runs/${run.id}`} className="font-medium hover:text-radiant-gold">
+                        {run.title}
+                      </Link>
+                      <div className="text-xs text-muted-foreground">{formatDate(run.started_at)} · {run.agent_key || run.kind}</div>
+                    </td>
+                    <td className="px-4 py-3">
+                      <span className="inline-flex items-center gap-1 rounded-full bg-black/20 px-2 py-1 text-xs">
+                        <Bot size={12} />
+                        {run.runtime}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3"><StatusBadge status={run.stale ? 'stale' : run.status} /></td>
+                    <td className="px-4 py-3 text-muted-foreground">{run.current_step || '-'}</td>
+                    <td className="px-4 py-3 text-muted-foreground">{run.subject_label || run.subject_id || '-'}</td>
+                    <td className="px-4 py-3 text-right tabular-nums">${run.cost_total.toFixed(4)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const cls =
+    status === 'completed' ? 'bg-green-500/15 text-green-300 border-green-500/30'
+      : status === 'failed' || status === 'stale' ? 'bg-red-500/15 text-red-300 border-red-500/30'
+        : status === 'waiting_for_approval' ? 'bg-yellow-500/15 text-yellow-300 border-yellow-500/30'
+          : 'bg-cyan-500/15 text-cyan-300 border-cyan-500/30'
+  return <span className={`rounded-full border px-2 py-1 text-xs ${cls}`}>{status}</span>
+}
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(new Date(value))
+}

--- a/app/api/admin/agents/runs/[runId]/approval/route.ts
+++ b/app/api/admin/agents/runs/[runId]/approval/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { supabaseAdmin } from '@/lib/supabase'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { AGENT_APPROVAL_STATUSES, type AgentApprovalStatus } from '@/lib/agent-run'
+
+export const dynamic = 'force-dynamic'
+
+function isApprovalStatus(value: string): value is AgentApprovalStatus {
+  return AGENT_APPROVAL_STATUSES.includes(value as AgentApprovalStatus)
+}
+
+/**
+ * POST /api/admin/agents/runs/:runId/approval
+ * Creates or records an approval checkpoint for a run.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { runId: string } },
+) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+  if (!supabaseAdmin) {
+    return NextResponse.json({ error: 'Database not available' }, { status: 500 })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as {
+    approval_type?: string
+    status?: string
+    requested_by_agent_key?: string | null
+    decision_notes?: string | null
+    metadata?: Record<string, unknown>
+  }
+
+  if (!body.approval_type) {
+    return NextResponse.json({ error: 'approval_type is required' }, { status: 400 })
+  }
+  const status = body.status ?? 'pending'
+  if (!isApprovalStatus(status)) {
+    return NextResponse.json({ error: 'Invalid approval status' }, { status: 400 })
+  }
+
+  const decided = status !== 'pending'
+  const { data, error } = await supabaseAdmin
+    .from('agent_approvals')
+    .insert({
+      run_id: params.runId,
+      approval_type: body.approval_type,
+      status,
+      requested_by_agent_key: body.requested_by_agent_key ?? null,
+      decided_by_user_id: decided ? auth.user.id : null,
+      decided_at: decided ? new Date().toISOString() : null,
+      decision_notes: body.decision_notes ?? null,
+      metadata: body.metadata ?? {},
+    })
+    .select('id')
+    .single()
+
+  if (error || !data?.id) {
+    console.error('[agent-approval] insert failed:', error)
+    return NextResponse.json({ error: 'Failed to record approval' }, { status: 500 })
+  }
+
+  await supabaseAdmin.from('agent_run_events').insert({
+    run_id: params.runId,
+    event_type: 'approval_recorded',
+    severity: status === 'rejected' ? 'warning' : 'info',
+    message: `${body.approval_type}: ${status}`,
+    metadata: { approval_id: data.id, status },
+  })
+
+  return NextResponse.json({ ok: true, approval_id: data.id })
+}

--- a/app/api/admin/agents/runs/[runId]/events/route.ts
+++ b/app/api/admin/agents/runs/[runId]/events/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { AGENT_EVENT_SEVERITIES, recordAgentEvent, type AgentEventSeverity } from '@/lib/agent-run'
+
+export const dynamic = 'force-dynamic'
+
+function isSeverity(value: string): value is AgentEventSeverity {
+  return AGENT_EVENT_SEVERITIES.includes(value as AgentEventSeverity)
+}
+
+/**
+ * POST /api/admin/agents/runs/:runId/events
+ * Writes an audit event for a run. Used by admin tools and future n8n callbacks.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { runId: string } },
+) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as {
+    event_type?: string
+    severity?: string
+    message?: string
+    metadata?: Record<string, unknown>
+    idempotency_key?: string
+  }
+
+  if (!body.event_type) {
+    return NextResponse.json({ error: 'event_type is required' }, { status: 400 })
+  }
+  if (body.severity && !isSeverity(body.severity)) {
+    return NextResponse.json({ error: 'Invalid severity' }, { status: 400 })
+  }
+
+  try {
+    const result = await recordAgentEvent({
+      runId: params.runId,
+      eventType: body.event_type,
+      severity: body.severity as AgentEventSeverity | undefined,
+      message: body.message ?? null,
+      metadata: body.metadata ?? {},
+      idempotencyKey: body.idempotency_key ?? null,
+    })
+
+    return NextResponse.json({ ok: true, event_id: result?.id ?? null })
+  } catch (err) {
+    console.error('[agent-events] write failed:', err)
+    return NextResponse.json({ error: 'Failed to write event' }, { status: 500 })
+  }
+}

--- a/app/api/admin/agents/runs/[runId]/route.ts
+++ b/app/api/admin/agents/runs/[runId]/route.ts
@@ -1,0 +1,145 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { supabaseAdmin } from '@/lib/supabase'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { AGENT_RUN_STATUSES, type AgentRunStatus } from '@/lib/agent-run'
+
+export const dynamic = 'force-dynamic'
+
+type CostRow = { amount: number | string | null }
+
+function isStatus(value: string): value is AgentRunStatus {
+  return AGENT_RUN_STATUSES.includes(value as AgentRunStatus)
+}
+
+/**
+ * GET /api/admin/agents/runs/:runId
+ * Returns one run with timeline detail, artifacts, approvals, handoffs, and costs.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { runId: string } },
+) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+  if (!supabaseAdmin) {
+    return NextResponse.json({ error: 'Database not available' }, { status: 500 })
+  }
+
+  const { data: run, error } = await supabaseAdmin
+    .from('agent_runs')
+    .select('*')
+    .eq('id', params.runId)
+    .single()
+
+  if (error || !run) {
+    return NextResponse.json({ error: 'Run not found' }, { status: 404 })
+  }
+
+  const [steps, events, artifacts, handoffs, approvals, costs] = await Promise.all([
+    supabaseAdmin
+      .from('agent_run_steps')
+      .select('*')
+      .eq('run_id', params.runId)
+      .order('started_at', { ascending: true }),
+    supabaseAdmin
+      .from('agent_run_events')
+      .select('*')
+      .eq('run_id', params.runId)
+      .order('occurred_at', { ascending: true }),
+    supabaseAdmin
+      .from('agent_run_artifacts')
+      .select('*')
+      .eq('run_id', params.runId)
+      .order('created_at', { ascending: false }),
+    supabaseAdmin
+      .from('agent_handoffs')
+      .select('*')
+      .eq('run_id', params.runId)
+      .order('created_at', { ascending: true }),
+    supabaseAdmin
+      .from('agent_approvals')
+      .select('*')
+      .eq('run_id', params.runId)
+      .order('requested_at', { ascending: true }),
+    supabaseAdmin
+      .from('cost_events')
+      .select('*')
+      .eq('agent_run_id', params.runId)
+      .order('occurred_at', { ascending: false }),
+  ])
+
+  const costTotal = ((costs.data || []) as CostRow[]).reduce(
+    (sum: number, row: CostRow) => sum + Number(row.amount ?? 0),
+    0,
+  )
+
+  return NextResponse.json({
+    run,
+    steps: steps.data || [],
+    events: events.data || [],
+    artifacts: artifacts.data || [],
+    handoffs: handoffs.data || [],
+    approvals: approvals.data || [],
+    costs: costs.data || [],
+    cost_total: Number(costTotal.toFixed(4)),
+  })
+}
+
+/**
+ * PATCH /api/admin/agents/runs/:runId
+ * Updates run state for admin controls like cancel, stale, or mark failed.
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { runId: string } },
+) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+  if (!supabaseAdmin) {
+    return NextResponse.json({ error: 'Database not available' }, { status: 500 })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as {
+    status?: string
+    error_message?: string | null
+    current_step?: string | null
+    outcome?: Record<string, unknown>
+  }
+
+  if (!body.status || !isStatus(body.status)) {
+    return NextResponse.json({ error: 'Valid status is required' }, { status: 400 })
+  }
+
+  const terminal = ['completed', 'failed', 'cancelled', 'stale'].includes(body.status)
+  const { data, error } = await supabaseAdmin
+    .from('agent_runs')
+    .update({
+      status: body.status,
+      error_message: body.error_message ?? null,
+      current_step: body.current_step ?? body.status,
+      outcome: body.outcome ?? {},
+      completed_at: terminal ? new Date().toISOString() : null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', params.runId)
+    .select('id')
+    .single()
+
+  if (error || !data) {
+    return NextResponse.json({ error: 'Failed to update run' }, { status: 500 })
+  }
+
+  await supabaseAdmin.from('agent_run_events').insert({
+    run_id: params.runId,
+    event_type: 'run_status_updated',
+    severity: body.status === 'failed' ? 'error' : 'info',
+    message: body.error_message ?? body.status,
+    metadata: { status: body.status },
+  })
+
+  return NextResponse.json({ ok: true, run_id: params.runId })
+}

--- a/app/api/admin/agents/runs/route.ts
+++ b/app/api/admin/agents/runs/route.ts
@@ -1,0 +1,130 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { supabaseAdmin } from '@/lib/supabase'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { AGENT_RUNTIMES, AGENT_RUN_STATUSES, type AgentRuntime, type AgentRunStatus } from '@/lib/agent-run'
+
+export const dynamic = 'force-dynamic'
+
+const STALE_THRESHOLD_MS = 30 * 60 * 1000
+
+type AgentRunListRow = {
+  id: string
+  agent_key: string | null
+  runtime: string
+  kind: string
+  title: string
+  status: string
+  subject_type: string | null
+  subject_id: string | null
+  subject_label: string | null
+  current_step: string | null
+  trigger_source: string | null
+  started_at: string
+  completed_at: string | null
+  stale_after: string | null
+  error_message: string | null
+  metadata: Record<string, unknown> | null
+}
+
+function isRuntime(value: string): value is AgentRuntime {
+  return AGENT_RUNTIMES.includes(value as AgentRuntime)
+}
+
+function isStatus(value: string): value is AgentRunStatus {
+  return AGENT_RUN_STATUSES.includes(value as AgentRunStatus)
+}
+
+/**
+ * GET /api/admin/agents/runs
+ * Lists recent agent runs with cost and approval summaries.
+ */
+export async function GET(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+  if (!supabaseAdmin) {
+    return NextResponse.json({ error: 'Database not available' }, { status: 500 })
+  }
+
+  const { searchParams } = new URL(request.url)
+  const runtime = searchParams.get('runtime')
+  const status = searchParams.get('status')
+  const activeOnly = searchParams.get('active') === 'true'
+  const limit = Math.min(parseInt(searchParams.get('limit') || '50', 10), 100)
+
+  if (runtime && runtime !== 'all' && !isRuntime(runtime)) {
+    return NextResponse.json({ error: 'Invalid runtime filter' }, { status: 400 })
+  }
+  if (status && status !== 'all' && !isStatus(status)) {
+    return NextResponse.json({ error: 'Invalid status filter' }, { status: 400 })
+  }
+
+  let query = supabaseAdmin
+    .from('agent_runs')
+    .select(
+      'id, agent_key, runtime, kind, title, status, subject_type, subject_id, subject_label, current_step, trigger_source, started_at, completed_at, stale_after, error_message, metadata',
+    )
+    .order('started_at', { ascending: false })
+    .limit(limit)
+
+  if (runtime && runtime !== 'all') query = query.eq('runtime', runtime)
+  if (status && status !== 'all') query = query.eq('status', status)
+  if (activeOnly) query = query.in('status', ['queued', 'running', 'waiting_for_approval'])
+
+  const { data: runs, error } = await query
+  if (error) {
+    console.error('[agent-runs] list failed:', error)
+    return NextResponse.json({ error: 'Failed to fetch agent runs' }, { status: 500 })
+  }
+
+  const typedRuns = (runs || []) as AgentRunListRow[]
+  const runIds = typedRuns.map((run) => run.id)
+  const [costsRes, approvalsRes] = runIds.length
+    ? await Promise.all([
+        supabaseAdmin
+          .from('cost_events')
+          .select('agent_run_id, amount')
+          .in('agent_run_id', runIds),
+        supabaseAdmin
+          .from('agent_approvals')
+          .select('run_id, status')
+          .in('run_id', runIds),
+      ])
+    : [{ data: [] }, { data: [] }]
+
+  const costByRun = new Map<string, number>()
+  for (const row of costsRes.data || []) {
+    const runId = row.agent_run_id as string | null
+    if (!runId) continue
+    costByRun.set(runId, (costByRun.get(runId) ?? 0) + Number(row.amount ?? 0))
+  }
+
+  const approvalsByRun = new Map<string, { pending: number; approved: number; rejected: number }>()
+  for (const row of approvalsRes.data || []) {
+    const runId = row.run_id as string
+    const summary = approvalsByRun.get(runId) ?? { pending: 0, approved: 0, rejected: 0 }
+    if (row.status === 'pending') summary.pending += 1
+    if (row.status === 'approved') summary.approved += 1
+    if (row.status === 'rejected') summary.rejected += 1
+    approvalsByRun.set(runId, summary)
+  }
+
+  const now = Date.now()
+  const enriched = typedRuns.map((run) => {
+    const staleAfter = run.stale_after ? new Date(run.stale_after as string).getTime() : null
+    const stale =
+      run.status === 'running' &&
+      ((staleAfter != null && now > staleAfter) ||
+        now - new Date(run.started_at as string).getTime() > STALE_THRESHOLD_MS)
+
+    return {
+      ...run,
+      stale,
+      cost_total: Number((costByRun.get(run.id) ?? 0).toFixed(4)),
+      approvals: approvalsByRun.get(run.id) ?? { pending: 0, approved: 0, rejected: 0 },
+    }
+  })
+
+  return NextResponse.json({ runs: enriched })
+}

--- a/app/api/admin/cost-events/ingest/route.ts
+++ b/app/api/admin/cost-events/ingest/route.ts
@@ -35,6 +35,7 @@ interface IngestCostEvent {
   currency?: string
   reference_type?: string
   reference_id?: string
+  agent_run_id?: string
   metadata?: Record<string, unknown>
 }
 
@@ -82,6 +83,7 @@ export async function POST(request: NextRequest) {
           currency: item.currency || 'usd',
           reference_type: item.reference_type || null,
           reference_id: item.reference_id || null,
+          agent_run_id: item.agent_run_id || null,
           metadata: item.metadata || {},
         })
 

--- a/app/api/admin/cost-events/route.ts
+++ b/app/api/admin/cost-events/route.ts
@@ -87,7 +87,7 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json()
-    const { occurred_at, source, amount, currency, reference_type, reference_id, metadata } = body
+    const { occurred_at, source, amount, currency, reference_type, reference_id, agent_run_id, metadata } = body
 
     if (!occurred_at || !source || amount == null || amount === '') {
       return NextResponse.json(
@@ -117,6 +117,7 @@ export async function POST(request: NextRequest) {
         currency: currency || 'usd',
         reference_type: reference_type || null,
         reference_id: reference_id || null,
+        agent_run_id: agent_run_id || null,
         metadata: metadata || {},
       })
       .select()

--- a/app/api/admin/outreach/leads/[id]/generate/route.ts
+++ b/app/api/admin/outreach/leads/[id]/generate/route.ts
@@ -15,6 +15,13 @@ import {
   type OutreachChannel,
 } from '@/lib/constants/prompt-keys'
 import { notifyOutreachDraftReady } from '@/lib/slack-outreach-notification'
+import {
+  endAgentRun,
+  markAgentRunFailed,
+  recordAgentEvent,
+  recordAgentStep,
+  startAgentRun,
+} from '@/lib/agent-run'
 
 export const dynamic = 'force-dynamic'
 /**
@@ -139,6 +146,39 @@ export async function POST(
       : null
 
   const triggeredAtIso = new Date().toISOString()
+  const agentRun = await startAgentRun({
+    agentKey: 'manual-admin',
+    runtime: 'manual',
+    kind: 'outreach_generation',
+    title: `Generate ${channel} outreach draft`,
+    subject: {
+      type: 'contact_submission',
+      id: contactId,
+      label: lead.name || lead.email || `Lead ${contactId}`,
+    },
+    triggerSource: 'admin:outreach_generate',
+    triggeredByUserId: auth.user.id,
+    currentStep: 'Lead validated',
+    metadata: {
+      channel,
+      template_key: templateKey ?? null,
+      sequence_step: sequenceStep,
+      force,
+      meeting_record_id: meetingRecordId,
+    },
+  })
+  const agentRunId = agentRun.id
+
+  await recordAgentStep({
+    runId: agentRunId,
+    stepKey: 'lead_validated',
+    name: 'Lead validated',
+    status: 'completed',
+    outputSummary: `Lead ${contactId} is eligible for outreach generation.`,
+    metadata: { contact_id: contactId, channel },
+    idempotencyKey: `${agentRunId}:lead_validated`,
+  }).catch((err) => console.warn('[generate] agent step failed', err))
+
   // Mark pending so the Outreach panel + Realtime show "running" copy while we
   // synchronously generate. The success/failed flip happens at the end of the
   // try/catch — the row is single-writer per request.
@@ -160,6 +200,7 @@ export async function POST(
             force,
             meetingRecordId,
             templateKey: templateKey as LinkedInTemplateKey | undefined,
+            agentRunId,
           })
         : await generateOutreachDraftInApp({
             contactId,
@@ -167,6 +208,7 @@ export async function POST(
             force,
             meetingRecordId,
             templateKey: templateKey as EmailTemplateKey | undefined,
+            agentRunId,
           })
 
     if (result.outcome === 'existing') {
@@ -185,6 +227,19 @@ export async function POST(
         .eq('source_system', 'outreach_queue')
         .eq('source_id', result.queueId)
         .maybeSingle()
+
+      await endAgentRun({
+        runId: agentRunId,
+        status: 'completed',
+        currentStep: 'Existing draft returned',
+        outcome: {
+          outcome: 'existing',
+          queue_id: result.queueId,
+          channel: result.channel,
+          template_key: result.templateKey,
+        },
+      }).catch((err) => console.warn('[generate] end agent run failed', err))
+
       const emailMessageId = (emRow?.id as string) ?? null
       const openDraftUrl = emailMessageId
         ? `/admin/email-messages/${emailMessageId}`
@@ -196,6 +251,7 @@ export async function POST(
         queueId: result.queueId,
         templateKey: result.templateKey,
         channel: result.channel,
+        agentRunId,
         emailMessageId,
         openDraftUrl,
       })
@@ -210,6 +266,12 @@ export async function POST(
           last_n8n_outreach_template_key: n8nSnapshot.last_n8n_outreach_template_key,
         })
         .eq('id', contactId)
+      await endAgentRun({
+        runId: agentRunId,
+        status: 'cancelled',
+        currentStep: 'Skipped existing task draft',
+        outcome: { outcome: 'skipped', reason: 'draft_exists' },
+      }).catch((err) => console.warn('[generate] end agent run failed', err))
       return NextResponse.json(
         {
           error:
@@ -217,6 +279,7 @@ export async function POST(
           outcome: 'skipped',
           reason: 'draft_exists',
           triggered: false,
+          agentRunId,
         },
         { status: 409 },
       )
@@ -242,12 +305,32 @@ export async function POST(
       }).catch((err) => {
         console.warn('[generate] notifyOutreachDraftReady failed', err)
       })
+      await recordAgentEvent({
+        runId: agentRunId,
+        eventType: 'notification_dispatched',
+        severity: 'info',
+        message: 'Slack draft-ready notification queued.',
+        metadata: { queue_id: result.id, channel },
+        idempotencyKey: `${agentRunId}:notification_dispatched`,
+      }).catch((err) => console.warn('[generate] agent event failed', err))
     }
 
     // Only `created` reaches here (`existing` and `skipped` return above).
     if (result.outcome !== 'created') {
       return NextResponse.json({ error: 'Unexpected generation outcome' }, { status: 500 })
     }
+
+    await endAgentRun({
+      runId: agentRunId,
+      status: 'completed',
+      currentStep: 'Outreach draft ready',
+      outcome: {
+        outcome: result.outcome,
+        queue_id: result.id,
+        channel,
+        template_key: templateKey ?? null,
+      },
+    }).catch((err) => console.warn('[generate] end agent run failed', err))
 
     return NextResponse.json({
       // `triggered` preserves the existing client contract (`useOutreachGeneration`
@@ -257,12 +340,28 @@ export async function POST(
       queueCountImmediate: 1,
       outcome: result.outcome,
       channel,
+      agentRunId,
       ...(templateKey ? { templateKey } : {}),
       id: result.id,
       subject: result.subject,
     })
   } catch (err) {
     console.error('[generate] in-app generation failed:', err)
+    const message = err instanceof Error ? err.message : String(err)
+    await recordAgentStep({
+      runId: agentRunId,
+      stepKey: 'generation_failed',
+      name: 'Generation failed',
+      status: 'failed',
+      outputSummary: message,
+      metadata: { channel, template_key: templateKey ?? null },
+      idempotencyKey: `${agentRunId}:generation_failed`,
+    }).catch((stepErr) => console.warn('[generate] agent failure step failed', stepErr))
+    await markAgentRunFailed(agentRunId, message, {
+      channel,
+      template_key: templateKey ?? null,
+      contact_id: contactId,
+    }).catch((runErr) => console.warn('[generate] mark agent run failed', runErr))
     await sb
       .from('contact_submissions')
       .update({
@@ -270,7 +369,6 @@ export async function POST(
       })
       .eq('id', contactId)
 
-    const message = err instanceof Error ? err.message : String(err)
     if (message === 'Meeting not found for this lead') {
       return NextResponse.json(
         { error: 'The selected meeting was not found for this lead.' },

--- a/components/admin/AdminSidebar.tsx
+++ b/components/admin/AdminSidebar.tsx
@@ -44,6 +44,7 @@ import {
   Mail,
   Inbox,
   UserCheck,
+  Bot,
 } from 'lucide-react'
 import { ADMIN_NAV, isNavItemActive, isContentExpanded, isChatEvalExpanded } from '@/lib/admin-nav'
 import { useState, useEffect } from 'react'
@@ -79,6 +80,7 @@ const NAV_ITEM_ICONS: Record<string, LucideIcon> = {
   '/admin/chat-eval/queue': MessageSquare,
   '/admin/analytics': BarChart3,
   '/admin/cost-revenue': DollarSign,
+  '/admin/agents': Bot,
   '/admin/client-experience': UserCheck,
   '/admin/testing': FlaskConical,
   '/admin/content': FolderOpen,

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -1,0 +1,57 @@
+# Agent Operations Rollout
+
+The Portfolio admin remains the control plane. Codex and n8n stay as the primary operating backbone, while Hermes is added as a secondary runtime after shared run tracing is available. OpenCode/OpenClaw are deferred until their work can be observed, audited, and rolled back through the same trace model.
+
+## Runtime Model
+
+Supported runtimes:
+
+- `codex` — primary engineering and repo-aware operator.
+- `n8n` — production workflow runtime for webhooks, schedules, integrations, and automation.
+- `hermes` — secondary local runtime for critique, research, gateway, and parity experiments.
+- `opencode` — deferred coding worker runtime for isolated review and worktree experiments.
+- `manual` — human-triggered admin actions and approvals.
+
+Supported run statuses:
+
+- `queued`
+- `running`
+- `waiting_for_approval`
+- `completed`
+- `failed`
+- `cancelled`
+- `stale`
+
+## Control Plane Shape
+
+The first version adds an Agent Operations console under `/admin/agents`. It reads generic agent trace tables instead of building a custom dashboard for every workflow. Existing workflow-specific pages remain live during the rollout.
+
+The shared trace tables are:
+
+- `agent_registry`
+- `agent_runs`
+- `agent_run_steps`
+- `agent_run_events`
+- `agent_run_artifacts`
+- `agent_handoffs`
+- `agent_approvals`
+
+Costs are linked through `cost_events.agent_run_id`.
+
+## Rollout Sequence
+
+1. Add the shared schema, helper library, and admin APIs.
+2. Add `/admin/agents`, `/admin/agents/runs`, and `/admin/agents/runs/[runId]`.
+3. Instrument outreach generation as the first production slice.
+4. Pass `agent_run_id` into app-triggered n8n payloads as workflows are updated.
+5. Register Hermes as a supported runtime for low-risk local tasks.
+6. Add approval gates for publishing, outbound email, production data writes, config changes, and public content derived from private material.
+7. Evaluate OpenCode/OpenClaw only after the shared trace layer can observe one test run.
+8. Gradually migrate older workflow run tables into the shared model where it reduces duplication.
+
+## Safety Rules
+
+- New agent work should create an `agent_run` before doing meaningful work.
+- External side effects should be represented by either an `agent_run_event`, an `agent_run_artifact`, or an `agent_approval`.
+- Runtime-specific pages may keep their existing tables, but new generic visibility should flow through `/admin/agents`.
+- Hermes and OpenCode should not mutate production data in v1 without a pending approval checkpoint.

--- a/lib/admin-nav.ts
+++ b/lib/admin-nav.ts
@@ -63,6 +63,7 @@ export const ADMIN_NAV: { dashboard: AdminNavItem; categories: AdminNavCategory[
         { label: 'Chat Eval', href: '/admin/chat-eval' },
         { label: 'Analytics', href: '/admin/analytics' },
         { label: 'Cost & Revenue', href: '/admin/cost-revenue' },
+        { label: 'Agent Operations', href: '/admin/agents' },
         { label: 'Client Experience', href: '/admin/client-experience' },
         { label: 'E2E Testing', href: '/admin/testing' },
       ],

--- a/lib/agent-run.test.ts
+++ b/lib/agent-run.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  fromMock: vi.fn(),
+  maybeSingleQueue: [] as Array<{ data: unknown; error: unknown }>,
+  singleQueue: [] as Array<{ data: unknown; error: unknown }>,
+  insertMock: vi.fn(),
+  updateMock: vi.fn(),
+  eqMock: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.fromMock,
+  },
+}))
+
+import {
+  attachAgentArtifact,
+  endAgentRun,
+  markAgentRunFailed,
+  recordAgentEvent,
+  recordAgentStep,
+  startAgentRun,
+} from './agent-run'
+
+function chain() {
+  const api = {
+    select: vi.fn(() => api),
+    eq: mocks.eqMock.mockImplementation(() => api),
+    maybeSingle: vi.fn(() => Promise.resolve(mocks.maybeSingleQueue.shift() ?? { data: null, error: null })),
+    single: vi.fn(() => Promise.resolve(mocks.singleQueue.shift() ?? { data: { id: 'new-id' }, error: null })),
+    insert: mocks.insertMock.mockImplementation(() => api),
+    update: mocks.updateMock.mockImplementation(() => api),
+  }
+  return api
+}
+
+describe('agent-run helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.maybeSingleQueue = []
+    mocks.singleQueue = []
+    mocks.fromMock.mockImplementation(() => chain())
+  })
+
+  it('starts a run and writes a start event', async () => {
+    mocks.maybeSingleQueue.push(
+      { data: null, error: null },
+      { data: { id: 'registry-1' }, error: null },
+    )
+    mocks.singleQueue.push(
+      { data: { id: 'run-1' }, error: null },
+      { data: { id: 'event-1' }, error: null },
+    )
+
+    const result = await startAgentRun({
+      agentKey: 'manual-admin',
+      runtime: 'manual',
+      kind: 'outreach_generation',
+      title: 'Generate outreach draft',
+      subject: { type: 'contact_submission', id: 42, label: 'Ada' },
+      idempotencyKey: 'idem-1',
+    })
+
+    expect(result).toEqual({ id: 'run-1' })
+    expect(mocks.fromMock).toHaveBeenCalledWith('agent_runs')
+    expect(mocks.insertMock).toHaveBeenCalledWith(expect.objectContaining({
+      runtime: 'manual',
+      subject_id: '42',
+      idempotency_key: 'idem-1',
+    }))
+    expect(mocks.fromMock).toHaveBeenCalledWith('agent_run_events')
+  })
+
+  it('returns an existing run for an idempotency key', async () => {
+    mocks.maybeSingleQueue.push({ data: { id: 'existing-run' }, error: null })
+
+    const result = await startAgentRun({
+      runtime: 'manual',
+      kind: 'outreach_generation',
+      title: 'Generate outreach draft',
+      idempotencyKey: 'idem-existing',
+    })
+
+    expect(result).toEqual({ id: 'existing-run' })
+    expect(mocks.insertMock).not.toHaveBeenCalled()
+  })
+
+  it('records a completed step and keeps the run running', async () => {
+    mocks.singleQueue.push({ data: { id: 'step-1' }, error: null })
+
+    const result = await recordAgentStep({
+      runId: 'run-1',
+      name: 'LLM draft generated',
+      status: 'completed',
+      idempotencyKey: 'step-idem',
+    })
+
+    expect(result).toEqual({ id: 'step-1' })
+    expect(mocks.fromMock).toHaveBeenCalledWith('agent_run_steps')
+    expect(mocks.updateMock).toHaveBeenCalledWith(expect.objectContaining({
+      current_step: 'LLM draft generated',
+      status: 'running',
+    }))
+  })
+
+  it('records events and artifacts', async () => {
+    mocks.singleQueue.push(
+      { data: { id: 'event-1' }, error: null },
+      { data: { id: 'artifact-1' }, error: null },
+    )
+
+    await expect(recordAgentEvent({ runId: 'run-1', eventType: 'note' })).resolves.toEqual({ id: 'event-1' })
+    await expect(attachAgentArtifact({
+      runId: 'run-1',
+      artifactType: 'outreach_draft',
+      refType: 'outreach_queue',
+      refId: 'queue-1',
+    })).resolves.toEqual({ id: 'artifact-1' })
+  })
+
+  it('ends and fails runs', async () => {
+    mocks.singleQueue.push({ data: { id: 'event-1' }, error: null })
+    await expect(endAgentRun({ runId: 'run-1', status: 'completed' })).resolves.toBeUndefined()
+    expect(mocks.updateMock).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'completed',
+      current_step: 'completed',
+    }))
+
+    mocks.singleQueue.push({ data: { id: 'event-2' }, error: null })
+    await expect(markAgentRunFailed('run-2', 'failed')).resolves.toBeUndefined()
+    expect(mocks.updateMock).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'failed',
+      error_message: 'failed',
+    }))
+  })
+})

--- a/lib/agent-run.ts
+++ b/lib/agent-run.ts
@@ -1,0 +1,321 @@
+import { supabaseAdmin } from '@/lib/supabase'
+
+export const AGENT_RUNTIMES = ['codex', 'n8n', 'hermes', 'opencode', 'manual'] as const
+export const AGENT_RUN_STATUSES = [
+  'queued',
+  'running',
+  'waiting_for_approval',
+  'completed',
+  'failed',
+  'cancelled',
+  'stale',
+] as const
+export const AGENT_EVENT_SEVERITIES = ['debug', 'info', 'warning', 'error'] as const
+export const AGENT_APPROVAL_STATUSES = ['pending', 'approved', 'rejected', 'cancelled'] as const
+
+export type AgentRuntime = (typeof AGENT_RUNTIMES)[number]
+export type AgentRunStatus = (typeof AGENT_RUN_STATUSES)[number]
+export type AgentEventSeverity = (typeof AGENT_EVENT_SEVERITIES)[number]
+export type AgentApprovalStatus = (typeof AGENT_APPROVAL_STATUSES)[number]
+
+export interface AgentSubjectRef {
+  type?: string | null
+  id?: string | number | null
+  label?: string | null
+}
+
+export interface StartAgentRunInput {
+  agentKey?: string | null
+  runtime: AgentRuntime
+  kind: string
+  title: string
+  status?: AgentRunStatus
+  subject?: AgentSubjectRef
+  triggerSource?: string | null
+  triggeredByUserId?: string | null
+  staleAfter?: string | null
+  currentStep?: string | null
+  metadata?: Record<string, unknown>
+  idempotencyKey?: string | null
+}
+
+export interface RecordAgentStepInput {
+  runId: string
+  stepKey?: string | null
+  name: string
+  status?: AgentRunStatus
+  startedAt?: string
+  completedAt?: string | null
+  latencyMs?: number | null
+  tokensIn?: number | null
+  tokensOut?: number | null
+  costUsd?: number | null
+  inputSummary?: string | null
+  outputSummary?: string | null
+  reasoning?: string | null
+  metadata?: Record<string, unknown>
+  idempotencyKey?: string | null
+}
+
+export interface RecordAgentEventInput {
+  runId: string
+  eventType: string
+  severity?: AgentEventSeverity
+  message?: string | null
+  metadata?: Record<string, unknown>
+  occurredAt?: string
+  idempotencyKey?: string | null
+}
+
+export interface EndAgentRunInput {
+  runId: string
+  status?: Extract<AgentRunStatus, 'completed' | 'failed' | 'cancelled' | 'stale'>
+  outcome?: Record<string, unknown>
+  errorMessage?: string | null
+  currentStep?: string | null
+}
+
+export interface AttachAgentArtifactInput {
+  runId: string
+  artifactType: string
+  title?: string | null
+  refType?: string | null
+  refId?: string | number | null
+  url?: string | null
+  metadata?: Record<string, unknown>
+  idempotencyKey?: string | null
+}
+
+function assertRuntime(runtime: string): asserts runtime is AgentRuntime {
+  if (!AGENT_RUNTIMES.includes(runtime as AgentRuntime)) {
+    throw new Error(`Invalid agent runtime: ${runtime}`)
+  }
+}
+
+function assertStatus(status: string): asserts status is AgentRunStatus {
+  if (!AGENT_RUN_STATUSES.includes(status as AgentRunStatus)) {
+    throw new Error(`Invalid agent run status: ${status}`)
+  }
+}
+
+function db() {
+  if (!supabaseAdmin) {
+    throw new Error('Database not available')
+  }
+  return supabaseAdmin
+}
+
+async function findRunByIdempotencyKey(idempotencyKey?: string | null): Promise<{ id: string } | null> {
+  if (!idempotencyKey) return null
+
+  const { data, error } = await db()
+    .from('agent_runs')
+    .select('id')
+    .eq('idempotency_key', idempotencyKey)
+    .maybeSingle()
+
+  if (error) {
+    throw new Error(`Failed to read agent run: ${error.message}`)
+  }
+  return data as { id: string } | null
+}
+
+export async function startAgentRun(input: StartAgentRunInput): Promise<{ id: string }> {
+  assertRuntime(input.runtime)
+  const status = input.status ?? 'running'
+  assertStatus(status)
+
+  const existing = await findRunByIdempotencyKey(input.idempotencyKey)
+  if (existing) return existing
+
+  const { data: registry } = input.agentKey
+    ? await db()
+        .from('agent_registry')
+        .select('id')
+        .eq('key', input.agentKey)
+        .maybeSingle()
+    : { data: null }
+
+  const { data, error } = await db()
+    .from('agent_runs')
+    .insert({
+      agent_registry_id: (registry as { id?: string } | null)?.id ?? null,
+      agent_key: input.agentKey ?? null,
+      runtime: input.runtime,
+      kind: input.kind,
+      title: input.title,
+      status,
+      subject_type: input.subject?.type ?? null,
+      subject_id: input.subject?.id == null ? null : String(input.subject.id),
+      subject_label: input.subject?.label ?? null,
+      trigger_source: input.triggerSource ?? null,
+      triggered_by_user_id: input.triggeredByUserId ?? null,
+      stale_after: input.staleAfter ?? null,
+      current_step: input.currentStep ?? null,
+      metadata: input.metadata ?? {},
+      idempotency_key: input.idempotencyKey ?? null,
+    })
+    .select('id')
+    .single()
+
+  if (error || !data?.id) {
+    if (error?.code === '23505') {
+      const retry = await findRunByIdempotencyKey(input.idempotencyKey)
+      if (retry) return retry
+    }
+    throw new Error(`Failed to start agent run: ${error?.message ?? 'missing id'}`)
+  }
+
+  await recordAgentEvent({
+    runId: data.id as string,
+    eventType: 'run_started',
+    severity: 'info',
+    message: input.title,
+    idempotencyKey: input.idempotencyKey ? `${input.idempotencyKey}:started` : null,
+    metadata: { runtime: input.runtime, kind: input.kind },
+  }).catch(() => {})
+
+  return { id: data.id as string }
+}
+
+export async function recordAgentStep(input: RecordAgentStepInput): Promise<{ id: string } | null> {
+  const status = input.status ?? 'completed'
+  assertStatus(status)
+
+  const { data, error } = await db()
+    .from('agent_run_steps')
+    .insert({
+      run_id: input.runId,
+      step_key: input.stepKey ?? null,
+      name: input.name,
+      status,
+      started_at: input.startedAt ?? new Date().toISOString(),
+      completed_at: input.completedAt ?? (status === 'completed' || status === 'failed' ? new Date().toISOString() : null),
+      latency_ms: input.latencyMs ?? null,
+      tokens_in: input.tokensIn ?? null,
+      tokens_out: input.tokensOut ?? null,
+      cost_usd: input.costUsd ?? null,
+      input_summary: input.inputSummary ?? null,
+      output_summary: input.outputSummary ?? null,
+      reasoning: input.reasoning ?? null,
+      metadata: input.metadata ?? {},
+      idempotency_key: input.idempotencyKey ?? null,
+    })
+    .select('id')
+    .single()
+
+  if (error) {
+    if (error.code === '23505') return null
+    throw new Error(`Failed to record agent step: ${error.message}`)
+  }
+
+  const runStatus: AgentRunStatus =
+    status === 'failed' || status === 'cancelled' || status === 'stale' || status === 'waiting_for_approval'
+      ? status
+      : 'running'
+
+  await db()
+    .from('agent_runs')
+    .update({
+      current_step: input.name,
+      status: runStatus,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', input.runId)
+
+  return data?.id ? { id: data.id as string } : null
+}
+
+export async function recordAgentEvent(input: RecordAgentEventInput): Promise<{ id: string } | null> {
+  const severity = input.severity ?? 'info'
+  if (!AGENT_EVENT_SEVERITIES.includes(severity)) {
+    throw new Error(`Invalid event severity: ${severity}`)
+  }
+
+  const { data, error } = await db()
+    .from('agent_run_events')
+    .insert({
+      run_id: input.runId,
+      event_type: input.eventType,
+      severity,
+      message: input.message ?? null,
+      metadata: input.metadata ?? {},
+      occurred_at: input.occurredAt ?? new Date().toISOString(),
+      idempotency_key: input.idempotencyKey ?? null,
+    })
+    .select('id')
+    .single()
+
+  if (error) {
+    if (error.code === '23505') return null
+    throw new Error(`Failed to record agent event: ${error.message}`)
+  }
+  return data?.id ? { id: data.id as string } : null
+}
+
+export async function endAgentRun(input: EndAgentRunInput): Promise<void> {
+  const status = input.status ?? 'completed'
+  assertStatus(status)
+
+  const { error } = await db()
+    .from('agent_runs')
+    .update({
+      status,
+      completed_at: new Date().toISOString(),
+      outcome: input.outcome ?? {},
+      error_message: input.errorMessage ?? null,
+      current_step: input.currentStep ?? status,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', input.runId)
+
+  if (error) {
+    throw new Error(`Failed to end agent run: ${error.message}`)
+  }
+
+  await recordAgentEvent({
+    runId: input.runId,
+    eventType: status === 'completed' ? 'run_completed' : 'run_finished',
+    severity: status === 'failed' ? 'error' : 'info',
+    message: input.errorMessage ?? status,
+    metadata: input.outcome ?? {},
+    idempotencyKey: `${input.runId}:${status}`,
+  }).catch(() => {})
+}
+
+export async function markAgentRunFailed(
+  runId: string,
+  errorMessage: string,
+  outcome?: Record<string, unknown>,
+): Promise<void> {
+  await endAgentRun({
+    runId,
+    status: 'failed',
+    errorMessage,
+    outcome: outcome ?? {},
+    currentStep: 'failed',
+  })
+}
+
+export async function attachAgentArtifact(input: AttachAgentArtifactInput): Promise<{ id: string } | null> {
+  const { data, error } = await db()
+    .from('agent_run_artifacts')
+    .insert({
+      run_id: input.runId,
+      artifact_type: input.artifactType,
+      title: input.title ?? null,
+      ref_type: input.refType ?? null,
+      ref_id: input.refId == null ? null : String(input.refId),
+      url: input.url ?? null,
+      metadata: input.metadata ?? {},
+      idempotency_key: input.idempotencyKey ?? null,
+    })
+    .select('id')
+    .single()
+
+  if (error) {
+    if (error.code === '23505') return null
+    throw new Error(`Failed to attach agent artifact: ${error.message}`)
+  }
+  return data?.id ? { id: data.id as string } : null
+}

--- a/lib/cost-calculator.test.ts
+++ b/lib/cost-calculator.test.ts
@@ -82,6 +82,7 @@ describe('recordCostEvent', () => {
       currency: 'usd',
       reference_type: null,
       reference_id: null,
+      agent_run_id: null,
       metadata: {},
     })
   })
@@ -151,7 +152,26 @@ describe('recordOpenAICost / recordAnthropicCost', () => {
         currency: 'usd',
         reference_type: 'diagnostic_audit',
         reference_id: 'audit-123',
+        agent_run_id: null,
         metadata: { model: 'gpt-4o-mini', operation: 'generate_insights' },
+      })
+    )
+  })
+
+  it('records agent_run_id when provided', async () => {
+    await recordAnthropicCost(
+      { input_tokens: 1_000_000, output_tokens: 0 },
+      'claude-3-5-sonnet-20241022',
+      { type: 'contact', id: '42' },
+      { operation: 'outreach_queue_in_app' },
+      'run-123',
+    )
+
+    expect(mocks.insertMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent_run_id: 'run-123',
+        reference_type: 'contact',
+        reference_id: '42',
       })
     )
   })

--- a/lib/cost-calculator.ts
+++ b/lib/cost-calculator.ts
@@ -45,6 +45,7 @@ export interface CostEventInput {
   currency?: string
   reference_type?: string
   reference_id?: string
+  agent_run_id?: string
   metadata?: Record<string, unknown>
 }
 
@@ -110,6 +111,7 @@ export async function recordCostEvent(event: CostEventInput): Promise<{ ok: bool
       currency: event.currency || 'usd',
       reference_type: event.reference_type ?? null,
       reference_id: event.reference_id ?? null,
+      agent_run_id: event.agent_run_id ?? null,
       metadata: event.metadata ?? {},
     })
     if (error) {
@@ -131,7 +133,8 @@ export async function recordOpenAICost(
   usage: Usage,
   model: string,
   reference?: { type: string; id: string },
-  metadata?: Record<string, unknown>
+  metadata?: Record<string, unknown>,
+  agentRunId?: string,
 ): Promise<void> {
   const amount = computeOpenAICost(usage, model)
   if (amount <= 0) return
@@ -141,6 +144,7 @@ export async function recordOpenAICost(
     amount,
     reference_type: reference?.type,
     reference_id: reference?.id,
+    agent_run_id: agentRunId,
     metadata: { model, ...metadata },
   })
 }
@@ -152,7 +156,8 @@ export async function recordAnthropicCost(
   usage: Usage,
   model: string,
   reference?: { type: string; id: string },
-  metadata?: Record<string, unknown>
+  metadata?: Record<string, unknown>,
+  agentRunId?: string,
 ): Promise<void> {
   const amount = computeAnthropicCost(usage, model)
   if (amount <= 0) return
@@ -162,6 +167,7 @@ export async function recordAnthropicCost(
     amount,
     reference_type: reference?.type,
     reference_id: reference?.id,
+    agent_run_id: agentRunId,
     metadata: { model, ...metadata },
   })
 }

--- a/lib/llm-dispatch.ts
+++ b/lib/llm-dispatch.ts
@@ -22,6 +22,7 @@ import {
 
 export interface LlmCostContext {
   reference?: { type: string; id: string }
+  agentRunId?: string
   metadata?: Record<string, unknown>
 }
 
@@ -104,6 +105,7 @@ async function callOpenAI(req: LlmJsonRequest): Promise<LlmJsonResponse> {
       req.model,
       req.costContext.reference,
       req.costContext.metadata,
+      req.costContext.agentRunId,
     ).catch(() => {})
   }
 
@@ -166,6 +168,7 @@ async function callAnthropic(req: LlmJsonRequest): Promise<LlmJsonResponse> {
       req.model,
       req.costContext.reference,
       req.costContext.metadata,
+      req.costContext.agentRunId,
     ).catch(() => {})
   }
 

--- a/lib/outreach-queue-generator.ts
+++ b/lib/outreach-queue-generator.ts
@@ -36,6 +36,10 @@ import {
 } from '@/lib/lead-correspondence-context'
 import { generateJsonCompletion } from '@/lib/llm-dispatch'
 import {
+  attachAgentArtifact,
+  recordAgentStep,
+} from '@/lib/agent-run'
+import {
   DEFAULT_OUTREACH_MODEL,
   inferProvider,
   type LlmProvider,
@@ -494,6 +498,7 @@ export async function generateOutreachDraftInApp(params: {
   includeLatestMeeting?: boolean
   sourceTaskId?: string | null
   templateKey?: EmailTemplateKey
+  agentRunId?: string | null
 }): Promise<InAppOutreachGenerateResult> {
   if (!isInAppOutreachGenerationEnabled()) {
     throw new Error('In-app outreach generation is disabled (ENABLE_IN_APP_OUTREACH_GEN=false)')
@@ -559,6 +564,23 @@ export async function generateOutreachDraftInApp(params: {
     sequenceStep,
   })
 
+  if (params.agentRunId) {
+    await recordAgentStep({
+      runId: params.agentRunId,
+      stepKey: 'prompt_context',
+      name: 'Prompt context assembled',
+      status: 'completed',
+      outputSummary: `Prepared ${templateKey} email prompt for contact ${params.contactId}.`,
+      metadata: {
+        channel: 'email',
+        template_key: templateKey,
+        model: ctx.model,
+        sequence_step: sequenceStep,
+      },
+      idempotencyKey: `${params.agentRunId}:email:prompt_context`,
+    }).catch((err) => console.warn('[outreach-queue-generator] agent step failed:', err))
+  }
+
   const completion = await generateJsonCompletion({
     model: ctx.model,
     systemPrompt: ctx.systemPrompt,
@@ -567,6 +589,7 @@ export async function generateOutreachDraftInApp(params: {
     maxTokens: ctx.maxTokens,
     costContext: {
       reference: { type: 'contact', id: String(params.contactId) },
+      agentRunId: params.agentRunId ?? undefined,
       metadata: {
         operation: 'outreach_queue_in_app',
         channel: 'email',
@@ -574,6 +597,25 @@ export async function generateOutreachDraftInApp(params: {
       },
     },
   })
+
+  if (params.agentRunId) {
+    await recordAgentStep({
+      runId: params.agentRunId,
+      stepKey: 'llm_dispatch',
+      name: 'LLM draft generated',
+      status: 'completed',
+      tokensIn: completion.usage?.prompt_tokens ?? completion.usage?.input_tokens ?? null,
+      tokensOut: completion.usage?.completion_tokens ?? completion.usage?.output_tokens ?? null,
+      outputSummary: `Generated email JSON with ${completion.provider}.`,
+      metadata: {
+        provider: completion.provider,
+        model: completion.model,
+        channel: 'email',
+        template_key: templateKey,
+      },
+      idempotencyKey: `${params.agentRunId}:email:llm_dispatch`,
+    }).catch((err) => console.warn('[outreach-queue-generator] agent step failed:', err))
+  }
 
   let parsed: { subject?: string; body?: string }
   try {
@@ -620,6 +662,28 @@ export async function generateOutreachDraftInApp(params: {
     throw new Error('Failed to save outreach draft')
   }
 
+  if (params.agentRunId) {
+    await attachAgentArtifact({
+      runId: params.agentRunId,
+      artifactType: 'outreach_draft',
+      title: subject,
+      refType: 'outreach_queue',
+      refId: inserted.id as string,
+      url: `/admin/outreach?contact=${params.contactId}`,
+      metadata: { channel: 'email', template_key: templateKey },
+      idempotencyKey: `${params.agentRunId}:email:artifact:${inserted.id}`,
+    }).catch((err) => console.warn('[outreach-queue-generator] agent artifact failed:', err))
+    await recordAgentStep({
+      runId: params.agentRunId,
+      stepKey: 'draft_saved',
+      name: 'Outreach draft saved',
+      status: 'completed',
+      outputSummary: `Saved draft ${inserted.id}.`,
+      metadata: { queue_id: inserted.id, channel: 'email' },
+      idempotencyKey: `${params.agentRunId}:email:draft_saved`,
+    }).catch((err) => console.warn('[outreach-queue-generator] agent step failed:', err))
+  }
+
   return {
     outcome: 'created',
     id: inserted.id as string,
@@ -660,6 +724,7 @@ export async function generateLinkedInDraftInApp(params: {
   includeLatestMeeting?: boolean
   sourceTaskId?: string | null
   templateKey?: LinkedInTemplateKey
+  agentRunId?: string | null
 }): Promise<InAppOutreachGenerateResult> {
   if (!isInAppOutreachGenerationEnabled()) {
     throw new Error('In-app outreach generation is disabled (ENABLE_IN_APP_OUTREACH_GEN=false)')
@@ -725,6 +790,23 @@ export async function generateLinkedInDraftInApp(params: {
     sequenceStep,
   })
 
+  if (params.agentRunId) {
+    await recordAgentStep({
+      runId: params.agentRunId,
+      stepKey: 'prompt_context',
+      name: 'Prompt context assembled',
+      status: 'completed',
+      outputSummary: `Prepared ${templateKey} LinkedIn prompt for contact ${params.contactId}.`,
+      metadata: {
+        channel: 'linkedin',
+        template_key: templateKey,
+        model: ctx.model,
+        sequence_step: sequenceStep,
+      },
+      idempotencyKey: `${params.agentRunId}:linkedin:prompt_context`,
+    }).catch((err) => console.warn('[outreach-queue-generator] agent step failed:', err))
+  }
+
   const completion = await generateJsonCompletion({
     model: ctx.model,
     systemPrompt: ctx.systemPrompt,
@@ -733,6 +815,7 @@ export async function generateLinkedInDraftInApp(params: {
     maxTokens: ctx.maxTokens,
     costContext: {
       reference: { type: 'contact', id: String(params.contactId) },
+      agentRunId: params.agentRunId ?? undefined,
       metadata: {
         operation: 'outreach_queue_in_app',
         channel: 'linkedin',
@@ -740,6 +823,25 @@ export async function generateLinkedInDraftInApp(params: {
       },
     },
   })
+
+  if (params.agentRunId) {
+    await recordAgentStep({
+      runId: params.agentRunId,
+      stepKey: 'llm_dispatch',
+      name: 'LLM draft generated',
+      status: 'completed',
+      tokensIn: completion.usage?.prompt_tokens ?? completion.usage?.input_tokens ?? null,
+      tokensOut: completion.usage?.completion_tokens ?? completion.usage?.output_tokens ?? null,
+      outputSummary: `Generated LinkedIn JSON with ${completion.provider}.`,
+      metadata: {
+        provider: completion.provider,
+        model: completion.model,
+        channel: 'linkedin',
+        template_key: templateKey,
+      },
+      idempotencyKey: `${params.agentRunId}:linkedin:llm_dispatch`,
+    }).catch((err) => console.warn('[outreach-queue-generator] agent step failed:', err))
+  }
 
   let parsed: { connection_note?: string; follow_up_dm?: string }
   try {
@@ -801,6 +903,28 @@ export async function generateLinkedInDraftInApp(params: {
   if (insertErr || !inserted?.id) {
     console.error('[outreach-queue-generator] linkedin insert error:', insertErr)
     throw new Error('Failed to save LinkedIn draft')
+  }
+
+  if (params.agentRunId) {
+    await attachAgentArtifact({
+      runId: params.agentRunId,
+      artifactType: 'outreach_draft',
+      title: `LinkedIn draft for ${ctx.contact.name}`,
+      refType: 'outreach_queue',
+      refId: inserted.id as string,
+      url: `/admin/outreach?contact=${params.contactId}`,
+      metadata: { channel: 'linkedin', template_key: templateKey },
+      idempotencyKey: `${params.agentRunId}:linkedin:artifact:${inserted.id}`,
+    }).catch((err) => console.warn('[outreach-queue-generator] agent artifact failed:', err))
+    await recordAgentStep({
+      runId: params.agentRunId,
+      stepKey: 'draft_saved',
+      name: 'Outreach draft saved',
+      status: 'completed',
+      outputSummary: `Saved LinkedIn draft ${inserted.id}.`,
+      metadata: { queue_id: inserted.id, channel: 'linkedin' },
+      idempotencyKey: `${params.agentRunId}:linkedin:draft_saved`,
+    }).catch((err) => console.warn('[outreach-queue-generator] agent step failed:', err))
   }
 
   return {

--- a/migrations/2026_04_30_agent_operations_foundation.sql
+++ b/migrations/2026_04_30_agent_operations_foundation.sql
@@ -1,0 +1,227 @@
+-- ============================================================================
+-- Agent Operations foundation
+-- Date: 2026-04-30
+-- Purpose: Shared run tracing, audit events, artifacts, handoffs, approvals,
+--          and cost linkage across Codex, n8n, Hermes, OpenCode, and manual work.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS agent_registry (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  key TEXT NOT NULL UNIQUE,
+  name TEXT NOT NULL,
+  runtime TEXT NOT NULL CHECK (runtime IN ('codex', 'n8n', 'hermes', 'opencode', 'manual')),
+  pod TEXT,
+  description TEXT,
+  risk_level TEXT NOT NULL DEFAULT 'medium' CHECK (risk_level IN ('low', 'medium', 'high')),
+  allowed_tools JSONB NOT NULL DEFAULT '[]'::jsonb,
+  default_requires_approval BOOLEAN NOT NULL DEFAULT false,
+  active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS agent_runs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_registry_id UUID REFERENCES agent_registry(id) ON DELETE SET NULL,
+  agent_key TEXT,
+  runtime TEXT NOT NULL CHECK (runtime IN ('codex', 'n8n', 'hermes', 'opencode', 'manual')),
+  kind TEXT NOT NULL,
+  title TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'queued'
+    CHECK (status IN ('queued', 'running', 'waiting_for_approval', 'completed', 'failed', 'cancelled', 'stale')),
+  subject_type TEXT,
+  subject_id TEXT,
+  subject_label TEXT,
+  current_step TEXT,
+  trigger_source TEXT,
+  triggered_by_user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  completed_at TIMESTAMPTZ,
+  stale_after TIMESTAMPTZ,
+  outcome JSONB NOT NULL DEFAULT '{}'::jsonb,
+  error_message TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  idempotency_key TEXT UNIQUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS agent_run_steps (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_id UUID NOT NULL REFERENCES agent_runs(id) ON DELETE CASCADE,
+  step_key TEXT,
+  name TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'running'
+    CHECK (status IN ('queued', 'running', 'waiting_for_approval', 'completed', 'failed', 'cancelled', 'stale')),
+  started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  completed_at TIMESTAMPTZ,
+  latency_ms INTEGER CHECK (latency_ms IS NULL OR latency_ms >= 0),
+  tokens_in INTEGER CHECK (tokens_in IS NULL OR tokens_in >= 0),
+  tokens_out INTEGER CHECK (tokens_out IS NULL OR tokens_out >= 0),
+  cost_usd DECIMAL(12,4) CHECK (cost_usd IS NULL OR cost_usd >= 0),
+  input_summary TEXT,
+  output_summary TEXT,
+  reasoning TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  idempotency_key TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_run_steps_idempotency
+  ON agent_run_steps (run_id, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS agent_run_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_id UUID NOT NULL REFERENCES agent_runs(id) ON DELETE CASCADE,
+  event_type TEXT NOT NULL,
+  severity TEXT NOT NULL DEFAULT 'info' CHECK (severity IN ('debug', 'info', 'warning', 'error')),
+  message TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  occurred_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  idempotency_key TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_run_events_idempotency
+  ON agent_run_events (run_id, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS agent_run_artifacts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_id UUID NOT NULL REFERENCES agent_runs(id) ON DELETE CASCADE,
+  artifact_type TEXT NOT NULL,
+  title TEXT,
+  ref_type TEXT,
+  ref_id TEXT,
+  url TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  idempotency_key TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_run_artifacts_idempotency
+  ON agent_run_artifacts (run_id, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS agent_handoffs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_id UUID NOT NULL REFERENCES agent_runs(id) ON DELETE CASCADE,
+  from_agent_key TEXT,
+  to_agent_key TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'accepted', 'completed', 'failed', 'cancelled')),
+  summary TEXT,
+  payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  completed_at TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS agent_approvals (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_id UUID NOT NULL REFERENCES agent_runs(id) ON DELETE CASCADE,
+  approval_type TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'approved', 'rejected', 'cancelled')),
+  requested_by_agent_key TEXT,
+  requested_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  decided_by_user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  decided_at TIMESTAMPTZ,
+  decision_notes TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+ALTER TABLE cost_events
+  ADD COLUMN IF NOT EXISTS agent_run_id UUID REFERENCES agent_runs(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_agent_runs_status_started
+  ON agent_runs (status, started_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_agent_runs_runtime_started
+  ON agent_runs (runtime, started_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_agent_runs_subject
+  ON agent_runs (subject_type, subject_id);
+
+CREATE INDEX IF NOT EXISTS idx_agent_run_steps_run_started
+  ON agent_run_steps (run_id, started_at);
+
+CREATE INDEX IF NOT EXISTS idx_agent_run_events_run_occurred
+  ON agent_run_events (run_id, occurred_at);
+
+CREATE INDEX IF NOT EXISTS idx_agent_run_artifacts_run_created
+  ON agent_run_artifacts (run_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_cost_events_agent_run_id
+  ON cost_events (agent_run_id)
+  WHERE agent_run_id IS NOT NULL;
+
+ALTER TABLE agent_registry ENABLE ROW LEVEL SECURITY;
+ALTER TABLE agent_runs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE agent_run_steps ENABLE ROW LEVEL SECURITY;
+ALTER TABLE agent_run_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE agent_run_artifacts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE agent_handoffs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE agent_approvals ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Admins can manage agent_registry" ON agent_registry;
+CREATE POLICY "Admins can manage agent_registry"
+  ON agent_registry FOR ALL TO authenticated
+  USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'))
+  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'));
+
+DROP POLICY IF EXISTS "Admins can manage agent_runs" ON agent_runs;
+CREATE POLICY "Admins can manage agent_runs"
+  ON agent_runs FOR ALL TO authenticated
+  USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'))
+  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'));
+
+DROP POLICY IF EXISTS "Admins can manage agent_run_steps" ON agent_run_steps;
+CREATE POLICY "Admins can manage agent_run_steps"
+  ON agent_run_steps FOR ALL TO authenticated
+  USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'))
+  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'));
+
+DROP POLICY IF EXISTS "Admins can manage agent_run_events" ON agent_run_events;
+CREATE POLICY "Admins can manage agent_run_events"
+  ON agent_run_events FOR ALL TO authenticated
+  USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'))
+  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'));
+
+DROP POLICY IF EXISTS "Admins can manage agent_run_artifacts" ON agent_run_artifacts;
+CREATE POLICY "Admins can manage agent_run_artifacts"
+  ON agent_run_artifacts FOR ALL TO authenticated
+  USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'))
+  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'));
+
+DROP POLICY IF EXISTS "Admins can manage agent_handoffs" ON agent_handoffs;
+CREATE POLICY "Admins can manage agent_handoffs"
+  ON agent_handoffs FOR ALL TO authenticated
+  USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'))
+  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'));
+
+DROP POLICY IF EXISTS "Admins can manage agent_approvals" ON agent_approvals;
+CREATE POLICY "Admins can manage agent_approvals"
+  ON agent_approvals FOR ALL TO authenticated
+  USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'))
+  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'));
+
+INSERT INTO agent_registry (key, name, runtime, pod, description, risk_level, default_requires_approval)
+VALUES
+  ('codex-engineering', 'Codex Engineering Operator', 'codex', 'Product & Automation', 'Primary repo-aware engineering and implementation operator.', 'high', true),
+  ('n8n-automation', 'n8n Automation Runtime', 'n8n', 'Product & Automation', 'Production workflow automation runtime for webhooks, schedules, and integrations.', 'medium', false),
+  ('hermes-secondary', 'Hermes Secondary Runtime', 'hermes', 'Product & Automation', 'Secondary local runtime for gateway, critique, research, and parity experiments.', 'medium', true),
+  ('opencode-evaluation', 'OpenCode Evaluation Runtime', 'opencode', 'Product & Automation', 'Deferred coding worker runtime for isolated review and implementation experiments.', 'high', true),
+  ('manual-admin', 'Manual Admin Action', 'manual', 'Operations', 'Human-triggered administrative or approval action.', 'low', false)
+ON CONFLICT (key) DO UPDATE
+SET
+  name = EXCLUDED.name,
+  runtime = EXCLUDED.runtime,
+  pod = EXCLUDED.pod,
+  description = EXCLUDED.description,
+  risk_level = EXCLUDED.risk_level,
+  default_requires_approval = EXCLUDED.default_requires_approval,
+  updated_at = now();
+
+COMMENT ON TABLE agent_runs IS 'Shared execution trace for agent and automation work across Codex, n8n, Hermes, OpenCode, and manual actions.';
+COMMENT ON COLUMN agent_runs.runtime IS 'Execution runtime: codex, n8n, hermes, opencode, or manual.';
+COMMENT ON COLUMN agent_runs.idempotency_key IS 'Optional stable key for retry-safe run creation.';
+COMMENT ON COLUMN cost_events.agent_run_id IS 'Links usage cost to a shared agent run trace.';


### PR DESCRIPTION
## Summary

- Add Agent Operations schema, helper library, and admin console routes.
- Add shared run/event/artifact/approval APIs under `/api/admin/agents/runs`.
- Instrument admin outreach draft generation with agent run tracing and cost linkage.

## Database

- Adds `migrations/2026_04_30_agent_operations_foundation.sql`.
- Migration has already been applied manually in Supabase SQL Editor to production and dev per screenshots.

## Validation

- `npx vitest run lib/agent-run.test.ts lib/cost-calculator.test.ts lib/__tests__/llm-dispatch.test.ts`
- `npx tsc --noEmit`

## Notes

- Existing workflow-specific pages remain backward compatible.
- Hermes and OpenCode are registered in the runtime model but not used as primary production runtimes in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new production database tables and admin APIs for agent run tracing plus links costs to runs, which can impact admin workflows and reporting if schema/API assumptions are wrong. Changes are admin-gated but touch core persistence and cost recording paths.
> 
> **Overview**
> Introduces an **Agent Operations** control plane: new admin pages at `/admin/agents` with a run console, filterable run list, and per-run detail view showing steps, events, artifacts, approvals, and aggregated cost.
> 
> Adds admin-only APIs under `/api/admin/agents/runs` to list runs (with stale detection, cost/approval rollups), fetch run detail, update run status, and record run events/approvals.
> 
> Implements a shared tracing helper (`lib/agent-run.ts` + tests) and a migration creating the agent trace schema (`agent_registry`, `agent_runs`, `agent_run_steps`, `agent_run_events`, `agent_run_artifacts`, `agent_handoffs`, `agent_approvals`) plus RLS policies and seed registry entries.
> 
> Links cost tracking to runs by adding `cost_events.agent_run_id` end-to-end (migration + cost-event APIs + cost calculator + LLM dispatch), and instruments admin outreach draft generation to create/step/event/artifact a run and pass `agentRunId` through to LLM cost recording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9c05743abb84a9ebe7aab5f3afa2628ee37d8ce. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->