### PR TITLE
[codex] trace app-triggered n8n runs

### DIFF
--- a/app/api/admin/agents/runs/[runId]/events/route.ts
+++ b/app/api/admin/agents/runs/[runId]/events/route.ts
@@ -8,6 +8,19 @@ function isSeverity(value: string): value is AgentEventSeverity {
   return AGENT_EVENT_SEVERITIES.includes(value as AgentEventSeverity)
 }
 
+async function authorizeAdminOrN8n(request: NextRequest) {
+  const token = request.headers.get('authorization')?.replace('Bearer ', '')
+  if (process.env.N8N_INGEST_SECRET && token === process.env.N8N_INGEST_SECRET) {
+    return null
+  }
+
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+  return null
+}
+
 /**
  * POST /api/admin/agents/runs/:runId/events
  * Writes an audit event for a run. Used by admin tools and future n8n callbacks.
@@ -16,10 +29,8 @@ export async function POST(
   request: NextRequest,
   { params }: { params: { runId: string } },
 ) {
-  const auth = await verifyAdmin(request)
-  if (isAuthError(auth)) {
-    return NextResponse.json({ error: auth.error }, { status: auth.status })
-  }
+  const authError = await authorizeAdminOrN8n(request)
+  if (authError) return authError
 
   const body = (await request.json().catch(() => ({}))) as {
     event_type?: string

--- a/app/api/admin/agents/runs/[runId]/route.ts
+++ b/app/api/admin/agents/runs/[runId]/route.ts
@@ -11,6 +11,19 @@ function isStatus(value: string): value is AgentRunStatus {
   return AGENT_RUN_STATUSES.includes(value as AgentRunStatus)
 }
 
+async function authorizeAdminOrN8n(request: NextRequest) {
+  const token = request.headers.get('authorization')?.replace('Bearer ', '')
+  if (process.env.N8N_INGEST_SECRET && token === process.env.N8N_INGEST_SECRET) {
+    return null
+  }
+
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+  return null
+}
+
 /**
  * GET /api/admin/agents/runs/:runId
  * Returns one run with timeline detail, artifacts, approvals, handoffs, and costs.
@@ -95,10 +108,8 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: { runId: string } },
 ) {
-  const auth = await verifyAdmin(request)
-  if (isAuthError(auth)) {
-    return NextResponse.json({ error: auth.error }, { status: auth.status })
-  }
+  const authError = await authorizeAdminOrN8n(request)
+  if (authError) return authError
   if (!supabaseAdmin) {
     return NextResponse.json({ error: 'Database not available' }, { status: 500 })
   }

--- a/app/api/admin/outreach/run-complete/route.ts
+++ b/app/api/admin/outreach/run-complete/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
+import { attachAgentArtifact, endAgentRun, markAgentRunFailed, recordAgentStep } from '@/lib/agent-run'
 
 export const dynamic = 'force-dynamic'
 
@@ -26,7 +27,13 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json().catch(() => ({}))
-    const { source } = body as { source?: string }
+    const { source, agent_run_id, status: completionStatus, leads_inserted, error_message } = body as {
+      source?: string
+      agent_run_id?: string
+      status?: string
+      leads_inserted?: number
+      error_message?: string
+    }
 
     if (!source || !VALID_SOURCES.includes(source as (typeof VALID_SOURCES)[number])) {
       return NextResponse.json(
@@ -37,6 +44,8 @@ export async function POST(request: NextRequest) {
 
     const completedAt = new Date().toISOString()
 
+    const status = completionStatus === 'failed' ? 'failed' : 'success'
+
     const { error } = await supabaseAdmin
       .from('warm_lead_trigger_audit')
       .insert({
@@ -44,7 +53,9 @@ export async function POST(request: NextRequest) {
         triggered_by: null,
         triggered_at: completedAt,
         options: {},
-        status: 'success',
+        status,
+        leads_inserted: leads_inserted ?? null,
+        error_message: error_message ?? null,
         completed_at: completedAt
       })
 
@@ -56,9 +67,57 @@ export async function POST(request: NextRequest) {
       )
     }
 
+    if (agent_run_id) {
+      try {
+        await recordAgentStep({
+          runId: agent_run_id,
+          stepKey: 'n8n_workflow_complete',
+          name: status === 'failed' ? 'n8n workflow failed' : 'n8n workflow completed',
+          status: status === 'failed' ? 'failed' : 'completed',
+          outputSummary: error_message ?? `${leads_inserted ?? 0} lead(s) inserted`,
+          metadata: {
+            source,
+            leads_inserted: leads_inserted ?? null,
+          },
+          idempotencyKey: `${agent_run_id}:complete:${source}`,
+        })
+
+        if (status === 'failed') {
+          await markAgentRunFailed(agent_run_id, error_message ?? 'n8n workflow failed', {
+            source,
+            leads_inserted: leads_inserted ?? null,
+          })
+        } else {
+          if (leads_inserted && leads_inserted > 0) {
+            await attachAgentArtifact({
+              runId: agent_run_id,
+              artifactType: 'lead_import',
+              title: `${leads_inserted} warm lead(s)`,
+              refType: 'warm_lead_trigger_audit',
+              refId: source,
+              metadata: { source, leads_inserted },
+              idempotencyKey: `${agent_run_id}:artifact:${source}`,
+            })
+          }
+          await endAgentRun({
+            runId: agent_run_id,
+            status: 'completed',
+            currentStep: 'Warm lead scrape complete',
+            outcome: {
+              source,
+              leads_inserted: leads_inserted ?? null,
+            },
+          })
+        }
+      } catch (agentError) {
+        console.warn('warm lead agent run update failed:', agentError)
+      }
+    }
+
     return NextResponse.json({
       success: true,
-      message: `Run complete recorded for source: ${source}`
+      message: `Run complete recorded for source: ${source}`,
+      agent_run_id: agent_run_id ?? null,
     })
   } catch (err) {
     console.error('run-complete error:', err)

--- a/app/api/admin/outreach/trigger/route.ts
+++ b/app/api/admin/outreach/trigger/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
 import { triggerWarmLeadScrape } from '@/lib/n8n'
 import { supabaseAdmin } from '@/lib/supabase'
+import { markAgentRunFailed, recordAgentStep, startAgentRun } from '@/lib/agent-run'
 
 export const dynamic = 'force-dynamic'
 
@@ -69,7 +70,7 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    const triggered: Record<string, { triggered: boolean; message: string; skipped?: boolean; executionId?: string }> = {}
+    const triggered: Record<string, { triggered: boolean; message: string; skipped?: boolean; executionId?: string; agent_run_id?: string }> = {}
 
     // Helper to trigger a single source
     const triggerSource = async (src: 'facebook' | 'google_contacts' | 'linkedin') => {
@@ -83,8 +84,26 @@ export async function POST(request: NextRequest) {
           }
         }
 
+        const agentRun = await startAgentRun({
+          agentKey: 'n8n-automation',
+          runtime: 'n8n',
+          kind: 'warm_lead_scrape',
+          title: `Run ${src} warm lead scraper`,
+          subject: { type: 'lead_source', id: src, label: src },
+          triggerSource: 'admin_outreach_trigger',
+          triggeredByUserId: userId,
+          currentStep: 'Dispatching n8n workflow',
+          metadata: {
+            workflow: `WRM-${src}`,
+            source: src,
+            options: options || {},
+          },
+          idempotencyKey: `n8n:warm-lead:${src}:${Date.now()}`,
+        })
+
         const result = await triggerWarmLeadScrape({
           source: src,
+          agentRunId: agentRun.id,
           options: options || {}
         })
 
@@ -99,7 +118,23 @@ export async function POST(request: NextRequest) {
             error_message: result.triggered ? null : result.message
           })
 
-        return result
+        if (result.triggered) {
+          await recordAgentStep({
+            runId: agentRun.id,
+            stepKey: 'n8n_webhook_dispatched',
+            name: 'n8n workflow dispatched',
+            status: 'completed',
+            outputSummary: result.message,
+            metadata: { source: src },
+            idempotencyKey: `${agentRun.id}:dispatch`,
+          }).catch((error) => console.warn('Warm lead agent dispatch step failed:', error))
+        } else {
+          await markAgentRunFailed(agentRun.id, result.message ?? 'Webhook trigger failed', {
+            source: src,
+          }).catch((error) => console.warn('Warm lead agent failure update failed:', error))
+        }
+
+        return { ...result, agent_run_id: agentRun.id }
       } catch (error) {
         const errorMsg = error instanceof Error ? error.message : 'Unknown error'
         

--- a/app/api/admin/social-content/trigger/route.ts
+++ b/app/api/admin/social-content/trigger/route.ts
@@ -4,6 +4,7 @@ import { triggerSocialContentExtraction } from '@/lib/n8n'
 import { getSocialContentPrompts } from '@/lib/system-prompts'
 import { supabaseAdmin } from '@/lib/supabase'
 import { extractMeetingTitle, extractMeetingSourceUrl, extractParticipants, extractMeetingSummary } from '@/lib/social-content'
+import { markAgentRunFailed, recordAgentStep, startAgentRun } from '@/lib/agent-run'
 
 export const dynamic = 'force-dynamic'
 
@@ -111,7 +112,12 @@ export async function POST(request: NextRequest) {
     // Insert all run rows before firing any webhooks (claim meetings)
     const runsToCreate = meetingIds.filter(id => !alreadyRunning.has(id))
 
-    type RunInfo = { run_id: string; meeting_record_id: string; status: 'running' | 'skipped_existing' | 'failed' }
+    type RunInfo = {
+      run_id: string
+      meeting_record_id: string
+      status: 'running' | 'skipped_existing' | 'failed'
+      agent_run_id?: string
+    }
     const runs: RunInfo[] = []
 
     // Add already-running runs as "skipped"
@@ -138,7 +144,28 @@ export async function POST(request: NextRequest) {
       }
 
       for (const row of inserted) {
-        runs.push({ run_id: row.id, meeting_record_id: row.meeting_record_id!, status: 'running' })
+        const meetingId = row.meeting_record_id!
+        const agentRun = await startAgentRun({
+          agentKey: 'n8n-automation',
+          runtime: 'n8n',
+          kind: 'social_content_extraction',
+          title: 'Extract social content from meeting',
+          subject: { type: 'meeting_record', id: meetingId, label: `Meeting ${meetingId}` },
+          triggerSource: 'admin_social_content_trigger',
+          triggeredByUserId: authResult.user.id,
+          currentStep: 'Dispatching n8n workflow',
+          metadata: {
+            workflow: 'WF-SOC-001',
+            legacy_run_id: row.id,
+          },
+          idempotencyKey: `n8n:social-content:${row.id}`,
+        })
+        runs.push({
+          run_id: row.id,
+          meeting_record_id: meetingId,
+          status: 'running',
+          agent_run_id: agentRun.id,
+        })
       }
     }
 
@@ -156,11 +183,26 @@ export async function POST(request: NextRequest) {
       const result = await triggerSocialContentExtraction({
         meetingRecordId: run.meeting_record_id,
         runId: run.run_id,
+        agentRunId: run.agent_run_id,
         prompts,
       })
 
       if (result.triggered) {
         triggeredCount++
+        if (run.agent_run_id) {
+          await recordAgentStep({
+            runId: run.agent_run_id,
+            stepKey: 'n8n_webhook_dispatched',
+            name: 'n8n workflow dispatched',
+            status: 'completed',
+            outputSummary: result.message,
+            metadata: {
+              workflow: 'WF-SOC-001',
+              legacy_run_id: run.run_id,
+            },
+            idempotencyKey: `${run.agent_run_id}:dispatch`,
+          }).catch((error) => console.warn('Agent run dispatch step failed:', error))
+        }
       } else {
         lastError = result.message
         await supabaseAdmin
@@ -172,10 +214,17 @@ export async function POST(request: NextRequest) {
           })
           .eq('id', run.run_id)
         run.status = 'failed'
+        if (run.agent_run_id) {
+          await markAgentRunFailed(run.agent_run_id, result.message ?? 'Webhook trigger failed', {
+            workflow: 'WF-SOC-001',
+            legacy_run_id: run.run_id,
+          }).catch((error) => console.warn('Agent run failure update failed:', error))
+        }
 
         // Short-circuit on n8n errors (e.g. 502) to avoid hammering a down service
         if (result.message?.includes('502') || result.message?.includes('503')) {
           for (let j = i + 1; j < newRuns.length; j++) {
+            const skippedRun = newRuns[j]
             await supabaseAdmin
               .from('social_content_extraction_runs')
               .update({
@@ -183,8 +232,14 @@ export async function POST(request: NextRequest) {
                 completed_at: new Date().toISOString(),
                 error_message: 'Skipped — n8n unavailable',
               })
-              .eq('id', newRuns[j].run_id)
-            newRuns[j].status = 'failed'
+              .eq('id', skippedRun.run_id)
+            skippedRun.status = 'failed'
+            if (skippedRun.agent_run_id) {
+              await markAgentRunFailed(skippedRun.agent_run_id, 'Skipped - n8n unavailable', {
+                workflow: 'WF-SOC-001',
+                legacy_run_id: skippedRun.run_id,
+              }).catch((error) => console.warn('Agent run failure update failed:', error))
+            }
           }
           break
         }
@@ -198,7 +253,12 @@ export async function POST(request: NextRequest) {
       message: triggeredCount > 0
         ? `${triggeredCount} extraction(s) triggered${skippedCount > 0 ? `, ${skippedCount} already running` : ''}`
         : lastError ?? 'No extractions triggered',
-      runs: runs.map(r => ({ run_id: r.run_id, meeting_record_id: r.meeting_record_id, status: r.status })),
+      runs: runs.map(r => ({
+        run_id: r.run_id,
+        agent_run_id: r.agent_run_id,
+        meeting_record_id: r.meeting_record_id,
+        status: r.status,
+      })),
       triggered: triggeredCount,
       skipped: skippedCount,
       failed: runs.filter(r => r.status === 'failed').length,

--- a/app/api/admin/social-content/workflow-complete/route.test.ts
+++ b/app/api/admin/social-content/workflow-complete/route.test.ts
@@ -102,7 +102,7 @@ describe('POST /api/admin/social-content/workflow-complete', () => {
     )
 
     expect(response.status).toBe(200)
-    expect(await response.json()).toEqual({ ok: true, run_id: 'soc-run-1' })
+    expect(await response.json()).toEqual({ ok: true, run_id: 'soc-run-1', agent_run_id: null })
     expect(insertBuilder.insert).toHaveBeenCalledWith({ status: 'running' })
 
     const updatePayload = updateBuilder.update.mock.calls[0][0] as Record<string, unknown>
@@ -138,7 +138,7 @@ describe('POST /api/admin/social-content/workflow-complete', () => {
     )
 
     expect(response.status).toBe(200)
-    expect(await response.json()).toEqual({ ok: true, run_id: 'run-7' })
+    expect(await response.json()).toEqual({ ok: true, run_id: 'run-7', agent_run_id: null })
 
     const updatePayload = updateBuilder.update.mock.calls[0][0] as Record<string, unknown>
     expect(updatePayload.status).toBe('success')

--- a/app/api/admin/social-content/workflow-complete/route.ts
+++ b/app/api/admin/social-content/workflow-complete/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
+import { attachAgentArtifact, endAgentRun, markAgentRunFailed, recordAgentStep } from '@/lib/agent-run'
 
 export const dynamic = 'force-dynamic'
 
@@ -19,8 +20,9 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json().catch(() => ({}))
-    const { run_id, status: completionStatus, items_inserted, error_message } = body as {
+    const { run_id, agent_run_id, status: completionStatus, items_inserted, error_message } = body as {
       run_id?: string
+      agent_run_id?: string
       status?: string
       items_inserted?: number
       error_message?: string
@@ -88,7 +90,58 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: error.message }, { status: 500 })
     }
 
-    return NextResponse.json({ ok: true, run_id: run.id })
+    if (agent_run_id) {
+      try {
+        await recordAgentStep({
+          runId: agent_run_id,
+          stepKey: 'n8n_workflow_complete',
+          name: status === 'failed' ? 'n8n workflow failed' : 'n8n workflow completed',
+          status: status === 'failed' ? 'failed' : 'completed',
+          outputSummary: error_message ?? `${items_inserted ?? 0} item(s) inserted`,
+          metadata: {
+            workflow: 'WF-SOC-001',
+            legacy_run_id: run.id,
+            items_inserted: items_inserted ?? null,
+          },
+          idempotencyKey: `${agent_run_id}:complete:${run.id}`,
+        })
+
+        if (items_inserted && items_inserted > 0) {
+          await attachAgentArtifact({
+            runId: agent_run_id,
+            artifactType: 'social_content',
+            title: `${items_inserted} social content item(s)`,
+            refType: 'social_content_extraction_run',
+            refId: run.id,
+            metadata: { workflow: 'WF-SOC-001', items_inserted },
+            idempotencyKey: `${agent_run_id}:artifact:${run.id}`,
+          })
+        }
+
+        if (status === 'failed') {
+          await markAgentRunFailed(agent_run_id, error_message ?? 'n8n workflow failed', {
+            workflow: 'WF-SOC-001',
+            legacy_run_id: run.id,
+            items_inserted: items_inserted ?? null,
+          })
+        } else {
+          await endAgentRun({
+            runId: agent_run_id,
+            status: 'completed',
+            currentStep: 'Social content extraction complete',
+            outcome: {
+              workflow: 'WF-SOC-001',
+              legacy_run_id: run.id,
+              items_inserted: items_inserted ?? null,
+            },
+          })
+        }
+      } catch (agentError) {
+        console.warn('social-content agent run update failed:', agentError)
+      }
+    }
+
+    return NextResponse.json({ ok: true, run_id: run.id, agent_run_id: agent_run_id ?? null })
   } catch (err) {
     console.error('social-content workflow-complete error:', err)
     return NextResponse.json(

--- a/app/api/admin/value-evidence/trigger/route.ts
+++ b/app/api/admin/value-evidence/trigger/route.ts
@@ -5,6 +5,7 @@ import {
   triggerValueEvidenceExtraction,
   triggerSocialListening,
 } from '@/lib/n8n'
+import { markAgentRunFailed, recordAgentStep, startAgentRun } from '@/lib/agent-run'
 
 export const dynamic = 'force-dynamic'
 
@@ -258,6 +259,37 @@ export async function POST(request: NextRequest) {
       console.warn('value_evidence_workflow_runs insert failed (table may not exist):', insertError.message)
     }
 
+    let agentRunId: string | undefined
+    if (run?.id) {
+      const title =
+        workflow === 'internal_extraction'
+          ? 'Extract value evidence'
+          : workflow === 'social_listening_lead'
+          ? 'Run lead social listening'
+          : 'Run market social listening'
+      const agentRun = await startAgentRun({
+        agentKey: 'n8n-automation',
+        runtime: 'n8n',
+        kind: workflow,
+        title,
+        subject: scopeContext
+          ? { type: scope_type, id: scope_id, label: scopeContext.scopeLabel }
+          : contact_submission_id
+          ? { type: 'contact_submission', id: contact_submission_id, label: `Lead ${contact_submission_id}` }
+          : { type: 'workflow', id: workflowId, label: workflowId },
+        triggerSource: 'admin_value_evidence_trigger',
+        triggeredByUserId: auth.user.id,
+        currentStep: 'Dispatching n8n workflow',
+        metadata: {
+          workflow_id: workflowId,
+          legacy_run_id: run.id,
+          scope: Object.keys(scope).length > 0 ? scope : null,
+        },
+        idempotencyKey: `n8n:value-evidence:${run.id}`,
+      })
+      agentRunId = agentRun.id
+    }
+
     let result: { triggered: boolean; message: string }
     let leadContext: Record<string, unknown> | undefined = scopeContext?.leadContext
 
@@ -283,7 +315,10 @@ export async function POST(request: NextRequest) {
     const runSocial = !validPhases || validPhases.includes('social')
 
     if (workflow === 'internal_extraction') {
-      const opts: { runId?: string; contactSubmissionIds?: number[] } = { runId: run?.id }
+      const opts: { runId?: string; agentRunId?: string; contactSubmissionIds?: number[] } = {
+        runId: run?.id,
+        agentRunId,
+      }
       if (scopeContext?.contactSubmissionId) {
         opts.contactSubmissionIds = [scopeContext.contactSubmissionId]
       }
@@ -292,6 +327,7 @@ export async function POST(request: NextRequest) {
       // Targeted social-only: use scope's leadContext
       result = await triggerSocialListening({
         runId: run?.id,
+        agentRunId,
         maxResults: validMaxResults,
         sources: validSources,
         contactSubmissionId: scopeContext.contactSubmissionId,
@@ -300,6 +336,7 @@ export async function POST(request: NextRequest) {
     } else {
       result = await triggerSocialListening({
         runId: run?.id,
+        agentRunId,
         maxResults: validMaxResults,
         sources: validSources,
         contactSubmissionId: isSingleLead ? contact_submission_id : scopeContext?.contactSubmissionId,
@@ -307,7 +344,26 @@ export async function POST(request: NextRequest) {
       })
     }
 
-    return NextResponse.json({ ...result, run_id: run?.id })
+    if (agentRunId) {
+      if (result.triggered) {
+        await recordAgentStep({
+          runId: agentRunId,
+          stepKey: 'n8n_webhook_dispatched',
+          name: 'n8n workflow dispatched',
+          status: 'completed',
+          outputSummary: result.message,
+          metadata: { workflow_id: workflowId, legacy_run_id: run?.id },
+          idempotencyKey: `${agentRunId}:dispatch`,
+        }).catch((error) => console.warn('Value evidence agent dispatch step failed:', error))
+      } else {
+        await markAgentRunFailed(agentRunId, result.message ?? 'Webhook trigger failed', {
+          workflow_id: workflowId,
+          legacy_run_id: run?.id,
+        }).catch((error) => console.warn('Value evidence agent run failure update failed:', error))
+      }
+    }
+
+    return NextResponse.json({ ...result, run_id: run?.id, agent_run_id: agentRunId ?? null })
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : 'Unknown error'
     console.error('Trigger error:', message)

--- a/app/api/admin/value-evidence/workflow-complete/route.test.ts
+++ b/app/api/admin/value-evidence/workflow-complete/route.test.ts
@@ -133,6 +133,7 @@ describe('POST /api/admin/value-evidence/workflow-complete', () => {
     expect(jsonMock).toHaveBeenCalledWith({
       ok: true,
       run_id: 'running-vep001',
+      agent_run_id: null,
       chained_social: false,
     })
   })
@@ -173,6 +174,7 @@ describe('POST /api/admin/value-evidence/workflow-complete', () => {
     expect(jsonMock).toHaveBeenCalledWith({
       ok: true,
       run_id: 'created-vep-run',
+      agent_run_id: null,
       chained_social: false,
     })
   })

--- a/app/api/admin/value-evidence/workflow-complete/route.ts
+++ b/app/api/admin/value-evidence/workflow-complete/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
 import { triggerSocialListening } from '@/lib/n8n'
+import { attachAgentArtifact, endAgentRun, markAgentRunFailed, recordAgentStep } from '@/lib/agent-run'
 
 export const dynamic = 'force-dynamic'
 
@@ -29,6 +30,7 @@ export async function POST(request: NextRequest) {
     const body = await request.json().catch(() => ({}))
     const {
       run_id,
+      agent_run_id,
       workflow_id,
       status: completionStatus,
       items_inserted,
@@ -36,6 +38,7 @@ export async function POST(request: NextRequest) {
       contact_submission_ids,
     } = body as {
       run_id?: string
+      agent_run_id?: string
       workflow_id?: string
       status?: string
       items_inserted?: number
@@ -244,11 +247,70 @@ export async function POST(request: NextRequest) {
 
       triggerSocialListening({
         runId: run.id,
+        agentRunId: agent_run_id,
         maxResults: socialMaxResults,
         sources: socialSources,
         contactSubmissionId,
         leadContext,
       }).catch(e => console.error('Auto-chain social trigger failed:', e))
+    }
+
+    if (agent_run_id) {
+      try {
+        await recordAgentStep({
+          runId: agent_run_id,
+          stepKey: `n8n_${wf}_complete`,
+          name: shouldChainSocial
+            ? 'Internal evidence phase completed'
+            : status === 'failed'
+            ? 'n8n workflow failed'
+            : 'n8n workflow completed',
+          status: status === 'failed' ? 'failed' : 'completed',
+          outputSummary: error_message ?? `${items_inserted ?? 0} item(s) inserted`,
+          metadata: {
+            workflow_id: wf,
+            legacy_run_id: run.id,
+            items_inserted: items_inserted ?? null,
+            chained_social: shouldChainSocial,
+          },
+          idempotencyKey: `${agent_run_id}:${wf}:complete:${run.id}`,
+        })
+
+        if (!shouldChainSocial && items_inserted && items_inserted > 0) {
+          await attachAgentArtifact({
+            runId: agent_run_id,
+            artifactType: 'value_evidence',
+            title: `${items_inserted} value evidence item(s)`,
+            refType: 'value_evidence_workflow_run',
+            refId: run.id,
+            metadata: { workflow_id: wf, items_inserted },
+            idempotencyKey: `${agent_run_id}:artifact:${run.id}`,
+          })
+        }
+
+        if (!shouldChainSocial) {
+          if (status === 'failed') {
+            await markAgentRunFailed(agent_run_id, error_message ?? 'n8n workflow failed', {
+              workflow_id: wf,
+              legacy_run_id: run.id,
+              items_inserted: items_inserted ?? null,
+            })
+          } else {
+            await endAgentRun({
+              runId: agent_run_id,
+              status: 'completed',
+              currentStep: 'Value evidence workflow complete',
+              outcome: {
+                workflow_id: wf,
+                legacy_run_id: run.id,
+                items_inserted: items_inserted ?? null,
+              },
+            })
+          }
+        }
+      } catch (agentError) {
+        console.warn('value-evidence agent run update failed:', agentError)
+      }
     }
 
     // Slack notification (non-blocking) — skip if auto-chaining (will notify on final completion)
@@ -269,7 +331,7 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    return NextResponse.json({ ok: true, run_id: run.id, chained_social: shouldChainSocial })
+    return NextResponse.json({ ok: true, run_id: run.id, agent_run_id: agent_run_id ?? null, chained_social: shouldChainSocial })
   } catch (err) {
     console.error('workflow-complete error:', err)
     return NextResponse.json(

--- a/app/api/admin/value-evidence/workflow-progress/route.ts
+++ b/app/api/admin/value-evidence/workflow-progress/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
+import { recordAgentEvent, recordAgentStep } from '@/lib/agent-run'
 
 export const dynamic = 'force-dynamic'
 
@@ -20,8 +21,9 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json().catch(() => ({}))
-    const { run_id, workflow_id, stage, status: stageStatus, items_count } = body as {
+    const { run_id, agent_run_id, workflow_id, stage, status: stageStatus, items_count } = body as {
       run_id?: string
+      agent_run_id?: string
       workflow_id?: string
       stage?: string
       status?: string
@@ -100,7 +102,40 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: error.message }, { status: 500 })
     }
 
-    return NextResponse.json({ ok: true, run_id: run.id })
+    if (agent_run_id) {
+      const normalizedStatus = stageStatus === 'error' ? 'failed' : stageStatus === 'running' ? 'running' : 'completed'
+      await recordAgentStep({
+        runId: agent_run_id,
+        stepKey: `n8n_${wf}_${stage}`,
+        name: stage,
+        status: normalizedStatus,
+        outputSummary: items_count != null ? `${items_count} item(s)` : stageStatus ?? 'complete',
+        metadata: {
+          workflow_id: wf,
+          legacy_run_id: run.id,
+          items_count: items_count ?? null,
+          n8n_status: stageStatus ?? null,
+        },
+        idempotencyKey: `${agent_run_id}:${wf}:${stage}:${stageStatus ?? 'complete'}`,
+      }).catch(async (agentError) => {
+        console.warn('workflow-progress agent step failed:', agentError)
+        await recordAgentEvent({
+          runId: agent_run_id,
+          eventType: 'n8n_progress',
+          severity: stageStatus === 'error' ? 'error' : 'info',
+          message: stage,
+          metadata: {
+            workflow_id: wf,
+            legacy_run_id: run.id,
+            items_count: items_count ?? null,
+            n8n_status: stageStatus ?? null,
+          },
+          idempotencyKey: `${agent_run_id}:${wf}:${stage}:event:${stageStatus ?? 'complete'}`,
+        }).catch(() => {})
+      })
+    }
+
+    return NextResponse.json({ ok: true, run_id: run.id, agent_run_id: agent_run_id ?? null })
   } catch (err) {
     console.error('workflow-progress error:', err)
     return NextResponse.json(

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -49,6 +49,23 @@ Costs are linked through `cost_events.agent_run_id`.
 7. Evaluate OpenCode/OpenClaw only after the shared trace layer can observe one test run.
 8. Gradually migrate older workflow run tables into the shared model where it reduces duplication.
 
+## n8n Callback Contract
+
+App-triggered n8n workflows should receive both the existing workflow-specific `run_id` and the shared `agent_run_id`. The legacy ID keeps existing workflow pages working; `agent_run_id` lets n8n report into Agent Operations.
+
+Supported callback conventions:
+
+- Progress callbacks include `agent_run_id`, `workflow_id`, `stage`, `status`, and optional item counts.
+- Completion callbacks include `agent_run_id`, `run_id`, `workflow_id`, `status`, optional item counts, and `error_message` on failure.
+- Generic callbacks can write events with `POST /api/admin/agents/runs/[runId]/events` using `N8N_INGEST_SECRET`.
+- Generic status updates can use `PATCH /api/admin/agents/runs/[runId]` using `N8N_INGEST_SECRET`.
+
+Current n8n trace coverage:
+
+- Social content extraction creates an `n8n` run, dispatches `agent_run_id`, and completes/fails the shared run from the n8n completion callback.
+- Value evidence workflows create an `n8n` run, dispatch `agent_run_id`, record progress stages, preserve auto-chained VEP-001 to VEP-002 behavior, and complete/fail the shared run after the final phase.
+- Warm lead scrapers create an `n8n` run, dispatch `agent_run_id`, and can complete/fail the shared run when the n8n completion callback echoes the ID.
+
 ## Safety Rules
 
 - New agent work should create an `agent_run` before doing meaningful work.

--- a/lib/n8n.ts
+++ b/lib/n8n.ts
@@ -1158,6 +1158,7 @@ export async function triggerOutreachSend(params: {
  */
 export async function triggerWarmLeadScrape(params: {
   source: 'facebook' | 'google_contacts' | 'linkedin'
+  agentRunId?: string
   options?: {
     /** For Facebook: list of group UIDs to scrape */
     group_uids?: string[]
@@ -1201,6 +1202,7 @@ export async function triggerWarmLeadScrape(params: {
     const payload = {
       source: params.source,
       triggered_at: new Date().toISOString(),
+      agent_run_id: params.agentRunId,
       ...params.options,
     }
     
@@ -1245,6 +1247,8 @@ export interface ValueEvidenceExtractionOptions {
   enrichments?: Record<number, { pain_points_freetext?: string }>
   /** Run ID for progress/complete callbacks; n8n can echo this back to update run status. */
   runId?: string
+  /** Shared Agent Operations trace id; n8n should echo this as agent_run_id in callbacks. */
+  agentRunId?: string
 }
 
 /**
@@ -1290,6 +1294,9 @@ export async function triggerValueEvidenceExtraction(
     if (options?.runId) {
       body.run_id = options.runId
     }
+    if (options?.agentRunId) {
+      body.agent_run_id = options.agentRunId
+    }
 
     const response = await fetchWithTimeout(N8N_VEP001_WEBHOOK_URL, {
       method: 'POST',
@@ -1322,6 +1329,8 @@ export async function triggerValueEvidenceExtraction(
 export interface SocialListeningOptions {
   /** Run ID for progress/complete callbacks; n8n can echo this back to update run status. */
   runId?: string
+  /** Shared Agent Operations trace id; n8n should echo this as agent_run_id in callbacks. */
+  agentRunId?: string
   /** Max results per platform (default 20 in n8n). Quick=5, Standard=10, Deep=20. */
   maxResults?: number
   /** Subset of sources to scrape; omit or pass all 5 for full run. */
@@ -1357,6 +1366,9 @@ export async function triggerSocialListening(options?: SocialListeningOptions): 
     }
     if (options?.runId) {
       body.run_id = options.runId
+    }
+    if (options?.agentRunId) {
+      body.agent_run_id = options.agentRunId
     }
     if (options?.maxResults) {
       body.maxResults = options.maxResults
@@ -1410,6 +1422,7 @@ const N8N_SOC002_WEBHOOK_URL =
 export async function triggerSocialContentExtraction(options?: {
   meetingRecordId?: string
   runId?: string
+  agentRunId?: string
   prompts?: {
     topicExtraction: string
     copywriting: string
@@ -1435,6 +1448,9 @@ export async function triggerSocialContentExtraction(options?: {
     }
     if (options?.runId) {
       body.run_id = options.runId
+    }
+    if (options?.agentRunId) {
+      body.agent_run_id = options.agentRunId
     }
     if (options?.meetingRecordId) {
       body.meeting_record_id = options.meetingRecordId


### PR DESCRIPTION
## Summary
- create Agent Operations runs for app-triggered social content, value evidence, and warm lead n8n workflows
- pass agent_run_id through n8n payloads and callbacks while preserving legacy run_id tables
- allow n8n bearer callbacks to write generic agent run events/status updates
- document the n8n callback contract

## Tests
- npx vitest run lib/agent-run.test.ts app/api/admin/social-content/workflow-complete/route.test.ts app/api/admin/value-evidence/workflow-complete/route.test.ts

## Notes
- Full npx tsc --noEmit is currently blocked by unrelated existing test-file type errors in lib/email-messages.test.ts and lib/gamma-lets-talk-slide.test.ts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new shared-secret authorization path and new side-effecting updates to `agent_runs` from n8n callbacks; mistakes could allow unauthorized status/event writes or leave runs in inconsistent states.
> 
> **Overview**
> Adds end-to-end **Agent Operations tracing** for app-triggered n8n workflows (warm lead scrape, social content extraction, and value evidence), creating `agent_runs` on dispatch, passing `agent_run_id` through webhook payloads, and updating the shared run on progress/completion (steps, artifacts, and fail/completion transitions).
> 
> Extends n8n callback surfaces to support generic Agent Ops updates: `POST /api/admin/agents/runs/[runId]/events` and `PATCH /api/admin/agents/runs/[runId]` now accept either admin auth *or* `Bearer N8N_INGEST_SECRET`.
> 
> Updates API responses/tests to include `agent_run_id`, and documents the n8n callback contract in `docs/agent-operations-rollout.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 068f85a44260a7a3fea9e3466a60342ebf905c17. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->