### PR TITLE
[codex] add read-only Hermes health bridge

### DIFF
--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -1,12 +1,39 @@
 'use client'
 
 import Link from 'next/link'
+import { useState } from 'react'
 import type { ReactNode } from 'react'
-import { Activity, ArrowRight, Bot, CheckCircle2, Clock, DollarSign, XCircle } from 'lucide-react'
+import { Activity, ArrowRight, Bot, CheckCircle2, Clock, DollarSign, RefreshCw, XCircle } from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
+import { getCurrentSession } from '@/lib/auth'
 
 export default function AgentOperationsPage() {
+  const [hermesLoading, setHermesLoading] = useState(false)
+  const [hermesResult, setHermesResult] = useState<{ runId: string; overall: string } | null>(null)
+  const [hermesError, setHermesError] = useState<string | null>(null)
+
+  async function runHermesHealthSummary() {
+    setHermesLoading(true)
+    setHermesError(null)
+    setHermesResult(null)
+    try {
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Missing admin session')
+      const res = await fetch('/api/admin/agents/hermes/system-health', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      })
+      const body = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(body.error || `HTTP ${res.status}`)
+      setHermesResult({ runId: body.run_id, overall: body.overall })
+    } catch (err) {
+      setHermesError(err instanceof Error ? err.message : 'Failed to run Hermes health summary')
+    } finally {
+      setHermesLoading(false)
+    }
+  }
+
   return (
     <ProtectedRoute requireAdmin>
       <div className="min-h-screen bg-background text-foreground p-6 lg:p-8">
@@ -39,14 +66,31 @@ export default function AgentOperationsPage() {
             </Link>
 
             <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/30 p-5">
-              <div className="flex items-center gap-2 text-cyan-300 mb-2">
-                <Bot size={20} />
-                <h2 className="text-lg font-semibold">Runtime Strategy</h2>
+              <div className="flex items-start justify-between gap-3 mb-3">
+                <div>
+                  <div className="flex items-center gap-2 text-cyan-300 mb-2">
+                    <Bot size={20} />
+                    <h2 className="text-lg font-semibold">Hermes Health Summary</h2>
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    Run a read-only secondary-runtime check across agent runs, n8n flags, costs, and workflow status.
+                  </p>
+                </div>
+                <button
+                  onClick={runHermesHealthSummary}
+                  disabled={hermesLoading}
+                  className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 bg-background/60 px-3 py-2 text-sm hover:border-radiant-gold/60 disabled:opacity-60"
+                >
+                  <RefreshCw size={16} className={hermesLoading ? 'animate-spin' : ''} />
+                  Run
+                </button>
               </div>
-              <p className="text-sm text-muted-foreground">
-                Codex and n8n are the primary backbone. Hermes is supported as a secondary runtime. OpenCode stays
-                deferred until traces prove safe.
-              </p>
+              {hermesResult ? (
+                <Link href={`/admin/agents/runs/${hermesResult.runId}`} className="text-sm text-radiant-gold hover:underline">
+                  Open {hermesResult.overall} health run
+                </Link>
+              ) : null}
+              {hermesError ? <p className="text-sm text-red-300">{hermesError}</p> : null}
             </div>
           </div>
 

--- a/app/admin/agents/runs/[runId]/page.tsx
+++ b/app/admin/agents/runs/[runId]/page.tsx
@@ -166,6 +166,11 @@ function List({ rows, titleKey, fallbackTitle, detailKey, empty }: { rows: AnyRo
         <div key={String(row.id)} className="rounded-lg border border-silicon-slate/50 bg-background/40 p-3">
           <p className="font-medium">{String(row[titleKey] || fallbackTitle)}</p>
           <p className="text-sm text-muted-foreground">{String(row[detailKey] ?? '')}</p>
+          {artifactSummary(row) ? (
+            <pre className="mt-2 max-h-56 overflow-auto whitespace-pre-wrap rounded-md bg-black/20 p-3 text-xs text-muted-foreground">
+              {artifactSummary(row)}
+            </pre>
+          ) : null}
           {row.url ? <a className="text-sm text-radiant-gold hover:underline" href={String(row.url)}>Open</a> : null}
         </div>
       ))}
@@ -185,4 +190,11 @@ function formatDate(value?: string) {
 
 function asString(value: unknown): string | undefined {
   return typeof value === 'string' ? value : undefined
+}
+
+function artifactSummary(row: AnyRow): string | null {
+  const metadata = row.metadata
+  if (!metadata || typeof metadata !== 'object') return null
+  const summary = (metadata as Record<string, unknown>).summary_markdown
+  return typeof summary === 'string' ? summary : null
 }

--- a/app/api/admin/agents/hermes/system-health/route.test.ts
+++ b/app/api/admin/agents/hermes/system-health/route.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  startAgentRun: vi.fn(),
+  recordAgentStep: vi.fn(),
+  attachAgentArtifact: vi.fn(),
+  endAgentRun: vi.fn(),
+  markAgentRunFailed: vi.fn(),
+  buildSummary: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-run', () => ({
+  startAgentRun: mocks.startAgentRun,
+  recordAgentStep: mocks.recordAgentStep,
+  attachAgentArtifact: mocks.attachAgentArtifact,
+  endAgentRun: mocks.endAgentRun,
+  markAgentRunFailed: mocks.markAgentRunFailed,
+}))
+
+vi.mock('@/lib/hermes-system-health', () => ({
+  buildHermesSystemHealthSummary: mocks.buildSummary,
+}))
+
+import { POST } from './route'
+
+function makeRequest() {
+  return new Request('http://localhost/api/admin/agents/hermes/system-health', {
+    method: 'POST',
+    headers: { authorization: 'Bearer token' },
+  })
+}
+
+describe('POST /api/admin/agents/hermes/system-health', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.startAgentRun.mockResolvedValue({ id: 'agent-run-1' })
+    mocks.recordAgentStep.mockResolvedValue({ id: 'step-1' })
+    mocks.attachAgentArtifact.mockResolvedValue({ id: 'artifact-1' })
+    mocks.endAgentRun.mockResolvedValue(undefined)
+    mocks.markAgentRunFailed.mockResolvedValue(undefined)
+    mocks.buildSummary.mockResolvedValue({
+      generatedAt: '2026-04-30T20:00:00.000Z',
+      overall: 'warning',
+      summaryMarkdown: '# Hermes System Health Summary\n\nOverall: warning',
+      warnings: ['MOCK_N8N is enabled'],
+      signals: {
+        database: 'connected',
+        n8n: { deploymentTier: 'staging', mockEnabled: true, outboundDisabled: false },
+        agentRuns24h: { total: 2, failed: 0, stale: 0, running: 1, byRuntime: { n8n: 1, hermes: 1 } },
+        costs24h: { totalUsd: 0.001, events: 1 },
+        workflows: {
+          socialContent: { ok: true, data: [] },
+          valueEvidence: { ok: true, data: [] },
+          warmLeads: { ok: true, data: [] },
+        },
+      },
+    })
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(makeRequest() as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.startAgentRun).not.toHaveBeenCalled()
+  })
+
+  it('creates a read-only Hermes run and attaches the summary artifact', async () => {
+    const response = await POST(makeRequest() as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual(expect.objectContaining({
+      ok: true,
+      run_id: 'agent-run-1',
+      overall: 'warning',
+    }))
+
+    expect(mocks.startAgentRun).toHaveBeenCalledWith(expect.objectContaining({
+      agentKey: 'hermes-secondary',
+      runtime: 'hermes',
+      kind: 'system_health_summary',
+      triggeredByUserId: 'admin-user',
+      metadata: expect.objectContaining({
+        execution_mode: 'bridge_read_only',
+        production_mutation_allowed: false,
+        requires_approval_for_writes: true,
+      }),
+    }))
+    expect(mocks.attachAgentArtifact).toHaveBeenCalledWith(expect.objectContaining({
+      runId: 'agent-run-1',
+      artifactType: 'system_health_summary',
+      metadata: expect.objectContaining({
+        summary_markdown: expect.stringContaining('Hermes System Health Summary'),
+      }),
+    }))
+    expect(mocks.endAgentRun).toHaveBeenCalledWith(expect.objectContaining({
+      runId: 'agent-run-1',
+      status: 'completed',
+    }))
+  })
+})

--- a/app/api/admin/agents/hermes/system-health/route.ts
+++ b/app/api/admin/agents/hermes/system-health/route.ts
@@ -1,0 +1,106 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { attachAgentArtifact, endAgentRun, markAgentRunFailed, recordAgentStep, startAgentRun } from '@/lib/agent-run'
+import { buildHermesSystemHealthSummary } from '@/lib/hermes-system-health'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * POST /api/admin/agents/hermes/system-health
+ *
+ * Read-only Hermes bridge slice. This records the work as a Hermes runtime run
+ * without granting Hermes write access to production data.
+ */
+export async function POST(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  let runId: string | null = null
+
+  try {
+    const run = await startAgentRun({
+      agentKey: 'hermes-secondary',
+      runtime: 'hermes',
+      kind: 'system_health_summary',
+      title: 'Generate system health summary',
+      subject: { type: 'system', id: 'portfolio', label: 'Portfolio operations' },
+      triggerSource: 'admin_hermes_system_health',
+      triggeredByUserId: auth.user.id,
+      currentStep: 'Collecting read-only health signals',
+      metadata: {
+        execution_mode: 'bridge_read_only',
+        production_mutation_allowed: false,
+        requires_approval_for_writes: true,
+      },
+      idempotencyKey: `hermes:system-health:${new Date().toISOString().slice(0, 16)}`,
+    })
+    runId = run.id
+
+    await recordAgentStep({
+      runId,
+      stepKey: 'collect_health_signals',
+      name: 'Collected read-only health signals',
+      status: 'running',
+      inputSummary: 'Database, n8n runtime flags, recent agent runs, costs, and workflow status snapshots.',
+      idempotencyKey: `${runId}:collect`,
+    })
+
+    const summary = await buildHermesSystemHealthSummary()
+
+    await recordAgentStep({
+      runId,
+      stepKey: 'summarize_health',
+      name: 'Summarized system health',
+      status: 'completed',
+      outputSummary: `Overall: ${summary.overall}; warnings: ${summary.warnings.length}`,
+      metadata: {
+        overall: summary.overall,
+        warnings: summary.warnings,
+      },
+      idempotencyKey: `${runId}:summary`,
+    })
+
+    await attachAgentArtifact({
+      runId,
+      artifactType: 'system_health_summary',
+      title: `System health summary - ${summary.overall}`,
+      refType: 'agent_run',
+      refId: runId,
+      metadata: {
+        summary_markdown: summary.summaryMarkdown,
+        signals: summary.signals,
+        warnings: summary.warnings,
+      },
+      idempotencyKey: `${runId}:artifact:system-health`,
+    })
+
+    await endAgentRun({
+      runId,
+      status: summary.overall === 'error' ? 'failed' : 'completed',
+      currentStep: 'System health summary ready',
+      errorMessage: summary.overall === 'error' ? summary.warnings[0] ?? 'System health summary failed' : null,
+      outcome: {
+        overall: summary.overall,
+        warning_count: summary.warnings.length,
+        generated_at: summary.generatedAt,
+      },
+    })
+
+    return NextResponse.json({
+      ok: summary.overall !== 'error',
+      run_id: runId,
+      overall: summary.overall,
+      warnings: summary.warnings,
+      summary_markdown: summary.summaryMarkdown,
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    if (runId) {
+      await markAgentRunFailed(runId, message, { bridge: 'hermes_system_health' }).catch(() => {})
+    }
+    console.error('[hermes-system-health] failed:', error)
+    return NextResponse.json({ error: message, run_id: runId }, { status: 500 })
+  }
+}

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -66,6 +66,19 @@ Current n8n trace coverage:
 - Value evidence workflows create an `n8n` run, dispatch `agent_run_id`, record progress stages, preserve auto-chained VEP-001 to VEP-002 behavior, and complete/fail the shared run after the final phase.
 - Warm lead scrapers create an `n8n` run, dispatch `agent_run_id`, and can complete/fail the shared run when the n8n completion callback echoes the ID.
 
+## Hermes Bridge
+
+The first Hermes slice is read-only: `POST /api/admin/agents/hermes/system-health`.
+
+It creates a `hermes` runtime run, collects operational health signals, records steps/events through the shared agent run tables, and attaches a system health summary artifact. The deployed app does not spawn a local Hermes process; this bridge establishes the trace and governance contract that Hermes Gateway can call later.
+
+Current safety constraints:
+
+- No production writes beyond agent trace tables.
+- No external publishing, email sending, or client-data mutation.
+- Metadata marks the run as `bridge_read_only`.
+- Future Hermes write actions must go through `agent_approvals`.
+
 ## Safety Rules
 
 - New agent work should create an `agent_run` before doing meaningful work.

--- a/lib/hermes-system-health.ts
+++ b/lib/hermes-system-health.ts
@@ -1,0 +1,245 @@
+import { describeN8nRuntimeFlags } from '@/lib/n8n-runtime-flags'
+import { supabaseAdmin } from '@/lib/supabase'
+
+type QueryResult<T> = {
+  ok: boolean
+  data: T
+  error?: string
+}
+
+type AgentRunHealthRow = {
+  id: string
+  runtime: string
+  kind: string
+  status: string
+  error_message: string | null
+  started_at: string
+}
+
+type WorkflowHealthRow = {
+  id: string
+  status: string
+  error_message?: string | null
+  completed_at?: string | null
+  triggered_at?: string | null
+}
+
+export type HermesSystemHealthSummary = {
+  generatedAt: string
+  overall: 'ok' | 'warning' | 'error'
+  summaryMarkdown: string
+  signals: {
+    database: 'connected' | 'unavailable'
+    n8n: {
+      deploymentTier: string
+      mockEnabled: boolean
+      outboundDisabled: boolean
+    }
+    agentRuns24h: {
+      total: number
+      failed: number
+      stale: number
+      running: number
+      byRuntime: Record<string, number>
+    }
+    costs24h: {
+      totalUsd: number
+      events: number
+    }
+    workflows: {
+      socialContent: QueryResult<WorkflowHealthRow[]>
+      valueEvidence: QueryResult<WorkflowHealthRow[]>
+      warmLeads: QueryResult<WorkflowHealthRow[]>
+    }
+  }
+  warnings: string[]
+}
+
+async function safeQuery<T>(label: string, query: PromiseLike<{ data: T | null; error: { message: string } | null }>): Promise<QueryResult<T | null>> {
+  try {
+    const { data, error } = await query
+    if (error) {
+      return { ok: false, data: null, error: `${label}: ${error.message}` }
+    }
+    return { ok: true, data }
+  } catch (error) {
+    return {
+      ok: false,
+      data: null,
+      error: `${label}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    }
+  }
+}
+
+function countByRuntime(rows: AgentRunHealthRow[]) {
+  return rows.reduce<Record<string, number>>((acc, row) => {
+    acc[row.runtime] = (acc[row.runtime] ?? 0) + 1
+    return acc
+  }, {})
+}
+
+function statusLine(label: string, result: QueryResult<WorkflowHealthRow[]>) {
+  if (!result.ok) return `- ${label}: unavailable (${result.error})`
+  const rows = result.data
+  if (rows.length === 0) return `- ${label}: no recent runs`
+  const failed = rows.filter((row) => row.status === 'failed').length
+  const running = rows.filter((row) => row.status === 'running').length
+  return `- ${label}: ${rows.length} recent, ${running} running, ${failed} failed`
+}
+
+export async function buildHermesSystemHealthSummary(): Promise<HermesSystemHealthSummary> {
+  const generatedAt = new Date().toISOString()
+  const since24h = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+  const n8nFlags = describeN8nRuntimeFlags()
+
+  if (!supabaseAdmin) {
+    return {
+      generatedAt,
+      overall: 'error',
+      summaryMarkdown: [
+        '# Hermes System Health Summary',
+        '',
+        'Database client is unavailable, so no operational checks could run.',
+      ].join('\n'),
+      signals: {
+        database: 'unavailable',
+        n8n: {
+          deploymentTier: n8nFlags.tier,
+          mockEnabled: n8nFlags.mockN8n.effective,
+          outboundDisabled: n8nFlags.disableOutbound.effective,
+        },
+        agentRuns24h: { total: 0, failed: 0, stale: 0, running: 0, byRuntime: {} },
+        costs24h: { totalUsd: 0, events: 0 },
+        workflows: {
+          socialContent: { ok: false, data: [], error: 'Database client unavailable' },
+          valueEvidence: { ok: false, data: [], error: 'Database client unavailable' },
+          warmLeads: { ok: false, data: [], error: 'Database client unavailable' },
+        },
+      },
+      warnings: ['Database client unavailable'],
+    }
+  }
+
+  const [dbProbe, agentRunsResult, costsResult, socialRunsResult, valueRunsResult, warmRunsResult] = await Promise.all([
+    safeQuery('database probe', supabaseAdmin.from('site_settings').select('id').limit(1).maybeSingle()),
+    safeQuery<AgentRunHealthRow[]>(
+      'agent_runs',
+      supabaseAdmin
+        .from('agent_runs')
+        .select('id, runtime, kind, status, error_message, started_at')
+        .gte('started_at', since24h)
+        .order('started_at', { ascending: false })
+        .limit(100),
+    ),
+    safeQuery<Array<{ amount: number | string | null }>>(
+      'cost_events',
+      supabaseAdmin
+        .from('cost_events')
+        .select('amount')
+        .gte('occurred_at', since24h)
+        .limit(500),
+    ),
+    safeQuery<WorkflowHealthRow[]>(
+      'social_content_extraction_runs',
+      supabaseAdmin
+        .from('social_content_extraction_runs')
+        .select('id, status, error_message, completed_at, triggered_at')
+        .order('triggered_at', { ascending: false })
+        .limit(10),
+    ),
+    safeQuery<WorkflowHealthRow[]>(
+      'value_evidence_workflow_runs',
+      supabaseAdmin
+        .from('value_evidence_workflow_runs')
+        .select('id, status, error_message, completed_at, triggered_at')
+        .order('triggered_at', { ascending: false })
+        .limit(10),
+    ),
+    safeQuery<WorkflowHealthRow[]>(
+      'warm_lead_trigger_audit',
+      supabaseAdmin
+        .from('warm_lead_trigger_audit')
+        .select('id, status, error_message, completed_at, triggered_at')
+        .order('triggered_at', { ascending: false })
+        .limit(10),
+    ),
+  ])
+
+  const agentRuns = agentRunsResult.ok && agentRunsResult.data ? agentRunsResult.data : []
+  const costs = costsResult.ok && costsResult.data ? costsResult.data : []
+  const failed = agentRuns.filter((row) => row.status === 'failed').length
+  const stale = agentRuns.filter((row) => row.status === 'stale').length
+  const running = agentRuns.filter((row) => row.status === 'running' || row.status === 'queued').length
+  const totalUsd = costs.reduce((sum, row) => sum + Number(row.amount ?? 0), 0)
+
+  const warnings = [
+    !dbProbe.ok ? 'Database probe failed' : null,
+    n8nFlags.mockN8n.effective ? 'MOCK_N8N is enabled' : null,
+    n8nFlags.disableOutbound.effective ? 'N8N outbound calls are disabled' : null,
+    failed > 0 ? `${failed} agent run(s) failed in the last 24 hours` : null,
+    stale > 0 ? `${stale} agent run(s) stale in the last 24 hours` : null,
+    !socialRunsResult.ok ? socialRunsResult.error : null,
+    !valueRunsResult.ok ? valueRunsResult.error : null,
+    !warmRunsResult.ok ? warmRunsResult.error : null,
+  ].filter(Boolean) as string[]
+
+  const overall: HermesSystemHealthSummary['overall'] =
+    !dbProbe.ok ? 'error' : warnings.length > 0 ? 'warning' : 'ok'
+
+  const summaryMarkdown = [
+    '# Hermes System Health Summary',
+    '',
+    `Generated: ${generatedAt}`,
+    `Overall: ${overall}`,
+    '',
+    '## Signals',
+    '',
+    `- Database: ${dbProbe.ok ? 'connected' : 'unavailable'}`,
+    `- n8n tier: ${n8nFlags.tier}`,
+    `- n8n mock enabled: ${String(n8nFlags.mockN8n.effective)}`,
+    `- n8n outbound disabled: ${String(n8nFlags.disableOutbound.effective)}`,
+    `- Agent runs in last 24h: ${agentRuns.length} total, ${running} running/queued, ${failed} failed, ${stale} stale`,
+    `- Cost events in last 24h: ${costs.length} event(s), $${totalUsd.toFixed(4)}`,
+    '',
+    '## Workflow Snapshots',
+    '',
+    statusLine('Social content', { ok: socialRunsResult.ok, data: socialRunsResult.data ?? [], error: socialRunsResult.error }),
+    statusLine('Value evidence', { ok: valueRunsResult.ok, data: valueRunsResult.data ?? [], error: valueRunsResult.error }),
+    statusLine('Warm leads', { ok: warmRunsResult.ok, data: warmRunsResult.data ?? [], error: warmRunsResult.error }),
+    '',
+    '## Warnings',
+    '',
+    ...(warnings.length > 0 ? warnings.map((warning) => `- ${warning}`) : ['- None']),
+  ].join('\n')
+
+  return {
+    generatedAt,
+    overall,
+    summaryMarkdown,
+    signals: {
+      database: dbProbe.ok ? 'connected' : 'unavailable',
+      n8n: {
+        deploymentTier: n8nFlags.tier,
+        mockEnabled: n8nFlags.mockN8n.effective,
+        outboundDisabled: n8nFlags.disableOutbound.effective,
+      },
+      agentRuns24h: {
+        total: agentRuns.length,
+        failed,
+        stale,
+        running,
+        byRuntime: countByRuntime(agentRuns),
+      },
+      costs24h: {
+        totalUsd: Number(totalUsd.toFixed(4)),
+        events: costs.length,
+      },
+      workflows: {
+        socialContent: { ok: socialRunsResult.ok, data: socialRunsResult.data ?? [], error: socialRunsResult.error },
+        valueEvidence: { ok: valueRunsResult.ok, data: valueRunsResult.data ?? [], error: valueRunsResult.error },
+        warmLeads: { ok: warmRunsResult.ok, data: warmRunsResult.data ?? [], error: warmRunsResult.error },
+      },
+    },
+    warnings,
+  }
+}


### PR DESCRIPTION
## Summary
- add a read-only Hermes system health bridge endpoint
- create hermes runtime agent runs with health-summary steps and artifacts
- add a Run button on Agent Operations and render summary artifacts on run detail
- document the Hermes bridge safety boundary

## Tests
- npx vitest run app/api/admin/agents/hermes/system-health/route.test.ts lib/agent-run.test.ts

## Notes
- Full npx tsc --noEmit remains blocked by unrelated existing test-file type errors in lib/email-messages.test.ts and lib/gamma-lets-talk-slide.test.ts.