### PR TITLE
[codex] add agent runtime policy gates

### DIFF
--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -7,6 +7,7 @@ import { Activity, ArrowRight, Bot, CheckCircle2, Clock, DollarSign, RefreshCw, 
 import ProtectedRoute from '@/components/ProtectedRoute'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
 import { getCurrentSession } from '@/lib/auth'
+import { APPROVAL_GATES, RUNTIME_POLICIES } from '@/lib/agent-policy'
 
 export default function AgentOperationsPage() {
   const [hermesLoading, setHermesLoading] = useState(false)
@@ -100,6 +101,43 @@ export default function AgentOperationsPage() {
             <SignalCard icon={<XCircle size={18} />} label="Failure modes" value="Failed, stale" />
             <SignalCard icon={<DollarSign size={18} />} label="Cost linkage" value="cost_events.agent_run_id" />
           </div>
+
+          <section className="mt-8 rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-5">
+            <h2 className="text-lg font-semibold mb-4">Runtime Policies</h2>
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+              {RUNTIME_POLICIES.map((policy) => (
+                <div key={policy.runtime} className="rounded-lg border border-silicon-slate/60 bg-background/35 p-4">
+                  <div className="flex items-center justify-between gap-3 mb-2">
+                    <p className="font-semibold">{policy.label}</p>
+                    <span className="rounded-full border border-silicon-slate/60 bg-black/20 px-2 py-1 text-xs">
+                      {policy.runtime}
+                    </span>
+                  </div>
+                  <div className="grid grid-cols-2 gap-2 text-xs text-muted-foreground">
+                    <PolicyFlag label="Read files" value={policy.canReadFiles} />
+                    <PolicyFlag label="Write files" value={policy.canWriteFiles} />
+                    <PolicyFlag label="External APIs" value={policy.canCallExternalApis} />
+                    <PolicyFlag label="Client data" value={policy.canTouchClientData} />
+                  </div>
+                  <p className="mt-3 text-xs text-muted-foreground">Production writes: {policy.canWriteProductionData}</p>
+                  <p className="mt-2 text-sm text-muted-foreground">{policy.notes}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="mt-6 rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-5">
+            <h2 className="text-lg font-semibold mb-4">Approval Gates</h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {APPROVAL_GATES.map((gate) => (
+                <div key={gate.action} className="rounded-lg border border-silicon-slate/60 bg-background/35 p-4">
+                  <p className="font-medium">{gate.label}</p>
+                  <p className="text-sm text-muted-foreground mt-1">{gate.description}</p>
+                  <p className="text-xs text-muted-foreground mt-2">Type: {gate.approvalType}</p>
+                </div>
+              ))}
+            </div>
+          </section>
         </div>
       </div>
     </ProtectedRoute>
@@ -114,6 +152,15 @@ function SignalCard({ icon, label, value }: { icon: ReactNode; label: string; va
         <span className="text-xs font-semibold uppercase tracking-wider">{label}</span>
       </div>
       <p className="text-sm font-medium">{value}</p>
+    </div>
+  )
+}
+
+function PolicyFlag({ label, value }: { label: string; value: boolean }) {
+  return (
+    <div className="flex items-center justify-between gap-2 rounded-md bg-black/10 px-2 py-1">
+      <span>{label}</span>
+      <span className={value ? 'text-green-300' : 'text-red-300'}>{value ? 'yes' : 'no'}</span>
     </div>
   )
 }

--- a/app/admin/agents/runs/[runId]/page.tsx
+++ b/app/admin/agents/runs/[runId]/page.tsx
@@ -60,6 +60,32 @@ function AgentRunDetailContent({ runId }: { runId: string }) {
     fetchDetail()
   }, [fetchDetail])
 
+  async function decideApproval(approvalId: string, status: 'approved' | 'rejected') {
+    try {
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Missing admin session')
+      const res = await fetch(`/api/admin/agents/runs/${runId}/approval`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${session.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          approval_id: approvalId,
+          status,
+          decision_notes: status === 'approved' ? 'Approved from Agent Operations' : 'Rejected from Agent Operations',
+        }),
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body.error || `HTTP ${res.status}`)
+      }
+      await fetchDetail()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update approval')
+    }
+  }
+
   return (
     <div className="min-h-screen bg-background text-foreground p-6 lg:p-8">
       <div className="max-w-6xl mx-auto">
@@ -118,7 +144,14 @@ function AgentRunDetailContent({ runId }: { runId: string }) {
               <h2 className="text-lg font-semibold mb-4">Artifacts & Approvals</h2>
               <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
                 <List rows={data.artifacts} titleKey="title" fallbackTitle="Artifact" detailKey="artifact_type" empty="No artifacts attached." />
-                <List rows={data.approvals} titleKey="approval_type" fallbackTitle="Approval" detailKey="status" empty="No approvals recorded." />
+                <List
+                  rows={data.approvals}
+                  titleKey="approval_type"
+                  fallbackTitle="Approval"
+                  detailKey="status"
+                  empty="No approvals recorded."
+                  onDecision={decideApproval}
+                />
               </div>
             </section>
           </>
@@ -158,7 +191,21 @@ function Timeline({ rows, timeKey, titleKey, detailKey, fallback }: { rows: AnyR
   )
 }
 
-function List({ rows, titleKey, fallbackTitle, detailKey, empty }: { rows: AnyRow[]; titleKey: string; fallbackTitle: string; detailKey: string; empty: string }) {
+function List({
+  rows,
+  titleKey,
+  fallbackTitle,
+  detailKey,
+  empty,
+  onDecision,
+}: {
+  rows: AnyRow[]
+  titleKey: string
+  fallbackTitle: string
+  detailKey: string
+  empty: string
+  onDecision?: (approvalId: string, status: 'approved' | 'rejected') => void
+}) {
   if (rows.length === 0) return <p className="text-sm text-muted-foreground">{empty}</p>
   return (
     <div className="space-y-2">
@@ -170,6 +217,22 @@ function List({ rows, titleKey, fallbackTitle, detailKey, empty }: { rows: AnyRo
             <pre className="mt-2 max-h-56 overflow-auto whitespace-pre-wrap rounded-md bg-black/20 p-3 text-xs text-muted-foreground">
               {artifactSummary(row)}
             </pre>
+          ) : null}
+          {onDecision && row.status === 'pending' && typeof row.id === 'string' ? (
+            <div className="mt-3 flex gap-2">
+              <button
+                onClick={() => onDecision(row.id as string, 'approved')}
+                className="rounded-md border border-green-500/40 bg-green-500/10 px-3 py-1 text-xs text-green-300 hover:bg-green-500/20"
+              >
+                Approve
+              </button>
+              <button
+                onClick={() => onDecision(row.id as string, 'rejected')}
+                className="rounded-md border border-red-500/40 bg-red-500/10 px-3 py-1 text-xs text-red-300 hover:bg-red-500/20"
+              >
+                Reject
+              </button>
+            </div>
           ) : null}
           {row.url ? <a className="text-sm text-radiant-gold hover:underline" href={String(row.url)}>Open</a> : null}
         </div>

--- a/app/api/admin/agents/policies/route.ts
+++ b/app/api/admin/agents/policies/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { APPROVAL_GATES, RUNTIME_POLICIES } from '@/lib/agent-policy'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  return NextResponse.json({
+    policies: RUNTIME_POLICIES,
+    approval_gates: APPROVAL_GATES,
+  })
+}

--- a/app/api/admin/agents/runs/[runId]/approval/route.ts
+++ b/app/api/admin/agents/runs/[runId]/approval/route.ts
@@ -26,6 +26,7 @@ export async function POST(
   }
 
   const body = (await request.json().catch(() => ({}))) as {
+    approval_id?: string
     approval_type?: string
     status?: string
     requested_by_agent_key?: string | null
@@ -34,7 +35,9 @@ export async function POST(
   }
 
   if (!body.approval_type) {
-    return NextResponse.json({ error: 'approval_type is required' }, { status: 400 })
+    if (!body.approval_id) {
+      return NextResponse.json({ error: 'approval_type is required' }, { status: 400 })
+    }
   }
   const status = body.status ?? 'pending'
   if (!isApprovalStatus(status)) {
@@ -42,33 +45,104 @@ export async function POST(
   }
 
   const decided = status !== 'pending'
-  const { data, error } = await supabaseAdmin
-    .from('agent_approvals')
-    .insert({
-      run_id: params.runId,
-      approval_type: body.approval_type,
-      status,
-      requested_by_agent_key: body.requested_by_agent_key ?? null,
-      decided_by_user_id: decided ? auth.user.id : null,
-      decided_at: decided ? new Date().toISOString() : null,
-      decision_notes: body.decision_notes ?? null,
-      metadata: body.metadata ?? {},
-    })
-    .select('id')
-    .single()
+  let approvalId = body.approval_id ?? null
 
-  if (error || !data?.id) {
-    console.error('[agent-approval] insert failed:', error)
-    return NextResponse.json({ error: 'Failed to record approval' }, { status: 500 })
+  if (approvalId) {
+    const { data, error } = await supabaseAdmin
+      .from('agent_approvals')
+      .update({
+        status,
+        decided_by_user_id: decided ? auth.user.id : null,
+        decided_at: decided ? new Date().toISOString() : null,
+        decision_notes: body.decision_notes ?? null,
+        metadata: body.metadata ?? {},
+      })
+      .eq('id', approvalId)
+      .eq('run_id', params.runId)
+      .select('id')
+      .single()
+
+    if (error || !data?.id) {
+      console.error('[agent-approval] update failed:', error)
+      return NextResponse.json({ error: 'Failed to update approval' }, { status: 500 })
+    }
+    approvalId = data.id as string
+  } else {
+    const { data, error } = await supabaseAdmin
+      .from('agent_approvals')
+      .insert({
+        run_id: params.runId,
+        approval_type: body.approval_type,
+        status,
+        requested_by_agent_key: body.requested_by_agent_key ?? null,
+        decided_by_user_id: decided ? auth.user.id : null,
+        decided_at: decided ? new Date().toISOString() : null,
+        decision_notes: body.decision_notes ?? null,
+        metadata: body.metadata ?? {},
+      })
+      .select('id')
+      .single()
+
+    if (error || !data?.id) {
+      console.error('[agent-approval] insert failed:', error)
+      return NextResponse.json({ error: 'Failed to record approval' }, { status: 500 })
+    }
+    approvalId = data.id as string
   }
 
   await supabaseAdmin.from('agent_run_events').insert({
     run_id: params.runId,
-    event_type: 'approval_recorded',
+    event_type: approvalId === body.approval_id ? 'approval_decided' : 'approval_recorded',
     severity: status === 'rejected' ? 'warning' : 'info',
-    message: `${body.approval_type}: ${status}`,
-    metadata: { approval_id: data.id, status },
+    message: `${body.approval_type ?? body.approval_id}: ${status}`,
+    metadata: { approval_id: approvalId, status },
   })
 
-  return NextResponse.json({ ok: true, approval_id: data.id })
+  if (status === 'pending') {
+    await supabaseAdmin
+      .from('agent_runs')
+      .update({
+        status: 'waiting_for_approval',
+        current_step: body.approval_type ? `Approval required: ${body.approval_type}` : 'Approval required',
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', params.runId)
+      .in('status', ['queued', 'running'])
+  }
+
+  if (status === 'rejected' || status === 'cancelled') {
+    await supabaseAdmin
+      .from('agent_runs')
+      .update({
+        status: status === 'rejected' ? 'failed' : 'cancelled',
+        current_step: status === 'rejected' ? 'Approval rejected' : 'Approval cancelled',
+        error_message: body.decision_notes ?? `Approval ${status}`,
+        completed_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', params.runId)
+  }
+
+  if (status === 'approved') {
+    const { data: pending } = await supabaseAdmin
+      .from('agent_approvals')
+      .select('id')
+      .eq('run_id', params.runId)
+      .eq('status', 'pending')
+      .limit(1)
+
+    if (!pending || pending.length === 0) {
+      await supabaseAdmin
+        .from('agent_runs')
+        .update({
+          status: 'running',
+          current_step: 'Approval granted',
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', params.runId)
+        .eq('status', 'waiting_for_approval')
+    }
+  }
+
+  return NextResponse.json({ ok: true, approval_id: approvalId })
 }

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -79,6 +79,31 @@ Current safety constraints:
 - Metadata marks the run as `bridge_read_only`.
 - Future Hermes write actions must go through `agent_approvals`.
 
+## Runtime Policy And Approval Gates
+
+Runtime policies live in `lib/agent-policy.ts` and are shown in `/admin/agents`.
+
+Policy dimensions:
+
+- file reads
+- file writes
+- external API calls
+- client-data access
+- production data writes
+- actions requiring approval
+
+Approval gates are represented in `agent_approvals`, not ad hoc UI state. Pending approvals move eligible runs into `waiting_for_approval`; approving the last pending checkpoint returns the run to `running`; rejecting or cancelling a checkpoint terminates the run as `failed` or `cancelled`.
+
+Current required approval gates:
+
+- publishing
+- sending email
+- database writes outside known workflows
+- production config changes
+- public content derived from private material
+
+Slack should be treated as a notification and lightweight decision surface later. The source of truth remains Portfolio admin plus `agent_approvals`.
+
 ## Safety Rules
 
 - New agent work should create an `agent_run` before doing meaningful work.

--- a/lib/agent-policy.test.ts
+++ b/lib/agent-policy.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { actionRequiresApproval, getApprovalGate, getRuntimePolicy } from './agent-policy'
+
+describe('agent runtime policies', () => {
+  it('keeps Hermes read-only without approval', () => {
+    const policy = getRuntimePolicy('hermes')
+
+    expect(policy.canReadFiles).toBe(true)
+    expect(policy.canWriteFiles).toBe(false)
+    expect(policy.canWriteProductionData).toBe('none')
+    expect(actionRequiresApproval('hermes', 'write_files')).toBe(true)
+    expect(actionRequiresApproval('hermes', 'client_data_access')).toBe(true)
+  })
+
+  it('requires approval for public publishing and email gates', () => {
+    expect(getApprovalGate('publish_public_content')?.approvalType).toBe('publishing')
+    expect(getApprovalGate('send_email')?.approvalType).toBe('send_email')
+    expect(actionRequiresApproval('n8n', 'publish_public_content')).toBe(true)
+    expect(actionRequiresApproval('n8n', 'send_email')).toBe(true)
+  })
+})

--- a/lib/agent-policy.ts
+++ b/lib/agent-policy.ts
@@ -1,0 +1,167 @@
+import type { AgentRuntime } from '@/lib/agent-run'
+
+export type AgentAction =
+  | 'read_files'
+  | 'write_files'
+  | 'external_api_call'
+  | 'client_data_access'
+  | 'known_workflow_db_write'
+  | 'unknown_db_write'
+  | 'publish_public_content'
+  | 'send_email'
+  | 'production_config_change'
+  | 'public_content_from_private_material'
+
+export type RuntimePolicy = {
+  runtime: AgentRuntime
+  label: string
+  canReadFiles: boolean
+  canWriteFiles: boolean
+  canCallExternalApis: boolean
+  canTouchClientData: boolean
+  canWriteProductionData: 'none' | 'known_workflows' | 'approval_only'
+  requiresApprovalFor: AgentAction[]
+  notes: string
+}
+
+export type ApprovalGate = {
+  action: AgentAction
+  label: string
+  approvalType: string
+  description: string
+}
+
+export const APPROVAL_GATES: ApprovalGate[] = [
+  {
+    action: 'publish_public_content',
+    label: 'Publishing',
+    approvalType: 'publishing',
+    description: 'Publishing public content or posting to an external audience.',
+  },
+  {
+    action: 'send_email',
+    label: 'Sending email',
+    approvalType: 'send_email',
+    description: 'Sending email or starting outbound email automation.',
+  },
+  {
+    action: 'unknown_db_write',
+    label: 'Unknown database write',
+    approvalType: 'unknown_db_write',
+    description: 'Database writes outside known, instrumented workflows.',
+  },
+  {
+    action: 'production_config_change',
+    label: 'Production config change',
+    approvalType: 'production_config_change',
+    description: 'Changing production environment, runtime, webhook, or policy configuration.',
+  },
+  {
+    action: 'public_content_from_private_material',
+    label: 'Private source to public content',
+    approvalType: 'private_material_public_content',
+    description: 'Public content derived from private notes, chats, transcripts, or client material.',
+  },
+]
+
+export const RUNTIME_POLICIES: RuntimePolicy[] = [
+  {
+    runtime: 'codex',
+    label: 'Codex Engineering Operator',
+    canReadFiles: true,
+    canWriteFiles: true,
+    canCallExternalApis: true,
+    canTouchClientData: false,
+    canWriteProductionData: 'approval_only',
+    requiresApprovalFor: [
+      'unknown_db_write',
+      'production_config_change',
+      'publish_public_content',
+      'send_email',
+      'public_content_from_private_material',
+    ],
+    notes: 'Primary engineering runtime. Repo writes are allowed; production side effects need approval.',
+  },
+  {
+    runtime: 'n8n',
+    label: 'n8n Automation Runtime',
+    canReadFiles: false,
+    canWriteFiles: false,
+    canCallExternalApis: true,
+    canTouchClientData: true,
+    canWriteProductionData: 'known_workflows',
+    requiresApprovalFor: [
+      'unknown_db_write',
+      'production_config_change',
+      'publish_public_content',
+      'send_email',
+      'public_content_from_private_material',
+    ],
+    notes: 'Production automation runtime. Known workflow writes are allowed; outbound actions stay gated.',
+  },
+  {
+    runtime: 'hermes',
+    label: 'Hermes Secondary Runtime',
+    canReadFiles: true,
+    canWriteFiles: false,
+    canCallExternalApis: false,
+    canTouchClientData: false,
+    canWriteProductionData: 'none',
+    requiresApprovalFor: [
+      'write_files',
+      'external_api_call',
+      'client_data_access',
+      'known_workflow_db_write',
+      'unknown_db_write',
+      'production_config_change',
+      'publish_public_content',
+      'send_email',
+      'public_content_from_private_material',
+    ],
+    notes: 'Read-only in v1. Any mutation or client-data access must create an approval checkpoint first.',
+  },
+  {
+    runtime: 'opencode',
+    label: 'OpenCode Evaluation Runtime',
+    canReadFiles: true,
+    canWriteFiles: false,
+    canCallExternalApis: false,
+    canTouchClientData: false,
+    canWriteProductionData: 'none',
+    requiresApprovalFor: [
+      'write_files',
+      'external_api_call',
+      'client_data_access',
+      'known_workflow_db_write',
+      'unknown_db_write',
+      'production_config_change',
+      'publish_public_content',
+      'send_email',
+      'public_content_from_private_material',
+    ],
+    notes: 'Deferred evaluation runtime. Isolated review only until trace and rollback behavior are proven.',
+  },
+  {
+    runtime: 'manual',
+    label: 'Manual Admin Action',
+    canReadFiles: false,
+    canWriteFiles: false,
+    canCallExternalApis: true,
+    canTouchClientData: true,
+    canWriteProductionData: 'known_workflows',
+    requiresApprovalFor: ['production_config_change', 'public_content_from_private_material'],
+    notes: 'Human-triggered admin actions. Existing admin auth remains the approval boundary for known workflows.',
+  },
+]
+
+export function getRuntimePolicy(runtime: AgentRuntime): RuntimePolicy {
+  return RUNTIME_POLICIES.find((policy) => policy.runtime === runtime) ?? RUNTIME_POLICIES[0]
+}
+
+export function getApprovalGate(action: AgentAction): ApprovalGate | undefined {
+  return APPROVAL_GATES.find((gate) => gate.action === action)
+}
+
+export function actionRequiresApproval(runtime: AgentRuntime, action: AgentAction): boolean {
+  return getRuntimePolicy(runtime).requiresApprovalFor.includes(action)
+}


### PR DESCRIPTION
## Summary
- add code-backed runtime policies and approval gate definitions
- expose policies through an admin API and Agent Operations UI
- make run approvals actionable with approve/reject controls backed by agent_approvals
- document Phase 6 policy and approval behavior, including Slack as a later notification channel

## Tests
- npx vitest run lib/agent-policy.test.ts app/api/admin/agents/hermes/system-health/route.test.ts lib/agent-run.test.ts

## Notes
- Full npx tsc --noEmit remains blocked by unrelated existing test-file type errors in lib/email-messages.test.ts and lib/gamma-lets-talk-slide.test.ts.