### PR TITLE
[codex] add agent approval drill

### DIFF
--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -13,6 +13,9 @@ export default function AgentOperationsPage() {
   const [hermesLoading, setHermesLoading] = useState(false)
   const [hermesResult, setHermesResult] = useState<{ runId: string; overall: string } | null>(null)
   const [hermesError, setHermesError] = useState<string | null>(null)
+  const [drillLoading, setDrillLoading] = useState(false)
+  const [drillResult, setDrillResult] = useState<{ runId: string; approvalType: string } | null>(null)
+  const [drillError, setDrillError] = useState<string | null>(null)
 
   async function runHermesHealthSummary() {
     setHermesLoading(true)
@@ -35,6 +38,34 @@ export default function AgentOperationsPage() {
     }
   }
 
+  async function createApprovalDrill() {
+    setDrillLoading(true)
+    setDrillError(null)
+    setDrillResult(null)
+    try {
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Missing admin session')
+      const res = await fetch('/api/admin/agents/approval-drill', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${session.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          approval_type: 'production_config_change',
+          note: 'Approval drill from Agent Operations.',
+        }),
+      })
+      const body = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(body.error || `HTTP ${res.status}`)
+      setDrillResult({ runId: body.run_id, approvalType: body.approval_type })
+    } catch (err) {
+      setDrillError(err instanceof Error ? err.message : 'Failed to create approval drill')
+    } finally {
+      setDrillLoading(false)
+    }
+  }
+
   return (
     <ProtectedRoute requireAdmin>
       <div className="min-h-screen bg-background text-foreground p-6 lg:p-8">
@@ -47,7 +78,7 @@ export default function AgentOperationsPage() {
             </p>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-5 mb-8">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-5 mb-8">
             <Link
               href="/admin/agents/runs"
               className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/30 p-5 hover:border-radiant-gold/60 transition-colors"
@@ -92,6 +123,34 @@ export default function AgentOperationsPage() {
                 </Link>
               ) : null}
               {hermesError ? <p className="text-sm text-red-300">{hermesError}</p> : null}
+            </div>
+
+            <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/30 p-5">
+              <div className="flex items-start justify-between gap-3 mb-3">
+                <div>
+                  <div className="flex items-center gap-2 text-yellow-300 mb-2">
+                    <CheckCircle2 size={20} />
+                    <h2 className="text-lg font-semibold">Approval Drill</h2>
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    Create a disposable approval checkpoint to verify approve and reject behavior.
+                  </p>
+                </div>
+                <button
+                  onClick={createApprovalDrill}
+                  disabled={drillLoading}
+                  className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 bg-background/60 px-3 py-2 text-sm hover:border-radiant-gold/60 disabled:opacity-60"
+                >
+                  <RefreshCw size={16} className={drillLoading ? 'animate-spin' : ''} />
+                  Create
+                </button>
+              </div>
+              {drillResult ? (
+                <Link href={`/admin/agents/runs/${drillResult.runId}`} className="text-sm text-radiant-gold hover:underline">
+                  Open {drillResult.approvalType} drill
+                </Link>
+              ) : null}
+              {drillError ? <p className="text-sm text-red-300">{drillError}</p> : null}
             </div>
           </div>
 

--- a/app/api/admin/agents/approval-drill/route.test.ts
+++ b/app/api/admin/agents/approval-drill/route.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  startAgentRun: vi.fn(),
+  recordAgentEvent: vi.fn(),
+  from: vi.fn(),
+  insert: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-run', () => ({
+  startAgentRun: mocks.startAgentRun,
+  recordAgentEvent: mocks.recordAgentEvent,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import { POST } from './route'
+
+function makeRequest(body: unknown = {}) {
+  return new Request('http://localhost/api/admin/agents/approval-drill', {
+    method: 'POST',
+    headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+function approvalInsertChain() {
+  const single = vi.fn().mockResolvedValue({ data: { id: 'approval-1' }, error: null })
+  const select = vi.fn(() => ({ single }))
+  mocks.insert.mockImplementation(() => ({ select }))
+  mocks.from.mockReturnValue({ insert: mocks.insert })
+}
+
+describe('POST /api/admin/agents/approval-drill', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.startAgentRun.mockResolvedValue({ id: 'run-1' })
+    mocks.recordAgentEvent.mockResolvedValue({ id: 'event-1' })
+    approvalInsertChain()
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(makeRequest() as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.startAgentRun).not.toHaveBeenCalled()
+  })
+
+  it('creates a waiting_for_approval drill run and pending approval', async () => {
+    const response = await POST(makeRequest({ approval_type: 'send_email' }) as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      ok: true,
+      run_id: 'run-1',
+      approval_id: 'approval-1',
+      approval_type: 'send_email',
+    })
+    expect(mocks.startAgentRun).toHaveBeenCalledWith(expect.objectContaining({
+      runtime: 'manual',
+      kind: 'approval_gate_drill',
+      status: 'waiting_for_approval',
+      triggeredByUserId: 'admin-user',
+    }))
+    expect(mocks.insert).toHaveBeenCalledWith(expect.objectContaining({
+      run_id: 'run-1',
+      approval_type: 'send_email',
+      status: 'pending',
+    }))
+  })
+
+  it('rejects unknown approval types', async () => {
+    const response = await POST(makeRequest({ approval_type: 'dangerous_unknown' }) as never)
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'Invalid approval_type' })
+    expect(mocks.startAgentRun).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/admin/agents/approval-drill/route.ts
+++ b/app/api/admin/agents/approval-drill/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { supabaseAdmin } from '@/lib/supabase'
+import { recordAgentEvent, startAgentRun } from '@/lib/agent-run'
+import { APPROVAL_GATES } from '@/lib/agent-policy'
+
+export const dynamic = 'force-dynamic'
+
+function isKnownApprovalType(value: string) {
+  return APPROVAL_GATES.some((gate) => gate.approvalType === value)
+}
+
+/**
+ * POST /api/admin/agents/approval-drill
+ *
+ * Creates a disposable run with a pending approval so the approval gate flow can
+ * be verified without touching a production workflow.
+ */
+export async function POST(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+  if (!supabaseAdmin) {
+    return NextResponse.json({ error: 'Database not available' }, { status: 500 })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as {
+    approval_type?: string
+    note?: string
+  }
+
+  const approvalType = body.approval_type || 'production_config_change'
+  if (!isKnownApprovalType(approvalType)) {
+    return NextResponse.json({ error: 'Invalid approval_type' }, { status: 400 })
+  }
+
+  try {
+    const run = await startAgentRun({
+      agentKey: 'manual-admin',
+      runtime: 'manual',
+      kind: 'approval_gate_drill',
+      title: 'Approval gate drill',
+      status: 'waiting_for_approval',
+      subject: { type: 'system', id: 'agent-approval-drill', label: 'Agent approval drill' },
+      triggerSource: 'admin_agent_approval_drill',
+      triggeredByUserId: auth.user.id,
+      currentStep: `Approval required: ${approvalType}`,
+      metadata: {
+        drill: true,
+        approval_type: approvalType,
+        note: body.note ?? null,
+      },
+      idempotencyKey: `approval-drill:${auth.user.id}:${Date.now()}`,
+    })
+
+    const { data, error } = await supabaseAdmin
+      .from('agent_approvals')
+      .insert({
+        run_id: run.id,
+        approval_type: approvalType,
+        status: 'pending',
+        requested_by_agent_key: 'manual-admin',
+        metadata: {
+          drill: true,
+          note: body.note ?? 'Approval drill created from Agent Operations.',
+        },
+      })
+      .select('id')
+      .single()
+
+    if (error || !data?.id) {
+      throw new Error(error?.message ?? 'Failed to create drill approval')
+    }
+
+    await recordAgentEvent({
+      runId: run.id,
+      eventType: 'approval_drill_created',
+      severity: 'info',
+      message: `${approvalType}: pending`,
+      metadata: { approval_id: data.id, approval_type: approvalType },
+      idempotencyKey: `${run.id}:approval-drill-created`,
+    }).catch(() => {})
+
+    return NextResponse.json({
+      ok: true,
+      run_id: run.id,
+      approval_id: data.id,
+      approval_type: approvalType,
+    })
+  } catch (error) {
+    console.error('[approval-drill] failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to create approval drill' },
+      { status: 500 },
+    )
+  }
+}

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -104,6 +104,15 @@ Current required approval gates:
 
 Slack should be treated as a notification and lightweight decision surface later. The source of truth remains Portfolio admin plus `agent_approvals`.
 
+## Approval Drill
+
+Use `POST /api/admin/agents/approval-drill` or the **Approval Drill** card on `/admin/agents` to create a disposable `manual` runtime run with a pending approval checkpoint. This verifies that:
+
+- pending approvals appear on the run detail page,
+- the run starts in `waiting_for_approval`,
+- approve/reject decisions write through `agent_approvals`,
+- rejected drills terminate without touching a production workflow.
+
 ## Safety Rules
 
 - New agent work should create an `agent_run` before doing meaningful work.


### PR DESCRIPTION
## Summary
- add an admin-only approval drill endpoint that creates a disposable waiting_for_approval run
- add an Approval Drill card to Agent Operations for quick verification
- document the approval drill verification path

## Tests
- npx vitest run app/api/admin/agents/approval-drill/route.test.ts lib/agent-policy.test.ts app/api/admin/agents/hermes/system-health/route.test.ts lib/agent-run.test.ts

## Notes
- Local worktree has unrelated pre-existing Gamma/email edits that are not included in this PR.
- Targeted TypeScript check for approval-drill/agent-policy files produced no errors.