### PR TITLE
[codex] add presentation bakeoff generator

### DIFF
--- a/app/admin/presentations/page.tsx
+++ b/app/admin/presentations/page.tsx
@@ -1,0 +1,421 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import Link from 'next/link'
+import {
+  ArrowRight,
+  CheckCircle2,
+  ClipboardList,
+  Copy,
+  ExternalLink,
+  Presentation,
+  Sparkles,
+} from 'lucide-react'
+import ProtectedRoute from '@/components/ProtectedRoute'
+import Breadcrumbs from '@/components/admin/Breadcrumbs'
+import {
+  buildPresentationBakeoffPlan,
+  type PresentationAudience,
+  type PresentationFormat,
+  type PresentationBakeoffInput,
+  type PresentationCandidate,
+} from '@/lib/presentation-bakeoff'
+
+const audienceOptions: { value: PresentationAudience; label: string }[] = [
+  { value: 'colleagues', label: 'Colleagues' },
+  { value: 'executives', label: 'Executives' },
+  { value: 'clients', label: 'Clients' },
+  { value: 'workshop_participants', label: 'Workshop participants' },
+  { value: 'public_audience', label: 'Public audience' },
+]
+
+const formatOptions: { value: PresentationFormat; label: string }[] = [
+  { value: 'one_hour_course', label: 'One-hour course' },
+  { value: 'sales_presentation', label: 'Sales presentation' },
+  { value: 'strategy_workshop', label: 'Strategy workshop' },
+  { value: 'internal_update', label: 'Internal update' },
+  { value: 'thought_leadership', label: 'Thought leadership' },
+]
+
+const defaultInput: PresentationBakeoffInput = {
+  title: 'Accelerated',
+  thesis: 'AI made artifacts cheaper. Product discipline turns speed into learning.',
+  audience: 'colleagues',
+  format: 'one_hour_course',
+  durationMinutes: 60,
+  proofAssets: [
+    'Audit tool',
+    'Value Evidence Pipeline',
+    'Chat Eval',
+    'Module Sync',
+    'n8n workflow proof',
+  ],
+  demoRoutes: ['/tools/audit', '/admin/value-evidence', '/admin/chat-eval', '/admin/module-sync'],
+  sourceAnchors: ['Stanford AI Index', 'McKinsey State of AI', 'Linux Foundation', 'Gartner agentic AI'],
+  brandSystem: 'amadutown',
+  needsEditablePptx: true,
+  needsLiveDemos: true,
+  needsSourceValidation: true,
+  needsFacilitatorNotes: true,
+}
+
+function splitLines(value: string): string[] {
+  return value
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
+function joinLines(value: string[] | undefined): string {
+  return (value ?? []).join('\n')
+}
+
+export default function PresentationGeneratorPage() {
+  return (
+    <ProtectedRoute requireAdmin>
+      <PresentationGeneratorContent />
+    </ProtectedRoute>
+  )
+}
+
+function PresentationGeneratorContent() {
+  const [title, setTitle] = useState(defaultInput.title)
+  const [thesis, setThesis] = useState(defaultInput.thesis)
+  const [audience, setAudience] = useState<PresentationAudience>(defaultInput.audience)
+  const [format, setFormat] = useState<PresentationFormat>(defaultInput.format)
+  const [durationMinutes, setDurationMinutes] = useState(String(defaultInput.durationMinutes))
+  const [proofAssets, setProofAssets] = useState(joinLines(defaultInput.proofAssets))
+  const [demoRoutes, setDemoRoutes] = useState(joinLines(defaultInput.demoRoutes))
+  const [sourceAnchors, setSourceAnchors] = useState(joinLines(defaultInput.sourceAnchors))
+  const [needsEditablePptx, setNeedsEditablePptx] = useState(Boolean(defaultInput.needsEditablePptx))
+  const [needsLiveDemos, setNeedsLiveDemos] = useState(Boolean(defaultInput.needsLiveDemos))
+  const [needsSourceValidation, setNeedsSourceValidation] = useState(Boolean(defaultInput.needsSourceValidation))
+  const [needsFacilitatorNotes, setNeedsFacilitatorNotes] = useState(Boolean(defaultInput.needsFacilitatorNotes))
+  const [copiedTool, setCopiedTool] = useState<string | null>(null)
+
+  const input = useMemo<PresentationBakeoffInput>(() => {
+    return {
+      title,
+      thesis,
+      audience,
+      format,
+      durationMinutes: Number(durationMinutes) || 60,
+      proofAssets: splitLines(proofAssets),
+      demoRoutes: splitLines(demoRoutes),
+      sourceAnchors: splitLines(sourceAnchors),
+      brandSystem: 'amadutown',
+      needsEditablePptx,
+      needsLiveDemos,
+      needsSourceValidation,
+      needsFacilitatorNotes,
+    }
+  }, [
+    title,
+    thesis,
+    audience,
+    format,
+    durationMinutes,
+    proofAssets,
+    demoRoutes,
+    sourceAnchors,
+    needsEditablePptx,
+    needsLiveDemos,
+    needsSourceValidation,
+    needsFacilitatorNotes,
+  ])
+
+  const plan = useMemo(() => buildPresentationBakeoffPlan(input), [input])
+
+  const copyPrompt = async (candidate: PresentationCandidate) => {
+    await navigator.clipboard.writeText(candidate.generationPrompt)
+    setCopiedTool(candidate.tool)
+    window.setTimeout(() => setCopiedTool(null), 1400)
+  }
+
+  return (
+    <div className="min-h-screen bg-background text-foreground p-6 lg:p-8">
+      <div className="mx-auto max-w-7xl">
+        <Breadcrumbs items={[{ label: 'Admin', href: '/admin' }, { label: 'Presentation Generator' }]} />
+
+        <div className="mb-8 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <div className="mb-3 flex items-center gap-2 text-radiant-gold">
+              <Presentation size={22} />
+              <span className="text-xs font-semibold uppercase tracking-[0.25em]">Presentation System</span>
+            </div>
+            <h1 className="text-3xl font-bold tracking-tight text-foreground lg:text-4xl">
+              Generate presentation options before choosing the deck.
+            </h1>
+            <p className="mt-3 max-w-3xl text-sm leading-6 text-muted-foreground">
+              Create one shared brief, then compare Codex/PPTX, Claude Design, and Gamma against the same standards:
+              clarity, voice, proof, demos, editability, export quality, and QA.
+            </p>
+          </div>
+          <Link
+            href="/admin/reports/gamma"
+            className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/40 px-4 py-2 text-sm font-medium text-radiant-gold transition-colors hover:bg-radiant-gold/10"
+          >
+            Open Gamma generator
+            <ExternalLink size={16} />
+          </Link>
+        </div>
+
+        <div className="grid gap-6 xl:grid-cols-[420px_1fr]">
+          <section className="rounded-xl border border-silicon-slate bg-silicon-slate/30 p-5">
+            <h2 className="mb-1 flex items-center gap-2 text-lg font-semibold">
+              <ClipboardList size={20} className="text-radiant-gold" />
+              Brief
+            </h2>
+            <p className="mb-5 text-sm text-muted-foreground">
+              Start with the same input for every tool. The bake-off is only useful when the candidates are working from the same job.
+            </p>
+
+            <div className="space-y-4">
+              <label className="block">
+                <span className="mb-1.5 block text-sm font-medium">Title</span>
+                <input
+                  value={title}
+                  onChange={(event) => setTitle(event.target.value)}
+                  className="w-full rounded-lg border border-silicon-slate bg-background px-3 py-2 text-sm outline-none ring-radiant-gold/40 focus:ring-2"
+                />
+              </label>
+
+              <label className="block">
+                <span className="mb-1.5 block text-sm font-medium">Thesis</span>
+                <textarea
+                  value={thesis}
+                  onChange={(event) => setThesis(event.target.value)}
+                  rows={3}
+                  className="w-full rounded-lg border border-silicon-slate bg-background px-3 py-2 text-sm leading-6 outline-none ring-radiant-gold/40 focus:ring-2"
+                />
+              </label>
+
+              <div className="grid grid-cols-2 gap-3">
+                <label className="block">
+                  <span className="mb-1.5 block text-sm font-medium">Audience</span>
+                  <select
+                    value={audience}
+                    onChange={(event) => setAudience(event.target.value as PresentationAudience)}
+                    className="w-full rounded-lg border border-silicon-slate bg-background px-3 py-2 text-sm outline-none ring-radiant-gold/40 focus:ring-2"
+                  >
+                    {audienceOptions.map((option) => (
+                      <option key={option.value} value={option.value}>{option.label}</option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="block">
+                  <span className="mb-1.5 block text-sm font-medium">Minutes</span>
+                  <input
+                    type="number"
+                    min="5"
+                    max="180"
+                    value={durationMinutes}
+                    onChange={(event) => setDurationMinutes(event.target.value)}
+                    className="w-full rounded-lg border border-silicon-slate bg-background px-3 py-2 text-sm outline-none ring-radiant-gold/40 focus:ring-2"
+                  />
+                </label>
+              </div>
+
+              <label className="block">
+                <span className="mb-1.5 block text-sm font-medium">Format</span>
+                <select
+                  value={format}
+                  onChange={(event) => setFormat(event.target.value as PresentationFormat)}
+                  className="w-full rounded-lg border border-silicon-slate bg-background px-3 py-2 text-sm outline-none ring-radiant-gold/40 focus:ring-2"
+                >
+                  {formatOptions.map((option) => (
+                    <option key={option.value} value={option.value}>{option.label}</option>
+                  ))}
+                </select>
+              </label>
+
+              <TextAreaList
+                label="Proof assets"
+                value={proofAssets}
+                onChange={setProofAssets}
+                placeholder="One proof asset per line"
+              />
+              <TextAreaList
+                label="Demo routes"
+                value={demoRoutes}
+                onChange={setDemoRoutes}
+                placeholder="/tools/audit"
+              />
+              <TextAreaList
+                label="Source anchors"
+                value={sourceAnchors}
+                onChange={setSourceAnchors}
+                placeholder="Stanford AI Index"
+              />
+
+              <div className="grid gap-2 rounded-lg border border-silicon-slate/70 bg-background/50 p-3">
+                <Toggle label="Editable PPTX required" checked={needsEditablePptx} onChange={setNeedsEditablePptx} />
+                <Toggle label="Live demos required" checked={needsLiveDemos} onChange={setNeedsLiveDemos} />
+                <Toggle label="Market/source validation required" checked={needsSourceValidation} onChange={setNeedsSourceValidation} />
+                <Toggle label="Facilitator notes required" checked={needsFacilitatorNotes} onChange={setNeedsFacilitatorNotes} />
+              </div>
+            </div>
+          </section>
+
+          <div className="space-y-6">
+            <section className="rounded-xl border border-radiant-gold/30 bg-radiant-gold/10 p-5">
+              <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                <div>
+                  <p className="mb-1 text-xs font-semibold uppercase tracking-[0.25em] text-radiant-gold">
+                    Recommendation
+                  </p>
+                  <h2 className="text-2xl font-bold">{plan.recommendedLabel}</h2>
+                  <p className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground">{plan.recommendation}</p>
+                </div>
+                <div className="rounded-lg border border-radiant-gold/40 bg-background px-4 py-3 text-center">
+                  <p className="text-xs uppercase tracking-wider text-muted-foreground">Best score</p>
+                  <p className="text-3xl font-bold text-radiant-gold">{plan.candidates[0].totalScore.toFixed(2)}</p>
+                </div>
+              </div>
+            </section>
+
+            <section className="grid gap-4 lg:grid-cols-3">
+              {plan.candidates.map((candidate) => (
+                <CandidateCard
+                  key={candidate.tool}
+                  candidate={candidate}
+                  copied={copiedTool === candidate.tool}
+                  onCopy={() => void copyPrompt(candidate)}
+                />
+              ))}
+            </section>
+
+            <section className="grid gap-4 lg:grid-cols-2">
+              <ChecklistCard title="Course plan" items={plan.coursePlan} />
+              <ChecklistCard title="Demo plan" items={plan.demoPlan} />
+              <ChecklistCard title="Source plan" items={plan.sourcePlan} />
+              <ChecklistCard title="Presentation-ready QA" items={plan.qaChecklist} />
+            </section>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function TextAreaList({
+  label,
+  value,
+  onChange,
+  placeholder,
+}: {
+  label: string
+  value: string
+  onChange: (value: string) => void
+  placeholder: string
+}) {
+  return (
+    <label className="block">
+      <span className="mb-1.5 block text-sm font-medium">{label}</span>
+      <textarea
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        rows={4}
+        placeholder={placeholder}
+        className="w-full rounded-lg border border-silicon-slate bg-background px-3 py-2 text-sm leading-6 outline-none ring-radiant-gold/40 placeholder:text-muted-foreground/60 focus:ring-2"
+      />
+    </label>
+  )
+}
+
+function Toggle({
+  label,
+  checked,
+  onChange,
+}: {
+  label: string
+  checked: boolean
+  onChange: (checked: boolean) => void
+}) {
+  return (
+    <label className="flex items-center justify-between gap-3 text-sm">
+      <span>{label}</span>
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(event) => onChange(event.target.checked)}
+        className="h-4 w-4 rounded border-silicon-slate accent-radiant-gold"
+      />
+    </label>
+  )
+}
+
+function CandidateCard({
+  candidate,
+  copied,
+  onCopy,
+}: {
+  candidate: PresentationCandidate
+  copied: boolean
+  onCopy: () => void
+}) {
+  return (
+    <article className="rounded-xl border border-silicon-slate bg-silicon-slate/30 p-4">
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-lg font-semibold">{candidate.label}</h3>
+          <p className="mt-1 text-xs uppercase tracking-wider text-radiant-gold">{candidate.role}</p>
+        </div>
+        <div className="rounded-lg bg-background px-3 py-2 text-right">
+          <p className="text-xs text-muted-foreground">Score</p>
+          <p className="text-xl font-bold text-radiant-gold">{candidate.totalScore.toFixed(2)}</p>
+        </div>
+      </div>
+      <p className="mb-2 text-sm text-muted-foreground">{candidate.bestFor}</p>
+      <p className="mb-4 text-sm text-muted-foreground/80">
+        <span className="font-medium text-foreground">Watch:</span> {candidate.watchOutFor}
+      </p>
+
+      <div className="mb-4 space-y-2">
+        {candidate.scores.slice(0, 5).map((score) => (
+          <div key={score.dimension}>
+            <div className="mb-1 flex items-center justify-between text-xs">
+              <span className="text-muted-foreground">{score.dimension}</span>
+              <span className="font-medium">{score.score}/5</span>
+            </div>
+            <div className="h-1.5 overflow-hidden rounded-full bg-background">
+              <div
+                className="h-full rounded-full bg-radiant-gold"
+                style={{ width: `${score.score * 20}%` }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <button
+        type="button"
+        onClick={onCopy}
+        className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-silicon-slate bg-background px-3 py-2 text-sm font-medium transition-colors hover:border-radiant-gold/50 hover:text-radiant-gold"
+      >
+        {copied ? <CheckCircle2 size={16} /> : <Copy size={16} />}
+        {copied ? 'Copied prompt' : 'Copy prompt'}
+      </button>
+    </article>
+  )
+}
+
+function ChecklistCard({ title, items }: { title: string; items: string[] }) {
+  return (
+    <section className="rounded-xl border border-silicon-slate bg-silicon-slate/30 p-5">
+      <h3 className="mb-4 flex items-center gap-2 text-lg font-semibold">
+        <Sparkles size={18} className="text-radiant-gold" />
+        {title}
+      </h3>
+      <ul className="space-y-3">
+        {items.map((item) => (
+          <li key={item} className="flex gap-3 text-sm leading-6 text-muted-foreground">
+            <ArrowRight size={15} className="mt-1 shrink-0 text-radiant-gold" />
+            <span>{item}</span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/components/admin/AdminSidebar.tsx
+++ b/components/admin/AdminSidebar.tsx
@@ -65,6 +65,7 @@ const NAV_ITEM_ICONS: Record<string, LucideIcon> = {
   '/admin/sales/bundles': Layers,
   '/admin/sales/scripts': FileText,
   '/admin/sales/upsell-paths': Route,
+  '/admin/presentations': Sparkles,
   '/admin/reports/gamma': Presentation,
   '/admin/client-projects': FolderKanban,
   '/admin/meetings': Video,

--- a/lib/admin-nav.ts
+++ b/lib/admin-nav.ts
@@ -43,6 +43,7 @@ export const ADMIN_NAV: { dashboard: AdminNavItem; categories: AdminNavCategory[
         { label: 'Bundles', href: '/admin/sales/bundles' },
         { label: 'Scripts', href: '/admin/sales/scripts' },
         { label: 'Upsell Paths', href: '/admin/sales/upsell-paths' },
+        { label: 'Presentation Generator', href: '/admin/presentations' },
         { label: 'Gamma Reports', href: '/admin/reports/gamma' },
       ],
     },

--- a/lib/presentation-bakeoff.test.ts
+++ b/lib/presentation-bakeoff.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { buildPresentationBakeoffPlan } from './presentation-bakeoff'
+
+describe('buildPresentationBakeoffPlan', () => {
+  it('recommends Codex/PPTX when editability, demos, and source validation matter', () => {
+    const plan = buildPresentationBakeoffPlan({
+      title: 'Accelerated',
+      thesis: 'AI made artifacts cheaper. Product discipline turns speed into learning.',
+      audience: 'colleagues',
+      format: 'one_hour_course',
+      durationMinutes: 60,
+      proofAssets: ['Audit tool', 'Value Evidence Pipeline'],
+      demoRoutes: ['/tools/audit', '/admin/value-evidence'],
+      sourceAnchors: ['Stanford AI Index', 'McKinsey State of AI'],
+      brandSystem: 'amadutown',
+      needsEditablePptx: true,
+      needsLiveDemos: true,
+      needsSourceValidation: true,
+      needsFacilitatorNotes: true,
+    })
+
+    expect(plan.recommendedTool).toBe('codex_pptx')
+    expect(plan.candidates[0].label).toBe('Codex / PPTX build')
+    expect(plan.qaChecklist).toContain('No unsupported market claims.')
+    expect(plan.demoPlan[0]).toContain('/tools/audit')
+  })
+
+  it('keeps Gamma as a candidate instead of the only workflow', () => {
+    const plan = buildPresentationBakeoffPlan({
+      title: 'Client Offer Presentation',
+      thesis: 'The product stays the same. The wrapping changes by operating capacity.',
+      audience: 'clients',
+      format: 'sales_presentation',
+      durationMinutes: 20,
+      brandSystem: 'amadutown',
+    })
+
+    expect(plan.candidates.map((candidate) => candidate.tool)).toEqual(
+      expect.arrayContaining(['codex_pptx', 'claude_design', 'gamma'])
+    )
+    expect(plan.candidates.find((candidate) => candidate.tool === 'gamma')?.generationPrompt).toMatch(
+      /fast alternate direction/i
+    )
+  })
+})

--- a/lib/presentation-bakeoff.ts
+++ b/lib/presentation-bakeoff.ts
@@ -1,0 +1,365 @@
+export const PRESENTATION_TOOLS = [
+  'codex_pptx',
+  'claude_design',
+  'gamma',
+] as const
+
+export type PresentationTool = (typeof PRESENTATION_TOOLS)[number]
+
+export type PresentationAudience =
+  | 'colleagues'
+  | 'executives'
+  | 'clients'
+  | 'workshop_participants'
+  | 'public_audience'
+
+export type PresentationFormat =
+  | 'one_hour_course'
+  | 'sales_presentation'
+  | 'strategy_workshop'
+  | 'internal_update'
+  | 'thought_leadership'
+
+export interface PresentationBakeoffInput {
+  title: string
+  thesis: string
+  audience: PresentationAudience
+  format: PresentationFormat
+  durationMinutes: number
+  proofAssets?: string[]
+  demoRoutes?: string[]
+  sourceAnchors?: string[]
+  brandSystem?: 'amadutown' | 'custom' | 'none'
+  needsEditablePptx?: boolean
+  needsLiveDemos?: boolean
+  needsSourceValidation?: boolean
+  needsFacilitatorNotes?: boolean
+}
+
+export interface PresentationCandidateScore {
+  dimension: string
+  score: number
+  weight: number
+  weightedScore: number
+  rationale: string
+}
+
+export interface PresentationCandidate {
+  tool: PresentationTool
+  label: string
+  role: string
+  bestFor: string
+  watchOutFor: string
+  generationPrompt: string
+  scores: PresentationCandidateScore[]
+  totalScore: number
+}
+
+export interface PresentationBakeoffPlan {
+  generatedAt: string
+  title: string
+  thesis: string
+  recommendedTool: PresentationTool
+  recommendedLabel: string
+  recommendation: string
+  coursePlan: string[]
+  requiredAssets: string[]
+  demoPlan: string[]
+  sourcePlan: string[]
+  qaChecklist: string[]
+  candidates: PresentationCandidate[]
+}
+
+const TOOL_LABELS: Record<PresentationTool, string> = {
+  codex_pptx: 'Codex / PPTX build',
+  claude_design: 'Claude Design prototype',
+  gamma: 'Gamma AI deck',
+}
+
+const TOOL_ROLES: Record<PresentationTool, string> = {
+  codex_pptx: 'Final packaging and repeatable build system',
+  claude_design: 'High-polish visual exploration',
+  gamma: 'Fast alternate visual direction',
+}
+
+const TOOL_STRENGTHS: Record<PresentationTool, string> = {
+  codex_pptx: 'Editable files, source control, QA, speaker notes, and deterministic rebuilds.',
+  claude_design: 'Strong visual atmosphere, layout polish, and prototype speed.',
+  gamma: 'Quick deck shaping and alternate structure when time matters.',
+}
+
+const TOOL_RISKS: Record<PresentationTool, string> = {
+  codex_pptx: 'Needs more setup and QA discipline than a single hosted prompt.',
+  claude_design: 'May produce beautiful artifacts that need translation into final PPTX packaging.',
+  gamma: 'Can look polished while weakening voice, evidence fidelity, or editability.',
+}
+
+const SCORE_WEIGHTS = {
+  course_clarity: 0.16,
+  voice_fit: 0.14,
+  brand_fit: 0.12,
+  proof_quality: 0.14,
+  strategic_strength: 0.12,
+  demo_readiness: 0.1,
+  editability: 0.1,
+  export_quality: 0.06,
+  qa_readiness: 0.06,
+} as const
+
+type ScoreDimension = keyof typeof SCORE_WEIGHTS
+
+const DIMENSION_LABELS: Record<ScoreDimension, string> = {
+  course_clarity: 'Course clarity',
+  voice_fit: 'Voice fit',
+  brand_fit: 'Brand fit',
+  proof_quality: 'Proof quality',
+  strategic_strength: 'Strategic strength',
+  demo_readiness: 'Demo readiness',
+  editability: 'Editability',
+  export_quality: 'Export quality',
+  qa_readiness: 'QA readiness',
+}
+
+function bounded(value: number): number {
+  return Math.max(1, Math.min(5, value))
+}
+
+function formatList(values: string[] | undefined, fallback: string): string {
+  const clean = (values ?? []).map((v) => v.trim()).filter(Boolean)
+  return clean.length > 0 ? clean.join(', ') : fallback
+}
+
+function baseScore(tool: PresentationTool, dimension: ScoreDimension): number {
+  const scores: Record<PresentationTool, Record<ScoreDimension, number>> = {
+    codex_pptx: {
+      course_clarity: 5,
+      voice_fit: 5,
+      brand_fit: 5,
+      proof_quality: 5,
+      strategic_strength: 5,
+      demo_readiness: 5,
+      editability: 4,
+      export_quality: 4,
+      qa_readiness: 5,
+    },
+    claude_design: {
+      course_clarity: 4,
+      voice_fit: 4,
+      brand_fit: 4,
+      proof_quality: 3,
+      strategic_strength: 4,
+      demo_readiness: 3,
+      editability: 3,
+      export_quality: 3,
+      qa_readiness: 3,
+    },
+    gamma: {
+      course_clarity: 4,
+      voice_fit: 3,
+      brand_fit: 3,
+      proof_quality: 3,
+      strategic_strength: 3,
+      demo_readiness: 3,
+      editability: 3,
+      export_quality: 4,
+      qa_readiness: 2,
+    },
+  }
+  return scores[tool][dimension]
+}
+
+function scoreAdjustment(
+  tool: PresentationTool,
+  dimension: ScoreDimension,
+  input: PresentationBakeoffInput
+): number {
+  let adjustment = 0
+
+  if (input.needsEditablePptx && tool === 'codex_pptx' && dimension === 'editability') adjustment += 1
+  if (input.needsEditablePptx && tool !== 'codex_pptx' && dimension === 'editability') adjustment -= 1
+
+  if (input.needsLiveDemos && tool === 'codex_pptx' && dimension === 'demo_readiness') adjustment += 1
+  if (input.needsLiveDemos && tool === 'gamma' && dimension === 'demo_readiness') adjustment -= 1
+
+  if (input.needsSourceValidation && tool === 'codex_pptx' && dimension === 'proof_quality') adjustment += 1
+  if (input.needsSourceValidation && tool === 'gamma' && dimension === 'proof_quality') adjustment -= 1
+
+  if (input.needsFacilitatorNotes && tool === 'codex_pptx' && dimension === 'qa_readiness') adjustment += 1
+  if (input.needsFacilitatorNotes && tool === 'claude_design' && dimension === 'qa_readiness') adjustment -= 1
+
+  if (input.brandSystem === 'amadutown' && tool === 'codex_pptx' && dimension === 'brand_fit') adjustment += 1
+  if (input.brandSystem === 'amadutown' && tool === 'gamma' && dimension === 'brand_fit') adjustment -= 1
+
+  return adjustment
+}
+
+function scoreRationale(
+  tool: PresentationTool,
+  dimension: ScoreDimension,
+  score: number,
+  input: PresentationBakeoffInput
+): string {
+  if (dimension === 'proof_quality') {
+    return input.needsSourceValidation
+      ? `${TOOL_LABELS[tool]} must keep source anchors visible and separate from slide copy.`
+      : `${TOOL_LABELS[tool]} should still keep evidence tied to the point being taught.`
+  }
+  if (dimension === 'demo_readiness') {
+    return input.needsLiveDemos
+      ? `${TOOL_LABELS[tool]} needs live routes, backup screenshots, and a clear talk track.`
+      : `${TOOL_LABELS[tool]} can use lighter proof moments because live demos are not required.`
+  }
+  if (dimension === 'editability') {
+    return input.needsEditablePptx
+      ? `${TOOL_LABELS[tool]} is scored against how easily the final deck can be edited.`
+      : `${TOOL_LABELS[tool]} is scored for review speed more than long-term editability.`
+  }
+  return score >= 4
+    ? `${TOOL_LABELS[tool]} is strong on ${DIMENSION_LABELS[dimension].toLowerCase()}.`
+    : `${TOOL_LABELS[tool]} needs extra review on ${DIMENSION_LABELS[dimension].toLowerCase()}.`
+}
+
+function buildScores(
+  tool: PresentationTool,
+  input: PresentationBakeoffInput
+): PresentationCandidateScore[] {
+  return (Object.keys(SCORE_WEIGHTS) as ScoreDimension[]).map((dimension) => {
+    const score = bounded(baseScore(tool, dimension) + scoreAdjustment(tool, dimension, input))
+    const weight = SCORE_WEIGHTS[dimension]
+    return {
+      dimension: DIMENSION_LABELS[dimension],
+      score,
+      weight,
+      weightedScore: Number((score * weight).toFixed(2)),
+      rationale: scoreRationale(tool, dimension, score, input),
+    }
+  })
+}
+
+function buildGenerationPrompt(tool: PresentationTool, input: PresentationBakeoffInput): string {
+  const proofAssets = formatList(input.proofAssets, 'available product screenshots and framework diagrams')
+  const demoRoutes = formatList(input.demoRoutes, 'relevant live demo routes')
+  const sourceAnchors = formatList(input.sourceAnchors, 'validated public sources')
+
+  return [
+    `Create a ${input.durationMinutes}-minute ${input.format.replaceAll('_', ' ')} titled "${input.title}".`,
+    `Thesis: ${input.thesis}`,
+    `Audience: ${input.audience.replaceAll('_', ' ')}.`,
+    'Use a grounded, practical, systems-minded voice. Start from a real product tension and move toward action.',
+    `Proof assets to incorporate: ${proofAssets}.`,
+    `Demo routes to support: ${demoRoutes}.`,
+    `Source anchors to preserve: ${sourceAnchors}.`,
+    'Build the story around idea -> plan -> proof -> demo -> source -> QA.',
+    tool === 'gamma'
+      ? 'Use Gamma for a fast alternate direction, but do not let it invent unsupported claims or flatten the voice.'
+      : tool === 'claude_design'
+        ? 'Use Claude Design for visual exploration, with a strong layout concept that can later be translated into the final deck.'
+        : 'Use Codex/PPTX as the delivery base with speaker notes, backup screenshots, source guide, contact sheet, and export verification.',
+  ].join('\n')
+}
+
+function buildCandidate(
+  tool: PresentationTool,
+  input: PresentationBakeoffInput
+): PresentationCandidate {
+  const scores = buildScores(tool, input)
+  const totalScore = Number(scores.reduce((sum, item) => sum + item.weightedScore, 0).toFixed(2))
+
+  return {
+    tool,
+    label: TOOL_LABELS[tool],
+    role: TOOL_ROLES[tool],
+    bestFor: TOOL_STRENGTHS[tool],
+    watchOutFor: TOOL_RISKS[tool],
+    generationPrompt: buildGenerationPrompt(tool, input),
+    scores,
+    totalScore,
+  }
+}
+
+function buildCoursePlan(input: PresentationBakeoffInput): string[] {
+  const format = input.format.replaceAll('_', ' ')
+  return [
+    `Open with the practical tension behind "${input.title}" and name why it matters to ${input.audience.replaceAll('_', ' ')}.`,
+    `Frame the ${format} around the decision the audience needs to make after the session.`,
+    'Build the first draft as a course map before choosing the final slide style.',
+    'Prototype at least three candidate directions: Codex/PPTX, Claude Design, and Gamma.',
+    'Use the same brief, proof assets, source anchors, and brand rules across every candidate.',
+    'Score candidates against clarity, voice, brand, proof, strategy, demo readiness, editability, export quality, and QA readiness.',
+    'Promote the winning direction into the final package with notes, demo runbook, source guide, contact sheet, and QA notes.',
+  ]
+}
+
+function buildDemoPlan(input: PresentationBakeoffInput): string[] {
+  const routes = (input.demoRoutes ?? []).map((route) => route.trim()).filter(Boolean)
+  if (routes.length === 0) {
+    return [
+      'Identify the live routes or product surfaces that prove the story.',
+      'Capture backup screenshots after the tool has meaningful content on screen.',
+      'Write a one-sentence reason for each demo before it goes into the deck.',
+    ]
+  }
+
+  return routes.map((route) => {
+    return `${route}: capture a backup screenshot, show the tool in action, and write the specific point it proves.`
+  })
+}
+
+function buildSourcePlan(input: PresentationBakeoffInput): string[] {
+  const anchors = (input.sourceAnchors ?? []).map((source) => source.trim()).filter(Boolean)
+  const base = input.needsSourceValidation
+    ? ['Validate current market claims before slide copy is finalized.']
+    : ['Keep source references available even if the deck is mostly internal.']
+
+  if (anchors.length === 0) {
+    return [
+      ...base,
+      'Create a source guide with claim, reference, URL, workshop talk track, and deck section.',
+      'Add a compact reference index slide when the deck makes industry claims.',
+    ]
+  }
+
+  return [
+    ...base,
+    ...anchors.map((source) => `${source}: map this source to one deck claim and one talk-track sentence.`),
+  ]
+}
+
+export function buildPresentationBakeoffPlan(
+  input: PresentationBakeoffInput
+): PresentationBakeoffPlan {
+  const candidates = PRESENTATION_TOOLS
+    .map((tool) => buildCandidate(tool, input))
+    .sort((a, b) => b.totalScore - a.totalScore)
+  const winner = candidates[0]
+
+  return {
+    generatedAt: new Date().toISOString(),
+    title: input.title,
+    thesis: input.thesis,
+    recommendedTool: winner.tool,
+    recommendedLabel: winner.label,
+    recommendation: `${winner.label} is the best delivery base for this brief because it scores highest across clarity, proof, editability, demo readiness, and QA discipline. Borrow visual ideas from the other candidates where they help, but keep the final package source-backed and presentation-ready.`,
+    coursePlan: buildCoursePlan(input),
+    requiredAssets: [
+      'Personality corpus and humanizer guidance',
+      input.brandSystem === 'amadutown' ? 'AmaduTown logo, palette, and prior framework visuals' : 'Brand assets and visual rules',
+      'Proof screenshots that show tools in action',
+      'Speaker notes and demo cues',
+      'Source guide for market or factual claims',
+      'Contact sheet and individual slide previews',
+    ],
+    demoPlan: buildDemoPlan(input),
+    sourcePlan: buildSourcePlan(input),
+    qaChecklist: [
+      'No stretched logo or off-brand asset treatment.',
+      'No blank proof screenshots or start-state screens where a working state would teach more.',
+      'No off-screen diagrams, clipped text, or unreadable crops.',
+      'No unsupported market claims.',
+      'No generic AI voice, filler phrases, or formulaic contrast lines.',
+      'PPTX, PDF, slide images, notes, source guide, demo runbook, and contact sheet are present.',
+      'Slide count, notes count, and key slide previews are verified.',
+    ],
+    candidates,
+  }
+}


### PR DESCRIPTION
## Summary

- adds an admin Presentation Generator page for comparing Codex/PPTX, Claude Design, and Gamma from one shared brief
- adds a deterministic presentation bakeoff scorer and focused unit coverage
- adds the Presentation Generator nav entry under Sales

## Validation

- `npx vitest run lib/presentation-bakeoff.test.ts`
- `npx tsc --noEmit --pretty false 2>&1 | rg "presentation-bakeoff|admin/presentations|AdminSidebar|admin-nav" || true`
