### PR TITLE
feat: add agent runtime hardening controls

### DIFF
--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import { useState } from 'react'
 import type { ReactNode } from 'react'
-import { Activity, ArrowRight, Bot, CheckCircle2, Clock, DollarSign, RefreshCw, XCircle } from 'lucide-react'
+import { Activity, ArrowRight, Bot, CheckCircle2, Clock, DollarSign, RefreshCw, ShieldAlert, XCircle } from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
 import { getCurrentSession } from '@/lib/auth'
@@ -16,6 +16,9 @@ export default function AgentOperationsPage() {
   const [drillLoading, setDrillLoading] = useState(false)
   const [drillResult, setDrillResult] = useState<{ runId: string; approvalType: string } | null>(null)
   const [drillError, setDrillError] = useState<string | null>(null)
+  const [runtimeLoading, setRuntimeLoading] = useState(false)
+  const [runtimeResult, setRuntimeResult] = useState<{ runId: string; available: boolean } | null>(null)
+  const [runtimeError, setRuntimeError] = useState<string | null>(null)
 
   async function runHermesHealthSummary() {
     setHermesLoading(true)
@@ -66,6 +69,31 @@ export default function AgentOperationsPage() {
     }
   }
 
+  async function evaluateOpenCodeRuntime() {
+    setRuntimeLoading(true)
+    setRuntimeError(null)
+    setRuntimeResult(null)
+    try {
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Missing admin session')
+      const res = await fetch('/api/admin/agents/runtime-evaluation', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${session.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ runtime: 'opencode' }),
+      })
+      const body = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(body.error || `HTTP ${res.status}`)
+      setRuntimeResult({ runId: body.run_id, available: Boolean(body.available) })
+    } catch (err) {
+      setRuntimeError(err instanceof Error ? err.message : 'Failed to evaluate OpenCode/OpenClaw')
+    } finally {
+      setRuntimeLoading(false)
+    }
+  }
+
   return (
     <ProtectedRoute requireAdmin>
       <div className="min-h-screen bg-background text-foreground p-6 lg:p-8">
@@ -78,7 +106,7 @@ export default function AgentOperationsPage() {
             </p>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-5 mb-8">
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-5 mb-8">
             <Link
               href="/admin/agents/runs"
               className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/30 p-5 hover:border-radiant-gold/60 transition-colors"
@@ -151,6 +179,34 @@ export default function AgentOperationsPage() {
                 </Link>
               ) : null}
               {drillError ? <p className="text-sm text-red-300">{drillError}</p> : null}
+            </div>
+
+            <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/30 p-5">
+              <div className="flex items-start justify-between gap-3 mb-3">
+                <div>
+                  <div className="flex items-center gap-2 text-orange-300 mb-2">
+                    <ShieldAlert size={20} />
+                    <h2 className="text-lg font-semibold">Runtime Evaluation</h2>
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    Probe OpenCode/OpenClaw availability without running worker tasks or mutating production data.
+                  </p>
+                </div>
+                <button
+                  onClick={evaluateOpenCodeRuntime}
+                  disabled={runtimeLoading}
+                  className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 bg-background/60 px-3 py-2 text-sm hover:border-radiant-gold/60 disabled:opacity-60"
+                >
+                  <RefreshCw size={16} className={runtimeLoading ? 'animate-spin' : ''} />
+                  Probe
+                </button>
+              </div>
+              {runtimeResult ? (
+                <Link href={`/admin/agents/runs/${runtimeResult.runId}`} className="text-sm text-radiant-gold hover:underline">
+                  Open {runtimeResult.available ? 'available' : 'unavailable'} runtime run
+                </Link>
+              ) : null}
+              {runtimeError ? <p className="text-sm text-red-300">{runtimeError}</p> : null}
             </div>
           </div>
 

--- a/app/admin/agents/runs/page.tsx
+++ b/app/admin/agents/runs/page.tsx
@@ -44,6 +44,8 @@ function AgentRunsContent() {
   const [status, setStatus] = useState<(typeof STATUSES)[number]>('all')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [sweepLoading, setSweepLoading] = useState(false)
+  const [sweepMessage, setSweepMessage] = useState<string | null>(null)
 
   const fetchRuns = useCallback(async () => {
     setLoading(true)
@@ -75,6 +77,28 @@ function AgentRunsContent() {
     fetchRuns()
   }, [fetchRuns])
 
+  async function sweepStaleRuns() {
+    setSweepLoading(true)
+    setSweepMessage(null)
+    setError(null)
+    try {
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Missing admin session')
+      const res = await fetch('/api/admin/agents/runs/stale-sweep', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      })
+      const body = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(body.error || `HTTP ${res.status}`)
+      setSweepMessage(`Checked ${body.checked ?? 0} active run(s); marked ${body.marked ?? 0} stale.`)
+      await fetchRuns()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to sweep stale runs')
+    } finally {
+      setSweepLoading(false)
+    }
+  }
+
   return (
     <div className="min-h-screen bg-background text-foreground p-6 lg:p-8">
       <div className="max-w-7xl mx-auto">
@@ -89,14 +113,30 @@ function AgentRunsContent() {
             <h1 className="text-3xl font-bold mb-1">Agent Runs</h1>
             <p className="text-muted-foreground text-sm">Live and historical traces across supported runtimes.</p>
           </div>
-          <button
-            onClick={fetchRuns}
-            className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 bg-silicon-slate/30 px-3 py-2 text-sm hover:border-radiant-gold/60"
-          >
-            <RefreshCw size={16} />
-            Refresh
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={sweepStaleRuns}
+              disabled={sweepLoading}
+              className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 bg-silicon-slate/30 px-3 py-2 text-sm hover:border-radiant-gold/60 disabled:opacity-60"
+            >
+              <RefreshCw size={16} className={sweepLoading ? 'animate-spin' : ''} />
+              Sweep stale
+            </button>
+            <button
+              onClick={fetchRuns}
+              className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 bg-silicon-slate/30 px-3 py-2 text-sm hover:border-radiant-gold/60"
+            >
+              <RefreshCw size={16} />
+              Refresh
+            </button>
+          </div>
         </div>
+
+        {sweepMessage ? (
+          <div className="mb-4 rounded-lg border border-cyan-500/40 bg-cyan-500/10 p-3 text-sm text-cyan-100">
+            {sweepMessage}
+          </div>
+        ) : null}
 
         <div className="mb-5 flex gap-3 flex-wrap">
           <select

--- a/app/api/admin/agents/runs/stale-sweep/route.test.ts
+++ b/app/api/admin/agents/runs/stale-sweep/route.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  sweepStaleAgentRuns: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-stale-runs', () => ({
+  sweepStaleAgentRuns: mocks.sweepStaleAgentRuns,
+}))
+
+import { POST } from './route'
+
+function makeRequest() {
+  return new Request('http://localhost/api/admin/agents/runs/stale-sweep', {
+    method: 'POST',
+    headers: { authorization: 'Bearer token' },
+  })
+}
+
+describe('POST /api/admin/agents/runs/stale-sweep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.sweepStaleAgentRuns.mockResolvedValue({ checked: 3, marked: 1, runIds: ['run-1'] })
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(makeRequest() as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.sweepStaleAgentRuns).not.toHaveBeenCalled()
+  })
+
+  it('returns stale sweep results', async () => {
+    const response = await POST(makeRequest() as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      ok: true,
+      checked: 3,
+      marked: 1,
+      runIds: ['run-1'],
+    })
+  })
+})

--- a/app/api/admin/agents/runs/stale-sweep/route.ts
+++ b/app/api/admin/agents/runs/stale-sweep/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { sweepStaleAgentRuns } from '@/lib/agent-stale-runs'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * POST /api/admin/agents/runs/stale-sweep
+ *
+ * Marks queued/running agent runs as stale when they exceed stale_after or the
+ * default active-run threshold. Approval waits are intentionally excluded.
+ */
+export async function POST(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  try {
+    const result = await sweepStaleAgentRuns()
+    return NextResponse.json({ ok: true, ...result })
+  } catch (error) {
+    console.error('[agent-runs] stale sweep failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to sweep stale agent runs' },
+      { status: 500 },
+    )
+  }
+}

--- a/app/api/admin/agents/runtime-evaluation/route.test.ts
+++ b/app/api/admin/agents/runtime-evaluation/route.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  startAgentRun: vi.fn(),
+  recordAgentStep: vi.fn(),
+  attachAgentArtifact: vi.fn(),
+  endAgentRun: vi.fn(),
+  markAgentRunFailed: vi.fn(),
+  evaluateRuntimeAvailability: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-run', () => ({
+  startAgentRun: mocks.startAgentRun,
+  recordAgentStep: mocks.recordAgentStep,
+  attachAgentArtifact: mocks.attachAgentArtifact,
+  endAgentRun: mocks.endAgentRun,
+  markAgentRunFailed: mocks.markAgentRunFailed,
+}))
+
+vi.mock('@/lib/agent-runtime-evaluation', () => ({
+  evaluateRuntimeAvailability: mocks.evaluateRuntimeAvailability,
+}))
+
+import { POST } from './route'
+
+function makeRequest(body: Record<string, unknown> = {}) {
+  return new Request('http://localhost/api/admin/agents/runtime-evaluation', {
+    method: 'POST',
+    headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/admin/agents/runtime-evaluation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.startAgentRun.mockResolvedValue({ id: 'runtime-run-1' })
+    mocks.recordAgentStep.mockResolvedValue({ id: 'step-1' })
+    mocks.attachAgentArtifact.mockResolvedValue({ id: 'artifact-1' })
+    mocks.endAgentRun.mockResolvedValue(undefined)
+    mocks.markAgentRunFailed.mockResolvedValue(undefined)
+    mocks.evaluateRuntimeAvailability.mockResolvedValue({
+      runtime: 'opencode',
+      available: false,
+      executable: null,
+      probes: [{ command: 'opencode', found: false, path: null }],
+      safeForProductionAutomation: false,
+      nextSteps: ['Install and authenticate OpenCode/OpenClaw before assigning production work.'],
+    })
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(makeRequest() as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.startAgentRun).not.toHaveBeenCalled()
+  })
+
+  it('creates an observable failed run when OpenCode is unavailable', async () => {
+    const response = await POST(makeRequest({ runtime: 'opencode' }) as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual(expect.objectContaining({
+      ok: false,
+      run_id: 'runtime-run-1',
+      runtime: 'opencode',
+      available: false,
+    }))
+    expect(mocks.startAgentRun).toHaveBeenCalledWith(expect.objectContaining({
+      agentKey: 'opencode-evaluation',
+      runtime: 'opencode',
+      kind: 'runtime_evaluation',
+      triggeredByUserId: 'admin-user',
+    }))
+    expect(mocks.recordAgentStep).toHaveBeenCalledWith(expect.objectContaining({
+      runId: 'runtime-run-1',
+      status: 'failed',
+    }))
+    expect(mocks.attachAgentArtifact).toHaveBeenCalledWith(expect.objectContaining({
+      artifactType: 'runtime_evaluation',
+    }))
+    expect(mocks.markAgentRunFailed).toHaveBeenCalledWith(
+      'runtime-run-1',
+      'OpenCode/OpenClaw command not installed or not on PATH',
+      expect.objectContaining({ available: false }),
+    )
+  })
+
+  it('rejects unsupported runtime targets', async () => {
+    const response = await POST(makeRequest({ runtime: 'codex' }) as never)
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'Unsupported runtime evaluation target' })
+    expect(mocks.startAgentRun).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/admin/agents/runtime-evaluation/route.ts
+++ b/app/api/admin/agents/runtime-evaluation/route.ts
@@ -1,0 +1,118 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import {
+  attachAgentArtifact,
+  endAgentRun,
+  markAgentRunFailed,
+  recordAgentStep,
+  startAgentRun,
+} from '@/lib/agent-run'
+import { evaluateRuntimeAvailability } from '@/lib/agent-runtime-evaluation'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * POST /api/admin/agents/runtime-evaluation
+ *
+ * Creates an observable, side-effect-free evaluation trace for deferred worker
+ * runtimes. v1 intentionally probes availability only; it does not execute
+ * arbitrary worker tasks.
+ */
+export async function POST(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as { runtime?: string }
+  const runtime = body.runtime ?? 'opencode'
+  if (runtime !== 'opencode') {
+    return NextResponse.json({ error: 'Unsupported runtime evaluation target' }, { status: 400 })
+  }
+
+  const run = await startAgentRun({
+    agentKey: 'opencode-evaluation',
+    runtime: 'opencode',
+    kind: 'runtime_evaluation',
+    title: 'Evaluate OpenCode/OpenClaw runtime',
+    subject: { type: 'runtime', id: 'opencode', label: 'OpenCode/OpenClaw' },
+    triggerSource: 'admin_runtime_evaluation',
+    triggeredByUserId: auth.user.id,
+    currentStep: 'Checking runtime availability',
+    metadata: {
+      side_effects_allowed: false,
+      production_mutation_allowed: false,
+      execution_mode: 'availability_probe',
+    },
+    idempotencyKey: `runtime-evaluation:${runtime}:${auth.user.id}:${Date.now()}`,
+  })
+
+  try {
+    const evaluation = await evaluateRuntimeAvailability('opencode')
+
+    await recordAgentStep({
+      runId: run.id,
+      stepKey: 'availability_probe',
+      name: 'Checked OpenCode/OpenClaw command availability',
+      status: evaluation.available ? 'completed' : 'failed',
+      inputSummary: 'Checked PATH for opencode, openclaw, and opencode-ai commands.',
+      outputSummary: evaluation.available
+        ? `Available at ${evaluation.executable}`
+        : 'No OpenCode/OpenClaw command found.',
+      metadata: evaluation,
+      idempotencyKey: `${run.id}:availability-probe`,
+    })
+
+    await attachAgentArtifact({
+      runId: run.id,
+      artifactType: 'runtime_evaluation',
+      title: 'OpenCode/OpenClaw Runtime Evaluation',
+      refType: 'runtime',
+      refId: 'opencode',
+      metadata: evaluation,
+      idempotencyKey: `${run.id}:artifact:runtime-evaluation`,
+    })
+
+    if (!evaluation.available) {
+      await markAgentRunFailed(run.id, 'OpenCode/OpenClaw command not installed or not on PATH', {
+        runtime: 'opencode',
+        available: false,
+        next_steps: evaluation.nextSteps,
+      })
+      return NextResponse.json({
+        ok: false,
+        run_id: run.id,
+        runtime: 'opencode',
+        available: false,
+        next_steps: evaluation.nextSteps,
+      })
+    }
+
+    await endAgentRun({
+      runId: run.id,
+      status: 'completed',
+      currentStep: 'Runtime availability confirmed',
+      outcome: {
+        runtime: 'opencode',
+        available: true,
+        executable: evaluation.executable,
+        safe_for_production_automation: false,
+      },
+    })
+
+    return NextResponse.json({
+      ok: true,
+      run_id: run.id,
+      runtime: 'opencode',
+      available: true,
+      executable: evaluation.executable,
+      next_steps: evaluation.nextSteps,
+    })
+  } catch (error) {
+    await markAgentRunFailed(run.id, error instanceof Error ? error.message : 'Runtime evaluation failed')
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Runtime evaluation failed', run_id: run.id },
+      { status: 500 },
+    )
+  }
+}

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -113,6 +113,16 @@ Use `POST /api/admin/agents/approval-drill` or the **Approval Drill** card on `/
 - approve/reject decisions write through `agent_approvals`,
 - rejected drills terminate without touching a production workflow.
 
+## OpenCode/OpenClaw Evaluation
+
+Use `POST /api/admin/agents/runtime-evaluation` or the **Runtime Evaluation** card on `/admin/agents` to create an observable `opencode` runtime evaluation run. The v1 probe is deliberately side-effect free: it checks whether `opencode`, `openclaw`, or `opencode-ai` is available on `PATH`, records the result as a step and artifact, and fails the run when no executable is installed.
+
+This keeps OpenCode/OpenClaw out of production automation until installation, auth, rollback, and audit behavior are proven through Agent Operations.
+
+## Stale Run Sweep
+
+Use `POST /api/admin/agents/runs/stale-sweep` or the **Sweep stale** button on `/admin/agents/runs` to mark queued/running runs as `stale` when they pass `stale_after` or the default active-run threshold. Runs waiting for approval are intentionally excluded so human checkpoints do not auto-expire as infrastructure failures.
+
 ## Safety Rules
 
 - New agent work should create an `agent_run` before doing meaningful work.

--- a/lib/agent-runtime-evaluation.ts
+++ b/lib/agent-runtime-evaluation.ts
@@ -1,0 +1,69 @@
+import { access } from 'node:fs/promises'
+import { constants } from 'node:fs'
+import path from 'node:path'
+import type { AgentRuntime } from '@/lib/agent-run'
+
+export type RuntimeEvaluationTarget = Extract<AgentRuntime, 'opencode'>
+
+export type RuntimeCommandProbe = {
+  command: string
+  found: boolean
+  path: string | null
+}
+
+export type RuntimeEvaluationResult = {
+  runtime: RuntimeEvaluationTarget
+  available: boolean
+  executable: string | null
+  probes: RuntimeCommandProbe[]
+  safeForProductionAutomation: false
+  nextSteps: string[]
+}
+
+const RUNTIME_COMMANDS: Record<RuntimeEvaluationTarget, string[]> = {
+  opencode: ['opencode', 'openclaw', 'opencode-ai'],
+}
+
+async function isExecutable(filePath: string) {
+  try {
+    await access(filePath, constants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export async function probeCommand(command: string, pathValue = process.env.PATH ?? ''): Promise<RuntimeCommandProbe> {
+  for (const dir of pathValue.split(path.delimiter).filter(Boolean)) {
+    const candidate = path.join(dir, command)
+    if (await isExecutable(candidate)) {
+      return { command, found: true, path: candidate }
+    }
+  }
+
+  return { command, found: false, path: null }
+}
+
+export async function evaluateRuntimeAvailability(runtime: RuntimeEvaluationTarget): Promise<RuntimeEvaluationResult> {
+  const probes = await Promise.all(RUNTIME_COMMANDS[runtime].map((command) => probeCommand(command)))
+  const executable = probes.find((probe) => probe.found)?.path ?? null
+
+  return {
+    runtime,
+    available: executable != null,
+    executable,
+    probes,
+    safeForProductionAutomation: false,
+    nextSteps: executable
+      ? [
+          'Run an isolated read-only test task in a disposable worktree.',
+          'Confirm auth configuration without exposing secrets.',
+          'Keep production writes behind agent_approvals.',
+        ]
+      : [
+          'Install and authenticate OpenCode/OpenClaw before assigning production work.',
+          'Run one observable test task through Agent Operations.',
+          'Prove rollback and audit behavior before enabling automation.',
+        ],
+  }
+}

--- a/lib/agent-stale-runs.test.ts
+++ b/lib/agent-stale-runs.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: null,
+}))
+
+import { isAgentRunStale } from './agent-stale-runs'
+
+const now = new Date('2026-04-30T12:00:00.000Z')
+
+describe('isAgentRunStale', () => {
+  it('marks queued and running runs stale after the default threshold', () => {
+    expect(isAgentRunStale({
+      status: 'running',
+      started_at: '2026-04-30T11:20:00.000Z',
+      stale_after: null,
+    }, now)).toBe(true)
+
+    expect(isAgentRunStale({
+      status: 'queued',
+      started_at: '2026-04-30T11:20:00.000Z',
+      stale_after: null,
+    }, now)).toBe(true)
+  })
+
+  it('honors explicit stale_after timestamps', () => {
+    expect(isAgentRunStale({
+      status: 'running',
+      started_at: '2026-04-30T11:59:00.000Z',
+      stale_after: '2026-04-30T11:59:30.000Z',
+    }, now)).toBe(true)
+  })
+
+  it('does not mark approval waits or terminal runs stale', () => {
+    expect(isAgentRunStale({
+      status: 'waiting_for_approval',
+      started_at: '2026-04-30T10:00:00.000Z',
+      stale_after: '2026-04-30T11:00:00.000Z',
+    }, now)).toBe(false)
+
+    expect(isAgentRunStale({
+      status: 'failed',
+      started_at: '2026-04-30T10:00:00.000Z',
+      stale_after: null,
+    }, now)).toBe(false)
+  })
+})

--- a/lib/agent-stale-runs.ts
+++ b/lib/agent-stale-runs.ts
@@ -1,0 +1,101 @@
+import { supabaseAdmin } from '@/lib/supabase'
+import type { AgentRunStatus } from '@/lib/agent-run'
+
+export const DEFAULT_AGENT_RUN_STALE_AFTER_MS = 30 * 60 * 1000
+
+export type StaleAgentRunCandidate = {
+  id: string
+  runtime: string
+  kind: string
+  status: AgentRunStatus
+  started_at: string
+  stale_after: string | null
+  current_step: string | null
+}
+
+export type StaleSweepResult = {
+  checked: number
+  marked: number
+  runIds: string[]
+}
+
+export function isAgentRunStale(
+  run: Pick<StaleAgentRunCandidate, 'status' | 'started_at' | 'stale_after'>,
+  now = new Date(),
+  defaultStaleAfterMs = DEFAULT_AGENT_RUN_STALE_AFTER_MS,
+) {
+  if (run.status !== 'queued' && run.status !== 'running') return false
+
+  const nowMs = now.getTime()
+  if (run.stale_after && nowMs > new Date(run.stale_after).getTime()) return true
+
+  return nowMs - new Date(run.started_at).getTime() > defaultStaleAfterMs
+}
+
+function db() {
+  if (!supabaseAdmin) {
+    throw new Error('Database not available')
+  }
+  return supabaseAdmin
+}
+
+export async function sweepStaleAgentRuns(now = new Date()): Promise<StaleSweepResult> {
+  const { data, error } = await db()
+    .from('agent_runs')
+    .select('id, runtime, kind, status, started_at, stale_after, current_step')
+    .in('status', ['queued', 'running'])
+    .order('started_at', { ascending: true })
+    .limit(250)
+
+  if (error) {
+    throw new Error(`Failed to read active agent runs: ${error.message}`)
+  }
+
+  const candidates = (data || []) as StaleAgentRunCandidate[]
+  const staleRuns = candidates.filter((run) => isAgentRunStale(run, now))
+  const completedAt = now.toISOString()
+
+  for (const run of staleRuns) {
+    const outcome = {
+      stale_sweep: true,
+      previous_status: run.status,
+      previous_step: run.current_step,
+      stale_after: run.stale_after,
+    }
+
+    const { error: updateError } = await db()
+      .from('agent_runs')
+      .update({
+        status: 'stale',
+        completed_at: completedAt,
+        current_step: 'stale',
+        error_message: 'Marked stale by agent run sweep',
+        outcome,
+        updated_at: completedAt,
+      })
+      .eq('id', run.id)
+      .in('status', ['queued', 'running'])
+
+    if (updateError) {
+      throw new Error(`Failed to mark agent run stale: ${updateError.message}`)
+    }
+
+    await db()
+      .from('agent_run_events')
+      .insert({
+        run_id: run.id,
+        event_type: 'run_marked_stale',
+        severity: 'warning',
+        message: 'Marked stale by agent run sweep',
+        metadata: outcome,
+        occurred_at: completedAt,
+        idempotency_key: `${run.id}:stale:${completedAt}`,
+      })
+  }
+
+  return {
+    checked: candidates.length,
+    marked: staleRuns.length,
+    runIds: staleRuns.map((run) => run.id),
+  }
+}


### PR DESCRIPTION
## Summary
- add side-effect-free OpenCode/OpenClaw runtime evaluation traces in Agent Operations
- add stale-run sweep API and admin control for queued/running agent runs
- document runtime evaluation and stale sweep operations

## Validation
- npx vitest run app/api/admin/agents/runtime-evaluation/route.test.ts app/api/admin/agents/runs/stale-sweep/route.test.ts lib/agent-stale-runs.test.ts lib/agent-run.test.ts app/api/admin/agents/approval-drill/route.test.ts app/api/admin/agents/hermes/system-health/route.test.ts lib/agent-policy.test.ts
- npx tsc --noEmit --pretty false
- npm run lint -- --file app/admin/agents/page.tsx --file app/admin/agents/runs/page.tsx --file app/api/admin/agents/runtime-evaluation/route.ts --file app/api/admin/agents/runs/stale-sweep/route.ts --file lib/agent-runtime-evaluation.ts --file lib/agent-stale-runs.ts
- npm run build

## Notes
- OpenCode/OpenClaw remains unavailable for production automation until installation/auth/rollback are proven.
- Stale sweep intentionally excludes waiting_for_approval runs so human checkpoints do not expire as infrastructure failures.