### PR TITLE
feat: add agent ops morning review cron

### DIFF
--- a/app/api/cron/agent-ops-morning-review/route.test.ts
+++ b/app/api/cron/agent-ops-morning-review/route.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  runAgentOpsMorningReview: vi.fn(),
+}))
+
+vi.mock('@/lib/agent-ops-morning-review', () => ({
+  runAgentOpsMorningReview: mocks.runAgentOpsMorningReview,
+}))
+
+import { POST } from './route'
+
+function makeRequest(token?: string) {
+  return new Request('http://localhost/api/cron/agent-ops-morning-review', {
+    method: 'POST',
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+  })
+}
+
+describe('POST /api/cron/agent-ops-morning-review', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.N8N_INGEST_SECRET = 'secret'
+    mocks.runAgentOpsMorningReview.mockResolvedValue({
+      runId: 'review-run-1',
+      generatedAt: '2026-05-01T09:00:00.000Z',
+      overall: 'warning',
+      staleSweep: { checked: 2, marked: 1, runIds: ['stale-1'] },
+      slackNotified: false,
+      summaryMarkdown: '# Agent Ops Morning Review',
+      health: {
+        warnings: ['1 agent run(s) failed in the last 24 hours'],
+      },
+    })
+  })
+
+  it('requires the n8n ingest secret', async () => {
+    const response = await POST(makeRequest('wrong') as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.runAgentOpsMorningReview).not.toHaveBeenCalled()
+  })
+
+  it('runs the morning review and returns the trace summary', async () => {
+    const response = await POST(makeRequest('secret') as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      ok: true,
+      run_id: 'review-run-1',
+      overall: 'warning',
+      stale_sweep: { checked: 2, marked: 1, runIds: ['stale-1'] },
+      slack_notified: false,
+      warnings: ['1 agent run(s) failed in the last 24 hours'],
+      summary_markdown: '# Agent Ops Morning Review',
+    })
+    expect(mocks.runAgentOpsMorningReview).toHaveBeenCalledWith('cron_agent_ops_morning_review')
+  })
+})

--- a/app/api/cron/agent-ops-morning-review/route.ts
+++ b/app/api/cron/agent-ops-morning-review/route.ts
@@ -1,0 +1,42 @@
+/**
+ * POST /api/cron/agent-ops-morning-review
+ *
+ * Runs the daily Agent Operations review without a human in the loop.
+ * Auth: Bearer N8N_INGEST_SECRET, matching the existing n8n-owned cron pattern.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { runAgentOpsMorningReview } from '@/lib/agent-ops-morning-review'
+
+export const dynamic = 'force-dynamic'
+
+function isAuthorized(request: NextRequest) {
+  const expectedSecret = process.env.N8N_INGEST_SECRET
+  const token = request.headers.get('authorization')?.replace(/^Bearer\s+/i, '')
+  return Boolean(expectedSecret && token === expectedSecret)
+}
+
+export async function POST(request: NextRequest) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const result = await runAgentOpsMorningReview('cron_agent_ops_morning_review')
+    return NextResponse.json({
+      ok: result.overall !== 'error',
+      run_id: result.runId,
+      overall: result.overall,
+      stale_sweep: result.staleSweep,
+      slack_notified: result.slackNotified,
+      warnings: result.health.warnings,
+      summary_markdown: result.summaryMarkdown,
+    })
+  } catch (error) {
+    console.error('[agent-ops-morning-review] failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Agent Ops morning review failed' },
+      { status: 500 },
+    )
+  }
+}

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -123,6 +123,18 @@ This keeps OpenCode/OpenClaw out of production automation until installation, au
 
 Use `POST /api/admin/agents/runs/stale-sweep` or the **Sweep stale** button on `/admin/agents/runs` to mark queued/running runs as `stale` when they pass `stale_after` or the default active-run threshold. Runs waiting for approval are intentionally excluded so human checkpoints do not auto-expire as infrastructure failures.
 
+## Agent Ops Morning Review
+
+Use `POST /api/cron/agent-ops-morning-review` with `Authorization: Bearer N8N_INGEST_SECRET` to run the daily no-human-in-the-loop review. The route:
+
+- creates a traceable `n8n` runtime run,
+- sweeps stale queued/running agent runs,
+- builds the Agent Operations health summary,
+- attaches an `agent_ops_morning_review` artifact,
+- optionally posts a Slack summary when `SLACK_AGENT_OPS_WEBHOOK_URL` is configured.
+
+Recommended schedule: n8n Cloud weekday morning trigger, owned by the automation layer. Slack remains a notification surface only; Portfolio admin and `agent_runs` remain the source of truth.
+
 ## Safety Rules
 
 - New agent work should create an `agent_run` before doing meaningful work.

--- a/lib/agent-ops-morning-review.test.ts
+++ b/lib/agent-ops-morning-review.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/agent-run', () => ({
+  attachAgentArtifact: vi.fn(),
+  endAgentRun: vi.fn(),
+  markAgentRunFailed: vi.fn(),
+  recordAgentEvent: vi.fn(),
+  recordAgentStep: vi.fn(),
+  startAgentRun: vi.fn(),
+}))
+
+vi.mock('@/lib/agent-stale-runs', () => ({
+  sweepStaleAgentRuns: vi.fn(),
+}))
+
+vi.mock('@/lib/hermes-system-health', () => ({
+  buildHermesSystemHealthSummary: vi.fn(),
+}))
+
+import { buildAgentOpsMorningReviewMarkdown } from './agent-ops-morning-review'
+
+describe('buildAgentOpsMorningReviewMarkdown', () => {
+  it('summarizes stale sweep, agent runs, costs, and warnings', () => {
+    const markdown = buildAgentOpsMorningReviewMarkdown({
+      generatedAt: '2026-05-01T09:00:00.000Z',
+      overall: 'warning',
+      runId: 'run-1',
+      staleSweep: { checked: 4, marked: 1, runIds: ['stale-1'] },
+      health: {
+        generatedAt: '2026-05-01T09:00:00.000Z',
+        overall: 'warning',
+        summaryMarkdown: '',
+        warnings: ['1 agent run(s) failed in the last 24 hours'],
+        signals: {
+          database: 'connected',
+          n8n: { deploymentTier: 'production', mockEnabled: false, outboundDisabled: false },
+          agentRuns24h: { total: 8, failed: 1, stale: 0, running: 2, byRuntime: { n8n: 3 } },
+          costs24h: { totalUsd: 0.1234, events: 2 },
+          workflows: {
+            socialContent: { ok: true, data: [] },
+            valueEvidence: { ok: true, data: [] },
+            warmLeads: { ok: true, data: [] },
+          },
+        },
+      },
+    })
+
+    expect(markdown).toContain('# Agent Ops Morning Review')
+    expect(markdown).toContain('Overall: warning')
+    expect(markdown).toContain('- Active runs checked: 4')
+    expect(markdown).toContain('- Runs marked stale: 1')
+    expect(markdown).toContain('- Agent runs: 8')
+    expect(markdown).toContain('- Cost total: $0.1234')
+    expect(markdown).toContain('- 1 agent run(s) failed in the last 24 hours')
+  })
+})

--- a/lib/agent-ops-morning-review.ts
+++ b/lib/agent-ops-morning-review.ts
@@ -1,0 +1,212 @@
+import {
+  attachAgentArtifact,
+  endAgentRun,
+  markAgentRunFailed,
+  recordAgentEvent,
+  recordAgentStep,
+  startAgentRun,
+} from '@/lib/agent-run'
+import { sweepStaleAgentRuns, type StaleSweepResult } from '@/lib/agent-stale-runs'
+import { buildHermesSystemHealthSummary, type HermesSystemHealthSummary } from '@/lib/hermes-system-health'
+
+export type AgentOpsMorningReviewResult = {
+  runId: string
+  generatedAt: string
+  overall: HermesSystemHealthSummary['overall']
+  staleSweep: StaleSweepResult
+  health: HermesSystemHealthSummary
+  slackNotified: boolean
+  summaryMarkdown: string
+}
+
+function baseUrl() {
+  return (
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    process.env.PORTFOLIO_BASE_URL ||
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    'https://amadutown.com'
+  ).replace(/\/$/, '')
+}
+
+export function buildAgentOpsMorningReviewMarkdown(input: {
+  generatedAt: string
+  overall: HermesSystemHealthSummary['overall']
+  staleSweep: StaleSweepResult
+  health: HermesSystemHealthSummary
+  runId?: string
+}) {
+  const agentOpsUrl = `${baseUrl()}/admin/agents/runs${input.runId ? `/${input.runId}` : ''}`
+  const recent = input.health.signals.agentRuns24h
+
+  return [
+    '# Agent Ops Morning Review',
+    '',
+    `Generated: ${input.generatedAt}`,
+    `Overall: ${input.overall}`,
+    `Review: ${agentOpsUrl}`,
+    '',
+    '## Run Hygiene',
+    '',
+    `- Active runs checked: ${input.staleSweep.checked}`,
+    `- Runs marked stale: ${input.staleSweep.marked}`,
+    '',
+    '## Last 24 Hours',
+    '',
+    `- Agent runs: ${recent.total}`,
+    `- Running/queued: ${recent.running}`,
+    `- Failed: ${recent.failed}`,
+    `- Stale: ${recent.stale}`,
+    `- Cost events: ${input.health.signals.costs24h.events}`,
+    `- Cost total: $${input.health.signals.costs24h.totalUsd.toFixed(4)}`,
+    '',
+    '## Warnings',
+    '',
+    ...(input.health.warnings.length > 0 ? input.health.warnings.map((warning) => `- ${warning}`) : ['- None']),
+  ].join('\n')
+}
+
+async function notifySlack(summaryMarkdown: string) {
+  const webhookUrl = process.env.SLACK_AGENT_OPS_WEBHOOK_URL
+  if (!webhookUrl || !webhookUrl.startsWith('https://')) return false
+
+  const text = summaryMarkdown
+    .replace(/^# Agent Ops Morning Review/m, '*Agent Ops Morning Review*')
+    .replace(/^## /gm, '*')
+    .replace(/\n\n/g, '\n')
+
+  try {
+    const response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text }),
+    })
+    if (!response.ok) {
+      console.warn('[agent-ops-morning-review] Slack webhook failed:', response.status)
+      return false
+    }
+    return true
+  } catch (error) {
+    console.warn(
+      '[agent-ops-morning-review] Slack webhook error:',
+      error instanceof Error ? error.message : error,
+    )
+    return false
+  }
+}
+
+export async function runAgentOpsMorningReview(triggerSource = 'cron_agent_ops_morning_review') {
+  const generatedAt = new Date().toISOString()
+  let runId: string | null = null
+
+  try {
+    const run = await startAgentRun({
+      agentKey: 'n8n-automation',
+      runtime: 'n8n',
+      kind: 'agent_ops_morning_review',
+      title: 'Run Agent Ops morning review',
+      subject: { type: 'system', id: 'agent-operations', label: 'Agent Operations' },
+      triggerSource,
+      currentStep: 'Sweeping stale agent runs',
+      metadata: {
+        execution_mode: 'scheduled_review',
+        production_mutation_allowed: true,
+        mutation_scope: ['agent_runs', 'agent_run_events', 'agent_run_artifacts'],
+        slack_notification_configured: Boolean(process.env.SLACK_AGENT_OPS_WEBHOOK_URL),
+      },
+      idempotencyKey: `agent-ops-morning-review:${generatedAt.slice(0, 10)}`,
+    })
+    runId = run.id
+
+    const staleSweep = await sweepStaleAgentRuns()
+    await recordAgentStep({
+      runId,
+      stepKey: 'stale_sweep',
+      name: 'Swept stale agent runs',
+      status: 'completed',
+      outputSummary: `Checked ${staleSweep.checked}; marked ${staleSweep.marked} stale.`,
+      metadata: staleSweep,
+      idempotencyKey: `${runId}:stale-sweep`,
+    })
+
+    const health = await buildHermesSystemHealthSummary()
+    await recordAgentStep({
+      runId,
+      stepKey: 'health_summary',
+      name: 'Built Agent Operations health summary',
+      status: health.overall === 'error' ? 'failed' : 'completed',
+      outputSummary: `Overall: ${health.overall}; warnings: ${health.warnings.length}`,
+      metadata: {
+        overall: health.overall,
+        warnings: health.warnings,
+        signals: health.signals,
+      },
+      idempotencyKey: `${runId}:health-summary`,
+    })
+
+    const summaryMarkdown = buildAgentOpsMorningReviewMarkdown({
+      generatedAt,
+      overall: health.overall,
+      staleSweep,
+      health,
+      runId,
+    })
+
+    const slackNotified = await notifySlack(summaryMarkdown)
+    await recordAgentEvent({
+      runId,
+      eventType: slackNotified ? 'slack_notification_sent' : 'slack_notification_skipped',
+      severity: 'info',
+      message: slackNotified
+        ? 'Agent Ops morning review posted to Slack'
+        : 'Slack notification skipped or unavailable',
+      metadata: { configured: Boolean(process.env.SLACK_AGENT_OPS_WEBHOOK_URL) },
+      idempotencyKey: `${runId}:slack-notification`,
+    })
+
+    await attachAgentArtifact({
+      runId,
+      artifactType: 'agent_ops_morning_review',
+      title: `Agent Ops Morning Review - ${health.overall}`,
+      refType: 'agent_run',
+      refId: runId,
+      metadata: {
+        summary_markdown: summaryMarkdown,
+        stale_sweep: staleSweep,
+        health_signals: health.signals,
+        warnings: health.warnings,
+        slack_notified: slackNotified,
+      },
+      idempotencyKey: `${runId}:artifact:morning-review`,
+    })
+
+    await endAgentRun({
+      runId,
+      status: health.overall === 'error' ? 'failed' : 'completed',
+      currentStep: 'Agent Ops morning review ready',
+      errorMessage: health.overall === 'error' ? health.warnings[0] ?? 'Agent Ops morning review failed' : null,
+      outcome: {
+        overall: health.overall,
+        warning_count: health.warnings.length,
+        stale_marked: staleSweep.marked,
+        slack_notified: slackNotified,
+        generated_at: generatedAt,
+      },
+    })
+
+    return {
+      runId,
+      generatedAt,
+      overall: health.overall,
+      staleSweep,
+      health,
+      slackNotified,
+      summaryMarkdown,
+    } satisfies AgentOpsMorningReviewResult
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Agent Ops morning review failed'
+    if (runId) {
+      await markAgentRunFailed(runId, message, { trigger_source: triggerSource }).catch(() => {})
+    }
+    throw error
+  }
+}


### PR DESCRIPTION
## Summary
- add a cron-safe Agent Ops morning review endpoint protected by N8N_INGEST_SECRET
- run stale sweep + Agent Operations health summary in one traceable n8n runtime run
- attach a morning review artifact and optionally notify Slack through SLACK_AGENT_OPS_WEBHOOK_URL
- document the n8n-owned weekday morning schedule pattern

## Validation
- npx vitest run app/api/cron/agent-ops-morning-review/route.test.ts lib/agent-ops-morning-review.test.ts app/api/admin/agents/runs/stale-sweep/route.test.ts lib/agent-stale-runs.test.ts app/api/admin/agents/hermes/system-health/route.test.ts lib/agent-run.test.ts
- npx tsc --noEmit --pretty false
- npm run lint -- --file app/api/cron/agent-ops-morning-review/route.ts --file lib/agent-ops-morning-review.ts
- npm run build

## Notes
- Slack is notification-only; Portfolio admin and agent_runs remain the source of truth.
- No Vercel cron schedule is added in this PR. n8n Cloud should call POST /api/cron/agent-ops-morning-review with Bearer N8N_INGEST_SECRET.