### PR TITLE
[codex] add technology and media bakeoff planning

### DIFF
--- a/app/admin/technology-bakeoffs/page.test.tsx
+++ b/app/admin/technology-bakeoffs/page.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { ADMIN_NAV } from '@/lib/admin-nav'
+import TechnologyBakeoffsPage from './page'
+
+vi.mock('@/components/ProtectedRoute', () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
+describe('TechnologyBakeoffsContent', () => {
+  it('renders the default media bakeoff plan', () => {
+    render(<TechnologyBakeoffsPage />)
+
+    expect(screen.getByRole('heading', { name: 'Technology Bakeoffs' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Image and video generation' })).toBeInTheDocument()
+    expect(screen.getByText(/Read-only planning mode/i)).toBeInTheDocument()
+    expect(screen.getAllByText(/fal media model gallery/i).length).toBeGreaterThan(0)
+  })
+
+  it('updates the plan when another surface is selected', () => {
+    render(<TechnologyBakeoffsPage />)
+
+    fireEvent.change(screen.getByLabelText('Surface'), {
+      target: { value: 'analytics' },
+    })
+
+    expect(screen.getByRole('heading', { name: 'Analytics and attribution' })).toBeInTheDocument()
+    expect(screen.getAllByText(/Vercel analytics/i).length).toBeGreaterThan(0)
+  })
+
+  it('is linked from Quality & insights admin navigation', () => {
+    const qualityCategory = ADMIN_NAV.categories.find((category) => category.label === 'Quality & insights')
+
+    expect(qualityCategory?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: 'Technology Bakeoffs',
+          href: '/admin/technology-bakeoffs',
+        }),
+      ])
+    )
+  })
+})

--- a/app/admin/technology-bakeoffs/page.tsx
+++ b/app/admin/technology-bakeoffs/page.tsx
@@ -1,0 +1,275 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import type { ReactNode } from 'react'
+import {
+  ArrowRight,
+  BarChart3,
+  CheckCircle2,
+  ClipboardList,
+  RotateCcw,
+  ShieldCheck,
+} from 'lucide-react'
+import ProtectedRoute from '@/components/ProtectedRoute'
+import Breadcrumbs from '@/components/admin/Breadcrumbs'
+import {
+  TECHNOLOGY_BAKEOFF_PROFILES,
+  TECHNOLOGY_BAKEOFF_SURFACES,
+  buildTechnologyBakeoffPlan,
+  type TechnologyBakeoffPriority,
+  type TechnologyBakeoffSurface,
+} from '@/lib/technology-bakeoff'
+
+const PRIORITIES: Array<{ value: TechnologyBakeoffPriority; label: string }> = [
+  { value: 'quality', label: 'Quality' },
+  { value: 'speed', label: 'Speed' },
+  { value: 'cost', label: 'Cost' },
+  { value: 'reliability', label: 'Reliability' },
+  { value: 'governance', label: 'Governance' },
+  { value: 'brand_control', label: 'Brand control' },
+  { value: 'conversion', label: 'Conversion' },
+]
+
+export default function TechnologyBakeoffsPage() {
+  return (
+    <ProtectedRoute requireAdmin>
+      <TechnologyBakeoffsContent />
+    </ProtectedRoute>
+  )
+}
+
+function TechnologyBakeoffsContent() {
+  const [surface, setSurface] = useState<TechnologyBakeoffSurface>('media_generation')
+  const [priority, setPriority] = useState<TechnologyBakeoffPriority>('reliability')
+  const [objective, setObjective] = useState('Choose the best current tool before changing the Portfolio default.')
+  const [currentDefault, setCurrentDefault] = useState('')
+  const [knownFailure, setKnownFailure] = useState('')
+  const [candidateOverrides, setCandidateOverrides] = useState('')
+
+  const plan = useMemo(() => {
+    return buildTechnologyBakeoffPlan({
+      surface,
+      objective,
+      priority,
+      currentDefault: currentDefault || undefined,
+      knownFailure: knownFailure || undefined,
+      candidateOverrides: candidateOverrides
+        .split(',')
+        .map((item) => item.trim())
+        .filter(Boolean),
+    })
+  }, [candidateOverrides, currentDefault, knownFailure, objective, priority, surface])
+
+  const profile = TECHNOLOGY_BAKEOFF_PROFILES[surface]
+
+  return (
+    <div className="min-h-screen bg-background text-foreground p-6 lg:p-8">
+      <div className="max-w-7xl mx-auto">
+        <Breadcrumbs items={[{ label: 'Admin Dashboard', href: '/admin' }, { label: 'Technology Bakeoffs' }]} />
+
+        <div className="mb-8 flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <h1 className="text-3xl font-bold mb-1">Technology Bakeoffs</h1>
+            <p className="text-muted-foreground text-sm max-w-3xl">
+              Compare fast-moving tools before Portfolio promotes a new default. V1 creates the scoring plan and
+              promotion gate only; it does not call vendors, persist results, or change production settings.
+            </p>
+          </div>
+          <div className="rounded-lg border border-radiant-gold/40 bg-radiant-gold/10 px-4 py-3 text-sm text-radiant-gold">
+            Read-only planning mode
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 xl:grid-cols-[360px_minmax(0,1fr)] gap-6">
+          <aside className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/25 p-5 h-fit">
+            <h2 className="text-lg font-semibold mb-4">Bakeoff Setup</h2>
+
+            <label className="block text-sm font-medium mb-2" htmlFor="surface">
+              Surface
+            </label>
+            <select
+              id="surface"
+              value={surface}
+              onChange={(event) => setSurface(event.target.value as TechnologyBakeoffSurface)}
+              className="w-full rounded-lg border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm mb-4"
+            >
+              {TECHNOLOGY_BAKEOFF_SURFACES.map((item) => (
+                <option key={item} value={item}>
+                  {TECHNOLOGY_BAKEOFF_PROFILES[item].label}
+                </option>
+              ))}
+            </select>
+
+            <label className="block text-sm font-medium mb-2" htmlFor="objective">
+              Decision question
+            </label>
+            <textarea
+              id="objective"
+              value={objective}
+              onChange={(event) => setObjective(event.target.value)}
+              rows={4}
+              className="w-full rounded-lg border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm mb-4"
+            />
+
+            <label className="block text-sm font-medium mb-2" htmlFor="priority">
+              Priority
+            </label>
+            <select
+              id="priority"
+              value={priority}
+              onChange={(event) => setPriority(event.target.value as TechnologyBakeoffPriority)}
+              className="w-full rounded-lg border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm mb-4"
+            >
+              {PRIORITIES.map((item) => (
+                <option key={item.value} value={item.value}>
+                  {item.label}
+                </option>
+              ))}
+            </select>
+
+            <label className="block text-sm font-medium mb-2" htmlFor="current-default">
+              Current default
+            </label>
+            <input
+              id="current-default"
+              value={currentDefault}
+              onChange={(event) => setCurrentDefault(event.target.value)}
+              placeholder="Optional"
+              className="w-full rounded-lg border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm mb-4"
+            />
+
+            <label className="block text-sm font-medium mb-2" htmlFor="known-failure">
+              Known failure
+            </label>
+            <input
+              id="known-failure"
+              value={knownFailure}
+              onChange={(event) => setKnownFailure(event.target.value)}
+              placeholder="Optional"
+              className="w-full rounded-lg border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm mb-4"
+            />
+
+            <label className="block text-sm font-medium mb-2" htmlFor="candidate-overrides">
+              Extra candidates
+            </label>
+            <input
+              id="candidate-overrides"
+              value={candidateOverrides}
+              onChange={(event) => setCandidateOverrides(event.target.value)}
+              placeholder="Comma separated"
+              className="w-full rounded-lg border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm"
+            />
+          </aside>
+
+          <main className="space-y-6">
+            <section className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/25 p-5">
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                <div>
+                  <p className="text-sm text-muted-foreground">{profile.adminArea}</p>
+                  <h2 className="text-2xl font-semibold mt-1">{plan.surfaceLabel}</h2>
+                </div>
+                <span className="rounded-full border border-silicon-slate/60 bg-background/50 px-3 py-1 text-xs text-muted-foreground">
+                  {plan.specialistSource ? `Specialist: ${plan.specialistSource}` : 'Generic evaluator'}
+                </span>
+              </div>
+              <p className="mt-4 text-sm text-muted-foreground">{plan.recommendedAction}</p>
+              <div className="mt-5 grid grid-cols-1 md:grid-cols-3 gap-3">
+                <Signal label="Decision" value={plan.decision.replaceAll('_', ' ')} />
+                <Signal label="Current default" value={plan.currentDefault} />
+                <Signal label="Fallback" value={plan.fallback} />
+              </div>
+            </section>
+
+            <section className="grid grid-cols-1 lg:grid-cols-2 gap-5">
+              <Panel icon={<ClipboardList size={18} />} title="Benchmark Runbook" items={plan.benchmarkRunbook} />
+              <Panel icon={<ShieldCheck size={18} />} title="Promotion Gate" items={plan.promotionGate} />
+              <Panel icon={<RotateCcw size={18} />} title="Rollback Plan" items={plan.rollbackPlan} />
+              <Panel icon={<CheckCircle2 size={18} />} title="Missing Evidence" items={plan.missingEvidence} />
+            </section>
+
+            <section className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/25 p-5">
+              <div className="flex items-center gap-2 mb-4">
+                <BarChart3 size={18} className="text-radiant-gold" />
+                <h2 className="text-lg font-semibold">Scoring Dimensions</h2>
+              </div>
+              <div className="space-y-3">
+                {plan.scores.map((score) => (
+                  <div key={score.dimension} className="rounded-lg border border-silicon-slate/60 bg-background/35 p-4">
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <p className="font-medium">{score.dimension}</p>
+                      <p className="text-sm text-muted-foreground">
+                        {score.score}/5 x {Math.round(score.weight * 100)}% = {score.weightedScore.toFixed(2)}
+                      </p>
+                    </div>
+                    <p className="mt-2 text-sm text-muted-foreground">{score.evidence}</p>
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            <section className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/25 p-5">
+              <div className="flex items-center gap-2 mb-4">
+                <ArrowRight size={18} className="text-radiant-gold" />
+                <h2 className="text-lg font-semibold">Candidates</h2>
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                {plan.candidates.map((candidate) => (
+                  <div key={candidate.id} className="rounded-lg border border-silicon-slate/60 bg-background/35 p-4">
+                    <p className="font-semibold">{candidate.label}</p>
+                    <p className="text-xs text-radiant-gold mt-1">{candidate.role}</p>
+                    <p className="text-sm text-muted-foreground mt-3">{candidate.bestFor}</p>
+                    <p className="text-xs text-muted-foreground mt-3">Watch: {candidate.watchOutFor}</p>
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            <section className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/25 p-5">
+              <h2 className="text-lg font-semibold mb-3">Integration Notes</h2>
+              <ul className="space-y-2 text-sm text-muted-foreground">
+                {plan.integrationNotes.map((item) => (
+                  <li key={item} className="flex gap-2">
+                    <span className="mt-2 h-1.5 w-1.5 rounded-full bg-radiant-gold shrink-0" />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+              <p className="mt-5 rounded-lg border border-silicon-slate/60 bg-background/35 p-4 text-sm">
+                <span className="font-medium">Next step: </span>
+                {plan.nextImplementationStep}
+              </p>
+            </section>
+          </main>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Signal({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-silicon-slate/60 bg-background/35 p-4">
+      <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="mt-2 text-sm font-medium capitalize">{value}</p>
+    </div>
+  )
+}
+
+function Panel({ icon, title, items }: { icon: ReactNode; title: string; items: string[] }) {
+  return (
+    <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/25 p-5">
+      <div className="flex items-center gap-2 mb-4">
+        <span className="text-radiant-gold">{icon}</span>
+        <h2 className="text-lg font-semibold">{title}</h2>
+      </div>
+      <ul className="space-y-2 text-sm text-muted-foreground">
+        {items.map((item) => (
+          <li key={item} className="flex gap-2">
+            <span className="mt-2 h-1.5 w-1.5 rounded-full bg-radiant-gold shrink-0" />
+            <span>{item}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -12,6 +12,8 @@ Supported runtimes:
 - `opencode` — deferred coding worker runtime for isolated review and worktree experiments.
 - `manual` — human-triggered admin actions and approvals.
 
+The standing operating role for site health, chatbot accuracy, scenario testing, and failure triage is the [Portfolio Operations Manager](./portfolio-operations-manager.md). It runs as an external Codex automation first and uses this Agent Operations control plane for visibility and approvals as deeper integration is added.
+
 Supported run statuses:
 
 - `queued`

--- a/docs/media-generation-bakeoff.md
+++ b/docs/media-generation-bakeoff.md
@@ -1,0 +1,88 @@
+# Image And Video Generation Bakeoff
+
+Use this when Portfolio needs to choose a new image or video generation model without guessing from demos, hype, or one good output.
+
+The goal is simple: run the same prompt packet through multiple providers, score the results, then install the winner behind a Portfolio adapter so the selected generator can change later without rebuilding the admin workflow.
+
+## Starting Providers
+
+| Provider | Role | Why it belongs in the bakeoff |
+| --- | --- | --- |
+| fal | Primary media playground and aggregator | Broad image, video, audio, and 3D model catalog; model pages include playgrounds, schemas, pricing, latency, and code examples. |
+| Replicate | Broad API fallback | Useful hosted model catalog for open and partner models; good secondary comparison surface. |
+| OpenRouter | Image routing specialist | Useful when image-capable models should sit beside text model routing. Treat as image-first unless required video generation APIs fit the workflow. |
+| Direct provider | Specialist path | Use when a first-party provider has the best model, rights, controls, or reliability and the extra lock-in is justified. |
+
+## Benchmark Packet
+
+Freeze the packet before running tests:
+
+- use case and target channel
+- shared prompt text
+- negative constraints
+- reference assets
+- required aspect ratios
+- output count per prompt
+- max latency
+- max cost per accepted asset
+- acceptance criteria
+
+Run each provider at least three times per prompt. A single output can be lucky. A production choice needs a pattern.
+
+## Scoring
+
+Score each provider from 1 to 5 on the same dimensions:
+
+| Dimension | Weight | What to check |
+| --- | ---: | --- |
+| Output quality | 22% | Visual quality, artifacts, realism or illustration quality, motion coherence for video. |
+| Prompt and reference fidelity | 16% | Follows prompt, uses references, keeps composition and constraints. |
+| Speed and throughput | 14% | p50 latency, p90 latency, queue behavior, batch behavior. |
+| Cost control | 10% | Cost per run and cost per accepted output. |
+| Brand and text control | 12% | Logo handling, type/text rendering, color discipline, character or product consistency. |
+| Workflow fit | 10% | Fits Portfolio's image, video, social, b-roll, and admin review flows. |
+| API installability | 8% | SDK/API maturity, schema clarity, auth path, local smoke test path. |
+| Observability and provenance | 8% | Can save model id, prompt version, settings, latency, cost, output URLs, and reviewer notes. |
+
+Promotion rule:
+
+- weighted score of 4.0 or higher
+- no privacy, rights, or safety blocker
+- beats the current default on the highest-priority dimension
+- stays inside latency and cost limits
+- has a working server-side adapter smoke test
+- keeps the old default as fallback for at least two successful production runs
+
+## Portfolio Integration Shape
+
+The app should not call each tool directly from the UI. Add a shared provider layer:
+
+```ts
+type MediaGenerationRequest = {
+  mode: 'image' | 'image_edit' | 'text_to_video' | 'image_to_video' | 'avatar_video'
+  prompt: string
+  referenceAssetUrls?: string[]
+  aspectRatio?: string
+  modelId: string
+  provider: 'fal' | 'replicate' | 'openrouter' | 'direct_provider'
+}
+```
+
+The admin playground should:
+
+- select a benchmark packet
+- run installed providers side by side
+- save output, cost, latency, status, and reviewer score
+- rank models with the scoring engine in `lib/media-generation-bakeoff.ts`
+- promote a selected provider/model into settings only after the gate passes
+
+The production content tools should read the selected provider/model from settings, not from hard-coded UI state.
+
+## Current Source Notes
+
+- fal documentation says every model has a Playground for real inputs and code samples, and its model pages show pricing, average latency, schemas, and copyable code.
+- fal's public site positions the platform as a library of 1000+ generative media models for image, video, voice, and code generation.
+- OpenRouter documentation supports image generation through its chat completions and responses endpoints, with model discovery by `output_modalities=image`.
+- Replicate documentation describes running models through a web playground or API; use model-level license and pricing checks before promotion.
+
+These sources change quickly. Refresh the provider shortlist before a serious bakeoff, especially for new video models.

--- a/docs/portfolio-operations-manager.md
+++ b/docs/portfolio-operations-manager.md
@@ -1,0 +1,197 @@
+# Portfolio Operations Manager
+
+The Portfolio Operations Manager is the ongoing operator for the Portfolio site. It can run from outside the website as a Codex-managed recurring job, while using the Portfolio admin as the source of truth for visibility, approvals, test runs, chatbot quality, and remediation.
+
+This role exists because the site now has enough moving parts that manual monitoring will eventually fail: public pages, admin workflows, chatbot/RAG quality, n8n workflows, database health, Vercel deployments, agent runs, and regression scenarios.
+
+## Operating Model
+
+Use a two-layer model:
+
+1. **External recurring manager:** A Codex automation runs on a schedule, inspects the repo and deployed/admin surfaces, runs safe checks, summarizes status, and opens a branch or handoff when something needs code work.
+2. **Internal control plane:** Portfolio admin remains the dashboard for runs, approvals, chatbot eval, testing, and operations history.
+
+Current automation:
+
+- Codex automation id: `portfolio-operations-manager`
+- Name: `Portfolio Operations Manager`
+- Schedule: daily at 9:00 AM America/New_York
+- Workspace: `/Users/vambahsillah/Projects/Portfolio`
+
+Default posture: the manager should fix broken things when it can do so safely, but it must not silently change production behavior, prompts, secrets, production n8n workflows, checkout or payment behavior, outbound messaging, or `origin/main`.
+
+The external manager can run read-only checks, run local tests, inspect logs and docs, create named branches, prepare scoped fixes, and report findings. Production changes, outbound emails, public publishing, secrets, and hosted config changes stay approval-gated.
+
+## Authority Matrix
+
+| Authority level | Allowed actions | Boundary |
+| --- | --- | --- |
+| Automatic | Repo inspection, local tests, diagnosis, read-only health checks, focused troubleshooting, stale-run cleanup recommendations, low-risk test-harness fixes, and low-risk code fixes prepared on a named branch. | Must preserve unrelated dirty work and report commands, files, and validation. |
+| Automatic branch, no merge | App regressions, broken admin or API behavior, flaky tests with clear fixture causes, docs/runbook fixes, and non-production workflow checks. | May create a scoped branch and commit only relevant files. Must not merge, push to `origin/main`, or change production settings. |
+| Approval required | All chatbot prompt changes, RAG policy changes, production environment/config changes, secrets, production n8n activation/deactivation, Vercel hosted settings, pricing, checkout, payment, guarantee behavior, outbound email, and public publishing. | Produce an approval packet with evidence, requested change, rollback, risk level, and exact approval needed. |
+| Never automatic | Direct push to `origin/main`, destructive git commands, secret exposure, production data deletion, broad architecture swaps, or silent replacement of core providers/runtimes. | Stop and escalate with a written recommendation. |
+
+When a fix is allowed, use the Portfolio branch rule: create a named branch, commit only scoped files, push only when the run is explicitly operating as a branch handoff, and do not merge. If the checkout is mixed with unrelated work, preserve it and report the constraint before committing.
+
+## Primary Surfaces
+
+- Admin home: `/admin`
+- Agent operations: `/admin/agents`
+- Agent run console: `/admin/agents/runs`
+- E2E testing dashboard: `/admin/testing`
+- Chatbot question bank: `/admin/testing/chatbot-questions`
+- Chat evaluation: `/admin/chat-eval`
+- Chat diagnoses: `/admin/chat-eval/diagnoses`
+- RAG health API: `/api/admin/rag-health`
+- n8n drift checker: `npm run n8n:drift-check:warn`
+- Database health checker: `npm run db:health-check`
+- Regression checklist: `docs/regression-smoke-checklist.md`
+- Integration matrix: `docs/integration-testing-environment-matrix.md`
+- Agent operations rollout: `docs/agent-operations-rollout.md`
+
+## Daily Responsibilities
+
+Run a lightweight health pass:
+
+- Check repo state and confirm no unrelated dirty work is being mixed into operations changes.
+- Review recent agent runs for failed, stale, or waiting-for-approval states.
+- Check chatbot evaluation stats for sharp drops in success rate, rising bad evaluations, or a backlog of unevaluated sessions.
+- Verify RAG health is reachable where credentials and admin auth are available.
+- Run focused local tests for recently changed operations surfaces when the checkout is clean enough.
+- Check n8n drift in warning mode when `N8N_API_KEY` is available.
+- Check database health when Supabase credentials are available.
+- Report failures with the failing command, affected surface, likely owner, and next action.
+
+## Weekly Responsibilities
+
+Run the broader quality pass:
+
+- Run `npm test` or the most targeted safe subset if repo-wide tests are known to be blocked by unrelated failures.
+- Run Playwright smoke coverage for admin/public paths when browser auth and environment variables are available.
+- Review the chatbot question bank coverage by category.
+- Run or request the Admin Testing presets:
+  - Smoke
+  - Critical
+  - Client Journey
+  - Chatbot Questions
+  - Credential Smoke after secrets or integration changes
+- Review recent chat diagnoses and make sure approved prompt or code fixes were applied intentionally.
+- Review n8n staging/production drift and flag meaningful differences.
+- Confirm Vercel production and staging contexts are healthy when deployment access is available.
+
+## Chatbot Accuracy Protocol
+
+The chatbot should be judged on answer usefulness, source alignment, escalation behavior, boundary handling, and whether it routes users toward the right AmaduTown offer or diagnostic path.
+
+The manager should:
+
+- Keep using `/admin/testing/chatbot-questions` as the question source.
+- Add new questions when failures reveal missing coverage.
+- Prefer category-level coverage over a pile of one-off prompts.
+- Compare failures against the active system prompt and RAG context before assuming model failure.
+- Diagnose bad sessions through `/admin/chat-eval/diagnose/batch`.
+- Propose prompt diffs only after a diagnosis trail.
+- Require Vambah's sign-off for every chatbot prompt, system-behavior, and RAG policy change, even when the diagnosis is strong.
+- Apply code or source-content fixes only through the normal branch/PR flow.
+
+The manager may automatically create or update non-behavioral question-bank coverage on a branch. It may also identify source gaps and propose source-content updates. It must not apply production prompt changes or broad answer-behavior changes without approval.
+
+Minimum recurring categories:
+
+- services and pricing
+- diagnostic/audit routing
+- publications and thought leadership
+- boundary questions
+- support escalation
+- unsupported or unsafe asks
+- local RAG/publications retrieval
+
+## Failure Triage
+
+Classify every failure into one of these buckets:
+
+| Bucket | Examples | First action |
+| --- | --- | --- |
+| Content or knowledge gap | Missing service detail, stale pricing explanation, weak publication answer | Update source content or chatbot knowledge, then rerun affected questions |
+| Prompt behavior | Overpromising, weak escalation, wrong tone, failure to ask clarifying question | Create diagnosis and prompt patch for review |
+| RAG/retrieval | Empty context, wrong source type, stale Pinecone result | Check `/api/admin/rag-health`, n8n RAG workflow, and ingestion status |
+| App regression | Route 500, broken admin page, API contract mismatch | Create branch, run focused tests, patch code, report validation |
+| Integration drift | n8n staging/prod mismatch, Stripe/Supabase/Vercel config mismatch | Produce drift report and exact approval request before changing hosted config |
+| Test harness issue | False positive, stale fixture, missing seed data | Fix the test or seed path separately from product behavior |
+
+## Repair And Escalation Loop
+
+Use this loop for every failure unless the failure is immediately in an approval-required or never-automatic category.
+
+1. **First failure:** diagnose, classify, run the smallest relevant check, and attempt a safe fix if the authority matrix allows it.
+2. **Second repeat failure in the same surface:** create a deeper RCA with evidence from tests, logs, chat evaluations, workflow drift, or admin/API responses. Attempt a second safe fix only if the cause is clear and the fix remains low-risk.
+3. **Third repeat failure or second failed fix attempt:** stop patching and produce an architecture review packet.
+
+An architecture review packet must include:
+
+- failing surface and timeline
+- evidence from tests, logs, chat eval, workflow drift, or admin/API checks
+- fixes already attempted and why they did not hold
+- alternate patterns or providers to consider
+- cost, latency, reliability, maintainability, and operational-risk notes
+- recommended next design and rollback plan
+
+Default repeated-failure threshold: three occurrences in the same surface or two failed fix attempts, whichever comes first.
+
+## Remediation Rules
+
+- For read-only failures, report directly with evidence.
+- For code fixes, create a named branch and commit only scoped files.
+- For prompt or chatbot behavior fixes, preserve the diagnosis and expected behavior.
+- For n8n or hosted config changes, prepare an approval packet before changing production.
+- For secrets or credential issues, never print secret values in reports.
+- For unrelated dirty work in the checkout, preserve it and either work around it or stop with a clear handoff.
+
+## Reporting Format
+
+Each run should return:
+
+- overall status: `green`, `yellow`, or `red`
+- checks run
+- failures and likely causes
+- failure classification and authority level used
+- fixes attempted
+- commands or admin surfaces used
+- chatbot accuracy notes
+- branches, commits, or files changed, if any
+- production approvals needed, if any
+- architecture review packet, if threshold was reached
+- next run focus
+
+## Escalation Gates
+
+Escalate to Vambah before:
+
+- changing production environment variables
+- activating/deactivating production n8n workflows
+- changing secrets or credentials
+- pushing directly to `origin/main`
+- sending outbound email or public posts
+- changing payment, pricing, checkout, or guarantee behavior
+- applying any chatbot prompt, system-behavior, or RAG policy change
+- applying a broad architecture swap or provider/runtime replacement
+
+## Deterministic Failure Examples
+
+| Example | Classification | Manager action |
+| --- | --- | --- |
+| Chatbot gives a bad pricing or service answer | Prompt behavior, source gap, or RAG/retrieval after diagnosis | Diagnose through chat eval and source/RAG checks. Add coverage or propose source updates on a branch if needed. Produce a prompt/RAG approval packet before any behavior change. |
+| n8n staging and production drift differ in workflow config | Integration drift | Run `npm run n8n:drift-check:warn` when credentials are available. Report meaningful drift and produce an approval packet before production n8n changes. |
+| Admin API or test fails because of a stale fixture or code regression | Test harness issue or app regression | Create a named branch, fix the scoped code/test issue, run focused validation, and report the branch. Do not merge or push to `origin/main`. |
+| Same admin API breaks for a third time after prior fixes | Repeated app regression | Stop patching and produce an architecture review packet with alternate designs and a recommended path. |
+
+## Implementation Path
+
+1. Create a Codex recurring automation named `Portfolio Operations Manager`.
+2. Keep this document as the automation's standing control document.
+3. Use `/admin/agents` as the future in-site home for manager run history and approvals.
+4. Add deeper app integration later only when it reduces manual work:
+   - a dedicated Operations Manager card on `/admin/agents`
+   - scheduled run summaries written into `agent_runs`
+   - one-click reruns of smoke, critical, and chatbot-question presets
+   - Slack or email digest after the Portfolio admin remains the source of truth

--- a/docs/subscription-cancellation-audit.md
+++ b/docs/subscription-cancellation-audit.md
@@ -1,0 +1,102 @@
+# Portfolio Subscription Cancellation Audit
+
+Recurring audit tracker for paid apps, hosted services, model/API providers,
+automation runtimes, design/media tools, and third-party integrations used by
+Portfolio.
+
+Authority boundary: this tracker never approves cancellation by itself. A tool
+only becomes a cancellation candidate after two consecutive audit sessions with
+no meaningful usage signal, or after clear redundancy plus a lower-risk
+replacement path. Production changes require explicit approval in the form
+`Cancel <tool/vendor> for Portfolio`.
+
+## 2026-05-01 Baseline Run
+
+Status: YELLOW
+
+Summary:
+
+- No cancellation approvals requested.
+- No tool has two consecutive inactive audit sessions yet; this is the baseline.
+- Supabase and n8n are active operational dependencies.
+- Meeting capture has a redundancy signal: Read.ai and Fireflies both posted
+  recaps into the meeting transcript workflow in April 2026.
+- In-app Read.ai OAuth storage looks stale even though the external Read.ai
+  account is active through the connector and Slack recap flow.
+- Vapi, Printful, and some media/social generation paths need another audit
+  session before any cancellation recommendation.
+
+Raw Findings
+
+- Git state: worktree was already dirty on `codex/client-ai-ops-roadmap`.
+  Existing modified/untracked files were treated as unrelated and left alone.
+- Existing durable tracker: none found before this file.
+- Repo evidence inspected: `package.json`, `.env.example`,
+  `.env.staging.example`, `n8n-exports/manifest.json`, n8n exports, docs,
+  app API routes, integration libraries, migrations, and admin/bakeoff docs.
+- Supabase connector: project `My Portfolio` is `ACTIVE_HEALTHY`; table counts
+  show active app usage, including `analytics_events`, `pain_point_evidence`,
+  `value_evidence_workflow_runs`, `meeting_records`, `gamma_reports`,
+  `heygen_config`, `orders`, and `cost_events`.
+- n8n Cloud connector: 76 workflows listed; recent executions observed on
+  2026-05-01, especially monitor/scheduled workflows and RAG webhook traffic.
+- Stripe connector: unavailable in this session due auth requirement.
+- Vercel connector: account/team project listing was not available from the
+  current connector context; repo has no `.vercel/project.json`.
+- Google Drive search: no clear subscription/billing tracker found.
+- Slack connector: `#meeting-transcripts` exists and contains recent Read.ai
+  and Fireflies recap posts in April 2026.
+- Read AI connector: recent meetings were available from April 2026 onward.
+
+Derived Inventory
+
+| Status | Tool/vendor | Purpose in Portfolio | Evidence source | Cost/billing signal | Last code/config/reference usage | Last operational usage signal | Dependencies/replacement risk | Session inactivity | Recommendation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| GREEN | Supabase | Primary database, auth/session data, storage-adjacent app state, realtime admin data | `@supabase/supabase-js`, env templates, migrations, connector table list | Paid status not shown; project is active healthy | Repo references across app/lib/scripts; last inspected 2026-05-01 | Active row counts across core tables; project active healthy | High: primary data plane | Active | Keep |
+| GREEN | n8n Cloud | Workflow automation runtime for lead intake, RAG, meetings, social, value evidence, progress updates | `n8n-exports`, env templates, `lib/n8n.ts`, n8n connector | Paid status not shown; cloud workspace active | Manifest last updated 2026-04-27; many env routes | Executions observed on 2026-05-01 | High: many webhooks and callbacks depend on it | Active | Keep; rationalize duplicate/staging workflows separately |
+| GREEN | OpenAI | In-app LLM generation, RAG embeddings in n8n, cost tracking | `lib/llm-dispatch.ts`, `lib/cost-calculator.ts`, n8n credential refs | Usage cost tracked in `cost_events` | Cost events last observed 2026-04-28 | Recent LLM cost rows and active code paths | Medium/high: outreach, audit, meeting, social, RAG | Active | Keep; update pricing rates periodically |
+| GREEN | Gamma | Admin report/deck generation and theme sync | `lib/gamma-client.ts`, Gamma report routes, env templates | API credit/billing unknown | `gamma_reports` rows and theme sync code | Last Gamma report row 2026-04-16; theme sync 2026-04-16 | Medium: deck/report workflow | Active | Keep |
+| GREEN | HeyGen | Avatar/video generation, catalog sync, report companion video | `lib/heygen.ts`, video-generation routes, `docs/heygen-template-brand-setup.md` | API plan unknown | Code and env routes active; sync tables present | Completed video job from 2026-03-25; catalog sync 2026-04-08 | Medium: video generation depends on it | Active but quieter | Keep; review cost after next content campaign |
+| GREEN | Read.ai | Meeting capture and Slack recap source; optional in-app meeting lookup | `lib/read-ai.ts`, migrations, meeting docs, Read AI connector, Slack recaps | Subscription status unknown | App token table exists but stored token expired 2026-03-27 | Connector lists April 2026 meetings; Slack recaps posted April 2026 | Medium: meeting follow-up pipeline uses recaps | Active externally; stale in app token | Keep account; investigate stale in-app token path |
+| GREEN | Slack | Meeting intake, sales notifications, outreach notifications, workflow status | n8n refs, env templates, Slack connector | Paid workspace status unknown | Many n8n Slack nodes and app webhook env vars | Recent transcript channel activity in April 2026 | Medium/high: ops notifications and meeting ingestion | Active | Keep |
+| YELLOW | Fireflies.ai | Meeting recaps appearing alongside Read.ai in Slack | Slack channel evidence | Subscription status unknown | No direct repo integration found | April 2026 recap posts in `#meeting-transcripts` | Low/medium: duplicate meeting assistant if Read.ai is canonical | Active but redundant | Investigate redundancy with Read.ai before renewal |
+| YELLOW | Pinecone | Vector store behind n8n RAG ingestion/query workflows | n8n manifest and node types | Paid status unknown | n8n credential refs; no direct app dependency found | RAG query execution observed 2026-04-30; ingestion workflow active in prod | Medium: RAG quality may depend on current index | Active via n8n | Investigate direct billing and whether local/Supabase RAG can replace |
+| YELLOW | Vercel | Hosting/deployments, Speed Insights dependency | package dependency, docs, Vercel connector attempt | Billing not available | `@vercel/speed-insights`, deployment docs | Connector could not list project in this session | High: production hosting likely depends on it | Unknown | Investigate with Vercel account/project access |
+| YELLOW | Stripe | Payments, checkout, webhooks, continuity plans | Stripe deps, payment routes, env templates | Connector auth required; app has 26 orders | Active code routes and Stripe env vars | Supabase orders exist; no live Stripe read available | High: commerce/payment path | Unknown | Keep until Stripe dashboard usage is checked |
+| YELLOW | Printful | Store fulfillment, product variants, shipping/mockups/webhooks | `lib/printful.ts`, Printful admin routes, env templates | Subscription/usage unknown | Code and product tables present | `orders` has rows; `printful_sync_log` has 0 rows | Medium: store fulfillment fallback required | First-session quiet | Watch; verify recent Printful dashboard/orders next run |
+| YELLOW | Vapi | Voice AI/webhook integration | `@vapi-ai/web`, `lib/vapi.ts`, `/api/vapi/webhook` | Usage/cost unknown | Env/template and webhook code present | No recent DB cost signal found this run | Medium if voice chat is public | First-session quiet | Watch; check Vapi dashboard next run |
+| YELLOW | Resend | Optional transactional email and deliverability webhooks | `resend` dependency, email delivery code, webhook route | Usage/cost unknown | Email provider fallback code present | `email_messages` has rows; provider-specific usage not verified | Low/medium: Gmail fallback exists | Unknown | Investigate whether Resend is configured in production |
+| YELLOW | Gmail/Google APIs | SMTP fallback, user Gmail drafts/OAuth, Drive sync | env templates, googleapis dependency, Gmail routes, Drive sync routes | Workspace/API billing unknown | Active code/config references | Gmail draft creds table empty; Drive queue has rows | Medium: email and asset workflows | Mixed | Keep; clean unused OAuth paths only after second quiet run |
+| YELLOW | Calendly | Booking links, n8n webhook router, report next-meeting links | env templates, n8n trigger refs, Calendly event libs | Paid status unknown | Active links and n8n routes | n8n active workflows include Calendly router | Medium: sales/onboarding booking | Active by config | Keep |
+| YELLOW | Apify | Lead scraping, social listening, actor health monitor | n8n env docs, n8n node refs | Paid status unknown | n8n workflows and env references | n8n actor monitors executed 2026-05-01 | Medium: lead discovery/value evidence | Active | Keep; review actor spend |
+| YELLOW | BuiltWith | Tech-stack lookup/enrichment | `lib/tech-stack-lookup.ts`, env templates | Paid status unknown | Code and env reference present | No operational evidence found this run | Low/medium: enrichment can be optional | First-session quiet | Watch |
+| YELLOW | ElevenLabs | TTS/audio in social content workflow | env templates, n8n env docs | Paid status unknown | Env and n8n docs reference | Social extraction last success 2026-04-08 | Medium for audio generation | First-session quiet-ish | Watch with social pipeline |
+| YELLOW | LinkedIn API | Social publishing / warm lead scraping credentials | env templates, auth/publishing routes, n8n docs | Paid status not applicable/unknown | Code and n8n references present | Warm lead audit last failed 2026-03-23 due outbound disabled | First-session quiet; public/social risk | Watch; verify before cancellation |
+| YELLOW | Google Drive | Video asset queue, script folders, Drive-to-RAG ingestion | `lib/google-drive.ts`, Drive sync routes, n8n RAG ingest | Workspace billing unknown | Code and n8n references present | Drive video queue has 35 rows; n8n ingestion active in prod | Medium: asset/provenance workflows | Active | Keep |
+| YELLOW | USPS | Address validation/suggest for commerce | `lib/usps.ts`, address routes, env templates | API cost unknown | Code and tests present | No operational evidence found this run | Low/medium: commerce UX fallback needed | First-session quiet | Watch |
+| YELLOW | Figma / Paper / Excalidraw / HeyGen design ecosystem | Design/reference tools around decks, diagrams, visual assets | bakeoff docs, local design docs, Drive search | Billing unknown | No production app dependency for Figma/Paper/Excalidraw found | No connector/billing evidence gathered this run | Low for app runtime; high for creative workflow if actively used | Unknown | Investigate manually; do not cancel from repo evidence alone |
+
+Candidate Cancellations
+
+None approved or recommended for cancellation on this baseline run.
+
+Investigate Before Next Run
+
+- Fireflies.ai vs Read.ai: confirm whether both are intentionally active. If
+  both are paid and both continue to post duplicate meeting summaries, choose a
+  canonical capture source before renewal.
+- Read.ai in-app OAuth: the Portfolio `integration_tokens` row is stale while
+  the external Read.ai connector is active. Decide whether to refresh the
+  Portfolio token path or remove that in-app lookup surface.
+- Vapi: verify dashboard usage and whether the public voice feature is enabled.
+- Printful: verify recent store orders/syncs outside Supabase before judging.
+- Pinecone: identify billing owner and whether current RAG can move to
+  Supabase/local retrieval after bakeoff evidence.
+- Vercel and Stripe: reconnect or authorize read-only billing/project access
+  for future audits.
+
+Approval Needed
+
+No cancellation action should be taken now. Future cancellation requires the
+exact phrase `Cancel <tool/vendor> for Portfolio`, then a separate verification,
+branch, deprecation packet, validation, and rollback plan for that named tool.

--- a/docs/technology-bakeoff-surface-map.md
+++ b/docs/technology-bakeoff-surface-map.md
@@ -1,0 +1,61 @@
+# Technology Bakeoff Surface Map
+
+Use this map to keep Portfolio from getting stale. Any workflow that depends on a fast-moving vendor, model, runtime, generation tool, integration, or automation layer should have a bakeoff path before the default is changed.
+
+The principle: do not swap tools because something looks new. Run a small, comparable test, score it, preserve evidence, then promote the winner behind an adapter or settings layer.
+
+## Priority Surfaces
+
+| Surface | Current Portfolio area | Bakeoff candidates | Primary criteria | Promotion gate |
+| --- | --- | --- | --- | --- |
+| Image and video generation | `/admin/content/video-generation`, social content, Gamma reports, media uploads | fal, Replicate, OpenRouter, direct providers, HeyGen, future video models | output quality, latency, cost, brand control, provenance, API fit | selected model passes `lib/media-generation-bakeoff.ts`, keeps old default as fallback |
+| Presentation and deck production | `/admin/presentations`, `/admin/reports/gamma`, course and deck packages | Codex/PPTX, Gamma, Claude Design, Paper, Excalidraw | clarity, voice, editability, export quality, proof, speaker readiness | winning base keeps source guide, notes, screenshots, QA exports |
+| Chat and diagnostic models | `/api/chat`, `/admin/chat-eval`, `/tools/audit`, `/api/chat/diagnostic` | hosted LLMs, local RAG, open-weight models, model routers | answer accuracy, source use, escalation quality, latency, cost, safety | chat eval score improves without hurting conversion or trust |
+| RAG and knowledge retrieval | `/api/knowledge`, `lib/rag-query.ts`, local RAG shadow mode, chatbot knowledge build | Supabase/Postgres retrieval, local vector stores, hosted vector DBs, rerankers | recall, precision, freshness, privacy, query latency, maintenance burden | shadow results beat current retrieval on saved test questions |
+| Social content generation | `/admin/social-content`, n8n social workflows, LinkedIn review queue | copy models, image models, TTS, scheduling/publishing tools | voice fit, approval burden, image quality, platform fit, rights, publish reliability | human review acceptance rate rises and private-source handling stays clean |
+| Voice and avatar video | video generation, HeyGen webhooks, VAPI webhook, meeting follow-up content | HeyGen, ElevenLabs, Vapi, avatar/video alternatives, direct TTS providers | voice quality, likeness/control, webhook reliability, cost per minute, consent and approval | approval gate for public/client-facing voice or avatar output |
+| Workflow automation runtime | n8n exports, `/admin/agents`, webhook routes, cron routes | n8n Cloud, Codex automations, Vercel cron, Supabase scheduled jobs, local scripts | observability, retries, cost, deploy friction, audit trail, rollback | new workflows write run traces or equivalent evidence before production use |
+| Agent runtimes | `/admin/agents`, Hermes bridge, OpenCode/OpenClaw evaluation | Codex, Hermes, OpenCode/OpenClaw, Claude Code, future coding agents | repository performance, auditability, permissions, rollback, handoff quality | runtime stays read-only or sandboxed until trace and approval behavior is proven |
+| Email and outbound messaging | `/admin/email-center`, Gmail helpers, Resend webhook, proposal/email drafts | Gmail API, Resend, SMTP, n8n email nodes, copy models | deliverability, personalization, auditability, reply handling, approval burden | outbound sends require traceable draft, approval state, and delivery event |
+| Lead discovery and enrichment | outreach dashboard, tech-stack lookup, warm lead workflows | Apify actors, BuiltWith, LinkedIn/Google sources, enrichment APIs, browser agents | data quality, source reliability, cost per useful lead, compliance, duplicate rate | enrichment improves qualified-lead yield without adding privacy risk |
+| Pricing, bundles, and ROI tools | `/admin/sales`, `/admin/cost-revenue`, `/pricing`, ROI tools | pricing models, market data sources, proposal generators, analytics providers | margin accuracy, offer clarity, conversion, source quality, update effort | changes are validated against cost/revenue and proposal acceptance data |
+| Testing and QA automation | `/admin/testing`, Playwright, API route tests, regression docs | Playwright, browser-use, synthetic monitors, visual diff tools, LLM judges | bug catch rate, false positives, speed, maintenance, screenshot evidence | new QA layer catches known regressions before adding CI or admin noise |
+| Payments, fulfillment, and commerce | checkout, Stripe routes, Printful webhook, store/services/products | Stripe features, checkout UX tools, fulfillment tools, tax/shipping providers | payment reliability, fulfillment accuracy, support burden, reconciliation | no default swap without test transaction, webhook trace, and rollback plan |
+| Analytics and attribution | `/admin/analytics`, funnel analytics, cost events, campaign pages | Vercel analytics, custom event tracking, PostHog, Supabase events, warehouse tools | event accuracy, funnel visibility, privacy, cost, operational usefulness | dashboard answers a decision the current analytics cannot answer |
+| Content and asset management | Content Hub, uploads, publications, products, projects, Google Drive sync | Supabase Storage, Drive, local staged assets, CMS tools, asset CDNs | provenance, speed, permissions, migration cost, public URL stability | source register and rollback path exist before moving canonical assets |
+
+## Review Cadence
+
+- Monthly: scan fast-moving model and generation surfaces: media, chat, RAG, social content, voice, agents.
+- Quarterly: review infrastructure surfaces: automation runtime, analytics, testing, commerce, asset storage.
+- Before any major campaign, deck, course, or launch: run the relevant bakeoff even if the current default still works.
+- After recurring failures or rising cost: run a bakeoff before patching around the same provider again.
+
+## Standard Bakeoff Packet
+
+Every bakeoff should produce:
+
+- decision question
+- current default and fallback
+- candidate list
+- shared test inputs
+- scoring dimensions and weights
+- run evidence
+- cost and latency notes
+- human review notes where judgment matters
+- recommendation
+- promotion gate
+- rollback path
+
+## Where The Code Should Converge
+
+Prefer reusable evaluators under `lib/*-bakeoff.ts` or `lib/*-evaluation.ts`. Production tools should read provider/model choices from settings or config, not hard-code a vendor directly in page components.
+
+Existing examples:
+
+- `lib/presentation-bakeoff.ts`
+- `lib/media-generation-bakeoff.ts`
+- `lib/ai-layer-fit-evaluation.ts`
+- `lib/agent-runtime-evaluation.ts`
+
+When a new surface gets repeated evaluation pressure, create the evaluator first, then wire it into the admin UI.

--- a/lib/media-generation-bakeoff.test.ts
+++ b/lib/media-generation-bakeoff.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { buildMediaGenerationBakeoffPlan } from './media-generation-bakeoff'
+
+describe('buildMediaGenerationBakeoffPlan', () => {
+  it('recommends fal for a broad image and video playground workflow', () => {
+    const plan = buildMediaGenerationBakeoffPlan({
+      title: 'AmaduTown media model bakeoff',
+      useCase: 'Compare image and video generation models before installing a selected generator into Portfolio.',
+      mode: 'campaign_media',
+      priority: 'production_reliability',
+      requiredAspectRatios: ['1:1', '16:9', '9:16'],
+      referenceAssets: ['AmaduTown shield logo', 'Portfolio admin screenshot'],
+      prompts: [
+        'Create a branded framework image for a LinkedIn post.',
+        'Create a six-second product walkthrough clip from a screenshot.',
+      ],
+      needsBatchGeneration: true,
+      needsApiInstallPath: true,
+      needsHumanApproval: true,
+      needsBrandConsistency: true,
+      needsVideoAudio: true,
+      maxAcceptableLatencySeconds: 90,
+      maxAcceptableCostUsd: 1.5,
+    })
+
+    expect(plan.recommendedProvider).toBe('fal')
+    expect(plan.recommendedLabel).toBe('fal media model gallery')
+    expect(plan.candidates[0].decision).toMatch(/promote_to_default|pilot_with_guardrails/)
+    expect(plan.benchmarkRunbook.join(' ')).toContain('cost per accepted asset')
+    expect(plan.portfolioIntegrationPlan.join(' ')).toContain('admin playground')
+  })
+
+  it('keeps OpenRouter out of the default video path until video generation fits the workflow', () => {
+    const plan = buildMediaGenerationBakeoffPlan({
+      title: 'Short-form video bakeoff',
+      useCase: 'Evaluate text-to-video models for client-facing short clips.',
+      mode: 'text_to_video',
+      priority: 'quality',
+      needsVideoAudio: true,
+      needsApiInstallPath: true,
+      needsHumanApproval: true,
+    })
+
+    const openrouter = plan.candidates.find((candidate) => candidate.provider === 'openrouter')
+
+    expect(openrouter?.decision).toMatch(/keep_as_specialist|sandbox_only/)
+    expect(openrouter?.modelDiscoveryPlan.join(' ')).toMatch(/Avoid treating OpenRouter as the video default/i)
+  })
+
+  it('allows a direct provider to win for brand-controlled image work', () => {
+    const plan = buildMediaGenerationBakeoffPlan({
+      title: 'Brand illustration model choice',
+      useCase: 'Pick the strongest image model for precise branded illustrations.',
+      mode: 'image_edit',
+      priority: 'brand_control',
+      currentDefaultProvider: 'direct_provider',
+      requiredAspectRatios: ['1:1'],
+      referenceAssets: ['AmaduTown shield logo'],
+      needsBrandConsistency: true,
+      needsHumanApproval: true,
+      requiresFirstPartyFeatures: true,
+      maxAcceptableLatencySeconds: 120,
+      maxAcceptableCostUsd: 2,
+    })
+
+    expect(plan.recommendedProvider).toBe('direct_provider')
+    expect(plan.promotionGate.join(' ')).toContain('selected Portfolio generator')
+    expect(plan.candidates[0].installPlan.join(' ')).toContain('provider-specific API key')
+  })
+})

--- a/lib/media-generation-bakeoff.ts
+++ b/lib/media-generation-bakeoff.ts
@@ -1,0 +1,492 @@
+export const MEDIA_GENERATION_PROVIDERS = [
+  'fal',
+  'replicate',
+  'openrouter',
+  'direct_provider',
+] as const
+
+export type MediaGenerationProvider = (typeof MEDIA_GENERATION_PROVIDERS)[number]
+
+export type MediaGenerationMode =
+  | 'image'
+  | 'image_edit'
+  | 'text_to_video'
+  | 'image_to_video'
+  | 'avatar_video'
+  | 'campaign_media'
+
+export type MediaGenerationPriority =
+  | 'quality'
+  | 'speed'
+  | 'cost'
+  | 'brand_control'
+  | 'production_reliability'
+
+export type MediaGenerationDecision =
+  | 'promote_to_default'
+  | 'pilot_with_guardrails'
+  | 'keep_as_specialist'
+  | 'sandbox_only'
+  | 'reject_for_current_workflow'
+
+export interface MediaGenerationBakeoffInput {
+  title: string
+  useCase: string
+  mode: MediaGenerationMode
+  priority: MediaGenerationPriority
+  requiredAspectRatios?: string[]
+  referenceAssets?: string[]
+  prompts?: string[]
+  currentDefaultProvider?: MediaGenerationProvider
+  needsBatchGeneration?: boolean
+  needsApiInstallPath?: boolean
+  needsHumanApproval?: boolean
+  needsBrandConsistency?: boolean
+  needsVideoAudio?: boolean
+  requiresFirstPartyFeatures?: boolean
+  maxAcceptableLatencySeconds?: number
+  maxAcceptableCostUsd?: number
+}
+
+export interface MediaGenerationScore {
+  dimension: string
+  score: number
+  weight: number
+  weightedScore: number
+  evidence: string
+}
+
+export interface MediaGenerationCandidate {
+  provider: MediaGenerationProvider
+  label: string
+  role: string
+  bestFor: string
+  watchOutFor: string
+  playgroundPlan: string[]
+  modelDiscoveryPlan: string[]
+  installPlan: string[]
+  scores: MediaGenerationScore[]
+  totalScore: number
+  decision: MediaGenerationDecision
+  decisionLabel: string
+}
+
+export interface MediaGenerationBakeoffPlan {
+  generatedAt: string
+  title: string
+  useCase: string
+  mode: MediaGenerationMode
+  recommendedProvider: MediaGenerationProvider
+  recommendedLabel: string
+  recommendation: string
+  scoringMethodology: string[]
+  benchmarkRunbook: string[]
+  promotionGate: string[]
+  portfolioIntegrationPlan: string[]
+  candidates: MediaGenerationCandidate[]
+}
+
+const PROVIDER_LABELS: Record<MediaGenerationProvider, string> = {
+  fal: 'fal media model gallery',
+  replicate: 'Replicate model API',
+  openrouter: 'OpenRouter image gateway',
+  direct_provider: 'Direct model provider',
+}
+
+const PROVIDER_ROLES: Record<MediaGenerationProvider, string> = {
+  fal: 'Primary playground and aggregator for image, video, audio, and 3D media models',
+  replicate: 'Broad API fallback for hosted open and partner models',
+  openrouter: 'Unified gateway when image generation should sit beside text model routing',
+  direct_provider: 'Specialist path for a model that outperforms aggregators or needs first-party features',
+}
+
+const PROVIDER_STRENGTHS: Record<MediaGenerationProvider, string> = {
+  fal: 'Fast media experimentation, public model pages, playgrounds, generated code samples, latency visibility, and broad media coverage.',
+  replicate: 'Simple API runs, strong model catalog, useful for comparing open and partner models without owning infrastructure.',
+  openrouter: 'Good fit when image-capable models need the same routing surface as text models and model discovery should be API-driven.',
+  direct_provider: 'Best when a first-party provider exposes capabilities, rights, controls, or reliability the aggregators do not carry yet.',
+}
+
+const PROVIDER_RISKS: Record<MediaGenerationProvider, string> = {
+  fal: 'Model availability and schemas vary by model, so production selection needs stored model ids and per-model run records.',
+  replicate: 'Latency, pricing, licensing, and output quality can vary widely across individual models.',
+  openrouter: 'Currently stronger for image routing than full video generation, so it should not be the only media provider.',
+  direct_provider: 'Locks the app into a provider-specific API and makes future comparisons harder unless wrapped behind a common interface.',
+}
+
+const SCORE_WEIGHTS = {
+  output_quality: 0.22,
+  prompt_and_reference_fidelity: 0.16,
+  speed_and_throughput: 0.14,
+  cost_control: 0.1,
+  brand_and_text_control: 0.12,
+  workflow_fit: 0.1,
+  api_installability: 0.08,
+  observability_and_provenance: 0.08,
+} as const
+
+type ScoreDimension = keyof typeof SCORE_WEIGHTS
+
+const DIMENSION_LABELS: Record<ScoreDimension, string> = {
+  output_quality: 'Output quality',
+  prompt_and_reference_fidelity: 'Prompt and reference fidelity',
+  speed_and_throughput: 'Speed and throughput',
+  cost_control: 'Cost control',
+  brand_and_text_control: 'Brand and text control',
+  workflow_fit: 'Workflow fit',
+  api_installability: 'API installability',
+  observability_and_provenance: 'Observability and provenance',
+}
+
+const DECISION_LABELS: Record<MediaGenerationDecision, string> = {
+  promote_to_default: 'Promote to default',
+  pilot_with_guardrails: 'Pilot with guardrails',
+  keep_as_specialist: 'Keep as specialist option',
+  sandbox_only: 'Sandbox only',
+  reject_for_current_workflow: 'Reject for current workflow',
+}
+
+function bounded(value: number): number {
+  return Math.max(1, Math.min(5, value))
+}
+
+function cleanList(values: string[] | undefined): string[] {
+  return (values ?? []).map((value) => value.trim()).filter(Boolean)
+}
+
+function modeLabel(mode: MediaGenerationMode): string {
+  return mode.replaceAll('_', ' ')
+}
+
+function baseScore(provider: MediaGenerationProvider, dimension: ScoreDimension): number {
+  const scores: Record<MediaGenerationProvider, Record<ScoreDimension, number>> = {
+    fal: {
+      output_quality: 4,
+      prompt_and_reference_fidelity: 4,
+      speed_and_throughput: 5,
+      cost_control: 4,
+      brand_and_text_control: 4,
+      workflow_fit: 5,
+      api_installability: 5,
+      observability_and_provenance: 4,
+    },
+    replicate: {
+      output_quality: 4,
+      prompt_and_reference_fidelity: 4,
+      speed_and_throughput: 3,
+      cost_control: 3,
+      brand_and_text_control: 3,
+      workflow_fit: 4,
+      api_installability: 5,
+      observability_and_provenance: 4,
+    },
+    openrouter: {
+      output_quality: 4,
+      prompt_and_reference_fidelity: 4,
+      speed_and_throughput: 4,
+      cost_control: 4,
+      brand_and_text_control: 4,
+      workflow_fit: 4,
+      api_installability: 4,
+      observability_and_provenance: 4,
+    },
+    direct_provider: {
+      output_quality: 5,
+      prompt_and_reference_fidelity: 5,
+      speed_and_throughput: 3,
+      cost_control: 2,
+      brand_and_text_control: 5,
+      workflow_fit: 3,
+      api_installability: 3,
+      observability_and_provenance: 3,
+    },
+  }
+  return scores[provider][dimension]
+}
+
+function scoreAdjustment(
+  provider: MediaGenerationProvider,
+  dimension: ScoreDimension,
+  input: MediaGenerationBakeoffInput
+): number {
+  let adjustment = 0
+
+  if (input.mode === 'text_to_video' || input.mode === 'image_to_video' || input.mode === 'campaign_media') {
+    if (provider === 'fal' && dimension === 'workflow_fit') adjustment += 1
+    if (provider === 'openrouter' && dimension === 'workflow_fit') adjustment -= 2
+  }
+
+  if (input.mode === 'image' || input.mode === 'image_edit') {
+    if (provider === 'openrouter' && dimension === 'workflow_fit') adjustment += 1
+  }
+
+  if (input.priority === 'speed' && provider === 'fal' && dimension === 'speed_and_throughput') adjustment += 1
+  if (input.priority === 'quality' && provider === 'direct_provider' && dimension === 'output_quality') adjustment += 1
+  if (input.priority === 'cost' && provider === 'direct_provider' && dimension === 'cost_control') adjustment -= 1
+  if (input.priority === 'brand_control' && provider === 'direct_provider' && dimension === 'brand_and_text_control') adjustment += 1
+
+  if (input.needsBatchGeneration && provider === 'fal' && dimension === 'speed_and_throughput') adjustment += 1
+  if (input.needsBatchGeneration && provider === 'direct_provider' && dimension === 'workflow_fit') adjustment -= 1
+
+  if (input.needsApiInstallPath && provider !== 'direct_provider' && dimension === 'api_installability') adjustment += 1
+  if (input.needsBrandConsistency && dimension === 'brand_and_text_control') {
+    if (provider === 'fal' || provider === 'direct_provider') adjustment += 1
+    if (provider === 'replicate') adjustment -= 1
+  }
+
+  if (input.needsVideoAudio) {
+    if (provider === 'fal' && dimension === 'workflow_fit') adjustment += 1
+    if (provider === 'openrouter' && dimension === 'workflow_fit') adjustment -= 1
+  }
+
+  if (input.requiresFirstPartyFeatures) {
+    if (provider === 'direct_provider' && dimension === 'output_quality') adjustment += 1
+    if (provider === 'direct_provider' && dimension === 'prompt_and_reference_fidelity') adjustment += 1
+    if (provider === 'direct_provider' && dimension === 'workflow_fit') adjustment += 1
+    if (provider !== 'direct_provider' && dimension === 'output_quality') adjustment -= 1
+    if (provider !== 'direct_provider' && dimension === 'prompt_and_reference_fidelity') adjustment -= 1
+    if (provider !== 'direct_provider' && dimension === 'workflow_fit') adjustment -= 1
+  }
+
+  if (input.currentDefaultProvider === provider && dimension === 'workflow_fit') adjustment += 1
+
+  return adjustment
+}
+
+function scoreEvidence(
+  provider: MediaGenerationProvider,
+  dimension: ScoreDimension,
+  score: number,
+  input: MediaGenerationBakeoffInput
+): string {
+  if (dimension === 'speed_and_throughput') {
+    const latency = input.maxAcceptableLatencySeconds
+      ? `Target return time is ${input.maxAcceptableLatencySeconds}s or less.`
+      : 'Measure p50 and p90 return time for every prompt.'
+    return `${PROVIDER_LABELS[provider]} should be judged on real run timing, queue behavior, and retry cost. ${latency}`
+  }
+
+  if (dimension === 'cost_control') {
+    const cost = input.maxAcceptableCostUsd
+      ? `Target cost is $${input.maxAcceptableCostUsd.toFixed(2)} or less per accepted asset.`
+      : 'Track cost per run and cost per accepted asset.'
+    return `${PROVIDER_LABELS[provider]} needs run-level cost tracking. ${cost}`
+  }
+
+  if (dimension === 'prompt_and_reference_fidelity') {
+    return `${PROVIDER_LABELS[provider]} is scored against whether it follows the same prompt, reference assets, aspect ratios, and negative constraints.`
+  }
+
+  if (dimension === 'observability_and_provenance') {
+    return `${PROVIDER_LABELS[provider]} must return enough metadata to save provider, model id, prompt version, seed or settings when available, latency, cost, and output URLs.`
+  }
+
+  return score >= 4
+    ? `${PROVIDER_LABELS[provider]} is a strong fit for ${DIMENSION_LABELS[dimension].toLowerCase()}.`
+    : `${PROVIDER_LABELS[provider]} needs extra validation for ${DIMENSION_LABELS[dimension].toLowerCase()}.`
+}
+
+function buildScores(
+  provider: MediaGenerationProvider,
+  input: MediaGenerationBakeoffInput
+): MediaGenerationScore[] {
+  return (Object.keys(SCORE_WEIGHTS) as ScoreDimension[]).map((dimension) => {
+    const score = bounded(baseScore(provider, dimension) + scoreAdjustment(provider, dimension, input))
+    const weight = SCORE_WEIGHTS[dimension]
+    return {
+      dimension: DIMENSION_LABELS[dimension],
+      score,
+      weight,
+      weightedScore: Number((score * weight).toFixed(2)),
+      evidence: scoreEvidence(provider, dimension, score, input),
+    }
+  })
+}
+
+function decisionFor(totalScore: number, provider: MediaGenerationProvider, input: MediaGenerationBakeoffInput): MediaGenerationDecision {
+  if (provider === 'openrouter' && (input.mode === 'text_to_video' || input.mode === 'image_to_video')) {
+    return totalScore >= 3.6 ? 'keep_as_specialist' : 'sandbox_only'
+  }
+  if (totalScore >= 4.35) return 'promote_to_default'
+  if (totalScore >= 3.8) return 'pilot_with_guardrails'
+  if (totalScore >= 3.3) return 'keep_as_specialist'
+  if (totalScore >= 2.7) return 'sandbox_only'
+  return 'reject_for_current_workflow'
+}
+
+function buildPlaygroundPlan(provider: MediaGenerationProvider, input: MediaGenerationBakeoffInput): string[] {
+  const prompts = cleanList(input.prompts)
+  const promptCount = prompts.length > 0 ? prompts.length : 3
+  const ratios = cleanList(input.requiredAspectRatios)
+
+  return [
+    `Run ${promptCount} shared ${modeLabel(input.mode)} prompt${promptCount === 1 ? '' : 's'} through the provider playground or API.`,
+    ratios.length > 0
+      ? `Test required aspect ratios: ${ratios.join(', ')}.`
+      : 'Test 1:1, 16:9, and 9:16 unless the campaign has a narrower format need.',
+    'Save every output with provider, model id, prompt version, settings, latency, cost, and reviewer notes.',
+    input.needsHumanApproval
+      ? 'Require human approval before any output becomes the selected production generator.'
+      : 'Keep human review available even if the first run is automated.',
+  ]
+}
+
+function buildModelDiscoveryPlan(provider: MediaGenerationProvider, input: MediaGenerationBakeoffInput): string[] {
+  if (provider === 'fal') {
+    return [
+      'Use fal model gallery and Sandbox to compare current image, video, audio, and 3D models against the same prompt set.',
+      'Prioritize models with visible pricing, average latency, API schema, and code examples.',
+      input.needsVideoAudio ? 'Include video models with native audio support in the shortlist.' : 'Separate silent video quality from audio or voiceover needs.',
+    ]
+  }
+
+  if (provider === 'replicate') {
+    return [
+      'Use Replicate playground and model pages to identify strong open or partner models for the use case.',
+      'Check model license, run count, examples, expected latency, and input/output schema before scoring.',
+      'Keep Replicate as a fallback or specialist path when a model is better there than on the primary aggregator.',
+    ]
+  }
+
+  if (provider === 'openrouter') {
+    return [
+      'Query image-capable models through OpenRouter model discovery before running tests.',
+      'Use it for image generation or edits where text and image routing should share one gateway.',
+      'Avoid treating OpenRouter as the video default until the required video models are exposed with usable generation APIs.',
+    ]
+  }
+
+  return [
+    'Use first-party model documentation when the required capability is missing, newer, or stronger outside aggregators.',
+    'Record any provider-specific settings that must be wrapped before Portfolio can switch models cleanly.',
+    'Only promote direct integration if the quality lift justifies extra lock-in and maintenance.',
+  ]
+}
+
+function buildInstallPlan(provider: MediaGenerationProvider): string[] {
+  if (provider === 'fal') {
+    return [
+      'Add a FAL_API_KEY environment variable and a server-side provider adapter.',
+      'Store selected model ids and per-run metadata in the media generation settings table.',
+      'Expose the selected provider/model in the admin playground selector after the adapter smoke test passes.',
+    ]
+  }
+
+  if (provider === 'replicate') {
+    return [
+      'Add a REPLICATE_API_TOKEN environment variable and a server-side provider adapter.',
+      'Normalize prediction status, output URLs, cost estimates, and webhook callbacks into the shared run record.',
+      'Expose Replicate models as specialist candidates unless they beat the default provider on the promotion gate.',
+    ]
+  }
+
+  if (provider === 'openrouter') {
+    return [
+      'Add an OPENROUTER_API_KEY environment variable if one is not already available.',
+      'Use model discovery to populate image-capable model choices and call the chat completions or responses endpoint with image modalities.',
+      'Limit initial Portfolio selection to image generation or editing until video support matches the workflow requirements.',
+    ]
+  }
+
+  return [
+    'Add the provider-specific API key through the normal secret path.',
+    'Wrap the first-party SDK behind the same Portfolio media provider interface.',
+    'Require a bakeoff record and a clear first-party capability advantage before allowing the direct provider to become the default.',
+  ]
+}
+
+function buildCandidate(
+  provider: MediaGenerationProvider,
+  input: MediaGenerationBakeoffInput
+): MediaGenerationCandidate {
+  const scores = buildScores(provider, input)
+  const totalScore = Number(scores.reduce((sum, item) => sum + item.weightedScore, 0).toFixed(2))
+  const decision = decisionFor(totalScore, provider, input)
+
+  return {
+    provider,
+    label: PROVIDER_LABELS[provider],
+    role: PROVIDER_ROLES[provider],
+    bestFor: PROVIDER_STRENGTHS[provider],
+    watchOutFor: PROVIDER_RISKS[provider],
+    playgroundPlan: buildPlaygroundPlan(provider, input),
+    modelDiscoveryPlan: buildModelDiscoveryPlan(provider, input),
+    installPlan: buildInstallPlan(provider),
+    scores,
+    totalScore,
+    decision,
+    decisionLabel: DECISION_LABELS[decision],
+  }
+}
+
+function buildBenchmarkRunbook(input: MediaGenerationBakeoffInput): string[] {
+  const prompts = cleanList(input.prompts)
+  const references = cleanList(input.referenceAssets)
+
+  return [
+    'Freeze one benchmark packet before testing: prompt text, references, aspect ratios, negative constraints, output count, and acceptance criteria.',
+    prompts.length > 0
+      ? `Use the supplied prompts as the initial benchmark set: ${prompts.join(' | ')}.`
+      : 'Start with three prompts: one brand/social image, one product proof image, and one motion/video prompt.',
+    references.length > 0
+      ? `Use the same reference assets for every provider: ${references.join(', ')}.`
+      : 'Use the same logo, brand palette, screenshot, or character reference for every provider when references are needed.',
+    'Run each candidate at least three times per prompt so quality and latency are not judged from a lucky or unlucky single output.',
+    'Score the accepted output, not the best-looking thumbnail alone: check prompt fidelity, format fit, usable text, artifacts, motion coherence, and edit burden.',
+    'Record cost per run, cost per accepted asset, p50 latency, p90 latency, reviewer score, failure rate, and notes.',
+  ]
+}
+
+function buildPromotionGate(input: MediaGenerationBakeoffInput): string[] {
+  return [
+    'A provider can become the selected Portfolio generator only if it scores at least 4.0 weighted total and does not fail output rights, privacy, or safety review.',
+    'A model can become the default only after it beats the current default on the highest-priority dimension and stays within latency and cost limits.',
+    input.needsHumanApproval
+      ? 'Human approval remains required before generated media is published or attached to a client-facing artifact.'
+      : 'Human review can be sampled for low-risk internal drafts, but client-facing publication still needs an approval path.',
+    'If a new model wins, install it behind the provider adapter and keep the old default as a fallback until two successful production runs complete.',
+    'Every production run must save provider, model id, prompt version, input asset ids, output URLs, latency, estimated cost, reviewer, and final status.',
+  ]
+}
+
+function buildPortfolioIntegrationPlan(input: MediaGenerationBakeoffInput): string[] {
+  return [
+    'Add a shared media provider adapter with a common request shape for image, image edit, text-to-video, image-to-video, and avatar/video workflows.',
+    'Add an admin playground that lets Portfolio run the same benchmark packet across installed providers and compare results side by side.',
+    'Persist provider settings separately from run history so a winning model can be selected without losing prior bakeoff evidence.',
+    'Expose the selected generator in the existing video/content admin workflow only after the adapter smoke test and promotion gate pass.',
+    input.currentDefaultProvider
+      ? `Keep ${PROVIDER_LABELS[input.currentDefaultProvider]} as the fallback until the new selected model proves itself.`
+      : 'Keep the first integration as a pilot default with a manual fallback path.',
+  ]
+}
+
+export function buildMediaGenerationBakeoffPlan(
+  input: MediaGenerationBakeoffInput
+): MediaGenerationBakeoffPlan {
+  const candidates = MEDIA_GENERATION_PROVIDERS
+    .map((provider) => buildCandidate(provider, input))
+    .sort((a, b) => b.totalScore - a.totalScore)
+  const winner = candidates[0]
+
+  return {
+    generatedAt: new Date().toISOString(),
+    title: input.title,
+    useCase: input.useCase,
+    mode: input.mode,
+    recommendedProvider: winner.provider,
+    recommendedLabel: winner.label,
+    recommendation: `${winner.label} is the strongest starting point for this ${modeLabel(input.mode)} workflow because it scores highest across quality, speed, workflow fit, installability, and provenance. Use the bakeoff result to select a model, then install it behind a Portfolio adapter instead of hard-coding the tool directly into the UI.`,
+    scoringMethodology: [
+      'Score every provider on a 1-5 scale, multiply by fixed weights, and rank by weighted total.',
+      'Judge quality from repeated runs against the same benchmark packet, not from marketing samples or one lucky output.',
+      'Separate provider selection from model selection: the provider may win the workflow while a specific model wins the creative job.',
+      'Treat speed, cost, failure rate, and reviewer acceptance as first-class signals beside visual quality.',
+      'Require provenance before promotion so the selected generator can be audited, replaced, or rolled back.',
+    ],
+    benchmarkRunbook: buildBenchmarkRunbook(input),
+    promotionGate: buildPromotionGate(input),
+    portfolioIntegrationPlan: buildPortfolioIntegrationPlan(input),
+    candidates,
+  }
+}

--- a/lib/technology-bakeoff.test.ts
+++ b/lib/technology-bakeoff.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import {
+  TECHNOLOGY_BAKEOFF_PROFILES,
+  TECHNOLOGY_BAKEOFF_SURFACES,
+  buildTechnologyBakeoffPlan,
+} from './technology-bakeoff'
+
+describe('buildTechnologyBakeoffPlan', () => {
+  it('returns a valid plan for every mapped surface', () => {
+    for (const surface of TECHNOLOGY_BAKEOFF_SURFACES) {
+      const plan = buildTechnologyBakeoffPlan({
+        surface,
+        objective: `Evaluate ${TECHNOLOGY_BAKEOFF_PROFILES[surface].label}`,
+        priority: 'reliability',
+      })
+
+      expect(plan.surface).toBe(surface)
+      expect(plan.surfaceLabel).toBe(TECHNOLOGY_BAKEOFF_PROFILES[surface].label)
+      expect(plan.candidates.length).toBeGreaterThan(0)
+      expect(plan.scores.length).toBeGreaterThan(0)
+      expect(plan.benchmarkRunbook.join(' ')).toContain('Decision question')
+      expect(plan.promotionGate.length).toBeGreaterThan(0)
+      expect(plan.rollbackPlan.length).toBeGreaterThan(0)
+      expect(plan.nextImplementationStep).toContain(plan.surfaceLabel)
+    }
+  })
+
+  it('rejects unsupported surfaces clearly', () => {
+    expect(() =>
+      buildTechnologyBakeoffPlan({
+        surface: 'unsupported_surface' as never,
+        objective: 'Try an unknown surface',
+        priority: 'quality',
+      })
+    ).toThrow(/Unsupported technology bakeoff surface/)
+  })
+
+  it('delegates media generation to the specialist evaluator shape', () => {
+    const plan = buildTechnologyBakeoffPlan({
+      surface: 'media_generation',
+      objective: 'Pick the best media model before changing Portfolio defaults.',
+      priority: 'speed',
+    })
+
+    expect(plan.specialistSource).toBe('media_generation')
+    expect(plan.candidates.map((candidate) => candidate.id)).toEqual(
+      expect.arrayContaining(['fal', 'replicate', 'openrouter', 'direct_provider'])
+    )
+    expect(plan.integrationNotes.join(' ')).toMatch(/provider adapter/i)
+  })
+
+  it('delegates presentations to the specialist evaluator shape', () => {
+    const plan = buildTechnologyBakeoffPlan({
+      surface: 'presentations',
+      objective: 'Choose a better deck production path.',
+      priority: 'quality',
+    })
+
+    expect(plan.specialistSource).toBe('presentation')
+    expect(plan.candidates.map((candidate) => candidate.id)).toEqual(
+      expect.arrayContaining(['codex_pptx', 'claude_design', 'gamma'])
+    )
+    expect(plan.promotionGate.join(' ')).toMatch(/unsupported market claims|generic AI voice/i)
+  })
+
+  it('reuses Agent Operations framing for agent runtime bakeoffs', () => {
+    const plan = buildTechnologyBakeoffPlan({
+      surface: 'agent_runtimes',
+      objective: 'Compare coding agent runtimes before assigning production work.',
+      priority: 'governance',
+      knownFailure: 'Runtime cannot be audited.',
+    })
+
+    expect(plan.specialistSource).toBe('agent_runtime')
+    expect(plan.recommendedAction).toMatch(/Agent Operations/i)
+    expect(plan.promotionGate.join(' ')).toMatch(/read-only or sandboxed/i)
+  })
+
+  it('adds candidate overrides ahead of generic profile candidates', () => {
+    const plan = buildTechnologyBakeoffPlan({
+      surface: 'analytics',
+      objective: 'Compare analytics tools.',
+      priority: 'conversion',
+      candidateOverrides: ['New Analytics Tool'],
+    })
+
+    expect(plan.candidates[0].label).toBe('New Analytics Tool')
+    expect(plan.candidates[0].role).toBe('User-supplied candidate')
+  })
+})

--- a/lib/technology-bakeoff.ts
+++ b/lib/technology-bakeoff.ts
@@ -1,0 +1,594 @@
+import {
+  buildMediaGenerationBakeoffPlan,
+  type MediaGenerationBakeoffInput,
+} from './media-generation-bakeoff'
+import {
+  buildPresentationBakeoffPlan,
+  type PresentationBakeoffInput,
+} from './presentation-bakeoff'
+
+export const TECHNOLOGY_BAKEOFF_SURFACES = [
+  'media_generation',
+  'presentations',
+  'chat_diagnostic_models',
+  'rag_retrieval',
+  'social_content',
+  'voice_avatar',
+  'workflow_automation',
+  'agent_runtimes',
+  'email_outbound',
+  'lead_enrichment',
+  'pricing_roi',
+  'testing_qa',
+  'commerce',
+  'analytics',
+  'content_assets',
+] as const
+
+export type TechnologyBakeoffSurface = (typeof TECHNOLOGY_BAKEOFF_SURFACES)[number]
+
+export type TechnologyBakeoffPriority =
+  | 'quality'
+  | 'speed'
+  | 'cost'
+  | 'reliability'
+  | 'governance'
+  | 'brand_control'
+  | 'conversion'
+
+export type TechnologyBakeoffDecision =
+  | 'promote_to_default'
+  | 'pilot_with_guardrails'
+  | 'keep_current_default'
+  | 'monitor_or_sandbox'
+  | 'reject_for_now'
+
+export interface TechnologyBakeoffInput {
+  surface: TechnologyBakeoffSurface
+  objective: string
+  priority: TechnologyBakeoffPriority
+  currentDefault?: string
+  knownFailure?: string
+  candidateOverrides?: string[]
+}
+
+export interface TechnologyBakeoffCandidate {
+  id: string
+  label: string
+  role: string
+  bestFor: string
+  watchOutFor: string
+}
+
+export interface TechnologyBakeoffScore {
+  dimension: string
+  score: number
+  weight: number
+  weightedScore: number
+  evidence: string
+}
+
+export interface TechnologyBakeoffPlan {
+  generatedAt: string
+  surface: TechnologyBakeoffSurface
+  surfaceLabel: string
+  objective: string
+  priority: TechnologyBakeoffPriority
+  decision: TechnologyBakeoffDecision
+  recommendedAction: string
+  currentDefault: string
+  fallback: string
+  candidates: TechnologyBakeoffCandidate[]
+  scores: TechnologyBakeoffScore[]
+  benchmarkRunbook: string[]
+  promotionGate: string[]
+  rollbackPlan: string[]
+  integrationNotes: string[]
+  missingEvidence: string[]
+  nextImplementationStep: string
+  specialistSource?: 'media_generation' | 'presentation' | 'agent_runtime'
+}
+
+type ScoreDimensionSeed = {
+  dimension: string
+  weight: number
+  evidence: string
+}
+
+type SurfaceProfile = {
+  surface: TechnologyBakeoffSurface
+  label: string
+  adminArea: string
+  candidates: TechnologyBakeoffCandidate[]
+  scoring: ScoreDimensionSeed[]
+  fallback: string
+  benchmarkFocus: string[]
+  promotionGate: string[]
+  rollbackPlan: string[]
+  integrationNotes: string[]
+  missingEvidence: string[]
+}
+
+const COMMON_PROMOTION_GATE = [
+  'Do not change production defaults from a plan alone.',
+  'Save the current default and fallback path before promoting a winner.',
+  'Require human approval for public-facing, client-facing, outbound, or production-write behavior.',
+]
+
+export const TECHNOLOGY_BAKEOFF_PROFILES: Record<TechnologyBakeoffSurface, SurfaceProfile> = {
+  media_generation: {
+    surface: 'media_generation',
+    label: 'Image and video generation',
+    adminArea: '/admin/content/video-generation, social content, Gamma reports, media uploads',
+    fallback: 'Keep the current video/social media generator and manual asset upload path.',
+    candidates: [
+      candidate('fal', 'fal media model gallery', 'Primary media aggregator', 'Image/video model discovery and fast media experimentation.', 'Model schemas and availability vary by model.'),
+      candidate('replicate', 'Replicate model API', 'Hosted model fallback', 'Open and partner models with simple API runs.', 'Latency, pricing, and licensing vary widely.'),
+      candidate('openrouter', 'OpenRouter image gateway', 'Image routing specialist', 'Image-capable model routing beside text routing.', 'Not the default for full video workflows.'),
+      candidate('direct_provider', 'Direct provider', 'Specialist path', 'First-party features, rights, or quality that beat aggregators.', 'Higher lock-in and adapter maintenance.'),
+    ],
+    scoring: mediaScoring(),
+    benchmarkFocus: [
+      'Run the same prompt packet across image, image edit, text-to-video, and image-to-video candidates.',
+      'Capture cost, latency, output URLs, model id, settings, reviewer score, and failure notes.',
+    ],
+    promotionGate: [
+      ...COMMON_PROMOTION_GATE,
+      'The selected model must pass the media generation promotion gate and keep the old default as fallback.',
+    ],
+    rollbackPlan: [
+      'Keep the previous provider/model id in settings until two successful production runs complete.',
+      'If generation fails, route the workflow back to manual upload or the previous provider.',
+    ],
+    integrationNotes: [
+      'Use the existing media evaluator as the specialist source.',
+      'Future live playground execution should sit behind a shared server-side media provider adapter.',
+    ],
+    missingEvidence: ['Real provider run latency', 'Cost per accepted asset', 'Reviewer acceptance rate'],
+  },
+  presentations: {
+    surface: 'presentations',
+    label: 'Presentation and deck production',
+    adminArea: '/admin/presentations, /admin/reports/gamma, course and deck packages',
+    fallback: 'Keep Codex/PPTX as the editable final packaging path.',
+    candidates: [
+      candidate('codex_pptx', 'Codex / PPTX build', 'Final packaging', 'Editable decks, source control, speaker notes, and QA.', 'Needs more setup than a hosted prompt.'),
+      candidate('claude_design', 'Claude Design prototype', 'Visual exploration', 'High-polish layout and direction finding.', 'May need translation into final editable assets.'),
+      candidate('gamma', 'Gamma AI deck', 'Fast alternate direction', 'Quick structure and visual alternatives.', 'Can weaken proof, voice, and editability.'),
+      candidate('paper_excalidraw', 'Paper or Excalidraw', 'Structure and diagrams', 'Workshop flow, diagrams, and visual thinking.', 'Usually not the final presentation package.'),
+    ],
+    scoring: [
+      scoreSeed('Clarity and narrative arc', 0.18, 'Audience can understand the argument and decision path.'),
+      scoreSeed('Voice and brand fit', 0.18, 'The output sounds like Vambah and preserves AmaduTown visual rules.'),
+      scoreSeed('Proof and source quality', 0.18, 'Screenshots, demos, and source anchors remain visible and reviewable.'),
+      scoreSeed('Editability and export quality', 0.16, 'The final artifact can be revised and exported without rebuilding from scratch.'),
+      scoreSeed('Presentation readiness', 0.16, 'Notes, timing, density, contrast, and backup assets are ready.'),
+      scoreSeed('Production repeatability', 0.14, 'The workflow can be repeated for future courses or decks.'),
+    ],
+    benchmarkFocus: [
+      'Use the same brief, thesis, proof assets, demo routes, and source anchors across candidates.',
+      'Score the final deliverable and the edit path, not just surface polish.',
+    ],
+    promotionGate: [
+      ...COMMON_PROMOTION_GATE,
+      'The winning base must keep source guide, notes, screenshots, QA exports, and editable source files.',
+    ],
+    rollbackPlan: [
+      'Keep the previous deck source and exported PDF as the fallback package.',
+      'If a hosted tool loses editability, translate only the useful visual ideas into the Codex/PPTX base.',
+    ],
+    integrationNotes: [
+      'Use the existing presentation evaluator as the specialist source.',
+      'Keep generated decks connected to source registers and proof screenshots.',
+    ],
+    missingEvidence: ['Candidate exports', 'Speaker-note quality', 'Visual QA screenshots'],
+  },
+  chat_diagnostic_models: genericProfile(
+    'chat_diagnostic_models',
+    'Chat and diagnostic models',
+    '/api/chat, /admin/chat-eval, /tools/audit, /api/chat/diagnostic',
+    ['Hosted LLMs', 'Local RAG', 'Open-weight models', 'Model routers'],
+    ['answer accuracy', 'source use', 'escalation quality', 'latency', 'cost', 'safety'],
+    'Keep the current chat model and diagnostic routing until shadow tests improve chat eval scores.'
+  ),
+  rag_retrieval: genericProfile(
+    'rag_retrieval',
+    'RAG and knowledge retrieval',
+    '/api/knowledge, lib/rag-query.ts, local RAG shadow mode, chatbot knowledge build',
+    ['Supabase/Postgres retrieval', 'Local vector stores', 'Hosted vector DBs', 'Rerankers'],
+    ['recall', 'precision', 'freshness', 'privacy', 'query latency', 'maintenance burden'],
+    'Keep the existing retrieval path and chatbot knowledge build until shadow results beat saved test questions.'
+  ),
+  social_content: genericProfile(
+    'social_content',
+    'Social content generation',
+    '/admin/social-content, n8n social workflows, LinkedIn review queue',
+    ['Copy models', 'Image models', 'TTS', 'Scheduling tools', 'Publishing tools'],
+    ['voice fit', 'approval burden', 'image quality', 'platform fit', 'rights', 'publish reliability'],
+    'Keep the human review queue and current publishing path.'
+  ),
+  voice_avatar: genericProfile(
+    'voice_avatar',
+    'Voice and avatar video',
+    'video generation, HeyGen webhooks, VAPI webhook, meeting follow-up content',
+    ['HeyGen', 'ElevenLabs', 'Vapi', 'Avatar alternatives', 'Direct TTS providers'],
+    ['voice quality', 'likeness control', 'webhook reliability', 'cost per minute', 'consent', 'approval'],
+    'Keep the current HeyGen/VAPI path and manual review for public or client-facing output.'
+  ),
+  workflow_automation: genericProfile(
+    'workflow_automation',
+    'Workflow automation runtime',
+    'n8n exports, /admin/agents, webhook routes, cron routes',
+    ['n8n Cloud', 'Codex automations', 'Vercel cron', 'Supabase scheduled jobs', 'Local scripts'],
+    ['observability', 'retries', 'cost', 'deploy friction', 'audit trail', 'rollback'],
+    'Keep n8n Cloud as the default automation runtime unless a traceable replacement wins.'
+  ),
+  agent_runtimes: {
+    surface: 'agent_runtimes',
+    label: 'Agent runtimes',
+    adminArea: '/admin/agents, Hermes bridge, OpenCode/OpenClaw evaluation',
+    fallback: 'Keep Codex as primary and keep Hermes/OpenCode-style runtimes read-only or sandboxed.',
+    candidates: [
+      candidate('codex', 'Codex', 'Primary repo-aware operator', 'Implementation, review, and local workspace execution.', 'Needs trace discipline for long-running work.'),
+      candidate('hermes', 'Hermes', 'Secondary local runtime', 'Critique, research, local health checks, and parity experiments.', 'Should stay read-only until write gates are proven.'),
+      candidate('opencode', 'OpenCode/OpenClaw', 'Coding worker candidate', 'Isolated review and worktree experiments.', 'Must prove install, auth, rollback, and audit behavior.'),
+      candidate('future_agent', 'Future coding agents', 'Watchlist', 'New runtimes with better specialization or cost.', 'No production writes without Agent Operations coverage.'),
+    ],
+    scoring: [
+      scoreSeed('Repository performance', 0.2, 'Completes scoped repo tasks with tests and low review burden.'),
+      scoreSeed('Auditability', 0.2, 'Creates observable runs, steps, artifacts, and decisions.'),
+      scoreSeed('Permission control', 0.18, 'Supports safe read/write boundaries and approval gates.'),
+      scoreSeed('Rollback and handoff quality', 0.18, 'Leaves branches, PRs, artifacts, and recovery paths clear.'),
+      scoreSeed('Runtime availability', 0.14, 'Can be installed, authenticated, and probed without exposing secrets.'),
+      scoreSeed('Cost and speed', 0.1, 'Improves throughput without increasing hidden risk.'),
+    ],
+    benchmarkFocus: [
+      'Use Agent Operations to create observable read-only probes before assigning work.',
+      'Compare runtimes on the same bounded repo task, then review traces, diffs, tests, and handoff quality.',
+    ],
+    promotionGate: [
+      ...COMMON_PROMOTION_GATE,
+      'A runtime must stay read-only or sandboxed until trace and approval behavior is proven.',
+      'Production writes require agent_approvals coverage.',
+    ],
+    rollbackPlan: [
+      'Stop assigning work to the runtime and close any unmerged branches or sandbox worktrees.',
+      'Keep Codex as the fallback runtime for repo-aware implementation.',
+    ],
+    integrationNotes: [
+      'Reuse the Agent Operations and runtime evaluation framing.',
+      'Do not import filesystem runtime probes into client-side bakeoff UI.',
+    ],
+    missingEvidence: ['Observable test run', 'Auth and install status', 'Rollback drill result'],
+  },
+  email_outbound: genericProfile(
+    'email_outbound',
+    'Email and outbound messaging',
+    '/admin/email-center, Gmail helpers, Resend webhook, proposal/email drafts',
+    ['Gmail API', 'Resend', 'SMTP', 'n8n email nodes', 'Copy models'],
+    ['deliverability', 'personalization', 'auditability', 'reply handling', 'approval burden'],
+    'Keep traceable drafts and approval state before outbound sends.'
+  ),
+  lead_enrichment: genericProfile(
+    'lead_enrichment',
+    'Lead discovery and enrichment',
+    'outreach dashboard, tech-stack lookup, warm lead workflows',
+    ['Apify actors', 'BuiltWith', 'LinkedIn/Google sources', 'Enrichment APIs', 'Browser agents'],
+    ['data quality', 'source reliability', 'cost per useful lead', 'compliance', 'duplicate rate'],
+    'Keep current enrichment sources until a candidate improves qualified-lead yield without privacy risk.'
+  ),
+  pricing_roi: genericProfile(
+    'pricing_roi',
+    'Pricing, bundles, and ROI tools',
+    '/admin/sales, /admin/cost-revenue, /pricing, ROI tools',
+    ['Pricing models', 'Market data sources', 'Proposal generators', 'Analytics providers'],
+    ['margin accuracy', 'offer clarity', 'conversion', 'source quality', 'update effort'],
+    'Keep current pricing rules until changes validate against cost/revenue and proposal acceptance data.'
+  ),
+  testing_qa: genericProfile(
+    'testing_qa',
+    'Testing and QA automation',
+    '/admin/testing, Playwright, API route tests, regression docs',
+    ['Playwright', 'Browser Use', 'Synthetic monitors', 'Visual diff tools', 'LLM judges'],
+    ['bug catch rate', 'false positives', 'speed', 'maintenance', 'screenshot evidence'],
+    'Keep the current focused tests and admin testing dashboard until new QA catches known regressions.'
+  ),
+  commerce: genericProfile(
+    'commerce',
+    'Payments, fulfillment, and commerce',
+    'checkout, Stripe routes, Printful webhook, store/services/products',
+    ['Stripe features', 'Checkout UX tools', 'Fulfillment tools', 'Tax/shipping providers'],
+    ['payment reliability', 'fulfillment accuracy', 'support burden', 'reconciliation'],
+    'Keep Stripe/Printful defaults until test transactions and webhook traces pass.'
+  ),
+  analytics: genericProfile(
+    'analytics',
+    'Analytics and attribution',
+    '/admin/analytics, funnel analytics, cost events, campaign pages',
+    ['Vercel analytics', 'Custom events', 'PostHog', 'Supabase events', 'Warehouse tools'],
+    ['event accuracy', 'funnel visibility', 'privacy', 'cost', 'operational usefulness'],
+    'Keep current analytics until the candidate answers a decision the dashboard cannot answer.'
+  ),
+  content_assets: genericProfile(
+    'content_assets',
+    'Content and asset management',
+    'Content Hub, uploads, publications, products, projects, Google Drive sync',
+    ['Supabase Storage', 'Google Drive', 'Local staged assets', 'CMS tools', 'Asset CDNs'],
+    ['provenance', 'speed', 'permissions', 'migration cost', 'public URL stability'],
+    'Keep current asset locations until source register and rollback path exist.'
+  ),
+}
+
+function candidate(id: string, label: string, role: string, bestFor: string, watchOutFor: string): TechnologyBakeoffCandidate {
+  return { id, label, role, bestFor, watchOutFor }
+}
+
+function scoreSeed(dimension: string, weight: number, evidence: string): ScoreDimensionSeed {
+  return { dimension, weight, evidence }
+}
+
+function mediaScoring(): ScoreDimensionSeed[] {
+  return [
+    scoreSeed('Output quality', 0.22, 'Visual quality, artifacts, realism or illustration quality, and motion coherence.'),
+    scoreSeed('Prompt and reference fidelity', 0.16, 'Follows prompt, reference assets, aspect ratios, and negative constraints.'),
+    scoreSeed('Speed and throughput', 0.14, 'Measures p50/p90 latency, queue behavior, and batch behavior.'),
+    scoreSeed('Cost control', 0.1, 'Tracks cost per run and cost per accepted output.'),
+    scoreSeed('Brand and text control', 0.12, 'Handles logos, text, color discipline, and product consistency.'),
+    scoreSeed('Workflow fit', 0.1, 'Fits Portfolio media, video, social, b-roll, and admin review flows.'),
+    scoreSeed('API installability', 0.08, 'Has a clear server-side adapter path.'),
+    scoreSeed('Observability and provenance', 0.08, 'Returns model id, settings, latency, cost, output URLs, and reviewer notes.'),
+  ]
+}
+
+function genericProfile(
+  surface: TechnologyBakeoffSurface,
+  label: string,
+  adminArea: string,
+  candidates: string[],
+  dimensions: string[],
+  fallback: string
+): SurfaceProfile {
+  const weight = Number((1 / dimensions.length).toFixed(2))
+  return {
+    surface,
+    label,
+    adminArea,
+    fallback,
+    candidates: candidates.map((name, index) => {
+      const id = name.toLowerCase().replaceAll(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '')
+      return candidate(
+        id,
+        name,
+        index === 0 ? 'Current or primary candidate class' : 'Comparison candidate class',
+        `Evaluate ${name} against the same benchmark packet.`,
+        'Do not promote without run evidence, rollback path, and approval where needed.'
+      )
+    }),
+    scoring: dimensions.map((dimension) => {
+      return scoreSeed(titleCase(dimension), weight, `Score candidate performance on ${dimension}.`)
+    }),
+    benchmarkFocus: [
+      'Use the same test inputs, constraints, and acceptance criteria for every candidate.',
+      'Capture evidence, reviewer notes, cost, latency, failure modes, and operational burden.',
+    ],
+    promotionGate: [
+      ...COMMON_PROMOTION_GATE,
+      'The candidate must beat the current default on the highest-priority dimension without adding unacceptable operational risk.',
+    ],
+    rollbackPlan: [
+      'Keep the current default active until the new candidate completes a pilot run.',
+      'Restore the prior setting, route, or provider if failure rate, cost, or review burden rises.',
+    ],
+    integrationNotes: [
+      `Use ${adminArea} as the operational context for evidence gathering.`,
+      'Add a specialist evaluator later if this surface needs domain-specific scoring.',
+    ],
+    missingEvidence: ['Current baseline score', 'Candidate run evidence', 'Cost and latency notes', 'Reviewer or operator notes'],
+  }
+}
+
+function titleCase(value: string): string {
+  return value
+    .split(' ')
+    .filter(Boolean)
+    .map((word) => `${word.slice(0, 1).toUpperCase()}${word.slice(1)}`)
+    .join(' ')
+}
+
+function scoreFromPriority(dimension: string, priority: TechnologyBakeoffPriority, knownFailure?: string): number {
+  const lower = dimension.toLowerCase()
+  let score = 3
+  if (priority === 'quality' && (lower.includes('quality') || lower.includes('accuracy') || lower.includes('precision'))) score += 1
+  if (priority === 'speed' && (lower.includes('speed') || lower.includes('latency') || lower.includes('throughput'))) score += 1
+  if (priority === 'cost' && (lower.includes('cost') || lower.includes('margin'))) score += 1
+  if (priority === 'reliability' && (lower.includes('reliability') || lower.includes('failure') || lower.includes('webhook'))) score += 1
+  if (priority === 'governance' && (lower.includes('approval') || lower.includes('privacy') || lower.includes('audit') || lower.includes('provenance'))) score += 1
+  if (priority === 'brand_control' && (lower.includes('brand') || lower.includes('voice') || lower.includes('text'))) score += 1
+  if (priority === 'conversion' && (lower.includes('conversion') || lower.includes('offer') || lower.includes('funnel'))) score += 1
+  if (knownFailure && lower.includes('reliability')) score -= 1
+  return Math.max(1, Math.min(5, score))
+}
+
+function buildScores(profile: SurfaceProfile, input: TechnologyBakeoffInput): TechnologyBakeoffScore[] {
+  return profile.scoring.map((seed) => {
+    const score = scoreFromPriority(seed.dimension, input.priority, input.knownFailure)
+    return {
+      dimension: seed.dimension,
+      score,
+      weight: seed.weight,
+      weightedScore: Number((score * seed.weight).toFixed(2)),
+      evidence: seed.evidence,
+    }
+  })
+}
+
+function genericDecision(scores: TechnologyBakeoffScore[], knownFailure?: string): TechnologyBakeoffDecision {
+  if (knownFailure) return 'pilot_with_guardrails'
+  const total = scores.reduce((sum, score) => sum + score.weightedScore, 0)
+  if (total >= 4.2) return 'promote_to_default'
+  if (total >= 3.4) return 'pilot_with_guardrails'
+  if (total >= 2.8) return 'monitor_or_sandbox'
+  return 'keep_current_default'
+}
+
+function decisionLabel(decision: TechnologyBakeoffDecision): string {
+  const labels: Record<TechnologyBakeoffDecision, string> = {
+    promote_to_default: 'Promote only after evidence review',
+    pilot_with_guardrails: 'Pilot with guardrails',
+    keep_current_default: 'Keep current default',
+    monitor_or_sandbox: 'Monitor or sandbox',
+    reject_for_now: 'Reject for now',
+  }
+  return labels[decision]
+}
+
+function applyCandidateOverrides(
+  profile: SurfaceProfile,
+  overrides: string[] | undefined
+): TechnologyBakeoffCandidate[] {
+  const overrideCandidates = (overrides ?? []).map((name) => name.trim()).filter(Boolean)
+  if (overrideCandidates.length === 0) return profile.candidates
+
+  const generated = overrideCandidates.map((name) => {
+    const id = name.toLowerCase().replaceAll(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '')
+    return candidate(id, name, 'User-supplied candidate', `Evaluate ${name} for this specific bakeoff objective.`, 'Needs the same evidence packet as built-in candidates.')
+  })
+  return [...generated, ...profile.candidates]
+}
+
+function buildSpecialistMediaPlan(input: TechnologyBakeoffInput, profile: SurfaceProfile): Partial<TechnologyBakeoffPlan> {
+  const mediaInput: MediaGenerationBakeoffInput = {
+    title: input.objective,
+    useCase: input.objective,
+    mode: 'campaign_media',
+    priority: input.priority === 'speed'
+      ? 'speed'
+      : input.priority === 'cost'
+        ? 'cost'
+        : input.priority === 'brand_control'
+          ? 'brand_control'
+          : input.priority === 'quality'
+            ? 'quality'
+            : 'production_reliability',
+    currentDefaultProvider: undefined,
+    needsBatchGeneration: true,
+    needsApiInstallPath: true,
+    needsHumanApproval: true,
+    needsBrandConsistency: true,
+    needsVideoAudio: true,
+  }
+  const plan = buildMediaGenerationBakeoffPlan(mediaInput)
+  return {
+    decision: plan.candidates[0]?.decision === 'promote_to_default' ? 'pilot_with_guardrails' : 'monitor_or_sandbox',
+    recommendedAction: `${plan.recommendedLabel}: ${plan.recommendation}`,
+    candidates: plan.candidates.map((item) => ({
+      id: item.provider,
+      label: item.label,
+      role: item.role,
+      bestFor: item.bestFor,
+      watchOutFor: item.watchOutFor,
+    })),
+    scores: plan.candidates[0]?.scores.map((score) => ({
+      dimension: score.dimension,
+      score: score.score,
+      weight: score.weight,
+      weightedScore: score.weightedScore,
+      evidence: score.evidence,
+    })) ?? buildScores(profile, input),
+    benchmarkRunbook: plan.benchmarkRunbook,
+    promotionGate: plan.promotionGate,
+    integrationNotes: plan.portfolioIntegrationPlan,
+    specialistSource: 'media_generation',
+  }
+}
+
+function buildSpecialistPresentationPlan(input: TechnologyBakeoffInput, profile: SurfaceProfile): Partial<TechnologyBakeoffPlan> {
+  const presentationInput: PresentationBakeoffInput = {
+    title: input.objective,
+    thesis: input.objective,
+    audience: 'clients',
+    format: 'thought_leadership',
+    durationMinutes: 30,
+    brandSystem: 'amadutown',
+    needsEditablePptx: true,
+    needsLiveDemos: true,
+    needsSourceValidation: true,
+    needsFacilitatorNotes: true,
+  }
+  const plan = buildPresentationBakeoffPlan(presentationInput)
+  return {
+    decision: 'pilot_with_guardrails',
+    recommendedAction: `${plan.recommendedLabel}: ${plan.recommendation}`,
+    candidates: plan.candidates.map((item) => ({
+      id: item.tool,
+      label: item.label,
+      role: item.role,
+      bestFor: item.bestFor,
+      watchOutFor: item.watchOutFor,
+    })),
+    scores: plan.candidates[0]?.scores.map((score) => ({
+      dimension: score.dimension,
+      score: score.score,
+      weight: score.weight,
+      weightedScore: score.weightedScore,
+      evidence: score.rationale,
+    })) ?? buildScores(profile, input),
+    benchmarkRunbook: plan.coursePlan,
+    promotionGate: plan.qaChecklist,
+    integrationNotes: plan.requiredAssets,
+    specialistSource: 'presentation',
+  }
+}
+
+function specialistPlan(input: TechnologyBakeoffInput, profile: SurfaceProfile): Partial<TechnologyBakeoffPlan> {
+  if (input.surface === 'media_generation') return buildSpecialistMediaPlan(input, profile)
+  if (input.surface === 'presentations') return buildSpecialistPresentationPlan(input, profile)
+  if (input.surface === 'agent_runtimes') {
+    return {
+      decision: 'monitor_or_sandbox',
+      recommendedAction: 'Use Agent Operations to probe runtime availability, then run a read-only task before any production work.',
+      specialistSource: 'agent_runtime',
+    }
+  }
+  return {}
+}
+
+export function buildTechnologyBakeoffPlan(input: TechnologyBakeoffInput): TechnologyBakeoffPlan {
+  const profile = TECHNOLOGY_BAKEOFF_PROFILES[input.surface]
+  if (!profile) {
+    throw new Error(`Unsupported technology bakeoff surface: ${String(input.surface)}`)
+  }
+
+  const scores = buildScores(profile, input)
+  const decision = genericDecision(scores, input.knownFailure)
+  const specialist = specialistPlan(input, profile)
+  const candidates = specialist.candidates ?? applyCandidateOverrides(profile, input.candidateOverrides)
+  const currentDefault = input.currentDefault?.trim() || 'Current Portfolio default'
+
+  return {
+    generatedAt: new Date().toISOString(),
+    surface: input.surface,
+    surfaceLabel: profile.label,
+    objective: input.objective,
+    priority: input.priority,
+    decision: specialist.decision ?? decision,
+    recommendedAction: specialist.recommendedAction
+      ?? `${decisionLabel(decision)} for ${profile.label}. Run the bakeoff packet before changing ${currentDefault}.`,
+    currentDefault,
+    fallback: profile.fallback,
+    candidates,
+    scores: specialist.scores ?? scores,
+    benchmarkRunbook: [
+      `Decision question: ${input.objective}`,
+      `Current default: ${currentDefault}`,
+      ...(input.knownFailure ? [`Known failure to test against: ${input.knownFailure}`] : []),
+      ...((specialist.benchmarkRunbook ?? profile.benchmarkFocus)),
+    ],
+    promotionGate: specialist.promotionGate ?? profile.promotionGate,
+    rollbackPlan: profile.rollbackPlan,
+    integrationNotes: specialist.integrationNotes ?? profile.integrationNotes,
+    missingEvidence: profile.missingEvidence,
+    nextImplementationStep: `Create a small evidence packet for ${profile.label} in ${profile.adminArea}, then compare candidates with the scoring plan.`,
+    specialistSource: specialist.specialistSource,
+  }
+}


### PR DESCRIPTION
## Summary

- adds a read-only Technology Bakeoffs admin planning surface
- adds deterministic technology and media generation bakeoff planners with regression coverage
- adds supporting docs for media generation, technology surface mapping, Portfolio operations management, and subscription cancellation audit notes
- links the Portfolio Operations Manager standing role from the agent operations rollout doc

## Validation

- `npx vitest run lib/technology-bakeoff.test.ts lib/media-generation-bakeoff.test.ts app/admin/technology-bakeoffs/page.test.tsx`
- `npx tsc --noEmit --pretty false 2>&1 | rg "technology-bakeoff|media-generation-bakeoff|technology-bakeoffs|portfolio-operations-manager|agent-operations-rollout" || true`

## Notes

- `excalidraw.log` was generated locally and intentionally left out of the PR.
