### PR TITLE
config: track credential baselines and provider smoke

### DIFF
--- a/docs/credential-inventory.json
+++ b/docs/credential-inventory.json
@@ -2,7 +2,12 @@
   "schemaVersion": 1,
   "policy": {
     "sourceOfTruth": "Infisical for runtime/API secrets; 1Password for human logins, recovery data, and client-shared passwords.",
-    "runtimeSinks": ["Vercel", "n8n", "Supabase", "local-env"],
+    "runtimeSinks": [
+      "Vercel",
+      "n8n",
+      "Supabase",
+      "local-env"
+    ],
     "agentAuthority": "Scoped read/run by default. Production revocation or client-impacting rotation requires an approval packet unless explicitly authorized.",
     "defaultCadenceDays": {
       "critical-production": 30,
@@ -11,6 +16,11 @@
       "standard-api": 90,
       "dev-test": 180,
       "oauth-session": 365
+    },
+    "baselineMetadata": {
+      "status": "pending-provider-confirmation means the credential is tracked but the last rotation date has not been verified from the source of truth yet.",
+      "requiredEvidence": "Provider dashboard/API event, Infisical audit/version metadata, 1Password item history, or an approved rotation packet.",
+      "updatedAt": "2026-05-01"
     }
   },
   "providers": {
@@ -41,11 +51,44 @@
       "sourceOfTruth": "infisical",
       "rotationMode": "generated-shared-secret",
       "rotationCadenceDays": 30,
-      "environments": ["dev", "staging", "prod"],
-      "runtimeSinks": ["Vercel", "n8n Variables", "local-env"],
-      "verification": ["npm run credentials:smoke -- --env {env}", "Admin -> Testing -> Credential Smoke"],
+      "environments": [
+        "dev",
+        "staging",
+        "prod"
+      ],
+      "runtimeSinks": [
+        "Vercel",
+        "n8n Variables",
+        "local-env"
+      ],
+      "verification": [
+        "npm run credentials:smoke -- --env {env}",
+        "Admin -> Testing -> Credential Smoke"
+      ],
       "rollback": "Restore previous Infisical version, re-sync Vercel/n8n/local env, rerun Credential Smoke.",
-      "approvalRequired": ["prod"]
+      "approvalRequired": [
+        "prod"
+      ],
+      "baseline": {
+        "dev": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        },
+        "staging": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        },
+        "prod": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        }
+      }
     },
     {
       "id": "supabase-service-role-key",
@@ -56,11 +99,45 @@
       "sourceOfTruth": "infisical",
       "rotationMode": "provider-dashboard-or-api",
       "rotationCadenceDays": 60,
-      "environments": ["dev", "staging", "prod"],
-      "runtimeSinks": ["Vercel", "n8n Variables", "local-env"],
-      "verification": ["npm run credentials:smoke -- --env {env}", "Admin -> Leads page loads", "Admin -> Testing -> Credential Smoke"],
+      "environments": [
+        "dev",
+        "staging",
+        "prod"
+      ],
+      "runtimeSinks": [
+        "Vercel",
+        "n8n Variables",
+        "local-env"
+      ],
+      "verification": [
+        "npm run credentials:smoke -- --env {env}",
+        "Admin -> Leads page loads",
+        "Admin -> Testing -> Credential Smoke"
+      ],
       "rollback": "Restore previous Supabase API key if still valid, re-sync sinks, rerun smoke tests.",
-      "approvalRequired": ["prod"]
+      "approvalRequired": [
+        "prod"
+      ],
+      "baseline": {
+        "dev": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        },
+        "staging": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        },
+        "prod": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        }
+      }
     },
     {
       "id": "openai-api-key",
@@ -71,11 +148,44 @@
       "sourceOfTruth": "infisical",
       "rotationMode": "provider-dashboard-or-api",
       "rotationCadenceDays": 90,
-      "environments": ["dev", "staging", "prod"],
-      "runtimeSinks": ["Vercel", "n8n Credentials", "local-env"],
-      "verification": ["npm run credentials:smoke -- --env {env}", "Run one LLM-backed admin generation in staging"],
+      "environments": [
+        "dev",
+        "staging",
+        "prod"
+      ],
+      "runtimeSinks": [
+        "Vercel",
+        "n8n Credentials",
+        "local-env"
+      ],
+      "verification": [
+        "npm run credentials:smoke -- --env {env}",
+        "Run one LLM-backed admin generation in staging"
+      ],
       "rollback": "Restore previous OpenAI key if still valid, re-sync runtime sinks, retry LLM smoke.",
-      "approvalRequired": ["prod"]
+      "approvalRequired": [
+        "prod"
+      ],
+      "baseline": {
+        "dev": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        },
+        "staging": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        },
+        "prod": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        }
+      }
     },
     {
       "id": "anthropic-api-key",
@@ -86,11 +196,44 @@
       "sourceOfTruth": "infisical",
       "rotationMode": "provider-dashboard-or-api",
       "rotationCadenceDays": 90,
-      "environments": ["dev", "staging", "prod"],
-      "runtimeSinks": ["Vercel", "n8n Credentials", "local-env"],
-      "verification": ["npm run credentials:smoke -- --env {env}", "Run one Anthropic-backed workflow in staging"],
+      "environments": [
+        "dev",
+        "staging",
+        "prod"
+      ],
+      "runtimeSinks": [
+        "Vercel",
+        "n8n Credentials",
+        "local-env"
+      ],
+      "verification": [
+        "npm run credentials:smoke -- --env {env}",
+        "Run one Anthropic-backed workflow in staging"
+      ],
       "rollback": "Restore previous Anthropic key if still valid, re-sync runtime sinks, retry LLM smoke.",
-      "approvalRequired": ["prod"]
+      "approvalRequired": [
+        "prod"
+      ],
+      "baseline": {
+        "dev": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        },
+        "staging": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        },
+        "prod": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        }
+      }
     },
     {
       "id": "openrouter-api-key",
@@ -101,11 +244,44 @@
       "sourceOfTruth": "infisical",
       "rotationMode": "provider-dashboard-or-api",
       "rotationCadenceDays": 90,
-      "environments": ["dev", "staging", "prod"],
-      "runtimeSinks": ["n8n Credentials", "n8n Variables", "local-env"],
-      "verification": ["npm run credentials:smoke -- --env {env}", "Run affected n8n workflow test"],
+      "environments": [
+        "dev",
+        "staging",
+        "prod"
+      ],
+      "runtimeSinks": [
+        "n8n Credentials",
+        "n8n Variables",
+        "local-env"
+      ],
+      "verification": [
+        "npm run credentials:smoke -- --env {env}",
+        "Run affected n8n workflow test"
+      ],
       "rollback": "Restore previous OpenRouter key if still valid, re-sync n8n, rerun workflow test.",
-      "approvalRequired": ["prod"]
+      "approvalRequired": [
+        "prod"
+      ],
+      "baseline": {
+        "dev": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        },
+        "staging": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        },
+        "prod": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        }
+      }
     },
     {
       "id": "gemini-api-key",
@@ -116,11 +292,43 @@
       "sourceOfTruth": "infisical",
       "rotationMode": "provider-dashboard-or-api",
       "rotationCadenceDays": 90,
-      "environments": ["dev", "staging", "prod"],
-      "runtimeSinks": ["n8n Variables", "local-env"],
-      "verification": ["npm run credentials:smoke -- --env {env}", "Run WF-SOC image generation smoke"],
+      "environments": [
+        "dev",
+        "staging",
+        "prod"
+      ],
+      "runtimeSinks": [
+        "n8n Variables",
+        "local-env"
+      ],
+      "verification": [
+        "npm run credentials:smoke -- --env {env}",
+        "Run WF-SOC image generation smoke"
+      ],
       "rollback": "Restore previous Gemini key if still valid, re-sync n8n, rerun media workflow.",
-      "approvalRequired": ["prod"]
+      "approvalRequired": [
+        "prod"
+      ],
+      "baseline": {
+        "dev": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        },
+        "staging": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        },
+        "prod": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        }
+      }
     },
     {
       "id": "elevenlabs-api-key",
@@ -131,11 +339,43 @@
       "sourceOfTruth": "infisical",
       "rotationMode": "provider-dashboard-or-api",
       "rotationCadenceDays": 90,
-      "environments": ["dev", "staging", "prod"],
-      "runtimeSinks": ["n8n Variables", "local-env"],
-      "verification": ["npm run credentials:smoke -- --env {env}", "Run WF-SOC voiceover smoke"],
+      "environments": [
+        "dev",
+        "staging",
+        "prod"
+      ],
+      "runtimeSinks": [
+        "n8n Variables",
+        "local-env"
+      ],
+      "verification": [
+        "npm run credentials:smoke -- --env {env}",
+        "Run WF-SOC voiceover smoke"
+      ],
       "rollback": "Restore previous ElevenLabs key if still valid, re-sync n8n, rerun media workflow.",
-      "approvalRequired": ["prod"]
+      "approvalRequired": [
+        "prod"
+      ],
+      "baseline": {
+        "dev": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        },
+        "staging": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        },
+        "prod": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        }
+      }
     },
     {
       "id": "apify-api-token",
@@ -146,11 +386,45 @@
       "sourceOfTruth": "infisical",
       "rotationMode": "provider-dashboard-or-api",
       "rotationCadenceDays": 60,
-      "environments": ["dev", "staging", "prod"],
-      "runtimeSinks": ["n8n Credentials", "n8n Variables", "local-env"],
-      "verification": ["npm run credentials:smoke -- --env {env}", "Run Apify user/me token smoke", "Run one affected n8n workflow test"],
+      "environments": [
+        "dev",
+        "staging",
+        "prod"
+      ],
+      "runtimeSinks": [
+        "n8n Credentials",
+        "n8n Variables",
+        "local-env"
+      ],
+      "verification": [
+        "npm run credentials:smoke -- --env {env}",
+        "Run Apify user/me token smoke",
+        "Run one affected n8n workflow test"
+      ],
       "rollback": "Restore previous Apify token if still valid, re-sync n8n, rerun affected workflows.",
-      "approvalRequired": ["prod"]
+      "approvalRequired": [
+        "prod"
+      ],
+      "baseline": {
+        "dev": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        },
+        "staging": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        },
+        "prod": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        }
+      }
     },
     {
       "id": "stripe-secret-key",
@@ -161,11 +435,43 @@
       "sourceOfTruth": "infisical",
       "rotationMode": "provider-dashboard-or-api",
       "rotationCadenceDays": 30,
-      "environments": ["dev", "staging", "prod"],
-      "runtimeSinks": ["Vercel", "local-env"],
-      "verification": ["npm run credentials:smoke -- --env {env}", "Admin -> Testing -> Create Test Checkout"],
+      "environments": [
+        "dev",
+        "staging",
+        "prod"
+      ],
+      "runtimeSinks": [
+        "Vercel",
+        "local-env"
+      ],
+      "verification": [
+        "npm run credentials:smoke -- --env {env}",
+        "Admin -> Testing -> Create Test Checkout"
+      ],
       "rollback": "Restore previous Stripe key if still valid, re-sync Vercel/local env, rerun checkout smoke.",
-      "approvalRequired": ["prod"]
+      "approvalRequired": [
+        "prod"
+      ],
+      "baseline": {
+        "dev": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        },
+        "staging": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        },
+        "prod": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        }
+      }
     },
     {
       "id": "stripe-webhook-secret",
@@ -176,11 +482,44 @@
       "sourceOfTruth": "infisical",
       "rotationMode": "provider-dashboard-or-api",
       "rotationCadenceDays": 30,
-      "environments": ["dev", "staging", "prod"],
-      "runtimeSinks": ["Vercel", "n8n Variables", "local-env"],
-      "verification": ["npm run credentials:smoke -- --env {env}", "Stripe webhook test event succeeds"],
+      "environments": [
+        "dev",
+        "staging",
+        "prod"
+      ],
+      "runtimeSinks": [
+        "Vercel",
+        "n8n Variables",
+        "local-env"
+      ],
+      "verification": [
+        "npm run credentials:smoke -- --env {env}",
+        "Stripe webhook test event succeeds"
+      ],
       "rollback": "Restore previous webhook signing secret if still valid, re-sync sinks, replay webhook test.",
-      "approvalRequired": ["prod"]
+      "approvalRequired": [
+        "prod"
+      ],
+      "baseline": {
+        "dev": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        },
+        "staging": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        },
+        "prod": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        }
+      }
     },
     {
       "id": "github-token",
@@ -191,11 +530,43 @@
       "sourceOfTruth": "infisical",
       "rotationMode": "provider-dashboard-or-api",
       "rotationCadenceDays": 60,
-      "environments": ["dev", "staging", "prod"],
-      "runtimeSinks": ["Vercel", "local-env"],
-      "verification": ["npm run credentials:smoke -- --env {env}", "Run module sync dry-run where available"],
+      "environments": [
+        "dev",
+        "staging",
+        "prod"
+      ],
+      "runtimeSinks": [
+        "Vercel",
+        "local-env"
+      ],
+      "verification": [
+        "npm run credentials:smoke -- --env {env}",
+        "Run module sync dry-run where available"
+      ],
       "rollback": "Restore previous GitHub token if still valid, re-sync sinks, rerun module sync smoke.",
-      "approvalRequired": ["prod"]
+      "approvalRequired": [
+        "prod"
+      ],
+      "baseline": {
+        "dev": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        },
+        "staging": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        },
+        "prod": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        }
+      }
     },
     {
       "id": "google-service-account-key",
@@ -206,11 +577,43 @@
       "sourceOfTruth": "infisical",
       "rotationMode": "provider-dashboard-or-api",
       "rotationCadenceDays": 60,
-      "environments": ["dev", "staging", "prod"],
-      "runtimeSinks": ["Vercel", "local-env"],
-      "verification": ["npm run credentials:smoke -- --env {env}", "Run Drive sync smoke"],
+      "environments": [
+        "dev",
+        "staging",
+        "prod"
+      ],
+      "runtimeSinks": [
+        "Vercel",
+        "local-env"
+      ],
+      "verification": [
+        "npm run credentials:smoke -- --env {env}",
+        "Run Drive sync smoke"
+      ],
       "rollback": "Restore previous Google service account key if still valid, re-sync sinks, rerun Drive sync.",
-      "approvalRequired": ["prod"]
+      "approvalRequired": [
+        "prod"
+      ],
+      "baseline": {
+        "dev": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        },
+        "staging": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        },
+        "prod": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        }
+      }
     },
     {
       "id": "linkedin-cookie",
@@ -221,11 +624,42 @@
       "sourceOfTruth": "1password",
       "rotationMode": "manual-reauth",
       "rotationCadenceDays": 365,
-      "environments": ["dev", "staging", "prod"],
-      "runtimeSinks": ["n8n Variables", "local-env"],
-      "verification": ["Run LinkedIn warm-lead workflow smoke"],
+      "environments": [
+        "dev",
+        "staging",
+        "prod"
+      ],
+      "runtimeSinks": [
+        "n8n Variables",
+        "local-env"
+      ],
+      "verification": [
+        "Run LinkedIn warm-lead workflow smoke"
+      ],
       "rollback": "Restore prior valid cookie only if the new browser session fails and no compromise is suspected.",
-      "approvalRequired": ["prod"]
+      "approvalRequired": [
+        "prod"
+      ],
+      "baseline": {
+        "dev": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        },
+        "staging": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        },
+        "prod": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        }
+      }
     },
     {
       "id": "gmail-app-password",
@@ -236,11 +670,42 @@
       "sourceOfTruth": "1password",
       "rotationMode": "manual-reauth",
       "rotationCadenceDays": 60,
-      "environments": ["dev", "staging", "prod"],
-      "runtimeSinks": ["Vercel", "local-env"],
-      "verification": ["Send email notification smoke in staging"],
+      "environments": [
+        "dev",
+        "staging",
+        "prod"
+      ],
+      "runtimeSinks": [
+        "Vercel",
+        "local-env"
+      ],
+      "verification": [
+        "Send email notification smoke in staging"
+      ],
       "rollback": "Restore previous app password only if still valid and no compromise is suspected.",
-      "approvalRequired": ["prod"]
+      "approvalRequired": [
+        "prod"
+      ],
+      "baseline": {
+        "dev": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        },
+        "staging": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        },
+        "prod": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
+          "updatedAt": "2026-05-01"
+        }
+      }
     }
   ]
 }

--- a/docs/credential-inventory.json
+++ b/docs/credential-inventory.json
@@ -26,6 +26,7 @@
   "providers": {
     "infisical": {
       "projectSlug": "portfolio",
+      "projectId": "b2634763-ea1d-448c-bf80-fccf6bb8e4a7",
       "secretPath": "/portfolio",
       "envMap": {
         "dev": "dev",

--- a/docs/credential-management-system.md
+++ b/docs/credential-management-system.md
@@ -29,9 +29,12 @@ npm run credentials:inject -- --env staging -- npm run n8n:drift-check -- --warn
 npm run credentials:rotate -- --secret n8n-ingest-secret --env staging
 npm run credentials:sync-runtime -- --secret n8n-ingest-secret --env staging
 npm run credentials:smoke -- --env staging
+npm run credentials:smoke -- --env staging --require-provider-access
 ```
 
 The broker never prints raw secret values. Rotation packets are written to `.credential-rotation-audits/`, which is ignored by git.
+
+Use plain `credentials:smoke` for local registry checks. Use `--require-provider-access` after `op` and `infisical` are installed/authenticated; that mode fails unless the broker can read one scoped test secret from each source of truth without printing its value.
 
 ## Rotation Rules
 
@@ -45,6 +48,7 @@ The broker never prints raw secret values. Rotation packets are written to `.cre
 ## Source And Sink Rules
 
 - The inventory owns canonical secret names, owners, source of truth, runtime sinks, cadence, verification, and rollback notes.
+- Each inventory entry has per-environment `baseline` metadata. `pending-provider-confirmation` means the secret is tracked but the last rotation date has not been verified from Infisical, 1Password, a provider dashboard/API, or an approved rotation packet.
 - `.env.local` and `.env.staging` are local runtime sinks only. Do not treat them as primary records.
 - n8n Variables/Credentials are runtime consumers. Prefer external secrets if the active n8n plan supports it; otherwise keep n8n values synced from Infisical/1Password.
 - Vercel env vars are deployment runtime consumers. Changing Vercel values only affects new deployments.
@@ -65,8 +69,10 @@ The broker never prints raw secret values. Rotation packets are written to `.cre
 - Create an Infisical `portfolio` project with `dev`, `staging`, and `prod` environments.
 - Create machine identities per environment, not one broad cross-client identity.
 - Populate Infisical secrets using the env var names in `docs/credential-inventory.json`.
+- Replace each `pending-provider-confirmation` baseline with a verified `lastRotatedAt` date and evidence note.
 - Configure runtime sinks from the source of truth: Vercel env vars, n8n Variables/Credentials, and local ignored env files.
 - Run `npm run credentials:smoke -- --env staging` after the first sync.
+- Run `npm run credentials:smoke -- --env staging --require-provider-access` before calling the system operational.
 
 ## Existing Portfolio References
 

--- a/scripts/credential-broker.ts
+++ b/scripts/credential-broker.ts
@@ -43,7 +43,15 @@ type CredentialSecret = {
   verification: string[]
   rollback: string
   approvalRequired?: EnvironmentName[]
+  baseline?: Partial<Record<EnvironmentName, CredentialBaseline>>
   lastRotatedAt?: Partial<Record<EnvironmentName, string>>
+}
+
+type CredentialBaseline = {
+  status: 'pending-provider-confirmation' | 'confirmed' | 'unknown'
+  lastRotatedAt: string | null
+  evidence: string
+  updatedAt: string
 }
 
 type RotationPacket = {
@@ -155,7 +163,8 @@ function listDue(inventory: CredentialInventory, args: ParsedArgs) {
   if (Number.isNaN(asOf.getTime())) fail(`Invalid --as-of value: ${String(args.options['as-of'])}`)
 
   const rows = envSecrets(inventory, env).map((secret) => {
-    const lastRotatedAt = secret.lastRotatedAt?.[env] ?? null
+    const baseline = getBaseline(secret, env)
+    const lastRotatedAt = baseline.lastRotatedAt
     const dueAt = lastRotatedAt ? addDays(new Date(lastRotatedAt), secret.rotationCadenceDays) : null
     const status = !lastRotatedAt ? 'needs-baseline' : dueAt && dueAt <= asOf ? 'due' : 'ok'
     return {
@@ -167,6 +176,8 @@ function listDue(inventory: CredentialInventory, args: ParsedArgs) {
       lastRotatedAt,
       dueAt: dueAt ? dueAt.toISOString().slice(0, 10) : null,
       status,
+      baselineStatus: baseline.status,
+      baselineEvidence: baseline.evidence,
       approvalRequired: secret.approvalRequired?.includes(env) ?? false,
     }
   })
@@ -180,7 +191,7 @@ function listDue(inventory: CredentialInventory, args: ParsedArgs) {
   for (const row of rows) {
     const approval = row.approvalRequired ? ' approval-required' : ''
     const due = row.dueAt ? ` due=${row.dueAt}` : ' due=unknown'
-    console.log(`${row.status.padEnd(14)} ${row.envVar.padEnd(32)} ${row.rotationMode}${due}${approval}`)
+    console.log(`${row.status.padEnd(14)} ${row.envVar.padEnd(32)} ${row.rotationMode}${due} baseline=${row.baselineStatus}${approval}`)
   }
 }
 
@@ -265,11 +276,12 @@ function syncRuntime(inventory: CredentialInventory, args: ParsedArgs) {
 
 function smoke(inventory: CredentialInventory, args: ParsedArgs) {
   const env = getEnv(args)
+  const requireProviderAccess = Boolean(args.options['require-provider-access'])
   const checks: Array<{ label: string; command: string[]; required: boolean }> = [
     { label: 'Inventory loads', command: ['node', '-e', `JSON.parse(require('fs').readFileSync(${JSON.stringify(INVENTORY_PATH)}, 'utf8'));`], required: true },
     { label: 'n8n export secret scan', command: ['bash', 'scripts/check-n8n-secrets.sh'], required: true },
-    { label: 'Infisical CLI available', command: ['infisical', '--version'], required: false },
-    { label: '1Password CLI available', command: ['op', '--version'], required: false },
+    { label: 'Infisical CLI available', command: ['infisical', '--version'], required: requireProviderAccess },
+    { label: '1Password CLI available', command: ['op', '--version'], required: requireProviderAccess },
   ]
 
   if (process.env.N8N_API_KEY) {
@@ -277,14 +289,57 @@ function smoke(inventory: CredentialInventory, args: ParsedArgs) {
   }
 
   const results = checks.map((check) => runCheck(check))
-  const dueCount = envSecrets(inventory, env).filter((secret) => !secret.lastRotatedAt?.[env]).length
+  const providerResults = runProviderAccessChecks(inventory, env, requireProviderAccess)
+  const dueCount = envSecrets(inventory, env).filter((secret) => !getBaseline(secret, env).lastRotatedAt).length
   console.log(`Credential inventory secrets for ${env}: ${envSecrets(inventory, env).length}`)
   console.log(`Secrets missing rotation baseline for ${env}: ${dueCount}`)
 
   const failedRequired = results.filter((result) => result.required && !result.ok)
-  if (failedRequired.length > 0) {
+  const failedProviderRequired = providerResults.filter((result) => result.required && !result.ok)
+  if (failedRequired.length > 0 || failedProviderRequired.length > 0) {
     process.exit(1)
   }
+}
+
+function getBaseline(secret: CredentialSecret, env: EnvironmentName): CredentialBaseline {
+  const explicit = secret.baseline?.[env]
+  if (explicit) return explicit
+  return {
+    status: secret.lastRotatedAt?.[env] ? 'confirmed' : 'unknown',
+    lastRotatedAt: secret.lastRotatedAt?.[env] ?? null,
+    evidence: secret.lastRotatedAt?.[env] ? 'legacy lastRotatedAt field' : 'baseline not recorded',
+    updatedAt: 'unknown',
+  }
+}
+
+function runProviderAccessChecks(inventory: CredentialInventory, env: EnvironmentName, required: boolean) {
+  const checks: Array<{ provider: SourceOfTruth; label: string; secret: CredentialSecret | undefined; required: boolean }> = [
+    {
+      provider: 'infisical',
+      label: 'Infisical scoped secret read',
+      secret: envSecrets(inventory, env).find((secret) => secret.sourceOfTruth === 'infisical'),
+      required,
+    },
+    {
+      provider: '1password',
+      label: '1Password scoped item read',
+      secret: envSecrets(inventory, env).find((secret) => secret.sourceOfTruth === '1password'),
+      required,
+    },
+  ]
+
+  return checks.map((check) => {
+    if (!check.secret) {
+      console.log(`skipped ${check.label} no ${check.provider} secret in inventory for ${env}`)
+      return { ...check, ok: !check.required }
+    }
+
+    const result = tryReadSecret(inventory, check.secret, env)
+    const marker = result.ok ? 'ok' : check.required ? 'failed' : 'skipped'
+    console.log(`${marker.padEnd(7)} ${check.label} (${check.secret.envVar})`)
+    if (result.ok === false && check.required) console.error(result.message)
+    return { ...check, ok: result.ok }
+  })
 }
 
 function selectSecrets(inventory: CredentialInventory, args: ParsedArgs, env: EnvironmentName): CredentialSecret[] {
@@ -297,6 +352,16 @@ function selectSecrets(inventory: CredentialInventory, args: ParsedArgs, env: En
 }
 
 function readSecret(inventory: CredentialInventory, secret: CredentialSecret, env: EnvironmentName): string {
+  const result = tryReadSecret(inventory, secret, env)
+  if (result.ok === false) fail(result.message)
+  return result.value
+}
+
+function tryReadSecret(
+  inventory: CredentialInventory,
+  secret: CredentialSecret,
+  env: EnvironmentName,
+): { ok: true; value: string } | { ok: false; message: string } {
   if (secret.sourceOfTruth === 'infisical') {
     const infisicalEnv = inventory.providers.infisical.envMap[env]
     const secretPath = inventory.providers.infisical.secretPath
@@ -307,9 +372,14 @@ function readSecret(inventory: CredentialInventory, secret: CredentialSecret, en
       env: process.env,
     })
     if (result.status !== 0) {
-      fail(`Infisical read failed for ${secret.envVar}. Authenticate the Infisical CLI and confirm ${infisicalEnv}${secretPath} access.`)
+      return {
+        ok: false,
+        message: `Infisical read failed for ${secret.envVar}. Authenticate the Infisical CLI and confirm ${infisicalEnv}${secretPath} access.`,
+      }
     }
-    return result.stdout.trim()
+    const value = result.stdout.trim()
+    if (!value) return { ok: false, message: `Infisical returned an empty value for ${secret.envVar}.` }
+    return { ok: true, value }
   }
 
   const vault = inventory.providers.onepassword.vaults[env]
@@ -321,9 +391,11 @@ function readSecret(inventory: CredentialInventory, secret: CredentialSecret, en
     env: process.env,
   })
   if (result.status !== 0) {
-    fail(`1Password read failed for ${secret.envVar}. Expected item ref ${ref}.`)
+    return { ok: false, message: `1Password read failed for ${secret.envVar}. Expected item ref ${ref}.` }
   }
-  return result.stdout.trim()
+  const value = result.stdout.trim()
+  if (!value) return { ok: false, message: `1Password returned an empty value for ${secret.envVar}.` }
+  return { ok: true, value }
 }
 
 function writeLocalEnv(filePath: string, envVar: string, value: string) {
@@ -430,6 +502,7 @@ Commands:
   rotate        --env <dev|staging|prod> --secret <id-or-envVar> [--local-env .env.staging] [--length 48]
   sync-runtime  --env <dev|staging|prod> --secret <id-or-envVar> [--local-env .env.staging]
   smoke         --env <dev|staging|prod>
+  smoke         --env <dev|staging|prod> --require-provider-access
 
 The broker never prints secret values. Rotation packets are written to .credential-rotation-audits/.`)
 }

--- a/scripts/credential-broker.ts
+++ b/scripts/credential-broker.ts
@@ -19,6 +19,7 @@ type CredentialInventory = {
   providers: {
     infisical: {
       projectSlug: string
+      projectId?: string
       secretPath: string
       envMap: Record<EnvironmentName, string>
     }
@@ -82,6 +83,7 @@ const ROOT = path.resolve(__dirname, '..')
 const INVENTORY_PATH = path.join(ROOT, 'docs', 'credential-inventory.json')
 const AUDIT_DIR = path.join(ROOT, '.credential-rotation-audits')
 const VALID_ENVS: EnvironmentName[] = ['dev', 'staging', 'prod']
+const PROVIDER_READ_TIMEOUT_MS = 10_000
 
 function main() {
   const args = parseArgs(process.argv.slice(2))
@@ -365,11 +367,14 @@ function tryReadSecret(
   if (secret.sourceOfTruth === 'infisical') {
     const infisicalEnv = inventory.providers.infisical.envMap[env]
     const secretPath = inventory.providers.infisical.secretPath
-    const result = spawnSync('infisical', ['secrets', 'get', secret.envVar, '--env', infisicalEnv, '--path', secretPath, '--plain'], {
+    const args = ['secrets', 'get', secret.envVar, '--env', infisicalEnv, '--path', secretPath, '--plain']
+    if (inventory.providers.infisical.projectId) args.push('--projectId', inventory.providers.infisical.projectId)
+    const result = spawnSync('infisical', args, {
       cwd: ROOT,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
       env: process.env,
+      timeout: PROVIDER_READ_TIMEOUT_MS,
     })
     if (result.status !== 0) {
       return {
@@ -383,17 +388,24 @@ function tryReadSecret(
   }
 
   const vault = inventory.providers.onepassword.vaults[env]
-  const ref = `op://${vault}/${secret.envVar}/credential`
-  const result = spawnSync('op', ['read', ref], {
+  const result = spawnSync('op', ['item', 'get', secret.envVar, '--vault', vault, '--format', 'json'], {
     cwd: ROOT,
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
     env: process.env,
+    timeout: PROVIDER_READ_TIMEOUT_MS,
   })
   if (result.status !== 0) {
-    return { ok: false, message: `1Password read failed for ${secret.envVar}. Expected item ref ${ref}.` }
+    return { ok: false, message: `1Password read failed for ${secret.envVar}. Expected item ${secret.envVar} in vault ${vault}.` }
   }
-  const value = result.stdout.trim()
+  let item: { fields?: Array<{ id?: string; label?: string; value?: string }> }
+  try {
+    item = JSON.parse(result.stdout) as { fields?: Array<{ id?: string; label?: string; value?: string }> }
+  } catch {
+    return { ok: false, message: `1Password returned invalid JSON for ${secret.envVar}.` }
+  }
+  const field = item.fields?.find((candidate) => candidate.label === 'credential' || candidate.id === 'credential')
+  const value = field?.value?.trim() ?? ''
   if (!value) return { ok: false, message: `1Password returned an empty value for ${secret.envVar}.` }
   return { ok: true, value }
 }


### PR DESCRIPTION
## Summary
- add explicit credential baseline metadata so pending rotation evidence is not inferred from local env files
- extend credential smoke checks to verify provider CLI availability and scoped Infisical access
- document provider-backed smoke behavior in the credential management system

## Validation
- npm --silent run credentials:list-due -- --env staging --json
- npm --silent run credentials:smoke -- --env staging
- npx tsc --noEmit --pretty false

Note: the 1Password scoped LINKEDIN_COOKIE item read is currently reported as skipped, while 1Password CLI availability passes.