### PR TITLE
docs: refresh subscription cancellation audit

### DIFF
--- a/docs/builtwith-deprecation-packet.md
+++ b/docs/builtwith-deprecation-packet.md
@@ -1,21 +1,26 @@
-# BuiltWith Deprecation Packet
+# BuiltWith Watch And Deprecation Packet
 
 Date: 2026-05-01
 
-Status: cancellation-review candidate. This packet is not approval to cancel
-BuiltWith or remove production functionality. Cancellation still requires the
-explicit phrase `Cancel BuiltWith for Portfolio`.
+Status: watch item. BuiltWith should remain active while Portfolio increases
+outreach and client traffic. This packet is a dependency map and future
+deprecation plan only; it is not approval to cancel BuiltWith or remove
+production functionality. Cancellation still requires the explicit phrase
+`Cancel BuiltWith for Portfolio`.
 
 ## Recommendation
 
-Prepare BuiltWith for a controlled deprecation unless dashboard/API usage shows
-recent operational value that was not visible from the current evidence pass.
+Keep BuiltWith as a watched integration until more prospects and clients move
+through the outreach, audit, implementation-strategy, and proposal workflows.
+The current traffic level is not enough to decide whether BuiltWith improves
+sales preparation, implementation strategy quality, or conversion.
 
-The likely replacement path is not another paid API by default. First preserve
-the existing admin-verified tech stack workflow, stop depending on automatic
-public-audit enrichment, and use manual or browser-assisted research for client
-stack confirmation. If automated enrichment is still useful, run a small
-provider bakeoff before promoting a replacement.
+If later evidence shows low usage, low conversion value, or avoidable spend, use
+this packet to plan a controlled deprecation. The likely replacement path is not
+another paid API by default. First preserve the existing admin-verified tech
+stack workflow, reduce automatic enrichment where appropriate, and use manual or
+browser-assisted research for client stack confirmation. If automated enrichment
+is still useful, run a small provider bakeoff before promoting a replacement.
 
 ## Evidence
 
@@ -24,10 +29,11 @@ provider bakeoff before promoting a replacement.
 - The BuiltWith dashboard/account check was attempted through Computer Use, but
   the site presented an image CAPTCHA before dashboard access. No account,
   cancellation, billing, or settings action was taken.
-- Repo evidence confirms BuiltWith has live integration surfaces, but no current
-  dashboard/API usage history was confirmed in this pass.
-- BuiltWith should remain a review candidate until dashboard/API usage is
-  checked or Vambah approves cancellation based on the available evidence.
+- Repo evidence confirms BuiltWith has live integration surfaces that support
+  sales preparation and implementation feasibility.
+- BuiltWith should remain on the watchlist until enough outreach/client volume
+  exists to evaluate whether its stack enrichment materially helps the
+  implementation strategy and sales flow.
 
 ## Portfolio Dependency Map
 
@@ -76,8 +82,8 @@ Docs:
 
 - `docs/admin-sales-lead-pipeline-sop.md` documents the lead-pipeline BuiltWith
   lookup, admin-verified stack reconciliation, and `BUILTWITH_API_KEY`.
-- `docs/subscription-cancellation-audit.md` tracks BuiltWith as the strongest
-  cancellation-review candidate after the 2026-05-01 billing evidence pass.
+- `docs/subscription-cancellation-audit.md` tracks BuiltWith as a watched
+  integration after the 2026-05-01 billing evidence pass.
 
 ## Blast Radius If Removed Incorrectly
 
@@ -92,12 +98,14 @@ Docs:
 
 ## Replacement Options
 
-Option A: keep BuiltWith with a stricter usage policy.
+Option A: keep BuiltWith and measure value during outreach.
 
 - Keep the current integration, but restrict use to qualified sales leads or
   paid-client preparation.
+- Track whether BuiltWith-informed implementation strategies improve sales
+  preparation, proposal quality, or conversion.
 - Add a feature flag or explicit admin-only gate before any automatic lookup.
-- Best if dashboard usage shows it is helping active sales work.
+- Best while client traffic is still ramping.
 
 Option B: deprecate automatic lookup and use manual/admin verification.
 
@@ -126,8 +134,8 @@ Option D: cache-only fallback.
 
 ## Approval-Gated Implementation Plan
 
-Only run this plan after Vambah gives the approval phrase
-`Cancel BuiltWith for Portfolio`.
+Only run this plan after there is enough sales/client evidence to justify
+removal and Vambah gives the approval phrase `Cancel BuiltWith for Portfolio`.
 
 1. Add a provider gate, for example `TECH_STACK_LOOKUP_PROVIDER=disabled` or
    `BUILTWITH_LOOKUP_ENABLED=false`, defaulting to disabled for automatic public

--- a/docs/builtwith-deprecation-packet.md
+++ b/docs/builtwith-deprecation-packet.md
@@ -1,0 +1,173 @@
+# BuiltWith Deprecation Packet
+
+Date: 2026-05-01
+
+Status: cancellation-review candidate. This packet is not approval to cancel
+BuiltWith or remove production functionality. Cancellation still requires the
+explicit phrase `Cancel BuiltWith for Portfolio`.
+
+## Recommendation
+
+Prepare BuiltWith for a controlled deprecation unless dashboard/API usage shows
+recent operational value that was not visible from the current evidence pass.
+
+The likely replacement path is not another paid API by default. First preserve
+the existing admin-verified tech stack workflow, stop depending on automatic
+public-audit enrichment, and use manual or browser-assisted research for client
+stack confirmation. If automated enrichment is still useful, run a small
+provider bakeoff before promoting a replacement.
+
+## Evidence
+
+- Gmail billing evidence found BuiltWith receipts on 2026-04-10 for $99.00,
+  $99.00, and $109.00.
+- The BuiltWith dashboard/account check was attempted through Computer Use, but
+  the site presented an image CAPTCHA before dashboard access. No account,
+  cancellation, billing, or settings action was taken.
+- Repo evidence confirms BuiltWith has live integration surfaces, but no current
+  dashboard/API usage history was confirmed in this pass.
+- BuiltWith should remain a review candidate until dashboard/API usage is
+  checked or Vambah approves cancellation based on the available evidence.
+
+## Portfolio Dependency Map
+
+Environment and core library:
+
+- `.env.example` declares `BUILTWITH_API_KEY`.
+- `lib/tech-stack-lookup.ts` normalizes BuiltWith Domain API v22 payloads,
+  extracts a lookup domain, calls `https://api.builtwith.com/v22/api.json`, and
+  returns technologies plus optional `creditsRemaining`.
+- `lib/constants/builtwith-tag-map.ts` maps BuiltWith tags into Portfolio's
+  canonical stack categories for feasibility scoring.
+
+Runtime/API surfaces:
+
+- `app/api/admin/tech-stack-lookup/route.ts` exposes the admin-only lookup
+  endpoint: `GET /api/admin/tech-stack-lookup?domain=example.com`.
+- `app/api/tools/audit/start/route.ts` runs a non-blocking BuiltWith enrichment
+  when a public standalone audit starts with a website URL, then stores
+  `diagnostic_audits.enriched_tech_stack`.
+- `app/api/tools/audit/context/route.ts` runs the same non-blocking enrichment
+  when audit context is updated with a website URL and no existing enrichment.
+- `app/api/admin/outreach/leads/[id]/route.ts` saves
+  `contact_submissions.website_tech_stack`, captures
+  `website_tech_stack_fetched_at`, and propagates the stack to linked
+  diagnostic audits.
+- `app/api/admin/contact-submissions/[id]/verified-tech-stack/route.ts` returns
+  BuiltWith, audit, and admin-verified stacks, then lets admins save
+  `contact_submissions.client_verified_tech_stack` as the source of truth.
+
+Admin and scoring surfaces:
+
+- `app/admin/outreach/page.tsx` shows the lead pipeline "Fetch tech stack"
+  action, calls the admin lookup API, stores the result on the lead, and shows
+  remaining credits when present.
+- `app/admin/sales/[auditId]/page.tsx` displays "Website technologies
+  (BuiltWith)" and the admin conflict-reconciliation UI.
+- `lib/implementation-feasibility.ts` merges client stack sources with
+  precedence `verified > audit > builtwith`, computes conflicts, and records
+  BuiltWith credit state.
+- `lib/implementation-feasibility.test.ts` verifies BuiltWith merge/conflict and
+  credit-state behavior.
+- `lib/tech-stack-lookup.test.ts` verifies BuiltWith payload normalization and
+  domain lookup behavior.
+
+Docs:
+
+- `docs/admin-sales-lead-pipeline-sop.md` documents the lead-pipeline BuiltWith
+  lookup, admin-verified stack reconciliation, and `BUILTWITH_API_KEY`.
+- `docs/subscription-cancellation-audit.md` tracks BuiltWith as the strongest
+  cancellation-review candidate after the 2026-05-01 billing evidence pass.
+
+## Blast Radius If Removed Incorrectly
+
+- Public audit submissions could silently lose `enriched_tech_stack`.
+- Sales/admin users could lose the one-click "Fetch tech stack" lead workflow.
+- Implementation strategy decks and proposals could have less automatic
+  feasibility context unless admin-verified or audit-provided stack data exists.
+- Existing database rows with `website_tech_stack` and `enriched_tech_stack`
+  should keep rendering; the deprecation should avoid deleting historical data.
+- Tests and SOP language currently assume a BuiltWith source and credit-state
+  model.
+
+## Replacement Options
+
+Option A: keep BuiltWith with a stricter usage policy.
+
+- Keep the current integration, but restrict use to qualified sales leads or
+  paid-client preparation.
+- Add a feature flag or explicit admin-only gate before any automatic lookup.
+- Best if dashboard usage shows it is helping active sales work.
+
+Option B: deprecate automatic lookup and use manual/admin verification.
+
+- Stop public audit `start` and `context` routes from calling BuiltWith.
+- Keep `client_verified_tech_stack` as the canonical source.
+- Let admins research a stack manually or with browser-assisted review, then
+  save it through the existing verified-stack UI.
+- Lowest-cost path and the recommended first deprecation step.
+
+Option C: replace with another enrichment provider after a bakeoff.
+
+- Compare BuiltWith against Apify actors, browser-assisted research, and any
+  lower-cost enrichment API using shared domains and evidence capture.
+- Score accuracy, coverage, latency, cost, rate limits, data provenance, and
+  operational fit.
+- Only promote a replacement behind an adapter or provider interface.
+
+Option D: cache-only fallback.
+
+- Preserve historical `website_tech_stack`, `enriched_tech_stack`, and
+  `client_verified_tech_stack` data.
+- Return a clear "provider unavailable" response from the admin lookup route
+  when no provider is configured.
+- Feasibility assessments continue from verified/audit data and existing cached
+  rows.
+
+## Approval-Gated Implementation Plan
+
+Only run this plan after Vambah gives the approval phrase
+`Cancel BuiltWith for Portfolio`.
+
+1. Add a provider gate, for example `TECH_STACK_LOOKUP_PROVIDER=disabled` or
+   `BUILTWITH_LOOKUP_ENABLED=false`, defaulting to disabled for automatic public
+   audit enrichment.
+2. Remove or gate fire-and-forget BuiltWith calls in
+   `app/api/tools/audit/start/route.ts` and
+   `app/api/tools/audit/context/route.ts`.
+3. Keep the admin-verified tech stack route and UI so sales can preserve
+   canonical client stack data without BuiltWith.
+4. Update `app/api/admin/tech-stack-lookup/route.ts` to return a clear
+   provider-disabled response unless a configured provider is intentionally
+   enabled.
+5. Update `lib/implementation-feasibility.ts` labels and tests only if the
+   source name changes from `builtwith` to a generic `enrichment` source.
+6. Update `.env.example`, `docs/admin-sales-lead-pipeline-sop.md`, and the
+   subscription tracker to reflect the new default.
+7. Cancel the BuiltWith account only after the code path is deployed or after
+   Vambah confirms the downtime is acceptable.
+
+## Validation
+
+Run focused validation after any implementation:
+
+```bash
+npm test -- --run lib/tech-stack-lookup.test.ts lib/implementation-feasibility.test.ts
+git diff --check
+```
+
+If route behavior changes, add route-level tests or manually verify:
+
+- `GET /api/admin/tech-stack-lookup?domain=example.com`
+- public audit start/context flows with and without a website URL
+- admin sales page verified-stack save flow
+
+## Rollback
+
+- Re-enable the provider flag or restore `BUILTWITH_API_KEY` if the integration
+  is still present.
+- Revert the implementation commit if the deprecation removes required sales
+  context.
+- Historical database fields should not need rollback because the recommended
+  path preserves existing `website_tech_stack`, `enriched_tech_stack`, and
+  `client_verified_tech_stack` values.

--- a/docs/subscription-cancellation-audit.md
+++ b/docs/subscription-cancellation-audit.md
@@ -21,9 +21,10 @@ Summary:
   or payment-confirmation emails were found for Gamma, n8n, Read.ai, Supabase,
   BuiltWith, Apify, HeyGen, ElevenLabs, Calendly, Anthropic, OpenAI/ChatGPT Pro,
   and Google Cloud.
-- BuiltWith is now the strongest cost-review candidate: recent receipts were
-  found, but no meaningful operational usage signal was confirmed in the repo,
-  database, n8n, or connector evidence gathered so far.
+- BuiltWith stays on the watchlist: recent receipts were found and operational
+  usage was not confirmed in this pass, but current client traffic is still too
+  low to judge whether the implementation-strategy workflow benefits from
+  BuiltWith enrichment.
 - Fireflies looks less like an active cancellation target and more like a
   cancellation-confirmation task: Gmail shows a refund on 2026-03-20 and a
   weekly digest on 2026-03-23. Verify whether the paid plan is already canceled
@@ -77,7 +78,7 @@ Derived Movement Since Manual Refresh
 
 | Tool/vendor | Billing evidence | Usage evidence | Movement | Recommendation |
 | --- | --- | --- | --- | --- |
-| BuiltWith | Three receipts on 2026-04-10 | No confirmed operational usage | Moves from watchlist to cost-review candidate | Prepare replacement/deprecation review before renewal; likely cancellation candidate if dashboard confirms no recent API usage |
+| BuiltWith | Three receipts on 2026-04-10 | No confirmed operational usage in this pass, but client traffic is still early | Remains a watch item | Keep for now; reassess after more outreach/client volume and implementation-strategy usage evidence |
 | Fireflies.ai | Refund on 2026-03-20 | Digest on 2026-03-23; prior duplicate recap evidence | Moves from redundancy watch to cancellation-confirmation check | Verify paid plan status; if already canceled, remove from cancellation queue and document as resolved |
 | Gamma | Receipts on 2026-05-01 and 2026-04-01 | Active report/deck code and DB rows | Stronger keep signal | Keep |
 | n8n Cloud | Receipt on 2026-04-22 | Active executions on 2026-05-01 | Stronger keep signal | Keep |
@@ -93,13 +94,14 @@ Derived Movement Since Manual Refresh
 | Resend | No billing receipt found | Optional provider with Gmail fallback | Still unresolved | Verify production env before keeping as paid dependency |
 | Pinecone | No billing receipt found | n8n RAG references active | Still unresolved | Check billing/API usage and compare with Supabase/local RAG replacement path |
 
-Candidate Cancellations
+Watch Items And Candidate Cancellations
 
-- **BuiltWith: candidate for cancellation review, not cancellation yet.** It has
-  recent paid receipts and repeated quiet operational evidence. Before approval,
-  verify dashboard/API usage, identify any live lead-enrichment flows still
-  calling it, and confirm whether browser/manual research or another enrichment
-  source can replace it. Deprecation packet:
+- **BuiltWith: watch item, not a cancellation candidate right now.** It has
+  recent paid receipts and the current pass did not confirm operational usage,
+  but Portfolio has not yet had enough client traffic to evaluate whether
+  BuiltWith improves implementation strategy, sales preparation, or conversion.
+  Keep it active through the next outreach/client cycle, then reassess with
+  dashboard/API usage and sales-flow evidence. Dependency packet:
   [builtwith-deprecation-packet.md](./builtwith-deprecation-packet.md).
 - **Fireflies: candidate for resolved/canceled status verification.** The refund
   suggests the paid plan may already be canceled. Do not request cancellation
@@ -112,9 +114,11 @@ Next Audit Focus
   before dashboard access, so usage confirmation needs Vambah handoff or
   explicit approval at that gate. Stop at any fresh login, payment-owner, or
   account-setting gate and record the needed manual step.
-- For BuiltWith, collect API/dashboard usage history and use
-  [builtwith-deprecation-packet.md](./builtwith-deprecation-packet.md) as the
-  approval-gated code-path and replacement plan if cancellation is approved.
+- For BuiltWith, keep it active while outreach ramps. Collect API/dashboard
+  usage history and compare implementation-strategy/proposal outcomes for leads
+  where stack enrichment helped versus leads where it did not. Use
+  [builtwith-deprecation-packet.md](./builtwith-deprecation-packet.md) only if a
+  later cancellation decision is approved.
 - For Fireflies, confirm whether the subscription is already canceled after the
   2026-03-20 refund.
 - For Vercel, locate the actual hosting account/project outside the current

--- a/docs/subscription-cancellation-audit.md
+++ b/docs/subscription-cancellation-audit.md
@@ -10,6 +10,114 @@ no meaningful usage signal, or after clear redundancy plus a lower-risk
 replacement path. Production changes require explicit approval in the form
 `Cancel <tool/vendor> for Portfolio`.
 
+## 2026-05-01 Billing Evidence Pass
+
+Status: YELLOW
+
+Summary:
+
+- No cancellation approvals requested and no cancellation action taken.
+- Gmail billing evidence materially improved the subscription map. Recent paid
+  or payment-confirmation emails were found for Gamma, n8n, Read.ai, Supabase,
+  BuiltWith, Apify, HeyGen, ElevenLabs, Calendly, Anthropic, OpenAI/ChatGPT Pro,
+  and Google Cloud.
+- BuiltWith is now the strongest cost-review candidate: recent receipts were
+  found, but no meaningful operational usage signal was confirmed in the repo,
+  database, n8n, or connector evidence gathered so far.
+- Fireflies looks less like an active cancellation target and more like a
+  cancellation-confirmation task: Gmail shows a refund on 2026-03-20 and a
+  weekly digest on 2026-03-23. Verify whether the paid plan is already canceled
+  before taking any further action.
+- Printful, Vapi, Resend, and Pinecone remain unresolved because they have
+  code/config references but no recent billing receipt evidence in Gmail.
+- Vercel remains unresolved: Gmail had only a Terms update, the connector did
+  not expose a team/project, and the repo has no `.vercel/project.json`.
+
+Raw Findings
+
+- Git state: branch `codex/subscription-cancellation-refresh`; unrelated
+  `.gitignore` modification present and left untouched.
+- Computer Use: Chrome was inspected. It was open to an Infisical success page.
+  A BuiltWith dashboard/login check was attempted, but BuiltWith presented an
+  image CAPTCHA before account access. The CAPTCHA was not solved and no
+  dashboard cancellation or account-setting actions were attempted.
+- Gmail search, 180-day billing window:
+  - Gamma receipt on 2026-05-01 and prior receipt on 2026-04-01.
+  - n8n receipt on 2026-04-22 for Cloud Pro-1, amount shown in snippet as
+    $63.75.
+  - Read AI receipt on 2026-04-20.
+  - Supabase payment received on 2026-04-09, amount shown in snippet as $25.27.
+  - BuiltWith receipts on 2026-04-10 for $99.00, $99.00, and $109.00.
+  - Apify invoices/payment-success emails on 2026-04-03, 2026-03-03,
+    2026-02-03, 2026-01-03, 2025-12-03, and 2025-11-03; latest amount shown in
+    snippet as $39.00.
+  - HeyGen receipts on 2026-04-14, 2026-03-14, and 2026-03-12.
+  - ElevenLabs receipts on 2026-04-19 and 2026-03-19.
+  - Calendly receipt on 2026-04-04.
+  - Google Cloud payment received on 2026-05-01, amount shown in snippet as
+    $9.33.
+  - Anthropic receipts on 2026-04-11, 2026-03-21, 2026-03-11, 2026-02-12, and
+    2025-12-16, plus a 2026-03-18 API credit access warning.
+  - OpenAI email on 2026-04-29 confirms ChatGPT Pro subscription; 2026-02-12
+    email confirms API usage tier increase.
+  - Fireflies refund on 2026-03-20 and weekly digest on 2026-03-23.
+  - No recent billing receipts found for Vercel, Printful, Vapi, Resend, or
+    Pinecone with the searched Gmail queries.
+- Local evidence retained from prior pass:
+  - BuiltWith has code/env references but no operational rows or connector usage
+    signal found.
+  - Vapi has voice code/env references but no fresh usage signal found.
+  - Printful has store/fulfillment code paths and product variants, but
+    `printful_sync_log` was empty in Supabase.
+  - Resend exists as an optional transactional email provider with Gmail SMTP
+    fallback.
+  - Pinecone remains active indirectly through n8n RAG workflow references.
+
+Derived Movement Since Manual Refresh
+
+| Tool/vendor | Billing evidence | Usage evidence | Movement | Recommendation |
+| --- | --- | --- | --- | --- |
+| BuiltWith | Three receipts on 2026-04-10 | No confirmed operational usage | Moves from watchlist to cost-review candidate | Prepare replacement/deprecation review before renewal; likely cancellation candidate if dashboard confirms no recent API usage |
+| Fireflies.ai | Refund on 2026-03-20 | Digest on 2026-03-23; prior duplicate recap evidence | Moves from redundancy watch to cancellation-confirmation check | Verify paid plan status; if already canceled, remove from cancellation queue and document as resolved |
+| Gamma | Receipts on 2026-05-01 and 2026-04-01 | Active report/deck code and DB rows | Stronger keep signal | Keep |
+| n8n Cloud | Receipt on 2026-04-22 | Active executions on 2026-05-01 | Stronger keep signal | Keep |
+| Read.ai | Receipt on 2026-04-20 | April meetings available | Stronger keep signal | Keep; fix stale in-app token separately |
+| Supabase | Payment on 2026-04-09 | Active project and table rows | Stronger keep signal | Keep |
+| Apify | Monthly invoices through 2026-04-03 | Actor monitor executions on 2026-05-01 | Stronger keep signal with spend-review need | Keep; review actor spend and scraping cadence |
+| HeyGen | Receipts through 2026-04-14 | Catalog/video code and DB rows | Stronger keep signal | Keep; review after next campaign |
+| ElevenLabs | Receipts through 2026-04-19 | One social-audio workflow reference; no new run confirmed | Paid but quiet-ish | Watch; review before renewal if social audio remains paused |
+| Calendly | Receipt on 2026-04-04 | Active booking links and n8n router references | Stronger keep signal | Keep |
+| Vercel | No billing receipt found; connector unavailable | Production hosting likely but unverified | Still unresolved | Needs dashboard/account check |
+| Printful | No billing receipt found | Fulfillment code exists; sync log quiet | Still unresolved | Check dashboard/store order history |
+| Vapi | No billing receipt found | Voice code exists; no usage signal | Still unresolved | Check dashboard call history and whether production voice UI is enabled |
+| Resend | No billing receipt found | Optional provider with Gmail fallback | Still unresolved | Verify production env before keeping as paid dependency |
+| Pinecone | No billing receipt found | n8n RAG references active | Still unresolved | Check billing/API usage and compare with Supabase/local RAG replacement path |
+
+Candidate Cancellations
+
+- **BuiltWith: candidate for cancellation review, not cancellation yet.** It has
+  recent paid receipts and repeated quiet operational evidence. Before approval,
+  verify dashboard/API usage, identify any live lead-enrichment flows still
+  calling it, and confirm whether browser/manual research or another enrichment
+  source can replace it.
+- **Fireflies: candidate for resolved/canceled status verification.** The refund
+  suggests the paid plan may already be canceled. Do not request cancellation
+  unless dashboard status says the paid plan is still active.
+
+Next Audit Focus
+
+- Use Computer Use on billing dashboards for BuiltWith, Fireflies, Vercel,
+  Printful, Vapi, Resend, and Pinecone. BuiltWith currently requires a CAPTCHA
+  before dashboard access, so usage confirmation needs Vambah handoff or
+  explicit approval at that gate. Stop at any fresh login, payment-owner, or
+  account-setting gate and record the needed manual step.
+- For BuiltWith, collect API/dashboard usage history and list exact Portfolio
+  code paths that would be deprecated or replaced if approved.
+- For Fireflies, confirm whether the subscription is already canceled after the
+  2026-03-20 refund.
+- For Vercel, locate the actual hosting account/project outside the current
+  connector context.
+
 ## 2026-05-01 Manual Refresh Run
 
 Status: YELLOW

--- a/docs/subscription-cancellation-audit.md
+++ b/docs/subscription-cancellation-audit.md
@@ -99,7 +99,8 @@ Candidate Cancellations
   recent paid receipts and repeated quiet operational evidence. Before approval,
   verify dashboard/API usage, identify any live lead-enrichment flows still
   calling it, and confirm whether browser/manual research or another enrichment
-  source can replace it.
+  source can replace it. Deprecation packet:
+  [builtwith-deprecation-packet.md](./builtwith-deprecation-packet.md).
 - **Fireflies: candidate for resolved/canceled status verification.** The refund
   suggests the paid plan may already be canceled. Do not request cancellation
   unless dashboard status says the paid plan is still active.
@@ -111,8 +112,9 @@ Next Audit Focus
   before dashboard access, so usage confirmation needs Vambah handoff or
   explicit approval at that gate. Stop at any fresh login, payment-owner, or
   account-setting gate and record the needed manual step.
-- For BuiltWith, collect API/dashboard usage history and list exact Portfolio
-  code paths that would be deprecated or replaced if approved.
+- For BuiltWith, collect API/dashboard usage history and use
+  [builtwith-deprecation-packet.md](./builtwith-deprecation-packet.md) as the
+  approval-gated code-path and replacement plan if cancellation is approved.
 - For Fireflies, confirm whether the subscription is already canceled after the
   2026-03-20 refund.
 - For Vercel, locate the actual hosting account/project outside the current

--- a/docs/subscription-cancellation-audit.md
+++ b/docs/subscription-cancellation-audit.md
@@ -25,10 +25,10 @@ Summary:
   usage was not confirmed in this pass, but current client traffic is still too
   low to judge whether the implementation-strategy workflow benefits from
   BuiltWith enrichment.
-- Fireflies looks less like an active cancellation target and more like a
-  cancellation-confirmation task: Gmail shows a refund on 2026-03-20 and a
-  weekly digest on 2026-03-23. Verify whether the paid plan is already canceled
-  before taking any further action.
+- Fireflies is resolved as canceled per Vambah confirmation on 2026-05-01.
+  Gmail also showed a refund on 2026-03-20 and a weekly digest on 2026-03-23.
+  Keep it out of the active cancellation queue unless new paid-plan evidence
+  appears.
 - Printful, Vapi, Resend, and Pinecone remain unresolved because they have
   code/config references but no recent billing receipt evidence in Gmail.
 - Vercel remains unresolved: Gmail had only a Terms update, the connector did
@@ -79,7 +79,7 @@ Derived Movement Since Manual Refresh
 | Tool/vendor | Billing evidence | Usage evidence | Movement | Recommendation |
 | --- | --- | --- | --- | --- |
 | BuiltWith | Three receipts on 2026-04-10 | No confirmed operational usage in this pass, but client traffic is still early | Remains a watch item | Keep for now; reassess after more outreach/client volume and implementation-strategy usage evidence |
-| Fireflies.ai | Refund on 2026-03-20 | Digest on 2026-03-23; prior duplicate recap evidence | Moves from redundancy watch to cancellation-confirmation check | Verify paid plan status; if already canceled, remove from cancellation queue and document as resolved |
+| Fireflies.ai | Refund on 2026-03-20; Vambah confirmed canceled on 2026-05-01 | Digest on 2026-03-23; prior duplicate recap evidence | Resolved as canceled | Remove from active cancellation queue; only re-open if new paid-plan evidence appears |
 | Gamma | Receipts on 2026-05-01 and 2026-04-01 | Active report/deck code and DB rows | Stronger keep signal | Keep |
 | n8n Cloud | Receipt on 2026-04-22 | Active executions on 2026-05-01 | Stronger keep signal | Keep |
 | Read.ai | Receipt on 2026-04-20 | April meetings available | Stronger keep signal | Keep; fix stale in-app token separately |
@@ -103,24 +103,24 @@ Watch Items And Candidate Cancellations
   Keep it active through the next outreach/client cycle, then reassess with
   dashboard/API usage and sales-flow evidence. Dependency packet:
   [builtwith-deprecation-packet.md](./builtwith-deprecation-packet.md).
-- **Fireflies: candidate for resolved/canceled status verification.** The refund
-  suggests the paid plan may already be canceled. Do not request cancellation
-  unless dashboard status says the paid plan is still active.
+- **Fireflies: resolved as canceled.** Vambah confirmed on 2026-05-01 that
+  Fireflies is already canceled. Do not treat it as an active cancellation
+  target unless new billing evidence shows a paid plan was restarted.
 
 Next Audit Focus
 
-- Use Computer Use on billing dashboards for BuiltWith, Fireflies, Vercel,
-  Printful, Vapi, Resend, and Pinecone. BuiltWith currently requires a CAPTCHA
-  before dashboard access, so usage confirmation needs Vambah handoff or
-  explicit approval at that gate. Stop at any fresh login, payment-owner, or
-  account-setting gate and record the needed manual step.
+- Use Computer Use on billing dashboards for Vercel, Printful, Vapi, Resend,
+  and Pinecone. BuiltWith currently requires a CAPTCHA before dashboard access,
+  so defer dashboard usage confirmation until the outreach/client-volume
+  reassessment. Stop at any fresh login, payment-owner, or account-setting gate
+  and record the needed manual step.
 - For BuiltWith, keep it active while outreach ramps. Collect API/dashboard
   usage history and compare implementation-strategy/proposal outcomes for leads
   where stack enrichment helped versus leads where it did not. Use
   [builtwith-deprecation-packet.md](./builtwith-deprecation-packet.md) only if a
   later cancellation decision is approved.
-- For Fireflies, confirm whether the subscription is already canceled after the
-  2026-03-20 refund.
+- For Fireflies, keep the resolved/canceled status unless new paid-plan evidence
+  appears.
 - For Vercel, locate the actual hosting account/project outside the current
   connector context.
 

--- a/docs/subscription-cancellation-audit.md
+++ b/docs/subscription-cancellation-audit.md
@@ -10,6 +10,90 @@ no meaningful usage signal, or after clear redundancy plus a lower-risk
 replacement path. Production changes require explicit approval in the form
 `Cancel <tool/vendor> for Portfolio`.
 
+## 2026-05-01 Manual Refresh Run
+
+Status: YELLOW
+
+Summary:
+
+- No cancellation approvals requested.
+- No tool has two consecutive inactive audit sessions yet.
+- Supabase, n8n Cloud, Read.ai, Slack, Gamma, HeyGen, Google Drive, and the
+  core LLM paths continue to show meaningful usage or active dependency signals.
+- Fireflies remains the clearest redundancy question because it appears to
+  overlap with Read.ai in meeting recap capture, but it is not ready for
+  cancellation without billing and owner confirmation.
+- Vercel and Stripe remain high-risk unknowns because billing/project access was
+  not available through the current connector context.
+- Printful, Vapi, BuiltWith, USPS, Resend, LinkedIn, and ElevenLabs remain
+  watchlist items, not cancellation candidates.
+
+Raw Findings
+
+- Git state: clean worktree before the refresh. The first local pass started
+  from `codex/source-respecting-llm-protocol`, then this doc-only update was
+  moved onto `codex/subscription-cancellation-refresh` from `main` before
+  commit.
+- Supabase connector: project `My Portfolio` is `ACTIVE_HEALTHY`. Current row
+  signals include `analytics_events` 4939, `pain_point_evidence` 4681,
+  `project_reminders` 857, `meeting_records` 109, `orders` 26,
+  `social_content_queue` 28, `drive_video_queue` 35, `heygen_config` 9084,
+  `gamma_reports` 6, and `cost_events` 13.
+- n8n Cloud connector: 76 workflows listed. Recent executions were successful
+  on 2026-05-01 through at least 18:00 UTC, including milestone planning,
+  Gamma cleanup, and Apify actor monitor workflows.
+- n8n export evidence: exported workflows include 60 Supabase nodes, 40 Slack
+  nodes, 18 OpenAI chat model nodes, 15 Gmail nodes, 9 schedule triggers, 5
+  Apify nodes, 4 Google Drive nodes, 3 Pinecone vector store nodes, 2 Calendly
+  triggers, 1 Stripe trigger, and 1 Anthropic node.
+- Read AI connector: six meetings were available since 2026-04-01, with the
+  latest starting on 2026-04-15. This keeps Read.ai active as an external
+  meeting-capture account even if the Portfolio in-app OAuth token path remains
+  stale.
+- Vercel connector: `list_teams` returned no teams, and the repo still has no
+  `.vercel/project.json`; project/deployment billing status remains unresolved.
+- Local reference counts across app/lib/scripts/docs show broad implementation
+  footprint: Gamma 1038, Read/Read.ai text paths 1701, HeyGen 626, Slack 541,
+  Stripe 466, Printful 398, Calendly 387, OpenAI 292, Anthropic 179, BuiltWith
+  175, USPS 146, Resend 134, Apify 137, Pinecone 117, Vapi 113, ElevenLabs
+  118, Gemini 34, and Fireflies 5.
+
+Derived Movement Since Baseline
+
+| Tool/vendor | Prior status | Refresh signal | Current inactivity status | Recommendation |
+| --- | --- | --- | --- | --- |
+| Supabase | GREEN | Project active and core tables show live Portfolio state | Active | Keep |
+| n8n Cloud | GREEN | Successful executions on 2026-05-01 and 76 workflows present | Active | Keep; later rationalize duplicate/staging workflows |
+| Read.ai | GREEN | April meetings available through connector | Active externally | Keep; separately fix or remove stale in-app token path |
+| Fireflies.ai | YELLOW | Only 5 local references; prior Slack evidence showed duplicate meeting recap behavior | Redundancy watch, not inactive | Investigate whether both meeting assistants are paid |
+| Vercel | YELLOW | Connector did not expose account/project; no `.vercel/project.json` | Unknown, high-risk | Keep; needs browser or account-level billing check |
+| Stripe | YELLOW | Strong repo and database dependency, but no live dashboard access in this run | Unknown, high-risk | Keep until Stripe billing/dashboard usage is checked |
+| Printful | YELLOW | Large code footprint, product variants present, sync log still quiet | First-session quiet continues | Watch; verify dashboard order/sync activity |
+| Vapi | YELLOW | Code/env footprint remains; no fresh usage signal found | First-session quiet continues | Watch; check Vapi dashboard before any recommendation |
+| BuiltWith | YELLOW | Code/env footprint remains; no fresh operational signal found | First-session quiet continues | Watch; evaluate replacement with browser/other enrichment |
+| USPS | YELLOW | Commerce address routes/tests remain; no fresh operational signal found | First-session quiet continues | Watch; keep until checkout/shipping path is reviewed |
+| Resend | YELLOW | Webhook and email code remain; provider-specific production usage unresolved | Unknown | Investigate whether production uses Resend or Gmail fallback |
+| ElevenLabs | YELLOW | n8n social audio reference remains; no new run confirmed | First-session quiet-ish | Watch with next social content campaign |
+
+Candidate Cancellations
+
+None. This refresh strengthens the watchlist, but it does not meet the
+two-session inactivity gate for any paid tool.
+
+Next Audit Focus
+
+- Use Computer Use or browser access for billing dashboards where connectors
+  are insufficient: Vercel, Stripe, Printful, Vapi, BuiltWith, ElevenLabs, and
+  any Fireflies account.
+- Decide whether Fireflies and Read.ai are both intentionally active before the
+  next renewal cycle.
+- Confirm whether Resend is configured in production or whether Gmail/n8n is
+  the real outbound channel.
+- Verify whether Printful has recent fulfillment activity outside the Portfolio
+  `printful_sync_log`.
+- Check whether Vapi is still enabled in production UX or only remains in the
+  template/product surface.
+
 ## 2026-05-01 Baseline Run
 
 Status: YELLOW


### PR DESCRIPTION
## Summary
- add a 2026-05-01 billing evidence pass to the subscription cancellation audit
- classify keep/watch/candidate status across billing, Gmail, connector, repo, and dashboard evidence
- preserve the no-cancellation-without-explicit-approval gate

## Validation
- reviewed doc diff for scope
- scanned audit doc for obvious secret/token patterns; only non-secret token wording was present

No cancellation action was taken.