### PR TITLE
feat: add admin subscription watch

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -61,12 +61,22 @@ type AnalyticsStats = {
   eventsByType?: Record<string, number>
 }
 type ConfigCountsRes = { users?: number; prompts?: number; contentItems?: number }
+type SubscriptionStatusRes = {
+  buckets?: {
+    keep?: string[]
+    watch?: string[]
+    unresolved?: string[]
+    resolvedCanceled?: string[]
+    needsDecision?: string[]
+  }
+  summary?: { headline?: string }
+}
 
 function AdminDashboardContent() {
   const [pipeline, setPipeline] = useState<{ outreach: OutreachDashboard | null; valueEvidence: ValueEvidenceDashboard | null; reports: ValueReportsRes['reports'] | null }>({ outreach: null, valueEvidence: null, reports: null })
   const [sales, setSales] = useState<{ stats: SalesRes['stats'] | null; campaigns: CampaignsRes['data'] | null }>({ stats: null, campaigns: null })
   const [postSale, setPostSale] = useState<{ projects: ClientProjectsRes['projects'] | null; tasks: MeetingTasksRes['tasks'] | null; guarantees: GuaranteesRes['data'] | null }>({ projects: null, tasks: null, guarantees: null })
-  const [quality, setQuality] = useState<{ chatStats: ChatEvalStats | null; chatSessions: ChatEvalSessionsRes['sessions'] | null; analytics: AnalyticsStats | null }>({ chatStats: null, chatSessions: null, analytics: null })
+  const [quality, setQuality] = useState<{ chatStats: ChatEvalStats | null; chatSessions: ChatEvalSessionsRes['sessions'] | null; analytics: AnalyticsStats | null; subscriptions: SubscriptionStatusRes | null }>({ chatStats: null, chatSessions: null, analytics: null, subscriptions: null })
   const [config, setConfig] = useState<ConfigCountsRes | null>(null)
   const [pipelineError, setPipelineError] = useState(false)
   const [salesError, setSalesError] = useState(false)
@@ -91,7 +101,7 @@ function AdminDashboardContent() {
       outreach, valueEvidence, reportsRes,
       salesRes, campaignsRes,
       projectsRes, tasksRes, guaranteesRes,
-      chatStats, chatSessionsRes, analyticsRes,
+      chatStats, chatSessionsRes, analyticsRes, subscriptionsRes,
       configRes,
     ] = await Promise.all([
       safeFetch('/api/admin/outreach/dashboard').catch(() => null),
@@ -105,6 +115,7 @@ function AdminDashboardContent() {
       safeFetch('/api/admin/chat-eval/stats?days=7').catch(() => null),
       safeFetch('/api/admin/chat-eval?limit=5').catch(() => null),
       safeFetch('/api/analytics/stats?days=7').catch(() => null),
+      safeFetch('/api/admin/subscriptions/status').catch(() => null),
       safeFetch('/api/admin/configuration/counts').catch(() => null),
     ])
 
@@ -132,11 +143,12 @@ function AdminDashboardContent() {
       })
     } else { setPostSaleError(true) }
 
-    if (chatStats || chatSessionsRes || analyticsRes) {
+    if (chatStats || chatSessionsRes || analyticsRes || subscriptionsRes) {
       setQuality({
         chatStats: chatStats ?? null,
         chatSessions: (chatSessionsRes as ChatEvalSessionsRes)?.sessions ?? null,
         analytics: analyticsRes ?? null,
+        subscriptions: subscriptionsRes ?? null,
       })
     } else { setQualityError(true) }
 
@@ -419,6 +431,7 @@ function AdminDashboardContent() {
             secondaryLinks={[
               { label: 'Analytics', href: '/admin/analytics' },
               { label: 'Cost & Revenue', href: '/admin/cost-revenue' },
+              { label: 'Subscription Watch', href: '/admin/subscriptions' },
               { label: 'E2E Testing', href: '/admin/testing' },
             ]}
             error={qualityError}
@@ -465,6 +478,12 @@ function AdminDashboardContent() {
                   />
                 </div>
                 <ul className="space-y-1.5 text-sm">
+                  {quality.subscriptions?.buckets && (
+                    <li className="flex justify-between gap-2 text-muted-foreground">
+                      <span className="truncate">Subscription watch</span>
+                      <span className="shrink-0">{quality.subscriptions.buckets.needsDecision?.length ?? 0} need review</span>
+                    </li>
+                  )}
                   {(quality.chatSessions ?? []).slice(0, 5).map((s, i) => (
                     <li key={i} className="truncate text-muted-foreground">{s?.visitor_email ?? s?.session_id ?? '—'}</li>
                   ))}

--- a/app/admin/subscriptions/page.tsx
+++ b/app/admin/subscriptions/page.tsx
@@ -1,0 +1,268 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import { AlertTriangle, CheckCircle2, CircleDollarSign, Clock3, FileText, ShieldCheck } from 'lucide-react'
+import ProtectedRoute from '@/components/ProtectedRoute'
+import Breadcrumbs from '@/components/admin/Breadcrumbs'
+
+type StatusKey = 'keep' | 'watch' | 'unresolved' | 'resolved_canceled'
+type StatusColor = 'green' | 'yellow' | 'red'
+
+interface VendorStatus {
+  name: string
+  status: StatusKey
+  statusColor: StatusColor
+  billingSignal: string
+  usageSignal: string
+  portfolioDependency: string
+  recommendation: string
+  nextAction: string
+  decisionRequired: boolean
+  links: Array<{ label: string; href: string }>
+}
+
+interface SubscriptionStatusRegistry {
+  generatedAt: string
+  sourceDocument: string
+  weeklyReportAutomationId: string
+  dailyMonitorAutomationId: string
+  approvalPhrasePattern: string
+  summary: {
+    status: StatusColor
+    headline: string
+    nextReviewFocus: string[]
+  }
+  buckets: {
+    keep: string[]
+    watch: string[]
+    unresolved: string[]
+    resolvedCanceled: string[]
+    needsDecision: string[]
+  }
+  vendors: VendorStatus[]
+}
+
+const statusLabels: Record<StatusKey, string> = {
+  keep: 'Keep',
+  watch: 'Watch',
+  unresolved: 'Unresolved',
+  resolved_canceled: 'Resolved',
+}
+
+const statusStyles: Record<StatusColor, string> = {
+  green: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-300',
+  yellow: 'border-amber-500/40 bg-amber-500/10 text-amber-300',
+  red: 'border-red-500/40 bg-red-500/10 text-red-300',
+}
+
+export default function AdminSubscriptionsPage() {
+  return (
+    <ProtectedRoute requireAdmin>
+      <AdminSubscriptionsPageContent />
+    </ProtectedRoute>
+  )
+}
+
+function AdminSubscriptionsPageContent() {
+  const [data, setData] = useState<SubscriptionStatusRegistry | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    async function loadStatus() {
+      setLoading(true)
+      setError(null)
+      try {
+        const res = await fetch('/api/admin/subscriptions/status')
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}))
+          throw new Error(body.error || `HTTP ${res.status}`)
+        }
+        const json = await res.json()
+        if (!cancelled) setData(json)
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load subscription status')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    loadStatus()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const decisionItems = useMemo(
+    () => data?.vendors.filter((vendor) => vendor.decisionRequired) ?? [],
+    [data]
+  )
+
+  return (
+    <div className="min-h-screen bg-background text-foreground p-6 lg:p-8">
+      <div className="max-w-7xl mx-auto">
+        <Breadcrumbs items={[
+          { label: 'Admin Dashboard', href: '/admin' },
+          { label: 'Subscription Watch' },
+        ]} />
+
+        <div className="mb-6 flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold mb-1">Subscription Watch</h1>
+            <p className="text-muted-foreground text-sm">Read-only view of paid tools, watch items, unresolved vendors, and cancellation gates.</p>
+          </div>
+          <div className="rounded-lg border border-silicon-slate bg-silicon-slate/30 px-4 py-3 text-sm text-muted-foreground">
+            Approval phrase: <span className="text-foreground font-medium">Cancel &lt;tool/vendor&gt; for Portfolio</span>
+          </div>
+        </div>
+
+        {loading ? (
+          <div className="flex items-center justify-center py-16 text-muted-foreground">Loading…</div>
+        ) : error ? (
+          <div className="rounded-lg border border-red-500/50 bg-red-500/10 p-6 text-red-300">
+            <p className="font-medium">Failed to load subscription status</p>
+            <p className="text-sm mt-1">{error}</p>
+          </div>
+        ) : data ? (
+          <>
+            <section className="mb-6 rounded-lg border border-silicon-slate bg-silicon-slate/30 p-5">
+              <div className="flex flex-wrap items-start justify-between gap-4">
+                <div>
+                  <div className="flex items-center gap-2 mb-2">
+                    <CircleDollarSign size={20} className="text-radiant-gold" />
+                    <h2 className="text-xl font-semibold">Current stance</h2>
+                  </div>
+                  <p className="text-sm text-muted-foreground max-w-3xl">{data.summary.headline}</p>
+                </div>
+                <div className={`rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide ${statusStyles[data.summary.status]}`}>
+                  {data.summary.status}
+                </div>
+              </div>
+            </section>
+
+            <section className="grid grid-cols-2 lg:grid-cols-5 gap-3 mb-6">
+              <BucketStat icon={<CheckCircle2 size={18} />} label="Keep" count={data.buckets.keep.length} />
+              <BucketStat icon={<Clock3 size={18} />} label="Watch" count={data.buckets.watch.length} />
+              <BucketStat icon={<AlertTriangle size={18} />} label="Unresolved" count={data.buckets.unresolved.length} />
+              <BucketStat icon={<ShieldCheck size={18} />} label="Resolved" count={data.buckets.resolvedCanceled.length} />
+              <BucketStat icon={<FileText size={18} />} label="Needs decision" count={data.buckets.needsDecision.length} />
+            </section>
+
+            {decisionItems.length > 0 && (
+              <section className="mb-6 rounded-lg border border-amber-500/40 bg-amber-500/10 p-5">
+                <h2 className="text-lg font-semibold text-amber-200 mb-3">Needs attention</h2>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                  {decisionItems.map((vendor) => (
+                    <div key={vendor.name} className="rounded-lg border border-amber-500/30 bg-background/40 p-4">
+                      <div className="flex items-center justify-between gap-3 mb-2">
+                        <h3 className="font-semibold">{vendor.name}</h3>
+                        <StatusPill status={vendor.status} color={vendor.statusColor} />
+                      </div>
+                      <p className="text-sm text-muted-foreground">{vendor.nextAction}</p>
+                    </div>
+                  ))}
+                </div>
+              </section>
+            )}
+
+            <section className="mb-6">
+              <h2 className="text-lg font-semibold mb-3">Vendor status</h2>
+              <div className="overflow-hidden rounded-lg border border-silicon-slate">
+                <div className="hidden lg:grid grid-cols-[160px_130px_1fr_1fr_1fr] gap-4 bg-silicon-slate/60 px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  <span>Vendor</span>
+                  <span>Status</span>
+                  <span>Billing signal</span>
+                  <span>Dependency</span>
+                  <span>Next action</span>
+                </div>
+                <div className="divide-y divide-silicon-slate">
+                  {data.vendors.map((vendor) => (
+                    <div key={vendor.name} className="grid grid-cols-1 lg:grid-cols-[160px_130px_1fr_1fr_1fr] gap-3 lg:gap-4 px-4 py-4">
+                      <div>
+                        <p className="font-semibold">{vendor.name}</p>
+                        {vendor.links.length > 0 && (
+                          <div className="mt-1 flex flex-wrap gap-2">
+                            {vendor.links.map((link) => (
+                              <Link key={link.href} href={link.href} className="text-xs text-radiant-gold hover:text-amber-400">
+                                {link.label}
+                              </Link>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                      <div>
+                        <StatusPill status={vendor.status} color={vendor.statusColor} />
+                      </div>
+                      <SignalBlock label="Billing" value={vendor.billingSignal} />
+                      <SignalBlock label="Dependency" value={vendor.portfolioDependency} />
+                      <SignalBlock label="Next action" value={vendor.nextAction} />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </section>
+
+            <section className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+              <div className="rounded-lg border border-silicon-slate bg-silicon-slate/30 p-5">
+                <h2 className="text-lg font-semibold mb-3">Next review focus</h2>
+                <ul className="space-y-2 text-sm text-muted-foreground">
+                  {data.summary.nextReviewFocus.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              </div>
+              <div className="rounded-lg border border-silicon-slate bg-silicon-slate/30 p-5">
+                <h2 className="text-lg font-semibold mb-3">Automation</h2>
+                <dl className="space-y-2 text-sm">
+                  <KeyValue label="Daily monitor" value={data.dailyMonitorAutomationId} />
+                  <KeyValue label="Weekly report" value={data.weeklyReportAutomationId} />
+                  <KeyValue label="Source" value={data.sourceDocument} />
+                  <KeyValue label="Last generated" value={data.generatedAt} />
+                </dl>
+              </div>
+            </section>
+          </>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function BucketStat({ icon, label, count }: { icon: React.ReactNode; label: string; count: number }) {
+  return (
+    <div className="rounded-lg border border-silicon-slate bg-silicon-slate/30 p-4">
+      <div className="flex items-center gap-2 text-muted-foreground mb-2">
+        {icon}
+        <span className="text-xs font-semibold uppercase tracking-wide">{label}</span>
+      </div>
+      <p className="text-2xl font-bold tabular-nums text-radiant-gold">{count}</p>
+    </div>
+  )
+}
+
+function StatusPill({ status, color }: { status: StatusKey; color: StatusColor }) {
+  return (
+    <span className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-medium ${statusStyles[color]}`}>
+      {statusLabels[status]}
+    </span>
+  )
+}
+
+function SignalBlock({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="lg:hidden text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-1">{label}</p>
+      <p className="text-sm text-muted-foreground leading-relaxed">{value}</p>
+    </div>
+  )
+}
+
+function KeyValue({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-wrap justify-between gap-2 border-b border-silicon-slate/70 pb-2 last:border-b-0">
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="font-mono text-xs text-foreground">{value}</dd>
+    </div>
+  )
+}

--- a/app/api/admin/subscriptions/status/route.ts
+++ b/app/api/admin/subscriptions/status/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { getSubscriptionStatusRegistry } from '@/lib/subscription-status'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  return NextResponse.json(getSubscriptionStatusRegistry())
+}

--- a/docs/subscription-status.json
+++ b/docs/subscription-status.json
@@ -1,0 +1,126 @@
+{
+  "generatedAt": "2026-05-01",
+  "sourceDocument": "/docs/subscription-cancellation-audit.md",
+  "weeklyReportAutomationId": "portfolio-subscription-weekly-report",
+  "dailyMonitorAutomationId": "portfolio-subscription-cancellation-monitor",
+  "approvalPhrasePattern": "Cancel <tool/vendor> for Portfolio",
+  "summary": {
+    "status": "yellow",
+    "headline": "Most core Portfolio subscriptions remain active or unresolved. BuiltWith is a watch item during outreach ramp; Fireflies is resolved as canceled.",
+    "nextReviewFocus": [
+      "Verify Vercel billing/project ownership.",
+      "Check Printful dashboard/store order history.",
+      "Check Vapi dashboard call history and production voice enablement.",
+      "Verify whether Resend is configured in production.",
+      "Check Pinecone billing/API usage against the RAG replacement path."
+    ]
+  },
+  "buckets": {
+    "keep": ["Gamma", "n8n Cloud", "Read.ai", "Supabase", "Apify", "HeyGen", "Calendly", "Anthropic", "OpenAI/ChatGPT Pro", "Google Cloud"],
+    "watch": ["BuiltWith", "ElevenLabs"],
+    "unresolved": ["Vercel", "Printful", "Vapi", "Resend", "Pinecone"],
+    "resolvedCanceled": ["Fireflies.ai"],
+    "needsDecision": ["Vercel", "Printful", "Vapi", "Resend", "Pinecone"]
+  },
+  "vendors": [
+    {
+      "name": "BuiltWith",
+      "status": "watch",
+      "statusColor": "yellow",
+      "billingSignal": "Receipts found on 2026-04-10 for $99.00, $99.00, and $109.00.",
+      "usageSignal": "No confirmed operational usage in the latest pass, but client traffic is still early.",
+      "portfolioDependency": "Tech-stack lookup/enrichment supports lead prep, implementation strategy, and feasibility assessment.",
+      "recommendation": "Keep active during outreach ramp; reassess after more leads, audits, implementation strategies, proposals, and client outcomes.",
+      "nextAction": "Compare sales-flow outcomes where BuiltWith enrichment helped versus leads where it did not.",
+      "decisionRequired": false,
+      "links": [
+        { "label": "Dependency packet", "href": "https://github.com/vsillah/Portfolio/blob/codex/admin-subscription-watch/docs/builtwith-deprecation-packet.md" },
+        { "label": "Audit tracker", "href": "https://github.com/vsillah/Portfolio/blob/codex/admin-subscription-watch/docs/subscription-cancellation-audit.md" }
+      ]
+    },
+    {
+      "name": "Fireflies.ai",
+      "status": "resolved_canceled",
+      "statusColor": "green",
+      "billingSignal": "Refund found on 2026-03-20; Vambah confirmed canceled on 2026-05-01.",
+      "usageSignal": "Prior Slack recap evidence overlapped with Read.ai; no longer an active paid-plan target.",
+      "portfolioDependency": "No direct Portfolio repo integration found in the latest audit.",
+      "recommendation": "Keep out of active cancellation queue unless new paid-plan evidence appears.",
+      "nextAction": "No action unless a new Fireflies receipt or paid-plan signal appears.",
+      "decisionRequired": false,
+      "links": [
+        { "label": "Audit tracker", "href": "https://github.com/vsillah/Portfolio/blob/codex/admin-subscription-watch/docs/subscription-cancellation-audit.md" }
+      ]
+    },
+    {
+      "name": "Vercel",
+      "status": "unresolved",
+      "statusColor": "yellow",
+      "billingSignal": "No billing receipt found in the latest Gmail pass; connector did not expose a team/project.",
+      "usageSignal": "Production hosting is likely but unverified from the current connector context.",
+      "portfolioDependency": "High-risk hosting/deployment dependency.",
+      "recommendation": "Keep until dashboard/account ownership and project billing are confirmed.",
+      "nextAction": "Use dashboard access to locate the actual hosting account/project and billing owner.",
+      "decisionRequired": true,
+      "links": [
+        { "label": "Audit tracker", "href": "https://github.com/vsillah/Portfolio/blob/codex/admin-subscription-watch/docs/subscription-cancellation-audit.md" }
+      ]
+    },
+    {
+      "name": "Printful",
+      "status": "unresolved",
+      "statusColor": "yellow",
+      "billingSignal": "No recent billing receipt found in the latest Gmail pass.",
+      "usageSignal": "Fulfillment code exists and product variants are present; printful_sync_log was quiet.",
+      "portfolioDependency": "Store fulfillment and merchandise sync risk.",
+      "recommendation": "Investigate before any cancellation decision.",
+      "nextAction": "Check Printful dashboard/store order history and whether merchandise remains part of the active offer set.",
+      "decisionRequired": true,
+      "links": [
+        { "label": "Audit tracker", "href": "https://github.com/vsillah/Portfolio/blob/codex/admin-subscription-watch/docs/subscription-cancellation-audit.md" }
+      ]
+    },
+    {
+      "name": "Vapi",
+      "status": "unresolved",
+      "statusColor": "yellow",
+      "billingSignal": "No recent billing receipt found in the latest Gmail pass.",
+      "usageSignal": "Voice code and env references exist; no fresh call usage signal was confirmed.",
+      "portfolioDependency": "Voice/audit experience risk if production voice UI is enabled.",
+      "recommendation": "Investigate dashboard call history before classifying.",
+      "nextAction": "Check Vapi dashboard call history and whether production voice UX is enabled.",
+      "decisionRequired": true,
+      "links": [
+        { "label": "Audit tracker", "href": "https://github.com/vsillah/Portfolio/blob/codex/admin-subscription-watch/docs/subscription-cancellation-audit.md" }
+      ]
+    },
+    {
+      "name": "Resend",
+      "status": "unresolved",
+      "statusColor": "yellow",
+      "billingSignal": "No recent billing receipt found in the latest Gmail pass.",
+      "usageSignal": "Optional transactional email provider with Gmail fallback.",
+      "portfolioDependency": "Transactional email delivery risk if production is configured to use Resend.",
+      "recommendation": "Verify production env before keeping as a paid dependency or removing.",
+      "nextAction": "Confirm whether production uses Resend or Gmail/n8n as the real outbound channel.",
+      "decisionRequired": true,
+      "links": [
+        { "label": "Audit tracker", "href": "https://github.com/vsillah/Portfolio/blob/codex/admin-subscription-watch/docs/subscription-cancellation-audit.md" }
+      ]
+    },
+    {
+      "name": "Pinecone",
+      "status": "unresolved",
+      "statusColor": "yellow",
+      "billingSignal": "No recent billing receipt found in the latest Gmail pass.",
+      "usageSignal": "n8n RAG workflow references remain active.",
+      "portfolioDependency": "RAG/vector-store workflow risk.",
+      "recommendation": "Check billing/API usage and compare with Supabase/local RAG replacement path.",
+      "nextAction": "Verify Pinecone usage and whether the current RAG path still depends on it.",
+      "decisionRequired": true,
+      "links": [
+        { "label": "Audit tracker", "href": "https://github.com/vsillah/Portfolio/blob/codex/admin-subscription-watch/docs/subscription-cancellation-audit.md" }
+      ]
+    }
+  ]
+}

--- a/lib/admin-nav.ts
+++ b/lib/admin-nav.ts
@@ -65,6 +65,7 @@ export const ADMIN_NAV: { dashboard: AdminNavItem; categories: AdminNavCategory[
         { label: 'Chat Eval', href: '/admin/chat-eval' },
         { label: 'Analytics', href: '/admin/analytics' },
         { label: 'Cost & Revenue', href: '/admin/cost-revenue' },
+        { label: 'Subscription Watch', href: '/admin/subscriptions' },
         { label: 'Agent Operations', href: '/admin/agents' },
         { label: 'Technology Bakeoffs', href: '/admin/technology-bakeoffs' },
         { label: 'Client Experience', href: '/admin/client-experience' },

--- a/lib/subscription-status.ts
+++ b/lib/subscription-status.ts
@@ -1,0 +1,52 @@
+import subscriptionStatus from '@/docs/subscription-status.json'
+
+export type SubscriptionStatusKey =
+  | 'keep'
+  | 'watch'
+  | 'unresolved'
+  | 'resolved_canceled'
+
+export type SubscriptionStatusColor = 'green' | 'yellow' | 'red'
+
+export interface SubscriptionStatusLink {
+  label: string
+  href: string
+}
+
+export interface SubscriptionVendorStatus {
+  name: string
+  status: SubscriptionStatusKey
+  statusColor: SubscriptionStatusColor
+  billingSignal: string
+  usageSignal: string
+  portfolioDependency: string
+  recommendation: string
+  nextAction: string
+  decisionRequired: boolean
+  links: SubscriptionStatusLink[]
+}
+
+export interface SubscriptionStatusRegistry {
+  generatedAt: string
+  sourceDocument: string
+  weeklyReportAutomationId: string
+  dailyMonitorAutomationId: string
+  approvalPhrasePattern: string
+  summary: {
+    status: SubscriptionStatusColor
+    headline: string
+    nextReviewFocus: string[]
+  }
+  buckets: {
+    keep: string[]
+    watch: string[]
+    unresolved: string[]
+    resolvedCanceled: string[]
+    needsDecision: string[]
+  }
+  vendors: SubscriptionVendorStatus[]
+}
+
+export function getSubscriptionStatusRegistry(): SubscriptionStatusRegistry {
+  return subscriptionStatus as SubscriptionStatusRegistry
+}


### PR DESCRIPTION
## Summary
- add a protected admin Subscription Watch page backed by the subscription status registry
- expose read-only subscription status through an admin API route
- surface subscription watch counts from the admin dashboard/nav

## Validation
- npx tsc --noEmit --pretty false
- git diff --check origin/main...HEAD

No cancellation action is taken by this change; it is a read-only monitoring surface.