### PR TITLE
feat: add agent engagement autopilot surface

### DIFF
--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -3,7 +3,18 @@
 import Link from 'next/link'
 import { useState } from 'react'
 import type { ReactNode } from 'react'
-import { Activity, ArrowRight, Bot, CheckCircle2, Clock, DollarSign, RefreshCw, ShieldAlert, XCircle } from 'lucide-react'
+import {
+  Activity,
+  ArrowRight,
+  Bot,
+  CalendarCheck,
+  CheckCircle2,
+  Clock,
+  DollarSign,
+  RefreshCw,
+  ShieldAlert,
+  XCircle,
+} from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
 import { getCurrentSession } from '@/lib/auth'
@@ -19,6 +30,9 @@ export default function AgentOperationsPage() {
   const [runtimeLoading, setRuntimeLoading] = useState(false)
   const [runtimeResult, setRuntimeResult] = useState<{ runId: string; available: boolean } | null>(null)
   const [runtimeError, setRuntimeError] = useState<string | null>(null)
+  const [morningLoading, setMorningLoading] = useState(false)
+  const [morningResult, setMorningResult] = useState<{ runId: string; overall: string; slackNotified: boolean } | null>(null)
+  const [morningError, setMorningError] = useState<string | null>(null)
 
   async function runHermesHealthSummary() {
     setHermesLoading(true)
@@ -91,6 +105,31 @@ export default function AgentOperationsPage() {
       setRuntimeError(err instanceof Error ? err.message : 'Failed to evaluate OpenCode/OpenClaw')
     } finally {
       setRuntimeLoading(false)
+    }
+  }
+
+  async function runMorningReview() {
+    setMorningLoading(true)
+    setMorningError(null)
+    setMorningResult(null)
+    try {
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Missing admin session')
+      const res = await fetch('/api/admin/agents/morning-review', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      })
+      const body = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(body.error || `HTTP ${res.status}`)
+      setMorningResult({
+        runId: body.run_id,
+        overall: body.overall,
+        slackNotified: Boolean(body.slack_notified),
+      })
+    } catch (err) {
+      setMorningError(err instanceof Error ? err.message : 'Failed to run Agent Ops morning review')
+    } finally {
+      setMorningLoading(false)
     }
   }
 
@@ -210,6 +249,87 @@ export default function AgentOperationsPage() {
             </div>
           </div>
 
+          <section className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-5">
+            <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+              <div>
+                <div className="flex items-center gap-2 text-radiant-gold mb-2">
+                  <CalendarCheck size={20} />
+                  <h2 className="text-lg font-semibold">Agent Engagement</h2>
+                </div>
+                <p className="text-sm text-muted-foreground max-w-3xl">
+                  Operational roster for the agents that are ready to run, where to engage them, and what approval gates apply.
+                </p>
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <button
+                  onClick={runMorningReview}
+                  disabled={morningLoading}
+                  className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/50 bg-radiant-gold/10 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15 disabled:opacity-60"
+                >
+                  <RefreshCw size={16} className={morningLoading ? 'animate-spin' : ''} />
+                  Run morning review
+                </button>
+                <Link
+                  href="/admin/agents/runs"
+                  className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 bg-background/60 px-3 py-2 text-sm hover:border-radiant-gold/60"
+                >
+                  <Activity size={16} />
+                  View runs
+                </Link>
+              </div>
+            </div>
+            {morningResult ? (
+              <div className="mt-4 rounded-lg border border-green-400/30 bg-green-500/10 px-4 py-3 text-sm">
+                <Link href={`/admin/agents/runs/${morningResult.runId}`} className="text-green-200 hover:underline">
+                  Open {morningResult.overall} morning review run
+                </Link>
+                <span className="text-muted-foreground">
+                  {' '}
+                  · Slack {morningResult.slackNotified ? 'notified' : 'not configured or skipped'}
+                </span>
+              </div>
+            ) : null}
+            {morningError ? <p className="mt-3 text-sm text-red-300">{morningError}</p> : null}
+
+            <div className="mt-5 grid grid-cols-1 lg:grid-cols-2 gap-4">
+              {AGENT_ENGAGEMENTS.map((agent) => (
+                <div key={agent.key} className="rounded-lg border border-silicon-slate/60 bg-background/35 p-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="font-semibold">{agent.name}</p>
+                      <p className="mt-1 text-sm text-muted-foreground">{agent.purpose}</p>
+                    </div>
+                    <span className="rounded-full border border-silicon-slate/60 bg-black/20 px-2 py-1 text-xs">
+                      {agent.runtime}
+                    </span>
+                  </div>
+                  <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Engage</p>
+                      <p className="mt-1">{agent.engage}</p>
+                    </div>
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Gate</p>
+                      <p className="mt-1">{agent.gate}</p>
+                    </div>
+                  </div>
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    {agent.links.map((link) => (
+                      <Link
+                        key={`${agent.key}-${link.href}`}
+                        href={link.href}
+                        className="inline-flex items-center gap-1 rounded-md border border-silicon-slate/60 bg-black/10 px-2 py-1 text-xs hover:border-radiant-gold/60"
+                      >
+                        {link.label}
+                        <ArrowRight size={12} />
+                      </Link>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
             <SignalCard icon={<Clock size={18} />} label="Active states" value="Queued, running, approval" />
             <SignalCard icon={<CheckCircle2 size={18} />} label="Completion" value="Completed, cancelled" />
@@ -270,6 +390,80 @@ function SignalCard({ icon, label, value }: { icon: ReactNode; label: string; va
     </div>
   )
 }
+
+const AGENT_ENGAGEMENTS = [
+  {
+    key: 'portfolio-operations-manager',
+    name: 'Portfolio Operations Manager',
+    runtime: 'n8n + codex',
+    purpose: 'Daily agent health, stale-run cleanup, Slack summary, and admin review trace.',
+    engage: 'Automatic morning review or the Run morning review button.',
+    gate: 'Notification-only; production config changes still require approval.',
+    links: [
+      { label: 'Runs', href: '/admin/agents/runs' },
+      { label: 'Runbook', href: '/admin/agents' },
+    ],
+  },
+  {
+    key: 'hermes-health-analyst',
+    name: 'Hermes Health Analyst',
+    runtime: 'hermes',
+    purpose: 'Read-only secondary-runtime summary across agent runs, costs, n8n flags, and workflow status.',
+    engage: 'Use Hermes Health Summary from this page.',
+    gate: 'No production writes in v1.',
+    links: [{ label: 'Runs', href: '/admin/agents/runs' }],
+  },
+  {
+    key: 'outreach-generation',
+    name: 'Outreach Generation Agent',
+    runtime: 'codex + n8n',
+    purpose: 'Creates observable outreach draft traces with prompt assembly, LLM dispatch, cost linkage, and artifact references.',
+    engage: 'Use existing outreach and lead-pipeline admin workflows.',
+    gate: 'Human review before sending email.',
+    links: [
+      { label: 'Lead Pipeline', href: '/admin/outreach' },
+      { label: 'Runs', href: '/admin/agents/runs' },
+    ],
+  },
+  {
+    key: 'evidence-listening',
+    name: 'Value Evidence Agent',
+    runtime: 'n8n',
+    purpose: 'Collects and routes value evidence, social-listening findings, and workflow traces for review.',
+    engage: 'Use Value Evidence and workflow-specific admin surfaces.',
+    gate: 'Public content and client-facing summaries require approval.',
+    links: [
+      { label: 'Value Evidence', href: '/admin/value-evidence' },
+      { label: 'Runs', href: '/admin/agents/runs' },
+    ],
+  },
+  {
+    key: 'approval-steward',
+    name: 'Approval Steward',
+    runtime: 'manual',
+    purpose: 'Keeps publishing, email, production config, and sensitive-data gates represented in agent_approvals.',
+    engage: 'Use Approval Drill and run-detail approval controls.',
+    gate: 'Approval state is the system of record.',
+    links: [{ label: 'Runs', href: '/admin/agents/runs' }],
+  },
+  {
+    key: 'slack-command-path',
+    name: 'Slack Command Path',
+    runtime: 'slack + n8n',
+    purpose: 'Mobile-friendly command surface for checking status without adding Telegram or another channel.',
+    engage: 'Planned Slack slash-command layer that calls admin-safe agent triggers.',
+    gate: 'Read-only commands first; mutating actions route to approval.',
+    links: [{ label: 'Runbook', href: '/admin/agents' }],
+  },
+] satisfies Array<{
+  key: string
+  name: string
+  runtime: string
+  purpose: string
+  engage: string
+  gate: string
+  links: Array<{ label: string; href: string }>
+}>
 
 function PolicyFlag({ label, value }: { label: string; value: boolean }) {
   return (

--- a/app/api/admin/agents/morning-review/route.test.ts
+++ b/app/api/admin/agents/morning-review/route.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  runAgentOpsMorningReview: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-ops-morning-review', () => ({
+  runAgentOpsMorningReview: mocks.runAgentOpsMorningReview,
+}))
+
+import { POST } from './route'
+
+function makeRequest() {
+  return new Request('http://localhost/api/admin/agents/morning-review', {
+    method: 'POST',
+    headers: { authorization: 'Bearer token' },
+  })
+}
+
+describe('POST /api/admin/agents/morning-review', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.runAgentOpsMorningReview.mockResolvedValue({
+      runId: 'review-run-1',
+      generatedAt: '2026-05-01T09:00:00.000Z',
+      overall: 'warning',
+      staleSweep: { checked: 2, marked: 1, runIds: ['stale-1'] },
+      slackNotified: false,
+      summaryMarkdown: '# Agent Ops Morning Review',
+      health: {
+        warnings: ['1 agent run(s) failed in the last 24 hours'],
+      },
+    })
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(makeRequest() as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.runAgentOpsMorningReview).not.toHaveBeenCalled()
+  })
+
+  it('runs the morning review through the admin engagement path', async () => {
+    const response = await POST(makeRequest() as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      ok: true,
+      run_id: 'review-run-1',
+      overall: 'warning',
+      stale_sweep: { checked: 2, marked: 1, runIds: ['stale-1'] },
+      slack_notified: false,
+      warnings: ['1 agent run(s) failed in the last 24 hours'],
+      summary_markdown: '# Agent Ops Morning Review',
+      triggered_by_user_id: 'admin-user',
+    })
+    expect(mocks.runAgentOpsMorningReview).toHaveBeenCalledWith('admin_agent_ops_morning_review')
+  })
+})

--- a/app/api/admin/agents/morning-review/route.ts
+++ b/app/api/admin/agents/morning-review/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { runAgentOpsMorningReview } from '@/lib/agent-ops-morning-review'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * POST /api/admin/agents/morning-review
+ *
+ * Admin-owned manual trigger for the Agent Operations morning review. The
+ * n8n cron route remains the no-human scheduled path; this route gives the
+ * admin console a safe on-demand engagement point with the same traced run.
+ */
+export async function POST(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  try {
+    const result = await runAgentOpsMorningReview('admin_agent_ops_morning_review')
+    return NextResponse.json({
+      ok: result.overall !== 'error',
+      run_id: result.runId,
+      overall: result.overall,
+      stale_sweep: result.staleSweep,
+      slack_notified: result.slackNotified,
+      warnings: result.health.warnings,
+      summary_markdown: result.summaryMarkdown,
+      triggered_by_user_id: auth.user.id,
+    })
+  } catch (error) {
+    console.error('[admin-agent-ops-morning-review] failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Agent Ops morning review failed' },
+      { status: 500 },
+    )
+  }
+}

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -28,6 +28,15 @@ Supported run statuses:
 
 The first version adds an Agent Operations console under `/admin/agents`. It reads generic agent trace tables instead of building a custom dashboard for every workflow. Existing workflow-specific pages remain live during the rollout.
 
+The console now includes an Agent Engagement roster so the operating model is visible from the same place as the traces:
+
+- Portfolio Operations Manager — n8n/Codex morning review, stale-run cleanup, Slack notification, and health artifact.
+- Hermes Health Analyst — read-only secondary runtime summary.
+- Outreach Generation Agent — traced outreach drafts and cost-linked LLM usage.
+- Value Evidence Agent — n8n evidence/listening workflows and generated reports.
+- Approval Steward — manual approval checkpoints stored in `agent_approvals`.
+- Slack Command Path — planned mobile-friendly command surface for read-only checks and approval-routed actions.
+
 The shared trace tables are:
 
 - `agent_registry`
@@ -136,6 +145,13 @@ Use `POST /api/cron/agent-ops-morning-review` with `Authorization: Bearer N8N_IN
 - optionally posts a Slack summary when `SLACK_AGENT_OPS_WEBHOOK_URL` is configured.
 
 Recommended schedule: n8n Cloud weekday morning trigger, owned by the automation layer. Slack remains a notification surface only; Portfolio admin and `agent_runs` remain the source of truth.
+
+Admin operators can also trigger the same review with `POST /api/admin/agents/morning-review` or the **Run morning review** button on `/admin/agents`. This path requires admin auth and uses `trigger_source = admin_agent_ops_morning_review`.
+
+The n8n import artifact lives at `n8n-exports/WF-AGENT-OPS-MORNING-REVIEW.json`. Keep it inactive until the n8n Cloud variables are confirmed:
+
+- `AMADUTOWN_PUBLIC_BASE_URL=https://amadutown.com`
+- `N8N_INGEST_SECRET=<same bearer secret configured in Portfolio>`
 
 ## Safety Rules
 

--- a/n8n-exports/README.md
+++ b/n8n-exports/README.md
@@ -5,6 +5,11 @@ This folder contains exported n8n workflows ready for import into n8n Cloud.
 ## 📁 Contents
 
 ### Workflows
+- **WF-AGENT-OPS-MORNING-REVIEW.json**
+  - Runs the Agent Operations morning review without a human in the loop
+  - Schedule: Weekdays at 9am in the n8n workspace timezone
+  - Calls `POST /api/cron/agent-ops-morning-review` and relies on Portfolio for trace creation, stale-run sweep, artifact attachment, and optional Slack notification
+
 - **WF-WRM-001-Facebook-Warm-Lead-Scraper.json**
   - Scrapes Facebook friends, group members, and post engagement
   - Schedule: Weekly (Mondays at 9am)
@@ -57,18 +62,23 @@ Requires `N8N_CLOUD_API_KEY` in `.env.local`. Matches by workflow name.
 
 ### 3. Configure Environment Variables
 Go to **Settings → Environments** and add:
+- `AMADUTOWN_PUBLIC_BASE_URL`
+- `N8N_INGEST_SECRET`
 - `APIFY_API_TOKEN`
 - `FACEBOOK_PROFILE_URL`
 - `FACEBOOK_GROUP_UIDS`
 - `LINKEDIN_COOKIE`
 - `LINKEDIN_PROFILE_URL`
 - `APP_BASE_URL`
-- `N8N_INGEST_SECRET`
 
 See [environment-variables-reference.md](./environment-variables-reference.md) for details.
 
 ### 4. Test Workflows
 ```bash
+# Agent Operations morning review
+curl -X POST https://amadutown.com/api/cron/agent-ops-morning-review \
+  -H "Authorization: Bearer $N8N_INGEST_SECRET"
+
 # Test each webhook
 curl -X POST https://your-workspace.app.n8n.cloud/webhook/wrm-001-facebook
 curl -X POST https://your-workspace.app.n8n.cloud/webhook/wrm-002-google-contacts
@@ -120,6 +130,7 @@ Environment variables must be set separately in n8n Cloud.
 - **Apify Token:** For web scraping actors
 - **LinkedIn Cookie:** For connections scraper (expires ~1 year)
 - **N8N Ingest Secret:** For webhook authentication (must match Next.js app)
+- **AmaduTown public base URL:** For scheduled app callbacks, usually `https://amadutown.com`
 - **Google OAuth2:** For Contacts API (use n8n's built-in OAuth2)
 
 ## 📈 Expected Usage

--- a/n8n-exports/WF-AGENT-OPS-MORNING-REVIEW.json
+++ b/n8n-exports/WF-AGENT-OPS-MORNING-REVIEW.json
@@ -1,0 +1,102 @@
+{
+  "name": "WF-AGENT-OPS: Morning Review",
+  "active": false,
+  "nodes": [
+    {
+      "id": "weekday-morning-schedule",
+      "name": "Weekday Morning Schedule",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.3,
+      "position": [0, 240],
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "cronExpression",
+              "expression": "0 9 * * 1-5"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "manual-run",
+      "name": "Manual Run",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [0, 440],
+      "parameters": {}
+    },
+    {
+      "id": "call-agent-ops-review",
+      "name": "Call Agent Ops Morning Review",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.4,
+      "position": [320, 336],
+      "parameters": {
+        "method": "POST",
+        "url": "={{($vars.AMADUTOWN_PUBLIC_BASE_URL || $env.AMADUTOWN_PUBLIC_BASE_URL || 'https://amadutown.com').replace(/\\/$/, '')}}/api/cron/agent-ops-morning-review",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{$vars.N8N_INGEST_SECRET || $env.N8N_INGEST_SECRET}}"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ source: 'n8n_cloud_morning_review', requested_at: new Date().toISOString() }) }}",
+        "options": {
+          "timeout": 120000
+        }
+      },
+      "retryOnFail": true,
+      "maxTries": 2,
+      "waitBetweenTries": 5000
+    },
+    {
+      "id": "note",
+      "name": "Agent Ops Morning Review Notes",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [-20, 40],
+      "parameters": {
+        "content": "## WF-AGENT-OPS: Morning Review\n\n**Purpose:** no-human-in-the-loop daily Agent Operations review.\n\n**Schedule:** weekdays at 9:00 AM in the n8n workspace timezone.\n\n**Flow:** Schedule or manual trigger -> POST Portfolio cron route -> route creates a traced n8n agent run, sweeps stale runs, attaches the review artifact, and posts Slack if `SLACK_AGENT_OPS_WEBHOOK_URL` is configured in Portfolio.\n\n**Required n8n variables:**\n- `AMADUTOWN_PUBLIC_BASE_URL` = `https://amadutown.com`\n- `N8N_INGEST_SECRET` = same secret configured in Portfolio\n\nKeep inactive until variables are confirmed, then activate in n8n Cloud."
+      }
+    }
+  ],
+  "connections": {
+    "Weekday Morning Schedule": {
+      "main": [
+        [
+          {
+            "node": "Call Agent Ops Morning Review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Manual Run": {
+      "main": [
+        [
+          {
+            "node": "Call Agent Ops Morning Review",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "timezone": "America/New_York"
+  }
+}

--- a/n8n-exports/manifest.json
+++ b/n8n-exports/manifest.json
@@ -3,6 +3,7 @@
   "use_case": "full_business_automation",
   "dependencies": ["n8n", "apify", "google_people_api", "slack", "openai", "calendly", "gmail", "pinecone"],
   "exported_workflows": [
+    "WF-AGENT-OPS-MORNING-REVIEW.json",
     "WF-WRM-001-Facebook-Warm-Lead-Scraper.json",
     "WF-WRM-002-Google-Contacts-Sync.json",
     "WF-WRM-003-LinkedIn-Warm-Lead-Scraper.json"
@@ -49,5 +50,5 @@
     { "id": "DiN2zado2GVk2Lka", "name": "WF-LMN-001: Ebook Nurture Sequence", "nodes": 21 }
   ],
   "export_note": "The 3 WRM workflow JSONs are pre-exported. All other active workflows are on the local n8n instance (http://127.0.0.1:5678). To bulk-export: n8n UI > Settings > Export All Workflows, or use the n8n MCP tools (n8n_get_workflow with mode=full for each ID). WF-CLG-002 (Outreach Generation) was retired 2026-04-27 — its export is preserved under archive/ for reference; runtime generation now happens in-app via lib/outreach-queue-generator.ts and the auto-follow-up branch of WF-CLG-003 calls /api/webhooks/n8n/outreach-followup-trigger.",
-  "last_updated": "2026-04-27"
+  "last_updated": "2026-05-01"
 }


### PR DESCRIPTION
## Summary
- add an Agent Engagement roster to the Agent Operations admin hub
- add a protected admin trigger for the Agent Ops morning review
- add an inactive n8n Cloud import artifact for the weekday morning review schedule

## Validation
- jq empty n8n-exports/WF-AGENT-OPS-MORNING-REVIEW.json n8n-exports/manifest.json
- n8n Cloud validate_workflow: valid, 0 errors, 1 general error-handling suggestion
- npm test -- app/api/admin/agents/morning-review/route.test.ts app/api/cron/agent-ops-morning-review/route.test.ts lib/agent-ops-morning-review.test.ts
- npm test -- app/api/admin/agents/hermes/system-health/route.test.ts app/api/admin/agents/runtime-evaluation/route.test.ts app/api/admin/agents/approval-drill/route.test.ts
- npx tsc --noEmit --pretty false
- npm run build

## Notes
- The n8n workflow is intentionally inactive until n8n Cloud variables are confirmed and the schedule is activated.
- Build emitted the existing local env warning that MOCK_N8N=false and N8N_DISABLE_OUTBOUND=false.