### PR TITLE
feat: add Slack Agent Ops command

### DIFF
--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -531,8 +531,8 @@ const AGENT_ENGAGEMENTS = [
     name: 'Slack Command Path',
     runtime: 'slack + n8n',
     purpose: 'Mobile-friendly command surface for checking status without adding Telegram or another channel.',
-    engage: 'Planned Slack slash-command layer that calls admin-safe agent triggers.',
-    gate: 'Read-only commands first; mutating actions route to approval.',
+    engage: 'Use /agent status, /agent failed, /agent approvals, or /agent morning-review in Slack.',
+    gate: 'Status, failed, and approvals are read-only; morning-review writes only the approved Agent Ops trace.',
     links: [{ label: 'Runbook', href: '/admin/agents' }],
   },
 ] satisfies Array<{

--- a/app/api/slack/agent/route.test.ts
+++ b/app/api/slack/agent/route.test.ts
@@ -1,0 +1,78 @@
+import { createHmac } from 'crypto'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  handleAgentSlackCommand: vi.fn(),
+}))
+
+vi.mock('@/lib/agent-slack-command', () => ({
+  handleAgentSlackCommand: mocks.handleAgentSlackCommand,
+}))
+
+import { POST } from './route'
+
+const ORIGINAL_ENV = process.env
+
+function signedRequest(body: URLSearchParams, secret = 'test-slack-secret') {
+  const rawBody = body.toString()
+  const timestamp = Math.floor(Date.now() / 1000).toString()
+  const signature = `v0=${createHmac('sha256', secret).update(`v0:${timestamp}:${rawBody}`).digest('hex')}`
+
+  return new Request('http://localhost/api/slack/agent', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/x-www-form-urlencoded',
+      'x-slack-request-timestamp': timestamp,
+      'x-slack-signature': signature,
+    },
+    body: rawBody,
+  })
+}
+
+describe('POST /api/slack/agent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env = { ...ORIGINAL_ENV, SLACK_SIGNING_SECRET: 'test-slack-secret' }
+    mocks.handleAgentSlackCommand.mockResolvedValue({
+      responseType: 'ephemeral',
+      text: 'Agent Ops status',
+    })
+  })
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV
+  })
+
+  it('rejects invalid Slack signatures', async () => {
+    const request = signedRequest(new URLSearchParams({ text: 'status' }), 'wrong-secret')
+
+    const response = await POST(request as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Invalid Slack signature' })
+    expect(mocks.handleAgentSlackCommand).not.toHaveBeenCalled()
+  })
+
+  it('dispatches form-encoded slash command text to the command handler', async () => {
+    const request = signedRequest(
+      new URLSearchParams({
+        text: 'status',
+        user_id: 'U123',
+        user_name: 'vambah',
+      }),
+    )
+
+    const response = await POST(request as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      response_type: 'ephemeral',
+      text: 'Agent Ops status',
+    })
+    expect(mocks.handleAgentSlackCommand).toHaveBeenCalledWith({
+      text: 'status',
+      userId: 'U123',
+      userName: 'vambah',
+    })
+  })
+})

--- a/app/api/slack/agent/route.ts
+++ b/app/api/slack/agent/route.ts
@@ -1,0 +1,63 @@
+import { createHmac, timingSafeEqual } from 'crypto'
+import { NextRequest, NextResponse } from 'next/server'
+import { handleAgentSlackCommand } from '@/lib/agent-slack-command'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * POST /api/slack/agent
+ * Slack slash command handler for /agent.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const rawBody = await request.text()
+    const isValid = verifySlackSignature(request, rawBody)
+    if (!isValid) {
+      return NextResponse.json({ error: 'Invalid Slack signature' }, { status: 401 })
+    }
+
+    const formData = new URLSearchParams(rawBody)
+    const result = await handleAgentSlackCommand({
+      text: formData.get('text') || '',
+      userId: formData.get('user_id'),
+      userName: formData.get('user_name'),
+    })
+
+    return NextResponse.json({
+      response_type: result.responseType,
+      text: result.text,
+    })
+  } catch (error) {
+    console.error('Error in Slack agent command:', error)
+    return NextResponse.json({
+      response_type: 'ephemeral',
+      text: 'An error occurred processing the Agent Ops command. Check the Portfolio logs and try again.',
+    })
+  }
+}
+
+function verifySlackSignature(request: NextRequest, rawBody: string) {
+  const signingSecret = process.env.SLACK_SIGNING_SECRET
+  if (!signingSecret) {
+    console.warn('SLACK_SIGNING_SECRET not configured -- skipping verification')
+    return true
+  }
+
+  const timestamp = request.headers.get('x-slack-request-timestamp')
+  const signature = request.headers.get('x-slack-signature')
+  if (!timestamp || !signature) return false
+
+  const timestampSeconds = Number(timestamp)
+  if (!Number.isFinite(timestampSeconds)) return false
+
+  const now = Math.floor(Date.now() / 1000)
+  if (Math.abs(now - timestampSeconds) > 300) return false
+
+  const basestring = `v0:${timestamp}:${rawBody}`
+  const expectedSignature = `v0=${createHmac('sha256', signingSecret).update(basestring).digest('hex')}`
+  const expected = Buffer.from(expectedSignature)
+  const actual = Buffer.from(signature)
+
+  if (expected.length !== actual.length) return false
+  return timingSafeEqual(expected, actual)
+}

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -164,6 +164,21 @@ The n8n import artifact lives at `n8n-exports/WF-AGENT-OPS-MORNING-REVIEW.json`.
 - `AMADUTOWN_PUBLIC_BASE_URL=https://amadutown.com`
 - `N8N_INGEST_SECRET=<same bearer secret configured in Portfolio>`
 
+## Slack Agent Command
+
+Configure the Slack slash command `/agent` to call `POST /api/slack/agent`. The production request URL is:
+
+- `https://amadutown.com/api/slack/agent`
+
+The route verifies Slack signatures with `SLACK_SIGNING_SECRET` when configured and returns ephemeral responses. Supported commands:
+
+- `/agent status` — active runs, failed/stale counts, pending approvals, and cost-event activity.
+- `/agent failed` — latest failed or stale agent runs with links back to Agent Operations.
+- `/agent approvals` — pending approval checkpoints with run links.
+- `/agent morning-review` — runs the approved Agent Ops morning review path with `trigger_source = slack_agent_ops_command`.
+
+Slack is an engagement surface, not the source of truth. The admin console and shared trace tables remain authoritative.
+
 ## Safety Rules
 
 - New agent work should create an `agent_run` before doing meaningful work.

--- a/lib/agent-slack-command.test.ts
+++ b/lib/agent-slack-command.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: null,
+}))
+
+vi.mock('@/lib/agent-ops-morning-review', () => ({
+  runAgentOpsMorningReview: vi.fn(),
+}))
+
+import { agentSlackCommandInternals } from '@/lib/agent-slack-command'
+
+describe('agent Slack command parsing', () => {
+  it('maps supported aliases to command handlers', () => {
+    expect(agentSlackCommandInternals.commandFromText('status')).toBe('status')
+    expect(agentSlackCommandInternals.commandFromText('failed')).toBe('failed')
+    expect(agentSlackCommandInternals.commandFromText('failures')).toBe('failed')
+    expect(agentSlackCommandInternals.commandFromText('approval')).toBe('approvals')
+    expect(agentSlackCommandInternals.commandFromText('approvals')).toBe('approvals')
+    expect(agentSlackCommandInternals.commandFromText('morning-review')).toBe('morning-review')
+    expect(agentSlackCommandInternals.commandFromText('morning')).toBe('morning-review')
+  })
+
+  it('falls back to help for empty or unknown commands', () => {
+    expect(agentSlackCommandInternals.commandFromText('')).toBe('help')
+    expect(agentSlackCommandInternals.commandFromText('unknown')).toBe('help')
+    expect(agentSlackCommandInternals.formatHelp()).toContain('/agent status')
+  })
+})

--- a/lib/agent-slack-command.ts
+++ b/lib/agent-slack-command.ts
@@ -1,0 +1,238 @@
+import { runAgentOpsMorningReview } from '@/lib/agent-ops-morning-review'
+import { supabaseAdmin } from '@/lib/supabase'
+
+type SlackCommandName = 'help' | 'status' | 'failed' | 'approvals' | 'morning-review'
+
+export type AgentSlackCommandInput = {
+  text: string
+  userId?: string | null
+  userName?: string | null
+}
+
+export type AgentSlackCommandResult = {
+  responseType: 'ephemeral'
+  text: string
+}
+
+type CountQueryResult = {
+  count: number | null
+  error: { message: string } | null
+}
+
+type AgentRunRow = {
+  id: string
+  title: string
+  runtime: string
+  status: string
+  subject_label: string | null
+  current_step: string | null
+  error_message: string | null
+  started_at: string
+}
+
+type AgentApprovalRow = {
+  id: string
+  run_id: string
+  approval_type: string
+  status: string
+  requested_at: string
+}
+
+function baseUrl() {
+  return (
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    process.env.PORTFOLIO_BASE_URL ||
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    'https://amadutown.com'
+  ).replace(/\/$/, '')
+}
+
+function agentRunsUrl(runId?: string) {
+  return `${baseUrl()}/admin/agents/runs${runId ? `/${runId}` : ''}`
+}
+
+function since24h() {
+  return new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+}
+
+function commandFromText(text: string): SlackCommandName {
+  const [command] = text.trim().toLowerCase().split(/\s+/)
+  if (!command || command === 'help') return 'help'
+  if (command === 'status') return 'status'
+  if (command === 'failed' || command === 'failures') return 'failed'
+  if (command === 'approval' || command === 'approvals') return 'approvals'
+  if (command === 'morning-review' || command === 'morning' || command === 'review') return 'morning-review'
+  return 'help'
+}
+
+function formatHelp() {
+  return [
+    '*Agent Ops commands*',
+    '`/agent status` - active runs, recent failures, pending approvals, and cost events.',
+    '`/agent failed` - latest failed or stale runs.',
+    '`/agent approvals` - pending approval checkpoints.',
+    '`/agent morning-review` - run the approved Agent Ops morning review trace.',
+  ].join('\n')
+}
+
+function formatDbUnavailable() {
+  return 'Agent Ops database is not available in this environment. Check Portfolio server env vars before using Slack commands.'
+}
+
+async function countRows(query: PromiseLike<CountQueryResult>) {
+  const { count, error } = await query
+  if (error) throw new Error(error.message)
+  return count ?? 0
+}
+
+export async function buildAgentStatusSlackText() {
+  if (!supabaseAdmin) return formatDbUnavailable()
+
+  try {
+    const since = since24h()
+    const [activeRuns, failedRuns, staleRuns, pendingApprovals, costEvents] = await Promise.all([
+      countRows(
+        supabaseAdmin
+          .from('agent_runs')
+          .select('id', { count: 'exact', head: true })
+          .in('status', ['queued', 'running', 'waiting_for_approval']),
+      ),
+      countRows(
+        supabaseAdmin
+          .from('agent_runs')
+          .select('id', { count: 'exact', head: true })
+          .eq('status', 'failed')
+          .gte('started_at', since),
+      ),
+      countRows(
+        supabaseAdmin
+          .from('agent_runs')
+          .select('id', { count: 'exact', head: true })
+          .eq('status', 'stale')
+          .gte('started_at', since),
+      ),
+      countRows(
+        supabaseAdmin
+          .from('agent_approvals')
+          .select('id', { count: 'exact', head: true })
+          .eq('status', 'pending'),
+      ),
+      countRows(
+        supabaseAdmin
+          .from('cost_events')
+          .select('id', { count: 'exact', head: true })
+          .gte('occurred_at', since),
+      ),
+    ])
+
+    return [
+      '*Agent Ops status*',
+      `Active runs: ${activeRuns}`,
+      `Failed runs, last 24h: ${failedRuns}`,
+      `Stale runs, last 24h: ${staleRuns}`,
+      `Pending approvals: ${pendingApprovals}`,
+      `Cost events, last 24h: ${costEvents}`,
+      `Review: ${agentRunsUrl()}`,
+    ].join('\n')
+  } catch (error) {
+    return `Agent Ops status check failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+  }
+}
+
+function formatRunLine(run: AgentRunRow) {
+  const subject = run.subject_label ? ` - ${run.subject_label}` : ''
+  const step = run.current_step ? ` (${run.current_step})` : ''
+  const error = run.error_message ? `: ${run.error_message}` : ''
+  return `- <${agentRunsUrl(run.id)}|${run.title}> [${run.runtime}/${run.status}]${subject}${step}${error}`
+}
+
+export async function buildFailedRunsSlackText(limit = 5) {
+  if (!supabaseAdmin) return formatDbUnavailable()
+
+  const { data, error } = await supabaseAdmin
+    .from('agent_runs')
+    .select('id, title, runtime, status, subject_label, current_step, error_message, started_at')
+    .in('status', ['failed', 'stale'])
+    .order('started_at', { ascending: false })
+    .limit(limit)
+
+  if (error) return `Failed run lookup failed: ${error.message}`
+
+  const runs = (data || []) as AgentRunRow[]
+  if (runs.length === 0) return `No failed or stale agent runs found. Review: ${agentRunsUrl()}`
+
+  return ['*Latest failed or stale agent runs*', ...runs.map(formatRunLine)].join('\n')
+}
+
+export async function buildApprovalsSlackText(limit = 5) {
+  if (!supabaseAdmin) return formatDbUnavailable()
+
+  const { data: approvals, error } = await supabaseAdmin
+    .from('agent_approvals')
+    .select('id, run_id, approval_type, status, requested_at')
+    .eq('status', 'pending')
+    .order('requested_at', { ascending: false })
+    .limit(limit)
+
+  if (error) return `Approval lookup failed: ${error.message}`
+
+  const pending = (approvals || []) as AgentApprovalRow[]
+  if (pending.length === 0) return `No pending agent approvals. Review: ${agentRunsUrl()}`
+
+  const runIds = pending.map((approval) => approval.run_id)
+  const { data: runs, error: runsError } = await supabaseAdmin
+    .from('agent_runs')
+    .select('id, title, runtime, status, subject_label, current_step, error_message, started_at')
+    .in('id', runIds)
+
+  if (runsError) return `Approval run lookup failed: ${runsError.message}`
+
+  const typedRuns = (runs || []) as AgentRunRow[]
+  const runsById = new Map(typedRuns.map((run) => [run.id, run]))
+  const lines = pending.map((approval) => {
+    const run = runsById.get(approval.run_id)
+    const title = run?.title ?? approval.run_id
+    const runtime = run ? ` [${run.runtime}/${run.status}]` : ''
+    return `- <${agentRunsUrl(approval.run_id)}|${title}>${runtime}: ${approval.approval_type}`
+  })
+
+  return ['*Pending agent approvals*', ...lines].join('\n')
+}
+
+export async function runMorningReviewSlackText(input: AgentSlackCommandInput) {
+  try {
+    const result = await runAgentOpsMorningReview('slack_agent_ops_command')
+    const actor = input.userName || input.userId || 'Slack user'
+    return [
+      '*Agent Ops morning review complete*',
+      `Triggered by: ${actor}`,
+      `Overall: ${result.overall}`,
+      `Stale marked: ${result.staleSweep.marked}`,
+      `Slack notification: ${result.slackNotified ? 'sent' : 'skipped'}`,
+      `Review: ${agentRunsUrl(result.runId)}`,
+    ].join('\n')
+  } catch (error) {
+    return `Agent Ops morning review failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+  }
+}
+
+export async function handleAgentSlackCommand(input: AgentSlackCommandInput): Promise<AgentSlackCommandResult> {
+  const command = commandFromText(input.text)
+  const text =
+    command === 'status'
+      ? await buildAgentStatusSlackText()
+      : command === 'failed'
+        ? await buildFailedRunsSlackText()
+        : command === 'approvals'
+          ? await buildApprovalsSlackText()
+          : command === 'morning-review'
+            ? await runMorningReviewSlackText(input)
+            : formatHelp()
+
+  return { responseType: 'ephemeral', text }
+}
+
+export const agentSlackCommandInternals = {
+  commandFromText,
+  formatHelp,
+}


### PR DESCRIPTION
## Summary
- add /api/slack/agent slash-command endpoint with Slack signature verification
- add Agent Ops command helpers for status, failed runs, pending approvals, and morning review
- document the /agent command setup and update the admin engagement copy

## Validation
- npm test -- lib/agent-slack-command.test.ts app/api/slack/agent/route.test.ts
- npx tsc --noEmit --pretty false
- npm run build