### PR TITLE
docs: capture AmaduTown email DNS state

### DIFF
--- a/docs/amadutown-email-domain-runbook.md
+++ b/docs/amadutown-email-domain-runbook.md
@@ -31,15 +31,37 @@ AmaduTown uses a phased hybrid email migration:
    - every alias routes to the expected mailbox
    - SPF, DKIM, and DMARC pass in a received-message header test
 
+Current setup state:
+
+- Google Workspace user `vambah@amadutown.com` is active.
+- Google Admin Console shows `hello@amadutown.com`, `clients@amadutown.com`, `billing@amadutown.com`, and `automation@amadutown.com` as alternate email aliases for the primary user.
+- Google Workspace confirmed the domain verification code, Gmail activation, and DKIM code entry.
+- Live send/receive and header inspection remain manual QA gates before client-facing cutover.
+
 ### Cloudflare DNS Records
 
-Based on Google Workspace Admin Help, new Workspace setups can use the single Google MX record:
+Manual verification was used for setup. Do not use automatic registrar/DNS authorization unless a later operator explicitly approves it.
 
-| Type | Name | Priority | Value |
-| --- | --- | --- | --- |
-| `MX` | `@` | `1` | `smtp.google.com` |
+Current Cloudflare records:
 
-Add SPF, DKIM, and DMARC TXT records from the Google Admin setup flow. DKIM values are generated per Workspace tenant, so do not hard-code them before the Google Admin console provides the selector/value.
+| Type | Name | Priority | Value | Purpose |
+| --- | --- | --- | --- | --- |
+| `TXT` | `@` | n/a | `google-site-verification=...` | Manual Google Workspace domain verification |
+| `MX` | `@` | `1` | `smtp.google.com` | Google Workspace Gmail routing |
+| `TXT` | `@` | n/a | `v=spf1 include:_spf.google.com ~all` | SPF authorization for Google mail |
+| `TXT` | `google._domainkey` | n/a | Google Workspace generated DKIM public key | DKIM signing for Workspace mail |
+| `TXT` | `_dmarc` | n/a | `v=DMARC1; p=none; rua=mailto:vambah@amadutown.com` | DMARC monitoring policy |
+
+Public DNS checks should return:
+
+```bash
+dig MX amadutown.com +short
+dig TXT amadutown.com +short
+dig TXT google._domainkey.amadutown.com +short
+dig TXT _dmarc.amadutown.com +short
+```
+
+Do not paste the full DKIM value into shared notes unless a DNS repair requires it. It is not a password, but it is noisy and should be read from Cloudflare or Google Admin when needed.
 
 ## Phase 2: Portfolio Environment
 

--- a/docs/amadutown-email-migration-inventory.md
+++ b/docs/amadutown-email-migration-inventory.md
@@ -6,22 +6,27 @@ This inventory supports the phased `amadutown.com` email rollout. It is intentio
 
 | Area | Status | Next Action |
 | --- | --- | --- |
-| Portfolio code | Ready in PR #81 | Merge after review, then set env vars in Vercel |
-| Vercel previews | Passing for `portfolio` and `portfolio-staging` | Verify post-merge production deployments |
-| Google Workspace | External setup required | Create Workspace user and aliases for `amadutown.com` |
+| Portfolio code | Merged via PR #81 | Set business email env vars in Vercel and keep transport credentials unchanged until cutover |
+| Vercel checks | Passing for `portfolio` and `portfolio-staging` on PR #81 | Re-verify after env var changes |
+| Google Workspace | Active for `vambah@amadutown.com` | Run live send/receive and header tests before client-facing cutover |
+| Domain DNS | Manual Cloudflare DNS configured and publicly visible | Monitor propagation, bounces, and SPF/DKIM/DMARC results from received-message headers |
+| Aliases | Created for `hello@`, `clients@`, `billing@`, and `automation@` | Confirm each alias receives mail and routes to the expected inbox/label |
 | n8n Cloud credentials | External setup required | Reconnect selected Gmail credentials to Workspace mailbox |
 | SaaS login migration | Inventory started | Update only business-critical accounts first |
 
 ## Domain DNS Snapshot
 
-Checked on 2026-05-01:
+Manual verification snapshot:
 
 | Record Type | Observed Value | Meaning |
 | --- | --- | --- |
 | Availability | `amadutown.com` is not available for purchase | Domain likely already owned or reserved |
 | Nameservers | `bailey.ns.cloudflare.com`, `zod.ns.cloudflare.com` | DNS is managed through Cloudflare |
-| MX | no record returned | Google Workspace mail routing still needs MX records |
-| TXT | no record returned | SPF/DKIM/DMARC still need to be configured |
+| MX | `1 smtp.google.com.` | Google Workspace Gmail routing is present |
+| TXT root | `v=spf1 include:_spf.google.com ~all` | SPF authorizes Google Workspace mail |
+| TXT root | `google-site-verification=...` | Google Workspace domain verification is present |
+| TXT `google._domainkey` | `v=DKIM1;k=rsa;p=...` | Google Workspace DKIM public key is present |
+| TXT `_dmarc` | `v=DMARC1; p=none; rua=mailto:vambah@amadutown.com` | DMARC monitoring is active before enforcement |
 
 ## Portfolio Environment Variables
 


### PR DESCRIPTION
## Summary
- update the AmaduTown email domain runbook with the current Google Workspace and Cloudflare DNS state
- update the migration inventory now that Workspace, aliases, MX, SPF, DKIM, and DMARC monitoring are in place
- keep full DKIM and secret material out of shared docs while preserving the verification path

## Validation
- git diff --check origin/main...HEAD
- dig MX amadutown.com +short
- dig TXT amadutown.com +short
- dig TXT google._domainkey.amadutown.com +short
- dig TXT _dmarc.amadutown.com +short

No DNS or hosted configuration was changed by this PR; it documents the observed state.