### PR TITLE
Hardening client AI ops roadmap operations

### DIFF
--- a/app/api/cron/client-ai-ops-monitor/route.test.ts
+++ b/app/api/cron/client-ai-ops-monitor/route.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  from: vi.fn(),
+  refreshRoadmapPhaseRollups: vi.fn(),
+  projectRoadmapTaskToMeetingTask: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+vi.mock('@/lib/client-ai-ops-roadmap-db', () => ({
+  refreshRoadmapPhaseRollups: mocks.refreshRoadmapPhaseRollups,
+  projectRoadmapTaskToMeetingTask: mocks.projectRoadmapTaskToMeetingTask,
+}))
+
+import { GET, POST } from './route'
+
+function request(method: 'GET' | 'POST', token?: string) {
+  return new Request('http://localhost/api/cron/client-ai-ops-monitor', {
+    method,
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+  })
+}
+
+function roadmapQuery(data: unknown[]) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    not: vi.fn().mockResolvedValue({ data, error: null }),
+  }
+}
+
+describe('client AI Ops monitor cron route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.N8N_INGEST_SECRET = 'n8n-secret'
+    process.env.CRON_SECRET = 'cron-secret'
+    mocks.from.mockReturnValue(roadmapQuery([]))
+  })
+
+  it('rejects requests without an accepted cron token', async () => {
+    const response = await POST(request('POST', 'wrong') as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.from).not.toHaveBeenCalled()
+  })
+
+  it('accepts Vercel cron GET requests authenticated with CRON_SECRET', async () => {
+    const response = await GET(request('GET', 'cron-secret') as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      ok: true,
+      checked: 0,
+      reports_created: 0,
+      followup_tasks_created: 0,
+    })
+    expect(mocks.from).toHaveBeenCalledWith('client_ai_ops_roadmaps')
+  })
+
+  it('keeps the n8n POST trigger path working', async () => {
+    const response = await POST(request('POST', 'n8n-secret') as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({ ok: true, checked: 0 })
+  })
+})

--- a/app/api/cron/client-ai-ops-monitor/route.ts
+++ b/app/api/cron/client-ai-ops-monitor/route.ts
@@ -1,15 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
-import { refreshRoadmapPhaseRollups } from '@/lib/client-ai-ops-roadmap-db'
+import {
+  projectRoadmapTaskToMeetingTask,
+  refreshRoadmapPhaseRollups,
+} from '@/lib/client-ai-ops-roadmap-db'
 
 export const dynamic = 'force-dynamic'
 
 type MonitorTaskRow = { id: string; title: string; status: string; due_date: string | null }
 type MonitorCostRow = { id: string; pricing_state: string; last_checked_at: string | null; label: string }
 
-export async function POST(request: NextRequest) {
-  const token = request.headers.get('authorization')?.replace('Bearer ', '')
-  if (!process.env.N8N_INGEST_SECRET || token !== process.env.N8N_INGEST_SECRET) {
+function isAuthorizedCronRequest(request: NextRequest): boolean {
+  const token = request.headers.get('authorization')?.replace(/^Bearer\s+/i, '')
+  const allowedTokens = [process.env.CRON_SECRET, process.env.N8N_INGEST_SECRET].filter(Boolean)
+  return Boolean(token && allowedTokens.includes(token))
+}
+
+async function runMonitor(request: NextRequest) {
+  if (!isAuthorizedCronRequest(request)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -96,7 +104,18 @@ export async function POST(request: NextRequest) {
         .eq('task_key', followupKey)
         .maybeSingle()
 
-      if (!existingFollowup) {
+      if (existingFollowup?.id) {
+        await projectRoadmapTaskToMeetingTask(roadmap.client_project_id, {
+          ...existingFollowup,
+          meeting_task_visible: true,
+          owner_type: 'amadutown',
+          priority: 'high',
+          status: 'pending',
+          title: 'Review AI Ops monitoring findings',
+          description: 'Review overdue tasks, stale pricing, missing reports, or open monitoring findings from the daily AI Ops monitor.',
+          due_date: null,
+        })
+      } else {
         const { data: firstPhase } = await supabaseAdmin
           .from('client_ai_ops_roadmap_phases')
           .select('id')
@@ -122,9 +141,12 @@ export async function POST(request: NextRequest) {
               cost_category: 'monitoring',
               metadata: { monitoring_summary: monitoringSummary },
             })
-            .select('id')
+            .select('*')
             .single()
-          if (task?.id) createdTasks.push(task.id)
+          if (task?.id) {
+            await projectRoadmapTaskToMeetingTask(roadmap.client_project_id, task)
+            createdTasks.push(task.id)
+          }
         }
       }
     }
@@ -136,4 +158,12 @@ export async function POST(request: NextRequest) {
     reports_created: createdReports.length,
     followup_tasks_created: createdTasks.length,
   })
+}
+
+export async function GET(request: NextRequest) {
+  return runMonitor(request)
+}
+
+export async function POST(request: NextRequest) {
+  return runMonitor(request)
 }

--- a/docs/client-ai-ops-roadmap-sop.md
+++ b/docs/client-ai-ops-roadmap-sop.md
@@ -1,0 +1,79 @@
+# Client AI Ops Roadmap SOP
+
+This is the operating guide for selling, implementing, monitoring, and improving client-owned AI Ops stacks.
+
+## Operating Principles
+
+- The client owns the hardware, accounts, credentials, project data, and production approvals.
+- AmaduTown access is named, revocable, and limited to startup, maintenance, monitoring, and approved changes.
+- Proposal roadmap snapshots are fixed at send time. Later registry or pricing changes become upgrade recommendations, not silent proposal edits.
+- Production technology swaps require approval before implementation.
+- Smoke-test records stay available until a manual cleanup pass is approved. Do not reuse real client records for tests without approval.
+
+## Sales Stage
+
+1. Start from the sales or proposal context and generate the Implementation Roadmap & Startup Costs panel.
+2. Review all phase tasks, startup costs, monthly operating costs, setup labor, and client responsibilities.
+3. Refresh any technology registry item marked `needs_review`, `stale`, `quote_required`, or `source_unavailable` before sending a proposal.
+4. Edit the roadmap estimate when the client has known constraints such as Mac-only, Windows-only, on-prem only, limited budget, or existing MDM/VPN tooling.
+5. Attach the roadmap snapshot to the proposal only after costs and assumptions are clear enough for the client to understand the real startup burden.
+
+## Delivery Stage
+
+1. When a proposal is accepted or a client project is created, create the project roadmap if it does not already exist.
+2. Project client-visible responsibilities into Client Dashboard tasks.
+3. Project AmaduTown delivery tasks into Meeting Tasks.
+4. Confirm each task has a phase, owner, due date when available, status, and source badge.
+5. Keep internal traces, private logs, admin-only notes, credentials, and agent execution details out of the client dashboard.
+
+## Monitoring Stage
+
+The daily monitor runs through `/api/cron/client-ai-ops-monitor`.
+
+- Vercel production cron uses `GET` with `Authorization: Bearer <CRON_SECRET>`.
+- n8n/manual triggers can still use `POST` with `Authorization: Bearer <N8N_INGEST_SECRET>`.
+- The monitor checks active and approved roadmaps for overdue tasks, stale pricing, missing reports, and open monitoring findings.
+- When findings exist, the monitor creates a roadmap report and an internal follow-up roadmap task.
+- Monitoring follow-up tasks are also projected into Meeting Tasks so the admin work queue shows the issue immediately.
+
+## Technology Registry
+
+The first registry seed is intentionally conservative. Pricing snapshots start as `needs_review` because live vendor pricing must be checked near the proposal date.
+
+Use the registry to compare:
+
+- cost and pricing freshness,
+- stack fit,
+- spin-up speed,
+- integration complexity,
+- governance and security fit,
+- monitoring support,
+- data ownership fit,
+- rollback burden.
+
+Better-scoring alternatives should create upgrade recommendations. They should not trigger automatic production swaps.
+
+## Monthly Reporting
+
+Monthly reports should separate:
+
+- client action,
+- AmaduTown action,
+- approval needed,
+- cost movement,
+- stale pricing,
+- blocker status,
+- monitoring findings,
+- upgrade recommendations.
+
+Client-facing summaries should be understandable and avoid exposing private logs, agent traces, credentials, or internal-only notes.
+
+## Real Client Pilot Checklist
+
+- Select one low-risk client project with a clear owner and known tech stack.
+- Refresh registry pricing for only the tools proposed for that client.
+- Generate the sales roadmap and confirm startup/monthly costs with the client.
+- Create the project roadmap after acceptance.
+- Verify Client Dashboard tasks and Meeting Tasks match the same source roadmap.
+- Run the monitor once and confirm any findings become internal Meeting Tasks.
+- Generate the first monthly report and review it before sending.

--- a/lib/client-ai-ops-roadmap-db.ts
+++ b/lib/client-ai-ops-roadmap-db.ts
@@ -271,39 +271,51 @@ export async function projectRoadmapTasks(clientProjectId: string): Promise<{ da
       }
     }
 
-    if (task.meeting_task_visible) {
-      const { data: existing } = await db
-        .from('meeting_action_tasks')
-        .select('id')
-        .eq('roadmap_task_id', roadmapTaskId)
-        .maybeSingle()
-
-      if (!existing) {
-        const { data, error } = await db
-          .from('meeting_action_tasks')
-          .insert({
-            meeting_record_id: null,
-            client_project_id: clientProjectId,
-            roadmap_task_id: roadmapTaskId,
-            title: task.title,
-            description: task.description,
-            owner: task.owner_type === 'client' ? 'Client' : 'AmaduTown',
-            due_date: task.due_date ?? null,
-            status: meetingTaskStatusFromRoadmap(task.status as RoadmapTaskStatus),
-            task_category: 'internal',
-            display_order: 0,
-          })
-          .select('id')
-          .single()
-
-        if (error) throw new Error(`Failed to create meeting roadmap task: ${error.message}`)
-        await db.from('client_ai_ops_roadmap_tasks').update({ meeting_action_task_id: data.id }).eq('id', roadmapTaskId)
-        meetingCreated += 1
-      }
-    }
+    const meetingTaskId = await projectRoadmapTaskToMeetingTask(clientProjectId, task)
+    if (meetingTaskId) meetingCreated += 1
   }
 
   return { dashboardCreated, meetingCreated }
+}
+
+export async function projectRoadmapTaskToMeetingTask(clientProjectId: string, task: JsonRecord): Promise<string | null> {
+  const db = requireDb()
+  const roadmapTaskId = task.id as string | undefined
+  if (!roadmapTaskId || !task.meeting_task_visible) return null
+
+  const { data: existing } = await db
+    .from('meeting_action_tasks')
+    .select('id')
+    .eq('roadmap_task_id', roadmapTaskId)
+    .maybeSingle()
+
+  if (existing?.id) {
+    if (!task.meeting_action_task_id) {
+      await db.from('client_ai_ops_roadmap_tasks').update({ meeting_action_task_id: existing.id }).eq('id', roadmapTaskId)
+    }
+    return null
+  }
+
+  const { data, error } = await db
+    .from('meeting_action_tasks')
+    .insert({
+      meeting_record_id: null,
+      client_project_id: clientProjectId,
+      roadmap_task_id: roadmapTaskId,
+      title: task.title,
+      description: task.description,
+      owner: task.owner_type === 'client' ? 'Client' : 'AmaduTown',
+      due_date: task.due_date ?? null,
+      status: meetingTaskStatusFromRoadmap(task.status as RoadmapTaskStatus),
+      task_category: 'internal',
+      display_order: 0,
+    })
+    .select('id')
+    .single()
+
+  if (error) throw new Error(`Failed to create meeting roadmap task: ${error.message}`)
+  await db.from('client_ai_ops_roadmap_tasks').update({ meeting_action_task_id: data.id }).eq('id', roadmapTaskId)
+  return data.id as string
 }
 
 export async function syncRoadmapTaskFromProjection(source: 'dashboard' | 'meeting', taskId: string, status: string): Promise<void> {

--- a/supabase/migrations/20260502040509_seed_client_ai_ops_technology_registry.sql
+++ b/supabase/migrations/20260502040509_seed_client_ai_ops_technology_registry.sql
@@ -1,0 +1,123 @@
+-- Seed the first AI Ops technology registry baseline.
+--
+-- These rows intentionally avoid claiming live pricing. Operators must refresh
+-- pricing before attaching recommendations to a proposal.
+
+WITH seed_options (
+  vendor,
+  product_name,
+  category,
+  best_fit,
+  avoid_when,
+  source_url,
+  pricing_model,
+  setup_complexity,
+  integration_complexity,
+  data_ownership_fit,
+  monitoring_support,
+  security_notes
+) AS (
+  VALUES
+    ('Apple', 'Mac mini', 'hardware', 'Mac-first clients that need a compact always-on local AI Ops node.', 'Client requires Windows-only management tooling or rack-mounted server hardware.', 'https://www.apple.com/mac-mini/', 'one_time', 'low', 'low', 'local', 'medium', 'Client-owned hardware; pair with MDM, disk encryption, and remote access controls.'),
+    ('Dell', 'OptiPlex Micro', 'hardware', 'PC-first clients that need a compact always-on Windows or Linux node.', 'Client needs GPU-heavy local inference or Mac-only workflows.', 'https://www.dell.com/en-us/shop/desktop-computers/sr/desktops/optiplex-desktops', 'one_time', 'low', 'low', 'local', 'medium', 'Client-owned hardware; pair with endpoint management, disk encryption, and remote access controls.'),
+    ('1Password', 'Business', 'credential_vault', 'Client teams that need shared vaults, role-based access, and contractor handoff controls.', 'Client cannot approve per-user SaaS spend or requires fully self-hosted credential storage.', 'https://1password.com/business', 'per_user', 'low', 'medium', 'hybrid', 'high', 'Use client-owned workspace; AmaduTown access should be named, time-bound, and revocable.'),
+    ('Bitwarden', 'Teams or Enterprise', 'credential_vault', 'Budget-sensitive teams that still need shared vaults and administrative controls.', 'Client requires the richer governance workflows of a higher-touch enterprise suite.', 'https://bitwarden.com/business/', 'per_user', 'low', 'medium', 'hybrid', 'high', 'Use client-owned organization; require named accounts and emergency access policy.'),
+    ('Tailscale', 'Business VPN', 'access_networking', 'Fast private access to client-owned nodes without exposing services publicly.', 'Client policy requires an existing VPN, dedicated firewall appliance, or no mesh network.', 'https://tailscale.com/business-vpn', 'per_user', 'low', 'medium', 'hybrid', 'high', 'Use device approval, ACLs, and client-owned admin control.'),
+    ('Cloudflare', 'Zero Trust', 'access_networking', 'Clients that need identity-aware access, browser isolation, DNS filtering, or policy controls.', 'Very small clients need the lowest-friction setup and have no Cloudflare footprint.', 'https://www.cloudflare.com/zero-trust/', 'per_user', 'medium', 'medium', 'hybrid', 'high', 'Use approval-based access policies and keep production service changes approval-gated.'),
+    ('Jamf', 'Jamf Now', 'identity_mdm', 'Mac-first small teams that need lightweight device management.', 'Client fleet is primarily Windows or already managed through Microsoft 365.', 'https://www.jamf.com/products/jamf-now/', 'monthly', 'low', 'medium', 'hybrid', 'medium', 'Use client-owned Jamf tenant; require offboarding and lost-device procedures.'),
+    ('Microsoft', 'Intune', 'identity_mdm', 'Microsoft 365 clients that need Windows, Mac, and mobile endpoint management.', 'Client does not use Microsoft identity or needs a lighter small-business setup.', 'https://www.microsoft.com/security/business/microsoft-intune', 'per_user', 'medium', 'medium', 'hybrid', 'high', 'Use client tenant and enforce conditional access with staged rollout.'),
+    ('Ollama', 'Local model runtime', 'ai_runtime', 'Local-first prototype inference on client-owned hardware.', 'Client requires managed uptime SLAs, hosted model routing, or centralized enterprise controls.', 'https://ollama.com/', 'unknown', 'low', 'medium', 'local', 'medium', 'Keep model and prompt logs local; benchmark before using in production workflows.'),
+    ('OpenAI', 'API Platform', 'ai_runtime', 'Managed model access when quality, tool calling, and latency matter more than local-only execution.', 'Client data policy forbids external model APIs or requires isolated self-hosted inference.', 'https://platform.openai.com/', 'usage_based', 'low', 'medium', 'cloud', 'high', 'Use client-owned API/account when possible; document data handling and approval boundaries.'),
+    ('Supabase', 'Postgres and Vector', 'vector_database', 'Project data, task state, vector search, and admin dashboards that need fast spin-up.', 'Client requires all database services to run on-premises.', 'https://supabase.com/', 'monthly', 'medium', 'medium', 'hybrid', 'high', 'Use RLS, service-role isolation, backups, and client-owned project where feasible.'),
+    ('n8n', 'Cloud', 'automation', 'Workflow automation that benefits from managed hosting and fast iteration.', 'Client policy requires all automation execution on local infrastructure.', 'https://n8n.io/cloud/', 'monthly', 'low', 'medium', 'cloud', 'high', 'Keep secrets in client-owned credentials; avoid silent production mutations.'),
+    ('Sentry', 'Application Monitoring', 'monitoring', 'Application error tracking and performance monitoring for deployed client-facing tools.', 'Client cannot approve third-party telemetry or needs only local logs.', 'https://sentry.io/', 'monthly', 'low', 'medium', 'cloud', 'high', 'Scrub sensitive payloads; document retention and client access.'),
+    ('Backblaze', 'B2 Cloud Storage', 'backup', 'Low-cost offsite backups for client-owned exports and artifacts.', 'Client requires backup storage only inside its physical premises.', 'https://www.backblaze.com/cloud-storage', 'usage_based', 'medium', 'medium', 'cloud', 'medium', 'Encrypt before upload when storing sensitive client data; client owns account and keys.')
+)
+INSERT INTO client_ai_ops_technology_options (
+  vendor,
+  product_name,
+  category,
+  best_fit,
+  avoid_when,
+  source_url,
+  pricing_model,
+  setup_complexity,
+  integration_complexity,
+  data_ownership_fit,
+  monitoring_support,
+  security_notes
+)
+SELECT
+  vendor,
+  product_name,
+  category,
+  best_fit,
+  avoid_when,
+  source_url,
+  pricing_model,
+  setup_complexity,
+  integration_complexity,
+  data_ownership_fit,
+  monitoring_support,
+  security_notes
+FROM seed_options
+ON CONFLICT (vendor, product_name) DO UPDATE SET
+  category = EXCLUDED.category,
+  best_fit = EXCLUDED.best_fit,
+  avoid_when = EXCLUDED.avoid_when,
+  source_url = EXCLUDED.source_url,
+  pricing_model = EXCLUDED.pricing_model,
+  setup_complexity = EXCLUDED.setup_complexity,
+  integration_complexity = EXCLUDED.integration_complexity,
+  data_ownership_fit = EXCLUDED.data_ownership_fit,
+  monitoring_support = EXCLUDED.monitoring_support,
+  security_notes = EXCLUDED.security_notes,
+  active = true,
+  updated_at = now();
+
+WITH snapshot_seed (vendor, product_name, pricing_state, billing_period, notes) AS (
+  VALUES
+    ('Apple', 'Mac mini', 'needs_review', 'one_time', 'Initial registry seed. Refresh live pricing before proposal use.'),
+    ('Dell', 'OptiPlex Micro', 'needs_review', 'one_time', 'Initial registry seed. Refresh live pricing before proposal use.'),
+    ('1Password', 'Business', 'needs_review', 'monthly', 'Initial registry seed. Refresh live pricing before proposal use.'),
+    ('Bitwarden', 'Teams or Enterprise', 'needs_review', 'monthly', 'Initial registry seed. Refresh live pricing before proposal use.'),
+    ('Tailscale', 'Business VPN', 'needs_review', 'monthly', 'Initial registry seed. Refresh live pricing before proposal use.'),
+    ('Cloudflare', 'Zero Trust', 'needs_review', 'monthly', 'Initial registry seed. Refresh live pricing before proposal use.'),
+    ('Jamf', 'Jamf Now', 'needs_review', 'monthly', 'Initial registry seed. Refresh live pricing before proposal use.'),
+    ('Microsoft', 'Intune', 'needs_review', 'monthly', 'Initial registry seed. Refresh live pricing before proposal use.'),
+    ('Ollama', 'Local model runtime', 'needs_review', NULL, 'Initial registry seed. Validate runtime fit and hardware requirements before proposal use.'),
+    ('OpenAI', 'API Platform', 'needs_review', 'usage_based', 'Initial registry seed. Refresh live pricing and data-handling assumptions before proposal use.'),
+    ('Supabase', 'Postgres and Vector', 'needs_review', 'monthly', 'Initial registry seed. Refresh live pricing and plan limits before proposal use.'),
+    ('n8n', 'Cloud', 'needs_review', 'monthly', 'Initial registry seed. Refresh live pricing and execution limits before proposal use.'),
+    ('Sentry', 'Application Monitoring', 'needs_review', 'monthly', 'Initial registry seed. Refresh live pricing and telemetry limits before proposal use.'),
+    ('Backblaze', 'B2 Cloud Storage', 'needs_review', 'usage_based', 'Initial registry seed. Refresh live pricing and storage assumptions before proposal use.')
+)
+INSERT INTO client_ai_ops_technology_price_snapshots (
+  technology_option_id,
+  pricing_state,
+  amount_low,
+  amount_high,
+  currency,
+  billing_period,
+  source_url,
+  notes
+)
+SELECT
+  option.id,
+  seed.pricing_state,
+  NULL,
+  NULL,
+  'USD',
+  seed.billing_period,
+  option.source_url,
+  seed.notes
+FROM snapshot_seed seed
+JOIN client_ai_ops_technology_options option
+  ON option.vendor = seed.vendor
+ AND option.product_name = seed.product_name
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM client_ai_ops_technology_price_snapshots existing
+  WHERE existing.technology_option_id = option.id
+    AND existing.notes = seed.notes
+);

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/client-ai-ops-monitor",
+      "schedule": "0 13 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Vercel-compatible daily cron config and allow the AI Ops monitor to authenticate with CRON_SECRET while preserving the existing N8N_INGEST_SECRET POST path
- project monitoring follow-up roadmap tasks into Meeting Tasks immediately so admin tracking does not lag behind cron findings
- add a conservative technology registry seed migration and an operator SOP for sales, delivery, monitoring, pricing refresh, and pilot rollout

## Validation
- npm test -- app/api/cron/client-ai-ops-monitor/route.test.ts lib/client-ai-ops-roadmap.test.ts lib/client-ai-ops-technology-registry.test.ts
- npx tsc --noEmit --pretty false
- npm run build

## Notes
- Smoke-test data was intentionally left in place.
- The new registry migration was not applied out of band. The currently linked Supabase project responds through the CLI, but it does not yet have the AI Ops registry tables, so the seed is left for migration review/deployment.
- Vercel contexts need CRON_SECRET configured before the scheduled cron can authenticate in production.