### PR TITLE
fix: acknowledge Slack agent commands immediately

### DIFF
--- a/app/api/slack/agent/route.test.ts
+++ b/app/api/slack/agent/route.test.ts
@@ -32,6 +32,12 @@ function signedRequest(body: URLSearchParams, secret = 'test-slack-secret') {
 describe('POST /api/slack/agent', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+      }),
+    )
     process.env = { ...ORIGINAL_ENV, SLACK_SIGNING_SECRET: 'test-slack-secret' }
     mocks.handleAgentSlackCommand.mockResolvedValue({
       responseType: 'ephemeral',
@@ -40,6 +46,7 @@ describe('POST /api/slack/agent', () => {
   })
 
   afterEach(() => {
+    vi.unstubAllGlobals()
     process.env = ORIGINAL_ENV
   })
 
@@ -90,5 +97,42 @@ describe('POST /api/slack/agent', () => {
       userId: 'U123',
       userName: 'vambah',
     })
+  })
+
+  it('acknowledges Slack immediately and posts detailed command output through response_url', async () => {
+    const request = signedRequest(
+      new URLSearchParams({
+        text: 'status',
+        user_id: 'U123',
+        user_name: 'vambah',
+        response_url: 'https://hooks.slack.com/commands/test-response',
+      }),
+    )
+
+    const response = await POST(request as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      response_type: 'ephemeral',
+      text: 'Agent Ops received `/agent status`. I am preparing the result now.',
+    })
+    await vi.waitFor(() => {
+      expect(mocks.handleAgentSlackCommand).toHaveBeenCalledWith({
+        text: 'status',
+        userId: 'U123',
+        userName: 'vambah',
+      })
+    })
+    expect(fetch).toHaveBeenCalledWith(
+      'https://hooks.slack.com/commands/test-response',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          response_type: 'ephemeral',
+          replace_original: false,
+          text: 'Agent Ops status',
+        }),
+      }),
+    )
   })
 })

--- a/app/api/slack/agent/route.ts
+++ b/app/api/slack/agent/route.ts
@@ -1,6 +1,5 @@
 import { createHmac, timingSafeEqual } from 'crypto'
 import { NextRequest, NextResponse } from 'next/server'
-import { handleAgentSlackCommand } from '@/lib/agent-slack-command'
 
 export const dynamic = 'force-dynamic'
 
@@ -17,11 +16,24 @@ export async function POST(request: NextRequest) {
     }
 
     const formData = new URLSearchParams(rawBody)
-    const result = await handleAgentSlackCommand({
+    const input = {
       text: formData.get('text') || '',
       userId: formData.get('user_id'),
       userName: formData.get('user_name'),
-    })
+    }
+    const responseUrl = formData.get('response_url')
+
+    if (responseUrl) {
+      void postDelayedAgentResponse(responseUrl, input)
+
+      return NextResponse.json({
+        response_type: 'ephemeral',
+        text: `Agent Ops received \`/agent ${input.text || 'help'}\`. I am preparing the result now.`,
+      })
+    }
+
+    const { handleAgentSlackCommand } = await import('@/lib/agent-slack-command')
+    const result = await handleAgentSlackCommand(input)
 
     return NextResponse.json({
       response_type: result.responseType,
@@ -33,6 +45,36 @@ export async function POST(request: NextRequest) {
       response_type: 'ephemeral',
       text: 'An error occurred processing the Agent Ops command. Check the Portfolio logs and try again.',
     })
+  }
+}
+
+async function postDelayedAgentResponse(
+  responseUrl: string,
+  input: { text: string; userId?: string | null; userName?: string | null },
+) {
+  try {
+    const { handleAgentSlackCommand } = await import('@/lib/agent-slack-command')
+    const result = await handleAgentSlackCommand(input)
+    await fetch(responseUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        response_type: result.responseType,
+        replace_original: false,
+        text: result.text,
+      }),
+    })
+  } catch (error) {
+    console.error('Error posting delayed Slack agent command response:', error)
+    await fetch(responseUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        response_type: 'ephemeral',
+        replace_original: false,
+        text: 'Agent Ops command started, but the delayed result failed. Check Portfolio logs and /admin/agents/runs.',
+      }),
+    }).catch(() => {})
   }
 }
 


### PR DESCRIPTION
## Summary
- acknowledge Slack /agent requests immediately when Slack provides response_url
- post detailed command results back to Slack through response_url asynchronously
- lazy-load the Agent Ops command handler for faster slash-command response path

## Validation
- npm test -- app/api/slack/agent/route.test.ts lib/agent-slack-command.test.ts
- npm run build:knowledge && npx tsc --noEmit --pretty false
- npm run build

## Context
Slack accepted /agent but reported the app did not respond. This keeps Slack inside its slash-command response window while the Agent Ops status work completes separately.