### PR TITLE
fix: return Slack agent status within response window

### DIFF
--- a/app/api/slack/agent/route.test.ts
+++ b/app/api/slack/agent/route.test.ts
@@ -3,10 +3,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   handleAgentSlackCommand: vi.fn(),
+  waitUntil: vi.fn(),
 }))
 
 vi.mock('@/lib/agent-slack-command', () => ({
   handleAgentSlackCommand: mocks.handleAgentSlackCommand,
+}))
+
+vi.mock('@vercel/functions', () => ({
+  waitUntil: mocks.waitUntil,
 }))
 
 import { POST } from './route'
@@ -46,6 +51,7 @@ describe('POST /api/slack/agent', () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     vi.unstubAllGlobals()
     process.env = ORIGINAL_ENV
   })
@@ -99,7 +105,7 @@ describe('POST /api/slack/agent', () => {
     })
   })
 
-  it('acknowledges Slack immediately and posts detailed command output through response_url', async () => {
+  it('returns detailed command output directly when it completes inside Slack response window', async () => {
     const request = signedRequest(
       new URLSearchParams({
         text: 'status',
@@ -114,15 +120,51 @@ describe('POST /api/slack/agent', () => {
     expect(response.status).toBe(200)
     expect(await response.json()).toEqual({
       response_type: 'ephemeral',
+      text: 'Agent Ops status',
+    })
+    expect(mocks.handleAgentSlackCommand).toHaveBeenCalledWith({
+      text: 'status',
+      userId: 'U123',
+      userName: 'vambah',
+    })
+    expect(fetch).not.toHaveBeenCalled()
+    expect(mocks.waitUntil).not.toHaveBeenCalled()
+  })
+
+  it('acknowledges Slack before the timeout and schedules delayed delivery when command work is slow', async () => {
+    vi.useFakeTimers()
+    mocks.handleAgentSlackCommand.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => resolve({ responseType: 'ephemeral', text: 'Slow status' }), 3000)
+        }),
+    )
+
+    const request = signedRequest(
+      new URLSearchParams({
+        text: 'status',
+        user_id: 'U123',
+        user_name: 'vambah',
+        response_url: 'https://hooks.slack.com/commands/test-response',
+      }),
+    )
+
+    const responsePromise = POST(request as never)
+    await vi.advanceTimersByTimeAsync(2500)
+    const response = await responsePromise
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      response_type: 'ephemeral',
       text: 'Agent Ops received `/agent status`. I am preparing the result now.',
     })
-    await vi.waitFor(() => {
-      expect(mocks.handleAgentSlackCommand).toHaveBeenCalledWith({
-        text: 'status',
-        userId: 'U123',
-        userName: 'vambah',
-      })
-    })
+
+    expect(mocks.waitUntil).toHaveBeenCalledTimes(1)
+    const delayedPromise = mocks.waitUntil.mock.calls[0]?.[0] as Promise<unknown>
+
+    await vi.advanceTimersByTimeAsync(500)
+    await delayedPromise
+
     expect(fetch).toHaveBeenCalledWith(
       'https://hooks.slack.com/commands/test-response',
       expect.objectContaining({
@@ -130,7 +172,7 @@ describe('POST /api/slack/agent', () => {
         body: JSON.stringify({
           response_type: 'ephemeral',
           replace_original: false,
-          text: 'Agent Ops status',
+          text: 'Slow status',
         }),
       }),
     )

--- a/app/api/slack/agent/route.ts
+++ b/app/api/slack/agent/route.ts
@@ -1,5 +1,6 @@
 import { createHmac, timingSafeEqual } from 'crypto'
 import { NextRequest, NextResponse } from 'next/server'
+import { waitUntil } from '@vercel/functions'
 
 export const dynamic = 'force-dynamic'
 
@@ -22,9 +23,18 @@ export async function POST(request: NextRequest) {
       userName: formData.get('user_name'),
     }
     const responseUrl = formData.get('response_url')
+    const commandResult = runAgentCommand(input)
 
     if (responseUrl) {
-      void postDelayedAgentResponse(responseUrl, input)
+      const result = await withTimeout(commandResult, 2500)
+      if (result) {
+        return NextResponse.json({
+          response_type: result.responseType,
+          text: result.text,
+        })
+      }
+
+      waitUntil(postDelayedAgentResponse(responseUrl, commandResult))
 
       return NextResponse.json({
         response_type: 'ephemeral',
@@ -32,8 +42,7 @@ export async function POST(request: NextRequest) {
       })
     }
 
-    const { handleAgentSlackCommand } = await import('@/lib/agent-slack-command')
-    const result = await handleAgentSlackCommand(input)
+    const result = await commandResult
 
     return NextResponse.json({
       response_type: result.responseType,
@@ -48,13 +57,34 @@ export async function POST(request: NextRequest) {
   }
 }
 
-async function postDelayedAgentResponse(
-  responseUrl: string,
+async function runAgentCommand(
   input: { text: string; userId?: string | null; userName?: string | null },
 ) {
+  const { handleAgentSlackCommand } = await import('@/lib/agent-slack-command')
+  return handleAgentSlackCommand(input)
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T | null> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => resolve(null), timeoutMs)
+    promise
+      .then((value) => {
+        clearTimeout(timer)
+        resolve(value)
+      })
+      .catch((error) => {
+        clearTimeout(timer)
+        reject(error)
+      })
+  })
+}
+
+async function postDelayedAgentResponse(
+  responseUrl: string,
+  commandResult: Promise<{ responseType: string; text: string }>,
+) {
   try {
-    const { handleAgentSlackCommand } = await import('@/lib/agent-slack-command')
-    const result = await handleAgentSlackCommand(input)
+    const result = await commandResult
     await fetch(responseUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@stripe/stripe-js": "^2.2.0",
         "@supabase/supabase-js": "^2.89.0",
         "@vapi-ai/web": "^2.5.2",
+        "@vercel/functions": "^3.5.0",
         "@vercel/speed-insights": "^1.3.1",
         "clsx": "^2.1.1",
         "diff": "^8.0.3",
@@ -4112,6 +4113,35 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@vercel/functions": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-3.5.0.tgz",
+      "integrity": "sha512-+RokZ+4gkYyOsKBuJ29cQ8iSZG123LLJbZfPry20kkTgrN9U0277La4feP4DnWVo3sGoYa4plCEKY9XKUYoX9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "3.4.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-web-identity": "*"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-web-identity": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.4.0.tgz",
+      "integrity": "sha512-p0sKfHkfRmMaqqDwNL4tjnX9TgRrLMlEtUjIxfrEns8pOxz1R9ztqOVI+ehqiq93/2/HnfPe/UBZkfAZwnx0UA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/@vercel/speed-insights": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@stripe/stripe-js": "^2.2.0",
     "@supabase/supabase-js": "^2.89.0",
     "@vapi-ai/web": "^2.5.2",
+    "@vercel/functions": "^3.5.0",
     "@vercel/speed-insights": "^1.3.1",
     "clsx": "^2.1.1",
     "diff": "^8.0.3",


### PR DESCRIPTION
## Summary
- return fast Agent Ops command results directly in the initial Slack slash-command response
- keep a timeout fallback acknowledgement for slower command work
- use Vercel waitUntil to reliably deliver slow command results through Slack response_url
- update route tests for both fast direct responses and slow delayed delivery

## Validation
- npm test -- app/api/slack/agent/route.test.ts lib/agent-slack-command.test.ts
- npm run build:knowledge && npx tsc --noEmit --pretty false
- npm run build