### PR TITLE
docs: add agent coordination pack

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,11 @@ This directory contains comprehensive documentation for the my-portfolio project
 
 - **[Admin/Sales Lead Pipeline SOP](./admin-sales-lead-pipeline-sop.md)** - Single source of truth for new admin and sales associates: lead pipeline (trigger, ingest, enrichment, outreach, review, send), inbound leads (contact form, chat, diagnostic, voice/VAPI), sales and proposals, configuring products/bundles/scripts, pricing research, post-sale lifecycle (payment, client projects, onboarding, milestones), follow-up sequences, workflow reference, and other admin tools.
 
+### Agent Coordination
+
+- **[Agent Roles](./agents/README.md)** - Role instructions for parallel Codex, Cursor, Hermes, and other agent chats working in Portfolio.
+- **[Integration Captain Queue](./integration-captain-queue.md)** - Shared queue for PR handoffs, merge readiness, Vercel verification, and blocked work.
+
 ### Source-respecting AI
 
 - **[Source-Respecting LLM Protocol](./source-respecting-llm-protocol.md)** - Open nonprofit protocol blueprint for banned/challenged authors, Black history archives, creator permissions, cited answers, source-use receipts, and payout simulation.

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -1,0 +1,29 @@
+# Agent Roles
+
+Use these role files when multiple Codex, Cursor, Hermes, or other agent chats are working in Portfolio at the same time.
+
+The goal is simple: workers can keep moving, but only one integration captain merges to `origin/main`.
+
+## Required Flow
+
+1. Pick the role that matches the chat's job.
+2. Read that role file before editing.
+3. Work on a named branch.
+4. Commit only scoped files.
+5. Push the branch.
+6. Open a PR if the work is ready for review.
+7. Add a handoff entry to `docs/integration-captain-queue.md`.
+8. Stop before merging unless the chat is explicitly acting as integration captain.
+
+## Roles
+
+| Role | File | Use When |
+| --- | --- | --- |
+| Integration Captain | `docs/agents/integration-captain.md` | Sequencing PRs, resolving conflicts, merging, and verifying Vercel |
+| PR Worker | `docs/agents/pr-worker.md` | Building a scoped feature/fix and handing it off |
+| Vercel Verifier | `docs/agents/vercel-verifier.md` | Checking preview or post-merge deployment health |
+| Slack Agent Reviewer | `docs/agents/slack-agent-reviewer.md` | Reviewing Slack command behavior before merge |
+
+## Standing Rule
+
+If multiple chats are active, treat the shared checkout as user-owned. Do not assume dirty files belong to the current chat.

--- a/docs/agents/integration-captain.md
+++ b/docs/agents/integration-captain.md
@@ -1,0 +1,75 @@
+# Integration Captain
+
+The integration captain is the only role that merges parallel Portfolio work into `origin/main`.
+
+## Authority
+
+You may:
+
+- inspect open PRs and remote branches
+- fetch and prune remotes
+- rebase or update branches when needed
+- resolve conflicts
+- merge ready PRs
+- verify Vercel after every merge
+- clean up merged branches and stale worktrees
+
+You must not:
+
+- merge draft PRs
+- merge branches with unresolved product/security questions
+- merge around pending or failed required Vercel contexts
+- include unrelated dirty files in an integration commit
+- delete recovery stashes unless Vambah explicitly approves it
+
+## Start Checklist
+
+Run these before acting:
+
+```bash
+git fetch --prune origin
+git status --short --branch
+gh pr list --state open --json number,title,headRefName,isDraft,mergeStateStatus,updatedAt,url,statusCheckRollup
+git worktree list
+git stash list --max-count=8
+```
+
+Confirm:
+
+- which branch the shared checkout is on
+- whether the checkout has dirty files
+- whether `main` equals `origin/main`
+- which PRs are ready, draft, blocked, or stale
+- whether any worker handoffs in `docs/integration-captain-queue.md` need action
+
+## Merge Gate
+
+Before merging a PR:
+
+- PR is not draft.
+- PR has a clear purpose and scoped file set.
+- Required validation is documented in the PR or handoff.
+- `Vercel - portfolio` preview is success.
+- `Vercel - portfolio-staging` preview is success.
+- Security-sensitive changes have a clear approval or fail-closed posture.
+- Production config, secrets, external sends, publishing, and database writes have explicit approval when required.
+
+After merging:
+
+1. Fetch `origin/main`.
+2. Fast-forward local `main`.
+3. Wait for both post-merge Vercel contexts:
+   - `Vercel - portfolio`
+   - `Vercel - portfolio-staging`
+4. Do not process the next merge until both are success or a real blocker is recorded.
+
+## Handoff Update
+
+After each processed PR, update `docs/integration-captain-queue.md` with:
+
+- status: merged, blocked, deferred, or needs owner input
+- merge commit if merged
+- Vercel result
+- any follow-up owner
+
+If the queue file itself has unrelated edits from another chat, do not overwrite them. Add your note below the relevant entry or report the conflict.

--- a/docs/agents/pr-worker.md
+++ b/docs/agents/pr-worker.md
@@ -1,0 +1,52 @@
+# PR Worker
+
+Use this role for a single scoped feature, fix, test, or documentation update.
+
+## Rules
+
+- Work on a named branch.
+- Keep the file set narrow.
+- Do not merge to `main`.
+- Do not push directly to `origin/main`.
+- Do not modify another chat's dirty files unless your task requires it and you understand the overlap.
+- If you touch production behavior, add focused validation.
+- If you touch security, approvals, Slack commands, email sending, payments, secrets, database writes, or public publishing, call out the risk clearly in the handoff.
+
+## Start Checklist
+
+```bash
+git fetch --prune origin
+git status --short --branch
+git log -1 --oneline --decorate
+```
+
+If the checkout is dirty before you start, identify whether the files belong to your task. If they do not, pause and either switch to a clean worktree/branch or ask the integration captain.
+
+## Before Handoff
+
+Run validation appropriate to the change:
+
+- docs-only: `git diff --check`
+- TypeScript/code: focused tests plus `npx tsc --noEmit --pretty false`
+- UI/admin changes: focused test or manual route check where practical
+- Vercel-sensitive changes: wait for preview checks after PR creation
+
+## Required Handoff
+
+Add or paste this into `docs/integration-captain-queue.md`:
+
+```md
+### PR Worker Handoff
+
+- Branch:
+- PR:
+- Purpose:
+- Changed files:
+- Validation run:
+- Known risks:
+- Requires approval before merge: yes/no
+- Safe to merge after checks: yes/no
+- Notes for integration captain:
+```
+
+Stop after pushing/opening the PR unless Vambah explicitly changes your role to integration captain.

--- a/docs/agents/slack-agent-reviewer.md
+++ b/docs/agents/slack-agent-reviewer.md
@@ -1,0 +1,43 @@
+# Slack Agent Reviewer
+
+Use this role before merging changes to Slack slash commands, Slack webhooks, Slack sync, or Agent Ops Slack behavior.
+
+## Review Priorities
+
+Check these before merge:
+
+- Slack request signatures fail closed outside local development.
+- Slash commands answer inside Slack's response window.
+- Slow work has an explicit user-visible path.
+- The route does not rely on frozen Vercel background work for critical delivery.
+- Command behavior is documented in tests.
+- Errors are visible to the user or recorded in Agent Ops.
+
+## Current Decision Standard
+
+For `/api/slack/agent`, prefer this behavior:
+
+- Fast command result: return directly in the initial Slack response.
+- Slow command result: use a reliable delivery path. Acceptable v1 paths are Vercel `waitUntil` posting to Slack `response_url`, or creating/referencing an `agent_run` and returning a run/status link or ID.
+
+Avoid the middle state where Slack receives an acknowledgement but the final result has no reliable delivery path.
+
+## Required Tests
+
+Slack route changes should usually test:
+
+- invalid signature is rejected
+- missing signing secret is rejected outside local development
+- valid slash command dispatches expected text/user context
+- fast result returns directly
+- slow result returns a truthful status/run response
+- any delayed delivery path is exercised if it exists
+
+## Handoff Note
+
+When reviewing a Slack PR, explicitly say whether the behavior is:
+
+- sync-only
+- durable async
+- hybrid with run/status handoff
+- unsafe/ambiguous

--- a/docs/agents/vercel-verifier.md
+++ b/docs/agents/vercel-verifier.md
@@ -1,0 +1,39 @@
+# Vercel Verifier
+
+Use this role when a chat is only checking deployment status.
+
+## Required Contexts
+
+Portfolio uses two Vercel contexts as merge and post-merge gates:
+
+- `Vercel - portfolio`
+- `Vercel - portfolio-staging`
+
+Both must pass before a ready PR is merged. Both must pass again after the merge lands on `main`.
+
+## Commands
+
+For PR checks:
+
+```bash
+gh pr checks <number>
+gh pr view <number> --json number,isDraft,mergeStateStatus,statusCheckRollup,url
+```
+
+For `main` status:
+
+```bash
+gh api repos/:owner/:repo/commits/main/status --jq '.state as $state | "combined_state=\($state)", (.statuses[] | [.context,.state,.target_url,.updated_at] | @tsv)'
+```
+
+## Reporting
+
+Report:
+
+- PR number or `main`
+- each Vercel context and state
+- target URL
+- timestamp
+- whether the result is merge-ready, post-merge verified, pending, failed, or blocked
+
+Do not call a deployment complete while either required context is pending.

--- a/docs/integration-captain-queue.md
+++ b/docs/integration-captain-queue.md
@@ -1,0 +1,96 @@
+# Integration Captain Queue
+
+This is the shared coordination surface for parallel Portfolio agent work.
+
+Every worker chat should add a handoff here or paste the same structure into the PR. The integration captain uses this file to sequence PRs, avoid duplicate merges, and preserve unresolved risks.
+
+## Operating Rules
+
+- Non-captain chats do not merge.
+- Draft PRs stay unmerged.
+- Required Vercel contexts must pass before and after merge.
+- Production config, secret, external-send, publishing, payment, and broad database changes require explicit approval.
+- If a PR changes a hot surface already being patched by another PR, mark it as overlap and wait for captain review.
+
+## Active Watch Items
+
+### Slack Agent Command Behavior
+
+- Current state: resolved in PR #92 and deployed to both Vercel contexts.
+- Standard: fast results return directly in Slack; slow results must use a reliable delivery path such as Vercel `waitUntil` for Slack `response_url` delivery or a durable `agent_run` link.
+- Watch item: future Slack command changes still need reviewer coverage because `/api/slack/agent` is a hot operations surface.
+- Role to apply: `docs/agents/slack-agent-reviewer.md`.
+
+### Source Protocol Database Verification
+
+- Git/deploy state: merged.
+- Remaining verification: source-protocol DB seed/API smoke after Supabase CLI auth and `SUPABASE_DB_PASSWORD` are correctly set.
+- Treat this as database verification, not a Git integration blocker.
+
+## Queue
+
+### Template
+
+```md
+### <PR or Branch Name>
+
+- Branch:
+- PR:
+- Owner/chat:
+- Purpose:
+- Changed files:
+- Validation run:
+- Vercel preview:
+- Known risks:
+- Requires approval before merge:
+- Safe to merge after checks:
+- Captain status:
+- Notes:
+```
+
+### PR #92 - Slack Agent Sync Status
+
+- Branch: `codex/slack-agent-sync-status`
+- PR: #92
+- Owner/chat: Slack agent command workstream
+- Purpose: Return Slack agent status inside the initial Slack response window.
+- Changed files:
+  - `app/api/slack/agent/route.ts`
+  - `app/api/slack/agent/route.test.ts`
+- Validation run: tests, typecheck, build, Vercel preview, post-merge Vercel production/staging, and live Slack smoke.
+- Vercel preview: passed for `portfolio` and `portfolio-staging`; post-merge deployments also passed.
+- Known risks: resolved by adding Vercel `waitUntil` delayed delivery for slow Slack commands.
+- Requires approval before merge: resolved.
+- Safe to merge after checks: merged.
+- Captain status: complete.
+- Notes: Live `/agent status` smoke returned Agent Ops status in `#agent-ops`.
+
+### Draft PR #91 - Client AI Ops Monitor Coverage
+
+- Branch: `cursor/regression-test-coverage-165f`
+- PR: #91
+- Owner/chat: Cursor coverage workstream
+- Purpose: Test coverage for client AI ops monitor findings.
+- Changed files: see PR.
+- Validation run: see PR.
+- Vercel preview: passed at last captain review.
+- Known risks: draft PR.
+- Requires approval before merge: no extra approval known, but draft status blocks merge.
+- Safe to merge after checks: no while draft.
+- Captain status: defer.
+- Notes: Worker should mark ready and provide handoff before captain processes.
+
+### Draft PR #75 - Agent Guardrails Coverage
+
+- Branch: `cursor/missing-test-coverage-e44f`
+- PR: #75
+- Owner/chat: Cursor coverage workstream
+- Purpose: Test coverage for agent guardrails and approval status.
+- Changed files: see PR.
+- Validation run: see PR.
+- Vercel preview: stale but previously passed.
+- Known risks: draft PR and old base.
+- Requires approval before merge: no extra approval known, but draft status blocks merge.
+- Safe to merge after checks: no while draft.
+- Captain status: defer.
+- Notes: Rebase/update before any future merge consideration.


### PR DESCRIPTION
## Summary
- add durable agent role docs for integration captain, PR worker, Vercel verifier, and Slack agent reviewer
- add a shared integration captain queue with current watch items and PR handoff templates
- link the coordination docs from the docs index

## Validation
- git diff --check

This is docs-only. No runtime behavior changes.