### PR TITLE
feat: add Slack agent engagement commands

### DIFF
--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -176,6 +176,8 @@ The route verifies Slack signatures with `SLACK_SIGNING_SECRET` when configured 
 - `/agent failed` — latest failed or stale agent runs with links back to Agent Operations.
 - `/agent approvals` — pending approval checkpoints with run links.
 - `/agent morning-review` — runs the approved Agent Ops morning review path with `trigger_source = slack_agent_ops_command`.
+- `/agent agents` — lists active and partial agent organization entries with their engagement keys.
+- `/agent run <agent-key>` — creates a traceable `manual` runtime engagement request in `agent_runs` without mutating production workflow data.
 
 Slack is an engagement surface, not the source of truth. The admin console and shared trace tables remain authoritative.
 

--- a/lib/agent-organization.ts
+++ b/lib/agent-organization.ts
@@ -331,6 +331,10 @@ export function getAgentsForPod(podKey: AgentPodKey) {
   return AGENT_ORGANIZATION.filter((agent) => agent.podKey === podKey)
 }
 
+export function getAgentByKey(agentKey: string) {
+  return AGENT_ORGANIZATION.find((agent) => agent.key === agentKey)
+}
+
 export function getAgentOrganizationSummary() {
   return AGENT_PODS.map((pod) => {
     const agents = getAgentsForPod(pod.key)

--- a/lib/agent-slack-command.test.ts
+++ b/lib/agent-slack-command.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/lib/supabase', () => ({
   supabaseAdmin: null,
@@ -8,9 +8,23 @@ vi.mock('@/lib/agent-ops-morning-review', () => ({
   runAgentOpsMorningReview: vi.fn(),
 }))
 
-import { agentSlackCommandInternals } from '@/lib/agent-slack-command'
+const agentRunMocks = vi.hoisted(() => ({
+  startAgentRun: vi.fn(),
+  recordAgentEvent: vi.fn(),
+}))
+
+vi.mock('@/lib/agent-run', () => ({
+  startAgentRun: agentRunMocks.startAgentRun,
+  recordAgentEvent: agentRunMocks.recordAgentEvent,
+}))
+
+import { agentSlackCommandInternals, createAgentEngagementSlackText } from '@/lib/agent-slack-command'
 
 describe('agent Slack command parsing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('maps supported aliases to command handlers', () => {
     expect(agentSlackCommandInternals.commandFromText('status')).toBe('status')
     expect(agentSlackCommandInternals.commandFromText('failed')).toBe('failed')
@@ -19,11 +33,59 @@ describe('agent Slack command parsing', () => {
     expect(agentSlackCommandInternals.commandFromText('approvals')).toBe('approvals')
     expect(agentSlackCommandInternals.commandFromText('morning-review')).toBe('morning-review')
     expect(agentSlackCommandInternals.commandFromText('morning')).toBe('morning-review')
+    expect(agentSlackCommandInternals.commandFromText('agents')).toBe('agents')
+    expect(agentSlackCommandInternals.commandFromText('list')).toBe('agents')
+    expect(agentSlackCommandInternals.commandFromText('run chief-of-staff')).toBe('run')
   })
 
   it('falls back to help for empty or unknown commands', () => {
     expect(agentSlackCommandInternals.commandFromText('')).toBe('help')
     expect(agentSlackCommandInternals.commandFromText('unknown')).toBe('help')
     expect(agentSlackCommandInternals.formatHelp()).toContain('/agent status')
+    expect(agentSlackCommandInternals.formatHelp()).toContain('/agent run <agent-key>')
+  })
+
+  it('formats the mapped agent list for Slack', () => {
+    const text = agentSlackCommandInternals.formatAgentListSlackText()
+
+    expect(text).toContain('Agent organization')
+    expect(text).toContain('chief-of-staff')
+    expect(text).toContain('automation-systems')
+    expect(text).toContain('/agent run <agent-key>')
+  })
+
+  it('creates a traceable engagement request for a known agent', async () => {
+    agentRunMocks.startAgentRun.mockResolvedValue({ id: 'run-123' })
+    agentRunMocks.recordAgentEvent.mockResolvedValue({ id: 'event-123' })
+
+    const text = await createAgentEngagementSlackText({
+      text: 'run chief-of-staff',
+      userId: 'U123',
+      userName: 'vambah',
+    })
+
+    expect(agentRunMocks.startAgentRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentKey: 'chief-of-staff',
+        runtime: 'manual',
+        kind: 'agent_engagement_request',
+        status: 'queued',
+      }),
+    )
+    expect(agentRunMocks.recordAgentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'run-123',
+        eventType: 'agent_engagement_requested',
+      }),
+    )
+    expect(text).toContain('Chief of Staff Agent engagement queued')
+    expect(text).toContain('/admin/agents/runs/run-123')
+  })
+
+  it('rejects unknown agent engagement keys', async () => {
+    const text = await createAgentEngagementSlackText({ text: 'run made-up-agent' })
+
+    expect(text).toContain('Unknown agent key')
+    expect(agentRunMocks.startAgentRun).not.toHaveBeenCalled()
   })
 })

--- a/lib/agent-slack-command.ts
+++ b/lib/agent-slack-command.ts
@@ -1,7 +1,9 @@
 import { runAgentOpsMorningReview } from '@/lib/agent-ops-morning-review'
+import { AGENT_ORGANIZATION, getAgentByKey } from '@/lib/agent-organization'
+import { startAgentRun, recordAgentEvent } from '@/lib/agent-run'
 import { supabaseAdmin } from '@/lib/supabase'
 
-type SlackCommandName = 'help' | 'status' | 'failed' | 'approvals' | 'morning-review'
+type SlackCommandName = 'help' | 'status' | 'failed' | 'approvals' | 'morning-review' | 'agents' | 'run'
 
 export type AgentSlackCommandInput = {
   text: string
@@ -62,7 +64,13 @@ function commandFromText(text: string): SlackCommandName {
   if (command === 'failed' || command === 'failures') return 'failed'
   if (command === 'approval' || command === 'approvals') return 'approvals'
   if (command === 'morning-review' || command === 'morning' || command === 'review') return 'morning-review'
+  if (command === 'agents' || command === 'list') return 'agents'
+  if (command === 'run' || command === 'start') return 'run'
   return 'help'
+}
+
+function commandArgs(text: string) {
+  return text.trim().split(/\s+/).slice(1)
 }
 
 function formatHelp() {
@@ -72,6 +80,8 @@ function formatHelp() {
     '`/agent failed` - latest failed or stale runs.',
     '`/agent approvals` - pending approval checkpoints.',
     '`/agent morning-review` - run the approved Agent Ops morning review trace.',
+    '`/agent agents` - list currently mapped agents and engagement keys.',
+    '`/agent run <agent-key>` - create a traceable engagement request for an agent.',
   ].join('\n')
 }
 
@@ -216,6 +226,82 @@ export async function runMorningReviewSlackText(input: AgentSlackCommandInput) {
   }
 }
 
+function formatAgentListSlackText() {
+  const active = AGENT_ORGANIZATION.filter((agent) => agent.status === 'active')
+  const partial = AGENT_ORGANIZATION.filter((agent) => agent.status === 'partial')
+  const plannedCount = AGENT_ORGANIZATION.filter((agent) => agent.status === 'planned').length
+  const lines = [...active, ...partial].map(
+    (agent) => `- \`${agent.key}\` - ${agent.name} [${agent.primaryRuntime}/${agent.status}]`,
+  )
+
+  return [
+    '*Agent organization*',
+    ...lines,
+    `Planned agents hidden from this quick list: ${plannedCount}`,
+    `Use \`/agent run <agent-key>\` to create a traceable engagement request.`,
+    `Review: ${baseUrl()}/admin/agents`,
+  ].join('\n')
+}
+
+export async function createAgentEngagementSlackText(input: AgentSlackCommandInput) {
+  const [agentKey] = commandArgs(input.text)
+  if (!agentKey) {
+    return [
+      'Missing agent key.',
+      'Use `/agent agents` to see available keys, then `/agent run <agent-key>`.',
+    ].join('\n')
+  }
+
+  const agent = getAgentByKey(agentKey)
+  if (!agent) {
+    return [
+      `Unknown agent key: \`${agentKey}\``,
+      'Use `/agent agents` to see available keys.',
+    ].join('\n')
+  }
+
+  try {
+    const actor = input.userName || input.userId || 'Slack user'
+    const run = await startAgentRun({
+      agentKey: agent.key,
+      runtime: 'manual',
+      kind: 'agent_engagement_request',
+      title: `Engage ${agent.name}`,
+      status: 'queued',
+      subject: { type: 'slack_command', id: input.userId ?? actor, label: actor },
+      triggerSource: 'slack_agent_run_command',
+      currentStep: 'Engagement request queued',
+      metadata: {
+        requested_agent: agent.key,
+        requested_agent_name: agent.name,
+        pod: agent.podKey,
+        primary_runtime: agent.primaryRuntime,
+        approval_gate: agent.approvalGate,
+        engagement_path: agent.engagementPath,
+      },
+    })
+
+    await recordAgentEvent({
+      runId: run.id,
+      eventType: 'agent_engagement_requested',
+      severity: 'info',
+      message: `${actor} requested ${agent.name} from Slack`,
+      metadata: { agent_key: agent.key, slack_user_id: input.userId ?? null, slack_user_name: input.userName ?? null },
+      idempotencyKey: `${run.id}:slack-requested`,
+    })
+
+    return [
+      `*${agent.name} engagement queued*`,
+      `Agent key: \`${agent.key}\``,
+      `Runtime path: ${agent.primaryRuntime}`,
+      `Current guardrail: ${agent.approvalGate}`,
+      `Review: ${agentRunsUrl(run.id)}`,
+    ].join('\n')
+  } catch (error) {
+    return `Agent engagement request failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+  }
+}
+
 export async function handleAgentSlackCommand(input: AgentSlackCommandInput): Promise<AgentSlackCommandResult> {
   const command = commandFromText(input.text)
   const text =
@@ -227,12 +313,18 @@ export async function handleAgentSlackCommand(input: AgentSlackCommandInput): Pr
           ? await buildApprovalsSlackText()
           : command === 'morning-review'
             ? await runMorningReviewSlackText(input)
-            : formatHelp()
+            : command === 'agents'
+              ? formatAgentListSlackText()
+              : command === 'run'
+                ? await createAgentEngagementSlackText(input)
+                : formatHelp()
 
   return { responseType: 'ephemeral', text }
 }
 
 export const agentSlackCommandInternals = {
   commandFromText,
+  commandArgs,
+  formatAgentListSlackText,
   formatHelp,
 }


### PR DESCRIPTION
## Summary
- add /agent agents to list active and partial agent organization entries
- add /agent run <agent-key> to create traceable manual engagement requests in agent_runs
- document the new Slack engagement commands in the agent operations rollout

## Safety
- /agent run only creates an Agent Ops trace row and event
- no production workflow mutation, publishing, outbound email, or n8n dispatch happens in this v1 path

## Validation
- npm test -- lib/agent-slack-command.test.ts app/api/slack/agent/route.test.ts
- npm run build:knowledge && npx tsc --noEmit --pretty false
- npm run build
- git push pre-push database health check