### PR TITLE
feat: add Vercel deployment watcher

### DIFF
--- a/docs/agents/vercel-verifier.md
+++ b/docs/agents/vercel-verifier.md
@@ -6,12 +6,25 @@ Use this role when a chat is only checking deployment status.
 
 Portfolio uses two Vercel contexts as merge and post-merge gates:
 
-- `Vercel - portfolio`
-- `Vercel - portfolio-staging`
+- `Vercel – portfolio`
+- `Vercel – portfolio-staging`
 
 Both must pass before a ready PR is merged. Both must pass again after the merge lands on `main`.
 
 ## Commands
+
+Autopilot watcher:
+
+```bash
+npm run deploy:watch -- --ref main
+npm run deploy:watch -- --ref <merge-sha> --timeout 900 --interval 30
+npm run deploy:watch:once -- --ref <pr-head-sha>
+```
+
+The watcher exits `0` when both required Vercel contexts pass, `1` when either
+context fails, and `2` when the contexts are still pending at timeout. Use the
+watcher as the default integration-captain gate before falling back to manual
+inspection.
 
 For PR checks:
 
@@ -37,3 +50,9 @@ Report:
 - whether the result is merge-ready, post-merge verified, pending, failed, or blocked
 
 Do not call a deployment complete while either required context is pending.
+
+## Pending Thresholds
+
+- Under 8 minutes: continue polling unless a context has failed.
+- 8-15 minutes: inspect the Vercel target URL or run `vercel ls <project> --scope vsillahs-projects`.
+- Over 15 minutes: treat as blocked until the deployment is inspected or re-run.

--- a/lib/vercel-deployment-watch.test.ts
+++ b/lib/vercel-deployment-watch.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatDeploymentWatchSummary,
+  parseDeploymentWatchArgs,
+  summarizeDeploymentStatus,
+} from './vercel-deployment-watch'
+
+describe('summarizeDeploymentStatus', () => {
+  it('marks the deployment successful when both Vercel contexts pass', () => {
+    const summary = summarizeDeploymentStatus({
+      state: 'success',
+      statuses: [
+        { context: 'Vercel – portfolio', state: 'success' },
+        { context: 'Vercel – portfolio-staging', state: 'success' },
+      ],
+    })
+
+    expect(summary.state).toBe('success')
+    expect(summary.pendingContexts).toHaveLength(0)
+    expect(summary.failedContexts).toHaveLength(0)
+  })
+
+  it('keeps the deployment pending when staging is still building', () => {
+    const summary = summarizeDeploymentStatus({
+      state: 'pending',
+      statuses: [
+        { context: 'Vercel – portfolio', state: 'success' },
+        {
+          context: 'Vercel – portfolio-staging',
+          state: 'pending',
+          description: 'Building',
+        },
+      ],
+    })
+
+    expect(summary.state).toBe('pending')
+    expect(summary.pendingContexts.map((status) => status.context)).toEqual([
+      'Vercel – portfolio-staging',
+    ])
+  })
+
+  it('marks missing contexts as pending instead of successful', () => {
+    const summary = summarizeDeploymentStatus({
+      state: 'success',
+      statuses: [{ context: 'Vercel – portfolio', state: 'success' }],
+    })
+
+    expect(summary.state).toBe('pending')
+    expect(summary.missingContexts).toEqual(['Vercel – portfolio-staging'])
+  })
+
+  it('marks failure or error states as failed', () => {
+    const summary = summarizeDeploymentStatus({
+      state: 'failure',
+      statuses: [
+        { context: 'Vercel – portfolio', state: 'success' },
+        { context: 'Vercel – portfolio-staging', state: 'error' },
+      ],
+    })
+
+    expect(summary.state).toBe('failed')
+    expect(summary.failedContexts.map((status) => status.context)).toEqual([
+      'Vercel – portfolio-staging',
+    ])
+  })
+})
+
+describe('parseDeploymentWatchArgs', () => {
+  it('uses Portfolio defaults', () => {
+    const options = parseDeploymentWatchArgs([])
+
+    expect(options.ref).toBe('main')
+    expect(options.owner).toBe('vsillah')
+    expect(options.repo).toBe('Portfolio')
+    expect(options.contexts).toEqual(['Vercel – portfolio', 'Vercel – portfolio-staging'])
+  })
+
+  it('parses ref, timing, and custom contexts', () => {
+    const options = parseDeploymentWatchArgs([
+      '--ref',
+      'abc123',
+      '--timeout',
+      '60',
+      '--interval',
+      '5',
+      '--contexts',
+      'A,B',
+      '--once',
+    ])
+
+    expect(options.ref).toBe('abc123')
+    expect(options.timeoutSeconds).toBe(60)
+    expect(options.intervalSeconds).toBe(5)
+    expect(options.contexts).toEqual(['A', 'B'])
+    expect(options.once).toBe(true)
+  })
+})
+
+describe('formatDeploymentWatchSummary', () => {
+  it('formats a concise terminal report', () => {
+    const summary = summarizeDeploymentStatus({
+      state: 'pending',
+      statuses: [
+        {
+          context: 'Vercel – portfolio',
+          state: 'success',
+          target_url: 'https://vercel.com/example',
+          updated_at: '2026-05-02T10:00:00Z',
+        },
+      ],
+    })
+
+    expect(formatDeploymentWatchSummary(summary)).toContain('deployment_state=pending')
+    expect(formatDeploymentWatchSummary(summary)).toContain('context="Vercel – portfolio"')
+    expect(formatDeploymentWatchSummary(summary)).toContain('url=https://vercel.com/example')
+  })
+})

--- a/lib/vercel-deployment-watch.ts
+++ b/lib/vercel-deployment-watch.ts
@@ -1,0 +1,198 @@
+export const DEFAULT_VERCEL_CONTEXTS = [
+  'Vercel – portfolio',
+  'Vercel – portfolio-staging',
+] as const
+
+export type DeploymentWatchState = 'success' | 'pending' | 'failed' | 'missing'
+
+export type GitHubCommitStatus = {
+  context: string
+  state: string
+  target_url?: string | null
+  description?: string | null
+  updated_at?: string | null
+}
+
+export type GitHubCombinedStatus = {
+  state: string
+  statuses?: GitHubCommitStatus[]
+}
+
+export type WatchedDeploymentContext = {
+  context: string
+  state: DeploymentWatchState
+  rawState?: string
+  targetUrl?: string
+  description?: string
+  updatedAt?: string
+}
+
+export type DeploymentWatchSummary = {
+  state: DeploymentWatchState
+  contexts: WatchedDeploymentContext[]
+  missingContexts: string[]
+  failedContexts: WatchedDeploymentContext[]
+  pendingContexts: WatchedDeploymentContext[]
+}
+
+export type DeploymentWatchOptions = {
+  ref: string
+  owner: string
+  repo: string
+  contexts: string[]
+  timeoutSeconds: number
+  intervalSeconds: number
+  once: boolean
+}
+
+const DEFAULT_OPTIONS: DeploymentWatchOptions = {
+  ref: 'main',
+  owner: 'vsillah',
+  repo: 'Portfolio',
+  contexts: [...DEFAULT_VERCEL_CONTEXTS],
+  timeoutSeconds: 900,
+  intervalSeconds: 30,
+  once: false,
+}
+
+function normalizeState(state: string | undefined): DeploymentWatchState {
+  if (state === 'success') return 'success'
+  if (state === 'failure' || state === 'error' || state === 'cancelled') return 'failed'
+  if (state === 'pending') return 'pending'
+  return 'pending'
+}
+
+function latestStatusByContext(statuses: GitHubCommitStatus[]): Map<string, GitHubCommitStatus> {
+  const byContext = new Map<string, GitHubCommitStatus>()
+
+  for (const status of statuses) {
+    const current = byContext.get(status.context)
+    const currentTime = current?.updated_at ? Date.parse(current.updated_at) : 0
+    const nextTime = status.updated_at ? Date.parse(status.updated_at) : 0
+
+    if (!current || nextTime >= currentTime) {
+      byContext.set(status.context, status)
+    }
+  }
+
+  return byContext
+}
+
+export function summarizeDeploymentStatus(
+  combinedStatus: GitHubCombinedStatus,
+  contexts: string[] = [...DEFAULT_VERCEL_CONTEXTS]
+): DeploymentWatchSummary {
+  const byContext = latestStatusByContext(combinedStatus.statuses ?? [])
+
+  const watchedContexts = contexts.map((context) => {
+    const status = byContext.get(context)
+
+    if (!status) {
+      return {
+        context,
+        state: 'missing' as const,
+      }
+    }
+
+    return {
+      context,
+      state: normalizeState(status.state),
+      rawState: status.state,
+      targetUrl: status.target_url ?? undefined,
+      description: status.description ?? undefined,
+      updatedAt: status.updated_at ?? undefined,
+    }
+  })
+
+  const missingContexts = watchedContexts
+    .filter((status) => status.state === 'missing')
+    .map((status) => status.context)
+  const failedContexts = watchedContexts.filter((status) => status.state === 'failed')
+  const pendingContexts = watchedContexts.filter(
+    (status) => status.state === 'pending' || status.state === 'missing'
+  )
+
+  let state: DeploymentWatchState = 'success'
+  if (failedContexts.length > 0) state = 'failed'
+  else if (pendingContexts.length > 0) state = 'pending'
+
+  return {
+    state,
+    contexts: watchedContexts,
+    missingContexts,
+    failedContexts,
+    pendingContexts,
+  }
+}
+
+export function parseDeploymentWatchArgs(argv: string[]): DeploymentWatchOptions {
+  const options: DeploymentWatchOptions = {
+    ...DEFAULT_OPTIONS,
+    contexts: [...DEFAULT_OPTIONS.contexts],
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    const next = argv[index + 1]
+
+    if (arg === '--ref' && next) {
+      options.ref = next
+      index += 1
+    } else if (arg === '--owner' && next) {
+      options.owner = next
+      index += 1
+    } else if (arg === '--repo' && next) {
+      options.repo = next
+      index += 1
+    } else if (arg === '--timeout' && next) {
+      options.timeoutSeconds = Number(next)
+      index += 1
+    } else if (arg === '--interval' && next) {
+      options.intervalSeconds = Number(next)
+      index += 1
+    } else if (arg === '--contexts' && next) {
+      options.contexts = next
+        .split(',')
+        .map((context) => context.trim())
+        .filter(Boolean)
+      index += 1
+    } else if (arg === '--once') {
+      options.once = true
+    } else if (arg === '--help' || arg === '-h') {
+      throw new Error('HELP_REQUESTED')
+    }
+  }
+
+  if (!Number.isFinite(options.timeoutSeconds) || options.timeoutSeconds <= 0) {
+    throw new Error('--timeout must be a positive number of seconds')
+  }
+
+  if (!Number.isFinite(options.intervalSeconds) || options.intervalSeconds <= 0) {
+    throw new Error('--interval must be a positive number of seconds')
+  }
+
+  if (options.contexts.length === 0) {
+    throw new Error('--contexts must include at least one status context')
+  }
+
+  return options
+}
+
+export function formatDeploymentWatchSummary(summary: DeploymentWatchSummary): string {
+  const lines = [`deployment_state=${summary.state}`]
+
+  for (const status of summary.contexts) {
+    const details = [
+      `context="${status.context}"`,
+      `state=${status.state}`,
+      status.rawState ? `raw=${status.rawState}` : undefined,
+      status.updatedAt ? `updated_at=${status.updatedAt}` : undefined,
+      status.description ? `description="${status.description}"` : undefined,
+      status.targetUrl ? `url=${status.targetUrl}` : undefined,
+    ].filter(Boolean)
+
+    lines.push(details.join(' '))
+  }
+
+  return lines.join('\n')
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "db:health-check:update": "tsx scripts/database-health-check.ts --update",
     "db:health-check:dev": "tsx scripts/database-health-check.ts --dev",
     "db:health-check:dev:update": "tsx scripts/database-health-check.ts --dev --update",
+    "deploy:watch": "tsx scripts/vercel-deployment-watch.ts",
+    "deploy:watch:once": "tsx scripts/vercel-deployment-watch.ts --once",
     "source-protocol:smoke": "tsx scripts/source-protocol-smoke.ts",
     "staging:publications-parity": "tsx scripts/ensure-publications-experience-parity.ts --env-file .env.staging",
     "printful:webhook": "tsx scripts/printful-setup-webhook.ts",

--- a/scripts/vercel-deployment-watch.ts
+++ b/scripts/vercel-deployment-watch.ts
@@ -1,0 +1,109 @@
+#!/usr/bin/env tsx
+import { spawnSync } from 'node:child_process'
+import {
+  formatDeploymentWatchSummary,
+  parseDeploymentWatchArgs,
+  summarizeDeploymentStatus,
+  type GitHubCombinedStatus,
+} from '../lib/vercel-deployment-watch'
+
+function usage(): string {
+  return `Usage:
+  npx tsx scripts/vercel-deployment-watch.ts [options]
+
+Options:
+  --ref <sha-or-branch>       Commit SHA or branch to watch. Defaults to main.
+  --owner <owner>             GitHub owner. Defaults to vsillah.
+  --repo <repo>               GitHub repo. Defaults to Portfolio.
+  --contexts <a,b>            Comma-separated status contexts.
+                             Defaults to both Portfolio Vercel contexts.
+  --timeout <seconds>         Max wait time. Defaults to 900.
+  --interval <seconds>        Poll interval. Defaults to 30.
+  --once                      Print one status snapshot and exit.
+  --help                      Show this help.
+
+Exit codes:
+  0 success
+  1 failed or command error
+  2 timed out while pending
+`
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function fetchCombinedStatus(owner: string, repo: string, ref: string): GitHubCombinedStatus {
+  const endpoint = `repos/${owner}/${repo}/commits/${encodeURIComponent(ref)}/status`
+  const result = spawnSync('gh', ['api', endpoint], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  if (result.status !== 0) {
+    const message = result.stderr.trim() || result.stdout.trim() || 'gh api failed'
+    throw new Error(message)
+  }
+
+  return JSON.parse(result.stdout) as GitHubCombinedStatus
+}
+
+async function main(): Promise<void> {
+  let options
+
+  try {
+    options = parseDeploymentWatchArgs(process.argv.slice(2))
+  } catch (error) {
+    if (error instanceof Error && error.message === 'HELP_REQUESTED') {
+      console.log(usage())
+      process.exit(0)
+    }
+
+    console.error(error instanceof Error ? error.message : error)
+    console.error('')
+    console.error(usage())
+    process.exit(1)
+  }
+
+  const startedAt = Date.now()
+  const timeoutMs = options.timeoutSeconds * 1000
+  let attempt = 0
+
+  while (true) {
+    attempt += 1
+
+    try {
+      const combinedStatus = fetchCombinedStatus(options.owner, options.repo, options.ref)
+      const summary = summarizeDeploymentStatus(combinedStatus, options.contexts)
+
+      console.log(`\n[attempt ${attempt}] ${new Date().toISOString()}`)
+      console.log(formatDeploymentWatchSummary(summary))
+
+      if (summary.state === 'success') {
+        process.exit(0)
+      }
+
+      if (summary.state === 'failed') {
+        process.exit(1)
+      }
+
+      if (options.once) {
+        process.exit(2)
+      }
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : error)
+      process.exit(1)
+    }
+
+    if (Date.now() - startedAt >= timeoutMs) {
+      console.error(
+        `Timed out after ${options.timeoutSeconds}s while waiting for Vercel deployment contexts.`
+      )
+      process.exit(2)
+    }
+
+    await sleep(options.intervalSeconds * 1000)
+  }
+}
+
+main()


### PR DESCRIPTION
## Summary
- add a small Vercel deployment watcher for the Portfolio and portfolio-staging status contexts
- add npm scripts for one-shot and polling deployment checks
- document the watcher in the Vercel verifier agent runbook with pending thresholds

## Validation
- npm test -- lib/vercel-deployment-watch.test.ts
- npx tsc --noEmit --pretty false
- npm run deploy:watch:once -- --ref main