### PR TITLE
feat: add Chief of Staff agent chat

### DIFF
--- a/app/admin/agents/chief-of-staff/page.tsx
+++ b/app/admin/agents/chief-of-staff/page.tsx
@@ -1,0 +1,202 @@
+'use client'
+
+import Link from 'next/link'
+import { FormEvent, useMemo, useState } from 'react'
+import { ArrowLeft, Bot, ExternalLink, Send } from 'lucide-react'
+import ProtectedRoute from '@/components/ProtectedRoute'
+import Breadcrumbs from '@/components/admin/Breadcrumbs'
+import { getCurrentSession } from '@/lib/auth'
+
+type ChatMessage = {
+  role: 'user' | 'assistant'
+  content: string
+  runId?: string
+  suggestedActions?: string[]
+}
+
+const STARTER_PROMPTS = [
+  'What needs my attention today?',
+  'Summarize current agent operations risk.',
+  'What should the agent organization do next?',
+]
+
+export default function ChiefOfStaffAgentPage() {
+  const [messages, setMessages] = useState<ChatMessage[]>([
+    {
+      role: 'assistant',
+      content:
+        'I can review the current Agent Operations context, call out blockers, and turn your intent into next actions. I am read-only in this first chat version.',
+      suggestedActions: STARTER_PROMPTS,
+    },
+  ])
+  const [input, setInput] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const history = useMemo(
+    () => messages.filter((message) => message.role === 'user' || message.role === 'assistant').slice(-8),
+    [messages],
+  )
+
+  async function sendMessage(nextMessage?: string) {
+    const message = (nextMessage ?? input).trim()
+    if (!message || loading) return
+
+    setInput('')
+    setError(null)
+    setLoading(true)
+    setMessages((current) => [...current, { role: 'user', content: message }])
+
+    try {
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Missing admin session')
+
+      const res = await fetch('/api/admin/agents/chief-of-staff/chat', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${session.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ message, history }),
+      })
+      const body = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(body.error || `HTTP ${res.status}`)
+
+      setMessages((current) => [
+        ...current,
+        {
+          role: 'assistant',
+          content: body.reply,
+          runId: body.run_id,
+          suggestedActions: Array.isArray(body.suggested_actions) ? body.suggested_actions : [],
+        },
+      ])
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Chief of Staff chat failed')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  function onSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    sendMessage()
+  }
+
+  return (
+    <ProtectedRoute requireAdmin>
+      <div className="min-h-screen bg-background text-foreground p-6 lg:p-8">
+        <div className="mx-auto max-w-5xl">
+          <Breadcrumbs
+            items={[
+              { label: 'Admin Dashboard', href: '/admin' },
+              { label: 'Agent Operations', href: '/admin/agents' },
+              { label: 'Chief of Staff' },
+            ]}
+          />
+
+          <Link
+            href="/admin/agents"
+            className="mb-6 inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
+          >
+            <ArrowLeft size={16} />
+            Back to Agent Operations
+          </Link>
+
+          <div className="mb-6 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+            <div>
+              <div className="mb-2 flex items-center gap-2 text-radiant-gold">
+                <Bot size={22} />
+                <p className="text-sm font-semibold uppercase tracking-wider">Chief of Staff Agent</p>
+              </div>
+              <h1 className="text-3xl font-bold">Executive Operations Chat</h1>
+              <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
+                Ask for priorities, blockers, run status, approval risk, and next actions across Agent Operations.
+              </p>
+            </div>
+            <Link
+              href="/admin/agents/runs"
+              className="inline-flex w-fit items-center gap-2 rounded-lg border border-silicon-slate/70 bg-background/60 px-3 py-2 text-sm hover:border-radiant-gold/60"
+            >
+              Runs
+              <ExternalLink size={14} />
+            </Link>
+          </div>
+
+          <section className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20">
+            <div className="max-h-[58vh] min-h-[420px] space-y-4 overflow-y-auto p-4 md:p-5">
+              {messages.map((message, index) => (
+                <div
+                  key={`${message.role}-${index}`}
+                  className={`flex ${message.role === 'user' ? 'justify-end' : 'justify-start'}`}
+                >
+                  <div
+                    className={`max-w-[82%] rounded-lg border px-4 py-3 ${
+                      message.role === 'user'
+                        ? 'border-radiant-gold/40 bg-radiant-gold/10'
+                        : 'border-silicon-slate/60 bg-background/60'
+                    }`}
+                  >
+                    <p className="whitespace-pre-wrap text-sm leading-6">{message.content}</p>
+                    {message.runId ? (
+                      <Link
+                        href={`/admin/agents/runs/${message.runId}`}
+                        className="mt-3 inline-flex items-center gap-1 text-xs text-radiant-gold hover:underline"
+                      >
+                        Open trace
+                        <ExternalLink size={12} />
+                      </Link>
+                    ) : null}
+                    {message.suggestedActions?.length ? (
+                      <div className="mt-3 flex flex-wrap gap-2">
+                        {message.suggestedActions.map((action) => (
+                          <button
+                            key={action}
+                            type="button"
+                            onClick={() => sendMessage(action)}
+                            disabled={loading}
+                            className="rounded-md border border-silicon-slate/60 bg-black/10 px-2 py-1 text-xs text-muted-foreground hover:border-radiant-gold/60 hover:text-foreground disabled:opacity-60"
+                          >
+                            {action}
+                          </button>
+                        ))}
+                      </div>
+                    ) : null}
+                  </div>
+                </div>
+              ))}
+              {loading ? (
+                <div className="flex justify-start">
+                  <div className="rounded-lg border border-silicon-slate/60 bg-background/60 px-4 py-3 text-sm text-muted-foreground">
+                    Reviewing Agent Operations context...
+                  </div>
+                </div>
+              ) : null}
+            </div>
+
+            <form onSubmit={onSubmit} className="border-t border-silicon-slate/70 p-4 md:p-5">
+              {error ? <p className="mb-3 text-sm text-red-300">{error}</p> : null}
+              <div className="flex flex-col gap-3 md:flex-row">
+                <textarea
+                  value={input}
+                  onChange={(event) => setInput(event.target.value)}
+                  placeholder="Ask what needs attention, what to run next, or what is blocked..."
+                  rows={3}
+                  className="min-h-[88px] flex-1 resize-none rounded-lg border border-silicon-slate/70 bg-background/80 px-3 py-2 text-sm outline-none focus:border-radiant-gold/70"
+                />
+                <button
+                  type="submit"
+                  disabled={loading || !input.trim()}
+                  className="inline-flex items-center justify-center gap-2 rounded-lg border border-radiant-gold/50 bg-radiant-gold/10 px-4 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15 disabled:opacity-60 md:w-32"
+                >
+                  <Send size={16} />
+                  Send
+                </button>
+              </div>
+            </form>
+          </section>
+        </div>
+      </div>
+    </ProtectedRoute>
+  )
+}

--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -11,6 +11,7 @@ import {
   CheckCircle2,
   Clock,
   DollarSign,
+  MessageSquare,
   RefreshCw,
   ShieldAlert,
   Workflow,
@@ -162,6 +163,24 @@ export default function AgentOperationsPage() {
                   </div>
                   <p className="text-sm text-muted-foreground">
                     View active and recent agent runs, current steps, runtime, costs, errors, and approvals.
+                  </p>
+                </div>
+                <ArrowRight size={20} className="text-muted-foreground shrink-0" />
+              </div>
+            </Link>
+
+            <Link
+              href="/admin/agents/chief-of-staff"
+              className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/30 p-5 hover:border-radiant-gold/60 transition-colors"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <div className="flex items-center gap-2 text-radiant-gold mb-2">
+                    <MessageSquare size={20} />
+                    <h2 className="text-lg font-semibold">Chief of Staff Chat</h2>
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    Ask for priorities, blockers, approval risk, and next actions from the agent operating context.
                   </p>
                 </div>
                 <ArrowRight size={20} className="text-muted-foreground shrink-0" />

--- a/app/api/admin/agents/chief-of-staff/chat/route.test.ts
+++ b/app/api/admin/agents/chief-of-staff/chat/route.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  runChiefOfStaffChat: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/chief-of-staff-chat', () => {
+  function normalizeChiefOfStaffHistory(history: Array<{ role: string; content: string }> | undefined) {
+    return (history ?? [])
+      .filter((message) => message.role === 'user' || message.role === 'assistant')
+      .map((message) => ({ role: message.role, content: message.content.trim() }))
+      .filter((message) => message.content.length > 0)
+  }
+
+  return {
+    normalizeChiefOfStaffHistory,
+    runChiefOfStaffChat: mocks.runChiefOfStaffChat,
+  }
+})
+
+import { POST } from './route'
+
+function makeRequest(body: Record<string, unknown> = { message: 'What needs attention?' }) {
+  return new Request('http://localhost/api/admin/agents/chief-of-staff/chat', {
+    method: 'POST',
+    headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/admin/agents/chief-of-staff/chat', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.runChiefOfStaffChat.mockResolvedValue({
+      runId: 'chief-run-1',
+      reply: 'The morning review is clean. Watch one pending approval.',
+      suggestedActions: ['Open Agent Operations'],
+      model: 'gpt-4o-mini',
+    })
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(makeRequest() as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.runChiefOfStaffChat).not.toHaveBeenCalled()
+  })
+
+  it('rejects empty messages', async () => {
+    const response = await POST(makeRequest({ message: '   ' }) as never)
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'Message is required' })
+    expect(mocks.runChiefOfStaffChat).not.toHaveBeenCalled()
+  })
+
+  it('runs an observable Chief of Staff chat', async () => {
+    const response = await POST(makeRequest({
+      message: 'What needs attention?',
+      history: [{ role: 'user', content: 'Earlier question' }],
+    }) as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      ok: true,
+      run_id: 'chief-run-1',
+      reply: 'The morning review is clean. Watch one pending approval.',
+      suggested_actions: ['Open Agent Operations'],
+      model: 'gpt-4o-mini',
+    })
+    expect(mocks.runChiefOfStaffChat).toHaveBeenCalledWith(expect.objectContaining({
+      message: 'What needs attention?',
+      userId: 'admin-user',
+      history: [{ role: 'user', content: 'Earlier question' }],
+    }))
+  })
+})

--- a/app/api/admin/agents/chief-of-staff/chat/route.ts
+++ b/app/api/admin/agents/chief-of-staff/chat/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import {
+  normalizeChiefOfStaffHistory,
+  runChiefOfStaffChat,
+  type ChiefOfStaffChatMessage,
+} from '@/lib/chief-of-staff-chat'
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 60
+
+/**
+ * POST /api/admin/agents/chief-of-staff/chat
+ *
+ * Admin-only conversational entrypoint for the Chief of Staff Agent. V1 is
+ * read-only: it summarizes operating context and records an observable
+ * agent_run, but it does not mutate production workflow data.
+ */
+export async function POST(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  let body: { message?: unknown; history?: unknown }
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const message = typeof body.message === 'string' ? body.message.trim() : ''
+  if (!message) {
+    return NextResponse.json({ error: 'Message is required' }, { status: 400 })
+  }
+
+  const history = Array.isArray(body.history)
+    ? normalizeChiefOfStaffHistory(body.history as ChiefOfStaffChatMessage[])
+    : []
+
+  try {
+    const result = await runChiefOfStaffChat({
+      message,
+      history,
+      userId: auth.user.id,
+    })
+
+    return NextResponse.json({
+      ok: true,
+      run_id: result.runId,
+      reply: result.reply,
+      suggested_actions: result.suggestedActions,
+      model: result.model,
+    })
+  } catch (error) {
+    console.error('[chief-of-staff-chat] failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Chief of Staff chat failed' },
+      { status: 500 },
+    )
+  }
+}

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -181,6 +181,16 @@ The route verifies Slack signatures with `SLACK_SIGNING_SECRET` when configured 
 
 Slack is an engagement surface, not the source of truth. The admin console and shared trace tables remain authoritative.
 
+## Chief of Staff Chat
+
+The first conversational agent surface is `/admin/agents/chief-of-staff`.
+
+- It is admin-only.
+- It reads current Agent Operations context: active runs, recent failed/stale runs, pending approvals, and cost events.
+- It creates a traced `codex` runtime `agent_run` for every exchange.
+- It uses `CHIEF_OF_STAFF_AGENT_MODEL` when set, otherwise `gpt-4o-mini`.
+- V1 is read-only. It can recommend next actions and approval paths, but it does not mutate production workflows, send messages, publish content, or change configuration.
+
 ## Safety Rules
 
 - New agent work should create an `agent_run` before doing meaningful work.

--- a/lib/chief-of-staff-chat.test.ts
+++ b/lib/chief-of-staff-chat.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/llm-dispatch', () => ({
+  generateJsonCompletion: vi.fn(),
+}))
+
+vi.mock('@/lib/agent-run', () => ({
+  startAgentRun: vi.fn(),
+  recordAgentStep: vi.fn(),
+  recordAgentEvent: vi.fn(),
+  endAgentRun: vi.fn(),
+  markAgentRunFailed: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: null,
+}))
+
+import {
+  buildChiefOfStaffPrompt,
+  normalizeChiefOfStaffHistory,
+  parseChiefOfStaffJson,
+  type ChiefOfStaffContext,
+} from './chief-of-staff-chat'
+
+const context: ChiefOfStaffContext = {
+  generatedAt: '2026-05-02T12:00:00.000Z',
+  activeRuns: [
+    {
+      id: 'run-1',
+      agent_key: 'chief-of-staff',
+      runtime: 'n8n',
+      title: 'Morning review',
+      status: 'running',
+      current_step: 'Checking stale runs',
+      error_message: null,
+      started_at: '2026-05-02T11:55:00.000Z',
+    },
+  ],
+  recentFailures: [],
+  pendingApprovals: [],
+  costEvents24h: {
+    count: 2,
+    totalUsd: 0.0123,
+    providers: ['openai'],
+    models: ['gpt-4o-mini'],
+  },
+}
+
+describe('Chief of Staff chat helpers', () => {
+  it('normalizes chat history to the last valid messages', () => {
+    const history = normalizeChiefOfStaffHistory([
+      { role: 'user', content: '  first  ' },
+      { role: 'assistant', content: '' },
+      { role: 'assistant', content: 'second' },
+      { role: 'user', content: 'third' },
+    ])
+
+    expect(history).toEqual([
+      { role: 'user', content: 'first' },
+      { role: 'assistant', content: 'second' },
+      { role: 'user', content: 'third' },
+    ])
+  })
+
+  it('parses the model JSON contract', () => {
+    const result = parseChiefOfStaffJson(JSON.stringify({
+      reply: 'Focus on the pending deployment and the approval queue.',
+      suggested_actions: ['Check failed runs', 'Run morning review'],
+    }))
+
+    expect(result.reply).toContain('pending deployment')
+    expect(result.suggestedActions).toEqual(['Check failed runs', 'Run morning review'])
+  })
+
+  it('builds a read-only operational prompt', () => {
+    const prompt = buildChiefOfStaffPrompt(context, [{ role: 'user', content: 'What needs attention?' }])
+
+    expect(prompt.systemPrompt).toContain('production mutations')
+    expect(prompt.systemPrompt).toContain('Return JSON only')
+    expect(prompt.userPrompt).toContain('Morning review')
+    expect(prompt.userPrompt).toContain('What needs attention?')
+  })
+})

--- a/lib/chief-of-staff-chat.ts
+++ b/lib/chief-of-staff-chat.ts
@@ -1,0 +1,277 @@
+import { generateJsonCompletion } from '@/lib/llm-dispatch'
+import {
+  endAgentRun,
+  markAgentRunFailed,
+  recordAgentEvent,
+  recordAgentStep,
+  startAgentRun,
+} from '@/lib/agent-run'
+import { supabaseAdmin } from '@/lib/supabase'
+
+export type ChiefOfStaffChatMessage = {
+  role: 'user' | 'assistant'
+  content: string
+}
+
+export type ChiefOfStaffChatRequest = {
+  message: string
+  history?: ChiefOfStaffChatMessage[]
+  userId?: string
+}
+
+export type ChiefOfStaffChatResponse = {
+  runId: string
+  reply: string
+  suggestedActions: string[]
+  model: string
+}
+
+type AgentRunSummaryRow = {
+  id: string
+  agent_key: string | null
+  runtime: string
+  title: string
+  status: string
+  current_step: string | null
+  error_message: string | null
+  started_at: string
+}
+
+type AgentApprovalSummaryRow = {
+  run_id: string
+  approval_type: string
+  status: string
+  requested_at: string
+}
+
+type CostSummaryRow = {
+  amount: number | string | null
+  provider: string | null
+  model: string | null
+}
+
+export type ChiefOfStaffContext = {
+  generatedAt: string
+  activeRuns: AgentRunSummaryRow[]
+  recentFailures: AgentRunSummaryRow[]
+  pendingApprovals: AgentApprovalSummaryRow[]
+  costEvents24h: {
+    count: number
+    totalUsd: number
+    providers: string[]
+    models: string[]
+  }
+}
+
+const DEFAULT_MODEL = 'gpt-4o-mini'
+
+function sinceHours(hours: number) {
+  return new Date(Date.now() - hours * 60 * 60 * 1000).toISOString()
+}
+
+function assertDatabase() {
+  if (!supabaseAdmin) {
+    throw new Error('Database not available')
+  }
+  return supabaseAdmin
+}
+
+export function normalizeChiefOfStaffHistory(
+  history: ChiefOfStaffChatMessage[] | undefined,
+): ChiefOfStaffChatMessage[] {
+  return (history ?? [])
+    .filter((message) => message.role === 'user' || message.role === 'assistant')
+    .map((message) => ({
+      role: message.role,
+      content: message.content.trim().slice(0, 2000),
+    }))
+    .filter((message) => message.content.length > 0)
+    .slice(-8)
+}
+
+export function parseChiefOfStaffJson(content: string): { reply: string; suggestedActions: string[] } {
+  const parsed = JSON.parse(content) as { reply?: unknown; suggested_actions?: unknown }
+  const reply = typeof parsed.reply === 'string' ? parsed.reply.trim() : ''
+  if (!reply) {
+    throw new Error('Chief of Staff response missing reply')
+  }
+
+  const suggestedActions = Array.isArray(parsed.suggested_actions)
+    ? parsed.suggested_actions
+        .filter((action): action is string => typeof action === 'string')
+        .map((action) => action.trim())
+        .filter(Boolean)
+        .slice(0, 5)
+    : []
+
+  return { reply, suggestedActions }
+}
+
+export async function collectChiefOfStaffContext(): Promise<ChiefOfStaffContext> {
+  const db = assertDatabase()
+  const since = sinceHours(24)
+
+  const [activeRes, failedRes, approvalsRes, costsRes] = await Promise.all([
+    db
+      .from('agent_runs')
+      .select('id, agent_key, runtime, title, status, current_step, error_message, started_at')
+      .in('status', ['queued', 'running', 'waiting_for_approval'])
+      .order('started_at', { ascending: false })
+      .limit(10),
+    db
+      .from('agent_runs')
+      .select('id, agent_key, runtime, title, status, current_step, error_message, started_at')
+      .in('status', ['failed', 'stale'])
+      .gte('started_at', since)
+      .order('started_at', { ascending: false })
+      .limit(10),
+    db
+      .from('agent_approvals')
+      .select('run_id, approval_type, status, requested_at')
+      .eq('status', 'pending')
+      .order('requested_at', { ascending: false })
+      .limit(10),
+    db
+      .from('cost_events')
+      .select('amount, provider, model')
+      .gte('occurred_at', since)
+      .limit(100),
+  ])
+
+  for (const result of [activeRes, failedRes, approvalsRes, costsRes]) {
+    if (result.error) {
+      throw new Error(result.error.message)
+    }
+  }
+
+  const costRows = (costsRes.data ?? []) as CostSummaryRow[]
+  const totalUsd = costRows.reduce((sum, row) => sum + Number(row.amount ?? 0), 0)
+
+  return {
+    generatedAt: new Date().toISOString(),
+    activeRuns: (activeRes.data ?? []) as AgentRunSummaryRow[],
+    recentFailures: (failedRes.data ?? []) as AgentRunSummaryRow[],
+    pendingApprovals: (approvalsRes.data ?? []) as AgentApprovalSummaryRow[],
+    costEvents24h: {
+      count: costRows.length,
+      totalUsd: Number(totalUsd.toFixed(4)),
+      providers: Array.from(new Set(costRows.map((row) => row.provider).filter(Boolean) as string[])),
+      models: Array.from(new Set(costRows.map((row) => row.model).filter(Boolean) as string[])),
+    },
+  }
+}
+
+export function buildChiefOfStaffPrompt(context: ChiefOfStaffContext, history: ChiefOfStaffChatMessage[]) {
+  return {
+    systemPrompt: [
+      'You are the Chief of Staff Agent for Vambah and AmaduTown.',
+      'Your job is to translate executive intent into clear priorities, operational status, escalation decisions, and next actions.',
+      'Use only the provided operating context. If the user asks for production mutations, sending messages, publishing, or config changes, explain that approval is required and suggest the approval path.',
+      'Be concise, direct, and operational. Do not pretend to have run tools that are not in the context.',
+      'Return JSON only with keys: reply, suggested_actions.',
+    ].join('\n'),
+    userPrompt: JSON.stringify(
+      {
+        current_context: context,
+        recent_chat_history: history,
+        response_contract: {
+          reply: 'A concise answer to the user. Prefer concrete status, blockers, and next steps.',
+          suggested_actions: 'Up to five short actions the user can take or ask the agent to do next.',
+        },
+      },
+      null,
+      2,
+    ),
+  }
+}
+
+export async function runChiefOfStaffChat(input: ChiefOfStaffChatRequest): Promise<ChiefOfStaffChatResponse> {
+  const message = input.message.trim()
+  if (!message) {
+    throw new Error('Message is required')
+  }
+
+  const history = normalizeChiefOfStaffHistory(input.history)
+  const run = await startAgentRun({
+    agentKey: 'chief-of-staff',
+    runtime: 'codex',
+    kind: 'chief_of_staff_chat',
+    title: 'Chief of Staff chat',
+    status: 'running',
+    subject: { type: 'admin_chat', id: input.userId ?? 'admin', label: 'Admin chat' },
+    triggerSource: 'admin_chief_of_staff_chat',
+    triggeredByUserId: input.userId,
+    currentStep: 'Collecting operating context',
+    metadata: { message_preview: message.slice(0, 240) },
+  })
+
+  try {
+    const context = await collectChiefOfStaffContext()
+    await recordAgentStep({
+      runId: run.id,
+      stepKey: 'collect_context',
+      name: 'Collected operating context',
+      status: 'completed',
+      inputSummary: message.slice(0, 500),
+      outputSummary: `${context.activeRuns.length} active, ${context.recentFailures.length} failed/stale, ${context.pendingApprovals.length} approvals`,
+    })
+
+    await recordAgentEvent({
+      runId: run.id,
+      eventType: 'chief_of_staff_message_received',
+      severity: 'info',
+      message: message.slice(0, 500),
+    })
+
+    const prompt = buildChiefOfStaffPrompt(context, [
+      ...history,
+      { role: 'user', content: message },
+    ])
+    const model = process.env.CHIEF_OF_STAFF_AGENT_MODEL || DEFAULT_MODEL
+    const completion = await generateJsonCompletion({
+      model,
+      systemPrompt: prompt.systemPrompt,
+      userPrompt: prompt.userPrompt,
+      temperature: 0.3,
+      maxTokens: 900,
+      costContext: {
+        agentRunId: run.id,
+        reference: { type: 'agent', id: 'chief-of-staff' },
+        metadata: { operation: 'chief_of_staff_chat' },
+      },
+    })
+
+    const parsed = parseChiefOfStaffJson(completion.content)
+    await recordAgentStep({
+      runId: run.id,
+      stepKey: 'generate_reply',
+      name: 'Generated Chief of Staff reply',
+      status: 'completed',
+      tokensIn: completion.usage?.prompt_tokens ?? completion.usage?.input_tokens ?? null,
+      tokensOut: completion.usage?.completion_tokens ?? completion.usage?.output_tokens ?? null,
+      outputSummary: parsed.reply.slice(0, 500),
+      metadata: { model, suggested_actions: parsed.suggestedActions },
+    })
+
+    await endAgentRun({
+      runId: run.id,
+      status: 'completed',
+      currentStep: 'Reply ready',
+      outcome: {
+        reply_preview: parsed.reply.slice(0, 500),
+        suggested_actions: parsed.suggestedActions,
+      },
+    })
+
+    return {
+      runId: run.id,
+      reply: parsed.reply,
+      suggestedActions: parsed.suggestedActions,
+      model,
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Chief of Staff chat failed'
+    await markAgentRunFailed(run.id, message, { source: 'chief_of_staff_chat' }).catch(() => {})
+    throw error
+  }
+}


### PR DESCRIPTION
## Summary
- add an admin-only Chief of Staff chat surface at /admin/agents/chief-of-staff
- add a traced read-only chat API that gathers Agent Ops context and records agent_runs
- link the chat from Agent Operations and document the V1 behavior

## Validation
- npm test -- lib/chief-of-staff-chat.test.ts app/api/admin/agents/chief-of-staff/chat/route.test.ts
- npx tsc --noEmit --pretty false
- npm run build