### PR TITLE
feat: add Chief of Staff action approvals

### DIFF
--- a/app/admin/agents/chief-of-staff/page.tsx
+++ b/app/admin/agents/chief-of-staff/page.tsx
@@ -2,16 +2,26 @@
 
 import Link from 'next/link'
 import { FormEvent, useMemo, useState } from 'react'
-import { ArrowLeft, Bot, ExternalLink, Send } from 'lucide-react'
+import { ArrowLeft, Bot, ExternalLink, Send, ShieldCheck } from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
 import { getCurrentSession } from '@/lib/auth'
+
+type ChiefOfStaffActionProposal = {
+  label: string
+  description: string
+  action: string
+  approvalType: string | null
+  requiresApproval: boolean
+  riskLevel: 'low' | 'medium' | 'high'
+}
 
 type ChatMessage = {
   role: 'user' | 'assistant'
   content: string
   runId?: string
   suggestedActions?: string[]
+  actionProposals?: ChiefOfStaffActionProposal[]
 }
 
 const STARTER_PROMPTS = [
@@ -31,6 +41,8 @@ export default function ChiefOfStaffAgentPage() {
   ])
   const [input, setInput] = useState('')
   const [loading, setLoading] = useState(false)
+  const [creatingApproval, setCreatingApproval] = useState<string | null>(null)
+  const [approvalLinks, setApprovalLinks] = useState<Record<string, string>>({})
   const [error, setError] = useState<string | null>(null)
 
   const history = useMemo(
@@ -69,6 +81,7 @@ export default function ChiefOfStaffAgentPage() {
           content: body.reply,
           runId: body.run_id,
           suggestedActions: Array.isArray(body.suggested_actions) ? body.suggested_actions : [],
+          actionProposals: Array.isArray(body.action_proposals) ? body.action_proposals : [],
         },
       ])
     } catch (err) {
@@ -81,6 +94,39 @@ export default function ChiefOfStaffAgentPage() {
   function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
     sendMessage()
+  }
+
+  async function createApprovalCheckpoint(sourceRunId: string | undefined, proposal: ChiefOfStaffActionProposal) {
+    if (!sourceRunId || creatingApproval) return
+
+    const key = `${sourceRunId}:${proposal.action}:${proposal.label}`
+    setCreatingApproval(key)
+    setError(null)
+
+    try {
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Missing admin session')
+
+      const res = await fetch('/api/admin/agents/chief-of-staff/actions', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${session.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          source_run_id: sourceRunId,
+          proposal,
+        }),
+      })
+      const body = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(body.error || `HTTP ${res.status}`)
+
+      setApprovalLinks((current) => ({ ...current, [key]: body.run_id }))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create approval checkpoint')
+    } finally {
+      setCreatingApproval(null)
+    }
   }
 
   return (
@@ -160,6 +206,61 @@ export default function ChiefOfStaffAgentPage() {
                             {action}
                           </button>
                         ))}
+                      </div>
+                    ) : null}
+                    {message.actionProposals?.length ? (
+                      <div className="mt-4 space-y-2">
+                        {message.actionProposals.map((proposal) => {
+                          const key = `${message.runId}:${proposal.action}:${proposal.label}`
+                          const approvalRunId = approvalLinks[key]
+
+                          return (
+                            <div
+                              key={key}
+                              className="rounded-lg border border-silicon-slate/60 bg-black/10 p-3"
+                            >
+                              <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                                <div>
+                                  <div className="flex flex-wrap items-center gap-2">
+                                    <p className="text-sm font-semibold">{proposal.label}</p>
+                                    <span className="rounded-full border border-silicon-slate/60 px-2 py-0.5 text-[11px] uppercase text-muted-foreground">
+                                      {proposal.riskLevel}
+                                    </span>
+                                    {proposal.approvalType ? (
+                                      <span className="rounded-full border border-radiant-gold/40 bg-radiant-gold/10 px-2 py-0.5 text-[11px] text-radiant-gold">
+                                        {proposal.approvalType}
+                                      </span>
+                                    ) : null}
+                                  </div>
+                                  <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                                    {proposal.description}
+                                  </p>
+                                </div>
+                                {proposal.requiresApproval ? (
+                                  approvalRunId ? (
+                                    <Link
+                                      href={`/admin/agents/runs/${approvalRunId}`}
+                                      className="inline-flex shrink-0 items-center gap-1 rounded-md border border-emerald-400/40 bg-emerald-500/10 px-2 py-1 text-xs text-emerald-200 hover:underline"
+                                    >
+                                      Approval created
+                                      <ExternalLink size={12} />
+                                    </Link>
+                                  ) : (
+                                    <button
+                                      type="button"
+                                      onClick={() => createApprovalCheckpoint(message.runId, proposal)}
+                                      disabled={loading || creatingApproval === key}
+                                      className="inline-flex shrink-0 items-center gap-1 rounded-md border border-radiant-gold/50 bg-radiant-gold/10 px-2 py-1 text-xs text-radiant-gold hover:bg-radiant-gold/15 disabled:opacity-60"
+                                    >
+                                      <ShieldCheck size={12} />
+                                      Create approval
+                                    </button>
+                                  )
+                                ) : null}
+                              </div>
+                            </div>
+                          )
+                        })}
                       </div>
                     ) : null}
                   </div>

--- a/app/api/admin/agents/chief-of-staff/actions/route.test.ts
+++ b/app/api/admin/agents/chief-of-staff/actions/route.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  startAgentRun: vi.fn(),
+  recordAgentEvent: vi.fn(),
+  from: vi.fn(),
+  insert: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-run', () => ({
+  startAgentRun: mocks.startAgentRun,
+  recordAgentEvent: mocks.recordAgentEvent,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import { POST } from './route'
+
+function makeRequest(body: unknown = {}) {
+  return new Request('http://localhost/api/admin/agents/chief-of-staff/actions', {
+    method: 'POST',
+    headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+function approvalInsertChain() {
+  const single = vi.fn().mockResolvedValue({ data: { id: 'approval-1' }, error: null })
+  const select = vi.fn(() => ({ single }))
+  mocks.insert.mockImplementation(() => ({ select }))
+  mocks.from.mockReturnValue({ insert: mocks.insert })
+}
+
+const approvalProposal = {
+  label: 'Approve outbound update',
+  description: 'Create an approval checkpoint before sending a client update.',
+  action: 'send_email',
+  approvalType: 'send_email',
+  requiresApproval: true,
+  riskLevel: 'high',
+}
+
+describe('POST /api/admin/agents/chief-of-staff/actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.startAgentRun.mockResolvedValue({ id: 'approval-run-1' })
+    mocks.recordAgentEvent.mockResolvedValue({ id: 'event-1' })
+    approvalInsertChain()
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(makeRequest() as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.startAgentRun).not.toHaveBeenCalled()
+  })
+
+  it('creates an approval checkpoint from a Chief of Staff proposal', async () => {
+    const response = await POST(makeRequest({
+      source_run_id: 'chief-run-1',
+      proposal: approvalProposal,
+    }) as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      ok: true,
+      run_id: 'approval-run-1',
+      approval_id: 'approval-1',
+      approval_type: 'send_email',
+      approval_required: true,
+    })
+    expect(mocks.startAgentRun).toHaveBeenCalledWith(expect.objectContaining({
+      agentKey: 'chief-of-staff',
+      runtime: 'manual',
+      kind: 'chief_of_staff_action_approval',
+      status: 'waiting_for_approval',
+      triggeredByUserId: 'admin-user',
+    }))
+    expect(mocks.insert).toHaveBeenCalledWith(expect.objectContaining({
+      run_id: 'approval-run-1',
+      approval_type: 'send_email',
+      status: 'pending',
+      requested_by_agent_key: 'chief-of-staff',
+    }))
+  })
+
+  it('rejects non-gated proposals', async () => {
+    const response = await POST(makeRequest({
+      source_run_id: 'chief-run-1',
+      proposal: {
+        label: 'Read status',
+        description: 'Review the current runs.',
+        action: 'read_files',
+        requiresApproval: false,
+        riskLevel: 'low',
+      },
+    }) as never)
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'Proposal does not require an approval checkpoint' })
+    expect(mocks.startAgentRun).not.toHaveBeenCalled()
+  })
+
+  it('rejects invalid proposals', async () => {
+    const response = await POST(makeRequest({
+      source_run_id: 'chief-run-1',
+      proposal: { label: 'Unknown', description: 'Bad action', action: 'dangerous_unknown' },
+    }) as never)
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'Valid proposal is required' })
+    expect(mocks.startAgentRun).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/admin/agents/chief-of-staff/actions/route.ts
+++ b/app/api/admin/agents/chief-of-staff/actions/route.ts
@@ -1,0 +1,164 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { recordAgentEvent, startAgentRun } from '@/lib/agent-run'
+import {
+  actionRequiresApproval,
+  getApprovalGate,
+  type AgentAction,
+} from '@/lib/agent-policy'
+import { supabaseAdmin } from '@/lib/supabase'
+import type { ChiefOfStaffActionProposal } from '@/lib/chief-of-staff-chat'
+
+export const dynamic = 'force-dynamic'
+
+const ACTIONS: AgentAction[] = [
+  'read_files',
+  'write_files',
+  'external_api_call',
+  'client_data_access',
+  'known_workflow_db_write',
+  'unknown_db_write',
+  'publish_public_content',
+  'send_email',
+  'production_config_change',
+  'public_content_from_private_material',
+]
+
+function isAgentAction(value: unknown): value is AgentAction {
+  return typeof value === 'string' && ACTIONS.includes(value as AgentAction)
+}
+
+function normalizeProposal(value: unknown): ChiefOfStaffActionProposal | null {
+  if (!value || typeof value !== 'object') return null
+
+  const raw = value as Record<string, unknown>
+  if (!isAgentAction(raw.action)) return null
+
+  const label = typeof raw.label === 'string' ? raw.label.trim() : ''
+  const description = typeof raw.description === 'string' ? raw.description.trim() : ''
+  if (!label || !description) return null
+
+  const gate = getApprovalGate(raw.action)
+  const requiresApproval = gate ? true : actionRequiresApproval('codex', raw.action)
+  const riskLevel = raw.riskLevel === 'low' || raw.riskLevel === 'medium' || raw.riskLevel === 'high'
+    ? raw.riskLevel
+    : requiresApproval
+      ? 'high'
+      : 'medium'
+
+  return {
+    label: label.slice(0, 120),
+    description: description.slice(0, 400),
+    action: raw.action,
+    approvalType: gate?.approvalType ?? null,
+    requiresApproval,
+    riskLevel,
+  }
+}
+
+/**
+ * POST /api/admin/agents/chief-of-staff/actions
+ *
+ * Converts a Chief of Staff recommendation into an observable approval
+ * checkpoint. This route does not execute the proposed action.
+ */
+export async function POST(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+  if (!supabaseAdmin) {
+    return NextResponse.json({ error: 'Database not available' }, { status: 500 })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as {
+    source_run_id?: unknown
+    proposal?: unknown
+  }
+
+  const sourceRunId = typeof body.source_run_id === 'string' ? body.source_run_id.trim() : ''
+  if (!sourceRunId) {
+    return NextResponse.json({ error: 'source_run_id is required' }, { status: 400 })
+  }
+
+  const proposal = normalizeProposal(body.proposal)
+  if (!proposal) {
+    return NextResponse.json({ error: 'Valid proposal is required' }, { status: 400 })
+  }
+
+  const approvalType = proposal.approvalType
+  if (!approvalType || !proposal.requiresApproval) {
+    return NextResponse.json({ error: 'Proposal does not require an approval checkpoint' }, { status: 400 })
+  }
+
+  try {
+    const run = await startAgentRun({
+      agentKey: 'chief-of-staff',
+      runtime: 'manual',
+      kind: 'chief_of_staff_action_approval',
+      title: proposal.label,
+      status: 'waiting_for_approval',
+      subject: {
+        type: 'agent_run',
+        id: sourceRunId,
+        label: 'Chief of Staff recommendation',
+      },
+      triggerSource: 'admin_chief_of_staff_action',
+      triggeredByUserId: auth.user.id,
+      currentStep: `Approval required: ${approvalType}`,
+      metadata: {
+        source_run_id: sourceRunId,
+        proposal,
+        executes_action: false,
+      },
+      idempotencyKey: `chief-of-staff-action:${sourceRunId}:${proposal.action}:${auth.user.id}:${Date.now()}`,
+    })
+
+    const { data, error } = await supabaseAdmin
+      .from('agent_approvals')
+      .insert({
+        run_id: run.id,
+        approval_type: approvalType,
+        status: 'pending',
+        requested_by_agent_key: 'chief-of-staff',
+        metadata: {
+          source_run_id: sourceRunId,
+          proposal,
+          executes_action: false,
+        },
+      })
+      .select('id')
+      .single()
+
+    if (error || !data?.id) {
+      throw new Error(error?.message ?? 'Failed to create approval checkpoint')
+    }
+
+    await recordAgentEvent({
+      runId: run.id,
+      eventType: 'chief_of_staff_approval_created',
+      severity: 'info',
+      message: `${approvalType}: ${proposal.label}`,
+      metadata: {
+        approval_id: data.id,
+        source_run_id: sourceRunId,
+        proposal,
+      },
+      idempotencyKey: `${run.id}:chief-of-staff-approval-created`,
+    }).catch(() => {})
+
+    return NextResponse.json({
+      ok: true,
+      run_id: run.id,
+      approval_id: data.id,
+      approval_type: approvalType,
+      approval_required: true,
+    })
+  } catch (error) {
+    console.error('[chief-of-staff-action] failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to create approval checkpoint' },
+      { status: 500 },
+    )
+  }
+}

--- a/app/api/admin/agents/chief-of-staff/chat/route.test.ts
+++ b/app/api/admin/agents/chief-of-staff/chat/route.test.ts
@@ -44,6 +44,16 @@ describe('POST /api/admin/agents/chief-of-staff/chat', () => {
       runId: 'chief-run-1',
       reply: 'The morning review is clean. Watch one pending approval.',
       suggestedActions: ['Open Agent Operations'],
+      actionProposals: [
+        {
+          label: 'Approve outbound update',
+          description: 'Create an approval checkpoint before sending a client update.',
+          action: 'send_email',
+          approvalType: 'send_email',
+          requiresApproval: true,
+          riskLevel: 'high',
+        },
+      ],
       model: 'gpt-4o-mini',
     })
   })
@@ -79,6 +89,16 @@ describe('POST /api/admin/agents/chief-of-staff/chat', () => {
       run_id: 'chief-run-1',
       reply: 'The morning review is clean. Watch one pending approval.',
       suggested_actions: ['Open Agent Operations'],
+      action_proposals: [
+        {
+          label: 'Approve outbound update',
+          description: 'Create an approval checkpoint before sending a client update.',
+          action: 'send_email',
+          approvalType: 'send_email',
+          requiresApproval: true,
+          riskLevel: 'high',
+        },
+      ],
       model: 'gpt-4o-mini',
     })
     expect(mocks.runChiefOfStaffChat).toHaveBeenCalledWith(expect.objectContaining({

--- a/app/api/admin/agents/chief-of-staff/chat/route.ts
+++ b/app/api/admin/agents/chief-of-staff/chat/route.ts
@@ -50,6 +50,7 @@ export async function POST(request: NextRequest) {
       run_id: result.runId,
       reply: result.reply,
       suggested_actions: result.suggestedActions,
+      action_proposals: result.actionProposals,
       model: result.model,
     })
   } catch (error) {

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -189,7 +189,10 @@ The first conversational agent surface is `/admin/agents/chief-of-staff`.
 - It reads current Agent Operations context: active runs, recent failed/stale runs, pending approvals, and cost events.
 - It creates a traced `codex` runtime `agent_run` for every exchange.
 - It uses `CHIEF_OF_STAFF_AGENT_MODEL` when set, otherwise `gpt-4o-mini`.
-- V1 is read-only. It can recommend next actions and approval paths, but it does not mutate production workflows, send messages, publish content, or change configuration.
+- It returns both plain suggested follow-ups and typed action proposals using the shared runtime policy action IDs.
+- Typed action proposals can be converted into approval checkpoints with `POST /api/admin/agents/chief-of-staff/actions`.
+- The approval action route creates a separate `manual` runtime run in `waiting_for_approval` and a pending `agent_approvals` record.
+- V1 remains non-executing. It can recommend next actions and create approval checkpoints, but it does not mutate production workflows, send messages, publish content, or change configuration.
 
 ## Safety Rules
 

--- a/lib/chief-of-staff-chat.test.ts
+++ b/lib/chief-of-staff-chat.test.ts
@@ -67,10 +67,28 @@ describe('Chief of Staff chat helpers', () => {
     const result = parseChiefOfStaffJson(JSON.stringify({
       reply: 'Focus on the pending deployment and the approval queue.',
       suggested_actions: ['Check failed runs', 'Run morning review'],
+      action_proposals: [
+        {
+          label: 'Approve outbound update',
+          description: 'Prepare a checkpoint before sending a client-facing status email.',
+          action: 'send_email',
+          risk_level: 'high',
+        },
+      ],
     }))
 
     expect(result.reply).toContain('pending deployment')
     expect(result.suggestedActions).toEqual(['Check failed runs', 'Run morning review'])
+    expect(result.actionProposals).toEqual([
+      {
+        label: 'Approve outbound update',
+        description: 'Prepare a checkpoint before sending a client-facing status email.',
+        action: 'send_email',
+        approvalType: 'send_email',
+        requiresApproval: true,
+        riskLevel: 'high',
+      },
+    ])
   })
 
   it('builds a read-only operational prompt', () => {
@@ -78,6 +96,7 @@ describe('Chief of Staff chat helpers', () => {
 
     expect(prompt.systemPrompt).toContain('production mutations')
     expect(prompt.systemPrompt).toContain('Return JSON only')
+    expect(prompt.systemPrompt).toContain('action_proposals')
     expect(prompt.userPrompt).toContain('Morning review')
     expect(prompt.userPrompt).toContain('What needs attention?')
   })

--- a/lib/chief-of-staff-chat.ts
+++ b/lib/chief-of-staff-chat.ts
@@ -6,6 +6,11 @@ import {
   recordAgentStep,
   startAgentRun,
 } from '@/lib/agent-run'
+import {
+  actionRequiresApproval,
+  getApprovalGate,
+  type AgentAction,
+} from '@/lib/agent-policy'
 import { supabaseAdmin } from '@/lib/supabase'
 
 export type ChiefOfStaffChatMessage = {
@@ -23,7 +28,17 @@ export type ChiefOfStaffChatResponse = {
   runId: string
   reply: string
   suggestedActions: string[]
+  actionProposals: ChiefOfStaffActionProposal[]
   model: string
+}
+
+export type ChiefOfStaffActionProposal = {
+  label: string
+  description: string
+  action: AgentAction
+  approvalType: string | null
+  requiresApproval: boolean
+  riskLevel: 'low' | 'medium' | 'high'
 }
 
 type AgentRunSummaryRow = {
@@ -64,6 +79,18 @@ export type ChiefOfStaffContext = {
 }
 
 const DEFAULT_MODEL = 'gpt-4o-mini'
+const CHIEF_OF_STAFF_ACTIONS: AgentAction[] = [
+  'read_files',
+  'write_files',
+  'external_api_call',
+  'client_data_access',
+  'known_workflow_db_write',
+  'unknown_db_write',
+  'publish_public_content',
+  'send_email',
+  'production_config_change',
+  'public_content_from_private_material',
+]
 
 function sinceHours(hours: number) {
   return new Date(Date.now() - hours * 60 * 60 * 1000).toISOString()
@@ -89,8 +116,55 @@ export function normalizeChiefOfStaffHistory(
     .slice(-8)
 }
 
-export function parseChiefOfStaffJson(content: string): { reply: string; suggestedActions: string[] } {
-  const parsed = JSON.parse(content) as { reply?: unknown; suggested_actions?: unknown }
+function isAgentAction(value: unknown): value is AgentAction {
+  return typeof value === 'string' && CHIEF_OF_STAFF_ACTIONS.includes(value as AgentAction)
+}
+
+function parseRiskLevel(value: unknown, requiresApproval: boolean): ChiefOfStaffActionProposal['riskLevel'] {
+  if (value === 'low' || value === 'medium' || value === 'high') return value
+  return requiresApproval ? 'high' : 'medium'
+}
+
+function parseActionProposals(parsed: { action_proposals?: unknown }): ChiefOfStaffActionProposal[] {
+  if (!Array.isArray(parsed.action_proposals)) return []
+
+  return parsed.action_proposals
+    .flatMap((proposal): ChiefOfStaffActionProposal[] => {
+      if (!proposal || typeof proposal !== 'object') return []
+      const raw = proposal as Record<string, unknown>
+      if (!isAgentAction(raw.action)) return []
+
+      const label = typeof raw.label === 'string' ? raw.label.trim() : ''
+      const description = typeof raw.description === 'string' ? raw.description.trim() : ''
+      if (!label || !description) return []
+
+      const gate = getApprovalGate(raw.action)
+      const requiresApproval = gate ? true : actionRequiresApproval('codex', raw.action)
+
+      return [
+        {
+          label: label.slice(0, 120),
+          description: description.slice(0, 400),
+          action: raw.action,
+          approvalType: gate?.approvalType ?? null,
+          requiresApproval,
+          riskLevel: parseRiskLevel(raw.risk_level, requiresApproval),
+        },
+      ]
+    })
+    .slice(0, 5)
+}
+
+export function parseChiefOfStaffJson(content: string): {
+  reply: string
+  suggestedActions: string[]
+  actionProposals: ChiefOfStaffActionProposal[]
+} {
+  const parsed = JSON.parse(content) as {
+    reply?: unknown
+    suggested_actions?: unknown
+    action_proposals?: unknown
+  }
   const reply = typeof parsed.reply === 'string' ? parsed.reply.trim() : ''
   if (!reply) {
     throw new Error('Chief of Staff response missing reply')
@@ -104,7 +178,7 @@ export function parseChiefOfStaffJson(content: string): { reply: string; suggest
         .slice(0, 5)
     : []
 
-  return { reply, suggestedActions }
+  return { reply, suggestedActions, actionProposals: parseActionProposals(parsed) }
 }
 
 export async function collectChiefOfStaffContext(): Promise<ChiefOfStaffContext> {
@@ -168,7 +242,9 @@ export function buildChiefOfStaffPrompt(context: ChiefOfStaffContext, history: C
       'Your job is to translate executive intent into clear priorities, operational status, escalation decisions, and next actions.',
       'Use only the provided operating context. If the user asks for production mutations, sending messages, publishing, or config changes, explain that approval is required and suggest the approval path.',
       'Be concise, direct, and operational. Do not pretend to have run tools that are not in the context.',
-      'Return JSON only with keys: reply, suggested_actions.',
+      'When proposing an executable next step, include a typed action proposal. The proposal is only a recommendation; it does not execute work.',
+      'Use only these action ids: read_files, write_files, external_api_call, client_data_access, known_workflow_db_write, unknown_db_write, publish_public_content, send_email, production_config_change, public_content_from_private_material.',
+      'Return JSON only with keys: reply, suggested_actions, action_proposals.',
     ].join('\n'),
     userPrompt: JSON.stringify(
       {
@@ -177,6 +253,14 @@ export function buildChiefOfStaffPrompt(context: ChiefOfStaffContext, history: C
         response_contract: {
           reply: 'A concise answer to the user. Prefer concrete status, blockers, and next steps.',
           suggested_actions: 'Up to five short actions the user can take or ask the agent to do next.',
+          action_proposals: [
+            {
+              label: 'Short button label for a concrete proposed action.',
+              description: 'One sentence describing the proposed action and why it is useful.',
+              action: 'One allowed action id. Use approval-gated ids for risky work.',
+              risk_level: 'low, medium, or high.',
+            },
+          ],
         },
       },
       null,
@@ -250,7 +334,11 @@ export async function runChiefOfStaffChat(input: ChiefOfStaffChatRequest): Promi
       tokensIn: completion.usage?.prompt_tokens ?? completion.usage?.input_tokens ?? null,
       tokensOut: completion.usage?.completion_tokens ?? completion.usage?.output_tokens ?? null,
       outputSummary: parsed.reply.slice(0, 500),
-      metadata: { model, suggested_actions: parsed.suggestedActions },
+      metadata: {
+        model,
+        suggested_actions: parsed.suggestedActions,
+        action_proposals: parsed.actionProposals,
+      },
     })
 
     await endAgentRun({
@@ -260,6 +348,7 @@ export async function runChiefOfStaffChat(input: ChiefOfStaffChatRequest): Promi
       outcome: {
         reply_preview: parsed.reply.slice(0, 500),
         suggested_actions: parsed.suggestedActions,
+        action_proposals: parsed.actionProposals,
       },
     })
 
@@ -267,6 +356,7 @@ export async function runChiefOfStaffChat(input: ChiefOfStaffChatRequest): Promi
       runId: run.id,
       reply: parsed.reply,
       suggestedActions: parsed.suggestedActions,
+      actionProposals: parsed.actionProposals,
       model,
     }
   } catch (error) {


### PR DESCRIPTION
## Summary
- adds typed Chief of Staff action proposals to the chat response contract
- adds an admin-only action endpoint that converts approval-gated proposals into pending agent_approvals without executing the action
- updates the Chief of Staff UI to show approval proposal cards and link created approval runs
- documents the non-executing approval checkpoint path

## Validation
- npm test -- lib/chief-of-staff-chat.test.ts app/api/admin/agents/chief-of-staff/chat/route.test.ts app/api/admin/agents/chief-of-staff/actions/route.test.ts
- npx tsc --noEmit --pretty false
- npm run lint
- npm run build
- integrated browser smoke: /admin/agents/chief-of-staff loaded locally and redirected to the admin login guard