### PR TITLE
feat: add admin agent engagement requests

### DIFF
--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -13,6 +13,7 @@ import {
   DollarSign,
   MessageSquare,
   RefreshCw,
+  Send,
   ShieldAlert,
   Workflow,
   XCircle,
@@ -38,6 +39,9 @@ export default function AgentOperationsPage() {
   const [morningLoading, setMorningLoading] = useState(false)
   const [morningResult, setMorningResult] = useState<{ runId: string; overall: string; slackNotified: boolean } | null>(null)
   const [morningError, setMorningError] = useState<string | null>(null)
+  const [engagingAgentKey, setEngagingAgentKey] = useState<string | null>(null)
+  const [engagementResults, setEngagementResults] = useState<Record<string, string>>({})
+  const [engagementError, setEngagementError] = useState<string | null>(null)
 
   async function runHermesHealthSummary() {
     setHermesLoading(true)
@@ -135,6 +139,33 @@ export default function AgentOperationsPage() {
       setMorningError(err instanceof Error ? err.message : 'Failed to run Agent Ops morning review')
     } finally {
       setMorningLoading(false)
+    }
+  }
+
+  async function queueAgentEngagement(agentKey: string, agentName: string) {
+    setEngagingAgentKey(agentKey)
+    setEngagementError(null)
+    try {
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Missing admin session')
+      const res = await fetch('/api/admin/agents/engage', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${session.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          agent_key: agentKey,
+          note: `Queued from Agent Operations for ${agentName}.`,
+        }),
+      })
+      const body = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(body.error || `HTTP ${res.status}`)
+      setEngagementResults((current) => ({ ...current, [agentKey]: body.run_id }))
+    } catch (err) {
+      setEngagementError(err instanceof Error ? err.message : 'Failed to queue agent engagement')
+    } finally {
+      setEngagingAgentKey(null)
     }
   }
 
@@ -368,6 +399,7 @@ export default function AgentOperationsPage() {
             <p className="text-sm text-muted-foreground max-w-3xl">
               Maps the target agent organization to the n8n workflow families currently wired into the operating system.
             </p>
+            {engagementError ? <p className="mt-3 text-sm text-red-300">{engagementError}</p> : null}
 
             <div className="mt-5 grid grid-cols-1 lg:grid-cols-2 gap-4">
               {AGENT_ORGANIZATION_SUMMARY.map((pod) => (
@@ -405,6 +437,27 @@ export default function AgentOperationsPage() {
                         ) : (
                           <p className="mt-2 text-xs text-muted-foreground">n8n: not primary runtime yet</p>
                         )}
+                        <div className="mt-3 flex flex-wrap gap-2">
+                          {engagementResults[agent.key] ? (
+                            <Link
+                              href={`/admin/agents/runs/${engagementResults[agent.key]}`}
+                              className="inline-flex items-center gap-1 rounded-md border border-emerald-400/40 bg-emerald-500/10 px-2 py-1 text-xs text-emerald-200 hover:underline"
+                            >
+                              Engagement queued
+                              <ArrowRight size={12} />
+                            </Link>
+                          ) : (
+                            <button
+                              type="button"
+                              onClick={() => queueAgentEngagement(agent.key, agent.name)}
+                              disabled={engagingAgentKey === agent.key}
+                              className="inline-flex items-center gap-1 rounded-md border border-radiant-gold/50 bg-radiant-gold/10 px-2 py-1 text-xs text-radiant-gold hover:bg-radiant-gold/15 disabled:opacity-60"
+                            >
+                              <Send size={12} />
+                              Queue engagement
+                            </button>
+                          )}
+                        </div>
                       </div>
                     ))}
                   </div>

--- a/app/api/admin/agents/engage/route.test.ts
+++ b/app/api/admin/agents/engage/route.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  startAgentRun: vi.fn(),
+  recordAgentEvent: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-run', () => ({
+  startAgentRun: mocks.startAgentRun,
+  recordAgentEvent: mocks.recordAgentEvent,
+}))
+
+import { POST } from './route'
+
+function makeRequest(body: unknown = {}) {
+  return new Request('http://localhost/api/admin/agents/engage', {
+    method: 'POST',
+    headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/admin/agents/engage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.startAgentRun.mockResolvedValue({ id: 'engagement-run-1' })
+    mocks.recordAgentEvent.mockResolvedValue({ id: 'event-1' })
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(makeRequest({ agent_key: 'chief-of-staff' }) as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.startAgentRun).not.toHaveBeenCalled()
+  })
+
+  it('queues a traceable engagement request', async () => {
+    const response = await POST(makeRequest({
+      agent_key: 'chief-of-staff',
+      note: 'Review current blockers.',
+    }) as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      ok: true,
+      run_id: 'engagement-run-1',
+      agent_key: 'chief-of-staff',
+      agent_name: 'Chief of Staff Agent',
+      status: 'queued',
+    })
+    expect(mocks.startAgentRun).toHaveBeenCalledWith(expect.objectContaining({
+      agentKey: 'chief-of-staff',
+      runtime: 'manual',
+      kind: 'agent_engagement_request',
+      status: 'queued',
+      triggeredByUserId: 'admin-user',
+    }))
+    expect(mocks.recordAgentEvent).toHaveBeenCalledWith(expect.objectContaining({
+      runId: 'engagement-run-1',
+      eventType: 'agent_engagement_requested',
+    }))
+  })
+
+  it('rejects unknown agents', async () => {
+    const response = await POST(makeRequest({ agent_key: 'unknown-agent' }) as never)
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'Unknown agent_key' })
+    expect(mocks.startAgentRun).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/admin/agents/engage/route.ts
+++ b/app/api/admin/agents/engage/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { recordAgentEvent, startAgentRun } from '@/lib/agent-run'
+import { getAgentByKey } from '@/lib/agent-organization'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * POST /api/admin/agents/engage
+ *
+ * Creates a traceable engagement request for one target agent. This queues
+ * work for review; it does not execute the agent or mutate production data.
+ */
+export async function POST(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as {
+    agent_key?: unknown
+    note?: unknown
+  }
+
+  const agentKey = typeof body.agent_key === 'string' ? body.agent_key.trim() : ''
+  if (!agentKey) {
+    return NextResponse.json({ error: 'agent_key is required' }, { status: 400 })
+  }
+
+  const agent = getAgentByKey(agentKey)
+  if (!agent) {
+    return NextResponse.json({ error: 'Unknown agent_key' }, { status: 400 })
+  }
+
+  const note = typeof body.note === 'string' ? body.note.trim().slice(0, 500) : null
+
+  try {
+    const run = await startAgentRun({
+      agentKey: agent.key,
+      runtime: 'manual',
+      kind: 'agent_engagement_request',
+      title: `Engage ${agent.name}`,
+      status: 'queued',
+      subject: { type: 'admin_agent_engagement', id: auth.user.id, label: 'Admin engagement request' },
+      triggerSource: 'admin_agent_engagement',
+      triggeredByUserId: auth.user.id,
+      currentStep: 'Engagement request queued',
+      metadata: {
+        requested_agent: agent.key,
+        requested_agent_name: agent.name,
+        pod: agent.podKey,
+        status: agent.status,
+        primary_runtime: agent.primaryRuntime,
+        approval_gate: agent.approvalGate,
+        engagement_path: agent.engagementPath,
+        note,
+        executes_action: false,
+      },
+      idempotencyKey: `admin-agent-engage:${agent.key}:${auth.user.id}:${Date.now()}`,
+    })
+
+    await recordAgentEvent({
+      runId: run.id,
+      eventType: 'agent_engagement_requested',
+      severity: 'info',
+      message: `Admin requested ${agent.name}`,
+      metadata: {
+        agent_key: agent.key,
+        requested_by_user_id: auth.user.id,
+        note,
+      },
+      idempotencyKey: `${run.id}:admin-agent-engagement-requested`,
+    }).catch(() => {})
+
+    return NextResponse.json({
+      ok: true,
+      run_id: run.id,
+      agent_key: agent.key,
+      agent_name: agent.name,
+      status: 'queued',
+    })
+  } catch (error) {
+    console.error('[admin-agent-engage] failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to queue agent engagement' },
+      { status: 500 },
+    )
+  }
+}

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -181,6 +181,17 @@ The route verifies Slack signatures with `SLACK_SIGNING_SECRET` when configured 
 
 Slack is an engagement surface, not the source of truth. The admin console and shared trace tables remain authoritative.
 
+## Agent Engagement Requests
+
+Use `POST /api/admin/agents/engage`, the **Queue engagement** buttons on `/admin/agents`, or Slack `/agent run <agent-key>` to create a traceable `manual` runtime engagement request for any mapped agent.
+
+Engagement requests:
+
+- create an `agent_run` with `kind = agent_engagement_request`,
+- start in `queued`,
+- record the requested agent key, pod, runtime path, and approval gate,
+- do not execute the target agent or mutate production data.
+
 ## Chief of Staff Chat
 
 The first conversational agent surface is `/admin/agents/chief-of-staff`.


### PR DESCRIPTION
## Summary
- adds an admin-only `/api/admin/agents/engage` route for traceable subagent engagement requests
- adds Queue engagement controls to every agent in the Agent Organization map
- records queued manual runtime runs without executing the target agent or mutating production data
- documents the engagement request path alongside Slack `/agent run <agent-key>`

## Validation
- npm test -- app/api/admin/agents/engage/route.test.ts lib/agent-slack-command.test.ts
- npx tsc --noEmit --pretty false
- npm run lint
- npm run build