### PR TITLE
feat: attach agent engagement work packets

### DIFF
--- a/app/api/admin/agents/engage/route.test.ts
+++ b/app/api/admin/agents/engage/route.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   isAuthError: vi.fn(),
   startAgentRun: vi.fn(),
   recordAgentEvent: vi.fn(),
+  attachAgentArtifact: vi.fn(),
 }))
 
 vi.mock('@/lib/auth-server', () => ({
@@ -15,6 +16,7 @@ vi.mock('@/lib/auth-server', () => ({
 vi.mock('@/lib/agent-run', () => ({
   startAgentRun: mocks.startAgentRun,
   recordAgentEvent: mocks.recordAgentEvent,
+  attachAgentArtifact: mocks.attachAgentArtifact,
 }))
 
 import { POST } from './route'
@@ -34,6 +36,7 @@ describe('POST /api/admin/agents/engage', () => {
     mocks.isAuthError.mockReturnValue(false)
     mocks.startAgentRun.mockResolvedValue({ id: 'engagement-run-1' })
     mocks.recordAgentEvent.mockResolvedValue({ id: 'event-1' })
+    mocks.attachAgentArtifact.mockResolvedValue({ id: 'artifact-1' })
   })
 
   it('requires admin auth', async () => {
@@ -60,6 +63,7 @@ describe('POST /api/admin/agents/engage', () => {
       agent_key: 'chief-of-staff',
       agent_name: 'Chief of Staff Agent',
       status: 'queued',
+      work_packet_attached: true,
     })
     expect(mocks.startAgentRun).toHaveBeenCalledWith(expect.objectContaining({
       agentKey: 'chief-of-staff',
@@ -71,6 +75,16 @@ describe('POST /api/admin/agents/engage', () => {
     expect(mocks.recordAgentEvent).toHaveBeenCalledWith(expect.objectContaining({
       runId: 'engagement-run-1',
       eventType: 'agent_engagement_requested',
+    }))
+    expect(mocks.attachAgentArtifact).toHaveBeenCalledWith(expect.objectContaining({
+      runId: 'engagement-run-1',
+      artifactType: 'agent_engagement_work_packet',
+      title: 'Chief of Staff Agent work packet',
+      metadata: expect.objectContaining({
+        summary_markdown: expect.stringContaining('Chief of Staff Agent Work Packet'),
+        suggested_next_action: expect.any(String),
+        executes_action: false,
+      }),
     }))
   })
 

--- a/app/api/admin/agents/engage/route.ts
+++ b/app/api/admin/agents/engage/route.ts
@@ -1,9 +1,61 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
-import { recordAgentEvent, startAgentRun } from '@/lib/agent-run'
-import { getAgentByKey } from '@/lib/agent-organization'
+import { attachAgentArtifact, recordAgentEvent, startAgentRun } from '@/lib/agent-run'
+import { AGENT_PODS, getAgentByKey } from '@/lib/agent-organization'
+import type { AgentOrganizationNode } from '@/lib/agent-organization'
 
 export const dynamic = 'force-dynamic'
+
+function buildWorkPacket(agent: AgentOrganizationNode, note: string | null) {
+  const pod = AGENT_PODS.find((item) => item.key === agent.podKey)
+  const activeWorkflows = agent.n8nWorkflows.filter((workflow) => workflow.active)
+  const workflowLines = activeWorkflows.length
+    ? activeWorkflows
+        .slice(0, 8)
+        .map((workflow) => `- ${workflow.name} (${workflow.environment})`)
+        .join('\n')
+    : '- No active n8n workflow is mapped as the primary runtime yet.'
+
+  const nextAction =
+    agent.status === 'planned'
+      ? 'Define a first narrow, read-only task before assigning production automation.'
+      : agent.primaryRuntime === 'n8n'
+        ? 'Review mapped workflow health and decide whether to trigger the existing admin or n8n path.'
+        : agent.primaryRuntime === 'codex'
+          ? 'Use Codex to draft or implement the next scoped artifact, then route through PR/deploy gates if code changes are needed.'
+          : 'Use the listed engagement path and keep any production side effect behind the approval gate.'
+
+  const summaryMarkdown = [
+    `## ${agent.name} Work Packet`,
+    '',
+    `**Pod:** ${pod?.name ?? agent.podKey}`,
+    `**Status:** ${agent.status}`,
+    `**Primary runtime:** ${agent.primaryRuntime}`,
+    '',
+    `**Responsibility:** ${agent.responsibility}`,
+    '',
+    `**Engagement path:** ${agent.engagementPath}`,
+    '',
+    `**Approval gate:** ${agent.approvalGate}`,
+    '',
+    '### Suggested next action',
+    nextAction,
+    '',
+    '### Workflow coverage',
+    workflowLines,
+    note ? ['', '### Operator note', note].join('\n') : '',
+  ]
+    .filter(Boolean)
+    .join('\n')
+
+  return {
+    pod: pod?.name ?? agent.podKey,
+    nextAction,
+    activeWorkflowCount: activeWorkflows.length,
+    workflowCount: agent.n8nWorkflows.length,
+    summaryMarkdown,
+  }
+}
 
 /**
  * POST /api/admin/agents/engage
@@ -35,6 +87,7 @@ export async function POST(request: NextRequest) {
   const note = typeof body.note === 'string' ? body.note.trim().slice(0, 500) : null
 
   try {
+    const workPacket = buildWorkPacket(agent, note)
     const run = await startAgentRun({
       agentKey: agent.key,
       runtime: 'manual',
@@ -49,10 +102,12 @@ export async function POST(request: NextRequest) {
         requested_agent: agent.key,
         requested_agent_name: agent.name,
         pod: agent.podKey,
+        pod_name: workPacket.pod,
         status: agent.status,
         primary_runtime: agent.primaryRuntime,
         approval_gate: agent.approvalGate,
         engagement_path: agent.engagementPath,
+        suggested_next_action: workPacket.nextAction,
         note,
         executes_action: false,
       },
@@ -72,12 +127,36 @@ export async function POST(request: NextRequest) {
       idempotencyKey: `${run.id}:admin-agent-engagement-requested`,
     }).catch(() => {})
 
+    const artifact = await attachAgentArtifact({
+      runId: run.id,
+      artifactType: 'agent_engagement_work_packet',
+      title: `${agent.name} work packet`,
+      refType: 'agent',
+      refId: agent.key,
+      metadata: {
+        summary_markdown: workPacket.summaryMarkdown,
+        requested_agent: agent.key,
+        requested_agent_name: agent.name,
+        pod: agent.podKey,
+        pod_name: workPacket.pod,
+        primary_runtime: agent.primaryRuntime,
+        approval_gate: agent.approvalGate,
+        engagement_path: agent.engagementPath,
+        suggested_next_action: workPacket.nextAction,
+        workflow_count: workPacket.workflowCount,
+        active_workflow_count: workPacket.activeWorkflowCount,
+        executes_action: false,
+      },
+      idempotencyKey: `${run.id}:agent-engagement-work-packet`,
+    })
+
     return NextResponse.json({
       ok: true,
       run_id: run.id,
       agent_key: agent.key,
       agent_name: agent.name,
       status: 'queued',
+      work_packet_attached: Boolean(artifact),
     })
   } catch (error) {
     console.error('[admin-agent-engage] failed:', error)

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -190,6 +190,7 @@ Engagement requests:
 - create an `agent_run` with `kind = agent_engagement_request`,
 - start in `queued`,
 - record the requested agent key, pod, runtime path, and approval gate,
+- attach an `agent_engagement_work_packet` artifact with a readable work brief, mapped workflow coverage, and suggested next action,
 - do not execute the target agent or mutate production data.
 
 ## Chief of Staff Chat


### PR DESCRIPTION
## Summary
- attaches a readable agent_engagement_work_packet artifact to admin engagement requests
- includes pod, status, primary runtime, approval gate, suggested next action, and mapped workflow coverage
- keeps engagement requests queued and non-executing

## Validation
- npm test -- app/api/admin/agents/engage/route.test.ts lib/agent-slack-command.test.ts
- npx tsc --noEmit --pretty false
- npm run lint
- npm run build