### PR TITLE
feat: run read-only agent engagement dispatch

### DIFF
--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -40,7 +40,7 @@ export default function AgentOperationsPage() {
   const [morningResult, setMorningResult] = useState<{ runId: string; overall: string; slackNotified: boolean } | null>(null)
   const [morningError, setMorningError] = useState<string | null>(null)
   const [engagingAgentKey, setEngagingAgentKey] = useState<string | null>(null)
-  const [engagementResults, setEngagementResults] = useState<Record<string, string>>({})
+  const [engagementResults, setEngagementResults] = useState<Record<string, { runId: string; status: string }>>({})
   const [engagementError, setEngagementError] = useState<string | null>(null)
 
   async function runHermesHealthSummary() {
@@ -161,7 +161,10 @@ export default function AgentOperationsPage() {
       })
       const body = await res.json().catch(() => ({}))
       if (!res.ok) throw new Error(body.error || `HTTP ${res.status}`)
-      setEngagementResults((current) => ({ ...current, [agentKey]: body.run_id }))
+      setEngagementResults((current) => ({
+        ...current,
+        [agentKey]: { runId: body.run_id, status: body.status || 'queued' },
+      }))
     } catch (err) {
       setEngagementError(err instanceof Error ? err.message : 'Failed to queue agent engagement')
     } finally {
@@ -440,10 +443,12 @@ export default function AgentOperationsPage() {
                         <div className="mt-3 flex flex-wrap gap-2">
                           {engagementResults[agent.key] ? (
                             <Link
-                              href={`/admin/agents/runs/${engagementResults[agent.key]}`}
+                              href={`/admin/agents/runs/${engagementResults[agent.key].runId}`}
                               className="inline-flex items-center gap-1 rounded-md border border-emerald-400/40 bg-emerald-500/10 px-2 py-1 text-xs text-emerald-200 hover:underline"
                             >
-                              Engagement queued
+                              {engagementResults[agent.key].status === 'completed'
+                                ? 'Read-only run ready'
+                                : 'Engagement queued'}
                               <ArrowRight size={12} />
                             </Link>
                           ) : (
@@ -454,7 +459,7 @@ export default function AgentOperationsPage() {
                               className="inline-flex items-center gap-1 rounded-md border border-radiant-gold/50 bg-radiant-gold/10 px-2 py-1 text-xs text-radiant-gold hover:bg-radiant-gold/15 disabled:opacity-60"
                             >
                               <Send size={12} />
-                              Queue engagement
+                              Run read-only
                             </button>
                           )}
                         </div>

--- a/app/api/admin/agents/engage/route.test.ts
+++ b/app/api/admin/agents/engage/route.test.ts
@@ -5,6 +5,8 @@ const mocks = vi.hoisted(() => ({
   isAuthError: vi.fn(),
   startAgentRun: vi.fn(),
   recordAgentEvent: vi.fn(),
+  recordAgentStep: vi.fn(),
+  endAgentRun: vi.fn(),
   attachAgentArtifact: vi.fn(),
 }))
 
@@ -16,6 +18,8 @@ vi.mock('@/lib/auth-server', () => ({
 vi.mock('@/lib/agent-run', () => ({
   startAgentRun: mocks.startAgentRun,
   recordAgentEvent: mocks.recordAgentEvent,
+  recordAgentStep: mocks.recordAgentStep,
+  endAgentRun: mocks.endAgentRun,
   attachAgentArtifact: mocks.attachAgentArtifact,
 }))
 
@@ -36,6 +40,8 @@ describe('POST /api/admin/agents/engage', () => {
     mocks.isAuthError.mockReturnValue(false)
     mocks.startAgentRun.mockResolvedValue({ id: 'engagement-run-1' })
     mocks.recordAgentEvent.mockResolvedValue({ id: 'event-1' })
+    mocks.recordAgentStep.mockResolvedValue({ id: 'step-1' })
+    mocks.endAgentRun.mockResolvedValue(undefined)
     mocks.attachAgentArtifact.mockResolvedValue({ id: 'artifact-1' })
   })
 
@@ -50,7 +56,7 @@ describe('POST /api/admin/agents/engage', () => {
     expect(mocks.startAgentRun).not.toHaveBeenCalled()
   })
 
-  it('queues a traceable engagement request', async () => {
+  it('runs a read-only dispatch for a mapped active or partial agent', async () => {
     const response = await POST(makeRequest({
       agent_key: 'chief-of-staff',
       note: 'Review current blockers.',
@@ -62,8 +68,10 @@ describe('POST /api/admin/agents/engage', () => {
       run_id: 'engagement-run-1',
       agent_key: 'chief-of-staff',
       agent_name: 'Chief of Staff Agent',
-      status: 'queued',
+      status: 'completed',
       work_packet_attached: true,
+      dispatch_artifact_attached: true,
+      execution_mode: 'read_only',
     })
     expect(mocks.startAgentRun).toHaveBeenCalledWith(expect.objectContaining({
       agentKey: 'chief-of-staff',
@@ -86,6 +94,51 @@ describe('POST /api/admin/agents/engage', () => {
         executes_action: false,
       }),
     }))
+    expect(mocks.recordAgentStep).toHaveBeenCalledWith(expect.objectContaining({
+      runId: 'engagement-run-1',
+      stepKey: 'read_only_dispatch',
+      metadata: expect.objectContaining({
+        execution_mode: 'read_only',
+        executes_action: false,
+      }),
+    }))
+    expect(mocks.attachAgentArtifact).toHaveBeenCalledWith(expect.objectContaining({
+      runId: 'engagement-run-1',
+      artifactType: 'agent_read_only_dispatch',
+      title: 'Chief of Staff Agent read-only dispatch',
+      metadata: expect.objectContaining({
+        summary_markdown: expect.stringContaining('Chief of Staff Agent Read-Only Dispatch'),
+        executes_action: false,
+      }),
+    }))
+    expect(mocks.endAgentRun).toHaveBeenCalledWith(expect.objectContaining({
+      runId: 'engagement-run-1',
+      status: 'completed',
+      outcome: expect.objectContaining({
+        execution_mode: 'read_only',
+        executes_action: false,
+      }),
+    }))
+  })
+
+  it('queues planned agents for review without executing a dispatch', async () => {
+    const response = await POST(makeRequest({
+      agent_key: 'strategic-narrative',
+    }) as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      ok: true,
+      run_id: 'engagement-run-1',
+      agent_key: 'strategic-narrative',
+      agent_name: 'Strategic Narrative Agent',
+      status: 'queued',
+      work_packet_attached: true,
+      dispatch_artifact_attached: false,
+      execution_mode: 'queued_for_review',
+    })
+    expect(mocks.recordAgentStep).not.toHaveBeenCalled()
+    expect(mocks.endAgentRun).not.toHaveBeenCalled()
   })
 
   it('rejects unknown agents', async () => {

--- a/app/api/admin/agents/engage/route.ts
+++ b/app/api/admin/agents/engage/route.ts
@@ -1,6 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
-import { attachAgentArtifact, recordAgentEvent, startAgentRun } from '@/lib/agent-run'
+import {
+  attachAgentArtifact,
+  endAgentRun,
+  recordAgentEvent,
+  recordAgentStep,
+  startAgentRun,
+} from '@/lib/agent-run'
 import { AGENT_PODS, getAgentByKey } from '@/lib/agent-organization'
 import type { AgentOrganizationNode } from '@/lib/agent-organization'
 
@@ -53,6 +59,63 @@ function buildWorkPacket(agent: AgentOrganizationNode, note: string | null) {
     nextAction,
     activeWorkflowCount: activeWorkflows.length,
     workflowCount: agent.n8nWorkflows.length,
+    summaryMarkdown,
+  }
+}
+
+function canRunReadOnlyDispatch(agent: AgentOrganizationNode) {
+  return agent.status !== 'planned'
+}
+
+function buildReadOnlyDispatch(agent: AgentOrganizationNode, note: string | null) {
+  const activeWorkflows = agent.n8nWorkflows.filter((workflow) => workflow.active)
+  const productionWorkflows = activeWorkflows.filter((workflow) => workflow.environment === 'production')
+  const stagingWorkflows = activeWorkflows.filter((workflow) => workflow.environment === 'staging')
+
+  const nextActions =
+    agent.key === 'chief-of-staff'
+      ? [
+          'Review active and failed Agent Ops runs.',
+          'Route approval-sensitive work through the approval queue.',
+          'Escalate stale or failed runtime work before assigning new automation.',
+        ]
+      : agent.primaryRuntime === 'n8n'
+        ? [
+            'Confirm mapped production workflows are active before triggering downstream work.',
+            'Use existing admin surfaces for workflow-specific writes.',
+            'Keep config or workflow changes behind an approval checkpoint.',
+          ]
+        : [
+            'Use the work packet to define the next scoped artifact.',
+            'Keep this run read-only until a human approves a specific mutation.',
+            'Attach evidence, drafts, or implementation branches back to Agent Ops.',
+          ]
+
+  const summaryMarkdown = [
+    `## ${agent.name} Read-Only Dispatch`,
+    '',
+    `**Runtime posture:** ${agent.primaryRuntime}`,
+    `**Execution:** read-only`,
+    `**Production workflows active:** ${productionWorkflows.length}`,
+    `**Staging workflows active:** ${stagingWorkflows.length}`,
+    '',
+    `**Current responsibility:** ${agent.responsibility}`,
+    '',
+    '### Suggested next actions',
+    ...nextActions.map((action) => `- ${action}`),
+    '',
+    '### Approval boundary',
+    agent.approvalGate,
+    note ? ['', '### Operator note', note].join('\n') : '',
+  ]
+    .filter(Boolean)
+    .join('\n')
+
+  return {
+    nextActions,
+    activeWorkflowCount: activeWorkflows.length,
+    productionWorkflowCount: productionWorkflows.length,
+    stagingWorkflowCount: stagingWorkflows.length,
     summaryMarkdown,
   }
 }
@@ -150,13 +213,75 @@ export async function POST(request: NextRequest) {
       idempotencyKey: `${run.id}:agent-engagement-work-packet`,
     })
 
+    let status: 'queued' | 'completed' = 'queued'
+    let dispatchArtifactAttached = false
+
+    if (canRunReadOnlyDispatch(agent)) {
+      const dispatch = buildReadOnlyDispatch(agent, note)
+      await recordAgentStep({
+        runId: run.id,
+        stepKey: 'read_only_dispatch',
+        name: 'Prepared read-only agent dispatch',
+        status: 'completed',
+        inputSummary: `Agent: ${agent.name}`,
+        outputSummary: `${dispatch.activeWorkflowCount} active mapped workflow(s); no production data mutation.`,
+        metadata: {
+          requested_agent: agent.key,
+          execution_mode: 'read_only',
+          production_workflow_count: dispatch.productionWorkflowCount,
+          staging_workflow_count: dispatch.stagingWorkflowCount,
+          next_actions: dispatch.nextActions,
+          executes_action: false,
+        },
+        idempotencyKey: `${run.id}:read-only-dispatch-step`,
+      })
+
+      const dispatchArtifact = await attachAgentArtifact({
+        runId: run.id,
+        artifactType: 'agent_read_only_dispatch',
+        title: `${agent.name} read-only dispatch`,
+        refType: 'agent',
+        refId: agent.key,
+        metadata: {
+          summary_markdown: dispatch.summaryMarkdown,
+          requested_agent: agent.key,
+          requested_agent_name: agent.name,
+          execution_mode: 'read_only',
+          production_workflow_count: dispatch.productionWorkflowCount,
+          staging_workflow_count: dispatch.stagingWorkflowCount,
+          next_actions: dispatch.nextActions,
+          approval_gate: agent.approvalGate,
+          executes_action: false,
+        },
+        idempotencyKey: `${run.id}:agent-read-only-dispatch`,
+      })
+      dispatchArtifactAttached = Boolean(dispatchArtifact)
+
+      await endAgentRun({
+        runId: run.id,
+        status: 'completed',
+        currentStep: 'Read-only dispatch ready',
+        outcome: {
+          requested_agent: agent.key,
+          execution_mode: 'read_only',
+          active_workflow_count: dispatch.activeWorkflowCount,
+          work_packet_attached: Boolean(artifact),
+          dispatch_artifact_attached: dispatchArtifactAttached,
+          executes_action: false,
+        },
+      })
+      status = 'completed'
+    }
+
     return NextResponse.json({
       ok: true,
       run_id: run.id,
       agent_key: agent.key,
       agent_name: agent.name,
-      status: 'queued',
+      status,
       work_packet_attached: Boolean(artifact),
+      dispatch_artifact_attached: dispatchArtifactAttached,
+      execution_mode: status === 'completed' ? 'read_only' : 'queued_for_review',
     })
   } catch (error) {
     console.error('[admin-agent-engage] failed:', error)

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -183,7 +183,7 @@ Slack is an engagement surface, not the source of truth. The admin console and s
 
 ## Agent Engagement Requests
 
-Use `POST /api/admin/agents/engage`, the **Queue engagement** buttons on `/admin/agents`, or Slack `/agent run <agent-key>` to create a traceable `manual` runtime engagement request for any mapped agent.
+Use `POST /api/admin/agents/engage`, the **Run read-only** buttons on `/admin/agents`, or Slack `/agent run <agent-key>` to create a traceable `manual` runtime engagement request for any mapped agent.
 
 Engagement requests:
 
@@ -191,7 +191,9 @@ Engagement requests:
 - start in `queued`,
 - record the requested agent key, pod, runtime path, and approval gate,
 - attach an `agent_engagement_work_packet` artifact with a readable work brief, mapped workflow coverage, and suggested next action,
-- do not execute the target agent or mutate production data.
+- for active or partial agents, complete a read-only dispatch step and attach an `agent_read_only_dispatch` artifact with next actions,
+- keep planned agents queued for review until they have a narrow first task,
+- do not mutate production data.
 
 ## Chief of Staff Chat
 


### PR DESCRIPTION
## Summary
- turn active/partial agent engagement requests into completed read-only dispatch runs
- attach agent_read_only_dispatch artifacts with next actions and workflow posture
- keep planned agents queued for review until a narrow first task exists

## Validation
- npm test -- app/api/admin/agents/engage/route.test.ts lib/agent-slack-command.test.ts
- npx tsc --noEmit --pretty false
- npm run lint
- npm run build