### PR TITLE
feat: align slack agent engagement dispatch

### DIFF
--- a/app/api/admin/agents/engage/route.ts
+++ b/app/api/admin/agents/engage/route.ts
@@ -1,124 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
-import {
-  attachAgentArtifact,
-  endAgentRun,
-  recordAgentEvent,
-  recordAgentStep,
-  startAgentRun,
-} from '@/lib/agent-run'
-import { AGENT_PODS, getAgentByKey } from '@/lib/agent-organization'
-import type { AgentOrganizationNode } from '@/lib/agent-organization'
+import { createAgentEngagementRun } from '@/lib/agent-engagement'
+import { getAgentByKey } from '@/lib/agent-organization'
 
 export const dynamic = 'force-dynamic'
-
-function buildWorkPacket(agent: AgentOrganizationNode, note: string | null) {
-  const pod = AGENT_PODS.find((item) => item.key === agent.podKey)
-  const activeWorkflows = agent.n8nWorkflows.filter((workflow) => workflow.active)
-  const workflowLines = activeWorkflows.length
-    ? activeWorkflows
-        .slice(0, 8)
-        .map((workflow) => `- ${workflow.name} (${workflow.environment})`)
-        .join('\n')
-    : '- No active n8n workflow is mapped as the primary runtime yet.'
-
-  const nextAction =
-    agent.status === 'planned'
-      ? 'Define a first narrow, read-only task before assigning production automation.'
-      : agent.primaryRuntime === 'n8n'
-        ? 'Review mapped workflow health and decide whether to trigger the existing admin or n8n path.'
-        : agent.primaryRuntime === 'codex'
-          ? 'Use Codex to draft or implement the next scoped artifact, then route through PR/deploy gates if code changes are needed.'
-          : 'Use the listed engagement path and keep any production side effect behind the approval gate.'
-
-  const summaryMarkdown = [
-    `## ${agent.name} Work Packet`,
-    '',
-    `**Pod:** ${pod?.name ?? agent.podKey}`,
-    `**Status:** ${agent.status}`,
-    `**Primary runtime:** ${agent.primaryRuntime}`,
-    '',
-    `**Responsibility:** ${agent.responsibility}`,
-    '',
-    `**Engagement path:** ${agent.engagementPath}`,
-    '',
-    `**Approval gate:** ${agent.approvalGate}`,
-    '',
-    '### Suggested next action',
-    nextAction,
-    '',
-    '### Workflow coverage',
-    workflowLines,
-    note ? ['', '### Operator note', note].join('\n') : '',
-  ]
-    .filter(Boolean)
-    .join('\n')
-
-  return {
-    pod: pod?.name ?? agent.podKey,
-    nextAction,
-    activeWorkflowCount: activeWorkflows.length,
-    workflowCount: agent.n8nWorkflows.length,
-    summaryMarkdown,
-  }
-}
-
-function canRunReadOnlyDispatch(agent: AgentOrganizationNode) {
-  return agent.status !== 'planned'
-}
-
-function buildReadOnlyDispatch(agent: AgentOrganizationNode, note: string | null) {
-  const activeWorkflows = agent.n8nWorkflows.filter((workflow) => workflow.active)
-  const productionWorkflows = activeWorkflows.filter((workflow) => workflow.environment === 'production')
-  const stagingWorkflows = activeWorkflows.filter((workflow) => workflow.environment === 'staging')
-
-  const nextActions =
-    agent.key === 'chief-of-staff'
-      ? [
-          'Review active and failed Agent Ops runs.',
-          'Route approval-sensitive work through the approval queue.',
-          'Escalate stale or failed runtime work before assigning new automation.',
-        ]
-      : agent.primaryRuntime === 'n8n'
-        ? [
-            'Confirm mapped production workflows are active before triggering downstream work.',
-            'Use existing admin surfaces for workflow-specific writes.',
-            'Keep config or workflow changes behind an approval checkpoint.',
-          ]
-        : [
-            'Use the work packet to define the next scoped artifact.',
-            'Keep this run read-only until a human approves a specific mutation.',
-            'Attach evidence, drafts, or implementation branches back to Agent Ops.',
-          ]
-
-  const summaryMarkdown = [
-    `## ${agent.name} Read-Only Dispatch`,
-    '',
-    `**Runtime posture:** ${agent.primaryRuntime}`,
-    `**Execution:** read-only`,
-    `**Production workflows active:** ${productionWorkflows.length}`,
-    `**Staging workflows active:** ${stagingWorkflows.length}`,
-    '',
-    `**Current responsibility:** ${agent.responsibility}`,
-    '',
-    '### Suggested next actions',
-    ...nextActions.map((action) => `- ${action}`),
-    '',
-    '### Approval boundary',
-    agent.approvalGate,
-    note ? ['', '### Operator note', note].join('\n') : '',
-  ]
-    .filter(Boolean)
-    .join('\n')
-
-  return {
-    nextActions,
-    activeWorkflowCount: activeWorkflows.length,
-    productionWorkflowCount: productionWorkflows.length,
-    stagingWorkflowCount: stagingWorkflows.length,
-    summaryMarkdown,
-  }
-}
 
 /**
  * POST /api/admin/agents/engage
@@ -150,138 +35,32 @@ export async function POST(request: NextRequest) {
   const note = typeof body.note === 'string' ? body.note.trim().slice(0, 500) : null
 
   try {
-    const workPacket = buildWorkPacket(agent, note)
-    const run = await startAgentRun({
-      agentKey: agent.key,
-      runtime: 'manual',
-      kind: 'agent_engagement_request',
-      title: `Engage ${agent.name}`,
-      status: 'queued',
-      subject: { type: 'admin_agent_engagement', id: auth.user.id, label: 'Admin engagement request' },
+    const result = await createAgentEngagementRun({
+      agent,
+      actor: {
+        subjectType: 'admin_agent_engagement',
+        subjectId: auth.user.id,
+        subjectLabel: 'Admin engagement request',
+        userId: auth.user.id,
+      },
       triggerSource: 'admin_agent_engagement',
-      triggeredByUserId: auth.user.id,
-      currentStep: 'Engagement request queued',
-      metadata: {
-        requested_agent: agent.key,
-        requested_agent_name: agent.name,
-        pod: agent.podKey,
-        pod_name: workPacket.pod,
-        status: agent.status,
-        primary_runtime: agent.primaryRuntime,
-        approval_gate: agent.approvalGate,
-        engagement_path: agent.engagementPath,
-        suggested_next_action: workPacket.nextAction,
-        note,
-        executes_action: false,
-      },
+      note,
+      requestedEventMessage: `Admin requested ${agent.name}`,
       idempotencyKey: `admin-agent-engage:${agent.key}:${auth.user.id}:${Date.now()}`,
-    })
-
-    await recordAgentEvent({
-      runId: run.id,
-      eventType: 'agent_engagement_requested',
-      severity: 'info',
-      message: `Admin requested ${agent.name}`,
-      metadata: {
-        agent_key: agent.key,
+      eventMetadata: {
         requested_by_user_id: auth.user.id,
-        note,
       },
-      idempotencyKey: `${run.id}:admin-agent-engagement-requested`,
-    }).catch(() => {})
-
-    const artifact = await attachAgentArtifact({
-      runId: run.id,
-      artifactType: 'agent_engagement_work_packet',
-      title: `${agent.name} work packet`,
-      refType: 'agent',
-      refId: agent.key,
-      metadata: {
-        summary_markdown: workPacket.summaryMarkdown,
-        requested_agent: agent.key,
-        requested_agent_name: agent.name,
-        pod: agent.podKey,
-        pod_name: workPacket.pod,
-        primary_runtime: agent.primaryRuntime,
-        approval_gate: agent.approvalGate,
-        engagement_path: agent.engagementPath,
-        suggested_next_action: workPacket.nextAction,
-        workflow_count: workPacket.workflowCount,
-        active_workflow_count: workPacket.activeWorkflowCount,
-        executes_action: false,
-      },
-      idempotencyKey: `${run.id}:agent-engagement-work-packet`,
     })
-
-    let status: 'queued' | 'completed' = 'queued'
-    let dispatchArtifactAttached = false
-
-    if (canRunReadOnlyDispatch(agent)) {
-      const dispatch = buildReadOnlyDispatch(agent, note)
-      await recordAgentStep({
-        runId: run.id,
-        stepKey: 'read_only_dispatch',
-        name: 'Prepared read-only agent dispatch',
-        status: 'completed',
-        inputSummary: `Agent: ${agent.name}`,
-        outputSummary: `${dispatch.activeWorkflowCount} active mapped workflow(s); no production data mutation.`,
-        metadata: {
-          requested_agent: agent.key,
-          execution_mode: 'read_only',
-          production_workflow_count: dispatch.productionWorkflowCount,
-          staging_workflow_count: dispatch.stagingWorkflowCount,
-          next_actions: dispatch.nextActions,
-          executes_action: false,
-        },
-        idempotencyKey: `${run.id}:read-only-dispatch-step`,
-      })
-
-      const dispatchArtifact = await attachAgentArtifact({
-        runId: run.id,
-        artifactType: 'agent_read_only_dispatch',
-        title: `${agent.name} read-only dispatch`,
-        refType: 'agent',
-        refId: agent.key,
-        metadata: {
-          summary_markdown: dispatch.summaryMarkdown,
-          requested_agent: agent.key,
-          requested_agent_name: agent.name,
-          execution_mode: 'read_only',
-          production_workflow_count: dispatch.productionWorkflowCount,
-          staging_workflow_count: dispatch.stagingWorkflowCount,
-          next_actions: dispatch.nextActions,
-          approval_gate: agent.approvalGate,
-          executes_action: false,
-        },
-        idempotencyKey: `${run.id}:agent-read-only-dispatch`,
-      })
-      dispatchArtifactAttached = Boolean(dispatchArtifact)
-
-      await endAgentRun({
-        runId: run.id,
-        status: 'completed',
-        currentStep: 'Read-only dispatch ready',
-        outcome: {
-          requested_agent: agent.key,
-          execution_mode: 'read_only',
-          active_workflow_count: dispatch.activeWorkflowCount,
-          work_packet_attached: Boolean(artifact),
-          dispatch_artifact_attached: dispatchArtifactAttached,
-          executes_action: false,
-        },
-      })
-      status = 'completed'
-    }
 
     return NextResponse.json({
       ok: true,
-      run_id: run.id,
+      run_id: result.runId,
       agent_key: agent.key,
       agent_name: agent.name,
-      status,
-      work_packet_attached: Boolean(artifact),
-      dispatch_artifact_attached: dispatchArtifactAttached,
-      execution_mode: status === 'completed' ? 'read_only' : 'queued_for_review',
+      status: result.status,
+      work_packet_attached: result.workPacketAttached,
+      dispatch_artifact_attached: result.dispatchArtifactAttached,
+      execution_mode: result.executionMode,
     })
   } catch (error) {
     console.error('[admin-agent-engage] failed:', error)

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -177,13 +177,13 @@ The route verifies Slack signatures with `SLACK_SIGNING_SECRET` when configured 
 - `/agent approvals` — pending approval checkpoints with run links.
 - `/agent morning-review` — runs the approved Agent Ops morning review path with `trigger_source = slack_agent_ops_command`.
 - `/agent agents` — lists active and partial agent organization entries with their engagement keys.
-- `/agent run <agent-key>` — creates a traceable `manual` runtime engagement request in `agent_runs` without mutating production workflow data.
+- `/agent run <agent-key>` — creates the same traceable `manual` runtime engagement request as the admin button; active or partial agents produce a read-only dispatch artifact, while planned agents stay queued for review.
 
 Slack is an engagement surface, not the source of truth. The admin console and shared trace tables remain authoritative.
 
 ## Agent Engagement Requests
 
-Use `POST /api/admin/agents/engage`, the **Run read-only** buttons on `/admin/agents`, or Slack `/agent run <agent-key>` to create a traceable `manual` runtime engagement request for any mapped agent.
+Use `POST /api/admin/agents/engage`, the **Run read-only** buttons on `/admin/agents`, or Slack `/agent run <agent-key>` to create a traceable `manual` runtime engagement request for any mapped agent. Both entry points use the same engagement helper so their run metadata, work packets, and read-only dispatch artifacts stay aligned.
 
 Engagement requests:
 

--- a/lib/agent-engagement.ts
+++ b/lib/agent-engagement.ts
@@ -1,0 +1,284 @@
+import {
+  attachAgentArtifact,
+  endAgentRun,
+  recordAgentEvent,
+  recordAgentStep,
+  startAgentRun,
+} from '@/lib/agent-run'
+import { AGENT_PODS } from '@/lib/agent-organization'
+import type { AgentOrganizationNode } from '@/lib/agent-organization'
+
+export type AgentEngagementExecutionMode = 'read_only' | 'queued_for_review'
+
+export interface CreateAgentEngagementRunInput {
+  agent: AgentOrganizationNode
+  actor: {
+    subjectType: string
+    subjectId: string
+    subjectLabel: string
+    userId?: string | null
+  }
+  triggerSource: string
+  note?: string | null
+  requestedEventMessage: string
+  idempotencyKey?: string | null
+  eventMetadata?: Record<string, unknown>
+}
+
+export interface AgentEngagementRunResult {
+  runId: string
+  status: 'queued' | 'completed'
+  executionMode: AgentEngagementExecutionMode
+  workPacketAttached: boolean
+  dispatchArtifactAttached: boolean
+}
+
+export function buildAgentEngagementWorkPacket(agent: AgentOrganizationNode, note: string | null) {
+  const pod = AGENT_PODS.find((item) => item.key === agent.podKey)
+  const activeWorkflows = agent.n8nWorkflows.filter((workflow) => workflow.active)
+  const workflowLines = activeWorkflows.length
+    ? activeWorkflows
+        .slice(0, 8)
+        .map((workflow) => `- ${workflow.name} (${workflow.environment})`)
+        .join('\n')
+    : '- No active n8n workflow is mapped as the primary runtime yet.'
+
+  const nextAction =
+    agent.status === 'planned'
+      ? 'Define a first narrow, read-only task before assigning production automation.'
+      : agent.primaryRuntime === 'n8n'
+        ? 'Review mapped workflow health and decide whether to trigger the existing admin or n8n path.'
+        : agent.primaryRuntime === 'codex'
+          ? 'Use Codex to draft or implement the next scoped artifact, then route through PR/deploy gates if code changes are needed.'
+          : 'Use the listed engagement path and keep any production side effect behind the approval gate.'
+
+  const summaryMarkdown = [
+    `## ${agent.name} Work Packet`,
+    '',
+    `**Pod:** ${pod?.name ?? agent.podKey}`,
+    `**Status:** ${agent.status}`,
+    `**Primary runtime:** ${agent.primaryRuntime}`,
+    '',
+    `**Responsibility:** ${agent.responsibility}`,
+    '',
+    `**Engagement path:** ${agent.engagementPath}`,
+    '',
+    `**Approval gate:** ${agent.approvalGate}`,
+    '',
+    '### Suggested next action',
+    nextAction,
+    '',
+    '### Workflow coverage',
+    workflowLines,
+    note ? ['', '### Operator note', note].join('\n') : '',
+  ]
+    .filter(Boolean)
+    .join('\n')
+
+  return {
+    pod: pod?.name ?? agent.podKey,
+    nextAction,
+    activeWorkflowCount: activeWorkflows.length,
+    workflowCount: agent.n8nWorkflows.length,
+    summaryMarkdown,
+  }
+}
+
+export function canRunReadOnlyAgentDispatch(agent: AgentOrganizationNode) {
+  return agent.status !== 'planned'
+}
+
+export function buildReadOnlyAgentDispatch(agent: AgentOrganizationNode, note: string | null) {
+  const activeWorkflows = agent.n8nWorkflows.filter((workflow) => workflow.active)
+  const productionWorkflows = activeWorkflows.filter((workflow) => workflow.environment === 'production')
+  const stagingWorkflows = activeWorkflows.filter((workflow) => workflow.environment === 'staging')
+
+  const nextActions =
+    agent.key === 'chief-of-staff'
+      ? [
+          'Review active and failed Agent Ops runs.',
+          'Route approval-sensitive work through the approval queue.',
+          'Escalate stale or failed runtime work before assigning new automation.',
+        ]
+      : agent.primaryRuntime === 'n8n'
+        ? [
+            'Confirm mapped production workflows are active before triggering downstream work.',
+            'Use existing admin surfaces for workflow-specific writes.',
+            'Keep config or workflow changes behind an approval checkpoint.',
+          ]
+        : [
+            'Use the work packet to define the next scoped artifact.',
+            'Keep this run read-only until a human approves a specific mutation.',
+            'Attach evidence, drafts, or implementation branches back to Agent Ops.',
+          ]
+
+  const summaryMarkdown = [
+    `## ${agent.name} Read-Only Dispatch`,
+    '',
+    `**Runtime posture:** ${agent.primaryRuntime}`,
+    `**Execution:** read-only`,
+    `**Production workflows active:** ${productionWorkflows.length}`,
+    `**Staging workflows active:** ${stagingWorkflows.length}`,
+    '',
+    `**Current responsibility:** ${agent.responsibility}`,
+    '',
+    '### Suggested next actions',
+    ...nextActions.map((action) => `- ${action}`),
+    '',
+    '### Approval boundary',
+    agent.approvalGate,
+    note ? ['', '### Operator note', note].join('\n') : '',
+  ]
+    .filter(Boolean)
+    .join('\n')
+
+  return {
+    nextActions,
+    activeWorkflowCount: activeWorkflows.length,
+    productionWorkflowCount: productionWorkflows.length,
+    stagingWorkflowCount: stagingWorkflows.length,
+    summaryMarkdown,
+  }
+}
+
+export async function createAgentEngagementRun(
+  input: CreateAgentEngagementRunInput,
+): Promise<AgentEngagementRunResult> {
+  const { agent } = input
+  const note = input.note ? input.note.trim().slice(0, 500) : null
+  const workPacket = buildAgentEngagementWorkPacket(agent, note)
+
+  const run = await startAgentRun({
+    agentKey: agent.key,
+    runtime: 'manual',
+    kind: 'agent_engagement_request',
+    title: `Engage ${agent.name}`,
+    status: 'queued',
+    subject: {
+      type: input.actor.subjectType,
+      id: input.actor.subjectId,
+      label: input.actor.subjectLabel,
+    },
+    triggerSource: input.triggerSource,
+    triggeredByUserId: input.actor.userId ?? null,
+    currentStep: 'Engagement request queued',
+    metadata: {
+      requested_agent: agent.key,
+      requested_agent_name: agent.name,
+      pod: agent.podKey,
+      pod_name: workPacket.pod,
+      status: agent.status,
+      primary_runtime: agent.primaryRuntime,
+      approval_gate: agent.approvalGate,
+      engagement_path: agent.engagementPath,
+      suggested_next_action: workPacket.nextAction,
+      note,
+      executes_action: false,
+    },
+    idempotencyKey: input.idempotencyKey ?? null,
+  })
+
+  await recordAgentEvent({
+    runId: run.id,
+    eventType: 'agent_engagement_requested',
+    severity: 'info',
+    message: input.requestedEventMessage,
+    metadata: {
+      agent_key: agent.key,
+      note,
+      ...(input.eventMetadata ?? {}),
+    },
+    idempotencyKey: `${run.id}:${input.triggerSource}:requested`,
+  }).catch(() => {})
+
+  const artifact = await attachAgentArtifact({
+    runId: run.id,
+    artifactType: 'agent_engagement_work_packet',
+    title: `${agent.name} work packet`,
+    refType: 'agent',
+    refId: agent.key,
+    metadata: {
+      summary_markdown: workPacket.summaryMarkdown,
+      requested_agent: agent.key,
+      requested_agent_name: agent.name,
+      pod: agent.podKey,
+      pod_name: workPacket.pod,
+      primary_runtime: agent.primaryRuntime,
+      approval_gate: agent.approvalGate,
+      engagement_path: agent.engagementPath,
+      suggested_next_action: workPacket.nextAction,
+      workflow_count: workPacket.workflowCount,
+      active_workflow_count: workPacket.activeWorkflowCount,
+      executes_action: false,
+    },
+    idempotencyKey: `${run.id}:agent-engagement-work-packet`,
+  })
+
+  let status: AgentEngagementRunResult['status'] = 'queued'
+  let dispatchArtifactAttached = false
+
+  if (canRunReadOnlyAgentDispatch(agent)) {
+    const dispatch = buildReadOnlyAgentDispatch(agent, note)
+    await recordAgentStep({
+      runId: run.id,
+      stepKey: 'read_only_dispatch',
+      name: 'Prepared read-only agent dispatch',
+      status: 'completed',
+      inputSummary: `Agent: ${agent.name}`,
+      outputSummary: `${dispatch.activeWorkflowCount} active mapped workflow(s); no production data mutation.`,
+      metadata: {
+        requested_agent: agent.key,
+        execution_mode: 'read_only',
+        production_workflow_count: dispatch.productionWorkflowCount,
+        staging_workflow_count: dispatch.stagingWorkflowCount,
+        next_actions: dispatch.nextActions,
+        executes_action: false,
+      },
+      idempotencyKey: `${run.id}:read-only-dispatch-step`,
+    })
+
+    const dispatchArtifact = await attachAgentArtifact({
+      runId: run.id,
+      artifactType: 'agent_read_only_dispatch',
+      title: `${agent.name} read-only dispatch`,
+      refType: 'agent',
+      refId: agent.key,
+      metadata: {
+        summary_markdown: dispatch.summaryMarkdown,
+        requested_agent: agent.key,
+        requested_agent_name: agent.name,
+        execution_mode: 'read_only',
+        production_workflow_count: dispatch.productionWorkflowCount,
+        staging_workflow_count: dispatch.stagingWorkflowCount,
+        next_actions: dispatch.nextActions,
+        approval_gate: agent.approvalGate,
+        executes_action: false,
+      },
+      idempotencyKey: `${run.id}:agent-read-only-dispatch`,
+    })
+    dispatchArtifactAttached = Boolean(dispatchArtifact)
+
+    await endAgentRun({
+      runId: run.id,
+      status: 'completed',
+      currentStep: 'Read-only dispatch ready',
+      outcome: {
+        requested_agent: agent.key,
+        execution_mode: 'read_only',
+        active_workflow_count: dispatch.activeWorkflowCount,
+        work_packet_attached: Boolean(artifact),
+        dispatch_artifact_attached: dispatchArtifactAttached,
+        executes_action: false,
+      },
+    })
+    status = 'completed'
+  }
+
+  return {
+    runId: run.id,
+    status,
+    executionMode: status === 'completed' ? 'read_only' : 'queued_for_review',
+    workPacketAttached: Boolean(artifact),
+    dispatchArtifactAttached,
+  }
+}

--- a/lib/agent-slack-command.test.ts
+++ b/lib/agent-slack-command.test.ts
@@ -11,11 +11,17 @@ vi.mock('@/lib/agent-ops-morning-review', () => ({
 const agentRunMocks = vi.hoisted(() => ({
   startAgentRun: vi.fn(),
   recordAgentEvent: vi.fn(),
+  recordAgentStep: vi.fn(),
+  endAgentRun: vi.fn(),
+  attachAgentArtifact: vi.fn(),
 }))
 
 vi.mock('@/lib/agent-run', () => ({
   startAgentRun: agentRunMocks.startAgentRun,
   recordAgentEvent: agentRunMocks.recordAgentEvent,
+  recordAgentStep: agentRunMocks.recordAgentStep,
+  endAgentRun: agentRunMocks.endAgentRun,
+  attachAgentArtifact: agentRunMocks.attachAgentArtifact,
 }))
 
 import { agentSlackCommandInternals, createAgentEngagementSlackText } from '@/lib/agent-slack-command'
@@ -57,6 +63,9 @@ describe('agent Slack command parsing', () => {
   it('creates a traceable engagement request for a known agent', async () => {
     agentRunMocks.startAgentRun.mockResolvedValue({ id: 'run-123' })
     agentRunMocks.recordAgentEvent.mockResolvedValue({ id: 'event-123' })
+    agentRunMocks.recordAgentStep.mockResolvedValue({ id: 'step-123' })
+    agentRunMocks.endAgentRun.mockResolvedValue(undefined)
+    agentRunMocks.attachAgentArtifact.mockResolvedValue({ id: 'artifact-123' })
 
     const text = await createAgentEngagementSlackText({
       text: 'run chief-of-staff',
@@ -78,7 +87,26 @@ describe('agent Slack command parsing', () => {
         eventType: 'agent_engagement_requested',
       }),
     )
-    expect(text).toContain('Chief of Staff Agent engagement queued')
+    expect(agentRunMocks.recordAgentStep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'run-123',
+        stepKey: 'read_only_dispatch',
+      }),
+    )
+    expect(agentRunMocks.attachAgentArtifact).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'run-123',
+        artifactType: 'agent_read_only_dispatch',
+      }),
+    )
+    expect(agentRunMocks.endAgentRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'run-123',
+        status: 'completed',
+      }),
+    )
+    expect(text).toContain('Chief of Staff Agent read-only dispatch ready')
+    expect(text).toContain('Execution mode: read_only')
     expect(text).toContain('/admin/agents/runs/run-123')
   })
 

--- a/lib/agent-slack-command.ts
+++ b/lib/agent-slack-command.ts
@@ -1,6 +1,6 @@
 import { runAgentOpsMorningReview } from '@/lib/agent-ops-morning-review'
+import { createAgentEngagementRun } from '@/lib/agent-engagement'
 import { AGENT_ORGANIZATION, getAgentByKey } from '@/lib/agent-organization'
-import { startAgentRun, recordAgentEvent } from '@/lib/agent-run'
 import { supabaseAdmin } from '@/lib/supabase'
 
 type SlackCommandName = 'help' | 'status' | 'failed' | 'approvals' | 'morning-review' | 'agents' | 'run'
@@ -262,40 +262,30 @@ export async function createAgentEngagementSlackText(input: AgentSlackCommandInp
 
   try {
     const actor = input.userName || input.userId || 'Slack user'
-    const run = await startAgentRun({
-      agentKey: agent.key,
-      runtime: 'manual',
-      kind: 'agent_engagement_request',
-      title: `Engage ${agent.name}`,
-      status: 'queued',
-      subject: { type: 'slack_command', id: input.userId ?? actor, label: actor },
+    const result = await createAgentEngagementRun({
+      agent,
+      actor: {
+        subjectType: 'slack_command',
+        subjectId: input.userId ?? actor,
+        subjectLabel: actor,
+      },
       triggerSource: 'slack_agent_run_command',
-      currentStep: 'Engagement request queued',
-      metadata: {
-        requested_agent: agent.key,
-        requested_agent_name: agent.name,
-        pod: agent.podKey,
-        primary_runtime: agent.primaryRuntime,
-        approval_gate: agent.approvalGate,
-        engagement_path: agent.engagementPath,
+      requestedEventMessage: `${actor} requested ${agent.name} from Slack`,
+      eventMetadata: {
+        slack_user_id: input.userId ?? null,
+        slack_user_name: input.userName ?? null,
       },
     })
 
-    await recordAgentEvent({
-      runId: run.id,
-      eventType: 'agent_engagement_requested',
-      severity: 'info',
-      message: `${actor} requested ${agent.name} from Slack`,
-      metadata: { agent_key: agent.key, slack_user_id: input.userId ?? null, slack_user_name: input.userName ?? null },
-      idempotencyKey: `${run.id}:slack-requested`,
-    })
-
     return [
-      `*${agent.name} engagement queued*`,
+      result.status === 'completed'
+        ? `*${agent.name} read-only dispatch ready*`
+        : `*${agent.name} engagement queued*`,
       `Agent key: \`${agent.key}\``,
       `Runtime path: ${agent.primaryRuntime}`,
+      `Execution mode: ${result.executionMode}`,
       `Current guardrail: ${agent.approvalGate}`,
-      `Review: ${agentRunsUrl(run.id)}`,
+      `Review: ${agentRunsUrl(result.runId)}`,
     ].join('\n')
   } catch (error) {
     return `Agent engagement request failed: ${error instanceof Error ? error.message : 'Unknown error'}`


### PR DESCRIPTION
## Summary
- extract shared agent engagement helper used by admin and Slack
- make Slack /agent run create the same work packet and read-only dispatch artifacts as the admin button
- document Slack/admin parity for engagement requests

## Validation
- npm test -- app/api/admin/agents/engage/route.test.ts lib/agent-slack-command.test.ts
- npx tsc --noEmit --pretty false
- npm run lint
- npm run build