### PR TITLE
feat: add chief of staff agent dispatch proposals

### DIFF
--- a/app/admin/agents/chief-of-staff/page.tsx
+++ b/app/admin/agents/chief-of-staff/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import { FormEvent, useMemo, useState } from 'react'
-import { ArrowLeft, Bot, ExternalLink, Send, ShieldCheck } from 'lucide-react'
+import { ArrowLeft, Bot, ExternalLink, PlayCircle, Send, ShieldCheck } from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
 import { getCurrentSession } from '@/lib/auth'
@@ -16,12 +16,22 @@ type ChiefOfStaffActionProposal = {
   riskLevel: 'low' | 'medium' | 'high'
 }
 
+type ChiefOfStaffAgentEngagementProposal = {
+  agentKey: string
+  agentName: string
+  label: string
+  rationale: string
+  status: 'active' | 'partial' | 'planned'
+  executionMode: 'read_only' | 'queued_for_review'
+}
+
 type ChatMessage = {
   role: 'user' | 'assistant'
   content: string
   runId?: string
   suggestedActions?: string[]
   actionProposals?: ChiefOfStaffActionProposal[]
+  agentEngagements?: ChiefOfStaffAgentEngagementProposal[]
 }
 
 const STARTER_PROMPTS = [
@@ -43,6 +53,8 @@ export default function ChiefOfStaffAgentPage() {
   const [loading, setLoading] = useState(false)
   const [creatingApproval, setCreatingApproval] = useState<string | null>(null)
   const [approvalLinks, setApprovalLinks] = useState<Record<string, string>>({})
+  const [engagingAgent, setEngagingAgent] = useState<string | null>(null)
+  const [engagementLinks, setEngagementLinks] = useState<Record<string, { runId: string; status: string }>>({})
   const [error, setError] = useState<string | null>(null)
 
   const history = useMemo(
@@ -82,6 +94,7 @@ export default function ChiefOfStaffAgentPage() {
           runId: body.run_id,
           suggestedActions: Array.isArray(body.suggested_actions) ? body.suggested_actions : [],
           actionProposals: Array.isArray(body.action_proposals) ? body.action_proposals : [],
+          agentEngagements: Array.isArray(body.agent_engagements) ? body.agent_engagements : [],
         },
       ])
     } catch (err) {
@@ -126,6 +139,42 @@ export default function ChiefOfStaffAgentPage() {
       setError(err instanceof Error ? err.message : 'Failed to create approval checkpoint')
     } finally {
       setCreatingApproval(null)
+    }
+  }
+
+  async function runAgentEngagement(sourceRunId: string | undefined, proposal: ChiefOfStaffAgentEngagementProposal) {
+    const key = `${sourceRunId}:${proposal.agentKey}:${proposal.label}`
+    if (engagingAgent === key) return
+
+    setEngagingAgent(key)
+    setError(null)
+
+    try {
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Missing admin session')
+
+      const res = await fetch('/api/admin/agents/engage', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${session.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          agent_key: proposal.agentKey,
+          note: `Launched from Chief of Staff chat${sourceRunId ? ` run ${sourceRunId}` : ''}: ${proposal.rationale}`,
+        }),
+      })
+      const body = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(body.error || `HTTP ${res.status}`)
+
+      setEngagementLinks((current) => ({
+        ...current,
+        [key]: { runId: body.run_id, status: body.status || 'queued' },
+      }))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to run agent engagement')
+    } finally {
+      setEngagingAgent(null)
     }
   }
 
@@ -257,6 +306,57 @@ export default function ChiefOfStaffAgentPage() {
                                     </button>
                                   )
                                 ) : null}
+                              </div>
+                            </div>
+                          )
+                        })}
+                      </div>
+                    ) : null}
+                    {message.agentEngagements?.length ? (
+                      <div className="mt-4 space-y-2">
+                        {message.agentEngagements.map((proposal) => {
+                          const key = `${message.runId}:${proposal.agentKey}:${proposal.label}`
+                          const engagement = engagementLinks[key]
+
+                          return (
+                            <div
+                              key={key}
+                              className="rounded-lg border border-cyan-400/30 bg-cyan-500/10 p-3"
+                            >
+                              <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                                <div>
+                                  <div className="flex flex-wrap items-center gap-2">
+                                    <p className="text-sm font-semibold">{proposal.label}</p>
+                                    <span className="rounded-full border border-cyan-300/40 px-2 py-0.5 text-[11px] text-cyan-100">
+                                      {proposal.agentKey}
+                                    </span>
+                                    <span className="rounded-full border border-silicon-slate/60 px-2 py-0.5 text-[11px] uppercase text-muted-foreground">
+                                      {proposal.executionMode}
+                                    </span>
+                                  </div>
+                                  <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                                    {proposal.rationale}
+                                  </p>
+                                </div>
+                                {engagement ? (
+                                  <Link
+                                    href={`/admin/agents/runs/${engagement.runId}`}
+                                    className="inline-flex shrink-0 items-center gap-1 rounded-md border border-emerald-400/40 bg-emerald-500/10 px-2 py-1 text-xs text-emerald-200 hover:underline"
+                                  >
+                                    {engagement.status === 'completed' ? 'Run ready' : 'Queued'}
+                                    <ExternalLink size={12} />
+                                  </Link>
+                                ) : (
+                                  <button
+                                    type="button"
+                                    onClick={() => runAgentEngagement(message.runId, proposal)}
+                                    disabled={loading || engagingAgent === key}
+                                    className="inline-flex shrink-0 items-center gap-1 rounded-md border border-cyan-300/40 bg-cyan-500/10 px-2 py-1 text-xs text-cyan-100 hover:bg-cyan-500/15 disabled:opacity-60"
+                                  >
+                                    <PlayCircle size={12} />
+                                    {proposal.executionMode === 'read_only' ? 'Run read-only' : 'Queue'}
+                                  </button>
+                                )}
                               </div>
                             </div>
                           )

--- a/app/api/admin/agents/chief-of-staff/chat/route.test.ts
+++ b/app/api/admin/agents/chief-of-staff/chat/route.test.ts
@@ -54,6 +54,16 @@ describe('POST /api/admin/agents/chief-of-staff/chat', () => {
           riskLevel: 'high',
         },
       ],
+      agentEngagements: [
+        {
+          agentKey: 'research-source-register',
+          agentName: 'Research & Source Register Agent',
+          label: 'Run research agent',
+          rationale: 'Collect source-backed context for the next decision.',
+          status: 'partial',
+          executionMode: 'read_only',
+        },
+      ],
       model: 'gpt-4o-mini',
     })
   })
@@ -97,6 +107,16 @@ describe('POST /api/admin/agents/chief-of-staff/chat', () => {
           approvalType: 'send_email',
           requiresApproval: true,
           riskLevel: 'high',
+        },
+      ],
+      agent_engagements: [
+        {
+          agentKey: 'research-source-register',
+          agentName: 'Research & Source Register Agent',
+          label: 'Run research agent',
+          rationale: 'Collect source-backed context for the next decision.',
+          status: 'partial',
+          executionMode: 'read_only',
         },
       ],
       model: 'gpt-4o-mini',

--- a/app/api/admin/agents/chief-of-staff/chat/route.ts
+++ b/app/api/admin/agents/chief-of-staff/chat/route.ts
@@ -51,6 +51,7 @@ export async function POST(request: NextRequest) {
       reply: result.reply,
       suggested_actions: result.suggestedActions,
       action_proposals: result.actionProposals,
+      agent_engagements: result.agentEngagements,
       model: result.model,
     })
   } catch (error) {

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -2,6 +2,8 @@
 
 The Portfolio admin remains the control plane. Codex and n8n stay as the primary operating backbone, while Hermes is added as a secondary runtime after shared run tracing is available. OpenCode/OpenClaw are deferred until their work can be observed, audited, and rolled back through the same trace model.
 
+The active execution queue for the remaining rollout work lives in [Agent Operations Task List](./agent-operations-task-list.md).
+
 ## Runtime Model
 
 Supported runtimes:
@@ -204,6 +206,7 @@ The first conversational agent surface is `/admin/agents/chief-of-staff`.
 - It creates a traced `codex` runtime `agent_run` for every exchange.
 - It uses `CHIEF_OF_STAFF_AGENT_MODEL` when set, otherwise `gpt-4o-mini`.
 - It returns both plain suggested follow-ups and typed action proposals using the shared runtime policy action IDs.
+- It can recommend mapped agent engagement proposals with `agent_key`, label, and rationale so the chat can launch the same read-only dispatch path used by `/admin/agents` and Slack.
 - Typed action proposals can be converted into approval checkpoints with `POST /api/admin/agents/chief-of-staff/actions`.
 - The approval action route creates a separate `manual` runtime run in `waiting_for_approval` and a pending `agent_approvals` record.
 - V1 remains non-executing. It can recommend next actions and create approval checkpoints, but it does not mutate production workflows, send messages, publish content, or change configuration.

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -1,0 +1,43 @@
+# Agent Operations Task List
+
+This is the active implementation queue for turning the agent organization into usable operating software.
+
+## Current Autopilot Block
+
+- [x] Confirm baseline: `origin/main`, open PRs, and production/staging Vercel deployment state.
+- [x] Keep Portfolio admin as the source of truth for agent operations.
+- [x] Support read-only agent dispatch from `/admin/agents`.
+- [x] Support the same read-only dispatch from Slack `/agent run <agent-key>`.
+- [ ] Let Chief of Staff chat recommend mapped agents and launch their read-only dispatch runs.
+- [ ] Keep every launched agent engagement visible in `/admin/agents/runs`.
+- [ ] Validate with focused tests, typecheck, lint, build, PR previews, merge, and production/staging deployment checks.
+
+## Next Operating Milestones
+
+1. Chief of Staff dispatcher
+   - The chat should recommend which mapped agent to run next.
+   - Recommendations should include `agent_key`, label, and rationale.
+   - Launching the recommendation must create the same traced read-only engagement used by admin and Slack.
+
+2. Agent-specific first tasks
+   - Give the highest-value partial agents a first narrow read-only task:
+     - `chief-of-staff`
+     - `research-source-register`
+     - `voice-content-architect`
+     - `automation-systems`
+     - `inbox-follow-up`
+   - Planned agents should stay queued until the first task is explicit.
+
+3. Approval-backed execution
+   - Convert safe read-only recommendations into approval checkpoints when they require side effects.
+   - Keep publishing, outbound email, unknown database writes, production config, and private-to-public content behind `agent_approvals`.
+
+4. Mobile operation
+   - Keep Slack as the lightweight command surface.
+   - Keep Portfolio admin as the source of truth.
+   - Avoid adding another channel unless Slack cannot support the workflow.
+
+5. Hardening
+   - Add stale-run handling for every runtime.
+   - Add dashboard-level cost summaries by agent and runtime.
+   - Keep n8n compatibility adapters live until the generic trace model is proven.

--- a/lib/chief-of-staff-chat.test.ts
+++ b/lib/chief-of-staff-chat.test.ts
@@ -75,6 +75,18 @@ describe('Chief of Staff chat helpers', () => {
           risk_level: 'high',
         },
       ],
+      agent_engagements: [
+        {
+          agent_key: 'research-source-register',
+          label: 'Run research agent',
+          rationale: 'Gather source-backed context for this decision.',
+        },
+        {
+          agent_key: 'unknown-agent',
+          label: 'Ignore unknown',
+          rationale: 'This should be dropped.',
+        },
+      ],
     }))
 
     expect(result.reply).toContain('pending deployment')
@@ -89,6 +101,16 @@ describe('Chief of Staff chat helpers', () => {
         riskLevel: 'high',
       },
     ])
+    expect(result.agentEngagements).toEqual([
+      {
+        agentKey: 'research-source-register',
+        agentName: 'Research & Source Register Agent',
+        label: 'Run research agent',
+        rationale: 'Gather source-backed context for this decision.',
+        status: 'partial',
+        executionMode: 'read_only',
+      },
+    ])
   })
 
   it('builds a read-only operational prompt', () => {
@@ -97,6 +119,7 @@ describe('Chief of Staff chat helpers', () => {
     expect(prompt.systemPrompt).toContain('production mutations')
     expect(prompt.systemPrompt).toContain('Return JSON only')
     expect(prompt.systemPrompt).toContain('action_proposals')
+    expect(prompt.systemPrompt).toContain('agent_engagements')
     expect(prompt.userPrompt).toContain('Morning review')
     expect(prompt.userPrompt).toContain('What needs attention?')
   })

--- a/lib/chief-of-staff-chat.ts
+++ b/lib/chief-of-staff-chat.ts
@@ -11,6 +11,7 @@ import {
   getApprovalGate,
   type AgentAction,
 } from '@/lib/agent-policy'
+import { getAgentByKey } from '@/lib/agent-organization'
 import { supabaseAdmin } from '@/lib/supabase'
 
 export type ChiefOfStaffChatMessage = {
@@ -29,6 +30,7 @@ export type ChiefOfStaffChatResponse = {
   reply: string
   suggestedActions: string[]
   actionProposals: ChiefOfStaffActionProposal[]
+  agentEngagements: ChiefOfStaffAgentEngagementProposal[]
   model: string
 }
 
@@ -39,6 +41,15 @@ export type ChiefOfStaffActionProposal = {
   approvalType: string | null
   requiresApproval: boolean
   riskLevel: 'low' | 'medium' | 'high'
+}
+
+export type ChiefOfStaffAgentEngagementProposal = {
+  agentKey: string
+  agentName: string
+  label: string
+  rationale: string
+  status: 'active' | 'partial' | 'planned'
+  executionMode: 'read_only' | 'queued_for_review'
 }
 
 type AgentRunSummaryRow = {
@@ -155,15 +166,53 @@ function parseActionProposals(parsed: { action_proposals?: unknown }): ChiefOfSt
     .slice(0, 5)
 }
 
+function parseAgentEngagements(parsed: { agent_engagements?: unknown }): ChiefOfStaffAgentEngagementProposal[] {
+  if (!Array.isArray(parsed.agent_engagements)) return []
+
+  const seen = new Set<string>()
+  return parsed.agent_engagements
+    .flatMap((proposal): ChiefOfStaffAgentEngagementProposal[] => {
+      if (!proposal || typeof proposal !== 'object') return []
+      const raw = proposal as Record<string, unknown>
+      const agentKey = typeof raw.agent_key === 'string' ? raw.agent_key.trim() : ''
+      if (!agentKey || seen.has(agentKey)) return []
+
+      const agent = getAgentByKey(agentKey)
+      if (!agent) return []
+      seen.add(agentKey)
+
+      const label = typeof raw.label === 'string' && raw.label.trim()
+        ? raw.label.trim()
+        : `Run ${agent.name}`
+      const rationale = typeof raw.rationale === 'string' && raw.rationale.trim()
+        ? raw.rationale.trim()
+        : agent.responsibility
+
+      return [
+        {
+          agentKey: agent.key,
+          agentName: agent.name,
+          label: label.slice(0, 120),
+          rationale: rationale.slice(0, 400),
+          status: agent.status,
+          executionMode: agent.status === 'planned' ? 'queued_for_review' : 'read_only',
+        },
+      ]
+    })
+    .slice(0, 4)
+}
+
 export function parseChiefOfStaffJson(content: string): {
   reply: string
   suggestedActions: string[]
   actionProposals: ChiefOfStaffActionProposal[]
+  agentEngagements: ChiefOfStaffAgentEngagementProposal[]
 } {
   const parsed = JSON.parse(content) as {
     reply?: unknown
     suggested_actions?: unknown
     action_proposals?: unknown
+    agent_engagements?: unknown
   }
   const reply = typeof parsed.reply === 'string' ? parsed.reply.trim() : ''
   if (!reply) {
@@ -178,7 +227,12 @@ export function parseChiefOfStaffJson(content: string): {
         .slice(0, 5)
     : []
 
-  return { reply, suggestedActions, actionProposals: parseActionProposals(parsed) }
+  return {
+    reply,
+    suggestedActions,
+    actionProposals: parseActionProposals(parsed),
+    agentEngagements: parseAgentEngagements(parsed),
+  }
 }
 
 export async function collectChiefOfStaffContext(): Promise<ChiefOfStaffContext> {
@@ -243,8 +297,10 @@ export function buildChiefOfStaffPrompt(context: ChiefOfStaffContext, history: C
       'Use only the provided operating context. If the user asks for production mutations, sending messages, publishing, or config changes, explain that approval is required and suggest the approval path.',
       'Be concise, direct, and operational. Do not pretend to have run tools that are not in the context.',
       'When proposing an executable next step, include a typed action proposal. The proposal is only a recommendation; it does not execute work.',
+      'When the next step should be handled by one of the mapped agents, include an agent_engagements proposal with the exact agent_key.',
       'Use only these action ids: read_files, write_files, external_api_call, client_data_access, known_workflow_db_write, unknown_db_write, publish_public_content, send_email, production_config_change, public_content_from_private_material.',
-      'Return JSON only with keys: reply, suggested_actions, action_proposals.',
+      'Use only these agent keys when recommending an agent engagement: chief-of-staff, research-source-register, private-knowledge-librarian, voice-content-architect, content-repurposing, engineering-copilot, automation-systems, agent-tooling-parity, website-product-copy, inbox-follow-up.',
+      'Return JSON only with keys: reply, suggested_actions, action_proposals, agent_engagements.',
     ].join('\n'),
     userPrompt: JSON.stringify(
       {
@@ -259,6 +315,13 @@ export function buildChiefOfStaffPrompt(context: ChiefOfStaffContext, history: C
               description: 'One sentence describing the proposed action and why it is useful.',
               action: 'One allowed action id. Use approval-gated ids for risky work.',
               risk_level: 'low, medium, or high.',
+            },
+          ],
+          agent_engagements: [
+            {
+              agent_key: 'A mapped agent key when a read-only agent run is the right next step.',
+              label: 'Short button label.',
+              rationale: 'One sentence explaining why this agent should be engaged.',
             },
           ],
         },
@@ -338,6 +401,7 @@ export async function runChiefOfStaffChat(input: ChiefOfStaffChatRequest): Promi
         model,
         suggested_actions: parsed.suggestedActions,
         action_proposals: parsed.actionProposals,
+        agent_engagements: parsed.agentEngagements,
       },
     })
 
@@ -349,6 +413,7 @@ export async function runChiefOfStaffChat(input: ChiefOfStaffChatRequest): Promi
         reply_preview: parsed.reply.slice(0, 500),
         suggested_actions: parsed.suggestedActions,
         action_proposals: parsed.actionProposals,
+        agent_engagements: parsed.agentEngagements,
       },
     })
 
@@ -357,6 +422,7 @@ export async function runChiefOfStaffChat(input: ChiefOfStaffChatRequest): Promi
       reply: parsed.reply,
       suggestedActions: parsed.suggestedActions,
       actionProposals: parsed.actionProposals,
+      agentEngagements: parsed.agentEngagements,
       model,
     }
   } catch (error) {


### PR DESCRIPTION
## Summary
- add an Agent Operations task list for the active rollout queue
- let Chief of Staff chat return mapped agent engagement proposals
- add chat buttons that launch the existing read-only agent engagement path and link to the traced run

## Validation
- npm test -- lib/chief-of-staff-chat.test.ts app/api/admin/agents/chief-of-staff/chat/route.test.ts app/api/admin/agents/engage/route.test.ts lib/agent-slack-command.test.ts
- npx tsc --noEmit --pretty false
- npm run lint
- npm run build