### PR TITLE
feat: add agent first task templates

### DIFF
--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -194,6 +194,7 @@ Engagement requests:
 - record the requested agent key, pod, runtime path, and approval gate,
 - attach an `agent_engagement_work_packet` artifact with a readable work brief, mapped workflow coverage, and suggested next action,
 - for active or partial agents, complete a read-only dispatch step and attach an `agent_read_only_dispatch` artifact with next actions,
+- include a first-task template for priority agents so each read-only dispatch has an objective, checklist, and expected output,
 - keep planned agents queued for review until they have a narrow first task,
 - do not mutate production data.
 

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -8,8 +8,9 @@ This is the active implementation queue for turning the agent organization into 
 - [x] Keep Portfolio admin as the source of truth for agent operations.
 - [x] Support read-only agent dispatch from `/admin/agents`.
 - [x] Support the same read-only dispatch from Slack `/agent run <agent-key>`.
-- [ ] Let Chief of Staff chat recommend mapped agents and launch their read-only dispatch runs.
-- [ ] Keep every launched agent engagement visible in `/admin/agents/runs`.
+- [x] Let Chief of Staff chat recommend mapped agents and launch their read-only dispatch runs.
+- [x] Keep every launched agent engagement visible in `/admin/agents/runs`.
+- [ ] Add first-task templates to read-only dispatch artifacts for priority agents.
 - [ ] Validate with focused tests, typecheck, lint, build, PR previews, merge, and production/staging deployment checks.
 
 ## Next Operating Milestones
@@ -20,7 +21,7 @@ This is the active implementation queue for turning the agent organization into 
    - Launching the recommendation must create the same traced read-only engagement used by admin and Slack.
 
 2. Agent-specific first tasks
-   - Give the highest-value partial agents a first narrow read-only task:
+   - Give the highest-value agents a first narrow read-only task:
      - `chief-of-staff`
      - `research-source-register`
      - `voice-content-architect`

--- a/lib/agent-engagement.test.ts
+++ b/lib/agent-engagement.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('./agent-run', () => ({
+  startAgentRun: vi.fn(),
+  recordAgentEvent: vi.fn(),
+  recordAgentStep: vi.fn(),
+  attachAgentArtifact: vi.fn(),
+  endAgentRun: vi.fn(),
+}))
+
+import { buildReadOnlyAgentDispatch } from './agent-engagement'
+import { getAgentByKey } from './agent-organization'
+
+describe('agent engagement first tasks', () => {
+  it('adds a concrete first task for research source register dispatches', () => {
+    const agent = getAgentByKey('research-source-register')
+    if (!agent) throw new Error('Missing research-source-register agent')
+
+    const dispatch = buildReadOnlyAgentDispatch(agent, 'Find evidence for the next post.')
+
+    expect(dispatch.firstTask.objective).toContain('source-backed research brief')
+    expect(dispatch.firstTask.checklist).toContain(
+      'Return a citation-ready source register and flag material requiring approval before public use.',
+    )
+    expect(dispatch.summaryMarkdown).toContain('### First task')
+    expect(dispatch.summaryMarkdown).toContain('### Expected output')
+  })
+
+  it('falls back to a safe read-only first task for unmapped templates', () => {
+    const agent = getAgentByKey('engineering-copilot')
+    if (!agent) throw new Error('Missing engineering-copilot agent')
+
+    const dispatch = buildReadOnlyAgentDispatch(agent, null)
+
+    expect(dispatch.firstTask.objective).toContain('Define the next narrow read-only task')
+    expect(dispatch.firstTask.output).toContain('Read-only work brief')
+  })
+})

--- a/lib/agent-engagement.ts
+++ b/lib/agent-engagement.ts
@@ -33,6 +33,72 @@ export interface AgentEngagementRunResult {
   dispatchArtifactAttached: boolean
 }
 
+export type AgentFirstTaskTemplate = {
+  objective: string
+  checklist: string[]
+  output: string
+}
+
+export const AGENT_FIRST_TASKS: Record<string, AgentFirstTaskTemplate> = {
+  'chief-of-staff': {
+    objective: 'Produce a current operating brief across runs, approvals, failures, and the next agent to engage.',
+    checklist: [
+      'Review active, failed, stale, and approval-waiting runs.',
+      'Identify the highest-risk blocker or unresolved handoff.',
+      'Recommend one next read-only agent engagement or one approval checkpoint.',
+    ],
+    output: 'Executive operations brief with blocker, owner, next action, and trace link.',
+  },
+  'research-source-register': {
+    objective: 'Prepare a source-backed research brief for the current decision without publishing or exposing private material.',
+    checklist: [
+      'Clarify the decision, claim, or content point that needs evidence.',
+      'List available source surfaces and whether each is public, private, or client-derived.',
+      'Return a citation-ready source register and flag material requiring approval before public use.',
+    ],
+    output: 'Research source register with source class, relevance, usage boundary, and approval risk.',
+  },
+  'voice-content-architect': {
+    objective: 'Turn a source-backed idea into Vambah-aligned content structure while preserving privacy boundaries.',
+    checklist: [
+      'Identify the narrative tension, audience, and desired operating outcome.',
+      'Map the idea into a reusable post, script, carousel, or campaign structure.',
+      'Flag any private-to-public content risk before drafting publishable copy.',
+    ],
+    output: 'Content architecture brief with angle, structure, proof points, and approval boundary.',
+  },
+  'automation-systems': {
+    objective: 'Review mapped automation workflow posture and identify the safest next operational action.',
+    checklist: [
+      'Summarize active production and staging workflow coverage.',
+      'Identify workflows that are safe to monitor versus workflows that require approval before mutation.',
+      'Recommend whether to inspect status, run a known admin path, or create an approval checkpoint.',
+    ],
+    output: 'Automation posture brief with workflow coverage, risk boundary, and next safe action.',
+  },
+  'inbox-follow-up': {
+    objective: 'Prepare a follow-up readiness brief without sending external messages.',
+    checklist: [
+      'Separate draft, reply-detection, nurture, and meeting-intake workflow coverage.',
+      'Flag any email send or public message action that requires human approval.',
+      'Recommend the safest next review surface for outbound or follow-up work.',
+    ],
+    output: 'Follow-up readiness brief with channel, workflow, approval gate, and next review step.',
+  },
+}
+
+function firstTaskForAgent(agent: AgentOrganizationNode): AgentFirstTaskTemplate {
+  return AGENT_FIRST_TASKS[agent.key] ?? {
+    objective: 'Define the next narrow read-only task before allowing this agent to perform side effects.',
+    checklist: [
+      'Confirm the agent responsibility and mapped runtime.',
+      'Identify the current evidence or workflow surface to inspect.',
+      'Return a reviewable artifact and keep production side effects behind the approval gate.',
+    ],
+    output: 'Read-only work brief with evidence, next action, and approval boundary.',
+  }
+}
+
 export function buildAgentEngagementWorkPacket(agent: AgentOrganizationNode, note: string | null) {
   const pod = AGENT_PODS.find((item) => item.key === agent.podKey)
   const activeWorkflows = agent.n8nWorkflows.filter((workflow) => workflow.active)
@@ -92,6 +158,7 @@ export function buildReadOnlyAgentDispatch(agent: AgentOrganizationNode, note: s
   const activeWorkflows = agent.n8nWorkflows.filter((workflow) => workflow.active)
   const productionWorkflows = activeWorkflows.filter((workflow) => workflow.environment === 'production')
   const stagingWorkflows = activeWorkflows.filter((workflow) => workflow.environment === 'staging')
+  const firstTask = firstTaskForAgent(agent)
 
   const nextActions =
     agent.key === 'chief-of-staff'
@@ -125,6 +192,15 @@ export function buildReadOnlyAgentDispatch(agent: AgentOrganizationNode, note: s
     '### Suggested next actions',
     ...nextActions.map((action) => `- ${action}`),
     '',
+    '### First task',
+    firstTask.objective,
+    '',
+    '### First task checklist',
+    ...firstTask.checklist.map((item) => `- ${item}`),
+    '',
+    '### Expected output',
+    firstTask.output,
+    '',
     '### Approval boundary',
     agent.approvalGate,
     note ? ['', '### Operator note', note].join('\n') : '',
@@ -137,6 +213,7 @@ export function buildReadOnlyAgentDispatch(agent: AgentOrganizationNode, note: s
     activeWorkflowCount: activeWorkflows.length,
     productionWorkflowCount: productionWorkflows.length,
     stagingWorkflowCount: stagingWorkflows.length,
+    firstTask,
     summaryMarkdown,
   }
 }
@@ -232,6 +309,7 @@ export async function createAgentEngagementRun(
         production_workflow_count: dispatch.productionWorkflowCount,
         staging_workflow_count: dispatch.stagingWorkflowCount,
         next_actions: dispatch.nextActions,
+        first_task: dispatch.firstTask,
         executes_action: false,
       },
       idempotencyKey: `${run.id}:read-only-dispatch-step`,
@@ -251,6 +329,7 @@ export async function createAgentEngagementRun(
         production_workflow_count: dispatch.productionWorkflowCount,
         staging_workflow_count: dispatch.stagingWorkflowCount,
         next_actions: dispatch.nextActions,
+        first_task: dispatch.firstTask,
         approval_gate: agent.approvalGate,
         executes_action: false,
       },
@@ -268,6 +347,7 @@ export async function createAgentEngagementRun(
         active_workflow_count: dispatch.activeWorkflowCount,
         work_packet_attached: Boolean(artifact),
         dispatch_artifact_attached: dispatchArtifactAttached,
+        first_task: dispatch.firstTask,
         executes_action: false,
       },
     })


### PR DESCRIPTION
## Summary
- add first-task templates for priority agents in read-only dispatch artifacts
- include objective, checklist, and expected output in dispatch metadata
- update the rollout task list to reflect the completed Chief of Staff dispatcher slice

## Validation
- npm test -- lib/agent-engagement.test.ts app/api/admin/agents/engage/route.test.ts lib/agent-slack-command.test.ts lib/chief-of-staff-chat.test.ts app/api/admin/agents/chief-of-staff/chat/route.test.ts
- npx tsc --noEmit --pretty false
- npm run lint
- npm run build