### PR TITLE
feat: add agent automation context dashboard

### DIFF
--- a/app/admin/agents/automations/page.tsx
+++ b/app/admin/agents/automations/page.tsx
@@ -1,0 +1,540 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import {
+  AlertTriangle,
+  ArrowRight,
+  Bot,
+  CheckCircle2,
+  Clock,
+  FileText,
+  RefreshCw,
+  ShieldAlert,
+  SlidersHorizontal,
+  XCircle,
+} from 'lucide-react'
+import ProtectedRoute from '@/components/ProtectedRoute'
+import Breadcrumbs from '@/components/admin/Breadcrumbs'
+import { getCurrentSession } from '@/lib/auth'
+import type {
+  AutomationBoundary,
+  AutomationCategory,
+  AutomationContextHealth,
+  AutomationRiskLevel,
+} from '@/lib/codex-automation-inventory'
+
+type AutomationProfile = {
+  id: string
+  name: string
+  kind: string
+  status: string
+  schedule: string | null
+  model: string | null
+  reasoningEffort: string | null
+  executionEnvironment: string | null
+  cwds: string[]
+  createdAt: number | null
+  updatedAt: number | null
+  category: AutomationCategory
+  riskLevel: AutomationRiskLevel
+  portfolioRelated: boolean
+  sourceFile: string
+  controlDocs: string[]
+  promptExcerpt: string
+  duplicateCandidate: boolean
+  managementBoundary: AutomationBoundary
+  contextHealth: AutomationContextHealth
+  contextGaps: string[]
+  contextProfile: {
+    purpose: string | null
+    operatingRhythm: string | null
+    recurringDecisions: string | null
+    inputs: string[]
+    dependencies: string[]
+    frictionPoints: string[]
+    authorityBoundary: AutomationBoundary
+    expectedOutputs: string[]
+    escalationTrigger: string | null
+    governingDocs: string[]
+  }
+}
+
+type AutomationInventoryResponse = {
+  available: boolean
+  reason?: string
+  sourceDirectory: string
+  generatedAt: string
+  automations: AutomationProfile[]
+  hiddenCount: number
+  overview: {
+    total: number
+    active: number
+    paused: number
+    duplicateCandidates: number
+    highRisk: number
+    missingContext: number
+  }
+}
+
+const ALL = 'all'
+const CATEGORIES = [ALL, 'Operations', 'Credentials', 'Model Ops', 'Organization', 'Content/Voice', 'Subscriptions', 'Other'] as const
+const STATUSES = [ALL, 'ACTIVE', 'PAUSED'] as const
+const RISKS = [ALL, 'low', 'medium', 'high'] as const
+const CONTEXT_HEALTH = [ALL, 'green', 'yellow', 'red'] as const
+const EMPTY_AUTOMATIONS: AutomationProfile[] = []
+
+export default function AgentAutomationsPage() {
+  return (
+    <ProtectedRoute requireAdmin>
+      <AgentAutomationsContent />
+    </ProtectedRoute>
+  )
+}
+
+function AgentAutomationsContent() {
+  const [inventory, setInventory] = useState<AutomationInventoryResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [category, setCategory] = useState<(typeof CATEGORIES)[number]>(ALL)
+  const [status, setStatus] = useState<(typeof STATUSES)[number]>(ALL)
+  const [risk, setRisk] = useState<(typeof RISKS)[number]>(ALL)
+  const [contextHealth, setContextHealth] = useState<(typeof CONTEXT_HEALTH)[number]>(ALL)
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+
+  const fetchInventory = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Missing admin session')
+      const res = await fetch('/api/admin/agents/automations', {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      })
+      const body = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(body.error || `HTTP ${res.status}`)
+      setInventory(body)
+      const first = body.automations?.[0]?.id
+      setSelectedId((current) => current || first || null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load automation inventory')
+      setInventory(null)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchInventory()
+  }, [fetchInventory])
+
+  const automations = useMemo(() => inventory?.automations || EMPTY_AUTOMATIONS, [inventory?.automations])
+  const filtered = useMemo(() => {
+    return automations.filter((automation) => {
+      if (category !== ALL && automation.category !== category) return false
+      if (status !== ALL && automation.status !== status) return false
+      if (risk !== ALL && automation.riskLevel !== risk) return false
+      if (contextHealth !== ALL && automation.contextHealth !== contextHealth) return false
+      return true
+    })
+  }, [automations, category, status, risk, contextHealth])
+
+  const selected = automations.find((automation) => automation.id === selectedId) || filtered[0] || null
+  const duplicateWarnings = automations.filter((automation) => automation.duplicateCandidate)
+  const workspaceWarnings = automations.filter((automation) => !automation.cwds.some((cwd) => cwd.includes('/Projects/Portfolio')))
+  const authorityWarnings = automations.filter(
+    (automation) => automation.riskLevel === 'high' && automation.contextGaps.includes('missing authority boundary'),
+  )
+  const docWarnings = automations.filter((automation) => automation.controlDocs.length === 0)
+
+  return (
+    <div className="min-h-screen bg-background text-foreground p-6 lg:p-8">
+      <div className="max-w-7xl mx-auto">
+        <Breadcrumbs items={[
+          { label: 'Admin Dashboard', href: '/admin' },
+          { label: 'Agent Operations', href: '/admin/agents' },
+          { label: 'Automation Context' },
+        ]} />
+
+        <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <h1 className="text-3xl font-bold mb-1">Automation Context</h1>
+            <p className="text-muted-foreground text-sm max-w-3xl">
+              Local-first inventory for Portfolio-related Codex automations, their risk boundaries, and the context agents need before acting.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Link
+              href="/admin/agents"
+              className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 bg-silicon-slate/30 px-3 py-2 text-sm hover:border-radiant-gold/60"
+            >
+              <Bot size={16} />
+              Agent Operations
+            </Link>
+            <button
+              onClick={fetchInventory}
+              disabled={loading}
+              className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/50 bg-radiant-gold/10 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15 disabled:opacity-60"
+            >
+              <RefreshCw size={16} className={loading ? 'animate-spin' : ''} />
+              Refresh
+            </button>
+          </div>
+        </div>
+
+        {loading ? (
+          <div className="py-16 text-center text-muted-foreground">Loading automation inventory...</div>
+        ) : error ? (
+          <FailureState title="Failed to load automation inventory" message={error} />
+        ) : inventory && !inventory.available ? (
+          <UnavailableState inventory={inventory} />
+        ) : inventory ? (
+          <>
+            <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-6 gap-3 mb-6">
+              <MetricCard label="Portfolio automations" value={inventory.overview.total} />
+              <MetricCard label="Active" value={inventory.overview.active} tone="green" />
+              <MetricCard label="Paused" value={inventory.overview.paused} />
+              <MetricCard label="Duplicates" value={inventory.overview.duplicateCandidates} tone={inventory.overview.duplicateCandidates ? 'yellow' : 'slate'} />
+              <MetricCard label="High risk" value={inventory.overview.highRisk} tone={inventory.overview.highRisk ? 'red' : 'slate'} />
+              <MetricCard label="Missing context" value={inventory.overview.missingContext} tone={inventory.overview.missingContext ? 'yellow' : 'slate'} />
+            </div>
+
+            <WarningPanels
+              hiddenCount={inventory.hiddenCount}
+              duplicateWarnings={duplicateWarnings}
+              workspaceWarnings={workspaceWarnings}
+              authorityWarnings={authorityWarnings}
+              docWarnings={docWarnings}
+            />
+
+            <section className="mb-6 rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
+              <div className="mb-4 flex items-center gap-2 text-radiant-gold">
+                <SlidersHorizontal size={18} />
+                <h2 className="font-semibold">Filters</h2>
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+                <FilterSelect label="Category" value={category} values={CATEGORIES} onChange={(value) => setCategory(value as (typeof CATEGORIES)[number])} />
+                <FilterSelect label="Status" value={status} values={STATUSES} onChange={(value) => setStatus(value as (typeof STATUSES)[number])} />
+                <FilterSelect label="Risk" value={risk} values={RISKS} onChange={(value) => setRisk(value as (typeof RISKS)[number])} />
+                <FilterSelect
+                  label="Context health"
+                  value={contextHealth}
+                  values={CONTEXT_HEALTH}
+                  onChange={(value) => setContextHealth(value as (typeof CONTEXT_HEALTH)[number])}
+                />
+              </div>
+            </section>
+
+            <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_420px] gap-6">
+              <AutomationTable automations={filtered} selectedId={selected?.id || null} onSelect={setSelectedId} />
+              {selected ? <ContextReadiness automation={selected} /> : null}
+            </div>
+
+            <p className="mt-5 text-xs text-muted-foreground">
+              Source: {inventory.sourceDirectory}. Generated {formatDateTime(inventory.generatedAt)}. Prompt excerpts are sanitized and truncated.
+            </p>
+          </>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function AutomationTable({
+  automations,
+  selectedId,
+  onSelect,
+}: {
+  automations: AutomationProfile[]
+  selectedId: string | null
+  onSelect: (id: string) => void
+}) {
+  if (automations.length === 0) {
+    return (
+      <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-8 text-center text-muted-foreground">
+        No automations match the current filters.
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-silicon-slate/70">
+      <table className="w-full text-sm">
+        <thead className="bg-silicon-slate/40 text-muted-foreground">
+          <tr>
+            <th className="text-left px-4 py-3 font-medium">Automation</th>
+            <th className="text-left px-4 py-3 font-medium">Status</th>
+            <th className="text-left px-4 py-3 font-medium">Schedule</th>
+            <th className="text-left px-4 py-3 font-medium">Category</th>
+            <th className="text-left px-4 py-3 font-medium">Risk</th>
+            <th className="text-left px-4 py-3 font-medium">Context</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-silicon-slate/60">
+          {automations.map((automation) => (
+            <tr
+              key={automation.id}
+              className={`cursor-pointer hover:bg-silicon-slate/20 ${selectedId === automation.id ? 'bg-radiant-gold/10' : ''}`}
+              onClick={() => onSelect(automation.id)}
+            >
+              <td className="px-4 py-3">
+                <p className="font-medium">{automation.name}</p>
+                <p className="mt-1 text-xs text-muted-foreground">{automation.id}</p>
+                <p className="mt-1 text-xs text-muted-foreground line-clamp-2">{automation.promptExcerpt || 'No prompt excerpt available.'}</p>
+              </td>
+              <td className="px-4 py-3"><StatusBadge status={automation.status} /></td>
+              <td className="px-4 py-3 text-muted-foreground">{formatSchedule(automation.schedule)}</td>
+              <td className="px-4 py-3">{automation.category}</td>
+              <td className="px-4 py-3"><RiskBadge risk={automation.riskLevel} /></td>
+              <td className="px-4 py-3"><ContextBadge health={automation.contextHealth} /></td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function ContextReadiness({ automation }: { automation: AutomationProfile }) {
+  const profile = automation.contextProfile
+
+  return (
+    <aside className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-5 h-fit">
+      <div className="mb-4 flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-semibold">{automation.name}</h2>
+          <p className="mt-1 text-xs text-muted-foreground break-all">{automation.sourceFile}</p>
+        </div>
+        <ContextBadge health={automation.contextHealth} />
+      </div>
+
+      <div className="mb-5 grid grid-cols-2 gap-2 text-xs">
+        <DetailPill label="Boundary" value={automation.managementBoundary} />
+        <DetailPill label="Runtime" value={automation.executionEnvironment || 'unknown'} />
+        <DetailPill label="Model" value={automation.model || 'unknown'} />
+        <DetailPill label="Reasoning" value={automation.reasoningEffort || 'unknown'} />
+      </div>
+
+      {automation.contextGaps.length > 0 ? (
+        <section className="mb-5 rounded-lg border border-yellow-400/30 bg-yellow-500/10 p-3">
+          <div className="mb-2 flex items-center gap-2 text-yellow-200">
+            <AlertTriangle size={16} />
+            <h3 className="font-medium">Context gaps</h3>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {automation.contextGaps.map((gap) => (
+              <span key={gap} className="rounded-full border border-yellow-400/30 bg-black/20 px-2 py-1 text-xs text-yellow-100">
+                {gap}
+              </span>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      <div className="space-y-4 text-sm">
+        <ContextBlock label="Purpose" value={profile.purpose} />
+        <ContextBlock label="Operating rhythm" value={profile.operatingRhythm} />
+        <ContextBlock label="Recurring decisions" value={profile.recurringDecisions} />
+        <ContextList label="Inputs and source paths" values={profile.inputs} />
+        <ContextList label="Dependencies" values={profile.dependencies} />
+        <ContextList label="Friction points" values={profile.frictionPoints} />
+        <ContextList label="Expected outputs" values={profile.expectedOutputs} />
+        <ContextBlock label="Escalation trigger" value={profile.escalationTrigger} />
+        <ContextList label="Governing docs, skills, and runbooks" values={profile.governingDocs} />
+      </div>
+    </aside>
+  )
+}
+
+function WarningPanels({
+  hiddenCount,
+  duplicateWarnings,
+  workspaceWarnings,
+  authorityWarnings,
+  docWarnings,
+}: {
+  hiddenCount: number
+  duplicateWarnings: AutomationProfile[]
+  workspaceWarnings: AutomationProfile[]
+  authorityWarnings: AutomationProfile[]
+  docWarnings: AutomationProfile[]
+}) {
+  const warnings = [
+    duplicateWarnings.length ? `${duplicateWarnings.length} duplicate or overlapping automation candidate(s)` : null,
+    workspaceWarnings.length ? `${workspaceWarnings.length} automation(s) missing the Portfolio workspace path` : null,
+    authorityWarnings.length ? `${authorityWarnings.length} high-risk automation(s) missing explicit authority boundaries` : null,
+    docWarnings.length ? `${docWarnings.length} automation(s) without governing docs, skills, or runbooks` : null,
+    hiddenCount ? `${hiddenCount} non-Portfolio automation(s) hidden by default` : null,
+  ].filter(Boolean) as string[]
+
+  if (warnings.length === 0) {
+    return (
+      <div className="mb-6 rounded-lg border border-green-400/30 bg-green-500/10 p-4 text-sm text-green-100">
+        <div className="flex items-center gap-2 font-medium"><CheckCircle2 size={18} /> No automation inventory warnings found.</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mb-6 grid grid-cols-1 lg:grid-cols-2 gap-3">
+      {warnings.map((warning) => (
+        <div key={warning} className="rounded-lg border border-yellow-400/30 bg-yellow-500/10 p-4 text-sm text-yellow-100">
+          <div className="flex items-center gap-2 font-medium"><AlertTriangle size={18} /> {warning}</div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function MetricCard({ label, value, tone = 'slate' }: { label: string; value: number; tone?: 'green' | 'yellow' | 'red' | 'slate' }) {
+  const toneClass =
+    tone === 'green' ? 'text-green-300' : tone === 'yellow' ? 'text-yellow-300' : tone === 'red' ? 'text-red-300' : 'text-foreground'
+  return (
+    <div className="rounded-lg border border-silicon-slate/60 bg-silicon-slate/20 p-4">
+      <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">{label}</p>
+      <p className={`mt-2 text-2xl font-bold ${toneClass}`}>{value}</p>
+    </div>
+  )
+}
+
+function FilterSelect({
+  label,
+  value,
+  values,
+  onChange,
+}: {
+  label: string
+  value: string
+  values: readonly string[]
+  onChange: (value: string) => void
+}) {
+  return (
+    <label className="text-sm">
+      <span className="mb-1 block text-xs font-semibold uppercase tracking-wider text-muted-foreground">{label}</span>
+      <select
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="w-full rounded-lg border border-silicon-slate/70 bg-background px-3 py-2 text-sm"
+      >
+        {values.map((option) => (
+          <option key={option} value={option}>{option === ALL ? `All ${label.toLowerCase()}` : option}</option>
+        ))}
+      </select>
+    </label>
+  )
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const className =
+    status === 'ACTIVE'
+      ? 'border-green-400/40 bg-green-500/10 text-green-200'
+      : status === 'PAUSED'
+        ? 'border-yellow-400/40 bg-yellow-500/10 text-yellow-200'
+        : 'border-silicon-slate/60 bg-black/20 text-muted-foreground'
+  return <span className={`rounded-full border px-2 py-1 text-xs ${className}`}>{status}</span>
+}
+
+function RiskBadge({ risk }: { risk: AutomationRiskLevel }) {
+  const className =
+    risk === 'high'
+      ? 'border-red-400/40 bg-red-500/10 text-red-200'
+      : risk === 'medium'
+        ? 'border-yellow-400/40 bg-yellow-500/10 text-yellow-200'
+        : 'border-green-400/40 bg-green-500/10 text-green-200'
+  return <span className={`rounded-full border px-2 py-1 text-xs ${className}`}>{risk}</span>
+}
+
+function ContextBadge({ health }: { health: AutomationContextHealth }) {
+  const icon = health === 'green' ? <CheckCircle2 size={13} /> : health === 'yellow' ? <AlertTriangle size={13} /> : <XCircle size={13} />
+  const className =
+    health === 'green'
+      ? 'border-green-400/40 bg-green-500/10 text-green-200'
+      : health === 'yellow'
+        ? 'border-yellow-400/40 bg-yellow-500/10 text-yellow-200'
+        : 'border-red-400/40 bg-red-500/10 text-red-200'
+  return <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs ${className}`}>{icon}{health}</span>
+}
+
+function DetailPill({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-silicon-slate/50 bg-black/10 p-2">
+      <p className="text-muted-foreground">{label}</p>
+      <p className="mt-1 font-medium">{value}</p>
+    </div>
+  )
+}
+
+function ContextBlock({ label, value }: { label: string; value: string | null }) {
+  return (
+    <section>
+      <h3 className="mb-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground">{label}</h3>
+      <p className={value ? 'text-foreground' : 'text-muted-foreground'}>{value || 'Not found in the current automation context.'}</p>
+    </section>
+  )
+}
+
+function ContextList({ label, values }: { label: string; values: string[] }) {
+  return (
+    <section>
+      <h3 className="mb-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground">{label}</h3>
+      {values.length > 0 ? (
+        <div className="flex flex-wrap gap-2">
+          {values.map((value) => (
+            <span key={value} className="rounded-md border border-silicon-slate/50 bg-black/10 px-2 py-1 text-xs break-all">
+              {value}
+            </span>
+          ))}
+        </div>
+      ) : (
+        <p className="text-muted-foreground">Not found in the current automation context.</p>
+      )}
+    </section>
+  )
+}
+
+function FailureState({ title, message }: { title: string; message: string }) {
+  return (
+    <div className="rounded-lg border border-red-500/50 bg-red-500/10 p-5 text-red-300">
+      <div className="flex items-center gap-2 font-medium"><AlertTriangle size={18} /> {title}</div>
+      <p className="text-sm mt-1">{message}</p>
+    </div>
+  )
+}
+
+function UnavailableState({ inventory }: { inventory: AutomationInventoryResponse }) {
+  return (
+    <div className="rounded-lg border border-yellow-400/40 bg-yellow-500/10 p-5 text-yellow-100">
+      <div className="mb-2 flex items-center gap-2 font-medium">
+        <ShieldAlert size={18} />
+        Local automation inventory unavailable
+      </div>
+      <p className="text-sm">
+        {inventory.reason || 'The local Codex automation directory cannot be read from this environment.'}
+      </p>
+      <p className="mt-3 flex items-center gap-2 text-xs text-yellow-100/80">
+        <FileText size={14} />
+        Expected source: {inventory.sourceDirectory}
+      </p>
+    </div>
+  )
+}
+
+function formatSchedule(schedule: string | null) {
+  if (!schedule) return '-'
+  return schedule
+    .replace('FREQ=', '')
+    .replace(/;BY/g, ' · BY')
+    .replace(/;INTERVAL=/g, ' · every ')
+}
+
+function formatDateTime(value: string | number | null) {
+  if (!value) return '-'
+  const date = typeof value === 'number' ? new Date(value) : new Date(value)
+  if (Number.isNaN(date.getTime())) return '-'
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(date)
+}

--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -11,6 +11,7 @@ import {
   CheckCircle2,
   Clock,
   DollarSign,
+  ListChecks,
   MessageSquare,
   RefreshCw,
   Send,
@@ -215,6 +216,24 @@ export default function AgentOperationsPage() {
                   </div>
                   <p className="text-sm text-muted-foreground">
                     Ask for priorities, blockers, approval risk, and next actions from the agent operating context.
+                  </p>
+                </div>
+                <ArrowRight size={20} className="text-muted-foreground shrink-0" />
+              </div>
+            </Link>
+
+            <Link
+              href="/admin/agents/automations"
+              className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/30 p-5 hover:border-radiant-gold/60 transition-colors"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <div className="flex items-center gap-2 text-cyan-300 mb-2">
+                    <ListChecks size={20} />
+                    <h2 className="text-lg font-semibold">Automation Context</h2>
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    Review Codex automation schedules, risk, duplicates, and context readiness for future agents.
                   </p>
                 </div>
                 <ArrowRight size={20} className="text-muted-foreground shrink-0" />

--- a/app/api/admin/agents/automations/route.test.ts
+++ b/app/api/admin/agents/automations/route.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  listCodexAutomationInventory: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/codex-automation-inventory', () => ({
+  listCodexAutomationInventory: mocks.listCodexAutomationInventory,
+}))
+
+import { GET } from './route'
+
+function makeRequest() {
+  return new Request('http://localhost/api/admin/agents/automations', {
+    headers: { authorization: 'Bearer token' },
+  })
+}
+
+describe('GET /api/admin/agents/automations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.listCodexAutomationInventory.mockResolvedValue({
+      available: true,
+      sourceDirectory: '/Users/vambahsillah/.codex/automations',
+      generatedAt: '2026-05-03T00:00:00.000Z',
+      automations: [
+        {
+          id: 'portfolio-operations-manager',
+          name: 'Portfolio Operations Manager',
+          promptExcerpt: 'Run a safe report.',
+        },
+      ],
+      hiddenCount: 1,
+      overview: {
+        total: 1,
+        active: 1,
+        paused: 0,
+        duplicateCandidates: 0,
+        highRisk: 0,
+        missingContext: 0,
+      },
+    })
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await GET(makeRequest() as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.listCodexAutomationInventory).not.toHaveBeenCalled()
+  })
+
+  it('returns the sanitized local automation inventory', async () => {
+    const response = await GET(makeRequest() as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual(expect.objectContaining({
+      available: true,
+      automations: [
+        expect.objectContaining({
+          id: 'portfolio-operations-manager',
+          promptExcerpt: 'Run a safe report.',
+        }),
+      ],
+      hiddenCount: 1,
+    }))
+  })
+})

--- a/app/api/admin/agents/automations/route.ts
+++ b/app/api/admin/agents/automations/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { listCodexAutomationInventory } from '@/lib/codex-automation-inventory'
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+export async function GET(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const inventory = await listCodexAutomationInventory()
+  return NextResponse.json(inventory)
+}

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -10,7 +10,8 @@ This is the active implementation queue for turning the agent organization into 
 - [x] Support the same read-only dispatch from Slack `/agent run <agent-key>`.
 - [x] Let Chief of Staff chat recommend mapped agents and launch their read-only dispatch runs.
 - [x] Keep every launched agent engagement visible in `/admin/agents/runs`.
-- [ ] Add first-task templates to read-only dispatch artifacts for priority agents.
+- [x] Add first-task templates to read-only dispatch artifacts for priority agents.
+- [x] Add read-only Automation Context visibility for Portfolio-related Codex automations.
 - [ ] Validate with focused tests, typecheck, lint, build, PR previews, merge, and production/staging deployment checks.
 
 ## Next Operating Milestones
@@ -39,6 +40,7 @@ This is the active implementation queue for turning the agent organization into 
    - Avoid adding another channel unless Slack cannot support the workflow.
 
 5. Hardening
+   - Keep Codex automation context visible in Agent Operations so future agents can inspect purpose, cadence, authority boundary, and missing context before acting.
    - Add stale-run handling for every runtime.
    - Add dashboard-level cost summaries by agent and runtime.
    - Keep n8n compatibility adapters live until the generic trace model is proven.

--- a/lib/admin-nav.ts
+++ b/lib/admin-nav.ts
@@ -67,6 +67,7 @@ export const ADMIN_NAV: { dashboard: AdminNavItem; categories: AdminNavCategory[
         { label: 'Cost & Revenue', href: '/admin/cost-revenue' },
         { label: 'Subscription Watch', href: '/admin/subscriptions' },
         { label: 'Agent Operations', href: '/admin/agents' },
+        { label: 'Automation Context', href: '/admin/agents/automations' },
         { label: 'Technology Bakeoffs', href: '/admin/technology-bakeoffs' },
         { label: 'Client Experience', href: '/admin/client-experience' },
         { label: 'E2E Testing', href: '/admin/testing' },

--- a/lib/codex-automation-inventory.test.ts
+++ b/lib/codex-automation-inventory.test.ts
@@ -1,0 +1,131 @@
+import { mkdtemp, rm, mkdir, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import path from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  listCodexAutomationInventory,
+  parseAutomationToml,
+} from './codex-automation-inventory'
+
+let tempRoot: string | null = null
+
+async function writeAutomation(id: string, body: string) {
+  if (!tempRoot) tempRoot = await mkdtemp(path.join(tmpdir(), 'codex-automations-'))
+  const dir = path.join(tempRoot, id)
+  await mkdir(dir, { recursive: true })
+  await writeFile(path.join(dir, 'automation.toml'), body)
+}
+
+afterEach(async () => {
+  if (tempRoot) {
+    await rm(tempRoot, { recursive: true, force: true })
+    tempRoot = null
+  }
+})
+
+describe('parseAutomationToml', () => {
+  it('parses the current Codex automation TOML shape', () => {
+    const parsed = parseAutomationToml(`
+version = 1
+id = "portfolio-operations-manager"
+kind = "cron"
+name = "Portfolio Operations Manager"
+prompt = "Run a daily Portfolio report.\\nDo not change production."
+status = "ACTIVE"
+rrule = "FREQ=DAILY;BYHOUR=9;BYMINUTE=0;BYSECOND=0"
+model = "gpt-5.5"
+reasoning_effort = "high"
+execution_environment = "local"
+cwds = ["/Users/vambahsillah/Projects/Portfolio", "/Users/vambahsillah/Documents"]
+created_at = 1777635786167
+updated_at = 1777636249936
+`)
+
+    expect(parsed).toEqual(expect.objectContaining({
+      id: 'portfolio-operations-manager',
+      kind: 'cron',
+      name: 'Portfolio Operations Manager',
+      status: 'ACTIVE',
+      rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0;BYSECOND=0',
+      reasoning_effort: 'high',
+      execution_environment: 'local',
+      cwds: ['/Users/vambahsillah/Projects/Portfolio', '/Users/vambahsillah/Documents'],
+      created_at: 1777635786167,
+    }))
+    expect(parsed.prompt).toContain('\nDo not change production.')
+  })
+})
+describe('listCodexAutomationInventory', () => {
+  it('returns unavailable when the local Codex automation directory is missing', async () => {
+    const inventory = await listCodexAutomationInventory('/definitely/not/a/codex/automation/root')
+
+    expect(inventory.available).toBe(false)
+    expect(inventory.automations).toEqual([])
+    expect(inventory.reason).toContain('not available')
+  })
+
+  it('includes Portfolio automations and hides personal automations by default', async () => {
+    await writeAutomation('portfolio-operations-manager', `
+id = "portfolio-operations-manager"
+kind = "cron"
+name = "Portfolio Operations Manager"
+prompt = "Use docs/portfolio-operations-manager.md. Run daily Portfolio health checks. Do not change production settings. Report failures and approval packets."
+status = "ACTIVE"
+rrule = "FREQ=DAILY;BYHOUR=9;BYMINUTE=0;BYSECOND=0"
+model = "gpt-5.5"
+reasoning_effort = "high"
+execution_environment = "local"
+cwds = ["/Users/vambahsillah/Projects/Portfolio"]
+created_at = 1
+updated_at = 2
+`)
+    await writeAutomation('personal-reminder', `
+id = "personal-reminder"
+kind = "cron"
+name = "Personal Reminder"
+prompt = "Remind me to drink water."
+status = "ACTIVE"
+rrule = "FREQ=DAILY;BYHOUR=12;BYMINUTE=0;BYSECOND=0"
+cwds = ["/Users/vambahsillah"]
+`)
+
+    const inventory = await listCodexAutomationInventory(tempRoot!)
+
+    expect(inventory.available).toBe(true)
+    expect(inventory.hiddenCount).toBe(1)
+    expect(inventory.automations).toHaveLength(1)
+    expect(inventory.automations[0]).toEqual(expect.objectContaining({
+      id: 'portfolio-operations-manager',
+      category: 'Operations',
+      portfolioRelated: true,
+      riskLevel: 'high',
+      managementBoundary: 'approval-required',
+    }))
+    expect(inventory.automations[0].controlDocs).toContain('docs/portfolio-operations-manager.md')
+  })
+
+  it('flags duplicate credential rotation jobs and sanitizes prompt excerpts', async () => {
+    for (const id of ['portfolio-credential-rotation-due-report', 'portfolio-credential-rotation-due-report-2']) {
+      await writeAutomation(id, `
+id = "${id}"
+kind = "cron"
+name = "Portfolio Credential Rotation Due Report"
+prompt = "Run Portfolio credential checks with API_KEY=super-secret-value. Do not rotate, revoke, or expose secret values. Produce an approval packet."
+status = "ACTIVE"
+rrule = "FREQ=WEEKLY;BYDAY=MO;BYHOUR=8;BYMINUTE=30;BYSECOND=0"
+model = "gpt-5.5"
+reasoning_effort = "high"
+execution_environment = "local"
+cwds = ["/Users/vambahsillah/Projects/Portfolio"]
+`)
+    }
+
+    const inventory = await listCodexAutomationInventory(tempRoot!)
+
+    expect(inventory.automations).toHaveLength(2)
+    expect(inventory.overview.duplicateCandidates).toBe(2)
+    expect(inventory.automations.every((automation) => automation.duplicateCandidate)).toBe(true)
+    expect(inventory.automations[0].promptExcerpt).not.toContain('super-secret-value')
+    expect(inventory.automations[0].category).toBe('Credentials')
+  })
+})

--- a/lib/codex-automation-inventory.ts
+++ b/lib/codex-automation-inventory.ts
@@ -1,0 +1,458 @@
+import { existsSync } from 'fs'
+import { readdir, readFile } from 'fs/promises'
+import { homedir } from 'os'
+import path from 'path'
+
+export type AutomationCategory =
+  | 'Operations'
+  | 'Credentials'
+  | 'Model Ops'
+  | 'Organization'
+  | 'Content/Voice'
+  | 'Subscriptions'
+  | 'Other'
+
+export type AutomationRiskLevel = 'low' | 'medium' | 'high'
+export type AutomationBoundary = 'read-only' | 'branch-only' | 'approval-required' | 'never automatic'
+export type AutomationContextHealth = 'green' | 'yellow' | 'red'
+
+export interface CodexAutomationProfile {
+  id: string
+  name: string
+  kind: string
+  status: string
+  schedule: string | null
+  model: string | null
+  reasoningEffort: string | null
+  executionEnvironment: string | null
+  cwds: string[]
+  createdAt: number | null
+  updatedAt: number | null
+  category: AutomationCategory
+  riskLevel: AutomationRiskLevel
+  portfolioRelated: boolean
+  sourceFile: string
+  controlDocs: string[]
+  promptExcerpt: string
+  duplicateCandidate: boolean
+  managementBoundary: AutomationBoundary
+  contextHealth: AutomationContextHealth
+  contextGaps: string[]
+  contextProfile: {
+    purpose: string | null
+    operatingRhythm: string | null
+    recurringDecisions: string | null
+    inputs: string[]
+    dependencies: string[]
+    frictionPoints: string[]
+    authorityBoundary: AutomationBoundary
+    expectedOutputs: string[]
+    escalationTrigger: string | null
+    governingDocs: string[]
+  }
+}
+
+export interface CodexAutomationInventory {
+  available: boolean
+  reason?: string
+  sourceDirectory: string
+  generatedAt: string
+  automations: CodexAutomationProfile[]
+  hiddenCount: number
+  overview: {
+    total: number
+    active: number
+    paused: number
+    duplicateCandidates: number
+    highRisk: number
+    missingContext: number
+  }
+}
+
+type ParsedAutomationToml = {
+  id?: string
+  name?: string
+  kind?: string
+  prompt?: string
+  status?: string
+  rrule?: string
+  model?: string
+  reasoning_effort?: string
+  execution_environment?: string
+  cwds?: string[]
+  created_at?: number
+  updated_at?: number
+}
+
+const PORTFOLIO_ROOT = '/Users/vambahsillah/Projects/Portfolio'
+const DEFAULT_AUTOMATIONS_DIR = path.join(homedir(), '.codex', 'automations')
+const SECRETISH_PATTERN =
+  /(sk-[A-Za-z0-9_-]{12,}|github_pat_[A-Za-z0-9_]{12,}|[A-Za-z0-9_]*(?:TOKEN|SECRET|KEY|PASSWORD)[A-Za-z0-9_]*\s*[:=]\s*["']?[^"'\s,}]+)/gi
+
+export function getDefaultCodexAutomationsDir() {
+  return process.env.CODEX_AUTOMATIONS_DIR || DEFAULT_AUTOMATIONS_DIR
+}
+
+export async function listCodexAutomationInventory(
+  automationRoot = getDefaultCodexAutomationsDir(),
+): Promise<CodexAutomationInventory> {
+  const generatedAt = new Date().toISOString()
+
+  if (!existsSync(automationRoot)) {
+    return unavailableInventory(automationRoot, generatedAt, 'Local Codex automation directory is not available in this environment')
+  }
+
+  let entries: string[]
+  try {
+    entries = await readdir(automationRoot)
+  } catch {
+    return unavailableInventory(automationRoot, generatedAt, 'Local Codex automation directory is not readable in this environment')
+  }
+
+  const parsed: CodexAutomationProfile[] = []
+  for (const entry of entries.sort()) {
+    const sourceFile = path.join(automationRoot, entry, 'automation.toml')
+    if (!existsSync(sourceFile)) continue
+
+    try {
+      const content = await readFile(sourceFile, 'utf8')
+      const raw = parseAutomationToml(content)
+      parsed.push(buildAutomationProfile(raw, sourceFile))
+    } catch {
+      // Keep the dashboard resilient. Broken files are skipped for v1 rather
+      // than blocking the whole inventory.
+    }
+  }
+
+  const withDuplicates = markDuplicateCandidates(parsed)
+  const automations = withDuplicates.filter((automation) => automation.portfolioRelated)
+  const hiddenCount = withDuplicates.length - automations.length
+
+  return {
+    available: true,
+    sourceDirectory: automationRoot,
+    generatedAt,
+    automations,
+    hiddenCount,
+    overview: buildOverview(automations),
+  }
+}
+
+export function parseAutomationToml(content: string): ParsedAutomationToml {
+  const parsed: ParsedAutomationToml = {}
+
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) continue
+    const match = trimmed.match(/^([A-Za-z0-9_]+)\s*=\s*(.+)$/)
+    if (!match) continue
+    const [, key, rawValue] = match
+    const value = parseTomlValue(rawValue)
+    ;(parsed as Record<string, unknown>)[key] = value
+  }
+
+  return parsed
+}
+
+function parseTomlValue(rawValue: string): string | number | string[] {
+  const value = rawValue.trim()
+  if (value.startsWith('[') && value.endsWith(']')) {
+    const inner = value.slice(1, -1).trim()
+    if (!inner) return []
+    return inner
+      .split(/,(?=(?:[^"]*"[^"]*")*[^"]*$)/)
+      .map((item) => parseTomlString(item.trim()))
+      .filter(Boolean)
+  }
+  if (value.startsWith('"') && value.endsWith('"')) {
+    return parseTomlString(value)
+  }
+  if (/^-?\d+$/.test(value)) return Number(value)
+  return value
+}
+
+function parseTomlString(value: string): string {
+  const trimmed = value.trim()
+  const unquoted = trimmed.startsWith('"') && trimmed.endsWith('"') ? trimmed.slice(1, -1) : trimmed
+  return unquoted
+    .replace(/\\"/g, '"')
+    .replace(/\\n/g, '\n')
+    .replace(/\\t/g, '\t')
+    .replace(/\\\\/g, '\\')
+}
+
+function buildAutomationProfile(raw: ParsedAutomationToml, sourceFile: string): CodexAutomationProfile {
+  const prompt = raw.prompt || ''
+  const name = raw.name || raw.id || path.basename(path.dirname(sourceFile))
+  const cwds = Array.isArray(raw.cwds) ? raw.cwds : []
+  const controlDocs = extractControlDocs(prompt)
+  const category = classifyCategory(name, prompt, cwds)
+  const managementBoundary = classifyBoundary(prompt)
+  const contextProfile = buildContextProfile(name, prompt, cwds, controlDocs, managementBoundary)
+  const contextGaps = findContextGaps(contextProfile, prompt)
+  const riskLevel = classifyRisk(prompt, category, managementBoundary)
+
+  return {
+    id: raw.id || path.basename(path.dirname(sourceFile)),
+    name,
+    kind: raw.kind || 'unknown',
+    status: raw.status || 'UNKNOWN',
+    schedule: raw.rrule || null,
+    model: raw.model || null,
+    reasoningEffort: raw.reasoning_effort || null,
+    executionEnvironment: raw.execution_environment || null,
+    cwds,
+    createdAt: typeof raw.created_at === 'number' ? raw.created_at : null,
+    updatedAt: typeof raw.updated_at === 'number' ? raw.updated_at : null,
+    category,
+    riskLevel,
+    portfolioRelated: isPortfolioRelated(name, prompt, cwds, controlDocs),
+    sourceFile,
+    controlDocs,
+    promptExcerpt: sanitizePromptExcerpt(prompt),
+    duplicateCandidate: false,
+    managementBoundary,
+    contextHealth: classifyContextHealth(contextGaps, riskLevel),
+    contextGaps,
+    contextProfile,
+  }
+}
+
+function unavailableInventory(sourceDirectory: string, generatedAt: string, reason: string): CodexAutomationInventory {
+  return {
+    available: false,
+    reason,
+    sourceDirectory,
+    generatedAt,
+    automations: [],
+    hiddenCount: 0,
+    overview: buildOverview([]),
+  }
+}
+
+function buildOverview(automations: CodexAutomationProfile[]) {
+  return {
+    total: automations.length,
+    active: automations.filter((automation) => automation.status === 'ACTIVE').length,
+    paused: automations.filter((automation) => automation.status === 'PAUSED').length,
+    duplicateCandidates: automations.filter((automation) => automation.duplicateCandidate).length,
+    highRisk: automations.filter((automation) => automation.riskLevel === 'high').length,
+    missingContext: automations.filter((automation) => automation.contextHealth !== 'green').length,
+  }
+}
+
+function extractControlDocs(prompt: string): string[] {
+  const matches = prompt.match(/(?:\/Users\/vambahsillah\/[^\s`'",)]+|(?:docs|lib|scripts|model-ops|personality-corpus)\/[^\s`'",)]+)/g) || []
+  return [
+    ...new Set(
+      matches
+        .map((item) => item.replace(/[.;:]+$/g, ''))
+        .filter((item) => /\.(md|json|jsonl|toml|ts|tsx|sql)$/i.test(item)),
+    ),
+  ]
+}
+
+function classifyCategory(name: string, prompt: string, cwds: string[]): AutomationCategory {
+  const nameText = name.toLowerCase()
+  if (nameText.includes('subscription') || nameText.includes('cancellation') || nameText.includes('vendor')) return 'Subscriptions'
+  if (nameText.includes('credential') || nameText.includes('rotation')) return 'Credentials'
+  if (nameText.includes('model') || nameText.includes('llm') || nameText.includes('hermes') || nameText.includes('rag')) return 'Model Ops'
+  if (nameText.includes('organization') || nameText.includes('workspace') || nameText.includes('codex project')) return 'Organization'
+  if (nameText.includes('personality') || nameText.includes('corpus') || nameText.includes('content') || nameText.includes('voice')) return 'Content/Voice'
+  if (nameText.includes('operation') || nameText.includes('health') || nameText.includes('monitor')) return 'Operations'
+
+  const haystack = `${prompt} ${cwds.join(' ')}`.toLowerCase()
+  if (haystack.includes('subscription') || haystack.includes('cancellation') || haystack.includes('vendor')) return 'Subscriptions'
+  if (haystack.includes('credential') || haystack.includes('secret') || haystack.includes('rotation')) return 'Credentials'
+  if (haystack.includes('model') || haystack.includes('llm') || haystack.includes('hermes') || haystack.includes('rag')) return 'Model Ops'
+  if (haystack.includes('organization') || haystack.includes('workspace') || haystack.includes('codex project')) return 'Organization'
+  if (haystack.includes('personality') || haystack.includes('corpus') || haystack.includes('content') || haystack.includes('voice')) return 'Content/Voice'
+  if (haystack.includes('subscription') || haystack.includes('cancellation') || haystack.includes('vendor')) return 'Subscriptions'
+  if (haystack.includes('operation') || haystack.includes('health') || haystack.includes('monitor')) return 'Operations'
+  return 'Other'
+}
+
+function classifyBoundary(prompt: string): AutomationBoundary {
+  const text = prompt.toLowerCase()
+  if (text.includes('never automatic') || text.includes('never automatically')) return 'never automatic'
+  if (text.includes('approval') || text.includes('do not rotate') || text.includes('do not revoke') || text.includes('production')) {
+    return 'approval-required'
+  }
+  if (text.includes('branch') || text.includes('do not merge') || text.includes('do not push')) return 'branch-only'
+  return 'read-only'
+}
+
+function classifyRisk(prompt: string, category: AutomationCategory, boundary: AutomationBoundary): AutomationRiskLevel {
+  const text = prompt.toLowerCase()
+  if (
+    boundary === 'never automatic' ||
+    text.includes('production') ||
+    text.includes('secret') ||
+    text.includes('credential') ||
+    text.includes('cancel a subscription') ||
+    text.includes('payment') ||
+    text.includes('checkout')
+  ) {
+    return 'high'
+  }
+  if (boundary === 'approval-required' || category === 'Model Ops' || category === 'Subscriptions') return 'medium'
+  return 'low'
+}
+
+function isPortfolioRelated(name: string, prompt: string, cwds: string[], controlDocs: string[]): boolean {
+  const haystack = `${name} ${prompt} ${cwds.join(' ')} ${controlDocs.join(' ')}`.toLowerCase()
+  return (
+    cwds.some((cwd) => cwd.startsWith(PORTFOLIO_ROOT)) ||
+    haystack.includes('/users/vambahsillah/projects/portfolio') ||
+    haystack.includes('portfolio') ||
+    haystack.includes('amadutown') ||
+    haystack.includes('agent operations')
+  )
+}
+
+function buildContextProfile(
+  name: string,
+  prompt: string,
+  cwds: string[],
+  controlDocs: string[],
+  authorityBoundary: AutomationBoundary,
+): CodexAutomationProfile['contextProfile'] {
+  return {
+    purpose: inferPurpose(name, prompt),
+    operatingRhythm: inferOperatingRhythm(prompt),
+    recurringDecisions: inferRecurringDecisions(prompt),
+    inputs: [...new Set([...cwds, ...controlDocs])],
+    dependencies: inferDependencies(prompt),
+    frictionPoints: inferFrictionPoints(prompt),
+    authorityBoundary,
+    expectedOutputs: inferExpectedOutputs(prompt),
+    escalationTrigger: inferEscalationTrigger(prompt),
+    governingDocs: controlDocs,
+  }
+}
+
+function inferPurpose(name: string, prompt: string) {
+  if (!prompt.trim()) return null
+  return `${name}: ${firstSentence(prompt)}`
+}
+
+function inferOperatingRhythm(prompt: string) {
+  const text = prompt.toLowerCase()
+  if (text.includes('monthly')) return 'monthly'
+  if (text.includes('weekly')) return 'weekly'
+  if (text.includes('daily')) return 'daily'
+  if (text.includes('recurring')) return 'recurring'
+  return null
+}
+
+function inferRecurringDecisions(prompt: string) {
+  const text = prompt.toLowerCase()
+  if (/(recommend|decision|approval|candidate|classify|risk|green\/yellow\/red|red status|yellow status)/.test(text)) {
+    return 'Reviews evidence and recommends status, next action, or approval path.'
+  }
+  return null
+}
+
+function inferDependencies(prompt: string) {
+  const deps = [
+    ['Codex', /codex/i],
+    ['Portfolio', /portfolio/i],
+    ['n8n', /n8n/i],
+    ['Hermes', /hermes/i],
+    ['LM Studio', /lm studio/i],
+    ['Supabase', /supabase/i],
+    ['Vercel', /vercel/i],
+    ['Slack', /slack/i],
+    ['Google Drive', /google drive|drive/i],
+    ['Stripe', /stripe/i],
+    ['1Password', /1password/i],
+    ['Infisical', /infisical/i],
+  ] as const
+  return deps.filter(([, pattern]) => pattern.test(prompt)).map(([name]) => name)
+}
+
+function inferFrictionPoints(prompt: string) {
+  const points: string[] = []
+  const text = prompt.toLowerCase()
+  if (text.includes('duplicate') || text.includes('drift')) points.push('Drift or duplicate automation risk')
+  if (text.includes('missing') || text.includes('unavailable')) points.push('Missing credentials, baselines, or local access')
+  if (text.includes('stale') || text.includes('blocked')) points.push('Stale or blocked source state')
+  if (text.includes('failed') || text.includes('failure')) points.push('Failure triage and retry boundary')
+  return points
+}
+
+function inferExpectedOutputs(prompt: string) {
+  const outputs: string[] = []
+  const text = prompt.toLowerCase()
+  if (text.includes('report')) outputs.push('report')
+  if (text.includes('approval packet') || text.includes('proposal')) outputs.push('approval packet')
+  if (text.includes('summary') || text.includes('summarize')) outputs.push('summary')
+  if (text.includes('branch')) outputs.push('branch handoff')
+  if (text.includes('alert') || text.includes('warning')) outputs.push('alert or warning')
+  return outputs
+}
+
+function inferEscalationTrigger(prompt: string) {
+  const text = prompt.toLowerCase()
+  if (text.includes('approval')) return 'Escalate when an approval-required action or packet is needed.'
+  if (text.includes('red status') || text.includes('red')) return 'Escalate on red status or critical failure.'
+  if (text.includes('blocker') || text.includes('blocked')) return 'Escalate on blocked source, credential, or runtime access.'
+  if (text.includes('failed') || text.includes('failure')) return 'Escalate on failed checks or repeated failure.'
+  return null
+}
+
+function firstSentence(prompt: string) {
+  return prompt.replace(/\s+/g, ' ').trim().split(/(?<=[.!?])\s+/)[0].slice(0, 180)
+}
+
+function findContextGaps(
+  profile: CodexAutomationProfile['contextProfile'],
+  prompt: string,
+): string[] {
+  const gaps: string[] = []
+  if (!profile.purpose) gaps.push('missing purpose')
+  if (!profile.operatingRhythm) gaps.push('missing operating rhythm')
+  if (!profile.recurringDecisions) gaps.push('missing recurring decisions')
+  if (profile.inputs.length === 0) gaps.push('missing inputs')
+  if (profile.expectedOutputs.length === 0) gaps.push('missing outputs')
+  if (profile.governingDocs.length === 0) gaps.push('missing control docs')
+  if (!profile.escalationTrigger) gaps.push('missing escalation trigger')
+  if (!/(do not|approval|required|read-only|never|branch|authority)/i.test(prompt)) gaps.push('missing authority boundary')
+  return gaps
+}
+
+function classifyContextHealth(contextGaps: string[], riskLevel: AutomationRiskLevel): AutomationContextHealth {
+  if (contextGaps.length === 0) return 'green'
+  if (riskLevel === 'high' && contextGaps.length > 2) return 'red'
+  if (contextGaps.length > 4) return 'red'
+  return 'yellow'
+}
+
+function sanitizePromptExcerpt(prompt: string) {
+  return prompt
+    .replace(SECRETISH_PATTERN, '[redacted]')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 220)
+}
+
+function markDuplicateCandidates(automations: CodexAutomationProfile[]) {
+  const counts = new Map<string, number>()
+  for (const automation of automations) {
+    const key = duplicateKey(automation)
+    counts.set(key, (counts.get(key) ?? 0) + 1)
+  }
+  return automations.map((automation) => ({
+    ...automation,
+    duplicateCandidate: (counts.get(duplicateKey(automation)) ?? 0) > 1,
+  }))
+}
+
+function duplicateKey(automation: CodexAutomationProfile) {
+  return automation.name
+    .toLowerCase()
+    .replace(/\b\d+\b/g, '')
+    .replace(/\s+/g, ' ')
+    .replace(/\s+-\s+copy$/g, '')
+    .trim()
+}


### PR DESCRIPTION
## Summary
- adds a read-only Automation Context page under Agent Operations
- inventories Portfolio-related Codex automations from the local Codex automation directory
- surfaces category, risk, duplicate candidates, authority boundary, context gaps, governing docs, and sanitized prompt excerpts
- adds an admin API route plus focused unit/API coverage

## Validation
- npm test -- lib/codex-automation-inventory.test.ts app/api/admin/agents/automations/route.test.ts
- npx tsc --noEmit --pretty false
- npm run lint
- npm run build
- fresh dev smoke at http://localhost:3001/admin/agents/automations redirects unauthenticated users to login
- local inventory helper detected 10 Portfolio-related automations and hid 1 non-Portfolio automation