### PR TITLE
Add public-safe personality corpus to chatbot knowledge

### DIFF
--- a/docs/email-rag-knowledge-and-chat-policy.md
+++ b/docs/email-rag-knowledge-and-chat-policy.md
@@ -17,10 +17,13 @@
 
 - **Health check (admin):** `GET /api/admin/rag-health` (optional `?q=` custom query). Confirms the app can reach the RAG webhook and return non-empty text. Still respects `MOCK_N8N` and `N8N_DISABLE_OUTBOUND`.
 - **n8n:** The workflow exposing `amadutown-rag-query` must be **active** and the Pinecone node must have valid credentials (see `docs/staging-n8n-activation-matrix.md` for historical staging notes).
+- **Local chatbot knowledge:** `GET /api/knowledge` and `GET /api/knowledge/chatbot` now include `docs/vambah-personality-public-safe.md`, a public-safe personality corpus summary generated from the governed local corpus. This improves the website chatbot's local knowledge bundle without mutating Pinecone.
+- **Pinecone status:** personality-corpus Pinecone ingestion remains deferred. Ingest only after reviewing the staged corpus pack and deciding whether the Pinecone-backed n8n workflow should treat it as a canonical source.
 
 ## Code entry points
 
 - [`lib/rag-query.ts`](../lib/rag-query.ts) — HTTP client and query string builder.  
+- [`lib/chatbot-knowledge.ts`](../lib/chatbot-knowledge.ts) — Local `/api/knowledge` source registry, including the public-safe personality corpus document.
 - [`lib/email-llm-context.ts`](../lib/email-llm-context.ts) — Appends RAG + optional chat blocks to the system prompt.  
 - [`lib/lead-chat-excerpt.ts`](../lib/lead-chat-excerpt.ts) — Optional site chat transcript.  
 - [`lib/outreach-queue-generator.ts`](../lib/outreach-queue-generator.ts), [`lib/delivery-email.ts`](../lib/delivery-email.ts) — Call the appender after template placeholders are resolved.

--- a/docs/vambah-personality-public-safe.md
+++ b/docs/vambah-personality-public-safe.md
@@ -1,0 +1,65 @@
+# Vambah Personality Corpus: Public-Safe RAG Pack
+
+Source pack: `2026.05.03-d2eabc3d4b55`
+
+Source hash: `d2eabc3d4b55ab55f58703b04517dff6b30e1c7f7142a93e7a254e9911ee2f60`
+
+Origin: `/Users/vambahsillah/Documents/Codex/2026-04-30/i-have-quite-a-bit-of/personality-corpus/rag-ready/vambah_personality_public_safe.md`
+
+Sensitivity: public-safe, private-derived summary. This document is intentionally staged for chatbot and RAG use. It is not raw source text.
+
+## Who Is Vambah Sillah?
+
+Vambah Sillah is a systems-minded, equity-driven product strategist, author, consultant, and builder working at the intersection of technology access, automation, community capacity, and practical business transformation.
+
+## What Defines His Work?
+
+- Access, not talent, often determines outcomes.
+- Technology should reduce burden, not create more work for already-overloaded people.
+- AI and automation are leverage tools, not substitutes for dignity, consent, ownership, or community.
+- Strategy only matters when it meets operational reality.
+- Business models clarify how value is created, delivered, and sustained.
+- Legacy is practical: open doors, share blueprints, build institutions, and make learning compound.
+- Power without governance can reproduce the harm it claims to solve.
+
+## Voice And Style
+
+Grounded, reflective, practical, morally clear, and systems-minded. The strongest pattern is lived scene, system diagnosis, practical framework, and action-oriented close.
+
+Common moves:
+
+- Open with a concrete moment, tension, or familiar phrase.
+- Expose the system beneath the surface-level problem.
+- Translate frameworks into plain language.
+- Convert raw material into structured assets: table, roadmap, script, chapter, product requirement, offer, or decision memo.
+- Pair critique with a practical next step.
+- End with a crisp principle, question, or invitation to act.
+
+## Projects And Domains
+
+- AmaduTown Advisory Solutions and AI/automation advisory work.
+- The Equity Code and technology equity thought leadership.
+- Accelerated and AI/product-management operating systems.
+- Mentor RI and nonprofit sustainability strategy.
+- LinkedIn, Medium, YouTube, and content-generation workflows.
+- The Art of Flipping Tables memoir work.
+- Code Breaker Chronicles / Quantum Rebel speculative fiction.
+- Customer outcomes, JTBD conversion, ATAS product roadmap, and client strategy work.
+
+## Content Pillars
+
+- AI and automation as leverage: AI should make real work lighter, clearer, and more humane.
+- Technology access, dignity, and equity: Innovation should expand dignity rather than concentrate power.
+- Product strategy and operating systems: Messy qualitative input can become structured decisions and repeatable systems.
+- Nonprofit capacity and practical strategy: Organizations do not need more slide decks; they need strategy that survives contact with reality.
+- Legacy, family, and institution-building: Legacy becomes public value when converted into tools, mentorship, institutions, and access.
+- Creative identity, worldbuilding, and power: Stories about power reveal the governance questions technology often hides.
+
+## Retrieval Metadata
+
+- source_type: personality_corpus
+- public_safe: true
+- sensitivity: public_safe_private_derived
+- retrieval_priority: high
+- intended_consumers: Portfolio chatbot, future Pinecone RAG, agent exports
+- raw_private_content_included: false

--- a/lib/__tests__/chatbot-knowledge.test.ts
+++ b/lib/__tests__/chatbot-knowledge.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { CHATBOT_KNOWLEDGE_SOURCES, getChatbotKnowledgeBody } from '../chatbot-knowledge'
+
+describe('chatbot knowledge corpus', () => {
+  it('includes the public-safe personality corpus source', () => {
+    expect(CHATBOT_KNOWLEDGE_SOURCES).toContainEqual({
+      path: 'docs/vambah-personality-public-safe.md',
+      sectionTitle: 'Vambah Personality Corpus (public-safe)',
+    })
+  })
+
+  it('loads the personality corpus in the chatbot knowledge body', async () => {
+    const result = await getChatbotKnowledgeBody()
+
+    expect(result).toHaveProperty('body')
+    if (!('body' in result)) return
+
+    expect(result.body).toContain('## Source: Vambah Personality Corpus (public-safe)')
+    expect(result.body).toContain('Source pack: `2026.05.03-d2eabc3d4b55`')
+    expect(result.body).toContain('raw_private_content_included: false')
+  })
+})

--- a/lib/chatbot-knowledge.ts
+++ b/lib/chatbot-knowledge.ts
@@ -22,6 +22,7 @@ export interface ChatbotKnowledgeEntry {
 export const CHATBOT_KNOWLEDGE_SOURCES: ChatbotKnowledgeEntry[] = [
   { path: 'docs/chatbot-products-and-services-overview.md', sectionTitle: 'What AmaduTown Offers (products and services)' },
   { path: 'docs/chatbot-campaigns-overview.md', sectionTitle: 'Active Promotions & Attraction Campaigns' },
+  { path: 'docs/vambah-personality-public-safe.md', sectionTitle: 'Vambah Personality Corpus (public-safe)' },
   { path: 'docs/user-help-guide.md', sectionTitle: 'User Help Guide' },
   { path: 'docs/admin-sales-lead-pipeline-sop.md', sectionTitle: 'Admin & Sales Lead Pipeline (overview)' },
   { path: 'README.md', sectionTitle: 'Project overview' },

--- a/scripts/build-chatbot-knowledge.ts
+++ b/scripts/build-chatbot-knowledge.ts
@@ -5,13 +5,9 @@
 
 import { readFile, writeFile } from 'fs/promises'
 import path from 'path'
+import { CHATBOT_KNOWLEDGE_SOURCES } from '../lib/chatbot-knowledge'
 
-const SOURCES: { path: string; sectionTitle?: string }[] = [
-  { path: 'docs/chatbot-products-and-services-overview.md', sectionTitle: 'What AmaduTown Offers (products and services)' },
-  { path: 'docs/user-help-guide.md', sectionTitle: 'User Help Guide' },
-  { path: 'docs/admin-sales-lead-pipeline-sop.md', sectionTitle: 'Admin & Sales Lead Pipeline (overview)' },
-  { path: 'README.md', sectionTitle: 'Project overview' },
-]
+const SOURCES = CHATBOT_KNOWLEDGE_SOURCES
 
 async function main() {
   const cwd = process.cwd()


### PR DESCRIPTION
## Summary
- add the public-safe Vambah personality corpus document to Portfolio docs
- include it in the existing `/api/knowledge` and `/api/knowledge/chatbot` source registry
- make the build-time chatbot knowledge generator reuse the runtime source registry
- add regression coverage so the personality corpus source stays included
- document that Pinecone ingestion remains deferred

## Validation
- `npm run build:knowledge`
- `npm test -- lib/__tests__/chatbot-knowledge.test.ts lib/__tests__/rag-query.test.ts`
- `npx tsc --noEmit`
- `npm run build`
- pre-push `npm run db:health-check` passed

## Notes
This change does not mutate Pinecone, n8n, prompts, or production configuration. It only extends the local chatbot knowledge bundle that the app already exposes via `/api/knowledge`.
