### PR TITLE
docs: add enhancement impact preflight

### DIFF
--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -8,12 +8,13 @@ The goal is simple: workers can keep moving, but only one integration captain me
 
 1. Pick the role that matches the chat's job.
 2. Read that role file before editing.
-3. Work on a named branch.
-4. Commit only scoped files.
-5. Push the branch.
-6. Open a PR if the work is ready for review.
-7. Add a handoff entry to `docs/integration-captain-queue.md`.
-8. Stop before merging unless the chat is explicitly acting as integration captain.
+3. Run the enhancement impact preflight when another chat may be working in the same area.
+4. Work on a named branch.
+5. Commit only scoped files.
+6. Push the branch.
+7. Open a PR if the work is ready for review.
+8. Add a handoff entry to `docs/integration-captain-queue.md`.
+9. Stop before merging unless the chat is explicitly acting as integration captain.
 
 ## Roles
 
@@ -21,6 +22,7 @@ The goal is simple: workers can keep moving, but only one integration captain me
 | --- | --- | --- |
 | Integration Captain | `docs/agents/integration-captain.md` | Sequencing PRs, resolving conflicts, merging, and verifying Vercel |
 | PR Worker | `docs/agents/pr-worker.md` | Building a scoped feature/fix and handing it off |
+| Enhancement Impact Preflight | `docs/agents/enhancement-impact-preflight.md` | Predicting overlap before parallel implementation starts |
 | Vercel Verifier | `docs/agents/vercel-verifier.md` | Checking preview or post-merge deployment health |
 | Slack Agent Reviewer | `docs/agents/slack-agent-reviewer.md` | Reviewing Slack command behavior before merge |
 

--- a/docs/agents/enhancement-impact-preflight.md
+++ b/docs/agents/enhancement-impact-preflight.md
@@ -1,0 +1,94 @@
+# Enhancement Impact Preflight
+
+Use this before starting two or more enhancements in parallel.
+
+The goal is to identify likely code overlap before implementation, not after two branches already conflict.
+
+## When To Run
+
+Run this preflight when:
+
+- two chats may work at the same time
+- an enhancement touches admin routes, shared libs, API routes, database schema, Slack, email, costs, approvals, or chatbot knowledge
+- the request sounds adjacent to another active branch or PR
+- the file set is unclear
+
+## Process
+
+1. Name the enhancement in one sentence.
+2. Identify the user-facing surface.
+3. Search for likely entry points.
+4. List predicted files before editing.
+5. Compare predicted files and shared symbols with active PRs, dirty files, and worktrees.
+6. Classify overlap as green, yellow, or red.
+
+## Commands
+
+Start with the current repo state:
+
+```bash
+git fetch --prune origin
+git status --short --branch
+git worktree list
+gh pr list --state open --json number,title,headRefName,isDraft,mergeStateStatus,updatedAt,url
+```
+
+Find likely files:
+
+```bash
+rg -n "<feature keyword>|<route>|<table>|<function>|<component>" app lib scripts docs supabase
+rg --files app lib scripts docs supabase | rg "<feature keyword>|<route>|<domain>"
+```
+
+Compare against active PRs:
+
+```bash
+gh pr diff <pr-number> --name-only
+git diff --name-only origin/main...origin/<branch-name>
+```
+
+## Overlap Classification
+
+Green:
+
+- no shared files
+- no shared route, API, table, generated artifact, or exported helper
+- enhancements can proceed independently
+
+Yellow:
+
+- different files but same user workflow, database table, API contract, generated content, or shared helper
+- proceed only with explicit ownership boundaries and merge order
+
+Red:
+
+- same file or same exported function/component/schema
+- same generated artifact or migration
+- one enhancement changes assumptions the other enhancement depends on
+- do not run independently; sequence the work or split ownership first
+
+## Required Preflight Output
+
+Every parallel worker should include this before implementation or in the PR handoff:
+
+```md
+### Enhancement Impact Preflight
+
+- Enhancement:
+- User-facing surface:
+- Predicted files:
+- Shared routes/APIs/tables/helpers:
+- Active PRs or branches checked:
+- Dirty worktree files checked:
+- Overlap rating: green/yellow/red
+- Coordination decision:
+- Merge-order note:
+```
+
+## Coordination Rules
+
+- If overlap is green, workers can proceed on separate branches.
+- If overlap is yellow, workers can proceed only after naming ownership boundaries.
+- If overlap is red, one owner should implement the shared layer first, or the integration captain should sequence the branches.
+- If predicted files change during implementation, update the handoff before opening the PR.
+- Generated files count as shared files. Do not let two workers regenerate the same artifact independently.

--- a/docs/agents/integration-captain.md
+++ b/docs/agents/integration-captain.md
@@ -41,6 +41,7 @@ Confirm:
 - whether `main` equals `origin/main`
 - which PRs are ready, draft, blocked, or stale
 - whether any worker handoffs in `docs/integration-captain-queue.md` need action
+- whether any ready PR skipped an impact preflight despite touching a hot surface
 
 ## Merge Gate
 
@@ -48,6 +49,7 @@ Before merging a PR:
 
 - PR is not draft.
 - PR has a clear purpose and scoped file set.
+- PR has an impact preflight when it touches a hot surface or overlaps another active branch.
 - Required validation is documented in the PR or handoff.
 - `Vercel - portfolio` preview is success.
 - `Vercel - portfolio-staging` preview is success.

--- a/docs/agents/pr-worker.md
+++ b/docs/agents/pr-worker.md
@@ -22,6 +22,8 @@ git log -1 --oneline --decorate
 
 If the checkout is dirty before you start, identify whether the files belong to your task. If they do not, pause and either switch to a clean worktree/branch or ask the integration captain.
 
+If another chat may be working in an adjacent area, run `docs/agents/enhancement-impact-preflight.md` before implementation and include the result in the handoff.
+
 ## Before Handoff
 
 Run validation appropriate to the change:
@@ -41,6 +43,12 @@ Add or paste this into `docs/integration-captain-queue.md`:
 - Branch:
 - PR:
 - Purpose:
+- Impact preflight:
+  - Predicted files:
+  - Shared routes/APIs/tables/helpers:
+  - Active PRs or branches checked:
+  - Overlap rating: green/yellow/red
+  - Coordination decision:
 - Changed files:
 - Validation run:
 - Known risks:

--- a/docs/integration-captain-queue.md
+++ b/docs/integration-captain-queue.md
@@ -38,6 +38,12 @@ Every worker chat should add a handoff here or paste the same structure into the
 - PR:
 - Owner/chat:
 - Purpose:
+- Impact preflight:
+  - Predicted files:
+  - Shared routes/APIs/tables/helpers:
+  - Active PRs or branches checked:
+  - Overlap rating:
+  - Coordination decision:
 - Changed files:
 - Validation run:
 - Vercel preview:


### PR DESCRIPTION
## Summary

Adds a pre-implementation coordination rule for parallel Portfolio enhancements so workers can predict codebase overlap before implementation starts.

## Changes

- adds `docs/agents/enhancement-impact-preflight.md`
- wires the preflight into the agent role README
- requires PR workers to include impact preflight details when adjacent work may exist
- adds integration-captain merge gate language for hot-surface overlap
- expands the shared queue template with preflight fields

## Validation

- `git diff --check`
- pre-push database health check passed

## Notes

This is a docs/process-only change. No runtime behavior changes.
