### PR TITLE
feat: add automation context to chief of staff chat

### DIFF
--- a/lib/chief-of-staff-chat.test.ts
+++ b/lib/chief-of-staff-chat.test.ts
@@ -20,8 +20,10 @@ import {
   buildChiefOfStaffPrompt,
   normalizeChiefOfStaffHistory,
   parseChiefOfStaffJson,
+  summarizeAutomationContext,
   type ChiefOfStaffContext,
 } from './chief-of-staff-chat'
+import type { CodexAutomationInventory } from './codex-automation-inventory'
 
 const context: ChiefOfStaffContext = {
   generatedAt: '2026-05-02T12:00:00.000Z',
@@ -44,6 +46,43 @@ const context: ChiefOfStaffContext = {
     totalUsd: 0.0123,
     providers: ['openai'],
     models: ['gpt-4o-mini'],
+  },
+  automationContext: {
+    available: true,
+    reason: null,
+    sourceDirectory: '/Users/vambahsillah/.codex/automations',
+    generatedAt: '2026-05-02T12:00:00.000Z',
+    overview: {
+      total: 2,
+      active: 2,
+      paused: 0,
+      duplicateCandidates: 0,
+      highRisk: 1,
+      missingContext: 1,
+    },
+    hiddenCount: 0,
+    highRiskAutomations: [
+      {
+        id: 'portfolio-credential-rotation-due-report',
+        name: 'Portfolio Credential Rotation Due Report',
+        category: 'Credentials',
+        boundary: 'approval-required',
+        contextHealth: 'yellow',
+        missingQuestions: ['governance'],
+      },
+    ],
+    contextGapAutomations: [
+      {
+        id: 'portfolio-credential-rotation-due-report',
+        name: 'Portfolio Credential Rotation Due Report',
+        category: 'Credentials',
+        riskLevel: 'high',
+        contextHealth: 'yellow',
+        missingQuestions: ['governance'],
+        recommendations: ['Reference the governing doc, skill, source register, or runbook path in the automation prompt.'],
+      },
+    ],
+    duplicateCandidates: [],
   },
 }
 
@@ -117,10 +156,92 @@ describe('Chief of Staff chat helpers', () => {
     const prompt = buildChiefOfStaffPrompt(context, [{ role: 'user', content: 'What needs attention?' }])
 
     expect(prompt.systemPrompt).toContain('production mutations')
+    expect(prompt.systemPrompt).toContain('Automation context')
     expect(prompt.systemPrompt).toContain('Return JSON only')
     expect(prompt.systemPrompt).toContain('action_proposals')
     expect(prompt.systemPrompt).toContain('agent_engagements')
     expect(prompt.userPrompt).toContain('Morning review')
+    expect(prompt.userPrompt).toContain('Portfolio Credential Rotation Due Report')
     expect(prompt.userPrompt).toContain('What needs attention?')
+  })
+
+  it('summarizes automation context without raw prompt excerpts', () => {
+    const inventory: CodexAutomationInventory = {
+      available: true,
+      sourceDirectory: '/Users/vambahsillah/.codex/automations',
+      generatedAt: '2026-05-02T12:00:00.000Z',
+      hiddenCount: 1,
+      overview: {
+        total: 2,
+        active: 2,
+        paused: 0,
+        duplicateCandidates: 1,
+        highRisk: 1,
+        missingContext: 1,
+      },
+      automations: [
+        {
+          id: 'portfolio-credential-rotation-due-report',
+          name: 'Portfolio Credential Rotation Due Report',
+          kind: 'cron',
+          status: 'ACTIVE',
+          schedule: 'FREQ=WEEKLY',
+          model: 'gpt-5.5',
+          reasoningEffort: 'high',
+          executionEnvironment: 'local',
+          cwds: ['/Users/vambahsillah/Projects/Portfolio'],
+          createdAt: 1,
+          updatedAt: 2,
+          category: 'Credentials',
+          riskLevel: 'high',
+          portfolioRelated: true,
+          sourceFile: '/Users/vambahsillah/.codex/automations/portfolio-credential-rotation-due-report/automation.toml',
+          controlDocs: [],
+          promptExcerpt: 'Run with API_KEY=[redacted].',
+          duplicateCandidate: true,
+          managementBoundary: 'approval-required',
+          contextHealth: 'yellow',
+          contextGaps: ['missing control docs'],
+          contextQuestions: [
+            {
+              id: 'governance',
+              question: 'What doc, skill, or runbook governs it?',
+              answered: false,
+              answer: null,
+              recommendation: 'Reference the governing doc, skill, source register, or runbook path in the automation prompt.',
+            },
+          ],
+          contextProfile: {
+            purpose: 'Check credential rotation posture.',
+            operatingRhythm: 'weekly',
+            recurringDecisions: 'Reviews evidence and recommends status, next action, or approval path.',
+            inputs: ['/Users/vambahsillah/Projects/Portfolio'],
+            dependencies: ['Codex', 'Portfolio'],
+            frictionPoints: [],
+            authorityBoundary: 'approval-required',
+            expectedOutputs: ['approval packet'],
+            escalationTrigger: 'Escalate when an approval-required action or packet is needed.',
+            governingDocs: [],
+          },
+        },
+      ],
+    }
+
+    const summary = summarizeAutomationContext(inventory)
+
+    expect(summary.available).toBe(true)
+    expect(summary.hiddenCount).toBe(1)
+    expect(summary.highRiskAutomations).toEqual([
+      {
+        id: 'portfolio-credential-rotation-due-report',
+        name: 'Portfolio Credential Rotation Due Report',
+        category: 'Credentials',
+        boundary: 'approval-required',
+        contextHealth: 'yellow',
+        missingQuestions: ['governance'],
+      },
+    ])
+    expect(JSON.stringify(summary)).not.toContain('API_KEY')
+    expect(summary.contextGapAutomations[0].recommendations).toContain('Reference the governing doc, skill, source register, or runbook path in the automation prompt.')
   })
 })

--- a/lib/chief-of-staff-chat.ts
+++ b/lib/chief-of-staff-chat.ts
@@ -12,6 +12,10 @@ import {
   type AgentAction,
 } from '@/lib/agent-policy'
 import { getAgentByKey } from '@/lib/agent-organization'
+import {
+  listCodexAutomationInventory,
+  type CodexAutomationInventory,
+} from '@/lib/codex-automation-inventory'
 import { supabaseAdmin } from '@/lib/supabase'
 
 export type ChiefOfStaffChatMessage = {
@@ -76,6 +80,37 @@ type CostSummaryRow = {
   model: string | null
 }
 
+export type ChiefOfStaffAutomationContext = {
+  available: boolean
+  reason: string | null
+  sourceDirectory: string
+  generatedAt: string
+  overview: CodexAutomationInventory['overview']
+  hiddenCount: number
+  highRiskAutomations: Array<{
+    id: string
+    name: string
+    category: string
+    boundary: string
+    contextHealth: string
+    missingQuestions: string[]
+  }>
+  contextGapAutomations: Array<{
+    id: string
+    name: string
+    category: string
+    riskLevel: string
+    contextHealth: string
+    missingQuestions: string[]
+    recommendations: string[]
+  }>
+  duplicateCandidates: Array<{
+    id: string
+    name: string
+    category: string
+  }>
+}
+
 export type ChiefOfStaffContext = {
   generatedAt: string
   activeRuns: AgentRunSummaryRow[]
@@ -87,6 +122,7 @@ export type ChiefOfStaffContext = {
     providers: string[]
     models: string[]
   }
+  automationContext: ChiefOfStaffAutomationContext
 }
 
 const DEFAULT_MODEL = 'gpt-4o-mini'
@@ -202,6 +238,75 @@ function parseAgentEngagements(parsed: { agent_engagements?: unknown }): ChiefOf
     .slice(0, 4)
 }
 
+export function summarizeAutomationContext(inventory: CodexAutomationInventory): ChiefOfStaffAutomationContext {
+  const automations = inventory.automations
+  const missingQuestions = (automation: CodexAutomationInventory['automations'][number]) =>
+    automation.contextQuestions
+      .filter((question) => !question.answered)
+      .map((question) => question.id)
+
+  if (!inventory.available) {
+    return {
+      available: false,
+      reason: inventory.reason ?? 'Automation inventory is unavailable.',
+      sourceDirectory: inventory.sourceDirectory,
+      generatedAt: inventory.generatedAt,
+      overview: inventory.overview,
+      hiddenCount: inventory.hiddenCount,
+      highRiskAutomations: [],
+      contextGapAutomations: [],
+      duplicateCandidates: [],
+    }
+  }
+
+  return {
+    available: true,
+    reason: null,
+    sourceDirectory: inventory.sourceDirectory,
+    generatedAt: inventory.generatedAt,
+    overview: inventory.overview,
+    hiddenCount: inventory.hiddenCount,
+    highRiskAutomations: automations
+      .filter((automation) => automation.riskLevel === 'high')
+      .slice(0, 6)
+      .map((automation) => ({
+        id: automation.id,
+        name: automation.name,
+        category: automation.category,
+        boundary: automation.managementBoundary,
+        contextHealth: automation.contextHealth,
+        missingQuestions: missingQuestions(automation),
+      })),
+    contextGapAutomations: automations
+      .filter((automation) => automation.contextQuestions.some((question) => !question.answered))
+      .sort((a, b) => {
+        const healthRank = { red: 0, yellow: 1, green: 2 }
+        return healthRank[a.contextHealth] - healthRank[b.contextHealth] || b.contextGaps.length - a.contextGaps.length
+      })
+      .slice(0, 6)
+      .map((automation) => ({
+        id: automation.id,
+        name: automation.name,
+        category: automation.category,
+        riskLevel: automation.riskLevel,
+        contextHealth: automation.contextHealth,
+        missingQuestions: missingQuestions(automation),
+        recommendations: automation.contextQuestions
+          .filter((question) => !question.answered)
+          .map((question) => question.recommendation)
+          .slice(0, 3),
+      })),
+    duplicateCandidates: automations
+      .filter((automation) => automation.duplicateCandidate)
+      .slice(0, 8)
+      .map((automation) => ({
+        id: automation.id,
+        name: automation.name,
+        category: automation.category,
+      })),
+  }
+}
+
 export function parseChiefOfStaffJson(content: string): {
   reply: string
   suggestedActions: string[]
@@ -239,7 +344,7 @@ export async function collectChiefOfStaffContext(): Promise<ChiefOfStaffContext>
   const db = assertDatabase()
   const since = sinceHours(24)
 
-  const [activeRes, failedRes, approvalsRes, costsRes] = await Promise.all([
+  const [activeRes, failedRes, approvalsRes, costsRes, automationInventory] = await Promise.all([
     db
       .from('agent_runs')
       .select('id, agent_key, runtime, title, status, current_step, error_message, started_at')
@@ -264,6 +369,7 @@ export async function collectChiefOfStaffContext(): Promise<ChiefOfStaffContext>
       .select('amount, provider, model')
       .gte('occurred_at', since)
       .limit(100),
+    listCodexAutomationInventory(),
   ])
 
   for (const result of [activeRes, failedRes, approvalsRes, costsRes]) {
@@ -286,6 +392,7 @@ export async function collectChiefOfStaffContext(): Promise<ChiefOfStaffContext>
       providers: Array.from(new Set(costRows.map((row) => row.provider).filter(Boolean) as string[])),
       models: Array.from(new Set(costRows.map((row) => row.model).filter(Boolean) as string[])),
     },
+    automationContext: summarizeAutomationContext(automationInventory),
   }
 }
 
@@ -296,6 +403,7 @@ export function buildChiefOfStaffPrompt(context: ChiefOfStaffContext, history: C
       'Your job is to translate executive intent into clear priorities, operational status, escalation decisions, and next actions.',
       'Use only the provided operating context. If the user asks for production mutations, sending messages, publishing, or config changes, explain that approval is required and suggest the approval path.',
       'Be concise, direct, and operational. Do not pretend to have run tools that are not in the context.',
+      'Automation context is a summarized, read-only inventory. Use it to identify risky automations, missing context, duplicate jobs, and when the Automation Systems Agent should be engaged.',
       'When proposing an executable next step, include a typed action proposal. The proposal is only a recommendation; it does not execute work.',
       'When the next step should be handled by one of the mapped agents, include an agent_engagements proposal with the exact agent_key.',
       'Use only these action ids: read_files, write_files, external_api_call, client_data_access, known_workflow_db_write, unknown_db_write, publish_public_content, send_email, production_config_change, public_content_from_private_material.',


### PR DESCRIPTION
## Summary
- adds sanitized Codex automation inventory context to Chief of Staff chat prompts
- summarizes automation totals, high-risk automations, context gaps, duplicate candidates, and inventory availability
- keeps raw automation prompt excerpts out of the Chief of Staff model context
- adds tests for the automation summary contract and prompt inclusion

## Validation
- npm test -- lib/chief-of-staff-chat.test.ts app/api/admin/agents/chief-of-staff/chat/route.test.ts lib/codex-automation-inventory.test.ts
- npx tsc --noEmit --pretty false
- npm run lint
- npm run build

## Notes
- V1 remains read-only. The Chief of Staff can recommend an Automation Systems engagement or approval path, but this change does not execute automation mutations.