### PR TITLE
feat: activate roadmap reporting rule

### DIFF
--- a/components/client-dashboard/AiOpsRoadmapSection.tsx
+++ b/components/client-dashboard/AiOpsRoadmapSection.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ClipboardList, DollarSign, ShieldCheck } from 'lucide-react'
+import { Activity, ClipboardList, DollarSign, ShieldCheck } from 'lucide-react'
 import type { RoadmapClientView } from '@/lib/client-ai-ops-roadmap'
 
 interface Props {
@@ -13,6 +13,15 @@ function formatCurrency(amount: number): string {
     currency: 'USD',
     maximumFractionDigits: 0,
   }).format(amount)
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return 'Not generated yet'
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(new Date(value))
 }
 
 export default function AiOpsRoadmapSection({ roadmap }: Props) {
@@ -96,6 +105,48 @@ export default function AiOpsRoadmapSection({ roadmap }: Props) {
               </li>
             ))}
           </ul>
+        </div>
+      )}
+
+      {roadmap.latestReport && (
+        <div className="mt-5 rounded-lg border border-cyan-900/60 bg-cyan-950/10 p-4">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <div className="flex items-center gap-2 mb-1">
+                <Activity className="w-4 h-4 text-cyan-300" />
+                <p className="text-xs text-gray-500 uppercase tracking-wide">Latest report</p>
+              </div>
+              <h4 className="font-medium text-gray-100">{roadmap.latestReport.title}</h4>
+              {roadmap.latestReport.summary && (
+                <p className="text-sm text-gray-400 mt-1">{roadmap.latestReport.summary}</p>
+              )}
+            </div>
+            <span className="text-xs px-2 py-1 rounded border border-gray-700 bg-gray-800 text-gray-300 capitalize">
+              {roadmap.latestReport.status.replace(/_/g, ' ')}
+            </span>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-4 gap-3 mt-4 text-sm">
+            <div>
+              <p className="text-xs text-gray-500 uppercase tracking-wide">Generated</p>
+              <p className="text-gray-300">{formatDate(roadmap.latestReport.generatedAt)}</p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 uppercase tracking-wide">Client actions</p>
+              <p className="text-gray-300">{roadmap.latestReport.clientActions.length}</p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 uppercase tracking-wide">Approvals</p>
+              <p className="text-gray-300">{roadmap.latestReport.approvalNeededCount}</p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 uppercase tracking-wide">Monitoring flags</p>
+              <p className="text-gray-300">
+                {(roadmap.latestReport.monitoringSummary?.overdueTasks ?? 0) +
+                  (roadmap.latestReport.monitoringSummary?.staleCostItems ?? 0) +
+                  (roadmap.latestReport.monitoringSummary?.reportMissing ? 1 : 0)}
+              </p>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/docs/client-ai-ops-roadmap-sop.md
+++ b/docs/client-ai-ops-roadmap-sop.md
@@ -6,6 +6,8 @@ This is the operating guide for selling, implementing, monitoring, and improving
 
 - The client owns the hardware, accounts, credentials, project data, and production approvals.
 - AmaduTown access is named, revocable, and limited to startup, maintenance, monitoring, and approved changes.
+- The roadmap is the shared source of truth. Client Dashboard tasks and admin Meeting Tasks are projections of the same roadmap task records, not separate parallel plans.
+- Every roadmap must include implementation, reporting, monitoring, and tracking. Treat reports, monitor findings, task projections, and cost assumptions as part of the roadmap deliverable.
 - Proposal roadmap snapshots are fixed at send time. Later registry or pricing changes become upgrade recommendations, not silent proposal edits.
 - Production technology swaps require approval before implementation.
 - Smoke-test records stay available until a manual cleanup pass is approved. Do not reuse real client records for tests without approval.
@@ -25,6 +27,7 @@ This is the operating guide for selling, implementing, monitoring, and improving
 3. Project AmaduTown delivery tasks into Meeting Tasks.
 4. Confirm each task has a phase, owner, due date when available, status, and source badge.
 5. Keep internal traces, private logs, admin-only notes, credentials, and agent execution details out of the client dashboard.
+6. If a roadmap task changes status from the client dashboard or meeting task queue, sync the status back to the source roadmap task and refresh phase rollups.
 
 ## Monitoring Stage
 
@@ -67,6 +70,18 @@ Monthly reports should separate:
 - upgrade recommendations.
 
 Client-facing summaries should be understandable and avoid exposing private logs, agent traces, credentials, or internal-only notes.
+
+## Roadmap Rule Checklist
+
+Use this checklist whenever a roadmap feature, monitor, report, or client implementation phase changes:
+
+- One shared roadmap object exists for the client project.
+- Client-visible roadmap tasks appear in the Client Dashboard.
+- AmaduTown/internal roadmap tasks appear in Meeting Tasks.
+- Status updates from either projection sync back to the roadmap task.
+- Phase rollups and cost summaries refresh after task or cost changes.
+- The monitor can create a roadmap report and follow-up task when drift, stale pricing, missing reports, or blockers appear.
+- Client-facing output excludes private logs, agent traces, credentials, and internal-only notes.
 
 ## Real Client Pilot Checklist
 

--- a/lib/client-ai-ops-roadmap-db.ts
+++ b/lib/client-ai-ops-roadmap-db.ts
@@ -79,13 +79,14 @@ export async function getRoadmapBundleForProject(clientProjectId: string): Promi
   const phases = (phasesRes.data || []) as JsonRecord[]
   const tasks = (tasksRes.data || []) as JsonRecord[]
   const costItems = (costsRes.data || []) as JsonRecord[]
+  const reports = (reportsRes.data || []) as JsonRecord[]
 
   return {
     roadmap: roadmap as JsonRecord,
     phases,
     tasks,
     costItems,
-    reports: (reportsRes.data || []) as JsonRecord[],
+    reports,
     clientView: buildClientRoadmapView({
       roadmap: {
         title: roadmap.title,
@@ -116,6 +117,17 @@ export async function getRoadmapBundleForProject(clientProjectId: string): Promi
         costType: item.cost_type as never,
         amount: item.amount == null ? null : Number(item.amount),
         category: item.category as never,
+      })),
+      reports: reports.map((report) => ({
+        title: report.title as string,
+        report_type: report.report_type as string,
+        status: report.status as string,
+        generated_at: report.generated_at as string | null,
+        summary: report.summary as string | null,
+        client_actions: Array.isArray(report.client_actions) ? (report.client_actions as string[]) : [],
+        amadutown_actions: Array.isArray(report.amadutown_actions) ? (report.amadutown_actions as string[]) : [],
+        approval_needed: Array.isArray(report.approval_needed) ? (report.approval_needed as string[]) : [],
+        monitoring_summary: report.monitoring_summary as Record<string, unknown> | null,
       })),
     }),
   }
@@ -346,7 +358,11 @@ export async function syncRoadmapTaskFromProjection(source: 'dashboard' | 'meeti
     .eq('id', roadmapTaskId)
     .maybeSingle()
 
-  if (roadmapTask?.phase_id) await refreshRoadmapPhaseStatus(roadmapTask.phase_id as string)
+  if (roadmapTask?.roadmap_id) {
+    await refreshRoadmapPhaseRollups(roadmapTask.roadmap_id as string)
+  } else if (roadmapTask?.phase_id) {
+    await refreshRoadmapPhaseStatus(roadmapTask.phase_id as string)
+  }
 }
 
 export async function refreshRoadmapPhaseRollups(roadmapId: string): Promise<void> {

--- a/lib/client-ai-ops-roadmap.test.ts
+++ b/lib/client-ai-ops-roadmap.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildDefaultClientAiOpsRoadmap,
+  buildClientRoadmapView,
   buildProposalRoadmapSnapshot,
   dashboardStatusFromRoadmap,
   meetingTaskStatusFromRoadmap,
@@ -47,5 +48,68 @@ describe('client AI ops roadmap', () => {
     expect(meetingTaskStatusFromRoadmap('cancelled')).toBe('cancelled')
     expect(roadmapStatusFromProjectedTask('complete')).toBe('complete')
     expect(roadmapStatusFromProjectedTask('pending')).toBe('pending')
+  })
+
+  it('adds a client-safe latest report summary to the roadmap view', () => {
+    const view = buildClientRoadmapView({
+      roadmap: {
+        title: 'Acme AI Ops Roadmap',
+        status: 'active',
+        client_summary: 'Implementation is underway.',
+      },
+      phases: [
+        {
+          id: 'phase-1',
+          title: 'Launch and reporting',
+          objective: 'Start reporting cadence.',
+          status: 'in_progress',
+          phase_order: 1,
+        },
+      ],
+      tasks: [
+        {
+          phase_id: 'phase-1',
+          title: 'Review report',
+          owner_type: 'client',
+          priority: 'high',
+          status: 'pending',
+          due_date: null,
+          client_visible: true,
+        },
+      ],
+      costItems: [],
+      reports: [
+        {
+          title: 'Monthly AI Ops report',
+          report_type: 'monthly',
+          status: 'needs_review',
+          generated_at: '2026-05-03T12:00:00.000Z',
+          summary: 'Roadmap is progressing with one overdue task.',
+          client_actions: ['Approve secure access plan'],
+          amadutown_actions: ['Internal escalation note that should not be exposed'],
+          approval_needed: ['Publish next client report'],
+          monitoring_summary: {
+            overdue_tasks: 1,
+            stale_cost_items: 2,
+            report_missing: false,
+            checked_at: '2026-05-03T12:00:00.000Z',
+          },
+        },
+      ],
+    })
+
+    expect(view.latestReport).toMatchObject({
+      title: 'Monthly AI Ops report',
+      status: 'needs_review',
+      clientActions: ['Approve secure access plan'],
+      amadutownActionsCount: 1,
+      approvalNeededCount: 1,
+      monitoringSummary: {
+        overdueTasks: 1,
+        staleCostItems: 2,
+        reportMissing: false,
+      },
+    })
+    expect(JSON.stringify(view.latestReport)).not.toContain('Internal escalation note')
   })
 })

--- a/lib/client-ai-ops-roadmap.ts
+++ b/lib/client-ai-ops-roadmap.ts
@@ -109,6 +109,23 @@ export interface RoadmapClientPhase {
   estimatedMonthlyOperatingCost: number
 }
 
+export interface RoadmapClientReportSummary {
+  title: string
+  reportType: string
+  status: string
+  generatedAt: string | null
+  summary: string | null
+  clientActions: string[]
+  amadutownActionsCount: number
+  approvalNeededCount: number
+  monitoringSummary: {
+    overdueTasks?: number
+    staleCostItems?: number
+    reportMissing?: boolean
+    checkedAt?: string | null
+  } | null
+}
+
 export interface RoadmapClientView {
   title: string
   status: RoadmapStatus
@@ -116,6 +133,7 @@ export interface RoadmapClientView {
   phases: RoadmapClientPhase[]
   costSummary: RoadmapCostRollup
   nextActions: Array<{ title: string; ownerType: RoadmapTaskOwner; priority: RoadmapPriority; dueDate: string | null }>
+  latestReport: RoadmapClientReportSummary | null
 }
 
 const DEFAULT_PHASES: RoadmapPhaseDraft[] = [
@@ -305,8 +323,20 @@ export function buildClientRoadmapView(input: {
   }>
   tasks: Array<{ phase_id: string; title: string; owner_type: RoadmapTaskOwner; priority: RoadmapPriority; status: RoadmapTaskStatus; due_date: string | null; client_visible: boolean }>
   costItems: Array<Pick<RoadmapCostItemDraft, 'payer' | 'costType' | 'amount' | 'category'>>
+  reports?: Array<{
+    title: string
+    report_type: string
+    status: string
+    generated_at: string | null
+    summary: string | null
+    client_actions?: string[] | null
+    amadutown_actions?: string[] | null
+    approval_needed?: string[] | null
+    monitoring_summary?: Record<string, unknown> | null
+  }>
 }): RoadmapClientView {
   const visibleTasks = input.tasks.filter((task) => task.client_visible)
+  const latestReport = input.reports?.[0]
   const phases = input.phases.map((phase) => {
     const phaseTasks = visibleTasks.filter((task) => task.phase_id === phase.id)
     return {
@@ -338,5 +368,25 @@ export function buildClientRoadmapView(input: {
         priority: task.priority,
         dueDate: task.due_date,
       })),
+    latestReport: latestReport
+      ? {
+          title: latestReport.title,
+          reportType: latestReport.report_type,
+          status: latestReport.status,
+          generatedAt: latestReport.generated_at,
+          summary: latestReport.summary,
+          clientActions: Array.isArray(latestReport.client_actions) ? latestReport.client_actions : [],
+          amadutownActionsCount: Array.isArray(latestReport.amadutown_actions) ? latestReport.amadutown_actions.length : 0,
+          approvalNeededCount: Array.isArray(latestReport.approval_needed) ? latestReport.approval_needed.length : 0,
+          monitoringSummary: latestReport.monitoring_summary
+            ? {
+                overdueTasks: typeof latestReport.monitoring_summary.overdue_tasks === 'number' ? latestReport.monitoring_summary.overdue_tasks : undefined,
+                staleCostItems: typeof latestReport.monitoring_summary.stale_cost_items === 'number' ? latestReport.monitoring_summary.stale_cost_items : undefined,
+                reportMissing: typeof latestReport.monitoring_summary.report_missing === 'boolean' ? latestReport.monitoring_summary.report_missing : undefined,
+                checkedAt: typeof latestReport.monitoring_summary.checked_at === 'string' ? latestReport.monitoring_summary.checked_at : null,
+              }
+            : null,
+        }
+      : null,
   }
 }


### PR DESCRIPTION
## Summary
- codifies the roadmap rule in the client AI Ops SOP
- exposes a client-safe latest report and monitoring summary in the roadmap dashboard view
- refreshes full roadmap rollups when projected dashboard or meeting-task statuses sync back

## Validation
- npm test -- lib/client-ai-ops-roadmap.test.ts app/api/cron/client-ai-ops-monitor/route.test.ts
- npx tsc --noEmit --pretty false
- npm run lint
- npm run build
- pre-push npm run db:health-check