### PR TITLE
fix: use site settings key for health probe

### DIFF
--- a/app/api/health/route.test.ts
+++ b/app/api/health/route.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  from: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+vi.mock('@/lib/n8n-runtime-flags', () => ({
+  describeN8nRuntimeFlags: () => ({
+    tier: 'production',
+    mockN8n: { effective: false },
+    disableOutbound: { effective: false },
+  }),
+}))
+
+import { GET } from './route'
+
+function siteSettingsQuery(error: unknown = null) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue({ data: { key: 'site_name' }, error }),
+  }
+}
+
+describe('health route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.from.mockReturnValue(siteSettingsQuery())
+  })
+
+  it('probes site_settings by key because production has no id column', async () => {
+    const query = siteSettingsQuery()
+    mocks.from.mockReturnValue(query)
+
+    const response = await GET()
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({ ok: true, db: 'connected' })
+    expect(mocks.from).toHaveBeenCalledWith('site_settings')
+    expect(query.select).toHaveBeenCalledWith('key')
+  })
+
+  it('returns 503 when the database probe fails', async () => {
+    mocks.from.mockReturnValue(siteSettingsQuery({ message: 'db unavailable' }))
+
+    const response = await GET()
+    const body = await response.json()
+
+    expect(response.status).toBe(503)
+    expect(body).toMatchObject({ ok: false, db: 'unreachable' })
+  })
+})

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -16,7 +16,7 @@ export async function GET() {
     if (supabaseAdmin) {
       const { error } = await supabaseAdmin
         .from('site_settings')
-        .select('id')
+        .select('key')
         .limit(1)
         .maybeSingle()
       dbOk = !error


### PR DESCRIPTION
## Summary
- fixes /api/health to probe site_settings.key instead of the non-existent production id column
- adds route coverage for the health probe success and failure paths

## Validation
- npm test -- app/api/health/route.test.ts
- npx tsc --noEmit --pretty false
- npm run build
- pre-push npm run db:health-check