### PR TITLE
chore: harden Vercel deployment watcher

### DIFF
--- a/docs/agents/vercel-verifier.md
+++ b/docs/agents/vercel-verifier.md
@@ -13,6 +13,10 @@ Both must pass before a ready PR is merged. Both must pass again after the merge
 
 ## Commands
 
+Runbook:
+
+- [Vercel Deployment Runbook](../vercel-deployment-runbook.md)
+
 Autopilot watcher:
 
 ```bash

--- a/docs/vercel-deployment-runbook.md
+++ b/docs/vercel-deployment-runbook.md
@@ -1,0 +1,48 @@
+# Vercel Deployment Runbook
+
+Use this runbook when the integration captain or autopilot is waiting on Vercel after a PR, merge, or redeploy.
+
+## Required Contexts
+
+Portfolio deployment is only complete when both contexts pass:
+
+- `Vercel – portfolio`
+- `Vercel – portfolio-staging`
+
+Run the watcher before merge for the PR head SHA and after merge for the merge SHA or `main`.
+
+```bash
+npm run deploy:watch:once -- --ref <pr-head-sha>
+npm run deploy:watch -- --ref <merge-sha> --timeout 900 --interval 30
+npm run deploy:watch -- --ref main --timeout 900 --interval 30
+```
+
+## Decision Thresholds
+
+- `success`: proceed.
+- `failed`: stop the merge/deploy flow and inspect Vercel logs.
+- `pending` under 8 minutes: keep polling.
+- `pending` for 8-15 minutes: inspect Vercel directly before assuming the build is healthy.
+- `pending` over 15 minutes: treat as blocked until inspected or rerun.
+
+Direct inspection commands:
+
+```bash
+vercel ls portfolio --scope vsillahs-projects
+vercel ls portfolio-staging --scope vsillahs-projects
+vercel inspect <deployment-url> --scope vsillahs-projects
+```
+
+## Premium Plan Guidance
+
+Upgrading Vercel is worth considering when deploy waiting becomes an operating bottleneck, especially because Portfolio builds both production and staging contexts for the same PR or merge.
+
+Upgrade is a good call if any of these become common:
+
+- staging or production regularly queues for more than 8 minutes,
+- PR review is blocked by build concurrency,
+- autopilot needs reliable overnight merge/deploy verification,
+- multiple agents are shipping branches in parallel,
+- deployment visibility becomes more valuable than the marginal subscription cost.
+
+Do not treat an upgrade as a substitute for the watcher. The watcher remains the source of truth for whether autopilot can proceed.

--- a/lib/vercel-deployment-watch.test.ts
+++ b/lib/vercel-deployment-watch.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   formatDeploymentWatchSummary,
+  getDeploymentWatchGuidance,
   parseDeploymentWatchArgs,
   summarizeDeploymentStatus,
 } from './vercel-deployment-watch'
@@ -113,5 +114,58 @@ describe('formatDeploymentWatchSummary', () => {
     expect(formatDeploymentWatchSummary(summary)).toContain('deployment_state=pending')
     expect(formatDeploymentWatchSummary(summary)).toContain('context="Vercel – portfolio"')
     expect(formatDeploymentWatchSummary(summary)).toContain('url=https://vercel.com/example')
+  })
+})
+
+describe('getDeploymentWatchGuidance', () => {
+  it('marks successful deployments as ready', () => {
+    const summary = summarizeDeploymentStatus({
+      state: 'success',
+      statuses: [
+        { context: 'Vercel – portfolio', state: 'success' },
+        { context: 'Vercel – portfolio-staging', state: 'success' },
+      ],
+    })
+
+    expect(getDeploymentWatchGuidance(summary)).toEqual([
+      'guidance=ready; both required Vercel contexts passed',
+    ])
+  })
+
+  it('asks autopilot to inspect a pending context after eight minutes', () => {
+    const summary = summarizeDeploymentStatus({
+      state: 'pending',
+      statuses: [
+        { context: 'Vercel – portfolio', state: 'success' },
+        {
+          context: 'Vercel – portfolio-staging',
+          state: 'pending',
+          target_url: 'https://vercel.com/example',
+          updated_at: '2026-05-02T10:00:00Z',
+        },
+      ],
+    })
+
+    expect(getDeploymentWatchGuidance(summary, Date.parse('2026-05-02T10:09:30Z'))).toEqual([
+      'guidance=inspect; context="Vercel – portfolio-staging" pending 9m; inspect Vercel before assuming the build is healthy inspect=https://vercel.com/example',
+    ])
+  })
+
+  it('blocks autopilot after fifteen minutes of pending deployment status', () => {
+    const summary = summarizeDeploymentStatus({
+      state: 'pending',
+      statuses: [
+        { context: 'Vercel – portfolio', state: 'success' },
+        {
+          context: 'Vercel – portfolio-staging',
+          state: 'pending',
+          updated_at: '2026-05-02T10:00:00Z',
+        },
+      ],
+    })
+
+    expect(getDeploymentWatchGuidance(summary, Date.parse('2026-05-02T10:15:00Z'))).toEqual([
+      'guidance=blocked; context="Vercel – portfolio-staging" pending 15m; inspect or rerun deployment before proceeding',
+    ])
   })
 })

--- a/lib/vercel-deployment-watch.ts
+++ b/lib/vercel-deployment-watch.ts
@@ -196,3 +196,42 @@ export function formatDeploymentWatchSummary(summary: DeploymentWatchSummary): s
 
   return lines.join('\n')
 }
+
+export function getDeploymentWatchGuidance(
+  summary: DeploymentWatchSummary,
+  nowMs = Date.now()
+): string[] {
+  if (summary.state === 'success') {
+    return ['guidance=ready; both required Vercel contexts passed']
+  }
+
+  if (summary.failedContexts.length > 0) {
+    return summary.failedContexts.map((status) => {
+      const urlHint = status.targetUrl ? ` inspect=${status.targetUrl}` : ''
+      return `guidance=failed; context="${status.context}" failed; stop merge/deploy flow and inspect logs${urlHint}`
+    })
+  }
+
+  return summary.pendingContexts.map((status) => {
+    if (status.state === 'missing') {
+      return `guidance=pending; context="${status.context}" missing; keep polling until GitHub receives the Vercel status`
+    }
+
+    const updatedMs = status.updatedAt ? Date.parse(status.updatedAt) : Number.NaN
+    const ageMinutes = Number.isFinite(updatedMs)
+      ? Math.max(0, Math.floor((nowMs - updatedMs) / 60000))
+      : null
+    const ageText = ageMinutes === null ? 'unknown age' : `${ageMinutes}m`
+    const urlHint = status.targetUrl ? ` inspect=${status.targetUrl}` : ''
+
+    if (ageMinutes !== null && ageMinutes >= 15) {
+      return `guidance=blocked; context="${status.context}" pending ${ageText}; inspect or rerun deployment before proceeding${urlHint}`
+    }
+
+    if (ageMinutes !== null && ageMinutes >= 8) {
+      return `guidance=inspect; context="${status.context}" pending ${ageText}; inspect Vercel before assuming the build is healthy${urlHint}`
+    }
+
+    return `guidance=pending; context="${status.context}" pending ${ageText}; continue polling${urlHint}`
+  })
+}

--- a/scripts/vercel-deployment-watch.ts
+++ b/scripts/vercel-deployment-watch.ts
@@ -2,6 +2,7 @@
 import { spawnSync } from 'node:child_process'
 import {
   formatDeploymentWatchSummary,
+  getDeploymentWatchGuidance,
   parseDeploymentWatchArgs,
   summarizeDeploymentStatus,
   type GitHubCombinedStatus,
@@ -78,6 +79,7 @@ async function main(): Promise<void> {
 
       console.log(`\n[attempt ${attempt}] ${new Date().toISOString()}`)
       console.log(formatDeploymentWatchSummary(summary))
+      console.log(getDeploymentWatchGuidance(summary).join('\n'))
 
       if (summary.state === 'success') {
         process.exit(0)


### PR DESCRIPTION
## Summary
- add explicit deployment watcher guidance for ready, pending, inspect, blocked, and failed states
- add a Vercel deployment runbook with autopilot thresholds and premium-plan decision criteria
- link the runbook from the Vercel verifier agent doc

## Validation
- npm test -- lib/vercel-deployment-watch.test.ts
- npx tsc --noEmit --pretty false
- npm run deploy:watch:once -- --ref main
- push hook: npm run db:health-check