### PR TITLE
feat: show latest agent engagement status

### DIFF
--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import type { ReactNode } from 'react'
 import {
   Activity,
@@ -27,6 +27,15 @@ import { APPROVAL_GATES, RUNTIME_POLICIES } from '@/lib/agent-policy'
 
 const AGENT_ORGANIZATION_SUMMARY = getAgentOrganizationSummary()
 
+type AgentEngagementRecord = {
+  runId: string
+  status: string
+  currentStep: string | null
+  startedAt: string | null
+  completedAt: string | null
+  executionMode: string | null
+}
+
 export default function AgentOperationsPage() {
   const [hermesLoading, setHermesLoading] = useState(false)
   const [hermesResult, setHermesResult] = useState<{ runId: string; overall: string } | null>(null)
@@ -41,8 +50,52 @@ export default function AgentOperationsPage() {
   const [morningResult, setMorningResult] = useState<{ runId: string; overall: string; slackNotified: boolean } | null>(null)
   const [morningError, setMorningError] = useState<string | null>(null)
   const [engagingAgentKey, setEngagingAgentKey] = useState<string | null>(null)
-  const [engagementResults, setEngagementResults] = useState<Record<string, { runId: string; status: string }>>({})
+  const [engagementResults, setEngagementResults] = useState<Record<string, AgentEngagementRecord>>({})
   const [engagementError, setEngagementError] = useState<string | null>(null)
+  const [engagementStatusLoading, setEngagementStatusLoading] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function loadEngagementStatuses() {
+      setEngagementStatusLoading(true)
+      try {
+        const session = await getCurrentSession()
+        if (!session?.access_token) return
+        const res = await fetch('/api/admin/agents/engagements', {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+        })
+        const body = await res.json().catch(() => ({}))
+        if (!res.ok) throw new Error(body.error || `HTTP ${res.status}`)
+        if (cancelled || !Array.isArray(body.engagements)) return
+
+        const byAgent: Record<string, AgentEngagementRecord> = {}
+        for (const item of body.engagements) {
+          if (!item?.agent_key || !item.run_id) continue
+          byAgent[item.agent_key] = {
+            runId: item.run_id,
+            status: item.status || 'queued',
+            currentStep: item.current_step || null,
+            startedAt: item.started_at || null,
+            completedAt: item.completed_at || null,
+            executionMode: item.execution_mode || null,
+          }
+        }
+        setEngagementResults((current) => ({ ...byAgent, ...current }))
+      } catch (err) {
+        if (!cancelled) {
+          setEngagementError(err instanceof Error ? err.message : 'Failed to load agent engagement status')
+        }
+      } finally {
+        if (!cancelled) setEngagementStatusLoading(false)
+      }
+    }
+
+    loadEngagementStatuses()
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   async function runHermesHealthSummary() {
     setHermesLoading(true)
@@ -164,7 +217,14 @@ export default function AgentOperationsPage() {
       if (!res.ok) throw new Error(body.error || `HTTP ${res.status}`)
       setEngagementResults((current) => ({
         ...current,
-        [agentKey]: { runId: body.run_id, status: body.status || 'queued' },
+        [agentKey]: {
+          runId: body.run_id,
+          status: body.status || 'queued',
+          currentStep: body.status === 'completed' ? 'Read-only dispatch ready' : 'Engagement request queued',
+          startedAt: new Date().toISOString(),
+          completedAt: body.status === 'completed' ? new Date().toISOString() : null,
+          executionMode: body.execution_mode || null,
+        },
       }))
     } catch (err) {
       setEngagementError(err instanceof Error ? err.message : 'Failed to queue agent engagement')
@@ -422,6 +482,9 @@ export default function AgentOperationsPage() {
               Maps the target agent organization to the n8n workflow families currently wired into the operating system.
             </p>
             {engagementError ? <p className="mt-3 text-sm text-red-300">{engagementError}</p> : null}
+            {engagementStatusLoading ? (
+              <p className="mt-3 text-xs text-muted-foreground">Loading latest engagement traces...</p>
+            ) : null}
 
             <div className="mt-5 grid grid-cols-1 lg:grid-cols-2 gap-4">
               {AGENT_ORGANIZATION_SUMMARY.map((pod) => (
@@ -441,49 +504,69 @@ export default function AgentOperationsPage() {
                     <OrgCount label="Planned" value={pod.plannedAgentCount} tone="slate" />
                   </div>
                   <div className="mt-4 space-y-3">
-                    {pod.agents.map((agent) => (
-                      <div key={agent.key} className="rounded-md border border-silicon-slate/50 bg-black/10 p-3">
-                        <div className="flex flex-wrap items-center gap-2">
-                          <p className="font-medium">{agent.name}</p>
-                          <StatusPill status={agent.status} />
-                          <span className="rounded-full border border-silicon-slate/50 px-2 py-0.5 text-xs text-muted-foreground">
-                            {agent.primaryRuntime}
-                          </span>
-                        </div>
-                        <p className="mt-2 text-sm text-muted-foreground">{agent.responsibility}</p>
-                        {agent.n8nWorkflows.length > 0 ? (
-                          <p className="mt-2 text-xs text-muted-foreground">
-                            n8n: {agent.n8nWorkflows.slice(0, 3).map((workflow) => workflow.name).join(', ')}
-                            {agent.n8nWorkflows.length > 3 ? ` +${agent.n8nWorkflows.length - 3} more` : ''}
-                          </p>
-                        ) : (
-                          <p className="mt-2 text-xs text-muted-foreground">n8n: not primary runtime yet</p>
-                        )}
-                        <div className="mt-3 flex flex-wrap gap-2">
-                          {engagementResults[agent.key] ? (
-                            <Link
-                              href={`/admin/agents/runs/${engagementResults[agent.key].runId}`}
-                              className="inline-flex items-center gap-1 rounded-md border border-emerald-400/40 bg-emerald-500/10 px-2 py-1 text-xs text-emerald-200 hover:underline"
-                            >
-                              {engagementResults[agent.key].status === 'completed'
-                                ? 'Read-only run ready'
-                                : 'Engagement queued'}
-                              <ArrowRight size={12} />
-                            </Link>
+                    {pod.agents.map((agent) => {
+                      const engagement = engagementResults[agent.key]
+
+                      return (
+                        <div key={agent.key} className="rounded-md border border-silicon-slate/50 bg-black/10 p-3">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <p className="font-medium">{agent.name}</p>
+                            <StatusPill status={agent.status} />
+                            <span className="rounded-full border border-silicon-slate/50 px-2 py-0.5 text-xs text-muted-foreground">
+                              {agent.primaryRuntime}
+                            </span>
+                          </div>
+                          <p className="mt-2 text-sm text-muted-foreground">{agent.responsibility}</p>
+                          {agent.n8nWorkflows.length > 0 ? (
+                            <p className="mt-2 text-xs text-muted-foreground">
+                              n8n: {agent.n8nWorkflows.slice(0, 3).map((workflow) => workflow.name).join(', ')}
+                              {agent.n8nWorkflows.length > 3 ? ` +${agent.n8nWorkflows.length - 3} more` : ''}
+                            </p>
                           ) : (
-                            <button
-                              type="button"
-                              onClick={() => queueAgentEngagement(agent.key, agent.name)}
-                              disabled={engagingAgentKey === agent.key}
-                              className="inline-flex items-center gap-1 rounded-md border border-radiant-gold/50 bg-radiant-gold/10 px-2 py-1 text-xs text-radiant-gold hover:bg-radiant-gold/15 disabled:opacity-60"
-                            >
-                              <Send size={12} />
-                              Run read-only
-                            </button>
+                            <p className="mt-2 text-xs text-muted-foreground">n8n: not primary runtime yet</p>
                           )}
+                          {engagement ? (
+                            <div className="mt-3 rounded-md border border-silicon-slate/50 bg-background/40 px-3 py-2 text-xs text-muted-foreground">
+                              <p>
+                                Latest engagement:{' '}
+                                <span className="text-foreground">
+                                  {engagement.status.replace(/_/g, ' ')}
+                                </span>
+                                {engagement.executionMode
+                                  ? ` · ${engagement.executionMode.replace(/_/g, ' ')}`
+                                  : ''}
+                              </p>
+                              {engagement.currentStep ? (
+                                <p className="mt-1">{engagement.currentStep}</p>
+                              ) : null}
+                            </div>
+                          ) : null}
+                          <div className="mt-3 flex flex-wrap gap-2">
+                            {engagement ? (
+                              <Link
+                                href={`/admin/agents/runs/${engagement.runId}`}
+                                className="inline-flex items-center gap-1 rounded-md border border-emerald-400/40 bg-emerald-500/10 px-2 py-1 text-xs text-emerald-200 hover:underline"
+                              >
+                                {engagement.status === 'completed'
+                                  ? 'Read-only run ready'
+                                  : 'Engagement queued'}
+                                <ArrowRight size={12} />
+                              </Link>
+                            ) : (
+                              <button
+                                type="button"
+                                onClick={() => queueAgentEngagement(agent.key, agent.name)}
+                                disabled={engagingAgentKey === agent.key}
+                                className="inline-flex items-center gap-1 rounded-md border border-radiant-gold/50 bg-radiant-gold/10 px-2 py-1 text-xs text-radiant-gold hover:bg-radiant-gold/15 disabled:opacity-60"
+                              >
+                                <Send size={12} />
+                                Run read-only
+                              </button>
+                            )}
+                          </div>
                         </div>
-                      </div>
-                    ))}
+                      )
+                    })}
                   </div>
                 </div>
               ))}

--- a/app/api/admin/agents/engagements/route.test.ts
+++ b/app/api/admin/agents/engagements/route.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  from: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import { GET } from './route'
+
+function request() {
+  return new Request('http://localhost/api/admin/agents/engagements', {
+    headers: { authorization: 'Bearer token' },
+  })
+}
+
+function engagementQuery(data: unknown[], error: unknown = null) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue({ data, error }),
+  }
+}
+
+describe('GET /api/admin/agents/engagements', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.from.mockReturnValue(engagementQuery([]))
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await GET(request() as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.from).not.toHaveBeenCalled()
+  })
+
+  it('returns latest traced engagement status for every mapped agent', async () => {
+    mocks.from.mockReturnValue(engagementQuery([
+      {
+        id: 'new-run',
+        agent_key: 'chief-of-staff',
+        status: 'completed',
+        current_step: 'Read-only dispatch ready',
+        started_at: '2026-05-04T12:05:00.000Z',
+        completed_at: '2026-05-04T12:06:00.000Z',
+        metadata: { requested_agent: 'chief-of-staff', execution_mode: 'read_only' },
+      },
+      {
+        id: 'old-run',
+        agent_key: 'chief-of-staff',
+        status: 'queued',
+        current_step: 'Engagement request queued',
+        started_at: '2026-05-04T12:00:00.000Z',
+        completed_at: null,
+        metadata: { requested_agent: 'chief-of-staff' },
+      },
+      {
+        id: 'metadata-run',
+        agent_key: 'manual',
+        status: 'queued',
+        current_step: 'Engagement request queued',
+        started_at: '2026-05-04T11:00:00.000Z',
+        completed_at: null,
+        metadata: { requested_agent: 'strategic-narrative', executes_action: false },
+      },
+    ]))
+
+    const response = await GET(request() as never)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(mocks.from).toHaveBeenCalledWith('agent_runs')
+    expect(body.engagements.length).toBeGreaterThan(10)
+    expect(body.engagements.find((item: { agent_key: string }) => item.agent_key === 'chief-of-staff')).toMatchObject({
+      run_id: 'new-run',
+      status: 'completed',
+      execution_mode: 'read_only',
+    })
+    expect(body.engagements.find((item: { agent_key: string }) => item.agent_key === 'strategic-narrative')).toMatchObject({
+      run_id: 'metadata-run',
+      status: 'queued',
+      execution_mode: 'read_only',
+    })
+  })
+
+  it('returns a server error when engagement lookup fails', async () => {
+    mocks.from.mockReturnValue(engagementQuery([], { message: 'database failed' }))
+
+    const response = await GET(request() as never)
+
+    expect(response.status).toBe(500)
+    expect(await response.json()).toEqual({ error: 'Failed to fetch agent engagements' })
+  })
+})

--- a/app/api/admin/agents/engagements/route.ts
+++ b/app/api/admin/agents/engagements/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { AGENT_ORGANIZATION } from '@/lib/agent-organization'
+import { supabaseAdmin } from '@/lib/supabase'
+
+export const dynamic = 'force-dynamic'
+
+type EngagementRunRow = {
+  id: string
+  agent_key: string | null
+  status: string
+  current_step: string | null
+  started_at: string
+  completed_at: string | null
+  metadata: Record<string, unknown> | null
+}
+
+export type AgentEngagementStatus = {
+  agent_key: string
+  run_id: string | null
+  status: string | null
+  current_step: string | null
+  started_at: string | null
+  completed_at: string | null
+  execution_mode: string | null
+}
+
+function executionMode(row: EngagementRunRow | undefined) {
+  const explicitMode = row?.metadata?.execution_mode
+  if (typeof explicitMode === 'string') return explicitMode
+
+  const executesAction = row?.metadata?.executes_action
+  if (typeof executesAction === 'boolean') {
+    return executesAction ? 'action' : 'read_only'
+  }
+
+  return null
+}
+
+function requestedAgentKey(row: EngagementRunRow) {
+  const requested = row.metadata?.requested_agent
+  return typeof requested === 'string' && requested.trim() ? requested.trim() : row.agent_key
+}
+
+/**
+ * GET /api/admin/agents/engagements
+ *
+ * Returns the latest traced engagement request for each mapped agent. This is
+ * read-only status for the admin roster; it does not execute agents.
+ */
+export async function GET(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+  if (!supabaseAdmin) {
+    return NextResponse.json({ error: 'Database not available' }, { status: 500 })
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from('agent_runs')
+    .select('id, agent_key, status, current_step, started_at, completed_at, metadata')
+    .eq('kind', 'agent_engagement_request')
+    .order('started_at', { ascending: false })
+    .limit(200)
+
+  if (error) {
+    console.error('[agent-engagements] list failed:', error)
+    return NextResponse.json({ error: 'Failed to fetch agent engagements' }, { status: 500 })
+  }
+
+  const latestByAgent = new Map<string, EngagementRunRow>()
+  for (const row of (data ?? []) as EngagementRunRow[]) {
+    const agentKey = requestedAgentKey(row)
+    if (!agentKey || latestByAgent.has(agentKey)) continue
+    latestByAgent.set(agentKey, row)
+  }
+
+  const engagements: AgentEngagementStatus[] = AGENT_ORGANIZATION.map((agent) => {
+    const latest = latestByAgent.get(agent.key)
+    return {
+      agent_key: agent.key,
+      run_id: latest?.id ?? null,
+      status: latest?.status ?? null,
+      current_step: latest?.current_step ?? null,
+      started_at: latest?.started_at ?? null,
+      completed_at: latest?.completed_at ?? null,
+      execution_mode: executionMode(latest),
+    }
+  })
+
+  return NextResponse.json({ engagements })
+}


### PR DESCRIPTION
## Summary
- add a read-only admin API for latest agent engagement traces by agent
- load persisted engagement status on the Agent Operations roster
- show latest status, execution mode, current step, and run detail link per agent

## Validation
- npm run build:knowledge
- npx tsc --noEmit --pretty false
- npm run lint
- npm test -- app/api/admin/agents/engagements/route.test.ts app/api/admin/agents/engage/route.test.ts app/api/admin/agents/chief-of-staff/chat/route.test.ts lib/agent-organization.test.ts
- npm run build

Note: build passes after linking the isolated worktree to the existing local .env.local; it emits the existing dev env warning about outbound n8n webhooks being enabled.