### PR TITLE
Add source protocol creator portal

### DIFF
--- a/app/admin/source-protocol/page.test.tsx
+++ b/app/admin/source-protocol/page.test.tsx
@@ -17,6 +17,7 @@ const overview = {
   generatedAt: '2026-05-03T12:00:00.000Z',
   summary: {
     creators: 1,
+    portalAccounts: 1,
     works: 1,
     activeGrants: 1,
     retrievableChunks: 1,
@@ -27,6 +28,7 @@ const overview = {
     accruedPayoutUsd: 0.006,
   },
   creators: [],
+  portalAccounts: [],
   works: [],
   licenseGrants: [],
   chunks: [],

--- a/app/admin/source-protocol/page.tsx
+++ b/app/admin/source-protocol/page.tsx
@@ -21,6 +21,7 @@ type SourceProtocolOverview = {
   migration?: string
   summary?: {
     creators: number
+    portalAccounts: number
     works: number
     activeGrants: number
     retrievableChunks: number
@@ -31,6 +32,7 @@ type SourceProtocolOverview = {
     accruedPayoutUsd: number
   }
   creators?: any[]
+  portalAccounts?: any[]
   works?: any[]
   licenseGrants?: any[]
   chunks?: any[]
@@ -160,6 +162,7 @@ function SourceProtocolContent() {
 
             <section className="mb-6 grid grid-cols-2 gap-3 lg:grid-cols-4">
               <Stat icon={<Users size={18} />} label="Creators" value={summary.creators} />
+              <Stat icon={<Users size={18} />} label="Portal accounts" value={summary.portalAccounts} />
               <Stat icon={<BookOpenCheck size={18} />} label="Works" value={summary.works} />
               <Stat icon={<Database size={18} />} label="Retrievable chunks" value={summary.retrievableChunks} />
               <Stat icon={<FileText size={18} />} label="Answer receipts" value={summary.answerReceipts} />

--- a/app/api/admin/source-protocol/overview/route.ts
+++ b/app/api/admin/source-protocol/overview/route.ts
@@ -11,6 +11,7 @@ type CountFilter = {
 
 const SOURCE_PROTOCOL_TABLES = [
   'source_creators',
+  'source_creator_portal_accounts',
   'licensed_works',
   'license_grants',
   'source_chunks',
@@ -62,6 +63,7 @@ export async function GET(request: NextRequest) {
   try {
     const [
       creators,
+      portalAccounts,
       works,
       activeGrants,
       retrievableChunks,
@@ -70,6 +72,7 @@ export async function GET(request: NextRequest) {
       openDisputes,
       heldPayouts,
       creatorRows,
+      portalAccountRows,
       workRows,
       grantRows,
       chunkRows,
@@ -80,6 +83,7 @@ export async function GET(request: NextRequest) {
       modelReviewRows,
     ] = await Promise.all([
       countRows('source_creators'),
+      countRows('source_creator_portal_accounts'),
       countRows('licensed_works'),
       countRows('license_grants', { column: 'status', value: 'active' }),
       countRows('source_chunks', { column: 'is_retrievable', value: true }),
@@ -90,6 +94,11 @@ export async function GET(request: NextRequest) {
       selectRows(
         'source_creators',
         'id, display_name, categories, rights_holder_types, verification_status, protected_identity, created_at',
+        'created_at'
+      ),
+      selectRows(
+        'source_creator_portal_accounts',
+        'id, creator_id, user_id, status, can_view_earnings, can_view_receipts, accepted_at, created_at',
         'created_at'
       ),
       selectRows(
@@ -144,6 +153,7 @@ export async function GET(request: NextRequest) {
       generatedAt: new Date().toISOString(),
       summary: {
         creators,
+        portalAccounts,
         works,
         activeGrants,
         retrievableChunks,
@@ -154,6 +164,7 @@ export async function GET(request: NextRequest) {
         accruedPayoutUsd: Number(accruedPayoutUsd.toFixed(6)),
       },
       creators: creatorRows,
+      portalAccounts: portalAccountRows,
       works: workRows,
       licenseGrants: grantRows,
       chunks: chunkRows,

--- a/app/api/source-protocol/creator/statement/route.test.ts
+++ b/app/api/source-protocol/creator/statement/route.test.ts
@@ -1,0 +1,97 @@
+import { NextRequest } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  from: vi.fn(),
+  authResult: {
+    user: { id: 'user-1' },
+    isAdmin: false,
+  } as any,
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAuth: vi.fn(async () => mocks.authResult),
+  isAuthError: (result: any) => 'error' in result,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import { GET } from './route'
+
+function request() {
+  return new NextRequest('https://example.com/api/source-protocol/creator/statement', {
+    headers: { authorization: 'Bearer test-token' },
+  })
+}
+
+function portalQuery(result: { data: unknown; error: unknown }) {
+  const maybeSingle = vi.fn().mockResolvedValue(result)
+  const limit = vi.fn().mockReturnValue({ maybeSingle })
+  const order = vi.fn().mockReturnValue({ limit })
+  const secondEq = vi.fn().mockReturnValue({ order })
+  const firstEq = vi.fn().mockReturnValue({ eq: secondEq })
+  const select = vi.fn().mockReturnValue({ eq: firstEq })
+  return { select, firstEq, secondEq, order, limit, maybeSingle }
+}
+
+describe('creator source protocol statement route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.authResult = {
+      user: { id: 'user-1' },
+      isAdmin: false,
+    }
+  })
+
+  it('rejects unauthenticated requests', async () => {
+    mocks.authResult = { error: 'Authentication required', status: 401 }
+
+    const response = await GET(request())
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Authentication required' })
+    expect(mocks.from).not.toHaveBeenCalled()
+  })
+
+  it('returns an unlinked state when the user has no active creator portal account', async () => {
+    const query = portalQuery({ data: null, error: null })
+    mocks.from.mockReturnValue(query)
+
+    const response = await GET(request())
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({
+      available: true,
+      linked: false,
+      reason: 'No active creator portal account is linked to this login yet.',
+    })
+    expect(mocks.from).toHaveBeenCalledWith('source_creator_portal_accounts')
+    expect(query.firstEq).toHaveBeenCalledWith('user_id', 'user-1')
+    expect(query.secondEq).toHaveBeenCalledWith('status', 'active')
+  })
+
+  it('returns the missing schema state when portal tables have not been applied', async () => {
+    mocks.from.mockReturnValue(portalQuery({
+      data: null,
+      error: {
+        code: '42P01',
+        message: 'relation "source_creator_portal_accounts" does not exist',
+      },
+    }))
+
+    const response = await GET(request())
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({
+      available: false,
+      linked: false,
+      migration: 'supabase/migrations/20260504092130_source_protocol_creator_portal.sql',
+    })
+  })
+})

--- a/app/api/source-protocol/creator/statement/route.ts
+++ b/app/api/source-protocol/creator/statement/route.ts
@@ -1,0 +1,181 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAuth, isAuthError } from '@/lib/auth-server'
+import { supabaseAdmin } from '@/lib/supabase'
+
+export const dynamic = 'force-dynamic'
+
+const SOURCE_PROTOCOL_TABLES = [
+  'source_creator_portal_accounts',
+  'source_creators',
+  'licensed_works',
+  'license_grants',
+  'source_chunks',
+  'answer_receipt_chunks',
+  'monthly_creator_payouts',
+  'creator_rights_disputes',
+] as const
+
+function isMissingSourceProtocolSchema(error: { code?: string; message?: string } | null | undefined): boolean {
+  if (!error) return false
+  const message = error.message?.toLowerCase() ?? ''
+  return (
+    error.code === '42P01' ||
+    SOURCE_PROTOCOL_TABLES.some((table) => message.includes(table)) ||
+    (message.includes('relation') && message.includes('does not exist'))
+  )
+}
+
+async function selectRows(table: string, columns: string, column: string, value: string, orderColumn = 'created_at') {
+  const { data, error } = await supabaseAdmin
+    .from(table)
+    .select(columns)
+    .eq(column, value)
+    .order(orderColumn, { ascending: false })
+  if (error) throw error
+  return data ?? []
+}
+
+export async function GET(request: NextRequest) {
+  const auth = await verifyAuth(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  if (!supabaseAdmin) {
+    return NextResponse.json({ error: 'Supabase admin client unavailable' }, { status: 500 })
+  }
+
+  try {
+    const { data: portal, error: portalError } = await supabaseAdmin
+      .from('source_creator_portal_accounts')
+      .select('id, creator_id, status, can_view_earnings, can_view_receipts, accepted_at, created_at')
+      .eq('user_id', auth.user.id)
+      .eq('status', 'active')
+      .order('created_at', { ascending: true })
+      .limit(1)
+      .maybeSingle()
+
+    if (portalError) throw portalError
+
+    if (!portal) {
+      return NextResponse.json({
+        available: true,
+        linked: false,
+        generatedAt: new Date().toISOString(),
+        reason: 'No active creator portal account is linked to this login yet.',
+      })
+    }
+
+    const creatorId = portal.creator_id
+
+    const [
+      creator,
+      works,
+      chunks,
+      payouts,
+      attributedChunks,
+      disputes,
+    ] = await Promise.all([
+      supabaseAdmin
+        .from('source_creators')
+        .select('id, display_name, categories, rights_holder_types, verification_status, protected_identity, public_bio, created_at')
+        .eq('id', creatorId)
+        .maybeSingle(),
+      selectRows(
+        'licensed_works',
+        'id, title, rights_holder_type, ban_status, chain_of_title_verified, community_consent_required, community_consent_verified, review_status, sensitivity_flags, created_at',
+        'creator_id',
+        creatorId
+      ),
+      selectRows(
+        'source_chunks',
+        'id, work_id, citation_label, source_location, sensitive_topics, is_retrievable, created_at',
+        'creator_id',
+        creatorId
+      ),
+      portal.can_view_earnings ? selectRows(
+        'monthly_creator_payouts',
+        'id, settlement_period, answer_receipt_ids, attributed_chunk_count, attributed_token_count, accrued_payout_usd, settlement_status, hold_reason, approved_at, paid_at, created_at',
+        'creator_id',
+        creatorId
+      ) : Promise.resolve([]),
+      portal.can_view_receipts ? selectRows(
+        'answer_receipt_chunks',
+        'answer_receipt_id, source_chunk_external_id, work_external_id, citation_label, supported_output_tokens, attribution_weight, accrued_payout_usd, created_at',
+        'creator_id',
+        creatorId
+      ) : Promise.resolve([]),
+      selectRows(
+        'creator_rights_disputes',
+        'id, dispute_type, status, summary, resolution_notes, resolved_at, created_at',
+        'creator_id',
+        creatorId
+      ),
+    ])
+
+    if (creator.error) throw creator.error
+    if (!creator.data) {
+      return NextResponse.json({ error: 'Linked creator profile was not found' }, { status: 404 })
+    }
+
+    const workIds = works.map((work: any) => work.id)
+    const { data: grants, error: grantsError } = workIds.length > 0
+      ? await supabaseAdmin
+        .from('license_grants')
+        .select('id, work_id, status, allowed_uses, blocked_topics, quote_limit_characters, expires_at, reviewed_at, created_at')
+        .in('work_id', workIds)
+        .order('created_at', { ascending: false })
+      : { data: [], error: null }
+
+    if (grantsError) throw grantsError
+
+    const accruedPayoutUsd = payouts.reduce((sum: number, payout: any) => (
+      sum + Number(payout.accrued_payout_usd ?? 0)
+    ), 0)
+    const attributedTokenCount = payouts.reduce((sum: number, payout: any) => (
+      sum + Number(payout.attributed_token_count ?? 0)
+    ), 0)
+    const heldPayouts = payouts.filter((payout: any) => payout.settlement_status === 'held_for_review').length
+    const openDisputes = disputes.filter((dispute: any) => ['open', 'investigating'].includes(dispute.status)).length
+
+    return NextResponse.json({
+      available: true,
+      linked: true,
+      generatedAt: new Date().toISOString(),
+      portal,
+      creator: creator.data,
+      summary: {
+        works: works.length,
+        activeGrants: (grants ?? []).filter((grant: any) => grant.status === 'active').length,
+        retrievableChunks: chunks.filter((chunk: any) => chunk.is_retrievable).length,
+        attributedReceipts: new Set(attributedChunks.map((chunk: any) => chunk.answer_receipt_id)).size,
+        monthlyPayouts: payouts.length,
+        accruedPayoutUsd: Number(accruedPayoutUsd.toFixed(6)),
+        attributedTokenCount,
+        heldPayouts,
+        openDisputes,
+      },
+      works,
+      licenseGrants: grants ?? [],
+      chunks,
+      payouts: portal.can_view_earnings ? payouts : [],
+      attributedChunks: portal.can_view_receipts ? attributedChunks : [],
+      disputes,
+    })
+  } catch (error: any) {
+    if (isMissingSourceProtocolSchema(error)) {
+      return NextResponse.json({
+        available: false,
+        linked: false,
+        generatedAt: new Date().toISOString(),
+        reason: 'Source protocol creator portal schema has not been applied in this environment.',
+        migration: 'supabase/migrations/20260504092130_source_protocol_creator_portal.sql',
+      })
+    }
+
+    return NextResponse.json(
+      { error: error?.message ?? 'Failed to load creator source protocol statement' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/creator/source-protocol/page.test.tsx
+++ b/app/creator/source-protocol/page.test.tsx
@@ -1,0 +1,159 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import CreatorSourceProtocolPage from './page'
+
+vi.mock('@/components/ProtectedRoute', () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('@/components/SiteThemeCorner', () => ({
+  default: () => null,
+}))
+
+vi.mock('@/lib/auth', () => ({
+  getCurrentSession: vi.fn(async () => ({ access_token: 'creator-token' })),
+}))
+
+const linkedStatement = {
+  available: true,
+  linked: true,
+  generatedAt: '2026-05-04T09:00:00.000Z',
+  portal: {
+    status: 'active',
+    can_view_earnings: true,
+    can_view_receipts: true,
+    accepted_at: '2026-05-04T09:00:00.000Z',
+  },
+  creator: {
+    display_name: 'Demo Creator',
+    categories: ['banned_author'],
+    rights_holder_types: ['author'],
+    verification_status: 'verified',
+    protected_identity: false,
+    public_bio: null,
+  },
+  summary: {
+    works: 1,
+    activeGrants: 1,
+    retrievableChunks: 1,
+    attributedReceipts: 1,
+    monthlyPayouts: 1,
+    accruedPayoutUsd: 0.006,
+    attributedTokenCount: 12,
+    heldPayouts: 0,
+    openDisputes: 0,
+  },
+  works: [
+    {
+      id: 'work-1',
+      title: 'Demo Work',
+      review_status: 'approved',
+      ban_status: 'challenged',
+      chain_of_title_verified: true,
+      community_consent_required: false,
+      community_consent_verified: false,
+    },
+  ],
+  licenseGrants: [
+    {
+      id: 'grant-1',
+      work_id: 'work-1',
+      status: 'active',
+      allowed_uses: ['retrieval', 'citation'],
+    },
+  ],
+  chunks: [
+    {
+      id: 'chunk-1',
+      work_id: 'work-1',
+      citation_label: 'Demo Work, p. 1',
+      is_retrievable: true,
+    },
+  ],
+  payouts: [
+    {
+      id: 'payout-1',
+      settlement_period: '2026-05',
+      settlement_status: 'simulation',
+      attributed_token_count: 12,
+      accrued_payout_usd: 0.006,
+      hold_reason: null,
+    },
+  ],
+  attributedChunks: [
+    {
+      answer_receipt_id: 'receipt-demo-001',
+      source_chunk_external_id: 'chunk-1',
+      citation_label: 'Demo Work, p. 1',
+      supported_output_tokens: 12,
+      attribution_weight: 1,
+      accrued_payout_usd: 0.006,
+    },
+  ],
+  disputes: [],
+}
+
+describe('CreatorSourceProtocolPage', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => linkedStatement,
+    })))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('renders linked creator rights and payout statement', async () => {
+    render(<CreatorSourceProtocolPage />)
+
+    expect(await screen.findByRole('heading', { name: 'Creator Statement' })).toBeInTheDocument()
+    expect(screen.getByText('Demo Creator')).toBeInTheDocument()
+    expect(screen.getByText(/Usage is calculated per approved answer receipt/i)).toBeInTheDocument()
+    expect(screen.getByText('Demo Work')).toBeInTheDocument()
+    expect(screen.getByText('$0.006')).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/source-protocol/creator/statement', {
+        headers: { Authorization: 'Bearer creator-token' },
+      })
+    })
+  })
+
+  it('renders the unlinked account state', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        available: true,
+        linked: false,
+        generatedAt: '2026-05-04T09:00:00.000Z',
+        reason: 'No active creator portal account is linked to this login yet.',
+      }),
+    })))
+
+    render(<CreatorSourceProtocolPage />)
+
+    expect(await screen.findByText('Your login is not linked to a creator account yet')).toBeInTheDocument()
+    expect(screen.getByText(/No active creator portal account/i)).toBeInTheDocument()
+  })
+
+  it('renders the missing schema state', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        available: false,
+        linked: false,
+        generatedAt: '2026-05-04T09:00:00.000Z',
+        reason: 'Source protocol creator portal schema has not been applied in this environment.',
+        migration: 'supabase/migrations/20260504092130_source_protocol_creator_portal.sql',
+      }),
+    })))
+
+    render(<CreatorSourceProtocolPage />)
+
+    expect(await screen.findByText('Creator portal schema is not available yet')).toBeInTheDocument()
+    expect(screen.getByText(/20260504092130_source_protocol_creator_portal/i)).toBeInTheDocument()
+  })
+})

--- a/app/creator/source-protocol/page.tsx
+++ b/app/creator/source-protocol/page.tsx
@@ -1,0 +1,391 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  AlertTriangle,
+  BookOpenCheck,
+  CircleDollarSign,
+  Database,
+  FileText,
+  Loader2,
+  ShieldCheck,
+} from 'lucide-react'
+import ProtectedRoute from '@/components/ProtectedRoute'
+import { getCurrentSession } from '@/lib/auth'
+import SiteThemeCorner from '@/components/SiteThemeCorner'
+
+type CreatorStatement = {
+  available: boolean
+  linked: boolean
+  generatedAt: string
+  reason?: string
+  migration?: string
+  portal?: {
+    status: string
+    can_view_earnings: boolean
+    can_view_receipts: boolean
+    accepted_at: string | null
+  }
+  creator?: {
+    display_name: string
+    categories: string[]
+    rights_holder_types: string[]
+    verification_status: string
+    protected_identity: boolean
+    public_bio: string | null
+  }
+  summary?: {
+    works: number
+    activeGrants: number
+    retrievableChunks: number
+    attributedReceipts: number
+    monthlyPayouts: number
+    accruedPayoutUsd: number
+    attributedTokenCount: number
+    heldPayouts: number
+    openDisputes: number
+  }
+  works?: any[]
+  licenseGrants?: any[]
+  chunks?: any[]
+  payouts?: any[]
+  attributedChunks?: any[]
+  disputes?: any[]
+}
+
+type TabKey = 'rights' | 'earnings' | 'receipts' | 'support'
+
+const TABS: Array<{ key: TabKey; label: string }> = [
+  { key: 'rights', label: 'Rights' },
+  { key: 'earnings', label: 'Earnings' },
+  { key: 'receipts', label: 'Receipts' },
+  { key: 'support', label: 'Support' },
+]
+
+export default function CreatorSourceProtocolPage() {
+  return (
+    <ProtectedRoute>
+      <CreatorSourceProtocolContent />
+    </ProtectedRoute>
+  )
+}
+
+function CreatorSourceProtocolContent() {
+  const [statement, setStatement] = useState<CreatorStatement | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [tab, setTab] = useState<TabKey>('rights')
+
+  const loadStatement = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Missing creator session')
+      const res = await fetch('/api/source-protocol/creator/statement', {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      })
+      const body = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(body.error || `HTTP ${res.status}`)
+      setStatement(body)
+    } catch (err) {
+      setStatement(null)
+      setError(err instanceof Error ? err.message : 'Failed to load creator statement')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    loadStatement()
+  }, [loadStatement])
+
+  const summary = statement?.summary
+  const tabCounts = useMemo(
+    () => ({
+      rights: (statement?.works?.length ?? 0) + (statement?.licenseGrants?.length ?? 0),
+      earnings: statement?.payouts?.length ?? 0,
+      receipts: statement?.attributedChunks?.length ?? 0,
+      support: statement?.disputes?.length ?? 0,
+    }),
+    [statement]
+  )
+
+  if (loading) {
+    return (
+      <>
+        <SiteThemeCorner />
+        <div className="min-h-screen bg-gray-950 flex items-center justify-center">
+          <div className="text-center">
+            <Loader2 className="w-8 h-8 animate-spin text-radiant-gold mx-auto mb-4" />
+            <p className="text-gray-400 text-sm">Loading your source statement...</p>
+          </div>
+        </div>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <SiteThemeCorner />
+      <div className="min-h-screen bg-gray-950 text-white">
+        <header className="border-b border-gray-800 bg-gray-900/70">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-5 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-radiant-gold">Source Protocol</p>
+              <h1 className="text-2xl font-bold">Creator Statement</h1>
+              <p className="text-sm text-gray-400 max-w-3xl">
+                Read-only visibility into approved works, source use, monthly payout accruals, and rights review status.
+              </p>
+            </div>
+            {statement?.creator && (
+              <div className="text-left lg:text-right">
+                <p className="font-semibold">{statement.creator.protected_identity ? 'Protected identity' : statement.creator.display_name}</p>
+                <p className="text-xs text-gray-500">{statement.creator.verification_status}</p>
+              </div>
+            )}
+          </div>
+        </header>
+
+        <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 space-y-6">
+          {error ? (
+            <Notice tone="red" title="Statement unavailable" body={error} />
+          ) : statement && !statement.available ? (
+            <Notice
+              tone="amber"
+              title="Creator portal schema is not available yet"
+              body={`${statement.reason ?? 'The migration must be applied before creator statements can load.'} Migration: ${statement.migration ?? 'creator portal migration'}.`}
+            />
+          ) : statement && !statement.linked ? (
+            <Notice
+              tone="amber"
+              title="Your login is not linked to a creator account yet"
+              body={statement.reason ?? 'A protocol admin must link your signed-in account to your creator profile before this statement can show private rights and earnings data.'}
+            />
+          ) : statement && summary ? (
+            <>
+              <section className="rounded-lg border border-gray-800 bg-gray-900/70 p-5">
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                  <div>
+                    <div className="mb-2 flex items-center gap-2">
+                      <ShieldCheck size={20} className="text-radiant-gold" />
+                      <h2 className="text-xl font-semibold">Current statement</h2>
+                    </div>
+                    <p className="text-sm text-gray-400 max-w-3xl">
+                      Usage is calculated per approved answer receipt. Money movement is grouped into monthly settlements so review, holds, and payout costs stay manageable.
+                    </p>
+                  </div>
+                  <StatusPill reviewNeeded={summary.openDisputes > 0 || summary.heldPayouts > 0} />
+                </div>
+              </section>
+
+              <section className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+                <Stat icon={<BookOpenCheck size={18} />} label="Works" value={summary.works} />
+                <Stat icon={<ShieldCheck size={18} />} label="Active grants" value={summary.activeGrants} />
+                <Stat icon={<Database size={18} />} label="Retrievable chunks" value={summary.retrievableChunks} />
+                <Stat icon={<FileText size={18} />} label="Attributed receipts" value={summary.attributedReceipts} />
+                <Stat icon={<CircleDollarSign size={18} />} label="Accrued payout" value={formatMoney(summary.accruedPayoutUsd)} />
+                <Stat icon={<FileText size={18} />} label="Attributed tokens" value={summary.attributedTokenCount} />
+                <Stat icon={<CircleDollarSign size={18} />} label="Monthly statements" value={summary.monthlyPayouts} />
+                <Stat icon={<AlertTriangle size={18} />} label="Open support items" value={summary.openDisputes} />
+              </section>
+
+              <section className="flex flex-wrap gap-2">
+                {TABS.map((item) => (
+                  <button
+                    key={item.key}
+                    type="button"
+                    onClick={() => setTab(item.key)}
+                    className={`rounded-lg border px-3 py-2 text-sm ${tab === item.key ? 'border-radiant-gold bg-radiant-gold/10 text-radiant-gold' : 'border-gray-800 text-gray-400 hover:text-white'}`}
+                  >
+                    {item.label} <span className="ml-1 font-mono text-xs">{tabCounts[item.key]}</span>
+                  </button>
+                ))}
+              </section>
+
+              <section className="overflow-hidden rounded-lg border border-gray-800 bg-gray-900/50">
+                {tab === 'rights' && <RightsTable works={statement.works ?? []} grants={statement.licenseGrants ?? []} chunks={statement.chunks ?? []} />}
+                {tab === 'earnings' && <PayoutTable rows={statement.payouts ?? []} canView={statement.portal?.can_view_earnings ?? false} />}
+                {tab === 'receipts' && <ReceiptTable rows={statement.attributedChunks ?? []} canView={statement.portal?.can_view_receipts ?? false} />}
+                {tab === 'support' && <SupportTable rows={statement.disputes ?? []} />}
+              </section>
+            </>
+          ) : null}
+        </main>
+      </div>
+    </>
+  )
+}
+
+function Notice({ tone, title, body }: { tone: 'amber' | 'red'; title: string; body: string }) {
+  const classes = tone === 'amber'
+    ? 'border-amber-500/40 bg-amber-500/10 text-amber-100'
+    : 'border-red-500/40 bg-red-500/10 text-red-200'
+  return (
+    <div className={`rounded-lg border p-6 ${classes}`}>
+      <p className="font-semibold">{title}</p>
+      <p className="mt-1 text-sm">{body}</p>
+    </div>
+  )
+}
+
+function StatusPill({ reviewNeeded }: { reviewNeeded: boolean }) {
+  return (
+    <div className={`inline-flex rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide ${reviewNeeded ? 'border-amber-500/40 bg-amber-500/10 text-amber-300' : 'border-emerald-500/40 bg-emerald-500/10 text-emerald-300'}`}>
+      {reviewNeeded ? 'Review needed' : 'Current'}
+    </div>
+  )
+}
+
+function Stat({ icon, label, value }: { icon: React.ReactNode; label: string; value: string | number }) {
+  return (
+    <div className="rounded-lg border border-gray-800 bg-gray-900/70 p-4">
+      <div className="mb-2 flex items-center gap-2 text-gray-400">
+        {icon}
+        <span className="text-xs font-semibold uppercase tracking-wide">{label}</span>
+      </div>
+      <p className="text-2xl font-bold tabular-nums text-radiant-gold">{value}</p>
+    </div>
+  )
+}
+
+function TableFrame({ headers, empty, children }: { headers: string[]; empty: boolean; children: React.ReactNode }) {
+  return (
+    <>
+      <div className="hidden grid-cols-5 gap-4 bg-gray-900 px-4 py-3 text-xs font-semibold uppercase tracking-wide text-gray-500 lg:grid">
+        {headers.map((header) => <span key={header}>{header}</span>)}
+      </div>
+      <div className="divide-y divide-gray-800">
+        {empty ? <div className="px-4 py-8 text-center text-sm text-gray-500">No records yet.</div> : children}
+      </div>
+    </>
+  )
+}
+
+function RightsTable({ works, grants, chunks }: { works: any[]; grants: any[]; chunks: any[] }) {
+  const grantsByWork = useMemo(() => groupBy(grants, 'work_id'), [grants])
+  const chunksByWork = useMemo(() => groupBy(chunks, 'work_id'), [chunks])
+
+  return (
+    <TableFrame headers={['Work', 'Rights status', 'Uses', 'Retrieval', 'Consent']} empty={works.length === 0}>
+      {works.map((work) => {
+        const activeGrants = (grantsByWork[work.id] ?? []).filter((grant: any) => grant.status === 'active')
+        const workChunks = chunksByWork[work.id] ?? []
+        return (
+          <Row key={work.id} cells={[
+            work.title,
+            `${work.review_status} / ${work.ban_status}`,
+            activeGrants.length > 0 ? list(activeGrants[0].allowed_uses) : 'No active grant',
+            `${workChunks.filter((chunk: any) => chunk.is_retrievable).length} of ${workChunks.length} chunks`,
+            work.community_consent_required ? consentLabel(work.community_consent_verified) : chainLabel(work.chain_of_title_verified),
+          ]} />
+        )
+      })}
+    </TableFrame>
+  )
+}
+
+function PayoutTable({ rows, canView }: { rows: any[]; canView: boolean }) {
+  if (!canView) {
+    return <div className="px-4 py-8 text-center text-sm text-gray-500">Earnings visibility is disabled for this portal account.</div>
+  }
+
+  return (
+    <TableFrame headers={['Period', 'Status', 'Tokens', 'Accrued', 'Settlement']} empty={rows.length === 0}>
+      {rows.map((row) => (
+        <Row key={row.id} cells={[
+          row.settlement_period,
+          row.settlement_status,
+          String(row.attributed_token_count ?? 0),
+          formatMoney(row.accrued_payout_usd),
+          row.hold_reason || (row.paid_at ? `Paid ${formatDate(row.paid_at)}` : 'Pending monthly review'),
+        ]} />
+      ))}
+    </TableFrame>
+  )
+}
+
+function ReceiptTable({ rows, canView }: { rows: any[]; canView: boolean }) {
+  if (!canView) {
+    return <div className="px-4 py-8 text-center text-sm text-gray-500">Receipt visibility is disabled for this portal account.</div>
+  }
+
+  return (
+    <TableFrame headers={['Receipt', 'Citation', 'Tokens', 'Weight', 'Accrued']} empty={rows.length === 0}>
+      {rows.map((row) => (
+        <Row key={`${row.answer_receipt_id}-${row.source_chunk_external_id}`} cells={[
+          shortId(row.answer_receipt_id),
+          row.citation_label,
+          String(row.supported_output_tokens ?? 0),
+          Number(row.attribution_weight ?? 0).toFixed(4),
+          formatMoney(row.accrued_payout_usd),
+        ]} />
+      ))}
+    </TableFrame>
+  )
+}
+
+function SupportTable({ rows }: { rows: any[] }) {
+  return (
+    <TableFrame headers={['Item', 'Type', 'Status', 'Opened', 'Summary']} empty={rows.length === 0}>
+      {rows.map((row) => (
+        <Row key={row.id} cells={[
+          shortId(row.id),
+          row.dispute_type,
+          row.status,
+          formatDate(row.created_at),
+          row.resolution_notes || row.summary,
+        ]} />
+      ))}
+    </TableFrame>
+  )
+}
+
+function Row({ cells }: { cells: string[] }) {
+  return (
+    <div className="grid grid-cols-1 gap-2 px-4 py-4 text-sm lg:grid-cols-5 lg:gap-4">
+      {cells.map((cell, index) => (
+        <div key={`${cell}-${index}`} className={index === 0 ? 'font-medium text-white' : 'text-gray-400'}>
+          <span className="break-words">{cell}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function groupBy(rows: any[], key: string): Record<string, any[]> {
+  return rows.reduce<Record<string, any[]>>((acc, row) => {
+    const value = row[key]
+    acc[value] = [...(acc[value] ?? []), row]
+    return acc
+  }, {})
+}
+
+function list(value: unknown): string {
+  return Array.isArray(value) && value.length > 0 ? value.join(', ') : 'None'
+}
+
+function shortId(value: string): string {
+  if (!value) return 'Unknown'
+  return value.length > 14 ? `${value.slice(0, 8)}...${value.slice(-4)}` : value
+}
+
+function chainLabel(value: boolean): string {
+  return value ? 'Chain verified' : 'Chain pending'
+}
+
+function consentLabel(value: boolean): string {
+  return value ? 'Consent verified' : 'Consent pending'
+}
+
+function formatDate(value: string): string {
+  if (!value) return 'Unknown'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' }).format(date)
+}
+
+function formatMoney(value: unknown): string {
+  const amount = Number(value ?? 0)
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 6 }).format(amount)
+}

--- a/database_schema_source_respecting_llm.sql
+++ b/database_schema_source_respecting_llm.sql
@@ -31,6 +31,23 @@ CREATE TABLE IF NOT EXISTS source_creators (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
+CREATE TABLE IF NOT EXISTS source_creator_portal_accounts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  creator_id UUID NOT NULL REFERENCES source_creators(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'active', 'suspended', 'revoked')),
+  can_view_earnings BOOLEAN NOT NULL DEFAULT TRUE,
+  can_view_receipts BOOLEAN NOT NULL DEFAULT TRUE,
+  invited_by UUID REFERENCES auth.users(id),
+  invited_at TIMESTAMPTZ,
+  accepted_at TIMESTAMPTZ,
+  admin_notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(creator_id, user_id)
+);
+
 CREATE TABLE IF NOT EXISTS licensed_works (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   creator_id UUID NOT NULL REFERENCES source_creators(id) ON DELETE CASCADE,
@@ -197,6 +214,8 @@ CREATE TABLE IF NOT EXISTS creator_rights_model_reviews (
 -- Indexes
 -- ============================================================================
 CREATE INDEX IF NOT EXISTS idx_source_creators_verification_status ON source_creators(verification_status);
+CREATE INDEX IF NOT EXISTS idx_source_creator_portal_accounts_user_status ON source_creator_portal_accounts(user_id, status);
+CREATE INDEX IF NOT EXISTS idx_source_creator_portal_accounts_creator_id ON source_creator_portal_accounts(creator_id);
 CREATE INDEX IF NOT EXISTS idx_licensed_works_creator_id ON licensed_works(creator_id);
 CREATE INDEX IF NOT EXISTS idx_licensed_works_review_status ON licensed_works(review_status);
 CREATE INDEX IF NOT EXISTS idx_license_grants_work_status ON license_grants(work_id, status);
@@ -215,6 +234,11 @@ CREATE INDEX IF NOT EXISTS idx_creator_rights_model_reviews_reviewed_at ON creat
 DROP TRIGGER IF EXISTS source_creators_updated_at ON source_creators;
 CREATE TRIGGER source_creators_updated_at
   BEFORE UPDATE ON source_creators
+  FOR EACH ROW EXECUTE FUNCTION update_source_respecting_llm_updated_at();
+
+DROP TRIGGER IF EXISTS source_creator_portal_accounts_updated_at ON source_creator_portal_accounts;
+CREATE TRIGGER source_creator_portal_accounts_updated_at
+  BEFORE UPDATE ON source_creator_portal_accounts
   FOR EACH ROW EXECUTE FUNCTION update_source_respecting_llm_updated_at();
 
 DROP TRIGGER IF EXISTS licensed_works_updated_at ON licensed_works;
@@ -246,6 +270,7 @@ CREATE TRIGGER creator_rights_disputes_updated_at
 -- Row Level Security
 -- ============================================================================
 ALTER TABLE source_creators ENABLE ROW LEVEL SECURITY;
+ALTER TABLE source_creator_portal_accounts ENABLE ROW LEVEL SECURITY;
 ALTER TABLE licensed_works ENABLE ROW LEVEL SECURITY;
 ALTER TABLE license_grants ENABLE ROW LEVEL SECURITY;
 ALTER TABLE source_chunks ENABLE ROW LEVEL SECURITY;
@@ -257,50 +282,172 @@ ALTER TABLE creator_rights_model_reviews ENABLE ROW LEVEL SECURITY;
 
 DROP POLICY IF EXISTS "Admins can manage source creators" ON source_creators;
 CREATE POLICY "Admins can manage source creators" ON source_creators
-  FOR ALL USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'))
-  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'));
+  FOR ALL USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'))
+  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'));
+
+DROP POLICY IF EXISTS "Admins can manage source creator portal accounts" ON source_creator_portal_accounts;
+CREATE POLICY "Admins can manage source creator portal accounts" ON source_creator_portal_accounts
+  FOR ALL
+  TO authenticated
+  USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'))
+  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'));
+
+DROP POLICY IF EXISTS "Creators can view their own active portal account" ON source_creator_portal_accounts;
+CREATE POLICY "Creators can view their own active portal account" ON source_creator_portal_accounts
+  FOR SELECT
+  TO authenticated
+  USING ((select auth.uid()) IS NOT NULL AND user_id = (select auth.uid()) AND status = 'active');
+
+DROP POLICY IF EXISTS "Creators can view their own source creator profile" ON source_creators;
+CREATE POLICY "Creators can view their own source creator profile" ON source_creators
+  FOR SELECT
+  TO authenticated
+  USING (
+    (select auth.uid()) IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM source_creator_portal_accounts portal
+      WHERE portal.creator_id = source_creators.id
+        AND portal.user_id = (select auth.uid())
+        AND portal.status = 'active'
+    )
+  );
 
 DROP POLICY IF EXISTS "Admins can manage licensed works" ON licensed_works;
 CREATE POLICY "Admins can manage licensed works" ON licensed_works
-  FOR ALL USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'))
-  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'));
+  FOR ALL USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'))
+  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'));
+
+DROP POLICY IF EXISTS "Creators can view their own licensed works" ON licensed_works;
+CREATE POLICY "Creators can view their own licensed works" ON licensed_works
+  FOR SELECT
+  TO authenticated
+  USING (
+    (select auth.uid()) IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM source_creator_portal_accounts portal
+      WHERE portal.creator_id = licensed_works.creator_id
+        AND portal.user_id = (select auth.uid())
+        AND portal.status = 'active'
+    )
+  );
 
 DROP POLICY IF EXISTS "Admins can manage license grants" ON license_grants;
 CREATE POLICY "Admins can manage license grants" ON license_grants
-  FOR ALL USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'))
-  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'));
+  FOR ALL USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'))
+  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'));
+
+DROP POLICY IF EXISTS "Creators can view grants for their own works" ON license_grants;
+CREATE POLICY "Creators can view grants for their own works" ON license_grants
+  FOR SELECT
+  TO authenticated
+  USING (
+    (select auth.uid()) IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM licensed_works work
+      JOIN source_creator_portal_accounts portal ON portal.creator_id = work.creator_id
+      WHERE work.id = license_grants.work_id
+        AND portal.user_id = (select auth.uid())
+        AND portal.status = 'active'
+    )
+  );
 
 DROP POLICY IF EXISTS "Admins can manage source chunks" ON source_chunks;
 CREATE POLICY "Admins can manage source chunks" ON source_chunks
-  FOR ALL USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'))
-  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'));
+  FOR ALL USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'))
+  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'));
+
+DROP POLICY IF EXISTS "Creators can view their own source chunks" ON source_chunks;
+CREATE POLICY "Creators can view their own source chunks" ON source_chunks
+  FOR SELECT
+  TO authenticated
+  USING (
+    (select auth.uid()) IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM source_creator_portal_accounts portal
+      WHERE portal.creator_id = source_chunks.creator_id
+        AND portal.user_id = (select auth.uid())
+        AND portal.status = 'active'
+    )
+  );
 
 DROP POLICY IF EXISTS "Admins can manage answer receipts" ON answer_receipts;
 CREATE POLICY "Admins can manage answer receipts" ON answer_receipts
-  FOR ALL USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'))
-  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'));
+  FOR ALL USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'))
+  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'));
 
 DROP POLICY IF EXISTS "Admins can manage answer receipt chunks" ON answer_receipt_chunks;
 CREATE POLICY "Admins can manage answer receipt chunks" ON answer_receipt_chunks
-  FOR ALL USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'))
-  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'));
+  FOR ALL USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'))
+  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'));
+
+DROP POLICY IF EXISTS "Creators can view their own attributed receipt chunks" ON answer_receipt_chunks;
+CREATE POLICY "Creators can view their own attributed receipt chunks" ON answer_receipt_chunks
+  FOR SELECT
+  TO authenticated
+  USING (
+    (select auth.uid()) IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM source_creator_portal_accounts portal
+      WHERE portal.creator_id = answer_receipt_chunks.creator_id
+        AND portal.user_id = (select auth.uid())
+        AND portal.status = 'active'
+        AND portal.can_view_receipts = TRUE
+    )
+  );
 
 DROP POLICY IF EXISTS "Admins can manage monthly creator payouts" ON monthly_creator_payouts;
 CREATE POLICY "Admins can manage monthly creator payouts" ON monthly_creator_payouts
-  FOR ALL USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'))
-  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'));
+  FOR ALL USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'))
+  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'));
+
+DROP POLICY IF EXISTS "Creators can view their own monthly payouts" ON monthly_creator_payouts;
+CREATE POLICY "Creators can view their own monthly payouts" ON monthly_creator_payouts
+  FOR SELECT
+  TO authenticated
+  USING (
+    (select auth.uid()) IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM source_creator_portal_accounts portal
+      WHERE portal.creator_id = monthly_creator_payouts.creator_id
+        AND portal.user_id = (select auth.uid())
+        AND portal.status = 'active'
+        AND portal.can_view_earnings = TRUE
+    )
+  );
 
 DROP POLICY IF EXISTS "Admins can manage creator rights disputes" ON creator_rights_disputes;
 CREATE POLICY "Admins can manage creator rights disputes" ON creator_rights_disputes
-  FOR ALL USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'))
-  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'));
+  FOR ALL USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'))
+  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'));
+
+DROP POLICY IF EXISTS "Creators can view their own disputes" ON creator_rights_disputes;
+CREATE POLICY "Creators can view their own disputes" ON creator_rights_disputes
+  FOR SELECT
+  TO authenticated
+  USING (
+    (select auth.uid()) IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM source_creator_portal_accounts portal
+      WHERE portal.creator_id = creator_rights_disputes.creator_id
+        AND portal.user_id = (select auth.uid())
+        AND portal.status = 'active'
+    )
+  );
 
 DROP POLICY IF EXISTS "Admins can manage creator rights model reviews" ON creator_rights_model_reviews;
 CREATE POLICY "Admins can manage creator rights model reviews" ON creator_rights_model_reviews
-  FOR ALL USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'))
-  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'));
+  FOR ALL USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'))
+  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'));
 
 GRANT ALL ON source_creators TO service_role;
+GRANT ALL ON source_creator_portal_accounts TO service_role;
 GRANT ALL ON licensed_works TO service_role;
 GRANT ALL ON license_grants TO service_role;
 GRANT ALL ON source_chunks TO service_role;

--- a/docs/source-respecting-llm-protocol.md
+++ b/docs/source-respecting-llm-protocol.md
@@ -113,6 +113,12 @@ The two write routes require `Authorization: Bearer <SOURCE_PROTOCOL_INGEST_SECR
 
 The overview route uses the regular admin session bearer token and is projected into `/admin/source-protocol`. That page is read-only: it shows per-use receipt accruals and monthly payout settlement status without approving, paying, revoking, or ingesting anything.
 
+Creator portal foundation:
+
+- `source_creator_portal_accounts` links an authenticated user to a creator profile. Access is explicit and admin-controlled; the protocol does not infer account ownership from names, emails, or public metadata.
+- `GET /api/source-protocol/creator/statement` returns the signed-in creator's read-only statement: works, active grants, retrievable chunks, attributed receipt rows, monthly payout rows, and dispute/support rows.
+- `/creator/source-protocol` projects that statement for nontechnical creators. It does not approve payouts, change licenses, ingest work, open disputes, or revoke grants.
+
 Smoke test:
 
 - `npm run source-protocol:smoke` builds a synthetic receipt and monthly settlement without network calls.

--- a/supabase/migrations/20260504092130_source_protocol_creator_portal.sql
+++ b/supabase/migrations/20260504092130_source_protocol_creator_portal.sql
@@ -1,0 +1,204 @@
+-- Creator-facing Source Protocol portal access.
+-- Links authenticated users to verified creator records without inferring identity
+-- from email, names, or public profile data.
+
+CREATE TABLE IF NOT EXISTS source_creator_portal_accounts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  creator_id UUID NOT NULL REFERENCES source_creators(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'active', 'suspended', 'revoked')),
+  can_view_earnings BOOLEAN NOT NULL DEFAULT TRUE,
+  can_view_receipts BOOLEAN NOT NULL DEFAULT TRUE,
+  invited_by UUID REFERENCES auth.users(id),
+  invited_at TIMESTAMPTZ,
+  accepted_at TIMESTAMPTZ,
+  admin_notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(creator_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_source_creator_portal_accounts_user_status
+  ON source_creator_portal_accounts(user_id, status);
+CREATE INDEX IF NOT EXISTS idx_source_creator_portal_accounts_creator_id
+  ON source_creator_portal_accounts(creator_id);
+
+DROP TRIGGER IF EXISTS source_creator_portal_accounts_updated_at ON source_creator_portal_accounts;
+CREATE TRIGGER source_creator_portal_accounts_updated_at
+  BEFORE UPDATE ON source_creator_portal_accounts
+  FOR EACH ROW EXECUTE FUNCTION update_source_respecting_llm_updated_at();
+
+ALTER TABLE source_creator_portal_accounts ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Admins can manage source creators" ON source_creators;
+CREATE POLICY "Admins can manage source creators" ON source_creators
+  FOR ALL
+  TO authenticated
+  USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'))
+  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'));
+
+DROP POLICY IF EXISTS "Admins can manage source creator portal accounts" ON source_creator_portal_accounts;
+CREATE POLICY "Admins can manage source creator portal accounts" ON source_creator_portal_accounts
+  FOR ALL
+  TO authenticated
+  USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'))
+  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'));
+
+DROP POLICY IF EXISTS "Creators can view their own active portal account" ON source_creator_portal_accounts;
+CREATE POLICY "Creators can view their own active portal account" ON source_creator_portal_accounts
+  FOR SELECT
+  TO authenticated
+  USING ((select auth.uid()) IS NOT NULL AND user_id = (select auth.uid()) AND status = 'active');
+
+DROP POLICY IF EXISTS "Admins can manage licensed works" ON licensed_works;
+CREATE POLICY "Admins can manage licensed works" ON licensed_works
+  FOR ALL
+  TO authenticated
+  USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'))
+  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'));
+
+DROP POLICY IF EXISTS "Admins can manage license grants" ON license_grants;
+CREATE POLICY "Admins can manage license grants" ON license_grants
+  FOR ALL
+  TO authenticated
+  USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'))
+  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'));
+
+DROP POLICY IF EXISTS "Admins can manage source chunks" ON source_chunks;
+CREATE POLICY "Admins can manage source chunks" ON source_chunks
+  FOR ALL
+  TO authenticated
+  USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'))
+  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'));
+
+DROP POLICY IF EXISTS "Admins can manage answer receipt chunks" ON answer_receipt_chunks;
+CREATE POLICY "Admins can manage answer receipt chunks" ON answer_receipt_chunks
+  FOR ALL
+  TO authenticated
+  USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'))
+  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'));
+
+DROP POLICY IF EXISTS "Admins can manage monthly creator payouts" ON monthly_creator_payouts;
+CREATE POLICY "Admins can manage monthly creator payouts" ON monthly_creator_payouts
+  FOR ALL
+  TO authenticated
+  USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'))
+  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'));
+
+DROP POLICY IF EXISTS "Admins can manage creator rights disputes" ON creator_rights_disputes;
+CREATE POLICY "Admins can manage creator rights disputes" ON creator_rights_disputes
+  FOR ALL
+  TO authenticated
+  USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'))
+  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = (select auth.uid()) AND role = 'admin'));
+
+DROP POLICY IF EXISTS "Creators can view their own source creator profile" ON source_creators;
+CREATE POLICY "Creators can view their own source creator profile" ON source_creators
+  FOR SELECT
+  TO authenticated
+  USING (
+    (select auth.uid()) IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM source_creator_portal_accounts portal
+      WHERE portal.creator_id = source_creators.id
+        AND portal.user_id = (select auth.uid())
+        AND portal.status = 'active'
+    )
+  );
+
+DROP POLICY IF EXISTS "Creators can view their own licensed works" ON licensed_works;
+CREATE POLICY "Creators can view their own licensed works" ON licensed_works
+  FOR SELECT
+  TO authenticated
+  USING (
+    (select auth.uid()) IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM source_creator_portal_accounts portal
+      WHERE portal.creator_id = licensed_works.creator_id
+        AND portal.user_id = (select auth.uid())
+        AND portal.status = 'active'
+    )
+  );
+
+DROP POLICY IF EXISTS "Creators can view grants for their own works" ON license_grants;
+CREATE POLICY "Creators can view grants for their own works" ON license_grants
+  FOR SELECT
+  TO authenticated
+  USING (
+    (select auth.uid()) IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM licensed_works work
+      JOIN source_creator_portal_accounts portal ON portal.creator_id = work.creator_id
+      WHERE work.id = license_grants.work_id
+        AND portal.user_id = (select auth.uid())
+        AND portal.status = 'active'
+    )
+  );
+
+DROP POLICY IF EXISTS "Creators can view their own source chunks" ON source_chunks;
+CREATE POLICY "Creators can view their own source chunks" ON source_chunks
+  FOR SELECT
+  TO authenticated
+  USING (
+    (select auth.uid()) IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM source_creator_portal_accounts portal
+      WHERE portal.creator_id = source_chunks.creator_id
+        AND portal.user_id = (select auth.uid())
+        AND portal.status = 'active'
+    )
+  );
+
+DROP POLICY IF EXISTS "Creators can view their own attributed receipt chunks" ON answer_receipt_chunks;
+CREATE POLICY "Creators can view their own attributed receipt chunks" ON answer_receipt_chunks
+  FOR SELECT
+  TO authenticated
+  USING (
+    (select auth.uid()) IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM source_creator_portal_accounts portal
+      WHERE portal.creator_id = answer_receipt_chunks.creator_id
+        AND portal.user_id = (select auth.uid())
+        AND portal.status = 'active'
+        AND portal.can_view_receipts = TRUE
+    )
+  );
+
+DROP POLICY IF EXISTS "Creators can view their own monthly payouts" ON monthly_creator_payouts;
+CREATE POLICY "Creators can view their own monthly payouts" ON monthly_creator_payouts
+  FOR SELECT
+  TO authenticated
+  USING (
+    (select auth.uid()) IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM source_creator_portal_accounts portal
+      WHERE portal.creator_id = monthly_creator_payouts.creator_id
+        AND portal.user_id = (select auth.uid())
+        AND portal.status = 'active'
+        AND portal.can_view_earnings = TRUE
+    )
+  );
+
+DROP POLICY IF EXISTS "Creators can view their own disputes" ON creator_rights_disputes;
+CREATE POLICY "Creators can view their own disputes" ON creator_rights_disputes
+  FOR SELECT
+  TO authenticated
+  USING (
+    (select auth.uid()) IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM source_creator_portal_accounts portal
+      WHERE portal.creator_id = creator_rights_disputes.creator_id
+        AND portal.user_id = (select auth.uid())
+        AND portal.status = 'active'
+    )
+  );
+
+GRANT ALL ON source_creator_portal_accounts TO service_role;


### PR DESCRIPTION
## Summary
- Add explicit creator portal account linking for Source Protocol creators with RLS policies for creator-owned read access
- Add signed-in creator statement API and /creator/source-protocol read-only portal for rights, receipts, monthly payout accruals, and support/dispute visibility
- Extend the admin Source Protocol overview with portal account counts
- Document the creator portal foundation

## Validation
- npm test -- app/api/source-protocol/creator/statement/route.test.ts app/creator/source-protocol/page.test.tsx app/admin/source-protocol/page.test.tsx lib/source-respecting-llm-protocol.test.ts lib/source-respecting-llm-persistence.test.ts
- npx tsc --noEmit --pretty false
- npm run lint -- --dir app/creator/source-protocol --dir app/api/source-protocol --dir app/admin/source-protocol --dir app/api/admin/source-protocol --file lib/admin-nav.ts
- git diff --check
- npm run build
- supabase db query --linked --file supabase/migrations/20260504092130_source_protocol_creator_portal.sql against My Portfolio- Dev
- supabase db advisors --linked --output json --level warn showed no remaining source-protocol auth init-plan warnings
- pre-push database health check passed

## Notes
- The linked dev database still has a pre-existing advisor error for public.documents_local_rag RLS. This PR does not touch that table.
- The creator portal is read-only; it does not approve payouts, mutate licenses, ingest work, open disputes, or revoke grants.