### PR TITLE
[codex] Add source protocol portal linking controls

### DIFF
--- a/app/admin/source-protocol/page.test.tsx
+++ b/app/admin/source-protocol/page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { ADMIN_NAV } from '@/lib/admin-nav'
@@ -28,7 +28,19 @@ const overview = {
     accruedPayoutUsd: 0.006,
   },
   creators: [],
-  portalAccounts: [],
+  portalAccounts: [
+    {
+      id: '8f111111-1111-4111-8111-111111111111',
+      creator_id: '7f111111-1111-4111-8111-111111111111',
+      user_id: '6f111111-1111-4111-8111-111111111111',
+      user_email: 'creator@example.com',
+      creator_display_name: 'Demo Creator',
+      status: 'active',
+      can_view_earnings: true,
+      can_view_receipts: true,
+      created_at: '2026-05-03T12:00:00.000Z',
+    },
+  ],
   works: [],
   licenseGrants: [],
   chunks: [],
@@ -70,6 +82,11 @@ describe('SourceProtocolPage', () => {
 
     expect(await screen.findByRole('heading', { name: 'Source Protocol' })).toBeInTheDocument()
     expect(screen.getByText(/Payouts accrue per answer receipt/i)).toBeInTheDocument()
+    expect(screen.getByText('Demo Creator')).toBeInTheDocument()
+    expect(screen.getByText('creator@example.com')).toBeInTheDocument()
+
+    fireEvent.click(screen.getAllByRole('button', { name: /Receipts/i })[0])
+
     expect(screen.getByText('allenai/Olmo-3-7B-Instruct')).toBeInTheDocument()
     expect(screen.getByText(/1 cited \/ 1 attributed/i)).toBeInTheDocument()
 

--- a/app/admin/source-protocol/page.tsx
+++ b/app/admin/source-protocol/page.tsx
@@ -7,6 +7,8 @@ import {
   CircleDollarSign,
   Database,
   FileText,
+  RefreshCw,
+  Search,
   ShieldCheck,
   Users,
 } from 'lucide-react'
@@ -43,9 +45,16 @@ type SourceProtocolOverview = {
   modelReviews?: any[]
 }
 
-type TabKey = 'creators' | 'works' | 'grants' | 'chunks' | 'receipts' | 'payouts' | 'reviews'
+type AdminUserOption = {
+  id: string
+  email: string
+  role: string
+}
+
+type TabKey = 'portal' | 'creators' | 'works' | 'grants' | 'chunks' | 'receipts' | 'payouts' | 'reviews'
 
 const TABS: Array<{ key: TabKey; label: string }> = [
+  { key: 'portal', label: 'Portal Access' },
   { key: 'creators', label: 'Creators' },
   { key: 'works', label: 'Works' },
   { key: 'grants', label: 'Grants' },
@@ -67,7 +76,16 @@ function SourceProtocolContent() {
   const [overview, setOverview] = useState<SourceProtocolOverview | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [tab, setTab] = useState<TabKey>('receipts')
+  const [tab, setTab] = useState<TabKey>('portal')
+  const [userSearch, setUserSearch] = useState('')
+  const [userOptions, setUserOptions] = useState<AdminUserOption[]>([])
+  const [selectedUserId, setSelectedUserId] = useState('')
+  const [selectedCreatorId, setSelectedCreatorId] = useState('')
+  const [portalStatus, setPortalStatus] = useState('active')
+  const [canViewEarnings, setCanViewEarnings] = useState(true)
+  const [canViewReceipts, setCanViewReceipts] = useState(true)
+  const [portalBusy, setPortalBusy] = useState(false)
+  const [portalMessage, setPortalMessage] = useState<string | null>(null)
 
   const loadOverview = useCallback(async () => {
     setLoading(true)
@@ -93,11 +111,87 @@ function SourceProtocolContent() {
     loadOverview()
   }, [loadOverview])
 
+  const searchUsers = useCallback(async () => {
+    setPortalMessage(null)
+    try {
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Missing admin session')
+      const params = new URLSearchParams({ page: '1', limit: '10' })
+      if (userSearch.trim()) params.set('search', userSearch.trim())
+      const res = await fetch(`/api/admin/users?${params}`, {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      })
+      const body = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(body.error || `HTTP ${res.status}`)
+      setUserOptions(body.users || [])
+    } catch (err) {
+      setPortalMessage(err instanceof Error ? err.message : 'Failed to search users')
+    }
+  }, [userSearch])
+
+  const createPortalAccount = useCallback(async () => {
+    setPortalBusy(true)
+    setPortalMessage(null)
+    try {
+      if (!selectedCreatorId || !selectedUserId) throw new Error('Choose both a creator and user')
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Missing admin session')
+      const res = await fetch('/api/admin/source-protocol/portal-accounts', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify({
+          creatorId: selectedCreatorId,
+          userId: selectedUserId,
+          status: portalStatus,
+          canViewEarnings,
+          canViewReceipts,
+        }),
+      })
+      const body = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(body.error || `HTTP ${res.status}`)
+      setPortalMessage('Portal account saved.')
+      await loadOverview()
+    } catch (err) {
+      setPortalMessage(err instanceof Error ? err.message : 'Failed to save portal account')
+    } finally {
+      setPortalBusy(false)
+    }
+  }, [canViewEarnings, canViewReceipts, loadOverview, portalStatus, selectedCreatorId, selectedUserId])
+
+  const updatePortalAccount = useCallback(async (accountId: string, update: Record<string, unknown>) => {
+    setPortalBusy(true)
+    setPortalMessage(null)
+    try {
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Missing admin session')
+      const res = await fetch('/api/admin/source-protocol/portal-accounts', {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify({ accountId, ...update }),
+      })
+      const body = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(body.error || `HTTP ${res.status}`)
+      setPortalMessage('Portal account updated.')
+      await loadOverview()
+    } catch (err) {
+      setPortalMessage(err instanceof Error ? err.message : 'Failed to update portal account')
+    } finally {
+      setPortalBusy(false)
+    }
+  }, [loadOverview])
+
   const summary = overview?.summary
   const hasOpenRightsIssue = Boolean(summary && (summary.openDisputes > 0 || summary.heldPayouts > 0))
   const tabCounts = useMemo(
     () => ({
       creators: overview?.creators?.length ?? 0,
+      portal: overview?.portalAccounts?.length ?? 0,
       works: overview?.works?.length ?? 0,
       grants: overview?.licenseGrants?.length ?? 0,
       chunks: overview?.chunks?.length ?? 0,
@@ -120,7 +214,7 @@ function SourceProtocolContent() {
           <div>
             <h1 className="text-3xl font-bold mb-1">Source Protocol</h1>
             <p className="text-muted-foreground text-sm max-w-3xl">
-              Read-only operating view for opt-in creator content, active license grants, cited answer receipts, and monthly payout settlement.
+              Operating view for opt-in creator content, active license grants, cited answer receipts, monthly payout settlement, and creator portal access.
             </p>
           </div>
           <div className="rounded-lg border border-silicon-slate bg-silicon-slate/30 px-4 py-3 text-xs text-muted-foreground">
@@ -189,7 +283,7 @@ function SourceProtocolContent() {
                 <KeyValue label="Model reviews shown" value={String(tabCounts.reviews)} />
                 <KeyValue label="Promotion policy" value="Quality and license gates" />
                 <KeyValue label="Last generated" value={formatDate(overview.generatedAt)} />
-                <KeyValue label="Mode" value="Read-only admin visibility" />
+                <KeyValue label="Mode" value="Admin visibility and portal access control" />
               </Panel>
             </section>
 
@@ -206,7 +300,31 @@ function SourceProtocolContent() {
               ))}
             </section>
 
-            <section className="overflow-hidden rounded-lg border border-silicon-slate">
+            <section className={tab === 'portal' ? '' : 'overflow-hidden rounded-lg border border-silicon-slate'}>
+              {tab === 'portal' && (
+                <PortalAccountsPanel
+                  creators={overview.creators ?? []}
+                  accounts={overview.portalAccounts ?? []}
+                  userSearch={userSearch}
+                  userOptions={userOptions}
+                  selectedCreatorId={selectedCreatorId}
+                  selectedUserId={selectedUserId}
+                  portalStatus={portalStatus}
+                  canViewEarnings={canViewEarnings}
+                  canViewReceipts={canViewReceipts}
+                  busy={portalBusy}
+                  message={portalMessage}
+                  onUserSearchChange={setUserSearch}
+                  onSearchUsers={searchUsers}
+                  onSelectedCreatorChange={setSelectedCreatorId}
+                  onSelectedUserChange={setSelectedUserId}
+                  onStatusChange={setPortalStatus}
+                  onCanViewEarningsChange={setCanViewEarnings}
+                  onCanViewReceiptsChange={setCanViewReceipts}
+                  onCreate={createPortalAccount}
+                  onUpdate={updatePortalAccount}
+                />
+              )}
               {tab === 'creators' && <CreatorsTable rows={overview.creators ?? []} />}
               {tab === 'works' && <WorksTable rows={overview.works ?? []} />}
               {tab === 'grants' && <GrantsTable rows={overview.licenseGrants ?? []} />}
@@ -232,6 +350,239 @@ function Notice({ tone, title, body }: { tone: 'amber' | 'red'; title: string; b
       <p className="mt-1 text-sm">{body}</p>
     </div>
   )
+}
+
+function PortalAccountsPanel({
+  creators,
+  accounts,
+  userSearch,
+  userOptions,
+  selectedCreatorId,
+  selectedUserId,
+  portalStatus,
+  canViewEarnings,
+  canViewReceipts,
+  busy,
+  message,
+  onUserSearchChange,
+  onSearchUsers,
+  onSelectedCreatorChange,
+  onSelectedUserChange,
+  onStatusChange,
+  onCanViewEarningsChange,
+  onCanViewReceiptsChange,
+  onCreate,
+  onUpdate,
+}: {
+  creators: any[]
+  accounts: any[]
+  userSearch: string
+  userOptions: AdminUserOption[]
+  selectedCreatorId: string
+  selectedUserId: string
+  portalStatus: string
+  canViewEarnings: boolean
+  canViewReceipts: boolean
+  busy: boolean
+  message: string | null
+  onUserSearchChange: (value: string) => void
+  onSearchUsers: () => void
+  onSelectedCreatorChange: (value: string) => void
+  onSelectedUserChange: (value: string) => void
+  onStatusChange: (value: string) => void
+  onCanViewEarningsChange: (value: boolean) => void
+  onCanViewReceiptsChange: (value: boolean) => void
+  onCreate: () => void
+  onUpdate: (accountId: string, update: Record<string, unknown>) => void
+}) {
+  return (
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(320px,420px)_1fr]">
+      <section className="rounded-lg border border-silicon-slate bg-silicon-slate/30 p-5">
+        <div className="mb-4 flex items-center gap-2">
+          <Users size={20} className="text-radiant-gold" />
+          <h2 className="text-lg font-semibold">Link creator access</h2>
+        </div>
+
+        <div className="space-y-4">
+          <label className="block text-sm">
+            <span className="mb-1 block text-muted-foreground">Creator</span>
+            <select
+              value={selectedCreatorId}
+              onChange={(event) => onSelectedCreatorChange(event.target.value)}
+              className="w-full rounded-lg border border-silicon-slate bg-background px-3 py-2 text-sm"
+            >
+              <option value="">Choose a creator</option>
+              {creators.map((creator) => (
+                <option key={creator.id} value={creator.id}>
+                  {creator.protected_identity ? `Protected identity (${shortId(creator.id)})` : creator.display_name}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <div>
+            <span className="mb-1 block text-sm text-muted-foreground">User account</span>
+            <div className="flex gap-2">
+              <input
+                type="search"
+                value={userSearch}
+                onChange={(event) => onUserSearchChange(event.target.value)}
+                placeholder="Search user email"
+                className="min-w-0 flex-1 rounded-lg border border-silicon-slate bg-background px-3 py-2 text-sm"
+              />
+              <button
+                type="button"
+                onClick={onSearchUsers}
+                disabled={busy}
+                className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate px-3 py-2 text-sm text-muted-foreground hover:text-foreground disabled:opacity-50"
+              >
+                <Search size={16} />
+                Search
+              </button>
+            </div>
+          </div>
+
+          <label className="block text-sm">
+            <span className="mb-1 block text-muted-foreground">Matched user</span>
+            <select
+              value={selectedUserId}
+              onChange={(event) => onSelectedUserChange(event.target.value)}
+              className="w-full rounded-lg border border-silicon-slate bg-background px-3 py-2 text-sm"
+            >
+              <option value="">Choose a user</option>
+              {userOptions.map((user) => (
+                <option key={user.id} value={user.id}>
+                  {user.email} ({user.role})
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="block text-sm">
+            <span className="mb-1 block text-muted-foreground">Initial status</span>
+            <select
+              value={portalStatus}
+              onChange={(event) => onStatusChange(event.target.value)}
+              className="w-full rounded-lg border border-silicon-slate bg-background px-3 py-2 text-sm"
+            >
+              <option value="active">Active</option>
+              <option value="pending">Pending</option>
+              <option value="suspended">Suspended</option>
+              <option value="revoked">Revoked</option>
+            </select>
+          </label>
+
+          <label className="flex items-center justify-between gap-3 rounded-lg border border-silicon-slate px-3 py-2 text-sm">
+            <span>Show earnings</span>
+            <input
+              type="checkbox"
+              checked={canViewEarnings}
+              onChange={(event) => onCanViewEarningsChange(event.target.checked)}
+            />
+          </label>
+          <label className="flex items-center justify-between gap-3 rounded-lg border border-silicon-slate px-3 py-2 text-sm">
+            <span>Show receipt details</span>
+            <input
+              type="checkbox"
+              checked={canViewReceipts}
+              onChange={(event) => onCanViewReceiptsChange(event.target.checked)}
+            />
+          </label>
+
+          <button
+            type="button"
+            onClick={onCreate}
+            disabled={busy || !selectedCreatorId || !selectedUserId}
+            className="w-full rounded-lg border border-radiant-gold bg-radiant-gold/10 px-3 py-2 text-sm font-semibold text-radiant-gold hover:bg-radiant-gold/20 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {busy ? 'Saving...' : 'Save portal link'}
+          </button>
+
+          {message && (
+            <p className="rounded-lg border border-silicon-slate bg-background/50 px-3 py-2 text-sm text-muted-foreground">
+              {message}
+            </p>
+          )}
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-lg border border-silicon-slate">
+        <div className="hidden grid-cols-6 gap-4 bg-silicon-slate/60 px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground lg:grid">
+          <span>Creator</span>
+          <span>User</span>
+          <span>Status</span>
+          <span>Visibility</span>
+          <span>Created</span>
+          <span>Actions</span>
+        </div>
+        <div className="divide-y divide-silicon-slate">
+          {accounts.length === 0 ? (
+            <div className="px-4 py-8 text-center text-sm text-muted-foreground">No portal accounts yet.</div>
+          ) : accounts.map((account) => (
+            <div key={account.id} className="grid grid-cols-1 gap-3 px-4 py-4 text-sm lg:grid-cols-6 lg:gap-4">
+              <div className="font-medium">{account.creator_display_name || shortId(account.creator_id)}</div>
+              <div className="text-muted-foreground">
+                <p>{account.user_email || shortId(account.user_id)}</p>
+                <p className="font-mono text-xs">{shortId(account.user_id)}</p>
+              </div>
+              <div>
+                <StatusBadge status={account.status} />
+              </div>
+              <div className="text-muted-foreground">
+                <p>{account.can_view_earnings ? 'Earnings visible' : 'Earnings hidden'}</p>
+                <p>{account.can_view_receipts ? 'Receipts visible' : 'Receipts hidden'}</p>
+              </div>
+              <div className="text-muted-foreground">{formatDate(account.created_at)}</div>
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={() => onUpdate(account.id, { status: account.status === 'active' ? 'suspended' : 'active' })}
+                  disabled={busy || account.status === 'revoked'}
+                  className="rounded border border-silicon-slate px-2 py-1 text-xs text-muted-foreground hover:text-foreground disabled:opacity-50"
+                >
+                  {account.status === 'active' ? 'Suspend' : 'Activate'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onUpdate(account.id, { status: 'revoked' })}
+                  disabled={busy || account.status === 'revoked'}
+                  className="rounded border border-red-500/40 px-2 py-1 text-xs text-red-300 disabled:opacity-50"
+                >
+                  Revoke
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onUpdate(account.id, { canViewEarnings: !account.can_view_earnings })}
+                  disabled={busy || account.status === 'revoked'}
+                  className="rounded border border-silicon-slate px-2 py-1 text-xs text-muted-foreground hover:text-foreground disabled:opacity-50"
+                >
+                  <RefreshCw size={12} className="inline" /> Earnings
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onUpdate(account.id, { canViewReceipts: !account.can_view_receipts })}
+                  disabled={busy || account.status === 'revoked'}
+                  className="rounded border border-silicon-slate px-2 py-1 text-xs text-muted-foreground hover:text-foreground disabled:opacity-50"
+                >
+                  <RefreshCw size={12} className="inline" /> Receipts
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const classes =
+    status === 'active'
+      ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-300'
+      : status === 'revoked'
+        ? 'border-red-500/40 bg-red-500/10 text-red-300'
+        : 'border-amber-500/40 bg-amber-500/10 text-amber-300'
+  return <span className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-medium ${classes}`}>{status}</span>
 }
 
 function Stat({ icon, label, value }: { icon: React.ReactNode; label: string; value: string | number }) {

--- a/app/api/admin/source-protocol/overview/route.ts
+++ b/app/api/admin/source-protocol/overview/route.ts
@@ -147,6 +147,24 @@ export async function GET(request: NextRequest) {
     const accruedPayoutUsd = payoutRows.reduce((sum: number, payout: any) => {
       return sum + Number(payout.accrued_payout_usd ?? 0)
     }, 0)
+    const portalUserIds = [...new Set(portalAccountRows.map((account: any) => account.user_id).filter(Boolean))]
+    const { data: portalUsers, error: portalUsersError } = portalUserIds.length > 0
+      ? await supabaseAdmin
+        .from('user_profiles')
+        .select('id, email, role')
+        .in('id', portalUserIds)
+      : { data: [], error: null }
+
+    if (portalUsersError) throw portalUsersError
+
+    const usersById = new Map<string, any>((portalUsers ?? []).map((user: any) => [user.id, user]))
+    const creatorsById = new Map<string, any>(creatorRows.map((creator: any) => [creator.id, creator]))
+    const enrichedPortalAccounts = portalAccountRows.map((account: any) => ({
+      ...account,
+      user_email: usersById.get(account.user_id)?.email ?? null,
+      user_role: usersById.get(account.user_id)?.role ?? null,
+      creator_display_name: creatorsById.get(account.creator_id)?.display_name ?? null,
+    }))
 
     return NextResponse.json({
       available: true,
@@ -164,7 +182,7 @@ export async function GET(request: NextRequest) {
         accruedPayoutUsd: Number(accruedPayoutUsd.toFixed(6)),
       },
       creators: creatorRows,
-      portalAccounts: portalAccountRows,
+      portalAccounts: enrichedPortalAccounts,
       works: workRows,
       licenseGrants: grantRows,
       chunks: chunkRows,

--- a/app/api/admin/source-protocol/portal-accounts/route.test.ts
+++ b/app/api/admin/source-protocol/portal-accounts/route.test.ts
@@ -1,0 +1,150 @@
+import { NextRequest } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  from: vi.fn(),
+  authResult: {
+    user: { id: '00000000-0000-4000-8000-000000000001' },
+    isAdmin: true,
+  } as any,
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: vi.fn(async () => mocks.authResult),
+  isAuthError: (result: any) => 'error' in result,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import { PATCH, POST } from './route'
+
+const creatorId = '10000000-0000-4000-8000-000000000001'
+const userId = '20000000-0000-4000-8000-000000000001'
+const accountId = '30000000-0000-4000-8000-000000000001'
+
+function request(method: 'POST' | 'PATCH', body: unknown) {
+  return new NextRequest('https://example.com/api/admin/source-protocol/portal-accounts', {
+    method,
+    headers: {
+      authorization: 'Bearer admin-token',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+function lookupQuery(data: unknown, error: unknown = null) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue({ data, error }),
+  }
+}
+
+describe('admin source protocol portal account route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.authResult = {
+      user: { id: '00000000-0000-4000-8000-000000000001' },
+      isAdmin: true,
+    }
+  })
+
+  it('rejects non-admin requests', async () => {
+    mocks.authResult = { error: 'Admin access required', status: 403 }
+
+    const response = await POST(request('POST', { creatorId, userId }))
+
+    expect(response.status).toBe(403)
+    expect(await response.json()).toEqual({ error: 'Admin access required' })
+    expect(mocks.from).not.toHaveBeenCalled()
+  })
+
+  it('creates or updates a creator portal link', async () => {
+    const upsert = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({
+          data: {
+            id: accountId,
+            creator_id: creatorId,
+            user_id: userId,
+            status: 'active',
+          },
+          error: null,
+        }),
+      }),
+    })
+
+    mocks.from.mockImplementation((table: string) => {
+      if (table === 'source_creator_portal_accounts') return { upsert }
+      return lookupQuery({ id: table === 'source_creators' ? creatorId : userId })
+    })
+
+    const response = await POST(request('POST', {
+      creatorId,
+      userId,
+      status: 'active',
+      canViewEarnings: true,
+      canViewReceipts: false,
+    }))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({ ok: true, account: { id: accountId, status: 'active' } })
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        creator_id: creatorId,
+        user_id: userId,
+        status: 'active',
+        can_view_earnings: true,
+        can_view_receipts: false,
+      }),
+      { onConflict: 'creator_id,user_id' }
+    )
+  })
+
+  it('updates portal link status and visibility', async () => {
+    const update = vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          maybeSingle: vi.fn().mockResolvedValue({
+            data: {
+              id: accountId,
+              status: 'suspended',
+              can_view_earnings: false,
+            },
+            error: null,
+          }),
+        }),
+      }),
+    })
+    mocks.from.mockReturnValue({ update })
+
+    const response = await PATCH(request('PATCH', {
+      accountId,
+      status: 'suspended',
+      canViewEarnings: false,
+    }))
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({ ok: true, account: { id: accountId, status: 'suspended' } })
+    expect(update).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'suspended',
+      can_view_earnings: false,
+    }))
+  })
+
+  it('validates UUID inputs', async () => {
+    const response = await POST(request('POST', {
+      creatorId: 'bad',
+      userId,
+    }))
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'creatorId and userId must be valid UUIDs' })
+  })
+})

--- a/app/api/admin/source-protocol/portal-accounts/route.ts
+++ b/app/api/admin/source-protocol/portal-accounts/route.ts
@@ -1,0 +1,179 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { supabaseAdmin } from '@/lib/supabase'
+
+export const dynamic = 'force-dynamic'
+
+const STATUSES = ['pending', 'active', 'suspended', 'revoked'] as const
+type PortalStatus = (typeof STATUSES)[number]
+
+function isMissingSourceProtocolSchema(error: { code?: string; message?: string } | null | undefined): boolean {
+  if (!error) return false
+  const message = error.message?.toLowerCase() ?? ''
+  return (
+    error.code === '42P01' ||
+    message.includes('source_creator_portal_accounts') ||
+    (message.includes('relation') && message.includes('does not exist'))
+  )
+}
+
+function isUuid(value: unknown): value is string {
+  return typeof value === 'string' && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)
+}
+
+function isStatus(value: unknown): value is PortalStatus {
+  return typeof value === 'string' && STATUSES.includes(value as PortalStatus)
+}
+
+function boolOrDefault(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback
+}
+
+async function ensureCreatorAndUser(creatorId: string, userId: string) {
+  const [creatorResult, userResult] = await Promise.all([
+    supabaseAdmin
+      .from('source_creators')
+      .select('id')
+      .eq('id', creatorId)
+      .maybeSingle(),
+    supabaseAdmin
+      .from('user_profiles')
+      .select('id')
+      .eq('id', userId)
+      .maybeSingle(),
+  ])
+
+  if (creatorResult.error) throw creatorResult.error
+  if (userResult.error) throw userResult.error
+  if (!creatorResult.data) return 'Creator not found'
+  if (!userResult.data) return 'User not found'
+  return null
+}
+
+function selectAccount() {
+  return 'id, creator_id, user_id, status, can_view_earnings, can_view_receipts, invited_by, invited_at, accepted_at, created_at, updated_at'
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  if (!supabaseAdmin) {
+    return NextResponse.json({ error: 'Supabase admin client unavailable' }, { status: 500 })
+  }
+
+  try {
+    const body = await request.json()
+    const creatorId = body.creatorId
+    const userId = body.userId
+    const status = isStatus(body.status) ? body.status : 'active'
+
+    if (!isUuid(creatorId) || !isUuid(userId)) {
+      return NextResponse.json({ error: 'creatorId and userId must be valid UUIDs' }, { status: 400 })
+    }
+
+    const missing = await ensureCreatorAndUser(creatorId, userId)
+    if (missing) return NextResponse.json({ error: missing }, { status: 404 })
+
+    const now = new Date().toISOString()
+    const row = {
+      creator_id: creatorId,
+      user_id: userId,
+      status,
+      can_view_earnings: boolOrDefault(body.canViewEarnings, true),
+      can_view_receipts: boolOrDefault(body.canViewReceipts, true),
+      invited_by: auth.user.id,
+      invited_at: now,
+      accepted_at: status === 'active' ? now : null,
+    }
+
+    const { data, error } = await supabaseAdmin
+      .from('source_creator_portal_accounts')
+      .upsert(row, { onConflict: 'creator_id,user_id' })
+      .select(selectAccount())
+      .single()
+
+    if (error) throw error
+
+    return NextResponse.json({ ok: true, account: data })
+  } catch (error: any) {
+    if (isMissingSourceProtocolSchema(error)) {
+      return NextResponse.json(
+        {
+          error: 'Source protocol creator portal schema has not been applied in this environment.',
+          migration: 'supabase/migrations/20260504092130_source_protocol_creator_portal.sql',
+        },
+        { status: 409 }
+      )
+    }
+
+    return NextResponse.json(
+      { error: error?.message ?? 'Failed to create portal account' },
+      { status: 500 }
+    )
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  if (!supabaseAdmin) {
+    return NextResponse.json({ error: 'Supabase admin client unavailable' }, { status: 500 })
+  }
+
+  try {
+    const body = await request.json()
+    const accountId = body.accountId
+
+    if (!isUuid(accountId)) {
+      return NextResponse.json({ error: 'accountId must be a valid UUID' }, { status: 400 })
+    }
+
+    const update: Record<string, unknown> = {}
+    if (body.status !== undefined) {
+      if (!isStatus(body.status)) {
+        return NextResponse.json({ error: 'Invalid portal account status' }, { status: 400 })
+      }
+      update.status = body.status
+      if (body.status === 'active') update.accepted_at = new Date().toISOString()
+    }
+    if (body.canViewEarnings !== undefined) update.can_view_earnings = boolOrDefault(body.canViewEarnings, true)
+    if (body.canViewReceipts !== undefined) update.can_view_receipts = boolOrDefault(body.canViewReceipts, true)
+
+    if (Object.keys(update).length === 0) {
+      return NextResponse.json({ error: 'No valid fields to update' }, { status: 400 })
+    }
+
+    const { data, error } = await supabaseAdmin
+      .from('source_creator_portal_accounts')
+      .update(update)
+      .eq('id', accountId)
+      .select(selectAccount())
+      .maybeSingle()
+
+    if (error) throw error
+    if (!data) return NextResponse.json({ error: 'Portal account not found' }, { status: 404 })
+
+    return NextResponse.json({ ok: true, account: data })
+  } catch (error: any) {
+    if (isMissingSourceProtocolSchema(error)) {
+      return NextResponse.json(
+        {
+          error: 'Source protocol creator portal schema has not been applied in this environment.',
+          migration: 'supabase/migrations/20260504092130_source_protocol_creator_portal.sql',
+        },
+        { status: 409 }
+      )
+    }
+
+    return NextResponse.json(
+      { error: error?.message ?? 'Failed to update portal account' },
+      { status: 500 }
+    )
+  }
+}

--- a/docs/source-respecting-llm-protocol.md
+++ b/docs/source-respecting-llm-protocol.md
@@ -118,6 +118,8 @@ Creator portal foundation:
 - `source_creator_portal_accounts` links an authenticated user to a creator profile. Access is explicit and admin-controlled; the protocol does not infer account ownership from names, emails, or public metadata.
 - `GET /api/source-protocol/creator/statement` returns the signed-in creator's read-only statement: works, active grants, retrievable chunks, attributed receipt rows, monthly payout rows, and dispute/support rows.
 - `/creator/source-protocol` projects that statement for nontechnical creators. It does not approve payouts, change licenses, ingest work, open disputes, or revoke grants.
+- `/admin/source-protocol` includes a `Portal Access` tab for admins to link a creator profile to an authenticated user account, set earnings/receipt visibility, and suspend or revoke portal access.
+- `POST/PATCH /api/admin/source-protocol/portal-accounts` are admin-only account-linking routes. They do not create creators, users, works, grants, receipts, disputes, or payouts.
 
 Smoke test:
 


### PR DESCRIPTION
## Summary
- add admin-only Source Protocol portal account POST/PATCH routes
- add a Portal Access tab for linking creator profiles to signed-in users and managing status/visibility
- enrich admin overview portal rows with user and creator display metadata
- document the new admin portal access workflow

## Validation
- npm test -- app/api/admin/source-protocol/portal-accounts/route.test.ts app/admin/source-protocol/page.test.tsx app/api/source-protocol/creator/statement/route.test.ts app/creator/source-protocol/page.test.tsx lib/source-respecting-llm-protocol.test.ts lib/source-respecting-llm-persistence.test.ts
- npx tsc --noEmit --pretty false
- npm run lint -- --dir app/admin/source-protocol --dir app/api/admin/source-protocol --dir app/creator/source-protocol --dir app/api/source-protocol
- git diff --check
- npm run build
- pre-push database health check passed