### PR TITLE
feat: route Chief of Staff through agent org

### DIFF
--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -272,12 +272,12 @@ export default function AgentOperationsPage() {
                 <div>
                   <div className="flex items-center gap-2 text-radiant-gold mb-2">
                     <MessageSquare size={20} />
-                    <h2 className="text-lg font-semibold">Chief of Staff Chat</h2>
-                  </div>
-                  <p className="text-sm text-muted-foreground">
-                    Ask for priorities, blockers, approval risk, and next actions from the agent operating context.
-                  </p>
+                  <h2 className="text-lg font-semibold">Chief of Staff Chat</h2>
                 </div>
+                <p className="text-sm text-muted-foreground">
+                    Use the front-door router for priorities, blockers, approval risk, and which agent should handle the next step.
+                </p>
+              </div>
                 <ArrowRight size={20} className="text-muted-foreground shrink-0" />
               </div>
             </Link>
@@ -390,10 +390,10 @@ export default function AgentOperationsPage() {
               <div>
                 <div className="flex items-center gap-2 text-radiant-gold mb-2">
                   <CalendarCheck size={20} />
-                  <h2 className="text-lg font-semibold">Agent Engagement</h2>
+                  <h2 className="text-lg font-semibold">Production Engagement Paths</h2>
                 </div>
                 <p className="text-sm text-muted-foreground max-w-3xl">
-                  Operational roster for the agents that are ready to run, where to engage them, and what approval gates apply.
+                  Current callable surfaces that already create traces, reviews, or workflow handoffs. Use Chief of Staff Chat when you want routing instead of choosing a path manually.
                 </p>
               </div>
               <div className="flex flex-wrap items-center gap-2">
@@ -479,7 +479,7 @@ export default function AgentOperationsPage() {
               <h2 className="text-lg font-semibold">Agent Organization Map</h2>
             </div>
             <p className="text-sm text-muted-foreground max-w-3xl">
-              Maps the target agent organization to the n8n workflow families currently wired into the operating system.
+              Target operating model for the agent organization. Each card describes the role, maturity, primary runtime, and mapped n8n workflow coverage. This is the org chart; the Production Engagement Paths above are the current ways to invoke work.
             </p>
             {engagementError ? <p className="mt-3 text-sm text-red-300">{engagementError}</p> : null}
             {engagementStatusLoading ? (

--- a/lib/chief-of-staff-chat.test.ts
+++ b/lib/chief-of-staff-chat.test.ts
@@ -18,6 +18,7 @@ vi.mock('@/lib/supabase', () => ({
 
 import {
   buildChiefOfStaffPrompt,
+  getChiefOfStaffAgentRoutingCatalog,
   normalizeChiefOfStaffHistory,
   parseChiefOfStaffJson,
   summarizeAutomationContext,
@@ -27,6 +28,7 @@ import type { CodexAutomationInventory } from './codex-automation-inventory'
 
 const context: ChiefOfStaffContext = {
   generatedAt: '2026-05-02T12:00:00.000Z',
+  agentRoutingCatalog: getChiefOfStaffAgentRoutingCatalog(),
   activeRuns: [
     {
       id: 'run-1',
@@ -157,12 +159,36 @@ describe('Chief of Staff chat helpers', () => {
 
     expect(prompt.systemPrompt).toContain('production mutations')
     expect(prompt.systemPrompt).toContain('Automation context')
+    expect(prompt.systemPrompt).toContain('front-door router')
     expect(prompt.systemPrompt).toContain('Return JSON only')
     expect(prompt.systemPrompt).toContain('action_proposals')
     expect(prompt.systemPrompt).toContain('agent_engagements')
+    expect(prompt.systemPrompt).toContain('strategic-narrative')
+    expect(prompt.systemPrompt).toContain('course-curriculum-builder')
     expect(prompt.userPrompt).toContain('Morning review')
+    expect(prompt.userPrompt).toContain('agentRoutingCatalog')
+    expect(prompt.userPrompt).toContain('Strategy & Narrative Pod')
     expect(prompt.userPrompt).toContain('Portfolio Credential Rotation Due Report')
     expect(prompt.userPrompt).toContain('What needs attention?')
+  })
+
+  it('keeps the Chief of Staff router aligned to the agent organization map', () => {
+    const catalog = getChiefOfStaffAgentRoutingCatalog()
+
+    expect(catalog.length).toBeGreaterThan(10)
+    expect(catalog.map((agent) => agent.key)).toEqual(expect.arrayContaining([
+      'chief-of-staff',
+      'strategic-narrative',
+      'research-source-register',
+      'voice-content-architect',
+      'automation-systems',
+      'inbox-follow-up',
+    ]))
+    expect(catalog.find((agent) => agent.key === 'automation-systems')).toMatchObject({
+      pod: 'Product & Automation Pod',
+      status: 'active',
+      primaryRuntime: 'n8n',
+    })
   })
 
   it('summarizes automation context without raw prompt excerpts', () => {

--- a/lib/chief-of-staff-chat.ts
+++ b/lib/chief-of-staff-chat.ts
@@ -11,7 +11,7 @@ import {
   getApprovalGate,
   type AgentAction,
 } from '@/lib/agent-policy'
-import { getAgentByKey } from '@/lib/agent-organization'
+import { AGENT_ORGANIZATION, AGENT_PODS, getAgentByKey } from '@/lib/agent-organization'
 import {
   listCodexAutomationInventory,
   type CodexAutomationInventory,
@@ -113,6 +113,7 @@ export type ChiefOfStaffAutomationContext = {
 
 export type ChiefOfStaffContext = {
   generatedAt: string
+  agentRoutingCatalog: ChiefOfStaffAgentRoutingEntry[]
   activeRuns: AgentRunSummaryRow[]
   recentFailures: AgentRunSummaryRow[]
   pendingApprovals: AgentApprovalSummaryRow[]
@@ -123,6 +124,18 @@ export type ChiefOfStaffContext = {
     models: string[]
   }
   automationContext: ChiefOfStaffAutomationContext
+}
+
+export type ChiefOfStaffAgentRoutingEntry = {
+  key: string
+  name: string
+  pod: string
+  status: 'active' | 'partial' | 'planned'
+  primaryRuntime: string
+  responsibility: string
+  engagementPath: string
+  approvalGate: string
+  activeWorkflowCount: number
 }
 
 const DEFAULT_MODEL = 'gpt-4o-mini'
@@ -148,6 +161,20 @@ function assertDatabase() {
     throw new Error('Database not available')
   }
   return supabaseAdmin
+}
+
+export function getChiefOfStaffAgentRoutingCatalog(): ChiefOfStaffAgentRoutingEntry[] {
+  return AGENT_ORGANIZATION.map((agent) => ({
+    key: agent.key,
+    name: agent.name,
+    pod: AGENT_PODS.find((pod) => pod.key === agent.podKey)?.name ?? agent.podKey,
+    status: agent.status,
+    primaryRuntime: agent.primaryRuntime,
+    responsibility: agent.responsibility,
+    engagementPath: agent.engagementPath,
+    approvalGate: agent.approvalGate,
+    activeWorkflowCount: agent.n8nWorkflows.filter((workflow) => workflow.active).length,
+  }))
 }
 
 export function normalizeChiefOfStaffHistory(
@@ -383,6 +410,7 @@ export async function collectChiefOfStaffContext(): Promise<ChiefOfStaffContext>
 
   return {
     generatedAt: new Date().toISOString(),
+    agentRoutingCatalog: getChiefOfStaffAgentRoutingCatalog(),
     activeRuns: (activeRes.data ?? []) as AgentRunSummaryRow[],
     recentFailures: (failedRes.data ?? []) as AgentRunSummaryRow[],
     pendingApprovals: (approvalsRes.data ?? []) as AgentApprovalSummaryRow[],
@@ -397,6 +425,8 @@ export async function collectChiefOfStaffContext(): Promise<ChiefOfStaffContext>
 }
 
 export function buildChiefOfStaffPrompt(context: ChiefOfStaffContext, history: ChiefOfStaffChatMessage[]) {
+  const agentKeys = context.agentRoutingCatalog.map((agent) => agent.key)
+
   return {
     systemPrompt: [
       'You are the Chief of Staff Agent for Vambah and AmaduTown.',
@@ -405,9 +435,12 @@ export function buildChiefOfStaffPrompt(context: ChiefOfStaffContext, history: C
       'Be concise, direct, and operational. Do not pretend to have run tools that are not in the context.',
       'Automation context is a summarized, read-only inventory. Use it to identify risky automations, missing context, duplicate jobs, and when the Automation Systems Agent should be engaged.',
       'When proposing an executable next step, include a typed action proposal. The proposal is only a recommendation; it does not execute work.',
+      'You are the front-door router for the agent organization. When the user asks who should handle work, choose the best mapped agent from the routing catalog.',
       'When the next step should be handled by one of the mapped agents, include an agent_engagements proposal with the exact agent_key.',
+      'Prefer active or partial agents for immediate read-only engagement. Planned agents can be recommended, but label them as queued for review in your reply.',
+      'If several agents could help, pick one primary next agent and at most two supporting agents.',
       'Use only these action ids: read_files, write_files, external_api_call, client_data_access, known_workflow_db_write, unknown_db_write, publish_public_content, send_email, production_config_change, public_content_from_private_material.',
-      'Use only these agent keys when recommending an agent engagement: chief-of-staff, research-source-register, private-knowledge-librarian, voice-content-architect, content-repurposing, engineering-copilot, automation-systems, agent-tooling-parity, website-product-copy, inbox-follow-up.',
+      `Use only these agent keys when recommending an agent engagement: ${agentKeys.join(', ')}.`,
       'Return JSON only with keys: reply, suggested_actions, action_proposals, agent_engagements.',
     ].join('\n'),
     userPrompt: JSON.stringify(


### PR DESCRIPTION
## Summary
- make the Chief of Staff router load its agent routing catalog from the canonical agent organization map
- include pod, runtime, status, engagement path, approval gate, and active workflow count in the operating context
- update the routing prompt so Chief of Staff can route to every mapped agent instead of a stale hard-coded subset
- add tests to keep the router aligned with the agent organization map

## Validation
- npm test -- lib/chief-of-staff-chat.test.ts app/api/admin/agents/chief-of-staff/chat/route.test.ts lib/agent-organization.test.ts
- npx tsc --noEmit --pretty false
- npm run lint
- npm run build
- pre-push db:health-check

Note: build emits the existing dev warning about MOCK_N8N=false and N8N_DISABLE_OUTBOUND=false, then completes successfully.