### PR TITLE
feat: add Agent Ops daily command room

### DIFF
--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -10,6 +10,7 @@ import {
   Bot,
   CheckCircle2,
   CircleDollarSign,
+  ClipboardList,
   Clock3,
   MessageSquare,
   Network,
@@ -76,6 +77,27 @@ type MissionSnapshot = {
     occurred_at: string
   }>
   latest_standup: MissionRun | null
+  daily_brief: {
+    headline: string
+    synthesis: string
+    generated_from: 'standup' | 'current_state'
+    run_id: string | null
+    updated_at: string
+    signals: string[]
+    next_actions: string[]
+  }
+  agent_inbox: Array<{
+    id: string
+    priority: 'high' | 'medium' | 'low'
+    agent_key: string
+    agent_name: string
+    pod: string
+    title: string
+    reason: string
+    action_label: string
+    href: string
+    source_run_id: string | null
+  }>
 }
 
 type WarRoomResult = {
@@ -288,6 +310,8 @@ export default function AgentOperationsPage() {
             <MetricCard icon={<Users size={16} />} label="Agents" value={topAgents.length} />
           </section>
 
+          <DailyBriefPanel brief={snapshot?.daily_brief ?? null} loading={loading} />
+
           <section className="mt-5 grid grid-cols-1 gap-5 xl:grid-cols-[1.2fr_0.8fr]">
             <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/25 p-4">
               <div className="flex items-center gap-2 text-radiant-gold">
@@ -353,17 +377,17 @@ export default function AgentOperationsPage() {
             <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/25 p-4">
               <div className="flex items-center justify-between gap-3">
                 <div className="flex items-center gap-2 text-radiant-gold">
-                  <AlertTriangle size={18} />
-                  <h2 className="font-semibold">Attention Queue</h2>
+                  <ClipboardList size={18} />
+                  <h2 className="font-semibold">Agent Inbox</h2>
                 </div>
                 <Link href="/admin/agents/runs" className="text-xs text-radiant-gold hover:underline">Open all</Link>
               </div>
               <div className="mt-3 space-y-2">
-                {snapshot?.attention_queue.length ? snapshot.attention_queue.slice(0, 5).map((run) => (
-                  <RunRow key={run.id} run={run} />
+                {snapshot?.agent_inbox.length ? snapshot.agent_inbox.slice(0, 5).map((item) => (
+                  <InboxRow key={item.id} item={item} />
                 )) : (
                   <p className="rounded-lg border border-silicon-slate/50 bg-black/10 p-3 text-sm text-muted-foreground">
-                    No failed, stale, approval-waiting, or high-cost runs need attention.
+                    No agent inbox items need attention.
                   </p>
                 )}
               </div>
@@ -462,6 +486,54 @@ function MetricCard({ icon, label, value, tone = 'default' }: { icon: ReactNode;
   )
 }
 
+function DailyBriefPanel({ brief, loading }: { brief: MissionSnapshot['daily_brief'] | null; loading: boolean }) {
+  return (
+    <section className="mt-5 rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 text-radiant-gold">
+            <Sparkles size={18} />
+            <h2 className="font-semibold">Daily Operating Brief</h2>
+          </div>
+          <p className="mt-2 text-lg font-semibold">
+            {brief?.headline ?? (loading ? 'Loading today’s agent brief...' : 'Run a standup to create today’s operating brief')}
+          </p>
+          <p className="mt-2 max-w-4xl text-sm leading-6 text-muted-foreground">
+            {brief?.synthesis ?? 'Mission Control will summarize standups, blockers, approvals, cost, and next actions here.'}
+          </p>
+        </div>
+        <div className="flex shrink-0 flex-wrap gap-2">
+          <span className="rounded-full border border-silicon-slate/60 bg-black/10 px-2.5 py-1 text-xs text-muted-foreground">
+            {brief?.generated_from === 'standup' ? 'From latest standup' : 'From current traces'}
+          </span>
+          {brief?.run_id ? (
+            <Link href={`/admin/agents/runs/${brief.run_id}`} className="rounded-full border border-radiant-gold/50 bg-radiant-gold/10 px-2.5 py-1 text-xs text-radiant-gold hover:bg-radiant-gold/15">
+              Open brief trace
+            </Link>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="mt-4 grid grid-cols-1 gap-3 lg:grid-cols-[0.9fr_1.1fr]">
+        <div className="flex flex-wrap gap-2">
+          {(brief?.signals ?? ['0 active run(s)', '0 failed or stale run(s)', '0 pending approval(s)']).map((signal) => (
+            <span key={signal} className="rounded-full border border-silicon-slate/50 bg-black/10 px-2.5 py-1 text-xs text-muted-foreground">
+              {signal}
+            </span>
+          ))}
+        </div>
+        <div className="space-y-1">
+          {(brief?.next_actions ?? ['Run War Room standup.']).slice(0, 3).map((action) => (
+            <p key={action} className="text-sm text-muted-foreground">
+              {action}
+            </p>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
 function StatusPill({ status }: { status: 'active' | 'partial' | 'planned' }) {
   const className =
     status === 'active'
@@ -473,20 +545,37 @@ function StatusPill({ status }: { status: 'active' | 'partial' | 'planned' }) {
   return <span className={`rounded-full border px-2 py-0.5 text-xs ${className}`}>{status}</span>
 }
 
-function RunRow({ run }: { run: MissionRun }) {
+function InboxRow({ item }: { item: MissionSnapshot['agent_inbox'][number] }) {
   return (
-    <Link href={`/admin/agents/runs/${run.id}`} className="block rounded-lg border border-silicon-slate/50 bg-black/10 p-3 text-sm hover:border-radiant-gold/50">
+    <Link href={item.href} className="block rounded-lg border border-silicon-slate/50 bg-black/10 p-3 text-sm hover:border-radiant-gold/50">
       <div className="flex items-start justify-between gap-3">
-        <div>
-          <p className="font-medium">{run.title}</p>
-          <p className="mt-1 text-xs text-muted-foreground">{run.runtime} · {run.status.replace(/_/g, ' ')}</p>
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <PriorityPill priority={item.priority} />
+            <span className="text-xs text-muted-foreground">{item.agent_name}</span>
+          </div>
+          <p className="mt-2 font-medium">{item.title}</p>
+          <p className="mt-1 line-clamp-2 text-muted-foreground">{item.reason}</p>
+          <p className="mt-2 text-xs text-muted-foreground">{item.pod}</p>
         </div>
-        <ArrowRight size={16} className="shrink-0 text-muted-foreground" />
+        <div className="flex shrink-0 items-center gap-1 text-xs text-radiant-gold">
+          {item.action_label}
+          <ArrowRight size={14} />
+        </div>
       </div>
-      {run.current_step ? <p className="mt-2 text-muted-foreground">{run.current_step}</p> : null}
-      {run.error_message ? <p className="mt-2 text-red-200">{run.error_message}</p> : null}
     </Link>
   )
+}
+
+function PriorityPill({ priority }: { priority: 'high' | 'medium' | 'low' }) {
+  const className =
+    priority === 'high'
+      ? 'border-red-400/40 bg-red-500/10 text-red-200'
+      : priority === 'medium'
+        ? 'border-yellow-400/40 bg-yellow-500/10 text-yellow-200'
+        : 'border-silicon-slate/60 bg-black/20 text-muted-foreground'
+
+  return <span className={`rounded-full border px-2 py-0.5 text-xs ${className}`}>{priority}</span>
 }
 
 function ResultPanel({ title, href, body, items }: { title: string; href: string; body: string; items: string[] }) {

--- a/app/api/admin/agents/mission-control/route.test.ts
+++ b/app/api/admin/agents/mission-control/route.test.ts
@@ -45,6 +45,16 @@ describe('GET /api/admin/agents/mission-control', () => {
       active_runs: [],
       latest_events: [],
       latest_standup: null,
+      daily_brief: {
+        headline: 'Run a standup to create today’s operating brief',
+        synthesis: 'No urgent agent signals are visible.',
+        generated_from: 'current_state',
+        run_id: null,
+        updated_at: '2026-05-04T12:00:00.000Z',
+        signals: ['1 active run(s)', '0 failed or stale run(s)', '0 pending approval(s)', '$0.2500 cost today'],
+        next_actions: ['Run War Room standup.'],
+      },
+      agent_inbox: [],
       approvals: [],
     })
   })
@@ -71,6 +81,10 @@ describe('GET /api/admin/agents/mission-control', () => {
       running: 1,
       cost_today: 0.25,
     })
+    expect(body.daily_brief).toMatchObject({
+      generated_from: 'current_state',
+    })
+    expect(body.agent_inbox).toEqual([])
     expect(mocks.buildAgentMissionControlSnapshot).toHaveBeenCalledOnce()
   })
 

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -33,9 +33,10 @@ The Agent Operations console under `/admin/agents` is now a Mission Control over
 The first viewport should show:
 
 - status strip for active, running, approvals, failed, stale, cost today, and mapped agents,
+- daily operating brief synthesized from the latest standup when available, otherwise current trace state,
 - Chief of Staff command input,
 - War Room standup/discuss actions,
-- attention queue for approval-waiting, failed, stale, or high-cost runs,
+- Agent Inbox for approval-waiting, failed, stale, high-cost, and stale-standup actions,
 - compact agent roster grouped by active/partial status,
 - latest activity,
 - links to deeper run, automation, policy, and runtime controls.
@@ -199,7 +200,15 @@ Slack is an engagement surface, not the source of truth. The admin console and s
 
 ## Mission Control And War Room
 
-Mission Control uses `GET /api/admin/agents/mission-control` as a derived read model over existing tables. It does not introduce new schema in v1. The endpoint returns the status strip, agent roster, attention queue, active runs, latest events, pending approvals, and latest standup trace.
+Mission Control uses `GET /api/admin/agents/mission-control` as a derived read model over existing tables. It does not introduce new schema in v1. The endpoint returns the status strip, agent roster, attention queue, Agent Inbox, Daily Operating Brief, active runs, latest events, pending approvals, and latest standup trace.
+
+The Daily Operating Brief and Agent Inbox are derived views, not new persistence:
+
+- latest completed War Room standup outcome becomes the brief synthesis when present,
+- if no recent standup exists, the brief falls back to current run, approval, cost, and stale-status signals,
+- Agent Inbox points each actionable item to its owning agent and trace,
+- pending approvals are represented once through `agent_approvals` instead of duplicating the waiting run,
+- stale standup reminders route back to Mission Control so the Chief of Staff can refresh the daily operating view.
 
 War Room uses `POST /api/admin/agents/war-room` with `{ command: 'standup' | 'discuss', message?: string }`.
 

--- a/lib/agent-mission-control.test.ts
+++ b/lib/agent-mission-control.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: null,
+}))
+
+import { buildAgentInbox, buildDailyOperatingBrief } from '@/lib/agent-mission-control'
+
+type InboxInput = Parameters<typeof buildAgentInbox>[0]
+type MissionRunRow = InboxInput['runs'][number]
+type ApprovalRow = InboxInput['approvals'][number]
+
+const now = '2026-05-04T12:00:00.000Z'
+
+function run(overrides: Partial<MissionRunRow>): MissionRunRow {
+  return {
+    id: 'run-1',
+    agent_key: 'chief-of-staff',
+    runtime: 'manual',
+    kind: 'agent_task',
+    title: 'Agent task',
+    status: 'completed',
+    subject_label: null,
+    current_step: null,
+    error_message: null,
+    started_at: now,
+    completed_at: now,
+    outcome: null,
+    metadata: null,
+    ...overrides,
+  }
+}
+
+function approval(overrides: Partial<ApprovalRow>): ApprovalRow {
+  return {
+    id: 'approval-1',
+    run_id: 'approval-run',
+    approval_type: 'send_email',
+    status: 'pending',
+    requested_at: now,
+    ...overrides,
+  }
+}
+
+describe('Agent Mission Control helpers', () => {
+  it('uses the latest standup synthesis as the daily operating brief', () => {
+    const latestStandup = run({
+      id: 'standup-run',
+      kind: 'agent_war_room_standup',
+      outcome: {
+        synthesis: 'Standup complete. Automation is clear, but follow-up needs review.',
+      },
+    })
+
+    const brief = buildDailyOperatingBrief({
+      approvals: [],
+      costToday: 0.1234,
+      latestStandup,
+      inbox: [],
+      activeRunsCount: 0,
+      failedRunsCount: 0,
+    })
+
+    expect(brief.generated_from).toBe('standup')
+    expect(brief.run_id).toBe('standup-run')
+    expect(brief.synthesis).toContain('Automation is clear')
+    expect(brief.signals).toContain('$0.1234 cost today')
+  })
+
+  it('builds an actionable inbox from approvals, failed runs, stale runs, high-cost runs, and stale standups', () => {
+    const failedRun = run({
+      id: 'failed-run',
+      agent_key: 'automation-systems',
+      status: 'failed',
+      title: 'Automation dispatch',
+      error_message: 'Webhook returned 500.',
+    })
+    const staleRun = run({
+      id: 'stale-run',
+      agent_key: 'chief-of-staff',
+      status: 'stale',
+      title: 'Morning review',
+      current_step: 'Waiting on runtime callback.',
+    })
+    const expensiveRun = run({
+      id: 'expensive-run',
+      agent_key: 'research-source-register',
+      status: 'completed',
+      title: 'Deep account research',
+    })
+    const approvalRun = run({
+      id: 'approval-run',
+      agent_key: 'inbox-follow-up',
+      status: 'waiting_for_approval',
+      title: 'Send follow-up email',
+    })
+
+    const inbox = buildAgentInbox({
+      runs: [failedRun, staleRun, expensiveRun, approvalRun],
+      approvals: [approval({ run_id: 'approval-run' })],
+      costByRun: new Map([['expensive-run', 0.31]]),
+      latestStandup: undefined,
+    })
+
+    expect(inbox.map((item) => item.title)).toEqual(expect.arrayContaining([
+      'Approval checkpoint: Send follow-up email',
+      'Failure needs triage: Automation dispatch',
+      'Stale run needs owner: Morning review',
+      'Cost review: Deep account research',
+      'No War Room standup yet',
+    ]))
+    expect(inbox.filter((item) => item.source_run_id === 'approval-run')).toHaveLength(1)
+    expect(inbox[0].priority).toBe('high')
+  })
+})

--- a/lib/agent-mission-control.ts
+++ b/lib/agent-mission-control.ts
@@ -13,6 +13,7 @@ type AgentRunRow = {
   error_message: string | null
   started_at: string
   completed_at: string | null
+  outcome: Record<string, unknown> | null
   metadata: Record<string, unknown> | null
 }
 
@@ -39,6 +40,29 @@ type EventRow = {
 }
 
 export type AgentMissionControlSnapshot = Awaited<ReturnType<typeof buildAgentMissionControlSnapshot>>
+
+export type AgentInboxItem = {
+  id: string
+  priority: 'high' | 'medium' | 'low'
+  agent_key: string
+  agent_name: string
+  pod: string
+  title: string
+  reason: string
+  action_label: string
+  href: string
+  source_run_id: string | null
+}
+
+export type DailyOperatingBrief = {
+  headline: string
+  synthesis: string
+  generated_from: 'standup' | 'current_state'
+  run_id: string | null
+  updated_at: string
+  signals: string[]
+  next_actions: string[]
+}
 
 function sinceHours(hours: number) {
   return new Date(Date.now() - hours * 60 * 60 * 1000).toISOString()
@@ -76,6 +100,160 @@ function summarizeRun(run: AgentRunRow, costByRun: Map<string, number>) {
   }
 }
 
+function findAgent(agentKey: string | null | undefined) {
+  return AGENT_ORGANIZATION.find((agent) => agent.key === agentKey) ?? AGENT_ORGANIZATION.find((agent) => agent.key === 'chief-of-staff')
+}
+
+function inboxItemForRun(run: AgentRunRow, costByRun: Map<string, number>): AgentInboxItem {
+  const agent = findAgent(run.agent_key ?? (typeof run.metadata?.requested_agent === 'string' ? run.metadata.requested_agent : null))
+  const cost = costByRun.get(run.id) ?? 0
+  const priority: AgentInboxItem['priority'] =
+    run.status === 'failed' || run.status === 'waiting_for_approval'
+      ? 'high'
+      : run.status === 'stale' || cost >= 0.25
+        ? 'medium'
+        : 'low'
+
+  const title =
+    run.status === 'waiting_for_approval'
+      ? `Approval needed: ${run.title}`
+      : run.status === 'failed'
+        ? `Failure needs triage: ${run.title}`
+        : run.status === 'stale'
+          ? `Stale run needs owner: ${run.title}`
+          : cost >= 0.25
+            ? `Cost review: ${run.title}`
+            : run.title
+
+  return {
+    id: `${run.id}:${run.status}`,
+    priority,
+    agent_key: agent?.key ?? 'chief-of-staff',
+    agent_name: agent?.name ?? 'Chief of Staff Agent',
+    pod: agent ? agentPodName(agent.podKey) : 'Chief of Staff',
+    title,
+    reason: run.error_message ?? run.current_step ?? `${run.runtime} run is ${run.status.replace(/_/g, ' ')}.`,
+    action_label: run.status === 'waiting_for_approval'
+      ? 'Review approval'
+      : run.status === 'failed' || run.status === 'stale'
+        ? 'Open trace'
+        : 'Review signal',
+    href: `/admin/agents/runs/${run.id}`,
+    source_run_id: run.id,
+  }
+}
+
+function inboxItemForApproval(approval: ApprovalRow, runsById: Map<string, AgentRunRow>): AgentInboxItem {
+  const run = runsById.get(approval.run_id)
+  const agent = findAgent(run?.agent_key)
+  return {
+    id: `${approval.id}:approval`,
+    priority: 'high',
+    agent_key: agent?.key ?? 'chief-of-staff',
+    agent_name: agent?.name ?? 'Chief of Staff Agent',
+    pod: agent ? agentPodName(agent.podKey) : 'Chief of Staff',
+    title: `Approval checkpoint: ${run?.title ?? approval.approval_type}`,
+    reason: `${approval.approval_type.replace(/_/g, ' ')} is pending.`,
+    action_label: 'Review approval',
+    href: `/admin/agents/runs/${approval.run_id}`,
+    source_run_id: approval.run_id,
+  }
+}
+
+export function buildAgentInbox(input: {
+  runs: AgentRunRow[]
+  approvals: ApprovalRow[]
+  costByRun: Map<string, number>
+  latestStandup: AgentRunRow | undefined
+}): AgentInboxItem[] {
+  const runsById = new Map(input.runs.map((run) => [run.id, run]))
+  const pendingApprovalRunIds = new Set(input.approvals.map((approval) => approval.run_id))
+  const failedRuns = input.runs.filter((run) => run.status === 'failed' || run.status === 'stale')
+  const approvalItems = input.approvals.map((approval) => inboxItemForApproval(approval, runsById))
+  const runItems = input.runs
+    .filter((run) =>
+      (run.status === 'waiting_for_approval' && !pendingApprovalRunIds.has(run.id)) ||
+      run.status === 'failed' ||
+      run.status === 'stale' ||
+      (input.costByRun.get(run.id) ?? 0) >= 0.25,
+    )
+    .map((run) => inboxItemForRun(run, input.costByRun))
+
+  const staleStandup =
+    !input.latestStandup ||
+    Date.now() - new Date(input.latestStandup.started_at).getTime() > 20 * 60 * 60 * 1000
+
+  const standupItem: AgentInboxItem | null = staleStandup
+    ? {
+        id: 'chief-of-staff:standup',
+        priority: failedRuns.length || input.approvals.length ? 'medium' : 'low',
+        agent_key: 'chief-of-staff',
+        agent_name: 'Chief of Staff Agent',
+        pod: 'Chief of Staff',
+        title: input.latestStandup ? 'Standup is stale' : 'No War Room standup yet',
+        reason: 'Run a standup to turn current signals into an operating brief.',
+        action_label: 'Run standup',
+        href: '/admin/agents',
+        source_run_id: input.latestStandup?.id ?? null,
+      }
+    : null
+
+  const priorityRank = { high: 0, medium: 1, low: 2 }
+  return [...approvalItems, ...runItems, ...(standupItem ? [standupItem] : [])]
+    .filter((item, index, list) => list.findIndex((candidate) => candidate.id === item.id) === index)
+    .sort((a, b) => priorityRank[a.priority] - priorityRank[b.priority])
+    .slice(0, 8)
+}
+
+export function buildDailyOperatingBrief(input: {
+  approvals: ApprovalRow[]
+  costToday: number
+  latestStandup: AgentRunRow | undefined
+  inbox: AgentInboxItem[]
+  activeRunsCount: number
+  failedRunsCount: number
+}): DailyOperatingBrief {
+  const standupSynthesis =
+    typeof input.latestStandup?.outcome?.synthesis === 'string'
+      ? input.latestStandup.outcome.synthesis
+      : null
+  const highPriorityCount = input.inbox.filter((item) => item.priority === 'high').length
+  const signals = [
+    `${input.activeRunsCount} active run(s)`,
+    `${input.failedRunsCount} failed or stale run(s)`,
+    `${input.approvals.length} pending approval(s)`,
+    `$${input.costToday.toFixed(4)} cost today`,
+  ]
+
+  if (standupSynthesis && input.latestStandup) {
+    return {
+      headline: highPriorityCount ? `${highPriorityCount} high-priority item(s) need attention` : 'Agent system is in reviewable shape',
+      synthesis: standupSynthesis,
+      generated_from: 'standup',
+      run_id: input.latestStandup.id,
+      updated_at: input.latestStandup.completed_at ?? input.latestStandup.started_at,
+      signals,
+      next_actions: input.inbox.length
+        ? input.inbox.slice(0, 3).map((item) => `${item.agent_name}: ${item.title}`)
+        : ['Use Chief of Staff Command for the next assignment.'],
+    }
+  }
+
+  return {
+    headline: highPriorityCount ? `${highPriorityCount} high-priority item(s) need attention` : 'Run a standup to create today’s operating brief',
+    synthesis: input.inbox.length
+      ? 'Mission Control has enough trace data to identify the next queue. Run a standup when you want a synthesized daily operating brief.'
+      : 'No urgent agent signals are visible. Run a standup to establish the next operating brief.',
+    generated_from: 'current_state',
+    run_id: null,
+    updated_at: new Date().toISOString(),
+    signals,
+    next_actions: input.inbox.length
+      ? input.inbox.slice(0, 3).map((item) => `${item.agent_name}: ${item.title}`)
+      : ['Run War Room standup.', 'Use Chief of Staff Command for the next assignment.'],
+  }
+}
+
 export async function buildAgentMissionControlSnapshot() {
   const db = assertDatabase()
   const since = sinceHours(24)
@@ -83,7 +261,7 @@ export async function buildAgentMissionControlSnapshot() {
   const [runsRes, costsRes, approvalsRes, eventsRes] = await Promise.all([
     db
       .from('agent_runs')
-      .select('id, agent_key, runtime, kind, title, status, subject_label, current_step, error_message, started_at, completed_at, metadata')
+      .select('id, agent_key, runtime, kind, title, status, subject_label, current_step, error_message, started_at, completed_at, outcome, metadata')
       .order('started_at', { ascending: false })
       .limit(50),
     db
@@ -138,6 +316,19 @@ export async function buildAgentMissionControlSnapshot() {
     .map((run) => summarizeRun(run, costByRun))
 
   const latestStandup = runs.find((run) => run.kind === 'agent_war_room_standup')
+  const latestStandupBrief = runs.find(
+    (run) => run.kind === 'agent_war_room_standup' && typeof run.outcome?.synthesis === 'string',
+  )
+  const agentInbox = buildAgentInbox({ runs, approvals, costByRun, latestStandup })
+  const costToday = Number(costs.reduce((sum, row) => sum + Number(row.amount ?? 0), 0).toFixed(4))
+  const dailyBrief = buildDailyOperatingBrief({
+    approvals,
+    costToday,
+    latestStandup: latestStandupBrief,
+    inbox: agentInbox,
+    activeRunsCount: activeRuns.length,
+    failedRunsCount: failedRuns.length,
+  })
 
   return {
     generated_at: new Date().toISOString(),
@@ -148,7 +339,7 @@ export async function buildAgentMissionControlSnapshot() {
       waiting_for_approval: countByStatus(runs, 'waiting_for_approval'),
       failed: countByStatus(runs, 'failed'),
       stale: countByStatus(runs, 'stale'),
-      cost_today: Number(costs.reduce((sum, row) => sum + Number(row.amount ?? 0), 0).toFixed(4)),
+      cost_today: costToday,
       pending_approvals: approvals.length,
     },
     roster: AGENT_PODS.map((pod) => {
@@ -180,6 +371,8 @@ export async function buildAgentMissionControlSnapshot() {
     active_runs: activeRuns.slice(0, 8).map((run) => summarizeRun(run, costByRun)),
     latest_events: events,
     latest_standup: latestStandup ? summarizeRun(latestStandup, costByRun) : null,
+    daily_brief: dailyBrief,
+    agent_inbox: agentInbox,
     approvals: approvals.slice(0, 8),
   }
 }


### PR DESCRIPTION
## Summary
- add Daily Operating Brief and Agent Inbox derived from Agent Ops trace data
- surface the new command-room panels on /admin/agents without adding schema
- document Mission Control brief/inbox behavior and add helper/API coverage

## Validation
- npm test -- lib/agent-mission-control.test.ts app/api/admin/agents/mission-control/route.test.ts
- npm test -- lib/agent-mission-control.test.ts app/api/admin/agents/mission-control/route.test.ts lib/agent-war-room.test.ts app/api/admin/agents/war-room/route.test.ts lib/agent-slack-command.test.ts app/api/slack/agent/route.test.ts
- npx tsc --noEmit --pretty false
- npm run build
- git diff --check

## Notes
- Build passed with the existing dev-env warning that MOCK_N8N=false and N8N_DISABLE_OUTBOUND=false.
- Integration Captain should own merge and deployment verification.