### PR TITLE
feat: route Agent Inbox items

### DIFF
--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -141,6 +141,7 @@ export default function AgentOperationsPage() {
   const [warRoomResult, setWarRoomResult] = useState<WarRoomResult | null>(null)
   const [actionLoading, setActionLoading] = useState<string | null>(null)
   const [actionResult, setActionResult] = useState<{ label: string; runId: string } | null>(null)
+  const [inboxRoutingId, setInboxRoutingId] = useState<string | null>(null)
 
   const authedFetch = useCallback(async (path: string, init: RequestInit = {}) => {
     const session = await getCurrentSession()
@@ -256,6 +257,26 @@ export default function AgentOperationsPage() {
       setError(err instanceof Error ? err.message : `${kind} failed`)
     } finally {
       setActionLoading(null)
+    }
+  }
+
+  async function routeInboxItem(item: MissionSnapshot['agent_inbox'][number]) {
+    setInboxRoutingId(item.id)
+    setActionResult(null)
+    setError(null)
+    try {
+      const response = await authedFetch('/api/admin/agents/inbox', {
+        method: 'POST',
+        body: JSON.stringify({ item_id: item.id }),
+      })
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`)
+      setActionResult({ label: `routed ${item.agent_name}`, runId: body.run_id })
+      await loadMissionControl()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Agent Inbox routing failed')
+    } finally {
+      setInboxRoutingId(null)
     }
   }
 
@@ -384,7 +405,12 @@ export default function AgentOperationsPage() {
               </div>
               <div className="mt-3 space-y-2">
                 {snapshot?.agent_inbox.length ? snapshot.agent_inbox.slice(0, 5).map((item) => (
-                  <InboxRow key={item.id} item={item} />
+                  <InboxRow
+                    key={item.id}
+                    item={item}
+                    routing={inboxRoutingId === item.id}
+                    onRoute={() => routeInboxItem(item)}
+                  />
                 )) : (
                   <p className="rounded-lg border border-silicon-slate/50 bg-black/10 p-3 text-sm text-muted-foreground">
                     No agent inbox items need attention.
@@ -545,9 +571,17 @@ function StatusPill({ status }: { status: 'active' | 'partial' | 'planned' }) {
   return <span className={`rounded-full border px-2 py-0.5 text-xs ${className}`}>{status}</span>
 }
 
-function InboxRow({ item }: { item: MissionSnapshot['agent_inbox'][number] }) {
+function InboxRow({
+  item,
+  routing,
+  onRoute,
+}: {
+  item: MissionSnapshot['agent_inbox'][number]
+  routing: boolean
+  onRoute: () => void
+}) {
   return (
-    <Link href={item.href} className="block rounded-lg border border-silicon-slate/50 bg-black/10 p-3 text-sm hover:border-radiant-gold/50">
+    <div className="rounded-lg border border-silicon-slate/50 bg-black/10 p-3 text-sm">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
@@ -558,12 +592,23 @@ function InboxRow({ item }: { item: MissionSnapshot['agent_inbox'][number] }) {
           <p className="mt-1 line-clamp-2 text-muted-foreground">{item.reason}</p>
           <p className="mt-2 text-xs text-muted-foreground">{item.pod}</p>
         </div>
-        <div className="flex shrink-0 items-center gap-1 text-xs text-radiant-gold">
-          {item.action_label}
-          <ArrowRight size={14} />
+        <div className="flex shrink-0 flex-col items-end gap-2">
+          <button
+            type="button"
+            onClick={onRoute}
+            disabled={routing}
+            className="inline-flex items-center gap-1 rounded-md border border-radiant-gold/50 bg-radiant-gold/10 px-2 py-1 text-xs text-radiant-gold hover:bg-radiant-gold/15 disabled:opacity-60"
+          >
+            {routing ? <RefreshCw size={13} className="animate-spin" /> : <Sparkles size={13} />}
+            Route
+          </button>
+          <Link href={item.href} className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-radiant-gold">
+            {item.action_label}
+            <ArrowRight size={14} />
+          </Link>
         </div>
       </div>
-    </Link>
+    </div>
   )
 }
 

--- a/app/api/admin/agents/inbox/route.test.ts
+++ b/app/api/admin/agents/inbox/route.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  routeAgentInboxItem: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-inbox-routing', () => ({
+  routeAgentInboxItem: mocks.routeAgentInboxItem,
+}))
+
+import { POST } from './route'
+
+function request(body: unknown = {}) {
+  return new Request('http://localhost/api/admin/agents/inbox', {
+    method: 'POST',
+    headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/admin/agents/inbox', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.routeAgentInboxItem.mockResolvedValue({
+      item: {
+        id: 'failed-run:failed',
+        title: 'Failure needs triage',
+      },
+      runId: 'route-run',
+      routeAction: 'agent_engagement',
+      status: 'completed',
+      executionMode: 'read_only',
+    })
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(request({ item_id: '1' }) as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.routeAgentInboxItem).not.toHaveBeenCalled()
+  })
+
+  it('routes an inbox item through the shared router', async () => {
+    const response = await POST(request({ item_id: 'failed-run:failed' }) as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      run_id: 'route-run',
+      route_action: 'agent_engagement',
+      status: 'completed',
+      execution_mode: 'read_only',
+    })
+    expect(mocks.routeAgentInboxItem).toHaveBeenCalledWith(expect.objectContaining({
+      itemRef: 'failed-run:failed',
+      triggerSource: 'admin_agent_inbox_route',
+      actor: expect.objectContaining({
+        id: 'admin-user',
+        userId: 'admin-user',
+        type: 'admin_user',
+      }),
+    }))
+  })
+
+  it('rejects missing item ids', async () => {
+    const response = await POST(request({}) as never)
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'item_id is required' })
+  })
+
+  it('returns not found for stale inbox references', async () => {
+    mocks.routeAgentInboxItem.mockRejectedValue(new Error('Agent Inbox item not found'))
+
+    const response = await POST(request({ item_id: 'missing' }) as never)
+
+    expect(response.status).toBe(404)
+    expect(await response.json()).toEqual({ error: 'Agent Inbox item not found' })
+  })
+})

--- a/app/api/admin/agents/inbox/route.ts
+++ b/app/api/admin/agents/inbox/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { routeAgentInboxItem } from '@/lib/agent-inbox-routing'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as {
+    item_id?: unknown
+  }
+
+  const itemRef = typeof body.item_id === 'string' ? body.item_id.trim() : ''
+  if (!itemRef) {
+    return NextResponse.json({ error: 'item_id is required' }, { status: 400 })
+  }
+
+  try {
+    const result = await routeAgentInboxItem({
+      itemRef,
+      actor: {
+        id: auth.user.id,
+        label: 'Admin user',
+        type: 'admin_user',
+        userId: auth.user.id,
+      },
+      triggerSource: 'admin_agent_inbox_route',
+    })
+
+    return NextResponse.json({
+      ok: true,
+      run_id: result.runId,
+      route_action: result.routeAction,
+      status: result.status,
+      execution_mode: result.executionMode,
+      item: result.item,
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to route Agent Inbox item'
+    const status = message === 'Agent Inbox item not found' ? 404 : 500
+    console.error('[admin-agent-inbox-route] failed:', error)
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -192,6 +192,9 @@ The route verifies Slack signatures with `SLACK_SIGNING_SECRET` when configured 
 - `/agent approvals` — pending approval checkpoints with run links.
 - `/agent morning-review` — runs the approved Agent Ops morning review path with `trigger_source = slack_agent_ops_command`.
 - `/agent agents` — lists active and partial agent organization entries with their engagement keys.
+- `/agent inbox` — lists numbered Agent Inbox items from Mission Control.
+- `/agent brief` — returns the current Daily Operating Brief.
+- `/agent route <number-or-id>` — routes an Agent Inbox item through the same read-only Chief of Staff/agent engagement path used by the admin console.
 - `/agent run <agent-key>` — creates the same traceable `manual` runtime engagement request as the admin button; active or partial agents produce a read-only dispatch artifact, while planned agents stay queued for review.
 - `/agent standup` — runs the text War Room standup and returns agent updates plus a Chief of Staff synthesis.
 - `/agent discuss <question>` — gathers mapped agent perspectives and returns a synthesized advisory response.
@@ -209,6 +212,8 @@ The Daily Operating Brief and Agent Inbox are derived views, not new persistence
 - Agent Inbox points each actionable item to its owning agent and trace,
 - pending approvals are represented once through `agent_approvals` instead of duplicating the waiting run,
 - stale standup reminders route back to Mission Control so the Chief of Staff can refresh the daily operating view.
+- Agent Inbox items can be routed from the admin console with `POST /api/admin/agents/inbox` or from Slack with `/agent route <number-or-id>`.
+- Routing an inbox item does not mutate production data: failed/stale/cost/approval items create a read-only `agent_engagement_request`; stale standup items run the read-only War Room standup.
 
 War Room uses `POST /api/admin/agents/war-room` with `{ command: 'standup' | 'discuss', message?: string }`.
 

--- a/lib/agent-inbox-routing.test.ts
+++ b/lib/agent-inbox-routing.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  buildAgentMissionControlSnapshot: vi.fn(),
+  createAgentEngagementRun: vi.fn(),
+  runAgentWarRoom: vi.fn(),
+}))
+
+vi.mock('@/lib/agent-mission-control', () => ({
+  buildAgentMissionControlSnapshot: mocks.buildAgentMissionControlSnapshot,
+}))
+
+vi.mock('@/lib/agent-engagement', () => ({
+  createAgentEngagementRun: mocks.createAgentEngagementRun,
+}))
+
+vi.mock('@/lib/agent-war-room', () => ({
+  runAgentWarRoom: mocks.runAgentWarRoom,
+}))
+
+import { buildAgentInboxRouteNote, findAgentInboxItem, routeAgentInboxItem } from '@/lib/agent-inbox-routing'
+import type { AgentInboxItem } from '@/lib/agent-mission-control'
+
+const failedItem: AgentInboxItem = {
+  id: 'failed-run:failed',
+  priority: 'high',
+  agent_key: 'automation-systems',
+  agent_name: 'Automation Systems Agent',
+  pod: 'Product & Automation',
+  title: 'Failure needs triage: Workflow dispatch',
+  reason: 'Webhook returned 500.',
+  action_label: 'Open trace',
+  href: '/admin/agents/runs/failed-run',
+  source_run_id: 'failed-run',
+}
+
+const standupItem: AgentInboxItem = {
+  id: 'chief-of-staff:standup',
+  priority: 'low',
+  agent_key: 'chief-of-staff',
+  agent_name: 'Chief of Staff Agent',
+  pod: 'Chief of Staff',
+  title: 'No War Room standup yet',
+  reason: 'Run a standup to turn current signals into an operating brief.',
+  action_label: 'Run standup',
+  href: '/admin/agents',
+  source_run_id: null,
+}
+
+describe('Agent Inbox routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.buildAgentMissionControlSnapshot.mockResolvedValue({
+      agent_inbox: [failedItem, standupItem],
+    })
+    mocks.createAgentEngagementRun.mockResolvedValue({
+      runId: 'engagement-run',
+      status: 'completed',
+      executionMode: 'read_only',
+    })
+    mocks.runAgentWarRoom.mockResolvedValue({
+      runId: 'standup-run',
+    })
+  })
+
+  it('finds inbox items by number or id', () => {
+    expect(findAgentInboxItem([failedItem, standupItem], '1')).toEqual(failedItem)
+    expect(findAgentInboxItem([failedItem, standupItem], 'chief-of-staff:standup')).toEqual(standupItem)
+    expect(findAgentInboxItem([failedItem, standupItem], '3')).toBeUndefined()
+  })
+
+  it('builds a route note with item context and source run', () => {
+    const note = buildAgentInboxRouteNote(failedItem)
+
+    expect(note).toContain('Failure needs triage')
+    expect(note).toContain('Priority: high')
+    expect(note).toContain('Source run: failed-run')
+  })
+
+  it('routes failed inbox items into read-only agent engagement runs', async () => {
+    const result = await routeAgentInboxItem({
+      itemRef: '1',
+      actor: { id: 'admin-user', label: 'Admin user', type: 'admin_user', userId: 'admin-user' },
+      triggerSource: 'test_route',
+    })
+
+    expect(mocks.createAgentEngagementRun).toHaveBeenCalledWith(expect.objectContaining({
+      agent: expect.objectContaining({ key: 'automation-systems' }),
+      triggerSource: 'test_route',
+      note: expect.stringContaining('Webhook returned 500.'),
+      eventMetadata: expect.objectContaining({
+        agent_inbox_item_id: 'failed-run:failed',
+        source_run_id: 'failed-run',
+        route_action: 'agent_engagement',
+      }),
+    }))
+    expect(result).toMatchObject({
+      runId: 'engagement-run',
+      routeAction: 'agent_engagement',
+      executionMode: 'read_only',
+    })
+  })
+
+  it('routes stale standup inbox items to War Room standup', async () => {
+    const result = await routeAgentInboxItem({
+      itemRef: '2',
+      actor: { id: 'U123', label: 'vambah', type: 'slack_command' },
+      triggerSource: 'test_standup_route',
+    })
+
+    expect(mocks.runAgentWarRoom).toHaveBeenCalledWith(expect.objectContaining({
+      command: 'standup',
+      triggerSource: 'test_standup_route',
+    }))
+    expect(mocks.createAgentEngagementRun).not.toHaveBeenCalled()
+    expect(result).toMatchObject({
+      runId: 'standup-run',
+      routeAction: 'war_room_standup',
+      executionMode: 'read_only',
+    })
+  })
+})

--- a/lib/agent-inbox-routing.ts
+++ b/lib/agent-inbox-routing.ts
@@ -1,0 +1,107 @@
+import { createAgentEngagementRun } from '@/lib/agent-engagement'
+import { runAgentWarRoom } from '@/lib/agent-war-room'
+import { getAgentByKey } from '@/lib/agent-organization'
+import { buildAgentMissionControlSnapshot } from '@/lib/agent-mission-control'
+import type { AgentInboxItem } from '@/lib/agent-mission-control'
+
+export type AgentInboxRouteActor = {
+  id: string
+  label: string
+  type: 'admin_user' | 'slack_command'
+  userId?: string | null
+}
+
+export type AgentInboxRouteResult = {
+  item: AgentInboxItem
+  runId: string
+  routeAction: 'war_room_standup' | 'agent_engagement'
+  status: 'queued' | 'completed'
+  executionMode: 'read_only' | 'queued_for_review'
+}
+
+export function findAgentInboxItem(items: AgentInboxItem[], itemRef: string) {
+  const trimmed = itemRef.trim()
+  const numericIndex = Number.parseInt(trimmed, 10)
+  if (Number.isFinite(numericIndex) && `${numericIndex}` === trimmed && numericIndex > 0) {
+    return items[numericIndex - 1]
+  }
+
+  return items.find((item) => item.id === trimmed)
+}
+
+export function buildAgentInboxRouteNote(item: AgentInboxItem) {
+  return [
+    `Agent Inbox item: ${item.title}`,
+    `Priority: ${item.priority}`,
+    `Reason: ${item.reason}`,
+    `Owning agent: ${item.agent_name}`,
+    item.source_run_id ? `Source run: ${item.source_run_id}` : null,
+  ]
+    .filter(Boolean)
+    .join('\n')
+}
+
+export async function routeAgentInboxItem(input: {
+  itemRef: string
+  actor: AgentInboxRouteActor
+  triggerSource: string
+}): Promise<AgentInboxRouteResult> {
+  const snapshot = await buildAgentMissionControlSnapshot()
+  const item = findAgentInboxItem(snapshot.agent_inbox, input.itemRef)
+  if (!item) {
+    throw new Error('Agent Inbox item not found')
+  }
+
+  if (item.id === 'chief-of-staff:standup') {
+    const result = await runAgentWarRoom({
+      command: 'standup',
+      triggerSource: input.triggerSource,
+      actor: {
+        id: input.actor.id,
+        label: input.actor.label,
+        type: input.actor.type,
+      },
+    })
+
+    return {
+      item,
+      runId: result.runId,
+      routeAction: 'war_room_standup',
+      status: 'completed',
+      executionMode: 'read_only',
+    }
+  }
+
+  const agent = getAgentByKey(item.agent_key) ?? getAgentByKey('chief-of-staff')
+  if (!agent) {
+    throw new Error('No routeable agent found for inbox item')
+  }
+
+  const result = await createAgentEngagementRun({
+    agent,
+    actor: {
+      subjectType: 'agent_inbox_item',
+      subjectId: item.id,
+      subjectLabel: item.title,
+      userId: input.actor.userId ?? null,
+    },
+    triggerSource: input.triggerSource,
+    note: buildAgentInboxRouteNote(item),
+    requestedEventMessage: `${input.actor.label} routed Agent Inbox item: ${item.title}`,
+    eventMetadata: {
+      agent_inbox_item_id: item.id,
+      agent_inbox_priority: item.priority,
+      source_run_id: item.source_run_id,
+      route_action: 'agent_engagement',
+      routed_by: input.actor.type,
+    },
+  })
+
+  return {
+    item,
+    runId: result.runId,
+    routeAction: 'agent_engagement',
+    status: result.status,
+    executionMode: result.executionMode,
+  }
+}

--- a/lib/agent-slack-command.test.ts
+++ b/lib/agent-slack-command.test.ts
@@ -20,6 +20,11 @@ const warRoomMocks = vi.hoisted(() => ({
   runAgentWarRoom: vi.fn(),
 }))
 
+const inboxMocks = vi.hoisted(() => ({
+  buildAgentMissionControlSnapshot: vi.fn(),
+  routeAgentInboxItem: vi.fn(),
+}))
+
 vi.mock('@/lib/agent-run', () => ({
   startAgentRun: agentRunMocks.startAgentRun,
   recordAgentEvent: agentRunMocks.recordAgentEvent,
@@ -32,9 +37,20 @@ vi.mock('@/lib/agent-war-room', () => ({
   runAgentWarRoom: warRoomMocks.runAgentWarRoom,
 }))
 
+vi.mock('@/lib/agent-mission-control', () => ({
+  buildAgentMissionControlSnapshot: inboxMocks.buildAgentMissionControlSnapshot,
+}))
+
+vi.mock('@/lib/agent-inbox-routing', () => ({
+  routeAgentInboxItem: inboxMocks.routeAgentInboxItem,
+}))
+
 import {
   agentSlackCommandInternals,
+  buildAgentBriefSlackText,
+  buildAgentInboxSlackText,
   createAgentEngagementSlackText,
+  routeAgentInboxSlackText,
   runWarRoomStandupSlackText,
 } from '@/lib/agent-slack-command'
 
@@ -53,6 +69,9 @@ describe('agent Slack command parsing', () => {
     expect(agentSlackCommandInternals.commandFromText('morning')).toBe('morning-review')
     expect(agentSlackCommandInternals.commandFromText('agents')).toBe('agents')
     expect(agentSlackCommandInternals.commandFromText('list')).toBe('agents')
+    expect(agentSlackCommandInternals.commandFromText('inbox')).toBe('inbox')
+    expect(agentSlackCommandInternals.commandFromText('brief')).toBe('brief')
+    expect(agentSlackCommandInternals.commandFromText('route 1')).toBe('route')
     expect(agentSlackCommandInternals.commandFromText('run chief-of-staff')).toBe('run')
     expect(agentSlackCommandInternals.commandFromText('standup')).toBe('standup')
     expect(agentSlackCommandInternals.commandFromText('discuss roadmap')).toBe('discuss')
@@ -63,6 +82,8 @@ describe('agent Slack command parsing', () => {
     expect(agentSlackCommandInternals.commandFromText('unknown')).toBe('help')
     expect(agentSlackCommandInternals.formatHelp()).toContain('/agent status')
     expect(agentSlackCommandInternals.formatHelp()).toContain('/agent run <agent-key>')
+    expect(agentSlackCommandInternals.formatHelp()).toContain('/agent inbox')
+    expect(agentSlackCommandInternals.formatHelp()).toContain('/agent route <number-or-id>')
     expect(agentSlackCommandInternals.formatHelp()).toContain('/agent standup')
   })
 
@@ -158,5 +179,74 @@ describe('agent Slack command parsing', () => {
     expect(text).toContain('Agent War Room standup complete')
     expect(text).toContain('Chief of Staff Agent')
     expect(text).toContain('/admin/agents/runs/standup-run')
+  })
+
+  it('formats numbered Agent Inbox items for Slack', async () => {
+    inboxMocks.buildAgentMissionControlSnapshot.mockResolvedValue({
+      agent_inbox: [
+        {
+          id: 'failed-run:failed',
+          priority: 'high',
+          agent_name: 'Automation Systems Agent',
+          title: 'Failure needs triage: Workflow dispatch',
+          reason: 'Webhook returned 500.',
+          source_run_id: 'failed-run',
+        },
+      ],
+    })
+
+    const text = await buildAgentInboxSlackText()
+
+    expect(text).toContain('Agent Inbox')
+    expect(text).toContain('1. *HIGH* Automation Systems Agent')
+    expect(text).toContain('/agent route <number>')
+    expect(text).toContain('/admin/agents/runs/failed-run')
+  })
+
+  it('formats the Daily Operating Brief for Slack', async () => {
+    inboxMocks.buildAgentMissionControlSnapshot.mockResolvedValue({
+      daily_brief: {
+        headline: '1 high-priority item needs attention',
+        synthesis: 'Chief of Staff recommends routing the failed workflow.',
+        run_id: 'standup-run',
+        signals: ['1 active run(s)', '1 failed or stale run(s)'],
+        next_actions: ['Automation Systems Agent: triage workflow'],
+      },
+    })
+
+    const text = await buildAgentBriefSlackText()
+
+    expect(text).toContain('Daily Operating Brief')
+    expect(text).toContain('Chief of Staff recommends')
+    expect(text).toContain('/admin/agents/runs/standup-run')
+  })
+
+  it('routes an Agent Inbox item from Slack', async () => {
+    inboxMocks.routeAgentInboxItem.mockResolvedValue({
+      item: {
+        title: 'Failure needs triage: Workflow dispatch',
+      },
+      runId: 'route-run',
+      routeAction: 'agent_engagement',
+      executionMode: 'read_only',
+    })
+
+    const text = await routeAgentInboxSlackText({
+      text: 'route 1',
+      userId: 'U123',
+      userName: 'vambah',
+    })
+
+    expect(inboxMocks.routeAgentInboxItem).toHaveBeenCalledWith(expect.objectContaining({
+      itemRef: '1',
+      triggerSource: 'slack_agent_inbox_route_command',
+      actor: expect.objectContaining({
+        id: 'U123',
+        label: 'vambah',
+        type: 'slack_command',
+      }),
+    }))
+    expect(text).toContain('Agent Inbox item routed')
+    expect(text).toContain('/admin/agents/runs/route-run')
   })
 })

--- a/lib/agent-slack-command.ts
+++ b/lib/agent-slack-command.ts
@@ -1,5 +1,7 @@
 import { runAgentOpsMorningReview } from '@/lib/agent-ops-morning-review'
 import { createAgentEngagementRun } from '@/lib/agent-engagement'
+import { routeAgentInboxItem } from '@/lib/agent-inbox-routing'
+import { buildAgentMissionControlSnapshot } from '@/lib/agent-mission-control'
 import { runAgentWarRoom } from '@/lib/agent-war-room'
 import { AGENT_ORGANIZATION, getAgentByKey } from '@/lib/agent-organization'
 import { supabaseAdmin } from '@/lib/supabase'
@@ -11,6 +13,9 @@ type SlackCommandName =
   | 'approvals'
   | 'morning-review'
   | 'agents'
+  | 'inbox'
+  | 'brief'
+  | 'route'
   | 'run'
   | 'standup'
   | 'discuss'
@@ -75,6 +80,9 @@ function commandFromText(text: string): SlackCommandName {
   if (command === 'approval' || command === 'approvals') return 'approvals'
   if (command === 'morning-review' || command === 'morning' || command === 'review') return 'morning-review'
   if (command === 'agents' || command === 'list') return 'agents'
+  if (command === 'inbox' || command === 'queue') return 'inbox'
+  if (command === 'brief') return 'brief'
+  if (command === 'route') return 'route'
   if (command === 'run' || command === 'start') return 'run'
   if (command === 'standup') return 'standup'
   if (command === 'discuss') return 'discuss'
@@ -93,10 +101,87 @@ function formatHelp() {
     '`/agent approvals` - pending approval checkpoints.',
     '`/agent morning-review` - run the approved Agent Ops morning review trace.',
     '`/agent agents` - list currently mapped agents and engagement keys.',
+    '`/agent inbox` - show numbered Agent Inbox items.',
+    '`/agent brief` - show the current Daily Operating Brief.',
+    '`/agent route <number-or-id>` - route an Agent Inbox item through Chief of Staff.',
     '`/agent run <agent-key>` - create a traceable engagement request for an agent.',
     '`/agent standup` - run a text War Room standup across active/partial agents.',
     '`/agent discuss <question>` - gather agent perspectives and a Chief of Staff synthesis.',
   ].join('\n')
+}
+
+export async function buildAgentInboxSlackText(limit = 5) {
+  try {
+    const snapshot = await buildAgentMissionControlSnapshot()
+    const items = snapshot.agent_inbox.slice(0, limit)
+    if (items.length === 0) {
+      return `*Agent Inbox*\nNo inbox items need attention.\nReview: ${baseUrl()}/admin/agents`
+    }
+
+    const lines = items.map((item, index) => {
+      const source = item.source_run_id ? ` <${agentRunsUrl(item.source_run_id)}|trace>` : ''
+      return `${index + 1}. *${item.priority.toUpperCase()}* ${item.agent_name}: ${item.title}${source}\n   ${item.reason}`
+    })
+
+    return [
+      '*Agent Inbox*',
+      ...lines,
+      'Route one with `/agent route <number>`.',
+      `Review: ${baseUrl()}/admin/agents`,
+    ].join('\n')
+  } catch (error) {
+    return `Agent Inbox lookup failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+  }
+}
+
+export async function buildAgentBriefSlackText() {
+  try {
+    const snapshot = await buildAgentMissionControlSnapshot()
+    const brief = snapshot.daily_brief
+    const trace = brief.run_id ? `\nTrace: ${agentRunsUrl(brief.run_id)}` : ''
+    return [
+      '*Daily Operating Brief*',
+      `*${brief.headline}*`,
+      brief.synthesis,
+      '',
+      '*Signals*',
+      ...brief.signals.map((signal) => `- ${signal}`),
+      '',
+      '*Next actions*',
+      ...brief.next_actions.slice(0, 3).map((action) => `- ${action}`),
+      `${trace}\nReview: ${baseUrl()}/admin/agents`.trim(),
+    ].join('\n')
+  } catch (error) {
+    return `Daily Operating Brief lookup failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+  }
+}
+
+export async function routeAgentInboxSlackText(input: AgentSlackCommandInput) {
+  const [itemRef] = commandArgs(input.text)
+  if (!itemRef) return 'Missing inbox item. Use `/agent inbox`, then `/agent route <number>`.'
+
+  try {
+    const actor = input.userName || input.userId || 'Slack user'
+    const result = await routeAgentInboxItem({
+      itemRef,
+      actor: {
+        id: input.userId ?? actor,
+        label: actor,
+        type: 'slack_command',
+      },
+      triggerSource: 'slack_agent_inbox_route_command',
+    })
+
+    return [
+      '*Agent Inbox item routed*',
+      `Item: ${result.item.title}`,
+      `Route action: ${result.routeAction.replace(/_/g, ' ')}`,
+      `Execution mode: ${result.executionMode}`,
+      `Review: ${agentRunsUrl(result.runId)}`,
+    ].join('\n')
+  } catch (error) {
+    return `Agent Inbox routing failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+  }
 }
 
 function formatDbUnavailable() {
@@ -379,13 +464,19 @@ export async function handleAgentSlackCommand(input: AgentSlackCommandInput): Pr
             ? await runMorningReviewSlackText(input)
             : command === 'agents'
               ? formatAgentListSlackText()
-              : command === 'run'
-                ? await createAgentEngagementSlackText(input)
-                : command === 'standup'
-                  ? await runWarRoomStandupSlackText(input)
-                  : command === 'discuss'
-                    ? await runWarRoomDiscussSlackText(input)
-                    : formatHelp()
+              : command === 'inbox'
+                ? await buildAgentInboxSlackText()
+                : command === 'brief'
+                  ? await buildAgentBriefSlackText()
+                  : command === 'route'
+                    ? await routeAgentInboxSlackText(input)
+                    : command === 'run'
+                      ? await createAgentEngagementSlackText(input)
+                      : command === 'standup'
+                        ? await runWarRoomStandupSlackText(input)
+                        : command === 'discuss'
+                          ? await runWarRoomDiscussSlackText(input)
+                          : formatHelp()
 
   return { responseType: 'ephemeral', text }
 }


### PR DESCRIPTION
## Summary
- add a traced Agent Inbox routing helper and admin POST endpoint
- add Route actions to Mission Control Agent Inbox items
- extend Slack `/agent` commands with inbox, brief, and route flows
- document the Agent Inbox routing path in the rollout plan

## Validation
- npm test -- lib/agent-inbox-routing.test.ts app/api/admin/agents/inbox/route.test.ts lib/agent-slack-command.test.ts app/api/slack/agent/route.test.ts app/api/admin/agents/engage/route.test.ts
- npx tsc --noEmit --pretty false
- npm run build
- git diff --check
- local in-app browser smoke: http://localhost:3000/admin/agents loads, Agent Inbox section shows Route action
- pre-push database health check passed

## Notes
- This branch does not merge to main. Integration Captain should reconcile and merge after checks are green.
