### PR TITLE
chore: add Git hygiene watch report

### DIFF
--- a/docs/agents/git-hygiene-watch-classifications.md
+++ b/docs/agents/git-hygiene-watch-classifications.md
@@ -1,0 +1,58 @@
+# Git Hygiene Watch Classifications
+
+Last reviewed: 2026-05-04
+
+Use this file as the integration captain's current disposition register for watch items that should not be deleted blindly.
+
+## Gone Local Branches
+
+These local branches have deleted upstreams and one commit not reachable from `origin/main`. Current recommendation: keep until the captain is ready to delete superseded local-only branches in one explicit cleanup pass.
+
+| Branch | Unique commit | Classification | Rationale | Next action |
+| --- | --- | --- | --- | --- |
+| `codex/agent-autopilot-tasklist` | `6e17fac` | `superseded` | Agent task list and Chief of Staff dispatch capabilities are now represented by the merged Agent Ops task list, Chief of Staff chat, engagement, and command-room work. | Safe to delete after one final captain review confirms no active chat references it. |
+| `codex/agent-engagement-hub` | `c0ba00c` | `superseded` | Admin engagement request functionality exists on `main` through `app/api/admin/agents/engage`, `lib/agent-engagement`, and `/admin/agents`. | Safe to delete after final review. |
+| `codex/agent-engagement-workpackets` | `837764c` | `superseded` | Work packet artifacts are present on `main` in `lib/agent-engagement.ts` and related tests. | Safe to delete after final review. |
+| `codex/agent-first-task-templates` | `cc2f475` | `superseded` | First-task templates are represented in current engagement dispatch logic and documented as complete in `docs/agent-operations-task-list.md`. | Safe to delete after final review. |
+| `codex/agent-readonly-dispatch` | `247b1ef` | `superseded` | Read-only dispatch is present on `main` through admin engagement and Slack command flow. | Safe to delete after final review. |
+| `codex/automation-context-dashboard` | `e96dc60` | `superseded` | Automation Context exists on `main` at `/admin/agents/automations` with nav entry and route coverage. | Safe to delete after final review. |
+| `codex/chief-of-staff-actions` | `c5f5012` | `superseded` | Chief of Staff approval/action routes and chat integration are present on `main`. | Safe to delete after final review. |
+| `codex/roadmap-rule-activation` | `80f5525` | `preserve` | This is outside the Agent Ops merge stream and touches client AI ops roadmap surfaces. Do not delete without a separate roadmap-owner review. | Keep and review separately. |
+| `codex/slack-agent-readonly-dispatch` | `f5d793e` | `superseded` | Slack `/agent run` read-only engagement dispatch is present on `main`. | Safe to delete after final review. |
+
+## Worktrees
+
+| Worktree | Branch | Classification | Rationale | Next action |
+| --- | --- | --- | --- | --- |
+| `/Users/vambahsillah/Projects/Portfolio` | varies | `normal` | Primary shared checkout. It may be detached for integration verification or on an active captain branch while work is in progress. | Keep. |
+| `/private/tmp/portfolio-slack-sync` | `main` | `normal` | Dedicated main worktree used to keep `main` available while the shared checkout is detached or on a branch. | Keep. |
+| `/private/tmp/portfolio-ops-approval-guard` | `codex/portfolio-ops-approval-guard` | `preserve` | Recovery/approval-guard worktree with unique commit history. | Keep until explicitly retired. |
+| `/private/tmp/portfolio-ops-approval-guard-20260502` | `codex/portfolio-ops-approval-guard-20260502` | `preserve` | Recovery/approval-guard worktree with unique commit history. | Keep until explicitly retired. |
+| `/private/tmp/portfolio-ops-approval-guard-20260503` | `codex/portfolio-ops-approval-guard-20260503` | `preserve` | Recovery/approval-guard worktree with unique commit history. | Keep until explicitly retired. |
+
+## Vercel Staging Lag
+
+Classification: `watch`.
+
+Use the thresholds in `docs/agents/vercel-verifier.md`:
+
+- under 5 minutes: `normal`
+- 5-10 minutes: `watch`
+- over 10 minutes repeatedly: `debt`
+- failed, cancelled, or timed out: `blocker`
+
+Next action: keep collecting timing through `npm run deploy:watch`; only escalate if staging repeatedly exceeds the debt threshold.
+
+## GitHub Transient Merge Errors
+
+Classification: `watch`.
+
+Current handling is sufficient:
+
+1. Check PR state.
+2. Check `origin/main`.
+3. Poll briefly.
+4. Retry once if the PR remains open, clean, and mergeable.
+5. Stop and report if the second attempt remains stuck.
+
+Next action: no automation yet. Add retry instrumentation only if this repeats across several PRs.

--- a/docs/agents/integration-captain.md
+++ b/docs/agents/integration-captain.md
@@ -32,6 +32,7 @@ git status --short --branch
 gh pr list --state open --json number,title,headRefName,isDraft,mergeStateStatus,updatedAt,url,statusCheckRollup
 git worktree list
 git stash list --max-count=8
+npm run git:hygiene:report
 ```
 
 Confirm:
@@ -159,3 +160,44 @@ Recommend automation when the same issue appears more than twice:
 - queue hygiene report: compare `docs/integration-captain-queue.md` against open PRs
 
 Start these as read-only reports. Only add auto-cleanup after the captain has proven the report is accurate over repeated runs.
+
+### Active Hygiene Report
+
+Run the read-only hygiene report before branch or worktree cleanup:
+
+```bash
+npm run git:hygiene:report
+```
+
+The report enacts the current watch-item policies:
+
+- gone local branches are classified by unique commits before any deletion
+- worktrees are classified by branch, dirty files, and commits missing from `origin/main`
+- open PRs are classified by draft/readiness age
+- open PR file overlap is surfaced before sequencing decisions
+- Vercel pending thresholds and GitHub transient merge handling are printed in the report header
+
+Use report output as evidence. Do not delete a branch or worktree from the report alone unless the recommendation is a cleanup candidate and no active chat owns it.
+
+Current watch-item dispositions live in `docs/agents/git-hygiene-watch-classifications.md`. Update that file when a gone branch moves from `watch` to `preserve`, `superseded`, `abandon`, or `needs PR`.
+
+### Vercel Lag Thresholds
+
+Classify Vercel pending contexts by elapsed time:
+
+- under 5 minutes: `normal`
+- 5-10 minutes: `watch`
+- over 10 minutes repeatedly: `debt`
+- failed, cancelled, or timed out: `blocker`
+
+If staging lags after production but stays pending, continue polling until the threshold requires inspection. Do not merge the next PR while either required context is pending.
+
+### GitHub Transient Merge Handling
+
+When GitHub returns `502`, `merge already in progress`, or a similar transient merge error:
+
+1. Check PR state with `gh pr view <number>`.
+2. Check `origin/main` status.
+3. Poll briefly for remote merge completion.
+4. Retry once only if the PR is still open, clean, and mergeable.
+5. If the second attempt is still stuck, classify it as `watch` for GitHub service state or `blocker` if the PR is no longer clean.

--- a/docs/agents/vercel-verifier.md
+++ b/docs/agents/vercel-verifier.md
@@ -57,6 +57,7 @@ Do not call a deployment complete while either required context is pending.
 
 ## Pending Thresholds
 
-- Under 8 minutes: continue polling unless a context has failed.
-- 8-15 minutes: inspect the Vercel target URL or run `vercel ls <project> --scope vsillahs-projects`.
-- Over 15 minutes: treat as blocked until the deployment is inspected or re-run.
+- Under 5 minutes: classify as `normal` and continue polling unless a context has failed.
+- 5-10 minutes: classify as `watch`; continue polling and prepare to inspect the target URL.
+- Over 10 minutes repeatedly: classify as `debt`; inspect the Vercel target URL or run `vercel ls <project> --scope vsillahs-projects`.
+- Failed, cancelled, or timed out: classify as `blocker` until the deployment is inspected or re-run.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "db:health-check:dev:update": "tsx scripts/database-health-check.ts --dev --update",
     "deploy:watch": "tsx scripts/vercel-deployment-watch.ts",
     "deploy:watch:once": "tsx scripts/vercel-deployment-watch.ts --once",
+    "git:hygiene:report": "tsx scripts/git-hygiene-report.ts",
     "source-protocol:smoke": "tsx scripts/source-protocol-smoke.ts",
     "staging:publications-parity": "tsx scripts/ensure-publications-experience-parity.ts --env-file .env.staging",
     "printful:webhook": "tsx scripts/printful-setup-webhook.ts",

--- a/scripts/git-hygiene-report.ts
+++ b/scripts/git-hygiene-report.ts
@@ -1,0 +1,351 @@
+#!/usr/bin/env tsx
+import { spawnSync } from 'node:child_process'
+
+type StatusLabel = 'normal' | 'watch' | 'debt' | 'blocker'
+
+type BranchReport = {
+  name: string
+  upstream: string
+  tracking: string
+  shortSha: string
+  subject: string
+  uniqueCommits: number
+  label: StatusLabel
+  recommendation: string
+}
+
+type WorktreeReport = {
+  path: string
+  branch: string
+  head: string
+  dirtyFiles: number
+  uniqueCommits: number
+  label: StatusLabel
+  recommendation: string
+}
+
+type PullRequestReport = {
+  number: number
+  title: string
+  headRefName: string
+  isDraft: boolean
+  ageHours: number
+  label: StatusLabel
+  recommendation: string
+}
+
+type OpenPullRequest = {
+  number: number
+  title: string
+  headRefName: string
+  isDraft: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+function run(args: string[], cwd = process.cwd()): string {
+  const result = spawnSync(args[0], args.slice(1), {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  if (result.status !== 0) {
+    const message = result.stderr.trim() || result.stdout.trim() || `${args.join(' ')} failed`
+    throw new Error(message)
+  }
+
+  return result.stdout.trim()
+}
+
+function tryRun(args: string[], cwd = process.cwd()): string {
+  const result = spawnSync(args[0], args.slice(1), {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  if (result.status !== 0) return ''
+  return result.stdout.trim()
+}
+
+function countLines(value: string): number {
+  if (!value.trim()) return 0
+  return value.split('\n').filter(Boolean).length
+}
+
+function countUniqueCommits(ref: string): number {
+  const count = tryRun(['git', 'rev-list', '--count', ref, '--not', 'origin/main'])
+  return Number(count || 0)
+}
+
+function countWorktreeUniqueCommits(path: string): number {
+  const count = tryRun(['git', '-C', path, 'rev-list', '--count', 'HEAD', '--not', 'origin/main'])
+  return Number(count || 0)
+}
+
+function getCurrentBranch(): string {
+  return tryRun(['git', 'branch', '--show-current']) || '(detached)'
+}
+
+function getGoneBranches(): BranchReport[] {
+  const output = run([
+    'git',
+    'for-each-ref',
+    'refs/heads',
+    '--format=%(refname:short)|%(upstream:short)|%(upstream:track)|%(objectname:short)|%(contents:subject)',
+  ])
+
+  return output
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => {
+      const [name, upstream, tracking, shortSha, ...subjectParts] = line.split('|')
+      const subject = subjectParts.join('|')
+      return { name, upstream, tracking, shortSha, subject }
+    })
+    .filter((branch) => branch.tracking.includes('gone'))
+    .map((branch) => {
+      const uniqueCommits = countUniqueCommits(branch.name)
+      const label: StatusLabel = uniqueCommits > 0 ? 'watch' : 'normal'
+      const recommendation =
+        uniqueCommits > 0
+          ? 'classify as preserve, superseded, abandon, or needs PR before deleting'
+          : 'safe cleanup candidate after captain confirms no worktree owns it'
+
+      return {
+        ...branch,
+        uniqueCommits,
+        label,
+        recommendation,
+      }
+    })
+}
+
+function parseWorktrees(): WorktreeReport[] {
+  const output = run(['git', 'worktree', 'list', '--porcelain'])
+  const blocks = output.split(/\n(?=worktree )/).filter(Boolean)
+
+  return blocks.map((block) => {
+    const lines = block.split('\n')
+    const path = lines.find((line) => line.startsWith('worktree '))?.slice('worktree '.length) ?? ''
+    const head = lines.find((line) => line.startsWith('HEAD '))?.slice('HEAD '.length, 19) ?? ''
+    const branchLine = lines.find((line) => line.startsWith('branch '))
+    const branch = branchLine ? branchLine.replace('branch refs/heads/', '') : '(detached)'
+    const dirtyFiles = countLines(tryRun(['git', '-C', path, 'status', '--porcelain']))
+    const uniqueCommits = countWorktreeUniqueCommits(path)
+
+    let label: StatusLabel = 'normal'
+    let recommendation = 'expected active or verification worktree'
+
+    if (dirtyFiles > 0) {
+      label = 'debt'
+      recommendation = 'identify owner before merge or cleanup'
+    } else if (branch === 'main' || branch === '(detached)') {
+      label = 'normal'
+      recommendation = 'keep as normal captain verification/main checkout'
+    } else if (uniqueCommits > 0) {
+      label = 'watch'
+      recommendation = 'preserve until branch owner or PR status is clear'
+    } else {
+      label = 'watch'
+      recommendation = 'cleanup candidate if no active chat still uses it'
+    }
+
+    return {
+      path,
+      branch,
+      head,
+      dirtyFiles,
+      uniqueCommits,
+      label,
+      recommendation,
+    }
+  })
+}
+
+function getOpenPullRequests(now = new Date()): PullRequestReport[] {
+  const output = tryRun([
+    'gh',
+    'pr',
+    'list',
+    '--state',
+    'open',
+    '--json',
+    'number,title,headRefName,isDraft,createdAt,updatedAt',
+  ])
+
+  if (!output) return []
+
+  const prs = JSON.parse(output) as OpenPullRequest[]
+
+  return prs.map((pr) => {
+    const createdAt = Date.parse(pr.createdAt)
+    const ageHours = Number.isFinite(createdAt)
+      ? Math.floor((now.getTime() - createdAt) / 36_000) / 100
+      : 0
+
+    let label: StatusLabel = 'normal'
+    let recommendation = 'no action'
+
+    if (!pr.isDraft && ageHours >= 48) {
+      label = 'debt'
+      recommendation = 'ready PR older than 48h; integration captain should sequence or block explicitly'
+    } else if (!pr.isDraft) {
+      label = 'normal'
+      recommendation = 'ready PR; process through normal merge gate'
+    } else if (ageHours >= 168) {
+      label = 'watch'
+      recommendation = 'draft older than 7d; ask owner whether to keep, close, or refresh'
+    } else {
+      label = 'normal'
+      recommendation = 'draft PR is expected parallel-work residue'
+    }
+
+    return {
+      number: pr.number,
+      title: pr.title,
+      headRefName: pr.headRefName,
+      isDraft: pr.isDraft,
+      ageHours,
+      label,
+      recommendation,
+    }
+  })
+}
+
+function getPrFileMap(prs: PullRequestReport[]): Map<string, PullRequestReport[]> {
+  const byFile = new Map<string, PullRequestReport[]>()
+
+  for (const pr of prs) {
+    const output = tryRun(['gh', 'pr', 'diff', String(pr.number), '--name-only'])
+    if (!output) continue
+
+    for (const file of output.split('\n').filter(Boolean)) {
+      const current = byFile.get(file) ?? []
+      current.push(pr)
+      byFile.set(file, current)
+    }
+  }
+
+  return byFile
+}
+
+function formatTable(headers: string[], rows: string[][]): string {
+  const allRows = [headers, ...rows]
+  const widths = headers.map((_, index) =>
+    Math.max(...allRows.map((row) => String(row[index] ?? '').length))
+  )
+
+  return allRows
+    .map((row, rowIndex) => {
+      const formatted = row
+        .map((value, index) => String(value).padEnd(widths[index]))
+        .join(' | ')
+      if (rowIndex === 0) {
+        return `${formatted}\n${widths.map((width) => '-'.repeat(width)).join('-|-')}`
+      }
+      return formatted
+    })
+    .join('\n')
+}
+
+function main(): void {
+  run(['git', 'fetch', '--prune', 'origin'])
+
+  const now = new Date()
+  const currentBranch = getCurrentBranch()
+  const goneBranches = getGoneBranches()
+  const worktrees = parseWorktrees()
+  const prs = getOpenPullRequests(now)
+  const fileMap = getPrFileMap(prs)
+  const overlappingFiles = [...fileMap.entries()].filter(([, owners]) => owners.length > 1)
+
+  console.log(`# Git Hygiene Watch Report`)
+  console.log(`Generated: ${now.toISOString()}`)
+  console.log(`Current branch: ${currentBranch}`)
+  console.log('')
+
+  console.log('## Watch Policy')
+  console.log('- Vercel pending under 5m: normal; 5-10m: watch; over 10m repeatedly: debt; failure or timeout: blocker.')
+  console.log('- GitHub 502 or merge-in-progress: check PR state, check origin/main, poll briefly, retry once if still open and clean.')
+  console.log('- Branch and worktree cleanup is report-only here; no deletion is performed.')
+  console.log('')
+
+  console.log('## Gone Local Branches')
+  if (goneBranches.length === 0) {
+    console.log('No local branches with gone upstreams.')
+  } else {
+    console.log(
+      formatTable(
+        ['label', 'branch', 'unique', 'sha', 'recommendation', 'subject'],
+        goneBranches.map((branch) => [
+          branch.label,
+          branch.name,
+          String(branch.uniqueCommits),
+          branch.shortSha,
+          branch.recommendation,
+          branch.subject,
+        ])
+      )
+    )
+  }
+  console.log('')
+
+  console.log('## Worktrees')
+  console.log(
+    formatTable(
+      ['label', 'branch', 'dirty', 'unique', 'head', 'path', 'recommendation'],
+      worktrees.map((worktree) => [
+        worktree.label,
+        worktree.branch,
+        String(worktree.dirtyFiles),
+        String(worktree.uniqueCommits),
+        worktree.head,
+        worktree.path,
+        worktree.recommendation,
+      ])
+    )
+  )
+  console.log('')
+
+  console.log('## Open PR Age')
+  if (prs.length === 0) {
+    console.log('No open PRs.')
+  } else {
+    console.log(
+      formatTable(
+        ['label', 'pr', 'draft', 'age_h', 'branch', 'recommendation', 'title'],
+        prs.map((pr) => [
+          pr.label,
+          `#${pr.number}`,
+          String(pr.isDraft),
+          String(pr.ageHours),
+          pr.headRefName,
+          pr.recommendation,
+          pr.title,
+        ])
+      )
+    )
+  }
+  console.log('')
+
+  console.log('## Open PR File Overlap')
+  if (overlappingFiles.length === 0) {
+    console.log('No overlapping files across open PRs.')
+  } else {
+    console.log(
+      formatTable(
+        ['label', 'file', 'prs', 'recommendation'],
+        overlappingFiles.map(([file, owners]) => [
+          'watch',
+          file,
+          owners.map((pr) => `#${pr.number}`).join(','),
+          'sequence PRs or require impact preflight before merging',
+        ])
+      )
+    )
+  }
+}
+
+main()


### PR DESCRIPTION
## Summary
- Adds a read-only Git hygiene report command for stale branch, worktree, PR age, and open PR file-overlap checks.
- Records current watch-item classifications for gone local branches, persistent worktrees, Vercel staging lag, and GitHub transient merge errors.
- Updates integration captain and Vercel verifier guidance with the new thresholds and retry policy.

## Validation
- npm run git:hygiene:report
- git diff --check
- npx tsc --noEmit --pretty false
- pre-push production database health check passed

## Notes
- Cleared stale local .next output before typecheck because it referenced a draft branch route no longer present on this branch.