### PR TITLE
docs: define Agent Operations roadmap

### DIFF
--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -98,6 +98,22 @@ type MissionSnapshot = {
     href: string
     source_run_id: string | null
   }>
+  engagement_queue: Array<{
+    run_id: string
+    agent_key: string
+    agent_name: string
+    pod: string
+    status: string
+    current_step: string | null
+    execution_mode: string
+    requested_from: string | null
+    source_inbox_item_id: string | null
+    source_run_id: string | null
+    note: string | null
+    next_action: string | null
+    started_at: string
+    completed_at: string | null
+  }>
 }
 
 type WarRoomResult = {
@@ -142,6 +158,7 @@ export default function AgentOperationsPage() {
   const [actionLoading, setActionLoading] = useState<string | null>(null)
   const [actionResult, setActionResult] = useState<{ label: string; runId: string } | null>(null)
   const [inboxRoutingId, setInboxRoutingId] = useState<string | null>(null)
+  const [engagementLoadingKey, setEngagementLoadingKey] = useState<string | null>(null)
 
   const authedFetch = useCallback(async (path: string, init: RequestInit = {}) => {
     const session = await getCurrentSession()
@@ -280,6 +297,29 @@ export default function AgentOperationsPage() {
     }
   }
 
+  async function launchAgentEngagement(agentKey: string, label: string, note?: string) {
+    setEngagementLoadingKey(agentKey)
+    setActionResult(null)
+    setError(null)
+    try {
+      const response = await authedFetch('/api/admin/agents/engage', {
+        method: 'POST',
+        body: JSON.stringify({
+          agent_key: agentKey,
+          note: note ? `Chief of Staff recommended: ${note}` : undefined,
+        }),
+      })
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`)
+      setActionResult({ label, runId: body.run_id })
+      await loadMissionControl()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Agent engagement launch failed')
+    } finally {
+      setEngagementLoadingKey(null)
+    }
+  }
+
   const topAgents = useMemo(
     () => snapshot?.roster.flatMap((pod) => pod.agents).filter((agent) => agent.status !== 'planned').slice(0, 10) ?? [],
     [snapshot],
@@ -377,12 +417,19 @@ export default function AgentOperationsPage() {
               </form>
 
               {chiefReply ? (
-                <ResultPanel
-                  title="Chief of Staff"
-                  href={`/admin/agents/runs/${chiefReply.run_id}`}
-                  body={chiefReply.reply}
-                  items={chiefReply.agent_engagements.map((agent) => `${agent.agentName}: ${agent.rationale}`)}
-                />
+                <>
+                  <ResultPanel
+                    title="Chief of Staff"
+                    href={`/admin/agents/runs/${chiefReply.run_id}`}
+                    body={chiefReply.reply}
+                    items={chiefReply.suggested_actions}
+                  />
+                  <AgentEngagementRecommendations
+                    recommendations={chiefReply.agent_engagements}
+                    loadingKey={engagementLoadingKey}
+                    onLaunch={(agent) => launchAgentEngagement(agent.agentKey, agent.agentName, agent.rationale)}
+                  />
+                </>
               ) : null}
 
               {warRoomResult ? (
@@ -419,6 +466,8 @@ export default function AgentOperationsPage() {
               </div>
             </div>
           </section>
+
+          <EngagementQueuePanel items={snapshot?.engagement_queue ?? []} />
 
           <section className="mt-5 grid grid-cols-1 gap-5 xl:grid-cols-[1fr_0.8fr]">
             <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
@@ -555,6 +604,97 @@ function DailyBriefPanel({ brief, loading }: { brief: MissionSnapshot['daily_bri
             </p>
           ))}
         </div>
+      </div>
+    </section>
+  )
+}
+
+function AgentEngagementRecommendations({
+  recommendations,
+  loadingKey,
+  onLaunch,
+}: {
+  recommendations: ChiefReply['agent_engagements']
+  loadingKey: string | null
+  onLaunch: (agent: ChiefReply['agent_engagements'][number]) => void
+}) {
+  if (!recommendations.length) return null
+
+  return (
+    <div className="mt-3 grid grid-cols-1 gap-2">
+      {recommendations.slice(0, 4).map((agent) => (
+        <div key={`${agent.agentKey}-${agent.label}`} className="rounded-lg border border-radiant-gold/20 bg-radiant-gold/5 p-3">
+          <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <p className="font-medium">{agent.agentName}</p>
+                <span className="rounded-full border border-silicon-slate/50 bg-black/10 px-2 py-0.5 text-xs text-muted-foreground">
+                  {agent.executionMode.replace(/_/g, ' ')}
+                </span>
+                <span className="rounded-full border border-silicon-slate/50 bg-black/10 px-2 py-0.5 text-xs text-muted-foreground">
+                  {agent.status}
+                </span>
+              </div>
+              <p className="mt-1 text-sm text-muted-foreground">{agent.rationale}</p>
+            </div>
+            <button
+              type="button"
+              onClick={() => onLaunch(agent)}
+              disabled={loadingKey === agent.agentKey}
+              className="inline-flex shrink-0 items-center justify-center gap-2 rounded-lg border border-radiant-gold/50 bg-radiant-gold/10 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15 disabled:opacity-60"
+            >
+              {loadingKey === agent.agentKey ? <RefreshCw size={14} className="animate-spin" /> : <Sparkles size={14} />}
+              Run read-only
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function EngagementQueuePanel({ items }: { items: MissionSnapshot['engagement_queue'] }) {
+  return (
+    <section className="mt-5 rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-2 text-radiant-gold">
+          <ClipboardList size={18} />
+          <h2 className="font-semibold">Engagement Work Queue</h2>
+        </div>
+        <Link href="/admin/agents/runs" className="text-xs text-radiant-gold hover:underline">
+          Open run console
+        </Link>
+      </div>
+      <div className="mt-3 grid grid-cols-1 gap-2 lg:grid-cols-2">
+        {items.length ? items.slice(0, 6).map((item) => (
+          <Link
+            key={item.run_id}
+            href={`/admin/agents/runs/${item.run_id}`}
+            className="rounded-lg border border-silicon-slate/50 bg-black/10 p-3 text-sm hover:border-radiant-gold/50"
+          >
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="font-medium">{item.agent_name}</span>
+              <span className="rounded-full border border-silicon-slate/50 bg-black/10 px-2 py-0.5 text-xs text-muted-foreground">
+                {item.status.replace(/_/g, ' ')}
+              </span>
+              <span className="rounded-full border border-silicon-slate/50 bg-black/10 px-2 py-0.5 text-xs text-muted-foreground">
+                {item.execution_mode.replace(/_/g, ' ')}
+              </span>
+            </div>
+            <p className="mt-2 line-clamp-2 text-muted-foreground">
+              {item.current_step ?? item.next_action ?? 'Engagement request is queued for review.'}
+            </p>
+            <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+              <span>{item.pod}</span>
+              <span>{formatTime(item.started_at)}</span>
+              {item.source_run_id ? <span>from inbox trace</span> : null}
+            </div>
+          </Link>
+        )) : (
+          <p className="rounded-lg border border-silicon-slate/50 bg-black/10 p-3 text-sm text-muted-foreground">
+            No routed agent engagements yet. Use Chief of Staff recommendations, Agent Inbox routing, or Slack `/agent run`.
+          </p>
+        )}
       </div>
     </section>
   )

--- a/app/api/admin/agents/mission-control/route.test.ts
+++ b/app/api/admin/agents/mission-control/route.test.ts
@@ -55,6 +55,7 @@ describe('GET /api/admin/agents/mission-control', () => {
         next_actions: ['Run War Room standup.'],
       },
       agent_inbox: [],
+      engagement_queue: [],
       approvals: [],
     })
   })
@@ -85,6 +86,7 @@ describe('GET /api/admin/agents/mission-control', () => {
       generated_from: 'current_state',
     })
     expect(body.agent_inbox).toEqual([])
+    expect(body.engagement_queue).toEqual([])
     expect(mocks.buildAgentMissionControlSnapshot).toHaveBeenCalledOnce()
   })
 

--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -1,0 +1,304 @@
+# Agent Operations Roadmap
+
+This roadmap is the scope-control document for Agent Operations. It defines what "done" means for the work, what belongs in each phase, and what should be deferred unless Vambah explicitly changes the scope.
+
+Portfolio admin remains the control plane. Slack remains the mobile command surface. `agent_runs`, `agent_run_steps`, `agent_run_events`, `agent_run_artifacts`, `agent_approvals`, and `cost_events.agent_run_id` remain the source of truth.
+
+## Product Definition
+
+Agent Operations is done when Vambah can:
+
+- see the agent system state at a glance from `/admin/agents`,
+- ask Chief of Staff what needs attention,
+- run or route read-only agent work from Mission Control or Slack,
+- see every agent run, handoff, artifact, approval, and cost in a traceable place,
+- approve or reject side-effecting work before it touches production, clients, public channels, or private-to-public material,
+- understand which agents are live, partial, planned, or deferred,
+- run the same morning/standup/status workflow without needing a human to manually check multiple tools,
+- hand off merge/deployment responsibility to the Integration Captain without losing traceability.
+
+## Operating Principles
+
+- One control plane: Portfolio admin is authoritative.
+- One mobile channel: Slack is enough for v1.
+- One trace model: all runtimes write into the shared agent run tables.
+- Read-only first: new agents start as advisory or dispatch-only.
+- Approval before mutation: publishing, sending, production writes, config changes, and private-to-public content require `agent_approvals`.
+- No hidden runtimes: Hermes, OpenCode, n8n, manual, and Codex work must be observable before they become operationally important.
+- Integration Captain owns merges to `main`; feature agents branch, commit, push, and stop.
+
+## Phase Roadmap
+
+### Phase 0: Architecture Baseline
+
+Status: Complete.
+
+Goal: Establish the runtime and trace model without breaking existing workflow pages.
+
+Definition of done:
+
+- `docs/agent-operations-rollout.md` names the architecture, runtimes, and statuses.
+- Supported runtimes are `codex`, `n8n`, `hermes`, `opencode`, and `manual`.
+- Supported statuses are `queued`, `running`, `waiting_for_approval`, `completed`, `failed`, `cancelled`, and `stale`.
+- Existing workflow-specific admin pages remain live.
+
+Out of scope:
+
+- Replacing every workflow status page.
+- Promoting Hermes or OpenCode as primary orchestrators.
+
+### Phase 1: Shared Trace Foundation
+
+Status: Complete.
+
+Goal: Make agent work observable through shared tables and helpers.
+
+Definition of done:
+
+- Shared schema exists for registry, runs, steps, events, artifacts, handoffs, and approvals.
+- `cost_events.agent_run_id` links usage cost to agent runs.
+- `lib/agent-run.ts` supports start, step, event, artifact, completion, and failure writes.
+- Helpers are retry-safe where practical through idempotency keys.
+- Unit tests cover core trace helper behavior.
+
+Out of scope:
+
+- Migrating every historical workflow table.
+- Building detailed dashboards before the trace foundation exists.
+
+### Phase 2: Mission Control Console
+
+Status: In review.
+
+Goal: Turn `/admin/agents` into a first-screen command center rather than a long observability page.
+
+Definition of done:
+
+- `/admin/agents` shows status strip, Daily Operating Brief, Chief of Staff command, Agent Inbox, Engagement Work Queue, active/partial roster, controls, and latest activity.
+- `/admin/agents/runs` lists recent and active runs.
+- `/admin/agents/runs/[runId]` shows timeline, artifacts, costs, approvals, errors, and related context.
+- Dense controls move into drilldowns or compact sections.
+- Admin route protection is consistent with other admin pages.
+- UI smoke confirms first viewport loads without server error.
+
+Out of scope:
+
+- A separate 3D graph or animated agent map.
+- Replacing every workflow-specific admin route.
+- Public-facing agent surfaces.
+
+### Phase 3: Conversational Routing
+
+Status: In review.
+
+Goal: Make Chief of Staff the natural-language front door for agent work.
+
+Definition of done:
+
+- `/admin/agents/chief-of-staff` can answer status, blocker, priority, and next-action questions from Agent Ops context.
+- Chief of Staff writes a traced `codex` run for each exchange.
+- Chief of Staff can return typed agent engagement recommendations.
+- Mission Control can launch recommended read-only engagements with `POST /api/admin/agents/engage`.
+- Launched engagements appear in the Engagement Work Queue and run console.
+
+Out of scope:
+
+- Letting Chief of Staff mutate production data directly.
+- Autonomous planning loops that launch multiple agents without traceable operator intent.
+- Long-term memory beyond trace/artifact summaries.
+
+### Phase 4: Agent Inbox And Work Queue
+
+Status: In review.
+
+Goal: Convert trace signals into a clear operating queue.
+
+Definition of done:
+
+- Agent Inbox derives actionable items from failed, stale, approval-waiting, high-cost, and stale-standup signals.
+- Admin can route inbox items.
+- Slack can list and route inbox items.
+- Engagement Work Queue derives from `agent_engagement_request` traces.
+- Queue items preserve source inbox item, source run, owning agent, next action, execution mode, and trace link.
+- No new table is introduced unless trace-derived queue state proves insufficient.
+
+Out of scope:
+
+- Kanban drag-and-drop.
+- Custom assignment tables.
+- Queue state that does not reconcile back to `agent_runs`.
+
+### Phase 5: Slack Mobile Command Surface
+
+Status: In review.
+
+Goal: Let Vambah check and route Agent Ops from Slack without adding another mobile channel.
+
+Definition of done:
+
+- `/agent status` summarizes active, failed, stale, approval, and cost signals.
+- `/agent agents` lists mapped runnable agents.
+- `/agent inbox` lists numbered Agent Inbox items.
+- `/agent route <number-or-id>` routes an inbox item.
+- `/agent engagements` lists the latest routed engagement queue.
+- `/agent brief` returns the Daily Operating Brief.
+- `/agent run <agent-key>` creates a traced read-only engagement.
+- `/agent standup` and `/agent discuss <question>` write War Room traces.
+- Slack signing is fail-closed when configured for production.
+- Slow commands either respond within Slack expectations or use a durable delayed path.
+
+Out of scope:
+
+- Telegram, SMS, Discord, or other chat surfaces in v1.
+- Slack actions that publish, send email, or write production data without approval.
+
+### Phase 6: n8n Production Instrumentation
+
+Status: Partial.
+
+Goal: Make production automations visible through the shared trace model.
+
+Definition of done:
+
+- App-triggered n8n calls include `agent_run_id`.
+- n8n callbacks can record progress events, completion, and structured failures.
+- Outreach, social content, value evidence, and warm lead workflows have shared trace coverage where practical.
+- Legacy workflow status pages remain compatible during migration.
+- Failure callbacks show in Agent Inbox and run detail.
+
+Out of scope:
+
+- Rewriting all n8n workflows at once.
+- Removing legacy workflow-specific run tables before replacement views are proven.
+- Letting n8n bypass approval gates for sensitive actions.
+
+### Phase 7: Approval-Backed Execution
+
+Status: Partial.
+
+Goal: Move from read-only dispatch toward safe execution where side effects are explicit.
+
+Definition of done:
+
+- Runtime policy is visible and test-covered.
+- Approval checkpoints use `agent_approvals`, not local UI state.
+- Run detail supports approval and rejection for pending checkpoints.
+- Publishing, outbound email, production data writes, config changes, and private-to-public content require approval.
+- Approval decisions are recorded as trace events.
+- Rejected work terminates safely or returns a reviewable failure.
+
+Out of scope:
+
+- Background agents approving their own work.
+- Implicit approval from Slack text that does not map to a specific checkpoint.
+- Bulk approvals without explicit target runs.
+
+### Phase 8: Hermes Secondary Runtime
+
+Status: Partial.
+
+Goal: Add Hermes as a secondary observable runtime for low-risk work.
+
+Definition of done:
+
+- Hermes is registered as a supported runtime.
+- Hermes system health bridge creates traced `hermes` runs.
+- Hermes outputs attach artifacts.
+- Hermes failures write structured events.
+- Hermes remains read-only for production-adjacent workflows unless an approval checkpoint exists.
+
+Out of scope:
+
+- Letting the web app spawn uncontrolled local Hermes processes.
+- Production data mutation through Hermes in v1.
+- Making Hermes the primary orchestrator.
+
+### Phase 9: Runtime Evaluation And Tooling Parity
+
+Status: Partial.
+
+Goal: Evaluate OpenCode/OpenClaw and future runtimes without letting them become hidden production dependencies.
+
+Definition of done:
+
+- Runtime evaluation route can detect whether candidate binaries exist.
+- At least one observable evaluation run writes to Agent Operations.
+- Tooling parity docs explain which runtimes can access which tools.
+- Any future worker runtime must prove install, auth, trace, rollback, and audit behavior before production automation.
+
+Out of scope:
+
+- OpenCode/OpenClaw production automation.
+- Untracked local worktree mutation from the admin UI.
+- Auto-installing agent runtimes from the web app.
+
+### Phase 10: Hardening, Reporting, And Migration
+
+Status: Planned.
+
+Goal: Make Agent Operations reliable enough to run as an operating system.
+
+Definition of done:
+
+- Stale-run detection covers all runtimes.
+- Dead-letter handling exists for failed or abandoned runs.
+- Cost dashboards group by runtime, agent, workflow, client/project, and artifact type.
+- Morning review runs on schedule and writes a traceable report.
+- Deployment watcher distinguishes Vercel queue delay from failure.
+- Old workflow run tables are either migrated or documented as domain-specific detail.
+- `docs/agentic-patterns.md` is updated once observability coverage is strong.
+
+Out of scope:
+
+- Removing working legacy tables just for architectural purity.
+- Fully autonomous production remediation.
+- Cost optimization that changes vendors without a bakeoff.
+
+## Cross-Phase Definition Of Done
+
+Every implementation phase must satisfy these gates before it is considered done:
+
+- Source of truth: New operational state is trace-backed or explicitly documented as derived.
+- UI: Admin can see the state or action without digging through raw logs.
+- Slack: If the workflow is mobile-relevant, Slack has a read-only command or clear reason for deferral.
+- Tests: Focused tests cover happy path, auth boundaries, malformed input, and failure behavior.
+- Type/build: Typecheck and production build pass, or failures are documented as pre-existing blockers.
+- Browser smoke: `/admin/agents` or the touched admin surface loads in the integrated browser.
+- Audit: Runs, approvals, events, and artifacts link back to a trace ID.
+- Safety: Side effects are approval-gated.
+- Integration: Work is on a named branch or PR, not merged directly to `main` by a non-captain chat.
+- Deployment: Integration Captain verifies both `portfolio` and `portfolio-staging`.
+
+## Scope Creep Rules
+
+The following require an explicit scope-change decision before implementation:
+
+- Adding a new chat channel beyond Slack.
+- Adding a new database table for queue state.
+- Adding autonomous multi-agent loops that launch more than one agent from one operator request.
+- Letting any runtime write production data outside a known workflow.
+- Letting Hermes or OpenCode mutate files or data from the web app.
+- Replacing legacy workflow pages.
+- Building visual graph/3D/animation-first views.
+- Adding new vendor/model/runtime dependencies without a bakeoff.
+- Moving merge/deploy authority away from the Integration Captain.
+
+## Current Review Stack
+
+These are the current known Agent Operations PR dependencies:
+
+- PR #125: Agent Inbox routing.
+- PR #127: Engagement Work Queue.
+
+Integration order:
+
+1. Merge PR #125.
+2. Retarget or merge PR #127.
+3. Rebase this roadmap branch if needed.
+4. Verify `portfolio` and `portfolio-staging`.
+
+## Next Three Build Phases
+
+1. Queue affordances: filters, owner/next-action clarity, and a focused queue drilldown if the overview becomes crowded.
+2. Approval-backed execution: convert recommended side effects into approval checkpoints with explicit action payloads.
+3. n8n trace expansion: make the highest-value automation workflows report progress and failure into Agent Operations consistently.

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -2,7 +2,7 @@
 
 The Portfolio admin remains the control plane. Codex and n8n stay as the primary operating backbone, while Hermes is added as a secondary runtime after shared run tracing is available. OpenCode/OpenClaw are deferred until their work can be observed, audited, and rolled back through the same trace model.
 
-The active execution queue for the remaining rollout work lives in [Agent Operations Task List](./agent-operations-task-list.md).
+The phase gates, definitions of done, and scope-control rules live in [Agent Operations Roadmap](./agent-operations-roadmap.md). The active execution queue for the remaining rollout work lives in [Agent Operations Task List](./agent-operations-task-list.md).
 
 ## Runtime Model
 

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -192,6 +192,7 @@ The route verifies Slack signatures with `SLACK_SIGNING_SECRET` when configured 
 - `/agent approvals` — pending approval checkpoints with run links.
 - `/agent morning-review` — runs the approved Agent Ops morning review path with `trigger_source = slack_agent_ops_command`.
 - `/agent agents` — lists active and partial agent organization entries with their engagement keys.
+- `/agent engagements` — lists the latest routed read-only engagement requests from the shared work queue.
 - `/agent inbox` — lists numbered Agent Inbox items from Mission Control.
 - `/agent brief` — returns the current Daily Operating Brief.
 - `/agent route <number-or-id>` — routes an Agent Inbox item through the same read-only Chief of Staff/agent engagement path used by the admin console.
@@ -203,7 +204,7 @@ Slack is an engagement surface, not the source of truth. The admin console and s
 
 ## Mission Control And War Room
 
-Mission Control uses `GET /api/admin/agents/mission-control` as a derived read model over existing tables. It does not introduce new schema in v1. The endpoint returns the status strip, agent roster, attention queue, Agent Inbox, Daily Operating Brief, active runs, latest events, pending approvals, and latest standup trace.
+Mission Control uses `GET /api/admin/agents/mission-control` as a derived read model over existing tables. It does not introduce new schema in v1. The endpoint returns the status strip, agent roster, attention queue, Agent Inbox, Engagement Work Queue, Daily Operating Brief, active runs, latest events, pending approvals, and latest standup trace.
 
 The Daily Operating Brief and Agent Inbox are derived views, not new persistence:
 
@@ -232,11 +233,14 @@ Engagement requests:
 - create an `agent_run` with `kind = agent_engagement_request`,
 - start in `queued`,
 - record the requested agent key, pod, runtime path, and approval gate,
+- preserve routing metadata such as source inbox item and source run when launched from Agent Inbox,
 - attach an `agent_engagement_work_packet` artifact with a readable work brief, mapped workflow coverage, and suggested next action,
 - for active or partial agents, complete a read-only dispatch step and attach an `agent_read_only_dispatch` artifact with next actions,
 - include a first-task template for priority agents so each read-only dispatch has an objective, checklist, and expected output,
 - keep planned agents queued for review until they have a narrow first task,
 - do not mutate production data.
+
+The Engagement Work Queue on `/admin/agents` and Slack `/agent engagements` are derived from these same `agent_engagement_request` traces. This makes routed requests visible as a queue without adding a new table or moving the source of truth out of `agent_runs`.
 
 ## Chief of Staff Chat
 
@@ -248,6 +252,7 @@ The first conversational agent surface is `/admin/agents/chief-of-staff`.
 - It uses `CHIEF_OF_STAFF_AGENT_MODEL` when set, otherwise `gpt-4o-mini`.
 - It returns both plain suggested follow-ups and typed action proposals using the shared runtime policy action IDs.
 - It can recommend mapped agent engagement proposals with `agent_key`, label, and rationale so the chat can launch the same read-only dispatch path used by `/admin/agents` and Slack.
+- Mission Control can launch those Chief of Staff recommendations directly through `POST /api/admin/agents/engage`, then the resulting work appears in the Engagement Work Queue.
 - Typed action proposals can be converted into approval checkpoints with `POST /api/admin/agents/chief-of-staff/actions`.
 - The approval action route creates a separate `manual` runtime run in `waiting_for_approval` and a pending `agent_approvals` record.
 - V1 remains non-executing. It can recommend next actions and create approval checkpoints, but it does not mutate production workflows, send messages, publish content, or change configuration.

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -1,46 +1,65 @@
 # Agent Operations Task List
 
-This is the active implementation queue for turning the agent organization into usable operating software.
+This is the active implementation queue for Agent Operations. The phase gates, definitions of done, and scope-control rules live in [Agent Operations Roadmap](./agent-operations-roadmap.md). If a proposed task is not allowed by that roadmap, treat it as a scope-change request before implementing it.
 
-## Current Autopilot Block
+## Integration Queue
 
-- [x] Confirm baseline: `origin/main`, open PRs, and production/staging Vercel deployment state.
-- [x] Keep Portfolio admin as the source of truth for agent operations.
-- [x] Support read-only agent dispatch from `/admin/agents`.
-- [x] Support the same read-only dispatch from Slack `/agent run <agent-key>`.
-- [x] Let Chief of Staff chat recommend mapped agents and launch their read-only dispatch runs.
-- [x] Keep every launched agent engagement visible in `/admin/agents/runs`.
-- [x] Add first-task templates to read-only dispatch artifacts for priority agents.
-- [x] Add read-only Automation Context visibility for Portfolio-related Codex automations.
-- [ ] Validate with focused tests, typecheck, lint, build, PR previews, merge, and production/staging deployment checks.
+- [ ] Merge PR #125: Agent Inbox routing.
+- [ ] Retarget or merge PR #127: Engagement Work Queue.
+- [ ] Merge this roadmap definition branch after PR #125 and PR #127 are reconciled.
+- [ ] Verify both Vercel contexts after merge:
+  - `Vercel – portfolio`
+  - `Vercel – portfolio-staging`
 
-## Next Operating Milestones
+## Next Build Queue
 
-1. Chief of Staff dispatcher
-   - The chat should recommend which mapped agent to run next.
-   - Recommendations should include `agent_key`, label, and rationale.
-   - Launching the recommendation must create the same traced read-only engagement used by admin and Slack.
+1. Queue affordances
+   - Add filters for status, agent, runtime, source, and execution mode.
+   - Clarify owner, next action, and source trace on queue items.
+   - Add a focused `/admin/agents/work` drilldown only if the overview becomes too crowded.
 
-2. Agent-specific first tasks
-   - Give the highest-value agents a first narrow read-only task:
-     - `chief-of-staff`
-     - `research-source-register`
-     - `voice-content-architect`
-     - `automation-systems`
-     - `inbox-follow-up`
-   - Planned agents should stay queued until the first task is explicit.
+2. Approval-backed execution
+   - Convert Chief of Staff side-effect recommendations into explicit approval checkpoints.
+   - Store the action payload with the approval/run artifact.
+   - Keep email, publishing, production config, unknown DB writes, and private-to-public material behind `agent_approvals`.
 
-3. Approval-backed execution
-   - Convert safe read-only recommendations into approval checkpoints when they require side effects.
-   - Keep publishing, outbound email, unknown database writes, production config, and private-to-public content behind `agent_approvals`.
+3. n8n trace expansion
+   - Prioritize workflows that already touch production automation or LLM costs.
+   - Pass `agent_run_id` into app-triggered payloads.
+   - Add progress, completion, and failure callbacks.
+   - Keep legacy workflow pages active until replacement views are proven.
 
-4. Mobile operation
-   - Keep Slack as the lightweight command surface.
-   - Keep Portfolio admin as the source of truth.
-   - Avoid adding another channel unless Slack cannot support the workflow.
+4. Reporting and hardening
+   - Add all-runtime stale-run detection.
+   - Add dead-letter handling for failed runs.
+   - Add cost summaries by runtime, agent, workflow, client/project, and artifact type.
+   - Keep morning review and deployment watcher outputs visible in Agent Operations.
 
-5. Hardening
-   - Keep Codex automation context visible in Agent Operations so future agents can inspect purpose, cadence, authority boundary, and missing context before acting.
-   - Add stale-run handling for every runtime.
-   - Add dashboard-level cost summaries by agent and runtime.
-   - Keep n8n compatibility adapters live until the generic trace model is proven.
+## Completed Or In Review
+
+- [x] Shared trace schema and helper library.
+- [x] `/admin/agents`, `/admin/agents/runs`, and run detail pages.
+- [x] Mission Control first-screen command center.
+- [x] Daily Operating Brief.
+- [x] Chief of Staff command and typed recommendations.
+- [x] Agent Inbox derived from trace signals.
+- [x] Read-only agent dispatch from admin and Slack.
+- [x] Slack `/agent` command surface for status, agents, inbox, route, brief, run, standup, and discuss.
+- [x] Hermes health bridge as read-only runtime trace.
+- [x] Approval drill and run-detail approval decisions.
+- [x] Runtime evaluation probe for OpenCode/OpenClaw.
+- [x] Engagement Work Queue in review.
+
+## Scope Guard
+
+Do not add the following without an explicit scope-change decision:
+
+- another chat channel beyond Slack,
+- a separate queue table,
+- autonomous multi-agent launch loops,
+- production data writes outside known workflows,
+- Hermes/OpenCode mutation from the web app,
+- replacement of legacy workflow pages,
+- graph/3D/animation-first views,
+- new vendors, models, or runtimes without a bakeoff,
+- non-captain merges to `main`.

--- a/lib/agent-engagement.ts
+++ b/lib/agent-engagement.ts
@@ -251,6 +251,7 @@ export async function createAgentEngagementRun(
       suggested_next_action: workPacket.nextAction,
       note,
       executes_action: false,
+      ...(input.eventMetadata ?? {}),
     },
     idempotencyKey: input.idempotencyKey ?? null,
   })

--- a/lib/agent-mission-control.test.ts
+++ b/lib/agent-mission-control.test.ts
@@ -4,7 +4,7 @@ vi.mock('@/lib/supabase', () => ({
   supabaseAdmin: null,
 }))
 
-import { buildAgentInbox, buildDailyOperatingBrief } from '@/lib/agent-mission-control'
+import { buildAgentEngagementQueue, buildAgentInbox, buildDailyOperatingBrief } from '@/lib/agent-mission-control'
 
 type InboxInput = Parameters<typeof buildAgentInbox>[0]
 type MissionRunRow = InboxInput['runs'][number]
@@ -111,5 +111,43 @@ describe('Agent Mission Control helpers', () => {
     ]))
     expect(inbox.filter((item) => item.source_run_id === 'approval-run')).toHaveLength(1)
     expect(inbox[0].priority).toBe('high')
+  })
+
+  it('builds a readable engagement queue from traced engagement requests', () => {
+    const queue = buildAgentEngagementQueue([
+      run({
+        id: 'engagement-run',
+        agent_key: 'manual',
+        kind: 'agent_engagement_request',
+        status: 'completed',
+        current_step: 'Read-only dispatch ready',
+        metadata: {
+          requested_agent: 'automation-systems',
+          route_action: 'agent_engagement',
+          agent_inbox_item_id: 'failed-run:failed',
+          source_run_id: 'failed-run',
+          note: 'Triage the failed webhook.',
+          suggested_next_action: 'Review mapped workflow health.',
+          executes_action: false,
+        },
+      }),
+      run({
+        id: 'ordinary-run',
+        kind: 'agent_task',
+      }),
+    ])
+
+    expect(queue).toHaveLength(1)
+    expect(queue[0]).toMatchObject({
+      run_id: 'engagement-run',
+      agent_key: 'automation-systems',
+      agent_name: 'Automation Systems Agent',
+      status: 'completed',
+      execution_mode: 'read_only',
+      requested_from: 'agent_engagement',
+      source_inbox_item_id: 'failed-run:failed',
+      source_run_id: 'failed-run',
+      next_action: 'Review mapped workflow health.',
+    })
   })
 })

--- a/lib/agent-mission-control.ts
+++ b/lib/agent-mission-control.ts
@@ -54,6 +54,23 @@ export type AgentInboxItem = {
   source_run_id: string | null
 }
 
+export type AgentEngagementQueueItem = {
+  run_id: string
+  agent_key: string
+  agent_name: string
+  pod: string
+  status: string
+  current_step: string | null
+  execution_mode: string
+  requested_from: string | null
+  source_inbox_item_id: string | null
+  source_run_id: string | null
+  note: string | null
+  next_action: string | null
+  started_at: string
+  completed_at: string | null
+}
+
 export type DailyOperatingBrief = {
   headline: string
   synthesis: string
@@ -104,8 +121,28 @@ function findAgent(agentKey: string | null | undefined) {
   return AGENT_ORGANIZATION.find((agent) => agent.key === agentKey) ?? AGENT_ORGANIZATION.find((agent) => agent.key === 'chief-of-staff')
 }
 
+function requestedAgentKey(run: AgentRunRow) {
+  const requested = run.metadata?.requested_agent
+  return typeof requested === 'string' && requested.trim() ? requested.trim() : run.agent_key
+}
+
+function stringMetadataValue(metadata: Record<string, unknown> | null | undefined, key: string) {
+  const value = metadata?.[key]
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function executionModeForRun(run: AgentRunRow) {
+  const explicitMode = stringMetadataValue(run.metadata, 'execution_mode')
+  if (explicitMode) return explicitMode
+
+  const executesAction = run.metadata?.executes_action ?? run.outcome?.executes_action
+  if (typeof executesAction === 'boolean') return executesAction ? 'action' : 'read_only'
+
+  return 'read_only'
+}
+
 function inboxItemForRun(run: AgentRunRow, costByRun: Map<string, number>): AgentInboxItem {
-  const agent = findAgent(run.agent_key ?? (typeof run.metadata?.requested_agent === 'string' ? run.metadata.requested_agent : null))
+  const agent = findAgent(requestedAgentKey(run))
   const cost = costByRun.get(run.id) ?? 0
   const priority: AgentInboxItem['priority'] =
     run.status === 'failed' || run.status === 'waiting_for_approval'
@@ -202,6 +239,31 @@ export function buildAgentInbox(input: {
   return [...approvalItems, ...runItems, ...(standupItem ? [standupItem] : [])]
     .filter((item, index, list) => list.findIndex((candidate) => candidate.id === item.id) === index)
     .sort((a, b) => priorityRank[a.priority] - priorityRank[b.priority])
+    .slice(0, 8)
+}
+
+export function buildAgentEngagementQueue(runs: AgentRunRow[]): AgentEngagementQueueItem[] {
+  return runs
+    .filter((run) => run.kind === 'agent_engagement_request')
+    .map((run) => {
+      const agent = findAgent(requestedAgentKey(run))
+      return {
+        run_id: run.id,
+        agent_key: agent?.key ?? 'chief-of-staff',
+        agent_name: agent?.name ?? 'Chief of Staff Agent',
+        pod: agent ? agentPodName(agent.podKey) : 'Chief of Staff',
+        status: run.status,
+        current_step: run.current_step,
+        execution_mode: executionModeForRun(run),
+        requested_from: stringMetadataValue(run.metadata, 'route_action') ?? run.subject_label,
+        source_inbox_item_id: stringMetadataValue(run.metadata, 'agent_inbox_item_id'),
+        source_run_id: stringMetadataValue(run.metadata, 'source_run_id'),
+        note: stringMetadataValue(run.metadata, 'note'),
+        next_action: stringMetadataValue(run.metadata, 'suggested_next_action'),
+        started_at: run.started_at,
+        completed_at: run.completed_at,
+      }
+    })
     .slice(0, 8)
 }
 
@@ -320,6 +382,7 @@ export async function buildAgentMissionControlSnapshot() {
     (run) => run.kind === 'agent_war_room_standup' && typeof run.outcome?.synthesis === 'string',
   )
   const agentInbox = buildAgentInbox({ runs, approvals, costByRun, latestStandup })
+  const engagementQueue = buildAgentEngagementQueue(runs)
   const costToday = Number(costs.reduce((sum, row) => sum + Number(row.amount ?? 0), 0).toFixed(4))
   const dailyBrief = buildDailyOperatingBrief({
     approvals,
@@ -373,6 +436,7 @@ export async function buildAgentMissionControlSnapshot() {
     latest_standup: latestStandup ? summarizeRun(latestStandup, costByRun) : null,
     daily_brief: dailyBrief,
     agent_inbox: agentInbox,
+    engagement_queue: engagementQueue,
     approvals: approvals.slice(0, 8),
   }
 }

--- a/lib/agent-slack-command.test.ts
+++ b/lib/agent-slack-command.test.ts
@@ -48,6 +48,7 @@ vi.mock('@/lib/agent-inbox-routing', () => ({
 import {
   agentSlackCommandInternals,
   buildAgentBriefSlackText,
+  buildAgentEngagementQueueSlackText,
   buildAgentInboxSlackText,
   createAgentEngagementSlackText,
   routeAgentInboxSlackText,
@@ -69,6 +70,9 @@ describe('agent Slack command parsing', () => {
     expect(agentSlackCommandInternals.commandFromText('morning')).toBe('morning-review')
     expect(agentSlackCommandInternals.commandFromText('agents')).toBe('agents')
     expect(agentSlackCommandInternals.commandFromText('list')).toBe('agents')
+    expect(agentSlackCommandInternals.commandFromText('engagements')).toBe('engagements')
+    expect(agentSlackCommandInternals.commandFromText('work')).toBe('engagements')
+    expect(agentSlackCommandInternals.commandFromText('queue')).toBe('engagements')
     expect(agentSlackCommandInternals.commandFromText('inbox')).toBe('inbox')
     expect(agentSlackCommandInternals.commandFromText('brief')).toBe('brief')
     expect(agentSlackCommandInternals.commandFromText('route 1')).toBe('route')
@@ -82,6 +86,7 @@ describe('agent Slack command parsing', () => {
     expect(agentSlackCommandInternals.commandFromText('unknown')).toBe('help')
     expect(agentSlackCommandInternals.formatHelp()).toContain('/agent status')
     expect(agentSlackCommandInternals.formatHelp()).toContain('/agent run <agent-key>')
+    expect(agentSlackCommandInternals.formatHelp()).toContain('/agent engagements')
     expect(agentSlackCommandInternals.formatHelp()).toContain('/agent inbox')
     expect(agentSlackCommandInternals.formatHelp()).toContain('/agent route <number-or-id>')
     expect(agentSlackCommandInternals.formatHelp()).toContain('/agent standup')
@@ -200,6 +205,30 @@ describe('agent Slack command parsing', () => {
     expect(text).toContain('Agent Inbox')
     expect(text).toContain('1. *HIGH* Automation Systems Agent')
     expect(text).toContain('/agent route <number>')
+    expect(text).toContain('/admin/agents/runs/failed-run')
+  })
+
+  it('formats the engagement work queue for Slack', async () => {
+    inboxMocks.buildAgentMissionControlSnapshot.mockResolvedValue({
+      engagement_queue: [
+        {
+          run_id: 'engagement-run',
+          agent_name: 'Automation Systems Agent',
+          status: 'completed',
+          execution_mode: 'read_only',
+          current_step: 'Read-only dispatch ready',
+          next_action: 'Review workflow health.',
+          source_run_id: 'failed-run',
+        },
+      ],
+    })
+
+    const text = await buildAgentEngagementQueueSlackText()
+
+    expect(text).toContain('Engagement Work Queue')
+    expect(text).toContain('Automation Systems Agent')
+    expect(text).toContain('[completed/read_only]')
+    expect(text).toContain('/admin/agents/runs/engagement-run')
     expect(text).toContain('/admin/agents/runs/failed-run')
   })
 

--- a/lib/agent-slack-command.ts
+++ b/lib/agent-slack-command.ts
@@ -13,6 +13,7 @@ type SlackCommandName =
   | 'approvals'
   | 'morning-review'
   | 'agents'
+  | 'engagements'
   | 'inbox'
   | 'brief'
   | 'route'
@@ -80,6 +81,7 @@ function commandFromText(text: string): SlackCommandName {
   if (command === 'approval' || command === 'approvals') return 'approvals'
   if (command === 'morning-review' || command === 'morning' || command === 'review') return 'morning-review'
   if (command === 'agents' || command === 'list') return 'agents'
+  if (command === 'engagements' || command === 'work' || command === 'queue') return 'engagements'
   if (command === 'inbox' || command === 'queue') return 'inbox'
   if (command === 'brief') return 'brief'
   if (command === 'route') return 'route'
@@ -101,6 +103,7 @@ function formatHelp() {
     '`/agent approvals` - pending approval checkpoints.',
     '`/agent morning-review` - run the approved Agent Ops morning review trace.',
     '`/agent agents` - list currently mapped agents and engagement keys.',
+    '`/agent engagements` - show the latest routed engagement work queue.',
     '`/agent inbox` - show numbered Agent Inbox items.',
     '`/agent brief` - show the current Daily Operating Brief.',
     '`/agent route <number-or-id>` - route an Agent Inbox item through Chief of Staff.',
@@ -108,6 +111,30 @@ function formatHelp() {
     '`/agent standup` - run a text War Room standup across active/partial agents.',
     '`/agent discuss <question>` - gather agent perspectives and a Chief of Staff synthesis.',
   ].join('\n')
+}
+
+export async function buildAgentEngagementQueueSlackText(limit = 5) {
+  try {
+    const snapshot = await buildAgentMissionControlSnapshot()
+    const items = snapshot.engagement_queue.slice(0, limit)
+    if (items.length === 0) {
+      return `*Engagement Work Queue*\nNo routed engagement requests yet.\nReview: ${baseUrl()}/admin/agents`
+    }
+
+    const lines = items.map((item, index) => {
+      const source = item.source_run_id ? ` from <${agentRunsUrl(item.source_run_id)}|inbox trace>` : ''
+      const step = item.current_step ?? item.next_action ?? 'Engagement request queued.'
+      return `${index + 1}. <${agentRunsUrl(item.run_id)}|${item.agent_name}> [${item.status}/${item.execution_mode}]${source}\n   ${step}`
+    })
+
+    return [
+      '*Engagement Work Queue*',
+      ...lines,
+      `Review: ${baseUrl()}/admin/agents`,
+    ].join('\n')
+  } catch (error) {
+    return `Engagement queue lookup failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+  }
 }
 
 export async function buildAgentInboxSlackText(limit = 5) {
@@ -464,19 +491,21 @@ export async function handleAgentSlackCommand(input: AgentSlackCommandInput): Pr
             ? await runMorningReviewSlackText(input)
             : command === 'agents'
               ? formatAgentListSlackText()
-              : command === 'inbox'
-                ? await buildAgentInboxSlackText()
-                : command === 'brief'
-                  ? await buildAgentBriefSlackText()
-                  : command === 'route'
-                    ? await routeAgentInboxSlackText(input)
-                    : command === 'run'
-                      ? await createAgentEngagementSlackText(input)
-                      : command === 'standup'
-                        ? await runWarRoomStandupSlackText(input)
-                        : command === 'discuss'
-                          ? await runWarRoomDiscussSlackText(input)
-                          : formatHelp()
+              : command === 'engagements'
+                ? await buildAgentEngagementQueueSlackText()
+                : command === 'inbox'
+                  ? await buildAgentInboxSlackText()
+                  : command === 'brief'
+                    ? await buildAgentBriefSlackText()
+                    : command === 'route'
+                      ? await routeAgentInboxSlackText(input)
+                      : command === 'run'
+                        ? await createAgentEngagementSlackText(input)
+                        : command === 'standup'
+                          ? await runWarRoomStandupSlackText(input)
+                          : command === 'discuss'
+                            ? await runWarRoomDiscussSlackText(input)
+                            : formatHelp()
 
   return { responseType: 'ephemeral', text }
 }


### PR DESCRIPTION
## Summary

Adds a scope-control roadmap for Agent Operations so the rollout has explicit phase gates, definitions of done, and out-of-scope boundaries.

Updates the rollout and task-list docs to point at the roadmap as the source of truth for phase gating and scope creep control.

## Integration Notes

This is stacked after the current Agent Ops review work. Recommended order for the Integration Captain:

1. Merge PR #125.
2. Retarget or merge PR #127.
3. Rebase or merge this roadmap branch after #125/#127 land.
4. Verify both Vercel contexts: `Vercel – portfolio` and `Vercel – portfolio-staging`.

## Validation

- `git diff --check`
- `rg -n "agent-operations-roadmap|agent-operations-task-list|agent-operations-rollout" docs/agent-operations-roadmap.md docs/agent-operations-rollout.md docs/agent-operations-task-list.md`
- pre-push `npm run db:health-check` via repository hook

Docs-only change; no app build was required for this branch.