### PR TITLE
feat: add Agent Engagement work queue

### DIFF
--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -98,6 +98,22 @@ type MissionSnapshot = {
     href: string
     source_run_id: string | null
   }>
+  engagement_queue: Array<{
+    run_id: string
+    agent_key: string
+    agent_name: string
+    pod: string
+    status: string
+    current_step: string | null
+    execution_mode: string
+    requested_from: string | null
+    source_inbox_item_id: string | null
+    source_run_id: string | null
+    note: string | null
+    next_action: string | null
+    started_at: string
+    completed_at: string | null
+  }>
 }
 
 type WarRoomResult = {
@@ -142,6 +158,7 @@ export default function AgentOperationsPage() {
   const [actionLoading, setActionLoading] = useState<string | null>(null)
   const [actionResult, setActionResult] = useState<{ label: string; runId: string } | null>(null)
   const [inboxRoutingId, setInboxRoutingId] = useState<string | null>(null)
+  const [engagementLoadingKey, setEngagementLoadingKey] = useState<string | null>(null)
 
   const authedFetch = useCallback(async (path: string, init: RequestInit = {}) => {
     const session = await getCurrentSession()
@@ -280,6 +297,29 @@ export default function AgentOperationsPage() {
     }
   }
 
+  async function launchAgentEngagement(agentKey: string, label: string, note?: string) {
+    setEngagementLoadingKey(agentKey)
+    setActionResult(null)
+    setError(null)
+    try {
+      const response = await authedFetch('/api/admin/agents/engage', {
+        method: 'POST',
+        body: JSON.stringify({
+          agent_key: agentKey,
+          note: note ? `Chief of Staff recommended: ${note}` : undefined,
+        }),
+      })
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`)
+      setActionResult({ label, runId: body.run_id })
+      await loadMissionControl()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Agent engagement launch failed')
+    } finally {
+      setEngagementLoadingKey(null)
+    }
+  }
+
   const topAgents = useMemo(
     () => snapshot?.roster.flatMap((pod) => pod.agents).filter((agent) => agent.status !== 'planned').slice(0, 10) ?? [],
     [snapshot],
@@ -377,12 +417,19 @@ export default function AgentOperationsPage() {
               </form>
 
               {chiefReply ? (
-                <ResultPanel
-                  title="Chief of Staff"
-                  href={`/admin/agents/runs/${chiefReply.run_id}`}
-                  body={chiefReply.reply}
-                  items={chiefReply.agent_engagements.map((agent) => `${agent.agentName}: ${agent.rationale}`)}
-                />
+                <>
+                  <ResultPanel
+                    title="Chief of Staff"
+                    href={`/admin/agents/runs/${chiefReply.run_id}`}
+                    body={chiefReply.reply}
+                    items={chiefReply.suggested_actions}
+                  />
+                  <AgentEngagementRecommendations
+                    recommendations={chiefReply.agent_engagements}
+                    loadingKey={engagementLoadingKey}
+                    onLaunch={(agent) => launchAgentEngagement(agent.agentKey, agent.agentName, agent.rationale)}
+                  />
+                </>
               ) : null}
 
               {warRoomResult ? (
@@ -419,6 +466,8 @@ export default function AgentOperationsPage() {
               </div>
             </div>
           </section>
+
+          <EngagementQueuePanel items={snapshot?.engagement_queue ?? []} />
 
           <section className="mt-5 grid grid-cols-1 gap-5 xl:grid-cols-[1fr_0.8fr]">
             <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
@@ -555,6 +604,97 @@ function DailyBriefPanel({ brief, loading }: { brief: MissionSnapshot['daily_bri
             </p>
           ))}
         </div>
+      </div>
+    </section>
+  )
+}
+
+function AgentEngagementRecommendations({
+  recommendations,
+  loadingKey,
+  onLaunch,
+}: {
+  recommendations: ChiefReply['agent_engagements']
+  loadingKey: string | null
+  onLaunch: (agent: ChiefReply['agent_engagements'][number]) => void
+}) {
+  if (!recommendations.length) return null
+
+  return (
+    <div className="mt-3 grid grid-cols-1 gap-2">
+      {recommendations.slice(0, 4).map((agent) => (
+        <div key={`${agent.agentKey}-${agent.label}`} className="rounded-lg border border-radiant-gold/20 bg-radiant-gold/5 p-3">
+          <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <p className="font-medium">{agent.agentName}</p>
+                <span className="rounded-full border border-silicon-slate/50 bg-black/10 px-2 py-0.5 text-xs text-muted-foreground">
+                  {agent.executionMode.replace(/_/g, ' ')}
+                </span>
+                <span className="rounded-full border border-silicon-slate/50 bg-black/10 px-2 py-0.5 text-xs text-muted-foreground">
+                  {agent.status}
+                </span>
+              </div>
+              <p className="mt-1 text-sm text-muted-foreground">{agent.rationale}</p>
+            </div>
+            <button
+              type="button"
+              onClick={() => onLaunch(agent)}
+              disabled={loadingKey === agent.agentKey}
+              className="inline-flex shrink-0 items-center justify-center gap-2 rounded-lg border border-radiant-gold/50 bg-radiant-gold/10 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15 disabled:opacity-60"
+            >
+              {loadingKey === agent.agentKey ? <RefreshCw size={14} className="animate-spin" /> : <Sparkles size={14} />}
+              Run read-only
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function EngagementQueuePanel({ items }: { items: MissionSnapshot['engagement_queue'] }) {
+  return (
+    <section className="mt-5 rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-2 text-radiant-gold">
+          <ClipboardList size={18} />
+          <h2 className="font-semibold">Engagement Work Queue</h2>
+        </div>
+        <Link href="/admin/agents/runs" className="text-xs text-radiant-gold hover:underline">
+          Open run console
+        </Link>
+      </div>
+      <div className="mt-3 grid grid-cols-1 gap-2 lg:grid-cols-2">
+        {items.length ? items.slice(0, 6).map((item) => (
+          <Link
+            key={item.run_id}
+            href={`/admin/agents/runs/${item.run_id}`}
+            className="rounded-lg border border-silicon-slate/50 bg-black/10 p-3 text-sm hover:border-radiant-gold/50"
+          >
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="font-medium">{item.agent_name}</span>
+              <span className="rounded-full border border-silicon-slate/50 bg-black/10 px-2 py-0.5 text-xs text-muted-foreground">
+                {item.status.replace(/_/g, ' ')}
+              </span>
+              <span className="rounded-full border border-silicon-slate/50 bg-black/10 px-2 py-0.5 text-xs text-muted-foreground">
+                {item.execution_mode.replace(/_/g, ' ')}
+              </span>
+            </div>
+            <p className="mt-2 line-clamp-2 text-muted-foreground">
+              {item.current_step ?? item.next_action ?? 'Engagement request is queued for review.'}
+            </p>
+            <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+              <span>{item.pod}</span>
+              <span>{formatTime(item.started_at)}</span>
+              {item.source_run_id ? <span>from inbox trace</span> : null}
+            </div>
+          </Link>
+        )) : (
+          <p className="rounded-lg border border-silicon-slate/50 bg-black/10 p-3 text-sm text-muted-foreground">
+            No routed agent engagements yet. Use Chief of Staff recommendations, Agent Inbox routing, or Slack `/agent run`.
+          </p>
+        )}
       </div>
     </section>
   )

--- a/app/api/admin/agents/mission-control/route.test.ts
+++ b/app/api/admin/agents/mission-control/route.test.ts
@@ -55,6 +55,7 @@ describe('GET /api/admin/agents/mission-control', () => {
         next_actions: ['Run War Room standup.'],
       },
       agent_inbox: [],
+      engagement_queue: [],
       approvals: [],
     })
   })
@@ -85,6 +86,7 @@ describe('GET /api/admin/agents/mission-control', () => {
       generated_from: 'current_state',
     })
     expect(body.agent_inbox).toEqual([])
+    expect(body.engagement_queue).toEqual([])
     expect(mocks.buildAgentMissionControlSnapshot).toHaveBeenCalledOnce()
   })
 

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -192,6 +192,7 @@ The route verifies Slack signatures with `SLACK_SIGNING_SECRET` when configured 
 - `/agent approvals` — pending approval checkpoints with run links.
 - `/agent morning-review` — runs the approved Agent Ops morning review path with `trigger_source = slack_agent_ops_command`.
 - `/agent agents` — lists active and partial agent organization entries with their engagement keys.
+- `/agent engagements` — lists the latest routed read-only engagement requests from the shared work queue.
 - `/agent inbox` — lists numbered Agent Inbox items from Mission Control.
 - `/agent brief` — returns the current Daily Operating Brief.
 - `/agent route <number-or-id>` — routes an Agent Inbox item through the same read-only Chief of Staff/agent engagement path used by the admin console.
@@ -203,7 +204,7 @@ Slack is an engagement surface, not the source of truth. The admin console and s
 
 ## Mission Control And War Room
 
-Mission Control uses `GET /api/admin/agents/mission-control` as a derived read model over existing tables. It does not introduce new schema in v1. The endpoint returns the status strip, agent roster, attention queue, Agent Inbox, Daily Operating Brief, active runs, latest events, pending approvals, and latest standup trace.
+Mission Control uses `GET /api/admin/agents/mission-control` as a derived read model over existing tables. It does not introduce new schema in v1. The endpoint returns the status strip, agent roster, attention queue, Agent Inbox, Engagement Work Queue, Daily Operating Brief, active runs, latest events, pending approvals, and latest standup trace.
 
 The Daily Operating Brief and Agent Inbox are derived views, not new persistence:
 
@@ -232,11 +233,14 @@ Engagement requests:
 - create an `agent_run` with `kind = agent_engagement_request`,
 - start in `queued`,
 - record the requested agent key, pod, runtime path, and approval gate,
+- preserve routing metadata such as source inbox item and source run when launched from Agent Inbox,
 - attach an `agent_engagement_work_packet` artifact with a readable work brief, mapped workflow coverage, and suggested next action,
 - for active or partial agents, complete a read-only dispatch step and attach an `agent_read_only_dispatch` artifact with next actions,
 - include a first-task template for priority agents so each read-only dispatch has an objective, checklist, and expected output,
 - keep planned agents queued for review until they have a narrow first task,
 - do not mutate production data.
+
+The Engagement Work Queue on `/admin/agents` and Slack `/agent engagements` are derived from these same `agent_engagement_request` traces. This makes routed requests visible as a queue without adding a new table or moving the source of truth out of `agent_runs`.
 
 ## Chief of Staff Chat
 
@@ -248,6 +252,7 @@ The first conversational agent surface is `/admin/agents/chief-of-staff`.
 - It uses `CHIEF_OF_STAFF_AGENT_MODEL` when set, otherwise `gpt-4o-mini`.
 - It returns both plain suggested follow-ups and typed action proposals using the shared runtime policy action IDs.
 - It can recommend mapped agent engagement proposals with `agent_key`, label, and rationale so the chat can launch the same read-only dispatch path used by `/admin/agents` and Slack.
+- Mission Control can launch those Chief of Staff recommendations directly through `POST /api/admin/agents/engage`, then the resulting work appears in the Engagement Work Queue.
 - Typed action proposals can be converted into approval checkpoints with `POST /api/admin/agents/chief-of-staff/actions`.
 - The approval action route creates a separate `manual` runtime run in `waiting_for_approval` and a pending `agent_approvals` record.
 - V1 remains non-executing. It can recommend next actions and create approval checkpoints, but it does not mutate production workflows, send messages, publish content, or change configuration.

--- a/lib/agent-engagement.ts
+++ b/lib/agent-engagement.ts
@@ -251,6 +251,7 @@ export async function createAgentEngagementRun(
       suggested_next_action: workPacket.nextAction,
       note,
       executes_action: false,
+      ...(input.eventMetadata ?? {}),
     },
     idempotencyKey: input.idempotencyKey ?? null,
   })

--- a/lib/agent-mission-control.test.ts
+++ b/lib/agent-mission-control.test.ts
@@ -4,7 +4,7 @@ vi.mock('@/lib/supabase', () => ({
   supabaseAdmin: null,
 }))
 
-import { buildAgentInbox, buildDailyOperatingBrief } from '@/lib/agent-mission-control'
+import { buildAgentEngagementQueue, buildAgentInbox, buildDailyOperatingBrief } from '@/lib/agent-mission-control'
 
 type InboxInput = Parameters<typeof buildAgentInbox>[0]
 type MissionRunRow = InboxInput['runs'][number]
@@ -111,5 +111,43 @@ describe('Agent Mission Control helpers', () => {
     ]))
     expect(inbox.filter((item) => item.source_run_id === 'approval-run')).toHaveLength(1)
     expect(inbox[0].priority).toBe('high')
+  })
+
+  it('builds a readable engagement queue from traced engagement requests', () => {
+    const queue = buildAgentEngagementQueue([
+      run({
+        id: 'engagement-run',
+        agent_key: 'manual',
+        kind: 'agent_engagement_request',
+        status: 'completed',
+        current_step: 'Read-only dispatch ready',
+        metadata: {
+          requested_agent: 'automation-systems',
+          route_action: 'agent_engagement',
+          agent_inbox_item_id: 'failed-run:failed',
+          source_run_id: 'failed-run',
+          note: 'Triage the failed webhook.',
+          suggested_next_action: 'Review mapped workflow health.',
+          executes_action: false,
+        },
+      }),
+      run({
+        id: 'ordinary-run',
+        kind: 'agent_task',
+      }),
+    ])
+
+    expect(queue).toHaveLength(1)
+    expect(queue[0]).toMatchObject({
+      run_id: 'engagement-run',
+      agent_key: 'automation-systems',
+      agent_name: 'Automation Systems Agent',
+      status: 'completed',
+      execution_mode: 'read_only',
+      requested_from: 'agent_engagement',
+      source_inbox_item_id: 'failed-run:failed',
+      source_run_id: 'failed-run',
+      next_action: 'Review mapped workflow health.',
+    })
   })
 })

--- a/lib/agent-mission-control.ts
+++ b/lib/agent-mission-control.ts
@@ -54,6 +54,23 @@ export type AgentInboxItem = {
   source_run_id: string | null
 }
 
+export type AgentEngagementQueueItem = {
+  run_id: string
+  agent_key: string
+  agent_name: string
+  pod: string
+  status: string
+  current_step: string | null
+  execution_mode: string
+  requested_from: string | null
+  source_inbox_item_id: string | null
+  source_run_id: string | null
+  note: string | null
+  next_action: string | null
+  started_at: string
+  completed_at: string | null
+}
+
 export type DailyOperatingBrief = {
   headline: string
   synthesis: string
@@ -104,8 +121,28 @@ function findAgent(agentKey: string | null | undefined) {
   return AGENT_ORGANIZATION.find((agent) => agent.key === agentKey) ?? AGENT_ORGANIZATION.find((agent) => agent.key === 'chief-of-staff')
 }
 
+function requestedAgentKey(run: AgentRunRow) {
+  const requested = run.metadata?.requested_agent
+  return typeof requested === 'string' && requested.trim() ? requested.trim() : run.agent_key
+}
+
+function stringMetadataValue(metadata: Record<string, unknown> | null | undefined, key: string) {
+  const value = metadata?.[key]
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function executionModeForRun(run: AgentRunRow) {
+  const explicitMode = stringMetadataValue(run.metadata, 'execution_mode')
+  if (explicitMode) return explicitMode
+
+  const executesAction = run.metadata?.executes_action ?? run.outcome?.executes_action
+  if (typeof executesAction === 'boolean') return executesAction ? 'action' : 'read_only'
+
+  return 'read_only'
+}
+
 function inboxItemForRun(run: AgentRunRow, costByRun: Map<string, number>): AgentInboxItem {
-  const agent = findAgent(run.agent_key ?? (typeof run.metadata?.requested_agent === 'string' ? run.metadata.requested_agent : null))
+  const agent = findAgent(requestedAgentKey(run))
   const cost = costByRun.get(run.id) ?? 0
   const priority: AgentInboxItem['priority'] =
     run.status === 'failed' || run.status === 'waiting_for_approval'
@@ -202,6 +239,31 @@ export function buildAgentInbox(input: {
   return [...approvalItems, ...runItems, ...(standupItem ? [standupItem] : [])]
     .filter((item, index, list) => list.findIndex((candidate) => candidate.id === item.id) === index)
     .sort((a, b) => priorityRank[a.priority] - priorityRank[b.priority])
+    .slice(0, 8)
+}
+
+export function buildAgentEngagementQueue(runs: AgentRunRow[]): AgentEngagementQueueItem[] {
+  return runs
+    .filter((run) => run.kind === 'agent_engagement_request')
+    .map((run) => {
+      const agent = findAgent(requestedAgentKey(run))
+      return {
+        run_id: run.id,
+        agent_key: agent?.key ?? 'chief-of-staff',
+        agent_name: agent?.name ?? 'Chief of Staff Agent',
+        pod: agent ? agentPodName(agent.podKey) : 'Chief of Staff',
+        status: run.status,
+        current_step: run.current_step,
+        execution_mode: executionModeForRun(run),
+        requested_from: stringMetadataValue(run.metadata, 'route_action') ?? run.subject_label,
+        source_inbox_item_id: stringMetadataValue(run.metadata, 'agent_inbox_item_id'),
+        source_run_id: stringMetadataValue(run.metadata, 'source_run_id'),
+        note: stringMetadataValue(run.metadata, 'note'),
+        next_action: stringMetadataValue(run.metadata, 'suggested_next_action'),
+        started_at: run.started_at,
+        completed_at: run.completed_at,
+      }
+    })
     .slice(0, 8)
 }
 
@@ -320,6 +382,7 @@ export async function buildAgentMissionControlSnapshot() {
     (run) => run.kind === 'agent_war_room_standup' && typeof run.outcome?.synthesis === 'string',
   )
   const agentInbox = buildAgentInbox({ runs, approvals, costByRun, latestStandup })
+  const engagementQueue = buildAgentEngagementQueue(runs)
   const costToday = Number(costs.reduce((sum, row) => sum + Number(row.amount ?? 0), 0).toFixed(4))
   const dailyBrief = buildDailyOperatingBrief({
     approvals,
@@ -373,6 +436,7 @@ export async function buildAgentMissionControlSnapshot() {
     latest_standup: latestStandup ? summarizeRun(latestStandup, costByRun) : null,
     daily_brief: dailyBrief,
     agent_inbox: agentInbox,
+    engagement_queue: engagementQueue,
     approvals: approvals.slice(0, 8),
   }
 }

--- a/lib/agent-slack-command.test.ts
+++ b/lib/agent-slack-command.test.ts
@@ -48,6 +48,7 @@ vi.mock('@/lib/agent-inbox-routing', () => ({
 import {
   agentSlackCommandInternals,
   buildAgentBriefSlackText,
+  buildAgentEngagementQueueSlackText,
   buildAgentInboxSlackText,
   createAgentEngagementSlackText,
   routeAgentInboxSlackText,
@@ -69,6 +70,9 @@ describe('agent Slack command parsing', () => {
     expect(agentSlackCommandInternals.commandFromText('morning')).toBe('morning-review')
     expect(agentSlackCommandInternals.commandFromText('agents')).toBe('agents')
     expect(agentSlackCommandInternals.commandFromText('list')).toBe('agents')
+    expect(agentSlackCommandInternals.commandFromText('engagements')).toBe('engagements')
+    expect(agentSlackCommandInternals.commandFromText('work')).toBe('engagements')
+    expect(agentSlackCommandInternals.commandFromText('queue')).toBe('engagements')
     expect(agentSlackCommandInternals.commandFromText('inbox')).toBe('inbox')
     expect(agentSlackCommandInternals.commandFromText('brief')).toBe('brief')
     expect(agentSlackCommandInternals.commandFromText('route 1')).toBe('route')
@@ -82,6 +86,7 @@ describe('agent Slack command parsing', () => {
     expect(agentSlackCommandInternals.commandFromText('unknown')).toBe('help')
     expect(agentSlackCommandInternals.formatHelp()).toContain('/agent status')
     expect(agentSlackCommandInternals.formatHelp()).toContain('/agent run <agent-key>')
+    expect(agentSlackCommandInternals.formatHelp()).toContain('/agent engagements')
     expect(agentSlackCommandInternals.formatHelp()).toContain('/agent inbox')
     expect(agentSlackCommandInternals.formatHelp()).toContain('/agent route <number-or-id>')
     expect(agentSlackCommandInternals.formatHelp()).toContain('/agent standup')
@@ -200,6 +205,30 @@ describe('agent Slack command parsing', () => {
     expect(text).toContain('Agent Inbox')
     expect(text).toContain('1. *HIGH* Automation Systems Agent')
     expect(text).toContain('/agent route <number>')
+    expect(text).toContain('/admin/agents/runs/failed-run')
+  })
+
+  it('formats the engagement work queue for Slack', async () => {
+    inboxMocks.buildAgentMissionControlSnapshot.mockResolvedValue({
+      engagement_queue: [
+        {
+          run_id: 'engagement-run',
+          agent_name: 'Automation Systems Agent',
+          status: 'completed',
+          execution_mode: 'read_only',
+          current_step: 'Read-only dispatch ready',
+          next_action: 'Review workflow health.',
+          source_run_id: 'failed-run',
+        },
+      ],
+    })
+
+    const text = await buildAgentEngagementQueueSlackText()
+
+    expect(text).toContain('Engagement Work Queue')
+    expect(text).toContain('Automation Systems Agent')
+    expect(text).toContain('[completed/read_only]')
+    expect(text).toContain('/admin/agents/runs/engagement-run')
     expect(text).toContain('/admin/agents/runs/failed-run')
   })
 

--- a/lib/agent-slack-command.ts
+++ b/lib/agent-slack-command.ts
@@ -13,6 +13,7 @@ type SlackCommandName =
   | 'approvals'
   | 'morning-review'
   | 'agents'
+  | 'engagements'
   | 'inbox'
   | 'brief'
   | 'route'
@@ -80,6 +81,7 @@ function commandFromText(text: string): SlackCommandName {
   if (command === 'approval' || command === 'approvals') return 'approvals'
   if (command === 'morning-review' || command === 'morning' || command === 'review') return 'morning-review'
   if (command === 'agents' || command === 'list') return 'agents'
+  if (command === 'engagements' || command === 'work' || command === 'queue') return 'engagements'
   if (command === 'inbox' || command === 'queue') return 'inbox'
   if (command === 'brief') return 'brief'
   if (command === 'route') return 'route'
@@ -101,6 +103,7 @@ function formatHelp() {
     '`/agent approvals` - pending approval checkpoints.',
     '`/agent morning-review` - run the approved Agent Ops morning review trace.',
     '`/agent agents` - list currently mapped agents and engagement keys.',
+    '`/agent engagements` - show the latest routed engagement work queue.',
     '`/agent inbox` - show numbered Agent Inbox items.',
     '`/agent brief` - show the current Daily Operating Brief.',
     '`/agent route <number-or-id>` - route an Agent Inbox item through Chief of Staff.',
@@ -108,6 +111,30 @@ function formatHelp() {
     '`/agent standup` - run a text War Room standup across active/partial agents.',
     '`/agent discuss <question>` - gather agent perspectives and a Chief of Staff synthesis.',
   ].join('\n')
+}
+
+export async function buildAgentEngagementQueueSlackText(limit = 5) {
+  try {
+    const snapshot = await buildAgentMissionControlSnapshot()
+    const items = snapshot.engagement_queue.slice(0, limit)
+    if (items.length === 0) {
+      return `*Engagement Work Queue*\nNo routed engagement requests yet.\nReview: ${baseUrl()}/admin/agents`
+    }
+
+    const lines = items.map((item, index) => {
+      const source = item.source_run_id ? ` from <${agentRunsUrl(item.source_run_id)}|inbox trace>` : ''
+      const step = item.current_step ?? item.next_action ?? 'Engagement request queued.'
+      return `${index + 1}. <${agentRunsUrl(item.run_id)}|${item.agent_name}> [${item.status}/${item.execution_mode}]${source}\n   ${step}`
+    })
+
+    return [
+      '*Engagement Work Queue*',
+      ...lines,
+      `Review: ${baseUrl()}/admin/agents`,
+    ].join('\n')
+  } catch (error) {
+    return `Engagement queue lookup failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+  }
 }
 
 export async function buildAgentInboxSlackText(limit = 5) {
@@ -464,19 +491,21 @@ export async function handleAgentSlackCommand(input: AgentSlackCommandInput): Pr
             ? await runMorningReviewSlackText(input)
             : command === 'agents'
               ? formatAgentListSlackText()
-              : command === 'inbox'
-                ? await buildAgentInboxSlackText()
-                : command === 'brief'
-                  ? await buildAgentBriefSlackText()
-                  : command === 'route'
-                    ? await routeAgentInboxSlackText(input)
-                    : command === 'run'
-                      ? await createAgentEngagementSlackText(input)
-                      : command === 'standup'
-                        ? await runWarRoomStandupSlackText(input)
-                        : command === 'discuss'
-                          ? await runWarRoomDiscussSlackText(input)
-                          : formatHelp()
+              : command === 'engagements'
+                ? await buildAgentEngagementQueueSlackText()
+                : command === 'inbox'
+                  ? await buildAgentInboxSlackText()
+                  : command === 'brief'
+                    ? await buildAgentBriefSlackText()
+                    : command === 'route'
+                      ? await routeAgentInboxSlackText(input)
+                      : command === 'run'
+                        ? await createAgentEngagementSlackText(input)
+                        : command === 'standup'
+                          ? await runWarRoomStandupSlackText(input)
+                          : command === 'discuss'
+                            ? await runWarRoomDiscussSlackText(input)
+                            : formatHelp()
 
   return { responseType: 'ephemeral', text }
 }


### PR DESCRIPTION
## Summary
- add an Engagement Work Queue to the Mission Control snapshot derived from `agent_engagement_request` traces
- show routed engagements on `/admin/agents` and let Chief of Staff recommendations launch read-only engagement requests
- preserve routing metadata on engagement runs so queue items can point back to source inbox traces
- add Slack `/agent engagements` for the same work queue
- update rollout docs and focused coverage

## Validation
- `npm test -- lib/agent-mission-control.test.ts lib/agent-slack-command.test.ts app/api/admin/agents/mission-control/route.test.ts app/api/admin/agents/engage/route.test.ts app/api/admin/agents/inbox/route.test.ts`
- `npm test -- app/api/slack/agent/route.test.ts lib/agent-slack-command.test.ts`
- `npm run build:knowledge && tsc --noEmit --pretty false`
- `npm run build`
- `git diff origin/main...HEAD --check`

## Integration note
This replaces closed stacked PR #127 after PR #125 merged and deleted its base branch. The branch has been rebased onto current `origin/main`.