### PR TITLE
docs: define Agent Operations roadmap

### DIFF
--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -1,0 +1,304 @@
+# Agent Operations Roadmap
+
+This roadmap is the scope-control document for Agent Operations. It defines what "done" means for the work, what belongs in each phase, and what should be deferred unless Vambah explicitly changes the scope.
+
+Portfolio admin remains the control plane. Slack remains the mobile command surface. `agent_runs`, `agent_run_steps`, `agent_run_events`, `agent_run_artifacts`, `agent_approvals`, and `cost_events.agent_run_id` remain the source of truth.
+
+## Product Definition
+
+Agent Operations is done when Vambah can:
+
+- see the agent system state at a glance from `/admin/agents`,
+- ask Chief of Staff what needs attention,
+- run or route read-only agent work from Mission Control or Slack,
+- see every agent run, handoff, artifact, approval, and cost in a traceable place,
+- approve or reject side-effecting work before it touches production, clients, public channels, or private-to-public material,
+- understand which agents are live, partial, planned, or deferred,
+- run the same morning/standup/status workflow without needing a human to manually check multiple tools,
+- hand off merge/deployment responsibility to the Integration Captain without losing traceability.
+
+## Operating Principles
+
+- One control plane: Portfolio admin is authoritative.
+- One mobile channel: Slack is enough for v1.
+- One trace model: all runtimes write into the shared agent run tables.
+- Read-only first: new agents start as advisory or dispatch-only.
+- Approval before mutation: publishing, sending, production writes, config changes, and private-to-public content require `agent_approvals`.
+- No hidden runtimes: Hermes, OpenCode, n8n, manual, and Codex work must be observable before they become operationally important.
+- Integration Captain owns merges to `main`; feature agents branch, commit, push, and stop.
+
+## Phase Roadmap
+
+### Phase 0: Architecture Baseline
+
+Status: Complete.
+
+Goal: Establish the runtime and trace model without breaking existing workflow pages.
+
+Definition of done:
+
+- `docs/agent-operations-rollout.md` names the architecture, runtimes, and statuses.
+- Supported runtimes are `codex`, `n8n`, `hermes`, `opencode`, and `manual`.
+- Supported statuses are `queued`, `running`, `waiting_for_approval`, `completed`, `failed`, `cancelled`, and `stale`.
+- Existing workflow-specific admin pages remain live.
+
+Out of scope:
+
+- Replacing every workflow status page.
+- Promoting Hermes or OpenCode as primary orchestrators.
+
+### Phase 1: Shared Trace Foundation
+
+Status: Complete.
+
+Goal: Make agent work observable through shared tables and helpers.
+
+Definition of done:
+
+- Shared schema exists for registry, runs, steps, events, artifacts, handoffs, and approvals.
+- `cost_events.agent_run_id` links usage cost to agent runs.
+- `lib/agent-run.ts` supports start, step, event, artifact, completion, and failure writes.
+- Helpers are retry-safe where practical through idempotency keys.
+- Unit tests cover core trace helper behavior.
+
+Out of scope:
+
+- Migrating every historical workflow table.
+- Building detailed dashboards before the trace foundation exists.
+
+### Phase 2: Mission Control Console
+
+Status: In review.
+
+Goal: Turn `/admin/agents` into a first-screen command center rather than a long observability page.
+
+Definition of done:
+
+- `/admin/agents` shows status strip, Daily Operating Brief, Chief of Staff command, Agent Inbox, Engagement Work Queue, active/partial roster, controls, and latest activity.
+- `/admin/agents/runs` lists recent and active runs.
+- `/admin/agents/runs/[runId]` shows timeline, artifacts, costs, approvals, errors, and related context.
+- Dense controls move into drilldowns or compact sections.
+- Admin route protection is consistent with other admin pages.
+- UI smoke confirms first viewport loads without server error.
+
+Out of scope:
+
+- A separate 3D graph or animated agent map.
+- Replacing every workflow-specific admin route.
+- Public-facing agent surfaces.
+
+### Phase 3: Conversational Routing
+
+Status: In review.
+
+Goal: Make Chief of Staff the natural-language front door for agent work.
+
+Definition of done:
+
+- `/admin/agents/chief-of-staff` can answer status, blocker, priority, and next-action questions from Agent Ops context.
+- Chief of Staff writes a traced `codex` run for each exchange.
+- Chief of Staff can return typed agent engagement recommendations.
+- Mission Control can launch recommended read-only engagements with `POST /api/admin/agents/engage`.
+- Launched engagements appear in the Engagement Work Queue and run console.
+
+Out of scope:
+
+- Letting Chief of Staff mutate production data directly.
+- Autonomous planning loops that launch multiple agents without traceable operator intent.
+- Long-term memory beyond trace/artifact summaries.
+
+### Phase 4: Agent Inbox And Work Queue
+
+Status: In review.
+
+Goal: Convert trace signals into a clear operating queue.
+
+Definition of done:
+
+- Agent Inbox derives actionable items from failed, stale, approval-waiting, high-cost, and stale-standup signals.
+- Admin can route inbox items.
+- Slack can list and route inbox items.
+- Engagement Work Queue derives from `agent_engagement_request` traces.
+- Queue items preserve source inbox item, source run, owning agent, next action, execution mode, and trace link.
+- No new table is introduced unless trace-derived queue state proves insufficient.
+
+Out of scope:
+
+- Kanban drag-and-drop.
+- Custom assignment tables.
+- Queue state that does not reconcile back to `agent_runs`.
+
+### Phase 5: Slack Mobile Command Surface
+
+Status: In review.
+
+Goal: Let Vambah check and route Agent Ops from Slack without adding another mobile channel.
+
+Definition of done:
+
+- `/agent status` summarizes active, failed, stale, approval, and cost signals.
+- `/agent agents` lists mapped runnable agents.
+- `/agent inbox` lists numbered Agent Inbox items.
+- `/agent route <number-or-id>` routes an inbox item.
+- `/agent engagements` lists the latest routed engagement queue.
+- `/agent brief` returns the Daily Operating Brief.
+- `/agent run <agent-key>` creates a traced read-only engagement.
+- `/agent standup` and `/agent discuss <question>` write War Room traces.
+- Slack signing is fail-closed when configured for production.
+- Slow commands either respond within Slack expectations or use a durable delayed path.
+
+Out of scope:
+
+- Telegram, SMS, Discord, or other chat surfaces in v1.
+- Slack actions that publish, send email, or write production data without approval.
+
+### Phase 6: n8n Production Instrumentation
+
+Status: Partial.
+
+Goal: Make production automations visible through the shared trace model.
+
+Definition of done:
+
+- App-triggered n8n calls include `agent_run_id`.
+- n8n callbacks can record progress events, completion, and structured failures.
+- Outreach, social content, value evidence, and warm lead workflows have shared trace coverage where practical.
+- Legacy workflow status pages remain compatible during migration.
+- Failure callbacks show in Agent Inbox and run detail.
+
+Out of scope:
+
+- Rewriting all n8n workflows at once.
+- Removing legacy workflow-specific run tables before replacement views are proven.
+- Letting n8n bypass approval gates for sensitive actions.
+
+### Phase 7: Approval-Backed Execution
+
+Status: Partial.
+
+Goal: Move from read-only dispatch toward safe execution where side effects are explicit.
+
+Definition of done:
+
+- Runtime policy is visible and test-covered.
+- Approval checkpoints use `agent_approvals`, not local UI state.
+- Run detail supports approval and rejection for pending checkpoints.
+- Publishing, outbound email, production data writes, config changes, and private-to-public content require approval.
+- Approval decisions are recorded as trace events.
+- Rejected work terminates safely or returns a reviewable failure.
+
+Out of scope:
+
+- Background agents approving their own work.
+- Implicit approval from Slack text that does not map to a specific checkpoint.
+- Bulk approvals without explicit target runs.
+
+### Phase 8: Hermes Secondary Runtime
+
+Status: Partial.
+
+Goal: Add Hermes as a secondary observable runtime for low-risk work.
+
+Definition of done:
+
+- Hermes is registered as a supported runtime.
+- Hermes system health bridge creates traced `hermes` runs.
+- Hermes outputs attach artifacts.
+- Hermes failures write structured events.
+- Hermes remains read-only for production-adjacent workflows unless an approval checkpoint exists.
+
+Out of scope:
+
+- Letting the web app spawn uncontrolled local Hermes processes.
+- Production data mutation through Hermes in v1.
+- Making Hermes the primary orchestrator.
+
+### Phase 9: Runtime Evaluation And Tooling Parity
+
+Status: Partial.
+
+Goal: Evaluate OpenCode/OpenClaw and future runtimes without letting them become hidden production dependencies.
+
+Definition of done:
+
+- Runtime evaluation route can detect whether candidate binaries exist.
+- At least one observable evaluation run writes to Agent Operations.
+- Tooling parity docs explain which runtimes can access which tools.
+- Any future worker runtime must prove install, auth, trace, rollback, and audit behavior before production automation.
+
+Out of scope:
+
+- OpenCode/OpenClaw production automation.
+- Untracked local worktree mutation from the admin UI.
+- Auto-installing agent runtimes from the web app.
+
+### Phase 10: Hardening, Reporting, And Migration
+
+Status: Planned.
+
+Goal: Make Agent Operations reliable enough to run as an operating system.
+
+Definition of done:
+
+- Stale-run detection covers all runtimes.
+- Dead-letter handling exists for failed or abandoned runs.
+- Cost dashboards group by runtime, agent, workflow, client/project, and artifact type.
+- Morning review runs on schedule and writes a traceable report.
+- Deployment watcher distinguishes Vercel queue delay from failure.
+- Old workflow run tables are either migrated or documented as domain-specific detail.
+- `docs/agentic-patterns.md` is updated once observability coverage is strong.
+
+Out of scope:
+
+- Removing working legacy tables just for architectural purity.
+- Fully autonomous production remediation.
+- Cost optimization that changes vendors without a bakeoff.
+
+## Cross-Phase Definition Of Done
+
+Every implementation phase must satisfy these gates before it is considered done:
+
+- Source of truth: New operational state is trace-backed or explicitly documented as derived.
+- UI: Admin can see the state or action without digging through raw logs.
+- Slack: If the workflow is mobile-relevant, Slack has a read-only command or clear reason for deferral.
+- Tests: Focused tests cover happy path, auth boundaries, malformed input, and failure behavior.
+- Type/build: Typecheck and production build pass, or failures are documented as pre-existing blockers.
+- Browser smoke: `/admin/agents` or the touched admin surface loads in the integrated browser.
+- Audit: Runs, approvals, events, and artifacts link back to a trace ID.
+- Safety: Side effects are approval-gated.
+- Integration: Work is on a named branch or PR, not merged directly to `main` by a non-captain chat.
+- Deployment: Integration Captain verifies both `portfolio` and `portfolio-staging`.
+
+## Scope Creep Rules
+
+The following require an explicit scope-change decision before implementation:
+
+- Adding a new chat channel beyond Slack.
+- Adding a new database table for queue state.
+- Adding autonomous multi-agent loops that launch more than one agent from one operator request.
+- Letting any runtime write production data outside a known workflow.
+- Letting Hermes or OpenCode mutate files or data from the web app.
+- Replacing legacy workflow pages.
+- Building visual graph/3D/animation-first views.
+- Adding new vendor/model/runtime dependencies without a bakeoff.
+- Moving merge/deploy authority away from the Integration Captain.
+
+## Current Review Stack
+
+These are the current known Agent Operations PR dependencies:
+
+- PR #125: Agent Inbox routing.
+- PR #127: Engagement Work Queue.
+
+Integration order:
+
+1. Merge PR #125.
+2. Retarget or merge PR #127.
+3. Rebase this roadmap branch if needed.
+4. Verify `portfolio` and `portfolio-staging`.
+
+## Next Three Build Phases
+
+1. Queue affordances: filters, owner/next-action clarity, and a focused queue drilldown if the overview becomes crowded.
+2. Approval-backed execution: convert recommended side effects into approval checkpoints with explicit action payloads.
+3. n8n trace expansion: make the highest-value automation workflows report progress and failure into Agent Operations consistently.

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -2,7 +2,7 @@
 
 The Portfolio admin remains the control plane. Codex and n8n stay as the primary operating backbone, while Hermes is added as a secondary runtime after shared run tracing is available. OpenCode/OpenClaw are deferred until their work can be observed, audited, and rolled back through the same trace model.
 
-The active execution queue for the remaining rollout work lives in [Agent Operations Task List](./agent-operations-task-list.md).
+The phase gates, definitions of done, and scope-control rules live in [Agent Operations Roadmap](./agent-operations-roadmap.md). The active execution queue for the remaining rollout work lives in [Agent Operations Task List](./agent-operations-task-list.md).
 
 ## Runtime Model
 

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -1,46 +1,65 @@
 # Agent Operations Task List
 
-This is the active implementation queue for turning the agent organization into usable operating software.
+This is the active implementation queue for Agent Operations. The phase gates, definitions of done, and scope-control rules live in [Agent Operations Roadmap](./agent-operations-roadmap.md). If a proposed task is not allowed by that roadmap, treat it as a scope-change request before implementing it.
 
-## Current Autopilot Block
+## Integration Queue
 
-- [x] Confirm baseline: `origin/main`, open PRs, and production/staging Vercel deployment state.
-- [x] Keep Portfolio admin as the source of truth for agent operations.
-- [x] Support read-only agent dispatch from `/admin/agents`.
-- [x] Support the same read-only dispatch from Slack `/agent run <agent-key>`.
-- [x] Let Chief of Staff chat recommend mapped agents and launch their read-only dispatch runs.
-- [x] Keep every launched agent engagement visible in `/admin/agents/runs`.
-- [x] Add first-task templates to read-only dispatch artifacts for priority agents.
-- [x] Add read-only Automation Context visibility for Portfolio-related Codex automations.
-- [ ] Validate with focused tests, typecheck, lint, build, PR previews, merge, and production/staging deployment checks.
+- [ ] Merge PR #125: Agent Inbox routing.
+- [ ] Retarget or merge PR #127: Engagement Work Queue.
+- [ ] Merge this roadmap definition branch after PR #125 and PR #127 are reconciled.
+- [ ] Verify both Vercel contexts after merge:
+  - `Vercel – portfolio`
+  - `Vercel – portfolio-staging`
 
-## Next Operating Milestones
+## Next Build Queue
 
-1. Chief of Staff dispatcher
-   - The chat should recommend which mapped agent to run next.
-   - Recommendations should include `agent_key`, label, and rationale.
-   - Launching the recommendation must create the same traced read-only engagement used by admin and Slack.
+1. Queue affordances
+   - Add filters for status, agent, runtime, source, and execution mode.
+   - Clarify owner, next action, and source trace on queue items.
+   - Add a focused `/admin/agents/work` drilldown only if the overview becomes too crowded.
 
-2. Agent-specific first tasks
-   - Give the highest-value agents a first narrow read-only task:
-     - `chief-of-staff`
-     - `research-source-register`
-     - `voice-content-architect`
-     - `automation-systems`
-     - `inbox-follow-up`
-   - Planned agents should stay queued until the first task is explicit.
+2. Approval-backed execution
+   - Convert Chief of Staff side-effect recommendations into explicit approval checkpoints.
+   - Store the action payload with the approval/run artifact.
+   - Keep email, publishing, production config, unknown DB writes, and private-to-public material behind `agent_approvals`.
 
-3. Approval-backed execution
-   - Convert safe read-only recommendations into approval checkpoints when they require side effects.
-   - Keep publishing, outbound email, unknown database writes, production config, and private-to-public content behind `agent_approvals`.
+3. n8n trace expansion
+   - Prioritize workflows that already touch production automation or LLM costs.
+   - Pass `agent_run_id` into app-triggered payloads.
+   - Add progress, completion, and failure callbacks.
+   - Keep legacy workflow pages active until replacement views are proven.
 
-4. Mobile operation
-   - Keep Slack as the lightweight command surface.
-   - Keep Portfolio admin as the source of truth.
-   - Avoid adding another channel unless Slack cannot support the workflow.
+4. Reporting and hardening
+   - Add all-runtime stale-run detection.
+   - Add dead-letter handling for failed runs.
+   - Add cost summaries by runtime, agent, workflow, client/project, and artifact type.
+   - Keep morning review and deployment watcher outputs visible in Agent Operations.
 
-5. Hardening
-   - Keep Codex automation context visible in Agent Operations so future agents can inspect purpose, cadence, authority boundary, and missing context before acting.
-   - Add stale-run handling for every runtime.
-   - Add dashboard-level cost summaries by agent and runtime.
-   - Keep n8n compatibility adapters live until the generic trace model is proven.
+## Completed Or In Review
+
+- [x] Shared trace schema and helper library.
+- [x] `/admin/agents`, `/admin/agents/runs`, and run detail pages.
+- [x] Mission Control first-screen command center.
+- [x] Daily Operating Brief.
+- [x] Chief of Staff command and typed recommendations.
+- [x] Agent Inbox derived from trace signals.
+- [x] Read-only agent dispatch from admin and Slack.
+- [x] Slack `/agent` command surface for status, agents, inbox, route, brief, run, standup, and discuss.
+- [x] Hermes health bridge as read-only runtime trace.
+- [x] Approval drill and run-detail approval decisions.
+- [x] Runtime evaluation probe for OpenCode/OpenClaw.
+- [x] Engagement Work Queue in review.
+
+## Scope Guard
+
+Do not add the following without an explicit scope-change decision:
+
+- another chat channel beyond Slack,
+- a separate queue table,
+- autonomous multi-agent launch loops,
+- production data writes outside known workflows,
+- Hermes/OpenCode mutation from the web app,
+- replacement of legacy workflow pages,
+- graph/3D/animation-first views,
+- new vendors, models, or runtimes without a bakeoff,
+- non-captain merges to `main`.


### PR DESCRIPTION
## Summary

Adds a scope-control roadmap for Agent Operations so the rollout has explicit phase gates, definitions of done, and out-of-scope boundaries.

Updates the rollout and task-list docs to point at the roadmap as the source of truth for phase gating and scope creep control.

## Integration Notes

This replaces closed stacked PR #128 after PR #129 landed. The branch has been rebased onto current `origin/main` and now contains only the roadmap docs delta.

## Validation

- `git diff origin/main...HEAD --check`
- `rg -n "agent-operations-roadmap|agent-operations-task-list|agent-operations-rollout" docs/agent-operations-roadmap.md docs/agent-operations-rollout.md docs/agent-operations-task-list.md`

Docs-only change; no app build was required for this branch.