### PR TITLE
feat: add approval-backed action payloads

### DIFF
--- a/app/admin/agents/runs/[runId]/page.tsx
+++ b/app/admin/agents/runs/[runId]/page.tsx
@@ -213,9 +213,9 @@ function List({
         <div key={String(row.id)} className="rounded-lg border border-silicon-slate/50 bg-background/40 p-3">
           <p className="font-medium">{String(row[titleKey] || fallbackTitle)}</p>
           <p className="text-sm text-muted-foreground">{String(row[detailKey] ?? '')}</p>
-          {artifactSummary(row) ? (
+          {rowSummary(row) ? (
             <pre className="mt-2 max-h-56 overflow-auto whitespace-pre-wrap rounded-md bg-black/20 p-3 text-xs text-muted-foreground">
-              {artifactSummary(row)}
+              {rowSummary(row)}
             </pre>
           ) : null}
           {onDecision && row.status === 'pending' && typeof row.id === 'string' ? (
@@ -255,9 +255,23 @@ function asString(value: unknown): string | undefined {
   return typeof value === 'string' ? value : undefined
 }
 
-function artifactSummary(row: AnyRow): string | null {
+function rowSummary(row: AnyRow): string | null {
   const metadata = row.metadata
   if (!metadata || typeof metadata !== 'object') return null
-  const summary = (metadata as Record<string, unknown>).summary_markdown
-  return typeof summary === 'string' ? summary : null
+  const record = metadata as Record<string, unknown>
+  const summary = record.summary_markdown
+  if (typeof summary === 'string') return summary
+
+  const payload = record.action_payload
+  if (payload && typeof payload === 'object') {
+    const actionPayload = payload as Record<string, unknown>
+    return [
+      `Action: ${String(actionPayload.action ?? '-').replace(/_/g, ' ')}`,
+      `Approval type: ${String(actionPayload.approval_type ?? '-').replace(/_/g, ' ')}`,
+      `Risk: ${String(actionPayload.risk_level ?? '-')}`,
+      `Executes action now: ${actionPayload.executes_action ? 'yes' : 'no'}`,
+      `Boundary: ${String(actionPayload.side_effect_boundary ?? 'No side effect is executed by this checkpoint.')}`,
+    ].join('\n')
+  }
+  return null
 }

--- a/app/api/admin/agents/chief-of-staff/actions/route.test.ts
+++ b/app/api/admin/agents/chief-of-staff/actions/route.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   isAuthError: vi.fn(),
   startAgentRun: vi.fn(),
   recordAgentEvent: vi.fn(),
+  attachAgentArtifact: vi.fn(),
   from: vi.fn(),
   insert: vi.fn(),
 }))
@@ -17,6 +18,7 @@ vi.mock('@/lib/auth-server', () => ({
 vi.mock('@/lib/agent-run', () => ({
   startAgentRun: mocks.startAgentRun,
   recordAgentEvent: mocks.recordAgentEvent,
+  attachAgentArtifact: mocks.attachAgentArtifact,
 }))
 
 vi.mock('@/lib/supabase', () => ({
@@ -58,6 +60,7 @@ describe('POST /api/admin/agents/chief-of-staff/actions', () => {
     mocks.isAuthError.mockReturnValue(false)
     mocks.startAgentRun.mockResolvedValue({ id: 'approval-run-1' })
     mocks.recordAgentEvent.mockResolvedValue({ id: 'event-1' })
+    mocks.attachAgentArtifact.mockResolvedValue({ id: 'artifact-1' })
     approvalInsertChain()
   })
 
@@ -92,12 +95,40 @@ describe('POST /api/admin/agents/chief-of-staff/actions', () => {
       kind: 'chief_of_staff_action_approval',
       status: 'waiting_for_approval',
       triggeredByUserId: 'admin-user',
+      metadata: expect.objectContaining({
+        action_payload: expect.objectContaining({
+          action: 'send_email',
+          approval_type: 'send_email',
+          source_run_id: 'chief-run-1',
+          requested_by_user_id: 'admin-user',
+          executes_action: false,
+        }),
+      }),
     }))
     expect(mocks.insert).toHaveBeenCalledWith(expect.objectContaining({
       run_id: 'approval-run-1',
       approval_type: 'send_email',
       status: 'pending',
       requested_by_agent_key: 'chief-of-staff',
+      metadata: expect.objectContaining({
+        action_payload: expect.objectContaining({
+          action: 'send_email',
+          executes_action: false,
+        }),
+      }),
+    }))
+    expect(mocks.attachAgentArtifact).toHaveBeenCalledWith(expect.objectContaining({
+      runId: 'approval-run-1',
+      artifactType: 'approval_action_payload',
+      refType: 'agent_approval',
+      refId: 'approval-1',
+      metadata: expect.objectContaining({
+        summary_markdown: expect.stringContaining('Approval Action Payload'),
+        action_payload: expect.objectContaining({
+          action: 'send_email',
+          executes_action: false,
+        }),
+      }),
     }))
   })
 

--- a/app/api/admin/agents/chief-of-staff/actions/route.ts
+++ b/app/api/admin/agents/chief-of-staff/actions/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
-import { recordAgentEvent, startAgentRun } from '@/lib/agent-run'
+import { attachAgentArtifact, recordAgentEvent, startAgentRun } from '@/lib/agent-run'
 import {
   actionRequiresApproval,
   getApprovalGate,
@@ -56,6 +56,60 @@ function normalizeProposal(value: unknown): ChiefOfStaffActionProposal | null {
   }
 }
 
+function sideEffectBoundary(action: AgentAction) {
+  switch (action) {
+    case 'send_email':
+      return 'No email is sent until this approval checkpoint is approved and executed by an approved workflow.'
+    case 'publish_public_content':
+      return 'No public content is published until this approval checkpoint is approved and executed by an approved workflow.'
+    case 'production_config_change':
+      return 'No production configuration is changed until this approval checkpoint is approved and executed by an approved workflow.'
+    case 'unknown_db_write':
+      return 'No database write outside known workflows is performed until this approval checkpoint is approved.'
+    case 'public_content_from_private_material':
+      return 'No private-derived material is moved to a public channel until this approval checkpoint is approved.'
+    default:
+      return 'The proposed action is recorded for review; no side effect is executed by this checkpoint.'
+  }
+}
+
+function buildActionPayload(input: {
+  proposal: ChiefOfStaffActionProposal
+  sourceRunId: string
+  userId: string
+}) {
+  return {
+    version: 1,
+    action: input.proposal.action,
+    approval_type: input.proposal.approvalType,
+    label: input.proposal.label,
+    description: input.proposal.description,
+    risk_level: input.proposal.riskLevel,
+    source_run_id: input.sourceRunId,
+    requested_by_user_id: input.userId,
+    execution_mode: 'approval_required',
+    executes_action: false,
+    side_effect_boundary: sideEffectBoundary(input.proposal.action),
+    created_at: new Date().toISOString(),
+  }
+}
+
+function formatActionPayloadSummary(payload: ReturnType<typeof buildActionPayload>) {
+  return [
+    `# Approval Action Payload: ${payload.label}`,
+    '',
+    `- Action: ${String(payload.action).replace(/_/g, ' ')}`,
+    `- Approval type: ${String(payload.approval_type).replace(/_/g, ' ')}`,
+    `- Risk: ${payload.risk_level}`,
+    `- Source run: ${payload.source_run_id}`,
+    `- Executes action now: ${payload.executes_action ? 'yes' : 'no'}`,
+    '',
+    payload.description,
+    '',
+    `Boundary: ${payload.side_effect_boundary}`,
+  ].join('\n')
+}
+
 /**
  * POST /api/admin/agents/chief-of-staff/actions
  *
@@ -92,6 +146,12 @@ export async function POST(request: NextRequest) {
   }
 
   try {
+    const actionPayload = buildActionPayload({
+      proposal,
+      sourceRunId,
+      userId: auth.user.id,
+    })
+
     const run = await startAgentRun({
       agentKey: 'chief-of-staff',
       runtime: 'manual',
@@ -109,6 +169,7 @@ export async function POST(request: NextRequest) {
       metadata: {
         source_run_id: sourceRunId,
         proposal,
+        action_payload: actionPayload,
         executes_action: false,
       },
       idempotencyKey: `chief-of-staff-action:${sourceRunId}:${proposal.action}:${auth.user.id}:${Date.now()}`,
@@ -124,6 +185,7 @@ export async function POST(request: NextRequest) {
         metadata: {
           source_run_id: sourceRunId,
           proposal,
+          action_payload: actionPayload,
           executes_action: false,
         },
       })
@@ -143,8 +205,25 @@ export async function POST(request: NextRequest) {
         approval_id: data.id,
         source_run_id: sourceRunId,
         proposal,
+        action_payload: actionPayload,
       },
       idempotencyKey: `${run.id}:chief-of-staff-approval-created`,
+    }).catch(() => {})
+
+    await attachAgentArtifact({
+      runId: run.id,
+      artifactType: 'approval_action_payload',
+      title: `Approval payload: ${proposal.label}`,
+      refType: 'agent_approval',
+      refId: data.id,
+      metadata: {
+        summary_markdown: formatActionPayloadSummary(actionPayload),
+        approval_id: data.id,
+        approval_type: approvalType,
+        source_run_id: sourceRunId,
+        action_payload: actionPayload,
+      },
+      idempotencyKey: `${run.id}:approval-action-payload`,
     }).catch(() => {})
 
     return NextResponse.json({

--- a/app/api/admin/agents/runs/[runId]/approval/route.test.ts
+++ b/app/api/admin/agents/runs/[runId]/approval/route.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  from: vi.fn(),
+  approvalUpdate: vi.fn(),
+  eventInsert: vi.fn(),
+  runUpdate: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import { POST } from './route'
+
+function makeRequest(body: unknown = {}) {
+  return new Request('http://localhost/api/admin/agents/runs/run-1/approval', {
+    method: 'POST',
+    headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+function eqChain<T>(result: T) {
+  const secondEq = vi.fn(() => result)
+  const firstEq = vi.fn(() => ({ eq: secondEq }))
+  return { eq: firstEq }
+}
+
+function setupSupabase(existingMetadata: Record<string, unknown> = {}) {
+  const existingSingle = vi.fn().mockResolvedValue({
+    data: {
+      id: 'approval-1',
+      approval_type: 'send_email',
+      metadata: existingMetadata,
+    },
+    error: null,
+  })
+  const updateSingle = vi.fn().mockResolvedValue({ data: { id: 'approval-1' }, error: null })
+  const pendingLimit = vi.fn().mockResolvedValue({ data: [], error: null })
+  const select = vi.fn((columns: string) => {
+    if (columns === 'id, approval_type, metadata') return { ...eqChain({ single: existingSingle }) }
+    if (columns === 'id') return { ...eqChain({ limit: pendingLimit }) }
+    return { ...eqChain({ single: vi.fn().mockResolvedValue({ data: null, error: null }) }) }
+  })
+
+  mocks.approvalUpdate.mockImplementation((payload) => ({
+    ...eqChain({
+      select: vi.fn(() => ({ single: updateSingle })),
+    }),
+    payload,
+  }))
+  mocks.eventInsert.mockResolvedValue({ data: { id: 'event-1' }, error: null })
+  mocks.runUpdate.mockImplementation(() => ({
+    eq: vi.fn(() => ({ eq: vi.fn().mockResolvedValue({ data: null, error: null }) })),
+  }))
+  mocks.from.mockImplementation((table: string) => {
+    if (table === 'agent_approvals') {
+      return {
+        select,
+        update: mocks.approvalUpdate,
+        insert: vi.fn(() => ({ select: vi.fn(() => ({ single: updateSingle })) })),
+      }
+    }
+    if (table === 'agent_run_events') return { insert: mocks.eventInsert }
+    if (table === 'agent_runs') return { update: mocks.runUpdate }
+    return {}
+  })
+}
+
+describe('POST /api/admin/agents/runs/[runId]/approval', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+  })
+
+  it('preserves existing action payload metadata when deciding an approval', async () => {
+    setupSupabase({
+      source_run_id: 'chief-run-1',
+      action_payload: {
+        action: 'send_email',
+        approval_type: 'send_email',
+        executes_action: false,
+      },
+    })
+
+    const response = await POST(makeRequest({
+      approval_id: 'approval-1',
+      status: 'approved',
+      decision_notes: 'Approved after reviewing the payload.',
+      metadata: {
+        action_payload: { action: 'tampered' },
+        reviewer_context: 'run detail',
+      },
+    }) as never, { params: { runId: 'run-1' } })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ ok: true, approval_id: 'approval-1' })
+    expect(mocks.approvalUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'approved',
+      decided_by_user_id: 'admin-user',
+      decision_notes: 'Approved after reviewing the payload.',
+      metadata: expect.objectContaining({
+        source_run_id: 'chief-run-1',
+        action_payload: expect.objectContaining({
+          action: 'send_email',
+          executes_action: false,
+        }),
+        reviewer_context: 'run detail',
+        decision: expect.objectContaining({
+          status: 'approved',
+          decision_notes: 'Approved after reviewing the payload.',
+          decided_by_user_id: 'admin-user',
+        }),
+      }),
+    }))
+    expect(mocks.eventInsert).toHaveBeenCalledWith(expect.objectContaining({
+      event_type: 'approval_decided',
+      metadata: expect.objectContaining({
+        approval_id: 'approval-1',
+        status: 'approved',
+      }),
+    }))
+  })
+
+  it('returns 404 when the approval id does not belong to the run', async () => {
+    const existingSingle = vi.fn().mockResolvedValue({ data: null, error: { message: 'not found' } })
+    mocks.from.mockReturnValue({
+      select: vi.fn(() => ({ ...eqChain({ single: existingSingle }) })),
+    })
+
+    const response = await POST(makeRequest({
+      approval_id: 'missing-approval',
+      status: 'approved',
+    }) as never, { params: { runId: 'run-1' } })
+
+    expect(response.status).toBe(404)
+    expect(await response.json()).toEqual({ error: 'Approval not found' })
+    expect(mocks.approvalUpdate).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/admin/agents/runs/[runId]/approval/route.ts
+++ b/app/api/admin/agents/runs/[runId]/approval/route.ts
@@ -48,6 +48,37 @@ export async function POST(
   let approvalId = body.approval_id ?? null
 
   if (approvalId) {
+    const { data: existing, error: existingError } = await supabaseAdmin
+      .from('agent_approvals')
+      .select('id, approval_type, metadata')
+      .eq('id', approvalId)
+      .eq('run_id', params.runId)
+      .single()
+
+    if (existingError || !existing?.id) {
+      console.error('[agent-approval] read failed:', existingError)
+      return NextResponse.json({ error: 'Approval not found' }, { status: 404 })
+    }
+
+    const existingMetadata =
+      existing.metadata && typeof existing.metadata === 'object'
+        ? existing.metadata as Record<string, unknown>
+        : {}
+    const decisionMetadata = decided
+      ? {
+          status,
+          decision_notes: body.decision_notes ?? null,
+          decided_by_user_id: auth.user.id,
+          decided_at: new Date().toISOString(),
+        }
+      : null
+    const mergedMetadata = {
+      ...existingMetadata,
+      ...(body.metadata ?? {}),
+      ...(existingMetadata.action_payload ? { action_payload: existingMetadata.action_payload } : {}),
+      ...(decisionMetadata ? { decision: decisionMetadata } : {}),
+    }
+
     const { data, error } = await supabaseAdmin
       .from('agent_approvals')
       .update({
@@ -55,7 +86,7 @@ export async function POST(
         decided_by_user_id: decided ? auth.user.id : null,
         decided_at: decided ? new Date().toISOString() : null,
         decision_notes: body.decision_notes ?? null,
-        metadata: body.metadata ?? {},
+        metadata: mergedMetadata,
       })
       .eq('id', approvalId)
       .eq('run_id', params.runId)
@@ -95,7 +126,12 @@ export async function POST(
     event_type: approvalId === body.approval_id ? 'approval_decided' : 'approval_recorded',
     severity: status === 'rejected' ? 'warning' : 'info',
     message: `${body.approval_type ?? body.approval_id}: ${status}`,
-    metadata: { approval_id: approvalId, status },
+    metadata: {
+      approval_id: approvalId,
+      status,
+      decision_notes: body.decision_notes ?? null,
+      ...(body.metadata ?? {}),
+    },
   })
 
   if (status === 'pending') {

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -19,9 +19,10 @@ This is the active implementation queue for Agent Operations. The phase gates, d
    - [x] Keep this inside Mission Control; do not add `/admin/agents/work` unless the overview becomes crowded after review.
 
 2. Approval-backed execution
-   - Convert Chief of Staff side-effect recommendations into explicit approval checkpoints.
-   - Store the action payload with the approval/run artifact.
-   - Keep email, publishing, production config, unknown DB writes, and private-to-public material behind `agent_approvals`.
+   - [x] Convert Chief of Staff side-effect recommendations into explicit approval checkpoints.
+   - [x] Store the action payload with the approval/run artifact.
+   - [x] Preserve approval action payload metadata when approve/reject decisions are recorded.
+   - [x] Keep email, publishing, production config, unknown DB writes, and private-to-public material behind `agent_approvals`.
 
 3. n8n trace expansion
    - Prioritize workflows that already touch production automation or LLM costs.
@@ -50,6 +51,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 - [x] Runtime evaluation probe for OpenCode/OpenClaw.
 - [x] Engagement Work Queue in review.
 - [x] Queue affordance filters and owner/source clarity in review.
+- [x] Approval-backed execution payloads and decision metadata in review.
 
 ## Scope Guard
 


### PR DESCRIPTION
## Summary
- records explicit approval action payloads for Chief of Staff side-effect recommendations
- attaches the approval payload as an agent artifact and keeps run/approval metadata aligned
- preserves original action payload metadata when approval decisions are recorded
- renders approval action payload summaries on run detail rows

## Safety scope
- no schema changes
- no action execution path added
- no email, publishing, production config, or unknown database writes are performed by this change
- side-effect recommendations remain gated by `agent_approvals`

## Validation
- `npm test -- app/api/admin/agents/chief-of-staff/actions/route.test.ts 'app/api/admin/agents/runs/[runId]/approval/route.test.ts' app/api/admin/agents/approval-drill/route.test.ts`\n- `npx tsc --noEmit`\n- `npm run build`\n- `git diff --check`\n- pre-push `npm run db:health-check`