### PR TITLE
feat: add n8n agent trace callbacks

### DIFF
--- a/app/api/admin/agents/runs/[runId]/events/route.test.ts
+++ b/app/api/admin/agents/runs/[runId]/events/route.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  recordAgentEvent: vi.fn(),
+  recordAgentStep: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-run', () => ({
+  AGENT_EVENT_SEVERITIES: ['debug', 'info', 'warning', 'error'],
+  AGENT_RUN_STATUSES: ['queued', 'running', 'waiting_for_approval', 'completed', 'failed', 'cancelled', 'stale'],
+  recordAgentEvent: mocks.recordAgentEvent,
+  recordAgentStep: mocks.recordAgentStep,
+}))
+
+import { POST } from './route'
+
+function makeRequest(body: unknown, token = 'test-n8n-secret') {
+  return new Request('http://localhost/api/admin/agents/runs/run-1/events', {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/admin/agents/runs/[runId]/events', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.N8N_INGEST_SECRET = 'test-n8n-secret'
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.recordAgentEvent.mockResolvedValue({ id: 'event-1' })
+    mocks.recordAgentStep.mockResolvedValue({ id: 'step-1' })
+  })
+
+  it('lets n8n report a stage as both an event and a run step', async () => {
+    const response = await POST(makeRequest({
+      workflow_id: 'WF-WRM-001',
+      stage: 'Scrape LinkedIn connections',
+      status: 'running',
+      items_count: 12,
+      metadata: { source: 'linkedin' },
+      idempotency_key: 'n8n-run-1:linkedin:scrape',
+    }) as never, { params: { runId: 'run-1' } })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ ok: true, event_id: 'event-1', step_id: 'step-1' })
+    expect(mocks.verifyAdmin).not.toHaveBeenCalled()
+    expect(mocks.recordAgentEvent).toHaveBeenCalledWith(expect.objectContaining({
+      runId: 'run-1',
+      eventType: 'n8n_progress',
+      severity: 'info',
+      message: 'Scrape LinkedIn connections',
+      metadata: expect.objectContaining({
+        source: 'linkedin',
+        workflow_id: 'WF-WRM-001',
+        stage: 'Scrape LinkedIn connections',
+        n8n_status: 'running',
+        items_count: 12,
+      }),
+      idempotencyKey: 'n8n-run-1:linkedin:scrape',
+    }))
+    expect(mocks.recordAgentStep).toHaveBeenCalledWith(expect.objectContaining({
+      runId: 'run-1',
+      stepKey: 'n8n_wf_wrm_001_scrape_linkedin_connections',
+      name: 'Scrape LinkedIn connections',
+      status: 'running',
+      outputSummary: '12 item(s)',
+      idempotencyKey: 'n8n-run-1:linkedin:scrape:step',
+    }))
+  })
+
+  it('normalizes n8n failure callbacks into failed steps and error events', async () => {
+    const response = await POST(makeRequest({
+      workflow_id: 'WF-SOC-001',
+      stage: 'Generate draft',
+      status: 'error',
+      error_message: 'LLM node timed out',
+    }) as never, { params: { runId: 'run-2' } })
+
+    expect(response.status).toBe(200)
+    expect(mocks.recordAgentEvent).toHaveBeenCalledWith(expect.objectContaining({
+      runId: 'run-2',
+      eventType: 'n8n_failure',
+      severity: 'error',
+      message: 'LLM node timed out',
+    }))
+    expect(mocks.recordAgentStep).toHaveBeenCalledWith(expect.objectContaining({
+      runId: 'run-2',
+      status: 'failed',
+      outputSummary: 'LLM node timed out',
+    }))
+  })
+
+  it('rejects malformed callback statuses', async () => {
+    const response = await POST(makeRequest({
+      stage: 'Unknown stage',
+      status: 'almost_done',
+    }) as never, { params: { runId: 'run-1' } })
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'Invalid callback status: almost_done' })
+    expect(mocks.recordAgentEvent).not.toHaveBeenCalled()
+    expect(mocks.recordAgentStep).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/admin/agents/runs/[runId]/events/route.ts
+++ b/app/api/admin/agents/runs/[runId]/events/route.ts
@@ -1,11 +1,46 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
-import { AGENT_EVENT_SEVERITIES, recordAgentEvent, type AgentEventSeverity } from '@/lib/agent-run'
+import {
+  AGENT_EVENT_SEVERITIES,
+  AGENT_RUN_STATUSES,
+  recordAgentEvent,
+  recordAgentStep,
+  type AgentEventSeverity,
+  type AgentRunStatus,
+} from '@/lib/agent-run'
 
 export const dynamic = 'force-dynamic'
 
 function isSeverity(value: string): value is AgentEventSeverity {
   return AGENT_EVENT_SEVERITIES.includes(value as AgentEventSeverity)
+}
+
+function normalizeCallbackStatus(status?: string | null): AgentRunStatus {
+  if (!status) return 'completed'
+
+  const normalized = status.toLowerCase()
+  if (normalized === 'complete' || normalized === 'completed' || normalized === 'success') {
+    return 'completed'
+  }
+  if (normalized === 'error' || normalized === 'failed' || normalized === 'failure') {
+    return 'failed'
+  }
+  if (normalized === 'in_progress' || normalized === 'started') {
+    return 'running'
+  }
+  if (AGENT_RUN_STATUSES.includes(normalized as AgentRunStatus)) {
+    return normalized as AgentRunStatus
+  }
+
+  throw new Error(`Invalid callback status: ${status}`)
+}
+
+function stepKey(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
 }
 
 async function authorizeAdminOrN8n(request: NextRequest) {
@@ -38,27 +73,67 @@ export async function POST(
     message?: string
     metadata?: Record<string, unknown>
     idempotency_key?: string
+    workflow_id?: string
+    stage?: string
+    status?: string
+    items_count?: number
+    error_message?: string
+    record_step?: boolean
+    step_key?: string
+    step_name?: string
   }
 
-  if (!body.event_type) {
-    return NextResponse.json({ error: 'event_type is required' }, { status: 400 })
+  if (!body.event_type && !body.stage && !body.record_step) {
+    return NextResponse.json({ error: 'event_type, stage, or record_step is required' }, { status: 400 })
   }
   if (body.severity && !isSeverity(body.severity)) {
     return NextResponse.json({ error: 'Invalid severity' }, { status: 400 })
   }
 
   try {
+    const callbackStatus = normalizeCallbackStatus(body.status)
+    const severity =
+      (body.severity as AgentEventSeverity | undefined) ??
+      (callbackStatus === 'failed' ? 'error' : 'info')
+    const eventType = body.event_type ?? (callbackStatus === 'failed' ? 'n8n_failure' : 'n8n_progress')
+    const metadata = {
+      ...(body.metadata ?? {}),
+      workflow_id: body.workflow_id ?? null,
+      stage: body.stage ?? null,
+      n8n_status: body.status ?? null,
+      items_count: body.items_count ?? null,
+      error_message: body.error_message ?? null,
+    }
+
     const result = await recordAgentEvent({
       runId: params.runId,
-      eventType: body.event_type,
-      severity: body.severity as AgentEventSeverity | undefined,
-      message: body.message ?? null,
-      metadata: body.metadata ?? {},
+      eventType,
+      severity,
+      message: body.message ?? body.error_message ?? body.stage ?? null,
+      metadata,
       idempotencyKey: body.idempotency_key ?? null,
     })
 
-    return NextResponse.json({ ok: true, event_id: result?.id ?? null })
+    let stepId: string | null = null
+    if (body.stage || body.record_step) {
+      const name = body.step_name ?? body.stage ?? body.event_type ?? 'n8n callback'
+      const step = await recordAgentStep({
+        runId: params.runId,
+        stepKey: body.step_key ?? stepKey(`n8n_${body.workflow_id ?? 'workflow'}_${name}`),
+        name,
+        status: callbackStatus,
+        outputSummary: body.error_message ?? (body.items_count != null ? `${body.items_count} item(s)` : body.status ?? null),
+        metadata,
+        idempotencyKey: body.idempotency_key ? `${body.idempotency_key}:step` : null,
+      })
+      stepId = step?.id ?? null
+    }
+
+    return NextResponse.json({ ok: true, event_id: result?.id ?? null, step_id: stepId })
   } catch (err) {
+    if (err instanceof Error && err.message.startsWith('Invalid callback status')) {
+      return NextResponse.json({ error: err.message }, { status: 400 })
+    }
     console.error('[agent-events] write failed:', err)
     return NextResponse.json({ error: 'Failed to write event' }, { status: 500 })
   }

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -92,9 +92,10 @@ App-triggered n8n workflows should receive both the existing workflow-specific `
 
 Supported callback conventions:
 
+- App-triggered payloads may include `agent_event_callback_url` and an `agent_trace` envelope. n8n workflows can call that URL with `Authorization: Bearer N8N_INGEST_SECRET` instead of reconstructing Portfolio routes by hand.
 - Progress callbacks include `agent_run_id`, `workflow_id`, `stage`, `status`, and optional item counts.
 - Completion callbacks include `agent_run_id`, `run_id`, `workflow_id`, `status`, optional item counts, and `error_message` on failure.
-- Generic callbacks can write events with `POST /api/admin/agents/runs/[runId]/events` using `N8N_INGEST_SECRET`.
+- Generic callbacks can write events and stage steps with `POST /api/admin/agents/runs/[runId]/events` using `N8N_INGEST_SECRET`. If the body includes `stage`, the route records both an `agent_run_event` and an `agent_run_step`; `status: error|failed|failure` is normalized to a failed step.
 - Generic status updates can use `PATCH /api/admin/agents/runs/[runId]` using `N8N_INGEST_SECRET`.
 
 Current n8n trace coverage:
@@ -102,6 +103,7 @@ Current n8n trace coverage:
 - Social content extraction creates an `n8n` run, dispatches `agent_run_id`, and completes/fails the shared run from the n8n completion callback.
 - Value evidence workflows create an `n8n` run, dispatch `agent_run_id`, record progress stages, preserve auto-chained VEP-001 to VEP-002 behavior, and complete/fail the shared run after the final phase.
 - Warm lead scrapers create an `n8n` run, dispatch `agent_run_id`, and can complete/fail the shared run when the n8n completion callback echoes the ID.
+- Social content extraction, value evidence, and warm lead scraper payloads now include a shared `agent_trace` envelope with the generic event callback URL when `agent_run_id` exists.
 
 ## Hermes Bridge
 

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -26,8 +26,9 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 
 3. n8n trace expansion
    - Prioritize workflows that already touch production automation or LLM costs.
-   - Pass `agent_run_id` into app-triggered payloads.
-   - Add progress, completion, and failure callbacks.
+   - [x] Pass `agent_run_id` plus a generic callback URL into traced social content, value evidence, and warm lead payloads.
+   - [x] Let generic n8n callbacks record both run events and stage steps.
+   - Add remaining workflow-specific progress, completion, and failure callbacks where legacy workflows still lack them.
    - Keep legacy workflow pages active until replacement views are proven.
 
 4. Reporting and hardening
@@ -52,6 +53,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 - [x] Engagement Work Queue in review.
 - [x] Queue affordance filters and owner/source clarity in review.
 - [x] Approval-backed execution payloads and decision metadata in review.
+- [x] n8n trace callback envelope and generic stage callback endpoint in review.
 
 ## Scope Guard
 

--- a/lib/__tests__/n8n-social-content-extraction.test.ts
+++ b/lib/__tests__/n8n-social-content-extraction.test.ts
@@ -12,6 +12,7 @@ describe('triggerSocialContentExtraction', () => {
     process.env.N8N_DISABLE_OUTBOUND = 'false'
     process.env.MOCK_N8N = 'false'
     process.env.N8N_SOC001_WEBHOOK_URL = 'https://example.test/webhook/social-content-extract'
+    process.env.N8N_CALLBACK_BASE_URL = 'https://portfolio.example.com'
   })
 
   afterEach(() => {
@@ -29,6 +30,7 @@ describe('triggerSocialContentExtraction', () => {
     const { triggerSocialContentExtraction } = await import('../n8n')
     const result = await triggerSocialContentExtraction({
       meetingRecordId: 'meeting-123',
+      agentRunId: 'agent-run-1',
       prompts: {
         topicExtraction: 'topic prompt',
         copywriting: 'copy prompt',
@@ -50,6 +52,14 @@ describe('triggerSocialContentExtraction', () => {
     const payload = JSON.parse(String(init.body)) as Record<string, unknown>
     expect(payload.workflow).toBe('WF-SOC-001')
     expect(payload.action).toBe('extract_social_content')
+    expect(payload.agent_run_id).toBe('agent-run-1')
+    expect(payload.agent_event_callback_url).toBe('https://portfolio.example.com/api/admin/agents/runs/agent-run-1/events')
+    expect(payload.agent_trace).toMatchObject({
+      version: 1,
+      runtime: 'n8n',
+      workflow_id: 'WF-SOC-001',
+      events_url: 'https://portfolio.example.com/api/admin/agents/runs/agent-run-1/events',
+    })
     expect(payload.meeting_record_id).toBe('meeting-123')
     expect(payload.prompts).toEqual({
       topicExtraction: 'topic prompt',

--- a/lib/__tests__/n8n-value-evidence.test.ts
+++ b/lib/__tests__/n8n-value-evidence.test.ts
@@ -12,6 +12,7 @@ describe('n8n value-evidence triggers', () => {
     vi.stubGlobal('fetch', mockFetch)
     process.env.N8N_DISABLE_OUTBOUND = 'false'
     process.env.MOCK_N8N = 'false'
+    process.env.N8N_CALLBACK_BASE_URL = 'https://portfolio.example.com'
   })
 
   afterEach(() => {
@@ -26,7 +27,7 @@ describe('n8n value-evidence triggers', () => {
 
     const { triggerSocialListening } = await import('../n8n')
 
-    const result = await triggerSocialListening({ runId: 'run-123', maxResults: 10 })
+    const result = await triggerSocialListening({ runId: 'run-123', agentRunId: 'agent-run-1', maxResults: 10 })
     expect(result.triggered).toBe(true)
 
     expect(mockFetch).toHaveBeenCalledTimes(1)
@@ -40,7 +41,15 @@ describe('n8n value-evidence triggers', () => {
       workflow: 'WF-VEP-002',
       action: 'social_listening_scrape',
       run_id: 'run-123',
+      agent_run_id: 'agent-run-1',
+      agent_event_callback_url: 'https://portfolio.example.com/api/admin/agents/runs/agent-run-1/events',
       maxResults: 10,
+    })
+    expect(body.agent_trace).toMatchObject({
+      version: 1,
+      runtime: 'n8n',
+      workflow_id: 'WF-VEP-002',
+      events_url: 'https://portfolio.example.com/api/admin/agents/runs/agent-run-1/events',
     })
   })
 

--- a/lib/__tests__/n8n-warm-lead-scrape.test.ts
+++ b/lib/__tests__/n8n-warm-lead-scrape.test.ts
@@ -15,6 +15,7 @@ describe('triggerWarmLeadScrape', () => {
     process.env.N8N_WRM003_WEBHOOK_URL = 'https://test.example.com/webhook/wrm-003'
     process.env.N8N_DISABLE_OUTBOUND = 'false'
     process.env.MOCK_N8N = 'false'
+    process.env.N8N_CALLBACK_BASE_URL = 'https://portfolio.example.com/'
   })
 
   afterEach(() => {
@@ -28,6 +29,7 @@ describe('triggerWarmLeadScrape', () => {
 
     const result = await triggerWarmLeadScrape({
       source: 'facebook',
+      agentRunId: 'agent-run-1',
       options: { max_leads: 10 },
     })
 
@@ -39,6 +41,17 @@ describe('triggerWarmLeadScrape', () => {
 
     const body = JSON.parse(init.body)
     expect(body.source).toBe('facebook')
+    expect(body.workflow).toBe('WRM-facebook')
+    expect(body.agent_run_id).toBe('agent-run-1')
+    expect(body.callbackBaseUrl).toBe('https://portfolio.example.com')
+    expect(body.agent_event_callback_url).toBe('https://portfolio.example.com/api/admin/agents/runs/agent-run-1/events')
+    expect(body.agent_trace).toMatchObject({
+      version: 1,
+      runtime: 'n8n',
+      agent_run_id: 'agent-run-1',
+      workflow_id: 'WRM-facebook',
+      events_url: 'https://portfolio.example.com/api/admin/agents/runs/agent-run-1/events',
+    })
     expect(body.max_leads).toBe(10)
     expect(body.triggered_at).toBeDefined()
   })

--- a/lib/n8n.ts
+++ b/lib/n8n.ts
@@ -31,6 +31,38 @@ export function n8nWebhookUrl(path: string): string {
   return `${N8N_BASE_URL}/webhook/${path}`
 }
 
+function n8nCallbackBaseUrl(): string {
+  return (
+    process.env.N8N_CALLBACK_BASE_URL ||
+    process.env.PORTFOLIO_BASE_URL ||
+    'https://amadutown.com'
+  ).replace(/\/+$/, '')
+}
+
+function n8nAgentTracePayload(agentRunId?: string, workflowId?: string): Record<string, unknown> {
+  if (!agentRunId) return {}
+
+  const eventsUrl = `${n8nCallbackBaseUrl()}/api/admin/agents/runs/${agentRunId}/events`
+  return {
+    agent_run_id: agentRunId,
+    agent_event_callback_url: eventsUrl,
+    agent_trace: {
+      version: 1,
+      runtime: 'n8n',
+      agent_run_id: agentRunId,
+      workflow_id: workflowId ?? null,
+      events_url: eventsUrl,
+      auth: 'Bearer N8N_INGEST_SECRET',
+      progress_payload: {
+        workflow_id: workflowId ?? '<workflow-id>',
+        stage: '<node-or-stage-name>',
+        status: 'running | completed | failed',
+        items_count: '<optional-number>',
+      },
+    },
+  }
+}
+
 /** Timeout for n8n webhook calls in milliseconds (30 seconds) */
 const N8N_TIMEOUT_MS = 30_000
 
@@ -1202,7 +1234,10 @@ export async function triggerWarmLeadScrape(params: {
     const payload = {
       source: params.source,
       triggered_at: new Date().toISOString(),
+      workflow: `WRM-${params.source}`,
+      callbackBaseUrl: n8nCallbackBaseUrl(),
       agent_run_id: params.agentRunId,
+      ...n8nAgentTracePayload(params.agentRunId, `WRM-${params.source}`),
       ...params.options,
     }
     
@@ -1283,7 +1318,8 @@ export async function triggerValueEvidenceExtraction(
       triggered_at: new Date().toISOString(),
       workflow: 'WF-VEP-001',
       action: 'extract_internal_evidence',
-      callbackBaseUrl: process.env.N8N_CALLBACK_BASE_URL || process.env.PORTFOLIO_BASE_URL || 'https://amadutown.com',
+      callbackBaseUrl: n8nCallbackBaseUrl(),
+      ...n8nAgentTracePayload(options?.agentRunId, 'WF-VEP-001'),
     }
     if (options?.contactSubmissionIds?.length) {
       body.contact_submission_ids = options.contactSubmissionIds
@@ -1293,9 +1329,6 @@ export async function triggerValueEvidenceExtraction(
     }
     if (options?.runId) {
       body.run_id = options.runId
-    }
-    if (options?.agentRunId) {
-      body.agent_run_id = options.agentRunId
     }
 
     const response = await fetchWithTimeout(N8N_VEP001_WEBHOOK_URL, {
@@ -1362,13 +1395,11 @@ export async function triggerSocialListening(options?: SocialListeningOptions): 
       triggered_at: new Date().toISOString(),
       workflow: 'WF-VEP-002',
       action: 'social_listening_scrape',
-      callbackBaseUrl: process.env.N8N_CALLBACK_BASE_URL || process.env.PORTFOLIO_BASE_URL || 'https://amadutown.com',
+      callbackBaseUrl: n8nCallbackBaseUrl(),
+      ...n8nAgentTracePayload(options?.agentRunId, 'WF-VEP-002'),
     }
     if (options?.runId) {
       body.run_id = options.runId
-    }
-    if (options?.agentRunId) {
-      body.agent_run_id = options.agentRunId
     }
     if (options?.maxResults) {
       body.maxResults = options.maxResults
@@ -1444,13 +1475,11 @@ export async function triggerSocialContentExtraction(options?: {
       triggered_at: new Date().toISOString(),
       workflow: 'WF-SOC-001',
       action: 'extract_social_content',
-      callbackBaseUrl: process.env.N8N_CALLBACK_BASE_URL || process.env.PORTFOLIO_BASE_URL || 'https://amadutown.com',
+      callbackBaseUrl: n8nCallbackBaseUrl(),
+      ...n8nAgentTracePayload(options?.agentRunId, 'WF-SOC-001'),
     }
     if (options?.runId) {
       body.run_id = options.runId
-    }
-    if (options?.agentRunId) {
-      body.agent_run_id = options.agentRunId
     }
     if (options?.meetingRecordId) {
       body.meeting_record_id = options.meetingRecordId


### PR DESCRIPTION
## Summary
- adds a reusable n8n agent trace envelope with `agent_run_id`, `agent_event_callback_url`, and callback payload guidance
- includes the trace envelope in social content, value evidence, and warm lead n8n trigger payloads when an agent run exists
- extends `POST /api/admin/agents/runs/[runId]/events` so n8n can report stage progress/failures as both events and agent run steps
- updates Agent Operations rollout docs and task list for the n8n callback contract

## Safety scope
- no schema changes
- no new n8n workflow activation
- no production data writes beyond existing agent trace tables when callbacks are invoked
- legacy workflow-specific pages and run tables remain active

## Validation
- `npm test -- 'app/api/admin/agents/runs/[runId]/events/route.test.ts' lib/__tests__/n8n-warm-lead-scrape.test.ts lib/__tests__/n8n-social-content-extraction.test.ts lib/__tests__/n8n-value-evidence.test.ts app/api/admin/social-content/workflow-complete/route.test.ts app/api/admin/value-evidence/workflow-complete/route.test.ts`\n- `npx tsc --noEmit`\n- `npm run build`\n- `git diff --check`\n- pre-push `npm run db:health-check`