### PR TITLE
feat: wire warm lead n8n trace callbacks

### DIFF
--- a/app/api/admin/outreach/leads/[id]/generate/route.test.ts
+++ b/app/api/admin/outreach/leads/[id]/generate/route.test.ts
@@ -8,6 +8,11 @@ const mocks = vi.hoisted(() => ({
   generateOutreachDraftInApp: vi.fn(),
   generateLinkedInDraftInApp: vi.fn(),
   isInAppOutreachGenerationEnabled: vi.fn(),
+  startAgentRun: vi.fn(),
+  recordAgentStep: vi.fn(),
+  recordAgentEvent: vi.fn(),
+  endAgentRun: vi.fn(),
+  markAgentRunFailed: vi.fn(),
 }))
 
 vi.mock('@/lib/auth-server', () => ({
@@ -29,6 +34,14 @@ vi.mock('@/lib/outreach-queue-generator', () => ({
 
 vi.mock('@/lib/slack-outreach-notification', () => ({
   notifyOutreachDraftReady: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/lib/agent-run', () => ({
+  startAgentRun: mocks.startAgentRun,
+  recordAgentStep: mocks.recordAgentStep,
+  recordAgentEvent: mocks.recordAgentEvent,
+  endAgentRun: mocks.endAgentRun,
+  markAgentRunFailed: mocks.markAgentRunFailed,
 }))
 
 import { POST } from './route'
@@ -83,7 +96,7 @@ function mockContactSubmissions(lead: LeadRow | null) {
 describe('POST /api/admin/outreach/leads/[id]/generate', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mocks.verifyAdmin.mockResolvedValue({ id: 'admin-user' })
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
     mocks.isAuthError.mockReturnValue(false)
     mocks.isInAppOutreachGenerationEnabled.mockReturnValue(true)
     mocks.generateOutreachDraftInApp.mockResolvedValue({
@@ -92,6 +105,11 @@ describe('POST /api/admin/outreach/leads/[id]/generate', () => {
       subject: 'Hello there',
       body: 'Draft body',
     })
+    mocks.startAgentRun.mockResolvedValue({ id: 'agent-run-1' })
+    mocks.recordAgentStep.mockResolvedValue({ id: 'step-1' })
+    mocks.recordAgentEvent.mockResolvedValue({ id: 'event-1' })
+    mocks.endAgentRun.mockResolvedValue({ id: 'agent-run-1' })
+    mocks.markAgentRunFailed.mockResolvedValue({ id: 'agent-run-1' })
   })
 
   it('returns auth error response when admin verification fails', async () => {

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -102,7 +102,7 @@ Current n8n trace coverage:
 
 - Social content extraction creates an `n8n` run, dispatches `agent_run_id`, and completes/fails the shared run from the n8n completion callback.
 - Value evidence workflows create an `n8n` run, dispatch `agent_run_id`, record progress stages, preserve auto-chained VEP-001 to VEP-002 behavior, and complete/fail the shared run after the final phase.
-- Warm lead scrapers create an `n8n` run, dispatch `agent_run_id`, and can complete/fail the shared run when the n8n completion callback echoes the ID.
+- Warm lead scrapers create an `n8n` run, dispatch `agent_run_id`, and the versioned WRM exports preserve the trace envelope through normalization before reporting successful ingest completion to `/api/admin/outreach/run-complete` and the generic trace event callback.
 - Social content extraction, value evidence, and warm lead scraper payloads now include a shared `agent_trace` envelope with the generic event callback URL when `agent_run_id` exists.
 
 ## Hermes Bridge

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -28,6 +28,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
    - Prioritize workflows that already touch production automation or LLM costs.
    - [x] Pass `agent_run_id` plus a generic callback URL into traced social content, value evidence, and warm lead payloads.
    - [x] Let generic n8n callbacks record both run events and stage steps.
+   - [x] Add warm lead export callbacks for successful ingest completion across Facebook, Google Contacts, and LinkedIn workflows.
    - Add remaining workflow-specific progress, completion, and failure callbacks where legacy workflows still lack them.
    - Keep legacy workflow pages active until replacement views are proven.
 

--- a/docs/warm-lead-workflow-integration.md
+++ b/docs/warm-lead-workflow-integration.md
@@ -96,7 +96,12 @@ To limit external API calls (e.g. Apify) to at most one per 24 hours per source,
   Returns `{ lastSuccessAt: string | null, shouldRun: boolean }`. `shouldRun` is false when the last successful run was within the last 24 hours. n8n uses this at the start of a run to skip the external API and end successfully when within the window.
 
 - **POST /api/admin/outreach/run-complete**  
-  Body: `{ source: "facebook" | "google_contacts" | "linkedin" }`. Records a successful run in `warm_lead_trigger_audit` so the next run sees "last run within 24h". Call this at the end of the workflow after ingest (or rely on the ingest endpoint updating the most recent `running` audit row when the run was app-triggered).
+  Body: `{ source: "facebook" | "google_contacts" | "linkedin", agent_run_id?: string, status?: "completed" | "failed", leads_inserted?: number, error_message?: string }`. Records a run in `warm_lead_trigger_audit` so the next run sees "last run within 24h". When `agent_run_id` is present, the endpoint also completes or fails the shared Agent Operations run.
+
+The versioned WRM workflow exports preserve `agent_run_id`, `agent_event_callback_url`, `agent_trace`, and `callbackBaseUrl` from the webhook payload through the normalization node. After a successful ingest, the workflows only report callbacks when `agent_run_id` exists:
+
+1. `POST /api/admin/outreach/run-complete` records legacy warm-lead completion and closes the shared run.
+2. `POST /api/admin/agents/runs/[runId]/events` records the generic `outreach_ingest_complete` stage event and step.
 
 **Trigger strategy:** Remove any redundant 10-minute webhook caller; keep one run-on-wake or schedule per workflow. The 24-hour gate ensures at most one API call per 24 hours.
 

--- a/lib/__tests__/n8n-warm-lead-workflow-export.test.ts
+++ b/lib/__tests__/n8n-warm-lead-workflow-export.test.ts
@@ -1,0 +1,119 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+type N8nConnection = {
+  node?: string
+  type?: string
+  index?: number
+}
+
+type N8nNode = {
+  name?: string
+  type?: string
+  parameters?: {
+    jsCode?: string
+    url?: string
+    jsonBody?: string
+    headerParameters?: {
+      parameters?: Array<{ name?: string; value?: string }>
+    }
+  }
+}
+
+type N8nWorkflow = {
+  nodes?: N8nNode[]
+  connections?: Record<string, { main?: N8nConnection[][] }>
+}
+
+const WORKFLOWS = [
+  {
+    file: 'WF-WRM-001-Facebook-Warm-Lead-Scraper.json',
+    source: 'facebook',
+    workflowId: 'WF-WRM-001',
+    normalizeNode: 'Normalize & Deduplicate',
+  },
+  {
+    file: 'WF-WRM-002-Google-Contacts-Sync.json',
+    source: 'google_contacts',
+    workflowId: 'WF-WRM-002',
+    normalizeNode: 'Normalize Contacts',
+  },
+  {
+    file: 'WF-WRM-003-LinkedIn-Warm-Lead-Scraper.json',
+    source: 'linkedin',
+    workflowId: 'WF-WRM-003',
+    normalizeNode: 'Normalize & Deduplicate',
+  },
+]
+
+function loadWorkflow(file: string): N8nWorkflow {
+  return JSON.parse(readFileSync(path.join(process.cwd(), 'n8n-exports', file), 'utf8')) as N8nWorkflow
+}
+
+function getNode(workflow: N8nWorkflow, name: string): N8nNode {
+  const node = workflow.nodes?.find(entry => entry.name === name)
+  expect(node, `Expected workflow node "${name}" to exist`).toBeDefined()
+  return node as N8nNode
+}
+
+function getAuthHeader(node: N8nNode): string | undefined {
+  return node.parameters?.headerParameters?.parameters?.find(header => header.name === 'Authorization')?.value
+}
+
+function expectConnection(workflow: N8nWorkflow, from: string, to: string, outputIndex = 0): void {
+  const outputs = workflow.connections?.[from]?.main ?? []
+  const target = outputs[outputIndex]?.find(connection => connection.node === to)
+  expect(target, `Expected "${from}" output ${outputIndex} to connect to "${to}"`).toBeDefined()
+}
+
+describe('warm lead n8n workflow export trace callbacks', () => {
+  it.each(WORKFLOWS)('$workflowId preserves agent trace fields through normalization', ({ file, normalizeNode }) => {
+    const workflow = loadWorkflow(file)
+    const node = getNode(workflow, normalizeNode)
+
+    expect(node.parameters?.jsCode).toContain("const triggerJson = $node['Webhook Trigger']?.json")
+    expect(node.parameters?.jsCode).toContain('agent_run_id: triggerBody.agent_run_id || null')
+    expect(node.parameters?.jsCode).toContain('agent_event_callback_url: triggerBody.agent_event_callback_url || null')
+    expect(node.parameters?.jsCode).toContain('return [{ json: { leads, count: leads.length, ...tracePayload } }];')
+  })
+
+  it.each(WORKFLOWS)('$workflowId posts ingest payload with trace id and n8n variable fallbacks', ({ file }) => {
+    const workflow = loadWorkflow(file)
+    const node = getNode(workflow, 'POST to Ingest API')
+
+    expect(node.parameters?.url).toContain('$json.callbackBaseUrl')
+    expect(node.parameters?.url).toContain('$vars.AMADUTOWN_PUBLIC_BASE_URL')
+    expect(getAuthHeader(node)).toBe('=Bearer {{ $vars.N8N_INGEST_SECRET || $env.N8N_INGEST_SECRET }}')
+    expect(node.parameters?.jsonBody).toContain('agent_run_id: $json.agent_run_id || undefined')
+  })
+
+  it.each(WORKFLOWS)('$workflowId calls run-complete and generic trace event after ingest', ({
+    file,
+    source,
+    workflowId,
+    normalizeNode,
+  }) => {
+    const workflow = loadWorkflow(file)
+    const guardNode = getNode(workflow, 'Has Agent Run ID')
+    const completionNode = getNode(workflow, 'Report Outreach Run Complete')
+    const eventNode = getNode(workflow, 'Report Agent Trace Event')
+
+    expect(guardNode.type).toBe('n8n-nodes-base.if')
+    expect(completionNode.parameters?.url).toContain('/api/admin/outreach/run-complete')
+    expect(completionNode.parameters?.jsonBody).toContain(`source: '${source}'`)
+    expect(completionNode.parameters?.jsonBody).toContain(`$node["${normalizeNode}"].json.agent_run_id`)
+    expect(getAuthHeader(completionNode)).toBe('=Bearer {{ $vars.N8N_INGEST_SECRET || $env.N8N_INGEST_SECRET }}')
+
+    expect(eventNode.parameters?.url).toContain('agent_event_callback_url')
+    expect(eventNode.parameters?.url).toContain('/api/admin/agents/runs/')
+    expect(eventNode.parameters?.jsonBody).toContain(`workflow_id: '${workflowId}'`)
+    expect(eventNode.parameters?.jsonBody).toContain("stage: 'outreach_ingest_complete'")
+    expect(eventNode.parameters?.jsonBody).toContain("status: 'completed'")
+    expect(getAuthHeader(eventNode)).toBe('=Bearer {{ $vars.N8N_INGEST_SECRET || $env.N8N_INGEST_SECRET }}')
+
+    expectConnection(workflow, 'POST to Ingest API', 'Has Agent Run ID')
+    expectConnection(workflow, 'Has Agent Run ID', 'Report Outreach Run Complete')
+    expectConnection(workflow, 'Report Outreach Run Complete', 'Report Agent Trace Event')
+  })
+})

--- a/n8n-exports/WF-WRM-001-Facebook-Warm-Lead-Scraper.json
+++ b/n8n-exports/WF-WRM-001-Facebook-Warm-Lead-Scraper.json
@@ -6,7 +6,10 @@
       "name": "Webhook Trigger",
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
-      "position": [200, 300],
+      "position": [
+        200,
+        300
+      ],
       "parameters": {
         "path": "wrm-001-facebook",
         "httpMethod": "POST",
@@ -19,14 +22,19 @@
       "name": "Weekly Schedule",
       "type": "n8n-nodes-base.scheduleTrigger",
       "typeVersion": 1.2,
-      "position": [200, 500],
+      "position": [
+        200,
+        500
+      ],
       "parameters": {
         "rule": {
           "interval": [
             {
               "field": "weeks",
               "weeksInterval": 1,
-              "triggerAtDay": [1],
+              "triggerAtDay": [
+                1
+              ],
               "triggerAtHour": 9,
               "triggerAtMinute": 0
             }
@@ -39,7 +47,10 @@
       "name": "Scrape FB Friends (Apify)",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [500, 200],
+      "position": [
+        500,
+        200
+      ],
       "parameters": {
         "method": "POST",
         "url": "=https://api.apify.com/v2/acts/alien_force~facebook-scraper-pro/runs?token={{$env.APIFY_TOKEN}}&waitForFinish=120",
@@ -65,7 +76,10 @@
       "name": "Scrape FB Groups (Apify)",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [500, 400],
+      "position": [
+        500,
+        400
+      ],
       "parameters": {
         "method": "POST",
         "url": "=https://api.apify.com/v2/acts/mdgjtp1~facebook-group-member/runs?token={{$env.APIFY_TOKEN}}&waitForFinish=120",
@@ -91,7 +105,10 @@
       "name": "Scrape FB Post Comments (Apify)",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [500, 600],
+      "position": [
+        500,
+        600
+      ],
       "parameters": {
         "method": "POST",
         "url": "=https://api.apify.com/v2/acts/apify~facebook-comments-scraper/runs?token={{$env.APIFY_TOKEN}}&waitForFinish=120",
@@ -117,9 +134,12 @@
       "name": "Normalize & Deduplicate",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [800, 400],
+      "position": [
+        800,
+        400
+      ],
       "parameters": {
-        "jsCode": "// Normalize Facebook scraper results into lead format\nconst allItems = $input.all();\nconst seen = new Set();\nconst leads = [];\n\nfor (const item of allItems) {\n  const d = item.json;\n  \n  // Try to extract name and profile URL from various Apify output formats\n  const name = d.name || d.profileName || d.authorName || d.userName || '';\n  const profileUrl = d.profileUrl || d.url || d.authorUrl || '';\n  const company = d.work || d.company || '';\n  const email = d.email || '';\n  \n  if (!name || name.length < 2) continue;\n  \n  // Deduplicate by profile URL or name\n  const dedupeKey = profileUrl || name.toLowerCase();\n  if (seen.has(dedupeKey)) continue;\n  seen.add(dedupeKey);\n  \n  // Determine source type based on data origin\n  let leadSource = 'warm_facebook_friends';\n  let sourceDetail = 'Facebook friend';\n  \n  if (d._groupId || d.groupName) {\n    leadSource = 'warm_facebook_groups';\n    sourceDetail = d.groupName || 'Facebook group';\n  } else if (d.commentText || d.reactionType) {\n    leadSource = 'warm_facebook_engagement';\n    sourceDetail = d.commentText ? 'Commented on post' : 'Reacted to post';\n  }\n  \n  leads.push({\n    name,\n    email: email || undefined,\n    company: company || undefined,\n    facebook_profile_url: profileUrl || undefined,\n    lead_source: leadSource,\n    warm_source_detail: sourceDetail,\n    job_title: d.jobTitle || d.headline || undefined,\n    location: d.location || d.city || undefined,\n  });\n}\n\nreturn [{ json: { leads, count: leads.length } }];"
+        "jsCode": "let tracePayload = {};\ntry {\n  const triggerJson = $node['Webhook Trigger']?.json || {};\n  const triggerBody = triggerJson.body || triggerJson;\n  tracePayload = {\n    agent_run_id: triggerBody.agent_run_id || null,\n    agent_event_callback_url: triggerBody.agent_event_callback_url || null,\n    agent_trace: triggerBody.agent_trace || null,\n    callbackBaseUrl: triggerBody.callbackBaseUrl || triggerBody.callback_base_url || null,\n  };\n} catch (error) {\n  tracePayload = {};\n}\n\n// Normalize Facebook scraper results into lead format\nconst allItems = $input.all();\nconst seen = new Set();\nconst leads = [];\n\nfor (const item of allItems) {\n  const d = item.json;\n  \n  // Try to extract name and profile URL from various Apify output formats\n  const name = d.name || d.profileName || d.authorName || d.userName || '';\n  const profileUrl = d.profileUrl || d.url || d.authorUrl || '';\n  const company = d.work || d.company || '';\n  const email = d.email || '';\n  \n  if (!name || name.length < 2) continue;\n  \n  // Deduplicate by profile URL or name\n  const dedupeKey = profileUrl || name.toLowerCase();\n  if (seen.has(dedupeKey)) continue;\n  seen.add(dedupeKey);\n  \n  // Determine source type based on data origin\n  let leadSource = 'warm_facebook_friends';\n  let sourceDetail = 'Facebook friend';\n  \n  if (d._groupId || d.groupName) {\n    leadSource = 'warm_facebook_groups';\n    sourceDetail = d.groupName || 'Facebook group';\n  } else if (d.commentText || d.reactionType) {\n    leadSource = 'warm_facebook_engagement';\n    sourceDetail = d.commentText ? 'Commented on post' : 'Reacted to post';\n  }\n  \n  leads.push({\n    name,\n    email: email || undefined,\n    company: company || undefined,\n    facebook_profile_url: profileUrl || undefined,\n    lead_source: leadSource,\n    warm_source_detail: sourceDetail,\n    job_title: d.jobTitle || d.headline || undefined,\n    location: d.location || d.city || undefined,\n  });\n}\n\nreturn [{ json: { leads, count: leads.length, ...tracePayload } }];"
       }
     },
     {
@@ -127,10 +147,13 @@
       "name": "POST to Ingest API",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [1100, 400],
+      "position": [
+        1100,
+        400
+      ],
       "parameters": {
         "method": "POST",
-        "url": "={{$env.APP_BASE_URL}}/api/admin/outreach/ingest",
+        "url": "={{ (($json.callbackBaseUrl || $vars.AMADUTOWN_PUBLIC_BASE_URL || $env.APP_BASE_URL || 'https://amadutown.com') + '').replace(/\\/+$/, '') + '/api/admin/outreach/ingest' }}",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
@@ -140,13 +163,13 @@
             },
             {
               "name": "Authorization",
-              "value": "=Bearer {{$env.N8N_INGEST_SECRET}}"
+              "value": "=Bearer {{ $vars.N8N_INGEST_SECRET || $env.N8N_INGEST_SECRET }}"
             }
           ]
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({ leads: $json.leads }) }}"
+        "jsonBody": "={{ JSON.stringify({ leads: $json.leads, agent_run_id: $json.agent_run_id || undefined }) }}"
       }
     },
     {
@@ -154,9 +177,106 @@
       "name": "WF-WRM-001 Info",
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
-      "position": [100, 100],
+      "position": [
+        100,
+        100
+      ],
       "parameters": {
         "content": "## WF-WRM-001: Facebook Warm Lead Scraper\n\n**Triggers:** Weekly schedule (Mon 9am) or manual webhook\n\n**Steps:**\n1. Scrape FB friends via Apify (alien_force/facebook-scraper-pro)\n2. Scrape FB group members via Apify (mdgjtp1/facebook-group-member)\n3. Scrape FB post commenters via Apify (apify/facebook-comments-scraper)\n4. Normalize & deduplicate all results\n5. POST batch to /api/admin/outreach/ingest\n\n**Env vars needed:**\n- APIFY_TOKEN\n- FACEBOOK_PROFILE_URL\n- FACEBOOK_GROUP_UIDS (JSON array)\n- APP_BASE_URL\n- N8N_INGEST_SECRET"
+      }
+    },
+    {
+      "id": "has_agent_run_id",
+      "name": "Has Agent Run ID",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        1360,
+        400
+      ],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "version": 2,
+            "leftValue": "",
+            "caseSensitive": true,
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "agent-run-id-present",
+              "leftValue": "={{ $json.agent_run_id || $node[\"Normalize & Deduplicate\"].json.agent_run_id }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "report_outreach_run_complete",
+      "name": "Report Outreach Run Complete",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1620,
+        320
+      ],
+      "parameters": {
+        "method": "POST",
+        "url": "={{ (($node[\"Normalize & Deduplicate\"].json.callbackBaseUrl || $vars.AMADUTOWN_PUBLIC_BASE_URL || $env.APP_BASE_URL || 'https://amadutown.com') + '').replace(/\\/+$/, '') + '/api/admin/outreach/run-complete' }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $vars.N8N_INGEST_SECRET || $env.N8N_INGEST_SECRET }}"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ source: 'facebook', agent_run_id: $node[\"Normalize & Deduplicate\"].json.agent_run_id, status: 'completed', leads_inserted: $node[\"Normalize & Deduplicate\"].json.count || (($node[\"Normalize & Deduplicate\"].json.leads || []).length) }) }}"
+      }
+    },
+    {
+      "id": "report_agent_trace_event",
+      "name": "Report Agent Trace Event",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1880,
+        320
+      ],
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $node[\"Normalize & Deduplicate\"].json.agent_event_callback_url || ((($node[\"Normalize & Deduplicate\"].json.callbackBaseUrl || $vars.AMADUTOWN_PUBLIC_BASE_URL || $env.APP_BASE_URL || 'https://amadutown.com') + '').replace(/\\/+$/, '') + '/api/admin/agents/runs/' + $node[\"Normalize & Deduplicate\"].json.agent_run_id + '/events') }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $vars.N8N_INGEST_SECRET || $env.N8N_INGEST_SECRET }}"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ workflow_id: 'WF-WRM-001', stage: 'outreach_ingest_complete', status: 'completed', items_count: $node[\"Normalize & Deduplicate\"].json.count || (($node[\"Normalize & Deduplicate\"].json.leads || []).length), metadata: { source: 'facebook' }, idempotency_key: $node[\"Normalize & Deduplicate\"].json.agent_run_id + ':WF-WRM-001:outreach_ingest_complete' }) }}"
       }
     }
   ],
@@ -241,6 +361,40 @@
         [
           {
             "node": "POST to Ingest API",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "POST to Ingest API": {
+      "main": [
+        [
+          {
+            "node": "Has Agent Run ID",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Agent Run ID": {
+      "main": [
+        [
+          {
+            "node": "Report Outreach Run Complete",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        []
+      ]
+    },
+    "Report Outreach Run Complete": {
+      "main": [
+        [
+          {
+            "node": "Report Agent Trace Event",
             "type": "main",
             "index": 0
           }

--- a/n8n-exports/WF-WRM-002-Google-Contacts-Sync.json
+++ b/n8n-exports/WF-WRM-002-Google-Contacts-Sync.json
@@ -6,7 +6,10 @@
       "name": "Webhook Trigger",
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
-      "position": [200, 300],
+      "position": [
+        200,
+        300
+      ],
       "parameters": {
         "path": "wrm-002-google-contacts",
         "httpMethod": "POST",
@@ -19,7 +22,10 @@
       "name": "Daily Schedule",
       "type": "n8n-nodes-base.scheduleTrigger",
       "typeVersion": 1.2,
-      "position": [200, 500],
+      "position": [
+        200,
+        500
+      ],
       "parameters": {
         "rule": {
           "interval": [
@@ -38,7 +44,10 @@
       "name": "Fetch Google Contacts",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [500, 400],
+      "position": [
+        500,
+        400
+      ],
       "parameters": {
         "method": "GET",
         "url": "https://people.googleapis.com/v1/people/me/connections",
@@ -47,7 +56,7 @@
           "parameters": [
             {
               "name": "Authorization",
-              "value": "=Bearer {{$env.GOOGLE_CONTACTS_TOKEN}}"
+              "value": "=Bearer {{ $vars.N8N_INGEST_SECRET || $env.N8N_INGEST_SECRET }}"
             }
           ]
         },
@@ -74,9 +83,12 @@
       "name": "Normalize Contacts",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [800, 400],
+      "position": [
+        800,
+        400
+      ],
       "parameters": {
-        "jsCode": "// Normalize Google Contacts API response into lead format\nconst connections = $json.connections || [];\nconst leads = [];\n\nfor (const person of connections) {\n  const names = person.names || [];\n  const emails = person.emailAddresses || [];\n  const phones = person.phoneNumbers || [];\n  const orgs = person.organizations || [];\n  const locations = person.locations || [];\n  \n  const name = names[0]?.displayName || '';\n  if (!name || name.length < 2) continue;\n  \n  const email = emails[0]?.value || '';\n  const phone = phones[0]?.value || '';\n  const company = orgs[0]?.name || '';\n  const jobTitle = orgs[0]?.title || '';\n  const location = locations[0]?.value || '';\n  \n  // Skip contacts without useful business info\n  // (keep those with email, company, or job title)\n  if (!email && !company && !jobTitle) continue;\n  \n  leads.push({\n    name,\n    email: email || undefined,\n    company: company || undefined,\n    job_title: jobTitle || undefined,\n    phone_number: phone || undefined,\n    location: location || undefined,\n    lead_source: 'warm_google_contacts',\n    warm_source_detail: 'Google Contacts sync',\n  });\n}\n\nreturn [{ json: { leads, count: leads.length } }];"
+        "jsCode": "let tracePayload = {};\ntry {\n  const triggerJson = $node['Webhook Trigger']?.json || {};\n  const triggerBody = triggerJson.body || triggerJson;\n  tracePayload = {\n    agent_run_id: triggerBody.agent_run_id || null,\n    agent_event_callback_url: triggerBody.agent_event_callback_url || null,\n    agent_trace: triggerBody.agent_trace || null,\n    callbackBaseUrl: triggerBody.callbackBaseUrl || triggerBody.callback_base_url || null,\n  };\n} catch (error) {\n  tracePayload = {};\n}\n\n// Normalize Google Contacts API response into lead format\nconst connections = $json.connections || [];\nconst leads = [];\n\nfor (const person of connections) {\n  const names = person.names || [];\n  const emails = person.emailAddresses || [];\n  const phones = person.phoneNumbers || [];\n  const orgs = person.organizations || [];\n  const locations = person.locations || [];\n  \n  const name = names[0]?.displayName || '';\n  if (!name || name.length < 2) continue;\n  \n  const email = emails[0]?.value || '';\n  const phone = phones[0]?.value || '';\n  const company = orgs[0]?.name || '';\n  const jobTitle = orgs[0]?.title || '';\n  const location = locations[0]?.value || '';\n  \n  // Skip contacts without useful business info\n  // (keep those with email, company, or job title)\n  if (!email && !company && !jobTitle) continue;\n  \n  leads.push({\n    name,\n    email: email || undefined,\n    company: company || undefined,\n    job_title: jobTitle || undefined,\n    phone_number: phone || undefined,\n    location: location || undefined,\n    lead_source: 'warm_google_contacts',\n    warm_source_detail: 'Google Contacts sync',\n  });\n}\n\nreturn [{ json: { leads, count: leads.length, ...tracePayload } }];"
       }
     },
     {
@@ -84,10 +96,13 @@
       "name": "POST to Ingest API",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [1100, 400],
+      "position": [
+        1100,
+        400
+      ],
       "parameters": {
         "method": "POST",
-        "url": "={{$env.APP_BASE_URL}}/api/admin/outreach/ingest",
+        "url": "={{ (($json.callbackBaseUrl || $vars.AMADUTOWN_PUBLIC_BASE_URL || $env.APP_BASE_URL || 'https://amadutown.com') + '').replace(/\\/+$/, '') + '/api/admin/outreach/ingest' }}",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
@@ -97,13 +112,13 @@
             },
             {
               "name": "Authorization",
-              "value": "=Bearer {{$env.N8N_INGEST_SECRET}}"
+              "value": "=Bearer {{ $vars.N8N_INGEST_SECRET || $env.N8N_INGEST_SECRET }}"
             }
           ]
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({ leads: $json.leads }) }}"
+        "jsonBody": "={{ JSON.stringify({ leads: $json.leads, agent_run_id: $json.agent_run_id || undefined }) }}"
       }
     },
     {
@@ -111,9 +126,106 @@
       "name": "WF-WRM-002 Info",
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
-      "position": [100, 100],
+      "position": [
+        100,
+        100
+      ],
       "parameters": {
         "content": "## WF-WRM-002: Google Contacts Sync\n\n**Triggers:** Daily schedule (8am) or manual webhook\n\n**Steps:**\n1. Fetch contacts from Google People API\n2. Filter for contacts with business info (email, company, job title)\n3. Normalize data format\n4. POST batch to /api/admin/outreach/ingest\n\n**Env vars needed:**\n- GOOGLE_CONTACTS_TOKEN (OAuth2 access token)\n- APP_BASE_URL\n- N8N_INGEST_SECRET\n\n**Note:** For production, use n8n's built-in Google OAuth2 credential with People API scope."
+      }
+    },
+    {
+      "id": "has_agent_run_id",
+      "name": "Has Agent Run ID",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        1360,
+        400
+      ],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "version": 2,
+            "leftValue": "",
+            "caseSensitive": true,
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "agent-run-id-present",
+              "leftValue": "={{ $json.agent_run_id || $node[\"Normalize Contacts\"].json.agent_run_id }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "report_outreach_run_complete",
+      "name": "Report Outreach Run Complete",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1620,
+        320
+      ],
+      "parameters": {
+        "method": "POST",
+        "url": "={{ (($node[\"Normalize Contacts\"].json.callbackBaseUrl || $vars.AMADUTOWN_PUBLIC_BASE_URL || $env.APP_BASE_URL || 'https://amadutown.com') + '').replace(/\\/+$/, '') + '/api/admin/outreach/run-complete' }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $vars.N8N_INGEST_SECRET || $env.N8N_INGEST_SECRET }}"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ source: 'google_contacts', agent_run_id: $node[\"Normalize Contacts\"].json.agent_run_id, status: 'completed', leads_inserted: $node[\"Normalize Contacts\"].json.count || (($node[\"Normalize Contacts\"].json.leads || []).length) }) }}"
+      }
+    },
+    {
+      "id": "report_agent_trace_event",
+      "name": "Report Agent Trace Event",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1880,
+        320
+      ],
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $node[\"Normalize Contacts\"].json.agent_event_callback_url || ((($node[\"Normalize Contacts\"].json.callbackBaseUrl || $vars.AMADUTOWN_PUBLIC_BASE_URL || $env.APP_BASE_URL || 'https://amadutown.com') + '').replace(/\\/+$/, '') + '/api/admin/agents/runs/' + $node[\"Normalize Contacts\"].json.agent_run_id + '/events') }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $vars.N8N_INGEST_SECRET || $env.N8N_INGEST_SECRET }}"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ workflow_id: 'WF-WRM-002', stage: 'outreach_ingest_complete', status: 'completed', items_count: $node[\"Normalize Contacts\"].json.count || (($node[\"Normalize Contacts\"].json.leads || []).length), metadata: { source: 'google_contacts' }, idempotency_key: $node[\"Normalize Contacts\"].json.agent_run_id + ':WF-WRM-002:outreach_ingest_complete' }) }}"
       }
     }
   ],
@@ -156,6 +268,40 @@
         [
           {
             "node": "POST to Ingest API",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "POST to Ingest API": {
+      "main": [
+        [
+          {
+            "node": "Has Agent Run ID",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Agent Run ID": {
+      "main": [
+        [
+          {
+            "node": "Report Outreach Run Complete",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        []
+      ]
+    },
+    "Report Outreach Run Complete": {
+      "main": [
+        [
+          {
+            "node": "Report Agent Trace Event",
             "type": "main",
             "index": 0
           }

--- a/n8n-exports/WF-WRM-003-LinkedIn-Warm-Lead-Scraper.json
+++ b/n8n-exports/WF-WRM-003-LinkedIn-Warm-Lead-Scraper.json
@@ -6,7 +6,10 @@
       "name": "Webhook Trigger",
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
-      "position": [200, 300],
+      "position": [
+        200,
+        300
+      ],
       "parameters": {
         "path": "wrm-003-linkedin",
         "httpMethod": "POST",
@@ -19,14 +22,19 @@
       "name": "Weekly Schedule",
       "type": "n8n-nodes-base.scheduleTrigger",
       "typeVersion": 1.2,
-      "position": [200, 500],
+      "position": [
+        200,
+        500
+      ],
       "parameters": {
         "rule": {
           "interval": [
             {
               "field": "weeks",
               "weeksInterval": 1,
-              "triggerAtDay": [3],
+              "triggerAtDay": [
+                3
+              ],
               "triggerAtHour": 9,
               "triggerAtMinute": 0
             }
@@ -39,7 +47,10 @@
       "name": "Scrape LI Connections (Apify)",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [500, 250],
+      "position": [
+        500,
+        250
+      ],
       "parameters": {
         "method": "POST",
         "url": "=https://api.apify.com/v2/acts/addeus~get-connections/runs?token={{$env.APIFY_TOKEN}}&waitForFinish=180",
@@ -65,7 +76,10 @@
       "name": "Scrape LI Post Engagement (Apify)",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [500, 500],
+      "position": [
+        500,
+        500
+      ],
       "parameters": {
         "method": "POST",
         "url": "=https://api.apify.com/v2/acts/harvestapi~linkedin-profile-posts/runs?token={{$env.APIFY_TOKEN}}&waitForFinish=180",
@@ -91,9 +105,12 @@
       "name": "Normalize & Deduplicate",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [800, 400],
+      "position": [
+        800,
+        400
+      ],
       "parameters": {
-        "jsCode": "// Normalize LinkedIn scraper results into lead format\nconst allItems = $input.all();\nconst seen = new Set();\nconst leads = [];\n\nfor (const item of allItems) {\n  const d = item.json;\n  \n  // Handle connections format (name, headline, profileUrl)\n  // Handle engagement format (commenters, reactors from posts)\n  const name = d.name || d.fullName || d.authorName || d.firstName + ' ' + (d.lastName || '') || '';\n  const profileUrl = d.profileUrl || d.url || d.authorProfileUrl || '';\n  const headline = d.headline || d.title || '';\n  const company = d.company || d.companyName || '';\n  \n  if (!name || name.trim().length < 2) continue;\n  \n  // Extract LinkedIn username from URL\n  let linkedinUsername = '';\n  if (profileUrl) {\n    const match = profileUrl.match(/linkedin\\.com\\/in\\/([^/?]+)/);\n    if (match) linkedinUsername = match[1];\n  }\n  \n  // Deduplicate by LinkedIn username or name\n  const dedupeKey = linkedinUsername || name.toLowerCase().trim();\n  if (seen.has(dedupeKey)) continue;\n  seen.add(dedupeKey);\n  \n  // Determine source type\n  let leadSource = 'warm_linkedin_connections';\n  let sourceDetail = 'LinkedIn 1st-degree connection';\n  \n  if (d.commentText || d.reactionType || d.engagementType) {\n    leadSource = 'warm_linkedin_engagement';\n    sourceDetail = d.commentText\n      ? 'Commented on LinkedIn post'\n      : 'Engaged with LinkedIn post';\n  }\n  \n  leads.push({\n    name: name.trim(),\n    company: company || undefined,\n    job_title: headline || undefined,\n    linkedin_url: profileUrl || undefined,\n    linkedin_username: linkedinUsername || undefined,\n    lead_source: leadSource,\n    warm_source_detail: sourceDetail,\n    location: d.location || d.geoLocation || undefined,\n  });\n}\n\nreturn [{ json: { leads, count: leads.length } }];"
+        "jsCode": "let tracePayload = {};\ntry {\n  const triggerJson = $node['Webhook Trigger']?.json || {};\n  const triggerBody = triggerJson.body || triggerJson;\n  tracePayload = {\n    agent_run_id: triggerBody.agent_run_id || null,\n    agent_event_callback_url: triggerBody.agent_event_callback_url || null,\n    agent_trace: triggerBody.agent_trace || null,\n    callbackBaseUrl: triggerBody.callbackBaseUrl || triggerBody.callback_base_url || null,\n  };\n} catch (error) {\n  tracePayload = {};\n}\n\n// Normalize LinkedIn scraper results into lead format\nconst allItems = $input.all();\nconst seen = new Set();\nconst leads = [];\n\nfor (const item of allItems) {\n  const d = item.json;\n  \n  // Handle connections format (name, headline, profileUrl)\n  // Handle engagement format (commenters, reactors from posts)\n  const name = d.name || d.fullName || d.authorName || d.firstName + ' ' + (d.lastName || '') || '';\n  const profileUrl = d.profileUrl || d.url || d.authorProfileUrl || '';\n  const headline = d.headline || d.title || '';\n  const company = d.company || d.companyName || '';\n  \n  if (!name || name.trim().length < 2) continue;\n  \n  // Extract LinkedIn username from URL\n  let linkedinUsername = '';\n  if (profileUrl) {\n    const match = profileUrl.match(/linkedin\\.com\\/in\\/([^/?]+)/);\n    if (match) linkedinUsername = match[1];\n  }\n  \n  // Deduplicate by LinkedIn username or name\n  const dedupeKey = linkedinUsername || name.toLowerCase().trim();\n  if (seen.has(dedupeKey)) continue;\n  seen.add(dedupeKey);\n  \n  // Determine source type\n  let leadSource = 'warm_linkedin_connections';\n  let sourceDetail = 'LinkedIn 1st-degree connection';\n  \n  if (d.commentText || d.reactionType || d.engagementType) {\n    leadSource = 'warm_linkedin_engagement';\n    sourceDetail = d.commentText\n      ? 'Commented on LinkedIn post'\n      : 'Engaged with LinkedIn post';\n  }\n  \n  leads.push({\n    name: name.trim(),\n    company: company || undefined,\n    job_title: headline || undefined,\n    linkedin_url: profileUrl || undefined,\n    linkedin_username: linkedinUsername || undefined,\n    lead_source: leadSource,\n    warm_source_detail: sourceDetail,\n    location: d.location || d.geoLocation || undefined,\n  });\n}\n\nreturn [{ json: { leads, count: leads.length, ...tracePayload } }];"
       }
     },
     {
@@ -101,10 +118,13 @@
       "name": "POST to Ingest API",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [1100, 400],
+      "position": [
+        1100,
+        400
+      ],
       "parameters": {
         "method": "POST",
-        "url": "={{$env.APP_BASE_URL}}/api/admin/outreach/ingest",
+        "url": "={{ (($json.callbackBaseUrl || $vars.AMADUTOWN_PUBLIC_BASE_URL || $env.APP_BASE_URL || 'https://amadutown.com') + '').replace(/\\/+$/, '') + '/api/admin/outreach/ingest' }}",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
@@ -114,13 +134,13 @@
             },
             {
               "name": "Authorization",
-              "value": "=Bearer {{$env.N8N_INGEST_SECRET}}"
+              "value": "=Bearer {{ $vars.N8N_INGEST_SECRET || $env.N8N_INGEST_SECRET }}"
             }
           ]
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({ leads: $json.leads }) }}"
+        "jsonBody": "={{ JSON.stringify({ leads: $json.leads, agent_run_id: $json.agent_run_id || undefined }) }}"
       }
     },
     {
@@ -128,9 +148,106 @@
       "name": "WF-WRM-003 Info",
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
-      "position": [100, 100],
+      "position": [
+        100,
+        100
+      ],
       "parameters": {
         "content": "## WF-WRM-003: LinkedIn Warm Lead Scraper\n\n**Triggers:** Weekly schedule (Wed 9am) or manual webhook\n\n**Steps:**\n1. Scrape LinkedIn 1st-degree connections via Apify (addeus/get-connections)\n2. Scrape LinkedIn post engagement via Apify (harvestapi/linkedin-profile-posts)\n3. Normalize & deduplicate all results\n4. POST batch to /api/admin/outreach/ingest\n\n**Env vars needed:**\n- APIFY_TOKEN\n- LINKEDIN_COOKIE (li_at cookie for connections scraper)\n- LINKEDIN_PROFILE_URL\n- APP_BASE_URL\n- N8N_INGEST_SECRET\n\n**Note:** LinkedIn profile viewers data is only accessible within LinkedIn's logged-in UI and cannot be reliably scraped. This workflow covers connections + post engagement."
+      }
+    },
+    {
+      "id": "has_agent_run_id",
+      "name": "Has Agent Run ID",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        1360,
+        400
+      ],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "version": 2,
+            "leftValue": "",
+            "caseSensitive": true,
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "agent-run-id-present",
+              "leftValue": "={{ $json.agent_run_id || $node[\"Normalize & Deduplicate\"].json.agent_run_id }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "report_outreach_run_complete",
+      "name": "Report Outreach Run Complete",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1620,
+        320
+      ],
+      "parameters": {
+        "method": "POST",
+        "url": "={{ (($node[\"Normalize & Deduplicate\"].json.callbackBaseUrl || $vars.AMADUTOWN_PUBLIC_BASE_URL || $env.APP_BASE_URL || 'https://amadutown.com') + '').replace(/\\/+$/, '') + '/api/admin/outreach/run-complete' }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $vars.N8N_INGEST_SECRET || $env.N8N_INGEST_SECRET }}"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ source: 'linkedin', agent_run_id: $node[\"Normalize & Deduplicate\"].json.agent_run_id, status: 'completed', leads_inserted: $node[\"Normalize & Deduplicate\"].json.count || (($node[\"Normalize & Deduplicate\"].json.leads || []).length) }) }}"
+      }
+    },
+    {
+      "id": "report_agent_trace_event",
+      "name": "Report Agent Trace Event",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1880,
+        320
+      ],
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $node[\"Normalize & Deduplicate\"].json.agent_event_callback_url || ((($node[\"Normalize & Deduplicate\"].json.callbackBaseUrl || $vars.AMADUTOWN_PUBLIC_BASE_URL || $env.APP_BASE_URL || 'https://amadutown.com') + '').replace(/\\/+$/, '') + '/api/admin/agents/runs/' + $node[\"Normalize & Deduplicate\"].json.agent_run_id + '/events') }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $vars.N8N_INGEST_SECRET || $env.N8N_INGEST_SECRET }}"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ workflow_id: 'WF-WRM-003', stage: 'outreach_ingest_complete', status: 'completed', items_count: $node[\"Normalize & Deduplicate\"].json.count || (($node[\"Normalize & Deduplicate\"].json.leads || []).length), metadata: { source: 'linkedin' }, idempotency_key: $node[\"Normalize & Deduplicate\"].json.agent_run_id + ':WF-WRM-003:outreach_ingest_complete' }) }}"
       }
     }
   ],
@@ -194,6 +311,40 @@
         [
           {
             "node": "POST to Ingest API",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "POST to Ingest API": {
+      "main": [
+        [
+          {
+            "node": "Has Agent Run ID",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Agent Run ID": {
+      "main": [
+        [
+          {
+            "node": "Report Outreach Run Complete",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        []
+      ]
+    },
+    "Report Outreach Run Complete": {
+      "main": [
+        [
+          {
+            "node": "Report Agent Trace Event",
             "type": "main",
             "index": 0
           }


### PR DESCRIPTION
## Summary

- updates the versioned WRM n8n exports to preserve `agent_run_id`, `agent_event_callback_url`, `agent_trace`, and `callbackBaseUrl` through normalization
- adds guarded callback nodes after successful warm-lead ingest so app-triggered Facebook, Google Contacts, and LinkedIn runs close through `/api/admin/outreach/run-complete` and record a generic Agent Operations event
- adds export-level regression tests and updates the warm-lead/Agent Ops docs
- fixes the nearby outreach-generate route test mock to match the Agent Ops auth/run-tracing contract introduced by PR #134

## Scope Notes

This PR only changes versioned n8n exports and app tests/docs. It does not mutate live n8n Cloud workflows. Live workflow import/update remains an Integration Captain or explicit production-automation step.

This replaces closed stacked PR #135 after PR #134 landed. The branch has been rebased onto current `origin/main`.

## Validation

- `npm test -- lib/__tests__/n8n-warm-lead-workflow-export.test.ts lib/__tests__/n8n-warm-lead-scrape.test.ts`
- `npm test -- app/api/admin/outreach/leads/[id]/generate/route.test.ts lib/__tests__/n8n-warm-lead-workflow-export.test.ts lib/__tests__/n8n-warm-lead-scrape.test.ts`
- `npm run build:knowledge && npx tsc --noEmit --pretty false`
- `npm run build`
- `git diff origin/main...HEAD --check`
- pre-push `npm run db:health-check`

## Deferred live automation

The versioned exports are updated here, but live n8n Cloud workflows were not imported or activated by this PR.