### PR TITLE
Add client agent readiness assessment

### DIFF
--- a/app/admin/reports/gamma/page.tsx
+++ b/app/admin/reports/gamma/page.tsx
@@ -110,7 +110,7 @@ const REPORT_TYPES: { value: ReportType; label: string; description: string; sli
   {
     value: 'audit_summary',
     label: 'Audit Summary',
-    description: 'Diagnostic audit results across all 6 categories with key insights and recommended actions.',
+    description: 'Diagnostic audit results across all audit categories with key insights and recommended actions.',
     slides: 11,
   },
   {

--- a/app/api/chat/diagnostic/route.ts
+++ b/app/api/chat/diagnostic/route.ts
@@ -64,6 +64,8 @@ export async function GET(request: NextRequest) {
         techStack: audit.tech_stack,
         automationNeeds: audit.automation_needs,
         aiReadiness: audit.ai_readiness,
+        agentReadiness: audit.agent_readiness ?? {},
+        agentReadinessAssessment: audit.agent_readiness_assessment ?? null,
         budgetTimeline: audit.budget_timeline,
         decisionMaking: audit.decision_making,
         diagnosticSummary: audit.diagnostic_summary,

--- a/app/api/tools/audit/update/route.ts
+++ b/app/api/tools/audit/update/route.ts
@@ -3,11 +3,13 @@ import { getDiagnosticAudit, saveDiagnosticAudit } from '@/lib/diagnostic'
 import { tryVerifyAuth } from '@/lib/auth-server'
 import { AUDIT_CATEGORY_ORDER, categoryFormToPayload } from '@/lib/audit-questions'
 import { computeReportTier } from '@/lib/audit-report-tier'
+import { buildAgentReadinessAssessment } from '@/lib/agent-readiness-assessment'
 import { triggerDiagnosticCompletionWebhook } from '@/lib/n8n'
 import { findOrCreateContactByEmail } from '@/lib/find-or-create-contact'
 import { getAuthUserPrimaryEmail } from '@/lib/auth-user-email'
 import { getClientIpFromRequest, isIpRateLimited } from '@/lib/simple-ip-rate-limit'
 import type { DiagnosticCategory } from '@/lib/n8n'
+import type { DiagnosticAuditData } from '@/lib/n8n'
 import type { DiagnosticAuditRecord } from '@/lib/diagnostic'
 
 export const dynamic = 'force-dynamic'
@@ -71,6 +73,9 @@ function buildSummary(payload: Record<string, Record<string, unknown>>): string 
   if (Object.keys(payload.ai_readiness || {}).length > 0) {
     parts.push('AI readiness and data/team context captured.')
   }
+  if (Object.keys(payload.agent_readiness || {}).length > 0) {
+    parts.push('Systems and agent readiness captured.')
+  }
   if (Object.keys(payload.budget_timeline || {}).length > 0) {
     parts.push('Budget and timeline preferences recorded.')
   }
@@ -85,7 +90,7 @@ function buildSummary(payload: Record<string, Record<string, unknown>>): string 
 /**
  * PUT /api/tools/audit/update
  * Body: { auditId: string, category: DiagnosticCategory, values: Record<string, string | string[] | boolean> }
- * Merges the category payload into the audit. If all 6 categories are present, marks completed and sets summary + scores.
+ * Merges the category payload into the audit. If all categories are present, marks completed and sets summary + scores.
  */
 export async function PUT(request: NextRequest) {
   try {
@@ -144,6 +149,7 @@ export async function PUT(request: NextRequest) {
       tech_stack: (existing.tech_stack as Record<string, unknown>) || {},
       automation_needs: (existing.automation_needs as Record<string, unknown>) || {},
       ai_readiness: (existing.ai_readiness as Record<string, unknown>) || {},
+      agent_readiness: (existing.agent_readiness as Record<string, unknown>) || {},
       budget_timeline: (existing.budget_timeline as Record<string, unknown>) || {},
       decision_making: (existing.decision_making as Record<string, unknown>) || {},
     }
@@ -153,12 +159,17 @@ export async function PUT(request: NextRequest) {
     const allCategoriesPresent = AUDIT_CATEGORY_ORDER.every(
       (c) => existingData[c] && Object.keys(existingData[c]).length > 0
     )
+    const hasAgentReadiness = Object.keys(existingData.agent_readiness).length > 0
 
-    const diagnosticData: Parameters<typeof saveDiagnosticAudit>[1]['diagnosticData'] = {
+    const diagnosticData: Partial<DiagnosticAuditData> = {
       business_challenges: existingData.business_challenges,
       tech_stack: existingData.tech_stack,
       automation_needs: existingData.automation_needs,
       ai_readiness: existingData.ai_readiness,
+      agent_readiness: existingData.agent_readiness,
+      ...(hasAgentReadiness
+        ? { agent_readiness_assessment: buildAgentReadinessAssessment(existingData.agent_readiness) }
+        : {}),
       budget_timeline: existingData.budget_timeline,
       decision_making: existingData.decision_making,
     }

--- a/app/tools/audit/page.tsx
+++ b/app/tools/audit/page.tsx
@@ -477,7 +477,7 @@ export default function AuditToolPage() {
               className="space-y-6"
             >
               {/* Visual stepper */}
-              <div className="rounded-xl border border-radiant-gold/30 bg-black/20 p-4" role="progressbar" aria-valuenow={categoryIndex + 1} aria-valuemin={1} aria-valuemax={6} aria-label="Audit progress">
+              <div className="rounded-xl border border-radiant-gold/30 bg-black/20 p-4" role="progressbar" aria-valuenow={categoryIndex + 1} aria-valuemin={1} aria-valuemax={AUDIT_CATEGORIES.length} aria-label="Audit progress">
                 <p className="text-muted-foreground text-sm mb-3">Your progress</p>
                 <div className="flex items-center justify-between gap-1">
                   {STEP_LABELS.map((label, i) => {

--- a/components/audits/AuditReportView.tsx
+++ b/components/audits/AuditReportView.tsx
@@ -23,6 +23,7 @@ import { useState } from 'react'
 import type { ReactNode } from 'react'
 
 import { getIndustryDisplayName } from '@/lib/constants/industry'
+import { labelForAgentReadinessLevel } from '@/lib/agent-readiness-assessment'
 import {
   getCategoryCaptureStatus,
   getEstimatedOpportunityValue,
@@ -159,6 +160,7 @@ export default function AuditReportView({
   const improvementAreas = getImprovementAreas(report)
   const enriched = report.enrichedTechStack
   const hasEnrichedTech = !!(enriched?.technologies && enriched.technologies.length > 0)
+  const agentReadiness = report.agentReadinessAssessment
 
   return (
     <div className="space-y-6">
@@ -257,6 +259,38 @@ export default function AuditReportView({
         <div className="rounded-lg border border-foreground/20 bg-black/20 p-4">
           <h2 className="font-semibold text-foreground mb-2">Summary</h2>
           <p className="text-sm text-muted-foreground">{report.diagnosticSummary}</p>
+        </div>
+      )}
+
+      {agentReadiness && (
+        <div className="rounded-lg border border-radiant-gold/30 bg-black/20 p-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <p className="text-muted-foreground text-sm">Systems & agent readiness</p>
+              <h2 className="text-lg font-semibold text-foreground">
+                {labelForAgentReadinessLevel(agentReadiness.overallLevel)}
+              </h2>
+            </div>
+            <span className="rounded-full border border-radiant-gold/40 bg-radiant-gold/10 px-3 py-1 text-xs font-medium text-radiant-gold">
+              Tier {agentReadiness.recommendationTier}
+            </span>
+          </div>
+          <p className="text-sm text-muted-foreground mt-2">{agentReadiness.clientSummary}</p>
+          <p className="text-sm text-foreground/90 mt-2">{agentReadiness.roadmapRecommendation}</p>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mt-4">
+            <ReadinessScore label="Context" value={agentReadiness.contextReadinessScore} />
+            <ReadinessScore label="Workflow" value={agentReadiness.workflowReadinessScore} />
+            <ReadinessScore label="Agent" value={agentReadiness.agentReadinessScore} />
+          </div>
+          {agentReadiness.systems.length > 0 && (
+            <div className="mt-4 flex flex-wrap gap-2">
+              {agentReadiness.systems.slice(0, 8).map((system) => (
+                <span key={system.name} className="rounded-full bg-muted/40 px-3 py-1 text-xs text-muted-foreground">
+                  {system.name}: {system.recommendedAiRole.replaceAll('_', ' ')}
+                </span>
+              ))}
+            </div>
+          )}
         </div>
       )}
 
@@ -413,6 +447,15 @@ function LockedPrompt({ title, body }: { title: string; body: string }) {
           <p className="text-xs text-muted-foreground mt-0.5">{body}</p>
         </div>
       </div>
+    </div>
+  )
+}
+
+function ReadinessScore({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-md border border-foreground/10 bg-black/20 p-3">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="text-xl font-bold text-radiant-gold">{value}/10</p>
     </div>
   )
 }

--- a/components/chat/Chat.tsx
+++ b/components/chat/Chat.tsx
@@ -9,6 +9,7 @@ import { VoiceChat } from './VoiceChat'
 import { CalendlyEmbed } from './CalendlyEmbed'
 import { DiagnosticContextPanel } from './DiagnosticContextPanel'
 import { generateSessionId, CHAT_STORAGE_KEY } from '@/lib/chat-utils'
+import { AUDIT_CATEGORY_ORDER } from '@/lib/audit-questions'
 import { isValidCalendlyUrl } from '@/lib/utils'
 import { supabase } from '@/lib/supabase'
 import { signInWithOAuth } from '@/lib/auth'
@@ -686,7 +687,7 @@ export function Chat({ initialMessage, visitorEmail, visitorName }: ChatProps) {
                   </div>
                   {diagnosticProgress && diagnosticProgress.completedCategories && diagnosticProgress.completedCategories.length > 0 && (
                     <div className="text-xs text-muted-foreground/90 mt-1">
-                      Completed: {diagnosticProgress.completedCategories.length} of 6 categories
+                      Completed: {diagnosticProgress.completedCategories.length} of {AUDIT_CATEGORY_ORDER.length} categories
                     </div>
                   )}
                 </motion.div>
@@ -729,7 +730,7 @@ export function Chat({ initialMessage, visitorEmail, visitorName }: ChatProps) {
                       <div className="flex-1">
                         <p className="text-sm font-medium text-radiant-gold">AI Readiness Assessment Started</p>
                         <p className="text-xs text-muted-foreground mt-1">
-                          I&apos;ll ask questions across 6 categories to understand your needs. 
+                          I&apos;ll ask questions across {AUDIT_CATEGORY_ORDER.length} categories to understand your needs.
                           Click &quot;Exit Assessment&quot; in the header anytime to return to regular chat.
                         </p>
                       </div>

--- a/lib/agent-readiness-assessment.test.ts
+++ b/lib/agent-readiness-assessment.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import { buildAgentReadinessAssessment } from './agent-readiness-assessment'
+
+describe('buildAgentReadinessAssessment', () => {
+  it('routes scattered document-heavy organizations to context layer first', () => {
+    const result = buildAgentReadinessAssessment({
+      systems: ['google_drive', 'email', 'spreadsheets'],
+      ownership_clarity: 'partial',
+      assignee_clarity: 'none',
+      status_tracking: 'none',
+      handoff_clarity: 'partial',
+      audit_trails: 'none',
+      permission_controls: 'partial',
+      api_access: 'some',
+      data_quality: 'partial',
+      reversibility: 'partial',
+      business_risk: 'medium',
+    })
+
+    expect(result.overallLevel).toBe('context_layer_first')
+    expect(result.recommendationTier).toBe(2)
+    expect(result.systems.some((system) => system.classification === 'context_only')).toBe(true)
+  })
+
+  it('recommends workflow copilots when systems are structured but not autonomous-ready', () => {
+    const result = buildAgentReadinessAssessment({
+      systems: ['hubspot', 'asana'],
+      ownership_clarity: 'documented',
+      assignee_clarity: 'documented',
+      status_tracking: 'documented',
+      handoff_clarity: 'partial',
+      audit_trails: 'partial',
+      permission_controls: 'documented',
+      api_access: 'some',
+      data_quality: 'mostly',
+      reversibility: 'partial',
+      business_risk: 'medium',
+    })
+
+    expect(result.overallLevel).toBe('workflow_copilot')
+    expect(result.recommendationTier).toBe(3)
+  })
+
+  it('keeps high-risk systems approval-gated even when structure is strong', () => {
+    const result = buildAgentReadinessAssessment({
+      systems: ['workday', 'payroll', 'jira'],
+      ownership_clarity: 'strong',
+      assignee_clarity: 'strong',
+      status_tracking: 'strong',
+      handoff_clarity: 'strong',
+      audit_trails: 'strong',
+      permission_controls: 'strong',
+      api_access: 'strong',
+      data_quality: 'strong',
+      reversibility: 'strong',
+      business_risk: 'high',
+    })
+
+    expect(result.overallLevel).toBe('approval_gated_agent')
+    expect(result.recommendationTier).toBe(4)
+    expect(result.systems.find((system) => system.category === 'payroll')?.recommendedAiRole).toBe('draft_with_approval')
+  })
+
+  it('allows bounded autonomy for low-risk mature workflow systems', () => {
+    const result = buildAgentReadinessAssessment({
+      systems: ['jira', 'linear', 'service_now'],
+      ownership_clarity: 'mature',
+      assignee_clarity: 'mature',
+      status_tracking: 'mature',
+      handoff_clarity: 'mature',
+      audit_trails: 'mature',
+      permission_controls: 'mature',
+      api_access: 'mature',
+      data_quality: 'mature',
+      reversibility: 'mature',
+      business_risk: 'low',
+    })
+
+    expect(result.overallLevel).toBe('bounded_autonomy')
+    expect(result.recommendationTier).toBe(5)
+  })
+})

--- a/lib/agent-readiness-assessment.ts
+++ b/lib/agent-readiness-assessment.ts
@@ -1,0 +1,272 @@
+export type AgentReadinessSystemCategory =
+  | 'crm'
+  | 'erp'
+  | 'hris'
+  | 'payroll'
+  | 'ticketing'
+  | 'project_management'
+  | 'documents'
+  | 'spreadsheet'
+  | 'communication'
+  | 'database'
+  | 'custom'
+  | 'other'
+
+export type AgentReadinessClassification =
+  | 'context_only'
+  | 'structured_reference'
+  | 'workflow_ready'
+  | 'agent_ready'
+
+export type RecommendedAiRole = 'read' | 'recommend' | 'draft_with_approval' | 'act_with_guardrails'
+export type AgentReadinessLevel =
+  | 'organize_first'
+  | 'context_layer_first'
+  | 'workflow_copilot'
+  | 'approval_gated_agent'
+  | 'bounded_autonomy'
+
+export interface AgentReadinessSystemAssessment {
+  name: string
+  category: AgentReadinessSystemCategory
+  classification: AgentReadinessClassification
+  confidence: 'low' | 'medium' | 'high'
+  scores: {
+    ownership: number
+    assignees: number
+    statefulness: number
+    handoffs: number
+    auditTrail: number
+    permissions: number
+    apiAccess: number
+    dataQuality: number
+    reversibility: number
+    risk: number
+  }
+  recommendedAiRole: RecommendedAiRole
+  notes?: string
+}
+
+export interface AgentReadinessAssessment {
+  systems: AgentReadinessSystemAssessment[]
+  contextReadinessScore: number
+  workflowReadinessScore: number
+  agentReadinessScore: number
+  overallLevel: AgentReadinessLevel
+  recommendationTier: 1 | 2 | 3 | 4 | 5
+  clientSummary: string
+  roadmapRecommendation: string
+}
+
+const SYSTEMS: Record<string, { name: string; category: AgentReadinessSystemCategory; base: AgentReadinessClassification }> = {
+  salesforce: { name: 'Salesforce', category: 'crm', base: 'workflow_ready' },
+  hubspot: { name: 'HubSpot', category: 'crm', base: 'workflow_ready' },
+  jira: { name: 'Jira', category: 'ticketing', base: 'agent_ready' },
+  linear: { name: 'Linear', category: 'project_management', base: 'agent_ready' },
+  asana: { name: 'Asana', category: 'project_management', base: 'workflow_ready' },
+  workday: { name: 'Workday / HRIS', category: 'hris', base: 'workflow_ready' },
+  oracle: { name: 'Oracle ERP', category: 'erp', base: 'workflow_ready' },
+  payroll: { name: 'Payroll system', category: 'payroll', base: 'workflow_ready' },
+  service_now: { name: 'ServiceNow', category: 'ticketing', base: 'agent_ready' },
+  google_drive: { name: 'Google Drive / Docs', category: 'documents', base: 'context_only' },
+  sharepoint: { name: 'SharePoint / OneDrive', category: 'documents', base: 'context_only' },
+  spreadsheets: { name: 'Spreadsheets', category: 'spreadsheet', base: 'structured_reference' },
+  email: { name: 'Email inboxes', category: 'communication', base: 'context_only' },
+  slack_teams: { name: 'Slack / Teams', category: 'communication', base: 'context_only' },
+  database: { name: 'Custom database', category: 'database', base: 'structured_reference' },
+  custom_app: { name: 'Custom internal app', category: 'custom', base: 'structured_reference' },
+}
+
+const scoreValue: Record<string, number> = {
+  none: 1,
+  unclear: 1,
+  low: 2,
+  scattered: 2,
+  partial: 5,
+  some: 5,
+  medium: 5,
+  documented: 7,
+  mostly: 7,
+  strong: 9,
+  high: 9,
+  mature: 10,
+}
+
+function normalizedScore(value: unknown, fallback: number): number {
+  if (typeof value !== 'string') return fallback
+  return scoreValue[value] ?? fallback
+}
+
+function riskScore(value: unknown): number {
+  if (value === 'high') return 2
+  if (value === 'medium') return 5
+  if (value === 'low') return 9
+  return 5
+}
+
+function average(values: number[]): number {
+  return Math.round(values.reduce((sum, value) => sum + value, 0) / values.length)
+}
+
+function downgradeForRisk(
+  classification: AgentReadinessClassification,
+  category: AgentReadinessSystemCategory,
+  risk: number,
+): AgentReadinessClassification {
+  if (risk <= 3 && classification === 'agent_ready') return 'workflow_ready'
+  if (risk <= 3 && category === 'payroll') return 'workflow_ready'
+  return classification
+}
+
+function roleFor(classification: AgentReadinessClassification, risk: number): RecommendedAiRole {
+  if (classification === 'context_only') return 'read'
+  if (classification === 'structured_reference') return 'recommend'
+  if (classification === 'workflow_ready') return 'draft_with_approval'
+  return risk <= 6 ? 'draft_with_approval' : 'act_with_guardrails'
+}
+
+function levelFromScores(context: number, workflow: number, agent: number, highRiskCount: number): AgentReadinessLevel {
+  if (context < 4 && workflow < 4) return 'organize_first'
+  if (context >= 5 && workflow < 5) return 'context_layer_first'
+  if (workflow >= 5 && agent < 6) return 'workflow_copilot'
+  if (agent >= 7 && highRiskCount === 0) return 'bounded_autonomy'
+  if (workflow >= 7 || agent >= 6) return 'approval_gated_agent'
+  return 'context_layer_first'
+}
+
+function tierFor(level: AgentReadinessLevel): 1 | 2 | 3 | 4 | 5 {
+  switch (level) {
+    case 'organize_first': return 1
+    case 'context_layer_first': return 2
+    case 'workflow_copilot': return 3
+    case 'approval_gated_agent': return 4
+    case 'bounded_autonomy': return 5
+  }
+}
+
+export function labelForAgentReadinessLevel(level: AgentReadinessLevel): string {
+  switch (level) {
+    case 'organize_first': return 'Organize first'
+    case 'context_layer_first': return 'Context layer first'
+    case 'workflow_copilot': return 'Workflow copilot'
+    case 'approval_gated_agent': return 'Approval-gated agent'
+    case 'bounded_autonomy': return 'Bounded autonomy'
+  }
+}
+
+function summaryFor(level: AgentReadinessLevel): string {
+  switch (level) {
+    case 'organize_first':
+      return 'Your information needs more structure before AI should do more than help organize and summarize it.'
+    case 'context_layer_first':
+      return 'Your data can support search, summarization, and knowledge retrieval before state-changing automation.'
+    case 'workflow_copilot':
+      return 'Your systems can support AI recommendations and drafts, with people approving the actual changes.'
+    case 'approval_gated_agent':
+      return 'Some systems are structured enough for agents to prepare and execute bounded actions after approval.'
+    case 'bounded_autonomy':
+      return 'Your strongest systems can support narrow autonomous actions when policy, monitoring, and rollback are in place.'
+  }
+}
+
+function roadmapFor(level: AgentReadinessLevel): string {
+  switch (level) {
+    case 'organize_first':
+      return 'Start with source inventory, ownership mapping, cleanup, and access controls before agent deployment.'
+    case 'context_layer_first':
+      return 'Prioritize a knowledge layer, document Q&A, meeting summaries, and source mapping.'
+    case 'workflow_copilot':
+      return 'Prioritize approval-gated copilots for follow-up drafts, task creation, reports, and workflow suggestions.'
+    case 'approval_gated_agent':
+      return 'Prioritize bounded agents with explicit approval gates for high-value workflow systems.'
+    case 'bounded_autonomy':
+      return 'Prioritize monitored agents for low-risk, reversible actions while keeping high-risk workflows approval-gated.'
+  }
+}
+
+export function buildAgentReadinessAssessment(input: Record<string, unknown> | null | undefined): AgentReadinessAssessment {
+  const systemKeys = Array.isArray(input?.systems) ? input?.systems as string[] : []
+  const customSystems = typeof input?.other_systems === 'string'
+    ? input.other_systems.split('\n').map((item) => item.trim()).filter(Boolean)
+    : []
+
+  const criteriaScores = {
+    ownership: normalizedScore(input?.ownership_clarity, 4),
+    assignees: normalizedScore(input?.assignee_clarity, 4),
+    statefulness: normalizedScore(input?.status_tracking, 4),
+    handoffs: normalizedScore(input?.handoff_clarity, 4),
+    auditTrail: normalizedScore(input?.audit_trails, 4),
+    permissions: normalizedScore(input?.permission_controls, 4),
+    apiAccess: normalizedScore(input?.api_access, 4),
+    dataQuality: normalizedScore(input?.data_quality, 4),
+    reversibility: normalizedScore(input?.reversibility, 4),
+    risk: riskScore(input?.business_risk),
+  }
+
+  const systems = [
+    ...systemKeys.map((key) => SYSTEMS[key]).filter(Boolean),
+    ...customSystems.map((name) => ({ name, category: 'other' as const, base: 'structured_reference' as const })),
+  ]
+
+  const assessedSystems = systems.map((system): AgentReadinessSystemAssessment => {
+    const workflowScore = average([
+      criteriaScores.ownership,
+      criteriaScores.assignees,
+      criteriaScores.statefulness,
+      criteriaScores.handoffs,
+      criteriaScores.auditTrail,
+      criteriaScores.permissions,
+    ])
+    const agentScore = average([
+      workflowScore,
+      criteriaScores.apiAccess,
+      criteriaScores.reversibility,
+      criteriaScores.risk,
+    ])
+    const classification = downgradeForRisk(
+      agentScore >= 8 ? 'agent_ready' : workflowScore >= 6 ? system.base : system.base === 'context_only' ? 'context_only' : 'structured_reference',
+      system.category,
+      criteriaScores.risk,
+    )
+
+    return {
+      name: system.name,
+      category: system.category,
+      classification,
+      confidence: systemKeys.length > 0 ? 'medium' : 'low',
+      scores: criteriaScores,
+      recommendedAiRole: roleFor(classification, criteriaScores.risk),
+      notes: criteriaScores.risk <= 3 ? 'High-risk system. Keep human approval in the loop.' : undefined,
+    }
+  })
+
+  const contextReadinessScore = assessedSystems.length
+    ? average(assessedSystems.map((system) => average([system.scores.dataQuality, system.scores.permissions])))
+    : average([criteriaScores.dataQuality, criteriaScores.permissions])
+  const workflowReadinessScore = average([
+    criteriaScores.ownership,
+    criteriaScores.assignees,
+    criteriaScores.statefulness,
+    criteriaScores.handoffs,
+    criteriaScores.auditTrail,
+  ])
+  const agentReadinessScore = average([
+    workflowReadinessScore,
+    criteriaScores.apiAccess,
+    criteriaScores.reversibility,
+    criteriaScores.risk,
+  ])
+  const highRiskCount = assessedSystems.filter((system) => system.scores.risk <= 3).length
+  const overallLevel = levelFromScores(contextReadinessScore, workflowReadinessScore, agentReadinessScore, highRiskCount)
+
+  return {
+    systems: assessedSystems,
+    contextReadinessScore,
+    workflowReadinessScore,
+    agentReadinessScore,
+    overallLevel,
+    recommendationTier: tierFor(overallLevel),
+    clientSummary: summaryFor(overallLevel),
+    roadmapRecommendation: roadmapFor(overallLevel),
+  }
+}

--- a/lib/audit-from-meetings.ts
+++ b/lib/audit-from-meetings.ts
@@ -121,7 +121,7 @@ Only include keys for which you found evidence in the transcript. Omit keys with
 
 /**
  * Call OpenAI to extract diagnostic audit data from combined meeting text.
- * Returns object matching DiagnosticAuditData shape (six categories + optional summary/scores).
+ * Returns object matching DiagnosticAuditData shape (audit categories + optional summary/scores).
  */
 export async function extractDiagnosticFromMeetingText(
   combinedText: string,

--- a/lib/audit-questions.ts
+++ b/lib/audit-questions.ts
@@ -1,5 +1,5 @@
 /**
- * Standalone AI / Automation Audit — same 6 categories as chat-based diagnostic.
+ * Standalone AI / Automation Audit categories.
  * Used by the /tools/audit form and maps directly to diagnostic_audits JSONB columns.
  */
 
@@ -141,6 +141,33 @@ const AI_CONCERNS = [
   { value: 'other', label: 'Other' },
 ]
 
+const AGENT_SYSTEM_OPTIONS = [
+  { value: 'salesforce', label: 'Salesforce' },
+  { value: 'hubspot', label: 'HubSpot' },
+  { value: 'jira', label: 'Jira' },
+  { value: 'linear', label: 'Linear' },
+  { value: 'asana', label: 'Asana' },
+  { value: 'workday', label: 'Workday / HRIS' },
+  { value: 'oracle', label: 'Oracle ERP' },
+  { value: 'payroll', label: 'Payroll system' },
+  { value: 'service_now', label: 'ServiceNow' },
+  { value: 'google_drive', label: 'Google Drive / Docs' },
+  { value: 'sharepoint', label: 'SharePoint / OneDrive' },
+  { value: 'spreadsheets', label: 'Spreadsheets' },
+  { value: 'email', label: 'Email inboxes' },
+  { value: 'slack_teams', label: 'Slack / Teams' },
+  { value: 'database', label: 'Custom database' },
+  { value: 'custom_app', label: 'Custom internal app' },
+]
+
+const READINESS_MATURITY_OPTIONS = [
+  { value: 'none', label: 'No / mostly missing' },
+  { value: 'partial', label: 'Partially true' },
+  { value: 'documented', label: 'Documented for key workflows' },
+  { value: 'strong', label: 'Strong and consistently used' },
+  { value: 'mature', label: 'Mature, governed, and auditable' },
+]
+
 const TIMELINE_OPTIONS = [
   { value: 'asap', label: 'As soon as possible' },
   { value: '4_8_weeks', label: 'Within 4–8 weeks' },
@@ -253,6 +280,29 @@ export const AUDIT_CATEGORIES: AuditCategoryConfig[] = [
         { value: 'built_something', label: 'We\'ve built or integrated AI' },
       ] },
       { key: 'concerns', label: 'Concerns or blockers', type: 'multiselect', options: AI_CONCERNS },
+    ],
+  },
+  {
+    id: 'agent_readiness',
+    title: 'Systems & agent readiness',
+    description: 'Which systems are structured enough for AI to read, recommend, draft, or act with guardrails?',
+    fields: [
+      { key: 'systems', label: 'Systems in use', type: 'multiselect', options: AGENT_SYSTEM_OPTIONS },
+      { key: 'other_systems', label: 'Other systems', type: 'multiline', multiple: true, placeholder: 'One system per line' },
+      { key: 'ownership_clarity', label: 'Clear system or workflow owners', type: 'select', options: READINESS_MATURITY_OPTIONS },
+      { key: 'assignee_clarity', label: 'Named assignees for work items', type: 'select', options: READINESS_MATURITY_OPTIONS },
+      { key: 'status_tracking', label: 'Defined statuses or states', type: 'select', options: READINESS_MATURITY_OPTIONS },
+      { key: 'handoff_clarity', label: 'Clear handoffs between people or teams', type: 'select', options: READINESS_MATURITY_OPTIONS },
+      { key: 'audit_trails', label: 'Change history or audit trails', type: 'select', options: READINESS_MATURITY_OPTIONS },
+      { key: 'permission_controls', label: 'Role-based permissions', type: 'select', options: READINESS_MATURITY_OPTIONS },
+      { key: 'api_access', label: 'API or integration access', type: 'select', options: READINESS_MATURITY_OPTIONS },
+      { key: 'data_quality', label: 'Data quality and consistency', type: 'select', options: READINESS_MATURITY_OPTIONS },
+      { key: 'reversibility', label: 'Ability to undo or correct changes', type: 'select', options: READINESS_MATURITY_OPTIONS },
+      { key: 'business_risk', label: 'Risk if AI changes the wrong thing', type: 'select', options: [
+        { value: 'low', label: 'Low risk' },
+        { value: 'medium', label: 'Medium risk' },
+        { value: 'high', label: 'High risk' },
+      ] },
     ],
   },
   {

--- a/lib/audit-report-tier.test.ts
+++ b/lib/audit-report-tier.test.ts
@@ -26,6 +26,7 @@ function buildAudit(
     tech_stack: categoryPayloads.tech_stack,
     automation_needs: categoryPayloads.automation_needs,
     ai_readiness: categoryPayloads.ai_readiness,
+    agent_readiness: categoryPayloads.agent_readiness,
     budget_timeline: categoryPayloads.budget_timeline,
     decision_making: categoryPayloads.decision_making,
     started_at: '2026-03-25T00:00:00.000Z',

--- a/lib/audit-report-tier.ts
+++ b/lib/audit-report-tier.ts
@@ -100,8 +100,8 @@ function hasValueEstimate(audit: DiagnosticAuditRecord): boolean {
  * Compute the report tier and available/locked sections for a diagnostic audit.
  *
  * Tier rules:
- * - Bronze:   < 6 categories OR no email
- * - Silver:   All 6 categories + email
+ * - Bronze:   incomplete categories OR no email
+ * - Silver:   all categories + email
  * - Gold:     Silver + website URL + industry (+ enrichment available)
  * - Platinum: Gold + generated strategy deck (gamma_reports linked)
  *

--- a/lib/audit-report-view.ts
+++ b/lib/audit-report-view.ts
@@ -13,6 +13,7 @@
  */
 
 import { AUDIT_CATEGORY_ORDER, formatPayloadLine } from '@/lib/audit-questions'
+import type { AgentReadinessAssessment } from '@/lib/agent-readiness-assessment'
 
 // ---------------------------------------------------------------------------
 // Canonical view-model
@@ -31,6 +32,8 @@ export interface AuditReportViewModel {
   techStack?: Record<string, unknown>
   automationNeeds?: Record<string, unknown>
   aiReadiness?: Record<string, unknown>
+  agentReadiness?: Record<string, unknown>
+  agentReadinessAssessment?: AgentReadinessAssessment | null
   budgetTimeline?: Record<string, unknown>
   decisionMaking?: Record<string, unknown>
   diagnosticSummary?: string
@@ -263,12 +266,13 @@ export function getImprovementAreas(results: AuditReportViewModel): ImprovementA
 // Category capture status (What we captured)
 // ---------------------------------------------------------------------------
 
-/** Short labels for the 6 audit categories, in `AUDIT_CATEGORY_ORDER`. */
+/** Short labels for the audit categories, in `AUDIT_CATEGORY_ORDER`. */
 export const STEP_LABELS = [
   'Challenges',
   'Tech stack',
   'Automation',
   'AI readiness',
+  'Agent',
   'Budget',
   'Decision',
 ] as const
@@ -279,6 +283,7 @@ export const RESULTS_CATEGORY_KEYS: (keyof AuditReportViewModel)[] = [
   'techStack',
   'automationNeeds',
   'aiReadiness',
+  'agentReadiness',
   'budgetTimeline',
   'decisionMaking',
 ]

--- a/lib/client-ai-ops-roadmap.test.ts
+++ b/lib/client-ai-ops-roadmap.test.ts
@@ -43,6 +43,28 @@ describe('client AI ops roadmap', () => {
     expect(snapshot.costSummary.monthlyClientOwned).toBeGreaterThan(0)
   })
 
+  it('uses agent readiness to shape roadmap recommendations when provided', () => {
+    const snapshot = buildProposalRoadmapSnapshot({
+      clientCompany: 'Acme Co',
+      implementationRequirements: {
+        agentReadinessAssessment: {
+          systems: [],
+          contextReadinessScore: 8,
+          workflowReadinessScore: 8,
+          agentReadinessScore: 5,
+          overallLevel: 'workflow_copilot',
+          recommendationTier: 3,
+          clientSummary: 'Workflow systems can support AI recommendations and drafts.',
+          roadmapRecommendation: 'Prioritize approval-gated copilots before autonomous action.',
+        },
+      },
+    })
+
+    expect(snapshot.clientSummary).toContain('approval-gated copilots')
+    expect(snapshot.phases.find((phase) => phase.phaseKey === 'agent_automation_deployment')?.objective)
+      .toContain('workflow copilots')
+  })
+
   it('maps statuses between roadmap and projected task tables', () => {
     expect(dashboardStatusFromRoadmap('blocked')).toBe('in_progress')
     expect(meetingTaskStatusFromRoadmap('cancelled')).toBe('cancelled')

--- a/lib/client-ai-ops-roadmap.ts
+++ b/lib/client-ai-ops-roadmap.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto'
+import type { AgentReadinessAssessment, AgentReadinessLevel } from './agent-readiness-assessment'
 
 export const ROADMAP_PHASES = [
   'discovery_ownership',
@@ -249,14 +250,92 @@ function hashContext(context: RoadmapContext): string {
   return createHash('sha256').update(JSON.stringify(context)).digest('hex').slice(0, 16)
 }
 
+function getAgentReadinessAssessment(context: RoadmapContext): AgentReadinessAssessment | null {
+  const maybeAssessment = context.implementationRequirements?.agentReadinessAssessment
+    ?? context.implementationRequirements?.agent_readiness_assessment
+
+  if (!maybeAssessment || typeof maybeAssessment !== 'object') return null
+
+  const assessment = maybeAssessment as Partial<AgentReadinessAssessment>
+  if (
+    !assessment.overallLevel ||
+    !assessment.clientSummary ||
+    !assessment.roadmapRecommendation ||
+    typeof assessment.contextReadinessScore !== 'number' ||
+    typeof assessment.workflowReadinessScore !== 'number' ||
+    typeof assessment.agentReadinessScore !== 'number'
+  ) {
+    return null
+  }
+
+  return assessment as AgentReadinessAssessment
+}
+
+function phaseAdjustmentsForReadiness(level: AgentReadinessLevel): Partial<Record<RoadmapPhaseKey, Pick<RoadmapPhaseDraft, 'objective' | 'acceptanceCriteria'>>> {
+  switch (level) {
+    case 'organize_first':
+      return {
+        discovery_ownership: {
+          objective: 'Inventory messy sources, confirm owners, clean up access, and define the minimum structure needed before agent work.',
+          acceptanceCriteria: ['Source inventory completed', 'System owners confirmed', 'Cleanup priorities approved'],
+        },
+        data_ai_foundation: {
+          objective: 'Create the context and source map AI needs before workflow automation or autonomous actions are considered.',
+          acceptanceCriteria: ['Context layer scope approved', 'Priority sources normalized', 'Access boundaries tested'],
+        },
+      }
+    case 'context_layer_first':
+      return {
+        data_ai_foundation: {
+          objective: 'Build a governed context layer across approved sources before changing workflow states.',
+          acceptanceCriteria: ['Approved data sources mapped', 'Permission groups documented', 'Retrieval passes source attribution checks'],
+        },
+      }
+    case 'workflow_copilot':
+      return {
+        agent_automation_deployment: {
+          objective: 'Deploy workflow copilots that draft, recommend, and route work while people approve state changes.',
+          acceptanceCriteria: ['Copilot scopes documented', 'Human approval paths tested', 'Workflow draft quality reviewed'],
+        },
+      }
+    case 'approval_gated_agent':
+      return {
+        agent_automation_deployment: {
+          objective: 'Deploy bounded agents with explicit approval gates for structured systems and higher-risk changes.',
+          acceptanceCriteria: ['Agent action policy approved', 'Approval gates tested', 'Rollback procedure documented'],
+        },
+      }
+    case 'bounded_autonomy':
+      return {
+        agent_automation_deployment: {
+          objective: 'Deploy monitored agents for low-risk reversible actions while keeping sensitive actions approval-gated.',
+          acceptanceCriteria: ['Autonomous action list approved', 'Monitoring alerts tested', 'Rollback procedure documented'],
+        },
+      }
+  }
+}
+
 export function buildDefaultClientAiOpsRoadmap(context: RoadmapContext = {}): RoadmapDraft {
   const name = context.clientCompany || context.clientName || 'Client'
+  const agentReadiness = getAgentReadinessAssessment(context)
+  const adjustments = agentReadiness ? phaseAdjustmentsForReadiness(agentReadiness.overallLevel) : {}
+
   return {
     title: `${name} AI Ops Roadmap`,
-    clientSummary:
-      'A phased implementation plan for client-owned AI infrastructure, transparent setup costs, agent deployment, monitoring, and continuity reporting.',
+    clientSummary: agentReadiness
+      ? `${agentReadiness.clientSummary} ${agentReadiness.roadmapRecommendation}`
+      : 'A phased implementation plan for client-owned AI infrastructure, transparent setup costs, agent deployment, monitoring, and continuity reporting.',
     inputHash: hashContext(context),
-    phases: DEFAULT_PHASES.map((phase) => ({ ...phase, acceptanceCriteria: [...phase.acceptanceCriteria] })),
+    phases: DEFAULT_PHASES.map((phase) => {
+      const adjustment = adjustments[phase.phaseKey]
+      return {
+        ...phase,
+        ...(adjustment ? { objective: adjustment.objective } : {}),
+        acceptanceCriteria: adjustment?.acceptanceCriteria
+          ? [...adjustment.acceptanceCriteria]
+          : [...phase.acceptanceCriteria],
+      }
+    }),
     tasks: DEFAULT_TASKS.map((t) => ({ ...t })),
     costItems: DEFAULT_COST_ITEMS.map((item) => ({ ...item })),
   }

--- a/lib/diagnostic.ts
+++ b/lib/diagnostic.ts
@@ -5,6 +5,7 @@
 
 import { supabaseAdmin } from './supabase'
 import type { DiagnosticAuditData, DiagnosticCategory, DiagnosticProgress } from './n8n'
+import type { AgentReadinessAssessment } from './agent-readiness-assessment'
 
 /** audit_type values on diagnostic_audits; must match DB CHECK constraint. */
 export type DiagnosticAuditType = 'chat' | 'standalone' | 'in_person' | 'from_meetings'
@@ -23,6 +24,8 @@ export interface DiagnosticAuditRecord {
   tech_stack: Record<string, unknown>
   automation_needs: Record<string, unknown>
   ai_readiness: Record<string, unknown>
+  agent_readiness?: Record<string, unknown> | null
+  agent_readiness_assessment?: AgentReadinessAssessment | null
   budget_timeline: Record<string, unknown>
   decision_making: Record<string, unknown>
   diagnostic_summary?: string | null
@@ -136,6 +139,12 @@ export async function saveDiagnosticAudit(
       }
       if (data.diagnosticData.ai_readiness) {
         updateData.ai_readiness = data.diagnosticData.ai_readiness
+      }
+      if (data.diagnosticData.agent_readiness) {
+        updateData.agent_readiness = data.diagnosticData.agent_readiness
+      }
+      if (data.diagnosticData.agent_readiness_assessment) {
+        updateData.agent_readiness_assessment = data.diagnosticData.agent_readiness_assessment
       }
       if (data.diagnosticData.budget_timeline) {
         updateData.budget_timeline = data.diagnosticData.budget_timeline
@@ -496,6 +505,7 @@ export function isValidDiagnosticCategory(category: string): category is Diagnos
     'tech_stack',
     'automation_needs',
     'ai_readiness',
+    'agent_readiness',
     'budget_timeline',
     'decision_making',
   ]
@@ -525,6 +535,7 @@ export function getDiagnosticProgress(audit: DiagnosticAuditRecord): number {
     'tech_stack',
     'automation_needs',
     'ai_readiness',
+    'agent_readiness',
     'budget_timeline',
     'decision_making',
   ]

--- a/lib/n8n.ts
+++ b/lib/n8n.ts
@@ -8,6 +8,7 @@ import {
   isMockN8nEnabled,
   isN8nOutboundDisabled,
 } from './n8n-runtime-flags'
+import type { AgentReadinessAssessment } from './agent-readiness-assessment'
 
 export { isMockN8nEnabled, isN8nOutboundDisabled }
 
@@ -267,6 +268,7 @@ function generateMockDiagnosticResponse(
     'tech_stack', 
     'automation_needs',
     'ai_readiness',
+    'agent_readiness',
     'budget_timeline',
     'decision_making'
   ]
@@ -314,6 +316,7 @@ function generateMockDiagnosticResponse(
     tech_stack: "What tools and systems are you currently using? This includes CRM, project management, communication tools, etc.",
     automation_needs: "Which processes or tasks take up the most time that you'd like to automate?",
     ai_readiness: "How would you describe your organization's readiness for AI adoption? Do you have clean data and processes documented?",
+    agent_readiness: "Which systems have clear owners, statuses, permissions, audit trails, and APIs that an AI agent could safely work with?",
     budget_timeline: "What budget range are you considering for improvements, and what's your ideal timeline?",
     decision_making: "Are you the decision maker for technology investments, or who else would be involved?"
   }
@@ -527,6 +530,7 @@ export type DiagnosticCategory =
   | 'tech_stack'
   | 'automation_needs'
   | 'ai_readiness'
+  | 'agent_readiness'
   | 'budget_timeline'
   | 'decision_making'
 
@@ -578,6 +582,8 @@ export interface DiagnosticAuditData {
   tech_stack: Record<string, unknown>
   automation_needs: Record<string, unknown>
   ai_readiness: Record<string, unknown>
+  agent_readiness?: Record<string, unknown>
+  agent_readiness_assessment?: AgentReadinessAssessment
   budget_timeline: Record<string, unknown>
   decision_making: Record<string, unknown>
   diagnostic_summary?: string

--- a/lib/testing/scenarios.ts
+++ b/lib/testing/scenarios.ts
@@ -77,7 +77,7 @@ export const browseAndBuyScenario: TestScenario = {
 export const chatToDiagnosticScenario: TestScenario = {
   id: 'chat_to_diagnostic',
   name: 'Chat to Diagnostic',
-  description: 'Engage with chat assistant, trigger diagnostic assessment, complete all 6 categories',
+  description: 'Engage with chat assistant, trigger diagnostic assessment, complete all diagnostic categories',
   journeyStage: ['prospect', 'lead'],
   
   steps: [

--- a/supabase/migrations/20260505132637_agent_readiness_assessment.sql
+++ b/supabase/migrations/20260505132637_agent_readiness_assessment.sql
@@ -1,0 +1,9 @@
+ALTER TABLE diagnostic_audits
+  ADD COLUMN IF NOT EXISTS agent_readiness JSONB NOT NULL DEFAULT '{}'::jsonb,
+  ADD COLUMN IF NOT EXISTS agent_readiness_assessment JSONB;
+
+COMMENT ON COLUMN diagnostic_audits.agent_readiness IS
+  'Raw Systems & Agent Readiness audit answers: system inventory, ownership, statefulness, auditability, permissions, API access, reversibility, and risk.';
+
+COMMENT ON COLUMN diagnostic_audits.agent_readiness_assessment IS
+  'Derived client agent/data readiness interpretation used by reports, proposals, and AI Ops roadmap recommendations.';


### PR DESCRIPTION
## Summary
- add Systems & agent readiness as a diagnostic audit category with durable raw answers and derived assessment storage
- add deterministic agent/data readiness scoring, interpretation tiers, and client-safe report rendering
- wire readiness recommendations into AI Ops roadmap snapshot shaping when provided by implementation requirements

## Validation
- npm test -- lib/agent-readiness-assessment.test.ts lib/client-ai-ops-roadmap.test.ts lib/audit-report-tier.test.ts lib/chat-validation.test.ts
- npx tsc --noEmit --pretty false
- npm run build

## Notes
- Build was run from the isolated worktree with a local symlink to the existing .env.local so secrets were not copied into the branch.
- Main checkout dirty docs were left untouched.