### PR TITLE
fix: preserve completed agent run status

### DIFF
--- a/lib/agent-run.test.ts
+++ b/lib/agent-run.test.ts
@@ -105,6 +105,24 @@ describe('agent-run helpers', () => {
     }))
   })
 
+  it('does not reopen a terminal run when a late completed step is recorded', async () => {
+    mocks.singleQueue.push({ data: { id: 'step-1' }, error: null })
+    mocks.maybeSingleQueue.push({ data: { status: 'completed' }, error: null })
+
+    const result = await recordAgentStep({
+      runId: 'run-1',
+      name: 'n8n callback finished',
+      status: 'completed',
+      idempotencyKey: 'late-step-idem',
+    })
+
+    expect(result).toEqual({ id: 'step-1' })
+    expect(mocks.updateMock).toHaveBeenCalledWith(expect.objectContaining({
+      current_step: 'n8n callback finished',
+      status: 'completed',
+    }))
+  })
+
   it('records events and artifacts', async () => {
     mocks.singleQueue.push(
       { data: { id: 'event-1' }, error: null },

--- a/lib/agent-run.ts
+++ b/lib/agent-run.ts
@@ -17,6 +17,12 @@ export type AgentRuntime = (typeof AGENT_RUNTIMES)[number]
 export type AgentRunStatus = (typeof AGENT_RUN_STATUSES)[number]
 export type AgentEventSeverity = (typeof AGENT_EVENT_SEVERITIES)[number]
 export type AgentApprovalStatus = (typeof AGENT_APPROVAL_STATUSES)[number]
+const TERMINAL_AGENT_RUN_STATUSES: ReadonlySet<AgentRunStatus> = new Set([
+  'completed',
+  'failed',
+  'cancelled',
+  'stale',
+])
 
 export interface AgentSubjectRef {
   type?: string | null
@@ -214,11 +220,21 @@ export async function recordAgentStep(input: RecordAgentStepInput): Promise<{ id
       ? status
       : 'running'
 
+  const { data: existingRun } = await db()
+    .from('agent_runs')
+    .select('status')
+    .eq('id', input.runId)
+    .maybeSingle()
+
+  const existingStatus = (existingRun as { status?: AgentRunStatus } | null)?.status
+  const shouldPreserveTerminalStatus =
+    existingStatus && TERMINAL_AGENT_RUN_STATUSES.has(existingStatus) && runStatus === 'running'
+
   await db()
     .from('agent_runs')
     .update({
       current_step: input.name,
-      status: runStatus,
+      status: shouldPreserveTerminalStatus ? existingStatus : runStatus,
       updated_at: new Date().toISOString(),
     })
     .eq('id', input.runId)


### PR DESCRIPTION
## Summary
- Prevent late completed progress steps from downgrading terminal agent runs back to running
- Add focused coverage for the n8n callback ordering case exposed by the WRM-002 staging smoke

## Validation
- npm test -- lib/agent-run.test.ts
- Staging WRM-002 synthetic smoke completed successfully in n8n execution 13044
- Agent Ops smoke run 80caedcb-7e30-4edc-967e-70d76ccc17fc is completed after correction

## Notes
- Integration Captain should merge; this branch intentionally does not touch unrelated dirty docs.