### PR TITLE
Add approval-gated agent swarm board

### DIFF
--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -9,6 +9,7 @@ import {
   ArrowRight,
   Bot,
   CheckCircle2,
+  Columns,
   CircleDollarSign,
   ClipboardList,
   Clock3,
@@ -355,6 +356,10 @@ export default function AgentOperationsPage() {
                 <Activity size={16} />
                 Runs
               </Link>
+              <Link href="/admin/agents/swarm-board" className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 bg-background/60 px-3 py-2 text-sm hover:border-radiant-gold/60">
+                <Columns size={16} />
+                Swarm Board
+              </Link>
             </div>
           </div>
 
@@ -512,6 +517,7 @@ export default function AgentOperationsPage() {
               <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2 xl:grid-cols-1">
                 <ControlLink href="/admin/agents/chief-of-staff" label="Chief of Staff Chat" />
                 <ControlLink href="/admin/agents/runs" label="Run Console" />
+                <ControlLink href="/admin/agents/swarm-board" label="Client Swarm Board" />
                 <ControlLink href="/admin/agents/automations" label="Automation Context" />
                 <ActionButton label="Morning review" loading={actionLoading === 'morning-review'} onClick={() => runOperatorAction('morning-review')} />
                 <ActionButton label="Hermes health" loading={actionLoading === 'hermes'} onClick={() => runOperatorAction('hermes')} />

--- a/app/admin/agents/swarm-board/page.tsx
+++ b/app/admin/agents/swarm-board/page.tsx
@@ -1,0 +1,314 @@
+'use client'
+
+import Link from 'next/link'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  AlertTriangle,
+  ArrowRight,
+  Bot,
+  CheckCircle2,
+  Columns,
+  LockKeyhole,
+  RefreshCw,
+} from 'lucide-react'
+import ProtectedRoute from '@/components/ProtectedRoute'
+import Breadcrumbs from '@/components/admin/Breadcrumbs'
+import { getCurrentSession } from '@/lib/auth'
+import type {
+  AgentSwarmBoardSnapshot,
+  SwarmBoardCard,
+  SwarmBoardColumnKey,
+} from '@/lib/agent-swarm-board'
+
+type Filter = 'all' | 'attention' | 'approval' | 'autonomous'
+
+const FILTERS: Array<{ key: Filter; label: string }> = [
+  { key: 'all', label: 'All' },
+  { key: 'attention', label: 'Needs attention' },
+  { key: 'approval', label: 'Waiting approval' },
+  { key: 'autonomous', label: 'Autonomous-ready' },
+]
+
+const COLUMN_TONES: Record<SwarmBoardColumnKey, string> = {
+  intake: 'border-silicon-slate/70',
+  discovery: 'border-blue-500/30',
+  decision_packet: 'border-teal-500/30',
+  provisioning_plan: 'border-amber-500/30',
+  build_configure: 'border-purple-500/30',
+  qa_isolation: 'border-cyan-500/30',
+  waiting_approval: 'border-yellow-500/40',
+  active_monitoring: 'border-green-500/35',
+  blocked_escalated: 'border-red-500/40',
+  done_archived: 'border-silicon-slate/70',
+}
+
+export default function AgentSwarmBoardPage() {
+  return (
+    <ProtectedRoute requireAdmin>
+      <AgentSwarmBoardContent />
+    </ProtectedRoute>
+  )
+}
+
+function AgentSwarmBoardContent() {
+  const [snapshot, setSnapshot] = useState<AgentSwarmBoardSnapshot | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [filter, setFilter] = useState<Filter>('all')
+
+  const fetchBoard = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Missing admin session')
+      const res = await fetch('/api/admin/agents/swarm-board', {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      })
+      const body = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(body.error || `HTTP ${res.status}`)
+      setSnapshot(body)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load client swarm board')
+      setSnapshot(null)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchBoard()
+  }, [fetchBoard])
+
+  const filteredColumns = useMemo(() => {
+    if (!snapshot) return []
+    return snapshot.columns.map((column) => ({
+      ...column,
+      cards: column.cards.filter((card) => cardMatchesFilter(card, filter)),
+    }))
+  }, [filter, snapshot])
+
+  return (
+    <div className="min-h-screen bg-background text-foreground p-6 lg:p-8">
+      <div className="mx-auto max-w-7xl">
+        <Breadcrumbs items={[
+          { label: 'Admin Dashboard', href: '/admin' },
+          { label: 'Agent Operations', href: '/admin/agents' },
+          { label: 'Swarm Board' },
+        ]} />
+
+        <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <div className="mb-2 inline-flex items-center gap-2 text-sm text-radiant-gold">
+              <Columns size={16} />
+              ATAS AI Agent Org
+            </div>
+            <h1 className="text-3xl font-bold">Client Swarm Board</h1>
+            <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+              Cross-client board for policy-bounded handoffs, swarm health, approval gates, and provisioning readiness.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Link
+              href="/admin/agents"
+              className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 bg-silicon-slate/30 px-3 py-2 text-sm hover:border-radiant-gold/60"
+            >
+              <Bot size={16} />
+              Mission Control
+            </Link>
+            <button
+              onClick={fetchBoard}
+              disabled={loading}
+              className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/50 bg-radiant-gold/10 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15 disabled:opacity-60"
+            >
+              <RefreshCw size={16} className={loading ? 'animate-spin' : ''} />
+              Refresh
+            </button>
+          </div>
+        </div>
+
+        {loading ? (
+          <div className="py-16 text-center text-muted-foreground">Loading client swarm board...</div>
+        ) : error ? (
+          <FailureState message={error} />
+        ) : snapshot ? (
+          <>
+            <div className="mb-6 grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-6">
+              <MetricCard label="Clients" value={snapshot.summary.clients} />
+              <MetricCard label="Active" value={snapshot.summary.active} />
+              <MetricCard label="Failed/stale" value={snapshot.summary.failed_or_stale} tone={snapshot.summary.failed_or_stale ? 'red' : 'slate'} />
+              <MetricCard label="Approvals" value={snapshot.summary.pending_approvals} tone={snapshot.summary.pending_approvals ? 'yellow' : 'slate'} />
+              <MetricCard label="Isolation failures" value={snapshot.summary.isolation_failures} tone={snapshot.summary.isolation_failures ? 'red' : 'slate'} />
+              <MetricCard label="Autonomous-ready" value={snapshot.summary.autonomous_ready} tone="green" />
+            </div>
+
+            <section className="mb-6 rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                <div>
+                  <h2 className="font-semibold">Handoff Boundary</h2>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    Read-only, planning, QA, and reporting handoffs can move autonomously. Provider writes, credentials, sends, publishing, production config, and client-data mutation wait for approval.
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {FILTERS.map((item) => (
+                    <button
+                      key={item.key}
+                      onClick={() => setFilter(item.key)}
+                      className={`rounded-lg border px-3 py-2 text-sm ${
+                        filter === item.key
+                          ? 'border-radiant-gold/60 bg-radiant-gold/15 text-radiant-gold'
+                          : 'border-silicon-slate/70 bg-silicon-slate/20 text-muted-foreground hover:text-foreground'
+                      }`}
+                    >
+                      {item.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </section>
+
+            <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+              {filteredColumns.map((column) => (
+                <section
+                  key={column.key}
+                  className={`rounded-lg border bg-silicon-slate/15 p-4 ${COLUMN_TONES[column.key]}`}
+                >
+                  <div className="mb-4 flex items-start justify-between gap-3">
+                    <div>
+                      <h2 className="font-semibold">{column.label}</h2>
+                      <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{column.description}</p>
+                    </div>
+                    <span className="rounded-full border border-silicon-slate/70 px-2 py-1 text-xs text-muted-foreground">
+                      {column.cards.length}
+                    </span>
+                  </div>
+
+                  <div className="space-y-3">
+                    {column.cards.length ? (
+                      column.cards.map((card) => <SwarmCard key={card.id} card={card} />)
+                    ) : (
+                      <p className="rounded-lg border border-dashed border-silicon-slate/60 px-3 py-6 text-center text-sm text-muted-foreground">
+                        No client swarms in this column.
+                      </p>
+                    )}
+                  </div>
+                </section>
+              ))}
+            </div>
+          </>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function cardMatchesFilter(card: SwarmBoardCard, filter: Filter) {
+  if (filter === 'attention') return card.moduleHealth === 'red' || card.failedOrStaleRuns > 0
+  if (filter === 'approval') return card.approvalState !== 'none'
+  if (filter === 'autonomous') return card.approvalState === 'none' && card.moduleHealth !== 'red'
+  return true
+}
+
+function SwarmCard({ card }: { card: SwarmBoardCard }) {
+  const HealthIcon = card.moduleHealth === 'red' ? AlertTriangle : card.approvalState !== 'none' ? LockKeyhole : CheckCircle2
+  return (
+    <article className="rounded-lg border border-silicon-slate/70 bg-background/70 p-4">
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="truncate font-semibold">{card.projectName}</h3>
+          <p className="mt-1 text-xs text-muted-foreground">{card.clientName}</p>
+        </div>
+        <span className={`rounded-full px-2 py-1 text-xs ${priorityClass(card.priority)}`}>
+          {card.priority}
+        </span>
+      </div>
+
+      <div className="mb-3 flex flex-wrap gap-2 text-xs">
+        <Badge label={card.currentAgentLabel} />
+        <Badge label={card.statusLabel} />
+        <Badge label={`isolation: ${card.isolationStatus.replace(/_/g, ' ')}`} />
+      </div>
+
+      <div className="mb-3 flex items-start gap-2 rounded-lg border border-silicon-slate/60 bg-silicon-slate/15 p-3">
+        <HealthIcon size={16} className={healthIconClass(card)} />
+        <div>
+          <p className="text-sm font-medium">{card.nextAction}</p>
+          <p className="mt-1 text-xs text-muted-foreground">{card.riskLabel}</p>
+        </div>
+      </div>
+
+      <div className="mb-4 grid grid-cols-3 gap-2 text-center text-xs">
+        <MiniMetric label="Active" value={card.activeRuns} />
+        <MiniMetric label="Failed" value={card.failedOrStaleRuns} />
+        <MiniMetric label="Approvals" value={card.pendingApprovals} />
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-2 text-xs">
+        <span className="text-muted-foreground">
+          {card.latestRunStatus ? `Latest run: ${card.latestRunStatus}` : 'No traced run yet'}
+        </span>
+        <Link href={card.latestRunId ? `/admin/agents/runs/${card.latestRunId}` : card.href} className="inline-flex items-center gap-1 text-radiant-gold hover:underline">
+          {card.latestRunId ? 'Open trace' : 'Open project'}
+          <ArrowRight size={14} />
+        </Link>
+      </div>
+    </article>
+  )
+}
+
+function MetricCard({ label, value, tone = 'slate' }: { label: string; value: number; tone?: 'slate' | 'green' | 'yellow' | 'red' }) {
+  const toneClass = {
+    slate: 'border-silicon-slate/70 bg-silicon-slate/20 text-foreground',
+    green: 'border-green-500/30 bg-green-500/10 text-green-300',
+    yellow: 'border-yellow-500/30 bg-yellow-500/10 text-yellow-300',
+    red: 'border-red-500/30 bg-red-500/10 text-red-300',
+  }[tone]
+  return (
+    <div className={`rounded-lg border p-4 ${toneClass}`}>
+      <p className="text-2xl font-semibold tabular-nums">{value}</p>
+      <p className="mt-1 text-xs text-muted-foreground">{label}</p>
+    </div>
+  )
+}
+
+function MiniMetric({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-lg border border-silicon-slate/60 bg-silicon-slate/15 px-2 py-2">
+      <p className="font-semibold tabular-nums">{value}</p>
+      <p className="mt-1 text-muted-foreground">{label}</p>
+    </div>
+  )
+}
+
+function Badge({ label }: { label: string }) {
+  return (
+    <span className="rounded-full border border-silicon-slate/70 bg-silicon-slate/20 px-2 py-1 text-muted-foreground">
+      {label}
+    </span>
+  )
+}
+
+function FailureState({ message }: { message: string }) {
+  return (
+    <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-6 text-red-200">
+      <div className="mb-2 flex items-center gap-2 font-semibold">
+        <AlertTriangle size={18} />
+        Failed to load Client Swarm Board
+      </div>
+      <p className="text-sm text-red-100/80">{message}</p>
+    </div>
+  )
+}
+
+function priorityClass(priority: SwarmBoardCard['priority']) {
+  if (priority === 'high') return 'bg-red-500/15 text-red-300 border border-red-500/30'
+  if (priority === 'medium') return 'bg-yellow-500/15 text-yellow-300 border border-yellow-500/30'
+  return 'bg-green-500/15 text-green-300 border border-green-500/30'
+}
+
+function healthIconClass(card: SwarmBoardCard) {
+  if (card.moduleHealth === 'red') return 'mt-0.5 text-red-300'
+  if (card.approvalState !== 'none') return 'mt-0.5 text-yellow-300'
+  return 'mt-0.5 text-green-300'
+}

--- a/app/admin/agents/swarm-board/page.tsx
+++ b/app/admin/agents/swarm-board/page.tsx
@@ -244,6 +244,23 @@ function SwarmCard({ card }: { card: SwarmBoardCard }) {
         <MiniMetric label="Approvals" value={card.pendingApprovals} />
       </div>
 
+      <div className="mb-4 rounded-lg border border-silicon-slate/60 bg-silicon-slate/15 p-3">
+        <div className="mb-2 flex items-start justify-between gap-3">
+          <div>
+            <p className="text-sm font-medium">Connector readiness</p>
+            <p className="mt-1 text-xs text-muted-foreground">{card.connectorSummary}</p>
+          </div>
+          <span className="rounded-full border border-silicon-slate/70 px-2 py-1 text-xs text-muted-foreground">
+            {card.readyConnectorCount}/{card.requiredConnectorCount}
+          </span>
+        </div>
+        <div className="mb-2 grid grid-cols-2 gap-2 text-center text-xs">
+          <MiniMetric label="Approval blocked" value={card.approvalBlockedConnectorCount} />
+          <MiniMetric label="Critical gaps" value={card.missingCriticalConnectorCount} />
+        </div>
+        <p className="text-xs text-muted-foreground">{card.connectorNextAction}</p>
+      </div>
+
       <div className="flex flex-wrap items-center justify-between gap-2 text-xs">
         <span className="text-muted-foreground">
           {card.latestRunStatus ? `Latest run: ${card.latestRunStatus}` : 'No traced run yet'}

--- a/app/api/admin/agents/swarm-board/route.test.ts
+++ b/app/api/admin/agents/swarm-board/route.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  buildAgentSwarmBoardSnapshot: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-swarm-board', () => ({
+  buildAgentSwarmBoardSnapshot: mocks.buildAgentSwarmBoardSnapshot,
+}))
+
+import { GET } from './route'
+
+function request() {
+  return new Request('http://localhost/api/admin/agents/swarm-board', {
+    headers: { authorization: 'Bearer token' },
+  })
+}
+
+describe('GET /api/admin/agents/swarm-board', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.buildAgentSwarmBoardSnapshot.mockResolvedValue({
+      generated_at: '2026-05-05T12:00:00.000Z',
+      summary: {
+        clients: 1,
+        active: 1,
+        failed_or_stale: 0,
+        pending_approvals: 0,
+        isolation_failures: 0,
+        autonomous_ready: 1,
+      },
+      columns: [
+        {
+          key: 'decision_packet',
+          label: 'Decision Packet',
+          description: 'LLM, RAG, auth, automation, and cost decisions.',
+          cards: [
+            {
+              id: 'client-swarm:project-1',
+              clientProjectId: 'project-1',
+              clientName: 'Acme',
+              projectName: 'Acme agent shell',
+              column: 'decision_packet',
+              priority: 'medium',
+              currentAgentKey: 'technology-evaluator',
+              currentAgentLabel: 'Technology Evaluator',
+              nextAction: 'Prepare LLM, RAG, and auth decision packet',
+              statusLabel: 'active',
+              riskLabel: 'read-only handoff safe',
+              approvalState: 'none',
+              isolationStatus: 'not_started',
+              moduleHealth: 'green',
+              latestRunId: null,
+              latestRunStatus: null,
+              failedOrStaleRuns: 0,
+              pendingApprovals: 0,
+              activeRuns: 0,
+              roadmapStatus: 'active',
+              dueDate: null,
+              href: '/admin/client-projects/project-1',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await GET(request() as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.buildAgentSwarmBoardSnapshot).not.toHaveBeenCalled()
+  })
+
+  it('returns the derived swarm board snapshot', async () => {
+    const response = await GET(request() as never)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.ok).toBe(true)
+    expect(body.summary).toMatchObject({
+      clients: 1,
+      autonomous_ready: 1,
+    })
+    expect(body.columns[0].cards[0]).toMatchObject({
+      clientProjectId: 'project-1',
+      currentAgentKey: 'technology-evaluator',
+    })
+  })
+
+  it('returns a server error when snapshot generation fails', async () => {
+    mocks.buildAgentSwarmBoardSnapshot.mockRejectedValue(new Error('Database not available'))
+
+    const response = await GET(request() as never)
+
+    expect(response.status).toBe(500)
+    expect(await response.json()).toEqual({ error: 'Database not available' })
+  })
+})

--- a/app/api/admin/agents/swarm-board/route.ts
+++ b/app/api/admin/agents/swarm-board/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { buildAgentSwarmBoardSnapshot } from '@/lib/agent-swarm-board'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * GET /api/admin/agents/swarm-board
+ *
+ * Derived cross-client board for ATAS Agent Org handoffs. V1 reads existing
+ * Agent Ops, approval, and Client AI Ops roadmap tables; it does not create a
+ * new queue table or mutate client/provider state.
+ */
+export async function GET(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  try {
+    const snapshot = await buildAgentSwarmBoardSnapshot()
+    return NextResponse.json({ ok: true, ...snapshot })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to build agent swarm board'
+    console.error('[agent-swarm-board] snapshot failed:', error)
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/lib/admin-nav.ts
+++ b/lib/admin-nav.ts
@@ -67,6 +67,7 @@ export const ADMIN_NAV: { dashboard: AdminNavItem; categories: AdminNavCategory[
         { label: 'Cost & Revenue', href: '/admin/cost-revenue' },
         { label: 'Subscription Watch', href: '/admin/subscriptions' },
         { label: 'Agent Operations', href: '/admin/agents' },
+        { label: 'Client Swarm Board', href: '/admin/agents/swarm-board' },
         { label: 'Automation Context', href: '/admin/agents/automations' },
         { label: 'Technology Bakeoffs', href: '/admin/technology-bakeoffs' },
         { label: 'Source Protocol', href: '/admin/source-protocol' },

--- a/lib/agent-swarm-board.test.ts
+++ b/lib/agent-swarm-board.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/supabase', () => ({ supabaseAdmin: null }))
+
+import {
+  buildAgentSwarmBoardSnapshotFromRows,
+  evaluateSwarmHandoffPolicy,
+} from './agent-swarm-board'
+
+const project = {
+  id: 'project-1',
+  project_name: 'Acme agent shell',
+  client_name: 'Acme',
+  project_status: 'active',
+  estimated_end_date: '2026-06-01',
+  created_at: '2026-05-05T12:00:00.000Z',
+}
+
+const roadmap = {
+  id: 'roadmap-1',
+  client_project_id: 'project-1',
+  title: 'Acme AI Ops Roadmap',
+  status: 'active',
+  snapshot: {},
+  updated_at: '2026-05-05T12:00:00.000Z',
+}
+
+describe('evaluateSwarmHandoffPolicy', () => {
+  it('allows read-only planning handoffs to proceed autonomously', () => {
+    expect(
+      evaluateSwarmHandoffPolicy({
+        stage: 'technology_decision',
+        requestedActions: ['read_files'],
+        riskLevel: 'medium',
+      }),
+    ).toMatchObject({
+      autonomousAllowed: true,
+      requiresApproval: false,
+      nextColumn: 'decision_packet',
+    })
+  })
+
+  it('routes side-effecting handoffs to approval', () => {
+    expect(
+      evaluateSwarmHandoffPolicy({
+        stage: 'provisioning_plan',
+        requestedActions: ['production_config_change', 'send_email'],
+        riskLevel: 'medium',
+      }),
+    ).toMatchObject({
+      autonomousAllowed: false,
+      requiresApproval: true,
+      approvalActions: ['production_config_change', 'send_email'],
+      nextColumn: 'waiting_approval',
+    })
+  })
+
+  it('blocks high-risk handoffs even when the requested action is read-only', () => {
+    expect(
+      evaluateSwarmHandoffPolicy({
+        stage: 'qa_isolation',
+        requestedActions: ['read_files'],
+        riskLevel: 'high',
+      }),
+    ).toMatchObject({
+      autonomousAllowed: false,
+      requiresApproval: true,
+      nextColumn: 'waiting_approval',
+    })
+  })
+})
+
+describe('buildAgentSwarmBoardSnapshotFromRows', () => {
+  it('places fake-client discovery to technology decision work in the decision packet column', () => {
+    const snapshot = buildAgentSwarmBoardSnapshotFromRows({
+      projects: [project],
+      roadmaps: [roadmap],
+      tasks: [
+        {
+          id: 'task-1',
+          roadmap_id: 'roadmap-1',
+          task_key: 'technology-decision-packet',
+          title: 'Prepare LLM, RAG, and auth decision packet',
+          status: 'pending',
+          priority: 'high',
+          owner_type: 'amadutown',
+          due_date: null,
+          metadata: {},
+        },
+      ],
+      reports: [],
+      runs: [
+        {
+          id: 'run-1',
+          agent_key: 'research-source-register',
+          runtime: 'codex',
+          kind: 'agent_engagement_request',
+          title: 'Discover client stack',
+          status: 'completed',
+          subject_type: 'client_project',
+          subject_id: 'project-1',
+          subject_label: 'Acme agent shell',
+          current_step: 'Discovery complete',
+          error_message: null,
+          started_at: '2026-05-05T12:00:00.000Z',
+          completed_at: '2026-05-05T12:02:00.000Z',
+          metadata: { client_project_id: 'project-1' },
+        },
+      ],
+      approvals: [],
+    })
+
+    const column = snapshot.columns.find((item) => item.key === 'decision_packet')
+    expect(column?.cards).toHaveLength(1)
+    expect(column?.cards[0]).toMatchObject({
+      clientProjectId: 'project-1',
+      currentAgentKey: 'technology-evaluator',
+      nextAction: 'Prepare LLM, RAG, and auth decision packet',
+      approvalState: 'none',
+      moduleHealth: 'green',
+    })
+    expect(snapshot.summary.autonomous_ready).toBe(1)
+  })
+
+  it('routes pending approvals to Waiting Approval regardless of open planning tasks', () => {
+    const snapshot = buildAgentSwarmBoardSnapshotFromRows({
+      projects: [project],
+      roadmaps: [roadmap],
+      tasks: [
+        {
+          id: 'task-1',
+          roadmap_id: 'roadmap-1',
+          task_key: 'repo-provisioning',
+          title: 'Prepare repo provisioning packet',
+          status: 'pending',
+          priority: 'medium',
+          owner_type: 'amadutown',
+          due_date: null,
+          metadata: {},
+        },
+      ],
+      reports: [],
+      runs: [
+        {
+          id: 'run-approval',
+          agent_key: 'automation-systems',
+          runtime: 'codex',
+          kind: 'agent_handoff',
+          title: 'Sync client credentials',
+          status: 'waiting_for_approval',
+          subject_type: 'client_project',
+          subject_id: 'project-1',
+          subject_label: 'Acme agent shell',
+          current_step: 'Approval needed',
+          error_message: null,
+          started_at: '2026-05-05T12:00:00.000Z',
+          completed_at: null,
+          metadata: { client_project_id: 'project-1' },
+        },
+      ],
+      approvals: [
+        {
+          id: 'approval-1',
+          run_id: 'run-approval',
+          approval_type: 'production_config_change',
+          status: 'pending',
+          requested_at: '2026-05-05T12:01:00.000Z',
+        },
+      ],
+    })
+
+    const waiting = snapshot.columns.find((item) => item.key === 'waiting_approval')
+    expect(waiting?.cards[0]).toMatchObject({
+      approvalState: 'pending',
+      pendingApprovals: 1,
+      priority: 'high',
+      currentAgentKey: 'approval-steward',
+    })
+    expect(snapshot.summary.pending_approvals).toBe(1)
+  })
+
+  it('routes failed or stale client swarm runs to blocked and escalated', () => {
+    const snapshot = buildAgentSwarmBoardSnapshotFromRows({
+      projects: [project],
+      roadmaps: [roadmap],
+      tasks: [],
+      reports: [],
+      runs: [
+        {
+          id: 'run-failed',
+          agent_key: 'engineering-copilot',
+          runtime: 'codex',
+          kind: 'agent_handoff',
+          title: 'Run isolation scan',
+          status: 'failed',
+          subject_type: 'client_project',
+          subject_id: 'project-1',
+          subject_label: 'Acme agent shell',
+          current_step: 'Isolation scan failed',
+          error_message: 'Portfolio env value detected',
+          started_at: '2026-05-05T12:00:00.000Z',
+          completed_at: null,
+          metadata: {},
+        },
+      ],
+      approvals: [],
+    })
+
+    const blocked = snapshot.columns.find((item) => item.key === 'blocked_escalated')
+    expect(blocked?.cards[0]).toMatchObject({
+      failedOrStaleRuns: 1,
+      moduleHealth: 'red',
+      currentAgentKey: 'chief-of-staff',
+    })
+    expect(snapshot.summary.failed_or_stale).toBe(1)
+  })
+})

--- a/lib/agent-swarm-board.test.ts
+++ b/lib/agent-swarm-board.test.ts
@@ -11,6 +11,8 @@ const project = {
   id: 'project-1',
   project_name: 'Acme agent shell',
   client_name: 'Acme',
+  client_email: 'ops@acme.test',
+  contact_submission_id: 101,
   project_status: 'active',
   estimated_end_date: '2026-06-01',
   created_at: '2026-05-05T12:00:00.000Z',
@@ -213,5 +215,71 @@ describe('buildAgentSwarmBoardSnapshotFromRows', () => {
       currentAgentKey: 'chief-of-staff',
     })
     expect(snapshot.summary.failed_or_stale).toBe(1)
+  })
+
+  it('adds audit-driven connector readiness to client swarm cards without side effects', () => {
+    const snapshot = buildAgentSwarmBoardSnapshotFromRows({
+      projects: [project],
+      roadmaps: [roadmap],
+      tasks: [
+        {
+          id: 'task-1',
+          roadmap_id: 'roadmap-1',
+          task_key: 'connector-provisioning-plan',
+          title: 'Prepare connector provisioning packet',
+          status: 'pending',
+          priority: 'medium',
+          owner_type: 'amadutown',
+          due_date: null,
+          metadata: {},
+        },
+      ],
+      reports: [],
+      runs: [],
+      approvals: [],
+      contacts: [
+        {
+          id: 101,
+          email: 'ops@acme.test',
+          website_tech_stack: { technologies: [{ name: 'WordPress' }] },
+          client_verified_tech_stack: null,
+        },
+      ],
+      audits: [
+        {
+          id: 'audit-1',
+          contact_submission_id: 101,
+          contact_email: 'ops@acme.test',
+          audit_type: 'standalone',
+          tech_stack: {
+            crm: 'hubspot',
+            email: 'gmail',
+            other_tools: ['Slack'],
+            website_technologies: ['Webflow'],
+          },
+          automation_needs: { priority_areas: ['lead_follow_up'] },
+          ai_readiness: { data_quality: 'integrated' },
+          budget_timeline: { budget_range: 'medium' },
+          decision_making: { decision_maker: true, approval_process: 'solo' },
+          enriched_tech_stack: { technologies: [{ name: 'Pinecone' }] },
+        },
+      ],
+    })
+
+    const card = snapshot.columns.flatMap((column) => column.cards)[0]
+    expect(card).toMatchObject({
+      requiredConnectorCount: expect.any(Number),
+      readyConnectorCount: 0,
+      approvalBlockedConnectorCount: 0,
+    })
+    expect(card.requiredConnectorCount).toBeGreaterThanOrEqual(5)
+    expect(card.connectorReadiness.items.map((item) => item.key)).toEqual(expect.arrayContaining([
+      'webflow',
+      'hubspot',
+      'google_workspace',
+      'slack',
+      'pinecone',
+    ]))
+    expect(card.connectorNextAction).toContain('setup packet')
   })
 })

--- a/lib/agent-swarm-board.ts
+++ b/lib/agent-swarm-board.ts
@@ -1,4 +1,9 @@
 import { actionRequiresApproval, type AgentAction } from '@/lib/agent-policy'
+import {
+  buildClientConnectorReadiness,
+  type ClientConnectorAuditSignal,
+  type ClientConnectorReadiness,
+} from '@/lib/client-connector-readiness'
 import { supabaseAdmin } from '@/lib/supabase'
 
 type JsonRecord = Record<string, unknown>
@@ -55,6 +60,13 @@ export type SwarmBoardCard = {
   activeRuns: number
   roadmapStatus: string | null
   dueDate: string | null
+  connectorReadiness: ClientConnectorReadiness
+  connectorSummary: string
+  requiredConnectorCount: number
+  readyConnectorCount: number
+  approvalBlockedConnectorCount: number
+  missingCriticalConnectorCount: number
+  connectorNextAction: string
   href: string
 }
 
@@ -83,6 +95,8 @@ type ClientProjectRow = {
   project_name: string
   client_name: string
   project_status: string
+  client_email?: string | null
+  contact_submission_id?: number | string | null
   estimated_end_date: string | null
   created_at: string | null
 }
@@ -141,6 +155,22 @@ type ApprovalRow = {
   requested_at: string
 }
 
+type ContactSubmissionRow = {
+  id: number
+  email: string | null
+  website_tech_stack: JsonRecord | null
+  client_verified_tech_stack: JsonRecord | null
+}
+
+type DiagnosticAuditRow = ClientConnectorAuditSignal & {
+  id: string | number
+  contact_submission_id: number | null
+  contact_email: string | null
+  completed_at?: string | null
+  updated_at?: string | null
+  created_at?: string | null
+}
+
 type SwarmBoardBuildInput = {
   projects: ClientProjectRow[]
   roadmaps: RoadmapRow[]
@@ -148,6 +178,8 @@ type SwarmBoardBuildInput = {
   reports: RoadmapReportRow[]
   runs: AgentRunRow[]
   approvals: ApprovalRow[]
+  contacts?: ContactSubmissionRow[]
+  audits?: DiagnosticAuditRow[]
 }
 
 const COLUMN_DEFINITIONS: Omit<SwarmBoardColumn, 'cards'>[] = [
@@ -367,10 +399,54 @@ export function buildAgentSwarmBoardSnapshotFromRows(input: SwarmBoardBuildInput
     approvalsByRun.set(approval.run_id, [...(approvalsByRun.get(approval.run_id) ?? []), approval])
   }
 
+  const contactsById = new Map<number, ContactSubmissionRow>()
+  const contactsByEmail = new Map<string, ContactSubmissionRow>()
+  for (const contact of input.contacts ?? []) {
+    contactsById.set(contact.id, contact)
+    if (contact.email) contactsByEmail.set(contact.email.toLowerCase(), contact)
+  }
+
+  const auditsByContactId = new Map<number, DiagnosticAuditRow[]>()
+  const auditsByEmail = new Map<string, DiagnosticAuditRow[]>()
+  for (const audit of input.audits ?? []) {
+    if (audit.contact_submission_id) {
+      auditsByContactId.set(audit.contact_submission_id, [...(auditsByContactId.get(audit.contact_submission_id) ?? []), audit])
+    }
+    if (audit.contact_email) {
+      const email = audit.contact_email.toLowerCase()
+      auditsByEmail.set(email, [...(auditsByEmail.get(email) ?? []), audit])
+    }
+  }
+
   const cards = input.projects.map((project): SwarmBoardCard => {
+    const projectContactId = project.contact_submission_id !== null && project.contact_submission_id !== undefined
+      ? Number(project.contact_submission_id)
+      : null
+    const projectEmail = project.client_email?.toLowerCase() ?? null
+    const contact = projectContactId && Number.isFinite(projectContactId)
+      ? contactsById.get(projectContactId)
+      : projectEmail
+        ? contactsByEmail.get(projectEmail)
+        : undefined
     const roadmap = roadmapsByProject.get(project.id) ?? null
     const tasks = roadmap ? tasksByRoadmap.get(roadmap.id) ?? [] : []
     const reports = roadmap ? reportsByRoadmap.get(roadmap.id) ?? [] : []
+    const audits = [
+      ...(projectContactId && Number.isFinite(projectContactId) ? auditsByContactId.get(projectContactId) ?? [] : []),
+      ...(projectEmail ? auditsByEmail.get(projectEmail) ?? [] : []),
+    ].filter((audit, index, rows) => rows.findIndex((item) => String(item.id) === String(audit.id)) === index)
+    const connectorReadiness = buildClientConnectorReadiness({
+      verifiedStack: contact?.client_verified_tech_stack ?? null,
+      auditSignals: audits,
+      builtWithStack: contact?.website_tech_stack ?? null,
+      roadmapSnapshot: roadmap?.snapshot ?? null,
+      roadmapTasks: tasks,
+      projectMetadata: {
+        project_name: project.project_name,
+        client_name: project.client_name,
+        project_status: project.project_status,
+      },
+    })
     const openTasks = tasks
       .filter((task) => !['complete', 'completed', 'cancelled'].includes(task.status))
       .sort((a, b) => {
@@ -416,6 +492,13 @@ export function buildAgentSwarmBoardSnapshotFromRows(input: SwarmBoardBuildInput
       activeRuns: activeRuns.length,
       roadmapStatus: roadmap?.status ?? null,
       dueDate: openTasks.find((task) => task.due_date)?.due_date ?? project.estimated_end_date,
+      connectorReadiness,
+      connectorSummary: connectorReadiness.summary,
+      requiredConnectorCount: connectorReadiness.requiredConnectorCount,
+      readyConnectorCount: connectorReadiness.readyConnectorCount,
+      approvalBlockedConnectorCount: connectorReadiness.approvalBlockedConnectorCount,
+      missingCriticalConnectorCount: connectorReadiness.missingCriticalConnectorCount,
+      connectorNextAction: connectorReadiness.connectorNextAction,
       href: `/admin/client-projects/${project.id}`,
     }
   })
@@ -444,12 +527,55 @@ export async function buildAgentSwarmBoardSnapshot(): Promise<AgentSwarmBoardSna
   if (!supabaseAdmin) throw new Error('Database not available')
   const db = supabaseAdmin
 
-  const [projectsRes, roadmapsRes, tasksRes, reportsRes, runsRes, approvalsRes] = await Promise.all([
-    db
-      .from('client_projects')
-      .select('id, project_name, client_name, project_status, estimated_end_date, created_at')
-      .order('created_at', { ascending: false })
-      .limit(50),
+  const projectsRes = await db
+    .from('client_projects')
+    .select('id, project_name, client_name, client_email, contact_submission_id, project_status, estimated_end_date, created_at')
+    .order('created_at', { ascending: false })
+    .limit(50)
+
+  if (projectsRes.error) throw new Error(projectsRes.error.message)
+
+  const projects = (projectsRes.data ?? []) as ClientProjectRow[]
+  const contactIds = [...new Set(projects
+    .map((project) => project.contact_submission_id)
+    .filter((id): id is number | string => id !== null && id !== undefined)
+    .map(Number)
+    .filter((id) => Number.isFinite(id)))]
+  const clientEmails = [...new Set(projects
+    .map((project) => project.client_email?.trim().toLowerCase())
+    .filter((email): email is string => Boolean(email)))]
+
+  const [contactsByIdRes, contactsByEmailRes, auditsByContactRes, auditsByEmailRes, roadmapsRes, tasksRes, reportsRes, runsRes, approvalsRes] = await Promise.all([
+    contactIds.length
+      ? db
+          .from('contact_submissions')
+          .select('id, email, website_tech_stack, client_verified_tech_stack')
+          .in('id', contactIds)
+      : Promise.resolve({ data: [], error: null }),
+    clientEmails.length
+      ? db
+          .from('contact_submissions')
+          .select('id, email, website_tech_stack, client_verified_tech_stack')
+          .in('email', clientEmails)
+      : Promise.resolve({ data: [], error: null }),
+    contactIds.length
+      ? db
+          .from('diagnostic_audits')
+          .select('id, contact_submission_id, contact_email, audit_type, tech_stack, automation_needs, ai_readiness, budget_timeline, decision_making, enriched_tech_stack, completed_at, updated_at, created_at')
+          .in('contact_submission_id', contactIds)
+          .order('completed_at', { ascending: false, nullsFirst: false })
+          .order('updated_at', { ascending: false })
+          .limit(100)
+      : Promise.resolve({ data: [], error: null }),
+    clientEmails.length
+      ? db
+          .from('diagnostic_audits')
+          .select('id, contact_submission_id, contact_email, audit_type, tech_stack, automation_needs, ai_readiness, budget_timeline, decision_making, enriched_tech_stack, completed_at, updated_at, created_at')
+          .in('contact_email', clientEmails)
+          .order('completed_at', { ascending: false, nullsFirst: false })
+          .order('updated_at', { ascending: false })
+          .limit(100)
+      : Promise.resolve({ data: [], error: null }),
     db
       .from('client_ai_ops_roadmaps')
       .select('id, client_project_id, title, status, snapshot, updated_at')
@@ -479,16 +605,23 @@ export async function buildAgentSwarmBoardSnapshot(): Promise<AgentSwarmBoardSna
       .limit(75),
   ])
 
-  for (const result of [projectsRes, roadmapsRes, tasksRes, reportsRes, runsRes, approvalsRes]) {
+  for (const result of [contactsByIdRes, contactsByEmailRes, auditsByContactRes, auditsByEmailRes, roadmapsRes, tasksRes, reportsRes, runsRes, approvalsRes]) {
     if (result.error) throw new Error(result.error.message)
   }
 
+  const contacts = [...((contactsByIdRes.data ?? []) as ContactSubmissionRow[]), ...((contactsByEmailRes.data ?? []) as ContactSubmissionRow[])]
+    .filter((contact, index, rows) => rows.findIndex((item) => item.id === contact.id) === index)
+  const audits = [...((auditsByContactRes.data ?? []) as DiagnosticAuditRow[]), ...((auditsByEmailRes.data ?? []) as DiagnosticAuditRow[])]
+    .filter((audit, index, rows) => rows.findIndex((item) => String(item.id) === String(audit.id)) === index)
+
   return buildAgentSwarmBoardSnapshotFromRows({
-    projects: (projectsRes.data ?? []) as ClientProjectRow[],
+    projects,
     roadmaps: (roadmapsRes.data ?? []) as RoadmapRow[],
     tasks: (tasksRes.data ?? []) as RoadmapTaskRow[],
     reports: (reportsRes.data ?? []) as RoadmapReportRow[],
     runs: (runsRes.data ?? []) as AgentRunRow[],
     approvals: (approvalsRes.data ?? []) as ApprovalRow[],
+    contacts,
+    audits,
   })
 }

--- a/lib/agent-swarm-board.ts
+++ b/lib/agent-swarm-board.ts
@@ -1,0 +1,494 @@
+import { actionRequiresApproval, type AgentAction } from '@/lib/agent-policy'
+import { supabaseAdmin } from '@/lib/supabase'
+
+type JsonRecord = Record<string, unknown>
+
+export type SwarmBoardColumnKey =
+  | 'intake'
+  | 'discovery'
+  | 'decision_packet'
+  | 'provisioning_plan'
+  | 'build_configure'
+  | 'qa_isolation'
+  | 'waiting_approval'
+  | 'active_monitoring'
+  | 'blocked_escalated'
+  | 'done_archived'
+
+export type SwarmBoardPriority = 'high' | 'medium' | 'low'
+
+export type SwarmHandoffStage =
+  | 'discovery'
+  | 'technology_decision'
+  | 'provisioning_plan'
+  | 'build_configure'
+  | 'qa_isolation'
+  | 'reporting'
+
+export type SwarmHandoffPolicyDecision = {
+  autonomousAllowed: boolean
+  requiresApproval: boolean
+  approvalActions: AgentAction[]
+  reason: string
+  nextColumn: SwarmBoardColumnKey
+}
+
+export type SwarmBoardCard = {
+  id: string
+  clientProjectId: string
+  clientName: string
+  projectName: string
+  column: SwarmBoardColumnKey
+  priority: SwarmBoardPriority
+  currentAgentKey: string
+  currentAgentLabel: string
+  nextAction: string
+  statusLabel: string
+  riskLabel: string
+  approvalState: 'none' | 'pending' | 'required'
+  isolationStatus: 'not_started' | 'pending' | 'passed' | 'failed'
+  moduleHealth: 'green' | 'yellow' | 'red'
+  latestRunId: string | null
+  latestRunStatus: string | null
+  failedOrStaleRuns: number
+  pendingApprovals: number
+  activeRuns: number
+  roadmapStatus: string | null
+  dueDate: string | null
+  href: string
+}
+
+export type SwarmBoardColumn = {
+  key: SwarmBoardColumnKey
+  label: string
+  description: string
+  cards: SwarmBoardCard[]
+}
+
+export type AgentSwarmBoardSnapshot = {
+  generated_at: string
+  summary: {
+    clients: number
+    active: number
+    failed_or_stale: number
+    pending_approvals: number
+    isolation_failures: number
+    autonomous_ready: number
+  }
+  columns: SwarmBoardColumn[]
+}
+
+type ClientProjectRow = {
+  id: string
+  project_name: string
+  client_name: string
+  project_status: string
+  estimated_end_date: string | null
+  created_at: string | null
+}
+
+type RoadmapRow = {
+  id: string
+  client_project_id: string
+  title: string
+  status: string
+  snapshot: JsonRecord | null
+  updated_at: string | null
+}
+
+type RoadmapTaskRow = {
+  id: string
+  roadmap_id: string
+  task_key: string
+  title: string
+  status: string
+  priority: SwarmBoardPriority | string
+  owner_type: string
+  due_date: string | null
+  metadata: JsonRecord | null
+}
+
+type RoadmapReportRow = {
+  roadmap_id: string
+  report_type: string
+  status: string
+  generated_at: string | null
+  monitoring_summary: JsonRecord | null
+}
+
+type AgentRunRow = {
+  id: string
+  agent_key: string | null
+  runtime: string
+  kind: string
+  title: string
+  status: string
+  subject_type: string | null
+  subject_id: string | null
+  subject_label: string | null
+  current_step: string | null
+  error_message: string | null
+  started_at: string
+  completed_at: string | null
+  metadata: JsonRecord | null
+}
+
+type ApprovalRow = {
+  id: string
+  run_id: string
+  approval_type: string
+  status: string
+  requested_at: string
+}
+
+type SwarmBoardBuildInput = {
+  projects: ClientProjectRow[]
+  roadmaps: RoadmapRow[]
+  tasks: RoadmapTaskRow[]
+  reports: RoadmapReportRow[]
+  runs: AgentRunRow[]
+  approvals: ApprovalRow[]
+}
+
+const COLUMN_DEFINITIONS: Omit<SwarmBoardColumn, 'cards'>[] = [
+  { key: 'intake', label: 'Intake', description: 'New client setup requests and unstarted swarm work.' },
+  { key: 'discovery', label: 'Discovery', description: 'Stack, goals, data, and risk profile collection.' },
+  { key: 'decision_packet', label: 'Decision Packet', description: 'LLM, RAG, auth, automation, and cost decisions.' },
+  { key: 'provisioning_plan', label: 'Provisioning Plan', description: 'Repo, provider, credential, and workflow setup packet.' },
+  { key: 'build_configure', label: 'Build/Configure', description: 'Generated shell, modules, workflow imports, and configs.' },
+  { key: 'qa_isolation', label: 'QA/Isolation', description: 'Build checks, synthetic tests, and isolation scans.' },
+  { key: 'waiting_approval', label: 'Waiting Approval', description: 'Provider writes, credentials, sends, publishing, and deployment gates.' },
+  { key: 'active_monitoring', label: 'Active/Monitoring', description: 'Launched swarms with health checks and reports.' },
+  { key: 'blocked_escalated', label: 'Blocked/Escalated', description: 'Failures, stale handoffs, and human/client decisions.' },
+  { key: 'done_archived', label: 'Done/Archived', description: 'Completed or cancelled client swarm setup.' },
+]
+
+const AUTONOMOUS_STAGE_TO_COLUMN: Record<SwarmHandoffStage, SwarmBoardColumnKey> = {
+  discovery: 'discovery',
+  technology_decision: 'decision_packet',
+  provisioning_plan: 'provisioning_plan',
+  build_configure: 'build_configure',
+  qa_isolation: 'qa_isolation',
+  reporting: 'active_monitoring',
+}
+
+const APPROVAL_ACTIONS = new Set<AgentAction>([
+  'unknown_db_write',
+  'production_config_change',
+  'publish_public_content',
+  'send_email',
+  'public_content_from_private_material',
+  'client_data_access',
+  'known_workflow_db_write',
+])
+
+function stringValue(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function projectIdFromRun(run: AgentRunRow): string | null {
+  if (run.subject_type === 'client_project' && run.subject_id) return run.subject_id
+  return (
+    stringValue(run.metadata?.client_project_id) ??
+    stringValue(run.metadata?.clientProjectId) ??
+    stringValue(run.metadata?.project_id) ??
+    null
+  )
+}
+
+function isolationStatusFromRoadmap(roadmap: RoadmapRow | null, tasks: RoadmapTaskRow[]) {
+  const snapshotStatus = stringValue(roadmap?.snapshot?.isolation_status)
+  if (snapshotStatus === 'passed' || snapshotStatus === 'failed' || snapshotStatus === 'pending') return snapshotStatus
+
+  const isolationTasks = tasks.filter((task) => {
+    const key = task.task_key.toLowerCase()
+    const title = task.title.toLowerCase()
+    return key.includes('isolation') || title.includes('isolation')
+  })
+  if (isolationTasks.some((task) => task.status === 'blocked' || task.status === 'cancelled')) return 'failed'
+  if (isolationTasks.some((task) => task.status === 'complete')) return 'passed'
+  if (isolationTasks.length > 0) return 'pending'
+  return 'not_started'
+}
+
+function columnFromTaskStatus(input: {
+  roadmap: RoadmapRow | null
+  openTasks: RoadmapTaskRow[]
+  failedOrStaleRuns: number
+  pendingApprovals: number
+  isolationStatus: SwarmBoardCard['isolationStatus']
+  projectStatus: string
+}): SwarmBoardColumnKey {
+  if (input.pendingApprovals > 0) return 'waiting_approval'
+  if (input.failedOrStaleRuns > 0 || input.isolationStatus === 'failed') return 'blocked_escalated'
+  if (input.projectStatus === 'completed' || input.roadmap?.status === 'completed') return 'done_archived'
+  if (input.projectStatus === 'cancelled' || input.roadmap?.status === 'cancelled') return 'done_archived'
+  if (input.roadmap?.status === 'active' && input.openTasks.length === 0) return 'active_monitoring'
+
+  const titles = input.openTasks.map((task) => `${task.task_key} ${task.title}`.toLowerCase()).join(' ')
+  if (!input.roadmap) return 'intake'
+  if (titles.includes('isolation') || titles.includes('validation') || titles.includes('qa')) return 'qa_isolation'
+  if (titles.includes('build') || titles.includes('configure') || titles.includes('workflow') || titles.includes('module')) return 'build_configure'
+  if (titles.includes('credential') || titles.includes('repo') || titles.includes('provider') || titles.includes('provision')) return 'provisioning_plan'
+  if (titles.includes('llm') || titles.includes('rag') || titles.includes('auth') || titles.includes('decision') || titles.includes('technology')) return 'decision_packet'
+  if (titles.includes('discovery') || titles.includes('ownership') || titles.includes('data source')) return 'discovery'
+  return 'intake'
+}
+
+function priorityFromSignals(input: {
+  pendingApprovals: number
+  failedOrStaleRuns: number
+  isolationStatus: SwarmBoardCard['isolationStatus']
+  openTasks: RoadmapTaskRow[]
+}): SwarmBoardPriority {
+  if (input.pendingApprovals > 0 || input.failedOrStaleRuns > 0 || input.isolationStatus === 'failed') return 'high'
+  if (input.openTasks.some((task) => task.priority === 'high' || task.status === 'blocked')) return 'medium'
+  return 'low'
+}
+
+function moduleHealth(input: {
+  pendingApprovals: number
+  failedOrStaleRuns: number
+  isolationStatus: SwarmBoardCard['isolationStatus']
+  reports: RoadmapReportRow[]
+}): SwarmBoardCard['moduleHealth'] {
+  if (input.failedOrStaleRuns > 0 || input.isolationStatus === 'failed') return 'red'
+  if (input.pendingApprovals > 0 || input.isolationStatus === 'pending') return 'yellow'
+  if (input.reports.some((report) => {
+    const summary = report.monitoring_summary ?? {}
+    return Number(summary.overdue_tasks ?? 0) > 0 || Boolean(summary.report_missing)
+  })) return 'yellow'
+  return 'green'
+}
+
+function currentAgentForColumn(column: SwarmBoardColumnKey) {
+  switch (column) {
+    case 'discovery':
+      return { key: 'research-source-register', label: 'Research & Source Register Agent' }
+    case 'decision_packet':
+      return { key: 'technology-evaluator', label: 'Technology Evaluator' }
+    case 'provisioning_plan':
+      return { key: 'automation-systems', label: 'Automation Systems Agent' }
+    case 'build_configure':
+      return { key: 'engineering-copilot', label: 'Engineering Copilot Agent' }
+    case 'qa_isolation':
+      return { key: 'engineering-copilot', label: 'QA & Isolation Agent' }
+    case 'waiting_approval':
+      return { key: 'approval-steward', label: 'Approval Steward' }
+    case 'blocked_escalated':
+      return { key: 'chief-of-staff', label: 'Chief of Staff Agent' }
+    case 'active_monitoring':
+      return { key: 'chief-of-staff', label: 'Client Swarm Monitor' }
+    default:
+      return { key: 'chief-of-staff', label: 'Chief of Staff Agent' }
+  }
+}
+
+function nextActionForCard(input: {
+  column: SwarmBoardColumnKey
+  pendingApprovals: number
+  failedOrStaleRuns: number
+  openTasks: RoadmapTaskRow[]
+}) {
+  if (input.pendingApprovals > 0) return 'Review the approval checkpoint before any side effect runs.'
+  if (input.failedOrStaleRuns > 0) return 'Open the latest failed or stale trace and route triage.'
+  const nextTask = input.openTasks[0]
+  if (nextTask) return nextTask.title
+
+  switch (input.column) {
+    case 'active_monitoring':
+      return 'Continue scheduled health monitoring and monthly reporting.'
+    case 'done_archived':
+      return 'Archive the completed swarm package and preserve handoff artifacts.'
+    default:
+      return 'Create the next read-only work packet.'
+  }
+}
+
+export function evaluateSwarmHandoffPolicy(input: {
+  stage: SwarmHandoffStage
+  runtime?: 'codex' | 'n8n' | 'hermes' | 'opencode' | 'manual'
+  requestedActions?: AgentAction[]
+  riskLevel?: 'low' | 'medium' | 'high'
+}): SwarmHandoffPolicyDecision {
+  const runtime = input.runtime ?? 'codex'
+  const requestedActions = input.requestedActions ?? ['read_files']
+  const approvalActions = requestedActions.filter((action) => APPROVAL_ACTIONS.has(action) || actionRequiresApproval(runtime, action))
+  const requiresApproval = approvalActions.length > 0 || input.riskLevel === 'high'
+
+  if (requiresApproval) {
+    return {
+      autonomousAllowed: false,
+      requiresApproval: true,
+      approvalActions,
+      reason: input.riskLevel === 'high'
+        ? 'High-risk handoffs must wait for an approval checkpoint.'
+        : 'Requested actions cross an approval boundary.',
+      nextColumn: 'waiting_approval',
+    }
+  }
+
+  return {
+    autonomousAllowed: true,
+    requiresApproval: false,
+    approvalActions: [],
+    reason: 'Read-only, planning, QA, or reporting handoff may proceed autonomously.',
+    nextColumn: AUTONOMOUS_STAGE_TO_COLUMN[input.stage],
+  }
+}
+
+export function buildAgentSwarmBoardSnapshotFromRows(input: SwarmBoardBuildInput): AgentSwarmBoardSnapshot {
+  const roadmapsByProject = new Map<string, RoadmapRow>()
+  for (const roadmap of input.roadmaps) {
+    if (!roadmapsByProject.has(roadmap.client_project_id)) {
+      roadmapsByProject.set(roadmap.client_project_id, roadmap)
+    }
+  }
+
+  const tasksByRoadmap = new Map<string, RoadmapTaskRow[]>()
+  for (const task of input.tasks) {
+    tasksByRoadmap.set(task.roadmap_id, [...(tasksByRoadmap.get(task.roadmap_id) ?? []), task])
+  }
+
+  const reportsByRoadmap = new Map<string, RoadmapReportRow[]>()
+  for (const report of input.reports) {
+    reportsByRoadmap.set(report.roadmap_id, [...(reportsByRoadmap.get(report.roadmap_id) ?? []), report])
+  }
+
+  const runsByProject = new Map<string, AgentRunRow[]>()
+  for (const run of input.runs) {
+    const projectId = projectIdFromRun(run)
+    if (!projectId) continue
+    runsByProject.set(projectId, [...(runsByProject.get(projectId) ?? []), run])
+  }
+
+  const approvalsByRun = new Map<string, ApprovalRow[]>()
+  for (const approval of input.approvals.filter((item) => item.status === 'pending')) {
+    approvalsByRun.set(approval.run_id, [...(approvalsByRun.get(approval.run_id) ?? []), approval])
+  }
+
+  const cards = input.projects.map((project): SwarmBoardCard => {
+    const roadmap = roadmapsByProject.get(project.id) ?? null
+    const tasks = roadmap ? tasksByRoadmap.get(roadmap.id) ?? [] : []
+    const reports = roadmap ? reportsByRoadmap.get(roadmap.id) ?? [] : []
+    const openTasks = tasks
+      .filter((task) => !['complete', 'completed', 'cancelled'].includes(task.status))
+      .sort((a, b) => {
+        const priorityRank: Record<string, number> = { high: 0, medium: 1, low: 2 }
+        return (priorityRank[a.priority] ?? 1) - (priorityRank[b.priority] ?? 1)
+      })
+    const runs = runsByProject.get(project.id) ?? []
+    const activeRuns = runs.filter((run) => ['queued', 'running', 'waiting_for_approval'].includes(run.status))
+    const failedOrStaleRuns = runs.filter((run) => run.status === 'failed' || run.status === 'stale').length
+    const pendingApprovals = runs.reduce((count, run) => count + (approvalsByRun.get(run.id)?.length ?? 0), 0)
+    const isolationStatus = isolationStatusFromRoadmap(roadmap, tasks)
+    const column = columnFromTaskStatus({
+      roadmap,
+      openTasks,
+      failedOrStaleRuns,
+      pendingApprovals,
+      isolationStatus,
+      projectStatus: project.project_status,
+    })
+    const agent = currentAgentForColumn(column)
+    const latestRun = runs[0] ?? null
+    const health = moduleHealth({ pendingApprovals, failedOrStaleRuns, isolationStatus, reports })
+
+    return {
+      id: `client-swarm:${project.id}`,
+      clientProjectId: project.id,
+      clientName: project.client_name,
+      projectName: project.project_name,
+      column,
+      priority: priorityFromSignals({ pendingApprovals, failedOrStaleRuns, isolationStatus, openTasks }),
+      currentAgentKey: agent.key,
+      currentAgentLabel: agent.label,
+      nextAction: nextActionForCard({ column, pendingApprovals, failedOrStaleRuns, openTasks }),
+      statusLabel: roadmap?.status ?? project.project_status,
+      riskLabel: pendingApprovals > 0 ? 'approval gated' : failedOrStaleRuns > 0 ? 'triage required' : 'read-only handoff safe',
+      approvalState: pendingApprovals > 0 ? 'pending' : column === 'waiting_approval' ? 'required' : 'none',
+      isolationStatus,
+      moduleHealth: health,
+      latestRunId: latestRun?.id ?? null,
+      latestRunStatus: latestRun?.status ?? null,
+      failedOrStaleRuns,
+      pendingApprovals,
+      activeRuns: activeRuns.length,
+      roadmapStatus: roadmap?.status ?? null,
+      dueDate: openTasks.find((task) => task.due_date)?.due_date ?? project.estimated_end_date,
+      href: `/admin/client-projects/${project.id}`,
+    }
+  })
+
+  const columns = COLUMN_DEFINITIONS.map((column) => ({
+    ...column,
+    cards: cards.filter((card) => card.column === column.key),
+  }))
+  const active = cards.filter((card) => !['done_archived'].includes(card.column)).length
+
+  return {
+    generated_at: new Date().toISOString(),
+    summary: {
+      clients: cards.length,
+      active,
+      failed_or_stale: cards.reduce((sum, card) => sum + card.failedOrStaleRuns, 0),
+      pending_approvals: cards.reduce((sum, card) => sum + card.pendingApprovals, 0),
+      isolation_failures: cards.filter((card) => card.isolationStatus === 'failed').length,
+      autonomous_ready: cards.filter((card) => card.approvalState === 'none' && card.moduleHealth !== 'red').length,
+    },
+    columns,
+  }
+}
+
+export async function buildAgentSwarmBoardSnapshot(): Promise<AgentSwarmBoardSnapshot> {
+  if (!supabaseAdmin) throw new Error('Database not available')
+  const db = supabaseAdmin
+
+  const [projectsRes, roadmapsRes, tasksRes, reportsRes, runsRes, approvalsRes] = await Promise.all([
+    db
+      .from('client_projects')
+      .select('id, project_name, client_name, project_status, estimated_end_date, created_at')
+      .order('created_at', { ascending: false })
+      .limit(50),
+    db
+      .from('client_ai_ops_roadmaps')
+      .select('id, client_project_id, title, status, snapshot, updated_at')
+      .not('client_project_id', 'is', null)
+      .order('updated_at', { ascending: false })
+      .limit(75),
+    db
+      .from('client_ai_ops_roadmap_tasks')
+      .select('id, roadmap_id, task_key, title, status, priority, owner_type, due_date, metadata')
+      .order('created_at', { ascending: false })
+      .limit(250),
+    db
+      .from('client_ai_ops_roadmap_reports')
+      .select('roadmap_id, report_type, status, generated_at, monitoring_summary')
+      .order('generated_at', { ascending: false })
+      .limit(100),
+    db
+      .from('agent_runs')
+      .select('id, agent_key, runtime, kind, title, status, subject_type, subject_id, subject_label, current_step, error_message, started_at, completed_at, metadata')
+      .order('started_at', { ascending: false })
+      .limit(150),
+    db
+      .from('agent_approvals')
+      .select('id, run_id, approval_type, status, requested_at')
+      .eq('status', 'pending')
+      .order('requested_at', { ascending: false })
+      .limit(75),
+  ])
+
+  for (const result of [projectsRes, roadmapsRes, tasksRes, reportsRes, runsRes, approvalsRes]) {
+    if (result.error) throw new Error(result.error.message)
+  }
+
+  return buildAgentSwarmBoardSnapshotFromRows({
+    projects: (projectsRes.data ?? []) as ClientProjectRow[],
+    roadmaps: (roadmapsRes.data ?? []) as RoadmapRow[],
+    tasks: (tasksRes.data ?? []) as RoadmapTaskRow[],
+    reports: (reportsRes.data ?? []) as RoadmapReportRow[],
+    runs: (runsRes.data ?? []) as AgentRunRow[],
+    approvals: (approvalsRes.data ?? []) as ApprovalRow[],
+  })
+}

--- a/lib/client-connector-readiness.test.ts
+++ b/lib/client-connector-readiness.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildClientConnectorReadiness } from './client-connector-readiness'
+
+describe('buildClientConnectorReadiness', () => {
+  it('maps audit stack and readiness fields into connector requirements', () => {
+    const readiness = buildClientConnectorReadiness({
+      auditSignals: [
+        {
+          id: 'audit-1',
+          audit_type: 'standalone',
+          tech_stack: {
+            crm: 'hubspot',
+            email: 'gmail',
+            marketing: 'mailchimp',
+            analytics: 'ga',
+            other_tools: ['Slack', 'Notion'],
+            website_technologies: ['Webflow'],
+            integration_readiness: 'some_apis',
+          },
+          automation_needs: { priority_areas: ['lead_follow_up', 'reporting'] },
+          ai_readiness: { data_quality: 'integrated', previous_ai_experience: 'team_tools' },
+          budget_timeline: { budget_range: 'medium' },
+          decision_making: { decision_maker: true, approval_process: 'solo' },
+          enriched_tech_stack: { technologies: [{ name: 'Pinecone' }] },
+        },
+      ],
+    })
+
+    expect(readiness.items.map((item) => item.key)).toEqual(expect.arrayContaining([
+      'webflow',
+      'hubspot',
+      'google_workspace',
+      'mailchimp',
+      'google_analytics',
+      'slack',
+      'notion',
+      'pinecone',
+    ]))
+    expect(readiness.requiredConnectorCount).toBeGreaterThanOrEqual(8)
+    expect(readiness.connectorNextAction).toContain('setup packet')
+  })
+
+  it('uses verified stack ahead of audit and BuiltWith for the same category', () => {
+    const readiness = buildClientConnectorReadiness({
+      verifiedStack: { technologies: [{ name: 'Salesforce' }] },
+      auditSignals: [{ id: 'audit-1', tech_stack: { crm: 'hubspot' } }],
+      builtWithStack: { technologies: [{ name: 'Pipedrive' }] },
+    })
+
+    const crm = readiness.items.find((item) => item.category === 'crm')
+    expect(crm).toMatchObject({
+      key: 'salesforce',
+      source: 'verified',
+    })
+  })
+
+  it('flags same-tier audit conflicts for review', () => {
+    const readiness = buildClientConnectorReadiness({
+      auditSignals: [
+        { id: 'audit-1', tech_stack: { crm: 'hubspot' } },
+        { id: 'audit-2', tech_stack: { crm: 'salesforce' } },
+      ],
+    })
+
+    expect(readiness.conflicts).toEqual([
+      expect.objectContaining({
+        category: 'crm',
+        providers: expect.arrayContaining(['HubSpot', 'Salesforce']),
+      }),
+    ])
+    expect(readiness.items.find((item) => item.category === 'crm')).toMatchObject({
+      status: 'review',
+    })
+  })
+
+  it('routes connector setup through approval when audit decision authority is blocked', () => {
+    const readiness = buildClientConnectorReadiness({
+      auditSignals: [
+        {
+          id: 'audit-1',
+          tech_stack: { crm: 'hubspot', email: 'gmail' },
+          decision_making: { decision_maker: false, approval_process: 'committee' },
+        },
+      ],
+    })
+
+    expect(readiness.approvalBlockedConnectorCount).toBeGreaterThan(0)
+    expect(readiness.items.filter((item) => item.status === 'approval_blocked').map((item) => item.key)).toEqual(
+      expect.arrayContaining(['hubspot', 'google_workspace']),
+    )
+  })
+})

--- a/lib/client-connector-readiness.ts
+++ b/lib/client-connector-readiness.ts
@@ -1,0 +1,394 @@
+import type { AgentAction } from '@/lib/agent-policy'
+
+type JsonRecord = Record<string, unknown>
+
+export type ClientConnectorCategory =
+  | 'website_cms'
+  | 'crm'
+  | 'email_calendar'
+  | 'docs_storage'
+  | 'analytics'
+  | 'automation'
+  | 'payments'
+  | 'social_outreach'
+  | 'support_chat'
+  | 'auth_identity'
+  | 'ai_model'
+  | 'rag_vector'
+  | 'communications'
+
+export type ClientConnectorSource =
+  | 'verified'
+  | 'audit'
+  | 'meeting_audit'
+  | 'builtwith'
+  | 'roadmap'
+  | 'project_metadata'
+  | 'inferred'
+
+export type ClientConnectorStatus = 'ready' | 'needs_auth' | 'missing' | 'review' | 'approval_blocked'
+
+export type ClientConnectorDefinition = {
+  key: string
+  label: string
+  category: ClientConnectorCategory
+  aliases: string[]
+  authMethod: 'oauth' | 'api_key' | 'service_account' | 'webhook' | 'manual' | 'none'
+  setupOwner: 'client' | 'amadutown' | 'shared'
+  requiredScopes: string[]
+  approvalActions: AgentAction[]
+  healthChecks: string[]
+  fallbackPath: string
+  critical: boolean
+}
+
+export type ClientConnectorReadinessItem = {
+  key: string
+  label: string
+  category: ClientConnectorCategory
+  status: ClientConnectorStatus
+  source: ClientConnectorSource
+  authMethod: ClientConnectorDefinition['authMethod']
+  setupOwner: ClientConnectorDefinition['setupOwner']
+  requiredScopes: string[]
+  approvalActions: AgentAction[]
+  healthChecks: string[]
+  fallbackPath: string
+  critical: boolean
+  evidence: string
+  nextAction: string
+}
+
+export type ClientConnectorReadiness = {
+  summary: string
+  requiredConnectorCount: number
+  readyConnectorCount: number
+  approvalBlockedConnectorCount: number
+  missingCriticalConnectorCount: number
+  connectorNextAction: string
+  items: ClientConnectorReadinessItem[]
+  conflicts: Array<{
+    category: ClientConnectorCategory
+    providers: string[]
+    sources: ClientConnectorSource[]
+  }>
+}
+
+export type ClientConnectorAuditSignal = {
+  id?: string | number | null
+  audit_type?: string | null
+  tech_stack?: JsonRecord | null
+  automation_needs?: JsonRecord | null
+  ai_readiness?: JsonRecord | null
+  budget_timeline?: JsonRecord | null
+  decision_making?: JsonRecord | null
+  enriched_tech_stack?: JsonRecord | null
+}
+
+export type BuildClientConnectorReadinessInput = {
+  verifiedStack?: JsonRecord | null
+  auditSignals?: ClientConnectorAuditSignal[]
+  builtWithStack?: JsonRecord | null
+  roadmapSnapshot?: JsonRecord | null
+  roadmapTasks?: Array<{ title?: string | null; task_key?: string | null; metadata?: JsonRecord | null }>
+  projectMetadata?: JsonRecord | null
+}
+
+type ConnectorSignal = {
+  definition: ClientConnectorDefinition
+  source: ClientConnectorSource
+  evidence: string
+  confidence: number
+}
+
+const CATEGORY_LABELS: Record<ClientConnectorCategory, string> = {
+  website_cms: 'Website/CMS',
+  crm: 'CRM',
+  email_calendar: 'Email/calendar',
+  docs_storage: 'Docs/storage',
+  analytics: 'Analytics',
+  automation: 'Automation',
+  payments: 'Payments',
+  social_outreach: 'Social/outreach',
+  support_chat: 'Support/chat',
+  auth_identity: 'Auth/identity',
+  ai_model: 'AI model',
+  rag_vector: 'RAG/vector',
+  communications: 'Communications',
+}
+
+export const CLIENT_CONNECTOR_CATALOG: ClientConnectorDefinition[] = [
+  connector('wordpress', 'WordPress', 'website_cms', ['wordpress', 'wp'], 'api_key', 'shared', ['REST API user/application password', 'Admin or editor access'], ['external_api_call', 'production_config_change'], ['REST API reachable', 'Admin role verified'], 'Use manual export/import or embedded forms until API access is approved.', true),
+  connector('webflow', 'Webflow', 'website_cms', ['webflow'], 'oauth', 'shared', ['Sites read', 'CMS read/write when approved'], ['external_api_call', 'production_config_change'], ['Site token valid', 'CMS collections readable'], 'Use published site scraping and manual CMS updates until OAuth is approved.', true),
+  connector('squarespace', 'Squarespace', 'website_cms', ['squarespace'], 'api_key', 'shared', ['Commerce/content API where available'], ['external_api_call', 'production_config_change'], ['API key valid', 'Site domain verified'], 'Use manual exports and form embeds when API access is limited.', true),
+  connector('shopify', 'Shopify', 'website_cms', ['shopify'], 'oauth', 'shared', ['Storefront read', 'Admin API read/write when approved'], ['external_api_call', 'production_config_change'], ['Storefront API valid', 'Webhook target verified'], 'Use CSV exports and manual product updates until app install is approved.', true),
+  connector('wix', 'Wix', 'website_cms', ['wix'], 'oauth', 'shared', ['Site read', 'CRM/forms read when approved'], ['external_api_call', 'production_config_change'], ['OAuth app authorized', 'Site read succeeds'], 'Use form notification parsing and manual CMS updates until OAuth is approved.', true),
+  connector('nextjs', 'Custom Next.js', 'website_cms', ['next.js', 'nextjs', 'vercel', 'custom next'], 'service_account', 'amadutown', ['Repository access', 'Deployment/project read'], ['external_api_call', 'production_config_change'], ['Repo access verified', 'Preview deploy readable'], 'Use read-only repository review and manual deployment notes.', true),
+
+  connector('hubspot', 'HubSpot', 'crm', ['hubspot', 'hubspot crm', 'hubspot marketing'], 'oauth', 'shared', ['CRM contacts read', 'CRM deals read', 'Marketing/email only when approved'], ['external_api_call', 'client_data_access'], ['OAuth token valid', 'Contact read smoke passes'], 'Use CSV exports and manual pipeline notes until OAuth is approved.', true),
+  connector('salesforce', 'Salesforce', 'crm', ['salesforce', 'salesforce crm'], 'oauth', 'shared', ['Objects read', 'Lead/contact read', 'Write scopes only after approval'], ['external_api_call', 'client_data_access'], ['Connected app authorized', 'SOQL read smoke passes'], 'Use reports export and manual upload while connected app is pending.', true),
+  connector('pipedrive', 'Pipedrive', 'crm', ['pipedrive'], 'api_key', 'shared', ['Deals read', 'Persons read', 'Activities read'], ['external_api_call', 'client_data_access'], ['API token valid', 'Pipeline read succeeds'], 'Use exported deals and activities until token approval.', true),
+  connector('zoho', 'Zoho CRM', 'crm', ['zoho', 'zoho crm'], 'oauth', 'shared', ['Contacts read', 'Deals read'], ['external_api_call', 'client_data_access'], ['OAuth token valid', 'Module read succeeds'], 'Use Zoho exports until OAuth approval.', true),
+  connector('airtable', 'Airtable', 'crm', ['airtable'], 'api_key', 'shared', ['Base read', 'Table read'], ['external_api_call', 'client_data_access'], ['Token valid', 'Base schema readable'], 'Use CSV export until personal access token approval.', false),
+  connector('google_sheets_crm', 'Google Sheets CRM', 'crm', ['google sheets', 'sheets-as-crm', 'spreadsheet crm', 'spreadsheets'], 'oauth', 'shared', ['Sheets read', 'Drive file read'], ['external_api_call', 'client_data_access'], ['Sheet readable', 'Owner verified'], 'Use client-provided CSV snapshots until Google OAuth approval.', false),
+
+  connector('google_workspace', 'Google Workspace', 'email_calendar', ['gmail', 'google workspace', 'google calendar', 'google drive'], 'oauth', 'shared', ['Gmail draft/send only when approved', 'Calendar read', 'Drive read'], ['external_api_call', 'client_data_access', 'send_email'], ['OAuth scopes confirmed', 'Draft-only smoke passes'], 'Use manual draft packets and uploaded files until OAuth approval.', true),
+  connector('microsoft_365', 'Microsoft 365 / Outlook', 'email_calendar', ['outlook', 'microsoft 365', 'office 365', 'teams'], 'oauth', 'shared', ['Mail draft/send only when approved', 'Calendar read', 'Teams read when approved'], ['external_api_call', 'client_data_access', 'send_email'], ['OAuth scopes confirmed', 'Calendar read smoke passes'], 'Use manual draft packets and uploaded files until Microsoft OAuth approval.', true),
+  connector('slack', 'Slack', 'communications', ['slack'], 'oauth', 'shared', ['Channels read', 'Messages write only when approved'], ['external_api_call', 'client_data_access'], ['App installed', 'Channel read succeeds'], 'Use manual status posts until Slack app approval.', false),
+  connector('whatsapp_twilio', 'WhatsApp / Twilio', 'communications', ['whatsapp', 'twilio'], 'api_key', 'shared', ['Messaging service read', 'Send only when approved'], ['external_api_call', 'client_data_access', 'send_email'], ['Webhook verified', 'Template status checked'], 'Use manual WhatsApp Business exports until Twilio approval.', false),
+
+  connector('google_drive', 'Google Drive', 'docs_storage', ['google drive', 'drive'], 'oauth', 'shared', ['Drive read', 'Scoped folder access'], ['external_api_call', 'client_data_access'], ['Folder access verified', 'File list smoke passes'], 'Use uploaded source folder snapshots until Drive OAuth approval.', true),
+  connector('notion', 'Notion', 'docs_storage', ['notion'], 'oauth', 'shared', ['Page read', 'Database read'], ['external_api_call', 'client_data_access'], ['Integration invited', 'Database read succeeds'], 'Use exported Markdown/PDF snapshots until Notion approval.', false),
+
+  connector('google_analytics', 'Google Analytics', 'analytics', ['google analytics', 'ga', 'ga4', 'google analytics 4'], 'oauth', 'shared', ['Analytics read'], ['external_api_call', 'client_data_access'], ['Property access verified', 'Report read succeeds'], 'Use exported traffic reports until OAuth approval.', false),
+  connector('mixpanel', 'Mixpanel', 'analytics', ['mixpanel'], 'api_key', 'shared', ['Project read', 'Export read'], ['external_api_call', 'client_data_access'], ['Token valid', 'Event query succeeds'], 'Use exported cohorts/reports until token approval.', false),
+
+  connector('n8n', 'n8n', 'automation', ['n8n'], 'api_key', 'amadutown', ['Workflow read', 'Execution read'], ['external_api_call', 'production_config_change'], ['Workflow list readable', 'Execution health readable'], 'Use workflow export/import files with manual activation.', true),
+  connector('zapier', 'Zapier', 'automation', ['zapier'], 'oauth', 'shared', ['Zap visibility where available'], ['external_api_call', 'production_config_change'], ['Zap inventory reviewed', 'Owner confirmed'], 'Use screenshots/exported Zap descriptions until access approval.', false),
+  connector('make', 'Make', 'automation', ['make', 'integromat'], 'api_key', 'shared', ['Scenario read', 'Execution read'], ['external_api_call', 'production_config_change'], ['Scenario inventory readable', 'Execution history accessible'], 'Use scenario export and manual setup packet.', false),
+  connector('supabase', 'Supabase', 'automation', ['supabase', 'postgres', 'postgresql'], 'service_account', 'shared', ['Database read', 'Edge/project read'], ['external_api_call', 'client_data_access', 'production_config_change'], ['Project linked', 'Read-only query smoke passes'], 'Use schema snapshots and SQL files until service access approval.', true),
+
+  connector('stripe', 'Stripe', 'payments', ['stripe'], 'api_key', 'shared', ['Restricted read key', 'Webhook read'], ['external_api_call', 'client_data_access', 'production_config_change'], ['Restricted key valid', 'Webhook endpoint verified'], 'Use exported transactions and manual webhook packet.', false),
+  connector('mailchimp', 'Mailchimp', 'social_outreach', ['mailchimp'], 'oauth', 'shared', ['Audience read', 'Campaign draft only when approved'], ['external_api_call', 'client_data_access', 'send_email'], ['Audience read succeeds', 'Draft-only path confirmed'], 'Use exported audience/campaign reports until OAuth approval.', false),
+  connector('meta', 'Meta / Facebook', 'social_outreach', ['meta', 'facebook', 'instagram', 'meta ads'], 'oauth', 'shared', ['Page/ad account read', 'Publishing only when approved'], ['external_api_call', 'client_data_access', 'publish_public_content'], ['Business access verified', 'Account read succeeds'], 'Use exported ad/page reports until Meta access approval.', false),
+  connector('linkedin', 'LinkedIn', 'social_outreach', ['linkedin'], 'oauth', 'shared', ['Profile/page read where available', 'Publishing only when approved'], ['external_api_call', 'client_data_access', 'publish_public_content'], ['Access owner confirmed', 'Publishing gate recorded'], 'Use manual review queue and browser-assisted research.', false),
+  connector('resend', 'Resend', 'social_outreach', ['resend'], 'api_key', 'amadutown', ['Domain/sender read', 'Send only when approved'], ['external_api_call', 'send_email', 'production_config_change'], ['Domain verified', 'Webhook reachable'], 'Use Gmail draft path until Resend approval.', false),
+
+  connector('openai', 'OpenAI', 'ai_model', ['openai', 'chatgpt', 'gpt'], 'api_key', 'shared', ['Model API key', 'Usage visibility'], ['external_api_call', 'client_data_access'], ['Key present in client-owned env', 'Model smoke passes'], 'Use manual/offline model evaluation until API key approval.', true),
+  connector('anthropic', 'Anthropic', 'ai_model', ['anthropic', 'claude'], 'api_key', 'shared', ['Model API key', 'Usage visibility'], ['external_api_call', 'client_data_access'], ['Key present in client-owned env', 'Model smoke passes'], 'Use manual/offline model evaluation until API key approval.', true),
+  connector('local_llm', 'Local/open-weight model', 'ai_model', ['local llm', 'ollama', 'lm studio', 'llama', 'mistral', 'qwen'], 'manual', 'amadutown', ['Local node access'], ['production_config_change'], ['Model available', 'Latency smoke passes'], 'Use hosted model fallback until local runtime is ready.', false),
+  connector('pinecone', 'Pinecone', 'rag_vector', ['pinecone'], 'api_key', 'shared', ['Index read/write when approved'], ['external_api_call', 'client_data_access', 'production_config_change'], ['Index reachable', 'Namespace policy recorded'], 'Use Supabase/local RAG shadow mode until Pinecone approval.', false),
+  connector('supabase_vector', 'Supabase Vector', 'rag_vector', ['supabase vector', 'pgvector', 'postgres vector'], 'service_account', 'shared', ['Vector table read/write when approved'], ['external_api_call', 'client_data_access', 'production_config_change'], ['Vector table reachable', 'RLS policy reviewed'], 'Use local JSON/search fallback until database approval.', false),
+]
+
+function connector(
+  key: string,
+  label: string,
+  category: ClientConnectorCategory,
+  aliases: string[],
+  authMethod: ClientConnectorDefinition['authMethod'],
+  setupOwner: ClientConnectorDefinition['setupOwner'],
+  requiredScopes: string[],
+  approvalActions: AgentAction[],
+  healthChecks: string[],
+  fallbackPath: string,
+  critical: boolean,
+): ClientConnectorDefinition {
+  return { key, label, category, aliases, authMethod, setupOwner, requiredScopes, approvalActions, healthChecks, fallbackPath, critical }
+}
+
+function normalize(value: unknown): string {
+  return String(value ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/[_-]+/g, ' ')
+}
+
+function valuesFromUnknown(value: unknown): string[] {
+  if (!value) return []
+  if (typeof value === 'string' || typeof value === 'number') return [String(value)]
+  if (Array.isArray(value)) return value.flatMap(valuesFromUnknown)
+  if (typeof value === 'object') {
+    const record = value as JsonRecord
+    if (typeof record.name === 'string') return [record.name]
+    return Object.values(record).flatMap(valuesFromUnknown)
+  }
+  return []
+}
+
+function definitionForValue(value: unknown, category?: ClientConnectorCategory): ClientConnectorDefinition | null {
+  const normalized = normalize(value)
+  if (!normalized || normalized === 'none' || normalized === 'other') return null
+  return CLIENT_CONNECTOR_CATALOG.find((definition) => {
+    if (category && definition.category !== category) return false
+    return definition.aliases.some((alias) => {
+      const aliasNorm = normalize(alias)
+      return normalized === aliasNorm || normalized.includes(aliasNorm) || aliasNorm.includes(normalized)
+    })
+  }) ?? null
+}
+
+function addSignal(signals: ConnectorSignal[], definition: ClientConnectorDefinition | null, source: ClientConnectorSource, evidence: string, confidence: number) {
+  if (!definition) return
+  signals.push({ definition, source, evidence, confidence })
+}
+
+function technologiesFromStack(stack: JsonRecord | null | undefined): unknown[] {
+  if (!stack || typeof stack !== 'object') return []
+  const direct = stack.technologies
+  if (Array.isArray(direct)) return direct
+  const byTag = stack.byTag
+  if (byTag && typeof byTag === 'object') return Object.values(byTag as JsonRecord).flatMap(valuesFromUnknown)
+  return []
+}
+
+function collectStackSignals(signals: ConnectorSignal[], stack: JsonRecord | null | undefined, source: ClientConnectorSource, confidence: number) {
+  for (const technology of technologiesFromStack(stack)) {
+    for (const value of valuesFromUnknown(technology)) {
+      addSignal(signals, definitionForValue(value), source, `Detected ${value}`, confidence)
+    }
+  }
+}
+
+function collectAuditSignals(signals: ConnectorSignal[], audit: ClientConnectorAuditSignal) {
+  const source: ClientConnectorSource = audit.audit_type === 'meeting_derived' || audit.audit_type === 'meeting' ? 'meeting_audit' : 'audit'
+  const tech = audit.tech_stack ?? {}
+  addSignal(signals, definitionForValue(tech.crm, 'crm'), source, `Audit CRM: ${String(tech.crm ?? '')}`, source === 'meeting_audit' ? 70 : 80)
+  addSignal(signals, definitionForValue(tech.email, 'email_calendar') ?? definitionForValue(tech.email, 'communications'), source, `Audit email/comms: ${String(tech.email ?? '')}`, source === 'meeting_audit' ? 70 : 80)
+  addSignal(signals, definitionForValue(tech.marketing, 'social_outreach') ?? definitionForValue(tech.marketing, 'crm'), source, `Audit marketing: ${String(tech.marketing ?? '')}`, source === 'meeting_audit' ? 70 : 80)
+  addSignal(signals, definitionForValue(tech.analytics, 'analytics'), source, `Audit analytics: ${String(tech.analytics ?? '')}`, source === 'meeting_audit' ? 70 : 80)
+
+  for (const tool of valuesFromUnknown(tech.other_tools)) {
+    addSignal(signals, definitionForValue(tool), source, `Audit other tool: ${tool}`, source === 'meeting_audit' ? 65 : 75)
+  }
+  for (const tool of valuesFromUnknown(tech.website_technologies)) {
+    addSignal(signals, definitionForValue(tool, 'website_cms') ?? definitionForValue(tool), source, `Audit website technology: ${tool}`, source === 'meeting_audit' ? 65 : 75)
+  }
+
+  collectStackSignals(signals, audit.enriched_tech_stack, source, source === 'meeting_audit' ? 68 : 78)
+
+  const automationAreas = valuesFromUnknown(audit.automation_needs?.priority_areas)
+  if (automationAreas.length > 0) addSignal(signals, definitionForValue('n8n'), 'inferred', `Audit automation priorities: ${automationAreas.join(', ')}`, 40)
+  if (automationAreas.some((area) => normalize(area).includes('lead') || normalize(area).includes('follow'))) {
+    addSignal(signals, definitionForValue('hubspot', 'crm'), 'inferred', 'Lead follow-up automation needs a CRM connector decision.', 35)
+    addSignal(signals, definitionForValue('gmail', 'email_calendar'), 'inferred', 'Lead follow-up automation needs an email/calendar connector decision.', 35)
+  }
+
+  const dataQuality = normalize(audit.ai_readiness?.data_quality)
+  const previousAi = normalize(audit.ai_readiness?.previous_ai_experience)
+  if (dataQuality || previousAi || valuesFromUnknown(audit.ai_readiness?.concerns).length > 0) {
+    addSignal(signals, definitionForValue('openai', 'ai_model'), 'inferred', 'AI readiness requires an AI model routing decision.', 35)
+  }
+  if (dataQuality.includes('integrated') || dataQuality.includes('ready') || dataQuality.includes('some systems')) {
+    addSignal(signals, definitionForValue('supabase vector', 'rag_vector'), 'inferred', 'AI readiness suggests a RAG/vector store decision.', 30)
+  }
+}
+
+function collectRoadmapSignals(signals: ConnectorSignal[], input: BuildClientConnectorReadinessInput) {
+  collectStackSignals(signals, input.roadmapSnapshot?.connector_readiness as JsonRecord | undefined, 'roadmap', 60)
+  const text = [
+    ...valuesFromUnknown(input.roadmapSnapshot?.stackSignals),
+    ...(input.roadmapTasks ?? []).flatMap((task) => valuesFromUnknown([task.task_key, task.title, task.metadata])),
+    ...valuesFromUnknown(input.projectMetadata),
+  ]
+  for (const value of text) {
+    addSignal(signals, definitionForValue(value), 'roadmap', `Roadmap/project signal: ${value}`, 50)
+  }
+}
+
+function sourceRank(source: ClientConnectorSource): number {
+  return {
+    verified: 100,
+    audit: 80,
+    meeting_audit: 70,
+    builtwith: 60,
+    roadmap: 50,
+    project_metadata: 45,
+    inferred: 30,
+  }[source]
+}
+
+function integrationReadiness(input: BuildClientConnectorReadinessInput): string {
+  return normalize(input.auditSignals?.find((audit) => audit.tech_stack?.integration_readiness)?.tech_stack?.integration_readiness)
+}
+
+function hasApprovalBlocker(input: BuildClientConnectorReadinessInput): boolean {
+  return Boolean(input.auditSignals?.some((audit) => {
+    const dm = audit.decision_making ?? {}
+    const approval = normalize(dm.approval_process)
+    return dm.decision_maker === false || approval.includes('committee') || approval.includes('budget threshold')
+  }))
+}
+
+function statusForSignal(signal: ConnectorSignal, input: BuildClientConnectorReadinessInput, hasConflict: boolean): ClientConnectorStatus {
+  if (hasConflict) return 'review'
+  if (hasApprovalBlocker(input) && signal.definition.approvalActions.length > 0) return 'approval_blocked'
+  const readiness = integrationReadiness(input)
+  if (signal.source === 'verified' && (readiness.includes('well') || readiness.includes('integrated') || readiness.includes('high'))) return 'ready'
+  if (signal.source === 'inferred') return 'missing'
+  if (signal.definition.authMethod === 'none') return 'ready'
+  return 'needs_auth'
+}
+
+function nextActionForItem(item: Omit<ClientConnectorReadinessItem, 'nextAction'>): string {
+  if (item.status === 'review') return `Resolve conflicting ${CATEGORY_LABELS[item.category]} signals before provisioning.`
+  if (item.status === 'approval_blocked') return `Create approval checkpoint before connecting ${item.label}.`
+  if (item.status === 'missing') return `Decide whether ${item.label} belongs in the client MVP connector set.`
+  if (item.status === 'needs_auth') return `Prepare ${item.authMethod} setup packet for ${item.label}; do not connect until approved.`
+  return `${item.label} connector is ready for read-only planning and health checks.`
+}
+
+export function buildClientConnectorReadiness(input: BuildClientConnectorReadinessInput): ClientConnectorReadiness {
+  const signals: ConnectorSignal[] = []
+  collectStackSignals(signals, input.verifiedStack, 'verified', 100)
+  for (const audit of input.auditSignals ?? []) collectAuditSignals(signals, audit)
+  collectStackSignals(signals, input.builtWithStack, 'builtwith', 60)
+  collectRoadmapSignals(signals, input)
+
+  const byCategory = new Map<ClientConnectorCategory, ConnectorSignal[]>()
+  for (const signal of signals) {
+    byCategory.set(signal.definition.category, [...(byCategory.get(signal.definition.category) ?? []), signal])
+  }
+
+  const conflicts: ClientConnectorReadiness['conflicts'] = []
+  const pickedSignals: ConnectorSignal[] = []
+  for (const [category, categorySignals] of byCategory) {
+    const sorted = categorySignals.sort((a, b) => (sourceRank(b.source) + b.confidence) - (sourceRank(a.source) + a.confidence))
+    const highestSourceRank = sourceRank(sorted[0]!.source)
+    const sameTier = sorted.filter((signal) => sourceRank(signal.source) === highestSourceRank)
+    const providerKeys = [...new Set(sameTier.map((signal) => signal.definition.key))]
+    if (providerKeys.length > 1 && highestSourceRank >= 70) {
+      conflicts.push({
+        category,
+        providers: providerKeys.map((key) => CLIENT_CONNECTOR_CATALOG.find((definition) => definition.key === key)?.label ?? key),
+        sources: [...new Set(sameTier.map((signal) => signal.source))],
+      })
+    }
+    pickedSignals.push(sorted[0]!)
+  }
+
+  const items = pickedSignals
+    .sort((a, b) => sourceRank(b.source) - sourceRank(a.source))
+    .map((signal): ClientConnectorReadinessItem => {
+      const hasConflict = conflicts.some((conflict) => conflict.category === signal.definition.category)
+      const base = {
+        key: signal.definition.key,
+        label: signal.definition.label,
+        category: signal.definition.category,
+        status: statusForSignal(signal, input, hasConflict),
+        source: signal.source,
+        authMethod: signal.definition.authMethod,
+        setupOwner: signal.definition.setupOwner,
+        requiredScopes: signal.definition.requiredScopes,
+        approvalActions: signal.definition.approvalActions,
+        healthChecks: signal.definition.healthChecks,
+        fallbackPath: signal.definition.fallbackPath,
+        critical: signal.definition.critical,
+        evidence: signal.evidence,
+      }
+      return { ...base, nextAction: nextActionForItem(base) }
+    })
+
+  const readyConnectorCount = items.filter((item) => item.status === 'ready').length
+  const approvalBlockedConnectorCount = items.filter((item) => item.status === 'approval_blocked').length
+  const missingCriticalConnectorCount = items.filter((item) => item.critical && (item.status === 'missing' || item.status === 'review')).length
+  const needsAuthCount = items.filter((item) => item.status === 'needs_auth').length
+  const nextItem = items.find((item) => item.status === 'approval_blocked')
+    ?? items.find((item) => item.status === 'review')
+    ?? items.find((item) => item.status === 'needs_auth')
+    ?? items.find((item) => item.status === 'missing' && item.critical)
+    ?? items[0]
+
+  return {
+    summary: items.length
+      ? `${items.length} required, ${readyConnectorCount} ready, ${needsAuthCount} need auth, ${approvalBlockedConnectorCount} approval-blocked`
+      : 'No connector requirements detected yet',
+    requiredConnectorCount: items.length,
+    readyConnectorCount,
+    approvalBlockedConnectorCount,
+    missingCriticalConnectorCount,
+    connectorNextAction: nextItem?.nextAction ?? 'Capture audit or verified stack data to build the connector setup packet.',
+    items,
+    conflicts,
+  }
+}


### PR DESCRIPTION
## Summary
- adds a derived Client Swarm Board under Agent Ops without creating a new queue table
- rolls up client swarm health from existing agent runs, approvals, roadmap, report, project, contact, and audit metadata
- adds approval-bounded autonomous handoff policy helpers and synthetic fixture coverage
- adds a read-only connector catalog/readiness layer using verified stack, audit stack/enrichment, meeting-derived audits, BuiltWith, roadmap signals, and project metadata
- links the board from /admin/agents and admin navigation as a drilldown, not a Mission Control replacement

## Connector Readiness
- maps common client systems into setup packets: CMS/web, CRM, email/calendar, docs/storage, analytics, automation, payments, social/outreach, comms, AI model, and RAG/vector stores
- treats audit fields as first-class evidence: CRM, email/workspace, marketing, analytics, automation needs, AI readiness, budget/timeline, and decision authority
- preserves source precedence: verified stack > audit/enrichment > meeting-derived audit > BuiltWith > roadmap/project signals
- surfaces required/ready/approval-blocked/critical-gap connector rollups on each swarm card

## Validation
- npm test -- lib/client-connector-readiness.test.ts lib/agent-swarm-board.test.ts app/api/admin/agents/swarm-board/route.test.ts
- npx tsc --noEmit --pretty false
- npm run build (compile/lint/type stage completed; blocked during page-data collection in isolated worktree because Supabase env vars are not present)

## Safety
- started from a fresh worktree/branch off origin/main
- left the warm-lead smoke branch and main checkout untouched
- V1 is read-only/approval-gated; provider writes, OAuth/credential sync, sends, publishing, production config, and client-data mutation route to approvals