### PR TITLE
test: add WRM production smoke mode

### DIFF
--- a/lib/__tests__/n8n-warm-lead-workflow-export.test.ts
+++ b/lib/__tests__/n8n-warm-lead-workflow-export.test.ts
@@ -15,6 +15,9 @@ type N8nNode = {
     jsCode?: string
     url?: string
     jsonBody?: string
+    conditions?: {
+      conditions?: Array<{ leftValue?: string }>
+    }
     headerParameters?: {
       parameters?: Array<{ name?: string; value?: string }>
     }
@@ -32,18 +35,21 @@ const WORKFLOWS = [
     source: 'facebook',
     workflowId: 'WF-WRM-001',
     normalizeNode: 'Normalize & Deduplicate',
+    liveTargets: ['Scrape FB Friends (Apify)', 'Scrape FB Groups (Apify)', 'Scrape FB Post Comments (Apify)'],
   },
   {
     file: 'WF-WRM-002-Google-Contacts-Sync.json',
     source: 'google_contacts',
     workflowId: 'WF-WRM-002',
     normalizeNode: 'Normalize Contacts',
+    liveTargets: ['Fetch Google Contacts'],
   },
   {
     file: 'WF-WRM-003-LinkedIn-Warm-Lead-Scraper.json',
     source: 'linkedin',
     workflowId: 'WF-WRM-003',
     normalizeNode: 'Normalize & Deduplicate',
+    liveTargets: ['Scrape LI Connections (Apify)', 'Scrape LI Post Engagement (Apify)'],
   },
 ]
 
@@ -68,6 +74,17 @@ function expectConnection(workflow: N8nWorkflow, from: string, to: string, outpu
 }
 
 describe('warm lead n8n workflow export trace callbacks', () => {
+  it('keeps exported workflows away from deprecated non-canonical lead sources', () => {
+    for (const { file, normalizeNode } of WORKFLOWS) {
+      const workflow = loadWorkflow(file)
+      const node = getNode(workflow, normalizeNode)
+
+      expect(node.parameters?.jsCode).not.toContain('warm_facebook_engagement')
+      expect(node.parameters?.jsCode).not.toContain('warm_linkedin_connections')
+      expect(node.parameters?.jsCode).not.toContain('warm_linkedin_engagement')
+    }
+  })
+
   it('keeps exported LinkedIn workflow aligned to canonical Portfolio lead sources', () => {
     const workflow = loadWorkflow('WF-WRM-003-LinkedIn-Warm-Lead-Scraper.json')
     const node = getNode(workflow, 'Normalize & Deduplicate')
@@ -84,7 +101,8 @@ describe('warm lead n8n workflow export trace callbacks', () => {
     expect(node.parameters?.jsCode).toContain("const triggerJson = $node['Webhook Trigger']?.json")
     expect(node.parameters?.jsCode).toContain('agent_run_id: triggerBody.agent_run_id || null')
     expect(node.parameters?.jsCode).toContain('agent_event_callback_url: triggerBody.agent_event_callback_url || null')
-    expect(node.parameters?.jsCode).toContain('return [{ json: { leads, count: leads.length, ...tracePayload } }];')
+    expect(node.parameters?.jsCode).toContain('is_test_data: triggerBody.is_test_data === true')
+    expect(node.parameters?.jsCode).toContain('...tracePayload')
   })
 
   it.each(WORKFLOWS)('$workflowId posts ingest payload with trace id and n8n variable fallbacks', ({ file }) => {
@@ -95,6 +113,31 @@ describe('warm lead n8n workflow export trace callbacks', () => {
     expect(node.parameters?.url).toContain('$vars.AMADUTOWN_PUBLIC_BASE_URL')
     expect(getAuthHeader(node)).toBe('=Bearer {{ $vars.N8N_INGEST_SECRET || $env.N8N_INGEST_SECRET }}')
     expect(node.parameters?.jsonBody).toContain('agent_run_id: $json.agent_run_id || undefined')
+    expect(node.parameters?.jsonBody).toContain('is_test_data: $json.is_test_data === true || undefined')
+  })
+
+  it.each(WORKFLOWS)('$workflowId routes webhook smoke mode through synthetic data only', ({
+    file,
+    normalizeNode,
+    liveTargets,
+  }) => {
+    const workflow = loadWorkflow(file)
+    const smokeGuard = getNode(workflow, 'Is Smoke Mode')
+    const syntheticNode = getNode(workflow, 'Synthetic Smoke Leads')
+
+    expect(smokeGuard.type).toBe('n8n-nodes-base.if')
+    expect(smokeGuard.parameters?.conditions?.conditions?.[0]?.leftValue).toContain('$json.body &&')
+    expect(smokeGuard.parameters?.conditions?.conditions?.[0]?.leftValue).not.toContain('?.')
+    expect(syntheticNode.type).toBe('n8n-nodes-base.code')
+    expect(syntheticNode.parameters?.jsCode).toContain('Synthetic Production Smoke Company')
+    expect(syntheticNode.parameters?.jsCode).toContain('is_test_data: true')
+
+    expectConnection(workflow, 'Webhook Trigger', 'Is Smoke Mode')
+    expectConnection(workflow, 'Is Smoke Mode', 'Synthetic Smoke Leads', 0)
+    expectConnection(workflow, 'Synthetic Smoke Leads', normalizeNode)
+    for (const liveTarget of liveTargets) {
+      expectConnection(workflow, 'Is Smoke Mode', liveTarget, 1)
+    }
   })
 
   it.each(WORKFLOWS)('$workflowId calls run-complete and generic trace event after ingest', ({
@@ -112,6 +155,8 @@ describe('warm lead n8n workflow export trace callbacks', () => {
     expect(completionNode.parameters?.url).toContain('/api/admin/outreach/run-complete')
     expect(completionNode.parameters?.jsonBody).toContain(`source: '${source}'`)
     expect(completionNode.parameters?.jsonBody).toContain(`$node["${normalizeNode}"].json.agent_run_id`)
+    expect(completionNode.parameters?.jsonBody).toContain(`mode: $node["${normalizeNode}"].json.mode || null`)
+    expect(completionNode.parameters?.jsonBody).toContain(`is_test_data: $node["${normalizeNode}"].json.is_test_data === true`)
     expect(getAuthHeader(completionNode)).toBe('=Bearer {{ $vars.N8N_INGEST_SECRET || $env.N8N_INGEST_SECRET }}')
 
     expect(eventNode.parameters?.url).toContain('agent_event_callback_url')
@@ -119,6 +164,8 @@ describe('warm lead n8n workflow export trace callbacks', () => {
     expect(eventNode.parameters?.jsonBody).toContain(`workflow_id: '${workflowId}'`)
     expect(eventNode.parameters?.jsonBody).toContain("stage: 'outreach_ingest_complete'")
     expect(eventNode.parameters?.jsonBody).toContain("status: 'completed'")
+    expect(eventNode.parameters?.jsonBody).toContain(`mode: $node["${normalizeNode}"].json.mode || null`)
+    expect(eventNode.parameters?.jsonBody).toContain(`is_test_data: $node["${normalizeNode}"].json.is_test_data === true`)
     expect(getAuthHeader(eventNode)).toBe('=Bearer {{ $vars.N8N_INGEST_SECRET || $env.N8N_INGEST_SECRET }}')
 
     expectConnection(workflow, 'POST to Ingest API', 'Has Agent Run ID')

--- a/n8n-exports/WF-WRM-001-Facebook-Warm-Lead-Scraper.json
+++ b/n8n-exports/WF-WRM-001-Facebook-Warm-Lead-Scraper.json
@@ -139,7 +139,7 @@
         400
       ],
       "parameters": {
-        "jsCode": "let tracePayload = {};\ntry {\n  const triggerJson = $node['Webhook Trigger']?.json || {};\n  const triggerBody = triggerJson.body || triggerJson;\n  tracePayload = {\n    agent_run_id: triggerBody.agent_run_id || null,\n    agent_event_callback_url: triggerBody.agent_event_callback_url || null,\n    agent_trace: triggerBody.agent_trace || null,\n    callbackBaseUrl: triggerBody.callbackBaseUrl || triggerBody.callback_base_url || null,\n  };\n} catch (error) {\n  tracePayload = {};\n}\n\n// Normalize Facebook scraper results into lead format\nconst allItems = $input.all();\nconst seen = new Set();\nconst leads = [];\n\nfor (const item of allItems) {\n  const d = item.json;\n  \n  // Try to extract name and profile URL from various Apify output formats\n  const name = d.name || d.profileName || d.authorName || d.userName || '';\n  const profileUrl = d.profileUrl || d.url || d.authorUrl || '';\n  const company = d.work || d.company || '';\n  const email = d.email || '';\n  \n  if (!name || name.length < 2) continue;\n  \n  // Deduplicate by profile URL or name\n  const dedupeKey = profileUrl || name.toLowerCase();\n  if (seen.has(dedupeKey)) continue;\n  seen.add(dedupeKey);\n  \n  // Determine source type based on data origin\n  let leadSource = 'warm_facebook_friends';\n  let sourceDetail = 'Facebook friend';\n  \n  if (d._groupId || d.groupName) {\n    leadSource = 'warm_facebook_groups';\n    sourceDetail = d.groupName || 'Facebook group';\n  } else if (d.commentText || d.reactionType) {\n    leadSource = 'warm_facebook_engagement';\n    sourceDetail = d.commentText ? 'Commented on post' : 'Reacted to post';\n  }\n  \n  leads.push({\n    name,\n    email: email || undefined,\n    company: company || undefined,\n    facebook_profile_url: profileUrl || undefined,\n    lead_source: leadSource,\n    warm_source_detail: sourceDetail,\n    job_title: d.jobTitle || d.headline || undefined,\n    location: d.location || d.city || undefined,\n  });\n}\n\nreturn [{ json: { leads, count: leads.length, ...tracePayload } }];"
+        "jsCode": "let tracePayload = {};\nlet triggerBody = {};\ntry {\n  const triggerJson = $node['Webhook Trigger']?.json || {};\n  triggerBody = triggerJson.body || triggerJson;\n  tracePayload = {\n    agent_run_id: triggerBody.agent_run_id || null,\n    agent_event_callback_url: triggerBody.agent_event_callback_url || null,\n    agent_trace: triggerBody.agent_trace || null,\n    callbackBaseUrl: triggerBody.callbackBaseUrl || triggerBody.callback_base_url || null,\n  };\n} catch (error) {\n  tracePayload = {};\n}\n\n// Normalize Facebook scraper results into lead format\nconst allItems = $input.all();\nconst seen = new Set();\nconst leads = [];\n\nfor (const item of allItems) {\n  const d = item.json;\n  \n  // Try to extract name and profile URL from various Apify output formats\n  const name = d.name || d.profileName || d.authorName || d.userName || '';\n  const profileUrl = d.profileUrl || d.url || d.authorUrl || '';\n  const company = d.work || d.company || '';\n  const email = d.email || '';\n  \n  if (!name || name.length < 2) continue;\n  \n  // Deduplicate by profile URL or name\n  const dedupeKey = profileUrl || name.toLowerCase();\n  if (seen.has(dedupeKey)) continue;\n  seen.add(dedupeKey);\n  \n  // Determine source type based on data origin\n  let leadSource = 'warm_facebook_friends';\n  let sourceDetail = 'Facebook friend';\n  \n  if (d._groupId || d.groupName) {\n    leadSource = 'warm_facebook_groups';\n    sourceDetail = d.groupName || 'Facebook group';\n  } else if (d.commentText || d.reactionType) {\n    leadSource = 'warm_facebook_friends';\n    sourceDetail = d.commentText ? 'Commented on post' : 'Reacted to post';\n  }\n  \n  leads.push({\n    name,\n    email: email || undefined,\n    company: company || undefined,\n    facebook_profile_url: profileUrl || undefined,\n    lead_source: leadSource,\n    warm_source_detail: sourceDetail,\n    job_title: d.jobTitle || d.headline || undefined,\n    location: d.location || d.city || undefined,\n  });\n}\n\nreturn [{ json: { leads, count: leads.length, is_test_data: triggerBody.is_test_data === true || triggerBody.mode === 'smoke' || triggerBody.run_mode === 'smoke', mode: triggerBody.mode || triggerBody.run_mode || null, ...tracePayload } }];"
       }
     },
     {
@@ -169,7 +169,7 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({ leads: $json.leads, agent_run_id: $json.agent_run_id || undefined }) }}"
+        "jsonBody": "={{ JSON.stringify({ leads: $json.leads, agent_run_id: $json.agent_run_id || undefined, is_test_data: $json.is_test_data === true || undefined }) }}"
       }
     },
     {
@@ -182,7 +182,7 @@
         100
       ],
       "parameters": {
-        "content": "## WF-WRM-001: Facebook Warm Lead Scraper\n\n**Triggers:** Weekly schedule (Mon 9am) or manual webhook\n\n**Steps:**\n1. Scrape FB friends via Apify (alien_force/facebook-scraper-pro)\n2. Scrape FB group members via Apify (mdgjtp1/facebook-group-member)\n3. Scrape FB post commenters via Apify (apify/facebook-comments-scraper)\n4. Normalize & deduplicate all results\n5. POST batch to /api/admin/outreach/ingest\n\n**Env vars needed:**\n- APIFY_TOKEN\n- FACEBOOK_PROFILE_URL\n- FACEBOOK_GROUP_UIDS (JSON array)\n- APP_BASE_URL\n- N8N_INGEST_SECRET"
+        "content": "## WF-WRM-001: Facebook Warm Lead Scraper\n\n**Triggers:** Weekly schedule (Mon 9am) or manual webhook\n\n**Steps:**\n1. Scrape FB friends via Apify (alien_force/facebook-scraper-pro)\n2. Scrape FB group members via Apify (mdgjtp1/facebook-group-member)\n3. Scrape FB post commenters via Apify (apify/facebook-comments-scraper)\n4. Normalize & deduplicate all results\n5. POST batch to /api/admin/outreach/ingest\n\n**Env vars needed:**\n- APIFY_TOKEN\n- FACEBOOK_PROFILE_URL\n- FACEBOOK_GROUP_UIDS (JSON array)\n- APP_BASE_URL\n- N8N_INGEST_SECRET\n\n**Smoke mode:** Webhook payload `{ \"mode\": \"smoke\", \"is_test_data\": true }` bypasses live source nodes, emits one synthetic lead, and marks ingest rows as `is_test_data = true`."
       }
     },
     {
@@ -246,7 +246,7 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({ source: 'facebook', agent_run_id: $node[\"Normalize & Deduplicate\"].json.agent_run_id, status: 'completed', leads_inserted: $node[\"Normalize & Deduplicate\"].json.count || (($node[\"Normalize & Deduplicate\"].json.leads || []).length) }) }}"
+        "jsonBody": "={{ JSON.stringify({ source: 'facebook', agent_run_id: $node[\"Normalize & Deduplicate\"].json.agent_run_id, status: 'completed', leads_inserted: $node[\"Normalize & Deduplicate\"].json.count || (($node[\"Normalize & Deduplicate\"].json.leads || []).length), mode: $node[\"Normalize & Deduplicate\"].json.mode || null, is_test_data: $node[\"Normalize & Deduplicate\"].json.is_test_data === true }) }}"
       }
     },
     {
@@ -276,7 +276,53 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({ workflow_id: 'WF-WRM-001', stage: 'outreach_ingest_complete', status: 'completed', items_count: $node[\"Normalize & Deduplicate\"].json.count || (($node[\"Normalize & Deduplicate\"].json.leads || []).length), metadata: { source: 'facebook' }, idempotency_key: $node[\"Normalize & Deduplicate\"].json.agent_run_id + ':WF-WRM-001:outreach_ingest_complete' }) }}"
+        "jsonBody": "={{ JSON.stringify({ workflow_id: 'WF-WRM-001', stage: 'outreach_ingest_complete', status: 'completed', items_count: $node[\"Normalize & Deduplicate\"].json.count || (($node[\"Normalize & Deduplicate\"].json.leads || []).length), metadata: { source: 'facebook', mode: $node[\"Normalize & Deduplicate\"].json.mode || null, is_test_data: $node[\"Normalize & Deduplicate\"].json.is_test_data === true }, idempotency_key: $node[\"Normalize & Deduplicate\"].json.agent_run_id + ':WF-WRM-001:outreach_ingest_complete' }) }}"
+      }
+    },
+    {
+      "id": "is_smoke_mode",
+      "name": "Is Smoke Mode",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        400,
+        300
+      ],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "version": 2,
+            "leftValue": "",
+            "caseSensitive": false,
+            "typeValidation": "loose"
+          },
+          "conditions": [
+            {
+              "id": "smoke-mode-requested",
+              "leftValue": "={{ (((($json.body && ($json.body.mode || $json.body.run_mode)) || $json.mode || $json.run_mode || '') + '').toLowerCase()) }}",
+              "rightValue": "smoke",
+              "operator": {
+                "type": "string",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "synthetic_smoke_leads",
+      "name": "Synthetic Smoke Leads",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        620,
+        160
+      ],
+      "parameters": {
+        "jsCode": "const timestamp = Date.now();\nreturn [{ json: {\n  name: 'ATAS Production Facebook Smoke Lead ' + timestamp,\n  profileUrl: 'https://facebook.example/atas-production-smoke-' + timestamp,\n  company: 'Synthetic Production Smoke Company',\n  jobTitle: 'Synthetic Smoke Tester',\n  location: 'Synthetic City',\n  smoke_marker: 'wrm-001-production-smoke',\n  is_test_data: true,\n} }];"
       }
     }
   ],
@@ -285,17 +331,7 @@
       "main": [
         [
           {
-            "node": "Scrape FB Friends (Apify)",
-            "type": "main",
-            "index": 0
-          },
-          {
-            "node": "Scrape FB Groups (Apify)",
-            "type": "main",
-            "index": 0
-          },
-          {
-            "node": "Scrape FB Post Comments (Apify)",
+            "node": "Is Smoke Mode",
             "type": "main",
             "index": 0
           }
@@ -395,6 +431,45 @@
         [
           {
             "node": "Report Agent Trace Event",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Is Smoke Mode": {
+      "main": [
+        [
+          {
+            "node": "Synthetic Smoke Leads",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Scrape FB Friends (Apify)",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Scrape FB Groups (Apify)",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Scrape FB Post Comments (Apify)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Synthetic Smoke Leads": {
+      "main": [
+        [
+          {
+            "node": "Normalize & Deduplicate",
             "type": "main",
             "index": 0
           }

--- a/n8n-exports/WF-WRM-002-Google-Contacts-Sync.json
+++ b/n8n-exports/WF-WRM-002-Google-Contacts-Sync.json
@@ -88,7 +88,7 @@
         400
       ],
       "parameters": {
-        "jsCode": "let tracePayload = {};\ntry {\n  const triggerJson = $node['Webhook Trigger']?.json || {};\n  const triggerBody = triggerJson.body || triggerJson;\n  tracePayload = {\n    agent_run_id: triggerBody.agent_run_id || null,\n    agent_event_callback_url: triggerBody.agent_event_callback_url || null,\n    agent_trace: triggerBody.agent_trace || null,\n    callbackBaseUrl: triggerBody.callbackBaseUrl || triggerBody.callback_base_url || null,\n  };\n} catch (error) {\n  tracePayload = {};\n}\n\n// Normalize Google Contacts API response into lead format\nconst connections = $json.connections || [];\nconst leads = [];\n\nfor (const person of connections) {\n  const names = person.names || [];\n  const emails = person.emailAddresses || [];\n  const phones = person.phoneNumbers || [];\n  const orgs = person.organizations || [];\n  const locations = person.locations || [];\n  \n  const name = names[0]?.displayName || '';\n  if (!name || name.length < 2) continue;\n  \n  const email = emails[0]?.value || '';\n  const phone = phones[0]?.value || '';\n  const company = orgs[0]?.name || '';\n  const jobTitle = orgs[0]?.title || '';\n  const location = locations[0]?.value || '';\n  \n  // Skip contacts without useful business info\n  // (keep those with email, company, or job title)\n  if (!email && !company && !jobTitle) continue;\n  \n  leads.push({\n    name,\n    email: email || undefined,\n    company: company || undefined,\n    job_title: jobTitle || undefined,\n    phone_number: phone || undefined,\n    location: location || undefined,\n    lead_source: 'warm_google_contacts',\n    warm_source_detail: 'Google Contacts sync',\n  });\n}\n\nreturn [{ json: { leads, count: leads.length, ...tracePayload } }];"
+        "jsCode": "let tracePayload = {};\nlet triggerBody = {};\ntry {\n  const triggerJson = $node['Webhook Trigger']?.json || {};\n  triggerBody = triggerJson.body || triggerJson;\n  tracePayload = {\n    agent_run_id: triggerBody.agent_run_id || null,\n    agent_event_callback_url: triggerBody.agent_event_callback_url || null,\n    agent_trace: triggerBody.agent_trace || null,\n    callbackBaseUrl: triggerBody.callbackBaseUrl || triggerBody.callback_base_url || null,\n  };\n} catch (error) {\n  tracePayload = {};\n}\n\n// Normalize Google Contacts node output into lead format\n// The Google Contacts node returns individual contact items via $input.all()\nconst allItems = $input.all();\nconst leads = [];\n\nfor (const item of allItems) {\n  const person = item.json;\n  const names = person.names || [];\n  const emails = person.emailAddresses || [];\n  const phones = person.phoneNumbers || [];\n  const orgs = person.organizations || [];\n  const locations = person.locations || [];\n  \n  const name = names[0]?.displayName || '';\n  if (!name || name.length < 2) continue;\n  \n  const email = emails[0]?.value || '';\n  const phone = phones[0]?.value || '';\n  const company = orgs[0]?.name || '';\n  const jobTitle = orgs[0]?.title || '';\n  const location = locations[0]?.value || '';\n  \n  if (!email && !company && !jobTitle) continue;\n  \n  leads.push({\n    name,\n    email: email || undefined,\n    company: company || undefined,\n    job_title: jobTitle || undefined,\n    phone_number: phone || undefined,\n    location: location || undefined,\n    lead_source: 'warm_google_contacts',\n    warm_source_detail: 'Google Contacts sync',\n  });\n}\n\nreturn [{ json: { leads, count: leads.length, is_test_data: triggerBody.is_test_data === true || triggerBody.mode === 'smoke' || triggerBody.run_mode === 'smoke', mode: triggerBody.mode || triggerBody.run_mode || null, ...tracePayload } }];"
       }
     },
     {
@@ -118,7 +118,7 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({ leads: $json.leads, agent_run_id: $json.agent_run_id || undefined }) }}"
+        "jsonBody": "={{ JSON.stringify({ leads: $json.leads, agent_run_id: $json.agent_run_id || undefined, is_test_data: $json.is_test_data === true || undefined }) }}"
       }
     },
     {
@@ -131,7 +131,7 @@
         100
       ],
       "parameters": {
-        "content": "## WF-WRM-002: Google Contacts Sync\n\n**Triggers:** Daily schedule (8am) or manual webhook\n\n**Steps:**\n1. Fetch contacts from Google People API\n2. Filter for contacts with business info (email, company, job title)\n3. Normalize data format\n4. POST batch to /api/admin/outreach/ingest\n\n**Env vars needed:**\n- GOOGLE_CONTACTS_TOKEN (OAuth2 access token)\n- APP_BASE_URL\n- N8N_INGEST_SECRET\n\n**Note:** For production, use n8n's built-in Google OAuth2 credential with People API scope."
+        "content": "## WF-WRM-002: Google Contacts Sync\n\n**Triggers:** Daily schedule (8am) or manual webhook\n\n**Steps:**\n1. Fetch contacts from Google People API\n2. Filter for contacts with business info (email, company, job title)\n3. Normalize data format\n4. POST batch to /api/admin/outreach/ingest\n\n**Env vars needed:**\n- GOOGLE_CONTACTS_TOKEN (OAuth2 access token)\n- APP_BASE_URL\n- N8N_INGEST_SECRET\n\n**Note:** For production, use n8n's built-in Google OAuth2 credential with People API scope.\n\n**Smoke mode:** Webhook payload `{ \"mode\": \"smoke\", \"is_test_data\": true }` bypasses live source nodes, emits one synthetic lead, and marks ingest rows as `is_test_data = true`."
       }
     },
     {
@@ -195,7 +195,7 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({ source: 'google_contacts', agent_run_id: $node[\"Normalize Contacts\"].json.agent_run_id, status: 'completed', leads_inserted: $node[\"Normalize Contacts\"].json.count || (($node[\"Normalize Contacts\"].json.leads || []).length) }) }}"
+        "jsonBody": "={{ JSON.stringify({ source: 'google_contacts', agent_run_id: $node[\"Normalize Contacts\"].json.agent_run_id, status: 'completed', leads_inserted: $node[\"Normalize Contacts\"].json.count || (($node[\"Normalize Contacts\"].json.leads || []).length), mode: $node[\"Normalize Contacts\"].json.mode || null, is_test_data: $node[\"Normalize Contacts\"].json.is_test_data === true }) }}"
       }
     },
     {
@@ -225,7 +225,53 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({ workflow_id: 'WF-WRM-002', stage: 'outreach_ingest_complete', status: 'completed', items_count: $node[\"Normalize Contacts\"].json.count || (($node[\"Normalize Contacts\"].json.leads || []).length), metadata: { source: 'google_contacts' }, idempotency_key: $node[\"Normalize Contacts\"].json.agent_run_id + ':WF-WRM-002:outreach_ingest_complete' }) }}"
+        "jsonBody": "={{ JSON.stringify({ workflow_id: 'WF-WRM-002', stage: 'outreach_ingest_complete', status: 'completed', items_count: $node[\"Normalize Contacts\"].json.count || (($node[\"Normalize Contacts\"].json.leads || []).length), metadata: { source: 'google_contacts', mode: $node[\"Normalize Contacts\"].json.mode || null, is_test_data: $node[\"Normalize Contacts\"].json.is_test_data === true }, idempotency_key: $node[\"Normalize Contacts\"].json.agent_run_id + ':WF-WRM-002:outreach_ingest_complete' }) }}"
+      }
+    },
+    {
+      "id": "is_smoke_mode",
+      "name": "Is Smoke Mode",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        400,
+        300
+      ],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "version": 2,
+            "leftValue": "",
+            "caseSensitive": false,
+            "typeValidation": "loose"
+          },
+          "conditions": [
+            {
+              "id": "smoke-mode-requested",
+              "leftValue": "={{ (((($json.body && ($json.body.mode || $json.body.run_mode)) || $json.mode || $json.run_mode || '') + '').toLowerCase()) }}",
+              "rightValue": "smoke",
+              "operator": {
+                "type": "string",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "synthetic_smoke_leads",
+      "name": "Synthetic Smoke Leads",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        620,
+        160
+      ],
+      "parameters": {
+        "jsCode": "const timestamp = Date.now();\nreturn [{ json: {\n  names: [{ displayName: 'ATAS Production Google Smoke Lead ' + timestamp }],\n  emailAddresses: [{ value: 'wrm-production-google-smoke-' + timestamp + '@example.com' }],\n  phoneNumbers: [{ value: '+15550000000' }],\n  organizations: [{ name: 'Synthetic Production Smoke Company', title: 'Synthetic Smoke Tester' }],\n  locations: [{ value: 'Synthetic City' }],\n  smoke_marker: 'wrm-002-production-smoke',\n  is_test_data: true,\n} }];"
       }
     }
   ],
@@ -234,7 +280,7 @@
       "main": [
         [
           {
-            "node": "Fetch Google Contacts",
+            "node": "Is Smoke Mode",
             "type": "main",
             "index": 0
           }
@@ -302,6 +348,35 @@
         [
           {
             "node": "Report Agent Trace Event",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Is Smoke Mode": {
+      "main": [
+        [
+          {
+            "node": "Synthetic Smoke Leads",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Fetch Google Contacts",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Synthetic Smoke Leads": {
+      "main": [
+        [
+          {
+            "node": "Normalize Contacts",
             "type": "main",
             "index": 0
           }

--- a/n8n-exports/WF-WRM-003-LinkedIn-Warm-Lead-Scraper.json
+++ b/n8n-exports/WF-WRM-003-LinkedIn-Warm-Lead-Scraper.json
@@ -110,7 +110,7 @@
         400
       ],
       "parameters": {
-        "jsCode": "let tracePayload = {};\ntry {\n  const triggerJson = $node['Webhook Trigger']?.json || {};\n  const triggerBody = triggerJson.body || triggerJson;\n  tracePayload = {\n    agent_run_id: triggerBody.agent_run_id || null,\n    agent_event_callback_url: triggerBody.agent_event_callback_url || null,\n    agent_trace: triggerBody.agent_trace || null,\n    callbackBaseUrl: triggerBody.callbackBaseUrl || triggerBody.callback_base_url || null,\n  };\n} catch (error) {\n  tracePayload = {};\n}\n\n// Normalize LinkedIn scraper results into lead format\nconst allItems = $input.all();\nconst seen = new Set();\nconst leads = [];\n\nfor (const item of allItems) {\n  const d = item.json;\n  \n  // Handle connections format (name, headline, profileUrl)\n  // Handle engagement format (commenters, reactors from posts)\n  const name = d.name || d.fullName || d.authorName || d.firstName + ' ' + (d.lastName || '') || '';\n  const profileUrl = d.profileUrl || d.url || d.authorProfileUrl || '';\n  const headline = d.headline || d.title || '';\n  const company = d.company || d.companyName || '';\n  \n  if (!name || name.trim().length < 2) continue;\n  \n  // Extract LinkedIn username from URL\n  let linkedinUsername = '';\n  if (profileUrl) {\n    const match = profileUrl.match(/linkedin\\.com\\/in\\/([^/?]+)/);\n    if (match) linkedinUsername = match[1];\n  }\n  \n  // Deduplicate by LinkedIn username or name\n  const dedupeKey = linkedinUsername || name.toLowerCase().trim();\n  if (seen.has(dedupeKey)) continue;\n  seen.add(dedupeKey);\n  \n  // Use the canonical Portfolio lead source; keep detail in warm_source_detail.\n  const leadSource = 'warm_linkedin';\n  let sourceDetail = 'LinkedIn 1st-degree connection';\n  \n  if (d.commentText || d.reactionType || d.engagementType) {\n    sourceDetail = d.commentText\n      ? 'Commented on LinkedIn post'\n      : 'Engaged with LinkedIn post';\n  }\n  \n  leads.push({\n    name: name.trim(),\n    company: company || undefined,\n    job_title: headline || undefined,\n    linkedin_url: profileUrl || undefined,\n    linkedin_username: linkedinUsername || undefined,\n    lead_source: leadSource,\n    warm_source_detail: sourceDetail,\n    location: d.location || d.geoLocation || undefined,\n  });\n}\n\nreturn [{ json: { leads, count: leads.length, ...tracePayload } }];"
+        "jsCode": "let tracePayload = {};\nlet triggerBody = {};\ntry {\n  const triggerJson = $node['Webhook Trigger']?.json || {};\n  triggerBody = triggerJson.body || triggerJson;\n  tracePayload = {\n    agent_run_id: triggerBody.agent_run_id || null,\n    agent_event_callback_url: triggerBody.agent_event_callback_url || null,\n    agent_trace: triggerBody.agent_trace || null,\n    callbackBaseUrl: triggerBody.callbackBaseUrl || triggerBody.callback_base_url || null,\n  };\n} catch (error) {\n  tracePayload = {};\n}\n\n// Normalize LinkedIn scraper results into lead format\nconst allItems = $input.all();\nconst seen = new Set();\nconst leads = [];\n\nfor (const item of allItems) {\n  const d = item.json;\n  \n  // Handle connections format (name, headline, profileUrl)\n  // Handle engagement format (commenters, reactors from posts)\n  const name = d.name || d.fullName || d.authorName || d.firstName + ' ' + (d.lastName || '') || '';\n  const profileUrl = d.profileUrl || d.url || d.authorProfileUrl || '';\n  const headline = d.headline || d.title || '';\n  const company = d.company || d.companyName || '';\n  \n  if (!name || name.trim().length < 2) continue;\n  \n  // Extract LinkedIn username from URL\n  let linkedinUsername = '';\n  if (profileUrl) {\n    const match = profileUrl.match(/linkedin\\.com\\/in\\/([^/?]+)/);\n    if (match) linkedinUsername = match[1];\n  }\n  \n  // Deduplicate by LinkedIn username or name\n  const dedupeKey = linkedinUsername || name.toLowerCase().trim();\n  if (seen.has(dedupeKey)) continue;\n  seen.add(dedupeKey);\n  \n  // Use the canonical Portfolio lead source; keep detail in warm_source_detail.\n  const leadSource = 'warm_linkedin';\n  let sourceDetail = 'LinkedIn 1st-degree connection';\n  \n  if (d.commentText || d.reactionType || d.engagementType) {\n    sourceDetail = d.commentText\n      ? 'Commented on LinkedIn post'\n      : 'Engaged with LinkedIn post';\n  }\n  \n  leads.push({\n    name: name.trim(),\n    company: company || undefined,\n    job_title: headline || undefined,\n    linkedin_url: profileUrl || undefined,\n    linkedin_username: linkedinUsername || undefined,\n    lead_source: leadSource,\n    warm_source_detail: sourceDetail,\n    location: d.location || d.geoLocation || undefined,\n  });\n}\n\nreturn [{ json: { leads, count: leads.length, is_test_data: triggerBody.is_test_data === true || triggerBody.mode === 'smoke' || triggerBody.run_mode === 'smoke', mode: triggerBody.mode || triggerBody.run_mode || null, ...tracePayload } }];"
       }
     },
     {
@@ -140,7 +140,7 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({ leads: $json.leads, agent_run_id: $json.agent_run_id || undefined }) }}"
+        "jsonBody": "={{ JSON.stringify({ leads: $json.leads, agent_run_id: $json.agent_run_id || undefined, is_test_data: $json.is_test_data === true || undefined }) }}"
       }
     },
     {
@@ -153,7 +153,7 @@
         100
       ],
       "parameters": {
-        "content": "## WF-WRM-003: LinkedIn Warm Lead Scraper\n\n**Triggers:** Weekly schedule (Wed 9am) or manual webhook\n\n**Steps:**\n1. Scrape LinkedIn 1st-degree connections via Apify (addeus/get-connections)\n2. Scrape LinkedIn post engagement via Apify (harvestapi/linkedin-profile-posts)\n3. Normalize & deduplicate all results\n4. POST batch to /api/admin/outreach/ingest\n\n**Env vars needed:**\n- APIFY_TOKEN\n- LINKEDIN_COOKIE (li_at cookie for connections scraper)\n- LINKEDIN_PROFILE_URL\n- APP_BASE_URL\n- N8N_INGEST_SECRET\n\n**Note:** LinkedIn profile viewers data is only accessible within LinkedIn's logged-in UI and cannot be reliably scraped. This workflow covers connections + post engagement."
+        "content": "## WF-WRM-003: LinkedIn Warm Lead Scraper\n\n**Triggers:** Weekly schedule (Wed 9am) or manual webhook\n\n**Steps:**\n1. Scrape LinkedIn 1st-degree connections via Apify (addeus/get-connections)\n2. Scrape LinkedIn post engagement via Apify (harvestapi/linkedin-profile-posts)\n3. Normalize & deduplicate all results\n4. POST batch to /api/admin/outreach/ingest\n\n**Env vars needed:**\n- APIFY_TOKEN\n- LINKEDIN_COOKIE (li_at cookie for connections scraper)\n- LINKEDIN_PROFILE_URL\n- APP_BASE_URL\n- N8N_INGEST_SECRET\n\n**Note:** LinkedIn profile viewers data is only accessible within LinkedIn's logged-in UI and cannot be reliably scraped. This workflow covers connections + post engagement.\n\n**Smoke mode:** Webhook payload `{ \"mode\": \"smoke\", \"is_test_data\": true }` bypasses live source nodes, emits one synthetic lead, and marks ingest rows as `is_test_data = true`."
       }
     },
     {
@@ -217,7 +217,7 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({ source: 'linkedin', agent_run_id: $node[\"Normalize & Deduplicate\"].json.agent_run_id, status: 'completed', leads_inserted: $node[\"Normalize & Deduplicate\"].json.count || (($node[\"Normalize & Deduplicate\"].json.leads || []).length) }) }}"
+        "jsonBody": "={{ JSON.stringify({ source: 'linkedin', agent_run_id: $node[\"Normalize & Deduplicate\"].json.agent_run_id, status: 'completed', leads_inserted: $node[\"Normalize & Deduplicate\"].json.count || (($node[\"Normalize & Deduplicate\"].json.leads || []).length), mode: $node[\"Normalize & Deduplicate\"].json.mode || null, is_test_data: $node[\"Normalize & Deduplicate\"].json.is_test_data === true }) }}"
       }
     },
     {
@@ -247,7 +247,53 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({ workflow_id: 'WF-WRM-003', stage: 'outreach_ingest_complete', status: 'completed', items_count: $node[\"Normalize & Deduplicate\"].json.count || (($node[\"Normalize & Deduplicate\"].json.leads || []).length), metadata: { source: 'linkedin' }, idempotency_key: $node[\"Normalize & Deduplicate\"].json.agent_run_id + ':WF-WRM-003:outreach_ingest_complete' }) }}"
+        "jsonBody": "={{ JSON.stringify({ workflow_id: 'WF-WRM-003', stage: 'outreach_ingest_complete', status: 'completed', items_count: $node[\"Normalize & Deduplicate\"].json.count || (($node[\"Normalize & Deduplicate\"].json.leads || []).length), metadata: { source: 'linkedin', mode: $node[\"Normalize & Deduplicate\"].json.mode || null, is_test_data: $node[\"Normalize & Deduplicate\"].json.is_test_data === true }, idempotency_key: $node[\"Normalize & Deduplicate\"].json.agent_run_id + ':WF-WRM-003:outreach_ingest_complete' }) }}"
+      }
+    },
+    {
+      "id": "is_smoke_mode",
+      "name": "Is Smoke Mode",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        400,
+        300
+      ],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "version": 2,
+            "leftValue": "",
+            "caseSensitive": false,
+            "typeValidation": "loose"
+          },
+          "conditions": [
+            {
+              "id": "smoke-mode-requested",
+              "leftValue": "={{ (((($json.body && ($json.body.mode || $json.body.run_mode)) || $json.mode || $json.run_mode || '') + '').toLowerCase()) }}",
+              "rightValue": "smoke",
+              "operator": {
+                "type": "string",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "synthetic_smoke_leads",
+      "name": "Synthetic Smoke Leads",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        620,
+        160
+      ],
+      "parameters": {
+        "jsCode": "const timestamp = Date.now();\nreturn [{ json: {\n  name: 'ATAS Production LinkedIn Smoke Lead ' + timestamp,\n  profileUrl: 'https://www.linkedin.com/in/atas-production-smoke-' + timestamp,\n  headline: 'Synthetic Smoke Tester',\n  company: 'Synthetic Production Smoke Company',\n  location: 'Synthetic City',\n  smoke_marker: 'wrm-003-production-smoke',\n  is_test_data: true,\n} }];"
       }
     }
   ],
@@ -256,12 +302,7 @@
       "main": [
         [
           {
-            "node": "Scrape LI Connections (Apify)",
-            "type": "main",
-            "index": 0
-          },
-          {
-            "node": "Scrape LI Post Engagement (Apify)",
+            "node": "Is Smoke Mode",
             "type": "main",
             "index": 0
           }
@@ -345,6 +386,40 @@
         [
           {
             "node": "Report Agent Trace Event",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Is Smoke Mode": {
+      "main": [
+        [
+          {
+            "node": "Synthetic Smoke Leads",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Scrape LI Connections (Apify)",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Scrape LI Post Engagement (Apify)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Synthetic Smoke Leads": {
+      "main": [
+        [
+          {
+            "node": "Normalize & Deduplicate",
             "type": "main",
             "index": 0
           }


### PR DESCRIPTION
## Summary\n- Adds webhook-only smoke mode to WRM Facebook, Google Contacts, and LinkedIn n8n exports.\n- Smoke mode bypasses live Apify/Google source nodes, emits one synthetic lead, and sends ingest with is_test_data=true.\n- Adds trace/callback metadata for mode and is_test_data, plus regression coverage for canonical lead sources and smoke routing.\n\n## Validation\n- npm test -- --run lib/__tests__/n8n-warm-lead-workflow-export.test.ts lib/__tests__/n8n-warm-lead-scrape.test.ts\n- git diff --check\n- Live n8n validation passed for WF-WRM-001, WF-WRM-002, WF-WRM-003 with 0 errors.\n- Production synthetic smoke executions succeeded: n8n executions 13066, 13067, 13068.\n- Production Agent Ops smoke runs completed: 93225e7d-056e-49d3-9a29-b572d7b15a8c, 9faed200-476a-4bc2-81b9-6aa290fb6f69, 7f910dd6-c29c-4bbb-bbda-284e2c9e3d9c.\n- Production DB check confirmed synthetic contacts are is_test_data=true and non-test smoke rows count is 0.\n\n## Integration Captain Notes\n- Do not merge until captain reviews live n8n patch alignment with these exports.\n- This branch does not include customer-data fixtures.\n- Remaining n8n validator warnings are pre-existing type-version/error-handling advisories, not blocking errors.