### PR TITLE
chore: add WRM production smoke gate

### DIFF
--- a/docs/warm-lead-workflow-integration.md
+++ b/docs/warm-lead-workflow-integration.md
@@ -105,6 +105,19 @@ The versioned WRM workflow exports preserve `agent_run_id`, `agent_event_callbac
 
 **Trigger strategy:** Remove any redundant 10-minute webhook caller; keep one run-on-wake or schedule per workflow. The 24-hour gate ensures at most one API call per 24 hours.
 
+### 1c. Production smoke gate
+
+Use the WRM production smoke gate after n8n workflow patches or deployment changes that affect warm lead capture. The gate triggers only the production webhook smoke branch for `WF-WRM-001`, `WF-WRM-002`, and `WF-WRM-003`; it does not run live source scrapers. Each smoke trigger creates an Agent Operations run, sends the shared trace envelope, verifies n8n progress callbacks, and confirms that only synthetic `contact_submissions` rows with `is_test_data=true` were inserted.
+
+```bash
+npm run wrm:smoke-gate -- --dry-run
+npm run wrm:smoke-gate
+```
+
+Live mode requires `PROD_SUPABASE_URL`, `PROD_SUPABASE_SERVICE_ROLE_KEY`, and the three production `N8N_WRM*_WEBHOOK_URL` values in `.env.local`. The callback base URL is locked to `https://amadutown.com`, and webhook URLs are rejected if they point at `webhook-test`.
+
+Do not point this gate at staging or non-production databases. Staging should use staging-scoped variables, staging data, and separate test fixtures so production customer data is never copied into non-prod.
+
 ### 2. Manual lead entry (salesperson)
 
 Salespeople can add a single lead from non-automated inputs (e.g. LinkedIn conversation, business card, referral, event) without using the ingest API or any shared secret.
@@ -323,6 +336,10 @@ await ingestMockWarmLeads(leads, authToken)
 N8N_WRM001_WEBHOOK_URL=https://n8n.amadutown.com/webhook/...
 N8N_WRM002_WEBHOOK_URL=https://n8n.amadutown.com/webhook/...
 N8N_WRM003_WEBHOOK_URL=https://n8n.amadutown.com/webhook/...
+
+# Production smoke gate database target
+PROD_SUPABASE_URL=https://...
+PROD_SUPABASE_SERVICE_ROLE_KEY=...
 
 # n8n Ingest Secret (for receiving scraped data)
 N8N_INGEST_SECRET=your-secret-key-here
@@ -543,6 +560,8 @@ ORDER BY tr.started_at DESC;
 - [ ] Set all environment variables in production
 - [ ] Configure n8n workflows in n8n Cloud
 - [ ] Test trigger API from admin dashboard
+- [ ] Run `npm run wrm:smoke-gate -- --dry-run`
+- [ ] Run `npm run wrm:smoke-gate` and confirm synthetic Agent Ops traces
 - [ ] Verify webhook URLs are accessible
 - [ ] Run E2E test in staging environment
 - [ ] Check monitoring queries

--- a/lib/__tests__/wrm-smoke-gate.test.ts
+++ b/lib/__tests__/wrm-smoke-gate.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import {
+  WRM_SMOKE_WORKFLOWS,
+  agentEventCallbackUrl,
+  assertProductionCallbackBaseUrl,
+  assertProductionWebhookUrl,
+  buildWrmSmokePayload,
+  isSyntheticSmokeName,
+} from '@/lib/wrm-smoke-gate'
+
+describe('WRM smoke gate helpers', () => {
+  it('builds a synthetic smoke payload with Agent Ops callback wiring', () => {
+    const workflow = WRM_SMOKE_WORKFLOWS[0]
+    const payload = buildWrmSmokePayload({
+      workflow,
+      runId: 'run-123',
+      callbackBaseUrl: 'https://amadutown.com/',
+    })
+
+    expect(payload).toEqual({
+      mode: 'smoke',
+      is_test_data: true,
+      callbackBaseUrl: 'https://amadutown.com',
+      agent_run_id: 'run-123',
+      agent_event_callback_url: 'https://amadutown.com/api/admin/agents/runs/run-123/events',
+      agent_trace: {
+        mode: 'smoke',
+        source: 'facebook',
+        workflow_id: 'WF-WRM-001',
+      },
+    })
+  })
+
+  it('rejects non-production callback URLs for the production gate', () => {
+    expect(() => assertProductionCallbackBaseUrl('https://amadutown.com')).not.toThrow()
+    expect(() => assertProductionCallbackBaseUrl('https://portfolio-staging-vsillahs-projects.vercel.app')).toThrow(
+      /requires callback base URL/
+    )
+  })
+
+  it('rejects webhook-test URLs for the production gate', () => {
+    expect(() => assertProductionWebhookUrl('N8N_WRM001_WEBHOOK_URL', 'https://amadutown.app.n8n.cloud/webhook/wrm-001-facebook')).not.toThrow()
+    expect(() => assertProductionWebhookUrl('N8N_WRM001_WEBHOOK_URL', 'https://amadutown.app.n8n.cloud/webhook-test/wrm-001-facebook')).toThrow(
+      /webhook-test/
+    )
+  })
+
+  it('recognizes source-specific synthetic smoke names', () => {
+    const linkedin = WRM_SMOKE_WORKFLOWS.find((workflow) => workflow.workflowId === 'WF-WRM-003')
+    expect(linkedin).toBeDefined()
+    expect(isSyntheticSmokeName('ATAS Production LinkedIn Smoke Lead 123', linkedin!)).toBe(true)
+    expect(isSyntheticSmokeName('ATAS Production Facebook Smoke Lead 123', linkedin!)).toBe(false)
+  })
+
+  it('formats Agent Ops callback URLs consistently', () => {
+    expect(agentEventCallbackUrl('https://amadutown.com/', 'abc')).toBe(
+      'https://amadutown.com/api/admin/agents/runs/abc/events'
+    )
+  })
+})

--- a/lib/wrm-smoke-gate.ts
+++ b/lib/wrm-smoke-gate.ts
@@ -1,0 +1,93 @@
+export type WrmSmokeSource = 'facebook' | 'google_contacts' | 'linkedin'
+
+export interface WrmSmokeWorkflow {
+  source: WrmSmokeSource
+  workflowId: string
+  title: string
+  envVar: string
+  leadSource: string
+  smokeNamePrefix: string
+}
+
+export interface WrmSmokePayloadInput {
+  workflow: WrmSmokeWorkflow
+  runId: string
+  callbackBaseUrl: string
+}
+
+export const WRM_SMOKE_WORKFLOWS: WrmSmokeWorkflow[] = [
+  {
+    source: 'facebook',
+    workflowId: 'WF-WRM-001',
+    title: 'WRM-001 production smoke gate',
+    envVar: 'N8N_WRM001_WEBHOOK_URL',
+    leadSource: 'warm_facebook_friends',
+    smokeNamePrefix: 'ATAS Production Facebook Smoke Lead',
+  },
+  {
+    source: 'google_contacts',
+    workflowId: 'WF-WRM-002',
+    title: 'WRM-002 production smoke gate',
+    envVar: 'N8N_WRM002_WEBHOOK_URL',
+    leadSource: 'warm_google_contacts',
+    smokeNamePrefix: 'ATAS Production Google Smoke Lead',
+  },
+  {
+    source: 'linkedin',
+    workflowId: 'WF-WRM-003',
+    title: 'WRM-003 production smoke gate',
+    envVar: 'N8N_WRM003_WEBHOOK_URL',
+    leadSource: 'warm_linkedin',
+    smokeNamePrefix: 'ATAS Production LinkedIn Smoke Lead',
+  },
+]
+
+export function normalizeBaseUrl(value: string): string {
+  return value.trim().replace(/\/+$/, '')
+}
+
+export function agentEventCallbackUrl(callbackBaseUrl: string, runId: string): string {
+  return `${normalizeBaseUrl(callbackBaseUrl)}/api/admin/agents/runs/${runId}/events`
+}
+
+export function buildWrmSmokePayload(input: WrmSmokePayloadInput): Record<string, unknown> {
+  return {
+    mode: 'smoke',
+    is_test_data: true,
+    callbackBaseUrl: normalizeBaseUrl(input.callbackBaseUrl),
+    agent_run_id: input.runId,
+    agent_event_callback_url: agentEventCallbackUrl(input.callbackBaseUrl, input.runId),
+    agent_trace: {
+      mode: 'smoke',
+      source: input.workflow.source,
+      workflow_id: input.workflow.workflowId,
+    },
+  }
+}
+
+export function assertProductionCallbackBaseUrl(callbackBaseUrl: string): void {
+  const normalized = normalizeBaseUrl(callbackBaseUrl)
+  if (normalized !== 'https://amadutown.com') {
+    throw new Error(
+      `WRM production smoke gate requires callback base URL https://amadutown.com; received ${normalized}`
+    )
+  }
+}
+
+export function assertProductionWebhookUrl(envVar: string, webhookUrl: string): void {
+  if (!webhookUrl.trim()) {
+    throw new Error(`${envVar} is required`)
+  }
+
+  const parsed = new URL(webhookUrl)
+  if (parsed.protocol !== 'https:') {
+    throw new Error(`${envVar} must use https`)
+  }
+  if (parsed.pathname.includes('/webhook-test/')) {
+    throw new Error(`${envVar} points at webhook-test; production smoke gate requires production webhook URLs`)
+  }
+}
+
+export function isSyntheticSmokeName(name: string, workflow: WrmSmokeWorkflow): boolean {
+  return name.startsWith(workflow.smokeNamePrefix)
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "deploy:watch": "tsx scripts/vercel-deployment-watch.ts",
     "deploy:watch:once": "tsx scripts/vercel-deployment-watch.ts --once",
     "git:hygiene:report": "tsx scripts/git-hygiene-report.ts",
+    "wrm:smoke-gate": "tsx scripts/wrm-production-smoke-gate.ts",
     "source-protocol:smoke": "tsx scripts/source-protocol-smoke.ts",
     "staging:publications-parity": "tsx scripts/ensure-publications-experience-parity.ts --env-file .env.staging",
     "printful:webhook": "tsx scripts/printful-setup-webhook.ts",

--- a/scripts/wrm-production-smoke-gate.ts
+++ b/scripts/wrm-production-smoke-gate.ts
@@ -1,0 +1,430 @@
+#!/usr/bin/env tsx
+/**
+ * Production-safe smoke gate for WRM n8n workflows.
+ *
+ * This gate triggers only the webhook smoke branch added to the WRM workflows.
+ * Smoke mode bypasses live Apify/Google source nodes and inserts synthetic
+ * contacts with is_test_data=true, while preserving Agent Ops traces.
+ */
+
+import { config } from 'dotenv'
+import { resolve } from 'node:path'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import {
+  WRM_SMOKE_WORKFLOWS,
+  assertProductionCallbackBaseUrl,
+  assertProductionWebhookUrl,
+  buildWrmSmokePayload,
+  type WrmSmokeWorkflow,
+} from '../lib/wrm-smoke-gate'
+
+config({ path: resolve(process.cwd(), '.env.local') })
+
+type GateOptions = {
+  dryRun: boolean
+  callbackBaseUrl: string
+  timeoutSeconds: number
+  intervalSeconds: number
+}
+
+type CreatedRun = {
+  workflow: WrmSmokeWorkflow
+  runId: string
+}
+
+type AgentRunRow = {
+  id: string
+  title: string
+  status: string
+  current_step: string | null
+  subject_id: string | null
+  subject_label: string | null
+  error_message: string | null
+}
+
+const TERMINAL_STATUSES = new Set(['completed', 'failed', 'cancelled', 'stale'])
+
+function usage(): string {
+  return `Usage:
+  npx tsx scripts/wrm-production-smoke-gate.ts [options]
+
+Options:
+  --dry-run                  Print planned checks without writing or triggering.
+  --callback-base-url <url>  Must be https://amadutown.com. Defaults to https://amadutown.com.
+  --timeout <seconds>        Max wait time. Defaults to 180.
+  --interval <seconds>       Poll interval. Defaults to 5.
+  --help                     Show this help.
+
+Required env for live mode:
+  PROD_SUPABASE_URL
+  PROD_SUPABASE_SERVICE_ROLE_KEY
+  N8N_WRM001_WEBHOOK_URL
+  N8N_WRM002_WEBHOOK_URL
+  N8N_WRM003_WEBHOOK_URL
+`
+}
+
+function readOptions(argv: string[]): GateOptions {
+  const options: GateOptions = {
+    dryRun: false,
+    callbackBaseUrl: 'https://amadutown.com',
+    timeoutSeconds: 180,
+    intervalSeconds: 5,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--help') {
+      console.log(usage())
+      process.exit(0)
+    }
+    if (arg === '--dry-run') {
+      options.dryRun = true
+      continue
+    }
+    if (arg === '--callback-base-url') {
+      options.callbackBaseUrl = readOptionValue(argv, index, arg)
+      index += 1
+      continue
+    }
+    if (arg === '--timeout') {
+      options.timeoutSeconds = Number(readOptionValue(argv, index, arg))
+      index += 1
+      continue
+    }
+    if (arg === '--interval') {
+      options.intervalSeconds = Number(readOptionValue(argv, index, arg))
+      index += 1
+      continue
+    }
+    throw new Error(`Unknown argument: ${arg}`)
+  }
+
+  if (!Number.isFinite(options.timeoutSeconds) || options.timeoutSeconds <= 0) {
+    throw new Error('--timeout must be a positive number')
+  }
+  if (!Number.isFinite(options.intervalSeconds) || options.intervalSeconds <= 0) {
+    throw new Error('--interval must be a positive number')
+  }
+
+  return options
+}
+
+function readOptionValue(argv: string[], index: number, arg: string): string {
+  const value = argv[index + 1]
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${arg} requires a value`)
+  }
+  return value
+}
+
+function requiredEnv(name: string): string {
+  const value = process.env[name]?.trim()
+  if (!value) throw new Error(`${name} is required`)
+  return value
+}
+
+function prodDb(): SupabaseClient {
+  return createClient(requiredEnv('PROD_SUPABASE_URL'), requiredEnv('PROD_SUPABASE_SERVICE_ROLE_KEY'), {
+    auth: { persistSession: false },
+  })
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function createAgentRun(supabase: SupabaseClient, workflow: WrmSmokeWorkflow): Promise<CreatedRun> {
+  const { data: registry } = await supabase
+    .from('agent_registry')
+    .select('id')
+    .eq('key', 'automation-systems')
+    .maybeSingle()
+
+  const idempotencyKey = `wrm-smoke-gate:${workflow.workflowId}:${Date.now()}`
+  const now = new Date().toISOString()
+  const metadata = {
+    workflow_id: workflow.workflowId,
+    source: workflow.source,
+    mode: 'smoke',
+    is_test_data: true,
+    gate: 'wrm-production-smoke-gate',
+  }
+
+  const { data, error } = await supabase
+    .from('agent_runs')
+    .insert({
+      agent_registry_id: (registry as { id?: string } | null)?.id ?? null,
+      agent_key: 'automation-systems',
+      runtime: 'n8n',
+      kind: 'warm_lead_smoke',
+      title: workflow.title,
+      status: 'running',
+      subject_type: 'workflow',
+      subject_id: workflow.workflowId,
+      subject_label: workflow.source,
+      trigger_source: 'wrm-production-smoke-gate',
+      current_step: 'Production smoke dispatched',
+      metadata,
+      idempotency_key: idempotencyKey,
+      created_at: now,
+      updated_at: now,
+    })
+    .select('id')
+    .single()
+
+  if (error || !data?.id) {
+    throw new Error(`Failed to create Agent Ops run for ${workflow.workflowId}: ${error?.message ?? 'missing id'}`)
+  }
+
+  const runId = data.id as string
+  await supabase.from('agent_run_events').insert({
+    run_id: runId,
+    event_type: 'run_started',
+    severity: 'info',
+    message: workflow.title,
+    metadata,
+    idempotency_key: `${idempotencyKey}:started`,
+  })
+  await supabase.from('agent_run_steps').insert({
+    run_id: runId,
+    step_key: 'production_smoke_dispatched',
+    name: 'Production smoke dispatched',
+    status: 'running',
+    metadata,
+    idempotency_key: `${idempotencyKey}:dispatch`,
+  })
+
+  return { workflow, runId }
+}
+
+async function markDispatchAccepted(supabase: SupabaseClient, runId: string): Promise<void> {
+  await supabase
+    .from('agent_run_steps')
+    .update({
+      status: 'completed',
+      completed_at: new Date().toISOString(),
+      output_summary: 'Production smoke webhook accepted',
+    })
+    .eq('run_id', runId)
+    .eq('step_key', 'production_smoke_dispatched')
+}
+
+async function markRunFailed(supabase: SupabaseClient, runId: string, message: string): Promise<void> {
+  await supabase
+    .from('agent_runs')
+    .update({
+      status: 'failed',
+      completed_at: new Date().toISOString(),
+      current_step: 'Production smoke gate failed',
+      error_message: message,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', runId)
+}
+
+async function triggerWorkflow(
+  supabase: SupabaseClient,
+  createdRun: CreatedRun,
+  callbackBaseUrl: string
+): Promise<void> {
+  const webhookUrl = requiredEnv(createdRun.workflow.envVar)
+  assertProductionWebhookUrl(createdRun.workflow.envVar, webhookUrl)
+
+  const response = await fetch(webhookUrl, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(
+      buildWrmSmokePayload({
+        workflow: createdRun.workflow,
+        runId: createdRun.runId,
+        callbackBaseUrl,
+      })
+    ),
+  })
+
+  const text = await response.text()
+  if (!response.ok) {
+    await markRunFailed(supabase, createdRun.runId, `Webhook returned ${response.status}`)
+    throw new Error(`${createdRun.workflow.workflowId} webhook returned ${response.status}: ${text.slice(0, 300)}`)
+  }
+
+  await markDispatchAccepted(supabase, createdRun.runId)
+}
+
+async function readRuns(supabase: SupabaseClient, runIds: string[]): Promise<AgentRunRow[]> {
+  const { data, error } = await supabase
+    .from('agent_runs')
+    .select('id,title,status,current_step,subject_id,subject_label,error_message')
+    .in('id', runIds)
+    .order('created_at', { ascending: true })
+
+  if (error) throw new Error(`Failed to read Agent Ops runs: ${error.message}`)
+  return (data ?? []) as AgentRunRow[]
+}
+
+async function readProgressEvents(supabase: SupabaseClient, runIds: string[]): Promise<Array<{ run_id: string }>> {
+  const { data, error } = await supabase
+    .from('agent_run_events')
+    .select('run_id')
+    .in('run_id', runIds)
+    .eq('event_type', 'n8n_progress')
+
+  if (error) throw new Error(`Failed to read Agent Ops events: ${error.message}`)
+  return (data ?? []) as Array<{ run_id: string }>
+}
+
+async function waitForTraceCompletion(
+  supabase: SupabaseClient,
+  createdRuns: CreatedRun[],
+  options: GateOptions
+): Promise<AgentRunRow[]> {
+  const startedAt = Date.now()
+  const runIds = createdRuns.map((run) => run.runId)
+
+  while (Date.now() - startedAt < options.timeoutSeconds * 1000) {
+    const [runs, events] = await Promise.all([
+      readRuns(supabase, runIds),
+      readProgressEvents(supabase, runIds),
+    ])
+
+    const progressRunIds = new Set(events.map((event) => event.run_id))
+    const allCompleted = runs.length === runIds.length && runs.every((run) => run.status === 'completed')
+    const allHaveProgress = runIds.every((runId) => progressRunIds.has(runId))
+    const failed = runs.find((run) => run.status === 'failed' || run.status === 'cancelled' || run.status === 'stale')
+
+    if (failed) {
+      throw new Error(`${failed.subject_id} finished with status ${failed.status}: ${failed.error_message ?? 'no error message'}`)
+    }
+    if (allCompleted && allHaveProgress) return runs
+
+    console.log(
+      `Waiting for Agent Ops traces: ${runs.filter((run) => run.status === 'completed').length}/${runIds.length} completed, ${progressRunIds.size}/${runIds.length} progress events`
+    )
+    await sleep(options.intervalSeconds * 1000)
+  }
+
+  throw new Error(`Timed out after ${options.timeoutSeconds}s waiting for WRM smoke traces`)
+}
+
+async function markUnfinishedRunsFailed(
+  supabase: SupabaseClient,
+  createdRuns: CreatedRun[],
+  message: string
+): Promise<void> {
+  if (createdRuns.length === 0) return
+
+  const latestRuns = await readRuns(
+    supabase,
+    createdRuns.map((run) => run.runId)
+  ).catch(() => [])
+  const terminalRunIds = new Set(latestRuns.filter((run) => TERMINAL_STATUSES.has(run.status)).map((run) => run.id))
+
+  await Promise.all(
+    createdRuns
+      .filter((run) => !terminalRunIds.has(run.runId))
+      .map((run) => markRunFailed(supabase, run.runId, message).catch(() => {}))
+  )
+}
+
+async function verifySyntheticRows(
+  supabase: SupabaseClient,
+  gateStartedAt: string,
+  workflows: WrmSmokeWorkflow[]
+): Promise<void> {
+  const { data: syntheticRows, error: syntheticError } = await supabase
+    .from('contact_submissions')
+    .select('id,name,lead_source,is_test_data,created_at')
+    .eq('is_test_data', true)
+    .gte('created_at', gateStartedAt)
+    .ilike('name', 'ATAS Production%Smoke Lead%')
+    .order('created_at', { ascending: false })
+    .limit(20)
+
+  if (syntheticError) throw new Error(`Failed to verify synthetic smoke rows: ${syntheticError.message}`)
+
+  for (const workflow of workflows) {
+    const found = (syntheticRows ?? []).some((row) => {
+      const typed = row as { name?: string; lead_source?: string }
+      return (
+        typeof typed.name === 'string' &&
+        typed.name.startsWith(workflow.smokeNamePrefix) &&
+        typed.lead_source === workflow.leadSource
+      )
+    })
+
+    if (!found) {
+      throw new Error(`No synthetic test row found for ${workflow.workflowId} after ${gateStartedAt}`)
+    }
+  }
+
+  const { data: nonTestRows, error: nonTestError } = await supabase
+    .from('contact_submissions')
+    .select('id,name,lead_source,is_test_data,created_at')
+    .neq('is_test_data', true)
+    .gte('created_at', gateStartedAt)
+    .ilike('name', 'ATAS Production%Smoke Lead%')
+    .limit(10)
+
+  if (nonTestError) throw new Error(`Failed to verify non-test smoke rows: ${nonTestError.message}`)
+  if ((nonTestRows ?? []).length > 0) {
+    throw new Error(`Found ${nonTestRows?.length ?? 0} smoke row(s) without is_test_data=true`)
+  }
+
+  console.log(`Verified ${syntheticRows?.length ?? 0} recent synthetic smoke row(s); non-test smoke rows: 0`)
+}
+
+async function main(): Promise<void> {
+  const options = readOptions(process.argv.slice(2))
+  assertProductionCallbackBaseUrl(options.callbackBaseUrl)
+
+  console.log('WRM production smoke gate')
+  console.log(`Mode: ${options.dryRun ? 'dry-run' : 'live synthetic smoke'}`)
+  console.log(`Callback base URL: ${options.callbackBaseUrl}`)
+  console.log(`Workflows: ${WRM_SMOKE_WORKFLOWS.map((workflow) => workflow.workflowId).join(', ')}`)
+
+  for (const workflow of WRM_SMOKE_WORKFLOWS) {
+    const webhookUrl = process.env[workflow.envVar] ?? ''
+    if (options.dryRun && !webhookUrl.trim()) continue
+    assertProductionWebhookUrl(workflow.envVar, webhookUrl)
+  }
+
+  if (options.dryRun) {
+    console.log('Dry run complete. No database writes or webhooks were triggered.')
+    return
+  }
+
+  const gateStartedAt = new Date(Date.now() - 5000).toISOString()
+  const supabase = prodDb()
+  const createdRuns: CreatedRun[] = []
+
+  try {
+    for (const workflow of WRM_SMOKE_WORKFLOWS) {
+      const created = await createAgentRun(supabase, workflow)
+      createdRuns.push(created)
+      console.log(`${workflow.workflowId}: Agent Ops run ${created.runId}`)
+    }
+
+    for (const createdRun of createdRuns) {
+      await triggerWorkflow(supabase, createdRun, options.callbackBaseUrl)
+      console.log(`${createdRun.workflow.workflowId}: webhook accepted`)
+    }
+
+    const completedRuns = await waitForTraceCompletion(supabase, createdRuns, options)
+    await verifySyntheticRows(supabase, gateStartedAt, WRM_SMOKE_WORKFLOWS)
+
+    console.log('WRM production smoke gate passed')
+    for (const run of completedRuns) {
+      console.log(`- ${run.subject_id}: ${run.status} (${run.id})`)
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    await markUnfinishedRunsFailed(supabase, createdRuns, message)
+    throw error
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

- add a reusable WRM production smoke gate for WF-WRM-001, WF-WRM-002, and WF-WRM-003
- centralize smoke payload and production URL guards in `lib/wrm-smoke-gate.ts`
- document the gate and deployment checklist steps for warm lead workflow changes

## Validation

- `npm test -- --run lib/__tests__/wrm-smoke-gate.test.ts lib/__tests__/n8n-warm-lead-workflow-export.test.ts`
- `npm run wrm:smoke-gate -- --dry-run`
- `npm run wrm:smoke-gate`
- `npm run lint`
- `npx tsc --noEmit --pretty false`
- PR preview Vercel contexts: `Vercel – portfolio` and `Vercel – portfolio-staging` passed

## Live synthetic smoke evidence

Latest captain-run gate evidence:

- WF-WRM-001 Agent Ops run: `a22af303-d5ec-4e0c-ba32-027a026b1780`
- WF-WRM-002 Agent Ops run: `8ca3d96d-3b09-42ae-88bb-9e252b59798a`
- WF-WRM-003 Agent Ops run: `38716c59-30a7-4283-b540-4a141e580e07`

The live gate verified 3 recent synthetic smoke rows and 0 non-test smoke rows. The script rejects staging callback URLs and `webhook-test` URLs so production smoke validation cannot accidentally use non-prod paths.

## Integration note

Reviewed by integration captain. Ready to merge after validation.