### PR TITLE
feat: add agent dead-letter monitor

### DIFF
--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -118,6 +118,22 @@ type MissionSnapshot = {
     started_at: string
     completed_at: string | null
   }>
+  dead_letter_queue: Array<{
+    run_id: string
+    agent_key: string
+    agent_name: string
+    pod: string
+    runtime: string
+    status: string
+    title: string
+    reason: string
+    age_hours: number
+    source_label: string
+    routed: boolean
+    routed_run_id: string | null
+    next_action: string
+    href: string
+  }>
 }
 
 type WarRoomResult = {
@@ -477,6 +493,8 @@ export default function AgentOperationsPage() {
 
           <EngagementQueuePanel items={snapshot?.engagement_queue ?? []} />
 
+          <DeadLetterPanel items={snapshot?.dead_letter_queue ?? []} />
+
           <section className="mt-5 grid grid-cols-1 gap-5 xl:grid-cols-[1fr_0.8fr]">
             <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
               <div className="flex items-center gap-2 text-radiant-gold">
@@ -770,6 +788,58 @@ function EngagementQueuePanel({ items }: { items: MissionSnapshot['engagement_qu
             No routed agent engagements yet. Use Chief of Staff recommendations, Agent Inbox routing, or Slack `/agent run`.
           </p>
         )}
+      </div>
+    </section>
+  )
+}
+
+function DeadLetterPanel({ items }: { items: MissionSnapshot['dead_letter_queue'] }) {
+  if (!items.length) return null
+
+  return (
+    <section className="mt-5 rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-2 text-radiant-gold">
+          <AlertTriangle size={18} />
+          <h2 className="font-semibold">Dead-Letter Monitor</h2>
+        </div>
+        <Link href="/admin/agents/runs" className="text-xs text-radiant-gold hover:underline">
+          Open failed runs
+        </Link>
+      </div>
+      <p className="mt-2 text-sm text-muted-foreground">
+        Failed and stale traces stay here until they have a routed engagement or are resolved. This is derived from Agent Ops traces, not a separate queue table.
+      </p>
+
+      <div className="mt-3 grid grid-cols-1 gap-2 lg:grid-cols-2">
+        {items.map((item) => (
+          <Link
+            key={item.run_id}
+            href={item.routed_run_id ? `/admin/agents/runs/${item.routed_run_id}` : item.href}
+            className="rounded-lg border border-silicon-slate/50 bg-black/10 p-3 text-sm hover:border-radiant-gold/50"
+          >
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="font-medium">{item.title}</span>
+              <span className={`rounded-full border px-2 py-0.5 text-xs ${item.routed ? 'border-emerald-400/40 bg-emerald-500/10 text-emerald-200' : 'border-red-400/40 bg-red-500/10 text-red-200'}`}>
+                {item.routed ? 'routed' : 'unrouted'}
+              </span>
+              <span className="rounded-full border border-silicon-slate/50 bg-black/10 px-2 py-0.5 text-xs text-muted-foreground">
+                {item.status}
+              </span>
+              <span className="rounded-full border border-silicon-slate/50 bg-black/10 px-2 py-0.5 text-xs text-muted-foreground">
+                {item.runtime}
+              </span>
+            </div>
+            <div className="mt-3 grid grid-cols-1 gap-2 text-xs text-muted-foreground sm:grid-cols-2">
+              <QueueDetail label="Owner" value={item.agent_name} />
+              <QueueDetail label="Source" value={item.source_label} />
+              <QueueDetail label="Pod" value={item.pod} />
+              <QueueDetail label="Age" value={`${item.age_hours}h`} />
+            </div>
+            <p className="mt-3 line-clamp-2 text-muted-foreground">{item.reason}</p>
+            <p className="mt-2 text-xs text-radiant-gold">{item.next_action}</p>
+          </Link>
+        ))}
       </div>
     </section>
   )

--- a/app/api/admin/agents/mission-control/route.test.ts
+++ b/app/api/admin/agents/mission-control/route.test.ts
@@ -56,6 +56,7 @@ describe('GET /api/admin/agents/mission-control', () => {
       },
       agent_inbox: [],
       engagement_queue: [],
+      dead_letter_queue: [],
       approvals: [],
     })
   })
@@ -87,6 +88,7 @@ describe('GET /api/admin/agents/mission-control', () => {
     })
     expect(body.agent_inbox).toEqual([])
     expect(body.engagement_queue).toEqual([])
+    expect(body.dead_letter_queue).toEqual([])
     expect(mocks.buildAgentMissionControlSnapshot).toHaveBeenCalledOnce()
   })
 

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -218,6 +218,8 @@ The Daily Operating Brief and Agent Inbox are derived views, not new persistence
 - Agent Inbox items can be routed from the admin console with `POST /api/admin/agents/inbox` or from Slack with `/agent route <number-or-id>`.
 - Routing an inbox item does not mutate production data: failed/stale/cost/approval items create a read-only `agent_engagement_request`; stale standup items run the read-only War Room standup.
 
+The Dead-Letter Monitor is derived from the same traces. It lists failed and stale runs, shows whether each one has already been routed into an engagement request, and links to the source or routed trace. This gives failed automation a visible holding area without adding a second queue table or moving authority away from `agent_runs`.
+
 War Room uses `POST /api/admin/agents/war-room` with `{ command: 'standup' | 'discuss', message?: string }`.
 
 - `standup` creates `kind = agent_war_room_standup`.

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -34,7 +34,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 
 4. Reporting and hardening
    - Add all-runtime stale-run detection.
-   - Add dead-letter handling for failed runs.
+   - [x] Add derived dead-letter handling for failed and stale runs without introducing a separate queue table.
    - Add cost summaries by runtime, agent, workflow, client/project, and artifact type.
    - Keep morning review and deployment watcher outputs visible in Agent Operations.
 
@@ -55,6 +55,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 - [x] Queue affordance filters and owner/source clarity in review.
 - [x] Approval-backed execution payloads and decision metadata in review.
 - [x] n8n trace callback envelope and generic stage callback endpoint in review.
+- [x] Dead-letter monitor for failed/stale traces in review.
 
 ## Scope Guard
 

--- a/lib/agent-mission-control.test.ts
+++ b/lib/agent-mission-control.test.ts
@@ -4,7 +4,12 @@ vi.mock('@/lib/supabase', () => ({
   supabaseAdmin: null,
 }))
 
-import { buildAgentEngagementQueue, buildAgentInbox, buildDailyOperatingBrief } from '@/lib/agent-mission-control'
+import {
+  buildAgentDeadLetterQueue,
+  buildAgentEngagementQueue,
+  buildAgentInbox,
+  buildDailyOperatingBrief,
+} from '@/lib/agent-mission-control'
 
 type InboxInput = Parameters<typeof buildAgentInbox>[0]
 type MissionRunRow = InboxInput['runs'][number]
@@ -151,6 +156,48 @@ describe('Agent Mission Control helpers', () => {
       source_inbox_item_id: 'failed-run:failed',
       source_run_id: 'failed-run',
       next_action: 'Review mapped workflow health.',
+    })
+  })
+
+  it('builds a dead-letter monitor from failed and stale runs with routing state', () => {
+    const failedRun = run({
+      id: 'failed-run',
+      agent_key: 'automation-systems',
+      runtime: 'n8n',
+      status: 'failed',
+      title: 'Warm lead sync',
+      error_message: 'Webhook returned 500.',
+      started_at: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+    })
+    const routedEngagement = run({
+      id: 'routed-engagement',
+      kind: 'agent_engagement_request',
+      status: 'queued',
+      metadata: {
+        requested_agent: 'automation-systems',
+        source_run_id: 'failed-run',
+      },
+    })
+    const staleRun = run({
+      id: 'stale-run',
+      agent_key: 'chief-of-staff',
+      status: 'stale',
+      title: 'Morning review',
+      current_step: 'waiting',
+    })
+
+    const queue = buildAgentDeadLetterQueue([failedRun, routedEngagement, staleRun])
+
+    expect(queue).toHaveLength(2)
+    expect(queue.find((item) => item.run_id === 'failed-run')).toMatchObject({
+      agent_name: 'Automation Systems Agent',
+      routed: true,
+      routed_run_id: 'routed-engagement',
+      next_action: 'Review routed engagement request.',
+    })
+    expect(queue.find((item) => item.run_id === 'stale-run')).toMatchObject({
+      routed: false,
+      next_action: 'Route stale run owner from Agent Inbox.',
     })
   })
 })

--- a/lib/agent-mission-control.ts
+++ b/lib/agent-mission-control.ts
@@ -74,6 +74,23 @@ export type AgentEngagementQueueItem = {
   completed_at: string | null
 }
 
+export type AgentDeadLetterItem = {
+  run_id: string
+  agent_key: string
+  agent_name: string
+  pod: string
+  runtime: string
+  status: string
+  title: string
+  reason: string
+  age_hours: number
+  source_label: string
+  routed: boolean
+  routed_run_id: string | null
+  next_action: string
+  href: string
+}
+
 export type DailyOperatingBrief = {
   headline: string
   synthesis: string
@@ -292,6 +309,48 @@ export function buildAgentEngagementQueue(runs: AgentRunRow[]): AgentEngagementQ
     .slice(0, 8)
 }
 
+export function buildAgentDeadLetterQueue(
+  runs: AgentRunRow[],
+): AgentDeadLetterItem[] {
+  const routedBySourceRun = new Map<string, AgentRunRow>()
+  for (const run of runs) {
+    if (run.kind !== 'agent_engagement_request') continue
+    const sourceRunId = stringMetadataValue(run.metadata, 'source_run_id')
+    if (!sourceRunId || routedBySourceRun.has(sourceRunId)) continue
+    routedBySourceRun.set(sourceRunId, run)
+  }
+
+  return runs
+    .filter((run) => run.status === 'failed' || run.status === 'stale')
+    .map((run) => {
+      const agent = findAgent(requestedAgentKey(run))
+      const routedRun = routedBySourceRun.get(run.id)
+      const agentName = agent?.name ?? 'Chief of Staff Agent'
+      const reason = run.error_message ?? run.current_step ?? `${run.runtime} run is ${run.status.replace(/_/g, ' ')}.`
+      return {
+        run_id: run.id,
+        agent_key: agent?.key ?? 'chief-of-staff',
+        agent_name: agentName,
+        pod: agent ? agentPodName(agent.podKey) : 'Chief of Staff',
+        runtime: run.runtime,
+        status: run.status,
+        title: run.title,
+        reason,
+        age_hours: Number(Math.max(0, (Date.now() - new Date(run.started_at).getTime()) / 36e5).toFixed(1)),
+        source_label: sourceLabelForRun(run),
+        routed: Boolean(routedRun),
+        routed_run_id: routedRun?.id ?? null,
+        next_action: routedRun
+          ? 'Review routed engagement request.'
+          : run.status === 'stale'
+            ? 'Route stale run owner from Agent Inbox.'
+            : 'Route failure triage from Agent Inbox.',
+        href: `/admin/agents/runs/${run.id}`,
+      }
+    })
+    .slice(0, 8)
+}
+
 export function buildDailyOperatingBrief(input: {
   approvals: ApprovalRow[]
   costToday: number
@@ -408,6 +467,7 @@ export async function buildAgentMissionControlSnapshot() {
   )
   const agentInbox = buildAgentInbox({ runs, approvals, costByRun, latestStandup })
   const engagementQueue = buildAgentEngagementQueue(runs)
+  const deadLetterQueue = buildAgentDeadLetterQueue(runs)
   const costToday = Number(costs.reduce((sum, row) => sum + Number(row.amount ?? 0), 0).toFixed(4))
   const dailyBrief = buildDailyOperatingBrief({
     approvals,
@@ -462,6 +522,7 @@ export async function buildAgentMissionControlSnapshot() {
     daily_brief: dailyBrief,
     agent_inbox: agentInbox,
     engagement_queue: engagementQueue,
+    dead_letter_queue: deadLetterQueue,
     approvals: approvals.slice(0, 8),
   }
 }


### PR DESCRIPTION
## Summary

- add a derived Dead-Letter Monitor to Mission Control for failed and stale Agent Ops traces
- show whether each failed/stale trace has already been routed into a read-only engagement request
- document the trace-derived dead-letter model without adding a new queue table

## Validation

- `npm test -- --run lib/agent-mission-control.test.ts app/api/admin/agents/mission-control/route.test.ts`
- `npm run lint`
- `npx tsc --noEmit --pretty false`
- `npm run build`
- `git diff --check origin/main...origin/codex/agent-dead-letter-monitor`
- PR preview Vercel contexts: `Vercel – portfolio` and `Vercel – portfolio-staging` passed

## Notes

The panel is hidden when there are no failed or stale traces, so Mission Control stays clean during healthy periods. State remains derived from `agent_runs` and engagement metadata; no new schema or production mutation path is introduced.

Reviewed by integration captain. Ready to merge after validation.