### PR TITLE
feat: add agent cost intelligence summary

### DIFF
--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -41,6 +41,14 @@ type MissionRun = {
   cost_total: number
 }
 
+type CostSummaryGroup = {
+  key: string
+  label: string
+  amount: number
+  event_count: number
+  run_count: number
+}
+
 type MissionSnapshot = {
   generated_at: string
   status_strip: {
@@ -86,6 +94,18 @@ type MissionSnapshot = {
     updated_at: string
     signals: string[]
     next_actions: string[]
+  }
+  cost_summary: {
+    window_hours: number
+    total: number
+    event_count: number
+    linked_event_count: number
+    unlinked_event_count: number
+    by_runtime: CostSummaryGroup[]
+    by_agent: CostSummaryGroup[]
+    by_workflow: CostSummaryGroup[]
+    by_client_project: CostSummaryGroup[]
+    by_artifact_type: CostSummaryGroup[]
   }
   agent_inbox: Array<{
     id: string
@@ -396,6 +416,7 @@ export default function AgentOperationsPage() {
           </section>
 
           <DailyBriefPanel brief={snapshot?.daily_brief ?? null} loading={loading} />
+          <CostSummaryPanel summary={snapshot?.cost_summary ?? null} />
 
           <section className="mt-5 grid grid-cols-1 gap-5 xl:grid-cols-[1.2fr_0.8fr]">
             <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/25 p-4">
@@ -633,6 +654,64 @@ function DailyBriefPanel({ brief, loading }: { brief: MissionSnapshot['daily_bri
         </div>
       </div>
     </section>
+  )
+}
+
+function CostSummaryPanel({ summary }: { summary: MissionSnapshot['cost_summary'] | null }) {
+  if (!summary || summary.total <= 0 || summary.event_count === 0) return null
+
+  const topRuntime = summary.by_runtime[0]
+  const topAgent = summary.by_agent[0]
+  const topWorkflow = summary.by_workflow[0]
+  const topClientProject = summary.by_client_project[0]
+  const topArtifactType = summary.by_artifact_type[0]
+  const linkedPercent = summary.event_count
+    ? Math.round((summary.linked_event_count / summary.event_count) * 100)
+    : 0
+
+  return (
+    <section className="mt-5 rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex items-center gap-2 text-radiant-gold">
+          <CircleDollarSign size={18} />
+          <h2 className="font-semibold">Cost Intelligence</h2>
+        </div>
+        <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+          <CostChip label={`${summary.window_hours}h total`} value={`$${summary.total.toFixed(4)}`} />
+          <CostChip label="Linked traces" value={`${linkedPercent}%`} />
+          {summary.unlinked_event_count ? <CostChip label="Unlinked events" value={summary.unlinked_event_count} /> : null}
+        </div>
+      </div>
+
+      <div className="mt-3 grid grid-cols-1 gap-2 md:grid-cols-5">
+        <CostSummaryCard title="Runtime" group={topRuntime} />
+        <CostSummaryCard title="Agent" group={topAgent} />
+        <CostSummaryCard title="Workflow" group={topWorkflow} />
+        <CostSummaryCard title="Client / Project" group={topClientProject} />
+        <CostSummaryCard title="Artifact" group={topArtifactType} />
+      </div>
+    </section>
+  )
+}
+
+function CostChip({ label, value }: { label: string; value: string | number }) {
+  return (
+    <span className="rounded-full border border-silicon-slate/50 bg-black/10 px-2.5 py-1">
+      {label}: <span className="text-foreground">{value}</span>
+    </span>
+  )
+}
+
+function CostSummaryCard({ title, group }: { title: string; group: CostSummaryGroup | undefined }) {
+  return (
+    <div className="rounded-lg border border-silicon-slate/50 bg-black/10 p-3">
+      <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">{title}</p>
+      <p className="mt-2 truncate text-sm font-medium">{group?.label ?? 'No signal'}</p>
+      <p className="mt-1 text-lg font-semibold">{group ? `$${group.amount.toFixed(4)}` : '$0.0000'}</p>
+      <p className="mt-1 text-xs text-muted-foreground">
+        {group ? `${group.event_count} event(s), ${group.run_count} run(s)` : 'No linked cost events'}
+      </p>
+    </div>
   )
 }
 

--- a/app/api/admin/agents/mission-control/route.test.ts
+++ b/app/api/admin/agents/mission-control/route.test.ts
@@ -54,6 +54,18 @@ describe('GET /api/admin/agents/mission-control', () => {
         signals: ['1 active run(s)', '0 failed or stale run(s)', '0 pending approval(s)', '$0.2500 cost today'],
         next_actions: ['Run War Room standup.'],
       },
+      cost_summary: {
+        window_hours: 24,
+        total: 0.25,
+        event_count: 1,
+        linked_event_count: 1,
+        unlinked_event_count: 0,
+        by_runtime: [{ key: 'n8n', label: 'n8n', amount: 0.25, event_count: 1, run_count: 1 }],
+        by_agent: [{ key: 'automation-systems', label: 'Automation Systems Agent', amount: 0.25, event_count: 1, run_count: 1 }],
+        by_workflow: [{ key: 'WF-WRM-003', label: 'WF-WRM-003', amount: 0.25, event_count: 1, run_count: 1 }],
+        by_client_project: [{ key: 'Unassigned', label: 'Unassigned client/project', amount: 0.25, event_count: 1, run_count: 1 }],
+        by_artifact_type: [{ key: 'warm_lead', label: 'warm lead', amount: 0.25, event_count: 1, run_count: 1 }],
+      },
       agent_inbox: [],
       engagement_queue: [],
       dead_letter_queue: [],
@@ -85,6 +97,10 @@ describe('GET /api/admin/agents/mission-control', () => {
     })
     expect(body.daily_brief).toMatchObject({
       generated_from: 'current_state',
+    })
+    expect(body.cost_summary).toMatchObject({
+      total: 0.25,
+      linked_event_count: 1,
     })
     expect(body.agent_inbox).toEqual([])
     expect(body.engagement_queue).toEqual([])

--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -234,7 +234,7 @@ Out of scope:
 
 ### Phase 10: Hardening, Reporting, And Migration
 
-Status: Planned.
+Status: Partial.
 
 Goal: Make Agent Operations reliable enough to run as an operating system.
 
@@ -253,6 +253,11 @@ Out of scope:
 - Removing working legacy tables just for architectural purity.
 - Fully autonomous production remediation.
 - Cost optimization that changes vendors without a bakeoff.
+
+Current progress:
+
+- Mission Control derives a 24-hour Cost Intelligence summary from `cost_events.agent_run_id` without adding schema or copying data.
+- The first grouped view covers runtime, agent, workflow, client/project, and artifact type where trace metadata exists, with safe unassigned fallbacks.
 
 ## Cross-Phase Definition Of Done
 

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -74,6 +74,7 @@ The shared trace tables are:
 - `agent_approvals`
 
 Costs are linked through `cost_events.agent_run_id`.
+Mission Control derives the first 24-hour cost summary by runtime, agent, workflow, client/project, and artifact type from those linked cost events plus run metadata.
 
 ## Rollout Sequence
 

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -35,7 +35,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 4. Reporting and hardening
    - Add all-runtime stale-run detection.
    - [x] Add derived dead-letter handling for failed and stale runs without introducing a separate queue table.
-   - Add cost summaries by runtime, agent, workflow, client/project, and artifact type.
+   - [x] Add cost summaries by runtime, agent, workflow, client/project, and artifact type.
    - Keep morning review and deployment watcher outputs visible in Agent Operations.
 
 ## Completed Or In Review
@@ -56,6 +56,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 - [x] Approval-backed execution payloads and decision metadata in review.
 - [x] n8n trace callback envelope and generic stage callback endpoint in review.
 - [x] Dead-letter monitor for failed/stale traces in review.
+- [x] Cost Intelligence summary by runtime, agent, workflow, client/project, and artifact type in review.
 
 ## Scope Guard
 

--- a/lib/agent-mission-control.test.ts
+++ b/lib/agent-mission-control.test.ts
@@ -6,6 +6,7 @@ vi.mock('@/lib/supabase', () => ({
 
 import {
   buildAgentDeadLetterQueue,
+  buildAgentCostSummary,
   buildAgentEngagementQueue,
   buildAgentInbox,
   buildDailyOperatingBrief,
@@ -199,5 +200,59 @@ describe('Agent Mission Control helpers', () => {
       routed: false,
       next_action: 'Route stale run owner from Agent Inbox.',
     })
+  })
+
+  it('groups trace-linked costs by runtime, agent, workflow, client project, and artifact type', () => {
+    const linkedRun = run({
+      id: 'cost-run',
+      agent_key: 'automation-systems',
+      runtime: 'n8n',
+      kind: 'agent_workflow',
+      subject_label: 'Anna Berin',
+      metadata: {
+        workflow_id: 'WF-WRM-003',
+        client_project_name: 'ATAS Staging',
+        artifact_type: 'warm_lead',
+      },
+    })
+
+    const summary = buildAgentCostSummary({
+      runsById: new Map([[linkedRun.id, linkedRun]]),
+      costs: [
+        {
+          agent_run_id: 'cost-run',
+          source: 'llm_openai',
+          reference_type: 'llm_completion',
+          amount: 0.2,
+          occurred_at: now,
+          metadata: {},
+        },
+        {
+          agent_run_id: 'cost-run',
+          source: 'llm_openai',
+          reference_type: 'llm_completion',
+          amount: '0.0555',
+          occurred_at: now,
+          metadata: {},
+        },
+        {
+          agent_run_id: null,
+          source: 'other',
+          reference_type: 'manual_adjustment',
+          amount: 0.01,
+          occurred_at: now,
+          metadata: { artifact_type: 'manual_note' },
+        },
+      ],
+    })
+
+    expect(summary.total).toBe(0.2655)
+    expect(summary.linked_event_count).toBe(2)
+    expect(summary.unlinked_event_count).toBe(1)
+    expect(summary.by_runtime[0]).toMatchObject({ key: 'n8n', amount: 0.2555, run_count: 1 })
+    expect(summary.by_agent[0]).toMatchObject({ key: 'automation-systems', label: 'Automation Systems Agent' })
+    expect(summary.by_workflow[0]).toMatchObject({ key: 'WF-WRM-003', label: 'WF-WRM-003' })
+    expect(summary.by_client_project[0]).toMatchObject({ key: 'ATAS Staging', label: 'ATAS Staging' })
+    expect(summary.by_artifact_type[0]).toMatchObject({ key: 'warm_lead', label: 'warm lead' })
   })
 })

--- a/lib/agent-mission-control.ts
+++ b/lib/agent-mission-control.ts
@@ -19,8 +19,11 @@ type AgentRunRow = {
 
 type CostEventRow = {
   agent_run_id: string | null
+  source: string | null
+  reference_type: string | null
   amount: number | string | null
   occurred_at: string
+  metadata: Record<string, unknown> | null
 }
 
 type ApprovalRow = {
@@ -101,6 +104,27 @@ export type DailyOperatingBrief = {
   next_actions: string[]
 }
 
+export type AgentCostGroup = {
+  key: string
+  label: string
+  amount: number
+  event_count: number
+  run_count: number
+}
+
+export type AgentCostSummary = {
+  window_hours: number
+  total: number
+  event_count: number
+  linked_event_count: number
+  unlinked_event_count: number
+  by_runtime: AgentCostGroup[]
+  by_agent: AgentCostGroup[]
+  by_workflow: AgentCostGroup[]
+  by_client_project: AgentCostGroup[]
+  by_artifact_type: AgentCostGroup[]
+}
+
 function sinceHours(hours: number) {
   return new Date(Date.now() - hours * 60 * 60 * 1000).toISOString()
 }
@@ -168,6 +192,163 @@ function readableLabel(value: string | null | undefined) {
     .replace(/_/g, ' ')
     .replace(/\s+/g, ' ')
     .trim()
+}
+
+function stableMetadataValue(
+  metadata: Record<string, unknown> | null | undefined,
+  keys: string[],
+) {
+  for (const key of keys) {
+    const value = metadata?.[key]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+    if (typeof value === 'number' && Number.isFinite(value)) return String(value)
+  }
+  return null
+}
+
+function labelFromKey(value: string | null | undefined, fallback: string) {
+  return readableLabel(value) ?? fallback
+}
+
+function costAmount(value: number | string | null | undefined) {
+  const amount = Number(value ?? 0)
+  return Number.isFinite(amount) ? amount : 0
+}
+
+function summarizeCostGroups(groups: Map<string, AgentCostGroup & { runIds: Set<string> }>) {
+  return Array.from(groups.values())
+    .map(({ runIds, ...group }) => ({
+      ...group,
+      amount: Number(group.amount.toFixed(4)),
+      run_count: runIds.size,
+    }))
+    .sort((a, b) => b.amount - a.amount || a.label.localeCompare(b.label))
+    .slice(0, 5)
+}
+
+function addCostGroup(
+  groups: Map<string, AgentCostGroup & { runIds: Set<string> }>,
+  key: string,
+  label: string,
+  amount: number,
+  runId: string | null,
+) {
+  const existing = groups.get(key) ?? {
+    key,
+    label,
+    amount: 0,
+    event_count: 0,
+    run_count: 0,
+    runIds: new Set<string>(),
+  }
+
+  existing.amount += amount
+  existing.event_count += 1
+  if (runId) existing.runIds.add(runId)
+  groups.set(key, existing)
+}
+
+function workflowKeyForCost(run: AgentRunRow | undefined, cost: CostEventRow) {
+  const workflow =
+    stableMetadataValue(run?.metadata, ['workflow_id', 'workflow', 'n8n_workflow_id', 'source_workflow']) ??
+    stableMetadataValue(cost.metadata, ['workflow_id', 'workflow', 'n8n_workflow_id', 'source_workflow']) ??
+    run?.kind ??
+    cost.reference_type ??
+    cost.source
+
+  return {
+    key: workflow ?? 'unspecified_workflow',
+    label: labelFromKey(workflow, 'Unspecified workflow'),
+  }
+}
+
+function clientProjectKeyForCost(run: AgentRunRow | undefined, cost: CostEventRow) {
+  const clientProject =
+    stableMetadataValue(run?.metadata, [
+      'client_project_name',
+      'project_name',
+      'client_name',
+      'client_project_id',
+      'project_id',
+      'client_id',
+    ]) ??
+    stableMetadataValue(cost.metadata, [
+      'client_project_name',
+      'project_name',
+      'client_name',
+      'client_project_id',
+      'project_id',
+      'client_id',
+    ]) ??
+    run?.subject_label
+
+  return {
+    key: clientProject ?? 'unassigned_client_project',
+    label: labelFromKey(clientProject, 'Unassigned client/project'),
+  }
+}
+
+function artifactTypeKeyForCost(run: AgentRunRow | undefined, cost: CostEventRow) {
+  const artifactType =
+    stableMetadataValue(cost.metadata, ['artifact_type', 'artifactType', 'output_type', 'content_type']) ??
+    stableMetadataValue(run?.metadata, ['artifact_type', 'artifactType', 'output_type', 'content_type']) ??
+    cost.reference_type ??
+    run?.kind ??
+    cost.source
+
+  return {
+    key: artifactType ?? 'unspecified_artifact',
+    label: labelFromKey(artifactType, 'Unspecified artifact'),
+  }
+}
+
+export function buildAgentCostSummary(input: {
+  costs: CostEventRow[]
+  runsById: Map<string, AgentRunRow>
+  windowHours?: number
+}): AgentCostSummary {
+  const runtimeGroups = new Map<string, AgentCostGroup & { runIds: Set<string> }>()
+  const agentGroups = new Map<string, AgentCostGroup & { runIds: Set<string> }>()
+  const workflowGroups = new Map<string, AgentCostGroup & { runIds: Set<string> }>()
+  const clientProjectGroups = new Map<string, AgentCostGroup & { runIds: Set<string> }>()
+  const artifactTypeGroups = new Map<string, AgentCostGroup & { runIds: Set<string> }>()
+
+  let total = 0
+  let linkedEventCount = 0
+
+  for (const cost of input.costs) {
+    const amount = costAmount(cost.amount)
+    total += amount
+
+    const run = cost.agent_run_id ? input.runsById.get(cost.agent_run_id) : undefined
+    if (cost.agent_run_id) linkedEventCount += 1
+
+    const agentKey = run ? requestedAgentKey(run) : null
+    const agent = agentKey ? findAgent(agentKey) : null
+    const workflow = workflowKeyForCost(run, cost)
+    const clientProject = clientProjectKeyForCost(run, cost)
+    const artifactType = artifactTypeKeyForCost(run, cost)
+    const runId = cost.agent_run_id ?? null
+
+    addCostGroup(runtimeGroups, run?.runtime ?? 'unlinked', labelFromKey(run?.runtime, 'Unlinked'), amount, runId)
+    addCostGroup(agentGroups, agent?.key ?? 'unassigned_agent', agent?.name ?? 'Unassigned agent', amount, runId)
+    addCostGroup(workflowGroups, workflow.key, workflow.label, amount, runId)
+    addCostGroup(clientProjectGroups, clientProject.key, clientProject.label, amount, runId)
+    addCostGroup(artifactTypeGroups, artifactType.key, artifactType.label, amount, runId)
+  }
+
+  return {
+    window_hours: input.windowHours ?? 24,
+    total: Number(total.toFixed(4)),
+    event_count: input.costs.length,
+    linked_event_count: linkedEventCount,
+    unlinked_event_count: input.costs.length - linkedEventCount,
+    by_runtime: summarizeCostGroups(runtimeGroups),
+    by_agent: summarizeCostGroups(agentGroups),
+    by_workflow: summarizeCostGroups(workflowGroups),
+    by_client_project: summarizeCostGroups(clientProjectGroups),
+    by_artifact_type: summarizeCostGroups(artifactTypeGroups),
+  }
 }
 
 function sourceLabelForRun(run: AgentRunRow) {
@@ -412,7 +593,7 @@ export async function buildAgentMissionControlSnapshot() {
       .limit(50),
     db
       .from('cost_events')
-      .select('agent_run_id, amount, occurred_at')
+      .select('agent_run_id, source, reference_type, amount, occurred_at, metadata')
       .gte('occurred_at', since)
       .limit(500),
     db
@@ -439,6 +620,7 @@ export async function buildAgentMissionControlSnapshot() {
   const approvals = (approvalsRes.data ?? []) as ApprovalRow[]
   const events = (eventsRes.data ?? []) as EventRow[]
   const costByRun = new Map<string, number>()
+  const runsById = new Map(runs.map((run) => [run.id, run]))
 
   for (const row of costs) {
     if (!row.agent_run_id) continue
@@ -469,6 +651,7 @@ export async function buildAgentMissionControlSnapshot() {
   const engagementQueue = buildAgentEngagementQueue(runs)
   const deadLetterQueue = buildAgentDeadLetterQueue(runs)
   const costToday = Number(costs.reduce((sum, row) => sum + Number(row.amount ?? 0), 0).toFixed(4))
+  const costSummary = buildAgentCostSummary({ costs, runsById, windowHours: 24 })
   const dailyBrief = buildDailyOperatingBrief({
     approvals,
     costToday,
@@ -520,6 +703,7 @@ export async function buildAgentMissionControlSnapshot() {
     latest_events: events,
     latest_standup: latestStandup ? summarizeRun(latestStandup, costByRun) : null,
     daily_brief: dailyBrief,
+    cost_summary: costSummary,
     agent_inbox: agentInbox,
     engagement_queue: engagementQueue,
     dead_letter_queue: deadLetterQueue,


### PR DESCRIPTION
## Summary

- add a 24-hour Mission Control cost summary grouped by runtime, agent, workflow, client/project, and artifact type
- render a compact Cost Intelligence panel only when cost events exist
- update Agent Operations roadmap/task docs for the Phase 10 reporting slice

## Validation

- `npm test -- --run lib/agent-mission-control.test.ts app/api/admin/agents/mission-control/route.test.ts`
- `npx tsc --noEmit --pretty false`
- `npm run lint`
- `git diff --check origin/main...origin/codex/agent-cost-summary`
- `npm run build`
- PR preview Vercel contexts: `Vercel – portfolio` and `Vercel – portfolio-staging` passed

## Notes

- No schema changes.
- No production customer data is copied into non-prod.
- Cost Intelligence is derived from `cost_events.agent_run_id` plus run metadata and uses safe fallback labels when metadata is missing.

Reviewed by integration captain. Ready to merge after validation.