### PR TITLE
feat: surface agent ops operating signals

### DIFF
--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -107,6 +107,17 @@ type MissionSnapshot = {
     by_client_project: CostSummaryGroup[]
     by_artifact_type: CostSummaryGroup[]
   }
+  operating_signals: Array<{
+    run_id: string
+    kind: 'morning_review' | 'deployment_watch'
+    title: string
+    status: string
+    signal: string
+    summary: string
+    updated_at: string
+    href: string
+    details: string[]
+  }>
   agent_inbox: Array<{
     id: string
     priority: 'high' | 'medium' | 'low'
@@ -417,6 +428,7 @@ export default function AgentOperationsPage() {
 
           <DailyBriefPanel brief={snapshot?.daily_brief ?? null} loading={loading} />
           <CostSummaryPanel summary={snapshot?.cost_summary ?? null} />
+          <OperatingSignalsPanel signals={snapshot?.operating_signals ?? []} />
 
           <section className="mt-5 grid grid-cols-1 gap-5 xl:grid-cols-[1.2fr_0.8fr]">
             <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/25 p-4">
@@ -712,6 +724,48 @@ function CostSummaryCard({ title, group }: { title: string; group: CostSummaryGr
         {group ? `${group.event_count} event(s), ${group.run_count} run(s)` : 'No linked cost events'}
       </p>
     </div>
+  )
+}
+
+function OperatingSignalsPanel({ signals }: { signals: MissionSnapshot['operating_signals'] }) {
+  if (!signals.length) return null
+
+  return (
+    <section className="mt-5 grid grid-cols-1 gap-3 lg:grid-cols-2">
+      {signals.map((signal) => {
+        const isHealthy = signal.status === 'completed' || signal.signal.toLowerCase().includes('success')
+        return (
+          <Link
+            key={`${signal.kind}-${signal.run_id}`}
+            href={signal.href}
+            className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4 hover:border-radiant-gold/50"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2 text-radiant-gold">
+                  {isHealthy ? <CheckCircle2 size={18} /> : <AlertTriangle size={18} />}
+                  <h2 className="font-semibold">{signal.title}</h2>
+                </div>
+                <p className="mt-2 text-lg font-semibold">{signal.signal}</p>
+                <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">{signal.summary}</p>
+              </div>
+              <span className="shrink-0 rounded-full border border-silicon-slate/50 bg-black/10 px-2.5 py-1 text-xs text-muted-foreground">
+                {formatTime(signal.updated_at)}
+              </span>
+            </div>
+            {signal.details.length ? (
+              <div className="mt-3 flex flex-wrap gap-2">
+                {signal.details.slice(0, 3).map((detail) => (
+                  <span key={detail} className="rounded-full border border-silicon-slate/50 bg-black/10 px-2.5 py-1 text-xs text-muted-foreground">
+                    {detail}
+                  </span>
+                ))}
+              </div>
+            ) : null}
+          </Link>
+        )
+      })}
+    </section>
   )
 }
 

--- a/app/api/admin/agents/mission-control/route.test.ts
+++ b/app/api/admin/agents/mission-control/route.test.ts
@@ -66,6 +66,7 @@ describe('GET /api/admin/agents/mission-control', () => {
         by_client_project: [{ key: 'Unassigned', label: 'Unassigned client/project', amount: 0.25, event_count: 1, run_count: 1 }],
         by_artifact_type: [{ key: 'warm_lead', label: 'warm lead', amount: 0.25, event_count: 1, run_count: 1 }],
       },
+      operating_signals: [],
       agent_inbox: [],
       engagement_queue: [],
       dead_letter_queue: [],
@@ -102,6 +103,7 @@ describe('GET /api/admin/agents/mission-control', () => {
       total: 0.25,
       linked_event_count: 1,
     })
+    expect(body.operating_signals).toEqual([])
     expect(body.agent_inbox).toEqual([])
     expect(body.engagement_queue).toEqual([])
     expect(body.dead_letter_queue).toEqual([])

--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -258,6 +258,8 @@ Current progress:
 
 - Mission Control derives a 24-hour Cost Intelligence summary from `cost_events.agent_run_id` without adding schema or copying data.
 - The first grouped view covers runtime, agent, workflow, client/project, and artifact type where trace metadata exists, with safe unassigned fallbacks.
+- Mission Control surfaces the latest `agent_ops_morning_review` and `agent_ops_deployment_watch` traces as Operating Signals.
+- The deployment watcher supports `--trace` so integration-captain and autopilot runs write a visible Agent Ops run/artifact.
 
 ## Cross-Phase Definition Of Done
 

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -163,6 +163,15 @@ This keeps OpenCode/OpenClaw out of production automation until installation, au
 
 Use `POST /api/admin/agents/runs/stale-sweep` or the **Sweep stale** button on `/admin/agents/runs` to mark queued/running runs as `stale` when they pass `stale_after` or the default active-run threshold. Runs waiting for approval are intentionally excluded so human checkpoints do not auto-expire as infrastructure failures.
 
+## Operating Signals
+
+Mission Control surfaces the latest morning review and deployment watcher traces as compact Operating Signals:
+
+- `agent_ops_morning_review` shows overall health, warning count, stale-run cleanup, and Slack notification state.
+- `agent_ops_deployment_watch` shows the latest Vercel deployment watcher state, required context states, and guidance.
+
+Use `npm run deploy:watch -- --ref <sha-or-branch> --trace` for integration-captain and autopilot deployment checks. The `--trace` flag records the final watcher output as an Agent Operations run and artifact. It does not change deployments and writes only to the shared Agent Ops trace tables.
+
 ## Agent Ops Morning Review
 
 Use `POST /api/cron/agent-ops-morning-review` with `Authorization: Bearer N8N_INGEST_SECRET` to run the daily no-human-in-the-loop review. The route:

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -36,7 +36,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
    - Add all-runtime stale-run detection.
    - [x] Add derived dead-letter handling for failed and stale runs without introducing a separate queue table.
    - [x] Add cost summaries by runtime, agent, workflow, client/project, and artifact type.
-   - Keep morning review and deployment watcher outputs visible in Agent Operations.
+   - [x] Keep morning review and deployment watcher outputs visible in Agent Operations.
 
 ## Completed Or In Review
 
@@ -57,6 +57,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 - [x] n8n trace callback envelope and generic stage callback endpoint in review.
 - [x] Dead-letter monitor for failed/stale traces in review.
 - [x] Cost Intelligence summary by runtime, agent, workflow, client/project, and artifact type in review.
+- [x] Operating Signals for morning review and deployment watcher traces in review.
 
 ## Scope Guard
 

--- a/docs/vercel-deployment-runbook.md
+++ b/docs/vercel-deployment-runbook.md
@@ -12,10 +12,12 @@ Portfolio deployment is only complete when both contexts pass:
 Run the watcher before merge for the PR head SHA and after merge for the merge SHA or `main`.
 
 ```bash
-npm run deploy:watch:once -- --ref <pr-head-sha>
-npm run deploy:watch -- --ref <merge-sha> --timeout 900 --interval 30
-npm run deploy:watch -- --ref main --timeout 900 --interval 30
+npm run deploy:watch:once -- --ref <pr-head-sha> --trace
+npm run deploy:watch -- --ref <merge-sha> --timeout 900 --interval 30 --trace
+npm run deploy:watch -- --ref main --timeout 900 --interval 30 --trace
 ```
+
+Use `--trace` for integration-captain and autopilot runs so the deployment watcher output appears in Agent Operations as an `agent_ops_deployment_watch` trace and artifact. Omit `--trace` only for scratch/local checks that should not write operational history.
 
 ## Decision Thresholds
 

--- a/lib/agent-mission-control.test.ts
+++ b/lib/agent-mission-control.test.ts
@@ -9,6 +9,7 @@ import {
   buildAgentCostSummary,
   buildAgentEngagementQueue,
   buildAgentInbox,
+  buildAgentOperatingSignals,
   buildDailyOperatingBrief,
 } from '@/lib/agent-mission-control'
 
@@ -254,5 +255,49 @@ describe('Agent Mission Control helpers', () => {
     expect(summary.by_workflow[0]).toMatchObject({ key: 'WF-WRM-003', label: 'WF-WRM-003' })
     expect(summary.by_client_project[0]).toMatchObject({ key: 'ATAS Staging', label: 'ATAS Staging' })
     expect(summary.by_artifact_type[0]).toMatchObject({ key: 'warm_lead', label: 'warm lead' })
+  })
+
+  it('surfaces morning review and deployment watcher traces as operating signals', () => {
+    const signals = buildAgentOperatingSignals([
+      run({
+        id: 'morning-run',
+        kind: 'agent_ops_morning_review',
+        status: 'completed',
+        current_step: 'Agent Ops morning review ready',
+        outcome: {
+          overall: 'ok',
+          warning_count: 0,
+          stale_marked: 1,
+          slack_notified: true,
+        },
+      }),
+      run({
+        id: 'deploy-run',
+        kind: 'agent_ops_deployment_watch',
+        status: 'completed',
+        outcome: {
+          deployment_state: 'success',
+          ref: 'main',
+          contexts: [
+            { context: 'Vercel – portfolio', state: 'success' },
+            { context: 'Vercel – portfolio-staging', state: 'success' },
+          ],
+          guidance: ['guidance=ready; both required Vercel contexts passed'],
+        },
+      }),
+    ])
+
+    expect(signals).toHaveLength(2)
+    expect(signals[0]).toMatchObject({
+      kind: 'morning_review',
+      signal: 'Overall: ok',
+      details: ['0 warning(s)', '1 stale run(s) marked', 'Slack notified'],
+    })
+    expect(signals[1]).toMatchObject({
+      kind: 'deployment_watch',
+      signal: 'Deployments: success',
+      summary: 'Latest watcher snapshot for main.',
+    })
+    expect(signals[1].details).toContain('Vercel – portfolio-staging: success')
   })
 })

--- a/lib/agent-mission-control.ts
+++ b/lib/agent-mission-control.ts
@@ -125,6 +125,18 @@ export type AgentCostSummary = {
   by_artifact_type: AgentCostGroup[]
 }
 
+export type AgentOperatingSignal = {
+  run_id: string
+  kind: 'morning_review' | 'deployment_watch'
+  title: string
+  status: string
+  signal: string
+  summary: string
+  updated_at: string
+  href: string
+  details: string[]
+}
+
 function sinceHours(hours: number) {
   return new Date(Date.now() - hours * 60 * 60 * 1000).toISOString()
 }
@@ -349,6 +361,85 @@ export function buildAgentCostSummary(input: {
     by_client_project: summarizeCostGroups(clientProjectGroups),
     by_artifact_type: summarizeCostGroups(artifactTypeGroups),
   }
+}
+
+export function buildAgentOperatingSignals(runs: AgentRunRow[]): AgentOperatingSignal[] {
+  const latestMorningReview = runs.find((run) => run.kind === 'agent_ops_morning_review')
+  const latestDeploymentWatch = runs.find((run) => run.kind === 'agent_ops_deployment_watch')
+  const signals: AgentOperatingSignal[] = []
+
+  if (latestMorningReview) {
+    const overall =
+      typeof latestMorningReview.outcome?.overall === 'string'
+        ? latestMorningReview.outcome.overall
+        : latestMorningReview.status
+    const warningCount =
+      typeof latestMorningReview.outcome?.warning_count === 'number'
+        ? latestMorningReview.outcome.warning_count
+        : null
+    const staleMarked =
+      typeof latestMorningReview.outcome?.stale_marked === 'number'
+        ? latestMorningReview.outcome.stale_marked
+        : null
+    const slackNotified =
+      typeof latestMorningReview.outcome?.slack_notified === 'boolean'
+        ? latestMorningReview.outcome.slack_notified
+        : null
+
+    signals.push({
+      run_id: latestMorningReview.id,
+      kind: 'morning_review',
+      title: 'Morning Review',
+      status: latestMorningReview.status,
+      signal: `Overall: ${overall}`,
+      summary: latestMorningReview.error_message ?? latestMorningReview.current_step ?? latestMorningReview.title,
+      updated_at: latestMorningReview.completed_at ?? latestMorningReview.started_at,
+      href: `/admin/agents/runs/${latestMorningReview.id}`,
+      details: [
+        warningCount === null ? null : `${warningCount} warning(s)`,
+        staleMarked === null ? null : `${staleMarked} stale run(s) marked`,
+        slackNotified === null ? null : slackNotified ? 'Slack notified' : 'Slack skipped',
+      ].filter((detail): detail is string => Boolean(detail)),
+    })
+  }
+
+  if (latestDeploymentWatch) {
+    const deploymentState =
+      typeof latestDeploymentWatch.outcome?.deployment_state === 'string'
+        ? latestDeploymentWatch.outcome.deployment_state
+        : latestDeploymentWatch.status
+    const ref =
+      typeof latestDeploymentWatch.outcome?.ref === 'string'
+        ? latestDeploymentWatch.outcome.ref
+        : stringMetadataValue(latestDeploymentWatch.metadata, 'ref')
+    const guidance = Array.isArray(latestDeploymentWatch.outcome?.guidance)
+      ? latestDeploymentWatch.outcome.guidance.filter((item): item is string => typeof item === 'string')
+      : []
+    const contexts = Array.isArray(latestDeploymentWatch.outcome?.contexts)
+      ? latestDeploymentWatch.outcome.contexts
+          .map((item) => {
+            if (!item || typeof item !== 'object') return null
+            const context = 'context' in item && typeof item.context === 'string' ? item.context : null
+            const state = 'state' in item && typeof item.state === 'string' ? item.state : null
+            return context && state ? `${context}: ${state}` : null
+          })
+          .filter((detail): detail is string => Boolean(detail))
+      : []
+
+    signals.push({
+      run_id: latestDeploymentWatch.id,
+      kind: 'deployment_watch',
+      title: 'Deployment Watcher',
+      status: latestDeploymentWatch.status,
+      signal: `Deployments: ${deploymentState}`,
+      summary: ref ? `Latest watcher snapshot for ${ref}.` : latestDeploymentWatch.current_step ?? latestDeploymentWatch.title,
+      updated_at: latestDeploymentWatch.completed_at ?? latestDeploymentWatch.started_at,
+      href: `/admin/agents/runs/${latestDeploymentWatch.id}`,
+      details: [...contexts.slice(0, 2), ...guidance.slice(0, 1)],
+    })
+  }
+
+  return signals
 }
 
 function sourceLabelForRun(run: AgentRunRow) {
@@ -650,6 +741,7 @@ export async function buildAgentMissionControlSnapshot() {
   const agentInbox = buildAgentInbox({ runs, approvals, costByRun, latestStandup })
   const engagementQueue = buildAgentEngagementQueue(runs)
   const deadLetterQueue = buildAgentDeadLetterQueue(runs)
+  const operatingSignals = buildAgentOperatingSignals(runs)
   const costToday = Number(costs.reduce((sum, row) => sum + Number(row.amount ?? 0), 0).toFixed(4))
   const costSummary = buildAgentCostSummary({ costs, runsById, windowHours: 24 })
   const dailyBrief = buildDailyOperatingBrief({
@@ -704,6 +796,7 @@ export async function buildAgentMissionControlSnapshot() {
     latest_standup: latestStandup ? summarizeRun(latestStandup, costByRun) : null,
     daily_brief: dailyBrief,
     cost_summary: costSummary,
+    operating_signals: operatingSignals,
     agent_inbox: agentInbox,
     engagement_queue: engagementQueue,
     dead_letter_queue: deadLetterQueue,

--- a/lib/vercel-deployment-watch.test.ts
+++ b/lib/vercel-deployment-watch.test.ts
@@ -87,6 +87,7 @@ describe('parseDeploymentWatchArgs', () => {
       '--contexts',
       'A,B',
       '--once',
+      '--trace',
     ])
 
     expect(options.ref).toBe('abc123')
@@ -94,6 +95,7 @@ describe('parseDeploymentWatchArgs', () => {
     expect(options.intervalSeconds).toBe(5)
     expect(options.contexts).toEqual(['A', 'B'])
     expect(options.once).toBe(true)
+    expect(options.trace).toBe(true)
   })
 })
 

--- a/lib/vercel-deployment-watch.ts
+++ b/lib/vercel-deployment-watch.ts
@@ -43,6 +43,7 @@ export type DeploymentWatchOptions = {
   timeoutSeconds: number
   intervalSeconds: number
   once: boolean
+  trace: boolean
 }
 
 const DEFAULT_OPTIONS: DeploymentWatchOptions = {
@@ -53,6 +54,7 @@ const DEFAULT_OPTIONS: DeploymentWatchOptions = {
   timeoutSeconds: 900,
   intervalSeconds: 30,
   once: false,
+  trace: false,
 }
 
 function normalizeState(state: string | undefined): DeploymentWatchState {
@@ -158,6 +160,8 @@ export function parseDeploymentWatchArgs(argv: string[]): DeploymentWatchOptions
       index += 1
     } else if (arg === '--once') {
       options.once = true
+    } else if (arg === '--trace') {
+      options.trace = true
     } else if (arg === '--help' || arg === '-h') {
       throw new Error('HELP_REQUESTED')
     }

--- a/scripts/vercel-deployment-watch.ts
+++ b/scripts/vercel-deployment-watch.ts
@@ -5,8 +5,18 @@ import {
   getDeploymentWatchGuidance,
   parseDeploymentWatchArgs,
   summarizeDeploymentStatus,
+  type DeploymentWatchSummary,
   type GitHubCombinedStatus,
 } from '../lib/vercel-deployment-watch'
+
+type AgentRunModule = typeof import('../lib/agent-run')
+
+let agentRunModulePromise: Promise<AgentRunModule> | null = null
+
+function loadAgentRunModule() {
+  agentRunModulePromise ??= import('../lib/agent-run')
+  return agentRunModulePromise
+}
 
 function usage(): string {
   return `Usage:
@@ -21,6 +31,7 @@ Options:
   --timeout <seconds>         Max wait time. Defaults to 900.
   --interval <seconds>        Poll interval. Defaults to 30.
   --once                      Print one status snapshot and exit.
+  --trace                     Write the final watcher output to Agent Operations.
   --help                      Show this help.
 
 Exit codes:
@@ -49,6 +60,137 @@ function fetchCombinedStatus(owner: string, repo: string, ref: string): GitHubCo
   return JSON.parse(result.stdout) as GitHubCombinedStatus
 }
 
+async function startTraceRun(options: ReturnType<typeof parseDeploymentWatchArgs>) {
+  if (!options.trace) return null
+
+  try {
+    const { startAgentRun } = await loadAgentRunModule()
+    const run = await startAgentRun({
+      agentKey: 'engineering-copilot',
+      runtime: 'manual',
+      kind: 'agent_ops_deployment_watch',
+      title: `Watch Vercel deployment contexts for ${options.ref}`,
+      subject: { type: 'deployment', id: options.ref, label: `${options.owner}/${options.repo}` },
+      triggerSource: 'vercel_deployment_watch_script',
+      currentStep: 'Watching Vercel deployment contexts',
+      metadata: {
+        ref: options.ref,
+        owner: options.owner,
+        repo: options.repo,
+        contexts: options.contexts,
+        timeout_seconds: options.timeoutSeconds,
+        interval_seconds: options.intervalSeconds,
+        once: options.once,
+      },
+    })
+
+    return run.id
+  } catch (error) {
+    console.warn(
+      `[deploy:watch] Agent Ops trace unavailable: ${error instanceof Error ? error.message : String(error)}`,
+    )
+    return null
+  }
+}
+
+async function recordTraceAttempt(input: {
+  runId: string | null
+  attempt: number
+  summary: DeploymentWatchSummary
+  guidance: string[]
+}) {
+  if (!input.runId) return
+
+  const { recordAgentStep } = await loadAgentRunModule()
+  await recordAgentStep({
+    runId: input.runId,
+    stepKey: `deployment_watch_attempt_${input.attempt}`,
+    name: `Deployment watch attempt ${input.attempt}`,
+    status: input.summary.state === 'failed' ? 'failed' : 'completed',
+    outputSummary: `Deployment state: ${input.summary.state}`,
+    metadata: {
+      deployment_state: input.summary.state,
+      contexts: input.summary.contexts,
+      guidance: input.guidance,
+    },
+    idempotencyKey: `${input.runId}:attempt:${input.attempt}`,
+  }).catch((error) => {
+    console.warn(
+      `[deploy:watch] Could not record trace attempt: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  })
+}
+
+async function finishTrace(input: {
+  runId: string | null
+  options: ReturnType<typeof parseDeploymentWatchArgs>
+  summary: DeploymentWatchSummary | null
+  guidance: string[]
+  attempts: number
+  exitStatus: 'completed' | 'failed' | 'cancelled' | 'stale'
+  errorMessage?: string | null
+}) {
+  if (!input.runId || !input.summary) return
+
+  const { attachAgentArtifact, endAgentRun } = await loadAgentRunModule()
+  const artifactMarkdown = [
+    '# Vercel Deployment Watch',
+    '',
+    `Ref: ${input.options.ref}`,
+    `Repo: ${input.options.owner}/${input.options.repo}`,
+    `State: ${input.summary.state}`,
+    `Attempts: ${input.attempts}`,
+    '',
+    '## Contexts',
+    '',
+    ...input.summary.contexts.map((context) => `- ${context.context}: ${context.state}`),
+    '',
+    '## Guidance',
+    '',
+    ...input.guidance.map((item) => `- ${item}`),
+  ].join('\n')
+
+  await attachAgentArtifact({
+    runId: input.runId,
+    artifactType: 'agent_ops_deployment_watch',
+    title: `Vercel deployment watch - ${input.summary.state}`,
+    refType: 'git_ref',
+    refId: input.options.ref,
+    metadata: {
+      summary_markdown: artifactMarkdown,
+      deployment_state: input.summary.state,
+      contexts: input.summary.contexts,
+      guidance: input.guidance,
+      attempts: input.attempts,
+    },
+    idempotencyKey: `${input.runId}:artifact:deployment-watch`,
+  }).catch((error) => {
+    console.warn(
+      `[deploy:watch] Could not attach trace artifact: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  })
+
+  await endAgentRun({
+    runId: input.runId,
+    status: input.exitStatus,
+    currentStep: `Deployment watch ${input.summary.state}`,
+    errorMessage: input.errorMessage ?? null,
+    outcome: {
+      deployment_state: input.summary.state,
+      ref: input.options.ref,
+      owner: input.options.owner,
+      repo: input.options.repo,
+      contexts: input.summary.contexts,
+      guidance: input.guidance,
+      attempts: input.attempts,
+    },
+  }).catch((error) => {
+    console.warn(
+      `[deploy:watch] Could not finish trace run: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  })
+}
+
 async function main(): Promise<void> {
   let options
 
@@ -69,6 +211,9 @@ async function main(): Promise<void> {
   const startedAt = Date.now()
   const timeoutMs = options.timeoutSeconds * 1000
   let attempt = 0
+  let traceRunId: string | null = await startTraceRun(options)
+  let latestSummary: DeploymentWatchSummary | null = null
+  let latestGuidance: string[] = []
 
   while (true) {
     attempt += 1
@@ -76,31 +221,76 @@ async function main(): Promise<void> {
     try {
       const combinedStatus = fetchCombinedStatus(options.owner, options.repo, options.ref)
       const summary = summarizeDeploymentStatus(combinedStatus, options.contexts)
+      const guidance = getDeploymentWatchGuidance(summary)
+      latestSummary = summary
+      latestGuidance = guidance
 
       console.log(`\n[attempt ${attempt}] ${new Date().toISOString()}`)
       console.log(formatDeploymentWatchSummary(summary))
-      console.log(getDeploymentWatchGuidance(summary).join('\n'))
+      console.log(guidance.join('\n'))
+      await recordTraceAttempt({ runId: traceRunId, attempt, summary, guidance })
 
       if (summary.state === 'success') {
+        await finishTrace({
+          runId: traceRunId,
+          options,
+          summary,
+          guidance,
+          attempts: attempt,
+          exitStatus: 'completed',
+        })
         process.exit(0)
       }
 
       if (summary.state === 'failed') {
+        await finishTrace({
+          runId: traceRunId,
+          options,
+          summary,
+          guidance,
+          attempts: attempt,
+          exitStatus: 'failed',
+          errorMessage: 'A required Vercel deployment context failed.',
+        })
         process.exit(1)
       }
 
       if (options.once) {
+        await finishTrace({
+          runId: traceRunId,
+          options,
+          summary,
+          guidance,
+          attempts: attempt,
+          exitStatus: 'completed',
+        })
         process.exit(2)
       }
     } catch (error) {
       console.error(error instanceof Error ? error.message : error)
+      if (traceRunId) {
+        const { markAgentRunFailed } = await loadAgentRunModule()
+        await markAgentRunFailed(
+          traceRunId,
+          error instanceof Error ? error.message : 'Deployment watch failed',
+          { ref: options.ref, owner: options.owner, repo: options.repo },
+        ).catch(() => {})
+      }
       process.exit(1)
     }
 
     if (Date.now() - startedAt >= timeoutMs) {
-      console.error(
-        `Timed out after ${options.timeoutSeconds}s while waiting for Vercel deployment contexts.`
-      )
+      const message = `Timed out after ${options.timeoutSeconds}s while waiting for Vercel deployment contexts.`
+      console.error(message)
+      await finishTrace({
+        runId: traceRunId,
+        options,
+        summary: latestSummary,
+        guidance: latestGuidance,
+        attempts: attempt,
+        exitStatus: 'failed',
+        errorMessage: message,
+      })
       process.exit(2)
     }
 


### PR DESCRIPTION
## Summary
- surface latest morning review and deployment watcher traces as Mission Control Operating Signals
- add deployment watcher `--trace` mode that writes an Agent Ops run/artifact only when explicitly requested
- document traced watcher usage for integration-captain and autopilot deployment checks

## Validation
- npm test -- --run lib/agent-mission-control.test.ts lib/vercel-deployment-watch.test.ts app/api/admin/agents/mission-control/route.test.ts
- npm run lint -- --file app/admin/agents/page.tsx --file app/api/admin/agents/mission-control/route.test.ts --file lib/agent-mission-control.ts --file lib/agent-mission-control.test.ts --file lib/vercel-deployment-watch.ts --file lib/vercel-deployment-watch.test.ts --file scripts/vercel-deployment-watch.ts
- npm run build
- npm run deploy:watch:once -- --ref 03c1e5d
- local smoke: MOCK_N8N=true N8N_DISABLE_OUTBOUND=true npm run dev -- --port 3002, then curl /admin/agents and /api/health

## Notes
- no schema changes
- no production customer data copied into non-production
- merge remains owned by Integration Captain