### PR TITLE
feat: add RAG knowledge governance manifest

### DIFF
--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -118,6 +118,25 @@ type MissionSnapshot = {
     href: string
     details: string[]
   }>
+  knowledge_governance: {
+    targetIndex: string
+    legacyIndex: string
+    mode: string
+    approvalGate: string
+    manifest: {
+      sourceCount: number
+      approvedSourceCount: number
+      excludedSourceCount: number
+      countsByNamespace: Record<string, number>
+      countsByPrivacyTier: Record<string, number>
+    }
+    validation: {
+      ok: boolean
+      errors: string[]
+      warnings: string[]
+      publicUnsafeApprovedCount: number
+    }
+  }
   agent_inbox: Array<{
     id: string
     priority: 'high' | 'medium' | 'low'
@@ -429,6 +448,7 @@ export default function AgentOperationsPage() {
           <DailyBriefPanel brief={snapshot?.daily_brief ?? null} loading={loading} />
           <CostSummaryPanel summary={snapshot?.cost_summary ?? null} />
           <OperatingSignalsPanel signals={snapshot?.operating_signals ?? []} />
+          <KnowledgeGovernancePanel governance={snapshot?.knowledge_governance ?? null} />
 
           <section className="mt-5 grid grid-cols-1 gap-5 xl:grid-cols-[1.2fr_0.8fr]">
             <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/25 p-4">
@@ -765,6 +785,50 @@ function OperatingSignalsPanel({ signals }: { signals: MissionSnapshot['operatin
           </Link>
         )
       })}
+    </section>
+  )
+}
+
+function KnowledgeGovernancePanel({ governance }: { governance: MissionSnapshot['knowledge_governance'] | null }) {
+  if (!governance) return null
+  const statusTone = governance.validation.ok ? 'text-emerald-200' : 'text-red-200'
+  const namespaces = Object.entries(governance.manifest.countsByNamespace)
+    .filter(([, count]) => count > 0)
+    .map(([namespace, count]) => `${namespace}: ${count}`)
+
+  return (
+    <section className="mt-5 rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2 text-radiant-gold">
+            <ShieldCheck size={18} />
+            <h2 className="font-semibold">RAG Knowledge Governance</h2>
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {governance.targetIndex} is staged in {governance.mode.replace(/_/g, ' ')}; {governance.legacyIndex} remains legacy read-only.
+          </p>
+        </div>
+        <Link href="/api/admin/rag-health" className="rounded-full border border-radiant-gold/50 bg-radiant-gold/10 px-3 py-1.5 text-xs text-radiant-gold hover:bg-radiant-gold/15">
+          RAG health
+        </Link>
+      </div>
+      <div className="mt-3 grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <MetricCard icon={<ClipboardList size={16} />} label="Sources" value={governance.manifest.sourceCount} />
+        <MetricCard icon={<CheckCircle2 size={16} />} label="Approved" value={governance.manifest.approvedSourceCount} />
+        <MetricCard icon={<AlertTriangle size={16} />} label="Violations" value={governance.validation.errors.length + governance.validation.publicUnsafeApprovedCount} tone={governance.validation.ok ? 'default' : 'red'} />
+        <MetricCard icon={<ShieldCheck size={16} />} label="Status" value={governance.validation.ok ? 'Ready' : 'Blocked'} />
+      </div>
+      <div className="mt-3 rounded-lg border border-silicon-slate/50 bg-black/10 p-3 text-sm">
+        <p className={`font-medium ${statusTone}`}>
+          {governance.validation.ok ? 'Manifest validation is clean.' : governance.validation.errors[0]}
+        </p>
+        <p className="mt-1 text-muted-foreground">
+          {namespaces.length ? namespaces.join(' | ') : 'No manifest namespaces populated yet.'}
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Approval gate: {governance.approvalGate.replace(/_/g, ' ')}
+        </p>
+      </div>
     </section>
   )
 }

--- a/app/api/admin/rag-health/route.ts
+++ b/app/api/admin/rag-health/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
 import { isMockN8nEnabled, isN8nOutboundDisabled } from '@/lib/n8n-runtime-flags'
-import { fetchRagContextForEmailQuery } from '@/lib/rag-query'
+import { fetchRagContextForEmailQueryWithDiagnostics } from '@/lib/rag-query'
+import { routePolicyFor, type RagRoute } from '@/lib/knowledge-governance'
+import { KNOWLEDGE_GOVERNANCE_STATUS } from '@/lib/knowledge-source-manifest'
 
 export const dynamic = 'force-dynamic'
 
@@ -22,16 +24,25 @@ export async function GET(request: NextRequest) {
       ok: false,
       skipped: true,
       reason: isMockN8nEnabled() ? 'MOCK_N8N' : 'N8N_DISABLE_OUTBOUND',
+      governance: KNOWLEDGE_GOVERNANCE_STATUS,
     })
   }
 
   const { searchParams } = new URL(request.url)
   const customQ = searchParams.get('q')?.trim()
+  const requestedRoute = searchParams.get('route')?.trim() as RagRoute | null
+  const route: RagRoute = requestedRoute && isSupportedRagRoute(requestedRoute)
+    ? requestedRoute
+    : 'public_chatbot_voice'
+  const policy = routePolicyFor(route)
   const query =
     customQ || 'Health check: one short paragraph on AmaduTown services and how you work with clients.'
 
   const t0 = Date.now()
-  const text = await fetchRagContextForEmailQuery(query, { ignoreEmailRagEnabled: true })
+  const { block: text, diagnostics } = await fetchRagContextForEmailQueryWithDiagnostics(query, {
+    ignoreEmailRagEnabled: true,
+    route,
+  })
   const latencyMs = Date.now() - t0
 
   if (!text) {
@@ -39,6 +50,10 @@ export async function GET(request: NextRequest) {
       {
         ok: false,
         latencyMs,
+        route,
+        policy,
+        diagnostics,
+        governance: KNOWLEDGE_GOVERNANCE_STATUS,
         message: 'RAG returned empty (check n8n workflow, Pinecone creds, and N8N_RAG_QUERY_WEBHOOK_URL).',
       },
       { status: 200 }
@@ -48,6 +63,14 @@ export async function GET(request: NextRequest) {
   return NextResponse.json({
     ok: true,
     latencyMs,
+    route,
+    policy,
+    diagnostics,
+    governance: KNOWLEDGE_GOVERNANCE_STATUS,
     preview: text.slice(0, 500) + (text.length > 500 ? '…' : ''),
   })
+}
+
+function isSupportedRagRoute(route: string): route is RagRoute {
+  return ['public_chatbot', 'public_chatbot_voice', 'outreach_email', 'admin_internal', 'legacy_health'].includes(route)
 }

--- a/app/api/admin/rag-ingest/route.ts
+++ b/app/api/admin/rag-ingest/route.ts
@@ -1,0 +1,138 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { isAuthError, verifyAdmin } from '@/lib/auth-server'
+import { endAgentRun, recordAgentEvent, startAgentRun } from '@/lib/agent-run'
+import { buildKnowledgeIngestionPlan } from '@/lib/knowledge-ingestion'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * POST /api/admin/rag-ingest
+ *
+ * Builds a governed shadow ingestion plan from the repo-owned knowledge manifest.
+ * n8n may trigger this endpoint, but Portfolio owns source validation,
+ * extraction, chunking, dedup, privacy checks, and Agent Ops trace recording.
+ *
+ * This endpoint does not mutate Pinecone yet. Production cutover and writes to
+ * `amadutown-knowledge-v1` remain approval-gated.
+ */
+export async function POST(request: NextRequest) {
+  const bearerToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const isN8nAuth = Boolean(process.env.N8N_INGEST_SECRET && bearerToken === process.env.N8N_INGEST_SECRET)
+
+  if (!isN8nAuth) {
+    const auth = await verifyAdmin(request)
+    if (isAuthError(auth)) {
+      return NextResponse.json({ error: auth.error }, { status: auth.status })
+    }
+  }
+
+  let body: Record<string, unknown> = {}
+  try {
+    body = await request.json()
+  } catch {
+    body = {}
+  }
+
+  const requestedWrite = body.write === true || body.dry_run === false
+  const sourceIds = Array.isArray(body.source_ids)
+    ? body.source_ids.filter((sourceId): sourceId is string => typeof sourceId === 'string')
+    : undefined
+
+  const plan = await buildKnowledgeIngestionPlan({
+    sourceIds,
+    includeUnapproved: body.include_unapproved === true,
+    ingestRunId: typeof body.ingest_run_id === 'string' ? body.ingest_run_id : undefined,
+  })
+
+  await recordKnowledgeIngestRun(plan, {
+    triggerSource: isN8nAuth ? 'n8n' : 'admin',
+    requestedWrite,
+  })
+
+  return NextResponse.json(
+    {
+      ...summarizePlan(plan),
+      write_status: requestedWrite
+        ? 'blocked_pending_pinecone_cutover_approval'
+        : 'shadow_plan_only',
+      approval_required: requestedWrite,
+    },
+    { status: plan.ok ? 200 : 422 },
+  )
+}
+
+function summarizePlan(plan: Awaited<ReturnType<typeof buildKnowledgeIngestionPlan>>) {
+  return {
+    ok: plan.ok,
+    mode: plan.mode,
+    ingest_run_id: plan.ingestRunId,
+    target_index: plan.targetIndex,
+    legacy_index: plan.legacyIndex,
+    source_count: plan.sourceCount,
+    approved_source_count: plan.approvedSourceCount,
+    chunk_count: plan.chunkCount,
+    skipped_sources: plan.skippedSources,
+    errors: plan.errors,
+    privacy_violations: plan.privacyViolations,
+    duplicate_chunk_count: plan.duplicateChunkCount,
+    namespace_counts: plan.namespaceCounts,
+    metadata_completeness: plan.metadataCompleteness,
+    sample_chunks: plan.chunks.slice(0, 5).map((chunk) => ({
+      id: chunk.id,
+      title: chunk.metadata.title,
+      source_id: chunk.metadata.sourceId,
+      namespace: chunk.metadata.namespace,
+      privacy_tier: chunk.metadata.privacyTier,
+      content_fingerprint: chunk.metadata.contentFingerprint,
+      text_preview: chunk.text.slice(0, 180),
+    })),
+  }
+}
+
+async function recordKnowledgeIngestRun(
+  plan: Awaited<ReturnType<typeof buildKnowledgeIngestionPlan>>,
+  context: { triggerSource: string; requestedWrite: boolean },
+) {
+  try {
+    const run = await startAgentRun({
+      agentKey: 'private-knowledge-librarian',
+      runtime: 'codex',
+      kind: 'rag_ingest_shadow_plan',
+      title: 'Governed RAG ingestion shadow plan',
+      status: plan.ok ? 'completed' : 'failed',
+      triggerSource: context.triggerSource,
+      metadata: {
+        target_index: plan.targetIndex,
+        legacy_index: plan.legacyIndex,
+        requested_write: context.requestedWrite,
+        source_count: plan.sourceCount,
+        chunk_count: plan.chunkCount,
+        skipped_source_count: plan.skippedSources.length,
+        privacy_violation_count: plan.privacyViolations.length,
+        duplicate_chunk_count: plan.duplicateChunkCount,
+      },
+      idempotencyKey: `rag-ingest-shadow:${plan.ingestRunId}`,
+    })
+
+    await recordAgentEvent({
+      runId: run.id,
+      eventType: plan.ok ? 'rag_ingest_shadow_ready' : 'rag_ingest_shadow_failed',
+      severity: plan.ok ? 'info' : 'error',
+      message: plan.ok
+        ? `Prepared ${plan.chunkCount} governed RAG chunks.`
+        : `Governed RAG ingestion blocked with ${plan.errors.length} errors.`,
+      metadata: summarizePlan(plan),
+      idempotencyKey: `rag-ingest-shadow:${plan.ingestRunId}:summary`,
+    })
+
+    await endAgentRun({
+      runId: run.id,
+      status: plan.ok ? 'completed' : 'failed',
+      outcome: summarizePlan(plan),
+      errorMessage: plan.ok ? null : plan.errors.join('; '),
+      currentStep: 'shadow plan complete',
+    })
+  } catch (error) {
+    console.warn('[rag-ingest] Agent Ops run recording skipped:', error instanceof Error ? error.message : error)
+  }
+}

--- a/docs/atas-knowledge-os-rag-governance.md
+++ b/docs/atas-knowledge-os-rag-governance.md
@@ -1,0 +1,98 @@
+# ATAS Knowledge OS RAG Governance
+
+This document defines the governed RAG design for the ATAS AI Agent Organization.
+It replaces broad Drive-to-Pinecone ingestion with source classification,
+namespace routing, approval gates, and Agent Ops visibility.
+
+## Operating Owner
+
+- **Pod:** Research & Knowledge
+- **Primary agent:** Private Knowledge Librarian
+- **Source classification owner:** Research & Source Register Agent
+- **Escalation owner:** Chief of Staff Agent
+
+The Private Knowledge Librarian owns ingestion runs, Pinecone namespaces,
+metadata completeness, duplicate detection, privacy checks, and retrieval health.
+The Research & Source Register Agent classifies source material before it is
+eligible for ingestion. The Chief of Staff Agent escalates failed health checks,
+privacy violations, eval regressions, and production cutover decisions.
+
+## Index Strategy
+
+- Current legacy index: `publications`
+- New staged index: `amadutown-knowledge-v1`
+- Cutover status: shadow only until approved
+
+The legacy `publications` index is retained for audit and rollback. It should not
+be deleted or overwritten during this phase.
+
+## Namespaces
+
+| Namespace | Purpose | Max public route privacy |
+| --- | --- | --- |
+| `public_chatbot` | Public facts, services, products, FAQs, campaigns | `public_safe` |
+| `voice_story` | Public-safe narrative, voice, thought leadership | `public_safe` |
+| `sales_context` | Client-safe proof, case studies, outreach examples | `client_safe` |
+| `internal_ops` | SOPs, admin workflows, runbooks | admin-only |
+| `legacy_quarantine` | Audit-only legacy Pinecone state | not routed |
+
+No public route should search all namespaces by default.
+
+## Source Manifest Contract
+
+Every ingested source must be listed in `lib/knowledge-source-manifest.ts`.
+Every chunk produced from that source must carry:
+
+- `sourceId`
+- `title`
+- `sourceType`
+- `namespace`
+- `privacyTier`
+- `canonicalPathOrUrl`
+- `contentFingerprint`
+- `chunkIndex`
+- `chunkCount`
+- `ingestRunId`
+
+Ingestion must reject unclassified sources, missing metadata, private material in
+public namespaces, and excluded private sources marked as RAG-approved.
+
+## Retrieval Routes
+
+| Route | Allowed namespaces | Max privacy | Default use |
+| --- | --- | --- | --- |
+| `public_chatbot` | `public_chatbot` | `public_safe` | Public factual answers |
+| `public_chatbot_voice` | `public_chatbot`, `voice_story` | `public_safe` | Public answers with voice/story context |
+| `outreach_email` | `sales_context`, `voice_story` | `client_safe` | In-app outreach and delivery drafts |
+| `admin_internal` | `internal_ops` | `internal` | Admin-only tools |
+| `legacy_health` | `legacy_quarantine` | `internal` | Legacy connectivity checks only |
+
+Portfolio's curated `/api/knowledge` bundle remains the authoritative public
+fact source for products, services, campaigns, and public-safe bio context.
+
+## Agent Ops Visibility
+
+Agent Ops should record:
+
+- ingest runs
+- source-audit runs
+- eval runs
+- approval requests
+- production cutover decisions
+- privacy violations
+- rollback notes
+
+The `/admin/agents` mission-control snapshot exposes the current manifest,
+namespace counts, validation status, and approval gate. `/api/admin/rag-health`
+returns route policy and governance status alongside the n8n RAG probe.
+
+## Approval Gates
+
+The following actions require explicit approval:
+
+- production cutover from `publications` to `amadutown-knowledge-v1`
+- any public chatbot/RAG behavior change
+- production n8n activation/deactivation for RAG workflows
+- promoting private-derived material into public retrieval
+- deleting or overwriting the legacy Pinecone index
+

--- a/docs/atas-knowledge-os-rag-governance.md
+++ b/docs/atas-knowledge-os-rag-governance.md
@@ -86,6 +86,18 @@ The `/admin/agents` mission-control snapshot exposes the current manifest,
 namespace counts, validation status, and approval gate. `/api/admin/rag-health`
 returns route policy and governance status alongside the n8n RAG probe.
 
+## Ingestion Trigger
+
+Governed ingestion starts at `POST /api/admin/rag-ingest`. The endpoint accepts
+admin auth or `Authorization: Bearer <N8N_INGEST_SECRET>` for n8n. It builds a
+shadow ingestion plan by validating the manifest, extracting local text, chunking
+content, generating deterministic IDs, checking metadata completeness, rejecting
+public namespace privacy violations, and recording an Agent Ops run.
+
+Current write mode is intentionally blocked. Requests with `{ "write": true }`
+return `blocked_pending_pinecone_cutover_approval` until Pinecone index creation,
+production n8n activation, and default retrieval cutover are explicitly approved.
+
 ## Approval Gates
 
 The following actions require explicit approval:
@@ -95,4 +107,3 @@ The following actions require explicit approval:
 - production n8n activation/deactivation for RAG workflows
 - promoting private-derived material into public retrieval
 - deleting or overwriting the legacy Pinecone index
-

--- a/docs/email-rag-knowledge-and-chat-policy.md
+++ b/docs/email-rag-knowledge-and-chat-policy.md
@@ -3,7 +3,7 @@
 ## Policy (implemented)
 
 1. **Pinecone / knowledge base (RAG)**  
-   In-app email drafts (outreach queue + delivery email) call the same n8n webhook as WF-SOC-001 and WF-MCH: `POST` to `N8N_RAG_QUERY_WEBHOOK_URL` or, by default, `{N8N_BASE_URL}/webhook/amadutown-rag-query` with body `{ "query": "…" }`. The workflow performs vector retrieval (Pinecone) and returns text that is appended to the system prompt under **“Relevant experience (from your knowledge base / Pinecone via RAG)”**.  
+   In-app email drafts (outreach queue + delivery email) call the same n8n webhook as WF-SOC-001 and WF-MCH: `POST` to `N8N_RAG_QUERY_WEBHOOK_URL` or, by default, `{N8N_BASE_URL}/webhook/amadutown-rag-query` with body `{ "query": "…", "route": "outreach_email", "allowed_namespaces": ["sales_context", "voice_story"], "max_privacy_tier": "client_safe" }`. The workflow performs vector retrieval (Pinecone) and returns text that is appended to the system prompt under **“Relevant experience (from your knowledge base / Pinecone via RAG)”**.  
    If the webhook fails or outbound n8n is disabled, the email is still generated without that block (graceful degradation).
 
 2. **LLM chat history**  
@@ -15,10 +15,10 @@
 
 ## Operations
 
-- **Health check (admin):** `GET /api/admin/rag-health` (optional `?q=` custom query). Confirms the app can reach the RAG webhook and return non-empty text. Still respects `MOCK_N8N` and `N8N_DISABLE_OUTBOUND`.
+- **Health check (admin):** `GET /api/admin/rag-health` (optional `?q=` custom query and `?route=public_chatbot_voice|public_chatbot|outreach_email|admin_internal|legacy_health`). Confirms the app can reach the RAG webhook and return non-empty text while also reporting the current governance manifest, route policy, namespace limits, and cutover gate. Still respects `MOCK_N8N` and `N8N_DISABLE_OUTBOUND`.
 - **n8n:** The workflow exposing `amadutown-rag-query` must be **active** and the Pinecone node must have valid credentials (see `docs/staging-n8n-activation-matrix.md` for historical staging notes).
 - **Local chatbot knowledge:** `GET /api/knowledge` and `GET /api/knowledge/chatbot` now include `docs/vambah-personality-public-safe.md`, a public-safe personality corpus summary generated from the governed local corpus. This improves the website chatbot's local knowledge bundle without mutating Pinecone.
-- **Pinecone status:** personality-corpus Pinecone ingestion remains deferred. Ingest only after reviewing the staged corpus pack and deciding whether the Pinecone-backed n8n workflow should treat it as a canonical source.
+- **Pinecone status:** personality-corpus Pinecone ingestion remains deferred. Ingest only after reviewing the staged corpus pack and deciding whether the Pinecone-backed n8n workflow should treat it as a canonical source. Legacy `publications` stays audit/rollback-only while the governed `amadutown-knowledge-v1` index is built and evaluated in shadow mode.
 
 ## Code entry points
 

--- a/docs/email-rag-knowledge-and-chat-policy.md
+++ b/docs/email-rag-knowledge-and-chat-policy.md
@@ -3,11 +3,11 @@
 ## Policy (implemented)
 
 1. **Pinecone / knowledge base (RAG)**  
-   In-app email drafts (outreach queue + delivery email) call the same n8n webhook as WF-SOC-001 and WF-MCH: `POST` to `N8N_RAG_QUERY_WEBHOOK_URL` or, by default, `{N8N_BASE_URL}/webhook/amadutown-rag-query` with body `{ "query": "…", "route": "outreach_email", "allowed_namespaces": ["sales_context", "voice_story"], "max_privacy_tier": "client_safe" }`. The workflow performs vector retrieval (Pinecone) and returns text that is appended to the system prompt under **“Relevant experience (from your knowledge base / Pinecone via RAG)”**.  
+   In-app email drafts (outreach queue + delivery email) call the same n8n webhook as WF-SOC-001 and WF-MCH: `POST` to `N8N_RAG_QUERY_WEBHOOK_URL` or, by default, `{N8N_BASE_URL}/webhook/amadutown-rag-query` with body `{ "query": "…", "route": "outreach_email", "allowed_namespaces": ["sales_context", "voice_story"], "max_privacy_tier": "client_safe" }`. The workflow performs vector retrieval (Pinecone) and returns text that is appended to the system prompt under **“Relevant experience (from your knowledge base / Pinecone via RAG)”**.
    If the webhook fails or outbound n8n is disabled, the email is still generated without that block (graceful degradation).
 
 2. **LLM chat history**  
-   **We do not** automatically embed `chat_messages` into Pinecone.  
+   **We do not** automatically embed `chat_messages` into Pinecone.
    **Optional prompt-only path:** when `EMAIL_RAG_INCLUDE_SITE_CHAT=true`, the app loads the most recent `chat_sessions` row whose `visitor_email` matches the lead’s email (case-insensitive) and appends the last up to 16 messages (capped in size) under **“Prior site chat with this email address”**. This is off by default for privacy; enable when you are comfortable matching site visitors to leads by email.
 
 3. **Disabling RAG for email only**  

--- a/docs/pinecone-publications-rag-audit.md
+++ b/docs/pinecone-publications-rag-audit.md
@@ -1,0 +1,82 @@
+# Pinecone Publications RAG Audit
+
+Date: 2026-05-05
+
+This is a read-only audit note for the legacy Pinecone `publications` index. It
+captures the current retrieval quality problem that motivated the governed ATAS
+Knowledge OS rebuild. No Pinecone records were deleted, overwritten, or promoted
+as part of this audit.
+
+## Scope
+
+- Legacy index: `publications`
+- New target index: `amadutown-knowledge-v1`
+- Legacy index treatment: audit and rollback only
+- Operational owner: Private Knowledge Librarian
+- Escalation owner: Chief of Staff Agent
+
+## Observed Legacy State
+
+The legacy index is usable from a connectivity standpoint, but the stored records
+do not meet the metadata, routing, or privacy requirements for production RAG.
+
+Observed index traits:
+
+- Record count: 3,387
+- Region: `us-east-1`
+- Shape: dense vector index
+- Namespace state: default namespace only
+- Legacy source marker: broad `source: "blob"` values rather than source IDs
+- Common blob types: PDF, DOCX, plain text, and CSV extraction remnants
+
+Representative metadata issues:
+
+- Missing durable source IDs
+- Missing source titles
+- Missing canonical paths or URLs
+- Missing privacy tiers
+- Missing route/use-case intent
+- Missing ingest run IDs
+- Missing stable chunk IDs tied to content fingerprints
+
+Representative content-quality issues:
+
+- Duplicate or near-duplicate chunks appear in top results.
+- Some chunks are small fragments from malformed extraction rather than useful
+  source-backed knowledge.
+- Several records look like raw operational exports rather than curated
+  public-safe knowledge.
+- At least one sampled result category appeared contact-like or client/private
+  enough that it should not be available to public routes.
+
+## Risk Classification
+
+| Risk | Status | Impact |
+| --- | --- | --- |
+| Source provenance | Failing | Chatbot cannot cite or rank trustworthy source titles. |
+| Metadata completeness | Failing | Retrieval cannot route by audience, privacy tier, or use case. |
+| Duplicate control | Failing | Top results can repeat the same weak passage. |
+| Privacy routing | Failing | Public and internal material are not cleanly separated. |
+| Extraction quality | Mixed | Some chunks are usable, but malformed records pollute retrieval. |
+| Rollback value | Useful | Keep as a legacy reference until the new index beats it in shadow. |
+
+## Required Remediation
+
+The current `WF-RAG-INGEST` behavior should remain legacy/read-only pending the
+governed rebuild. Future ingestion must go through Portfolio-owned validation:
+
+- source manifest classification
+- required metadata checks
+- deterministic content fingerprints
+- deterministic chunk IDs
+- namespace policy enforcement
+- privacy-tier enforcement
+- duplicate detection
+- Agent Ops run recording
+
+## Cutover Gate
+
+Do not route production chatbot or outreach retrieval to `amadutown-knowledge-v1`
+until shadow evaluation shows that the new index is materially better than
+`publications` on relevance, source quality, deduplication, and privacy safety.
+

--- a/docs/pinecone-publications-rag-audit.md
+++ b/docs/pinecone-publications-rag-audit.md
@@ -74,9 +74,13 @@ governed rebuild. Future ingestion must go through Portfolio-owned validation:
 - duplicate detection
 - Agent Ops run recording
 
+The replacement trigger is `POST /api/admin/rag-ingest`. n8n can call this route
+with `Authorization: Bearer <N8N_INGEST_SECRET>`, but the app keeps control of
+manifest validation, extraction, chunking, deduplication, privacy checks, and run
+recording.
+
 ## Cutover Gate
 
 Do not route production chatbot or outreach retrieval to `amadutown-knowledge-v1`
 until shadow evaluation shows that the new index is materially better than
 `publications` on relevance, source quality, deduplication, and privacy safety.
-

--- a/lib/__tests__/email-llm-context.test.ts
+++ b/lib/__tests__/email-llm-context.test.ts
@@ -22,6 +22,9 @@ const disabledRagDiag = {
   http_status: null,
   latency_ms: null,
   empty_response: false,
+  route: 'outreach_email' as const,
+  allowed_namespaces: ['sales_context', 'voice_story'] as const,
+  max_privacy_tier: 'client_safe',
 }
 
 vi.mock('@/lib/rag-query', () => ({
@@ -95,6 +98,9 @@ describe('appendPineconeAndChatContextWithMetadata', () => {
         http_status: 200,
         latency_ms: 12,
         empty_response: false,
+        route: 'outreach_email',
+        allowed_namespaces: ['sales_context', 'voice_story'],
+        max_privacy_tier: 'client_safe',
       },
     })
     mockFetchRecentSiteChatExcerptForLeadEmail.mockResolvedValue(null)
@@ -126,6 +132,9 @@ describe('appendPineconeAndChatContextWithMetadata', () => {
         http_status: 200,
         latency_ms: 1,
         empty_response: false,
+        route: 'outreach_email',
+        allowed_namespaces: ['sales_context', 'voice_story'],
+        max_privacy_tier: 'client_safe',
       },
     })
     mockFetchRecentSiteChatExcerptForLeadEmail.mockResolvedValue(null)

--- a/lib/__tests__/rag-query.test.ts
+++ b/lib/__tests__/rag-query.test.ts
@@ -44,7 +44,12 @@ describe('rag-query', () => {
     expect(fetchMock.mock.calls[0][1]).toMatchObject({
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-      body: JSON.stringify({ query: 'query text' }),
+      body: JSON.stringify({
+        query: 'query text',
+        route: 'outreach_email',
+        allowed_namespaces: ['sales_context', 'voice_story'],
+        max_privacy_tier: 'client_safe',
+      }),
     })
     expect(result.block).toBe('Voice-of-brand excerpt.')
     expect(result.diagnostics).toMatchObject({
@@ -54,6 +59,9 @@ describe('rag-query', () => {
       error_class: null,
       http_status: null,
       empty_response: false,
+      route: 'outreach_email',
+      allowed_namespaces: ['sales_context', 'voice_story'],
+      max_privacy_tier: 'client_safe',
     })
     expect(result.diagnostics.latency_ms).toEqual(expect.any(Number))
   })
@@ -77,6 +85,36 @@ describe('rag-query', () => {
       attempted: true,
       error_class: null,
       empty_response: true,
+    })
+  })
+
+  it('sends route policy metadata for public chatbot probes', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ output: 'Public-safe excerpt.' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { fetchRagContextForEmailQueryWithDiagnostics } = await importRagQuery()
+    const result = await fetchRagContextForEmailQueryWithDiagnostics('query', {
+      route: 'public_chatbot_voice',
+      allowedNamespaces: ['public_chatbot', 'voice_story', 'internal_ops'],
+    })
+
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({
+      body: JSON.stringify({
+        query: 'query',
+        route: 'public_chatbot_voice',
+        allowed_namespaces: ['public_chatbot', 'voice_story'],
+        max_privacy_tier: 'public_safe',
+      }),
+    })
+    expect(result.diagnostics).toMatchObject({
+      route: 'public_chatbot_voice',
+      allowed_namespaces: ['public_chatbot', 'voice_story'],
+      max_privacy_tier: 'public_safe',
     })
   })
 

--- a/lib/agent-mission-control.ts
+++ b/lib/agent-mission-control.ts
@@ -1,4 +1,5 @@
 import { AGENT_ORGANIZATION, AGENT_PODS } from '@/lib/agent-organization'
+import { KNOWLEDGE_GOVERNANCE_STATUS } from '@/lib/knowledge-source-manifest'
 import { supabaseAdmin } from '@/lib/supabase'
 
 type AgentRunRow = {
@@ -797,6 +798,7 @@ export async function buildAgentMissionControlSnapshot() {
     daily_brief: dailyBrief,
     cost_summary: costSummary,
     operating_signals: operatingSignals,
+    knowledge_governance: KNOWLEDGE_GOVERNANCE_STATUS,
     agent_inbox: agentInbox,
     engagement_queue: engagementQueue,
     dead_letter_queue: deadLetterQueue,

--- a/lib/agent-organization.test.ts
+++ b/lib/agent-organization.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   AGENT_ORGANIZATION,
   AGENT_PODS,
+  getAgentByKey,
   getAgentOrganizationSummary,
   getN8nWorkflowCoverage,
 } from './agent-organization'
@@ -29,5 +30,16 @@ describe('agent organization registry', () => {
     expect(summary).toHaveLength(6)
     expect(summary.find((pod) => pod.key === 'product_automation')?.activeWorkflowCount).toBeGreaterThan(10)
     expect(summary.find((pod) => pod.key === 'strategy_narrative')?.plannedAgentCount).toBe(3)
+  })
+
+  it('assigns governed RAG ownership and approval gates to the Research & Knowledge pod', () => {
+    const librarian = getAgentByKey('private-knowledge-librarian')
+    const sourceRegister = getAgentByKey('research-source-register')
+
+    expect(librarian?.responsibility).toContain('metadata completeness')
+    expect(librarian?.responsibility).toContain('privacy checks')
+    expect(librarian?.approvalGate).toContain('Production cutover')
+    expect(librarian?.approvalGate).toContain('public chatbot/RAG policy changes')
+    expect(sourceRegister?.approvalGate).toContain('unclassified material')
   })
 })

--- a/lib/agent-organization.ts
+++ b/lib/agent-organization.ts
@@ -47,7 +47,7 @@ export const AGENT_PODS: AgentPodDefinition[] = [
   {
     key: 'research_knowledge',
     name: 'Research & Knowledge Pod',
-    purpose: 'Maintains evidence, source registers, private knowledge, RAG context, and decision support.',
+    purpose: 'Maintains evidence, source registers, governed knowledge ingestion, RAG context, and decision support.',
   },
   {
     key: 'content_production',
@@ -124,9 +124,9 @@ export const AGENT_ORGANIZATION: AgentOrganizationNode[] = [
     podKey: 'research_knowledge',
     status: 'partial',
     primaryRuntime: 'mixed',
-    responsibility: 'Collect, classify, and retrieve source-backed evidence for decisions, content, and client work.',
-    engagementPath: '/admin/value-evidence, RAG workflows, and lead research workflows.',
-    approvalGate: 'Private or client-derived material requires review before public use.',
+    responsibility: 'Collect and classify source-backed evidence before it is eligible for value evidence, content, RAG, or client work.',
+    engagementPath: '/admin/value-evidence, the knowledge source manifest, RAG audit reports, and lead research workflows.',
+    approvalGate: 'Private, client-derived, or unclassified material requires review before public or RAG use.',
     n8nWorkflows: [
       { id: 'uxsDWErRpICMxoRM', name: 'Lead Research and Qualifying Agent', environment: 'production', active: true },
       { id: 'iqGylSD1c2lDxlDT', name: 'WF-VEP-001: Internal Evidence Extraction', environment: 'production', active: true },
@@ -141,11 +141,11 @@ export const AGENT_ORGANIZATION: AgentOrganizationNode[] = [
     podKey: 'research_knowledge',
     status: 'partial',
     primaryRuntime: 'n8n',
-    responsibility: 'Keep RAG and private knowledge retrieval paths current without exposing raw private material.',
-    engagementPath: 'RAG ingest/query workflows and Portfolio knowledge surfaces.',
-    approvalGate: 'No private material quoted publicly without explicit approval.',
+    responsibility: 'Operate governed RAG ingestion, Pinecone namespaces, metadata completeness, duplicate detection, privacy checks, and retrieval health.',
+    engagementPath: '/api/admin/rag-health, knowledge source manifest, RAG ingest/query workflows, and Portfolio knowledge surfaces.',
+    approvalGate: 'Production cutover, private-source promotion, public chatbot/RAG policy changes, and raw private material usage require explicit approval.',
     n8nWorkflows: [
-      { id: 'yCNUqSHfyXpxNDLm', name: 'WF-RAG-INGEST: Google Drive -> Pinecone Ingestion (Daily)', environment: 'production', active: true },
+      { id: 'yCNUqSHfyXpxNDLm', name: 'WF-RAG-INGEST: Google Drive -> Pinecone Ingestion (Daily) [legacy read-only pending governed ingest]', environment: 'production', active: true },
       { id: '7Xn0fxEgXlbK6Gmm', name: 'WF-RAG-QUERY: Webhook RAG Search', environment: 'production', active: true },
       { id: '5YImo1TTgEInnfxw', name: 'WF-RAG-CHAT: Public Chatbot', environment: 'production', active: true },
       { id: 'Y56hALscpB5Asq7j', name: 'WF-RAG-DIAGNOSTIC: Multi-Category Assessment', environment: 'production', active: true },

--- a/lib/email-llm-context.ts
+++ b/lib/email-llm-context.ts
@@ -93,6 +93,9 @@ export interface PineconeChatContextMetadata {
   ragHttpStatus: number | null
   ragLatencyMs: number | null
   ragEmptyResponse: boolean
+  ragRoute: string
+  ragAllowedNamespaces: string[]
+  ragMaxPrivacyTier: string
 }
 
 export async function appendPineconeAndChatContextToSystemPrompt(
@@ -127,7 +130,7 @@ export async function appendPineconeAndChatContextWithMetadata(
   })
 
   const [ragResult, chatBlock] = await Promise.all([
-    fetchRagContextForEmailQueryWithDiagnostics(ragQuery),
+    fetchRagContextForEmailQueryWithDiagnostics(ragQuery, { route: 'outreach_email' }),
     fetchRecentSiteChatExcerptForLeadEmail(input.contact.email),
   ])
   const ragBlock = ragResult.block
@@ -158,6 +161,9 @@ export async function appendPineconeAndChatContextWithMetadata(
       ragHttpStatus: d.http_status,
       ragLatencyMs: d.latency_ms,
       ragEmptyResponse: d.empty_response,
+      ragRoute: d.route,
+      ragAllowedNamespaces: d.allowed_namespaces,
+      ragMaxPrivacyTier: d.max_privacy_tier,
     },
   }
 }

--- a/lib/knowledge-governance.test.ts
+++ b/lib/knowledge-governance.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildKnowledgeChunkMetadata,
+  createContentFingerprint,
+  createKnowledgeChunkId,
+  routePolicyFor,
+  validateKnowledgeSourceManifest,
+  type KnowledgeSourceManifestEntry,
+} from './knowledge-governance'
+import { KNOWLEDGE_SOURCE_MANIFEST } from './knowledge-source-manifest'
+
+const validSource: KnowledgeSourceManifestEntry = {
+  sourceId: 'source-1',
+  title: 'Source One',
+  sourceType: 'portfolio_doc',
+  namespace: 'public_chatbot',
+  privacyTier: 'public_safe',
+  canonicalPathOrUrl: 'docs/source-one.md',
+  intendedConsumers: ['public_chatbot'],
+  approvedForRag: true,
+}
+
+describe('knowledge governance', () => {
+  it('validates the repo-owned knowledge source manifest', () => {
+    const result = validateKnowledgeSourceManifest(KNOWLEDGE_SOURCE_MANIFEST)
+
+    expect(result.ok).toBe(true)
+    expect(result.countsByNamespace.public_chatbot).toBeGreaterThan(0)
+    expect(result.countsByNamespace.legacy_quarantine).toBe(1)
+  })
+
+  it('rejects duplicate source ids and missing required metadata', () => {
+    const result = validateKnowledgeSourceManifest([
+      validSource,
+      {
+        ...validSource,
+        title: '',
+        canonicalPathOrUrl: '',
+      },
+    ])
+
+    expect(result.ok).toBe(false)
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        'Duplicate knowledge sourceId: source-1.',
+        'source-1 is missing title.',
+        'source-1 is missing canonicalPathOrUrl.',
+      ]),
+    )
+  })
+
+  it('blocks private material from public namespaces', () => {
+    const result = validateKnowledgeSourceManifest([
+      {
+        ...validSource,
+        sourceId: 'private-public-source',
+        namespace: 'public_chatbot',
+        privacyTier: 'private',
+      },
+    ])
+
+    expect(result.ok).toBe(false)
+    expect(result.errors).toContain('private-public-source cannot use private in public_chatbot.')
+  })
+
+  it('blocks excluded private sources from RAG approval', () => {
+    const result = validateKnowledgeSourceManifest([
+      {
+        ...validSource,
+        sourceId: 'excluded-source',
+        sourceType: 'excluded_private',
+        namespace: 'legacy_quarantine',
+        privacyTier: 'private',
+        approvedForRag: true,
+      },
+    ])
+
+    expect(result.ok).toBe(false)
+    expect(result.errors).toContain('excluded-source is excluded_private and cannot be approved for RAG.')
+  })
+
+  it('creates stable content fingerprints and chunk ids', () => {
+    const a = createContentFingerprint('  Hello   WORLD ')
+    const b = createContentFingerprint('hello world')
+
+    expect(a).toBe(b)
+    expect(createKnowledgeChunkId({ sourceId: 'source-1', contentFingerprint: a, chunkIndex: 2 })).toBe(
+      `source-1:${a}:2`,
+    )
+  })
+
+  it('builds complete chunk metadata', () => {
+    const metadata = buildKnowledgeChunkMetadata({
+      source: validSource,
+      chunkText: 'Chunk text',
+      chunkIndex: 0,
+      chunkCount: 2,
+      ingestRunId: 'run-1',
+    })
+
+    expect(metadata).toMatchObject({
+      sourceId: 'source-1',
+      title: 'Source One',
+      namespace: 'public_chatbot',
+      privacyTier: 'public_safe',
+      chunkIndex: 0,
+      chunkCount: 2,
+      ingestRunId: 'run-1',
+    })
+    expect(metadata.contentFingerprint).toHaveLength(64)
+  })
+
+  it('keeps public and outreach retrieval policies separated', () => {
+    expect(routePolicyFor('public_chatbot').allowedNamespaces).toEqual(['public_chatbot'])
+    expect(routePolicyFor('public_chatbot').maxPrivacyTier).toBe('public_safe')
+    expect(routePolicyFor('outreach_email').allowedNamespaces).toEqual(['sales_context', 'voice_story'])
+    expect(routePolicyFor('outreach_email').maxPrivacyTier).toBe('client_safe')
+    expect(routePolicyFor('admin_internal').allowedNamespaces).toEqual(['internal_ops'])
+  })
+})

--- a/lib/knowledge-governance.ts
+++ b/lib/knowledge-governance.ts
@@ -1,0 +1,264 @@
+import crypto from 'crypto'
+
+export const KNOWLEDGE_TARGET_INDEX = 'amadutown-knowledge-v1'
+export const LEGACY_PINECONE_INDEX = 'publications'
+
+export const KNOWLEDGE_NAMESPACES = [
+  'public_chatbot',
+  'voice_story',
+  'sales_context',
+  'internal_ops',
+  'legacy_quarantine',
+] as const
+
+export type KnowledgeNamespace = (typeof KNOWLEDGE_NAMESPACES)[number]
+
+export const KNOWLEDGE_PRIVACY_TIERS = [
+  'public',
+  'public_safe',
+  'client_safe',
+  'internal',
+  'private',
+] as const
+
+export type KnowledgePrivacyTier = (typeof KNOWLEDGE_PRIVACY_TIERS)[number]
+
+export type KnowledgeSourceType =
+  | 'portfolio_doc'
+  | 'public_safe_corpus'
+  | 'publication'
+  | 'case_study'
+  | 'sales_proof'
+  | 'ops_runbook'
+  | 'legacy_pinecone'
+  | 'excluded_private'
+
+export interface KnowledgeSourceManifestEntry {
+  sourceId: string
+  title: string
+  sourceType: KnowledgeSourceType
+  namespace: KnowledgeNamespace
+  privacyTier: KnowledgePrivacyTier
+  canonicalPathOrUrl: string
+  intendedConsumers: string[]
+  approvedForRag: boolean
+  notes?: string
+}
+
+export interface KnowledgeChunkMetadata {
+  sourceId: string
+  title: string
+  sourceType: KnowledgeSourceType
+  namespace: KnowledgeNamespace
+  privacyTier: KnowledgePrivacyTier
+  canonicalPathOrUrl: string
+  contentFingerprint: string
+  chunkIndex: number
+  chunkCount: number
+  ingestRunId: string
+}
+
+export type RagRoute =
+  | 'public_chatbot'
+  | 'public_chatbot_voice'
+  | 'outreach_email'
+  | 'admin_internal'
+  | 'legacy_health'
+
+export interface RagRoutePolicy {
+  route: RagRoute
+  preferredKnowledge: 'curated_first' | 'pinecone_first' | 'internal_only' | 'legacy_probe'
+  allowedNamespaces: KnowledgeNamespace[]
+  maxPrivacyTier: KnowledgePrivacyTier
+  approvalRequiredForCutover: boolean
+}
+
+const privacyRank: Record<KnowledgePrivacyTier, number> = {
+  public: 1,
+  public_safe: 2,
+  client_safe: 3,
+  internal: 4,
+  private: 5,
+}
+
+export const RAG_ROUTE_POLICIES: Record<RagRoute, RagRoutePolicy> = {
+  public_chatbot: {
+    route: 'public_chatbot',
+    preferredKnowledge: 'curated_first',
+    allowedNamespaces: ['public_chatbot'],
+    maxPrivacyTier: 'public_safe',
+    approvalRequiredForCutover: true,
+  },
+  public_chatbot_voice: {
+    route: 'public_chatbot_voice',
+    preferredKnowledge: 'curated_first',
+    allowedNamespaces: ['public_chatbot', 'voice_story'],
+    maxPrivacyTier: 'public_safe',
+    approvalRequiredForCutover: true,
+  },
+  outreach_email: {
+    route: 'outreach_email',
+    preferredKnowledge: 'pinecone_first',
+    allowedNamespaces: ['sales_context', 'voice_story'],
+    maxPrivacyTier: 'client_safe',
+    approvalRequiredForCutover: true,
+  },
+  admin_internal: {
+    route: 'admin_internal',
+    preferredKnowledge: 'internal_only',
+    allowedNamespaces: ['internal_ops'],
+    maxPrivacyTier: 'internal',
+    approvalRequiredForCutover: true,
+  },
+  legacy_health: {
+    route: 'legacy_health',
+    preferredKnowledge: 'legacy_probe',
+    allowedNamespaces: ['legacy_quarantine'],
+    maxPrivacyTier: 'internal',
+    approvalRequiredForCutover: false,
+  },
+}
+
+export interface KnowledgeManifestValidationResult {
+  ok: boolean
+  errors: string[]
+  warnings: string[]
+  countsByNamespace: Record<KnowledgeNamespace, number>
+  countsByPrivacyTier: Record<KnowledgePrivacyTier, number>
+}
+
+export function normalizeKnowledgeContent(content: string): string {
+  return content.toLowerCase().trim().replace(/\s+/g, ' ')
+}
+
+export function createContentFingerprint(content: string): string {
+  return crypto.createHash('sha256').update(normalizeKnowledgeContent(content)).digest('hex')
+}
+
+export function createKnowledgeChunkId(input: {
+  sourceId: string
+  contentFingerprint: string
+  chunkIndex: number
+}): string {
+  return `${input.sourceId}:${input.contentFingerprint}:${input.chunkIndex}`
+}
+
+export function buildKnowledgeChunkMetadata(input: {
+  source: KnowledgeSourceManifestEntry
+  chunkText: string
+  chunkIndex: number
+  chunkCount: number
+  ingestRunId: string
+}): KnowledgeChunkMetadata {
+  return {
+    sourceId: input.source.sourceId,
+    title: input.source.title,
+    sourceType: input.source.sourceType,
+    namespace: input.source.namespace,
+    privacyTier: input.source.privacyTier,
+    canonicalPathOrUrl: input.source.canonicalPathOrUrl,
+    contentFingerprint: createContentFingerprint(input.chunkText),
+    chunkIndex: input.chunkIndex,
+    chunkCount: input.chunkCount,
+    ingestRunId: input.ingestRunId,
+  }
+}
+
+export function routePolicyFor(route: RagRoute): RagRoutePolicy {
+  return RAG_ROUTE_POLICIES[route]
+}
+
+export function isPrivacyTierAllowed(
+  privacyTier: KnowledgePrivacyTier,
+  maxPrivacyTier: KnowledgePrivacyTier,
+): boolean {
+  return privacyRank[privacyTier] <= privacyRank[maxPrivacyTier]
+}
+
+export function validateKnowledgeSourceManifest(
+  entries: KnowledgeSourceManifestEntry[],
+): KnowledgeManifestValidationResult {
+  const errors: string[] = []
+  const warnings: string[] = []
+  const sourceIds = new Set<string>()
+  const countsByNamespace = zeroCounts(KNOWLEDGE_NAMESPACES)
+  const countsByPrivacyTier = zeroCounts(KNOWLEDGE_PRIVACY_TIERS)
+
+  for (const entry of entries) {
+    if (!entry.sourceId.trim()) errors.push('Manifest entry is missing sourceId.')
+    if (!entry.title.trim()) errors.push(`${entry.sourceId || '(missing sourceId)'} is missing title.`)
+    if (!entry.canonicalPathOrUrl.trim()) errors.push(`${entry.sourceId} is missing canonicalPathOrUrl.`)
+    if (!entry.intendedConsumers.length) errors.push(`${entry.sourceId} is missing intendedConsumers.`)
+
+    if (sourceIds.has(entry.sourceId)) {
+      errors.push(`Duplicate knowledge sourceId: ${entry.sourceId}.`)
+    }
+    sourceIds.add(entry.sourceId)
+
+    countsByNamespace[entry.namespace] += 1
+    countsByPrivacyTier[entry.privacyTier] += 1
+
+    if (entry.namespace === 'public_chatbot' && !isPrivacyTierAllowed(entry.privacyTier, 'public_safe')) {
+      errors.push(`${entry.sourceId} cannot use ${entry.privacyTier} in public_chatbot.`)
+    }
+
+    if (entry.namespace === 'voice_story' && !isPrivacyTierAllowed(entry.privacyTier, 'public_safe')) {
+      errors.push(`${entry.sourceId} cannot use ${entry.privacyTier} in voice_story.`)
+    }
+
+    if (entry.namespace === 'sales_context' && !isPrivacyTierAllowed(entry.privacyTier, 'client_safe')) {
+      errors.push(`${entry.sourceId} cannot use ${entry.privacyTier} in sales_context.`)
+    }
+
+    if (entry.namespace === 'legacy_quarantine' && entry.approvedForRag) {
+      warnings.push(`${entry.sourceId} is in legacy_quarantine but marked approvedForRag.`)
+    }
+
+    if (entry.sourceType === 'excluded_private' && entry.approvedForRag) {
+      errors.push(`${entry.sourceId} is excluded_private and cannot be approved for RAG.`)
+    }
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    countsByNamespace,
+    countsByPrivacyTier,
+  }
+}
+
+export function buildKnowledgeGovernanceStatus(entries: KnowledgeSourceManifestEntry[]) {
+  const validation = validateKnowledgeSourceManifest(entries)
+  const approvedSources = entries.filter((entry) => entry.approvedForRag)
+  const publicUnsafeApproved = approvedSources.filter(
+    (entry) =>
+      ['public_chatbot', 'voice_story'].includes(entry.namespace) &&
+      !isPrivacyTierAllowed(entry.privacyTier, 'public_safe'),
+  )
+
+  return {
+    targetIndex: KNOWLEDGE_TARGET_INDEX,
+    legacyIndex: LEGACY_PINECONE_INDEX,
+    mode: 'shadow_not_cutover',
+    approvalGate: 'production_cutover_required',
+    manifest: {
+      sourceCount: entries.length,
+      approvedSourceCount: approvedSources.length,
+      excludedSourceCount: entries.filter((entry) => !entry.approvedForRag).length,
+      countsByNamespace: validation.countsByNamespace,
+      countsByPrivacyTier: validation.countsByPrivacyTier,
+    },
+    validation: {
+      ok: validation.ok,
+      errors: validation.errors,
+      warnings: validation.warnings,
+      publicUnsafeApprovedCount: publicUnsafeApproved.length,
+    },
+    routePolicies: Object.values(RAG_ROUTE_POLICIES),
+  }
+}
+
+function zeroCounts<T extends readonly string[]>(keys: T): Record<T[number], number> {
+  return Object.fromEntries(keys.map((key) => [key, 0])) as Record<T[number], number>
+}

--- a/lib/knowledge-ingestion.test.ts
+++ b/lib/knowledge-ingestion.test.ts
@@ -1,0 +1,91 @@
+import fs from 'fs/promises'
+import os from 'os'
+import path from 'path'
+import { describe, expect, it } from 'vitest'
+import { buildKnowledgeIngestionPlan, splitKnowledgeText } from './knowledge-ingestion'
+import type { KnowledgeSourceManifestEntry } from './knowledge-governance'
+
+async function makeFixtureSource(text: string, overrides: Partial<KnowledgeSourceManifestEntry> = {}) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'knowledge-ingest-'))
+  await fs.mkdir(path.join(root, 'docs'), { recursive: true })
+  await fs.writeFile(path.join(root, 'docs', 'source.md'), text, 'utf8')
+
+  const source: KnowledgeSourceManifestEntry = {
+    sourceId: 'fixture-source',
+    title: 'Fixture Source',
+    sourceType: 'portfolio_doc',
+    namespace: 'public_chatbot',
+    privacyTier: 'public_safe',
+    canonicalPathOrUrl: 'docs/source.md',
+    intendedConsumers: ['test'],
+    approvedForRag: true,
+    ...overrides,
+  }
+
+  return { root, source }
+}
+
+describe('knowledge ingestion planner', () => {
+  it('extracts approved manifest sources into deterministic chunks and metadata', async () => {
+    const { root, source } = await makeFixtureSource('Alpha paragraph.\n\nBeta paragraph.')
+
+    const first = await buildKnowledgeIngestionPlan({
+      rootDir: root,
+      manifest: [source],
+      ingestRunId: 'run-1',
+      chunkSizeChars: 200,
+    })
+    const second = await buildKnowledgeIngestionPlan({
+      rootDir: root,
+      manifest: [source],
+      ingestRunId: 'run-1',
+      chunkSizeChars: 200,
+    })
+
+    expect(first.ok).toBe(true)
+    expect(first.chunkCount).toBe(1)
+    expect(first.chunks[0].id).toBe(second.chunks[0].id)
+    expect(first.chunks[0].metadata).toMatchObject({
+      sourceId: 'fixture-source',
+      title: 'Fixture Source',
+      namespace: 'public_chatbot',
+      privacyTier: 'public_safe',
+      ingestRunId: 'run-1',
+    })
+    expect(first.metadataCompleteness.incompleteChunkCount).toBe(0)
+  })
+
+  it('skips unapproved sources unless explicitly included', async () => {
+    const { root, source } = await makeFixtureSource('Useful source.', { approvedForRag: false })
+
+    const plan = await buildKnowledgeIngestionPlan({ rootDir: root, manifest: [source] })
+
+    expect(plan.chunkCount).toBe(0)
+    expect(plan.skippedSources[0]).toMatchObject({
+      sourceId: 'fixture-source',
+      reason: 'source is not approved for RAG',
+    })
+  })
+
+  it('blocks contact-like content in public namespaces', async () => {
+    const { root, source } = await makeFixtureSource('Reach the client at person@example.com.')
+
+    const plan = await buildKnowledgeIngestionPlan({ rootDir: root, manifest: [source] })
+
+    expect(plan.ok).toBe(false)
+    expect(plan.chunkCount).toBe(0)
+    expect(plan.privacyViolations[0]).toContain('email_address')
+  })
+
+  it('creates overlapping chunks without losing text', () => {
+    const sourceText = Array.from({ length: 40 }, (_, index) => `Sentence ${index + 1} carries useful context.`).join(' ')
+    const chunks = splitKnowledgeText(sourceText, {
+      chunkSizeChars: 220,
+      chunkOverlapChars: 30,
+    })
+
+    expect(chunks.length).toBeGreaterThan(1)
+    expect(chunks.join(' ')).toContain('Sentence 1')
+    expect(chunks.join(' ')).toContain('Sentence 40')
+  })
+})

--- a/lib/knowledge-ingestion.ts
+++ b/lib/knowledge-ingestion.ts
@@ -1,0 +1,287 @@
+import fs from 'fs/promises'
+import path from 'path'
+import {
+  KNOWLEDGE_TARGET_INDEX,
+  LEGACY_PINECONE_INDEX,
+  type KnowledgeChunkMetadata,
+  type KnowledgeNamespace,
+  type KnowledgeSourceManifestEntry,
+  buildKnowledgeChunkMetadata,
+  createKnowledgeChunkId,
+  isPrivacyTierAllowed,
+  validateKnowledgeSourceManifest,
+} from './knowledge-governance'
+import { KNOWLEDGE_SOURCE_MANIFEST } from './knowledge-source-manifest'
+
+export interface KnowledgeIngestionChunk {
+  id: string
+  text: string
+  metadata: KnowledgeChunkMetadata
+}
+
+export interface KnowledgeIngestionSkippedSource {
+  sourceId: string
+  title: string
+  reason: string
+}
+
+export interface KnowledgeIngestionPlan {
+  ok: boolean
+  mode: 'shadow_plan'
+  ingestRunId: string
+  targetIndex: string
+  legacyIndex: string
+  chunks: KnowledgeIngestionChunk[]
+  skippedSources: KnowledgeIngestionSkippedSource[]
+  errors: string[]
+  privacyViolations: string[]
+  duplicateChunkCount: number
+  sourceCount: number
+  approvedSourceCount: number
+  chunkCount: number
+  namespaceCounts: Record<KnowledgeNamespace, number>
+  metadataCompleteness: {
+    completeChunkCount: number
+    incompleteChunkCount: number
+  }
+}
+
+export interface BuildKnowledgeIngestionPlanOptions {
+  rootDir?: string
+  manifest?: KnowledgeSourceManifestEntry[]
+  ingestRunId?: string
+  sourceIds?: string[]
+  includeUnapproved?: boolean
+  chunkSizeChars?: number
+  chunkOverlapChars?: number
+}
+
+const PUBLIC_NAMESPACES: ReadonlySet<KnowledgeNamespace> = new Set(['public_chatbot', 'voice_story'])
+
+const CONTACT_LIKE_PATTERNS: Array<{ label: string; pattern: RegExp }> = [
+  { label: 'email_address', pattern: /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i },
+  { label: 'phone_number', pattern: /(?:\+?1[\s.-]?)?(?:\(?\d{3}\)?[\s.-]?)\d{3}[\s.-]?\d{4}\b/ },
+  { label: 'ssn_like_value', pattern: /\b\d{3}-\d{2}-\d{4}\b/ },
+]
+
+export async function buildKnowledgeIngestionPlan(
+  options: BuildKnowledgeIngestionPlanOptions = {},
+): Promise<KnowledgeIngestionPlan> {
+  const rootDir = options.rootDir ?? process.cwd()
+  const ingestRunId = options.ingestRunId ?? `knowledge-ingest-${new Date().toISOString()}`
+  const chunkSizeChars = options.chunkSizeChars ?? 1800
+  const chunkOverlapChars = options.chunkOverlapChars ?? 200
+  const selectedSourceIds = new Set(options.sourceIds ?? [])
+  const manifest = (options.manifest ?? KNOWLEDGE_SOURCE_MANIFEST).filter((source) =>
+    selectedSourceIds.size ? selectedSourceIds.has(source.sourceId) : true,
+  )
+  const validation = validateKnowledgeSourceManifest(manifest)
+  const chunks: KnowledgeIngestionChunk[] = []
+  const skippedSources: KnowledgeIngestionSkippedSource[] = []
+  const errors = [...validation.errors]
+  const privacyViolations: string[] = []
+  const seenChunkIds = new Set<string>()
+  const namespaceCounts: Record<KnowledgeNamespace, number> = {
+    public_chatbot: 0,
+    voice_story: 0,
+    sales_context: 0,
+    internal_ops: 0,
+    legacy_quarantine: 0,
+  }
+  let duplicateChunkCount = 0
+
+  for (const source of manifest) {
+    if (!source.approvedForRag && !options.includeUnapproved) {
+      skippedSources.push(skip(source, 'source is not approved for RAG'))
+      continue
+    }
+
+    if (source.namespace === 'legacy_quarantine') {
+      skippedSources.push(skip(source, 'legacy quarantine is audit-only'))
+      continue
+    }
+
+    let text: string
+    try {
+      text = await extractManifestSourceText(source, rootDir)
+    } catch (error) {
+      errors.push(`${source.sourceId}: ${error instanceof Error ? error.message : 'failed to extract source'}`)
+      skippedSources.push(skip(source, 'extraction failed'))
+      continue
+    }
+
+    const normalized = text.trim()
+    if (!normalized) {
+      errors.push(`${source.sourceId}: extracted text is empty`)
+      skippedSources.push(skip(source, 'empty extraction'))
+      continue
+    }
+
+    if (PUBLIC_NAMESPACES.has(source.namespace)) {
+      const violation = findContactLikeViolation(normalized)
+      if (violation) {
+        const message = `${source.sourceId}: ${violation} detected in ${source.namespace}`
+        privacyViolations.push(message)
+        errors.push(message)
+        skippedSources.push(skip(source, 'privacy violation in public namespace'))
+        continue
+      }
+
+      if (!isPrivacyTierAllowed(source.privacyTier, 'public_safe')) {
+        const message = `${source.sourceId}: ${source.privacyTier} exceeds public_safe`
+        privacyViolations.push(message)
+        errors.push(message)
+        skippedSources.push(skip(source, 'privacy tier exceeds public route policy'))
+        continue
+      }
+    }
+
+    const sourceChunks = splitKnowledgeText(normalized, { chunkSizeChars, chunkOverlapChars })
+    const chunkCount = sourceChunks.length
+
+    sourceChunks.forEach((chunkText, chunkIndex) => {
+      const metadata = buildKnowledgeChunkMetadata({
+        source,
+        chunkText,
+        chunkIndex,
+        chunkCount,
+        ingestRunId,
+      })
+      const id = createKnowledgeChunkId({
+        sourceId: source.sourceId,
+        contentFingerprint: metadata.contentFingerprint,
+        chunkIndex,
+      })
+
+      if (seenChunkIds.has(id)) {
+        duplicateChunkCount += 1
+        return
+      }
+
+      seenChunkIds.add(id)
+      namespaceCounts[source.namespace] += 1
+      chunks.push({ id, text: chunkText, metadata })
+    })
+  }
+
+  const completeChunkCount = chunks.filter((chunk) => isCompleteChunkMetadata(chunk.metadata)).length
+  const incompleteChunkCount = chunks.length - completeChunkCount
+
+  return {
+    ok: validation.ok && errors.length === 0 && privacyViolations.length === 0,
+    mode: 'shadow_plan',
+    ingestRunId,
+    targetIndex: KNOWLEDGE_TARGET_INDEX,
+    legacyIndex: LEGACY_PINECONE_INDEX,
+    chunks,
+    skippedSources,
+    errors,
+    privacyViolations,
+    duplicateChunkCount,
+    sourceCount: manifest.length,
+    approvedSourceCount: manifest.filter((source) => source.approvedForRag).length,
+    chunkCount: chunks.length,
+    namespaceCounts,
+    metadataCompleteness: {
+      completeChunkCount,
+      incompleteChunkCount,
+    },
+  }
+}
+
+export async function extractManifestSourceText(
+  source: KnowledgeSourceManifestEntry,
+  rootDir = process.cwd(),
+): Promise<string> {
+  if (/^https?:\/\//i.test(source.canonicalPathOrUrl)) {
+    throw new Error('remote URL extraction is not enabled for governed ingestion')
+  }
+
+  if (source.canonicalPathOrUrl.startsWith('pinecone://')) {
+    throw new Error('legacy Pinecone sources are audit-only')
+  }
+
+  const filePath = path.isAbsolute(source.canonicalPathOrUrl)
+    ? source.canonicalPathOrUrl
+    : path.join(rootDir, source.canonicalPathOrUrl)
+  const ext = path.extname(filePath).toLowerCase()
+
+  if (['.md', '.mdx', '.txt', '.csv', '.json'].includes(ext)) {
+    return fs.readFile(filePath, 'utf8')
+  }
+
+  throw new Error(`unsupported source extension: ${ext || '(none)'}`)
+}
+
+export function splitKnowledgeText(
+  text: string,
+  options: { chunkSizeChars?: number; chunkOverlapChars?: number } = {},
+): string[] {
+  const chunkSizeChars = Math.max(options.chunkSizeChars ?? 1800, 200)
+  const chunkOverlapChars = Math.min(Math.max(options.chunkOverlapChars ?? 200, 0), chunkSizeChars - 1)
+  const normalized = text.replace(/\r\n/g, '\n').replace(/[ \t]+/g, ' ').trim()
+
+  if (!normalized) return []
+  if (normalized.length <= chunkSizeChars) return [normalized]
+
+  const chunks: string[] = []
+  let start = 0
+
+  while (start < normalized.length) {
+    const targetEnd = Math.min(start + chunkSizeChars, normalized.length)
+    const end = findChunkBoundary(normalized, start, targetEnd)
+    const chunk = normalized.slice(start, end).trim()
+    if (chunk) chunks.push(chunk)
+    if (end >= normalized.length) break
+    start = Math.max(end - chunkOverlapChars, start + 1)
+  }
+
+  return chunks
+}
+
+function findChunkBoundary(text: string, start: number, targetEnd: number): number {
+  if (targetEnd >= text.length) return text.length
+
+  const boundaryWindow = text.slice(start, targetEnd)
+  const paragraphBoundary = boundaryWindow.lastIndexOf('\n\n')
+  if (paragraphBoundary > boundaryWindow.length * 0.5) return start + paragraphBoundary
+
+  const sentenceBoundary = Math.max(
+    boundaryWindow.lastIndexOf('. '),
+    boundaryWindow.lastIndexOf('! '),
+    boundaryWindow.lastIndexOf('? '),
+  )
+  if (sentenceBoundary > boundaryWindow.length * 0.5) return start + sentenceBoundary + 1
+
+  const wordBoundary = boundaryWindow.lastIndexOf(' ')
+  if (wordBoundary > boundaryWindow.length * 0.5) return start + wordBoundary
+
+  return targetEnd
+}
+
+function findContactLikeViolation(text: string): string | null {
+  return CONTACT_LIKE_PATTERNS.find(({ pattern }) => pattern.test(text))?.label ?? null
+}
+
+function isCompleteChunkMetadata(metadata: KnowledgeChunkMetadata): boolean {
+  return Boolean(
+    metadata.sourceId &&
+      metadata.title &&
+      metadata.sourceType &&
+      metadata.namespace &&
+      metadata.privacyTier &&
+      metadata.canonicalPathOrUrl &&
+      metadata.contentFingerprint &&
+      Number.isInteger(metadata.chunkIndex) &&
+      Number.isInteger(metadata.chunkCount) &&
+      metadata.ingestRunId,
+  )
+}
+
+function skip(source: KnowledgeSourceManifestEntry, reason: string): KnowledgeIngestionSkippedSource {
+  return {
+    sourceId: source.sourceId,
+    title: source.title,
+    reason,
+  }
+}

--- a/lib/knowledge-source-manifest.ts
+++ b/lib/knowledge-source-manifest.ts
@@ -1,0 +1,73 @@
+import {
+  buildKnowledgeGovernanceStatus,
+  type KnowledgeSourceManifestEntry,
+} from '@/lib/knowledge-governance'
+
+export const KNOWLEDGE_SOURCE_MANIFEST: KnowledgeSourceManifestEntry[] = [
+  {
+    sourceId: 'portfolio-chatbot-products-services',
+    title: 'What AmaduTown Offers',
+    sourceType: 'portfolio_doc',
+    namespace: 'public_chatbot',
+    privacyTier: 'public',
+    canonicalPathOrUrl: 'docs/chatbot-products-and-services-overview.md',
+    intendedConsumers: ['public_chatbot', 'voice_agent'],
+    approvedForRag: true,
+    notes: 'Authoritative public service/product facts; /api/knowledge remains primary.',
+  },
+  {
+    sourceId: 'portfolio-chatbot-campaigns',
+    title: 'Active Promotions and Attraction Campaigns',
+    sourceType: 'portfolio_doc',
+    namespace: 'public_chatbot',
+    privacyTier: 'public',
+    canonicalPathOrUrl: 'docs/chatbot-campaigns-overview.md',
+    intendedConsumers: ['public_chatbot', 'voice_agent'],
+    approvedForRag: true,
+  },
+  {
+    sourceId: 'vambah-personality-public-safe',
+    title: 'Vambah Personality Corpus Public-Safe Pack',
+    sourceType: 'public_safe_corpus',
+    namespace: 'voice_story',
+    privacyTier: 'public_safe',
+    canonicalPathOrUrl: 'docs/vambah-personality-public-safe.md',
+    intendedConsumers: ['public_chatbot', 'outreach_email', 'content_agents'],
+    approvedForRag: true,
+    notes: 'Private-derived aggregate only; raw private exports are not included.',
+  },
+  {
+    sourceId: 'portfolio-user-help-guide',
+    title: 'Portfolio User Help Guide',
+    sourceType: 'portfolio_doc',
+    namespace: 'public_chatbot',
+    privacyTier: 'public',
+    canonicalPathOrUrl: 'docs/user-help-guide.md',
+    intendedConsumers: ['public_chatbot'],
+    approvedForRag: true,
+  },
+  {
+    sourceId: 'admin-sales-lead-pipeline-sop',
+    title: 'Admin Sales Lead Pipeline SOP',
+    sourceType: 'ops_runbook',
+    namespace: 'internal_ops',
+    privacyTier: 'internal',
+    canonicalPathOrUrl: 'docs/admin-sales-lead-pipeline-sop.md',
+    intendedConsumers: ['admin_internal', 'agent_ops'],
+    approvedForRag: true,
+  },
+  {
+    sourceId: 'legacy-publications-pinecone',
+    title: 'Legacy Publications Pinecone Index',
+    sourceType: 'legacy_pinecone',
+    namespace: 'legacy_quarantine',
+    privacyTier: 'internal',
+    canonicalPathOrUrl: 'pinecone://publications',
+    intendedConsumers: ['audit_only'],
+    approvedForRag: false,
+    notes: 'Read-only legacy index retained for audit and rollback until shadow index passes.',
+  },
+]
+
+export const KNOWLEDGE_GOVERNANCE_STATUS =
+  buildKnowledgeGovernanceStatus(KNOWLEDGE_SOURCE_MANIFEST)

--- a/lib/rag-query.ts
+++ b/lib/rag-query.ts
@@ -5,6 +5,7 @@
  */
 
 import { isMockN8nEnabled, isN8nOutboundDisabled } from '@/lib/n8n-runtime-flags'
+import { routePolicyFor, type KnowledgeNamespace, type RagRoute } from '@/lib/knowledge-governance'
 
 /** Kept in sync with `lib/n8n.ts` default base URL (avoid importing the full n8n client from email paths). */
 const N8N_BASE_URL = process.env.N8N_BASE_URL || 'https://amadutown.app.n8n.cloud'
@@ -73,6 +74,10 @@ export function buildEmailRagQueryText(context: {
 export type RagQueryOptions = {
   /** Set for /api/admin/rag-health so connectivity is tested even when EMAIL_RAG_ENABLED=false. */
   ignoreEmailRagEnabled?: boolean
+  /** Route/use case lets n8n constrain namespaces instead of searching all RAG content. */
+  route?: RagRoute
+  /** Optional narrowing within the selected route policy. */
+  allowedNamespaces?: KnowledgeNamespace[]
 }
 
 export type RagSkippedReason =
@@ -95,11 +100,15 @@ export interface RagFetchDiagnostics {
   latency_ms: number | null
   /** True when HTTP succeeded but the normalized RAG block was empty. */
   empty_response: boolean
+  route: RagRoute
+  allowed_namespaces: KnowledgeNamespace[]
+  max_privacy_tier: string
 }
 
 const emptyDiagnostics = (
   query: string,
   skipped: RagSkippedReason,
+  options?: RagQueryOptions,
 ): RagFetchDiagnostics => ({
   rag_query_chars: query.trim().length,
   skipped_reason: skipped,
@@ -108,7 +117,22 @@ const emptyDiagnostics = (
   http_status: null,
   latency_ms: null,
   empty_response: false,
+  ...ragRouteDiagnostics(options),
 })
+
+function ragRouteDiagnostics(options?: RagQueryOptions) {
+  const route = options?.route ?? 'outreach_email'
+  const policy = routePolicyFor(route)
+  const allowed = options?.allowedNamespaces?.length
+    ? options.allowedNamespaces.filter((namespace) => policy.allowedNamespaces.includes(namespace))
+    : policy.allowedNamespaces
+
+  return {
+    route,
+    allowed_namespaces: allowed,
+    max_privacy_tier: policy.maxPrivacyTier,
+  }
+}
 
 /**
  * POST to the RAG webhook and return plain text + structured skip/error/empty flags.
@@ -126,22 +150,23 @@ export async function fetchRagContextForEmailQueryWithDiagnostics(
     http_status: null,
     latency_ms: null,
     empty_response: false,
+    ...ragRouteDiagnostics(options),
   })
 
   if (!options?.ignoreEmailRagEnabled && process.env.EMAIL_RAG_ENABLED === 'false') {
-    return { block: null, diagnostics: emptyDiagnostics(query, 'email_rag_disabled') }
+    return { block: null, diagnostics: emptyDiagnostics(query, 'email_rag_disabled', options) }
   }
 
   if (isN8nOutboundDisabled()) {
-    return { block: null, diagnostics: emptyDiagnostics(query, 'n8n_outbound_disabled') }
+    return { block: null, diagnostics: emptyDiagnostics(query, 'n8n_outbound_disabled', options) }
   }
 
   if (isMockN8nEnabled()) {
-    return { block: null, diagnostics: emptyDiagnostics(query, 'mock_n8n_enabled') }
+    return { block: null, diagnostics: emptyDiagnostics(query, 'mock_n8n_enabled', options) }
   }
 
   if (!q) {
-    return { block: null, diagnostics: emptyDiagnostics(query, 'empty_query') }
+    return { block: null, diagnostics: emptyDiagnostics(query, 'empty_query', options) }
   }
 
   const url = getRagQueryWebhookUrl()
@@ -153,7 +178,7 @@ export async function fetchRagContextForEmailQueryWithDiagnostics(
     const res = await fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-      body: JSON.stringify({ query: q }),
+      body: JSON.stringify({ query: q, ...ragRouteDiagnostics(options) }),
       signal: controller.signal,
     })
 


### PR DESCRIPTION
## Summary

- add a governed knowledge source manifest with namespace, privacy tier, and route policy metadata
- expose RAG knowledge governance status in Agent Mission Control and `/api/admin/rag-health`
- send route, allowed namespace, and max privacy tier diagnostics through email/RAG query calls
- add a shadow-only governed RAG ingestion planner and admin/n8n-triggerable endpoint at `/api/admin/rag-ingest`
- document the ATAS Knowledge OS governance model and legacy Pinecone `publications` audit gates
- update Research & Knowledge agent language around governed ingestion and approval-gated RAG cutover

## Validation

- `npm test -- --run lib/knowledge-governance.test.ts lib/knowledge-ingestion.test.ts lib/__tests__/rag-query.test.ts lib/__tests__/email-llm-context.test.ts lib/agent-organization.test.ts lib/agent-mission-control.test.ts app/api/admin/agents/mission-control/route.test.ts`
- `npx tsc --noEmit --pretty false`
- `npm run lint`
- `git diff --check origin/main...HEAD`

## Notes

- Preserved from dirty local work discovered during integration-captain cleanup.
- Draft until the RAG governance + ingestion slice gets a focused captain review and Vercel preview checks finish.
- No schema changes. No Pinecone writes. No production cutover. Public/private RAG policy remains approval-gated.
