### PR TITLE
fix: load env for deployment watcher traces

### DIFF
--- a/scripts/vercel-deployment-watch.ts
+++ b/scripts/vercel-deployment-watch.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env tsx
+import { config } from 'dotenv'
 import { spawnSync } from 'node:child_process'
+import { resolve } from 'node:path'
 import {
   formatDeploymentWatchSummary,
   getDeploymentWatchGuidance,
@@ -8,6 +10,8 @@ import {
   type DeploymentWatchSummary,
   type GitHubCombinedStatus,
 } from '../lib/vercel-deployment-watch'
+
+config({ path: resolve(process.cwd(), '.env.local') })
 
 type AgentRunModule = typeof import('../lib/agent-run')
 


### PR DESCRIPTION
## Summary
- load .env.local in the deployment watcher CLI before lazy-loading Agent Ops helpers
- keeps normal watcher reads non-mutating while allowing --trace to create Agent Ops runs/artifacts from local autopilot/integration-captain runs

## Validation
- npm test -- --run lib/vercel-deployment-watch.test.ts
- npm run lint -- --file scripts/vercel-deployment-watch.ts --file lib/vercel-deployment-watch.ts --file lib/vercel-deployment-watch.test.ts
- npm run deploy:watch:once -- --ref 5cd912d9044043287be9422da63984670a48fc66 --trace
- verified latest agent_ops_deployment_watch run completed for merge SHA 5cd912d9044043287be9422da63984670a48fc66
- npm run build

## Notes
- no schema changes
- no customer data copied into non-production
- merge remains owned by Integration Captain