### PR TITLE
fix: secure local RAG documents table

### DIFF
--- a/supabase/migrations/20260506090332_secure_documents_local_rag_rls.sql
+++ b/supabase/migrations/20260506090332_secure_documents_local_rag_rls.sql
@@ -1,0 +1,14 @@
+-- Security Advisor 0013: public.documents_local_rag is in an exposed schema.
+-- This local RAG table is server/workflow managed, so enabling RLS without
+-- anon/authenticated policies denies Data API access while preserving
+-- service_role maintenance paths.
+
+DO $$
+BEGIN
+  IF to_regclass('public.documents_local_rag') IS NOT NULL THEN
+    ALTER TABLE public.documents_local_rag ENABLE ROW LEVEL SECURITY;
+
+    COMMENT ON TABLE public.documents_local_rag IS
+      'Local RAG document chunks. RLS is enabled to deny anon/authenticated Data API access; server-side service_role workflows manage retrieval and maintenance.';
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- add a Supabase migration to enable RLS on public.documents_local_rag
- keep anon/authenticated Data API access denied by adding no public policies
- guard the migration so lower environments without the table do not fail

## Validation
- git diff --check -- supabase/migrations/20260506090332_secure_documents_local_rag_rls.sql
- push hook production database health check passed
- production SQL applied via Supabase Management API query path
- production verification: documents_local_rag exists, RLS enabled, 0 public policies, no anon/authenticated grants, intended table comment present
- Supabase security advisors ran against production; documents_local_rag exposed-table warning is cleared. Remaining warnings are unrelated existing function search_path / security-definer / extension-in-public findings.

## Notes
- No data deletion, no policy grants, and no client-data exposure.
- `supabase migration list --linked` still rejects the current SUPABASE_DB_PASSWORD for the production pooler, so migration-history reconciliation should be handled after the prod DB password is corrected/confirmed. The SQL itself is idempotent if `db push` runs later.
