### PR TITLE
feat: report stale sweep coverage by runtime

### DIFF
--- a/app/api/admin/agents/morning-review/route.test.ts
+++ b/app/api/admin/agents/morning-review/route.test.ts
@@ -33,7 +33,12 @@ describe('POST /api/admin/agents/morning-review', () => {
       runId: 'review-run-1',
       generatedAt: '2026-05-01T09:00:00.000Z',
       overall: 'warning',
-      staleSweep: { checked: 2, marked: 1, runIds: ['stale-1'] },
+      staleSweep: {
+        checked: 2,
+        marked: 1,
+        runIds: ['stale-1'],
+        byRuntime: { n8n: { checked: 2, marked: 1 } },
+      },
       slackNotified: false,
       summaryMarkdown: '# Agent Ops Morning Review',
       health: {
@@ -61,7 +66,12 @@ describe('POST /api/admin/agents/morning-review', () => {
       ok: true,
       run_id: 'review-run-1',
       overall: 'warning',
-      stale_sweep: { checked: 2, marked: 1, runIds: ['stale-1'] },
+      stale_sweep: {
+        checked: 2,
+        marked: 1,
+        runIds: ['stale-1'],
+        byRuntime: { n8n: { checked: 2, marked: 1 } },
+      },
       slack_notified: false,
       warnings: ['1 agent run(s) failed in the last 24 hours'],
       summary_markdown: '# Agent Ops Morning Review',

--- a/app/api/admin/agents/runs/stale-sweep/route.test.ts
+++ b/app/api/admin/agents/runs/stale-sweep/route.test.ts
@@ -29,7 +29,12 @@ describe('POST /api/admin/agents/runs/stale-sweep', () => {
     vi.clearAllMocks()
     mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
     mocks.isAuthError.mockReturnValue(false)
-    mocks.sweepStaleAgentRuns.mockResolvedValue({ checked: 3, marked: 1, runIds: ['run-1'] })
+    mocks.sweepStaleAgentRuns.mockResolvedValue({
+      checked: 3,
+      marked: 1,
+      runIds: ['run-1'],
+      byRuntime: { n8n: { checked: 2, marked: 1 }, codex: { checked: 1, marked: 0 } },
+    })
   })
 
   it('requires admin auth', async () => {
@@ -52,6 +57,7 @@ describe('POST /api/admin/agents/runs/stale-sweep', () => {
       checked: 3,
       marked: 1,
       runIds: ['run-1'],
+      byRuntime: { n8n: { checked: 2, marked: 1 }, codex: { checked: 1, marked: 0 } },
     })
   })
 })

--- a/app/api/cron/agent-ops-morning-review/route.test.ts
+++ b/app/api/cron/agent-ops-morning-review/route.test.ts
@@ -25,7 +25,12 @@ describe('POST /api/cron/agent-ops-morning-review', () => {
       runId: 'review-run-1',
       generatedAt: '2026-05-01T09:00:00.000Z',
       overall: 'warning',
-      staleSweep: { checked: 2, marked: 1, runIds: ['stale-1'] },
+      staleSweep: {
+        checked: 2,
+        marked: 1,
+        runIds: ['stale-1'],
+        byRuntime: { n8n: { checked: 2, marked: 1 } },
+      },
       slackNotified: false,
       summaryMarkdown: '# Agent Ops Morning Review',
       health: {
@@ -50,7 +55,12 @@ describe('POST /api/cron/agent-ops-morning-review', () => {
       ok: true,
       run_id: 'review-run-1',
       overall: 'warning',
-      stale_sweep: { checked: 2, marked: 1, runIds: ['stale-1'] },
+      stale_sweep: {
+        checked: 2,
+        marked: 1,
+        runIds: ['stale-1'],
+        byRuntime: { n8n: { checked: 2, marked: 1 } },
+      },
       slack_notified: false,
       warnings: ['1 agent run(s) failed in the last 24 hours'],
       summary_markdown: '# Agent Ops Morning Review',

--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -260,6 +260,7 @@ Current progress:
 - The first grouped view covers runtime, agent, workflow, client/project, and artifact type where trace metadata exists, with safe unassigned fallbacks.
 - Mission Control surfaces the latest `agent_ops_morning_review` and `agent_ops_deployment_watch` traces as Operating Signals.
 - The deployment watcher supports `--trace` so integration-captain and autopilot runs write a visible Agent Ops run/artifact.
+- Stale-run detection now reports checked and marked counts by runtime across `codex`, `n8n`, `hermes`, `opencode`, and `manual` runs when those runtimes have active queued/running work.
 
 ## Cross-Phase Definition Of Done
 

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -161,7 +161,7 @@ This keeps OpenCode/OpenClaw out of production automation until installation, au
 
 ## Stale Run Sweep
 
-Use `POST /api/admin/agents/runs/stale-sweep` or the **Sweep stale** button on `/admin/agents/runs` to mark queued/running runs as `stale` when they pass `stale_after` or the default active-run threshold. Runs waiting for approval are intentionally excluded so human checkpoints do not auto-expire as infrastructure failures.
+Use `POST /api/admin/agents/runs/stale-sweep` or the **Sweep stale** button on `/admin/agents/runs` to mark queued/running runs as `stale` when they pass `stale_after` or the default active-run threshold. The sweep is runtime-neutral across `codex`, `n8n`, `hermes`, `opencode`, and `manual` traces, and reports checked/marked counts by runtime. Runs waiting for approval are intentionally excluded so human checkpoints do not auto-expire as infrastructure failures.
 
 ## Operating Signals
 

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -33,7 +33,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
    - Keep legacy workflow pages active until replacement views are proven.
 
 4. Reporting and hardening
-   - Add all-runtime stale-run detection.
+   - [x] Add all-runtime stale-run detection.
    - [x] Add derived dead-letter handling for failed and stale runs without introducing a separate queue table.
    - [x] Add cost summaries by runtime, agent, workflow, client/project, and artifact type.
    - [x] Keep morning review and deployment watcher outputs visible in Agent Operations.
@@ -56,6 +56,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 - [x] Approval-backed execution payloads and decision metadata in review.
 - [x] n8n trace callback envelope and generic stage callback endpoint in review.
 - [x] Dead-letter monitor for failed/stale traces in review.
+- [x] All-runtime stale sweep coverage reporting in review.
 - [x] Cost Intelligence summary by runtime, agent, workflow, client/project, and artifact type in review.
 - [x] Operating Signals for morning review and deployment watcher traces in review.
 

--- a/lib/agent-ops-morning-review.test.ts
+++ b/lib/agent-ops-morning-review.test.ts
@@ -25,7 +25,16 @@ describe('buildAgentOpsMorningReviewMarkdown', () => {
       generatedAt: '2026-05-01T09:00:00.000Z',
       overall: 'warning',
       runId: 'run-1',
-      staleSweep: { checked: 4, marked: 1, runIds: ['stale-1'] },
+      staleSweep: {
+        checked: 4,
+        marked: 1,
+        runIds: ['stale-1'],
+        byRuntime: {
+          codex: { checked: 1, marked: 0 },
+          n8n: { checked: 2, marked: 1 },
+          hermes: { checked: 1, marked: 0 },
+        },
+      },
       health: {
         generatedAt: '2026-05-01T09:00:00.000Z',
         overall: 'warning',
@@ -49,6 +58,8 @@ describe('buildAgentOpsMorningReviewMarkdown', () => {
     expect(markdown).toContain('Overall: warning')
     expect(markdown).toContain('- Active runs checked: 4')
     expect(markdown).toContain('- Runs marked stale: 1')
+    expect(markdown).toContain('### Runtime Coverage')
+    expect(markdown).toContain('- n8n: checked 2, marked 1')
     expect(markdown).toContain('- Agent runs: 8')
     expect(markdown).toContain('- Cost total: $0.1234')
     expect(markdown).toContain('- 1 agent run(s) failed in the last 24 hours')

--- a/lib/agent-ops-morning-review.ts
+++ b/lib/agent-ops-morning-review.ts
@@ -37,6 +37,9 @@ export function buildAgentOpsMorningReviewMarkdown(input: {
 }) {
   const agentOpsUrl = `${baseUrl()}/admin/agents/runs${input.runId ? `/${input.runId}` : ''}`
   const recent = input.health.signals.agentRuns24h
+  const runtimeLines = Object.entries(input.staleSweep.byRuntime)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([runtime, summary]) => `- ${runtime}: checked ${summary.checked}, marked ${summary.marked}`)
 
   return [
     '# Agent Ops Morning Review',
@@ -49,6 +52,7 @@ export function buildAgentOpsMorningReviewMarkdown(input: {
     '',
     `- Active runs checked: ${input.staleSweep.checked}`,
     `- Runs marked stale: ${input.staleSweep.marked}`,
+    ...(runtimeLines.length ? ['', '### Runtime Coverage', '', ...runtimeLines] : []),
     '',
     '## Last 24 Hours',
     '',
@@ -188,6 +192,7 @@ export async function runAgentOpsMorningReview(triggerSource = 'cron_agent_ops_m
         overall: health.overall,
         warning_count: health.warnings.length,
         stale_marked: staleSweep.marked,
+        stale_by_runtime: staleSweep.byRuntime,
         slack_notified: slackNotified,
         generated_at: generatedAt,
       },

--- a/lib/agent-stale-runs.test.ts
+++ b/lib/agent-stale-runs.test.ts
@@ -4,7 +4,7 @@ vi.mock('@/lib/supabase', () => ({
   supabaseAdmin: null,
 }))
 
-import { isAgentRunStale } from './agent-stale-runs'
+import { buildStaleSweepResult, isAgentRunStale } from './agent-stale-runs'
 
 const now = new Date('2026-04-30T12:00:00.000Z')
 
@@ -43,5 +43,35 @@ describe('isAgentRunStale', () => {
       started_at: '2026-04-30T10:00:00.000Z',
       stale_after: null,
     }, now)).toBe(false)
+  })
+
+  it('summarizes stale sweep coverage across all supported runtimes', () => {
+    const candidates = [
+      { id: 'codex-1', runtime: 'codex' },
+      { id: 'n8n-1', runtime: 'n8n' },
+      { id: 'hermes-1', runtime: 'hermes' },
+      { id: 'opencode-1', runtime: 'opencode' },
+      { id: 'manual-1', runtime: 'manual' },
+    ]
+    const result = buildStaleSweepResult(candidates, [
+      { id: 'codex-1', runtime: 'codex' },
+      { id: 'n8n-1', runtime: 'n8n' },
+      { id: 'hermes-1', runtime: 'hermes' },
+      { id: 'opencode-1', runtime: 'opencode' },
+      { id: 'manual-1', runtime: 'manual' },
+    ])
+
+    expect(result).toEqual({
+      checked: 5,
+      marked: 5,
+      runIds: ['codex-1', 'n8n-1', 'hermes-1', 'opencode-1', 'manual-1'],
+      byRuntime: {
+        codex: { checked: 1, marked: 1 },
+        n8n: { checked: 1, marked: 1 },
+        hermes: { checked: 1, marked: 1 },
+        opencode: { checked: 1, marked: 1 },
+        manual: { checked: 1, marked: 1 },
+      },
+    })
   })
 })

--- a/lib/agent-stale-runs.ts
+++ b/lib/agent-stale-runs.ts
@@ -17,6 +17,7 @@ export type StaleSweepResult = {
   checked: number
   marked: number
   runIds: string[]
+  byRuntime: Record<string, { checked: number; marked: number }>
 }
 
 export function isAgentRunStale(
@@ -37,6 +38,30 @@ function db() {
     throw new Error('Database not available')
   }
   return supabaseAdmin
+}
+
+export function buildStaleSweepResult(
+  candidates: Pick<StaleAgentRunCandidate, 'id' | 'runtime'>[],
+  staleRuns: Pick<StaleAgentRunCandidate, 'id' | 'runtime'>[],
+): StaleSweepResult {
+  const byRuntime: StaleSweepResult['byRuntime'] = {}
+
+  for (const run of candidates) {
+    byRuntime[run.runtime] ??= { checked: 0, marked: 0 }
+    byRuntime[run.runtime].checked += 1
+  }
+
+  for (const run of staleRuns) {
+    byRuntime[run.runtime] ??= { checked: 0, marked: 0 }
+    byRuntime[run.runtime].marked += 1
+  }
+
+  return {
+    checked: candidates.length,
+    marked: staleRuns.length,
+    runIds: staleRuns.map((run) => run.id),
+    byRuntime,
+  }
 }
 
 export async function sweepStaleAgentRuns(now = new Date()): Promise<StaleSweepResult> {
@@ -93,9 +118,5 @@ export async function sweepStaleAgentRuns(now = new Date()): Promise<StaleSweepR
       })
   }
 
-  return {
-    checked: candidates.length,
-    marked: staleRuns.length,
-    runIds: staleRuns.map((run) => run.id),
-  }
+  return buildStaleSweepResult(candidates, staleRuns)
 }


### PR DESCRIPTION
## Summary
- report stale sweep checked/marked counts by runtime across active Agent Ops traces
- include runtime coverage in the Agent Ops morning review report
- mark all-runtime stale detection complete in the Agent Operations roadmap/task list

## Validation
- npm test -- --run lib/agent-stale-runs.test.ts lib/agent-ops-morning-review.test.ts app/api/admin/agents/runs/stale-sweep/route.test.ts app/api/admin/agents/morning-review/route.test.ts app/api/cron/agent-ops-morning-review/route.test.ts
- npm run lint -- --file lib/agent-stale-runs.ts --file lib/agent-stale-runs.test.ts --file lib/agent-ops-morning-review.ts --file lib/agent-ops-morning-review.test.ts --file app/api/admin/agents/runs/stale-sweep/route.test.ts --file app/api/admin/agents/morning-review/route.test.ts --file app/api/cron/agent-ops-morning-review/route.test.ts
- npm run build
- local smoke with MOCK_N8N=true N8N_DISABLE_OUTBOUND=true npm run dev -- --port 3002; /admin/agents 200 and /api/health 200

## Notes
- no schema changes
- no production customer data copied into non-production
- merge remains owned by Integration Captain