### PR TITLE
feat: add Agent Ops budget policy rules

### DIFF
--- a/app/api/admin/agents/chief-of-staff/chat/route.test.ts
+++ b/app/api/admin/agents/chief-of-staff/chat/route.test.ts
@@ -65,6 +65,13 @@ describe('POST /api/admin/agents/chief-of-staff/chat', () => {
         },
       ],
       model: 'gpt-4o-mini',
+      budgetDecision: {
+        status: 'allowed',
+        estimatedCostUsd: 0.001,
+        warningUsd: 0.25,
+        limitUsd: 1,
+        rule: { key: 'llm_codex_per_call' },
+      },
     })
   })
 
@@ -120,6 +127,13 @@ describe('POST /api/admin/agents/chief-of-staff/chat', () => {
         },
       ],
       model: 'gpt-4o-mini',
+      budget_decision: {
+        status: 'allowed',
+        estimated_cost_usd: 0.001,
+        warning_usd: 0.25,
+        limit_usd: 1,
+        rule_key: 'llm_codex_per_call',
+      },
     })
     expect(mocks.runChiefOfStaffChat).toHaveBeenCalledWith(expect.objectContaining({
       message: 'What needs attention?',

--- a/app/api/admin/agents/chief-of-staff/chat/route.ts
+++ b/app/api/admin/agents/chief-of-staff/chat/route.ts
@@ -53,6 +53,13 @@ export async function POST(request: NextRequest) {
       action_proposals: result.actionProposals,
       agent_engagements: result.agentEngagements,
       model: result.model,
+      budget_decision: {
+        status: result.budgetDecision.status,
+        estimated_cost_usd: result.budgetDecision.estimatedCostUsd,
+        warning_usd: result.budgetDecision.warningUsd,
+        limit_usd: result.budgetDecision.limitUsd,
+        rule_key: result.budgetDecision.rule.key,
+      },
     })
   } catch (error) {
     console.error('[chief-of-staff-chat] failed:', error)

--- a/app/api/admin/agents/policies/route.test.ts
+++ b/app/api/admin/agents/policies/route.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+import { GET } from './route'
+
+function request() {
+  return new Request('http://localhost/api/admin/agents/policies', {
+    headers: { authorization: 'Bearer token' },
+  })
+}
+
+describe('GET /api/admin/agents/policies', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await GET(request() as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+  })
+
+  it('returns runtime policies, approval gates, and budget rules', async () => {
+    const response = await GET(request() as never)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.policies).toEqual(expect.arrayContaining([
+      expect.objectContaining({ runtime: 'codex' }),
+      expect.objectContaining({ runtime: 'n8n' }),
+    ]))
+    expect(body.approval_gates).toEqual(expect.arrayContaining([
+      expect.objectContaining({ action: 'send_email' }),
+    ]))
+    expect(body.budget_rules).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        key: 'llm_n8n_per_call',
+        runtime: 'n8n',
+        scope: 'per_call',
+      }),
+      expect.objectContaining({
+        key: 'llm_default_per_call',
+        runtime: 'any',
+      }),
+    ]))
+  })
+})

--- a/app/api/admin/agents/policies/route.ts
+++ b/app/api/admin/agents/policies/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { DEFAULT_AGENT_BUDGET_RULES } from '@/lib/agent-budget-policy'
 import { APPROVAL_GATES, RUNTIME_POLICIES } from '@/lib/agent-policy'
 
 export const dynamic = 'force-dynamic'
@@ -13,5 +14,6 @@ export async function GET(request: NextRequest) {
   return NextResponse.json({
     policies: RUNTIME_POLICIES,
     approval_gates: APPROVAL_GATES,
+    budget_rules: DEFAULT_AGENT_BUDGET_RULES,
   })
 }

--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -265,6 +265,7 @@ Current progress:
 - `docs/agentic-patterns.md` now reflects the stronger Agent Ops observability state while preserving partial coverage notes for legacy/domain flows.
 - Video generation workflow sync runs now create linked Agent Ops traces while preserving the existing domain status table for admin chips/history.
 - Pre-flight budget policy helpers now define per-runtime LLM warning/cap rules and expose them through the admin policy API; enforcement remains adoption-by-adoption, not a silent global behavior change.
+- Chief of Staff chat now runs a traced pre-flight budget check before dispatching its LLM call, carrying the budget decision into cost metadata and the API response.
 
 ## Cross-Phase Definition Of Done
 

--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -264,6 +264,7 @@ Current progress:
 - Legacy workflow-specific run tables are mapped in `docs/agent-operations-rollout.md` as either domain detail to keep or future trace-link migration candidates.
 - `docs/agentic-patterns.md` now reflects the stronger Agent Ops observability state while preserving partial coverage notes for legacy/domain flows.
 - Video generation workflow sync runs now create linked Agent Ops traces while preserving the existing domain status table for admin chips/history.
+- Pre-flight budget policy helpers now define per-runtime LLM warning/cap rules and expose them through the admin policy API; enforcement remains adoption-by-adoption, not a silent global behavior change.
 
 ## Cross-Phase Definition Of Done
 

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -168,6 +168,7 @@ V1 budget policy is advisory and pre-flight ready:
 - runtime-specific per-call LLM warning and cap thresholds exist for `codex`, `n8n`, `hermes`, `opencode`, and `manual`;
 - estimates use the existing LLM cost calculator and model-provider inference;
 - blocked decisions can be raised by shared helpers before dispatch;
+- Chief of Staff chat is the first adopted path and records its budget decision before LLM dispatch;
 - live workflows are not yet globally blocked until each adoption path has a targeted test and approval gate.
 
 Slack should be treated as a notification and lightweight decision surface later. The source of truth remains Portfolio admin plus `agent_approvals`.

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -161,6 +161,15 @@ Current required approval gates:
 - production config changes
 - public content derived from private material
 
+Budget policy rules live in `lib/agent-budget-policy.ts` and are exposed by `GET /api/admin/agents/policies`.
+
+V1 budget policy is advisory and pre-flight ready:
+
+- runtime-specific per-call LLM warning and cap thresholds exist for `codex`, `n8n`, `hermes`, `opencode`, and `manual`;
+- estimates use the existing LLM cost calculator and model-provider inference;
+- blocked decisions can be raised by shared helpers before dispatch;
+- live workflows are not yet globally blocked until each adoption path has a targeted test and approval gate.
+
 Slack should be treated as a notification and lightweight decision surface later. The source of truth remains Portfolio admin plus `agent_approvals`.
 
 ## Approval Drill

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -63,6 +63,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 - [x] Cost Intelligence summary by runtime, agent, workflow, client/project, and artifact type in review.
 - [x] Operating Signals for morning review and deployment watcher traces in review.
 - [x] Pre-flight budget policy helpers and admin policy API visibility in review.
+- [x] Chief of Staff chat pre-flight budget adoption in review.
 
 ## Scope Guard
 

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -62,6 +62,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 - [x] All-runtime stale sweep coverage reporting in review.
 - [x] Cost Intelligence summary by runtime, agent, workflow, client/project, and artifact type in review.
 - [x] Operating Signals for morning review and deployment watcher traces in review.
+- [x] Pre-flight budget policy helpers and admin policy API visibility in review.
 
 ## Scope Guard
 

--- a/docs/agentic-patterns.md
+++ b/docs/agentic-patterns.md
@@ -416,6 +416,7 @@ Each section follows the same template: *Definition · Where we use it today · 
 **Where we use it today.**
 - [`lib/cost-calculator.ts`](../lib/cost-calculator.ts) computes post-hoc costs.
 - [`lib/agent-budget-policy.ts`](../lib/agent-budget-policy.ts) defines pre-flight per-runtime LLM warning and cap rules.
+- Chief of Staff chat checks the Agent Ops budget policy before dispatch and logs the decision in its trace metadata.
 - Cost-events ingest accumulates spend per event.
 - `cost_events.agent_run_id` links usage costs to shared Agent Ops traces.
 - Mission Control derives 24-hour Cost Intelligence by runtime, agent, workflow, client/project, and artifact type where run metadata exists.

--- a/docs/agentic-patterns.md
+++ b/docs/agentic-patterns.md
@@ -415,6 +415,7 @@ Each section follows the same template: *Definition · Where we use it today · 
 
 **Where we use it today.**
 - [`lib/cost-calculator.ts`](../lib/cost-calculator.ts) computes post-hoc costs.
+- [`lib/agent-budget-policy.ts`](../lib/agent-budget-policy.ts) defines pre-flight per-runtime LLM warning and cap rules.
 - Cost-events ingest accumulates spend per event.
 - `cost_events.agent_run_id` links usage costs to shared Agent Ops traces.
 - Mission Control derives 24-hour Cost Intelligence by runtime, agent, workflow, client/project, and artifact type where run metadata exists.
@@ -422,7 +423,7 @@ Each section follows the same template: *Definition · Where we use it today · 
 **Coverage.** Strong post-hoc; Partial pre-flight.
 
 **Gaps.**
-- No pre-flight budget cap — a runaway loop can rack up cost before the monitor fires.
+- Pre-flight budget evaluation exists, but it is not yet enforced across every LLM dispatch path.
 - Model IDs are hard-coded at call sites; no tenant/tier-aware policy.
 
 **Retrofit backlog.** Ticket [#5](#top-retrofit-tickets) — policy router selects model + budget by tier.
@@ -481,7 +482,7 @@ These are the first five PR-sized items seeded from the scorecard. Ticket 1 has 
 - **Scope.** Add `lib/llm/policy-router.ts` that chooses `{ provider, model, maxOutputTokens, budgetUsd }` given a `{ feature, tenantTier, env }` input. Defaults live in config; overrides via env vars per [`.cursor/rules/n8n-integration.mdc`](../.cursor/rules/n8n-integration.mdc) pattern. First adoption in [`lib/ai-onboarding-generator.ts`](../lib/ai-onboarding-generator.ts).
 - **Acceptance criteria.**
   - Every LLM call in the onboarding generator goes through the router; no literal model strings remain in that file.
-  - Router refuses to dispatch a call whose estimated cost exceeds the budget cap and logs the refusal.
+  - Router reuses the Agent Ops budget policy helper, refuses to dispatch a call whose estimated cost exceeds the budget cap, and logs the refusal.
   - Scorecard rows for Routing and Cost/Resource Control updated.
 
 ---

--- a/lib/agent-budget-policy.test.ts
+++ b/lib/agent-budget-policy.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assertAgentBudgetAllowed,
+  evaluateAgentBudget,
+  estimateAgentLlmCost,
+  getAgentBudgetRule,
+} from './agent-budget-policy'
+
+describe('agent budget policy', () => {
+  it('allows a low-cost manual admin LLM estimate', () => {
+    const decision = evaluateAgentBudget({
+      runtime: 'manual',
+      model: 'gpt-4o-mini',
+      estimatedInputTokens: 1_000,
+      estimatedOutputTokens: 1_000,
+    })
+
+    expect(decision.status).toBe('allowed')
+    expect(decision.estimatedCostUsd).toBeCloseTo(0.00075, 6)
+    expect(decision.rule.key).toBe('llm_manual_per_call')
+  })
+
+  it('warns when the estimate crosses the runtime warning threshold', () => {
+    const decision = evaluateAgentBudget({
+      runtime: 'hermes',
+      model: 'claude-3-5-haiku-20241022',
+      estimatedInputTokens: 10_000,
+      estimatedOutputTokens: 10_000,
+    })
+
+    expect(decision.status).toBe('warning')
+    expect(decision.estimatedCostUsd).toBeCloseTo(0.048, 6)
+    expect(decision.warningUsd).toBe(0.02)
+    expect(decision.limitUsd).toBe(0.1)
+  })
+
+  it('blocks a high-cost Codex estimate before dispatch', () => {
+    const decision = evaluateAgentBudget({
+      runtime: 'codex',
+      model: 'gpt-4o',
+      estimatedInputTokens: 100_000,
+      estimatedOutputTokens: 100_000,
+    })
+
+    expect(decision.status).toBe('blocked')
+    expect(decision.estimatedCostUsd).toBeCloseTo(1.25, 6)
+    expect(() => assertAgentBudgetAllowed({
+      runtime: 'codex',
+      model: 'gpt-4o',
+      estimatedInputTokens: 100_000,
+      estimatedOutputTokens: 100_000,
+    })).toThrow(/exceeds Codex LLM call cap/)
+  })
+
+  it('uses provider fallbacks for unknown model ids', () => {
+    expect(estimateAgentLlmCost({
+      runtime: 'n8n',
+      model: 'gpt-future-model',
+      estimatedInputTokens: 1_000,
+      estimatedOutputTokens: 1_000,
+    })).toBeCloseTo(0.0125, 6)
+
+    expect(estimateAgentLlmCost({
+      runtime: 'n8n',
+      model: 'claude-future-model',
+      estimatedInputTokens: 1_000,
+      estimatedOutputTokens: 1_000,
+    })).toBeCloseTo(0.018, 6)
+  })
+
+  it('falls back to the default rule when no runtime-specific rule exists', () => {
+    const rule = getAgentBudgetRule('n8n', [
+      {
+        key: 'fallback',
+        label: 'Fallback',
+        runtime: 'any',
+        scope: 'per_call',
+        warningUsd: 0.01,
+        limitUsd: 0.02,
+        notes: 'test fallback',
+      },
+    ])
+
+    expect(rule.key).toBe('fallback')
+  })
+})

--- a/lib/agent-budget-policy.ts
+++ b/lib/agent-budget-policy.ts
@@ -1,0 +1,171 @@
+import type { AgentRuntime } from '@/lib/agent-run'
+import { computeAnthropicCost, computeOpenAICost, type Usage } from '@/lib/cost-calculator'
+import { inferProvider } from '@/lib/constants/llm-models'
+
+export type AgentBudgetDecisionStatus = 'allowed' | 'warning' | 'blocked'
+export type AgentBudgetScope = 'per_call' | 'per_run' | 'daily'
+export type AgentBudgetRuntime = AgentRuntime | 'any'
+
+export interface AgentBudgetRule {
+  key: string
+  label: string
+  runtime: AgentBudgetRuntime
+  scope: AgentBudgetScope
+  warningUsd: number
+  limitUsd: number
+  appliesTo?: string[]
+  notes: string
+}
+
+export interface AgentBudgetEstimateInput {
+  runtime: AgentRuntime
+  model: string
+  estimatedInputTokens?: number
+  estimatedOutputTokens?: number
+  maxTokens?: number
+  metadata?: Record<string, unknown>
+}
+
+export interface AgentBudgetDecision {
+  status: AgentBudgetDecisionStatus
+  estimatedCostUsd: number
+  limitUsd: number
+  warningUsd: number
+  rule: AgentBudgetRule
+  reason: string
+}
+
+export const DEFAULT_AGENT_BUDGET_RULES: AgentBudgetRule[] = [
+  {
+    key: 'llm_codex_per_call',
+    label: 'Codex LLM call',
+    runtime: 'codex',
+    scope: 'per_call',
+    warningUsd: 0.25,
+    limitUsd: 1,
+    notes: 'Engineering operator calls can be larger, but should still surface cost risk before dispatch.',
+  },
+  {
+    key: 'llm_n8n_per_call',
+    label: 'n8n LLM call',
+    runtime: 'n8n',
+    scope: 'per_call',
+    warningUsd: 0.1,
+    limitUsd: 0.5,
+    notes: 'Production automation calls should remain tightly bounded unless an approved workflow overrides the cap.',
+  },
+  {
+    key: 'llm_hermes_per_call',
+    label: 'Hermes LLM call',
+    runtime: 'hermes',
+    scope: 'per_call',
+    warningUsd: 0.02,
+    limitUsd: 0.1,
+    notes: 'Hermes remains a secondary read-only runtime in v1; larger work should route through approval.',
+  },
+  {
+    key: 'llm_opencode_per_call',
+    label: 'OpenCode evaluation LLM call',
+    runtime: 'opencode',
+    scope: 'per_call',
+    warningUsd: 0.02,
+    limitUsd: 0.1,
+    notes: 'OpenCode/OpenClaw evaluation calls stay small until runtime audit behavior is proven.',
+  },
+  {
+    key: 'llm_manual_per_call',
+    label: 'Manual admin LLM call',
+    runtime: 'manual',
+    scope: 'per_call',
+    warningUsd: 0.05,
+    limitUsd: 0.25,
+    notes: 'Human-triggered admin calls should show cost risk before creating expensive one-off work.',
+  },
+  {
+    key: 'llm_default_per_call',
+    label: 'Default LLM call',
+    runtime: 'any',
+    scope: 'per_call',
+    warningUsd: 0.1,
+    limitUsd: 0.5,
+    notes: 'Fallback rule for unknown or future runtimes until a runtime-specific policy is defined.',
+  },
+]
+
+export function getAgentBudgetRule(
+  runtime: AgentRuntime,
+  rules: AgentBudgetRule[] = DEFAULT_AGENT_BUDGET_RULES,
+): AgentBudgetRule {
+  return (
+    rules.find((rule) => rule.runtime === runtime && rule.scope === 'per_call') ??
+    rules.find((rule) => rule.runtime === 'any' && rule.scope === 'per_call') ??
+    DEFAULT_AGENT_BUDGET_RULES[DEFAULT_AGENT_BUDGET_RULES.length - 1]
+  )
+}
+
+export function estimateAgentLlmCost(input: AgentBudgetEstimateInput): number {
+  const outputTokens = input.estimatedOutputTokens ?? input.maxTokens ?? 0
+  const usage: Usage = {
+    prompt_tokens: input.estimatedInputTokens ?? 0,
+    completion_tokens: outputTokens,
+    input_tokens: input.estimatedInputTokens ?? 0,
+    output_tokens: outputTokens,
+  }
+
+  const provider = inferProvider(input.model)
+  const cost = provider === 'anthropic'
+    ? computeAnthropicCost(usage, input.model)
+    : computeOpenAICost(usage, input.model)
+
+  return Math.round(cost * 1_000_000) / 1_000_000
+}
+
+export function evaluateAgentBudget(
+  input: AgentBudgetEstimateInput,
+  rules: AgentBudgetRule[] = DEFAULT_AGENT_BUDGET_RULES,
+): AgentBudgetDecision {
+  const rule = getAgentBudgetRule(input.runtime, rules)
+  const estimatedCostUsd = estimateAgentLlmCost(input)
+
+  if (estimatedCostUsd > rule.limitUsd) {
+    return {
+      status: 'blocked',
+      estimatedCostUsd,
+      warningUsd: rule.warningUsd,
+      limitUsd: rule.limitUsd,
+      rule,
+      reason: `Estimated cost $${estimatedCostUsd.toFixed(4)} exceeds ${rule.label} cap $${rule.limitUsd.toFixed(4)}.`,
+    }
+  }
+
+  if (estimatedCostUsd > rule.warningUsd) {
+    return {
+      status: 'warning',
+      estimatedCostUsd,
+      warningUsd: rule.warningUsd,
+      limitUsd: rule.limitUsd,
+      rule,
+      reason: `Estimated cost $${estimatedCostUsd.toFixed(4)} exceeds ${rule.label} warning $${rule.warningUsd.toFixed(4)}.`,
+    }
+  }
+
+  return {
+    status: 'allowed',
+    estimatedCostUsd,
+    warningUsd: rule.warningUsd,
+    limitUsd: rule.limitUsd,
+    rule,
+    reason: `Estimated cost $${estimatedCostUsd.toFixed(4)} is within ${rule.label} budget.`,
+  }
+}
+
+export function assertAgentBudgetAllowed(
+  input: AgentBudgetEstimateInput,
+  rules: AgentBudgetRule[] = DEFAULT_AGENT_BUDGET_RULES,
+): AgentBudgetDecision {
+  const decision = evaluateAgentBudget(input, rules)
+  if (decision.status === 'blocked') {
+    throw new Error(decision.reason)
+  }
+  return decision
+}

--- a/lib/chief-of-staff-chat.test.ts
+++ b/lib/chief-of-staff-chat.test.ts
@@ -18,6 +18,7 @@ vi.mock('@/lib/supabase', () => ({
 
 import {
   buildChiefOfStaffPrompt,
+  evaluateChiefOfStaffBudget,
   getChiefOfStaffAgentRoutingCatalog,
   normalizeChiefOfStaffHistory,
   parseChiefOfStaffJson,
@@ -170,6 +171,30 @@ describe('Chief of Staff chat helpers', () => {
     expect(prompt.userPrompt).toContain('Strategy & Narrative Pod')
     expect(prompt.userPrompt).toContain('Portfolio Credential Rotation Due Report')
     expect(prompt.userPrompt).toContain('What needs attention?')
+  })
+
+  it('evaluates the Chief of Staff LLM budget before dispatch', () => {
+    const decision = evaluateChiefOfStaffBudget({
+      model: 'gpt-4o-mini',
+      systemPrompt: 'You are the Chief of Staff Agent.',
+      userPrompt: 'Summarize the current operating state.',
+      maxTokens: 900,
+    })
+
+    expect(decision.status).toBe('allowed')
+    expect(decision.rule.key).toBe('llm_codex_per_call')
+  })
+
+  it('blocks oversized Chief of Staff prompts before dispatch', () => {
+    const decision = evaluateChiefOfStaffBudget({
+      model: 'gpt-4o',
+      systemPrompt: 'x'.repeat(2_000_000),
+      userPrompt: 'y'.repeat(2_000_000),
+      maxTokens: 100_000,
+    })
+
+    expect(decision.status).toBe('blocked')
+    expect(decision.reason).toContain('exceeds Codex LLM call cap')
   })
 
   it('keeps the Chief of Staff router aligned to the agent organization map', () => {

--- a/lib/chief-of-staff-chat.ts
+++ b/lib/chief-of-staff-chat.ts
@@ -11,6 +11,10 @@ import {
   getApprovalGate,
   type AgentAction,
 } from '@/lib/agent-policy'
+import {
+  evaluateAgentBudget,
+  type AgentBudgetDecision,
+} from '@/lib/agent-budget-policy'
 import { AGENT_ORGANIZATION, AGENT_PODS, getAgentByKey } from '@/lib/agent-organization'
 import {
   listCodexAutomationInventory,
@@ -36,6 +40,7 @@ export type ChiefOfStaffChatResponse = {
   actionProposals: ChiefOfStaffActionProposal[]
   agentEngagements: ChiefOfStaffAgentEngagementProposal[]
   model: string
+  budgetDecision: AgentBudgetDecision
 }
 
 export type ChiefOfStaffActionProposal = {
@@ -139,6 +144,7 @@ export type ChiefOfStaffAgentRoutingEntry = {
 }
 
 const DEFAULT_MODEL = 'gpt-4o-mini'
+const DEFAULT_MAX_TOKENS = 900
 const CHIEF_OF_STAFF_ACTIONS: AgentAction[] = [
   'read_files',
   'write_files',
@@ -161,6 +167,25 @@ function assertDatabase() {
     throw new Error('Database not available')
   }
   return supabaseAdmin
+}
+
+function estimateTokensFromText(text: string): number {
+  return Math.ceil(text.length / 4)
+}
+
+export function evaluateChiefOfStaffBudget(input: {
+  model: string
+  systemPrompt: string
+  userPrompt: string
+  maxTokens?: number
+}): AgentBudgetDecision {
+  return evaluateAgentBudget({
+    runtime: 'codex',
+    model: input.model,
+    estimatedInputTokens: estimateTokensFromText(`${input.systemPrompt}\n${input.userPrompt}`),
+    maxTokens: input.maxTokens ?? DEFAULT_MAX_TOKENS,
+    metadata: { operation: 'chief_of_staff_chat' },
+  })
 }
 
 export function getChiefOfStaffAgentRoutingCatalog(): ChiefOfStaffAgentRoutingEntry[] {
@@ -516,16 +541,64 @@ export async function runChiefOfStaffChat(input: ChiefOfStaffChatRequest): Promi
       { role: 'user', content: message },
     ])
     const model = process.env.CHIEF_OF_STAFF_AGENT_MODEL || DEFAULT_MODEL
+    const budgetDecision = evaluateChiefOfStaffBudget({
+      model,
+      systemPrompt: prompt.systemPrompt,
+      userPrompt: prompt.userPrompt,
+      maxTokens: DEFAULT_MAX_TOKENS,
+    })
+
+    await recordAgentStep({
+      runId: run.id,
+      stepKey: 'budget_check',
+      name: 'Checked Chief of Staff budget',
+      status: budgetDecision.status === 'blocked' ? 'failed' : 'completed',
+      outputSummary: budgetDecision.reason,
+      metadata: {
+        budget_status: budgetDecision.status,
+        estimated_cost_usd: budgetDecision.estimatedCostUsd,
+        warning_usd: budgetDecision.warningUsd,
+        limit_usd: budgetDecision.limitUsd,
+        rule_key: budgetDecision.rule.key,
+      },
+    })
+
+    if (budgetDecision.status !== 'allowed') {
+      await recordAgentEvent({
+        runId: run.id,
+        eventType: 'agent_budget_policy_decision',
+        severity: budgetDecision.status === 'blocked' ? 'error' : 'warning',
+        message: budgetDecision.reason,
+        metadata: {
+          budget_status: budgetDecision.status,
+          estimated_cost_usd: budgetDecision.estimatedCostUsd,
+          warning_usd: budgetDecision.warningUsd,
+          limit_usd: budgetDecision.limitUsd,
+          rule_key: budgetDecision.rule.key,
+          model,
+        },
+      })
+    }
+
+    if (budgetDecision.status === 'blocked') {
+      throw new Error(budgetDecision.reason)
+    }
+
     const completion = await generateJsonCompletion({
       model,
       systemPrompt: prompt.systemPrompt,
       userPrompt: prompt.userPrompt,
       temperature: 0.3,
-      maxTokens: 900,
+      maxTokens: DEFAULT_MAX_TOKENS,
       costContext: {
         agentRunId: run.id,
         reference: { type: 'agent', id: 'chief-of-staff' },
-        metadata: { operation: 'chief_of_staff_chat' },
+        metadata: {
+          operation: 'chief_of_staff_chat',
+          budget_status: budgetDecision.status,
+          budget_rule_key: budgetDecision.rule.key,
+          estimated_cost_usd: budgetDecision.estimatedCostUsd,
+        },
       },
     })
 
@@ -540,6 +613,11 @@ export async function runChiefOfStaffChat(input: ChiefOfStaffChatRequest): Promi
       outputSummary: parsed.reply.slice(0, 500),
       metadata: {
         model,
+        budget_decision: {
+          status: budgetDecision.status,
+          estimatedCostUsd: budgetDecision.estimatedCostUsd,
+          ruleKey: budgetDecision.rule.key,
+        },
         suggested_actions: parsed.suggestedActions,
         action_proposals: parsed.actionProposals,
         agent_engagements: parsed.agentEngagements,
@@ -552,6 +630,11 @@ export async function runChiefOfStaffChat(input: ChiefOfStaffChatRequest): Promi
       currentStep: 'Reply ready',
       outcome: {
         reply_preview: parsed.reply.slice(0, 500),
+        budget_decision: {
+          status: budgetDecision.status,
+          estimatedCostUsd: budgetDecision.estimatedCostUsd,
+          ruleKey: budgetDecision.rule.key,
+        },
         suggested_actions: parsed.suggestedActions,
         action_proposals: parsed.actionProposals,
         agent_engagements: parsed.agentEngagements,
@@ -565,6 +648,7 @@ export async function runChiefOfStaffChat(input: ChiefOfStaffChatRequest): Promi
       actionProposals: parsed.actionProposals,
       agentEngagements: parsed.agentEngagements,
       model,
+      budgetDecision,
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Chief of Staff chat failed'


### PR DESCRIPTION
## Summary
- add a pure Agent Ops budget-policy helper for per-runtime LLM warnings and caps
- expose budget rules through the existing admin agent policies API
- adopt the policy in Chief of Staff chat before LLM dispatch, with traced allowed/warning/blocked decisions
- document that broader enforcement remains adoption-by-adoption, not a silent global behavior change

## Validation
- npm test -- --run lib/agent-budget-policy.test.ts app/api/admin/agents/policies/route.test.ts lib/agent-policy.test.ts
- npm test -- --run lib/chief-of-staff-chat.test.ts app/api/admin/agents/chief-of-staff/chat/route.test.ts lib/agent-budget-policy.test.ts app/api/admin/agents/policies/route.test.ts
- npx tsc --noEmit --pretty false
- git diff --check
- npm run build

## Safety
- No schema changes.
- No live workflow triggers.
- No production or customer data copied into non-production.
- Push hook ran the existing read-only database health check and passed.
- Integration Captain owns merge and deployment verification.