### PR TITLE
feat: add subscription budget query surface

### DIFF
--- a/app/admin/subscriptions/page.tsx
+++ b/app/admin/subscriptions/page.tsx
@@ -22,12 +22,46 @@ interface VendorStatus {
   links: Array<{ label: string; href: string }>
 }
 
+interface BudgetLineItem {
+  vendor: string
+  amountUsd: number
+  billingCadence: 'monthly' | 'usage_based' | 'annual' | 'unknown'
+  status: StatusKey | 'unknown'
+  evidence: string
+  budgetAction: string
+}
+
+interface BudgetSummary {
+  monthlyTargetUsd: number
+  confirmedMonthlyRunRateUsd: number
+  overTargetUsd: number
+  confidence: 'partial_receipt_verified' | 'tracker_only' | 'dashboard_verified'
+  lastReceiptRefresh: string
+  queryExamples: string[]
+  notes: string[]
+  lineItems: BudgetLineItem[]
+  watchItems: string[]
+}
+
+interface BudgetQueryResult {
+  query: string
+  answer: string
+  monthlyTargetUsd: number | null
+  confirmedMonthlyRunRateUsd: number | null
+  overTargetUsd: number | null
+  matchingLineItems: BudgetLineItem[]
+  suggestedCuts: BudgetLineItem[]
+  unresolvedChecks: string[]
+}
+
 interface SubscriptionStatusRegistry {
   generatedAt: string
   sourceDocument: string
   weeklyReportAutomationId: string
   dailyMonitorAutomationId: string
   approvalPhrasePattern: string
+  budget?: BudgetSummary
+  queryResult?: BudgetQueryResult
   summary: {
     status: StatusColor
     headline: string
@@ -66,7 +100,9 @@ export default function AdminSubscriptionsPage() {
 
 function AdminSubscriptionsPageContent() {
   const [data, setData] = useState<SubscriptionStatusRegistry | null>(null)
+  const [query, setQuery] = useState('How much are we spending monthly, and are we under $300?')
   const [loading, setLoading] = useState(true)
+  const [queryLoading, setQueryLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
@@ -98,6 +134,25 @@ function AdminSubscriptionsPageContent() {
     () => data?.vendors.filter((vendor) => vendor.decisionRequired) ?? [],
     [data]
   )
+  const budget = data?.budget
+  const queryResult = data?.queryResult
+
+  async function runBudgetQuery() {
+    setQueryLoading(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/admin/subscriptions/status?q=${encodeURIComponent(query)}`)
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body.error || `HTTP ${res.status}`)
+      }
+      setData(await res.json())
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to run subscription query')
+    } finally {
+      setQueryLoading(false)
+    }
+  }
 
   return (
     <div className="min-h-screen bg-background text-foreground p-6 lg:p-8">
@@ -141,6 +196,74 @@ function AdminSubscriptionsPageContent() {
               </div>
             </section>
 
+            {budget && (
+              <section className="mb-6 rounded-lg border border-silicon-slate bg-silicon-slate/30 p-5">
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                  <div>
+                    <div className="flex items-center gap-2 mb-2">
+                      <CircleDollarSign size={20} className="text-radiant-gold" />
+                      <h2 className="text-xl font-semibold">Budget query</h2>
+                    </div>
+                    <p className="text-sm text-muted-foreground">
+                      Confirmed monthly run-rate from receipts and the subscription tracker.
+                    </p>
+                  </div>
+                  <div className={`rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide ${budget.overTargetUsd > 0 ? statusStyles.yellow : statusStyles.green}`}>
+                    {budget.overTargetUsd > 0 ? `$${budget.overTargetUsd.toFixed(2)} over target` : 'Under target'}
+                  </div>
+                </div>
+
+                <div className="mt-5 grid grid-cols-1 md:grid-cols-3 gap-3">
+                  <Signal label="Monthly target" value={`$${budget.monthlyTargetUsd.toFixed(2)}`} />
+                  <Signal label="Confirmed run-rate" value={`$${budget.confirmedMonthlyRunRateUsd.toFixed(2)}`} />
+                  <Signal label="Receipt refresh" value={budget.lastReceiptRefresh} />
+                </div>
+
+                <div className="mt-5 flex flex-col gap-3 lg:flex-row">
+                  <input
+                    value={query}
+                    onChange={(event) => setQuery(event.target.value)}
+                    placeholder="Ask a budget question"
+                    className="min-w-0 flex-1 rounded-lg border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm"
+                  />
+                  <button
+                    type="button"
+                    onClick={runBudgetQuery}
+                    disabled={queryLoading}
+                    className="rounded-lg bg-radiant-gold px-4 py-2 text-sm font-semibold text-background disabled:opacity-60"
+                  >
+                    {queryLoading ? 'Querying…' : 'Run query'}
+                  </button>
+                </div>
+
+                {queryResult && (
+                  <div className="mt-4 rounded-lg border border-radiant-gold/30 bg-radiant-gold/10 p-4">
+                    <p className="text-sm font-medium text-radiant-gold">{queryResult.answer}</p>
+                    <div className="mt-3 grid grid-cols-1 lg:grid-cols-2 gap-3">
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">Top budget levers</p>
+                        <ul className="space-y-1 text-sm text-muted-foreground">
+                          {queryResult.suggestedCuts.slice(0, 4).map((item) => (
+                            <li key={item.vendor}>
+                              {item.vendor}: ${item.amountUsd.toFixed(2)}
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">Unresolved checks</p>
+                        <ul className="space-y-1 text-sm text-muted-foreground">
+                          {queryResult.unresolvedChecks.slice(0, 4).map((item) => (
+                            <li key={item}>{item}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </section>
+            )}
+
             <section className="grid grid-cols-2 lg:grid-cols-5 gap-3 mb-6">
               <BucketStat icon={<CheckCircle2 size={18} />} label="Keep" count={data.buckets.keep.length} />
               <BucketStat icon={<Clock3 size={18} />} label="Watch" count={data.buckets.watch.length} />
@@ -168,6 +291,26 @@ function AdminSubscriptionsPageContent() {
 
             <section className="mb-6">
               <h2 className="text-lg font-semibold mb-3">Vendor status</h2>
+              {budget && (
+                <div className="mb-3 overflow-hidden rounded-lg border border-silicon-slate">
+                  <div className="hidden lg:grid grid-cols-[180px_120px_1fr_1fr] gap-4 bg-silicon-slate/60 px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    <span>Vendor</span>
+                    <span>Monthly</span>
+                    <span>Evidence</span>
+                    <span>Budget action</span>
+                  </div>
+                  <div className="divide-y divide-silicon-slate">
+                    {budget.lineItems.map((item) => (
+                      <div key={item.vendor} className="grid grid-cols-1 lg:grid-cols-[180px_120px_1fr_1fr] gap-3 lg:gap-4 px-4 py-4">
+                        <p className="font-semibold">{item.vendor}</p>
+                        <p className="text-sm font-semibold text-radiant-gold">${item.amountUsd.toFixed(2)}</p>
+                        <SignalBlock label="Evidence" value={item.evidence} />
+                        <SignalBlock label="Budget action" value={item.budgetAction} />
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
               <div className="overflow-hidden rounded-lg border border-silicon-slate">
                 <div className="hidden lg:grid grid-cols-[160px_130px_1fr_1fr_1fr] gap-4 bg-silicon-slate/60 px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                   <span>Vendor</span>
@@ -254,6 +397,15 @@ function SignalBlock({ label, value }: { label: string; value: string }) {
     <div>
       <p className="lg:hidden text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-1">{label}</p>
       <p className="text-sm text-muted-foreground leading-relaxed">{value}</p>
+    </div>
+  )
+}
+
+function Signal({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-silicon-slate/60 bg-background/35 p-4">
+      <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="mt-2 text-sm font-medium">{value}</p>
     </div>
   )
 }

--- a/app/api/admin/subscriptions/status/route.ts
+++ b/app/api/admin/subscriptions/status/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
-import { getSubscriptionStatusRegistry } from '@/lib/subscription-status'
+import { answerSubscriptionBudgetQuery, getSubscriptionStatusRegistry } from '@/lib/subscription-status'
 
 export const dynamic = 'force-dynamic'
 
@@ -8,6 +8,14 @@ export async function GET(request: NextRequest) {
   const auth = await verifyAdmin(request)
   if (isAuthError(auth)) {
     return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const query = request.nextUrl.searchParams.get('q')?.trim()
+  if (query) {
+    return NextResponse.json({
+      ...getSubscriptionStatusRegistry(),
+      queryResult: answerSubscriptionBudgetQuery(query),
+    })
   }
 
   return NextResponse.json(getSubscriptionStatusRegistry())

--- a/docs/apify-call-bakeoff-analysis.md
+++ b/docs/apify-call-bakeoff-analysis.md
@@ -1,0 +1,55 @@
+# Apify Call Bakeoff Analysis
+
+Date: 2026-05-06
+
+Purpose: keep Apify under active watch, identify every current Portfolio call surface found in n8n exports, and define the evidence needed before replacing Apify with a cheaper or better tool.
+
+## Current Spend
+
+- Confirmed recurring charge: $39/month.
+- Evidence: Apify payment-success invoices on 2026-04-03 and 2026-05-03.
+- Current recommendation: keep for now, but run a replacement bakeoff before the next renewal window.
+
+## Runtime Evidence
+
+- n8n Cloud execution `13174` for workflow `HqpDGIHxvJqXKHuT` succeeded on 2026-05-06.
+- That execution checked `alien_force~facebook-scraper-pro` and `harvestapi~linkedin-profile-search`.
+- Both monitored actors returned `no_runs` with `totalRuns: 0`, producing warning alerts rather than evidence of recent productive actor usage.
+- Static exports show more Apify call surfaces than the current monitor checks. The monitor should be expanded or the bakeoff should pull direct Apify run history before a final replacement decision.
+
+## Configured Apify Call Surfaces
+
+| Workflow | Node | Actor | Purpose | Replacement candidates |
+| --- | --- | --- | --- | --- |
+| `WF-WRM-001: Facebook Warm Lead Scraper` | `Scrape FB Friends (Apify)` | `alien_force~facebook-scraper-pro` | Facebook warm lead discovery from profile/friends data. | Native/manual Facebook review, browser-agent extraction, LinkedIn-first warm lead path, disable unless campaign-owned cookies are valid. |
+| `WF-WRM-001: Facebook Warm Lead Scraper` | `Scrape FB Groups (Apify)` | `mdgjtp1~facebook-group-member` | Facebook group member discovery. | Manual group review, Meta/community export where available, browser-agent extraction behind approval. |
+| `WF-WRM-001: Facebook Warm Lead Scraper` | `Scrape FB Post Comments (Apify)` | `apify~facebook-comments-scraper` | Commenter discovery from Facebook posts. | Native post export/manual triage, browser-agent extraction, shift warm lead collection to opted-in forms. |
+| `WF-WRM-003: LinkedIn Warm Lead Scraper` | `Scrape LI Connections (Apify)` | `addeus~get-connections` | LinkedIn 1st-degree connection extraction. | LinkedIn CSV export/manual upload, browser-agent extraction, CRM/contact imports. |
+| `WF-WRM-003: LinkedIn Warm Lead Scraper` | `Scrape LI Post Engagement (Apify)` | `harvestapi~linkedin-profile-posts` | LinkedIn post engagement leads. | LinkedIn native analytics/manual export, browser-agent extraction, lower-frequency campaign review. |
+| `WF-VEP-002: Social Listening Pipeline` | `Scrape Reddit` | `trudax~reddit-scraper-lite` | Reddit social listening for value evidence. | Reddit API/search RSS where allowed, Brave/Search API, browser search with cached source register. |
+| `WF-VEP-002: Social Listening Pipeline` | `Scrape Google Maps` | `compass~crawler-google-places` | Local business/place discovery and reviews. | Google Places API, manual CSV, Google Business Profile exports, SerpAPI/Maps alternatives. |
+| `WF-VEP-002: Social Listening Pipeline` | `Scrape LinkedIn` | `harvestapi~linkedin-post-search` | LinkedIn content listening. | LinkedIn native/manual search, browser-agent sampling, campaign-limited runbooks. |
+| `WF-VEP-002: Social Listening Pipeline` | `Run G2 Actor` | `focused_vanguard~g2-reviews-scraper` | G2 review evidence. | G2 manual export where permitted, browser/search snippets, vendor review APIs. |
+| `WF-VEP-002: Social Listening Pipeline` | `Run Capterra Actor` | `dionysus_way~capterra-reviews` | Capterra review evidence. | Capterra manual export where permitted, browser/search snippets, vendor review APIs. |
+| `HeyGen Cold Email - Sub Agent - Jono Catliff` | `Get Profile data` | `VhxlqQXRwhW8H5hNV` | LinkedIn profile enrichment in an older cold-email flow. | Remove if flow is retired; otherwise compare with Hunter/Apollo/Clay-style enrichment. |
+| `HeyGen Cold Email - Sub Agent - Jono Catliff` | `Run Website Video Scraper: Sync` | `dz_omar~ultimate-screenshot` | Website screenshot/video capture for personalization. | Playwright screenshot/video capture, Browser Use capture, Vercel/Chromium job. |
+
+## Bakeoff Criteria
+
+Score every replacement against the same packet:
+
+- Cost per useful lead or usable evidence item.
+- Source reliability and duplication rate.
+- Compliance and account-risk exposure.
+- Runtime reliability, retry behavior, and observability.
+- Fit with existing n8n and Portfolio admin trace surfaces.
+- Replacement effort and rollback path.
+
+## Recommended Next Step
+
+Run a read-only Apify run-history pull before renewal:
+
+1. Pull recent run counts, cost/compute units, status, and dataset item counts for every actor above.
+2. Mark actors with `no_runs` or empty datasets as pause candidates.
+3. For actors with meaningful output, run one bakeoff packet against at least one alternative.
+4. Keep Apify only for actors that produce a lower cost per useful result or materially better data quality than the replacement.

--- a/docs/subscription-cancellation-audit.md
+++ b/docs/subscription-cancellation-audit.md
@@ -178,6 +178,44 @@ Next Audit Focus
 - Review ElevenLabs renewal before 2026-05-19 against the next planned
   social/audio/video campaign.
 
+## 2026-05-06 Budget Query Readiness Update
+
+Status: YELLOW
+
+Summary:
+
+- Added a receipt-backed budget snapshot to `docs/subscription-status.json` so
+  `/admin/subscriptions` and `GET /api/admin/subscriptions/status?q=...` can
+  answer monthly spend questions such as "Are we under $300?"
+- Confirmed monthly run-rate snapshot: `$791.02` against a `$300` target, with
+  `$491.02` over target.
+- This is a partial receipt-verified snapshot, not final bank reconciliation.
+  Recent quick enrollments/cancellations, especially the Anthropic to ChatGPT
+  switch, may reduce next-month realized spend.
+- Gamma and Apify remain watch items. Gamma is a low-dollar watch item. Apify is
+  now linked to `docs/apify-call-bakeoff-analysis.md` for actor-level
+  replacement analysis.
+- No cancellation was performed and no approval phrase was given.
+
+Raw Findings:
+
+- Gmail receipts confirmed: Gamma `$25.00`, n8n `$63.75`, Read.ai `$20.98`,
+  Supabase `$25.27`, BuiltWith `$307.00` across three receipts, Apify `$39.00`,
+  HeyGen `$30.81`, ElevenLabs `$23.38`, Calendly `$12.75`, Google Cloud `$9.33`,
+  Anthropic `$106.25`, OpenAI/ChatGPT Pro `$106.25`, and Vercel `$21.25`.
+- n8n Cloud execution `13174` for workflow `HqpDGIHxvJqXKHuT` succeeded on
+  2026-05-06 and showed the Apify Actor Health Monitor checking
+  `alien_force~facebook-scraper-pro` and `harvestapi~linkedin-profile-search`.
+  Both returned `no_runs` warnings, so the actor monitor itself is active but
+  does not prove recent productive actor usage.
+
+Next Audit Focus:
+
+- Refresh the budget snapshot after the Anthropic/ChatGPT transition settles.
+- Pull direct Apify run history, dataset item counts, and compute/cost data for
+  every configured actor before the next Apify renewal.
+- Keep Gamma and Apify visible in the admin dashboard watch path.
+
 ## 2026-05-05 Daily Monitor Run
 
 Status: YELLOW

--- a/docs/subscription-status.json
+++ b/docs/subscription-status.json
@@ -4,6 +4,141 @@
   "weeklyReportAutomationId": "portfolio-subscription-weekly-report",
   "dailyMonitorAutomationId": "portfolio-subscription-cancellation-monitor",
   "approvalPhrasePattern": "Cancel <tool/vendor> for Portfolio",
+  "budget": {
+    "monthlyTargetUsd": 300,
+    "confirmedMonthlyRunRateUsd": 791.02,
+    "overTargetUsd": 491.02,
+    "confidence": "partial_receipt_verified",
+    "lastReceiptRefresh": "2026-05-06",
+    "queryExamples": [
+      "How much are we spending monthly?",
+      "Are we under $300?",
+      "Which vendors put us over budget?",
+      "What can we cut to get under budget?"
+    ],
+    "notes": [
+      "Confirmed from Gmail receipts and the subscription audit tracker; unresolved usage-based tools still require dashboard verification.",
+      "Recent quick enrollments/cancellations may make next-month realized spend lower than this snapshot.",
+      "Cancellation remains approval-gated; this budget view is read-only."
+    ],
+    "lineItems": [
+      {
+        "vendor": "BuiltWith",
+        "amountUsd": 307,
+        "billingCadence": "monthly",
+        "status": "watch",
+        "evidence": "Three receipts on 2026-04-10: $109.00, $99.00, and $99.00.",
+        "budgetAction": "Keep under watch during outreach ramp; largest cut lever if client-volume evidence does not justify it."
+      },
+      {
+        "vendor": "Anthropic",
+        "amountUsd": 106.25,
+        "billingCadence": "monthly",
+        "status": "watch",
+        "evidence": "Receipt on 2026-04-11 for Claude Max plan with tax.",
+        "budgetAction": "Expected to drop if the ChatGPT switch replaces Claude Max before renewal."
+      },
+      {
+        "vendor": "OpenAI / ChatGPT Pro",
+        "amountUsd": 106.25,
+        "billingCadence": "monthly",
+        "status": "keep",
+        "evidence": "ChatGPT Pro subscription email on 2026-04-29 with $106.25 total.",
+        "budgetAction": "Keep as the primary premium AI plan if Anthropic is canceled."
+      },
+      {
+        "vendor": "n8n Cloud",
+        "amountUsd": 63.75,
+        "billingCadence": "monthly",
+        "status": "keep",
+        "evidence": "Receipt on 2026-04-22 for Cloud Pro-1 with tax.",
+        "budgetAction": "Keep while workflows remain active; optimize workflow errors separately."
+      },
+      {
+        "vendor": "Apify",
+        "amountUsd": 39,
+        "billingCadence": "monthly",
+        "status": "keep",
+        "evidence": "Payment-success invoices on 2026-04-03 and 2026-05-03 for $39.",
+        "budgetAction": "Keep on watch; run Apify actor bakeoff before renewal to test cheaper or better replacements."
+      },
+      {
+        "vendor": "HeyGen",
+        "amountUsd": 30.81,
+        "billingCadence": "monthly",
+        "status": "keep",
+        "evidence": "Receipt on 2026-04-14 for HeyGen Creator Platform with tax.",
+        "budgetAction": "Review after the next video campaign."
+      },
+      {
+        "vendor": "Gamma",
+        "amountUsd": 25,
+        "billingCadence": "monthly",
+        "status": "keep",
+        "evidence": "Receipt on 2026-05-01 for Gamma Pro.",
+        "budgetAction": "Keep an eye on usage; continue comparing against Codex/PPTX and other deck paths."
+      },
+      {
+        "vendor": "Supabase",
+        "amountUsd": 25.27,
+        "billingCadence": "monthly",
+        "status": "keep",
+        "evidence": "Payment received on 2026-04-09 for $25.27.",
+        "budgetAction": "Keep; core data plane."
+      },
+      {
+        "vendor": "ElevenLabs",
+        "amountUsd": 23.38,
+        "billingCadence": "monthly",
+        "status": "watch",
+        "evidence": "Receipt on 2026-04-19 for Creator subscription with tax.",
+        "budgetAction": "Watch through the next social/audio cycle."
+      },
+      {
+        "vendor": "Vercel",
+        "amountUsd": 21.25,
+        "billingCadence": "monthly",
+        "status": "keep",
+        "evidence": "Receipt on 2026-05-06 for Vercel Pro with tax.",
+        "budgetAction": "Keep; active production and staging hosting."
+      },
+      {
+        "vendor": "Read.ai",
+        "amountUsd": 20.98,
+        "billingCadence": "monthly",
+        "status": "keep",
+        "evidence": "Receipt on 2026-04-20 for Read Pro Plan with tax.",
+        "budgetAction": "Keep while meeting transcript workflow is active."
+      },
+      {
+        "vendor": "Calendly",
+        "amountUsd": 12.75,
+        "billingCadence": "monthly",
+        "status": "keep",
+        "evidence": "Receipt on 2026-04-04 for Standard with tax.",
+        "budgetAction": "Low-cost keep unless replaced by another scheduling path."
+      },
+      {
+        "vendor": "Google Cloud",
+        "amountUsd": 9.33,
+        "billingCadence": "monthly",
+        "status": "keep",
+        "evidence": "Google Cloud payment received on 2026-05-01 for $9.33.",
+        "budgetAction": "Keep; low-cost usage-based infrastructure."
+      }
+    ],
+    "watchItems": [
+      "Gamma",
+      "Apify",
+      "BuiltWith",
+      "ElevenLabs",
+      "OpenRouter",
+      "Vapi",
+      "Pinecone",
+      "Resend",
+      "Printful"
+    ]
+  },
   "summary": {
     "status": "yellow",
     "headline": "Core Portfolio subscriptions remain active. OpenRouter and Resend stay quiet, while Apify and ElevenLabs are confirmed paid/active.",
@@ -195,6 +330,10 @@
       "nextAction": "Review actor cadence and spend before the next renewal window.",
       "decisionRequired": false,
       "links": [
+        {
+          "label": "Apify bakeoff analysis",
+          "href": "https://github.com/vsillah/Portfolio/blob/main/docs/apify-call-bakeoff-analysis.md"
+        },
         {
           "label": "Audit tracker",
           "href": "https://github.com/vsillah/Portfolio/blob/main/docs/subscription-cancellation-audit.md"

--- a/lib/subscription-status.test.ts
+++ b/lib/subscription-status.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { answerSubscriptionBudgetQuery, getSubscriptionStatusRegistry } from './subscription-status'
+
+describe('subscription status budget queries', () => {
+  it('exposes a receipt-backed monthly budget snapshot', () => {
+    const registry = getSubscriptionStatusRegistry()
+
+    expect(registry.budget?.monthlyTargetUsd).toBe(300)
+    expect(registry.budget?.confirmedMonthlyRunRateUsd).toBeGreaterThan(300)
+    expect(registry.budget?.lineItems.map((item) => item.vendor)).toEqual(
+      expect.arrayContaining(['Gamma', 'Apify', 'OpenAI / ChatGPT Pro'])
+    )
+  })
+
+  it('answers under-budget queries with spend and cut candidates', () => {
+    const result = answerSubscriptionBudgetQuery('Are we under $300 and what can we cut?')
+
+    expect(result.answer).toContain('$791.02')
+    expect(result.answer).toContain('over the $300 target')
+    expect(result.suggestedCuts[0]?.vendor).toBe('BuiltWith')
+    expect(result.unresolvedChecks.length).toBeGreaterThan(0)
+  })
+
+  it('keeps Gamma and Apify visible as budget watch items', () => {
+    const result = answerSubscriptionBudgetQuery('Should we keep an eye on Gamma and Apify?')
+
+    expect(result.answer).toContain('Gamma')
+    expect(result.answer).toContain('Apify')
+  })
+})

--- a/lib/subscription-status.ts
+++ b/lib/subscription-status.ts
@@ -26,12 +26,34 @@ export interface SubscriptionVendorStatus {
   links: SubscriptionStatusLink[]
 }
 
+export interface SubscriptionBudgetLineItem {
+  vendor: string
+  amountUsd: number
+  billingCadence: 'monthly' | 'usage_based' | 'annual' | 'unknown'
+  status: SubscriptionStatusKey | 'unknown'
+  evidence: string
+  budgetAction: string
+}
+
+export interface SubscriptionBudgetSummary {
+  monthlyTargetUsd: number
+  confirmedMonthlyRunRateUsd: number
+  overTargetUsd: number
+  confidence: 'partial_receipt_verified' | 'tracker_only' | 'dashboard_verified'
+  lastReceiptRefresh: string
+  queryExamples: string[]
+  notes: string[]
+  lineItems: SubscriptionBudgetLineItem[]
+  watchItems: string[]
+}
+
 export interface SubscriptionStatusRegistry {
   generatedAt: string
   sourceDocument: string
   weeklyReportAutomationId: string
   dailyMonitorAutomationId: string
   approvalPhrasePattern: string
+  budget?: SubscriptionBudgetSummary
   summary: {
     status: SubscriptionStatusColor
     headline: string
@@ -47,6 +69,75 @@ export interface SubscriptionStatusRegistry {
   vendors: SubscriptionVendorStatus[]
 }
 
+export interface SubscriptionQueryResult {
+  query: string
+  answer: string
+  monthlyTargetUsd: number | null
+  confirmedMonthlyRunRateUsd: number | null
+  overTargetUsd: number | null
+  matchingLineItems: SubscriptionBudgetLineItem[]
+  suggestedCuts: SubscriptionBudgetLineItem[]
+  unresolvedChecks: string[]
+}
+
 export function getSubscriptionStatusRegistry(): SubscriptionStatusRegistry {
   return subscriptionStatus as SubscriptionStatusRegistry
+}
+
+export function answerSubscriptionBudgetQuery(query: string): SubscriptionQueryResult {
+  const registry = getSubscriptionStatusRegistry()
+  const budget = registry.budget
+  const normalized = query.toLowerCase()
+  const lineItems = budget?.lineItems ?? []
+
+  const matchingLineItems = lineItems.filter((item) => {
+    const haystack = `${item.vendor} ${item.status} ${item.evidence} ${item.budgetAction}`.toLowerCase()
+    return normalized
+      .split(/\s+/)
+      .filter((token) => token.length > 2)
+      .some((token) => haystack.includes(token))
+  })
+
+  const suggestedCuts = [...lineItems]
+    .filter((item) => item.status === 'watch' || /cut|pause|replace|review|watch/i.test(item.budgetAction))
+    .sort((a, b) => b.amountUsd - a.amountUsd)
+    .slice(0, 6)
+
+  const unresolvedChecks = registry.vendors
+    .filter((vendor) => vendor.status === 'unresolved' || vendor.decisionRequired)
+    .map((vendor) => `${vendor.name}: ${vendor.nextAction}`)
+
+  const target = budget?.monthlyTargetUsd ?? null
+  const runRate = budget?.confirmedMonthlyRunRateUsd ?? null
+  const overTarget = budget?.overTargetUsd ?? null
+
+  let answer = registry.summary.headline
+  if (budget && (normalized.includes('spend') || normalized.includes('budget') || normalized.includes('300') || normalized.includes('monthly') || normalized.includes('cost'))) {
+    const direction = budget.overTargetUsd > 0
+      ? `over the $${budget.monthlyTargetUsd.toFixed(0)} target by $${budget.overTargetUsd.toFixed(2)}`
+      : `under the $${budget.monthlyTargetUsd.toFixed(0)} target`
+    answer = `Confirmed monthly run-rate is $${budget.confirmedMonthlyRunRateUsd.toFixed(2)}, ${direction}.`
+  }
+  if (budget && (normalized.includes('cut') || normalized.includes('cancel') || normalized.includes('under'))) {
+    const topCuts = suggestedCuts.slice(0, 3).map((item) => `${item.vendor} ($${item.amountUsd.toFixed(2)})`).join(', ')
+    answer = `${answer} Biggest budget levers: ${topCuts}. Cancellation still requires the approval phrase: ${registry.approvalPhrasePattern}.`
+  }
+  if (budget && (normalized.includes('apify') || normalized.includes('gamma'))) {
+    const watched = budget.lineItems
+      .filter((item) => ['apify', 'gamma'].includes(item.vendor.toLowerCase()))
+      .map((item) => `${item.vendor}: $${item.amountUsd.toFixed(2)}; ${item.budgetAction}`)
+      .join(' ')
+    answer = watched || answer
+  }
+
+  return {
+    query,
+    answer,
+    monthlyTargetUsd: target,
+    confirmedMonthlyRunRateUsd: runRate,
+    overTargetUsd: overTarget,
+    matchingLineItems: matchingLineItems.length > 0 ? matchingLineItems : lineItems,
+    suggestedCuts,
+    unresolvedChecks,
+  }
 }

--- a/lib/technology-bakeoff.test.ts
+++ b/lib/technology-bakeoff.test.ts
@@ -87,4 +87,17 @@ describe('buildTechnologyBakeoffPlan', () => {
     expect(plan.candidates[0].label).toBe('New Analytics Tool')
     expect(plan.candidates[0].role).toBe('User-supplied candidate')
   })
+
+  it('uses Apify call evidence for lead enrichment bakeoffs', () => {
+    const plan = buildTechnologyBakeoffPlan({
+      surface: 'lead_enrichment',
+      objective: 'Decide whether Apify actors should be replaced before renewal.',
+      priority: 'cost',
+      currentDefault: 'Apify actors',
+    })
+
+    expect(plan.candidates.map((candidate) => candidate.id)).toEqual(expect.arrayContaining(['apify_actors', 'browser_agents']))
+    expect(plan.benchmarkRunbook.join(' ')).toContain('docs/apify-call-bakeoff-analysis.md')
+    expect(plan.missingEvidence.join(' ')).toContain('Direct Apify run history')
+  })
 })

--- a/lib/technology-bakeoff.ts
+++ b/lib/technology-bakeoff.ts
@@ -269,14 +269,47 @@ export const TECHNOLOGY_BAKEOFF_PROFILES: Record<TechnologyBakeoffSurface, Surfa
     ['deliverability', 'personalization', 'auditability', 'reply handling', 'approval burden'],
     'Keep traceable drafts and approval state before outbound sends.'
   ),
-  lead_enrichment: genericProfile(
-    'lead_enrichment',
-    'Lead discovery and enrichment',
-    'outreach dashboard, tech-stack lookup, warm lead workflows',
-    ['Apify actors', 'BuiltWith', 'LinkedIn/Google sources', 'Enrichment APIs', 'Browser agents'],
-    ['data quality', 'source reliability', 'cost per useful lead', 'compliance', 'duplicate rate'],
-    'Keep current enrichment sources until a candidate improves qualified-lead yield without privacy risk.'
-  ),
+  lead_enrichment: {
+    surface: 'lead_enrichment',
+    label: 'Lead discovery and enrichment',
+    adminArea: 'outreach dashboard, tech-stack lookup, warm lead workflows, docs/apify-call-bakeoff-analysis.md',
+    fallback: 'Keep current enrichment sources until a candidate improves qualified-lead yield without privacy risk.',
+    candidates: [
+      candidate('apify_actors', 'Apify actors', 'Current scraper runtime', 'Facebook, LinkedIn, Reddit, Google Maps, G2, Capterra, and screenshot/video scraping where actors still return useful output.', 'Run-history may show empty datasets or account-risky scraping; do not renew blindly.'),
+      candidate('builtwith', 'BuiltWith', 'Tech-stack enrichment', 'Website technology lookup for lead prep and implementation strategy.', 'High monthly spend needs conversion evidence.'),
+      candidate('first_party_exports', 'First-party exports and CSVs', 'Low-cost source path', 'LinkedIn exports, CRM/contact imports, Google/Meta/native exports, and manually approved lists.', 'More manual setup and less automation.'),
+      candidate('browser_agents', 'Browser agents', 'Targeted extraction candidate', 'Campaign-limited research with visible source capture and less platform lock-in.', 'Needs strict rate limits, approval gates, and source register output.'),
+      candidate('search_apis', 'Search and maps APIs', 'Structured API candidate', 'Brave/Search APIs, Google Places, or review APIs where terms and cost fit.', 'Coverage varies by source and may need separate compliance review.'),
+    ],
+    scoring: [
+      scoreSeed('Cost per useful lead', 0.22, 'Compare monthly spend, run cost, and accepted lead/evidence count.'),
+      scoreSeed('Data quality and freshness', 0.2, 'Score useful, current, deduplicated records against accepted lead criteria.'),
+      scoreSeed('Source reliability', 0.18, 'Measure failed runs, empty datasets, throttling, and actor maintenance risk.'),
+      scoreSeed('Compliance and account risk', 0.16, 'Prefer first-party exports and permitted APIs over fragile scraping.'),
+      scoreSeed('Workflow fit', 0.14, 'Fits n8n, Portfolio ingest, provenance, and admin review without new hidden work.'),
+      scoreSeed('Rollback path', 0.1, 'Can pause or restore without breaking outreach operations.'),
+    ],
+    benchmarkFocus: [
+      'Use docs/apify-call-bakeoff-analysis.md as the starting actor inventory.',
+      'Pull recent Apify run count, compute/cost, dataset item count, failure rate, and accepted-result rate for each actor.',
+      'Run the same lead/evidence packet through Apify and at least one alternative for the top active actor categories.',
+    ],
+    promotionGate: [
+      ...COMMON_PROMOTION_GATE,
+      'Replacement must lower cost per useful lead or materially improve accepted data quality.',
+      'Do not replace a scraper with another scraping path unless compliance and account-risk exposure are equal or better.',
+    ],
+    rollbackPlan: [
+      'Keep existing Apify workflow nodes disabled, not deleted, until the replacement completes two successful review cycles.',
+      'Restore Apify actor nodes if accepted-result rate drops, source coverage falls, or manual burden rises.',
+    ],
+    integrationNotes: [
+      'Link each actor decision to docs/apify-call-bakeoff-analysis.md.',
+      'Expose Apify as a subscription watch item, not an automatic cancellation candidate.',
+      'Persist accepted-result counts separately from raw scrape counts before changing provider defaults.',
+    ],
+    missingEvidence: ['Direct Apify run history', 'Compute/cost by actor', 'Accepted-result rate by actor', 'Replacement run evidence'],
+  },
   pricing_roi: genericProfile(
     'pricing_roi',
     'Pricing, bundles, and ROI tools',


### PR DESCRIPTION
## Summary
- add a receipt-backed budget snapshot to the Subscription Watch admin surface
- add a read-only budget query path through `/api/admin/subscriptions/status?q=...`
- document Apify call surfaces and wire the lead-enrichment bakeoff profile to that evidence

## Validation
- npm test -- --run lib/subscription-status.test.ts lib/technology-bakeoff.test.ts
- git diff --check
- npx tsc --noEmit --pretty false
- npm run build
- push-hook database health check

## Safety
- No schema changes.
- No cancellation, provider mutation, billing action, or external workflow trigger.
- Budget values are static receipt/tracker evidence and marked partial receipt-verified, not final bank reconciliation.
- Cancellation remains approval-gated with `Cancel <tool/vendor> for Portfolio`.
