### PR TITLE
feat: check outreach generation budget

### DIFF
--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -266,6 +266,7 @@ Current progress:
 - Video generation workflow sync runs now create linked Agent Ops traces while preserving the existing domain status table for admin chips/history.
 - Pre-flight budget policy helpers now define per-runtime LLM warning/cap rules and expose them through the admin policy API; enforcement remains adoption-by-adoption, not a silent global behavior change.
 - Chief of Staff chat now runs a traced pre-flight budget check before dispatching its LLM call, carrying the budget decision into cost metadata and the API response.
+- In-app outreach generation now checks the manual-runtime budget before email or LinkedIn LLM dispatch, records warning/block decisions in Agent Ops traces, and persists the budget decision into `outreach_queue.generation_inputs`.
 
 ## Cross-Phase Definition Of Done
 

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -169,6 +169,7 @@ V1 budget policy is advisory and pre-flight ready:
 - estimates use the existing LLM cost calculator and model-provider inference;
 - blocked decisions can be raised by shared helpers before dispatch;
 - Chief of Staff chat is the first adopted path and records its budget decision before LLM dispatch;
+- in-app outreach email and LinkedIn generation now check the manual-runtime budget before dispatch and persist the decision into draft provenance;
 - live workflows are not yet globally blocked until each adoption path has a targeted test and approval gate.
 
 Slack should be treated as a notification and lightweight decision surface later. The source of truth remains Portfolio admin plus `agent_approvals`.

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -64,6 +64,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 - [x] Operating Signals for morning review and deployment watcher traces in review.
 - [x] Pre-flight budget policy helpers and admin policy API visibility in review.
 - [x] Chief of Staff chat pre-flight budget adoption in review.
+- [x] Outreach email and LinkedIn pre-flight budget adoption in review.
 
 ## Scope Guard
 

--- a/docs/agentic-patterns.md
+++ b/docs/agentic-patterns.md
@@ -417,6 +417,7 @@ Each section follows the same template: *Definition · Where we use it today · 
 - [`lib/cost-calculator.ts`](../lib/cost-calculator.ts) computes post-hoc costs.
 - [`lib/agent-budget-policy.ts`](../lib/agent-budget-policy.ts) defines pre-flight per-runtime LLM warning and cap rules.
 - Chief of Staff chat checks the Agent Ops budget policy before dispatch and logs the decision in its trace metadata.
+- Outreach email and LinkedIn draft generation check the manual-runtime budget before dispatch, trace warning/block decisions, and persist the decision in draft provenance.
 - Cost-events ingest accumulates spend per event.
 - `cost_events.agent_run_id` links usage costs to shared Agent Ops traces.
 - Mission Control derives 24-hour Cost Intelligence by runtime, agent, workflow, client/project, and artifact type where run metadata exists.

--- a/lib/__tests__/outreach-queue-generator.test.ts
+++ b/lib/__tests__/outreach-queue-generator.test.ts
@@ -24,6 +24,20 @@ vi.mock('@/lib/lead-research-context', () => ({
 }))
 
 vi.mock('@/lib/cost-calculator', () => ({
+  computeOpenAICost: (usage: { prompt_tokens?: number; completion_tokens?: number }, model: string) => {
+    const rates = model === 'gpt-4o'
+      ? { input: 2.5, output: 10 }
+      : { input: 0.15, output: 0.6 }
+    return ((usage.prompt_tokens ?? 0) / 1_000_000) * rates.input +
+      ((usage.completion_tokens ?? 0) / 1_000_000) * rates.output
+  },
+  computeAnthropicCost: (usage: { input_tokens?: number; output_tokens?: number }, model: string) => {
+    const rates = model === 'claude-sonnet-4-20250514'
+      ? { input: 3, output: 15 }
+      : { input: 0.8, output: 4 }
+    return ((usage.input_tokens ?? 0) / 1_000_000) * rates.input +
+      ((usage.output_tokens ?? 0) / 1_000_000) * rates.output
+  },
   recordOpenAICost: (...args: unknown[]) => mockRecordOpenAICost(...args),
   recordAnthropicCost: (...args: unknown[]) => mockRecordAnthropicCost(...args),
 }))
@@ -221,6 +235,35 @@ describe('outreach-queue-generator helpers', () => {
     const { isInAppOutreachGenerationEnabled } = await import('../outreach-queue-generator')
     expect(isInAppOutreachGenerationEnabled()).toBe(false)
   })
+
+  it('allows normal outreach prompts within the manual admin budget', async () => {
+    const { evaluateOutreachBudget, EMAIL_USER_PROMPT } = await import('../outreach-queue-generator')
+    const decision = evaluateOutreachBudget({
+      channel: 'email',
+      model: 'gpt-4o-mini',
+      systemPrompt: 'Brief context for a single outreach draft.',
+      userPrompt: EMAIL_USER_PROMPT,
+      maxTokens: 600,
+    })
+
+    expect(decision.status).toBe('allowed')
+    expect(decision.rule.key).toBe('llm_manual_per_call')
+    expect(decision.estimatedCostUsd).toBeGreaterThan(0)
+  })
+
+  it('blocks oversized outreach prompts before dispatch', async () => {
+    const { evaluateOutreachBudget, EMAIL_USER_PROMPT } = await import('../outreach-queue-generator')
+    const decision = evaluateOutreachBudget({
+      channel: 'email',
+      model: 'gpt-4o',
+      systemPrompt: 'x'.repeat(2_000_000),
+      userPrompt: EMAIL_USER_PROMPT,
+      maxTokens: 100_000,
+    })
+
+    expect(decision.status).toBe('blocked')
+    expect(decision.reason).toContain('Manual admin LLM call cap')
+  })
 })
 
 describe('generateOutreachDraftInApp', () => {
@@ -376,6 +419,30 @@ describe('generateOutreachDraftInApp', () => {
     expect(typeof inputs?.rag_query_chars).toBe('number')
     expect((inputs?.rag_query_chars as number) ?? 0).toBeGreaterThan(0)
     expect(inputs?.rag_empty_response).toBe(false)
+    expect(inputs?.budget_status).toBe('allowed')
+    expect(inputs?.budget_rule_key).toBe('llm_manual_per_call')
+    expect(typeof inputs?.budget_estimated_cost_usd).toBe('number')
+    expect(inputs?.budget_warning_usd).toBe(0.05)
+    expect(inputs?.budget_limit_usd).toBe(0.25)
+  })
+
+  it('rejects an email draft before dispatch when the budget check blocks it', async () => {
+    mockGetSystemPrompt.mockResolvedValueOnce({
+      prompt: 'x'.repeat(2_000_000),
+      config: { model: 'gpt-4o', temperature: 0.7, maxTokens: 100_000 },
+      version: 99,
+    })
+
+    const { generateOutreachDraftInApp } = await import('../outreach-queue-generator')
+    await expect(
+      generateOutreachDraftInApp({
+        contactId: 99,
+        templateKey: 'email_cold_outreach',
+        force: true,
+      }),
+    ).rejects.toThrow('Manual admin LLM call cap')
+
+    expect(mockFetch).not.toHaveBeenCalled()
   })
 
   it('reflects prior outreach history in generation_inputs (Phase 3)', async () => {
@@ -588,5 +655,8 @@ describe('generateLinkedInDraftInApp', () => {
     expect(inputs?.pinecone_block_hash).toBeNull()
     expect(inputs?.meeting_text_source).toBe('none')
     expect(inputs?.rag_skipped_reason).toBe('email_rag_disabled')
+    expect(inputs?.budget_status).toBe('allowed')
+    expect(inputs?.budget_rule_key).toBe('llm_manual_per_call')
+    expect(typeof inputs?.budget_estimated_cost_usd).toBe('number')
   })
 })

--- a/lib/outreach-queue-generator.ts
+++ b/lib/outreach-queue-generator.ts
@@ -38,8 +38,13 @@ import {
 import { generateJsonCompletion } from '@/lib/llm-dispatch'
 import {
   attachAgentArtifact,
+  recordAgentEvent,
   recordAgentStep,
 } from '@/lib/agent-run'
+import {
+  evaluateAgentBudget,
+  type AgentBudgetDecision,
+} from '@/lib/agent-budget-policy'
 import {
   DEFAULT_OUTREACH_MODEL,
   inferProvider,
@@ -69,6 +74,70 @@ export const LINKEDIN_USER_PROMPT =
 
 export function userPromptFor(channel: OutreachChannel): string {
   return channel === 'linkedin' ? LINKEDIN_USER_PROMPT : EMAIL_USER_PROMPT
+}
+
+function estimateTokensFromText(text: string): number {
+  return Math.ceil(text.length / 4)
+}
+
+export function evaluateOutreachBudget(input: {
+  channel: OutreachChannel
+  model: string
+  systemPrompt: string
+  userPrompt: string
+  maxTokens: number
+}): AgentBudgetDecision {
+  return evaluateAgentBudget({
+    runtime: 'manual',
+    model: input.model,
+    estimatedInputTokens: estimateTokensFromText(`${input.systemPrompt}\n${input.userPrompt}`),
+    maxTokens: input.maxTokens,
+    metadata: {
+      operation: 'outreach_queue_in_app',
+      channel: input.channel,
+    },
+  })
+}
+
+async function recordOutreachBudgetDecision(args: {
+  agentRunId?: string | null
+  channel: OutreachChannel
+  templateKey: string
+  decision: AgentBudgetDecision
+}) {
+  if (!args.agentRunId) return
+
+  const metadata = {
+    channel: args.channel,
+    template_key: args.templateKey,
+    budget_status: args.decision.status,
+    budget_rule_key: args.decision.rule.key,
+    estimated_cost_usd: args.decision.estimatedCostUsd,
+    warning_usd: args.decision.warningUsd,
+    limit_usd: args.decision.limitUsd,
+  }
+
+  await recordAgentStep({
+    runId: args.agentRunId,
+    stepKey: 'budget_check',
+    name: 'Checked outreach budget',
+    status: args.decision.status === 'blocked' ? 'failed' : 'completed',
+    outputSummary: args.decision.reason,
+    costUsd: args.decision.estimatedCostUsd,
+    metadata,
+    idempotencyKey: `${args.agentRunId}:${args.channel}:budget_check`,
+  }).catch((err) => console.warn('[outreach-queue-generator] agent budget step failed:', err))
+
+  if (args.decision.status !== 'allowed') {
+    await recordAgentEvent({
+      runId: args.agentRunId,
+      eventType: 'budget_check',
+      severity: args.decision.status === 'blocked' ? 'error' : 'warning',
+      message: args.decision.reason,
+      metadata,
+      idempotencyKey: `${args.agentRunId}:${args.channel}:budget_check:${args.decision.status}`,
+    }).catch((err) => console.warn('[outreach-queue-generator] agent budget event failed:', err))
+  }
 }
 
 /** Max chars for user-supplied meeting summary (prompt injection / cost guard). */
@@ -205,6 +274,12 @@ export interface GenerationInputs {
   rag_http_status: number | null
   rag_latency_ms: number | null
   rag_empty_response: boolean
+  budget_status: AgentBudgetDecision['status']
+  budget_estimated_cost_usd: number
+  budget_warning_usd: number
+  budget_limit_usd: number
+  budget_rule_key: string
+  budget_reason: string
 }
 
 function buildGenerationInputs(args: {
@@ -212,8 +287,9 @@ function buildGenerationInputs(args: {
   templateKey: string
   channel: OutreachChannel
   sequenceStep: number
+  budgetDecision: AgentBudgetDecision
 }): GenerationInputs {
-  const { ctx, templateKey, channel, sequenceStep } = args
+  const { ctx, templateKey, channel, sequenceStep, budgetDecision } = args
   return {
     template_key: templateKey,
     prompt_version: ctx.promptRow?.version ?? null,
@@ -243,6 +319,12 @@ function buildGenerationInputs(args: {
     rag_http_status: ctx.contextSizes.ragHttpStatus,
     rag_latency_ms: ctx.contextSizes.ragLatencyMs,
     rag_empty_response: ctx.contextSizes.ragEmptyResponse,
+    budget_status: budgetDecision.status,
+    budget_estimated_cost_usd: budgetDecision.estimatedCostUsd,
+    budget_warning_usd: budgetDecision.warningUsd,
+    budget_limit_usd: budgetDecision.limitUsd,
+    budget_rule_key: budgetDecision.rule.key,
+    budget_reason: budgetDecision.reason,
   }
 }
 
@@ -655,6 +737,23 @@ export async function generateOutreachDraftInApp(params: {
     }).catch((err) => console.warn('[outreach-queue-generator] agent step failed:', err))
   }
 
+  const budgetDecision = evaluateOutreachBudget({
+    channel: 'email',
+    model: ctx.model,
+    systemPrompt: ctx.systemPrompt,
+    userPrompt: EMAIL_USER_PROMPT,
+    maxTokens: ctx.maxTokens,
+  })
+  await recordOutreachBudgetDecision({
+    agentRunId: params.agentRunId,
+    channel: 'email',
+    templateKey,
+    decision: budgetDecision,
+  })
+  if (budgetDecision.status === 'blocked') {
+    throw new Error(budgetDecision.reason)
+  }
+
   const completion = await generateJsonCompletion({
     model: ctx.model,
     systemPrompt: ctx.systemPrompt,
@@ -668,6 +767,9 @@ export async function generateOutreachDraftInApp(params: {
         operation: 'outreach_queue_in_app',
         channel: 'email',
         template_key: templateKey,
+        budget_status: budgetDecision.status,
+        budget_rule_key: budgetDecision.rule.key,
+        budget_estimated_cost_usd: budgetDecision.estimatedCostUsd,
       },
     },
   })
@@ -686,6 +788,9 @@ export async function generateOutreachDraftInApp(params: {
         model: completion.model,
         channel: 'email',
         template_key: templateKey,
+        budget_status: budgetDecision.status,
+        budget_rule_key: budgetDecision.rule.key,
+        budget_estimated_cost_usd: budgetDecision.estimatedCostUsd,
       },
       idempotencyKey: `${params.agentRunId}:email:llm_dispatch`,
     }).catch((err) => console.warn('[outreach-queue-generator] agent step failed:', err))
@@ -710,6 +815,7 @@ export async function generateOutreachDraftInApp(params: {
     templateKey,
     channel: 'email',
     sequenceStep,
+    budgetDecision,
   })
 
   const { data: inserted, error: insertErr } = await supabaseAdmin
@@ -881,6 +987,23 @@ export async function generateLinkedInDraftInApp(params: {
     }).catch((err) => console.warn('[outreach-queue-generator] agent step failed:', err))
   }
 
+  const budgetDecision = evaluateOutreachBudget({
+    channel: 'linkedin',
+    model: ctx.model,
+    systemPrompt: ctx.systemPrompt,
+    userPrompt: LINKEDIN_USER_PROMPT,
+    maxTokens: ctx.maxTokens,
+  })
+  await recordOutreachBudgetDecision({
+    agentRunId: params.agentRunId,
+    channel: 'linkedin',
+    templateKey,
+    decision: budgetDecision,
+  })
+  if (budgetDecision.status === 'blocked') {
+    throw new Error(budgetDecision.reason)
+  }
+
   const completion = await generateJsonCompletion({
     model: ctx.model,
     systemPrompt: ctx.systemPrompt,
@@ -894,6 +1017,9 @@ export async function generateLinkedInDraftInApp(params: {
         operation: 'outreach_queue_in_app',
         channel: 'linkedin',
         template_key: templateKey,
+        budget_status: budgetDecision.status,
+        budget_rule_key: budgetDecision.rule.key,
+        budget_estimated_cost_usd: budgetDecision.estimatedCostUsd,
       },
     },
   })
@@ -912,6 +1038,9 @@ export async function generateLinkedInDraftInApp(params: {
         model: completion.model,
         channel: 'linkedin',
         template_key: templateKey,
+        budget_status: budgetDecision.status,
+        budget_rule_key: budgetDecision.rule.key,
+        budget_estimated_cost_usd: budgetDecision.estimatedCostUsd,
       },
       idempotencyKey: `${params.agentRunId}:linkedin:llm_dispatch`,
     }).catch((err) => console.warn('[outreach-queue-generator] agent step failed:', err))
@@ -953,6 +1082,7 @@ export async function generateLinkedInDraftInApp(params: {
     templateKey,
     channel: 'linkedin',
     sequenceStep,
+    budgetDecision,
   })
 
   const { data: inserted, error: insertErr } = await supabaseAdmin


### PR DESCRIPTION
## Summary
- adds a manual-runtime budget preflight before in-app outreach email and LinkedIn LLM dispatch
- traces warning/block decisions into Agent Ops when a run id is present
- persists budget decision metadata into outreach_queue.generation_inputs for draft provenance
- updates Agent Ops roadmap docs to reflect the outreach adoption slice

## Validation
- npm test -- --run lib/__tests__/outreach-queue-generator.test.ts lib/agent-budget-policy.test.ts
- npm test -- --run 'app/api/admin/outreach/leads/[id]/generate/route.test.ts' lib/__tests__/outreach-queue-generator.test.ts lib/agent-budget-policy.test.ts\n- npx tsc --noEmit --pretty false\n- git diff --check\n- npm run build\n\n## Safety\n- no schema changes\n- no live outreach generation or n8n workflow trigger\n- no production customer data copied into non-prod\n- Integration Captain should own merge and Vercel verification\n