### PR TITLE
feat: trace onboarding budget checks

### DIFF
--- a/app/api/admin/proposals/generate-onboarding-content/route.test.ts
+++ b/app/api/admin/proposals/generate-onboarding-content/route.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  generateAIOnboardingContent: vi.fn(),
+  startAgentRun: vi.fn(),
+  recordAgentStep: vi.fn(),
+  endAgentRun: vi.fn(),
+  markAgentRunFailed: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/ai-onboarding-generator', () => ({
+  generateAIOnboardingContent: mocks.generateAIOnboardingContent,
+}))
+
+vi.mock('@/lib/agent-run', () => ({
+  startAgentRun: mocks.startAgentRun,
+  recordAgentStep: mocks.recordAgentStep,
+  endAgentRun: mocks.endAgentRun,
+  markAgentRunFailed: mocks.markAgentRunFailed,
+}))
+
+import { POST } from './route'
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/admin/proposals/generate-onboarding-content', {
+    method: 'POST',
+    headers: {
+      authorization: 'Bearer token',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/admin/proposals/generate-onboarding-content', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.startAgentRun.mockResolvedValue({ id: 'agent-run-1' })
+    mocks.recordAgentStep.mockResolvedValue({ id: 'step-1' })
+    mocks.endAgentRun.mockResolvedValue(undefined)
+    mocks.markAgentRunFailed.mockResolvedValue(undefined)
+    mocks.generateAIOnboardingContent.mockResolvedValue({
+      setup_requirements: [],
+      milestones: [],
+      access_needs: ['Admin access'],
+      tools_and_platforms: ['Google Workspace'],
+      client_actions: ['Name the kickoff owner'],
+    })
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(makeRequest({ line_items: [] }) as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.startAgentRun).not.toHaveBeenCalled()
+  })
+
+  it('rejects missing line items before creating a run', async () => {
+    const response = await POST(makeRequest({ client_name: 'Test Client' }) as never)
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'line_items array is required' })
+    expect(mocks.startAgentRun).not.toHaveBeenCalled()
+  })
+
+  it('creates a traced manual run and passes agentRunId to the generator', async () => {
+    const response = await POST(makeRequest({
+      client_name: 'Test Client',
+      client_company: 'Acme',
+      bundle_name: 'AI Accelerator',
+      line_items: [
+        {
+          title: 'Automation setup',
+          content_type: 'service',
+          price: 2500,
+        },
+      ],
+    }) as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual(expect.objectContaining({
+      agent_run_id: 'agent-run-1',
+      content: expect.objectContaining({
+        access_needs: ['Admin access'],
+      }),
+    }))
+    expect(mocks.startAgentRun).toHaveBeenCalledWith(expect.objectContaining({
+      agentKey: 'proposal-business-model',
+      runtime: 'manual',
+      kind: 'generate_onboarding_content',
+      triggeredByUserId: 'admin-user',
+      metadata: expect.objectContaining({
+        operation: 'generate_onboarding_content',
+        execution_mode: 'admin_preview',
+        production_mutation_allowed: false,
+      }),
+    }))
+    expect(mocks.generateAIOnboardingContent).toHaveBeenCalledWith(expect.objectContaining({
+      agentRunId: 'agent-run-1',
+      client_name: 'Test Client',
+      bundle_name: 'AI Accelerator',
+    }))
+    expect(mocks.endAgentRun).toHaveBeenCalledWith(expect.objectContaining({
+      runId: 'agent-run-1',
+      status: 'completed',
+      currentStep: 'Onboarding content ready',
+    }))
+  })
+
+  it('marks the traced run failed when generation fails', async () => {
+    mocks.generateAIOnboardingContent.mockRejectedValue(new Error('budget blocked'))
+
+    const response = await POST(makeRequest({
+      client_name: 'Test Client',
+      line_items: [
+        {
+          title: 'Automation setup',
+          content_type: 'service',
+          price: 2500,
+        },
+      ],
+    }) as never)
+
+    expect(response.status).toBe(500)
+    expect(await response.json()).toEqual({ error: 'Failed to generate onboarding content' })
+    expect(mocks.markAgentRunFailed).toHaveBeenCalledWith(
+      'agent-run-1',
+      'budget blocked',
+      { operation: 'generate_onboarding_content' },
+    )
+  })
+})

--- a/app/api/admin/proposals/generate-onboarding-content/route.ts
+++ b/app/api/admin/proposals/generate-onboarding-content/route.ts
@@ -1,6 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
 import { generateAIOnboardingContent, type OnboardingGenerationInput } from '@/lib/ai-onboarding-generator'
+import {
+  endAgentRun,
+  markAgentRunFailed,
+  recordAgentStep,
+  startAgentRun,
+} from '@/lib/agent-run'
 
 export const dynamic = 'force-dynamic'
 
@@ -16,6 +22,8 @@ export async function POST(request: NextRequest) {
   if (isAuthError(auth)) {
     return NextResponse.json({ error: auth.error }, { status: auth.status })
   }
+
+  let agentRunId: string | null = null
 
   try {
     const body = await request.json()
@@ -53,11 +61,73 @@ export async function POST(request: NextRequest) {
       gamma_report_id: gamma_report_id || undefined,
     }
 
+    const agentRun = await startAgentRun({
+      agentKey: 'proposal-business-model',
+      runtime: 'manual',
+      kind: 'generate_onboarding_content',
+      title: 'Generate onboarding preview content',
+      subject: {
+        type: 'proposal',
+        id: value_report_id || diagnostic_audit_id || contact_submission_id || 'draft',
+        label: client_name || client_company || bundle_name || 'Draft proposal',
+      },
+      triggerSource: 'admin',
+      triggeredByUserId: auth.user.id,
+      currentStep: 'Assembling onboarding prompt',
+      metadata: {
+        operation: 'generate_onboarding_content',
+        client_name: client_name ?? null,
+        client_company: client_company ?? null,
+        bundle_name: bundle_name ?? null,
+        line_item_count: line_items.length,
+        execution_mode: 'admin_preview',
+        production_mutation_allowed: false,
+      },
+      idempotencyKey: `onboarding-content:${auth.user.id}:${Date.now()}`,
+    })
+    agentRunId = agentRun.id
+
+    await recordAgentStep({
+      runId: agentRunId,
+      stepKey: 'input_validated',
+      name: 'Validated onboarding generation input',
+      status: 'completed',
+      outputSummary: `Validated ${line_items.length} line item(s).`,
+      metadata: {
+        line_item_count: line_items.length,
+        has_diagnostic_audit: Boolean(auditIdStr),
+        has_value_report: Boolean(value_report_id),
+        has_gamma_report: Boolean(gamma_report_id),
+      },
+      idempotencyKey: `${agentRunId}:input_validated`,
+    }).catch((err) => console.warn('[generate-onboarding-content] agent step failed:', err))
+
+    input.agentRunId = agentRunId
     const content = await generateAIOnboardingContent(input)
 
-    return NextResponse.json({ content })
+    await endAgentRun({
+      runId: agentRunId,
+      status: 'completed',
+      currentStep: 'Onboarding content ready',
+      outcome: {
+        setup_requirements: content.setup_requirements.length,
+        milestones: content.milestones.length,
+        access_needs: content.access_needs.length,
+        tools_and_platforms: content.tools_and_platforms.length,
+        client_actions: content.client_actions.length,
+      },
+    })
+
+    return NextResponse.json({ content, agent_run_id: agentRunId })
   } catch (error) {
     console.error('Generate onboarding content error:', error)
+    if (agentRunId) {
+      await markAgentRunFailed(
+        agentRunId,
+        error instanceof Error ? error.message : 'Failed to generate onboarding content',
+        { operation: 'generate_onboarding_content' },
+      ).catch((err) => console.warn('[generate-onboarding-content] mark failed:', err))
+    }
     return NextResponse.json(
       { error: 'Failed to generate onboarding content' },
       { status: 500 }

--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -269,6 +269,7 @@ Current progress:
 - In-app outreach generation now checks the manual-runtime budget before email or LinkedIn LLM dispatch, records warning/block decisions in Agent Ops traces, and persists the budget decision into `outreach_queue.generation_inputs`.
 - Admin delivery email draft generation now starts a manual Agent Ops trace, checks the manual-runtime budget before OpenAI dispatch, and links post-hoc OpenAI cost events back to the trace.
 - Admin meeting lead extraction now starts a manual Agent Ops trace, checks the manual-runtime budget before OpenAI dispatch, and links lead-extraction cost events back to the trace.
+- AI onboarding preview generation now creates a traced manual Agent Ops run from the admin preview endpoint, checks the manual-runtime budget before OpenAI dispatch, and links generated cost events to the trace when available.
 
 ## Cross-Phase Definition Of Done
 

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -172,6 +172,7 @@ V1 budget policy is advisory and pre-flight ready:
 - in-app outreach email and LinkedIn generation now check the manual-runtime budget before dispatch and persist the decision into draft provenance;
 - admin delivery email draft generation now checks the manual-runtime budget before OpenAI dispatch and links cost events to the created Agent Ops trace;
 - admin meeting lead extraction now checks the manual-runtime budget before OpenAI dispatch and links cost events to the created Agent Ops trace;
+- AI onboarding preview generation now checks the manual-runtime budget before OpenAI dispatch and records a manual Agent Ops trace from the admin preview endpoint;
 - live workflows are not yet globally blocked until each adoption path has a targeted test and approval gate.
 
 Slack should be treated as a notification and lightweight decision surface later. The source of truth remains Portfolio admin plus `agent_approvals`.

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -67,6 +67,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 - [x] Outreach email and LinkedIn pre-flight budget adoption in review.
 - [x] Delivery email draft pre-flight budget adoption and trace linkage in review.
 - [x] Meeting lead extraction pre-flight budget adoption and trace linkage in review.
+- [x] AI onboarding preview pre-flight budget adoption in review.
 
 ## Scope Guard
 

--- a/docs/agentic-patterns.md
+++ b/docs/agentic-patterns.md
@@ -420,6 +420,7 @@ Each section follows the same template: *Definition · Where we use it today · 
 - Outreach email and LinkedIn draft generation check the manual-runtime budget before dispatch, trace warning/block decisions, and persist the decision in draft provenance.
 - Admin delivery email draft generation checks the manual-runtime budget before OpenAI dispatch and links cost events to its Agent Ops trace.
 - Admin meeting lead extraction checks the manual-runtime budget before OpenAI dispatch and links cost events to its Agent Ops trace.
+- AI onboarding preview generation checks the manual-runtime budget before dispatch and links admin-triggered previews to a manual Agent Ops run.
 - Cost-events ingest accumulates spend per event.
 - `cost_events.agent_run_id` links usage costs to shared Agent Ops traces.
 - Mission Control derives 24-hour Cost Intelligence by runtime, agent, workflow, client/project, and artifact type where run metadata exists.

--- a/lib/ai-onboarding-generator.test.ts
+++ b/lib/ai-onboarding-generator.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  recordOpenAICost: vi.fn(),
+  recordAgentStep: vi.fn(),
+  recordAgentEvent: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: null,
+}))
+
+vi.mock('@/lib/cost-calculator', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/cost-calculator')>()
+  return {
+    ...actual,
+    recordOpenAICost: mocks.recordOpenAICost,
+  }
+})
+
+vi.mock('@/lib/agent-run', () => ({
+  recordAgentStep: mocks.recordAgentStep,
+  recordAgentEvent: mocks.recordAgentEvent,
+}))
+
+describe('ai-onboarding-generator budget policy', () => {
+  const originalEnv = { ...process.env }
+  let mockFetch: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                setup_requirements: [],
+                milestones: [],
+                access_needs: ['Workspace admin access'],
+                tools_and_platforms: ['Google Workspace'],
+                client_actions: ['Confirm kickoff owner'],
+              }),
+            },
+          },
+        ],
+        usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 },
+      }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+    process.env.OPENAI_API_KEY = 'sk-test-key'
+    mocks.recordAgentStep.mockResolvedValue({ id: 'step-1' })
+    mocks.recordAgentEvent.mockResolvedValue({ id: 'event-1' })
+    mocks.recordOpenAICost.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    process.env = { ...originalEnv }
+  })
+
+  it('allows a normal onboarding prompt within the manual admin budget', async () => {
+    const { evaluateAIOnboardingBudget } = await import('./ai-onboarding-generator')
+
+    const decision = evaluateAIOnboardingBudget({
+      userPrompt: 'Generate onboarding content for one small proposal.',
+    })
+
+    expect(decision.status).toBe('allowed')
+    expect(decision.rule.key).toBe('llm_manual_per_call')
+    expect(decision.estimatedCostUsd).toBeGreaterThan(0)
+  })
+
+  it('blocks oversized onboarding prompts before OpenAI dispatch', async () => {
+    const { evaluateAIOnboardingBudget } = await import('./ai-onboarding-generator')
+
+    const decision = evaluateAIOnboardingBudget({
+      model: 'gpt-4o',
+      userPrompt: 'x'.repeat(2_000_000),
+      maxTokens: 100_000,
+    })
+
+    expect(decision.status).toBe('blocked')
+    expect(decision.reason).toContain('Manual admin LLM call cap')
+  })
+
+  it('records budget metadata when generation succeeds with an agent run', async () => {
+    const { generateAIOnboardingContent } = await import('./ai-onboarding-generator')
+
+    const result = await generateAIOnboardingContent({
+      agentRunId: 'agent-run-1',
+      client_name: 'Test Client',
+      bundle_name: 'AI Accelerator',
+      line_items: [
+        {
+          title: 'Automation setup',
+          description: 'Configure workspace automation',
+          content_type: 'service',
+          price: 2500,
+        },
+      ],
+    })
+
+    expect(result.access_needs).toEqual(['Workspace admin access'])
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(mocks.recordAgentStep).toHaveBeenCalledWith(expect.objectContaining({
+      runId: 'agent-run-1',
+      stepKey: 'budget_check',
+      status: 'completed',
+      metadata: expect.objectContaining({
+        budget_status: 'allowed',
+        budget_rule_key: 'llm_manual_per_call',
+        client_name: 'Test Client',
+        bundle_name: 'AI Accelerator',
+      }),
+    }))
+    expect(mocks.recordAgentEvent).not.toHaveBeenCalled()
+    expect(mocks.recordOpenAICost).toHaveBeenCalledWith(
+      expect.objectContaining({ prompt_tokens: 100 }),
+      'gpt-4o-mini',
+      { type: 'proposal', id: 'onboarding-preview' },
+      expect.objectContaining({
+        operation: 'generate_onboarding_content',
+        budget_status: 'allowed',
+        budget_rule_key: 'llm_manual_per_call',
+      }),
+      'agent-run-1',
+    )
+  })
+
+  it('rejects generation before fetch when the budget check blocks', async () => {
+    const { generateAIOnboardingContent } = await import('./ai-onboarding-generator')
+
+    await expect(
+      generateAIOnboardingContent({
+        line_items: [
+          {
+            title: 'Huge implementation',
+            description: 'x'.repeat(8_000_000),
+            content_type: 'service',
+            price: 2500,
+          },
+        ],
+      }),
+    ).rejects.toThrow('Manual admin LLM call cap')
+
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+})

--- a/lib/ai-onboarding-generator.ts
+++ b/lib/ai-onboarding-generator.ts
@@ -8,7 +8,20 @@
 
 import { supabaseAdmin } from '@/lib/supabase'
 import { recordOpenAICost } from '@/lib/cost-calculator'
+import {
+  evaluateAgentBudget,
+  type AgentBudgetDecision,
+} from '@/lib/agent-budget-policy'
+import {
+  recordAgentEvent,
+  recordAgentStep,
+} from '@/lib/agent-run'
 import type { SetupRequirement, MilestoneTemplate, CommunicationPlan, WinCondition, WarrantyTerms } from '@/lib/onboarding-templates'
+
+const ONBOARDING_MODEL = 'gpt-4o-mini'
+const ONBOARDING_MAX_TOKENS = 2000
+const ONBOARDING_SYSTEM_PROMPT =
+  'You are an onboarding specialist. Respond only with valid JSON matching the requested structure.'
 
 export interface AIOnboardingContent {
   setup_requirements: SetupRequirement[]
@@ -33,6 +46,7 @@ export interface OnboardingGenerationInput {
   diagnostic_audit_id?: string
   value_report_id?: string
   gamma_report_id?: string
+  agentRunId?: string | null
 }
 
 interface ContextData {
@@ -181,6 +195,70 @@ Respond with JSON matching this structure:
 }`
 }
 
+function estimateTokensFromText(text: string): number {
+  return Math.ceil(text.length / 4)
+}
+
+export function evaluateAIOnboardingBudget(input: {
+  model?: string
+  systemPrompt?: string
+  userPrompt: string
+  maxTokens?: number
+}): AgentBudgetDecision {
+  return evaluateAgentBudget({
+    runtime: 'manual',
+    model: input.model ?? ONBOARDING_MODEL,
+    estimatedInputTokens: estimateTokensFromText(
+      `${input.systemPrompt ?? ONBOARDING_SYSTEM_PROMPT}\n${input.userPrompt}`,
+    ),
+    maxTokens: input.maxTokens ?? ONBOARDING_MAX_TOKENS,
+    metadata: {
+      operation: 'generate_onboarding_content',
+    },
+  })
+}
+
+async function recordOnboardingBudgetDecision(args: {
+  agentRunId?: string | null
+  decision: AgentBudgetDecision
+  clientName?: string
+  bundleName?: string
+}) {
+  if (!args.agentRunId) return
+
+  const metadata = {
+    budget_status: args.decision.status,
+    budget_rule_key: args.decision.rule.key,
+    estimated_cost_usd: args.decision.estimatedCostUsd,
+    warning_usd: args.decision.warningUsd,
+    limit_usd: args.decision.limitUsd,
+    client_name: args.clientName ?? null,
+    bundle_name: args.bundleName ?? null,
+  }
+
+  await recordAgentStep({
+    runId: args.agentRunId,
+    stepKey: 'budget_check',
+    name: 'Checked onboarding generation budget',
+    status: args.decision.status === 'blocked' ? 'failed' : 'completed',
+    outputSummary: args.decision.reason,
+    costUsd: args.decision.estimatedCostUsd,
+    metadata,
+    idempotencyKey: `${args.agentRunId}:onboarding_budget_check`,
+  }).catch((err) => console.warn('[ai-onboarding-generator] agent budget step failed:', err))
+
+  if (args.decision.status !== 'allowed') {
+    await recordAgentEvent({
+      runId: args.agentRunId,
+      eventType: 'agent_budget_policy_decision',
+      severity: args.decision.status === 'blocked' ? 'error' : 'warning',
+      message: args.decision.reason,
+      metadata,
+      idempotencyKey: `${args.agentRunId}:onboarding_budget_check:${args.decision.status}`,
+    }).catch((err) => console.warn('[ai-onboarding-generator] agent budget event failed:', err))
+  }
+}
+
 export async function generateAIOnboardingContent(
   input: OnboardingGenerationInput
 ): Promise<AIOnboardingContent> {
@@ -191,6 +269,23 @@ export async function generateAIOnboardingContent(
 
   const ctx = await gatherContext(input)
   const prompt = buildPrompt(input, ctx)
+  const budgetDecision = evaluateAIOnboardingBudget({
+    model: ONBOARDING_MODEL,
+    systemPrompt: ONBOARDING_SYSTEM_PROMPT,
+    userPrompt: prompt,
+    maxTokens: ONBOARDING_MAX_TOKENS,
+  })
+
+  await recordOnboardingBudgetDecision({
+    agentRunId: input.agentRunId,
+    decision: budgetDecision,
+    clientName: input.client_name,
+    bundleName: input.bundle_name,
+  })
+
+  if (budgetDecision.status === 'blocked') {
+    throw new Error(budgetDecision.reason)
+  }
 
   const response = await fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
@@ -199,16 +294,16 @@ export async function generateAIOnboardingContent(
       Authorization: `Bearer ${apiKey}`,
     },
     body: JSON.stringify({
-      model: 'gpt-4o-mini',
+      model: ONBOARDING_MODEL,
       messages: [
         {
           role: 'system',
-          content: 'You are an onboarding specialist. Respond only with valid JSON matching the requested structure.',
+          content: ONBOARDING_SYSTEM_PROMPT,
         },
         { role: 'user', content: prompt },
       ],
       temperature: 0.7,
-      max_tokens: 2000,
+      max_tokens: ONBOARDING_MAX_TOKENS,
       response_format: { type: 'json_object' },
     }),
   })
@@ -226,9 +321,15 @@ export async function generateAIOnboardingContent(
   if (usage) {
     recordOpenAICost(
       usage,
-      'gpt-4o-mini',
+      ONBOARDING_MODEL,
       { type: 'proposal', id: 'onboarding-preview' },
-      { operation: 'generate_onboarding_content' }
+      {
+        operation: 'generate_onboarding_content',
+        budget_status: budgetDecision.status,
+        budget_rule_key: budgetDecision.rule.key,
+        budget_estimated_cost_usd: budgetDecision.estimatedCostUsd,
+      },
+      input.agentRunId ?? undefined,
     ).catch(() => {})
   }
 


### PR DESCRIPTION
## Summary
- adds a manual-runtime budget preflight before AI onboarding preview OpenAI dispatch
- records admin preview generation as a manual Agent Ops run using proposal-business-model
- links cost metadata and cost_events agent_run_id when the admin preview path has a run id
- updates Agent Ops roadmap docs to reflect the onboarding adoption slice

## Validation
- npm test -- --run lib/ai-onboarding-generator.test.ts app/api/admin/proposals/generate-onboarding-content/route.test.ts lib/agent-budget-policy.test.ts
- npx tsc --noEmit --pretty false
- git diff --check
- npm run build

## Safety
- no schema changes
- no live onboarding/proposal generation was triggered
- no production customer data copied into non-prod
- push hook PROD database health check passed
- Integration Captain should own merge and Vercel verification
