### PR TITLE
feat: trace delivery email budget checks

### DIFF
--- a/app/api/admin/contacts/[id]/compose-delivery/route.test.ts
+++ b/app/api/admin/contacts/[id]/compose-delivery/route.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => {
+  class MockDeliveryDraftError extends Error {
+    constructor(
+      message: string,
+      public readonly code:
+        | 'openai_not_configured'
+        | 'openai_upstream'
+        | 'invalid_response'
+        | 'budget_blocked',
+    ) {
+      super(message)
+      this.name = 'DeliveryDraftError'
+    }
+  }
+
+  return {
+    DeliveryDraftError: MockDeliveryDraftError,
+    verifyAdmin: vi.fn(),
+    isAuthError: vi.fn(),
+    generateDeliveryDraft: vi.fn(),
+    startAgentRun: vi.fn(),
+    recordAgentStep: vi.fn(),
+    endAgentRun: vi.fn(),
+    markAgentRunFailed: vi.fn(),
+  }
+})
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: vi.fn(),
+  },
+}))
+
+vi.mock('@/lib/delivery-email', () => ({
+  DeliveryDraftError: mocks.DeliveryDraftError,
+  generateDeliveryDraft: mocks.generateDeliveryDraft,
+}))
+
+vi.mock('@/lib/agent-run', () => ({
+  startAgentRun: mocks.startAgentRun,
+  recordAgentStep: mocks.recordAgentStep,
+  endAgentRun: mocks.endAgentRun,
+  markAgentRunFailed: mocks.markAgentRunFailed,
+}))
+
+import { POST } from './route'
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest('http://localhost/api/admin/contacts/42/compose-delivery', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/admin/contacts/[id]/compose-delivery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    mocks.verifyAdmin.mockResolvedValue({
+      user: { id: 'admin-user-1' },
+      isAdmin: true,
+    })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.startAgentRun.mockResolvedValue({ id: 'agent-run-1' })
+    mocks.recordAgentStep.mockResolvedValue({ id: 'step-1' })
+    mocks.endAgentRun.mockResolvedValue(undefined)
+    mocks.markAgentRunFailed.mockResolvedValue(undefined)
+    mocks.generateDeliveryDraft.mockResolvedValue({
+      subject: 'Delivery draft',
+      body: 'Here are the resources.',
+      dashboardUrl: null,
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('requires admin auth before starting an agent run', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Authentication required', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(makeRequest({}), { params: { id: '42' } })
+
+    expect(response.status).toBe(401)
+    expect(mocks.startAgentRun).not.toHaveBeenCalled()
+  })
+
+  it('starts a trace, passes agentRunId to the draft generator, and returns it', async () => {
+    const response = await POST(
+      makeRequest({
+        assetIds: [{ type: 'gamma_report', id: 'gamma-1' }],
+        templateKey: 'email_asset_delivery',
+        includeDashboardLink: false,
+      }),
+      { params: { id: '42' } },
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      subject: 'Delivery draft',
+      body: 'Here are the resources.',
+      dashboardUrl: null,
+      agentRunId: 'agent-run-1',
+    })
+    expect(mocks.startAgentRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentKey: 'manual-admin',
+        runtime: 'manual',
+        kind: 'delivery_email_draft',
+        triggerSource: 'admin:compose_delivery',
+        triggeredByUserId: 'admin-user-1',
+      }),
+    )
+    expect(mocks.generateDeliveryDraft).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contactId: 42,
+        agentRunId: 'agent-run-1',
+        templateKey: 'email_asset_delivery',
+      }),
+    )
+    expect(mocks.endAgentRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'agent-run-1',
+        status: 'completed',
+      }),
+    )
+  })
+
+  it('marks the trace failed and returns a safe message when budget blocks generation', async () => {
+    mocks.generateDeliveryDraft.mockRejectedValue(
+      new mocks.DeliveryDraftError('Estimated cost exceeds cap.', 'budget_blocked'),
+    )
+
+    const response = await POST(
+      makeRequest({ includeDashboardLink: false }),
+      { params: { id: '42' } },
+    )
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error:
+        'This delivery draft is over the current Agent Ops budget limit. Reduce the prompt, asset set, or model size before retrying.',
+    })
+    expect(mocks.markAgentRunFailed).toHaveBeenCalledWith(
+      'agent-run-1',
+      'Estimated cost exceeds cap.',
+      expect.objectContaining({ contact_id: 42 }),
+    )
+  })
+})

--- a/app/api/admin/contacts/[id]/compose-delivery/route.ts
+++ b/app/api/admin/contacts/[id]/compose-delivery/route.ts
@@ -8,6 +8,12 @@ import { verifyAdmin, isAuthError } from '@/lib/auth-server'
 import { supabaseAdmin } from '@/lib/supabase'
 import { DeliveryDraftError, generateDeliveryDraft, type AssetRef } from '@/lib/delivery-email'
 import type { EmailTemplateKey } from '@/lib/constants/prompt-keys'
+import {
+  endAgentRun,
+  markAgentRunFailed,
+  recordAgentStep,
+  startAgentRun,
+} from '@/lib/agent-run'
 
 export const dynamic = 'force-dynamic'
 
@@ -69,6 +75,43 @@ export async function POST(
     }
   }
 
+  const agentRun = await startAgentRun({
+    agentKey: 'manual-admin',
+    runtime: 'manual',
+    kind: 'delivery_email_draft',
+    title: 'Generate delivery email draft',
+    subject: {
+      type: 'contact_submission',
+      id: contactId,
+      label: `Lead ${contactId}`,
+    },
+    triggerSource: 'admin:compose_delivery',
+    triggeredByUserId: auth.user.id,
+    currentStep: 'Delivery request validated',
+    metadata: {
+      template_key: templateKey ?? null,
+      asset_count: assetIds.length,
+      include_dashboard_link: includeDashboardLink,
+      has_dashboard_url: !!dashboardUrl,
+    },
+  })
+  const agentRunId = agentRun.id
+
+  await recordAgentStep({
+    runId: agentRunId,
+    stepKey: 'delivery_request_validated',
+    name: 'Delivery request validated',
+    status: 'completed',
+    outputSummary: `Prepared delivery draft request for contact ${contactId}.`,
+    metadata: {
+      contact_id: contactId,
+      template_key: templateKey ?? null,
+      asset_count: assetIds.length,
+      has_dashboard_url: !!dashboardUrl,
+    },
+    idempotencyKey: `${agentRunId}:delivery_request_validated`,
+  }).catch((err) => console.warn('[Compose delivery] agent step failed', err))
+
   try {
     const draft = await generateDeliveryDraft({
       contactId,
@@ -76,12 +119,49 @@ export async function POST(
       templateKey,
       customNote: customNote || undefined,
       dashboardUrl,
+      agentRunId,
     })
 
-    return NextResponse.json(draft)
+    await endAgentRun({
+      runId: agentRunId,
+      status: 'completed',
+      currentStep: 'Delivery draft ready',
+      outcome: {
+        contact_id: contactId,
+        template_key: templateKey ?? null,
+        asset_count: assetIds.length,
+      },
+    }).catch((err) => console.warn('[Compose delivery] end agent run failed', err))
+
+    return NextResponse.json({ ...draft, agentRunId })
   } catch (err) {
     console.error('[Compose delivery] Error:', err)
+    const message = err instanceof Error ? err.message : String(err)
+    await recordAgentStep({
+      runId: agentRunId,
+      stepKey: 'delivery_generation_failed',
+      name: 'Delivery draft generation failed',
+      status: 'failed',
+      outputSummary: message,
+      metadata: {
+        contact_id: contactId,
+        template_key: templateKey ?? null,
+      },
+      idempotencyKey: `${agentRunId}:delivery_generation_failed`,
+    }).catch((stepErr) => console.warn('[Compose delivery] agent failure step failed', stepErr))
+    await markAgentRunFailed(agentRunId, message, {
+      contact_id: contactId,
+      template_key: templateKey ?? null,
+      asset_count: assetIds.length,
+    }).catch((runErr) => console.warn('[Compose delivery] mark agent run failed', runErr))
+
     if (err instanceof DeliveryDraftError) {
+      if (err.code === 'budget_blocked') {
+        return NextResponse.json(
+          { error: 'This delivery draft is over the current Agent Ops budget limit. Reduce the prompt, asset set, or model size before retrying.' },
+          { status: 400 }
+        )
+      }
       if (err.code === 'openai_not_configured') {
         return NextResponse.json(
           {

--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -267,6 +267,7 @@ Current progress:
 - Pre-flight budget policy helpers now define per-runtime LLM warning/cap rules and expose them through the admin policy API; enforcement remains adoption-by-adoption, not a silent global behavior change.
 - Chief of Staff chat now runs a traced pre-flight budget check before dispatching its LLM call, carrying the budget decision into cost metadata and the API response.
 - In-app outreach generation now checks the manual-runtime budget before email or LinkedIn LLM dispatch, records warning/block decisions in Agent Ops traces, and persists the budget decision into `outreach_queue.generation_inputs`.
+- Admin delivery email draft generation now starts a manual Agent Ops trace, checks the manual-runtime budget before OpenAI dispatch, and links post-hoc OpenAI cost events back to the trace.
 
 ## Cross-Phase Definition Of Done
 

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -170,6 +170,7 @@ V1 budget policy is advisory and pre-flight ready:
 - blocked decisions can be raised by shared helpers before dispatch;
 - Chief of Staff chat is the first adopted path and records its budget decision before LLM dispatch;
 - in-app outreach email and LinkedIn generation now check the manual-runtime budget before dispatch and persist the decision into draft provenance;
+- admin delivery email draft generation now checks the manual-runtime budget before OpenAI dispatch and links cost events to the created Agent Ops trace;
 - live workflows are not yet globally blocked until each adoption path has a targeted test and approval gate.
 
 Slack should be treated as a notification and lightweight decision surface later. The source of truth remains Portfolio admin plus `agent_approvals`.

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -65,6 +65,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 - [x] Pre-flight budget policy helpers and admin policy API visibility in review.
 - [x] Chief of Staff chat pre-flight budget adoption in review.
 - [x] Outreach email and LinkedIn pre-flight budget adoption in review.
+- [x] Delivery email draft pre-flight budget adoption and trace linkage in review.
 
 ## Scope Guard
 

--- a/docs/agentic-patterns.md
+++ b/docs/agentic-patterns.md
@@ -418,6 +418,7 @@ Each section follows the same template: *Definition · Where we use it today · 
 - [`lib/agent-budget-policy.ts`](../lib/agent-budget-policy.ts) defines pre-flight per-runtime LLM warning and cap rules.
 - Chief of Staff chat checks the Agent Ops budget policy before dispatch and logs the decision in its trace metadata.
 - Outreach email and LinkedIn draft generation check the manual-runtime budget before dispatch, trace warning/block decisions, and persist the decision in draft provenance.
+- Admin delivery email draft generation checks the manual-runtime budget before OpenAI dispatch and links cost events to its Agent Ops trace.
 - Cost-events ingest accumulates spend per event.
 - `cost_events.agent_run_id` links usage costs to shared Agent Ops traces.
 - Mission Control derives 24-hour Cost Intelligence by runtime, agent, workflow, client/project, and artifact type where run metadata exists.

--- a/lib/delivery-email.test.ts
+++ b/lib/delivery-email.test.ts
@@ -6,14 +6,27 @@ vi.mock('@/lib/supabase', () => ({
 vi.mock('@/lib/system-prompts', () => ({
   getSystemPrompt: vi.fn(),
 }))
-vi.mock('@/lib/cost-calculator', () => ({
-  recordOpenAICost: vi.fn(),
-}))
+vi.mock('@/lib/cost-calculator', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/cost-calculator')>()
+  return {
+    ...actual,
+    recordOpenAICost: vi.fn(),
+  }
+})
 vi.mock('@/lib/notifications', () => ({
-  sendEmail: vi.fn(),
+  sendEmailWithOutcome: vi.fn(),
+}))
+vi.mock('@/lib/agent-run', () => ({
+  recordAgentEvent: vi.fn(),
+  recordAgentStep: vi.fn(),
 }))
 
-import { suggestEmailTemplate, type ContactPageData } from './delivery-email'
+import {
+  DELIVERY_EMAIL_USER_PROMPT,
+  evaluateDeliveryEmailBudget,
+  suggestEmailTemplate,
+  type ContactPageData,
+} from './delivery-email'
 
 function makeContactData(overrides: Partial<ContactPageData> = {}): ContactPageData {
   return {
@@ -62,5 +75,32 @@ describe('suggestEmailTemplate', () => {
     const result = suggestEmailTemplate(makeContactData())
 
     expect(result).toBe('email_cold_outreach')
+  })
+})
+
+describe('evaluateDeliveryEmailBudget', () => {
+  it('allows normal delivery email prompts within the manual admin budget', () => {
+    const decision = evaluateDeliveryEmailBudget({
+      model: 'gpt-4o-mini',
+      systemPrompt: 'Brief context for a single delivery email draft.',
+      userPrompt: DELIVERY_EMAIL_USER_PROMPT,
+      maxTokens: 800,
+    })
+
+    expect(decision.status).toBe('allowed')
+    expect(decision.rule.key).toBe('llm_manual_per_call')
+    expect(decision.estimatedCostUsd).toBeGreaterThan(0)
+  })
+
+  it('blocks oversized delivery email prompts before dispatch', () => {
+    const decision = evaluateDeliveryEmailBudget({
+      model: 'gpt-4o',
+      systemPrompt: 'x'.repeat(2_000_000),
+      userPrompt: DELIVERY_EMAIL_USER_PROMPT,
+      maxTokens: 100_000,
+    })
+
+    expect(decision.status).toBe('blocked')
+    expect(decision.reason).toContain('Manual admin LLM call cap')
   })
 })

--- a/lib/delivery-email.ts
+++ b/lib/delivery-email.ts
@@ -11,6 +11,11 @@ import { getSystemPrompt } from '@/lib/system-prompts'
 import { logCommunication } from '@/lib/communications'
 import { recordOpenAICost } from '@/lib/cost-calculator'
 import { sendEmailWithOutcome } from '@/lib/notifications'
+import {
+  evaluateAgentBudget,
+  type AgentBudgetDecision,
+} from '@/lib/agent-budget-policy'
+import { recordAgentEvent, recordAgentStep } from '@/lib/agent-run'
 import type { EmailTemplateKey } from '@/lib/constants/prompt-keys'
 import type {
   ContactEnrichment,
@@ -31,7 +36,11 @@ import { getEmailFromName } from '@/lib/business-email-config'
 export class DeliveryDraftError extends Error {
   constructor(
     message: string,
-    public readonly code: 'openai_not_configured' | 'openai_upstream' | 'invalid_response'
+    public readonly code:
+      | 'openai_not_configured'
+      | 'openai_upstream'
+      | 'invalid_response'
+      | 'budget_blocked'
   ) {
     super(message)
     this.name = 'DeliveryDraftError'
@@ -51,6 +60,7 @@ export interface DeliveryDraftInput {
   templateKey?: EmailTemplateKey
   customNote?: string
   dashboardUrl?: string
+  agentRunId?: string | null
 }
 
 export interface DeliveryDraft {
@@ -353,6 +363,71 @@ function buildAssetSummary(assets: AssetDetail[], templateKey?: string, dashboar
 
 /* ───────── Draft Generation ───────── */
 
+export const DELIVERY_EMAIL_USER_PROMPT =
+  'Draft the email now. Respond only with JSON: { "subject": "...", "body": "..." }'
+
+function estimateTokensFromText(text: string): number {
+  return Math.ceil(text.length / 4)
+}
+
+export function evaluateDeliveryEmailBudget(input: {
+  model: string
+  systemPrompt: string
+  userPrompt: string
+  maxTokens: number
+}): AgentBudgetDecision {
+  return evaluateAgentBudget({
+    runtime: 'manual',
+    model: input.model,
+    estimatedInputTokens: estimateTokensFromText(`${input.systemPrompt}\n${input.userPrompt}`),
+    maxTokens: input.maxTokens,
+    metadata: {
+      operation: 'delivery_email_draft',
+    },
+  })
+}
+
+async function recordDeliveryEmailBudgetDecision(args: {
+  agentRunId?: string | null
+  contactId: number
+  templateKey: string
+  decision: AgentBudgetDecision
+}) {
+  if (!args.agentRunId) return
+
+  const metadata = {
+    contact_id: args.contactId,
+    template_key: args.templateKey,
+    budget_status: args.decision.status,
+    budget_rule_key: args.decision.rule.key,
+    estimated_cost_usd: args.decision.estimatedCostUsd,
+    warning_usd: args.decision.warningUsd,
+    limit_usd: args.decision.limitUsd,
+  }
+
+  await recordAgentStep({
+    runId: args.agentRunId,
+    stepKey: 'budget_check',
+    name: 'Checked delivery email budget',
+    status: args.decision.status === 'blocked' ? 'failed' : 'completed',
+    outputSummary: args.decision.reason,
+    costUsd: args.decision.estimatedCostUsd,
+    metadata,
+    idempotencyKey: `${args.agentRunId}:delivery_email:budget_check`,
+  }).catch((err) => console.warn('[delivery-email] agent budget step failed:', err))
+
+  if (args.decision.status !== 'allowed') {
+    await recordAgentEvent({
+      runId: args.agentRunId,
+      eventType: 'budget_check',
+      severity: args.decision.status === 'blocked' ? 'error' : 'warning',
+      message: args.decision.reason,
+      metadata,
+      idempotencyKey: `${args.agentRunId}:delivery_email:budget_check:${args.decision.status}`,
+    }).catch((err) => console.warn('[delivery-email] agent budget event failed:', err))
+  }
+}
+
 /**
  * Generate a delivery email draft using the selected template + LLM.
  * Injects tiered research brief and anonymized social proof.
@@ -417,6 +492,23 @@ export async function generateDeliveryDraft(input: DeliveryDraftInput): Promise<
   const model = config.model || 'gpt-4o-mini'
   const temperature = config.temperature ?? 0.7
   const maxTokens = config.maxTokens ?? 800
+  const userPrompt = DELIVERY_EMAIL_USER_PROMPT
+
+  const budgetDecision = evaluateDeliveryEmailBudget({
+    model,
+    systemPrompt,
+    userPrompt,
+    maxTokens,
+  })
+  await recordDeliveryEmailBudgetDecision({
+    agentRunId: input.agentRunId,
+    contactId: input.contactId,
+    templateKey,
+    decision: budgetDecision,
+  })
+  if (budgetDecision.status === 'blocked') {
+    throw new DeliveryDraftError(budgetDecision.reason, 'budget_blocked')
+  }
 
   const response = await fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
@@ -428,7 +520,7 @@ export async function generateDeliveryDraft(input: DeliveryDraftInput): Promise<
       model,
       messages: [
         { role: 'system', content: systemPrompt },
-        { role: 'user', content: 'Draft the email now. Respond only with JSON: { "subject": "...", "body": "..." }' },
+        { role: 'user', content: userPrompt },
       ],
       temperature,
       max_tokens: maxTokens,
@@ -451,7 +543,13 @@ export async function generateDeliveryDraft(input: DeliveryDraftInput): Promise<
       usage,
       model,
       { type: 'contact', id: String(input.contactId) },
-      { operation: `${templateKey}_draft` }
+      {
+        operation: `${templateKey}_draft`,
+        budget_status: budgetDecision.status,
+        budget_rule_key: budgetDecision.rule.key,
+        budget_estimated_cost_usd: budgetDecision.estimatedCostUsd,
+      },
+      input.agentRunId ?? undefined,
     ).catch(() => {})
   }
 


### PR DESCRIPTION
## Summary

- adds manual-runtime pre-flight budget evaluation to admin delivery email draft generation before OpenAI dispatch
- starts a manual Agent Ops trace around `/api/admin/contacts/[id]/compose-delivery`, links the draft generator and OpenAI cost event to that trace, and marks failed traces on errors
- documents the delivery-email budget adoption slice in the Agent Ops roadmap and agentic patterns notes

## Validation

- `npm test -- --run lib/delivery-email.test.ts 'app/api/admin/contacts/[id]/compose-delivery/route.test.ts'`\n- `npx tsc --noEmit --pretty false`\n- `git diff --check`\n- `npm run build`\n\n## Notes\n\nThis branch is independent from unmerged onboarding-budget work and should be merged by Integration Captain after existing budget-policy PR sequencing is reconciled.\n\nBuild emitted the existing local env warning that `MOCK_N8N=false` and `N8N_DISABLE_OUTBOUND=false`; this slice did not trigger n8n workflows.