### PR TITLE
feat: trace meeting lead budget checks

### DIFF
--- a/app/api/admin/meetings/[id]/extract-lead-fields/route.test.ts
+++ b/app/api/admin/meetings/[id]/extract-lead-fields/route.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => {
+  class MockLeadFromMeetingError extends Error {
+    constructor(
+      message: string,
+      public readonly code:
+        | 'budget_blocked'
+        | 'openai_not_configured'
+        | 'openai_upstream'
+        | 'invalid_response',
+    ) {
+      super(message)
+      this.name = 'LeadFromMeetingError'
+    }
+  }
+
+  return {
+    LeadFromMeetingError: MockLeadFromMeetingError,
+    verifyAdmin: vi.fn(),
+    isAuthError: vi.fn(),
+    extractLeadFieldsFromMeeting: vi.fn(),
+    startAgentRun: vi.fn(),
+    recordAgentStep: vi.fn(),
+    endAgentRun: vi.fn(),
+    markAgentRunFailed: vi.fn(),
+  }
+})
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/lead-from-meeting', () => ({
+  LeadFromMeetingError: mocks.LeadFromMeetingError,
+  extractLeadFieldsFromMeeting: mocks.extractLeadFieldsFromMeeting,
+}))
+
+vi.mock('@/lib/agent-run', () => ({
+  startAgentRun: mocks.startAgentRun,
+  recordAgentStep: mocks.recordAgentStep,
+  endAgentRun: mocks.endAgentRun,
+  markAgentRunFailed: mocks.markAgentRunFailed,
+}))
+
+import { POST } from './route'
+
+function makeRequest() {
+  return new NextRequest('http://localhost/api/admin/meetings/meeting-1/extract-lead-fields', {
+    method: 'POST',
+  })
+}
+
+describe('POST /api/admin/meetings/[id]/extract-lead-fields', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    mocks.verifyAdmin.mockResolvedValue({
+      user: { id: 'admin-user-1' },
+      isAdmin: true,
+    })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.startAgentRun.mockResolvedValue({ id: 'agent-run-1' })
+    mocks.recordAgentStep.mockResolvedValue({ id: 'step-1' })
+    mocks.endAgentRun.mockResolvedValue(undefined)
+    mocks.markAgentRunFailed.mockResolvedValue(undefined)
+    mocks.extractLeadFieldsFromMeeting.mockResolvedValue({
+      meeting: {
+        id: 'meeting-1',
+        meeting_type: 'discovery',
+        meeting_date: '2026-05-06',
+      },
+      extracted: {
+        name: 'Jane Prospect',
+        company: 'Acme Co',
+      },
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('requires admin auth before starting an agent run', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Authentication required', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(makeRequest(), { params: { id: 'meeting-1' } })
+
+    expect(response.status).toBe(401)
+    expect(mocks.startAgentRun).not.toHaveBeenCalled()
+  })
+
+  it('starts a trace, passes agentRunId to extraction, and returns it', async () => {
+    const response = await POST(makeRequest(), { params: { id: 'meeting-1' } })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      meeting: {
+        id: 'meeting-1',
+        meeting_type: 'discovery',
+        meeting_date: '2026-05-06',
+      },
+      fields: {
+        name: 'Jane Prospect',
+        company: 'Acme Co',
+      },
+      agentRunId: 'agent-run-1',
+    })
+    expect(mocks.startAgentRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentKey: 'manual-admin',
+        runtime: 'manual',
+        kind: 'meeting_lead_extraction',
+        triggerSource: 'admin:meeting_extract_lead_fields',
+        triggeredByUserId: 'admin-user-1',
+      }),
+    )
+    expect(mocks.extractLeadFieldsFromMeeting).toHaveBeenCalledWith('meeting-1', {
+      agentRunId: 'agent-run-1',
+    })
+    expect(mocks.endAgentRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'agent-run-1',
+        status: 'completed',
+      }),
+    )
+  })
+
+  it('marks the trace failed and returns a safe message when budget blocks extraction', async () => {
+    mocks.extractLeadFieldsFromMeeting.mockRejectedValue(
+      new mocks.LeadFromMeetingError('Estimated cost exceeds cap.', 'budget_blocked'),
+    )
+
+    const response = await POST(makeRequest(), { params: { id: 'meeting-1' } })
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error:
+        'This meeting transcript is over the current Agent Ops budget limit. Shorten the transcript or split the extraction before retrying.',
+    })
+    expect(mocks.markAgentRunFailed).toHaveBeenCalledWith(
+      'agent-run-1',
+      'Estimated cost exceeds cap.',
+      { meeting_record_id: 'meeting-1' },
+    )
+  })
+})

--- a/app/api/admin/meetings/[id]/extract-lead-fields/route.ts
+++ b/app/api/admin/meetings/[id]/extract-lead-fields/route.ts
@@ -1,6 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
-import { extractLeadFieldsFromMeeting } from '@/lib/lead-from-meeting'
+import { extractLeadFieldsFromMeeting, LeadFromMeetingError } from '@/lib/lead-from-meeting'
+import {
+  endAgentRun,
+  markAgentRunFailed,
+  recordAgentStep,
+  startAgentRun,
+} from '@/lib/agent-run'
 
 export const dynamic = 'force-dynamic'
 
@@ -25,8 +31,49 @@ export async function POST(
     return NextResponse.json({ error: 'Meeting ID is required' }, { status: 400 })
   }
 
+  const agentRun = await startAgentRun({
+    agentKey: 'manual-admin',
+    runtime: 'manual',
+    kind: 'meeting_lead_extraction',
+    title: 'Extract lead fields from meeting',
+    subject: {
+      type: 'meeting_record',
+      id: meetingId,
+      label: `Meeting ${meetingId}`,
+    },
+    triggerSource: 'admin:meeting_extract_lead_fields',
+    triggeredByUserId: auth.user.id,
+    currentStep: 'Meeting extraction requested',
+    metadata: {
+      meeting_record_id: meetingId,
+    },
+  })
+  const agentRunId = agentRun.id
+
+  await recordAgentStep({
+    runId: agentRunId,
+    stepKey: 'meeting_extraction_requested',
+    name: 'Meeting extraction requested',
+    status: 'completed',
+    outputSummary: `Prepared lead-field extraction for meeting ${meetingId}.`,
+    metadata: { meeting_record_id: meetingId },
+    idempotencyKey: `${agentRunId}:meeting_extraction_requested`,
+  }).catch((err) => console.warn('[extract-lead-fields] agent step failed', err))
+
   try {
-    const { meeting, extracted } = await extractLeadFieldsFromMeeting(meetingId)
+    const { meeting, extracted } = await extractLeadFieldsFromMeeting(meetingId, {
+      agentRunId,
+    })
+
+    await endAgentRun({
+      runId: agentRunId,
+      status: 'completed',
+      currentStep: 'Lead fields extracted',
+      outcome: {
+        meeting_record_id: meeting.id,
+        extracted_fields: Object.keys(extracted),
+      },
+    }).catch((err) => console.warn('[extract-lead-fields] end agent run failed', err))
 
     return NextResponse.json({
       meeting: {
@@ -35,13 +82,32 @@ export async function POST(
         meeting_date: meeting.meeting_date,
       },
       fields: extracted,
+      agentRunId,
     })
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Extraction failed'
     console.error('[extract-lead-fields] Error:', message)
+    await recordAgentStep({
+      runId: agentRunId,
+      stepKey: 'meeting_extraction_failed',
+      name: 'Meeting lead extraction failed',
+      status: 'failed',
+      outputSummary: message,
+      metadata: { meeting_record_id: meetingId },
+      idempotencyKey: `${agentRunId}:meeting_extraction_failed`,
+    }).catch((stepErr) => console.warn('[extract-lead-fields] agent failure step failed', stepErr))
+    await markAgentRunFailed(agentRunId, message, {
+      meeting_record_id: meetingId,
+    }).catch((runErr) => console.warn('[extract-lead-fields] mark agent run failed', runErr))
 
     if (message.includes('not found')) {
       return NextResponse.json({ error: message }, { status: 404 })
+    }
+    if (err instanceof LeadFromMeetingError && err.code === 'budget_blocked') {
+      return NextResponse.json(
+        { error: 'This meeting transcript is over the current Agent Ops budget limit. Shorten the transcript or split the extraction before retrying.' },
+        { status: 400 }
+      )
     }
     return NextResponse.json({ error: 'Failed to extract lead fields from meeting transcript' }, { status: 500 })
   }

--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -268,6 +268,7 @@ Current progress:
 - Chief of Staff chat now runs a traced pre-flight budget check before dispatching its LLM call, carrying the budget decision into cost metadata and the API response.
 - In-app outreach generation now checks the manual-runtime budget before email or LinkedIn LLM dispatch, records warning/block decisions in Agent Ops traces, and persists the budget decision into `outreach_queue.generation_inputs`.
 - Admin delivery email draft generation now starts a manual Agent Ops trace, checks the manual-runtime budget before OpenAI dispatch, and links post-hoc OpenAI cost events back to the trace.
+- Admin meeting lead extraction now starts a manual Agent Ops trace, checks the manual-runtime budget before OpenAI dispatch, and links lead-extraction cost events back to the trace.
 
 ## Cross-Phase Definition Of Done
 

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -171,6 +171,7 @@ V1 budget policy is advisory and pre-flight ready:
 - Chief of Staff chat is the first adopted path and records its budget decision before LLM dispatch;
 - in-app outreach email and LinkedIn generation now check the manual-runtime budget before dispatch and persist the decision into draft provenance;
 - admin delivery email draft generation now checks the manual-runtime budget before OpenAI dispatch and links cost events to the created Agent Ops trace;
+- admin meeting lead extraction now checks the manual-runtime budget before OpenAI dispatch and links cost events to the created Agent Ops trace;
 - live workflows are not yet globally blocked until each adoption path has a targeted test and approval gate.
 
 Slack should be treated as a notification and lightweight decision surface later. The source of truth remains Portfolio admin plus `agent_approvals`.

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -66,6 +66,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 - [x] Chief of Staff chat pre-flight budget adoption in review.
 - [x] Outreach email and LinkedIn pre-flight budget adoption in review.
 - [x] Delivery email draft pre-flight budget adoption and trace linkage in review.
+- [x] Meeting lead extraction pre-flight budget adoption and trace linkage in review.
 
 ## Scope Guard
 

--- a/docs/agentic-patterns.md
+++ b/docs/agentic-patterns.md
@@ -419,6 +419,7 @@ Each section follows the same template: *Definition · Where we use it today · 
 - Chief of Staff chat checks the Agent Ops budget policy before dispatch and logs the decision in its trace metadata.
 - Outreach email and LinkedIn draft generation check the manual-runtime budget before dispatch, trace warning/block decisions, and persist the decision in draft provenance.
 - Admin delivery email draft generation checks the manual-runtime budget before OpenAI dispatch and links cost events to its Agent Ops trace.
+- Admin meeting lead extraction checks the manual-runtime budget before OpenAI dispatch and links cost events to its Agent Ops trace.
 - Cost-events ingest accumulates spend per event.
 - `cost_events.agent_run_id` links usage costs to shared Agent Ops traces.
 - Mission Control derives 24-hour Cost Intelligence by runtime, agent, workflow, client/project, and artifact type where run metadata exists.

--- a/lib/lead-from-meeting.test.ts
+++ b/lib/lead-from-meeting.test.ts
@@ -7,6 +7,8 @@ const {
   mockEq,
   mockSingle,
   mockRecordOpenAICost,
+  mockRecordAgentStep,
+  mockRecordAgentEvent,
 } = vi.hoisted(() => {
   const mockSingle = vi.fn()
   const mockEq = vi.fn(() => ({ single: mockSingle }))
@@ -14,6 +16,8 @@ const {
   const mockFrom = vi.fn(() => ({ select: mockSelect }))
   const mockSupabaseAdmin = { from: mockFrom }
   const mockRecordOpenAICost = vi.fn(() => Promise.resolve())
+  const mockRecordAgentStep = vi.fn(() => Promise.resolve({ id: 'step-1' }))
+  const mockRecordAgentEvent = vi.fn(() => Promise.resolve({ id: 'event-1' }))
 
   return {
     mockSupabaseAdmin,
@@ -22,6 +26,8 @@ const {
     mockEq,
     mockSingle,
     mockRecordOpenAICost,
+    mockRecordAgentStep,
+    mockRecordAgentEvent,
   }
 })
 
@@ -29,11 +35,22 @@ vi.mock('@/lib/supabase', () => ({
   supabaseAdmin: mockSupabaseAdmin,
 }))
 
-vi.mock('@/lib/cost-calculator', () => ({
-  recordOpenAICost: mockRecordOpenAICost,
+vi.mock('@/lib/cost-calculator', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/cost-calculator')>()
+  return {
+    ...actual,
+    recordOpenAICost: mockRecordOpenAICost,
+  }
+})
+
+vi.mock('@/lib/agent-run', () => ({
+  recordAgentStep: mockRecordAgentStep,
+  recordAgentEvent: mockRecordAgentEvent,
 }))
 
 import {
+  buildLeadExtractionUserPrompt,
+  evaluateLeadFromMeetingBudget,
   fetchMeetingForExtraction,
   extractLeadFieldsFromTranscript,
   extractLeadFieldsFromMeeting,
@@ -48,11 +65,15 @@ describe('lead-from-meeting', () => {
     mockEq.mockClear()
     mockSingle.mockClear()
     mockRecordOpenAICost.mockClear()
+    mockRecordAgentStep.mockClear()
+    mockRecordAgentEvent.mockClear()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
     vi.unstubAllGlobals()
     process.env = { ...originalEnv }
   })
 
   afterEach(() => {
+    vi.restoreAllMocks()
     vi.unstubAllGlobals()
     process.env = { ...originalEnv }
   })
@@ -116,6 +137,29 @@ describe('lead-from-meeting', () => {
     expect(mockRecordOpenAICost).toHaveBeenCalledTimes(1)
   })
 
+  it('allows normal meeting lead extraction prompts within the manual admin budget', () => {
+    const decision = evaluateLeadFromMeetingBudget({
+      systemPrompt: 'Extract contact details.',
+      userPrompt: buildLeadExtractionUserPrompt('Short meeting transcript.'),
+    })
+
+    expect(decision.status).toBe('allowed')
+    expect(decision.rule.key).toBe('llm_manual_per_call')
+    expect(decision.estimatedCostUsd).toBeGreaterThan(0)
+  })
+
+  it('blocks oversized meeting lead extraction prompts before dispatch', () => {
+    const decision = evaluateLeadFromMeetingBudget({
+      systemPrompt: 'Extract contact details.',
+      userPrompt: buildLeadExtractionUserPrompt('x'.repeat(2_000_000)),
+      model: 'gpt-4o',
+      maxTokens: 100_000,
+    })
+
+    expect(decision.status).toBe('blocked')
+    expect(decision.reason).toContain('Manual admin LLM call cap')
+  })
+
   it('throws a generic extraction error when OpenAI returns non-OK', async () => {
     process.env.OPENAI_API_KEY = 'test-key'
 
@@ -128,6 +172,55 @@ describe('lead-from-meeting', () => {
     await expect(
       extractLeadFieldsFromTranscript('Need details for lead creation')
     ).rejects.toThrow('AI extraction failed')
+  })
+
+  it('records budget trace metadata and links cost when agentRunId is supplied', async () => {
+    process.env.OPENAI_API_KEY = 'test-key'
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        usage: { prompt_tokens: 123, completion_tokens: 45, total_tokens: 168 },
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                name: 'Morgan Lead',
+                company: 'Example Co',
+              }),
+            },
+          },
+        ],
+      }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const extracted = await extractLeadFieldsFromTranscript(
+      'Morgan says the sales team needs cleaner follow-up.',
+      { agentRunId: 'agent-run-1', meetingRecordId: 'meeting-99' },
+    )
+
+    expect(extracted.name).toBe('Morgan Lead')
+    expect(mockRecordAgentStep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'agent-run-1',
+        stepKey: 'budget_check',
+        metadata: expect.objectContaining({
+          meeting_record_id: 'meeting-99',
+          budget_status: 'allowed',
+        }),
+      }),
+    )
+    expect(mockRecordOpenAICost).toHaveBeenCalledWith(
+      expect.any(Object),
+      'gpt-4o-mini',
+      { type: 'lead_extraction', id: 'meeting-99' },
+      expect.objectContaining({
+        operation: 'lead_from_meeting',
+        budget_status: 'allowed',
+      }),
+      'agent-run-1',
+    )
   })
 
   it('extractLeadFieldsFromMeeting runs fetch -> combine -> extract flow', async () => {

--- a/lib/lead-from-meeting.ts
+++ b/lib/lead-from-meeting.ts
@@ -9,8 +9,15 @@
 import { supabaseAdmin } from '@/lib/supabase'
 import { combineMeetingText, type MeetingForAudit } from '@/lib/audit-from-meetings'
 import { recordOpenAICost, type Usage } from '@/lib/cost-calculator'
+import {
+  evaluateAgentBudget,
+  type AgentBudgetDecision,
+} from '@/lib/agent-budget-policy'
+import { recordAgentEvent, recordAgentStep } from '@/lib/agent-run'
 
 const MAX_TRANSCRIPT_CHARS = 60_000
+const LEAD_EXTRACTION_MODEL = 'gpt-4o-mini'
+const LEAD_EXTRACTION_MAX_TOKENS = 2000
 
 export interface ExtractedLeadFields {
   name?: string
@@ -25,6 +32,16 @@ export interface ExtractedLeadFields {
   quick_wins?: string
   employee_count?: string
   meeting_context_summary?: string
+}
+
+export class LeadFromMeetingError extends Error {
+  constructor(
+    message: string,
+    public readonly code: 'budget_blocked' | 'openai_not_configured' | 'openai_upstream' | 'invalid_response',
+  ) {
+    super(message)
+    this.name = 'LeadFromMeetingError'
+  }
 }
 
 const SYSTEM_PROMPT = `You are a sales intelligence assistant. Extract contact and business information from a meeting transcript so a salesperson can create a lead record.
@@ -45,6 +62,70 @@ Output valid JSON with these keys (omit any where you found no evidence):
 - meeting_context_summary: 2-3 sentence summary of the meeting — what was discussed, what they need, and any next steps mentioned.
 
 Be precise. Extract real details from the transcript, not generic placeholders. If something wasn't mentioned, omit that key. Output only valid JSON.`
+
+export function buildLeadExtractionUserPrompt(transcript: string): string {
+  return `Extract lead/contact information from this meeting transcript.\n\n${transcript}`
+}
+
+function estimateTokensFromText(text: string): number {
+  return Math.ceil(text.length / 4)
+}
+
+export function evaluateLeadFromMeetingBudget(input: {
+  systemPrompt: string
+  userPrompt: string
+  model?: string
+  maxTokens?: number
+}): AgentBudgetDecision {
+  return evaluateAgentBudget({
+    runtime: 'manual',
+    model: input.model ?? LEAD_EXTRACTION_MODEL,
+    estimatedInputTokens: estimateTokensFromText(`${input.systemPrompt}\n${input.userPrompt}`),
+    maxTokens: input.maxTokens ?? LEAD_EXTRACTION_MAX_TOKENS,
+    metadata: {
+      operation: 'lead_from_meeting',
+    },
+  })
+}
+
+async function recordLeadFromMeetingBudgetDecision(args: {
+  agentRunId?: string | null
+  meetingRecordId?: string | null
+  decision: AgentBudgetDecision
+}) {
+  if (!args.agentRunId) return
+
+  const metadata = {
+    meeting_record_id: args.meetingRecordId ?? null,
+    budget_status: args.decision.status,
+    budget_rule_key: args.decision.rule.key,
+    estimated_cost_usd: args.decision.estimatedCostUsd,
+    warning_usd: args.decision.warningUsd,
+    limit_usd: args.decision.limitUsd,
+  }
+
+  await recordAgentStep({
+    runId: args.agentRunId,
+    stepKey: 'budget_check',
+    name: 'Checked meeting lead extraction budget',
+    status: args.decision.status === 'blocked' ? 'failed' : 'completed',
+    outputSummary: args.decision.reason,
+    costUsd: args.decision.estimatedCostUsd,
+    metadata,
+    idempotencyKey: `${args.agentRunId}:meeting_lead_extraction:budget_check`,
+  }).catch((err) => console.warn('[lead-from-meeting] agent budget step failed:', err))
+
+  if (args.decision.status !== 'allowed') {
+    await recordAgentEvent({
+      runId: args.agentRunId,
+      eventType: 'budget_check',
+      severity: args.decision.status === 'blocked' ? 'error' : 'warning',
+      message: args.decision.reason,
+      metadata,
+      idempotencyKey: `${args.agentRunId}:meeting_lead_extraction:budget_check:${args.decision.status}`,
+    }).catch((err) => console.warn('[lead-from-meeting] agent budget event failed:', err))
+  }
+}
 
 /**
  * Fetch a single meeting record by ID with transcript content.
@@ -74,7 +155,8 @@ export async function fetchMeetingForExtraction(
  * Extract lead fields from a meeting transcript using OpenAI.
  */
 export async function extractLeadFieldsFromTranscript(
-  combinedText: string
+  combinedText: string,
+  options?: { agentRunId?: string | null; meetingRecordId?: string | null },
 ): Promise<ExtractedLeadFields> {
   const trimmed = combinedText.trim()
   if (!trimmed) {
@@ -86,7 +168,23 @@ export async function extractLeadFieldsFromTranscript(
 
   const apiKey = process.env.OPENAI_API_KEY
   if (!apiKey) {
-    throw new Error('OPENAI_API_KEY is not configured')
+    throw new LeadFromMeetingError('OPENAI_API_KEY is not configured', 'openai_not_configured')
+  }
+
+  const userPrompt = buildLeadExtractionUserPrompt(trimmed)
+  const budgetDecision = evaluateLeadFromMeetingBudget({
+    systemPrompt: SYSTEM_PROMPT,
+    userPrompt,
+    model: LEAD_EXTRACTION_MODEL,
+    maxTokens: LEAD_EXTRACTION_MAX_TOKENS,
+  })
+  await recordLeadFromMeetingBudgetDecision({
+    agentRunId: options?.agentRunId,
+    meetingRecordId: options?.meetingRecordId,
+    decision: budgetDecision,
+  })
+  if (budgetDecision.status === 'blocked') {
+    throw new LeadFromMeetingError(budgetDecision.reason, 'budget_blocked')
   }
 
   const response = await fetch('https://api.openai.com/v1/chat/completions', {
@@ -96,16 +194,13 @@ export async function extractLeadFieldsFromTranscript(
       Authorization: `Bearer ${apiKey}`,
     },
     body: JSON.stringify({
-      model: 'gpt-4o-mini',
+      model: LEAD_EXTRACTION_MODEL,
       messages: [
         { role: 'system', content: SYSTEM_PROMPT },
-        {
-          role: 'user',
-          content: `Extract lead/contact information from this meeting transcript.\n\n${trimmed}`,
-        },
+        { role: 'user', content: userPrompt },
       ],
       temperature: 0.2,
-      max_tokens: 2000,
+      max_tokens: LEAD_EXTRACTION_MAX_TOKENS,
       response_format: { type: 'json_object' },
     }),
   })
@@ -113,17 +208,28 @@ export async function extractLeadFieldsFromTranscript(
   if (!response.ok) {
     const errText = await response.text()
     console.error('OpenAI API error (lead-from-meeting):', errText)
-    throw new Error('AI extraction failed')
+    throw new LeadFromMeetingError('AI extraction failed', 'openai_upstream')
   }
 
   const result = await response.json()
   const content = result.choices?.[0]?.message?.content
   const usage = result.usage as Usage | undefined
   if (usage) {
-    recordOpenAICost(usage, 'gpt-4o-mini', { type: 'lead_extraction', id: 'from_meeting' }, { operation: 'lead_from_meeting' }).catch(() => {})
+    recordOpenAICost(
+      usage,
+      LEAD_EXTRACTION_MODEL,
+      { type: 'lead_extraction', id: options?.meetingRecordId ?? 'from_meeting' },
+      {
+        operation: 'lead_from_meeting',
+        budget_status: budgetDecision.status,
+        budget_rule_key: budgetDecision.rule.key,
+        budget_estimated_cost_usd: budgetDecision.estimatedCostUsd,
+      },
+      options?.agentRunId ?? undefined,
+    ).catch(() => {})
   }
   if (!content) {
-    throw new Error('No AI response')
+    throw new LeadFromMeetingError('No AI response', 'invalid_response')
   }
 
   let parsed: unknown
@@ -131,7 +237,7 @@ export async function extractLeadFieldsFromTranscript(
     parsed = JSON.parse(content)
   } catch {
     console.error('Failed to parse AI response (lead-from-meeting):', content)
-    throw new Error('Failed to parse AI response')
+    throw new LeadFromMeetingError('Failed to parse AI response', 'invalid_response')
   }
 
   const obj = parsed as Record<string, unknown>
@@ -157,7 +263,8 @@ export async function extractLeadFieldsFromTranscript(
  * Full pipeline: fetch meeting → combine text → extract lead fields.
  */
 export async function extractLeadFieldsFromMeeting(
-  meetingRecordId: string
+  meetingRecordId: string,
+  options?: { agentRunId?: string | null },
 ): Promise<{ meeting: MeetingForAudit; extracted: ExtractedLeadFields }> {
   const meeting = await fetchMeetingForExtraction(meetingRecordId)
   if (!meeting) {
@@ -169,6 +276,9 @@ export async function extractLeadFieldsFromMeeting(
     throw new Error('No transcript content to extract from')
   }
 
-  const extracted = await extractLeadFieldsFromTranscript(combinedText)
+  const extracted = await extractLeadFieldsFromTranscript(combinedText, {
+    agentRunId: options?.agentRunId,
+    meetingRecordId,
+  })
   return { meeting, extracted }
 }


### PR DESCRIPTION
## Summary

- adds manual-runtime pre-flight budget evaluation to meeting lead-field extraction before OpenAI dispatch
- starts a manual Agent Ops trace around `/api/admin/meetings/[id]/extract-lead-fields`, passes `agentRunId` into extraction, and links lead-extraction cost events back to the trace
- records failed extraction traces and documents the new adoption slice in Agent Ops roadmap/pattern docs

## Validation

- `npm test -- --run lib/lead-from-meeting.test.ts 'app/api/admin/meetings/[id]/extract-lead-fields/route.test.ts'`\n- `npx tsc --noEmit --pretty false`\n- `git diff --check`\n- `npm run build`\n- push hook production DB health check\n\n## Notes\n\nThis branch is independent from the dirty onboarding-budget PR #160 and should be merged by Integration Captain after current draft sequencing is reconciled.\n\nBuild emitted the existing local env warning that `MOCK_N8N=false` and `N8N_DISABLE_OUTBOUND=false`; this slice did not trigger n8n workflows.