### PR TITLE
feat: trace audit meetings budget checks

### DIFF
--- a/app/api/admin/audit-from-meetings/route.test.ts
+++ b/app/api/admin/audit-from-meetings/route.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => {
+  class MockAuditFromMeetingsError extends Error {
+    constructor(
+      message: string,
+      public readonly code:
+        | 'budget_blocked'
+        | 'openai_not_configured'
+        | 'openai_upstream'
+        | 'invalid_response',
+    ) {
+      super(message)
+      this.name = 'AuditFromMeetingsError'
+    }
+  }
+
+  return {
+    AuditFromMeetingsError: MockAuditFromMeetingsError,
+    verifyAdmin: vi.fn(),
+    isAuthError: vi.fn(),
+    buildDiagnosticFromMeetings: vi.fn(),
+    saveDiagnosticAudit: vi.fn(),
+    from: vi.fn(),
+    startAgentRun: vi.fn(),
+    recordAgentStep: vi.fn(),
+    endAgentRun: vi.fn(),
+    markAgentRunFailed: vi.fn(),
+  }
+})
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+vi.mock('@/lib/diagnostic', () => ({
+  saveDiagnosticAudit: mocks.saveDiagnosticAudit,
+}))
+
+vi.mock('@/lib/audit-from-meetings', () => ({
+  AuditFromMeetingsError: mocks.AuditFromMeetingsError,
+  buildDiagnosticFromMeetings: mocks.buildDiagnosticFromMeetings,
+}))
+
+vi.mock('@/lib/agent-run', () => ({
+  startAgentRun: mocks.startAgentRun,
+  recordAgentStep: mocks.recordAgentStep,
+  endAgentRun: mocks.endAgentRun,
+  markAgentRunFailed: mocks.markAgentRunFailed,
+}))
+
+import { POST } from './route'
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest('http://localhost/api/admin/audit-from-meetings', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/admin/audit-from-meetings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    mocks.verifyAdmin.mockResolvedValue({
+      user: { id: 'admin-user-1' },
+      isAdmin: true,
+    })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.startAgentRun.mockResolvedValue({ id: 'agent-run-1' })
+    mocks.recordAgentStep.mockResolvedValue({ id: 'step-1' })
+    mocks.endAgentRun.mockResolvedValue(undefined)
+    mocks.markAgentRunFailed.mockResolvedValue(undefined)
+    mocks.from.mockImplementation((table: string) => {
+      if (table === 'chat_sessions') {
+        return {
+          insert: vi.fn(() => Promise.resolve({ error: null })),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+    mocks.buildDiagnosticFromMeetings.mockResolvedValue({
+      meetings: [{ id: 'meeting-1' }],
+      combinedText: 'meeting transcript',
+      extracted: {
+        business_challenges: {},
+        tech_stack: {},
+        automation_needs: {},
+        ai_readiness: {},
+        budget_timeline: {},
+        decision_making: {},
+        diagnostic_summary: 'Summary',
+      },
+    })
+    mocks.saveDiagnosticAudit.mockResolvedValue({
+      id: 'audit-1',
+      error: null,
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('requires admin auth before starting an agent run', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Authentication required', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(makeRequest({ contact_submission_id: 42 }))
+
+    expect(response.status).toBe(401)
+    expect(mocks.startAgentRun).not.toHaveBeenCalled()
+  })
+
+  it('starts a trace, passes agentRunId to extraction, and returns it', async () => {
+    const response = await POST(makeRequest({ contact_submission_id: 42 }))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      auditId: 'audit-1',
+      sessionId: expect.stringMatching(/^meetings_42_/),
+      meetingsUsed: 1,
+      agentRunId: 'agent-run-1',
+    })
+    expect(mocks.startAgentRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentKey: 'manual-admin',
+        runtime: 'manual',
+        kind: 'audit_from_meetings',
+        triggerSource: 'admin:audit_from_meetings',
+        triggeredByUserId: 'admin-user-1',
+      }),
+    )
+    expect(mocks.buildDiagnosticFromMeetings).toHaveBeenCalledWith(
+      42,
+      undefined,
+      { agentRunId: 'agent-run-1' },
+    )
+    expect(mocks.endAgentRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'agent-run-1',
+        status: 'completed',
+        outcome: expect.objectContaining({
+          audit_id: 'audit-1',
+          meetings_used: 1,
+        }),
+      }),
+    )
+  })
+
+  it('marks the trace failed and returns a safe message when budget blocks extraction', async () => {
+    mocks.buildDiagnosticFromMeetings.mockRejectedValue(
+      new mocks.AuditFromMeetingsError('Estimated cost exceeds cap.', 'budget_blocked'),
+    )
+
+    const response = await POST(makeRequest({ contact_submission_id: 42 }))
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error:
+        'This meeting audit is over the current Agent Ops budget limit. Use fewer meetings or shorten the transcripts before retrying.',
+    })
+    expect(mocks.markAgentRunFailed).toHaveBeenCalledWith(
+      'agent-run-1',
+      'Estimated cost exceeds cap.',
+      expect.objectContaining({ contact_submission_id: 42 }),
+    )
+  })
+})

--- a/app/api/admin/audit-from-meetings/route.ts
+++ b/app/api/admin/audit-from-meetings/route.ts
@@ -2,7 +2,13 @@ import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
 import { supabaseAdmin } from '@/lib/supabase'
 import { saveDiagnosticAudit } from '@/lib/diagnostic'
-import { buildDiagnosticFromMeetings } from '@/lib/audit-from-meetings'
+import { AuditFromMeetingsError, buildDiagnosticFromMeetings } from '@/lib/audit-from-meetings'
+import {
+  endAgentRun,
+  markAgentRunFailed,
+  recordAgentStep,
+  startAgentRun,
+} from '@/lib/agent-run'
 
 export const dynamic = 'force-dynamic'
 
@@ -23,6 +29,9 @@ export async function POST(request: NextRequest) {
   if (isAuthError(auth)) {
     return NextResponse.json({ error: auth.error }, { status: auth.status })
   }
+
+  let agentRunId: string | null = null
+  let failureMetadata: Record<string, unknown> = {}
 
   try {
     const body = await request.json().catch(() => ({}))
@@ -72,11 +81,55 @@ export async function POST(request: NextRequest) {
       resolvedContactId = cid
     }
 
+    const agentRun = await startAgentRun({
+      agentKey: 'manual-admin',
+      runtime: 'manual',
+      kind: 'audit_from_meetings',
+      title: 'Build diagnostic audit from meetings',
+      subject: {
+        type: hasProject ? 'client_project' : 'contact_submission',
+        id: hasProject ? clientProjectId : resolvedContactId,
+        label: hasProject ? `Project ${clientProjectId}` : `Lead ${resolvedContactId}`,
+      },
+      triggerSource: 'admin:audit_from_meetings',
+      triggeredByUserId: auth.user.id,
+      currentStep: 'Audit extraction requested',
+      metadata: {
+        contact_submission_id: resolvedContactId,
+        client_project_id: clientProjectId ?? null,
+        sales_session_id: salesSessionId ?? null,
+      },
+    })
+    agentRunId = agentRun.id
+    failureMetadata = {
+      contact_submission_id: resolvedContactId,
+      client_project_id: clientProjectId ?? null,
+      sales_session_id: salesSessionId ?? null,
+    }
+
+    await recordAgentStep({
+      runId: agentRunId,
+      stepKey: 'audit_extraction_requested',
+      name: 'Audit extraction requested',
+      status: 'completed',
+      outputSummary: `Prepared audit-from-meetings extraction for lead ${resolvedContactId}.`,
+      metadata: {
+        contact_submission_id: resolvedContactId,
+        client_project_id: clientProjectId ?? null,
+        sales_session_id: salesSessionId ?? null,
+      },
+      idempotencyKey: `${agentRunId}:audit_extraction_requested`,
+    }).catch((err) => console.warn('[audit-from-meetings] agent step failed', err))
+
     const { meetings, extracted } = await buildDiagnosticFromMeetings(
       hasContact ? (contactSubmissionId as number) : undefined,
-      hasProject ? clientProjectId : undefined
+      hasProject ? clientProjectId : undefined,
+      { agentRunId },
     ).catch((err) => {
       const msg = err instanceof Error ? err.message : 'Failed to build audit from meetings'
+      if (err instanceof AuditFromMeetingsError && err.code === 'budget_blocked') {
+        throw Object.assign(err, { status: 400 })
+      }
       if (msg.includes('No meetings') || msg.includes('No transcript')) {
         throw Object.assign(new Error(msg), { status: 400 })
       }
@@ -104,6 +157,10 @@ export async function POST(request: NextRequest) {
 
     if (sessionError) {
       console.error('audit-from-meetings: chat_sessions insert failed', sessionError)
+      await markAgentRunFailed(agentRunId, 'Could not create audit session', {
+        contact_submission_id: resolvedContactId,
+        client_project_id: clientProjectId ?? null,
+      }).catch((runErr) => console.warn('[audit-from-meetings] mark agent run failed', runErr))
       return NextResponse.json(
         { error: 'Could not create audit session' },
         { status: 500 }
@@ -133,6 +190,10 @@ export async function POST(request: NextRequest) {
 
     if (result.error) {
       console.error('audit-from-meetings: saveDiagnosticAudit failed', result.error)
+      await markAgentRunFailed(agentRunId, result.error.message || 'Could not save audit', {
+        contact_submission_id: resolvedContactId,
+        client_project_id: clientProjectId ?? null,
+      }).catch((runErr) => console.warn('[audit-from-meetings] mark agent run failed', runErr))
       return NextResponse.json(
         { error: result.error.message || 'Could not save audit' },
         { status: 500 }
@@ -152,17 +213,51 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    await endAgentRun({
+      runId: agentRunId,
+      status: 'completed',
+      currentStep: 'Diagnostic audit ready',
+      outcome: {
+        audit_id: result.id,
+        session_id: sessionId,
+        contact_submission_id: resolvedContactId,
+        client_project_id: clientProjectId ?? null,
+        meetings_used: meetings.length,
+      },
+    }).catch((err) => console.warn('[audit-from-meetings] end agent run failed', err))
+
     return NextResponse.json({
       auditId: result.id,
       sessionId,
       meetingsUsed: meetings.length,
+      agentRunId,
     })
   } catch (e) {
     const err = e as Error & { status?: number }
-    if (err.status === 400) {
+    const status = err.status
+    if (agentRunId) {
+      await recordAgentStep({
+        runId: agentRunId,
+        stepKey: 'audit_from_meetings_failed',
+        name: 'Audit from meetings failed',
+        status: 'failed',
+        outputSummary: err.message || 'Audit from meetings failed',
+        metadata: failureMetadata,
+        idempotencyKey: `${agentRunId}:audit_from_meetings_failed`,
+      }).catch((stepErr) => console.warn('[audit-from-meetings] agent failure step failed', stepErr))
+      await markAgentRunFailed(agentRunId, err.message || 'Audit from meetings failed', failureMetadata)
+        .catch((runErr) => console.warn('[audit-from-meetings] mark agent run failed', runErr))
+    }
+    if (err instanceof AuditFromMeetingsError && err.code === 'budget_blocked') {
+      return NextResponse.json(
+        { error: 'This meeting audit is over the current Agent Ops budget limit. Use fewer meetings or shorten the transcripts before retrying.' },
+        { status: 400 }
+      )
+    }
+    if (status === 400) {
       return NextResponse.json({ error: err.message || 'Bad request' }, { status: 400 })
     }
-    if (err.status === 413) {
+    if (status === 413) {
       return NextResponse.json({ error: err.message || 'Payload too large' }, { status: 413 })
     }
     console.error('audit-from-meetings error', e)

--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -270,6 +270,7 @@ Current progress:
 - Admin delivery email draft generation now starts a manual Agent Ops trace, checks the manual-runtime budget before OpenAI dispatch, and links post-hoc OpenAI cost events back to the trace.
 - Admin meeting lead extraction now starts a manual Agent Ops trace, checks the manual-runtime budget before OpenAI dispatch, and links lead-extraction cost events back to the trace.
 - AI onboarding preview generation now creates a traced manual Agent Ops run from the admin preview endpoint, checks the manual-runtime budget before OpenAI dispatch, and links generated cost events to the trace when available.
+- Admin audit-from-meetings generation now starts a manual Agent Ops trace, checks the manual-runtime budget before OpenAI dispatch, and links diagnostic-extraction cost events back to the trace.
 
 ## Cross-Phase Definition Of Done
 

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -173,6 +173,7 @@ V1 budget policy is advisory and pre-flight ready:
 - admin delivery email draft generation now checks the manual-runtime budget before OpenAI dispatch and links cost events to the created Agent Ops trace;
 - admin meeting lead extraction now checks the manual-runtime budget before OpenAI dispatch and links cost events to the created Agent Ops trace;
 - AI onboarding preview generation now checks the manual-runtime budget before OpenAI dispatch and records a manual Agent Ops trace from the admin preview endpoint;
+- admin audit-from-meetings generation now checks the manual-runtime budget before OpenAI dispatch and links cost events to the created Agent Ops trace;
 - live workflows are not yet globally blocked until each adoption path has a targeted test and approval gate.
 
 Slack should be treated as a notification and lightweight decision surface later. The source of truth remains Portfolio admin plus `agent_approvals`.

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -68,6 +68,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 - [x] Delivery email draft pre-flight budget adoption and trace linkage in review.
 - [x] Meeting lead extraction pre-flight budget adoption and trace linkage in review.
 - [x] AI onboarding preview pre-flight budget adoption in review.
+- [x] Audit-from-meetings pre-flight budget adoption and trace linkage in review.
 
 ## Scope Guard
 

--- a/docs/agentic-patterns.md
+++ b/docs/agentic-patterns.md
@@ -421,6 +421,7 @@ Each section follows the same template: *Definition · Where we use it today · 
 - Admin delivery email draft generation checks the manual-runtime budget before OpenAI dispatch and links cost events to its Agent Ops trace.
 - Admin meeting lead extraction checks the manual-runtime budget before OpenAI dispatch and links cost events to its Agent Ops trace.
 - AI onboarding preview generation checks the manual-runtime budget before dispatch and links admin-triggered previews to a manual Agent Ops run.
+- Admin audit-from-meetings generation checks the manual-runtime budget before OpenAI dispatch and links cost events to its Agent Ops trace.
 - Cost-events ingest accumulates spend per event.
 - `cost_events.agent_run_id` links usage costs to shared Agent Ops traces.
 - Mission Control derives 24-hour Cost Intelligence by runtime, agent, workflow, client/project, and artifact type where run metadata exists.

--- a/lib/audit-from-meetings.test.ts
+++ b/lib/audit-from-meetings.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  recordOpenAICost: vi.fn(() => Promise.resolve()),
+  recordAgentStep: vi.fn(() => Promise.resolve({ id: 'step-1' })),
+  recordAgentEvent: vi.fn(() => Promise.resolve({ id: 'event-1' })),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: vi.fn(),
+  },
+}))
+
+vi.mock('@/lib/cost-calculator', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/cost-calculator')>()
+  return {
+    ...actual,
+    recordOpenAICost: mocks.recordOpenAICost,
+  }
+})
+
+vi.mock('@/lib/agent-run', () => ({
+  recordAgentStep: mocks.recordAgentStep,
+  recordAgentEvent: mocks.recordAgentEvent,
+}))
+
+import {
+  buildAuditFromMeetingsUserPrompt,
+  evaluateAuditFromMeetingsBudget,
+  extractDiagnosticFromMeetingText,
+} from './audit-from-meetings'
+
+describe('audit-from-meetings budget policy', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.unstubAllGlobals()
+    process.env = { ...originalEnv }
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    process.env = { ...originalEnv }
+  })
+
+  it('allows normal audit-from-meetings prompts within the manual admin budget', () => {
+    const decision = evaluateAuditFromMeetingsBudget({
+      systemPrompt: 'Extract diagnostic fields.',
+      userPrompt: buildAuditFromMeetingsUserPrompt('Short meeting transcript.'),
+    })
+
+    expect(decision.status).toBe('allowed')
+    expect(decision.rule.key).toBe('llm_manual_per_call')
+    expect(decision.estimatedCostUsd).toBeGreaterThan(0)
+  })
+
+  it('blocks oversized audit-from-meetings prompts before dispatch', () => {
+    const decision = evaluateAuditFromMeetingsBudget({
+      systemPrompt: 'Extract diagnostic fields.',
+      userPrompt: buildAuditFromMeetingsUserPrompt('x'.repeat(2_000_000)),
+      model: 'gpt-4o',
+      maxTokens: 100_000,
+    })
+
+    expect(decision.status).toBe('blocked')
+    expect(decision.reason).toContain('Manual admin LLM call cap')
+  })
+
+  it('records budget trace metadata and links cost when agentRunId is supplied', async () => {
+    process.env.OPENAI_API_KEY = 'test-key'
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 },
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                business_challenges: { primary_challenges: ['manual_processes'] },
+                tech_stack: { crm: 'hubspot' },
+                automation_needs: { priority_areas: ['lead_follow_up'] },
+                ai_readiness: { data_quality: 'some_systems' },
+                budget_timeline: { timeline: 'quarter' },
+                decision_making: { decision_maker: true },
+                diagnostic_summary: 'They need cleaner follow-up.',
+              }),
+            },
+          },
+        ],
+      }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const extracted = await extractDiagnosticFromMeetingText(
+      'Meeting transcript says follow-up is inconsistent.',
+      {
+        agentRunId: 'agent-run-1',
+        contactSubmissionId: 42,
+      },
+    )
+
+    expect(extracted.diagnostic_summary).toBe('They need cleaner follow-up.')
+    expect(mocks.recordAgentStep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'agent-run-1',
+        stepKey: 'budget_check',
+        metadata: expect.objectContaining({
+          contact_submission_id: 42,
+          budget_status: 'allowed',
+        }),
+      }),
+    )
+    expect(mocks.recordOpenAICost).toHaveBeenCalledWith(
+      expect.any(Object),
+      'gpt-4o-mini',
+      { type: 'contact', id: '42' },
+      expect.objectContaining({
+        operation: 'audit_from_meetings',
+        budget_status: 'allowed',
+      }),
+      'agent-run-1',
+    )
+  })
+})

--- a/lib/audit-from-meetings.ts
+++ b/lib/audit-from-meetings.ts
@@ -6,8 +6,15 @@
 
 import { supabaseAdmin } from '@/lib/supabase'
 import { recordOpenAICost, type Usage } from '@/lib/cost-calculator'
+import {
+  evaluateAgentBudget,
+  type AgentBudgetDecision,
+} from '@/lib/agent-budget-policy'
+import { recordAgentEvent, recordAgentStep } from '@/lib/agent-run'
 export const MAX_COMBINED_CHARS = 100_000
 export const MAX_MEETINGS = 20
+const AUDIT_FROM_MEETINGS_MODEL = 'gpt-4o-mini'
+const AUDIT_FROM_MEETINGS_MAX_TOKENS = 4000
 
 export interface MeetingForAudit {
   id: string
@@ -77,6 +84,9 @@ export function combineMeetingText(meetings: MeetingForAudit[]): string {
 
 export interface ExtractDiagnosticOptions {
   includeScores?: boolean
+  agentRunId?: string | null
+  contactSubmissionId?: number | null
+  clientProjectId?: string | null
 }
 
 export interface ExtractedDiagnostic {
@@ -92,6 +102,16 @@ export interface ExtractedDiagnostic {
   urgency_score?: number
   opportunity_score?: number
   sales_notes?: string
+}
+
+export class AuditFromMeetingsError extends Error {
+  constructor(
+    message: string,
+    public readonly code: 'budget_blocked' | 'openai_not_configured' | 'openai_upstream' | 'invalid_response',
+  ) {
+    super(message)
+    this.name = 'AuditFromMeetingsError'
+  }
 }
 
 const SYSTEM_PROMPT = `You are a sales intelligence analyst. Extract diagnostic audit data from meeting transcripts.
@@ -119,13 +139,79 @@ Output valid JSON with these exact top-level keys. Use the same field names and 
 
 Only include keys for which you found evidence in the transcript. Omit keys with no evidence. Respond only with valid JSON.`
 
+export function buildAuditFromMeetingsUserPrompt(combinedText: string): string {
+  return `Extract diagnostic audit data from these meeting transcripts.\n\n${combinedText}`
+}
+
+function estimateTokensFromText(text: string): number {
+  return Math.ceil(text.length / 4)
+}
+
+export function evaluateAuditFromMeetingsBudget(input: {
+  systemPrompt: string
+  userPrompt: string
+  model?: string
+  maxTokens?: number
+}): AgentBudgetDecision {
+  return evaluateAgentBudget({
+    runtime: 'manual',
+    model: input.model ?? AUDIT_FROM_MEETINGS_MODEL,
+    estimatedInputTokens: estimateTokensFromText(`${input.systemPrompt}\n${input.userPrompt}`),
+    maxTokens: input.maxTokens ?? AUDIT_FROM_MEETINGS_MAX_TOKENS,
+    metadata: {
+      operation: 'audit_from_meetings',
+    },
+  })
+}
+
+async function recordAuditFromMeetingsBudgetDecision(args: {
+  agentRunId?: string | null
+  contactSubmissionId?: number | null
+  clientProjectId?: string | null
+  decision: AgentBudgetDecision
+}) {
+  if (!args.agentRunId) return
+
+  const metadata = {
+    contact_submission_id: args.contactSubmissionId ?? null,
+    client_project_id: args.clientProjectId ?? null,
+    budget_status: args.decision.status,
+    budget_rule_key: args.decision.rule.key,
+    estimated_cost_usd: args.decision.estimatedCostUsd,
+    warning_usd: args.decision.warningUsd,
+    limit_usd: args.decision.limitUsd,
+  }
+
+  await recordAgentStep({
+    runId: args.agentRunId,
+    stepKey: 'budget_check',
+    name: 'Checked audit-from-meetings budget',
+    status: args.decision.status === 'blocked' ? 'failed' : 'completed',
+    outputSummary: args.decision.reason,
+    costUsd: args.decision.estimatedCostUsd,
+    metadata,
+    idempotencyKey: `${args.agentRunId}:audit_from_meetings:budget_check`,
+  }).catch((err) => console.warn('[audit-from-meetings] agent budget step failed:', err))
+
+  if (args.decision.status !== 'allowed') {
+    await recordAgentEvent({
+      runId: args.agentRunId,
+      eventType: 'budget_check',
+      severity: args.decision.status === 'blocked' ? 'error' : 'warning',
+      message: args.decision.reason,
+      metadata,
+      idempotencyKey: `${args.agentRunId}:audit_from_meetings:budget_check:${args.decision.status}`,
+    }).catch((err) => console.warn('[audit-from-meetings] agent budget event failed:', err))
+  }
+}
+
 /**
  * Call OpenAI to extract diagnostic audit data from combined meeting text.
  * Returns object matching DiagnosticAuditData shape (audit categories + optional summary/scores).
  */
 export async function extractDiagnosticFromMeetingText(
   combinedText: string,
-  _options?: ExtractDiagnosticOptions
+  options?: ExtractDiagnosticOptions
 ): Promise<ExtractedDiagnostic> {
   const trimmed = combinedText.trim()
   if (!trimmed) {
@@ -137,7 +223,24 @@ export async function extractDiagnosticFromMeetingText(
 
   const apiKey = process.env.OPENAI_API_KEY
   if (!apiKey) {
-    throw new Error('OPENAI_API_KEY is not configured')
+    throw new AuditFromMeetingsError('OPENAI_API_KEY is not configured', 'openai_not_configured')
+  }
+
+  const userPrompt = buildAuditFromMeetingsUserPrompt(trimmed)
+  const budgetDecision = evaluateAuditFromMeetingsBudget({
+    systemPrompt: SYSTEM_PROMPT,
+    userPrompt,
+    model: AUDIT_FROM_MEETINGS_MODEL,
+    maxTokens: AUDIT_FROM_MEETINGS_MAX_TOKENS,
+  })
+  await recordAuditFromMeetingsBudgetDecision({
+    agentRunId: options?.agentRunId,
+    contactSubmissionId: options?.contactSubmissionId,
+    clientProjectId: options?.clientProjectId,
+    decision: budgetDecision,
+  })
+  if (budgetDecision.status === 'blocked') {
+    throw new AuditFromMeetingsError(budgetDecision.reason, 'budget_blocked')
   }
 
   const response = await fetch('https://api.openai.com/v1/chat/completions', {
@@ -147,13 +250,13 @@ export async function extractDiagnosticFromMeetingText(
       Authorization: `Bearer ${apiKey}`,
     },
     body: JSON.stringify({
-      model: 'gpt-4o-mini',
+      model: AUDIT_FROM_MEETINGS_MODEL,
       messages: [
         { role: 'system', content: SYSTEM_PROMPT },
-        { role: 'user', content: `Extract diagnostic audit data from these meeting transcripts.\n\n${trimmed}` },
+        { role: 'user', content: userPrompt },
       ],
       temperature: 0.3,
-      max_tokens: 4000,
+      max_tokens: AUDIT_FROM_MEETINGS_MAX_TOKENS,
       response_format: { type: 'json_object' },
     }),
   })
@@ -161,17 +264,34 @@ export async function extractDiagnosticFromMeetingText(
   if (!response.ok) {
     const errText = await response.text()
     console.error('OpenAI API error (audit-from-meetings):', errText)
-    throw new Error('AI extraction failed')
+    throw new AuditFromMeetingsError('AI extraction failed', 'openai_upstream')
   }
 
   const result = await response.json()
   const content = result.choices?.[0]?.message?.content
   const usage = result.usage as Usage | undefined
   if (usage) {
-    recordOpenAICost(usage, 'gpt-4o-mini', { type: 'diagnostic_audit', id: 'from_meetings' }, { operation: 'audit_from_meetings' }).catch(() => {})
+    const reference =
+      options?.clientProjectId
+        ? { type: 'client_project', id: options.clientProjectId }
+        : options?.contactSubmissionId != null
+          ? { type: 'contact', id: String(options.contactSubmissionId) }
+          : { type: 'diagnostic_audit', id: 'from_meetings' }
+    recordOpenAICost(
+      usage,
+      AUDIT_FROM_MEETINGS_MODEL,
+      reference,
+      {
+        operation: 'audit_from_meetings',
+        budget_status: budgetDecision.status,
+        budget_rule_key: budgetDecision.rule.key,
+        budget_estimated_cost_usd: budgetDecision.estimatedCostUsd,
+      },
+      options?.agentRunId ?? undefined,
+    ).catch(() => {})
   }
   if (!content) {
-    throw new Error('No AI response')
+    throw new AuditFromMeetingsError('No AI response', 'invalid_response')
   }
 
   let parsed: unknown
@@ -179,7 +299,7 @@ export async function extractDiagnosticFromMeetingText(
     parsed = JSON.parse(content)
   } catch {
     console.error('Failed to parse AI response (audit-from-meetings):', content)
-    throw new Error('Failed to parse AI response')
+    throw new AuditFromMeetingsError('Failed to parse AI response', 'invalid_response')
   }
 
   const obj = parsed as Record<string, unknown>
@@ -205,7 +325,8 @@ export async function extractDiagnosticFromMeetingText(
  */
 export async function buildDiagnosticFromMeetings(
   contactSubmissionId?: number,
-  clientProjectId?: string
+  clientProjectId?: string,
+  options?: { agentRunId?: string | null },
 ): Promise<{ meetings: MeetingForAudit[]; combinedText: string; extracted: ExtractedDiagnostic }> {
   const meetings = await fetchMeetingsForAudit(contactSubmissionId, clientProjectId)
   if (meetings.length === 0) {
@@ -220,6 +341,11 @@ export async function buildDiagnosticFromMeetings(
     throw new Error(`Combined transcript exceeds ${MAX_COMBINED_CHARS} characters (${meetings.length} meetings). Use fewer meetings.`)
   }
 
-  const extracted = await extractDiagnosticFromMeetingText(combinedText, { includeScores: true })
+  const extracted = await extractDiagnosticFromMeetingText(combinedText, {
+    includeScores: true,
+    agentRunId: options?.agentRunId,
+    contactSubmissionId,
+    clientProjectId,
+  })
   return { meetings, combinedText, extracted }
 }


### PR DESCRIPTION
## Summary

- adds manual-runtime pre-flight budget evaluation to audit-from-meetings diagnostic extraction before OpenAI dispatch
- starts a manual Agent Ops trace around `/api/admin/audit-from-meetings`, passes `agentRunId` into extraction, and links diagnostic-extraction cost events back to the trace
- marks audit-from-meetings failures in Agent Ops and documents the new budget adoption slice

## Validation

- `npm test -- --run lib/audit-from-meetings.test.ts app/api/admin/audit-from-meetings/route.test.ts`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- `npm run build`
- push hook production DB health check

## Notes

This branch is independent from the dirty onboarding-budget PR #160 and should be merged by Integration Captain after current draft sequencing is reconciled.

Build emitted the existing local env warning that `MOCK_N8N=false` and `N8N_DISABLE_OUTBOUND=false`; this slice did not trigger n8n workflows.