### PR TITLE
feat: trace video prompt budget checks

### DIFF
--- a/app/api/admin/video-generation/format-prompt/route.test.ts
+++ b/app/api/admin/video-generation/format-prompt/route.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  getVideoPromptFormatterPrompt: vi.fn(),
+  recordOpenAICost: vi.fn(),
+  startAgentRun: vi.fn(),
+  recordAgentStep: vi.fn(),
+  recordAgentEvent: vi.fn(),
+  endAgentRun: vi.fn(),
+  markAgentRunFailed: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/system-prompts', () => ({
+  getVideoPromptFormatterPrompt: mocks.getVideoPromptFormatterPrompt,
+}))
+
+vi.mock('@/lib/cost-calculator', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/cost-calculator')>()
+  return {
+    ...actual,
+    recordOpenAICost: mocks.recordOpenAICost,
+  }
+})
+
+vi.mock('@/lib/agent-run', () => ({
+  startAgentRun: mocks.startAgentRun,
+  recordAgentStep: mocks.recordAgentStep,
+  recordAgentEvent: mocks.recordAgentEvent,
+  endAgentRun: mocks.endAgentRun,
+  markAgentRunFailed: mocks.markAgentRunFailed,
+}))
+
+import {
+  POST,
+} from './route'
+import {
+  buildVideoPromptFormatterUserMessage,
+  evaluateVideoPromptFormatterBudget,
+} from '@/lib/video-prompt-format'
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest('http://localhost/api/admin/video-generation/format-prompt', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/admin/video-generation/format-prompt', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.unstubAllGlobals()
+    process.env = { ...originalEnv, OPENAI_API_KEY: 'test-key' }
+    mocks.verifyAdmin.mockResolvedValue({
+      user: { id: 'admin-user-1' },
+      isAdmin: true,
+    })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.getVideoPromptFormatterPrompt.mockResolvedValue({
+      id: 'prompt-1',
+      key: 'video_prompt_formatter',
+      name: 'Video prompt formatter',
+      prompt: 'Format video notes into a content brief.',
+      config: { model: 'gpt-4o-mini', temperature: 0.4, maxTokens: 800 },
+      version: 1,
+    })
+    mocks.startAgentRun.mockResolvedValue({ id: 'agent-run-1' })
+    mocks.recordAgentStep.mockResolvedValue({ id: 'step-1' })
+    mocks.recordAgentEvent.mockResolvedValue({ id: 'event-1' })
+    mocks.endAgentRun.mockResolvedValue(undefined)
+    mocks.markAgentRunFailed.mockResolvedValue(undefined)
+    mocks.recordOpenAICost.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    process.env = { ...originalEnv }
+  })
+
+  it('requires admin auth before starting a trace', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Authentication required', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(makeRequest({ rawText: 'Make a short video.' }))
+
+    expect(response.status).toBe(401)
+    expect(mocks.startAgentRun).not.toHaveBeenCalled()
+  })
+
+  it('formats the prompt, records budget metadata, links cost, and returns agentRunId', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 },
+        choices: [
+          {
+            message: {
+              content: 'TOPIC: Practical automation\nTARGET AUDIENCE: Small business owners',
+            },
+          },
+        ],
+      }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const response = await POST(makeRequest({
+      rawText: 'I want a video about making automation practical.',
+      audience: 'small business owners',
+      tone: 'plainspoken',
+      angle: 'automation that reduces burden',
+    }))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      formattedPrompt: 'TOPIC: Practical automation\nTARGET AUDIENCE: Small business owners',
+      agentRunId: 'agent-run-1',
+    })
+    expect(mocks.startAgentRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentKey: 'manual-admin',
+        runtime: 'manual',
+        kind: 'video_prompt_format',
+        triggerSource: 'admin:video_prompt_format',
+        triggeredByUserId: 'admin-user-1',
+      }),
+    )
+    expect(mocks.recordAgentStep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'agent-run-1',
+        stepKey: 'budget_check',
+        metadata: expect.objectContaining({
+          operation: 'video_prompt_format',
+          budget_status: 'allowed',
+        }),
+      }),
+    )
+    expect(mocks.recordOpenAICost).toHaveBeenCalledWith(
+      expect.any(Object),
+      'gpt-4o-mini',
+      { type: 'video_prompt_format', id: 'agent-run-1' },
+      expect.objectContaining({
+        operation: 'video_prompt_format',
+        budget_status: 'allowed',
+      }),
+      'agent-run-1',
+    )
+    expect(mocks.endAgentRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'agent-run-1',
+        status: 'completed',
+      }),
+    )
+  })
+
+  it('marks the trace failed and returns a safe message when budget blocks formatting', async () => {
+    mocks.getVideoPromptFormatterPrompt.mockResolvedValue({
+      id: 'prompt-1',
+      key: 'video_prompt_formatter',
+      name: 'Video prompt formatter',
+      prompt: 'Format video notes into a content brief.',
+      config: { model: 'gpt-4o', temperature: 0.4, maxTokens: 100_000 },
+      version: 1,
+    })
+    const mockFetch = vi.fn()
+    vi.stubGlobal('fetch', mockFetch)
+
+    const response = await POST(makeRequest({
+      rawText: 'x'.repeat(2_000_000),
+    }))
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error:
+        'This video prompt formatting request is over the current Agent Ops budget limit. Shorten the notes or reduce the configured max tokens before retrying.',
+    })
+    expect(mockFetch).not.toHaveBeenCalled()
+    expect(mocks.recordAgentStep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'agent-run-1',
+        stepKey: 'budget_check',
+        status: 'failed',
+      }),
+    )
+    expect(mocks.markAgentRunFailed).toHaveBeenCalledWith(
+      'agent-run-1',
+      expect.stringContaining('Estimated cost'),
+      { operation: 'video_prompt_format' },
+    )
+  })
+
+  it('builds detail fields into the formatter user message', () => {
+    const message = buildVideoPromptFormatterUserMessage({
+      rawText: 'Make this into a video brief.',
+      audience: 'operators',
+      tone: 'direct',
+      angle: 'reduce manual work',
+    })
+
+    expect(message).toContain('Make this into a video brief.')
+    expect(message).toContain('TARGET AUDIENCE: operators')
+    expect(message).toContain('TONE: direct')
+    expect(message).toContain('ANGLE / HOOK: reduce manual work')
+  })
+
+  it('evaluates normal formatter prompts within the manual budget', () => {
+    const decision = evaluateVideoPromptFormatterBudget({
+      systemPrompt: 'Format notes.',
+      userMessage: 'Short notes.',
+    })
+
+    expect(decision.status).toBe('allowed')
+    expect(decision.rule.key).toBe('llm_manual_per_call')
+    expect(decision.estimatedCostUsd).toBeGreaterThan(0)
+  })
+})

--- a/app/api/admin/video-generation/format-prompt/route.ts
+++ b/app/api/admin/video-generation/format-prompt/route.ts
@@ -7,23 +7,29 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
 import { getVideoPromptFormatterPrompt } from '@/lib/system-prompts'
-import { recordOpenAICost } from '@/lib/cost-calculator'
+import { recordOpenAICost, type Usage } from '@/lib/cost-calculator'
+import {
+  endAgentRun,
+  markAgentRunFailed,
+  recordAgentStep,
+  startAgentRun,
+} from '@/lib/agent-run'
+import {
+  buildVideoPromptFormatterUserMessage,
+  evaluateVideoPromptFormatterBudget,
+  recordVideoPromptFormatterBudgetDecision,
+  VIDEO_PROMPT_FORMAT_OPERATION,
+  VideoPromptFormatError,
+} from '@/lib/video-prompt-format'
 
 export const dynamic = 'force-dynamic'
 
 export async function POST(request: NextRequest) {
+  let agentRunId: string | null = null
   try {
     const auth = await verifyAdmin(request)
     if (isAuthError(auth)) {
       return NextResponse.json({ error: auth.error }, { status: auth.status })
-    }
-
-    const apiKey = process.env.OPENAI_API_KEY
-    if (!apiKey) {
-      return NextResponse.json(
-        { error: 'OpenAI API key not configured' },
-        { status: 500 }
-      )
     }
 
     const body = await request.json().catch(() => ({}))
@@ -46,14 +52,69 @@ export async function POST(request: NextRequest) {
     const temperature = typeof config.temperature === 'number' ? config.temperature : 0.5
     const maxTokens = typeof config.maxTokens === 'number' ? config.maxTokens : 800
 
-    const detailLines: string[] = []
-    if (audience) detailLines.push(`TARGET AUDIENCE: ${audience}`)
-    if (tone) detailLines.push(`TONE: ${tone}`)
-    if (angle) detailLines.push(`ANGLE / HOOK: ${angle}`)
+    const userMessage = buildVideoPromptFormatterUserMessage({
+      rawText,
+      audience,
+      tone,
+      angle,
+    })
 
-    const userMessage = detailLines.length > 0
-      ? `${rawText}\n\nAdditional details provided by the user:\n${detailLines.join('\n')}`
-      : rawText
+    const agentRun = await startAgentRun({
+      agentKey: 'manual-admin',
+      runtime: 'manual',
+      kind: 'video_prompt_format',
+      title: 'Format video generation prompt',
+      subject: {
+        type: 'video_prompt',
+        label: rawText.slice(0, 80),
+      },
+      triggerSource: 'admin:video_prompt_format',
+      triggeredByUserId: auth.user.id,
+      currentStep: 'Video prompt request validated',
+      metadata: {
+        model,
+        max_tokens: maxTokens,
+        has_audience: !!audience,
+        has_tone: !!tone,
+        has_angle: !!angle,
+        prompt_key: systemPromptObj?.key ?? 'video_prompt_formatter',
+      },
+    })
+    agentRunId = agentRun.id
+
+    await recordAgentStep({
+      runId: agentRunId,
+      stepKey: 'video_prompt_request_validated',
+      name: 'Video prompt request validated',
+      status: 'completed',
+      inputSummary: rawText.slice(0, 240),
+      metadata: {
+        model,
+        max_tokens: maxTokens,
+        raw_text_chars: rawText.length,
+        user_message_chars: userMessage.length,
+      },
+      idempotencyKey: `${agentRunId}:video_prompt_request_validated`,
+    }).catch((err) => console.warn('[format-prompt] agent validation step failed:', err))
+
+    const apiKey = process.env.OPENAI_API_KEY
+    if (!apiKey) {
+      throw new VideoPromptFormatError('OPENAI_API_KEY is not configured', 'openai_not_configured')
+    }
+
+    const budgetDecision = evaluateVideoPromptFormatterBudget({
+      systemPrompt,
+      userMessage,
+      model,
+      maxTokens,
+    })
+    await recordVideoPromptFormatterBudgetDecision({
+      agentRunId,
+      decision: budgetDecision,
+    })
+    if (budgetDecision.status === 'blocked') {
+      throw new VideoPromptFormatError(budgetDecision.reason, 'budget_blocked')
+    }
 
     const response = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
@@ -75,24 +136,87 @@ export async function POST(request: NextRequest) {
     if (!response.ok) {
       const errText = await response.text()
       console.error('[format-prompt] OpenAI error:', errText)
-      return NextResponse.json(
-        { error: 'AI formatting failed' },
-        { status: 500 }
-      )
+      throw new VideoPromptFormatError('AI formatting failed', 'openai_upstream')
     }
 
     const aiResult = await response.json()
     const content = aiResult.choices?.[0]?.message?.content?.trim() ?? ''
-    const usage = aiResult.usage
+    const usage = aiResult.usage as Usage | undefined
     if (usage) {
-      recordOpenAICost(usage, model, undefined, {
-        operation: 'video_prompt_format',
-      }).catch(() => {})
+      recordOpenAICost(
+        usage,
+        model,
+        { type: 'video_prompt_format', id: agentRunId },
+        {
+          operation: VIDEO_PROMPT_FORMAT_OPERATION,
+          budget_status: budgetDecision.status,
+          budget_rule_key: budgetDecision.rule.key,
+          budget_estimated_cost_usd: budgetDecision.estimatedCostUsd,
+        },
+        agentRunId,
+      ).catch(() => {})
     }
 
-    return NextResponse.json({ formattedPrompt: content })
+    if (!content) {
+      throw new VideoPromptFormatError('No AI response', 'invalid_response')
+    }
+
+    await endAgentRun({
+      runId: agentRunId,
+      status: 'completed',
+      currentStep: 'Video prompt formatted',
+      outcome: {
+        model,
+        prompt_chars: content.length,
+      },
+    }).catch((err) => console.warn('[format-prompt] end agent run failed:', err))
+
+    return NextResponse.json({ formattedPrompt: content, agentRunId })
   } catch (error) {
     console.error('[format-prompt] Error:', error)
+
+    const message = error instanceof Error ? error.message : String(error)
+    if (agentRunId) {
+      await recordAgentStep({
+        runId: agentRunId,
+        stepKey: 'video_prompt_format_failed',
+        name: 'Video prompt formatting failed',
+        status: 'failed',
+        outputSummary: message,
+        idempotencyKey: `${agentRunId}:video_prompt_format_failed`,
+      }).catch((stepErr) => console.warn('[format-prompt] agent failure step failed:', stepErr))
+      await markAgentRunFailed(agentRunId, message, {
+        operation: VIDEO_PROMPT_FORMAT_OPERATION,
+      }).catch((runErr) => console.warn('[format-prompt] mark agent run failed:', runErr))
+    }
+
+    if (error instanceof VideoPromptFormatError) {
+      if (error.code === 'budget_blocked') {
+        return NextResponse.json(
+          { error: 'This video prompt formatting request is over the current Agent Ops budget limit. Shorten the notes or reduce the configured max tokens before retrying.' },
+          { status: 400 },
+        )
+      }
+      if (error.code === 'openai_not_configured') {
+        return NextResponse.json(
+          { error: 'OpenAI API key not configured' },
+          { status: 503 },
+        )
+      }
+      if (error.code === 'openai_upstream') {
+        return NextResponse.json(
+          { error: 'AI formatting failed' },
+          { status: 502 },
+        )
+      }
+      if (error.code === 'invalid_response') {
+        return NextResponse.json(
+          { error: 'The AI returned an empty response. Try formatting again or adjust the video prompt formatter system prompt.' },
+          { status: 502 },
+        )
+      }
+    }
+
     return NextResponse.json(
       { error: 'Something went wrong. Please try again.' },
       { status: 500 }

--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -271,6 +271,7 @@ Current progress:
 - Admin meeting lead extraction now starts a manual Agent Ops trace, checks the manual-runtime budget before OpenAI dispatch, and links lead-extraction cost events back to the trace.
 - AI onboarding preview generation now creates a traced manual Agent Ops run from the admin preview endpoint, checks the manual-runtime budget before OpenAI dispatch, and links generated cost events to the trace when available.
 - Admin audit-from-meetings generation now starts a manual Agent Ops trace, checks the manual-runtime budget before OpenAI dispatch, and links diagnostic-extraction cost events back to the trace.
+- Admin video prompt formatting now starts a manual Agent Ops trace, checks the manual-runtime budget before OpenAI dispatch, and links prompt-formatting cost events back to the trace.
 
 ## Cross-Phase Definition Of Done
 

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -174,6 +174,7 @@ V1 budget policy is advisory and pre-flight ready:
 - admin meeting lead extraction now checks the manual-runtime budget before OpenAI dispatch and links cost events to the created Agent Ops trace;
 - AI onboarding preview generation now checks the manual-runtime budget before OpenAI dispatch and records a manual Agent Ops trace from the admin preview endpoint;
 - admin audit-from-meetings generation now checks the manual-runtime budget before OpenAI dispatch and links cost events to the created Agent Ops trace;
+- admin video prompt formatting now checks the manual-runtime budget before OpenAI dispatch and links cost events to the created Agent Ops trace;
 - live workflows are not yet globally blocked until each adoption path has a targeted test and approval gate.
 
 Slack should be treated as a notification and lightweight decision surface later. The source of truth remains Portfolio admin plus `agent_approvals`.

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -69,6 +69,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 - [x] Meeting lead extraction pre-flight budget adoption and trace linkage in review.
 - [x] AI onboarding preview pre-flight budget adoption in review.
 - [x] Audit-from-meetings pre-flight budget adoption and trace linkage in review.
+- [x] Video prompt formatter pre-flight budget adoption and trace linkage in review.
 
 ## Scope Guard
 

--- a/docs/agentic-patterns.md
+++ b/docs/agentic-patterns.md
@@ -422,6 +422,7 @@ Each section follows the same template: *Definition · Where we use it today · 
 - Admin meeting lead extraction checks the manual-runtime budget before OpenAI dispatch and links cost events to its Agent Ops trace.
 - AI onboarding preview generation checks the manual-runtime budget before dispatch and links admin-triggered previews to a manual Agent Ops run.
 - Admin audit-from-meetings generation checks the manual-runtime budget before OpenAI dispatch and links cost events to its Agent Ops trace.
+- Admin video prompt formatting checks the manual-runtime budget before OpenAI dispatch and links cost events to its Agent Ops trace.
 - Cost-events ingest accumulates spend per event.
 - `cost_events.agent_run_id` links usage costs to shared Agent Ops traces.
 - Mission Control derives 24-hour Cost Intelligence by runtime, agent, workflow, client/project, and artifact type where run metadata exists.

--- a/lib/video-prompt-format.ts
+++ b/lib/video-prompt-format.ts
@@ -1,0 +1,90 @@
+import {
+  evaluateAgentBudget,
+  type AgentBudgetDecision,
+} from '@/lib/agent-budget-policy'
+import { recordAgentEvent, recordAgentStep } from '@/lib/agent-run'
+
+export const VIDEO_PROMPT_FORMAT_OPERATION = 'video_prompt_format'
+
+export class VideoPromptFormatError extends Error {
+  constructor(
+    message: string,
+    public readonly code: 'budget_blocked' | 'openai_not_configured' | 'openai_upstream' | 'invalid_response',
+  ) {
+    super(message)
+    this.name = 'VideoPromptFormatError'
+  }
+}
+
+function estimateTokensFromText(text: string): number {
+  return Math.ceil(text.length / 4)
+}
+
+export function buildVideoPromptFormatterUserMessage(input: {
+  rawText: string
+  audience?: string
+  tone?: string
+  angle?: string
+}): string {
+  const detailLines: string[] = []
+  if (input.audience) detailLines.push(`TARGET AUDIENCE: ${input.audience}`)
+  if (input.tone) detailLines.push(`TONE: ${input.tone}`)
+  if (input.angle) detailLines.push(`ANGLE / HOOK: ${input.angle}`)
+
+  return detailLines.length > 0
+    ? `${input.rawText}\n\nAdditional details provided by the user:\n${detailLines.join('\n')}`
+    : input.rawText
+}
+
+export function evaluateVideoPromptFormatterBudget(input: {
+  systemPrompt: string
+  userMessage: string
+  model?: string
+  maxTokens?: number
+}): AgentBudgetDecision {
+  return evaluateAgentBudget({
+    runtime: 'manual',
+    model: input.model ?? 'gpt-4o-mini',
+    estimatedInputTokens: estimateTokensFromText(`${input.systemPrompt}\n${input.userMessage}`),
+    maxTokens: input.maxTokens ?? 800,
+    metadata: {
+      operation: VIDEO_PROMPT_FORMAT_OPERATION,
+    },
+  })
+}
+
+export async function recordVideoPromptFormatterBudgetDecision(args: {
+  agentRunId: string
+  decision: AgentBudgetDecision
+}) {
+  const metadata = {
+    operation: VIDEO_PROMPT_FORMAT_OPERATION,
+    budget_status: args.decision.status,
+    budget_rule_key: args.decision.rule.key,
+    estimated_cost_usd: args.decision.estimatedCostUsd,
+    warning_usd: args.decision.warningUsd,
+    limit_usd: args.decision.limitUsd,
+  }
+
+  await recordAgentStep({
+    runId: args.agentRunId,
+    stepKey: 'budget_check',
+    name: 'Checked video prompt formatter budget',
+    status: args.decision.status === 'blocked' ? 'failed' : 'completed',
+    outputSummary: args.decision.reason,
+    costUsd: args.decision.estimatedCostUsd,
+    metadata,
+    idempotencyKey: `${args.agentRunId}:video_prompt_format:budget_check`,
+  }).catch((err) => console.warn('[format-prompt] agent budget step failed:', err))
+
+  if (args.decision.status !== 'allowed') {
+    await recordAgentEvent({
+      runId: args.agentRunId,
+      eventType: 'budget_check',
+      severity: args.decision.status === 'blocked' ? 'error' : 'warning',
+      message: args.decision.reason,
+      metadata,
+      idempotencyKey: `${args.agentRunId}:video_prompt_format:budget_check:${args.decision.status}`,
+    }).catch((err) => console.warn('[format-prompt] agent budget event failed:', err))
+  }
+}


### PR DESCRIPTION
## Summary\n- add manual Agent Ops tracing to the video prompt formatter endpoint\n- run manual-runtime budget preflight before OpenAI dispatch\n- link video prompt formatting cost events to the created agent run\n- document the Phase 10 budget-policy adoption slice\n\n## Validation\n- npm test -- --run app/api/admin/video-generation/format-prompt/route.test.ts\n- npx tsc --noEmit --pretty false\n- git diff --check\n- npm run build\n- pre-push database health check passed\n\n## Notes\n- No n8n workflows were triggered.\n- Build emitted the existing local env warning that MOCK_N8N=false and N8N_DISABLE_OUTBOUND=false.