### PR TITLE
feat: trace video ideas budget checks

### DIFF
--- a/app/api/admin/video-generation/generate-ideas/route.test.ts
+++ b/app/api/admin/video-generation/generate-ideas/route.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  fetchVideoIdeasContext: vi.fn(),
+  serializeContextForPrompt: vi.fn(),
+  fetchVideoContextByEmail: vi.fn(),
+  recordOpenAICost: vi.fn(),
+  startAgentRun: vi.fn(),
+  recordAgentStep: vi.fn(),
+  recordAgentEvent: vi.fn(),
+  endAgentRun: vi.fn(),
+  markAgentRunFailed: vi.fn(),
+  from: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+vi.mock('@/lib/video-ideas-context', () => ({
+  fetchVideoIdeasContext: mocks.fetchVideoIdeasContext,
+  serializeContextForPrompt: mocks.serializeContextForPrompt,
+}))
+
+vi.mock('@/lib/video-context', () => ({
+  fetchVideoContextByEmail: mocks.fetchVideoContextByEmail,
+}))
+
+vi.mock('@/lib/cost-calculator', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/cost-calculator')>()
+  return {
+    ...actual,
+    recordOpenAICost: mocks.recordOpenAICost,
+  }
+})
+
+vi.mock('@/lib/agent-run', () => ({
+  startAgentRun: mocks.startAgentRun,
+  recordAgentStep: mocks.recordAgentStep,
+  recordAgentEvent: mocks.recordAgentEvent,
+  endAgentRun: mocks.endAgentRun,
+  markAgentRunFailed: mocks.markAgentRunFailed,
+}))
+
+import { POST } from './route'
+import { evaluateVideoIdeasGenerationBudget } from '@/lib/video-ideas-generation'
+
+function makeRequest(body: Record<string, unknown>, headers?: Record<string, string>) {
+  return new NextRequest('http://localhost/api/admin/video-generation/generate-ideas', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/admin/video-generation/generate-ideas', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.unstubAllGlobals()
+    process.env = { ...originalEnv, OPENAI_API_KEY: 'test-key' }
+    mocks.verifyAdmin.mockResolvedValue({
+      user: { id: 'admin-user-1' },
+      isAdmin: true,
+    })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.startAgentRun.mockResolvedValue({ id: 'agent-run-1' })
+    mocks.recordAgentStep.mockResolvedValue({ id: 'step-1' })
+    mocks.recordAgentEvent.mockResolvedValue({ id: 'event-1' })
+    mocks.endAgentRun.mockResolvedValue(undefined)
+    mocks.markAgentRunFailed.mockResolvedValue(undefined)
+    mocks.recordOpenAICost.mockResolvedValue(undefined)
+    mocks.fetchVideoContextByEmail.mockResolvedValue({ found: false })
+    mocks.fetchVideoIdeasContext.mockResolvedValue({ meetings: [], chatSessions: [], siteContent: [] })
+    mocks.serializeContextForPrompt.mockReturnValue('Short context.')
+    mocks.from.mockImplementation((table: string) => {
+      if (table === 'video_ideas_queue') {
+        return {
+          insert: vi.fn(() => ({
+            select: vi.fn(() => Promise.resolve({ data: [{ id: 'idea-1' }], error: null })),
+          })),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    process.env = { ...originalEnv }
+  })
+
+  it('requires admin auth before starting a trace', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Authentication required', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(makeRequest({ mode: 'from_direction', customPrompt: 'Make a video.' }))
+
+    expect(response.status).toBe(401)
+    expect(mocks.startAgentRun).not.toHaveBeenCalled()
+  })
+
+  it('generates ideas, records budget metadata, links cost, and returns agentRunId', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        usage: { prompt_tokens: 500, completion_tokens: 1000, total_tokens: 1500 },
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                ideas: [
+                  {
+                    title: 'Automation That Gives Time Back',
+                    script: 'A practical script.',
+                    storyboard: { scenes: [{ sceneNumber: 1, description: 'Open on admin workflow.' }] },
+                  },
+                ],
+              }),
+            },
+          },
+        ],
+      }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const response = await POST(makeRequest({
+      mode: 'from_direction',
+      customPrompt: 'Turn this note into one practical video.',
+      limit: 1,
+    }))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      ideas: [
+        {
+          title: 'Automation That Gives Time Back',
+          script: 'A practical script.',
+          storyboard: { scenes: [{ sceneNumber: 1, description: 'Open on admin workflow.' }] },
+        },
+      ],
+      addedToQueue: 1,
+      mode: 'from_direction',
+      agentRunId: 'agent-run-1',
+    })
+    expect(mocks.startAgentRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentKey: 'manual-admin',
+        runtime: 'manual',
+        kind: 'video_ideas_generation',
+        triggerSource: 'admin:video_generate_ideas',
+        triggeredByUserId: 'admin-user-1',
+      }),
+    )
+    expect(mocks.recordAgentStep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'agent-run-1',
+        stepKey: 'budget_check',
+        metadata: expect.objectContaining({
+          operation: 'video_ideas_generation',
+          mode: 'from_direction',
+          budget_status: 'warning',
+        }),
+      }),
+    )
+    expect(mocks.recordOpenAICost).toHaveBeenCalledWith(
+      expect.any(Object),
+      'gpt-4o',
+      { type: 'video_ideas_generation', id: 'agent-run-1' },
+      expect.objectContaining({
+        operation: 'video_ideas_generation',
+        mode: 'from_direction',
+        budget_status: 'warning',
+      }),
+      'agent-run-1',
+    )
+    expect(mocks.endAgentRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'agent-run-1',
+        status: 'completed',
+      }),
+    )
+  })
+
+  it('marks the trace failed and returns a safe message when budget blocks generation', async () => {
+    mocks.serializeContextForPrompt.mockReturnValue('x'.repeat(1_000_000))
+    const mockFetch = vi.fn()
+    vi.stubGlobal('fetch', mockFetch)
+
+    const response = await POST(makeRequest({
+      mode: 'from_scratch',
+      limit: 10,
+      includeTranscripts: true,
+    }))
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error:
+        'This video ideas request is over the current Agent Ops budget limit. Use fewer ideas, shorter notes, or less transcript context before retrying.',
+      agentRunId: 'agent-run-1',
+    })
+    expect(mockFetch).not.toHaveBeenCalled()
+    expect(mocks.recordAgentStep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'agent-run-1',
+        stepKey: 'budget_check',
+        status: 'failed',
+      }),
+    )
+    expect(mocks.markAgentRunFailed).toHaveBeenCalledWith(
+      'agent-run-1',
+      expect.stringContaining('Estimated cost'),
+      expect.objectContaining({ operation: 'video_ideas_generation', mode: 'from_scratch' }),
+    )
+  })
+
+  it('warns but allows normal video idea prompts under the manual hard cap', () => {
+    const decision = evaluateVideoIdeasGenerationBudget({
+      systemPrompt: 'Generate ideas.',
+      userPrompt: 'Short direction.',
+    })
+
+    expect(decision.status).toBe('warning')
+    expect(decision.rule.key).toBe('llm_manual_per_call')
+    expect(decision.estimatedCostUsd).toBeGreaterThan(0)
+    expect(decision.estimatedCostUsd).toBeLessThan(decision.limitUsd)
+  })
+})

--- a/app/api/admin/video-generation/generate-ideas/route.ts
+++ b/app/api/admin/video-generation/generate-ideas/route.ts
@@ -13,12 +13,26 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
 import { supabaseAdmin } from '@/lib/supabase'
-import { recordOpenAICost } from '@/lib/cost-calculator'
+import { recordOpenAICost, type Usage } from '@/lib/cost-calculator'
+import {
+  endAgentRun,
+  markAgentRunFailed,
+  recordAgentStep,
+  startAgentRun,
+} from '@/lib/agent-run'
 import {
   fetchVideoIdeasContext,
   serializeContextForPrompt,
 } from '@/lib/video-ideas-context'
 import { fetchVideoContextByEmail } from '@/lib/video-context'
+import {
+  evaluateVideoIdeasGenerationBudget,
+  recordVideoIdeasGenerationBudgetDecision,
+  VIDEO_IDEAS_GENERATION_MAX_TOKENS,
+  VIDEO_IDEAS_GENERATION_MODEL,
+  VIDEO_IDEAS_GENERATION_OPERATION,
+  VideoIdeasGenerationError,
+} from '@/lib/video-ideas-generation'
 
 export const dynamic = 'force-dynamic'
 
@@ -106,6 +120,7 @@ function parseBody(body: Record<string, unknown>): GenerateParams {
 async function runGeneration(
   params: GenerateParams,
   apiKey: string,
+  agentRunId?: string | null,
   onStep?: (data: Record<string, unknown>) => void
 ): Promise<{ ideas: VideoIdea[]; addedToQueue: number; mode: string; error?: string }> {
   const { mode, limit, includeTranscripts, customPrompt, email, audience, tone, angle, meetingIds } = params
@@ -166,6 +181,23 @@ async function runGeneration(
     userPrompt = parts.join('\n')
   }
 
+  onStep?.({ step: 'budget_check', detail: 'Checking Agent Ops budget before AI dispatch...' })
+  const budgetDecision = evaluateVideoIdeasGenerationBudget({
+    systemPrompt,
+    userPrompt,
+    model: VIDEO_IDEAS_GENERATION_MODEL,
+    maxTokens: VIDEO_IDEAS_GENERATION_MAX_TOKENS,
+  })
+  await recordVideoIdeasGenerationBudgetDecision({
+    agentRunId,
+    mode,
+    limit,
+    decision: budgetDecision,
+  })
+  if (budgetDecision.status === 'blocked') {
+    throw new VideoIdeasGenerationError(budgetDecision.reason, 'budget_blocked')
+  }
+
   onStep?.({ step: 'calling_llm', detail: mode === 'from_direction' ? 'Polishing script with GPT-4o...' : 'Brainstorming with GPT-4o...' })
 
   const response = await fetch('https://api.openai.com/v1/chat/completions', {
@@ -175,13 +207,13 @@ async function runGeneration(
       Authorization: `Bearer ${apiKey}`,
     },
     body: JSON.stringify({
-      model: 'gpt-4o',
+      model: VIDEO_IDEAS_GENERATION_MODEL,
       messages: [
         { role: 'system', content: systemPrompt },
         { role: 'user', content: userPrompt },
       ],
       temperature: mode === 'from_direction' ? 0.5 : 0.8,
-      max_tokens: 8000,
+      max_tokens: VIDEO_IDEAS_GENERATION_MAX_TOKENS,
       response_format: { type: 'json_object' },
     }),
   })
@@ -189,23 +221,32 @@ async function runGeneration(
   if (!response.ok) {
     const errText = await response.text()
     console.error('[generate-ideas] OpenAI error:', errText)
-    return { ideas: [], addedToQueue: 0, mode, error: 'AI generation failed' }
+    throw new VideoIdeasGenerationError('AI generation failed', 'openai_upstream')
   }
 
   onStep?.({ step: 'parsing', detail: 'Processing AI response...' })
 
   const aiResult = await response.json()
   const content = aiResult.choices?.[0]?.message?.content
-  const usage = aiResult.usage
+  const usage = aiResult.usage as Usage | undefined
   if (usage) {
-    recordOpenAICost(usage, 'gpt-4o', undefined, {
-      operation: 'video_ideas_generation',
-      mode,
-    }).catch(() => {})
+    recordOpenAICost(
+      usage,
+      VIDEO_IDEAS_GENERATION_MODEL,
+      { type: 'video_ideas_generation', id: agentRunId ?? mode },
+      {
+        operation: VIDEO_IDEAS_GENERATION_OPERATION,
+        mode,
+        budget_status: budgetDecision.status,
+        budget_rule_key: budgetDecision.rule.key,
+        budget_estimated_cost_usd: budgetDecision.estimatedCostUsd,
+      },
+      agentRunId ?? undefined,
+    ).catch(() => {})
   }
 
   if (!content) {
-    return { ideas: [], addedToQueue: 0, mode, error: 'No AI response' }
+    throw new VideoIdeasGenerationError('No AI response', 'invalid_response')
   }
 
   let parsed: { ideas?: VideoIdea[] }
@@ -218,11 +259,11 @@ async function runGeneration(
         parsed = { ideas: JSON.parse(match[0]) }
       } catch {
         console.error('[generate-ideas] Failed to parse AI response:', content.slice(0, 500))
-        return { ideas: [], addedToQueue: 0, mode, error: 'Failed to parse AI response' }
+        throw new VideoIdeasGenerationError('Failed to parse AI response', 'invalid_response')
       }
     } else {
       console.error('[generate-ideas] No JSON array in response:', content.slice(0, 500))
-      return { ideas: [], addedToQueue: 0, mode, error: 'Failed to parse AI response' }
+      throw new VideoIdeasGenerationError('Failed to parse AI response', 'invalid_response')
     }
   }
 
@@ -263,27 +304,79 @@ async function runGeneration(
 }
 
 export async function POST(request: NextRequest) {
+  let agentRunId: string | null = null
+  let parsedParams: GenerateParams | null = null
   try {
     const auth = await verifyAdmin(request)
     if (isAuthError(auth)) {
       return NextResponse.json({ error: auth.error }, { status: auth.status })
     }
 
-    const apiKey = process.env.OPENAI_API_KEY
-    if (!apiKey) {
-      return NextResponse.json({ error: 'OpenAI API key not configured' }, { status: 500 })
-    }
-
     const body = await request.json().catch(() => ({}))
     const params = parseBody(body)
+    parsedParams = params
     const wantsSSE = request.headers.get('accept')?.includes('text/event-stream')
 
+    const agentRun = await startAgentRun({
+      agentKey: 'manual-admin',
+      runtime: 'manual',
+      kind: 'video_ideas_generation',
+      title: params.mode === 'from_direction' ? 'Polish video idea draft' : 'Generate video ideas',
+      subject: {
+        type: 'video_ideas',
+        label: params.customPrompt ? params.customPrompt.slice(0, 80) : `${params.mode}:${params.limit}`,
+      },
+      triggerSource: 'admin:video_generate_ideas',
+      triggeredByUserId: auth.user.id,
+      currentStep: 'Video ideas request validated',
+      metadata: {
+        mode: params.mode,
+        limit: params.limit,
+        include_transcripts: params.includeTranscripts,
+        has_custom_prompt: !!params.customPrompt,
+        has_email_context: !!params.email,
+        meeting_ids_count: params.meetingIds.length,
+      },
+    })
+    agentRunId = agentRun.id
+    const activeAgentRunId = agentRun.id
+
+    await recordAgentStep({
+      runId: activeAgentRunId,
+      stepKey: 'video_ideas_request_validated',
+      name: 'Video ideas request validated',
+      status: 'completed',
+      inputSummary: params.customPrompt ? params.customPrompt.slice(0, 240) : `${params.mode} request for ${params.limit} idea(s).`,
+      metadata: {
+        mode: params.mode,
+        limit: params.limit,
+        include_transcripts: params.includeTranscripts,
+        meeting_ids_count: params.meetingIds.length,
+      },
+      idempotencyKey: `${activeAgentRunId}:video_ideas_request_validated`,
+    }).catch((err) => console.warn('[generate-ideas] agent validation step failed:', err))
+
+    const apiKey = process.env.OPENAI_API_KEY
+    if (!apiKey) {
+      throw new VideoIdeasGenerationError('OPENAI_API_KEY is not configured', 'openai_not_configured')
+    }
+
     if (!wantsSSE) {
-      const result = await runGeneration(params, apiKey)
+      const result = await runGeneration(params, apiKey, activeAgentRunId)
       if (result.error) {
         return NextResponse.json({ error: result.error }, { status: 500 })
       }
-      return NextResponse.json({ ideas: result.ideas, addedToQueue: result.addedToQueue, mode: result.mode })
+      await endAgentRun({
+        runId: activeAgentRunId,
+        status: 'completed',
+        currentStep: 'Video ideas queued',
+        outcome: {
+          mode: result.mode,
+          ideas: result.ideas.length,
+          added_to_queue: result.addedToQueue,
+        },
+      }).catch((err) => console.warn('[generate-ideas] end agent run failed:', err))
+      return NextResponse.json({ ideas: result.ideas, addedToQueue: result.addedToQueue, mode: result.mode, agentRunId: activeAgentRunId })
     }
 
     const encoder = new TextEncoder()
@@ -294,20 +387,44 @@ export async function POST(request: NextRequest) {
         }
 
         try {
-          const result = await runGeneration(params, apiKey, send)
+          const result = await runGeneration(params, apiKey, activeAgentRunId, send)
 
           if (result.error) {
             send({ step: 'error', error: result.error })
           } else {
+            await endAgentRun({
+              runId: activeAgentRunId,
+              status: 'completed',
+              currentStep: 'Video ideas queued',
+              outcome: {
+                mode: result.mode,
+                ideas: result.ideas.length,
+                added_to_queue: result.addedToQueue,
+              },
+            }).catch((err) => console.warn('[generate-ideas] end agent run failed:', err))
             send({
               step: 'done',
               ideas: result.ideas.length,
               addedToQueue: result.addedToQueue,
               mode: result.mode,
+              agentRunId: activeAgentRunId,
             })
           }
         } catch (err) {
-          send({ step: 'error', error: err instanceof Error ? err.message : String(err) })
+          const message = err instanceof Error ? err.message : String(err)
+          await recordAgentStep({
+            runId: activeAgentRunId,
+            stepKey: 'video_ideas_generation_failed',
+            name: 'Video ideas generation failed',
+            status: 'failed',
+            outputSummary: message,
+            idempotencyKey: `${activeAgentRunId}:video_ideas_generation_failed`,
+          }).catch((stepErr) => console.warn('[generate-ideas] agent failure step failed:', stepErr))
+          await markAgentRunFailed(activeAgentRunId, message, {
+            operation: VIDEO_IDEAS_GENERATION_OPERATION,
+            mode: params.mode,
+          }).catch((runErr) => console.warn('[generate-ideas] mark agent run failed:', runErr))
+          send({ step: 'error', error: safeVideoIdeasErrorMessage(err), agentRunId: activeAgentRunId })
         } finally {
           controller.close()
         }
@@ -324,6 +441,54 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     console.error('[generate-ideas] Error:', error)
     const message = error instanceof Error ? error.message : String(error)
+    if (agentRunId) {
+      await recordAgentStep({
+        runId: agentRunId,
+        stepKey: 'video_ideas_generation_failed',
+        name: 'Video ideas generation failed',
+        status: 'failed',
+        outputSummary: message,
+        idempotencyKey: `${agentRunId}:video_ideas_generation_failed`,
+      }).catch((stepErr) => console.warn('[generate-ideas] agent failure step failed:', stepErr))
+      await markAgentRunFailed(agentRunId, message, {
+        operation: VIDEO_IDEAS_GENERATION_OPERATION,
+        mode: parsedParams?.mode ?? null,
+      }).catch((runErr) => console.warn('[generate-ideas] mark agent run failed:', runErr))
+    }
+
+    if (error instanceof VideoIdeasGenerationError) {
+      return NextResponse.json(
+        { error: safeVideoIdeasErrorMessage(error), agentRunId },
+        { status: videoIdeasErrorStatus(error) },
+      )
+    }
+
     return NextResponse.json({ error: message }, { status: 500 })
   }
+}
+
+function safeVideoIdeasErrorMessage(error: unknown): string {
+  if (error instanceof VideoIdeasGenerationError) {
+    if (error.code === 'budget_blocked') {
+      return 'This video ideas request is over the current Agent Ops budget limit. Use fewer ideas, shorter notes, or less transcript context before retrying.'
+    }
+    if (error.code === 'openai_not_configured') {
+      return 'OpenAI API key not configured'
+    }
+    if (error.code === 'openai_upstream') {
+      return 'AI generation failed'
+    }
+    if (error.code === 'invalid_response') {
+      return 'The AI returned an unexpected response. Try generating again or adjust the video idea prompt.'
+    }
+  }
+
+  return error instanceof Error ? error.message : String(error)
+}
+
+function videoIdeasErrorStatus(error: VideoIdeasGenerationError): number {
+  if (error.code === 'budget_blocked') return 400
+  if (error.code === 'openai_not_configured') return 503
+  if (error.code === 'openai_upstream' || error.code === 'invalid_response') return 502
+  return 500
 }

--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -272,6 +272,7 @@ Current progress:
 - AI onboarding preview generation now creates a traced manual Agent Ops run from the admin preview endpoint, checks the manual-runtime budget before OpenAI dispatch, and links generated cost events to the trace when available.
 - Admin audit-from-meetings generation now starts a manual Agent Ops trace, checks the manual-runtime budget before OpenAI dispatch, and links diagnostic-extraction cost events back to the trace.
 - Admin video prompt formatting now starts a manual Agent Ops trace, checks the manual-runtime budget before OpenAI dispatch, and links prompt-formatting cost events back to the trace.
+- Admin video ideas generation now starts a manual Agent Ops trace, checks the manual-runtime budget after context assembly and before GPT-4o dispatch, and links idea-generation cost events back to the trace.
 
 ## Cross-Phase Definition Of Done
 

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -175,6 +175,7 @@ V1 budget policy is advisory and pre-flight ready:
 - AI onboarding preview generation now checks the manual-runtime budget before OpenAI dispatch and records a manual Agent Ops trace from the admin preview endpoint;
 - admin audit-from-meetings generation now checks the manual-runtime budget before OpenAI dispatch and links cost events to the created Agent Ops trace;
 - admin video prompt formatting now checks the manual-runtime budget before OpenAI dispatch and links cost events to the created Agent Ops trace;
+- admin video ideas generation now checks the manual-runtime budget after context assembly and before GPT-4o dispatch, with generated cost events linked to the created Agent Ops trace;
 - live workflows are not yet globally blocked until each adoption path has a targeted test and approval gate.
 
 Slack should be treated as a notification and lightweight decision surface later. The source of truth remains Portfolio admin plus `agent_approvals`.

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -70,6 +70,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 - [x] AI onboarding preview pre-flight budget adoption in review.
 - [x] Audit-from-meetings pre-flight budget adoption and trace linkage in review.
 - [x] Video prompt formatter pre-flight budget adoption and trace linkage in review.
+- [x] Video ideas generation pre-flight budget adoption and trace linkage in review.
 
 ## Scope Guard
 

--- a/docs/agentic-patterns.md
+++ b/docs/agentic-patterns.md
@@ -423,6 +423,7 @@ Each section follows the same template: *Definition · Where we use it today · 
 - AI onboarding preview generation checks the manual-runtime budget before dispatch and links admin-triggered previews to a manual Agent Ops run.
 - Admin audit-from-meetings generation checks the manual-runtime budget before OpenAI dispatch and links cost events to its Agent Ops trace.
 - Admin video prompt formatting checks the manual-runtime budget before OpenAI dispatch and links cost events to its Agent Ops trace.
+- Admin video ideas generation checks the manual-runtime budget after context assembly and before GPT-4o dispatch, then links cost events to its Agent Ops trace.
 - Cost-events ingest accumulates spend per event.
 - `cost_events.agent_run_id` links usage costs to shared Agent Ops traces.
 - Mission Control derives 24-hour Cost Intelligence by runtime, agent, workflow, client/project, and artifact type where run metadata exists.

--- a/lib/video-ideas-generation.ts
+++ b/lib/video-ideas-generation.ts
@@ -1,0 +1,82 @@
+import {
+  evaluateAgentBudget,
+  type AgentBudgetDecision,
+} from '@/lib/agent-budget-policy'
+import { recordAgentEvent, recordAgentStep } from '@/lib/agent-run'
+
+export const VIDEO_IDEAS_GENERATION_OPERATION = 'video_ideas_generation'
+export const VIDEO_IDEAS_GENERATION_MODEL = 'gpt-4o'
+export const VIDEO_IDEAS_GENERATION_MAX_TOKENS = 8000
+
+export class VideoIdeasGenerationError extends Error {
+  constructor(
+    message: string,
+    public readonly code: 'budget_blocked' | 'openai_not_configured' | 'openai_upstream' | 'invalid_response',
+  ) {
+    super(message)
+    this.name = 'VideoIdeasGenerationError'
+  }
+}
+
+function estimateTokensFromText(text: string): number {
+  return Math.ceil(text.length / 4)
+}
+
+export function evaluateVideoIdeasGenerationBudget(input: {
+  systemPrompt: string
+  userPrompt: string
+  model?: string
+  maxTokens?: number
+}): AgentBudgetDecision {
+  return evaluateAgentBudget({
+    runtime: 'manual',
+    model: input.model ?? VIDEO_IDEAS_GENERATION_MODEL,
+    estimatedInputTokens: estimateTokensFromText(`${input.systemPrompt}\n${input.userPrompt}`),
+    maxTokens: input.maxTokens ?? VIDEO_IDEAS_GENERATION_MAX_TOKENS,
+    metadata: {
+      operation: VIDEO_IDEAS_GENERATION_OPERATION,
+    },
+  })
+}
+
+export async function recordVideoIdeasGenerationBudgetDecision(args: {
+  agentRunId?: string | null
+  mode: string
+  limit: number
+  decision: AgentBudgetDecision
+}) {
+  if (!args.agentRunId) return
+
+  const metadata = {
+    operation: VIDEO_IDEAS_GENERATION_OPERATION,
+    mode: args.mode,
+    limit: args.limit,
+    budget_status: args.decision.status,
+    budget_rule_key: args.decision.rule.key,
+    estimated_cost_usd: args.decision.estimatedCostUsd,
+    warning_usd: args.decision.warningUsd,
+    limit_usd: args.decision.limitUsd,
+  }
+
+  await recordAgentStep({
+    runId: args.agentRunId,
+    stepKey: 'budget_check',
+    name: 'Checked video ideas generation budget',
+    status: args.decision.status === 'blocked' ? 'failed' : 'completed',
+    outputSummary: args.decision.reason,
+    costUsd: args.decision.estimatedCostUsd,
+    metadata,
+    idempotencyKey: `${args.agentRunId}:video_ideas_generation:budget_check`,
+  }).catch((err) => console.warn('[generate-ideas] agent budget step failed:', err))
+
+  if (args.decision.status !== 'allowed') {
+    await recordAgentEvent({
+      runId: args.agentRunId,
+      eventType: 'budget_check',
+      severity: args.decision.status === 'blocked' ? 'error' : 'warning',
+      message: args.decision.reason,
+      metadata,
+      idempotencyKey: `${args.agentRunId}:video_ideas_generation:budget_check:${args.decision.status}`,
+    }).catch((err) => console.warn('[generate-ideas] agent budget event failed:', err))
+  }
+}


### PR DESCRIPTION
## Summary
- add manual Agent Ops tracing to the video ideas generation endpoint
- run manual-runtime budget preflight after context assembly and before GPT-4o dispatch
- link video ideas generation cost events to the created agent run
- preserve JSON and SSE response paths with safe budget/upstream errors
- document the Phase 10 budget-policy adoption slice

## Validation
- npm test -- --run app/api/admin/video-generation/generate-ideas/route.test.ts app/api/admin/video-generation/format-prompt/route.test.ts
- npx tsc --noEmit --pretty false
- git diff --check
- npm run build
- pre-push production database health check passed

## Notes
- No n8n workflows were triggered.
- Build emitted the existing local env warning that MOCK_N8N=false and N8N_DISABLE_OUTBOUND=false.
- Normal video idea generation currently warns under policy because GPT-4o with an 8000-token cap is above the manual warning threshold but below the hard cap.
