### PR TITLE
[codex] trace social carousel budget checks

### DIFF
--- a/app/api/admin/social-content/[id]/convert-to-carousel/route.test.ts
+++ b/app/api/admin/social-content/[id]/convert-to-carousel/route.test.ts
@@ -1,0 +1,273 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  getSocialCarouselSlidesPrompt: vi.fn(),
+  renderCarousel: vi.fn(),
+  recordOpenAICost: vi.fn(),
+  startAgentRun: vi.fn(),
+  recordAgentStep: vi.fn(),
+  recordAgentEvent: vi.fn(),
+  endAgentRun: vi.fn(),
+  markAgentRunFailed: vi.fn(),
+  from: vi.fn(),
+  select: vi.fn(),
+  eq: vi.fn(),
+  single: vi.fn(),
+  update: vi.fn(),
+  updateEq: vi.fn(),
+  storageFrom: vi.fn(),
+  upload: vi.fn(),
+  getPublicUrl: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/system-prompts', () => ({
+  getSocialCarouselSlidesPrompt: mocks.getSocialCarouselSlidesPrompt,
+}))
+
+vi.mock('@/lib/carousel', () => ({
+  renderCarousel: mocks.renderCarousel,
+}))
+
+vi.mock('@/lib/cost-calculator', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/cost-calculator')>()
+  return {
+    ...actual,
+    recordOpenAICost: mocks.recordOpenAICost,
+  }
+})
+
+vi.mock('@/lib/agent-run', () => ({
+  startAgentRun: mocks.startAgentRun,
+  recordAgentStep: mocks.recordAgentStep,
+  recordAgentEvent: mocks.recordAgentEvent,
+  endAgentRun: mocks.endAgentRun,
+  markAgentRunFailed: mocks.markAgentRunFailed,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+    storage: {
+      from: mocks.storageFrom,
+    },
+  },
+}))
+
+import { POST } from './route'
+import { evaluateSocialCarouselGenerationBudget } from '@/lib/social-carousel-generation'
+
+function makeRequest() {
+  return new NextRequest('http://localhost/api/admin/social-content/social-1/convert-to-carousel', {
+    method: 'POST',
+  })
+}
+
+describe('POST /api/admin/social-content/[id]/convert-to-carousel', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.unstubAllGlobals()
+    process.env = { ...originalEnv, OPENAI_API_KEY: 'test-key' }
+
+    mocks.verifyAdmin.mockResolvedValue({
+      user: { id: 'admin-user-1' },
+      isAdmin: true,
+    })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.getSocialCarouselSlidesPrompt.mockResolvedValue('Create carousel slides as JSON.')
+    mocks.startAgentRun.mockResolvedValue({ id: 'agent-run-1' })
+    mocks.recordAgentStep.mockResolvedValue({ id: 'step-1' })
+    mocks.recordAgentEvent.mockResolvedValue({ id: 'event-1' })
+    mocks.endAgentRun.mockResolvedValue(undefined)
+    mocks.markAgentRunFailed.mockResolvedValue(undefined)
+    mocks.recordOpenAICost.mockResolvedValue(undefined)
+    mocks.single.mockResolvedValue({
+      data: {
+        post_text: 'Automation should reduce burden, not add work.',
+        topic_extracted: {
+          topic: 'Practical automation',
+          key_insight: 'Technology should make work lighter.',
+          personal_tie_in: 'Operators need tools that meet reality.',
+        },
+        hormozi_framework: { hook: 'reduce burden' },
+        hashtags: ['AI', 'Automation'],
+      },
+      error: null,
+    })
+    mocks.eq.mockReturnValue({ single: mocks.single })
+    mocks.select.mockReturnValue({ eq: mocks.eq })
+    mocks.updateEq.mockResolvedValue({ error: null })
+    mocks.update.mockReturnValue({ eq: mocks.updateEq })
+    mocks.from.mockImplementation((table: string) => {
+      if (table === 'social_content_queue') {
+        return {
+          select: mocks.select,
+          update: mocks.update,
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+    mocks.renderCarousel.mockResolvedValue({
+      pngBuffers: [Buffer.from('slide-1'), Buffer.from('slide-2'), Buffer.from('slide-3')],
+      pdfBuffer: Buffer.from('pdf'),
+    })
+    mocks.upload.mockResolvedValue({ error: null })
+    mocks.getPublicUrl.mockImplementation((fileName: string) => ({
+      data: { publicUrl: `https://cdn.example.com/${fileName}` },
+    }))
+    mocks.storageFrom.mockReturnValue({
+      upload: mocks.upload,
+      getPublicUrl: mocks.getPublicUrl,
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    process.env = { ...originalEnv }
+  })
+
+  it('requires admin auth before fetching content or starting a trace', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Authentication required', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(makeRequest(), { params: { id: 'social-1' } })
+
+    expect(response.status).toBe(401)
+    expect(mocks.from).not.toHaveBeenCalled()
+    expect(mocks.startAgentRun).not.toHaveBeenCalled()
+  })
+
+  it('converts to carousel, records budget metadata, links cost, and returns agentRunId', async () => {
+    const slides = [
+      { slideNumber: 1, heading: 'Reduce burden', body: 'Start with the real workflow.' },
+      { slideNumber: 2, heading: 'Find the drag', body: 'Name what costs time.' },
+      { slideNumber: 3, heading: 'Build lighter', body: 'Automate the repeatable work.' },
+    ]
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        usage: { prompt_tokens: 200, completion_tokens: 400, total_tokens: 600 },
+        choices: [{ message: { content: JSON.stringify({ slides }) } }],
+      }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const response = await POST(makeRequest(), { params: { id: 'social-1' } })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      content_format: 'carousel',
+      carousel_slides: slides,
+      carousel_slide_urls: [
+        'https://cdn.example.com/carousels/social-1/slide_01.png',
+        'https://cdn.example.com/carousels/social-1/slide_02.png',
+        'https://cdn.example.com/carousels/social-1/slide_03.png',
+      ],
+      carousel_pdf_url: 'https://cdn.example.com/carousels/social-1/carousel.pdf',
+      slide_count: 3,
+      agentRunId: 'agent-run-1',
+    })
+    expect(mocks.startAgentRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentKey: 'manual-admin',
+        runtime: 'manual',
+        kind: 'social_carousel_generation',
+        triggerSource: 'admin:social_convert_to_carousel',
+        triggeredByUserId: 'admin-user-1',
+      }),
+    )
+    expect(mocks.recordAgentStep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'agent-run-1',
+        stepKey: 'budget_check',
+        metadata: expect.objectContaining({
+          operation: 'social_carousel_generation',
+          social_content_id: 'social-1',
+          budget_status: 'allowed',
+        }),
+      }),
+    )
+    expect(mocks.recordOpenAICost).toHaveBeenCalledWith(
+      expect.any(Object),
+      'gpt-4o',
+      { type: 'social_content_queue', id: 'social-1' },
+      expect.objectContaining({
+        operation: 'social_carousel_generation',
+        budget_status: 'allowed',
+      }),
+      'agent-run-1',
+    )
+    expect(mocks.endAgentRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'agent-run-1',
+        status: 'completed',
+        outcome: expect.objectContaining({
+          social_content_id: 'social-1',
+          slide_count: 3,
+        }),
+      }),
+    )
+  })
+
+  it('marks the trace failed and returns a safe message when budget blocks conversion', async () => {
+    mocks.single.mockResolvedValue({
+      data: {
+        post_text: 'x'.repeat(1_000_000),
+        topic_extracted: {},
+        hormozi_framework: {},
+        hashtags: [],
+      },
+      error: null,
+    })
+    const mockFetch = vi.fn()
+    vi.stubGlobal('fetch', mockFetch)
+
+    const response = await POST(makeRequest(), { params: { id: 'social-1' } })
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error:
+        'This carousel conversion is over the current Agent Ops budget limit. Shorten the post or reduce the carousel prompt size before retrying.',
+      agentRunId: 'agent-run-1',
+    })
+    expect(mockFetch).not.toHaveBeenCalled()
+    expect(mocks.recordAgentStep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'agent-run-1',
+        stepKey: 'budget_check',
+        status: 'failed',
+      }),
+    )
+    expect(mocks.markAgentRunFailed).toHaveBeenCalledWith(
+      'agent-run-1',
+      expect.stringContaining('Estimated cost'),
+      expect.objectContaining({
+        operation: 'social_carousel_generation',
+        social_content_id: 'social-1',
+      }),
+    )
+  })
+
+  it('evaluates normal carousel prompts within the manual budget', () => {
+    const decision = evaluateSocialCarouselGenerationBudget({
+      systemPrompt: 'Create carousel slides.',
+      userMessage: 'Short post.',
+    })
+
+    expect(decision.status).toBe('allowed')
+    expect(decision.rule.key).toBe('llm_manual_per_call')
+    expect(decision.estimatedCostUsd).toBeGreaterThan(0)
+  })
+})

--- a/app/api/admin/social-content/[id]/convert-to-carousel/route.ts
+++ b/app/api/admin/social-content/[id]/convert-to-carousel/route.ts
@@ -3,6 +3,21 @@ import { supabaseAdmin } from '@/lib/supabase'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
 import { renderCarousel } from '@/lib/carousel'
 import type { CarouselSlide } from '@/lib/social-content'
+import { recordOpenAICost, type Usage } from '@/lib/cost-calculator'
+import {
+  endAgentRun,
+  markAgentRunFailed,
+  recordAgentStep,
+  startAgentRun,
+} from '@/lib/agent-run'
+import {
+  evaluateSocialCarouselGenerationBudget,
+  recordSocialCarouselGenerationBudgetDecision,
+  SOCIAL_CAROUSEL_GENERATION_MAX_TOKENS,
+  SOCIAL_CAROUSEL_GENERATION_MODEL,
+  SOCIAL_CAROUSEL_GENERATION_OPERATION,
+  SocialCarouselGenerationError,
+} from '@/lib/social-carousel-generation'
 
 export const dynamic = 'force-dynamic'
 export const maxDuration = 60
@@ -17,6 +32,7 @@ export async function POST(
   request: NextRequest,
   { params }: { params: { id: string } }
 ) {
+  let agentRunId: string | null = null
   try {
     const authResult = await verifyAdmin(request)
     if (isAuthError(authResult)) {
@@ -35,6 +51,40 @@ export async function POST(
       return NextResponse.json({ error: 'Content not found' }, { status: 404 })
     }
 
+    const agentRun = await startAgentRun({
+      agentKey: 'manual-admin',
+      runtime: 'manual',
+      kind: 'social_carousel_generation',
+      title: 'Convert social post to carousel',
+      subject: {
+        type: 'social_content_queue',
+        id,
+        label: `Social content ${id}`,
+      },
+      triggerSource: 'admin:social_convert_to_carousel',
+      triggeredByUserId: authResult.user.id,
+      currentStep: 'Social carousel request validated',
+      metadata: {
+        has_topic: !!row.topic_extracted,
+        has_framework: !!row.hormozi_framework,
+        hashtag_count: Array.isArray(row.hashtags) ? row.hashtags.length : 0,
+      },
+    })
+    agentRunId = agentRun.id
+
+    await recordAgentStep({
+      runId: agentRunId,
+      stepKey: 'social_carousel_request_validated',
+      name: 'Social carousel request validated',
+      status: 'completed',
+      inputSummary: typeof row.post_text === 'string' ? row.post_text.slice(0, 240) : null,
+      metadata: {
+        social_content_id: id,
+        post_text_chars: typeof row.post_text === 'string' ? row.post_text.length : 0,
+      },
+      idempotencyKey: `${agentRunId}:social_carousel_request_validated`,
+    }).catch((err) => console.warn('[convert-to-carousel] agent validation step failed:', err))
+
     const { getSocialCarouselSlidesPrompt } = await import('@/lib/system-prompts')
     const systemPrompt = await getSocialCarouselSlidesPrompt()
 
@@ -48,7 +98,22 @@ Hashtags: ${(row.hashtags || []).join(', ')}`
 
     const openaiKey = process.env.OPENAI_API_KEY
     if (!openaiKey) {
-      return NextResponse.json({ error: 'OpenAI API key not configured' }, { status: 500 })
+      throw new SocialCarouselGenerationError('OPENAI_API_KEY is not configured', 'openai_not_configured')
+    }
+
+    const budgetDecision = evaluateSocialCarouselGenerationBudget({
+      systemPrompt,
+      userMessage,
+      model: SOCIAL_CAROUSEL_GENERATION_MODEL,
+      maxTokens: SOCIAL_CAROUSEL_GENERATION_MAX_TOKENS,
+    })
+    await recordSocialCarouselGenerationBudgetDecision({
+      agentRunId,
+      socialContentId: id,
+      decision: budgetDecision,
+    })
+    if (budgetDecision.status === 'blocked') {
+      throw new SocialCarouselGenerationError(budgetDecision.reason, 'budget_blocked')
     }
 
     const aiResponse = await fetch('https://api.openai.com/v1/chat/completions', {
@@ -58,35 +123,50 @@ Hashtags: ${(row.hashtags || []).join(', ')}`
         'Authorization': `Bearer ${openaiKey}`,
       },
       body: JSON.stringify({
-        model: 'gpt-4o',
+        model: SOCIAL_CAROUSEL_GENERATION_MODEL,
         messages: [
           { role: 'system', content: systemPrompt },
           { role: 'user', content: userMessage },
         ],
         temperature: 0.7,
-        max_tokens: 4096,
+        max_tokens: SOCIAL_CAROUSEL_GENERATION_MAX_TOKENS,
         response_format: { type: 'json_object' },
       }),
     })
 
     if (!aiResponse.ok) {
       console.error('OpenAI API error:', await aiResponse.text())
-      return NextResponse.json({ error: 'Failed to generate carousel content' }, { status: 502 })
+      throw new SocialCarouselGenerationError('Failed to generate carousel content', 'openai_upstream')
     }
 
     const aiData = await aiResponse.json()
     const rawContent = aiData.choices?.[0]?.message?.content
+    const usage = aiData.usage as Usage | undefined
+    if (usage) {
+      recordOpenAICost(
+        usage,
+        SOCIAL_CAROUSEL_GENERATION_MODEL,
+        { type: 'social_content_queue', id },
+        {
+          operation: SOCIAL_CAROUSEL_GENERATION_OPERATION,
+          budget_status: budgetDecision.status,
+          budget_rule_key: budgetDecision.rule.key,
+          budget_estimated_cost_usd: budgetDecision.estimatedCostUsd,
+        },
+        agentRunId,
+      ).catch(() => {})
+    }
     let slides: CarouselSlide[]
 
     try {
       const parsed = JSON.parse(rawContent)
       slides = Array.isArray(parsed) ? parsed : parsed.slides || []
     } catch {
-      return NextResponse.json({ error: 'Failed to parse AI-generated slides' }, { status: 502 })
+      throw new SocialCarouselGenerationError('Failed to parse AI-generated slides', 'invalid_response')
     }
 
     if (slides.length < 3) {
-      return NextResponse.json({ error: 'AI generated too few slides' }, { status: 502 })
+      throw new SocialCarouselGenerationError('AI generated too few slides', 'invalid_response')
     }
 
     await supabaseAdmin
@@ -144,6 +224,18 @@ Hashtags: ${(row.hashtags || []).join(', ')}`
       })
       .eq('id', id)
 
+    await endAgentRun({
+      runId: agentRunId,
+      status: 'completed',
+      currentStep: 'Social carousel ready',
+      outcome: {
+        social_content_id: id,
+        slide_count: slides.length,
+        slide_url_count: slideUrls.length,
+        has_pdf: !!pdfUrl,
+      },
+    }).catch((err) => console.warn('[convert-to-carousel] end agent run failed:', err))
+
     return NextResponse.json({
       success: true,
       content_format: 'carousel',
@@ -151,12 +243,59 @@ Hashtags: ${(row.hashtags || []).join(', ')}`
       carousel_slide_urls: slideUrls,
       carousel_pdf_url: pdfUrl,
       slide_count: slides.length,
+      agentRunId,
     })
   } catch (error) {
     console.error('Error in convert-to-carousel:', error)
+    const message = error instanceof Error ? error.message : String(error)
+    if (agentRunId) {
+      await recordAgentStep({
+        runId: agentRunId,
+        stepKey: 'social_carousel_generation_failed',
+        name: 'Social carousel generation failed',
+        status: 'failed',
+        outputSummary: message,
+        idempotencyKey: `${agentRunId}:social_carousel_generation_failed`,
+      }).catch((stepErr) => console.warn('[convert-to-carousel] agent failure step failed:', stepErr))
+      await markAgentRunFailed(agentRunId, message, {
+        operation: SOCIAL_CAROUSEL_GENERATION_OPERATION,
+        social_content_id: params.id,
+      }).catch((runErr) => console.warn('[convert-to-carousel] mark agent run failed:', runErr))
+    }
+
+    if (error instanceof SocialCarouselGenerationError) {
+      return NextResponse.json(
+        { error: safeSocialCarouselErrorMessage(error), agentRunId },
+        { status: socialCarouselErrorStatus(error) },
+      )
+    }
+
     return NextResponse.json(
       { error: 'Failed to convert to carousel. Please try again.' },
       { status: 500 }
     )
   }
+}
+
+function safeSocialCarouselErrorMessage(error: SocialCarouselGenerationError): string {
+  if (error.code === 'budget_blocked') {
+    return 'This carousel conversion is over the current Agent Ops budget limit. Shorten the post or reduce the carousel prompt size before retrying.'
+  }
+  if (error.code === 'openai_not_configured') {
+    return 'OpenAI API key not configured'
+  }
+  if (error.code === 'openai_upstream') {
+    return 'Failed to generate carousel content'
+  }
+  if (error.code === 'invalid_response') {
+    return 'The AI returned an invalid carousel response. Try converting again or adjust the carousel system prompt.'
+  }
+  return 'Failed to convert to carousel. Please try again.'
+}
+
+function socialCarouselErrorStatus(error: SocialCarouselGenerationError): number {
+  if (error.code === 'budget_blocked') return 400
+  if (error.code === 'openai_not_configured') return 503
+  if (error.code === 'openai_upstream' || error.code === 'invalid_response') return 502
+  return 500
 }

--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -273,6 +273,7 @@ Current progress:
 - Admin audit-from-meetings generation now starts a manual Agent Ops trace, checks the manual-runtime budget before OpenAI dispatch, and links diagnostic-extraction cost events back to the trace.
 - Admin video prompt formatting now starts a manual Agent Ops trace, checks the manual-runtime budget before OpenAI dispatch, and links prompt-formatting cost events back to the trace.
 - Admin video ideas generation now starts a manual Agent Ops trace, checks the manual-runtime budget after context assembly and before GPT-4o dispatch, and links idea-generation cost events back to the trace.
+- Admin social carousel conversion now starts a manual Agent Ops trace, checks the manual-runtime budget before GPT-4o dispatch, and links carousel-generation cost events back to the trace.
 
 ## Cross-Phase Definition Of Done
 

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -176,6 +176,7 @@ V1 budget policy is advisory and pre-flight ready:
 - admin audit-from-meetings generation now checks the manual-runtime budget before OpenAI dispatch and links cost events to the created Agent Ops trace;
 - admin video prompt formatting now checks the manual-runtime budget before OpenAI dispatch and links cost events to the created Agent Ops trace;
 - admin video ideas generation now checks the manual-runtime budget after context assembly and before GPT-4o dispatch, with generated cost events linked to the created Agent Ops trace;
+- admin social carousel conversion now checks the manual-runtime budget before GPT-4o dispatch, with generated cost events linked to the created Agent Ops trace;
 - live workflows are not yet globally blocked until each adoption path has a targeted test and approval gate.
 
 Slack should be treated as a notification and lightweight decision surface later. The source of truth remains Portfolio admin plus `agent_approvals`.

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -71,6 +71,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 - [x] Audit-from-meetings pre-flight budget adoption and trace linkage in review.
 - [x] Video prompt formatter pre-flight budget adoption and trace linkage in review.
 - [x] Video ideas generation pre-flight budget adoption and trace linkage in review.
+- [x] Social carousel conversion pre-flight budget adoption and trace linkage in review.
 
 ## Scope Guard
 

--- a/docs/agentic-patterns.md
+++ b/docs/agentic-patterns.md
@@ -424,6 +424,7 @@ Each section follows the same template: *Definition · Where we use it today · 
 - Admin audit-from-meetings generation checks the manual-runtime budget before OpenAI dispatch and links cost events to its Agent Ops trace.
 - Admin video prompt formatting checks the manual-runtime budget before OpenAI dispatch and links cost events to its Agent Ops trace.
 - Admin video ideas generation checks the manual-runtime budget after context assembly and before GPT-4o dispatch, then links cost events to its Agent Ops trace.
+- Admin social carousel conversion checks the manual-runtime budget before GPT-4o dispatch and links cost events to its Agent Ops trace.
 - Cost-events ingest accumulates spend per event.
 - `cost_events.agent_run_id` links usage costs to shared Agent Ops traces.
 - Mission Control derives 24-hour Cost Intelligence by runtime, agent, workflow, client/project, and artifact type where run metadata exists.

--- a/lib/social-carousel-generation.ts
+++ b/lib/social-carousel-generation.ts
@@ -1,0 +1,80 @@
+import {
+  evaluateAgentBudget,
+  type AgentBudgetDecision,
+} from '@/lib/agent-budget-policy'
+import { recordAgentEvent, recordAgentStep } from '@/lib/agent-run'
+
+export const SOCIAL_CAROUSEL_GENERATION_OPERATION = 'social_carousel_generation'
+export const SOCIAL_CAROUSEL_GENERATION_MODEL = 'gpt-4o'
+export const SOCIAL_CAROUSEL_GENERATION_MAX_TOKENS = 4096
+
+export class SocialCarouselGenerationError extends Error {
+  constructor(
+    message: string,
+    public readonly code: 'budget_blocked' | 'openai_not_configured' | 'openai_upstream' | 'invalid_response',
+  ) {
+    super(message)
+    this.name = 'SocialCarouselGenerationError'
+  }
+}
+
+function estimateTokensFromText(text: string): number {
+  return Math.ceil(text.length / 4)
+}
+
+export function evaluateSocialCarouselGenerationBudget(input: {
+  systemPrompt: string
+  userMessage: string
+  model?: string
+  maxTokens?: number
+}): AgentBudgetDecision {
+  return evaluateAgentBudget({
+    runtime: 'manual',
+    model: input.model ?? SOCIAL_CAROUSEL_GENERATION_MODEL,
+    estimatedInputTokens: estimateTokensFromText(`${input.systemPrompt}\n${input.userMessage}`),
+    maxTokens: input.maxTokens ?? SOCIAL_CAROUSEL_GENERATION_MAX_TOKENS,
+    metadata: {
+      operation: SOCIAL_CAROUSEL_GENERATION_OPERATION,
+    },
+  })
+}
+
+export async function recordSocialCarouselGenerationBudgetDecision(args: {
+  agentRunId?: string | null
+  socialContentId: string
+  decision: AgentBudgetDecision
+}) {
+  if (!args.agentRunId) return
+
+  const metadata = {
+    operation: SOCIAL_CAROUSEL_GENERATION_OPERATION,
+    social_content_id: args.socialContentId,
+    budget_status: args.decision.status,
+    budget_rule_key: args.decision.rule.key,
+    estimated_cost_usd: args.decision.estimatedCostUsd,
+    warning_usd: args.decision.warningUsd,
+    limit_usd: args.decision.limitUsd,
+  }
+
+  await recordAgentStep({
+    runId: args.agentRunId,
+    stepKey: 'budget_check',
+    name: 'Checked social carousel generation budget',
+    status: args.decision.status === 'blocked' ? 'failed' : 'completed',
+    outputSummary: args.decision.reason,
+    costUsd: args.decision.estimatedCostUsd,
+    metadata,
+    idempotencyKey: `${args.agentRunId}:social_carousel_generation:budget_check`,
+  }).catch((err) => console.warn('[convert-to-carousel] agent budget step failed:', err))
+
+  if (args.decision.status !== 'allowed') {
+    await recordAgentEvent({
+      runId: args.agentRunId,
+      eventType: 'budget_check',
+      severity: args.decision.status === 'blocked' ? 'error' : 'warning',
+      message: args.decision.reason,
+      metadata,
+      idempotencyKey: `${args.agentRunId}:social_carousel_generation:budget_check:${args.decision.status}`,
+    }).catch((err) => console.warn('[convert-to-carousel] agent budget event failed:', err))
+  }
+}


### PR DESCRIPTION
## Summary

Adds Agent Ops pre-flight budget tracing to the admin social content carousel conversion route.

## Changes

- Starts a manual Agent Ops run for `POST /api/admin/social-content/[id]/convert-to-carousel`
- Evaluates the manual-runtime LLM budget before GPT-4o dispatch
- Records budget steps/events and marks blocked/failed runs safely
- Links OpenAI cost events back to the created `agent_run_id`
- Adds focused route coverage for auth, success/cost linkage, and budget blocking
- Updates Agent Ops roadmap docs for the new Phase 10 adoption surface

## Validation

- `npm test -- --run 'app/api/admin/social-content/[id]/convert-to-carousel/route.test.ts'`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- `npm run build`

## Notes

- `npm run build` emitted the existing local warning that `MOCK_N8N=false` and `N8N_DISABLE_OUTBOUND=false`; this build did not trigger n8n workflows.
- Pre-push database health check passed.
