### PR TITLE
[codex] trace in-person diagnostic budget checks

### DIFF
--- a/app/api/admin/sales/in-person-diagnostic/generate-insights/route.test.ts
+++ b/app/api/admin/sales/in-person-diagnostic/generate-insights/route.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  recordOpenAICost: vi.fn(),
+  startAgentRun: vi.fn(),
+  recordAgentStep: vi.fn(),
+  recordAgentEvent: vi.fn(),
+  endAgentRun: vi.fn(),
+  markAgentRunFailed: vi.fn(),
+  from: vi.fn(),
+  update: vi.fn(),
+  eq: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/cost-calculator', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/cost-calculator')>()
+  return {
+    ...actual,
+    recordOpenAICost: mocks.recordOpenAICost,
+  }
+})
+
+vi.mock('@/lib/agent-run', () => ({
+  startAgentRun: mocks.startAgentRun,
+  recordAgentStep: mocks.recordAgentStep,
+  recordAgentEvent: mocks.recordAgentEvent,
+  endAgentRun: mocks.endAgentRun,
+  markAgentRunFailed: mocks.markAgentRunFailed,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import { POST } from './route'
+import { evaluateInPersonDiagnosticInsightsBudget } from '@/lib/in-person-diagnostic-insights'
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest('http://localhost/api/admin/sales/in-person-diagnostic/generate-insights', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+function validBody(overrides: Record<string, unknown> = {}) {
+  return {
+    audit_id: 'audit-1',
+    client_name: 'Anna Berin',
+    client_company: 'Berin Studio',
+    diagnostic_data: {
+      business_challenges: { bottleneck: 'manual follow-up' },
+      tech_stack: { crm: 'spreadsheet' },
+      automation_needs: { priority: 'lead routing' },
+    },
+    ...overrides,
+  }
+}
+
+describe('POST /api/admin/sales/in-person-diagnostic/generate-insights', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.unstubAllGlobals()
+    process.env = { ...originalEnv, OPENAI_API_KEY: 'test-key' }
+
+    mocks.verifyAdmin.mockResolvedValue({
+      user: { id: 'admin-user-1' },
+      isAdmin: true,
+    })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.startAgentRun.mockResolvedValue({ id: 'agent-run-1' })
+    mocks.recordAgentStep.mockResolvedValue({ id: 'step-1' })
+    mocks.recordAgentEvent.mockResolvedValue({ id: 'event-1' })
+    mocks.endAgentRun.mockResolvedValue(undefined)
+    mocks.markAgentRunFailed.mockResolvedValue(undefined)
+    mocks.recordOpenAICost.mockResolvedValue(undefined)
+    mocks.eq.mockResolvedValue({ error: null })
+    mocks.update.mockReturnValue({ eq: mocks.eq })
+    mocks.from.mockImplementation((table: string) => {
+      if (table === 'diagnostic_audits') {
+        return {
+          update: mocks.update,
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    process.env = { ...originalEnv }
+  })
+
+  it('requires admin auth before starting a trace', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Authentication required', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(makeRequest(validBody()))
+
+    expect(response.status).toBe(401)
+    expect(mocks.startAgentRun).not.toHaveBeenCalled()
+    expect(mocks.from).not.toHaveBeenCalled()
+  })
+
+  it('generates insights, records budget metadata, links cost, and returns agentRunId', async () => {
+    const aiPayload = {
+      diagnostic_summary: 'Manual follow-up is slowing lead conversion.',
+      key_insights: ['Follow-up is not assigned consistently.', 'A CRM source of truth is missing.'],
+      recommended_actions: ['Create lead routing rules.', 'Add an owner field to every lead.'],
+      urgency_score: 7,
+      opportunity_score: 8,
+      sales_notes: 'Strong fit for a lightweight automation sprint.',
+    }
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        usage: { prompt_tokens: 250, completion_tokens: 500, total_tokens: 750 },
+        choices: [{ message: { content: JSON.stringify(aiPayload) } }],
+      }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const response = await POST(makeRequest(validBody()))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      summary: aiPayload.diagnostic_summary,
+      insights: aiPayload.key_insights,
+      actions: aiPayload.recommended_actions,
+      urgency_score: 7,
+      opportunity_score: 8,
+      sales_notes: aiPayload.sales_notes,
+      agentRunId: 'agent-run-1',
+    })
+    expect(mocks.startAgentRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentKey: 'manual-admin',
+        runtime: 'manual',
+        kind: 'in_person_diagnostic_insights',
+        triggerSource: 'admin:in_person_diagnostic_generate_insights',
+        triggeredByUserId: 'admin-user-1',
+      }),
+    )
+    expect(mocks.recordAgentStep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'agent-run-1',
+        stepKey: 'budget_check',
+        metadata: expect.objectContaining({
+          operation: 'in_person_diagnostic_insights',
+          audit_id: 'audit-1',
+          budget_status: 'allowed',
+        }),
+      }),
+    )
+    expect(mocks.recordOpenAICost).toHaveBeenCalledWith(
+      expect.any(Object),
+      'gpt-4o-mini',
+      { type: 'diagnostic_audit', id: 'audit-1' },
+      expect.objectContaining({
+        operation: 'in_person_diagnostic_insights',
+        budget_status: 'allowed',
+      }),
+      'agent-run-1',
+    )
+    expect(mocks.endAgentRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'agent-run-1',
+        status: 'completed',
+        outcome: expect.objectContaining({
+          audit_id: 'audit-1',
+          insight_count: 2,
+          action_count: 2,
+        }),
+      }),
+    )
+  })
+
+  it('marks the trace failed and returns a safe message when budget blocks generation', async () => {
+    const mockFetch = vi.fn()
+    vi.stubGlobal('fetch', mockFetch)
+
+    const response = await POST(makeRequest(validBody({
+      diagnostic_data: {
+        business_challenges: { notes: 'x'.repeat(8_000_000) },
+      },
+    })))
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error:
+        'This in-person diagnostic insight request is over the current Agent Ops budget limit. Shorten the diagnostic notes before retrying.',
+      agentRunId: 'agent-run-1',
+    })
+    expect(mockFetch).not.toHaveBeenCalled()
+    expect(mocks.recordAgentStep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'agent-run-1',
+        stepKey: 'budget_check',
+        status: 'failed',
+      }),
+    )
+    expect(mocks.markAgentRunFailed).toHaveBeenCalledWith(
+      'agent-run-1',
+      expect.stringContaining('Estimated cost'),
+      expect.objectContaining({
+        operation: 'in_person_diagnostic_insights',
+        audit_id: 'audit-1',
+      }),
+    )
+  })
+
+  it('allows normal in-person diagnostic insight prompts under the manual runtime budget', () => {
+    const decision = evaluateInPersonDiagnosticInsightsBudget({
+      systemPrompt: 'Respond only with JSON.',
+      userPrompt: 'Summarize a short diagnostic conversation.',
+    })
+
+    expect(decision.status).toBe('allowed')
+    expect(decision.rule.runtime).toBe('manual')
+  })
+})

--- a/app/api/admin/sales/in-person-diagnostic/generate-insights/route.ts
+++ b/app/api/admin/sales/in-person-diagnostic/generate-insights/route.ts
@@ -1,9 +1,25 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
 import { supabaseAdmin } from '@/lib/supabase'
-import { recordOpenAICost } from '@/lib/cost-calculator'
+import { recordOpenAICost, type Usage } from '@/lib/cost-calculator'
+import {
+  endAgentRun,
+  markAgentRunFailed,
+  recordAgentStep,
+  startAgentRun,
+} from '@/lib/agent-run'
+import {
+  evaluateInPersonDiagnosticInsightsBudget,
+  IN_PERSON_DIAGNOSTIC_INSIGHTS_MAX_TOKENS,
+  IN_PERSON_DIAGNOSTIC_INSIGHTS_MODEL,
+  IN_PERSON_DIAGNOSTIC_INSIGHTS_OPERATION,
+  InPersonDiagnosticInsightsError,
+  recordInPersonDiagnosticInsightsBudgetDecision,
+} from '@/lib/in-person-diagnostic-insights'
 
 export const dynamic = 'force-dynamic'
+
+const IN_PERSON_DIAGNOSTIC_SYSTEM_PROMPT = 'You are a sales intelligence analyst. Respond only with valid JSON.'
 
 /**
  * POST /api/admin/sales/in-person-diagnostic/generate-insights
@@ -16,6 +32,9 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: admin.error }, { status: admin.status })
   }
 
+  let agentRunId: string | null = null
+  let auditId: string | null = null
+
   try {
     const body = await request.json()
     const { audit_id, client_name, client_company, diagnostic_data } = body
@@ -23,10 +42,47 @@ export async function POST(request: NextRequest) {
     if (!audit_id || !diagnostic_data) {
       return NextResponse.json({ error: 'audit_id and diagnostic_data are required' }, { status: 400 })
     }
+    auditId = audit_id
+
+    const agentRun = await startAgentRun({
+      agentKey: 'manual-admin',
+      runtime: 'manual',
+      kind: 'in_person_diagnostic_insights',
+      title: 'Generate in-person diagnostic insights',
+      subject: {
+        type: 'diagnostic_audit',
+        id: audit_id,
+        label: client_company || client_name || `Diagnostic audit ${audit_id}`,
+      },
+      triggerSource: 'admin:in_person_diagnostic_generate_insights',
+      triggeredByUserId: admin.user.id,
+      currentStep: 'In-person diagnostic request validated',
+      metadata: {
+        has_client_name: !!client_name,
+        has_client_company: !!client_company,
+        diagnostic_section_count: typeof diagnostic_data === 'object' && diagnostic_data
+          ? Object.keys(diagnostic_data).length
+          : 0,
+      },
+    })
+    agentRunId = agentRun.id
+
+    await recordAgentStep({
+      runId: agentRunId,
+      stepKey: 'in_person_diagnostic_request_validated',
+      name: 'In-person diagnostic request validated',
+      status: 'completed',
+      metadata: {
+        audit_id,
+        has_client_name: !!client_name,
+        has_client_company: !!client_company,
+      },
+      idempotencyKey: `${agentRunId}:in_person_diagnostic_request_validated`,
+    }).catch((err) => console.warn('[generate-insights] agent validation step failed:', err))
 
     const apiKey = process.env.OPENAI_API_KEY
     if (!apiKey) {
-      return NextResponse.json({ error: 'OpenAI API key not configured' }, { status: 500 })
+      throw new InPersonDiagnosticInsightsError('OPENAI_API_KEY is not configured', 'openai_not_configured')
     }
 
     // Build a prompt from the diagnostic data
@@ -71,6 +127,21 @@ Respond in JSON format:
   "sales_notes": "Brief note about the overall sales opportunity"
 }`
 
+    const budgetDecision = evaluateInPersonDiagnosticInsightsBudget({
+      systemPrompt: IN_PERSON_DIAGNOSTIC_SYSTEM_PROMPT,
+      userPrompt: prompt,
+      model: IN_PERSON_DIAGNOSTIC_INSIGHTS_MODEL,
+      maxTokens: IN_PERSON_DIAGNOSTIC_INSIGHTS_MAX_TOKENS,
+    })
+    await recordInPersonDiagnosticInsightsBudgetDecision({
+      agentRunId,
+      auditId: audit_id,
+      decision: budgetDecision,
+    })
+    if (budgetDecision.status === 'blocked') {
+      throw new InPersonDiagnosticInsightsError(budgetDecision.reason, 'budget_blocked')
+    }
+
     const response = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
       headers: {
@@ -78,13 +149,13 @@ Respond in JSON format:
         Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify({
-        model: 'gpt-4o-mini',
+        model: IN_PERSON_DIAGNOSTIC_INSIGHTS_MODEL,
         messages: [
-          { role: 'system', content: 'You are a sales intelligence analyst. Respond only with valid JSON.' },
+          { role: 'system', content: IN_PERSON_DIAGNOSTIC_SYSTEM_PROMPT },
           { role: 'user', content: prompt },
         ],
         temperature: 0.7,
-        max_tokens: 1000,
+        max_tokens: IN_PERSON_DIAGNOSTIC_INSIGHTS_MAX_TOKENS,
         response_format: { type: 'json_object' },
       }),
     })
@@ -92,17 +163,28 @@ Respond in JSON format:
     if (!response.ok) {
       const errText = await response.text()
       console.error('OpenAI API error:', errText)
-      return NextResponse.json({ error: 'AI generation failed' }, { status: 500 })
+      throw new InPersonDiagnosticInsightsError('AI generation failed', 'openai_upstream')
     }
 
     const aiResult = await response.json()
     const content = aiResult.choices?.[0]?.message?.content
-    const usage = aiResult.usage
+    const usage = aiResult.usage as Usage | undefined
     if (usage) {
-      recordOpenAICost(usage, 'gpt-4o-mini', { type: 'diagnostic_audit', id: audit_id }, { operation: 'generate_insights' }).catch(() => {})
+      recordOpenAICost(
+        usage,
+        IN_PERSON_DIAGNOSTIC_INSIGHTS_MODEL,
+        { type: 'diagnostic_audit', id: audit_id },
+        {
+          operation: IN_PERSON_DIAGNOSTIC_INSIGHTS_OPERATION,
+          budget_status: budgetDecision.status,
+          budget_rule_key: budgetDecision.rule.key,
+          budget_estimated_cost_usd: budgetDecision.estimatedCostUsd,
+        },
+        agentRunId,
+      ).catch(() => {})
     }
     if (!content) {
-      return NextResponse.json({ error: 'No AI response' }, { status: 500 })
+      throw new InPersonDiagnosticInsightsError('No AI response', 'invalid_response')
     }
 
     let parsed: {
@@ -117,7 +199,7 @@ Respond in JSON format:
       parsed = JSON.parse(content)
     } catch {
       console.error('Failed to parse AI response:', content)
-      return NextResponse.json({ error: 'Failed to parse AI response' }, { status: 500 })
+      throw new InPersonDiagnosticInsightsError('Failed to parse AI response', 'invalid_response')
     }
 
     // Update the diagnostic audit with generated insights
@@ -139,6 +221,20 @@ Respond in JSON format:
       // Non-fatal: return the insights even if save failed
     }
 
+    await endAgentRun({
+      runId: agentRunId,
+      status: 'completed',
+      currentStep: 'In-person diagnostic insights ready',
+      outcome: {
+        audit_id,
+        insight_count: parsed.key_insights?.length ?? 0,
+        action_count: parsed.recommended_actions?.length ?? 0,
+        urgency_score: parsed.urgency_score ?? null,
+        opportunity_score: parsed.opportunity_score ?? null,
+        persisted: !updateError,
+      },
+    }).catch((err) => console.warn('[generate-insights] end agent run failed:', err))
+
     return NextResponse.json({
       summary: parsed.diagnostic_summary,
       insights: parsed.key_insights || [],
@@ -146,9 +242,56 @@ Respond in JSON format:
       urgency_score: parsed.urgency_score,
       opportunity_score: parsed.opportunity_score,
       sales_notes: parsed.sales_notes,
+      agentRunId,
     })
   } catch (error) {
     console.error('Generate insights API error:', error)
+    const message = error instanceof Error ? error.message : String(error)
+    if (agentRunId) {
+      await recordAgentStep({
+        runId: agentRunId,
+        stepKey: 'in_person_diagnostic_insights_failed',
+        name: 'In-person diagnostic insights failed',
+        status: 'failed',
+        outputSummary: message,
+        idempotencyKey: `${agentRunId}:in_person_diagnostic_insights_failed`,
+      }).catch((stepErr) => console.warn('[generate-insights] agent failure step failed:', stepErr))
+      await markAgentRunFailed(agentRunId, message, {
+        operation: IN_PERSON_DIAGNOSTIC_INSIGHTS_OPERATION,
+        audit_id: auditId,
+      }).catch((runErr) => console.warn('[generate-insights] mark agent run failed:', runErr))
+    }
+
+    if (error instanceof InPersonDiagnosticInsightsError) {
+      return NextResponse.json(
+        { error: safeInPersonDiagnosticInsightsErrorMessage(error), agentRunId },
+        { status: inPersonDiagnosticInsightsErrorStatus(error) },
+      )
+    }
+
     return NextResponse.json({ error: 'Failed to generate insights' }, { status: 500 })
   }
+}
+
+function safeInPersonDiagnosticInsightsErrorMessage(error: InPersonDiagnosticInsightsError): string {
+  if (error.code === 'budget_blocked') {
+    return 'This in-person diagnostic insight request is over the current Agent Ops budget limit. Shorten the diagnostic notes before retrying.'
+  }
+  if (error.code === 'openai_not_configured') {
+    return 'OpenAI API key not configured'
+  }
+  if (error.code === 'openai_upstream') {
+    return 'AI generation failed'
+  }
+  if (error.code === 'invalid_response') {
+    return 'The AI returned an invalid insight response. Try generating again or reduce the diagnostic notes.'
+  }
+  return 'Failed to generate insights'
+}
+
+function inPersonDiagnosticInsightsErrorStatus(error: InPersonDiagnosticInsightsError): number {
+  if (error.code === 'budget_blocked') return 400
+  if (error.code === 'openai_not_configured') return 503
+  if (error.code === 'openai_upstream' || error.code === 'invalid_response') return 502
+  return 500
 }

--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -274,6 +274,7 @@ Current progress:
 - Admin video prompt formatting now starts a manual Agent Ops trace, checks the manual-runtime budget before OpenAI dispatch, and links prompt-formatting cost events back to the trace.
 - Admin video ideas generation now starts a manual Agent Ops trace, checks the manual-runtime budget after context assembly and before GPT-4o dispatch, and links idea-generation cost events back to the trace.
 - Admin social carousel conversion now starts a manual Agent Ops trace, checks the manual-runtime budget before GPT-4o dispatch, and links carousel-generation cost events back to the trace.
+- Admin in-person diagnostic insights now start a manual Agent Ops trace, check the manual-runtime budget before GPT-4o-mini dispatch, and link insight-generation cost events back to the trace.
 
 ## Cross-Phase Definition Of Done
 

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -177,6 +177,7 @@ V1 budget policy is advisory and pre-flight ready:
 - admin video prompt formatting now checks the manual-runtime budget before OpenAI dispatch and links cost events to the created Agent Ops trace;
 - admin video ideas generation now checks the manual-runtime budget after context assembly and before GPT-4o dispatch, with generated cost events linked to the created Agent Ops trace;
 - admin social carousel conversion now checks the manual-runtime budget before GPT-4o dispatch, with generated cost events linked to the created Agent Ops trace;
+- admin in-person diagnostic insight generation now checks the manual-runtime budget before GPT-4o-mini dispatch, with generated cost events linked to the created Agent Ops trace;
 - live workflows are not yet globally blocked until each adoption path has a targeted test and approval gate.
 
 Slack should be treated as a notification and lightweight decision surface later. The source of truth remains Portfolio admin plus `agent_approvals`.

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -72,6 +72,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 - [x] Video prompt formatter pre-flight budget adoption and trace linkage in review.
 - [x] Video ideas generation pre-flight budget adoption and trace linkage in review.
 - [x] Social carousel conversion pre-flight budget adoption and trace linkage in review.
+- [x] In-person diagnostic insights pre-flight budget adoption and trace linkage in review.
 
 ## Scope Guard
 

--- a/docs/agentic-patterns.md
+++ b/docs/agentic-patterns.md
@@ -425,6 +425,7 @@ Each section follows the same template: *Definition · Where we use it today · 
 - Admin video prompt formatting checks the manual-runtime budget before OpenAI dispatch and links cost events to its Agent Ops trace.
 - Admin video ideas generation checks the manual-runtime budget after context assembly and before GPT-4o dispatch, then links cost events to its Agent Ops trace.
 - Admin social carousel conversion checks the manual-runtime budget before GPT-4o dispatch and links cost events to its Agent Ops trace.
+- Admin in-person diagnostic insight generation checks the manual-runtime budget before GPT-4o-mini dispatch and links cost events to its Agent Ops trace.
 - Cost-events ingest accumulates spend per event.
 - `cost_events.agent_run_id` links usage costs to shared Agent Ops traces.
 - Mission Control derives 24-hour Cost Intelligence by runtime, agent, workflow, client/project, and artifact type where run metadata exists.

--- a/lib/in-person-diagnostic-insights.ts
+++ b/lib/in-person-diagnostic-insights.ts
@@ -1,0 +1,80 @@
+import {
+  evaluateAgentBudget,
+  type AgentBudgetDecision,
+} from '@/lib/agent-budget-policy'
+import { recordAgentEvent, recordAgentStep } from '@/lib/agent-run'
+
+export const IN_PERSON_DIAGNOSTIC_INSIGHTS_OPERATION = 'in_person_diagnostic_insights'
+export const IN_PERSON_DIAGNOSTIC_INSIGHTS_MODEL = 'gpt-4o-mini'
+export const IN_PERSON_DIAGNOSTIC_INSIGHTS_MAX_TOKENS = 1000
+
+export class InPersonDiagnosticInsightsError extends Error {
+  constructor(
+    message: string,
+    public readonly code: 'budget_blocked' | 'openai_not_configured' | 'openai_upstream' | 'invalid_response',
+  ) {
+    super(message)
+    this.name = 'InPersonDiagnosticInsightsError'
+  }
+}
+
+function estimateTokensFromText(text: string): number {
+  return Math.ceil(text.length / 4)
+}
+
+export function evaluateInPersonDiagnosticInsightsBudget(input: {
+  systemPrompt: string
+  userPrompt: string
+  model?: string
+  maxTokens?: number
+}): AgentBudgetDecision {
+  return evaluateAgentBudget({
+    runtime: 'manual',
+    model: input.model ?? IN_PERSON_DIAGNOSTIC_INSIGHTS_MODEL,
+    estimatedInputTokens: estimateTokensFromText(`${input.systemPrompt}\n${input.userPrompt}`),
+    maxTokens: input.maxTokens ?? IN_PERSON_DIAGNOSTIC_INSIGHTS_MAX_TOKENS,
+    metadata: {
+      operation: IN_PERSON_DIAGNOSTIC_INSIGHTS_OPERATION,
+    },
+  })
+}
+
+export async function recordInPersonDiagnosticInsightsBudgetDecision(args: {
+  agentRunId?: string | null
+  auditId: string
+  decision: AgentBudgetDecision
+}) {
+  if (!args.agentRunId) return
+
+  const metadata = {
+    operation: IN_PERSON_DIAGNOSTIC_INSIGHTS_OPERATION,
+    audit_id: args.auditId,
+    budget_status: args.decision.status,
+    budget_rule_key: args.decision.rule.key,
+    estimated_cost_usd: args.decision.estimatedCostUsd,
+    warning_usd: args.decision.warningUsd,
+    limit_usd: args.decision.limitUsd,
+  }
+
+  await recordAgentStep({
+    runId: args.agentRunId,
+    stepKey: 'budget_check',
+    name: 'Checked in-person diagnostic insights budget',
+    status: args.decision.status === 'blocked' ? 'failed' : 'completed',
+    outputSummary: args.decision.reason,
+    costUsd: args.decision.estimatedCostUsd,
+    metadata,
+    idempotencyKey: `${args.agentRunId}:in_person_diagnostic_insights:budget_check`,
+  }).catch((err) => console.warn('[generate-insights] agent budget step failed:', err))
+
+  if (args.decision.status !== 'allowed') {
+    await recordAgentEvent({
+      runId: args.agentRunId,
+      eventType: 'budget_check',
+      severity: args.decision.status === 'blocked' ? 'error' : 'warning',
+      message: args.decision.reason,
+      metadata,
+      idempotencyKey: `${args.agentRunId}:in_person_diagnostic_insights:budget_check:${args.decision.status}`,
+    }).catch((err) => console.warn('[generate-insights] agent budget event failed:', err))
+  }
+}


### PR DESCRIPTION
## Summary

Adds Agent Ops pre-flight budget tracing to in-person diagnostic insight generation.

## Changes

- Starts a manual Agent Ops run for `POST /api/admin/sales/in-person-diagnostic/generate-insights`
- Evaluates the manual-runtime LLM budget before GPT-4o-mini dispatch
- Records budget steps/events and marks blocked/failed runs safely
- Links OpenAI cost events back to the created `agent_run_id`
- Adds focused route coverage for auth, success/cost linkage, and budget blocking
- Updates Agent Ops roadmap docs for the new Phase 10 adoption surface

## Validation

- `npm test -- --run 'app/api/admin/sales/in-person-diagnostic/generate-insights/route.test.ts'`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- `npm run build`

## Notes

- `npm run build` emitted the existing local warning that `MOCK_N8N=false` and `N8N_DISABLE_OUTBOUND=false`; this build did not trigger n8n workflows.
- Pre-push database health check passed.
