### PR TITLE
[codex] trace meeting pain budget checks

### DIFF
--- a/app/api/admin/meetings/classify-pain-points/route.test.ts
+++ b/app/api/admin/meetings/classify-pain-points/route.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  recordOpenAICost: vi.fn(),
+  startAgentRun: vi.fn(),
+  recordAgentStep: vi.fn(),
+  recordAgentEvent: vi.fn(),
+  endAgentRun: vi.fn(),
+  markAgentRunFailed: vi.fn(),
+  refreshCategoryStats: vi.fn(),
+  linkEvidenceToCalculations: vi.fn(),
+  from: vi.fn(),
+  categoriesSelect: vi.fn(),
+  categoriesEq: vi.fn(),
+  evidenceInsert: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/cost-calculator', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/cost-calculator')>()
+  return {
+    ...actual,
+    recordOpenAICost: mocks.recordOpenAICost,
+  }
+})
+
+vi.mock('@/lib/agent-run', () => ({
+  startAgentRun: mocks.startAgentRun,
+  recordAgentStep: mocks.recordAgentStep,
+  recordAgentEvent: mocks.recordAgentEvent,
+  endAgentRun: mocks.endAgentRun,
+  markAgentRunFailed: mocks.markAgentRunFailed,
+}))
+
+vi.mock('@/lib/value-evidence-linker', () => ({
+  refreshCategoryStats: mocks.refreshCategoryStats,
+  linkEvidenceToCalculations: mocks.linkEvidenceToCalculations,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import { POST } from './route'
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest('http://localhost/api/admin/meetings/classify-pain-points', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/admin/meetings/classify-pain-points', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.unstubAllGlobals()
+    process.env = { ...originalEnv, OPENAI_API_KEY: 'test-key' }
+
+    mocks.verifyAdmin.mockResolvedValue({
+      user: { id: 'admin-user-1' },
+      isAdmin: true,
+    })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.startAgentRun.mockResolvedValue({ id: 'agent-run-1' })
+    mocks.recordAgentStep.mockResolvedValue({ id: 'step-1' })
+    mocks.recordAgentEvent.mockResolvedValue({ id: 'event-1' })
+    mocks.endAgentRun.mockResolvedValue(undefined)
+    mocks.markAgentRunFailed.mockResolvedValue(undefined)
+    mocks.recordOpenAICost.mockResolvedValue(undefined)
+    mocks.refreshCategoryStats.mockResolvedValue(undefined)
+    mocks.linkEvidenceToCalculations.mockResolvedValue(undefined)
+    mocks.categoriesEq.mockResolvedValue({
+      data: [
+        {
+          id: 'cat-manual',
+          name: 'manual_processes',
+          display_name: 'Manual Processes',
+          description: 'Manual repetitive work',
+        },
+      ],
+      error: null,
+    })
+    mocks.categoriesSelect.mockReturnValue({ eq: mocks.categoriesEq })
+    mocks.evidenceInsert.mockResolvedValue({ error: null })
+    mocks.from.mockImplementation((table: string) => {
+      if (table === 'pain_point_categories') {
+        return { select: mocks.categoriesSelect }
+      }
+      if (table === 'pain_point_evidence') {
+        return { insert: mocks.evidenceInsert }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    process.env = { ...originalEnv }
+  })
+
+  it('requires admin auth before starting a trace', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Authentication required', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(makeRequest({ pain_points: 'Manual follow-up is inconsistent.' }))
+
+    expect(response.status).toBe(401)
+    expect(mocks.startAgentRun).not.toHaveBeenCalled()
+    expect(mocks.from).not.toHaveBeenCalled()
+  })
+
+  it('classifies unmatched notes with AI, links cost, and returns agentRunId', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        usage: { prompt_tokens: 250, completion_tokens: 100, total_tokens: 350 },
+        choices: [
+          {
+            message: {
+              content: JSON.stringify([
+                { index: 1, category_name: 'manual_processes', confidence: 0.71 },
+              ]),
+            },
+          },
+        ],
+      }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const response = await POST(makeRequest({
+      pain_points: '- Team morale needs improvement and clearer handoffs',
+      quick_wins: '',
+      contact_submission_id: 42,
+      insert_evidence: true,
+    }))
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.agentRunId).toBe('agent-run-1')
+    expect(body.classified).toHaveLength(1)
+    expect(body.classified[0]).toMatchObject({
+      categoryId: 'cat-manual',
+      categoryName: 'manual_processes',
+      method: 'ai',
+    })
+    expect(body.evidence).toMatchObject({ inserted: 1, errors: [] })
+    expect(mocks.startAgentRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentKey: 'manual-admin',
+        runtime: 'manual',
+        kind: 'meeting_pain_classification',
+        triggerSource: 'admin:meetings_classify_pain_points',
+        triggeredByUserId: 'admin-user-1',
+      }),
+    )
+    expect(mocks.recordAgentStep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'agent-run-1',
+        stepKey: 'budget_check',
+        metadata: expect.objectContaining({
+          operation: 'meeting_pain_classification',
+          budget_status: 'allowed',
+          unmatched_count: 1,
+        }),
+      }),
+    )
+    expect(mocks.recordOpenAICost).toHaveBeenCalledWith(
+      expect.any(Object),
+      'gpt-4o-mini',
+      { type: 'meeting_pain_classification', id: 'agent-run-1' },
+      expect.objectContaining({
+        operation: 'meeting_pain_classification',
+        budget_status: 'allowed',
+      }),
+      'agent-run-1',
+    )
+    expect(mocks.endAgentRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'agent-run-1',
+        status: 'completed',
+        outcome: expect.objectContaining({
+          classified_count: 1,
+          inserted_evidence_count: 1,
+        }),
+      }),
+    )
+  })
+
+  it('marks the trace failed and returns a safe message when budget blocks AI classification', async () => {
+    const mockFetch = vi.fn()
+    vi.stubGlobal('fetch', mockFetch)
+
+    const response = await POST(makeRequest({
+      pain_points: `- ${'x'.repeat(8_000_000)}`,
+      quick_wins: '',
+    }))
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error:
+        'This meeting pain classification request is over the current Agent Ops budget limit. Shorten the meeting notes before retrying.',
+      agentRunId: 'agent-run-1',
+    })
+    expect(mockFetch).not.toHaveBeenCalled()
+    expect(mocks.recordAgentStep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'agent-run-1',
+        stepKey: 'budget_check',
+        status: 'failed',
+      }),
+    )
+    expect(mocks.markAgentRunFailed).toHaveBeenCalledWith(
+      'agent-run-1',
+      expect.stringContaining('Estimated cost'),
+      expect.objectContaining({
+        operation: 'meeting_pain_classification',
+      }),
+    )
+  })
+})

--- a/app/api/admin/meetings/classify-pain-points/route.ts
+++ b/app/api/admin/meetings/classify-pain-points/route.ts
@@ -3,7 +3,15 @@ import { verifyAdmin, isAuthError } from '@/lib/auth-server'
 import {
   classifyMeetingPainPoints,
   insertClassifiedEvidence,
+  MEETING_PAIN_CLASSIFICATION_OPERATION,
+  MeetingPainClassificationError,
 } from '@/lib/meeting-pain-classifier'
+import {
+  endAgentRun,
+  markAgentRunFailed,
+  recordAgentStep,
+  startAgentRun,
+} from '@/lib/agent-run'
 
 export const dynamic = 'force-dynamic'
 
@@ -19,6 +27,9 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: auth.error }, { status: auth.status })
   }
 
+  let agentRunId: string | null = null
+  let contactSubmissionIdForTrace: number | null = null
+
   let body: Record<string, unknown>
   try {
     body = await request.json()
@@ -31,6 +42,7 @@ export async function POST(request: NextRequest) {
   const contactSubmissionId = typeof body.contact_submission_id === 'number'
     ? body.contact_submission_id
     : undefined
+  contactSubmissionIdForTrace = contactSubmissionId ?? null
   const shouldInsertEvidence = body.insert_evidence === true
 
   if (!painPoints.trim() && !quickWins.trim()) {
@@ -41,7 +53,41 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const result = await classifyMeetingPainPoints(painPoints, quickWins)
+    const agentRun = await startAgentRun({
+      agentKey: 'manual-admin',
+      runtime: 'manual',
+      kind: MEETING_PAIN_CLASSIFICATION_OPERATION,
+      title: 'Classify meeting pain points',
+      subject: {
+        type: contactSubmissionId ? 'contact_submission' : 'meeting_pain_points',
+        id: contactSubmissionId ?? null,
+        label: contactSubmissionId ? `Contact submission ${contactSubmissionId}` : 'Meeting pain point classification',
+      },
+      triggerSource: 'admin:meetings_classify_pain_points',
+      triggeredByUserId: auth.user.id,
+      currentStep: 'Meeting pain point classification request validated',
+      metadata: {
+        pain_points_chars: painPoints.length,
+        quick_wins_chars: quickWins.length,
+        insert_evidence: shouldInsertEvidence,
+      },
+    })
+    agentRunId = agentRun.id
+
+    await recordAgentStep({
+      runId: agentRunId,
+      stepKey: 'meeting_pain_classification_request_validated',
+      name: 'Meeting pain classification request validated',
+      status: 'completed',
+      inputSummary: [painPoints, quickWins].filter(Boolean).join('\n').slice(0, 240),
+      metadata: {
+        contact_submission_id: contactSubmissionId ?? null,
+        insert_evidence: shouldInsertEvidence,
+      },
+      idempotencyKey: `${agentRunId}:meeting_pain_classification_request_validated`,
+    }).catch((err) => console.warn('[classify-pain-points] agent validation step failed:', err))
+
+    const result = await classifyMeetingPainPoints(painPoints, quickWins, { agentRunId })
 
     let evidenceResult = null
     if (shouldInsertEvidence && result.classified.length > 0) {
@@ -51,16 +97,71 @@ export async function POST(request: NextRequest) {
       )
     }
 
+    await endAgentRun({
+      runId: agentRunId,
+      status: 'completed',
+      currentStep: 'Meeting pain points classified',
+      outcome: {
+        classified_count: result.classified.length,
+        unclassified_count: result.unclassified.length,
+        inserted_evidence_count: evidenceResult?.inserted ?? 0,
+        evidence_error_count: evidenceResult?.errors.length ?? 0,
+      },
+    }).catch((err) => console.warn('[classify-pain-points] end agent run failed:', err))
+
     return NextResponse.json({
       classified: result.classified,
       unclassified: result.unclassified,
       evidence: evidenceResult,
+      agentRunId,
     })
   } catch (err) {
     console.error('[classify-pain-points] Error:', err)
+    const message = err instanceof Error ? err.message : String(err)
+    if (agentRunId) {
+      await recordAgentStep({
+        runId: agentRunId,
+        stepKey: 'meeting_pain_classification_failed',
+        name: 'Meeting pain classification failed',
+        status: 'failed',
+        outputSummary: message,
+        idempotencyKey: `${agentRunId}:meeting_pain_classification_failed`,
+      }).catch((stepErr) => console.warn('[classify-pain-points] agent failure step failed:', stepErr))
+      await markAgentRunFailed(agentRunId, message, {
+        operation: MEETING_PAIN_CLASSIFICATION_OPERATION,
+        contact_submission_id: contactSubmissionIdForTrace,
+      }).catch((runErr) => console.warn('[classify-pain-points] mark agent run failed:', runErr))
+    }
+
+    if (err instanceof MeetingPainClassificationError) {
+      return NextResponse.json(
+        { error: safeMeetingPainClassificationErrorMessage(err), agentRunId },
+        { status: meetingPainClassificationErrorStatus(err) },
+      )
+    }
+
     return NextResponse.json(
       { error: 'Classification failed' },
       { status: 500 }
     )
   }
+}
+
+function safeMeetingPainClassificationErrorMessage(error: MeetingPainClassificationError): string {
+  if (error.code === 'budget_blocked') {
+    return 'This meeting pain classification request is over the current Agent Ops budget limit. Shorten the meeting notes before retrying.'
+  }
+  if (error.code === 'openai_upstream') {
+    return 'AI classification failed'
+  }
+  if (error.code === 'invalid_response') {
+    return 'The AI returned an invalid classification response. Try again with shorter meeting notes.'
+  }
+  return 'Classification failed'
+}
+
+function meetingPainClassificationErrorStatus(error: MeetingPainClassificationError): number {
+  if (error.code === 'budget_blocked') return 400
+  if (error.code === 'openai_upstream' || error.code === 'invalid_response') return 502
+  return 500
 }

--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -275,6 +275,7 @@ Current progress:
 - Admin video ideas generation now starts a manual Agent Ops trace, checks the manual-runtime budget after context assembly and before GPT-4o dispatch, and links idea-generation cost events back to the trace.
 - Admin social carousel conversion now starts a manual Agent Ops trace, checks the manual-runtime budget before GPT-4o dispatch, and links carousel-generation cost events back to the trace.
 - Admin in-person diagnostic insights now start a manual Agent Ops trace, check the manual-runtime budget before GPT-4o-mini dispatch, and link insight-generation cost events back to the trace.
+- Admin meeting pain classification now starts a manual Agent Ops trace, checks the manual-runtime budget before GPT-4o-mini fallback classification, and links AI fallback cost events back to the trace.
 
 ## Cross-Phase Definition Of Done
 

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -178,6 +178,7 @@ V1 budget policy is advisory and pre-flight ready:
 - admin video ideas generation now checks the manual-runtime budget after context assembly and before GPT-4o dispatch, with generated cost events linked to the created Agent Ops trace;
 - admin social carousel conversion now checks the manual-runtime budget before GPT-4o dispatch, with generated cost events linked to the created Agent Ops trace;
 - admin in-person diagnostic insight generation now checks the manual-runtime budget before GPT-4o-mini dispatch, with generated cost events linked to the created Agent Ops trace;
+- admin meeting pain classification now checks the manual-runtime budget before GPT-4o-mini fallback classification, with generated cost events linked to the created Agent Ops trace;
 - live workflows are not yet globally blocked until each adoption path has a targeted test and approval gate.
 
 Slack should be treated as a notification and lightweight decision surface later. The source of truth remains Portfolio admin plus `agent_approvals`.

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -73,6 +73,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 - [x] Video ideas generation pre-flight budget adoption and trace linkage in review.
 - [x] Social carousel conversion pre-flight budget adoption and trace linkage in review.
 - [x] In-person diagnostic insights pre-flight budget adoption and trace linkage in review.
+- [x] Meeting pain classification pre-flight budget adoption and trace linkage in review.
 
 ## Scope Guard
 

--- a/docs/agentic-patterns.md
+++ b/docs/agentic-patterns.md
@@ -426,6 +426,7 @@ Each section follows the same template: *Definition · Where we use it today · 
 - Admin video ideas generation checks the manual-runtime budget after context assembly and before GPT-4o dispatch, then links cost events to its Agent Ops trace.
 - Admin social carousel conversion checks the manual-runtime budget before GPT-4o dispatch and links cost events to its Agent Ops trace.
 - Admin in-person diagnostic insight generation checks the manual-runtime budget before GPT-4o-mini dispatch and links cost events to its Agent Ops trace.
+- Admin meeting pain classification checks the manual-runtime budget before GPT-4o-mini fallback classification and links AI fallback cost events to its Agent Ops trace.
 - Cost-events ingest accumulates spend per event.
 - `cost_events.agent_run_id` links usage costs to shared Agent Ops traces.
 - Mission Control derives 24-hour Cost Intelligence by runtime, agent, workflow, client/project, and artifact type where run metadata exists.

--- a/lib/meeting-pain-classifier.ts
+++ b/lib/meeting-pain-classifier.ts
@@ -12,6 +12,9 @@
 
 import { supabaseAdmin } from '@/lib/supabase'
 import { refreshCategoryStats, linkEvidenceToCalculations } from '@/lib/value-evidence-linker'
+import { evaluateAgentBudget, type AgentBudgetDecision } from '@/lib/agent-budget-policy'
+import { recordAgentEvent, recordAgentStep } from '@/lib/agent-run'
+import { recordOpenAICost, type Usage } from '@/lib/cost-calculator'
 
 // ============================================================================
 // Types
@@ -43,6 +46,24 @@ export interface InsertEvidenceResult {
   inserted: number
   errors: string[]
   affectedCategoryIds: string[]
+}
+
+export interface MeetingPainClassificationOptions {
+  agentRunId?: string | null
+}
+
+export const MEETING_PAIN_CLASSIFICATION_OPERATION = 'meeting_pain_classification'
+export const MEETING_PAIN_CLASSIFICATION_MODEL = 'gpt-4o-mini'
+export const MEETING_PAIN_CLASSIFICATION_MAX_TOKENS = 1000
+
+export class MeetingPainClassificationError extends Error {
+  constructor(
+    message: string,
+    public readonly code: 'budget_blocked' | 'openai_upstream' | 'invalid_response',
+  ) {
+    super(message)
+    this.name = 'MeetingPainClassificationError'
+  }
 }
 
 // ============================================================================
@@ -123,6 +144,66 @@ export const CATEGORY_KEYWORDS: Record<string, string[]> = {
 }
 
 const MIN_CONFIDENCE_THRESHOLD = 0.3
+
+function estimateTokensFromText(text: string): number {
+  return Math.ceil(text.length / 4)
+}
+
+export function evaluateMeetingPainClassificationBudget(input: {
+  prompt: string
+  model?: string
+  maxTokens?: number
+}): AgentBudgetDecision {
+  return evaluateAgentBudget({
+    runtime: 'manual',
+    model: input.model ?? MEETING_PAIN_CLASSIFICATION_MODEL,
+    estimatedInputTokens: estimateTokensFromText(input.prompt),
+    maxTokens: input.maxTokens ?? MEETING_PAIN_CLASSIFICATION_MAX_TOKENS,
+    metadata: {
+      operation: MEETING_PAIN_CLASSIFICATION_OPERATION,
+    },
+  })
+}
+
+async function recordMeetingPainClassificationBudgetDecision(args: {
+  agentRunId?: string | null
+  unmatchedCount: number
+  decision: AgentBudgetDecision
+}) {
+  if (!args.agentRunId) return
+
+  const metadata = {
+    operation: MEETING_PAIN_CLASSIFICATION_OPERATION,
+    unmatched_count: args.unmatchedCount,
+    budget_status: args.decision.status,
+    budget_rule_key: args.decision.rule.key,
+    estimated_cost_usd: args.decision.estimatedCostUsd,
+    warning_usd: args.decision.warningUsd,
+    limit_usd: args.decision.limitUsd,
+  }
+
+  await recordAgentStep({
+    runId: args.agentRunId,
+    stepKey: 'budget_check',
+    name: 'Checked meeting pain classification budget',
+    status: args.decision.status === 'blocked' ? 'failed' : 'completed',
+    outputSummary: args.decision.reason,
+    costUsd: args.decision.estimatedCostUsd,
+    metadata,
+    idempotencyKey: `${args.agentRunId}:meeting_pain_classification:budget_check`,
+  }).catch((err) => console.warn('[meeting-pain-classifier] agent budget step failed:', err))
+
+  if (args.decision.status !== 'allowed') {
+    await recordAgentEvent({
+      runId: args.agentRunId,
+      eventType: 'budget_check',
+      severity: args.decision.status === 'blocked' ? 'error' : 'warning',
+      message: args.decision.reason,
+      metadata,
+      idempotencyKey: `${args.agentRunId}:meeting_pain_classification:budget_check:${args.decision.status}`,
+    }).catch((err) => console.warn('[meeting-pain-classifier] agent budget event failed:', err))
+  }
+}
 
 // ============================================================================
 // Text splitting
@@ -220,7 +301,8 @@ function keywordClassifyItem(
 
 async function aiClassifyItems(
   items: string[],
-  categories: PainPointCategory[]
+  categories: PainPointCategory[],
+  options: MeetingPainClassificationOptions = {}
 ): Promise<ClassifiedItem[]> {
   if (items.length === 0 || categories.length === 0) return []
 
@@ -250,6 +332,20 @@ Respond with a JSON array where each element has:
 Only include items that have a reasonable match (confidence >= 0.3). Respond ONLY with the JSON array, no other text.`
 
   try {
+    const budgetDecision = evaluateMeetingPainClassificationBudget({
+      prompt,
+      model: MEETING_PAIN_CLASSIFICATION_MODEL,
+      maxTokens: MEETING_PAIN_CLASSIFICATION_MAX_TOKENS,
+    })
+    await recordMeetingPainClassificationBudgetDecision({
+      agentRunId: options.agentRunId,
+      unmatchedCount: items.length,
+      decision: budgetDecision,
+    })
+    if (budgetDecision.status === 'blocked') {
+      throw new MeetingPainClassificationError(budgetDecision.reason, 'budget_blocked')
+    }
+
     const response = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
       headers: {
@@ -257,19 +353,35 @@ Only include items that have a reasonable match (confidence >= 0.3). Respond ONL
         Authorization: `Bearer ${OPENAI_API_KEY}`,
       },
       body: JSON.stringify({
-        model: 'gpt-4o-mini',
+        model: MEETING_PAIN_CLASSIFICATION_MODEL,
         messages: [{ role: 'user', content: prompt }],
         temperature: 0.2,
-        max_tokens: 1000,
+        max_tokens: MEETING_PAIN_CLASSIFICATION_MAX_TOKENS,
       }),
     })
 
     if (!response.ok) {
       console.error('[meeting-pain-classifier] OpenAI API error:', response.status)
-      return []
+      throw new MeetingPainClassificationError('OpenAI classification failed', 'openai_upstream')
     }
 
     const data = await response.json()
+    const usage = data.usage as Usage | undefined
+    if (usage) {
+      recordOpenAICost(
+        usage,
+        MEETING_PAIN_CLASSIFICATION_MODEL,
+        { type: 'meeting_pain_classification', id: options.agentRunId ?? 'untraced' },
+        {
+          operation: MEETING_PAIN_CLASSIFICATION_OPERATION,
+          unmatched_count: items.length,
+          budget_status: budgetDecision.status,
+          budget_rule_key: budgetDecision.rule.key,
+          budget_estimated_cost_usd: budgetDecision.estimatedCostUsd,
+        },
+        options.agentRunId ?? undefined,
+      ).catch(() => {})
+    }
     const content = data.choices?.[0]?.message?.content?.trim() || ''
 
     const jsonMatch = content.match(/\[[\s\S]*\]/)
@@ -304,6 +416,9 @@ Only include items that have a reasonable match (confidence >= 0.3). Respond ONL
 
     return results
   } catch (err) {
+    if (err instanceof MeetingPainClassificationError) {
+      throw err
+    }
     console.error('[meeting-pain-classifier] AI classification failed:', err)
     return []
   }
@@ -315,7 +430,8 @@ Only include items that have a reasonable match (confidence >= 0.3). Respond ONL
 
 export async function classifyMeetingPainPoints(
   painPointsText: string,
-  quickWinsText: string
+  quickWinsText: string,
+  options: MeetingPainClassificationOptions = {}
 ): Promise<ClassifyResult> {
   const sb = supabaseAdmin
   if (!sb) throw new Error('supabaseAdmin not available (server-side only)')
@@ -353,7 +469,7 @@ export async function classifyMeetingPainPoints(
   }
 
   if (unmatched.length > 0) {
-    const aiResults = await aiClassifyItems(unmatched, categories)
+    const aiResults = await aiClassifyItems(unmatched, categories, options)
     const aiMatchedTexts = new Set(aiResults.map((r) => r.text))
 
     classified.push(...aiResults)


### PR DESCRIPTION
## Summary
- add Agent Ops tracing around admin meeting pain-point classification
- preflight the GPT-4o-mini fallback classifier through the Agent Ops budget policy
- link fallback OpenAI usage/cost events back to the generated agent run
- add route coverage for auth, traced success, evidence insertion, and budget blocking

## Validation
- npm test -- --run 'app/api/admin/meetings/classify-pain-points/route.test.ts' lib/meeting-pain-classifier.test.ts
- npx tsc --noEmit --pretty false
- git diff --check
- npm run build

## Notes
- Build emitted the existing local n8n outbound warning because .env.local has MOCK_N8N=false and N8N_DISABLE_OUTBOUND=false; no n8n workflows were triggered by this change.