### PR TITLE
[codex] trace llm judge budget checks

### DIFF
--- a/app/api/admin/llm-judge/route.test.ts
+++ b/app/api/admin/llm-judge/route.test.ts
@@ -1,0 +1,299 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  recordOpenAICost: vi.fn(),
+  recordAnthropicCost: vi.fn(),
+  startAgentRun: vi.fn(),
+  recordAgentStep: vi.fn(),
+  recordAgentEvent: vi.fn(),
+  endAgentRun: vi.fn(),
+  markAgentRunFailed: vi.fn(),
+  getLlmJudgePrompt: vi.fn(),
+  getChatbotPrompt: vi.fn(),
+  getVoiceAgentPrompt: vi.fn(),
+  getPromptConfig: vi.fn(),
+  from: vi.fn(),
+  sessionSelect: vi.fn(),
+  sessionEq: vi.fn(),
+  sessionSingle: vi.fn(),
+  evalUpsert: vi.fn(),
+  evalSelect: vi.fn(),
+  evalSingle: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/cost-calculator', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/cost-calculator')>()
+  return {
+    ...actual,
+    recordOpenAICost: mocks.recordOpenAICost,
+    recordAnthropicCost: mocks.recordAnthropicCost,
+  }
+})
+
+vi.mock('@/lib/agent-run', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/agent-run')>()
+  return {
+    ...actual,
+    startAgentRun: mocks.startAgentRun,
+    recordAgentStep: mocks.recordAgentStep,
+    recordAgentEvent: mocks.recordAgentEvent,
+    endAgentRun: mocks.endAgentRun,
+    markAgentRunFailed: mocks.markAgentRunFailed,
+  }
+})
+
+vi.mock('@/lib/system-prompts', () => ({
+  getLlmJudgePrompt: mocks.getLlmJudgePrompt,
+  getChatbotPrompt: mocks.getChatbotPrompt,
+  getVoiceAgentPrompt: mocks.getVoiceAgentPrompt,
+  getPromptConfig: mocks.getPromptConfig,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import { POST } from './route'
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest('http://localhost/api/admin/llm-judge', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/admin/llm-judge', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.unstubAllGlobals()
+    process.env = { ...originalEnv, OPENAI_API_KEY: 'test-openai-key' }
+
+    mocks.verifyAdmin.mockResolvedValue({
+      user: { id: 'admin-user-1' },
+      isAdmin: true,
+    })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.startAgentRun.mockResolvedValue({ id: 'agent-run-1' })
+    mocks.recordAgentStep.mockResolvedValue({ id: 'step-1' })
+    mocks.recordAgentEvent.mockResolvedValue({ id: 'event-1' })
+    mocks.endAgentRun.mockResolvedValue(undefined)
+    mocks.markAgentRunFailed.mockResolvedValue(undefined)
+    mocks.recordOpenAICost.mockResolvedValue(undefined)
+    mocks.recordAnthropicCost.mockResolvedValue(undefined)
+    mocks.getLlmJudgePrompt.mockResolvedValue('Evaluate the conversation and return JSON with rating, reasoning, confidence, categories, and suggestions.')
+    mocks.getChatbotPrompt.mockResolvedValue('Be accurate, concise, and helpful.')
+    mocks.getVoiceAgentPrompt.mockResolvedValue('Be accurate, concise, and helpful.')
+    mocks.getPromptConfig.mockResolvedValue({
+      model: 'claude-sonnet-4-20250514',
+      temperature: 0.3,
+    })
+    mocks.sessionSingle.mockResolvedValue({
+      data: {
+        session_id: 'session-1',
+        visitor_name: 'Taylor Client',
+        visitor_email: 'taylor@example.com',
+        is_escalated: false,
+        chat_messages: [
+          {
+            id: 'message-1',
+            role: 'user',
+            content: 'Can you help me understand your services?',
+            metadata: {},
+            created_at: '2026-05-07T10:00:00Z',
+          },
+          {
+            id: 'message-2',
+            role: 'assistant',
+            content: 'Yes. We help teams adopt practical AI workflows.',
+            metadata: {},
+            created_at: '2026-05-07T10:00:05Z',
+          },
+        ],
+      },
+      error: null,
+    })
+    mocks.sessionEq.mockReturnValue({ single: mocks.sessionSingle })
+    mocks.sessionSelect.mockReturnValue({ eq: mocks.sessionEq })
+    mocks.evalSingle.mockResolvedValue({
+      data: { id: 'eval-1' },
+      error: null,
+    })
+    mocks.evalSelect.mockReturnValue({ single: mocks.evalSingle })
+    mocks.evalUpsert.mockReturnValue({ select: mocks.evalSelect })
+    mocks.from.mockImplementation((table: string) => {
+      if (table === 'chat_sessions') {
+        return { select: mocks.sessionSelect }
+      }
+      if (table === 'llm_judge_evaluations') {
+        return { upsert: mocks.evalUpsert }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    process.env = { ...originalEnv }
+  })
+
+  it('requires admin auth before starting a trace', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Authentication required', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(makeRequest({ session_id: 'session-1' }))
+
+    expect(response.status).toBe(401)
+    expect(mocks.startAgentRun).not.toHaveBeenCalled()
+    expect(mocks.from).not.toHaveBeenCalled()
+  })
+
+  it('evaluates a chat session, links LLM cost, and returns agentRunId', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        usage: { prompt_tokens: 400, completion_tokens: 120, total_tokens: 520 },
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                rating: 'good',
+                reasoning: 'The assistant answered the user clearly.',
+                confidence: 0.82,
+                categories: [],
+                suggestions: ['Keep responses specific.'],
+              }),
+            },
+          },
+        ],
+      }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const response = await POST(makeRequest({
+      session_id: 'session-1',
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      prompt_version: 'v1',
+    }))
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.agentRunId).toBe('agent-run-1')
+    expect(body.evaluation).toMatchObject({
+      id: 'eval-1',
+      session_id: 'session-1',
+      rating: 'good',
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+    })
+    expect(mocks.startAgentRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentKey: 'manual-admin',
+        runtime: 'manual',
+        kind: 'llm_judge_chat_eval',
+        triggerSource: 'admin:llm_judge',
+        triggeredByUserId: 'admin-user-1',
+      }),
+    )
+    expect(mocks.recordAgentStep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'agent-run-1',
+        stepKey: 'budget_check',
+        metadata: expect.objectContaining({
+          operation: 'chat_eval',
+          budget_status: 'allowed',
+          session_id: 'session-1',
+        }),
+      }),
+    )
+    expect(mocks.recordOpenAICost).toHaveBeenCalledWith(
+      expect.any(Object),
+      'gpt-4o-mini',
+      { type: 'chat_session', id: 'session-1' },
+      expect.objectContaining({
+        operation: 'chat_eval',
+        budget_status: 'allowed',
+      }),
+      'agent-run-1',
+    )
+    expect(mocks.endAgentRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'agent-run-1',
+        status: 'completed',
+        outcome: expect.objectContaining({
+          evaluation_id: 'eval-1',
+          session_id: 'session-1',
+          rating: 'good',
+        }),
+      }),
+    )
+  })
+
+  it('marks the trace failed and returns a safe message when the budget blocks evaluation', async () => {
+    mocks.sessionSingle.mockResolvedValue({
+      data: {
+        session_id: 'session-1',
+        visitor_name: 'Taylor Client',
+        visitor_email: 'taylor@example.com',
+        is_escalated: false,
+        chat_messages: [
+          {
+            id: 'message-1',
+            role: 'user',
+            content: 'x'.repeat(8_000_000),
+            metadata: {},
+            created_at: '2026-05-07T10:00:00Z',
+          },
+        ],
+      },
+      error: null,
+    })
+    const mockFetch = vi.fn()
+    vi.stubGlobal('fetch', mockFetch)
+
+    const response = await POST(makeRequest({
+      session_id: 'session-1',
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+    }))
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error:
+        'This chat evaluation is over the current Agent Ops budget limit. Evaluate a shorter session or lower the selected model before retrying.',
+      agentRunId: 'agent-run-1',
+    })
+    expect(mockFetch).not.toHaveBeenCalled()
+    expect(mocks.recordAgentStep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'agent-run-1',
+        stepKey: 'budget_check',
+        status: 'failed',
+      }),
+    )
+    expect(mocks.markAgentRunFailed).toHaveBeenCalledWith(
+      'agent-run-1',
+      expect.stringContaining('Estimated cost'),
+      expect.objectContaining({
+        operation: 'chat_eval',
+        session_id: 'session-1',
+      }),
+    )
+  })
+})

--- a/app/api/admin/llm-judge/route.ts
+++ b/app/api/admin/llm-judge/route.ts
@@ -5,11 +5,18 @@ import {
   evaluateConversation, 
   AVAILABLE_MODELS,
   DEFAULT_JUDGE_CONFIG,
+  LlmJudgeBudgetError,
   type ChatMessageForJudge, 
   type JudgeContext,
   type JudgeConfig,
   type LLMProvider
 } from '@/lib/llm-judge'
+import {
+  endAgentRun,
+  markAgentRunFailed,
+  recordAgentStep,
+  startAgentRun,
+} from '@/lib/agent-run'
 
 export const dynamic = 'force-dynamic'
 
@@ -27,9 +34,13 @@ export async function POST(request: NextRequest) {
     )
   }
 
+  let agentRunId: string | null = null
+  let sessionIdForFailure: string | null = null
+
   try {
     const body = await request.json()
     const { session_id, provider, model, prompt_version } = body
+    sessionIdForFailure = typeof session_id === 'string' ? session_id : null
 
     if (!session_id) {
       return NextResponse.json(
@@ -80,6 +91,44 @@ export async function POST(request: NextRequest) {
       )
     }
 
+    const agentRun = await startAgentRun({
+      agentKey: 'manual-admin',
+      runtime: 'manual',
+      kind: 'llm_judge_chat_eval',
+      title: 'Evaluate chat session',
+      subject: {
+        type: 'chat_session',
+        id: session_id,
+        label: session.visitor_name || session.visitor_email || session_id,
+      },
+      triggerSource: 'admin:llm_judge',
+      triggeredByUserId: authResult.user.id,
+      currentStep: 'Preparing chat evaluation',
+      metadata: {
+        provider: selectedProvider,
+        model: selectedModel,
+        prompt_version: prompt_version || 'v1',
+        message_count: messages.length,
+      },
+    })
+    agentRunId = agentRun.id
+
+    await recordAgentStep({
+      runId: agentRunId,
+      stepKey: 'llm_judge_request_validated',
+      name: 'Validated chat evaluation request',
+      status: 'completed',
+      outputSummary: `Evaluating ${messages.length} message(s) with ${selectedModel}`,
+      metadata: {
+        session_id,
+        provider: selectedProvider,
+        model: selectedModel,
+        prompt_version: prompt_version || 'v1',
+        message_count: messages.length,
+      },
+      idempotencyKey: `${agentRunId}:llm_judge_request_validated`,
+    })
+
     // Prepare messages for judge
     const messagesForJudge: ChatMessageForJudge[] = messages.map((m: any) => ({
       role: m.role,
@@ -119,7 +168,12 @@ export async function POST(request: NextRequest) {
     }
 
     // Run evaluation
-    const evaluation = await evaluateConversation(messagesForJudge, context, config)
+    const evaluation = await evaluateConversation(messagesForJudge, context, config, {
+      agentRunId,
+      runtime: 'manual',
+      reference: { type: 'chat_session', id: session_id },
+      operation: 'chat_eval',
+    })
 
     // Save evaluation to database
     const { data: savedEval, error: saveError } = await supabaseAdmin
@@ -144,8 +198,27 @@ export async function POST(request: NextRequest) {
       // Still return the evaluation even if save fails
     }
 
+    await endAgentRun({
+      runId: agentRunId,
+      status: 'completed',
+      currentStep: 'Chat evaluation complete',
+      outcome: {
+        evaluation_id: savedEval?.id ?? null,
+        session_id,
+        rating: evaluation.rating,
+        confidence: evaluation.confidence,
+        category_count: evaluation.categories.length,
+        suggestion_count: evaluation.suggestions?.length ?? 0,
+        provider: config.provider,
+        model: config.model,
+        prompt_version: config.promptVersion,
+        save_error: saveError?.message ?? null,
+      },
+    })
+
     return NextResponse.json({
       success: true,
+      agentRunId,
       evaluation: {
         id: savedEval?.id,
         session_id,
@@ -161,6 +234,36 @@ export async function POST(request: NextRequest) {
     })
   } catch (error) {
     console.error('LLM Judge API error:', error)
+    if (agentRunId) {
+      const message = error instanceof Error ? error.message : 'LLM judge evaluation failed'
+      await recordAgentStep({
+        runId: agentRunId,
+        stepKey: 'llm_judge_failed',
+        name: 'Chat evaluation failed',
+        status: 'failed',
+        outputSummary: message,
+        metadata: {
+          session_id: sessionIdForFailure,
+        },
+        idempotencyKey: `${agentRunId}:llm_judge_failed`,
+      }).catch(() => {})
+      await markAgentRunFailed(agentRunId, message, {
+        operation: 'chat_eval',
+        session_id: sessionIdForFailure,
+      }).catch(() => {})
+    }
+
+    if (error instanceof LlmJudgeBudgetError) {
+      return NextResponse.json(
+        {
+          error:
+            'This chat evaluation is over the current Agent Ops budget limit. Evaluate a shorter session or lower the selected model before retrying.',
+          agentRunId,
+        },
+        { status: 400 },
+      )
+    }
+
     return NextResponse.json(
       { error: error instanceof Error ? error.message : 'Internal server error' },
       { status: 500 }

--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -276,6 +276,7 @@ Current progress:
 - Admin social carousel conversion now starts a manual Agent Ops trace, checks the manual-runtime budget before GPT-4o dispatch, and links carousel-generation cost events back to the trace.
 - Admin in-person diagnostic insights now start a manual Agent Ops trace, check the manual-runtime budget before GPT-4o-mini dispatch, and link insight-generation cost events back to the trace.
 - Admin meeting pain classification now starts a manual Agent Ops trace, checks the manual-runtime budget before GPT-4o-mini fallback classification, and links AI fallback cost events back to the trace.
+- Admin Chat Eval LLM judge evaluation now starts a manual Agent Ops trace, checks the manual-runtime budget before Anthropic/OpenAI dispatch, and links judge cost events back to the trace.
 
 ## Cross-Phase Definition Of Done
 

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -179,6 +179,7 @@ V1 budget policy is advisory and pre-flight ready:
 - admin social carousel conversion now checks the manual-runtime budget before GPT-4o dispatch, with generated cost events linked to the created Agent Ops trace;
 - admin in-person diagnostic insight generation now checks the manual-runtime budget before GPT-4o-mini dispatch, with generated cost events linked to the created Agent Ops trace;
 - admin meeting pain classification now checks the manual-runtime budget before GPT-4o-mini fallback classification, with generated cost events linked to the created Agent Ops trace;
+- admin Chat Eval LLM judge evaluation now checks the manual-runtime budget before Anthropic/OpenAI dispatch, with generated cost events linked to the created Agent Ops trace;
 - live workflows are not yet globally blocked until each adoption path has a targeted test and approval gate.
 
 Slack should be treated as a notification and lightweight decision surface later. The source of truth remains Portfolio admin plus `agent_approvals`.

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -74,6 +74,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 - [x] Social carousel conversion pre-flight budget adoption and trace linkage in review.
 - [x] In-person diagnostic insights pre-flight budget adoption and trace linkage in review.
 - [x] Meeting pain classification pre-flight budget adoption and trace linkage in review.
+- [x] Chat Eval LLM judge pre-flight budget adoption and trace linkage in review.
 
 ## Scope Guard
 

--- a/docs/agentic-patterns.md
+++ b/docs/agentic-patterns.md
@@ -427,6 +427,7 @@ Each section follows the same template: *Definition · Where we use it today · 
 - Admin social carousel conversion checks the manual-runtime budget before GPT-4o dispatch and links cost events to its Agent Ops trace.
 - Admin in-person diagnostic insight generation checks the manual-runtime budget before GPT-4o-mini dispatch and links cost events to its Agent Ops trace.
 - Admin meeting pain classification checks the manual-runtime budget before GPT-4o-mini fallback classification and links AI fallback cost events to its Agent Ops trace.
+- Admin Chat Eval LLM judge evaluation checks the manual-runtime budget before Anthropic/OpenAI dispatch and links judge cost events to its Agent Ops trace.
 - Cost-events ingest accumulates spend per event.
 - `cost_events.agent_run_id` links usage costs to shared Agent Ops traces.
 - Mission Control derives 24-hour Cost Intelligence by runtime, agent, workflow, client/project, and artifact type where run metadata exists.

--- a/lib/llm-judge.ts
+++ b/lib/llm-judge.ts
@@ -10,6 +10,11 @@ import {
   recordAnthropicCost,
   type Usage,
 } from './cost-calculator'
+import {
+  evaluateAgentBudget,
+  type AgentBudgetDecision,
+} from './agent-budget-policy'
+import { recordAgentEvent, recordAgentStep, type AgentRuntime } from './agent-run'
 
 export interface ChatMessageForJudge {
   role: 'user' | 'assistant' | 'support'
@@ -51,6 +56,23 @@ export interface JudgeConfig {
   promptVersion: string
   temperature?: number
 }
+
+export interface JudgeExecutionOptions {
+  agentRunId?: string | null
+  runtime?: AgentRuntime
+  reference?: { type: string; id: string }
+  operation?: string
+}
+
+export class LlmJudgeBudgetError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'LlmJudgeBudgetError'
+  }
+}
+
+const CHAT_EVAL_OPERATION = 'chat_eval'
+const CHAT_EVAL_MAX_TOKENS = 1024
 
 // Available models for each provider
 export const AVAILABLE_MODELS: Record<LLMProvider, Array<{ id: string; name: string; description: string }>> = {
@@ -134,6 +156,69 @@ Issue categories to use (if applicable):
 - "Inappropriate escalation"
 - "System prompt violation"
 `
+
+function estimateTokensFromText(text: string): number {
+  return Math.ceil(text.length / 4)
+}
+
+export function evaluateLlmJudgeBudget(input: {
+  prompt: string
+  model: string
+  maxTokens?: number
+  runtime?: AgentRuntime
+  operation?: string
+}): AgentBudgetDecision {
+  return evaluateAgentBudget({
+    runtime: input.runtime ?? 'manual',
+    model: input.model,
+    estimatedInputTokens: estimateTokensFromText(input.prompt),
+    maxTokens: input.maxTokens ?? CHAT_EVAL_MAX_TOKENS,
+    metadata: {
+      operation: input.operation ?? CHAT_EVAL_OPERATION,
+    },
+  })
+}
+
+async function recordLlmJudgeBudgetDecision(args: {
+  agentRunId?: string | null
+  sessionId?: string | null
+  operation: string
+  decision: AgentBudgetDecision
+}) {
+  if (!args.agentRunId) return
+
+  const metadata = {
+    session_id: args.sessionId ?? null,
+    operation: args.operation,
+    budget_status: args.decision.status,
+    budget_rule_key: args.decision.rule.key,
+    estimated_cost_usd: args.decision.estimatedCostUsd,
+    warning_usd: args.decision.warningUsd,
+    limit_usd: args.decision.limitUsd,
+  }
+
+  await recordAgentStep({
+    runId: args.agentRunId,
+    stepKey: 'budget_check',
+    name: 'Checked LLM judge budget',
+    status: args.decision.status === 'blocked' ? 'failed' : 'completed',
+    outputSummary: args.decision.reason,
+    costUsd: args.decision.estimatedCostUsd,
+    metadata,
+    idempotencyKey: `${args.agentRunId}:llm_judge:budget_check`,
+  }).catch((err) => console.warn('[llm-judge] agent budget step failed:', err))
+
+  if (args.decision.status !== 'allowed') {
+    await recordAgentEvent({
+      runId: args.agentRunId,
+      eventType: 'budget_check',
+      severity: args.decision.status === 'blocked' ? 'error' : 'warning',
+      message: args.decision.reason,
+      metadata,
+      idempotencyKey: `${args.agentRunId}:llm_judge:budget_check:${args.decision.status}`,
+    }).catch((err) => console.warn('[llm-judge] agent budget event failed:', err))
+  }
+}
 
 /**
  * Get the evaluation criteria from database or fallback
@@ -290,18 +375,36 @@ export function parseJudgeResponse(response: string): JudgeEvaluation {
 export async function evaluateConversation(
   messages: ChatMessageForJudge[],
   context: JudgeContext,
-  config?: JudgeConfig
+  config?: JudgeConfig,
+  options: JudgeExecutionOptions = {},
 ): Promise<JudgeEvaluation> {
   // Use provided config or fetch from database
   const judgeConfig = config || await getJudgeModelConfig()
+  const operation = options.operation ?? CHAT_EVAL_OPERATION
   
   // Build prompt (now async to fetch criteria from database)
   const prompt = await buildJudgePrompt(messages, context)
+  const budgetDecision = evaluateLlmJudgeBudget({
+    prompt,
+    model: judgeConfig.model,
+    maxTokens: CHAT_EVAL_MAX_TOKENS,
+    runtime: options.runtime ?? 'manual',
+    operation,
+  })
+  await recordLlmJudgeBudgetDecision({
+    agentRunId: options.agentRunId,
+    sessionId: options.reference?.id,
+    operation,
+    decision: budgetDecision,
+  })
+  if (budgetDecision.status === 'blocked') {
+    throw new LlmJudgeBudgetError(budgetDecision.reason)
+  }
   
   if (judgeConfig.provider === 'anthropic') {
-    return evaluateWithClaude(prompt, judgeConfig)
+    return evaluateWithClaude(prompt, judgeConfig, options, budgetDecision)
   } else {
-    return evaluateWithOpenAI(prompt, judgeConfig)
+    return evaluateWithOpenAI(prompt, judgeConfig, options, budgetDecision)
   }
 }
 
@@ -310,7 +413,9 @@ export async function evaluateConversation(
  */
 async function evaluateWithClaude(
   prompt: string,
-  config: JudgeConfig
+  config: JudgeConfig,
+  options: JudgeExecutionOptions = {},
+  budgetDecision?: AgentBudgetDecision,
 ): Promise<JudgeEvaluation> {
   const apiKey = process.env.ANTHROPIC_API_KEY
   
@@ -349,7 +454,18 @@ async function evaluateWithClaude(
     const content = data.content?.[0]?.text || ''
     const usage = data.usage as Usage | undefined
     if (usage) {
-      recordAnthropicCost(usage, config.model, undefined, { operation: 'chat_eval' }).catch(() => {})
+      recordAnthropicCost(
+        usage,
+        config.model,
+        options.reference,
+        {
+          operation: options.operation ?? CHAT_EVAL_OPERATION,
+          budget_status: budgetDecision?.status,
+          budget_estimated_cost_usd: budgetDecision?.estimatedCostUsd,
+          budget_rule_key: budgetDecision?.rule.key,
+        },
+        options.agentRunId ?? undefined,
+      ).catch(() => {})
     }
     return parseJudgeResponse(content)
   } catch (error) {
@@ -363,7 +479,9 @@ async function evaluateWithClaude(
  */
 async function evaluateWithOpenAI(
   prompt: string,
-  config: JudgeConfig
+  config: JudgeConfig,
+  options: JudgeExecutionOptions = {},
+  budgetDecision?: AgentBudgetDecision,
 ): Promise<JudgeEvaluation> {
   const apiKey = process.env.OPENAI_API_KEY
   
@@ -404,7 +522,18 @@ async function evaluateWithOpenAI(
     const content = data.choices?.[0]?.message?.content || ''
     const usage = data.usage as Usage | undefined
     if (usage) {
-      recordOpenAICost(usage, config.model, undefined, { operation: 'chat_eval' }).catch(() => {})
+      recordOpenAICost(
+        usage,
+        config.model,
+        options.reference,
+        {
+          operation: options.operation ?? CHAT_EVAL_OPERATION,
+          budget_status: budgetDecision?.status,
+          budget_estimated_cost_usd: budgetDecision?.estimatedCostUsd,
+          budget_rule_key: budgetDecision?.rule.key,
+        },
+        options.agentRunId ?? undefined,
+      ).catch(() => {})
     }
     return parseJudgeResponse(content)
   } catch (error) {


### PR DESCRIPTION
## Summary
- add Agent Ops tracing around admin Chat Eval LLM judge evaluation
- preflight the selected Anthropic/OpenAI judge model through the Agent Ops budget policy after prompt assembly
- link judge usage/cost events back to the generated agent run
- add route coverage for auth, traced success, cost linkage, and budget blocking

## Validation
- npm test -- --run app/api/admin/llm-judge/route.test.ts
- npx tsc --noEmit --pretty false
- git diff --check
- npm run build

## Notes
- Build emitted the existing local n8n outbound warning because .env.local has MOCK_N8N=false and N8N_DISABLE_OUTBOUND=false; no n8n workflows were triggered by this change.
- Pre-push ran the repository database health check against PROD because production credentials are present locally; it was read-only and passed.