### PR TITLE
[codex] close phase 10 llm budget coverage

### DIFF
--- a/app/api/admin/chat-eval/axial-codes/generate/route.ts
+++ b/app/api/admin/chat-eval/axial-codes/generate/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
-import { generateAxialCodes, DEFAULT_JUDGE_CONFIG, AVAILABLE_MODELS, LLMProvider, AxialCodeResult } from '@/lib/llm-judge'
+import { generateAxialCodes, DEFAULT_JUDGE_CONFIG, AVAILABLE_MODELS, LlmJudgeBudgetError, LLMProvider, AxialCodeResult } from '@/lib/llm-judge'
+import { endAgentRun, markAgentRunFailed, recordAgentStep, startAgentRun } from '@/lib/agent-run'
 
 export const dynamic = 'force-dynamic'
 
@@ -18,6 +19,8 @@ export async function POST(request: NextRequest) {
       { status: authResult.status }
     )
   }
+
+  let agentRunId: string | null = null
 
   try {
     const body = await request.json()
@@ -71,6 +74,43 @@ export async function POST(request: NextRequest) {
     const uniqueOpenCodes = [...new Set(openCodesWithContext.map((oc: { code: string; sessionId: string; rating: 'good' | 'bad' | undefined; notes: string | undefined }) => oc.code))]
     const uniqueSessionIds = [...new Set(openCodesWithContext.map((oc: { code: string; sessionId: string; rating: 'good' | 'bad' | undefined; notes: string | undefined }) => oc.sessionId))]
 
+    const agentRun = await startAgentRun({
+      agentKey: 'manual-admin',
+      runtime: 'manual',
+      kind: 'chat_eval_axial_codes',
+      title: 'Generate Chat Eval axial codes',
+      subject: {
+        type: 'chat_eval_sessions',
+        id: uniqueSessionIds.slice(0, 5).join(','),
+        label: `${uniqueSessionIds.length} session(s), ${uniqueOpenCodes.length} open code(s)`,
+      },
+      triggerSource: 'admin:chat_eval_axial_codes',
+      triggeredByUserId: authResult.user.id,
+      currentStep: 'Preparing axial code generation',
+      metadata: {
+        provider: selectedProvider,
+        model: selectedModel,
+        session_count: uniqueSessionIds.length,
+        open_code_count: uniqueOpenCodes.length,
+      },
+    })
+    agentRunId = agentRun.id
+
+    await recordAgentStep({
+      runId: agentRunId,
+      stepKey: 'axial_code_request_validated',
+      name: 'Validated axial code generation request',
+      status: 'completed',
+      outputSummary: `Generating axial codes from ${uniqueOpenCodes.length} open code(s).`,
+      metadata: {
+        provider: selectedProvider,
+        model: selectedModel,
+        session_count: uniqueSessionIds.length,
+        open_code_count: uniqueOpenCodes.length,
+      },
+      idempotencyKey: `${agentRunId}:axial_code_request_validated`,
+    })
+
     // Generate axial codes using LLM
     const config = {
       provider: selectedProvider,
@@ -79,7 +119,12 @@ export async function POST(request: NextRequest) {
       temperature: 0.3,
     }
 
-    const result = await generateAxialCodes(openCodesWithContext, config)
+    const result = await generateAxialCodes(openCodesWithContext, config, {
+      agentRunId,
+      runtime: 'manual',
+      reference: { type: 'chat_eval_axial_codes', id: agentRunId },
+      operation: 'axial_codes',
+    })
 
     // Store the generation in the database
     const { data: generation, error: insertError } = await supabaseAdmin
@@ -98,6 +143,12 @@ export async function POST(request: NextRequest) {
 
     if (insertError) {
       console.error('Error storing generation:', insertError)
+      if (agentRunId) {
+        await markAgentRunFailed(agentRunId, 'Failed to store axial code generation', {
+          operation: 'axial_codes',
+          session_count: uniqueSessionIds.length,
+        }).catch(() => {})
+      }
       return NextResponse.json(
         { error: 'Failed to store generation result' },
         { status: 500 }
@@ -123,8 +174,24 @@ export async function POST(request: NextRequest) {
       // Don't fail the whole request, the generation is already stored
     }
 
+    await endAgentRun({
+      runId: agentRunId,
+      status: 'completed',
+      currentStep: 'Axial code generation complete',
+      outcome: {
+        generation_id: generation.id,
+        axial_code_count: result.axial_codes.length,
+        source_session_count: uniqueSessionIds.length,
+        source_open_code_count: uniqueOpenCodes.length,
+        review_error: reviewError?.message ?? null,
+        provider: selectedProvider,
+        model: selectedModel,
+      },
+    })
+
     return NextResponse.json({
       generation_id: generation.id,
+      agentRunId,
       axial_codes: result.axial_codes,
       source_sessions_count: uniqueSessionIds.length,
       source_open_codes_count: uniqueOpenCodes.length,
@@ -132,6 +199,28 @@ export async function POST(request: NextRequest) {
     })
   } catch (error) {
     console.error('Axial code generation error:', error)
+    if (agentRunId) {
+      const message = error instanceof Error ? error.message : 'Axial code generation failed'
+      await recordAgentStep({
+        runId: agentRunId,
+        stepKey: 'axial_code_generation_failed',
+        name: 'Axial code generation failed',
+        status: 'failed',
+        outputSummary: message,
+        idempotencyKey: `${agentRunId}:axial_code_generation_failed`,
+      }).catch(() => {})
+      await markAgentRunFailed(agentRunId, message, { operation: 'axial_codes' }).catch(() => {})
+    }
+    if (error instanceof LlmJudgeBudgetError) {
+      return NextResponse.json(
+        {
+          error:
+            'This axial code generation request is over the current Agent Ops budget limit. Select fewer sessions or use a lower-cost model before retrying.',
+          agentRunId,
+        },
+        { status: 400 },
+      )
+    }
     return NextResponse.json(
       { error: error instanceof Error ? error.message : 'Internal server error' },
       { status: 500 }

--- a/app/api/admin/chat-eval/diagnose/batch/route.ts
+++ b/app/api/admin/chat-eval/diagnose/batch/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
-import { diagnoseError, DEFAULT_JUDGE_CONFIG, AVAILABLE_MODELS, LLMProvider, type SessionData, type EvaluationData } from '@/lib/llm-judge'
+import { diagnoseError, DEFAULT_JUDGE_CONFIG, AVAILABLE_MODELS, LlmJudgeBudgetError, LLMProvider, type SessionData, type EvaluationData } from '@/lib/llm-judge'
 import { getChatbotPrompt, getVoiceAgentPrompt } from '@/lib/system-prompts'
+import { endAgentRun, markAgentRunFailed, recordAgentStep, startAgentRun } from '@/lib/agent-run'
 
 export const dynamic = 'force-dynamic'
 
@@ -19,6 +20,8 @@ export async function POST(request: NextRequest) {
       { status: authResult.status }
     )
   }
+
+  let agentRunId: string | null = null
 
   try {
     let body: unknown
@@ -58,6 +61,41 @@ export async function POST(request: NextRequest) {
       promptVersion: 'v1',
       temperature: 0.3,
     }
+
+    const agentRun = await startAgentRun({
+      agentKey: 'manual-admin',
+      runtime: 'manual',
+      kind: 'chat_eval_diagnosis_batch',
+      title: 'Batch diagnose Chat Eval errors',
+      subject: {
+        type: 'chat_eval_sessions',
+        id: session_ids.slice(0, 5).join(','),
+        label: `${session_ids.length} session(s)`,
+      },
+      triggerSource: 'admin:chat_eval_diagnose_batch',
+      triggeredByUserId: authResult.user.id,
+      currentStep: 'Preparing batch chat error diagnosis',
+      metadata: {
+        provider: selectedProvider,
+        model: selectedModel,
+        session_count: session_ids.length,
+      },
+    })
+    agentRunId = agentRun.id
+
+    await recordAgentStep({
+      runId: agentRunId,
+      stepKey: 'chat_eval_diagnosis_batch_validated',
+      name: 'Validated batch diagnosis request',
+      status: 'completed',
+      outputSummary: `Diagnosing ${session_ids.length} chat session(s).`,
+      metadata: {
+        provider: selectedProvider,
+        model: selectedModel,
+        session_count: session_ids.length,
+      },
+      idempotencyKey: `${agentRunId}:chat_eval_diagnosis_batch_validated`,
+    })
 
     const results = []
 
@@ -166,7 +204,12 @@ export async function POST(request: NextRequest) {
         }
 
         // Run diagnosis
-        const diagnosis = await diagnoseError(sessionData, evaluationData, systemPrompt, config)
+        const diagnosis = await diagnoseError(sessionData, evaluationData, systemPrompt, config, {
+          agentRunId,
+          runtime: 'manual',
+          reference: { type: 'chat_eval_diagnosis', id: String(sessionId) },
+          operation: 'diagnose',
+        })
 
         // Store diagnosis
         const { data: storedDiagnosis, error: storeError } = await supabaseAdmin
@@ -205,7 +248,9 @@ export async function POST(request: NextRequest) {
         results.push({
           session_id: sessionId,
           success: false,
-          error: error instanceof Error ? error.message : 'Unknown error',
+          error: error instanceof LlmJudgeBudgetError
+            ? 'This chat error diagnosis is over the current Agent Ops budget limit. Use a shorter session or lower-cost model before retrying.'
+            : error instanceof Error ? error.message : 'Unknown error',
         })
       }
     }
@@ -213,7 +258,30 @@ export async function POST(request: NextRequest) {
     const successCount = results.filter(r => r.success).length
     const failureCount = results.filter(r => !r.success).length
 
+    if (failureCount === results.length) {
+      await markAgentRunFailed(agentRunId, 'All batch chat error diagnoses failed', {
+        operation: 'diagnose',
+        total: results.length,
+        successful: successCount,
+        failed: failureCount,
+      }).catch(() => {})
+    } else {
+      await endAgentRun({
+        runId: agentRunId,
+        status: 'completed',
+        currentStep: 'Batch chat error diagnosis complete',
+        outcome: {
+          total: results.length,
+          successful: successCount,
+          failed: failureCount,
+          provider: selectedProvider,
+          model: selectedModel,
+        },
+      })
+    }
+
     return NextResponse.json({
+      agentRunId,
       results,
       summary: {
         total: results.length,
@@ -224,6 +292,17 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error)
     console.error('Batch diagnosis error:', error)
+    if (agentRunId) {
+      await recordAgentStep({
+        runId: agentRunId,
+        stepKey: 'chat_eval_diagnosis_batch_failed',
+        name: 'Batch chat error diagnosis failed',
+        status: 'failed',
+        outputSummary: errorMessage,
+        idempotencyKey: `${agentRunId}:chat_eval_diagnosis_batch_failed`,
+      }).catch(() => {})
+      await markAgentRunFailed(agentRunId, errorMessage, { operation: 'diagnose_batch' }).catch(() => {})
+    }
     return NextResponse.json(
       { error: errorMessage || 'Internal server error' },
       { status: 500 }

--- a/app/api/admin/chat-eval/diagnose/route.ts
+++ b/app/api/admin/chat-eval/diagnose/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
-import { diagnoseError, DEFAULT_JUDGE_CONFIG, AVAILABLE_MODELS, LLMProvider, type SessionData, type EvaluationData } from '@/lib/llm-judge'
+import { diagnoseError, DEFAULT_JUDGE_CONFIG, AVAILABLE_MODELS, LlmJudgeBudgetError, LLMProvider, type SessionData, type EvaluationData } from '@/lib/llm-judge'
 import { getChatbotPrompt, getVoiceAgentPrompt } from '@/lib/system-prompts'
+import { endAgentRun, markAgentRunFailed, recordAgentStep, startAgentRun } from '@/lib/agent-run'
 
 export const dynamic = 'force-dynamic'
 
@@ -20,9 +21,13 @@ export async function POST(request: NextRequest) {
     )
   }
 
+  let agentRunId: string | null = null
+  let sessionIdForFailure: string | null = null
+
   try {
     const body = await request.json()
     const { session_id, evaluation_id, provider, model } = body
+    sessionIdForFailure = typeof session_id === 'string' ? session_id : null
 
     if (!session_id) {
       return NextResponse.json(
@@ -156,7 +161,50 @@ export async function POST(request: NextRequest) {
       temperature: 0.3,
     }
 
-    const diagnosis = await diagnoseError(sessionData, evaluationData, systemPrompt, config)
+    const agentRun = await startAgentRun({
+      agentKey: 'manual-admin',
+      runtime: 'manual',
+      kind: 'chat_eval_diagnosis',
+      title: 'Diagnose Chat Eval error',
+      subject: {
+        type: 'chat_session',
+        id: session_id,
+        label: session.visitor_name || session.visitor_email || session_id,
+      },
+      triggerSource: 'admin:chat_eval_diagnose',
+      triggeredByUserId: authResult.user.id,
+      currentStep: 'Preparing chat error diagnosis',
+      metadata: {
+        provider: selectedProvider,
+        model: selectedModel,
+        evaluation_id: evaluation.id,
+        message_count: messages.length,
+      },
+    })
+    agentRunId = agentRun.id
+
+    await recordAgentStep({
+      runId: agentRunId,
+      stepKey: 'chat_eval_diagnosis_request_validated',
+      name: 'Validated chat error diagnosis request',
+      status: 'completed',
+      outputSummary: `Diagnosing chat session ${session_id}.`,
+      metadata: {
+        provider: selectedProvider,
+        model: selectedModel,
+        session_id,
+        evaluation_id: evaluation.id,
+        message_count: messages.length,
+      },
+      idempotencyKey: `${agentRunId}:chat_eval_diagnosis_request_validated`,
+    })
+
+    const diagnosis = await diagnoseError(sessionData, evaluationData, systemPrompt, config, {
+      agentRunId,
+      runtime: 'manual',
+      reference: { type: 'chat_eval_diagnosis', id: session_id },
+      operation: 'diagnose',
+    })
 
     // Store diagnosis in database
     const { data: storedDiagnosis, error: storeError } = await supabaseAdmin
@@ -179,14 +227,38 @@ export async function POST(request: NextRequest) {
 
     if (storeError) {
       console.error('Error storing diagnosis:', storeError)
+      if (agentRunId) {
+        await markAgentRunFailed(agentRunId, 'Failed to store diagnosis', {
+          operation: 'diagnose',
+          session_id,
+          evaluation_id: evaluation.id,
+        }).catch(() => {})
+      }
       return NextResponse.json(
         { error: 'Failed to store diagnosis' },
         { status: 500 }
       )
     }
 
+    await endAgentRun({
+      runId: agentRunId,
+      status: 'completed',
+      currentStep: 'Chat error diagnosis complete',
+      outcome: {
+        diagnosis_id: storedDiagnosis.id,
+        session_id,
+        evaluation_id: evaluation.id,
+        error_type: diagnosis.error_type,
+        confidence: diagnosis.confidence,
+        recommendation_count: diagnosis.recommendations.length,
+        provider: selectedProvider,
+        model: selectedModel,
+      },
+    })
+
     return NextResponse.json({
       diagnosis_id: storedDiagnosis.id,
+      agentRunId,
       diagnosis: {
         root_cause: diagnosis.root_cause,
         error_type: diagnosis.error_type,
@@ -197,6 +269,32 @@ export async function POST(request: NextRequest) {
     })
   } catch (error) {
     console.error('Error diagnosis error:', error)
+    if (agentRunId) {
+      const message = error instanceof Error ? error.message : 'Chat error diagnosis failed'
+      await recordAgentStep({
+        runId: agentRunId,
+        stepKey: 'chat_eval_diagnosis_failed',
+        name: 'Chat error diagnosis failed',
+        status: 'failed',
+        outputSummary: message,
+        metadata: { session_id: sessionIdForFailure },
+        idempotencyKey: `${agentRunId}:chat_eval_diagnosis_failed`,
+      }).catch(() => {})
+      await markAgentRunFailed(agentRunId, message, {
+        operation: 'diagnose',
+        session_id: sessionIdForFailure,
+      }).catch(() => {})
+    }
+    if (error instanceof LlmJudgeBudgetError) {
+      return NextResponse.json(
+        {
+          error:
+            'This chat error diagnosis is over the current Agent Ops budget limit. Use a shorter session or lower-cost model before retrying.',
+          agentRunId,
+        },
+        { status: 400 },
+      )
+    }
     return NextResponse.json(
       { error: error instanceof Error ? error.message : 'Internal server error' },
       { status: 500 }

--- a/app/api/admin/value-evidence/validate-sources/route.ts
+++ b/app/api/admin/value-evidence/validate-sources/route.ts
@@ -7,6 +7,7 @@ import {
   PROMPT_VERSION,
   JUDGE_VERSION,
 } from '@/lib/source-validator'
+import { endAgentRun, markAgentRunFailed, recordAgentStep, startAgentRun } from '@/lib/agent-run'
 
 export const dynamic = 'force-dynamic'
 
@@ -72,15 +73,60 @@ export async function POST(request: NextRequest) {
     )
   }
 
+  let agentRunId: string | null = null
+
   try {
     if (table === 'pain_point_evidence') {
       // Sample-audit: smaller limit + force-pin Haiku regardless of body.
       // Per CTO guardrail: "Sample audit" must never become a footgun that
       // quietly runs Opus if a default changes or is overridden.
       const effectiveLimit = isSampleAudit ? Math.min(limit, 20) : limit
-      const judgeOpts = isSampleAudit
-        ? { model: 'claude-3-5-haiku-20241022' }
-        : undefined
+      const agentRun = await startAgentRun({
+        agentKey: 'manual-admin',
+        runtime: 'manual',
+        kind: 'source_validation_pain_point_evidence',
+        title: 'Validate pain point evidence sources',
+        subject: {
+          type: 'pain_point_evidence',
+          id: `${mode}:${effectiveLimit}`,
+          label: `${mode} validation (${effectiveLimit} row limit)`,
+        },
+        triggerSource: 'admin:value_evidence_validate_sources',
+        triggeredByUserId: auth.user?.id ?? null,
+        currentStep: 'Preparing source validation',
+        metadata: {
+          table,
+          mode,
+          limit: effectiveLimit,
+          stale_days: staleDays,
+          dry_run: dryRun,
+          sample_audit: isSampleAudit,
+        },
+      })
+      agentRunId = agentRun.id
+
+      await recordAgentStep({
+        runId: agentRunId,
+        stepKey: 'source_validation_request_validated',
+        name: 'Validated source validation request',
+        status: 'completed',
+        outputSummary: `${table} ${mode} run with ${effectiveLimit} row limit.`,
+        metadata: {
+          table,
+          mode,
+          limit: effectiveLimit,
+          stale_days: staleDays,
+          dry_run: dryRun,
+        },
+        idempotencyKey: `${agentRunId}:source_validation_request_validated`,
+      })
+
+      const judgeOpts = {
+        ...(isSampleAudit ? { model: 'claude-3-5-haiku-20241022' } : {}),
+        agentRunId,
+        runtime: 'manual' as const,
+        reference: { type: 'source_validation', id: agentRunId },
+      }
 
       const { summary, items } = await runPainPointEvidenceValidation({
         mode: mode as Mode,
@@ -103,7 +149,25 @@ export async function POST(request: NextRequest) {
         prompt_version: PROMPT_VERSION,
       }))
 
+      await endAgentRun({
+        runId: agentRunId,
+        status: 'completed',
+        currentStep: 'Source validation complete',
+        outcome: {
+          table,
+          mode,
+          attempted: summary.attempted ?? 0,
+          validated: summary.validated ?? 0,
+          rejected: summary.rejected ?? 0,
+          quarantined: summary.quarantined ?? 0,
+          errors: summary.errors ?? 0,
+          llm_cost_usd: summary.llm_cost_usd ?? 0,
+          dry_run: dryRun,
+        },
+      })
+
       return NextResponse.json({
+        agentRunId,
         summary,
         items: enrichedItems,
         prompt_version: PROMPT_VERSION,
@@ -125,6 +189,31 @@ export async function POST(request: NextRequest) {
   } catch (e) {
     const msg = (e as Error).message ?? 'unknown error'
     console.error('[validate-sources] batch error:', msg)
+    if (agentRunId) {
+      await recordAgentStep({
+        runId: agentRunId,
+        stepKey: 'source_validation_failed',
+        name: 'Source validation failed',
+        status: 'failed',
+        outputSummary: msg,
+        idempotencyKey: `${agentRunId}:source_validation_failed`,
+      }).catch(() => {})
+      await markAgentRunFailed(agentRunId, msg, {
+        table,
+        mode,
+        operation: 'source_validator_llm_judge',
+      }).catch(() => {})
+    }
+    if (/Estimated cost .*exceeds/i.test(msg)) {
+      return NextResponse.json(
+        {
+          error:
+            'This source validation request is over the current Agent Ops budget limit. Lower the row limit or use sample-audit before retrying.',
+          agentRunId,
+        },
+        { status: 400 },
+      )
+    }
     return NextResponse.json(
       { error: 'Source validation run failed. See server logs for details.' },
       { status: 500 }

--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -277,6 +277,8 @@ Current progress:
 - Admin in-person diagnostic insights now start a manual Agent Ops trace, check the manual-runtime budget before GPT-4o-mini dispatch, and link insight-generation cost events back to the trace.
 - Admin meeting pain classification now starts a manual Agent Ops trace, checks the manual-runtime budget before GPT-4o-mini fallback classification, and links AI fallback cost events back to the trace.
 - Admin Chat Eval LLM judge evaluation now starts a manual Agent Ops trace, checks the manual-runtime budget before Anthropic/OpenAI dispatch, and links judge cost events back to the trace.
+- Admin Chat Eval axial-code generation and error diagnosis now start manual Agent Ops traces, check budget before Anthropic/OpenAI dispatch, and link cost events back to the trace.
+- Value Evidence source validation and dev testing LLM helpers now run pre-flight budget checks before direct provider calls.
 
 ## Cross-Phase Definition Of Done
 

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -180,6 +180,8 @@ V1 budget policy is advisory and pre-flight ready:
 - admin in-person diagnostic insight generation now checks the manual-runtime budget before GPT-4o-mini dispatch, with generated cost events linked to the created Agent Ops trace;
 - admin meeting pain classification now checks the manual-runtime budget before GPT-4o-mini fallback classification, with generated cost events linked to the created Agent Ops trace;
 - admin Chat Eval LLM judge evaluation now checks the manual-runtime budget before Anthropic/OpenAI dispatch, with generated cost events linked to the created Agent Ops trace;
+- admin Chat Eval axial-code generation and error diagnosis now check the manual-runtime budget before Anthropic/OpenAI dispatch, with generated cost events linked to the created Agent Ops trace;
+- Value Evidence source validation and dev testing LLM helpers now check budget before direct provider calls;
 - live workflows are not yet globally blocked until each adoption path has a targeted test and approval gate.
 
 Slack should be treated as a notification and lightweight decision surface later. The source of truth remains Portfolio admin plus `agent_approvals`.

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -75,6 +75,8 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 - [x] In-person diagnostic insights pre-flight budget adoption and trace linkage in review.
 - [x] Meeting pain classification pre-flight budget adoption and trace linkage in review.
 - [x] Chat Eval LLM judge pre-flight budget adoption and trace linkage in review.
+- [x] Chat Eval axial-code and diagnosis pre-flight budget adoption and trace linkage in review.
+- [x] Source validator and dev testing LLM pre-flight budget cleanup in review.
 
 ## Scope Guard
 

--- a/docs/agentic-patterns.md
+++ b/docs/agentic-patterns.md
@@ -428,6 +428,8 @@ Each section follows the same template: *Definition · Where we use it today · 
 - Admin in-person diagnostic insight generation checks the manual-runtime budget before GPT-4o-mini dispatch and links cost events to its Agent Ops trace.
 - Admin meeting pain classification checks the manual-runtime budget before GPT-4o-mini fallback classification and links AI fallback cost events to its Agent Ops trace.
 - Admin Chat Eval LLM judge evaluation checks the manual-runtime budget before Anthropic/OpenAI dispatch and links judge cost events to its Agent Ops trace.
+- Admin Chat Eval axial-code generation and error diagnosis check the manual-runtime budget before Anthropic/OpenAI dispatch and link judge cost events to Agent Ops traces.
+- Value Evidence source validation and dev testing LLM helpers check budget before direct provider calls.
 - Cost-events ingest accumulates spend per event.
 - `cost_events.agent_run_id` links usage costs to shared Agent Ops traces.
 - Mission Control derives 24-hour Cost Intelligence by runtime, agent, workflow, client/project, and artifact type where run metadata exists.

--- a/lib/llm-judge-budget.test.ts
+++ b/lib/llm-judge-budget.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  recordOpenAICost: vi.fn(),
+  recordAnthropicCost: vi.fn(),
+  recordAgentStep: vi.fn(),
+  recordAgentEvent: vi.fn(),
+}))
+
+vi.mock('@/lib/cost-calculator', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/cost-calculator')>()
+  return {
+    ...actual,
+    recordOpenAICost: mocks.recordOpenAICost,
+    recordAnthropicCost: mocks.recordAnthropicCost,
+  }
+})
+
+vi.mock('@/lib/agent-run', () => {
+  return {
+    recordAgentStep: mocks.recordAgentStep,
+    recordAgentEvent: mocks.recordAgentEvent,
+  }
+})
+
+vi.mock('@/lib/system-prompts', () => ({
+  getLlmJudgePrompt: vi.fn(),
+  getChatbotPrompt: vi.fn(),
+  getVoiceAgentPrompt: vi.fn(),
+  getPromptConfig: vi.fn(),
+}))
+
+import {
+  diagnoseError,
+  generateAxialCodes,
+  LlmJudgeBudgetError,
+  type EvaluationData,
+  type SessionData,
+} from './llm-judge'
+
+describe('llm-judge budget adoption', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllGlobals()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    process.env = { ...originalEnv, OPENAI_API_KEY: 'test-openai-key' }
+    mocks.recordOpenAICost.mockResolvedValue(undefined)
+    mocks.recordAnthropicCost.mockResolvedValue(undefined)
+    mocks.recordAgentStep.mockResolvedValue({ id: 'step-1' })
+    mocks.recordAgentEvent.mockResolvedValue({ id: 'event-1' })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    process.env = { ...originalEnv }
+  })
+
+  it('links axial-code cost events to the provided agent run', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        usage: { prompt_tokens: 300, completion_tokens: 80, total_tokens: 380 },
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                axial_codes: [
+                  {
+                    code: 'Follow-up Quality',
+                    description: 'Follow-up gaps and missed next steps.',
+                    source_open_codes: ['missed follow-up'],
+                  },
+                ],
+              }),
+            },
+          },
+        ],
+      }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const result = await generateAxialCodes(
+      [{ code: 'missed follow-up', sessionId: 'session-1', rating: 'bad' }],
+      { provider: 'openai', model: 'gpt-4o-mini', promptVersion: 'v1', temperature: 0.3 },
+      {
+        agentRunId: 'agent-run-1',
+        reference: { type: 'chat_eval_axial_codes', id: 'agent-run-1' },
+        operation: 'axial_codes',
+      },
+    )
+
+    expect(result.axial_codes).toHaveLength(1)
+    expect(mocks.recordAgentStep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'agent-run-1',
+        stepKey: 'budget_check',
+        metadata: expect.objectContaining({
+          operation: 'axial_codes',
+          budget_status: 'allowed',
+        }),
+      }),
+    )
+    expect(mocks.recordOpenAICost).toHaveBeenCalledWith(
+      expect.any(Object),
+      'gpt-4o-mini',
+      { type: 'chat_eval_axial_codes', id: 'agent-run-1' },
+      expect.objectContaining({
+        operation: 'axial_codes',
+        budget_status: 'allowed',
+      }),
+      'agent-run-1',
+    )
+  })
+
+  it('blocks oversized diagnosis prompts before dispatch', async () => {
+    const mockFetch = vi.fn()
+    vi.stubGlobal('fetch', mockFetch)
+
+    const session: SessionData = {
+      session_id: 'session-1',
+      channel: 'text',
+      messages: [
+        {
+          role: 'user',
+          content: 'x'.repeat(8_000_000),
+        },
+      ],
+    }
+    const evaluation: EvaluationData = {
+      id: 'eval-1',
+      rating: 'bad',
+      notes: 'The answer failed.',
+    }
+
+    await expect(
+      diagnoseError(
+        session,
+        evaluation,
+        'System prompt',
+        { provider: 'openai', model: 'gpt-4o-mini', promptVersion: 'v1', temperature: 0.3 },
+        {
+          agentRunId: 'agent-run-1',
+          reference: { type: 'chat_eval_diagnosis', id: 'session-1' },
+          operation: 'diagnose',
+        },
+      ),
+    ).rejects.toBeInstanceOf(LlmJudgeBudgetError)
+
+    expect(mockFetch).not.toHaveBeenCalled()
+    expect(mocks.recordAgentStep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'agent-run-1',
+        stepKey: 'budget_check',
+        status: 'failed',
+        metadata: expect.objectContaining({
+          operation: 'diagnose',
+          budget_status: 'blocked',
+        }),
+      }),
+    )
+  })
+})

--- a/lib/llm-judge.ts
+++ b/lib/llm-judge.ts
@@ -73,6 +73,10 @@ export class LlmJudgeBudgetError extends Error {
 
 const CHAT_EVAL_OPERATION = 'chat_eval'
 const CHAT_EVAL_MAX_TOKENS = 1024
+const AXIAL_CODES_OPERATION = 'axial_codes'
+const AXIAL_CODES_MAX_TOKENS = 2048
+const DIAGNOSE_OPERATION = 'diagnose'
+const DIAGNOSE_MAX_TOKENS = 4096
 
 // Available models for each provider
 export const AVAILABLE_MODELS: Record<LLMProvider, Array<{ id: string; name: string; description: string }>> = {
@@ -205,7 +209,7 @@ async function recordLlmJudgeBudgetDecision(args: {
     outputSummary: args.decision.reason,
     costUsd: args.decision.estimatedCostUsd,
     metadata,
-    idempotencyKey: `${args.agentRunId}:llm_judge:budget_check`,
+    idempotencyKey: `${args.agentRunId}:${args.operation}:${args.sessionId ?? 'aggregate'}:budget_check`,
   }).catch((err) => console.warn('[llm-judge] agent budget step failed:', err))
 
   if (args.decision.status !== 'allowed') {
@@ -215,7 +219,7 @@ async function recordLlmJudgeBudgetDecision(args: {
       severity: args.decision.status === 'blocked' ? 'error' : 'warning',
       message: args.decision.reason,
       metadata,
-      idempotencyKey: `${args.agentRunId}:llm_judge:budget_check:${args.decision.status}`,
+      idempotencyKey: `${args.agentRunId}:${args.operation}:${args.sessionId ?? 'aggregate'}:budget_check:${args.decision.status}`,
     }).catch((err) => console.warn('[llm-judge] agent budget event failed:', err))
   }
 }
@@ -726,7 +730,9 @@ function parseAxialCodeResponse(response: string, openCodes: OpenCodeWithContext
  */
 async function generateAxialCodesWithClaude(
   prompt: string,
-  config: JudgeConfig
+  config: JudgeConfig,
+  options: JudgeExecutionOptions = {},
+  budgetDecision?: AgentBudgetDecision,
 ): Promise<string> {
   const apiKey = process.env.ANTHROPIC_API_KEY
   
@@ -758,7 +764,18 @@ async function generateAxialCodesWithClaude(
   const data = await response.json()
   const usage = data.usage as Usage | undefined
   if (usage) {
-    recordAnthropicCost(usage, config.model, undefined, { operation: 'axial_codes' }).catch(() => {})
+    recordAnthropicCost(
+      usage,
+      config.model,
+      options.reference,
+      {
+        operation: options.operation ?? AXIAL_CODES_OPERATION,
+        budget_status: budgetDecision?.status,
+        budget_estimated_cost_usd: budgetDecision?.estimatedCostUsd,
+        budget_rule_key: budgetDecision?.rule.key,
+      },
+      options.agentRunId ?? undefined,
+    ).catch(() => {})
   }
   return data.content?.[0]?.text || ''
 }
@@ -768,7 +785,9 @@ async function generateAxialCodesWithClaude(
  */
 async function generateAxialCodesWithOpenAI(
   prompt: string,
-  config: JudgeConfig
+  config: JudgeConfig,
+  options: JudgeExecutionOptions = {},
+  budgetDecision?: AgentBudgetDecision,
 ): Promise<string> {
   const apiKey = process.env.OPENAI_API_KEY
   
@@ -804,7 +823,18 @@ async function generateAxialCodesWithOpenAI(
   const data = await response.json()
   const usage = data.usage as Usage | undefined
   if (usage) {
-    recordOpenAICost(usage, config.model, undefined, { operation: 'axial_codes' }).catch(() => {})
+    recordOpenAICost(
+      usage,
+      config.model,
+      options.reference,
+      {
+        operation: options.operation ?? AXIAL_CODES_OPERATION,
+        budget_status: budgetDecision?.status,
+        budget_estimated_cost_usd: budgetDecision?.estimatedCostUsd,
+        budget_rule_key: budgetDecision?.rule.key,
+      },
+      options.agentRunId ?? undefined,
+    ).catch(() => {})
   }
   return data.choices?.[0]?.message?.content || ''
 }
@@ -815,20 +845,38 @@ async function generateAxialCodesWithOpenAI(
  */
 export async function generateAxialCodes(
   openCodes: OpenCodeWithContext[],
-  config: JudgeConfig = DEFAULT_JUDGE_CONFIG
+  config: JudgeConfig = DEFAULT_JUDGE_CONFIG,
+  options: JudgeExecutionOptions = {},
 ): Promise<AxialCodeGenerationResult> {
   if (openCodes.length === 0) {
     return { axial_codes: [] }
   }
   
   const prompt = buildAxialCodingPrompt(openCodes)
+  const operation = options.operation ?? AXIAL_CODES_OPERATION
+  const budgetDecision = evaluateLlmJudgeBudget({
+    prompt,
+    model: config.model,
+    maxTokens: AXIAL_CODES_MAX_TOKENS,
+    runtime: options.runtime ?? 'manual',
+    operation,
+  })
+  await recordLlmJudgeBudgetDecision({
+    agentRunId: options.agentRunId,
+    sessionId: options.reference?.id,
+    operation,
+    decision: budgetDecision,
+  })
+  if (budgetDecision.status === 'blocked') {
+    throw new LlmJudgeBudgetError(budgetDecision.reason)
+  }
   
   let responseText: string
   
   if (config.provider === 'anthropic') {
-    responseText = await generateAxialCodesWithClaude(prompt, config)
+    responseText = await generateAxialCodesWithClaude(prompt, config, options, budgetDecision)
   } else {
-    responseText = await generateAxialCodesWithOpenAI(prompt, config)
+    responseText = await generateAxialCodesWithOpenAI(prompt, config, options, budgetDecision)
   }
   
   return parseAxialCodeResponse(responseText, openCodes)
@@ -1078,7 +1126,9 @@ function parseErrorDiagnosisResponse(response: string): ErrorDiagnosis {
  */
 async function diagnoseErrorWithClaude(
   prompt: string,
-  config: JudgeConfig
+  config: JudgeConfig,
+  options: JudgeExecutionOptions = {},
+  budgetDecision?: AgentBudgetDecision,
 ): Promise<string> {
   const apiKey = process.env.ANTHROPIC_API_KEY
   
@@ -1110,7 +1160,18 @@ async function diagnoseErrorWithClaude(
   const data = await response.json()
   const usage = data.usage as Usage | undefined
   if (usage) {
-    recordAnthropicCost(usage, config.model, undefined, { operation: 'diagnose' }).catch(() => {})
+    recordAnthropicCost(
+      usage,
+      config.model,
+      options.reference,
+      {
+        operation: options.operation ?? DIAGNOSE_OPERATION,
+        budget_status: budgetDecision?.status,
+        budget_estimated_cost_usd: budgetDecision?.estimatedCostUsd,
+        budget_rule_key: budgetDecision?.rule.key,
+      },
+      options.agentRunId ?? undefined,
+    ).catch(() => {})
   }
   return data.content?.[0]?.text || ''
 }
@@ -1120,7 +1181,9 @@ async function diagnoseErrorWithClaude(
  */
 async function diagnoseErrorWithOpenAI(
   prompt: string,
-  config: JudgeConfig
+  config: JudgeConfig,
+  options: JudgeExecutionOptions = {},
+  budgetDecision?: AgentBudgetDecision,
 ): Promise<string> {
   const apiKey = process.env.OPENAI_API_KEY
   
@@ -1156,7 +1219,18 @@ async function diagnoseErrorWithOpenAI(
   const data = await response.json()
   const usage = data.usage as Usage | undefined
   if (usage) {
-    recordOpenAICost(usage, config.model, undefined, { operation: 'diagnose' }).catch(() => {})
+    recordOpenAICost(
+      usage,
+      config.model,
+      options.reference,
+      {
+        operation: options.operation ?? DIAGNOSE_OPERATION,
+        budget_status: budgetDecision?.status,
+        budget_estimated_cost_usd: budgetDecision?.estimatedCostUsd,
+        budget_rule_key: budgetDecision?.rule.key,
+      },
+      options.agentRunId ?? undefined,
+    ).catch(() => {})
   }
   return data.choices?.[0]?.message?.content || ''
 }
@@ -1169,16 +1243,34 @@ export async function diagnoseError(
   session: SessionData,
   evaluation: EvaluationData,
   systemPrompt?: string,
-  config: JudgeConfig = DEFAULT_JUDGE_CONFIG
+  config: JudgeConfig = DEFAULT_JUDGE_CONFIG,
+  options: JudgeExecutionOptions = {},
 ): Promise<ErrorDiagnosis> {
   const prompt = buildErrorDiagnosisPrompt(session, evaluation, systemPrompt)
+  const operation = options.operation ?? DIAGNOSE_OPERATION
+  const budgetDecision = evaluateLlmJudgeBudget({
+    prompt,
+    model: config.model,
+    maxTokens: DIAGNOSE_MAX_TOKENS,
+    runtime: options.runtime ?? 'manual',
+    operation,
+  })
+  await recordLlmJudgeBudgetDecision({
+    agentRunId: options.agentRunId,
+    sessionId: options.reference?.id ?? session.session_id,
+    operation,
+    decision: budgetDecision,
+  })
+  if (budgetDecision.status === 'blocked') {
+    throw new LlmJudgeBudgetError(budgetDecision.reason)
+  }
   
   let responseText: string
   
   if (config.provider === 'anthropic') {
-    responseText = await diagnoseErrorWithClaude(prompt, config)
+    responseText = await diagnoseErrorWithClaude(prompt, config, options, budgetDecision)
   } else {
-    responseText = await diagnoseErrorWithOpenAI(prompt, config)
+    responseText = await diagnoseErrorWithOpenAI(prompt, config, options, budgetDecision)
   }
   
   return parseErrorDiagnosisResponse(responseText)

--- a/lib/source-validator/llm-judge.test.ts
+++ b/lib/source-validator/llm-judge.test.ts
@@ -1,5 +1,24 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
+const mocks = vi.hoisted(() => ({
+  recordAgentStep: vi.fn(),
+  recordAgentEvent: vi.fn(),
+  recordAnthropicCost: vi.fn(),
+}))
+
+vi.mock('@/lib/agent-run', () => ({
+  recordAgentStep: mocks.recordAgentStep,
+  recordAgentEvent: mocks.recordAgentEvent,
+}))
+
+vi.mock('@/lib/cost-calculator', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/cost-calculator')>()
+  return {
+    ...actual,
+    recordAnthropicCost: mocks.recordAnthropicCost,
+  }
+})
+
 import { judgeBatch, PROMPT_VERSION, JUDGE_VERSION, __internal } from './llm-judge'
 import type { ExcerptFaithfulnessClaim } from './llm-judge'
 
@@ -65,6 +84,9 @@ describe('judgeBatch — live mode (fetch mocked)', () => {
 
   beforeEach(() => {
     process.env.ANTHROPIC_API_KEY = 'test-key-abc'
+    mocks.recordAgentStep.mockResolvedValue({ id: 'step-1' })
+    mocks.recordAgentEvent.mockResolvedValue({ id: 'event-1' })
+    mocks.recordAnthropicCost.mockResolvedValue(undefined)
   })
   afterEach(() => {
     if (ORIGINAL_KEY === undefined) delete process.env.ANTHROPIC_API_KEY
@@ -139,6 +161,43 @@ describe('judgeBatch — live mode (fetch mocked)', () => {
   it('fails fast if ANTHROPIC_API_KEY is missing', async () => {
     delete process.env.ANTHROPIC_API_KEY
     await expect(judgeBatch([base], {})).rejects.toThrow(/ANTHROPIC_API_KEY/)
+  })
+
+  it('records budget warnings for high-cost traced batches', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        content: [
+          {
+            text: JSON.stringify([
+              { id: 'row-1', supported: 'yes', quantified: 'yes', verdict: 'faithful', reason: 'ok', confidence: 0.9 },
+            ]),
+          },
+        ],
+        usage: { input_tokens: 10_000, output_tokens: 1_000 },
+      }),
+      text: async () => '',
+    }) as unknown as typeof fetch
+    const oversized = {
+      ...base,
+      excerpt: 'x'.repeat(8_000_000),
+    }
+
+    await judgeBatch([oversized], {
+      fetchImpl,
+      model: 'claude-3-opus-20240229',
+      agentRunId: 'agent-run-1',
+      reference: { type: 'source_validation', id: 'source-validation-1' },
+    })
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    expect(mocks.recordAgentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'agent-run-1',
+        eventType: 'budget_check',
+        severity: 'warning',
+      }),
+    )
   })
 
   it('fills in "insufficient" placeholders for omitted ids', async () => {

--- a/lib/source-validator/llm-judge.ts
+++ b/lib/source-validator/llm-judge.ts
@@ -16,7 +16,9 @@
  *   - Returns usage + cost so the API route can log it per run.
  */
 
-import { computeAnthropicCost, type Usage } from '@/lib/cost-calculator'
+import { computeAnthropicCost, recordAnthropicCost, type Usage } from '@/lib/cost-calculator'
+import { evaluateAgentBudget, type AgentBudgetDecision } from '@/lib/agent-budget-policy'
+import { recordAgentEvent, recordAgentStep, type AgentRuntime } from '@/lib/agent-run'
 
 // -----------------------------------------------------------------------------
 // Version constants
@@ -75,6 +77,10 @@ export interface JudgeBatchOptions {
   timeoutMs?: number
   /** Inject a fetch for tests. */
   fetchImpl?: typeof fetch
+  /** Optional Agent Ops run for traced admin validation runs. */
+  agentRunId?: string | null
+  runtime?: AgentRuntime
+  reference?: { type: string; id: string }
 }
 
 export interface JudgeBatchResult {
@@ -117,6 +123,53 @@ Derive verdict from (a) and (b):
 Respond with a JSON array (no markdown fences, no prose). Each element: {"id": string, "supported": "yes"|"no", "quantified": "yes"|"no"|"approximate"|"not_applicable", "verdict": "faithful"|"unfaithful"|"insufficient", "reason": string (<=25 words), "confidence": number between 0 and 1}
 
 Preserve input order. Keep reasons factual and concise. Never invent numbers.`
+
+const SOURCE_VALIDATOR_OPERATION = 'source_validator_llm_judge'
+const SOURCE_VALIDATOR_MAX_TOKENS = 1500
+
+function estimateTokensFromText(text: string): number {
+  return Math.ceil(text.length / 4)
+}
+
+async function recordSourceValidatorBudgetDecision(args: {
+  agentRunId?: string | null
+  referenceId?: string | null
+  decision: AgentBudgetDecision
+}) {
+  if (!args.agentRunId) return
+
+  const metadata = {
+    reference_id: args.referenceId ?? null,
+    operation: SOURCE_VALIDATOR_OPERATION,
+    budget_status: args.decision.status,
+    budget_rule_key: args.decision.rule.key,
+    estimated_cost_usd: args.decision.estimatedCostUsd,
+    warning_usd: args.decision.warningUsd,
+    limit_usd: args.decision.limitUsd,
+  }
+
+  await recordAgentStep({
+    runId: args.agentRunId,
+    stepKey: 'budget_check',
+    name: 'Checked source validation LLM judge budget',
+    status: args.decision.status === 'blocked' ? 'failed' : 'completed',
+    outputSummary: args.decision.reason,
+    costUsd: args.decision.estimatedCostUsd,
+    metadata,
+    idempotencyKey: `${args.agentRunId}:source_validator_llm_judge:${args.referenceId ?? 'batch'}:budget_check`,
+  }).catch((err) => console.warn('[source-validator/llm-judge] agent budget step failed:', err))
+
+  if (args.decision.status !== 'allowed') {
+    await recordAgentEvent({
+      runId: args.agentRunId,
+      eventType: 'budget_check',
+      severity: args.decision.status === 'blocked' ? 'error' : 'warning',
+      message: args.decision.reason,
+      metadata,
+      idempotencyKey: `${args.agentRunId}:source_validator_llm_judge:${args.referenceId ?? 'batch'}:budget_check:${args.decision.status}`,
+    }).catch((err) => console.warn('[source-validator/llm-judge] agent budget event failed:', err))
+  }
+}
 
 function buildUserPrompt(items: ExcerptFaithfulnessClaim[]): string {
   const lines: string[] = []
@@ -300,6 +353,21 @@ export async function judgeBatch(
 
   const fetchImpl = options.fetchImpl ?? fetch
   const userPrompt = buildUserPrompt(items)
+  const budgetDecision = evaluateAgentBudget({
+    runtime: options.runtime ?? 'manual',
+    model,
+    estimatedInputTokens: estimateTokensFromText(`${SYSTEM_PROMPT}\n${userPrompt}`),
+    maxTokens: SOURCE_VALIDATOR_MAX_TOKENS,
+    metadata: { operation: SOURCE_VALIDATOR_OPERATION },
+  })
+  await recordSourceValidatorBudgetDecision({
+    agentRunId: options.agentRunId,
+    referenceId: options.reference?.id,
+    decision: budgetDecision,
+  })
+  if (budgetDecision.status === 'blocked') {
+    throw new Error(budgetDecision.reason)
+  }
 
   let lastError: Error | null = null
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
@@ -336,6 +404,20 @@ export async function judgeBatch(
       const verdicts = parseBatchResponse(raw, items)
       const usage: Usage = data.usage ?? { input_tokens: 0, output_tokens: 0 }
       const cost_usd = computeAnthropicCost(usage, model)
+      if (usage && options.agentRunId) {
+        recordAnthropicCost(
+          usage,
+          model,
+          options.reference,
+          {
+            operation: SOURCE_VALIDATOR_OPERATION,
+            budget_status: budgetDecision.status,
+            budget_estimated_cost_usd: budgetDecision.estimatedCostUsd,
+            budget_rule_key: budgetDecision.rule.key,
+          },
+          options.agentRunId,
+        ).catch(() => {})
+      }
 
       return {
         verdicts,

--- a/lib/testing/chat-agent.ts
+++ b/lib/testing/chat-agent.ts
@@ -14,6 +14,7 @@ import type {
   LLMProvider,
   DiagnosticStep
 } from './types'
+import { evaluateAgentBudget } from '@/lib/agent-budget-policy'
 
 // ============================================================================
 // System Prompts
@@ -333,7 +334,17 @@ export class ChatAgent {
     if (!apiKey) {
       throw new Error('OPENAI_API_KEY not configured')
     }
-    
+    const budgetDecision = evaluateAgentBudget({
+      runtime: 'manual',
+      model,
+      estimatedInputTokens: Math.ceil(messages.map((m) => m.content).join('\n').length / 4),
+      maxTokens: 200,
+      metadata: { operation: 'testing_chat_agent' },
+    })
+    if (budgetDecision.status === 'blocked') {
+      throw new Error(budgetDecision.reason)
+    }
+
     const response = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
       headers: {
@@ -384,6 +395,17 @@ export class ChatAgent {
         role: m.role as 'user' | 'assistant',
         content: m.content
       }))
+
+    const budgetDecision = evaluateAgentBudget({
+      runtime: 'manual',
+      model,
+      estimatedInputTokens: Math.ceil(messages.map((m) => m.content).join('\n').length / 4),
+      maxTokens: 200,
+      metadata: { operation: 'testing_chat_agent' },
+    })
+    if (budgetDecision.status === 'blocked') {
+      throw new Error(budgetDecision.reason)
+    }
     
     const response = await fetch('https://api.anthropic.com/v1/messages', {
       method: 'POST',

--- a/lib/testing/remediation.ts
+++ b/lib/testing/remediation.ts
@@ -18,6 +18,7 @@ import type {
 import { createClient } from '@supabase/supabase-js'
 import { n8nWebhookUrl } from '../n8n'
 import { testDb } from './test-db-cast'
+import { evaluateAgentBudget } from '@/lib/agent-budget-policy'
 
 // ============================================================================
 // Configuration
@@ -27,6 +28,25 @@ const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!
 const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN
 const GITHUB_REPO = process.env.GITHUB_REPO || 'owner/my-portfolio'
+
+function assertTestingLlmBudgetAllowed(input: {
+  prompt: string
+  model: string
+  maxTokens?: number
+  operation: string
+}) {
+  const decision = evaluateAgentBudget({
+    runtime: 'manual',
+    model: input.model,
+    estimatedInputTokens: Math.ceil(input.prompt.length / 4),
+    maxTokens: input.maxTokens ?? 1000,
+    metadata: { operation: input.operation },
+  })
+  if (decision.status === 'blocked') {
+    throw new Error(decision.reason)
+  }
+  return decision
+}
 
 // ============================================================================
 // Remediation Engine
@@ -451,6 +471,12 @@ Respond with JSON in this format:
 }`
 
     try {
+      assertTestingLlmBudgetAllowed({
+        prompt,
+        model: 'gpt-4o',
+        maxTokens: 1000,
+        operation: 'testing_fix_generation',
+      })
       const response = await fetch('https://api.openai.com/v1/chat/completions', {
         method: 'POST',
         headers: {
@@ -516,6 +542,12 @@ Provide a more detailed analysis in JSON format:
 }`
 
     try {
+      assertTestingLlmBudgetAllowed({
+        prompt,
+        model: 'gpt-4o-mini',
+        maxTokens: 1000,
+        operation: 'testing_analysis_enhancement',
+      })
       const response = await fetch('https://api.openai.com/v1/chat/completions', {
         method: 'POST',
         headers: {


### PR DESCRIPTION
## Summary
- closes the remaining Phase 10 LLM/budget cleanup surfaces by adding pre-flight budget checks and trace linkage for Chat Eval axial-code generation and diagnosis
- adds Agent Ops tracing, budget decisions, and cost linkage for Value Evidence source validation LLM judging
- adds pre-flight budget guards to dev-only testing LLM helpers
- updates Agent Operations roadmap docs to mark the cleanup surfaces as in review

## Validation
- `npm test -- --run lib/llm-judge-budget.test.ts lib/source-validator/llm-judge.test.ts app/api/admin/llm-judge/route.test.ts`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- `npm run build`
- pre-push `npm run db:health-check` passed against PROD read-only health check

## Notes
- `npm run build` still emits the known dev outbound n8n warning when local env has outbound webhooks enabled.
- This PR is draft for Integration Captain merge sequencing.
