### PR TITLE
[codex] add agent run recovery requests

### DIFF
--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -181,6 +181,7 @@ type MissionSnapshot = {
     source_label: string
     routed: boolean
     routed_run_id: string | null
+    routed_kind: string | null
     next_action: string
     href: string
   }>
@@ -229,6 +230,7 @@ export default function AgentOperationsPage() {
   const [actionResult, setActionResult] = useState<{ label: string; runId: string } | null>(null)
   const [inboxRoutingId, setInboxRoutingId] = useState<string | null>(null)
   const [engagementLoadingKey, setEngagementLoadingKey] = useState<string | null>(null)
+  const [recoveryLoadingRunId, setRecoveryLoadingRunId] = useState<string | null>(null)
 
   const authedFetch = useCallback(async (path: string, init: RequestInit = {}) => {
     const session = await getCurrentSession()
@@ -390,6 +392,28 @@ export default function AgentOperationsPage() {
     }
   }
 
+  async function requestRunRecovery(item: MissionSnapshot['dead_letter_queue'][number]) {
+    setRecoveryLoadingRunId(item.run_id)
+    setActionResult(null)
+    setError(null)
+    try {
+      const response = await authedFetch(`/api/admin/agents/runs/${item.run_id}/retry`, {
+        method: 'POST',
+        body: JSON.stringify({
+          note: `Mission Control recovery request for ${item.status} ${item.runtime} run.`,
+        }),
+      })
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`)
+      setActionResult({ label: `recovery for ${item.agent_name}`, runId: body.run_id })
+      await loadMissionControl()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to request recovery')
+    } finally {
+      setRecoveryLoadingRunId(null)
+    }
+  }
+
   const topAgents = useMemo(
     () => snapshot?.roster.flatMap((pod) => pod.agents).filter((agent) => agent.status !== 'planned').slice(0, 10) ?? [],
     [snapshot],
@@ -546,7 +570,11 @@ export default function AgentOperationsPage() {
 
           <EngagementQueuePanel items={snapshot?.engagement_queue ?? []} />
 
-          <DeadLetterPanel items={snapshot?.dead_letter_queue ?? []} />
+          <DeadLetterPanel
+            items={snapshot?.dead_letter_queue ?? []}
+            recoveryLoadingRunId={recoveryLoadingRunId}
+            onRecover={requestRunRecovery}
+          />
 
           <section className="mt-5 grid grid-cols-1 gap-5 xl:grid-cols-[1fr_0.8fr]">
             <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
@@ -990,7 +1018,15 @@ function EngagementQueuePanel({ items }: { items: MissionSnapshot['engagement_qu
   )
 }
 
-function DeadLetterPanel({ items }: { items: MissionSnapshot['dead_letter_queue'] }) {
+function DeadLetterPanel({
+  items,
+  recoveryLoadingRunId,
+  onRecover,
+}: {
+  items: MissionSnapshot['dead_letter_queue']
+  recoveryLoadingRunId: string | null
+  onRecover: (item: MissionSnapshot['dead_letter_queue'][number]) => void
+}) {
   if (!items.length) return null
 
   return (
@@ -1010,10 +1046,9 @@ function DeadLetterPanel({ items }: { items: MissionSnapshot['dead_letter_queue'
 
       <div className="mt-3 grid grid-cols-1 gap-2 lg:grid-cols-2">
         {items.map((item) => (
-          <Link
+          <div
             key={item.run_id}
-            href={item.routed_run_id ? `/admin/agents/runs/${item.routed_run_id}` : item.href}
-            className="rounded-lg border border-silicon-slate/50 bg-black/10 p-3 text-sm hover:border-radiant-gold/50"
+            className="rounded-lg border border-silicon-slate/50 bg-black/10 p-3 text-sm"
           >
             <div className="flex flex-wrap items-center gap-2">
               <span className="font-medium">{item.title}</span>
@@ -1034,8 +1069,28 @@ function DeadLetterPanel({ items }: { items: MissionSnapshot['dead_letter_queue'
               <QueueDetail label="Age" value={`${item.age_hours}h`} />
             </div>
             <p className="mt-3 line-clamp-2 text-muted-foreground">{item.reason}</p>
-            <p className="mt-2 text-xs text-radiant-gold">{item.next_action}</p>
-          </Link>
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              <Link
+                href={item.routed_run_id ? `/admin/agents/runs/${item.routed_run_id}` : item.href}
+                className="inline-flex items-center gap-1 rounded-md border border-radiant-gold/40 bg-radiant-gold/10 px-2.5 py-1 text-xs text-radiant-gold hover:bg-radiant-gold/15"
+              >
+                {item.routed ? 'Open routed trace' : 'Open source trace'}
+                <ArrowRight size={12} />
+              </Link>
+              {!item.routed ? (
+                <button
+                  type="button"
+                  onClick={() => onRecover(item)}
+                  disabled={recoveryLoadingRunId === item.run_id}
+                  className="inline-flex items-center gap-1 rounded-md border border-silicon-slate/60 bg-background/50 px-2.5 py-1 text-xs hover:border-radiant-gold/50 disabled:opacity-60"
+                >
+                  <RefreshCw size={12} className={recoveryLoadingRunId === item.run_id ? 'animate-spin' : ''} />
+                  Request retry
+                </button>
+              ) : null}
+              <span className="text-xs text-muted-foreground">{item.next_action}</span>
+            </div>
+          </div>
         ))}
       </div>
     </section>

--- a/app/api/admin/agents/runs/[runId]/retry/route.test.ts
+++ b/app/api/admin/agents/runs/[runId]/retry/route.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  createAgentRunRecoveryRequest: vi.fn(),
+  from: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-run-recovery', () => {
+  return {
+    isRecoverableAgentRunStatus: (status: string) =>
+      status === 'failed' || status === 'stale' || status === 'cancelled',
+    createAgentRunRecoveryRequest: mocks.createAgentRunRecoveryRequest,
+  }
+})
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import { POST } from './route'
+
+function makeRequest(body: unknown = {}) {
+  return new Request('http://localhost/api/admin/agents/runs/source-run-1/retry', {
+    method: 'POST',
+    headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+function sourceRun(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'source-run-1',
+    agent_key: 'automation-systems',
+    runtime: 'n8n',
+    kind: 'warm_lead_scrape',
+    title: 'Warm lead scrape',
+    status: 'failed',
+    subject_type: 'workflow',
+    subject_id: 'WF-WRM-003',
+    subject_label: 'LinkedIn Warm Lead Scraper',
+    current_step: 'Normalize webhook payload',
+    error_message: 'Webhook returned 500.',
+    metadata: {},
+    ...overrides,
+  }
+}
+
+function sourceRunQuery(data = sourceRun(), error: unknown = null) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({ data, error }),
+  }
+}
+
+function recoveryQuery(data: unknown[] = []) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    contains: vi.fn().mockResolvedValue({ data, error: null }),
+  }
+}
+
+describe('POST /api/admin/agents/runs/[runId]/retry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.createAgentRunRecoveryRequest.mockResolvedValue({
+      runId: 'recovery-run-1',
+      recoveryPacketAttached: true,
+      plan: {
+        retry_attempt: 2,
+        earliest_retry_at: '2026-05-07T12:15:00.000Z',
+        target_agent_key: 'automation-systems',
+        target_agent_name: 'Automation Systems Agent',
+        execution_mode: 'read_only_recovery_request',
+      },
+    })
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(makeRequest() as never, { params: { runId: 'source-run-1' } })
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.from).not.toHaveBeenCalled()
+  })
+
+  it('creates a read-only recovery request for a failed run', async () => {
+    mocks.from
+      .mockReturnValueOnce(sourceRunQuery(sourceRun()))
+      .mockReturnValueOnce(recoveryQuery([{ id: 'prior-recovery' }]))
+
+    const response = await POST(makeRequest({ note: 'Retry after payload check.' }) as never, {
+      params: { runId: 'source-run-1' },
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      ok: true,
+      run_id: 'recovery-run-1',
+      source_run_id: 'source-run-1',
+      retry_attempt: 2,
+      earliest_retry_at: '2026-05-07T12:15:00.000Z',
+      target_agent_key: 'automation-systems',
+      target_agent_name: 'Automation Systems Agent',
+      recovery_packet_attached: true,
+      execution_mode: 'read_only_recovery_request',
+    })
+    expect(mocks.createAgentRunRecoveryRequest).toHaveBeenCalledWith(expect.objectContaining({
+      previousRecoveryCount: 1,
+      actor: expect.objectContaining({
+        subjectType: 'agent_run',
+        subjectId: 'source-run-1',
+        userId: 'admin-user',
+      }),
+      note: 'Retry after payload check.',
+    }))
+  })
+
+  it('rejects non-recoverable active runs', async () => {
+    mocks.from.mockReturnValueOnce(sourceRunQuery(sourceRun({ status: 'running' })))
+
+    const response = await POST(makeRequest() as never, { params: { runId: 'source-run-1' } })
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: 'Only failed, stale, or cancelled runs can be queued for recovery',
+    })
+    expect(mocks.createAgentRunRecoveryRequest).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/admin/agents/runs/[runId]/retry/route.ts
+++ b/app/api/admin/agents/runs/[runId]/retry/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import {
+  createAgentRunRecoveryRequest,
+  isRecoverableAgentRunStatus,
+  type AgentRunRecoverySource,
+} from '@/lib/agent-run-recovery'
+import { supabaseAdmin } from '@/lib/supabase'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * POST /api/admin/agents/runs/:runId/retry
+ *
+ * Creates a traced, read-only recovery request for a failed/stale/cancelled
+ * Agent Ops run. This does not re-run production automation directly.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { runId: string } },
+) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+  if (!supabaseAdmin) {
+    return NextResponse.json({ error: 'Database not available' }, { status: 500 })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as { note?: unknown }
+  const note = typeof body.note === 'string' ? body.note.trim().slice(0, 500) : null
+
+  const { data: run, error } = await supabaseAdmin
+    .from('agent_runs')
+    .select('id, agent_key, runtime, kind, title, status, subject_type, subject_id, subject_label, current_step, error_message, metadata')
+    .eq('id', params.runId)
+    .single()
+
+  if (error || !run) {
+    return NextResponse.json({ error: 'Run not found' }, { status: 404 })
+  }
+
+  const sourceRun = run as AgentRunRecoverySource
+  if (!isRecoverableAgentRunStatus(sourceRun.status)) {
+    return NextResponse.json(
+      { error: 'Only failed, stale, or cancelled runs can be queued for recovery' },
+      { status: 400 },
+    )
+  }
+
+  const previousRecoveries = await supabaseAdmin
+    .from('agent_runs')
+    .select('id')
+    .eq('kind', 'agent_recovery_request')
+    .contains('metadata', { source_run_id: params.runId })
+
+  if (previousRecoveries.error) {
+    return NextResponse.json({ error: 'Failed to inspect prior recovery requests' }, { status: 500 })
+  }
+
+  try {
+    const result = await createAgentRunRecoveryRequest({
+      sourceRun,
+      previousRecoveryCount: previousRecoveries.data?.length ?? 0,
+      actor: {
+        subjectType: 'agent_run',
+        subjectId: params.runId,
+        subjectLabel: `Recovery for ${sourceRun.title}`,
+        userId: auth.user.id,
+      },
+      note,
+    })
+
+    return NextResponse.json({
+      ok: true,
+      run_id: result.runId,
+      source_run_id: params.runId,
+      retry_attempt: result.plan.retry_attempt,
+      earliest_retry_at: result.plan.earliest_retry_at,
+      target_agent_key: result.plan.target_agent_key,
+      target_agent_name: result.plan.target_agent_name,
+      recovery_packet_attached: result.recoveryPacketAttached,
+      execution_mode: result.plan.execution_mode,
+    })
+  } catch (err) {
+    console.error('[agent-run-retry] failed:', err)
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Failed to queue recovery request' },
+      { status: 500 },
+    )
+  }
+}

--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -279,6 +279,7 @@ Current progress:
 - Admin Chat Eval LLM judge evaluation now starts a manual Agent Ops trace, checks the manual-runtime budget before Anthropic/OpenAI dispatch, and links judge cost events back to the trace.
 - Admin Chat Eval axial-code generation and error diagnosis now start manual Agent Ops traces, check budget before Anthropic/OpenAI dispatch, and link cost events back to the trace.
 - Value Evidence source validation and dev testing LLM helpers now run pre-flight budget checks before direct provider calls.
+- Failed, stale, and cancelled Agent Ops traces can now create a read-only recovery request with retry attempt, backoff, earliest-retry metadata, and an attached recovery packet. This routes dead-letter work without re-running production automation from Mission Control.
 
 ## Cross-Phase Definition Of Done
 

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -205,6 +205,10 @@ This keeps OpenCode/OpenClaw out of production automation until installation, au
 
 Use `POST /api/admin/agents/runs/stale-sweep` or the **Sweep stale** button on `/admin/agents/runs` to mark queued/running runs as `stale` when they pass `stale_after` or the default active-run threshold. The sweep is runtime-neutral across `codex`, `n8n`, `hermes`, `opencode`, and `manual` traces, and reports checked/marked counts by runtime. Runs waiting for approval are intentionally excluded so human checkpoints do not auto-expire as infrastructure failures.
 
+## Dead-Letter Recovery Requests
+
+Mission Control derives the Dead-Letter Monitor from failed and stale Agent Ops traces. Use `POST /api/admin/agents/runs/[runId]/retry` or **Request retry** on the Dead-Letter Monitor to create a read-only `agent_recovery_request` trace. The recovery request records retry attempt, capped backoff, earliest retry time, source run, target agent, and a recovery packet artifact. It does not re-run production automation directly; the actual retry remains behind the known workflow and approval gates.
+
 ## Operating Signals
 
 Mission Control surfaces the latest morning review and deployment watcher traces as compact Operating Signals:

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -35,6 +35,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 4. Reporting and hardening
    - [x] Add all-runtime stale-run detection.
    - [x] Add derived dead-letter handling for failed and stale runs without introducing a separate queue table.
+   - [x] Add read-only recovery requests for dead-letter runs with retry/backoff metadata.
    - [x] Add cost summaries by runtime, agent, workflow, client/project, and artifact type.
    - [x] Keep morning review and deployment watcher outputs visible in Agent Operations.
    - [x] Document legacy workflow run tables as domain detail or future trace-link migration candidates.
@@ -59,6 +60,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 - [x] Approval-backed execution payloads and decision metadata in review.
 - [x] n8n trace callback envelope and generic stage callback endpoint in review.
 - [x] Dead-letter monitor for failed/stale traces in review.
+- [x] Dead-letter recovery request action and routed retry packet in review.
 - [x] All-runtime stale sweep coverage reporting in review.
 - [x] Cost Intelligence summary by runtime, agent, workflow, client/project, and artifact type in review.
 - [x] Operating Signals for morning review and deployment watcher traces in review.

--- a/docs/agentic-patterns.md
+++ b/docs/agentic-patterns.md
@@ -336,13 +336,13 @@ Each section follows the same template: *Definition · Where we use it today · 
 - Runtime gates: [`lib/n8n-runtime-flags.ts`](../lib/n8n-runtime-flags.ts) (`isN8nOutboundDisabled`, `isMockN8nEnabled`).
 - User-facing error hygiene enforced by [`.cursor/rules/no-expose-errors-to-users.mdc`](../.cursor/rules/no-expose-errors-to-users.mdc).
 - Trigger functions in [`lib/n8n.ts`](../lib/n8n.ts) return `{ triggered, message }` shape.
-- Agent Operations marks failed and stale runs, derives a Dead-Letter Monitor from those traces, and lets stale sweeps report checked/marked counts by runtime.
+- Agent Operations marks failed and stale runs, derives a Dead-Letter Monitor from those traces, lets stale sweeps report checked/marked counts by runtime, and can create read-only recovery requests with retry/backoff metadata.
 
 **Coverage.** Partial.
 
 **Gaps.**
 - No standard retry/backoff helper for LLM calls or n8n triggers — each call site reinvents `try/catch`.
-- Dead-letter visibility exists for Agent Ops traces, but retry/backoff and remediation ownership are still call-site specific.
+- Dead-letter visibility and routed recovery requests exist for Agent Ops traces, but provider-call retry wrappers are still call-site specific.
 
 **Retrofit backlog.** Ticket [#3](#top-retrofit-tickets) — retry/backoff helper.
 

--- a/lib/agent-mission-control.test.ts
+++ b/lib/agent-mission-control.test.ts
@@ -195,11 +195,44 @@ describe('Agent Mission Control helpers', () => {
       agent_name: 'Automation Systems Agent',
       routed: true,
       routed_run_id: 'routed-engagement',
+      routed_kind: 'agent_engagement_request',
       next_action: 'Review routed engagement request.',
     })
     expect(queue.find((item) => item.run_id === 'stale-run')).toMatchObject({
       routed: false,
       next_action: 'Route stale run owner from Agent Inbox.',
+    })
+  })
+
+  it('treats recovery requests as routed dead-letter work', () => {
+    const failedRun = run({
+      id: 'failed-run',
+      agent_key: 'automation-systems',
+      runtime: 'n8n',
+      status: 'failed',
+      title: 'Warm lead sync',
+      error_message: 'Webhook returned 500.',
+    })
+    const retryRequest = run({
+      id: 'retry-request',
+      kind: 'agent_recovery_request',
+      status: 'completed',
+      metadata: {
+        requested_agent: 'automation-systems',
+        source_run_id: 'failed-run',
+        retry_attempt: 1,
+      },
+    })
+
+    const queue = buildAgentDeadLetterQueue([failedRun, retryRequest])
+
+    expect(queue).toHaveLength(1)
+    expect(queue[0]).toMatchObject({
+      run_id: 'failed-run',
+      routed: true,
+      routed_run_id: 'retry-request',
+      routed_kind: 'agent_recovery_request',
+      next_action: 'Review retry request.',
     })
   })
 

--- a/lib/agent-mission-control.ts
+++ b/lib/agent-mission-control.ts
@@ -91,6 +91,7 @@ export type AgentDeadLetterItem = {
   source_label: string
   routed: boolean
   routed_run_id: string | null
+  routed_kind: string | null
   next_action: string
   href: string
 }
@@ -555,7 +556,7 @@ export function buildAgentInbox(input: {
 
 export function buildAgentEngagementQueue(runs: AgentRunRow[]): AgentEngagementQueueItem[] {
   return runs
-    .filter((run) => run.kind === 'agent_engagement_request')
+    .filter((run) => run.kind === 'agent_engagement_request' || run.kind === 'agent_recovery_request')
     .map((run) => {
       const agent = findAgent(requestedAgentKey(run))
       const agentName = agent?.name ?? 'Chief of Staff Agent'
@@ -587,7 +588,7 @@ export function buildAgentDeadLetterQueue(
 ): AgentDeadLetterItem[] {
   const routedBySourceRun = new Map<string, AgentRunRow>()
   for (const run of runs) {
-    if (run.kind !== 'agent_engagement_request') continue
+    if (run.kind !== 'agent_engagement_request' && run.kind !== 'agent_recovery_request') continue
     const sourceRunId = stringMetadataValue(run.metadata, 'source_run_id')
     if (!sourceRunId || routedBySourceRun.has(sourceRunId)) continue
     routedBySourceRun.set(sourceRunId, run)
@@ -613,8 +614,11 @@ export function buildAgentDeadLetterQueue(
         source_label: sourceLabelForRun(run),
         routed: Boolean(routedRun),
         routed_run_id: routedRun?.id ?? null,
+        routed_kind: routedRun?.kind ?? null,
         next_action: routedRun
-          ? 'Review routed engagement request.'
+          ? routedRun.kind === 'agent_recovery_request'
+            ? 'Review retry request.'
+            : 'Review routed engagement request.'
           : run.status === 'stale'
             ? 'Route stale run owner from Agent Inbox.'
             : 'Route failure triage from Agent Inbox.',

--- a/lib/agent-run-recovery.test.ts
+++ b/lib/agent-run-recovery.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/agent-run', () => ({
+  startAgentRun: vi.fn(),
+  recordAgentEvent: vi.fn(),
+  attachAgentArtifact: vi.fn(),
+  endAgentRun: vi.fn(),
+}))
+
+import {
+  buildAgentRunRecoveryPlan,
+  createAgentRunRecoveryRequest,
+  isRecoverableAgentRunStatus,
+  type AgentRunRecoverySource,
+} from '@/lib/agent-run-recovery'
+import * as agentRun from '@/lib/agent-run'
+
+function sourceRun(overrides: Partial<AgentRunRecoverySource> = {}): AgentRunRecoverySource {
+  return {
+    id: 'source-run-1',
+    agent_key: 'automation-systems',
+    runtime: 'n8n',
+    kind: 'warm_lead_scrape',
+    title: 'Warm lead scrape',
+    status: 'failed',
+    subject_type: 'workflow',
+    subject_id: 'WF-WRM-003',
+    subject_label: 'LinkedIn Warm Lead Scraper',
+    current_step: 'Normalize webhook payload',
+    error_message: 'Webhook returned 500.',
+    metadata: {},
+    ...overrides,
+  }
+}
+
+describe('agent run recovery planning', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(agentRun.startAgentRun).mockResolvedValue({ id: 'recovery-run-1' })
+    vi.mocked(agentRun.recordAgentEvent).mockResolvedValue({ id: 'event-1' })
+    vi.mocked(agentRun.attachAgentArtifact).mockResolvedValue({ id: 'artifact-1' })
+    vi.mocked(agentRun.endAgentRun).mockResolvedValue(undefined)
+  })
+
+  it('only treats failed, stale, and cancelled runs as recoverable', () => {
+    expect(isRecoverableAgentRunStatus('failed')).toBe(true)
+    expect(isRecoverableAgentRunStatus('stale')).toBe(true)
+    expect(isRecoverableAgentRunStatus('cancelled')).toBe(true)
+    expect(isRecoverableAgentRunStatus('completed')).toBe(false)
+    expect(isRecoverableAgentRunStatus('running')).toBe(false)
+  })
+
+  it('builds a read-only retry packet with bounded backoff metadata', () => {
+    const plan = buildAgentRunRecoveryPlan({
+      sourceRun: sourceRun(),
+      previousRecoveryCount: 2,
+      now: new Date('2026-05-07T12:00:00.000Z'),
+      note: 'Check webhook payload before retry.',
+    })
+
+    expect(plan).toMatchObject({
+      source_run_id: 'source-run-1',
+      source_status: 'failed',
+      target_agent_key: 'automation-systems',
+      target_agent_name: 'Automation Systems Agent',
+      retry_attempt: 3,
+      backoff_minutes: 60,
+      earliest_retry_at: '2026-05-07T13:00:00.000Z',
+      execution_mode: 'read_only_recovery_request',
+    })
+    expect(plan.summary_markdown).toContain('This request does not re-run production automation')
+    expect(plan.summary_markdown).toContain('Check webhook payload before retry.')
+  })
+
+  it('uses requested_agent metadata when the original run was routed through another agent', () => {
+    const plan = buildAgentRunRecoveryPlan({
+      sourceRun: sourceRun({
+        agent_key: 'manual-admin',
+        metadata: { requested_agent: 'inbox-follow-up' },
+        status: 'stale',
+      }),
+      now: new Date('2026-05-07T12:00:00.000Z'),
+    })
+
+    expect(plan.target_agent_key).toBe('inbox-follow-up')
+    expect(plan.target_agent_name).toBe('Inbox & Follow-Up Agent')
+    expect(plan.next_action).toContain('original runtime is still active')
+  })
+
+  it('rejects active or successful runs', () => {
+    expect(() =>
+      buildAgentRunRecoveryPlan({
+        sourceRun: sourceRun({ status: 'completed' }),
+      }),
+    ).toThrow('Only failed, stale, or cancelled runs can be queued for recovery')
+  })
+
+  it('creates recovery and source trace events without executing production work', async () => {
+    const result = await createAgentRunRecoveryRequest({
+      sourceRun: sourceRun(),
+      previousRecoveryCount: 0,
+      actor: {
+        subjectType: 'agent_run',
+        subjectId: 'source-run-1',
+        subjectLabel: 'Recovery for Warm lead scrape',
+        userId: 'admin-user',
+      },
+      note: 'Review source payload first.',
+      now: new Date('2026-05-07T12:00:00.000Z'),
+    })
+
+    expect(result).toMatchObject({
+      runId: 'recovery-run-1',
+      recoveryPacketAttached: true,
+      plan: {
+        retry_attempt: 1,
+        backoff_minutes: 5,
+        execution_mode: 'read_only_recovery_request',
+      },
+    })
+    expect(agentRun.startAgentRun).toHaveBeenCalledWith(expect.objectContaining({
+      kind: 'agent_recovery_request',
+      status: 'queued',
+      metadata: expect.objectContaining({
+        source_run_id: 'source-run-1',
+        executes_action: false,
+      }),
+    }))
+    expect(agentRun.recordAgentEvent).toHaveBeenCalledWith(expect.objectContaining({
+      runId: 'recovery-run-1',
+      eventType: 'agent_recovery_requested',
+    }))
+    expect(agentRun.recordAgentEvent).toHaveBeenCalledWith(expect.objectContaining({
+      runId: 'source-run-1',
+      eventType: 'agent_recovery_linked',
+      metadata: expect.objectContaining({
+        recovery_run_id: 'recovery-run-1',
+      }),
+    }))
+    expect(agentRun.endAgentRun).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'completed',
+      outcome: expect.objectContaining({
+        executes_action: false,
+      }),
+    }))
+  })
+})

--- a/lib/agent-run-recovery.ts
+++ b/lib/agent-run-recovery.ts
@@ -1,0 +1,235 @@
+import {
+  attachAgentArtifact,
+  endAgentRun,
+  recordAgentEvent,
+  startAgentRun,
+} from '@/lib/agent-run'
+import { getAgentByKey } from '@/lib/agent-organization'
+
+export type RecoverableAgentRunStatus = 'failed' | 'stale' | 'cancelled'
+
+export type AgentRunRecoverySource = {
+  id: string
+  agent_key: string | null
+  runtime: string
+  kind: string
+  title: string
+  status: string
+  subject_type: string | null
+  subject_id: string | null
+  subject_label: string | null
+  current_step: string | null
+  error_message: string | null
+  metadata: Record<string, unknown> | null
+}
+
+export type AgentRunRecoveryPlan = {
+  source_run_id: string
+  source_status: RecoverableAgentRunStatus
+  target_agent_key: string
+  target_agent_name: string
+  retry_attempt: number
+  backoff_minutes: number
+  earliest_retry_at: string
+  execution_mode: 'read_only_recovery_request'
+  next_action: string
+  summary_markdown: string
+}
+
+export type CreateAgentRunRecoveryRequestInput = {
+  sourceRun: AgentRunRecoverySource
+  previousRecoveryCount?: number
+  actor: {
+    userId?: string | null
+    subjectType: string
+    subjectId: string
+    subjectLabel: string
+  }
+  note?: string | null
+  now?: Date
+}
+
+export function isRecoverableAgentRunStatus(status: string): status is RecoverableAgentRunStatus {
+  return status === 'failed' || status === 'stale' || status === 'cancelled'
+}
+
+function boundedRetryAttempt(previousRecoveryCount: number) {
+  const normalized = Number.isFinite(previousRecoveryCount) ? Math.max(0, Math.floor(previousRecoveryCount)) : 0
+  return normalized + 1
+}
+
+function backoffMinutesForAttempt(attempt: number) {
+  if (attempt <= 1) return 5
+  if (attempt === 2) return 15
+  if (attempt === 3) return 60
+  return 240
+}
+
+function requestedAgentKey(sourceRun: AgentRunRecoverySource) {
+  const requested = sourceRun.metadata?.requested_agent
+  if (typeof requested === 'string' && requested.trim()) return requested.trim()
+  return sourceRun.agent_key || 'chief-of-staff'
+}
+
+export function buildAgentRunRecoveryPlan(input: {
+  sourceRun: AgentRunRecoverySource
+  previousRecoveryCount?: number
+  note?: string | null
+  now?: Date
+}): AgentRunRecoveryPlan {
+  const { sourceRun } = input
+  if (!isRecoverableAgentRunStatus(sourceRun.status)) {
+    throw new Error('Only failed, stale, or cancelled runs can be queued for recovery')
+  }
+
+  const agentKey = requestedAgentKey(sourceRun)
+  const agent = getAgentByKey(agentKey) ?? getAgentByKey('chief-of-staff')
+  const attempt = boundedRetryAttempt(input.previousRecoveryCount ?? 0)
+  const backoffMinutes = backoffMinutesForAttempt(attempt)
+  const now = input.now ?? new Date()
+  const earliestRetryAt = new Date(now.getTime() + backoffMinutes * 60 * 1000).toISOString()
+  const reason = sourceRun.error_message ?? sourceRun.current_step ?? `${sourceRun.runtime} run is ${sourceRun.status}.`
+  const note = input.note?.trim()
+  const nextAction =
+    sourceRun.status === 'stale'
+      ? 'Inspect the stale trace, confirm whether the original runtime is still active, then retry through the safest existing workflow path.'
+      : 'Inspect the failure trace, confirm inputs and approval boundary, then retry through the safest existing workflow path.'
+
+  const summaryMarkdown = [
+    `## Recovery Request for ${sourceRun.title}`,
+    '',
+    `**Source run:** ${sourceRun.id}`,
+    `**Source status:** ${sourceRun.status}`,
+    `**Runtime:** ${sourceRun.runtime}`,
+    `**Kind:** ${sourceRun.kind}`,
+    `**Target agent:** ${agent?.name ?? 'Chief of Staff Agent'}`,
+    `**Retry attempt:** ${attempt}`,
+    `**Backoff:** ${backoffMinutes} minute(s)`,
+    `**Earliest retry:** ${earliestRetryAt}`,
+    '',
+    '### Reason',
+    reason,
+    '',
+    '### Next action',
+    nextAction,
+    '',
+    '### Safety boundary',
+    'This request does not re-run production automation. It creates a traced recovery packet for review and keeps execution behind the existing workflow and approval gates.',
+    note ? ['', '### Operator note', note].join('\n') : '',
+  ]
+    .filter(Boolean)
+    .join('\n')
+
+  return {
+    source_run_id: sourceRun.id,
+    source_status: sourceRun.status,
+    target_agent_key: agent?.key ?? 'chief-of-staff',
+    target_agent_name: agent?.name ?? 'Chief of Staff Agent',
+    retry_attempt: attempt,
+    backoff_minutes: backoffMinutes,
+    earliest_retry_at: earliestRetryAt,
+    execution_mode: 'read_only_recovery_request',
+    next_action: nextAction,
+    summary_markdown: summaryMarkdown,
+  }
+}
+
+export async function createAgentRunRecoveryRequest(input: CreateAgentRunRecoveryRequestInput) {
+  const note = input.note?.trim().slice(0, 500) || null
+  const plan = buildAgentRunRecoveryPlan({
+    sourceRun: input.sourceRun,
+    previousRecoveryCount: input.previousRecoveryCount,
+    note,
+    now: input.now,
+  })
+
+  const run = await startAgentRun({
+    agentKey: plan.target_agent_key,
+    runtime: 'manual',
+    kind: 'agent_recovery_request',
+    title: `Recovery request: ${input.sourceRun.title}`,
+    status: 'queued',
+    subject: {
+      type: input.actor.subjectType,
+      id: input.actor.subjectId,
+      label: input.actor.subjectLabel,
+    },
+    triggerSource: 'admin_agent_run_recovery',
+    triggeredByUserId: input.actor.userId ?? null,
+    currentStep: 'Recovery request prepared',
+    metadata: {
+      route_action: 'agent_recovery_retry',
+      requested_agent: plan.target_agent_key,
+      requested_agent_name: plan.target_agent_name,
+      source_run_id: input.sourceRun.id,
+      source_status: input.sourceRun.status,
+      source_runtime: input.sourceRun.runtime,
+      source_kind: input.sourceRun.kind,
+      retry_attempt: plan.retry_attempt,
+      backoff_minutes: plan.backoff_minutes,
+      earliest_retry_at: plan.earliest_retry_at,
+      note,
+      executes_action: false,
+    },
+    idempotencyKey: `agent-recovery:${input.sourceRun.id}:${plan.retry_attempt}`,
+  })
+
+  await recordAgentEvent({
+    runId: run.id,
+    eventType: 'agent_recovery_requested',
+    severity: 'warning',
+    message: `Recovery requested for ${input.sourceRun.title}`,
+    metadata: {
+      source_run_id: input.sourceRun.id,
+      retry_attempt: plan.retry_attempt,
+      earliest_retry_at: plan.earliest_retry_at,
+      note,
+    },
+    idempotencyKey: `${run.id}:agent-recovery-requested`,
+  }).catch(() => {})
+
+  await recordAgentEvent({
+    runId: input.sourceRun.id,
+    eventType: 'agent_recovery_linked',
+    severity: 'warning',
+    message: `Recovery request created: ${run.id}`,
+    metadata: {
+      recovery_run_id: run.id,
+      retry_attempt: plan.retry_attempt,
+      earliest_retry_at: plan.earliest_retry_at,
+      target_agent_key: plan.target_agent_key,
+    },
+    idempotencyKey: `${input.sourceRun.id}:agent-recovery:${run.id}`,
+  }).catch(() => {})
+
+  const artifact = await attachAgentArtifact({
+    runId: run.id,
+    artifactType: 'agent_recovery_packet',
+    title: `${input.sourceRun.title} recovery packet`,
+    refType: 'agent_run',
+    refId: input.sourceRun.id,
+    metadata: {
+      ...plan,
+      note,
+      executes_action: false,
+    },
+    idempotencyKey: `${run.id}:agent-recovery-packet`,
+  })
+
+  await endAgentRun({
+    runId: run.id,
+    status: 'completed',
+    currentStep: 'Recovery request ready',
+    outcome: {
+      ...plan,
+      recovery_packet_attached: Boolean(artifact),
+      executes_action: false,
+    },
+  })
+
+  return {
+    runId: run.id,
+    plan,
+    recoveryPacketAttached: Boolean(artifact),
+  }
+}


### PR DESCRIPTION
## Summary
- adds a read-only recovery request flow for failed, stale, and cancelled Agent Ops traces
- exposes a Mission Control **Request retry** action in the Dead-Letter Monitor without directly re-running production automation
- records retry attempt, capped backoff, earliest retry time, source run, target agent, and a recovery packet artifact
- treats recovery requests as routed dead-letter work in Mission Control and Engagement Queue
- updates Agent Operations roadmap docs and the Agentic Patterns exception-handling note

## Validation
- `npm test -- --run lib/agent-run-recovery.test.ts lib/agent-mission-control.test.ts 'app/api/admin/agents/runs/[runId]/retry/route.test.ts' app/api/admin/agents/mission-control/route.test.ts`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- `npm run build`
- integrated browser smoke: `http://127.0.0.1:3000/admin/agents` returned 200 and redirected unauthenticated users to login
- pre-push `npm run db:health-check` passed against PROD read-only health check

## Safety Notes
- The retry endpoint creates a traced `agent_recovery_request` packet only.
- It does not trigger n8n, send messages, publish content, or mutate production workflow data.
- Actual retries remain behind known workflow and approval gates.
