### PR TITLE
ci: quiet database health workflow warnings

### DIFF
--- a/.github/workflows/database-health-check.yml
+++ b/.github/workflows/database-health-check.yml
@@ -17,6 +17,8 @@ on:
 jobs:
   health-check:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     
     steps:
       - name: Checkout code
@@ -25,33 +27,18 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       
       - name: Install dependencies
         run: npm ci
-      
-      - name: Download baseline from artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: database-baseline
-          path: .
-        continue-on-error: true
-      
+
       - name: Run database health check
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: npm run db:health-check
-      
-      - name: Upload baseline artifact
-        if: success()
-        uses: actions/upload-artifact@v4
-        with:
-          name: database-baseline
-          path: .database-baseline.json
-          retention-days: 90
-      
+
       - name: Send Slack notification on failure
         if: failure()
         uses: slackapi/slack-github-action@v1


### PR DESCRIPTION
## Summary
- run the database health workflow on Node 24
- opt GitHub JavaScript actions into the Node 24 runtime
- remove artifact download/upload steps for the tracked database baseline file

## Validation
- ruby YAML parse for .github/workflows/database-health-check.yml
- git diff --check
- npm run db:health-check
