### PR TITLE
ci: update GitHub Actions Node runtime

### DIFF
--- a/.github/workflows/database-health-check.yml
+++ b/.github/workflows/database-health-check.yml
@@ -22,10 +22,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'

--- a/.github/workflows/sync-module-to-spinoff.yml
+++ b/.github/workflows/sync-module-to-spinoff.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/verify-standalone-templates.yml
+++ b/.github/workflows/verify-standalone-templates.yml
@@ -33,7 +33,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build matrix
         id: set-matrix
@@ -60,12 +60,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Copy template to isolated directory
         run: |


### PR DESCRIPTION
## Summary
- update GitHub checkout/setup-node actions to current v6 releases
- move the remaining workflow Node pin from 20 to 24
- keep the database-health workflow on Node 24 after the artifact-noise cleanup

## Validation
- GitHub API confirmed latest actions/checkout release: v6.0.2
- GitHub API confirmed latest actions/setup-node release: v6.4.0
- ruby YAML parse for all .github/workflows/*.yml
- rg confirmed no checkout/setup-node@v4 or node-version '20' remains
- git diff --check
- npm run db:health-check
