### PR TITLE
feat: add n8n retry backoff helper

### DIFF
--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -234,7 +234,7 @@ Out of scope:
 
 ### Phase 10: Hardening, Reporting, And Migration
 
-Status: Partial.
+Status: Complete / monitoring.
 
 Goal: Make Agent Operations reliable enough to run as an operating system.
 
@@ -258,6 +258,32 @@ Current progress:
 
 - Mission Control derives a 24-hour Cost Intelligence summary from `cost_events.agent_run_id` without adding schema or copying data.
 - The first grouped view covers runtime, agent, workflow, client/project, and artifact type where trace metadata exists, with safe unassigned fallbacks.
+- Source validator and dev-testing LLM surfaces now use pre-flight budget checks and Agent Ops trace linkage, completing the last known Phase 10 LLM/budget trace cleanup surfaces.
+
+### Phase 11: Provider Resilience And Retry Hygiene
+
+Status: In progress.
+
+Goal: Standardize how provider calls recover from transient n8n, LLM, and tool failures.
+
+Definition of done:
+
+- A shared retry/backoff helper exists for provider calls.
+- n8n trigger calls use capped retry behavior for transient network and gateway failures.
+- Direct LLM call sites can adopt the same helper without bespoke loops.
+- Provider failures remain user-safe and traceable; implementation details stay in logs/traces.
+- Retry metadata can feed dead-letter and recovery flows without introducing a separate queue table.
+
+Out of scope:
+
+- Retrying non-idempotent production mutations without an explicit workflow-level safety check.
+- Replacing existing dead-letter visibility.
+- Changing vendors, models, or workflow ownership.
+
+Current progress:
+
+- A reusable `lib/llm/with-retry.ts` helper is being introduced with capped exponential backoff, configurable retryable error matching, and a give-up hook for dead-letter integration.
+- The first adoption targets n8n trigger calls, where transient 502/503/504 and network failures can be retried without exposing raw provider errors to users.
 - Mission Control surfaces the latest `agent_ops_morning_review` and `agent_ops_deployment_watch` traces as Operating Signals.
 - The deployment watcher supports `--trace` so integration-captain and autopilot runs write a visible Agent Ops run/artifact.
 - Stale-run detection now reports checked and marked counts by runtime across `codex`, `n8n`, `hermes`, `opencode`, and `manual` runs when those runtimes have active queued/running work.

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -41,6 +41,12 @@ This is the active implementation queue for Agent Operations. The phase gates, d
    - [x] Document legacy workflow run tables as domain detail or future trace-link migration candidates.
    - [x] Update the Agentic Patterns scorecard to reflect strong Agent Ops observability.
    - [x] Link video generation workflow sync runs to Agent Ops traces while preserving domain status UI.
+   - [x] Complete the known Phase 10 LLM/budget trace cleanup surfaces.
+
+5. Provider resilience
+   - [x] Add a shared retry/backoff helper for provider calls.
+   - [x] Adopt the helper for retryable n8n trigger calls.
+   - Add remaining direct LLM/provider call-site adoptions where transient failures still use bespoke retry or plain `try/catch`.
 
 ## Completed Or In Review
 
@@ -79,6 +85,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 - [x] Chat Eval LLM judge pre-flight budget adoption and trace linkage in review.
 - [x] Chat Eval axial-code and diagnosis pre-flight budget adoption and trace linkage in review.
 - [x] Source validator and dev testing LLM pre-flight budget cleanup in review.
+- [x] Shared provider retry/backoff helper and first n8n trigger adoption in review.
 
 ## Scope Guard
 

--- a/docs/agentic-patterns.md
+++ b/docs/agentic-patterns.md
@@ -32,7 +32,7 @@ Our pinned 20 patterns, grouped the same way as the talk:
 | 13 | Self-Consistency | Self-awareness | Absent |
 | 14 | Learning & Feedback | Self-awareness | Partial |
 | 15 | Memory Management | Self-awareness | Partial |
-| 16 | Exception Handling | Production | Partial |
+| 16 | Exception Handling | Production | Partial / improving |
 | 17 | Human-in-the-Loop | Production | Strong on publish / Partial elsewhere |
 | 18 | Guardrails & Safety | Production | Strong (authz) / Partial (content) |
 | 19 | Monitoring & Observability | Production | Strong in Agent Ops / Partial in legacy flows |
@@ -337,14 +337,16 @@ Each section follows the same template: *Definition · Where we use it today · 
 - User-facing error hygiene enforced by [`.cursor/rules/no-expose-errors-to-users.mdc`](../.cursor/rules/no-expose-errors-to-users.mdc).
 - Trigger functions in [`lib/n8n.ts`](../lib/n8n.ts) return `{ triggered, message }` shape.
 - Agent Operations marks failed and stale runs, derives a Dead-Letter Monitor from those traces, lets stale sweeps report checked/marked counts by runtime, and can create read-only recovery requests with retry/backoff metadata.
+- [`lib/llm/with-retry.ts`](../lib/llm/with-retry.ts) provides a shared capped backoff helper with configurable retryable error matching and a give-up hook.
+- n8n trigger calls use the shared helper for transient network and gateway failures while preserving generic user-facing failure messages.
 
-**Coverage.** Partial.
+**Coverage.** Partial / improving.
 
 **Gaps.**
-- No standard retry/backoff helper for LLM calls or n8n triggers — each call site reinvents `try/catch`.
-- Dead-letter visibility and routed recovery requests exist for Agent Ops traces, but provider-call retry wrappers are still call-site specific.
+- Direct LLM call sites still need to adopt the shared retry helper where transient provider failures are expected.
+- Dead-letter visibility and routed recovery requests exist for Agent Ops traces, but some provider-call retry wrappers are still call-site specific.
 
-**Retrofit backlog.** Ticket [#3](#top-retrofit-tickets) — retry/backoff helper.
+**Retrofit backlog.** Continue Ticket [#3](#top-retrofit-tickets) by adopting the shared helper across remaining direct LLM/provider calls.
 
 ---
 
@@ -471,14 +473,15 @@ These are the first five PR-sized items seeded from the scorecard. Ticket 1 has 
   - Scorecard row for Reflection updated to "Partial" on completion.
 - **Depends on.** Ticket #1 (for observability).
 
-### Ticket 3 — Retry/backoff helper for LLM/n8n calls (Exception Handling)
+### Ticket 3 — Retry/backoff helper for LLM/n8n calls (Exception Handling) — in progress
 
-- **Owner.** _TBD_
+- **Owner.** Agent Operations rollout.
 - **Scope.** Add `lib/llm/with-retry.ts` with capped exponential backoff + jitter, configurable retryable error matcher, and a dead-letter hook. Wrap the trigger functions in [`lib/n8n.ts`](../lib/n8n.ts) and the direct LLM call sites found via grep.
+- **First adoption.** n8n trigger calls now retry transient network and 502/503/504 failures through the shared helper.
 - **Acceptance criteria.**
   - Unit tests for: success-on-first-try, success-after-N-retries, gives-up-after-max, honors non-retryable errors.
   - User-facing errors remain generic per `no-expose-errors-to-users.mdc`.
-  - Scorecard row for Exception Handling updated to "Strong" on completion.
+  - Scorecard row for Exception Handling updated to "Strong" after direct LLM/provider call sites also adopt the helper.
 
 ### Ticket 4 — Content-safety gate before LinkedIn publish (Guardrails)
 

--- a/lib/__tests__/n8n-social-content-extraction.test.ts
+++ b/lib/__tests__/n8n-social-content-extraction.test.ts
@@ -13,6 +13,7 @@ describe('triggerSocialContentExtraction', () => {
     process.env.MOCK_N8N = 'false'
     process.env.N8N_SOC001_WEBHOOK_URL = 'https://example.test/webhook/social-content-extract'
     process.env.N8N_CALLBACK_BASE_URL = 'https://portfolio.example.com'
+    process.env.N8N_RETRY_DELAY_MS = '0'
   })
 
   afterEach(() => {
@@ -90,8 +91,8 @@ describe('triggerSocialContentExtraction', () => {
   it('returns a failed result when webhook responds with non-2xx', async () => {
     mockFetch.mockResolvedValue({
       ok: false,
-      status: 502,
-      text: async () => 'bad gateway',
+      status: 400,
+      text: async () => 'bad request',
     })
 
     const { triggerSocialContentExtraction } = await import('../n8n')
@@ -99,8 +100,30 @@ describe('triggerSocialContentExtraction', () => {
 
     expect(result).toEqual({
       triggered: false,
-      message: 'Webhook returned 502',
+      message: 'Webhook returned 400',
     })
+  })
+
+  it('retries retryable gateway responses before returning success', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        text: async () => 'bad gateway',
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () => '',
+      })
+
+    const { triggerSocialContentExtraction } = await import('../n8n')
+    const result = await triggerSocialContentExtraction()
+
+    expect(result).toEqual({
+      triggered: true,
+      message: 'Social content extraction triggered',
+    })
+    expect(mockFetch).toHaveBeenCalledTimes(2)
   })
 
   it('returns a failed result when webhook fetch throws', async () => {

--- a/lib/llm/with-retry.test.ts
+++ b/lib/llm/with-retry.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest'
+import { isLikelyTransientError, withRetry } from './with-retry'
+
+describe('withRetry', () => {
+  it('returns success on the first attempt', async () => {
+    const operation = vi.fn().mockResolvedValue('ok')
+
+    await expect(withRetry(operation, { maxRetries: 2, sleep: async () => {} })).resolves.toBe('ok')
+
+    expect(operation).toHaveBeenCalledTimes(1)
+    expect(operation).toHaveBeenCalledWith({ attempt: 0, attemptNumber: 1 })
+  })
+
+  it('returns success after retrying retryable errors', async () => {
+    const operation = vi.fn()
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockRejectedValueOnce(new Error('502 bad gateway'))
+      .mockResolvedValueOnce('ok')
+    const onRetry = vi.fn()
+
+    await expect(withRetry(operation, {
+      maxRetries: 2,
+      baseDelayMs: 10,
+      jitterRatio: 0,
+      sleep: async () => {},
+      onRetry,
+    })).resolves.toBe('ok')
+
+    expect(operation).toHaveBeenCalledTimes(3)
+    expect(onRetry).toHaveBeenCalledTimes(2)
+    expect(onRetry).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      attempt: 0,
+      attemptNumber: 1,
+      nextDelayMs: 10,
+    }))
+    expect(onRetry).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      attempt: 1,
+      attemptNumber: 2,
+      nextDelayMs: 20,
+    }))
+  })
+
+  it('gives up after max retries and calls the dead-letter hook', async () => {
+    const error = new Error('503 unavailable')
+    const operation = vi.fn().mockRejectedValue(error)
+    const onGiveUp = vi.fn()
+
+    await expect(withRetry(operation, {
+      maxRetries: 1,
+      sleep: async () => {},
+      onGiveUp,
+    })).rejects.toBe(error)
+
+    expect(operation).toHaveBeenCalledTimes(2)
+    expect(onGiveUp).toHaveBeenCalledWith(expect.objectContaining({
+      attempt: 1,
+      attemptNumber: 2,
+      nextDelayMs: null,
+      error,
+    }))
+  })
+
+  it('does not retry non-retryable errors', async () => {
+    const error = new Error('validation failed')
+    const operation = vi.fn().mockRejectedValue(error)
+    const onRetry = vi.fn()
+
+    await expect(withRetry(operation, {
+      maxRetries: 3,
+      sleep: async () => {},
+      onRetry,
+    })).rejects.toBe(error)
+
+    expect(operation).toHaveBeenCalledTimes(1)
+    expect(onRetry).not.toHaveBeenCalled()
+  })
+
+  it('allows a custom retryable error matcher', async () => {
+    const operation = vi.fn()
+      .mockRejectedValueOnce(new Error('rate limited'))
+      .mockResolvedValueOnce('ok')
+
+    await expect(withRetry(operation, {
+      maxRetries: 1,
+      sleep: async () => {},
+      isRetryableError: error => error instanceof Error && error.message.includes('rate limited'),
+    })).resolves.toBe('ok')
+
+    expect(operation).toHaveBeenCalledTimes(2)
+  })
+
+  it('classifies common transient network and gateway errors', () => {
+    expect(isLikelyTransientError(new Error('fetch failed'))).toBe(true)
+    expect(isLikelyTransientError(new Error('n8n request timed out after 30s'))).toBe(true)
+    expect(isLikelyTransientError(new Error('502 bad gateway'))).toBe(true)
+    expect(isLikelyTransientError(new Error('validation failed'))).toBe(false)
+  })
+})

--- a/lib/llm/with-retry.ts
+++ b/lib/llm/with-retry.ts
@@ -1,0 +1,136 @@
+export interface RetryAttemptContext {
+  /** Zero-based failed attempt index. */
+  attempt: number
+  /** One-based attempt number for logs and traces. */
+  attemptNumber: number
+  maxRetries: number
+  error: unknown
+}
+
+export interface RetryContext extends RetryAttemptContext {
+  nextDelayMs: number | null
+}
+
+export interface RetryOperationContext {
+  /** Zero-based operation attempt index. */
+  attempt: number
+  /** One-based operation attempt number. */
+  attemptNumber: number
+}
+
+export interface WithRetryOptions {
+  label?: string
+  maxRetries?: number
+  baseDelayMs?: number
+  maxDelayMs?: number
+  jitterRatio?: number
+  random?: () => number
+  sleep?: (delayMs: number) => Promise<void>
+  isRetryableError?: (error: unknown, context: RetryAttemptContext) => boolean
+  onRetry?: (context: RetryContext) => void | Promise<void>
+  onGiveUp?: (context: RetryContext) => void | Promise<void>
+}
+
+const DEFAULT_MAX_RETRIES = 0
+const DEFAULT_BASE_DELAY_MS = 250
+const DEFAULT_MAX_DELAY_MS = 5_000
+const DEFAULT_JITTER_RATIO = 0.2
+
+function defaultSleep(delayMs: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, delayMs))
+}
+
+function normalizeNonNegativeInteger(value: number | undefined, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    return fallback
+  }
+  return Math.floor(value)
+}
+
+function computeDelayMs(params: {
+  attempt: number
+  baseDelayMs: number
+  maxDelayMs: number
+  jitterRatio: number
+  random: () => number
+}): number {
+  const exponentialDelay = params.baseDelayMs * (2 ** params.attempt)
+  const cappedDelay = Math.min(exponentialDelay, params.maxDelayMs)
+  const safeJitterRatio = Math.max(0, params.jitterRatio)
+
+  if (safeJitterRatio === 0 || cappedDelay === 0) {
+    return cappedDelay
+  }
+
+  const jitterWindow = cappedDelay * safeJitterRatio
+  const jitter = (params.random() * 2 - 1) * jitterWindow
+  return Math.max(0, Math.round(cappedDelay + jitter))
+}
+
+export function isLikelyTransientError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false
+  }
+
+  const message = error.message.toLowerCase()
+  return (
+    message.includes('timed out') ||
+    message.includes('timeout') ||
+    message.includes('econnrefused') ||
+    message.includes('econnreset') ||
+    message.includes('enotfound') ||
+    message.includes('fetch failed') ||
+    message.includes('network') ||
+    message.includes('502') ||
+    message.includes('503') ||
+    message.includes('504')
+  )
+}
+
+export async function withRetry<T>(
+  operation: (context: RetryOperationContext) => Promise<T>,
+  options: WithRetryOptions = {}
+): Promise<T> {
+  const maxRetries = normalizeNonNegativeInteger(options.maxRetries, DEFAULT_MAX_RETRIES)
+  const baseDelayMs = normalizeNonNegativeInteger(options.baseDelayMs, DEFAULT_BASE_DELAY_MS)
+  const maxDelayMs = normalizeNonNegativeInteger(options.maxDelayMs, DEFAULT_MAX_DELAY_MS)
+  const jitterRatio = typeof options.jitterRatio === 'number' && Number.isFinite(options.jitterRatio)
+    ? Math.max(0, options.jitterRatio)
+    : DEFAULT_JITTER_RATIO
+  const random = options.random ?? Math.random
+  const sleep = options.sleep ?? defaultSleep
+  const isRetryableError = options.isRetryableError ?? isLikelyTransientError
+
+  for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
+    try {
+      return await operation({ attempt, attemptNumber: attempt + 1 })
+    } catch (error) {
+      const attemptContext: RetryAttemptContext = {
+        attempt,
+        attemptNumber: attempt + 1,
+        maxRetries,
+        error,
+      }
+      const shouldRetry = attempt < maxRetries && isRetryableError(error, attemptContext)
+      const nextDelayMs = shouldRetry
+        ? computeDelayMs({ attempt, baseDelayMs, maxDelayMs, jitterRatio, random })
+        : null
+      const retryContext: RetryContext = {
+        ...attemptContext,
+        nextDelayMs,
+      }
+
+      if (!shouldRetry) {
+        await options.onGiveUp?.(retryContext)
+        throw error
+      }
+
+      await options.onRetry?.(retryContext)
+      if (nextDelayMs && nextDelayMs > 0) {
+        await sleep(nextDelayMs)
+      }
+    }
+  }
+
+  throw new Error(`Retry loop exited unexpectedly${options.label ? ` for ${options.label}` : ''}`)
+}

--- a/lib/n8n.ts
+++ b/lib/n8n.ts
@@ -9,6 +9,7 @@ import {
   isN8nOutboundDisabled,
 } from './n8n-runtime-flags'
 import type { AgentReadinessAssessment } from './agent-readiness-assessment'
+import { isLikelyTransientError, withRetry } from './llm/with-retry'
 
 export { isMockN8nEnabled, isN8nOutboundDisabled }
 
@@ -67,11 +68,19 @@ function n8nAgentTracePayload(agentRunId?: string, workflowId?: string): Record<
 /** Timeout for n8n webhook calls in milliseconds (30 seconds) */
 const N8N_TIMEOUT_MS = 30_000
 
+function readNonNegativeIntegerEnv(name: string, fallback: number): number {
+  const value = Number(process.env[name])
+  if (!Number.isFinite(value) || value < 0) {
+    return fallback
+  }
+  return Math.floor(value)
+}
+
 /** Maximum number of retry attempts for transient failures */
-const N8N_MAX_RETRIES = 1
+const N8N_MAX_RETRIES = readNonNegativeIntegerEnv('N8N_MAX_RETRIES', 1)
 
 /** Delay before retry in milliseconds */
-const N8N_RETRY_DELAY_MS = 2_000
+const N8N_RETRY_DELAY_MS = readNonNegativeIntegerEnv('N8N_RETRY_DELAY_MS', 2_000)
 
 // ============================================================================
 // Resilient Fetch Helper
@@ -113,22 +122,61 @@ function sleep(ms: number): Promise<void> {
  * Determine whether an error is transient (worth retrying)
  */
 function isTransientError(error: unknown): boolean {
-  if (error instanceof Error) {
-    const msg = error.message.toLowerCase()
-    // Network-level failures, timeouts, 502/503/504 gateway errors
-    return (
-      msg.includes('timed out') ||
-      msg.includes('econnrefused') ||
-      msg.includes('econnreset') ||
-      msg.includes('enotfound') ||
-      msg.includes('fetch failed') ||
-      msg.includes('network') ||
-      msg.includes('502') ||
-      msg.includes('503') ||
-      msg.includes('504')
-    )
+  return isLikelyTransientError(error)
+}
+
+class N8nRetryableStatusError extends Error {
+  constructor(
+    readonly status: number,
+    readonly responseText: string
+  ) {
+    super(`n8n webhook returned retryable status ${status}: ${responseText}`)
+    this.name = 'N8nRetryableStatusError'
   }
-  return false
+}
+
+function isRetryableWebhookStatus(status: number): boolean {
+  return status === 502 || status === 503 || status === 504
+}
+
+async function fetchN8nWebhookWithRetry(
+  label: string,
+  url: string,
+  init: RequestInit,
+  timeoutMs: number = N8N_TIMEOUT_MS
+): Promise<Response> {
+  return withRetry(
+    async () => {
+      const response = await fetchWithTimeout(url, init, timeoutMs)
+
+      if (isRetryableWebhookStatus(response.status)) {
+        const responseText = await response.text().catch(() => '')
+        throw new N8nRetryableStatusError(response.status, responseText)
+      }
+
+      return response
+    },
+    {
+      label,
+      maxRetries: N8N_MAX_RETRIES,
+      baseDelayMs: N8N_RETRY_DELAY_MS,
+      maxDelayMs: Math.max(N8N_RETRY_DELAY_MS, 10_000),
+      jitterRatio: process.env.NODE_ENV === 'test' ? 0 : 0.1,
+      isRetryableError: isTransientError,
+      onRetry: ({ attemptNumber, nextDelayMs, error }) => {
+        console.warn(
+          `[n8n] ${label} transient failure on attempt ${attemptNumber}; retrying in ${nextDelayMs ?? 0}ms`,
+          error instanceof Error ? error.message : error
+        )
+      },
+      onGiveUp: ({ attemptNumber, error }) => {
+        console.warn(
+          `[n8n] ${label} failed after attempt ${attemptNumber}`,
+          error instanceof Error ? error.message : error
+        )
+      },
+    }
+  )
 }
 
 // ============================================================================
@@ -413,7 +461,7 @@ export async function triggerLeadQualificationWebhook(
   }
 
   try {
-    const response = await fetch(N8N_LEAD_WEBHOOK_URL, {
+    const response = await fetchN8nWebhookWithRetry('lead qualification webhook', N8N_LEAD_WEBHOOK_URL, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -474,7 +522,7 @@ export async function triggerEbookNurtureSequence(
   }
 
   try {
-    const response = await fetchWithTimeout(N8N_EBOOK_NURTURE_WEBHOOK_URL, {
+    const response = await fetchN8nWebhookWithRetry('ebook nurture webhook', N8N_EBOOK_NURTURE_WEBHOOK_URL, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -1024,7 +1072,7 @@ export async function triggerDiagnosticCompletionWebhook(
       source: completionSource,
     }
 
-    const response = await fetch(completionWebhookUrl, {
+    const response = await fetchN8nWebhookWithRetry('diagnostic completion webhook', completionWebhookUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -1059,7 +1107,7 @@ export async function checkN8nHealth(): Promise<boolean> {
 
   try {
     // Send a health check message using n8n chat trigger format
-    const response = await fetch(N8N_WEBHOOK_URL, {
+    const response = await fetchN8nWebhookWithRetry('n8n health check', N8N_WEBHOOK_URL, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -1162,7 +1210,7 @@ export async function triggerOutreachSend(params: {
   }
 
   try {
-    const response = await fetch(N8N_CLG003_WEBHOOK_URL, {
+    const response = await fetchN8nWebhookWithRetry('outreach send webhook', N8N_CLG003_WEBHOOK_URL, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -1247,7 +1295,7 @@ export async function triggerWarmLeadScrape(params: {
       ...params.options,
     }
     
-    const response = await fetch(webhookUrl, {
+    const response = await fetchN8nWebhookWithRetry(`warm lead scrape ${params.source} webhook`, webhookUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -1337,7 +1385,7 @@ export async function triggerValueEvidenceExtraction(
       body.run_id = options.runId
     }
 
-    const response = await fetchWithTimeout(N8N_VEP001_WEBHOOK_URL, {
+    const response = await fetchN8nWebhookWithRetry('value evidence extraction webhook', N8N_VEP001_WEBHOOK_URL, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -1419,7 +1467,7 @@ export async function triggerSocialListening(options?: SocialListeningOptions): 
     if (options?.leadContext) {
       Object.assign(body, options.leadContext)
     }
-    const response = await fetchWithTimeout(N8N_VEP002_WEBHOOK_URL, {
+    const response = await fetchN8nWebhookWithRetry('social listening webhook', N8N_VEP002_WEBHOOK_URL, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -1494,7 +1542,7 @@ export async function triggerSocialContentExtraction(options?: {
       body.prompts = options.prompts
     }
 
-    const response = await fetch(N8N_SOC001_WEBHOOK_URL, {
+    const response = await fetchN8nWebhookWithRetry('social content extraction webhook', N8N_SOC001_WEBHOOK_URL, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
@@ -1537,7 +1585,7 @@ export async function triggerSocialContentPublish(payload: {
   }
 
   try {
-    const response = await fetch(N8N_SOC002_WEBHOOK_URL, {
+    const response = await fetchN8nWebhookWithRetry('social content publish webhook', N8N_SOC002_WEBHOOK_URL, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({


### PR DESCRIPTION
## Summary
- add a reusable provider retry helper with capped backoff, retryable error matching, and give-up hook support
- route n8n trigger calls through the shared helper for transient network and 502/503/504 failures
- update Agent Ops roadmap/task docs and scorecard for Phase 11 provider resilience

## Validation
- npm test -- --run lib/llm/with-retry.test.ts lib/__tests__/n8n-social-content-extraction.test.ts lib/__tests__/n8n-outbound-gate.test.ts lib/__tests__/n8n-warm-lead-scrape.test.ts lib/__tests__/n8n-value-evidence.test.ts
- npm test -- --run lib/n8n.test.ts lib/__tests__/n8n-lead-qualification.test.ts
- npx tsc --noEmit --pretty false
- git diff --check
- npm run build

Note: build passed with the existing local env warning that dev has MOCK_N8N=false and N8N_DISABLE_OUTBOUND=false configured.