### PR TITLE
feat: adopt retry helper for llm providers

### DIFF
--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -284,6 +284,7 @@ Current progress:
 
 - A reusable `lib/llm/with-retry.ts` helper is being introduced with capped exponential backoff, configurable retryable error matching, and a give-up hook for dead-letter integration.
 - The first adoption targets n8n trigger calls, where transient 502/503/504 and network failures can be retried without exposing raw provider errors to users.
+- The next adoption targets central LLM provider dispatch and the source-validator LLM judge, replacing bespoke retry loops with the shared helper.
 - Mission Control surfaces the latest `agent_ops_morning_review` and `agent_ops_deployment_watch` traces as Operating Signals.
 - The deployment watcher supports `--trace` so integration-captain and autopilot runs write a visible Agent Ops run/artifact.
 - Stale-run detection now reports checked and marked counts by runtime across `codex`, `n8n`, `hermes`, `opencode`, and `manual` runs when those runtimes have active queued/running work.

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -46,6 +46,8 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 5. Provider resilience
    - [x] Add a shared retry/backoff helper for provider calls.
    - [x] Adopt the helper for retryable n8n trigger calls.
+   - [x] Adopt the helper for central OpenAI/Anthropic JSON dispatch.
+   - [x] Replace the source-validator LLM judge's bespoke retry loop with the shared helper.
    - Add remaining direct LLM/provider call-site adoptions where transient failures still use bespoke retry or plain `try/catch`.
 
 ## Completed Or In Review
@@ -86,6 +88,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 - [x] Chat Eval axial-code and diagnosis pre-flight budget adoption and trace linkage in review.
 - [x] Source validator and dev testing LLM pre-flight budget cleanup in review.
 - [x] Shared provider retry/backoff helper and first n8n trigger adoption in review.
+- [x] Central LLM dispatch and source-validator retry helper adoption in review.
 
 ## Scope Guard
 

--- a/docs/agentic-patterns.md
+++ b/docs/agentic-patterns.md
@@ -339,6 +339,8 @@ Each section follows the same template: *Definition · Where we use it today · 
 - Agent Operations marks failed and stale runs, derives a Dead-Letter Monitor from those traces, lets stale sweeps report checked/marked counts by runtime, and can create read-only recovery requests with retry/backoff metadata.
 - [`lib/llm/with-retry.ts`](../lib/llm/with-retry.ts) provides a shared capped backoff helper with configurable retryable error matching and a give-up hook.
 - n8n trigger calls use the shared helper for transient network and gateway failures while preserving generic user-facing failure messages.
+- Central OpenAI/Anthropic JSON dispatch in [`lib/llm-dispatch.ts`](../lib/llm-dispatch.ts) uses the shared helper for retryable provider statuses.
+- The source-validator LLM judge in [`lib/source-validator/llm-judge.ts`](../lib/source-validator/llm-judge.ts) uses the shared helper instead of a bespoke retry loop.
 
 **Coverage.** Partial / improving.
 
@@ -478,6 +480,7 @@ These are the first five PR-sized items seeded from the scorecard. Ticket 1 has 
 - **Owner.** Agent Operations rollout.
 - **Scope.** Add `lib/llm/with-retry.ts` with capped exponential backoff + jitter, configurable retryable error matcher, and a dead-letter hook. Wrap the trigger functions in [`lib/n8n.ts`](../lib/n8n.ts) and the direct LLM call sites found via grep.
 - **First adoption.** n8n trigger calls now retry transient network and 502/503/504 failures through the shared helper.
+- **Follow-on adoption.** Central OpenAI/Anthropic JSON dispatch and source-validator LLM judge calls use the shared helper for retryable provider/network failures.
 - **Acceptance criteria.**
   - Unit tests for: success-on-first-try, success-after-N-retries, gives-up-after-max, honors non-retryable errors.
   - User-facing errors remain generic per `no-expose-errors-to-users.mdc`.

--- a/lib/__tests__/llm-dispatch.test.ts
+++ b/lib/__tests__/llm-dispatch.test.ts
@@ -16,6 +16,7 @@ beforeEach(() => {
   mockRecordAnthropicCost.mockReset()
   mockRecordOpenAICost.mockResolvedValue(undefined)
   mockRecordAnthropicCost.mockResolvedValue(undefined)
+  process.env.LLM_RETRY_DELAY_MS = '0'
 })
 
 afterEach(() => {
@@ -114,5 +115,52 @@ describe('generateJsonCompletion — provider routing', () => {
         userPrompt: 'u',
       }),
     ).rejects.toThrowError('ANTHROPIC_API_KEY not configured')
+  })
+
+  it('retries transient OpenAI status responses before returning success', async () => {
+    process.env.OPENAI_API_KEY = 'sk-test'
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        text: async () => 'temporarily unavailable',
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          choices: [{ message: { content: '{"recovered":true}' } }],
+          usage: { prompt_tokens: 5, completion_tokens: 7, total_tokens: 12 },
+        }),
+      })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { generateJsonCompletion } = await import('../llm-dispatch')
+    const result = await generateJsonCompletion({
+      model: 'gpt-4o-mini',
+      systemPrompt: 'system',
+      userPrompt: 'user',
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(result.content).toBe('{"recovered":true}')
+  })
+
+  it('does not retry non-retryable provider status responses', async () => {
+    process.env.OPENAI_API_KEY = 'sk-test'
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: async () => 'bad request',
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { generateJsonCompletion } = await import('../llm-dispatch')
+    await expect(generateJsonCompletion({
+      model: 'gpt-4o-mini',
+      systemPrompt: 'system',
+      userPrompt: 'user',
+    })).rejects.toThrowError('OpenAI request failed: 400')
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/lib/llm-dispatch.ts
+++ b/lib/llm-dispatch.ts
@@ -19,6 +19,7 @@ import {
   recordOpenAICost,
   type Usage,
 } from '@/lib/cost-calculator'
+import { withRetry } from '@/lib/llm/with-retry'
 
 export interface LlmCostContext {
   reference?: { type: string; id: string }
@@ -45,6 +46,67 @@ export interface LlmJsonResponse {
 
 const DEFAULT_TEMPERATURE = 0.7
 const DEFAULT_MAX_TOKENS = 800
+const LLM_MAX_RETRIES = readNonNegativeIntegerEnv('LLM_MAX_RETRIES', 1)
+const LLM_RETRY_DELAY_MS = readNonNegativeIntegerEnv('LLM_RETRY_DELAY_MS', 500)
+
+function readNonNegativeIntegerEnv(name: string, fallback: number): number {
+  const value = Number(process.env[name])
+  if (!Number.isFinite(value) || value < 0) {
+    return fallback
+  }
+  return Math.floor(value)
+}
+
+class RetryableProviderStatusError extends Error {
+  constructor(
+    readonly provider: LlmProvider,
+    readonly status: number,
+    readonly responseText: string,
+  ) {
+    super(`${provider} request failed with retryable status ${status}`)
+    this.name = 'RetryableProviderStatusError'
+  }
+}
+
+function isRetryableProviderStatus(status: number): boolean {
+  return status === 408 || status === 429 || status === 500 || status === 502 || status === 503 || status === 504
+}
+
+async function fetchProviderWithRetry(
+  provider: LlmProvider,
+  url: string,
+  init: RequestInit,
+): Promise<Response> {
+  return withRetry(
+    async () => {
+      const response = await fetch(url, init)
+      if (isRetryableProviderStatus(response.status)) {
+        const responseText = await response.text().catch(() => '')
+        throw new RetryableProviderStatusError(provider, response.status, responseText.slice(0, 400))
+      }
+      return response
+    },
+    {
+      label: `${provider} llm dispatch`,
+      maxRetries: LLM_MAX_RETRIES,
+      baseDelayMs: LLM_RETRY_DELAY_MS,
+      maxDelayMs: Math.max(LLM_RETRY_DELAY_MS, 5_000),
+      jitterRatio: process.env.NODE_ENV === 'test' ? 0 : 0.1,
+      onRetry: ({ attemptNumber, nextDelayMs, error }) => {
+        console.warn(
+          `[llm-dispatch] ${provider} transient failure on attempt ${attemptNumber}; retrying in ${nextDelayMs ?? 0}ms`,
+          error instanceof Error ? error.message : error,
+        )
+      },
+      onGiveUp: ({ attemptNumber, error }) => {
+        console.warn(
+          `[llm-dispatch] ${provider} failed after attempt ${attemptNumber}`,
+          error instanceof Error ? error.message : error,
+        )
+      },
+    },
+  )
+}
 
 /**
  * Call the provider implied by `model` and return the raw JSON-string response.
@@ -77,7 +139,7 @@ async function callOpenAI(req: LlmJsonRequest): Promise<LlmJsonResponse> {
     response_format: { type: 'json_object' as const },
   }
 
-  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+  const response = await fetchProviderWithRetry('openai', 'https://api.openai.com/v1/chat/completions', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -133,7 +195,7 @@ async function callAnthropic(req: LlmJsonRequest): Promise<LlmJsonResponse> {
     ],
   }
 
-  const response = await fetch('https://api.anthropic.com/v1/messages', {
+  const response = await fetchProviderWithRetry('anthropic', 'https://api.anthropic.com/v1/messages', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/lib/llm/with-retry.test.ts
+++ b/lib/llm/with-retry.test.ts
@@ -92,6 +92,8 @@ describe('withRetry', () => {
   it('classifies common transient network and gateway errors', () => {
     expect(isLikelyTransientError(new Error('fetch failed'))).toBe(true)
     expect(isLikelyTransientError(new Error('n8n request timed out after 30s'))).toBe(true)
+    expect(isLikelyTransientError(new Error('429 rate limited'))).toBe(true)
+    expect(isLikelyTransientError(new Error('500 server error'))).toBe(true)
     expect(isLikelyTransientError(new Error('502 bad gateway'))).toBe(true)
     expect(isLikelyTransientError(new Error('validation failed'))).toBe(false)
   })

--- a/lib/llm/with-retry.ts
+++ b/lib/llm/with-retry.ts
@@ -81,6 +81,9 @@ export function isLikelyTransientError(error: unknown): boolean {
     message.includes('enotfound') ||
     message.includes('fetch failed') ||
     message.includes('network') ||
+    message.includes('408') ||
+    message.includes('429') ||
+    message.includes('500') ||
     message.includes('502') ||
     message.includes('503') ||
     message.includes('504')

--- a/lib/source-validator/llm-judge.ts
+++ b/lib/source-validator/llm-judge.ts
@@ -19,6 +19,7 @@
 import { computeAnthropicCost, recordAnthropicCost, type Usage } from '@/lib/cost-calculator'
 import { evaluateAgentBudget, type AgentBudgetDecision } from '@/lib/agent-budget-policy'
 import { recordAgentEvent, recordAgentStep, type AgentRuntime } from '@/lib/agent-run'
+import { isLikelyTransientError, withRetry } from '@/lib/llm/with-retry'
 
 // -----------------------------------------------------------------------------
 // Version constants
@@ -370,74 +371,100 @@ export async function judgeBatch(
   }
 
   let lastError: Error | null = null
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    const controller = new AbortController()
-    const t = setTimeout(() => controller.abort(), timeoutMs)
-    try {
-      const response = await fetchImpl('https://api.anthropic.com/v1/messages', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-api-key': apiKey,
-          'anthropic-version': '2023-06-01',
+  try {
+    return await withRetry(
+      async () => {
+        const controller = new AbortController()
+        const t = setTimeout(() => controller.abort(), timeoutMs)
+        try {
+          const response = await fetchImpl('https://api.anthropic.com/v1/messages', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'x-api-key': apiKey,
+              'anthropic-version': '2023-06-01',
+            },
+            body: JSON.stringify({
+              model,
+              max_tokens: 1500,
+              system: SYSTEM_PROMPT,
+              messages: [{ role: 'user', content: userPrompt }],
+              temperature: 0.0,
+            }),
+            signal: controller.signal,
+          })
+
+          if (!response.ok) {
+            const body = await response.text().catch(() => '')
+            throw new Error(`Anthropic API ${response.status}: ${body.slice(0, 200)}`)
+          }
+          const data = (await response.json()) as {
+            content?: Array<{ text?: string }>
+            usage?: Usage
+          }
+          const raw = data.content?.[0]?.text ?? ''
+          const verdicts = parseBatchResponse(raw, items)
+          const usage: Usage = data.usage ?? { input_tokens: 0, output_tokens: 0 }
+          const cost_usd = computeAnthropicCost(usage, model)
+          if (usage && options.agentRunId) {
+            recordAnthropicCost(
+              usage,
+              model,
+              options.reference,
+              {
+                operation: SOURCE_VALIDATOR_OPERATION,
+                budget_status: budgetDecision.status,
+                budget_estimated_cost_usd: budgetDecision.estimatedCostUsd,
+                budget_rule_key: budgetDecision.rule.key,
+              },
+              options.agentRunId,
+            ).catch(() => {})
+          }
+
+          return {
+            verdicts,
+            usage,
+            cost_usd,
+            model,
+            prompt_version: PROMPT_VERSION,
+            judge_version: JUDGE_VERSION,
+            dry_run: false,
+            raw,
+          }
+        } catch (error) {
+          if (error instanceof DOMException && error.name === 'AbortError') {
+            throw new Error(`Anthropic judge request timed out after ${timeoutMs / 1000}s`)
+          }
+          throw error
+        } finally {
+          clearTimeout(t)
+        }
+      },
+      {
+        label: 'source validator LLM judge',
+        maxRetries: Math.max(0, maxAttempts - 1),
+        baseDelayMs: process.env.NODE_ENV === 'test' ? 0 : 500,
+        maxDelayMs: 5_000,
+        jitterRatio: process.env.NODE_ENV === 'test' ? 0 : 0.25,
+        isRetryableError: (error) => {
+          if (error instanceof Error && error.name === 'AbortError') {
+            return true
+          }
+          return isLikelyTransientError(error)
         },
-        body: JSON.stringify({
-          model,
-          max_tokens: 1500,
-          system: SYSTEM_PROMPT,
-          messages: [{ role: 'user', content: userPrompt }],
-          temperature: 0.0,
-        }),
-        signal: controller.signal,
-      })
-      clearTimeout(t)
-
-      if (!response.ok) {
-        const body = await response.text().catch(() => '')
-        throw new Error(`Anthropic API ${response.status}: ${body.slice(0, 200)}`)
+        onRetry: ({ attemptNumber, nextDelayMs, error }) => {
+          console.warn(
+            `[source-validator/llm-judge] transient failure on attempt ${attemptNumber}; retrying in ${nextDelayMs ?? 0}ms`,
+            error instanceof Error ? error.message : error,
+          )
+        },
+        onGiveUp: ({ error }) => {
+          lastError = error as Error
+        },
       }
-      const data = (await response.json()) as {
-        content?: Array<{ text?: string }>
-        usage?: Usage
-      }
-      const raw = data.content?.[0]?.text ?? ''
-      const verdicts = parseBatchResponse(raw, items)
-      const usage: Usage = data.usage ?? { input_tokens: 0, output_tokens: 0 }
-      const cost_usd = computeAnthropicCost(usage, model)
-      if (usage && options.agentRunId) {
-        recordAnthropicCost(
-          usage,
-          model,
-          options.reference,
-          {
-            operation: SOURCE_VALIDATOR_OPERATION,
-            budget_status: budgetDecision.status,
-            budget_estimated_cost_usd: budgetDecision.estimatedCostUsd,
-            budget_rule_key: budgetDecision.rule.key,
-          },
-          options.agentRunId,
-        ).catch(() => {})
-      }
-
-      return {
-        verdicts,
-        usage,
-        cost_usd,
-        model,
-        prompt_version: PROMPT_VERSION,
-        judge_version: JUDGE_VERSION,
-        dry_run: false,
-        raw,
-      }
-    } catch (e) {
-      clearTimeout(t)
-      lastError = e as Error
-      if (attempt < maxAttempts) {
-        const backoffMs = 500 * Math.pow(2, attempt - 1) + Math.floor(Math.random() * 250)
-        await new Promise((res) => setTimeout(res, backoffMs))
-        continue
-      }
-    }
+    )
+  } catch (error) {
+    lastError = lastError ?? (error as Error)
   }
 
   throw new Error(


### PR DESCRIPTION
## Summary
- route central OpenAI/Anthropic JSON dispatch through the shared retry helper for retryable provider statuses
- replace the source-validator LLM judge bespoke retry loop with the shared helper
- expand transient error classification for provider rate-limit/server responses
- update Agent Ops roadmap/task docs and scorecard for Phase 11 provider resilience progress

## Validation
- npm test -- --run lib/llm/with-retry.test.ts lib/__tests__/llm-dispatch.test.ts lib/source-validator/llm-judge.test.ts
- npx tsc --noEmit --pretty false
- git diff --check
- npm run build

Note: build passed with the existing local env warning that dev has MOCK_N8N=false and N8N_DISABLE_OUTBOUND=false configured.