### PR TITLE
feat: retry direct provider helper calls

### DIFF
--- a/app/api/admin/sales/in-person-diagnostic/generate-insights/route.test.ts
+++ b/app/api/admin/sales/in-person-diagnostic/generate-insights/route.test.ts
@@ -74,7 +74,7 @@ describe('POST /api/admin/sales/in-person-diagnostic/generate-insights', () => {
     vi.clearAllMocks()
     vi.spyOn(console, 'error').mockImplementation(() => {})
     vi.unstubAllGlobals()
-    process.env = { ...originalEnv, OPENAI_API_KEY: 'test-key' }
+    process.env = { ...originalEnv, OPENAI_API_KEY: 'test-key', LLM_RETRY_DELAY_MS: '0' }
 
     mocks.verifyAdmin.mockResolvedValue({
       user: { id: 'admin-user-1' },
@@ -219,6 +219,43 @@ describe('POST /api/admin/sales/in-person-diagnostic/generate-insights', () => {
       expect.objectContaining({
         operation: 'in_person_diagnostic_insights',
         audit_id: 'audit-1',
+      }),
+    )
+  })
+
+  it('retries a transient OpenAI failure before saving generated insights', async () => {
+    const aiPayload = {
+      diagnostic_summary: 'Manual follow-up is slowing lead conversion.',
+      key_insights: ['Follow-up is not assigned consistently.'],
+      recommended_actions: ['Create lead routing rules.'],
+      urgency_score: 7,
+      opportunity_score: 8,
+      sales_notes: 'Strong fit for a lightweight automation sprint.',
+    }
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({
+        status: 503,
+        ok: false,
+        text: async () => 'temporarily unavailable',
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        json: async () => ({
+          choices: [{ message: { content: JSON.stringify(aiPayload) } }],
+        }),
+      })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const response = await POST(makeRequest(validBody()))
+
+    expect(response.status).toBe(200)
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(mocks.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        diagnostic_summary: aiPayload.diagnostic_summary,
+        key_insights: aiPayload.key_insights,
+        recommended_actions: aiPayload.recommended_actions,
       }),
     )
   })

--- a/app/api/admin/sales/in-person-diagnostic/generate-insights/route.ts
+++ b/app/api/admin/sales/in-person-diagnostic/generate-insights/route.ts
@@ -16,6 +16,7 @@ import {
   InPersonDiagnosticInsightsError,
   recordInPersonDiagnosticInsightsBudgetDecision,
 } from '@/lib/in-person-diagnostic-insights'
+import { fetchProviderWithRetry } from '@/lib/llm/provider-fetch'
 
 export const dynamic = 'force-dynamic'
 
@@ -142,7 +143,7 @@ Respond in JSON format:
       throw new InPersonDiagnosticInsightsError(budgetDecision.reason, 'budget_blocked')
     }
 
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    const response = await fetchProviderWithRetry('openai', 'https://api.openai.com/v1/chat/completions', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -285,6 +285,7 @@ Current progress:
 - A reusable `lib/llm/with-retry.ts` helper is being introduced with capped exponential backoff, configurable retryable error matching, and a give-up hook for dead-letter integration.
 - The first adoption targets n8n trigger calls, where transient 502/503/504 and network failures can be retried without exposing raw provider errors to users.
 - The next adoption targets central LLM provider dispatch and the source-validator LLM judge, replacing bespoke retry loops with the shared helper.
+- Direct OpenAI helpers for audit-from-meetings, meeting lead extraction, AI onboarding preview, and delivery email drafts now use a shared provider fetch wrapper.
 - Mission Control surfaces the latest `agent_ops_morning_review` and `agent_ops_deployment_watch` traces as Operating Signals.
 - The deployment watcher supports `--trace` so integration-captain and autopilot runs write a visible Agent Ops run/artifact.
 - Stale-run detection now reports checked and marked counts by runtime across `codex`, `n8n`, `hermes`, `opencode`, and `manual` runs when those runtimes have active queued/running work.

--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -285,7 +285,7 @@ Current progress:
 - A reusable `lib/llm/with-retry.ts` helper is being introduced with capped exponential backoff, configurable retryable error matching, and a give-up hook for dead-letter integration.
 - The first adoption targets n8n trigger calls, where transient 502/503/504 and network failures can be retried without exposing raw provider errors to users.
 - The next adoption targets central LLM provider dispatch and the source-validator LLM judge, replacing bespoke retry loops with the shared helper.
-- Direct OpenAI helpers for audit-from-meetings, meeting lead extraction, AI onboarding preview, and delivery email drafts now use a shared provider fetch wrapper.
+- Direct OpenAI helpers for audit-from-meetings, meeting lead extraction, AI onboarding preview, delivery email drafts, meeting pain classification, and in-person diagnostic insights now use a shared provider fetch wrapper.
 - Mission Control surfaces the latest `agent_ops_morning_review` and `agent_ops_deployment_watch` traces as Operating Signals.
 - The deployment watcher supports `--trace` so integration-captain and autopilot runs write a visible Agent Ops run/artifact.
 - Stale-run detection now reports checked and marked counts by runtime across `codex`, `n8n`, `hermes`, `opencode`, and `manual` runs when those runtimes have active queued/running work.

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -48,6 +48,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
    - [x] Adopt the helper for retryable n8n trigger calls.
    - [x] Adopt the helper for central OpenAI/Anthropic JSON dispatch.
    - [x] Replace the source-validator LLM judge's bespoke retry loop with the shared helper.
+   - [x] Adopt shared provider fetch retries for audit-from-meetings, meeting lead extraction, AI onboarding preview, and delivery email drafts.
    - Add remaining direct LLM/provider call-site adoptions where transient failures still use bespoke retry or plain `try/catch`.
 
 ## Completed Or In Review
@@ -89,6 +90,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 - [x] Source validator and dev testing LLM pre-flight budget cleanup in review.
 - [x] Shared provider retry/backoff helper and first n8n trigger adoption in review.
 - [x] Central LLM dispatch and source-validator retry helper adoption in review.
+- [x] Direct OpenAI helper retry adoption for audit/lead/onboarding/delivery surfaces in review.
 
 ## Scope Guard
 

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -49,6 +49,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
    - [x] Adopt the helper for central OpenAI/Anthropic JSON dispatch.
    - [x] Replace the source-validator LLM judge's bespoke retry loop with the shared helper.
    - [x] Adopt shared provider fetch retries for audit-from-meetings, meeting lead extraction, AI onboarding preview, and delivery email drafts.
+   - [x] Adopt shared provider fetch retries for meeting pain classification and in-person diagnostic insights.
    - Add remaining direct LLM/provider call-site adoptions where transient failures still use bespoke retry or plain `try/catch`.
 
 ## Completed Or In Review
@@ -91,6 +92,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 - [x] Shared provider retry/backoff helper and first n8n trigger adoption in review.
 - [x] Central LLM dispatch and source-validator retry helper adoption in review.
 - [x] Direct OpenAI helper retry adoption for audit/lead/onboarding/delivery surfaces in review.
+- [x] Direct OpenAI helper retry adoption for meeting pain classification and in-person diagnostic insights in review.
 
 ## Scope Guard
 

--- a/docs/agentic-patterns.md
+++ b/docs/agentic-patterns.md
@@ -341,7 +341,7 @@ Each section follows the same template: *Definition · Where we use it today · 
 - n8n trigger calls use the shared helper for transient network and gateway failures while preserving generic user-facing failure messages.
 - Central OpenAI/Anthropic JSON dispatch in [`lib/llm-dispatch.ts`](../lib/llm-dispatch.ts) uses the shared helper for retryable provider statuses.
 - The source-validator LLM judge in [`lib/source-validator/llm-judge.ts`](../lib/source-validator/llm-judge.ts) uses the shared helper instead of a bespoke retry loop.
-- Direct OpenAI helpers use [`lib/llm/provider-fetch.ts`](../lib/llm/provider-fetch.ts) for retryable provider failures across audit-from-meetings, meeting lead extraction, AI onboarding preview, and delivery email drafts.
+- Direct OpenAI helpers use [`lib/llm/provider-fetch.ts`](../lib/llm/provider-fetch.ts) for retryable provider failures across audit-from-meetings, meeting lead extraction, AI onboarding preview, delivery email drafts, meeting pain classification, and in-person diagnostic insights.
 
 **Coverage.** Partial / improving.
 
@@ -482,7 +482,7 @@ These are the first five PR-sized items seeded from the scorecard. Ticket 1 has 
 - **Scope.** Add `lib/llm/with-retry.ts` with capped exponential backoff + jitter, configurable retryable error matcher, and a dead-letter hook. Wrap the trigger functions in [`lib/n8n.ts`](../lib/n8n.ts) and the direct LLM call sites found via grep.
 - **First adoption.** n8n trigger calls now retry transient network and 502/503/504 failures through the shared helper.
 - **Follow-on adoption.** Central OpenAI/Anthropic JSON dispatch and source-validator LLM judge calls use the shared helper for retryable provider/network failures.
-- **Direct helper adoption.** Audit-from-meetings, meeting lead extraction, AI onboarding preview, and delivery email drafts now use the shared provider fetch wrapper.
+- **Direct helper adoption.** Audit-from-meetings, meeting lead extraction, AI onboarding preview, delivery email drafts, meeting pain classification, and in-person diagnostic insights now use the shared provider fetch wrapper.
 - **Acceptance criteria.**
   - Unit tests for: success-on-first-try, success-after-N-retries, gives-up-after-max, honors non-retryable errors.
   - User-facing errors remain generic per `no-expose-errors-to-users.mdc`.

--- a/docs/agentic-patterns.md
+++ b/docs/agentic-patterns.md
@@ -341,6 +341,7 @@ Each section follows the same template: *Definition · Where we use it today · 
 - n8n trigger calls use the shared helper for transient network and gateway failures while preserving generic user-facing failure messages.
 - Central OpenAI/Anthropic JSON dispatch in [`lib/llm-dispatch.ts`](../lib/llm-dispatch.ts) uses the shared helper for retryable provider statuses.
 - The source-validator LLM judge in [`lib/source-validator/llm-judge.ts`](../lib/source-validator/llm-judge.ts) uses the shared helper instead of a bespoke retry loop.
+- Direct OpenAI helpers use [`lib/llm/provider-fetch.ts`](../lib/llm/provider-fetch.ts) for retryable provider failures across audit-from-meetings, meeting lead extraction, AI onboarding preview, and delivery email drafts.
 
 **Coverage.** Partial / improving.
 
@@ -481,6 +482,7 @@ These are the first five PR-sized items seeded from the scorecard. Ticket 1 has 
 - **Scope.** Add `lib/llm/with-retry.ts` with capped exponential backoff + jitter, configurable retryable error matcher, and a dead-letter hook. Wrap the trigger functions in [`lib/n8n.ts`](../lib/n8n.ts) and the direct LLM call sites found via grep.
 - **First adoption.** n8n trigger calls now retry transient network and 502/503/504 failures through the shared helper.
 - **Follow-on adoption.** Central OpenAI/Anthropic JSON dispatch and source-validator LLM judge calls use the shared helper for retryable provider/network failures.
+- **Direct helper adoption.** Audit-from-meetings, meeting lead extraction, AI onboarding preview, and delivery email drafts now use the shared provider fetch wrapper.
 - **Acceptance criteria.**
   - Unit tests for: success-on-first-try, success-after-N-retries, gives-up-after-max, honors non-retryable errors.
   - User-facing errors remain generic per `no-expose-errors-to-users.mdc`.

--- a/lib/ai-onboarding-generator.test.ts
+++ b/lib/ai-onboarding-generator.test.ts
@@ -50,6 +50,7 @@ describe('ai-onboarding-generator budget policy', () => {
     })
     vi.stubGlobal('fetch', mockFetch)
     process.env.OPENAI_API_KEY = 'sk-test-key'
+    process.env.LLM_RETRY_DELAY_MS = '0'
     mocks.recordAgentStep.mockResolvedValue({ id: 'step-1' })
     mocks.recordAgentEvent.mockResolvedValue({ id: 'event-1' })
     mocks.recordOpenAICost.mockResolvedValue(undefined)
@@ -127,6 +128,50 @@ describe('ai-onboarding-generator budget policy', () => {
       }),
       'agent-run-1',
     )
+  })
+
+  it('retries transient OpenAI responses before returning onboarding content', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        text: async () => 'temporary outage',
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          choices: [
+            {
+              message: {
+                content: JSON.stringify({
+                  setup_requirements: [],
+                  milestones: [],
+                  access_needs: ['Recovered admin access'],
+                  tools_and_platforms: ['Google Workspace'],
+                  client_actions: ['Confirm kickoff owner'],
+                }),
+              },
+            },
+          ],
+          usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 },
+        }),
+      })
+
+    const { generateAIOnboardingContent } = await import('./ai-onboarding-generator')
+
+    const result = await generateAIOnboardingContent({
+      line_items: [
+        {
+          title: 'Automation setup',
+          description: 'Configure workspace automation',
+          content_type: 'service',
+          price: 2500,
+        },
+      ],
+    })
+
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(result.access_needs).toEqual(['Recovered admin access'])
   })
 
   it('rejects generation before fetch when the budget check blocks', async () => {

--- a/lib/ai-onboarding-generator.ts
+++ b/lib/ai-onboarding-generator.ts
@@ -16,6 +16,7 @@ import {
   recordAgentEvent,
   recordAgentStep,
 } from '@/lib/agent-run'
+import { fetchProviderWithRetry } from '@/lib/llm/provider-fetch'
 import type { SetupRequirement, MilestoneTemplate, CommunicationPlan, WinCondition, WarrantyTerms } from '@/lib/onboarding-templates'
 
 const ONBOARDING_MODEL = 'gpt-4o-mini'
@@ -287,7 +288,7 @@ export async function generateAIOnboardingContent(
     throw new Error(budgetDecision.reason)
   }
 
-  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+  const response = await fetchProviderWithRetry('openai', 'https://api.openai.com/v1/chat/completions', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/lib/audit-from-meetings.test.ts
+++ b/lib/audit-from-meetings.test.ts
@@ -39,6 +39,7 @@ describe('audit-from-meetings budget policy', () => {
     vi.spyOn(console, 'error').mockImplementation(() => {})
     vi.unstubAllGlobals()
     process.env = { ...originalEnv }
+    process.env.LLM_RETRY_DELAY_MS = '0'
   })
 
   afterEach(() => {
@@ -125,5 +126,45 @@ describe('audit-from-meetings budget policy', () => {
       }),
       'agent-run-1',
     )
+  })
+
+  it('retries transient OpenAI responses before parsing diagnostic output', async () => {
+    process.env.OPENAI_API_KEY = 'test-key'
+
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        text: async () => 'temporary outage',
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 },
+          choices: [
+            {
+              message: {
+                content: JSON.stringify({
+                  business_challenges: { primary_challenges: ['manual_processes'] },
+                  tech_stack: {},
+                  automation_needs: {},
+                  ai_readiness: {},
+                  budget_timeline: {},
+                  decision_making: {},
+                  diagnostic_summary: 'Recovered after retry.',
+                }),
+              },
+            },
+          ],
+        }),
+      })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const extracted = await extractDiagnosticFromMeetingText(
+      'Meeting transcript says follow-up is inconsistent.'
+    )
+
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(extracted.diagnostic_summary).toBe('Recovered after retry.')
   })
 })

--- a/lib/audit-from-meetings.ts
+++ b/lib/audit-from-meetings.ts
@@ -11,6 +11,7 @@ import {
   type AgentBudgetDecision,
 } from '@/lib/agent-budget-policy'
 import { recordAgentEvent, recordAgentStep } from '@/lib/agent-run'
+import { fetchProviderWithRetry } from '@/lib/llm/provider-fetch'
 export const MAX_COMBINED_CHARS = 100_000
 export const MAX_MEETINGS = 20
 const AUDIT_FROM_MEETINGS_MODEL = 'gpt-4o-mini'
@@ -243,7 +244,7 @@ export async function extractDiagnosticFromMeetingText(
     throw new AuditFromMeetingsError(budgetDecision.reason, 'budget_blocked')
   }
 
-  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+  const response = await fetchProviderWithRetry('openai', 'https://api.openai.com/v1/chat/completions', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/lib/delivery-email.ts
+++ b/lib/delivery-email.ts
@@ -31,6 +31,7 @@ import {
 } from '@/lib/meeting-tasks-context'
 import { appendPineconeAndChatContextToSystemPrompt } from '@/lib/email-llm-context'
 import { getEmailFromName } from '@/lib/business-email-config'
+import { fetchProviderWithRetry } from '@/lib/llm/provider-fetch'
 
 /** Thrown for compose-delivery; route maps codes to HTTP status and safe admin-facing messages. */
 export class DeliveryDraftError extends Error {
@@ -510,7 +511,7 @@ export async function generateDeliveryDraft(input: DeliveryDraftInput): Promise<
     throw new DeliveryDraftError(budgetDecision.reason, 'budget_blocked')
   }
 
-  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+  const response = await fetchProviderWithRetry('openai', 'https://api.openai.com/v1/chat/completions', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/lib/lead-from-meeting.test.ts
+++ b/lib/lead-from-meeting.test.ts
@@ -70,6 +70,7 @@ describe('lead-from-meeting', () => {
     vi.spyOn(console, 'error').mockImplementation(() => {})
     vi.unstubAllGlobals()
     process.env = { ...originalEnv }
+    process.env.LLM_RETRY_DELAY_MS = '0'
   })
 
   afterEach(() => {
@@ -172,6 +173,42 @@ describe('lead-from-meeting', () => {
     await expect(
       extractLeadFieldsFromTranscript('Need details for lead creation')
     ).rejects.toThrow('AI extraction failed')
+  })
+
+  it('retries transient OpenAI responses before mapping extracted lead fields', async () => {
+    process.env.OPENAI_API_KEY = 'test-key'
+
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        text: async () => 'temporary outage',
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          usage: { prompt_tokens: 123, completion_tokens: 45, total_tokens: 168 },
+          choices: [
+            {
+              message: {
+                content: JSON.stringify({
+                  name: 'Retry Lead',
+                  company: 'Recovered Co',
+                }),
+              },
+            },
+          ],
+        }),
+      })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const extracted = await extractLeadFieldsFromTranscript(
+      'Transcript says this lead should recover after a transient provider outage.'
+    )
+
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(extracted.name).toBe('Retry Lead')
+    expect(extracted.company).toBe('Recovered Co')
   })
 
   it('records budget trace metadata and links cost when agentRunId is supplied', async () => {

--- a/lib/lead-from-meeting.ts
+++ b/lib/lead-from-meeting.ts
@@ -14,6 +14,7 @@ import {
   type AgentBudgetDecision,
 } from '@/lib/agent-budget-policy'
 import { recordAgentEvent, recordAgentStep } from '@/lib/agent-run'
+import { fetchProviderWithRetry } from '@/lib/llm/provider-fetch'
 
 const MAX_TRANSCRIPT_CHARS = 60_000
 const LEAD_EXTRACTION_MODEL = 'gpt-4o-mini'
@@ -187,7 +188,7 @@ export async function extractLeadFieldsFromTranscript(
     throw new LeadFromMeetingError(budgetDecision.reason, 'budget_blocked')
   }
 
-  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+  const response = await fetchProviderWithRetry('openai', 'https://api.openai.com/v1/chat/completions', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/lib/llm-dispatch.ts
+++ b/lib/llm-dispatch.ts
@@ -19,7 +19,7 @@ import {
   recordOpenAICost,
   type Usage,
 } from '@/lib/cost-calculator'
-import { withRetry } from '@/lib/llm/with-retry'
+import { fetchProviderWithRetry } from '@/lib/llm/provider-fetch'
 
 export interface LlmCostContext {
   reference?: { type: string; id: string }
@@ -46,67 +46,6 @@ export interface LlmJsonResponse {
 
 const DEFAULT_TEMPERATURE = 0.7
 const DEFAULT_MAX_TOKENS = 800
-const LLM_MAX_RETRIES = readNonNegativeIntegerEnv('LLM_MAX_RETRIES', 1)
-const LLM_RETRY_DELAY_MS = readNonNegativeIntegerEnv('LLM_RETRY_DELAY_MS', 500)
-
-function readNonNegativeIntegerEnv(name: string, fallback: number): number {
-  const value = Number(process.env[name])
-  if (!Number.isFinite(value) || value < 0) {
-    return fallback
-  }
-  return Math.floor(value)
-}
-
-class RetryableProviderStatusError extends Error {
-  constructor(
-    readonly provider: LlmProvider,
-    readonly status: number,
-    readonly responseText: string,
-  ) {
-    super(`${provider} request failed with retryable status ${status}`)
-    this.name = 'RetryableProviderStatusError'
-  }
-}
-
-function isRetryableProviderStatus(status: number): boolean {
-  return status === 408 || status === 429 || status === 500 || status === 502 || status === 503 || status === 504
-}
-
-async function fetchProviderWithRetry(
-  provider: LlmProvider,
-  url: string,
-  init: RequestInit,
-): Promise<Response> {
-  return withRetry(
-    async () => {
-      const response = await fetch(url, init)
-      if (isRetryableProviderStatus(response.status)) {
-        const responseText = await response.text().catch(() => '')
-        throw new RetryableProviderStatusError(provider, response.status, responseText.slice(0, 400))
-      }
-      return response
-    },
-    {
-      label: `${provider} llm dispatch`,
-      maxRetries: LLM_MAX_RETRIES,
-      baseDelayMs: LLM_RETRY_DELAY_MS,
-      maxDelayMs: Math.max(LLM_RETRY_DELAY_MS, 5_000),
-      jitterRatio: process.env.NODE_ENV === 'test' ? 0 : 0.1,
-      onRetry: ({ attemptNumber, nextDelayMs, error }) => {
-        console.warn(
-          `[llm-dispatch] ${provider} transient failure on attempt ${attemptNumber}; retrying in ${nextDelayMs ?? 0}ms`,
-          error instanceof Error ? error.message : error,
-        )
-      },
-      onGiveUp: ({ attemptNumber, error }) => {
-        console.warn(
-          `[llm-dispatch] ${provider} failed after attempt ${attemptNumber}`,
-          error instanceof Error ? error.message : error,
-        )
-      },
-    },
-  )
-}
 
 /**
  * Call the provider implied by `model` and return the raw JSON-string response.

--- a/lib/llm/provider-fetch.ts
+++ b/lib/llm/provider-fetch.ts
@@ -1,0 +1,64 @@
+import type { LlmProvider } from '@/lib/constants/llm-models'
+import { withRetry } from '@/lib/llm/with-retry'
+
+function readNonNegativeIntegerEnv(name: string, fallback: number): number {
+  const value = Number(process.env[name])
+  if (!Number.isFinite(value) || value < 0) {
+    return fallback
+  }
+  return Math.floor(value)
+}
+
+class RetryableProviderStatusError extends Error {
+  constructor(
+    readonly provider: LlmProvider,
+    readonly status: number,
+    readonly responseText: string,
+  ) {
+    super(`${provider} request failed with retryable status ${status}`)
+    this.name = 'RetryableProviderStatusError'
+  }
+}
+
+function isRetryableProviderStatus(status: number): boolean {
+  return status === 408 || status === 429 || status === 500 || status === 502 || status === 503 || status === 504
+}
+
+export async function fetchProviderWithRetry(
+  provider: LlmProvider,
+  url: string,
+  init: RequestInit,
+): Promise<Response> {
+  const maxRetries = readNonNegativeIntegerEnv('LLM_MAX_RETRIES', 1)
+  const retryDelayMs = readNonNegativeIntegerEnv('LLM_RETRY_DELAY_MS', 500)
+
+  return withRetry(
+    async () => {
+      const response = await fetch(url, init)
+      if (isRetryableProviderStatus(response.status)) {
+        const responseText = await response.text().catch(() => '')
+        throw new RetryableProviderStatusError(provider, response.status, responseText.slice(0, 400))
+      }
+      return response
+    },
+    {
+      label: `${provider} provider call`,
+      maxRetries,
+      baseDelayMs: retryDelayMs,
+      maxDelayMs: Math.max(retryDelayMs, 5_000),
+      jitterRatio: process.env.NODE_ENV === 'test' ? 0 : 0.1,
+      onRetry: ({ attemptNumber, nextDelayMs, error }) => {
+        console.warn(
+          `[provider-fetch] ${provider} transient failure on attempt ${attemptNumber}; retrying in ${nextDelayMs ?? 0}ms`,
+          error instanceof Error ? error.message : error,
+        )
+      },
+      onGiveUp: ({ attemptNumber, error }) => {
+        console.warn(
+          `[provider-fetch] ${provider} failed after attempt ${attemptNumber}`,
+          error instanceof Error ? error.message : error,
+        )
+      },
+    },
+  )
+}

--- a/lib/meeting-pain-classifier.test.ts
+++ b/lib/meeting-pain-classifier.test.ts
@@ -63,7 +63,7 @@ describe('meeting-pain-classifier', () => {
     mockRefreshCategoryStats.mockClear()
     mockLinkEvidenceToCalculations.mockClear()
     vi.unstubAllGlobals()
-    process.env = { ...originalEnv }
+    process.env = { ...originalEnv, LLM_RETRY_DELAY_MS: '0' }
   })
 
   afterEach(() => {
@@ -168,5 +168,57 @@ short
 
     expect(mockRefreshCategoryStats).toHaveBeenCalledTimes(2)
     expect(mockLinkEvidenceToCalculations).toHaveBeenCalledTimes(2)
+  })
+
+  it('retries a transient OpenAI classification failure before returning AI matches', async () => {
+    process.env.OPENAI_API_KEY = 'test-key'
+    mockCategoriesEq.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'cat-manual',
+          name: 'manual_processes',
+          display_name: 'Manual Processes',
+          description: 'Manual repetitive work',
+        },
+      ],
+      error: null,
+    })
+
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({
+        status: 503,
+        ok: false,
+        text: async () => 'temporarily unavailable',
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        json: async () => ({
+          choices: [
+            {
+              message: {
+                content: JSON.stringify([
+                  { index: 1, category_name: 'manual_processes', confidence: 0.74 },
+                ]),
+              },
+            },
+          ],
+        }),
+      })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const result = await classifyMeetingPainPoints(
+      'Operational ambiguity keeps creating buyer handoff drag',
+      ''
+    )
+
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(result.classified).toHaveLength(1)
+    expect(result.classified[0]).toMatchObject({
+      categoryId: 'cat-manual',
+      categoryName: 'manual_processes',
+      method: 'ai',
+    })
+    expect(result.unclassified).toEqual([])
   })
 })

--- a/lib/meeting-pain-classifier.ts
+++ b/lib/meeting-pain-classifier.ts
@@ -15,6 +15,7 @@ import { refreshCategoryStats, linkEvidenceToCalculations } from '@/lib/value-ev
 import { evaluateAgentBudget, type AgentBudgetDecision } from '@/lib/agent-budget-policy'
 import { recordAgentEvent, recordAgentStep } from '@/lib/agent-run'
 import { recordOpenAICost, type Usage } from '@/lib/cost-calculator'
+import { fetchProviderWithRetry } from '@/lib/llm/provider-fetch'
 
 // ============================================================================
 // Types
@@ -346,7 +347,7 @@ Only include items that have a reasonable match (confidence >= 0.3). Respond ONL
       throw new MeetingPainClassificationError(budgetDecision.reason, 'budget_blocked')
     }
 
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    const response = await fetchProviderWithRetry('openai', 'https://api.openai.com/v1/chat/completions', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- extract shared provider fetch retry wrapper for OpenAI/Anthropic calls
- keep llm-dispatch on the shared wrapper instead of private retry code
- adopt retryable provider fetches for audit-from-meetings, meeting lead extraction, AI onboarding preview, delivery email drafts, meeting pain classification, and in-person diagnostic insights
- add focused retry coverage for adopted direct OpenAI helpers
- update Agent Ops roadmap/task docs and scorecard for Phase 11 provider resilience progress

## Validation
- npm test -- --run lib/llm/with-retry.test.ts lib/__tests__/llm-dispatch.test.ts lib/audit-from-meetings.test.ts lib/lead-from-meeting.test.ts lib/ai-onboarding-generator.test.ts lib/delivery-email.test.ts
- npm test -- --run lib/meeting-pain-classifier.test.ts app/api/admin/sales/in-person-diagnostic/generate-insights/route.test.ts
- npx tsc --noEmit --pretty false
- git diff --check
- npm run build

Note: build passed with the existing local env warning that dev has MOCK_N8N=false and N8N_DISABLE_OUTBOUND=false configured. The push hook also ran the production database health check and reported healthy.