### PR TITLE
feat: retry media generation provider calls

### DIFF
--- a/app/api/admin/social-content/[id]/convert-to-carousel/route.test.ts
+++ b/app/api/admin/social-content/[id]/convert-to-carousel/route.test.ts
@@ -77,7 +77,7 @@ describe('POST /api/admin/social-content/[id]/convert-to-carousel', () => {
     vi.clearAllMocks()
     vi.spyOn(console, 'error').mockImplementation(() => {})
     vi.unstubAllGlobals()
-    process.env = { ...originalEnv, OPENAI_API_KEY: 'test-key' }
+    process.env = { ...originalEnv, OPENAI_API_KEY: 'test-key', LLM_RETRY_DELAY_MS: '0' }
 
     mocks.verifyAdmin.mockResolvedValue({
       user: { id: 'admin-user-1' },
@@ -271,6 +271,34 @@ describe('POST /api/admin/social-content/[id]/convert-to-carousel', () => {
         social_content_id: 'social-1',
       }),
     )
+  })
+
+  it('retries a transient OpenAI failure before rendering carousel assets', async () => {
+    const slides = [
+      { slideNumber: 1, heading: 'Reduce burden', body: 'Start with the real workflow.' },
+      { slideNumber: 2, heading: 'Find the drag', body: 'Name what costs time.' },
+      { slideNumber: 3, heading: 'Build lighter', body: 'Automate the repeatable work.' },
+    ]
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({
+        status: 503,
+        ok: false,
+        text: async () => 'temporarily unavailable',
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        json: async () => ({
+          choices: [{ message: { content: JSON.stringify({ slides }) } }],
+        }),
+      })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const response = await POST(makeRequest(), { params: { id: 'social-1' } })
+
+    expect(response.status).toBe(200)
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(mocks.renderCarousel).toHaveBeenCalledWith(slides)
   })
 
   it('evaluates normal carousel prompts within the manual budget', () => {

--- a/app/api/admin/social-content/[id]/convert-to-carousel/route.ts
+++ b/app/api/admin/social-content/[id]/convert-to-carousel/route.ts
@@ -18,6 +18,7 @@ import {
   SOCIAL_CAROUSEL_GENERATION_OPERATION,
   SocialCarouselGenerationError,
 } from '@/lib/social-carousel-generation'
+import { fetchProviderWithRetry } from '@/lib/llm/provider-fetch'
 
 export const dynamic = 'force-dynamic'
 export const maxDuration = 60
@@ -116,7 +117,7 @@ Hashtags: ${(row.hashtags || []).join(', ')}`
       throw new SocialCarouselGenerationError(budgetDecision.reason, 'budget_blocked')
     }
 
-    const aiResponse = await fetch('https://api.openai.com/v1/chat/completions', {
+    const aiResponse = await fetchProviderWithRetry('openai', 'https://api.openai.com/v1/chat/completions', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/app/api/admin/video-generation/format-prompt/route.test.ts
+++ b/app/api/admin/video-generation/format-prompt/route.test.ts
@@ -61,7 +61,7 @@ describe('POST /api/admin/video-generation/format-prompt', () => {
     vi.clearAllMocks()
     vi.spyOn(console, 'error').mockImplementation(() => {})
     vi.unstubAllGlobals()
-    process.env = { ...originalEnv, OPENAI_API_KEY: 'test-key' }
+    process.env = { ...originalEnv, OPENAI_API_KEY: 'test-key', LLM_RETRY_DELAY_MS: '0' }
     mocks.verifyAdmin.mockResolvedValue({
       user: { id: 'admin-user-1' },
       isAdmin: true,
@@ -210,6 +210,40 @@ describe('POST /api/admin/video-generation/format-prompt', () => {
       expect.stringContaining('Estimated cost'),
       { operation: 'video_prompt_format' },
     )
+  })
+
+  it('retries a transient OpenAI failure before returning the formatted prompt', async () => {
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({
+        status: 503,
+        ok: false,
+        text: async () => 'temporarily unavailable',
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        json: async () => ({
+          choices: [
+            {
+              message: {
+                content: 'TOPIC: Practical automation\nTARGET AUDIENCE: Small business owners',
+              },
+            },
+          ],
+        }),
+      })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const response = await POST(makeRequest({
+      rawText: 'I want a video about making automation practical.',
+    }))
+
+    expect(response.status).toBe(200)
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    await expect(response.json()).resolves.toEqual({
+      formattedPrompt: 'TOPIC: Practical automation\nTARGET AUDIENCE: Small business owners',
+      agentRunId: 'agent-run-1',
+    })
   })
 
   it('builds detail fields into the formatter user message', () => {

--- a/app/api/admin/video-generation/format-prompt/route.ts
+++ b/app/api/admin/video-generation/format-prompt/route.ts
@@ -21,6 +21,7 @@ import {
   VIDEO_PROMPT_FORMAT_OPERATION,
   VideoPromptFormatError,
 } from '@/lib/video-prompt-format'
+import { fetchProviderWithRetry } from '@/lib/llm/provider-fetch'
 
 export const dynamic = 'force-dynamic'
 
@@ -116,7 +117,7 @@ export async function POST(request: NextRequest) {
       throw new VideoPromptFormatError(budgetDecision.reason, 'budget_blocked')
     }
 
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    const response = await fetchProviderWithRetry('openai', 'https://api.openai.com/v1/chat/completions', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/app/api/admin/video-generation/generate-ideas/route.test.ts
+++ b/app/api/admin/video-generation/generate-ideas/route.test.ts
@@ -73,7 +73,7 @@ describe('POST /api/admin/video-generation/generate-ideas', () => {
     vi.clearAllMocks()
     vi.spyOn(console, 'error').mockImplementation(() => {})
     vi.unstubAllGlobals()
-    process.env = { ...originalEnv, OPENAI_API_KEY: 'test-key' }
+    process.env = { ...originalEnv, OPENAI_API_KEY: 'test-key', LLM_RETRY_DELAY_MS: '0' }
     mocks.verifyAdmin.mockResolvedValue({
       user: { id: 'admin-user-1' },
       isAdmin: true,
@@ -255,6 +255,53 @@ describe('POST /api/admin/video-generation/generate-ideas', () => {
       'agent-run-1',
       expect.stringContaining('Estimated cost'),
       expect.objectContaining({ operation: 'video_ideas_generation', mode: 'from_scratch' }),
+    )
+  })
+
+  it('retries a transient OpenAI failure before queueing generated ideas', async () => {
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({
+        status: 503,
+        ok: false,
+        text: async () => 'temporarily unavailable',
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        json: async () => ({
+          choices: [
+            {
+              message: {
+                content: JSON.stringify({
+                  ideas: [
+                    {
+                      title: 'Automation That Gives Time Back',
+                      script: 'A practical script.',
+                      storyboard: { scenes: [{ sceneNumber: 1, description: 'Open on admin workflow.' }] },
+                    },
+                  ],
+                }),
+              },
+            },
+          ],
+        }),
+      })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const response = await POST(makeRequest({
+      mode: 'from_direction',
+      customPrompt: 'Turn this note into one practical video.',
+      limit: 1,
+    }))
+
+    expect(response.status).toBe(200)
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        addedToQueue: 1,
+        mode: 'from_direction',
+        agentRunId: 'agent-run-1',
+      }),
     )
   })
 

--- a/app/api/admin/video-generation/generate-ideas/route.ts
+++ b/app/api/admin/video-generation/generate-ideas/route.ts
@@ -33,6 +33,7 @@ import {
   VIDEO_IDEAS_GENERATION_OPERATION,
   VideoIdeasGenerationError,
 } from '@/lib/video-ideas-generation'
+import { fetchProviderWithRetry } from '@/lib/llm/provider-fetch'
 
 export const dynamic = 'force-dynamic'
 
@@ -200,7 +201,7 @@ async function runGeneration(
 
   onStep?.({ step: 'calling_llm', detail: mode === 'from_direction' ? 'Polishing script with GPT-4o...' : 'Brainstorming with GPT-4o...' })
 
-  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+  const response = await fetchProviderWithRetry('openai', 'https://api.openai.com/v1/chat/completions', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -285,7 +285,7 @@ Current progress:
 - A reusable `lib/llm/with-retry.ts` helper is being introduced with capped exponential backoff, configurable retryable error matching, and a give-up hook for dead-letter integration.
 - The first adoption targets n8n trigger calls, where transient 502/503/504 and network failures can be retried without exposing raw provider errors to users.
 - The next adoption targets central LLM provider dispatch and the source-validator LLM judge, replacing bespoke retry loops with the shared helper.
-- Direct OpenAI helpers for audit-from-meetings, meeting lead extraction, AI onboarding preview, delivery email drafts, meeting pain classification, and in-person diagnostic insights now use a shared provider fetch wrapper.
+- Direct OpenAI helpers for audit-from-meetings, meeting lead extraction, AI onboarding preview, delivery email drafts, meeting pain classification, in-person diagnostic insights, social carousel conversion, video prompt formatting, and video ideas generation now use a shared provider fetch wrapper.
 - Mission Control surfaces the latest `agent_ops_morning_review` and `agent_ops_deployment_watch` traces as Operating Signals.
 - The deployment watcher supports `--trace` so integration-captain and autopilot runs write a visible Agent Ops run/artifact.
 - Stale-run detection now reports checked and marked counts by runtime across `codex`, `n8n`, `hermes`, `opencode`, and `manual` runs when those runtimes have active queued/running work.

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -50,6 +50,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
    - [x] Replace the source-validator LLM judge's bespoke retry loop with the shared helper.
    - [x] Adopt shared provider fetch retries for audit-from-meetings, meeting lead extraction, AI onboarding preview, and delivery email drafts.
    - [x] Adopt shared provider fetch retries for meeting pain classification and in-person diagnostic insights.
+   - [x] Adopt shared provider fetch retries for social carousel conversion, video prompt formatting, and video ideas generation.
    - Add remaining direct LLM/provider call-site adoptions where transient failures still use bespoke retry or plain `try/catch`.
 
 ## Completed Or In Review
@@ -93,6 +94,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 - [x] Central LLM dispatch and source-validator retry helper adoption in review.
 - [x] Direct OpenAI helper retry adoption for audit/lead/onboarding/delivery surfaces in review.
 - [x] Direct OpenAI helper retry adoption for meeting pain classification and in-person diagnostic insights in review.
+- [x] Direct OpenAI helper retry adoption for social carousel and video generation surfaces in review.
 
 ## Scope Guard
 

--- a/docs/agentic-patterns.md
+++ b/docs/agentic-patterns.md
@@ -341,7 +341,7 @@ Each section follows the same template: *Definition · Where we use it today · 
 - n8n trigger calls use the shared helper for transient network and gateway failures while preserving generic user-facing failure messages.
 - Central OpenAI/Anthropic JSON dispatch in [`lib/llm-dispatch.ts`](../lib/llm-dispatch.ts) uses the shared helper for retryable provider statuses.
 - The source-validator LLM judge in [`lib/source-validator/llm-judge.ts`](../lib/source-validator/llm-judge.ts) uses the shared helper instead of a bespoke retry loop.
-- Direct OpenAI helpers use [`lib/llm/provider-fetch.ts`](../lib/llm/provider-fetch.ts) for retryable provider failures across audit-from-meetings, meeting lead extraction, AI onboarding preview, delivery email drafts, meeting pain classification, and in-person diagnostic insights.
+- Direct OpenAI helpers use [`lib/llm/provider-fetch.ts`](../lib/llm/provider-fetch.ts) for retryable provider failures across audit-from-meetings, meeting lead extraction, AI onboarding preview, delivery email drafts, meeting pain classification, in-person diagnostic insights, social carousel conversion, video prompt formatting, and video ideas generation.
 
 **Coverage.** Partial / improving.
 
@@ -482,7 +482,7 @@ These are the first five PR-sized items seeded from the scorecard. Ticket 1 has 
 - **Scope.** Add `lib/llm/with-retry.ts` with capped exponential backoff + jitter, configurable retryable error matcher, and a dead-letter hook. Wrap the trigger functions in [`lib/n8n.ts`](../lib/n8n.ts) and the direct LLM call sites found via grep.
 - **First adoption.** n8n trigger calls now retry transient network and 502/503/504 failures through the shared helper.
 - **Follow-on adoption.** Central OpenAI/Anthropic JSON dispatch and source-validator LLM judge calls use the shared helper for retryable provider/network failures.
-- **Direct helper adoption.** Audit-from-meetings, meeting lead extraction, AI onboarding preview, delivery email drafts, meeting pain classification, and in-person diagnostic insights now use the shared provider fetch wrapper.
+- **Direct helper adoption.** Audit-from-meetings, meeting lead extraction, AI onboarding preview, delivery email drafts, meeting pain classification, in-person diagnostic insights, social carousel conversion, video prompt formatting, and video ideas generation now use the shared provider fetch wrapper.
 - **Acceptance criteria.**
   - Unit tests for: success-on-first-try, success-after-N-retries, gives-up-after-max, honors non-retryable errors.
   - User-facing errors remain generic per `no-expose-errors-to-users.mdc`.


### PR DESCRIPTION
## Summary
- adopt shared provider fetch retries for social carousel conversion
- adopt shared provider fetch retries for video prompt formatting
- adopt shared provider fetch retries for video ideas generation
- add transient OpenAI 503 retry coverage for all three media/video surfaces
- update Agent Ops roadmap/task docs and scorecard for Phase 11 progress

## Validation
- npm test -- --run app/api/admin/social-content/[id]/convert-to-carousel/route.test.ts app/api/admin/video-generation/format-prompt/route.test.ts app/api/admin/video-generation/generate-ideas/route.test.ts
- npx tsc --noEmit --pretty false
- git diff --check
- npm run build

Note: stacked on PR #177 because this depends on lib/llm/provider-fetch.ts from that branch. Build passed with the existing local env warning that dev has MOCK_N8N=false and N8N_DISABLE_OUTBOUND=false configured. Push hook ran the production DB health check and reported healthy.