### PR TITLE
feat: retry testing provider calls

### DIFF
--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -285,7 +285,7 @@ Current progress:
 - A reusable `lib/llm/with-retry.ts` helper is being introduced with capped exponential backoff, configurable retryable error matching, and a give-up hook for dead-letter integration.
 - The first adoption targets n8n trigger calls, where transient 502/503/504 and network failures can be retried without exposing raw provider errors to users.
 - The next adoption targets central LLM provider dispatch and the source-validator LLM judge, replacing bespoke retry loops with the shared helper.
-- Direct OpenAI helpers for audit-from-meetings, meeting lead extraction, AI onboarding preview, delivery email drafts, meeting pain classification, in-person diagnostic insights, social carousel conversion, video prompt formatting, and video ideas generation now use a shared provider fetch wrapper.
+- Direct provider helpers for audit-from-meetings, meeting lead extraction, AI onboarding preview, delivery email drafts, meeting pain classification, in-person diagnostic insights, social carousel conversion, video prompt formatting, video ideas generation, dev testing remediation, and dev testing chat-agent calls now use a shared provider fetch wrapper.
 - Mission Control surfaces the latest `agent_ops_morning_review` and `agent_ops_deployment_watch` traces as Operating Signals.
 - The deployment watcher supports `--trace` so integration-captain and autopilot runs write a visible Agent Ops run/artifact.
 - Stale-run detection now reports checked and marked counts by runtime across `codex`, `n8n`, `hermes`, `opencode`, and `manual` runs when those runtimes have active queued/running work.

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -51,6 +51,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
    - [x] Adopt shared provider fetch retries for audit-from-meetings, meeting lead extraction, AI onboarding preview, and delivery email drafts.
    - [x] Adopt shared provider fetch retries for meeting pain classification and in-person diagnostic insights.
    - [x] Adopt shared provider fetch retries for social carousel conversion, video prompt formatting, and video ideas generation.
+   - [x] Adopt shared provider fetch retries for dev testing chat-agent and remediation LLM helpers.
    - Add remaining direct LLM/provider call-site adoptions where transient failures still use bespoke retry or plain `try/catch`.
 
 ## Completed Or In Review
@@ -95,6 +96,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 - [x] Direct OpenAI helper retry adoption for audit/lead/onboarding/delivery surfaces in review.
 - [x] Direct OpenAI helper retry adoption for meeting pain classification and in-person diagnostic insights in review.
 - [x] Direct OpenAI helper retry adoption for social carousel and video generation surfaces in review.
+- [x] Dev testing LLM helper retry adoption for chat-agent and remediation surfaces in review.
 
 ## Scope Guard
 

--- a/docs/agentic-patterns.md
+++ b/docs/agentic-patterns.md
@@ -341,7 +341,7 @@ Each section follows the same template: *Definition · Where we use it today · 
 - n8n trigger calls use the shared helper for transient network and gateway failures while preserving generic user-facing failure messages.
 - Central OpenAI/Anthropic JSON dispatch in [`lib/llm-dispatch.ts`](../lib/llm-dispatch.ts) uses the shared helper for retryable provider statuses.
 - The source-validator LLM judge in [`lib/source-validator/llm-judge.ts`](../lib/source-validator/llm-judge.ts) uses the shared helper instead of a bespoke retry loop.
-- Direct OpenAI helpers use [`lib/llm/provider-fetch.ts`](../lib/llm/provider-fetch.ts) for retryable provider failures across audit-from-meetings, meeting lead extraction, AI onboarding preview, delivery email drafts, meeting pain classification, in-person diagnostic insights, social carousel conversion, video prompt formatting, and video ideas generation.
+- Direct provider helpers use [`lib/llm/provider-fetch.ts`](../lib/llm/provider-fetch.ts) for retryable provider failures across audit-from-meetings, meeting lead extraction, AI onboarding preview, delivery email drafts, meeting pain classification, in-person diagnostic insights, social carousel conversion, video prompt formatting, video ideas generation, dev testing remediation, and dev testing chat-agent calls.
 
 **Coverage.** Partial / improving.
 
@@ -434,7 +434,7 @@ Each section follows the same template: *Definition · Where we use it today · 
 - Admin meeting pain classification checks the manual-runtime budget before GPT-4o-mini fallback classification and links AI fallback cost events to its Agent Ops trace.
 - Admin Chat Eval LLM judge evaluation checks the manual-runtime budget before Anthropic/OpenAI dispatch and links judge cost events to its Agent Ops trace.
 - Admin Chat Eval axial-code generation and error diagnosis check the manual-runtime budget before Anthropic/OpenAI dispatch and link judge cost events to Agent Ops traces.
-- Value Evidence source validation and dev testing LLM helpers check budget before direct provider calls.
+- Value Evidence source validation and dev testing LLM helpers check budget before direct provider calls; dev testing chat-agent and remediation helpers also retry transient provider failures through the shared provider fetch wrapper.
 - Cost-events ingest accumulates spend per event.
 - `cost_events.agent_run_id` links usage costs to shared Agent Ops traces.
 - Mission Control derives 24-hour Cost Intelligence by runtime, agent, workflow, client/project, and artifact type where run metadata exists.
@@ -482,7 +482,7 @@ These are the first five PR-sized items seeded from the scorecard. Ticket 1 has 
 - **Scope.** Add `lib/llm/with-retry.ts` with capped exponential backoff + jitter, configurable retryable error matcher, and a dead-letter hook. Wrap the trigger functions in [`lib/n8n.ts`](../lib/n8n.ts) and the direct LLM call sites found via grep.
 - **First adoption.** n8n trigger calls now retry transient network and 502/503/504 failures through the shared helper.
 - **Follow-on adoption.** Central OpenAI/Anthropic JSON dispatch and source-validator LLM judge calls use the shared helper for retryable provider/network failures.
-- **Direct helper adoption.** Audit-from-meetings, meeting lead extraction, AI onboarding preview, delivery email drafts, meeting pain classification, in-person diagnostic insights, social carousel conversion, video prompt formatting, and video ideas generation now use the shared provider fetch wrapper.
+- **Direct helper adoption.** Audit-from-meetings, meeting lead extraction, AI onboarding preview, delivery email drafts, meeting pain classification, in-person diagnostic insights, social carousel conversion, video prompt formatting, video ideas generation, dev testing remediation, and dev testing chat-agent calls now use the shared provider fetch wrapper.
 - **Acceptance criteria.**
   - Unit tests for: success-on-first-try, success-after-N-retries, gives-up-after-max, honors non-retryable errors.
   - User-facing errors remain generic per `no-expose-errors-to-users.mdc`.

--- a/lib/testing/chat-agent.test.ts
+++ b/lib/testing/chat-agent.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ChatAgent } from './chat-agent'
+import type { ChatAgentConfig, TestPersona, TestScenario } from './types'
+
+const persona: TestPersona = {
+  id: 'persona-1',
+  name: 'Anna',
+  company: 'Berin Studio',
+  email: 'test-anna@example.com',
+  role: 'decision_maker',
+  urgency: 'medium',
+  budget: '$5K-$15K',
+  techSavvy: 6,
+  decisionTimeline: '30_days',
+  painPoints: ['manual follow-up'],
+  interestAreas: ['ai_automation'],
+  communicationStyle: 'brief',
+  objectionProbability: 0.2,
+  commonObjections: ['Will this add more work?'],
+}
+
+const scenario: TestScenario = {
+  id: 'scenario-1',
+  name: 'Chat inquiry',
+  description: 'A prospect asks about automation.',
+  journeyStage: 'prospect',
+  steps: [],
+  variability: {
+    skipProbability: {},
+    delayRange: [0, 0],
+    responseVariation: false,
+  },
+  expectedOutcomes: {
+    mustComplete: [],
+    mustNotError: [],
+    dataValidation: [],
+  },
+  estimatedDuration: 0,
+  tags: ['chat'],
+}
+
+function config(overrides: Partial<ChatAgentConfig> = {}): ChatAgentConfig {
+  return {
+    persona,
+    scenario,
+    llmProvider: 'openai',
+    model: 'gpt-4o-mini',
+    maxTurns: 5,
+    responseDelay: [0, 1],
+    temperature: 0.7,
+    ...overrides,
+  }
+}
+
+describe('ChatAgent provider retries', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.unstubAllGlobals()
+    process.env = {
+      ...originalEnv,
+      OPENAI_API_KEY: 'test-openai-key',
+      ANTHROPIC_API_KEY: 'test-anthropic-key',
+      LLM_RETRY_DELAY_MS: '0',
+    }
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    process.env = { ...originalEnv }
+  })
+
+  it('retries transient OpenAI failures before returning a generated client response', async () => {
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({
+        status: 503,
+        ok: false,
+        text: async () => 'temporarily unavailable',
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        json: async () => ({
+          choices: [{ message: { content: 'Yes, I want the workflow to feel lighter.' } }],
+        }),
+      })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const agent = new ChatAgent(config())
+    const response = await agent.generateResponse('What brings you here?')
+
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(response).toEqual({
+      message: 'Yes, I want the workflow to feel lighter.',
+      shouldContinue: true,
+    })
+  })
+
+  it('retries transient Anthropic failures before returning a generated client response', async () => {
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({
+        status: 503,
+        ok: false,
+        text: async () => 'temporarily unavailable',
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        json: async () => ({
+          content: [{ text: 'I need help reducing manual follow-up.' }],
+        }),
+      })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const agent = new ChatAgent(config({ llmProvider: 'anthropic', model: 'claude-3-haiku-20240307' }))
+    const response = await agent.generateResponse('What brings you here?')
+
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(response).toEqual({
+      message: 'I need help reducing manual follow-up.',
+      shouldContinue: true,
+    })
+  })
+})

--- a/lib/testing/chat-agent.ts
+++ b/lib/testing/chat-agent.ts
@@ -15,6 +15,7 @@ import type {
   DiagnosticStep
 } from './types'
 import { evaluateAgentBudget } from '@/lib/agent-budget-policy'
+import { fetchProviderWithRetry } from '@/lib/llm/provider-fetch'
 
 // ============================================================================
 // System Prompts
@@ -345,7 +346,7 @@ export class ChatAgent {
       throw new Error(budgetDecision.reason)
     }
 
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    const response = await fetchProviderWithRetry('openai', 'https://api.openai.com/v1/chat/completions', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -407,7 +408,7 @@ export class ChatAgent {
       throw new Error(budgetDecision.reason)
     }
     
-    const response = await fetch('https://api.anthropic.com/v1/messages', {
+    const response = await fetchProviderWithRetry('anthropic', 'https://api.anthropic.com/v1/messages', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/lib/testing/remediation.test.ts
+++ b/lib/testing/remediation.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TestErrorContext, TestPersona } from './types'
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({})),
+}))
+
+import { RemediationEngine } from './remediation'
+
+const persona: TestPersona = {
+  id: 'persona-1',
+  name: 'Anna',
+  company: 'Berin Studio',
+  email: 'test-anna@example.com',
+  role: 'decision_maker',
+  urgency: 'medium',
+  budget: '$5K-$15K',
+  techSavvy: 6,
+  decisionTimeline: '30_days',
+  painPoints: ['manual follow-up'],
+  interestAreas: ['ai_automation'],
+  communicationStyle: 'brief',
+  objectionProbability: 0.2,
+  commonObjections: ['Will this add more work?'],
+}
+
+function errorContext(overrides: Partial<TestErrorContext> = {}): TestErrorContext {
+  return {
+    errorId: 'err-1',
+    testRunId: 'run-1',
+    clientSessionId: 'session-1',
+    timestamp: new Date('2026-05-08T00:00:00Z').toISOString(),
+    errorType: 'api_error',
+    errorMessage: 'API returned 500',
+    scenario: 'Chat inquiry',
+    stepIndex: 1,
+    stepType: 'chat',
+    persona,
+    likelySourceFiles: ['app/api/chat/route.ts'],
+    relevantCodeSnippets: [
+      {
+        file: 'app/api/chat/route.ts',
+        startLine: 1,
+        endLine: 3,
+        content: 'export async function POST() { return Response.json({ ok: false }) }',
+      },
+    ],
+    ...overrides,
+  }
+}
+
+describe('RemediationEngine provider retries', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.unstubAllGlobals()
+    process.env = {
+      ...originalEnv,
+      NEXT_PUBLIC_SUPABASE_URL: 'https://example.supabase.co',
+      SUPABASE_SERVICE_ROLE_KEY: 'test-service-role',
+      OPENAI_API_KEY: 'test-openai-key',
+      LLM_RETRY_DELAY_MS: '0',
+    }
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    process.env = { ...originalEnv }
+  })
+
+  it('retries transient OpenAI failures while enhancing test error analysis', async () => {
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({
+        status: 503,
+        ok: false,
+        text: async () => 'temporarily unavailable',
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        json: async () => ({
+          choices: [
+            {
+              message: {
+                content: JSON.stringify({
+                  rootCause: 'The chat route returned an unhandled server error.',
+                  suggestedApproach: 'Add a guarded response path and cover it with an API test.',
+                  additionalFiles: ['lib/chat/service.ts'],
+                }),
+              },
+            },
+          ],
+        }),
+      })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const engine = new RemediationEngine()
+    const analysis = await engine.analyzeErrors([errorContext()])
+
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(analysis.rootCause).toBe('The chat route returned an unhandled server error.')
+    expect(analysis.suggestedApproach).toBe('Add a guarded response path and cover it with an API test.')
+    expect(analysis.affectedFiles).toContain('lib/chat/service.ts')
+  })
+
+  it('retries transient OpenAI failures while generating a proposed test fix', async () => {
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({
+        status: 503,
+        ok: false,
+        text: async () => 'temporarily unavailable',
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        json: async () => ({
+          choices: [
+            {
+              message: {
+                content: JSON.stringify({
+                  fixedContent: 'export async function POST() { return Response.json({ ok: true }) }',
+                  explanation: 'Return a successful response for the tested path.',
+                }),
+              },
+            },
+          ],
+        }),
+      })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const engine = new RemediationEngine()
+    const fixes = await engine.generateFixes(
+      [errorContext()],
+      {
+        rootCause: 'The chat route returned an unhandled server error.',
+        suggestedApproach: 'Guard the response path.',
+        affectedFiles: ['app/api/chat/route.ts'],
+        confidence: 0.8,
+        estimatedComplexity: 'simple',
+      },
+    )
+
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(fixes).toHaveLength(1)
+    expect(fixes[0]).toMatchObject({
+      file: 'app/api/chat/route.ts',
+      fixedContent: 'export async function POST() { return Response.json({ ok: true }) }',
+      explanation: 'Return a successful response for the tested path.',
+    })
+  })
+})

--- a/lib/testing/remediation.ts
+++ b/lib/testing/remediation.ts
@@ -19,6 +19,7 @@ import { createClient } from '@supabase/supabase-js'
 import { n8nWebhookUrl } from '../n8n'
 import { testDb } from './test-db-cast'
 import { evaluateAgentBudget } from '@/lib/agent-budget-policy'
+import { fetchProviderWithRetry } from '@/lib/llm/provider-fetch'
 
 // ============================================================================
 // Configuration
@@ -477,7 +478,7 @@ Respond with JSON in this format:
         maxTokens: 1000,
         operation: 'testing_fix_generation',
       })
-      const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      const response = await fetchProviderWithRetry('openai', 'https://api.openai.com/v1/chat/completions', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -548,7 +549,7 @@ Provide a more detailed analysis in JSON format:
         maxTokens: 1000,
         operation: 'testing_analysis_enhancement',
       })
-      const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      const response = await fetchProviderWithRetry('openai', 'https://api.openai.com/v1/chat/completions', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- route dev testing chat-agent OpenAI and Anthropic calls through the shared provider retry wrapper
- route dev testing remediation OpenAI analysis/fix generation calls through the shared provider retry wrapper
- add transient 503 retry coverage for chat-agent OpenAI, chat-agent Anthropic, remediation analysis, and remediation fix generation
- update Agent Ops roadmap/task docs and exception-handling scorecard for Phase 11 progress

## Validation
- npm test -- --run lib/testing/chat-agent.test.ts lib/testing/remediation.test.ts
- npx tsc --noEmit --pretty false
- git diff --check
- npm run build

Note: build passed with the existing local env warning that dev has MOCK_N8N=false and N8N_DISABLE_OUTBOUND=false configured. Push hook ran the production DB health check and reported healthy. This branch is independent of live workflow execution and uses mocked provider responses in tests.