### PR TITLE
chore: add Vercel deployment metrics

### DIFF
--- a/docs/agents/git-hygiene-watch-classifications.md
+++ b/docs/agents/git-hygiene-watch-classifications.md
@@ -32,7 +32,7 @@ These local branches have deleted upstreams and one commit not reachable from `o
 
 ## Vercel Staging Lag
 
-Classification: `watch`.
+Classification: `debt`.
 
 Use the thresholds in `docs/agents/vercel-verifier.md`:
 
@@ -41,7 +41,19 @@ Use the thresholds in `docs/agents/vercel-verifier.md`:
 - over 10 minutes repeatedly: `debt`
 - failed, cancelled, or timed out: `blocker`
 
-Next action: keep collecting timing through `npm run deploy:watch`; only escalate if staging repeatedly exceeds the debt threshold.
+Current finding: recent deployment metrics show `portfolio-staging` waits much longer than `portfolio` before builds start because both Vercel projects build the same PR branches. This is an integration-flow bottleneck, not only normal queue variance.
+
+Next action:
+
+1. Run `npm run deploy:metrics` during captain sweeps to keep queue/build timing visible.
+2. Change the pre-merge gate so routine PRs require the `portfolio` preview plus local/GitHub checks, while `portfolio-staging` remains required after merge on `main`.
+3. After the gate is updated, configure the `portfolio-staging` Vercel project to skip preview builds with:
+
+   ```bash
+   [ "$VERCEL_ENV" = "preview" ] && exit 0 || exit 1
+   ```
+
+4. Do not apply that Vercel ignore rule while branch protection or captain policy still requires a successful `Vercel – portfolio-staging` preview context.
 
 ## GitHub Transient Merge Errors
 

--- a/docs/agents/integration-captain.md
+++ b/docs/agents/integration-captain.md
@@ -53,7 +53,7 @@ Before merging a PR:
 - PR has an impact preflight when it touches a hot surface or overlaps another active branch.
 - Required validation is documented in the PR or handoff.
 - `Vercel - portfolio` preview is success.
-- `Vercel - portfolio-staging` preview is success.
+- `Vercel - portfolio-staging` preview is not required for routine PRs once the staging project is configured to skip preview builds. If a PR explicitly changes staging env handling, n8n integration behavior, Vercel config, or release gates, require a staging preview or an equivalent staging smoke before merge.
 - Security-sensitive changes have a clear approval or fail-closed posture.
 - Production config, secrets, external sends, publishing, and database writes have explicit approval when required.
 
@@ -129,6 +129,7 @@ If that command returns commits, classify the branch as `watch` or `debt` instea
 
 - Process one non-draft PR at a time.
 - Do not start the next merge until both post-merge Vercel contexts are green.
+- Treat `portfolio` preview as the routine pre-merge Vercel gate. Treat `portfolio-staging` as a post-merge production-parity gate unless the PR touches staging-sensitive surfaces.
 - Treat draft PRs as `normal` unless they overlap hot files, stay stale for several days, or their work already landed elsewhere.
 - Promote a draft PR to merge consideration only after the owner marks it ready or the captain verifies its intent directly.
 - If two PRs touch the same hot files, merge the lower-risk/shared-foundation PR first, then re-check the second PR against updated `main`.

--- a/docs/vercel-deployment-runbook.md
+++ b/docs/vercel-deployment-runbook.md
@@ -12,7 +12,7 @@ Portfolio deployment is only complete when both contexts pass:
 Run the watcher before merge for the PR head SHA and after merge for the merge SHA or `main`.
 
 ```bash
-npm run deploy:watch:once -- --ref <pr-head-sha> --trace
+npm run deploy:watch:once -- --ref <pr-head-sha> --contexts "Vercel – portfolio" --trace
 npm run deploy:watch -- --ref <merge-sha> --timeout 900 --interval 30 --trace
 npm run deploy:watch -- --ref main --timeout 900 --interval 30 --trace
 ```
@@ -34,6 +34,50 @@ vercel ls portfolio --scope vsillahs-projects
 vercel ls portfolio-staging --scope vsillahs-projects
 vercel inspect <deployment-url> --scope vsillahs-projects
 ```
+
+For queue/build timing evidence, run:
+
+```bash
+npm run deploy:metrics
+```
+
+Use the metrics report to distinguish:
+
+- queue time: Vercel concurrency pressure before the build starts,
+- build time: actual project build duration,
+- total time: end-to-end wait from deployment creation to ready.
+
+## Queue Reduction Policy
+
+Portfolio currently has two Vercel projects attached to the same GitHub repo:
+
+- `portfolio`
+- `portfolio-staging`
+
+This is useful for production/staging parity, but it can double preview-build
+pressure when every PR branch creates deployments in both projects. If staging
+preview builds repeatedly delay integration, prefer this rollout:
+
+1. Keep `portfolio` preview deployments as the routine pre-merge PR gate.
+2. Keep both `portfolio` and `portfolio-staging` production deployments as the post-merge gate.
+3. Stop `portfolio-staging` from building routine PR preview branches.
+4. Require an explicit staging preview or equivalent staging smoke only when a PR touches staging env handling, n8n integration behavior, Vercel config, or release gates.
+
+Recommended `portfolio-staging` Ignored Build Step once the gate is updated:
+
+```bash
+[ "$VERCEL_ENV" = "preview" ] && exit 0 || exit 1
+```
+
+Vercel semantics: exit `0` cancels the build; exit `1` continues the build.
+Apply this only to `portfolio-staging`, not to `portfolio`, because the main
+project still needs PR previews.
+
+Do not apply the ignore rule if GitHub branch protection requires
+`Vercel – portfolio-staging` to pass on PR branches. In that case, skipped
+staging previews may leave otherwise mergeable PRs blocked or unstable. As of
+2026-05-08, GitHub `main` branch protection is not enforcing required status
+checks, so this rule is owned by integration-captain policy rather than GitHub.
 
 ## Premium Plan Guidance
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "db:health-check:dev:update": "tsx scripts/database-health-check.ts --dev --update",
     "deploy:watch": "tsx scripts/vercel-deployment-watch.ts",
     "deploy:watch:once": "tsx scripts/vercel-deployment-watch.ts --once",
+    "deploy:metrics": "tsx scripts/vercel-deployment-metrics.ts",
     "git:hygiene:report": "tsx scripts/git-hygiene-report.ts",
     "wrm:smoke-gate": "tsx scripts/wrm-production-smoke-gate.ts",
     "source-protocol:smoke": "tsx scripts/source-protocol-smoke.ts",

--- a/scripts/vercel-deployment-metrics.ts
+++ b/scripts/vercel-deployment-metrics.ts
@@ -1,0 +1,242 @@
+#!/usr/bin/env tsx
+import { spawnSync } from 'node:child_process'
+
+type VercelDeployment = {
+  url: string
+  name: string
+  state: string
+  target?: string | null
+  createdAt?: number
+  buildingAt?: number
+  ready?: number
+  meta?: {
+    githubPrId?: string
+    githubCommitRef?: string
+    githubCommitSha?: string
+    githubCommitMessage?: string
+  }
+}
+
+type VercelListResponse = {
+  deployments?: VercelDeployment[]
+}
+
+type DeploymentMetric = {
+  project: string
+  state: string
+  target: string
+  ref: string
+  pr: string
+  url: string
+  queueSeconds: number | null
+  buildSeconds: number | null
+  totalSeconds: number | null
+}
+
+type MetricSummary = {
+  project: string
+  target: string
+  count: number
+  averageQueueSeconds: number
+  averageBuildSeconds: number
+  averageTotalSeconds: number
+  maxTotalSeconds: number
+}
+
+const DEFAULT_PROJECTS = ['portfolio', 'portfolio-staging']
+
+function parseArgs(argv: string[]) {
+  const options = {
+    projects: [...DEFAULT_PROJECTS],
+    limit: 20,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    const next = argv[index + 1]
+
+    if (arg === '--projects' && next) {
+      options.projects = next
+        .split(',')
+        .map((project) => project.trim())
+        .filter(Boolean)
+      index += 1
+    } else if (arg === '--limit' && next) {
+      options.limit = Number(next)
+      index += 1
+    } else if (arg === '--help' || arg === '-h') {
+      console.log(`Usage:
+  npm run deploy:metrics -- [options]
+
+Options:
+  --projects <a,b>   Vercel projects to inspect. Defaults to portfolio,portfolio-staging.
+  --limit <n>        Number of recent deployments per project to include. Defaults to 20.
+`)
+      process.exit(0)
+    }
+  }
+
+  if (options.projects.length === 0) {
+    throw new Error('--projects must include at least one project')
+  }
+
+  if (!Number.isFinite(options.limit) || options.limit <= 0) {
+    throw new Error('--limit must be a positive number')
+  }
+
+  return options
+}
+
+function runVercelList(project: string): VercelDeployment[] {
+  const result = spawnSync('vercel', ['ls', project, '--yes', '--format', 'json'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  if (result.status !== 0) {
+    const message = result.stderr.trim() || result.stdout.trim() || 'vercel ls failed'
+    throw new Error(`${project}: ${message}`)
+  }
+
+  const parsed = JSON.parse(result.stdout) as VercelListResponse
+  return parsed.deployments ?? []
+}
+
+function secondsBetween(end: number | undefined, start: number | undefined): number | null {
+  if (!end || !start || end < start) return null
+  return Math.round((end - start) / 1000)
+}
+
+function toMetric(project: string, deployment: VercelDeployment, now = Date.now()): DeploymentMetric {
+  const target = deployment.target ?? 'preview'
+  const createdAt = deployment.createdAt
+  const buildingAt = deployment.buildingAt
+  const readyAt = deployment.ready
+
+  const queueSeconds = buildingAt
+    ? secondsBetween(buildingAt, createdAt)
+    : deployment.state === 'QUEUED'
+      ? secondsBetween(now, createdAt)
+      : null
+
+  const buildSeconds = readyAt && buildingAt
+    ? secondsBetween(readyAt, buildingAt)
+    : deployment.state === 'BUILDING'
+      ? secondsBetween(now, buildingAt ?? createdAt)
+      : null
+
+  const totalSeconds = readyAt
+    ? secondsBetween(readyAt, createdAt)
+    : deployment.state === 'QUEUED' || deployment.state === 'BUILDING'
+      ? secondsBetween(now, createdAt)
+      : null
+
+  return {
+    project,
+    state: deployment.state,
+    target,
+    ref: deployment.meta?.githubCommitRef ?? 'unknown',
+    pr: deployment.meta?.githubPrId ?? '',
+    url: deployment.url,
+    queueSeconds,
+    buildSeconds,
+    totalSeconds,
+  }
+}
+
+function average(values: Array<number | null>): number {
+  const finite = values.filter((value): value is number => Number.isFinite(value))
+  if (finite.length === 0) return 0
+  return finite.reduce((sum, value) => sum + value, 0) / finite.length
+}
+
+function summarize(metrics: DeploymentMetric[]): MetricSummary[] {
+  const readyMetrics = metrics.filter((metric) => metric.state === 'READY' && metric.totalSeconds !== null)
+  const groups = new Map<string, DeploymentMetric[]>()
+
+  for (const metric of readyMetrics) {
+    const key = `${metric.project}:${metric.target}`
+    groups.set(key, [...(groups.get(key) ?? []), metric])
+  }
+
+  return [...groups.entries()]
+    .map(([key, group]) => {
+      const [project, target] = key.split(':')
+      return {
+        project,
+        target,
+        count: group.length,
+        averageQueueSeconds: average(group.map((metric) => metric.queueSeconds)),
+        averageBuildSeconds: average(group.map((metric) => metric.buildSeconds)),
+        averageTotalSeconds: average(group.map((metric) => metric.totalSeconds)),
+        maxTotalSeconds: Math.max(...group.map((metric) => metric.totalSeconds ?? 0)),
+      }
+    })
+    .sort((a, b) => a.project.localeCompare(b.project) || a.target.localeCompare(b.target))
+}
+
+function formatSeconds(seconds: number | null): string {
+  if (seconds === null) return '-'
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  const remainder = seconds % 60
+  return `${minutes}m${remainder.toString().padStart(2, '0')}s`
+}
+
+function printSummary(summaries: MetricSummary[]) {
+  console.log('Deployment Timing Summary')
+  console.log('project\ttarget\tcount\tavg_queue\tavg_build\tavg_total\tmax_total')
+
+  for (const summary of summaries) {
+    console.log(
+      [
+        summary.project,
+        summary.target,
+        summary.count,
+        formatSeconds(Math.round(summary.averageQueueSeconds)),
+        formatSeconds(Math.round(summary.averageBuildSeconds)),
+        formatSeconds(Math.round(summary.averageTotalSeconds)),
+        formatSeconds(Math.round(summary.maxTotalSeconds)),
+      ].join('\t')
+    )
+  }
+}
+
+function printRecent(metrics: DeploymentMetric[]) {
+  console.log('')
+  console.log('Recent Deployments')
+  console.log('project\tstate\ttarget\tpr\tqueue\tbuild\ttotal\tref\turl')
+
+  for (const metric of metrics) {
+    console.log(
+      [
+        metric.project,
+        metric.state,
+        metric.target,
+        metric.pr || '-',
+        formatSeconds(metric.queueSeconds),
+        formatSeconds(metric.buildSeconds),
+        formatSeconds(metric.totalSeconds),
+        metric.ref,
+        metric.url,
+      ].join('\t')
+    )
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  const metrics = options.projects.flatMap((project) =>
+    runVercelList(project)
+      .slice(0, options.limit)
+      .map((deployment) => toMetric(project, deployment))
+  )
+
+  printSummary(summarize(metrics))
+  printRecent(metrics)
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- add npm run deploy:metrics to summarize Vercel queue/build/total times across portfolio and portfolio-staging
- update the deployment runbook with the queue-reduction policy and staging preview skip command
- update integration captain guidance so routine PRs use portfolio preview before merge while both production deployments remain post-merge gates
- reclassify staging lag as deployment-flow debt with concrete next actions

## Validation
- npm run deploy:metrics -- --limit 8
- npm run deploy:metrics -- --limit 4
- npx tsc --noEmit --pretty false
- git diff --check
- push hook database health check

## Operational note
I did not apply the live Vercel ignored-build setting because the Vercel connector returned 403 for project settings and the CLI does not expose a project-setting update command for commandForIgnoringBuildStep. The documented staging project setting is: `[ "" = "preview" ] && exit 0 || exit 1`.