### PR TITLE
docs: document disabled staging previews

### DIFF
--- a/docs/agents/git-hygiene-watch-classifications.md
+++ b/docs/agents/git-hygiene-watch-classifications.md
@@ -47,13 +47,10 @@ Next action:
 
 1. Run `npm run deploy:metrics` during captain sweeps to keep queue/build timing visible.
 2. Change the pre-merge gate so routine PRs require the `portfolio` preview plus local/GitHub checks, while `portfolio-staging` remains required after merge on `main`.
-3. After the gate is updated, configure the `portfolio-staging` Vercel project to skip preview builds with:
+3. After the gate is updated, configure the `portfolio-staging` Vercel project with `previewDeploymentsDisabled: true`.
+4. Do not disable staging preview deployments while branch protection or captain policy still requires a successful `Vercel – portfolio-staging` preview context.
 
-   ```bash
-   [ "$VERCEL_ENV" = "preview" ] && exit 0 || exit 1
-   ```
-
-4. Do not apply that Vercel ignore rule while branch protection or captain policy still requires a successful `Vercel – portfolio-staging` preview context.
+Resolution note, 2026-05-08: `portfolio-staging` was configured with `previewDeploymentsDisabled: true`. A smoke branch confirmed the next branch push created a `portfolio` preview only; no new `portfolio-staging` preview deployment was created.
 
 ## GitHub Transient Merge Errors
 

--- a/docs/agents/integration-captain.md
+++ b/docs/agents/integration-captain.md
@@ -53,7 +53,7 @@ Before merging a PR:
 - PR has an impact preflight when it touches a hot surface or overlaps another active branch.
 - Required validation is documented in the PR or handoff.
 - `Vercel - portfolio` preview is success.
-- `Vercel - portfolio-staging` preview is not required for routine PRs once the staging project is configured to skip preview builds. If a PR explicitly changes staging env handling, n8n integration behavior, Vercel config, or release gates, require a staging preview or an equivalent staging smoke before merge.
+- `Vercel - portfolio-staging` preview is not required for routine PRs while the staging project has preview deployments disabled. If a PR explicitly changes staging env handling, n8n integration behavior, Vercel config, or release gates, require an equivalent staging smoke before merge.
 - Security-sensitive changes have a clear approval or fail-closed posture.
 - Production config, secrets, external sends, publishing, and database writes have explicit approval when required.
 

--- a/docs/vercel-deployment-runbook.md
+++ b/docs/vercel-deployment-runbook.md
@@ -63,21 +63,22 @@ preview builds repeatedly delay integration, prefer this rollout:
 3. Stop `portfolio-staging` from building routine PR preview branches.
 4. Require an explicit staging preview or equivalent staging smoke only when a PR touches staging env handling, n8n integration behavior, Vercel config, or release gates.
 
-Recommended `portfolio-staging` Ignored Build Step once the gate is updated:
+Live `portfolio-staging` setting as of 2026-05-08:
 
-```bash
-[ "$VERCEL_ENV" = "preview" ] && exit 0 || exit 1
-```
+- `previewDeploymentsDisabled: true`
 
-Vercel semantics: exit `0` cancels the build; exit `1` continues the build.
+This setting is stronger than an Ignored Build Step. The ignored-build command
+still creates and queues a deployment before Vercel can evaluate the command,
+which does not remove the queue bottleneck. Disabling staging preview
+deployments prevents routine PR branches from entering the staging project queue
+at all.
+
 Apply this only to `portfolio-staging`, not to `portfolio`, because the main
-project still needs PR previews.
-
-Do not apply the ignore rule if GitHub branch protection requires
-`Vercel – portfolio-staging` to pass on PR branches. In that case, skipped
-staging previews may leave otherwise mergeable PRs blocked or unstable. As of
-2026-05-08, GitHub `main` branch protection is not enforcing required status
-checks, so this rule is owned by integration-captain policy rather than GitHub.
+project still needs PR previews. Do not disable staging previews if GitHub
+branch protection requires `Vercel – portfolio-staging` to pass on PR branches.
+As of 2026-05-08, GitHub `main` branch protection is not enforcing required
+status checks, so this rule is owned by integration-captain policy rather than
+GitHub.
 
 ## Premium Plan Guidance
 


### PR DESCRIPTION
## Summary
- document the live portfolio-staging setting that disables preview deployments
- clarify why ignored build steps were not enough to remove queue pressure
- update integration-captain guidance to require portfolio previews pre-merge and both production contexts post-merge

## Validation
- git diff --check
- npm run deploy:metrics -- --limit 4
- production DB health push hook
- smoke branch confirmed no new portfolio-staging preview deployment after previewDeploymentsDisabled was enabled