### PR TITLE
test: close provider retry audit

### DIFF
--- a/app/api/admin/llm-judge/route.test.ts
+++ b/app/api/admin/llm-judge/route.test.ts
@@ -245,6 +245,62 @@ describe('POST /api/admin/llm-judge', () => {
     )
   })
 
+  it('retries a transient OpenAI judge failure before completing evaluation', async () => {
+    process.env.LLM_RETRY_DELAY_MS = '0'
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => 'temporary provider outage',
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          usage: { prompt_tokens: 300, completion_tokens: 90, total_tokens: 390 },
+          choices: [
+            {
+              message: {
+                content: JSON.stringify({
+                  rating: 'good',
+                  reasoning: 'The assistant recovered and completed the evaluation.',
+                  confidence: 0.79,
+                  categories: [],
+                }),
+              },
+            },
+          ],
+        }),
+      })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const response = await POST(makeRequest({
+      session_id: 'session-1',
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      prompt_version: 'v1',
+    }))
+
+    expect(response.status).toBe(200)
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(mocks.recordOpenAICost).toHaveBeenCalledWith(
+      expect.objectContaining({ total_tokens: 390 }),
+      'gpt-4o-mini',
+      { type: 'chat_session', id: 'session-1' },
+      expect.objectContaining({
+        operation: 'chat_eval',
+        budget_status: 'allowed',
+      }),
+      'agent-run-1',
+    )
+    expect(mocks.endAgentRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'agent-run-1',
+        status: 'completed',
+      }),
+    )
+  })
+
   it('marks the trace failed and returns a safe message when the budget blocks evaluation', async () => {
     mocks.sessionSingle.mockResolvedValue({
       data: {

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -52,7 +52,8 @@ This is the active implementation queue for Agent Operations. The phase gates, d
    - [x] Adopt shared provider fetch retries for meeting pain classification and in-person diagnostic insights.
    - [x] Adopt shared provider fetch retries for social carousel conversion, video prompt formatting, and video ideas generation.
    - [x] Adopt shared provider fetch retries for dev testing chat-agent and remediation LLM helpers.
-   - Add remaining direct LLM/provider call-site adoptions where transient failures still use bespoke retry or plain `try/catch`.
+   - [x] Adopt shared provider fetch retries for Chat Eval LLM judge evaluation, axial-code generation, and error diagnosis calls.
+   - [x] Complete final direct-provider audit; remaining provider URLs are wrapper usage, tests, or the source-validator injected-fetch path already wrapped by `withRetry`.
 
 ## Completed Or In Review
 
@@ -97,6 +98,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 - [x] Direct OpenAI helper retry adoption for meeting pain classification and in-person diagnostic insights in review.
 - [x] Direct OpenAI helper retry adoption for social carousel and video generation surfaces in review.
 - [x] Dev testing LLM helper retry adoption for chat-agent and remediation surfaces in review.
+- [x] Chat Eval LLM judge retry adoption and Phase 11 closure audit in review.
 
 ## Scope Guard
 

--- a/docs/agentic-patterns.md
+++ b/docs/agentic-patterns.md
@@ -32,7 +32,7 @@ Our pinned 20 patterns, grouped the same way as the talk:
 | 13 | Self-Consistency | Self-awareness | Absent |
 | 14 | Learning & Feedback | Self-awareness | Partial |
 | 15 | Memory Management | Self-awareness | Partial |
-| 16 | Exception Handling | Production | Partial / improving |
+| 16 | Exception Handling | Production | Strong |
 | 17 | Human-in-the-Loop | Production | Strong on publish / Partial elsewhere |
 | 18 | Guardrails & Safety | Production | Strong (authz) / Partial (content) |
 | 19 | Monitoring & Observability | Production | Strong in Agent Ops / Partial in legacy flows |
@@ -341,15 +341,16 @@ Each section follows the same template: *Definition · Where we use it today · 
 - n8n trigger calls use the shared helper for transient network and gateway failures while preserving generic user-facing failure messages.
 - Central OpenAI/Anthropic JSON dispatch in [`lib/llm-dispatch.ts`](../lib/llm-dispatch.ts) uses the shared helper for retryable provider statuses.
 - The source-validator LLM judge in [`lib/source-validator/llm-judge.ts`](../lib/source-validator/llm-judge.ts) uses the shared helper instead of a bespoke retry loop.
-- Direct provider helpers use [`lib/llm/provider-fetch.ts`](../lib/llm/provider-fetch.ts) for retryable provider failures across audit-from-meetings, meeting lead extraction, AI onboarding preview, delivery email drafts, meeting pain classification, in-person diagnostic insights, social carousel conversion, video prompt formatting, video ideas generation, dev testing remediation, and dev testing chat-agent calls.
+- Direct provider helpers use [`lib/llm/provider-fetch.ts`](../lib/llm/provider-fetch.ts) for retryable provider failures across audit-from-meetings, meeting lead extraction, AI onboarding preview, delivery email drafts, meeting pain classification, in-person diagnostic insights, social carousel conversion, video prompt formatting, video ideas generation, Chat Eval LLM judge evaluation/axial-code/diagnosis calls, dev testing remediation, and dev testing chat-agent calls.
+- The source-validator LLM judge still accepts an injected `fetchImpl` for timeout and test control, but that provider call is wrapped by the shared retry helper rather than a bespoke loop.
 
-**Coverage.** Partial / improving.
+**Coverage.** Strong.
 
 **Gaps.**
-- Direct LLM call sites still need to adopt the shared retry helper where transient provider failures are expected.
-- Dead-letter visibility and routed recovery requests exist for Agent Ops traces, but some provider-call retry wrappers are still call-site specific.
+- Some domain workflows still translate provider failures into their own user-facing copy, so future work should keep error language aligned with the no-sensitive-errors rule.
+- Dead-letter visibility and routed recovery requests exist for Agent Ops traces, but legacy workflow-specific status pages still need gradual trace-link migration.
 
-**Retrofit backlog.** Continue Ticket [#3](#top-retrofit-tickets) by adopting the shared helper across remaining direct LLM/provider calls.
+**Retrofit backlog.** Ticket [#3](#top-retrofit-tickets) is complete for known OpenAI/Anthropic direct provider call sites. Future provider additions should use `fetchProviderWithRetry` or wrap injected/test fetches with `withRetry` before shipping.
 
 ---
 
@@ -476,13 +477,14 @@ These are the first five PR-sized items seeded from the scorecard. Ticket 1 has 
   - Scorecard row for Reflection updated to "Partial" on completion.
 - **Depends on.** Ticket #1 (for observability).
 
-### Ticket 3 — Retry/backoff helper for LLM/n8n calls (Exception Handling) — in progress
+### Ticket 3 — Retry/backoff helper for LLM/n8n calls (Exception Handling) — complete
 
 - **Owner.** Agent Operations rollout.
 - **Scope.** Add `lib/llm/with-retry.ts` with capped exponential backoff + jitter, configurable retryable error matcher, and a dead-letter hook. Wrap the trigger functions in [`lib/n8n.ts`](../lib/n8n.ts) and the direct LLM call sites found via grep.
 - **First adoption.** n8n trigger calls now retry transient network and 502/503/504 failures through the shared helper.
 - **Follow-on adoption.** Central OpenAI/Anthropic JSON dispatch and source-validator LLM judge calls use the shared helper for retryable provider/network failures.
-- **Direct helper adoption.** Audit-from-meetings, meeting lead extraction, AI onboarding preview, delivery email drafts, meeting pain classification, in-person diagnostic insights, social carousel conversion, video prompt formatting, video ideas generation, dev testing remediation, and dev testing chat-agent calls now use the shared provider fetch wrapper.
+- **Direct helper adoption.** Audit-from-meetings, meeting lead extraction, AI onboarding preview, delivery email drafts, meeting pain classification, in-person diagnostic insights, social carousel conversion, video prompt formatting, video ideas generation, Chat Eval LLM judge evaluation/axial-code/diagnosis calls, dev testing remediation, and dev testing chat-agent calls now use the shared provider fetch wrapper.
+- **Closure audit.** Remaining direct provider URL grep results are either shared wrapper usage, tests asserting provider URLs, or the source-validator injected-fetch path wrapped by `withRetry` for timeout/test control.
 - **Acceptance criteria.**
   - Unit tests for: success-on-first-try, success-after-N-retries, gives-up-after-max, honors non-retryable errors.
   - User-facing errors remain generic per `no-expose-errors-to-users.mdc`.

--- a/lib/llm-judge.ts
+++ b/lib/llm-judge.ts
@@ -15,6 +15,7 @@ import {
   type AgentBudgetDecision,
 } from './agent-budget-policy'
 import { recordAgentEvent, recordAgentStep, type AgentRuntime } from './agent-run'
+import { fetchProviderWithRetry } from './llm/provider-fetch'
 
 export interface ChatMessageForJudge {
   role: 'user' | 'assistant' | 'support'
@@ -428,7 +429,7 @@ async function evaluateWithClaude(
   }
   
   try {
-    const response = await fetch('https://api.anthropic.com/v1/messages', {
+    const response = await fetchProviderWithRetry('anthropic', 'https://api.anthropic.com/v1/messages', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -494,7 +495,7 @@ async function evaluateWithOpenAI(
   }
   
   try {
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    const response = await fetchProviderWithRetry('openai', 'https://api.openai.com/v1/chat/completions', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -740,7 +741,7 @@ async function generateAxialCodesWithClaude(
     throw new Error('ANTHROPIC_API_KEY environment variable is not configured')
   }
   
-  const response = await fetch('https://api.anthropic.com/v1/messages', {
+  const response = await fetchProviderWithRetry('anthropic', 'https://api.anthropic.com/v1/messages', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -795,7 +796,7 @@ async function generateAxialCodesWithOpenAI(
     throw new Error('OPENAI_API_KEY environment variable is not configured')
   }
   
-  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+  const response = await fetchProviderWithRetry('openai', 'https://api.openai.com/v1/chat/completions', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -1136,7 +1137,7 @@ async function diagnoseErrorWithClaude(
     throw new Error('ANTHROPIC_API_KEY environment variable is not configured')
   }
   
-  const response = await fetch('https://api.anthropic.com/v1/messages', {
+  const response = await fetchProviderWithRetry('anthropic', 'https://api.anthropic.com/v1/messages', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -1191,7 +1192,7 @@ async function diagnoseErrorWithOpenAI(
     throw new Error('OPENAI_API_KEY environment variable is not configured')
   }
   
-  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+  const response = await fetchProviderWithRetry('openai', 'https://api.openai.com/v1/chat/completions', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- Routes the remaining Chat Eval LLM judge OpenAI/Anthropic calls through the shared provider retry wrapper.
- Adds focused retry coverage for transient OpenAI judge failures.
- Updates Agent Ops roadmap docs to close the known Phase 11 provider resilience audit, with the source-validator injected fetch path documented as intentionally wrapped by withRetry.

## Validation
- npx vitest run app/api/admin/llm-judge/route.test.ts
- npx vitest run lib/llm/provider-fetch.test.ts app/api/admin/llm-judge/route.test.ts
- npx tsc --noEmit
- rg direct raw OpenAI/Anthropic fetch audit: clean for raw fetch calls; remaining provider URLs are wrapper usage, tests, or source-validator injected fetch inside withRetry
- Push hook database health check passed

## Integration Notes
- Draft PR for Integration Captain. Do not merge from this chat.
- No schema changes, env changes, or live workflow/customer-data smoke required.
- Vercel – portfolio and Vercel – portfolio-staging should be checked by Integration Captain after merge sequencing.