### PR TITLE
fix: guard duplicate recovery requests

### DIFF
--- a/app/api/admin/agents/runs/[runId]/retry/route.test.ts
+++ b/app/api/admin/agents/runs/[runId]/retry/route.test.ts
@@ -12,10 +12,10 @@ vi.mock('@/lib/auth-server', () => ({
   isAuthError: mocks.isAuthError,
 }))
 
-vi.mock('@/lib/agent-run-recovery', () => {
+vi.mock('@/lib/agent-run-recovery', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/agent-run-recovery')>()
   return {
-    isRecoverableAgentRunStatus: (status: string) =>
-      status === 'failed' || status === 'stale' || status === 'cancelled',
+    ...actual,
     createAgentRunRecoveryRequest: mocks.createAgentRunRecoveryRequest,
   }
 })
@@ -102,7 +102,17 @@ describe('POST /api/admin/agents/runs/[runId]/retry', () => {
   it('creates a read-only recovery request for a failed run', async () => {
     mocks.from
       .mockReturnValueOnce(sourceRunQuery(sourceRun()))
-      .mockReturnValueOnce(recoveryQuery([{ id: 'prior-recovery' }]))
+      .mockReturnValueOnce(recoveryQuery([
+        {
+          id: 'prior-recovery',
+          status: 'completed',
+          metadata: {
+            source_run_id: 'source-run-1',
+            retry_attempt: 1,
+            earliest_retry_at: '2026-05-07T11:00:00.000Z',
+          },
+        },
+      ]))
 
     const response = await POST(makeRequest({ note: 'Retry after payload check.' }) as never, {
       params: { runId: 'source-run-1' },
@@ -129,6 +139,37 @@ describe('POST /api/admin/agents/runs/[runId]/retry', () => {
       }),
       note: 'Retry after payload check.',
     }))
+  })
+
+  it('blocks duplicate recovery requests while a prior backoff window is active', async () => {
+    mocks.from
+      .mockReturnValueOnce(sourceRunQuery(sourceRun()))
+      .mockReturnValueOnce(recoveryQuery([
+        {
+          id: 'recovery-run-1',
+          status: 'completed',
+          metadata: {
+            source_run_id: 'source-run-1',
+            retry_attempt: 1,
+            earliest_retry_at: '2999-05-07T12:15:00.000Z',
+          },
+        },
+      ]))
+
+    const response = await POST(makeRequest({ note: 'Retry again.' }) as never, {
+      params: { runId: 'source-run-1' },
+    })
+
+    expect(response.status).toBe(409)
+    expect(await response.json()).toEqual({
+      ok: false,
+      error: 'A recovery request is already waiting for its backoff window.',
+      source_run_id: 'source-run-1',
+      recovery_run_id: 'recovery-run-1',
+      retry_attempt: 1,
+      earliest_retry_at: '2999-05-07T12:15:00.000Z',
+    })
+    expect(mocks.createAgentRunRecoveryRequest).not.toHaveBeenCalled()
   })
 
   it('rejects non-recoverable active runs', async () => {

--- a/app/api/admin/agents/runs/[runId]/retry/route.ts
+++ b/app/api/admin/agents/runs/[runId]/retry/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
 import {
   createAgentRunRecoveryRequest,
+  findActiveAgentRunRecoveryBackoff,
   isRecoverableAgentRunStatus,
   type AgentRunRecoverySource,
 } from '@/lib/agent-run-recovery'
@@ -50,12 +51,27 @@ export async function POST(
 
   const previousRecoveries = await supabaseAdmin
     .from('agent_runs')
-    .select('id')
+    .select('id, status, metadata')
     .eq('kind', 'agent_recovery_request')
     .contains('metadata', { source_run_id: params.runId })
 
   if (previousRecoveries.error) {
     return NextResponse.json({ error: 'Failed to inspect prior recovery requests' }, { status: 500 })
+  }
+
+  const activeBackoff = findActiveAgentRunRecoveryBackoff(previousRecoveries.data ?? [])
+  if (activeBackoff) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: 'A recovery request is already waiting for its backoff window.',
+        source_run_id: params.runId,
+        recovery_run_id: activeBackoff.recovery_run_id,
+        retry_attempt: activeBackoff.retry_attempt,
+        earliest_retry_at: activeBackoff.earliest_retry_at,
+      },
+      { status: 409 },
+    )
   }
 
   try {

--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -262,7 +262,7 @@ Current progress:
 
 ### Phase 11: Provider Resilience And Retry Hygiene
 
-Status: In progress.
+Status: Complete / monitoring.
 
 Goal: Standardize how provider calls recover from transient n8n, LLM, and tool failures.
 
@@ -284,7 +284,7 @@ Current progress:
 
 - A reusable `lib/llm/with-retry.ts` helper is being introduced with capped exponential backoff, configurable retryable error matching, and a give-up hook for dead-letter integration.
 - The first adoption targets n8n trigger calls, where transient 502/503/504 and network failures can be retried without exposing raw provider errors to users.
-- The next adoption targets central LLM provider dispatch and the source-validator LLM judge, replacing bespoke retry loops with the shared helper.
+- Central LLM provider dispatch and the source-validator LLM judge use the shared helper, replacing bespoke retry loops where the provider call is not intentionally injected for tests/timeouts.
 - Direct provider helpers for audit-from-meetings, meeting lead extraction, AI onboarding preview, delivery email drafts, meeting pain classification, in-person diagnostic insights, social carousel conversion, video prompt formatting, video ideas generation, dev testing remediation, and dev testing chat-agent calls now use a shared provider fetch wrapper.
 - Mission Control surfaces the latest `agent_ops_morning_review` and `agent_ops_deployment_watch` traces as Operating Signals.
 - The deployment watcher supports `--trace` so integration-captain and autopilot runs write a visible Agent Ops run/artifact.
@@ -308,6 +308,30 @@ Current progress:
 - Admin Chat Eval axial-code generation and error diagnosis now start manual Agent Ops traces, check budget before Anthropic/OpenAI dispatch, and link cost events back to the trace.
 - Value Evidence source validation and dev testing LLM helpers now run pre-flight budget checks before direct provider calls.
 - Failed, stale, and cancelled Agent Ops traces can now create a read-only recovery request with retry attempt, backoff, earliest-retry metadata, and an attached recovery packet. This routes dead-letter work without re-running production automation from Mission Control.
+
+### Phase 12: Operational Recovery Hygiene
+
+Status: In progress.
+
+Goal: Make recovery and dead-letter handling durable enough for daily use without creating duplicate queues or bypassing approval gates.
+
+Definition of done:
+
+- Recovery requests respect their backoff windows and do not create duplicate retry packets while a prior recovery is still waiting.
+- Mission Control clearly distinguishes unrouted failures from failures that already have recovery work in motion.
+- Stale and failed traces remain trace-derived; no separate dead-letter table is introduced.
+- Recovery requests remain read-only and never re-run production automation directly.
+- Focused tests cover duplicate recovery prevention, expired backoff windows, and recoverable status boundaries.
+
+Out of scope:
+
+- Fully autonomous remediation.
+- Retrying production workflows from the web app without workflow-specific safety checks.
+- Adding a separate queue table for dead-letter state.
+
+Current progress:
+
+- Recovery request creation now checks prior `agent_recovery_request` traces for active `earliest_retry_at` windows and returns a conflict response instead of creating duplicate packets during backoff.
 
 ## Cross-Phase Definition Of Done
 

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -55,6 +55,10 @@ This is the active implementation queue for Agent Operations. The phase gates, d
    - [x] Adopt shared provider fetch retries for Chat Eval LLM judge evaluation, axial-code generation, and error diagnosis calls.
    - [x] Complete final direct-provider audit; remaining provider URLs are wrapper usage, tests, or the source-validator injected-fetch path already wrapped by `withRetry`.
 
+6. Operational recovery hygiene
+   - [x] Prevent duplicate recovery request packets while a prior recovery backoff window is still active.
+   - Add recovery stale/expired visibility where Mission Control needs sharper operator guidance.
+
 ## Completed Or In Review
 
 - [x] Shared trace schema and helper library.
@@ -99,6 +103,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 - [x] Direct OpenAI helper retry adoption for social carousel and video generation surfaces in review.
 - [x] Dev testing LLM helper retry adoption for chat-agent and remediation surfaces in review.
 - [x] Chat Eval LLM judge retry adoption and Phase 11 closure audit in review.
+- [x] Recovery request backoff guard in review.
 
 ## Scope Guard
 

--- a/lib/agent-run-recovery.test.ts
+++ b/lib/agent-run-recovery.test.ts
@@ -10,6 +10,7 @@ vi.mock('@/lib/agent-run', () => ({
 import {
   buildAgentRunRecoveryPlan,
   createAgentRunRecoveryRequest,
+  findActiveAgentRunRecoveryBackoff,
   isRecoverableAgentRunStatus,
   type AgentRunRecoverySource,
 } from '@/lib/agent-run-recovery'
@@ -93,6 +94,56 @@ describe('agent run recovery planning', () => {
         sourceRun: sourceRun({ status: 'completed' }),
       }),
     ).toThrow('Only failed, stale, or cancelled runs can be queued for recovery')
+  })
+
+  it('finds the active recovery backoff window for duplicate retry requests', () => {
+    const activeBackoff = findActiveAgentRunRecoveryBackoff([
+      {
+        id: 'old-recovery',
+        status: 'completed',
+        metadata: {
+          retry_attempt: 1,
+          earliest_retry_at: '2026-05-07T11:45:00.000Z',
+        },
+      },
+      {
+        id: 'next-recovery',
+        status: 'completed',
+        metadata: {
+          retry_attempt: 2,
+          earliest_retry_at: '2026-05-07T12:15:00.000Z',
+        },
+      },
+    ], new Date('2026-05-07T12:00:00.000Z'))
+
+    expect(activeBackoff).toEqual({
+      recovery_run_id: 'next-recovery',
+      retry_attempt: 2,
+      earliest_retry_at: '2026-05-07T12:15:00.000Z',
+    })
+  })
+
+  it('ignores failed or expired recovery backoff windows', () => {
+    const activeBackoff = findActiveAgentRunRecoveryBackoff([
+      {
+        id: 'failed-recovery',
+        status: 'failed',
+        metadata: {
+          retry_attempt: 2,
+          earliest_retry_at: '2026-05-07T12:15:00.000Z',
+        },
+      },
+      {
+        id: 'expired-recovery',
+        status: 'completed',
+        metadata: {
+          retry_attempt: 1,
+          earliest_retry_at: '2026-05-07T11:45:00.000Z',
+        },
+      },
+    ], new Date('2026-05-07T12:00:00.000Z'))
+
+    expect(activeBackoff).toBeNull()
   })
 
   it('creates recovery and source trace events without executing production work', async () => {

--- a/lib/agent-run-recovery.ts
+++ b/lib/agent-run-recovery.ts
@@ -36,6 +36,18 @@ export type AgentRunRecoveryPlan = {
   summary_markdown: string
 }
 
+export type AgentRunRecoveryBackoffCandidate = {
+  id: string
+  status?: string | null
+  metadata: Record<string, unknown> | null
+}
+
+export type ActiveAgentRunRecoveryBackoff = {
+  recovery_run_id: string
+  retry_attempt: number | null
+  earliest_retry_at: string
+}
+
 export type CreateAgentRunRecoveryRequestInput = {
   sourceRun: AgentRunRecoverySource
   previousRecoveryCount?: number
@@ -69,6 +81,45 @@ function requestedAgentKey(sourceRun: AgentRunRecoverySource) {
   const requested = sourceRun.metadata?.requested_agent
   if (typeof requested === 'string' && requested.trim()) return requested.trim()
   return sourceRun.agent_key || 'chief-of-staff'
+}
+
+function readRecoveryRetryAttempt(metadata: Record<string, unknown> | null | undefined) {
+  const value = metadata?.retry_attempt
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function readRecoveryEarliestRetryAt(metadata: Record<string, unknown> | null | undefined) {
+  const value = metadata?.earliest_retry_at
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+export function findActiveAgentRunRecoveryBackoff(
+  recoveries: AgentRunRecoveryBackoffCandidate[],
+  now = new Date(),
+): ActiveAgentRunRecoveryBackoff | null {
+  const nowMs = now.getTime()
+  const active = recoveries
+    .filter((recovery) => recovery.status !== 'failed' && recovery.status !== 'cancelled' && recovery.status !== 'stale')
+    .map((recovery) => {
+      const earliestRetryAt = readRecoveryEarliestRetryAt(recovery.metadata)
+      const retryAtMs = earliestRetryAt ? new Date(earliestRetryAt).getTime() : Number.NaN
+      return {
+        recovery,
+        earliestRetryAt,
+        retryAtMs,
+      }
+    })
+    .filter((item) => item.earliestRetryAt && Number.isFinite(item.retryAtMs) && item.retryAtMs > nowMs)
+    .sort((a, b) => a.retryAtMs - b.retryAtMs)
+
+  const next = active[0]
+  if (!next?.earliestRetryAt) return null
+
+  return {
+    recovery_run_id: next.recovery.id,
+    retry_attempt: readRecoveryRetryAttempt(next.recovery.metadata),
+    earliest_retry_at: next.earliestRetryAt,
+  }
 }
 
 export function buildAgentRunRecoveryPlan(input: {


### PR DESCRIPTION
## Summary
- Adds a recovery backoff guard so duplicate Agent Ops recovery requests are blocked while a prior recovery packet is still waiting for its earliest retry time.
- Returns a 409 response with the existing recovery run id and earliest retry metadata instead of creating another retry packet.
- Updates the Agent Operations roadmap/task list to move into Phase 12 operational recovery hygiene.

## Validation
- npx vitest run lib/agent-run-recovery.test.ts 'app/api/admin/agents/runs/[runId]/retry/route.test.ts'
- npx tsc --noEmit
- git diff --check
- Push hook database health check passed

## Integration Notes
- Draft PR for Integration Captain. Do not merge from this chat.
- No schema changes or environment changes.
- No production workflow/customer-data smoke was run; this is route/helper logic plus tests.
- Vercel – portfolio and Vercel – portfolio-staging should be verified by Integration Captain after merge sequencing.