### PR TITLE
feat: surface recovery backoff in mission control

### DIFF
--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -182,6 +182,10 @@ type MissionSnapshot = {
     routed: boolean
     routed_run_id: string | null
     routed_kind: string | null
+    routed_status: string | null
+    recovery_retry_attempt: number | null
+    recovery_earliest_retry_at: string | null
+    recovery_backoff_active: boolean
     next_action: string
     href: string
   }>
@@ -1053,7 +1057,13 @@ function DeadLetterPanel({
             <div className="flex flex-wrap items-center gap-2">
               <span className="font-medium">{item.title}</span>
               <span className={`rounded-full border px-2 py-0.5 text-xs ${item.routed ? 'border-emerald-400/40 bg-emerald-500/10 text-emerald-200' : 'border-red-400/40 bg-red-500/10 text-red-200'}`}>
-                {item.routed ? 'routed' : 'unrouted'}
+                {item.routed
+                  ? item.recovery_backoff_active
+                    ? 'recovery waiting'
+                    : item.routed_kind === 'agent_recovery_request'
+                      ? 'recovery routed'
+                      : 'routed'
+                  : 'unrouted'}
               </span>
               <span className="rounded-full border border-silicon-slate/50 bg-black/10 px-2 py-0.5 text-xs text-muted-foreground">
                 {item.status}
@@ -1067,6 +1077,9 @@ function DeadLetterPanel({
               <QueueDetail label="Source" value={item.source_label} />
               <QueueDetail label="Pod" value={item.pod} />
               <QueueDetail label="Age" value={`${item.age_hours}h`} />
+              {item.routed_status ? <QueueDetail label="Routed status" value={item.routed_status} /> : null}
+              {item.recovery_retry_attempt ? <QueueDetail label="Retry attempt" value={String(item.recovery_retry_attempt)} /> : null}
+              {item.recovery_earliest_retry_at ? <QueueDetail label="Earliest retry" value={formatTime(item.recovery_earliest_retry_at)} /> : null}
             </div>
             <p className="mt-3 line-clamp-2 text-muted-foreground">{item.reason}</p>
             <div className="mt-3 flex flex-wrap items-center gap-2">

--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -332,6 +332,7 @@ Out of scope:
 Current progress:
 
 - Recovery request creation now checks prior `agent_recovery_request` traces for active `earliest_retry_at` windows and returns a conflict response instead of creating duplicate packets during backoff.
+- Mission Control dead-letter items now show routed recovery status, retry attempt, earliest retry time, and whether the retry packet is still waiting inside the backoff window.
 
 ## Cross-Phase Definition Of Done
 

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -57,6 +57,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
 
 6. Operational recovery hygiene
    - [x] Prevent duplicate recovery request packets while a prior recovery backoff window is still active.
+   - [x] Add Mission Control visibility for routed recovery status, retry attempt, earliest retry time, and active backoff state.
    - Add recovery stale/expired visibility where Mission Control needs sharper operator guidance.
 
 ## Completed Or In Review

--- a/lib/agent-mission-control.test.ts
+++ b/lib/agent-mission-control.test.ts
@@ -232,7 +232,44 @@ describe('Agent Mission Control helpers', () => {
       routed: true,
       routed_run_id: 'retry-request',
       routed_kind: 'agent_recovery_request',
+      routed_status: 'completed',
       next_action: 'Review retry request.',
+    })
+  })
+
+  it('shows recovery backoff state for dead-letter runs with active retry packets', () => {
+    const failedRun = run({
+      id: 'failed-run',
+      agent_key: 'automation-systems',
+      runtime: 'n8n',
+      status: 'failed',
+      title: 'Warm lead sync',
+      error_message: 'Webhook returned 500.',
+    })
+    const retryRequest = run({
+      id: 'retry-request',
+      kind: 'agent_recovery_request',
+      status: 'completed',
+      metadata: {
+        requested_agent: 'automation-systems',
+        source_run_id: 'failed-run',
+        retry_attempt: 2,
+        earliest_retry_at: '2999-05-07T12:15:00.000Z',
+      },
+    })
+
+    const queue = buildAgentDeadLetterQueue([failedRun, retryRequest])
+
+    expect(queue[0]).toMatchObject({
+      run_id: 'failed-run',
+      routed: true,
+      routed_run_id: 'retry-request',
+      routed_kind: 'agent_recovery_request',
+      routed_status: 'completed',
+      recovery_retry_attempt: 2,
+      recovery_earliest_retry_at: '2999-05-07T12:15:00.000Z',
+      recovery_backoff_active: true,
+      next_action: 'Recovery is waiting for its backoff window.',
     })
   })
 

--- a/lib/agent-mission-control.ts
+++ b/lib/agent-mission-control.ts
@@ -92,6 +92,10 @@ export type AgentDeadLetterItem = {
   routed: boolean
   routed_run_id: string | null
   routed_kind: string | null
+  routed_status: string | null
+  recovery_retry_attempt: number | null
+  recovery_earliest_retry_at: string | null
+  recovery_backoff_active: boolean
   next_action: string
   href: string
 }
@@ -187,6 +191,11 @@ function requestedAgentKey(run: AgentRunRow) {
 function stringMetadataValue(metadata: Record<string, unknown> | null | undefined, key: string) {
   const value = metadata?.[key]
   return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function numberMetadataValue(metadata: Record<string, unknown> | null | undefined, key: string) {
+  const value = metadata?.[key]
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
 }
 
 function executionModeForRun(run: AgentRunRow) {
@@ -601,6 +610,19 @@ export function buildAgentDeadLetterQueue(
       const routedRun = routedBySourceRun.get(run.id)
       const agentName = agent?.name ?? 'Chief of Staff Agent'
       const reason = run.error_message ?? run.current_step ?? `${run.runtime} run is ${run.status.replace(/_/g, ' ')}.`
+      const recoveryRetryAttempt =
+        routedRun?.kind === 'agent_recovery_request'
+          ? numberMetadataValue(routedRun.metadata, 'retry_attempt')
+          : null
+      const recoveryEarliestRetryAt =
+        routedRun?.kind === 'agent_recovery_request'
+          ? stringMetadataValue(routedRun.metadata, 'earliest_retry_at')
+          : null
+      const recoveryBackoffActive =
+        Boolean(recoveryEarliestRetryAt) &&
+        Number.isFinite(new Date(recoveryEarliestRetryAt ?? '').getTime()) &&
+        new Date(recoveryEarliestRetryAt ?? '').getTime() > Date.now()
+
       return {
         run_id: run.id,
         agent_key: agent?.key ?? 'chief-of-staff',
@@ -615,9 +637,15 @@ export function buildAgentDeadLetterQueue(
         routed: Boolean(routedRun),
         routed_run_id: routedRun?.id ?? null,
         routed_kind: routedRun?.kind ?? null,
+        routed_status: routedRun?.status ?? null,
+        recovery_retry_attempt: recoveryRetryAttempt,
+        recovery_earliest_retry_at: recoveryEarliestRetryAt,
+        recovery_backoff_active: recoveryBackoffActive,
         next_action: routedRun
           ? routedRun.kind === 'agent_recovery_request'
-            ? 'Review retry request.'
+            ? recoveryBackoffActive
+              ? 'Recovery is waiting for its backoff window.'
+              : 'Review retry request.'
             : 'Review routed engagement request.'
           : run.status === 'stale'
             ? 'Route stale run owner from Agent Inbox.'


### PR DESCRIPTION
## Summary
- Adds recovery/backoff state to Mission Control dead-letter items so routed recovery work is visibly distinct from unrouted failures.
- Shows routed status, retry attempt, earliest retry time, and active backoff state in the Dead-Letter Monitor.
- Updates the Phase 12 roadmap/task list with the recovery visibility slice.

## Validation
- npx vitest run lib/agent-mission-control.test.ts
- npx tsc --noEmit
- git diff --check
- Push hook database health check passed

## Integration Notes
- Draft PR for Integration Captain. Do not merge from this chat.
- No schema changes or environment changes.
- No production workflow/customer-data smoke was run; this is derived Mission Control display logic plus tests.
- Vercel – portfolio and Vercel – portfolio-staging should be verified by Integration Captain after merge sequencing.