### PR TITLE
Add runtime placement to Client AI Ops roadmap

### DIFF
--- a/docs/client-ai-ops-roadmap-sop.md
+++ b/docs/client-ai-ops-roadmap-sop.md
@@ -5,6 +5,7 @@ This is the operating guide for selling, implementing, monitoring, and improving
 ## Operating Principles
 
 - The client owns the hardware, accounts, credentials, project data, and production approvals.
+- The roadmap must choose where the client data store, local LLM repository, and always-on worker runtime live: client-owned Mac mini/PC node, cloud runtime, or hybrid local/cloud fallback.
 - AmaduTown access is named, revocable, and limited to startup, maintenance, monitoring, and approved changes.
 - The roadmap is the shared source of truth. Client Dashboard tasks and admin Meeting Tasks are projections of the same roadmap task records, not separate parallel plans.
 - Every roadmap must include implementation, reporting, monitoring, and tracking. Treat reports, monitor findings, task projections, and cost assumptions as part of the roadmap deliverable.
@@ -18,7 +19,8 @@ This is the operating guide for selling, implementing, monitoring, and improving
 2. Review all phase tasks, startup costs, monthly operating costs, setup labor, and client responsibilities.
 3. Refresh any technology registry item marked `needs_review`, `stale`, `quote_required`, or `source_unavailable` before sending a proposal.
 4. Edit the roadmap estimate when the client has known constraints such as Mac-only, Windows-only, on-prem only, limited budget, or existing MDM/VPN tooling.
-5. Attach the roadmap snapshot to the proposal only after costs and assumptions are clear enough for the client to understand the real startup burden.
+5. Confirm whether 24/7 access is expected from client-owned hardware, a cloud runtime, or hybrid fallback before presenting startup and monthly costs.
+6. Attach the roadmap snapshot to the proposal only after costs and assumptions are clear enough for the client to understand the real startup burden.
 
 ## Delivery Stage
 
@@ -27,7 +29,8 @@ This is the operating guide for selling, implementing, monitoring, and improving
 3. Project AmaduTown delivery tasks into Meeting Tasks.
 4. Confirm each task has a phase, owner, due date when available, status, and source badge.
 5. Keep internal traces, private logs, admin-only notes, credentials, and agent execution details out of the client dashboard.
-6. If a roadmap task changes status from the client dashboard or meeting task queue, sync the status back to the source roadmap task and refresh phase rollups.
+6. Treat local-device setup, cloud provisioning, remote access, and runtime configuration as approval-gated implementation work.
+7. If a roadmap task changes status from the client dashboard or meeting task queue, sync the status back to the source roadmap task and refresh phase rollups.
 
 ## Monitoring Stage
 

--- a/lib/client-ai-ops-roadmap-db.ts
+++ b/lib/client-ai-ops-roadmap-db.ts
@@ -92,6 +92,7 @@ export async function getRoadmapBundleForProject(clientProjectId: string): Promi
         title: roadmap.title,
         status: roadmap.status,
         client_summary: roadmap.client_summary,
+        snapshot: roadmap.snapshot as Record<string, unknown> | null,
       },
       phases: phases.map((phase) => ({
         id: phase.id as string,
@@ -165,7 +166,10 @@ export async function ensureRoadmapForProject(clientProjectId: string, options?:
       status: 'active',
       generated_from: options?.generatedFrom ?? 'manual',
       client_summary: draft.clientSummary,
-      snapshot: { input_hash: draft.inputHash },
+      snapshot: {
+        input_hash: draft.inputHash,
+        runtime_placement_options: draft.runtimePlacementOptions,
+      },
       created_by: options?.userId ?? null,
     })
     .select('*')
@@ -381,17 +385,29 @@ export async function refreshRoadmapPhaseRollups(roadmapId: string): Promise<voi
     .select('payer, cost_type, amount, category')
     .eq('roadmap_id', roadmapId)
 
+  const { data: roadmap } = await db
+    .from('client_ai_ops_roadmaps')
+    .select('snapshot')
+    .eq('id', roadmapId)
+    .maybeSingle()
+
   type CostRollupRow = { payer: string; cost_type: string; amount: number | string | null; category: string }
+  const existingSnapshot = roadmap?.snapshot && typeof roadmap.snapshot === 'object'
+    ? roadmap.snapshot as Record<string, unknown>
+    : {}
 
   await db
     .from('client_ai_ops_roadmaps')
     .update({
-      snapshot: { cost_summary: rollUpRoadmapCosts(((costs || []) as CostRollupRow[]).map((item) => ({
-        payer: item.payer as never,
-        costType: item.cost_type as never,
-        amount: item.amount == null ? null : Number(item.amount),
-        category: item.category as never,
-      }))) },
+      snapshot: {
+        ...existingSnapshot,
+        cost_summary: rollUpRoadmapCosts(((costs || []) as CostRollupRow[]).map((item) => ({
+          payer: item.payer as never,
+          costType: item.cost_type as never,
+          amount: item.amount == null ? null : Number(item.amount),
+          category: item.category as never,
+        }))),
+      },
       updated_at: new Date().toISOString(),
     })
     .eq('id', roadmapId)

--- a/lib/client-ai-ops-roadmap.test.ts
+++ b/lib/client-ai-ops-roadmap.test.ts
@@ -19,6 +19,28 @@ describe('client AI ops roadmap', () => {
     expect(a.phases).toHaveLength(5)
     expect(a.tasks.map((task) => task.taskKey)).toContain('client-vault')
     expect(a.costItems.map((item) => item.category)).toContain('hardware')
+    expect(a.runtimePlacementOptions.map((option) => option.key)).toEqual([
+      'client_local_node',
+      'cloud_runtime',
+      'hybrid_local_cloud',
+    ])
+  })
+
+  it('makes 24/7 data and local LLM repository placement explicit', () => {
+    const roadmap = buildDefaultClientAiOpsRoadmap({ clientCompany: 'Acme Co' })
+
+    expect(roadmap.clientSummary).toContain('24/7 data and local LLM repository placement')
+    expect(roadmap.phases.find((phase) => phase.phaseKey === 'infrastructure_access')?.acceptanceCriteria)
+      .toContain('Runtime placement selected')
+    expect(roadmap.tasks.find((task) => task.taskKey === 'hardware-decision')).toMatchObject({
+      title: 'Select data and local LLM repository placement',
+      clientVisible: true,
+      meetingTaskVisible: true,
+    })
+    expect(roadmap.costItems.map((item) => item.key)).toEqual(expect.arrayContaining([
+      'local-node',
+      'cloud-runtime-host',
+    ]))
   })
 
   it('rolls up client-owned startup and monthly costs', () => {
@@ -132,6 +154,11 @@ describe('client AI ops roadmap', () => {
         reportMissing: false,
       },
     })
+    expect(view.runtimePlacementOptions.map((option) => option.key)).toEqual([
+      'client_local_node',
+      'cloud_runtime',
+      'hybrid_local_cloud',
+    ])
     expect(JSON.stringify(view.latestReport)).not.toContain('Internal escalation note')
   })
 })

--- a/lib/client-ai-ops-roadmap.ts
+++ b/lib/client-ai-ops-roadmap.ts
@@ -41,6 +41,17 @@ export interface RoadmapContext {
   implementationRequirements?: Record<string, unknown> | null
 }
 
+export type RoadmapRuntimePlacementKey = 'client_local_node' | 'cloud_runtime' | 'hybrid_local_cloud'
+
+export interface RoadmapRuntimePlacementOption {
+  key: RoadmapRuntimePlacementKey
+  label: string
+  description: string
+  alwaysOn: boolean
+  dataResidence: 'client_device' | 'cloud' | 'hybrid'
+  approvalNote: string
+}
+
 export interface RoadmapPhaseDraft {
   phaseKey: RoadmapPhaseKey
   phaseOrder: number
@@ -84,6 +95,7 @@ export interface RoadmapDraft {
   title: string
   clientSummary: string
   inputHash: string
+  runtimePlacementOptions: RoadmapRuntimePlacementOption[]
   phases: RoadmapPhaseDraft[]
   tasks: RoadmapTaskDraft[]
   costItems: RoadmapCostItemDraft[]
@@ -131,11 +143,39 @@ export interface RoadmapClientView {
   title: string
   status: RoadmapStatus
   clientSummary: string | null
+  runtimePlacementOptions: RoadmapRuntimePlacementOption[]
   phases: RoadmapClientPhase[]
   costSummary: RoadmapCostRollup
   nextActions: Array<{ title: string; ownerType: RoadmapTaskOwner; priority: RoadmapPriority; dueDate: string | null }>
   latestReport: RoadmapClientReportSummary | null
 }
+
+export const DEFAULT_RUNTIME_PLACEMENT_OPTIONS: RoadmapRuntimePlacementOption[] = [
+  {
+    key: 'client_local_node',
+    label: 'Client-owned local node',
+    description: 'Run the data store, local LLM repository, or automation worker on a client-owned Mac mini, mini PC, or equivalent always-on device.',
+    alwaysOn: true,
+    dataResidence: 'client_device',
+    approvalNote: 'Requires client-owned hardware, named remote access, backup, monitoring, and approval before production runtime changes.',
+  },
+  {
+    key: 'cloud_runtime',
+    label: 'Cloud runtime host',
+    description: 'Run the data store, local model fallback, or agent worker in a cloud environment for 24/7 access when client hardware is not practical.',
+    alwaysOn: true,
+    dataResidence: 'cloud',
+    approvalNote: 'Requires provider, region, cost owner, credential boundary, and deployment approval before provisioning.',
+  },
+  {
+    key: 'hybrid_local_cloud',
+    label: 'Hybrid local plus cloud fallback',
+    description: 'Keep sensitive data or local models on a client-owned node while using cloud hosting for uptime, failover, or remote access.',
+    alwaysOn: true,
+    dataResidence: 'hybrid',
+    approvalNote: 'Requires a clear split between local data, cloud services, backups, monitoring, and failover approval.',
+  },
+]
 
 const DEFAULT_PHASES: RoadmapPhaseDraft[] = [
   {
@@ -150,9 +190,9 @@ const DEFAULT_PHASES: RoadmapPhaseDraft[] = [
     phaseKey: 'infrastructure_access',
     phaseOrder: 2,
     title: 'Infrastructure and access',
-    objective: 'Configure the local or hybrid node, secure remote access, backups, and monitoring baseline.',
+    objective: 'Choose where the data and local LLM repository will live, then configure the local device, cloud runtime, or hybrid fallback for 24/7 access.',
     status: 'pending',
-    acceptanceCriteria: ['Node path selected', 'Remote access gated by named accounts', 'Backup and monitoring baseline recorded'],
+    acceptanceCriteria: ['Runtime placement selected', 'Remote access gated by named accounts', 'Backup and monitoring baseline recorded'],
   },
   {
     phaseKey: 'data_ai_foundation',
@@ -183,7 +223,7 @@ const DEFAULT_PHASES: RoadmapPhaseDraft[] = [
 const DEFAULT_TASKS: RoadmapTaskDraft[] = [
   task('client-vault', 'discovery_ownership', 'Create client-owned password vault', 'Client creates the shared vault and invites named AmaduTown maintainer access.', 'client', 'high', true, true, 'access_security', 0, 'Vault exists and access is named, logged, and revocable.'),
   task('ownership-map', 'discovery_ownership', 'Confirm ownership and access map', 'Document who owns accounts, data, hardware, logs, and approval decisions.', 'shared', 'high', true, true, 'other', 0, 'Ownership map is visible in project record.'),
-  task('hardware-decision', 'infrastructure_access', 'Select local node or cloud fallback', 'Choose Mac mini, mini PC, existing hardware, or cloud fallback based on stack and budget.', 'shared', 'high', true, true, 'hardware', 1200, 'Selected path has expected startup and monthly costs.'),
+  task('hardware-decision', 'infrastructure_access', 'Select data and local LLM repository placement', 'Choose whether the client data store, local LLM repository, or automation worker runs on a Mac mini, mini PC, cloud runtime, or hybrid local/cloud path for 24/7 access.', 'shared', 'high', true, true, 'hardware', 1200, 'Selected path has expected startup, monthly, backup, monitoring, and approval requirements.'),
   task('secure-remote-access', 'infrastructure_access', 'Configure secure remote access', 'Set up private access for maintenance without exposing admin surfaces publicly.', 'amadutown', 'high', false, true, 'access_security', 20, 'Maintainer access works through named account and MFA.'),
   task('backup-monitoring', 'infrastructure_access', 'Set backup and monitoring baseline', 'Configure backup status and core health checks for the selected infrastructure path.', 'amadutown', 'medium', true, true, 'backup', 150, 'Backup and health check status are visible in roadmap report.'),
   task('data-source-map', 'data_ai_foundation', 'Map approved data sources and permissions', 'Identify documents, databases, tools, and user groups the AI system may access.', 'shared', 'high', true, true, 'other', 0, 'Approved and forbidden data sources are documented.'),
@@ -195,10 +235,11 @@ const DEFAULT_TASKS: RoadmapTaskDraft[] = [
 ]
 
 const DEFAULT_COST_ITEMS: RoadmapCostItemDraft[] = [
-  cost('local-node', 'infrastructure_access', 'hardware', 'Local AI operations node', 'Mac mini, mini PC, or equivalent client-owned always-on device.', 'client', 'one_time', 1200, 'needs_review'),
+  cost('local-node', 'infrastructure_access', 'hardware', 'Client-owned local runtime node', 'Mac mini, mini PC, or equivalent always-on device for local data, local LLM repository, or automation workers.', 'client', 'one_time', 1200, 'needs_review'),
+  cost('cloud-runtime-host', 'infrastructure_access', 'ai_runtime', 'Cloud runtime host or fallback', 'Cloud host for 24/7 access when client-owned hardware is not practical or when hybrid failover is needed.', 'client', 'monthly', 75, 'needs_review'),
   cost('remote-access', 'infrastructure_access', 'access_security', 'Secure remote access', 'Private access layer for maintenance and support.', 'client', 'monthly', 20, 'needs_review'),
   cost('credential-vault', 'discovery_ownership', 'access_security', 'Password vault', 'Client-owned credential vault for setup and maintenance access.', 'client', 'monthly', 25, 'needs_review'),
-  cost('backup', 'infrastructure_access', 'backup', 'Backup storage', 'Encrypted backup drive, NAS allocation, or cloud backup path.', 'client', 'one_time', 150, 'needs_review'),
+  cost('backup', 'infrastructure_access', 'backup', 'Runtime and repository backup', 'Encrypted backup drive, NAS allocation, or cloud backup path for the selected data/local LLM repository placement.', 'client', 'one_time', 150, 'needs_review'),
   cost('ai-runtime', 'data_ai_foundation', 'ai_runtime', 'AI/runtime usage', 'Model, API, local runtime, or embedded AI subscription costs.', 'client', 'monthly', 50, 'needs_review'),
   cost('automation', 'agent_automation_deployment', 'automation', 'Workflow automation tooling', 'n8n, workflow runtime, connectors, or equivalent automation layer.', 'client', 'monthly', 30, 'needs_review'),
 ]
@@ -324,8 +365,9 @@ export function buildDefaultClientAiOpsRoadmap(context: RoadmapContext = {}): Ro
     title: `${name} AI Ops Roadmap`,
     clientSummary: agentReadiness
       ? `${agentReadiness.clientSummary} ${agentReadiness.roadmapRecommendation}`
-      : 'A phased implementation plan for client-owned AI infrastructure, transparent setup costs, agent deployment, monitoring, and continuity reporting.',
+      : 'A phased implementation plan for client-owned AI infrastructure, 24/7 data and local LLM repository placement, transparent setup costs, agent deployment, monitoring, and continuity reporting.',
     inputHash: hashContext(context),
+    runtimePlacementOptions: DEFAULT_RUNTIME_PLACEMENT_OPTIONS.map((option) => ({ ...option })),
     phases: DEFAULT_PHASES.map((phase) => {
       const adjustment = adjustments[phase.phaseKey]
       return {
@@ -389,7 +431,7 @@ export function buildProposalRoadmapSnapshot(context: RoadmapContext = {}): Road
 }
 
 export function buildClientRoadmapView(input: {
-  roadmap: { title: string; status: RoadmapStatus; client_summary: string | null }
+  roadmap: { title: string; status: RoadmapStatus; client_summary: string | null; snapshot?: Record<string, unknown> | null }
   phases: Array<{
     id?: string
     title: string
@@ -436,6 +478,9 @@ export function buildClientRoadmapView(input: {
     title: input.roadmap.title,
     status: input.roadmap.status,
     clientSummary: input.roadmap.client_summary,
+    runtimePlacementOptions: Array.isArray(input.roadmap.snapshot?.runtime_placement_options)
+      ? input.roadmap.snapshot.runtime_placement_options as RoadmapRuntimePlacementOption[]
+      : DEFAULT_RUNTIME_PLACEMENT_OPTIONS.map((option) => ({ ...option })),
     phases,
     costSummary: rollUpRoadmapCosts(input.costItems),
     nextActions: visibleTasks


### PR DESCRIPTION
## Summary
- makes local-device, cloud-hosted, and hybrid runtime placement explicit in Client AI Ops roadmap drafts
- adds client-facing runtime placement options for data stores, local LLM repositories, and always-on worker runtimes
- persists runtime placement options in roadmap snapshots and preserves them during cost rollup refreshes
- updates roadmap tests and SOP language for 24/7 access and approval-gated local/cloud provisioning

## Enhancement Impact Preflight
- Enhancement: Add runtime placement options to Client AI Ops roadmap implementation.
- User-facing surface: Client AI Ops roadmap/proposal snapshot, client dashboard roadmap projection, admin project roadmap creation.
- Predicted files: lib/client-ai-ops-roadmap.ts, lib/client-ai-ops-roadmap-db.ts, lib/client-ai-ops-roadmap.test.ts, docs/client-ai-ops-roadmap-sop.md.
- Shared routes/APIs/tables/helpers: client_ai_ops_roadmaps snapshot, roadmap phases/tasks/cost items, getRoadmapBundleForProject, ensureRoadmapForProject, refreshRoadmapPhaseRollups.
- Active PRs or branches checked: no open PRs; checked credential-reporting-next, subscription-watch-next, vercel-build-observability worktrees.
- Dirty worktree files checked: current worktree clean before edits; parallel worktrees clean.
- Overlap rating: green.
- Coordination decision: proceed independently inside Client AI Ops roadmap ownership boundary.
- Merge-order note: can merge independently before or after unrelated credential/subscription/Vercel work; avoid simultaneous edits to client_ai_ops roadmap snapshot handling.

## Validation
- npm test -- lib/client-ai-ops-roadmap.test.ts app/api/cron/client-ai-ops-monitor/route.test.ts lib/client-ai-ops-technology-registry.test.ts
- npm run build:knowledge && npx tsc --noEmit --pretty false

## Safety
- no migrations
- no provider provisioning, local device setup, credential sync, or cloud deployment execution
- runtime placement remains planning/projection data; local/cloud setup stays approval-gated