### PR TITLE
Extend subscription budget query readiness

### DIFF
--- a/app/admin/subscriptions/page.tsx
+++ b/app/admin/subscriptions/page.tsx
@@ -31,14 +31,32 @@ interface BudgetLineItem {
   budgetAction: string
 }
 
+interface TransitionAdjustment {
+  vendor: string
+  amountUsd: number
+  confidence: 'expected_if_cancellation_holds' | 'confirmed' | 'watch_only'
+  rationale: string
+}
+
+interface ApifyCallAnalysis {
+  configuredActorSurfaces: number
+  lastMonitorExecution: string
+  analysisDocument: string
+  nextAction: string
+}
+
 interface BudgetSummary {
   monthlyTargetUsd: number
   confirmedMonthlyRunRateUsd: number
   overTargetUsd: number
+  expectedNextCycleRunRateUsd?: number
+  expectedNextCycleOverTargetUsd?: number
   confidence: 'partial_receipt_verified' | 'tracker_only' | 'dashboard_verified'
   lastReceiptRefresh: string
   queryExamples: string[]
   notes: string[]
+  transitionAdjustments?: TransitionAdjustment[]
+  apifyCallAnalysis?: ApifyCallAnalysis
   lineItems: BudgetLineItem[]
   watchItems: string[]
 }
@@ -49,8 +67,12 @@ interface BudgetQueryResult {
   monthlyTargetUsd: number | null
   confirmedMonthlyRunRateUsd: number | null
   overTargetUsd: number | null
+  expectedNextCycleRunRateUsd: number | null
+  expectedNextCycleOverTargetUsd: number | null
   matchingLineItems: BudgetLineItem[]
   suggestedCuts: BudgetLineItem[]
+  transitionAdjustments: TransitionAdjustment[]
+  apifyCallAnalysis: ApifyCallAnalysis | null
   unresolvedChecks: string[]
 }
 
@@ -213,9 +235,13 @@ function AdminSubscriptionsPageContent() {
                   </div>
                 </div>
 
-                <div className="mt-5 grid grid-cols-1 md:grid-cols-3 gap-3">
+                <div className="mt-5 grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-3">
                   <Signal label="Monthly target" value={`$${budget.monthlyTargetUsd.toFixed(2)}`} />
                   <Signal label="Confirmed run-rate" value={`$${budget.confirmedMonthlyRunRateUsd.toFixed(2)}`} />
+                  <Signal
+                    label="Projected next cycle"
+                    value={budget.expectedNextCycleRunRateUsd ? `$${budget.expectedNextCycleRunRateUsd.toFixed(2)}` : 'Pending'}
+                  />
                   <Signal label="Receipt refresh" value={budget.lastReceiptRefresh} />
                 </div>
 
@@ -239,7 +265,7 @@ function AdminSubscriptionsPageContent() {
                 {queryResult && (
                   <div className="mt-4 rounded-lg border border-radiant-gold/30 bg-radiant-gold/10 p-4">
                     <p className="text-sm font-medium text-radiant-gold">{queryResult.answer}</p>
-                    <div className="mt-3 grid grid-cols-1 lg:grid-cols-2 gap-3">
+                    <div className="mt-3 grid grid-cols-1 lg:grid-cols-3 gap-3">
                       <div>
                         <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">Top budget levers</p>
                         <ul className="space-y-1 text-sm text-muted-foreground">
@@ -258,7 +284,22 @@ function AdminSubscriptionsPageContent() {
                           ))}
                         </ul>
                       </div>
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">Transition adjustments</p>
+                        <ul className="space-y-1 text-sm text-muted-foreground">
+                          {queryResult.transitionAdjustments.slice(0, 4).map((item) => (
+                            <li key={item.vendor}>
+                              {item.vendor}: {item.amountUsd < 0 ? '-' : '+'}${Math.abs(item.amountUsd).toFixed(2)}
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
                     </div>
+                    {queryResult.apifyCallAnalysis && (
+                      <p className="mt-3 text-xs text-muted-foreground">
+                        Apify analysis: {queryResult.apifyCallAnalysis.configuredActorSurfaces} configured actor surfaces. {queryResult.apifyCallAnalysis.lastMonitorExecution}
+                      </p>
+                    )}
                   </div>
                 )}
               </section>

--- a/docs/apify-call-bakeoff-analysis.md
+++ b/docs/apify-call-bakeoff-analysis.md
@@ -16,6 +16,7 @@ Purpose: keep Apify under active watch, identify every current Portfolio call su
 - That execution checked `alien_force~facebook-scraper-pro` and `harvestapi~linkedin-profile-search`.
 - Both monitored actors returned `no_runs` with `totalRuns: 0`, producing warning alerts rather than evidence of recent productive actor usage.
 - Static exports show more Apify call surfaces than the current monitor checks. The monitor should be expanded or the bakeoff should pull direct Apify run history before a final replacement decision.
+- 2026-05-09 dashboard readiness update: the admin Subscription Watch budget query exposes this analysis as the Apify watch path and treats the 12 configured actor surfaces as replacement-analysis scope, not cancellation evidence by itself.
 
 ## Configured Apify Call Surfaces
 

--- a/docs/subscription-cancellation-audit.md
+++ b/docs/subscription-cancellation-audit.md
@@ -10,6 +10,36 @@ no meaningful usage signal, or after clear redundancy plus a lower-risk
 replacement path. Production changes require explicit approval in the form
 `Cancel <tool/vendor> for Portfolio`.
 
+## 2026-05-09 Budget Query Readiness Update
+
+Status: YELLOW
+
+Summary:
+
+- No cancellation approvals requested and no cancellation action taken.
+- The admin Subscription Watch surface now separates the current receipt-backed
+  run-rate from the projected next-cycle run-rate, so the dashboard can answer
+  questions about whether the month is inflated by quick enrollments,
+  cancellations, and the Anthropic-to-ChatGPT switch.
+- Current confirmed run-rate remains `$791.02` against the `$300.00` monthly
+  target. The tracked Anthropic adjustment is `-$106.25` if cancellation holds,
+  projecting a next-cycle run-rate of `$684.77`, still `$384.77` over target.
+- Gamma and Apify remain explicit watch items. Gamma stays in the deck/tooling
+  comparison path. Apify stays tied to actor-level replacement analysis rather
+  than a simple cancellation recommendation.
+- The Apify analysis currently identifies 12 configured actor call surfaces and
+  requires direct Apify run history, actor costs, dataset counts, and accepted
+  result rates before deciding whether to replace, pause, or keep Apify.
+
+Raw Findings
+
+- Dashboard/data source updated: `/docs/subscription-status.json`.
+- Query helper updated: `/lib/subscription-status.ts`.
+- Admin view updated: `/app/admin/subscriptions/page.tsx`.
+- Apify evidence source remains `/docs/apify-call-bakeoff-analysis.md`.
+- This update does not touch shared cost-event schema or production billing
+  writes.
+
 ## 2026-05-08 Daily Monitor Run
 
 Status: YELLOW

--- a/docs/subscription-status.json
+++ b/docs/subscription-status.json
@@ -8,6 +8,8 @@
     "monthlyTargetUsd": 300,
     "confirmedMonthlyRunRateUsd": 791.02,
     "overTargetUsd": 491.02,
+    "expectedNextCycleRunRateUsd": 684.77,
+    "expectedNextCycleOverTargetUsd": 384.77,
     "confidence": "partial_receipt_verified",
     "lastReceiptRefresh": "2026-05-06",
     "queryExamples": [
@@ -21,6 +23,20 @@
       "Recent quick enrollments/cancellations may make next-month realized spend lower than this snapshot.",
       "Cancellation remains approval-gated; this budget view is read-only."
     ],
+    "transitionAdjustments": [
+      {
+        "vendor": "Anthropic",
+        "amountUsd": -106.25,
+        "confidence": "expected_if_cancellation_holds",
+        "rationale": "Claude Max appears in the current receipt-backed run-rate, but the ChatGPT switch should remove this line from the next settled cycle if cancellation remains in place."
+      }
+    ],
+    "apifyCallAnalysis": {
+      "configuredActorSurfaces": 12,
+      "lastMonitorExecution": "n8n execution 13174 on 2026-05-06 checked two actors and found no recent runs.",
+      "analysisDocument": "/docs/apify-call-bakeoff-analysis.md",
+      "nextAction": "Pull direct Apify run history, actor costs, dataset counts, and accepted-result rates before deciding whether to replace, pause, or keep Apify."
+    },
     "lineItems": [
       {
         "vendor": "BuiltWith",

--- a/lib/subscription-status.test.ts
+++ b/lib/subscription-status.test.ts
@@ -7,6 +7,7 @@ describe('subscription status budget queries', () => {
 
     expect(registry.budget?.monthlyTargetUsd).toBe(300)
     expect(registry.budget?.confirmedMonthlyRunRateUsd).toBeGreaterThan(300)
+    expect(registry.budget?.expectedNextCycleRunRateUsd).toBeLessThan(registry.budget?.confirmedMonthlyRunRateUsd ?? 0)
     expect(registry.budget?.lineItems.map((item) => item.vendor)).toEqual(
       expect.arrayContaining(['Gamma', 'Apify', 'OpenAI / ChatGPT Pro'])
     )
@@ -22,9 +23,19 @@ describe('subscription status budget queries', () => {
   })
 
   it('keeps Gamma and Apify visible as budget watch items', () => {
-    const result = answerSubscriptionBudgetQuery('Should we keep an eye on Gamma and Apify?')
+    const result = answerSubscriptionBudgetQuery('Should we keep an eye on Gamma and Apify, and analyze Apify calls?')
 
     expect(result.answer).toContain('Gamma')
     expect(result.answer).toContain('Apify')
+    expect(result.apifyCallAnalysis?.configuredActorSurfaces).toBeGreaterThan(0)
+  })
+
+  it('handles transition spend from the Anthropic to ChatGPT switch', () => {
+    const result = answerSubscriptionBudgetQuery('Will spend go down next month after switching from Anthropic to ChatGPT?')
+
+    expect(result.answer).toContain('transition activity')
+    expect(result.answer).toContain('Anthropic')
+    expect(result.expectedNextCycleRunRateUsd).toBe(684.77)
+    expect(result.transitionAdjustments[0]?.amountUsd).toBeLessThan(0)
   })
 })

--- a/lib/subscription-status.ts
+++ b/lib/subscription-status.ts
@@ -35,14 +35,32 @@ export interface SubscriptionBudgetLineItem {
   budgetAction: string
 }
 
+export interface SubscriptionTransitionAdjustment {
+  vendor: string
+  amountUsd: number
+  confidence: 'expected_if_cancellation_holds' | 'confirmed' | 'watch_only'
+  rationale: string
+}
+
+export interface SubscriptionApifyCallAnalysis {
+  configuredActorSurfaces: number
+  lastMonitorExecution: string
+  analysisDocument: string
+  nextAction: string
+}
+
 export interface SubscriptionBudgetSummary {
   monthlyTargetUsd: number
   confirmedMonthlyRunRateUsd: number
   overTargetUsd: number
+  expectedNextCycleRunRateUsd?: number
+  expectedNextCycleOverTargetUsd?: number
   confidence: 'partial_receipt_verified' | 'tracker_only' | 'dashboard_verified'
   lastReceiptRefresh: string
   queryExamples: string[]
   notes: string[]
+  transitionAdjustments?: SubscriptionTransitionAdjustment[]
+  apifyCallAnalysis?: SubscriptionApifyCallAnalysis
   lineItems: SubscriptionBudgetLineItem[]
   watchItems: string[]
 }
@@ -75,8 +93,12 @@ export interface SubscriptionQueryResult {
   monthlyTargetUsd: number | null
   confirmedMonthlyRunRateUsd: number | null
   overTargetUsd: number | null
+  expectedNextCycleRunRateUsd: number | null
+  expectedNextCycleOverTargetUsd: number | null
   matchingLineItems: SubscriptionBudgetLineItem[]
   suggestedCuts: SubscriptionBudgetLineItem[]
+  transitionAdjustments: SubscriptionTransitionAdjustment[]
+  apifyCallAnalysis: SubscriptionApifyCallAnalysis | null
   unresolvedChecks: string[]
 }
 
@@ -110,6 +132,9 @@ export function answerSubscriptionBudgetQuery(query: string): SubscriptionQueryR
   const target = budget?.monthlyTargetUsd ?? null
   const runRate = budget?.confirmedMonthlyRunRateUsd ?? null
   const overTarget = budget?.overTargetUsd ?? null
+  const expectedRunRate = budget?.expectedNextCycleRunRateUsd ?? null
+  const expectedOverTarget = budget?.expectedNextCycleOverTargetUsd ?? null
+  const transitionAdjustments = budget?.transitionAdjustments ?? []
 
   let answer = registry.summary.headline
   if (budget && (normalized.includes('spend') || normalized.includes('budget') || normalized.includes('300') || normalized.includes('monthly') || normalized.includes('cost'))) {
@@ -117,6 +142,11 @@ export function answerSubscriptionBudgetQuery(query: string): SubscriptionQueryR
       ? `over the $${budget.monthlyTargetUsd.toFixed(0)} target by $${budget.overTargetUsd.toFixed(2)}`
       : `under the $${budget.monthlyTargetUsd.toFixed(0)} target`
     answer = `Confirmed monthly run-rate is $${budget.confirmedMonthlyRunRateUsd.toFixed(2)}, ${direction}.`
+  }
+  if (budget && (normalized.includes('switch') || normalized.includes('anthropic') || normalized.includes('chatgpt') || normalized.includes('next month') || normalized.includes('next cycle') || normalized.includes('go down') || normalized.includes('cancellation') || normalized.includes('enrollment'))) {
+    const transitionTotal = Math.abs(transitionAdjustments.reduce((sum, item) => sum + item.amountUsd, 0))
+    const projected = budget.expectedNextCycleRunRateUsd
+    answer = `${answer} Current spend is inflated by transition activity. The tracked next-cycle adjustment is $${transitionTotal.toFixed(2)} from Anthropic if the cancellation holds, which projects the settled run-rate at $${projected?.toFixed(2) ?? 'unknown'}.`
   }
   if (budget && (normalized.includes('cut') || normalized.includes('cancel') || normalized.includes('under'))) {
     const topCuts = suggestedCuts.slice(0, 3).map((item) => `${item.vendor} ($${item.amountUsd.toFixed(2)})`).join(', ')
@@ -128,6 +158,9 @@ export function answerSubscriptionBudgetQuery(query: string): SubscriptionQueryR
       .map((item) => `${item.vendor}: $${item.amountUsd.toFixed(2)}; ${item.budgetAction}`)
       .join(' ')
     answer = watched || answer
+    if (normalized.includes('apify') && budget.apifyCallAnalysis) {
+      answer = `${answer} Apify has ${budget.apifyCallAnalysis.configuredActorSurfaces} configured actor surfaces in the current analysis; ${budget.apifyCallAnalysis.nextAction}`
+    }
   }
 
   return {
@@ -136,8 +169,12 @@ export function answerSubscriptionBudgetQuery(query: string): SubscriptionQueryR
     monthlyTargetUsd: target,
     confirmedMonthlyRunRateUsd: runRate,
     overTargetUsd: overTarget,
+    expectedNextCycleRunRateUsd: expectedRunRate,
+    expectedNextCycleOverTargetUsd: expectedOverTarget,
     matchingLineItems: matchingLineItems.length > 0 ? matchingLineItems : lineItems,
     suggestedCuts,
+    transitionAdjustments,
+    apifyCallAnalysis: budget?.apifyCallAnalysis ?? null,
     unresolvedChecks,
   }
 }


### PR DESCRIPTION
## Summary
- separates confirmed subscription run-rate from projected next-cycle spend in the Subscription Watch data model
- surfaces Anthropic-to-ChatGPT transition adjustments and Apify actor-analysis context in the admin budget query result
- documents the May 9 budget-query readiness update and keeps Gamma/Apify on watch without approving cancellations

## Validation
- npm test -- --run lib/subscription-status.test.ts lib/technology-bakeoff.test.ts app/admin/technology-bakeoffs/page.test.tsx
- npm run lint -- --file app/admin/subscriptions/page.tsx --file app/api/admin/subscriptions/status/route.ts --file lib/subscription-status.ts --file lib/technology-bakeoff.ts
- git diff --check
- npm run db:health-check, passed after sourcing /Users/vambahsillah/Projects/Portfolio/.env.local from the isolated subscription worktree

## Notes
- No shared cost-event schema changes.
- Initial push hook failed because the isolated worktree did not have its own .env.local. PROD_SUPABASE_URL and PROD_SUPABASE_SERVICE_ROLE_KEY are present in the main Portfolio .env.local, and the production database health check passed when sourced from there.
- The main .env.local produced a shell warning on line 100 when sourced directly; secrets were not printed and the file was not modified.