### PR TITLE
feat: add credential rotation reporting

### DIFF
--- a/app/admin/credentials/page.test.tsx
+++ b/app/admin/credentials/page.test.tsx
@@ -1,0 +1,121 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import CredentialAdminPage from './page'
+
+vi.mock('@/components/ProtectedRoute', () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('@/lib/auth', () => ({
+  getCurrentSession: vi.fn(async () => ({ access_token: 'admin-token' })),
+}))
+
+const baseReport = {
+  generatedAt: '2026-05-09T12:00:00.000Z',
+  env: 'staging',
+  asOf: '2026-05-09',
+  sourceBoundary: 'Infisical for runtime/API secrets; 1Password for human logins.',
+  providerContext: {
+    infisicalProject: 'portfolio',
+    infisicalPath: '/portfolio',
+    onePasswordVault: 'Portfolio / staging',
+  },
+  summary: {
+    total: 2,
+    ok: 0,
+    due: 0,
+    needsBaseline: 2,
+    approvalRequired: 0,
+    providerConfirmed: 0,
+    providerPending: 2,
+  },
+  bySource: { infisical: 1, '1password': 1 },
+  byRisk: { 'standard-api': 1, 'oauth-session': 1 },
+  byRuntimeSink: { Vercel: 1, 'local-env': 1 },
+  blockers: ['2 staging secrets need provider-confirmed rotation baselines.'],
+  rows: [
+    {
+      id: 'openai-api-key',
+      envVar: 'OPENAI_API_KEY',
+      displayName: 'OpenAI API key',
+      risk: 'standard-api',
+      sourceOfTruth: 'infisical',
+      cadenceDays: 90,
+      approvalRequired: false,
+      baselineStatus: 'pending-provider-confirmation',
+      lastRotatedAt: null,
+      dueAt: null,
+      status: 'needs-baseline',
+      nextAction: 'Confirm provider history and record lastRotatedAt evidence.',
+    },
+    {
+      id: 'linkedin-cookie',
+      envVar: 'LINKEDIN_COOKIE',
+      displayName: 'LinkedIn browser session',
+      risk: 'oauth-session',
+      sourceOfTruth: '1password',
+      cadenceDays: 365,
+      approvalRequired: false,
+      baselineStatus: 'pending-provider-confirmation',
+      lastRotatedAt: null,
+      dueAt: null,
+      status: 'needs-baseline',
+      nextAction: 'Confirm provider history and record lastRotatedAt evidence.',
+    },
+  ],
+}
+
+describe('CredentialAdminPage', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      const env = url.includes('env=prod') ? 'prod' : 'staging'
+      return {
+        ok: true,
+        json: async () => ({
+          ...baseReport,
+          env,
+          providerContext: {
+            ...baseReport.providerContext,
+            onePasswordVault: env === 'prod' ? 'Portfolio / prod' : 'Portfolio / staging',
+          },
+        }),
+      }
+    }))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('renders credential posture without exposing secret values', async () => {
+    render(<CredentialAdminPage />)
+
+    expect(await screen.findByRole('heading', { name: 'Credential Reporting' })).toBeInTheDocument()
+    expect(screen.getByText('Baseline needed')).toBeInTheDocument()
+    expect(screen.getByText('2 need baseline / 0 due / 0 ok')).toBeInTheDocument()
+    expect(screen.getByText('OPENAI_API_KEY')).toBeInTheDocument()
+    expect(screen.getByText('LINKEDIN_COOKIE')).toBeInTheDocument()
+    expect(screen.queryByText('super-secret-value')).not.toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/admin/credentials/report?env=staging', {
+        headers: { Authorization: 'Bearer admin-token' },
+      })
+    })
+  })
+
+  it('reloads the selected environment', async () => {
+    render(<CredentialAdminPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'prod' }))
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/admin/credentials/report?env=prod', {
+        headers: { Authorization: 'Bearer admin-token' },
+      })
+    })
+    expect(await screen.findByText('Portfolio / prod')).toBeInTheDocument()
+  })
+})

--- a/app/admin/credentials/page.tsx
+++ b/app/admin/credentials/page.tsx
@@ -1,0 +1,276 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { ReactNode } from 'react'
+import { AlertTriangle, CheckCircle2, Clock3, Database, KeyRound, RefreshCw, ShieldCheck } from 'lucide-react'
+import ProtectedRoute from '@/components/ProtectedRoute'
+import Breadcrumbs from '@/components/admin/Breadcrumbs'
+import { getCurrentSession } from '@/lib/auth'
+
+type CredentialEnv = 'dev' | 'staging' | 'prod'
+
+type CredentialReportRow = {
+  id: string
+  envVar: string
+  displayName: string
+  risk: string
+  sourceOfTruth: 'infisical' | '1password'
+  cadenceDays: number
+  approvalRequired: boolean
+  baselineStatus: string
+  lastRotatedAt: string | null
+  dueAt: string | null
+  status: 'needs-baseline' | 'due' | 'ok'
+  nextAction: string
+}
+
+type CredentialReport = {
+  generatedAt: string
+  env: CredentialEnv
+  asOf: string
+  sourceBoundary: string
+  providerContext: {
+    infisicalProject: string
+    infisicalPath: string
+    onePasswordVault: string
+  }
+  summary: {
+    total: number
+    ok: number
+    due: number
+    needsBaseline: number
+    approvalRequired: number
+    providerConfirmed: number
+    providerPending: number
+  }
+  bySource: Record<string, number>
+  byRisk: Record<string, number>
+  byRuntimeSink: Record<string, number>
+  blockers: string[]
+  rows: CredentialReportRow[]
+}
+
+const ENVS: CredentialEnv[] = ['dev', 'staging', 'prod']
+
+export default function CredentialAdminPage() {
+  return (
+    <ProtectedRoute requireAdmin>
+      <CredentialAdminContent />
+    </ProtectedRoute>
+  )
+}
+
+function CredentialAdminContent() {
+  const [env, setEnv] = useState<CredentialEnv>('staging')
+  const [report, setReport] = useState<CredentialReport | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const loadReport = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Missing admin session')
+      const response = await fetch(`/api/admin/credentials/report?env=${env}`, {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      })
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`)
+      setReport(body)
+    } catch (err) {
+      setReport(null)
+      setError(err instanceof Error ? err.message : 'Failed to load credential report')
+    } finally {
+      setLoading(false)
+    }
+  }, [env])
+
+  useEffect(() => {
+    loadReport()
+  }, [loadReport])
+
+  const posture = useMemo(() => {
+    if (!report) return { label: 'Unknown', tone: 'slate' }
+    if (report.summary.due > 0) return { label: 'Rotation due', tone: 'red' }
+    if (report.summary.needsBaseline > 0) return { label: 'Baseline needed', tone: 'amber' }
+    return { label: 'Current', tone: 'green' }
+  }, [report])
+
+  return (
+    <div className="min-h-screen bg-background text-foreground p-6 lg:p-8">
+      <div className="max-w-7xl mx-auto">
+        <Breadcrumbs items={[
+          { label: 'Admin Dashboard', href: '/admin' },
+          { label: 'Credential Reporting' },
+        ]} />
+
+        <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <h1 className="text-3xl font-bold mb-1">Credential Reporting</h1>
+            <p className="text-muted-foreground text-sm max-w-3xl">
+              Rotation visibility for the Portfolio credential inventory. Values are never loaded or displayed here.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="flex rounded-lg border border-silicon-slate bg-silicon-slate/30 p-1">
+              {ENVS.map((item) => (
+                <button
+                  key={item}
+                  onClick={() => setEnv(item)}
+                  className={`rounded-md px-3 py-1.5 text-sm ${env === item ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'}`}
+                >
+                  {item}
+                </button>
+              ))}
+            </div>
+            <button
+              onClick={loadReport}
+              className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate bg-silicon-slate/30 px-3 py-2 text-sm hover:bg-silicon-slate"
+            >
+              <RefreshCw size={16} />
+              Refresh
+            </button>
+          </div>
+        </div>
+
+        {loading ? (
+          <div className="flex items-center justify-center py-16 text-muted-foreground">Loading...</div>
+        ) : error ? (
+          <Notice title="Credential report unavailable" body={error} tone="red" />
+        ) : report ? (
+          <>
+            <section className="mb-6 rounded-lg border border-silicon-slate bg-silicon-slate/30 p-5">
+              <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                <div>
+                  <div className="mb-2 flex items-center gap-2 text-sm text-muted-foreground">
+                    <ShieldCheck size={16} />
+                    <span>{report.providerContext.infisicalProject}:{report.providerContext.infisicalPath}</span>
+                    <span>/</span>
+                    <span>{report.providerContext.onePasswordVault}</span>
+                  </div>
+                  <h2 className="text-2xl font-semibold">{posture.label}</h2>
+                  <p className="mt-1 text-sm text-muted-foreground">Generated {new Date(report.generatedAt).toLocaleString()}</p>
+                </div>
+                <div className={`rounded-lg border px-4 py-3 text-sm ${posture.tone === 'red' ? 'border-red-500/40 bg-red-500/10 text-red-200' : posture.tone === 'amber' ? 'border-amber-500/40 bg-amber-500/10 text-amber-200' : 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200'}`}>
+                  {report.summary.needsBaseline} need baseline / {report.summary.due} due / {report.summary.ok} ok
+                </div>
+              </div>
+            </section>
+
+            <section className="mb-6 grid grid-cols-1 gap-4 md:grid-cols-4">
+              <Metric icon={<KeyRound size={18} />} label="Tracked" value={report.summary.total} />
+              <Metric icon={<CheckCircle2 size={18} />} label="OK" value={report.summary.ok} />
+              <Metric icon={<Clock3 size={18} />} label="Due" value={report.summary.due} />
+              <Metric icon={<AlertTriangle size={18} />} label="Need baseline" value={report.summary.needsBaseline} />
+            </section>
+
+            {report.blockers.length > 0 && (
+              <section className="mb-6 rounded-lg border border-amber-500/30 bg-amber-500/10 p-4">
+                <h2 className="mb-2 flex items-center gap-2 text-sm font-semibold text-amber-100">
+                  <AlertTriangle size={16} />
+                  Visibility blockers
+                </h2>
+                <ul className="space-y-1 text-sm text-amber-50/90">
+                  {report.blockers.map((blocker) => <li key={blocker}>{blocker}</li>)}
+                </ul>
+              </section>
+            )}
+
+            <section className="mb-6 grid grid-cols-1 gap-4 lg:grid-cols-3">
+              <Breakdown title="Sources" rows={report.bySource} />
+              <Breakdown title="Risk" rows={report.byRisk} />
+              <Breakdown title="Runtime Sinks" rows={report.byRuntimeSink} />
+            </section>
+
+            <section className="overflow-hidden rounded-lg border border-silicon-slate">
+              <div className="border-b border-silicon-slate bg-silicon-slate/40 px-4 py-3">
+                <h2 className="font-semibold">Rotation inventory</h2>
+              </div>
+              <div className="overflow-x-auto">
+                <table className="min-w-full divide-y divide-silicon-slate text-sm">
+                  <thead className="bg-silicon-slate/30 text-left text-xs uppercase tracking-wide text-muted-foreground">
+                    <tr>
+                      <th className="px-4 py-3">Status</th>
+                      <th className="px-4 py-3">Secret</th>
+                      <th className="px-4 py-3">Source</th>
+                      <th className="px-4 py-3">Cadence</th>
+                      <th className="px-4 py-3">Due</th>
+                      <th className="px-4 py-3">Next action</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-silicon-slate">
+                    {report.rows.map((row) => (
+                      <tr key={row.id}>
+                        <td className="px-4 py-3"><StatusPill status={row.status} /></td>
+                        <td className="px-4 py-3">
+                          <div className="font-mono text-xs">{row.envVar}</div>
+                          <div className="text-xs text-muted-foreground">{row.displayName}</div>
+                        </td>
+                        <td className="px-4 py-3">{row.sourceOfTruth}</td>
+                        <td className="px-4 py-3">{row.cadenceDays}d</td>
+                        <td className="px-4 py-3">{row.dueAt ?? 'unknown'}</td>
+                        <td className="px-4 py-3 text-muted-foreground">{row.nextAction}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          </>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function Metric({ icon, label, value }: { icon: ReactNode; label: string; value: number }) {
+  return (
+    <div className="rounded-lg border border-silicon-slate bg-silicon-slate/30 p-4">
+      <div className="mb-3 flex items-center gap-2 text-muted-foreground">
+        {icon}
+        <span className="text-sm">{label}</span>
+      </div>
+      <div className="text-3xl font-semibold">{value}</div>
+    </div>
+  )
+}
+
+function Breakdown({ title, rows }: { title: string; rows: Record<string, number> }) {
+  return (
+    <div className="rounded-lg border border-silicon-slate bg-silicon-slate/30 p-4">
+      <h2 className="mb-3 flex items-center gap-2 font-semibold">
+        <Database size={16} />
+        {title}
+      </h2>
+      <div className="space-y-2">
+        {Object.entries(rows).map(([key, value]) => (
+          <div key={key} className="flex items-center justify-between gap-3 text-sm">
+            <span className="text-muted-foreground">{key}</span>
+            <span className="font-mono">{value}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function StatusPill({ status }: { status: CredentialReportRow['status'] }) {
+  const classes = status === 'ok'
+    ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-200'
+    : status === 'due'
+      ? 'border-red-500/30 bg-red-500/10 text-red-200'
+      : 'border-amber-500/30 bg-amber-500/10 text-amber-200'
+
+  return <span className={`inline-flex rounded-full border px-2 py-1 text-xs ${classes}`}>{status}</span>
+}
+
+function Notice({ title, body, tone }: { title: string; body: string; tone: 'red' | 'amber' }) {
+  const classes = tone === 'red' ? 'border-red-500/40 bg-red-500/10 text-red-100' : 'border-amber-500/40 bg-amber-500/10 text-amber-100'
+  return (
+    <div className={`rounded-lg border p-4 ${classes}`}>
+      <h2 className="mb-1 font-semibold">{title}</h2>
+      <p className="text-sm opacity-90">{body}</p>
+    </div>
+  )
+}

--- a/app/api/admin/credentials/report/route.test.ts
+++ b/app/api/admin/credentials/report/route.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  readFile: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('node:fs/promises', () => ({
+  readFile: mocks.readFile,
+  default: { readFile: mocks.readFile },
+}))
+
+import { GET } from './route'
+
+function request(url = 'http://localhost/api/admin/credentials/report?env=staging') {
+  return new Request(url, {
+    headers: { authorization: 'Bearer token' },
+  })
+}
+
+const inventory = {
+  schemaVersion: 1,
+  policy: {
+    sourceOfTruth: 'Infisical for runtime/API secrets; 1Password for human logins.',
+    runtimeSinks: ['Vercel', 'n8n'],
+    agentAuthority: 'Scoped read/run by default.',
+    defaultCadenceDays: { 'standard-api': 90 },
+  },
+  providers: {
+    infisical: {
+      projectSlug: 'portfolio',
+      secretPath: '/portfolio',
+      envMap: { dev: 'dev', staging: 'staging', prod: 'prod' },
+    },
+    onepassword: {
+      vaults: {
+        dev: 'Portfolio / dev',
+        staging: 'Portfolio / staging',
+        prod: 'Portfolio / prod',
+      },
+    },
+  },
+  secrets: [
+    {
+      id: 'openai-api-key',
+      envVar: 'OPENAI_API_KEY',
+      displayName: 'OpenAI API key',
+      category: 'llm',
+      risk: 'standard-api',
+      sourceOfTruth: 'infisical',
+      rotationMode: 'provider-dashboard-or-api',
+      rotationCadenceDays: 90,
+      environments: ['staging'],
+      runtimeSinks: ['Vercel'],
+      verification: ['npm run credentials:smoke -- --env {env}'],
+      rollback: 'Restore previous key.',
+      baseline: {
+        staging: {
+          status: 'pending-provider-confirmation',
+          lastRotatedAt: null,
+          evidence: 'Pending provider confirmation.',
+          updatedAt: '2026-05-01',
+        },
+      },
+    },
+  ],
+}
+
+describe('GET /api/admin/credentials/report', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.readFile.mockResolvedValue(JSON.stringify(inventory))
+  })
+
+  it('requires admin auth before reading the inventory', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await GET(request() as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.readFile).not.toHaveBeenCalled()
+  })
+
+  it('returns a credential report for the requested environment', async () => {
+    const response = await GET(request('http://localhost/api/admin/credentials/report?env=staging&asOf=2026-05-09') as never)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({
+      env: 'staging',
+      asOf: '2026-05-09',
+      summary: {
+        total: 1,
+        needsBaseline: 1,
+      },
+      providerContext: {
+        infisicalProject: 'portfolio',
+        onePasswordVault: 'Portfolio / staging',
+      },
+    })
+    expect(body.rows[0]).toMatchObject({
+      envVar: 'OPENAI_API_KEY',
+      status: 'needs-baseline',
+    })
+  })
+
+  it('rejects invalid environments', async () => {
+    const response = await GET(request('http://localhost/api/admin/credentials/report?env=qa') as never)
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'Invalid env. Expected dev, staging, or prod.' })
+  })
+})

--- a/app/api/admin/credentials/report/route.ts
+++ b/app/api/admin/credentials/report/route.ts
@@ -1,0 +1,38 @@
+import { readFile } from 'node:fs/promises'
+import * as path from 'node:path'
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import {
+  buildCredentialReport,
+  isCredentialEnvironment,
+  type CredentialInventory,
+} from '@/lib/credential-report'
+
+export const dynamic = 'force-dynamic'
+
+const INVENTORY_PATH = path.join(process.cwd(), 'docs', 'credential-inventory.json')
+
+export async function GET(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const { searchParams } = new URL(request.url)
+  const env = searchParams.get('env') || 'staging'
+  const asOf = searchParams.get('asOf') || new Date().toISOString()
+
+  if (!isCredentialEnvironment(env)) {
+    return NextResponse.json({ error: 'Invalid env. Expected dev, staging, or prod.' }, { status: 400 })
+  }
+
+  try {
+    const inventory = JSON.parse(await readFile(INVENTORY_PATH, 'utf8')) as CredentialInventory
+    return NextResponse.json(buildCredentialReport(inventory, env, asOf))
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to build credential report' },
+      { status: 500 }
+    )
+  }
+}

--- a/docs/credential-management-system.md
+++ b/docs/credential-management-system.md
@@ -25,6 +25,8 @@ All commands read `docs/credential-inventory.json`.
 
 ```bash
 npm run credentials:list-due -- --env staging
+npm run credentials:report -- --env staging
+npm run credentials:report -- --env staging --json
 npm run credentials:inject -- --env staging -- npm run n8n:drift-check -- --warn
 npm run credentials:rotate -- --secret n8n-ingest-secret --env staging
 npm run credentials:sync-runtime -- --secret n8n-ingest-secret --env staging
@@ -35,6 +37,8 @@ npm run credentials:smoke -- --env staging --require-provider-access
 The broker never prints raw secret values. Rotation packets are written to `.credential-rotation-audits/`, which is ignored by git.
 
 Use plain `credentials:smoke` for local registry checks. Use `--require-provider-access` after `op` and `infisical` are installed/authenticated; that mode fails unless the broker can read one scoped test secret from each source of truth without printing its value.
+
+Use `credentials:report` for rotation visibility. It is read-only and summarizes the inventory by status, source of truth, risk, runtime sink, approval boundary, and next action. It does not fetch or print secret values. The same report is exposed to admins at `/admin/credentials` through `/api/admin/credentials/report`.
 
 ## Rotation Rules
 

--- a/lib/credential-report.test.ts
+++ b/lib/credential-report.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest'
+import { buildCredentialReport, renderCredentialReportMarkdown, type CredentialInventory } from './credential-report'
+
+const inventory: CredentialInventory = {
+  schemaVersion: 1,
+  policy: {
+    sourceOfTruth: 'Infisical for runtime/API secrets; 1Password for human logins.',
+    runtimeSinks: ['Vercel', 'n8n', 'local-env'],
+    agentAuthority: 'Scoped read/run by default.',
+    defaultCadenceDays: {
+      'critical-production': 30,
+      'standard-api': 90,
+    },
+  },
+  providers: {
+    infisical: {
+      projectSlug: 'portfolio',
+      projectId: 'project-id',
+      secretPath: '/portfolio',
+      envMap: { dev: 'dev', staging: 'staging', prod: 'prod' },
+    },
+    onepassword: {
+      vaults: {
+        dev: 'Portfolio / dev',
+        staging: 'Portfolio / staging',
+        prod: 'Portfolio / prod',
+      },
+    },
+  },
+  secrets: [
+    {
+      id: 'due-secret',
+      envVar: 'DUE_SECRET',
+      displayName: 'Due secret',
+      category: 'api',
+      risk: 'standard-api',
+      sourceOfTruth: 'infisical',
+      rotationMode: 'provider-dashboard-or-api',
+      rotationCadenceDays: 30,
+      environments: ['staging', 'prod'],
+      runtimeSinks: ['Vercel', 'n8n'],
+      verification: ['npm run credentials:smoke -- --env {env}'],
+      rollback: 'Restore previous value.',
+      approvalRequired: ['prod'],
+      baseline: {
+        staging: {
+          status: 'confirmed',
+          lastRotatedAt: '2026-03-01',
+          evidence: 'Infisical audit log',
+          updatedAt: '2026-03-01',
+        },
+      },
+    },
+    {
+      id: 'missing-baseline',
+      envVar: 'MISSING_BASELINE',
+      displayName: 'Missing baseline',
+      category: 'login',
+      risk: 'critical-production',
+      sourceOfTruth: '1password',
+      rotationMode: 'manual-reauth',
+      rotationCadenceDays: 90,
+      environments: ['staging'],
+      runtimeSinks: ['local-env'],
+      verification: ['Manual login check'],
+      rollback: 'Re-authenticate.',
+      baseline: {
+        staging: {
+          status: 'pending-provider-confirmation',
+          lastRotatedAt: null,
+          evidence: 'Pending provider confirmation.',
+          updatedAt: '2026-05-01',
+        },
+      },
+    },
+  ],
+}
+
+describe('credential report', () => {
+  it('summarizes due and missing-baseline credential visibility without secret values', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-09T12:00:00.000Z'))
+
+    const report = buildCredentialReport(inventory, 'staging', '2026-05-09')
+
+    expect(report.summary).toMatchObject({
+      total: 2,
+      ok: 0,
+      due: 1,
+      needsBaseline: 1,
+      approvalRequired: 0,
+      providerConfirmed: 1,
+      providerPending: 1,
+    })
+    expect(report.providerContext).toEqual({
+      infisicalProject: 'portfolio',
+      infisicalPath: '/portfolio',
+      onePasswordVault: 'Portfolio / staging',
+    })
+    expect(report.bySource).toEqual({ infisical: 1, '1password': 1 })
+    expect(report.blockers).toEqual([
+      '1 staging secrets need provider-confirmed rotation baselines.',
+      '1 staging secrets are due for rotation.',
+    ])
+    expect(report.rows.map((row) => row.envVar)).toEqual(['DUE_SECRET', 'MISSING_BASELINE'])
+
+    const markdown = renderCredentialReportMarkdown(report)
+    expect(markdown).toContain('Credential Rotation Visibility (staging)')
+    expect(markdown).toContain('DUE_SECRET')
+    expect(markdown).not.toContain('super-secret')
+
+    vi.useRealTimers()
+  })
+})

--- a/lib/credential-report.ts
+++ b/lib/credential-report.ts
@@ -1,0 +1,285 @@
+export type CredentialEnvironment = 'dev' | 'staging' | 'prod'
+export type CredentialSourceOfTruth = 'infisical' | '1password'
+
+export type CredentialBaselineStatus = 'pending-provider-confirmation' | 'confirmed' | 'unknown'
+
+export type CredentialBaseline = {
+  status: CredentialBaselineStatus
+  lastRotatedAt: string | null
+  evidence: string
+  updatedAt: string
+}
+
+export type CredentialSecret = {
+  id: string
+  envVar: string
+  displayName: string
+  category: string
+  risk: string
+  sourceOfTruth: CredentialSourceOfTruth
+  rotationMode: string
+  rotationCadenceDays: number
+  environments: CredentialEnvironment[]
+  runtimeSinks: string[]
+  verification: string[]
+  rollback: string
+  approvalRequired?: CredentialEnvironment[]
+  baseline?: Partial<Record<CredentialEnvironment, CredentialBaseline>>
+  lastRotatedAt?: Partial<Record<CredentialEnvironment, string>>
+}
+
+export type CredentialInventory = {
+  schemaVersion: number
+  policy: {
+    sourceOfTruth: string
+    runtimeSinks: string[]
+    agentAuthority: string
+    defaultCadenceDays: Record<string, number>
+  }
+  providers: {
+    infisical: {
+      projectSlug: string
+      projectId?: string
+      secretPath: string
+      envMap: Record<CredentialEnvironment, string>
+    }
+    onepassword: {
+      vaults: Record<CredentialEnvironment, string>
+    }
+  }
+  secrets: CredentialSecret[]
+}
+
+export type CredentialReportRow = {
+  id: string
+  envVar: string
+  displayName: string
+  category: string
+  risk: string
+  sourceOfTruth: CredentialSourceOfTruth
+  rotationMode: string
+  cadenceDays: number
+  runtimeSinks: string[]
+  approvalRequired: boolean
+  baselineStatus: CredentialBaselineStatus
+  baselineEvidence: string
+  lastRotatedAt: string | null
+  dueAt: string | null
+  daysUntilDue: number | null
+  status: 'needs-baseline' | 'due' | 'ok'
+  nextAction: string
+}
+
+export type CredentialReport = {
+  generatedAt: string
+  env: CredentialEnvironment
+  asOf: string
+  sourceBoundary: string
+  runtimeSinks: string[]
+  providerContext: {
+    infisicalProject: string
+    infisicalPath: string
+    onePasswordVault: string
+  }
+  summary: {
+    total: number
+    ok: number
+    due: number
+    needsBaseline: number
+    approvalRequired: number
+    providerConfirmed: number
+    providerPending: number
+  }
+  bySource: Record<CredentialSourceOfTruth, number>
+  byRisk: Record<string, number>
+  byRuntimeSink: Record<string, number>
+  blockers: string[]
+  rows: CredentialReportRow[]
+}
+
+export const CREDENTIAL_ENVS: CredentialEnvironment[] = ['dev', 'staging', 'prod']
+
+export function isCredentialEnvironment(value: string): value is CredentialEnvironment {
+  return CREDENTIAL_ENVS.includes(value as CredentialEnvironment)
+}
+
+export function buildCredentialReport(
+  inventory: CredentialInventory,
+  env: CredentialEnvironment,
+  asOfInput: string | Date = new Date()
+): CredentialReport {
+  const asOfDate = asDate(asOfInput)
+  const rows = inventory.secrets
+    .filter((secret) => secret.environments.includes(env))
+    .map((secret) => buildReportRow(secret, env, asOfDate))
+    .sort((a, b) => {
+      const statusOrder = { due: 0, 'needs-baseline': 1, ok: 2 }
+      const statusDelta = statusOrder[a.status] - statusOrder[b.status]
+      if (statusDelta !== 0) return statusDelta
+      return a.envVar.localeCompare(b.envVar)
+    })
+
+  const summary = {
+    total: rows.length,
+    ok: rows.filter((row) => row.status === 'ok').length,
+    due: rows.filter((row) => row.status === 'due').length,
+    needsBaseline: rows.filter((row) => row.status === 'needs-baseline').length,
+    approvalRequired: rows.filter((row) => row.approvalRequired).length,
+    providerConfirmed: rows.filter((row) => row.baselineStatus === 'confirmed').length,
+    providerPending: rows.filter((row) => row.baselineStatus !== 'confirmed').length,
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    env,
+    asOf: dateOnly(asOfDate),
+    sourceBoundary: inventory.policy.sourceOfTruth,
+    runtimeSinks: inventory.policy.runtimeSinks,
+    providerContext: {
+      infisicalProject: inventory.providers.infisical.projectSlug,
+      infisicalPath: inventory.providers.infisical.secretPath,
+      onePasswordVault: inventory.providers.onepassword.vaults[env],
+    },
+    summary,
+    bySource: countBy(rows, (row) => row.sourceOfTruth),
+    byRisk: countBy(rows, (row) => row.risk),
+    byRuntimeSink: countRuntimeSinks(rows),
+    blockers: buildBlockers(summary, env),
+    rows,
+  }
+}
+
+export function renderCredentialReportMarkdown(report: CredentialReport): string {
+  const lines = [
+    `# Credential Rotation Visibility (${report.env})`,
+    '',
+    `Generated: ${report.generatedAt}`,
+    `As of: ${report.asOf}`,
+    '',
+    '## Summary',
+    '',
+    `- Total tracked secrets: ${report.summary.total}`,
+    `- OK: ${report.summary.ok}`,
+    `- Due: ${report.summary.due}`,
+    `- Missing provider-confirmed baseline: ${report.summary.needsBaseline}`,
+    `- Approval-gated in this environment: ${report.summary.approvalRequired}`,
+    '',
+    '## Provider Context',
+    '',
+    `- Infisical project/path: ${report.providerContext.infisicalProject}:${report.providerContext.infisicalPath}`,
+    `- 1Password vault: ${report.providerContext.onePasswordVault}`,
+    `- Source boundary: ${report.sourceBoundary}`,
+    '',
+    '## Blockers',
+    '',
+    ...(report.blockers.length > 0 ? report.blockers.map((blocker) => `- ${blocker}`) : ['- None']),
+    '',
+    '## Secrets',
+    '',
+    '| Status | Env Var | Source | Risk | Due | Baseline | Next action |',
+    '| --- | --- | --- | --- | --- | --- | --- |',
+    ...report.rows.map((row) => [
+      row.status,
+      row.envVar,
+      row.sourceOfTruth,
+      row.risk,
+      row.dueAt ?? 'unknown',
+      row.baselineStatus,
+      row.nextAction,
+    ].map(escapeTableCell).join(' | ')).map((line) => `| ${line} |`),
+    '',
+  ]
+
+  return `${lines.join('\n')}\n`
+}
+
+function buildReportRow(secret: CredentialSecret, env: CredentialEnvironment, asOfDate: Date): CredentialReportRow {
+  const baseline = getBaseline(secret, env)
+  const lastRotatedAt = baseline.lastRotatedAt
+  const dueDate = lastRotatedAt ? addDays(new Date(lastRotatedAt), secret.rotationCadenceDays) : null
+  const daysUntilDue = dueDate ? Math.ceil((dueDate.getTime() - asOfDate.getTime()) / 86_400_000) : null
+  const status = !lastRotatedAt ? 'needs-baseline' : dueDate && dueDate <= asOfDate ? 'due' : 'ok'
+
+  return {
+    id: secret.id,
+    envVar: secret.envVar,
+    displayName: secret.displayName,
+    category: secret.category,
+    risk: secret.risk,
+    sourceOfTruth: secret.sourceOfTruth,
+    rotationMode: secret.rotationMode,
+    cadenceDays: secret.rotationCadenceDays,
+    runtimeSinks: secret.runtimeSinks,
+    approvalRequired: secret.approvalRequired?.includes(env) ?? false,
+    baselineStatus: baseline.status,
+    baselineEvidence: baseline.evidence,
+    lastRotatedAt,
+    dueAt: dueDate ? dateOnly(dueDate) : null,
+    daysUntilDue,
+    status,
+    nextAction: nextAction(status, baseline.status, secret.approvalRequired?.includes(env) ?? false),
+  }
+}
+
+function getBaseline(secret: CredentialSecret, env: CredentialEnvironment): CredentialBaseline {
+  const explicit = secret.baseline?.[env]
+  if (explicit) return explicit
+  return {
+    status: secret.lastRotatedAt?.[env] ? 'confirmed' : 'unknown',
+    lastRotatedAt: secret.lastRotatedAt?.[env] ?? null,
+    evidence: secret.lastRotatedAt?.[env] ? 'legacy lastRotatedAt field' : 'baseline not recorded',
+    updatedAt: 'unknown',
+  }
+}
+
+function nextAction(status: CredentialReportRow['status'], baselineStatus: CredentialBaselineStatus, approvalRequired: boolean): string {
+  if (status === 'needs-baseline') return 'Confirm provider history and record lastRotatedAt evidence.'
+  if (approvalRequired) return 'Prepare approval packet before rotation or revocation.'
+  if (status === 'due') return 'Run staged rotation packet and smoke checks.'
+  if (baselineStatus !== 'confirmed') return 'Upgrade baseline evidence to provider-confirmed.'
+  return 'No action needed.'
+}
+
+function buildBlockers(summary: CredentialReport['summary'], env: CredentialEnvironment): string[] {
+  const blockers: string[] = []
+  if (summary.needsBaseline > 0) blockers.push(`${summary.needsBaseline} ${env} secrets need provider-confirmed rotation baselines.`)
+  if (summary.due > 0) blockers.push(`${summary.due} ${env} secrets are due for rotation.`)
+  if (env === 'prod' && summary.approvalRequired > 0) blockers.push('Production rotation or revocation requires an approval packet.')
+  return blockers
+}
+
+function countBy<T extends string>(rows: CredentialReportRow[], key: (row: CredentialReportRow) => T): Record<T, number> {
+  return rows.reduce((acc, row) => {
+    const value = key(row)
+    acc[value] = (acc[value] ?? 0) + 1
+    return acc
+  }, {} as Record<T, number>)
+}
+
+function countRuntimeSinks(rows: CredentialReportRow[]): Record<string, number> {
+  const counts: Record<string, number> = {}
+  for (const row of rows) {
+    for (const sink of row.runtimeSinks) counts[sink] = (counts[sink] ?? 0) + 1
+  }
+  return counts
+}
+
+function asDate(value: string | Date): Date {
+  const date = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(date.getTime())) throw new Error(`Invalid report date: ${String(value)}`)
+  return date
+}
+
+function addDays(date: Date, days: number): Date {
+  const copy = new Date(date)
+  copy.setUTCDate(copy.getUTCDate() + days)
+  return copy
+}
+
+function dateOnly(date: Date): string {
+  return date.toISOString().slice(0, 10)
+}
+
+function escapeTableCell(value: string): string {
+  return value.replace(/\|/g, '\\|')
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "n8n:drift-check": "tsx scripts/n8n-workflow-drift-check.ts",
     "n8n:drift-check:warn": "tsx scripts/n8n-workflow-drift-check.ts -- --warn",
     "credentials:list-due": "tsx scripts/credential-broker.ts list-due",
+    "credentials:report": "tsx scripts/credential-broker.ts report",
     "credentials:inject": "tsx scripts/credential-broker.ts inject",
     "credentials:rotate": "tsx scripts/credential-broker.ts rotate",
     "credentials:sync-runtime": "tsx scripts/credential-broker.ts sync-runtime",

--- a/scripts/credential-broker.ts
+++ b/scripts/credential-broker.ts
@@ -3,6 +3,7 @@ import { spawnSync } from 'node:child_process'
 import { createHash, randomBytes } from 'node:crypto'
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import * as path from 'node:path'
+import { buildCredentialReport, renderCredentialReportMarkdown } from '../lib/credential-report'
 
 type EnvironmentName = 'dev' | 'staging' | 'prod'
 type SourceOfTruth = 'infisical' | '1password'
@@ -92,6 +93,9 @@ function main() {
   switch (args.command) {
     case 'list-due':
       listDue(inventory, args)
+      break
+    case 'report':
+      report(inventory, args)
       break
     case 'inject':
       inject(inventory, args)
@@ -195,6 +199,19 @@ function listDue(inventory: CredentialInventory, args: ParsedArgs) {
     const due = row.dueAt ? ` due=${row.dueAt}` : ' due=unknown'
     console.log(`${row.status.padEnd(14)} ${row.envVar.padEnd(32)} ${row.rotationMode}${due} baseline=${row.baselineStatus}${approval}`)
   }
+}
+
+function report(inventory: CredentialInventory, args: ParsedArgs) {
+  const env = getEnv(args)
+  const asOf = String(args.options['as-of'] || new Date().toISOString())
+  const credentialReport = buildCredentialReport(inventory, env, asOf)
+
+  if (args.options.json) {
+    console.log(JSON.stringify(credentialReport, null, 2))
+    return
+  }
+
+  console.log(renderCredentialReportMarkdown(credentialReport))
 }
 
 function inject(inventory: CredentialInventory, args: ParsedArgs) {
@@ -510,6 +527,7 @@ function printHelp() {
 
 Commands:
   list-due      --env <dev|staging|prod> [--as-of YYYY-MM-DD] [--json]
+  report        --env <dev|staging|prod> [--as-of YYYY-MM-DD] [--json]
   inject        --env <dev|staging|prod> [--secret id-or-envVar[,..]] -- <command>
   rotate        --env <dev|staging|prod> --secret <id-or-envVar> [--local-env .env.staging] [--length 48]
   sync-runtime  --env <dev|staging|prod> --secret <id-or-envVar> [--local-env .env.staging]


### PR DESCRIPTION
## Summary
- add a read-only credential reporting module that summarizes rotation status without loading or printing secret values
- add `credentials:report` CLI output in markdown and JSON
- add admin-only `/api/admin/credentials/report` plus direct `/admin/credentials` visibility surface
- document the reporting command and admin surface
- add coverage for the report builder, admin API, and admin page environment switching

## Validation
- `npm run build:knowledge`
- `npx tsc --noEmit --pretty false --skipLibCheck`
- `npx vitest run lib/credential-report.test.ts app/api/admin/credentials/report/route.test.ts app/admin/credentials/page.test.tsx --reporter=dot`
- `npm run lint -- --file app/admin/credentials/page.tsx --file app/admin/credentials/page.test.tsx --file app/api/admin/credentials/report/route.ts --file app/api/admin/credentials/report/route.test.ts --file lib/credential-report.ts --file lib/credential-report.test.ts --file scripts/credential-broker.ts`
- `npx tsx scripts/credential-broker.ts report --env staging --json`

## Scope / overlap
- Owned scope: credential docs, broker/reporting scripts, credential admin/report surface
- Avoided shared nav and Agent Ops files
- Overlap rating: low