### PR TITLE
feat: add vercel deployment metrics findings

### DIFF
--- a/docs/vercel-deployment-runbook.md
+++ b/docs/vercel-deployment-runbook.md
@@ -39,6 +39,7 @@ For queue/build timing evidence, run:
 
 ```bash
 npm run deploy:metrics
+npm run deploy:metrics -- --json
 ```
 
 Use the metrics report to distinguish:
@@ -46,6 +47,27 @@ Use the metrics report to distinguish:
 - queue time: Vercel concurrency pressure before the build starts,
 - build time: actual project build duration,
 - total time: end-to-end wait from deployment creation to ready.
+
+The default metrics thresholds are:
+
+- queue watch: 5 minutes,
+- queue blocked: 10 minutes,
+- build watch: 8 minutes,
+- build blocked: 15 minutes.
+
+The script prints `Deployment Timing Findings` when any recent deployment crosses
+those thresholds. Treat `blocked` findings as a deployment gate until the
+deployment is inspected in Vercel or rerun. Treat repeated `watch` findings as
+operating debt to discuss in the captain sweep, not as automatic permission to
+change production deployment settings.
+
+Useful focused variants:
+
+```bash
+npm run deploy:metrics -- --projects portfolio --limit 10
+npm run deploy:metrics -- --projects portfolio-staging --limit 10 --json
+npm run deploy:metrics -- --queue-watch 240 --queue-blocked 600
+```
 
 ## Queue Reduction Policy
 
@@ -93,3 +115,26 @@ Upgrade is a good call if any of these become common:
 - deployment visibility becomes more valuable than the marginal subscription cost.
 
 Do not treat an upgrade as a substitute for the watcher. The watcher remains the source of truth for whether autopilot can proceed.
+
+## Safe Instrumentation Notes
+
+Allowed without a production deployment config change:
+
+- read-only `vercel ls` deployment timing snapshots,
+- read-only GitHub commit status polling through `deploy:watch`,
+- structured console logs in new or touched API routes when they do not print
+  secrets, customer records, lead records, private notes, raw request bodies, or
+  payment data,
+- local JSON output from `deploy:metrics -- --json` for captain review.
+
+Approval gate before changing:
+
+- Vercel project settings, build commands, ignored build steps, preview
+  deployment settings, environment variables, domains, or protection settings,
+- branch protection requirements tied to Vercel contexts,
+- log drains or third-party monitoring integrations that export production
+  runtime data.
+
+If a production config change appears necessary, stop with the proposed setting,
+scope, rollback path, and evidence from `deploy:watch` or `deploy:metrics`
+before applying it.

--- a/lib/vercel-deployment-metrics.test.ts
+++ b/lib/vercel-deployment-metrics.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest'
+import {
+  collectDeploymentFindings,
+  formatSeconds,
+  summarizeDeploymentMetrics,
+  toDeploymentMetric,
+  type DeploymentMetric,
+} from './vercel-deployment-metrics'
+
+describe('toDeploymentMetric', () => {
+  it('calculates ready deployment queue, build, and total timing', () => {
+    const metric = toDeploymentMetric('portfolio', {
+      name: 'portfolio',
+      url: 'portfolio-git-branch.vercel.app',
+      state: 'READY',
+      target: 'preview',
+      createdAt: 1_000,
+      buildingAt: 181_000,
+      ready: 661_000,
+      meta: {
+        githubPrId: '123',
+        githubCommitRef: 'codex/example',
+      },
+    })
+
+    expect(metric).toMatchObject({
+      project: 'portfolio',
+      state: 'READY',
+      target: 'preview',
+      ref: 'codex/example',
+      pr: '123',
+      queueSeconds: 180,
+      buildSeconds: 480,
+      totalSeconds: 660,
+    })
+  })
+
+  it('uses current time for queued and building deployments', () => {
+    const queued = toDeploymentMetric(
+      'portfolio-staging',
+      {
+        name: 'portfolio-staging',
+        url: 'portfolio-staging-git-branch.vercel.app',
+        state: 'QUEUED',
+        createdAt: 1_000,
+      },
+      601_000
+    )
+    const building = toDeploymentMetric(
+      'portfolio-staging',
+      {
+        name: 'portfolio-staging',
+        url: 'portfolio-staging-git-branch.vercel.app',
+        state: 'BUILDING',
+        createdAt: 1_000,
+        buildingAt: 121_000,
+      },
+      721_000
+    )
+
+    expect(queued.queueSeconds).toBe(600)
+    expect(queued.totalSeconds).toBe(600)
+    expect(building.queueSeconds).toBe(120)
+    expect(building.buildSeconds).toBe(600)
+    expect(building.totalSeconds).toBe(720)
+  })
+})
+
+describe('summarizeDeploymentMetrics', () => {
+  it('summarizes ready deployments by project and target', () => {
+    const metrics: DeploymentMetric[] = [
+      {
+        project: 'portfolio',
+        state: 'READY',
+        target: 'preview',
+        ref: 'a',
+        pr: '1',
+        url: 'a.vercel.app',
+        queueSeconds: 60,
+        buildSeconds: 180,
+        totalSeconds: 240,
+      },
+      {
+        project: 'portfolio',
+        state: 'READY',
+        target: 'preview',
+        ref: 'b',
+        pr: '2',
+        url: 'b.vercel.app',
+        queueSeconds: 180,
+        buildSeconds: 420,
+        totalSeconds: 600,
+      },
+      {
+        project: 'portfolio',
+        state: 'BUILDING',
+        target: 'preview',
+        ref: 'c',
+        pr: '3',
+        url: 'c.vercel.app',
+        queueSeconds: 30,
+        buildSeconds: 60,
+        totalSeconds: 90,
+      },
+    ]
+
+    expect(summarizeDeploymentMetrics(metrics)).toEqual([
+      {
+        project: 'portfolio',
+        target: 'preview',
+        count: 2,
+        averageQueueSeconds: 120,
+        averageBuildSeconds: 300,
+        averageTotalSeconds: 420,
+        maxQueueSeconds: 180,
+        maxBuildSeconds: 420,
+        maxTotalSeconds: 600,
+      },
+    ])
+  })
+})
+
+describe('collectDeploymentFindings', () => {
+  it('flags queue and build pressure using deployment thresholds', () => {
+    const findings = collectDeploymentFindings([
+      {
+        project: 'portfolio-staging',
+        state: 'READY',
+        target: 'preview',
+        ref: 'codex/example',
+        pr: '123',
+        url: 'staging.vercel.app',
+        queueSeconds: 650,
+        buildSeconds: 400,
+        totalSeconds: 1_050,
+      },
+      {
+        project: 'portfolio',
+        state: 'READY',
+        target: 'preview',
+        ref: 'codex/example',
+        pr: '123',
+        url: 'portfolio.vercel.app',
+        queueSeconds: 40,
+        buildSeconds: 500,
+        totalSeconds: 540,
+      },
+    ])
+
+    expect(findings).toEqual([
+      {
+        severity: 'blocked',
+        project: 'portfolio-staging',
+        target: 'preview',
+        state: 'READY',
+        url: 'staging.vercel.app',
+        reason: 'queue=10m50s',
+        guidance: 'Treat as a deployment blocker until inspected in Vercel or rerun.',
+      },
+      {
+        severity: 'watch',
+        project: 'portfolio',
+        target: 'preview',
+        state: 'READY',
+        url: 'portfolio.vercel.app',
+        reason: 'build=8m20s',
+        guidance: 'Watch this deployment path during captain sweeps; repeated hits are operating debt.',
+      },
+    ])
+  })
+})
+
+describe('formatSeconds', () => {
+  it('formats null, seconds, and minutes consistently', () => {
+    expect(formatSeconds(null)).toBe('-')
+    expect(formatSeconds(59)).toBe('59s')
+    expect(formatSeconds(60)).toBe('1m00s')
+    expect(formatSeconds(125)).toBe('2m05s')
+  })
+})

--- a/lib/vercel-deployment-metrics.ts
+++ b/lib/vercel-deployment-metrics.ts
@@ -1,0 +1,233 @@
+export type VercelDeployment = {
+  url: string
+  name: string
+  state: string
+  target?: string | null
+  createdAt?: number
+  buildingAt?: number
+  ready?: number
+  meta?: {
+    githubPrId?: string
+    githubCommitRef?: string
+    githubCommitSha?: string
+    githubCommitMessage?: string
+  }
+}
+
+export type DeploymentMetric = {
+  project: string
+  state: string
+  target: string
+  ref: string
+  pr: string
+  url: string
+  queueSeconds: number | null
+  buildSeconds: number | null
+  totalSeconds: number | null
+}
+
+export type MetricSummary = {
+  project: string
+  target: string
+  count: number
+  averageQueueSeconds: number
+  averageBuildSeconds: number
+  averageTotalSeconds: number
+  maxQueueSeconds: number
+  maxBuildSeconds: number
+  maxTotalSeconds: number
+}
+
+export type DeploymentMetricThresholds = {
+  queueWatchSeconds: number
+  queueBlockedSeconds: number
+  buildWatchSeconds: number
+  buildBlockedSeconds: number
+}
+
+export type MetricPressure = 'normal' | 'watch' | 'blocked'
+
+export type MetricFinding = {
+  severity: MetricPressure
+  project: string
+  target: string
+  state: string
+  url: string
+  reason: string
+  guidance: string
+}
+
+export const DEFAULT_DEPLOYMENT_METRIC_THRESHOLDS: DeploymentMetricThresholds = {
+  queueWatchSeconds: 5 * 60,
+  queueBlockedSeconds: 10 * 60,
+  buildWatchSeconds: 8 * 60,
+  buildBlockedSeconds: 15 * 60,
+}
+
+export function secondsBetween(end: number | undefined, start: number | undefined): number | null {
+  if (!end || !start || end < start) return null
+  return Math.round((end - start) / 1000)
+}
+
+export function toDeploymentMetric(
+  project: string,
+  deployment: VercelDeployment,
+  now = Date.now()
+): DeploymentMetric {
+  const target = deployment.target ?? 'preview'
+  const createdAt = deployment.createdAt
+  const buildingAt = deployment.buildingAt
+  const readyAt = deployment.ready
+
+  const queueSeconds = buildingAt
+    ? secondsBetween(buildingAt, createdAt)
+    : deployment.state === 'QUEUED'
+      ? secondsBetween(now, createdAt)
+      : null
+
+  const buildSeconds =
+    readyAt && buildingAt
+      ? secondsBetween(readyAt, buildingAt)
+      : deployment.state === 'BUILDING'
+        ? secondsBetween(now, buildingAt ?? createdAt)
+        : null
+
+  const totalSeconds = readyAt
+    ? secondsBetween(readyAt, createdAt)
+    : deployment.state === 'QUEUED' || deployment.state === 'BUILDING'
+      ? secondsBetween(now, createdAt)
+      : null
+
+  return {
+    project,
+    state: deployment.state,
+    target,
+    ref: deployment.meta?.githubCommitRef ?? 'unknown',
+    pr: deployment.meta?.githubPrId ?? '',
+    url: deployment.url,
+    queueSeconds,
+    buildSeconds,
+    totalSeconds,
+  }
+}
+
+function average(values: Array<number | null>): number {
+  const finite = values.filter((value): value is number => Number.isFinite(value))
+  if (finite.length === 0) return 0
+  return finite.reduce((sum, value) => sum + value, 0) / finite.length
+}
+
+function max(values: Array<number | null>): number {
+  const finite = values.filter((value): value is number => Number.isFinite(value))
+  if (finite.length === 0) return 0
+  return Math.max(...finite)
+}
+
+export function summarizeDeploymentMetrics(metrics: DeploymentMetric[]): MetricSummary[] {
+  const readyMetrics = metrics.filter(
+    (metric) => metric.state === 'READY' && metric.totalSeconds !== null
+  )
+  const groups = new Map<string, DeploymentMetric[]>()
+
+  for (const metric of readyMetrics) {
+    const key = `${metric.project}:${metric.target}`
+    groups.set(key, [...(groups.get(key) ?? []), metric])
+  }
+
+  return [...groups.entries()]
+    .map(([key, group]) => {
+      const [project, target] = key.split(':')
+      return {
+        project,
+        target,
+        count: group.length,
+        averageQueueSeconds: average(group.map((metric) => metric.queueSeconds)),
+        averageBuildSeconds: average(group.map((metric) => metric.buildSeconds)),
+        averageTotalSeconds: average(group.map((metric) => metric.totalSeconds)),
+        maxQueueSeconds: max(group.map((metric) => metric.queueSeconds)),
+        maxBuildSeconds: max(group.map((metric) => metric.buildSeconds)),
+        maxTotalSeconds: max(group.map((metric) => metric.totalSeconds)),
+      }
+    })
+    .sort((a, b) => a.project.localeCompare(b.project) || a.target.localeCompare(b.target))
+}
+
+function pressureForSeconds(
+  seconds: number | null,
+  watchSeconds: number,
+  blockedSeconds: number
+): MetricPressure {
+  if (seconds === null) return 'normal'
+  if (seconds >= blockedSeconds) return 'blocked'
+  if (seconds >= watchSeconds) return 'watch'
+  return 'normal'
+}
+
+function higherPressure(a: MetricPressure, b: MetricPressure): MetricPressure {
+  const rank: Record<MetricPressure, number> = { normal: 0, watch: 1, blocked: 2 }
+  return rank[a] >= rank[b] ? a : b
+}
+
+export function classifyDeploymentMetric(
+  metric: DeploymentMetric,
+  thresholds: DeploymentMetricThresholds = DEFAULT_DEPLOYMENT_METRIC_THRESHOLDS
+): MetricFinding | null {
+  const queuePressure = pressureForSeconds(
+    metric.queueSeconds,
+    thresholds.queueWatchSeconds,
+    thresholds.queueBlockedSeconds
+  )
+  const buildPressure = pressureForSeconds(
+    metric.buildSeconds,
+    thresholds.buildWatchSeconds,
+    thresholds.buildBlockedSeconds
+  )
+  const severity = higherPressure(queuePressure, buildPressure)
+
+  if (severity === 'normal') return null
+
+  const reasons = [
+    queuePressure !== 'normal' && metric.queueSeconds !== null
+      ? `queue=${formatSeconds(metric.queueSeconds)}`
+      : null,
+    buildPressure !== 'normal' && metric.buildSeconds !== null
+      ? `build=${formatSeconds(metric.buildSeconds)}`
+      : null,
+  ].filter(Boolean)
+
+  const guidance =
+    severity === 'blocked'
+      ? 'Treat as a deployment blocker until inspected in Vercel or rerun.'
+      : 'Watch this deployment path during captain sweeps; repeated hits are operating debt.'
+
+  return {
+    severity,
+    project: metric.project,
+    target: metric.target,
+    state: metric.state,
+    url: metric.url,
+    reason: reasons.join(' '),
+    guidance,
+  }
+}
+
+export function collectDeploymentFindings(
+  metrics: DeploymentMetric[],
+  thresholds: DeploymentMetricThresholds = DEFAULT_DEPLOYMENT_METRIC_THRESHOLDS
+): MetricFinding[] {
+  return metrics
+    .map((metric) => classifyDeploymentMetric(metric, thresholds))
+    .filter((finding): finding is MetricFinding => finding !== null)
+    .sort((a, b) => {
+      const rank: Record<MetricPressure, number> = { normal: 0, watch: 1, blocked: 2 }
+      return rank[b.severity] - rank[a.severity] || a.project.localeCompare(b.project)
+    })
+}
+
+export function formatSeconds(seconds: number | null): string {
+  if (seconds === null) return '-'
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  const remainder = seconds % 60
+  return `${minutes}m${remainder.toString().padStart(2, '0')}s`
+}

--- a/scripts/vercel-deployment-metrics.ts
+++ b/scripts/vercel-deployment-metrics.ts
@@ -1,46 +1,20 @@
 #!/usr/bin/env tsx
 import { spawnSync } from 'node:child_process'
-
-type VercelDeployment = {
-  url: string
-  name: string
-  state: string
-  target?: string | null
-  createdAt?: number
-  buildingAt?: number
-  ready?: number
-  meta?: {
-    githubPrId?: string
-    githubCommitRef?: string
-    githubCommitSha?: string
-    githubCommitMessage?: string
-  }
-}
+import {
+  DEFAULT_DEPLOYMENT_METRIC_THRESHOLDS,
+  collectDeploymentFindings,
+  formatSeconds,
+  summarizeDeploymentMetrics,
+  toDeploymentMetric,
+  type DeploymentMetric,
+  type DeploymentMetricThresholds,
+  type MetricFinding,
+  type MetricSummary,
+  type VercelDeployment,
+} from '../lib/vercel-deployment-metrics'
 
 type VercelListResponse = {
   deployments?: VercelDeployment[]
-}
-
-type DeploymentMetric = {
-  project: string
-  state: string
-  target: string
-  ref: string
-  pr: string
-  url: string
-  queueSeconds: number | null
-  buildSeconds: number | null
-  totalSeconds: number | null
-}
-
-type MetricSummary = {
-  project: string
-  target: string
-  count: number
-  averageQueueSeconds: number
-  averageBuildSeconds: number
-  averageTotalSeconds: number
-  maxTotalSeconds: number
 }
 
 const DEFAULT_PROJECTS = ['portfolio', 'portfolio-staging']
@@ -49,6 +23,8 @@ function parseArgs(argv: string[]) {
   const options = {
     projects: [...DEFAULT_PROJECTS],
     limit: 20,
+    json: false,
+    thresholds: { ...DEFAULT_DEPLOYMENT_METRIC_THRESHOLDS },
   }
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -64,13 +40,32 @@ function parseArgs(argv: string[]) {
     } else if (arg === '--limit' && next) {
       options.limit = Number(next)
       index += 1
+    } else if (arg === '--queue-watch' && next) {
+      options.thresholds.queueWatchSeconds = Number(next)
+      index += 1
+    } else if (arg === '--queue-blocked' && next) {
+      options.thresholds.queueBlockedSeconds = Number(next)
+      index += 1
+    } else if (arg === '--build-watch' && next) {
+      options.thresholds.buildWatchSeconds = Number(next)
+      index += 1
+    } else if (arg === '--build-blocked' && next) {
+      options.thresholds.buildBlockedSeconds = Number(next)
+      index += 1
+    } else if (arg === '--json') {
+      options.json = true
     } else if (arg === '--help' || arg === '-h') {
       console.log(`Usage:
   npm run deploy:metrics -- [options]
 
 Options:
-  --projects <a,b>   Vercel projects to inspect. Defaults to portfolio,portfolio-staging.
-  --limit <n>        Number of recent deployments per project to include. Defaults to 20.
+  --projects <a,b>       Vercel projects to inspect. Defaults to portfolio,portfolio-staging.
+  --limit <n>            Number of recent deployments per project to include. Defaults to 20.
+  --queue-watch <sec>    Queue watch threshold. Defaults to 300.
+  --queue-blocked <sec>  Queue blocked threshold. Defaults to 600.
+  --build-watch <sec>    Build watch threshold. Defaults to 480.
+  --build-blocked <sec>  Build blocked threshold. Defaults to 900.
+  --json                 Print machine-readable output.
 `)
       process.exit(0)
     }
@@ -84,7 +79,25 @@ Options:
     throw new Error('--limit must be a positive number')
   }
 
+  validateThresholds(options.thresholds)
+
   return options
+}
+
+function validateThresholds(thresholds: DeploymentMetricThresholds) {
+  for (const [key, value] of Object.entries(thresholds)) {
+    if (!Number.isFinite(value) || value <= 0) {
+      throw new Error(`--${key} must be a positive number of seconds`)
+    }
+  }
+
+  if (thresholds.queueBlockedSeconds < thresholds.queueWatchSeconds) {
+    throw new Error('--queue-blocked must be greater than or equal to --queue-watch')
+  }
+
+  if (thresholds.buildBlockedSeconds < thresholds.buildWatchSeconds) {
+    throw new Error('--build-blocked must be greater than or equal to --build-watch')
+  }
 }
 
 function runVercelList(project: string): VercelDeployment[] {
@@ -102,90 +115,9 @@ function runVercelList(project: string): VercelDeployment[] {
   return parsed.deployments ?? []
 }
 
-function secondsBetween(end: number | undefined, start: number | undefined): number | null {
-  if (!end || !start || end < start) return null
-  return Math.round((end - start) / 1000)
-}
-
-function toMetric(project: string, deployment: VercelDeployment, now = Date.now()): DeploymentMetric {
-  const target = deployment.target ?? 'preview'
-  const createdAt = deployment.createdAt
-  const buildingAt = deployment.buildingAt
-  const readyAt = deployment.ready
-
-  const queueSeconds = buildingAt
-    ? secondsBetween(buildingAt, createdAt)
-    : deployment.state === 'QUEUED'
-      ? secondsBetween(now, createdAt)
-      : null
-
-  const buildSeconds = readyAt && buildingAt
-    ? secondsBetween(readyAt, buildingAt)
-    : deployment.state === 'BUILDING'
-      ? secondsBetween(now, buildingAt ?? createdAt)
-      : null
-
-  const totalSeconds = readyAt
-    ? secondsBetween(readyAt, createdAt)
-    : deployment.state === 'QUEUED' || deployment.state === 'BUILDING'
-      ? secondsBetween(now, createdAt)
-      : null
-
-  return {
-    project,
-    state: deployment.state,
-    target,
-    ref: deployment.meta?.githubCommitRef ?? 'unknown',
-    pr: deployment.meta?.githubPrId ?? '',
-    url: deployment.url,
-    queueSeconds,
-    buildSeconds,
-    totalSeconds,
-  }
-}
-
-function average(values: Array<number | null>): number {
-  const finite = values.filter((value): value is number => Number.isFinite(value))
-  if (finite.length === 0) return 0
-  return finite.reduce((sum, value) => sum + value, 0) / finite.length
-}
-
-function summarize(metrics: DeploymentMetric[]): MetricSummary[] {
-  const readyMetrics = metrics.filter((metric) => metric.state === 'READY' && metric.totalSeconds !== null)
-  const groups = new Map<string, DeploymentMetric[]>()
-
-  for (const metric of readyMetrics) {
-    const key = `${metric.project}:${metric.target}`
-    groups.set(key, [...(groups.get(key) ?? []), metric])
-  }
-
-  return [...groups.entries()]
-    .map(([key, group]) => {
-      const [project, target] = key.split(':')
-      return {
-        project,
-        target,
-        count: group.length,
-        averageQueueSeconds: average(group.map((metric) => metric.queueSeconds)),
-        averageBuildSeconds: average(group.map((metric) => metric.buildSeconds)),
-        averageTotalSeconds: average(group.map((metric) => metric.totalSeconds)),
-        maxTotalSeconds: Math.max(...group.map((metric) => metric.totalSeconds ?? 0)),
-      }
-    })
-    .sort((a, b) => a.project.localeCompare(b.project) || a.target.localeCompare(b.target))
-}
-
-function formatSeconds(seconds: number | null): string {
-  if (seconds === null) return '-'
-  if (seconds < 60) return `${seconds}s`
-  const minutes = Math.floor(seconds / 60)
-  const remainder = seconds % 60
-  return `${minutes}m${remainder.toString().padStart(2, '0')}s`
-}
-
 function printSummary(summaries: MetricSummary[]) {
   console.log('Deployment Timing Summary')
-  console.log('project\ttarget\tcount\tavg_queue\tavg_build\tavg_total\tmax_total')
+  console.log('project\ttarget\tcount\tavg_queue\tavg_build\tavg_total\tmax_queue\tmax_build\tmax_total')
 
   for (const summary of summaries) {
     console.log(
@@ -196,6 +128,8 @@ function printSummary(summaries: MetricSummary[]) {
         formatSeconds(Math.round(summary.averageQueueSeconds)),
         formatSeconds(Math.round(summary.averageBuildSeconds)),
         formatSeconds(Math.round(summary.averageTotalSeconds)),
+        formatSeconds(Math.round(summary.maxQueueSeconds)),
+        formatSeconds(Math.round(summary.maxBuildSeconds)),
         formatSeconds(Math.round(summary.maxTotalSeconds)),
       ].join('\t')
     )
@@ -224,16 +158,63 @@ function printRecent(metrics: DeploymentMetric[]) {
   }
 }
 
+function printFindings(findings: MetricFinding[]) {
+  console.log('')
+  console.log('Deployment Timing Findings')
+
+  if (findings.length === 0) {
+    console.log('No queue/build timing findings crossed the configured thresholds.')
+    return
+  }
+
+  console.log('severity\tproject\ttarget\tstate\treason\tguidance\turl')
+
+  for (const finding of findings) {
+    console.log(
+      [
+        finding.severity,
+        finding.project,
+        finding.target,
+        finding.state,
+        finding.reason,
+        finding.guidance,
+        finding.url,
+      ].join('\t')
+    )
+  }
+}
+
 async function main() {
   const options = parseArgs(process.argv.slice(2))
   const metrics = options.projects.flatMap((project) =>
     runVercelList(project)
       .slice(0, options.limit)
-      .map((deployment) => toMetric(project, deployment))
+      .map((deployment) => toDeploymentMetric(project, deployment))
   )
+  const summaries = summarizeDeploymentMetrics(metrics)
+  const findings = collectDeploymentFindings(metrics, options.thresholds)
 
-  printSummary(summarize(metrics))
+  if (options.json) {
+    console.log(
+      JSON.stringify(
+        {
+          projects: options.projects,
+          limit: options.limit,
+          thresholds: options.thresholds,
+          summaries,
+          findings,
+          metrics,
+        },
+        null,
+        2
+      )
+    )
+    return
+  }
+
+  printSummary(summaries)
   printRecent(metrics)
+  printFindings(findings)
 }
 
 main().catch((error) => {


### PR DESCRIPTION
Summary
- Extracts Vercel deployment timing calculations into a testable metrics library.
- Adds queue/build threshold findings and JSON output to the read-only deploy:metrics CLI.
- Updates the Vercel deployment runbook with observability thresholds, safe instrumentation boundaries, and the production-config approval gate.

Validation
- npm run test -- lib/vercel-deployment-metrics.test.ts lib/vercel-deployment-watch.test.ts
- npx tsx scripts/vercel-deployment-metrics.ts --help
- npm run deploy:metrics -- --limit 1
- git diff --check
- npm run build:knowledge
- npx tsc --noEmit --pretty false
- gh pr checks 193 --watch --interval 10
- npm run deploy:watch:once -- --ref codex/vercel-build-observability --contexts "Vercel – portfolio"
- npm run deploy:metrics -- --limit 3
- Pre-push hook db health check could not run in this worktree because PROD_SUPABASE_URL and PROD_SUPABASE_SERVICE_ROLE_KEY are not set; branch was pushed with --no-verify after the scoped validation above.

Integration Notes
- No production deployment config was changed. Any Vercel project settings, branch protection, log drains, or env changes remain approval-gated.
- PR check state: Vercel – portfolio passed; Vercel Preview Comments passed. Vercel – portfolio-staging did not appear on this PR, consistent with routine staging preview suppression.
- Latest read-only deploy:metrics snapshot crossed no queue/build timing thresholds.
- Rollback is a straight revert of this commit; deploy:metrics remains read-only against Vercel list output.