### PR TITLE
feat: add memory organization progress tracking

### DIFF
--- a/app/admin/agents/automations/page.tsx
+++ b/app/admin/agents/automations/page.tsx
@@ -22,6 +22,7 @@ import type {
   AutomationCategory,
   AutomationContextHealth,
   AutomationRiskLevel,
+  MemoryOrganizationTaskStatus,
 } from '@/lib/codex-automation-inventory'
 
 type AutomationProfile = {
@@ -81,6 +82,19 @@ type AutomationInventoryResponse = {
     duplicateCandidates: number
     highRisk: number
     missingContext: number
+  }
+  progress: {
+    label: string
+    percent: number
+    completedTasks: number
+    totalTasks: number
+    tasks: {
+      id: string
+      label: string
+      description: string
+      status: MemoryOrganizationTaskStatus
+      progress: number
+    }[]
   }
 }
 
@@ -224,6 +238,8 @@ function AgentAutomationsContent() {
               docWarnings={docWarnings}
             />
 
+            <MemoryOrganizationProgress progress={inventory.progress} />
+
             <div className="mb-6 inline-flex rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-1">
               <button
                 onClick={() => setViewMode('inventory')}
@@ -336,6 +352,56 @@ function AutomationTable({
         </tbody>
       </table>
     </div>
+  )
+}
+
+function MemoryOrganizationProgress({ progress }: { progress: AutomationInventoryResponse['progress'] }) {
+  return (
+    <section className="mb-6 rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-5">
+      <div className="mb-4 flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <div className="flex items-center gap-2 text-radiant-gold">
+            <ListChecks size={18} />
+            <h2 className="font-semibold">{progress.label}</h2>
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {progress.completedTasks} of {progress.totalTasks} workflow tasks complete. This progress is computed from the current read-only inventory.
+          </p>
+        </div>
+        <div className="text-right">
+          <p className="text-2xl font-bold">{progress.percent}%</p>
+          <p className="text-xs uppercase tracking-wider text-muted-foreground">overall readiness</p>
+        </div>
+      </div>
+
+      <div className="mb-5 h-3 overflow-hidden rounded-full bg-black/30">
+        <div
+          className="h-full rounded-full bg-radiant-gold transition-all"
+          style={{ width: `${Math.max(0, Math.min(progress.percent, 100))}%` }}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-3">
+        {progress.tasks.map((task) => (
+          <div key={task.id} className="rounded-lg border border-silicon-slate/60 bg-background/50 p-4">
+            <div className="mb-2 flex items-center justify-between gap-3">
+              <h3 className="text-sm font-semibold">{task.label}</h3>
+              <TaskStatusBadge status={task.status} />
+            </div>
+            <p className="min-h-[40px] text-xs text-muted-foreground">{task.description}</p>
+            <div className="mt-3 flex items-center gap-3">
+              <div className="h-2 flex-1 overflow-hidden rounded-full bg-black/30">
+                <div
+                  className={`h-full rounded-full ${task.status === 'completed' ? 'bg-green-400' : task.status === 'blocked' ? 'bg-red-400' : 'bg-yellow-300'}`}
+                  style={{ width: `${Math.max(0, Math.min(task.progress, 100))}%` }}
+                />
+              </div>
+              <span className="w-10 text-right text-xs text-muted-foreground">{task.progress}%</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
   )
 }
 
@@ -587,6 +653,18 @@ function ContextBadge({ health }: { health: AutomationContextHealth }) {
         ? 'border-yellow-400/40 bg-yellow-500/10 text-yellow-200'
         : 'border-red-400/40 bg-red-500/10 text-red-200'
   return <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs ${className}`}>{icon}{health}</span>
+}
+
+function TaskStatusBadge({ status }: { status: MemoryOrganizationTaskStatus }) {
+  const className =
+    status === 'completed'
+      ? 'border-green-400/40 bg-green-500/10 text-green-200'
+      : status === 'blocked'
+        ? 'border-red-400/40 bg-red-500/10 text-red-200'
+        : status === 'in_progress'
+          ? 'border-yellow-400/40 bg-yellow-500/10 text-yellow-200'
+          : 'border-silicon-slate/60 bg-black/20 text-muted-foreground'
+  return <span className={`rounded-full border px-2 py-1 text-[11px] ${className}`}>{status.replace('_', ' ')}</span>
 }
 
 function DetailPill({ label, value }: { label: string; value: string }) {

--- a/docs/memory-context-organization-workflow.md
+++ b/docs/memory-context-organization-workflow.md
@@ -1,0 +1,83 @@
+# Memory And Context Organization Workflow
+
+This document defines the Portfolio-facing workflow for organizing Codex memory, workspace-root visibility, automation context, and readiness reporting. It is intentionally read-only for local Codex operational state.
+
+## Scope
+
+Owned in this workflow:
+
+- Portfolio Admin automation and context dashboard surfaces.
+- Codex workspace-root visibility for Portfolio-related automations.
+- Memory and context readiness reporting.
+- Workflow docs that help future agents understand what to inspect before acting.
+
+Outside the Portfolio git worktree:
+
+- Direct writes under `~/.codex/memories`.
+- Direct writes under `~/.codex/automations`.
+- SQLite or Codex Desktop state repairs.
+
+Any operational state write outside the repo must be called out before it happens, backed up when appropriate, and reported separately from git changes.
+
+## Dashboard Progress Model
+
+The Automation Context dashboard reports progress from the current read-only inventory. Progress is not a project-management database and does not create or save tasks. It is a computed readiness signal.
+
+Current task series:
+
+1. Automation inventory: local TOML inventory is readable.
+2. Context readiness questions: every visible automation can be evaluated against the seven operating-context questions.
+3. Workspace-root visibility: visible automations declare the Portfolio workspace path in `cwds`.
+4. Governing docs and runbooks: visible automations reference docs, skills, source paths, or runbooks.
+5. Authority boundaries: visible automations state what agents may inspect, recommend, or never do automatically.
+6. Duplicate and overlap review: duplicate automation candidates are flagged for deliberate consolidation or justification.
+7. Memory/context cleanup backlog: context-health status identifies remaining docs, prompts, or runbooks needed before repair work.
+
+## Readiness Questions
+
+Each automation is checked against these questions:
+
+1. What does this automation protect or improve?
+2. What decision does it support?
+3. What does it inspect?
+4. What should it never do automatically?
+5. What should it produce?
+6. What failure should alert Vambah?
+7. What doc, skill, or runbook governs it?
+
+Missing answers should create recommendations only. V1 does not generate final answers or write them back to TOML, memory, skills, or docs.
+
+## Enhancement Impact Preflight
+
+### Enhancement Impact Preflight
+
+- Enhancement: Add a computed next-step task series and progress bar for Portfolio memory/context organization readiness.
+- User-facing surface: `/admin/agents/automations`, under Agent Operations.
+- Predicted files: `app/admin/agents/automations/page.tsx`, `lib/codex-automation-inventory.ts`, `lib/codex-automation-inventory.test.ts`, `docs/memory-context-organization-workflow.md`.
+- Shared routes/APIs/tables/helpers: `lib/codex-automation-inventory.ts` and the existing `/api/admin/agents/automations` response shape; no database tables or mutating APIs.
+- Active PRs or branches checked: `codex/client-ai-ops-roadmap-next` PR 190, `codex/subscription-watch-next` PR 191, `codex/credential-reporting-next` PR 192, `codex/vercel-build-observability` worktree.
+- Dirty worktree files checked: current `codex/memory-organization-next` worktree was clean before implementation.
+- Overlap rating: green.
+- Coordination decision: Proceed in the dedicated memory organization worktree; do not touch Agent Ops, Client AI Ops, credential reporting, subscription watch, or Vercel observability files.
+- Merge-order note: Can merge independently after the integration captain handles active roadmap, credential, subscription, and observability branches; no shared files were identified.
+
+Implementation update: `lib/chief-of-staff-chat.test.ts` also needed a fixture update because it imports the automation inventory contract. This was an intentional shared-helper compatibility fix, not a change to Chief of Staff behavior. The overlap rating remains green against active PRs because no active PR modifies that file or helper.
+
+## Operating Boundary
+
+The dashboard may show that local operational state is missing or incomplete. It should not repair that state by itself.
+
+Allowed:
+
+- Read local automation metadata server-side.
+- Sanitize and summarize prompts.
+- Flag missing workspace roots, missing docs, missing authority boundaries, duplicates, and context gaps.
+- Show progress and task status computed from the inventory.
+
+Not allowed in this workflow without an explicit operational-state step:
+
+- Editing `~/.codex/automations`.
+- Editing `~/.codex/memories`.
+- Updating Codex SQLite thread state.
+- Rewriting Codex Desktop workspace roots.
+- Pausing, deleting, creating, or rescheduling automations.

--- a/lib/chief-of-staff-chat.test.ts
+++ b/lib/chief-of-staff-chat.test.ts
@@ -230,6 +230,21 @@ describe('Chief of Staff chat helpers', () => {
         highRisk: 1,
         missingContext: 1,
       },
+      progress: {
+        label: 'Memory and automation context readiness',
+        percent: 86,
+        completedTasks: 6,
+        totalTasks: 7,
+        tasks: [
+          {
+            id: 'governing-docs',
+            label: 'Governing docs and runbooks',
+            description: 'Map each automation to at least one governing doc, skill, source path, or runbook.',
+            status: 'in_progress',
+            progress: 50,
+          },
+        ],
+      },
       automations: [
         {
           id: 'portfolio-credential-rotation-due-report',

--- a/lib/codex-automation-inventory.test.ts
+++ b/lib/codex-automation-inventory.test.ts
@@ -103,6 +103,16 @@ cwds = ["/Users/vambahsillah"]
     }))
     expect(inventory.automations[0].controlDocs).toContain('docs/portfolio-operations-manager.md')
     expect(inventory.automations[0].contextQuestions.every((question) => question.answered)).toBe(true)
+    expect(inventory.progress.tasks.map((task) => task.id)).toEqual([
+      'inventory',
+      'context-questions',
+      'workspace-roots',
+      'governing-docs',
+      'authority-boundaries',
+      'duplicate-review',
+      'memory-context-cleanup',
+    ])
+    expect(inventory.progress.percent).toBe(100)
   })
 
   it('marks unanswered context-readiness questions without generating answers', async () => {
@@ -130,6 +140,8 @@ cwds = ["/Users/vambahsillah/Projects/Portfolio"]
     ]))
     expect(unanswered.find((question) => question.id === 'boundary')?.answer).toBeNull()
     expect(unanswered.find((question) => question.id === 'boundary')?.recommendation).toContain('authority boundary')
+    expect(inventory.progress.percent).toBeLessThan(100)
+    expect(inventory.progress.tasks.find((task) => task.id === 'memory-context-cleanup')?.status).toBe('pending')
   })
 
   it('flags duplicate credential rotation jobs and sanitizes prompt excerpts', async () => {

--- a/lib/codex-automation-inventory.ts
+++ b/lib/codex-automation-inventory.ts
@@ -24,6 +24,16 @@ export interface CodexAutomationContextQuestion {
   recommendation: string
 }
 
+export type MemoryOrganizationTaskStatus = 'completed' | 'in_progress' | 'pending' | 'blocked'
+
+export interface MemoryOrganizationTask {
+  id: string
+  label: string
+  description: string
+  status: MemoryOrganizationTaskStatus
+  progress: number
+}
+
 export interface CodexAutomationProfile {
   id: string
   name: string
@@ -75,6 +85,13 @@ export interface CodexAutomationInventory {
     duplicateCandidates: number
     highRisk: number
     missingContext: number
+  }
+  progress: {
+    label: string
+    percent: number
+    completedTasks: number
+    totalTasks: number
+    tasks: MemoryOrganizationTask[]
   }
 }
 
@@ -144,6 +161,7 @@ export async function listCodexAutomationInventory(
     automations,
     hiddenCount,
     overview: buildOverview(automations),
+    progress: buildMemoryOrganizationProgress(true, automations),
   }
 }
 
@@ -238,6 +256,7 @@ function unavailableInventory(sourceDirectory: string, generatedAt: string, reas
     automations: [],
     hiddenCount: 0,
     overview: buildOverview([]),
+    progress: buildMemoryOrganizationProgress(false, []),
   }
 }
 
@@ -250,6 +269,86 @@ function buildOverview(automations: CodexAutomationProfile[]) {
     highRisk: automations.filter((automation) => automation.riskLevel === 'high').length,
     missingContext: automations.filter((automation) => automation.contextHealth !== 'green').length,
   }
+}
+
+function buildMemoryOrganizationProgress(available: boolean, automations: CodexAutomationProfile[]) {
+  const total = automations.length
+  const contextReady = automations.filter((automation) => automation.contextHealth === 'green').length
+  const workspaceReady = automations.filter((automation) => automation.cwds.some((cwd) => cwd.includes('/Projects/Portfolio'))).length
+  const docsReady = automations.filter((automation) => automation.controlDocs.length > 0).length
+  const boundaryReady = automations.filter((automation) => !automation.contextGaps.includes('missing authority boundary')).length
+  const duplicatesReady = automations.filter((automation) => !automation.duplicateCandidate).length
+
+  const taskInputs = [
+    {
+      id: 'inventory',
+      label: 'Automation inventory',
+      description: 'Read Portfolio-related Codex automation metadata from the local TOML source of truth.',
+      progress: available ? 100 : 0,
+    },
+    {
+      id: 'context-questions',
+      label: 'Context readiness questions',
+      description: 'Evaluate each visible automation against the seven operating-context questions.',
+      progress: total > 0 ? 100 : 0,
+    },
+    {
+      id: 'workspace-roots',
+      label: 'Workspace-root visibility',
+      description: 'Confirm visible automations declare the Portfolio workspace path in their execution context.',
+      progress: ratioPercent(workspaceReady, total),
+    },
+    {
+      id: 'governing-docs',
+      label: 'Governing docs and runbooks',
+      description: 'Map each automation to at least one governing doc, skill, source path, or runbook.',
+      progress: ratioPercent(docsReady, total),
+    },
+    {
+      id: 'authority-boundaries',
+      label: 'Authority boundaries',
+      description: 'Confirm each automation states what agents may inspect, recommend, or never do automatically.',
+      progress: ratioPercent(boundaryReady, total),
+    },
+    {
+      id: 'duplicate-review',
+      label: 'Duplicate and overlap review',
+      description: 'Flag overlapping automation jobs so the next agent can consolidate or justify them deliberately.',
+      progress: ratioPercent(duplicatesReady, total),
+    },
+    {
+      id: 'memory-context-cleanup',
+      label: 'Memory/context cleanup backlog',
+      description: 'Use context health to identify the remaining docs, prompts, or runbooks needed before automation repair.',
+      progress: ratioPercent(contextReady, total),
+    },
+  ]
+
+  const tasks = taskInputs.map((task): MemoryOrganizationTask => ({
+    ...task,
+    status: classifyTaskStatus(task.progress, available),
+  }))
+  const completedTasks = tasks.filter((task) => task.status === 'completed').length
+
+  return {
+    label: 'Memory and automation context readiness',
+    percent: ratioPercent(tasks.reduce((sum, task) => sum + task.progress, 0), tasks.length * 100),
+    completedTasks,
+    totalTasks: tasks.length,
+    tasks,
+  }
+}
+
+function ratioPercent(done: number, total: number) {
+  if (total <= 0) return 0
+  return Math.round((done / total) * 100)
+}
+
+function classifyTaskStatus(progress: number, available: boolean): MemoryOrganizationTaskStatus {
+  if (!available) return 'blocked'
+  if (progress >= 100) return 'completed'
+  if (progress > 0) return 'in_progress'
+  return 'pending'
 }
 
 function extractControlDocs(prompt: string): string[] {


### PR DESCRIPTION
## Summary

Adds a read-only memory/context organization progress layer to the Portfolio Automation Context dashboard.

- Adds computed workflow tasks and an overall progress bar to `/admin/agents/automations`.
- Extends the Codex automation inventory response with `progress` metadata derived from the local read-only inventory.
- Adds focused tests for the progress model and updates the Chief of Staff fixture for the shared inventory contract.
- Documents the Portfolio-facing memory/context organization workflow and operating boundaries.

## Enhancement Impact Preflight

- Enhancement: Add a computed next-step task series and progress bar for Portfolio memory/context organization readiness.
- User-facing surface: `/admin/agents/automations`, under Agent Operations.
- Predicted files: `app/admin/agents/automations/page.tsx`, `lib/codex-automation-inventory.ts`, `lib/codex-automation-inventory.test.ts`, `docs/memory-context-organization-workflow.md`.
- Shared routes/APIs/tables/helpers: `lib/codex-automation-inventory.ts` and the existing `/api/admin/agents/automations` response shape; no database tables or mutating APIs.
- Active PRs or branches checked: `codex/client-ai-ops-roadmap-next` PR 190, `codex/subscription-watch-next` PR 191, `codex/credential-reporting-next` PR 192, `codex/vercel-build-observability` worktree.
- Dirty worktree files checked: current `codex/memory-organization-next` worktree was clean before implementation.
- Overlap rating: green.
- Coordination decision: Proceeded in the dedicated memory organization worktree only.
- Merge-order note: Can merge independently after integration captain sequencing; no active PR modifies these dashboard/inventory files.

Implementation update: `lib/chief-of-staff-chat.test.ts` also needed a fixture update because it imports the automation inventory contract. This is an intentional shared-helper compatibility fix, not a Chief of Staff behavior change.

## Validation

- `npx vitest run lib/codex-automation-inventory.test.ts app/api/admin/agents/automations/route.test.ts lib/chief-of-staff-chat.test.ts`
- `npx tsc --noEmit`
- `curl http://localhost:3000/admin/agents/automations` returned `200` after sourcing the main checkout `.env.local` into the dev-server process only.
- Real local inventory smoke: 13 visible Portfolio automations, 87% memory/context readiness.

## Operational State

No direct writes were made under `~/.codex/memories` or `~/.codex/automations`.

Read-only local state inspection used `~/.codex/automations` through the dashboard inventory helper. `npm ci` installed ignored local `node_modules` in this worktree so validation could run.
