### PR TITLE
feat: add automation context repair packets

### DIFF
--- a/app/admin/agents/automations/page.tsx
+++ b/app/admin/agents/automations/page.tsx
@@ -21,6 +21,7 @@ import type {
   AutomationBoundary,
   AutomationCategory,
   AutomationContextHealth,
+  CodexAutomationRepairPriority,
   AutomationRiskLevel,
   MemoryOrganizationTaskStatus,
 } from '@/lib/codex-automation-inventory'
@@ -96,6 +97,17 @@ type AutomationInventoryResponse = {
       progress: number
     }[]
   }
+  repairPackets: {
+    automationId: string
+    automationName: string
+    priority: CodexAutomationRepairPriority
+    summary: string
+    missingQuestions: string[]
+    recommendedActions: string[]
+    governingDocCandidates: string[]
+    sourceFile: string
+    operationalBoundary: string
+  }[]
 }
 
 const ALL = 'all'
@@ -104,7 +116,7 @@ const STATUSES = [ALL, 'ACTIVE', 'PAUSED'] as const
 const RISKS = [ALL, 'low', 'medium', 'high'] as const
 const CONTEXT_HEALTH = [ALL, 'green', 'yellow', 'red'] as const
 const EMPTY_AUTOMATIONS: AutomationProfile[] = []
-type ViewMode = 'inventory' | 'context-gaps'
+type ViewMode = 'inventory' | 'context-gaps' | 'repair-packets'
 
 export default function AgentAutomationsPage() {
   return (
@@ -221,13 +233,14 @@ function AgentAutomationsContent() {
           <UnavailableState inventory={inventory} />
         ) : inventory ? (
           <>
-            <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-6 gap-3 mb-6">
+            <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-7 gap-3 mb-6">
               <MetricCard label="Portfolio automations" value={inventory.overview.total} />
               <MetricCard label="Active" value={inventory.overview.active} tone="green" />
               <MetricCard label="Paused" value={inventory.overview.paused} />
               <MetricCard label="Duplicates" value={inventory.overview.duplicateCandidates} tone={inventory.overview.duplicateCandidates ? 'yellow' : 'slate'} />
               <MetricCard label="High risk" value={inventory.overview.highRisk} tone={inventory.overview.highRisk ? 'red' : 'slate'} />
               <MetricCard label="Missing context" value={inventory.overview.missingContext} tone={inventory.overview.missingContext ? 'yellow' : 'slate'} />
+              <MetricCard label="Repair packets" value={inventory.repairPackets.length} tone={inventory.repairPackets.length ? 'yellow' : 'slate'} />
             </div>
 
             <WarningPanels
@@ -255,6 +268,13 @@ function AgentAutomationsContent() {
                 <ListChecks size={16} />
                 Context Gaps
               </button>
+              <button
+                onClick={() => setViewMode('repair-packets')}
+                className={`inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm ${viewMode === 'repair-packets' ? 'bg-radiant-gold/15 text-radiant-gold' : 'text-muted-foreground hover:text-foreground'}`}
+              >
+                <ShieldAlert size={16} />
+                Repair Packets
+              </button>
             </div>
 
             <section className="mb-6 rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
@@ -280,7 +300,7 @@ function AgentAutomationsContent() {
                 <AutomationTable automations={filtered} selectedId={selected?.id || null} onSelect={setSelectedId} />
                 {selected ? <ContextReadiness automation={selected} /> : null}
               </div>
-            ) : (
+            ) : viewMode === 'context-gaps' ? (
               <ContextGapsView
                 automations={contextGapAutomations}
                 onSelect={(id) => {
@@ -288,6 +308,8 @@ function AgentAutomationsContent() {
                   setViewMode('inventory')
                 }}
               />
+            ) : (
+              <RepairPacketsView packets={inventory.repairPackets} />
             )}
 
             <p className="mt-5 text-xs text-muted-foreground">
@@ -546,6 +568,76 @@ function ContextGapsView({
   )
 }
 
+function RepairPacketsView({ packets }: { packets: AutomationInventoryResponse['repairPackets'] }) {
+  if (packets.length === 0) {
+    return (
+      <div className="rounded-lg border border-green-400/30 bg-green-500/10 p-6 text-green-100">
+        <div className="flex items-center gap-2 font-medium">
+          <CheckCircle2 size={18} />
+          No repair packets are needed for the current automation inventory.
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <section className="space-y-4">
+      <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
+        <div className="flex items-center gap-2 text-radiant-gold">
+          <ShieldAlert size={18} />
+          <h2 className="font-semibold">Repair Packets</h2>
+        </div>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Read-only next-action packets for automations with missing context, duplicate risk, or incomplete governing references. These packets do not write to Codex memory or automation state.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
+        {packets.map((packet) => (
+          <article key={packet.automationId} className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-5">
+            <div className="mb-4 flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+              <div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <h3 className="text-lg font-semibold">{packet.automationName}</h3>
+                  <RepairPriorityBadge priority={packet.priority} />
+                </div>
+                <p className="mt-1 text-xs text-muted-foreground">{packet.automationId}</p>
+              </div>
+              <p className="text-xs text-muted-foreground break-all md:max-w-[260px]">{packet.sourceFile}</p>
+            </div>
+
+            <p className="mb-4 text-sm text-foreground">{packet.summary}</p>
+
+            <div className="mb-4">
+              <h4 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">Missing readiness</h4>
+              {packet.missingQuestions.length > 0 ? (
+                <div className="flex flex-wrap gap-2">
+                  {packet.missingQuestions.map((question) => (
+                    <span key={question} className="rounded-full border border-yellow-400/30 bg-yellow-500/10 px-2 py-1 text-xs text-yellow-100">
+                      {question}
+                    </span>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground">No missing questions; packet exists for duplicate or overlap review.</p>
+              )}
+            </div>
+
+            <ContextList label="Recommended actions" values={packet.recommendedActions} />
+            <div className="mt-4">
+              <ContextList label="Governing doc candidates" values={packet.governingDocCandidates} />
+            </div>
+
+            <div className="mt-4 rounded-lg border border-silicon-slate/60 bg-black/10 p-3 text-xs text-muted-foreground">
+              {packet.operationalBoundary}
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  )
+}
+
 function WarningPanels({
   hiddenCount,
   duplicateWarnings,
@@ -642,6 +734,16 @@ function RiskBadge({ risk }: { risk: AutomationRiskLevel }) {
         ? 'border-yellow-400/40 bg-yellow-500/10 text-yellow-200'
         : 'border-green-400/40 bg-green-500/10 text-green-200'
   return <span className={`rounded-full border px-2 py-1 text-xs ${className}`}>{risk}</span>
+}
+
+function RepairPriorityBadge({ priority }: { priority: CodexAutomationRepairPriority }) {
+  const className =
+    priority === 'high'
+      ? 'border-red-400/40 bg-red-500/10 text-red-200'
+      : priority === 'medium'
+        ? 'border-yellow-400/40 bg-yellow-500/10 text-yellow-200'
+        : 'border-green-400/40 bg-green-500/10 text-green-200'
+  return <span className={`rounded-full border px-2 py-1 text-xs ${className}`}>{priority} priority</span>
 }
 
 function ContextBadge({ health }: { health: AutomationContextHealth }) {

--- a/docs/memory-context-organization-workflow.md
+++ b/docs/memory-context-organization-workflow.md
@@ -47,6 +47,21 @@ Each automation is checked against these questions:
 
 Missing answers should create recommendations only. V1 does not generate final answers or write them back to TOML, memory, skills, or docs.
 
+## Repair Packets
+
+Repair packets turn readiness gaps into reviewable next-action packets. They are generated from the read-only inventory and should be treated as planning artifacts, not as permission to mutate Codex state.
+
+Each packet includes:
+
+- the automation id and source TOML file,
+- priority based on risk, context health, and duplicate status,
+- missing readiness questions,
+- recommended context additions,
+- governing doc candidates,
+- and the operational boundary that no `~/.codex` memory or automation files should be edited without a separate approved operational-state step.
+
+Use repair packets to decide which prompt, doc, skill, or runbook needs a scoped follow-up PR or an explicitly approved local-state update.
+
 ## Enhancement Impact Preflight
 
 ### Enhancement Impact Preflight
@@ -62,6 +77,18 @@ Missing answers should create recommendations only. V1 does not generate final a
 - Merge-order note: Can merge independently after the integration captain handles active roadmap, credential, subscription, and observability branches; no shared files were identified.
 
 Implementation update: `lib/chief-of-staff-chat.test.ts` also needed a fixture update because it imports the automation inventory contract. This was an intentional shared-helper compatibility fix, not a change to Chief of Staff behavior. The overlap rating remains green against active PRs because no active PR modifies that file or helper.
+
+### Enhancement Impact Preflight
+
+- Enhancement: Add read-only repair packets for automation memory/context gaps.
+- User-facing surface: `/admin/agents/automations`, under Agent Operations.
+- Predicted files: `app/admin/agents/automations/page.tsx`, `lib/codex-automation-inventory.ts`, `lib/codex-automation-inventory.test.ts`, `docs/memory-context-organization-workflow.md`.
+- Shared routes/APIs/tables/helpers: `lib/codex-automation-inventory.ts` and the existing `/api/admin/agents/automations` response shape; no database tables or mutating APIs.
+- Active PRs or branches checked: `codex/client-ai-ops-roadmap-next` PR 190, `codex/subscription-watch-next` PR 191, `codex/credential-reporting-next` PR 192, `codex/vercel-build-observability` PR 193, `cursor/regression-test-coverage-224e` PR 195.
+- Dirty worktree files checked: current `codex/memory-context-repair-packets` worktree was clean before implementation.
+- Overlap rating: green.
+- Coordination decision: Proceed in the dedicated memory organization worktree and keep changes limited to automation context dashboard, inventory, tests, and memory workflow docs.
+- Merge-order note: Can merge independently after integration-captain review; active PRs do not touch these files.
 
 ## Operating Boundary
 

--- a/lib/chief-of-staff-chat.test.ts
+++ b/lib/chief-of-staff-chat.test.ts
@@ -245,6 +245,19 @@ describe('Chief of Staff chat helpers', () => {
           },
         ],
       },
+      repairPackets: [
+        {
+          automationId: 'portfolio-credential-rotation-due-report',
+          automationName: 'Portfolio Credential Rotation Due Report',
+          priority: 'high',
+          summary: 'Portfolio Credential Rotation Due Report needs context repair for missing governance.',
+          missingQuestions: ['governance'],
+          recommendedActions: ['Reference the governing doc, skill, source register, or runbook path in the automation prompt.'],
+          governingDocCandidates: ['docs/memory-context-organization-workflow.md'],
+          sourceFile: '/Users/vambahsillah/.codex/automations/portfolio-credential-rotation-due-report/automation.toml',
+          operationalBoundary: 'Read-only packet. Do not edit ~/.codex/automations or ~/.codex/memories without an explicit operational-state step.',
+        },
+      ],
       automations: [
         {
           id: 'portfolio-credential-rotation-due-report',

--- a/lib/codex-automation-inventory.test.ts
+++ b/lib/codex-automation-inventory.test.ts
@@ -142,6 +142,17 @@ cwds = ["/Users/vambahsillah/Projects/Portfolio"]
     expect(unanswered.find((question) => question.id === 'boundary')?.recommendation).toContain('authority boundary')
     expect(inventory.progress.percent).toBeLessThan(100)
     expect(inventory.progress.tasks.find((task) => task.id === 'memory-context-cleanup')?.status).toBe('pending')
+    expect(inventory.repairPackets).toHaveLength(1)
+    expect(inventory.repairPackets[0]).toEqual(expect.objectContaining({
+      automationId: 'portfolio-thin-monitor',
+      priority: 'high',
+      missingQuestions: expect.arrayContaining(['decision', 'boundary', 'outputs', 'escalation', 'governance']),
+      operationalBoundary: expect.stringContaining('Read-only packet'),
+    }))
+    expect(inventory.repairPackets[0].recommendedActions).toEqual(expect.arrayContaining([
+      expect.stringContaining('authority boundary'),
+      expect.stringContaining('expected output'),
+    ]))
   })
 
   it('flags duplicate credential rotation jobs and sanitizes prompt excerpts', async () => {
@@ -167,5 +178,8 @@ cwds = ["/Users/vambahsillah/Projects/Portfolio"]
     expect(inventory.automations.every((automation) => automation.duplicateCandidate)).toBe(true)
     expect(inventory.automations[0].promptExcerpt).not.toContain('super-secret-value')
     expect(inventory.automations[0].category).toBe('Credentials')
+    expect(inventory.repairPackets).toHaveLength(2)
+    expect(inventory.repairPackets.every((packet) => packet.priority === 'high')).toBe(true)
+    expect(inventory.repairPackets[0].recommendedActions).toContain('Review duplicate automation candidates and decide whether to consolidate, rename, or document why both should remain active.')
   })
 })

--- a/lib/codex-automation-inventory.ts
+++ b/lib/codex-automation-inventory.ts
@@ -34,6 +34,20 @@ export interface MemoryOrganizationTask {
   progress: number
 }
 
+export type CodexAutomationRepairPriority = 'high' | 'medium' | 'low'
+
+export interface CodexAutomationRepairPacket {
+  automationId: string
+  automationName: string
+  priority: CodexAutomationRepairPriority
+  summary: string
+  missingQuestions: string[]
+  recommendedActions: string[]
+  governingDocCandidates: string[]
+  sourceFile: string
+  operationalBoundary: string
+}
+
 export interface CodexAutomationProfile {
   id: string
   name: string
@@ -93,6 +107,7 @@ export interface CodexAutomationInventory {
     totalTasks: number
     tasks: MemoryOrganizationTask[]
   }
+  repairPackets: CodexAutomationRepairPacket[]
 }
 
 type ParsedAutomationToml = {
@@ -162,6 +177,7 @@ export async function listCodexAutomationInventory(
     hiddenCount,
     overview: buildOverview(automations),
     progress: buildMemoryOrganizationProgress(true, automations),
+    repairPackets: buildRepairPackets(automations),
   }
 }
 
@@ -257,6 +273,7 @@ function unavailableInventory(sourceDirectory: string, generatedAt: string, reas
     hiddenCount: 0,
     overview: buildOverview([]),
     progress: buildMemoryOrganizationProgress(false, []),
+    repairPackets: [],
   }
 }
 
@@ -349,6 +366,68 @@ function classifyTaskStatus(progress: number, available: boolean): MemoryOrganiz
   if (progress >= 100) return 'completed'
   if (progress > 0) return 'in_progress'
   return 'pending'
+}
+
+function buildRepairPackets(automations: CodexAutomationProfile[]): CodexAutomationRepairPacket[] {
+  return automations
+    .filter((automation) => automation.contextHealth !== 'green' || automation.duplicateCandidate)
+    .map((automation) => {
+      const missingQuestions = automation.contextQuestions
+        .filter((question) => !question.answered)
+        .map((question) => question.id)
+      const recommendedActions = [
+        ...automation.contextQuestions
+          .filter((question) => !question.answered)
+          .map((question) => question.recommendation),
+        ...(automation.duplicateCandidate ? ['Review duplicate automation candidates and decide whether to consolidate, rename, or document why both should remain active.'] : []),
+        ...(!automation.cwds.some((cwd) => cwd.includes('/Projects/Portfolio')) ? ['Add the Portfolio workspace root to the automation context or document why it runs from another workspace.'] : []),
+      ]
+
+      return {
+        automationId: automation.id,
+        automationName: automation.name,
+        priority: classifyRepairPriority(automation),
+        summary: summarizeRepairPacket(automation, missingQuestions),
+        missingQuestions,
+        recommendedActions: [...new Set(recommendedActions)],
+        governingDocCandidates: suggestGoverningDocCandidates(automation),
+        sourceFile: automation.sourceFile,
+        operationalBoundary: 'Read-only packet. Do not edit ~/.codex/automations or ~/.codex/memories without an explicit operational-state step.',
+      }
+    })
+    .sort((a, b) => {
+      const priorityRank: Record<CodexAutomationRepairPriority, number> = { high: 0, medium: 1, low: 2 }
+      return priorityRank[a.priority] - priorityRank[b.priority] || a.automationName.localeCompare(b.automationName)
+    })
+}
+
+function classifyRepairPriority(automation: CodexAutomationProfile): CodexAutomationRepairPriority {
+  if (automation.riskLevel === 'high' && automation.contextHealth === 'red') return 'high'
+  if (automation.riskLevel === 'high' && automation.duplicateCandidate) return 'high'
+  if (automation.contextHealth === 'red') return 'high'
+  if (automation.riskLevel === 'high' || automation.contextHealth === 'yellow') return 'medium'
+  return 'low'
+}
+
+function summarizeRepairPacket(automation: CodexAutomationProfile, missingQuestions: string[]) {
+  const issues = [
+    ...missingQuestions.map((question) => `missing ${question}`),
+    ...(automation.duplicateCandidate ? ['duplicate candidate'] : []),
+  ]
+  return issues.length > 0
+    ? `${automation.name} needs context repair for ${issues.join(', ')}.`
+    : `${automation.name} needs a light review before it can be marked fully ready.`
+}
+
+function suggestGoverningDocCandidates(automation: CodexAutomationProfile) {
+  const categorySlug = automation.category.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
+  const candidates = [
+    ...automation.controlDocs,
+    'docs/memory-context-organization-workflow.md',
+    `docs/automations/${automation.id}.md`,
+    `docs/automations/${categorySlug}-runbook.md`,
+  ]
+  return [...new Set(candidates)]
 }
 
 function extractControlDocs(prompt: string): string[] {


### PR DESCRIPTION
## Summary

Adds read-only repair packets to the Automation Context dashboard so memory/context gaps become concrete next-action packets without mutating Codex operational state.

- Extends the local automation inventory with `repairPackets` derived from context health, duplicate status, and missing readiness questions.
- Adds a Repair Packets tab to `/admin/agents/automations` with priority, missing readiness, recommended actions, governing doc candidates, source file, and explicit operational boundary.
- Updates tests for repair packet generation and shared Chief of Staff fixture compatibility.
- Extends the memory/context organization workflow doc with repair-packet usage and preflight results.

## Enhancement Impact Preflight

- Enhancement: Add read-only repair packets for automation memory/context gaps.
- User-facing surface: `/admin/agents/automations`, under Agent Operations.
- Predicted files: `app/admin/agents/automations/page.tsx`, `lib/codex-automation-inventory.ts`, `lib/codex-automation-inventory.test.ts`, `docs/memory-context-organization-workflow.md`.
- Shared routes/APIs/tables/helpers: `lib/codex-automation-inventory.ts` and the existing `/api/admin/agents/automations` response shape; no database tables or mutating APIs.
- Active PRs or branches checked: `codex/client-ai-ops-roadmap-next` PR 190, `codex/subscription-watch-next` PR 191, `codex/credential-reporting-next` PR 192, `codex/vercel-build-observability` PR 193, `cursor/regression-test-coverage-224e` PR 195.
- Dirty worktree files checked: current `codex/memory-context-repair-packets` worktree was clean before implementation.
- Overlap rating: green.
- Coordination decision: Proceeded in the dedicated memory organization worktree and kept changes limited to automation context dashboard, inventory, tests, and memory workflow docs.
- Merge-order note: Can merge independently after integration-captain review; active PRs do not touch these files.

Implementation update: `lib/chief-of-staff-chat.test.ts` needed a fixture update because it imports the automation inventory contract. This is an intentional shared-helper compatibility fix, not a Chief of Staff behavior change.

## Validation

- `npx vitest run lib/codex-automation-inventory.test.ts app/api/admin/agents/automations/route.test.ts lib/chief-of-staff-chat.test.ts`
- `npx tsc --noEmit`
- `git diff --check`
- Route smoke: `/admin/agents/automations` returned `200` after sourcing the main checkout `.env.local` into the dev-server process only.
- Real local inventory smoke: 13 visible Portfolio automations, 87% memory/context readiness, 6 repair packets.

## Operational State

No direct writes were made under `~/.codex/memories` or `~/.codex/automations`.

Read-only local state inspection used `~/.codex/automations` through the dashboard inventory helper. `npm ci` installed ignored local `node_modules` in this worktree so validation could run. The main checkout `.env.local` was sourced into the dev-server process only for route smoke; it was not copied or modified.
