### PR TITLE
feat: add agent coordination substrate

### DIFF
--- a/app/admin/agents/coordination/page.tsx
+++ b/app/admin/agents/coordination/page.tsx
@@ -1,0 +1,459 @@
+'use client'
+
+import Link from 'next/link'
+import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  AlertTriangle,
+  ArrowRight,
+  Bot,
+  CheckCircle2,
+  GitPullRequest,
+  Network,
+  RefreshCw,
+  ShieldCheck,
+} from 'lucide-react'
+import ProtectedRoute from '@/components/ProtectedRoute'
+import Breadcrumbs from '@/components/admin/Breadcrumbs'
+import { getCurrentSession } from '@/lib/auth'
+import type { AgentRuntime } from '@/lib/agent-run'
+import type { AgentWorkItem, AgentWorkItemStatus } from '@/lib/agent-work-items'
+
+const STATUSES: Array<'all' | AgentWorkItemStatus> = [
+  'all',
+  'queued',
+  'assigned',
+  'in_progress',
+  'blocked',
+  'ready_for_review',
+  'ready_for_merge',
+  'merged',
+  'deployed',
+  'cancelled',
+]
+
+type WorkItemForm = {
+  title: string
+  objective: string
+  owner_agent_key: string
+  owner_runtime: AgentRuntime
+  branch_name: string
+  worktree_path: string
+  expected_files: string
+}
+
+const DEFAULT_FORM: WorkItemForm = {
+  title: '',
+  objective: '',
+  owner_agent_key: 'chief-of-staff',
+  owner_runtime: 'codex',
+  branch_name: '',
+  worktree_path: '',
+  expected_files: '',
+}
+
+export default function AgentCoordinationPage() {
+  return (
+    <ProtectedRoute requireAdmin>
+      <AgentCoordinationContent />
+    </ProtectedRoute>
+  )
+}
+
+function AgentCoordinationContent() {
+  const [items, setItems] = useState<AgentWorkItem[]>([])
+  const [status, setStatus] = useState<'all' | AgentWorkItemStatus>('all')
+  const [loading, setLoading] = useState(true)
+  const [submitting, setSubmitting] = useState(false)
+  const [actionId, setActionId] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [form, setForm] = useState<WorkItemForm>(DEFAULT_FORM)
+
+  const authedFetch = useCallback(async (path: string, init: RequestInit = {}) => {
+    const session = await getCurrentSession()
+    if (!session?.access_token) throw new Error('Missing admin session')
+    return fetch(path, {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${session.access_token}`,
+        ...(init.body ? { 'Content-Type': 'application/json' } : {}),
+        ...(init.headers ?? {}),
+      },
+    })
+  }, [])
+
+  const loadItems = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const query = status === 'all' ? '' : `?status=${status}`
+      const response = await authedFetch(`/api/admin/agents/work-items${query}`)
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`)
+      setItems(body.work_items ?? [])
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load work items')
+      setItems([])
+    } finally {
+      setLoading(false)
+    }
+  }, [authedFetch, status])
+
+  useEffect(() => {
+    loadItems()
+  }, [loadItems])
+
+  const summary = useMemo(() => ({
+    active: items.filter((item) => !['merged', 'deployed', 'cancelled'].includes(item.status)).length,
+    blocked: items.filter((item) => item.status === 'blocked').length,
+    review: items.filter((item) => item.status === 'ready_for_review' || item.status === 'ready_for_merge').length,
+    approvals: items.filter((item) => Boolean(item.approval_id)).length,
+  }), [items])
+
+  async function createWorkItem(event: FormEvent) {
+    event.preventDefault()
+    setSubmitting(true)
+    setError(null)
+    try {
+      const response = await authedFetch('/api/admin/agents/work-items', {
+        method: 'POST',
+        body: JSON.stringify({
+          title: form.title,
+          objective: form.objective,
+          owner_agent_key: form.owner_agent_key,
+          owner_runtime: form.owner_runtime,
+          branch_name: form.branch_name || null,
+          worktree_path: form.worktree_path || null,
+          expected_files: form.expected_files.split('\n').map((line) => line.trim()).filter(Boolean),
+          source_type: 'admin_agent_coordination',
+          source_label: 'Agent Coordination',
+        }),
+      })
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`)
+      setForm(DEFAULT_FORM)
+      await loadItems()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create work item')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  async function quickAction(item: AgentWorkItem, action: 'block' | 'validation' | 'handoff') {
+    const note =
+      action === 'block'
+        ? 'Needs Integration Captain review before proceeding.'
+        : action === 'validation'
+          ? 'Validation packet recorded from Agent Coordination.'
+          : 'Hand off to Integration Captain for gated review.'
+    setActionId(`${action}:${item.id}`)
+    setError(null)
+    try {
+      const path =
+        action === 'block'
+          ? `/api/admin/agents/work-items/${item.id}/block`
+          : action === 'validation'
+            ? `/api/admin/agents/work-items/${item.id}/validation`
+            : `/api/admin/agents/work-items/${item.id}/handoff`
+      const body =
+        action === 'block'
+          ? { blocker_summary: note }
+          : action === 'validation'
+            ? { validation_summary: note, ready_for_merge: true }
+            : {
+                to_agent_key: 'integration-captain',
+                to_runtime: 'codex',
+                summary: note,
+                acceptance_criteria: 'Review PR, checks, deployment gates, and merge eligibility.',
+              }
+      const response = await authedFetch(path, { method: 'POST', body: JSON.stringify(body) })
+      const responseBody = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(responseBody.error || `HTTP ${response.status}`)
+      await loadItems()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Action failed')
+    } finally {
+      setActionId(null)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-background text-foreground p-6 lg:p-8">
+      <div className="mx-auto max-w-7xl">
+        <Breadcrumbs items={[
+          { label: 'Admin Dashboard', href: '/admin' },
+          { label: 'Agent Operations', href: '/admin/agents' },
+          { label: 'Coordination' },
+        ]} />
+
+        <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <div className="mb-2 inline-flex items-center gap-2 text-sm text-radiant-gold">
+              <Network size={16} />
+              Agent Coordination Substrate
+            </div>
+            <h1 className="text-3xl font-bold">Agent Coordination</h1>
+            <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+              Durable work packets, handoffs, blockers, PR links, and approval-gated merge/deploy states across Codex, n8n, Hermes, OpenCode, and manual operators.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Link
+              href="/admin/agents"
+              className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 bg-silicon-slate/30 px-3 py-2 text-sm hover:border-radiant-gold/60"
+            >
+              <Bot size={16} />
+              Mission Control
+            </Link>
+            <button
+              onClick={loadItems}
+              disabled={loading}
+              className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/50 bg-radiant-gold/10 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15 disabled:opacity-60"
+            >
+              <RefreshCw size={16} className={loading ? 'animate-spin' : ''} />
+              Refresh
+            </button>
+          </div>
+        </div>
+
+        <div className="mb-6 grid grid-cols-2 gap-3 md:grid-cols-4">
+          <Metric label="Active" value={summary.active} />
+          <Metric label="Blocked" value={summary.blocked} tone={summary.blocked ? 'red' : 'slate'} />
+          <Metric label="Review queue" value={summary.review} tone={summary.review ? 'yellow' : 'slate'} />
+          <Metric label="Approval-linked" value={summary.approvals} tone={summary.approvals ? 'green' : 'slate'} />
+        </div>
+
+        <section className="mb-6 rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
+          <div className="mb-4 flex flex-wrap gap-2">
+            {STATUSES.map((item) => (
+              <button
+                key={item}
+                onClick={() => setStatus(item)}
+                className={`rounded-lg border px-3 py-2 text-sm ${
+                  status === item
+                    ? 'border-radiant-gold/60 bg-radiant-gold/15 text-radiant-gold'
+                    : 'border-silicon-slate/70 bg-silicon-slate/20 text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                {item.replace(/_/g, ' ')}
+              </button>
+            ))}
+          </div>
+
+          <form onSubmit={createWorkItem} className="grid gap-3 lg:grid-cols-3">
+            <input
+              value={form.title}
+              onChange={(event) => setForm((prev) => ({ ...prev, title: event.target.value }))}
+              placeholder="Work item title"
+              className="rounded-lg border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm"
+            />
+            <input
+              value={form.owner_agent_key}
+              onChange={(event) => setForm((prev) => ({ ...prev, owner_agent_key: event.target.value }))}
+              placeholder="owner agent key"
+              className="rounded-lg border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm"
+            />
+            <input
+              value={form.branch_name}
+              onChange={(event) => setForm((prev) => ({ ...prev, branch_name: event.target.value }))}
+              placeholder="branch name"
+              className="rounded-lg border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm"
+            />
+            <textarea
+              value={form.objective}
+              onChange={(event) => setForm((prev) => ({ ...prev, objective: event.target.value }))}
+              placeholder="Objective and acceptance criteria"
+              rows={3}
+              className="rounded-lg border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm lg:col-span-2"
+            />
+            <div className="grid gap-3">
+              <input
+                value={form.worktree_path}
+                onChange={(event) => setForm((prev) => ({ ...prev, worktree_path: event.target.value }))}
+                placeholder="worktree path"
+                className="rounded-lg border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm"
+              />
+              <button
+                type="submit"
+                disabled={submitting || !form.title.trim() || !form.objective.trim()}
+                className="inline-flex items-center justify-center gap-2 rounded-lg border border-radiant-gold/60 bg-radiant-gold/15 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/20 disabled:opacity-50"
+              >
+                <Network size={16} />
+                Create work item
+              </button>
+            </div>
+          </form>
+        </section>
+
+        {error ? <FailureState message={error} /> : null}
+
+        {loading ? (
+          <div className="py-16 text-center text-muted-foreground">Loading coordination work...</div>
+        ) : items.length ? (
+          <div className="space-y-3">
+            {items.map((item) => (
+              <WorkItemCard
+                key={item.id}
+                item={item}
+                actionId={actionId}
+                onAction={quickAction}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 px-4 py-12 text-center text-muted-foreground">
+            No agent coordination work items match the current filter.
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function WorkItemCard({
+  item,
+  actionId,
+  onAction,
+}: {
+  item: AgentWorkItem
+  actionId: string | null
+  onAction: (item: AgentWorkItem, action: 'block' | 'validation' | 'handoff') => void
+}) {
+  return (
+    <article className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0">
+          <div className="mb-2 flex flex-wrap items-center gap-2">
+            <StatusBadge status={item.status} />
+            <span className="rounded-full border border-silicon-slate/70 px-2 py-1 text-xs text-muted-foreground">
+              {item.owner_runtime}
+            </span>
+            {item.owner_agent_key ? (
+              <span className="rounded-full border border-silicon-slate/70 px-2 py-1 text-xs text-muted-foreground">
+                {item.owner_agent_key}
+              </span>
+            ) : null}
+          </div>
+          <h2 className="text-lg font-semibold">{item.title}</h2>
+          <p className="mt-1 max-w-4xl text-sm text-muted-foreground">{item.objective}</p>
+          <div className="mt-3 grid gap-2 text-xs text-muted-foreground md:grid-cols-2 xl:grid-cols-4">
+            <SmallField label="Branch" value={item.branch_name} />
+            <SmallField label="Worktree" value={item.worktree_path} />
+            <SmallField label="Overlap" value={item.overlap_group} />
+            <SmallField label="Updated" value={new Date(item.updated_at).toLocaleString()} />
+          </div>
+          {item.blocker_summary || item.validation_summary ? (
+            <div className="mt-3 grid gap-2 md:grid-cols-2">
+              {item.blocker_summary ? <Callout icon="warn" label="Blocker" value={item.blocker_summary} /> : null}
+              {item.validation_summary ? <Callout icon="check" label="Validation" value={item.validation_summary} /> : null}
+            </div>
+          ) : null}
+        </div>
+        <div className="flex flex-wrap gap-2 lg:justify-end">
+          {item.pr_url ? (
+            <Link
+              href={item.pr_url}
+              className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 px-3 py-2 text-sm hover:border-radiant-gold/60"
+            >
+              <GitPullRequest size={16} />
+              PR {item.pr_number ?? ''}
+            </Link>
+          ) : null}
+          {item.active_run_id ? (
+            <Link
+              href={`/admin/agents/runs/${item.active_run_id}`}
+              className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 px-3 py-2 text-sm hover:border-radiant-gold/60"
+            >
+              Trace
+              <ArrowRight size={16} />
+            </Link>
+          ) : null}
+          <button
+            onClick={() => onAction(item, 'block')}
+            disabled={Boolean(actionId)}
+            className="rounded-lg border border-silicon-slate/70 px-3 py-2 text-sm hover:border-red-400/60 disabled:opacity-50"
+          >
+            Block
+          </button>
+          <button
+            onClick={() => onAction(item, 'validation')}
+            disabled={Boolean(actionId)}
+            className="rounded-lg border border-silicon-slate/70 px-3 py-2 text-sm hover:border-yellow-400/60 disabled:opacity-50"
+          >
+            Validate
+          </button>
+          <button
+            onClick={() => onAction(item, 'handoff')}
+            disabled={Boolean(actionId)}
+            className="rounded-lg border border-silicon-slate/70 px-3 py-2 text-sm hover:border-radiant-gold/60 disabled:opacity-50"
+          >
+            Handoff
+          </button>
+        </div>
+      </div>
+    </article>
+  )
+}
+
+function Metric({ label, value, tone = 'slate' }: { label: string; value: number; tone?: 'slate' | 'red' | 'yellow' | 'green' }) {
+  const toneClass =
+    tone === 'red'
+      ? 'border-red-500/35 text-red-200'
+      : tone === 'yellow'
+        ? 'border-yellow-500/35 text-yellow-100'
+        : tone === 'green'
+          ? 'border-green-500/35 text-green-100'
+          : 'border-silicon-slate/70'
+  return (
+    <div className={`rounded-lg border bg-silicon-slate/20 p-4 ${toneClass}`}>
+      <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="mt-2 text-2xl font-semibold">{value}</p>
+    </div>
+  )
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const tone =
+    status === 'blocked'
+      ? 'border-red-500/40 bg-red-500/10 text-red-200'
+      : status === 'ready_for_merge'
+        ? 'border-yellow-500/40 bg-yellow-500/10 text-yellow-100'
+        : status === 'deployed' || status === 'merged'
+          ? 'border-green-500/40 bg-green-500/10 text-green-100'
+          : 'border-silicon-slate/70 bg-silicon-slate/20 text-muted-foreground'
+  return <span className={`rounded-full border px-2 py-1 text-xs ${tone}`}>{status.replace(/_/g, ' ')}</span>
+}
+
+function SmallField({ label, value }: { label: string; value: string | null }) {
+  return (
+    <div className="min-w-0">
+      <span className="block uppercase tracking-wide text-muted-foreground/70">{label}</span>
+      <span className="block truncate">{value || 'Not set'}</span>
+    </div>
+  )
+}
+
+function Callout({ icon, label, value }: { icon: 'warn' | 'check'; label: string; value: string }) {
+  const Icon = icon === 'warn' ? AlertTriangle : CheckCircle2
+  return (
+    <div className="flex gap-2 rounded-lg border border-silicon-slate/70 bg-background/50 p-3 text-sm">
+      <Icon size={16} className={icon === 'warn' ? 'text-red-300' : 'text-green-300'} />
+      <div>
+        <p className="font-medium">{label}</p>
+        <p className="mt-1 text-muted-foreground">{value}</p>
+      </div>
+    </div>
+  )
+}
+
+function FailureState({ message }: { message: string }) {
+  return (
+    <div className="mb-6 flex items-start gap-3 rounded-lg border border-red-500/40 bg-red-500/10 p-4 text-red-100">
+      <ShieldCheck size={18} />
+      <div>
+        <p className="font-medium">Coordination layer unavailable</p>
+        <p className="mt-1 text-sm text-red-100/80">{message}</p>
+      </div>
+    </div>
+  )
+}

--- a/app/api/admin/agents/work-items/[id]/block/route.ts
+++ b/app/api/admin/agents/work-items/[id]/block/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { recordAgentWorkItemBlocker } from '@/lib/agent-work-items'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as { blocker_summary?: unknown }
+  const blockerSummary = typeof body.blocker_summary === 'string' ? body.blocker_summary.trim() : ''
+  if (!blockerSummary) {
+    return NextResponse.json({ error: 'blocker_summary is required' }, { status: 400 })
+  }
+
+  try {
+    const work_item = await recordAgentWorkItemBlocker({ id: params.id, blockerSummary })
+    return NextResponse.json({ ok: true, work_item })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to block work item'
+    const status = message === 'Agent work item not found' ? 404 : 500
+    console.error('[agent-work-item-block] failed:', error)
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/app/api/admin/agents/work-items/[id]/claim/route.ts
+++ b/app/api/admin/agents/work-items/[id]/claim/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { claimAgentWorkItem } from '@/lib/agent-work-items'
+import { AGENT_RUNTIMES, type AgentRuntime } from '@/lib/agent-run'
+
+export const dynamic = 'force-dynamic'
+
+function isRuntime(value: string): value is AgentRuntime {
+  return AGENT_RUNTIMES.includes(value as AgentRuntime)
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as {
+    owner_agent_key?: unknown
+    owner_runtime?: unknown
+    actor_label?: unknown
+  }
+  const ownerAgentKey = typeof body.owner_agent_key === 'string' ? body.owner_agent_key.trim() : ''
+  if (!ownerAgentKey) {
+    return NextResponse.json({ error: 'owner_agent_key is required' }, { status: 400 })
+  }
+  const ownerRuntime: AgentRuntime | undefined = typeof body.owner_runtime === 'string' ? body.owner_runtime as AgentRuntime : undefined
+  if (ownerRuntime && !isRuntime(ownerRuntime)) {
+    return NextResponse.json({ error: 'Invalid owner_runtime' }, { status: 400 })
+  }
+
+  try {
+    const work_item = await claimAgentWorkItem({
+      id: params.id,
+      ownerAgentKey,
+      ownerRuntime,
+      actorLabel: typeof body.actor_label === 'string' ? body.actor_label : 'Admin user',
+    })
+    return NextResponse.json({ ok: true, work_item })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to claim work item'
+    const status = message === 'Agent work item not found' ? 404 : 500
+    console.error('[agent-work-item-claim] failed:', error)
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/app/api/admin/agents/work-items/[id]/handoff/route.ts
+++ b/app/api/admin/agents/work-items/[id]/handoff/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { handoffAgentWorkItem } from '@/lib/agent-work-items'
+import { AGENT_RUNTIMES, type AgentRuntime } from '@/lib/agent-run'
+
+export const dynamic = 'force-dynamic'
+
+function isRuntime(value: string): value is AgentRuntime {
+  return AGENT_RUNTIMES.includes(value as AgentRuntime)
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as Record<string, unknown>
+  const toAgentKey = typeof body.to_agent_key === 'string' ? body.to_agent_key.trim() : ''
+  const summary = typeof body.summary === 'string' ? body.summary.trim() : ''
+  if (!toAgentKey || !summary) {
+    return NextResponse.json({ error: 'to_agent_key and summary are required' }, { status: 400 })
+  }
+  const toRuntime: AgentRuntime | undefined = typeof body.to_runtime === 'string' ? body.to_runtime as AgentRuntime : undefined
+  if (toRuntime && !isRuntime(toRuntime)) {
+    return NextResponse.json({ error: 'Invalid to_runtime' }, { status: 400 })
+  }
+
+  try {
+    const result = await handoffAgentWorkItem({
+      id: params.id,
+      toAgentKey,
+      toRuntime,
+      fromAgentKey: typeof body.from_agent_key === 'string' ? body.from_agent_key : null,
+      handoffType: typeof body.handoff_type === 'string' ? body.handoff_type : null,
+      summary,
+      acceptanceCriteria: typeof body.acceptance_criteria === 'string' ? body.acceptance_criteria : null,
+      idempotencyKey: typeof body.idempotency_key === 'string' ? body.idempotency_key : null,
+    })
+    return NextResponse.json({ ok: true, work_item: result.workItem, handoff_id: result.handoffId })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to hand off work item'
+    const status = message === 'Agent work item not found' ? 404 : 500
+    console.error('[agent-work-item-handoff] failed:', error)
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/app/api/admin/agents/work-items/[id]/pr/route.ts
+++ b/app/api/admin/agents/work-items/[id]/pr/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { attachAgentWorkItemPr } from '@/lib/agent-work-items'
+
+export const dynamic = 'force-dynamic'
+
+function stringArray(value: unknown) {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as Record<string, unknown>
+  const prNumber = typeof body.pr_number === 'number' && Number.isFinite(body.pr_number)
+    ? body.pr_number
+    : null
+
+  try {
+    const work_item = await attachAgentWorkItemPr({
+      id: params.id,
+      prNumber,
+      prUrl: typeof body.pr_url === 'string' ? body.pr_url : null,
+      branchName: typeof body.branch_name === 'string' ? body.branch_name : null,
+      touchedFiles: stringArray(body.touched_files),
+    })
+    return NextResponse.json({ ok: true, work_item })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to attach PR'
+    const status = message === 'Agent work item not found' ? 404 : 500
+    console.error('[agent-work-item-pr] failed:', error)
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/app/api/admin/agents/work-items/[id]/route.ts
+++ b/app/api/admin/agents/work-items/[id]/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import {
+  AGENT_WORK_ITEM_STATUSES,
+  cancelAgentWorkItem,
+  completeAgentWorkItem,
+  getAgentWorkItem,
+  updateAgentWorkItemStatus,
+  type AgentWorkItemStatus,
+} from '@/lib/agent-work-items'
+
+export const dynamic = 'force-dynamic'
+
+function isStatus(value: string): value is AgentWorkItemStatus {
+  return AGENT_WORK_ITEM_STATUSES.includes(value as AgentWorkItemStatus)
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  try {
+    const work_item = await getAgentWorkItem(params.id)
+    if (!work_item) return NextResponse.json({ error: 'Work item not found' }, { status: 404 })
+    return NextResponse.json({ work_item })
+  } catch (error) {
+    console.error('[agent-work-item] fetch failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to fetch work item' },
+      { status: 500 },
+    )
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as {
+    status?: string
+    note?: string | null
+  }
+
+  if (!body.status || !isStatus(body.status)) {
+    return NextResponse.json({ error: 'Valid status is required' }, { status: 400 })
+  }
+
+  try {
+    const work_item = body.status === 'cancelled'
+      ? await cancelAgentWorkItem({ id: params.id, reason: body.note ?? null })
+      : body.status === 'merged' || body.status === 'deployed'
+        ? await completeAgentWorkItem({
+            id: params.id,
+            status: body.status,
+            validationSummary: body.note ?? null,
+          })
+        : await updateAgentWorkItemStatus({
+            id: params.id,
+            status: body.status,
+            note: body.note ?? null,
+          })
+
+    return NextResponse.json({ ok: true, work_item })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to update work item'
+    const status = message === 'Agent work item not found' ? 404 : 500
+    console.error('[agent-work-item] update failed:', error)
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/app/api/admin/agents/work-items/[id]/validation/route.ts
+++ b/app/api/admin/agents/work-items/[id]/validation/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { recordAgentWorkItemValidation } from '@/lib/agent-work-items'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as {
+    validation_summary?: unknown
+    ready_for_merge?: unknown
+  }
+  const validationSummary = typeof body.validation_summary === 'string' ? body.validation_summary.trim() : ''
+  if (!validationSummary) {
+    return NextResponse.json({ error: 'validation_summary is required' }, { status: 400 })
+  }
+
+  try {
+    const work_item = await recordAgentWorkItemValidation({
+      id: params.id,
+      validationSummary,
+      readyForMerge: body.ready_for_merge === true,
+    })
+    return NextResponse.json({ ok: true, work_item })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to record validation'
+    const status = message === 'Agent work item not found' ? 404 : 500
+    console.error('[agent-work-item-validation] failed:', error)
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/app/api/admin/agents/work-items/route.test.ts
+++ b/app/api/admin/agents/work-items/route.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  listAgentWorkItems: vi.fn(),
+  createAgentWorkItem: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-work-items', () => ({
+  AGENT_WORK_ITEM_PRIORITIES: ['low', 'medium', 'high', 'urgent'],
+  AGENT_WORK_ITEM_STATUSES: [
+    'proposed',
+    'queued',
+    'assigned',
+    'in_progress',
+    'blocked',
+    'ready_for_review',
+    'ready_for_merge',
+    'merged',
+    'deployed',
+    'cancelled',
+  ],
+  listAgentWorkItems: mocks.listAgentWorkItems,
+  createAgentWorkItem: mocks.createAgentWorkItem,
+}))
+
+vi.mock('@/lib/agent-run', () => ({
+  AGENT_RUNTIMES: ['codex', 'n8n', 'hermes', 'opencode', 'manual'],
+}))
+
+import { GET, POST } from './route'
+
+function request(url = 'http://localhost/api/admin/agents/work-items', body?: unknown) {
+  return new Request(url, {
+    method: body ? 'POST' : 'GET',
+    headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+    body: body ? JSON.stringify(body) : undefined,
+  })
+}
+
+describe('/api/admin/agents/work-items', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.listAgentWorkItems.mockResolvedValue([{ id: 'work-1', title: 'Coordinate' }])
+    mocks.createAgentWorkItem.mockResolvedValue({ id: 'work-1', title: 'Coordinate' })
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await GET(request() as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.listAgentWorkItems).not.toHaveBeenCalled()
+  })
+
+  it('lists work items and validates status filters', async () => {
+    const response = await GET(request('http://localhost/api/admin/agents/work-items?status=queued') as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ work_items: [{ id: 'work-1', title: 'Coordinate' }] })
+    expect(mocks.listAgentWorkItems).toHaveBeenCalledWith(expect.objectContaining({ status: 'queued' }))
+
+    const bad = await GET(request('http://localhost/api/admin/agents/work-items?status=bogus') as never)
+    expect(bad.status).toBe(400)
+  })
+
+  it('creates a work item with scoped fields', async () => {
+    const response = await POST(request('http://localhost/api/admin/agents/work-items', {
+      title: 'Coordinate feature',
+      objective: 'Build shared assignment bus',
+      owner_agent_key: 'chief-of-staff',
+      owner_runtime: 'codex',
+      expected_files: ['lib/agent-work-items.ts'],
+    }) as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({ ok: true, work_item: { id: 'work-1' } })
+    expect(mocks.createAgentWorkItem).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'Coordinate feature',
+      objective: 'Build shared assignment bus',
+      ownerAgentKey: 'chief-of-staff',
+      ownerRuntime: 'codex',
+      expectedFiles: ['lib/agent-work-items.ts'],
+    }))
+  })
+
+  it('rejects malformed create payloads', async () => {
+    const missing = await POST(request('http://localhost/api/admin/agents/work-items', { title: 'Missing objective' }) as never)
+    expect(missing.status).toBe(400)
+
+    const badRuntime = await POST(request('http://localhost/api/admin/agents/work-items', {
+      title: 'Bad runtime',
+      objective: 'Bad runtime',
+      owner_runtime: 'bogus',
+    }) as never)
+    expect(badRuntime.status).toBe(400)
+  })
+})

--- a/app/api/admin/agents/work-items/route.ts
+++ b/app/api/admin/agents/work-items/route.ts
@@ -1,0 +1,120 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import {
+  AGENT_WORK_ITEM_PRIORITIES,
+  AGENT_WORK_ITEM_STATUSES,
+  createAgentWorkItem,
+  listAgentWorkItems,
+  type AgentWorkItemPriority,
+  type AgentWorkItemStatus,
+} from '@/lib/agent-work-items'
+import { AGENT_RUNTIMES, type AgentRuntime } from '@/lib/agent-run'
+
+export const dynamic = 'force-dynamic'
+
+function isStatus(value: string): value is AgentWorkItemStatus {
+  return AGENT_WORK_ITEM_STATUSES.includes(value as AgentWorkItemStatus)
+}
+
+function isPriority(value: string): value is AgentWorkItemPriority {
+  return AGENT_WORK_ITEM_PRIORITIES.includes(value as AgentWorkItemPriority)
+}
+
+function isRuntime(value: string): value is AgentRuntime {
+  return AGENT_RUNTIMES.includes(value as AgentRuntime)
+}
+
+function stringArray(value: unknown) {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
+}
+
+export async function GET(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const { searchParams } = new URL(request.url)
+  const status = searchParams.get('status')
+  if (status && !isStatus(status)) {
+    return NextResponse.json({ error: 'Invalid status' }, { status: 400 })
+  }
+  const statusFilter: AgentWorkItemStatus | null = status ? status as AgentWorkItemStatus : null
+
+  try {
+    const work_items = await listAgentWorkItems({
+      status: statusFilter,
+      ownerAgentKey: searchParams.get('owner_agent_key'),
+      limit: Number(searchParams.get('limit') || 50),
+    })
+    return NextResponse.json({ work_items })
+  } catch (error) {
+    console.error('[agent-work-items] list failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to list work items' },
+      { status: 500 },
+    )
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as Record<string, unknown>
+  const title = typeof body.title === 'string' ? body.title.trim() : ''
+  const objective = typeof body.objective === 'string' ? body.objective.trim() : ''
+  if (!title || !objective) {
+    return NextResponse.json({ error: 'title and objective are required' }, { status: 400 })
+  }
+
+  const priority = typeof body.priority === 'string' ? body.priority : 'medium'
+  if (!isPriority(priority)) {
+    return NextResponse.json({ error: 'Invalid priority' }, { status: 400 })
+  }
+
+  const status = typeof body.status === 'string' ? body.status : undefined
+  if (status && !['proposed', 'queued', 'assigned', 'in_progress'].includes(status)) {
+    return NextResponse.json({ error: 'Invalid initial status' }, { status: 400 })
+  }
+
+  const ownerRuntime: AgentRuntime | undefined = typeof body.owner_runtime === 'string' ? body.owner_runtime as AgentRuntime : undefined
+  if (ownerRuntime && !isRuntime(ownerRuntime)) {
+    return NextResponse.json({ error: 'Invalid owner_runtime' }, { status: 400 })
+  }
+
+  try {
+    const work_item = await createAgentWorkItem({
+      title,
+      objective,
+      priority,
+      status: status as 'proposed' | 'queued' | 'assigned' | 'in_progress' | undefined,
+      ownerAgentKey: typeof body.owner_agent_key === 'string' ? body.owner_agent_key : null,
+      ownerRuntime,
+      source: {
+        type: typeof body.source_type === 'string' ? body.source_type : 'admin_agent_coordination',
+        id: typeof body.source_id === 'string' || typeof body.source_id === 'number' ? body.source_id : auth.user.id,
+        label: typeof body.source_label === 'string' ? body.source_label : 'Admin coordination request',
+      },
+      sourceRunId: typeof body.source_run_id === 'string' ? body.source_run_id : null,
+      parentWorkItemId: typeof body.parent_work_item_id === 'string' ? body.parent_work_item_id : null,
+      branchName: typeof body.branch_name === 'string' ? body.branch_name : null,
+      worktreePath: typeof body.worktree_path === 'string' ? body.worktree_path : null,
+      expectedFiles: stringArray(body.expected_files),
+      overlapGroup: typeof body.overlap_group === 'string' ? body.overlap_group : null,
+      dependencyIds: stringArray(body.dependency_ids),
+      metadata: typeof body.metadata === 'object' && body.metadata ? body.metadata as Record<string, unknown> : {},
+      idempotencyKey: typeof body.idempotency_key === 'string' ? body.idempotency_key : null,
+    })
+
+    return NextResponse.json({ ok: true, work_item })
+  } catch (error) {
+    console.error('[agent-work-items] create failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to create work item' },
+      { status: 500 },
+    )
+  }
+}

--- a/commands/captain-sweep.md
+++ b/commands/captain-sweep.md
@@ -74,6 +74,18 @@ Clean conservatively:
 - Preserve recovery stashes and unknown worktrees unless Vambah explicitly approves cleanup.
 - Leave watch/debt items documented instead of guessing ownership.
 
+## Agent Coordination Gate
+
+Use the Agent Coordination substrate as the shared assignment bus:
+
+- Check `/admin/agents/coordination` and Slack `/agent captain` before merging ready PRs.
+- Match PRs to coordination work items by `branch_name`, `pr_number`, or `pr_url`.
+- Attach reviewable PRs to their work item and set them to `ready_for_review`.
+- When checks are green and the branch is merge-clean, record validation and set the item to `ready_for_merge`; this creates an approval checkpoint instead of granting automatic merge authority.
+- After merge and both Vercel contexts pass, mark the item `deployed` and record deployment evidence in the validation summary.
+- If checks fail, conflicts appear, or deployment verification is blocked, mark the item `blocked` with the exact blocker and next owner.
+- Treat Slack `/agent captain` as a status surface only. It must not merge PRs or mutate production.
+
 ## Report Format
 
 Return a concise status report:

--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -4,6 +4,8 @@ This roadmap is the scope-control document for Agent Operations. It defines what
 
 Portfolio admin remains the control plane. Slack remains the mobile command surface. `agent_runs`, `agent_run_steps`, `agent_run_events`, `agent_run_artifacts`, `agent_approvals`, and `cost_events.agent_run_id` remain the source of truth.
 
+Agent Coordination adds a thin work-item layer on top of Agent Ops. `agent_work_items` is the shared assignment bus for cross-runtime work packets, branch/worktree ownership, blockers, PR links, validation summaries, and gated merge/deploy states. It does not replace `agent_runs`; every work item links back to a trace and records state changes as Agent Ops events. Handoffs continue to flow through `agent_handoffs`.
+
 ## Product Definition
 
 Agent Operations is done when Vambah can:

--- a/lib/admin-nav.ts
+++ b/lib/admin-nav.ts
@@ -67,6 +67,7 @@ export const ADMIN_NAV: { dashboard: AdminNavItem; categories: AdminNavCategory[
         { label: 'Cost & Revenue', href: '/admin/cost-revenue' },
         { label: 'Subscription Watch', href: '/admin/subscriptions' },
         { label: 'Agent Operations', href: '/admin/agents' },
+        { label: 'Agent Coordination', href: '/admin/agents/coordination' },
         { label: 'Client Swarm Board', href: '/admin/agents/swarm-board' },
         { label: 'Automation Context', href: '/admin/agents/automations' },
         { label: 'Technology Bakeoffs', href: '/admin/technology-bakeoffs' },

--- a/lib/agent-slack-command.test.ts
+++ b/lib/agent-slack-command.test.ts
@@ -25,6 +25,13 @@ const inboxMocks = vi.hoisted(() => ({
   routeAgentInboxItem: vi.fn(),
 }))
 
+const workItemMocks = vi.hoisted(() => ({
+  listAgentWorkItems: vi.fn(),
+  getAgentWorkItem: vi.fn(),
+  claimAgentWorkItem: vi.fn(),
+  handoffAgentWorkItem: vi.fn(),
+}))
+
 vi.mock('@/lib/agent-run', () => ({
   startAgentRun: agentRunMocks.startAgentRun,
   recordAgentEvent: agentRunMocks.recordAgentEvent,
@@ -45,12 +52,25 @@ vi.mock('@/lib/agent-inbox-routing', () => ({
   routeAgentInboxItem: inboxMocks.routeAgentInboxItem,
 }))
 
+vi.mock('@/lib/agent-work-items', () => ({
+  listAgentWorkItems: workItemMocks.listAgentWorkItems,
+  getAgentWorkItem: workItemMocks.getAgentWorkItem,
+  claimAgentWorkItem: workItemMocks.claimAgentWorkItem,
+  handoffAgentWorkItem: workItemMocks.handoffAgentWorkItem,
+}))
+
 import {
   agentSlackCommandInternals,
+  buildAgentBlockersSlackText,
   buildAgentBriefSlackText,
   buildAgentEngagementQueueSlackText,
+  buildAgentPrsSlackText,
+  buildAgentWorkItemsSlackText,
+  buildCaptainQueueSlackText,
+  claimAgentWorkItemSlackText,
   buildAgentInboxSlackText,
   createAgentEngagementSlackText,
+  handoffAgentWorkItemSlackText,
   routeAgentInboxSlackText,
   runWarRoomStandupSlackText,
 } from '@/lib/agent-slack-command'
@@ -71,8 +91,13 @@ describe('agent Slack command parsing', () => {
     expect(agentSlackCommandInternals.commandFromText('agents')).toBe('agents')
     expect(agentSlackCommandInternals.commandFromText('list')).toBe('agents')
     expect(agentSlackCommandInternals.commandFromText('engagements')).toBe('engagements')
-    expect(agentSlackCommandInternals.commandFromText('work')).toBe('engagements')
+    expect(agentSlackCommandInternals.commandFromText('work')).toBe('work-items')
     expect(agentSlackCommandInternals.commandFromText('queue')).toBe('engagements')
+    expect(agentSlackCommandInternals.commandFromText('claim work-1')).toBe('claim')
+    expect(agentSlackCommandInternals.commandFromText('handoff work-1 automation-systems')).toBe('handoff')
+    expect(agentSlackCommandInternals.commandFromText('blockers')).toBe('blockers')
+    expect(agentSlackCommandInternals.commandFromText('prs')).toBe('prs')
+    expect(agentSlackCommandInternals.commandFromText('captain')).toBe('captain')
     expect(agentSlackCommandInternals.commandFromText('inbox')).toBe('inbox')
     expect(agentSlackCommandInternals.commandFromText('brief')).toBe('brief')
     expect(agentSlackCommandInternals.commandFromText('route 1')).toBe('route')
@@ -87,6 +112,8 @@ describe('agent Slack command parsing', () => {
     expect(agentSlackCommandInternals.formatHelp()).toContain('/agent status')
     expect(agentSlackCommandInternals.formatHelp()).toContain('/agent run <agent-key>')
     expect(agentSlackCommandInternals.formatHelp()).toContain('/agent engagements')
+    expect(agentSlackCommandInternals.formatHelp()).toContain('/agent work [id]')
+    expect(agentSlackCommandInternals.formatHelp()).toContain('/agent captain')
     expect(agentSlackCommandInternals.formatHelp()).toContain('/agent inbox')
     expect(agentSlackCommandInternals.formatHelp()).toContain('/agent route <number-or-id>')
     expect(agentSlackCommandInternals.formatHelp()).toContain('/agent standup')
@@ -277,5 +304,135 @@ describe('agent Slack command parsing', () => {
     }))
     expect(text).toContain('Agent Inbox item routed')
     expect(text).toContain('/admin/agents/runs/route-run')
+  })
+
+  it('formats active coordination work items for Slack', async () => {
+    workItemMocks.listAgentWorkItems.mockResolvedValue([
+      {
+        id: 'work-1',
+        title: 'Coordinate feature',
+        objective: 'Build the substrate',
+        status: 'ready_for_review',
+        owner_agent_key: 'chief-of-staff',
+        owner_runtime: 'codex',
+        branch_name: 'codex/agent-coordination-substrate',
+        pr_url: 'https://github.test/pull/1',
+        pr_number: 1,
+        approval_id: null,
+      },
+    ])
+
+    const text = await buildAgentWorkItemsSlackText({ text: 'work' })
+
+    expect(text).toContain('Agent coordination work')
+    expect(text).toContain('Coordinate feature')
+    expect(text).toContain('PR 1')
+    expect(text).toContain('/admin/agents/coordination')
+  })
+
+  it('formats one coordination work item for Slack', async () => {
+    workItemMocks.getAgentWorkItem.mockResolvedValue({
+      id: 'work-1',
+      title: 'Coordinate feature',
+      objective: 'Build the substrate',
+      status: 'blocked',
+      owner_agent_key: 'chief-of-staff',
+      owner_runtime: 'codex',
+      branch_name: null,
+      pr_url: null,
+      pr_number: null,
+      approval_id: null,
+      active_run_id: 'run-1',
+      blocker_summary: 'Needs captain review',
+      validation_summary: null,
+      latest_handoff: null,
+    })
+
+    const text = await buildAgentWorkItemsSlackText({ text: 'work work-1' })
+
+    expect(text).toContain('Agent work item')
+    expect(text).toContain('Needs captain review')
+    expect(text).toContain('/admin/agents/runs/run-1')
+  })
+
+  it('claims and hands off coordination work from Slack', async () => {
+    workItemMocks.claimAgentWorkItem.mockResolvedValue({
+      title: 'Coordinate feature',
+      objective: 'Build the substrate',
+      status: 'assigned',
+      owner_agent_key: 'automation-systems',
+      owner_runtime: 'codex',
+      branch_name: null,
+      pr_url: null,
+      pr_number: null,
+      approval_id: null,
+      active_run_id: 'run-1',
+    })
+    const claimText = await claimAgentWorkItemSlackText({
+      text: 'claim work-1 automation-systems',
+      userName: 'vambah',
+    })
+    expect(workItemMocks.claimAgentWorkItem).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'work-1',
+      ownerAgentKey: 'automation-systems',
+    }))
+    expect(claimText).toContain('Agent work item claimed')
+
+    workItemMocks.handoffAgentWorkItem.mockResolvedValue({
+      handoffId: 'handoff-1',
+      workItem: {
+        title: 'Coordinate feature',
+        objective: 'Build the substrate',
+        status: 'assigned',
+        owner_agent_key: 'integration-captain',
+        owner_runtime: 'codex',
+        branch_name: null,
+        pr_url: null,
+        pr_number: null,
+        approval_id: null,
+        active_run_id: 'run-2',
+      },
+    })
+    const handoffText = await handoffAgentWorkItemSlackText({
+      text: 'handoff work-1 integration-captain ready for review',
+      userName: 'vambah',
+    })
+    expect(workItemMocks.handoffAgentWorkItem).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'work-1',
+      toAgentKey: 'integration-captain',
+    }))
+    expect(handoffText).toContain('Agent work item handed off')
+    expect(handoffText).toContain('handoff-1')
+  })
+
+  it('formats blocker, PR, and captain queues', async () => {
+    workItemMocks.listAgentWorkItems.mockResolvedValue([
+      {
+        title: 'Blocked feature',
+        objective: 'Needs credentials',
+        status: 'blocked',
+        owner_agent_key: 'chief-of-staff',
+        owner_runtime: 'codex',
+        branch_name: null,
+        pr_url: null,
+        pr_number: null,
+        approval_id: 'approval-1',
+      },
+      {
+        title: 'Review feature',
+        objective: 'Review PR',
+        status: 'ready_for_merge',
+        owner_agent_key: 'chief-of-staff',
+        owner_runtime: 'codex',
+        branch_name: 'codex/review',
+        pr_url: 'https://github.test/pull/2',
+        pr_number: 2,
+        approval_id: null,
+      },
+    ])
+
+    await expect(buildAgentBlockersSlackText()).resolves.toContain('Blocked agent coordination work')
+    await expect(buildAgentPrsSlackText()).resolves.toContain('Coordination PR queue')
+    await expect(buildCaptainQueueSlackText()).resolves.toContain('Integration Captain queue')
   })
 })

--- a/lib/agent-slack-command.ts
+++ b/lib/agent-slack-command.ts
@@ -5,6 +5,13 @@ import { buildAgentMissionControlSnapshot } from '@/lib/agent-mission-control'
 import { runAgentWarRoom } from '@/lib/agent-war-room'
 import { AGENT_ORGANIZATION, getAgentByKey } from '@/lib/agent-organization'
 import { supabaseAdmin } from '@/lib/supabase'
+import {
+  claimAgentWorkItem,
+  getAgentWorkItem,
+  handoffAgentWorkItem,
+  listAgentWorkItems,
+  type AgentWorkItem,
+} from '@/lib/agent-work-items'
 
 type SlackCommandName =
   | 'help'
@@ -14,6 +21,12 @@ type SlackCommandName =
   | 'morning-review'
   | 'agents'
   | 'engagements'
+  | 'work-items'
+  | 'claim'
+  | 'handoff'
+  | 'blockers'
+  | 'prs'
+  | 'captain'
   | 'inbox'
   | 'brief'
   | 'route'
@@ -69,6 +82,10 @@ function agentRunsUrl(runId?: string) {
   return `${baseUrl()}/admin/agents/runs${runId ? `/${runId}` : ''}`
 }
 
+function agentCoordinationUrl() {
+  return `${baseUrl()}/admin/agents/coordination`
+}
+
 function since24h() {
   return new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
 }
@@ -81,8 +98,14 @@ function commandFromText(text: string): SlackCommandName {
   if (command === 'approval' || command === 'approvals') return 'approvals'
   if (command === 'morning-review' || command === 'morning' || command === 'review') return 'morning-review'
   if (command === 'agents' || command === 'list') return 'agents'
-  if (command === 'engagements' || command === 'work' || command === 'queue') return 'engagements'
-  if (command === 'inbox' || command === 'queue') return 'inbox'
+  if (command === 'engagements' || command === 'queue') return 'engagements'
+  if (command === 'work') return 'work-items'
+  if (command === 'claim') return 'claim'
+  if (command === 'handoff') return 'handoff'
+  if (command === 'blockers') return 'blockers'
+  if (command === 'prs') return 'prs'
+  if (command === 'captain') return 'captain'
+  if (command === 'inbox') return 'inbox'
   if (command === 'brief') return 'brief'
   if (command === 'route') return 'route'
   if (command === 'run' || command === 'start') return 'run'
@@ -104,6 +127,12 @@ function formatHelp() {
     '`/agent morning-review` - run the approved Agent Ops morning review trace.',
     '`/agent agents` - list currently mapped agents and engagement keys.',
     '`/agent engagements` - show the latest routed engagement work queue.',
+    '`/agent work [id]` - show coordination work items or one work packet.',
+    '`/agent claim <id> [agent-key]` - claim a coordination work item.',
+    '`/agent handoff <id> <agent-key>` - request an agent-to-agent handoff.',
+    '`/agent blockers` - show blocked coordination work.',
+    '`/agent prs` - show work waiting on PR review or merge.',
+    '`/agent captain` - show the Integration Captain coordination queue.',
     '`/agent inbox` - show numbered Agent Inbox items.',
     '`/agent brief` - show the current Daily Operating Brief.',
     '`/agent route <number-or-id>` - route an Agent Inbox item through Chief of Staff.',
@@ -111,6 +140,127 @@ function formatHelp() {
     '`/agent standup` - run a text War Room standup across active/partial agents.',
     '`/agent discuss <question>` - gather agent perspectives and a Chief of Staff synthesis.',
   ].join('\n')
+}
+
+function formatWorkItemLine(item: AgentWorkItem, index?: number) {
+  const number = typeof index === 'number' ? `${index + 1}. ` : '- '
+  const owner = item.owner_agent_key ? `${item.owner_agent_key}/${item.owner_runtime}` : item.owner_runtime
+  const branch = item.branch_name ? ` branch=${item.branch_name}` : ''
+  const pr = item.pr_url ? ` <${item.pr_url}|PR ${item.pr_number ?? ''}>` : ''
+  const approval = item.approval_id ? ' approval-linked' : ''
+  return `${number}*${item.title}* [${item.status}/${owner}]${branch}${pr}${approval}\n   ${item.objective}`
+}
+
+export async function buildAgentWorkItemsSlackText(input: AgentSlackCommandInput) {
+  const [itemId] = commandArgs(input.text)
+  try {
+    if (itemId) {
+      const item = await getAgentWorkItem(itemId)
+      if (!item) return `Work item not found: \`${itemId}\``
+      return [
+        '*Agent work item*',
+        formatWorkItemLine(item),
+        item.blocker_summary ? `Blocker: ${item.blocker_summary}` : null,
+        item.validation_summary ? `Validation: ${item.validation_summary}` : null,
+        item.latest_handoff ? `Latest handoff: ${item.latest_handoff.from_agent_key ?? 'unknown'} -> ${item.latest_handoff.to_agent_key ?? 'unknown'}` : null,
+        item.active_run_id ? `Trace: ${agentRunsUrl(item.active_run_id)}` : null,
+        `Review: ${agentCoordinationUrl()}`,
+      ].filter(Boolean).join('\n')
+    }
+
+    const items = (await listAgentWorkItems({ limit: 8 }))
+      .filter((item) => !['merged', 'deployed', 'cancelled'].includes(item.status))
+      .slice(0, 8)
+    if (items.length === 0) return `No active agent coordination work items. Review: ${agentCoordinationUrl()}`
+    return ['*Agent coordination work*', ...items.map(formatWorkItemLine), `Review: ${agentCoordinationUrl()}`].join('\n')
+  } catch (error) {
+    return `Agent work lookup failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+  }
+}
+
+export async function claimAgentWorkItemSlackText(input: AgentSlackCommandInput) {
+  const [itemId, agentKeyArg] = commandArgs(input.text)
+  if (!itemId) return 'Missing work item. Use `/agent work`, then `/agent claim <id> [agent-key]`.'
+  const ownerAgentKey = agentKeyArg || 'manual-admin'
+  try {
+    const actor = input.userName || input.userId || 'Slack user'
+    const item = await claimAgentWorkItem({
+      id: itemId,
+      ownerAgentKey,
+      actorLabel: actor,
+    })
+    return [
+      '*Agent work item claimed*',
+      formatWorkItemLine(item),
+      item.active_run_id ? `Trace: ${agentRunsUrl(item.active_run_id)}` : `Review: ${agentCoordinationUrl()}`,
+    ].join('\n')
+  } catch (error) {
+    return `Agent work claim failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+  }
+}
+
+export async function handoffAgentWorkItemSlackText(input: AgentSlackCommandInput) {
+  const [itemId, toAgentKey, ...summaryParts] = commandArgs(input.text)
+  if (!itemId || !toAgentKey) return 'Missing handoff details. Use `/agent handoff <id> <agent-key> [summary]`.'
+  try {
+    const actor = input.userName || input.userId || 'Slack user'
+    const result = await handoffAgentWorkItem({
+      id: itemId,
+      toAgentKey,
+      fromAgentKey: 'manual-admin',
+      summary: summaryParts.join(' ').trim() || `${actor} requested handoff to ${toAgentKey}`,
+      acceptanceCriteria: 'Review the work packet, update status, and attach PR or blocker evidence.',
+    })
+    return [
+      '*Agent work item handed off*',
+      formatWorkItemLine(result.workItem),
+      result.handoffId ? `Handoff: ${result.handoffId}` : null,
+      result.workItem.active_run_id ? `Trace: ${agentRunsUrl(result.workItem.active_run_id)}` : `Review: ${agentCoordinationUrl()}`,
+    ].filter(Boolean).join('\n')
+  } catch (error) {
+    return `Agent work handoff failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+  }
+}
+
+export async function buildAgentBlockersSlackText() {
+  try {
+    const items = await listAgentWorkItems({ status: 'blocked', limit: 8 })
+    if (items.length === 0) return `No blocked coordination work. Review: ${agentCoordinationUrl()}`
+    return ['*Blocked agent coordination work*', ...items.map(formatWorkItemLine), `Review: ${agentCoordinationUrl()}`].join('\n')
+  } catch (error) {
+    return `Agent blocker lookup failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+  }
+}
+
+export async function buildAgentPrsSlackText() {
+  try {
+    const items = (await listAgentWorkItems({ limit: 50 }))
+      .filter((item) => item.status === 'ready_for_review' || item.status === 'ready_for_merge')
+      .slice(0, 8)
+    if (items.length === 0) return `No coordination PRs are waiting for review or merge. Review: ${agentCoordinationUrl()}`
+    return ['*Coordination PR queue*', ...items.map(formatWorkItemLine), `Review: ${agentCoordinationUrl()}`].join('\n')
+  } catch (error) {
+    return `Agent PR queue lookup failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+  }
+}
+
+export async function buildCaptainQueueSlackText() {
+  try {
+    const items = await listAgentWorkItems({ limit: 100 })
+    const review = items.filter((item) => item.status === 'ready_for_review' || item.status === 'ready_for_merge')
+    const blocked = items.filter((item) => item.status === 'blocked')
+    const approval = items.filter((item) => Boolean(item.approval_id))
+    return [
+      '*Integration Captain queue*',
+      `Review/merge candidates: ${review.length}`,
+      `Blocked: ${blocked.length}`,
+      `Approval-linked: ${approval.length}`,
+      review.slice(0, 5).map(formatWorkItemLine).join('\n') || 'No PR-ready work items.',
+      `Review: ${agentCoordinationUrl()}`,
+    ].join('\n')
+  } catch (error) {
+    return `Captain queue lookup failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+  }
 }
 
 export async function buildAgentEngagementQueueSlackText(limit = 5) {
@@ -493,19 +643,31 @@ export async function handleAgentSlackCommand(input: AgentSlackCommandInput): Pr
               ? formatAgentListSlackText()
               : command === 'engagements'
                 ? await buildAgentEngagementQueueSlackText()
-                : command === 'inbox'
-                  ? await buildAgentInboxSlackText()
-                  : command === 'brief'
-                    ? await buildAgentBriefSlackText()
-                    : command === 'route'
-                      ? await routeAgentInboxSlackText(input)
-                      : command === 'run'
-                        ? await createAgentEngagementSlackText(input)
-                        : command === 'standup'
-                          ? await runWarRoomStandupSlackText(input)
-                          : command === 'discuss'
-                            ? await runWarRoomDiscussSlackText(input)
-                            : formatHelp()
+                : command === 'work-items'
+                  ? await buildAgentWorkItemsSlackText(input)
+                  : command === 'claim'
+                    ? await claimAgentWorkItemSlackText(input)
+                    : command === 'handoff'
+                      ? await handoffAgentWorkItemSlackText(input)
+                      : command === 'blockers'
+                        ? await buildAgentBlockersSlackText()
+                        : command === 'prs'
+                          ? await buildAgentPrsSlackText()
+                          : command === 'captain'
+                            ? await buildCaptainQueueSlackText()
+                            : command === 'inbox'
+                              ? await buildAgentInboxSlackText()
+                              : command === 'brief'
+                                ? await buildAgentBriefSlackText()
+                                : command === 'route'
+                                  ? await routeAgentInboxSlackText(input)
+                                  : command === 'run'
+                                    ? await createAgentEngagementSlackText(input)
+                                    : command === 'standup'
+                                      ? await runWarRoomStandupSlackText(input)
+                                      : command === 'discuss'
+                                        ? await runWarRoomDiscussSlackText(input)
+                                        : formatHelp()
 
   return { responseType: 'ephemeral', text }
 }

--- a/lib/agent-work-items.test.ts
+++ b/lib/agent-work-items.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  fromMock: vi.fn(),
+  insertMock: vi.fn(),
+  updateMock: vi.fn(),
+  maybeSingleQueue: [] as Array<{ data: unknown; error: unknown }>,
+  singleQueue: [] as Array<{ data: unknown; error: unknown }>,
+  listQueue: [] as Array<{ data: unknown; error: unknown }>,
+  startAgentRun: vi.fn(),
+  recordAgentEvent: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.fromMock,
+  },
+}))
+
+vi.mock('@/lib/agent-run', () => ({
+  AGENT_RUNTIMES: ['codex', 'n8n', 'hermes', 'opencode', 'manual'],
+  startAgentRun: mocks.startAgentRun,
+  recordAgentEvent: mocks.recordAgentEvent,
+}))
+
+import {
+  attachAgentWorkItemPr,
+  cancelAgentWorkItem,
+  claimAgentWorkItem,
+  createAgentWorkItem,
+  handoffAgentWorkItem,
+  listAgentWorkItems,
+  recordAgentWorkItemBlocker,
+  recordAgentWorkItemValidation,
+} from './agent-work-items'
+
+function chain() {
+  const api = {
+    select: vi.fn(() => api),
+    eq: vi.fn(() => api),
+    in: vi.fn(() => api),
+    order: vi.fn(() => api),
+    limit: vi.fn(() => Promise.resolve(mocks.listQueue.shift() ?? { data: [], error: null })),
+    maybeSingle: vi.fn(() => Promise.resolve(mocks.maybeSingleQueue.shift() ?? { data: null, error: null })),
+    single: vi.fn(() => Promise.resolve(mocks.singleQueue.shift() ?? { data: { id: 'row-id' }, error: null })),
+    insert: mocks.insertMock.mockImplementation(() => api),
+    update: mocks.updateMock.mockImplementation(() => api),
+  }
+  return api
+}
+
+const baseItem = {
+  id: 'work-1',
+  title: 'Coordinate feature',
+  objective: 'Build the coordination layer',
+  status: 'queued',
+  priority: 'medium',
+  owner_agent_key: 'chief-of-staff',
+  owner_runtime: 'codex',
+  source_type: null,
+  source_id: null,
+  source_label: null,
+  source_run_id: null,
+  active_run_id: 'run-1',
+  parent_work_item_id: null,
+  branch_name: null,
+  worktree_path: null,
+  pr_number: null,
+  pr_url: null,
+  expected_files: [],
+  touched_files: [],
+  overlap_group: null,
+  dependency_ids: [],
+  blocker_summary: null,
+  validation_summary: null,
+  approval_id: null,
+  metadata: {},
+  idempotency_key: null,
+  created_at: '2026-05-09T00:00:00.000Z',
+  updated_at: '2026-05-09T00:00:00.000Z',
+  completed_at: null,
+}
+
+function queueExistingItem(item = baseItem) {
+  mocks.maybeSingleQueue.push({ data: item, error: null })
+  mocks.listQueue.push({ data: [], error: null })
+}
+
+describe('agent work item helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.maybeSingleQueue = []
+    mocks.singleQueue = []
+    mocks.listQueue = []
+    mocks.fromMock.mockImplementation(() => chain())
+    mocks.startAgentRun.mockResolvedValue({ id: 'run-1' })
+    mocks.recordAgentEvent.mockResolvedValue({ id: 'event-1' })
+  })
+
+  it('creates a trace-linked work item', async () => {
+    mocks.maybeSingleQueue.push({ data: null, error: null })
+    mocks.singleQueue.push({ data: { ...baseItem, id: 'work-1' }, error: null })
+
+    const result = await createAgentWorkItem({
+      title: 'Coordinate feature',
+      objective: 'Build the coordination layer',
+      ownerAgentKey: 'chief-of-staff',
+      ownerRuntime: 'codex',
+      expectedFiles: ['lib/agent-work-items.ts'],
+      idempotencyKey: 'coordination:1',
+    })
+
+    expect(result.id).toBe('work-1')
+    expect(mocks.startAgentRun).toHaveBeenCalledWith(expect.objectContaining({
+      kind: 'agent_work_item',
+      runtime: 'codex',
+      status: 'queued',
+    }))
+    expect(mocks.insertMock).toHaveBeenCalledWith(expect.objectContaining({
+      active_run_id: 'run-1',
+      expected_files: ['lib/agent-work-items.ts'],
+      idempotency_key: 'coordination:1',
+    }))
+    expect(mocks.recordAgentEvent).toHaveBeenCalledWith(expect.objectContaining({
+      eventType: 'agent_work_item_created',
+    }))
+  })
+
+  it('returns an existing idempotent work item', async () => {
+    mocks.maybeSingleQueue.push({ data: baseItem, error: null })
+
+    const result = await createAgentWorkItem({
+      title: 'Coordinate feature',
+      objective: 'Build the coordination layer',
+      idempotencyKey: 'coordination:1',
+    })
+
+    expect(result.id).toBe('work-1')
+    expect(mocks.startAgentRun).not.toHaveBeenCalled()
+  })
+
+  it('lists work items with optional filters', async () => {
+    mocks.listQueue.push({ data: [baseItem], error: null })
+
+    const result = await listAgentWorkItems({ status: 'queued', ownerAgentKey: 'chief-of-staff' })
+
+    expect(result).toHaveLength(1)
+    expect(mocks.fromMock).toHaveBeenCalledWith('agent_work_items')
+  })
+
+  it('claims, blocks, attaches PRs, and cancels work items', async () => {
+    queueExistingItem()
+    mocks.singleQueue.push({ data: { ...baseItem, status: 'assigned' }, error: null })
+    await expect(claimAgentWorkItem({ id: 'work-1', ownerAgentKey: 'chief-of-staff' })).resolves.toMatchObject({ status: 'assigned' })
+
+    queueExistingItem()
+    mocks.singleQueue.push({ data: { ...baseItem, status: 'blocked', blocker_summary: 'blocked' }, error: null })
+    await expect(recordAgentWorkItemBlocker({ id: 'work-1', blockerSummary: 'blocked' })).resolves.toMatchObject({ status: 'blocked' })
+
+    queueExistingItem()
+    mocks.singleQueue.push({ data: { ...baseItem, status: 'ready_for_review', pr_number: 12 }, error: null })
+    await expect(attachAgentWorkItemPr({ id: 'work-1', prNumber: 12, touchedFiles: ['lib/a.ts'] })).resolves.toMatchObject({ pr_number: 12 })
+
+    queueExistingItem()
+    mocks.singleQueue.push({ data: { ...baseItem, status: 'cancelled' }, error: null })
+    await expect(cancelAgentWorkItem({ id: 'work-1', reason: 'duplicate' })).resolves.toMatchObject({ status: 'cancelled' })
+  })
+
+  it('creates an approval checkpoint when validation marks work ready for merge', async () => {
+    queueExistingItem()
+    mocks.singleQueue.push(
+      { data: { id: 'approval-1' }, error: null },
+      { data: { ...baseItem, status: 'ready_for_merge', approval_id: 'approval-1' }, error: null },
+    )
+
+    const result = await recordAgentWorkItemValidation({
+      id: 'work-1',
+      validationSummary: 'Tests passed',
+      readyForMerge: true,
+    })
+
+    expect(result.status).toBe('ready_for_merge')
+    expect(mocks.fromMock).toHaveBeenCalledWith('agent_approvals')
+    expect(mocks.updateMock).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'waiting_for_approval',
+    }))
+  })
+
+  it('records handoffs through agent_handoffs', async () => {
+    queueExistingItem()
+    mocks.singleQueue.push(
+      { data: { id: 'handoff-1' }, error: null },
+      { data: { ...baseItem, owner_agent_key: 'automation-systems' }, error: null },
+    )
+
+    const result = await handoffAgentWorkItem({
+      id: 'work-1',
+      toAgentKey: 'automation-systems',
+      summary: 'Please continue implementation',
+    })
+
+    expect(result.handoffId).toBe('handoff-1')
+    expect(mocks.fromMock).toHaveBeenCalledWith('agent_handoffs')
+    expect(mocks.insertMock).toHaveBeenCalledWith(expect.objectContaining({
+      work_item_id: 'work-1',
+      to_agent_key: 'automation-systems',
+    }))
+  })
+
+  it('rejects invalid runtime and status values', async () => {
+    await expect(createAgentWorkItem({
+      title: 'Bad runtime',
+      objective: 'Bad runtime',
+      ownerRuntime: 'bad' as never,
+    })).rejects.toThrow('Invalid owner_runtime')
+
+    await expect(listAgentWorkItems({ status: 'bad' as never })).rejects.toThrow('Invalid work item status')
+  })
+})

--- a/lib/agent-work-items.ts
+++ b/lib/agent-work-items.ts
@@ -1,0 +1,603 @@
+import { getAgentByKey } from '@/lib/agent-organization'
+import {
+  AGENT_RUNTIMES,
+  recordAgentEvent,
+  startAgentRun,
+  type AgentRuntime,
+} from '@/lib/agent-run'
+import { supabaseAdmin } from '@/lib/supabase'
+
+export const AGENT_WORK_ITEM_STATUSES = [
+  'proposed',
+  'queued',
+  'assigned',
+  'in_progress',
+  'blocked',
+  'ready_for_review',
+  'ready_for_merge',
+  'merged',
+  'deployed',
+  'cancelled',
+] as const
+
+export const AGENT_WORK_ITEM_PRIORITIES = ['low', 'medium', 'high', 'urgent'] as const
+
+export type AgentWorkItemStatus = (typeof AGENT_WORK_ITEM_STATUSES)[number]
+export type AgentWorkItemPriority = (typeof AGENT_WORK_ITEM_PRIORITIES)[number]
+
+export type AgentWorkItem = {
+  id: string
+  title: string
+  objective: string
+  status: AgentWorkItemStatus
+  priority: AgentWorkItemPriority
+  owner_agent_key: string | null
+  owner_runtime: AgentRuntime
+  source_type: string | null
+  source_id: string | null
+  source_label: string | null
+  source_run_id: string | null
+  active_run_id: string | null
+  parent_work_item_id: string | null
+  branch_name: string | null
+  worktree_path: string | null
+  pr_number: number | null
+  pr_url: string | null
+  expected_files: string[]
+  touched_files: string[]
+  overlap_group: string | null
+  dependency_ids: string[]
+  blocker_summary: string | null
+  validation_summary: string | null
+  approval_id: string | null
+  metadata: Record<string, unknown>
+  idempotency_key: string | null
+  created_at: string
+  updated_at: string
+  completed_at: string | null
+}
+
+export type AgentWorkItemHandoff = {
+  id: string
+  run_id: string | null
+  work_item_id: string | null
+  from_agent_key: string | null
+  to_agent_key: string | null
+  handoff_type: string | null
+  summary: string | null
+  acceptance_criteria: string | null
+  status: string
+  created_at: string
+  accepted_at: string | null
+  completed_at: string | null
+  metadata: Record<string, unknown> | null
+}
+
+export type AgentWorkItemDetail = AgentWorkItem & {
+  latest_handoff: AgentWorkItemHandoff | null
+}
+
+type WorkItemSource = {
+  type?: string | null
+  id?: string | number | null
+  label?: string | null
+}
+
+export type CreateAgentWorkItemInput = {
+  title: string
+  objective: string
+  priority?: AgentWorkItemPriority
+  status?: Extract<AgentWorkItemStatus, 'proposed' | 'queued' | 'assigned' | 'in_progress'>
+  ownerAgentKey?: string | null
+  ownerRuntime?: AgentRuntime
+  source?: WorkItemSource
+  sourceRunId?: string | null
+  parentWorkItemId?: string | null
+  branchName?: string | null
+  worktreePath?: string | null
+  expectedFiles?: string[]
+  overlapGroup?: string | null
+  dependencyIds?: string[]
+  metadata?: Record<string, unknown>
+  idempotencyKey?: string | null
+}
+
+type WorkItemUpdate = Partial<{
+  status: AgentWorkItemStatus
+  priority: AgentWorkItemPriority
+  owner_agent_key: string | null
+  owner_runtime: AgentRuntime
+  source_type: string | null
+  source_id: string | null
+  source_label: string | null
+  source_run_id: string | null
+  active_run_id: string | null
+  parent_work_item_id: string | null
+  branch_name: string | null
+  worktree_path: string | null
+  pr_number: number | null
+  pr_url: string | null
+  expected_files: string[]
+  touched_files: string[]
+  overlap_group: string | null
+  dependency_ids: string[]
+  blocker_summary: string | null
+  validation_summary: string | null
+  approval_id: string | null
+  metadata: Record<string, unknown>
+  completed_at: string | null
+}>
+
+const APPROVAL_GATED_STATUSES: ReadonlySet<AgentWorkItemStatus> = new Set([
+  'ready_for_merge',
+  'merged',
+  'deployed',
+])
+
+function db() {
+  if (!supabaseAdmin) throw new Error('Database not available')
+  return supabaseAdmin
+}
+
+function assertRuntime(value: string): asserts value is AgentRuntime {
+  if (!AGENT_RUNTIMES.includes(value as AgentRuntime)) {
+    throw new Error(`Invalid owner_runtime: ${value}`)
+  }
+}
+
+function assertStatus(value: string): asserts value is AgentWorkItemStatus {
+  if (!AGENT_WORK_ITEM_STATUSES.includes(value as AgentWorkItemStatus)) {
+    throw new Error(`Invalid work item status: ${value}`)
+  }
+}
+
+function assertPriority(value: string): asserts value is AgentWorkItemPriority {
+  if (!AGENT_WORK_ITEM_PRIORITIES.includes(value as AgentWorkItemPriority)) {
+    throw new Error(`Invalid work item priority: ${value}`)
+  }
+}
+
+function cleanText(value: string, fallback: string) {
+  const trimmed = value.trim()
+  return trimmed || fallback
+}
+
+function normalizeStringArray(values: string[] | undefined) {
+  return Array.from(new Set((values ?? []).map((value) => value.trim()).filter(Boolean)))
+}
+
+function runtimeForAgent(agentKey: string | null | undefined, fallback: AgentRuntime): AgentRuntime {
+  const runtime = getAgentByKey(agentKey ?? '')?.primaryRuntime
+  if (runtime === 'codex' || runtime === 'n8n' || runtime === 'hermes' || runtime === 'manual') {
+    return runtime
+  }
+  return fallback
+}
+
+async function findWorkItemByIdempotencyKey(idempotencyKey?: string | null): Promise<AgentWorkItem | null> {
+  if (!idempotencyKey) return null
+  const { data, error } = await db()
+    .from('agent_work_items')
+    .select('*')
+    .eq('idempotency_key', idempotencyKey)
+    .maybeSingle()
+
+  if (error) throw new Error(`Failed to read work item: ${error.message}`)
+  return (data as AgentWorkItem | null) ?? null
+}
+
+export async function listAgentWorkItems(input: {
+  status?: AgentWorkItemStatus | null
+  ownerAgentKey?: string | null
+  limit?: number
+} = {}): Promise<AgentWorkItem[]> {
+  let query = db()
+    .from('agent_work_items')
+    .select('*')
+
+  if (input.status) {
+    assertStatus(input.status)
+    query = query.eq('status', input.status)
+  }
+  if (input.ownerAgentKey) {
+    query = query.eq('owner_agent_key', input.ownerAgentKey)
+  }
+
+  const { data, error } = await query
+    .order('updated_at', { ascending: false })
+    .limit(input.limit ?? 50)
+  if (error) throw new Error(`Failed to list work items: ${error.message}`)
+  return (data ?? []) as AgentWorkItem[]
+}
+
+export async function getAgentWorkItem(id: string): Promise<AgentWorkItemDetail | null> {
+  const { data, error } = await db()
+    .from('agent_work_items')
+    .select('*')
+    .eq('id', id)
+    .maybeSingle()
+
+  if (error) throw new Error(`Failed to read work item: ${error.message}`)
+  if (!data) return null
+
+  const { data: handoffs } = await db()
+    .from('agent_handoffs')
+    .select('*')
+    .eq('work_item_id', id)
+    .order('created_at', { ascending: false })
+    .limit(1)
+
+  return {
+    ...(data as AgentWorkItem),
+    latest_handoff: ((handoffs ?? [])[0] as AgentWorkItemHandoff | undefined) ?? null,
+  }
+}
+
+async function requireAgentWorkItem(id: string) {
+  const item = await getAgentWorkItem(id)
+  if (!item) throw new Error('Agent work item not found')
+  return item
+}
+
+async function createApprovalCheckpoint(item: AgentWorkItem, status: AgentWorkItemStatus) {
+  if (!item.active_run_id) return null
+  if (item.approval_id) return item.approval_id
+
+  const { data, error } = await db()
+    .from('agent_approvals')
+    .insert({
+      run_id: item.active_run_id,
+      approval_type: 'agent_work_item_merge',
+      status: 'pending',
+      requested_by_agent_key: item.owner_agent_key ?? null,
+      metadata: {
+        work_item_id: item.id,
+        requested_status: status,
+        branch_name: item.branch_name,
+        pr_number: item.pr_number,
+        pr_url: item.pr_url,
+      },
+    })
+    .select('id')
+    .single()
+
+  if (error || !data?.id) throw new Error(error?.message ?? 'Failed to create work item approval')
+
+  await db()
+    .from('agent_runs')
+    .update({
+      status: 'waiting_for_approval',
+      current_step: `Approval required: ${status}`,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', item.active_run_id)
+    .in('status', ['queued', 'running'])
+
+  return data.id as string
+}
+
+async function updateWorkItem(
+  item: AgentWorkItem,
+  patch: WorkItemUpdate,
+  event: { type: string; message: string; metadata?: Record<string, unknown> },
+) {
+  const status = patch.status ?? item.status
+  assertStatus(status)
+
+  const approvalId = APPROVAL_GATED_STATUSES.has(status)
+    ? await createApprovalCheckpoint(item, status)
+    : null
+
+  const nextPatch = {
+    ...patch,
+    ...(approvalId ? { approval_id: approvalId } : {}),
+    updated_at: new Date().toISOString(),
+  }
+
+  const { data, error } = await db()
+    .from('agent_work_items')
+    .update(nextPatch)
+    .eq('id', item.id)
+    .select('*')
+    .single()
+
+  if (error || !data) throw new Error(error?.message ?? 'Failed to update work item')
+
+  const runId = (data as AgentWorkItem).active_run_id ?? item.active_run_id
+  if (runId) {
+    await recordAgentEvent({
+      runId,
+      eventType: event.type,
+      severity: status === 'blocked' ? 'warning' : 'info',
+      message: event.message,
+      metadata: {
+        work_item_id: item.id,
+        status,
+        approval_id: approvalId,
+        ...(event.metadata ?? {}),
+      },
+      idempotencyKey: `${item.id}:${event.type}:${Date.now()}`,
+    }).catch(() => {})
+  }
+
+  return data as AgentWorkItem
+}
+
+export async function createAgentWorkItem(input: CreateAgentWorkItemInput): Promise<AgentWorkItem> {
+  const existing = await findWorkItemByIdempotencyKey(input.idempotencyKey)
+  if (existing) return existing
+
+  const ownerRuntime = input.ownerRuntime ?? runtimeForAgent(input.ownerAgentKey, 'manual')
+  assertRuntime(ownerRuntime)
+  const priority = input.priority ?? 'medium'
+  assertPriority(priority)
+  const status = input.status ?? (input.ownerAgentKey ? 'assigned' : 'queued')
+  assertStatus(status)
+
+  const title = cleanText(input.title, 'Untitled agent work item').slice(0, 240)
+  const objective = cleanText(input.objective, title)
+  const sourceId = input.source?.id == null ? null : String(input.source.id)
+  const run = await startAgentRun({
+    agentKey: input.ownerAgentKey ?? 'manual-admin',
+    runtime: ownerRuntime,
+    kind: 'agent_work_item',
+    title,
+    status: 'queued',
+    subject: {
+      type: input.source?.type ?? 'agent_work_item',
+      id: sourceId ?? input.idempotencyKey ?? title,
+      label: input.source?.label ?? title,
+    },
+    triggerSource: 'agent_coordination',
+    currentStep: `Work item ${status}`,
+    metadata: {
+      work_item_status: status,
+      owner_agent_key: input.ownerAgentKey ?? null,
+      ...(input.metadata ?? {}),
+    },
+    idempotencyKey: input.idempotencyKey ? `${input.idempotencyKey}:run` : null,
+  })
+
+  const { data, error } = await db()
+    .from('agent_work_items')
+    .insert({
+      title,
+      objective,
+      status,
+      priority,
+      owner_agent_key: input.ownerAgentKey ?? null,
+      owner_runtime: ownerRuntime,
+      source_type: input.source?.type ?? null,
+      source_id: sourceId,
+      source_label: input.source?.label ?? null,
+      source_run_id: input.sourceRunId ?? null,
+      active_run_id: run.id,
+      parent_work_item_id: input.parentWorkItemId ?? null,
+      branch_name: input.branchName ?? null,
+      worktree_path: input.worktreePath ?? null,
+      expected_files: normalizeStringArray(input.expectedFiles),
+      overlap_group: input.overlapGroup ?? null,
+      dependency_ids: input.dependencyIds ?? [],
+      metadata: input.metadata ?? {},
+      idempotency_key: input.idempotencyKey ?? null,
+    })
+    .select('*')
+    .single()
+
+  if (error || !data) {
+    if (error?.code === '23505') {
+      const retry = await findWorkItemByIdempotencyKey(input.idempotencyKey)
+      if (retry) return retry
+    }
+    throw new Error(error?.message ?? 'Failed to create work item')
+  }
+
+  await recordAgentEvent({
+    runId: run.id,
+    eventType: 'agent_work_item_created',
+    severity: 'info',
+    message: title,
+    metadata: { work_item_id: data.id, status },
+    idempotencyKey: input.idempotencyKey ? `${input.idempotencyKey}:created` : null,
+  }).catch(() => {})
+
+  return data as AgentWorkItem
+}
+
+export async function claimAgentWorkItem(input: {
+  id: string
+  ownerAgentKey: string
+  ownerRuntime?: AgentRuntime
+  actorLabel?: string | null
+}) {
+  const item = await requireAgentWorkItem(input.id)
+  const runtime = input.ownerRuntime ?? runtimeForAgent(input.ownerAgentKey, item.owner_runtime)
+  assertRuntime(runtime)
+  return updateWorkItem(
+    item,
+    {
+      status: 'assigned',
+      owner_agent_key: input.ownerAgentKey,
+      owner_runtime: runtime,
+      blocker_summary: null,
+    },
+    {
+      type: 'agent_work_item_claimed',
+      message: `${input.actorLabel ?? input.ownerAgentKey} claimed ${item.title}`,
+      metadata: { owner_agent_key: input.ownerAgentKey, owner_runtime: runtime },
+    },
+  )
+}
+
+export async function updateAgentWorkItemStatus(input: {
+  id: string
+  status: AgentWorkItemStatus
+  note?: string | null
+}) {
+  const item = await requireAgentWorkItem(input.id)
+  return updateWorkItem(
+    item,
+    {
+      status: input.status,
+      completed_at: ['merged', 'deployed', 'cancelled'].includes(input.status)
+        ? new Date().toISOString()
+        : null,
+    },
+    {
+      type: 'agent_work_item_status_updated',
+      message: input.note ?? `${item.title}: ${input.status}`,
+    },
+  )
+}
+
+export async function recordAgentWorkItemBlocker(input: { id: string; blockerSummary: string }) {
+  const item = await requireAgentWorkItem(input.id)
+  return updateWorkItem(
+    item,
+    { status: 'blocked', blocker_summary: input.blockerSummary },
+    {
+      type: 'agent_work_item_blocked',
+      message: input.blockerSummary,
+    },
+  )
+}
+
+export async function attachAgentWorkItemPr(input: {
+  id: string
+  prNumber?: number | null
+  prUrl?: string | null
+  branchName?: string | null
+  touchedFiles?: string[]
+}) {
+  const item = await requireAgentWorkItem(input.id)
+  return updateWorkItem(
+    item,
+    {
+      status: 'ready_for_review',
+      pr_number: input.prNumber ?? item.pr_number,
+      pr_url: input.prUrl ?? item.pr_url,
+      branch_name: input.branchName ?? item.branch_name,
+      touched_files: normalizeStringArray(input.touchedFiles ?? item.touched_files),
+    },
+    {
+      type: 'agent_work_item_pr_attached',
+      message: input.prUrl ?? input.branchName ?? `PR attached to ${item.title}`,
+      metadata: { pr_number: input.prNumber ?? item.pr_number, pr_url: input.prUrl ?? item.pr_url },
+    },
+  )
+}
+
+export async function recordAgentWorkItemValidation(input: {
+  id: string
+  validationSummary: string
+  readyForMerge?: boolean
+}) {
+  const item = await requireAgentWorkItem(input.id)
+  return updateWorkItem(
+    item,
+    {
+      status: input.readyForMerge ? 'ready_for_merge' : item.status,
+      validation_summary: input.validationSummary,
+    },
+    {
+      type: 'agent_work_item_validation_recorded',
+      message: input.validationSummary,
+    },
+  )
+}
+
+export async function handoffAgentWorkItem(input: {
+  id: string
+  toAgentKey: string
+  fromAgentKey?: string | null
+  handoffType?: string | null
+  summary: string
+  acceptanceCriteria?: string | null
+  toRuntime?: AgentRuntime
+  idempotencyKey?: string | null
+}) {
+  const item = await requireAgentWorkItem(input.id)
+  const runtime = input.toRuntime ?? runtimeForAgent(input.toAgentKey, item.owner_runtime)
+  assertRuntime(runtime)
+
+  const { data, error } = await db()
+    .from('agent_handoffs')
+    .insert({
+      run_id: item.active_run_id,
+      work_item_id: item.id,
+      from_agent_key: input.fromAgentKey ?? item.owner_agent_key,
+      to_agent_key: input.toAgentKey,
+      handoff_type: input.handoffType ?? 'agent_work_item_handoff',
+      summary: input.summary,
+      acceptance_criteria: input.acceptanceCriteria ?? null,
+      status: 'pending',
+      metadata: { owner_runtime: runtime },
+      idempotency_key: input.idempotencyKey ?? null,
+    })
+    .select('id')
+    .single()
+
+  if (error) {
+    if (error.code !== '23505') throw new Error(`Failed to record handoff: ${error.message}`)
+  }
+
+  const updated = await updateWorkItem(
+    item,
+    {
+      status: 'assigned',
+      owner_agent_key: input.toAgentKey,
+      owner_runtime: runtime,
+      blocker_summary: null,
+    },
+    {
+      type: 'agent_work_item_handed_off',
+      message: input.summary,
+      metadata: {
+        handoff_id: data?.id ?? null,
+        from_agent_key: input.fromAgentKey ?? item.owner_agent_key,
+        to_agent_key: input.toAgentKey,
+      },
+    },
+  )
+
+  return {
+    workItem: updated,
+    handoffId: (data?.id as string | undefined) ?? null,
+  }
+}
+
+export async function completeAgentWorkItem(input: {
+  id: string
+  status?: Extract<AgentWorkItemStatus, 'merged' | 'deployed'>
+  validationSummary?: string | null
+}) {
+  const item = await requireAgentWorkItem(input.id)
+  return updateWorkItem(
+    item,
+    {
+      status: input.status ?? 'deployed',
+      validation_summary: input.validationSummary ?? item.validation_summary,
+      completed_at: new Date().toISOString(),
+    },
+    {
+      type: 'agent_work_item_completed',
+      message: input.validationSummary ?? `${item.title}: complete`,
+    },
+  )
+}
+
+export async function cancelAgentWorkItem(input: { id: string; reason?: string | null }) {
+  const item = await requireAgentWorkItem(input.id)
+  return updateWorkItem(
+    item,
+    {
+      status: 'cancelled',
+      blocker_summary: input.reason ?? item.blocker_summary,
+      completed_at: new Date().toISOString(),
+    },
+    {
+      type: 'agent_work_item_cancelled',
+      message: input.reason ?? `${item.title}: cancelled`,
+    },
+  )
+}

--- a/supabase/migrations/20260509191244_agent_coordination_work_items.sql
+++ b/supabase/migrations/20260509191244_agent_coordination_work_items.sql
@@ -1,0 +1,104 @@
+-- Agent Coordination Substrate
+-- Adds a thin Agent Ops-native work layer for cross-runtime assignment,
+-- handoffs, blockers, PR linkage, and gated merge/deploy progression.
+
+CREATE TABLE IF NOT EXISTS public.agent_work_items (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  title TEXT NOT NULL,
+  objective TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'proposed'
+    CHECK (status IN (
+      'proposed',
+      'queued',
+      'assigned',
+      'in_progress',
+      'blocked',
+      'ready_for_review',
+      'ready_for_merge',
+      'merged',
+      'deployed',
+      'cancelled'
+    )),
+  priority TEXT NOT NULL DEFAULT 'medium'
+    CHECK (priority IN ('low', 'medium', 'high', 'urgent')),
+  owner_agent_key TEXT,
+  owner_runtime TEXT NOT NULL DEFAULT 'manual'
+    CHECK (owner_runtime IN ('codex', 'n8n', 'hermes', 'opencode', 'manual')),
+  source_type TEXT,
+  source_id TEXT,
+  source_label TEXT,
+  source_run_id UUID REFERENCES public.agent_runs(id) ON DELETE SET NULL,
+  active_run_id UUID REFERENCES public.agent_runs(id) ON DELETE SET NULL,
+  parent_work_item_id UUID REFERENCES public.agent_work_items(id) ON DELETE SET NULL,
+  branch_name TEXT,
+  worktree_path TEXT,
+  pr_number INTEGER,
+  pr_url TEXT,
+  expected_files TEXT[] NOT NULL DEFAULT '{}',
+  touched_files TEXT[] NOT NULL DEFAULT '{}',
+  overlap_group TEXT,
+  dependency_ids UUID[] NOT NULL DEFAULT '{}',
+  blocker_summary TEXT,
+  validation_summary TEXT,
+  approval_id UUID REFERENCES public.agent_approvals(id) ON DELETE SET NULL,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  idempotency_key TEXT UNIQUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  completed_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS agent_work_items_status_idx
+  ON public.agent_work_items(status, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS agent_work_items_owner_idx
+  ON public.agent_work_items(owner_agent_key, owner_runtime, status);
+
+CREATE INDEX IF NOT EXISTS agent_work_items_active_run_idx
+  ON public.agent_work_items(active_run_id);
+
+CREATE INDEX IF NOT EXISTS agent_work_items_source_run_idx
+  ON public.agent_work_items(source_run_id);
+
+ALTER TABLE public.agent_work_items ENABLE ROW LEVEL SECURITY;
+
+CREATE TABLE IF NOT EXISTS public.agent_handoffs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_id UUID REFERENCES public.agent_runs(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.agent_handoffs ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE IF EXISTS public.agent_handoffs
+  ADD COLUMN IF NOT EXISTS work_item_id UUID REFERENCES public.agent_work_items(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS from_agent_key TEXT,
+  ADD COLUMN IF NOT EXISTS to_agent_key TEXT,
+  ADD COLUMN IF NOT EXISTS handoff_type TEXT,
+  ADD COLUMN IF NOT EXISTS summary TEXT,
+  ADD COLUMN IF NOT EXISTS acceptance_criteria TEXT,
+  ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'accepted', 'completed', 'cancelled')),
+  ADD COLUMN IF NOT EXISTS accepted_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS completed_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  ADD COLUMN IF NOT EXISTS idempotency_key TEXT;
+
+CREATE INDEX IF NOT EXISTS agent_handoffs_work_item_idx
+  ON public.agent_handoffs(work_item_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS agent_handoffs_idempotency_key_idx
+  ON public.agent_handoffs(idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+COMMENT ON TABLE public.agent_work_items IS
+  'Durable Agent Ops-native work items for cross-runtime assignment, handoff, PR tracking, blockers, validation, and gated merge/deploy coordination.';
+
+COMMENT ON COLUMN public.agent_work_items.status IS
+  'Coordination status: proposed, queued, assigned, in_progress, blocked, ready_for_review, ready_for_merge, merged, deployed, or cancelled.';
+
+COMMENT ON COLUMN public.agent_work_items.approval_id IS
+  'Pending or decided approval checkpoint for gated merge/deploy progression.';
+
+COMMENT ON COLUMN public.agent_handoffs.work_item_id IS
+  'Optional Agent Coordination work item associated with this handoff.';


### PR DESCRIPTION
## Summary

- adds the Agent Ops-native `agent_work_items` coordination layer with linked runs, approvals, PR metadata, blockers, validation summaries, and handoff support
- adds shared `lib/agent-work-items.ts` helpers plus admin API routes for create/list/fetch/update/claim/handoff/block/PR/validation actions
- adds `/admin/agents/coordination` and extends `/agent` Slack commands for work, claim, handoff, blockers, PR queue, and captain queue status
- updates captain-sweep guidance and the Agent Ops roadmap to treat coordination work as gated, traceable, and non-automerge in v1

## Validation

- `vitest run lib/agent-work-items.test.ts lib/agent-slack-command.test.ts app/api/admin/agents/work-items/route.test.ts`
- `tsc --noEmit --pretty false`
- `npm run build`
- `git diff --check`

Build note: build passed using a temporary `.env.local` symlink from the main checkout, then the symlink was removed. The existing local env warning about `MOCK_N8N=false` and `N8N_DISABLE_OUTBOUND=false` appeared during build; no live workflow or customer-data smoke was run.

## Integration Notes

- Apply `supabase/migrations/20260509191244_agent_coordination_work_items.sql` before expecting `/admin/agents/coordination` or Slack work-item commands to persist data.
- The migration creates `agent_work_items`, enables RLS, and extends `agent_handoffs` for work-item handoffs.
- `ready_for_merge`, `merged`, and `deployed` status transitions create/link an `agent_approvals` checkpoint; v1 does not auto-merge or allow Slack-triggered production mutation.
- Local `supabase migration list --local` could not run because the local Supabase Postgres service was not listening on `127.0.0.1:54322`.
- Vercel contexts to verify after merge: `Vercel – portfolio` and `Vercel – portfolio-staging`.
