### PR TITLE
docs: add automation context runbooks

### DIFF
--- a/docs/automations/README.md
+++ b/docs/automations/README.md
@@ -1,0 +1,23 @@
+# Portfolio Automation Runbooks
+
+This folder holds repo-owned governing docs for Portfolio-related Codex automations. These files give future agents enough operating context to understand purpose, inputs, outputs, authority, and escalation before acting.
+
+These runbooks do not replace the local Codex automation TOML files under `~/.codex/automations`. They are Portfolio-facing context documents that repair missing governance references without writing to local operational state.
+
+## Active Repair Targets
+
+| Automation | Runbook | Category |
+| --- | --- | --- |
+| `portfolio-credential-rotation-due-report` | [`portfolio-credential-rotation-due-report.md`](./portfolio-credential-rotation-due-report.md) | Credentials |
+| `portfolio-credential-rotation-due-report-2` | [`portfolio-credential-rotation-due-report-2.md`](./portfolio-credential-rotation-due-report-2.md) | Credentials |
+| `codex-automation-notification-digest` | [`codex-automation-notification-digest.md`](./codex-automation-notification-digest.md) | Operations |
+| `codex-project-organization-monitor` | [`codex-project-organization-monitor.md`](./codex-project-organization-monitor.md) | Organization |
+| `daily-screen-recording-workflow-review` | [`daily-screen-recording-workflow-review.md`](./daily-screen-recording-workflow-review.md) | Operations |
+| `personality-corpus-report-monitor` | [`personality-corpus-report-monitor.md`](./personality-corpus-report-monitor.md) | Content/Voice |
+
+## Shared Rules
+
+- Keep local automation TOML files as the source of truth for schedule, prompt, model, and execution environment.
+- Keep this folder as the source of truth for repo-owned governing context.
+- Do not edit `~/.codex/automations`, `~/.codex/memories`, or Codex SQLite state from a Portfolio PR.
+- Any direct operational-state repair needs a separate approval step, backup plan, and explicit handoff.

--- a/docs/automations/codex-automation-notification-digest.md
+++ b/docs/automations/codex-automation-notification-digest.md
@@ -1,0 +1,36 @@
+# Codex Automation Notification Digest
+
+Automation id: `codex-automation-notification-digest`
+
+## Purpose
+
+Summarize local Codex automation notifications so Vambah can see meaningful changes without reviewing every automation artifact manually.
+
+## Operating Rhythm
+
+Recurring digest. Confirm the exact schedule from local Codex automation metadata.
+
+## Decisions Supported
+
+- Which automation notifications need attention.
+- Whether a digest item should become a repair packet, follow-up PR, or operational-state request.
+
+## Inputs
+
+- Local automation notification state, read-only.
+- [`../memory-context-organization-workflow.md`](../memory-context-organization-workflow.md)
+- Automation runbooks in this folder.
+
+## Authority Boundary
+
+Digest and triage only. Do not edit notification state, automation TOMLs, memory files, or repo docs from the digest without a separate scoped task.
+
+## Expected Outputs
+
+- Concise digest of meaningful automation notifications.
+- Clear no-change report when there is nothing material.
+- Follow-up recommendation for repo-owned docs or explicitly approved operational-state repair.
+
+## Escalation Trigger
+
+Escalate when repeated failures, high-risk credential items, duplicate automation conflicts, or missing local access prevent reliable digesting.

--- a/docs/automations/codex-project-organization-monitor.md
+++ b/docs/automations/codex-project-organization-monitor.md
@@ -1,0 +1,37 @@
+# Codex Project Organization Monitor
+
+Automation id: `codex-project-organization-monitor`
+
+## Purpose
+
+Detect drift between Portfolio's intended project root and the local Codex workspace or chat state.
+
+## Operating Rhythm
+
+Recurring organization drift check.
+
+## Decisions Supported
+
+- Whether active Codex work is rooted in Portfolio.
+- Whether a workspace-root repair is needed.
+- Whether a repo doc or instruction needs a clarification.
+
+## Inputs
+
+- [`organization-runbook.md`](./organization-runbook.md)
+- [`../memory-context-organization-workflow.md`](../memory-context-organization-workflow.md)
+- Local Codex workspace state, read-only.
+
+## Authority Boundary
+
+Read-only inspection and reporting. Do not edit Codex SQLite state, Desktop JSON state, generated chat folders, or memory files without explicit approval and backups.
+
+## Expected Outputs
+
+- Workspace-root status.
+- Drift finding with exact affected paths.
+- Repair packet when operational-state changes are required.
+
+## Escalation Trigger
+
+Escalate when active chats are outside Portfolio, when Codex Desktop reverts workspace roots, or when the repair requires local state edits.

--- a/docs/automations/content-voice-runbook.md
+++ b/docs/automations/content-voice-runbook.md
@@ -1,0 +1,34 @@
+# Content And Voice Automation Runbook
+
+Use this runbook for automations that inspect personality corpus reports, content voice drift, or content-system readiness.
+
+## Purpose
+
+Keep Portfolio-facing content and voice systems current without exposing private source material or raw corpus exports.
+
+## Decisions Supported
+
+- Whether the personality corpus changed materially.
+- Whether a content or voice report needs Vambah's attention.
+- Whether derived summaries need a repo-owned workflow update.
+
+## Inputs
+
+- [`docs/memory-context-organization-workflow.md`](../memory-context-organization-workflow.md)
+- Personality corpus reports and derived summaries, read-only.
+- Public-safe voice docs in the Portfolio repo.
+- Private corpus exports only as local source material, not quoted into reports.
+
+## Authority Boundary
+
+Agents may inspect derived summaries, report changes, and recommend doc updates. Agents must not quote private exports, move corpus files, or edit `~/.codex/memories` without explicit approval.
+
+## Expected Outputs
+
+- Short change report.
+- No-change confirmation when reports are stable.
+- Escalation note when private-source handling or migration drift needs review.
+
+## Escalation Trigger
+
+Escalate when private source material appears in a public artifact, corpus migration paths drift, or report generation fails repeatedly.

--- a/docs/automations/credentials-runbook.md
+++ b/docs/automations/credentials-runbook.md
@@ -1,0 +1,36 @@
+# Credentials Automation Runbook
+
+Use this runbook for Codex automations that inspect credential rotation readiness, due dates, or approval packets.
+
+## Purpose
+
+Protect Portfolio runtime credentials by keeping rotation status visible without exposing, rotating, revoking, or syncing secrets automatically.
+
+## Decisions Supported
+
+- Which credentials are due or overdue for rotation.
+- Whether a staging drill or production proposal packet is needed.
+- Whether duplicate credential-monitoring automations should be consolidated or kept with documented scope.
+
+## Inputs
+
+- [`docs/credential-management-system.md`](../credential-management-system.md)
+- [`docs/credential-rotation-runbook.md`](../credential-rotation-runbook.md)
+- [`docs/credential-rotation-map.md`](../credential-rotation-map.md)
+- [`docs/credential-inventory.json`](../credential-inventory.json)
+- Local Codex automation metadata under `~/.codex/automations`, read-only.
+
+## Authority Boundary
+
+Agents may inspect docs, produce status reports, and prepare approval packets. Agents must not print secrets, rotate secrets, revoke secrets, update runtime sinks, or edit local automation state without explicit approval.
+
+## Expected Outputs
+
+- Credential due report.
+- Duplicate-monitor finding when overlapping jobs exist.
+- Approval packet when production or client-impacting action is needed.
+- Clear statement of checks that could not run due to missing provider access.
+
+## Escalation Trigger
+
+Escalate to Vambah when a production credential is overdue, a secret may be exposed, duplicate jobs conflict, provider access is missing, or any rotation/revocation would affect production or client systems.

--- a/docs/automations/daily-screen-recording-workflow-review.md
+++ b/docs/automations/daily-screen-recording-workflow-review.md
@@ -1,0 +1,37 @@
+# Daily Screen Recording Workflow Review
+
+Automation id: `daily-screen-recording-workflow-review`
+
+## Purpose
+
+Review screen-recording workflow state and surface only meaningful operational issues or follow-up needs.
+
+## Operating Rhythm
+
+Daily review.
+
+## Decisions Supported
+
+- Whether the recording workflow is healthy.
+- Whether a failed or missing recording needs attention.
+- Whether the workflow needs repo documentation or an explicitly approved local-state repair.
+
+## Inputs
+
+- [`../memory-context-organization-workflow.md`](../memory-context-organization-workflow.md)
+- Relevant local workflow reports or state files, read-only.
+- Any repo-owned docs referenced by the workflow.
+
+## Authority Boundary
+
+Read-only review only. Do not move recordings, delete recordings, edit local automation state, or expose private screen content in repo artifacts.
+
+## Expected Outputs
+
+- Brief health report.
+- Missing/failed workflow finding when needed.
+- Follow-up packet for repo docs or operational-state repair.
+
+## Escalation Trigger
+
+Escalate when recordings contain sensitive material, the workflow repeatedly fails, source files are unavailable, or a fix requires local state changes.

--- a/docs/automations/organization-runbook.md
+++ b/docs/automations/organization-runbook.md
@@ -1,0 +1,34 @@
+# Organization Automation Runbook
+
+Use this runbook for Codex automations that inspect Portfolio workspace roots, chat placement, project naming, or context organization drift.
+
+## Purpose
+
+Keep Portfolio work attached to the real project root, `/Users/vambahsillah/Projects/Portfolio`, while treating `/Users/vambahsillah/Projects` as the parent container.
+
+## Decisions Supported
+
+- Whether active chats or workspace roots point at the wrong project.
+- Whether drift is informational or requires an explicit operational-state repair.
+- Whether a repo doc, workflow instruction, or local Codex state needs a scoped follow-up.
+
+## Inputs
+
+- [`docs/memory-context-organization-workflow.md`](../memory-context-organization-workflow.md)
+- [`../agents/enhancement-impact-preflight.md`](../agents/enhancement-impact-preflight.md)
+- `/Users/vambahsillah/.codex/state_5.sqlite`, read-only unless an approved repair step exists.
+- `/Users/vambahsillah/.codex/.codex-global-state.json`, read-only unless an approved repair step exists.
+
+## Authority Boundary
+
+Agents may inspect workspace roots, report active chat counts, and prepare repair plans. Agents must not rewrite Codex SQLite state or Desktop workspace JSON from a Portfolio PR.
+
+## Expected Outputs
+
+- Workspace-root status.
+- Drift report with exact paths.
+- Recommended repo doc updates or operational repair packet.
+
+## Escalation Trigger
+
+Escalate when active chats are rooted outside Portfolio, Codex Desktop keeps restoring the wrong root, or a repair would require editing Codex local state.

--- a/docs/automations/personality-corpus-report-monitor.md
+++ b/docs/automations/personality-corpus-report-monitor.md
@@ -1,0 +1,38 @@
+# Personality Corpus Report Monitor
+
+Automation id: `personality-corpus-report-monitor`
+
+## Purpose
+
+Monitor derived personality corpus reports and surface material changes while keeping private source exports protected.
+
+## Operating Rhythm
+
+Recurring report review. Confirm the exact schedule from local Codex automation metadata.
+
+## Decisions Supported
+
+- Whether the corpus report changed in a way that affects content work.
+- Whether a migration path, source map, or derived summary needs follow-up.
+- Whether Portfolio needs a repo-owned doc update.
+
+## Inputs
+
+- [`content-voice-runbook.md`](./content-voice-runbook.md)
+- [`../memory-context-organization-workflow.md`](../memory-context-organization-workflow.md)
+- Derived personality corpus reports, read-only.
+- Private source exports only as local source material; do not quote them.
+
+## Authority Boundary
+
+Read-only report monitoring. Do not edit `~/.codex/memories`, move corpus files, quote private exports, or alter automation TOMLs without explicit approval.
+
+## Expected Outputs
+
+- No-change summary when reports are stable.
+- Material-change summary when derived reports shift.
+- Repair packet when paths, governance, or privacy boundaries are missing.
+
+## Escalation Trigger
+
+Escalate when private content appears in a public artifact, corpus reports fail repeatedly, or the monitor runs outside the expected Portfolio governance boundary.

--- a/docs/automations/portfolio-credential-rotation-due-report-2.md
+++ b/docs/automations/portfolio-credential-rotation-due-report-2.md
@@ -1,0 +1,37 @@
+# Portfolio Credential Rotation Due Report 2
+
+Automation id: `portfolio-credential-rotation-due-report-2`
+
+## Purpose
+
+This automation appears to overlap with `portfolio-credential-rotation-due-report`. Keep it visible until Vambah or the integration captain decides whether to consolidate, rename, pause, or document a distinct scope.
+
+## Operating Rhythm
+
+Credential due review. Confirm the exact schedule from local Codex automation metadata before relying on timing.
+
+## Decisions Supported
+
+- Whether this job is a duplicate or a deliberately separate credential-reporting lane.
+- Whether one credential report should become authoritative.
+
+## Inputs
+
+- [`credentials-runbook.md`](./credentials-runbook.md)
+- [`portfolio-credential-rotation-due-report.md`](./portfolio-credential-rotation-due-report.md)
+- [`../credential-management-system.md`](../credential-management-system.md)
+- Local Codex automation metadata, read-only.
+
+## Authority Boundary
+
+Read-only review only. Do not pause, delete, edit, or reschedule this automation without a separate approved operational-state step.
+
+## Expected Outputs
+
+- Duplicate candidate finding.
+- Recommendation to consolidate, rename, or justify both jobs.
+- Approval packet if an operational-state change is requested.
+
+## Escalation Trigger
+
+Escalate when duplicate jobs produce conflicting reports or when consolidation would require editing `~/.codex/automations`.

--- a/docs/automations/portfolio-credential-rotation-due-report.md
+++ b/docs/automations/portfolio-credential-rotation-due-report.md
@@ -1,0 +1,39 @@
+# Portfolio Credential Rotation Due Report
+
+Automation id: `portfolio-credential-rotation-due-report`
+
+## Purpose
+
+Keep credential rotation due dates visible for Portfolio without rotating, revoking, syncing, or exposing secrets.
+
+## Operating Rhythm
+
+Weekly credential due review.
+
+## Decisions Supported
+
+- Which credentials need review now.
+- Whether a production approval packet is needed.
+- Whether duplicate credential reporting jobs should be consolidated.
+
+## Inputs
+
+- [`credentials-runbook.md`](./credentials-runbook.md)
+- [`../credential-management-system.md`](../credential-management-system.md)
+- [`../credential-rotation-runbook.md`](../credential-rotation-runbook.md)
+- [`../credential-rotation-map.md`](../credential-rotation-map.md)
+- [`../credential-inventory.json`](../credential-inventory.json)
+
+## Authority Boundary
+
+Read-only report generation only. Do not print, rotate, revoke, or sync secret values. Production-impacting action requires explicit approval.
+
+## Expected Outputs
+
+- Credential due report.
+- Duplicate-monitor note when another job overlaps.
+- Approval packet recommendation when required.
+
+## Escalation Trigger
+
+Escalate when production credentials are overdue, provider access is missing, or duplicate jobs disagree about status.

--- a/docs/memory-context-organization-workflow.md
+++ b/docs/memory-context-organization-workflow.md
@@ -62,6 +62,8 @@ Each packet includes:
 
 Use repair packets to decide which prompt, doc, skill, or runbook needs a scoped follow-up PR or an explicitly approved local-state update.
 
+Repo-owned automation runbooks now live under [`docs/automations/`](./automations/README.md). When a repair packet points at a missing governing doc, prefer adding or updating one of those runbooks before requesting any direct `~/.codex` automation edit.
+
 ## Enhancement Impact Preflight
 
 ### Enhancement Impact Preflight
@@ -89,6 +91,18 @@ Implementation update: `lib/chief-of-staff-chat.test.ts` also needed a fixture u
 - Overlap rating: green.
 - Coordination decision: Proceed in the dedicated memory organization worktree and keep changes limited to automation context dashboard, inventory, tests, and memory workflow docs.
 - Merge-order note: Can merge independently after integration-captain review; active PRs do not touch these files.
+
+### Enhancement Impact Preflight
+
+- Enhancement: Add repo-owned governing runbooks for automation repair packet targets.
+- User-facing surface: `/admin/agents/automations` repair packets and the linked Portfolio documentation trail.
+- Predicted files: `docs/automations/README.md`, `docs/automations/*-runbook.md`, `docs/automations/<automation-id>.md`, `docs/memory-context-organization-workflow.md`.
+- Shared routes/APIs/tables/helpers: none; docs only.
+- Active PRs or branches checked: no open PRs at implementation start; only `main` and this `codex/memory-context-runbooks` worktree were active.
+- Dirty worktree files checked: current `codex/memory-context-runbooks` worktree was clean before implementation.
+- Overlap rating: green.
+- Coordination decision: Proceed with repo-owned docs only. Do not edit dashboard code, shared helpers, local Codex memory, or local Codex automation state.
+- Merge-order note: Can merge independently after review because it adds governing docs only.
 
 ## Operating Boundary
 


### PR DESCRIPTION
## Summary

Adds repo-owned governing runbooks for the current automation repair packet targets.

- Adds `docs/automations/README.md` as the index for Portfolio automation runbooks.
- Adds shared category runbooks for credentials, organization, and content/voice automations.
- Adds per-automation runbooks for the six repair packet targets currently surfaced by the dashboard.
- Updates `docs/memory-context-organization-workflow.md` to route missing-governance repair packets toward repo-owned docs first.

## Enhancement Impact Preflight

- Enhancement: Add repo-owned governing runbooks for automation repair packet targets.
- User-facing surface: `/admin/agents/automations` repair packets and the linked Portfolio documentation trail.
- Predicted files: `docs/automations/README.md`, `docs/automations/*-runbook.md`, `docs/automations/<automation-id>.md`, `docs/memory-context-organization-workflow.md`.
- Shared routes/APIs/tables/helpers: none; docs only.
- Active PRs or branches checked: no open PRs at implementation start; only `main` and this `codex/memory-context-runbooks` worktree were active.
- Dirty worktree files checked: current `codex/memory-context-runbooks` worktree was clean before implementation.
- Overlap rating: green.
- Coordination decision: Proceeded with repo-owned docs only. Did not edit dashboard code, shared helpers, local Codex memory, or local Codex automation state.
- Merge-order note: Can merge independently after review because it adds governing docs only.

## Validation

- `npm run build:knowledge`
- `npx tsc --noEmit`
- `npx vitest run lib/codex-automation-inventory.test.ts app/api/admin/agents/automations/route.test.ts`
- `git diff --check`

## Operational State

No direct writes were made under `~/.codex/memories` or `~/.codex/automations`.

Read-only local automation inventory was inspected through the existing dashboard helper to identify repair packet targets. `npm ci` installed ignored local `node_modules` in this worktree so validation could run.
