### PR TITLE
feat: add Codex workspace root visibility

### DIFF
--- a/app/admin/agents/automations/page.tsx
+++ b/app/admin/agents/automations/page.tsx
@@ -108,6 +108,33 @@ type AutomationInventoryResponse = {
     sourceFile: string
     operationalBoundary: string
   }[]
+  workspaceRoots: {
+    available: boolean
+    reason?: string
+    generatedAt: string
+    expectedRoot: string
+    stateDatabase: string
+    globalStateFile: string
+    savedWorkspaceRoots: string[]
+    activeWorkspaceRoots: string[]
+    projectOrderRoots: string[]
+    threadRoots: {
+      cwd: string
+      activeCount: number
+      portfolioRoot: boolean
+    }[]
+    overview: {
+      activeThreads: number
+      portfolioThreads: number
+      nonPortfolioThreads: number
+      savedRootDrift: number
+      activeRootDrift: number
+      projectOrderDrift: number
+    }
+    health: AutomationContextHealth
+    warnings: string[]
+    operationalBoundary: string
+  }
 }
 
 const ALL = 'all'
@@ -251,6 +278,8 @@ function AgentAutomationsContent() {
               docWarnings={docWarnings}
             />
 
+            <WorkspaceRootVisibility report={inventory.workspaceRoots} />
+
             <MemoryOrganizationProgress progress={inventory.progress} />
 
             <div className="mb-6 inline-flex rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-1">
@@ -374,6 +403,96 @@ function AutomationTable({
         </tbody>
       </table>
     </div>
+  )
+}
+
+function WorkspaceRootVisibility({ report }: { report: AutomationInventoryResponse['workspaceRoots'] }) {
+  if (!report.available) {
+    return (
+      <section className="mb-6 rounded-lg border border-yellow-400/40 bg-yellow-500/10 p-5 text-yellow-100">
+        <div className="mb-2 flex items-center gap-2 font-medium">
+          <ShieldAlert size={18} />
+          Codex workspace-root visibility unavailable
+        </div>
+        <p className="text-sm">{report.reason || 'Local Codex workspace state could not be read from this environment.'}</p>
+        <p className="mt-3 text-xs text-yellow-100/80">Expected root: {report.expectedRoot}</p>
+      </section>
+    )
+  }
+
+  const driftCount = report.overview.nonPortfolioThreads + report.overview.savedRootDrift + report.overview.activeRootDrift + report.overview.projectOrderDrift
+
+  return (
+    <section className="mb-6 rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-5">
+      <div className="mb-4 flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="font-semibold text-radiant-gold">Codex Workspace Roots</h2>
+            <ContextBadge health={report.health} />
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Read-only view of Codex Desktop roots and active thread placement. Expected root: {report.expectedRoot}.
+          </p>
+        </div>
+        <div className="grid grid-cols-3 gap-2 text-right text-xs">
+          <DetailPill label="Active threads" value={String(report.overview.activeThreads)} />
+          <DetailPill label="Portfolio" value={String(report.overview.portfolioThreads)} />
+          <DetailPill label="Drift" value={String(driftCount)} />
+        </div>
+      </div>
+
+      {report.warnings.length > 0 ? (
+        <div className="mb-4 grid grid-cols-1 lg:grid-cols-2 gap-3">
+          {report.warnings.map((warning) => (
+            <div key={warning} className="rounded-lg border border-yellow-400/30 bg-yellow-500/10 p-3 text-sm text-yellow-100">
+              <div className="flex items-center gap-2"><AlertTriangle size={16} /> {warning}</div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="mb-4 rounded-lg border border-green-400/30 bg-green-500/10 p-3 text-sm text-green-100">
+          <div className="flex items-center gap-2"><CheckCircle2 size={16} /> Active Codex roots are aligned with Portfolio.</div>
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_360px] gap-4">
+        <div className="overflow-hidden rounded-lg border border-silicon-slate/70">
+          <table className="w-full text-sm">
+            <thead className="bg-silicon-slate/40 text-muted-foreground">
+              <tr>
+                <th className="text-left px-4 py-3 font-medium">Thread root</th>
+                <th className="text-left px-4 py-3 font-medium">Active chats</th>
+                <th className="text-left px-4 py-3 font-medium">Alignment</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-silicon-slate/60">
+              {report.threadRoots.length > 0 ? report.threadRoots.map((root) => (
+                <tr key={root.cwd}>
+                  <td className="px-4 py-3 break-all">{root.cwd}</td>
+                  <td className="px-4 py-3">{root.activeCount}</td>
+                  <td className="px-4 py-3">
+                    {root.portfolioRoot ? <ContextBadge health="green" /> : <ContextBadge health="yellow" />}
+                  </td>
+                </tr>
+              )) : (
+                <tr>
+                  <td className="px-4 py-3 text-muted-foreground" colSpan={3}>No active thread roots were found.</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="space-y-4 text-sm">
+          <ContextList label="Saved workspace roots" values={report.savedWorkspaceRoots} />
+          <ContextList label="Active workspace roots" values={report.activeWorkspaceRoots} />
+          <ContextList label="Project order roots" values={report.projectOrderRoots} />
+          <div className="rounded-lg border border-silicon-slate/60 bg-black/10 p-3 text-xs text-muted-foreground">
+            {report.operationalBoundary}
+          </div>
+        </div>
+      </div>
+    </section>
   )
 }
 

--- a/app/api/admin/agents/automations/route.test.ts
+++ b/app/api/admin/agents/automations/route.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   verifyAdmin: vi.fn(),
   isAuthError: vi.fn(),
   listCodexAutomationInventory: vi.fn(),
+  getCodexWorkspaceRootReport: vi.fn(),
 }))
 
 vi.mock('@/lib/auth-server', () => ({
@@ -13,6 +14,10 @@ vi.mock('@/lib/auth-server', () => ({
 
 vi.mock('@/lib/codex-automation-inventory', () => ({
   listCodexAutomationInventory: mocks.listCodexAutomationInventory,
+}))
+
+vi.mock('@/lib/codex-workspace-roots', () => ({
+  getCodexWorkspaceRootReport: mocks.getCodexWorkspaceRootReport,
 }))
 
 import { GET } from './route'
@@ -48,6 +53,36 @@ describe('GET /api/admin/agents/automations', () => {
         highRisk: 0,
         missingContext: 0,
       },
+      progress: {
+        label: 'Memory and automation context readiness',
+        percent: 100,
+        completedTasks: 7,
+        totalTasks: 7,
+        tasks: [],
+      },
+      repairPackets: [],
+    })
+    mocks.getCodexWorkspaceRootReport.mockResolvedValue({
+      available: true,
+      generatedAt: '2026-05-03T00:00:00.000Z',
+      expectedRoot: '/Users/vambahsillah/Projects/Portfolio',
+      stateDatabase: '/Users/vambahsillah/.codex/state_5.sqlite',
+      globalStateFile: '/Users/vambahsillah/.codex/.codex-global-state.json',
+      savedWorkspaceRoots: ['/Users/vambahsillah/Projects/Portfolio'],
+      activeWorkspaceRoots: ['/Users/vambahsillah/Projects/Portfolio'],
+      projectOrderRoots: ['/Users/vambahsillah/Projects/Portfolio'],
+      threadRoots: [],
+      overview: {
+        activeThreads: 0,
+        portfolioThreads: 0,
+        nonPortfolioThreads: 0,
+        savedRootDrift: 0,
+        activeRootDrift: 0,
+        projectOrderDrift: 0,
+      },
+      health: 'green',
+      warnings: [],
+      operationalBoundary: 'Read-only workspace visibility.',
     })
   })
 
@@ -60,6 +95,7 @@ describe('GET /api/admin/agents/automations', () => {
     expect(response.status).toBe(401)
     expect(await response.json()).toEqual({ error: 'Unauthorized' })
     expect(mocks.listCodexAutomationInventory).not.toHaveBeenCalled()
+    expect(mocks.getCodexWorkspaceRootReport).not.toHaveBeenCalled()
   })
 
   it('returns the sanitized local automation inventory', async () => {
@@ -75,6 +111,10 @@ describe('GET /api/admin/agents/automations', () => {
         }),
       ],
       hiddenCount: 1,
+      workspaceRoots: expect.objectContaining({
+        expectedRoot: '/Users/vambahsillah/Projects/Portfolio',
+        health: 'green',
+      }),
     }))
   })
 })

--- a/app/api/admin/agents/automations/route.ts
+++ b/app/api/admin/agents/automations/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
 import { listCodexAutomationInventory } from '@/lib/codex-automation-inventory'
+import { getCodexWorkspaceRootReport } from '@/lib/codex-workspace-roots'
 
 export const dynamic = 'force-dynamic'
 export const runtime = 'nodejs'
@@ -11,6 +12,9 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: auth.error }, { status: auth.status })
   }
 
-  const inventory = await listCodexAutomationInventory()
-  return NextResponse.json(inventory)
+  const [inventory, workspaceRoots] = await Promise.all([
+    listCodexAutomationInventory(),
+    getCodexWorkspaceRootReport(),
+  ])
+  return NextResponse.json({ ...inventory, workspaceRoots })
 }

--- a/docs/memory-context-organization-workflow.md
+++ b/docs/memory-context-organization-workflow.md
@@ -64,6 +64,17 @@ Use repair packets to decide which prompt, doc, skill, or runbook needs a scoped
 
 Repo-owned automation runbooks now live under [`docs/automations/`](./automations/README.md). When a repair packet points at a missing governing doc, prefer adding or updating one of those runbooks before requesting any direct `~/.codex` automation edit.
 
+## Workspace-Root Visibility
+
+The dashboard also surfaces a read-only Codex workspace-root report. It compares the expected Portfolio root with:
+
+- Codex Desktop saved workspace roots,
+- Codex Desktop active workspace roots,
+- Codex project-order roots,
+- and active non-archived thread roots grouped by `cwd`.
+
+This report is for visibility and repair planning only. It must not rewrite `.codex-global-state.json`, `state_5.sqlite`, thread roots, or Desktop state from a Portfolio PR.
+
 ## Enhancement Impact Preflight
 
 ### Enhancement Impact Preflight
@@ -104,6 +115,18 @@ Implementation update: `lib/chief-of-staff-chat.test.ts` also needed a fixture u
 - Coordination decision: Proceed with repo-owned docs only. Do not edit dashboard code, shared helpers, local Codex memory, or local Codex automation state.
 - Merge-order note: Can merge independently after review because it adds governing docs only.
 
+### Enhancement Impact Preflight
+
+- Enhancement: Add read-only Codex workspace-root and active chat placement visibility to the Automation Context dashboard.
+- User-facing surface: `/admin/agents/automations`, under Agent Operations.
+- Predicted files: `app/admin/agents/automations/page.tsx`, `app/api/admin/agents/automations/route.ts`, `app/api/admin/agents/automations/route.test.ts`, `lib/codex-workspace-roots.ts`, `lib/codex-workspace-roots.test.ts`, `docs/memory-context-organization-workflow.md`.
+- Shared routes/APIs/tables/helpers: existing `/api/admin/agents/automations` response shape; no database tables, migrations, or mutating APIs.
+- Active PRs or branches checked: no open PRs at implementation start; only `main` and this `codex/workspace-root-visibility` worktree were active.
+- Dirty worktree files checked: current `codex/workspace-root-visibility` worktree was clean before implementation.
+- Overlap rating: green.
+- Coordination decision: Proceed in the dedicated memory organization worktree. Keep the report read-only and do not edit local Codex state.
+- Merge-order note: Can merge independently after review because there are no active overlapping PRs.
+
 ## Operating Boundary
 
 The dashboard may show that local operational state is missing or incomplete. It should not repair that state by itself.
@@ -114,6 +137,7 @@ Allowed:
 - Sanitize and summarize prompts.
 - Flag missing workspace roots, missing docs, missing authority boundaries, duplicates, and context gaps.
 - Show progress and task status computed from the inventory.
+- Show read-only Codex workspace-root and active thread placement drift.
 
 Not allowed in this workflow without an explicit operational-state step:
 

--- a/lib/codex-workspace-roots.test.ts
+++ b/lib/codex-workspace-roots.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { buildCodexWorkspaceRootReport } from './codex-workspace-roots'
+
+describe('buildCodexWorkspaceRootReport', () => {
+  it('reports green when workspace roots and active threads are under Portfolio', () => {
+    const report = buildCodexWorkspaceRootReport({
+      expectedRoot: '/Users/vambahsillah/Projects/Portfolio',
+      globalState: {
+        'electron-saved-workspace-roots': ['/Users/vambahsillah/Projects/Portfolio'],
+        'active-workspace-roots': ['/Users/vambahsillah/Projects/Portfolio'],
+        'project-order': ['/Users/vambahsillah/Projects/Portfolio'],
+      },
+      threadRoots: [
+        { cwd: '/Users/vambahsillah/Projects/Portfolio', activeCount: 12, portfolioRoot: true },
+        { cwd: '/Users/vambahsillah/Projects/Portfolio/docs', activeCount: 1, portfolioRoot: true },
+      ],
+    }, '2026-05-09T00:00:00.000Z')
+
+    expect(report.health).toBe('green')
+    expect(report.overview).toEqual(expect.objectContaining({
+      activeThreads: 13,
+      portfolioThreads: 13,
+      nonPortfolioThreads: 0,
+      savedRootDrift: 0,
+      activeRootDrift: 0,
+      projectOrderDrift: 0,
+    }))
+    expect(report.warnings).toEqual([])
+  })
+
+  it('reports drift without mutating Codex state', () => {
+    const report = buildCodexWorkspaceRootReport({
+      expectedRoot: '/Users/vambahsillah/Projects/Portfolio',
+      globalState: {
+        'electron-saved-workspace-roots': ['/Users/vambahsillah/Projects'],
+        'active-workspace-roots': ['/Users/vambahsillah/Projects/Work'],
+        'project-order': ['/Users/vambahsillah/Projects/Portfolio', '/Users/vambahsillah/Projects/Personal'],
+      },
+      threadRoots: [
+        { cwd: '/Users/vambahsillah/Projects/Portfolio', activeCount: 20, portfolioRoot: true },
+        { cwd: '/Users/vambahsillah/Projects', activeCount: 17, portfolioRoot: false },
+      ],
+    }, '2026-05-09T00:00:00.000Z')
+
+    expect(report.health).toBe('red')
+    expect(report.overview.nonPortfolioThreads).toBe(17)
+    expect(report.overview.savedRootDrift).toBe(1)
+    expect(report.overview.activeRootDrift).toBe(1)
+    expect(report.overview.projectOrderDrift).toBe(1)
+    expect(report.warnings).toEqual(expect.arrayContaining([
+      '1 saved workspace root(s) do not point at Portfolio.',
+      '1 active workspace root(s) do not point at Portfolio.',
+      '1 project-order root(s) do not point at Portfolio.',
+      '17 active thread(s) are rooted outside Portfolio.',
+    ]))
+    expect(report.operationalBoundary).toContain('Read-only workspace visibility')
+  })
+})

--- a/lib/codex-workspace-roots.ts
+++ b/lib/codex-workspace-roots.ts
@@ -1,0 +1,240 @@
+import { existsSync } from 'fs'
+import { readFile } from 'fs/promises'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import { homedir } from 'os'
+import path from 'path'
+
+const execFileAsync = promisify(execFile)
+
+export type CodexWorkspaceHealth = 'green' | 'yellow' | 'red'
+
+export interface CodexThreadRootSummary {
+  cwd: string
+  activeCount: number
+  portfolioRoot: boolean
+}
+
+export interface CodexWorkspaceRootReport {
+  available: boolean
+  reason?: string
+  generatedAt: string
+  expectedRoot: string
+  stateDatabase: string
+  globalStateFile: string
+  savedWorkspaceRoots: string[]
+  activeWorkspaceRoots: string[]
+  projectOrderRoots: string[]
+  threadRoots: CodexThreadRootSummary[]
+  overview: {
+    activeThreads: number
+    portfolioThreads: number
+    nonPortfolioThreads: number
+    savedRootDrift: number
+    activeRootDrift: number
+    projectOrderDrift: number
+  }
+  health: CodexWorkspaceHealth
+  warnings: string[]
+  operationalBoundary: string
+}
+
+type WorkspaceStateInput = {
+  globalState: Record<string, unknown> | null
+  threadRoots: CodexThreadRootSummary[]
+  expectedRoot?: string
+  stateDatabase?: string
+  globalStateFile?: string
+}
+
+const EXPECTED_PORTFOLIO_ROOT = '/Users/vambahsillah/Projects/Portfolio'
+const DEFAULT_CODEX_HOME = path.join(homedir(), '.codex')
+const WORKSPACE_ROOT_KEYS = {
+  saved: 'electron-saved-workspace-roots',
+  active: 'active-workspace-roots',
+  projectOrder: 'project-order',
+}
+
+export async function getCodexWorkspaceRootReport(codexHome = DEFAULT_CODEX_HOME): Promise<CodexWorkspaceRootReport> {
+  const generatedAt = new Date().toISOString()
+  const stateDatabase = path.join(codexHome, 'state_5.sqlite')
+  const globalStateFile = path.join(codexHome, '.codex-global-state.json')
+
+  if (!existsSync(codexHome)) {
+    return unavailableWorkspaceReport(generatedAt, stateDatabase, globalStateFile, 'Local Codex home is not available in this environment')
+  }
+
+  let globalState: Record<string, unknown> | null = null
+  if (existsSync(globalStateFile)) {
+    try {
+      globalState = JSON.parse(await readFile(globalStateFile, 'utf8')) as Record<string, unknown>
+    } catch {
+      return unavailableWorkspaceReport(generatedAt, stateDatabase, globalStateFile, 'Codex global state file is not readable JSON')
+    }
+  }
+
+  let threadRoots: CodexThreadRootSummary[] = []
+  if (existsSync(stateDatabase)) {
+    try {
+      threadRoots = await readThreadRootSummaries(stateDatabase)
+    } catch {
+      return unavailableWorkspaceReport(generatedAt, stateDatabase, globalStateFile, 'Codex thread database could not be queried read-only')
+    }
+  }
+
+  return buildCodexWorkspaceRootReport({
+    globalState,
+    threadRoots,
+    expectedRoot: EXPECTED_PORTFOLIO_ROOT,
+    stateDatabase,
+    globalStateFile,
+  }, generatedAt)
+}
+
+export function buildCodexWorkspaceRootReport(input: WorkspaceStateInput, generatedAt = new Date().toISOString()): CodexWorkspaceRootReport {
+  const expectedRoot = input.expectedRoot || EXPECTED_PORTFOLIO_ROOT
+  const stateDatabase = input.stateDatabase || path.join(DEFAULT_CODEX_HOME, 'state_5.sqlite')
+  const globalStateFile = input.globalStateFile || path.join(DEFAULT_CODEX_HOME, '.codex-global-state.json')
+  const savedWorkspaceRoots = extractRootList(input.globalState, WORKSPACE_ROOT_KEYS.saved)
+  const activeWorkspaceRoots = extractRootList(input.globalState, WORKSPACE_ROOT_KEYS.active)
+  const projectOrderRoots = extractRootList(input.globalState, WORKSPACE_ROOT_KEYS.projectOrder)
+  const threadRoots = input.threadRoots
+    .map((root) => ({
+      ...root,
+      portfolioRoot: isPortfolioRoot(root.cwd, expectedRoot),
+    }))
+    .sort((a, b) => b.activeCount - a.activeCount || a.cwd.localeCompare(b.cwd))
+
+  const activeThreads = threadRoots.reduce((sum, root) => sum + root.activeCount, 0)
+  const portfolioThreads = threadRoots.filter((root) => root.portfolioRoot).reduce((sum, root) => sum + root.activeCount, 0)
+  const nonPortfolioThreads = activeThreads - portfolioThreads
+  const savedRootDrift = countRootDrift(savedWorkspaceRoots, expectedRoot)
+  const activeRootDrift = countRootDrift(activeWorkspaceRoots, expectedRoot)
+  const projectOrderDrift = countRootDrift(projectOrderRoots, expectedRoot)
+  const warnings = buildWorkspaceWarnings({
+    savedWorkspaceRoots,
+    activeWorkspaceRoots,
+    projectOrderRoots,
+    threadRoots,
+    expectedRoot,
+    nonPortfolioThreads,
+    savedRootDrift,
+    activeRootDrift,
+    projectOrderDrift,
+  })
+
+  return {
+    available: Boolean(input.globalState || input.threadRoots.length > 0),
+    generatedAt,
+    expectedRoot,
+    stateDatabase,
+    globalStateFile,
+    savedWorkspaceRoots,
+    activeWorkspaceRoots,
+    projectOrderRoots,
+    threadRoots,
+    overview: {
+      activeThreads,
+      portfolioThreads,
+      nonPortfolioThreads,
+      savedRootDrift,
+      activeRootDrift,
+      projectOrderDrift,
+    },
+    health: classifyWorkspaceHealth(nonPortfolioThreads, savedRootDrift + activeRootDrift + projectOrderDrift),
+    warnings,
+    operationalBoundary: 'Read-only workspace visibility. Do not edit Codex SQLite, Desktop workspace JSON, or thread roots without an explicit operational-state repair step and backups.',
+  }
+}
+
+async function readThreadRootSummaries(stateDatabase: string): Promise<CodexThreadRootSummary[]> {
+  const query = [
+    'select cwd, count(*) active_count',
+    'from threads',
+    'where archived = 0',
+    'group by cwd',
+    'order by active_count desc;',
+  ].join(' ')
+  const { stdout } = await execFileAsync('sqlite3', ['-json', stateDatabase, query], { maxBuffer: 1024 * 1024 })
+  const rows = JSON.parse(stdout || '[]') as Array<{ cwd?: string; active_count?: number }>
+  return rows
+    .filter((row) => typeof row.cwd === 'string' && typeof row.active_count === 'number')
+    .map((row) => ({
+      cwd: row.cwd || '',
+      activeCount: row.active_count || 0,
+      portfolioRoot: isPortfolioRoot(row.cwd || '', EXPECTED_PORTFOLIO_ROOT),
+    }))
+}
+
+function extractRootList(globalState: Record<string, unknown> | null, key: string) {
+  const value = globalState?.[key]
+  if (!Array.isArray(value)) return []
+  return value.filter((item): item is string => typeof item === 'string')
+}
+
+function isPortfolioRoot(root: string, expectedRoot: string) {
+  return root === expectedRoot || root.startsWith(`${expectedRoot}/`)
+}
+
+function countRootDrift(roots: string[], expectedRoot: string) {
+  return roots.filter((root) => !isPortfolioRoot(root, expectedRoot)).length
+}
+
+function classifyWorkspaceHealth(nonPortfolioThreads: number, rootDrift: number): CodexWorkspaceHealth {
+  if (nonPortfolioThreads === 0 && rootDrift === 0) return 'green'
+  if (nonPortfolioThreads > 10 || rootDrift > 2) return 'red'
+  return 'yellow'
+}
+
+function buildWorkspaceWarnings(input: {
+  savedWorkspaceRoots: string[]
+  activeWorkspaceRoots: string[]
+  projectOrderRoots: string[]
+  threadRoots: CodexThreadRootSummary[]
+  expectedRoot: string
+  nonPortfolioThreads: number
+  savedRootDrift: number
+  activeRootDrift: number
+  projectOrderDrift: number
+}) {
+  const warnings: string[] = []
+  if (input.savedWorkspaceRoots.length === 0) warnings.push('No saved Codex Desktop workspace roots were found.')
+  if (input.activeWorkspaceRoots.length === 0) warnings.push('No active Codex Desktop workspace roots were found.')
+  if (input.savedRootDrift > 0) warnings.push(`${input.savedRootDrift} saved workspace root(s) do not point at Portfolio.`)
+  if (input.activeRootDrift > 0) warnings.push(`${input.activeRootDrift} active workspace root(s) do not point at Portfolio.`)
+  if (input.projectOrderDrift > 0) warnings.push(`${input.projectOrderDrift} project-order root(s) do not point at Portfolio.`)
+  if (input.nonPortfolioThreads > 0) warnings.push(`${input.nonPortfolioThreads} active thread(s) are rooted outside Portfolio.`)
+  if (!input.threadRoots.some((root) => root.cwd === input.expectedRoot)) warnings.push('No active thread group is rooted exactly at Portfolio.')
+  return warnings
+}
+
+function unavailableWorkspaceReport(
+  generatedAt: string,
+  stateDatabase: string,
+  globalStateFile: string,
+  reason: string,
+): CodexWorkspaceRootReport {
+  return {
+    available: false,
+    reason,
+    generatedAt,
+    expectedRoot: EXPECTED_PORTFOLIO_ROOT,
+    stateDatabase,
+    globalStateFile,
+    savedWorkspaceRoots: [],
+    activeWorkspaceRoots: [],
+    projectOrderRoots: [],
+    threadRoots: [],
+    overview: {
+      activeThreads: 0,
+      portfolioThreads: 0,
+      nonPortfolioThreads: 0,
+      savedRootDrift: 0,
+      activeRootDrift: 0,
+      projectOrderDrift: 0,
+    },
+    health: 'yellow',
+    warnings: [reason],
+    operationalBoundary: 'Read-only workspace visibility. Do not edit Codex SQLite, Desktop workspace JSON, or thread roots without an explicit operational-state repair step and backups.',
+  }
+}


### PR DESCRIPTION
## Summary

Adds read-only Codex workspace-root and active chat placement visibility to the Automation Context dashboard.

- Adds `lib/codex-workspace-roots.ts` to read local Codex Desktop roots and active thread cwd groups server-side.
- Extends `/api/admin/agents/automations` with a `workspaceRoots` report.
- Adds a Codex Workspace Roots panel to `/admin/agents/automations` with drift counts, warnings, thread-root table, and explicit read-only boundary.
- Documents the workspace-root visibility layer in the memory/context workflow doc.

## Enhancement Impact Preflight

- Enhancement: Add read-only Codex workspace-root and active chat placement visibility to the Automation Context dashboard.
- User-facing surface: `/admin/agents/automations`, under Agent Operations.
- Predicted files: `app/admin/agents/automations/page.tsx`, `app/api/admin/agents/automations/route.ts`, `app/api/admin/agents/automations/route.test.ts`, `lib/codex-workspace-roots.ts`, `lib/codex-workspace-roots.test.ts`, `docs/memory-context-organization-workflow.md`.
- Shared routes/APIs/tables/helpers: existing `/api/admin/agents/automations` response shape; no database tables, migrations, or mutating APIs.
- Active PRs or branches checked: no open PRs at implementation start; only `main` and this `codex/workspace-root-visibility` worktree were active.
- Dirty worktree files checked: current `codex/workspace-root-visibility` worktree was clean before implementation.
- Overlap rating: green.
- Coordination decision: Proceeded in the dedicated memory organization worktree. Kept the report read-only and did not edit local Codex state.
- Merge-order note: Can merge independently after review because there are no active overlapping PRs.

## Validation

- `npm run build:knowledge`
- `npx vitest run lib/codex-workspace-roots.test.ts lib/codex-automation-inventory.test.ts app/api/admin/agents/automations/route.test.ts`
- `npx tsc --noEmit`
- `git diff --check`
- Route smoke: `/admin/agents/automations` returned `200` after sourcing the main checkout `.env.local` into the dev-server process only.

## Live Read-Only Snapshot

The local workspace report currently shows:

- Health: `red`
- Active threads: `33`
- Portfolio-rooted threads: `8`
- Non-Portfolio threads: `25`
- Saved workspace root drift: `3`
- Active workspace root drift: `1`
- Project-order root drift: `3`

Top active thread roots:

- `/Users/vambahsillah/Projects`: `23`
- `/Users/vambahsillah/Projects/Portfolio`: `8`
- `/Users/vambahsillah/Documents/Codex/2026-04-30/i-have-quite-a-bit-of`: `1`
- `/Users/vambahsillah/Documents/Codex/2026-04-30/i-need-you-to-help-me`: `1`

## Operational State

No direct writes were made under `~/.codex/memories`, `~/.codex/automations`, `~/.codex/state_5.sqlite`, or `~/.codex/.codex-global-state.json`.

Read-only local state inspection used `~/.codex/state_5.sqlite` and `~/.codex/.codex-global-state.json`. `npm ci` installed ignored local `node_modules` in this worktree so validation could run. The main checkout `.env.local` was sourced into the dev-server process only for route smoke; it was not copied or modified.
