### PR TITLE
feat: extend credential reporting baseline workflow

### DIFF
--- a/app/admin/credentials/page.test.tsx
+++ b/app/admin/credentials/page.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ADMIN_NAV } from '@/lib/admin-nav'
 import CredentialAdminPage from './page'
 
 vi.mock('@/components/ProtectedRoute', () => ({
@@ -117,5 +118,18 @@ describe('CredentialAdminPage', () => {
       })
     })
     expect(await screen.findByText('Portfolio / prod')).toBeInTheDocument()
+  })
+
+  it('is linked from Configuration admin navigation', () => {
+    const configurationCategory = ADMIN_NAV.categories.find((category) => category.label === 'Configuration')
+
+    expect(configurationCategory?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: 'Credential Reporting',
+          href: '/admin/credentials',
+        }),
+      ])
+    )
   })
 })

--- a/docs/credential-management-system.md
+++ b/docs/credential-management-system.md
@@ -27,6 +27,8 @@ All commands read `docs/credential-inventory.json`.
 npm run credentials:list-due -- --env staging
 npm run credentials:report -- --env staging
 npm run credentials:report -- --env staging --json
+npm run credentials:baseline-template -- --env staging
+npm run credentials:baseline-template -- --env staging --json
 npm run credentials:inject -- --env staging -- npm run n8n:drift-check -- --warn
 npm run credentials:rotate -- --secret n8n-ingest-secret --env staging
 npm run credentials:sync-runtime -- --secret n8n-ingest-secret --env staging
@@ -39,6 +41,8 @@ The broker never prints raw secret values. Rotation packets are written to `.cre
 Use plain `credentials:smoke` for local registry checks. Use `--require-provider-access` after `op` and `infisical` are installed/authenticated; that mode fails unless the broker can read one scoped test secret from each source of truth without printing its value.
 
 Use `credentials:report` for rotation visibility. It is read-only and summarizes the inventory by status, source of truth, risk, runtime sink, approval boundary, and next action. It does not fetch or print secret values. The same report is exposed to admins at `/admin/credentials` through `/api/admin/credentials/report`.
+
+Use `credentials:baseline-template` when `credentials:report` shows `needs-baseline`. It emits provider-confirmation placeholders for each missing environment baseline so the operator can verify provider history, fill `lastRotatedAt`, preserve evidence, and update `docs/credential-inventory.json` without guessing from local env files.
 
 ## Rotation Rules
 

--- a/lib/admin-nav.ts
+++ b/lib/admin-nav.ts
@@ -91,6 +91,7 @@ export const ADMIN_NAV: { dashboard: AdminNavItem; categories: AdminNavCategory[
         { label: 'User Management', href: '/admin/users' },
         { label: 'System Prompts', href: '/admin/prompts' },
         { label: 'Module Sync', href: '/admin/module-sync' },
+        { label: 'Credential Reporting', href: '/admin/credentials' },
         { label: 'Email Preview', href: '/admin/email-preview' },
       ],
       expandableItemHref: '/admin/content',

--- a/lib/credential-report.test.ts
+++ b/lib/credential-report.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
-import { buildCredentialReport, renderCredentialReportMarkdown, type CredentialInventory } from './credential-report'
+import {
+  buildCredentialBaselineTemplate,
+  buildCredentialReport,
+  renderCredentialBaselineTemplateMarkdown,
+  renderCredentialReportMarkdown,
+  type CredentialInventory,
+} from './credential-report'
 
 const inventory: CredentialInventory = {
   schemaVersion: 1,
@@ -110,5 +116,27 @@ describe('credential report', () => {
     expect(markdown).not.toContain('super-secret')
 
     vi.useRealTimers()
+  })
+
+  it('builds a provider-confirmation template for missing baselines', () => {
+    const entries = buildCredentialBaselineTemplate(inventory, 'staging', '2026-05-09')
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({
+      secretId: 'missing-baseline',
+      envVar: 'MISSING_BASELINE',
+      sourceOfTruth: '1password',
+      baseline: {
+        status: 'pending-provider-confirmation',
+        lastRotatedAt: null,
+        updatedAt: '2026-05-09',
+      },
+    })
+    expect(entries[0].baseline.evidence).toContain('TODO: Confirm MISSING_BASELINE staging rotation date')
+
+    const markdown = renderCredentialBaselineTemplateMarkdown('staging', entries)
+    expect(markdown).toContain('Credential Baseline Template (staging)')
+    expect(markdown).toContain('MISSING_BASELINE')
+    expect(markdown).not.toContain('super-secret')
   })
 })

--- a/lib/credential-report.ts
+++ b/lib/credential-report.ts
@@ -97,6 +97,16 @@ export type CredentialReport = {
   rows: CredentialReportRow[]
 }
 
+export type CredentialBaselineTemplateEntry = {
+  secretId: string
+  envVar: string
+  displayName: string
+  sourceOfTruth: CredentialSourceOfTruth
+  baseline: CredentialBaseline
+  runtimeSinks: string[]
+  verification: string[]
+}
+
 export const CREDENTIAL_ENVS: CredentialEnvironment[] = ['dev', 'staging', 'prod']
 
 export function isCredentialEnvironment(value: string): value is CredentialEnvironment {
@@ -189,6 +199,59 @@ export function renderCredentialReportMarkdown(report: CredentialReport): string
     ].map(escapeTableCell).join(' | ')).map((line) => `| ${line} |`),
     '',
   ]
+
+  return `${lines.join('\n')}\n`
+}
+
+export function buildCredentialBaselineTemplate(
+  inventory: CredentialInventory,
+  env: CredentialEnvironment,
+  updatedAtInput: string | Date = new Date()
+): CredentialBaselineTemplateEntry[] {
+  const updatedAt = dateOnly(asDate(updatedAtInput))
+  return inventory.secrets
+    .filter((secret) => secret.environments.includes(env))
+    .filter((secret) => !getBaseline(secret, env).lastRotatedAt)
+    .map((secret) => ({
+      secretId: secret.id,
+      envVar: secret.envVar,
+      displayName: secret.displayName,
+      sourceOfTruth: secret.sourceOfTruth,
+      baseline: {
+        status: 'pending-provider-confirmation',
+        lastRotatedAt: null,
+        evidence: `TODO: Confirm ${secret.envVar} ${env} rotation date from ${secret.sourceOfTruth} history, provider dashboard/API, or approved rotation packet.`,
+        updatedAt,
+      },
+      runtimeSinks: secret.runtimeSinks,
+      verification: secret.verification.map((item) => item.split('{env}').join(env)),
+    }))
+}
+
+export function renderCredentialBaselineTemplateMarkdown(env: CredentialEnvironment, entries: CredentialBaselineTemplateEntry[]): string {
+  const lines = [
+    `# Credential Baseline Template (${env})`,
+    '',
+    'Use this as an editing checklist for `docs/credential-inventory.json`. Confirm provider history before replacing `lastRotatedAt` or evidence values.',
+    '',
+    `Missing baselines: ${entries.length}`,
+    '',
+  ]
+
+  for (const entry of entries) {
+    lines.push(
+      `## ${entry.envVar}`,
+      '',
+      `- Secret id: ${entry.secretId}`,
+      `- Source of truth: ${entry.sourceOfTruth}`,
+      `- Runtime sinks: ${entry.runtimeSinks.join(', ')}`,
+      '',
+      '```json',
+      JSON.stringify({ [env]: entry.baseline }, null, 2),
+      '```',
+      ''
+    )
+  }
 
   return `${lines.join('\n')}\n`
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "n8n:drift-check:warn": "tsx scripts/n8n-workflow-drift-check.ts -- --warn",
     "credentials:list-due": "tsx scripts/credential-broker.ts list-due",
     "credentials:report": "tsx scripts/credential-broker.ts report",
+    "credentials:baseline-template": "tsx scripts/credential-broker.ts baseline-template",
     "credentials:inject": "tsx scripts/credential-broker.ts inject",
     "credentials:rotate": "tsx scripts/credential-broker.ts rotate",
     "credentials:sync-runtime": "tsx scripts/credential-broker.ts sync-runtime",

--- a/scripts/credential-broker.ts
+++ b/scripts/credential-broker.ts
@@ -3,7 +3,12 @@ import { spawnSync } from 'node:child_process'
 import { createHash, randomBytes } from 'node:crypto'
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import * as path from 'node:path'
-import { buildCredentialReport, renderCredentialReportMarkdown } from '../lib/credential-report'
+import {
+  buildCredentialBaselineTemplate,
+  buildCredentialReport,
+  renderCredentialBaselineTemplateMarkdown,
+  renderCredentialReportMarkdown,
+} from '../lib/credential-report'
 
 type EnvironmentName = 'dev' | 'staging' | 'prod'
 type SourceOfTruth = 'infisical' | '1password'
@@ -96,6 +101,9 @@ function main() {
       break
     case 'report':
       report(inventory, args)
+      break
+    case 'baseline-template':
+      baselineTemplate(inventory, args)
       break
     case 'inject':
       inject(inventory, args)
@@ -212,6 +220,19 @@ function report(inventory: CredentialInventory, args: ParsedArgs) {
   }
 
   console.log(renderCredentialReportMarkdown(credentialReport))
+}
+
+function baselineTemplate(inventory: CredentialInventory, args: ParsedArgs) {
+  const env = getEnv(args)
+  const updatedAt = String(args.options['updated-at'] || new Date().toISOString())
+  const entries = buildCredentialBaselineTemplate(inventory, env, updatedAt)
+
+  if (args.options.json) {
+    console.log(JSON.stringify(entries, null, 2))
+    return
+  }
+
+  console.log(renderCredentialBaselineTemplateMarkdown(env, entries))
 }
 
 function inject(inventory: CredentialInventory, args: ParsedArgs) {
@@ -528,6 +549,7 @@ function printHelp() {
 Commands:
   list-due      --env <dev|staging|prod> [--as-of YYYY-MM-DD] [--json]
   report        --env <dev|staging|prod> [--as-of YYYY-MM-DD] [--json]
+  baseline-template --env <dev|staging|prod> [--updated-at YYYY-MM-DD] [--json]
   inject        --env <dev|staging|prod> [--secret id-or-envVar[,..]] -- <command>
   rotate        --env <dev|staging|prod> --secret <id-or-envVar> [--local-env .env.staging] [--length 48]
   sync-runtime  --env <dev|staging|prod> --secret <id-or-envVar> [--local-env .env.staging]


### PR DESCRIPTION
## Summary
- add Credential Reporting to the Configuration admin navigation after coordination
- add `credentials:baseline-template` for provider-confirmation baseline placeholders
- extend credential reporting tests for baseline templates and nav discoverability
- document the baseline-template workflow

## Validation
- `npm run build:knowledge`
- `npx tsc --noEmit --pretty false --skipLibCheck`
- `npx vitest run lib/credential-report.test.ts app/api/admin/credentials/report/route.test.ts app/admin/credentials/page.test.tsx --reporter=dot`
- `npm run lint -- --file lib/admin-nav.ts --file app/admin/credentials/page.tsx --file app/admin/credentials/page.test.tsx --file app/api/admin/credentials/report/route.ts --file app/api/admin/credentials/report/route.test.ts --file lib/credential-report.ts --file lib/credential-report.test.ts --file scripts/credential-broker.ts`
- `npx tsx scripts/credential-broker.ts baseline-template --env staging --json`

## Scope / overlap
- Owned scope: credential docs, broker/reporting scripts, credential admin/report surface
- Shared nav touched only after explicit roadmap approval
- Avoided Agent Ops files
- Overlap rating: medium-low