### PR TITLE
docs: make captain sweep multi-agent repeatable

### DIFF
--- a/commands/captain-sweep.md
+++ b/commands/captain-sweep.md
@@ -48,10 +48,43 @@ For each ready PR, process one at a time:
 1. Confirm the PR is not draft.
 2. Confirm the file set is scoped and does not mix unrelated work.
 3. Confirm hot surfaces have impact preflight, focused validation, or explicit sequencing.
-4. Run or verify focused tests appropriate to the touched files.
-5. Require `Vercel - portfolio` preview success before merge.
-6. Require staging-specific smoke only when the PR touches staging, n8n integration behavior, Vercel config, env handling, release gates, or another staging-sensitive surface.
-7. Merge only after checks and risks are clean.
+4. Classify the PR as docs-only, low-risk code, or hot-surface code.
+5. For non-docs PRs, run the Multi-Agent Review Gate before moving the work item to `ready_for_merge`.
+6. Run or verify focused tests appropriate to the touched files.
+7. Require `Vercel - portfolio` preview success before merge.
+8. Require staging-specific smoke only when the PR touches staging, n8n integration behavior, Vercel config, env handling, release gates, or another staging-sensitive surface.
+9. Merge only after checks and risks are clean.
+
+## Multi-Agent Review Gate
+
+Use this gate for every non-docs PR and for docs PRs that touch policies, runbooks, migrations, security posture, customer-facing commitments, or operational instructions.
+
+Launch three independent read-only review lanes before the captain makes the merge decision:
+
+1. `PR scope/risk reviewer`
+   - Inspect changed files, purpose, and blast radius.
+   - Classify the PR as docs-only, code/data-affecting, security-sensitive, migration/data-affecting, or workflow-affecting.
+   - Name the risks, evidence assumptions, and whether the PR is narrow enough to undraft or merge.
+2. `Validation planner`
+   - Infer the minimum focused validation from the changed files and package scripts.
+   - Name broader validation only when the blast radius justifies it.
+   - State which expensive/live checks can be skipped and why.
+3. `Agent Coordination auditor`
+   - Confirm the PR has exactly one Agent Coordination work item, or recommend the title/owner/status for one.
+   - Check overlap against other open PRs by touched file and overlap group.
+   - Recommend the next status transition and whether an approval checkpoint is needed.
+
+The captain owns synthesis:
+
+- Do not delegate the final merge decision.
+- Record the review result and exact validation commands in the work item's validation summary.
+- Keep the work item at `ready_for_review` while the PR is draft, checks are pending, or the review lanes disagree on a material risk.
+- Move the work item to `ready_for_merge` only after the captain validates the plan and creates the approval checkpoint.
+
+Docs-only fast path:
+
+- If the PR is clearly docs-only, does not change policy/runbook authority, and has no cross-PR overlap, the captain may skip subagents.
+- Still run `git diff --check` and verify the PR is not draft, scoped, and merge-clean.
 
 ## Post-Merge Gate
 

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -20,6 +20,8 @@ The goal is simple: workers can keep moving, but only one integration captain me
 
 Use `captain sweep` when Vambah wants the integration captain to inspect repo state, process ready PRs, verify GitHub/Vercel gates, and clean up conservatively. The command spec lives at `commands/captain-sweep.md`.
 
+For non-docs PRs, `captain sweep` now uses a repeatable multi-agent review gate before merge consideration. The Integration Captain keeps merge authority, but parallel read-only reviewers split scope/risk review, validation planning, and Agent Coordination audit so PRs are not merged from a single-thread judgment call.
+
 ## Roles
 
 | Role | File | Use When |

--- a/docs/agents/integration-captain.md
+++ b/docs/agents/integration-captain.md
@@ -53,6 +53,11 @@ Before merging a PR:
 - PR is not draft.
 - PR has a clear purpose and scoped file set.
 - PR has an impact preflight when it touches a hot surface or overlaps another active branch.
+- Non-docs PRs have passed the repeatable multi-agent review gate:
+  - PR scope/risk reviewer classifies blast radius and risks.
+  - Validation planner names focused and optional broader checks.
+  - Agent Coordination auditor confirms the work item, overlap group, and status transition.
+  - The captain synthesizes the three read-only reports and records the result in Agent Coordination.
 - Required validation is documented in the PR or handoff.
 - `Vercel - portfolio` preview is success.
 - `Vercel - portfolio-staging` preview is not required for routine PRs while the staging project has preview deployments disabled. If a PR explicitly changes staging env handling, n8n integration behavior, Vercel config, or release gates, require an equivalent staging smoke before merge.
@@ -135,6 +140,29 @@ If that command returns commits, classify the branch as `watch` or `debt` instea
 - Treat draft PRs as `normal` unless they overlap hot files, stay stale for several days, or their work already landed elsewhere.
 - Promote a draft PR to merge consideration only after the owner marks it ready or the captain verifies its intent directly.
 - If two PRs touch the same hot files, merge the lower-risk/shared-foundation PR first, then re-check the second PR against updated `main`.
+
+### Repeatable Multi-Agent Review
+
+Use parallel read-only reviewers when a PR changes code, generated data consumed by code, admin UI, runtime behavior, workflow configuration, security posture, or operational policy. The point is not more ceremony; it is to make the Integration Captain faster and less brittle by separating three kinds of judgment that are easy to blur in one thread.
+
+Required lanes:
+
+- `PR scope/risk reviewer`: changed files, blast radius, risks, evidence assumptions, and scope readiness.
+- `Validation planner`: minimum focused validation, optional broader validation, and safe skips.
+- `Agent Coordination auditor`: existing or needed work item, overlap group, PR attachment, blocker state, and next status transition.
+
+Captain synthesis:
+
+- Keep all lanes read-only.
+- Trust but reconcile the lane reports against current GitHub state.
+- Run the chosen validation locally or verify equivalent CI evidence.
+- Record a compact validation summary on the Agent Coordination work item before setting it to `ready_for_merge`.
+- Close subagents after their reports are incorporated.
+
+Fast path:
+
+- For simple docs-only PRs, use the single-captain path with `git diff --check`, PR scope review, and normal Vercel/deploy gates.
+- Escalate docs-only PRs into the multi-agent gate when they change governance, approval rules, runbooks, security instructions, or public/customer commitments.
 
 ### Hot File Awareness
 


### PR DESCRIPTION
## Summary
- adds a repeatable Multi-Agent Review Gate to `captain sweep`
- documents the three read-only lanes: scope/risk reviewer, validation planner, and Agent Coordination auditor
- updates the Integration Captain role and agent-role index so the protocol is discoverable outside the command file

## Validation
- `git diff --check`

## Integration Notes
- Docs/protocol-only change.
- No runtime code, migrations, live workflow, or customer-data smoke was run.
- Agent Coordination work item: `c494435d-015a-4730-a4fd-1fdf8dc229d9`.
- Standard deployment verification should still check both `Vercel – portfolio` and `Vercel – portfolio-staging` after merge.