### PR TITLE
feat: add client AI org board projections

### DIFF
--- a/lib/agent-swarm-board.test.ts
+++ b/lib/agent-swarm-board.test.ts
@@ -283,6 +283,50 @@ describe('buildAgentSwarmBoardSnapshotFromRows', () => {
     ]))
     expect(card.connectorNextAction).toContain('setup packet')
   })
+
+  it('uses org-board metadata before title inference for client swarm placement', () => {
+    const snapshot = buildAgentSwarmBoardSnapshotFromRows({
+      projects: [project],
+      roadmaps: [roadmap],
+      tasks: [
+        {
+          id: 'task-structured',
+          roadmap_id: 'roadmap-1',
+          task_key: 'plain-task',
+          title: 'Plain task with no routing keywords',
+          status: 'pending',
+          priority: 'medium',
+          owner_type: 'amadutown',
+          due_date: null,
+          metadata: {
+            org_board: {
+              column: 'qa_isolation',
+              stage: 'qa_isolation',
+              owner_agent_key: 'engineering-copilot',
+              owner_agent_label: 'Engineering Copilot Agent',
+              approval_posture: 'required',
+              isolation_required: true,
+              internal_handoff_label: 'Run synthetic validation packet',
+            },
+          },
+        },
+      ],
+      reports: [],
+      runs: [],
+      approvals: [],
+    })
+
+    const qaColumn = snapshot.columns.find((item) => item.key === 'qa_isolation')
+    expect(qaColumn?.cards).toHaveLength(1)
+    expect(qaColumn?.cards[0]).toMatchObject({
+      currentAgentKey: 'engineering-copilot',
+      currentAgentLabel: 'Engineering Copilot Agent',
+      nextAction: 'Run synthetic validation packet',
+      approvalState: 'required',
+      isolationStatus: 'pending',
+      riskLabel: 'approval required before side effects',
+    })
+  })
 })
 
 describe('buildAgentOrgBoardSnapshotFromRows', () => {

--- a/lib/agent-swarm-board.ts
+++ b/lib/agent-swarm-board.ts
@@ -218,6 +218,16 @@ type RoadmapTaskRow = {
   metadata: JsonRecord | null
 }
 
+type RoadmapTaskOrgBoardMetadata = {
+  column?: SwarmBoardColumnKey
+  owner_agent_key?: string
+  owner_agent_label?: string
+  approval_posture?: 'none' | 'required' | 'pending'
+  isolation_required?: boolean
+  internal_handoff_label?: string
+  client_visible_label?: string
+}
+
 type RoadmapReportRow = {
   roadmap_id: string
   report_type: string
@@ -367,6 +377,8 @@ function isolationStatusFromRoadmap(roadmap: RoadmapRow | null, tasks: RoadmapTa
   const snapshotStatus = stringValue(roadmap?.snapshot?.isolation_status)
   if (snapshotStatus === 'passed' || snapshotStatus === 'failed' || snapshotStatus === 'pending') return snapshotStatus
 
+  if (tasks.some((task) => orgBoardProjection(task)?.isolation_required)) return 'pending'
+
   const isolationTasks = tasks.filter((task) => {
     const key = task.task_key.toLowerCase()
     const title = task.title.toLowerCase()
@@ -376,6 +388,27 @@ function isolationStatusFromRoadmap(roadmap: RoadmapRow | null, tasks: RoadmapTa
   if (isolationTasks.some((task) => task.status === 'complete')) return 'passed'
   if (isolationTasks.length > 0) return 'pending'
   return 'not_started'
+}
+
+function orgBoardProjection(task: RoadmapTaskRow): RoadmapTaskOrgBoardMetadata | null {
+  const value = task.metadata?.org_board
+  if (!value || typeof value !== 'object') return null
+  const projection = value as RoadmapTaskOrgBoardMetadata
+  if (!projection.column) return null
+  return projection
+}
+
+function orgBoardColumn(task: RoadmapTaskRow): SwarmBoardColumnKey | null {
+  const column = orgBoardProjection(task)?.column
+  const allowed = new Set<SwarmBoardColumnKey>(COLUMN_DEFINITIONS.map((item) => item.key))
+  return column && allowed.has(column) ? column : null
+}
+
+function orgBoardApprovalPosture(tasks: RoadmapTaskRow[]): 'none' | 'required' | 'pending' {
+  const postures = tasks.map((task) => orgBoardProjection(task)?.approval_posture)
+  if (postures.includes('pending')) return 'pending'
+  if (postures.includes('required')) return 'required'
+  return 'none'
 }
 
 function columnFromTaskStatus(input: {
@@ -391,6 +424,9 @@ function columnFromTaskStatus(input: {
   if (input.projectStatus === 'completed' || input.roadmap?.status === 'completed') return 'done_archived'
   if (input.projectStatus === 'cancelled' || input.roadmap?.status === 'cancelled') return 'done_archived'
   if (input.roadmap?.status === 'active' && input.openTasks.length === 0) return 'active_monitoring'
+
+  const metadataColumn = input.openTasks.map(orgBoardColumn).find((column): column is SwarmBoardColumnKey => Boolean(column))
+  if (metadataColumn) return metadataColumn
 
   const titles = input.openTasks.map((task) => `${task.task_key} ${task.title}`.toLowerCase()).join(' ')
   if (!input.roadmap) return 'intake'
@@ -451,6 +487,17 @@ function currentAgentForColumn(column: SwarmBoardColumnKey) {
   }
 }
 
+function currentAgentForTasks(column: SwarmBoardColumnKey, openTasks: RoadmapTaskRow[]) {
+  const projection = openTasks.map(orgBoardProjection).find((item) => item?.owner_agent_key)
+  if (projection?.owner_agent_key) {
+    return {
+      key: projection.owner_agent_key,
+      label: projection.owner_agent_label ?? projection.owner_agent_key,
+    }
+  }
+  return currentAgentForColumn(column)
+}
+
 function nextActionForCard(input: {
   column: SwarmBoardColumnKey
   pendingApprovals: number
@@ -460,6 +507,8 @@ function nextActionForCard(input: {
   if (input.pendingApprovals > 0) return 'Review the approval checkpoint before any side effect runs.'
   if (input.failedOrStaleRuns > 0) return 'Open the latest failed or stale trace and route triage.'
   const nextTask = input.openTasks[0]
+  const orgBoardLabel = nextTask ? stringValue(orgBoardProjection(nextTask)?.internal_handoff_label) : null
+  if (orgBoardLabel) return orgBoardLabel
   if (nextTask) return nextTask.title
 
   switch (input.column) {
@@ -601,9 +650,11 @@ export function buildAgentSwarmBoardSnapshotFromRows(input: SwarmBoardBuildInput
       isolationStatus,
       projectStatus: project.project_status,
     })
-    const agent = currentAgentForColumn(column)
+    const agent = currentAgentForTasks(column, openTasks)
     const latestRun = runs[0] ?? null
     const health = moduleHealth({ pendingApprovals, failedOrStaleRuns, isolationStatus, reports })
+    const approvalPosture = orgBoardApprovalPosture(openTasks)
+    const approvalState = pendingApprovals > 0 ? 'pending' : approvalPosture === 'required' || column === 'waiting_approval' ? 'required' : 'none'
 
     return {
       id: `client-swarm:${project.id}`,
@@ -616,8 +667,8 @@ export function buildAgentSwarmBoardSnapshotFromRows(input: SwarmBoardBuildInput
       currentAgentLabel: agent.label,
       nextAction: nextActionForCard({ column, pendingApprovals, failedOrStaleRuns, openTasks }),
       statusLabel: roadmap?.status ?? project.project_status,
-      riskLabel: pendingApprovals > 0 ? 'approval gated' : failedOrStaleRuns > 0 ? 'triage required' : 'read-only handoff safe',
-      approvalState: pendingApprovals > 0 ? 'pending' : column === 'waiting_approval' ? 'required' : 'none',
+      riskLabel: pendingApprovals > 0 ? 'approval gated' : failedOrStaleRuns > 0 ? 'triage required' : approvalState === 'required' ? 'approval required before side effects' : 'read-only handoff safe',
+      approvalState,
       isolationStatus,
       moduleHealth: health,
       latestRunId: latestRun?.id ?? null,

--- a/lib/client-ai-ops-roadmap-db.ts
+++ b/lib/client-ai-ops-roadmap-db.ts
@@ -7,10 +7,27 @@ import {
   roadmapStatusFromProjectedTask,
   rollUpRoadmapCosts,
   type RoadmapClientView,
+  type RoadmapOrgBoardProjection,
   type RoadmapTaskStatus,
 } from './client-ai-ops-roadmap'
 
 type JsonRecord = Record<string, unknown>
+
+function orgBoardMetadata(projection: RoadmapOrgBoardProjection | undefined): JsonRecord {
+  if (!projection) return {}
+  return {
+    org_board: {
+      column: projection.column,
+      stage: projection.stage,
+      owner_agent_key: projection.ownerAgentKey,
+      owner_agent_label: projection.ownerAgentLabel,
+      approval_posture: projection.approvalPosture,
+      isolation_required: projection.isolationRequired,
+      client_visible_label: projection.clientVisibleLabel ?? null,
+      internal_handoff_label: projection.internalHandoffLabel ?? null,
+    },
+  }
+}
 
 export interface RoadmapBundle {
   roadmap: JsonRecord
@@ -212,6 +229,7 @@ export async function ensureRoadmapForProject(clientProjectId: string, options?:
         cost_category: task.costCategory,
         estimated_cost: task.estimatedCost,
         acceptance_criteria: task.acceptanceCriteria,
+        metadata: orgBoardMetadata(task.orgBoard),
       })),
     )
     .select('*')

--- a/lib/client-ai-ops-roadmap.test.ts
+++ b/lib/client-ai-ops-roadmap.test.ts
@@ -43,6 +43,27 @@ describe('client AI ops roadmap', () => {
     ]))
   })
 
+  it('adds structured org-board projections to default roadmap tasks', () => {
+    const roadmap = buildDefaultClientAiOpsRoadmap({ clientCompany: 'Acme Co' })
+
+    expect(roadmap.tasks.find((task) => task.taskKey === 'hardware-decision')?.orgBoard).toMatchObject({
+      column: 'decision_packet',
+      stage: 'technology_decision',
+      ownerAgentKey: 'technology-evaluator',
+      approvalPosture: 'none',
+      isolationRequired: false,
+    })
+    expect(roadmap.tasks.find((task) => task.taskKey === 'workflow-validation')?.orgBoard).toMatchObject({
+      column: 'qa_isolation',
+      stage: 'qa_isolation',
+      ownerAgentKey: 'engineering-copilot',
+      approvalPosture: 'none',
+      isolationRequired: true,
+      internalHandoffLabel: 'Run synthetic validation and escalation behavior checks.',
+    })
+    expect(roadmap.tasks.every((task) => task.orgBoard)).toBe(true)
+  })
+
   it('rolls up client-owned startup and monthly costs', () => {
     const rollup = rollUpRoadmapCosts([
       { payer: 'client', costType: 'one_time', amount: 1000, category: 'hardware' },

--- a/lib/client-ai-ops-roadmap.ts
+++ b/lib/client-ai-ops-roadmap.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto'
 import type { AgentReadinessAssessment, AgentReadinessLevel } from './agent-readiness-assessment'
+import type { SwarmBoardColumnKey, SwarmHandoffStage } from './agent-swarm-board'
 
 export const ROADMAP_PHASES = [
   'discovery_ownership',
@@ -61,6 +62,17 @@ export interface RoadmapPhaseDraft {
   acceptanceCriteria: string[]
 }
 
+export type RoadmapOrgBoardProjection = {
+  column: SwarmBoardColumnKey
+  stage: SwarmHandoffStage
+  ownerAgentKey: string
+  ownerAgentLabel: string
+  approvalPosture: 'none' | 'required' | 'pending'
+  isolationRequired: boolean
+  clientVisibleLabel?: string
+  internalHandoffLabel?: string
+}
+
 export interface RoadmapTaskDraft {
   taskKey: string
   phaseKey: RoadmapPhaseKey
@@ -74,6 +86,7 @@ export interface RoadmapTaskDraft {
   costCategory?: RoadmapCostCategory
   estimatedCost: number
   acceptanceCriteria: string
+  orgBoard?: RoadmapOrgBoardProjection
 }
 
 export interface RoadmapCostItemDraft {
@@ -220,6 +233,119 @@ const DEFAULT_PHASES: RoadmapPhaseDraft[] = [
   },
 ]
 
+const ORG_BOARD_PROJECTIONS: Record<string, RoadmapOrgBoardProjection> = {
+  'client-vault': {
+    column: 'discovery',
+    stage: 'discovery',
+    ownerAgentKey: 'chief-of-staff',
+    ownerAgentLabel: 'Chief of Staff Agent',
+    approvalPosture: 'required',
+    isolationRequired: false,
+    clientVisibleLabel: 'Set up controlled access',
+    internalHandoffLabel: 'Confirm vault ownership and named maintainer access before any credential handling.',
+  },
+  'ownership-map': {
+    column: 'discovery',
+    stage: 'discovery',
+    ownerAgentKey: 'research-source-register',
+    ownerAgentLabel: 'Research & Source Register Agent',
+    approvalPosture: 'none',
+    isolationRequired: false,
+    clientVisibleLabel: 'Confirm ownership map',
+    internalHandoffLabel: 'Document account, data, and approval ownership before build work.',
+  },
+  'hardware-decision': {
+    column: 'decision_packet',
+    stage: 'technology_decision',
+    ownerAgentKey: 'technology-evaluator',
+    ownerAgentLabel: 'Technology Evaluator',
+    approvalPosture: 'none',
+    isolationRequired: false,
+    clientVisibleLabel: 'Choose runtime placement',
+    internalHandoffLabel: 'Prepare local, cloud, or hybrid runtime decision packet.',
+  },
+  'secure-remote-access': {
+    column: 'provisioning_plan',
+    stage: 'provisioning_plan',
+    ownerAgentKey: 'automation-systems',
+    ownerAgentLabel: 'Automation Systems Agent',
+    approvalPosture: 'required',
+    isolationRequired: true,
+    clientVisibleLabel: 'Configure secure access',
+    internalHandoffLabel: 'Prepare remote access provisioning packet behind approval.',
+  },
+  'backup-monitoring': {
+    column: 'provisioning_plan',
+    stage: 'provisioning_plan',
+    ownerAgentKey: 'automation-systems',
+    ownerAgentLabel: 'Automation Systems Agent',
+    approvalPosture: 'none',
+    isolationRequired: true,
+    clientVisibleLabel: 'Set monitoring baseline',
+    internalHandoffLabel: 'Create backup and health-check provisioning plan.',
+  },
+  'data-source-map': {
+    column: 'discovery',
+    stage: 'discovery',
+    ownerAgentKey: 'research-source-register',
+    ownerAgentLabel: 'Research & Source Register Agent',
+    approvalPosture: 'none',
+    isolationRequired: false,
+    clientVisibleLabel: 'Map approved sources',
+    internalHandoffLabel: 'Classify approved and forbidden data sources.',
+  },
+  'ai-runtime-selection': {
+    column: 'decision_packet',
+    stage: 'technology_decision',
+    ownerAgentKey: 'technology-evaluator',
+    ownerAgentLabel: 'Technology Evaluator',
+    approvalPosture: 'none',
+    isolationRequired: false,
+    clientVisibleLabel: 'Select AI runtime',
+    internalHandoffLabel: 'Prepare model/runtime decision packet with cost and governance notes.',
+  },
+  'agent-registry': {
+    column: 'build_configure',
+    stage: 'build_configure',
+    ownerAgentKey: 'automation-systems',
+    ownerAgentLabel: 'Automation Systems Agent',
+    approvalPosture: 'required',
+    isolationRequired: true,
+    clientVisibleLabel: 'Register approved agents',
+    internalHandoffLabel: 'Create registry and policy records after approval gates are clear.',
+  },
+  'workflow-validation': {
+    column: 'qa_isolation',
+    stage: 'qa_isolation',
+    ownerAgentKey: 'engineering-copilot',
+    ownerAgentLabel: 'Engineering Copilot Agent',
+    approvalPosture: 'none',
+    isolationRequired: true,
+    clientVisibleLabel: 'Validate workflows',
+    internalHandoffLabel: 'Run synthetic validation and escalation behavior checks.',
+  },
+  'handoff-training': {
+    column: 'active_monitoring',
+    stage: 'reporting',
+    ownerAgentKey: 'chief-of-staff',
+    ownerAgentLabel: 'Chief of Staff Agent',
+    approvalPosture: 'none',
+    isolationRequired: false,
+    clientVisibleLabel: 'Complete handoff',
+    internalHandoffLabel: 'Prepare handoff and support cadence summary.',
+  },
+  'monthly-reporting': {
+    column: 'active_monitoring',
+    stage: 'reporting',
+    ownerAgentKey: 'chief-of-staff',
+    ownerAgentLabel: 'Chief of Staff Agent',
+    approvalPosture: 'none',
+    isolationRequired: false,
+    clientVisibleLabel: 'Start health reporting',
+    internalHandoffLabel: 'Generate first monitored roadmap report.',
+  },
+}
+
 const DEFAULT_TASKS: RoadmapTaskDraft[] = [
   task('client-vault', 'discovery_ownership', 'Create client-owned password vault', 'Client creates the shared vault and invites named AmaduTown maintainer access.', 'client', 'high', true, true, 'access_security', 0, 'Vault exists and access is named, logged, and revocable.'),
   task('ownership-map', 'discovery_ownership', 'Confirm ownership and access map', 'Document who owns accounts, data, hardware, logs, and approval decisions.', 'shared', 'high', true, true, 'other', 0, 'Ownership map is visible in project record.'),
@@ -270,6 +396,7 @@ function task(
     costCategory,
     estimatedCost,
     acceptanceCriteria,
+    orgBoard: ORG_BOARD_PROJECTIONS[taskKey],
   }
 }
 


### PR DESCRIPTION
Summary
- Add structured org-board projection metadata to default Client AI Ops roadmap tasks.
- Persist the projection into existing roadmap task metadata so the Agent Swarm Board has a durable contract.
- Teach the swarm board to prefer org_board metadata for column placement, agent ownership, approval posture, isolation status, and handoff labels before falling back to title inference.

Validation
- npm test -- --run lib/client-ai-ops-roadmap.test.ts lib/agent-swarm-board.test.ts
- npx tsc --noEmit --pretty false
- git diff --check
- npm run build

Integration Notes
- No migration required; client_ai_ops_roadmap_tasks.metadata already exists as JSONB.
- Build required local ignored symlinks to the root node_modules and .env.local in this fresh worktree; neither is committed.
- Build produced the existing local warning that outbound n8n webhooks are enabled when MOCK_N8N=false and N8N_DISABLE_OUTBOUND=false; no live workflow or customer-data smoke was run.
- Post-merge Vercel contexts still need captain verification: Vercel – portfolio and Vercel – portfolio-staging.