### PR TITLE
feat: add agent evaluation rubrics

### DIFF
--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -13,6 +13,7 @@ import {
   CircleDollarSign,
   ClipboardList,
   Clock3,
+  Gauge,
   MessageSquare,
   Network,
   Radio,
@@ -20,6 +21,7 @@ import {
   Send,
   ShieldCheck,
   Sparkles,
+  TrendingDown,
   Users,
 } from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
@@ -106,6 +108,45 @@ type MissionSnapshot = {
     by_workflow: CostSummaryGroup[]
     by_client_project: CostSummaryGroup[]
     by_artifact_type: CostSummaryGroup[]
+  }
+  quality_summary: {
+    window_hours: number
+    generated_at: string
+    rubric_count: number
+    evaluation_count: number
+    average_score: number | null
+    pass_rate: number | null
+    by_agent: Array<{
+      agent_key: string
+      evaluation_count: number
+      average_score: number | null
+      pass_rate: number | null
+      latest_score: number | null
+      latest_evaluated_at: string | null
+    }>
+    needs_coaching: Array<{
+      agent_key: string
+      rubric_key: string
+      rubric_name: string
+      latest_score: number | null
+      threshold: number
+      reason: string
+      run_id: string | null
+      evaluated_at: string | null
+    }>
+    rubric_trends: Array<{
+      rubric_key: string
+      rubric_name: string
+      agent_key: string
+      workflow_key: string | null
+      latest_score: number | null
+      average_score: number | null
+      pass_rate: number | null
+      evaluation_count: number
+      threshold: number
+      latest_evaluated_at: string | null
+      direction: 'up' | 'down' | 'flat' | 'unknown'
+    }>
   }
   operating_signals: Array<{
     run_id: string
@@ -475,6 +516,7 @@ export default function AgentOperationsPage() {
 
           <DailyBriefPanel brief={snapshot?.daily_brief ?? null} loading={loading} />
           <CostSummaryPanel summary={snapshot?.cost_summary ?? null} />
+          <QualitySignalsPanel summary={snapshot?.quality_summary ?? null} />
           <OperatingSignalsPanel signals={snapshot?.operating_signals ?? []} />
           <KnowledgeGovernancePanel governance={snapshot?.knowledge_governance ?? null} />
 
@@ -776,6 +818,99 @@ function CostSummaryCard({ title, group }: { title: string; group: CostSummaryGr
         {group ? `${group.event_count} event(s), ${group.run_count} run(s)` : 'No linked cost events'}
       </p>
     </div>
+  )
+}
+
+function QualitySignalsPanel({ summary }: { summary: MissionSnapshot['quality_summary'] | null }) {
+  const hasEvaluations = Boolean(summary?.evaluation_count)
+  const qualityScore = summary?.average_score === null || summary?.average_score === undefined
+    ? 'No score'
+    : `${summary.average_score.toFixed(1)}`
+  const passRate = summary?.pass_rate === null || summary?.pass_rate === undefined
+    ? 'No pass rate'
+    : `${Math.round(summary.pass_rate * 100)}%`
+
+  return (
+    <section className="mt-5 rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <div className="flex items-center gap-2 text-radiant-gold">
+            <Gauge size={18} />
+            <h2 className="font-semibold">Quality Signals</h2>
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Rubric-backed scoring for agent output quality, coaching needs, and trend visibility.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+          <CostChip label={`${summary?.window_hours ?? 24}h score`} value={qualityScore} />
+          <CostChip label="Pass rate" value={passRate} />
+          <CostChip label="Rubrics" value={summary?.rubric_count ?? 0} />
+          <CostChip label="Evaluations" value={summary?.evaluation_count ?? 0} />
+        </div>
+      </div>
+
+      {hasEvaluations ? (
+        <div className="mt-3 grid grid-cols-1 gap-3 xl:grid-cols-[0.9fr_1.1fr]">
+          <div className="rounded-lg border border-silicon-slate/50 bg-black/10 p-3">
+            <div className="flex items-center gap-2 text-yellow-200">
+              <TrendingDown size={16} />
+              <p className="text-sm font-semibold">Needs Coaching</p>
+            </div>
+            <div className="mt-3 space-y-2">
+              {summary?.needs_coaching.length ? summary.needs_coaching.slice(0, 4).map((item) => (
+                <Link
+                  key={`${item.agent_key}-${item.rubric_key}`}
+                  href={item.run_id ? `/admin/agents/runs/${item.run_id}` : '/admin/agents'}
+                  className="block rounded-lg border border-yellow-400/20 bg-yellow-500/5 p-3 text-sm hover:border-yellow-400/40"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <p className="font-medium">{item.agent_key.replace(/-/g, ' ')}</p>
+                    <span className="rounded-full border border-yellow-400/40 bg-yellow-500/10 px-2 py-0.5 text-xs text-yellow-100">
+                      {item.latest_score === null ? 'No score' : `${item.latest_score.toFixed(1)} / ${item.threshold.toFixed(0)}`}
+                    </span>
+                  </div>
+                  <p className="mt-1 line-clamp-2 text-muted-foreground">{item.rubric_name}</p>
+                  <p className="mt-1 text-xs text-muted-foreground">{item.reason}</p>
+                </Link>
+              )) : (
+                <p className="rounded-lg border border-silicon-slate/50 bg-background/30 p-3 text-sm text-muted-foreground">
+                  No coaching signals in the current window.
+                </p>
+              )}
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-silicon-slate/50 bg-black/10 p-3">
+            <p className="text-sm font-semibold">Rubric Trends</p>
+            <div className="mt-3 grid grid-cols-1 gap-2 md:grid-cols-2">
+              {(summary?.rubric_trends ?? []).slice(0, 6).map((trend) => (
+                <div key={trend.rubric_key} className="rounded-lg border border-silicon-slate/50 bg-background/30 p-3 text-sm">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <p className="truncate font-medium">{trend.rubric_name}</p>
+                      <p className="mt-0.5 text-xs text-muted-foreground">{trend.agent_key.replace(/-/g, ' ')}</p>
+                    </div>
+                    <span className={`shrink-0 rounded-full border px-2 py-0.5 text-xs ${trend.latest_score !== null && trend.latest_score < trend.threshold ? 'border-yellow-400/40 bg-yellow-500/10 text-yellow-100' : 'border-silicon-slate/50 bg-black/10 text-muted-foreground'}`}>
+                      {trend.latest_score === null ? 'Pending' : trend.latest_score.toFixed(1)}
+                    </span>
+                  </div>
+                  <div className="mt-2 flex flex-wrap gap-2 text-xs text-muted-foreground">
+                    <span>{trend.evaluation_count} eval(s)</span>
+                    <span>Pass {trend.pass_rate === null ? '-' : `${Math.round(trend.pass_rate * 100)}%`}</span>
+                    <span>{trend.direction}</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      ) : (
+        <p className="mt-3 rounded-lg border border-silicon-slate/50 bg-black/10 p-3 text-sm text-muted-foreground">
+          No evaluations recorded yet. Run a rubric evaluation from a trace detail page or the evaluation API to establish the first quality baseline.
+        </p>
+      )}
+    </section>
   )
 }
 

--- a/app/admin/agents/runs/[runId]/page.tsx
+++ b/app/admin/agents/runs/[runId]/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import type { ReactNode } from 'react'
 import Link from 'next/link'
-import { AlertTriangle, ArrowLeft, Bot, DollarSign, FileText, RefreshCw } from 'lucide-react'
+import { AlertTriangle, ArrowLeft, Bot, DollarSign, FileText, Gauge, RefreshCw } from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
 import { getCurrentSession } from '@/lib/auth'
@@ -18,8 +18,17 @@ type RunDetail = {
   approvals: AnyRow[]
   handoffs: AnyRow[]
   costs: AnyRow[]
+  evaluations: AnyRow[]
   cost_total: number
 }
+
+const RUBRIC_OPTIONS = [
+  { key: 'chief-of-staff-synthesis-quality', label: 'Chief of Staff synthesis quality' },
+  { key: 'warm-lead-capture-trace-completeness', label: 'Warm lead trace completeness' },
+  { key: 'meeting-intake-follow-up-safety-isolation', label: 'Meeting intake safety isolation' },
+  { key: 'inbox-follow-up-approval-readiness', label: 'Inbox follow-up approval readiness' },
+  { key: 'research-source-register-source-quality', label: 'Research source quality' },
+]
 
 export default function AgentRunDetailPage({ params }: { params: { runId: string } }) {
   return (
@@ -33,6 +42,8 @@ function AgentRunDetailContent({ runId }: { runId: string }) {
   const [data, setData] = useState<RunDetail | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [rubricKey, setRubricKey] = useState(RUBRIC_OPTIONS[0].key)
+  const [evaluating, setEvaluating] = useState(false)
 
   const fetchDetail = useCallback(async () => {
     setLoading(true)
@@ -86,6 +97,32 @@ function AgentRunDetailContent({ runId }: { runId: string }) {
     }
   }
 
+  async function evaluateRun() {
+    setEvaluating(true)
+    setError(null)
+    try {
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Missing admin session')
+      const res = await fetch(`/api/admin/agents/runs/${runId}/evaluate`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${session.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ rubric_key: rubricKey }),
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body.error || `HTTP ${res.status}`)
+      }
+      await fetchDetail()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to evaluate run')
+    } finally {
+      setEvaluating(false)
+    }
+  }
+
   return (
     <div className="min-h-screen bg-background text-foreground p-6 lg:p-8">
       <div className="max-w-6xl mx-auto">
@@ -114,13 +151,32 @@ function AgentRunDetailContent({ runId }: { runId: string }) {
                 <h1 className="text-3xl font-bold mb-1">{String(data.run.title ?? 'Agent run')}</h1>
                 <p className="text-sm text-muted-foreground">{String(data.run.kind ?? 'run')} · {String(data.run.id)}</p>
               </div>
-              <button
-                onClick={fetchDetail}
-                className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 bg-silicon-slate/30 px-3 py-2 text-sm hover:border-radiant-gold/60"
-              >
-                <RefreshCw size={16} />
-                Refresh
-              </button>
+              <div className="flex flex-wrap items-center gap-2">
+                <select
+                  value={rubricKey}
+                  onChange={(event) => setRubricKey(event.target.value)}
+                  className="h-10 rounded-lg border border-silicon-slate/70 bg-silicon-slate/30 px-3 text-sm outline-none focus:border-radiant-gold/60"
+                >
+                  {RUBRIC_OPTIONS.map((option) => (
+                    <option key={option.key} value={option.key}>{option.label}</option>
+                  ))}
+                </select>
+                <button
+                  onClick={evaluateRun}
+                  disabled={evaluating}
+                  className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/50 bg-radiant-gold/10 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15 disabled:opacity-60"
+                >
+                  <Gauge size={16} />
+                  {evaluating ? 'Evaluating...' : 'Evaluate'}
+                </button>
+                <button
+                  onClick={fetchDetail}
+                  className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 bg-silicon-slate/30 px-3 py-2 text-sm hover:border-radiant-gold/60"
+                >
+                  <RefreshCw size={16} />
+                  Refresh
+                </button>
+              </div>
             </div>
 
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
@@ -129,6 +185,11 @@ function AgentRunDetailContent({ runId }: { runId: string }) {
               <Metric icon={<DollarSign size={18} />} label="Cost" value={`$${data.cost_total.toFixed(4)}`} />
               <Metric icon={<FileText size={18} />} label="Artifacts" value={String(data.artifacts.length)} />
             </div>
+
+            <section className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-5 mb-6">
+              <h2 className="text-lg font-semibold mb-4">Evaluations</h2>
+              <EvaluationList rows={data.evaluations} />
+            </section>
 
             <section className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-5 mb-6">
               <h2 className="text-lg font-semibold mb-4">Steps</h2>
@@ -187,6 +248,62 @@ function Timeline({ rows, timeKey, titleKey, detailKey, fallback }: { rows: AnyR
           {row.status ? <p className="text-xs text-muted-foreground mt-1">Status: {String(row.status)}</p> : null}
         </div>
       ))}
+    </div>
+  )
+}
+
+function EvaluationList({ rows }: { rows: AnyRow[] }) {
+  if (rows.length === 0) {
+    return <p className="text-sm text-muted-foreground">No rubric evaluations recorded yet.</p>
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+      {rows.map((row) => {
+        const score = typeof row.score === 'number' ? row.score : Number(row.score ?? 0)
+        const passed = row.passed === true
+        const reasons = Array.isArray(row.failure_reasons)
+          ? row.failure_reasons.filter((reason): reason is string => typeof reason === 'string')
+          : []
+        const dimensions = row.dimension_scores && typeof row.dimension_scores === 'object'
+          ? Object.entries(row.dimension_scores as Record<string, unknown>)
+          : []
+
+        return (
+          <div key={String(row.id)} className="rounded-lg border border-silicon-slate/50 bg-background/40 p-3">
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <p className="font-medium">{String(row.rubric_key ?? 'rubric')}</p>
+                <p className="mt-1 text-sm text-muted-foreground">{String(row.summary ?? row.judge_model ?? '')}</p>
+              </div>
+              <span className={`shrink-0 rounded-full border px-2 py-0.5 text-xs ${passed ? 'border-emerald-400/40 bg-emerald-500/10 text-emerald-200' : 'border-yellow-400/40 bg-yellow-500/10 text-yellow-100'}`}>
+                {Number.isFinite(score) ? score.toFixed(1) : '-'} {passed ? 'pass' : 'review'}
+              </span>
+            </div>
+            <div className="mt-3 flex flex-wrap gap-2 text-xs text-muted-foreground">
+              <span>{String(row.agent_key ?? '-').replace(/-/g, ' ')}</span>
+              <span>{String(row.judge_model ?? '-')}</span>
+              <span>{formatDate(asString(row.created_at))}</span>
+            </div>
+            {dimensions.length ? (
+              <div className="mt-3 grid grid-cols-2 gap-2 text-xs text-muted-foreground">
+                {dimensions.slice(0, 6).map(([key, value]) => (
+                  <div key={key} className="rounded-md border border-silicon-slate/50 bg-black/10 px-2 py-1">
+                    {key.replace(/_/g, ' ')}: <span className="text-foreground/80">{Number(value).toFixed(1)}</span>
+                  </div>
+                ))}
+              </div>
+            ) : null}
+            {reasons.length ? (
+              <div className="mt-3 space-y-1">
+                {reasons.slice(0, 3).map((reason) => (
+                  <p key={reason} className="text-xs text-yellow-100">{reason}</p>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        )
+      })}
     </div>
   )
 }

--- a/app/api/admin/agents/evaluations/[agentKey]/route.ts
+++ b/app/api/admin/agents/evaluations/[agentKey]/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { getAgentQualitySummary } from '@/lib/agent-evaluations'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * GET /api/admin/agents/evaluations/:agentKey
+ *
+ * Returns quality trends and coaching signals for one agent.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { agentKey: string } },
+) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const agentKey = params.agentKey?.trim()
+  if (!agentKey) {
+    return NextResponse.json({ error: 'agentKey is required' }, { status: 400 })
+  }
+
+  try {
+    const url = new URL(request.url)
+    const windowHoursValue = Number(url.searchParams.get('window_hours') ?? 24)
+    const windowHours = Number.isFinite(windowHoursValue) && windowHoursValue > 0 ? windowHoursValue : 24
+    const summary = await getAgentQualitySummary({ agentKey, windowHours })
+    return NextResponse.json({ ok: true, ...summary })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to load agent evaluation detail'
+    console.error('[agent-evaluations] detail failed:', error)
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/app/api/admin/agents/evaluations/route.test.ts
+++ b/app/api/admin/agents/evaluations/route.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  getAgentQualitySummary: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-evaluations', () => ({
+  getAgentQualitySummary: mocks.getAgentQualitySummary,
+}))
+
+import { GET } from './route'
+
+function request(url = 'http://localhost/api/admin/agents/evaluations') {
+  return new Request(url, {
+    headers: { authorization: 'Bearer token' },
+  })
+}
+
+describe('GET /api/admin/agents/evaluations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.getAgentQualitySummary.mockResolvedValue({
+      window_hours: 24,
+      generated_at: '2026-05-10T10:00:00.000Z',
+      rubric_count: 1,
+      evaluation_count: 1,
+      average_score: 91,
+      pass_rate: 1,
+      by_agent: [],
+      needs_coaching: [],
+      rubric_trends: [],
+    })
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await GET(request() as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.getAgentQualitySummary).not.toHaveBeenCalled()
+  })
+
+  it('returns an empty-safe quality summary', async () => {
+    const response = await GET(request('http://localhost/api/admin/agents/evaluations?agent_key=chief-of-staff') as never)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({
+      ok: true,
+      rubric_count: 1,
+      evaluation_count: 1,
+      average_score: 91,
+    })
+    expect(mocks.getAgentQualitySummary).toHaveBeenCalledWith({
+      agentKey: 'chief-of-staff',
+      windowHours: 24,
+    })
+  })
+})

--- a/app/api/admin/agents/evaluations/route.ts
+++ b/app/api/admin/agents/evaluations/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { getAgentQualitySummary } from '@/lib/agent-evaluations'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * GET /api/admin/agents/evaluations
+ *
+ * Returns rubric-backed quality signals for Mission Control.
+ */
+export async function GET(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  try {
+    const url = new URL(request.url)
+    const agentKey = url.searchParams.get('agent_key')?.trim() || undefined
+    const windowHoursValue = Number(url.searchParams.get('window_hours') ?? 24)
+    const windowHours = Number.isFinite(windowHoursValue) && windowHoursValue > 0 ? windowHoursValue : 24
+    const summary = await getAgentQualitySummary({ agentKey, windowHours })
+    return NextResponse.json({ ok: true, ...summary })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to load agent evaluations'
+    console.error('[agent-evaluations] list failed:', error)
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/app/api/admin/agents/runs/[runId]/evaluate/route.test.ts
+++ b/app/api/admin/agents/runs/[runId]/evaluate/route.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  evaluateAgentRun: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-evaluations', () => ({
+  evaluateAgentRun: mocks.evaluateAgentRun,
+}))
+
+import { POST } from './route'
+
+function request(body: unknown = {}) {
+  return new Request('http://localhost/api/admin/agents/runs/run-1/evaluate', {
+    method: 'POST',
+    headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/admin/agents/runs/:runId/evaluate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.evaluateAgentRun.mockResolvedValue({
+      id: 'eval-1',
+      run_id: 'run-1',
+      rubric_key: 'chief-of-staff-synthesis-quality',
+      score: 91,
+      passed: true,
+    })
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(request({ rubric_key: 'chief-of-staff-synthesis-quality' }) as never, { params: { runId: 'run-1' } })
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.evaluateAgentRun).not.toHaveBeenCalled()
+  })
+
+  it('rejects malformed evaluation requests', async () => {
+    const response = await POST(request({}) as never, { params: { runId: 'run-1' } })
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'rubric_key is required' })
+    expect(mocks.evaluateAgentRun).not.toHaveBeenCalled()
+  })
+
+  it('creates a trace-linked evaluation', async () => {
+    const response = await POST(request({ rubric_key: 'chief-of-staff-synthesis-quality' }) as never, { params: { runId: 'run-1' } })
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({
+      ok: true,
+      evaluation: {
+        id: 'eval-1',
+        run_id: 'run-1',
+        rubric_key: 'chief-of-staff-synthesis-quality',
+      },
+    })
+    expect(mocks.evaluateAgentRun).toHaveBeenCalledWith('run-1', 'chief-of-staff-synthesis-quality')
+  })
+
+  it('returns 404 when the run or rubric is missing', async () => {
+    mocks.evaluateAgentRun.mockRejectedValue(new Error('Agent run not found'))
+
+    const response = await POST(request({ rubric_key: 'chief-of-staff-synthesis-quality' }) as never, { params: { runId: 'missing-run' } })
+
+    expect(response.status).toBe(404)
+    expect(await response.json()).toEqual({ error: 'Agent run not found' })
+  })
+})

--- a/app/api/admin/agents/runs/[runId]/evaluate/route.ts
+++ b/app/api/admin/agents/runs/[runId]/evaluate/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { evaluateAgentRun } from '@/lib/agent-evaluations'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * POST /api/admin/agents/runs/:runId/evaluate
+ *
+ * Scores an existing run against a stored rubric and writes a trace-linked
+ * evaluation. This never mutates prompts, skills, n8n workflows, or Slack.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { runId: string } },
+) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as {
+    rubric_key?: string
+  }
+  const rubricKey = body.rubric_key?.trim()
+  if (!params.runId?.trim()) {
+    return NextResponse.json({ error: 'runId is required' }, { status: 400 })
+  }
+  if (!rubricKey) {
+    return NextResponse.json({ error: 'rubric_key is required' }, { status: 400 })
+  }
+
+  try {
+    const evaluation = await evaluateAgentRun(params.runId, rubricKey)
+    return NextResponse.json({ ok: true, evaluation })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to evaluate agent run'
+    if (message === 'Agent run not found' || message === 'Evaluation rubric not found') {
+      return NextResponse.json({ error: message }, { status: 404 })
+    }
+    if (message.includes('required') || message.includes('threshold')) {
+      return NextResponse.json({ error: message }, { status: 400 })
+    }
+    console.error('[agent-evaluations] run evaluation failed:', error)
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/app/api/admin/agents/runs/[runId]/route.ts
+++ b/app/api/admin/agents/runs/[runId]/route.ts
@@ -50,7 +50,7 @@ export async function GET(
     return NextResponse.json({ error: 'Run not found' }, { status: 404 })
   }
 
-  const [steps, events, artifacts, handoffs, approvals, costs] = await Promise.all([
+  const [steps, events, artifacts, handoffs, approvals, costs, evaluations] = await Promise.all([
     supabaseAdmin
       .from('agent_run_steps')
       .select('*')
@@ -81,6 +81,11 @@ export async function GET(
       .select('*')
       .eq('agent_run_id', params.runId)
       .order('occurred_at', { ascending: false }),
+    supabaseAdmin
+      .from('agent_run_evaluations')
+      .select('*')
+      .eq('run_id', params.runId)
+      .order('created_at', { ascending: false }),
   ])
 
   const costTotal = ((costs.data || []) as CostRow[]).reduce(
@@ -96,6 +101,7 @@ export async function GET(
     handoffs: handoffs.data || [],
     approvals: approvals.data || [],
     costs: costs.data || [],
+    evaluations: evaluations.data || [],
     cost_total: Number(costTotal.toFixed(4)),
   })
 }

--- a/docs/hyperagent-parity-plan.md
+++ b/docs/hyperagent-parity-plan.md
@@ -1,0 +1,80 @@
+# Hyperagent Parity Plan
+
+## Positioning
+
+Hyperagent is a useful benchmark for agent operating infrastructure, not a replacement for Portfolio.
+
+Portfolio remains the control plane because it already owns the domain-specific pieces that matter for AmaduTown: Agent Ops traces, approvals, n8n workflow visibility, Slack commands, Mission Control, client-delivery context, and non-production data isolation rules.
+
+The first parity target is rubric-based evaluation. This gives Portfolio a quality loop similar to Hyperagent Rubrics while keeping changes approval-gated.
+
+## Feature Matrix
+
+| Hyperagent feature | Portfolio equivalent today | Gap | Planned response | Priority |
+| --- | --- | --- | --- | --- |
+| Persistent cloud agents | n8n workflows, Codex lanes, Hermes probes, Agent Ops traces | Runtimes are visible but not scored consistently | Keep Portfolio as runtime-neutral trace layer | High |
+| Skills and memories | Codex skills, agent organization, docs, source manifests | Failure-driven skill improvement is manual | Store evaluation failures as coaching candidates before any skill change | High |
+| Slack invocation | `/agent` Slack command and Agent Ops routes | Standup and discuss paths exist, quality loop was missing | Add evaluation commands later after admin scoring proves stable | Medium |
+| MCP and tool invocation | Codex MCP/tooling, n8n credentials, app APIs | Tool access differs by runtime | Keep runtime policy and approval gates as source of truth | Medium |
+| Cron and recurring agents | n8n schedules, Vercel cron, Portfolio monitors | Quality of recurring outputs not trended | Score key recurring runs against rubrics | High |
+| Fleet command center | `/admin/agents` Mission Control, run console, swarm board | Quality and coaching were not first-viewport signals | Add Quality Signals, Needs Coaching, and Rubric Trends panels | High |
+| Cost tracking | `cost_events`, Agent Ops cost summary | Cost was not paired with successful quality | Add score history first; cost-per-good-output is next | Medium |
+| Rubric evaluation | New `agent_eval_rubrics` and `agent_run_evaluations` | No historical score baseline yet | Seed first rubrics and allow manual run evaluation | High |
+| Self-improving skills | Approval-gated Codex/Hermes skill edits | Auto-mutation would be risky | Store recommendations only; no autonomous prompt or skill mutation in v1 | High |
+| External runtime marketplace | Runtime model supports `codex`, `n8n`, `hermes`, `opencode`, `manual` | Hyperagent API/workspace access not confirmed | Treat Hyperagent as a benchmarked external candidate | Low |
+
+## V1 Implementation
+
+V1 adds the evaluation foundation:
+
+- `agent_eval_rubrics` stores active rubrics by agent and workflow.
+- `agent_run_evaluations` stores trace-linked scores, dimension scores, judge implementation, summaries, and failure reasons.
+- `evaluateAgentRun(runId, rubricKey)` scores one run against one rubric and records a trace event.
+- `getAgentQualitySummary(...)` returns Mission Control-ready quality, trend, and coaching signals.
+- Mission Control shows Quality Signals, Needs Coaching, and Rubric Trends.
+- Run detail pages allow a human admin to evaluate a trace against one of the seeded rubrics.
+
+The v1 judge is deterministic and trace-based. The schema is compatible with LLM-as-judge scoring, but the first implementation avoids unapproved model spend and avoids autonomous mutation.
+
+## Seed Rubrics
+
+- `chief-of-staff-synthesis-quality`
+- `warm-lead-capture-trace-completeness`
+- `meeting-intake-follow-up-safety-isolation`
+- `inbox-follow-up-approval-readiness`
+- `research-source-register-source-quality`
+
+## Safety Model
+
+Evaluation results are observability and coaching signals only.
+
+They do not:
+
+- rewrite prompts,
+- modify Codex or Hermes skills,
+- change n8n workflows,
+- send Slack messages,
+- publish content,
+- touch client data,
+- or mutate production runtime behavior.
+
+Any prompt, skill, routing, policy, workflow, or production behavior change must go through the existing approval and integration-captain paths.
+
+## Definition Of Done
+
+- Rubric tables are migrated with RLS enabled.
+- Seed rubrics exist in dev and production databases.
+- Admin evaluation APIs require admin auth.
+- A run can be evaluated from the run detail page.
+- Mission Control remains safe with no evaluations.
+- Low scores appear as Needs Coaching signals.
+- Evaluation events link back to the source `agent_run`.
+- No production prompt, skill, n8n workflow, or Slack behavior changes automatically.
+
+## Next Parity Targets
+
+1. Add cost-per-passing-output and cost-per-agent-quality trend.
+2. Add Slack read-only commands for quality status after admin scoring is proven.
+3. Add LLM-as-judge behind a budget and approval gate.
+4. Add improvement candidate artifacts for failed evaluations.
+5. Evaluate Hyperagent as an external runtime only after API/workspace access is confirmed.

--- a/lib/agent-evaluations.test.ts
+++ b/lib/agent-evaluations.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: null,
+}))
+
+vi.mock('@/lib/agent-run', () => ({
+  recordAgentEvent: vi.fn(),
+}))
+
+import {
+  scoreAgentRunAgainstRubric,
+  summarizeAgentQuality,
+  validateAgentEvalRubric,
+  type AgentEvalRubricRow,
+  type AgentEvalRunRow,
+  type AgentRunEvaluationRow,
+} from '@/lib/agent-evaluations'
+
+const rubric: AgentEvalRubricRow = {
+  id: 'rubric-1',
+  key: 'chief-of-staff-synthesis-quality',
+  agent_key: 'chief-of-staff',
+  workflow_key: 'agent_war_room_standup',
+  name: 'Chief of Staff Synthesis Quality',
+  description: null,
+  dimensions: [
+    { key: 'grounding', label: 'Grounded in current traces', weight: 0.25 },
+    { key: 'synthesis', label: 'Clear executive synthesis', weight: 0.25 },
+    { key: 'next_actions', label: 'Specific next actions', weight: 0.25 },
+    { key: 'approval_gates', label: 'Approval gates are explicit', weight: 0.25 },
+  ],
+  threshold: 82,
+  active: true,
+  metadata: {},
+}
+
+const run: AgentEvalRunRow = {
+  id: 'run-1',
+  agent_key: 'chief-of-staff',
+  runtime: 'manual',
+  kind: 'agent_war_room_standup',
+  title: 'War Room standup',
+  status: 'completed',
+  subject_label: null,
+  current_step: 'Standup synthesized',
+  error_message: null,
+  started_at: '2026-05-10T10:00:00.000Z',
+  completed_at: '2026-05-10T10:01:00.000Z',
+  outcome: { synthesis: 'Clear status and next actions.' },
+  metadata: { requires_approval: true },
+}
+
+function evaluation(overrides: Partial<AgentRunEvaluationRow>): AgentRunEvaluationRow {
+  return {
+    id: 'eval-1',
+    run_id: 'run-1',
+    rubric_id: 'rubric-1',
+    rubric_key: 'chief-of-staff-synthesis-quality',
+    agent_key: 'chief-of-staff',
+    workflow_key: 'agent_war_room_standup',
+    score: 90,
+    passed: true,
+    dimension_scores: { grounding: 90 },
+    judge_model: 'deterministic-agent-eval-v1',
+    summary: 'Passed',
+    failure_reasons: [],
+    metadata: {},
+    created_at: '2026-05-10T10:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('agent evaluation helpers', () => {
+  it('validates rubric dimensions and threshold range', () => {
+    expect(validateAgentEvalRubric(rubric)).toHaveLength(4)
+    expect(() => validateAgentEvalRubric({ ...rubric, dimensions: [] })).toThrow('Rubric requires at least one dimension')
+    expect(() => validateAgentEvalRubric({ ...rubric, threshold: 101 })).toThrow('Rubric threshold must be between 0 and 100')
+  })
+
+  it('scores completed runs and keeps mutations approval-gated', () => {
+    const scored = scoreAgentRunAgainstRubric(run, rubric)
+
+    expect(scored.score).toBeGreaterThanOrEqual(82)
+    expect(scored.passed).toBe(true)
+    expect(scored.dimension_scores).toMatchObject({
+      grounding: expect.any(Number),
+      synthesis: expect.any(Number),
+      next_actions: expect.any(Number),
+      approval_gates: expect.any(Number),
+    })
+    expect(scored.metadata).toMatchObject({
+      mutation_policy: 'approval_gated',
+      autonomous_mutation: false,
+    })
+  })
+
+  it('turns failed evaluations into coaching signals without prompt mutation', () => {
+    const scored = scoreAgentRunAgainstRubric({
+      ...run,
+      status: 'failed',
+      error_message: 'LLM request failed',
+      outcome: null,
+    }, rubric)
+
+    expect(scored.passed).toBe(false)
+    expect(scored.failure_reasons).toEqual(expect.arrayContaining([
+      'Run failed before producing a reviewable output.',
+      'Run error: LLM request failed',
+    ]))
+    expect(scored.metadata.autonomous_mutation).toBe(false)
+  })
+
+  it('groups quality summary by agent, workflow, and rubric trend', () => {
+    const summary = summarizeAgentQuality({
+      rubrics: [rubric],
+      evaluations: [
+        evaluation({ id: 'eval-2', run_id: 'run-2', score: 72, passed: false, created_at: '2026-05-10T11:00:00.000Z' }),
+        evaluation({ id: 'eval-1', run_id: 'run-1', score: 90, passed: true, created_at: '2026-05-10T10:00:00.000Z' }),
+      ],
+    })
+
+    expect(summary.evaluation_count).toBe(2)
+    expect(summary.average_score).toBe(81)
+    expect(summary.by_agent[0]).toMatchObject({
+      agent_key: 'chief-of-staff',
+      evaluation_count: 2,
+      pass_rate: 0.5,
+    })
+    expect(summary.rubric_trends[0]).toMatchObject({
+      rubric_key: 'chief-of-staff-synthesis-quality',
+      workflow_key: 'agent_war_room_standup',
+      latest_score: 72,
+      direction: 'down',
+    })
+    expect(summary.needs_coaching[0]).toMatchObject({
+      agent_key: 'chief-of-staff',
+      rubric_key: 'chief-of-staff-synthesis-quality',
+      run_id: 'run-2',
+    })
+  })
+})

--- a/lib/agent-evaluations.ts
+++ b/lib/agent-evaluations.ts
@@ -1,0 +1,521 @@
+import { recordAgentEvent } from '@/lib/agent-run'
+import { supabaseAdmin } from '@/lib/supabase'
+
+export type AgentEvalDimension = {
+  key: string
+  label: string
+  weight?: number
+}
+
+export type AgentEvalRubricRow = {
+  id: string
+  key: string
+  agent_key: string
+  workflow_key: string | null
+  name: string
+  description: string | null
+  dimensions: unknown
+  threshold: number | string
+  active: boolean
+  metadata: Record<string, unknown> | null
+}
+
+export type AgentEvalRunRow = {
+  id: string
+  agent_key: string | null
+  runtime: string
+  kind: string
+  title: string
+  status: string
+  subject_label: string | null
+  current_step: string | null
+  error_message: string | null
+  started_at: string
+  completed_at: string | null
+  outcome: Record<string, unknown> | null
+  metadata: Record<string, unknown> | null
+}
+
+export type AgentRunEvaluationRow = {
+  id: string
+  run_id: string
+  rubric_id: string
+  rubric_key: string
+  agent_key: string
+  workflow_key: string | null
+  score: number | string
+  passed: boolean
+  dimension_scores: Record<string, number> | null
+  judge_model: string
+  summary: string | null
+  failure_reasons: string[] | null
+  metadata: Record<string, unknown> | null
+  created_at: string
+}
+
+export type RecordAgentRunEvaluationInput = {
+  runId: string
+  rubricId: string
+  rubricKey: string
+  agentKey: string
+  workflowKey?: string | null
+  score: number
+  threshold?: number
+  dimensionScores?: Record<string, number>
+  judgeModel?: string
+  summary?: string | null
+  failureReasons?: string[]
+  metadata?: Record<string, unknown>
+}
+
+export type ScoredAgentRunEvaluation = {
+  run_id: string
+  rubric_id: string
+  rubric_key: string
+  agent_key: string
+  workflow_key: string | null
+  score: number
+  passed: boolean
+  dimension_scores: Record<string, number>
+  judge_model: string
+  summary: string
+  failure_reasons: string[]
+  metadata: Record<string, unknown>
+}
+
+export type AgentQualityTrend = {
+  rubric_key: string
+  rubric_name: string
+  agent_key: string
+  workflow_key: string | null
+  latest_score: number | null
+  average_score: number | null
+  pass_rate: number | null
+  evaluation_count: number
+  threshold: number
+  latest_evaluated_at: string | null
+  direction: 'up' | 'down' | 'flat' | 'unknown'
+}
+
+export type AgentQualitySummary = {
+  window_hours: number
+  generated_at: string
+  rubric_count: number
+  evaluation_count: number
+  average_score: number | null
+  pass_rate: number | null
+  by_agent: Array<{
+    agent_key: string
+    evaluation_count: number
+    average_score: number | null
+    pass_rate: number | null
+    latest_score: number | null
+    latest_evaluated_at: string | null
+  }>
+  needs_coaching: Array<{
+    agent_key: string
+    rubric_key: string
+    rubric_name: string
+    latest_score: number | null
+    threshold: number
+    reason: string
+    run_id: string | null
+    evaluated_at: string | null
+  }>
+  rubric_trends: AgentQualityTrend[]
+}
+
+function db() {
+  if (!supabaseAdmin) {
+    throw new Error('Database not available')
+  }
+  return supabaseAdmin
+}
+
+function clampScore(score: number) {
+  return Math.max(0, Math.min(100, Number(score.toFixed(2))))
+}
+
+function scoreValue(value: number | string | null | undefined) {
+  const numberValue = Number(value ?? 0)
+  return Number.isFinite(numberValue) ? numberValue : 0
+}
+
+function normalizeDimensions(dimensions: unknown): AgentEvalDimension[] {
+  if (!Array.isArray(dimensions)) return []
+  return dimensions
+    .map((dimension): AgentEvalDimension | null => {
+      if (!dimension || typeof dimension !== 'object') return null
+      const record = dimension as Record<string, unknown>
+      const key = typeof record.key === 'string' ? record.key.trim() : ''
+      const label = typeof record.label === 'string' ? record.label.trim() : key
+      const weight = typeof record.weight === 'number' && Number.isFinite(record.weight) ? record.weight : undefined
+      return key && label ? { key, label, ...(weight === undefined ? {} : { weight }) } : null
+    })
+    .filter((dimension): dimension is AgentEvalDimension => Boolean(dimension))
+}
+
+export function validateAgentEvalRubric(rubric: Pick<AgentEvalRubricRow, 'key' | 'agent_key' | 'name' | 'dimensions' | 'threshold'>): AgentEvalDimension[] {
+  if (!rubric.key?.trim()) throw new Error('Rubric key is required')
+  if (!rubric.agent_key?.trim()) throw new Error('Rubric agent key is required')
+  if (!rubric.name?.trim()) throw new Error('Rubric name is required')
+
+  const threshold = scoreValue(rubric.threshold)
+  if (threshold < 0 || threshold > 100) {
+    throw new Error('Rubric threshold must be between 0 and 100')
+  }
+
+  const dimensions = normalizeDimensions(rubric.dimensions)
+  if (!dimensions.length) {
+    throw new Error('Rubric requires at least one dimension')
+  }
+  return dimensions
+}
+
+function runHasOutcome(run: AgentEvalRunRow) {
+  return Boolean(run.outcome && Object.keys(run.outcome).length > 0)
+}
+
+function runHasTraceMetadata(run: AgentEvalRunRow) {
+  return Boolean(run.current_step || run.subject_label || (run.metadata && Object.keys(run.metadata).length > 0))
+}
+
+function scoreDimension(baseScore: number, dimension: AgentEvalDimension, run: AgentEvalRunRow) {
+  const key = `${dimension.key} ${dimension.label}`.toLowerCase()
+  let score = baseScore
+
+  if (key.includes('trace') || key.includes('ground') || key.includes('provenance') || key.includes('attribution')) {
+    if (!runHasTraceMetadata(run)) score -= 15
+  }
+  if (key.includes('approval') || key.includes('send') || key.includes('outbound')) {
+    const approvalRequired = run.metadata?.requires_approval ?? run.outcome?.requires_approval
+    const statusShowsApproval = run.status === 'waiting_for_approval'
+    if (approvalRequired === false && !statusShowsApproval) score -= 10
+  }
+  if (key.includes('safety') || key.includes('privacy') || key.includes('isolation') || key.includes('boundary')) {
+    if (run.error_message || run.status === 'failed') score -= 20
+  }
+  if (key.includes('synthesis') || key.includes('action') || key.includes('handoff')) {
+    if (!runHasOutcome(run) && run.status === 'completed') score -= 10
+    if (!run.current_step) score -= 5
+  }
+
+  return clampScore(score)
+}
+
+export function scoreAgentRunAgainstRubric(run: AgentEvalRunRow, rubric: AgentEvalRubricRow): ScoredAgentRunEvaluation {
+  const dimensions = validateAgentEvalRubric(rubric)
+  const threshold = scoreValue(rubric.threshold)
+  const statusScore =
+    run.status === 'completed'
+      ? 90
+      : run.status === 'running' || run.status === 'queued' || run.status === 'waiting_for_approval'
+        ? 68
+        : run.status === 'stale' || run.status === 'cancelled'
+          ? 45
+          : 25
+
+  let baseScore = statusScore
+  if (run.error_message) baseScore -= 25
+  if (!run.current_step) baseScore -= 5
+  if (run.status === 'completed' && !runHasOutcome(run)) baseScore -= 5
+
+  const dimensionScores = dimensions.reduce<Record<string, number>>((acc, dimension) => {
+    acc[dimension.key] = scoreDimension(baseScore, dimension, run)
+    return acc
+  }, {})
+
+  const weightedTotal = dimensions.reduce((sum, dimension) => {
+    const weight = dimension.weight ?? 1 / dimensions.length
+    return sum + (dimensionScores[dimension.key] ?? 0) * weight
+  }, 0)
+  const totalWeight = dimensions.reduce((sum, dimension) => sum + (dimension.weight ?? 1 / dimensions.length), 0) || 1
+  const score = clampScore(weightedTotal / totalWeight)
+  const failureReasons = [
+    run.status === 'failed' ? 'Run failed before producing a reviewable output.' : null,
+    run.status === 'stale' ? 'Run is stale and needs owner follow-up.' : null,
+    run.error_message ? `Run error: ${run.error_message}` : null,
+    run.status === 'completed' && !runHasOutcome(run) ? 'Completed run does not expose a structured outcome.' : null,
+    score < threshold ? `Score ${score.toFixed(2)} is below threshold ${threshold.toFixed(2)}.` : null,
+  ].filter((reason): reason is string => Boolean(reason))
+
+  return {
+    run_id: run.id,
+    rubric_id: rubric.id,
+    rubric_key: rubric.key,
+    agent_key: rubric.agent_key || run.agent_key || 'chief-of-staff',
+    workflow_key: rubric.workflow_key ?? run.kind ?? null,
+    score,
+    passed: score >= threshold,
+    dimension_scores: dimensionScores,
+    judge_model: 'deterministic-agent-eval-v1',
+    summary: score >= threshold
+      ? `${rubric.name} passed at ${score.toFixed(2)}.`
+      : `${rubric.name} needs coaching at ${score.toFixed(2)}.`,
+    failure_reasons: failureReasons,
+    metadata: {
+      run_status: run.status,
+      runtime: run.runtime,
+      threshold,
+      mutation_policy: 'approval_gated',
+      autonomous_mutation: false,
+    },
+  }
+}
+
+export async function recordAgentRunEvaluation(input: RecordAgentRunEvaluationInput): Promise<AgentRunEvaluationRow> {
+  if (!input.runId.trim()) throw new Error('runId is required')
+  if (!input.rubricKey.trim()) throw new Error('rubricKey is required')
+  if (!input.agentKey.trim()) throw new Error('agentKey is required')
+  if (!Number.isFinite(input.score) || input.score < 0 || input.score > 100) {
+    throw new Error('Evaluation score must be between 0 and 100')
+  }
+
+  const score = clampScore(input.score)
+  const threshold = input.threshold ?? 80
+  const { data, error } = await db()
+    .from('agent_run_evaluations')
+    .upsert({
+      run_id: input.runId,
+      rubric_id: input.rubricId,
+      rubric_key: input.rubricKey,
+      agent_key: input.agentKey,
+      workflow_key: input.workflowKey ?? null,
+      score,
+      passed: score >= threshold,
+      dimension_scores: input.dimensionScores ?? {},
+      judge_model: input.judgeModel ?? 'deterministic-agent-eval-v1',
+      summary: input.summary ?? null,
+      failure_reasons: input.failureReasons ?? [],
+      metadata: {
+        ...(input.metadata ?? {}),
+        threshold,
+        mutation_policy: 'approval_gated',
+        autonomous_mutation: false,
+      },
+    }, { onConflict: 'run_id,rubric_key' })
+    .select('id, run_id, rubric_id, rubric_key, agent_key, workflow_key, score, passed, dimension_scores, judge_model, summary, failure_reasons, metadata, created_at')
+    .single()
+
+  if (error) throw new Error(`Failed to record agent evaluation: ${error.message}`)
+  return data as AgentRunEvaluationRow
+}
+
+export async function evaluateAgentRun(runId: string, rubricKey: string): Promise<AgentRunEvaluationRow> {
+  const runIdValue = runId.trim()
+  const rubricKeyValue = rubricKey.trim()
+  if (!runIdValue) throw new Error('runId is required')
+  if (!rubricKeyValue) throw new Error('rubricKey is required')
+
+  const [runRes, rubricRes] = await Promise.all([
+    db()
+      .from('agent_runs')
+      .select('id, agent_key, runtime, kind, title, status, subject_label, current_step, error_message, started_at, completed_at, outcome, metadata')
+      .eq('id', runIdValue)
+      .maybeSingle(),
+    db()
+      .from('agent_eval_rubrics')
+      .select('id, key, agent_key, workflow_key, name, description, dimensions, threshold, active, metadata')
+      .eq('key', rubricKeyValue)
+      .eq('active', true)
+      .maybeSingle(),
+  ])
+
+  if (runRes.error) throw new Error(`Failed to fetch agent run: ${runRes.error.message}`)
+  if (rubricRes.error) throw new Error(`Failed to fetch evaluation rubric: ${rubricRes.error.message}`)
+  if (!runRes.data) throw new Error('Agent run not found')
+  if (!rubricRes.data) throw new Error('Evaluation rubric not found')
+
+  const scored = scoreAgentRunAgainstRubric(runRes.data as AgentEvalRunRow, rubricRes.data as AgentEvalRubricRow)
+  const threshold = scoreValue((rubricRes.data as AgentEvalRubricRow).threshold)
+  const evaluation = await recordAgentRunEvaluation({
+    runId: scored.run_id,
+    rubricId: scored.rubric_id,
+    rubricKey: scored.rubric_key,
+    agentKey: scored.agent_key,
+    workflowKey: scored.workflow_key,
+    score: scored.score,
+    threshold,
+    dimensionScores: scored.dimension_scores,
+    judgeModel: scored.judge_model,
+    summary: scored.summary,
+    failureReasons: scored.failure_reasons,
+    metadata: scored.metadata,
+  })
+
+  await recordAgentEvent({
+    runId: runIdValue,
+    eventType: 'agent_run_evaluated',
+    severity: evaluation.passed ? 'info' : 'warning',
+    message: evaluation.summary ?? `Evaluated ${rubricKeyValue}`,
+    metadata: {
+      evaluation_id: evaluation.id,
+      rubric_key: evaluation.rubric_key,
+      score: scoreValue(evaluation.score),
+      passed: evaluation.passed,
+      judge_model: evaluation.judge_model,
+      failure_reasons: evaluation.failure_reasons ?? [],
+    },
+    idempotencyKey: `${runIdValue}:${rubricKeyValue}:evaluation`,
+  })
+
+  return evaluation
+}
+
+export function getEmptyAgentQualitySummary(windowHours = 24): AgentQualitySummary {
+  return {
+    window_hours: windowHours,
+    generated_at: new Date().toISOString(),
+    rubric_count: 0,
+    evaluation_count: 0,
+    average_score: null,
+    pass_rate: null,
+    by_agent: [],
+    needs_coaching: [],
+    rubric_trends: [],
+  }
+}
+
+export function summarizeAgentQuality(input: {
+  rubrics: AgentEvalRubricRow[]
+  evaluations: AgentRunEvaluationRow[]
+  windowHours?: number
+}): AgentQualitySummary {
+  const windowHours = input.windowHours ?? 24
+  const activeRubrics = input.rubrics.filter((rubric) => rubric.active)
+  const rubricsByKey = new Map(activeRubrics.map((rubric) => [rubric.key, rubric]))
+  const evaluations = [...input.evaluations].sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+  const totalScore = evaluations.reduce((sum, evaluation) => sum + scoreValue(evaluation.score), 0)
+  const passCount = evaluations.filter((evaluation) => evaluation.passed).length
+  const byAgent = new Map<string, AgentRunEvaluationRow[]>()
+  const byRubric = new Map<string, AgentRunEvaluationRow[]>()
+
+  for (const evaluation of evaluations) {
+    byAgent.set(evaluation.agent_key, [...(byAgent.get(evaluation.agent_key) ?? []), evaluation])
+    byRubric.set(evaluation.rubric_key, [...(byRubric.get(evaluation.rubric_key) ?? []), evaluation])
+  }
+
+  const agentSummaries = Array.from(byAgent.entries())
+    .map(([agentKey, rows]) => {
+      const latest = rows[0]
+      const rowScore = rows.reduce((sum, evaluation) => sum + scoreValue(evaluation.score), 0)
+      const rowPassCount = rows.filter((evaluation) => evaluation.passed).length
+      return {
+        agent_key: agentKey,
+        evaluation_count: rows.length,
+        average_score: Number((rowScore / rows.length).toFixed(2)),
+        pass_rate: Number((rowPassCount / rows.length).toFixed(2)),
+        latest_score: latest ? scoreValue(latest.score) : null,
+        latest_evaluated_at: latest?.created_at ?? null,
+      }
+    })
+    .sort((a, b) => (a.average_score ?? 0) - (b.average_score ?? 0))
+
+  const rubricTrends = activeRubrics.map<AgentQualityTrend>((rubric) => {
+    const rows = byRubric.get(rubric.key) ?? []
+    const latest = rows[0]
+    const previous = rows[1]
+    const average = rows.length
+      ? Number((rows.reduce((sum, evaluation) => sum + scoreValue(evaluation.score), 0) / rows.length).toFixed(2))
+      : null
+    const passRate = rows.length
+      ? Number((rows.filter((evaluation) => evaluation.passed).length / rows.length).toFixed(2))
+      : null
+    const latestScore = latest ? scoreValue(latest.score) : null
+    const previousScore = previous ? scoreValue(previous.score) : null
+    const direction =
+      latestScore === null || previousScore === null
+        ? 'unknown'
+        : latestScore > previousScore
+          ? 'up'
+          : latestScore < previousScore
+            ? 'down'
+            : 'flat'
+
+    return {
+      rubric_key: rubric.key,
+      rubric_name: rubric.name,
+      agent_key: rubric.agent_key,
+      workflow_key: rubric.workflow_key,
+      latest_score: latestScore,
+      average_score: average,
+      pass_rate: passRate,
+      evaluation_count: rows.length,
+      threshold: scoreValue(rubric.threshold),
+      latest_evaluated_at: latest?.created_at ?? null,
+      direction,
+    }
+  })
+
+  const needsCoaching = rubricTrends
+    .map((trend): AgentQualitySummary['needs_coaching'][number] | null => {
+      const latest = (byRubric.get(trend.rubric_key) ?? [])[0]
+      const latestScore = trend.latest_score
+      const lowLatest = latestScore !== null && latestScore < trend.threshold
+      const weakPassRate = trend.pass_rate !== null && trend.pass_rate < 0.8 && trend.evaluation_count >= 2
+      if (!lowLatest && !weakPassRate) return null
+
+      return {
+        agent_key: trend.agent_key,
+        rubric_key: trend.rubric_key,
+        rubric_name: trend.rubric_name,
+        latest_score: latestScore,
+        threshold: trend.threshold,
+        reason: lowLatest
+          ? `Latest score is below ${trend.threshold.toFixed(2)}.`
+          : `Pass rate is ${Math.round((trend.pass_rate ?? 0) * 100)}%.`,
+        run_id: latest?.run_id ?? null,
+        evaluated_at: latest?.created_at ?? null,
+      }
+    })
+    .filter((item): item is AgentQualitySummary['needs_coaching'][number] => Boolean(item))
+    .slice(0, 8)
+
+  return {
+    window_hours: windowHours,
+    generated_at: new Date().toISOString(),
+    rubric_count: activeRubrics.length,
+    evaluation_count: evaluations.length,
+    average_score: evaluations.length ? Number((totalScore / evaluations.length).toFixed(2)) : null,
+    pass_rate: evaluations.length ? Number((passCount / evaluations.length).toFixed(2)) : null,
+    by_agent: agentSummaries,
+    needs_coaching: needsCoaching,
+    rubric_trends: rubricTrends,
+  }
+}
+
+export async function getAgentQualitySummary(input: {
+  agentKey?: string
+  windowHours?: number
+} = {}): Promise<AgentQualitySummary> {
+  const windowHours = input.windowHours ?? 24
+  const since = new Date(Date.now() - windowHours * 60 * 60 * 1000).toISOString()
+
+  let rubricQuery = db()
+    .from('agent_eval_rubrics')
+    .select('id, key, agent_key, workflow_key, name, description, dimensions, threshold, active, metadata')
+    .eq('active', true)
+    .order('agent_key', { ascending: true })
+
+  let evaluationQuery = db()
+    .from('agent_run_evaluations')
+    .select('id, run_id, rubric_id, rubric_key, agent_key, workflow_key, score, passed, dimension_scores, judge_model, summary, failure_reasons, metadata, created_at')
+    .gte('created_at', since)
+    .order('created_at', { ascending: false })
+    .limit(250)
+
+  if (input.agentKey) {
+    rubricQuery = rubricQuery.eq('agent_key', input.agentKey)
+    evaluationQuery = evaluationQuery.eq('agent_key', input.agentKey)
+  }
+
+  const [rubricRes, evaluationRes] = await Promise.all([rubricQuery, evaluationQuery])
+  if (rubricRes.error) throw new Error(`Failed to fetch evaluation rubrics: ${rubricRes.error.message}`)
+  if (evaluationRes.error) throw new Error(`Failed to fetch agent evaluations: ${evaluationRes.error.message}`)
+
+  return summarizeAgentQuality({
+    rubrics: (rubricRes.data ?? []) as AgentEvalRubricRow[],
+    evaluations: (evaluationRes.data ?? []) as AgentRunEvaluationRow[],
+    windowHours,
+  })
+}

--- a/lib/agent-mission-control.ts
+++ b/lib/agent-mission-control.ts
@@ -1,4 +1,5 @@
 import { AGENT_ORGANIZATION, AGENT_PODS } from '@/lib/agent-organization'
+import { getAgentQualitySummary, getEmptyAgentQualitySummary } from '@/lib/agent-evaluations'
 import { KNOWLEDGE_GOVERNANCE_STATUS } from '@/lib/knowledge-source-manifest'
 import { supabaseAdmin } from '@/lib/supabase'
 
@@ -785,6 +786,10 @@ export async function buildAgentMissionControlSnapshot() {
     activeRunsCount: activeRuns.length,
     failedRunsCount: failedRuns.length,
   })
+  const qualitySummary = await getAgentQualitySummary({ windowHours: 24 }).catch((error) => {
+    console.warn('[agent-mission-control] quality summary unavailable:', error)
+    return getEmptyAgentQualitySummary(24)
+  })
 
   return {
     generated_at: new Date().toISOString(),
@@ -829,6 +834,7 @@ export async function buildAgentMissionControlSnapshot() {
     latest_standup: latestStandup ? summarizeRun(latestStandup, costByRun) : null,
     daily_brief: dailyBrief,
     cost_summary: costSummary,
+    quality_summary: qualitySummary,
     operating_signals: operatingSignals,
     knowledge_governance: KNOWLEDGE_GOVERNANCE_STATUS,
     agent_inbox: agentInbox,

--- a/supabase/migrations/20260510105350_agent_eval_rubrics.sql
+++ b/supabase/migrations/20260510105350_agent_eval_rubrics.sql
@@ -1,0 +1,172 @@
+-- Hyperagent-inspired agent evaluation foundation.
+-- These tables keep rubrics and run-level scores trace-backed without mutating
+-- prompts, skills, workflows, or runtime behavior.
+
+CREATE TABLE IF NOT EXISTS public.agent_eval_rubrics (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  key TEXT NOT NULL UNIQUE,
+  agent_key TEXT NOT NULL,
+  workflow_key TEXT,
+  name TEXT NOT NULL,
+  description TEXT,
+  dimensions JSONB NOT NULL DEFAULT '[]'::jsonb,
+  threshold NUMERIC(5, 2) NOT NULL DEFAULT 80,
+  active BOOLEAN NOT NULL DEFAULT true,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT agent_eval_rubrics_key_not_blank CHECK (length(trim(key)) > 0),
+  CONSTRAINT agent_eval_rubrics_agent_key_not_blank CHECK (length(trim(agent_key)) > 0),
+  CONSTRAINT agent_eval_rubrics_name_not_blank CHECK (length(trim(name)) > 0),
+  CONSTRAINT agent_eval_rubrics_dimensions_array CHECK (jsonb_typeof(dimensions) = 'array'),
+  CONSTRAINT agent_eval_rubrics_has_dimensions CHECK (jsonb_array_length(dimensions) > 0),
+  CONSTRAINT agent_eval_rubrics_threshold_range CHECK (threshold >= 0 AND threshold <= 100)
+);
+
+CREATE TABLE IF NOT EXISTS public.agent_run_evaluations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_id UUID NOT NULL REFERENCES public.agent_runs(id) ON DELETE CASCADE,
+  rubric_id UUID NOT NULL REFERENCES public.agent_eval_rubrics(id) ON DELETE RESTRICT,
+  rubric_key TEXT NOT NULL,
+  agent_key TEXT NOT NULL,
+  workflow_key TEXT,
+  score NUMERIC(5, 2) NOT NULL,
+  passed BOOLEAN NOT NULL,
+  dimension_scores JSONB NOT NULL DEFAULT '{}'::jsonb,
+  judge_model TEXT NOT NULL DEFAULT 'deterministic-agent-eval-v1',
+  summary TEXT,
+  failure_reasons TEXT[] NOT NULL DEFAULT '{}',
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT agent_run_evaluations_rubric_key_not_blank CHECK (length(trim(rubric_key)) > 0),
+  CONSTRAINT agent_run_evaluations_agent_key_not_blank CHECK (length(trim(agent_key)) > 0),
+  CONSTRAINT agent_run_evaluations_score_range CHECK (score >= 0 AND score <= 100),
+  CONSTRAINT agent_run_evaluations_dimension_scores_object CHECK (jsonb_typeof(dimension_scores) = 'object')
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS agent_run_evaluations_run_rubric_uidx
+  ON public.agent_run_evaluations(run_id, rubric_key);
+
+CREATE INDEX IF NOT EXISTS agent_eval_rubrics_active_agent_idx
+  ON public.agent_eval_rubrics(active, agent_key);
+
+CREATE INDEX IF NOT EXISTS agent_run_evaluations_agent_created_idx
+  ON public.agent_run_evaluations(agent_key, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS agent_run_evaluations_rubric_created_idx
+  ON public.agent_run_evaluations(rubric_key, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS agent_run_evaluations_run_idx
+  ON public.agent_run_evaluations(run_id);
+
+ALTER TABLE public.agent_eval_rubrics ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.agent_run_evaluations ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE public.agent_eval_rubrics IS 'Rubric definitions for evaluating agent and workflow output quality.';
+COMMENT ON TABLE public.agent_run_evaluations IS 'Trace-linked agent run evaluations and coaching signals.';
+COMMENT ON COLUMN public.agent_eval_rubrics.dimensions IS 'Array of rubric dimension objects with key, label, and optional weight.';
+COMMENT ON COLUMN public.agent_run_evaluations.judge_model IS 'Judge implementation or model used for the score. V1 uses deterministic trace scoring unless an LLM judge is explicitly enabled.';
+
+INSERT INTO public.agent_eval_rubrics (
+  key,
+  agent_key,
+  workflow_key,
+  name,
+  description,
+  dimensions,
+  threshold,
+  active,
+  metadata
+)
+VALUES
+  (
+    'chief-of-staff-synthesis-quality',
+    'chief-of-staff',
+    'agent_war_room_standup',
+    'Chief of Staff Synthesis Quality',
+    'Checks whether Chief of Staff summaries are coherent, actionable, grounded in current traces, and explicit about approval gates.',
+    '[
+      {"key":"grounding","label":"Grounded in current traces","weight":0.25},
+      {"key":"synthesis","label":"Clear executive synthesis","weight":0.25},
+      {"key":"next_actions","label":"Specific next actions","weight":0.25},
+      {"key":"approval_gates","label":"Approval gates are explicit","weight":0.25}
+    ]'::jsonb,
+    82,
+    true,
+    '{"source":"hyperagent_parity_v1","mutation_policy":"approval_gated"}'::jsonb
+  ),
+  (
+    'warm-lead-capture-trace-completeness',
+    'warm-lead-capture',
+    'warm_lead_capture',
+    'Warm Lead Capture Trace Completeness',
+    'Checks whether warm-lead automation traces capture canonical source, test-data boundaries, cost linkage, and downstream handoff status.',
+    '[
+      {"key":"trace_completeness","label":"Run trace is complete","weight":0.3},
+      {"key":"source_canonicalization","label":"Lead source is canonical","weight":0.25},
+      {"key":"data_boundary","label":"Production and non-production data boundaries are clear","weight":0.25},
+      {"key":"handoff_status","label":"Downstream handoff is visible","weight":0.2}
+    ]'::jsonb,
+    85,
+    true,
+    '{"source":"hyperagent_parity_v1","non_prod_data_rule":true}'::jsonb
+  ),
+  (
+    'meeting-intake-follow-up-safety-isolation',
+    'meeting-intake-follow-up',
+    'meeting_intake_follow_up',
+    'Meeting Intake and Follow-Up Safety Isolation',
+    'Checks whether meeting intake work preserves channel boundaries, separates test from production records, and keeps outbound actions approval-gated.',
+    '[
+      {"key":"channel_isolation","label":"Channel and source isolation","weight":0.25},
+      {"key":"test_data_boundary","label":"Synthetic/test records are isolated","weight":0.25},
+      {"key":"approval_readiness","label":"Outbound actions require approval","weight":0.25},
+      {"key":"traceability","label":"Trace links intake to follow-up","weight":0.25}
+    ]'::jsonb,
+    85,
+    true,
+    '{"source":"hyperagent_parity_v1","approval_required_for_outbound":true}'::jsonb
+  ),
+  (
+    'inbox-follow-up-approval-readiness',
+    'inbox-follow-up',
+    'outreach_follow_up',
+    'Inbox and Follow-Up Approval Readiness',
+    'Checks whether follow-up drafts are attributable, client-safe, approval-ready, and clear about send-state.',
+    '[
+      {"key":"attribution","label":"Context and source attribution","weight":0.25},
+      {"key":"client_safety","label":"Client-safe content handling","weight":0.25},
+      {"key":"approval_package","label":"Approval package is complete","weight":0.25},
+      {"key":"send_state","label":"Send state is unambiguous","weight":0.25}
+    ]'::jsonb,
+    84,
+    true,
+    '{"source":"hyperagent_parity_v1","send_requires_approval":true}'::jsonb
+  ),
+  (
+    'research-source-register-source-quality',
+    'research-source-register',
+    'research_source_register',
+    'Research and Source Register Source Quality',
+    'Checks whether research outputs separate public and private material, preserve provenance, and identify weak or missing evidence.',
+    '[
+      {"key":"provenance","label":"Source provenance is preserved","weight":0.3},
+      {"key":"privacy_boundary","label":"Private material is summarized safely","weight":0.25},
+      {"key":"evidence_quality","label":"Evidence quality is assessed","weight":0.25},
+      {"key":"source_gaps","label":"Gaps and assumptions are visible","weight":0.2}
+    ]'::jsonb,
+    86,
+    true,
+    '{"source":"hyperagent_parity_v1","source_protocol":true}'::jsonb
+  )
+ON CONFLICT (key) DO UPDATE
+SET
+  agent_key = EXCLUDED.agent_key,
+  workflow_key = EXCLUDED.workflow_key,
+  name = EXCLUDED.name,
+  description = EXCLUDED.description,
+  dimensions = EXCLUDED.dimensions,
+  threshold = EXCLUDED.threshold,
+  active = EXCLUDED.active,
+  metadata = EXCLUDED.metadata,
+  updated_at = now();


### PR DESCRIPTION
Summary
- Adds trace-backed agent evaluation rubric tables and seed rubrics for Chief of Staff, warm lead capture, meeting intake/follow-up, inbox follow-up, and research source quality.
- Adds evaluation helpers and admin APIs for quality summaries and run-level scoring.
- Surfaces Quality Signals, Needs Coaching, and Rubric Trends in Mission Control, plus an Evaluate action on run detail pages.
- Documents Hyperagent feature parity posture and next targets.

Validation
- npm test -- --run lib/agent-evaluations.test.ts app/api/admin/agents/evaluations/route.test.ts app/api/admin/agents/runs/[runId]/evaluate/route.test.ts app/api/admin/agents/mission-control/route.test.ts
- npx tsc --noEmit --pretty false
- npm run lint -- --file app/admin/agents/page.tsx --file app/admin/agents/runs/[runId]/page.tsx --file lib/agent-evaluations.ts
- git diff --check
- Local smoke: npm run dev -- --hostname 127.0.0.1 --port 3000; curl -I /admin/agents returned 200; GET /admin/agents returned 200.
- Pre-push database health check passed.

Integration Notes
- Requires Supabase migration: supabase/migrations/20260510105350_agent_eval_rubrics.sql.
- RLS is enabled on both new evaluation tables; admin APIs use service-role server-side access.
- V1 scoring is deterministic and trace-based to avoid unapproved model spend. Schema supports future LLM-as-judge scoring behind budget/approval gates.
- No production prompts, skills, n8n workflows, Slack behavior, or customer data flows are mutated automatically.
- Vercel – portfolio and Vercel – portfolio-staging not checked from this non-captain lane; Integration Captain should verify after merge.