### PR TITLE
feat: add Slack agent chat events

### DIFF
--- a/app/api/slack/agent/events/route.test.ts
+++ b/app/api/slack/agent/events/route.test.ts
@@ -1,0 +1,104 @@
+import { createHmac } from 'crypto'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  handleSlackAgentEvent: vi.fn(),
+  waitUntil: vi.fn(),
+}))
+
+vi.mock('@/lib/agent-slack-events', () => ({
+  handleSlackAgentEvent: mocks.handleSlackAgentEvent,
+}))
+
+vi.mock('@vercel/functions', () => ({
+  waitUntil: mocks.waitUntil,
+}))
+
+import { POST } from './route'
+
+const ORIGINAL_ENV = process.env
+
+function signedRequest(body: unknown, secret = 'test-slack-secret', extraHeaders: Record<string, string> = {}) {
+  const rawBody = JSON.stringify(body)
+  const timestamp = Math.floor(Date.now() / 1000).toString()
+  const signature = `v0=${createHmac('sha256', secret).update(`v0:${timestamp}:${rawBody}`).digest('hex')}`
+
+  return new Request('http://localhost/api/slack/agent/events', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-slack-request-timestamp': timestamp,
+      'x-slack-signature': signature,
+      ...extraHeaders,
+    },
+    body: rawBody,
+  })
+}
+
+describe('POST /api/slack/agent/events', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env = { ...ORIGINAL_ENV, SLACK_SIGNING_SECRET: 'test-slack-secret' }
+    mocks.handleSlackAgentEvent.mockResolvedValue({ handled: true, runId: 'run-123' })
+  })
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV
+  })
+
+  it('rejects invalid Slack signatures', async () => {
+    const request = signedRequest({ type: 'event_callback' }, 'wrong-secret')
+
+    const response = await POST(request as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Invalid Slack signature' })
+    expect(mocks.handleSlackAgentEvent).not.toHaveBeenCalled()
+  })
+
+  it('responds to Slack URL verification challenges', async () => {
+    const request = signedRequest({ type: 'url_verification', challenge: 'challenge-token' })
+
+    const response = await POST(request as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ challenge: 'challenge-token' })
+    expect(mocks.waitUntil).not.toHaveBeenCalled()
+  })
+
+  it('acknowledges Slack event callbacks and schedules async handling', async () => {
+    const payload = {
+      type: 'event_callback',
+      event_id: 'Ev123',
+      event: {
+        type: 'app_mention',
+        user: 'U123',
+        channel: 'C123',
+        text: '<@UAGENT> status?',
+      },
+    }
+    const request = signedRequest(payload)
+
+    const response = await POST(request as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ ok: true })
+    expect(mocks.handleSlackAgentEvent).toHaveBeenCalledWith(payload)
+    expect(mocks.waitUntil).toHaveBeenCalledWith(expect.any(Promise))
+  })
+
+  it('dedupes Slack retries before scheduling event work', async () => {
+    const request = signedRequest(
+      { type: 'event_callback', event_id: 'Ev123' },
+      'test-slack-secret',
+      { 'x-slack-retry-num': '1' },
+    )
+
+    const response = await POST(request as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ ok: true, skipped: 'slack_retry' })
+    expect(mocks.handleSlackAgentEvent).not.toHaveBeenCalled()
+    expect(mocks.waitUntil).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/slack/agent/events/route.ts
+++ b/app/api/slack/agent/events/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { waitUntil } from '@vercel/functions'
+import { handleSlackAgentEvent, type SlackAgentEventPayload } from '@/lib/agent-slack-events'
+import { verifySlackSignature } from '@/lib/slack-signature'
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 60
+
+/**
+ * POST /api/slack/agent/events
+ *
+ * Slack Events API handler for conversational Agent Ops access. V1 supports
+ * app mentions and direct messages, routes them into the read-only Chief of
+ * Staff chat layer, and posts the response back to Slack.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const rawBody = await request.text()
+    const isValid = verifySlackSignature(request, rawBody)
+    if (!isValid) {
+      return NextResponse.json({ error: 'Invalid Slack signature' }, { status: 401 })
+    }
+
+    let payload: SlackAgentEventPayload
+    try {
+      payload = JSON.parse(rawBody)
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+    }
+
+    if (payload.type === 'url_verification') {
+      return NextResponse.json({ challenge: payload.challenge ?? '' })
+    }
+
+    if (request.headers.get('x-slack-retry-num')) {
+      return NextResponse.json({ ok: true, skipped: 'slack_retry' })
+    }
+
+    waitUntil(handleSlackAgentEvent(payload))
+    return NextResponse.json({ ok: true })
+  } catch (error) {
+    console.error('Error in Slack agent event handler:', error)
+    return NextResponse.json({ ok: false, error: 'Slack agent event failed' }, { status: 500 })
+  }
+}

--- a/app/api/slack/agent/route.ts
+++ b/app/api/slack/agent/route.ts
@@ -1,6 +1,6 @@
-import { createHmac, timingSafeEqual } from 'crypto'
 import { NextRequest, NextResponse } from 'next/server'
 import { waitUntil } from '@vercel/functions'
+import { verifySlackSignature } from '@/lib/slack-signature'
 
 export const dynamic = 'force-dynamic'
 
@@ -106,36 +106,4 @@ async function postDelayedAgentResponse(
       }),
     }).catch(() => {})
   }
-}
-
-function verifySlackSignature(request: NextRequest, rawBody: string) {
-  const signingSecret = process.env.SLACK_SIGNING_SECRET
-  if (!signingSecret) {
-    const allowUnsignedLocal =
-      process.env.NODE_ENV !== 'production' && !process.env.VERCEL && process.env.NEXT_PUBLIC_APP_ENV !== 'staging'
-    if (allowUnsignedLocal) {
-      console.warn('SLACK_SIGNING_SECRET not configured -- skipping verification for local development')
-      return true
-    }
-    console.warn('SLACK_SIGNING_SECRET not configured -- rejecting Slack request')
-    return false
-  }
-
-  const timestamp = request.headers.get('x-slack-request-timestamp')
-  const signature = request.headers.get('x-slack-signature')
-  if (!timestamp || !signature) return false
-
-  const timestampSeconds = Number(timestamp)
-  if (!Number.isFinite(timestampSeconds)) return false
-
-  const now = Math.floor(Date.now() / 1000)
-  if (Math.abs(now - timestampSeconds) > 300) return false
-
-  const basestring = `v0:${timestamp}:${rawBody}`
-  const expectedSignature = `v0=${createHmac('sha256', signingSecret).update(basestring).digest('hex')}`
-  const expected = Buffer.from(expectedSignature)
-  const actual = Buffer.from(signature)
-
-  if (expected.length !== actual.length) return false
-  return timingSafeEqual(expected, actual)
 }

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -266,6 +266,29 @@ The route verifies Slack signatures with `SLACK_SIGNING_SECRET` when configured 
 
 Slack is an engagement surface, not the source of truth. The admin console and shared trace tables remain authoritative.
 
+## Slack Agent Chat
+
+Configure Slack Events API subscriptions for the Agent Ops app to call `POST /api/slack/agent/events`. The production request URL is:
+
+- `https://amadutown.com/api/slack/agent/events`
+
+V1 supports:
+
+- `app_mention` — mention the Agent Ops bot in a channel and ask a freeform question.
+- `message.im` — DM the Agent Ops bot directly.
+- `url_verification` — returns Slack's challenge during Events API setup.
+
+Required Slack app configuration:
+
+- Event subscriptions enabled with request URL `https://amadutown.com/api/slack/agent/events`.
+- Bot events: `app_mention` and `message.im`.
+- Bot token scopes: `app_mentions:read`, `im:history`, and `chat:write`.
+- Environment variables: `SLACK_SIGNING_SECRET` and `SLACK_BOT_TOKEN`.
+
+The event route verifies Slack signatures with `SLACK_SIGNING_SECRET`, ignores bot/subtype events, acknowledges Slack immediately, and uses `SLACK_BOT_TOKEN` to post the Chief of Staff reply back into the originating thread. The conversation path reuses the existing read-only Chief of Staff chat engine and records an observable `agent_run` with `trigger_source = slack_agent_chat`.
+
+Chat is for freeform status, triage, and coordination. Deterministic operations should stay on `/agent` commands, and production-impacting actions remain approval-gated.
+
 ## Mission Control And War Room
 
 Mission Control uses `GET /api/admin/agents/mission-control` as a derived read model over existing tables. It does not introduce new schema in v1. The endpoint returns the status strip, agent roster, attention queue, Agent Inbox, Engagement Work Queue, Daily Operating Brief, active runs, latest events, pending approvals, and latest standup trace.

--- a/lib/agent-slack-events.test.ts
+++ b/lib/agent-slack-events.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  runChiefOfStaffChat: vi.fn(),
+}))
+
+vi.mock('@/lib/chief-of-staff-chat', () => ({
+  runChiefOfStaffChat: mocks.runChiefOfStaffChat,
+}))
+
+import {
+  formatChiefOfStaffSlackReply,
+  handleSlackAgentEvent,
+  normalizeSlackAgentMessage,
+  shouldHandleSlackAgentEvent,
+} from './agent-slack-events'
+
+const ORIGINAL_ENV = process.env
+
+describe('agent Slack events', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ ok: true, ts: '1700000000.000001' }),
+      }),
+    )
+    process.env = {
+      ...ORIGINAL_ENV,
+      NEXT_PUBLIC_APP_URL: 'https://amadutown.test',
+      SLACK_BOT_TOKEN: 'xoxb-test',
+    }
+    mocks.runChiefOfStaffChat.mockResolvedValue({
+      runId: 'run-123',
+      reply: 'Two items need attention.',
+      suggestedActions: ['Check blockers', 'Review PR queue'],
+      agentEngagements: [
+        {
+          agentKey: 'chief-of-staff',
+          rationale: 'Coordinate the next operating decision.',
+        },
+      ],
+      actionProposals: [],
+      model: 'gpt-4o-mini',
+      budgetDecision: { status: 'allowed' },
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    process.env = ORIGINAL_ENV
+  })
+
+  it('handles app mentions and direct messages only', () => {
+    expect(shouldHandleSlackAgentEvent({
+      type: 'app_mention',
+      user: 'U123',
+      channel: 'C123',
+      text: '<@BOT> status?',
+    })).toBe(true)
+
+    expect(shouldHandleSlackAgentEvent({
+      type: 'message',
+      channel_type: 'im',
+      user: 'U123',
+      channel: 'D123',
+      text: 'status?',
+    })).toBe(true)
+
+    expect(shouldHandleSlackAgentEvent({
+      type: 'message',
+      channel_type: 'channel',
+      user: 'U123',
+      channel: 'C123',
+      text: 'status?',
+    })).toBe(false)
+
+    expect(shouldHandleSlackAgentEvent({
+      type: 'app_mention',
+      bot_id: 'B123',
+      user: 'U123',
+      channel: 'C123',
+      text: '<@BOT> status?',
+    })).toBe(false)
+  })
+
+  it('normalizes mention text into a freeform Chief of Staff prompt', () => {
+    expect(normalizeSlackAgentMessage({
+      text: '<@UAGENT>   what is blocked right now?  <@UOTHER>',
+    })).toBe('what is blocked right now?')
+  })
+
+  it('routes a Slack mention into Chief of Staff chat and replies in thread', async () => {
+    const result = await handleSlackAgentEvent({
+      type: 'event_callback',
+      event_id: 'Ev123',
+      event: {
+        type: 'app_mention',
+        user: 'U123',
+        channel: 'C123',
+        text: '<@UAGENT> what needs attention?',
+        ts: '1700000000.000000',
+      },
+    })
+
+    expect(result).toEqual({ handled: true, runId: 'run-123' })
+    expect(mocks.runChiefOfStaffChat).toHaveBeenCalledWith({
+      message: 'what needs attention?',
+      userId: 'slack:U123',
+      triggerSource: 'slack_agent_chat',
+    })
+    expect(fetch).toHaveBeenCalledWith(
+      'https://slack.com/api/chat.postMessage',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer xoxb-test',
+        }),
+        body: expect.stringContaining('"channel":"C123"'),
+      }),
+    )
+    expect((fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0]?.[1]?.body).toContain('"thread_ts":"1700000000.000000"')
+  })
+
+  it('formats Chief of Staff replies with trace links', () => {
+    const text = formatChiefOfStaffSlackReply({
+      runId: 'run-123',
+      reply: 'Check the queue.',
+      suggestedActions: ['Review blockers'],
+      agentEngagements: [
+        {
+          agentKey: 'automation-systems',
+          rationale: 'Inspect workflow health.',
+        },
+      ],
+      actionProposals: [],
+      model: 'gpt-4o-mini',
+      budgetDecision: { status: 'allowed' },
+    } as never)
+
+    expect(text).toContain('Check the queue.')
+    expect(text).toContain('*Suggested next actions*')
+    expect(text).toContain('`automation-systems` -')
+    expect(text).toContain('https://amadutown.test/admin/agents/runs/run-123')
+  })
+})

--- a/lib/agent-slack-events.ts
+++ b/lib/agent-slack-events.ts
@@ -1,0 +1,130 @@
+import { runChiefOfStaffChat } from '@/lib/chief-of-staff-chat'
+
+export type SlackAgentEvent = {
+  type?: string
+  channel?: string
+  channel_type?: string
+  user?: string
+  text?: string
+  ts?: string
+  thread_ts?: string
+  bot_id?: string
+  subtype?: string
+}
+
+export type SlackAgentEventPayload = {
+  type?: string
+  challenge?: string
+  event_id?: string
+  event?: SlackAgentEvent
+}
+
+type SlackPostMessageInput = {
+  channel: string
+  text: string
+  threadTs?: string
+}
+
+type HandleableSlackAgentEvent = SlackAgentEvent & {
+  channel: string
+  user: string
+}
+
+export function shouldHandleSlackAgentEvent(event: SlackAgentEvent | undefined): event is HandleableSlackAgentEvent {
+  if (!event) return false
+  if (event.bot_id || event.subtype) return false
+  if (!event.user || !event.channel) return false
+  if (event.type === 'app_mention') return true
+  return event.type === 'message' && event.channel_type === 'im'
+}
+
+export function normalizeSlackAgentMessage(event: SlackAgentEvent) {
+  return (event.text || '')
+    .replace(/<@[A-Z0-9]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+export function formatChiefOfStaffSlackReply(result: Awaited<ReturnType<typeof runChiefOfStaffChat>>) {
+  const parts = [
+    result.reply,
+    result.suggestedActions.length
+      ? `*Suggested next actions*\n${result.suggestedActions.map((action) => `- ${action}`).join('\n')}`
+      : null,
+    result.agentEngagements.length
+      ? `*Relevant agents*\n${result.agentEngagements
+        .map((agent) => `- \`${agent.agentKey}\` - ${agent.rationale}`)
+        .join('\n')}`
+      : null,
+    `Trace: ${baseUrl()}/admin/agents/runs/${result.runId}`,
+  ]
+
+  return parts.filter(Boolean).join('\n\n')
+}
+
+export async function handleSlackAgentEvent(payload: SlackAgentEventPayload) {
+  const event = payload.event
+  if (!shouldHandleSlackAgentEvent(event)) {
+    return { handled: false as const, reason: 'unsupported_event' }
+  }
+
+  const channel = event.channel
+  const user = event.user
+  const message = normalizeSlackAgentMessage(event)
+  if (!message) {
+    await postSlackAgentMessage({
+      channel,
+      threadTs: event.thread_ts || event.ts,
+      text: 'Ask me a question or tell me what Agent Ops should inspect. For deterministic controls, use `/agent help`.',
+    })
+    return { handled: true as const, reason: 'empty_message' }
+  }
+
+  const result = await runChiefOfStaffChat({
+    message,
+    userId: `slack:${user}`,
+    triggerSource: 'slack_agent_chat',
+  })
+
+  await postSlackAgentMessage({
+    channel,
+    threadTs: event.thread_ts || event.ts,
+    text: formatChiefOfStaffSlackReply(result),
+  })
+
+  return { handled: true as const, runId: result.runId }
+}
+
+export async function postSlackAgentMessage(input: SlackPostMessageInput) {
+  const token = process.env.SLACK_BOT_TOKEN
+  if (!token) {
+    console.warn('[agent-slack-events] SLACK_BOT_TOKEN not configured; skipping Slack reply')
+    return { ok: false, skipped: true, error: 'missing_slack_bot_token' }
+  }
+
+  const response = await fetch('https://slack.com/api/chat.postMessage', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+    body: JSON.stringify({
+      channel: input.channel,
+      text: input.text,
+      thread_ts: input.threadTs,
+      unfurl_links: false,
+      unfurl_media: false,
+    }),
+  })
+
+  const body = await response.json().catch(() => null)
+  if (!response.ok || body?.ok === false) {
+    console.warn('[agent-slack-events] Slack reply failed:', response.status, body)
+  }
+
+  return body
+}
+
+function baseUrl() {
+  return process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_BASE_URL || 'https://amadutown.com'
+}

--- a/lib/chief-of-staff-chat.ts
+++ b/lib/chief-of-staff-chat.ts
@@ -31,6 +31,7 @@ export type ChiefOfStaffChatRequest = {
   message: string
   history?: ChiefOfStaffChatMessage[]
   userId?: string
+  triggerSource?: string
 }
 
 export type ChiefOfStaffChatResponse = {
@@ -512,7 +513,7 @@ export async function runChiefOfStaffChat(input: ChiefOfStaffChatRequest): Promi
     title: 'Chief of Staff chat',
     status: 'running',
     subject: { type: 'admin_chat', id: input.userId ?? 'admin', label: 'Admin chat' },
-    triggerSource: 'admin_chief_of_staff_chat',
+    triggerSource: input.triggerSource ?? 'admin_chief_of_staff_chat',
     triggeredByUserId: input.userId,
     currentStep: 'Collecting operating context',
     metadata: { message_preview: message.slice(0, 240) },

--- a/lib/slack-signature.ts
+++ b/lib/slack-signature.ts
@@ -1,0 +1,34 @@
+import { createHmac, timingSafeEqual } from 'crypto'
+import { NextRequest } from 'next/server'
+
+export function verifySlackSignature(request: NextRequest, rawBody: string) {
+  const signingSecret = process.env.SLACK_SIGNING_SECRET
+  if (!signingSecret) {
+    const allowUnsignedLocal =
+      process.env.NODE_ENV !== 'production' && !process.env.VERCEL && process.env.NEXT_PUBLIC_APP_ENV !== 'staging'
+    if (allowUnsignedLocal) {
+      console.warn('SLACK_SIGNING_SECRET not configured -- skipping verification for local development')
+      return true
+    }
+    console.warn('SLACK_SIGNING_SECRET not configured -- rejecting Slack request')
+    return false
+  }
+
+  const timestamp = request.headers.get('x-slack-request-timestamp')
+  const signature = request.headers.get('x-slack-signature')
+  if (!timestamp || !signature) return false
+
+  const timestampSeconds = Number(timestamp)
+  if (!Number.isFinite(timestampSeconds)) return false
+
+  const now = Math.floor(Date.now() / 1000)
+  if (Math.abs(now - timestampSeconds) > 300) return false
+
+  const basestring = `v0:${timestamp}:${rawBody}`
+  const expectedSignature = `v0=${createHmac('sha256', signingSecret).update(basestring).digest('hex')}`
+  const expected = Buffer.from(expectedSignature)
+  const actual = Buffer.from(signature)
+
+  if (expected.length !== actual.length) return false
+  return timingSafeEqual(expected, actual)
+}


### PR DESCRIPTION
Summary
- Add a Slack Events API endpoint for Agent Ops app mentions and direct-message chat.
- Route Slack freeform messages into the existing read-only Chief of Staff chat engine and post replies back into the originating Slack thread.
- Share Slack signature verification between slash commands and events, and document required Slack event subscriptions/scopes/env vars.

Validation
- npm test -- --run lib/agent-slack-events.test.ts app/api/slack/agent/events/route.test.ts app/api/slack/agent/route.test.ts app/api/admin/agents/chief-of-staff/chat/route.test.ts
- npx tsc --noEmit --pretty false
- git diff --check
- set -a; source /Users/vambahsillah/Projects/Portfolio/.env.local; set +a; npm run build

Integration Notes
- Requires Slack app Events API request URL: https://amadutown.com/api/slack/agent/events
- Required bot events: app_mention and message.im.
- Required bot scopes: app_mentions:read, im:history, chat:write.
- Required env vars: SLACK_SIGNING_SECRET and SLACK_BOT_TOKEN.
- Build passed with the existing local outbound n8n warning. No live Slack event smoke was run.
- Vercel contexts not checked yet: Vercel – portfolio, Vercel – portfolio-staging.