### PR TITLE
feat: add open brain memory dashboard

### DIFF
--- a/app/admin/agents/open-brain/page.tsx
+++ b/app/admin/agents/open-brain/page.tsx
@@ -1,0 +1,474 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { ReactNode } from 'react'
+import Link from 'next/link'
+import {
+  AlertTriangle,
+  Brain,
+  CheckCircle2,
+  Database,
+  FileText,
+  GitBranch,
+  Network,
+  RefreshCw,
+  ShieldCheck,
+} from 'lucide-react'
+import ProtectedRoute from '@/components/ProtectedRoute'
+import Breadcrumbs from '@/components/admin/Breadcrumbs'
+import { getCurrentSession } from '@/lib/auth'
+import type { OpenBrainSnapshot } from '@/lib/open-brain'
+
+type ViewMode = 'sources' | 'proposals' | 'wiki' | 'parity'
+
+export default function OpenBrainPage() {
+  return (
+    <ProtectedRoute requireAdmin>
+      <OpenBrainContent />
+    </ProtectedRoute>
+  )
+}
+
+function OpenBrainContent() {
+  const [snapshot, setSnapshot] = useState<OpenBrainSnapshot | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [viewMode, setViewMode] = useState<ViewMode>('sources')
+  const [actionMessage, setActionMessage] = useState<string | null>(null)
+  const [reviewingProposalId, setReviewingProposalId] = useState<string | null>(null)
+
+  const authedFetch = useCallback(async (url: string, init: RequestInit = {}) => {
+    const session = await getCurrentSession()
+    if (!session?.access_token) throw new Error('Missing admin session')
+    const res = await fetch(url, {
+      ...init,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${session.access_token}`,
+        ...(init.headers || {}),
+      },
+    })
+    const body = await res.json().catch(() => ({}))
+    if (!res.ok) throw new Error(body.error || `HTTP ${res.status}`)
+    return body
+  }, [])
+
+  const fetchSnapshot = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      setSnapshot(await authedFetch('/api/admin/agents/open-brain'))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load Open Brain status')
+      setSnapshot(null)
+    } finally {
+      setLoading(false)
+    }
+  }, [authedFetch])
+
+  useEffect(() => {
+    fetchSnapshot()
+  }, [fetchSnapshot])
+
+  const pendingProposals = useMemo(
+    () => snapshot?.proposals.filter((proposal) => proposal.status === 'pending') || [],
+    [snapshot?.proposals],
+  )
+
+  async function compileWiki() {
+    setActionMessage(null)
+    try {
+      const body = await authedFetch('/api/admin/agents/open-brain/wiki/compile', { method: 'POST', body: '{}' })
+      setActionMessage(`${body.pages?.length || 0} wiki page preview(s) compiled. Approval is required before repo writes.`)
+    } catch (err) {
+      setActionMessage(err instanceof Error ? err.message : 'Wiki compile failed')
+    }
+  }
+
+  async function reviewProposal(id: string, action: 'approve' | 'reject') {
+    setActionMessage(null)
+    setReviewingProposalId(id)
+    try {
+      await authedFetch(`/api/admin/agents/open-brain/proposals/${encodeURIComponent(id)}/${action}`, {
+        method: 'POST',
+        body: JSON.stringify({ reason: `${action === 'approve' ? 'Approved' : 'Rejected'} from Portfolio Admin.` }),
+      })
+      setActionMessage(`Proposal ${action === 'approve' ? 'approved' : 'rejected'}.`)
+      await fetchSnapshot()
+    } catch (err) {
+      setActionMessage(err instanceof Error ? err.message : `Proposal ${action} failed`)
+    } finally {
+      setReviewingProposalId(null)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-background text-foreground p-6 lg:p-8">
+      <div className="mx-auto max-w-7xl">
+        <Breadcrumbs items={[
+          { label: 'Admin Dashboard', href: '/admin' },
+          { label: 'Agent Operations', href: '/admin/agents' },
+          { label: 'Open Brain' },
+        ]} />
+
+        <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wider text-radiant-gold">Agent Operations</p>
+            <h1 className="mt-1 text-3xl font-bold">Open Brain</h1>
+            <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+              Local-first memory projection for Portfolio Agent Ops. The local Open Brain remains the source of truth; Portfolio shows health, proposals, source freshness, and generated wiki previews.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Link
+              href="/admin/agents/automations"
+              className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 bg-silicon-slate/30 px-3 py-2 text-sm hover:border-radiant-gold/60"
+            >
+              <GitBranch size={16} />
+              Automation Context
+            </Link>
+            <button
+              onClick={fetchSnapshot}
+              disabled={loading}
+              className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/50 bg-radiant-gold/10 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15 disabled:opacity-60"
+            >
+              <RefreshCw size={16} className={loading ? 'animate-spin' : ''} />
+              Refresh
+            </button>
+          </div>
+        </div>
+
+        {loading ? (
+          <div className="py-16 text-center text-muted-foreground">Loading Open Brain status...</div>
+        ) : error ? (
+          <FailureState title="Failed to load Open Brain" message={error} />
+        ) : snapshot ? (
+          <>
+            {!snapshot.service.available ? (
+              <section className="mb-6 rounded-lg border border-yellow-400/40 bg-yellow-500/10 p-4 text-yellow-100">
+                <div className="mb-2 flex items-center gap-2 font-medium">
+                  <AlertTriangle size={18} />
+                  Local Open Brain service not initialized
+                </div>
+                <p className="text-sm">{snapshot.service.reason}</p>
+                <p className="mt-2 text-xs text-yellow-100/80">Home: {snapshot.service.home}</p>
+              </section>
+            ) : null}
+
+            <div className="mb-6 grid grid-cols-2 md:grid-cols-4 xl:grid-cols-8 gap-3">
+              <MetricCard label="Sources" value={snapshot.overview.sources} tone="slate" />
+              <MetricCard label="Memories" value={snapshot.overview.memories} tone={snapshot.overview.memories ? 'green' : 'yellow'} />
+              <MetricCard label="Pending" value={snapshot.overview.pendingProposals} tone={snapshot.overview.pendingProposals ? 'yellow' : 'slate'} />
+              <MetricCard label="Approved" value={snapshot.overview.approvedProposals} tone="green" />
+              <MetricCard label="Rejected" value={snapshot.overview.rejectedProposals} tone="slate" />
+              <MetricCard label="Wiki pages" value={snapshot.overview.wikiPages} tone={snapshot.overview.wikiPages ? 'green' : 'yellow'} />
+              <MetricCard label="Stale sources" value={snapshot.overview.staleSources} tone={snapshot.overview.staleSources ? 'yellow' : 'slate'} />
+              <MetricCard label="Private" value={snapshot.overview.privateRecords} tone={snapshot.overview.privateRecords ? 'red' : 'slate'} />
+            </div>
+
+            <section className="mb-6 rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-5">
+              <div className="mb-4 flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                <div>
+                  <div className="flex items-center gap-2 text-radiant-gold">
+                    <Brain size={18} />
+                    <h2 className="font-semibold">Context Packet</h2>
+                  </div>
+                  <p className="mt-2 text-sm text-muted-foreground">{snapshot.contextPacket.purpose}</p>
+                </div>
+                <div className="grid grid-cols-2 gap-2 text-xs">
+                  <HealthPill label="Sources" value={snapshot.health.sourceFreshness} />
+                  <HealthPill label="Memory" value={snapshot.health.memoryHealth} />
+                  <HealthPill label="Proposals" value={snapshot.health.proposalHealth} />
+                  <HealthPill label="Wiki" value={snapshot.health.wikiOverlay} />
+                </div>
+              </div>
+              <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 text-sm">
+                <ListBlock label="Boundaries" values={snapshot.contextPacket.boundaries} />
+                <ListBlock label="Current risks" values={snapshot.contextPacket.currentRisks} empty="No immediate risks in the projection." />
+                <ListBlock label="Expected outputs" values={snapshot.contextPacket.expectedOutputs} />
+              </div>
+            </section>
+
+            <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+              <div className="inline-flex rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-1">
+                <ModeButton icon={<Database size={16} />} active={viewMode === 'sources'} onClick={() => setViewMode('sources')}>Sources</ModeButton>
+                <ModeButton icon={<ShieldCheck size={16} />} active={viewMode === 'proposals'} onClick={() => setViewMode('proposals')}>Proposals</ModeButton>
+                <ModeButton icon={<FileText size={16} />} active={viewMode === 'wiki'} onClick={() => setViewMode('wiki')}>Wiki Overlay</ModeButton>
+                <ModeButton icon={<Network size={16} />} active={viewMode === 'parity'} onClick={() => setViewMode('parity')}>Runtime Parity</ModeButton>
+              </div>
+              <button
+                onClick={compileWiki}
+                className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/50 bg-radiant-gold/10 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15"
+              >
+                <FileText size={16} />
+                Compile wiki preview
+              </button>
+            </div>
+
+            {actionMessage ? (
+              <div className="mb-6 rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-3 text-sm text-muted-foreground">
+                {actionMessage}
+              </div>
+            ) : null}
+
+            {viewMode === 'sources' ? <SourcesView snapshot={snapshot} /> : null}
+            {viewMode === 'proposals' ? (
+              <ProposalsView
+                proposals={pendingProposals.length ? pendingProposals : snapshot.proposals}
+                reviewingProposalId={reviewingProposalId}
+                onReview={reviewProposal}
+              />
+            ) : null}
+            {viewMode === 'wiki' ? <WikiView pages={snapshot.wikiPages} /> : null}
+            {viewMode === 'parity' ? <ParityView snapshot={snapshot} /> : null}
+
+            <p className="mt-5 text-xs text-muted-foreground">
+              Generated {formatDateTime(snapshot.generatedAt)}. {snapshot.service.operationalBoundary}
+            </p>
+          </>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function SourcesView({ snapshot }: { snapshot: OpenBrainSnapshot }) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-silicon-slate/70">
+      <table className="w-full text-sm">
+        <thead className="bg-silicon-slate/40 text-muted-foreground">
+          <tr>
+            <th className="px-4 py-3 text-left font-medium">Source</th>
+            <th className="px-4 py-3 text-left font-medium">Kind</th>
+            <th className="px-4 py-3 text-left font-medium">Privacy</th>
+            <th className="px-4 py-3 text-left font-medium">Confidence</th>
+            <th className="px-4 py-3 text-left font-medium">Last observed</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-silicon-slate/60">
+          {snapshot.sources.map((source) => (
+            <tr key={source.id}>
+              <td className="px-4 py-3">
+                <p className="font-medium">{source.title}</p>
+                <p className="mt-1 text-xs text-muted-foreground">{source.summary}</p>
+                <p className="mt-1 break-all text-xs text-muted-foreground">{source.path || source.id}</p>
+              </td>
+              <td className="px-4 py-3">{source.kind}</td>
+              <td className="px-4 py-3"><PrivacyBadge tier={source.privacyTier} /></td>
+              <td className="px-4 py-3">{Math.round(source.confidence * 100)}%</td>
+              <td className="px-4 py-3 text-muted-foreground">{formatDateTime(source.lastObservedAt)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function ProposalsView({
+  proposals,
+  reviewingProposalId,
+  onReview,
+}: {
+  proposals: OpenBrainSnapshot['proposals']
+  reviewingProposalId: string | null
+  onReview: (id: string, action: 'approve' | 'reject') => void
+}) {
+  if (proposals.length === 0) {
+    return <EmptyState message="No Open Brain memory proposals are pending or stored locally." />
+  }
+  return (
+    <section className="grid grid-cols-1 xl:grid-cols-2 gap-4">
+      {proposals.map((proposal) => (
+        <article key={proposal.id} className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-5">
+          <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+            <h3 className="font-semibold">{proposal.proposedMemory.title}</h3>
+            <StatusBadge value={proposal.status} />
+          </div>
+          <p className="mb-3 text-sm text-muted-foreground">{proposal.proposedMemory.body}</p>
+          <div className="grid grid-cols-2 gap-2 text-xs">
+            <Detail label="Kind" value={proposal.proposedMemory.kind} />
+            <Detail label="Privacy" value={proposal.proposedMemory.privacyTier} />
+            <Detail label="Confidence" value={`${Math.round(proposal.proposedMemory.confidence * 100)}%`} />
+            <Detail label="Created" value={formatDateTime(proposal.createdAt)} />
+          </div>
+          <p className="mt-3 text-xs text-muted-foreground">{proposal.reason}</p>
+          {proposal.status === 'pending' ? (
+            <div className="mt-4 flex flex-wrap gap-2">
+              <button
+                onClick={() => onReview(proposal.id, 'approve')}
+                disabled={reviewingProposalId === proposal.id}
+                className="inline-flex items-center gap-2 rounded-lg border border-green-400/40 bg-green-500/10 px-3 py-2 text-sm text-green-200 hover:bg-green-500/15 disabled:opacity-60"
+              >
+                <CheckCircle2 size={16} />
+                Approve
+              </button>
+              <button
+                onClick={() => onReview(proposal.id, 'reject')}
+                disabled={reviewingProposalId === proposal.id}
+                className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 bg-background px-3 py-2 text-sm text-muted-foreground hover:border-radiant-gold/60 disabled:opacity-60"
+              >
+                Reject
+              </button>
+            </div>
+          ) : null}
+        </article>
+      ))}
+    </section>
+  )
+}
+
+function WikiView({ pages }: { pages: OpenBrainSnapshot['wikiPages'] }) {
+  if (pages.length === 0) {
+    return <EmptyState message="No generated wiki overlays yet. Approve memory proposals before compiling repo-owned docs." />
+  }
+  return (
+    <section className="space-y-4">
+      {pages.map((page) => (
+        <article key={page.slug} className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-5">
+          <div className="mb-3 flex flex-col gap-2 lg:flex-row lg:items-start lg:justify-between">
+            <div>
+              <h3 className="font-semibold">{page.title}</h3>
+              <p className="mt-1 text-xs text-muted-foreground">{page.path}</p>
+            </div>
+            <PrivacyBadge tier={page.privacyTier} />
+          </div>
+          <pre className="max-h-72 overflow-auto rounded-lg border border-silicon-slate/60 bg-black/20 p-3 text-xs text-muted-foreground whitespace-pre-wrap">
+            {page.markdown}
+          </pre>
+        </article>
+      ))}
+    </section>
+  )
+}
+
+function ParityView({ snapshot }: { snapshot: OpenBrainSnapshot }) {
+  return (
+    <section className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      <article className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-5">
+        <div className="mb-4 flex items-center gap-2 text-radiant-gold">
+          <Database size={18} />
+          <h2 className="font-semibold">Local Service</h2>
+        </div>
+        <div className="grid grid-cols-1 gap-2 text-sm">
+          <Detail label="Storage" value={snapshot.service.storage} />
+          <Detail label="Home" value={snapshot.service.home} />
+          <Detail label="Database configured" value={snapshot.service.databaseConfigured ? 'yes' : 'no'} />
+          <Detail label="MCP configured" value={snapshot.service.mcpConfigured ? 'yes' : 'no'} />
+          <Detail label="MCP URL" value={snapshot.service.mcpUrl || 'not configured'} />
+        </div>
+      </article>
+
+      <div className="space-y-3">
+        {snapshot.runtimeParity.map((runtime) => (
+          <article key={runtime.runtime} className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
+            <div className="mb-2 flex items-center justify-between gap-3">
+              <h3 className="font-semibold">{runtime.runtime}</h3>
+              <StatusBadge value={runtime.status} />
+            </div>
+            <p className="break-all text-xs text-muted-foreground">{runtime.configPath}</p>
+            <p className="mt-2 text-sm text-muted-foreground">{runtime.note}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function MetricCard({ label, value, tone = 'slate' }: { label: string; value: number; tone?: 'slate' | 'green' | 'yellow' | 'red' }) {
+  const toneClass = tone === 'green' ? 'text-green-300' : tone === 'yellow' ? 'text-yellow-200' : tone === 'red' ? 'text-red-300' : 'text-foreground'
+  return (
+    <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
+      <p className={`text-2xl font-bold ${toneClass}`}>{value}</p>
+      <p className="mt-1 text-xs text-muted-foreground">{label}</p>
+    </div>
+  )
+}
+
+function ModeButton({ active, onClick, icon, children }: { active: boolean; onClick: () => void; icon: ReactNode; children: ReactNode }) {
+  return (
+    <button
+      onClick={onClick}
+      className={`inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm ${active ? 'bg-radiant-gold/15 text-radiant-gold' : 'text-muted-foreground hover:text-foreground'}`}
+    >
+      {icon}
+      {children}
+    </button>
+  )
+}
+
+function ListBlock({ label, values, empty = 'None.' }: { label: string; values: string[]; empty?: string }) {
+  return (
+    <div>
+      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">{label}</h3>
+      {values.length > 0 ? (
+        <ul className="space-y-2">
+          {values.map((value) => <li key={value} className="rounded-lg border border-silicon-slate/60 bg-black/10 p-3">{value}</li>)}
+        </ul>
+      ) : (
+        <p className="rounded-lg border border-silicon-slate/60 bg-black/10 p-3 text-muted-foreground">{empty}</p>
+      )}
+    </div>
+  )
+}
+
+function HealthPill({ label, value }: { label: string; value: 'green' | 'yellow' | 'red' }) {
+  return (
+    <div className="rounded-lg border border-silicon-slate/60 bg-black/10 p-2">
+      <p className="text-muted-foreground">{label}</p>
+      <p className={value === 'green' ? 'text-green-300' : value === 'yellow' ? 'text-yellow-200' : 'text-red-300'}>{value}</p>
+    </div>
+  )
+}
+
+function StatusBadge({ value }: { value: string }) {
+  const tone = value === 'approved' || value === 'connected'
+    ? 'border-green-400/30 bg-green-500/10 text-green-200'
+    : value === 'pending' || value === 'blocked'
+      ? 'border-yellow-400/30 bg-yellow-500/10 text-yellow-100'
+      : 'border-silicon-slate/70 bg-silicon-slate/30 text-muted-foreground'
+  return <span className={`rounded-full border px-2 py-1 text-xs ${tone}`}>{value}</span>
+}
+
+function PrivacyBadge({ tier }: { tier: string }) {
+  const tone = tier === 'private' ? 'border-red-400/30 bg-red-500/10 text-red-200' : 'border-silicon-slate/70 bg-silicon-slate/30 text-muted-foreground'
+  return <span className={`rounded-full border px-2 py-1 text-xs ${tone}`}>{tier}</span>
+}
+
+function Detail({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-silicon-slate/60 bg-black/10 p-3">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="mt-1 break-all">{value}</p>
+    </div>
+  )
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-8 text-center text-muted-foreground">
+      {message}
+    </div>
+  )
+}
+
+function FailureState({ title, message }: { title: string; message: string }) {
+  return (
+    <div className="rounded-lg border border-red-400/40 bg-red-500/10 p-6 text-red-100">
+      <div className="mb-2 flex items-center gap-2 font-medium">
+        <AlertTriangle size={18} />
+        {title}
+      </div>
+      <p className="text-sm">{message}</p>
+    </div>
+  )
+}
+
+function formatDateTime(value: string) {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(new Date(value))
+}

--- a/app/api/admin/agents/open-brain/proposals/[id]/approve/route.test.ts
+++ b/app/api/admin/agents/open-brain/proposals/[id]/approve/route.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  reviewOpenBrainProposal: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/open-brain', () => ({
+  reviewOpenBrainProposal: mocks.reviewOpenBrainProposal,
+}))
+
+import { POST } from './route'
+
+function makeRequest() {
+  return new Request('http://localhost/api/admin/agents/open-brain/proposals/proposal%3A1/approve', {
+    method: 'POST',
+    headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+    body: JSON.stringify({ reason: 'Looks correct' }),
+  })
+}
+
+describe('POST /api/admin/agents/open-brain/proposals/[id]/approve', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.reviewOpenBrainProposal.mockResolvedValue({ id: 'proposal:1', status: 'approved' })
+  })
+
+  it('approves a proposal through the local Open Brain store', async () => {
+    const response = await POST(makeRequest() as never, { params: { id: 'proposal%3A1' } })
+
+    expect(response.status).toBe(200)
+    expect(mocks.reviewOpenBrainProposal).toHaveBeenCalledWith('proposal:1', 'approved', 'Looks correct', 'admin-user')
+    expect(await response.json()).toEqual({ proposal: { id: 'proposal:1', status: 'approved' } })
+  })
+})

--- a/app/api/admin/agents/open-brain/proposals/[id]/approve/route.ts
+++ b/app/api/admin/agents/open-brain/proposals/[id]/approve/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { reviewOpenBrainProposal } from '@/lib/open-brain'
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const body = await request.json().catch(() => ({}))
+  try {
+    const proposal = await reviewOpenBrainProposal(
+      decodeURIComponent(params.id),
+      'approved',
+      typeof body.reason === 'string' ? body.reason : 'Approved from Portfolio Admin.',
+      auth.user?.id || 'portfolio-admin',
+    )
+    return NextResponse.json({ proposal })
+  } catch (err) {
+    return NextResponse.json({ error: err instanceof Error ? err.message : 'Proposal approval failed' }, { status: 404 })
+  }
+}

--- a/app/api/admin/agents/open-brain/proposals/[id]/reject/route.ts
+++ b/app/api/admin/agents/open-brain/proposals/[id]/reject/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { reviewOpenBrainProposal } from '@/lib/open-brain'
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const body = await request.json().catch(() => ({}))
+  try {
+    const proposal = await reviewOpenBrainProposal(
+      decodeURIComponent(params.id),
+      'rejected',
+      typeof body.reason === 'string' ? body.reason : 'Rejected from Portfolio Admin.',
+      auth.user?.id || 'portfolio-admin',
+    )
+    return NextResponse.json({ proposal })
+  } catch (err) {
+    return NextResponse.json({ error: err instanceof Error ? err.message : 'Proposal rejection failed' }, { status: 404 })
+  }
+}

--- a/app/api/admin/agents/open-brain/proposals/route.test.ts
+++ b/app/api/admin/agents/open-brain/proposals/route.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  createOpenBrainProposal: vi.fn(),
+  validateMemoryProposal: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/open-brain', () => ({
+  createOpenBrainProposal: mocks.createOpenBrainProposal,
+  validateMemoryProposal: mocks.validateMemoryProposal,
+}))
+
+import { POST } from './route'
+
+function makeRequest(body: unknown) {
+  return new Request('http://localhost/api/admin/agents/open-brain/proposals', {
+    method: 'POST',
+    headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/admin/agents/open-brain/proposals', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.validateMemoryProposal.mockReturnValue([])
+    mocks.createOpenBrainProposal.mockResolvedValue({
+      id: 'proposal:1',
+      status: 'pending',
+      proposedMemory: { title: 'Memory' },
+    })
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(makeRequest({}) as never)
+
+    expect(response.status).toBe(401)
+    expect(mocks.createOpenBrainProposal).not.toHaveBeenCalled()
+  })
+
+  it('rejects invalid proposals', async () => {
+    mocks.validateMemoryProposal.mockReturnValue(['Body is required.'])
+
+    const response = await POST(makeRequest({ title: 'Missing body' }) as never)
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'Body is required.' })
+  })
+
+  it('creates an approval-gated proposal with the admin user id', async () => {
+    const response = await POST(makeRequest({
+      kind: 'workflow',
+      title: 'Memory',
+      body: 'Body',
+      privacyTier: 'internal_ops',
+      reason: 'Needs review',
+    }) as never)
+
+    expect(response.status).toBe(201)
+    expect(mocks.createOpenBrainProposal).toHaveBeenCalledWith(expect.objectContaining({
+      createdBy: 'admin-user',
+      title: 'Memory',
+    }))
+  })
+})

--- a/app/api/admin/agents/open-brain/proposals/route.ts
+++ b/app/api/admin/agents/open-brain/proposals/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { createOpenBrainProposal, validateMemoryProposal } from '@/lib/open-brain'
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+export async function POST(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const body = await request.json().catch(() => null)
+  if (!body) return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+
+  const errors = validateMemoryProposal(body)
+  if (errors.length > 0) return NextResponse.json({ error: errors.join(' ') }, { status: 400 })
+
+  const proposal = await createOpenBrainProposal({
+    ...body,
+    createdBy: auth.user?.id || 'portfolio-admin',
+  })
+  return NextResponse.json({ proposal }, { status: 201 })
+}

--- a/app/api/admin/agents/open-brain/route.test.ts
+++ b/app/api/admin/agents/open-brain/route.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  getOpenBrainSnapshot: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/open-brain', () => ({
+  getOpenBrainSnapshot: mocks.getOpenBrainSnapshot,
+}))
+
+import { GET } from './route'
+
+function makeRequest() {
+  return new Request('http://localhost/api/admin/agents/open-brain', {
+    headers: { authorization: 'Bearer token' },
+  })
+}
+
+describe('GET /api/admin/agents/open-brain', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.getOpenBrainSnapshot.mockResolvedValue({
+      generatedAt: '2026-05-10T12:00:00.000Z',
+      service: { available: true, storage: 'local_jsonl' },
+      overview: { sources: 3, memories: 1, pendingProposals: 2 },
+    })
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await GET(makeRequest() as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.getOpenBrainSnapshot).not.toHaveBeenCalled()
+  })
+
+  it('returns the sanitized Open Brain snapshot', async () => {
+    const response = await GET(makeRequest() as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual(expect.objectContaining({
+      generatedAt: '2026-05-10T12:00:00.000Z',
+      overview: expect.objectContaining({ sources: 3 }),
+    }))
+  })
+})

--- a/app/api/admin/agents/open-brain/route.ts
+++ b/app/api/admin/agents/open-brain/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { getOpenBrainSnapshot } from '@/lib/open-brain'
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+export async function GET(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const snapshot = await getOpenBrainSnapshot()
+  return NextResponse.json(snapshot)
+}

--- a/app/api/admin/agents/open-brain/wiki/compile/route.ts
+++ b/app/api/admin/agents/open-brain/wiki/compile/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { getOpenBrainSnapshot } from '@/lib/open-brain'
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+export async function POST(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const snapshot = await getOpenBrainSnapshot()
+  return NextResponse.json({
+    mode: 'preview',
+    approvalRequired: true,
+    message: 'Compiled wiki overlay preview only. Commit or file writes require a separate approved repo change.',
+    pages: snapshot.wikiPages,
+  })
+}

--- a/docs/memory-context-organization-workflow.md
+++ b/docs/memory-context-organization-workflow.md
@@ -75,6 +75,12 @@ The dashboard also surfaces a read-only Codex workspace-root report. It compares
 
 This report is for visibility and repair planning only. It must not rewrite `.codex-global-state.json`, `state_5.sqlite`, thread roots, or Desktop state from a Portfolio PR.
 
+## Local-First Open Brain Alignment
+
+The Portfolio memory/context workflow now treats a local Open Brain as the durable memory source of truth. Portfolio Admin is the visibility, approval, and generated-overlay surface; it is not the owner of the brain.
+
+See [`open-brain-local-service.md`](./open-brain-local-service.md) for the local service contract, MCP tool expectations, privacy tiers, and Karpathy Wiki overlay boundary.
+
 ## Enhancement Impact Preflight
 
 ### Enhancement Impact Preflight
@@ -127,6 +133,18 @@ Implementation update: `lib/chief-of-staff-chat.test.ts` also needed a fixture u
 - Coordination decision: Proceed in the dedicated memory organization worktree. Keep the report read-only and do not edit local Codex state.
 - Merge-order note: Can merge independently after review because there are no active overlapping PRs.
 
+### Enhancement Impact Preflight
+
+- Enhancement: Add a local-first Open Brain projection and Karpathy Wiki overlay controls for Portfolio Agent Ops memory/context work.
+- User-facing surface: `/admin/agents/open-brain`, under Agent Operations.
+- Predicted files: `lib/open-brain.ts`, `app/api/admin/agents/open-brain/**`, `app/admin/agents/open-brain/page.tsx`, `lib/admin-nav.ts`, `docs/open-brain-local-service.md`, `docs/memory-context-organization-workflow.md`, Open Brain tests.
+- Shared routes/APIs/tables/helpers: Agent Operations admin nav and local automation/workspace inventory helpers; no Supabase tables or mutating Codex operational-state APIs.
+- Active PRs or branches checked: PR #208 `codex/hyperagent-evaluations`, PR #210 `codex/agent-identity-names`, plus sibling worktrees for credential reporting and subscription watch.
+- Dirty worktree files checked: current `codex/memory-organization-next` worktree was clean before implementation.
+- Overlap rating: yellow.
+- Coordination decision: Proceed in the dedicated memory organization worktree. Avoid Agent Ops evaluation, identity naming, credential reporting, subscription watch, Client AI Ops roadmap, and Vercel observability files unless a direct compatibility issue appears.
+- Merge-order note: Land after or alongside active Agent Operations PRs with integration-captain review of shared admin navigation; no production or local Open Brain operational state is changed by this PR.
+
 ## Operating Boundary
 
 The dashboard may show that local operational state is missing or incomplete. It should not repair that state by itself.
@@ -138,6 +156,7 @@ Allowed:
 - Flag missing workspace roots, missing docs, missing authority boundaries, duplicates, and context gaps.
 - Show progress and task status computed from the inventory.
 - Show read-only Codex workspace-root and active thread placement drift.
+- Show Open Brain source freshness, proposal health, runtime parity, and wiki overlay previews.
 
 Not allowed in this workflow without an explicit operational-state step:
 
@@ -146,3 +165,4 @@ Not allowed in this workflow without an explicit operational-state step:
 - Updating Codex SQLite thread state.
 - Rewriting Codex Desktop workspace roots.
 - Pausing, deleting, creating, or rescheduling automations.
+- Registering Open Brain MCP config in Codex, Hermes, OpenCode, Claude, Cursor, or ChatGPT without a separate operational-state approval.

--- a/docs/open-brain-local-service.md
+++ b/docs/open-brain-local-service.md
@@ -1,0 +1,90 @@
+# Local-First Open Brain Service
+
+This document defines the Portfolio-facing contract for the local Open Brain. The Open Brain is user-owned local infrastructure; Portfolio Admin is only a dashboard, proposal, and wiki-overlay surface.
+
+## Source Of Truth
+
+- Primary memory owner: local Open Brain service outside the Portfolio repo.
+- Default storage target: local Postgres with pgvector.
+- Local fallback for V1 development: `OPEN_BRAIN_HOME` JSON files for proposals and approved memories.
+- Optional projection: Portfolio Admin at `/admin/agents/open-brain`.
+- Optional mirror: Supabase or hosted dashboards may mirror sanitized metadata later, but must not become the only memory store.
+
+## Core Records
+
+- `sources`: Codex automations, workspace-root reports, repair packets, runbooks, agent runs, handoffs, work items, and generated wiki pages.
+- `events`: append-only observations from tools and agents.
+- `memories`: approved facts, decisions, preferences, workflows, risks, and operating rules.
+- `links`: relationships between sources, memories, docs, automations, runs, and agents.
+- `proposals`: approval-gated requests before durable memory changes are accepted.
+
+Every record must carry:
+
+- source id or source path,
+- confidence,
+- privacy tier,
+- fingerprint,
+- last observed or created timestamp,
+- and an audit trail for approval or rejection when it becomes durable memory.
+
+## Privacy Tiers
+
+- `public_safe`: may be compiled into public-facing docs.
+- `client_safe`: usable in client-specific views after client scoping.
+- `internal_ops`: visible inside Portfolio Admin and internal runbooks.
+- `private`: local-only; never compiled into repo-owned wiki pages.
+
+## Portfolio Boundaries
+
+Portfolio may:
+
+- read sanitized Open Brain status,
+- show pending proposals,
+- approve or reject proposed memory records,
+- compile wiki overlay previews,
+- and show runtime parity status.
+
+Portfolio must not:
+
+- treat generated wiki docs as the source of truth,
+- generate durable memories from inference without approval,
+- write directly to `~/.codex/memories`, `~/.codex/automations`, Codex SQLite, or Desktop workspace state,
+- publish private memory records into repo-owned docs,
+- or assume Codex MCP configuration applies to Hermes, OpenCode, Claude, Cursor, or ChatGPT.
+
+## MCP Tool Contract
+
+The local service should expose these MCP tools:
+
+- `capture_memory`
+- `search_memory`
+- `get_context_packet`
+- `propose_memory_write`
+- `list_pending_memory_proposals`
+- `link_memory_to_source`
+- `compile_wiki_overlay`
+
+The first production MCP registration is an operational-state step. It should be approved separately, because it edits runtime config outside the Portfolio git worktree.
+
+## Karpathy Wiki Overlay
+
+Karpathy Wiki pages are compiled views from approved, non-private Open Brain records. Initial pages:
+
+- automation map,
+- workspace-root state,
+- repair backlog,
+- governing runbooks,
+- decision log,
+- agent handoff map.
+
+Generated pages must link back to Open Brain memory ids and source ids. A wiki compile from Portfolio Admin is preview-only until a separate approved repo change commits the markdown.
+
+## V1 Scope
+
+V1 is intentionally narrow:
+
+- Agent Ops and Codex state only.
+- No broad client, sales, or personality corpus ingestion.
+- Summaries and paths only; no raw secrets or private exports.
+- Approval-gated durable writes by default.
+- Runtime parity is reported as connected, skipped, or blocked; actual config registration is separate.

--- a/lib/admin-nav.ts
+++ b/lib/admin-nav.ts
@@ -70,6 +70,7 @@ export const ADMIN_NAV: { dashboard: AdminNavItem; categories: AdminNavCategory[
         { label: 'Agent Coordination', href: '/admin/agents/coordination' },
         { label: 'Client Swarm Board', href: '/admin/agents/swarm-board' },
         { label: 'Automation Context', href: '/admin/agents/automations' },
+        { label: 'Open Brain', href: '/admin/agents/open-brain' },
         { label: 'Technology Bakeoffs', href: '/admin/technology-bakeoffs' },
         { label: 'Source Protocol', href: '/admin/source-protocol' },
         { label: 'Client Experience', href: '/admin/client-experience' },

--- a/lib/open-brain.test.ts
+++ b/lib/open-brain.test.ts
@@ -1,0 +1,163 @@
+import { mkdtemp, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import path from 'path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  compileKarpathyWikiOverlay,
+  createOpenBrainProposal,
+  fingerprintOpenBrainRecord,
+  getOpenBrainSnapshot,
+  reviewOpenBrainProposal,
+  sanitizeOpenBrainText,
+  validateMemoryProposal,
+  type OpenBrainMemoryRecord,
+} from './open-brain'
+
+vi.mock('./codex-automation-inventory', () => ({
+  listCodexAutomationInventory: vi.fn(async () => ({
+    available: true,
+    sourceDirectory: '/Users/vambahsillah/.codex/automations',
+    generatedAt: '2026-05-10T12:00:00.000Z',
+    automations: [
+      {
+        id: 'portfolio-operations-manager',
+        name: 'Portfolio Operations Manager',
+        category: 'Operations',
+        riskLevel: 'high',
+        contextHealth: 'yellow',
+        sourceFile: '/Users/vambahsillah/.codex/automations/portfolio-operations-manager/automation.toml',
+        updatedAt: 1,
+      },
+    ],
+    repairPackets: [
+      {
+        automationId: 'portfolio-operations-manager',
+        automationName: 'Portfolio Operations Manager',
+        summary: 'Portfolio Operations Manager needs context repair.',
+        missingQuestions: ['boundary'],
+        recommendedActions: ['Add an authority boundary.'],
+        sourceFile: '/Users/vambahsillah/.codex/automations/portfolio-operations-manager/automation.toml',
+      },
+    ],
+  })),
+}))
+
+vi.mock('./codex-workspace-roots', () => ({
+  getCodexWorkspaceRootReport: vi.fn(async () => ({
+    available: true,
+    generatedAt: '2026-05-10T12:00:00.000Z',
+    stateDatabase: '/Users/vambahsillah/.codex/state_5.sqlite',
+    overview: {
+      portfolioThreads: 8,
+      nonPortfolioThreads: 2,
+    },
+    health: 'yellow',
+  })),
+}))
+
+let tempRoot: string | null = null
+
+async function makeTempRoot() {
+  tempRoot = await mkdtemp(path.join(tmpdir(), 'open-brain-'))
+  return tempRoot
+}
+
+afterEach(async () => {
+  if (tempRoot) {
+    await rm(tempRoot, { recursive: true, force: true })
+    tempRoot = null
+  }
+  vi.unstubAllEnvs()
+})
+
+describe('Open Brain projection', () => {
+  it('builds a local-first snapshot from Agent Ops and Codex sources', async () => {
+    const root = await makeTempRoot()
+    const snapshot = await getOpenBrainSnapshot(root)
+
+    expect(snapshot.service.storage).toBe('local_jsonl')
+    expect(snapshot.sources.map((source) => source.kind)).toEqual(expect.arrayContaining([
+      'codex_automation',
+      'workspace_root_report',
+      'repair_packet',
+      'runbook',
+    ]))
+    expect(snapshot.proposals[0]).toEqual(expect.objectContaining({
+      id: 'proposal:repair:portfolio-operations-manager',
+      status: 'pending',
+    }))
+    expect(snapshot.contextPacket.boundaries).toContain('Do not mutate ~/.codex operational state from Portfolio APIs.')
+  })
+
+  it('validates privacy tiers and secret-like public text', () => {
+    expect(validateMemoryProposal({
+      kind: 'workflow',
+      title: 'Credential workflow',
+      body: 'API_KEY=secret-value should never be public',
+      privacyTier: 'public_safe',
+      reason: 'test',
+    })).toContain('Public-safe memory cannot contain secret-like values.')
+  })
+
+  it('creates, approves, and compiles approved non-private memory into wiki pages', async () => {
+    const root = await makeTempRoot()
+    const proposal = await createOpenBrainProposal({
+      kind: 'decision',
+      title: 'Portfolio owns projection only',
+      body: 'The local Open Brain owns durable memory. Portfolio compiles approved overlays.',
+      privacyTier: 'internal_ops',
+      confidence: 0.93,
+      sourceIds: ['runbook:docs/open-brain-local-service.md'],
+      reason: 'Plan decision',
+    }, root)
+
+    const approved = await reviewOpenBrainProposal(proposal.id, 'approved', 'Accepted', 'admin', root)
+    const snapshot = await getOpenBrainSnapshot(root)
+
+    expect(approved.status).toBe('approved')
+    expect(snapshot.memories).toHaveLength(1)
+    expect(snapshot.wikiPages[0]).toEqual(expect.objectContaining({
+      slug: 'decision-memory',
+      path: 'docs/open-brain/wiki/decision-memory.md',
+    }))
+    expect(snapshot.wikiPages[0].markdown).toContain('Portfolio owns projection only')
+  })
+
+  it('can approve a generated repair proposal after persisting it locally', async () => {
+    const root = await makeTempRoot()
+
+    const approved = await reviewOpenBrainProposal(
+      'proposal:repair:portfolio-operations-manager',
+      'approved',
+      'Repair proposal accepted',
+      'admin',
+      root,
+    )
+    const snapshot = await getOpenBrainSnapshot(root)
+
+    expect(approved.status).toBe('approved')
+    expect(snapshot.overview.approvedProposals).toBe(1)
+    expect(snapshot.memories[0].title).toContain('Portfolio Operations Manager')
+  })
+
+  it('does not compile private memories into wiki overlays', () => {
+    const memory: OpenBrainMemoryRecord = {
+      id: 'memory:private',
+      kind: 'fact',
+      title: 'Private fact',
+      body: 'Private body',
+      privacyTier: 'private',
+      confidence: 0.9,
+      sourceIds: [],
+      createdAt: '2026-05-10T12:00:00.000Z',
+      updatedAt: '2026-05-10T12:00:00.000Z',
+      fingerprint: fingerprintOpenBrainRecord(['private']),
+    }
+
+    expect(compileKarpathyWikiOverlay([memory])).toEqual([])
+  })
+
+  it('sanitizes secret-like content', () => {
+    expect(sanitizeOpenBrainText('Use API_KEY=secret-value in local testing')).toBe('Use [redacted] in local testing')
+  })
+})

--- a/lib/open-brain.ts
+++ b/lib/open-brain.ts
@@ -1,0 +1,574 @@
+import { createHash, randomUUID } from 'crypto'
+import { existsSync } from 'fs'
+import { mkdir, readFile, writeFile } from 'fs/promises'
+import { homedir } from 'os'
+import path from 'path'
+import { listCodexAutomationInventory } from './codex-automation-inventory'
+import { getCodexWorkspaceRootReport } from './codex-workspace-roots'
+
+export type OpenBrainPrivacyTier = 'public_safe' | 'client_safe' | 'internal_ops' | 'private'
+export type OpenBrainSourceKind =
+  | 'codex_automation'
+  | 'workspace_root_report'
+  | 'repair_packet'
+  | 'runbook'
+  | 'agent_run'
+  | 'handoff'
+  | 'work_item'
+  | 'wiki_page'
+export type OpenBrainMemoryKind = 'fact' | 'decision' | 'preference' | 'workflow' | 'risk' | 'operating_rule'
+export type OpenBrainProposalStatus = 'pending' | 'approved' | 'rejected'
+
+export interface OpenBrainSourceRecord {
+  id: string
+  kind: OpenBrainSourceKind
+  title: string
+  summary: string
+  path: string | null
+  privacyTier: OpenBrainPrivacyTier
+  confidence: number
+  lastObservedAt: string
+  fingerprint: string
+}
+
+export interface OpenBrainMemoryRecord {
+  id: string
+  kind: OpenBrainMemoryKind
+  title: string
+  body: string
+  privacyTier: OpenBrainPrivacyTier
+  confidence: number
+  sourceIds: string[]
+  createdAt: string
+  updatedAt: string
+  fingerprint: string
+}
+
+export interface OpenBrainLinkRecord {
+  id: string
+  fromId: string
+  toId: string
+  relationship: string
+  createdAt: string
+}
+
+export interface OpenBrainProposalRecord {
+  id: string
+  status: OpenBrainProposalStatus
+  proposedMemory: Omit<OpenBrainMemoryRecord, 'id' | 'createdAt' | 'updatedAt' | 'fingerprint'>
+  sourceIds: string[]
+  reason: string
+  createdBy: string
+  createdAt: string
+  reviewedAt: string | null
+  reviewedBy: string | null
+  reviewReason: string | null
+}
+
+export interface OpenBrainWikiPage {
+  slug: string
+  title: string
+  path: string
+  markdown: string
+  sourceMemoryIds: string[]
+  privacyTier: OpenBrainPrivacyTier
+}
+
+export interface OpenBrainRuntimeParity {
+  runtime: 'Codex' | 'Hermes' | 'OpenCode' | 'ChatGPT' | 'Claude' | 'Cursor'
+  status: 'connected' | 'skipped' | 'blocked'
+  configPath: string
+  note: string
+}
+
+export interface OpenBrainSnapshot {
+  generatedAt: string
+  service: {
+    available: boolean
+    storage: 'postgres_pgvector' | 'local_jsonl' | 'unconfigured'
+    home: string
+    databaseConfigured: boolean
+    mcpConfigured: boolean
+    mcpUrl: string | null
+    reason: string | null
+    operationalBoundary: string
+  }
+  overview: {
+    sources: number
+    memories: number
+    pendingProposals: number
+    approvedProposals: number
+    rejectedProposals: number
+    wikiPages: number
+    staleSources: number
+    privateRecords: number
+  }
+  health: {
+    sourceFreshness: 'green' | 'yellow' | 'red'
+    memoryHealth: 'green' | 'yellow' | 'red'
+    proposalHealth: 'green' | 'yellow' | 'red'
+    wikiOverlay: 'green' | 'yellow' | 'red'
+  }
+  sources: OpenBrainSourceRecord[]
+  memories: OpenBrainMemoryRecord[]
+  proposals: OpenBrainProposalRecord[]
+  wikiPages: OpenBrainWikiPage[]
+  runtimeParity: OpenBrainRuntimeParity[]
+  contextPacket: {
+    purpose: string
+    boundaries: string[]
+    requiredInputs: string[]
+    currentRisks: string[]
+    expectedOutputs: string[]
+  }
+}
+
+export interface OpenBrainProposalInput {
+  kind: OpenBrainMemoryKind
+  title: string
+  body: string
+  privacyTier: OpenBrainPrivacyTier
+  confidence?: number
+  sourceIds?: string[]
+  reason: string
+  createdBy?: string
+}
+
+const DEFAULT_OPEN_BRAIN_HOME = path.join(homedir(), '.open-brain')
+const PORTFOLIO_ROOT = '/Users/vambahsillah/Projects/Portfolio'
+const PROPOSALS_FILE = 'proposals.json'
+const MEMORIES_FILE = 'memories.json'
+const SECRETISH_PATTERN =
+  /(sk-[A-Za-z0-9_-]{12,}|github_pat_[A-Za-z0-9_]{12,}|[A-Za-z0-9_]*(?:TOKEN|SECRET|KEY|PASSWORD)[A-Za-z0-9_]*\s*[:=]\s*["']?[^"'\s,}]+)/gi
+
+export function getOpenBrainHome() {
+  return process.env.OPEN_BRAIN_HOME || DEFAULT_OPEN_BRAIN_HOME
+}
+
+export async function getOpenBrainSnapshot(openBrainHome = getOpenBrainHome()): Promise<OpenBrainSnapshot> {
+  const generatedAt = new Date().toISOString()
+  const [inventory, workspaceRoots, persistedMemories, persistedProposals] = await Promise.all([
+    listCodexAutomationInventory(),
+    getCodexWorkspaceRootReport(),
+    readJsonArray<OpenBrainMemoryRecord>(path.join(openBrainHome, MEMORIES_FILE)),
+    readJsonArray<OpenBrainProposalRecord>(path.join(openBrainHome, PROPOSALS_FILE)),
+  ])
+
+  const sources = dedupeSources([
+    ...inventory.automations.map((automation): OpenBrainSourceRecord => ({
+      id: `automation:${automation.id}`,
+      kind: 'codex_automation',
+      title: automation.name,
+      summary: sanitizeOpenBrainText(`${automation.category} automation. Risk ${automation.riskLevel}. Context ${automation.contextHealth}.`),
+      path: automation.sourceFile,
+      privacyTier: 'internal_ops',
+      confidence: 0.9,
+      lastObservedAt: inventory.generatedAt,
+      fingerprint: fingerprintOpenBrainRecord(['codex_automation', automation.id, automation.sourceFile, automation.updatedAt || '']),
+    })),
+    ...inventory.repairPackets.map((packet): OpenBrainSourceRecord => ({
+      id: `repair:${packet.automationId}`,
+      kind: 'repair_packet',
+      title: `${packet.automationName} repair packet`,
+      summary: sanitizeOpenBrainText(packet.summary),
+      path: packet.sourceFile,
+      privacyTier: 'internal_ops',
+      confidence: 0.86,
+      lastObservedAt: inventory.generatedAt,
+      fingerprint: fingerprintOpenBrainRecord(['repair_packet', packet.automationId, packet.summary]),
+    })),
+    {
+      id: 'workspace-root-report:codex',
+      kind: 'workspace_root_report',
+      title: 'Codex workspace-root report',
+      summary: workspaceRoots.available
+        ? `${workspaceRoots.overview.portfolioThreads} Portfolio thread(s), ${workspaceRoots.overview.nonPortfolioThreads} non-Portfolio thread(s), health ${workspaceRoots.health}.`
+        : workspaceRoots.reason || 'Codex workspace-root report unavailable.',
+      path: workspaceRoots.stateDatabase,
+      privacyTier: 'internal_ops',
+      confidence: workspaceRoots.available ? 0.88 : 0.45,
+      lastObservedAt: workspaceRoots.generatedAt,
+      fingerprint: fingerprintOpenBrainRecord(['workspace_root_report', workspaceRoots.generatedAt, JSON.stringify(workspaceRoots.overview)]),
+    },
+    ...buildRunbookSources(generatedAt),
+  ])
+
+  const repairProposals = inventory.repairPackets.map((packet): OpenBrainProposalRecord => {
+    const createdAt = inventory.generatedAt
+    const title = `${packet.automationName} needs memory/context repair`
+    const body = sanitizeOpenBrainText([
+      packet.summary,
+      `Missing context: ${packet.missingQuestions.join(', ') || 'none'}.`,
+      `Recommended actions: ${packet.recommendedActions.join(' ')}`,
+    ].join('\n'))
+    return {
+      id: `proposal:repair:${packet.automationId}`,
+      status: 'pending',
+      proposedMemory: {
+        kind: 'workflow',
+        title,
+        body,
+        privacyTier: 'internal_ops',
+        confidence: 0.82,
+        sourceIds: [`repair:${packet.automationId}`, `automation:${packet.automationId}`],
+      },
+      sourceIds: [`repair:${packet.automationId}`, `automation:${packet.automationId}`],
+      reason: 'Generated from read-only automation repair packet. Requires approval before durable memory write.',
+      createdBy: 'portfolio-open-brain-projection',
+      createdAt,
+      reviewedAt: null,
+      reviewedBy: null,
+      reviewReason: null,
+    }
+  })
+
+  const proposals = mergeProposals(persistedProposals, repairProposals)
+  const memories = dedupeMemories([
+    ...persistedMemories,
+    ...proposals.filter((proposal) => proposal.status === 'approved').map(proposalToMemory),
+  ])
+  const wikiPages = compileKarpathyWikiOverlay(memories)
+  const pendingProposals = proposals.filter((proposal) => proposal.status === 'pending').length
+  const approvedProposals = proposals.filter((proposal) => proposal.status === 'approved').length
+  const rejectedProposals = proposals.filter((proposal) => proposal.status === 'rejected').length
+  const service = getServiceStatus(openBrainHome)
+
+  return {
+    generatedAt,
+    service,
+    overview: {
+      sources: sources.length,
+      memories: memories.length,
+      pendingProposals,
+      approvedProposals,
+      rejectedProposals,
+      wikiPages: wikiPages.length,
+      staleSources: sources.filter((source) => isStale(source.lastObservedAt, generatedAt)).length,
+      privateRecords: [
+        ...sources.map((source) => source.privacyTier),
+        ...memories.map((memory) => memory.privacyTier),
+        ...proposals.map((proposal) => proposal.proposedMemory.privacyTier),
+      ].filter((tier) => tier === 'private').length,
+    },
+    health: {
+      sourceFreshness: classifyFreshness(sources, generatedAt),
+      memoryHealth: memories.length > 0 ? 'green' : pendingProposals > 0 ? 'yellow' : 'red',
+      proposalHealth: pendingProposals > 10 ? 'red' : pendingProposals > 0 ? 'yellow' : 'green',
+      wikiOverlay: wikiPages.length > 0 ? 'green' : approvedProposals > 0 ? 'yellow' : 'red',
+    },
+    sources,
+    memories,
+    proposals,
+    wikiPages,
+    runtimeParity: buildRuntimeParity(openBrainHome),
+    contextPacket: buildContextPacket(sources, memories, proposals),
+  }
+}
+
+export function validateMemoryProposal(input: OpenBrainProposalInput): string[] {
+  const errors: string[] = []
+  if (!['fact', 'decision', 'preference', 'workflow', 'risk', 'operating_rule'].includes(input.kind)) errors.push('Unsupported memory kind.')
+  if (!input.title?.trim()) errors.push('Title is required.')
+  if (!input.body?.trim()) errors.push('Body is required.')
+  if (!['public_safe', 'client_safe', 'internal_ops', 'private'].includes(input.privacyTier)) errors.push('Privacy tier is required.')
+  if (!input.reason?.trim()) errors.push('Proposal reason is required.')
+  if (input.privacyTier === 'public_safe' && input.body.match(SECRETISH_PATTERN)) errors.push('Public-safe memory cannot contain secret-like values.')
+  return errors
+}
+
+export async function createOpenBrainProposal(
+  input: OpenBrainProposalInput,
+  openBrainHome = getOpenBrainHome(),
+): Promise<OpenBrainProposalRecord> {
+  const errors = validateMemoryProposal(input)
+  if (errors.length > 0) throw new Error(errors.join(' '))
+  await mkdir(openBrainHome, { recursive: true })
+  const proposalsPath = path.join(openBrainHome, PROPOSALS_FILE)
+  const proposals = await readJsonArray<OpenBrainProposalRecord>(proposalsPath)
+  const now = new Date().toISOString()
+  const proposedMemory = {
+    kind: input.kind,
+    title: sanitizeOpenBrainText(input.title),
+    body: sanitizeOpenBrainText(input.body),
+    privacyTier: input.privacyTier,
+    confidence: clampConfidence(input.confidence ?? 0.75),
+    sourceIds: input.sourceIds || [],
+  }
+  const proposal: OpenBrainProposalRecord = {
+    id: `proposal:${randomUUID()}`,
+    status: 'pending',
+    proposedMemory,
+    sourceIds: proposedMemory.sourceIds,
+    reason: sanitizeOpenBrainText(input.reason),
+    createdBy: input.createdBy || 'portfolio-admin',
+    createdAt: now,
+    reviewedAt: null,
+    reviewedBy: null,
+    reviewReason: null,
+  }
+  await writeJsonArray(proposalsPath, [...proposals, proposal])
+  return proposal
+}
+
+export async function reviewOpenBrainProposal(
+  id: string,
+  status: Extract<OpenBrainProposalStatus, 'approved' | 'rejected'>,
+  reviewReason: string,
+  reviewedBy = 'portfolio-admin',
+  openBrainHome = getOpenBrainHome(),
+): Promise<OpenBrainProposalRecord> {
+  const proposalsPath = path.join(openBrainHome, PROPOSALS_FILE)
+  const proposals = await readJsonArray<OpenBrainProposalRecord>(proposalsPath)
+  let index = proposals.findIndex((proposal) => proposal.id === id)
+  if (index === -1) {
+    const generated = (await getOpenBrainSnapshot(openBrainHome)).proposals.find((proposal) => proposal.id === id)
+    if (!generated) throw new Error('Proposal not found in local Open Brain proposal store.')
+    proposals.push(generated)
+    index = proposals.length - 1
+  }
+  const reviewed = {
+    ...proposals[index],
+    status,
+    reviewedAt: new Date().toISOString(),
+    reviewedBy,
+    reviewReason: sanitizeOpenBrainText(reviewReason || status),
+  }
+  proposals[index] = reviewed
+  await writeJsonArray(proposalsPath, proposals)
+  if (status === 'approved') {
+    const memoriesPath = path.join(openBrainHome, MEMORIES_FILE)
+    const memories = await readJsonArray<OpenBrainMemoryRecord>(memoriesPath)
+    await writeJsonArray(memoriesPath, dedupeMemories([...memories, proposalToMemory(reviewed)]))
+  }
+  return reviewed
+}
+
+export function compileKarpathyWikiOverlay(memories: OpenBrainMemoryRecord[]): OpenBrainWikiPage[] {
+  const approved = memories.filter((memory) => memory.privacyTier !== 'private')
+  const grouped = new Map<OpenBrainMemoryKind, OpenBrainMemoryRecord[]>()
+  for (const memory of approved) {
+    grouped.set(memory.kind, [...(grouped.get(memory.kind) || []), memory])
+  }
+
+  const pages: OpenBrainWikiPage[] = []
+  for (const [kind, records] of grouped.entries()) {
+    const title = `${titleCase(kind.replace('_', ' '))} Memory`
+    const slug = `${kind.replace(/_/g, '-')}-memory`
+    const markdown = [
+      `# ${title}`,
+      '',
+      'Generated Karpathy Wiki overlay from approved Open Brain records. The local Open Brain remains the source of truth.',
+      '',
+      ...records.map((record) => [
+        `## ${record.title}`,
+        '',
+        record.body,
+        '',
+        `- Open Brain memory: \`${record.id}\``,
+        `- Privacy tier: \`${record.privacyTier}\``,
+        `- Sources: ${record.sourceIds.map((sourceId) => `\`${sourceId}\``).join(', ') || 'none'}`,
+        '',
+      ].join('\n')),
+    ].join('\n')
+    pages.push({
+      slug,
+      title,
+      path: `docs/open-brain/wiki/${slug}.md`,
+      markdown,
+      sourceMemoryIds: records.map((record) => record.id),
+      privacyTier: records.some((record) => record.privacyTier === 'internal_ops') ? 'internal_ops' : 'public_safe',
+    })
+  }
+  return pages.sort((a, b) => a.slug.localeCompare(b.slug))
+}
+
+export function fingerprintOpenBrainRecord(parts: unknown[]) {
+  return createHash('sha256').update(parts.map((part) => String(part)).join('\u001f')).digest('hex')
+}
+
+export function sanitizeOpenBrainText(value: string, maxLength = 700) {
+  return value.replace(SECRETISH_PATTERN, '[redacted]').replace(/\s+/g, ' ').trim().slice(0, maxLength)
+}
+
+function getServiceStatus(openBrainHome: string): OpenBrainSnapshot['service'] {
+  const databaseUrl = process.env.OPEN_BRAIN_DATABASE_URL || ''
+  const mcpUrl = process.env.OPEN_BRAIN_MCP_URL || ''
+  const storage = databaseUrl ? 'postgres_pgvector' : existsSync(openBrainHome) ? 'local_jsonl' : 'unconfigured'
+  const available = Boolean(databaseUrl || existsSync(openBrainHome))
+  return {
+    available,
+    storage,
+    home: openBrainHome,
+    databaseConfigured: Boolean(databaseUrl),
+    mcpConfigured: Boolean(mcpUrl),
+    mcpUrl: mcpUrl || null,
+    reason: available ? null : 'Local Open Brain storage is not configured yet. Set OPEN_BRAIN_DATABASE_URL or initialize OPEN_BRAIN_HOME.',
+    operationalBoundary: 'Portfolio is a projection and approval surface. The local Open Brain service remains the source of truth; direct writes to Codex operational state require a separate approved repair step.',
+  }
+}
+
+function buildRunbookSources(generatedAt: string): OpenBrainSourceRecord[] {
+  const runbooks = [
+    'docs/memory-context-organization-workflow.md',
+    'docs/automations/README.md',
+    'docs/automations/organization-runbook.md',
+    'docs/automations/credentials-runbook.md',
+    'docs/automations/content-voice-runbook.md',
+  ]
+  return runbooks.map((docPath) => ({
+    id: `runbook:${docPath}`,
+    kind: 'runbook',
+    title: path.basename(docPath),
+    summary: `Repo-owned governing document for Portfolio memory, context, and automation workflows.`,
+    path: path.join(PORTFOLIO_ROOT, docPath),
+    privacyTier: 'internal_ops',
+    confidence: 0.8,
+    lastObservedAt: generatedAt,
+    fingerprint: fingerprintOpenBrainRecord(['runbook', docPath]),
+  }))
+}
+
+function buildRuntimeParity(openBrainHome: string): OpenBrainRuntimeParity[] {
+  const codexConfig = path.join(homedir(), '.codex', 'config.toml')
+  const hermesConfig = path.join(homedir(), '.hermes', 'hermes-agent')
+  const opencodeConfig = path.join(homedir(), '.config', 'opencode')
+  const cursorConfig = path.join(homedir(), '.cursor')
+  return [
+    {
+      runtime: 'Codex',
+      status: existsSync(codexConfig) ? 'blocked' : 'skipped',
+      configPath: codexConfig,
+      note: existsSync(codexConfig)
+        ? 'Codex config exists; register the Open Brain MCP server after approval.'
+        : 'Codex config was not found on this machine.',
+    },
+    {
+      runtime: 'Hermes',
+      status: existsSync(hermesConfig) ? 'blocked' : 'skipped',
+      configPath: hermesConfig,
+      note: existsSync(hermesConfig)
+        ? 'Hermes runtime exists; MCP parity registration still needs an approved operational step.'
+        : 'Hermes runtime was not found on this machine.',
+    },
+    {
+      runtime: 'OpenCode',
+      status: existsSync(opencodeConfig) ? 'blocked' : 'skipped',
+      configPath: opencodeConfig,
+      note: existsSync(opencodeConfig)
+        ? 'OpenCode-style config exists; connection should be verified by its own doctor/list command.'
+        : 'OpenCode config was not found on this machine.',
+    },
+    {
+      runtime: 'ChatGPT',
+      status: 'blocked',
+      configPath: openBrainHome,
+      note: 'Needs an MCP or connector bridge that points at the local Open Brain service.',
+    },
+    {
+      runtime: 'Claude',
+      status: 'blocked',
+      configPath: openBrainHome,
+      note: 'Needs a separate Claude MCP registration; Codex config is not inherited.',
+    },
+    {
+      runtime: 'Cursor',
+      status: existsSync(cursorConfig) ? 'blocked' : 'skipped',
+      configPath: cursorConfig,
+      note: existsSync(cursorConfig)
+        ? 'Cursor config exists; MCP registration should be handled separately from Codex.'
+        : 'Cursor config was not found on this machine.',
+    },
+  ]
+}
+
+function buildContextPacket(
+  sources: OpenBrainSourceRecord[],
+  memories: OpenBrainMemoryRecord[],
+  proposals: OpenBrainProposalRecord[],
+): OpenBrainSnapshot['contextPacket'] {
+  return {
+    purpose: 'Use the local Open Brain to understand Portfolio Agent Ops context before acting; Portfolio Admin is the projection and approval layer.',
+    boundaries: [
+      'Do not treat generated wiki pages as the source of truth.',
+      'Do not write durable memories from agent inference without approval.',
+      'Do not mutate ~/.codex operational state from Portfolio APIs.',
+    ],
+    requiredInputs: sources.slice(0, 6).map((source) => source.title),
+    currentRisks: [
+      ...(memories.length === 0 ? ['No approved durable Open Brain memories have been accepted yet.'] : []),
+      ...(proposals.some((proposal) => proposal.status === 'pending') ? ['Pending memory proposals need review before wiki overlay generation.'] : []),
+    ],
+    expectedOutputs: [
+      'Context packet before agent action',
+      'Approval-gated memory proposal',
+      'Generated wiki overlay from approved non-private records',
+    ],
+  }
+}
+
+function mergeProposals(persisted: OpenBrainProposalRecord[], generated: OpenBrainProposalRecord[]) {
+  const byId = new Map<string, OpenBrainProposalRecord>()
+  for (const proposal of generated) byId.set(proposal.id, proposal)
+  for (const proposal of persisted) byId.set(proposal.id, proposal)
+  return [...byId.values()].sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+}
+
+function proposalToMemory(proposal: OpenBrainProposalRecord): OpenBrainMemoryRecord {
+  const createdAt = proposal.reviewedAt || proposal.createdAt
+  return {
+    id: `memory:${proposal.id.replace(/^proposal:/, '')}`,
+    ...proposal.proposedMemory,
+    sourceIds: proposal.proposedMemory.sourceIds || proposal.sourceIds,
+    createdAt,
+    updatedAt: createdAt,
+    fingerprint: fingerprintOpenBrainRecord([
+      proposal.proposedMemory.kind,
+      proposal.proposedMemory.title,
+      proposal.proposedMemory.body,
+      proposal.proposedMemory.privacyTier,
+    ]),
+  }
+}
+
+function dedupeSources(sources: OpenBrainSourceRecord[]) {
+  return [...new Map(sources.map((source) => [source.fingerprint, source])).values()]
+}
+
+function dedupeMemories(memories: OpenBrainMemoryRecord[]) {
+  return [...new Map(memories.map((memory) => [memory.fingerprint, memory])).values()]
+}
+
+function classifyFreshness(sources: OpenBrainSourceRecord[], now: string) {
+  if (sources.length === 0) return 'red'
+  const stale = sources.filter((source) => isStale(source.lastObservedAt, now)).length
+  if (stale === 0) return 'green'
+  if (stale > sources.length / 2) return 'red'
+  return 'yellow'
+}
+
+function isStale(lastObservedAt: string, now: string) {
+  return Date.parse(now) - Date.parse(lastObservedAt) > 1000 * 60 * 60 * 24 * 14
+}
+
+function clampConfidence(value: number) {
+  return Math.max(0, Math.min(1, value))
+}
+
+async function readJsonArray<T>(filePath: string): Promise<T[]> {
+  if (!existsSync(filePath)) return []
+  try {
+    const parsed = JSON.parse(await readFile(filePath, 'utf8'))
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+async function writeJsonArray<T>(filePath: string, records: T[]) {
+  await mkdir(path.dirname(filePath), { recursive: true })
+  await writeFile(filePath, `${JSON.stringify(records, null, 2)}\n`, 'utf8')
+}
+
+function titleCase(value: string) {
+  return value.replace(/\b\w/g, (letter) => letter.toUpperCase())
+}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "deploy:watch:once": "tsx scripts/vercel-deployment-watch.ts --once",
     "deploy:metrics": "tsx scripts/vercel-deployment-metrics.ts",
     "git:hygiene:report": "tsx scripts/git-hygiene-report.ts",
+    "open-brain:mcp": "tsx scripts/open-brain-mcp-server.ts",
     "wrm:smoke-gate": "tsx scripts/wrm-production-smoke-gate.ts",
     "source-protocol:smoke": "tsx scripts/source-protocol-smoke.ts",
     "staging:publications-parity": "tsx scripts/ensure-publications-experience-parity.ts --env-file .env.staging",

--- a/scripts/open-brain-mcp-server.ts
+++ b/scripts/open-brain-mcp-server.ts
@@ -1,0 +1,169 @@
+#!/usr/bin/env tsx
+import { createInterface } from 'readline'
+import {
+  compileKarpathyWikiOverlay,
+  createOpenBrainProposal,
+  getOpenBrainSnapshot,
+  type OpenBrainMemoryKind,
+  type OpenBrainPrivacyTier,
+} from '../lib/open-brain'
+
+type RpcRequest = {
+  id?: string | number
+  method?: string
+  params?: {
+    name?: string
+    arguments?: Record<string, unknown>
+  }
+}
+
+const tools = [
+  {
+    name: 'capture_memory',
+    description: 'Create an approval-gated Open Brain memory proposal. Durable memory writes still require approval.',
+    inputSchema: proposalSchema(),
+  },
+  {
+    name: 'search_memory',
+    description: 'Search approved local Open Brain memories and source projections.',
+    inputSchema: {
+      type: 'object',
+      properties: { query: { type: 'string' } },
+      required: ['query'],
+    },
+  },
+  {
+    name: 'get_context_packet',
+    description: 'Return the compact context packet agents should read before acting.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'propose_memory_write',
+    description: 'Create an approval-gated proposed memory write.',
+    inputSchema: proposalSchema(),
+  },
+  {
+    name: 'list_pending_memory_proposals',
+    description: 'List pending Open Brain memory proposals.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'link_memory_to_source',
+    description: 'Return a proposal payload for linking memory and source records. Link persistence is approval-gated in V1.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        memoryId: { type: 'string' },
+        sourceId: { type: 'string' },
+        relationship: { type: 'string' },
+      },
+      required: ['memoryId', 'sourceId', 'relationship'],
+    },
+  },
+  {
+    name: 'compile_wiki_overlay',
+    description: 'Compile Karpathy Wiki overlay previews from approved non-private memories.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+]
+
+const rl = createInterface({ input: process.stdin, crlfDelay: Infinity })
+
+rl.on('line', async (line) => {
+  if (!line.trim()) return
+  let request: RpcRequest
+  try {
+    request = JSON.parse(line)
+  } catch {
+    write({ error: { code: -32700, message: 'Parse error' } })
+    return
+  }
+
+  try {
+    if (request.method === 'initialize') {
+      write({ id: request.id, result: { protocolVersion: '2024-11-05', serverInfo: { name: 'portfolio-open-brain', version: '0.1.0' }, capabilities: { tools: {} } } })
+      return
+    }
+    if (request.method === 'tools/list') {
+      write({ id: request.id, result: { tools } })
+      return
+    }
+    if (request.method === 'tools/call') {
+      write({ id: request.id, result: await callTool(request.params?.name || '', request.params?.arguments || {}) })
+      return
+    }
+    write({ id: request.id, error: { code: -32601, message: 'Method not found' } })
+  } catch (err) {
+    write({ id: request.id, error: { code: -32000, message: err instanceof Error ? err.message : 'Tool call failed' } })
+  }
+})
+
+async function callTool(name: string, args: Record<string, unknown>) {
+  const snapshot = await getOpenBrainSnapshot()
+  if (name === 'get_context_packet') return asText(snapshot.contextPacket)
+  if (name === 'list_pending_memory_proposals') return asText(snapshot.proposals.filter((proposal) => proposal.status === 'pending'))
+  if (name === 'compile_wiki_overlay') return asText({ mode: 'preview', pages: compileKarpathyWikiOverlay(snapshot.memories) })
+  if (name === 'search_memory') {
+    const query = String(args.query || '').toLowerCase()
+    return asText({
+      memories: snapshot.memories.filter((memory) => `${memory.title} ${memory.body}`.toLowerCase().includes(query)),
+      sources: snapshot.sources.filter((source) => `${source.title} ${source.summary} ${source.path || ''}`.toLowerCase().includes(query)),
+    })
+  }
+  if (name === 'capture_memory' || name === 'propose_memory_write') {
+    const proposal = await createOpenBrainProposal({
+      kind: args.kind as OpenBrainMemoryKind,
+      title: String(args.title || ''),
+      body: String(args.body || ''),
+      privacyTier: args.privacyTier as OpenBrainPrivacyTier,
+      confidence: typeof args.confidence === 'number' ? args.confidence : undefined,
+      sourceIds: Array.isArray(args.sourceIds) ? args.sourceIds.filter((item): item is string => typeof item === 'string') : [],
+      reason: String(args.reason || ''),
+      createdBy: 'open-brain-mcp',
+    })
+    return asText({ proposal, approvalRequired: true })
+  }
+  if (name === 'link_memory_to_source') {
+    return asText({
+      approvalRequired: true,
+      link: {
+        memoryId: args.memoryId,
+        sourceId: args.sourceId,
+        relationship: args.relationship,
+      },
+      note: 'V1 returns a link proposal payload only; durable link persistence should go through proposal review.',
+    })
+  }
+  throw new Error(`Unknown tool: ${name}`)
+}
+
+function asText(value: unknown) {
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(value, null, 2),
+      },
+    ],
+  }
+}
+
+function write(value: unknown) {
+  process.stdout.write(`${JSON.stringify(value)}\n`)
+}
+
+function proposalSchema() {
+  return {
+    type: 'object',
+    properties: {
+      kind: { type: 'string', enum: ['fact', 'decision', 'preference', 'workflow', 'risk', 'operating_rule'] },
+      title: { type: 'string' },
+      body: { type: 'string' },
+      privacyTier: { type: 'string', enum: ['public_safe', 'client_safe', 'internal_ops', 'private'] },
+      confidence: { type: 'number' },
+      sourceIds: { type: 'array', items: { type: 'string' } },
+      reason: { type: 'string' },
+    },
+    required: ['kind', 'title', 'body', 'privacyTier', 'reason'],
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a Portfolio Admin Open Brain dashboard under Agent Operations for local-first memory/source health, pending proposals, wiki overlay previews, and cross-runtime parity status.
- Adds server-only Open Brain projection logic over the existing Codex automation inventory and workspace-root report, with source records, approval-gated memory proposals, privacy tiers, fingerprint dedupe, and Karpathy Wiki compilation from approved non-private memories.
- Adds admin APIs for snapshot reads, proposal creation, proposal approve/reject, and wiki preview compilation, plus a local stdio MCP server script exposing the planned Open Brain tools.
- Documents the local-first Open Brain contract and records the Enhancement Impact Preflight with yellow overlap because active Agent Operations PRs also touch shared admin surfaces.

## Validation

- `npm test -- lib/open-brain.test.ts app/api/admin/agents/open-brain/route.test.ts app/api/admin/agents/open-brain/proposals/route.test.ts 'app/api/admin/agents/open-brain/proposals/[id]/approve/route.test.ts'`
- `npm test -- lib/codex-automation-inventory.test.ts lib/codex-workspace-roots.test.ts app/api/admin/agents/automations/route.test.ts`
- `npx tsc --noEmit --pretty false`
- `npm run lint`
- `printf '%s\n' '{"id":1,"method":"tools/list"}' | npm run open-brain:mcp --silent`
- `npm run build` using `/Users/vambahsillah/Projects/Portfolio/.env.local` loaded with `dotenv.parse` because this sibling worktree does not have its own ignored `.env.local` file.

## Integration Notes

- Draft PR: integration captain should sequence this with Agent Operations PRs #208 and #210 because the overlap rating is yellow around shared Agent Operations navigation/workflow context.
- No Supabase migrations or hosted persistence are included in V1.
- No local operational state was written: this PR did not edit `~/.codex/memories`, `~/.codex/automations`, Codex SQLite/Desktop state, or `~/.open-brain`.
- The Portfolio UI can approve/reject local Open Brain proposals, but generated wiki output remains preview-only until a separate approved repo change writes markdown.
- Vercel contexts checked on PR: `Vercel – portfolio` passed. Integration captain should verify both `Vercel – portfolio` and `Vercel – portfolio-staging` after merge sequencing.
