### PR TITLE
feat: add AI risk compliance agent

### DIFF
--- a/docs/agent-identity-map.md
+++ b/docs/agent-identity-map.md
@@ -17,6 +17,7 @@ The Chief of Staff identity is fixed by rule:
 | `research-source-register` | Askia Muhammad (Songhai) - Research Source Register |
 | `private-knowledge-librarian` | Hatshepsut (Kemet) - Private Knowledge Librarian |
 | `decision-journal` | Nzinga (Ndongo/Matamba) - Decision Journal |
+| `risk-compliance-intelligence` | Moremi (Ife) - Risk & Compliance |
 | `voice-content-architect` | Nefertiti (Kemet) - Voice & Content Architect |
 | `content-repurposing` | Hannibal (Carthage) - Content Repurposing |
 | `amadutown-brand` | Taharqa (Kush) - AmaduTown Brand |

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -58,7 +58,7 @@ Current pod alignment:
 
 - Chief of Staff — Agent Ops morning review and executive escalation layer.
 - Strategy & Narrative — planned Codex/Hermes-first agents; not primarily n8n yet.
-- Research & Knowledge — lead research, RAG, diagnostics, value evidence, source register workflows.
+- Research & Knowledge — lead research, RAG, diagnostics, value evidence, source register workflows, and AI risk/compliance intelligence.
 - Content Production — social extraction, repurposing, audio/image regeneration, brand/course agents.
 - Product & Automation — client workflow backbone, monitoring, provisioning, task sync, tooling parity.
 - Publishing & Follow-Up — social publish, outbound/follow-up, Gmail draft, nurture, warm lead capture, and meeting intake/follow-up.
@@ -68,6 +68,12 @@ Agent organization load balancing now splits the former overloaded `Samori Toure
 - `Samori Toure (Wassoulou) - Inbox & Follow-Up` owns cold outreach sends, reply detection, Gmail draft preparation, and lead-magnet nurture.
 - `Behanzin (Dahomey) - Warm Lead Capture` owns approved WRM Facebook, Google Contacts, and LinkedIn warm-source capture while preserving source-specific traceability.
 - `Amanirenas (Kush) - Meeting Intake & Follow-Up` owns Slack intake, Calendly routing, meeting completion, agenda generation/sending, and follow-up scheduling.
+
+AI risk and compliance work is now a separate Research & Knowledge lane:
+
+- `Askia Muhammad (Songhai) - Research Source Register` collects and classifies source-backed evidence.
+- `Moremi (Ife) - Risk & Compliance` watches AI agent, AI ethics, security, privacy, and regulatory signals, maps them to Portfolio exposure, and opens upgrade requests when a gap appears.
+- `Piye (Kush) - Engineering Copilot` and `Yaa Asantewaa (Ashanti) - Automation Systems` own remediation only after the risk owner produces a scoped upgrade request.
 
 The shared trace tables are:
 

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -67,6 +67,8 @@ This is the active implementation queue for Agent Operations. The phase gates, d
    - [x] Add the global `agent-org-load-balancer` meta-skill for identifying overloaded or overlapping agents.
    - [x] Spin out warm lead capture from the overloaded Samori Toure (Wassoulou) - Inbox & Follow-Up.
    - [x] Spin out meeting intake and follow-up from the overloaded Samori Toure (Wassoulou) - Inbox & Follow-Up.
+   - [x] Spin out Moremi (Ife) - Risk & Compliance for AI agent/current-event risk monitoring and Portfolio exposure checks.
+   - [ ] Add a scheduled read-only risk signal monitor once source feeds and scoring criteria are approved.
    - [ ] Continue monitoring Yaa Asantewaa (Ashanti) - Automation Systems for a future split only if trace/work-item load stays high.
 
 ## Completed Or In Review

--- a/docs/ai-risk-compliance-agent.md
+++ b/docs/ai-risk-compliance-agent.md
@@ -1,0 +1,72 @@
+# Moremi (Ife) - Risk & Compliance
+
+## Purpose
+
+Moremi (Ife) - Risk & Compliance watches AI agent, AI ethics, security, privacy, and regulatory developments, then translates relevant signals into Portfolio exposure checks and upgrade requests.
+
+This is a spinout from the Research & Knowledge pod. It does not replace the Research Source Register. The source register collects and classifies evidence; Moremi decides whether the evidence creates operational risk for Portfolio.
+
+## Parent And Supporting Agents
+
+- Parent pod: Research & Knowledge
+- Primary router: Shaka (Zulu) - Chief of Staff
+- Evidence intake: Askia Muhammad (Songhai) - Research Source Register
+- Implementation owner when a gap is confirmed: Piye (Kush) - Engineering Copilot
+- Automation owner when a workflow or monitor is needed: Yaa Asantewaa (Ashanti) - Automation Systems
+- Decision capture: Nzinga (Ndongo/Matamba) - Decision Journal
+
+## Watch Topics
+
+- Agent autonomy failures, including tool misuse, unapproved actions, and prompt injection.
+- Data privacy, consent, retention, and client-data exposure.
+- AI safety, bias, discrimination, model misuse, and deceptive output risks.
+- Regulatory obligations affecting AI agents, general-purpose AI, automated decisions, data processing, and consumer disclosures.
+- Vendor incidents involving AI infrastructure, agent frameworks, model providers, workflow automation, browser automation, RAG systems, and retrieval stores.
+- Security guidance for LLM and agentic systems.
+
+## Signal Triage
+
+Every signal should be classified before it becomes work:
+
+| Classification | Meaning | Next step |
+| --- | --- | --- |
+| `watch_only` | Interesting, but no credible Portfolio exposure yet. | Save source and revisit if pattern repeats. |
+| `exposure_check` | Plausible Portfolio surface exists. | Open a read-only assessment work item. |
+| `upgrade_request` | Confirmed gap or missing control. | Open a scoped implementation request. |
+| `approval_required` | Fix may touch policy, production config, public content, external sends, or client data. | Route to Shaka and approval gate. |
+
+## Exposure Checklist
+
+When a signal is relevant, Moremi checks Portfolio for:
+
+- Affected route, workflow, agent, prompt, model, provider, or data store.
+- Existing policy or approval gate covering the risk.
+- Existing trace coverage in `agent_runs`, `agent_run_events`, `agent_approvals`, or `agent_work_items`.
+- Whether the risk affects production, staging, local-only development, or documentation.
+- Whether the risk involves client data, leads, meetings, payment data, private knowledge, credentials, publishing, outbound email, or production config.
+- Required owner for remediation.
+
+## Outputs
+
+- Risk signal brief with source, affected Portfolio surface, likelihood, impact, and confidence.
+- Portfolio exposure assessment.
+- Upgrade request routed to the right owner agent.
+- Approval packet when remediation crosses an approval gate.
+- Decision journal entry after acceptance, rejection, or deferral.
+
+## Safety Boundaries
+
+- Read-only research and exposure checks are allowed.
+- No production workflow mutation, config change, prompt change, public claim, vendor switch, database write outside known safe workflows, publishing, or external send is allowed without approval.
+- Do not copy production customer, lead, client, contact, meeting, payment, or private operational data into non-production validation.
+- Do not treat news commentary as policy. Prefer primary sources, regulator guidance, vendor incident notices, standards bodies, and security advisories where available.
+
+## Definition Of Done
+
+A risk signal is done when it has one of these outcomes:
+
+- `watch_only`: source retained and no current Portfolio exposure found.
+- `exposure_check`: assessment complete and owner assigned.
+- `upgrade_request`: scoped remediation request created with validation criteria.
+- `approval_required`: approval packet created and routed.
+- `closed`: risk accepted, resolved, superseded, or marked not applicable with rationale.

--- a/lib/agent-organization.test.ts
+++ b/lib/agent-organization.test.ts
@@ -97,4 +97,21 @@ describe('agent organization registry', () => {
     expect(librarian?.approvalGate).toContain('public chatbot/RAG policy changes')
     expect(sourceRegister?.approvalGate).toContain('unclassified material')
   })
+
+  it('adds a narrow AI risk and compliance owner without taking over source intake', () => {
+    const riskAgent = getAgentByKey('risk-compliance-intelligence')
+    const sourceRegister = getAgentByKey('research-source-register')
+
+    expect(riskAgent).toMatchObject({
+      name: 'Moremi (Ife) - Risk & Compliance',
+      podKey: 'research_knowledge',
+      status: 'partial',
+      primaryRuntime: 'mixed',
+      n8nWorkflows: [],
+    })
+    expect(riskAgent?.responsibility).toContain('map them to Portfolio exposure')
+    expect(riskAgent?.responsibility).toContain('open upgrade requests')
+    expect(riskAgent?.approvalGate).toContain('Read-only exposure assessment')
+    expect(sourceRegister?.responsibility).toContain('Collect and classify source-backed evidence')
+  })
 })

--- a/lib/agent-organization.ts
+++ b/lib/agent-organization.ts
@@ -167,6 +167,17 @@ export const AGENT_ORGANIZATION: AgentOrganizationNode[] = [
     n8nWorkflows: [],
   },
   {
+    key: 'risk-compliance-intelligence',
+    name: 'Moremi (Ife) - Risk & Compliance',
+    podKey: 'research_knowledge',
+    status: 'partial',
+    primaryRuntime: 'mixed',
+    responsibility: 'Monitor AI agent, AI ethics, security, privacy, and regulatory signals, map them to Portfolio exposure, and open upgrade requests when gaps appear.',
+    engagementPath: 'Research intake from source registers and news monitors, Agent Ops work items, Chief of Staff escalation, and future Slack status routing.',
+    approvalGate: 'Read-only exposure assessment by default; policy changes, production config changes, public claims, workflow mutation, or client-data access require approval.',
+    n8nWorkflows: [],
+  },
+  {
     key: 'voice-content-architect',
     name: 'Nefertiti (Kemet) - Voice & Content Architect',
     podKey: 'content_production',

--- a/migrations/2026_05_10_agent_risk_compliance.sql
+++ b/migrations/2026_05_10_agent_risk_compliance.sql
@@ -1,0 +1,35 @@
+-- Register the AI risk and compliance intelligence agent.
+-- Keeps the routing key stable while adding a user-facing African royal identity.
+
+INSERT INTO agent_registry (
+  key,
+  name,
+  runtime,
+  pod,
+  description,
+  risk_level,
+  default_requires_approval,
+  active,
+  updated_at
+)
+VALUES (
+  'risk-compliance-intelligence',
+  'Moremi (Ife) - Risk & Compliance',
+  'codex',
+  'Research & Knowledge',
+  'Monitors AI agent, AI ethics, security, privacy, and regulatory signals, maps them to Portfolio exposure, and opens upgrade requests when gaps appear.',
+  'high',
+  true,
+  true,
+  now()
+)
+ON CONFLICT (key) DO UPDATE
+SET
+  name = EXCLUDED.name,
+  runtime = EXCLUDED.runtime,
+  pod = EXCLUDED.pod,
+  description = EXCLUDED.description,
+  risk_level = EXCLUDED.risk_level,
+  default_requires_approval = EXCLUDED.default_requires_approval,
+  active = EXCLUDED.active,
+  updated_at = now();


### PR DESCRIPTION
## Summary
- Adds Moremi (Ife) - Risk & Compliance as a narrow Research & Knowledge owner for AI agent, ethics, security, privacy, and regulatory signal monitoring.
- Documents the boundary: Askia gathers/classifies evidence; Moremi maps signals to Portfolio exposure and opens upgrade requests; Engineering/Automation implement only after scoped requests.
- Adds a registry migration for the new agent without changing existing technical keys, routes, Slack commands, or workflow IDs.

## Validation
- npm test -- --run lib/agent-organization.test.ts lib/agent-mission-control.test.ts lib/agent-swarm-board.test.ts lib/agent-run-recovery.test.ts lib/agent-slack-command.test.ts lib/agent-engagement.test.ts lib/chief-of-staff-chat.test.ts app/api/admin/agents/engage/route.test.ts app/api/admin/agents/mission-control/route.test.ts app/api/admin/agents/swarm-board/route.test.ts 'app/api/admin/agents/runs/[runId]/retry/route.test.ts' app/api/admin/agents/war-room/route.test.ts app/api/admin/agents/chief-of-staff/chat/route.test.ts
- npx tsc --noEmit --pretty false
- npx next lint --file lib/agent-organization.ts --file lib/agent-organization.test.ts

## Integration Notes
- Stacked on PR #210 / codex/agent-identity-names because it depends on the African royal agent identity convention.
- Apply #210 first, then this PR. After #210 lands, this PR can be retargeted to main if needed.
- Requires applying migration `migrations/2026_05_10_agent_risk_compliance.sql` after the identity-name registry migration.
- No production data reads, live news monitor activation, n8n workflow changes, or external sends were performed.
- Vercel contexts not checked from this non-captain lane.