### PR TITLE
fix: ignore non-uuid chief of staff user ids

### DIFF
--- a/lib/chief-of-staff-chat.test.ts
+++ b/lib/chief-of-staff-chat.test.ts
@@ -20,6 +20,7 @@ import {
   buildChiefOfStaffPrompt,
   evaluateChiefOfStaffBudget,
   getChiefOfStaffAgentRoutingCatalog,
+  getChiefOfStaffTriggeredByUserId,
   normalizeChiefOfStaffHistory,
   parseChiefOfStaffJson,
   summarizeAutomationContext,
@@ -103,6 +104,14 @@ describe('Chief of Staff chat helpers', () => {
       { role: 'assistant', content: 'second' },
       { role: 'user', content: 'third' },
     ])
+  })
+
+  it('only writes UUID user identifiers to agent run ownership fields', () => {
+    expect(getChiefOfStaffTriggeredByUserId('019e111a-4fb3-7950-86ae-d9608f4e1a14')).toBe(
+      '019e111a-4fb3-7950-86ae-d9608f4e1a14',
+    )
+    expect(getChiefOfStaffTriggeredByUserId('slack:U08FJLLKWF3')).toBeNull()
+    expect(getChiefOfStaffTriggeredByUserId(undefined)).toBeNull()
   })
 
   it('parses the model JSON contract', () => {

--- a/lib/chief-of-staff-chat.ts
+++ b/lib/chief-of-staff-chat.ts
@@ -216,6 +216,13 @@ export function normalizeChiefOfStaffHistory(
     .slice(-8)
 }
 
+export function getChiefOfStaffTriggeredByUserId(userId: string | undefined) {
+  if (!userId) return null
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(userId)
+    ? userId
+    : null
+}
+
 function isAgentAction(value: unknown): value is AgentAction {
   return typeof value === 'string' && CHIEF_OF_STAFF_ACTIONS.includes(value as AgentAction)
 }
@@ -514,7 +521,7 @@ export async function runChiefOfStaffChat(input: ChiefOfStaffChatRequest): Promi
     status: 'running',
     subject: { type: 'admin_chat', id: input.userId ?? 'admin', label: 'Admin chat' },
     triggerSource: input.triggerSource ?? 'admin_chief_of_staff_chat',
-    triggeredByUserId: input.userId,
+    triggeredByUserId: getChiefOfStaffTriggeredByUserId(input.userId),
     currentStep: 'Collecting operating context',
     metadata: { message_preview: message.slice(0, 240) },
   })


### PR DESCRIPTION
## Summary
- Prevent Slack user identifiers like `slack:U08FJLLKWF3` from being written to the UUID-backed `agent_runs.triggered_by_user_id` field.
- Preserve the Slack-originating user reference in the Agent Ops subject while keeping admin UUID attribution intact.
- Add focused coverage for UUID vs non-UUID Chief of Staff user identifiers.

## Validation
- `npm test -- --run lib/chief-of-staff-chat.test.ts lib/agent-slack-events.test.ts app/api/slack/agent/events/route.test.ts`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- Pre-push DB health check passed after loading Portfolio root env.

## Integration Notes
- Fixes the live Slack Events API smoke failure seen in production logs: invalid input syntax for type uuid.
- No migration or env change required.
- Live Slack smoke should be rerun after merge/deploy.