### PR TITLE
fix: skip unsupported slack agent events

### DIFF
--- a/app/api/slack/agent/events/route.test.ts
+++ b/app/api/slack/agent/events/route.test.ts
@@ -8,6 +8,20 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@/lib/agent-slack-events', () => ({
   handleSlackAgentEvent: mocks.handleSlackAgentEvent,
+  shouldHandleSlackAgentEvent: (event?: {
+    type?: string
+    bot_id?: string
+    subtype?: string
+    user?: string
+    channel?: string
+    channel_type?: string
+  }) => {
+    if (!event) return false
+    if (event.bot_id || event.subtype) return false
+    if (!event.user || !event.channel) return false
+    if (event.type === 'app_mention') return true
+    return event.type === 'message' && event.channel_type === 'im'
+  },
 }))
 
 vi.mock('@vercel/functions', () => ({
@@ -85,6 +99,28 @@ describe('POST /api/slack/agent/events', () => {
     expect(await response.json()).toEqual({ ok: true })
     expect(mocks.handleSlackAgentEvent).toHaveBeenCalledWith(payload)
     expect(mocks.waitUntil).toHaveBeenCalledWith(expect.any(Promise))
+  })
+
+  it('acknowledges unsupported channel message events without scheduling work', async () => {
+    const payload = {
+      type: 'event_callback',
+      event_id: 'EvChannelMessage',
+      event: {
+        type: 'message',
+        channel_type: 'channel',
+        user: 'U123',
+        channel: 'C123',
+        text: 'regular channel chatter',
+      },
+    }
+    const request = signedRequest(payload)
+
+    const response = await POST(request as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ ok: true, skipped: 'unsupported_event' })
+    expect(mocks.handleSlackAgentEvent).not.toHaveBeenCalled()
+    expect(mocks.waitUntil).not.toHaveBeenCalled()
   })
 
   it('dedupes Slack retries before scheduling event work', async () => {

--- a/app/api/slack/agent/events/route.ts
+++ b/app/api/slack/agent/events/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { waitUntil } from '@vercel/functions'
-import { handleSlackAgentEvent, type SlackAgentEventPayload } from '@/lib/agent-slack-events'
+import {
+  handleSlackAgentEvent,
+  shouldHandleSlackAgentEvent,
+  type SlackAgentEventPayload,
+} from '@/lib/agent-slack-events'
 import { verifySlackSignature } from '@/lib/slack-signature'
 
 export const dynamic = 'force-dynamic'
@@ -34,6 +38,10 @@ export async function POST(request: NextRequest) {
 
     if (request.headers.get('x-slack-retry-num')) {
       return NextResponse.json({ ok: true, skipped: 'slack_retry' })
+    }
+
+    if (payload.type === 'event_callback' && !shouldHandleSlackAgentEvent(payload.event)) {
+      return NextResponse.json({ ok: true, skipped: 'unsupported_event' })
     }
 
     waitUntil(handleSlackAgentEvent(payload))

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -285,7 +285,9 @@ Required Slack app configuration:
 - Bot token scopes: `app_mentions:read`, `im:history`, and `chat:write`.
 - Environment variables: `SLACK_SIGNING_SECRET` and `SLACK_BOT_TOKEN`.
 
-The event route verifies Slack signatures with `SLACK_SIGNING_SECRET`, ignores bot/subtype events, acknowledges Slack immediately, and uses `SLACK_BOT_TOKEN` to post the Chief of Staff reply back into the originating thread. The conversation path reuses the existing read-only Chief of Staff chat engine and records an observable `agent_run` with `trigger_source = slack_agent_chat`.
+Do not subscribe the Agent Ops app to `message.channels` for the conversational path. Broad channel-message subscriptions create unnecessary webhook traffic and should be reserved for a separately scoped ingestion workflow. The route still acknowledges unsupported channel-message events with `skipped = unsupported_event` as a defense-in-depth guard.
+
+The event route verifies Slack signatures with `SLACK_SIGNING_SECRET`, skips unsupported events before scheduling async work, ignores bot/subtype events, acknowledges Slack immediately, and uses `SLACK_BOT_TOKEN` to post the Chief of Staff reply back into the originating thread. The conversation path reuses the existing read-only Chief of Staff chat engine and records an observable `agent_run` with `trigger_source = slack_agent_chat`.
 
 Chat is for freeform status, triage, and coordination. Deterministic operations should stay on `/agent` commands, and production-impacting actions remain approval-gated.
 

--- a/lib/agent-slack-events.test.ts
+++ b/lib/agent-slack-events.test.ts
@@ -78,6 +78,14 @@ describe('agent Slack events', () => {
     })).toBe(false)
 
     expect(shouldHandleSlackAgentEvent({
+      type: 'message',
+      channel_type: 'channel',
+      user: 'U123',
+      channel: 'C123',
+      text: '<@UAGENT> status?',
+    })).toBe(false)
+
+    expect(shouldHandleSlackAgentEvent({
       type: 'app_mention',
       bot_id: 'B123',
       user: 'U123',


### PR DESCRIPTION
## Summary
- Skip unsupported Slack Events API payloads before scheduling background work.
- Adds regression coverage for broad channel message events so `message.channels` config drift does not trigger Chief of Staff processing.
- Documents that Agent Ops conversational Slack should only subscribe to `app_mention` and `message.im`.

## Validation
- `npm test -- --run lib/agent-slack-events.test.ts app/api/slack/agent/events/route.test.ts`
- `npx tsx scripts/build-chatbot-knowledge.ts`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- Pre-push DB health check passed after loading Portfolio root env.

## Integration Notes
- No migration or environment change required.
- This is defense-in-depth for the live Slack conversational path that was smoke-verified after #214.
- Slack app config should still remove the extra `message.channels` bot event when the Slack API UI is accessible.
- Post-merge deploy verification required for both Vercel contexts: `Vercel – portfolio` and `Vercel – portfolio-staging`.
