### PR TITLE
Add weekly subscription report for May 11

### DIFF
--- a/docs/apify-call-bakeoff-analysis.md
+++ b/docs/apify-call-bakeoff-analysis.md
@@ -38,6 +38,25 @@ Purpose: keep Apify under active watch, identify every current Portfolio call su
 
 Current read: Apify's $39/month subscription is not justified by all configured actors equally. Four actor categories produced useful-looking volume in the sample: Reddit listening, Google Maps, LinkedIn post search, and Capterra reviews. Eight configured surfaces are no-run, failing, or empty-output and should be paused, replaced, or retired before Apify is treated as a durable default.
 
+## Replacement Bakeoff Gate
+
+Run replacement tests only for the productive categories. Do not spend time
+benchmarking no-run, failing, or empty-output actors until a workflow owner
+proves the campaign still needs that source.
+
+| Productive category | Current Apify signal | Replacement to test first | Why this is the first challenger | Gate |
+| --- | ---: | --- | --- | --- |
+| Reddit listening | 72 items / $0.47360 | Brave Search API with Reddit/source filters, then official Reddit Data API only if terms fit | Brave is $5 per 1,000 search requests with $5 monthly credits, which is enough for a low-volume evidence monitor. Reddit's official free API has rate limits and commercial use can require a separate agreement. | Promote replacement only if it captures the same conversations with lower review burden and acceptable source attribution. |
+| Google Maps | 68 items / $0.58600 | Google Places API Text Search/Nearby Search with field masks and strict quotas | Google Places pricing is transparent; Text Search/Nearby Search Pro list 5,000 free monthly calls, then $32 per 1,000 for the first paid tier. This can beat Apify if the workflow needs verified place data instead of broad scraping. | Promote only if Places returns enough qualified businesses with required fields while staying inside the free/low-tier quota. |
+| LinkedIn post search | 135 items / $0.27220 | Browser-agent sampling plus manual review packet | This is the strongest current Apify value signal, but LinkedIn-style extraction has account and compliance risk. A browser/manual packet should test whether smaller sampled searches produce enough accepted leads. | Keep Apify unless the replacement returns comparable accepted leads without increasing account risk or manual time. |
+| Capterra reviews | 40 items / $0.62400 | Brave Search or browser capture into a source register | Review-site evidence is usually sparse and source-sensitive. A search/browser capture may be cheaper if it preserves URLs, snippets, and review context without needing a dedicated actor. | Promote only if accepted evidence quality matches Apify and source URLs remain reviewable. |
+
+Source notes for the bakeoff packet:
+
+- Google Maps Platform pricing should be checked from the official pricing page before each run; as of the 2026-05-09 check, Places API Text Search Pro and Nearby Search Pro list 5,000 free monthly calls and then $32 per 1,000 in the first paid tier.
+- Brave Search API pricing should be checked from Brave before each run; as of the 2026-05-09 check, Search is listed at $5 per 1,000 requests with $5 monthly credits.
+- Reddit source use must be reviewed against Reddit's Data API Wiki and Data API Terms before any commercial workflow uses official Reddit API data. The official wiki lists 100 QPM free-access limits for eligible OAuth clients; the terms say commercial or out-of-scope use may require a separate agreement.
+
 ## Configured Apify Call Surfaces
 
 | Workflow | Node | Actor | Purpose | Replacement candidates |

--- a/docs/subscription-cancellation-audit.md
+++ b/docs/subscription-cancellation-audit.md
@@ -10,6 +10,129 @@ no meaningful usage signal, or after clear redundancy plus a lower-risk
 replacement path. Production changes require explicit approval in the form
 `Cancel <tool/vendor> for Portfolio`.
 
+## 2026-05-11 Weekly Subscription Report
+
+Status: YELLOW
+
+Summary:
+
+- No cancellation approvals requested and no cancellation action taken.
+- The root checkout at `/Users/vambahsillah/Projects/Portfolio` was on
+  `codex/hyperagent-evaluations` with pre-existing dirty changes in
+  `docs/subscription-cancellation-audit.md` and
+  `docs/subscription-status.json`, so this weekly update was staged in the
+  clean `codex/subscription-watch-next` worktree to preserve unrelated work.
+- Core operational dependencies moved since the prior weekly run: n8n Cloud
+  still has 77 workflows, 72 active workflows, and a successful execution at
+  2026-05-11T13:01:18Z; Supabase production `agent_runs` increased to 33 with
+  the latest row at 2026-05-11T13:00:02Z; Vercel project metadata shows
+  `portfolio` and `portfolio-staging` updated on 2026-05-11.
+- No vendor changed cancellation status this week. The standing decisions still
+  hold: BuiltWith remains a protected watch item during the outreach/client
+  volume ramp, and Fireflies remains resolved as canceled per Vambah's
+  2026-05-01 confirmation unless new paid-plan evidence appears.
+- OpenRouter remains consecutive quiet evidence with zero current-key usage,
+  but no active spend or approved replacement path was confirmed, so it stays
+  watch/investigate rather than a cancellation candidate.
+- Read AI and Calendly direct API checks still returned 401. Existing receipt,
+  meeting, scheduling, and n8n evidence keep them as keep/auth-refresh items.
+- Apify remains paid and active enough to keep at the account level. The next
+  decision is actor-level cleanup: pause or replace weak no-run, failing, and
+  empty-output surfaces before any account-level cancellation decision.
+- ElevenLabs remains active on Creator with the same 18,068 of 164,102
+  character usage signal. Review before the 2026-05-19 renewal window against
+  the next planned audio/video campaign.
+
+Raw Findings
+
+- Git state at start: `/Users/vambahsillah/Projects/Portfolio` was on
+  `codex/hyperagent-evaluations` with dirty subscription tracker files from a
+  prior monitor run. `/Users/vambahsillah/Projects/Portfolio.worktrees/subscription-watch`
+  was clean on `codex/subscription-watch-next`.
+- Prior weekly automation memory was missing; the durable tracker, structured
+  admin status file, and daily monitor memory were used as continuity state.
+- Safe read-only provider checks were run at 2026-05-11T13:03Z. Secret values,
+  raw account payloads, and raw logs are not included in this report.
+- Supabase production aggregate reads found: `analytics_events` 5019,
+  `meeting_records` 110, `orders` 26, `gamma_reports` 6,
+  `social_content_queue` 29, `drive_video_queue` 35, `email_messages` 9,
+  `documents_local_rag` 3434, `printful_sync_log` 0, `cost_events` 14,
+  `video_generation_jobs` 4, `diagnostic_audits` 29, `outreach_queue` 9,
+  `contact_submissions` 268, and `agent_runs` 33.
+- Supabase latest usage signals: latest Gamma report created 2026-05-02;
+  latest social content row created 2026-05-07; latest agent run created
+  2026-05-11; latest email row remains a 2026-04-30 row using `n8n` transport.
+- n8n Cloud API: 77 workflows, 72 active workflows, and latest successful
+  execution started at 2026-05-11T13:01:18Z.
+- Vercel CLI is authenticated under `vsillahs-projects`; project metadata shows
+  `portfolio` updated at 2026-05-11T09:22:41Z and `portfolio-staging` updated
+  at 2026-05-11T09:22:40Z, both on Node 24.x.
+- Apify API: account still reports `STARTER`; latest sampled run remains a
+  succeeded run on 2026-05-06.
+- ElevenLabs API: subscription remains active on Creator with 18,068 of 164,102
+  characters used.
+- OpenRouter API: current key still reports zero usage.
+- Vapi API: latest returned call remains a 2026-04-30 `webCall` with ended
+  status.
+- Pinecone API: one ready serverless index named `publications` exists in
+  `aws/us-east-1`.
+- Printful API: two native stores remain visible; `printful_sync_log` remains
+  empty.
+- Hunter.io API: account remains Free with quota data visible and reset date
+  2026-06-09.
+- Read AI API and Calendly API both returned 401.
+
+Derived Movement Since Prior Weekly Run
+
+| Tool/vendor | Latest evidence | Inactivity status | Recommendation |
+| --- | --- | --- | --- |
+| Supabase | Production counts refreshed; `agent_runs` increased to 33 and `cost_events` to 14 | Active | Keep |
+| n8n Cloud | 77 workflows, 72 active, successful execution on 2026-05-11 | Active | Keep; continue separate workflow-error hygiene |
+| Vercel | `portfolio` and `portfolio-staging` project records updated on 2026-05-11 | Active | Keep |
+| Stripe | Checkout/order code and 26 order rows remain | Active revenue dependency | Keep |
+| OpenAI | Cost/event and generation code paths remain | Active | Keep; continue cost monitoring |
+| Anthropic | Code/workflow references remain; transition adjustment still expected | Watch | Decide after next receipt/bakeoff refresh |
+| Gamma | Latest completed report remains 2026-05-02; report/admin code active | Active enough | Keep; watch deck alternatives |
+| HeyGen | Video-generation paths and config rows remain | Campaign-dependent active | Keep; review after next video campaign |
+| Read.ai | Direct API auth still returns 401; receipt and meeting rows remain | Auth unresolved | Keep; refresh auth |
+| BuiltWith | Protected outreach-ramp decision remains | Protected watch | Keep during outreach/client-volume ramp |
+| Fireflies.ai | No new paid evidence; previously confirmed canceled | Resolved canceled | Keep out of active queue |
+| Vapi | 2026-04-30 call still visible; no newer call found | Quiet since recent call | Investigate billing/voice UX |
+| Printful | Two API stores visible; `printful_sync_log` remains empty | Quiet sync | Investigate store/order strategy |
+| Resend | No live key/billing evidence confirmed; latest email row still uses `n8n` | Usage unresolved | Verify Vercel env/billing before deciding |
+| Pinecone | Ready `publications` serverless index remains | Active infrastructure exists | Investigate billing/API traffic |
+| Hunter.io | API reports Free plan | Not a paid cancellation target | Keep/watch |
+| OpenRouter | Zero usage again for current key | Consecutive quiet key evidence | Watch; prepare deprecation packet only after bakeoff |
+| Apify | Starter plan plus actor-level analysis remains | Active paid dependency | Keep; pause/replace weak actor surfaces first |
+| ElevenLabs | Active Creator subscription; quota still available | Active paid dependency | Watch renewal against next campaign |
+| Calendly | Direct API auth still returns 401; scheduling links and n8n triggers remain | Auth unresolved | Refresh token; keep |
+
+Candidate Cancellations
+
+- **No automatic cancellation.**
+- **No current vendor meets the cancellation threshold in this weekly run.**
+- No approval phrase was given in this run.
+
+Next Audit Focus
+
+- Refresh Read AI and Calendly auth before using those providers as usage
+  evidence.
+- Confirm OpenRouter's role in the next media/model bakeoff; if unused again and
+  no active spend exists, prepare a deprecation packet rather than canceling
+  automatically.
+- Verify whether Resend exists in Vercel production env or billing, and whether
+  Gmail/n8n is the only real outbound path.
+- Confirm Vapi dashboard billing and whether production voice UX is intended to
+  stay enabled.
+- Check Pinecone billing/API traffic and compare with the Supabase/local RAG
+  replacement path.
+- Check Printful dashboard/order history and decide whether both stores remain
+  strategically active.
+- Review ElevenLabs renewal before 2026-05-19 against the next planned
+  social/audio/video campaign.
+- Continue the Apify actor-level replacement bakeoff by pausing or replacing
+  weak actor surfaces before considering account-level changes.
+
 ## 2026-05-09 Apify Run-History Evidence Update
 
 Status: YELLOW

--- a/docs/subscription-cancellation-audit.md
+++ b/docs/subscription-cancellation-audit.md
@@ -31,12 +31,19 @@ Summary:
   configured Apify actor as equally valuable. Pause or replace the weak
   surfaces first, then run replacement tests against only the productive
   categories before the next renewal decision.
+- Replacement gate added after checking current primary-source pricing/terms:
+  test Brave Search against Reddit/Capterra evidence capture, Google Places API
+  against Google Maps discovery, and browser/manual sampling against LinkedIn
+  post search. Do not benchmark no-run or empty-output actors until a workflow
+  owner proves the campaign still needs that source.
 
 Raw Findings
 
 - Token source: existing local `APIFY_TOKEN`; values were not printed.
 - Evidence source updated: `/docs/apify-call-bakeoff-analysis.md`.
 - Dashboard data updated: `/docs/subscription-status.json`.
+- Pricing/terms checked from Brave Search API, Google Maps Platform pricing,
+  Reddit Data API Wiki, and Reddit Data API Terms on 2026-05-09.
 - No shared cost-event schema changes and no production write actions.
 
 ## 2026-05-09 Budget Query Readiness Update

--- a/docs/subscription-status.json
+++ b/docs/subscription-status.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-08",
+  "generatedAt": "2026-05-11",
   "sourceDocument": "/docs/subscription-cancellation-audit.md",
   "weeklyReportAutomationId": "portfolio-subscription-weekly-report",
   "dailyMonitorAutomationId": "portfolio-subscription-cancellation-monitor",
@@ -21,6 +21,8 @@
     "notes": [
       "Confirmed from Gmail receipts and the subscription audit tracker; unresolved usage-based tools still require dashboard verification.",
       "Recent quick enrollments/cancellations may make next-month realized spend lower than this snapshot.",
+      "2026-05-10 provider refresh kept the budget status yellow: no cancellation approval was requested and no vendor crossed the cancellation threshold.",
+      "2026-05-11 weekly refresh kept the budget status yellow: n8n, Supabase, and Vercel showed fresh operational movement; no vendor crossed the cancellation threshold.",
       "Cancellation remains approval-gated; this budget view is read-only."
     ],
     "transitionAdjustments": [
@@ -33,7 +35,7 @@
     ],
     "apifyCallAnalysis": {
       "configuredActorSurfaces": 12,
-      "lastMonitorExecution": "Direct Apify API pull on 2026-05-09 sampled the latest 10 runs per configured actor; n8n execution 13174 on 2026-05-06 only checked two actors.",
+      "lastMonitorExecution": "Direct Apify API pull on 2026-05-09 sampled the latest 10 runs per configured actor; 2026-05-11 account refresh still reports STARTER with latest sampled run history through 2026-05-06.",
       "sampledRuns": 59,
       "succeededRuns": 40,
       "failedRuns": 19,
@@ -319,21 +321,23 @@
       "Vapi",
       "Pinecone",
       "Resend",
-      "Printful"
+      "Printful",
+      "Read.ai",
+      "Calendly"
     ]
   },
   "summary": {
     "status": "yellow",
-    "headline": "Core Portfolio subscriptions remain active. OpenRouter stays quiet, Apify and ElevenLabs are confirmed active, and Vercel production/staging deploys were later verified Ready.",
+    "headline": "Weekly refresh: core subscriptions remain active, n8n/Supabase/Vercel moved today, and no vendor reached the cancellation threshold.",
     "nextReviewFocus": [
-      "Keep deployment queue metrics visible after staging preview suppression.",
+      "Refresh Read AI and Calendly auth before using those providers as usage evidence.",
       "Confirm OpenRouter's role in the next media/model bakeoff.",
       "Verify whether Resend exists in Vercel production env or billing.",
-      "Refresh Read AI and Calendly auth before drawing usage conclusions.",
       "Confirm Vapi dashboard billing and intended production voice UX.",
       "Check Pinecone billing/API traffic against Supabase/local RAG.",
+      "Check Printful dashboard order history and active store strategy.",
       "Review ElevenLabs renewal before 2026-05-19.",
-      "Continue the Apify actor-level replacement bakeoff before renewal."
+      "Continue the Apify actor-level replacement bakeoff by pausing weak surfaces before account-level changes."
     ]
   },
   "buckets": {
@@ -359,19 +363,21 @@
       "ElevenLabs",
       "OpenRouter",
       "Anthropic",
-      "Vapi"
+      "Vapi",
+      "Apify"
     ],
     "unresolved": [
       "Printful",
       "Resend",
-      "Pinecone"
+      "Pinecone",
+      "Read.ai auth",
+      "Calendly auth"
     ],
     "resolvedCanceled": [
       "Fireflies.ai"
     ],
     "needsDecision": [
       "Vapi",
-      "Vercel",
       "Printful",
       "Resend",
       "Pinecone",
@@ -387,10 +393,10 @@
       "name": "Vapi",
       "status": "watch",
       "statusColor": "yellow",
-      "billingSignal": "Dashboard billing still needs verification; direct API returned one recent call with a small recorded call cost.",
+      "billingSignal": "Dashboard billing still needs verification; direct API returned one 2026-04-30 call with a small recorded call cost and no newer calls in this refresh.",
       "usageSignal": "Vapi Calls API returned a webCall created on 2026-04-30; code/env/webhook references remain.",
       "portfolioDependency": "Voice/audit experience risk if production voice UX is enabled.",
-      "recommendation": "Investigate billing and intended voice UX; no longer a provisional red cancellation gate.",
+      "recommendation": "Investigate billing and intended voice UX; no cancellation action without a dashboard/billing decision.",
       "nextAction": "Check Vapi dashboard billing and decide whether the voice path should stay enabled.",
       "decisionRequired": true,
       "links": [
@@ -442,12 +448,12 @@
       "name": "Vercel",
       "status": "keep",
       "statusColor": "green",
-      "billingSignal": "Billing owner still needs documentation; CLI access is authenticated under vsillahs-projects.",
-      "usageSignal": "Vercel CLI showed both portfolio projects updated on 2026-05-08; a later deployment monitor confirmed both production contexts READY.",
+      "billingSignal": "Prior receipt evidence remains; CLI access is authenticated under vsillahs-projects.",
+      "usageSignal": "Vercel CLI showed portfolio updated at 2026-05-11T09:22:41Z and portfolio-staging updated at 2026-05-11T09:22:40Z; both use Node 24.x.",
       "portfolioDependency": "High-risk hosting/deployment dependency.",
-      "recommendation": "Keep; operationally active.",
-      "nextAction": "Keep deployment queue metrics visible and keep billing owner documentation current.",
-      "decisionRequired": true,
+      "recommendation": "Keep; operationally active hosting/deployment dependency.",
+      "nextAction": "Keep deployment monitoring and billing-owner documentation current.",
+      "decisionRequired": false,
       "links": [
         {
           "label": "Audit tracker",
@@ -476,8 +482,8 @@
       "name": "Resend",
       "status": "unresolved",
       "statusColor": "yellow",
-      "billingSignal": "No billing evidence confirmed in this run.",
-      "usageSignal": "Optional transactional provider remains in env/code, but the latest production email row still uses n8n transport.",
+      "billingSignal": "No live key or billing evidence confirmed in this run.",
+      "usageSignal": "Optional transactional provider remains in env templates/code, but the latest production email row still uses n8n transport.",
       "portfolioDependency": "Transactional email delivery risk if production is configured to use Resend.",
       "recommendation": "Verify production env and billing before keeping as a paid dependency or removing.",
       "nextAction": "Confirm whether production uses Resend or Gmail/n8n as the real outbound channel.",
@@ -494,7 +500,7 @@
       "status": "unresolved",
       "statusColor": "yellow",
       "billingSignal": "Billing/API traffic not confirmed; direct API showed active infrastructure.",
-      "usageSignal": "One ready serverless publications index exists; n8n RAG references and local/Supabase RAG rows also remain.",
+      "usageSignal": "One ready serverless publications index exists in aws/us-east-1; n8n RAG references and local/Supabase RAG rows also remain.",
       "portfolioDependency": "RAG/vector-store workflow risk.",
       "recommendation": "Investigate billing/API traffic and compare with Supabase/local RAG replacement path.",
       "nextAction": "Verify whether current RAG traffic still depends on Pinecone before any deprecation.",
@@ -510,11 +516,11 @@
       "name": "Apify",
       "status": "keep",
       "statusColor": "green",
-      "billingSignal": "Prior Gmail pass found a payment-success invoice on 2026-05-03 for $39; direct API reports STARTER plan.",
-      "usageSignal": "n8n exports include Apify nodes, n8n Cloud executions continue, and direct Apify run history includes a succeeded run on 2026-05-06.",
+      "billingSignal": "Prior invoice evidence remains; direct API still reports STARTER plan on 2026-05-11.",
+      "usageSignal": "n8n exports include Apify nodes, direct run history still shows recent runs through 2026-05-06, and the 2026-05-09 actor analysis found four useful categories plus eight weak surfaces.",
       "portfolioDependency": "Lead sourcing, scraping, and actor-monitor automation.",
-      "recommendation": "Keep; continue cadence and spend review separately from cancellation.",
-      "nextAction": "Review actor cadence and spend before the next renewal window.",
+      "recommendation": "Keep account-level subscription for now; pause or replace weak actor surfaces before any account-level decision.",
+      "nextAction": "Continue actor-level replacement tests for no-run, failing, and empty-output surfaces before renewal.",
       "decisionRequired": false,
       "links": [
         {
@@ -531,11 +537,11 @@
       "name": "Hunter.io",
       "status": "keep",
       "statusColor": "green",
-      "billingSignal": "Direct API returned plan Free with 5 used searches, 5 used credits, 10 used verifications, and reset date 2026-05-09.",
+      "billingSignal": "Direct API returned plan Free with request quota visible and reset date 2026-06-09.",
       "usageSignal": "HUNTER_API_KEY, lead-source references, and n8n Hunter node-swap docs are present.",
       "portfolioDependency": "Lead discovery and email enrichment workflow risk.",
       "recommendation": "Keep/watch; not a paid cancellation target unless the account upgrades or becomes redundant.",
-      "nextAction": "Recheck if Hunter.io moves from Free to paid or lead workflows stop using it.",
+      "nextAction": "Recheck only if Hunter.io moves from Free to paid or lead workflows stop using it.",
       "decisionRequired": false,
       "links": [
         {
@@ -548,11 +554,11 @@
       "name": "OpenRouter",
       "status": "watch",
       "statusColor": "yellow",
-      "billingSignal": "Direct API returned zero current-key usage and no confirmed active spend.",
-      "usageSignal": "OPENROUTER_API_KEY, media bakeoff references, and Gmail draft workflow docs are present.",
+      "billingSignal": "Direct API returned zero current-key usage again on 2026-05-11 and no confirmed active spend.",
+      "usageSignal": "OPENROUTER_API_KEY, media bakeoff references, and n8n OpenRouter nodes remain present.",
       "portfolioDependency": "Specialist model-routing path for image/media and draft-reply workflows.",
       "recommendation": "Watch until bakeoff evidence confirms whether it is active, sandbox-only, or replaceable.",
-      "nextAction": "Decide after the next media/model bakeoff whether OpenRouter should stay configured.",
+      "nextAction": "If unused again, prepare a deprecation packet after the media/model bakeoff rather than canceling automatically.",
       "decisionRequired": true,
       "links": [
         {
@@ -565,11 +571,11 @@
       "name": "ElevenLabs",
       "status": "watch",
       "statusColor": "yellow",
-      "billingSignal": "Receipts found through 2026-04-19 in the prior billing pass.",
-      "usageSignal": "Direct API reports active Creator subscription with 18,068 of 164,102 characters used; social/audio workflow references remain.",
+      "billingSignal": "Direct API reports active Creator subscription; prior receipt evidence remains.",
+      "usageSignal": "Direct API reports 18,068 of 164,102 characters used; social/audio workflow references remain.",
       "portfolioDependency": "Audio generation for social/video content campaigns.",
       "recommendation": "Watch through the next social content cycle before renewal review.",
-      "nextAction": "Confirm next campaign audio usage before renewing or downgrading.",
+      "nextAction": "Confirm next campaign audio usage before the 2026-05-19 renewal window.",
       "decisionRequired": false,
       "links": [
         {
@@ -577,6 +583,57 @@
           "href": "https://github.com/vsillah/Portfolio/blob/main/docs/subscription-cancellation-audit.md"
         }
       ]
+    },
+    {
+      "name": "Read.ai",
+      "links": [
+        {
+          "label": "Audit tracker",
+          "href": "https://github.com/vsillah/Portfolio/blob/main/docs/subscription-cancellation-audit.md"
+        }
+      ],
+      "status": "keep",
+      "statusColor": "yellow",
+      "billingSignal": "Prior receipt evidence remains; 2026-05-11 direct API meeting-list call returned 401.",
+      "usageSignal": "Supabase meeting rows, docs, and Read.ai workflow references remain; live provider usage needs auth refresh.",
+      "portfolioDependency": "Meeting transcript and follow-up intelligence workflow risk.",
+      "recommendation": "Keep while meeting transcript workflow is active; refresh auth before drawing new usage conclusions.",
+      "nextAction": "Refresh Read AI auth and re-run meeting usage check.",
+      "decisionRequired": true
+    },
+    {
+      "name": "Calendly",
+      "links": [
+        {
+          "label": "Audit tracker",
+          "href": "https://github.com/vsillah/Portfolio/blob/main/docs/subscription-cancellation-audit.md"
+        }
+      ],
+      "status": "keep",
+      "statusColor": "yellow",
+      "billingSignal": "Prior receipt evidence remains; 2026-05-11 direct API user lookup returned 401.",
+      "usageSignal": "Scheduling links, n8n Calendly triggers, and report scheduling code remain active in the repo.",
+      "portfolioDependency": "Client scheduling and lifecycle automation risk.",
+      "recommendation": "Keep as low-cost scheduling infrastructure unless a replacement path is approved.",
+      "nextAction": "Refresh Calendly token and re-run event-type usage check.",
+      "decisionRequired": true
+    },
+    {
+      "name": "Anthropic",
+      "links": [
+        {
+          "label": "Audit tracker",
+          "href": "https://github.com/vsillah/Portfolio/blob/main/docs/subscription-cancellation-audit.md"
+        }
+      ],
+      "status": "watch",
+      "statusColor": "yellow",
+      "billingSignal": "Receipt-backed current run-rate includes Anthropic, but the ChatGPT transition should remove it next cycle if cancellation holds.",
+      "usageSignal": "Anthropic code and n8n workflow references remain, including evaluation and social-listening paths.",
+      "portfolioDependency": "LLM fallback/evaluation path risk if removed before bakeoff decisions settle.",
+      "recommendation": "Watch through the next receipt and model bakeoff refresh before deprecation.",
+      "nextAction": "Confirm whether Anthropic remains canceled or still needed as a fallback after the ChatGPT switch.",
+      "decisionRequired": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- adds the 2026-05-11 weekly subscription report to the durable cancellation audit
- updates the read-only admin subscription status JSON to generatedAt 2026-05-11
- preserves BuiltWith as protected watch and Fireflies as resolved canceled

## Validation
- jq empty docs/subscription-status.json
- npm test -- --run lib/subscription-status.test.ts
- git diff --check
- pre-push database health check passed

## Notes
- Root checkout had pre-existing dirty subscription tracker changes on codex/hyperagent-evaluations, so this update was staged from the clean subscription worktree.
- Repo labels codex and codex-automation were not available; only default labels exist.