### PR TITLE
feat: add automation action tracker

### DIFF
--- a/app/admin/agents/automations/page.tsx
+++ b/app/admin/agents/automations/page.tsx
@@ -7,8 +7,10 @@ import {
   ArrowRight,
   Bot,
   CheckCircle2,
+  ClipboardList,
   FileText,
   ListChecks,
+  PlayCircle,
   RefreshCw,
   ShieldAlert,
   SlidersHorizontal,
@@ -137,13 +139,64 @@ type AutomationInventoryResponse = {
   }
 }
 
+type AutomationActionStatus = 'open' | 'in_progress' | 'blocked' | 'done' | 'dismissed'
+type AutomationActionItem = {
+  id: string
+  automationId: string
+  automationName: string
+  statusColor: 'green' | 'yellow' | 'red' | 'unknown'
+  headline: string
+  summary: string
+  kind: 'blocker_or_approval' | 'next_run_focus'
+  text: string
+  priority: 'low' | 'medium' | 'high' | 'urgent'
+  actionStatus: AutomationActionStatus
+  owner: string | null
+  note: string | null
+  linkedWorkItemId: string | null
+  firstSeenAt: string
+  lastSeenAt: string
+  occurrenceCount: number
+  sourceFiles: string[]
+  latestSourceFile: string
+  codexThreadHint: string | null
+}
+
+type AutomationActionTrackerResponse = {
+  available: boolean
+  reason?: string
+  generatedAt: string
+  sourceDirectory: string
+  stateFile: string
+  actions: AutomationActionItem[]
+  recentNotifications: {
+    automationId: string
+    automationName: string
+    ranAtUtc: string
+    status: string
+    headline: string
+    sourceFile: string
+    actionCount: number
+  }[]
+  summary: {
+    total: number
+    open: number
+    inProgress: number
+    blocked: number
+    done: number
+    dismissed: number
+    urgent: number
+    high: number
+  }
+}
+
 const ALL = 'all'
 const CATEGORIES = [ALL, 'Operations', 'Credentials', 'Model Ops', 'Organization', 'Content/Voice', 'Subscriptions', 'Other'] as const
 const STATUSES = [ALL, 'ACTIVE', 'PAUSED'] as const
 const RISKS = [ALL, 'low', 'medium', 'high'] as const
 const CONTEXT_HEALTH = [ALL, 'green', 'yellow', 'red'] as const
 const EMPTY_AUTOMATIONS: AutomationProfile[] = []
-type ViewMode = 'inventory' | 'context-gaps' | 'repair-packets'
+type ViewMode = 'actions' | 'inventory' | 'context-gaps' | 'repair-packets'
 
 export default function AgentAutomationsPage() {
   return (
@@ -157,12 +210,15 @@ function AgentAutomationsContent() {
   const [inventory, setInventory] = useState<AutomationInventoryResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [actionTracker, setActionTracker] = useState<AutomationActionTrackerResponse | null>(null)
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [actionLoadingId, setActionLoadingId] = useState<string | null>(null)
   const [category, setCategory] = useState<(typeof CATEGORIES)[number]>(ALL)
   const [status, setStatus] = useState<(typeof STATUSES)[number]>(ALL)
   const [risk, setRisk] = useState<(typeof RISKS)[number]>(ALL)
   const [contextHealth, setContextHealth] = useState<(typeof CONTEXT_HEALTH)[number]>(ALL)
   const [selectedId, setSelectedId] = useState<string | null>(null)
-  const [viewMode, setViewMode] = useState<ViewMode>('inventory')
+  const [viewMode, setViewMode] = useState<ViewMode>('actions')
 
   const fetchInventory = useCallback(async () => {
     setLoading(true)
@@ -170,12 +226,22 @@ function AgentAutomationsContent() {
     try {
       const session = await getCurrentSession()
       if (!session?.access_token) throw new Error('Missing admin session')
-      const res = await fetch('/api/admin/agents/automations', {
-        headers: { Authorization: `Bearer ${session.access_token}` },
-      })
-      const body = await res.json().catch(() => ({}))
-      if (!res.ok) throw new Error(body.error || `HTTP ${res.status}`)
+      const headers = { Authorization: `Bearer ${session.access_token}` }
+      const [inventoryRes, actionsRes] = await Promise.all([
+        fetch('/api/admin/agents/automations', { headers }),
+        fetch('/api/admin/agents/automation-actions', { headers }),
+      ])
+      const body = await inventoryRes.json().catch(() => ({}))
+      if (!inventoryRes.ok) throw new Error(body.error || `HTTP ${inventoryRes.status}`)
       setInventory(body)
+      const actionsBody = await actionsRes.json().catch(() => ({}))
+      if (actionsRes.ok) {
+        setActionTracker(actionsBody)
+        setActionError(null)
+      } else {
+        setActionTracker(null)
+        setActionError(actionsBody.error || `HTTP ${actionsRes.status}`)
+      }
       const first = body.automations?.[0]?.id
       setSelectedId((current) => current || first || null)
     } catch (err) {
@@ -185,6 +251,54 @@ function AgentAutomationsContent() {
       setLoading(false)
     }
   }, [])
+
+  const updateAction = useCallback(async (action: AutomationActionItem, status: AutomationActionStatus, note?: string | null) => {
+    setActionLoadingId(action.id)
+    setActionError(null)
+    try {
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Missing admin session')
+      const res = await fetch('/api/admin/agents/automation-actions', {
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${session.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ action_id: action.id, status, note }),
+      })
+      const body = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(body.error || `HTTP ${res.status}`)
+      await fetchInventory()
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to update action')
+    } finally {
+      setActionLoadingId(null)
+    }
+  }, [fetchInventory])
+
+  const promoteAction = useCallback(async (action: AutomationActionItem) => {
+    setActionLoadingId(action.id)
+    setActionError(null)
+    try {
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Missing admin session')
+      const res = await fetch('/api/admin/agents/automation-actions', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${session.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ action_id: action.id }),
+      })
+      const body = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(body.error || `HTTP ${res.status}`)
+      await fetchInventory()
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to create Agent Ops work item')
+    } finally {
+      setActionLoadingId(null)
+    }
+  }, [fetchInventory])
 
   useEffect(() => {
     fetchInventory()
@@ -263,11 +377,11 @@ function AgentAutomationsContent() {
             <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-7 gap-3 mb-6">
               <MetricCard label="Portfolio automations" value={inventory.overview.total} />
               <MetricCard label="Active" value={inventory.overview.active} tone="green" />
-              <MetricCard label="Paused" value={inventory.overview.paused} />
+              <MetricCard label="Open actions" value={actionTracker?.summary.open ?? 0} tone={(actionTracker?.summary.open ?? 0) ? 'yellow' : 'slate'} />
+              <MetricCard label="Blocked actions" value={actionTracker?.summary.blocked ?? 0} tone={(actionTracker?.summary.blocked ?? 0) ? 'red' : 'slate'} />
               <MetricCard label="Duplicates" value={inventory.overview.duplicateCandidates} tone={inventory.overview.duplicateCandidates ? 'yellow' : 'slate'} />
               <MetricCard label="High risk" value={inventory.overview.highRisk} tone={inventory.overview.highRisk ? 'red' : 'slate'} />
               <MetricCard label="Missing context" value={inventory.overview.missingContext} tone={inventory.overview.missingContext ? 'yellow' : 'slate'} />
-              <MetricCard label="Repair packets" value={inventory.repairPackets.length} tone={inventory.repairPackets.length ? 'yellow' : 'slate'} />
             </div>
 
             <WarningPanels
@@ -283,6 +397,13 @@ function AgentAutomationsContent() {
             <MemoryOrganizationProgress progress={inventory.progress} />
 
             <div className="mb-6 inline-flex rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-1">
+              <button
+                onClick={() => setViewMode('actions')}
+                className={`inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm ${viewMode === 'actions' ? 'bg-radiant-gold/15 text-radiant-gold' : 'text-muted-foreground hover:text-foreground'}`}
+              >
+                <ClipboardList size={16} />
+                Action Tracker
+              </button>
               <button
                 onClick={() => setViewMode('inventory')}
                 className={`inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm ${viewMode === 'inventory' ? 'bg-radiant-gold/15 text-radiant-gold' : 'text-muted-foreground hover:text-foreground'}`}
@@ -324,7 +445,15 @@ function AgentAutomationsContent() {
               </div>
             </section>
 
-            {viewMode === 'inventory' ? (
+            {viewMode === 'actions' ? (
+              <AutomationActionsView
+                tracker={actionTracker}
+                error={actionError}
+                actionLoadingId={actionLoadingId}
+                onUpdate={updateAction}
+                onPromote={promoteAction}
+              />
+            ) : viewMode === 'inventory' ? (
               <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_420px] gap-6">
                 <AutomationTable automations={filtered} selectedId={selected?.id || null} onSelect={setSelectedId} />
                 {selected ? <ContextReadiness automation={selected} /> : null}
@@ -403,6 +532,208 @@ function AutomationTable({
         </tbody>
       </table>
     </div>
+  )
+}
+
+function AutomationActionsView({
+  tracker,
+  error,
+  actionLoadingId,
+  onUpdate,
+  onPromote,
+}: {
+  tracker: AutomationActionTrackerResponse | null
+  error: string | null
+  actionLoadingId: string | null
+  onUpdate: (action: AutomationActionItem, status: AutomationActionStatus, note?: string | null) => void
+  onPromote: (action: AutomationActionItem) => void
+}) {
+  if (error) {
+    return <FailureState title="Failed to load automation actions" message={error} />
+  }
+
+  if (!tracker) {
+    return (
+      <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-8 text-center text-muted-foreground">
+        Loading automation action tracker...
+      </div>
+    )
+  }
+
+  if (!tracker.available) {
+    return <FailureState title="Automation action tracker unavailable" message={tracker.reason || 'Local notification state could not be read.'} />
+  }
+
+  const activeActions = tracker.actions.filter((action) => action.actionStatus !== 'dismissed')
+
+  return (
+    <section className="space-y-5">
+      <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-5">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <div className="flex items-center gap-2 text-radiant-gold">
+              <ClipboardList size={18} />
+              <h2 className="font-semibold">Automation Action Tracker</h2>
+            </div>
+            <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+              Converts daily automation blockers and next-run focus items into a local working queue. Status, notes, and Agent Ops links are written to {tracker.stateFile}; summarized progress is exported for the next automation pass.
+            </p>
+          </div>
+          <div className="grid grid-cols-3 gap-2 text-right text-xs">
+            <DetailPill label="Tracked" value={String(tracker.summary.total)} />
+            <DetailPill label="In progress" value={String(tracker.summary.inProgress)} />
+            <DetailPill label="Done" value={String(tracker.summary.done)} />
+          </div>
+        </div>
+      </div>
+
+      {activeActions.length === 0 ? (
+        <div className="rounded-lg border border-green-400/30 bg-green-500/10 p-6 text-green-100">
+          <div className="flex items-center gap-2 font-medium">
+            <CheckCircle2 size={18} />
+            No active automation actions are waiting on the tracker.
+          </div>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_360px] gap-5">
+          <div className="space-y-4">
+            {activeActions.map((action) => (
+              <AutomationActionCard
+                key={action.id}
+                action={action}
+                loading={actionLoadingId === action.id}
+                onUpdate={onUpdate}
+                onPromote={onPromote}
+              />
+            ))}
+          </div>
+
+          <aside className="space-y-4">
+            <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
+              <h3 className="mb-3 text-sm font-semibold text-radiant-gold">Recent Automation Reports</h3>
+              <div className="space-y-3">
+                {tracker.recentNotifications.slice(0, 8).map((notification) => (
+                  <div key={notification.sourceFile} className="rounded-md border border-silicon-slate/50 bg-black/10 p-3">
+                    <div className="mb-1 flex items-center justify-between gap-2">
+                      <p className="text-sm font-medium">{notification.automationName}</p>
+                      <StatusColorBadge status={notification.status} />
+                    </div>
+                    <p className="text-xs text-muted-foreground">{notification.headline}</p>
+                    <p className="mt-2 text-xs text-muted-foreground">
+                      {notification.actionCount} action(s) · {formatDateTime(notification.ranAtUtc)}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </aside>
+        </div>
+      )}
+    </section>
+  )
+}
+
+function AutomationActionCard({
+  action,
+  loading,
+  onUpdate,
+  onPromote,
+}: {
+  action: AutomationActionItem
+  loading: boolean
+  onUpdate: (action: AutomationActionItem, status: AutomationActionStatus, note?: string | null) => void
+  onPromote: (action: AutomationActionItem) => void
+}) {
+  const [note, setNote] = useState(action.note ?? '')
+
+  useEffect(() => {
+    setNote(action.note ?? '')
+  }, [action.note, action.id])
+
+  return (
+    <article className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-5">
+      <div className="mb-4 flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <div className="mb-2 flex flex-wrap items-center gap-2">
+            <ActionStatusBadge status={action.actionStatus} />
+            <ActionPriorityBadge priority={action.priority} />
+            <StatusColorBadge status={action.statusColor} />
+            <span className="rounded-full border border-silicon-slate/60 bg-black/10 px-2 py-1 text-xs text-muted-foreground">
+              {action.kind === 'blocker_or_approval' ? 'Blocker or approval' : 'Next run focus'}
+            </span>
+          </div>
+          <h3 className="text-base font-semibold">{action.text}</h3>
+          <p className="mt-2 text-sm text-muted-foreground">{action.summary || action.headline}</p>
+        </div>
+        {action.linkedWorkItemId ? (
+          <Link
+            href="/admin/agents/coordination"
+            className="inline-flex items-center gap-2 rounded-lg border border-green-400/40 bg-green-500/10 px-3 py-2 text-sm text-green-100 hover:underline"
+          >
+            Open work item
+            <ArrowRight size={15} />
+          </Link>
+        ) : (
+          <button
+            onClick={() => onPromote(action)}
+            disabled={loading}
+            className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/50 bg-radiant-gold/10 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15 disabled:opacity-60"
+          >
+            <PlayCircle size={15} />
+            Create work item
+          </button>
+        )}
+      </div>
+
+      <div className="mb-4 grid grid-cols-2 md:grid-cols-4 gap-2 text-xs">
+        <DetailPill label="Automation" value={action.automationName} />
+        <DetailPill label="Seen" value={`${action.occurrenceCount}x`} />
+        <DetailPill label="First seen" value={formatDateShort(action.firstSeenAt)} />
+        <DetailPill label="Last seen" value={formatDateShort(action.lastSeenAt)} />
+      </div>
+
+      <label className="mb-3 block text-sm">
+        <span className="mb-1 block text-xs font-semibold uppercase tracking-wider text-muted-foreground">Progress note for next automation run</span>
+        <textarea
+          value={note}
+          onChange={(event) => setNote(event.target.value)}
+          rows={2}
+          className="w-full rounded-lg border border-silicon-slate/70 bg-background px-3 py-2 text-sm"
+          placeholder="Add what changed, what is blocked, or what the next run should check."
+        />
+      </label>
+
+      <div className="flex flex-wrap gap-2">
+        <button
+          onClick={() => onUpdate(action, 'in_progress', note)}
+          disabled={loading}
+          className="rounded-lg border border-silicon-slate/70 bg-background px-3 py-2 text-sm hover:border-radiant-gold/60 disabled:opacity-60"
+        >
+          Mark in progress
+        </button>
+        <button
+          onClick={() => onUpdate(action, 'blocked', note)}
+          disabled={loading}
+          className="rounded-lg border border-red-400/40 bg-red-500/10 px-3 py-2 text-sm text-red-100 hover:bg-red-500/15 disabled:opacity-60"
+        >
+          Mark blocked
+        </button>
+        <button
+          onClick={() => onUpdate(action, 'done', note)}
+          disabled={loading}
+          className="rounded-lg border border-green-400/40 bg-green-500/10 px-3 py-2 text-sm text-green-100 hover:bg-green-500/15 disabled:opacity-60"
+        >
+          Mark done
+        </button>
+        <button
+          onClick={() => onUpdate(action, 'dismissed', note)}
+          disabled={loading}
+          className="rounded-lg border border-silicon-slate/70 bg-black/10 px-3 py-2 text-sm text-muted-foreground hover:text-foreground disabled:opacity-60"
+        >
+          Dismiss
+        </button>
+      </div>
+    </article>
   )
 }
 
@@ -888,6 +1219,44 @@ function TaskStatusBadge({ status }: { status: MemoryOrganizationTaskStatus }) {
   return <span className={`rounded-full border px-2 py-1 text-[11px] ${className}`}>{status.replace('_', ' ')}</span>
 }
 
+function ActionStatusBadge({ status }: { status: AutomationActionStatus }) {
+  const className =
+    status === 'done'
+      ? 'border-green-400/40 bg-green-500/10 text-green-200'
+      : status === 'blocked'
+        ? 'border-red-400/40 bg-red-500/10 text-red-200'
+        : status === 'in_progress'
+          ? 'border-yellow-400/40 bg-yellow-500/10 text-yellow-200'
+          : status === 'dismissed'
+            ? 'border-silicon-slate/60 bg-black/20 text-muted-foreground'
+            : 'border-radiant-gold/40 bg-radiant-gold/10 text-radiant-gold'
+  return <span className={`rounded-full border px-2 py-1 text-xs ${className}`}>{status.replace('_', ' ')}</span>
+}
+
+function ActionPriorityBadge({ priority }: { priority: AutomationActionItem['priority'] }) {
+  const className =
+    priority === 'urgent'
+      ? 'border-red-400/50 bg-red-500/15 text-red-100'
+      : priority === 'high'
+        ? 'border-yellow-400/40 bg-yellow-500/10 text-yellow-100'
+        : priority === 'medium'
+          ? 'border-blue-400/40 bg-blue-500/10 text-blue-100'
+          : 'border-silicon-slate/60 bg-black/20 text-muted-foreground'
+  return <span className={`rounded-full border px-2 py-1 text-xs ${className}`}>{priority}</span>
+}
+
+function StatusColorBadge({ status }: { status: string }) {
+  const className =
+    status === 'green'
+      ? 'border-green-400/40 bg-green-500/10 text-green-200'
+      : status === 'yellow'
+        ? 'border-yellow-400/40 bg-yellow-500/10 text-yellow-200'
+        : status === 'red'
+          ? 'border-red-400/40 bg-red-500/10 text-red-200'
+          : 'border-silicon-slate/60 bg-black/20 text-muted-foreground'
+  return <span className={`rounded-full border px-2 py-1 text-xs ${className}`}>{status}</span>
+}
+
 function DetailPill({ label, value }: { label: string; value: string }) {
   return (
     <div className="rounded-md border border-silicon-slate/50 bg-black/10 p-2">
@@ -969,5 +1338,15 @@ function formatDateTime(value: string | number | null) {
     day: 'numeric',
     hour: 'numeric',
     minute: '2-digit',
+  }).format(date)
+}
+
+function formatDateShort(value: string | null) {
+  if (!value) return '-'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return '-'
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
   }).format(date)
 }

--- a/app/api/admin/agents/automation-actions/route.ts
+++ b/app/api/admin/agents/automation-actions/route.ts
@@ -1,0 +1,118 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import {
+  listAutomationActionTracker,
+  updateAutomationActionState,
+  type AutomationActionStatus,
+} from '@/lib/codex-automation-action-tracker'
+import { createAgentWorkItem } from '@/lib/agent-work-items'
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+const ACTION_STATUSES: AutomationActionStatus[] = ['open', 'in_progress', 'blocked', 'done', 'dismissed']
+
+function isActionStatus(value: unknown): value is AutomationActionStatus {
+  return typeof value === 'string' && ACTION_STATUSES.includes(value as AutomationActionStatus)
+}
+
+export async function GET(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const tracker = await listAutomationActionTracker()
+  return NextResponse.json(tracker)
+}
+
+export async function PATCH(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as Record<string, unknown>
+  const actionId = typeof body.action_id === 'string' ? body.action_id.trim() : ''
+  if (!actionId) {
+    return NextResponse.json({ error: 'action_id is required' }, { status: 400 })
+  }
+
+  const status = body.status === undefined ? undefined : body.status
+  if (status !== undefined && !isActionStatus(status)) {
+    return NextResponse.json({ error: 'Invalid status' }, { status: 400 })
+  }
+
+  const update = await updateAutomationActionState(actionId, {
+    status,
+    owner: typeof body.owner === 'string' ? body.owner : body.owner === null ? null : undefined,
+    note: typeof body.note === 'string' ? body.note : body.note === null ? null : undefined,
+  })
+
+  return NextResponse.json({ ok: true, action_state: update })
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as Record<string, unknown>
+  const actionId = typeof body.action_id === 'string' ? body.action_id.trim() : ''
+  if (!actionId) {
+    return NextResponse.json({ error: 'action_id is required' }, { status: 400 })
+  }
+
+  const tracker = await listAutomationActionTracker()
+  const action = tracker.actions.find((item) => item.id === actionId)
+  if (!action) {
+    return NextResponse.json({ error: 'Automation action not found' }, { status: 404 })
+  }
+
+  try {
+    const workItem = await createAgentWorkItem({
+      title: `${action.automationName}: ${action.text}`,
+      objective: [
+        action.text,
+        action.summary ? `Context: ${action.summary}` : null,
+        action.codexThreadHint ? `Thread hint: ${action.codexThreadHint}` : null,
+      ].filter(Boolean).join('\n'),
+      priority: action.priority === 'urgent' ? 'urgent' : action.priority === 'high' ? 'high' : 'medium',
+      status: 'queued',
+      ownerAgentKey: 'chief-of-staff',
+      ownerRuntime: 'codex',
+      source: {
+        type: 'codex_automation_action',
+        id: action.id,
+        label: action.automationName,
+      },
+      expectedFiles: action.sourceFiles,
+      metadata: {
+        automation_id: action.automationId,
+        automation_name: action.automationName,
+        action_kind: action.kind,
+        source_files: action.sourceFiles,
+        latest_source_file: action.latestSourceFile,
+        first_seen_at: action.firstSeenAt,
+        last_seen_at: action.lastSeenAt,
+        occurrence_count: action.occurrenceCount,
+      },
+      idempotencyKey: action.id,
+    })
+
+    await updateAutomationActionState(action.id, {
+      status: 'in_progress',
+      linkedWorkItemId: workItem.id,
+      note: action.note ?? 'Promoted into Agent Ops work item.',
+    })
+
+    return NextResponse.json({ ok: true, work_item: workItem })
+  } catch (error) {
+    console.error('[automation-actions] create work item failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to create work item' },
+      { status: 500 },
+    )
+  }
+}

--- a/lib/codex-automation-action-tracker.test.ts
+++ b/lib/codex-automation-action-tracker.test.ts
@@ -1,0 +1,101 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import path from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  listAutomationActionTracker,
+  updateAutomationActionState,
+} from './codex-automation-action-tracker'
+
+let tempRoot: string | null = null
+
+async function root() {
+  if (!tempRoot) tempRoot = await mkdtemp(path.join(tmpdir(), 'automation-actions-'))
+  return tempRoot
+}
+
+async function writeNotification(relativePath: string, payload: unknown) {
+  const file = path.join(await root(), relativePath)
+  await mkdir(path.dirname(file), { recursive: true })
+  await writeFile(file, `${JSON.stringify(payload, null, 2)}\n`, 'utf8')
+  return file
+}
+
+afterEach(async () => {
+  if (tempRoot) {
+    await rm(tempRoot, { recursive: true, force: true })
+    tempRoot = null
+  }
+})
+
+describe('listAutomationActionTracker', () => {
+  it('turns notification next steps into stable action records', async () => {
+    await writeNotification('sent/2026-05-11/2026-05-11T13-05-56Z--portfolio-operations-manager.json', {
+      automation_id: 'portfolio-operations-manager',
+      automation_name: 'Portfolio Operations Manager',
+      ran_at_utc: '2026-05-11T13:05:56Z',
+      status: 'red',
+      headline: 'Portfolio health green; chat-eval approval gate still red',
+      summary: 'Prompt mutation gate remains unresolved.',
+      blockers_or_approvals: ['Approval/design needed for chat-eval prompt mutation gate architecture.'],
+      next_run_focus: ['Verify chat-eval approval-gate fix lands.'],
+      codex_thread_hint: 'Portfolio Operations Manager daily pass',
+    })
+    await writeNotification('sent/2026-05-12/2026-05-12T13-05-56Z--portfolio-operations-manager.json', {
+      automation_id: 'portfolio-operations-manager',
+      automation_name: 'Portfolio Operations Manager',
+      ran_at_utc: '2026-05-12T13:05:56Z',
+      status: 'yellow',
+      headline: 'Chat-eval approval gate still needs follow-through',
+      summary: 'Same approval packet is still unresolved.',
+      blockers_or_approvals: ['Approval/design needed for chat-eval prompt mutation gate architecture.'],
+      next_run_focus: ['Increase chat evaluation coverage.'],
+    })
+
+    const tracker = await listAutomationActionTracker(await root())
+
+    expect(tracker.available).toBe(true)
+    expect(tracker.actions).toHaveLength(3)
+    const repeated = tracker.actions.find((action) => action.text.includes('Approval/design needed'))
+    expect(repeated).toEqual(expect.objectContaining({
+      automationId: 'portfolio-operations-manager',
+      actionStatus: 'open',
+      occurrenceCount: 2,
+      priority: 'urgent',
+      firstSeenAt: '2026-05-11T13:05:56Z',
+      lastSeenAt: '2026-05-12T13:05:56Z',
+    }))
+    expect(tracker.summary.open).toBe(3)
+    expect(tracker.automationFeedback[0]).toEqual(expect.objectContaining({
+      automationId: 'portfolio-operations-manager',
+      openActions: 3,
+    }))
+  })
+
+  it('persists action status and writes feedback for the next automation pass', async () => {
+    await writeNotification('pending/2026-05-11T13-32-16Z--daily-screen-recording-workflow-review.json', {
+      automation_id: 'daily-screen-recording-workflow-review',
+      automation_name: 'Daily Screen Recording Workflow Review',
+      ran_at_utc: '2026-05-11T13:32:16Z',
+      status: 'green',
+      headline: 'Workflow review found five automation candidates',
+      next_run_focus: ['Check whether worktree/env drift repeats.'],
+    })
+    const initial = await listAutomationActionTracker(await root())
+    const action = initial.actions[0]
+
+    await updateAutomationActionState(action.id, {
+      status: 'in_progress',
+      note: 'Worktree preflight task is being drafted.',
+    }, await root())
+    const updated = await listAutomationActionTracker(await root())
+    const feedback = JSON.parse(await readFile(path.join(await root(), 'automation-action-feedback.json'), 'utf8'))
+
+    expect(updated.actions[0]).toEqual(expect.objectContaining({
+      actionStatus: 'in_progress',
+      note: 'Worktree preflight task is being drafted.',
+    }))
+    expect(updated.summary.inProgress).toBe(1)
+    expect(feedback.feedback[0].progressNotes[0]).toContain('Worktree preflight task is being drafted.')
+  })
+})

--- a/lib/codex-automation-action-tracker.ts
+++ b/lib/codex-automation-action-tracker.ts
@@ -1,0 +1,460 @@
+import { createHash } from 'crypto'
+import { existsSync } from 'fs'
+import { mkdir, readdir, readFile, rename, writeFile } from 'fs/promises'
+import { homedir } from 'os'
+import path from 'path'
+
+export type AutomationActionStatus = 'open' | 'in_progress' | 'blocked' | 'done' | 'dismissed'
+export type AutomationActionKind = 'blocker_or_approval' | 'next_run_focus'
+export type AutomationActionPriority = 'low' | 'medium' | 'high' | 'urgent'
+
+export interface AutomationActionUpdate {
+  status?: AutomationActionStatus
+  owner?: string | null
+  note?: string | null
+  linkedWorkItemId?: string | null
+}
+
+export interface AutomationActionItem {
+  id: string
+  automationId: string
+  automationName: string
+  statusColor: 'green' | 'yellow' | 'red' | 'unknown'
+  headline: string
+  summary: string
+  kind: AutomationActionKind
+  text: string
+  priority: AutomationActionPriority
+  actionStatus: AutomationActionStatus
+  owner: string | null
+  note: string | null
+  linkedWorkItemId: string | null
+  firstSeenAt: string
+  lastSeenAt: string
+  occurrenceCount: number
+  sourceFiles: string[]
+  latestSourceFile: string
+  codexThreadHint: string | null
+}
+
+export interface AutomationActionTracker {
+  available: boolean
+  reason?: string
+  generatedAt: string
+  sourceDirectory: string
+  stateFile: string
+  actions: AutomationActionItem[]
+  recentNotifications: AutomationNotificationSummary[]
+  summary: {
+    total: number
+    open: number
+    inProgress: number
+    blocked: number
+    done: number
+    dismissed: number
+    urgent: number
+    high: number
+  }
+  automationFeedback: AutomationActionFeedback[]
+}
+
+export interface AutomationNotificationSummary {
+  automationId: string
+  automationName: string
+  ranAtUtc: string
+  status: string
+  headline: string
+  sourceFile: string
+  actionCount: number
+}
+
+export interface AutomationActionFeedback {
+  automationId: string
+  automationName: string
+  openActions: number
+  inProgressActions: number
+  blockedActions: number
+  doneActions: number
+  lastProgressAt: string | null
+  progressNotes: string[]
+}
+
+type NotificationPayload = {
+  automation_id?: string
+  automation_name?: string
+  ran_at_utc?: string
+  status?: string
+  headline?: string
+  summary?: string
+  blockers_or_approvals?: unknown
+  next_run_focus?: unknown
+  codex_thread_hint?: string
+}
+
+type ActionState = {
+  status?: AutomationActionStatus
+  owner?: string | null
+  note?: string | null
+  linkedWorkItemId?: string | null
+  updatedAt?: string
+}
+
+type TrackerState = {
+  version: 1
+  updatedAt: string
+  actions: Record<string, ActionState>
+}
+
+type RawAction = {
+  id: string
+  automationId: string
+  automationName: string
+  statusColor: AutomationActionItem['statusColor']
+  headline: string
+  summary: string
+  kind: AutomationActionKind
+  text: string
+  priority: AutomationActionPriority
+  seenAt: string
+  sourceFile: string
+  codexThreadHint: string | null
+}
+
+const DEFAULT_NOTIFICATIONS_DIR = path.join(homedir(), '.codex', 'automation-notifications')
+const STATE_FILENAME = 'action-tracker.json'
+const FEEDBACK_FILENAME = 'automation-action-feedback.json'
+const MAX_SENT_DAYS = 14
+const MAX_NOTIFICATION_FILES = 200
+
+export function getDefaultAutomationNotificationsDir() {
+  return process.env.CODEX_AUTOMATION_NOTIFICATIONS_DIR || DEFAULT_NOTIFICATIONS_DIR
+}
+
+export async function listAutomationActionTracker(
+  notificationsRoot = getDefaultAutomationNotificationsDir(),
+): Promise<AutomationActionTracker> {
+  const generatedAt = new Date().toISOString()
+  const stateFile = path.join(notificationsRoot, STATE_FILENAME)
+
+  if (!existsSync(notificationsRoot)) {
+    return unavailableTracker(notificationsRoot, stateFile, generatedAt, 'Local automation notification directory is not available')
+  }
+
+  try {
+    const [state, notifications] = await Promise.all([
+      readTrackerState(stateFile),
+      readNotificationPayloads(notificationsRoot),
+    ])
+    const actions = buildActions(notifications.flatMap((notification) => notification.actions), state)
+    const tracker: AutomationActionTracker = {
+      available: true,
+      generatedAt,
+      sourceDirectory: notificationsRoot,
+      stateFile,
+      actions,
+      recentNotifications: notifications.map((notification) => notification.summary),
+      summary: summarizeActions(actions),
+      automationFeedback: buildAutomationFeedback(actions),
+    }
+    await writeFeedbackFile(notificationsRoot, tracker.automationFeedback)
+    return tracker
+  } catch (error) {
+    return unavailableTracker(
+      notificationsRoot,
+      stateFile,
+      generatedAt,
+      error instanceof Error ? error.message : 'Failed to read automation action tracker',
+    )
+  }
+}
+
+export async function updateAutomationActionState(
+  actionId: string,
+  update: AutomationActionUpdate,
+  notificationsRoot = getDefaultAutomationNotificationsDir(),
+) {
+  const stateFile = path.join(notificationsRoot, STATE_FILENAME)
+  const state = await readTrackerState(stateFile)
+  const current = state.actions[actionId] ?? {}
+  state.actions[actionId] = {
+    ...current,
+    ...normalizeUpdate(update),
+    updatedAt: new Date().toISOString(),
+  }
+  state.updatedAt = state.actions[actionId].updatedAt!
+  await writeTrackerState(stateFile, state)
+  return state.actions[actionId]
+}
+
+function unavailableTracker(sourceDirectory: string, stateFile: string, generatedAt: string, reason: string): AutomationActionTracker {
+  return {
+    available: false,
+    reason,
+    generatedAt,
+    sourceDirectory,
+    stateFile,
+    actions: [],
+    recentNotifications: [],
+    summary: {
+      total: 0,
+      open: 0,
+      inProgress: 0,
+      blocked: 0,
+      done: 0,
+      dismissed: 0,
+      urgent: 0,
+      high: 0,
+    },
+    automationFeedback: [],
+  }
+}
+
+async function readNotificationPayloads(notificationsRoot: string) {
+  const files = await findNotificationFiles(notificationsRoot)
+  const notifications: Array<{ summary: AutomationNotificationSummary; actions: RawAction[] }> = []
+
+  for (const file of files) {
+    const payload = await readJsonFile<NotificationPayload>(file)
+    if (!payload) continue
+    const automationId = clean(payload.automation_id) || slugFromFile(file)
+    const automationName = clean(payload.automation_name) || automationId
+    const ranAtUtc = clean(payload.ran_at_utc) || timestampFromFile(file) || new Date(0).toISOString()
+    const statusColor = normalizeStatusColor(payload.status)
+    const base = {
+      automationId,
+      automationName,
+      statusColor,
+      headline: clean(payload.headline) || 'Automation report',
+      summary: clean(payload.summary) || '',
+      seenAt: ranAtUtc,
+      sourceFile: file,
+      codexThreadHint: clean(payload.codex_thread_hint),
+    }
+    const actions: RawAction[] = [
+      ...stringArray(payload.blockers_or_approvals).map((text) => buildRawAction(base, 'blocker_or_approval', text)),
+      ...stringArray(payload.next_run_focus).map((text) => buildRawAction(base, 'next_run_focus', text)),
+    ]
+    notifications.push({
+      summary: {
+        automationId,
+        automationName,
+        ranAtUtc,
+        status: statusColor,
+        headline: base.headline,
+        sourceFile: file,
+        actionCount: actions.length,
+      },
+      actions,
+    })
+  }
+
+  return notifications.sort((a, b) => b.summary.ranAtUtc.localeCompare(a.summary.ranAtUtc))
+}
+
+async function findNotificationFiles(notificationsRoot: string) {
+  const files: string[] = []
+  const pendingDir = path.join(notificationsRoot, 'pending')
+  if (existsSync(pendingDir)) {
+    files.push(...await jsonFilesInDirectory(pendingDir))
+  }
+
+  const sentDir = path.join(notificationsRoot, 'sent')
+  if (existsSync(sentDir)) {
+    const days = (await readdir(sentDir, { withFileTypes: true }))
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort()
+      .slice(-MAX_SENT_DAYS)
+    for (const day of days) {
+      files.push(...await jsonFilesInDirectory(path.join(sentDir, day)))
+    }
+  }
+
+  return files
+    .sort((a, b) => b.localeCompare(a))
+    .slice(0, MAX_NOTIFICATION_FILES)
+}
+
+async function jsonFilesInDirectory(directory: string) {
+  const entries = await readdir(directory, { withFileTypes: true })
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.json'))
+    .map((entry) => path.join(directory, entry.name))
+}
+
+function buildRawAction(
+  base: Omit<RawAction, 'id' | 'kind' | 'text' | 'priority'>,
+  kind: AutomationActionKind,
+  text: string,
+): RawAction {
+  const normalized = normalizeText(text)
+  const id = `${base.automationId}:${kind}:${hash(normalized)}`
+  return {
+    ...base,
+    id,
+    kind,
+    text,
+    priority: classifyPriority(kind, base.statusColor, text),
+  }
+}
+
+function buildActions(rawActions: RawAction[], state: TrackerState): AutomationActionItem[] {
+  const grouped = new Map<string, RawAction[]>()
+  for (const action of rawActions) {
+    grouped.set(action.id, [...(grouped.get(action.id) ?? []), action])
+  }
+
+  return Array.from(grouped.entries())
+    .map(([id, occurrences]) => {
+      const sorted = occurrences.sort((a, b) => a.seenAt.localeCompare(b.seenAt))
+      const first = sorted[0]
+      const latest = sorted[sorted.length - 1]
+      const actionState = state.actions[id] ?? {}
+      return {
+        id,
+        automationId: latest.automationId,
+        automationName: latest.automationName,
+        statusColor: latest.statusColor,
+        headline: latest.headline,
+        summary: latest.summary,
+        kind: latest.kind,
+        text: latest.text,
+        priority: latest.priority,
+        actionStatus: actionState.status ?? 'open',
+        owner: actionState.owner ?? null,
+        note: actionState.note ?? null,
+        linkedWorkItemId: actionState.linkedWorkItemId ?? null,
+        firstSeenAt: first.seenAt,
+        lastSeenAt: latest.seenAt,
+        occurrenceCount: sorted.length,
+        sourceFiles: Array.from(new Set(sorted.map((action) => action.sourceFile))),
+        latestSourceFile: latest.sourceFile,
+        codexThreadHint: latest.codexThreadHint,
+      }
+    })
+    .sort((a, b) => {
+      const statusRank: Record<AutomationActionStatus, number> = { blocked: 0, open: 1, in_progress: 2, done: 3, dismissed: 4 }
+      const priorityRank: Record<AutomationActionPriority, number> = { urgent: 0, high: 1, medium: 2, low: 3 }
+      return statusRank[a.actionStatus] - statusRank[b.actionStatus]
+        || priorityRank[a.priority] - priorityRank[b.priority]
+        || b.lastSeenAt.localeCompare(a.lastSeenAt)
+    })
+}
+
+function buildAutomationFeedback(actions: AutomationActionItem[]): AutomationActionFeedback[] {
+  const byAutomation = new Map<string, AutomationActionItem[]>()
+  for (const action of actions) {
+    byAutomation.set(action.automationId, [...(byAutomation.get(action.automationId) ?? []), action])
+  }
+
+  return Array.from(byAutomation.entries())
+    .map(([automationId, automationActions]) => {
+      const latestAction = automationActions
+        .filter((action) => action.note)
+        .sort((a, b) => b.lastSeenAt.localeCompare(a.lastSeenAt))[0]
+      return {
+        automationId,
+        automationName: automationActions[0]?.automationName ?? automationId,
+        openActions: automationActions.filter((action) => action.actionStatus === 'open').length,
+        inProgressActions: automationActions.filter((action) => action.actionStatus === 'in_progress').length,
+        blockedActions: automationActions.filter((action) => action.actionStatus === 'blocked').length,
+        doneActions: automationActions.filter((action) => action.actionStatus === 'done').length,
+        lastProgressAt: latestAction?.lastSeenAt ?? null,
+        progressNotes: automationActions
+          .filter((action) => action.note)
+          .slice(0, 5)
+          .map((action) => `${action.text}: ${action.note}`),
+      }
+    })
+    .sort((a, b) => (b.blockedActions + b.openActions) - (a.blockedActions + a.openActions))
+}
+
+function summarizeActions(actions: AutomationActionItem[]): AutomationActionTracker['summary'] {
+  return {
+    total: actions.length,
+    open: actions.filter((action) => action.actionStatus === 'open').length,
+    inProgress: actions.filter((action) => action.actionStatus === 'in_progress').length,
+    blocked: actions.filter((action) => action.actionStatus === 'blocked').length,
+    done: actions.filter((action) => action.actionStatus === 'done').length,
+    dismissed: actions.filter((action) => action.actionStatus === 'dismissed').length,
+    urgent: actions.filter((action) => action.priority === 'urgent').length,
+    high: actions.filter((action) => action.priority === 'high').length,
+  }
+}
+
+async function readTrackerState(stateFile: string): Promise<TrackerState> {
+  const state = await readJsonFile<TrackerState>(stateFile)
+  if (!state || state.version !== 1 || typeof state.actions !== 'object' || !state.actions) {
+    return { version: 1, updatedAt: new Date(0).toISOString(), actions: {} }
+  }
+  return state
+}
+
+async function writeTrackerState(stateFile: string, state: TrackerState) {
+  await mkdir(path.dirname(stateFile), { recursive: true })
+  const tmpFile = `${stateFile}.${process.pid}.tmp`
+  await writeFile(tmpFile, `${JSON.stringify(state, null, 2)}\n`, 'utf8')
+  await rename(tmpFile, stateFile)
+}
+
+async function writeFeedbackFile(notificationsRoot: string, feedback: AutomationActionFeedback[]) {
+  const file = path.join(notificationsRoot, FEEDBACK_FILENAME)
+  await mkdir(path.dirname(file), { recursive: true })
+  await writeFile(file, `${JSON.stringify({ generatedAt: new Date().toISOString(), feedback }, null, 2)}\n`, 'utf8')
+}
+
+async function readJsonFile<T>(file: string): Promise<T | null> {
+  if (!existsSync(file)) return null
+  try {
+    return JSON.parse(await readFile(file, 'utf8')) as T
+  } catch {
+    return null
+  }
+}
+
+function normalizeUpdate(update: AutomationActionUpdate): ActionState {
+  const normalized: ActionState = {}
+  if (update.status) normalized.status = update.status
+  if (update.owner !== undefined) normalized.owner = clean(update.owner)
+  if (update.note !== undefined) normalized.note = clean(update.note)
+  if (update.linkedWorkItemId !== undefined) normalized.linkedWorkItemId = clean(update.linkedWorkItemId)
+  return normalized
+}
+
+function stringArray(value: unknown) {
+  return Array.isArray(value) ? value.map((item) => clean(item)).filter((item): item is string => Boolean(item)) : []
+}
+
+function clean(value: unknown) {
+  return typeof value === 'string' ? value.trim() || null : null
+}
+
+function normalizeStatusColor(status: unknown): AutomationActionItem['statusColor'] {
+  const value = typeof status === 'string' ? status.toLowerCase() : ''
+  if (value === 'green' || value === 'yellow' || value === 'red') return value
+  return 'unknown'
+}
+
+function classifyPriority(kind: AutomationActionKind, statusColor: AutomationActionItem['statusColor'], text: string): AutomationActionPriority {
+  const normalized = text.toLowerCase()
+  if (statusColor === 'red' || normalized.includes('approval') || normalized.includes('blocked') || normalized.includes('fails')) return 'urgent'
+  if (kind === 'blocker_or_approval' || statusColor === 'yellow') return 'high'
+  if (normalized.includes('verify') || normalized.includes('confirm') || normalized.includes('refresh')) return 'medium'
+  return 'low'
+}
+
+function normalizeText(text: string) {
+  return text.toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim()
+}
+
+function hash(value: string) {
+  return createHash('sha1').update(value).digest('hex').slice(0, 12)
+}
+
+function timestampFromFile(file: string) {
+  return path.basename(file).match(/^(\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z)/)?.[1]?.replace(/T(\d{2})-(\d{2})-(\d{2})Z/, 'T$1:$2:$3Z') ?? null
+}
+
+function slugFromFile(file: string) {
+  return path.basename(file).replace(/^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z--/, '').replace(/\.json$/, '')
+}


### PR DESCRIPTION
## Summary
- Adds a local Codex automation action tracker API that turns pending/sent automation notification JSON into persistent next-step records.
- Adds an Action Tracker tab to the existing Portfolio Admin automation context page for marking actions in progress, blocked, done, or dismissed and promoting them into Agent Ops work items.
- Writes a machine-readable automation feedback file so future scheduled runs can see prior progress and unresolved blockers.

## Validation
- npm test -- lib/codex-automation-action-tracker.test.ts app/api/admin/agents/automations/route.test.ts
- npx tsc --noEmit --pretty false
- npx tsx real tracker smoke against /Users/vambahsillah/.codex/automation-notifications: available=true, total=83, open=83, recent=18, feedback=8

## Integration Notes
- Local action state is stored outside the repo at /Users/vambahsillah/.codex/automation-notifications/action-tracker.json when a status/note is changed.
- The read path writes /Users/vambahsillah/.codex/automation-notifications/automation-action-feedback.json for producer automations to consume.
- I updated the local Portfolio-related Codex automation prompts on this machine to read that feedback file before finalizing future runs.
- Vercel contexts not checked in this non-captain branch; integration captain should verify Vercel – portfolio and Vercel – portfolio-staging before merge.