### PR TITLE
feat: add AI risk signal monitor

### DIFF
--- a/app/api/admin/agents/risk-compliance/monitor/route.test.ts
+++ b/app/api/admin/agents/risk-compliance/monitor/route.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+import { GET, POST } from './route'
+
+function request(body: Record<string, unknown> = {}) {
+  return new Request('http://localhost/api/admin/agents/risk-compliance/monitor', {
+    method: 'POST',
+    headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('/api/admin/agents/risk-compliance/monitor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await GET(new Request('http://localhost/api/admin/agents/risk-compliance/monitor') as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+  })
+
+  it('returns the read-only monitor summary', async () => {
+    const response = await GET(new Request('http://localhost/api/admin/agents/risk-compliance/monitor') as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      monitor: {
+        ownerAgentKey: 'risk-compliance-intelligence',
+        ownerAgentName: 'Moremi (Ife) - Risk & Compliance',
+      },
+    })
+  })
+
+  it('assesses supplied signals without creating work items', async () => {
+    const response = await POST(request({
+      signals: [
+        {
+          title: 'AI agent prompt injection vulnerability affects browser automation',
+          summary: 'Security researchers report indirect prompt injection that can trigger unsafe tool calls.',
+          sourceName: 'Security advisory',
+        },
+      ],
+    }) as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      assessments: [
+        {
+          classification: expect.stringMatching(/exposure_check|upgrade_request|approval_required/),
+          ownerAgentKey: 'risk-compliance-intelligence',
+        },
+      ],
+      side_effects: {
+        work_items_created: false,
+        production_mutation_allowed: false,
+      },
+    })
+  })
+
+  it('rejects malformed signal payloads', async () => {
+    const response = await POST(request({ signals: [{ title: 'Missing summary' }] }) as never)
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'signals array with title and summary is required' })
+  })
+})

--- a/app/api/admin/agents/risk-compliance/monitor/route.test.ts
+++ b/app/api/admin/agents/risk-compliance/monitor/route.test.ts
@@ -66,8 +66,15 @@ describe('/api/admin/agents/risk-compliance/monitor', () => {
       ok: true,
       assessments: [
         {
-          classification: expect.stringMatching(/exposure_check|upgrade_request|approval_required/),
+          classification: 'approval_required',
           ownerAgentKey: 'risk-compliance-intelligence',
+          upgradeRequest: expect.objectContaining({
+            priority: 'urgent',
+            metadata: expect.objectContaining({
+              approval_required: true,
+              exposure_surfaces: expect.arrayContaining(['agent-tool-use', 'runtime-security']),
+            }),
+          }),
         },
       ],
       side_effects: {

--- a/app/api/admin/agents/risk-compliance/monitor/route.ts
+++ b/app/api/admin/agents/risk-compliance/monitor/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import {
+  assessAiRiskSignals,
+  getAiRiskSignalMonitorSummary,
+  type AiRiskSignalInput,
+} from '@/lib/ai-risk-signal-monitor'
+
+export const dynamic = 'force-dynamic'
+
+function parseSignals(value: unknown): AiRiskSignalInput[] {
+  if (!Array.isArray(value)) return []
+  return value
+    .filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === 'object')
+    .map((item) => ({
+      id: typeof item.id === 'string' ? item.id : undefined,
+      title: typeof item.title === 'string' ? item.title.trim() : '',
+      summary: typeof item.summary === 'string' ? item.summary.trim() : '',
+      sourceUrl: typeof item.sourceUrl === 'string' ? item.sourceUrl : null,
+      sourceName: typeof item.sourceName === 'string' ? item.sourceName : null,
+      category: typeof item.category === 'string' ? item.category : null,
+      severity: typeof item.severity === 'string' ? item.severity : null,
+      publishedAt: typeof item.publishedAt === 'string' ? item.publishedAt : null,
+      tags: Array.isArray(item.tags) ? item.tags.filter((tag): tag is string => typeof tag === 'string') : [],
+    }))
+    .filter((item) => item.title && item.summary)
+}
+
+export async function GET(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  return NextResponse.json({
+    ok: true,
+    monitor: getAiRiskSignalMonitorSummary(),
+  })
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as Record<string, unknown>
+  const signals = parseSignals(body.signals)
+  if (!signals.length) {
+    return NextResponse.json({ error: 'signals array with title and summary is required' }, { status: 400 })
+  }
+
+  const assessments = assessAiRiskSignals(signals)
+  return NextResponse.json({
+    ok: true,
+    monitor: getAiRiskSignalMonitorSummary(),
+    assessments,
+    upgrade_requests: assessments.map((assessment) => assessment.upgradeRequest).filter(Boolean),
+    side_effects: {
+      work_items_created: false,
+      production_mutation_allowed: false,
+      note: 'This endpoint only classifies supplied signals. Creating work items remains approval-gated.',
+    },
+  })
+}

--- a/docs/ai-risk-compliance-agent.md
+++ b/docs/ai-risk-compliance-agent.md
@@ -35,6 +35,31 @@ Every signal should be classified before it becomes work:
 | `upgrade_request` | Confirmed gap or missing control. | Open a scoped implementation request. |
 | `approval_required` | Fix may touch policy, production config, public content, external sends, or client data. | Route to Shaka and approval gate. |
 
+## Read-Only Monitor Endpoint
+
+The first implementation surface is read-only:
+
+- `GET /api/admin/agents/risk-compliance/monitor` returns Moremi's monitor configuration and safety boundary.
+- `POST /api/admin/agents/risk-compliance/monitor` accepts supplied signal briefs and returns exposure assessments plus proposed upgrade-request payloads.
+- The endpoint does not fetch live news, create work items, mutate workflows, write to production tables, or send notifications in v1.
+
+Expected signal payload:
+
+```json
+{
+  "signals": [
+    {
+      "title": "Regulator issues AI agent privacy warning",
+      "summary": "The warning focuses on agents processing customer data without consent controls.",
+      "sourceName": "Regulator bulletin",
+      "sourceUrl": "https://example.com/source",
+      "severity": "high",
+      "category": "privacy_data"
+    }
+  ]
+}
+```
+
 ## Exposure Checklist
 
 When a signal is relevant, Moremi checks Portfolio for:
@@ -60,6 +85,16 @@ When a signal is relevant, Moremi checks Portfolio for:
 - No production workflow mutation, config change, prompt change, public claim, vendor switch, database write outside known safe workflows, publishing, or external send is allowed without approval.
 - Do not copy production customer, lead, client, contact, meeting, payment, or private operational data into non-production validation.
 - Do not treat news commentary as policy. Prefer primary sources, regulator guidance, vendor incident notices, standards bodies, and security advisories where available.
+
+## Baseline Source Families
+
+Moremi should prioritize primary and standards-oriented sources before commentary:
+
+- [OWASP Agent Security Initiative](https://owasp.org/www-project-top-10-for-large-language-model-applications/initiatives/agent_security_initiative/) for agentic AI security risks.
+- [OWASP AI Vulnerability Scoring System](https://aivss.owasp.org/) for severity scoring patterns specific to AI risks.
+- [NIST AI Risk Management Framework](https://www.nist.gov/itl/ai-risk-management-framework) and the Generative AI Profile for risk management vocabulary.
+- [EU Regulation 2024/1689](https://eur-lex.europa.eu/eli/reg/2024/1689/oj) for AI Act obligations and regulatory language.
+- [FTC AI business guidance](https://www.ftc.gov/business-guidance/technology/artificial-intelligence) for consumer protection and AI claims/disclosure risk.
 
 ## Definition Of Done
 

--- a/lib/ai-risk-signal-monitor.test.ts
+++ b/lib/ai-risk-signal-monitor.test.ts
@@ -44,6 +44,40 @@ describe('AI risk signal monitor', () => {
     expect(assessment.upgradeRequest).toBeNull()
   })
 
+  it('routes prompt and runtime security signals through approval-required packets', () => {
+    const [assessment] = assessAiRiskSignals([
+      {
+        id: 'security-advisory-1',
+        title: 'AI agent prompt injection vulnerability affects browser automation',
+        summary: 'Security researchers report indirect prompt injection that can trigger unsafe tool calls.',
+        sourceName: 'Security advisory',
+        sourceUrl: 'https://example.com/advisory',
+        tags: ['tool injection'],
+      },
+    ])
+
+    expect(assessment).toMatchObject({
+      classification: 'approval_required',
+      severity: 'high',
+      category: 'prompt_injection',
+    })
+    expect(assessment.exposureSurfaces.map((surface) => surface.key)).toEqual(expect.arrayContaining([
+      'agent-tool-use',
+      'runtime-security',
+    ]))
+    expect(assessment.upgradeRequest).toMatchObject({
+      source_id: 'security-advisory-1',
+      source_label: 'Security advisory',
+      priority: 'urgent',
+      metadata: expect.objectContaining({
+        approval_required: true,
+        classification: 'approval_required',
+        source_url: 'https://example.com/advisory',
+        exposure_surfaces: expect.arrayContaining(['agent-tool-use', 'runtime-security']),
+      }),
+    })
+  })
+
   it('returns a read-only monitor summary with Moremi as owner', () => {
     expect(getAiRiskSignalMonitorSummary()).toMatchObject({
       ownerAgentKey: 'risk-compliance-intelligence',

--- a/lib/ai-risk-signal-monitor.test.ts
+++ b/lib/ai-risk-signal-monitor.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { assessAiRiskSignals, getAiRiskSignalMonitorSummary } from './ai-risk-signal-monitor'
+
+describe('AI risk signal monitor', () => {
+  it('classifies privacy and regulatory signals as approval-routed exposure', () => {
+    const [assessment] = assessAiRiskSignals([
+      {
+        title: 'Regulator issues AI agent privacy enforcement warning',
+        summary: 'The warning focuses on AI agents processing customer data without consent or retention controls.',
+        sourceName: 'Regulator bulletin',
+      },
+    ])
+
+    expect(assessment).toMatchObject({
+      classification: 'approval_required',
+      severity: 'critical',
+      category: 'privacy_data',
+      ownerAgentKey: 'risk-compliance-intelligence',
+      ownerAgentName: 'Moremi (Ife) - Risk & Compliance',
+    })
+    expect(assessment.exposureSurfaces.map((surface) => surface.key)).toEqual(expect.arrayContaining([
+      'client-data-boundary',
+      'ai-policy-governance',
+    ]))
+    expect(assessment.upgradeRequest).toMatchObject({
+      priority: 'urgent',
+      owner_agent_key: 'risk-compliance-intelligence',
+      metadata: expect.objectContaining({ approval_required: true }),
+    })
+  })
+
+  it('keeps unrelated signals as watch-only without upgrade requests', () => {
+    const [assessment] = assessAiRiskSignals([
+      {
+        title: 'AI conference announces new keynote track',
+        summary: 'The event includes broad commentary about AI adoption and demos.',
+        sourceName: 'Conference site',
+        severity: 'low',
+      },
+    ])
+
+    expect(assessment.classification).toBe('watch_only')
+    expect(assessment.exposureSurfaces).toEqual([])
+    expect(assessment.upgradeRequest).toBeNull()
+  })
+
+  it('returns a read-only monitor summary with Moremi as owner', () => {
+    expect(getAiRiskSignalMonitorSummary()).toMatchObject({
+      ownerAgentKey: 'risk-compliance-intelligence',
+      ownerAgentName: 'Moremi (Ife) - Risk & Compliance',
+      safetyBoundary: expect.stringContaining('Read-only signal assessment'),
+    })
+  })
+})

--- a/lib/ai-risk-signal-monitor.ts
+++ b/lib/ai-risk-signal-monitor.ts
@@ -88,7 +88,7 @@ const KEYWORD_SURFACES: Array<{
     },
   },
   {
-    keywords: ['eu ai act', 'regulation', 'regulatory', 'compliance', 'enforcement', 'gpaI', 'general-purpose ai', 'automated decision'],
+    keywords: ['eu ai act', 'regulation', 'regulatory', 'compliance', 'enforcement', 'gpai', 'general-purpose ai', 'automated decision'],
     surface: {
       key: 'ai-policy-governance',
       label: 'AI policy, disclosure, and approval governance',
@@ -205,6 +205,12 @@ function surfacesForSignal(text: string) {
 }
 
 function classifySignal(severity: AiRiskSignalSeverity, surfaces: AiRiskExposureSurface[], text: string): AiRiskSignalClassification {
+  const approvalSurfaceKeys = new Set([
+    'agent-tool-use',
+    'client-data-boundary',
+    'ai-policy-governance',
+    'runtime-security',
+  ])
   const approvalKeywords = [
     'production config',
     'credential',
@@ -212,11 +218,20 @@ function classifySignal(severity: AiRiskSignalSeverity, surfaces: AiRiskExposure
     'client data',
     'customer data',
     'personal data',
+    'prompt injection',
+    'tool injection',
+    'jailbreak',
+    'indirect prompt',
+    'unsafe tool',
+    'browser automation',
+    'remote code',
+    'api key',
     'public claim',
     'regulation',
     'enforcement',
   ]
   if (severity === 'critical' || approvalKeywords.some((keyword) => text.includes(keyword))) return 'approval_required'
+  if (severityRank(severity) >= 2 && surfaces.some((surface) => approvalSurfaceKeys.has(surface.key))) return 'approval_required'
   if (severity === 'high' && surfaces.length > 0) return 'upgrade_request'
   if (surfaces.length > 0) return 'exposure_check'
   return 'watch_only'

--- a/lib/ai-risk-signal-monitor.ts
+++ b/lib/ai-risk-signal-monitor.ts
@@ -1,0 +1,309 @@
+import { getAgentByKey } from '@/lib/agent-organization'
+
+export const AI_RISK_SIGNAL_CATEGORIES = [
+  'agent_autonomy',
+  'prompt_injection',
+  'privacy_data',
+  'regulatory',
+  'security',
+  'bias_safety',
+  'vendor_incident',
+  'consumer_disclosure',
+] as const
+
+export const AI_RISK_SIGNAL_SEVERITIES = ['low', 'medium', 'high', 'critical'] as const
+export const AI_RISK_SIGNAL_CLASSIFICATIONS = ['watch_only', 'exposure_check', 'upgrade_request', 'approval_required'] as const
+
+export type AiRiskSignalCategory = (typeof AI_RISK_SIGNAL_CATEGORIES)[number]
+export type AiRiskSignalSeverity = (typeof AI_RISK_SIGNAL_SEVERITIES)[number]
+export type AiRiskSignalClassification = (typeof AI_RISK_SIGNAL_CLASSIFICATIONS)[number]
+
+export type AiRiskSignalInput = {
+  id?: string
+  title: string
+  summary: string
+  sourceUrl?: string | null
+  sourceName?: string | null
+  category?: AiRiskSignalCategory | string | null
+  severity?: AiRiskSignalSeverity | string | null
+  publishedAt?: string | null
+  tags?: string[]
+}
+
+export type AiRiskExposureSurface = {
+  key: string
+  label: string
+  reason: string
+  ownerAgentKey: string
+  ownerAgentName: string
+  approvalGate: string
+}
+
+export type AiRiskSignalAssessment = {
+  signalId: string
+  title: string
+  classification: AiRiskSignalClassification
+  severity: AiRiskSignalSeverity
+  category: AiRiskSignalCategory
+  confidence: 'low' | 'medium' | 'high'
+  rationale: string
+  exposureSurfaces: AiRiskExposureSurface[]
+  ownerAgentKey: 'risk-compliance-intelligence'
+  ownerAgentName: string
+  recommendedNextAction: string
+  upgradeRequest: {
+    title: string
+    objective: string
+    priority: 'low' | 'medium' | 'high' | 'urgent'
+    owner_agent_key: string
+    source_type: 'ai_risk_signal'
+    source_id: string
+    source_label: string
+    metadata: Record<string, unknown>
+  } | null
+}
+
+const KEYWORD_SURFACES: Array<{
+  keywords: string[]
+  surface: Omit<AiRiskExposureSurface, 'ownerAgentName'>
+}> = [
+  {
+    keywords: ['prompt injection', 'tool injection', 'jailbreak', 'indirect prompt'],
+    surface: {
+      key: 'agent-tool-use',
+      label: 'Agent tool invocation and prompt handling',
+      reason: 'Portfolio runs tool-using agents, Slack commands, RAG prompts, and workflow dispatch paths.',
+      ownerAgentKey: 'agent-tooling-parity',
+      approvalGate: 'Prompt, runtime, and production behavior changes require review.',
+    },
+  },
+  {
+    keywords: ['privacy', 'personal data', 'client data', 'customer data', 'retention', 'consent', 'pii'],
+    surface: {
+      key: 'client-data-boundary',
+      label: 'Client, lead, meeting, and private knowledge data boundaries',
+      reason: 'Portfolio handles lead, client, meeting, email, knowledge, and private operational records.',
+      ownerAgentKey: 'private-knowledge-librarian',
+      approvalGate: 'Client data access, private-source promotion, and public use of private material require approval.',
+    },
+  },
+  {
+    keywords: ['eu ai act', 'regulation', 'regulatory', 'compliance', 'enforcement', 'gpaI', 'general-purpose ai', 'automated decision'],
+    surface: {
+      key: 'ai-policy-governance',
+      label: 'AI policy, disclosure, and approval governance',
+      reason: 'Portfolio exposes AI workflows, public chatbot behavior, admin automation, and client-facing AI Ops advice.',
+      ownerAgentKey: 'risk-compliance-intelligence',
+      approvalGate: 'Policy changes, public claims, and client-facing commitments require approval.',
+    },
+  },
+  {
+    keywords: ['security', 'credential', 'secret', 'api key', 'supply chain', 'remote code', 'browser automation'],
+    surface: {
+      key: 'runtime-security',
+      label: 'Runtime, credential, and browser automation security',
+      reason: 'Portfolio uses API keys, webhooks, browser-capable agents, n8n workflows, and production integrations.',
+      ownerAgentKey: 'automation-systems',
+      approvalGate: 'Credential changes, production config changes, and external API changes require approval.',
+    },
+  },
+  {
+    keywords: ['bias', 'discrimination', 'fairness', 'safety', 'harmful', 'deceptive'],
+    surface: {
+      key: 'public-ai-output-quality',
+      label: 'Public AI output, recommendation, and disclosure quality',
+      reason: 'Portfolio includes public chatbot, source-respecting LLM, social content, and advisory recommendation surfaces.',
+      ownerAgentKey: 'voice-content-architect',
+      approvalGate: 'Public content, public claims, and client-facing recommendations require human review.',
+    },
+  },
+  {
+    keywords: ['vendor', 'model provider', 'openai', 'anthropic', 'vercel', 'supabase', 'n8n', 'pinecone', 'slack'],
+    surface: {
+      key: 'vendor-dependency',
+      label: 'AI/runtime vendor dependency and incident exposure',
+      reason: 'Portfolio depends on model providers, Vercel, Supabase, n8n, Pinecone, Slack, and related workflow providers.',
+      ownerAgentKey: 'agent-tooling-parity',
+      approvalGate: 'Vendor replacement, model routing, and production config changes require approval.',
+    },
+  },
+]
+
+const CATEGORY_KEYWORDS: Record<AiRiskSignalCategory, string[]> = {
+  agent_autonomy: ['agent', 'autonomous', 'tool use', 'tool call', 'computer use', 'browser automation'],
+  prompt_injection: ['prompt injection', 'jailbreak', 'indirect prompt', 'tool injection'],
+  privacy_data: ['privacy', 'personal data', 'customer data', 'client data', 'pii', 'retention', 'consent'],
+  regulatory: ['regulation', 'compliance', 'eu ai act', 'nist', 'ftc', 'law', 'policy'],
+  security: ['security', 'credential', 'secret', 'exploit', 'vulnerability', 'supply chain'],
+  bias_safety: ['bias', 'discrimination', 'safety', 'harmful', 'deceptive'],
+  vendor_incident: ['vendor', 'outage', 'incident', 'breach', 'model provider', 'platform'],
+  consumer_disclosure: ['disclosure', 'claim', 'advertising', 'consumer', 'deceptive', 'transparency'],
+}
+
+function normalizedText(signal: AiRiskSignalInput) {
+  return `${signal.title} ${signal.summary} ${(signal.tags ?? []).join(' ')}`.toLowerCase()
+}
+
+function stableSignalId(signal: AiRiskSignalInput, index: number) {
+  if (signal.id?.trim()) return signal.id.trim()
+  const base = `${signal.sourceName ?? 'signal'}:${signal.title}`.toLowerCase().replace(/[^a-z0-9]+/g, '-')
+  return `${base.replace(/^-|-$/g, '').slice(0, 80) || 'ai-risk-signal'}-${index + 1}`
+}
+
+function normalizeSeverity(value: string | null | undefined, text: string): AiRiskSignalSeverity {
+  if (AI_RISK_SIGNAL_SEVERITIES.includes(value as AiRiskSignalSeverity)) return value as AiRiskSignalSeverity
+  if (/\b(critical|breach|enforcement|ban|illegal|exploit)\b/.test(text)) return 'critical'
+  if (/\b(high risk|regulation|privacy|security|credential|client data|customer data|prompt injection)\b/.test(text)) return 'high'
+  if (/\b(warning|guidance|policy|audit|disclosure|safety)\b/.test(text)) return 'medium'
+  return 'low'
+}
+
+function normalizeCategory(value: string | null | undefined, text: string): AiRiskSignalCategory {
+  if (AI_RISK_SIGNAL_CATEGORIES.includes(value as AiRiskSignalCategory)) return value as AiRiskSignalCategory
+  const priorityOrder: AiRiskSignalCategory[] = [
+    'prompt_injection',
+    'privacy_data',
+    'regulatory',
+    'security',
+    'bias_safety',
+    'vendor_incident',
+    'consumer_disclosure',
+    'agent_autonomy',
+  ]
+  const match = priorityOrder.find((category) =>
+    CATEGORY_KEYWORDS[category].some((keyword) => text.includes(keyword)),
+  )
+  return match ?? 'agent_autonomy'
+}
+
+function severityRank(severity: AiRiskSignalSeverity) {
+  return { low: 0, medium: 1, high: 2, critical: 3 }[severity]
+}
+
+function priorityForAssessment(
+  classification: AiRiskSignalClassification,
+  severity: AiRiskSignalSeverity,
+): 'low' | 'medium' | 'high' | 'urgent' {
+  if (classification === 'approval_required' || severity === 'critical') return 'urgent'
+  if (classification === 'upgrade_request' || severity === 'high') return 'high'
+  if (classification === 'exposure_check' || severity === 'medium') return 'medium'
+  return 'low'
+}
+
+function surfacesForSignal(text: string) {
+  const surfaces = KEYWORD_SURFACES
+    .filter(({ keywords }) => keywords.some((keyword) => text.includes(keyword)))
+    .map(({ surface }) => {
+      const agent = getAgentByKey(surface.ownerAgentKey)
+      return {
+        ...surface,
+        ownerAgentName: agent?.name ?? surface.ownerAgentKey,
+      }
+    })
+
+  return surfaces.filter((surface, index, list) => list.findIndex((item) => item.key === surface.key) === index)
+}
+
+function classifySignal(severity: AiRiskSignalSeverity, surfaces: AiRiskExposureSurface[], text: string): AiRiskSignalClassification {
+  const approvalKeywords = [
+    'production config',
+    'credential',
+    'secret',
+    'client data',
+    'customer data',
+    'personal data',
+    'public claim',
+    'regulation',
+    'enforcement',
+  ]
+  if (severity === 'critical' || approvalKeywords.some((keyword) => text.includes(keyword))) return 'approval_required'
+  if (severity === 'high' && surfaces.length > 0) return 'upgrade_request'
+  if (surfaces.length > 0) return 'exposure_check'
+  return 'watch_only'
+}
+
+export function assessAiRiskSignals(signals: AiRiskSignalInput[]): AiRiskSignalAssessment[] {
+  const owner = getAgentByKey('risk-compliance-intelligence')
+
+  return signals.map((signal, index) => {
+    const text = normalizedText(signal)
+    const signalId = stableSignalId(signal, index)
+    const severity = normalizeSeverity(signal.severity, text)
+    const category = normalizeCategory(signal.category, text)
+    const exposureSurfaces = surfacesForSignal(text)
+    const classification = classifySignal(severity, exposureSurfaces, text)
+    const priority = priorityForAssessment(classification, severity)
+    const confidence = exposureSurfaces.length >= 2 || severityRank(severity) >= 2 ? 'high' : exposureSurfaces.length === 1 ? 'medium' : 'low'
+    const ownerAgentName = owner?.name ?? 'Moremi (Ife) - Risk & Compliance'
+    const sourceLabel = signal.sourceName ?? signal.sourceUrl ?? signal.title
+    const recommendedNextAction =
+      classification === 'watch_only'
+        ? 'Retain the signal for trend monitoring; no Portfolio exposure found from the provided text.'
+        : classification === 'exposure_check'
+          ? 'Open a read-only exposure check against the identified Portfolio surfaces.'
+          : classification === 'upgrade_request'
+            ? 'Create a scoped upgrade request for the highest-risk exposed surface.'
+            : 'Create an approval-routed risk packet before any remediation work begins.'
+
+    const upgradeRequest = classification === 'watch_only'
+      ? null
+      : {
+          title: `Review AI risk signal: ${signal.title}`,
+          objective: [
+            `Assess ${signal.title} for Portfolio exposure.`,
+            exposureSurfaces.length
+              ? `Check surfaces: ${exposureSurfaces.map((surface) => surface.label).join('; ')}.`
+              : 'Confirm whether any Portfolio surface is exposed.',
+            'Produce a scoped remediation or acceptance note.',
+          ].join(' '),
+          priority,
+          owner_agent_key: 'risk-compliance-intelligence',
+          source_type: 'ai_risk_signal' as const,
+          source_id: signalId,
+          source_label: sourceLabel,
+          metadata: {
+            classification,
+            severity,
+            category,
+            source_url: signal.sourceUrl ?? null,
+            published_at: signal.publishedAt ?? null,
+            exposure_surfaces: exposureSurfaces.map((surface) => surface.key),
+            approval_required: classification === 'approval_required',
+          },
+        }
+
+    return {
+      signalId,
+      title: signal.title,
+      classification,
+      severity,
+      category,
+      confidence,
+      rationale: exposureSurfaces.length
+        ? `Matched ${exposureSurfaces.length} Portfolio exposure surface(s) from the signal text.`
+        : 'No Portfolio exposure surface matched from the provided signal text.',
+      exposureSurfaces,
+      ownerAgentKey: 'risk-compliance-intelligence',
+      ownerAgentName,
+      recommendedNextAction,
+      upgradeRequest,
+    }
+  })
+}
+
+export function getAiRiskSignalMonitorSummary() {
+  return {
+    ownerAgentKey: 'risk-compliance-intelligence',
+    ownerAgentName: getAgentByKey('risk-compliance-intelligence')?.name ?? 'Moremi (Ife) - Risk & Compliance',
+    supportingAgents: [
+      'research-source-register',
+      'agent-tooling-parity',
+      'engineering-copilot',
+      'automation-systems',
+      'decision-journal',
+    ],
+    categories: AI_RISK_SIGNAL_CATEGORIES,
+    classifications: AI_RISK_SIGNAL_CLASSIFICATIONS,
+    safetyBoundary: 'Read-only signal assessment. Work-item creation, production config, workflow mutation, public claims, and client-data access require approval.',
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a read-only Moremi risk signal monitor library for classifying AI/agent ethics, compliance, privacy, security, and vendor signals against Portfolio exposure surfaces.
- Adds admin-only `GET/POST /api/admin/agents/risk-compliance/monitor` for monitor metadata and supplied-signal assessment.
- Extends the Moremi operating doc with the v1 endpoint, safety boundary, signal payload, and baseline source families.

## Validation
- npm test -- --run lib/ai-risk-signal-monitor.test.ts app/api/admin/agents/risk-compliance/monitor/route.test.ts lib/agent-organization.test.ts
- npx tsc --noEmit --pretty false
- npx next lint --file lib/ai-risk-signal-monitor.ts --file lib/ai-risk-signal-monitor.test.ts --file app/api/admin/agents/risk-compliance/monitor/route.ts --file app/api/admin/agents/risk-compliance/monitor/route.test.ts
- pre-push database health check passed

## Integration Notes
- Draft PR for Integration Captain.
- V1 is read-only: no live news fetching, work-item creation, production mutation, external sends, or workflow changes.
- The endpoint returns upgrade-request payloads only; creating actual `agent_work_items` remains a later approval-gated step.
- Vercel contexts not checked from this non-captain lane.