### PR TITLE
fix: gate chat eval prompt applications

### DIFF
--- a/app/api/admin/chat-eval/diagnoses/[id]/apply-prompt/route.test.ts
+++ b/app/api/admin/chat-eval/diagnoses/[id]/apply-prompt/route.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  clearPromptCache: vi.fn(),
+  from: vi.fn(),
+  diagnosisSingle: vi.fn(),
+  updateSingle: vi.fn(),
+  insert: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/system-prompts', () => ({
+  clearPromptCache: mocks.clearPromptCache,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import { POST } from './route'
+
+const params = { params: Promise.resolve({ id: 'diagnosis-1' }) }
+
+function request(body: Record<string, unknown> = {}) {
+  return new Request('http://localhost/api/admin/chat-eval/diagnoses/diagnosis-1/apply-prompt', {
+    method: 'POST',
+    headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+function setupSupabaseChains() {
+  const diagnosisEq = vi.fn(() => ({ single: mocks.diagnosisSingle }))
+  const diagnosisSelect = vi.fn(() => ({ eq: diagnosisEq }))
+  const updateEq = vi.fn(() => ({ select: vi.fn(() => ({ single: mocks.updateSingle })) }))
+  const update = vi.fn(() => ({ eq: updateEq }))
+
+  mocks.from.mockImplementation((table: string) => {
+    if (table === 'error_diagnoses') return { select: diagnosisSelect }
+    if (table === 'system_prompts') return { update }
+    if (table === 'fix_applications') return { insert: mocks.insert }
+    throw new Error(`Unexpected table: ${table}`)
+  })
+}
+
+describe('POST /api/admin/chat-eval/diagnoses/[id]/apply-prompt', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.diagnosisSingle.mockResolvedValue({
+      data: {
+        status: 'approved',
+        recommendations: [
+          {
+            id: 'rec-1',
+            type: 'prompt',
+            approved: true,
+            changes: {
+              target: 'system_prompt',
+              old_value: 'Old prompt',
+              new_value: 'New prompt',
+            },
+          },
+        ],
+      },
+      error: null,
+    })
+    mocks.updateSingle.mockResolvedValue({ data: { id: 'prompt-1', key: 'chatbot' }, error: null })
+    mocks.insert.mockResolvedValue({ data: null, error: null })
+    setupSupabaseChains()
+  })
+
+  it('requires diagnosis approval before mutating prompts', async () => {
+    mocks.diagnosisSingle.mockResolvedValue({
+      data: {
+        status: 'pending',
+        recommendations: [
+          {
+            id: 'rec-1',
+            type: 'prompt',
+            approved: true,
+            changes: { target: 'system_prompt', new_value: 'New prompt' },
+          },
+        ],
+      },
+      error: null,
+    })
+
+    const response = await POST(request({ recommendation_id: 'rec-1' }) as never, params)
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: 'Diagnosis must be approved before applying prompt fixes',
+    })
+    expect(mocks.clearPromptCache).not.toHaveBeenCalled()
+    expect(mocks.from).not.toHaveBeenCalledWith('system_prompts')
+  })
+
+  it('requires the selected prompt recommendation to be approved', async () => {
+    mocks.diagnosisSingle.mockResolvedValue({
+      data: {
+        status: 'approved',
+        recommendations: [
+          {
+            id: 'rec-1',
+            type: 'prompt',
+            approved: false,
+            changes: { target: 'system_prompt', new_value: 'New prompt' },
+          },
+        ],
+      },
+      error: null,
+    })
+
+    const response = await POST(request({ recommendation_id: 'rec-1' }) as never, params)
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: 'Prompt recommendation must be approved before applying',
+    })
+    expect(mocks.clearPromptCache).not.toHaveBeenCalled()
+    expect(mocks.from).not.toHaveBeenCalledWith('system_prompts')
+  })
+
+  it('updates the mapped chatbot prompt after approval', async () => {
+    const response = await POST(request({ recommendation_id: 'rec-1' }) as never, params)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      success: true,
+      prompt: { id: 'prompt-1', key: 'chatbot' },
+      message: 'Prompt "chatbot" updated successfully',
+    })
+    expect(mocks.clearPromptCache).toHaveBeenCalledWith('chatbot')
+    expect(mocks.insert).toHaveBeenCalledWith(expect.objectContaining({
+      diagnosis_id: 'diagnosis-1',
+      change_type: 'prompt',
+      target_identifier: 'chatbot',
+      application_method: 'auto',
+      applied_by: 'admin-user',
+    }))
+  })
+})

--- a/app/api/admin/chat-eval/diagnoses/[id]/apply-prompt/route.ts
+++ b/app/api/admin/chat-eval/diagnoses/[id]/apply-prompt/route.ts
@@ -42,6 +42,13 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       )
     }
 
+    if (diagnosis.status !== 'approved') {
+      return NextResponse.json(
+        { error: 'Diagnosis must be approved before applying prompt fixes' },
+        { status: 400 }
+      )
+    }
+
     // Find the recommendation
     const recommendations = diagnosis.recommendations || []
     let recommendation: any = null
@@ -58,6 +65,13 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       return NextResponse.json(
         { error: 'Prompt recommendation not found' },
         { status: 404 }
+      )
+    }
+
+    if (recommendation.approved !== true) {
+      return NextResponse.json(
+        { error: 'Prompt recommendation must be approved before applying' },
+        { status: 400 }
       )
     }
 

--- a/app/api/admin/chat-eval/diagnoses/[id]/apply/route.test.ts
+++ b/app/api/admin/chat-eval/diagnoses/[id]/apply/route.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  clearPromptCache: vi.fn(),
+  from: vi.fn(),
+  diagnosisSingle: vi.fn(),
+  promptSingle: vi.fn(),
+  insert: vi.fn(),
+  historyUpdate: vi.fn(),
+  diagnosisUpdate: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/system-prompts', () => ({
+  clearPromptCache: mocks.clearPromptCache,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import { POST } from './route'
+
+const params = { params: Promise.resolve({ id: 'diagnosis-1' }) }
+
+function request(body: Record<string, unknown> = {}) {
+  return new Request('http://localhost/api/admin/chat-eval/diagnoses/diagnosis-1/apply', {
+    method: 'POST',
+    headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+function setupSupabaseChains() {
+  const diagnosisEq = vi.fn(() => ({ single: mocks.diagnosisSingle }))
+  const diagnosisSelect = vi.fn(() => ({ eq: diagnosisEq }))
+
+  const promptEqVersion = vi.fn(() => Promise.resolve({ data: null, error: null }))
+  const promptEqPromptId = vi.fn(() => ({ eq: promptEqVersion }))
+  mocks.historyUpdate.mockReturnValue({ eq: promptEqPromptId })
+
+  const promptEqKey = vi.fn(() => ({ select: vi.fn(() => ({ single: mocks.promptSingle })) }))
+  const promptUpdate = vi.fn(() => ({ eq: promptEqKey }))
+
+  const diagnosisUpdateEq = vi.fn(() => Promise.resolve({ data: null, error: null }))
+  mocks.diagnosisUpdate.mockReturnValue({ eq: diagnosisUpdateEq })
+
+  mocks.from.mockImplementation((table: string) => {
+    if (table === 'error_diagnoses') {
+      return {
+        select: diagnosisSelect,
+        update: mocks.diagnosisUpdate,
+      }
+    }
+    if (table === 'system_prompts') return { update: promptUpdate }
+    if (table === 'system_prompt_history') return { update: mocks.historyUpdate }
+    if (table === 'fix_applications') return { insert: mocks.insert }
+    throw new Error(`Unexpected table: ${table}`)
+  })
+}
+
+describe('POST /api/admin/chat-eval/diagnoses/[id]/apply', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.diagnosisSingle.mockResolvedValue({
+      data: {
+        status: 'approved',
+        recommendations: [
+          {
+            id: 'rec-approved',
+            type: 'prompt',
+            approved: true,
+            changes: {
+              target: 'system_prompt',
+              old_value: 'Old prompt',
+              new_value: 'New prompt',
+              can_auto_apply: true,
+            },
+          },
+          {
+            id: 'rec-unapproved',
+            type: 'prompt',
+            approved: false,
+            changes: {
+              target: 'system_prompt',
+              old_value: 'Old prompt',
+              new_value: 'Unapproved prompt',
+              can_auto_apply: true,
+            },
+          },
+        ],
+      },
+      error: null,
+    })
+    mocks.promptSingle.mockResolvedValue({ data: { id: 'prompt-1', version: 3 }, error: null })
+    mocks.insert.mockResolvedValue({ data: null, error: null })
+    setupSupabaseChains()
+  })
+
+  it('rejects explicitly selected recommendations that were not approved', async () => {
+    const response = await POST(
+      request({ recommendation_ids: ['rec-unapproved'], auto_apply: true }) as never,
+      params
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: 'Only approved recommendations can be applied',
+    })
+    expect(mocks.from).not.toHaveBeenCalledWith('system_prompts')
+    expect(mocks.clearPromptCache).not.toHaveBeenCalled()
+  })
+
+  it('applies an explicitly selected approved prompt recommendation', async () => {
+    const response = await POST(
+      request({ recommendation_ids: ['rec-approved'], auto_apply: true }) as never,
+      params
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      applied: [
+        {
+          recommendation_id: 'rec-approved',
+          status: 'applied',
+          method: 'auto',
+          changes: {
+            target: 'chatbot',
+            old_value: 'Old prompt',
+            new_value: 'New prompt',
+          },
+        },
+      ],
+      instructions: [],
+      summary: {
+        total: 1,
+        auto_applied: 1,
+        requires_manual: 0,
+      },
+    })
+    expect(mocks.clearPromptCache).toHaveBeenCalledWith('chatbot')
+  })
+})

--- a/app/api/admin/chat-eval/diagnoses/[id]/apply/route.ts
+++ b/app/api/admin/chat-eval/diagnoses/[id]/apply/route.ts
@@ -50,9 +50,22 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     }
 
     const recommendations = diagnosis.recommendations || []
-    
+    const hasSpecificRecommendationIds = Array.isArray(recommendation_ids)
+
+    if (hasSpecificRecommendationIds) {
+      const selectedRecommendations = recommendations.filter((rec: any) => recommendation_ids.includes(rec.id))
+      const unapprovedSelection = selectedRecommendations.find((rec: any) => rec.approved !== true)
+
+      if (unapprovedSelection) {
+        return NextResponse.json(
+          { error: 'Only approved recommendations can be applied' },
+          { status: 400 }
+        )
+      }
+    }
+
     // Filter recommendations if specific IDs provided
-    const recommendationsToApply = recommendation_ids && Array.isArray(recommendation_ids)
+    const recommendationsToApply = hasSpecificRecommendationIds
       ? recommendations.filter((rec: any) => recommendation_ids.includes(rec.id))
       : recommendations.filter((rec: any) => rec.approved !== false)
 


### PR DESCRIPTION
## Summary
- Rebuilds the old approval-guard work from current `main` instead of reviving stale local branches.
- Requires diagnosis-level approval before `apply-prompt` can mutate system prompts.
- Requires selected prompt recommendations to be explicitly approved in both `apply-prompt` and the broader `apply` route.
- Adds focused regression tests for both mutation routes.

## Validation
- npm test -- --run app/api/admin/chat-eval/diagnoses/[id]/apply-prompt/route.test.ts app/api/admin/chat-eval/diagnoses/[id]/apply/route.test.ts
- git diff --check
- npx next lint --file app/api/admin/chat-eval/diagnoses/[id]/apply-prompt/route.ts --file app/api/admin/chat-eval/diagnoses/[id]/apply-prompt/route.test.ts --file app/api/admin/chat-eval/diagnoses/[id]/apply/route.ts --file app/api/admin/chat-eval/diagnoses/[id]/apply/route.test.ts
- npx tsc --noEmit --pretty false
- npm run build
- pre-push production DB health check

## Integration Notes
- No schema migration.
- No live workflow or customer-data smoke was run.
- Build passed with the existing local env warning that outbound n8n webhooks are enabled.
- After this merges, delete the stale local-only `portfolio-ops-approval-guard*` branches.