### PR TITLE
feat: add vercel autoresearch approvals

### DIFF
--- a/app/admin/agents/coordination/page.test.tsx
+++ b/app/admin/agents/coordination/page.test.tsx
@@ -1,0 +1,97 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import AgentCoordinationPage from './page'
+
+vi.mock('@/components/ProtectedRoute', () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('@/components/admin/Breadcrumbs', () => ({
+  default: () => null,
+}))
+
+vi.mock('@/lib/auth', () => ({
+  getCurrentSession: vi.fn(async () => ({ access_token: 'admin-token' })),
+}))
+
+const approvalCard = {
+  approvalId: 'approval-1',
+  runId: 'run-1',
+  workItemId: 'work-1',
+  status: 'pending',
+  requestedAt: '2026-05-11T12:00:00.000Z',
+  proposal: {
+    id: 'next-build-profile',
+    title: 'Profile the Next.js build path',
+    hypothesis: 'Find the slow build step.',
+    expectedImpact: 'Reduce deployment research time.',
+    scorecardBaseline: {
+      project: 'portfolio',
+      target: 'preview',
+      queueSeconds: 1,
+      buildSeconds: 221,
+      totalSeconds: 223,
+    },
+    touchedFiles: ['package.json'],
+    touchedSettings: [],
+    riskLevel: 'low',
+    approvalState: 'not_required',
+    approvalQuestion: 'Approve a read-only/local build-profile experiment?',
+    rollbackPath: 'Discard the branch.',
+    evidence: ['build=3m41s'],
+  },
+  notification: {
+    slackSentAt: '2026-05-11T12:01:00.000Z',
+    slackSkippedAt: null,
+  },
+  workItem: {
+    id: 'work-1',
+    title: 'Profile the Next.js build path',
+    status: 'ready_for_review',
+    active_run_id: 'run-1',
+    approval_id: 'approval-1',
+    updated_at: '2026-05-11T12:00:00.000Z',
+  },
+}
+
+describe('AgentCoordinationPage Vercel AutoResearch approvals', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.startsWith('/api/admin/agents/vercel-research/proposals')) {
+        return { ok: true, json: async () => ({ ok: true, approvals: [approvalCard] }) }
+      }
+      if (url.startsWith('/api/admin/agents/work-items')) {
+        return { ok: true, json: async () => ({ work_items: [] }) }
+      }
+      if (url === '/api/admin/agents/runs/run-1/approval' && init?.method === 'POST') {
+        return { ok: true, json: async () => ({ ok: true, approval_id: 'approval-1' }) }
+      }
+      return { ok: false, status: 404, json: async () => ({ error: 'not found' }) }
+    }))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('shows pending Vercel AutoResearch approvals inline and approves from the card', async () => {
+    render(<AgentCoordinationPage />)
+
+    expect(await screen.findByText('Vercel AutoResearch approvals')).toBeInTheDocument()
+    expect(screen.getAllByText('Profile the Next.js build path').length).toBeGreaterThan(0)
+    expect(screen.getByText('Approve a read-only/local build-profile experiment?')).toBeInTheDocument()
+    expect(screen.getByText('Slack notified')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }))
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/admin/agents/runs/run-1/approval', expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ Authorization: 'Bearer admin-token' }),
+        body: expect.stringContaining('"status":"approved"'),
+      }))
+    })
+  })
+})

--- a/app/admin/agents/coordination/page.tsx
+++ b/app/admin/agents/coordination/page.tsx
@@ -5,18 +5,21 @@ import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react'
 import {
   AlertTriangle,
   ArrowRight,
+  BellRing,
   Bot,
   CheckCircle2,
   GitPullRequest,
   Network,
   RefreshCw,
   ShieldCheck,
+  XCircle,
 } from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
 import { getCurrentSession } from '@/lib/auth'
 import type { AgentRuntime } from '@/lib/agent-run'
 import type { AgentWorkItem, AgentWorkItemStatus } from '@/lib/agent-work-items'
+import type { VercelResearchProposal } from '@/lib/vercel-deployment-research'
 
 const STATUSES: Array<'all' | AgentWorkItemStatus> = [
   'all',
@@ -39,6 +42,27 @@ type WorkItemForm = {
   branch_name: string
   worktree_path: string
   expected_files: string
+}
+
+type VercelResearchApprovalCard = {
+  approvalId: string
+  runId: string
+  workItemId: string
+  status: string
+  requestedAt: string
+  proposal: VercelResearchProposal
+  notification: {
+    slackSentAt: string | null
+    slackSkippedAt: string | null
+  }
+  workItem: {
+    id: string
+    title: string
+    status: string
+    active_run_id: string | null
+    approval_id: string | null
+    updated_at: string
+  } | null
 }
 
 const DEFAULT_FORM: WorkItemForm = {
@@ -67,6 +91,7 @@ function AgentCoordinationContent() {
   const [actionId, setActionId] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [form, setForm] = useState<WorkItemForm>(DEFAULT_FORM)
+  const [vercelResearchApprovals, setVercelResearchApprovals] = useState<VercelResearchApprovalCard[]>([])
 
   const authedFetch = useCallback(async (path: string, init: RequestInit = {}) => {
     const session = await getCurrentSession()
@@ -98,9 +123,22 @@ function AgentCoordinationContent() {
     }
   }, [authedFetch, status])
 
+  const loadVercelResearchApprovals = useCallback(async () => {
+    try {
+      const response = await authedFetch('/api/admin/agents/vercel-research/proposals')
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`)
+      setVercelResearchApprovals(body.approvals ?? [])
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load Vercel AutoResearch approvals')
+      setVercelResearchApprovals([])
+    }
+  }, [authedFetch])
+
   useEffect(() => {
     loadItems()
-  }, [loadItems])
+    loadVercelResearchApprovals()
+  }, [loadItems, loadVercelResearchApprovals])
 
   const summary = useMemo(() => ({
     active: items.filter((item) => !['merged', 'deployed', 'cancelled'].includes(item.status)).length,
@@ -108,6 +146,10 @@ function AgentCoordinationContent() {
     review: items.filter((item) => item.status === 'ready_for_review' || item.status === 'ready_for_merge').length,
     approvals: items.filter((item) => Boolean(item.approval_id)).length,
   }), [items])
+
+  async function refreshAll() {
+    await Promise.all([loadItems(), loadVercelResearchApprovals()])
+  }
 
   async function createWorkItem(event: FormEvent) {
     event.preventDefault()
@@ -131,7 +173,7 @@ function AgentCoordinationContent() {
       const body = await response.json().catch(() => ({}))
       if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`)
       setForm(DEFAULT_FORM)
-      await loadItems()
+      await refreshAll()
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create work item')
     } finally {
@@ -169,9 +211,34 @@ function AgentCoordinationContent() {
       const response = await authedFetch(path, { method: 'POST', body: JSON.stringify(body) })
       const responseBody = await response.json().catch(() => ({}))
       if (!response.ok) throw new Error(responseBody.error || `HTTP ${response.status}`)
-      await loadItems()
+      await refreshAll()
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Action failed')
+    } finally {
+      setActionId(null)
+    }
+  }
+
+  async function decideVercelResearchApproval(card: VercelResearchApprovalCard, status: 'approved' | 'rejected') {
+    setActionId(`${status}:${card.approvalId}`)
+    setError(null)
+    try {
+      const response = await authedFetch(`/api/admin/agents/runs/${card.runId}/approval`, {
+        method: 'POST',
+        body: JSON.stringify({
+          approval_id: card.approvalId,
+          status,
+          decision_notes:
+            status === 'approved'
+              ? 'Approved Vercel AutoResearch proposal from Agent Coordination.'
+              : 'Rejected Vercel AutoResearch proposal from Agent Coordination.',
+        }),
+      })
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`)
+      await refreshAll()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Approval update failed')
     } finally {
       setActionId(null)
     }
@@ -206,7 +273,7 @@ function AgentCoordinationContent() {
               Mission Control
             </Link>
             <button
-              onClick={loadItems}
+              onClick={refreshAll}
               disabled={loading}
               className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/50 bg-radiant-gold/10 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15 disabled:opacity-60"
             >
@@ -222,6 +289,12 @@ function AgentCoordinationContent() {
           <Metric label="Review queue" value={summary.review} tone={summary.review ? 'yellow' : 'slate'} />
           <Metric label="Approval-linked" value={summary.approvals} tone={summary.approvals ? 'green' : 'slate'} />
         </div>
+
+        <VercelResearchApprovalPanel
+          approvals={vercelResearchApprovals}
+          actionId={actionId}
+          onDecision={decideVercelResearchApproval}
+        />
 
         <section className="mb-6 rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
           <div className="mb-4 flex flex-wrap gap-2">
@@ -307,6 +380,90 @@ function AgentCoordinationContent() {
         )}
       </div>
     </div>
+  )
+}
+
+function VercelResearchApprovalPanel({
+  approvals,
+  actionId,
+  onDecision,
+}: {
+  approvals: VercelResearchApprovalCard[]
+  actionId: string | null
+  onDecision: (card: VercelResearchApprovalCard, status: 'approved' | 'rejected') => void
+}) {
+  return (
+    <section className="mb-6 rounded-lg border border-yellow-500/30 bg-yellow-500/5 p-4">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <BellRing size={18} className="text-yellow-200" />
+          <div>
+            <h2 className="font-semibold text-yellow-100">Vercel AutoResearch approvals</h2>
+            <p className="text-sm text-muted-foreground">Event-driven proposal gates ready for one-click review.</p>
+          </div>
+        </div>
+        <span className="rounded-full border border-yellow-500/30 px-2 py-1 text-xs text-yellow-100">
+          {approvals.length} pending
+        </span>
+      </div>
+
+      {approvals.length === 0 ? (
+        <p className="rounded-lg border border-silicon-slate/60 bg-background/40 p-3 text-sm text-muted-foreground">
+          No Vercel AutoResearch proposal is waiting for approval.
+        </p>
+      ) : (
+        <div className="grid gap-3 lg:grid-cols-2">
+          {approvals.map((card) => (
+            <article key={card.approvalId} className="rounded-lg border border-yellow-500/25 bg-background/50 p-4">
+              <div className="mb-2 flex flex-wrap items-center gap-2">
+                <span className="rounded-full border border-yellow-500/30 bg-yellow-500/10 px-2 py-1 text-xs text-yellow-100">
+                  {card.proposal.riskLevel} risk
+                </span>
+                <span className="rounded-full border border-silicon-slate/70 px-2 py-1 text-xs text-muted-foreground">
+                  {card.proposal.approvalState.replace(/_/g, ' ')}
+                </span>
+                {card.notification.slackSentAt ? (
+                  <span className="rounded-full border border-green-500/30 bg-green-500/10 px-2 py-1 text-xs text-green-100">
+                    Slack notified
+                  </span>
+                ) : null}
+              </div>
+              <h3 className="font-semibold">{card.proposal.title}</h3>
+              <p className="mt-2 text-sm text-muted-foreground">{card.proposal.approvalQuestion}</p>
+              <div className="mt-3 grid gap-2 text-xs text-muted-foreground sm:grid-cols-2">
+                <SmallField label="Work item" value={card.workItem?.title ?? card.workItemId} />
+                <SmallField label="Requested" value={new Date(card.requestedAt).toLocaleString()} />
+              </div>
+              <div className="mt-4 flex flex-wrap gap-2">
+                <button
+                  onClick={() => onDecision(card, 'approved')}
+                  disabled={Boolean(actionId)}
+                  className="inline-flex items-center gap-2 rounded-lg border border-green-500/40 bg-green-500/10 px-3 py-2 text-sm text-green-100 hover:bg-green-500/15 disabled:opacity-50"
+                >
+                  <CheckCircle2 size={16} />
+                  Approve
+                </button>
+                <button
+                  onClick={() => onDecision(card, 'rejected')}
+                  disabled={Boolean(actionId)}
+                  className="inline-flex items-center gap-2 rounded-lg border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-100 hover:bg-red-500/15 disabled:opacity-50"
+                >
+                  <XCircle size={16} />
+                  Reject
+                </button>
+                <Link
+                  href={`/admin/agents/runs/${card.runId}`}
+                  className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 px-3 py-2 text-sm hover:border-radiant-gold/60"
+                >
+                  Evidence
+                  <ArrowRight size={16} />
+                </Link>
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
   )
 }
 

--- a/app/api/admin/agents/runs/[runId]/approval/route.test.ts
+++ b/app/api/admin/agents/runs/[runId]/approval/route.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   approvalUpdate: vi.fn(),
   eventInsert: vi.fn(),
   runUpdate: vi.fn(),
+  workItemUpdate: vi.fn(),
 }))
 
 vi.mock('@/lib/auth-server', () => ({
@@ -36,11 +37,11 @@ function eqChain<T>(result: T) {
   return { eq: firstEq }
 }
 
-function setupSupabase(existingMetadata: Record<string, unknown> = {}) {
+function setupSupabase(existingMetadata: Record<string, unknown> = {}, approvalType = 'send_email') {
   const existingSingle = vi.fn().mockResolvedValue({
     data: {
       id: 'approval-1',
-      approval_type: 'send_email',
+      approval_type: approvalType,
       metadata: existingMetadata,
     },
     error: null,
@@ -63,6 +64,9 @@ function setupSupabase(existingMetadata: Record<string, unknown> = {}) {
   mocks.runUpdate.mockImplementation(() => ({
     eq: vi.fn(() => ({ eq: vi.fn().mockResolvedValue({ data: null, error: null }) })),
   }))
+  mocks.workItemUpdate.mockImplementation(() => ({
+    eq: vi.fn().mockResolvedValue({ data: null, error: null }),
+  }))
   mocks.from.mockImplementation((table: string) => {
     if (table === 'agent_approvals') {
       return {
@@ -73,6 +77,7 @@ function setupSupabase(existingMetadata: Record<string, unknown> = {}) {
     }
     if (table === 'agent_run_events') return { insert: mocks.eventInsert }
     if (table === 'agent_runs') return { update: mocks.runUpdate }
+    if (table === 'agent_work_items') return { update: mocks.workItemUpdate }
     return {}
   })
 }
@@ -147,5 +152,25 @@ describe('POST /api/admin/agents/runs/[runId]/approval', () => {
     expect(response.status).toBe(404)
     expect(await response.json()).toEqual({ error: 'Approval not found' })
     expect(mocks.approvalUpdate).not.toHaveBeenCalled()
+  })
+
+  it('blocks rejected Vercel AutoResearch proposals instead of advancing them', async () => {
+    setupSupabase({
+      work_item_id: 'work-1',
+      proposal_id: 'next-build-profile',
+    }, 'vercel_deployment_research_proposal')
+
+    const response = await POST(makeRequest({
+      approval_id: 'approval-1',
+      status: 'rejected',
+      decision_notes: 'Not worth the deployment risk.',
+    }) as never, { params: { runId: 'run-1' } })
+
+    expect(response.status).toBe(200)
+    expect(mocks.workItemUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'blocked',
+      blocker_summary: 'Not worth the deployment risk.',
+      validation_summary: 'Not worth the deployment risk.',
+    }))
   })
 })

--- a/app/api/admin/agents/runs/[runId]/approval/route.ts
+++ b/app/api/admin/agents/runs/[runId]/approval/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
 import { AGENT_APPROVAL_STATUSES, type AgentApprovalStatus } from '@/lib/agent-run'
+import { VERCEL_RESEARCH_APPROVAL_TYPE } from '@/lib/vercel-deployment-research'
 
 export const dynamic = 'force-dynamic'
 
@@ -46,6 +47,8 @@ export async function POST(
 
   const decided = status !== 'pending'
   let approvalId = body.approval_id ?? null
+  let approvalType = body.approval_type ?? null
+  let approvalMetadata: Record<string, unknown> = body.metadata ?? {}
 
   if (approvalId) {
     const { data: existing, error: existingError } = await supabaseAdmin
@@ -64,6 +67,7 @@ export async function POST(
       existing.metadata && typeof existing.metadata === 'object'
         ? existing.metadata as Record<string, unknown>
         : {}
+    approvalType = existing.approval_type as string
     const decisionMetadata = decided
       ? {
           status,
@@ -78,6 +82,7 @@ export async function POST(
       ...(existingMetadata.action_payload ? { action_payload: existingMetadata.action_payload } : {}),
       ...(decisionMetadata ? { decision: decisionMetadata } : {}),
     }
+    approvalMetadata = mergedMetadata
 
     const { data, error } = await supabaseAdmin
       .from('agent_approvals')
@@ -99,6 +104,8 @@ export async function POST(
     }
     approvalId = data.id as string
   } else {
+    approvalType = body.approval_type as string
+    approvalMetadata = body.metadata ?? {}
     const { data, error } = await supabaseAdmin
       .from('agent_approvals')
       .insert({
@@ -125,7 +132,7 @@ export async function POST(
     run_id: params.runId,
     event_type: approvalId === body.approval_id ? 'approval_decided' : 'approval_recorded',
     severity: status === 'rejected' ? 'warning' : 'info',
-    message: `${body.approval_type ?? body.approval_id}: ${status}`,
+    message: `${approvalType ?? body.approval_id}: ${status}`,
     metadata: {
       approval_id: approvalId,
       status,
@@ -133,6 +140,25 @@ export async function POST(
       ...(body.metadata ?? {}),
     },
   })
+
+  const workItemId =
+    approvalType === VERCEL_RESEARCH_APPROVAL_TYPE && typeof approvalMetadata.work_item_id === 'string'
+      ? approvalMetadata.work_item_id
+      : null
+  if (workItemId && (status === 'approved' || status === 'rejected' || status === 'cancelled')) {
+    await supabaseAdmin
+      .from('agent_work_items')
+      .update({
+        status: status === 'approved' ? 'assigned' : 'blocked',
+        blocker_summary: status === 'approved' ? null : body.decision_notes ?? `Vercel AutoResearch proposal ${status}`,
+        validation_summary:
+          status === 'approved'
+            ? 'Vercel AutoResearch proposal approved for the next scoped research action. Merge and production deployment remain gated.'
+            : body.decision_notes ?? `Vercel AutoResearch proposal ${status}.`,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', workItemId)
+  }
 
   if (status === 'pending') {
     await supabaseAdmin

--- a/app/api/admin/agents/vercel-research/proposals/route.test.ts
+++ b/app/api/admin/agents/vercel-research/proposals/route.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  listPendingVercelResearchApprovals: vi.fn(),
+  createVercelResearchApproval: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/vercel-deployment-research-approvals', () => ({
+  listPendingVercelResearchApprovals: mocks.listPendingVercelResearchApprovals,
+  createVercelResearchApproval: mocks.createVercelResearchApproval,
+}))
+
+import { GET, POST } from './route'
+
+function request(body?: unknown) {
+  return new Request('http://localhost/api/admin/agents/vercel-research/proposals', {
+    method: body ? 'POST' : 'GET',
+    headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+    body: body ? JSON.stringify(body) : undefined,
+  })
+}
+
+const proposal = {
+  id: 'next-build-profile',
+  title: 'Profile build',
+  hypothesis: 'Find build bottlenecks.',
+  expectedImpact: 'Lower deployment research time.',
+  scorecardBaseline: {
+    project: 'portfolio',
+    target: 'preview',
+    queueSeconds: 10,
+    buildSeconds: 300,
+    totalSeconds: 310,
+  },
+  touchedFiles: ['package.json'],
+  touchedSettings: [],
+  riskLevel: 'low',
+  approvalState: 'not_required',
+  approvalQuestion: 'Approve the build-profile experiment?',
+  rollbackPath: 'Discard the branch.',
+  evidence: ['build=5m00s'],
+}
+
+describe('/api/admin/agents/vercel-research/proposals', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.listPendingVercelResearchApprovals.mockResolvedValue([{ approvalId: 'approval-1' }])
+    mocks.createVercelResearchApproval.mockResolvedValue({
+      workItem: { id: 'work-1' },
+      approvalId: 'approval-1',
+      runId: 'run-1',
+      notification: { sent: true },
+    })
+  })
+
+  it('lists pending AutoResearch approvals', async () => {
+    const response = await GET(request() as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ ok: true, approvals: [{ approvalId: 'approval-1' }] })
+  })
+
+  it('creates a proposal approval packet for the current admin', async () => {
+    const response = await POST(request({ proposal }) as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({ ok: true, approvalId: 'approval-1' })
+    expect(mocks.createVercelResearchApproval).toHaveBeenCalledWith({
+      proposal,
+      createdByUserId: 'admin-user',
+    })
+  })
+
+  it('rejects malformed proposal packets', async () => {
+    const response = await POST(request({ proposal: { id: 'missing-title' } }) as never)
+
+    expect(response.status).toBe(400)
+    expect(mocks.createVercelResearchApproval).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/admin/agents/vercel-research/proposals/route.ts
+++ b/app/api/admin/agents/vercel-research/proposals/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import {
+  createVercelResearchApproval,
+  listPendingVercelResearchApprovals,
+} from '@/lib/vercel-deployment-research-approvals'
+import type { VercelResearchProposal } from '@/lib/vercel-deployment-research'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  try {
+    const approvals = await listPendingVercelResearchApprovals()
+    return NextResponse.json({ ok: true, approvals })
+  } catch (error) {
+    console.error('[vercel-research-proposals] list failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to list Vercel AutoResearch proposals' },
+      { status: 500 },
+    )
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as {
+    proposal?: VercelResearchProposal
+  }
+  if (!body.proposal?.id || !body.proposal.title || !body.proposal.approvalQuestion) {
+    return NextResponse.json({ error: 'proposal id, title, and approvalQuestion are required' }, { status: 400 })
+  }
+
+  try {
+    const result = await createVercelResearchApproval({
+      proposal: body.proposal,
+      createdByUserId: auth.user.id,
+    })
+    return NextResponse.json({ ok: true, ...result })
+  } catch (error) {
+    console.error('[vercel-research-proposals] create failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to create Vercel AutoResearch proposal' },
+      { status: 500 },
+    )
+  }
+}

--- a/docs/vercel-deployment-autoresearch.md
+++ b/docs/vercel-deployment-autoresearch.md
@@ -1,0 +1,59 @@
+# Vercel Deployment AutoResearch
+
+Use this workflow to turn Vercel build/deployment performance work into bounded
+research proposals with a visible approval gate.
+
+## Operating Model
+
+V1 is planning and approval only. It does not run autonomous experiments, merge
+branches, or change hosted Vercel settings.
+
+```bash
+npm run deploy:metrics -- --json
+npm run deploy:research:plan
+npm run deploy:research:plan -- --json
+```
+
+The planner uses the current deployment metrics scorecard to propose focused
+experiments. A proposal becomes actionable only after it is routed into Agent
+Coordination as a pending `vercel_deployment_research_proposal` approval.
+
+## Approval Gate
+
+Approval packets must include:
+
+- proposal title,
+- hypothesis,
+- expected impact,
+- scorecard baseline,
+- touched files or hosted settings,
+- risk level,
+- rollback path,
+- explicit approval question.
+
+Approving a proposal authorizes only the next scoped research action. It does
+not authorize merge, production deployment, or Vercel hosted configuration
+changes. Rejected proposals are marked blocked in Agent Coordination.
+
+## Notifications
+
+Proposal-ready notifications are event-driven. There is no schedule.
+
+- Destination: Slack Agent Ops via `SLACK_AGENT_OPS_WEBHOOK_URL`.
+- Trigger: first creation of a pending Vercel AutoResearch approval.
+- Idempotency: the approval metadata records whether Slack was sent or skipped,
+  so resubmitting the same proposal does not spam Slack.
+- Fallback: if the webhook is absent, the approval still appears in Agent
+  Coordination and the notification is marked skipped.
+
+## Boundaries
+
+- Agent Ops owns traces, artifacts, and approval state.
+- Agent Coordination is the visible review surface.
+- Integration Captain still owns merge and deployment sequencing.
+- Technology Bakeoff owns vendor, runtime, or provider promotion decisions.
+- Open Brain may receive approved summaries later, but it is not the execution
+  engine, approval source of truth, or notification service.
+- Vercel project settings, env vars, build commands, ignored build steps,
+  branch protection, domains, log drains, and provider integrations remain
+  separate production-config approval gates.

--- a/lib/vercel-autoresearch-notification.test.ts
+++ b/lib/vercel-autoresearch-notification.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  buildVercelResearchApprovalSlackText,
+  buildVercelResearchApprovalUrl,
+  notifyVercelResearchApprovalReady,
+} from './vercel-autoresearch-notification'
+import type { VercelResearchProposal } from './vercel-deployment-research'
+
+const proposal: VercelResearchProposal = {
+  id: 'next-build-profile',
+  title: 'Profile the Next.js build path',
+  hypothesis: 'Build profiling can identify the slowest local step.',
+  expectedImpact: 'Lower build investigation time.',
+  scorecardBaseline: {
+    project: 'portfolio',
+    target: 'preview',
+    queueSeconds: 10,
+    buildSeconds: 300,
+    totalSeconds: 310,
+  },
+  touchedFiles: ['package.json'],
+  touchedSettings: [],
+  riskLevel: 'low',
+  approvalState: 'not_required',
+  approvalQuestion: 'Approve the build profile experiment?',
+  rollbackPath: 'Discard the branch.',
+  evidence: ['build=5m00s'],
+}
+
+describe('Vercel AutoResearch Slack notifications', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
+  it('builds a direct Agent Coordination approval URL and Slack message', () => {
+    vi.stubEnv('NEXT_PUBLIC_BASE_URL', 'https://portfolio.example.com/')
+
+    expect(buildVercelResearchApprovalUrl({ runId: 'run-1' })).toBe(
+      'https://portfolio.example.com/admin/agents/coordination?approvalRunId=run-1'
+    )
+    expect(buildVercelResearchApprovalSlackText({
+      approvalId: 'approval-1',
+      runId: 'run-1',
+      workItemId: 'work-1',
+      proposal,
+    })).toContain('*Proposal:* Profile the Next.js build path')
+  })
+
+  it('skips safely when Slack Agent Ops webhook is not configured', async () => {
+    await expect(notifyVercelResearchApprovalReady({
+      approvalId: 'approval-1',
+      runId: 'run-1',
+      workItemId: 'work-1',
+      proposal,
+    })).resolves.toBe(false)
+  })
+
+  it('sends to the Slack Agent Ops webhook when configured', async () => {
+    vi.stubEnv('SLACK_AGENT_OPS_WEBHOOK_URL', 'https://hooks.slack.test/agent-ops')
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(notifyVercelResearchApprovalReady({
+      approvalId: 'approval-1',
+      runId: 'run-1',
+      workItemId: 'work-1',
+      proposal,
+    })).resolves.toBe(true)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://hooks.slack.test/agent-ops',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('Profile the Next.js build path'),
+      })
+    )
+  })
+})

--- a/lib/vercel-autoresearch-notification.ts
+++ b/lib/vercel-autoresearch-notification.ts
@@ -1,0 +1,61 @@
+import type { VercelResearchProposal } from './vercel-deployment-research'
+
+export type VercelResearchApprovalNotificationInput = {
+  approvalId: string
+  runId: string
+  workItemId: string
+  proposal: VercelResearchProposal
+}
+
+function baseUrl() {
+  return (
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    process.env.PORTFOLIO_BASE_URL ||
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    'https://amadutown.com'
+  ).replace(/\/$/, '')
+}
+
+export function buildVercelResearchApprovalUrl(input: Pick<VercelResearchApprovalNotificationInput, 'runId'>) {
+  return `${baseUrl()}/admin/agents/coordination?approvalRunId=${encodeURIComponent(input.runId)}`
+}
+
+export function buildVercelResearchApprovalSlackText(input: VercelResearchApprovalNotificationInput) {
+  const proposal = input.proposal
+  const url = buildVercelResearchApprovalUrl(input)
+  return [
+    '*Vercel AutoResearch proposal ready for approval*',
+    `*Proposal:* ${proposal.title}`,
+    `*Risk:* ${proposal.riskLevel}`,
+    `*Approval:* ${proposal.approvalQuestion}`,
+    `*Expected impact:* ${proposal.expectedImpact}`,
+    `*Work item:* ${input.workItemId}`,
+    `*Approve / reject:* ${url}`,
+  ].join('\n')
+}
+
+export async function notifyVercelResearchApprovalReady(
+  input: VercelResearchApprovalNotificationInput,
+): Promise<boolean> {
+  const webhookUrl = process.env.SLACK_AGENT_OPS_WEBHOOK_URL
+  if (!webhookUrl || !webhookUrl.startsWith('https://')) return false
+
+  try {
+    const response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: buildVercelResearchApprovalSlackText(input) }),
+    })
+    if (!response.ok) {
+      console.warn('[vercel-autoresearch-notification] Slack webhook failed:', response.status)
+      return false
+    }
+    return true
+  } catch (error) {
+    console.warn(
+      '[vercel-autoresearch-notification] Slack webhook error:',
+      error instanceof Error ? error.message : error,
+    )
+    return false
+  }
+}

--- a/lib/vercel-deployment-research-approvals.test.ts
+++ b/lib/vercel-deployment-research-approvals.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { VercelResearchProposal } from './vercel-deployment-research'
+
+const mocks = vi.hoisted(() => ({
+  createAgentWorkItem: vi.fn(),
+  recordAgentEvent: vi.fn(),
+  notify: vi.fn(),
+  from: vi.fn(),
+  approvalInsert: vi.fn(),
+  approvalUpdate: vi.fn(),
+  workItemUpdate: vi.fn(),
+  runUpdate: vi.fn(),
+}))
+
+vi.mock('./agent-work-items', () => ({
+  createAgentWorkItem: mocks.createAgentWorkItem,
+}))
+
+vi.mock('./agent-run', () => ({
+  recordAgentEvent: mocks.recordAgentEvent,
+}))
+
+vi.mock('./vercel-autoresearch-notification', () => ({
+  notifyVercelResearchApprovalReady: mocks.notify,
+}))
+
+vi.mock('./supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import { createVercelResearchApproval } from './vercel-deployment-research-approvals'
+
+const proposal: VercelResearchProposal = {
+  id: 'next-build-profile',
+  title: 'Profile build',
+  hypothesis: 'Build profiling can find the slow path.',
+  expectedImpact: 'Better deployment research focus.',
+  scorecardBaseline: {
+    project: 'portfolio',
+    target: 'preview',
+    queueSeconds: 10,
+    buildSeconds: 300,
+    totalSeconds: 310,
+  },
+  touchedFiles: ['package.json'],
+  touchedSettings: [],
+  riskLevel: 'low',
+  approvalState: 'not_required',
+  approvalQuestion: 'Approve the build-profile experiment?',
+  rollbackPath: 'Discard the branch.',
+  evidence: ['build=5m00s'],
+}
+
+function updateEqChain() {
+  return { eq: vi.fn(() => ({ in: vi.fn().mockResolvedValue({ data: null, error: null }) })) }
+}
+
+function setupNewApproval() {
+  const single = vi.fn().mockResolvedValue({
+    data: {
+      id: 'approval-1',
+      run_id: 'run-1',
+      status: 'pending',
+      requested_at: '2026-05-11T12:00:00.000Z',
+      metadata: {
+        work_item_id: 'work-1',
+        proposal_id: proposal.id,
+        proposal,
+      },
+    },
+    error: null,
+  })
+  mocks.approvalInsert.mockReturnValue({ select: vi.fn(() => ({ single })) })
+  mocks.approvalUpdate.mockReturnValue({ eq: vi.fn().mockResolvedValue({ data: null, error: null }) })
+  mocks.workItemUpdate.mockReturnValue({ eq: vi.fn().mockResolvedValue({ data: null, error: null }) })
+  mocks.runUpdate.mockReturnValue(updateEqChain())
+  mocks.from.mockImplementation((table: string) => {
+    if (table === 'agent_approvals') {
+      return {
+        insert: mocks.approvalInsert,
+        update: mocks.approvalUpdate,
+      }
+    }
+    if (table === 'agent_work_items') return { update: mocks.workItemUpdate }
+    if (table === 'agent_runs') return { update: mocks.runUpdate }
+    return {}
+  })
+}
+
+function setupExistingApproval() {
+  const maybeSingle = vi.fn().mockResolvedValue({
+    data: {
+      id: 'approval-1',
+      run_id: 'run-1',
+      status: 'pending',
+      requested_at: '2026-05-11T12:00:00.000Z',
+      metadata: {
+        work_item_id: 'work-1',
+        proposal_id: proposal.id,
+        proposal,
+        notification: { slack_agent_ops_sent_at: '2026-05-11T12:01:00.000Z' },
+      },
+    },
+    error: null,
+  })
+  mocks.from.mockImplementation((table: string) => {
+    if (table === 'agent_approvals') {
+      return {
+        select: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle })) })),
+      }
+    }
+    return {}
+  })
+}
+
+describe('createVercelResearchApproval', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.recordAgentEvent.mockResolvedValue({ id: 'event-1' })
+    mocks.notify.mockResolvedValue(true)
+  })
+
+  it('creates one pending approval and dispatches one notification intent', async () => {
+    mocks.createAgentWorkItem.mockResolvedValue({
+      id: 'work-1',
+      active_run_id: 'run-1',
+      approval_id: null,
+    })
+    setupNewApproval()
+
+    await expect(createVercelResearchApproval({
+      proposal,
+      createdByUserId: 'admin-user',
+    })).resolves.toMatchObject({
+      approvalId: 'approval-1',
+      runId: 'run-1',
+      notification: { sent: true },
+    })
+
+    expect(mocks.approvalInsert).toHaveBeenCalledWith(expect.objectContaining({
+      approval_type: 'vercel_deployment_research_proposal',
+      status: 'pending',
+      metadata: expect.objectContaining({
+        proposal_id: 'next-build-profile',
+        action_payload: expect.objectContaining({ executes_action: false }),
+      }),
+    }))
+    expect(mocks.notify).toHaveBeenCalledTimes(1)
+    expect(mocks.approvalUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      metadata: expect.objectContaining({
+        notification: expect.objectContaining({
+          slack_agent_ops_sent_at: expect.any(String),
+        }),
+      }),
+    }))
+  })
+
+  it('does not resend when a duplicate proposal already has notification metadata', async () => {
+    mocks.createAgentWorkItem.mockResolvedValue({
+      id: 'work-1',
+      active_run_id: 'run-1',
+      approval_id: 'approval-1',
+    })
+    setupExistingApproval()
+
+    await expect(createVercelResearchApproval({
+      proposal,
+      createdByUserId: 'admin-user',
+    })).resolves.toMatchObject({
+      approvalId: 'approval-1',
+      notification: { sent: true },
+    })
+
+    expect(mocks.notify).not.toHaveBeenCalled()
+  })
+})

--- a/lib/vercel-deployment-research-approvals.ts
+++ b/lib/vercel-deployment-research-approvals.ts
@@ -1,0 +1,254 @@
+import { recordAgentEvent } from './agent-run'
+import { createAgentWorkItem, type AgentWorkItem } from './agent-work-items'
+import { supabaseAdmin } from './supabase'
+import {
+  VERCEL_RESEARCH_APPROVAL_TYPE,
+  type VercelResearchProposal,
+} from './vercel-deployment-research'
+import { notifyVercelResearchApprovalReady } from './vercel-autoresearch-notification'
+
+export type VercelResearchApprovalCard = {
+  approvalId: string
+  runId: string
+  workItemId: string
+  status: string
+  requestedAt: string
+  proposal: VercelResearchProposal
+  notification: {
+    slackSentAt: string | null
+    slackSkippedAt: string | null
+  }
+  workItem: Pick<AgentWorkItem, 'id' | 'title' | 'status' | 'active_run_id' | 'approval_id' | 'updated_at'> | null
+}
+
+type ApprovalRow = {
+  id: string
+  run_id: string
+  status: string
+  requested_at: string
+  metadata: Record<string, unknown> | null
+}
+
+function db() {
+  if (!supabaseAdmin) throw new Error('Database not available')
+  return supabaseAdmin
+}
+
+function proposalFromMetadata(metadata: Record<string, unknown> | null): VercelResearchProposal | null {
+  const proposal = metadata?.proposal
+  if (!proposal || typeof proposal !== 'object') return null
+  return proposal as VercelResearchProposal
+}
+
+function stringMetadata(metadata: Record<string, unknown> | null, key: string) {
+  const value = metadata?.[key]
+  return typeof value === 'string' && value.trim() ? value : null
+}
+
+function notificationMetadata(metadata: Record<string, unknown> | null) {
+  const notification = metadata?.notification
+  if (!notification || typeof notification !== 'object') {
+    return { slackSentAt: null, slackSkippedAt: null }
+  }
+  const record = notification as Record<string, unknown>
+  return {
+    slackSentAt: typeof record.slack_agent_ops_sent_at === 'string' ? record.slack_agent_ops_sent_at : null,
+    slackSkippedAt: typeof record.slack_agent_ops_skipped_at === 'string' ? record.slack_agent_ops_skipped_at : null,
+  }
+}
+
+async function getApproval(approvalId: string): Promise<ApprovalRow | null> {
+  const { data, error } = await db()
+    .from('agent_approvals')
+    .select('id, run_id, status, requested_at, metadata')
+    .eq('id', approvalId)
+    .maybeSingle()
+
+  if (error) throw new Error(`Failed to read AutoResearch approval: ${error.message}`)
+  return data as ApprovalRow | null
+}
+
+async function notifyApprovalOnce(approval: ApprovalRow, workItemId: string, proposal: VercelResearchProposal) {
+  const metadata = approval.metadata ?? {}
+  const notification = notificationMetadata(metadata)
+  if (notification.slackSentAt || notification.slackSkippedAt) {
+    return { sent: Boolean(notification.slackSentAt), skipped: Boolean(notification.slackSkippedAt) }
+  }
+
+  const sent = await notifyVercelResearchApprovalReady({
+    approvalId: approval.id,
+    runId: approval.run_id,
+    workItemId,
+    proposal,
+  })
+  const now = new Date().toISOString()
+  const nextMetadata = {
+    ...metadata,
+    notification: {
+      ...(typeof metadata.notification === 'object' && metadata.notification ? metadata.notification : {}),
+      ...(sent ? { slack_agent_ops_sent_at: now } : { slack_agent_ops_skipped_at: now }),
+    },
+  }
+
+  await db()
+    .from('agent_approvals')
+    .update({ metadata: nextMetadata })
+    .eq('id', approval.id)
+
+  return { sent, skipped: !sent }
+}
+
+export async function createVercelResearchApproval(input: {
+  proposal: VercelResearchProposal
+  createdByUserId: string
+}) {
+  const proposal = input.proposal
+  const workItem = await createAgentWorkItem({
+    title: proposal.title,
+    objective: [
+      proposal.hypothesis,
+      '',
+      `Expected impact: ${proposal.expectedImpact}`,
+      `Approval question: ${proposal.approvalQuestion}`,
+    ].join('\n'),
+    priority: proposal.riskLevel === 'high' ? 'high' : 'medium',
+    status: 'queued',
+    ownerAgentKey: 'integration-captain',
+    ownerRuntime: 'codex',
+    source: {
+      type: 'vercel_deployment_research',
+      id: proposal.id,
+      label: 'Vercel AutoResearch',
+    },
+    expectedFiles: proposal.touchedFiles,
+    overlapGroup: 'vercel-deployment-research',
+    metadata: {
+      vercel_research: true,
+      proposal,
+      approval_type: VERCEL_RESEARCH_APPROVAL_TYPE,
+      created_by_user_id: input.createdByUserId,
+    },
+    idempotencyKey: `vercel-autoresearch:${proposal.id}`,
+  })
+
+  if (!workItem.active_run_id) {
+    throw new Error('Vercel AutoResearch work item did not create an active run')
+  }
+
+  let approval = workItem.approval_id ? await getApproval(workItem.approval_id) : null
+  if (!approval) {
+    const { data, error } = await db()
+      .from('agent_approvals')
+      .insert({
+        run_id: workItem.active_run_id,
+        approval_type: VERCEL_RESEARCH_APPROVAL_TYPE,
+        status: 'pending',
+        requested_by_agent_key: 'integration-captain',
+        metadata: {
+          work_item_id: workItem.id,
+          proposal_id: proposal.id,
+          proposal,
+          approval_question: proposal.approvalQuestion,
+          action_payload: {
+            action: 'authorize_vercel_deployment_research',
+            approval_type: VERCEL_RESEARCH_APPROVAL_TYPE,
+            proposal_id: proposal.id,
+            executes_action: false,
+          },
+        },
+      })
+      .select('id, run_id, status, requested_at, metadata')
+      .single()
+
+    if (error || !data?.id) {
+      throw new Error(error?.message ?? 'Failed to create Vercel AutoResearch approval')
+    }
+    approval = data as ApprovalRow
+
+    await db()
+      .from('agent_work_items')
+      .update({
+        status: 'ready_for_review',
+        approval_id: approval.id,
+        validation_summary: 'Vercel AutoResearch proposal packet is ready for approval.',
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', workItem.id)
+
+    await db()
+      .from('agent_runs')
+      .update({
+        status: 'waiting_for_approval',
+        current_step: `Approval required: ${VERCEL_RESEARCH_APPROVAL_TYPE}`,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', workItem.active_run_id)
+      .in('status', ['queued', 'running'])
+
+    await recordAgentEvent({
+      runId: workItem.active_run_id,
+      eventType: 'vercel_autoresearch_approval_created',
+      severity: 'info',
+      message: proposal.approvalQuestion,
+      metadata: {
+        approval_id: approval.id,
+        work_item_id: workItem.id,
+        proposal_id: proposal.id,
+      },
+      idempotencyKey: `${workItem.id}:vercel-autoresearch-approval-created`,
+    }).catch(() => {})
+  }
+
+  const notification = await notifyApprovalOnce(approval, workItem.id, proposal)
+
+  return {
+    workItem,
+    approvalId: approval.id,
+    runId: approval.run_id,
+    notification,
+  }
+}
+
+export async function listPendingVercelResearchApprovals(): Promise<VercelResearchApprovalCard[]> {
+  const { data, error } = await db()
+    .from('agent_approvals')
+    .select('id, run_id, status, requested_at, metadata')
+    .eq('approval_type', VERCEL_RESEARCH_APPROVAL_TYPE)
+    .eq('status', 'pending')
+    .order('requested_at', { ascending: false })
+    .limit(20)
+
+  if (error) throw new Error(`Failed to list Vercel AutoResearch approvals: ${error.message}`)
+  const approvals = (data ?? []) as ApprovalRow[]
+  const workItemIds = approvals
+    .map((approval) => stringMetadata(approval.metadata, 'work_item_id'))
+    .filter((id): id is string => Boolean(id))
+
+  let workItems = new Map<string, AgentWorkItem>()
+  if (workItemIds.length > 0) {
+    const { data: itemRows, error: itemError } = await db()
+      .from('agent_work_items')
+      .select('id, title, status, active_run_id, approval_id, updated_at')
+      .in('id', workItemIds)
+
+    if (itemError) throw new Error(`Failed to list Vercel AutoResearch work items: ${itemError.message}`)
+    workItems = new Map((itemRows ?? []).map((item: unknown) => [(item as AgentWorkItem).id, item as AgentWorkItem]))
+  }
+
+  return approvals.flatMap((approval) => {
+    const proposal = proposalFromMetadata(approval.metadata)
+    const workItemId = stringMetadata(approval.metadata, 'work_item_id')
+    if (!proposal || !workItemId) return []
+    const notification = notificationMetadata(approval.metadata)
+    return [{
+      approvalId: approval.id,
+      runId: approval.run_id,
+      workItemId,
+      status: approval.status,
+      requestedAt: approval.requested_at,
+      proposal,
+      notification,
+      workItem: workItems.get(workItemId) ?? null,
+    }]
+  })
+}

--- a/lib/vercel-deployment-research.test.ts
+++ b/lib/vercel-deployment-research.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildVercelResearchPlan,
+  requiresVercelProductionConfigApproval,
+  type VercelResearchProposal,
+} from './vercel-deployment-research'
+import type { DeploymentMetric } from './vercel-deployment-metrics'
+
+function metric(overrides: Partial<DeploymentMetric> = {}): DeploymentMetric {
+  return {
+    project: 'portfolio',
+    state: 'READY',
+    target: 'preview',
+    ref: 'main',
+    pr: '193',
+    url: 'portfolio-preview.vercel.app',
+    queueSeconds: 40,
+    buildSeconds: 210,
+    totalSeconds: 250,
+    ...overrides,
+  }
+}
+
+describe('buildVercelResearchPlan', () => {
+  it('creates a planning-only profile proposal from deployment metrics', () => {
+    const plan = buildVercelResearchPlan({
+      generatedAt: '2026-05-11T12:00:00.000Z',
+      metrics: [metric()],
+    })
+
+    expect(plan.approvalType).toBe('vercel_deployment_research_proposal')
+    expect(plan.proposals[0]).toMatchObject({
+      id: 'next-build-profile',
+      riskLevel: 'low',
+      approvalState: 'not_required',
+    })
+    expect(plan.operatingRules.join(' ')).toContain('does not execute experiments automatically')
+  })
+
+  it('marks production config proposal candidates as approval-required', () => {
+    const plan = buildVercelResearchPlan({
+      metrics: [
+        metric({
+          project: 'portfolio-staging',
+          queueSeconds: 650,
+          buildSeconds: 180,
+          totalSeconds: 830,
+        }),
+      ],
+    })
+
+    expect(plan.findings.map((finding) => finding.reason)).toContain('queue=10m50s')
+    expect(plan.proposals.find((proposal) => proposal.id === 'vercel-queue-config-review')).toMatchObject({
+      riskLevel: 'high',
+      approvalState: 'approval_required',
+      touchedSettings: expect.arrayContaining(['Vercel project preview deployment setting']),
+    })
+  })
+})
+
+describe('requiresVercelProductionConfigApproval', () => {
+  it('detects hosted deployment settings as approval-gated', () => {
+    const proposal = {
+      touchedSettings: ['Vercel project preview deployment setting'],
+    } satisfies Pick<VercelResearchProposal, 'touchedSettings'>
+
+    expect(requiresVercelProductionConfigApproval(proposal)).toBe(true)
+    expect(requiresVercelProductionConfigApproval({ touchedSettings: [] })).toBe(false)
+  })
+})

--- a/lib/vercel-deployment-research.ts
+++ b/lib/vercel-deployment-research.ts
@@ -1,0 +1,201 @@
+import {
+  DEFAULT_DEPLOYMENT_METRIC_THRESHOLDS,
+  collectDeploymentFindings,
+  formatSeconds,
+  summarizeDeploymentMetrics,
+  type DeploymentMetric,
+  type DeploymentMetricThresholds,
+  type MetricFinding,
+  type MetricSummary,
+} from './vercel-deployment-metrics'
+
+export const VERCEL_RESEARCH_APPROVAL_TYPE = 'vercel_deployment_research_proposal'
+
+export type VercelResearchRiskLevel = 'low' | 'medium' | 'high'
+export type VercelResearchApprovalState = 'not_required' | 'approval_required'
+
+export type VercelResearchProposal = {
+  id: string
+  title: string
+  hypothesis: string
+  expectedImpact: string
+  scorecardBaseline: {
+    project: string
+    target: string
+    queueSeconds: number | null
+    buildSeconds: number | null
+    totalSeconds: number | null
+  }
+  touchedFiles: string[]
+  touchedSettings: string[]
+  riskLevel: VercelResearchRiskLevel
+  approvalState: VercelResearchApprovalState
+  approvalQuestion: string
+  rollbackPath: string
+  evidence: string[]
+}
+
+export type VercelResearchPlan = {
+  generatedAt: string
+  approvalType: typeof VERCEL_RESEARCH_APPROVAL_TYPE
+  thresholds: DeploymentMetricThresholds
+  summaries: MetricSummary[]
+  findings: MetricFinding[]
+  proposals: VercelResearchProposal[]
+  operatingRules: string[]
+}
+
+export type VercelResearchPlanInput = {
+  metrics: DeploymentMetric[]
+  thresholds?: DeploymentMetricThresholds
+  generatedAt?: string
+}
+
+export function requiresVercelProductionConfigApproval(proposal: Pick<VercelResearchProposal, 'touchedSettings'>) {
+  return proposal.touchedSettings.some((setting) =>
+    /vercel project|environment variable|env var|build command|ignored build step|preview deployment|branch protection|domain|log drain|provider integration/i.test(setting)
+  )
+}
+
+function highestTotalMetric(metrics: DeploymentMetric[]) {
+  return [...metrics]
+    .filter((metric) => metric.totalSeconds !== null)
+    .sort((a, b) => (b.totalSeconds ?? 0) - (a.totalSeconds ?? 0))[0] ?? null
+}
+
+function highestBuildMetric(metrics: DeploymentMetric[]) {
+  return [...metrics]
+    .filter((metric) => metric.buildSeconds !== null)
+    .sort((a, b) => (b.buildSeconds ?? 0) - (a.buildSeconds ?? 0))[0] ?? null
+}
+
+function metricBaseline(metric: DeploymentMetric | null): VercelResearchProposal['scorecardBaseline'] {
+  return {
+    project: metric?.project ?? 'portfolio',
+    target: metric?.target ?? 'preview',
+    queueSeconds: metric?.queueSeconds ?? null,
+    buildSeconds: metric?.buildSeconds ?? null,
+    totalSeconds: metric?.totalSeconds ?? null,
+  }
+}
+
+function timingEvidence(metric: DeploymentMetric | null) {
+  if (!metric) return ['No deployment metrics were available; establish a baseline before running experiments.']
+  return [
+    `${metric.project}/${metric.target} ${metric.state}`,
+    `queue ${formatSeconds(metric.queueSeconds)}`,
+    `build ${formatSeconds(metric.buildSeconds)}`,
+    `total ${formatSeconds(metric.totalSeconds)}`,
+    `deployment ${metric.url}`,
+  ]
+}
+
+function proposal(
+  input: Omit<VercelResearchProposal, 'approvalState'>,
+): VercelResearchProposal {
+  const draft = { ...input, approvalState: 'not_required' as const }
+  return {
+    ...draft,
+    approvalState: requiresVercelProductionConfigApproval(draft) ? 'approval_required' : 'not_required',
+  }
+}
+
+export function buildVercelResearchPlan(input: VercelResearchPlanInput): VercelResearchPlan {
+  const thresholds = input.thresholds ?? DEFAULT_DEPLOYMENT_METRIC_THRESHOLDS
+  const summaries = summarizeDeploymentMetrics(input.metrics)
+  const findings = collectDeploymentFindings(input.metrics, thresholds)
+  const slowestTotal = highestTotalMetric(input.metrics)
+  const slowestBuild = highestBuildMetric(input.metrics)
+
+  const proposals: VercelResearchProposal[] = [
+    proposal({
+      id: 'next-build-profile',
+      title: 'Profile the Next.js build path before changing deployment settings',
+      hypothesis: 'A focused build-profile pass can identify whether build time is coming from app compilation, generated knowledge, tests, or static asset work before any hosted settings are changed.',
+      expectedImpact: 'Create a lower-risk experiment queue and avoid guessing at Vercel project settings.',
+      scorecardBaseline: metricBaseline(slowestBuild),
+      touchedFiles: ['package.json', 'scripts/build-chatbot-knowledge.ts', 'next.config.js'],
+      touchedSettings: [],
+      riskLevel: 'low',
+      approvalQuestion: 'Approve a read-only/local build-profile experiment that does not change production Vercel configuration?',
+      rollbackPath: 'Discard the experiment branch if build timing does not improve or the profile adds noisy instrumentation.',
+      evidence: timingEvidence(slowestBuild),
+    }),
+  ]
+
+  if (findings.some((finding) => finding.reason.includes('queue='))) {
+    proposals.push(proposal({
+      id: 'vercel-queue-config-review',
+      title: 'Review Vercel queue pressure before changing project settings',
+      hypothesis: 'Queue pressure may be reduced by adjusting preview deployment policy or build concurrency, but those hosted settings are production-adjacent and need explicit approval.',
+      expectedImpact: 'Reduce integration-captain waiting time when queue findings repeat across sweeps.',
+      scorecardBaseline: metricBaseline(slowestTotal),
+      touchedFiles: ['docs/vercel-deployment-runbook.md'],
+      touchedSettings: ['Vercel project preview deployment setting', 'Vercel build concurrency or plan setting'],
+      riskLevel: 'high',
+      approvalQuestion: 'Approve preparing a Vercel project-setting proposal packet without applying any hosted setting yet?',
+      rollbackPath: 'Leave current Vercel project settings unchanged and continue using deploy:watch plus deploy:metrics.',
+      evidence: findings.filter((finding) => finding.reason.includes('queue=')).map((finding) => `${finding.project}/${finding.target}: ${finding.reason}`),
+    }))
+  }
+
+  return {
+    generatedAt: input.generatedAt ?? new Date().toISOString(),
+    approvalType: VERCEL_RESEARCH_APPROVAL_TYPE,
+    thresholds,
+    summaries,
+    findings,
+    proposals,
+    operatingRules: [
+      'AutoResearch V1 is planning/proposal oriented; it does not execute experiments automatically.',
+      'Approval authorizes only the next scoped research action, not merge or production deployment.',
+      'Vercel project settings, env vars, build commands, branch protection, log drains, and provider integrations remain explicit approval gates.',
+      'Open Brain may receive approved summaries only; Agent Ops remains the approval and trace surface.',
+    ],
+  }
+}
+
+export function formatVercelResearchPlanMarkdown(plan: VercelResearchPlan) {
+  const lines = [
+    '# Vercel Deployment AutoResearch Plan',
+    '',
+    `Generated: ${plan.generatedAt}`,
+    `Approval type: ${plan.approvalType}`,
+    '',
+    '## Timing Summary',
+    '',
+    ...(
+      plan.summaries.length
+        ? plan.summaries.map((summary) => `- ${summary.project}/${summary.target}: avg build ${formatSeconds(Math.round(summary.averageBuildSeconds))}, avg total ${formatSeconds(Math.round(summary.averageTotalSeconds))}, max total ${formatSeconds(summary.maxTotalSeconds)}`)
+        : ['- No ready deployment timing summaries were available.']
+    ),
+    '',
+    '## Findings',
+    '',
+    ...(
+      plan.findings.length
+        ? plan.findings.map((finding) => `- ${finding.severity}: ${finding.project}/${finding.target} ${finding.reason}`)
+        : ['- No queue/build timing findings crossed the configured thresholds.']
+    ),
+    '',
+    '## Proposals',
+    '',
+    ...plan.proposals.flatMap((item) => [
+      `### ${item.title}`,
+      '',
+      `- ID: ${item.id}`,
+      `- Risk: ${item.riskLevel}`,
+      `- Approval: ${item.approvalState}`,
+      `- Hypothesis: ${item.hypothesis}`,
+      `- Expected impact: ${item.expectedImpact}`,
+      `- Approval question: ${item.approvalQuestion}`,
+      `- Rollback: ${item.rollbackPath}`,
+      `- Evidence: ${item.evidence.join('; ')}`,
+      '',
+    ]),
+    '## Operating Rules',
+    '',
+    ...plan.operatingRules.map((rule) => `- ${rule}`),
+  ]
+  return lines.join('\n')
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "deploy:watch": "tsx scripts/vercel-deployment-watch.ts",
     "deploy:watch:once": "tsx scripts/vercel-deployment-watch.ts --once",
     "deploy:metrics": "tsx scripts/vercel-deployment-metrics.ts",
+    "deploy:research:plan": "tsx scripts/vercel-deployment-research-plan.ts",
     "git:hygiene:report": "tsx scripts/git-hygiene-report.ts",
     "open-brain:mcp": "tsx scripts/open-brain-mcp-server.ts",
     "wrm:smoke-gate": "tsx scripts/wrm-production-smoke-gate.ts",

--- a/scripts/vercel-deployment-research-plan.ts
+++ b/scripts/vercel-deployment-research-plan.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env tsx
+import { spawnSync } from 'node:child_process'
+import {
+  buildVercelResearchPlan,
+  formatVercelResearchPlanMarkdown,
+  type VercelResearchPlan,
+} from '../lib/vercel-deployment-research'
+import type { DeploymentMetric } from '../lib/vercel-deployment-metrics'
+
+type MetricsOutput = {
+  metrics?: DeploymentMetric[]
+}
+
+export function parseArgs(argv: string[]) {
+  const options = {
+    json: false,
+    limit: 20,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    const next = argv[index + 1]
+
+    if (arg === '--json') {
+      options.json = true
+    } else if (arg === '--limit' && next) {
+      options.limit = Number(next)
+      index += 1
+    } else if (arg === '--help' || arg === '-h') {
+      console.log(`Usage:
+  npm run deploy:research:plan -- [options]
+
+Options:
+  --limit <n>  Number of recent deployments per Vercel project to inspect. Defaults to 20.
+  --json       Print machine-readable output.
+`)
+      process.exit(0)
+    }
+  }
+
+  if (!Number.isFinite(options.limit) || options.limit <= 0) {
+    throw new Error('--limit must be a positive number')
+  }
+
+  return options
+}
+
+function readDeploymentMetrics(limit: number): DeploymentMetric[] {
+  const result = spawnSync('tsx', ['scripts/vercel-deployment-metrics.ts', '--json', '--limit', String(limit)], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  if (result.status !== 0) {
+    const message = result.stderr.trim() || result.stdout.trim() || 'deploy:metrics failed'
+    throw new Error(message)
+  }
+
+  const parsed = JSON.parse(result.stdout) as MetricsOutput
+  return parsed.metrics ?? []
+}
+
+export function buildPlanFromMetrics(metrics: DeploymentMetric[]): VercelResearchPlan {
+  return buildVercelResearchPlan({ metrics })
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  const plan = buildPlanFromMetrics(readDeploymentMetrics(options.limit))
+  if (options.json) {
+    console.log(JSON.stringify(plan, null, 2))
+    return
+  }
+  console.log(formatVercelResearchPlanMarkdown(plan))
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Summary
- Add a Vercel AutoResearch planner that turns deployment metrics into approval-ready proposal packets.
- Route ready proposals into Agent Coordination work items and `agent_approvals` with idempotent Slack Agent Ops notification metadata.
- Add a compact Pending Approvals panel in Agent Coordination with inline approve/reject actions and evidence links.
- Document the approval, Open Brain, Integration Captain, production config, and Technology Bakeoff boundaries.

## Validation
- `npm run test -- app/admin/agents/coordination/page.test.tsx app/api/admin/agents/work-items/route.test.ts`
- `npm run test -- lib/vercel-deployment-research.test.ts lib/vercel-autoresearch-notification.test.ts lib/vercel-deployment-research-approvals.test.ts app/api/admin/agents/vercel-research/proposals/route.test.ts 'app/api/admin/agents/runs/[runId]/approval/route.test.ts'`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- `npm run deploy:research:plan -- --limit 2`
- `npm run build`

## Integration Notes
- No production deployment config was changed. Vercel settings, env vars, build commands, ignored build steps, branch protection, log drains, and provider integrations remain explicit approval gates.
- Slack notifications are event-driven through `SLACK_AGENT_OPS_WEBHOOK_URL` and are skipped safely when the webhook is absent.
- Approval only authorizes the next scoped research action; merge/deploy sequencing remains with Integration Captain.
- Open Brain is not used as the notification engine, approval source of truth, or executor; only approved summaries/proposals should be synced there later.
- Technology Bakeoff remains the promotion path for vendor/runtime/provider recommendations.
- Vercel contexts checked in this lane: local read-only `deploy:research:plan` consumed live Vercel deployment metrics; no pre/post merge deployment verification was run because this is a draft non-merged PR.