### PR TITLE
feat: add AI risk source feeds

### DIFF
--- a/app/api/admin/agents/risk-compliance/monitor/route.test.ts
+++ b/app/api/admin/agents/risk-compliance/monitor/route.test.ts
@@ -47,7 +47,33 @@ describe('/api/admin/agents/risk-compliance/monitor', () => {
         ownerAgentKey: 'risk-compliance-intelligence',
         ownerAgentName: 'Moremi (Ife) - Risk & Compliance',
       },
+      source_feeds: expect.arrayContaining([
+        expect.objectContaining({ key: 'owasp-agent-security-initiative', enabled: true }),
+        expect.objectContaining({ key: 'ftc-ai-guidance', enabled: true }),
+      ]),
     })
+  })
+
+  it('filters source feeds by category and priority', async () => {
+    const response = await GET(
+      new Request('http://localhost/api/admin/agents/risk-compliance/monitor?category=prompt_injection&priority=standards') as never,
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.source_feeds.map((feed: { key: string }) => feed.key)).toEqual([
+      'owasp-agent-security-initiative',
+      'owasp-aivss',
+    ])
+  })
+
+  it('rejects invalid source feed filters', async () => {
+    const response = await GET(
+      new Request('http://localhost/api/admin/agents/risk-compliance/monitor?category=unknown') as never,
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'Invalid category' })
   })
 
   it('assesses supplied signals without creating work items', async () => {

--- a/app/api/admin/agents/risk-compliance/monitor/route.ts
+++ b/app/api/admin/agents/risk-compliance/monitor/route.ts
@@ -3,6 +3,11 @@ import { verifyAdmin, isAuthError } from '@/lib/auth-server'
 import {
   assessAiRiskSignals,
   getAiRiskSignalMonitorSummary,
+  getAiRiskSourceFeeds,
+  AI_RISK_SIGNAL_CATEGORIES,
+  AI_RISK_SOURCE_PRIORITIES,
+  type AiRiskSignalCategory,
+  type AiRiskSourcePriority,
   type AiRiskSignalInput,
 } from '@/lib/ai-risk-signal-monitor'
 
@@ -32,9 +37,27 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: auth.error }, { status: auth.status })
   }
 
+  const { searchParams } = new URL(request.url)
+  const category = searchParams.get('category')
+  if (category && !AI_RISK_SIGNAL_CATEGORIES.includes(category as AiRiskSignalCategory)) {
+    return NextResponse.json({ error: 'Invalid category' }, { status: 400 })
+  }
+  const priority = searchParams.get('priority')
+  if (priority && !AI_RISK_SOURCE_PRIORITIES.includes(priority as AiRiskSourcePriority)) {
+    return NextResponse.json({ error: 'Invalid source priority' }, { status: 400 })
+  }
+  const enabledOnly = searchParams.get('enabled_only') !== 'false'
+  const categoryFilter = category ? category as AiRiskSignalCategory : undefined
+  const priorityFilter = priority ? priority as AiRiskSourcePriority : undefined
+
   return NextResponse.json({
     ok: true,
     monitor: getAiRiskSignalMonitorSummary(),
+    source_feeds: getAiRiskSourceFeeds({
+      enabledOnly,
+      category: categoryFilter,
+      priority: priorityFilter,
+    }),
   })
 }
 

--- a/docs/ai-risk-compliance-agent.md
+++ b/docs/ai-risk-compliance-agent.md
@@ -42,6 +42,10 @@ The first implementation surface is read-only:
 - `GET /api/admin/agents/risk-compliance/monitor` returns Moremi's monitor configuration and safety boundary.
 - `POST /api/admin/agents/risk-compliance/monitor` accepts supplied signal briefs and returns exposure assessments plus proposed upgrade-request payloads.
 - The endpoint does not fetch live news, create work items, mutate workflows, write to production tables, or send notifications in v1.
+- Source feeds are explicit and filterable before ingestion is automated:
+  - `GET /api/admin/agents/risk-compliance/monitor?category=prompt_injection`
+  - `GET /api/admin/agents/risk-compliance/monitor?priority=standards`
+  - `GET /api/admin/agents/risk-compliance/monitor?enabled_only=false`
 
 Expected signal payload:
 

--- a/lib/ai-risk-signal-monitor.test.ts
+++ b/lib/ai-risk-signal-monitor.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { assessAiRiskSignals, getAiRiskSignalMonitorSummary } from './ai-risk-signal-monitor'
+import {
+  assessAiRiskSignals,
+  getAiRiskSignalMonitorSummary,
+  getAiRiskSourceFeeds,
+} from './ai-risk-signal-monitor'
 
 describe('AI risk signal monitor', () => {
   it('classifies privacy and regulatory signals as approval-routed exposure', () => {
@@ -82,7 +86,22 @@ describe('AI risk signal monitor', () => {
     expect(getAiRiskSignalMonitorSummary()).toMatchObject({
       ownerAgentKey: 'risk-compliance-intelligence',
       ownerAgentName: 'Moremi (Ife) - Risk & Compliance',
+      enabledSourceFeedCount: 5,
       safetyBoundary: expect.stringContaining('Read-only signal assessment'),
     })
+  })
+
+  it('exposes approved source feeds with filtering before live ingestion exists', () => {
+    expect(getAiRiskSourceFeeds({ enabledOnly: true }).map((feed) => feed.key)).toEqual(expect.arrayContaining([
+      'owasp-agent-security-initiative',
+      'nist-ai-rmf',
+      'eu-ai-act',
+      'ftc-ai-guidance',
+    ]))
+    expect(getAiRiskSourceFeeds({ category: 'prompt_injection' }).map((feed) => feed.key)).toEqual(expect.arrayContaining([
+      'owasp-agent-security-initiative',
+      'owasp-aivss',
+    ]))
+    expect(getAiRiskSourceFeeds({ priority: 'vendor', enabledOnly: true })).toEqual([])
   })
 })

--- a/lib/ai-risk-signal-monitor.ts
+++ b/lib/ai-risk-signal-monitor.ts
@@ -13,10 +13,12 @@ export const AI_RISK_SIGNAL_CATEGORIES = [
 
 export const AI_RISK_SIGNAL_SEVERITIES = ['low', 'medium', 'high', 'critical'] as const
 export const AI_RISK_SIGNAL_CLASSIFICATIONS = ['watch_only', 'exposure_check', 'upgrade_request', 'approval_required'] as const
+export const AI_RISK_SOURCE_PRIORITIES = ['primary', 'standards', 'vendor', 'news', 'commentary'] as const
 
 export type AiRiskSignalCategory = (typeof AI_RISK_SIGNAL_CATEGORIES)[number]
 export type AiRiskSignalSeverity = (typeof AI_RISK_SIGNAL_SEVERITIES)[number]
 export type AiRiskSignalClassification = (typeof AI_RISK_SIGNAL_CLASSIFICATIONS)[number]
+export type AiRiskSourcePriority = (typeof AI_RISK_SOURCE_PRIORITIES)[number]
 
 export type AiRiskSignalInput = {
   id?: string
@@ -62,6 +64,87 @@ export type AiRiskSignalAssessment = {
     metadata: Record<string, unknown>
   } | null
 }
+
+export type AiRiskSourceFeed = {
+  key: string
+  name: string
+  url: string
+  priority: AiRiskSourcePriority
+  ownerAgentKey: 'research-source-register' | 'risk-compliance-intelligence' | 'agent-tooling-parity'
+  categories: AiRiskSignalCategory[]
+  cadence: 'daily' | 'weekly' | 'event_driven'
+  enabled: boolean
+  notes: string
+}
+
+export const AI_RISK_SOURCE_FEEDS: AiRiskSourceFeed[] = [
+  {
+    key: 'owasp-agent-security-initiative',
+    name: 'OWASP Agent Security Initiative',
+    url: 'https://owasp.org/www-project-top-10-for-large-language-model-applications/initiatives/agent_security_initiative/',
+    priority: 'standards',
+    ownerAgentKey: 'research-source-register',
+    categories: ['agent_autonomy', 'prompt_injection', 'security'],
+    cadence: 'weekly',
+    enabled: true,
+    notes: 'Agentic AI security standards and risk vocabulary.',
+  },
+  {
+    key: 'owasp-aivss',
+    name: 'OWASP AI Vulnerability Scoring System',
+    url: 'https://aivss.owasp.org/',
+    priority: 'standards',
+    ownerAgentKey: 'research-source-register',
+    categories: ['security', 'agent_autonomy', 'prompt_injection'],
+    cadence: 'weekly',
+    enabled: true,
+    notes: 'Severity scoring reference for AI-specific vulnerability triage.',
+  },
+  {
+    key: 'nist-ai-rmf',
+    name: 'NIST AI Risk Management Framework',
+    url: 'https://www.nist.gov/itl/ai-risk-management-framework',
+    priority: 'standards',
+    ownerAgentKey: 'research-source-register',
+    categories: ['regulatory', 'bias_safety', 'privacy_data'],
+    cadence: 'weekly',
+    enabled: true,
+    notes: 'Risk management vocabulary and governance reference.',
+  },
+  {
+    key: 'eu-ai-act',
+    name: 'EU Artificial Intelligence Act',
+    url: 'https://eur-lex.europa.eu/eli/reg/2024/1689/oj',
+    priority: 'primary',
+    ownerAgentKey: 'risk-compliance-intelligence',
+    categories: ['regulatory', 'consumer_disclosure', 'privacy_data'],
+    cadence: 'weekly',
+    enabled: true,
+    notes: 'Primary regulation text for EU AI Act obligations.',
+  },
+  {
+    key: 'ftc-ai-guidance',
+    name: 'FTC Artificial Intelligence Business Guidance',
+    url: 'https://www.ftc.gov/business-guidance/technology/artificial-intelligence',
+    priority: 'primary',
+    ownerAgentKey: 'risk-compliance-intelligence',
+    categories: ['consumer_disclosure', 'bias_safety', 'privacy_data'],
+    cadence: 'weekly',
+    enabled: true,
+    notes: 'US consumer protection, AI claims, disclosure, and unfair/deceptive practice guidance.',
+  },
+  {
+    key: 'model-provider-security-notices',
+    name: 'Model Provider Security and Incident Notices',
+    url: 'https://status.openai.com/',
+    priority: 'vendor',
+    ownerAgentKey: 'agent-tooling-parity',
+    categories: ['vendor_incident', 'security'],
+    cadence: 'event_driven',
+    enabled: false,
+    notes: 'Placeholder vendor signal family; enable only after provider-specific feed policy is approved.',
+  },
+]
 
 const KEYWORD_SURFACES: Array<{
   keywords: string[]
@@ -307,6 +390,7 @@ export function assessAiRiskSignals(signals: AiRiskSignalInput[]): AiRiskSignalA
 }
 
 export function getAiRiskSignalMonitorSummary() {
+  const enabledFeeds = AI_RISK_SOURCE_FEEDS.filter((feed) => feed.enabled)
   return {
     ownerAgentKey: 'risk-compliance-intelligence',
     ownerAgentName: getAgentByKey('risk-compliance-intelligence')?.name ?? 'Moremi (Ife) - Risk & Compliance',
@@ -319,6 +403,22 @@ export function getAiRiskSignalMonitorSummary() {
     ],
     categories: AI_RISK_SIGNAL_CATEGORIES,
     classifications: AI_RISK_SIGNAL_CLASSIFICATIONS,
+    sourceFeeds: AI_RISK_SOURCE_FEEDS,
+    enabledSourceFeedCount: enabledFeeds.length,
+    sourceFeedPriorities: AI_RISK_SOURCE_PRIORITIES,
     safetyBoundary: 'Read-only signal assessment. Work-item creation, production config, workflow mutation, public claims, and client-data access require approval.',
   }
+}
+
+export function getAiRiskSourceFeeds(input: {
+  enabledOnly?: boolean
+  priority?: AiRiskSourcePriority
+  category?: AiRiskSignalCategory
+} = {}) {
+  return AI_RISK_SOURCE_FEEDS.filter((feed) => {
+    if (input.enabledOnly && !feed.enabled) return false
+    if (input.priority && feed.priority !== input.priority) return false
+    if (input.category && !feed.categories.includes(input.category)) return false
+    return true
+  })
 }


### PR DESCRIPTION
## Summary
- Adds Moremi's approved AI risk source-feed registry for standards, primary regulatory guidance, and future vendor incident feeds.
- Exposes source feeds through the existing risk-compliance monitor endpoint with category, priority, and enabled-only filters.
- Keeps vendor incident feed disabled until provider-specific source policy is approved.

## Validation
- npm test -- --run lib/ai-risk-signal-monitor.test.ts app/api/admin/agents/risk-compliance/monitor/route.test.ts
- npx tsc --noEmit --pretty false
- npx next lint --file lib/ai-risk-signal-monitor.ts --file lib/ai-risk-signal-monitor.test.ts --file app/api/admin/agents/risk-compliance/monitor/route.ts --file app/api/admin/agents/risk-compliance/monitor/route.test.ts
- pre-push production DB health check passed

## Integration Notes
- Draft PR for Integration Captain.
- V1 remains read-only: no live feed fetching, no scheduled ingestion, no work-item creation, no production mutation.
- Next step after this lands is an approval-gated conversion endpoint from Moremi assessments to agent work items.