### PR TITLE
Make Open Brain the canonical memory layer

### DIFF
--- a/app/admin/agents/open-brain/page.tsx
+++ b/app/admin/agents/open-brain/page.tsx
@@ -158,11 +158,13 @@ function OpenBrainContent() {
 
             <div className="mb-6 grid grid-cols-2 md:grid-cols-4 xl:grid-cols-8 gap-3">
               <MetricCard label="Sources" value={snapshot.overview.sources} tone="slate" />
+              <MetricCard label="Events" value={snapshot.overview.events} tone={snapshot.overview.events ? 'green' : 'slate'} />
               <MetricCard label="Memories" value={snapshot.overview.memories} tone={snapshot.overview.memories ? 'green' : 'yellow'} />
               <MetricCard label="Pending" value={snapshot.overview.pendingProposals} tone={snapshot.overview.pendingProposals ? 'yellow' : 'slate'} />
               <MetricCard label="Approved" value={snapshot.overview.approvedProposals} tone="green" />
               <MetricCard label="Rejected" value={snapshot.overview.rejectedProposals} tone="slate" />
               <MetricCard label="Wiki pages" value={snapshot.overview.wikiPages} tone={snapshot.overview.wikiPages ? 'green' : 'yellow'} />
+              <MetricCard label="RAG docs" value={snapshot.overview.ragProjectionDocuments} tone={snapshot.overview.ragProjectionDocuments ? 'green' : 'slate'} />
               <MetricCard label="Stale sources" value={snapshot.overview.staleSources} tone={snapshot.overview.staleSources ? 'yellow' : 'slate'} />
               <MetricCard label="Private" value={snapshot.overview.privateRecords} tone={snapshot.overview.privateRecords ? 'red' : 'slate'} />
               <MetricCard label="Router lanes" value={snapshot.modelOps.routerDecisions.length} tone={snapshot.modelOps.available ? 'green' : 'yellow'} />

--- a/app/api/admin/rag-ingest/route.ts
+++ b/app/api/admin/rag-ingest/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { isAuthError, verifyAdmin } from '@/lib/auth-server'
 import { endAgentRun, recordAgentEvent, startAgentRun } from '@/lib/agent-run'
 import { buildKnowledgeIngestionPlan } from '@/lib/knowledge-ingestion'
+import { fingerprintOpenBrainRecord, recordOpenBrainEvent, recordOpenBrainSource } from '@/lib/open-brain'
 
 export const dynamic = 'force-dynamic'
 
@@ -48,6 +49,10 @@ export async function POST(request: NextRequest) {
     triggerSource: isN8nAuth ? 'n8n' : 'admin',
     requestedWrite,
   })
+  await recordKnowledgeIngestOpenBrainTrace(plan, {
+    triggerSource: isN8nAuth ? 'n8n' : 'admin',
+    requestedWrite,
+  })
 
   return NextResponse.json(
     {
@@ -59,6 +64,65 @@ export async function POST(request: NextRequest) {
     },
     { status: plan.ok ? 200 : 422 },
   )
+}
+
+async function recordKnowledgeIngestOpenBrainTrace(
+  plan: Awaited<ReturnType<typeof buildKnowledgeIngestionPlan>>,
+  context: { triggerSource: string; requestedWrite: boolean },
+) {
+  try {
+    const source = await recordOpenBrainSource({
+      id: `rag-projection:shadow-plan:${plan.ingestRunId}`,
+      kind: context.requestedWrite ? 'pinecone_projection' : 'rag_projection',
+      title: 'Governed RAG ingestion shadow plan',
+      summary: context.requestedWrite
+        ? 'Pinecone write was requested but blocked pending explicit cutover approval.'
+        : `Prepared shadow-only RAG projection with ${plan.chunkCount} chunk(s) from approved sources.`,
+      path: 'app/api/admin/rag-ingest/route.ts',
+      privacyTier: 'internal_ops',
+      confidence: plan.ok ? 0.86 : 0.65,
+      fingerprint: fingerprintOpenBrainRecord([
+        'rag_projection_shadow_plan',
+        plan.ingestRunId,
+        plan.targetIndex,
+        plan.chunkCount,
+        plan.errors.join('|'),
+        context.requestedWrite,
+      ]),
+    })
+
+    await recordOpenBrainEvent({
+      id: `event:rag-projection-staged:${plan.ingestRunId}`,
+      kind: 'rag_projection_staged',
+      title: 'RAG projection staged',
+      summary: plan.ok
+        ? `Staged ${plan.chunkCount} governed chunk(s). Pinecone write status remains blocked pending approval.`
+        : `RAG projection failed validation with ${plan.errors.length} error(s).`,
+      privacyTier: 'internal_ops',
+      confidence: plan.ok ? 0.86 : 0.65,
+      sourceIds: [source.id],
+      fingerprint: fingerprintOpenBrainRecord([
+        'rag_projection_staged',
+        plan.ingestRunId,
+        plan.chunkCount,
+        plan.privacyViolations.length,
+        context.requestedWrite,
+      ]),
+      metadata: {
+        ingestRunId: plan.ingestRunId,
+        targetIndex: plan.targetIndex,
+        legacyIndex: plan.legacyIndex,
+        triggerSource: context.triggerSource,
+        requestedWrite: context.requestedWrite,
+        writeStatus: context.requestedWrite ? 'blocked_pending_pinecone_cutover_approval' : 'shadow_plan_only',
+        chunkCount: plan.chunkCount,
+        sourceCount: plan.sourceCount,
+        privacyViolationCount: plan.privacyViolations.length,
+      },
+    })
+  } catch (error) {
+    console.warn('[rag-ingest] Open Brain trace skipped:', error instanceof Error ? error.message : error)
+  }
 }
 
 function summarizePlan(plan: Awaited<ReturnType<typeof buildKnowledgeIngestionPlan>>) {

--- a/docs/atas-knowledge-os-rag-governance.md
+++ b/docs/atas-knowledge-os-rag-governance.md
@@ -68,7 +68,9 @@ public namespaces, and excluded private sources marked as RAG-approved.
 | `legacy_health` | `legacy_quarantine` | `internal` | Legacy connectivity checks only |
 
 Portfolio's curated `/api/knowledge` bundle remains the authoritative public
-fact source for products, services, campaigns, and public-safe bio context.
+fact projection for products, services, campaigns, and public-safe bio context.
+The canonical durable-memory layer is the local Open Brain; `/api/knowledge`
+and Pinecone are downstream projections.
 
 ## Agent Ops Visibility
 
@@ -98,6 +100,16 @@ Current write mode is intentionally blocked. Requests with `{ "write": true }`
 return `blocked_pending_pinecone_cutover_approval` until Pinecone index creation,
 production n8n activation, and default retrieval cutover are explicitly approved.
 
+Each shadow plan also records sanitized Open Brain source/event records:
+
+- source kind `rag_projection` for shadow-only plans,
+- source kind `pinecone_projection` when a write was requested and blocked,
+- event kind `rag_projection_staged` with counts, status, privacy-violation
+  count, and approval state.
+
+These records are trace metadata only. They do not write Pinecone, promote
+private-derived material, or create durable Open Brain memories.
+
 ## Approval Gates
 
 The following actions require explicit approval:
@@ -107,3 +119,6 @@ The following actions require explicit approval:
 - production n8n activation/deactivation for RAG workflows
 - promoting private-derived material into public retrieval
 - deleting or overwriting the legacy Pinecone index
+- ingesting Open Brain projections into Pinecone
+- promoting any Open Brain memory into public chatbot or RAG projections unless
+  it is approved and `public_safe`

--- a/docs/memory-context-organization-workflow.md
+++ b/docs/memory-context-organization-workflow.md
@@ -81,6 +81,20 @@ The Portfolio memory/context workflow now treats a local Open Brain as the durab
 
 See [`open-brain-local-service.md`](./open-brain-local-service.md) for the local service contract, MCP tool expectations, privacy tiers, and Karpathy Wiki overlay boundary.
 
+All future memory-producing systems should route through the Open Brain record
+order: source/event first, proposal second, approved memory third, projection
+last. Portfolio docs, chatbot knowledge, Pinecone, and Karpathy Wiki output are
+compiled projections, not canonical memory.
+
+Initial producer routes now covered by the contract:
+
+- personality corpus public-safe pack,
+- local chatbot knowledge bundle,
+- governed RAG/Pinecone shadow ingestion plans,
+- Vercel AutoResearch proposal packets,
+- Model Ops router decisions and swap requests,
+- Codex automation and workspace-root reports.
+
 ## Enhancement Impact Preflight
 
 ### Enhancement Impact Preflight
@@ -157,6 +171,8 @@ Allowed:
 - Show progress and task status computed from the inventory.
 - Show read-only Codex workspace-root and active thread placement drift.
 - Show Open Brain source freshness, proposal health, runtime parity, and wiki overlay previews.
+- Show Open Brain source/event traces from personality corpus, chatbot knowledge, RAG shadow plans, AutoResearch proposal packets, Model Ops, and Codex automation state.
+- Show public-safe Open Brain RAG projection previews with deletion and rollback metadata.
 
 Not allowed in this workflow without an explicit operational-state step:
 
@@ -166,3 +182,5 @@ Not allowed in this workflow without an explicit operational-state step:
 - Rewriting Codex Desktop workspace roots.
 - Pausing, deleting, creating, or rescheduling automations.
 - Registering Open Brain MCP config in Codex, Hermes, OpenCode, Claude, Cursor, or ChatGPT without a separate operational-state approval.
+- Writing Open Brain projection documents into Pinecone without a separate cutover approval.
+- Promoting private or unapproved Open Brain records into wiki pages, chatbot knowledge, public docs, or public RAG.

--- a/docs/open-brain-local-service.md
+++ b/docs/open-brain-local-service.md
@@ -5,19 +5,21 @@ This document defines the Portfolio-facing contract for the local Open Brain. Th
 ## Source Of Truth
 
 - Primary memory owner: local Open Brain service outside the Portfolio repo.
-- Default storage target: local Postgres with pgvector.
-- Local fallback for V1 development: `OPEN_BRAIN_HOME` JSON files for proposals and approved memories.
+- Default local home: `OPEN_BRAIN_HOME=~/.open-brain`.
+- Later storage target: local Postgres with pgvector.
+- Local fallback for V1 development: `OPEN_BRAIN_HOME` JSON files for sources, events, links, proposals, and approved memories.
 - Optional projection: Portfolio Admin at `/admin/agents/open-brain`.
 - Optional mirror: Supabase or hosted dashboards may mirror sanitized metadata later, but must not become the only memory store.
 
 ## Core Records
 
-- `sources`: Codex automations, workspace-root reports, repair packets, runbooks, agent runs, handoffs, work items, and generated wiki pages.
+- `sources`: Codex automations, workspace-root reports, repair packets, runbooks, agent runs, handoffs, work items, personality corpus projections, chatbot knowledge bundles, RAG/Pinecone staging plans, AutoResearch proposal packets, and generated wiki pages.
 - `events`: append-only observations from tools and agents.
 - `memories`: approved facts, decisions, preferences, workflows, risks, and operating rules.
 - `links`: relationships between sources, memories, docs, automations, runs, and agents.
 - `proposals`: approval-gated requests before durable memory changes are accepted.
 - `model_ops`: local LLM benchmark, RAG quality, candidate, cultural-resource, swap-request, and unified router-decision projections.
+- `wiki_overlay`: compiled non-canonical pages from approved non-private records.
 
 Every record must carry:
 
@@ -43,6 +45,8 @@ Portfolio may:
 - show pending proposals,
 - approve or reject proposed memory records,
 - compile wiki overlay previews,
+- expose public-safe RAG projection previews,
+- record sanitized source/event traces from approved producer workflows,
 - and show runtime parity status.
 
 Portfolio must not:
@@ -51,6 +55,8 @@ Portfolio must not:
 - generate durable memories from inference without approval,
 - write directly to `~/.codex/memories`, `~/.codex/automations`, Codex SQLite, or Desktop workspace state,
 - publish private memory records into repo-owned docs,
+- write raw private exports into `/api/knowledge`, wiki pages, or Pinecone,
+- ingest Open Brain projections into Pinecone without an explicit cutover approval,
 - bifurcate local open-source and frontier model routing into separate user-facing router experiences,
 - change production model defaults without an approved Model Ops swap request,
 - or assume Codex MCP configuration applies to Hermes, OpenCode, Claude, Cursor, or ChatGPT.
@@ -91,6 +97,8 @@ The local service should expose these MCP tools:
 
 The first production MCP registration is an operational-state step. It should be approved separately, because it edits runtime config outside the Portfolio git worktree.
 
+The repo-owned MCP server prototype is `scripts/open-brain-mcp-server.ts`. It exposes the tool names above and stores local JSON records under `OPEN_BRAIN_HOME`, but registering it with Codex, Hermes, OpenCode, Claude, Cursor, or ChatGPT remains a separate local-state change.
+
 ## Karpathy Wiki Overlay
 
 Karpathy Wiki pages are compiled views from approved, non-private Open Brain records. Initial pages:
@@ -101,15 +109,50 @@ Karpathy Wiki pages are compiled views from approved, non-private Open Brain rec
 - governing runbooks,
 - decision log,
 - agent handoff map.
+- source register,
+- memory governance rules,
+- AutoResearch experiment ledger.
 
 Generated pages must link back to Open Brain memory ids and source ids. A wiki compile from Portfolio Admin is preview-only until a separate approved repo change commits the markdown.
+
+## Producer Routing
+
+Memory-producing systems should write Open Brain records in this order:
+
+1. `source`: where the evidence or producer output came from.
+2. `event`: append-only observation that something changed, was staged, or needs review.
+3. `proposal`: suggested durable memory for facts, preferences, decisions, workflows, risks, or operating rules.
+4. `memory`: approved durable record after review.
+5. `projection`: wiki, Portfolio Admin, chatbot knowledge, Pinecone/RAG, or agent context packet.
+
+Current producer routes:
+
+- Personality corpus: public-safe derived pack appears as a `personality_corpus` source; raw private exports remain outside public projections.
+- Chatbot knowledge: `/api/knowledge` remains a public-safe projection, not canonical memory.
+- RAG/Pinecone: `/api/admin/rag-ingest` records shadow-plan source/event records and blocks writes pending cutover approval.
+- AutoResearch: proposal creation records `autoresearch_proposal` source/event records; experiments, merges, deploys, hosted config changes, and durable memories remain separately gated.
+- Model Ops: router decisions and swap requests appear as projection sources; model defaults remain approval-gated.
+
+## RAG And Pinecone Projection
+
+Open Brain-approved `public_safe` memories can be compiled into RAG projection documents. Each projected document must carry:
+
+- Open Brain memory id,
+- Open Brain source ids,
+- privacy tier,
+- source hash,
+- projection version,
+- deletion key,
+- rollback key.
+
+Pinecone remains a downstream projection. It must be rebuildable from approved Open Brain records and must not contain private records, unapproved inferences, or raw private exports.
 
 ## V1 Scope
 
 V1 is intentionally narrow:
 
-- Agent Ops and Codex state only.
-- No broad client, sales, or personality corpus ingestion.
+- Agent Ops, Codex state, personality-corpus public-safe projection metadata, chatbot knowledge projection metadata, RAG shadow-plan traces, AutoResearch proposal traces, and Model Ops projections.
+- No broad client, sales, raw personality corpus, or private chat export ingestion.
 - Summaries and paths only; no raw secrets or private exports.
 - Approval-gated durable writes by default.
 - Runtime parity is reported as connected, skipped, or blocked; actual config registration is separate.

--- a/docs/vercel-deployment-autoresearch.md
+++ b/docs/vercel-deployment-autoresearch.md
@@ -17,6 +17,9 @@ npm run deploy:research:plan -- --json
 The planner uses the current deployment metrics scorecard to propose focused
 experiments. A proposal becomes actionable only after it is routed into Agent
 Coordination as a pending `vercel_deployment_research_proposal` approval.
+Creating that approval also records sanitized Open Brain source/event records so
+the proposal is visible in the local memory timeline without becoming durable
+memory.
 
 ## Approval Gate
 
@@ -52,8 +55,11 @@ Proposal-ready notifications are event-driven. There is no schedule.
 - Agent Coordination is the visible review surface.
 - Integration Captain still owns merge and deployment sequencing.
 - Technology Bakeoff owns vendor, runtime, or provider promotion decisions.
-- Open Brain may receive approved summaries later, but it is not the execution
-  engine, approval source of truth, or notification service.
+- Open Brain records the proposal trace as source/event metadata, but it is not
+  the execution engine, approval source of truth, or notification service.
+- Approved experiment outcomes may become Open Brain memory proposals later.
+  They do not become durable memory unless reviewed and approved in the Open
+  Brain flow.
 - Vercel project settings, env vars, build commands, ignored build steps,
   branch protection, domains, log drains, and provider integrations remain
   separate production-config approval gates.

--- a/lib/open-brain.test.ts
+++ b/lib/open-brain.test.ts
@@ -7,9 +7,13 @@ import {
   createOpenBrainProposal,
   fingerprintOpenBrainRecord,
   getOpenBrainSnapshot,
+  linkOpenBrainRecords,
+  recordOpenBrainEvent,
+  recordOpenBrainSource,
   reviewOpenBrainProposal,
   sanitizeOpenBrainText,
   validateMemoryProposal,
+  buildOpenBrainRagProjection,
   type OpenBrainMemoryRecord,
 } from './open-brain'
 
@@ -81,7 +85,11 @@ describe('Open Brain projection', () => {
       'workspace_root_report',
       'repair_packet',
       'runbook',
+      'personality_corpus',
+      'chatbot_knowledge',
+      'rag_projection',
     ]))
+    expect(snapshot.events.map((event) => event.kind)).toContain('source_observed')
     expect(snapshot.proposals[0]).toEqual(expect.objectContaining({
       id: 'proposal:repair:portfolio-operations-manager',
       status: 'pending',
@@ -116,6 +124,10 @@ describe('Open Brain projection', () => {
 
     expect(approved.status).toBe('approved')
     expect(snapshot.memories).toHaveLength(1)
+    expect(snapshot.events.map((event) => event.kind)).toEqual(expect.arrayContaining([
+      'proposal_created',
+      'proposal_approved',
+    ]))
     expect(snapshot.wikiPages[0]).toEqual(expect.objectContaining({
       slug: 'decision-memory',
       path: 'docs/open-brain/wiki/decision-memory.md',
@@ -155,6 +167,82 @@ describe('Open Brain projection', () => {
     }
 
     expect(compileKarpathyWikiOverlay([memory])).toEqual([])
+  })
+
+  it('persists source, event, and link records in the local Open Brain home', async () => {
+    const root = await makeTempRoot()
+    const source = await recordOpenBrainSource({
+      id: 'autoresearch:proposal:test',
+      kind: 'autoresearch_proposal',
+      title: 'Test AutoResearch proposal',
+      summary: 'Approval packet created without executing the experiment.',
+      path: null,
+      privacyTier: 'internal_ops',
+      confidence: 0.8,
+    }, root)
+    await recordOpenBrainEvent({
+      id: 'event:autoresearch-proposal-created:test',
+      kind: 'autoresearch_proposal_created',
+      title: 'AutoResearch proposal created',
+      summary: 'Proposal trace only.',
+      privacyTier: 'internal_ops',
+      confidence: 0.82,
+      sourceIds: [source.id],
+    }, root)
+    const proposal = await createOpenBrainProposal({
+      kind: 'workflow',
+      title: 'Approved trace linking',
+      body: 'Open Brain links approved memory records back to source records.',
+      privacyTier: 'internal_ops',
+      sourceIds: [source.id],
+      reason: 'test',
+    }, root)
+    const approved = await reviewOpenBrainProposal(proposal.id, 'approved', 'Accepted', 'admin', root)
+    const link = await linkOpenBrainRecords({
+      fromId: `memory:${approved.id.replace(/^proposal:/, '')}`,
+      toId: source.id,
+      relationship: 'derived_from',
+    }, root)
+    const snapshot = await getOpenBrainSnapshot(root)
+
+    expect(snapshot.sources).toEqual(expect.arrayContaining([expect.objectContaining({ id: source.id })]))
+    expect(snapshot.events).toEqual(expect.arrayContaining([expect.objectContaining({ kind: 'autoresearch_proposal_created' })]))
+    expect(snapshot.links).toEqual([expect.objectContaining({ id: link.id, relationship: 'derived_from' })])
+    expect(snapshot.wikiPages.map((page) => page.slug)).toContain('autoresearch-experiment-ledger')
+  })
+
+  it('projects only approved public-safe memories into RAG documents', () => {
+    const publicMemory: OpenBrainMemoryRecord = {
+      id: 'memory:public',
+      kind: 'fact',
+      title: 'Public-safe profile',
+      body: 'Public-safe derived summary only.',
+      privacyTier: 'public_safe',
+      confidence: 0.9,
+      sourceIds: ['personality-corpus:public-safe'],
+      createdAt: '2026-05-10T12:00:00.000Z',
+      updatedAt: '2026-05-10T12:00:00.000Z',
+      fingerprint: fingerprintOpenBrainRecord(['public']),
+    }
+    const privateMemory: OpenBrainMemoryRecord = {
+      ...publicMemory,
+      id: 'memory:private',
+      title: 'Private profile',
+      privacyTier: 'private',
+      fingerprint: fingerprintOpenBrainRecord(['private']),
+    }
+    const projection = buildOpenBrainRagProjection([publicMemory, privateMemory])
+
+    expect(projection.documents).toHaveLength(1)
+    expect(projection.documents[0].metadata).toEqual(expect.objectContaining({
+      openBrainMemoryId: 'memory:public',
+      openBrainSourceIds: ['personality-corpus:public-safe'],
+      privacyTier: 'public_safe',
+      projectionVersion: 'open-brain-rag-projection-v1',
+      deletionKey: 'open-brain:memory:public',
+    }))
+    expect(projection.pineconeWriteStatus).toBe('blocked_pending_approval')
+    expect(projection.excludedPrivateCount).toBe(1)
   })
 
   it('sanitizes secret-like content', () => {

--- a/lib/open-brain.ts
+++ b/lib/open-brain.ts
@@ -20,8 +20,23 @@ export type OpenBrainSourceKind =
   | 'model_ops_report'
   | 'model_ops_dashboard'
   | 'model_ops_swap_request'
+  | 'personality_corpus'
+  | 'chatbot_knowledge'
+  | 'rag_projection'
+  | 'pinecone_projection'
+  | 'autoresearch_proposal'
+  | 'autoresearch_result'
+  | 'open_brain_runtime'
 export type OpenBrainMemoryKind = 'fact' | 'decision' | 'preference' | 'workflow' | 'risk' | 'operating_rule'
 export type OpenBrainProposalStatus = 'pending' | 'approved' | 'rejected'
+export type OpenBrainEventKind =
+  | 'source_observed'
+  | 'proposal_created'
+  | 'proposal_approved'
+  | 'proposal_rejected'
+  | 'projection_compiled'
+  | 'autoresearch_proposal_created'
+  | 'rag_projection_staged'
 
 export interface OpenBrainSourceRecord {
   id: string
@@ -56,6 +71,19 @@ export interface OpenBrainLinkRecord {
   createdAt: string
 }
 
+export interface OpenBrainEventRecord {
+  id: string
+  kind: OpenBrainEventKind
+  title: string
+  summary: string
+  privacyTier: OpenBrainPrivacyTier
+  confidence: number
+  sourceIds: string[]
+  createdAt: string
+  fingerprint: string
+  metadata?: Record<string, unknown>
+}
+
 export interface OpenBrainProposalRecord {
   id: string
   status: OpenBrainProposalStatus
@@ -76,6 +104,21 @@ export interface OpenBrainWikiPage {
   markdown: string
   sourceMemoryIds: string[]
   privacyTier: OpenBrainPrivacyTier
+}
+
+export interface OpenBrainRagProjectionDocument {
+  id: string
+  title: string
+  text: string
+  metadata: {
+    openBrainMemoryId: string
+    openBrainSourceIds: string[]
+    privacyTier: Extract<OpenBrainPrivacyTier, 'public_safe'>
+    sourceHash: string
+    projectionVersion: string
+    deletionKey: string
+    rollbackKey: string
+  }
 }
 
 export interface OpenBrainRuntimeParity {
@@ -104,6 +147,9 @@ export interface OpenBrainSnapshot {
     approvedProposals: number
     rejectedProposals: number
     wikiPages: number
+    events: number
+    links: number
+    ragProjectionDocuments: number
     staleSources: number
     privateRecords: number
   }
@@ -114,9 +160,18 @@ export interface OpenBrainSnapshot {
     wikiOverlay: 'green' | 'yellow' | 'red'
   }
   sources: OpenBrainSourceRecord[]
+  events: OpenBrainEventRecord[]
+  links: OpenBrainLinkRecord[]
   memories: OpenBrainMemoryRecord[]
   proposals: OpenBrainProposalRecord[]
   wikiPages: OpenBrainWikiPage[]
+  ragProjection: {
+    version: string
+    documents: OpenBrainRagProjectionDocument[]
+    eligibleMemoryCount: number
+    excludedPrivateCount: number
+    pineconeWriteStatus: 'blocked_pending_approval'
+  }
   runtimeParity: OpenBrainRuntimeParity[]
   modelOps: ModelOpsProjection
   contextPacket: {
@@ -143,6 +198,10 @@ const DEFAULT_OPEN_BRAIN_HOME = path.join(homedir(), '.open-brain')
 const PORTFOLIO_ROOT = '/Users/vambahsillah/Projects/Portfolio'
 const PROPOSALS_FILE = 'proposals.json'
 const MEMORIES_FILE = 'memories.json'
+const SOURCES_FILE = 'sources.json'
+const EVENTS_FILE = 'events.json'
+const LINKS_FILE = 'links.json'
+const RAG_PROJECTION_VERSION = 'open-brain-rag-projection-v1'
 const SECRETISH_PATTERN =
   /(sk-[A-Za-z0-9_-]{12,}|github_pat_[A-Za-z0-9_]{12,}|[A-Za-z0-9_]*(?:TOKEN|SECRET|KEY|PASSWORD)[A-Za-z0-9_]*\s*[:=]\s*["']?[^"'\s,}]+)/gi
 
@@ -152,11 +211,23 @@ export function getOpenBrainHome() {
 
 export async function getOpenBrainSnapshot(openBrainHome = getOpenBrainHome()): Promise<OpenBrainSnapshot> {
   const generatedAt = new Date().toISOString()
-  const [inventory, workspaceRoots, persistedMemories, persistedProposals, modelOps] = await Promise.all([
+  const [
+    inventory,
+    workspaceRoots,
+    persistedMemories,
+    persistedProposals,
+    persistedSources,
+    persistedEvents,
+    persistedLinks,
+    modelOps,
+  ] = await Promise.all([
     listCodexAutomationInventory(),
     getCodexWorkspaceRootReport(),
     readJsonArray<OpenBrainMemoryRecord>(path.join(openBrainHome, MEMORIES_FILE)),
     readJsonArray<OpenBrainProposalRecord>(path.join(openBrainHome, PROPOSALS_FILE)),
+    readJsonArray<OpenBrainSourceRecord>(path.join(openBrainHome, SOURCES_FILE)),
+    readJsonArray<OpenBrainEventRecord>(path.join(openBrainHome, EVENTS_FILE)),
+    readJsonArray<OpenBrainLinkRecord>(path.join(openBrainHome, LINKS_FILE)),
     getModelOpsProjection(),
   ])
 
@@ -198,6 +269,8 @@ export async function getOpenBrainSnapshot(openBrainHome = getOpenBrainHome()): 
     },
     ...buildRunbookSources(generatedAt),
     ...buildModelOpsSources(modelOps),
+    ...(await buildKnowledgeProjectionSources(generatedAt)),
+    ...persistedSources,
   ])
 
   const repairProposals = inventory.repairPackets.map((packet): OpenBrainProposalRecord => {
@@ -234,7 +307,13 @@ export async function getOpenBrainSnapshot(openBrainHome = getOpenBrainHome()): 
     ...persistedMemories,
     ...proposals.filter((proposal) => proposal.status === 'approved').map(proposalToMemory),
   ])
-  const wikiPages = compileKarpathyWikiOverlay(memories)
+  const events = dedupeEvents([
+    ...buildObservedSourceEvents(sources, generatedAt),
+    ...persistedEvents,
+  ])
+  const links = dedupeLinks(persistedLinks)
+  const wikiPages = compileKarpathyWikiOverlay(memories, events)
+  const ragProjection = buildOpenBrainRagProjection(memories)
   const pendingProposals = proposals.filter((proposal) => proposal.status === 'pending').length
   const approvedProposals = proposals.filter((proposal) => proposal.status === 'approved').length
   const rejectedProposals = proposals.filter((proposal) => proposal.status === 'rejected').length
@@ -250,9 +329,13 @@ export async function getOpenBrainSnapshot(openBrainHome = getOpenBrainHome()): 
       approvedProposals,
       rejectedProposals,
       wikiPages: wikiPages.length,
+      events: events.length,
+      links: links.length,
+      ragProjectionDocuments: ragProjection.documents.length,
       staleSources: sources.filter((source) => isStale(source.lastObservedAt, generatedAt)).length,
       privateRecords: [
         ...sources.map((source) => source.privacyTier),
+        ...events.map((event) => event.privacyTier),
         ...memories.map((memory) => memory.privacyTier),
         ...proposals.map((proposal) => proposal.proposedMemory.privacyTier),
       ].filter((tier) => tier === 'private').length,
@@ -264,9 +347,12 @@ export async function getOpenBrainSnapshot(openBrainHome = getOpenBrainHome()): 
       wikiOverlay: wikiPages.length > 0 ? 'green' : approvedProposals > 0 ? 'yellow' : 'red',
     },
     sources,
+    events,
+    links,
     memories,
     proposals,
     wikiPages,
+    ragProjection,
     runtimeParity: buildRuntimeParity(openBrainHome),
     modelOps,
     contextPacket: buildContextPacket(sources, memories, proposals, modelOps),
@@ -315,6 +401,19 @@ export async function createOpenBrainProposal(
     reviewReason: null,
   }
   await writeJsonArray(proposalsPath, [...proposals, proposal])
+  await recordOpenBrainEvent({
+    kind: 'proposal_created',
+    title: `Memory proposal created: ${proposal.proposedMemory.title}`,
+    summary: proposal.reason,
+    privacyTier: proposal.proposedMemory.privacyTier,
+    confidence: proposal.proposedMemory.confidence,
+    sourceIds: proposal.sourceIds,
+    metadata: {
+      proposalId: proposal.id,
+      createdBy: proposal.createdBy,
+      memoryKind: proposal.proposedMemory.kind,
+    },
+  }, openBrainHome)
   return proposal
 }
 
@@ -348,10 +447,129 @@ export async function reviewOpenBrainProposal(
     const memories = await readJsonArray<OpenBrainMemoryRecord>(memoriesPath)
     await writeJsonArray(memoriesPath, dedupeMemories([...memories, proposalToMemory(reviewed)]))
   }
+  await recordOpenBrainEvent({
+    kind: status === 'approved' ? 'proposal_approved' : 'proposal_rejected',
+    title: `Memory proposal ${status}: ${reviewed.proposedMemory.title}`,
+    summary: reviewed.reviewReason || status,
+    privacyTier: reviewed.proposedMemory.privacyTier,
+    confidence: reviewed.proposedMemory.confidence,
+    sourceIds: reviewed.sourceIds,
+    metadata: {
+      proposalId: reviewed.id,
+      reviewedBy: reviewed.reviewedBy,
+      memoryKind: reviewed.proposedMemory.kind,
+    },
+  }, openBrainHome)
   return reviewed
 }
 
-export function compileKarpathyWikiOverlay(memories: OpenBrainMemoryRecord[]): OpenBrainWikiPage[] {
+export async function recordOpenBrainSource(
+  source: Omit<OpenBrainSourceRecord, 'lastObservedAt' | 'fingerprint'> & {
+    lastObservedAt?: string
+    fingerprint?: string
+  },
+  openBrainHome = getOpenBrainHome(),
+): Promise<OpenBrainSourceRecord> {
+  const now = new Date().toISOString()
+  const record: OpenBrainSourceRecord = {
+    ...source,
+    title: sanitizeOpenBrainText(source.title, 180),
+    summary: sanitizeOpenBrainText(source.summary),
+    lastObservedAt: source.lastObservedAt || now,
+    fingerprint: source.fingerprint || fingerprintOpenBrainRecord([
+      source.kind,
+      source.id,
+      source.title,
+      source.summary,
+      source.path || '',
+    ]),
+  }
+  const filePath = path.join(openBrainHome, SOURCES_FILE)
+  const sources = await readJsonArray<OpenBrainSourceRecord>(filePath)
+  await writeJsonArray(filePath, dedupeSources([...sources, record]))
+  return record
+}
+
+export async function recordOpenBrainEvent(
+  input: Omit<OpenBrainEventRecord, 'id' | 'createdAt' | 'fingerprint'> & {
+    id?: string
+    createdAt?: string
+    fingerprint?: string
+  },
+  openBrainHome = getOpenBrainHome(),
+): Promise<OpenBrainEventRecord> {
+  const now = new Date().toISOString()
+  const record: OpenBrainEventRecord = {
+    id: input.id || `event:${randomUUID()}`,
+    kind: input.kind,
+    title: sanitizeOpenBrainText(input.title, 180),
+    summary: sanitizeOpenBrainText(input.summary),
+    privacyTier: input.privacyTier,
+    confidence: clampConfidence(input.confidence),
+    sourceIds: input.sourceIds,
+    createdAt: input.createdAt || now,
+    fingerprint: input.fingerprint || fingerprintOpenBrainRecord([
+      input.kind,
+      input.title,
+      input.summary,
+      input.sourceIds.join(','),
+      input.createdAt || now,
+    ]),
+    metadata: input.metadata,
+  }
+  const filePath = path.join(openBrainHome, EVENTS_FILE)
+  const events = await readJsonArray<OpenBrainEventRecord>(filePath)
+  await writeJsonArray(filePath, dedupeEvents([...events, record]))
+  return record
+}
+
+export async function linkOpenBrainRecords(
+  input: Omit<OpenBrainLinkRecord, 'id' | 'createdAt'> & { id?: string; createdAt?: string },
+  openBrainHome = getOpenBrainHome(),
+): Promise<OpenBrainLinkRecord> {
+  const record: OpenBrainLinkRecord = {
+    id: input.id || `link:${fingerprintOpenBrainRecord([input.fromId, input.toId, input.relationship]).slice(0, 16)}`,
+    fromId: input.fromId,
+    toId: input.toId,
+    relationship: sanitizeOpenBrainText(input.relationship, 160),
+    createdAt: input.createdAt || new Date().toISOString(),
+  }
+  const filePath = path.join(openBrainHome, LINKS_FILE)
+  const links = await readJsonArray<OpenBrainLinkRecord>(filePath)
+  await writeJsonArray(filePath, dedupeLinks([...links, record]))
+  return record
+}
+
+export function buildOpenBrainRagProjection(memories: OpenBrainMemoryRecord[]): OpenBrainSnapshot['ragProjection'] {
+  const publicSafe = memories.filter((memory) => memory.privacyTier === 'public_safe')
+  const documents = publicSafe.map((memory): OpenBrainRagProjectionDocument => ({
+    id: `open-brain-rag:${memory.id}`,
+    title: memory.title,
+    text: memory.body,
+    metadata: {
+      openBrainMemoryId: memory.id,
+      openBrainSourceIds: memory.sourceIds,
+      privacyTier: 'public_safe',
+      sourceHash: memory.fingerprint,
+      projectionVersion: RAG_PROJECTION_VERSION,
+      deletionKey: `open-brain:${memory.id}`,
+      rollbackKey: `open-brain:${memory.fingerprint}`,
+    },
+  }))
+
+  return {
+    version: RAG_PROJECTION_VERSION,
+    documents,
+    eligibleMemoryCount: publicSafe.length,
+    excludedPrivateCount: memories.filter((memory) => memory.privacyTier !== 'public_safe').length,
+    pineconeWriteStatus: 'blocked_pending_approval',
+  }
+}
+
+export function compileKarpathyWikiOverlay(
+  memories: OpenBrainMemoryRecord[],
+  events: OpenBrainEventRecord[] = [],
+): OpenBrainWikiPage[] {
   const approved = memories.filter((memory) => memory.privacyTier !== 'private')
   const grouped = new Map<OpenBrainMemoryKind, OpenBrainMemoryRecord[]>()
   for (const memory of approved) {
@@ -385,6 +603,35 @@ export function compileKarpathyWikiOverlay(memories: OpenBrainMemoryRecord[]): O
       markdown,
       sourceMemoryIds: records.map((record) => record.id),
       privacyTier: records.some((record) => record.privacyTier === 'internal_ops') ? 'internal_ops' : 'public_safe',
+    })
+  }
+
+  const autoresearchEvents = events.filter((event) =>
+    event.privacyTier !== 'private' && event.kind.startsWith('autoresearch_')
+  )
+  if (autoresearchEvents.length > 0) {
+    pages.push({
+      slug: 'autoresearch-experiment-ledger',
+      title: 'AutoResearch Experiment Ledger',
+      path: 'docs/open-brain/wiki/autoresearch-experiment-ledger.md',
+      markdown: [
+        '# AutoResearch Experiment Ledger',
+        '',
+        'Generated Karpathy Wiki overlay from Open Brain source/event records. The local Open Brain remains the source of truth.',
+        '',
+        ...autoresearchEvents.map((event) => [
+          `## ${event.title}`,
+          '',
+          event.summary,
+          '',
+          `- Open Brain event: \`${event.id}\``,
+          `- Privacy tier: \`${event.privacyTier}\``,
+          `- Sources: ${event.sourceIds.map((sourceId) => `\`${sourceId}\``).join(', ') || 'none'}`,
+          '',
+        ].join('\n')),
+      ].join('\n'),
+      sourceMemoryIds: [],
+      privacyTier: autoresearchEvents.some((event) => event.privacyTier === 'internal_ops') ? 'internal_ops' : 'public_safe',
     })
   }
   return pages.sort((a, b) => a.slug.localeCompare(b.slug))
@@ -433,6 +680,78 @@ function buildRunbookSources(generatedAt: string): OpenBrainSourceRecord[] {
     confidence: 0.8,
     lastObservedAt: generatedAt,
     fingerprint: fingerprintOpenBrainRecord(['runbook', docPath]),
+  }))
+}
+
+async function buildKnowledgeProjectionSources(generatedAt: string): Promise<OpenBrainSourceRecord[]> {
+  const personalityPath = path.join(PORTFOLIO_ROOT, 'docs/vambah-personality-public-safe.md')
+  const chatbotPath = path.join(PORTFOLIO_ROOT, 'lib/chatbot-knowledge.ts')
+  const ragManifestPath = path.join(PORTFOLIO_ROOT, 'lib/knowledge-source-manifest.ts')
+  const sources: OpenBrainSourceRecord[] = []
+
+  if (existsSync(personalityPath)) {
+    const content = await readFile(personalityPath, 'utf8').catch(() => '')
+    sources.push({
+      id: 'personality-corpus:public-safe',
+      kind: 'personality_corpus',
+      title: 'Personality corpus public-safe pack',
+      summary: 'Public-safe derived personality corpus pack used by content agents and chatbot knowledge. Raw private exports are excluded.',
+      path: personalityPath,
+      privacyTier: 'public_safe',
+      confidence: 0.9,
+      lastObservedAt: generatedAt,
+      fingerprint: fingerprintOpenBrainRecord(['personality_corpus', personalityPath, content]),
+    })
+  }
+
+  if (existsSync(chatbotPath)) {
+    const content = await readFile(chatbotPath, 'utf8').catch(() => '')
+    sources.push({
+      id: 'chatbot-knowledge:local-bundle',
+      kind: 'chatbot_knowledge',
+      title: 'Portfolio chatbot knowledge bundle',
+      summary: 'Local /api/knowledge bundle remains a public-safe projection and should not become canonical memory.',
+      path: chatbotPath,
+      privacyTier: 'public_safe',
+      confidence: 0.86,
+      lastObservedAt: generatedAt,
+      fingerprint: fingerprintOpenBrainRecord(['chatbot_knowledge', chatbotPath, content]),
+    })
+  }
+
+  if (existsSync(ragManifestPath)) {
+    const content = await readFile(ragManifestPath, 'utf8').catch(() => '')
+    sources.push({
+      id: 'rag-projection:knowledge-source-manifest',
+      kind: 'rag_projection',
+      title: 'Governed RAG source manifest',
+      summary: 'Repo-owned RAG manifest stages approved public-safe/client-safe projections; Pinecone writes remain approval-gated.',
+      path: ragManifestPath,
+      privacyTier: 'internal_ops',
+      confidence: 0.88,
+      lastObservedAt: generatedAt,
+      fingerprint: fingerprintOpenBrainRecord(['rag_projection', ragManifestPath, content]),
+    })
+  }
+
+  return sources
+}
+
+function buildObservedSourceEvents(sources: OpenBrainSourceRecord[], generatedAt: string): OpenBrainEventRecord[] {
+  return sources.map((source) => ({
+    id: `event:source-observed:${source.id}`,
+    kind: 'source_observed',
+    title: `Observed source: ${source.title}`,
+    summary: source.summary,
+    privacyTier: source.privacyTier,
+    confidence: source.confidence,
+    sourceIds: [source.id],
+    createdAt: generatedAt,
+    fingerprint: fingerprintOpenBrainRecord(['source_observed', source.id, source.fingerprint]),
+    metadata: {
+      sourceKind: source.kind,
+      path: source.path,
+    },
   }))
 }
 
@@ -600,6 +919,14 @@ function proposalToMemory(proposal: OpenBrainProposalRecord): OpenBrainMemoryRec
 
 function dedupeSources(sources: OpenBrainSourceRecord[]) {
   return [...new Map(sources.map((source) => [source.fingerprint, source])).values()]
+}
+
+function dedupeEvents(events: OpenBrainEventRecord[]) {
+  return [...new Map(events.map((event) => [event.fingerprint, event])).values()]
+}
+
+function dedupeLinks(links: OpenBrainLinkRecord[]) {
+  return [...new Map(links.map((link) => [link.id, link])).values()]
 }
 
 function dedupeMemories(memories: OpenBrainMemoryRecord[]) {

--- a/lib/vercel-deployment-research-approvals.test.ts
+++ b/lib/vercel-deployment-research-approvals.test.ts
@@ -5,6 +5,9 @@ const mocks = vi.hoisted(() => ({
   createAgentWorkItem: vi.fn(),
   recordAgentEvent: vi.fn(),
   notify: vi.fn(),
+  fingerprintOpenBrainRecord: vi.fn((parts: unknown[]) => `fingerprint:${parts.join(':')}`),
+  recordOpenBrainEvent: vi.fn(),
+  recordOpenBrainSource: vi.fn(),
   from: vi.fn(),
   approvalInsert: vi.fn(),
   approvalUpdate: vi.fn(),
@@ -22,6 +25,12 @@ vi.mock('./agent-run', () => ({
 
 vi.mock('./vercel-autoresearch-notification', () => ({
   notifyVercelResearchApprovalReady: mocks.notify,
+}))
+
+vi.mock('./open-brain', () => ({
+  fingerprintOpenBrainRecord: mocks.fingerprintOpenBrainRecord,
+  recordOpenBrainEvent: mocks.recordOpenBrainEvent,
+  recordOpenBrainSource: mocks.recordOpenBrainSource,
 }))
 
 vi.mock('./supabase', () => ({
@@ -120,6 +129,14 @@ describe('createVercelResearchApproval', () => {
     vi.clearAllMocks()
     mocks.recordAgentEvent.mockResolvedValue({ id: 'event-1' })
     mocks.notify.mockResolvedValue(true)
+    mocks.recordOpenBrainSource.mockResolvedValue({
+      id: 'autoresearch:proposal:next-build-profile',
+      kind: 'autoresearch_proposal',
+    })
+    mocks.recordOpenBrainEvent.mockResolvedValue({
+      id: 'event:autoresearch-proposal-created:next-build-profile',
+      kind: 'autoresearch_proposal_created',
+    })
   })
 
   it('creates one pending approval and dispatches one notification intent', async () => {
@@ -148,6 +165,17 @@ describe('createVercelResearchApproval', () => {
       }),
     }))
     expect(mocks.notify).toHaveBeenCalledTimes(1)
+    expect(mocks.recordOpenBrainSource).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'autoresearch:proposal:next-build-profile',
+      kind: 'autoresearch_proposal',
+      privacyTier: 'internal_ops',
+    }))
+    expect(mocks.recordOpenBrainEvent).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'event:autoresearch-proposal-created:next-build-profile',
+      kind: 'autoresearch_proposal_created',
+      sourceIds: ['autoresearch:proposal:next-build-profile'],
+      metadata: expect.objectContaining({ executesAction: false }),
+    }))
     expect(mocks.approvalUpdate).toHaveBeenCalledWith(expect.objectContaining({
       metadata: expect.objectContaining({
         notification: expect.objectContaining({

--- a/lib/vercel-deployment-research-approvals.ts
+++ b/lib/vercel-deployment-research-approvals.ts
@@ -6,6 +6,7 @@ import {
   type VercelResearchProposal,
 } from './vercel-deployment-research'
 import { notifyVercelResearchApprovalReady } from './vercel-autoresearch-notification'
+import { fingerprintOpenBrainRecord, recordOpenBrainEvent, recordOpenBrainSource } from './open-brain'
 
 export type VercelResearchApprovalCard = {
   approvalId: string
@@ -197,6 +198,15 @@ export async function createVercelResearchApproval(input: {
       },
       idempotencyKey: `${workItem.id}:vercel-autoresearch-approval-created`,
     }).catch(() => {})
+
+    await recordVercelResearchOpenBrainTrace({
+      proposal,
+      approvalId: approval.id,
+      runId: workItem.active_run_id,
+      workItemId: workItem.id,
+    }).catch((error) => {
+      console.warn('[vercel-autoresearch] Open Brain trace skipped:', error instanceof Error ? error.message : error)
+    })
   }
 
   const notification = await notifyApprovalOnce(approval, workItem.id, proposal)
@@ -207,6 +217,60 @@ export async function createVercelResearchApproval(input: {
     runId: approval.run_id,
     notification,
   }
+}
+
+async function recordVercelResearchOpenBrainTrace(input: {
+  proposal: VercelResearchProposal
+  approvalId: string
+  runId: string
+  workItemId: string
+}) {
+  const sourceId = `autoresearch:proposal:${input.proposal.id}`
+  const source = await recordOpenBrainSource({
+    id: sourceId,
+    kind: 'autoresearch_proposal',
+    title: input.proposal.title,
+    summary: [
+      input.proposal.hypothesis,
+      `Approval question: ${input.proposal.approvalQuestion}`,
+      `Risk level: ${input.proposal.riskLevel}.`,
+    ].join(' '),
+    path: null,
+    privacyTier: 'internal_ops',
+    confidence: 0.84,
+    fingerprint: fingerprintOpenBrainRecord([
+      'autoresearch_proposal',
+      input.proposal.id,
+      input.proposal.hypothesis,
+      input.proposal.approvalQuestion,
+    ]),
+  })
+
+  await recordOpenBrainEvent({
+    id: `event:autoresearch-proposal-created:${input.proposal.id}`,
+    kind: 'autoresearch_proposal_created',
+    title: `AutoResearch proposal created: ${input.proposal.title}`,
+    summary: 'Approval packet created. The proposal does not execute experiments, merge, deploy, mutate production config, or write durable memory directly.',
+    privacyTier: 'internal_ops',
+    confidence: 0.86,
+    sourceIds: [source.id],
+    fingerprint: fingerprintOpenBrainRecord([
+      'autoresearch_proposal_created',
+      input.proposal.id,
+      input.approvalId,
+      input.runId,
+      input.workItemId,
+    ]),
+    metadata: {
+      proposalId: input.proposal.id,
+      approvalId: input.approvalId,
+      runId: input.runId,
+      workItemId: input.workItemId,
+      approvalState: input.proposal.approvalState,
+      riskLevel: input.proposal.riskLevel,
+      executesAction: false,
+    },
+  })
 }
 
 export async function listPendingVercelResearchApprovals(): Promise<VercelResearchApprovalCard[]> {

--- a/scripts/open-brain-mcp-server.ts
+++ b/scripts/open-brain-mcp-server.ts
@@ -4,6 +4,7 @@ import {
   compileKarpathyWikiOverlay,
   createOpenBrainProposal,
   getOpenBrainSnapshot,
+  linkOpenBrainRecords,
   type OpenBrainMemoryKind,
   type OpenBrainPrivacyTier,
 } from '../lib/open-brain'
@@ -49,7 +50,7 @@ const tools = [
   },
   {
     name: 'link_memory_to_source',
-    description: 'Return a proposal payload for linking memory and source records. Link persistence is approval-gated in V1.',
+    description: 'Create an auditable local Open Brain link between an approved memory and source record.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -102,7 +103,7 @@ async function callTool(name: string, args: Record<string, unknown>) {
   const snapshot = await getOpenBrainSnapshot()
   if (name === 'get_context_packet') return asText(snapshot.contextPacket)
   if (name === 'list_pending_memory_proposals') return asText(snapshot.proposals.filter((proposal) => proposal.status === 'pending'))
-  if (name === 'compile_wiki_overlay') return asText({ mode: 'preview', pages: compileKarpathyWikiOverlay(snapshot.memories) })
+  if (name === 'compile_wiki_overlay') return asText({ mode: 'preview', pages: compileKarpathyWikiOverlay(snapshot.memories, snapshot.events) })
   if (name === 'search_memory') {
     const query = String(args.query || '').toLowerCase()
     return asText({
@@ -124,14 +125,19 @@ async function callTool(name: string, args: Record<string, unknown>) {
     return asText({ proposal, approvalRequired: true })
   }
   if (name === 'link_memory_to_source') {
+    const memoryId = String(args.memoryId || '')
+    const sourceId = String(args.sourceId || '')
+    const relationship = String(args.relationship || '')
+    if (!snapshot.memories.some((memory) => memory.id === memoryId)) throw new Error('Memory not found.')
+    if (!snapshot.sources.some((source) => source.id === sourceId)) throw new Error('Source not found.')
+    const link = await linkOpenBrainRecords({
+      fromId: memoryId,
+      toId: sourceId,
+      relationship,
+    })
     return asText({
-      approvalRequired: true,
-      link: {
-        memoryId: args.memoryId,
-        sourceId: args.sourceId,
-        relationship: args.relationship,
-      },
-      note: 'V1 returns a link proposal payload only; durable link persistence should go through proposal review.',
+      link,
+      note: 'Link recorded locally. This does not promote any memory, mutate agent config, or write to public docs.',
     })
   }
   throw new Error(`Unknown tool: ${name}`)


### PR DESCRIPTION
## Summary
- Promote Open Brain records to first-class source/event/link/memory/proposal/wiki/RAG projection primitives.
- Route RAG shadow plans and Vercel AutoResearch approval packets into sanitized Open Brain source/event traces without executing writes.
- Update Open Brain, RAG governance, memory workflow, and AutoResearch docs to keep Portfolio, wiki, chatbot knowledge, and Pinecone as projections.
- Extend MCP preview behavior and dashboard metrics for event/RAG projection visibility.

## Validation
- npm test -- --run lib/open-brain.test.ts lib/vercel-deployment-research-approvals.test.ts lib/knowledge-ingestion.test.ts
- npx tsc --noEmit --pretty false
- npm run lint
- npm run build
- printf initialize/tools-list into npm run open-brain:mcp --silent
- Open Brain snapshot smoke: local_jsonl available, Pinecone blocked_pending_approval

## Safety
- No Pinecone writes.
- No production config mutation.
- No agent runtime MCP config registration.
- No raw private corpus/export content added to reports, wiki, chatbot knowledge, or RAG projection.
- Local runtime home initialized at ~/.open-brain with 700 permissions only.