### PR TITLE
feat: add AI risk work item conversion

### DIFF
--- a/app/api/admin/agents/risk-compliance/monitor/route.test.ts
+++ b/app/api/admin/agents/risk-compliance/monitor/route.test.ts
@@ -3,11 +3,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   verifyAdmin: vi.fn(),
   isAuthError: vi.fn(),
+  createAgentWorkItem: vi.fn(),
 }))
 
 vi.mock('@/lib/auth-server', () => ({
   verifyAdmin: mocks.verifyAdmin,
   isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-work-items', () => ({
+  createAgentWorkItem: mocks.createAgentWorkItem,
 }))
 
 import { GET, POST } from './route'
@@ -25,6 +30,11 @@ describe('/api/admin/agents/risk-compliance/monitor', () => {
     vi.clearAllMocks()
     mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
     mocks.isAuthError.mockReturnValue(false)
+    mocks.createAgentWorkItem.mockResolvedValue({
+      id: 'work-item-1',
+      title: 'Review AI risk signal: AI agent prompt injection vulnerability affects browser automation',
+      status: 'proposed',
+    })
   })
 
   it('requires admin auth', async () => {
@@ -103,8 +113,83 @@ describe('/api/admin/agents/risk-compliance/monitor', () => {
           }),
         },
       ],
+      work_item_requests: [
+        expect.objectContaining({
+          status: 'proposed',
+          ownerAgentKey: 'risk-compliance-intelligence',
+          ownerRuntime: 'manual',
+          overlapGroup: 'ai-risk-compliance',
+          idempotencyKey: expect.stringMatching(/^ai-risk-signal:security-advisory-ai-agent-prompt-injection-vulnerability/),
+        }),
+      ],
+      work_items: [],
       side_effects: {
         work_items_created: false,
+        work_item_count: 0,
+        production_mutation_allowed: false,
+      },
+    })
+    expect(mocks.createAgentWorkItem).not.toHaveBeenCalled()
+  })
+
+  it('requires confirmation before creating work items', async () => {
+    const response = await POST(request({
+      create_work_items: true,
+      signals: [
+        {
+          id: 'security-advisory-1',
+          title: 'AI agent prompt injection vulnerability affects browser automation',
+          summary: 'Security researchers report indirect prompt injection that can trigger unsafe tool calls.',
+          sourceName: 'Security advisory',
+        },
+      ],
+    }) as never)
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: 'confirmation must be create_ai_risk_work_items to create work items',
+    })
+    expect(mocks.createAgentWorkItem).not.toHaveBeenCalled()
+  })
+
+  it('creates proposed work items when explicitly confirmed', async () => {
+    const response = await POST(request({
+      create_work_items: true,
+      confirmation: 'create_ai_risk_work_items',
+      signals: [
+        {
+          id: 'security-advisory-1',
+          title: 'AI agent prompt injection vulnerability affects browser automation',
+          summary: 'Security researchers report indirect prompt injection that can trigger unsafe tool calls.',
+          sourceName: 'Security advisory',
+        },
+      ],
+    }) as never)
+
+    expect(response.status).toBe(200)
+    expect(mocks.createAgentWorkItem).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'Review AI risk signal: AI agent prompt injection vulnerability affects browser automation',
+      status: 'proposed',
+      ownerAgentKey: 'risk-compliance-intelligence',
+      ownerRuntime: 'manual',
+      overlapGroup: 'ai-risk-compliance',
+      idempotencyKey: 'ai-risk-signal:security-advisory-1:approval_required',
+      metadata: expect.objectContaining({
+        conversion_requires_review: true,
+        exposure_surfaces: expect.arrayContaining(['agent-tool-use', 'runtime-security']),
+      }),
+    }))
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      work_items: [
+        {
+          id: 'work-item-1',
+          status: 'proposed',
+        },
+      ],
+      side_effects: {
+        work_items_created: true,
+        work_item_count: 1,
         production_mutation_allowed: false,
       },
     })

--- a/app/api/admin/agents/risk-compliance/monitor/route.ts
+++ b/app/api/admin/agents/risk-compliance/monitor/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
 import {
   assessAiRiskSignals,
+  buildAiRiskWorkItemRequests,
   getAiRiskSignalMonitorSummary,
   getAiRiskSourceFeeds,
   AI_RISK_SIGNAL_CATEGORIES,
@@ -10,6 +11,7 @@ import {
   type AiRiskSourcePriority,
   type AiRiskSignalInput,
 } from '@/lib/ai-risk-signal-monitor'
+import { createAgentWorkItem } from '@/lib/agent-work-items'
 
 export const dynamic = 'force-dynamic'
 
@@ -29,6 +31,13 @@ function parseSignals(value: unknown): AiRiskSignalInput[] {
       tags: Array.isArray(item.tags) ? item.tags.filter((tag): tag is string => typeof tag === 'string') : [],
     }))
     .filter((item) => item.title && item.summary)
+}
+
+function toCreateWorkItemInput(
+  request: ReturnType<typeof buildAiRiskWorkItemRequests>[number],
+) {
+  const { sourceAssessment: _sourceAssessment, ...input } = request
+  return input
 }
 
 export async function GET(request: NextRequest) {
@@ -74,15 +83,35 @@ export async function POST(request: NextRequest) {
   }
 
   const assessments = assessAiRiskSignals(signals)
+  const workItemRequests = buildAiRiskWorkItemRequests(assessments)
+  const shouldCreateWorkItems = body.create_work_items === true
+  if (shouldCreateWorkItems && body.confirmation !== 'create_ai_risk_work_items') {
+    return NextResponse.json(
+      { error: 'confirmation must be create_ai_risk_work_items to create work items' },
+      { status: 400 },
+    )
+  }
+
+  const workItems = shouldCreateWorkItems
+    ? await Promise.all(workItemRequests.map((request) =>
+        createAgentWorkItem(toCreateWorkItemInput(request)),
+      ))
+    : []
+
   return NextResponse.json({
     ok: true,
     monitor: getAiRiskSignalMonitorSummary(),
     assessments,
     upgrade_requests: assessments.map((assessment) => assessment.upgradeRequest).filter(Boolean),
+    work_item_requests: workItemRequests.map(toCreateWorkItemInput),
+    work_items: workItems,
     side_effects: {
-      work_items_created: false,
+      work_items_created: workItems.length > 0,
+      work_item_count: workItems.length,
       production_mutation_allowed: false,
-      note: 'This endpoint only classifies supplied signals. Creating work items remains approval-gated.',
+      note: shouldCreateWorkItems
+        ? 'Created proposed Agent Ops work items only. Production remediation remains approval-gated.'
+        : 'This endpoint only classifies supplied signals. Set create_work_items with confirmation to create proposed work items.',
     },
   })
 }

--- a/docs/ai-risk-compliance-agent.md
+++ b/docs/ai-risk-compliance-agent.md
@@ -35,13 +35,16 @@ Every signal should be classified before it becomes work:
 | `upgrade_request` | Confirmed gap or missing control. | Open a scoped implementation request. |
 | `approval_required` | Fix may touch policy, production config, public content, external sends, or client data. | Route to Shaka and approval gate. |
 
-## Read-Only Monitor Endpoint
+## Monitor Endpoint
 
-The first implementation surface is read-only:
+The first implementation surface is read-only by default and approval-gated for work creation:
 
 - `GET /api/admin/agents/risk-compliance/monitor` returns Moremi's monitor configuration and safety boundary.
 - `POST /api/admin/agents/risk-compliance/monitor` accepts supplied signal briefs and returns exposure assessments plus proposed upgrade-request payloads.
-- The endpoint does not fetch live news, create work items, mutate workflows, write to production tables, or send notifications in v1.
+- Default `POST` behavior does not create work items, mutate workflows, write remediation changes, or send notifications.
+- `POST` may create proposed Agent Ops work items only when the caller sends both `create_work_items: true` and `confirmation: "create_ai_risk_work_items"`.
+- Created work items stay in `proposed` status with human review required before remediation, merge, deployment, production config, or workflow mutation.
+- The endpoint does not fetch live news automatically in v1.
 - Source feeds are explicit and filterable before ingestion is automated:
   - `GET /api/admin/agents/risk-compliance/monitor?category=prompt_injection`
   - `GET /api/admin/agents/risk-compliance/monitor?priority=standards`
@@ -57,6 +60,25 @@ Expected signal payload:
       "summary": "The warning focuses on agents processing customer data without consent controls.",
       "sourceName": "Regulator bulletin",
       "sourceUrl": "https://example.com/source",
+      "severity": "high",
+      "category": "privacy_data"
+    }
+  ]
+}
+```
+
+Explicit work-item conversion payload:
+
+```json
+{
+  "create_work_items": true,
+  "confirmation": "create_ai_risk_work_items",
+  "signals": [
+    {
+      "id": "regulator-agent-privacy-warning",
+      "title": "Regulator issues AI agent privacy warning",
+      "summary": "The warning focuses on agents processing customer data without consent controls.",
+      "sourceName": "Regulator bulletin",
       "severity": "high",
       "category": "privacy_data"
     }
@@ -80,6 +102,7 @@ When a signal is relevant, Moremi checks Portfolio for:
 - Risk signal brief with source, affected Portfolio surface, likelihood, impact, and confidence.
 - Portfolio exposure assessment.
 - Upgrade request routed to the right owner agent.
+- Proposed Agent Ops work item when explicitly confirmed.
 - Approval packet when remediation crosses an approval gate.
 - Decision journal entry after acceptance, rejection, or deferral.
 

--- a/lib/ai-risk-signal-monitor.test.ts
+++ b/lib/ai-risk-signal-monitor.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   assessAiRiskSignals,
+  buildAiRiskWorkItemRequests,
   getAiRiskSignalMonitorSummary,
   getAiRiskSourceFeeds,
 } from './ai-risk-signal-monitor'
@@ -103,5 +104,38 @@ describe('AI risk signal monitor', () => {
       'owasp-aivss',
     ]))
     expect(getAiRiskSourceFeeds({ priority: 'vendor', enabledOnly: true })).toEqual([])
+  })
+
+  it('builds proposed work item requests only for actionable assessments', () => {
+    const assessments = assessAiRiskSignals([
+      {
+        id: 'actionable-risk',
+        title: 'AI agent prompt injection vulnerability affects browser automation',
+        summary: 'Security researchers report indirect prompt injection that can trigger unsafe tool calls.',
+        sourceName: 'Security advisory',
+      },
+      {
+        id: 'watch-risk',
+        title: 'AI conference announces new keynote track',
+        summary: 'The event includes broad commentary about AI adoption and demos.',
+        sourceName: 'Conference site',
+        severity: 'low',
+      },
+    ])
+
+    expect(buildAiRiskWorkItemRequests(assessments)).toEqual([
+      expect.objectContaining({
+        title: 'Review AI risk signal: AI agent prompt injection vulnerability affects browser automation',
+        status: 'proposed',
+        ownerAgentKey: 'risk-compliance-intelligence',
+        ownerRuntime: 'manual',
+        overlapGroup: 'ai-risk-compliance',
+        idempotencyKey: 'ai-risk-signal:actionable-risk:approval_required',
+        metadata: expect.objectContaining({
+          conversion_requires_review: true,
+          exposure_surfaces: expect.arrayContaining(['agent-tool-use', 'runtime-security']),
+        }),
+      }),
+    ])
   })
 })

--- a/lib/ai-risk-signal-monitor.ts
+++ b/lib/ai-risk-signal-monitor.ts
@@ -1,4 +1,5 @@
 import { getAgentByKey } from '@/lib/agent-organization'
+import type { CreateAgentWorkItemInput } from '@/lib/agent-work-items'
 
 export const AI_RISK_SIGNAL_CATEGORIES = [
   'agent_autonomy',
@@ -63,6 +64,10 @@ export type AiRiskSignalAssessment = {
     source_label: string
     metadata: Record<string, unknown>
   } | null
+}
+
+export type AiRiskWorkItemRequest = CreateAgentWorkItemInput & {
+  sourceAssessment: AiRiskSignalAssessment
 }
 
 export type AiRiskSourceFeed = {
@@ -387,6 +392,42 @@ export function assessAiRiskSignals(signals: AiRiskSignalInput[]): AiRiskSignalA
       upgradeRequest,
     }
   })
+}
+
+export function buildAiRiskWorkItemRequests(
+  assessments: AiRiskSignalAssessment[],
+): AiRiskWorkItemRequest[] {
+  return assessments
+    .filter((assessment) => assessment.upgradeRequest)
+    .map((assessment) => {
+      const request = assessment.upgradeRequest!
+      return {
+        title: request.title,
+        objective: request.objective,
+        priority: request.priority,
+        status: 'proposed',
+        ownerAgentKey: request.owner_agent_key,
+        ownerRuntime: 'manual',
+        source: {
+          type: request.source_type,
+          id: request.source_id,
+          label: request.source_label,
+        },
+        expectedFiles: [],
+        overlapGroup: 'ai-risk-compliance',
+        metadata: {
+          ...request.metadata,
+          owner_agent_name: assessment.ownerAgentName,
+          recommended_next_action: assessment.recommendedNextAction,
+          confidence: assessment.confidence,
+          rationale: assessment.rationale,
+          exposure_surfaces_detail: assessment.exposureSurfaces,
+          conversion_requires_review: true,
+        },
+        idempotencyKey: `ai-risk-signal:${request.source_id}:${assessment.classification}`,
+        sourceAssessment: assessment,
+      }
+    })
 }
 
 export function getAiRiskSignalMonitorSummary() {


### PR DESCRIPTION
## Summary
- add Moremi work-item request conversion for actionable AI risk assessments
- gate Agent Ops work-item creation behind explicit create_work_items confirmation
- update route tests and Moremi docs for read-only default plus proposed-work-item creation

## Validation
- npm test -- --run lib/ai-risk-signal-monitor.test.ts app/api/admin/agents/risk-compliance/monitor/route.test.ts lib/agent-work-items.test.ts
- npx next lint --file lib/ai-risk-signal-monitor.ts --file lib/ai-risk-signal-monitor.test.ts --file app/api/admin/agents/risk-compliance/monitor/route.ts --file app/api/admin/agents/risk-compliance/monitor/route.test.ts
- npx tsc --noEmit --pretty false
- git diff --check
- git push pre-push database health check passed

## Integration Notes
- Draft PR for Integration Captain; do not merge from this chat.
- Default monitor POST remains read-only. Work items are only created when create_work_items is true and confirmation is create_ai_risk_work_items.
- Created items are proposed only; production remediation, deployment, workflow mutation, and external sends remain approval-gated.
- Vercel contexts not checked from this implementation lane: Vercel – portfolio and Vercel – portfolio-staging should be verified by Integration Captain after merge.