### PR TITLE
feat: add Moremi operational drill

### DIFF
--- a/app/admin/agents/coordination/page.test.tsx
+++ b/app/admin/agents/coordination/page.test.tsx
@@ -62,6 +62,55 @@ describe('AgentCoordinationPage Vercel AutoResearch approvals', () => {
       if (url.startsWith('/api/admin/agents/vercel-research/proposals')) {
         return { ok: true, json: async () => ({ ok: true, approvals: [approvalCard] }) }
       }
+      if (url === '/api/admin/agents/risk-compliance/drill' && init?.method === 'POST') {
+        return {
+          ok: true,
+          json: async () => ({
+            ok: true,
+            work_item: {
+              id: 'work-moremi-drill',
+              title: 'Review AI risk signal: Synthetic Moremi drill: prompt injection risk in browser automation',
+              objective: 'Assess synthetic prompt injection risk.',
+              status: 'proposed',
+              priority: 'urgent',
+              owner_agent_key: 'risk-compliance-intelligence',
+              owner_runtime: 'manual',
+              source_type: 'ai_risk_signal',
+              source_id: 'moremi-operational-drill-prompt-injection-browser-automation',
+              source_label: 'Synthetic Agent Ops drill',
+              source_run_id: null,
+              active_run_id: 'run-moremi-drill',
+              parent_work_item_id: null,
+              branch_name: null,
+              worktree_path: null,
+              pr_number: null,
+              pr_url: null,
+              expected_files: [],
+              touched_files: [],
+              overlap_group: 'ai-risk-compliance',
+              dependency_ids: [],
+              blocker_summary: null,
+              validation_summary: null,
+              approval_id: null,
+              metadata: {},
+              idempotency_key: 'ai-risk-drill:moremi-operational-drill:v1',
+              created_at: '2026-05-11T12:02:00.000Z',
+              updated_at: '2026-05-11T12:02:00.000Z',
+              completed_at: null,
+            },
+            assessment: {
+              classification: 'approval_required',
+              severity: 'high',
+              recommendedNextAction: 'Create an approval-routed risk packet before any remediation work begins.',
+            },
+            verification: {
+              admin_path: '/admin/agents/coordination',
+              slack_command: '/agent work',
+              expected_status: 'proposed',
+            },
+          }),
+        }
+      }
       if (url.startsWith('/api/admin/agents/work-items')) {
         return { ok: true, json: async () => ({ work_items: [] }) }
       }
@@ -93,5 +142,20 @@ describe('AgentCoordinationPage Vercel AutoResearch approvals', () => {
         body: expect.stringContaining('"status":"approved"'),
       }))
     })
+  })
+
+  it('runs the Moremi operational drill and shows the Slack verification command', async () => {
+    render(<AgentCoordinationPage />)
+
+    expect(await screen.findByText('Moremi operational drill')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Run drill' }))
+
+    expect(await screen.findByText('Drill created or reused')).toBeInTheDocument()
+    expect(screen.getByText('/agent work')).toBeInTheDocument()
+    expect(fetch).toHaveBeenCalledWith('/api/admin/agents/risk-compliance/drill', expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({ Authorization: 'Bearer admin-token' }),
+      body: expect.stringContaining('run_moremi_operational_drill'),
+    }))
   })
 })

--- a/app/admin/agents/coordination/page.tsx
+++ b/app/admin/agents/coordination/page.tsx
@@ -65,6 +65,20 @@ type VercelResearchApprovalCard = {
   } | null
 }
 
+type MoremiOperationalDrillResult = {
+  work_item: AgentWorkItem
+  assessment: {
+    classification: string
+    severity: string
+    recommendedNextAction: string
+  }
+  verification: {
+    admin_path: string
+    slack_command: string
+    expected_status: string
+  }
+}
+
 const DEFAULT_FORM: WorkItemForm = {
   title: '',
   objective: '',
@@ -92,6 +106,7 @@ function AgentCoordinationContent() {
   const [error, setError] = useState<string | null>(null)
   const [form, setForm] = useState<WorkItemForm>(DEFAULT_FORM)
   const [vercelResearchApprovals, setVercelResearchApprovals] = useState<VercelResearchApprovalCard[]>([])
+  const [moremiDrillResult, setMoremiDrillResult] = useState<MoremiOperationalDrillResult | null>(null)
 
   const authedFetch = useCallback(async (path: string, init: RequestInit = {}) => {
     const session = await getCurrentSession()
@@ -244,6 +259,25 @@ function AgentCoordinationContent() {
     }
   }
 
+  async function runMoremiOperationalDrill() {
+    setActionId('moremi-drill')
+    setError(null)
+    try {
+      const response = await authedFetch('/api/admin/agents/risk-compliance/drill', {
+        method: 'POST',
+        body: JSON.stringify({ confirmation: 'run_moremi_operational_drill' }),
+      })
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`)
+      setMoremiDrillResult(body)
+      await refreshAll()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Moremi drill failed')
+    } finally {
+      setActionId(null)
+    }
+  }
+
   return (
     <div className="min-h-screen bg-background text-foreground p-6 lg:p-8">
       <div className="mx-auto max-w-7xl">
@@ -294,6 +328,12 @@ function AgentCoordinationContent() {
           approvals={vercelResearchApprovals}
           actionId={actionId}
           onDecision={decideVercelResearchApproval}
+        />
+
+        <MoremiOperationalDrillPanel
+          result={moremiDrillResult}
+          running={actionId === 'moremi-drill'}
+          onRun={runMoremiOperationalDrill}
         />
 
         <section className="mb-6 rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
@@ -380,6 +420,55 @@ function AgentCoordinationContent() {
         )}
       </div>
     </div>
+  )
+}
+
+function MoremiOperationalDrillPanel({
+  result,
+  running,
+  onRun,
+}: {
+  result: MoremiOperationalDrillResult | null
+  running: boolean
+  onRun: () => void
+}) {
+  return (
+    <section className="mb-6 rounded-lg border border-green-500/30 bg-green-500/5 p-4">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <div className="mb-2 flex items-center gap-2 text-sm text-green-100">
+            <ShieldCheck size={18} />
+            Moremi operational drill
+          </div>
+          <h2 className="font-semibold">Synthetic AI risk signal to Agent Ops work item</h2>
+          <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+            Creates or reuses one proposed, synthetic Moremi work item. This validates the Agent Coordination and Slack visibility path without production remediation, external sends, or client-data access.
+          </p>
+        </div>
+        <button
+          onClick={onRun}
+          disabled={running}
+          className="inline-flex items-center justify-center gap-2 rounded-lg border border-green-500/40 bg-green-500/10 px-3 py-2 text-sm text-green-100 hover:bg-green-500/15 disabled:opacity-50"
+        >
+          <RefreshCw size={16} className={running ? 'animate-spin' : ''} />
+          Run drill
+        </button>
+      </div>
+
+      {result ? (
+        <div className="mt-4 grid gap-3 lg:grid-cols-3">
+          <SmallField label="Work item" value={result.work_item.title} />
+          <SmallField label="Status" value={result.work_item.status} />
+          <SmallField label="Slack check" value={result.verification.slack_command} />
+          <div className="rounded-lg border border-green-500/20 bg-background/40 p-3 text-sm lg:col-span-3">
+            <p className="font-medium text-green-100">Drill created or reused</p>
+            <p className="mt-1 text-muted-foreground">
+              {result.assessment.classification.replace(/_/g, ' ')} / {result.assessment.severity}. Expected visibility: {result.verification.expected_status} in Agent Coordination and Slack.
+            </p>
+          </div>
+        </div>
+      ) : null}
+    </section>
   )
 }
 

--- a/app/api/admin/agents/risk-compliance/drill/route.test.ts
+++ b/app/api/admin/agents/risk-compliance/drill/route.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  createAgentWorkItem: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-work-items', () => ({
+  createAgentWorkItem: mocks.createAgentWorkItem,
+}))
+
+import { GET, POST } from './route'
+
+function request(body: Record<string, unknown> = {}) {
+  return new Request('http://localhost/api/admin/agents/risk-compliance/drill', {
+    method: 'POST',
+    headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('/api/admin/agents/risk-compliance/drill', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.createAgentWorkItem.mockResolvedValue({
+      id: 'work-moremi-drill',
+      title: 'Review AI risk signal: Synthetic Moremi drill: prompt injection risk in browser automation',
+      status: 'proposed',
+      owner_agent_key: 'risk-compliance-intelligence',
+      owner_runtime: 'manual',
+      active_run_id: 'run-moremi-drill',
+    })
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await GET(new Request('http://localhost/api/admin/agents/risk-compliance/drill') as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+  })
+
+  it('previews the synthetic drill without creating work items', async () => {
+    const response = await GET(new Request('http://localhost/api/admin/agents/risk-compliance/drill') as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      signal: {
+        id: 'moremi-operational-drill-prompt-injection-browser-automation',
+        sourceName: 'Synthetic Agent Ops drill',
+      },
+      assessment: {
+        classification: 'approval_required',
+        ownerAgentKey: 'risk-compliance-intelligence',
+      },
+      work_item_request: {
+        status: 'proposed',
+        ownerAgentKey: 'risk-compliance-intelligence',
+        ownerRuntime: 'manual',
+        overlapGroup: 'ai-risk-compliance',
+        idempotencyKey: 'ai-risk-drill:moremi-operational-drill:v1',
+        metadata: expect.objectContaining({
+          synthetic_drill: true,
+          non_production_data: true,
+          production_mutation_allowed: false,
+          slack_verification_command: '/agent work',
+        }),
+      },
+      side_effects: {
+        work_items_created: false,
+        production_mutation_allowed: false,
+      },
+    })
+    expect(mocks.createAgentWorkItem).not.toHaveBeenCalled()
+  })
+
+  it('requires explicit confirmation before creating the synthetic work item', async () => {
+    const response = await POST(request() as never)
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: 'confirmation must be run_moremi_operational_drill to create the synthetic drill work item',
+    })
+    expect(mocks.createAgentWorkItem).not.toHaveBeenCalled()
+  })
+
+  it('creates an idempotent proposed work item for the operational drill', async () => {
+    const response = await POST(request({ confirmation: 'run_moremi_operational_drill' }) as never)
+
+    expect(response.status).toBe(200)
+    expect(mocks.createAgentWorkItem).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'Review AI risk signal: Synthetic Moremi drill: prompt injection risk in browser automation',
+      status: 'proposed',
+      ownerAgentKey: 'risk-compliance-intelligence',
+      ownerRuntime: 'manual',
+      overlapGroup: 'ai-risk-compliance',
+      idempotencyKey: 'ai-risk-drill:moremi-operational-drill:v1',
+      metadata: expect.objectContaining({
+        synthetic_drill: true,
+        approval_required_before_remediation: true,
+      }),
+    }))
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      work_item: {
+        id: 'work-moremi-drill',
+        status: 'proposed',
+      },
+      verification: {
+        admin_path: '/admin/agents/coordination',
+        slack_command: '/agent work',
+        expected_status: 'proposed',
+      },
+      side_effects: {
+        work_items_created: true,
+        work_item_count: 1,
+        production_mutation_allowed: false,
+      },
+    })
+  })
+})

--- a/app/api/admin/agents/risk-compliance/drill/route.ts
+++ b/app/api/admin/agents/risk-compliance/drill/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { createAgentWorkItem } from '@/lib/agent-work-items'
+import {
+  MOREMI_OPERATIONAL_DRILL_SIGNAL,
+  buildMoremiOperationalDrillWorkItemRequest,
+  getAiRiskSignalMonitorSummary,
+} from '@/lib/ai-risk-signal-monitor'
+
+export const dynamic = 'force-dynamic'
+
+function toCreateWorkItemInput(
+  request: ReturnType<typeof buildMoremiOperationalDrillWorkItemRequest>['workItemRequest'],
+) {
+  const { sourceAssessment: _sourceAssessment, ...input } = request
+  return input
+}
+
+export async function GET(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const { assessment, workItemRequest } = buildMoremiOperationalDrillWorkItemRequest()
+
+  return NextResponse.json({
+    ok: true,
+    monitor: getAiRiskSignalMonitorSummary(),
+    signal: MOREMI_OPERATIONAL_DRILL_SIGNAL,
+    assessment,
+    work_item_request: toCreateWorkItemInput(workItemRequest),
+    side_effects: {
+      work_items_created: false,
+      production_mutation_allowed: false,
+      note: 'Preview only. POST with confirmation run_moremi_operational_drill to create the proposed synthetic work item.',
+    },
+  })
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as Record<string, unknown>
+  if (body.confirmation !== 'run_moremi_operational_drill') {
+    return NextResponse.json(
+      { error: 'confirmation must be run_moremi_operational_drill to create the synthetic drill work item' },
+      { status: 400 },
+    )
+  }
+
+  const { assessment, workItemRequest } = buildMoremiOperationalDrillWorkItemRequest()
+  const workItem = await createAgentWorkItem(toCreateWorkItemInput(workItemRequest))
+
+  return NextResponse.json({
+    ok: true,
+    monitor: getAiRiskSignalMonitorSummary(),
+    signal: MOREMI_OPERATIONAL_DRILL_SIGNAL,
+    assessment,
+    work_item_request: toCreateWorkItemInput(workItemRequest),
+    work_item: workItem,
+    verification: {
+      admin_path: '/admin/agents/coordination',
+      slack_command: '/agent work',
+      expected_status: 'proposed',
+    },
+    side_effects: {
+      work_items_created: true,
+      work_item_count: 1,
+      production_mutation_allowed: false,
+      note: 'Created or reused an idempotent proposed Agent Ops work item. Production remediation remains approval-gated.',
+    },
+  })
+}

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -68,6 +68,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
    - [x] Spin out warm lead capture from the overloaded Samori Toure (Wassoulou) - Inbox & Follow-Up.
    - [x] Spin out meeting intake and follow-up from the overloaded Samori Toure (Wassoulou) - Inbox & Follow-Up.
    - [x] Spin out Moremi (Ife) - Risk & Compliance for AI agent/current-event risk monitoring and Portfolio exposure checks.
+   - [x] Add a synthetic Moremi operational drill that proves AI risk signal conversion into proposed Agent Ops work items.
    - [ ] Add a scheduled read-only risk signal monitor once source feeds and scoring criteria are approved.
    - [ ] Continue monitoring Yaa Asantewaa (Ashanti) - Automation Systems for a future split only if trace/work-item load stays high.
 

--- a/docs/ai-risk-compliance-agent.md
+++ b/docs/ai-risk-compliance-agent.md
@@ -50,6 +50,16 @@ The first implementation surface is read-only by default and approval-gated for 
   - `GET /api/admin/agents/risk-compliance/monitor?priority=standards`
   - `GET /api/admin/agents/risk-compliance/monitor?enabled_only=false`
 
+### Operational Drill
+
+Moremi has a repeatable synthetic drill for proving the signal-to-work-item path without production remediation or client-data access.
+
+- `GET /api/admin/agents/risk-compliance/drill` previews the synthetic signal, assessment, and proposed work-item request.
+- `POST /api/admin/agents/risk-compliance/drill` creates or reuses one idempotent proposed work item only when the caller sends `confirmation: "run_moremi_operational_drill"`.
+- The drill uses the fixed idempotency key `ai-risk-drill:moremi-operational-drill:v1`.
+- The created work item stays `proposed`, is tagged as synthetic/non-production data, and should be visible in `/admin/agents/coordination` and Slack `/agent work`.
+- Production remediation, workflow mutation, public claims, and client-data access remain approval-gated.
+
 Expected signal payload:
 
 ```json

--- a/lib/ai-risk-signal-monitor.test.ts
+++ b/lib/ai-risk-signal-monitor.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   assessAiRiskSignals,
   buildAiRiskWorkItemRequests,
+  buildMoremiOperationalDrillWorkItemRequest,
   getAiRiskSignalMonitorSummary,
   getAiRiskSourceFeeds,
 } from './ai-risk-signal-monitor'
@@ -137,5 +138,31 @@ describe('AI risk signal monitor', () => {
         }),
       }),
     ])
+  })
+
+  it('builds an idempotent synthetic Moremi operational drill packet', () => {
+    const { assessment, workItemRequest } = buildMoremiOperationalDrillWorkItemRequest()
+
+    expect(assessment).toMatchObject({
+      signalId: 'moremi-operational-drill-prompt-injection-browser-automation',
+      classification: 'approval_required',
+      severity: 'high',
+      ownerAgentKey: 'risk-compliance-intelligence',
+    })
+    expect(workItemRequest).toMatchObject({
+      title: 'Review AI risk signal: Synthetic Moremi drill: prompt injection risk in browser automation',
+      status: 'proposed',
+      ownerAgentKey: 'risk-compliance-intelligence',
+      ownerRuntime: 'manual',
+      overlapGroup: 'ai-risk-compliance',
+      idempotencyKey: 'ai-risk-drill:moremi-operational-drill:v1',
+      metadata: expect.objectContaining({
+        synthetic_drill: true,
+        non_production_data: true,
+        production_mutation_allowed: false,
+        slack_verification_command: '/agent work',
+        admin_verification_path: '/admin/agents/coordination',
+      }),
+    })
   })
 })

--- a/lib/ai-risk-signal-monitor.ts
+++ b/lib/ai-risk-signal-monitor.ts
@@ -82,6 +82,20 @@ export type AiRiskSourceFeed = {
   notes: string
 }
 
+export const MOREMI_OPERATIONAL_DRILL_SIGNAL: AiRiskSignalInput = {
+  id: 'moremi-operational-drill-prompt-injection-browser-automation',
+  title: 'Synthetic Moremi drill: prompt injection risk in browser automation',
+  summary: [
+    'Synthetic Agent Ops validation signal for indirect prompt injection in tool-using agents.',
+    'Use this to prove Moremi can create a proposed work item without production remediation, external sends, or client-data access.',
+  ].join(' '),
+  sourceName: 'Synthetic Agent Ops drill',
+  sourceUrl: null,
+  category: 'prompt_injection',
+  severity: 'high',
+  tags: ['synthetic', 'agent-ops-drill', 'prompt injection', 'browser automation', 'unsafe tool call'],
+}
+
 export const AI_RISK_SOURCE_FEEDS: AiRiskSourceFeed[] = [
   {
     key: 'owasp-agent-security-initiative',
@@ -428,6 +442,32 @@ export function buildAiRiskWorkItemRequests(
         sourceAssessment: assessment,
       }
     })
+}
+
+export function buildMoremiOperationalDrillWorkItemRequest() {
+  const [assessment] = assessAiRiskSignals([MOREMI_OPERATIONAL_DRILL_SIGNAL])
+  const [request] = buildAiRiskWorkItemRequests([assessment])
+
+  if (!request) {
+    throw new Error('Moremi operational drill did not produce a work item request')
+  }
+
+  return {
+    assessment,
+    workItemRequest: {
+      ...request,
+      metadata: {
+        ...request.metadata,
+        synthetic_drill: true,
+        non_production_data: true,
+        production_mutation_allowed: false,
+        approval_required_before_remediation: true,
+        admin_verification_path: '/admin/agents/coordination',
+        slack_verification_command: '/agent work',
+      },
+      idempotencyKey: 'ai-risk-drill:moremi-operational-drill:v1',
+    },
+  }
 }
 
 export function getAiRiskSignalMonitorSummary() {


### PR DESCRIPTION
Summary
- Adds an admin-only Moremi operational drill endpoint that previews and creates/reuses one idempotent synthetic AI risk work item.
- Adds a Portfolio Admin Agent Coordination panel to run the drill and show the Slack `/agent work` verification path.
- Documents the drill and covers the helper, API route, and admin UI behavior.

Validation
- npm test -- --run lib/ai-risk-signal-monitor.test.ts app/api/admin/agents/risk-compliance/drill/route.test.ts app/admin/agents/coordination/page.test.tsx app/api/admin/agents/risk-compliance/monitor/route.test.ts
- npm run build:knowledge && npx tsc --noEmit --pretty false
- git diff --check
- npm run build

Integration Notes
- No migration required.
- The drill creates only a proposed synthetic/non-production Agent Ops work item using idempotency key `ai-risk-drill:moremi-operational-drill:v1`.
- No live workflow, customer-data smoke, production remediation, external send, or production config mutation was run.
- Build passed with the existing local env warning that outbound n8n webhooks are enabled in `.env.local`.
- Vercel contexts to verify after merge: `Vercel – portfolio` and `Vercel – portfolio-staging`.