### PR TITLE
feat: add Moremi read-only risk monitor

### DIFF
--- a/app/api/cron/moremi-risk-monitor/route.test.ts
+++ b/app/api/cron/moremi-risk-monitor/route.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  runMoremiRiskSignalMonitor: vi.fn(),
+}))
+
+vi.mock('@/lib/moremi-risk-signal-monitor', () => ({
+  runMoremiRiskSignalMonitor: mocks.runMoremiRiskSignalMonitor,
+}))
+
+import { GET, POST } from './route'
+
+function request(method: 'GET' | 'POST', token?: string) {
+  return new Request('http://localhost/api/cron/moremi-risk-monitor', {
+    method,
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+  })
+}
+
+describe('/api/cron/moremi-risk-monitor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.CRON_SECRET = 'cron-secret'
+    process.env.N8N_INGEST_SECRET = 'n8n-secret'
+    mocks.runMoremiRiskSignalMonitor.mockResolvedValue({
+      runId: 'moremi-run-1',
+      generatedAt: '2026-05-12T12:00:00.000Z',
+      overall: 'warning',
+      enabledSourceFeedCount: 5,
+      disabledSourceFeedCount: 1,
+      warnings: ['No enabled source feed currently covers vendor_incident.'],
+      summaryMarkdown: '# Moremi AI Risk Signal Monitor',
+    })
+  })
+
+  it('rejects unauthenticated cron requests', async () => {
+    const response = await POST(request('POST', 'wrong') as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.runMoremiRiskSignalMonitor).not.toHaveBeenCalled()
+  })
+
+  it('runs from Vercel cron GET with CRON_SECRET', async () => {
+    const response = await GET(request('GET', 'cron-secret') as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      ok: true,
+      run_id: 'moremi-run-1',
+      overall: 'warning',
+      enabled_source_feed_count: 5,
+      disabled_source_feed_count: 1,
+      warnings: ['No enabled source feed currently covers vendor_incident.'],
+      summary_markdown: '# Moremi AI Risk Signal Monitor',
+      side_effects: {
+        work_items_created: false,
+        production_mutation_allowed: false,
+        live_external_fetch: false,
+        client_data_access: false,
+      },
+    })
+    expect(mocks.runMoremiRiskSignalMonitor).toHaveBeenCalledWith('vercel_cron_moremi_risk_monitor')
+  })
+
+  it('keeps an n8n/manual POST trigger path available', async () => {
+    const response = await POST(request('POST', 'n8n-secret') as never)
+
+    expect(response.status).toBe(200)
+    expect(mocks.runMoremiRiskSignalMonitor).toHaveBeenCalledWith('manual_cron_moremi_risk_monitor')
+  })
+})

--- a/app/api/cron/moremi-risk-monitor/route.ts
+++ b/app/api/cron/moremi-risk-monitor/route.ts
@@ -1,0 +1,59 @@
+/**
+ * GET/POST /api/cron/moremi-risk-monitor
+ *
+ * Runs Moremi's scheduled read-only AI risk signal monitor.
+ * Auth: Bearer CRON_SECRET or N8N_INGEST_SECRET.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { runMoremiRiskSignalMonitor } from '@/lib/moremi-risk-signal-monitor'
+
+export const dynamic = 'force-dynamic'
+
+function isAuthorizedCronRequest(request: NextRequest): boolean {
+  const token = request.headers.get('authorization')?.replace(/^Bearer\s+/i, '')
+  const allowedTokens = [process.env.CRON_SECRET, process.env.N8N_INGEST_SECRET].filter(Boolean)
+  return Boolean(token && allowedTokens.includes(token))
+}
+
+async function runMonitor(request: NextRequest) {
+  if (!isAuthorizedCronRequest(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const result = await runMoremiRiskSignalMonitor(
+      request.method === 'GET' ? 'vercel_cron_moremi_risk_monitor' : 'manual_cron_moremi_risk_monitor',
+    )
+
+    return NextResponse.json({
+      ok: true,
+      run_id: result.runId,
+      overall: result.overall,
+      enabled_source_feed_count: result.enabledSourceFeedCount,
+      disabled_source_feed_count: result.disabledSourceFeedCount,
+      warnings: result.warnings,
+      summary_markdown: result.summaryMarkdown,
+      side_effects: {
+        work_items_created: false,
+        production_mutation_allowed: false,
+        live_external_fetch: false,
+        client_data_access: false,
+      },
+    })
+  } catch (error) {
+    console.error('[moremi-risk-monitor] failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Moremi AI risk signal monitor failed' },
+      { status: 500 },
+    )
+  }
+}
+
+export async function GET(request: NextRequest) {
+  return runMonitor(request)
+}
+
+export async function POST(request: NextRequest) {
+  return runMonitor(request)
+}

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -69,7 +69,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
    - [x] Spin out meeting intake and follow-up from the overloaded Samori Toure (Wassoulou) - Inbox & Follow-Up.
    - [x] Spin out Moremi (Ife) - Risk & Compliance for AI agent/current-event risk monitoring and Portfolio exposure checks.
    - [x] Add a synthetic Moremi operational drill that proves AI risk signal conversion into proposed Agent Ops work items.
-   - [ ] Add a scheduled read-only risk signal monitor once source feeds and scoring criteria are approved.
+   - [x] Add a scheduled read-only risk signal monitor once source feeds and scoring criteria are approved.
    - [ ] Continue monitoring Yaa Asantewaa (Ashanti) - Automation Systems for a future split only if trace/work-item load stays high.
 
 ## Completed Or In Review

--- a/docs/ai-risk-compliance-agent.md
+++ b/docs/ai-risk-compliance-agent.md
@@ -50,6 +50,16 @@ The first implementation surface is read-only by default and approval-gated for 
   - `GET /api/admin/agents/risk-compliance/monitor?priority=standards`
   - `GET /api/admin/agents/risk-compliance/monitor?enabled_only=false`
 
+### Scheduled Read-Only Monitor
+
+Moremi runs a weekly source-feed coverage monitor through Vercel cron:
+
+- `GET /api/cron/moremi-risk-monitor` runs from Vercel cron with `CRON_SECRET`.
+- `POST /api/cron/moremi-risk-monitor` remains available for n8n/manual cron triggering with `N8N_INGEST_SECRET`.
+- The monitor creates an Agent Ops run and artifact with enabled/disabled feed counts, category coverage, priority coverage, and warnings.
+- The monitor does not fetch live external pages, create work items, mutate workflows, change production config, send public content, or touch client data.
+- The first schedule is weekly on Monday at 14:00 UTC, after the daily client AI Ops monitor.
+
 ### Operational Drill
 
 Moremi has a repeatable synthetic drill for proving the signal-to-work-item path without production remediation or client-data access.

--- a/lib/moremi-risk-signal-monitor.test.ts
+++ b/lib/moremi-risk-signal-monitor.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  startAgentRun: vi.fn(),
+  recordAgentStep: vi.fn(),
+  attachAgentArtifact: vi.fn(),
+  endAgentRun: vi.fn(),
+  markAgentRunFailed: vi.fn(),
+}))
+
+vi.mock('@/lib/agent-run', () => ({
+  startAgentRun: mocks.startAgentRun,
+  recordAgentStep: mocks.recordAgentStep,
+  attachAgentArtifact: mocks.attachAgentArtifact,
+  endAgentRun: mocks.endAgentRun,
+  markAgentRunFailed: mocks.markAgentRunFailed,
+}))
+
+import {
+  buildMoremiRiskSignalMonitorMarkdown,
+  runMoremiRiskSignalMonitor,
+} from './moremi-risk-signal-monitor'
+
+describe('Moremi risk signal monitor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-12T12:00:00.000Z'))
+    mocks.startAgentRun.mockResolvedValue({ id: 'moremi-run-1' })
+    mocks.recordAgentStep.mockResolvedValue({ id: 'step-1' })
+    mocks.attachAgentArtifact.mockResolvedValue({ id: 'artifact-1' })
+    mocks.endAgentRun.mockResolvedValue(undefined)
+    mocks.markAgentRunFailed.mockResolvedValue(undefined)
+  })
+
+  it('builds a read-only coverage markdown summary', () => {
+    const markdown = buildMoremiRiskSignalMonitorMarkdown({
+      generatedAt: '2026-05-12T12:00:00.000Z',
+      overall: 'warning',
+      enabledSourceFeedCount: 5,
+      disabledSourceFeedCount: 1,
+      coverageByCategory: {
+        agent_autonomy: 2,
+        prompt_injection: 2,
+        privacy_data: 3,
+        regulatory: 2,
+        security: 2,
+        bias_safety: 2,
+        vendor_incident: 0,
+        consumer_disclosure: 1,
+      },
+      coverageByPriority: {
+        primary: 2,
+        standards: 3,
+        vendor: 0,
+        news: 0,
+        commentary: 0,
+      },
+      warnings: ['No enabled source feed currently covers vendor_incident.'],
+      runId: 'run-1',
+    })
+
+    expect(markdown).toContain('Moremi AI Risk Signal Monitor')
+    expect(markdown).toContain('Read-only source-feed coverage review.')
+    expect(markdown).toContain('vendor_incident: 0 enabled feed(s)')
+    expect(markdown).toContain('No enabled source feed currently covers vendor_incident.')
+    expect(markdown).toContain('/admin/agents/runs/run-1')
+  })
+
+  it('records a read-only Agent Ops run with source-feed coverage artifact', async () => {
+    const result = await runMoremiRiskSignalMonitor('test_moremi_risk_monitor')
+
+    expect(result).toMatchObject({
+      runId: 'moremi-run-1',
+      generatedAt: '2026-05-12T12:00:00.000Z',
+      overall: 'warning',
+      enabledSourceFeedCount: 5,
+      disabledSourceFeedCount: 1,
+    })
+    expect(result.warnings).toEqual(expect.arrayContaining([
+      'No enabled source feed currently covers vendor_incident.',
+      'Model Provider Security and Incident Notices is disabled pending policy approval.',
+    ]))
+    expect(mocks.startAgentRun).toHaveBeenCalledWith(expect.objectContaining({
+      agentKey: 'risk-compliance-intelligence',
+      runtime: 'manual',
+      kind: 'ai_risk_signal_monitor',
+      triggerSource: 'test_moremi_risk_monitor',
+      metadata: expect.objectContaining({
+        execution_mode: 'scheduled_read_only',
+        production_mutation_allowed: false,
+        creates_work_items: false,
+        live_external_fetch: false,
+        client_data_access: false,
+      }),
+      idempotencyKey: 'moremi-risk-signal-monitor:2026-05-12',
+    }))
+    expect(mocks.recordAgentStep).toHaveBeenCalledWith(expect.objectContaining({
+      runId: 'moremi-run-1',
+      stepKey: 'source_feed_coverage',
+      status: 'completed',
+      metadata: expect.objectContaining({
+        coverage_by_category: expect.objectContaining({ vendor_incident: 0 }),
+        coverage_by_priority: expect.objectContaining({ standards: 3 }),
+      }),
+    }))
+    expect(mocks.attachAgentArtifact).toHaveBeenCalledWith(expect.objectContaining({
+      runId: 'moremi-run-1',
+      artifactType: 'ai_risk_signal_monitor',
+      metadata: expect.objectContaining({
+        summary_markdown: expect.stringContaining('Moremi AI Risk Signal Monitor'),
+        warnings: expect.arrayContaining(['No enabled source feed currently covers vendor_incident.']),
+      }),
+    }))
+    expect(mocks.endAgentRun).toHaveBeenCalledWith(expect.objectContaining({
+      runId: 'moremi-run-1',
+      status: 'completed',
+      outcome: expect.objectContaining({
+        overall: 'warning',
+        production_mutation_allowed: false,
+      }),
+    }))
+  })
+})

--- a/lib/moremi-risk-signal-monitor.ts
+++ b/lib/moremi-risk-signal-monitor.ts
@@ -1,0 +1,221 @@
+import {
+  attachAgentArtifact,
+  endAgentRun,
+  markAgentRunFailed,
+  recordAgentStep,
+  startAgentRun,
+} from '@/lib/agent-run'
+import {
+  AI_RISK_SIGNAL_CATEGORIES,
+  AI_RISK_SOURCE_PRIORITIES,
+  getAiRiskSignalMonitorSummary,
+  getAiRiskSourceFeeds,
+  type AiRiskSignalCategory,
+  type AiRiskSourcePriority,
+} from '@/lib/ai-risk-signal-monitor'
+
+export type MoremiRiskSignalMonitorResult = {
+  runId: string
+  generatedAt: string
+  overall: 'ok' | 'warning'
+  enabledSourceFeedCount: number
+  disabledSourceFeedCount: number
+  coverageByCategory: Record<AiRiskSignalCategory, number>
+  coverageByPriority: Record<AiRiskSourcePriority, number>
+  warnings: string[]
+  summaryMarkdown: string
+}
+
+function emptyCategoryCoverage() {
+  return Object.fromEntries(AI_RISK_SIGNAL_CATEGORIES.map((category) => [category, 0])) as Record<AiRiskSignalCategory, number>
+}
+
+function emptyPriorityCoverage() {
+  return Object.fromEntries(AI_RISK_SOURCE_PRIORITIES.map((priority) => [priority, 0])) as Record<AiRiskSourcePriority, number>
+}
+
+function buildCoverage() {
+  const enabledFeeds = getAiRiskSourceFeeds({ enabledOnly: true })
+  const allFeeds = getAiRiskSourceFeeds({ enabledOnly: false })
+  const coverageByCategory = emptyCategoryCoverage()
+  const coverageByPriority = emptyPriorityCoverage()
+
+  for (const feed of enabledFeeds) {
+    coverageByPriority[feed.priority] += 1
+    for (const category of feed.categories) {
+      coverageByCategory[category] += 1
+    }
+  }
+
+  const disabledFeeds = allFeeds.filter((feed) => !feed.enabled)
+  const uncoveredCategories = AI_RISK_SIGNAL_CATEGORIES.filter((category) => coverageByCategory[category] === 0)
+  const warnings = [
+    ...(enabledFeeds.length === 0 ? ['No approved AI risk source feeds are enabled.'] : []),
+    ...uncoveredCategories.map((category) => `No enabled source feed currently covers ${category}.`),
+    ...disabledFeeds.map((feed) => `${feed.name} is disabled pending policy approval.`),
+  ]
+
+  return {
+    allFeeds,
+    enabledFeeds,
+    disabledFeeds,
+    coverageByCategory,
+    coverageByPriority,
+    warnings,
+  }
+}
+
+export function buildMoremiRiskSignalMonitorMarkdown(input: {
+  generatedAt: string
+  overall: 'ok' | 'warning'
+  enabledSourceFeedCount: number
+  disabledSourceFeedCount: number
+  coverageByCategory: Record<AiRiskSignalCategory, number>
+  coverageByPriority: Record<AiRiskSourcePriority, number>
+  warnings: string[]
+  runId?: string
+}) {
+  const runUrl = input.runId ? `/admin/agents/runs/${input.runId}` : '/admin/agents/runs'
+  const categoryLines = AI_RISK_SIGNAL_CATEGORIES.map((category) => `- ${category}: ${input.coverageByCategory[category]} enabled feed(s)`)
+  const priorityLines = AI_RISK_SOURCE_PRIORITIES.map((priority) => `- ${priority}: ${input.coverageByPriority[priority]} enabled feed(s)`)
+
+  return [
+    '# Moremi AI Risk Signal Monitor',
+    '',
+    `Generated: ${input.generatedAt}`,
+    `Overall: ${input.overall}`,
+    `Review: ${runUrl}`,
+    '',
+    '## Safety Boundary',
+    '',
+    '- Read-only source-feed coverage review.',
+    '- No live external fetch, work-item creation, remediation, production config change, public claim, or client-data access.',
+    '- Actionable findings must be converted through the existing explicit confirmation path.',
+    '',
+    '## Source Feed Coverage',
+    '',
+    `- Enabled feeds: ${input.enabledSourceFeedCount}`,
+    `- Disabled feeds: ${input.disabledSourceFeedCount}`,
+    '',
+    '### Categories',
+    '',
+    ...categoryLines,
+    '',
+    '### Priorities',
+    '',
+    ...priorityLines,
+    '',
+    '## Warnings',
+    '',
+    ...(input.warnings.length ? input.warnings.map((warning) => `- ${warning}`) : ['- None']),
+  ].join('\n')
+}
+
+export async function runMoremiRiskSignalMonitor(triggerSource = 'cron_moremi_risk_signal_monitor') {
+  const generatedAt = new Date().toISOString()
+  let runId: string | null = null
+
+  try {
+    const monitor = getAiRiskSignalMonitorSummary()
+    const coverage = buildCoverage()
+    const overall = coverage.warnings.length ? 'warning' : 'ok'
+
+    const run = await startAgentRun({
+      agentKey: 'risk-compliance-intelligence',
+      runtime: 'manual',
+      kind: 'ai_risk_signal_monitor',
+      title: 'Run Moremi AI risk signal monitor',
+      subject: { type: 'system', id: 'ai-risk-compliance', label: 'AI risk and compliance' },
+      triggerSource,
+      currentStep: 'Reviewing approved AI risk source feeds',
+      metadata: {
+        execution_mode: 'scheduled_read_only',
+        production_mutation_allowed: false,
+        creates_work_items: false,
+        live_external_fetch: false,
+        client_data_access: false,
+        approval_required_for_remediation: true,
+        source_feed_count: coverage.allFeeds.length,
+      },
+      idempotencyKey: `moremi-risk-signal-monitor:${generatedAt.slice(0, 10)}`,
+    })
+    runId = run.id
+
+    await recordAgentStep({
+      runId,
+      stepKey: 'source_feed_coverage',
+      name: 'Reviewed approved AI risk source feed coverage',
+      status: 'completed',
+      outputSummary: `Enabled feeds: ${coverage.enabledFeeds.length}; warnings: ${coverage.warnings.length}`,
+      metadata: {
+        monitor,
+        enabled_source_feeds: coverage.enabledFeeds,
+        disabled_source_feeds: coverage.disabledFeeds,
+        coverage_by_category: coverage.coverageByCategory,
+        coverage_by_priority: coverage.coverageByPriority,
+        warnings: coverage.warnings,
+      },
+      idempotencyKey: `${runId}:source-feed-coverage`,
+    })
+
+    const summaryMarkdown = buildMoremiRiskSignalMonitorMarkdown({
+      generatedAt,
+      overall,
+      enabledSourceFeedCount: coverage.enabledFeeds.length,
+      disabledSourceFeedCount: coverage.disabledFeeds.length,
+      coverageByCategory: coverage.coverageByCategory,
+      coverageByPriority: coverage.coverageByPriority,
+      warnings: coverage.warnings,
+      runId,
+    })
+
+    await attachAgentArtifact({
+      runId,
+      artifactType: 'ai_risk_signal_monitor',
+      title: `Moremi AI Risk Signal Monitor - ${overall}`,
+      refType: 'agent_run',
+      refId: runId,
+      metadata: {
+        summary_markdown: summaryMarkdown,
+        source_feeds: coverage.allFeeds,
+        coverage_by_category: coverage.coverageByCategory,
+        coverage_by_priority: coverage.coverageByPriority,
+        warnings: coverage.warnings,
+        safety_boundary: monitor.safetyBoundary,
+      },
+      idempotencyKey: `${runId}:artifact:ai-risk-signal-monitor`,
+    })
+
+    await endAgentRun({
+      runId,
+      status: 'completed',
+      currentStep: 'Moremi AI risk signal monitor ready',
+      outcome: {
+        overall,
+        warning_count: coverage.warnings.length,
+        enabled_source_feed_count: coverage.enabledFeeds.length,
+        disabled_source_feed_count: coverage.disabledFeeds.length,
+        generated_at: generatedAt,
+        production_mutation_allowed: false,
+      },
+    })
+
+    return {
+      runId,
+      generatedAt,
+      overall,
+      enabledSourceFeedCount: coverage.enabledFeeds.length,
+      disabledSourceFeedCount: coverage.disabledFeeds.length,
+      coverageByCategory: coverage.coverageByCategory,
+      coverageByPriority: coverage.coverageByPriority,
+      warnings: coverage.warnings,
+      summaryMarkdown,
+    } satisfies MoremiRiskSignalMonitorResult
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Moremi AI risk signal monitor failed'
+    if (runId) {
+      await markAgentRunFailed(runId, message, { trigger_source: triggerSource }).catch(() => {})
+    }
+    throw error
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/cron/client-ai-ops-monitor",
       "schedule": "0 13 * * *"
+    },
+    {
+      "path": "/api/cron/moremi-risk-monitor",
+      "schedule": "0 14 * * 1"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- add Moremi's weekly read-only AI risk source-feed coverage monitor
- expose authenticated GET/POST cron entrypoints that create an Agent Ops run and artifact
- document the cron safety boundary and mark the scheduled monitor roadmap item complete

## Validation

- `npm test -- --run lib/moremi-risk-signal-monitor.test.ts app/api/cron/moremi-risk-monitor/route.test.ts lib/ai-risk-signal-monitor.test.ts app/api/cron/client-ai-ops-monitor/route.test.ts`
- `npm run build:knowledge && npx tsc --noEmit --pretty false`
- `git diff --check`
- `npm run build`

Build passed with the existing local environment warning that outbound n8n webhooks are enabled. No live workflow or customer-data smoke was run.

## Integration Notes

- No database migration required.
- Adds a weekly Vercel cron at `0 14 * * 1` for `/api/cron/moremi-risk-monitor`.
- The monitor is read-only: no live external fetch, no work-item creation, no production mutation, no public content, and no client-data access.
- Remediation remains approval-gated through the existing Moremi signal-to-work-item path.
- Integration Captain should verify both Vercel contexts after merge: `Vercel – portfolio` and `Vercel – portfolio-staging`.
