### PR TITLE
feat: surface Moremi monitor status

### DIFF
--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -150,7 +150,7 @@ type MissionSnapshot = {
   }
   operating_signals: Array<{
     run_id: string
-    kind: 'morning_review' | 'deployment_watch'
+    kind: 'morning_review' | 'deployment_watch' | 'ai_risk_signal_monitor'
     title: string
     status: string
     signal: string
@@ -920,7 +920,11 @@ function OperatingSignalsPanel({ signals }: { signals: MissionSnapshot['operatin
   return (
     <section className="mt-5 grid grid-cols-1 gap-3 lg:grid-cols-2">
       {signals.map((signal) => {
-        const isHealthy = signal.status === 'completed' || signal.signal.toLowerCase().includes('success')
+        const signalText = signal.signal.toLowerCase()
+        const isHealthy =
+          (signal.status === 'completed' || signalText.includes('success')) &&
+          !signalText.includes('warning') &&
+          !signalText.includes('failed')
         return (
           <Link
             key={`${signal.kind}-${signal.run_id}`}

--- a/lib/agent-mission-control.test.ts
+++ b/lib/agent-mission-control.test.ts
@@ -327,7 +327,7 @@ describe('Agent Mission Control helpers', () => {
     expect(summary.by_artifact_type[0]).toMatchObject({ key: 'warm_lead', label: 'warm lead' })
   })
 
-  it('surfaces morning review and deployment watcher traces as operating signals', () => {
+  it('surfaces morning review, deployment watcher, and Moremi monitor traces as operating signals', () => {
     const signals = buildAgentOperatingSignals([
       run({
         id: 'morning-run',
@@ -355,9 +355,21 @@ describe('Agent Mission Control helpers', () => {
           guidance: ['guidance=ready; both required Vercel contexts passed'],
         },
       }),
+      run({
+        id: 'moremi-run',
+        kind: 'ai_risk_signal_monitor',
+        status: 'completed',
+        current_step: 'Moremi AI risk signal monitor ready',
+        outcome: {
+          overall: 'warning',
+          warning_count: 2,
+          enabled_source_feed_count: 5,
+          disabled_source_feed_count: 1,
+        },
+      }),
     ])
 
-    expect(signals).toHaveLength(2)
+    expect(signals).toHaveLength(3)
     expect(signals[0]).toMatchObject({
       kind: 'morning_review',
       signal: 'Overall: ok',
@@ -369,5 +381,17 @@ describe('Agent Mission Control helpers', () => {
       summary: 'Latest watcher snapshot for main.',
     })
     expect(signals[1].details).toContain('Vercel – portfolio-staging: success')
+    expect(signals[2]).toMatchObject({
+      kind: 'ai_risk_signal_monitor',
+      title: 'Moremi Risk Monitor',
+      signal: 'Coverage: warning',
+      summary: 'Moremi AI risk signal monitor ready',
+      details: [
+        '2 warning(s)',
+        '5 enabled feed(s)',
+        '1 disabled feed(s)',
+        'Read-only; remediation approval-gated',
+      ],
+    })
   })
 })

--- a/lib/agent-mission-control.ts
+++ b/lib/agent-mission-control.ts
@@ -134,7 +134,7 @@ export type AgentCostSummary = {
 
 export type AgentOperatingSignal = {
   run_id: string
-  kind: 'morning_review' | 'deployment_watch'
+  kind: 'morning_review' | 'deployment_watch' | 'ai_risk_signal_monitor'
   title: string
   status: string
   signal: string
@@ -378,6 +378,7 @@ export function buildAgentCostSummary(input: {
 export function buildAgentOperatingSignals(runs: AgentRunRow[]): AgentOperatingSignal[] {
   const latestMorningReview = runs.find((run) => run.kind === 'agent_ops_morning_review')
   const latestDeploymentWatch = runs.find((run) => run.kind === 'agent_ops_deployment_watch')
+  const latestRiskSignalMonitor = runs.find((run) => run.kind === 'ai_risk_signal_monitor')
   const signals: AgentOperatingSignal[] = []
 
   if (latestMorningReview) {
@@ -448,6 +449,42 @@ export function buildAgentOperatingSignals(runs: AgentRunRow[]): AgentOperatingS
       updated_at: latestDeploymentWatch.completed_at ?? latestDeploymentWatch.started_at,
       href: `/admin/agents/runs/${latestDeploymentWatch.id}`,
       details: [...contexts.slice(0, 2), ...guidance.slice(0, 1)],
+    })
+  }
+
+  if (latestRiskSignalMonitor) {
+    const overall =
+      typeof latestRiskSignalMonitor.outcome?.overall === 'string'
+        ? latestRiskSignalMonitor.outcome.overall
+        : latestRiskSignalMonitor.status
+    const warningCount =
+      typeof latestRiskSignalMonitor.outcome?.warning_count === 'number'
+        ? latestRiskSignalMonitor.outcome.warning_count
+        : null
+    const enabledFeeds =
+      typeof latestRiskSignalMonitor.outcome?.enabled_source_feed_count === 'number'
+        ? latestRiskSignalMonitor.outcome.enabled_source_feed_count
+        : null
+    const disabledFeeds =
+      typeof latestRiskSignalMonitor.outcome?.disabled_source_feed_count === 'number'
+        ? latestRiskSignalMonitor.outcome.disabled_source_feed_count
+        : null
+
+    signals.push({
+      run_id: latestRiskSignalMonitor.id,
+      kind: 'ai_risk_signal_monitor',
+      title: 'Moremi Risk Monitor',
+      status: latestRiskSignalMonitor.status,
+      signal: `Coverage: ${overall}`,
+      summary: latestRiskSignalMonitor.error_message ?? latestRiskSignalMonitor.current_step ?? latestRiskSignalMonitor.title,
+      updated_at: latestRiskSignalMonitor.completed_at ?? latestRiskSignalMonitor.started_at,
+      href: `/admin/agents/runs/${latestRiskSignalMonitor.id}`,
+      details: [
+        warningCount === null ? null : `${warningCount} warning(s)`,
+        enabledFeeds === null ? null : `${enabledFeeds} enabled feed(s)`,
+        disabledFeeds === null ? null : `${disabledFeeds} disabled feed(s)`,
+        'Read-only; remediation approval-gated',
+      ].filter((detail): detail is string => Boolean(detail)),
     })
   }
 

--- a/lib/agent-slack-command.test.ts
+++ b/lib/agent-slack-command.test.ts
@@ -65,6 +65,7 @@ import {
   buildAgentBriefSlackText,
   buildAgentEngagementQueueSlackText,
   buildAgentPrsSlackText,
+  buildAgentRiskMonitorSlackText,
   buildAgentWorkItemsSlackText,
   buildCaptainQueueSlackText,
   claimAgentWorkItemSlackText,
@@ -88,6 +89,8 @@ describe('agent Slack command parsing', () => {
     expect(agentSlackCommandInternals.commandFromText('approvals')).toBe('approvals')
     expect(agentSlackCommandInternals.commandFromText('morning-review')).toBe('morning-review')
     expect(agentSlackCommandInternals.commandFromText('morning')).toBe('morning-review')
+    expect(agentSlackCommandInternals.commandFromText('risk')).toBe('risk')
+    expect(agentSlackCommandInternals.commandFromText('moremi')).toBe('risk')
     expect(agentSlackCommandInternals.commandFromText('agents')).toBe('agents')
     expect(agentSlackCommandInternals.commandFromText('list')).toBe('agents')
     expect(agentSlackCommandInternals.commandFromText('engagements')).toBe('engagements')
@@ -111,6 +114,7 @@ describe('agent Slack command parsing', () => {
     expect(agentSlackCommandInternals.commandFromText('unknown')).toBe('help')
     expect(agentSlackCommandInternals.formatHelp()).toContain('/agent status')
     expect(agentSlackCommandInternals.formatHelp()).toContain('/agent run <agent-key>')
+    expect(agentSlackCommandInternals.formatHelp()).toContain('/agent risk')
     expect(agentSlackCommandInternals.formatHelp()).toContain('/agent engagements')
     expect(agentSlackCommandInternals.formatHelp()).toContain('/agent work [id]')
     expect(agentSlackCommandInternals.formatHelp()).toContain('/agent captain')
@@ -275,6 +279,36 @@ describe('agent Slack command parsing', () => {
     expect(text).toContain('Daily Operating Brief')
     expect(text).toContain('Chief of Staff recommends')
     expect(text).toContain('/admin/agents/runs/standup-run')
+  })
+
+  it('formats Moremi risk monitor status for Slack', async () => {
+    inboxMocks.buildAgentMissionControlSnapshot.mockResolvedValue({
+      operating_signals: [
+        {
+          run_id: 'moremi-run',
+          kind: 'ai_risk_signal_monitor',
+          title: 'Moremi Risk Monitor',
+          status: 'completed',
+          signal: 'Coverage: warning',
+          summary: 'Moremi AI risk signal monitor ready',
+          updated_at: '2026-05-12T12:00:00.000Z',
+          href: '/admin/agents/runs/moremi-run',
+          details: [
+            '2 warning(s)',
+            '5 enabled feed(s)',
+            '1 disabled feed(s)',
+            'Read-only; remediation approval-gated',
+          ],
+        },
+      ],
+    })
+
+    const text = await buildAgentRiskMonitorSlackText()
+
+    expect(text).toContain('Moremi Risk Monitor')
+    expect(text).toContain('Coverage: warning')
+    expect(text).toContain('Read-only; remediation approval-gated')
+    expect(text).toContain('/admin/agents/runs/moremi-run')
   })
 
   it('routes an Agent Inbox item from Slack', async () => {

--- a/lib/agent-slack-command.ts
+++ b/lib/agent-slack-command.ts
@@ -19,6 +19,7 @@ type SlackCommandName =
   | 'failed'
   | 'approvals'
   | 'morning-review'
+  | 'risk'
   | 'agents'
   | 'engagements'
   | 'work-items'
@@ -97,6 +98,7 @@ function commandFromText(text: string): SlackCommandName {
   if (command === 'failed' || command === 'failures') return 'failed'
   if (command === 'approval' || command === 'approvals') return 'approvals'
   if (command === 'morning-review' || command === 'morning' || command === 'review') return 'morning-review'
+  if (command === 'risk' || command === 'moremi') return 'risk'
   if (command === 'agents' || command === 'list') return 'agents'
   if (command === 'engagements' || command === 'queue') return 'engagements'
   if (command === 'work') return 'work-items'
@@ -125,6 +127,7 @@ function formatHelp() {
     '`/agent failed` - latest failed or stale runs.',
     '`/agent approvals` - pending approval checkpoints.',
     '`/agent morning-review` - run the approved Agent Ops morning review trace.',
+    '`/agent risk` - show Moremi risk monitor coverage and latest trace.',
     '`/agent agents` - list currently mapped agents and engagement keys.',
     '`/agent engagements` - show the latest routed engagement work queue.',
     '`/agent work [id]` - show coordination work items or one work packet.',
@@ -330,6 +333,32 @@ export async function buildAgentBriefSlackText() {
     ].join('\n')
   } catch (error) {
     return `Daily Operating Brief lookup failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+  }
+}
+
+export async function buildAgentRiskMonitorSlackText() {
+  try {
+    const snapshot = await buildAgentMissionControlSnapshot()
+    const signal = snapshot.operating_signals.find((item) => item.kind === 'ai_risk_signal_monitor')
+    if (!signal) {
+      return [
+        '*Moremi Risk Monitor*',
+        'No Moremi risk monitor trace is visible yet.',
+        `Review: ${baseUrl()}/admin/agents`,
+      ].join('\n')
+    }
+
+    return [
+      '*Moremi Risk Monitor*',
+      `*${signal.signal}*`,
+      signal.summary,
+      '',
+      '*Details*',
+      ...signal.details.map((detail) => `- ${detail}`),
+      `Review: ${baseUrl()}${signal.href}`,
+    ].join('\n')
+  } catch (error) {
+    return `Moremi risk monitor lookup failed: ${error instanceof Error ? error.message : 'Unknown error'}`
   }
 }
 
@@ -639,35 +668,37 @@ export async function handleAgentSlackCommand(input: AgentSlackCommandInput): Pr
           ? await buildApprovalsSlackText()
           : command === 'morning-review'
             ? await runMorningReviewSlackText(input)
-            : command === 'agents'
-              ? formatAgentListSlackText()
-              : command === 'engagements'
-                ? await buildAgentEngagementQueueSlackText()
-                : command === 'work-items'
-                  ? await buildAgentWorkItemsSlackText(input)
-                  : command === 'claim'
-                    ? await claimAgentWorkItemSlackText(input)
-                    : command === 'handoff'
-                      ? await handoffAgentWorkItemSlackText(input)
-                      : command === 'blockers'
-                        ? await buildAgentBlockersSlackText()
-                        : command === 'prs'
-                          ? await buildAgentPrsSlackText()
-                          : command === 'captain'
-                            ? await buildCaptainQueueSlackText()
-                            : command === 'inbox'
-                              ? await buildAgentInboxSlackText()
-                              : command === 'brief'
-                                ? await buildAgentBriefSlackText()
-                                : command === 'route'
-                                  ? await routeAgentInboxSlackText(input)
-                                  : command === 'run'
-                                    ? await createAgentEngagementSlackText(input)
-                                    : command === 'standup'
-                                      ? await runWarRoomStandupSlackText(input)
-                                      : command === 'discuss'
-                                        ? await runWarRoomDiscussSlackText(input)
-                                        : formatHelp()
+            : command === 'risk'
+              ? await buildAgentRiskMonitorSlackText()
+              : command === 'agents'
+                ? formatAgentListSlackText()
+                : command === 'engagements'
+                  ? await buildAgentEngagementQueueSlackText()
+                  : command === 'work-items'
+                    ? await buildAgentWorkItemsSlackText(input)
+                    : command === 'claim'
+                      ? await claimAgentWorkItemSlackText(input)
+                      : command === 'handoff'
+                        ? await handoffAgentWorkItemSlackText(input)
+                        : command === 'blockers'
+                          ? await buildAgentBlockersSlackText()
+                          : command === 'prs'
+                            ? await buildAgentPrsSlackText()
+                            : command === 'captain'
+                              ? await buildCaptainQueueSlackText()
+                              : command === 'inbox'
+                                ? await buildAgentInboxSlackText()
+                                : command === 'brief'
+                                  ? await buildAgentBriefSlackText()
+                                  : command === 'route'
+                                    ? await routeAgentInboxSlackText(input)
+                                    : command === 'run'
+                                      ? await createAgentEngagementSlackText(input)
+                                      : command === 'standup'
+                                        ? await runWarRoomStandupSlackText(input)
+                                        : command === 'discuss'
+                                          ? await runWarRoomDiscussSlackText(input)
+                                          : formatHelp()
 
   return { responseType: 'ephemeral', text }
 }


### PR DESCRIPTION
## Summary

- surface Moremi's latest AI risk signal monitor as a Mission Control operating signal
- add `/agent risk` and `/agent moremi` Slack command support for the latest Moremi monitor trace
- keep warning coverage visually distinct from healthy completed operating signals

## Validation

- `npm test -- --run lib/agent-mission-control.test.ts lib/agent-slack-command.test.ts app/api/admin/agents/mission-control/route.test.ts`
- `npm run build:knowledge && npx tsc --noEmit --pretty false`
- `git diff --check`
- `npm run build`

Build passed with the existing local environment warning that outbound n8n webhooks are enabled. No live workflow or customer-data smoke was run.

## Integration Notes

- No database migration required.
- No cron, production mutation, remediation, live external fetch, or client-data access changes.
- Slack remains a read-only visibility surface for this slice.
- Integration Captain should verify both Vercel contexts after merge: `Vercel – portfolio` and `Vercel – portfolio-staging`.
