### PR TITLE
feat: complete Moremi warning review loop

### DIFF
--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -262,9 +262,34 @@ type ChiefReply = {
   }>
 }
 
+type MoremiMonitorReview = {
+  has_monitor: boolean
+  run: {
+    id: string
+    status: string
+    overall: string | null
+    generated_at: string | null
+    completed_at: string | null
+    href: string
+  } | null
+  warnings: string[]
+  warning_count: number
+  enabled_source_feed_count: number
+  disabled_source_feed_count: number
+  safety_boundary: string | null
+  linked_work_items: Array<{
+    id: string
+    title: string
+    status: string
+    owner_agent_key: string | null
+  }>
+}
+
 export default function AgentOperationsPage() {
   const [snapshot, setSnapshot] = useState<MissionSnapshot | null>(null)
+  const [moremiReview, setMoremiReview] = useState<MoremiMonitorReview | null>(null)
   const [loading, setLoading] = useState(true)
+  const [moremiReviewLoading, setMoremiReviewLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [command, setCommand] = useState('')
   const [chiefLoading, setChiefLoading] = useState(false)
@@ -276,6 +301,7 @@ export default function AgentOperationsPage() {
   const [inboxRoutingId, setInboxRoutingId] = useState<string | null>(null)
   const [engagementLoadingKey, setEngagementLoadingKey] = useState<string | null>(null)
   const [recoveryLoadingRunId, setRecoveryLoadingRunId] = useState<string | null>(null)
+  const [moremiReviewConfirm, setMoremiReviewConfirm] = useState(false)
 
   const authedFetch = useCallback(async (path: string, init: RequestInit = {}) => {
     const session = await getCurrentSession()
@@ -305,9 +331,28 @@ export default function AgentOperationsPage() {
     }
   }, [authedFetch])
 
+  const loadMoremiReview = useCallback(async () => {
+    setMoremiReviewLoading(true)
+    try {
+      const response = await authedFetch('/api/admin/agents/risk-compliance/monitor?review=latest')
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`)
+      setMoremiReview(body.review)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load Moremi review')
+    } finally {
+      setMoremiReviewLoading(false)
+    }
+  }, [authedFetch])
+
   useEffect(() => {
     loadMissionControl()
-  }, [loadMissionControl])
+    loadMoremiReview()
+  }, [loadMissionControl, loadMoremiReview])
+
+  async function refreshMissionControl() {
+    await Promise.all([loadMissionControl(), loadMoremiReview()])
+  }
 
   async function submitChiefOfStaff(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
@@ -459,6 +504,36 @@ export default function AgentOperationsPage() {
     }
   }
 
+  async function createMoremiWarningWorkItems() {
+    if (!moremiReviewConfirm) {
+      setMoremiReviewConfirm(true)
+      return
+    }
+
+    setActionLoading('moremi-review')
+    setActionResult(null)
+    setError(null)
+    try {
+      const response = await authedFetch('/api/admin/agents/risk-compliance/monitor', {
+        method: 'POST',
+        body: JSON.stringify({
+          action: 'create_moremi_warning_work_items',
+          confirmation: 'create_moremi_warning_work_items',
+        }),
+      })
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`)
+      setMoremiReview(body.review)
+      setMoremiReviewConfirm(false)
+      setActionResult({ label: `Moremi proposed ${body.work_items?.length ?? 0} work item(s)`, runId: body.review?.run?.id ?? 'moremi' })
+      await loadMissionControl()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Moremi review action failed')
+    } finally {
+      setActionLoading(null)
+    }
+  }
+
   const topAgents = useMemo(
     () => snapshot?.roster.flatMap((pod) => pod.agents).filter((agent) => agent.status !== 'planned').slice(0, 10) ?? [],
     [snapshot],
@@ -480,11 +555,11 @@ export default function AgentOperationsPage() {
             </div>
             <div className="flex flex-wrap gap-2">
               <button
-                onClick={loadMissionControl}
-                disabled={loading}
+                onClick={refreshMissionControl}
+                disabled={loading || moremiReviewLoading}
                 className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 bg-background/60 px-3 py-2 text-sm hover:border-radiant-gold/60 disabled:opacity-60"
               >
-                <RefreshCw size={16} className={loading ? 'animate-spin' : ''} />
+                <RefreshCw size={16} className={loading || moremiReviewLoading ? 'animate-spin' : ''} />
                 Refresh
               </button>
               <Link href="/admin/agents/runs" className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/50 bg-radiant-gold/10 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15">
@@ -518,6 +593,14 @@ export default function AgentOperationsPage() {
           <CostSummaryPanel summary={snapshot?.cost_summary ?? null} />
           <QualitySignalsPanel summary={snapshot?.quality_summary ?? null} />
           <OperatingSignalsPanel signals={snapshot?.operating_signals ?? []} />
+          <MoremiReviewPanel
+            review={moremiReview}
+            loading={moremiReviewLoading}
+            confirm={moremiReviewConfirm}
+            actionLoading={actionLoading === 'moremi-review'}
+            onCreate={createMoremiWarningWorkItems}
+            onCancel={() => setMoremiReviewConfirm(false)}
+          />
           <KnowledgeGovernancePanel governance={snapshot?.knowledge_governance ?? null} />
 
           <section className="mt-5 grid grid-cols-1 gap-5 xl:grid-cols-[1.2fr_0.8fr]">
@@ -711,6 +794,16 @@ function MetricCard({ icon, label, value, tone = 'default' }: { icon: ReactNode;
         <span className="text-xs font-semibold uppercase tracking-wider">{label}</span>
       </div>
       <p className={`mt-2 text-2xl font-semibold ${toneClass}`}>{value}</p>
+    </div>
+  )
+}
+
+function MiniMetric({ label, value, tone = 'default' }: { label: string; value: string | number; tone?: 'default' | 'yellow' | 'green' }) {
+  const toneClass = tone === 'yellow' ? 'text-yellow-200' : tone === 'green' ? 'text-emerald-200' : 'text-foreground'
+  return (
+    <div className="rounded-lg border border-silicon-slate/50 bg-black/10 p-3">
+      <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">{label}</p>
+      <p className={`mt-1 text-lg font-semibold ${toneClass}`}>{value}</p>
     </div>
   )
 }
@@ -956,6 +1049,130 @@ function OperatingSignalsPanel({ signals }: { signals: MissionSnapshot['operatin
           </Link>
         )
       })}
+    </section>
+  )
+}
+
+function MoremiReviewPanel({
+  review,
+  loading,
+  confirm,
+  actionLoading,
+  onCreate,
+  onCancel,
+}: {
+  review: MoremiMonitorReview | null
+  loading: boolean
+  confirm: boolean
+  actionLoading: boolean
+  onCreate: () => void
+  onCancel: () => void
+}) {
+  const hasWarnings = (review?.warning_count ?? 0) > 0
+  const linkedCount = review?.linked_work_items.length ?? 0
+
+  return (
+    <section className="mt-5 rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <div className="flex items-center gap-2 text-radiant-gold">
+            {hasWarnings ? <AlertTriangle size={18} /> : <ShieldCheck size={18} />}
+            <h2 className="font-semibold">Moremi Warning Review</h2>
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Converts the latest read-only AI risk monitor warnings into proposed Agent Ops work items only after explicit confirmation.
+          </p>
+        </div>
+        {review?.run ? (
+          <Link
+            href={review.run.href}
+            className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 bg-background/60 px-3 py-2 text-sm hover:border-radiant-gold/60"
+          >
+            Latest trace
+            <ArrowRight size={16} />
+          </Link>
+        ) : null}
+      </div>
+
+      {loading ? (
+        <p className="mt-3 text-sm text-muted-foreground">Loading latest Moremi review...</p>
+      ) : !review?.has_monitor ? (
+        <p className="mt-3 rounded-lg border border-silicon-slate/50 bg-black/10 p-3 text-sm text-muted-foreground">
+          No Moremi monitor trace exists yet. Run the scheduled monitor or wait for the next read-only review before creating work items.
+        </p>
+      ) : (
+        <>
+          <div className="mt-4 grid grid-cols-2 gap-3 lg:grid-cols-5">
+            <MiniMetric label="Status" value={review.run?.overall ?? review.run?.status ?? 'unknown'} />
+            <MiniMetric label="Warnings" value={review.warning_count} tone={hasWarnings ? 'yellow' : 'green'} />
+            <MiniMetric label="Enabled feeds" value={review.enabled_source_feed_count} />
+            <MiniMetric label="Disabled feeds" value={review.disabled_source_feed_count} tone={review.disabled_source_feed_count ? 'yellow' : undefined} />
+            <MiniMetric label="Linked work" value={linkedCount} />
+          </div>
+
+          {review.warnings.length ? (
+            <div className="mt-4 rounded-lg border border-silicon-slate/50 bg-black/10 p-3">
+              <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Warnings</p>
+              <ul className="mt-2 space-y-2 text-sm text-muted-foreground">
+                {review.warnings.slice(0, 5).map((warning) => (
+                  <li key={warning} className="flex gap-2">
+                    <AlertTriangle size={14} className="mt-0.5 shrink-0 text-radiant-gold" />
+                    <span>{warning}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          {review.linked_work_items.length ? (
+            <div className="mt-4 rounded-lg border border-silicon-slate/50 bg-black/10 p-3">
+              <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Linked proposed work</p>
+              <div className="mt-2 space-y-2 text-sm">
+                {review.linked_work_items.slice(0, 4).map((item) => (
+                  <div key={item.id} className="flex flex-wrap items-center justify-between gap-2">
+                    <span className="text-foreground">{item.title}</span>
+                    <span className="rounded-full border border-silicon-slate/50 bg-black/10 px-2.5 py-1 text-xs text-muted-foreground">
+                      {item.status}
+                    </span>
+                  </div>
+                ))}
+              </div>
+              <Link href="/admin/agents/coordination" className="mt-3 inline-flex items-center gap-2 text-sm text-radiant-gold hover:underline">
+                Open Agent Coordination
+                <ArrowRight size={14} />
+              </Link>
+            </div>
+          ) : null}
+
+          <div className="mt-4 flex flex-col gap-3 rounded-lg border border-silicon-slate/50 bg-black/10 p-3 md:flex-row md:items-center md:justify-between">
+            <p className="text-sm text-muted-foreground">
+              {confirm
+                ? 'Confirming creates or reuses proposed work items only. Remediation and production changes remain approval-gated.'
+                : 'Review warnings first, then create proposed work items when they need tracked follow-through.'}
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {confirm ? (
+                <button
+                  type="button"
+                  onClick={onCancel}
+                  className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 bg-background/60 px-3 py-2 text-sm hover:border-radiant-gold/60"
+                >
+                  Cancel
+                </button>
+              ) : null}
+              <button
+                type="button"
+                onClick={onCreate}
+                disabled={!hasWarnings || actionLoading}
+                className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/50 bg-radiant-gold/10 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15 disabled:opacity-60"
+              >
+                <ClipboardList size={16} />
+                {confirm ? 'Confirm proposed work items' : 'Create proposed work items'}
+              </button>
+            </div>
+          </div>
+        </>
+      )}
     </section>
   )
 }

--- a/app/api/admin/agents/risk-compliance/monitor/route.test.ts
+++ b/app/api/admin/agents/risk-compliance/monitor/route.test.ts
@@ -4,6 +4,8 @@ const mocks = vi.hoisted(() => ({
   verifyAdmin: vi.fn(),
   isAuthError: vi.fn(),
   createAgentWorkItem: vi.fn(),
+  getLatestMoremiMonitorReview: vi.fn(),
+  createMoremiWarningWorkItems: vi.fn(),
 }))
 
 vi.mock('@/lib/auth-server', () => ({
@@ -13,6 +15,12 @@ vi.mock('@/lib/auth-server', () => ({
 
 vi.mock('@/lib/agent-work-items', () => ({
   createAgentWorkItem: mocks.createAgentWorkItem,
+}))
+
+vi.mock('@/lib/moremi-monitor-review', () => ({
+  MOREMI_WARNING_WORK_ITEMS_CONFIRMATION: 'create_moremi_warning_work_items',
+  getLatestMoremiMonitorReview: mocks.getLatestMoremiMonitorReview,
+  createMoremiWarningWorkItems: mocks.createMoremiWarningWorkItems,
 }))
 
 import { GET, POST } from './route'
@@ -34,6 +42,29 @@ describe('/api/admin/agents/risk-compliance/monitor', () => {
       id: 'work-item-1',
       title: 'Review AI risk signal: AI agent prompt injection vulnerability affects browser automation',
       status: 'proposed',
+    })
+    mocks.getLatestMoremiMonitorReview.mockResolvedValue({
+      has_monitor: true,
+      run: { id: 'moremi-run', href: '/admin/agents/runs/moremi-run', overall: 'warning' },
+      warnings: ['OWASP AIVSS is disabled pending policy approval.'],
+      warning_count: 1,
+      linked_work_items: [],
+      side_effects: {
+        work_items_created: false,
+        production_mutation_allowed: false,
+        live_external_fetch: false,
+        client_data_access: false,
+      },
+    })
+    mocks.createMoremiWarningWorkItems.mockResolvedValue({
+      review: {
+        has_monitor: true,
+        run: { id: 'moremi-run', href: '/admin/agents/runs/moremi-run', overall: 'warning' },
+        warnings: ['OWASP AIVSS is disabled pending policy approval.'],
+        warning_count: 1,
+        linked_work_items: [{ id: 'moremi-work-1', status: 'proposed' }],
+      },
+      work_items: [{ id: 'moremi-work-1', status: 'proposed' }],
     })
   })
 
@@ -75,6 +106,23 @@ describe('/api/admin/agents/risk-compliance/monitor', () => {
       'owasp-agent-security-initiative',
       'owasp-aivss',
     ])
+  })
+
+  it('returns the latest monitor review state', async () => {
+    const response = await GET(
+      new Request('http://localhost/api/admin/agents/risk-compliance/monitor?review=latest') as never,
+    )
+
+    expect(response.status).toBe(200)
+    expect(mocks.getLatestMoremiMonitorReview).toHaveBeenCalled()
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      review: {
+        has_monitor: true,
+        run: { id: 'moremi-run' },
+        warnings: ['OWASP AIVSS is disabled pending policy approval.'],
+      },
+    })
   })
 
   it('rejects invalid source feed filters', async () => {
@@ -191,6 +239,40 @@ describe('/api/admin/agents/risk-compliance/monitor', () => {
         work_items_created: true,
         work_item_count: 1,
         production_mutation_allowed: false,
+      },
+    })
+  })
+
+  it('requires Moremi review confirmation before creating warning work items', async () => {
+    const response = await POST(request({
+      action: 'create_moremi_warning_work_items',
+      confirmation: 'wrong',
+    }) as never)
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: 'confirmation must be create_moremi_warning_work_items to create Moremi warning work items',
+    })
+    expect(mocks.createMoremiWarningWorkItems).not.toHaveBeenCalled()
+  })
+
+  it('creates or reuses proposed work items from the latest Moremi warnings when confirmed', async () => {
+    const response = await POST(request({
+      action: 'create_moremi_warning_work_items',
+      confirmation: 'create_moremi_warning_work_items',
+    }) as never)
+
+    expect(response.status).toBe(200)
+    expect(mocks.createMoremiWarningWorkItems).toHaveBeenCalled()
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      work_items: [{ id: 'moremi-work-1', status: 'proposed' }],
+      side_effects: {
+        work_items_created: true,
+        work_item_count: 1,
+        production_mutation_allowed: false,
+        live_external_fetch: false,
+        client_data_access: false,
       },
     })
   })

--- a/app/api/admin/agents/risk-compliance/monitor/route.ts
+++ b/app/api/admin/agents/risk-compliance/monitor/route.ts
@@ -12,6 +12,11 @@ import {
   type AiRiskSignalInput,
 } from '@/lib/ai-risk-signal-monitor'
 import { createAgentWorkItem } from '@/lib/agent-work-items'
+import {
+  createMoremiWarningWorkItems,
+  getLatestMoremiMonitorReview,
+  MOREMI_WARNING_WORK_ITEMS_CONFIRMATION,
+} from '@/lib/moremi-monitor-review'
 
 export const dynamic = 'force-dynamic'
 
@@ -47,6 +52,14 @@ export async function GET(request: NextRequest) {
   }
 
   const { searchParams } = new URL(request.url)
+  const reviewMode = searchParams.get('review') === 'latest' || searchParams.get('mode') === 'latest_review'
+  if (reviewMode) {
+    return NextResponse.json({
+      ok: true,
+      review: await getLatestMoremiMonitorReview(),
+    })
+  }
+
   const category = searchParams.get('category')
   if (category && !AI_RISK_SIGNAL_CATEGORIES.includes(category as AiRiskSignalCategory)) {
     return NextResponse.json({ error: 'Invalid category' }, { status: 400 })
@@ -77,6 +90,30 @@ export async function POST(request: NextRequest) {
   }
 
   const body = (await request.json().catch(() => ({}))) as Record<string, unknown>
+  if (body.action === 'create_moremi_warning_work_items') {
+    if (body.confirmation !== MOREMI_WARNING_WORK_ITEMS_CONFIRMATION) {
+      return NextResponse.json(
+        { error: `confirmation must be ${MOREMI_WARNING_WORK_ITEMS_CONFIRMATION} to create Moremi warning work items` },
+        { status: 400 },
+      )
+    }
+
+    const result = await createMoremiWarningWorkItems()
+    return NextResponse.json({
+      ok: true,
+      review: result.review,
+      work_items: result.work_items,
+      side_effects: {
+        work_items_created: result.work_items.length > 0,
+        work_item_count: result.work_items.length,
+        production_mutation_allowed: false,
+        live_external_fetch: false,
+        client_data_access: false,
+        note: 'Created or reused proposed Agent Ops work items only. Remediation remains approval-gated.',
+      },
+    })
+  }
+
   const signals = parseSignals(body.signals)
   if (!signals.length) {
     return NextResponse.json({ error: 'signals array with title and summary is required' }, { status: 400 })

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -70,6 +70,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
    - [x] Spin out Moremi (Ife) - Risk & Compliance for AI agent/current-event risk monitoring and Portfolio exposure checks.
    - [x] Add a synthetic Moremi operational drill that proves AI risk signal conversion into proposed Agent Ops work items.
    - [x] Add a scheduled read-only risk signal monitor once source feeds and scoring criteria are approved.
+   - [x] Add the Moremi governance loop that reviews latest monitor warnings and explicitly converts them into proposed Agent Ops work items from Admin or Slack.
    - [ ] Continue monitoring Yaa Asantewaa (Ashanti) - Automation Systems for a future split only if trace/work-item load stays high.
 
 ## Completed Or In Review

--- a/docs/ai-risk-compliance-agent.md
+++ b/docs/ai-risk-compliance-agent.md
@@ -41,8 +41,10 @@ The first implementation surface is read-only by default and approval-gated for 
 
 - `GET /api/admin/agents/risk-compliance/monitor` returns Moremi's monitor configuration and safety boundary.
 - `POST /api/admin/agents/risk-compliance/monitor` accepts supplied signal briefs and returns exposure assessments plus proposed upgrade-request payloads.
+- `GET /api/admin/agents/risk-compliance/monitor?review=latest` returns the latest scheduled monitor run, monitor artifact, warnings, source-feed coverage, safety boundary, and linked work items.
 - Default `POST` behavior does not create work items, mutate workflows, write remediation changes, or send notifications.
 - `POST` may create proposed Agent Ops work items only when the caller sends both `create_work_items: true` and `confirmation: "create_ai_risk_work_items"`.
+- Latest monitor warnings may be converted into proposed Agent Ops work items only when the caller sends `action: "create_moremi_warning_work_items"` and `confirmation: "create_moremi_warning_work_items"`.
 - Created work items stay in `proposed` status with human review required before remediation, merge, deployment, production config, or workflow mutation.
 - The endpoint does not fetch live news automatically in v1.
 - Source feeds are explicit and filterable before ingestion is automated:
@@ -59,6 +61,20 @@ Moremi runs a weekly source-feed coverage monitor through Vercel cron:
 - The monitor creates an Agent Ops run and artifact with enabled/disabled feed counts, category coverage, priority coverage, and warnings.
 - The monitor does not fetch live external pages, create work items, mutate workflows, change production config, send public content, or touch client data.
 - The first schedule is weekly on Monday at 14:00 UTC, after the daily client AI Ops monitor.
+- Admins can review the latest monitor warning state in Agent Operations Mission Control and explicitly create or reuse proposed warning work items from the same control plane.
+- Slack mirrors the same read/write boundary: `/agent risk` is read-only, and `/agent risk review create_moremi_warning_work_items` creates or reuses proposed work items only.
+
+### Moremi Signal Resolution
+
+A Moremi signal is considered done when one of these outcomes is recorded through Agent Ops:
+
+- No action needed after review.
+- A proposed work item exists for the warning.
+- An approval packet is routed for gated remediation.
+- Risk is explicitly accepted with rationale.
+- The resulting work item reaches `merged`, `deployed`, or `cancelled`.
+
+The review loop does not add new statuses. It uses the existing coordination statuses from `proposed` through `deployed` so warnings remain visible in `/admin/agents/coordination`, `/agent work`, and `/agent captain`.
 
 ### Operational Drill
 
@@ -103,6 +119,15 @@ Explicit work-item conversion payload:
       "category": "privacy_data"
     }
   ]
+}
+```
+
+Latest monitor warning conversion payload:
+
+```json
+{
+  "action": "create_moremi_warning_work_items",
+  "confirmation": "create_moremi_warning_work_items"
 }
 ```
 

--- a/lib/agent-slack-command.test.ts
+++ b/lib/agent-slack-command.test.ts
@@ -32,6 +32,11 @@ const workItemMocks = vi.hoisted(() => ({
   handoffAgentWorkItem: vi.fn(),
 }))
 
+const moremiReviewMocks = vi.hoisted(() => ({
+  getLatestMoremiMonitorReview: vi.fn(),
+  createMoremiWarningWorkItems: vi.fn(),
+}))
+
 vi.mock('@/lib/agent-run', () => ({
   startAgentRun: agentRunMocks.startAgentRun,
   recordAgentEvent: agentRunMocks.recordAgentEvent,
@@ -59,6 +64,12 @@ vi.mock('@/lib/agent-work-items', () => ({
   handoffAgentWorkItem: workItemMocks.handoffAgentWorkItem,
 }))
 
+vi.mock('@/lib/moremi-monitor-review', () => ({
+  MOREMI_WARNING_WORK_ITEMS_CONFIRMATION: 'create_moremi_warning_work_items',
+  getLatestMoremiMonitorReview: moremiReviewMocks.getLatestMoremiMonitorReview,
+  createMoremiWarningWorkItems: moremiReviewMocks.createMoremiWarningWorkItems,
+}))
+
 import {
   agentSlackCommandInternals,
   buildAgentBlockersSlackText,
@@ -79,6 +90,36 @@ import {
 describe('agent Slack command parsing', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    moremiReviewMocks.getLatestMoremiMonitorReview.mockResolvedValue({
+      has_monitor: true,
+      run: {
+        id: 'moremi-run',
+        href: '/admin/agents/runs/moremi-run',
+        status: 'completed',
+        overall: 'warning',
+      },
+      warnings: ['OWASP AIVSS is disabled pending policy approval.'],
+      warning_count: 1,
+      enabled_source_feed_count: 5,
+      disabled_source_feed_count: 1,
+      linked_work_items: [],
+    })
+    moremiReviewMocks.createMoremiWarningWorkItems.mockResolvedValue({
+      review: {
+        run: {
+          id: 'moremi-run',
+          href: '/admin/agents/runs/moremi-run',
+        },
+        warning_count: 1,
+      },
+      work_items: [
+        {
+          id: 'work-1',
+          title: 'Review Moremi warning: OWASP AIVSS is disabled pending policy approval.',
+          status: 'proposed',
+        },
+      ],
+    })
   })
 
   it('maps supported aliases to command handlers', () => {
@@ -282,33 +323,55 @@ describe('agent Slack command parsing', () => {
   })
 
   it('formats Moremi risk monitor status for Slack', async () => {
-    inboxMocks.buildAgentMissionControlSnapshot.mockResolvedValue({
-      operating_signals: [
-        {
-          run_id: 'moremi-run',
-          kind: 'ai_risk_signal_monitor',
-          title: 'Moremi Risk Monitor',
-          status: 'completed',
-          signal: 'Coverage: warning',
-          summary: 'Moremi AI risk signal monitor ready',
-          updated_at: '2026-05-12T12:00:00.000Z',
-          href: '/admin/agents/runs/moremi-run',
-          details: [
-            '2 warning(s)',
-            '5 enabled feed(s)',
-            '1 disabled feed(s)',
-            'Read-only; remediation approval-gated',
-          ],
-        },
-      ],
-    })
-
     const text = await buildAgentRiskMonitorSlackText()
 
     expect(text).toContain('Moremi Risk Monitor')
     expect(text).toContain('Coverage: warning')
+    expect(text).toContain('1 warning(s)')
     expect(text).toContain('Read-only; remediation approval-gated')
     expect(text).toContain('/admin/agents/runs/moremi-run')
+  })
+
+  it('creates proposed Moremi warning work items from Slack only when confirmed', async () => {
+    const text = await buildAgentRiskMonitorSlackText({
+      text: 'risk review create_moremi_warning_work_items',
+      userId: 'U123',
+      userName: 'vambah',
+    })
+
+    expect(moremiReviewMocks.createMoremiWarningWorkItems).toHaveBeenCalled()
+    expect(text).toContain('Moremi Risk Review')
+    expect(text).toContain('Work items created or reused: 1')
+    expect(text).toContain('work-1')
+    expect(text).toContain('/admin/agents/coordination')
+  })
+
+  it('rejects malformed Moremi risk review confirmation from Slack', async () => {
+    const text = await buildAgentRiskMonitorSlackText({
+      text: 'risk review wrong',
+      userId: 'U123',
+      userName: 'vambah',
+    })
+
+    expect(moremiReviewMocks.createMoremiWarningWorkItems).not.toHaveBeenCalled()
+    expect(text).toContain('Malformed confirmation')
+    expect(text).toContain('create_moremi_warning_work_items')
+  })
+
+  it('handles a missing Moremi monitor from Slack', async () => {
+    moremiReviewMocks.getLatestMoremiMonitorReview.mockResolvedValueOnce({
+      has_monitor: false,
+      run: null,
+      warnings: [],
+      warning_count: 0,
+      enabled_source_feed_count: 0,
+      disabled_source_feed_count: 0,
+      linked_work_items: [],
+    })
+
+    const text = await buildAgentRiskMonitorSlackText()
+
+    expect(text).toContain('No Moremi risk monitor trace is visible yet')
   })
 
   it('routes an Agent Inbox item from Slack', async () => {

--- a/lib/agent-slack-command.ts
+++ b/lib/agent-slack-command.ts
@@ -12,6 +12,11 @@ import {
   listAgentWorkItems,
   type AgentWorkItem,
 } from '@/lib/agent-work-items'
+import {
+  createMoremiWarningWorkItems,
+  getLatestMoremiMonitorReview,
+  MOREMI_WARNING_WORK_ITEMS_CONFIRMATION,
+} from '@/lib/moremi-monitor-review'
 
 type SlackCommandName =
   | 'help'
@@ -128,6 +133,7 @@ function formatHelp() {
     '`/agent approvals` - pending approval checkpoints.',
     '`/agent morning-review` - run the approved Agent Ops morning review trace.',
     '`/agent risk` - show Moremi risk monitor coverage and latest trace.',
+    '`/agent risk review create_moremi_warning_work_items` - create or reuse proposed work items from latest Moremi warnings.',
     '`/agent agents` - list currently mapped agents and engagement keys.',
     '`/agent engagements` - show the latest routed engagement work queue.',
     '`/agent work [id]` - show coordination work items or one work packet.',
@@ -336,11 +342,46 @@ export async function buildAgentBriefSlackText() {
   }
 }
 
-export async function buildAgentRiskMonitorSlackText() {
+export async function buildAgentRiskMonitorSlackText(input: AgentSlackCommandInput = { text: 'risk' }) {
   try {
-    const snapshot = await buildAgentMissionControlSnapshot()
-    const signal = snapshot.operating_signals.find((item) => item.kind === 'ai_risk_signal_monitor')
-    if (!signal) {
+    const [subcommand, confirmation] = commandArgs(input.text)
+
+    if (subcommand === 'review' && confirmation === MOREMI_WARNING_WORK_ITEMS_CONFIRMATION) {
+      const result = await createMoremiWarningWorkItems()
+      if (!result.review.run) {
+        return [
+          '*Moremi Risk Review*',
+          'No Moremi monitor trace is visible yet.',
+          `Review: ${baseUrl()}/admin/agents`,
+        ].join('\n')
+      }
+
+      const itemLines = result.work_items.length
+        ? result.work_items.map((item) => `- ${item.id}: ${item.title} [${item.status}]`)
+        : ['- No warnings required new work items.']
+
+      return [
+        '*Moremi Risk Review*',
+        `Latest trace: <${baseUrl()}${result.review.run.href}|${result.review.run.id}>`,
+        `Warnings: ${result.review.warning_count}`,
+        `Work items created or reused: ${result.work_items.length}`,
+        '',
+        '*Work items*',
+        ...itemLines,
+        `Coordination: ${baseUrl()}/admin/agents/coordination`,
+      ].join('\n')
+    }
+
+    if (subcommand === 'review' && confirmation) {
+      return [
+        '*Moremi Risk Review*',
+        `Malformed confirmation. Use \`/agent risk review ${MOREMI_WARNING_WORK_ITEMS_CONFIRMATION}\` to create proposed work items.`,
+        'Slack cannot approve remediation, merge code, mutate workflows, or touch production config.',
+      ].join('\n')
+    }
+
+    const review = await getLatestMoremiMonitorReview()
+    if (!review.run) {
       return [
         '*Moremi Risk Monitor*',
         'No Moremi risk monitor trace is visible yet.',
@@ -348,14 +389,25 @@ export async function buildAgentRiskMonitorSlackText() {
       ].join('\n')
     }
 
+    const warnings = review.warnings.length
+      ? review.warnings.slice(0, 5).map((warning) => `- ${warning}`)
+      : ['- None']
+
     return [
       '*Moremi Risk Monitor*',
-      `*${signal.signal}*`,
-      signal.summary,
+      `*Coverage: ${review.run.overall ?? review.run.status}*`,
+      `Latest trace: <${baseUrl()}${review.run.href}|${review.run.id}>`,
       '',
       '*Details*',
-      ...signal.details.map((detail) => `- ${detail}`),
-      `Review: ${baseUrl()}${signal.href}`,
+      `- ${review.warning_count} warning(s)`,
+      `- ${review.enabled_source_feed_count} enabled feed(s)`,
+      `- ${review.disabled_source_feed_count} disabled feed(s)`,
+      `- ${review.linked_work_items.length} linked work item(s)`,
+      '- Read-only; remediation approval-gated',
+      '',
+      '*Warnings*',
+      ...warnings,
+      `Create proposed work items: \`/agent risk review ${MOREMI_WARNING_WORK_ITEMS_CONFIRMATION}\``,
     ].join('\n')
   } catch (error) {
     return `Moremi risk monitor lookup failed: ${error instanceof Error ? error.message : 'Unknown error'}`
@@ -669,7 +721,7 @@ export async function handleAgentSlackCommand(input: AgentSlackCommandInput): Pr
           : command === 'morning-review'
             ? await runMorningReviewSlackText(input)
             : command === 'risk'
-              ? await buildAgentRiskMonitorSlackText()
+              ? await buildAgentRiskMonitorSlackText(input)
               : command === 'agents'
                 ? formatAgentListSlackText()
                 : command === 'engagements'

--- a/lib/moremi-monitor-review.test.ts
+++ b/lib/moremi-monitor-review.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  from: vi.fn(),
+  createAgentWorkItem: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+vi.mock('@/lib/agent-work-items', () => ({
+  createAgentWorkItem: mocks.createAgentWorkItem,
+}))
+
+import {
+  createMoremiWarningWorkItems,
+  getLatestMoremiMonitorReview,
+} from './moremi-monitor-review'
+
+function queryReturning(result: unknown) {
+  const query = {
+    select: vi.fn(() => query),
+    eq: vi.fn(() => query),
+    order: vi.fn(() => query),
+    limit: vi.fn(async () => result),
+  }
+  return query
+}
+
+const runRow = {
+  id: 'run-moremi-1',
+  title: 'Run Moremi AI risk signal monitor',
+  status: 'completed',
+  current_step: 'Moremi AI risk signal monitor ready',
+  error_message: null,
+  started_at: '2026-05-12T12:00:00.000Z',
+  completed_at: '2026-05-12T12:01:00.000Z',
+  outcome: {
+    overall: 'warning',
+    warning_count: 1,
+    enabled_source_feed_count: 5,
+    disabled_source_feed_count: 1,
+    generated_at: '2026-05-12T12:00:00.000Z',
+  },
+  metadata: {},
+}
+
+const artifactRow = {
+  id: 'artifact-1',
+  title: 'Moremi AI Risk Signal Monitor - warning',
+  artifact_type: 'ai_risk_signal_monitor',
+  created_at: '2026-05-12T12:01:00.000Z',
+  metadata: {
+    summary_markdown: '# Moremi AI Risk Signal Monitor',
+    warnings: ['OWASP AIVSS is disabled pending policy approval.'],
+    source_feeds: [
+      { key: 'owasp-agent-security-initiative', enabled: true },
+      { key: 'owasp-aivss', enabled: false },
+    ],
+    coverage_by_category: { prompt_injection: 2 },
+    coverage_by_priority: { standards: 2 },
+    safety_boundary: 'Read-only source-feed coverage review.',
+  },
+}
+
+describe('Moremi monitor review helper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns an empty state when no monitor exists', async () => {
+    mocks.from.mockReturnValueOnce(queryReturning({ data: [], error: null }))
+
+    const review = await getLatestMoremiMonitorReview()
+
+    expect(review).toMatchObject({
+      has_monitor: false,
+      run: null,
+      warnings: [],
+      linked_work_items: [],
+      side_effects: {
+        work_items_created: false,
+        production_mutation_allowed: false,
+        live_external_fetch: false,
+        client_data_access: false,
+      },
+    })
+  })
+
+  it('returns the latest monitor artifact and linked work items', async () => {
+    mocks.from
+      .mockReturnValueOnce(queryReturning({ data: [runRow], error: null }))
+      .mockReturnValueOnce(queryReturning({ data: [artifactRow], error: null }))
+      .mockReturnValueOnce(queryReturning({
+        data: [
+          {
+            id: 'work-1',
+            title: 'Review Moremi warning',
+            status: 'proposed',
+            source_run_id: 'run-moremi-1',
+          },
+        ],
+        error: null,
+      }))
+
+    const review = await getLatestMoremiMonitorReview()
+
+    expect(review).toMatchObject({
+      has_monitor: true,
+      run: {
+        id: 'run-moremi-1',
+        href: '/admin/agents/runs/run-moremi-1',
+        overall: 'warning',
+      },
+      artifact: {
+        id: 'artifact-1',
+        summary_markdown: '# Moremi AI Risk Signal Monitor',
+      },
+      warnings: ['OWASP AIVSS is disabled pending policy approval.'],
+      warning_count: 1,
+      enabled_source_feed_count: 5,
+      disabled_source_feed_count: 1,
+      linked_work_items: [
+        expect.objectContaining({ id: 'work-1', status: 'proposed' }),
+      ],
+    })
+  })
+
+  it('creates idempotent proposed work items for monitor warnings', async () => {
+    mocks.from
+      .mockReturnValueOnce(queryReturning({ data: [runRow], error: null }))
+      .mockReturnValueOnce(queryReturning({ data: [artifactRow], error: null }))
+      .mockReturnValueOnce(queryReturning({ data: [], error: null }))
+      .mockReturnValueOnce(queryReturning({ data: [runRow], error: null }))
+      .mockReturnValueOnce(queryReturning({ data: [artifactRow], error: null }))
+      .mockReturnValueOnce(queryReturning({
+        data: [{ id: 'work-1', title: 'Review Moremi warning', status: 'proposed' }],
+        error: null,
+      }))
+
+    mocks.createAgentWorkItem.mockResolvedValue({
+      id: 'work-1',
+      title: 'Review Moremi warning: OWASP AIVSS is disabled pending policy approval.',
+      status: 'proposed',
+    })
+
+    const result = await createMoremiWarningWorkItems()
+
+    expect(mocks.createAgentWorkItem).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'Review Moremi warning: OWASP AIVSS is disabled pending policy approval.',
+      status: 'proposed',
+      ownerAgentKey: 'risk-compliance-intelligence',
+      ownerRuntime: 'manual',
+      sourceRunId: 'run-moremi-1',
+      overlapGroup: 'ai-risk-compliance',
+      idempotencyKey: expect.stringMatching(/^moremi-warning:run-moremi-1:/),
+      metadata: expect.objectContaining({
+        moremi_warning_work_item: true,
+        warning: 'OWASP AIVSS is disabled pending policy approval.',
+        production_mutation_allowed: false,
+        live_external_fetch: false,
+        client_data_access: false,
+      }),
+    }))
+    expect(result.work_items).toEqual([
+      expect.objectContaining({ id: 'work-1', status: 'proposed' }),
+    ])
+    expect(result.review.linked_work_items).toEqual([
+      expect.objectContaining({ id: 'work-1', status: 'proposed' }),
+    ])
+  })
+})

--- a/lib/moremi-monitor-review.ts
+++ b/lib/moremi-monitor-review.ts
@@ -1,0 +1,262 @@
+import { createHash } from 'crypto'
+import { createAgentWorkItem, type AgentWorkItem } from '@/lib/agent-work-items'
+import { supabaseAdmin } from '@/lib/supabase'
+
+export const MOREMI_WARNING_WORK_ITEMS_CONFIRMATION = 'create_moremi_warning_work_items'
+
+type AgentRunRow = {
+  id: string
+  title: string
+  status: string
+  current_step: string | null
+  error_message: string | null
+  started_at: string
+  completed_at: string | null
+  outcome: Record<string, unknown> | null
+  metadata: Record<string, unknown> | null
+}
+
+type AgentArtifactRow = {
+  id: string
+  title: string
+  artifact_type: string
+  metadata: Record<string, unknown> | null
+  created_at: string
+}
+
+export type MoremiMonitorReviewState = {
+  has_monitor: boolean
+  run: {
+    id: string
+    title: string
+    status: string
+    current_step: string | null
+    error_message: string | null
+    generated_at: string | null
+    completed_at: string | null
+    overall: string | null
+    href: string
+  } | null
+  artifact: {
+    id: string
+    title: string
+    created_at: string
+    summary_markdown: string | null
+  } | null
+  warnings: string[]
+  warning_count: number
+  enabled_source_feed_count: number
+  disabled_source_feed_count: number
+  coverage_by_category: Record<string, number>
+  coverage_by_priority: Record<string, number>
+  source_feeds: Array<Record<string, unknown>>
+  safety_boundary: string | null
+  linked_work_items: AgentWorkItem[]
+  side_effects: {
+    work_items_created: boolean
+    production_mutation_allowed: boolean
+    live_external_fetch: boolean
+    client_data_access: boolean
+  }
+}
+
+export type MoremiWarningWorkItemCreationResult = {
+  review: MoremiMonitorReviewState
+  work_items: AgentWorkItem[]
+}
+
+function db() {
+  if (!supabaseAdmin) throw new Error('Database not available')
+  return supabaseAdmin
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0) : []
+}
+
+function asNumberRecord(value: unknown): Record<string, number> {
+  const record = asRecord(value)
+  return Object.fromEntries(
+    Object.entries(record).filter((entry): entry is [string, number] => typeof entry[1] === 'number'),
+  )
+}
+
+function asSourceFeeds(value: unknown): Array<Record<string, unknown>> {
+  return Array.isArray(value)
+    ? value.filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === 'object' && !Array.isArray(item))
+    : []
+}
+
+function warningHash(warning: string) {
+  return createHash('sha256').update(warning.trim()).digest('hex').slice(0, 16)
+}
+
+function shortWarning(warning: string, maxLength = 120) {
+  const clean = warning.trim()
+  return clean.length <= maxLength ? clean : `${clean.slice(0, maxLength - 1)}...`
+}
+
+export async function getLatestMoremiMonitorReview(): Promise<MoremiMonitorReviewState> {
+  const { data: runRows, error: runError } = await db()
+    .from('agent_runs')
+    .select('id,title,status,current_step,error_message,started_at,completed_at,outcome,metadata')
+    .eq('kind', 'ai_risk_signal_monitor')
+    .order('started_at', { ascending: false })
+    .limit(1)
+
+  if (runError) throw new Error(`Failed to read latest Moremi monitor run: ${runError.message}`)
+  const run = (runRows?.[0] ?? null) as AgentRunRow | null
+
+  if (!run) {
+    return {
+      has_monitor: false,
+      run: null,
+      artifact: null,
+      warnings: [],
+      warning_count: 0,
+      enabled_source_feed_count: 0,
+      disabled_source_feed_count: 0,
+      coverage_by_category: {},
+      coverage_by_priority: {},
+      source_feeds: [],
+      safety_boundary: null,
+      linked_work_items: [],
+      side_effects: {
+        work_items_created: false,
+        production_mutation_allowed: false,
+        live_external_fetch: false,
+        client_data_access: false,
+      },
+    }
+  }
+
+  const [
+    { data: artifactRows, error: artifactError },
+    { data: workItemRows, error: workItemError },
+  ] = await Promise.all([
+    db()
+      .from('agent_run_artifacts')
+      .select('id,title,artifact_type,metadata,created_at')
+      .eq('run_id', run.id)
+      .eq('artifact_type', 'ai_risk_signal_monitor')
+      .order('created_at', { ascending: false })
+      .limit(1),
+    db()
+      .from('agent_work_items')
+      .select('*')
+      .eq('source_run_id', run.id)
+      .order('updated_at', { ascending: false })
+      .limit(50),
+  ])
+
+  if (artifactError) throw new Error(`Failed to read Moremi monitor artifact: ${artifactError.message}`)
+  if (workItemError) throw new Error(`Failed to read Moremi linked work items: ${workItemError.message}`)
+
+  const artifact = (artifactRows?.[0] ?? null) as AgentArtifactRow | null
+  const artifactMetadata = asRecord(artifact?.metadata)
+  const outcome = asRecord(run.outcome)
+  const sourceFeeds = asSourceFeeds(artifactMetadata.source_feeds)
+  const warnings = asStringArray(artifactMetadata.warnings)
+  const enabledCount = typeof outcome.enabled_source_feed_count === 'number'
+    ? outcome.enabled_source_feed_count
+    : sourceFeeds.filter((feed) => feed.enabled === true).length
+  const disabledCount = typeof outcome.disabled_source_feed_count === 'number'
+    ? outcome.disabled_source_feed_count
+    : sourceFeeds.filter((feed) => feed.enabled === false).length
+
+  return {
+    has_monitor: true,
+    run: {
+      id: run.id,
+      title: run.title,
+      status: run.status,
+      current_step: run.current_step,
+      error_message: run.error_message,
+      generated_at: typeof outcome.generated_at === 'string' ? outcome.generated_at : run.started_at,
+      completed_at: run.completed_at,
+      overall: typeof outcome.overall === 'string' ? outcome.overall : null,
+      href: `/admin/agents/runs/${run.id}`,
+    },
+    artifact: artifact
+      ? {
+          id: artifact.id,
+          title: artifact.title,
+          created_at: artifact.created_at,
+          summary_markdown: typeof artifactMetadata.summary_markdown === 'string' ? artifactMetadata.summary_markdown : null,
+        }
+      : null,
+    warnings,
+    warning_count: typeof outcome.warning_count === 'number' ? outcome.warning_count : warnings.length,
+    enabled_source_feed_count: enabledCount,
+    disabled_source_feed_count: disabledCount,
+    coverage_by_category: asNumberRecord(artifactMetadata.coverage_by_category),
+    coverage_by_priority: asNumberRecord(artifactMetadata.coverage_by_priority),
+    source_feeds: sourceFeeds,
+    safety_boundary: typeof artifactMetadata.safety_boundary === 'string' ? artifactMetadata.safety_boundary : null,
+    linked_work_items: (workItemRows ?? []) as AgentWorkItem[],
+    side_effects: {
+      work_items_created: false,
+      production_mutation_allowed: false,
+      live_external_fetch: false,
+      client_data_access: false,
+    },
+  }
+}
+
+export async function createMoremiWarningWorkItems(): Promise<MoremiWarningWorkItemCreationResult> {
+  const review = await getLatestMoremiMonitorReview()
+  if (!review.run || review.warnings.length === 0) {
+    return { review, work_items: [] }
+  }
+  const run = review.run
+
+  const workItems = await Promise.all(review.warnings.map((warning) => {
+    const hash = warningHash(warning)
+    return createAgentWorkItem({
+      title: `Review Moremi warning: ${shortWarning(warning)}`,
+      objective: [
+        `Review the Moremi AI risk monitor warning from run ${run.id}: ${warning}`,
+        'Decide whether no action is needed, risk should be accepted, an approval packet is required, or a remediation task should be proposed.',
+      ].join(' '),
+      priority: 'medium',
+      status: 'proposed',
+      ownerAgentKey: 'risk-compliance-intelligence',
+      ownerRuntime: 'manual',
+      source: {
+        type: 'ai_risk_signal_monitor_warning',
+        id: `${run.id}:${hash}`,
+        label: 'Moremi AI risk monitor warning',
+      },
+      sourceRunId: run.id,
+      overlapGroup: 'ai-risk-compliance',
+      metadata: {
+        moremi_warning_work_item: true,
+        monitor_run_id: run.id,
+        warning,
+        warning_hash: hash,
+        source_feed_context: {
+          enabled_source_feed_count: review.enabled_source_feed_count,
+          disabled_source_feed_count: review.disabled_source_feed_count,
+          coverage_by_category: review.coverage_by_category,
+          coverage_by_priority: review.coverage_by_priority,
+        },
+        safety_boundary: review.safety_boundary,
+        approval_boundary: 'Moremi warning work items are proposed review records only. Remediation, publishing, production config changes, workflow mutation, client-data access, and external sends require their existing approval gates.',
+        production_mutation_allowed: false,
+        live_external_fetch: false,
+        client_data_access: false,
+        public_content_allowed: false,
+      },
+      idempotencyKey: `moremi-warning:${run.id}:${hash}`,
+    })
+  }))
+
+  return {
+    review: await getLatestMoremiMonitorReview(),
+    work_items: workItems,
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable latest Moremi monitor review model backed by Agent Ops runs, artifacts, and linked work items
- add an explicit confirmed Admin/Slack path to create or reuse proposed work items from monitor warnings
- surface the Moremi warning review loop in Agent Operations Mission Control and document the final resolution criteria

## Validation
- `npm test -- --run lib/moremi-monitor-review.test.ts app/api/admin/agents/risk-compliance/monitor/route.test.ts lib/agent-slack-command.test.ts`
- `npm test -- --run lib/ai-risk-signal-monitor.test.ts lib/moremi-risk-signal-monitor.test.ts lib/moremi-monitor-review.test.ts app/api/admin/agents/risk-compliance/monitor/route.test.ts app/api/admin/agents/risk-compliance/drill/route.test.ts app/api/cron/moremi-risk-monitor/route.test.ts lib/agent-slack-command.test.ts lib/agent-mission-control.test.ts app/admin/agents/coordination/page.test.tsx lib/agent-work-items.test.ts`
- `npm run build:knowledge && npx tsc --noEmit --pretty false`
- `git diff --check`
- `npm run build`

Build passed with the existing local env warning that outbound n8n webhooks are enabled in the dev environment. No live workflow or customer-data smoke was run.

## Integration Notes
- No database migration required; this reuses existing Agent Ops run, artifact, and work-item tables.
- Mutation requires the explicit confirmation phrase `create_moremi_warning_work_items`.
- Created records remain `proposed`; remediation, workflow mutation, production config changes, public sends, and client-data access remain approval-gated.
- Vercel contexts to verify after merge: `Vercel – portfolio` and `Vercel – portfolio-staging`.
