### PR TITLE
Add Portfolio worktree env bootstrap

### DIFF
--- a/docs/worktree-env-bootstrap.md
+++ b/docs/worktree-env-bootstrap.md
@@ -1,0 +1,33 @@
+# Worktree Env Bootstrap
+
+Use this when creating a sibling Portfolio worktree for Codex, Hermes, or other
+agent implementation lanes.
+
+```bash
+npm run worktree:env
+```
+
+The script finds the `main` worktree and symlinks local runtime files into the
+current worktree:
+
+- `.env.local`
+- `.env.staging`
+- `.vercel`
+
+These paths are gitignored. The script does not print secret values and does not
+copy secrets into git-tracked files. Symlinks are preferred so credential
+rotation in the main checkout is reflected in future worktree runs.
+
+You can override the source checkout or linked paths:
+
+```bash
+npm run worktree:env -- --source /Users/vambahsillah/Projects/Portfolio
+npm run worktree:env -- --paths .env.local,.vercel
+```
+
+The database pre-push health check is still production-aware:
+
+- local pushes without explicit `PROD_SUPABASE_URL` and
+  `PROD_SUPABASE_SERVICE_ROLE_KEY` skip the production baseline check,
+- CI still runs the check,
+- `npm run db:health-check:dev` remains available for dev database validation.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "credentials:rotate": "tsx scripts/credential-broker.ts rotate",
     "credentials:sync-runtime": "tsx scripts/credential-broker.ts sync-runtime",
     "credentials:smoke": "tsx scripts/credential-broker.ts smoke",
+    "worktree:env": "tsx scripts/bootstrap-worktree-env.ts",
     "db:health-check": "tsx scripts/database-health-check.ts",
     "db:health-check:update": "tsx scripts/database-health-check.ts --update",
     "db:health-check:dev": "tsx scripts/database-health-check.ts --dev",

--- a/scripts/bootstrap-worktree-env.test.ts
+++ b/scripts/bootstrap-worktree-env.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import {
+  parseArgs,
+  parseWorktreeList,
+  selectSourceRoot,
+} from './bootstrap-worktree-env'
+
+describe('bootstrap-worktree-env', () => {
+  it('parses default options', () => {
+    expect(parseArgs([])).toEqual({
+      sourceRoot: null,
+      localPaths: ['.env.local', '.env.staging', '.vercel'],
+      replaceBrokenSymlinks: true,
+    })
+  })
+
+  it('parses source and path overrides', () => {
+    expect(parseArgs(['--source', '/tmp/main', '--paths', '.env.local,.vercel'])).toEqual({
+      sourceRoot: '/tmp/main',
+      localPaths: ['.env.local', '.vercel'],
+      replaceBrokenSymlinks: true,
+    })
+  })
+
+  it('selects the main worktree as the default source root', () => {
+    const entries = parseWorktreeList(`worktree /Users/vambahsillah/Projects/Portfolio
+HEAD abc123
+branch refs/heads/main
+
+worktree /Users/vambahsillah/Projects/Portfolio.worktrees/feature
+HEAD def456
+branch refs/heads/codex/feature
+`)
+
+    expect(selectSourceRoot(entries, '/fallback')).toBe('/Users/vambahsillah/Projects/Portfolio')
+  })
+
+  it('falls back to the current checkout when main is not listed', () => {
+    expect(selectSourceRoot([], '/fallback')).toBe('/fallback')
+  })
+})

--- a/scripts/bootstrap-worktree-env.ts
+++ b/scripts/bootstrap-worktree-env.ts
@@ -1,0 +1,147 @@
+#!/usr/bin/env tsx
+import { spawnSync } from 'node:child_process'
+import { existsSync, lstatSync, readlinkSync, symlinkSync, unlinkSync } from 'node:fs'
+import { basename, dirname, relative, resolve } from 'node:path'
+
+const DEFAULT_LOCAL_PATHS = ['.env.local', '.env.staging', '.vercel']
+
+type BootstrapOptions = {
+  sourceRoot: string | null
+  localPaths: string[]
+  replaceBrokenSymlinks: boolean
+}
+
+type WorktreeEntry = {
+  path: string
+  branch: string | null
+}
+
+export function parseArgs(argv: string[]): BootstrapOptions {
+  const options: BootstrapOptions = {
+    sourceRoot: null,
+    localPaths: DEFAULT_LOCAL_PATHS,
+    replaceBrokenSymlinks: true,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    const next = argv[index + 1]
+
+    if (arg === '--source' && next) {
+      options.sourceRoot = resolve(next)
+      index += 1
+    } else if (arg === '--paths' && next) {
+      options.localPaths = next
+        .split(',')
+        .map((value) => value.trim())
+        .filter(Boolean)
+      index += 1
+    } else if (arg === '--keep-broken-symlinks') {
+      options.replaceBrokenSymlinks = false
+    } else if (arg === '--help' || arg === '-h') {
+      console.log(`Usage:
+  npm run worktree:env -- [options]
+
+Options:
+  --source <path>  Source checkout to link local env files from. Defaults to the main worktree.
+  --paths <list>   Comma-separated local paths to link. Defaults to .env.local,.env.staging,.vercel.
+`)
+      process.exit(0)
+    } else {
+      throw new Error(`Unknown option: ${arg}`)
+    }
+  }
+
+  if (options.localPaths.length === 0) {
+    throw new Error('--paths must include at least one local path')
+  }
+
+  return options
+}
+
+export function parseWorktreeList(output: string): WorktreeEntry[] {
+  return output
+    .split(/\n(?=worktree )/)
+    .map((block) => {
+      const lines = block.split('\n').filter(Boolean)
+      const path = lines.find((line) => line.startsWith('worktree '))?.slice('worktree '.length) ?? ''
+      const branch = lines.find((line) => line.startsWith('branch '))?.slice('branch '.length) ?? null
+      return path ? { path, branch } : null
+    })
+    .filter((entry): entry is WorktreeEntry => Boolean(entry))
+}
+
+export function selectSourceRoot(entries: WorktreeEntry[], fallback: string): string {
+  return entries.find((entry) => entry.branch === 'refs/heads/main')?.path ?? fallback
+}
+
+function gitWorktreeEntries(): WorktreeEntry[] {
+  const result = spawnSync('git', ['worktree', 'list', '--porcelain'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  if (result.status !== 0) {
+    const message = result.stderr.trim() || result.stdout.trim() || 'git worktree list failed'
+    throw new Error(message)
+  }
+
+  return parseWorktreeList(result.stdout)
+}
+
+function isBrokenSymlink(path: string) {
+  try {
+    const stat = lstatSync(path)
+    if (!stat.isSymbolicLink()) return false
+    const target = resolve(dirname(path), readlinkSync(path))
+    return !existsSync(target)
+  } catch {
+    return false
+  }
+}
+
+function linkLocalPath(sourceRoot: string, targetRoot: string, localPath: string, replaceBrokenSymlinks: boolean) {
+  const source = resolve(sourceRoot, localPath)
+  const target = resolve(targetRoot, localPath)
+
+  if (!existsSync(source)) {
+    return `skip ${localPath}: source not found in ${sourceRoot}`
+  }
+
+  if (existsSync(target)) {
+    return `skip ${localPath}: already present`
+  }
+
+  if (isBrokenSymlink(target)) {
+    if (!replaceBrokenSymlinks) return `skip ${localPath}: broken symlink already present`
+    unlinkSync(target)
+  }
+
+  symlinkSync(source, target)
+  return `linked ${localPath} -> ${relative(targetRoot, source)}`
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  const targetRoot = process.cwd()
+  const sourceRoot = options.sourceRoot ?? selectSourceRoot(gitWorktreeEntries(), targetRoot)
+
+  if (resolve(sourceRoot) === resolve(targetRoot)) {
+    console.log(`Current checkout already appears to be the source worktree: ${sourceRoot}`)
+    return
+  }
+
+  console.log(`Linking local worktree runtime files from ${sourceRoot} into ${targetRoot}`)
+  for (const localPath of options.localPaths) {
+    console.log(linkLocalPath(sourceRoot, targetRoot, localPath, options.replaceBrokenSymlinks))
+  }
+
+  console.log(`Done. Linked paths are gitignored; ${basename(sourceRoot)} remains the source of local secrets.`)
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exit(1)
+  })
+}

--- a/scripts/database-health-check.ts
+++ b/scripts/database-health-check.ts
@@ -39,17 +39,6 @@ const SUPABASE_SERVICE_KEY = useDev
 const urlVar = useDev ? 'NEXT_PUBLIC_SUPABASE_URL' : 'PROD_SUPABASE_URL'
 const keyVar = useDev ? 'SUPABASE_SERVICE_ROLE_KEY' : 'PROD_SUPABASE_SERVICE_ROLE_KEY'
 
-if (!SUPABASE_URL?.trim()) {
-  console.error(`❌ ${urlVar} is missing.`)
-  console.error('   Add it to .env.local in the project root (or set in CI).')
-  process.exit(1)
-}
-if (!SUPABASE_SERVICE_KEY?.trim()) {
-  console.error(`❌ ${keyVar} is missing.`)
-  console.error('   Add it to .env.local in the project root (or set in CI).')
-  process.exit(1)
-}
-
 const SUPABASE_URL_SAFE: string = SUPABASE_URL as string
 const SUPABASE_SERVICE_KEY_SAFE: string = SUPABASE_SERVICE_KEY as string
 const BASELINE_FILE = path.join(
@@ -157,6 +146,17 @@ async function main() {
     console.log('   To enforce prod row counts before push, add those vars (same project as .database-baseline.json).')
     console.log('   To check your dev database: npm run db:health-check:dev')
     process.exit(0)
+  }
+
+  if (!SUPABASE_URL?.trim()) {
+    console.error(`❌ ${urlVar} is missing.`)
+    console.error('   Add it to .env.local in the project root (or set in CI).')
+    process.exit(1)
+  }
+  if (!SUPABASE_SERVICE_KEY?.trim()) {
+    console.error(`❌ ${keyVar} is missing.`)
+    console.error('   Add it to .env.local in the project root (or set in CI).')
+    process.exit(1)
   }
 
   console.log(`🔍 Running database health check [${envLabel}]...\n`)


### PR DESCRIPTION
## Summary
- add `npm run worktree:env` to symlink local runtime files from the main Portfolio checkout into sibling worktrees
- document the worktree env bootstrap flow and safety boundary
- fix `scripts/database-health-check.ts` so local no-prod-env worktrees actually reach the intended skip path before failing on missing credentials

## Validation
- `npm run worktree:env`
- `npm run db:health-check` with linked env files
- no-env smoke: temporarily moved linked env files aside and confirmed `npm run db:health-check` exits cleanly through the local skip path
- `npm test -- --run scripts/bootstrap-worktree-env.test.ts`
- `npm run build:knowledge && npx tsc --noEmit --pretty false`
- `npm run lint`
- `git diff --check`
- normal `git push` passed the repaired pre-push database health check

## Notes
- The bootstrap script links gitignored files only and does not print secret values.
- Stop before merge: Integration Captain should review and merge/deploy.