### PR TITLE
Gate Vercel AutoResearch Open Brain traces

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,14 @@ NEXT_PUBLIC_SITE_URL=http://localhost:3000
 NEXT_PUBLIC_BASE_URL=http://localhost:3000
 ADMIN_URL=http://localhost:3000/admin
 
+# ── Open Brain producer gates ────────────────────────────────────────────────
+# AutoResearch can emit sanitized Open Brain source/event trace records when it
+# creates an approval packet. This does not execute experiments, promote durable
+# memory, write Pinecone, or mutate production config.
+# Keep off by default; enable deliberately in local/staging after reviewing
+# Open Brain event volume and privacy behavior.
+OPEN_BRAIN_AUTORESEARCH_TRACE=false
+
 # ── Supabase (DEV — used by the app at runtime) ─────────────────────────────
 NEXT_PUBLIC_SUPABASE_URL=https://YOUR_DEV_PROJECT.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-dev-anon-key

--- a/.env.staging.example
+++ b/.env.staging.example
@@ -39,6 +39,10 @@ N8N_CLOUD_API_KEY=
 # N8N_DISABLE_OUTBOUND=true
 # MOCK_N8N=true
 
+# Optional: emit sanitized AutoResearch source/event traces into Open Brain.
+# Default is off unless explicitly enabled.
+# OPEN_BRAIN_AUTORESEARCH_TRACE=true
+
 # Slack test channel routing (set to "test-" to route test messages to #test-* channels)
 # When set, n8n workflows should prefix Slack channel names with this value for test runs.
 # N8N_SLACK_CHANNEL_PREFIX=test-

--- a/docs/memory-context-organization-workflow.md
+++ b/docs/memory-context-organization-workflow.md
@@ -91,7 +91,7 @@ Initial producer routes now covered by the contract:
 - personality corpus public-safe pack,
 - local chatbot knowledge bundle,
 - governed RAG/Pinecone shadow ingestion plans,
-- Vercel AutoResearch proposal packets,
+- Vercel AutoResearch proposal packets when `OPEN_BRAIN_AUTORESEARCH_TRACE=true`,
 - Model Ops router decisions and swap requests,
 - Codex automation and workspace-root reports.
 
@@ -171,7 +171,7 @@ Allowed:
 - Show progress and task status computed from the inventory.
 - Show read-only Codex workspace-root and active thread placement drift.
 - Show Open Brain source freshness, proposal health, runtime parity, and wiki overlay previews.
-- Show Open Brain source/event traces from personality corpus, chatbot knowledge, RAG shadow plans, AutoResearch proposal packets, Model Ops, and Codex automation state.
+- Show Open Brain source/event traces from personality corpus, chatbot knowledge, RAG shadow plans, gated AutoResearch proposal packets, Model Ops, and Codex automation state.
 - Show public-safe Open Brain RAG projection previews with deletion and rollback metadata.
 
 Not allowed in this workflow without an explicit operational-state step:

--- a/docs/open-brain-local-service.md
+++ b/docs/open-brain-local-service.md
@@ -130,7 +130,7 @@ Current producer routes:
 - Personality corpus: public-safe derived pack appears as a `personality_corpus` source; raw private exports remain outside public projections.
 - Chatbot knowledge: `/api/knowledge` remains a public-safe projection, not canonical memory.
 - RAG/Pinecone: `/api/admin/rag-ingest` records shadow-plan source/event records and blocks writes pending cutover approval.
-- AutoResearch: proposal creation records `autoresearch_proposal` source/event records; experiments, merges, deploys, hosted config changes, and durable memories remain separately gated.
+- AutoResearch: when `OPEN_BRAIN_AUTORESEARCH_TRACE=true`, proposal creation records `autoresearch_proposal` source/event records; experiments, merges, deploys, hosted config changes, and durable memories remain separately gated. Keep this producer flag off by default until trace volume and privacy behavior are reviewed.
 - Model Ops: router decisions and swap requests appear as projection sources; model defaults remain approval-gated.
 
 ## RAG And Pinecone Projection

--- a/docs/vercel-deployment-autoresearch.md
+++ b/docs/vercel-deployment-autoresearch.md
@@ -17,9 +17,18 @@ npm run deploy:research:plan -- --json
 The planner uses the current deployment metrics scorecard to propose focused
 experiments. A proposal becomes actionable only after it is routed into Agent
 Coordination as a pending `vercel_deployment_research_proposal` approval.
-Creating that approval also records sanitized Open Brain source/event records so
-the proposal is visible in the local memory timeline without becoming durable
-memory.
+When `OPEN_BRAIN_AUTORESEARCH_TRACE=true`, creating that approval also records
+sanitized Open Brain source/event records so the proposal is visible in the
+local memory timeline without becoming durable memory.
+
+Default:
+
+```bash
+OPEN_BRAIN_AUTORESEARCH_TRACE=false
+```
+
+Enable the flag deliberately in local or staging first. Production should only
+enable it after reviewing trace volume and privacy behavior.
 
 ## Approval Gate
 
@@ -56,7 +65,8 @@ Proposal-ready notifications are event-driven. There is no schedule.
 - Integration Captain still owns merge and deployment sequencing.
 - Technology Bakeoff owns vendor, runtime, or provider promotion decisions.
 - Open Brain records the proposal trace as source/event metadata, but it is not
-  the execution engine, approval source of truth, or notification service.
+  the execution engine, approval source of truth, or notification service. This
+  trace path is disabled unless `OPEN_BRAIN_AUTORESEARCH_TRACE=true`.
 - Approved experiment outcomes may become Open Brain memory proposals later.
   They do not become durable memory unless reviewed and approved in the Open
   Brain flow.

--- a/lib/vercel-deployment-research-approvals.test.ts
+++ b/lib/vercel-deployment-research-approvals.test.ts
@@ -127,6 +127,7 @@ function setupExistingApproval() {
 describe('createVercelResearchApproval', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    process.env.OPEN_BRAIN_AUTORESEARCH_TRACE = '1'
     mocks.recordAgentEvent.mockResolvedValue({ id: 'event-1' })
     mocks.notify.mockResolvedValue(true)
     mocks.recordOpenBrainSource.mockResolvedValue({
@@ -202,5 +203,25 @@ describe('createVercelResearchApproval', () => {
     })
 
     expect(mocks.notify).not.toHaveBeenCalled()
+  })
+
+  it('skips Open Brain trace when disabled', async () => {
+    delete process.env.OPEN_BRAIN_AUTORESEARCH_TRACE
+    mocks.createAgentWorkItem.mockResolvedValue({
+      id: 'work-1',
+      active_run_id: 'run-1',
+      approval_id: null,
+    })
+    setupNewApproval()
+
+    await expect(createVercelResearchApproval({
+      proposal,
+      createdByUserId: 'admin-user',
+    })).resolves.toMatchObject({
+      approvalId: 'approval-1',
+    })
+
+    expect(mocks.recordOpenBrainSource).not.toHaveBeenCalled()
+    expect(mocks.recordOpenBrainEvent).not.toHaveBeenCalled()
   })
 })

--- a/lib/vercel-deployment-research-approvals.ts
+++ b/lib/vercel-deployment-research-approvals.ts
@@ -30,6 +30,12 @@ type ApprovalRow = {
   metadata: Record<string, unknown> | null
 }
 
+function shouldRecordOpenBrainTrace() {
+  const raw = process.env.OPEN_BRAIN_AUTORESEARCH_TRACE
+  if (!raw) return false
+  return raw === '1' || raw.toLowerCase() === 'true'
+}
+
 function db() {
   if (!supabaseAdmin) throw new Error('Database not available')
   return supabaseAdmin
@@ -199,14 +205,16 @@ export async function createVercelResearchApproval(input: {
       idempotencyKey: `${workItem.id}:vercel-autoresearch-approval-created`,
     }).catch(() => {})
 
-    await recordVercelResearchOpenBrainTrace({
-      proposal,
-      approvalId: approval.id,
-      runId: workItem.active_run_id,
-      workItemId: workItem.id,
-    }).catch((error) => {
-      console.warn('[vercel-autoresearch] Open Brain trace skipped:', error instanceof Error ? error.message : error)
-    })
+    if (shouldRecordOpenBrainTrace()) {
+      await recordVercelResearchOpenBrainTrace({
+        proposal,
+        approvalId: approval.id,
+        runId: workItem.active_run_id,
+        workItemId: workItem.id,
+      }).catch((error) => {
+        console.warn('[vercel-autoresearch] Open Brain trace skipped:', error instanceof Error ? error.message : error)
+      })
+    }
   }
 
   const notification = await notifyApprovalOnce(approval, workItem.id, proposal)


### PR DESCRIPTION
## Summary
- Keep AutoResearch Open Brain source/event trace emission behind OPEN_BRAIN_AUTORESEARCH_TRACE.
- Document the producer gate in env templates and Open Brain/AutoResearch docs.
- Preserve default-off behavior so production-adjacent experiment traces are deliberate, source/event-only, and not durable memories.

## Validation
- npm test -- --run lib/vercel-deployment-research-approvals.test.ts lib/open-brain.test.ts
- npx tsc --noEmit --pretty false
- npm run lint
- push hook db:health-check passed

## Safety
- No experiments execute automatically.
- No durable Open Brain memory promotion.
- No Pinecone write.
- No production config mutation.
- Default env template value is OPEN_BRAIN_AUTORESEARCH_TRACE=false.