### PR TITLE
Add banned books rights-ready corpus swarm

### DIFF
--- a/app/admin/source-protocol/page.test.tsx
+++ b/app/admin/source-protocol/page.test.tsx
@@ -63,6 +63,54 @@ const overview = {
   monthlyPayouts: [],
   disputes: [],
   modelReviews: [],
+  bannedBooksCorpus: {
+    generatedAt: '2026-05-12T00:00:00.000Z',
+    scope: 'U.S. school and library bans/challenges first.',
+    licenseModel: 'RAG only.',
+    sourceSpine: [
+      {
+        name: 'ALA Most Challenged Books',
+        role: 'Annual challenged-title evidence.',
+      },
+    ],
+    swarmAgents: [
+      {
+        key: 'banned-book-source-registry',
+        name: 'Amina, Source Registry Lead',
+        lane: 'Discovery evidence',
+        output: 'Source evidence only.',
+        boundary: 'No rights-holder guesses.',
+        approvalGate: 'Source evidence required.',
+      },
+    ],
+    summary: {
+      stagedRecords: 1,
+      sourceSpineCount: 1,
+      rightsReadyRecords: 1,
+      outreachReadyRecords: 1,
+      activeLicenseRecords: 0,
+      retrievableRecords: 0,
+      blockedRecords: 0,
+    },
+    records: [
+      {
+        id: 'demo-book',
+        canonicalTitle: 'Demo Challenged Book',
+        authors: ['Demo Author'],
+        banStatus: 'challenged',
+        jurisdictionContext: 'U.S. school challenge evidence.',
+        rightsholderCandidate: {
+          name: 'Demo Author or publisher',
+          confidence: 'medium',
+        },
+        outreachStatus: 'not_started',
+        licenseStatus: 'not_requested',
+        ingestionStatus: 'not_started',
+        nextAction: 'Draft RAG-only permission packet.',
+      },
+    ],
+    safeguards: ['Do not ingest full text before license approval.'],
+  },
 }
 
 describe('SourceProtocolPage', () => {
@@ -81,6 +129,12 @@ describe('SourceProtocolPage', () => {
     render(<SourceProtocolPage />)
 
     expect(await screen.findByRole('heading', { name: 'Source Protocol' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Banned Books Rights-Ready Corpus' })).toBeInTheDocument()
+    expect(screen.getByText('Amina, Source Registry Lead')).toBeInTheDocument()
+    expect(screen.getByText('Demo Challenged Book')).toBeInTheDocument()
+
+    fireEvent.click(screen.getAllByRole('button', { name: /Portal Access/i })[0])
+
     expect(screen.getByText(/Payouts accrue per answer receipt/i)).toBeInTheDocument()
     expect(screen.getByText('Demo Creator')).toBeInTheDocument()
     expect(screen.getByText('creator@example.com')).toBeInTheDocument()

--- a/app/admin/source-protocol/page.tsx
+++ b/app/admin/source-protocol/page.tsx
@@ -43,6 +43,24 @@ type SourceProtocolOverview = {
   monthlyPayouts?: any[]
   disputes?: any[]
   modelReviews?: any[]
+  bannedBooksCorpus?: {
+    generatedAt: string
+    scope: string
+    licenseModel: string
+    sourceSpine: any[]
+    swarmAgents: any[]
+    summary: {
+      stagedRecords: number
+      sourceSpineCount: number
+      rightsReadyRecords: number
+      outreachReadyRecords: number
+      activeLicenseRecords: number
+      retrievableRecords: number
+      blockedRecords: number
+    }
+    records: any[]
+    safeguards: string[]
+  }
 }
 
 type AdminUserOption = {
@@ -51,9 +69,10 @@ type AdminUserOption = {
   role: string
 }
 
-type TabKey = 'portal' | 'creators' | 'works' | 'grants' | 'chunks' | 'receipts' | 'payouts' | 'reviews'
+type TabKey = 'bannedBooks' | 'portal' | 'creators' | 'works' | 'grants' | 'chunks' | 'receipts' | 'payouts' | 'reviews'
 
 const TABS: Array<{ key: TabKey; label: string }> = [
+  { key: 'bannedBooks', label: 'Banned Books' },
   { key: 'portal', label: 'Portal Access' },
   { key: 'creators', label: 'Creators' },
   { key: 'works', label: 'Works' },
@@ -76,7 +95,7 @@ function SourceProtocolContent() {
   const [overview, setOverview] = useState<SourceProtocolOverview | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [tab, setTab] = useState<TabKey>('portal')
+  const [tab, setTab] = useState<TabKey>('bannedBooks')
   const [userSearch, setUserSearch] = useState('')
   const [userOptions, setUserOptions] = useState<AdminUserOption[]>([])
   const [selectedUserId, setSelectedUserId] = useState('')
@@ -198,6 +217,7 @@ function SourceProtocolContent() {
       receipts: overview?.receipts?.length ?? 0,
       payouts: overview?.monthlyPayouts?.length ?? 0,
       reviews: overview?.modelReviews?.length ?? 0,
+      bannedBooks: overview?.bannedBooksCorpus?.summary.stagedRecords ?? 0,
     }),
     [overview]
   )
@@ -325,6 +345,7 @@ function SourceProtocolContent() {
                   onUpdate={updatePortalAccount}
                 />
               )}
+              {tab === 'bannedBooks' && <BannedBooksCorpusPanel corpus={overview.bannedBooksCorpus} />}
               {tab === 'creators' && <CreatorsTable rows={overview.creators ?? []} />}
               {tab === 'works' && <WorksTable rows={overview.works ?? []} />}
               {tab === 'grants' && <GrantsTable rows={overview.licenseGrants ?? []} />}
@@ -567,6 +588,108 @@ function PortalAccountsPanel({
                   <RefreshCw size={12} className="inline" /> Receipts
                 </button>
               </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}
+
+function BannedBooksCorpusPanel({ corpus }: { corpus: SourceProtocolOverview['bannedBooksCorpus'] }) {
+  if (!corpus) {
+    return (
+      <div className="rounded-lg border border-silicon-slate px-4 py-8 text-center text-sm text-muted-foreground">
+        No banned-books corpus projection is available.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <section className="rounded-lg border border-silicon-slate bg-silicon-slate/30 p-5">
+        <div className="mb-4 flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <div className="mb-2 flex items-center gap-2">
+              <BookOpenCheck size={20} className="text-radiant-gold" />
+              <h2 className="text-lg font-semibold">Banned Books Rights-Ready Corpus</h2>
+            </div>
+            <p className="max-w-4xl text-sm text-muted-foreground">{corpus.scope}</p>
+            <p className="mt-2 max-w-4xl text-sm text-muted-foreground">{corpus.licenseModel}</p>
+          </div>
+          <div className="rounded-full border border-amber-500/40 bg-amber-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-300">
+            Staged only
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3 lg:grid-cols-6">
+          <Stat icon={<FileText size={18} />} label="Staged" value={corpus.summary.stagedRecords} />
+          <Stat icon={<Database size={18} />} label="Sources" value={corpus.summary.sourceSpineCount} />
+          <Stat icon={<ShieldCheck size={18} />} label="Rights-ready" value={corpus.summary.rightsReadyRecords} />
+          <Stat icon={<Users size={18} />} label="Outreach-ready" value={corpus.summary.outreachReadyRecords} />
+          <Stat icon={<CircleDollarSign size={18} />} label="Active licenses" value={corpus.summary.activeLicenseRecords} />
+          <Stat icon={<BookOpenCheck size={18} />} label="Retrievable" value={corpus.summary.retrievableRecords} />
+        </div>
+      </section>
+
+      <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <Panel title="Source spine">
+          {corpus.sourceSpine.map((source) => (
+            <KeyValue key={source.name} label={source.name} value={source.role} />
+          ))}
+        </Panel>
+        <Panel title="Safeguards">
+          {corpus.safeguards.map((safeguard, index) => (
+            <KeyValue key={safeguard} label={`Gate ${index + 1}`} value={safeguard} />
+          ))}
+        </Panel>
+      </section>
+
+      <section className="overflow-hidden rounded-lg border border-silicon-slate">
+        <div className="bg-silicon-slate/60 px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          MECE agent lanes
+        </div>
+        <div className="divide-y divide-silicon-slate">
+          {corpus.swarmAgents.map((agent) => (
+            <div key={agent.key} className="grid grid-cols-1 gap-3 px-4 py-4 text-sm lg:grid-cols-5 lg:gap-4">
+              <div>
+                <p className="font-medium text-foreground">{agent.name}</p>
+                <p className="font-mono text-xs text-muted-foreground">{agent.key}</p>
+              </div>
+              <div className="text-muted-foreground">{agent.lane}</div>
+              <div className="text-muted-foreground">{agent.output}</div>
+              <div className="text-muted-foreground">{agent.boundary}</div>
+              <div className="text-muted-foreground">{agent.approvalGate}</div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-lg border border-silicon-slate">
+        <div className="bg-silicon-slate/60 px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Staged rights-ready shortlist
+        </div>
+        <div className="divide-y divide-silicon-slate">
+          {corpus.records.map((record) => (
+            <div key={record.id} className="grid grid-cols-1 gap-3 px-4 py-4 text-sm lg:grid-cols-5 lg:gap-4">
+              <div>
+                <p className="font-medium text-foreground">{record.canonicalTitle}</p>
+                <p className="text-muted-foreground">{list(record.authors)}</p>
+              </div>
+              <div className="text-muted-foreground">
+                <p>{record.banStatus}</p>
+                <p>{record.jurisdictionContext}</p>
+              </div>
+              <div className="text-muted-foreground">
+                <p>{record.rightsholderCandidate.name}</p>
+                <p>{record.rightsholderCandidate.confidence} confidence</p>
+              </div>
+              <div className="text-muted-foreground">
+                <p>Outreach: {record.outreachStatus}</p>
+                <p>License: {record.licenseStatus}</p>
+                <p>Ingestion: {record.ingestionStatus}</p>
+              </div>
+              <div className="text-muted-foreground">{record.nextAction}</div>
             </div>
           ))}
         </div>

--- a/app/api/admin/source-protocol/overview/route.test.ts
+++ b/app/api/admin/source-protocol/overview/route.test.ts
@@ -192,6 +192,17 @@ describe('GET /api/admin/source-protocol/overview', () => {
         { id: 'payout-2', accrued_payout_usd: 0.0000004 },
       ],
       modelReviews: [{ id: 'review-1', recommendation: 'keep' }],
+      bannedBooksCorpus: {
+        summary: {
+          stagedRecords: expect.any(Number),
+          rightsReadyRecords: expect.any(Number),
+          retrievableRecords: 0,
+        },
+        swarmAgents: expect.arrayContaining([
+          expect.objectContaining({ key: 'banned-book-source-registry' }),
+          expect.objectContaining({ key: 'rights-governance-review' }),
+        ]),
+      },
     })
     expect(mocks.from).toHaveBeenCalledWith('source_creators')
     expect(mocks.from).toHaveBeenCalledWith('answer_receipt_chunks')

--- a/app/api/admin/source-protocol/overview/route.ts
+++ b/app/api/admin/source-protocol/overview/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
 import { supabaseAdmin } from '@/lib/supabase'
+import { buildBannedBooksCorpusProjection } from '@/lib/banned-books-corpus'
 
 export const dynamic = 'force-dynamic'
 
@@ -191,6 +192,7 @@ export async function GET(request: NextRequest) {
       monthlyPayouts: payoutRows,
       disputes: disputeRows,
       modelReviews: modelReviewRows,
+      bannedBooksCorpus: buildBannedBooksCorpusProjection(),
     })
   } catch (error: any) {
     if (isMissingSourceProtocolSchema(error)) {

--- a/data/source-protocol/banned-books-rights-ready-corpus.json
+++ b/data/source-protocol/banned-books-rights-ready-corpus.json
@@ -1,0 +1,221 @@
+{
+  "generatedAt": "2026-05-12T00:00:00.000Z",
+  "scope": "U.S. school and library bans/challenges first; rights-ready shortlist before maximum title volume.",
+  "licenseModel": "RAG only: retrieval, citation, summarization, educational use, optional commercial use, limited excerpt allowance, revocation, payout participation; fine-tuning excluded for v1.",
+  "sourceSpine": [
+    {
+      "name": "ALA Most Challenged Books",
+      "url": "https://www.ala.org/bbooks/frequentlychallengedbooks/top10",
+      "role": "Annual challenged-title evidence and censorship trend context."
+    },
+    {
+      "name": "PEN America Index of School Book Bans",
+      "url": "https://pen.org/pen-america-index-of-school-book-bans-2024-2025/",
+      "role": "School-ban index source spine for title-level discovery and jurisdiction evidence."
+    },
+    {
+      "name": "EveryLibrary Banned Book Database",
+      "url": "https://action.everylibrary.org/everylibrary_s_banned_book_database",
+      "role": "Secondary title discovery and public advocacy evidence."
+    },
+    {
+      "name": "NCAC and publisher/author pages",
+      "url": "https://ncac.org/resource/book-censorship-toolkit",
+      "role": "Enrichment for public statements, advocacy context, and rightsholder contact paths."
+    }
+  ],
+  "records": [
+    {
+      "id": "gender-queer-maia-kobabe",
+      "canonicalTitle": "Gender Queer",
+      "authors": ["Maia Kobabe"],
+      "editionAliases": ["Gender Queer: A Memoir"],
+      "isbnCandidates": [],
+      "banStatus": "challenged",
+      "jurisdictionContext": "U.S. libraries and schools; ALA 2025 Most Challenged Books list.",
+      "affectedAudience": "K-12 students and public library patrons",
+      "evidence": [
+        {
+          "sourceName": "ALA Most Challenged Books",
+          "sourceUrl": "https://www.ala.org/bbooks/frequentlychallengedbooks/top10",
+          "evidenceType": "challenge_list",
+          "note": "Listed as number 3 on ALA's 2025 Most Challenged Books page."
+        }
+      ],
+      "rightsholderCandidate": {
+        "name": "Maia Kobabe or publisher/agent",
+        "type": "author",
+        "contactPath": "Author/publisher permissions inquiry",
+        "confidence": "medium"
+      },
+      "outreachStatus": "not_started",
+      "licenseStatus": "not_requested",
+      "ingestionStatus": "not_started",
+      "chainOfTitleStatus": "unknown",
+      "sensitivityFlags": ["lgbtqia"],
+      "notes": "Prioritize careful outreach because the work is frequently targeted for LGBTQIA+ content."
+    },
+    {
+      "id": "sold-patricia-mccormick",
+      "canonicalTitle": "Sold",
+      "authors": ["Patricia McCormick"],
+      "editionAliases": [],
+      "isbnCandidates": [],
+      "banStatus": "challenged",
+      "jurisdictionContext": "U.S. libraries and schools; ALA 2025 Most Challenged Books list.",
+      "affectedAudience": "K-12 students and public library patrons",
+      "evidence": [
+        {
+          "sourceName": "ALA Most Challenged Books",
+          "sourceUrl": "https://www.ala.org/bbooks/frequentlychallengedbooks/top10",
+          "evidenceType": "challenge_list",
+          "note": "Listed as number 1 on ALA's 2025 Most Challenged Books page."
+        }
+      ],
+      "rightsholderCandidate": {
+        "name": "Patricia McCormick or publisher/agent",
+        "type": "author",
+        "contactPath": "Author/publisher permissions inquiry",
+        "confidence": "medium"
+      },
+      "outreachStatus": "not_started",
+      "licenseStatus": "not_requested",
+      "ingestionStatus": "not_started",
+      "chainOfTitleStatus": "unknown",
+      "sensitivityFlags": ["sexual_violence", "minors"],
+      "notes": "Sensitive subject matter requires blocked-topic and excerpt-limit review before any retrievability."
+    },
+    {
+      "id": "last-night-at-the-telegraph-club-malinda-lo",
+      "canonicalTitle": "Last Night at the Telegraph Club",
+      "authors": ["Malinda Lo"],
+      "editionAliases": [],
+      "isbnCandidates": [],
+      "banStatus": "challenged",
+      "jurisdictionContext": "U.S. libraries and schools; ALA 2025 Most Challenged Books list.",
+      "affectedAudience": "K-12 students and public library patrons",
+      "evidence": [
+        {
+          "sourceName": "ALA Most Challenged Books",
+          "sourceUrl": "https://www.ala.org/bbooks/frequentlychallengedbooks/top10",
+          "evidenceType": "challenge_list",
+          "note": "Listed as tied number 5 on ALA's 2025 Most Challenged Books page."
+        }
+      ],
+      "rightsholderCandidate": {
+        "name": "Malinda Lo or publisher/agent",
+        "type": "author",
+        "contactPath": "Author/publisher permissions inquiry",
+        "confidence": "medium"
+      },
+      "outreachStatus": "not_started",
+      "licenseStatus": "not_requested",
+      "ingestionStatus": "not_started",
+      "chainOfTitleStatus": "unknown",
+      "sensitivityFlags": ["lgbtqia", "asian_american_history"],
+      "notes": "Good rights-ready candidate because author-facing mission alignment may be strong."
+    },
+    {
+      "id": "the-bluest-eye-toni-morrison",
+      "canonicalTitle": "The Bluest Eye",
+      "authors": ["Toni Morrison"],
+      "editionAliases": [],
+      "isbnCandidates": [],
+      "banStatus": "challenged",
+      "jurisdictionContext": "Recurring U.S. school and library challenge subject; include in first rights mapping pass.",
+      "affectedAudience": "K-12 students and public library patrons",
+      "evidence": [
+        {
+          "sourceName": "PEN America Index of School Book Bans",
+          "sourceUrl": "https://pen.org/pen-america-index-of-school-book-bans-2024-2025/",
+          "evidenceType": "school_ban_index",
+          "note": "Use PEN index enrichment to confirm current district-level evidence before outreach."
+        },
+        {
+          "sourceName": "ALA Most Challenged Books",
+          "sourceUrl": "https://www.ala.org/bbooks/frequentlychallengedbooks/top10",
+          "evidenceType": "challenge_context",
+          "note": "ALA states current censorship justifications frequently target race, racism, equity, and social justice."
+        }
+      ],
+      "rightsholderCandidate": {
+        "name": "Toni Morrison estate or publisher",
+        "type": "estate",
+        "contactPath": "Estate/publisher permissions inquiry",
+        "confidence": "medium"
+      },
+      "outreachStatus": "not_started",
+      "licenseStatus": "not_requested",
+      "ingestionStatus": "not_started",
+      "chainOfTitleStatus": "unknown",
+      "sensitivityFlags": ["race", "sexual_violence", "minors"],
+      "notes": "Estate/publisher-controlled rights likely; hold for rights-holder verification before author-facing sequence."
+    },
+    {
+      "id": "the-hate-u-give-angie-thomas",
+      "canonicalTitle": "The Hate U Give",
+      "authors": ["Angie Thomas"],
+      "editionAliases": [],
+      "isbnCandidates": [],
+      "banStatus": "challenged",
+      "jurisdictionContext": "Recurring U.S. school and library challenge subject; include in first rights mapping pass.",
+      "affectedAudience": "K-12 students and public library patrons",
+      "evidence": [
+        {
+          "sourceName": "PEN America Index of School Book Bans",
+          "sourceUrl": "https://pen.org/pen-america-index-of-school-book-bans-2024-2025/",
+          "evidenceType": "school_ban_index",
+          "note": "Use PEN index enrichment to confirm current district-level evidence before outreach."
+        },
+        {
+          "sourceName": "ALA Most Challenged Books",
+          "sourceUrl": "https://www.ala.org/bbooks/frequentlychallengedbooks/top10",
+          "evidenceType": "challenge_context",
+          "note": "ALA states current censorship justifications frequently target race, racism, equity, and social justice."
+        }
+      ],
+      "rightsholderCandidate": {
+        "name": "Angie Thomas or publisher/agent",
+        "type": "author",
+        "contactPath": "Author/publisher permissions inquiry",
+        "confidence": "medium"
+      },
+      "outreachStatus": "not_started",
+      "licenseStatus": "not_requested",
+      "ingestionStatus": "not_started",
+      "chainOfTitleStatus": "unknown",
+      "sensitivityFlags": ["race", "police_violence"],
+      "notes": "Good candidate for mission-forward outreach once publisher/agent path is verified."
+    },
+    {
+      "id": "looking-for-alaska-john-green",
+      "canonicalTitle": "Looking for Alaska",
+      "authors": ["John Green"],
+      "editionAliases": [],
+      "isbnCandidates": [],
+      "banStatus": "challenged",
+      "jurisdictionContext": "U.S. libraries and schools; ALA 2025 Most Challenged Books list.",
+      "affectedAudience": "K-12 students and public library patrons",
+      "evidence": [
+        {
+          "sourceName": "ALA Most Challenged Books",
+          "sourceUrl": "https://www.ala.org/bbooks/frequentlychallengedbooks/top10",
+          "evidenceType": "challenge_list",
+          "note": "Listed as tied number 8 on ALA's 2025 Most Challenged Books page."
+        }
+      ],
+      "rightsholderCandidate": {
+        "name": "John Green or publisher/agent",
+        "type": "author",
+        "contactPath": "Author/publisher permissions inquiry",
+        "confidence": "medium"
+      },
+      "outreachStatus": "not_started",
+      "licenseStatus": "not_requested",
+      "ingestionStatus": "not_started",
+      "chainOfTitleStatus": "unknown",
+      "sensitivityFlags": ["sexual_content", "substance_use"],
+      "notes": "Include in outreach sequencing after rights-holder contact verification."
+    }
+  ]
+}

--- a/docs/banned-books-rights-ready-corpus.md
+++ b/docs/banned-books-rights-ready-corpus.md
@@ -1,0 +1,65 @@
+# Banned Books Rights-Ready Corpus
+
+This workflow builds a U.S.-first banned and challenged books inventory for
+rights-cleared RAG ingestion. The first deliverable is a rights-ready shortlist,
+not a claim that every globally banned book has been captured.
+
+## Operating Model
+
+The registry is staged in `data/source-protocol/banned-books-rights-ready-corpus.json`
+and projected into `/admin/source-protocol` under the `Banned Books` tab.
+
+```bash
+npm run banned-books:report
+npm run banned-books:report -- --json
+```
+
+The projection reuses the existing Source-Respecting LLM Protocol:
+
+- creators map to `source_creators`,
+- approved works map to `licensed_works`,
+- explicit RAG-only permission maps to `license_grants`,
+- full text and chunks map to `source_chunks` only after rights approval,
+- usage and payout attribution continue through `answer_receipts`,
+  `answer_receipt_chunks`, and `monthly_creator_payouts`.
+
+## Swarm Lanes
+
+The v1 swarm is intentionally MECE:
+
+- Amina, Source Registry Lead: source evidence only.
+- Nana Asma'u, Bibliographic Normalizer: canonical work and edition dedupe.
+- Yaa Asantewaa, Rights Holder Mapper: likely rightsholder and contact path.
+- Nzinga, Outreach Strategist: RAG-only permission packets and follow-up.
+- Mansa Musa, Creator Economics Lead: payout simulation assumptions.
+- Imhotep, Ingestion Architect: rights-cleared chunking and indexing plan.
+- Shaka, Governance Captain: rights, consent, revocation, and sensitivity gates.
+- Timbuktu Scribe, QA Archivist: provenance and audit reports.
+
+## Rights Boundary
+
+V1 permission asks for retrieval, citation, summarization, educational use,
+optional commercial use, limited excerpt allowance, revocation, and payout
+participation. Fine-tuning is excluded unless a later legal review approves it.
+
+Do not ingest copyrighted full text, run OCR, create embeddings, or mark chunks
+retrievable until all of these are true:
+
+- active RAG-only license grant,
+- verified chain of title,
+- sensitivity review complete,
+- governance approval recorded.
+
+## Review Loop
+
+Recurring reports should include:
+
+- titles discovered,
+- source-evidence coverage,
+- rights-ready titles,
+- outreach-ready titles,
+- outreach sent and responses,
+- approvals and blocked works,
+- indexed chunks,
+- answer receipt accruals,
+- monthly payout simulation.

--- a/docs/source-respecting-llm-protocol.md
+++ b/docs/source-respecting-llm-protocol.md
@@ -121,6 +121,13 @@ Creator portal foundation:
 - `/admin/source-protocol` includes a `Portal Access` tab for admins to link a creator profile to an authenticated user account, set earnings/receipt visibility, and suspend or revoke portal access.
 - `POST/PATCH /api/admin/source-protocol/portal-accounts` are admin-only account-linking routes. They do not create creators, users, works, grants, receipts, disputes, or payouts.
 
+Banned-books corpus foundation:
+
+- `data/source-protocol/banned-books-rights-ready-corpus.json` stages the U.S.-first banned/challenged books shortlist, source evidence, rightsholder candidates, outreach status, license status, and ingestion status.
+- `lib/banned-books-corpus.ts` projects that staged inventory into Source Protocol draft records and enforces the v1 guardrail: no full text, OCR, embeddings, or retrievable chunks until an active RAG-only license grant and verified chain of title exist.
+- `/admin/source-protocol` includes a `Banned Books` tab for the MECE agent lanes, staged shortlist, source spine, and safeguards.
+- `npm run banned-books:report` prints the current staged registry, swarm lanes, next actions, and safeguards for recurring review.
+
 Smoke test:
 
 - `npm run source-protocol:smoke` builds a synthetic receipt and monthly settlement without network calls.

--- a/lib/banned-books-corpus.test.ts
+++ b/lib/banned-books-corpus.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildBannedBooksCorpusProjection,
+  buildSourceProtocolDraft,
+  canCreateRetrievableChunks,
+  dedupeBannedBookRecords,
+  isOutreachReady,
+  normalizeBannedBookKey,
+  type BannedBookStagedRecord,
+} from './banned-books-corpus'
+
+function record(overrides: Partial<BannedBookStagedRecord> = {}): BannedBookStagedRecord {
+  return {
+    id: 'demo',
+    canonicalTitle: 'Demo Book',
+    authors: ['Demo Author'],
+    editionAliases: [],
+    isbnCandidates: [],
+    banStatus: 'challenged',
+    jurisdictionContext: 'U.S. school challenge evidence.',
+    affectedAudience: 'K-12 students',
+    evidence: [
+      {
+        sourceName: 'ALA Most Challenged Books',
+        sourceUrl: 'https://www.ala.org/bbooks/frequentlychallengedbooks/top10',
+        evidenceType: 'challenge_list',
+        note: 'Demo evidence.',
+      },
+    ],
+    rightsholderCandidate: {
+      name: 'Demo Author or publisher',
+      type: 'author',
+      contactPath: 'Author/publisher permissions inquiry',
+      confidence: 'medium',
+    },
+    outreachStatus: 'not_started',
+    licenseStatus: 'not_requested',
+    ingestionStatus: 'not_started',
+    chainOfTitleStatus: 'unknown',
+    sensitivityFlags: [],
+    notes: 'Demo notes.',
+    ...overrides,
+  }
+}
+
+describe('banned books corpus projection', () => {
+  it('builds a staged rights-ready projection with MECE swarm lanes', () => {
+    const projection = buildBannedBooksCorpusProjection()
+
+    expect(projection.summary.stagedRecords).toBeGreaterThan(0)
+    expect(projection.summary.sourceSpineCount).toBeGreaterThanOrEqual(3)
+    expect(projection.summary.outreachReadyRecords).toBeGreaterThan(0)
+    expect(projection.summary.retrievableRecords).toBe(0)
+    expect(projection.swarmAgents.map((agent) => agent.key)).toEqual([
+      'banned-book-source-registry',
+      'book-normalization',
+      'rights-holder-mapping',
+      'creator-outreach',
+      'payout-modeling',
+      'corpus-ingestion-indexing',
+      'rights-governance-review',
+      'evidence-qa-audit',
+    ])
+    expect(projection.safeguards.join(' ')).toContain('Do not ingest full text')
+  })
+
+  it('dedupes duplicate title and author records while preserving evidence', () => {
+    const records = dedupeBannedBookRecords([
+      record({ id: 'first', canonicalTitle: 'Demo Book', editionAliases: ['First edition'] }),
+      record({
+        id: 'second',
+        canonicalTitle: 'Demo  Book!',
+        editionAliases: ['Paperback'],
+        evidence: [
+          {
+            sourceName: 'PEN America',
+            sourceUrl: 'https://pen.org/pen-america-index-of-school-book-bans-2024-2025/',
+            evidenceType: 'school_ban_index',
+            note: 'Second source.',
+          },
+        ],
+      }),
+    ])
+
+    expect(records).toHaveLength(1)
+    expect(records[0].editionAliases).toEqual(['First edition', 'Paperback'])
+    expect(records[0].evidence).toHaveLength(2)
+  })
+
+  it('blocks retrievable chunks until license and chain-of-title gates pass', () => {
+    expect(canCreateRetrievableChunks(record())).toBe(false)
+    expect(isOutreachReady(record())).toBe(true)
+
+    const approved = record({
+      licenseStatus: 'active',
+      chainOfTitleStatus: 'verified',
+      ingestionStatus: 'retrievable',
+    })
+
+    expect(canCreateRetrievableChunks(approved)).toBe(true)
+    expect(buildSourceProtocolDraft(record()).chunkPolicy).toMatchObject({
+      canChunk: false,
+      canEmbed: false,
+      canRetrieve: false,
+    })
+    expect(buildSourceProtocolDraft(approved).chunkPolicy).toMatchObject({
+      canChunk: true,
+      canEmbed: true,
+      canRetrieve: true,
+    })
+  })
+
+  it('normalizes title and author into stable canonical keys', () => {
+    expect(normalizeBannedBookKey(record({ canonicalTitle: 'The Hate U Give', authors: ['Angie Thomas'] }))).toBe(
+      'the-hate-u-give:angie-thomas'
+    )
+  })
+})

--- a/lib/banned-books-corpus.ts
+++ b/lib/banned-books-corpus.ts
@@ -1,0 +1,397 @@
+import stagedCorpus from '@/data/source-protocol/banned-books-rights-ready-corpus.json'
+import type {
+  CreatorCategory,
+  LicenseUse,
+  LicensedWork,
+  RightsHolderType,
+} from './source-respecting-llm-protocol'
+
+export type BannedBookSwarmLaneKey =
+  | 'banned-book-source-registry'
+  | 'book-normalization'
+  | 'rights-holder-mapping'
+  | 'creator-outreach'
+  | 'payout-modeling'
+  | 'corpus-ingestion-indexing'
+  | 'rights-governance-review'
+  | 'evidence-qa-audit'
+
+export type BannedBookEvidenceType =
+  | 'challenge_list'
+  | 'school_ban_index'
+  | 'challenge_context'
+  | 'district_record'
+  | 'publisher_statement'
+  | 'author_statement'
+
+export type BannedBookBanStatus = 'banned' | 'challenged' | 'restricted' | 'unknown'
+export type BannedBookOutreachStatus = 'not_started' | 'ready' | 'drafted' | 'sent' | 'responded' | 'blocked'
+export type BannedBookLicenseStatus = 'not_requested' | 'pending_review' | 'active' | 'revoked' | 'disputed'
+export type BannedBookIngestionStatus = 'not_started' | 'blocked' | 'staged' | 'indexed_shadow' | 'retrievable'
+export type BannedBookRightsConfidence = 'low' | 'medium' | 'high'
+
+export type BannedBookSourceSpineEntry = {
+  name: string
+  url: string
+  role: string
+}
+
+export type BannedBookEvidence = {
+  sourceName: string
+  sourceUrl: string
+  evidenceType: BannedBookEvidenceType
+  note: string
+}
+
+export type BannedBookRightsholderCandidate = {
+  name: string
+  type: RightsHolderType
+  contactPath: string
+  confidence: BannedBookRightsConfidence
+}
+
+export type BannedBookStagedRecord = {
+  id: string
+  canonicalTitle: string
+  authors: string[]
+  editionAliases: string[]
+  isbnCandidates: string[]
+  banStatus: BannedBookBanStatus
+  jurisdictionContext: string
+  affectedAudience: string
+  evidence: BannedBookEvidence[]
+  rightsholderCandidate: BannedBookRightsholderCandidate
+  outreachStatus: BannedBookOutreachStatus
+  licenseStatus: BannedBookLicenseStatus
+  ingestionStatus: BannedBookIngestionStatus
+  chainOfTitleStatus: 'unknown' | 'pending' | 'verified'
+  sensitivityFlags: string[]
+  notes: string
+}
+
+export type BannedBookSwarmAgent = {
+  key: BannedBookSwarmLaneKey
+  name: string
+  lane: string
+  responsibility: string
+  output: string
+  boundary: string
+  approvalGate: string
+}
+
+export type BannedBooksCorpusProjection = {
+  generatedAt: string
+  scope: string
+  licenseModel: string
+  sourceSpine: BannedBookSourceSpineEntry[]
+  swarmAgents: BannedBookSwarmAgent[]
+  summary: {
+    stagedRecords: number
+    sourceSpineCount: number
+    rightsReadyRecords: number
+    outreachReadyRecords: number
+    activeLicenseRecords: number
+    retrievableRecords: number
+    blockedRecords: number
+  }
+  records: Array<BannedBookStagedRecord & {
+    normalizedKey: string
+    rightsReady: boolean
+    outreachReady: boolean
+    retrievableEligible: boolean
+    sourceProtocolDraft: {
+      creator: {
+        displayName: string
+        categories: CreatorCategory[]
+        rightsHolderTypes: RightsHolderType[]
+        verificationStatus: 'pending' | 'verified' | 'needs_review'
+      }
+      work: Pick<
+        LicensedWork,
+        'id' | 'creatorId' | 'title' | 'rightsHolderType' | 'banStatus' | 'chainOfTitleVerified'
+      > & {
+        reviewStatus: 'staged' | 'approved' | 'blocked' | 'disputed' | 'revoked'
+        sourceType: 'manual'
+        sensitivityFlags: string[]
+      }
+      licenseGrant: {
+        status: BannedBookLicenseStatus
+        allowedUses: LicenseUse[]
+        quoteLimitCharacters: number
+        fineTuningAllowed: false
+      }
+      chunkPolicy: {
+        canChunk: boolean
+        canEmbed: boolean
+        canRetrieve: boolean
+        reason: string
+      }
+    }
+    nextAction: string
+  }>
+  safeguards: string[]
+}
+
+export const BANNED_BOOKS_SWARM_AGENTS: BannedBookSwarmAgent[] = [
+  {
+    key: 'banned-book-source-registry',
+    name: 'Amina, Source Registry Lead',
+    lane: 'Discovery evidence',
+    responsibility: 'Collect title-level ban and challenge evidence from PEN, ALA, EveryLibrary, district records, and public statements.',
+    output: 'Source evidence only.',
+    boundary: 'No rights-holder guesses or outreach decisions.',
+    approvalGate: 'Source URL and evidence type must be present before a title enters the staged registry.',
+  },
+  {
+    key: 'book-normalization',
+    name: "Nana Asma'u, Bibliographic Normalizer",
+    lane: 'Canonical works',
+    responsibility: 'Dedupe titles, editions, ISBNs, authors, publishers, years, formats, and series relationships.',
+    output: 'Canonical work records plus edition aliases.',
+    boundary: 'No contact enrichment or permission claims.',
+    approvalGate: 'Conflicting editions remain staged until evidence QA resolves them.',
+  },
+  {
+    key: 'rights-holder-mapping',
+    name: 'Yaa Asantewaa, Rights Holder Mapper',
+    lane: 'Rights path',
+    responsibility: 'Identify likely author, publisher, estate, agent, illustrator, translator, or co-rightsholder.',
+    output: 'Contact path and confidence level.',
+    boundary: 'No outreach is sent from this lane.',
+    approvalGate: 'Low-confidence or estate/publisher-controlled paths require governance review.',
+  },
+  {
+    key: 'creator-outreach',
+    name: 'Nzinga, Outreach Strategist',
+    lane: 'Permission packets',
+    responsibility: 'Generate RAG-only permission packets, outreach sequences, value proposition, and follow-up cadence.',
+    output: 'Draft outreach and CRM stages.',
+    boundary: 'No public creator communications are sent without approval.',
+    approvalGate: 'Human approval before first contact or follow-up.',
+  },
+  {
+    key: 'payout-modeling',
+    name: 'Mansa Musa, Creator Economics Lead',
+    lane: 'Attribution economics',
+    responsibility: 'Map supported output tokens to answer receipts and monthly creator payout simulation.',
+    output: 'Payout simulation assumptions and statement requirements.',
+    boundary: 'No real money movement.',
+    approvalGate: 'Real payouts require approved settlement status and payment operations review.',
+  },
+  {
+    key: 'corpus-ingestion-indexing',
+    name: 'Imhotep, Ingestion Architect',
+    lane: 'Rights-cleared ingestion',
+    responsibility: 'Design file intake, OCR/text extraction, chunking, citation labels, embeddings, retrievability flags, and revocation handling.',
+    output: 'Ingestion plan and chunk metadata requirements.',
+    boundary: 'No full text, OCR, embedding, or retrievability before active license grants.',
+    approvalGate: 'Active license, verified chain of title, and sensitivity review must pass.',
+  },
+  {
+    key: 'rights-governance-review',
+    name: 'Shaka, Governance Captain',
+    lane: 'Rights gates',
+    responsibility: 'Review chain of title, blocked uses, community consent, sensitive topics, revocations, disputes, and approval gates.',
+    output: 'Approve, hold, block, or dispute decisions.',
+    boundary: 'Does not bypass Source Protocol license logic.',
+    approvalGate: 'Required before any staged work becomes retrievable.',
+  },
+  {
+    key: 'evidence-qa-audit',
+    name: 'Timbuktu Scribe, QA Archivist',
+    lane: 'Audit trail',
+    responsibility: 'Cross-check records, flag conflicts, preserve provenance, and produce audit-ready reports.',
+    output: 'Evidence QA notes and recurring report inputs.',
+    boundary: 'No mutation of rights status without governance review.',
+    approvalGate: 'All records need source evidence before outreach or ingestion.',
+  },
+]
+
+const RAG_ONLY_ALLOWED_USES: LicenseUse[] = ['retrieval', 'citation', 'summarization', 'educational', 'commercial']
+
+function normalizeValue(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+export function normalizeBannedBookKey(record: Pick<BannedBookStagedRecord, 'canonicalTitle' | 'authors'>): string {
+  return `${normalizeValue(record.canonicalTitle)}:${record.authors.map(normalizeValue).sort().join('+')}`
+}
+
+export function dedupeBannedBookRecords(records: BannedBookStagedRecord[]): BannedBookStagedRecord[] {
+  const byKey = new Map<string, BannedBookStagedRecord>()
+  for (const record of records) {
+    const key = normalizeBannedBookKey(record)
+    const existing = byKey.get(key)
+    if (!existing) {
+      byKey.set(key, {
+        ...record,
+        editionAliases: [...new Set(record.editionAliases)],
+        isbnCandidates: [...new Set(record.isbnCandidates)],
+        evidence: uniqueEvidence(record.evidence),
+        sensitivityFlags: [...new Set(record.sensitivityFlags)],
+      })
+      continue
+    }
+
+    byKey.set(key, {
+      ...existing,
+      editionAliases: [...new Set([...existing.editionAliases, ...record.editionAliases])],
+      isbnCandidates: [...new Set([...existing.isbnCandidates, ...record.isbnCandidates])],
+      evidence: uniqueEvidence([...existing.evidence, ...record.evidence]),
+      sensitivityFlags: [...new Set([...existing.sensitivityFlags, ...record.sensitivityFlags])],
+      notes: [existing.notes, record.notes].filter(Boolean).join(' | '),
+    })
+  }
+  return [...byKey.values()]
+}
+
+function uniqueEvidence(evidence: BannedBookEvidence[]): BannedBookEvidence[] {
+  const seen = new Set<string>()
+  return evidence.filter((entry) => {
+    const key = `${entry.sourceName}:${entry.sourceUrl}:${entry.note}`
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+export function isRightsReady(record: BannedBookStagedRecord): boolean {
+  return (
+    record.evidence.length > 0 &&
+    record.rightsholderCandidate.confidence !== 'low' &&
+    record.chainOfTitleStatus !== 'verified' &&
+    record.licenseStatus === 'not_requested'
+  )
+}
+
+export function isOutreachReady(record: BannedBookStagedRecord): boolean {
+  return isRightsReady(record) && record.outreachStatus === 'not_started'
+}
+
+export function canCreateRetrievableChunks(record: BannedBookStagedRecord): boolean {
+  return (
+    record.licenseStatus === 'active' &&
+    record.chainOfTitleStatus === 'verified' &&
+    record.ingestionStatus === 'retrievable'
+  )
+}
+
+export function buildSourceProtocolDraft(record: BannedBookStagedRecord) {
+  const chainOfTitleVerified = record.chainOfTitleStatus === 'verified'
+  const retrievableEligible = canCreateRetrievableChunks(record)
+  return {
+    creator: {
+      displayName: record.rightsholderCandidate.name,
+      categories: ['banned_author', 'challenged_author'] as CreatorCategory[],
+      rightsHolderTypes: [record.rightsholderCandidate.type],
+      verificationStatus: chainOfTitleVerified ? 'verified' as const : 'pending' as const,
+    },
+    work: {
+      id: `staged:${record.id}`,
+      creatorId: `staged-creator:${record.id}`,
+      title: record.canonicalTitle,
+      rightsHolderType: record.rightsholderCandidate.type,
+      banStatus: record.banStatus,
+      chainOfTitleVerified,
+      reviewStatus: retrievableEligible ? 'approved' as const : 'staged' as const,
+      sourceType: 'manual' as const,
+      sensitivityFlags: record.sensitivityFlags,
+    },
+    licenseGrant: {
+      status: record.licenseStatus,
+      allowedUses: RAG_ONLY_ALLOWED_USES,
+      quoteLimitCharacters: 280,
+      fineTuningAllowed: false as const,
+    },
+    chunkPolicy: {
+      canChunk: retrievableEligible,
+      canEmbed: retrievableEligible,
+      canRetrieve: retrievableEligible,
+      reason: retrievableEligible
+        ? 'Active RAG-only license, verified chain of title, and retrievable ingestion status are present.'
+        : 'Hold full text, OCR, embeddings, and retrieval until active license grant and chain-of-title review are complete.',
+    },
+  }
+}
+
+function nextActionFor(record: BannedBookStagedRecord): string {
+  if (canCreateRetrievableChunks(record)) return 'Eligible for rights-cleared chunking and retrieval QA.'
+  if (record.licenseStatus === 'active' && record.chainOfTitleStatus !== 'verified') return 'Verify chain of title before ingestion.'
+  if (record.outreachStatus === 'not_started' && isOutreachReady(record)) return 'Draft RAG-only permission packet.'
+  if (record.rightsholderCandidate.confidence === 'low') return 'Improve rightsholder evidence before outreach.'
+  return 'Hold in staged research inventory.'
+}
+
+export function buildBannedBooksCorpusProjection(): BannedBooksCorpusProjection {
+  const records = dedupeBannedBookRecords(stagedCorpus.records as BannedBookStagedRecord[])
+  const projectedRecords = records.map((record) => ({
+    ...record,
+    normalizedKey: normalizeBannedBookKey(record),
+    rightsReady: isRightsReady(record),
+    outreachReady: isOutreachReady(record),
+    retrievableEligible: canCreateRetrievableChunks(record),
+    sourceProtocolDraft: buildSourceProtocolDraft(record),
+    nextAction: nextActionFor(record),
+  }))
+
+  return {
+    generatedAt: stagedCorpus.generatedAt,
+    scope: stagedCorpus.scope,
+    licenseModel: stagedCorpus.licenseModel,
+    sourceSpine: stagedCorpus.sourceSpine,
+    swarmAgents: BANNED_BOOKS_SWARM_AGENTS,
+    summary: {
+      stagedRecords: projectedRecords.length,
+      sourceSpineCount: stagedCorpus.sourceSpine.length,
+      rightsReadyRecords: projectedRecords.filter((record) => record.rightsReady).length,
+      outreachReadyRecords: projectedRecords.filter((record) => record.outreachReady).length,
+      activeLicenseRecords: projectedRecords.filter((record) => record.licenseStatus === 'active').length,
+      retrievableRecords: projectedRecords.filter((record) => record.retrievableEligible).length,
+      blockedRecords: projectedRecords.filter((record) =>
+        record.outreachStatus === 'blocked' || record.ingestionStatus === 'blocked' || record.licenseStatus === 'disputed'
+      ).length,
+    },
+    records: projectedRecords,
+    safeguards: [
+      'Do not ingest full text, OCR, embed, or mark chunks retrievable before an active RAG-only license grant exists.',
+      'Do not infer rights ownership from title metadata; rights-holder confidence must be recorded separately from source evidence.',
+      'Fine-tuning is excluded from v1 permission packets unless a separate legal review approves it later.',
+      'Answer receipts and monthly payout rows remain simulation-first until payout operations are approved.',
+      'Public outreach, production ingestion, and creator payout activation remain approval-gated.',
+    ],
+  }
+}
+
+export function formatBannedBooksCorpusReport(projection = buildBannedBooksCorpusProjection()): string {
+  return [
+    '# Banned Books Rights-Ready Corpus',
+    '',
+    `Generated: ${projection.generatedAt}`,
+    `Scope: ${projection.scope}`,
+    `License model: ${projection.licenseModel}`,
+    '',
+    '## Summary',
+    '',
+    `- Staged records: ${projection.summary.stagedRecords}`,
+    `- Rights-ready records: ${projection.summary.rightsReadyRecords}`,
+    `- Outreach-ready records: ${projection.summary.outreachReadyRecords}`,
+    `- Active license records: ${projection.summary.activeLicenseRecords}`,
+    `- Retrievable records: ${projection.summary.retrievableRecords}`,
+    '',
+    '## Swarm Lanes',
+    '',
+    ...projection.swarmAgents.map((agent) => `- ${agent.name} (${agent.key}): ${agent.output}`),
+    '',
+    '## Staged Works',
+    '',
+    ...projection.records.map((record) => `- ${record.canonicalTitle} by ${record.authors.join(', ')}: ${record.nextAction}`),
+    '',
+    '## Safeguards',
+    '',
+    ...projection.safeguards.map((safeguard) => `- ${safeguard}`),
+  ].join('\n')
+}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "deploy:metrics": "tsx scripts/vercel-deployment-metrics.ts",
     "deploy:research:plan": "tsx scripts/vercel-deployment-research-plan.ts",
     "git:hygiene:report": "tsx scripts/git-hygiene-report.ts",
+    "banned-books:report": "tsx scripts/banned-books-corpus-report.ts",
     "model-ops:snapshot": "tsx scripts/sync-model-ops-snapshot.ts",
     "model-ops:snapshot:check": "tsx scripts/sync-model-ops-snapshot.ts --check",
     "model-ops:research:plan": "tsx scripts/model-ops-research-plan.ts",

--- a/scripts/banned-books-corpus-report.ts
+++ b/scripts/banned-books-corpus-report.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env tsx
+import {
+  buildBannedBooksCorpusProjection,
+  formatBannedBooksCorpusReport,
+} from '../lib/banned-books-corpus'
+
+export function parseArgs(argv: string[]) {
+  const options = {
+    json: false,
+  }
+
+  for (const arg of argv) {
+    if (arg === '--json') {
+      options.json = true
+    } else if (arg === '--help' || arg === '-h') {
+      console.log(`Usage:
+  npm run banned-books:report -- [options]
+
+Options:
+  --json  Print machine-readable output.
+`)
+      process.exit(0)
+    } else {
+      throw new Error(`Unknown option: ${arg}`)
+    }
+  }
+
+  return options
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  const projection = buildBannedBooksCorpusProjection()
+
+  if (options.json) {
+    console.log(JSON.stringify(projection, null, 2))
+    return
+  }
+
+  console.log(formatBannedBooksCorpusReport(projection))
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Summary
- add a staged U.S.-first banned/challenged books corpus registry optimized for rights-ready outreach
- define MECE swarm lanes with culturally grounded display names and stable technical keys
- project staged titles into Source Protocol draft records while blocking full text, OCR, embedding, and retrieval until active license + chain-of-title gates pass
- add a Banned Books tab to /admin/source-protocol and expose the projection through the source protocol overview API
- add `npm run banned-books:report` for recurring review output

## Validation
- `npm test -- --run lib/banned-books-corpus.test.ts app/api/admin/source-protocol/overview/route.test.ts app/admin/source-protocol/page.test.tsx`
- `npm run banned-books:report`
- `npm run banned-books:report -- --json`
- `npm run build:knowledge`
- `npx tsc --noEmit --pretty false`
- `npm run lint`
- `git diff --check`
- normal `git push` passed the local pre-push database health check

## Notes
- This is staged/research-only. No copyrighted full text is ingested, no outreach is sent, no retrieval is enabled, and no production payout behavior changes.
- Stop before merge: Integration Captain should review and merge/deploy.