### PR TITLE
Surface Open Brain runtime and producer gate status

### DIFF
--- a/app/admin/agents/open-brain/page.tsx
+++ b/app/admin/agents/open-brain/page.tsx
@@ -20,7 +20,7 @@ import Breadcrumbs from '@/components/admin/Breadcrumbs'
 import { getCurrentSession } from '@/lib/auth'
 import type { OpenBrainSnapshot } from '@/lib/open-brain'
 
-type ViewMode = 'router' | 'sources' | 'proposals' | 'wiki' | 'parity'
+type ViewMode = 'router' | 'sources' | 'proposals' | 'wiki' | 'parity' | 'producers'
 
 export default function OpenBrainPage() {
   return (
@@ -117,7 +117,7 @@ function OpenBrainContent() {
             <p className="text-xs font-semibold uppercase tracking-wider text-radiant-gold">Agent Operations</p>
             <h1 className="mt-1 text-3xl font-bold">Open Brain</h1>
             <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
-              Local-first memory projection for Portfolio Agent Ops. The local Open Brain remains the source of truth; Portfolio shows health, proposals, source freshness, and generated wiki previews.
+              Local-first memory projection for Portfolio Agent Ops. The local Open Brain remains the source of truth; Portfolio shows health, proposals, source freshness, producer gates, and generated wiki previews.
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
@@ -168,6 +168,7 @@ function OpenBrainContent() {
               <MetricCard label="Stale sources" value={snapshot.overview.staleSources} tone={snapshot.overview.staleSources ? 'yellow' : 'slate'} />
               <MetricCard label="Private" value={snapshot.overview.privateRecords} tone={snapshot.overview.privateRecords ? 'red' : 'slate'} />
               <MetricCard label="Router lanes" value={snapshot.modelOps.routerDecisions.length} tone={snapshot.modelOps.available ? 'green' : 'yellow'} />
+              <MetricCard label="Producer gates" value={snapshot.overview.enabledProducerGates} tone={snapshot.overview.enabledProducerGates ? 'green' : 'yellow'} />
             </div>
 
             <section className="mb-6 rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-5">
@@ -200,6 +201,7 @@ function OpenBrainContent() {
                 <ModeButton icon={<ShieldCheck size={16} />} active={viewMode === 'proposals'} onClick={() => setViewMode('proposals')}>Proposals</ModeButton>
                 <ModeButton icon={<FileText size={16} />} active={viewMode === 'wiki'} onClick={() => setViewMode('wiki')}>Wiki Overlay</ModeButton>
                 <ModeButton icon={<Network size={16} />} active={viewMode === 'parity'} onClick={() => setViewMode('parity')}>Runtime Parity</ModeButton>
+                <ModeButton icon={<GitBranch size={16} />} active={viewMode === 'producers'} onClick={() => setViewMode('producers')}>Producers</ModeButton>
               </div>
               <button
                 onClick={compileWiki}
@@ -227,6 +229,7 @@ function OpenBrainContent() {
             ) : null}
             {viewMode === 'wiki' ? <WikiView pages={snapshot.wikiPages} /> : null}
             {viewMode === 'parity' ? <ParityView snapshot={snapshot} /> : null}
+            {viewMode === 'producers' ? <ProducerView snapshot={snapshot} /> : null}
 
             <p className="mt-5 text-xs text-muted-foreground">
               Generated {formatDateTime(snapshot.generatedAt)}. {snapshot.service.operationalBoundary}
@@ -498,6 +501,31 @@ function ParityView({ snapshot }: { snapshot: OpenBrainSnapshot }) {
   )
 }
 
+function ProducerView({ snapshot }: { snapshot: OpenBrainSnapshot }) {
+  return (
+    <section className="grid grid-cols-1 xl:grid-cols-2 gap-4">
+      {snapshot.producerGates.map((gate) => (
+        <article key={gate.id} className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-5">
+          <div className="mb-3 flex flex-wrap items-start justify-between gap-2">
+            <div>
+              <h3 className="font-semibold">{gate.label}</h3>
+              <p className="mt-1 text-xs text-muted-foreground">{gate.id}</p>
+            </div>
+            <StatusBadge value={gate.status} />
+          </div>
+          <p className="mb-4 text-sm text-muted-foreground">{gate.note}</p>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-xs">
+            <Detail label="Source kind" value={gate.sourceKind} />
+            <Detail label="Event kind" value={gate.eventKind || 'none'} />
+            <Detail label="Privacy" value={gate.privacyTier} />
+            <Detail label="Config" value={gate.envVar ? `${gate.envVar}=${gate.configuredValue || 'unset'}` : 'always evaluated'} />
+          </div>
+        </article>
+      ))}
+    </section>
+  )
+}
+
 function MetricCard({ label, value, tone = 'slate' }: { label: string; value: number; tone?: 'slate' | 'green' | 'yellow' | 'red' }) {
   const toneClass = tone === 'green' ? 'text-green-300' : tone === 'yellow' ? 'text-yellow-200' : tone === 'red' ? 'text-red-300' : 'text-foreground'
   return (
@@ -558,11 +586,11 @@ function LaneBadge({ lane }: { lane: string }) {
 }
 
 function StatusBadge({ value }: { value: string }) {
-  const tone = value === 'approved' || value === 'connected'
+  const tone = value === 'approved' || value === 'connected' || value === 'enabled'
     ? 'border-green-400/30 bg-green-500/10 text-green-200'
     : value === 'approved_policy'
       ? 'border-green-400/30 bg-green-500/10 text-green-200'
-      : value === 'pending' || value === 'blocked' || value === 'approval_required' || value === 'shadow_only'
+      : value === 'pending' || value === 'blocked' || value === 'approval_required' || value === 'shadow_only' || value === 'approval_gated'
       ? 'border-yellow-400/30 bg-yellow-500/10 text-yellow-100'
       : 'border-silicon-slate/70 bg-silicon-slate/30 text-muted-foreground'
   return <span className={`rounded-full border px-2 py-1 text-xs ${tone}`}>{value}</span>

--- a/lib/open-brain.test.ts
+++ b/lib/open-brain.test.ts
@@ -95,6 +95,32 @@ describe('Open Brain projection', () => {
       status: 'pending',
     }))
     expect(snapshot.contextPacket.boundaries).toContain('Do not mutate ~/.codex operational state from Portfolio APIs.')
+    expect(snapshot.producerGates.map((gate) => gate.id)).toEqual(expect.arrayContaining([
+      'producer:personality-corpus',
+      'producer:chatbot-knowledge',
+      'producer:autoresearch',
+      'producer:model-ops',
+      'producer:rag-pinecone',
+    ]))
+    expect(snapshot.overview.producerGates).toBe(snapshot.producerGates.length)
+  })
+
+  it('keeps AutoResearch producer traces disabled until explicitly configured', async () => {
+    const root = await makeTempRoot()
+    let snapshot = await getOpenBrainSnapshot(root)
+
+    expect(snapshot.producerGates.find((gate) => gate.id === 'producer:autoresearch')).toEqual(expect.objectContaining({
+      status: 'disabled',
+      envVar: 'OPEN_BRAIN_AUTORESEARCH_TRACE',
+    }))
+
+    vi.stubEnv('OPEN_BRAIN_AUTORESEARCH_TRACE', 'true')
+    snapshot = await getOpenBrainSnapshot(root)
+
+    expect(snapshot.producerGates.find((gate) => gate.id === 'producer:autoresearch')).toEqual(expect.objectContaining({
+      status: 'enabled',
+      configuredValue: 'true',
+    }))
   })
 
   it('validates privacy tiers and secret-like public text', () => {

--- a/lib/open-brain.ts
+++ b/lib/open-brain.ts
@@ -128,6 +128,18 @@ export interface OpenBrainRuntimeParity {
   note: string
 }
 
+export interface OpenBrainProducerGate {
+  id: string
+  label: string
+  status: 'enabled' | 'disabled' | 'shadow_only' | 'approval_gated' | 'blocked'
+  sourceKind: OpenBrainSourceKind
+  eventKind: OpenBrainEventKind | null
+  privacyTier: OpenBrainPrivacyTier
+  envVar: string | null
+  configuredValue: string | null
+  note: string
+}
+
 export interface OpenBrainSnapshot {
   generatedAt: string
   service: {
@@ -152,6 +164,8 @@ export interface OpenBrainSnapshot {
     ragProjectionDocuments: number
     staleSources: number
     privateRecords: number
+    producerGates: number
+    enabledProducerGates: number
   }
   health: {
     sourceFreshness: 'green' | 'yellow' | 'red'
@@ -173,6 +187,7 @@ export interface OpenBrainSnapshot {
     pineconeWriteStatus: 'blocked_pending_approval'
   }
   runtimeParity: OpenBrainRuntimeParity[]
+  producerGates: OpenBrainProducerGate[]
   modelOps: ModelOpsProjection
   contextPacket: {
     purpose: string
@@ -314,10 +329,12 @@ export async function getOpenBrainSnapshot(openBrainHome = getOpenBrainHome()): 
   const links = dedupeLinks(persistedLinks)
   const wikiPages = compileKarpathyWikiOverlay(memories, events)
   const ragProjection = buildOpenBrainRagProjection(memories)
+  const runtimeParity = await buildRuntimeParity(openBrainHome)
+  const producerGates = buildProducerGates(modelOps)
   const pendingProposals = proposals.filter((proposal) => proposal.status === 'pending').length
   const approvedProposals = proposals.filter((proposal) => proposal.status === 'approved').length
   const rejectedProposals = proposals.filter((proposal) => proposal.status === 'rejected').length
-  const service = getServiceStatus(openBrainHome)
+  const service = getServiceStatus(openBrainHome, runtimeParity.some((runtime) => runtime.status === 'connected'))
 
   return {
     generatedAt,
@@ -339,6 +356,8 @@ export async function getOpenBrainSnapshot(openBrainHome = getOpenBrainHome()): 
         ...memories.map((memory) => memory.privacyTier),
         ...proposals.map((proposal) => proposal.proposedMemory.privacyTier),
       ].filter((tier) => tier === 'private').length,
+      producerGates: producerGates.length,
+      enabledProducerGates: producerGates.filter((gate) => gate.status === 'enabled').length,
     },
     health: {
       sourceFreshness: classifyFreshness(sources, generatedAt),
@@ -353,9 +372,10 @@ export async function getOpenBrainSnapshot(openBrainHome = getOpenBrainHome()): 
     proposals,
     wikiPages,
     ragProjection,
-    runtimeParity: buildRuntimeParity(openBrainHome),
+    runtimeParity,
+    producerGates,
     modelOps,
-    contextPacket: buildContextPacket(sources, memories, proposals, modelOps),
+    contextPacket: buildContextPacket(sources, memories, proposals, modelOps, producerGates),
   }
 }
 
@@ -645,7 +665,7 @@ export function sanitizeOpenBrainText(value: string, maxLength = 700) {
   return value.replace(SECRETISH_PATTERN, '[redacted]').replace(/\s+/g, ' ').trim().slice(0, maxLength)
 }
 
-function getServiceStatus(openBrainHome: string): OpenBrainSnapshot['service'] {
+function getServiceStatus(openBrainHome: string, runtimeMcpConfigured = false): OpenBrainSnapshot['service'] {
   const databaseUrl = process.env.OPEN_BRAIN_DATABASE_URL || ''
   const mcpUrl = process.env.OPEN_BRAIN_MCP_URL || ''
   const storage = databaseUrl ? 'postgres_pgvector' : existsSync(openBrainHome) ? 'local_jsonl' : 'unconfigured'
@@ -655,7 +675,7 @@ function getServiceStatus(openBrainHome: string): OpenBrainSnapshot['service'] {
     storage,
     home: openBrainHome,
     databaseConfigured: Boolean(databaseUrl),
-    mcpConfigured: Boolean(mcpUrl),
+    mcpConfigured: Boolean(mcpUrl || runtimeMcpConfigured),
     mcpUrl: mcpUrl || null,
     reason: available ? null : 'Local Open Brain storage is not configured yet. Set OPEN_BRAIN_DATABASE_URL or initialize OPEN_BRAIN_HOME.',
     operationalBoundary: 'Portfolio is a projection and approval surface. The local Open Brain service remains the source of truth; direct writes to Codex operational state require a separate approved repair step.',
@@ -807,26 +827,36 @@ function buildModelOpsSources(modelOps: ModelOpsProjection): OpenBrainSourceReco
   ]
 }
 
-function buildRuntimeParity(openBrainHome: string): OpenBrainRuntimeParity[] {
+async function buildRuntimeParity(openBrainHome: string): Promise<OpenBrainRuntimeParity[]> {
   const codexConfig = path.join(homedir(), '.codex', 'config.toml')
-  const hermesConfig = path.join(homedir(), '.hermes', 'hermes-agent')
+  const hermesConfig = path.join(homedir(), '.hermes', 'config.yaml')
   const opencodeConfig = path.join(homedir(), '.config', 'opencode')
   const cursorConfig = path.join(homedir(), '.cursor')
+  const [codexConfigText, hermesConfigText] = await Promise.all([
+    readOptionalText(codexConfig),
+    readOptionalText(hermesConfig),
+  ])
+  const codexConnected = hasOpenBrainMcpRegistration(codexConfigText, openBrainHome)
+  const hermesConnected = hasOpenBrainMcpRegistration(hermesConfigText, openBrainHome)
   return [
     {
       runtime: 'Codex',
-      status: existsSync(codexConfig) ? 'blocked' : 'skipped',
+      status: codexConnected ? 'connected' : existsSync(codexConfig) ? 'blocked' : 'skipped',
       configPath: codexConfig,
-      note: existsSync(codexConfig)
-        ? 'Codex config exists; register the Open Brain MCP server after approval.'
+      note: codexConnected
+        ? 'Codex config includes the open-brain MCP stdio server and local OPEN_BRAIN_HOME.'
+        : existsSync(codexConfig)
+        ? 'Codex config exists, but the Open Brain MCP registration was not detected.'
         : 'Codex config was not found on this machine.',
     },
     {
       runtime: 'Hermes',
-      status: existsSync(hermesConfig) ? 'blocked' : 'skipped',
+      status: hermesConnected ? 'connected' : existsSync(hermesConfig) ? 'blocked' : 'skipped',
       configPath: hermesConfig,
-      note: existsSync(hermesConfig)
-        ? 'Hermes runtime exists; MCP parity registration still needs an approved operational step.'
+      note: hermesConnected
+        ? 'Hermes config includes the open-brain MCP stdio server and local OPEN_BRAIN_HOME.'
+        : existsSync(hermesConfig)
+        ? 'Hermes config exists, but the Open Brain MCP registration was not detected.'
         : 'Hermes runtime was not found on this machine.',
     },
     {
@@ -860,11 +890,77 @@ function buildRuntimeParity(openBrainHome: string): OpenBrainRuntimeParity[] {
   ]
 }
 
+function buildProducerGates(modelOps: ModelOpsProjection): OpenBrainProducerGate[] {
+  const autoresearchTrace = process.env.OPEN_BRAIN_AUTORESEARCH_TRACE || null
+  return [
+    {
+      id: 'producer:personality-corpus',
+      label: 'Personality corpus',
+      status: 'enabled',
+      sourceKind: 'personality_corpus',
+      eventKind: 'source_observed',
+      privacyTier: 'public_safe',
+      envVar: null,
+      configuredValue: null,
+      note: 'Public-safe derived corpus pack may be observed as an Open Brain source. Raw private exports remain excluded.',
+    },
+    {
+      id: 'producer:chatbot-knowledge',
+      label: 'Chatbot knowledge',
+      status: 'enabled',
+      sourceKind: 'chatbot_knowledge',
+      eventKind: 'source_observed',
+      privacyTier: 'public_safe',
+      envVar: null,
+      configuredValue: null,
+      note: 'Portfolio /api/knowledge is a projection source only; durable memory still requires approval.',
+    },
+    {
+      id: 'producer:autoresearch',
+      label: 'AutoResearch traces',
+      status: autoresearchTrace === 'true' || autoresearchTrace === '1' ? 'enabled' : 'disabled',
+      sourceKind: 'autoresearch_proposal',
+      eventKind: 'autoresearch_proposal_created',
+      privacyTier: 'internal_ops',
+      envVar: 'OPEN_BRAIN_AUTORESEARCH_TRACE',
+      configuredValue: autoresearchTrace,
+      note: autoresearchTrace === 'true' || autoresearchTrace === '1'
+        ? 'AutoResearch can emit source/event traces and approval packets, but cannot execute experiments automatically.'
+        : 'AutoResearch trace emission is off until OPEN_BRAIN_AUTORESEARCH_TRACE=true is explicitly configured.',
+    },
+    {
+      id: 'producer:model-ops',
+      label: 'Model Ops projection',
+      status: modelOps.available ? 'enabled' : 'blocked',
+      sourceKind: modelOps.available ? 'model_ops_dashboard' : 'model_ops_report',
+      eventKind: 'source_observed',
+      privacyTier: 'internal_ops',
+      envVar: null,
+      configuredValue: null,
+      note: modelOps.available
+        ? 'Model Ops reports can be observed as source records; model swaps remain approval-gated.'
+        : modelOps.reason || 'Model Ops report data is not currently available.',
+    },
+    {
+      id: 'producer:rag-pinecone',
+      label: 'RAG and Pinecone',
+      status: 'approval_gated',
+      sourceKind: 'rag_projection',
+      eventKind: 'rag_projection_staged',
+      privacyTier: 'public_safe',
+      envVar: null,
+      configuredValue: null,
+      note: 'RAG staging can use approved public-safe projections. Pinecone writes remain blocked until a separate approval step.',
+    },
+  ]
+}
+
 function buildContextPacket(
   sources: OpenBrainSourceRecord[],
   memories: OpenBrainMemoryRecord[],
   proposals: OpenBrainProposalRecord[],
   modelOps: ModelOpsProjection,
+  producerGates: OpenBrainProducerGate[],
 ): OpenBrainSnapshot['contextPacket'] {
   return {
     purpose: 'Use the local Open Brain to understand Portfolio Agent Ops context before acting; Portfolio Admin is the projection and approval layer.',
@@ -883,6 +979,9 @@ function buildContextPacket(
       ...(modelOps.available && modelOps.routerDecisions.some((decision) => decision.approvalState === 'approval_required')
         ? ['Model Ops has approval-gated router decisions that cannot be applied automatically.']
         : []),
+      ...(producerGates.some((gate) => gate.status === 'blocked')
+        ? ['One or more Open Brain producer gates are blocked and should not emit records yet.']
+        : []),
     ],
     expectedOutputs: [
       'Context packet before agent action',
@@ -891,6 +990,20 @@ function buildContextPacket(
       'Unified router decision before local, frontier, hybrid, tool, or approval-gated model execution',
     ],
   }
+}
+
+async function readOptionalText(filePath: string) {
+  if (!existsSync(filePath)) return null
+  try {
+    return await readFile(filePath, 'utf8')
+  } catch {
+    return null
+  }
+}
+
+function hasOpenBrainMcpRegistration(configText: string | null, openBrainHome: string) {
+  if (!configText) return false
+  return configText.includes('open-brain') && configText.includes('OPEN_BRAIN_HOME') && configText.includes(openBrainHome)
 }
 
 function mergeProposals(persisted: OpenBrainProposalRecord[], generated: OpenBrainProposalRecord[]) {


### PR DESCRIPTION
## Summary
- update Open Brain snapshot parity detection so Codex and Hermes show connected when their MCP configs include open-brain and OPEN_BRAIN_HOME
- add producer gate records for personality corpus, chatbot knowledge, AutoResearch traces, Model Ops, and RAG/Pinecone projection
- surface producer gates in Portfolio Admin with tests for AutoResearch's default-disabled behavior

## Validation
- npm test -- --run lib/open-brain.test.ts
- npx tsc --noEmit --pretty false
- npm run lint
- npm run build
- npx tsx snapshot smoke confirmed Codex/Hermes connected and AutoResearch disabled by default

## Notes
- Build emitted the existing local env warning that MOCK_N8N=false and N8N_DISABLE_OUTBOUND=false can allow outbound n8n webhooks during development; no build failure.