### PR TITLE
feat: surface credential rotation packet visibility

### DIFF
--- a/app/admin/credentials/page.test.tsx
+++ b/app/admin/credentials/page.test.tsx
@@ -34,6 +34,25 @@ const baseReport = {
   bySource: { infisical: 1, '1password': 1 },
   byRisk: { 'standard-api': 1, 'oauth-session': 1 },
   byRuntimeSink: { Vercel: 1, 'local-env': 1 },
+  packetSummary: {
+    total: 1,
+    drafted: 1,
+    synced: 0,
+    verified: 0,
+    revocationPending: 0,
+    blocked: 0,
+    latestCreatedAt: '2026-05-09T12:00:00.000Z',
+  },
+  packets: [
+    {
+      createdAt: '2026-05-09T12:00:00.000Z',
+      type: 'rotation',
+      envVar: 'OPENAI_API_KEY',
+      status: 'drafted',
+      approvalRequired: false,
+      localEnvUpdated: false,
+    },
+  ],
   blockers: ['2 staging secrets need provider-confirmed rotation baselines.'],
   rows: [
     {
@@ -96,8 +115,10 @@ describe('CredentialAdminPage', () => {
     expect(await screen.findByRole('heading', { name: 'Credential Reporting' })).toBeInTheDocument()
     expect(screen.getByText('Baseline needed')).toBeInTheDocument()
     expect(screen.getByText('2 need baseline / 0 due / 0 ok')).toBeInTheDocument()
-    expect(screen.getByText('OPENAI_API_KEY')).toBeInTheDocument()
+    expect(screen.getAllByText('OPENAI_API_KEY').length).toBeGreaterThan(0)
     expect(screen.getByText('LINKEDIN_COOKIE')).toBeInTheDocument()
+    expect(screen.getByText('Rotation packets')).toBeInTheDocument()
+    expect(screen.getByText('Drafted')).toBeInTheDocument()
     expect(screen.queryByText('super-secret-value')).not.toBeInTheDocument()
 
     await waitFor(() => {

--- a/app/admin/credentials/page.tsx
+++ b/app/admin/credentials/page.tsx
@@ -46,6 +46,23 @@ type CredentialReport = {
   bySource: Record<string, number>
   byRisk: Record<string, number>
   byRuntimeSink: Record<string, number>
+  packetSummary: {
+    total: number
+    drafted: number
+    synced: number
+    verified: number
+    revocationPending: number
+    blocked: number
+    latestCreatedAt: string | null
+  }
+  packets: Array<{
+    createdAt: string
+    type: 'rotation' | 'runtime-sync'
+    envVar: string
+    status: 'drafted' | 'synced' | 'verified' | 'revocation-pending' | 'blocked'
+    approvalRequired: boolean
+    localEnvUpdated: boolean
+  }>
   blockers: string[]
   rows: CredentialReportRow[]
 }
@@ -183,6 +200,50 @@ function CredentialAdminContent() {
               <Breakdown title="Runtime Sinks" rows={report.byRuntimeSink} />
             </section>
 
+            <section className="mb-6 rounded-lg border border-silicon-slate bg-silicon-slate/30 p-4">
+              <div className="mb-3 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                <h2 className="font-semibold">Rotation packets</h2>
+                <div className="text-xs text-muted-foreground">
+                  Latest: {report.packetSummary.latestCreatedAt ? new Date(report.packetSummary.latestCreatedAt).toLocaleString() : 'none'}
+                </div>
+              </div>
+              <div className="mb-4 grid grid-cols-2 gap-3 md:grid-cols-5">
+                <MiniMetric label="Drafted" value={report.packetSummary.drafted} />
+                <MiniMetric label="Synced" value={report.packetSummary.synced} />
+                <MiniMetric label="Verified" value={report.packetSummary.verified} />
+                <MiniMetric label="Revocation" value={report.packetSummary.revocationPending} />
+                <MiniMetric label="Blocked" value={report.packetSummary.blocked} />
+              </div>
+              {report.packets.length > 0 ? (
+                <div className="overflow-x-auto">
+                  <table className="min-w-full divide-y divide-silicon-slate text-sm">
+                    <thead className="text-left text-xs uppercase tracking-wide text-muted-foreground">
+                      <tr>
+                        <th className="px-2 py-2">Status</th>
+                        <th className="px-2 py-2">Created</th>
+                        <th className="px-2 py-2">Type</th>
+                        <th className="px-2 py-2">Secret</th>
+                        <th className="px-2 py-2">Approval</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-silicon-slate">
+                      {report.packets.slice(0, 8).map((packet) => (
+                        <tr key={`${packet.createdAt}-${packet.envVar}-${packet.type}`}>
+                          <td className="px-2 py-2">{packet.status}</td>
+                          <td className="px-2 py-2">{new Date(packet.createdAt).toLocaleString()}</td>
+                          <td className="px-2 py-2">{packet.type}</td>
+                          <td className="px-2 py-2 font-mono text-xs">{packet.envVar}</td>
+                          <td className="px-2 py-2">{packet.approvalRequired ? 'required' : 'not required'}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground">No local rotation packets found.</p>
+              )}
+            </section>
+
             <section className="overflow-hidden rounded-lg border border-silicon-slate">
               <div className="border-b border-silicon-slate bg-silicon-slate/40 px-4 py-3">
                 <h2 className="font-semibold">Rotation inventory</h2>
@@ -251,6 +312,15 @@ function Breakdown({ title, rows }: { title: string; rows: Record<string, number
           </div>
         ))}
       </div>
+    </div>
+  )
+}
+
+function MiniMetric({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-lg border border-silicon-slate bg-background/40 px-3 py-2">
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <div className="text-lg font-semibold">{value}</div>
     </div>
   )
 }

--- a/app/api/admin/credentials/report/route.test.ts
+++ b/app/api/admin/credentials/report/route.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   verifyAdmin: vi.fn(),
   isAuthError: vi.fn(),
+  readdir: vi.fn(),
   readFile: vi.fn(),
 }))
 
@@ -12,8 +13,9 @@ vi.mock('@/lib/auth-server', () => ({
 }))
 
 vi.mock('node:fs/promises', () => ({
+  readdir: mocks.readdir,
   readFile: mocks.readFile,
-  default: { readFile: mocks.readFile },
+  default: { readdir: mocks.readdir, readFile: mocks.readFile },
 }))
 
 import { GET } from './route'
@@ -77,7 +79,28 @@ describe('GET /api/admin/credentials/report', () => {
     vi.clearAllMocks()
     mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
     mocks.isAuthError.mockReturnValue(false)
-    mocks.readFile.mockResolvedValue(JSON.stringify(inventory))
+    mocks.readdir.mockResolvedValue(['2026-05-09-staging-openai-api-key-rotation.json'])
+    mocks.readFile.mockImplementation(async (file: string) => {
+      if (file.includes('.credential-rotation-audits')) {
+        return JSON.stringify({
+          createdAt: '2026-05-09T12:00:00.000Z',
+          type: 'rotation',
+          environment: 'staging',
+          secretId: 'openai-api-key',
+          envVar: 'OPENAI_API_KEY',
+          sourceOfTruth: 'infisical',
+          rotationMode: 'provider-dashboard-or-api',
+          cadenceDays: 90,
+          runtimeSinks: ['Vercel'],
+          approvalRequired: false,
+          generatedFingerprint: null,
+          action: 'Provider-backed rotation required.',
+          verification: ['npm run credentials:smoke -- --env staging'],
+          rollback: 'Restore previous key.',
+        })
+      }
+      return JSON.stringify(inventory)
+    })
   })
 
   it('requires admin auth before reading the inventory', async () => {
@@ -106,6 +129,10 @@ describe('GET /api/admin/credentials/report', () => {
       providerContext: {
         infisicalProject: 'portfolio',
         onePasswordVault: 'Portfolio / staging',
+      },
+      packetSummary: {
+        total: 1,
+        drafted: 1,
       },
     })
     expect(body.rows[0]).toMatchObject({

--- a/app/api/admin/credentials/report/route.ts
+++ b/app/api/admin/credentials/report/route.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises'
+import { readdir, readFile } from 'node:fs/promises'
 import * as path from 'node:path'
 import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
@@ -6,11 +6,13 @@ import {
   buildCredentialReport,
   isCredentialEnvironment,
   type CredentialInventory,
+  type CredentialRotationPacket,
 } from '@/lib/credential-report'
 
 export const dynamic = 'force-dynamic'
 
 const INVENTORY_PATH = path.join(process.cwd(), 'docs', 'credential-inventory.json')
+const AUDIT_DIR = path.join(process.cwd(), '.credential-rotation-audits')
 
 export async function GET(request: NextRequest) {
   const auth = await verifyAdmin(request)
@@ -28,11 +30,31 @@ export async function GET(request: NextRequest) {
 
   try {
     const inventory = JSON.parse(await readFile(INVENTORY_PATH, 'utf8')) as CredentialInventory
-    return NextResponse.json(buildCredentialReport(inventory, env, asOf))
+    return NextResponse.json(buildCredentialReport(inventory, env, asOf, await readRotationPackets()))
   } catch (error) {
     return NextResponse.json(
       { error: error instanceof Error ? error.message : 'Failed to build credential report' },
       { status: 500 }
     )
+  }
+}
+
+async function readRotationPackets(): Promise<CredentialRotationPacket[]> {
+  try {
+    const files = await readdir(AUDIT_DIR)
+    const packets = await Promise.all(
+      files
+        .filter((file) => file.endsWith('.json'))
+        .map(async (file) => {
+          try {
+            return JSON.parse(await readFile(path.join(AUDIT_DIR, file), 'utf8')) as CredentialRotationPacket
+          } catch {
+            return null
+          }
+        })
+    )
+    return packets.filter((packet): packet is CredentialRotationPacket => Boolean(packet))
+  } catch {
+    return []
   }
 }

--- a/docs/credential-management-system.md
+++ b/docs/credential-management-system.md
@@ -42,6 +42,8 @@ Use plain `credentials:smoke` for local registry checks. Use `--require-provider
 
 Use `credentials:report` for rotation visibility. It is read-only and summarizes the inventory by status, source of truth, risk, runtime sink, approval boundary, and next action. It does not fetch or print secret values. The same report is exposed to admins at `/admin/credentials` through `/api/admin/credentials/report`.
 
+When local `.credential-rotation-audits/*.json` packets exist, `credentials:report` and `/admin/credentials` also summarize packet metadata by status (`drafted`, `synced`, `verified`, `revocation-pending`, `blocked`). Packet reporting is value-free: it shows secret ids/env var names, timestamps, approval state, runtime sinks, and verification commands, not credential values.
+
 Use `credentials:baseline-template` when `credentials:report` shows `needs-baseline`. It emits provider-confirmation placeholders for each missing environment baseline so the operator can verify provider history, fill `lastRotatedAt`, preserve evidence, and update `docs/credential-inventory.json` without guessing from local env files.
 
 ## Rotation Rules

--- a/lib/credential-report.test.ts
+++ b/lib/credential-report.test.ts
@@ -87,7 +87,25 @@ describe('credential report', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-05-09T12:00:00.000Z'))
 
-    const report = buildCredentialReport(inventory, 'staging', '2026-05-09')
+    const report = buildCredentialReport(inventory, 'staging', '2026-05-09', [
+      {
+        createdAt: '2026-05-08T12:00:00.000Z',
+        type: 'rotation',
+        environment: 'staging',
+        secretId: 'missing-baseline',
+        envVar: 'MISSING_BASELINE',
+        sourceOfTruth: '1password',
+        rotationMode: 'manual-reauth',
+        cadenceDays: 90,
+        runtimeSinks: ['local-env'],
+        approvalRequired: false,
+        generatedFingerprint: null,
+        action: 'Generated replacement value and wrote it to the requested ignored local env sink.',
+        verification: ['Manual login check'],
+        rollback: 'Re-authenticate.',
+        localEnvUpdated: '.env.staging',
+      },
+    ])
 
     expect(report.summary).toMatchObject({
       total: 2,
@@ -104,6 +122,16 @@ describe('credential report', () => {
       onePasswordVault: 'Portfolio / staging',
     })
     expect(report.bySource).toEqual({ infisical: 1, '1password': 1 })
+    expect(report.packetSummary).toMatchObject({
+      total: 1,
+      synced: 1,
+      latestCreatedAt: '2026-05-08T12:00:00.000Z',
+    })
+    expect(report.packets[0]).toMatchObject({
+      envVar: 'MISSING_BASELINE',
+      status: 'synced',
+      localEnvUpdated: true,
+    })
     expect(report.blockers).toEqual([
       '1 staging secrets need provider-confirmed rotation baselines.',
       '1 staging secrets are due for rotation.',
@@ -112,6 +140,7 @@ describe('credential report', () => {
 
     const markdown = renderCredentialReportMarkdown(report)
     expect(markdown).toContain('Credential Rotation Visibility (staging)')
+    expect(markdown).toContain('Rotation Packets')
     expect(markdown).toContain('DUE_SECRET')
     expect(markdown).not.toContain('super-secret')
 

--- a/lib/credential-report.ts
+++ b/lib/credential-report.ts
@@ -93,8 +93,55 @@ export type CredentialReport = {
   bySource: Record<CredentialSourceOfTruth, number>
   byRisk: Record<string, number>
   byRuntimeSink: Record<string, number>
+  packetSummary: CredentialPacketSummary
+  packets: CredentialPacketReport[]
   blockers: string[]
   rows: CredentialReportRow[]
+}
+
+export type CredentialPacketStatus = 'drafted' | 'synced' | 'verified' | 'revocation-pending' | 'blocked'
+
+export type CredentialRotationPacket = {
+  createdAt: string
+  type: 'rotation' | 'runtime-sync'
+  environment: CredentialEnvironment
+  secretId: string
+  envVar: string
+  sourceOfTruth: CredentialSourceOfTruth
+  rotationMode: string
+  cadenceDays: number
+  runtimeSinks: string[]
+  approvalRequired: boolean
+  generatedFingerprint: string | null
+  action: string
+  verification: string[]
+  rollback: string
+  localEnvUpdated?: string
+}
+
+export type CredentialPacketReport = {
+  createdAt: string
+  type: CredentialRotationPacket['type']
+  environment: CredentialEnvironment
+  secretId: string
+  envVar: string
+  sourceOfTruth: CredentialSourceOfTruth
+  status: CredentialPacketStatus
+  approvalRequired: boolean
+  runtimeSinks: string[]
+  verification: string[]
+  generatedFingerprint: string | null
+  localEnvUpdated: boolean
+}
+
+export type CredentialPacketSummary = {
+  total: number
+  drafted: number
+  synced: number
+  verified: number
+  revocationPending: number
+  blocked: number
+  latestCreatedAt: string | null
 }
 
 export type CredentialBaselineTemplateEntry = {
@@ -116,7 +163,8 @@ export function isCredentialEnvironment(value: string): value is CredentialEnvir
 export function buildCredentialReport(
   inventory: CredentialInventory,
   env: CredentialEnvironment,
-  asOfInput: string | Date = new Date()
+  asOfInput: string | Date = new Date(),
+  packets: CredentialRotationPacket[] = []
 ): CredentialReport {
   const asOfDate = asDate(asOfInput)
   const rows = inventory.secrets
@@ -138,6 +186,10 @@ export function buildCredentialReport(
     providerConfirmed: rows.filter((row) => row.baselineStatus === 'confirmed').length,
     providerPending: rows.filter((row) => row.baselineStatus !== 'confirmed').length,
   }
+  const packetReports = packets
+    .filter((packet) => packet.environment === env)
+    .map(toPacketReport)
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
 
   return {
     generatedAt: new Date().toISOString(),
@@ -154,7 +206,9 @@ export function buildCredentialReport(
     bySource: countBy(rows, (row) => row.sourceOfTruth),
     byRisk: countBy(rows, (row) => row.risk),
     byRuntimeSink: countRuntimeSinks(rows),
-    blockers: buildBlockers(summary, env),
+    packetSummary: summarizePackets(packetReports),
+    packets: packetReports,
+    blockers: buildBlockers(summary, env, packetReports),
     rows,
   }
 }
@@ -184,6 +238,30 @@ export function renderCredentialReportMarkdown(report: CredentialReport): string
     '',
     ...(report.blockers.length > 0 ? report.blockers.map((blocker) => `- ${blocker}`) : ['- None']),
     '',
+    '## Rotation Packets',
+    '',
+    `- Total packets: ${report.packetSummary.total}`,
+    `- Drafted: ${report.packetSummary.drafted}`,
+    `- Synced: ${report.packetSummary.synced}`,
+    `- Verified: ${report.packetSummary.verified}`,
+    `- Revocation pending: ${report.packetSummary.revocationPending}`,
+    `- Blocked: ${report.packetSummary.blocked}`,
+    `- Latest packet: ${report.packetSummary.latestCreatedAt ?? 'none'}`,
+    '',
+    ...(report.packets.length > 0
+      ? [
+        '| Status | Created | Type | Env Var | Approval |',
+        '| --- | --- | --- | --- | --- |',
+        ...report.packets.slice(0, 10).map((packet) => [
+          packet.status,
+          packet.createdAt,
+          packet.type,
+          packet.envVar,
+          packet.approvalRequired ? 'required' : 'not-required',
+        ].map(escapeTableCell).join(' | ')).map((line) => `| ${line} |`),
+        '',
+      ]
+      : ['No local rotation packets found.', '']),
     '## Secrets',
     '',
     '| Status | Env Var | Source | Risk | Due | Baseline | Next action |',
@@ -303,11 +381,55 @@ function nextAction(status: CredentialReportRow['status'], baselineStatus: Crede
   return 'No action needed.'
 }
 
-function buildBlockers(summary: CredentialReport['summary'], env: CredentialEnvironment): string[] {
+function toPacketReport(packet: CredentialRotationPacket): CredentialPacketReport {
+  return {
+    createdAt: packet.createdAt,
+    type: packet.type,
+    environment: packet.environment,
+    secretId: packet.secretId,
+    envVar: packet.envVar,
+    sourceOfTruth: packet.sourceOfTruth,
+    status: inferPacketStatus(packet),
+    approvalRequired: packet.approvalRequired,
+    runtimeSinks: packet.runtimeSinks,
+    verification: packet.verification,
+    generatedFingerprint: packet.generatedFingerprint,
+    localEnvUpdated: Boolean(packet.localEnvUpdated),
+  }
+}
+
+function inferPacketStatus(packet: CredentialRotationPacket): CredentialPacketStatus {
+  const action = packet.action.toLowerCase()
+  if (action.includes('blocked')) return 'blocked'
+  if (action.includes('verified')) return 'verified'
+  if (packet.approvalRequired) return 'revocation-pending'
+  if (packet.localEnvUpdated) return 'synced'
+  return 'drafted'
+}
+
+function summarizePackets(packets: CredentialPacketReport[]): CredentialPacketSummary {
+  return {
+    total: packets.length,
+    drafted: packets.filter((packet) => packet.status === 'drafted').length,
+    synced: packets.filter((packet) => packet.status === 'synced').length,
+    verified: packets.filter((packet) => packet.status === 'verified').length,
+    revocationPending: packets.filter((packet) => packet.status === 'revocation-pending').length,
+    blocked: packets.filter((packet) => packet.status === 'blocked').length,
+    latestCreatedAt: packets[0]?.createdAt ?? null,
+  }
+}
+
+function buildBlockers(
+  summary: CredentialReport['summary'],
+  env: CredentialEnvironment,
+  packets: CredentialPacketReport[]
+): string[] {
   const blockers: string[] = []
   if (summary.needsBaseline > 0) blockers.push(`${summary.needsBaseline} ${env} secrets need provider-confirmed rotation baselines.`)
   if (summary.due > 0) blockers.push(`${summary.due} ${env} secrets are due for rotation.`)
   if (env === 'prod' && summary.approvalRequired > 0) blockers.push('Production rotation or revocation requires an approval packet.')
+  if (packets.some((packet) => packet.status === 'blocked')) blockers.push('At least one local rotation packet is blocked.')
+  if (packets.some((packet) => packet.status === 'revocation-pending')) blockers.push('At least one local rotation packet is waiting on revocation approval.')
   return blockers
 }
 

--- a/scripts/credential-broker.ts
+++ b/scripts/credential-broker.ts
@@ -1,11 +1,12 @@
 #!/usr/bin/env tsx
 import { spawnSync } from 'node:child_process'
 import { createHash, randomBytes } from 'node:crypto'
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
 import * as path from 'node:path'
 import {
   buildCredentialBaselineTemplate,
   buildCredentialReport,
+  type CredentialRotationPacket,
   renderCredentialBaselineTemplateMarkdown,
   renderCredentialReportMarkdown,
 } from '../lib/credential-report'
@@ -212,7 +213,7 @@ function listDue(inventory: CredentialInventory, args: ParsedArgs) {
 function report(inventory: CredentialInventory, args: ParsedArgs) {
   const env = getEnv(args)
   const asOf = String(args.options['as-of'] || new Date().toISOString())
-  const credentialReport = buildCredentialReport(inventory, env, asOf)
+  const credentialReport = buildCredentialReport(inventory, env, asOf, readRotationPackets())
 
   if (args.options.json) {
     console.log(JSON.stringify(credentialReport, null, 2))
@@ -499,6 +500,19 @@ function writePacket(packet: RotationPacket) {
   const stamp = packet.createdAt.split(':').join('-').replace(/\.\d+Z$/, 'Z')
   const filename = `${stamp}-${packet.environment}-${packet.secretId}-${packet.type}.json`
   writeFileSync(path.join(AUDIT_DIR, filename), `${JSON.stringify(packet, null, 2)}\n`)
+}
+
+function readRotationPackets(): CredentialRotationPacket[] {
+  if (!existsSync(AUDIT_DIR)) return []
+  return readdirSync(AUDIT_DIR)
+    .filter((file) => file.endsWith('.json'))
+    .flatMap((file) => {
+      try {
+        return [JSON.parse(readFileSync(path.join(AUDIT_DIR, file), 'utf8')) as CredentialRotationPacket]
+      } catch {
+        return []
+      }
+    })
 }
 
 function printPacketSummary(packet: RotationPacket) {


### PR DESCRIPTION
## Summary
- add value-free rotation packet metadata to credential reports
- read local `.credential-rotation-audits/*.json` packets from the CLI and admin API when present
- surface packet counts/statuses in `/admin/credentials`
- document packet status reporting as value-free rotation visibility

## Validation
- `npm run build:knowledge`
- `npx tsc --noEmit --pretty false --skipLibCheck`
- `npx vitest run lib/credential-report.test.ts app/api/admin/credentials/report/route.test.ts app/admin/credentials/page.test.tsx --reporter=dot`
- `npm run lint -- --file app/admin/credentials/page.tsx --file app/admin/credentials/page.test.tsx --file app/api/admin/credentials/report/route.ts --file app/api/admin/credentials/report/route.test.ts --file lib/credential-report.ts --file lib/credential-report.test.ts --file scripts/credential-broker.ts`
- `npx tsx scripts/credential-broker.ts report --env staging --json`

## Scope / overlap
- Owned scope: credential docs, broker/reporting scripts, credential admin/report surface
- No shared nav changes in this PR
- No Agent Ops files touched
- Overlap rating: low