### PR TITLE
feat: add credential runtime sink visibility

### DIFF
--- a/app/admin/credentials/page.test.tsx
+++ b/app/admin/credentials/page.test.tsx
@@ -31,6 +31,12 @@ const baseReport = {
     providerConfirmed: 0,
     providerPending: 2,
   },
+  sinkPresenceSummary: {
+    present: 1,
+    missing: 0,
+    unknown: 1,
+    unavailable: 0,
+  },
   bySource: { infisical: 1, '1password': 1 },
   byRisk: { 'standard-api': 1, 'oauth-session': 1 },
   byRuntimeSink: { Vercel: 1, 'local-env': 1 },
@@ -67,6 +73,20 @@ const baseReport = {
       lastRotatedAt: null,
       dueAt: null,
       status: 'needs-baseline',
+      sinkPresence: [
+        {
+          sink: 'Vercel',
+          status: 'unknown',
+          evidence: 'Runtime sink was not checked for this report.',
+          checkedAt: 'not-checked',
+        },
+      ],
+      sinkPresenceSummary: {
+        present: 0,
+        missing: 0,
+        unknown: 1,
+        unavailable: 0,
+      },
       nextAction: 'Confirm provider history and record lastRotatedAt evidence.',
     },
     {
@@ -81,6 +101,20 @@ const baseReport = {
       lastRotatedAt: null,
       dueAt: null,
       status: 'needs-baseline',
+      sinkPresence: [
+        {
+          sink: 'local-env',
+          status: 'present',
+          evidence: 'Found key name in local env file: .env.staging.',
+          checkedAt: '2026-05-09T12:00:00.000Z',
+        },
+      ],
+      sinkPresenceSummary: {
+        present: 1,
+        missing: 0,
+        unknown: 0,
+        unavailable: 0,
+      },
       nextAction: 'Confirm provider history and record lastRotatedAt evidence.',
     },
   ],
@@ -118,6 +152,9 @@ describe('CredentialAdminPage', () => {
     expect(screen.getAllByText('OPENAI_API_KEY').length).toBeGreaterThan(0)
     expect(screen.getByText('LINKEDIN_COOKIE')).toBeInTheDocument()
     expect(screen.getByText('Rotation packets')).toBeInTheDocument()
+    expect(screen.getByText('Runtime sink presence')).toBeInTheDocument()
+    expect(screen.getByText('local-env: present')).toBeInTheDocument()
+    expect(screen.getByText('Vercel: unknown')).toBeInTheDocument()
     expect(screen.getByText('Drafted')).toBeInTheDocument()
     expect(screen.queryByText('super-secret-value')).not.toBeInTheDocument()
 

--- a/app/admin/credentials/page.tsx
+++ b/app/admin/credentials/page.tsx
@@ -21,7 +21,21 @@ type CredentialReportRow = {
   lastRotatedAt: string | null
   dueAt: string | null
   status: 'needs-baseline' | 'due' | 'ok'
+  sinkPresence: Array<{
+    sink: string
+    status: 'present' | 'missing' | 'unknown' | 'unavailable'
+    evidence: string
+    checkedAt: string
+  }>
+  sinkPresenceSummary: CredentialSinkPresenceSummary
   nextAction: string
+}
+
+type CredentialSinkPresenceSummary = {
+  present: number
+  missing: number
+  unknown: number
+  unavailable: number
 }
 
 type CredentialReport = {
@@ -43,6 +57,7 @@ type CredentialReport = {
     providerConfirmed: number
     providerPending: number
   }
+  sinkPresenceSummary: CredentialSinkPresenceSummary
   bySource: Record<string, number>
   byRisk: Record<string, number>
   byRuntimeSink: Record<string, number>
@@ -182,6 +197,19 @@ function CredentialAdminContent() {
               <Metric icon={<AlertTriangle size={18} />} label="Need baseline" value={report.summary.needsBaseline} />
             </section>
 
+            <section className="mb-6 rounded-lg border border-silicon-slate bg-silicon-slate/30 p-4">
+              <div className="mb-3 flex flex-col gap-1 md:flex-row md:items-center md:justify-between">
+                <h2 className="font-semibold">Runtime sink presence</h2>
+                <p className="text-xs text-muted-foreground">Name-only checks; values are not read or displayed.</p>
+              </div>
+              <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+                <MiniMetric label="Present" value={report.sinkPresenceSummary.present} />
+                <MiniMetric label="Missing" value={report.sinkPresenceSummary.missing} />
+                <MiniMetric label="Unknown" value={report.sinkPresenceSummary.unknown} />
+                <MiniMetric label="Unavailable" value={report.sinkPresenceSummary.unavailable} />
+              </div>
+            </section>
+
             {report.blockers.length > 0 && (
               <section className="mb-6 rounded-lg border border-amber-500/30 bg-amber-500/10 p-4">
                 <h2 className="mb-2 flex items-center gap-2 text-sm font-semibold text-amber-100">
@@ -255,6 +283,7 @@ function CredentialAdminContent() {
                       <th className="px-4 py-3">Status</th>
                       <th className="px-4 py-3">Secret</th>
                       <th className="px-4 py-3">Source</th>
+                      <th className="px-4 py-3">Runtime sinks</th>
                       <th className="px-4 py-3">Cadence</th>
                       <th className="px-4 py-3">Due</th>
                       <th className="px-4 py-3">Next action</th>
@@ -269,6 +298,7 @@ function CredentialAdminContent() {
                           <div className="text-xs text-muted-foreground">{row.displayName}</div>
                         </td>
                         <td className="px-4 py-3">{row.sourceOfTruth}</td>
+                        <td className="px-4 py-3"><SinkPresenceBadges observations={row.sinkPresence} /></td>
                         <td className="px-4 py-3">{row.cadenceDays}d</td>
                         <td className="px-4 py-3">{row.dueAt ?? 'unknown'}</td>
                         <td className="px-4 py-3 text-muted-foreground">{row.nextAction}</td>
@@ -333,6 +363,31 @@ function StatusPill({ status }: { status: CredentialReportRow['status'] }) {
       : 'border-amber-500/30 bg-amber-500/10 text-amber-200'
 
   return <span className={`inline-flex rounded-full border px-2 py-1 text-xs ${classes}`}>{status}</span>
+}
+
+function SinkPresenceBadges({ observations }: { observations: CredentialReportRow['sinkPresence'] }) {
+  if (observations.length === 0) return <span className="text-xs text-muted-foreground">not checked</span>
+
+  return (
+    <div className="flex min-w-44 flex-wrap gap-1">
+      {observations.map((observation) => (
+        <span
+          key={`${observation.sink}-${observation.status}`}
+          title={observation.evidence}
+          className={`inline-flex rounded-full border px-2 py-1 text-xs ${sinkPresenceClass(observation.status)}`}
+        >
+          {observation.sink}: {observation.status}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+function sinkPresenceClass(status: CredentialReportRow['sinkPresence'][number]['status']) {
+  if (status === 'present') return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-200'
+  if (status === 'missing') return 'border-red-500/30 bg-red-500/10 text-red-200'
+  if (status === 'unavailable') return 'border-slate-500/30 bg-slate-500/10 text-slate-200'
+  return 'border-amber-500/30 bg-amber-500/10 text-amber-200'
 }
 
 function Notice({ title, body, tone }: { title: string; body: string; tone: 'red' | 'amber' }) {

--- a/app/api/admin/credentials/report/route.test.ts
+++ b/app/api/admin/credentials/report/route.test.ts
@@ -134,6 +134,9 @@ describe('GET /api/admin/credentials/report', () => {
         total: 1,
         drafted: 1,
       },
+      sinkPresenceSummary: {
+        unknown: 1,
+      },
     })
     expect(body.rows[0]).toMatchObject({
       envVar: 'OPENAI_API_KEY',

--- a/docs/credential-management-system.md
+++ b/docs/credential-management-system.md
@@ -26,6 +26,7 @@ All commands read `docs/credential-inventory.json`.
 ```bash
 npm run credentials:list-due -- --env staging
 npm run credentials:report -- --env staging
+npm run credentials:report -- --env staging --check-sinks
 npm run credentials:report -- --env staging --json
 npm run credentials:baseline-template -- --env staging
 npm run credentials:baseline-template -- --env staging --json
@@ -41,6 +42,8 @@ The broker never prints raw secret values. Rotation packets are written to `.cre
 Use plain `credentials:smoke` for local registry checks. Use `--require-provider-access` after `op` and `infisical` are installed/authenticated; that mode fails unless the broker can read one scoped test secret from each source of truth without printing its value.
 
 Use `credentials:report` for rotation visibility. It is read-only and summarizes the inventory by status, source of truth, risk, runtime sink, approval boundary, and next action. It does not fetch or print secret values. The same report is exposed to admins at `/admin/credentials` through `/api/admin/credentials/report`.
+
+Use `credentials:report -- --check-sinks` when the operator needs runtime sink presence visibility. This mode inspects local env files by key name only and marks other runtime sinks as `unknown` unless a value-free metadata adapter is configured. It never reads or prints secret values, and unknown/unavailable sink states should be treated as visibility gaps, not proof that a credential is absent.
 
 When local `.credential-rotation-audits/*.json` packets exist, `credentials:report` and `/admin/credentials` also summarize packet metadata by status (`drafted`, `synced`, `verified`, `revocation-pending`, `blocked`). Packet reporting is value-free: it shows secret ids/env var names, timestamps, approval state, runtime sinks, and verification commands, not credential values.
 

--- a/lib/credential-report.test.ts
+++ b/lib/credential-report.test.ts
@@ -127,6 +127,12 @@ describe('credential report', () => {
       synced: 1,
       latestCreatedAt: '2026-05-08T12:00:00.000Z',
     })
+    expect(report.sinkPresenceSummary).toEqual({
+      present: 0,
+      missing: 0,
+      unknown: 3,
+      unavailable: 0,
+    })
     expect(report.packets[0]).toMatchObject({
       envVar: 'MISSING_BASELINE',
       status: 'synced',
@@ -141,10 +147,46 @@ describe('credential report', () => {
     const markdown = renderCredentialReportMarkdown(report)
     expect(markdown).toContain('Credential Rotation Visibility (staging)')
     expect(markdown).toContain('Rotation Packets')
+    expect(markdown).toContain('Runtime Sink Presence')
     expect(markdown).toContain('DUE_SECRET')
     expect(markdown).not.toContain('super-secret')
 
     vi.useRealTimers()
+  })
+
+  it('merges value-free runtime sink presence observations into report rows', () => {
+    const report = buildCredentialReport(inventory, 'staging', '2026-05-09', [], [
+      {
+        secretId: 'missing-baseline',
+        envVar: 'MISSING_BASELINE',
+        sink: 'local-env',
+        status: 'present',
+        evidence: 'Found key name in local env file: .env.staging.',
+        checkedAt: '2026-05-09T12:00:00.000Z',
+      },
+      {
+        secretId: 'due-secret',
+        envVar: 'DUE_SECRET',
+        sink: 'Vercel',
+        status: 'missing',
+        evidence: 'Key name was not listed by Vercel metadata.',
+        checkedAt: '2026-05-09T12:00:00.000Z',
+      },
+    ])
+
+    expect(report.sinkPresenceSummary).toEqual({
+      present: 1,
+      missing: 1,
+      unknown: 1,
+      unavailable: 0,
+    })
+    expect(report.rows.find((row) => row.envVar === 'MISSING_BASELINE')?.sinkPresence).toEqual([
+      expect.objectContaining({
+        sink: 'local-env',
+        status: 'present',
+      }),
+    ])
+    expect(JSON.stringify(report)).not.toContain('super-secret')
   })
 
   it('builds a provider-confirmation template for missing baselines', () => {

--- a/lib/credential-report.ts
+++ b/lib/credential-report.ts
@@ -67,6 +67,8 @@ export type CredentialReportRow = {
   dueAt: string | null
   daysUntilDue: number | null
   status: 'needs-baseline' | 'due' | 'ok'
+  sinkPresence: CredentialSinkPresenceObservation[]
+  sinkPresenceSummary: CredentialSinkPresenceSummary
   nextAction: string
 }
 
@@ -90,6 +92,7 @@ export type CredentialReport = {
     providerConfirmed: number
     providerPending: number
   }
+  sinkPresenceSummary: CredentialSinkPresenceSummary
   bySource: Record<CredentialSourceOfTruth, number>
   byRisk: Record<string, number>
   byRuntimeSink: Record<string, number>
@@ -144,6 +147,24 @@ export type CredentialPacketSummary = {
   latestCreatedAt: string | null
 }
 
+export type CredentialSinkPresenceStatus = 'present' | 'missing' | 'unknown' | 'unavailable'
+
+export type CredentialSinkPresenceObservation = {
+  secretId: string
+  envVar: string
+  sink: string
+  status: CredentialSinkPresenceStatus
+  evidence: string
+  checkedAt: string
+}
+
+export type CredentialSinkPresenceSummary = {
+  present: number
+  missing: number
+  unknown: number
+  unavailable: number
+}
+
 export type CredentialBaselineTemplateEntry = {
   secretId: string
   envVar: string
@@ -164,12 +185,13 @@ export function buildCredentialReport(
   inventory: CredentialInventory,
   env: CredentialEnvironment,
   asOfInput: string | Date = new Date(),
-  packets: CredentialRotationPacket[] = []
+  packets: CredentialRotationPacket[] = [],
+  sinkPresence: CredentialSinkPresenceObservation[] = []
 ): CredentialReport {
   const asOfDate = asDate(asOfInput)
   const rows = inventory.secrets
     .filter((secret) => secret.environments.includes(env))
-    .map((secret) => buildReportRow(secret, env, asOfDate))
+    .map((secret) => buildReportRow(secret, env, asOfDate, sinkPresenceForSecret(secret, sinkPresence)))
     .sort((a, b) => {
       const statusOrder = { due: 0, 'needs-baseline': 1, ok: 2 }
       const statusDelta = statusOrder[a.status] - statusOrder[b.status]
@@ -203,6 +225,7 @@ export function buildCredentialReport(
       onePasswordVault: inventory.providers.onepassword.vaults[env],
     },
     summary,
+    sinkPresenceSummary: summarizeSinkPresence(rows.flatMap((row) => row.sinkPresence)),
     bySource: countBy(rows, (row) => row.sourceOfTruth),
     byRisk: countBy(rows, (row) => row.risk),
     byRuntimeSink: countRuntimeSinks(rows),
@@ -227,6 +250,9 @@ export function renderCredentialReportMarkdown(report: CredentialReport): string
     `- Due: ${report.summary.due}`,
     `- Missing provider-confirmed baseline: ${report.summary.needsBaseline}`,
     `- Approval-gated in this environment: ${report.summary.approvalRequired}`,
+    `- Runtime sinks present: ${report.sinkPresenceSummary.present}`,
+    `- Runtime sinks missing: ${report.sinkPresenceSummary.missing}`,
+    `- Runtime sinks unknown/unavailable: ${report.sinkPresenceSummary.unknown + report.sinkPresenceSummary.unavailable}`,
     '',
     '## Provider Context',
     '',
@@ -262,10 +288,17 @@ export function renderCredentialReportMarkdown(report: CredentialReport): string
         '',
       ]
       : ['No local rotation packets found.', '']),
+    '## Runtime Sink Presence',
+    '',
+    `- Present: ${report.sinkPresenceSummary.present}`,
+    `- Missing: ${report.sinkPresenceSummary.missing}`,
+    `- Unknown: ${report.sinkPresenceSummary.unknown}`,
+    `- Unavailable: ${report.sinkPresenceSummary.unavailable}`,
+    '',
     '## Secrets',
     '',
-    '| Status | Env Var | Source | Risk | Due | Baseline | Next action |',
-    '| --- | --- | --- | --- | --- | --- | --- |',
+    '| Status | Env Var | Source | Risk | Due | Baseline | Sink presence | Next action |',
+    '| --- | --- | --- | --- | --- | --- | --- | --- |',
     ...report.rows.map((row) => [
       row.status,
       row.envVar,
@@ -273,6 +306,7 @@ export function renderCredentialReportMarkdown(report: CredentialReport): string
       row.risk,
       row.dueAt ?? 'unknown',
       row.baselineStatus,
+      formatSinkPresence(row.sinkPresenceSummary),
       row.nextAction,
     ].map(escapeTableCell).join(' | ')).map((line) => `| ${line} |`),
     '',
@@ -334,7 +368,12 @@ export function renderCredentialBaselineTemplateMarkdown(env: CredentialEnvironm
   return `${lines.join('\n')}\n`
 }
 
-function buildReportRow(secret: CredentialSecret, env: CredentialEnvironment, asOfDate: Date): CredentialReportRow {
+function buildReportRow(
+  secret: CredentialSecret,
+  env: CredentialEnvironment,
+  asOfDate: Date,
+  sinkPresence: CredentialSinkPresenceObservation[]
+): CredentialReportRow {
   const baseline = getBaseline(secret, env)
   const lastRotatedAt = baseline.lastRotatedAt
   const dueDate = lastRotatedAt ? addDays(new Date(lastRotatedAt), secret.rotationCadenceDays) : null
@@ -358,8 +397,49 @@ function buildReportRow(secret: CredentialSecret, env: CredentialEnvironment, as
     dueAt: dueDate ? dateOnly(dueDate) : null,
     daysUntilDue,
     status,
+    sinkPresence,
+    sinkPresenceSummary: summarizeSinkPresence(sinkPresence),
     nextAction: nextAction(status, baseline.status, secret.approvalRequired?.includes(env) ?? false),
   }
+}
+
+function sinkPresenceForSecret(
+  secret: CredentialSecret,
+  observations: CredentialSinkPresenceObservation[]
+): CredentialSinkPresenceObservation[] {
+  const bySink = new Map(
+    observations
+      .filter((observation) => observation.secretId === secret.id || observation.envVar === secret.envVar)
+      .map((observation) => [observation.sink, observation])
+  )
+
+  return secret.runtimeSinks.map((sink) => bySink.get(sink) ?? {
+    secretId: secret.id,
+    envVar: secret.envVar,
+    sink,
+    status: 'unknown',
+    evidence: 'Runtime sink was not checked for this report.',
+    checkedAt: 'not-checked',
+  })
+}
+
+function summarizeSinkPresence(observations: CredentialSinkPresenceObservation[]): CredentialSinkPresenceSummary {
+  return {
+    present: observations.filter((observation) => observation.status === 'present').length,
+    missing: observations.filter((observation) => observation.status === 'missing').length,
+    unknown: observations.filter((observation) => observation.status === 'unknown').length,
+    unavailable: observations.filter((observation) => observation.status === 'unavailable').length,
+  }
+}
+
+function formatSinkPresence(summary: CredentialSinkPresenceSummary): string {
+  const parts = [
+    summary.present > 0 ? `${summary.present} present` : '',
+    summary.missing > 0 ? `${summary.missing} missing` : '',
+    summary.unknown > 0 ? `${summary.unknown} unknown` : '',
+    summary.unavailable > 0 ? `${summary.unavailable} unavailable` : '',
+  ].filter(Boolean)
+  return parts.length > 0 ? parts.join(', ') : 'none'
 }
 
 function getBaseline(secret: CredentialSecret, env: CredentialEnvironment): CredentialBaseline {

--- a/scripts/credential-broker.ts
+++ b/scripts/credential-broker.ts
@@ -6,6 +6,7 @@ import * as path from 'node:path'
 import {
   buildCredentialBaselineTemplate,
   buildCredentialReport,
+  type CredentialSinkPresenceObservation,
   type CredentialRotationPacket,
   renderCredentialBaselineTemplateMarkdown,
   renderCredentialReportMarkdown,
@@ -213,7 +214,8 @@ function listDue(inventory: CredentialInventory, args: ParsedArgs) {
 function report(inventory: CredentialInventory, args: ParsedArgs) {
   const env = getEnv(args)
   const asOf = String(args.options['as-of'] || new Date().toISOString())
-  const credentialReport = buildCredentialReport(inventory, env, asOf, readRotationPackets())
+  const sinkPresence = args.options['check-sinks'] ? collectRuntimeSinkPresence(inventory, env) : []
+  const credentialReport = buildCredentialReport(inventory, env, asOf, readRotationPackets(), sinkPresence)
 
   if (args.options.json) {
     console.log(JSON.stringify(credentialReport, null, 2))
@@ -515,6 +517,94 @@ function readRotationPackets(): CredentialRotationPacket[] {
     })
 }
 
+function collectRuntimeSinkPresence(
+  inventory: CredentialInventory,
+  env: EnvironmentName
+): CredentialSinkPresenceObservation[] {
+  const checkedAt = new Date().toISOString()
+  const localEnvKeys = readLocalEnvKeys(env)
+
+  return envSecrets(inventory, env).flatMap((secret) => secret.runtimeSinks.map((sink) => {
+    if (sink === 'local-env') {
+      return localEnvPresenceObservation(secret, sink, checkedAt, localEnvKeys)
+    }
+
+    return {
+      secretId: secret.id,
+      envVar: secret.envVar,
+      sink,
+      status: 'unknown',
+      evidence: `${sink} metadata check is not configured in this read-only broker path.`,
+      checkedAt,
+    } satisfies CredentialSinkPresenceObservation
+  }))
+}
+
+function readLocalEnvKeys(env: EnvironmentName): { files: Array<{ file: string; keys: Set<string> }>; missingFiles: string[] } {
+  const candidates = Array.from(new Set([
+    `.env.${env}`,
+    env === 'dev' ? '.env.local' : `.env.${env}.local`,
+    '.env.local',
+  ]))
+  const files: Array<{ file: string; keys: Set<string> }> = []
+  const missingFiles: string[] = []
+
+  for (const file of candidates) {
+    const resolved = path.join(ROOT, file)
+    if (!existsSync(resolved)) {
+      missingFiles.push(file)
+      continue
+    }
+    const keys = new Set<string>()
+    for (const line of readFileSync(resolved, 'utf8').split(/\r?\n/)) {
+      const match = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=/)
+      if (match) keys.add(match[1])
+    }
+    files.push({ file, keys })
+  }
+
+  return { files, missingFiles }
+}
+
+function localEnvPresenceObservation(
+  secret: CredentialSecret,
+  sink: string,
+  checkedAt: string,
+  localEnvKeys: { files: Array<{ file: string; keys: Set<string> }>; missingFiles: string[] }
+): CredentialSinkPresenceObservation {
+  const matches = localEnvKeys.files.filter((file) => file.keys.has(secret.envVar)).map((file) => file.file)
+  if (matches.length > 0) {
+    return {
+      secretId: secret.id,
+      envVar: secret.envVar,
+      sink,
+      status: 'present',
+      evidence: `Found key name in local env file: ${matches.join(', ')}.`,
+      checkedAt,
+    }
+  }
+
+  if (localEnvKeys.files.length === 0) {
+    return {
+      secretId: secret.id,
+      envVar: secret.envVar,
+      sink,
+      status: 'unavailable',
+      evidence: `No local env files found to inspect. Checked: ${localEnvKeys.missingFiles.join(', ')}.`,
+      checkedAt,
+    }
+  }
+
+  return {
+    secretId: secret.id,
+    envVar: secret.envVar,
+    sink,
+    status: 'missing',
+    evidence: `Key name was not found in inspected local env files: ${localEnvKeys.files.map((file) => file.file).join(', ')}.`,
+    checkedAt,
+  }
+}
+
 function printPacketSummary(packet: RotationPacket) {
   console.log(`${packet.type} packet written for ${packet.envVar} (${packet.environment})`)
   console.log(`source=${packet.sourceOfTruth} sinks=${packet.runtimeSinks.join(', ')}`)
@@ -562,7 +652,7 @@ function printHelp() {
 
 Commands:
   list-due      --env <dev|staging|prod> [--as-of YYYY-MM-DD] [--json]
-  report        --env <dev|staging|prod> [--as-of YYYY-MM-DD] [--json]
+  report        --env <dev|staging|prod> [--as-of YYYY-MM-DD] [--check-sinks] [--json]
   baseline-template --env <dev|staging|prod> [--updated-at YYYY-MM-DD] [--json]
   inject        --env <dev|staging|prod> [--secret id-or-envVar[,..]] -- <command>
   rotate        --env <dev|staging|prod> --secret <id-or-envVar> [--local-env .env.staging] [--length 48]


### PR DESCRIPTION
## Summary
- Adds value-free runtime sink presence observations to the credential report model and markdown output.
- Adds `credentials:report -- --check-sinks` for read-only local env key-name checks while keeping Vercel/n8n/Supabase states unknown unless a metadata adapter is configured.
- Surfaces sink presence summaries and per-secret sink badges on `/admin/credentials`.

## Validation
- `npm run build:knowledge`
- `npx tsc --noEmit --pretty false --skipLibCheck`
- `npx vitest run lib/credential-report.test.ts app/api/admin/credentials/report/route.test.ts app/admin/credentials/page.test.tsx --reporter=dot`
- `npm run lint -- --file app/admin/credentials/page.tsx --file app/admin/credentials/page.test.tsx --file app/api/admin/credentials/report/route.ts --file app/api/admin/credentials/report/route.test.ts --file lib/credential-report.ts --file lib/credential-report.test.ts --file scripts/credential-broker.ts`
- `npx tsx scripts/credential-broker.ts report --env staging --check-sinks --json`

## Integration Notes
- No credential values are read, printed, committed, or displayed. Local env checks parse key names only.
- Admin API remains non-live: it reports unknown sink states unless observations are supplied by the broker path.
- Vercel / n8n / Supabase live metadata adapters remain a follow-up before this can be called full cross-sink drift proof.
- Vercel contexts checked before merge gate: #239 had `Vercel – portfolio` green before landing. This PR still needs normal preview checks from GitHub/Vercel.
- Do not merge from this lane; Integration Captain owns merge/deploy sequencing.