### PR TITLE
feat: check Vercel credential sink metadata

### DIFF
--- a/docs/credential-management-system.md
+++ b/docs/credential-management-system.md
@@ -43,7 +43,7 @@ Use plain `credentials:smoke` for local registry checks. Use `--require-provider
 
 Use `credentials:report` for rotation visibility. It is read-only and summarizes the inventory by status, source of truth, risk, runtime sink, approval boundary, and next action. It does not fetch or print secret values. The same report is exposed to admins at `/admin/credentials` through `/api/admin/credentials/report`.
 
-Use `credentials:report -- --check-sinks` when the operator needs runtime sink presence visibility. This mode inspects local env files by key name only and marks other runtime sinks as `unknown` unless a value-free metadata adapter is configured. It never reads or prints secret values, and unknown/unavailable sink states should be treated as visibility gaps, not proof that a credential is absent.
+Use `credentials:report -- --check-sinks` when the operator needs runtime sink presence visibility. This mode inspects local env files and Vercel environment metadata by key name only, then marks other runtime sinks as `unknown` unless a value-free metadata adapter is configured. It never reads or prints secret values, and unknown/unavailable sink states should be treated as visibility gaps, not proof that a credential is absent.
 
 When local `.credential-rotation-audits/*.json` packets exist, `credentials:report` and `/admin/credentials` also summarize packet metadata by status (`drafted`, `synced`, `verified`, `revocation-pending`, `blocked`). Packet reporting is value-free: it shows secret ids/env var names, timestamps, approval state, runtime sinks, and verification commands, not credential values.
 

--- a/scripts/credential-broker.ts
+++ b/scripts/credential-broker.ts
@@ -92,6 +92,7 @@ const INVENTORY_PATH = path.join(ROOT, 'docs', 'credential-inventory.json')
 const AUDIT_DIR = path.join(ROOT, '.credential-rotation-audits')
 const VALID_ENVS: EnvironmentName[] = ['dev', 'staging', 'prod']
 const PROVIDER_READ_TIMEOUT_MS = 10_000
+const VERCEL_METADATA_TIMEOUT_MS = 15_000
 
 function main() {
   const args = parseArgs(process.argv.slice(2))
@@ -523,10 +524,14 @@ function collectRuntimeSinkPresence(
 ): CredentialSinkPresenceObservation[] {
   const checkedAt = new Date().toISOString()
   const localEnvKeys = readLocalEnvKeys(env)
+  const vercelEnvKeys = readVercelEnvKeys(env)
 
   return envSecrets(inventory, env).flatMap((secret) => secret.runtimeSinks.map((sink) => {
     if (sink === 'local-env') {
       return localEnvPresenceObservation(secret, sink, checkedAt, localEnvKeys)
+    }
+    if (sink === 'Vercel') {
+      return vercelPresenceObservation(secret, sink, checkedAt, vercelEnvKeys)
     }
 
     return {
@@ -538,6 +543,93 @@ function collectRuntimeSinkPresence(
       checkedAt,
     } satisfies CredentialSinkPresenceObservation
   }))
+}
+
+function vercelTargetForEnv(env: EnvironmentName): 'development' | 'preview' | 'production' {
+  if (env === 'dev') return 'development'
+  if (env === 'prod') return 'production'
+  return 'preview'
+}
+
+function readVercelEnvKeys(env: EnvironmentName): { target: string; keys: Set<string>; unavailableReason: string | null } {
+  const target = vercelTargetForEnv(env)
+  const result = spawnSync('vercel', ['env', 'list', target, '--format', 'json', '--cwd', ROOT, '--non-interactive'], {
+    cwd: ROOT,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: process.env,
+    timeout: VERCEL_METADATA_TIMEOUT_MS,
+  })
+
+  if (result.status !== 0) {
+    return {
+      target,
+      keys: new Set(),
+      unavailableReason: `Vercel env metadata unavailable for ${target}. Authenticate the Vercel CLI and confirm project access.`,
+    }
+  }
+
+  const jsonStart = result.stdout.indexOf('{')
+  if (jsonStart === -1) {
+    return {
+      target,
+      keys: new Set(),
+      unavailableReason: `Vercel env metadata for ${target} did not include JSON output.`,
+    }
+  }
+
+  try {
+    const parsed = JSON.parse(result.stdout.slice(jsonStart)) as { envs?: Array<{ key?: string }> }
+    return {
+      target,
+      keys: new Set((parsed.envs ?? []).flatMap((item) => item.key ? [item.key] : [])),
+      unavailableReason: null,
+    }
+  } catch {
+    return {
+      target,
+      keys: new Set(),
+      unavailableReason: `Vercel env metadata for ${target} returned invalid JSON.`,
+    }
+  }
+}
+
+function vercelPresenceObservation(
+  secret: CredentialSecret,
+  sink: string,
+  checkedAt: string,
+  vercelEnvKeys: { target: string; keys: Set<string>; unavailableReason: string | null }
+): CredentialSinkPresenceObservation {
+  if (vercelEnvKeys.unavailableReason) {
+    return {
+      secretId: secret.id,
+      envVar: secret.envVar,
+      sink,
+      status: 'unavailable',
+      evidence: vercelEnvKeys.unavailableReason,
+      checkedAt,
+    }
+  }
+
+  if (vercelEnvKeys.keys.has(secret.envVar)) {
+    return {
+      secretId: secret.id,
+      envVar: secret.envVar,
+      sink,
+      status: 'present',
+      evidence: `Found key name in Vercel ${vercelEnvKeys.target} environment metadata.`,
+      checkedAt,
+    }
+  }
+
+  return {
+    secretId: secret.id,
+    envVar: secret.envVar,
+    sink,
+    status: 'missing',
+    evidence: `Key name was not listed in Vercel ${vercelEnvKeys.target} environment metadata.`,
+    checkedAt,
+  }
 }
 
 function readLocalEnvKeys(env: EnvironmentName): { files: Array<{ file: string; keys: Set<string> }>; missingFiles: string[] } {


### PR DESCRIPTION
## Summary
- Adds a value-free Vercel metadata adapter to `credentials:report -- --check-sinks`.
- Maps Portfolio environments to Vercel targets (`dev` -> `development`, `staging` -> `preview`, `prod` -> `production`).
- Classifies Vercel runtime sinks as `present`, `missing`, or `unavailable` using env var key names only.
- Updates credential management docs to describe local env plus Vercel name-only sink checks.

## Validation
- `npm run build:knowledge`
- `npx tsc --noEmit --pretty false --skipLibCheck`
- `npx vitest run lib/credential-report.test.ts app/api/admin/credentials/report/route.test.ts app/admin/credentials/page.test.tsx --reporter=dot`
- `npm run lint -- --file scripts/credential-broker.ts`
- `npx tsx scripts/credential-broker.ts report --env staging --check-sinks --json`

Note: I initially ran `next lint` with the Markdown doc file included and Next.js correctly failed to parse Markdown; reran lint against the TypeScript broker file successfully.

## Integration Notes
- No credential values are read, printed, committed, or displayed. The Vercel CLI output used here includes key names and metadata only.
- This is read-only reporting; it does not update Vercel, n8n, Supabase, Infisical, 1Password, or local env files.
- n8n and Supabase metadata adapters remain follow-up work.
- Do not merge from this lane; Integration Captain owns merge/deploy sequencing.