### PR TITLE
feat: check n8n credential metadata safely

### DIFF
--- a/docs/credential-management-system.md
+++ b/docs/credential-management-system.md
@@ -43,7 +43,7 @@ Use plain `credentials:smoke` for local registry checks. Use `--require-provider
 
 Use `credentials:report` for rotation visibility. It is read-only and summarizes the inventory by status, source of truth, risk, runtime sink, approval boundary, and next action. It does not fetch or print secret values. The same report is exposed to admins at `/admin/credentials` through `/api/admin/credentials/report`.
 
-Use `credentials:report -- --check-sinks` when the operator needs runtime sink presence visibility. This mode inspects local env files and Vercel environment metadata by key name only, then marks other runtime sinks as `unknown` unless a value-free metadata adapter is configured. It never reads or prints secret values, and unknown/unavailable sink states should be treated as visibility gaps, not proof that a credential is absent.
+Use `credentials:report -- --check-sinks` when the operator needs runtime sink presence visibility. This mode inspects local env files and Vercel environment metadata by key name only. It also checks n8n credential metadata names/types through the n8n API when `N8N_API_KEY` is available; n8n Variables remain `unknown` until a key-only path exists because the variables API may include values. It never reads or prints secret values, and unknown/unavailable sink states should be treated as visibility gaps, not proof that a credential is absent.
 
 When local `.credential-rotation-audits/*.json` packets exist, `credentials:report` and `/admin/credentials` also summarize packet metadata by status (`drafted`, `synced`, `verified`, `revocation-pending`, `blocked`). Packet reporting is value-free: it shows secret ids/env var names, timestamps, approval state, runtime sinks, and verification commands, not credential values.
 

--- a/scripts/credential-broker.ts
+++ b/scripts/credential-broker.ts
@@ -93,6 +93,7 @@ const AUDIT_DIR = path.join(ROOT, '.credential-rotation-audits')
 const VALID_ENVS: EnvironmentName[] = ['dev', 'staging', 'prod']
 const PROVIDER_READ_TIMEOUT_MS = 10_000
 const VERCEL_METADATA_TIMEOUT_MS = 15_000
+const N8N_METADATA_TIMEOUT_MS = 15_000
 
 function main() {
   const args = parseArgs(process.argv.slice(2))
@@ -525,6 +526,7 @@ function collectRuntimeSinkPresence(
   const checkedAt = new Date().toISOString()
   const localEnvKeys = readLocalEnvKeys(env)
   const vercelEnvKeys = readVercelEnvKeys(env)
+  const n8nCredentialMetadata = readN8nCredentialMetadata()
 
   return envSecrets(inventory, env).flatMap((secret) => secret.runtimeSinks.map((sink) => {
     if (sink === 'local-env') {
@@ -532,6 +534,12 @@ function collectRuntimeSinkPresence(
     }
     if (sink === 'Vercel') {
       return vercelPresenceObservation(secret, sink, checkedAt, vercelEnvKeys)
+    }
+    if (sink === 'n8n Variables') {
+      return n8nVariablePresenceObservation(secret, sink, checkedAt)
+    }
+    if (sink === 'n8n Credentials') {
+      return n8nCredentialPresenceObservation(secret, sink, checkedAt, n8nCredentialMetadata)
     }
 
     return {
@@ -543,6 +551,144 @@ function collectRuntimeSinkPresence(
       checkedAt,
     } satisfies CredentialSinkPresenceObservation
   }))
+}
+
+type N8nCredentialMetadata = {
+  unavailableReason: string | null
+  credentials: Array<{ name: string; type: string }>
+}
+
+function readN8nCredentialMetadata(): N8nCredentialMetadata {
+  const apiKey = process.env.N8N_API_KEY
+  const baseUrl = (process.env.N8N_BASE_URL || 'https://amadutown.app.n8n.cloud').replace(/\/$/, '')
+
+  if (!apiKey) {
+    return {
+      unavailableReason: 'n8n credential metadata unavailable because N8N_API_KEY is not set.',
+      credentials: [],
+    }
+  }
+
+  const script = `
+const baseUrl = process.env.N8N_BASE_URL || 'https://amadutown.app.n8n.cloud';
+const apiKey = process.env.N8N_API_KEY;
+(async () => {
+  const response = await fetch(baseUrl.replace(/\\/$/, '') + '/api/v1/credentials', {
+    headers: { 'X-N8N-API-KEY': apiKey, Accept: 'application/json' },
+  });
+  if (!response.ok) process.exit(1);
+  const body = await response.json();
+  const items = Array.isArray(body) ? body : Array.isArray(body.data) ? body.data : [];
+  const credentials = items.map((item) => ({ name: String(item.name || ''), type: String(item.type || '') }));
+  console.log(JSON.stringify({ credentials }));
+})().catch(() => process.exit(1));
+`
+  const result = spawnSync(process.execPath, ['-e', script], {
+    cwd: ROOT,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, N8N_BASE_URL: baseUrl, N8N_API_KEY: apiKey },
+    timeout: N8N_METADATA_TIMEOUT_MS,
+  })
+
+  if (result.status !== 0) {
+    return {
+      unavailableReason: 'n8n credential metadata unavailable. Authenticate N8N_API_KEY and confirm read access to /api/v1/credentials.',
+      credentials: [],
+    }
+  }
+
+  try {
+    const parsed = JSON.parse(result.stdout) as { credentials?: Array<{ name?: string; type?: string }> }
+    return {
+      unavailableReason: null,
+      credentials: (parsed.credentials ?? []).map((credential) => ({
+        name: credential.name ?? '',
+        type: credential.type ?? '',
+      })),
+    }
+  } catch {
+    return {
+      unavailableReason: 'n8n credential metadata returned invalid JSON after value-free reduction.',
+      credentials: [],
+    }
+  }
+}
+
+function n8nVariablePresenceObservation(
+  secret: CredentialSecret,
+  sink: string,
+  checkedAt: string
+): CredentialSinkPresenceObservation {
+  return {
+    secretId: secret.id,
+    envVar: secret.envVar,
+    sink,
+    status: 'unknown',
+    evidence: 'n8n variable metadata was not checked because the variables API may include secret values. Use a future key-only adapter or approved sanitized export.',
+    checkedAt,
+  }
+}
+
+function n8nCredentialPresenceObservation(
+  secret: CredentialSecret,
+  sink: string,
+  checkedAt: string,
+  metadata: N8nCredentialMetadata
+): CredentialSinkPresenceObservation {
+  if (metadata.unavailableReason) {
+    return {
+      secretId: secret.id,
+      envVar: secret.envVar,
+      sink,
+      status: 'unavailable',
+      evidence: metadata.unavailableReason,
+      checkedAt,
+    }
+  }
+
+  const keys = n8nCredentialReferenceKeys(secret).map((key) => key.toLowerCase())
+  const matches = metadata.credentials.filter((credential) => {
+    const name = credential.name.toLowerCase()
+    const type = credential.type.toLowerCase()
+    return keys.some((key) => name === key || type === key || name.includes(key) || type.includes(key))
+  })
+
+  if (matches.length > 0) {
+    return {
+      secretId: secret.id,
+      envVar: secret.envVar,
+      sink,
+      status: 'present',
+      evidence: `Found n8n credential metadata for ${secret.envVar}: ${formatReferenceList(matches.map((credential) => `${credential.name || 'unnamed'}:${credential.type || 'unknown'}`))}.`,
+      checkedAt,
+    }
+  }
+
+  return {
+    secretId: secret.id,
+    envVar: secret.envVar,
+    sink,
+    status: 'missing',
+    evidence: `No n8n credential metadata matched ${secret.envVar}.`,
+    checkedAt,
+  }
+}
+
+function n8nCredentialReferenceKeys(secret: CredentialSecret): string[] {
+  const keys: Record<string, string[]> = {
+    ANTHROPIC_API_KEY: ['anthropicApi', 'anthropic api key', 'anthropic account'],
+    APIFY_API_TOKEN: ['apifyApi', 'apify account'],
+    OPENAI_API_KEY: ['openAiApi', 'openai account', 'openai staging account'],
+    OPENROUTER_API_KEY: ['openRouterApi', 'openrouter account', 'openrouter api'],
+  }
+  return keys[secret.envVar] ?? [secret.envVar.toLowerCase(), secret.displayName.toLowerCase()]
+}
+
+function formatReferenceList(references: string[]): string {
+  const displayed = references.slice(0, 4)
+  const suffix = references.length > displayed.length ? ` and ${references.length - displayed.length} more` : ''
+  return `${displayed.join(', ')}${suffix}`
 }
 
 function vercelTargetForEnv(env: EnvironmentName): 'development' | 'preview' | 'production' {


### PR DESCRIPTION
## Summary
- Adds a value-free n8n credential metadata adapter to `credentials:report -- --check-sinks`.
- Uses `/api/v1/credentials` only when `N8N_API_KEY` is available, then immediately reduces the response to credential names/types.
- Leaves `n8n Variables` as `unknown` because the n8n variables API may include values.
- Updates credential docs with the n8n credential/variable safety boundary.

## Validation
- `npm run build:knowledge`
- `./node_modules/.bin/tsc --noEmit --pretty false --skipLibCheck`
- `./node_modules/.bin/vitest run lib/credential-report.test.ts app/api/admin/credentials/report/route.test.ts app/admin/credentials/page.test.tsx --reporter=dot`
- `npm run lint -- --file scripts/credential-broker.ts`
- `bash scripts/check-n8n-secrets.sh`
- `npx tsx scripts/credential-broker.ts report --env staging --check-sinks --json`

Blocked optional live check:
- `npm run n8n:drift-check -- --warn` could not run because `N8N_API_KEY` is not set in this shell.

## Integration Notes
- No credential values are read, printed, committed, or displayed.
- The n8n credential API response is reduced to name/type metadata inside a child Node process before the broker parses it.
- This PR does not call workflow executions, scrape n8n UI, mutate n8n, update runtime sinks, rotate credentials, or touch production config.
- n8n Variables stay unknown by design until a key-only API/export path exists.
- Do not merge from this lane; Integration Captain owns merge/deploy sequencing.