### PR TITLE
feat: add credential sink gap actions

### DIFF
--- a/app/admin/credentials/page.test.tsx
+++ b/app/admin/credentials/page.test.tsx
@@ -59,6 +59,16 @@ const baseReport = {
       localEnvUpdated: false,
     },
   ],
+  sinkGapActions: [
+    {
+      secretId: 'openai-api-key',
+      envVar: 'OPENAI_API_KEY',
+      sink: 'Vercel',
+      status: 'unknown',
+      action: 'Add a key-only metadata adapter or approved sanitized evidence path for Vercel.',
+      evidence: 'Runtime sink was not checked for this report.',
+    },
+  ],
   blockers: ['2 staging secrets need provider-confirmed rotation baselines.'],
   rows: [
     {
@@ -153,6 +163,8 @@ describe('CredentialAdminPage', () => {
     expect(screen.getByText('LINKEDIN_COOKIE')).toBeInTheDocument()
     expect(screen.getByText('Rotation packets')).toBeInTheDocument()
     expect(screen.getByText('Runtime sink presence')).toBeInTheDocument()
+    expect(screen.getByText('Runtime sink gap actions')).toBeInTheDocument()
+    expect(screen.getByText('Add a key-only metadata adapter or approved sanitized evidence path for Vercel.')).toBeInTheDocument()
     expect(screen.getByText('local-env: present')).toBeInTheDocument()
     expect(screen.getByText('Vercel: unknown')).toBeInTheDocument()
     expect(screen.getByText('Drafted')).toBeInTheDocument()

--- a/app/admin/credentials/page.tsx
+++ b/app/admin/credentials/page.tsx
@@ -78,6 +78,14 @@ type CredentialReport = {
     approvalRequired: boolean
     localEnvUpdated: boolean
   }>
+  sinkGapActions: Array<{
+    secretId: string
+    envVar: string
+    sink: string
+    status: 'missing' | 'unknown' | 'unavailable'
+    action: string
+    evidence: string
+  }>
   blockers: string[]
   rows: CredentialReportRow[]
 }
@@ -226,6 +234,39 @@ function CredentialAdminContent() {
               <Breakdown title="Sources" rows={report.bySource} />
               <Breakdown title="Risk" rows={report.byRisk} />
               <Breakdown title="Runtime Sinks" rows={report.byRuntimeSink} />
+            </section>
+
+            <section className="mb-6 rounded-lg border border-silicon-slate bg-silicon-slate/30 p-4">
+              <div className="mb-3 flex flex-col gap-1 md:flex-row md:items-center md:justify-between">
+                <h2 className="font-semibold">Runtime sink gap actions</h2>
+                <p className="text-xs text-muted-foreground">Actionable visibility gaps without secret values.</p>
+              </div>
+              {report.sinkGapActions.length > 0 ? (
+                <div className="overflow-x-auto">
+                  <table className="min-w-full divide-y divide-silicon-slate text-sm">
+                    <thead className="text-left text-xs uppercase tracking-wide text-muted-foreground">
+                      <tr>
+                        <th className="px-2 py-2">Secret</th>
+                        <th className="px-2 py-2">Sink</th>
+                        <th className="px-2 py-2">Status</th>
+                        <th className="px-2 py-2">Action</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-silicon-slate">
+                      {report.sinkGapActions.slice(0, 10).map((gap) => (
+                        <tr key={`${gap.envVar}-${gap.sink}-${gap.status}`}>
+                          <td className="px-2 py-2 font-mono text-xs">{gap.envVar}</td>
+                          <td className="px-2 py-2">{gap.sink}</td>
+                          <td className="px-2 py-2">{gap.status}</td>
+                          <td className="px-2 py-2 text-muted-foreground">{gap.action}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground">No runtime sink gaps found.</p>
+              )}
             </section>
 
             <section className="mb-6 rounded-lg border border-silicon-slate bg-silicon-slate/30 p-4">

--- a/app/api/admin/credentials/report/route.test.ts
+++ b/app/api/admin/credentials/report/route.test.ts
@@ -137,6 +137,13 @@ describe('GET /api/admin/credentials/report', () => {
       sinkPresenceSummary: {
         unknown: 1,
       },
+      sinkGapActions: [
+        expect.objectContaining({
+          envVar: 'OPENAI_API_KEY',
+          sink: 'Vercel',
+          status: 'unknown',
+        }),
+      ],
     })
     expect(body.rows[0]).toMatchObject({
       envVar: 'OPENAI_API_KEY',

--- a/docs/credential-management-system.md
+++ b/docs/credential-management-system.md
@@ -45,6 +45,8 @@ Use `credentials:report` for rotation visibility. It is read-only and summarizes
 
 Use `credentials:report -- --check-sinks` when the operator needs runtime sink presence visibility. This mode inspects local env files and Vercel environment metadata by key name only. It also checks n8n credential metadata names/types through the n8n API when `N8N_API_KEY` is available; n8n Variables remain `unknown` until a key-only path exists because the variables API may include values. It never reads or prints secret values, and unknown/unavailable sink states should be treated as visibility gaps, not proof that a credential is absent.
 
+The report includes runtime sink gap actions for `missing`, `unknown`, and `unavailable` sink states. These are operator tasks, not automatic mutations: sync missing sinks from the source of truth, restore read-only metadata access when checks are unavailable, or add a key-only adapter before treating unknown states as verified.
+
 When local `.credential-rotation-audits/*.json` packets exist, `credentials:report` and `/admin/credentials` also summarize packet metadata by status (`drafted`, `synced`, `verified`, `revocation-pending`, `blocked`). Packet reporting is value-free: it shows secret ids/env var names, timestamps, approval state, runtime sinks, and verification commands, not credential values.
 
 Use `credentials:baseline-template` when `credentials:report` shows `needs-baseline`. It emits provider-confirmation placeholders for each missing environment baseline so the operator can verify provider history, fill `lastRotatedAt`, preserve evidence, and update `docs/credential-inventory.json` without guessing from local env files.

--- a/lib/credential-report.test.ts
+++ b/lib/credential-report.test.ts
@@ -133,6 +133,14 @@ describe('credential report', () => {
       unknown: 3,
       unavailable: 0,
     })
+    expect(report.sinkGapActions).toHaveLength(3)
+    expect(report.sinkGapActions).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        envVar: 'DUE_SECRET',
+        sink: 'Vercel',
+        status: 'unknown',
+      }),
+    ]))
     expect(report.packets[0]).toMatchObject({
       envVar: 'MISSING_BASELINE',
       status: 'synced',
@@ -148,6 +156,7 @@ describe('credential report', () => {
     expect(markdown).toContain('Credential Rotation Visibility (staging)')
     expect(markdown).toContain('Rotation Packets')
     expect(markdown).toContain('Runtime Sink Presence')
+    expect(markdown).toContain('Runtime Sink Gap Actions')
     expect(markdown).toContain('DUE_SECRET')
     expect(markdown).not.toContain('super-secret')
 
@@ -180,6 +189,11 @@ describe('credential report', () => {
       unknown: 1,
       unavailable: 0,
     })
+    expect(report.sinkGapActions.map((gap) => `${gap.envVar}:${gap.sink}:${gap.status}`)).toEqual([
+      'DUE_SECRET:Vercel:missing',
+      'DUE_SECRET:n8n:unknown',
+    ])
+    expect(report.blockers).toContain('At least one runtime sink is missing expected credential metadata.')
     expect(report.rows.find((row) => row.envVar === 'MISSING_BASELINE')?.sinkPresence).toEqual([
       expect.objectContaining({
         sink: 'local-env',

--- a/lib/credential-report.ts
+++ b/lib/credential-report.ts
@@ -98,6 +98,7 @@ export type CredentialReport = {
   byRuntimeSink: Record<string, number>
   packetSummary: CredentialPacketSummary
   packets: CredentialPacketReport[]
+  sinkGapActions: CredentialSinkGapAction[]
   blockers: string[]
   rows: CredentialReportRow[]
 }
@@ -165,6 +166,15 @@ export type CredentialSinkPresenceSummary = {
   unavailable: number
 }
 
+export type CredentialSinkGapAction = {
+  secretId: string
+  envVar: string
+  sink: string
+  status: Exclude<CredentialSinkPresenceStatus, 'present'>
+  action: string
+  evidence: string
+}
+
 export type CredentialBaselineTemplateEntry = {
   secretId: string
   envVar: string
@@ -212,6 +222,7 @@ export function buildCredentialReport(
     .filter((packet) => packet.environment === env)
     .map(toPacketReport)
     .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+  const sinkGapActions = buildSinkGapActions(rows)
 
   return {
     generatedAt: new Date().toISOString(),
@@ -231,7 +242,8 @@ export function buildCredentialReport(
     byRuntimeSink: countRuntimeSinks(rows),
     packetSummary: summarizePackets(packetReports),
     packets: packetReports,
-    blockers: buildBlockers(summary, env, packetReports),
+    sinkGapActions,
+    blockers: buildBlockers(summary, env, packetReports, sinkGapActions),
     rows,
   }
 }
@@ -295,6 +307,21 @@ export function renderCredentialReportMarkdown(report: CredentialReport): string
     `- Unknown: ${report.sinkPresenceSummary.unknown}`,
     `- Unavailable: ${report.sinkPresenceSummary.unavailable}`,
     '',
+    '## Runtime Sink Gap Actions',
+    '',
+    ...(report.sinkGapActions.length > 0
+      ? [
+        '| Env Var | Sink | Status | Action |',
+        '| --- | --- | --- | --- |',
+        ...report.sinkGapActions.slice(0, 20).map((gap) => [
+          gap.envVar,
+          gap.sink,
+          gap.status,
+          gap.action,
+        ].map(escapeTableCell).join(' | ')).map((line) => `| ${line} |`),
+        '',
+      ]
+      : ['No runtime sink gaps found.', '']),
     '## Secrets',
     '',
     '| Status | Env Var | Source | Risk | Due | Baseline | Sink presence | Next action |',
@@ -432,6 +459,37 @@ function summarizeSinkPresence(observations: CredentialSinkPresenceObservation[]
   }
 }
 
+function buildSinkGapActions(rows: CredentialReportRow[]): CredentialSinkGapAction[] {
+  return rows.flatMap((row) => row.sinkPresence
+    .filter((observation): observation is CredentialSinkPresenceObservation & { status: CredentialSinkGapAction['status'] } => observation.status !== 'present')
+    .map((observation) => ({
+      secretId: row.id,
+      envVar: row.envVar,
+      sink: observation.sink,
+      status: observation.status,
+      action: sinkGapAction(observation),
+      evidence: observation.evidence,
+    })))
+    .sort((a, b) => {
+      const statusOrder = { missing: 0, unavailable: 1, unknown: 2 }
+      const statusDelta = statusOrder[a.status] - statusOrder[b.status]
+      if (statusDelta !== 0) return statusDelta
+      const sinkDelta = a.sink.localeCompare(b.sink)
+      if (sinkDelta !== 0) return sinkDelta
+      return a.envVar.localeCompare(b.envVar)
+    })
+}
+
+function sinkGapAction(observation: CredentialSinkPresenceObservation): string {
+  if (observation.status === 'missing') {
+    return `Sync ${observation.envVar} into ${observation.sink} from the source of truth, then rerun credentials:report -- --check-sinks.`
+  }
+  if (observation.status === 'unavailable') {
+    return `Restore read-only ${observation.sink} metadata access, then rerun credentials:report -- --check-sinks.`
+  }
+  return `Add a key-only metadata adapter or approved sanitized evidence path for ${observation.sink}.`
+}
+
 function formatSinkPresence(summary: CredentialSinkPresenceSummary): string {
   const parts = [
     summary.present > 0 ? `${summary.present} present` : '',
@@ -502,7 +560,8 @@ function summarizePackets(packets: CredentialPacketReport[]): CredentialPacketSu
 function buildBlockers(
   summary: CredentialReport['summary'],
   env: CredentialEnvironment,
-  packets: CredentialPacketReport[]
+  packets: CredentialPacketReport[],
+  sinkGapActions: CredentialSinkGapAction[]
 ): string[] {
   const blockers: string[] = []
   if (summary.needsBaseline > 0) blockers.push(`${summary.needsBaseline} ${env} secrets need provider-confirmed rotation baselines.`)
@@ -510,6 +569,8 @@ function buildBlockers(
   if (env === 'prod' && summary.approvalRequired > 0) blockers.push('Production rotation or revocation requires an approval packet.')
   if (packets.some((packet) => packet.status === 'blocked')) blockers.push('At least one local rotation packet is blocked.')
   if (packets.some((packet) => packet.status === 'revocation-pending')) blockers.push('At least one local rotation packet is waiting on revocation approval.')
+  if (sinkGapActions.some((gap) => gap.status === 'missing')) blockers.push('At least one runtime sink is missing expected credential metadata.')
+  if (sinkGapActions.some((gap) => gap.status === 'unavailable')) blockers.push('At least one runtime sink metadata check is unavailable.')
   return blockers
 }
 


### PR DESCRIPTION
## Summary
- Adds `sinkGapActions` to credential reports for runtime sink states that are `missing`, `unknown`, or `unavailable`.
- Shows runtime sink gap actions in `/admin/credentials` so operators can see the next step without reading credential values.
- Extends markdown/JSON report output and docs with the sink-gap action boundary.

## Validation
- `npm run build:knowledge`
- `./node_modules/.bin/tsc --noEmit --pretty false --skipLibCheck`
- `./node_modules/.bin/vitest run lib/credential-report.test.ts app/api/admin/credentials/report/route.test.ts app/admin/credentials/page.test.tsx --reporter=dot`
- `npm run lint -- --file lib/credential-report.ts --file lib/credential-report.test.ts --file app/api/admin/credentials/report/route.test.ts --file app/admin/credentials/page.tsx --file app/admin/credentials/page.test.tsx`
- `npx tsx scripts/credential-broker.ts report --env staging --check-sinks --json`
- `git diff --check`

## Integration Notes
- Read-only reporting only. No credential values are read, printed, committed, displayed, synced, rotated, or revoked.
- Gap actions are operator tasks, not automatic mutations.
- Current isolated worktree has no local env files, so local-env checks report unavailable in the CLI smoke; this is expected and value-free.
- Do not merge from this lane; Integration Captain owns merge/deploy sequencing.