### PR TITLE
docs: record credential baseline metadata

### DIFF
--- a/docs/credential-baseline-evidence.md
+++ b/docs/credential-baseline-evidence.md
@@ -1,0 +1,33 @@
+# Credential Baseline Evidence
+
+Last updated: 2026-05-13
+
+This note records the value-free evidence used to replace the staging `pending-provider-confirmation` baselines in `docs/credential-inventory.json`.
+
+No secret values were read, printed, committed, or copied into this file. The evidence below comes from provider metadata only: n8n credential names/types/timestamps, Vercel environment-variable metadata, 1Password item metadata, or an operator-confirmed session update.
+
+## Staging Baselines
+
+| Secret | Baseline | Evidence |
+| --- | --- | --- |
+| `N8N_INGEST_SECRET` | 2026-04-16 | n8n credential metadata for `ATAS Ingest Bearer Auth`, updated 2026-04-16T03:44:21Z. |
+| `SUPABASE_SERVICE_ROLE_KEY` | 2026-03-22 | n8n credential metadata for `Supabase Service Role`, updated 2026-03-22T00:38:59Z. |
+| `OPENAI_API_KEY` | 2026-04-19 | Vercel Preview metadata for `OPENAI_API_KEY`, updated 2026-04-19T12:04:06Z. |
+| `ANTHROPIC_API_KEY` | 2026-03-21 | n8n credential metadata for `Anthropic Staging Account`, updated 2026-03-21T14:11:17Z. |
+| `OPENROUTER_API_KEY` | 2026-03-21 | n8n credential metadata for `OpenRouter Staging Account`, updated 2026-03-21T15:06:12Z. |
+| `GEMINI_API_KEY` | 2026-03-22 | n8n credential metadata for `Gemini API Key`, updated 2026-03-22T00:45:06Z. |
+| `ELEVENLABS_API_KEY` | 2026-03-22 | n8n credential metadata for `ElevenLabs API Key`, updated 2026-03-22T00:45:54Z. |
+| `APIFY_API_TOKEN` | 2026-03-22 | n8n credential metadata for `Apify API Token`, updated 2026-03-22T00:44:30Z. |
+| `STRIPE_SECRET_KEY` | 2026-02-23 | n8n credential metadata for `Stripe Test`, updated 2026-02-23T21:05:10Z. |
+| `STRIPE_WEBHOOK_SECRET` | 2026-01-13 | Vercel Preview metadata for `STRIPE_WEBHOOK_SECRET`, updated 2026-01-13T16:51:05Z. |
+| `GITHUB_TOKEN` | 2026-03-12 | n8n credential metadata for `GitHub account`, updated 2026-03-12T02:25:06Z. |
+| `GOOGLE_SERVICE_ACCOUNT_KEY` | 2026-05-13 | Vercel Preview metadata after approved preview sync on 2026-05-13T13:27:32Z. |
+| `LINKEDIN_COOKIE` | 2026-05-13 | Operator added a current LinkedIn `li_at` session cookie to local env on 2026-05-13. |
+| `GMAIL_APP_PASSWORD` | 2026-05-01 | 1Password `Portfolio / staging` item metadata for `GMAIL_APP_PASSWORD`, created/updated 2026-05-01T14:48:30Z. |
+
+## Evidence Limits
+
+- Infisical source-of-truth history was not used in this pass because the available CLI path returns secret values by default. A future safe adapter should query Infisical metadata without returning values.
+- Vercel metadata proves environment-variable presence/update time, not necessarily upstream provider key creation time.
+- n8n credential metadata proves encrypted credential item update time, not necessarily upstream provider key creation time.
+- `LINKEDIN_COOKIE` is a browser-session credential and may expire outside the normal cadence if LinkedIn invalidates the session.

--- a/docs/credential-inventory.json
+++ b/docs/credential-inventory.json
@@ -78,10 +78,10 @@
           "updatedAt": "2026-05-01"
         },
         "staging": {
-          "status": "pending-provider-confirmation",
-          "lastRotatedAt": null,
-          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
-          "updatedAt": "2026-05-01"
+          "status": "confirmed",
+          "lastRotatedAt": "2026-04-16",
+          "evidence": "n8n Credentials metadata: ATAS Ingest Bearer Auth updated 2026-04-16T03:44:21Z; value not read.",
+          "updatedAt": "2026-05-13"
         },
         "prod": {
           "status": "pending-provider-confirmation",
@@ -127,10 +127,10 @@
           "updatedAt": "2026-05-01"
         },
         "staging": {
-          "status": "pending-provider-confirmation",
-          "lastRotatedAt": null,
-          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
-          "updatedAt": "2026-05-01"
+          "status": "confirmed",
+          "lastRotatedAt": "2026-03-22",
+          "evidence": "n8n Credentials metadata: Supabase Service Role updated 2026-03-22T00:38:59Z; value not read.",
+          "updatedAt": "2026-05-13"
         },
         "prod": {
           "status": "pending-provider-confirmation",
@@ -175,10 +175,10 @@
           "updatedAt": "2026-05-01"
         },
         "staging": {
-          "status": "pending-provider-confirmation",
-          "lastRotatedAt": null,
-          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
-          "updatedAt": "2026-05-01"
+          "status": "confirmed",
+          "lastRotatedAt": "2026-04-19",
+          "evidence": "Vercel preview metadata: OPENAI_API_KEY updated 2026-04-19T12:04:06Z; value not read.",
+          "updatedAt": "2026-05-13"
         },
         "prod": {
           "status": "pending-provider-confirmation",
@@ -223,10 +223,10 @@
           "updatedAt": "2026-05-01"
         },
         "staging": {
-          "status": "pending-provider-confirmation",
-          "lastRotatedAt": null,
-          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
-          "updatedAt": "2026-05-01"
+          "status": "confirmed",
+          "lastRotatedAt": "2026-03-21",
+          "evidence": "n8n Credentials metadata: Anthropic Staging Account updated 2026-03-21T14:11:17Z; value not read.",
+          "updatedAt": "2026-05-13"
         },
         "prod": {
           "status": "pending-provider-confirmation",
@@ -271,10 +271,10 @@
           "updatedAt": "2026-05-01"
         },
         "staging": {
-          "status": "pending-provider-confirmation",
-          "lastRotatedAt": null,
-          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
-          "updatedAt": "2026-05-01"
+          "status": "confirmed",
+          "lastRotatedAt": "2026-03-21",
+          "evidence": "n8n Credentials metadata: OpenRouter Staging Account updated 2026-03-21T15:06:12Z; value not read.",
+          "updatedAt": "2026-05-13"
         },
         "prod": {
           "status": "pending-provider-confirmation",
@@ -318,10 +318,10 @@
           "updatedAt": "2026-05-01"
         },
         "staging": {
-          "status": "pending-provider-confirmation",
-          "lastRotatedAt": null,
-          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
-          "updatedAt": "2026-05-01"
+          "status": "confirmed",
+          "lastRotatedAt": "2026-03-22",
+          "evidence": "n8n Credentials metadata: Gemini API Key updated 2026-03-22T00:45:06Z; value not read.",
+          "updatedAt": "2026-05-13"
         },
         "prod": {
           "status": "pending-provider-confirmation",
@@ -365,10 +365,10 @@
           "updatedAt": "2026-05-01"
         },
         "staging": {
-          "status": "pending-provider-confirmation",
-          "lastRotatedAt": null,
-          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
-          "updatedAt": "2026-05-01"
+          "status": "confirmed",
+          "lastRotatedAt": "2026-03-22",
+          "evidence": "n8n Credentials metadata: ElevenLabs API Key updated 2026-03-22T00:45:54Z; value not read.",
+          "updatedAt": "2026-05-13"
         },
         "prod": {
           "status": "pending-provider-confirmation",
@@ -414,10 +414,10 @@
           "updatedAt": "2026-05-01"
         },
         "staging": {
-          "status": "pending-provider-confirmation",
-          "lastRotatedAt": null,
-          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
-          "updatedAt": "2026-05-01"
+          "status": "confirmed",
+          "lastRotatedAt": "2026-03-22",
+          "evidence": "n8n Credentials metadata: Apify API Token updated 2026-03-22T00:44:30Z; value not read.",
+          "updatedAt": "2026-05-13"
         },
         "prod": {
           "status": "pending-provider-confirmation",
@@ -461,10 +461,10 @@
           "updatedAt": "2026-05-01"
         },
         "staging": {
-          "status": "pending-provider-confirmation",
-          "lastRotatedAt": null,
-          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
-          "updatedAt": "2026-05-01"
+          "status": "confirmed",
+          "lastRotatedAt": "2026-02-23",
+          "evidence": "n8n Credentials metadata: Stripe Test updated 2026-02-23T21:05:10Z; value not read.",
+          "updatedAt": "2026-05-13"
         },
         "prod": {
           "status": "pending-provider-confirmation",
@@ -509,10 +509,10 @@
           "updatedAt": "2026-05-01"
         },
         "staging": {
-          "status": "pending-provider-confirmation",
-          "lastRotatedAt": null,
-          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
-          "updatedAt": "2026-05-01"
+          "status": "confirmed",
+          "lastRotatedAt": "2026-01-13",
+          "evidence": "Vercel preview metadata: STRIPE_WEBHOOK_SECRET updated 2026-01-13T16:51:05Z; value not read.",
+          "updatedAt": "2026-05-13"
         },
         "prod": {
           "status": "pending-provider-confirmation",
@@ -556,10 +556,10 @@
           "updatedAt": "2026-05-01"
         },
         "staging": {
-          "status": "pending-provider-confirmation",
-          "lastRotatedAt": null,
-          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
-          "updatedAt": "2026-05-01"
+          "status": "confirmed",
+          "lastRotatedAt": "2026-03-12",
+          "evidence": "n8n Credentials metadata: GitHub account updated 2026-03-12T02:25:06Z; value not read.",
+          "updatedAt": "2026-05-13"
         },
         "prod": {
           "status": "pending-provider-confirmation",
@@ -603,10 +603,10 @@
           "updatedAt": "2026-05-01"
         },
         "staging": {
-          "status": "pending-provider-confirmation",
-          "lastRotatedAt": null,
-          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
-          "updatedAt": "2026-05-01"
+          "status": "confirmed",
+          "lastRotatedAt": "2026-05-13",
+          "evidence": "Vercel preview metadata: GOOGLE_SERVICE_ACCOUNT_KEY synced 2026-05-13T13:27:32Z after operator approval; source key value not read.",
+          "updatedAt": "2026-05-13"
         },
         "prod": {
           "status": "pending-provider-confirmation",
@@ -649,10 +649,10 @@
           "updatedAt": "2026-05-01"
         },
         "staging": {
-          "status": "pending-provider-confirmation",
-          "lastRotatedAt": null,
-          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
-          "updatedAt": "2026-05-01"
+          "status": "confirmed",
+          "lastRotatedAt": "2026-05-13",
+          "evidence": "Operator added current LinkedIn li_at session cookie to local env on 2026-05-13; value not read.",
+          "updatedAt": "2026-05-13"
         },
         "prod": {
           "status": "pending-provider-confirmation",
@@ -695,10 +695,10 @@
           "updatedAt": "2026-05-01"
         },
         "staging": {
-          "status": "pending-provider-confirmation",
-          "lastRotatedAt": null,
-          "evidence": "Pending provider/source-of-truth confirmation; do not infer from local env files.",
-          "updatedAt": "2026-05-01"
+          "status": "confirmed",
+          "lastRotatedAt": "2026-05-01",
+          "evidence": "1Password Portfolio / staging metadata: GMAIL_APP_PASSWORD item created/updated 2026-05-01T14:48:30Z; value not read.",
+          "updatedAt": "2026-05-13"
         },
         "prod": {
           "status": "pending-provider-confirmation",

--- a/docs/credential-management-system.md
+++ b/docs/credential-management-system.md
@@ -93,6 +93,7 @@ Use `credentials:baseline-template` when `credentials:report` shows `needs-basel
 
 - `docs/credential-rotation-map.md`
 - `docs/credential-rotation-runbook.md`
+- `docs/credential-baseline-evidence.md`
 - `docs/n8n-secrets-remediation.md`
 - `n8n-exports/environment-variables-reference.md`
 


### PR DESCRIPTION
## Summary
- replace staging credential baseline placeholders with value-free provider metadata dates
- add a credential baseline evidence note documenting n8n, Vercel, 1Password, and operator-session evidence limits
- link the evidence note from the credential management system doc

## Validation
- `node -e 'JSON.parse(require("fs").readFileSync("docs/credential-inventory.json","utf8")); console.log("credential inventory json ok")'`
- `npx tsx scripts/credential-broker.ts report --env staging --json` -> needsBaseline 0, providerConfirmed 14, due 3
- `npx tsx scripts/credential-broker.ts report --env staging --check-sinks --json` -> present 27, missing 0, unknown 8, unavailable 0
- `npm run credentials:smoke -- --env staging`
- `npx vitest run lib/credential-report.test.ts app/admin/credentials/page.test.tsx`
- `git diff --check`

## Integration Notes
- This PR is documentation/inventory metadata only; no secret values are committed.
- The report now surfaces 3 real staging rotations due: `GITHUB_TOKEN`, `STRIPE_SECRET_KEY`, and `STRIPE_WEBHOOK_SECRET`.
- n8n Variables remain intentionally unknown until a key-only metadata adapter exists.
- Vercel contexts were not redeployed for this docs/inventory-only branch.