### PR TITLE
docs: record staging credential rotation drill

### DIFF
--- a/docs/credential-baseline-evidence.md
+++ b/docs/credential-baseline-evidence.md
@@ -18,9 +18,9 @@ No secret values were read, printed, committed, or copied into this file. The ev
 | `GEMINI_API_KEY` | 2026-03-22 | n8n credential metadata for `Gemini API Key`, updated 2026-03-22T00:45:06Z. |
 | `ELEVENLABS_API_KEY` | 2026-03-22 | n8n credential metadata for `ElevenLabs API Key`, updated 2026-03-22T00:45:54Z. |
 | `APIFY_API_TOKEN` | 2026-03-22 | n8n credential metadata for `Apify API Token`, updated 2026-03-22T00:44:30Z. |
-| `STRIPE_SECRET_KEY` | 2026-02-23 | n8n credential metadata for `Stripe Test`, updated 2026-02-23T21:05:10Z. |
-| `STRIPE_WEBHOOK_SECRET` | 2026-01-13 | Vercel Preview metadata for `STRIPE_WEBHOOK_SECRET`, updated 2026-01-13T16:51:05Z. |
-| `GITHUB_TOKEN` | 2026-03-12 | n8n credential metadata for `GitHub account`, updated 2026-03-12T02:25:06Z. |
+| `STRIPE_SECRET_KEY` | 2026-05-13 | Approved staging-only rotation drill: Infisical staging `/portfolio` secret synced, local and `portfolio-staging` Vercel runtime sinks updated, staging redeployed, and Stripe API smokes returned 200. |
+| `STRIPE_WEBHOOK_SECRET` | 2026-05-13 | Approved staging-only rotation drill: Infisical staging `/portfolio` secret synced, local and `portfolio-staging` Vercel runtime sinks updated, Stripe destination URL corrected to `/api/payments/webhook`, and a signed staging webhook probe returned 200. |
+| `GITHUB_TOKEN` | 2026-05-13 | Approved staging-only rotation drill: Infisical staging `/portfolio` secret synced, local and `portfolio-staging` Vercel runtime sinks updated, and GitHub repo-read smoke returned 200. |
 | `GOOGLE_SERVICE_ACCOUNT_KEY` | 2026-05-13 | Vercel Preview metadata after approved preview sync on 2026-05-13T13:27:32Z. |
 | `LINKEDIN_COOKIE` | 2026-05-13 | Operator added a current LinkedIn `li_at` session cookie to local env on 2026-05-13. |
 | `GMAIL_APP_PASSWORD` | 2026-05-01 | 1Password `Portfolio / staging` item metadata for `GMAIL_APP_PASSWORD`, created/updated 2026-05-01T14:48:30Z. |

--- a/docs/credential-inventory.json
+++ b/docs/credential-inventory.json
@@ -462,8 +462,8 @@
         },
         "staging": {
           "status": "confirmed",
-          "lastRotatedAt": "2026-02-23",
-          "evidence": "n8n Credentials metadata: Stripe Test updated 2026-02-23T21:05:10Z; value not read.",
+          "lastRotatedAt": "2026-05-13",
+          "evidence": "Infisical staging /portfolio secret synced 2026-05-13 after approved staging-only rotation drill; local, Vercel portfolio-staging runtime sinks, and Stripe API smokes verified; value not printed.",
           "updatedAt": "2026-05-13"
         },
         "prod": {
@@ -510,8 +510,8 @@
         },
         "staging": {
           "status": "confirmed",
-          "lastRotatedAt": "2026-01-13",
-          "evidence": "Vercel preview metadata: STRIPE_WEBHOOK_SECRET updated 2026-01-13T16:51:05Z; value not read.",
+          "lastRotatedAt": "2026-05-13",
+          "evidence": "Infisical staging /portfolio secret synced 2026-05-13 after approved staging-only rotation drill; Stripe destination URL corrected to /api/payments/webhook and signed staging webhook probe returned 200; value not printed.",
           "updatedAt": "2026-05-13"
         },
         "prod": {
@@ -557,8 +557,8 @@
         },
         "staging": {
           "status": "confirmed",
-          "lastRotatedAt": "2026-03-12",
-          "evidence": "n8n Credentials metadata: GitHub account updated 2026-03-12T02:25:06Z; value not read.",
+          "lastRotatedAt": "2026-05-13",
+          "evidence": "Infisical staging /portfolio secret synced 2026-05-13 after approved staging-only rotation drill; local, Vercel portfolio-staging runtime sinks, and GitHub repo-read smoke verified; value not printed.",
           "updatedAt": "2026-05-13"
         },
         "prod": {


### PR DESCRIPTION
Summary
- Records the approved staging-only rotation drill for GITHUB_TOKEN, STRIPE_SECRET_KEY, and STRIPE_WEBHOOK_SECRET.
- Updates value-free staging baseline evidence to reflect Infisical source-of-truth sync, Vercel portfolio-staging runtime sync, staging redeploy, and smoke results.
- Notes the Stripe webhook route correction to /api/payments/webhook and successful signed staging probe.

Validation
- npm run credentials:smoke -- --env staging
- npm run credentials:report -- --env staging --check-sinks --json
- GitHub repo-read smoke returned 200.
- Stripe API smokes for products, customers, checkout sessions, and payment intents returned 200.
- Signed staging webhook probe returned 200 / received true.
- Vercel portfolio-staging production env metadata updated 2026-05-13 and staging redeploy is Ready.

Integration Notes
- No production credential revocation or production project env mutation was performed.
- Runtime secret values were not printed, committed, or documented.
- Unrelated dirty files docs/subscription-cancellation-audit.md and docs/subscription-status.json were preserved and excluded.
- Vercel – portfolio was not touched; Vercel – portfolio-staging was redeployed and verified Ready.
- n8n Variables remain an unknown visibility gap for STRIPE_WEBHOOK_SECRET because the broker does not read variable values.