### PR TITLE
feat: trace client progress update delivery

### DIFF
--- a/app/api/progress-updates/[id]/delivered/route.test.ts
+++ b/app/api/progress-updates/[id]/delivered/route.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  updateProgressUpdateLogStatus: vi.fn(),
+}))
+
+vi.mock('@/lib/progress-update-templates', () => ({
+  updateProgressUpdateLogStatus: mocks.updateProgressUpdateLogStatus,
+}))
+
+import { POST } from './route'
+
+function request(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/progress-updates/log-1/delivered', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/progress-updates/[id]/delivered', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.updateProgressUpdateLogStatus.mockResolvedValue(true)
+  })
+
+  it('rejects malformed delivery status', async () => {
+    const response = await POST(
+      request({ delivery_status: 'queued' }) as never,
+      { params: Promise.resolve({ id: 'log-1' }) },
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: 'delivery_status must be "sent" or "failed"',
+    })
+  })
+
+  it('passes agent_run_id through to the progress update log helper', async () => {
+    const response = await POST(
+      request({
+        delivery_status: 'sent',
+        agent_run_id: 'agent-run-1',
+      }) as never,
+      { params: Promise.resolve({ id: 'log-1' }) },
+    )
+
+    expect(response.status).toBe(200)
+    expect(mocks.updateProgressUpdateLogStatus).toHaveBeenCalledWith(
+      'log-1',
+      'sent',
+      undefined,
+      'agent-run-1',
+    )
+    expect(await response.json()).toEqual({
+      success: true,
+      log_id: 'log-1',
+      delivery_status: 'sent',
+      agent_run_id: 'agent-run-1',
+    })
+  })
+})

--- a/app/api/progress-updates/[id]/delivered/route.ts
+++ b/app/api/progress-updates/[id]/delivered/route.ts
@@ -20,7 +20,7 @@ export async function POST(
     const { id: logId } = await params
     const body = await request.json()
 
-    const { delivery_status, error_message } = body
+    const { delivery_status, error_message, agent_run_id } = body
 
     if (!delivery_status || !['sent', 'failed'].includes(delivery_status)) {
       return NextResponse.json(
@@ -32,7 +32,8 @@ export async function POST(
     const success = await updateProgressUpdateLogStatus(
       logId,
       delivery_status,
-      error_message
+      error_message,
+      typeof agent_run_id === 'string' ? agent_run_id : null,
     )
 
     if (!success) {
@@ -46,6 +47,7 @@ export async function POST(
       success: true,
       log_id: logId,
       delivery_status,
+      agent_run_id: typeof agent_run_id === 'string' ? agent_run_id : null,
     })
   } catch (error) {
     console.error(

--- a/docs/agent-operations-rollout.md
+++ b/docs/agent-operations-rollout.md
@@ -116,7 +116,8 @@ Current n8n trace coverage:
 - Social content extraction creates an `n8n` run, dispatches `agent_run_id`, and completes/fails the shared run from the n8n completion callback.
 - Value evidence workflows create an `n8n` run, dispatch `agent_run_id`, record progress stages, preserve auto-chained VEP-001 to VEP-002 behavior, and complete/fail the shared run after the final phase.
 - Warm lead scrapers create an `n8n` run, dispatch `agent_run_id`, and the versioned WRM exports preserve the trace envelope through normalization before reporting successful ingest completion to `/api/admin/outreach/run-complete` and the generic trace event callback.
-- Social content extraction, value evidence, and warm lead scraper payloads now include a shared `agent_trace` envelope with the generic event callback URL when `agent_run_id` exists.
+- Client progress updates create an `n8n` run before dispatching the progress-update router, include `agent_run_id` and `agent_trace` in the webhook payload, and complete/fail the shared run from the delivery callback when n8n echoes `agent_run_id`.
+- Social content extraction, value evidence, warm lead scraper, and client progress update payloads now include a shared `agent_trace` envelope with the generic event callback URL when `agent_run_id` exists.
 
 ## Legacy Workflow Run Tables
 
@@ -129,6 +130,7 @@ Current n8n trace coverage:
 | `warm_lead_trigger_audit` | Warm Lead Capture / warm lead scrapers | Linked through `agent_run_id` for app-triggered scraper runs and completion artifacts. | Keep for source last-run checks, trigger audit, and scraper-specific options. Agent Operations remains canonical for run outcome visibility. |
 | `video_generation_workflow_runs` | Content Production / video sync workflows | Linked through `agent_run_id` for admin-triggered HeyGen catalog and Drive script sync runs. | Keep as domain progress for video sync chips/history; shared Agent Ops runs are canonical for audit, stale detection, artifacts, and cross-runtime visibility. |
 | `video_generation_jobs` | Content Production / generated media | Artifact/job table, not a generic run table. | Keep as the media job source of truth. Future video agents should attach job references as `agent_run_artifacts` instead of migrating the job table into `agent_runs`. |
+| `progress_update_log` | Product & Automation / client progress updates | New sends start an `n8n` Agent Ops run and n8n delivery callbacks can complete/fail that run when `agent_run_id` is echoed. | Keep as client-update delivery history and message body storage; Agent Ops handles cross-runtime visibility, stale detection, and delivery trace status. |
 
 Migration rules:
 

--- a/docs/agent-operations-task-list.md
+++ b/docs/agent-operations-task-list.md
@@ -28,6 +28,7 @@ This is the active implementation queue for Agent Operations. The phase gates, d
    - [x] Pass `agent_run_id` plus a generic callback URL into traced social content, value evidence, and warm lead payloads.
    - [x] Let generic n8n callbacks record both run events and stage steps.
    - [x] Add warm lead export callbacks for successful ingest completion across Facebook, Google Contacts, and LinkedIn workflows.
+   - [x] Add client progress update delivery trace callbacks for the progress-update n8n router.
    - Add remaining workflow-specific progress, completion, and failure callbacks where legacy workflows still lack them.
    - Keep legacy workflow pages active until replacement views are proven.
 

--- a/lib/__tests__/n8n-progress-update-workflow-export.test.ts
+++ b/lib/__tests__/n8n-progress-update-workflow-export.test.ts
@@ -1,0 +1,50 @@
+import fs from 'fs'
+import path from 'path'
+import { describe, expect, it } from 'vitest'
+
+const WORKFLOW_PATH = path.join(process.cwd(), 'n8n-exports/Client-Progress-Update-Router.json')
+
+function loadWorkflow() {
+  return JSON.parse(fs.readFileSync(WORKFLOW_PATH, 'utf8')) as {
+    nodes: Array<{
+      name: string
+      parameters?: {
+        sendHeaders?: boolean
+        headerParameters?: { parameters?: Array<{ name: string; value: string }> }
+        bodyParameters?: { parameters?: Array<{ name: string; value: string }> }
+      }
+    }>
+  }
+}
+
+describe('Client Progress Update Router export', () => {
+  it.each(['Slack Delivery Callback', 'Email Delivery Callback'])(
+    '%s echoes Agent Ops trace metadata and authenticates callbacks',
+    (nodeName) => {
+      const workflow = loadWorkflow()
+      const node = workflow.nodes.find((item) => item.name === nodeName)
+
+      expect(node?.parameters?.sendHeaders).toBe(true)
+      expect(node?.parameters?.headerParameters?.parameters).toEqual(
+        expect.arrayContaining([
+          {
+            name: 'x-ingest-secret',
+            value: '={{ $vars.N8N_INGEST_SECRET || $env.N8N_INGEST_SECRET }}',
+          },
+        ]),
+      )
+      expect(node?.parameters?.bodyParameters?.parameters).toEqual(
+        expect.arrayContaining([
+          {
+            name: 'agent_run_id',
+            value: "={{ $('Progress Update Webhook').item.json.body.agent_run_id || '' }}",
+          },
+          {
+            name: 'delivery_status',
+            value: 'sent',
+          },
+        ]),
+      )
+    },
+  )
+})

--- a/lib/progress-update-templates.test.ts
+++ b/lib/progress-update-templates.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./supabase', () => ({
+  supabaseAdmin: {},
+}))
+
+vi.mock('./agent-run', () => ({
+  attachAgentArtifact: vi.fn(),
+  endAgentRun: vi.fn(),
+  markAgentRunFailed: vi.fn(),
+  recordAgentStep: vi.fn(),
+  startAgentRun: vi.fn(),
+}))
+
+import { buildProgressUpdateAgentTracePayload } from './progress-update-templates'
+
+describe('progress update agent trace payloads', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('returns null trace fields when no agent run exists', () => {
+    expect(buildProgressUpdateAgentTracePayload(null)).toEqual({
+      agent_run_id: null,
+      agent_event_callback_url: null,
+      agent_trace: null,
+    })
+  })
+
+  it('builds the generic Agent Ops callback envelope for n8n', () => {
+    vi.stubEnv('NEXT_PUBLIC_BASE_URL', 'https://portfolio.example.com/')
+
+    expect(buildProgressUpdateAgentTracePayload('agent-run-1')).toMatchObject({
+      agent_run_id: 'agent-run-1',
+      agent_event_callback_url: 'https://portfolio.example.com/api/admin/agents/runs/agent-run-1/events',
+      agent_trace: {
+        version: 1,
+        runtime: 'n8n',
+        agent_run_id: 'agent-run-1',
+        workflow_id: 'client-progress-update-router',
+        events_url: 'https://portfolio.example.com/api/admin/agents/runs/agent-run-1/events',
+        auth: 'Bearer N8N_INGEST_SECRET',
+      },
+    })
+  })
+})

--- a/lib/progress-update-templates.ts
+++ b/lib/progress-update-templates.ts
@@ -8,6 +8,13 @@
 
 import { supabaseAdmin } from './supabase'
 import { n8nWebhookUrl } from './n8n'
+import {
+  attachAgentArtifact,
+  endAgentRun,
+  markAgentRunFailed,
+  recordAgentStep,
+  startAgentRun,
+} from './agent-run'
 import type {
   Milestone,
   CommunicationPlan,
@@ -96,6 +103,9 @@ export interface ProgressUpdateWebhookPayload {
   milestones_progress: string
   attachments: ProgressUpdateAttachment[]
   callback_url: string
+  agent_run_id?: string | null
+  agent_event_callback_url?: string | null
+  agent_trace?: Record<string, unknown> | null
 }
 
 export interface ProgressUpdateLogEntry {
@@ -112,6 +122,43 @@ export interface ProgressUpdateLogEntry {
   delivery_status: 'pending' | 'sent' | 'failed' | 'skipped'
   n8n_webhook_fired_at: string | null
   triggered_by: 'admin' | 'slack_cmd' | 'system'
+}
+
+const PROGRESS_UPDATE_WORKFLOW_ID = 'client-progress-update-router'
+
+function portfolioBaseUrl(): string {
+  if (process.env.NEXT_PUBLIC_BASE_URL) return process.env.NEXT_PUBLIC_BASE_URL.replace(/\/+$/, '')
+  if (process.env.PORTFOLIO_BASE_URL) return process.env.PORTFOLIO_BASE_URL.replace(/\/+$/, '')
+  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`.replace(/\/+$/, '')
+  return 'http://localhost:3000'
+}
+
+export function buildProgressUpdateAgentTracePayload(
+  agentRunId: string | null,
+  workflowId = PROGRESS_UPDATE_WORKFLOW_ID,
+): Pick<ProgressUpdateWebhookPayload, 'agent_run_id' | 'agent_event_callback_url' | 'agent_trace'> {
+  if (!agentRunId) {
+    return {
+      agent_run_id: null,
+      agent_event_callback_url: null,
+      agent_trace: null,
+    }
+  }
+
+  const eventsUrl = `${portfolioBaseUrl()}/api/admin/agents/runs/${agentRunId}/events`
+  return {
+    agent_run_id: agentRunId,
+    agent_event_callback_url: eventsUrl,
+    agent_trace: {
+      version: 1,
+      runtime: 'n8n',
+      agent_run_id: agentRunId,
+      workflow_id: workflowId,
+      events_url: eventsUrl,
+      auth: 'Bearer N8N_INGEST_SECRET',
+      completion_callback: 'n8n should echo agent_run_id to callback_url after delivery.',
+    },
+  }
 }
 
 // ============================================================================
@@ -490,7 +537,8 @@ export async function createProgressUpdateLog(
 export async function updateProgressUpdateLogStatus(
   logId: string,
   status: 'sent' | 'failed',
-  errorMessage?: string
+  errorMessage?: string,
+  agentRunId?: string | null,
 ): Promise<boolean> {
   try {
     const updateData: Record<string, unknown> = {
@@ -510,7 +558,49 @@ export async function updateProgressUpdateLogStatus(
 
     if (error) {
       console.error('Error updating progress update log:', error)
+      if (agentRunId) {
+        await markAgentRunFailed(agentRunId, `Progress update delivery callback failed for log ${logId}`, {
+          log_id: logId,
+          delivery_status: status,
+          error_message: error.message,
+        }).catch(() => {})
+      }
       return false
+    }
+
+    if (agentRunId) {
+      await recordAgentStep({
+        runId: agentRunId,
+        stepKey: 'delivery_callback_received',
+        name: status === 'sent' ? 'Progress update delivery confirmed' : 'Progress update delivery failed',
+        status: status === 'sent' ? 'completed' : 'failed',
+        outputSummary: errorMessage ?? `Delivery status: ${status}`,
+        metadata: { log_id: logId, delivery_status: status },
+        idempotencyKey: `${agentRunId}:delivery:${logId}:${status}`,
+      }).catch(() => {})
+
+      if (status === 'sent') {
+        await attachAgentArtifact({
+          runId: agentRunId,
+          artifactType: 'progress_update_delivery',
+          title: 'Client progress update delivery',
+          refType: 'progress_update_log',
+          refId: logId,
+          metadata: { delivery_status: status },
+          idempotencyKey: `${agentRunId}:artifact:${logId}`,
+        }).catch(() => {})
+        await endAgentRun({
+          runId: agentRunId,
+          status: 'completed',
+          currentStep: 'Progress update delivered',
+          outcome: { log_id: logId, delivery_status: status },
+        }).catch(() => {})
+      } else {
+        await markAgentRunFailed(agentRunId, errorMessage ?? 'Progress update delivery failed', {
+          log_id: logId,
+          delivery_status: status,
+        }).catch(() => {})
+      }
     }
 
     return true
@@ -609,7 +699,7 @@ export async function triggerProgressUpdate(params: {
   customNote?: string
   attachments?: ProgressUpdateAttachment[]
   triggeredBy?: 'admin' | 'slack_cmd' | 'system'
-}): Promise<{ logId: string; channel: string; updateType: string } | null> {
+}): Promise<{ logId: string; channel: string; updateType: string; agentRunId: string | null } | null> {
   const {
     clientProjectId,
     milestoneIndex,
@@ -661,9 +751,7 @@ export async function triggerProgressUpdate(params: {
   const channel: 'slack' | 'email' = plan.slack_channel ? 'slack' : 'email'
 
   // 7. Build callback URL
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || process.env.VERCEL_URL
-    ? `https://${process.env.VERCEL_URL}`
-    : 'http://localhost:3000'
+  const baseUrl = portfolioBaseUrl()
 
   // 8. Create log entry (pre-send, status=pending)
   const logEntry: ProgressUpdateLogEntry = {
@@ -688,6 +776,47 @@ export async function triggerProgressUpdate(params: {
     return null
   }
 
+  let agentRunId: string | null = null
+  try {
+    const agentRun = await startAgentRun({
+      agentKey: 'automation-systems',
+      runtime: 'n8n',
+      kind: 'client_progress_update_delivery',
+      title: 'Deliver client progress update',
+      subject: { type: 'client_project', id: clientProjectId, label: plan.client_name },
+      triggerSource: `progress_update_${triggeredBy}`,
+      currentStep: 'Preparing progress update delivery',
+      metadata: {
+        workflow_id: PROGRESS_UPDATE_WORKFLOW_ID,
+        log_id: logResult.id,
+        onboarding_plan_id: plan.id,
+        update_type: updateType,
+        channel,
+        milestone_index: milestoneIndex,
+        approval_boundary: 'This trace observes delivery only. Client-visible sends remain governed by the existing progress-update workflow and approval policy.',
+      },
+      idempotencyKey: `progress-update:${logResult.id}`,
+    })
+    agentRunId = agentRun.id
+    await recordAgentStep({
+      runId: agentRunId,
+      stepKey: 'progress_update_rendered',
+      name: 'Progress update rendered',
+      status: 'completed',
+      inputSummary: `${updateType} for ${plan.client_name}`,
+      outputSummary: `Prepared ${channel} delivery payload`,
+      metadata: {
+        log_id: logResult.id,
+        channel,
+        update_type: updateType,
+        milestone_index: milestoneIndex,
+      },
+      idempotencyKey: `${agentRunId}:rendered:${logResult.id}`,
+    })
+  } catch (traceError) {
+    console.warn('[progress-update] Agent Ops trace unavailable:', traceError)
+  }
+
   // 9. Fire n8n webhook
   const callbackUrl = `${baseUrl}/api/progress-updates/${logResult.id}/delivered`
 
@@ -706,17 +835,36 @@ export async function triggerProgressUpdate(params: {
     milestones_progress: context.milestones_progress,
     attachments: attachments || [],
     callback_url: callbackUrl,
+    ...buildProgressUpdateAgentTracePayload(agentRunId),
   }
 
   const webhookFired = await fireProgressUpdateWebhook(webhookPayload)
 
   // Update log with webhook timestamp
   if (webhookFired) {
+    if (agentRunId) {
+      await recordAgentStep({
+        runId: agentRunId,
+        stepKey: 'n8n_webhook_dispatched',
+        name: 'n8n progress update workflow dispatched',
+        status: 'running',
+        outputSummary: `Waiting for ${channel} delivery callback`,
+        metadata: { log_id: logResult.id, channel, callback_url: callbackUrl },
+        idempotencyKey: `${agentRunId}:dispatch:${logResult.id}`,
+      }).catch(() => {})
+    }
     await supabaseAdmin
       .from('progress_update_log')
       .update({ n8n_webhook_fired_at: new Date().toISOString() })
       .eq('id', logResult.id)
   } else {
+    if (agentRunId) {
+      await markAgentRunFailed(agentRunId, 'Failed to fire progress update webhook', {
+        log_id: logResult.id,
+        channel,
+        update_type: updateType,
+      }).catch(() => {})
+    }
     await supabaseAdmin
       .from('progress_update_log')
       .update({
@@ -730,6 +878,7 @@ export async function triggerProgressUpdate(params: {
     logId: logResult.id,
     channel,
     updateType,
+    agentRunId,
   }
 }
 

--- a/n8n-exports/Client-Progress-Update-Router.json
+++ b/n8n-exports/Client-Progress-Update-Router.json
@@ -120,10 +120,27 @@
             {
               "name": "delivery_status",
               "value": "sent"
+            },
+            {
+              "name": "agent_run_id",
+              "value": "={{ $('Progress Update Webhook').item.json.body.agent_run_id || '' }}"
+            },
+            {
+              "name": "channel",
+              "value": "slack"
             }
           ]
         },
-        "options": {}
+        "options": {},
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "x-ingest-secret",
+              "value": "={{ $vars.N8N_INGEST_SECRET || $env.N8N_INGEST_SECRET }}"
+            }
+          ]
+        }
       },
       "name": "Slack Delivery Callback",
       "waitBetweenTries": 2000,
@@ -147,10 +164,27 @@
             {
               "name": "delivery_status",
               "value": "sent"
+            },
+            {
+              "name": "agent_run_id",
+              "value": "={{ $('Progress Update Webhook').item.json.body.agent_run_id || '' }}"
+            },
+            {
+              "name": "channel",
+              "value": "email"
             }
           ]
         },
-        "options": {}
+        "options": {},
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "x-ingest-secret",
+              "value": "={{ $vars.N8N_INGEST_SECRET || $env.N8N_INGEST_SECRET }}"
+            }
+          ]
+        }
       },
       "name": "Email Delivery Callback",
       "waitBetweenTries": 2000,
@@ -166,7 +200,7 @@
     },
     {
       "parameters": {
-        "content": "## Client Progress Update Router\n\nReceives progress update payloads from the portfolio app when a milestone is marked complete.\n\n**Routing Logic:**\n- If `channel == 'slack'` -> Posts to the client's Slack channel (by ID)\n- If `channel == 'email'` -> Sends email via Gmail\n\n**After delivery:** Calls the callback URL to confirm delivery status.\n\n**Note:** Attachments are included as links in the message body."
+        "content": "## Client Progress Update Router\n\nReceives progress update payloads from the portfolio app when a milestone is marked complete.\n\n**Routing Logic:**\n- If `channel == 'slack'` -> Posts to the client's Slack channel (by ID)\n- If `channel == 'email'` -> Sends email via Gmail\n\n**After delivery:** Calls the callback URL to confirm delivery status.\n\n**Note:** Attachments are included as links in the message body.\n\n**Agent Ops trace:** The Portfolio payload may include `agent_run_id` and `agent_trace`. Callback nodes echo `agent_run_id` so Portfolio can complete the shared Agent Operations run after delivery."
       },
       "name": "Workflow Notes",
       "id": "workflow-note",


### PR DESCRIPTION
## Summary
- start an Agent Ops n8n run when client progress updates dispatch through the progress-update router
- pass agent_run_id and a generic trace envelope into the n8n payload, then complete or fail the run from the delivery callback
- update the Client Progress Update Router export and docs so Integration Captain can patch the live workflow without running production data

## Validation
- npm test -- --run lib/progress-update-templates.test.ts 'app/api/progress-updates/[id]/delivered/route.test.ts' lib/__tests__/n8n-progress-update-workflow-export.test.ts
- noglob npx next lint --file lib/progress-update-templates.ts --file lib/progress-update-templates.test.ts --file app/api/progress-updates/[id]/delivered/route.ts --file app/api/progress-updates/[id]/delivered/route.test.ts --file lib/__tests__/n8n-progress-update-workflow-export.test.ts
- npx tsc --noEmit --pretty false
- git diff --check

## Integration Notes
- Draft PR for Integration Captain. Do not merge from this lane.
- No live n8n workflow was executed and no production customer data was touched.
- The checked-in n8n export includes the callback patch; live n8n still needs Integration Captain to import/patch and verify.
- Vercel contexts not checked from this non-captain lane: Vercel – portfolio, Vercel – portfolio-staging.