### PR TITLE
feat: redesign agent ops command surfaces

### DIFF
--- a/app/admin/agents/coordination/page.test.tsx
+++ b/app/admin/agents/coordination/page.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import AgentCoordinationPage from './page'
@@ -15,12 +15,79 @@ vi.mock('@/lib/auth', () => ({
   getCurrentSession: vi.fn(async () => ({ access_token: 'admin-token' })),
 }))
 
+const now = '2026-05-11T12:00:00.000Z'
+
+const workItems = [
+  {
+    id: 'work-queue-1',
+    title: 'Approve agent run recovery request',
+    objective: 'Decide whether Shaka can move the recovery packet into validation.',
+    status: 'ready_for_review',
+    priority: 'high',
+    owner_agent_key: 'chief-of-staff',
+    owner_runtime: 'codex',
+    source_type: 'agent_run',
+    source_id: 'run-queue-1',
+    source_label: 'Agent run trace',
+    source_run_id: 'run-queue-1',
+    active_run_id: 'run-queue-1',
+    parent_work_item_id: null,
+    branch_name: 'codex/agent-run-recovery',
+    worktree_path: '/Users/vambahsillah/Projects/Portfolio.worktrees/recovery',
+    pr_number: 231,
+    pr_url: 'https://github.com/example/portfolio/pull/231',
+    expected_files: ['app/admin/agents/coordination/page.tsx'],
+    touched_files: [],
+    overlap_group: 'agent-ops',
+    dependency_ids: [],
+    blocker_summary: null,
+    validation_summary: 'Focused tests pass; awaiting executive decision.',
+    approval_id: 'approval-1',
+    metadata: { recommendation: 'Approve validation after checking the trace and PR evidence.', risk: 'medium' },
+    idempotency_key: null,
+    created_at: now,
+    updated_at: now,
+    completed_at: null,
+  },
+  {
+    id: 'work-queue-2',
+    title: 'Unblock Moremi drill handoff',
+    objective: 'Resolve the synthetic risk signal owner handoff before any remediation.',
+    status: 'blocked',
+    priority: 'urgent',
+    owner_agent_key: 'risk-compliance-intelligence',
+    owner_runtime: 'manual',
+    source_type: 'ai_risk_signal',
+    source_id: 'moremi-operational-drill',
+    source_label: 'Synthetic Agent Ops drill',
+    source_run_id: null,
+    active_run_id: 'run-moremi-drill',
+    parent_work_item_id: null,
+    branch_name: null,
+    worktree_path: null,
+    pr_number: null,
+    pr_url: null,
+    expected_files: [],
+    touched_files: [],
+    overlap_group: 'ai-risk-compliance',
+    dependency_ids: [],
+    blocker_summary: 'Needs Integration Captain owner decision.',
+    validation_summary: null,
+    approval_id: null,
+    metadata: {},
+    idempotency_key: 'ai-risk-drill:moremi-operational-drill:v1',
+    created_at: now,
+    updated_at: now,
+    completed_at: null,
+  },
+]
+
 const approvalCard = {
   approvalId: 'approval-1',
   runId: 'run-1',
   workItemId: 'work-1',
   status: 'pending',
-  requestedAt: '2026-05-11T12:00:00.000Z',
+  requestedAt: now,
   proposal: {
     id: 'next-build-profile',
     title: 'Profile the Next.js build path',
@@ -51,84 +118,101 @@ const approvalCard = {
     status: 'ready_for_review',
     active_run_id: 'run-1',
     approval_id: 'approval-1',
-    updated_at: '2026-05-11T12:00:00.000Z',
+    updated_at: now,
   },
 }
 
-describe('AgentCoordinationPage Vercel AutoResearch approvals', () => {
+function moremiDrillResponse() {
+  return {
+    ok: true,
+    work_item: {
+      ...workItems[1],
+      id: 'work-moremi-drill',
+      title: 'Review AI risk signal: Synthetic Moremi drill: prompt injection risk in browser automation',
+      status: 'proposed',
+    },
+    assessment: {
+      classification: 'approval_required',
+      severity: 'high',
+      recommendedNextAction: 'Create an approval-routed risk packet before any remediation work begins.',
+    },
+    verification: {
+      admin_path: '/admin/agents/coordination',
+      slack_command: '/agent work',
+      expected_status: 'proposed',
+    },
+  }
+}
+
+function setupFetch({ failWorkItems = false } = {}) {
+  vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input)
+
+    if (url === '/api/admin/agents/work-items' && init?.method === 'POST') {
+      return { ok: true, json: async () => ({ ok: true, work_item: workItems[0] }) }
+    }
+
+    if (url.includes('/api/admin/agents/work-items/work-queue-1/block') && init?.method === 'POST') {
+      return { ok: true, json: async () => ({ ok: true }) }
+    }
+
+    if (url.includes('/api/admin/agents/work-items/work-queue-1/validation') && init?.method === 'POST') {
+      return { ok: true, json: async () => ({ ok: true }) }
+    }
+
+    if (url.includes('/api/admin/agents/work-items/work-queue-1/handoff') && init?.method === 'POST') {
+      return { ok: true, json: async () => ({ ok: true }) }
+    }
+
+    if (url.startsWith('/api/admin/agents/work-items')) {
+      if (failWorkItems) return { ok: false, status: 503, json: async () => ({ error: 'work item service unavailable' }) }
+      const status = new URL(`http://localhost${url}`).searchParams.get('status')
+      const filtered = status ? workItems.filter((item) => item.status === status) : workItems
+      return { ok: true, json: async () => ({ work_items: filtered }) }
+    }
+
+    if (url.startsWith('/api/admin/agents/vercel-research/proposals')) {
+      return { ok: true, json: async () => ({ ok: true, approvals: [approvalCard] }) }
+    }
+
+    if (url === '/api/admin/agents/risk-compliance/drill' && init?.method === 'POST') {
+      return { ok: true, json: async () => moremiDrillResponse() }
+    }
+
+    if (url === '/api/admin/agents/runs/run-1/approval' && init?.method === 'POST') {
+      return { ok: true, json: async () => ({ ok: true, approval_id: 'approval-1' }) }
+    }
+
+    return { ok: false, status: 404, json: async () => ({ error: 'not found' }) }
+  }))
+}
+
+describe('AgentCoordinationPage decision queue controller', () => {
   beforeEach(() => {
-    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = String(input)
-      if (url.startsWith('/api/admin/agents/vercel-research/proposals')) {
-        return { ok: true, json: async () => ({ ok: true, approvals: [approvalCard] }) }
-      }
-      if (url === '/api/admin/agents/risk-compliance/drill' && init?.method === 'POST') {
-        return {
-          ok: true,
-          json: async () => ({
-            ok: true,
-            work_item: {
-              id: 'work-moremi-drill',
-              title: 'Review AI risk signal: Synthetic Moremi drill: prompt injection risk in browser automation',
-              objective: 'Assess synthetic prompt injection risk.',
-              status: 'proposed',
-              priority: 'urgent',
-              owner_agent_key: 'risk-compliance-intelligence',
-              owner_runtime: 'manual',
-              source_type: 'ai_risk_signal',
-              source_id: 'moremi-operational-drill-prompt-injection-browser-automation',
-              source_label: 'Synthetic Agent Ops drill',
-              source_run_id: null,
-              active_run_id: 'run-moremi-drill',
-              parent_work_item_id: null,
-              branch_name: null,
-              worktree_path: null,
-              pr_number: null,
-              pr_url: null,
-              expected_files: [],
-              touched_files: [],
-              overlap_group: 'ai-risk-compliance',
-              dependency_ids: [],
-              blocker_summary: null,
-              validation_summary: null,
-              approval_id: null,
-              metadata: {},
-              idempotency_key: 'ai-risk-drill:moremi-operational-drill:v1',
-              created_at: '2026-05-11T12:02:00.000Z',
-              updated_at: '2026-05-11T12:02:00.000Z',
-              completed_at: null,
-            },
-            assessment: {
-              classification: 'approval_required',
-              severity: 'high',
-              recommendedNextAction: 'Create an approval-routed risk packet before any remediation work begins.',
-            },
-            verification: {
-              admin_path: '/admin/agents/coordination',
-              slack_command: '/agent work',
-              expected_status: 'proposed',
-            },
-          }),
-        }
-      }
-      if (url.startsWith('/api/admin/agents/work-items')) {
-        return { ok: true, json: async () => ({ work_items: [] }) }
-      }
-      if (url === '/api/admin/agents/runs/run-1/approval' && init?.method === 'POST') {
-        return { ok: true, json: async () => ({ ok: true, approval_id: 'approval-1' }) }
-      }
-      return { ok: false, status: 404, json: async () => ({ error: 'not found' }) }
-    }))
+    setupFetch()
   })
 
   afterEach(() => {
     vi.unstubAllGlobals()
   })
 
+  it('renders the Decision Queue hierarchy with action-required cards and trace language', async () => {
+    render(<AgentCoordinationPage />)
+
+    expect(await screen.findByRole('heading', { name: 'Decision Queue Controller' })).toBeInTheDocument()
+    expect(screen.getByText('Action required')).toBeInTheDocument()
+    expect(screen.getAllByText('Executive summary').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Controller recommendation').length).toBeGreaterThan(0)
+    expect(screen.getByText('Approve validation after checking the trace and PR evidence.')).toBeInTheDocument()
+    expect(screen.getByText('risk: medium')).toBeInTheDocument()
+    expect(screen.getAllByText('Trace').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Owner').length).toBeGreaterThan(0)
+  })
+
   it('shows pending Vercel AutoResearch approvals inline and approves from the card', async () => {
     render(<AgentCoordinationPage />)
 
-    expect(await screen.findByText('Vercel AutoResearch approvals')).toBeInTheDocument()
+    expect(await screen.findByText('Vercel AutoResearch approvals decision queue')).toBeInTheDocument()
     expect(screen.getAllByText('Profile the Next.js build path').length).toBeGreaterThan(0)
     expect(screen.getByText('Approve a read-only/local build-profile experiment?')).toBeInTheDocument()
     expect(screen.getByText('Slack notified')).toBeInTheDocument()
@@ -152,10 +236,74 @@ describe('AgentCoordinationPage Vercel AutoResearch approvals', () => {
 
     expect(await screen.findByText('Drill created or reused')).toBeInTheDocument()
     expect(screen.getByText('/agent work')).toBeInTheDocument()
+    expect(screen.getByText('Create an approval-routed risk packet before any remediation work begins.')).toBeInTheDocument()
     expect(fetch).toHaveBeenCalledWith('/api/admin/agents/risk-compliance/drill', expect.objectContaining({
       method: 'POST',
       headers: expect.objectContaining({ Authorization: 'Bearer admin-token' }),
       body: expect.stringContaining('run_moremi_operational_drill'),
     }))
+  })
+
+  it('creates a controller work item with expected files and owner runtime', async () => {
+    render(<AgentCoordinationPage />)
+
+    await screen.findByText('Create controller work item')
+    fireEvent.change(screen.getByPlaceholderText('Work item title'), { target: { value: 'Prepare controller decision packet' } })
+    fireEvent.change(screen.getByPlaceholderText('owner agent key'), { target: { value: 'integration-captain' } })
+    fireEvent.change(screen.getByLabelText('owner runtime'), { target: { value: 'hermes' } })
+    fireEvent.change(screen.getByPlaceholderText('branch name'), { target: { value: 'codex/controller-decision' } })
+    fireEvent.change(screen.getByPlaceholderText('Objective and acceptance criteria'), { target: { value: 'Route one decision through the controller.' } })
+    fireEvent.change(screen.getByPlaceholderText('worktree path'), { target: { value: '/tmp/controller' } })
+    fireEvent.change(screen.getByPlaceholderText('expected files, one per line'), { target: { value: 'app/admin/agents/coordination/page.tsx\napp/admin/agents/coordination/page.test.tsx' } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create work item' }))
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/admin/agents/work-items', expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('"owner_runtime":"hermes"'),
+      }))
+    })
+    expect(fetch).toHaveBeenCalledWith('/api/admin/agents/work-items', expect.objectContaining({
+      body: expect.stringContaining('app/admin/agents/coordination/page.test.tsx'),
+    }))
+  })
+
+  it('filters by status without changing the route or API shape', async () => {
+    render(<AgentCoordinationPage />)
+
+    expect(await screen.findByText('Approve agent run recovery request')).toBeInTheDocument()
+    const filters = screen.getByLabelText('Status filters')
+    fireEvent.click(within(filters).getByRole('button', { name: 'blocked' }))
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/admin/agents/work-items?status=blocked', expect.any(Object))
+    })
+    expect(await screen.findByText('Unblock Moremi drill handoff')).toBeInTheDocument()
+  })
+
+  it('runs quick actions for block, validation, and handoff from executable controls', async () => {
+    render(<AgentCoordinationPage />)
+
+    await screen.findByText('Approve agent run recovery request')
+    fireEvent.click(screen.getByRole('button', { name: 'Block Approve agent run recovery request' }))
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith('/api/admin/agents/work-items/work-queue-1/block', expect.objectContaining({ method: 'POST' })))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Record validation for Approve agent run recovery request' }))
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith('/api/admin/agents/work-items/work-queue-1/validation', expect.objectContaining({ method: 'POST' })))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Handoff Approve agent run recovery request' }))
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith('/api/admin/agents/work-items/work-queue-1/handoff', expect.objectContaining({ method: 'POST' })))
+  })
+
+  it('shows the failed fetch state when the work-item queue is unavailable', async () => {
+    vi.unstubAllGlobals()
+    setupFetch({ failWorkItems: true })
+
+    render(<AgentCoordinationPage />)
+
+    expect(await screen.findByText('Coordination layer unavailable')).toBeInTheDocument()
+    expect(screen.getByText('work item service unavailable')).toBeInTheDocument()
+    expect(screen.getByText('No agent coordination work items match the current filter.')).toBeInTheDocument()
   })
 })

--- a/app/admin/agents/coordination/page.tsx
+++ b/app/admin/agents/coordination/page.tsx
@@ -12,6 +12,7 @@ import {
   Network,
   RefreshCw,
   ShieldCheck,
+  ShieldAlert,
   XCircle,
 } from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
@@ -23,6 +24,7 @@ import type { VercelResearchProposal } from '@/lib/vercel-deployment-research'
 
 const STATUSES: Array<'all' | AgentWorkItemStatus> = [
   'all',
+  'proposed',
   'queued',
   'assigned',
   'in_progress',
@@ -290,12 +292,12 @@ function AgentCoordinationContent() {
         <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div>
             <div className="mb-2 inline-flex items-center gap-2 text-sm text-radiant-gold">
-              <Network size={16} />
-              Agent Coordination Substrate
+              <ShieldAlert size={16} />
+              Agent Ops controller
             </div>
-            <h1 className="text-3xl font-bold">Agent Coordination</h1>
+            <h1 className="text-3xl font-bold">Decision Queue Controller</h1>
             <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
-              Durable work packets, handoffs, blockers, PR links, and approval-gated merge/deploy states across Codex, n8n, Hermes, OpenCode, and manual operators.
+              Executive queue for action-required work, approval decisions, controller recommendations, risk posture, ownership, status, and trace links across Codex, n8n, Hermes, OpenCode, and manual operators.
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
@@ -318,7 +320,7 @@ function AgentCoordinationContent() {
         </div>
 
         <div className="mb-6 grid grid-cols-2 gap-3 md:grid-cols-4">
-          <Metric label="Active" value={summary.active} />
+          <Metric label="Action required" value={summary.active} />
           <Metric label="Blocked" value={summary.blocked} tone={summary.blocked ? 'red' : 'slate'} />
           <Metric label="Review queue" value={summary.review} tone={summary.review ? 'yellow' : 'slate'} />
           <Metric label="Approval-linked" value={summary.approvals} tone={summary.approvals ? 'green' : 'slate'} />
@@ -337,7 +339,12 @@ function AgentCoordinationContent() {
         />
 
         <section className="mb-6 rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
-          <div className="mb-4 flex flex-wrap gap-2">
+          <div className="mb-4 flex flex-col gap-3">
+            <div>
+              <h2 className="text-base font-semibold">Queue filters</h2>
+              <p className="mt-1 text-sm text-muted-foreground">Filter controller decisions by status without changing the route or work-item APIs.</p>
+            </div>
+            <div className="flex flex-wrap gap-2" aria-label="Status filters">
             {STATUSES.map((item) => (
               <button
                 key={item}
@@ -351,9 +358,14 @@ function AgentCoordinationContent() {
                 {item.replace(/_/g, ' ')}
               </button>
             ))}
+            </div>
           </div>
 
-          <form onSubmit={createWorkItem} className="grid gap-3 lg:grid-cols-3">
+          <form onSubmit={createWorkItem} className="grid gap-3 border-t border-silicon-slate/60 pt-4 lg:grid-cols-3">
+            <div className="lg:col-span-3">
+              <h2 className="text-base font-semibold">Create controller work item</h2>
+              <p className="mt-1 text-sm text-muted-foreground">Open a decision packet with owner, objective, expected files, branch, and worktree context.</p>
+            </div>
             <input
               value={form.title}
               onChange={(event) => setForm((prev) => ({ ...prev, title: event.target.value }))}
@@ -366,6 +378,17 @@ function AgentCoordinationContent() {
               placeholder="owner agent key"
               className="rounded-lg border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm"
             />
+            <select
+              value={form.owner_runtime}
+              onChange={(event) => setForm((prev) => ({ ...prev, owner_runtime: event.target.value as AgentRuntime }))}
+              aria-label="owner runtime"
+              className="rounded-lg border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm"
+            >
+              <option value="codex">codex</option>
+              <option value="n8n">n8n</option>
+              <option value="hermes">hermes</option>
+              <option value="manual">manual</option>
+            </select>
             <input
               value={form.branch_name}
               onChange={(event) => setForm((prev) => ({ ...prev, branch_name: event.target.value }))}
@@ -384,6 +407,13 @@ function AgentCoordinationContent() {
                 value={form.worktree_path}
                 onChange={(event) => setForm((prev) => ({ ...prev, worktree_path: event.target.value }))}
                 placeholder="worktree path"
+                className="rounded-lg border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm"
+              />
+              <textarea
+                value={form.expected_files}
+                onChange={(event) => setForm((prev) => ({ ...prev, expected_files: event.target.value }))}
+                placeholder="expected files, one per line"
+                rows={2}
                 className="rounded-lg border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm"
               />
               <button
@@ -438,9 +468,9 @@ function MoremiOperationalDrillPanel({
         <div>
           <div className="mb-2 flex items-center gap-2 text-sm text-green-100">
             <ShieldCheck size={18} />
-            Moremi operational drill
+            Moremi controller drill
           </div>
-          <h2 className="font-semibold">Synthetic AI risk signal to Agent Ops work item</h2>
+          <h2 className="font-semibold">Moremi operational drill</h2>
           <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
             Creates or reuses one proposed, synthetic Moremi work item. This validates the Agent Coordination and Slack visibility path without production remediation, external sends, or client-data access.
           </p>
@@ -459,6 +489,7 @@ function MoremiOperationalDrillPanel({
         <div className="mt-4 grid gap-3 lg:grid-cols-3">
           <SmallField label="Work item" value={result.work_item.title} />
           <SmallField label="Status" value={result.work_item.status} />
+          <SmallField label="Recommendation" value={result.assessment.recommendedNextAction} />
           <SmallField label="Slack check" value={result.verification.slack_command} />
           <div className="rounded-lg border border-green-500/20 bg-background/40 p-3 text-sm lg:col-span-3">
             <p className="font-medium text-green-100">Drill created or reused</p>
@@ -487,8 +518,8 @@ function VercelResearchApprovalPanel({
         <div className="flex items-center gap-2">
           <BellRing size={18} className="text-yellow-200" />
           <div>
-            <h2 className="font-semibold text-yellow-100">Vercel AutoResearch approvals</h2>
-            <p className="text-sm text-muted-foreground">Event-driven proposal gates ready for one-click review.</p>
+            <h2 className="font-semibold text-yellow-100">Vercel AutoResearch approvals decision queue</h2>
+            <p className="text-sm text-muted-foreground">Approval cards ready for controller review, recommendation, risk check, and trace follow-up.</p>
           </div>
         </div>
         <span className="rounded-full border border-yellow-500/30 px-2 py-1 text-xs text-yellow-100">
@@ -518,10 +549,19 @@ function VercelResearchApprovalPanel({
                 ) : null}
               </div>
               <h3 className="font-semibold">{card.proposal.title}</h3>
-              <p className="mt-2 text-sm text-muted-foreground">{card.proposal.approvalQuestion}</p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                <span className="font-medium text-yellow-100">Action required: </span>
+                {card.proposal.approvalQuestion}
+              </p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                <span className="font-medium text-foreground">Recommendation: </span>
+                {card.proposal.hypothesis}
+              </p>
               <div className="mt-3 grid gap-2 text-xs text-muted-foreground sm:grid-cols-2">
                 <SmallField label="Work item" value={card.workItem?.title ?? card.workItemId} />
+                <SmallField label="Status" value={card.workItem?.status ?? card.status} />
                 <SmallField label="Requested" value={new Date(card.requestedAt).toLocaleString()} />
+                <SmallField label="Trace" value={card.runId} />
               </div>
               <div className="mt-4 flex flex-wrap gap-2">
                 <button
@@ -565,6 +605,15 @@ function WorkItemCard({
   actionId: string | null
   onAction: (item: AgentWorkItem, action: 'block' | 'validation' | 'handoff') => void
 }) {
+  const recommendation = typeof item.metadata?.recommendation === 'string'
+    ? item.metadata.recommendation
+    : item.validation_summary || 'Review owner packet, trace evidence, and next gate before changing status.'
+  const risk = typeof item.metadata?.risk === 'string'
+    ? item.metadata.risk
+    : item.approval_id
+      ? 'approval linked'
+      : item.priority
+
   return (
     <article className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
@@ -579,13 +628,23 @@ function WorkItemCard({
                 {item.owner_agent_key}
               </span>
             ) : null}
+            <span className="rounded-full border border-radiant-gold/30 bg-radiant-gold/10 px-2 py-1 text-xs text-radiant-gold">
+              risk: {risk}
+            </span>
           </div>
-          <h2 className="text-lg font-semibold">{item.title}</h2>
+          <p className="text-xs uppercase tracking-wide text-muted-foreground/70">Executive summary</p>
+          <h2 className="mt-1 text-lg font-semibold">{item.title}</h2>
           <p className="mt-1 max-w-4xl text-sm text-muted-foreground">{item.objective}</p>
+          <div className="mt-3 rounded-lg border border-radiant-gold/20 bg-radiant-gold/5 p-3 text-sm">
+            <p className="font-medium text-radiant-gold">Controller recommendation</p>
+            <p className="mt-1 text-muted-foreground">{recommendation}</p>
+          </div>
           <div className="mt-3 grid gap-2 text-xs text-muted-foreground md:grid-cols-2 xl:grid-cols-4">
+            <SmallField label="Owner" value={item.owner_agent_key} />
+            <SmallField label="Status" value={item.status} />
             <SmallField label="Branch" value={item.branch_name} />
             <SmallField label="Worktree" value={item.worktree_path} />
-            <SmallField label="Overlap" value={item.overlap_group} />
+            <SmallField label="Trace" value={item.active_run_id} />
             <SmallField label="Updated" value={new Date(item.updated_at).toLocaleString()} />
           </div>
           {item.blocker_summary || item.validation_summary ? (
@@ -595,7 +654,7 @@ function WorkItemCard({
             </div>
           ) : null}
         </div>
-        <div className="flex flex-wrap gap-2 lg:justify-end">
+        <div className="flex flex-wrap gap-2 lg:min-w-64 lg:justify-end">
           {item.pr_url ? (
             <Link
               href={item.pr_url}
@@ -617,22 +676,28 @@ function WorkItemCard({
           <button
             onClick={() => onAction(item, 'block')}
             disabled={Boolean(actionId)}
-            className="rounded-lg border border-silicon-slate/70 px-3 py-2 text-sm hover:border-red-400/60 disabled:opacity-50"
+            aria-label={`Block ${item.title}`}
+            className="inline-flex items-center gap-2 rounded-lg border border-red-500/45 bg-red-500/10 px-3 py-2 text-sm text-red-100 shadow-sm hover:bg-red-500/15 disabled:opacity-50"
           >
+            <AlertTriangle size={16} />
             Block
           </button>
           <button
             onClick={() => onAction(item, 'validation')}
             disabled={Boolean(actionId)}
-            className="rounded-lg border border-silicon-slate/70 px-3 py-2 text-sm hover:border-yellow-400/60 disabled:opacity-50"
+            aria-label={`Record validation for ${item.title}`}
+            className="inline-flex items-center gap-2 rounded-lg border border-yellow-500/45 bg-yellow-500/10 px-3 py-2 text-sm text-yellow-100 shadow-sm hover:bg-yellow-500/15 disabled:opacity-50"
           >
+            <CheckCircle2 size={16} />
             Validate
           </button>
           <button
             onClick={() => onAction(item, 'handoff')}
             disabled={Boolean(actionId)}
-            className="rounded-lg border border-silicon-slate/70 px-3 py-2 text-sm hover:border-radiant-gold/60 disabled:opacity-50"
+            aria-label={`Handoff ${item.title}`}
+            className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/50 bg-radiant-gold/10 px-3 py-2 text-sm text-radiant-gold shadow-sm hover:bg-radiant-gold/15 disabled:opacity-50"
           >
+            <Network size={16} />
             Handoff
           </button>
         </div>

--- a/app/admin/agents/page.test.tsx
+++ b/app/admin/agents/page.test.tsx
@@ -1,0 +1,269 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import AgentOperationsPage from './page'
+
+vi.mock('@/components/ProtectedRoute', () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('@/components/admin/Breadcrumbs', () => ({
+  default: () => null,
+}))
+
+vi.mock('@/lib/auth', () => ({
+  getCurrentSession: vi.fn(async () => ({ access_token: 'admin-token' })),
+}))
+
+const missionSnapshot = {
+  generated_at: '2026-05-13T12:00:00.000Z',
+  status_strip: {
+    active: 4,
+    queued: 2,
+    running: 1,
+    waiting_for_approval: 3,
+    failed: 0,
+    stale: 0,
+    cost_today: 1.2345,
+    pending_approvals: 3,
+  },
+  roster: [
+    {
+      key: 'command',
+      name: 'Command',
+      purpose: 'Coordinate agent work.',
+      agents: [
+        {
+          key: 'chief-of-staff',
+          name: 'Shaka',
+          pod: 'Command',
+          status: 'active',
+          runtime: 'portfolio',
+          responsibility: 'Chief of Staff for agent operations.',
+          active_workflow_count: 2,
+          latest_run: {
+            id: 'run-shaka',
+            agent_key: 'chief-of-staff',
+            runtime: 'portfolio',
+            kind: 'standup',
+            title: 'Latest Shaka standup',
+            status: 'completed',
+            subject_label: null,
+            current_step: null,
+            error_message: null,
+            started_at: '2026-05-13T11:45:00.000Z',
+            completed_at: '2026-05-13T11:50:00.000Z',
+            cost_total: 0,
+          },
+        },
+        {
+          key: 'automation-systems',
+          name: 'Amina',
+          pod: 'Automation',
+          status: 'active',
+          runtime: 'n8n',
+          responsibility: 'Keeps automation lanes moving.',
+          active_workflow_count: 1,
+          latest_run: null,
+        },
+      ],
+    },
+  ],
+  attention_queue: [],
+  active_runs: [],
+  latest_events: [
+    {
+      run_id: 'run-shaka',
+      event_type: 'standup.completed',
+      severity: 'info',
+      message: 'Standup finished.',
+      occurred_at: '2026-05-13T11:50:00.000Z',
+    },
+  ],
+  latest_standup: null,
+  daily_brief: {
+    headline: 'Agent Ops is steady',
+    synthesis: 'Decision queue is visible and the Kanban lanes are ready for review.',
+    generated_from: 'current_state',
+    run_id: null,
+    updated_at: '2026-05-13T12:00:00.000Z',
+    signals: ['1 running run', '3 pending approvals'],
+    next_actions: ['Review the decision queue.', 'Open Kanban for lane ownership.'],
+  },
+  cost_summary: {
+    window_hours: 24,
+    total: 0,
+    event_count: 0,
+    linked_event_count: 0,
+    unlinked_event_count: 0,
+    by_runtime: [],
+    by_agent: [],
+    by_workflow: [],
+    by_client_project: [],
+    by_artifact_type: [],
+  },
+  quality_summary: {
+    window_hours: 24,
+    generated_at: '2026-05-13T12:00:00.000Z',
+    rubric_count: 1,
+    evaluation_count: 0,
+    average_score: null,
+    pass_rate: null,
+    by_agent: [],
+    needs_coaching: [],
+    rubric_trends: [],
+  },
+  operating_signals: [],
+  knowledge_governance: null,
+  agent_inbox: [
+    {
+      id: 'chief-of-staff:standup',
+      priority: 'medium',
+      agent_key: 'chief-of-staff',
+      agent_name: 'Shaka',
+      pod: 'Command',
+      title: 'Run the daily standup',
+      reason: 'Keep the operating brief fresh.',
+      action_label: 'Run standup',
+      href: '/admin/agents',
+      source_run_id: null,
+    },
+  ],
+  engagement_queue: [],
+  dead_letter_queue: [],
+}
+
+const moremiReview = {
+  has_monitor: true,
+  run: {
+    id: 'moremi-run',
+    status: 'completed',
+    overall: 'clean',
+    generated_at: '2026-05-13T12:00:00.000Z',
+    completed_at: '2026-05-13T12:00:00.000Z',
+    href: '/admin/agents/runs/moremi-run',
+  },
+  warnings: [],
+  warning_count: 0,
+  enabled_source_feed_count: 2,
+  disabled_source_feed_count: 0,
+  safety_boundary: 'read_only',
+  linked_work_items: [],
+}
+
+describe('AgentOperationsPage mission control landing', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url === '/api/admin/agents/mission-control') {
+        return { ok: true, json: async () => missionSnapshot }
+      }
+      if (url === '/api/admin/agents/risk-compliance/monitor?review=latest') {
+        return { ok: true, json: async () => ({ review: moremiReview }) }
+      }
+      if (url === '/api/admin/agents/chief-of-staff/chat' && init?.method === 'POST') {
+        return {
+          ok: true,
+          json: async () => ({
+            run_id: 'shaka-chat-run',
+            reply: 'Review approvals first, then clear the Kanban blockers.',
+            suggested_actions: ['Open coordination', 'Open Kanban'],
+            agent_engagements: [],
+          }),
+        }
+      }
+      if (url === '/api/admin/agents/war-room' && init?.method === 'POST') {
+        return {
+          ok: true,
+          json: async () => ({
+            run_id: 'standup-run',
+            command: 'standup',
+            synthesis: 'Standup complete.',
+            updates: [
+              {
+                agent_key: 'chief-of-staff',
+                agent_name: 'Shaka',
+                pod: 'Command',
+                runtime: 'portfolio',
+                status: 'completed',
+                update: 'Decision queue is ready.',
+                next_action: 'Review pending approvals.',
+                approval_gate: 'required',
+              },
+            ],
+          }),
+        }
+      }
+      return { ok: false, status: 404, json: async () => ({ error: 'not found' }) }
+    }))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('loads the mission control landing with primary actions and status hierarchy', async () => {
+    render(<AgentOperationsPage />)
+
+    expect(await screen.findByRole('heading', { name: 'Agent Ops Mission Control' })).toBeInTheDocument()
+
+    const actionBar = screen.getByLabelText('Mission Control actions')
+    expect(within(actionBar).getByRole('button', { name: /Refresh/i })).toBeInTheDocument()
+    expect(within(actionBar).getByRole('link', { name: /Open Kanban/i })).toHaveAttribute('href', '/admin/agents/swarm-board')
+    expect(within(actionBar).getByRole('link', { name: /Open controller/i })).toHaveAttribute('href', '/admin/agents/coordination')
+    expect(within(actionBar).getByRole('link', { name: /Run Console/i })).toHaveAttribute('href', '/admin/agents/runs')
+    expect(within(actionBar).getByRole('button', { name: /Run standup/i })).toBeInTheDocument()
+
+    const statusBlocks = screen.getByLabelText('Mission Control status blocks')
+    expect(within(statusBlocks).getByRole('link', { name: /Decision Queue/i })).toHaveAttribute('href', '/admin/agents/coordination')
+    expect(within(statusBlocks).getByRole('link', { name: /Kanban/i })).toHaveAttribute('href', '/admin/agents/swarm-board')
+    expect(within(statusBlocks).getByLabelText('Agents roster status')).toHaveTextContent('2')
+    expect(within(statusBlocks).getByLabelText('Health / read-only status')).toHaveTextContent('Read-only healthy')
+
+    expect(screen.getByRole('heading', { name: 'Ask Shaka' })).toBeInTheDocument()
+    expect(screen.getByRole('textbox', { name: 'Ask Shaka' })).toBeInTheDocument()
+    expect(screen.getByText('Daily Operating Brief')).toBeInTheDocument()
+
+    expect(within(statusBlocks).queryByRole('button', { name: /Status only/i })).not.toBeInTheDocument()
+    expect(within(statusBlocks).getByText('Status only')).toHaveAttribute('data-status-only', 'true')
+    expect(within(statusBlocks).getByText('No mutation')).toHaveAttribute('data-status-only', 'true')
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/admin/agents/mission-control', expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer admin-token' }),
+      }))
+    })
+  })
+
+  it('posts inline Ask Shaka messages through the existing Chief of Staff chat endpoint', async () => {
+    render(<AgentOperationsPage />)
+
+    const input = await screen.findByRole('textbox', { name: 'Ask Shaka' })
+    fireEvent.change(input, { target: { value: 'What needs attention?' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Ask' }))
+
+    expect(await screen.findByText('Review approvals first, then clear the Kanban blockers.')).toBeInTheDocument()
+    expect(screen.getAllByText('Shaka').length).toBeGreaterThan(0)
+
+    expect(fetch).toHaveBeenCalledWith('/api/admin/agents/chief-of-staff/chat', expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({ Authorization: 'Bearer admin-token' }),
+      body: JSON.stringify({ message: 'What needs attention?' }),
+    }))
+  })
+
+  it('runs the top-bar standup through the war-room POST action', async () => {
+    render(<AgentOperationsPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /Run standup/i }))
+
+    expect(await screen.findByText('Standup complete.')).toBeInTheDocument()
+    expect(screen.getByText('War Room Standup')).toBeInTheDocument()
+
+    expect(fetch).toHaveBeenCalledWith('/api/admin/agents/war-room', expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({ Authorization: 'Bearer admin-token' }),
+      body: JSON.stringify({ command: 'standup', message: '' }),
+    }))
+  })
+})

--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -538,23 +538,28 @@ export default function AgentOperationsPage() {
     () => snapshot?.roster.flatMap((pod) => pod.agents).filter((agent) => agent.status !== 'planned').slice(0, 10) ?? [],
     [snapshot],
   )
+  const rosterCount = snapshot?.roster.flatMap((pod) => pod.agents).filter((agent) => agent.status !== 'planned').length ?? 0
+  const decisionQueueCount = snapshot?.status_strip.pending_approvals ?? snapshot?.status_strip.waiting_for_approval ?? 0
+  const kanbanSignalCount = (snapshot?.status_strip.running ?? 0) + (snapshot?.status_strip.queued ?? 0)
+  const healthLabel = (snapshot?.status_strip.failed ?? 0) || (snapshot?.status_strip.stale ?? 0) ? 'Needs review' : 'Read-only healthy'
 
   return (
     <ProtectedRoute requireAdmin>
-      <div className="min-h-screen bg-background text-foreground p-5 lg:p-7">
+      <div className="min-h-screen bg-[#06080d] p-5 text-foreground lg:p-7">
         <div className="max-w-7xl mx-auto">
           <Breadcrumbs items={[{ label: 'Admin Dashboard', href: '/admin' }, { label: 'Agent Operations' }]} />
 
-          <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="flex flex-col gap-4 rounded-xl border border-silicon-slate/70 bg-silicon-slate/15 p-5 shadow-2xl shadow-black/30 lg:flex-row lg:items-start lg:justify-between">
             <div>
-              <p className="text-xs font-semibold uppercase tracking-wider text-radiant-gold">Mission Control</p>
-              <h1 className="mt-1 text-3xl font-bold">Agent Operations</h1>
+              <p className="text-xs font-semibold uppercase tracking-wider text-radiant-gold">Mission Control Landing</p>
+              <h1 className="mt-1 text-3xl font-bold">Agent Ops Mission Control</h1>
               <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
-                One command surface for agent status, standups, blockers, and traceable engagement across Codex, n8n, Hermes, OpenCode, and manual work.
+                Command the agent operating layer from one landing page: decisions, Kanban work, roster health, read-only status, standups, and Shaka guidance.
               </p>
             </div>
-            <div className="flex flex-wrap gap-2">
+            <div className="flex flex-wrap gap-2" aria-label="Mission Control actions">
               <button
+                type="button"
                 onClick={refreshMissionControl}
                 disabled={loading || moremiReviewLoading}
                 className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 bg-background/60 px-3 py-2 text-sm hover:border-radiant-gold/60 disabled:opacity-60"
@@ -562,14 +567,27 @@ export default function AgentOperationsPage() {
                 <RefreshCw size={16} className={loading || moremiReviewLoading ? 'animate-spin' : ''} />
                 Refresh
               </button>
-              <Link href="/admin/agents/runs" className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/50 bg-radiant-gold/10 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15">
-                <Activity size={16} />
-                Runs
-              </Link>
-              <Link href="/admin/agents/swarm-board" className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 bg-background/60 px-3 py-2 text-sm hover:border-radiant-gold/60">
+              <Link href="/admin/agents/swarm-board" className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/50 bg-radiant-gold/10 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15">
                 <Columns size={16} />
-                Swarm Board
+                Open Kanban
               </Link>
+              <Link href="/admin/agents/coordination" className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 bg-background/60 px-3 py-2 text-sm hover:border-radiant-gold/60">
+                <ShieldCheck size={16} />
+                Open controller
+              </Link>
+              <Link href="/admin/agents/runs" className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 bg-background/60 px-3 py-2 text-sm hover:border-radiant-gold/60">
+                <Activity size={16} />
+                Run Console
+              </Link>
+              <button
+                type="button"
+                onClick={() => runWarRoom('standup')}
+                disabled={warRoomLoading !== null}
+                className="inline-flex items-center gap-2 rounded-lg border border-emerald-400/40 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-100 hover:bg-emerald-500/15 disabled:opacity-60"
+              >
+                {warRoomLoading === 'standup' ? <RefreshCw size={16} className="animate-spin" /> : <Sparkles size={16} />}
+                Run standup
+              </button>
             </div>
           </div>
 
@@ -579,41 +597,60 @@ export default function AgentOperationsPage() {
             </div>
           ) : null}
 
-          <section className="mt-5 grid grid-cols-2 gap-3 lg:grid-cols-7">
-            <MetricCard icon={<Radio size={16} />} label="Active" value={snapshot?.status_strip.active ?? 0} />
-            <MetricCard icon={<Clock3 size={16} />} label="Running" value={snapshot?.status_strip.running ?? 0} />
-            <MetricCard icon={<ShieldCheck size={16} />} label="Approvals" value={snapshot?.status_strip.pending_approvals ?? 0} />
-            <MetricCard icon={<AlertTriangle size={16} />} label="Failed" value={snapshot?.status_strip.failed ?? 0} tone="red" />
-            <MetricCard icon={<AlertTriangle size={16} />} label="Stale" value={snapshot?.status_strip.stale ?? 0} tone="yellow" />
-            <MetricCard icon={<CircleDollarSign size={16} />} label="Cost today" value={`$${(snapshot?.status_strip.cost_today ?? 0).toFixed(4)}`} />
-            <MetricCard icon={<Users size={16} />} label="Agents" value={topAgents.length} />
+          <section className="mt-5 grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4" aria-label="Mission Control status blocks">
+            <MissionStatusCard
+              as="link"
+              href="/admin/agents/coordination"
+              icon={<ShieldCheck size={18} />}
+              label="Decision Queue"
+              value={decisionQueueCount}
+              detail="Approval-gated coordination"
+              status={decisionQueueCount ? 'Needs decision' : 'Clear'}
+              tone={decisionQueueCount ? 'yellow' : 'green'}
+            />
+            <MissionStatusCard
+              as="link"
+              href="/admin/agents/swarm-board"
+              icon={<Columns size={18} />}
+              label="Kanban"
+              value={kanbanSignalCount}
+              detail="Queued and running lanes"
+              status="Open board"
+              tone="blue"
+            />
+            <MissionStatusCard
+              icon={<Users size={18} />}
+              label="Agents roster"
+              value={rosterCount}
+              detail={`${snapshot?.roster.length ?? 0} operating pod(s)`}
+              status="Status only"
+              tone="neutral"
+            />
+            <MissionStatusCard
+              icon={<Radio size={18} />}
+              label="Health / read-only"
+              value={healthLabel}
+              detail={`${snapshot?.status_strip.failed ?? 0} failed, ${snapshot?.status_strip.stale ?? 0} stale`}
+              status="No mutation"
+              tone={healthLabel === 'Read-only healthy' ? 'green' : 'red'}
+            />
           </section>
-
-          <DailyBriefPanel brief={snapshot?.daily_brief ?? null} loading={loading} />
-          <CostSummaryPanel summary={snapshot?.cost_summary ?? null} />
-          <QualitySignalsPanel summary={snapshot?.quality_summary ?? null} />
-          <OperatingSignalsPanel signals={snapshot?.operating_signals ?? []} />
-          <MoremiReviewPanel
-            review={moremiReview}
-            loading={moremiReviewLoading}
-            confirm={moremiReviewConfirm}
-            actionLoading={actionLoading === 'moremi-review'}
-            onCreate={createMoremiWarningWorkItems}
-            onCancel={() => setMoremiReviewConfirm(false)}
-          />
-          <KnowledgeGovernancePanel governance={snapshot?.knowledge_governance ?? null} />
 
           <section className="mt-5 grid grid-cols-1 gap-5 xl:grid-cols-[1.2fr_0.8fr]">
             <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/25 p-4">
               <div className="flex items-center gap-2 text-radiant-gold">
                 <MessageSquare size={18} />
-                <h2 className="font-semibold">Chief of Staff Command</h2>
+                <h2 className="font-semibold">Ask Shaka</h2>
               </div>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Inline Chief of Staff guidance uses the existing chat endpoint. Recommendations stay read-only until routed through the approval gates below.
+              </p>
               <form onSubmit={submitChiefOfStaff} className="mt-3 flex flex-col gap-3 md:flex-row">
                 <input
                   value={command}
                   onChange={(event) => setCommand(event.target.value)}
-                  placeholder="Ask what needs attention, or type a topic for /discuss..."
+                  aria-label="Ask Shaka"
+                  placeholder="Ask Shaka what needs attention, or type a topic for discussion..."
                   className="min-h-[44px] flex-1 rounded-lg border border-silicon-slate/70 bg-background/70 px-3 text-sm outline-none focus:border-radiant-gold/70"
                 />
                 <div className="flex gap-2">
@@ -624,15 +661,6 @@ export default function AgentOperationsPage() {
                   >
                     <Send size={16} />
                     Ask
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => runWarRoom('standup')}
-                    disabled={warRoomLoading !== null}
-                    className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 bg-background/60 px-3 py-2 text-sm hover:border-radiant-gold/60 disabled:opacity-60"
-                  >
-                    <Sparkles size={16} />
-                    Standup
                   </button>
                   <button
                     type="button"
@@ -649,7 +677,7 @@ export default function AgentOperationsPage() {
               {chiefReply ? (
                 <>
                   <ResultPanel
-                    title="Chief of Staff"
+                    title="Shaka"
                     href={`/admin/agents/runs/${chiefReply.run_id}`}
                     body={chiefReply.reply}
                     items={chiefReply.suggested_actions}
@@ -696,6 +724,31 @@ export default function AgentOperationsPage() {
               </div>
             </div>
           </section>
+
+          <DailyBriefPanel brief={snapshot?.daily_brief ?? null} loading={loading} />
+
+          <section className="mt-5 grid grid-cols-2 gap-3 lg:grid-cols-7">
+            <MetricCard icon={<Radio size={16} />} label="Active" value={snapshot?.status_strip.active ?? 0} />
+            <MetricCard icon={<Clock3 size={16} />} label="Running" value={snapshot?.status_strip.running ?? 0} />
+            <MetricCard icon={<ShieldCheck size={16} />} label="Approvals" value={snapshot?.status_strip.pending_approvals ?? 0} />
+            <MetricCard icon={<AlertTriangle size={16} />} label="Failed" value={snapshot?.status_strip.failed ?? 0} tone="red" />
+            <MetricCard icon={<AlertTriangle size={16} />} label="Stale" value={snapshot?.status_strip.stale ?? 0} tone="yellow" />
+            <MetricCard icon={<CircleDollarSign size={16} />} label="Cost today" value={`$${(snapshot?.status_strip.cost_today ?? 0).toFixed(4)}`} />
+            <MetricCard icon={<Users size={16} />} label="Agents" value={rosterCount} />
+          </section>
+
+          <CostSummaryPanel summary={snapshot?.cost_summary ?? null} />
+          <QualitySignalsPanel summary={snapshot?.quality_summary ?? null} />
+          <OperatingSignalsPanel signals={snapshot?.operating_signals ?? []} />
+          <MoremiReviewPanel
+            review={moremiReview}
+            loading={moremiReviewLoading}
+            confirm={moremiReviewConfirm}
+            actionLoading={actionLoading === 'moremi-review'}
+            onCreate={createMoremiWarningWorkItems}
+            onCancel={() => setMoremiReviewConfirm(false)}
+          />
+          <KnowledgeGovernancePanel governance={snapshot?.knowledge_governance ?? null} />
 
           <EngagementQueuePanel items={snapshot?.engagement_queue ?? []} />
 
@@ -745,7 +798,7 @@ export default function AgentOperationsPage() {
               <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2 xl:grid-cols-1">
                 <ControlLink href="/admin/agents/chief-of-staff" label="Chief of Staff Chat" />
                 <ControlLink href="/admin/agents/runs" label="Run Console" />
-                <ControlLink href="/admin/agents/swarm-board" label="Client Swarm Board" />
+                <ControlLink href="/admin/agents/swarm-board" label="Agent Kanban" />
                 <ControlLink href="/admin/agents/automations" label="Automation Context" />
                 <ActionButton label="Morning review" loading={actionLoading === 'morning-review'} onClick={() => runOperatorAction('morning-review')} />
                 <ActionButton label="Hermes health" loading={actionLoading === 'hermes'} onClick={() => runOperatorAction('hermes')} />
@@ -795,6 +848,70 @@ function MetricCard({ icon, label, value, tone = 'default' }: { icon: ReactNode;
       </div>
       <p className={`mt-2 text-2xl font-semibold ${toneClass}`}>{value}</p>
     </div>
+  )
+}
+
+function MissionStatusCard({
+  as = 'status',
+  href,
+  icon,
+  label,
+  value,
+  detail,
+  status,
+  tone,
+}: {
+  as?: 'link' | 'status'
+  href?: string
+  icon: ReactNode
+  label: string
+  value: string | number
+  detail: string
+  status: string
+  tone: 'green' | 'yellow' | 'red' | 'blue' | 'neutral'
+}) {
+  const content = (
+    <>
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2 text-radiant-gold">
+          {icon}
+          <p className="text-xs font-semibold uppercase tracking-wider">{label}</p>
+        </div>
+        <StatusOnlyPill tone={tone}>{status}</StatusOnlyPill>
+      </div>
+      <p className="mt-4 text-2xl font-semibold">{value}</p>
+      <p className="mt-1 text-sm text-muted-foreground">{detail}</p>
+    </>
+  )
+
+  if (as === 'link' && href) {
+    return (
+      <Link href={href} className="block rounded-lg border border-silicon-slate/60 bg-silicon-slate/20 p-4 hover:border-radiant-gold/50">
+        {content}
+      </Link>
+    )
+  }
+
+  return (
+    <div className="rounded-lg border border-silicon-slate/60 bg-silicon-slate/20 p-4" aria-label={`${label} status`}>
+      {content}
+    </div>
+  )
+}
+
+function StatusOnlyPill({ children, tone }: { children: ReactNode; tone: 'green' | 'yellow' | 'red' | 'blue' | 'neutral' }) {
+  const toneClass = {
+    green: 'border-emerald-400/40 bg-emerald-500/10 text-emerald-200',
+    yellow: 'border-yellow-400/40 bg-yellow-500/10 text-yellow-100',
+    red: 'border-red-400/40 bg-red-500/10 text-red-200',
+    blue: 'border-sky-400/40 bg-sky-500/10 text-sky-200',
+    neutral: 'border-silicon-slate/60 bg-black/20 text-muted-foreground',
+  }[tone]
+
+  return (
+    <span className={`shrink-0 rounded-full border px-2.5 py-1 text-xs font-medium ${toneClass}`} data-status-only="true">
+      {children}
+    </span>
   )
 }
 

--- a/app/admin/agents/swarm-board/page.test.tsx
+++ b/app/admin/agents/swarm-board/page.test.tsx
@@ -1,0 +1,185 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import AgentSwarmBoardPage from './page'
+
+vi.mock('@/components/ProtectedRoute', () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('@/components/admin/Breadcrumbs', () => ({
+  default: () => null,
+}))
+
+vi.mock('@/lib/auth', () => ({
+  getCurrentSession: vi.fn(async () => ({ access_token: 'admin-token' })),
+}))
+
+const longLaneLabel = 'Operations lane with an unusually long ownership label that should wrap cleanly inside the board column'
+const longTaskTitle = 'Coordinate the cross-runtime agent handoff with a very long implementation label that remains readable'
+
+const boardSnapshot = {
+  ok: true,
+  generated_at: '2026-05-13T12:00:00.000Z',
+  summary: {
+    clients: 0,
+    active: 0,
+    failed_or_stale: 0,
+    pending_approvals: 0,
+    isolation_failures: 0,
+    autonomous_ready: 0,
+  },
+  columns: [],
+  organization: {
+    generated_at: '2026-05-13T12:00:00.000Z',
+    summary: {
+      agents: 2,
+      live_agents: 1,
+      active_work_items: 1,
+      unassigned_work_items: 0,
+      blocked_work_items: 1,
+      ready_for_merge: 0,
+      pending_approvals: 0,
+      activity_entries: 1,
+    },
+    lanes: [
+      {
+        key: 'operations',
+        label: longLaneLabel,
+        agentKey: 'automation-systems',
+        agentName: 'Amina - Automation Systems',
+        status: 'live',
+        tasks: [
+          {
+            id: 'work-1',
+            title: longTaskTitle,
+            objective: 'Keep Agent Ops work moving through a visible lane.',
+            status: 'blocked',
+            priority: 'high',
+            ownerAgentKey: 'automation-systems',
+            ownerAgentName: 'Amina - Automation Systems',
+            ownerRuntime: 'codex',
+            branchName: 'codex/agent-ops-redesign',
+            worktreePath: '/Users/vambahsillah/Projects/Portfolio.worktrees/agent-ops-redesign',
+            prNumber: 203,
+            prUrl: 'https://github.com/example/portfolio/pull/203',
+            activeRunId: 'run-1',
+            blockerSummary: 'Waiting on staging smoke confirmation.',
+            validationSummary: 'Focused route tests passed.',
+            overlapGroup: 'agent-ops-redesign',
+            updatedAt: '2026-05-13T11:50:00.000Z',
+          },
+        ],
+      },
+      {
+        key: 'empty',
+        label: 'Empty validation lane',
+        agentKey: null,
+        agentName: 'Unassigned',
+        status: 'idle',
+        tasks: [],
+      },
+    ],
+    agents: [
+      {
+        key: 'automation-systems',
+        name: 'Amina - Automation Systems',
+        podKey: 'operations',
+        podName: 'Operations Pod',
+        status: 'active',
+        runtime: 'codex',
+        live: true,
+        todayTurns: 4,
+        latestAction: 'Updated a work item.',
+        latestRunId: 'run-1',
+      },
+    ],
+    activity: [
+      {
+        id: 'activity-1',
+        occurredAt: '2026-05-13T11:55:00.000Z',
+        agentKey: 'automation-systems',
+        agentName: 'Amina - Automation Systems',
+        podKey: 'operations',
+        action: 'work_item.updated',
+        summary: 'Moved a blocked item into review.',
+        runId: 'run-1',
+        severity: 'info',
+      },
+    ],
+    warRoom: {
+      roster: [],
+      commands: ['/agent work'],
+      suggestedPrompt: 'Ask for blockers.',
+    },
+  },
+}
+
+describe('AgentSwarmBoardPage', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => boardSnapshot,
+    })))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('defaults to the Agent Kanban work-lane view', async () => {
+    render(<AgentSwarmBoardPage />)
+
+    expect(await screen.findByRole('heading', { name: 'Agent Kanban' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Agent Org Board' })).toBeInTheDocument()
+    expect(screen.getByText(/Work-lane Kanban organized by agent ownership/i)).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Kanban lanes' })).toHaveAttribute('aria-selected', 'true')
+    expect(fetch).toHaveBeenCalledWith('/api/admin/agents/swarm-board', expect.objectContaining({
+      headers: expect.objectContaining({ Authorization: 'Bearer admin-token' }),
+    }))
+  })
+
+  it('renders lanes and explicit card affordances', async () => {
+    render(<AgentSwarmBoardPage />)
+
+    expect(await screen.findByRole('region', { name: `${longLaneLabel} lane` })).toBeInTheDocument()
+    expect(screen.getByRole('region', { name: 'Empty validation lane lane' })).toBeInTheDocument()
+    expect(screen.getByText(longTaskTitle)).toBeInTheDocument()
+    expect(screen.getAllByText('Trace').length).toBeGreaterThan(0)
+    expect(screen.getByText('Owner')).toBeInTheDocument()
+    expect(screen.getByText('Blocker:')).toBeInTheDocument()
+    expect(screen.getByText('Validation:')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: `Open pull request 203 for ${longTaskTitle}` })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: `Open trace run-1 for ${longTaskTitle}` })).toHaveAttribute('href', '/admin/agents/runs/run-1')
+  })
+
+  it('switches secondary modes as board views', async () => {
+    render(<AgentSwarmBoardPage />)
+
+    expect(await screen.findByRole('tab', { name: 'Activity board' })).toHaveAttribute('aria-selected', 'false')
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Activity board' }))
+
+    expect(await screen.findByRole('heading', { name: 'Hive Mind' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Activity board' })).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByRole('tab', { name: 'Kanban lanes' })).toHaveAttribute('aria-selected', 'false')
+  })
+
+  it('shows empty lane copy when no tasks are active', async () => {
+    render(<AgentSwarmBoardPage />)
+
+    expect(await screen.findByText('No active tasks in this lane')).toBeInTheDocument()
+  })
+
+  it('keeps long lane and card labels accessible without truncation-only styling', async () => {
+    render(<AgentSwarmBoardPage />)
+
+    const laneLabel = await screen.findByTitle(longLaneLabel)
+    const cardTitle = screen.getByTitle(longTaskTitle)
+
+    expect(laneLabel).toHaveTextContent(longLaneLabel)
+    expect(laneLabel).toHaveClass('break-words')
+    expect(cardTitle).toHaveTextContent(longTaskTitle)
+    expect(cardTitle).toHaveClass('break-words')
+  })
+})

--- a/app/admin/agents/swarm-board/page.tsx
+++ b/app/admin/agents/swarm-board/page.tsx
@@ -33,14 +33,14 @@ type BoardSnapshot = AgentSwarmBoardSnapshot & {
   organization?: AgentOrgBoardSnapshot
 }
 
-type BoardMode = 'mission' | 'hive' | 'agents' | 'war-room' | 'client-builder'
+type BoardMode = 'kanban' | 'hive' | 'agents' | 'war-room' | 'client-builder'
 
 const MODES: Array<{ key: BoardMode; label: string; icon: typeof LayoutDashboard }> = [
-  { key: 'mission', label: 'Mission Control', icon: LayoutDashboard },
-  { key: 'hive', label: 'Hive Mind', icon: Activity },
-  { key: 'agents', label: 'Agents', icon: Users },
-  { key: 'war-room', label: 'War Room', icon: MessageSquare },
-  { key: 'client-builder', label: 'Client AI Builder', icon: Columns },
+  { key: 'kanban', label: 'Kanban lanes', icon: LayoutDashboard },
+  { key: 'hive', label: 'Activity board', icon: Activity },
+  { key: 'agents', label: 'Agent roster', icon: Users },
+  { key: 'war-room', label: 'War room board', icon: MessageSquare },
+  { key: 'client-builder', label: 'Client builder board', icon: Columns },
 ]
 
 export default function AgentSwarmBoardPage() {
@@ -55,7 +55,7 @@ function AgentSwarmBoardContent() {
   const [snapshot, setSnapshot] = useState<BoardSnapshot | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [mode, setMode] = useState<BoardMode>('mission')
+  const [mode, setMode] = useState<BoardMode>('kanban')
   const [activityFilter, setActivityFilter] = useState('all')
 
   const fetchBoard = useCallback(async () => {
@@ -95,18 +95,18 @@ function AgentSwarmBoardContent() {
         <Breadcrumbs items={[
           { label: 'Admin Dashboard', href: '/admin' },
           { label: 'Agent Operations', href: '/admin/agents' },
-          { label: 'Agent Org Board' },
+          { label: 'Agent Kanban' },
         ]} />
 
         <header className="mb-5 flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
           <div>
             <div className="mb-2 inline-flex items-center gap-2 text-sm text-radiant-gold">
               <Bot size={16} />
-              ATAS AI Agent Organization
+              ATAS Agent Ops drilldown
             </div>
-            <h1 className="text-3xl font-bold">Agent Org Board</h1>
+            <h1 className="text-3xl font-bold">Agent Kanban</h1>
             <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
-              One Portfolio-native command surface for ATAS agent work, shared activity, handoffs, and client AI org builder execution.
+              Agent Org Board work lanes for ownership, blockers, validation, traces, and pull requests across the Portfolio agent team.
             </p>
           </div>
           <div className="flex flex-wrap items-center gap-2">
@@ -135,16 +135,16 @@ function AgentSwarmBoardContent() {
         ) : snapshot && organization ? (
           <div className="grid gap-5 xl:grid-cols-[220px_minmax(0,1fr)]">
             <aside className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/15 p-3">
-              <p className="px-2 pb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Workspace</p>
-              <div className="space-y-1">
+              <p className="px-2 pb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Board views</p>
+              <div className="space-y-1" role="tablist" aria-label="Agent board views">
                 {MODES.map((item) => {
                   const Icon = item.icon
                   return (
                     <button
                       key={item.key}
                       onClick={() => setMode(item.key)}
-                      aria-pressed={mode === item.key}
-                      aria-current={mode === item.key ? 'page' : undefined}
+                      role="tab"
+                      aria-selected={mode === item.key}
                       className={`flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm transition ${
                         mode === item.key
                           ? 'bg-radiant-gold/15 text-radiant-gold'
@@ -157,6 +157,9 @@ function AgentSwarmBoardContent() {
                   )
                 })}
               </div>
+              <p className="mt-3 px-2 text-xs leading-relaxed text-muted-foreground">
+                Kanban lanes are the default work drilldown. Other views summarize the same org snapshot from different board angles.
+              </p>
 
               <div className="mt-5 grid grid-cols-2 gap-2">
                 <RailMetric label="Live" value={organization.summary.live_agents} />
@@ -167,7 +170,7 @@ function AgentSwarmBoardContent() {
             </aside>
 
             <main className="min-w-0">
-              {mode === 'mission' && <MissionBoard organization={organization} />}
+              {mode === 'kanban' && <KanbanBoard organization={organization} />}
               {mode === 'hive' && (
                 <HiveMind
                   organization={organization}
@@ -187,10 +190,21 @@ function AgentSwarmBoardContent() {
   )
 }
 
-function MissionBoard({ organization }: { organization: AgentOrgBoardSnapshot }) {
+function KanbanBoard({ organization }: { organization: AgentOrgBoardSnapshot }) {
   return (
-    <div className="space-y-4">
+    <div className="space-y-4" role="tabpanel" aria-label="Kanban lanes">
       <SummaryStrip organization={organization} />
+      <section className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/15 p-4">
+        <div className="flex flex-col gap-2 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold">Agent Org Board</h2>
+            <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+              Work-lane Kanban organized by agent ownership. Use each card to inspect the trace, PR, owner, blocker, validation, and current status before handoff or merge review.
+            </p>
+          </div>
+          <Badge label="default Kanban view" />
+        </div>
+      </section>
       <div className="grid gap-3 xl:grid-cols-4">
         {organization.lanes.map((lane) => (
           <TaskLane key={lane.key} lane={lane} />
@@ -216,12 +230,12 @@ function SummaryStrip({ organization }: { organization: AgentOrgBoardSnapshot })
 
 function TaskLane({ lane }: { lane: AgentOrgBoardLane }) {
   return (
-    <section className="min-h-[420px] rounded-lg border border-silicon-slate/70 bg-silicon-slate/15">
+    <section className="min-h-[420px] rounded-lg border border-silicon-slate/70 bg-silicon-slate/15" aria-label={`${lane.label} lane`}>
       <div className="border-b border-silicon-slate/60 p-3">
         <div className="flex items-center justify-between gap-3">
           <div className="min-w-0">
-            <h2 className="truncate font-semibold" title={lane.label}>{lane.label}</h2>
-            <p className="mt-1 truncate text-xs text-muted-foreground" title={lane.agentName}>{lane.agentName}</p>
+            <h2 className="break-words font-semibold" title={lane.label}>{lane.label}</h2>
+            <p className="mt-1 break-words text-xs text-muted-foreground" title={lane.agentName}>{lane.agentName}</p>
           </div>
           <span className="rounded-full border border-silicon-slate/70 px-2 py-1 text-xs text-muted-foreground">
             {lane.tasks.length}
@@ -233,7 +247,7 @@ function TaskLane({ lane }: { lane: AgentOrgBoardLane }) {
           lane.tasks.map((task) => <WorkItemCard key={task.id} task={task} />)
         ) : (
           <p className="rounded-lg border border-dashed border-silicon-slate/60 px-3 py-8 text-center text-sm text-muted-foreground">
-            No active tasks
+            No active tasks in this lane
           </p>
         )}
       </div>
@@ -246,22 +260,34 @@ function WorkItemCard({ task }: { task: AgentOrgBoardTask }) {
     <article className="rounded-lg border border-silicon-slate/70 bg-background/70 p-3">
       <div className="mb-2 flex items-start justify-between gap-2">
         <div className="min-w-0">
-          <p className="truncate text-sm font-semibold" title={task.title}>{task.title}</p>
-          <p className="mt-1 text-xs text-muted-foreground">{task.status.replace(/_/g, ' ')}</p>
+          <p className="break-words text-sm font-semibold" title={task.title}>{task.title}</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            <span className="font-medium text-foreground/80">Status:</span> {task.status.replace(/_/g, ' ')}
+          </p>
         </div>
         <span className={`rounded-full px-2 py-1 text-xs ${priorityClass(task.priority)}`}>{task.priority}</span>
       </div>
       {task.objective && <p className="mb-3 line-clamp-2 text-xs text-muted-foreground">{task.objective}</p>}
-      <div className="flex flex-wrap gap-2 text-xs">
+      <dl className="grid gap-2 text-xs">
+        <CardDetail label="Trace" value={task.activeRunId ?? 'No active trace'} />
+        <CardDetail label="Owner" value={task.ownerAgentName} />
+        {task.ownerRuntime && <CardDetail label="Runtime" value={task.ownerRuntime} />}
+        {task.branchName && <CardDetail label="Branch" value={task.branchName} />}
+        {task.overlapGroup && <CardDetail label="Overlap" value={task.overlapGroup} />}
+      </dl>
+      <div className="mt-3 flex flex-wrap gap-2 text-xs">
         {task.branchName && <Badge label={task.branchName} />}
         {task.ownerRuntime && <Badge label={task.ownerRuntime} />}
-        {task.overlapGroup && <Badge label={`overlap: ${task.overlapGroup}`} />}
       </div>
       {task.blockerSummary && (
-        <p className="mt-3 rounded-lg border border-red-500/30 bg-red-500/10 p-2 text-xs text-red-200">{task.blockerSummary}</p>
+        <p className="mt-3 rounded-lg border border-red-500/30 bg-red-500/10 p-2 text-xs text-red-200">
+          <span className="font-semibold">Blocker:</span> {task.blockerSummary}
+        </p>
       )}
       {task.validationSummary && (
-        <p className="mt-3 rounded-lg border border-green-500/30 bg-green-500/10 p-2 text-xs text-green-200">{task.validationSummary}</p>
+        <p className="mt-3 rounded-lg border border-green-500/30 bg-green-500/10 p-2 text-xs text-green-200">
+          <span className="font-semibold">Validation:</span> {task.validationSummary}
+        </p>
       )}
       <div className="mt-3 flex items-center justify-between gap-2 text-xs text-muted-foreground">
         <span>{formatRelative(task.updatedAt)}</span>
@@ -275,10 +301,28 @@ function WorkItemCard({ task }: { task: AgentOrgBoardTask }) {
             PR {task.prNumber}
           </a>
         ) : (
-          <span>No PR</span>
+          <span>PR: none</span>
         )}
+        {task.activeRunId ? (
+          <a
+            href={`/admin/agents/runs/${task.activeRunId}`}
+            aria-label={`Open trace ${task.activeRunId} for ${task.title}`}
+            className="inline-flex items-center gap-1 text-radiant-gold hover:underline"
+          >
+            Trace
+          </a>
+        ) : null}
       </div>
     </article>
+  )
+}
+
+function CardDetail({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="grid grid-cols-[64px_minmax(0,1fr)] gap-2 rounded-lg border border-silicon-slate/60 bg-silicon-slate/10 px-2 py-1.5">
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="min-w-0 break-words text-foreground/85" title={value}>{value}</dd>
+    </div>
   )
 }
 

--- a/lib/agent-swarm-board.ts
+++ b/lib/agent-swarm-board.ts
@@ -116,6 +116,7 @@ export type AgentOrgBoardTask = {
   worktreePath: string | null
   prNumber: number | null
   prUrl: string | null
+  activeRunId: string | null
   blockerSummary: string | null
   validationSummary: string | null
   overlapGroup: string | null
@@ -806,6 +807,7 @@ export function buildAgentOrgBoardSnapshotFromRows(input: AgentOrgBoardBuildInpu
     worktreePath: item.worktree_path,
     prNumber: item.pr_number,
     prUrl: item.pr_url,
+    activeRunId: item.active_run_id,
     blockerSummary: item.blocker_summary,
     validationSummary: item.validation_summary,
     overlapGroup: item.overlap_group,


### PR DESCRIPTION
Summary
- Redesigns Agent Ops Mission Control around clear status blocks, inline Ask Shaka, and explicit Kanban, standup, controller, and run-console entry points.
- Reframes Agent Coordination as the Decision Queue Controller with clearer executive summary, action-required language, recommendation, risk, owner, status, trace, and quick-action affordances.
- Reuses `/admin/agents/swarm-board` as the Agent Kanban / Agent Org Board drilldown with clearer lane/card hierarchy, active-run trace links, and focused page tests.

Validation
- `npm test -- app/admin/agents/page.test.tsx app/admin/agents/coordination/page.test.tsx app/admin/agents/swarm-board/page.test.tsx app/api/admin/agents/mission-control/route.test.ts app/api/admin/agents/work-items/route.test.ts app/api/admin/agents/swarm-board/route.test.ts lib/agent-mission-control.test.ts lib/agent-swarm-board.test.ts`
- `npx tsc --noEmit --pretty false`
- `npm run lint`
- `npm run build`
- Earlier full-suite gate before the review patch: `set -a; source .env.local; set +a; unset SLACK_AGENT_OPS_WEBHOOK_URL; export EMAIL_FROM_NAME=AmaduTown; unset BUSINESS_FROM_NAME; npm test`
- Browser smoke fallback with Playwright confirmed unauthenticated admin routes load and redirect to login for `/admin/agents`, `/admin/agents/coordination`, and `/admin/agents/swarm-board`.

Review Notes
- Review patch added missing Mission Control top-level `Open controller` and `Run Console` actions.
- Review patch changed Kanban task trace display from work-item id text to active-run trace id/link when available.

Integration Notes
- No schema migrations.
- No new backend API in this phase; inline Ask Shaka uses the existing Chief of Staff chat endpoint.
- `/admin/agents/swarm-board` remains the stable Kanban URL.
- No live workflow or customer-data smoke was run.
- Push hook database health check passed before branch push and after the amended review patch push.
- Vercel contexts are not deployment-verified from this worker lane: `Vercel - portfolio` and `Vercel - portfolio-staging` remain captain approval gates.
- Rollback path: revert commit `3733b8e` or close this draft PR before merge.
