### PR TITLE
feat: add scoped shaka context

### DIFF
--- a/app/admin/agents/coordination/page.test.tsx
+++ b/app/admin/agents/coordination/page.test.tsx
@@ -183,6 +183,18 @@ function setupFetch({ failWorkItems = false } = {}) {
       return { ok: true, json: async () => ({ ok: true, approval_id: 'approval-1' }) }
     }
 
+    if (url === '/api/admin/agents/chief-of-staff/chat' && init?.method === 'POST') {
+      return {
+        ok: true,
+        json: async () => ({
+          ok: true,
+          run_id: 'shaka-context-run',
+          reply: 'Shaka says this needs a trace review before approval.',
+          suggested_actions: ['Open evidence', 'Review risk'],
+        }),
+      }
+    }
+
     return { ok: false, status: 404, json: async () => ({ error: 'not found' }) }
   }))
 }
@@ -226,6 +238,23 @@ describe('AgentCoordinationPage decision queue controller', () => {
         body: expect.stringContaining('"status":"approved"'),
       }))
     })
+  })
+
+  it('asks Shaka about a pending approval with scoped context', async () => {
+    render(<AgentCoordinationPage />)
+
+    expect(await screen.findByText('Vercel AutoResearch approvals decision queue')).toBeInTheDocument()
+    const approvalCardElement = screen.getByText('Approve a read-only/local build-profile experiment?').closest('article')
+    expect(approvalCardElement).not.toBeNull()
+
+    fireEvent.click(within(approvalCardElement as HTMLElement).getByRole('button', { name: 'Ask Shaka' }))
+
+    expect(await screen.findByText('Shaka context answer')).toBeInTheDocument()
+    expect(screen.getByText('Shaka says this needs a trace review before approval.')).toBeInTheDocument()
+    expect(fetch).toHaveBeenCalledWith('/api/admin/agents/chief-of-staff/chat', expect.objectContaining({
+      method: 'POST',
+      body: expect.stringContaining('"context_ref":{"type":"approval","id":"approval-1"}'),
+    }))
   })
 
   it('runs the Moremi operational drill and shows the Slack verification command', async () => {
@@ -294,6 +323,19 @@ describe('AgentCoordinationPage decision queue controller', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Handoff Approve agent run recovery request' }))
     await waitFor(() => expect(fetch).toHaveBeenCalledWith('/api/admin/agents/work-items/work-queue-1/handoff', expect.objectContaining({ method: 'POST' })))
+  })
+
+  it('asks Shaka about a work item with scoped context', async () => {
+    render(<AgentCoordinationPage />)
+
+    await screen.findByText('Approve agent run recovery request')
+    fireEvent.click(screen.getByRole('button', { name: 'Ask Shaka about Approve agent run recovery request' }))
+
+    expect(await screen.findByText('Shaka context answer')).toBeInTheDocument()
+    expect(fetch).toHaveBeenCalledWith('/api/admin/agents/chief-of-staff/chat', expect.objectContaining({
+      method: 'POST',
+      body: expect.stringContaining('"context_ref":{"type":"work_item","id":"work-queue-1"}'),
+    }))
   })
 
   it('shows the failed fetch state when the work-item queue is unavailable', async () => {

--- a/app/admin/agents/coordination/page.tsx
+++ b/app/admin/agents/coordination/page.tsx
@@ -9,6 +9,7 @@ import {
   Bot,
   CheckCircle2,
   GitPullRequest,
+  MessageSquare,
   Network,
   RefreshCw,
   ShieldCheck,
@@ -81,6 +82,17 @@ type MoremiOperationalDrillResult = {
   }
 }
 
+type ShakaContextRef = {
+  type: 'work_item' | 'approval'
+  id: string
+}
+
+type ShakaContextReply = {
+  run_id: string
+  reply: string
+  suggested_actions: string[]
+}
+
 const DEFAULT_FORM: WorkItemForm = {
   title: '',
   objective: '',
@@ -109,6 +121,7 @@ function AgentCoordinationContent() {
   const [form, setForm] = useState<WorkItemForm>(DEFAULT_FORM)
   const [vercelResearchApprovals, setVercelResearchApprovals] = useState<VercelResearchApprovalCard[]>([])
   const [moremiDrillResult, setMoremiDrillResult] = useState<MoremiOperationalDrillResult | null>(null)
+  const [shakaReply, setShakaReply] = useState<ShakaContextReply | null>(null)
 
   const authedFetch = useCallback(async (path: string, init: RequestInit = {}) => {
     const session = await getCurrentSession()
@@ -280,6 +293,28 @@ function AgentCoordinationContent() {
     }
   }
 
+  async function askShaka(message: string, contextRef: ShakaContextRef) {
+    setActionId(`shaka:${contextRef.type}:${contextRef.id}`)
+    setShakaReply(null)
+    setError(null)
+    try {
+      const response = await authedFetch('/api/admin/agents/chief-of-staff/chat', {
+        method: 'POST',
+        body: JSON.stringify({
+          message,
+          context_ref: contextRef,
+        }),
+      })
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`)
+      setShakaReply(body)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Shaka context request failed')
+    } finally {
+      setActionId(null)
+    }
+  }
+
   return (
     <div className="min-h-screen bg-background text-foreground p-6 lg:p-8">
       <div className="mx-auto max-w-7xl">
@@ -330,6 +365,10 @@ function AgentCoordinationContent() {
           approvals={vercelResearchApprovals}
           actionId={actionId}
           onDecision={decideVercelResearchApproval}
+          onAskShaka={(card) => askShaka(
+            'Should I approve or reject this approval request? Summarize the recommendation, risk, evidence, and safest next step.',
+            { type: 'approval', id: card.approvalId },
+          )}
         />
 
         <MoremiOperationalDrillPanel
@@ -337,6 +376,8 @@ function AgentCoordinationContent() {
           running={actionId === 'moremi-drill'}
           onRun={runMoremiOperationalDrill}
         />
+
+        {shakaReply ? <ShakaContextResponse reply={shakaReply} /> : null}
 
         <section className="mb-6 rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
           <div className="mb-4 flex flex-col gap-3">
@@ -440,6 +481,10 @@ function AgentCoordinationContent() {
                 item={item}
                 actionId={actionId}
                 onAction={quickAction}
+                onAskShaka={(workItem) => askShaka(
+                  'What action is required on this work item? Summarize the recommendation, risk, evidence, and next approval-safe step.',
+                  { type: 'work_item', id: workItem.id },
+                )}
               />
             ))}
           </div>
@@ -503,14 +548,48 @@ function MoremiOperationalDrillPanel({
   )
 }
 
+function ShakaContextResponse({ reply }: { reply: ShakaContextReply }) {
+  return (
+    <section className="mb-6 rounded-lg border border-radiant-gold/35 bg-radiant-gold/10 p-4">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <div className="flex items-center gap-2 text-radiant-gold">
+            <MessageSquare size={18} />
+            <h2 className="font-semibold">Shaka context answer</h2>
+          </div>
+          <p className="mt-2 whitespace-pre-wrap text-sm text-foreground/90">{reply.reply}</p>
+        </div>
+        <Link
+          href={`/admin/agents/runs/${reply.run_id}`}
+          className="inline-flex shrink-0 items-center gap-2 rounded-lg border border-radiant-gold/50 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15"
+        >
+          Open Shaka trace
+          <ArrowRight size={16} />
+        </Link>
+      </div>
+      {reply.suggested_actions.length ? (
+        <div className="mt-3 flex flex-wrap gap-2">
+          {reply.suggested_actions.map((action) => (
+            <span key={action} className="rounded-full border border-radiant-gold/30 bg-background/40 px-2.5 py-1 text-xs text-radiant-gold">
+              {action}
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  )
+}
+
 function VercelResearchApprovalPanel({
   approvals,
   actionId,
   onDecision,
+  onAskShaka,
 }: {
   approvals: VercelResearchApprovalCard[]
   actionId: string | null
   onDecision: (card: VercelResearchApprovalCard, status: 'approved' | 'rejected') => void
+  onAskShaka: (card: VercelResearchApprovalCard) => void
 }) {
   return (
     <section className="mb-6 rounded-lg border border-yellow-500/30 bg-yellow-500/5 p-4">
@@ -587,6 +666,14 @@ function VercelResearchApprovalPanel({
                   Evidence
                   <ArrowRight size={16} />
                 </Link>
+                <button
+                  onClick={() => onAskShaka(card)}
+                  disabled={Boolean(actionId)}
+                  className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/50 bg-radiant-gold/10 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15 disabled:opacity-50"
+                >
+                  <MessageSquare size={16} />
+                  Ask Shaka
+                </button>
               </div>
             </article>
           ))}
@@ -600,10 +687,12 @@ function WorkItemCard({
   item,
   actionId,
   onAction,
+  onAskShaka,
 }: {
   item: AgentWorkItem
   actionId: string | null
   onAction: (item: AgentWorkItem, action: 'block' | 'validation' | 'handoff') => void
+  onAskShaka: (item: AgentWorkItem) => void
 }) {
   const recommendation = typeof item.metadata?.recommendation === 'string'
     ? item.metadata.recommendation
@@ -673,6 +762,15 @@ function WorkItemCard({
               <ArrowRight size={16} />
             </Link>
           ) : null}
+          <button
+            onClick={() => onAskShaka(item)}
+            disabled={Boolean(actionId)}
+            aria-label={`Ask Shaka about ${item.title}`}
+            className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/50 bg-radiant-gold/10 px-3 py-2 text-sm text-radiant-gold shadow-sm hover:bg-radiant-gold/15 disabled:opacity-50"
+          >
+            <MessageSquare size={16} />
+            Ask Shaka
+          </button>
           <button
             onClick={() => onAction(item, 'block')}
             disabled={Boolean(actionId)}

--- a/app/admin/agents/runs/[runId]/page.test.tsx
+++ b/app/admin/agents/runs/[runId]/page.test.tsx
@@ -1,0 +1,120 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import AgentRunDetailPage from './page'
+
+vi.mock('@/components/ProtectedRoute', () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('@/components/admin/Breadcrumbs', () => ({
+  default: () => null,
+}))
+
+vi.mock('@/lib/auth', () => ({
+  getCurrentSession: vi.fn(async () => ({ access_token: 'admin-token' })),
+}))
+
+const runDetail = {
+  run: {
+    id: 'run-1',
+    title: 'Approval notification trace',
+    kind: 'chief_of_staff_chat',
+    runtime: 'codex',
+    status: 'waiting_for_approval',
+  },
+  steps: [
+    {
+      id: 'step-1',
+      name: 'Collected context',
+      output_summary: 'One pending approval',
+      status: 'completed',
+      started_at: '2026-05-13T12:00:00.000Z',
+    },
+  ],
+  events: [],
+  artifacts: [],
+  approvals: [
+    {
+      id: 'approval-1',
+      approval_type: 'production_config_change',
+      status: 'pending',
+      metadata: {
+        action_payload: {
+          action: 'production_config_change',
+          approval_type: 'production_config_change',
+          risk_level: 'high',
+          executes_action: false,
+          side_effect_boundary: 'Checkpoint only.',
+        },
+      },
+    },
+  ],
+  handoffs: [],
+  costs: [],
+  evaluations: [],
+  cost_total: 0,
+}
+
+function setupFetch() {
+  vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input)
+    if (url === '/api/admin/agents/runs/run-1' && !init?.method) {
+      return { ok: true, json: async () => runDetail }
+    }
+    if (url === '/api/admin/agents/chief-of-staff/chat' && init?.method === 'POST') {
+      return {
+        ok: true,
+        json: async () => ({
+          ok: true,
+          run_id: 'shaka-run-1',
+          reply: 'Shaka says review the approval payload and do not mutate production yet.',
+          suggested_actions: ['Review payload', 'Open evidence'],
+        }),
+      }
+    }
+    if (url === '/api/admin/agents/runs/run-1/approval' && init?.method === 'POST') {
+      return { ok: true, json: async () => ({ ok: true }) }
+    }
+    return { ok: false, status: 404, json: async () => ({ error: 'not found' }) }
+  }))
+}
+
+describe('AgentRunDetailPage scoped Shaka context', () => {
+  beforeEach(() => {
+    setupFetch()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('asks Shaka about the current run trace', async () => {
+    render(<AgentRunDetailPage params={{ runId: 'run-1' }} />)
+
+    expect(await screen.findByRole('heading', { name: 'Approval notification trace' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Ask Shaka about this run' }))
+
+    expect(await screen.findByText('Shaka context answer')).toBeInTheDocument()
+    expect(screen.getByText('Shaka says review the approval payload and do not mutate production yet.')).toBeInTheDocument()
+    expect(fetch).toHaveBeenCalledWith('/api/admin/agents/chief-of-staff/chat', expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({ Authorization: 'Bearer admin-token' }),
+      body: expect.stringContaining('"context_ref":{"type":"run","id":"run-1"}'),
+    }))
+  })
+
+  it('asks Shaka about a pending approval from the run detail approval card', async () => {
+    render(<AgentRunDetailPage params={{ runId: 'run-1' }} />)
+
+    expect(await screen.findByText('production_config_change')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Ask Shaka about approval approval-1' }))
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/admin/agents/chief-of-staff/chat', expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('"context_ref":{"type":"approval","id":"approval-1"}'),
+      }))
+    })
+  })
+})

--- a/app/admin/agents/runs/[runId]/page.tsx
+++ b/app/admin/agents/runs/[runId]/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import type { ReactNode } from 'react'
 import Link from 'next/link'
-import { AlertTriangle, ArrowLeft, Bot, DollarSign, FileText, Gauge, RefreshCw } from 'lucide-react'
+import { AlertTriangle, ArrowLeft, Bot, DollarSign, FileText, Gauge, MessageSquare, RefreshCw } from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
 import { getCurrentSession } from '@/lib/auth'
@@ -20,6 +20,12 @@ type RunDetail = {
   costs: AnyRow[]
   evaluations: AnyRow[]
   cost_total: number
+}
+
+type ShakaContextReply = {
+  run_id: string
+  reply: string
+  suggested_actions: string[]
 }
 
 const RUBRIC_OPTIONS = [
@@ -44,6 +50,8 @@ function AgentRunDetailContent({ runId }: { runId: string }) {
   const [error, setError] = useState<string | null>(null)
   const [rubricKey, setRubricKey] = useState(RUBRIC_OPTIONS[0].key)
   const [evaluating, setEvaluating] = useState(false)
+  const [shakaLoading, setShakaLoading] = useState<string | null>(null)
+  const [shakaReply, setShakaReply] = useState<ShakaContextReply | null>(null)
 
   const fetchDetail = useCallback(async () => {
     setLoading(true)
@@ -123,6 +131,34 @@ function AgentRunDetailContent({ runId }: { runId: string }) {
     }
   }
 
+  async function askShaka(contextRef: { type: 'run' | 'approval'; id: string }, message: string) {
+    setShakaLoading(`${contextRef.type}:${contextRef.id}`)
+    setShakaReply(null)
+    setError(null)
+    try {
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Missing admin session')
+      const res = await fetch('/api/admin/agents/chief-of-staff/chat', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${session.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          message,
+          context_ref: contextRef,
+        }),
+      })
+      const body = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(body.error || `HTTP ${res.status}`)
+      setShakaReply(body)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Shaka context request failed')
+    } finally {
+      setShakaLoading(null)
+    }
+  }
+
   return (
     <div className="min-h-screen bg-background text-foreground p-6 lg:p-8">
       <div className="max-w-6xl mx-auto">
@@ -162,6 +198,18 @@ function AgentRunDetailContent({ runId }: { runId: string }) {
                   ))}
                 </select>
                 <button
+                  onClick={() => askShaka(
+                    { type: 'run', id: runId },
+                    'Summarize this run trace. What failed or needs action, what evidence matters, and what is the safest next step?',
+                  )}
+                  disabled={Boolean(shakaLoading)}
+                  aria-label="Ask Shaka about this run"
+                  className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/50 bg-radiant-gold/10 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15 disabled:opacity-60"
+                >
+                  <MessageSquare size={16} />
+                  {shakaLoading === `run:${runId}` ? 'Asking...' : 'Ask Shaka'}
+                </button>
+                <button
                   onClick={evaluateRun}
                   disabled={evaluating}
                   className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/50 bg-radiant-gold/10 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15 disabled:opacity-60"
@@ -178,6 +226,8 @@ function AgentRunDetailContent({ runId }: { runId: string }) {
                 </button>
               </div>
             </div>
+
+            {shakaReply ? <ShakaContextResponse reply={shakaReply} /> : null}
 
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
               <Metric icon={<Bot size={18} />} label="Runtime" value={String(data.run.runtime ?? '-')} />
@@ -212,6 +262,11 @@ function AgentRunDetailContent({ runId }: { runId: string }) {
                   detailKey="status"
                   empty="No approvals recorded."
                   onDecision={decideApproval}
+                  onAskShaka={(approvalId) => askShaka(
+                    { type: 'approval', id: approvalId },
+                    'Should I approve or reject this approval? Summarize the action required, risk, evidence, and safest next step.',
+                  )}
+                  shakaLoading={shakaLoading}
                 />
               </div>
             </section>
@@ -231,6 +286,37 @@ function Metric({ icon, label, value }: { icon: ReactNode; label: string; value:
       </div>
       <p className="font-semibold">{value}</p>
     </div>
+  )
+}
+
+function ShakaContextResponse({ reply }: { reply: ShakaContextReply }) {
+  return (
+    <section className="mb-6 rounded-lg border border-radiant-gold/35 bg-radiant-gold/10 p-5">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <div className="flex items-center gap-2 text-radiant-gold">
+            <MessageSquare size={18} />
+            <h2 className="font-semibold">Shaka context answer</h2>
+          </div>
+          <p className="mt-2 whitespace-pre-wrap text-sm text-foreground/90">{reply.reply}</p>
+        </div>
+        <Link
+          href={`/admin/agents/runs/${reply.run_id}`}
+          className="inline-flex shrink-0 items-center gap-2 rounded-lg border border-radiant-gold/50 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15"
+        >
+          Open Shaka trace
+        </Link>
+      </div>
+      {reply.suggested_actions.length ? (
+        <div className="mt-3 flex flex-wrap gap-2">
+          {reply.suggested_actions.map((action) => (
+            <span key={action} className="rounded-full border border-radiant-gold/30 bg-background/40 px-2.5 py-1 text-xs text-radiant-gold">
+              {action}
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </section>
   )
 }
 
@@ -315,6 +401,8 @@ function List({
   detailKey,
   empty,
   onDecision,
+  onAskShaka,
+  shakaLoading,
 }: {
   rows: AnyRow[]
   titleKey: string
@@ -322,6 +410,8 @@ function List({
   detailKey: string
   empty: string
   onDecision?: (approvalId: string, status: 'approved' | 'rejected') => void
+  onAskShaka?: (approvalId: string) => void
+  shakaLoading?: string | null
 }) {
   if (rows.length === 0) return <p className="text-sm text-muted-foreground">{empty}</p>
   return (
@@ -336,7 +426,7 @@ function List({
             </pre>
           ) : null}
           {onDecision && row.status === 'pending' && typeof row.id === 'string' ? (
-            <div className="mt-3 flex gap-2">
+            <div className="mt-3 flex flex-wrap gap-2">
               <button
                 onClick={() => onDecision(row.id as string, 'approved')}
                 className="rounded-md border border-green-500/40 bg-green-500/10 px-3 py-1 text-xs text-green-300 hover:bg-green-500/20"
@@ -349,6 +439,17 @@ function List({
               >
                 Reject
               </button>
+              {onAskShaka ? (
+                <button
+                  onClick={() => onAskShaka(row.id as string)}
+                  disabled={shakaLoading === `approval:${String(row.id)}`}
+                  aria-label={`Ask Shaka about approval ${String(row.id)}`}
+                  className="inline-flex items-center gap-1 rounded-md border border-radiant-gold/40 bg-radiant-gold/10 px-3 py-1 text-xs text-radiant-gold hover:bg-radiant-gold/20 disabled:opacity-60"
+                >
+                  <MessageSquare size={13} />
+                  {shakaLoading === `approval:${String(row.id)}` ? 'Asking...' : 'Ask Shaka'}
+                </button>
+              ) : null}
             </div>
           ) : null}
           {row.url ? <a className="text-sm text-radiant-gold hover:underline" href={String(row.url)}>Open</a> : null}

--- a/app/api/admin/agents/chief-of-staff/chat/route.test.ts
+++ b/app/api/admin/agents/chief-of-staff/chat/route.test.ts
@@ -21,6 +21,13 @@ vi.mock('@/lib/chief-of-staff-chat', () => {
 
   return {
     normalizeChiefOfStaffHistory,
+    normalizeChiefOfStaffContextRef: (value: unknown) => {
+      if (!value || typeof value !== 'object') return null
+      const record = value as Record<string, unknown>
+      return (record.type === 'run' || record.type === 'work_item' || record.type === 'approval') && typeof record.id === 'string' && record.id.trim()
+        ? { type: record.type, id: record.id.trim() }
+        : null
+    },
     runChiefOfStaffChat: mocks.runChiefOfStaffChat,
   }
 })
@@ -94,6 +101,17 @@ describe('POST /api/admin/agents/chief-of-staff/chat', () => {
     expect(mocks.runChiefOfStaffChat).not.toHaveBeenCalled()
   })
 
+  it('rejects invalid scoped context references', async () => {
+    const response = await POST(makeRequest({
+      message: 'What should I do here?',
+      context_ref: { type: 'lane', id: 'integration-captain' },
+    }) as never)
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'Invalid context_ref' })
+    expect(mocks.runChiefOfStaffChat).not.toHaveBeenCalled()
+  })
+
   it('runs an observable Chief of Staff chat', async () => {
     const response = await POST(makeRequest({
       message: 'What needs attention?',
@@ -139,6 +157,20 @@ describe('POST /api/admin/agents/chief-of-staff/chat', () => {
       message: 'What needs attention?',
       userId: 'admin-user',
       history: [{ role: 'user', content: 'Earlier question' }],
+      contextRef: null,
+    }))
+  })
+
+  it('passes scoped context references to Shaka', async () => {
+    const response = await POST(makeRequest({
+      message: 'Should I approve this?',
+      context_ref: { type: 'approval', id: 'approval-1' },
+    }) as never)
+
+    expect(response.status).toBe(200)
+    expect(mocks.runChiefOfStaffChat).toHaveBeenCalledWith(expect.objectContaining({
+      message: 'Should I approve this?',
+      contextRef: { type: 'approval', id: 'approval-1' },
     }))
   })
 })

--- a/app/api/admin/agents/chief-of-staff/chat/route.ts
+++ b/app/api/admin/agents/chief-of-staff/chat/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
 import {
   normalizeChiefOfStaffHistory,
+  normalizeChiefOfStaffContextRef,
   runChiefOfStaffChat,
   type ChiefOfStaffChatMessage,
 } from '@/lib/chief-of-staff-chat'
@@ -22,7 +23,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: auth.error }, { status: auth.status })
   }
 
-  let body: { message?: unknown; history?: unknown }
+  let body: { message?: unknown; history?: unknown; context_ref?: unknown }
   try {
     body = await request.json()
   } catch {
@@ -37,12 +38,17 @@ export async function POST(request: NextRequest) {
   const history = Array.isArray(body.history)
     ? normalizeChiefOfStaffHistory(body.history as ChiefOfStaffChatMessage[])
     : []
+  const contextRef = normalizeChiefOfStaffContextRef(body.context_ref)
+  if (body.context_ref !== undefined && !contextRef) {
+    return NextResponse.json({ error: 'Invalid context_ref' }, { status: 400 })
+  }
 
   try {
     const result = await runChiefOfStaffChat({
       message,
       history,
       userId: auth.user.id,
+      contextRef,
     })
 
     return NextResponse.json({

--- a/lib/chief-of-staff-chat.test.ts
+++ b/lib/chief-of-staff-chat.test.ts
@@ -18,9 +18,11 @@ vi.mock('@/lib/supabase', () => ({
 
 import {
   buildChiefOfStaffPrompt,
+  buildChiefOfStaffScopedContextFromRows,
   evaluateChiefOfStaffBudget,
   getChiefOfStaffAgentRoutingCatalog,
   getChiefOfStaffTriggeredByUserId,
+  normalizeChiefOfStaffContextRef,
   normalizeChiefOfStaffHistory,
   parseChiefOfStaffJson,
   summarizeAutomationContext,
@@ -45,6 +47,7 @@ const context: ChiefOfStaffContext = {
   ],
   recentFailures: [],
   pendingApprovals: [],
+  scopedContext: null,
   costEvents24h: {
     count: 2,
     totalUsd: 0.0123,
@@ -114,6 +117,51 @@ describe('Chief of Staff chat helpers', () => {
     expect(getChiefOfStaffTriggeredByUserId(undefined)).toBeNull()
   })
 
+  it('normalizes supported scoped context references', () => {
+    expect(normalizeChiefOfStaffContextRef({ type: 'run', id: ' run-1 ' })).toEqual({ type: 'run', id: 'run-1' })
+    expect(normalizeChiefOfStaffContextRef({ type: 'work_item', id: 'work-1' })).toEqual({ type: 'work_item', id: 'work-1' })
+    expect(normalizeChiefOfStaffContextRef({ type: 'approval', id: 'approval-1' })).toEqual({ type: 'approval', id: 'approval-1' })
+    expect(normalizeChiefOfStaffContextRef({ type: 'lane', id: 'lane-1' })).toBeNull()
+    expect(normalizeChiefOfStaffContextRef({ type: 'run', id: '   ' })).toBeNull()
+  })
+
+  it('builds scoped context packets from work item, run, and approval rows', () => {
+    const scoped = buildChiefOfStaffScopedContextFromRows({
+      ref: { type: 'work_item', id: 'work-1' },
+      workItem: {
+        id: 'work-1',
+        title: 'Approve production Slack agent ops notification',
+        objective: 'Verify approval notification before sending.',
+        status: 'blocked',
+        priority: 'high',
+        owner_agent_key: 'chief-of-staff',
+        owner_runtime: 'codex',
+        active_run_id: 'run-1',
+        approval_id: 'approval-1',
+        metadata: { recommendation: 'Reject until the trace has production evidence.', risk: 'high' },
+      },
+      run: {
+        id: 'run-1',
+        title: 'Approval notification trace',
+        status: 'waiting_for_approval',
+        agent_key: 'chief-of-staff',
+      },
+      approval: {
+        id: 'approval-1',
+        run_id: 'run-1',
+        approval_type: 'production_config_change',
+        status: 'pending',
+      },
+    })
+
+    expect(scoped.available).toBe(true)
+    expect(scoped.actionRequired).toBe(true)
+    expect(scoped.recommendation).toBe('Reject until the trace has production evidence.')
+    expect(scoped.riskStatus).toBe('high')
+    expect(scoped.evidenceLinks).toEqual(['/admin/agents/runs/run-1', '/admin/agents/coordination'])
+    expect(scoped.records.workItem).toMatchObject({ id: 'work-1', active_run_id: 'run-1' })
+  })
+
   it('parses the model JSON contract', () => {
     const result = parseChiefOfStaffJson(JSON.stringify({
       reply: 'Focus on the pending deployment and the approval queue.',
@@ -180,6 +228,32 @@ describe('Chief of Staff chat helpers', () => {
     expect(prompt.userPrompt).toContain('Strategy & Narrative Pod')
     expect(prompt.userPrompt).toContain('Portfolio Credential Rotation Due Report')
     expect(prompt.userPrompt).toContain('What needs attention?')
+  })
+
+  it('prioritizes scoped context instructions in the prompt', () => {
+    const prompt = buildChiefOfStaffPrompt({
+      ...context,
+      scopedContext: buildChiefOfStaffScopedContextFromRows({
+        ref: { type: 'approval', id: 'approval-1' },
+        approval: {
+          id: 'approval-1',
+          run_id: 'run-1',
+          approval_type: 'production_config_change',
+          status: 'pending',
+        },
+        run: {
+          id: 'run-1',
+          title: 'Production config drill',
+          status: 'waiting_for_approval',
+        },
+      }),
+    }, [{ role: 'user', content: 'Should I approve this?' }])
+
+    expect(prompt.systemPrompt).toContain('When scopedContext is present')
+    expect(prompt.systemPrompt).toContain('Do not approve, reject, retry, merge, deploy, or mutate anything yourself')
+    expect(prompt.userPrompt).toContain('scopedContext')
+    expect(prompt.userPrompt).toContain('production_config_change')
+    expect(prompt.userPrompt).toContain('/admin/agents/runs/run-1')
   })
 
   it('evaluates the Chief of Staff LLM budget before dispatch', () => {

--- a/lib/chief-of-staff-chat.ts
+++ b/lib/chief-of-staff-chat.ts
@@ -27,11 +27,17 @@ export type ChiefOfStaffChatMessage = {
   content: string
 }
 
+export type ChiefOfStaffContextRef = {
+  type: 'run' | 'work_item' | 'approval'
+  id: string
+}
+
 export type ChiefOfStaffChatRequest = {
   message: string
   history?: ChiefOfStaffChatMessage[]
   userId?: string
   triggerSource?: string
+  contextRef?: ChiefOfStaffContextRef | null
 }
 
 export type ChiefOfStaffChatResponse = {
@@ -122,6 +128,7 @@ export type ChiefOfStaffContext = {
   activeRuns: AgentRunSummaryRow[]
   recentFailures: AgentRunSummaryRow[]
   pendingApprovals: AgentApprovalSummaryRow[]
+  scopedContext: ChiefOfStaffScopedContext | null
   costEvents24h: {
     count: number
     totalUsd: number
@@ -141,6 +148,20 @@ export type ChiefOfStaffAgentRoutingEntry = {
   engagementPath: string
   approvalGate: string
   activeWorkflowCount: number
+}
+
+export type ChiefOfStaffScopedContext = {
+  ref: ChiefOfStaffContextRef
+  available: boolean
+  label: string
+  summary: string
+  actionRequired: boolean
+  recommendation: string
+  riskStatus: string
+  owner: string | null
+  status: string | null
+  evidenceLinks: string[]
+  records: Record<string, unknown>
 }
 
 const DEFAULT_MODEL = 'gpt-4o-mini'
@@ -215,6 +236,15 @@ export function normalizeChiefOfStaffHistory(
     .slice(-8)
 }
 
+export function normalizeChiefOfStaffContextRef(value: unknown): ChiefOfStaffContextRef | null {
+  if (!value || typeof value !== 'object') return null
+  const record = value as Record<string, unknown>
+  const type = record.type
+  const id = typeof record.id === 'string' ? record.id.trim() : ''
+  if ((type !== 'run' && type !== 'work_item' && type !== 'approval') || !id) return null
+  return { type, id: id.slice(0, 160) }
+}
+
 export function getChiefOfStaffTriggeredByUserId(userId: string | undefined) {
   if (!userId) return null
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(userId)
@@ -224,6 +254,133 @@ export function getChiefOfStaffTriggeredByUserId(userId: string | undefined) {
 
 function isAgentAction(value: unknown): value is AgentAction {
   return typeof value === 'string' && CHIEF_OF_STAFF_ACTIONS.includes(value as AgentAction)
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
+}
+
+function compactValue(value: unknown): unknown {
+  if (typeof value === 'string') return value.length > 900 ? `${value.slice(0, 900)}...` : value
+  if (Array.isArray(value)) return value.slice(0, 8).map(compactValue)
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .slice(0, 20)
+        .map(([key, item]) => [key, compactValue(item)]),
+    )
+  }
+  return value
+}
+
+function pickCompactRecord(row: unknown, keys: string[]): Record<string, unknown> | null {
+  if (!row || typeof row !== 'object') return null
+  const record = row as Record<string, unknown>
+  return Object.fromEntries(
+    keys
+      .filter((key) => key in record)
+      .map((key) => [key, compactValue(record[key])]),
+  )
+}
+
+function statusRequiresAction(status: unknown) {
+  return typeof status === 'string' && [
+    'pending',
+    'queued',
+    'running',
+    'waiting_for_approval',
+    'failed',
+    'stale',
+    'blocked',
+    'ready_for_review',
+    'ready_for_merge',
+    'proposed',
+  ].includes(status)
+}
+
+function scopedUnavailable(ref: ChiefOfStaffContextRef, label: string): ChiefOfStaffScopedContext {
+  return {
+    ref,
+    available: false,
+    label,
+    summary: 'The requested context was not found or is not available to Shaka.',
+    actionRequired: false,
+    recommendation: 'Refresh the page and confirm the source record still exists before taking action.',
+    riskStatus: 'unknown',
+    owner: null,
+    status: null,
+    evidenceLinks: [],
+    records: {},
+  }
+}
+
+export function buildChiefOfStaffScopedContextFromRows(input: {
+  ref: ChiefOfStaffContextRef
+  run?: Record<string, unknown> | null
+  workItem?: Record<string, unknown> | null
+  approval?: Record<string, unknown> | null
+  steps?: Record<string, unknown>[]
+  events?: Record<string, unknown>[]
+}): ChiefOfStaffScopedContext {
+  const run = input.run ?? null
+  const workItem = input.workItem ?? null
+  const approval = input.approval ?? null
+  const primary = input.ref.type === 'run' ? run : input.ref.type === 'work_item' ? workItem : approval
+  if (!primary) {
+    return scopedUnavailable(input.ref, `${input.ref.type.replace(/_/g, ' ')} ${input.ref.id}`)
+  }
+
+  const status = String(primary.status ?? run?.status ?? workItem?.status ?? approval?.status ?? '')
+  const title = String(primary.title ?? primary.approval_type ?? primary.id ?? input.ref.id)
+  const owner = String(workItem?.owner_agent_key ?? run?.agent_key ?? run?.runtime ?? '') || null
+  const actionRequired = statusRequiresAction(status)
+  const riskStatus = String(
+    asRecord(workItem?.metadata).risk
+      ?? asRecord(approval?.metadata).risk_level
+      ?? asRecord(approval?.metadata).risk
+      ?? (approval ? approval.approval_type : null)
+      ?? (status === 'failed' || status === 'stale' || status === 'blocked' ? 'elevated' : 'normal'),
+  )
+  const recommendation = String(
+    asRecord(workItem?.metadata).recommendation
+      ?? workItem?.validation_summary
+      ?? (approval && approval.status === 'pending' ? 'Review the approval payload, trace evidence, and risk boundary before approving or rejecting.' : null)
+      ?? (run && (run.status === 'failed' || run.status === 'stale') ? 'Inspect the latest events and route recovery through the existing Agent Ops approval path.' : null)
+      ?? 'Summarize the evidence, confirm whether action is required, and keep any mutation behind the existing approval gates.'
+  )
+
+  const evidenceLinks = Array.from(new Set([
+    run?.id ? `/admin/agents/runs/${String(run.id)}` : null,
+    workItem?.id ? '/admin/agents/coordination' : null,
+    approval?.run_id ? `/admin/agents/runs/${String(approval.run_id)}` : null,
+  ].filter((link): link is string => Boolean(link))))
+
+  const summaryParts = [
+    `${input.ref.type.replace(/_/g, ' ')}: ${title}`,
+    status ? `status: ${status}` : null,
+    owner ? `owner: ${owner}` : null,
+    actionRequired ? 'action required' : 'no immediate action indicated',
+  ].filter(Boolean)
+
+  return {
+    ref: input.ref,
+    available: true,
+    label: title,
+    summary: summaryParts.join(' / '),
+    actionRequired,
+    recommendation,
+    riskStatus,
+    owner,
+    status: status || null,
+    evidenceLinks,
+    records: {
+      run: pickCompactRecord(run, ['id', 'agent_key', 'runtime', 'kind', 'title', 'status', 'current_step', 'error_message', 'started_at', 'completed_at', 'outcome', 'metadata']),
+      workItem: pickCompactRecord(workItem, ['id', 'title', 'objective', 'status', 'priority', 'owner_agent_key', 'owner_runtime', 'active_run_id', 'approval_id', 'branch_name', 'pr_url', 'blocker_summary', 'validation_summary', 'metadata', 'updated_at']),
+      approval: pickCompactRecord(approval, ['id', 'run_id', 'approval_type', 'status', 'requested_by', 'requested_at', 'decided_at', 'decision_notes', 'metadata']),
+      latestSteps: (input.steps ?? []).slice(0, 5).map((step) => pickCompactRecord(step, ['id', 'step_key', 'name', 'status', 'output_summary', 'started_at', 'completed_at'])),
+      latestEvents: (input.events ?? []).slice(-5).map((event) => pickCompactRecord(event, ['id', 'event_type', 'severity', 'message', 'occurred_at', 'metadata'])),
+    },
+  }
 }
 
 function parseRiskLevel(value: unknown, requiresApproval: boolean): ChiefOfStaffActionProposal['riskLevel'] {
@@ -452,6 +609,7 @@ export async function collectChiefOfStaffContext(): Promise<ChiefOfStaffContext>
     activeRuns: (activeRes.data ?? []) as AgentRunSummaryRow[],
     recentFailures: (failedRes.data ?? []) as AgentRunSummaryRow[],
     pendingApprovals: (approvalsRes.data ?? []) as AgentApprovalSummaryRow[],
+    scopedContext: null,
     costEvents24h: {
       count: costRows.length,
       totalUsd: Number(totalUsd.toFixed(4)),
@@ -462,6 +620,80 @@ export async function collectChiefOfStaffContext(): Promise<ChiefOfStaffContext>
   }
 }
 
+export async function collectChiefOfStaffScopedContext(
+  contextRef: ChiefOfStaffContextRef | null | undefined,
+): Promise<ChiefOfStaffScopedContext | null> {
+  if (!contextRef) return null
+  const db = assertDatabase()
+
+  if (contextRef.type === 'run') {
+    const runRes = await db.from('agent_runs').select('*').eq('id', contextRef.id).maybeSingle()
+    if (runRes.error) throw new Error(runRes.error.message)
+    if (!runRes.data) return scopedUnavailable(contextRef, `run ${contextRef.id}`)
+
+    const [stepsRes, eventsRes, approvalsRes, workItemsRes] = await Promise.all([
+      db.from('agent_run_steps').select('*').eq('run_id', contextRef.id).order('started_at', { ascending: true }).limit(8),
+      db.from('agent_run_events').select('*').eq('run_id', contextRef.id).order('occurred_at', { ascending: true }).limit(12),
+      db.from('agent_approvals').select('*').eq('run_id', contextRef.id).order('requested_at', { ascending: false }).limit(5),
+      db.from('agent_work_items').select('*').eq('active_run_id', contextRef.id).order('updated_at', { ascending: false }).limit(1),
+    ])
+    for (const result of [stepsRes, eventsRes, approvalsRes, workItemsRes]) {
+      if (result.error) throw new Error(result.error.message)
+    }
+    return buildChiefOfStaffScopedContextFromRows({
+      ref: contextRef,
+      run: runRes.data as Record<string, unknown>,
+      workItem: ((workItemsRes.data ?? [])[0] ?? null) as Record<string, unknown> | null,
+      approval: ((approvalsRes.data ?? [])[0] ?? null) as Record<string, unknown> | null,
+      steps: (stepsRes.data ?? []) as Record<string, unknown>[],
+      events: (eventsRes.data ?? []) as Record<string, unknown>[],
+    })
+  }
+
+  if (contextRef.type === 'work_item') {
+    const workItemRes = await db.from('agent_work_items').select('*').eq('id', contextRef.id).maybeSingle()
+    if (workItemRes.error) throw new Error(workItemRes.error.message)
+    const workItem = (workItemRes.data ?? null) as Record<string, unknown> | null
+    if (!workItem) return scopedUnavailable(contextRef, `work item ${contextRef.id}`)
+
+    const activeRunId = typeof workItem.active_run_id === 'string' ? workItem.active_run_id : null
+    const approvalId = typeof workItem.approval_id === 'string' ? workItem.approval_id : null
+    const [runRes, approvalRes] = await Promise.all([
+      activeRunId ? db.from('agent_runs').select('*').eq('id', activeRunId).maybeSingle() : Promise.resolve({ data: null, error: null }),
+      approvalId ? db.from('agent_approvals').select('*').eq('id', approvalId).maybeSingle() : Promise.resolve({ data: null, error: null }),
+    ])
+    for (const result of [runRes, approvalRes]) {
+      if (result.error) throw new Error(result.error.message)
+    }
+    return buildChiefOfStaffScopedContextFromRows({
+      ref: contextRef,
+      run: (runRes.data ?? null) as Record<string, unknown> | null,
+      workItem,
+      approval: (approvalRes.data ?? null) as Record<string, unknown> | null,
+    })
+  }
+
+  const approvalRes = await db.from('agent_approvals').select('*').eq('id', contextRef.id).maybeSingle()
+  if (approvalRes.error) throw new Error(approvalRes.error.message)
+  const approval = (approvalRes.data ?? null) as Record<string, unknown> | null
+  if (!approval) return scopedUnavailable(contextRef, `approval ${contextRef.id}`)
+
+  const runId = typeof approval.run_id === 'string' ? approval.run_id : null
+  const [runRes, workItemsRes] = await Promise.all([
+    runId ? db.from('agent_runs').select('*').eq('id', runId).maybeSingle() : Promise.resolve({ data: null, error: null }),
+    db.from('agent_work_items').select('*').eq('approval_id', contextRef.id).order('updated_at', { ascending: false }).limit(1),
+  ])
+  for (const result of [runRes, workItemsRes]) {
+    if (result.error) throw new Error(result.error.message)
+  }
+  return buildChiefOfStaffScopedContextFromRows({
+    ref: contextRef,
+    run: (runRes.data ?? null) as Record<string, unknown> | null,
+    workItem: ((workItemsRes.data ?? [])[0] ?? null) as Record<string, unknown> | null,
+    approval,
+  })
+}
+
 export function buildChiefOfStaffPrompt(context: ChiefOfStaffContext, history: ChiefOfStaffChatMessage[]) {
   const agentKeys = context.agentRoutingCatalog.map((agent) => agent.key)
 
@@ -470,6 +702,8 @@ export function buildChiefOfStaffPrompt(context: ChiefOfStaffContext, history: C
       'You are the Shaka (Zulu) - Chief of Staff for Vambah and AmaduTown.',
       'Your job is to translate executive intent into clear priorities, operational status, escalation decisions, and next actions.',
       'Use only the provided operating context. If the user asks for production mutations, sending messages, publishing, or config changes, explain that approval is required and suggest the approval path.',
+      'When scopedContext is present, answer about that specific run, work item, or approval before giving broader operating guidance.',
+      'For scopedContext, clearly state whether action is required, the recommended next step, the risk/status, the owner when known, and the evidence link path. Do not approve, reject, retry, merge, deploy, or mutate anything yourself.',
       'Be concise, direct, and operational. Do not pretend to have run tools that are not in the context.',
       'Automation context is a summarized, read-only inventory. Use it to identify risky automations, missing context, duplicate jobs, and when the Yaa Asantewaa (Ashanti) - Automation Systems should be engaged.',
       'When proposing an executable next step, include a typed action proposal. The proposal is only a recommendation; it does not execute work.',
@@ -518,28 +752,38 @@ export async function runChiefOfStaffChat(input: ChiefOfStaffChatRequest): Promi
   }
 
   const history = normalizeChiefOfStaffHistory(input.history)
+  const contextRef = input.contextRef ?? null
   const run = await startAgentRun({
     agentKey: 'chief-of-staff',
     runtime: 'codex',
     kind: 'chief_of_staff_chat',
     title: 'Chief of Staff chat',
     status: 'running',
-    subject: { type: 'admin_chat', id: input.userId ?? 'admin', label: 'Admin chat' },
+    subject: contextRef
+      ? { type: `admin_chat:${contextRef.type}`, id: contextRef.id, label: `Scoped ${contextRef.type.replace(/_/g, ' ')}` }
+      : { type: 'admin_chat', id: input.userId ?? 'admin', label: 'Admin chat' },
     triggerSource: input.triggerSource ?? 'admin_chief_of_staff_chat',
     triggeredByUserId: getChiefOfStaffTriggeredByUserId(input.userId),
     currentStep: 'Collecting operating context',
-    metadata: { message_preview: message.slice(0, 240) },
+    metadata: { message_preview: message.slice(0, 240), context_ref: contextRef },
   })
 
   try {
-    const context = await collectChiefOfStaffContext()
+    const [context, scopedContext] = await Promise.all([
+      collectChiefOfStaffContext(),
+      collectChiefOfStaffScopedContext(contextRef),
+    ])
+    context.scopedContext = scopedContext
     await recordAgentStep({
       runId: run.id,
       stepKey: 'collect_context',
       name: 'Collected operating context',
       status: 'completed',
       inputSummary: message.slice(0, 500),
-      outputSummary: `${context.activeRuns.length} active, ${context.recentFailures.length} failed/stale, ${context.pendingApprovals.length} approvals`,
+      outputSummary: scopedContext
+        ? `${context.activeRuns.length} active, ${context.recentFailures.length} failed/stale, ${context.pendingApprovals.length} approvals; scoped ${scopedContext.ref.type}: ${scopedContext.label}`
+        : `${context.activeRuns.length} active, ${context.recentFailures.length} failed/stale, ${context.pendingApprovals.length} approvals`,
+      metadata: scopedContext ? { scoped_context: scopedContext } : undefined,
     })
 
     await recordAgentEvent({
@@ -608,6 +852,7 @@ export async function runChiefOfStaffChat(input: ChiefOfStaffChatRequest): Promi
         reference: { type: 'agent', id: 'chief-of-staff' },
         metadata: {
           operation: 'chief_of_staff_chat',
+          context_ref: contextRef,
           budget_status: budgetDecision.status,
           budget_rule_key: budgetDecision.rule.key,
           estimated_cost_usd: budgetDecision.estimatedCostUsd,
@@ -634,6 +879,7 @@ export async function runChiefOfStaffChat(input: ChiefOfStaffChatRequest): Promi
         suggested_actions: parsed.suggestedActions,
         action_proposals: parsed.actionProposals,
         agent_engagements: parsed.agentEngagements,
+        context_ref: contextRef,
       },
     })
 
@@ -651,6 +897,7 @@ export async function runChiefOfStaffChat(input: ChiefOfStaffChatRequest): Promi
         suggested_actions: parsed.suggestedActions,
         action_proposals: parsed.actionProposals,
         agent_engagements: parsed.agentEngagements,
+        context_ref: contextRef,
       },
     })
 


### PR DESCRIPTION
## Summary
- Adds optional `context_ref` support to the Shaka Chief of Staff chat API for run, work item, and approval context.
- Adds context-aware Ask Shaka controls to the Decision Queue and run detail surfaces so users can ask for action required, recommendation, risk/status, owner, and evidence without leaving the workflow.
- Preserves all existing approval gates: Shaka can advise, but cannot approve, reject, retry, merge, deploy, or mutate records.

## Validation
- `npm test -- lib/chief-of-staff-chat.test.ts app/api/admin/agents/chief-of-staff/chat/route.test.ts app/admin/agents/page.test.tsx app/admin/agents/coordination/page.test.tsx app/admin/agents/swarm-board/page.test.tsx 'app/admin/agents/runs/[runId]/page.test.tsx' app/api/admin/agents/mission-control/route.test.ts app/api/admin/agents/work-items/route.test.ts app/api/admin/agents/swarm-board/route.test.ts lib/agent-mission-control.test.ts lib/agent-swarm-board.test.ts`\n- `npm run build:knowledge && npx tsc --noEmit --pretty false`\n- `npm run lint`\n- `npm run worktree:env`\n- `npm run build`\n- Push hook: `scripts/database-health-check.ts` passed against configured production health baseline.\n- No live workflow or customer-data smoke was run.\n\n## Integration Notes\n- No schema migration or environment variable changes.\n- Fresh worktree required `npm run worktree:env` before build to link `.env.local` and `.vercel`.\n- Build emitted existing n8n outbound warnings for the linked local environment; no webhook execution was triggered by this change.\n- Vercel contexts still need post-merge verification: `Vercel – portfolio` and `Vercel – portfolio-staging`.\n- Rollback path: revert commit `e5737b2` or close this draft PR before merge.