### PR TITLE
fix: align agent ops background token

### DIFF
--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -545,7 +545,7 @@ export default function AgentOperationsPage() {
 
   return (
     <ProtectedRoute requireAdmin>
-      <div className="min-h-screen bg-[#06080d] p-5 text-foreground lg:p-7">
+      <div className="min-h-screen bg-background p-5 text-foreground lg:p-7">
         <div className="max-w-7xl mx-auto">
           <Breadcrumbs items={[{ label: 'Admin Dashboard', href: '/admin' }, { label: 'Agent Operations' }]} />
 


### PR DESCRIPTION
## Summary
- Replaces the hardcoded darker Agent Ops Mission Control page background with the shared `bg-background` admin token.
- Keeps the redesigned panels and controls intact while matching the rest of the admin dark-mode surface.

## Validation
- `npm test -- app/admin/agents/page.test.tsx`
- Pre-push database health check passed.
- Local browser verification at `http://localhost:3000/admin/agents`.

## Integration Notes
- CSS-only/token alignment change.
- No API, schema, or environment changes.
- Vercel production/staging verification needed after merge.