### PR TITLE
feat: clarify autoresearch decision framing

### DIFF
--- a/app/admin/agents/coordination/page.test.tsx
+++ b/app/admin/agents/coordination/page.test.tsx
@@ -107,6 +107,22 @@ const approvalCard = {
     approvalQuestion: 'Approve a read-only/local build-profile experiment?',
     rollbackPath: 'Discard the branch.',
     evidence: ['build=3m41s'],
+    decisionFrame: {
+      experiment: 'Local build-profile experiment before hosted deployment changes',
+      objective: 'Identify whether slow deployments are caused by app compilation or generated knowledge.',
+      successMetric: 'Build duration and named bottleneck',
+      target: 'Keep build time under 8m or name the bottleneck.',
+      currentRun: 'portfolio/preview built in 3m41s.',
+      distanceFromGoal: '4m19s inside the build watch goal.',
+      goalStatus: 'on_track',
+      recommendedAction: 'run_another_test',
+      recommendation: 'Run another timing sample or close unless build time crosses the watch threshold again.',
+      decisionOptions: [
+        { action: 'approve', label: 'Approve read-only profile', when: 'Use when build time crosses the target.' },
+        { action: 'run_another_test', label: 'Collect another timing sample', when: 'Use when the latest run is inside target.' },
+        { action: 'close', label: 'Close as healthy', when: 'Use when build timing is inside target.' },
+      ],
+    },
   },
   notification: {
     slackSentAt: '2026-05-11T12:01:00.000Z',
@@ -227,7 +243,9 @@ describe('AgentCoordinationPage decision queue controller', () => {
 
     expect(await screen.findByText('Vercel AutoResearch approvals decision queue')).toBeInTheDocument()
     expect(screen.getAllByText('Profile the Next.js build path').length).toBeGreaterThan(0)
-    expect(screen.getByText('Approve a read-only/local build-profile experiment?')).toBeInTheDocument()
+    expect(screen.getByText('Distance from goal')).toBeInTheDocument()
+    expect(screen.getByText('4m19s inside the build watch goal.')).toBeInTheDocument()
+    expect(screen.getByText('Collect another timing sample')).toBeInTheDocument()
     expect(screen.getByText('Slack notified')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Approve' }))
@@ -245,7 +263,7 @@ describe('AgentCoordinationPage decision queue controller', () => {
     render(<AgentCoordinationPage />)
 
     expect(await screen.findByText('Vercel AutoResearch approvals decision queue')).toBeInTheDocument()
-    const approvalCardElement = screen.getByText('Approve a read-only/local build-profile experiment?').closest('article')
+    const approvalCardElement = screen.getByText('4m19s inside the build watch goal.').closest('article')
     expect(approvalCardElement).not.toBeNull()
 
     fireEvent.click(within(approvalCardElement as HTMLElement).getByRole('button', { name: 'Ask Shaka' }))
@@ -262,7 +280,7 @@ describe('AgentCoordinationPage decision queue controller', () => {
     render(<AgentCoordinationPage />)
 
     expect(await screen.findByText('Vercel AutoResearch approvals decision queue')).toBeInTheDocument()
-    const approvalCardElement = screen.getByText('Approve a read-only/local build-profile experiment?').closest('article')
+    const approvalCardElement = screen.getByText('4m19s inside the build watch goal.').closest('article')
     expect(approvalCardElement).not.toBeNull()
 
     fireEvent.click(within(approvalCardElement as HTMLElement).getByRole('button', { name: 'Ask Shaka' }))

--- a/app/admin/agents/coordination/page.tsx
+++ b/app/admin/agents/coordination/page.tsx
@@ -376,7 +376,7 @@ function AgentCoordinationContent() {
           actionId={actionId}
           onDecision={decideVercelResearchApproval}
           onAskShaka={(card) => askShaka(
-            'Should I approve or reject this approval request? Summarize the recommendation, risk, evidence, and safest next step.',
+            'Should I approve, reject, run another test, or close this approval request? Summarize the experiment, objective, goal, current run, distance from goal, recommendation, risk, evidence, and safest next step.',
             { type: 'approval', id: card.approvalId },
           )}
         />
@@ -643,7 +643,9 @@ function VercelResearchApprovalPanel({
         </p>
       ) : (
         <div className="grid gap-4">
-          {approvals.map((card) => (
+          {approvals.map((card) => {
+            const decision = card.proposal.decisionFrame
+            return (
             <article key={card.approvalId} className="rounded-lg border border-yellow-500/25 bg-background/55 p-5">
               <div className="mb-2 flex flex-wrap items-center gap-2">
                 <span className="rounded-full border border-yellow-500/30 bg-yellow-500/10 px-2 py-1 text-xs text-yellow-100">
@@ -659,11 +661,50 @@ function VercelResearchApprovalPanel({
                 ) : null}
               </div>
               <h3 className="text-xl font-semibold">{card.proposal.title}</h3>
-              <div className="mt-4 grid gap-3 lg:grid-cols-2">
-                <DecisionSummaryBlock label="Action required" value={card.proposal.approvalQuestion} tone="yellow" />
-                <DecisionSummaryBlock label="Controller recommendation" value={card.proposal.hypothesis} />
-                <DecisionSummaryBlock label="Benefits" value={card.proposal.expectedImpact} />
-                <DecisionSummaryBlock label="Rollback path" value={card.proposal.rollbackPath} />
+              <div className="mt-4 grid gap-3">
+                <DecisionSummaryBlock
+                  label="Experiment"
+                  value={decision?.experiment ?? card.proposal.hypothesis}
+                />
+                <DecisionSummaryBlock
+                  label="Objective"
+                  value={decision?.objective ?? card.proposal.expectedImpact}
+                />
+                <div className="grid gap-2 md:grid-cols-2">
+                  <DecisionSummaryBlock
+                    label="Goal"
+                    value={decision?.target ?? 'No explicit goal recorded for this proposal.'}
+                    tone="yellow"
+                  />
+                  <DecisionSummaryBlock
+                    label="Current run"
+                    value={decision?.currentRun ?? card.proposal.evidence.join('; ')}
+                  />
+                  <DecisionSummaryBlock
+                    label="Distance from goal"
+                    value={decision?.distanceFromGoal ?? 'No goal-distance calculation was recorded.'}
+                    tone={decision?.goalStatus === 'blocked' ? 'red' : decision?.goalStatus === 'watch' ? 'yellow' : 'green'}
+                  />
+                  <DecisionSummaryBlock
+                    label="Recommended next step"
+                    value={decision?.recommendation ?? card.proposal.approvalQuestion}
+                    tone="yellow"
+                  />
+                </div>
+              </div>
+              <div className="mt-3 rounded-lg border border-silicon-slate/60 bg-background/40 p-3">
+                <p className="text-xs uppercase tracking-wide text-muted-foreground/70">Decision choices</p>
+                <div className="mt-2 grid gap-2">
+                  {(decision?.decisionOptions ?? [
+                    { label: 'Approve', when: card.proposal.approvalQuestion },
+                    { label: 'Reject', when: 'Use when the evidence is not strong enough or the risk boundary is unclear.' },
+                  ]).map((option) => (
+                    <div key={option.label} className="rounded-md border border-silicon-slate/60 px-3 py-2 text-sm">
+                      <p className="font-medium text-foreground">{option.label}</p>
+                      <p className="text-muted-foreground">{option.when}</p>
+                    </div>
+                  ))}
+                </div>
               </div>
               <div className="mt-3 grid gap-2 text-xs text-muted-foreground sm:grid-cols-2">
                 <SmallField label="Work item" value={card.workItem?.title ?? card.workItemId} />
@@ -705,19 +746,11 @@ function VercelResearchApprovalPanel({
                 </button>
               </div>
             </article>
-          ))}
+            )
+          })}
         </div>
       )}
     </section>
-  )
-}
-
-function DecisionSummaryBlock({ label, value, tone = 'default' }: { label: string; value: string; tone?: 'default' | 'yellow' }) {
-  return (
-    <div className={`rounded-lg border p-3 ${tone === 'yellow' ? 'border-yellow-500/30 bg-yellow-500/10' : 'border-silicon-slate/60 bg-black/10'}`}>
-      <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">{label}</p>
-      <p className="mt-2 text-sm leading-6 text-foreground/90">{value}</p>
-    </div>
   )
 }
 
@@ -869,6 +902,31 @@ function StatusBadge({ status }: { status: string }) {
           ? 'border-green-500/40 bg-green-500/10 text-green-100'
           : 'border-silicon-slate/70 bg-silicon-slate/20 text-muted-foreground'
   return <span className={`rounded-full border px-2 py-1 text-xs ${tone}`}>{status.replace(/_/g, ' ')}</span>
+}
+
+function DecisionSummaryBlock({
+  label,
+  value,
+  tone = 'slate',
+}: {
+  label: string
+  value: string
+  tone?: 'slate' | 'red' | 'yellow' | 'green'
+}) {
+  const toneClass =
+    tone === 'red'
+      ? 'border-red-500/35 bg-red-500/10'
+      : tone === 'yellow'
+        ? 'border-yellow-500/35 bg-yellow-500/10'
+        : tone === 'green'
+          ? 'border-green-500/35 bg-green-500/10'
+          : 'border-silicon-slate/60 bg-background/40'
+  return (
+    <div className={`rounded-lg border p-3 text-sm ${toneClass}`}>
+      <p className="text-xs uppercase tracking-wide text-muted-foreground/70">{label}</p>
+      <p className="mt-1 text-foreground">{value}</p>
+    </div>
+  )
 }
 
 function SmallField({ label, value }: { label: string; value: string | null }) {

--- a/app/admin/agents/runs/[runId]/page.test.tsx
+++ b/app/admin/agents/runs/[runId]/page.test.tsx
@@ -50,6 +50,22 @@ const runDetail = {
           riskLevel: 'high',
           approvalQuestion: 'Approve preparing a Vercel project-setting proposal packet without applying any hosted setting yet?',
           evidence: ['portfolio/production: queue above threshold'],
+          decisionFrame: {
+            experiment: 'Queue-pressure review for staging production deployments',
+            objective: 'Decide whether repeated staging queue time is worth a deeper Vercel settings proposal.',
+            successMetric: 'Deployment queue time',
+            target: 'Stay under the 5m queue watch threshold.',
+            currentRun: 'portfolio-staging/production queued for 9m13s.',
+            distanceFromGoal: '4m13s over the watch goal and 47s under the blocked threshold.',
+            goalStatus: 'watch',
+            recommendedAction: 'approve',
+            recommendation: 'Approve preparing a settings proposal packet only. Do not change Vercel settings yet.',
+            decisionOptions: [
+              { action: 'approve', label: 'Approve proposal packet', when: 'Use when the queue gap is real enough to justify a scoped settings proposal.' },
+              { action: 'run_another_test', label: 'Run another deployment watch', when: 'Use when the signal may be one noisy deployment.' },
+              { action: 'reject', label: 'Reject as not worth pursuing', when: 'Use when the settings lane is too risky.' },
+            ],
+          },
         },
         action_payload: {
           action: 'production_config_change',
@@ -158,10 +174,13 @@ describe('AgentRunDetailPage scoped Shaka context', () => {
     render(<AgentRunDetailPage params={{ runId: 'run-1' }} />)
 
     expect(await screen.findByRole('heading', { name: 'Review Vercel queue pressure before changing project settings' })).toBeInTheDocument()
-    expect(screen.getByText('Problem / opportunity')).toBeInTheDocument()
-    expect(screen.getByText('Benefits')).toBeInTheDocument()
+    expect(screen.getByText('Experiment')).toBeInTheDocument()
+    expect(screen.getByText('Objective')).toBeInTheDocument()
+    expect(screen.getByText('Goal')).toBeInTheDocument()
+    expect(screen.getByText('Distance from goal')).toBeInTheDocument()
+    expect(screen.getByText('4m13s over the watch goal and 47s under the blocked threshold.')).toBeInTheDocument()
     expect(screen.getByText('Drawbacks')).toBeInTheDocument()
-    expect(screen.getByText('Recommendation')).toBeInTheDocument()
+    expect(screen.getByText('Recommended next action')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Approve' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Decline' })).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Ask Shaka about approval approval-1' }))

--- a/app/admin/agents/runs/[runId]/page.tsx
+++ b/app/admin/agents/runs/[runId]/page.tsx
@@ -278,7 +278,7 @@ function AgentRunDetailContent({ runId }: { runId: string }) {
                 onDecision={decideApproval}
                 onAskShaka={(approvalId) => askShaka(
                   { type: 'approval', id: approvalId },
-                  'Should I approve or reject this approval? Summarize the problem or opportunity, benefits, drawbacks, recommendation, evidence, and safest next step.',
+                  'Should I approve, reject, run another test, or close this approval? Summarize the experiment, objective, goal, current run, distance from goal, evidence, risk, and safest next action.',
                 )}
                 shakaLoading={shakaLoading}
               />
@@ -520,10 +520,13 @@ function ApprovalDecisionList({
             </div>
 
             <div className="mt-4 grid grid-cols-1 gap-3 lg:grid-cols-2">
-              <DecisionBlock label="Problem / opportunity" value={summary.problem} />
-              <DecisionBlock label="Benefits" value={summary.benefits} />
+              <DecisionBlock label="Experiment" value={summary.experiment} />
+              <DecisionBlock label="Objective" value={summary.problem} />
+              {summary.goal ? <DecisionBlock label="Goal" value={summary.goal} /> : null}
+              {summary.currentRun ? <DecisionBlock label="Current run" value={summary.currentRun} /> : null}
+              {summary.distanceFromGoal ? <DecisionBlock label="Distance from goal" value={summary.distanceFromGoal} emphasis={summary.goalStatus === 'watch' || summary.goalStatus === 'blocked'} /> : null}
               <DecisionBlock label="Drawbacks" value={summary.drawbacks} />
-              <DecisionBlock label="Recommendation" value={summary.recommendation} emphasis />
+              <DecisionBlock label="Recommended next action" value={summary.benefits} emphasis />
             </div>
 
             {summary.evidence.length ? (
@@ -688,20 +691,24 @@ function approvalExecutiveSummary(row: AnyRow) {
   const evidence = asStringArray(proposal.evidence)
   const touchedSettings = asStringArray(proposal.touchedSettings)
   const touchedFiles = asStringArray(proposal.touchedFiles)
+  const decisionFrame = asRecord(proposal.decisionFrame)
   const approvalQuestion = typeof metadata.approval_question === 'string' ? metadata.approval_question : null
   const executesAction = actionPayload.executes_action === true
   const risk = String(proposal.riskLevel ?? metadata.risk_level ?? metadata.risk ?? actionPayload.risk_level ?? 'not specified')
   const title = String(proposal.title ?? row.approval_type ?? 'Approval checkpoint')
   const action = formatLabel(actionPayload.action, formatLabel(row.approval_type, 'approval checkpoint'))
 
-  const problem = String(
-    proposal.hypothesis
+  const experiment = String(decisionFrame.experiment ?? proposal.title ?? title)
+  const objective = String(
+    decisionFrame.objective
+      ?? proposal.hypothesis
       ?? approvalQuestion
       ?? metadata.problem_statement
       ?? `A human decision is required before ${action}.`,
   )
   const benefits = String(
-    proposal.expectedImpact
+    decisionFrame.recommendation
+      ?? proposal.expectedImpact
       ?? metadata.benefits
       ?? 'Approving lets the agent proceed through the existing gated workflow with a recorded decision.',
   )
@@ -723,12 +730,17 @@ function approvalExecutiveSummary(row: AnyRow) {
   return {
     title,
     actionRequired: `Action required: ${action}.`,
-    problem,
+    problem: objective,
     benefits,
     drawbacks: drawbacksParts.join(' '),
     recommendation,
     risk,
     evidence,
+    experiment,
+    goal: typeof decisionFrame.target === 'string' ? decisionFrame.target : null,
+    currentRun: typeof decisionFrame.currentRun === 'string' ? decisionFrame.currentRun : null,
+    distanceFromGoal: typeof decisionFrame.distanceFromGoal === 'string' ? decisionFrame.distanceFromGoal : null,
+    goalStatus: typeof decisionFrame.goalStatus === 'string' ? decisionFrame.goalStatus : null,
   }
 }
 

--- a/lib/vercel-autoresearch-notification.ts
+++ b/lib/vercel-autoresearch-notification.ts
@@ -22,13 +22,21 @@ export function buildVercelResearchApprovalUrl(input: Pick<VercelResearchApprova
 
 export function buildVercelResearchApprovalSlackText(input: VercelResearchApprovalNotificationInput) {
   const proposal = input.proposal
+  const decision = proposal.decisionFrame
   const url = buildVercelResearchApprovalUrl(input)
   return [
     '*Vercel AutoResearch proposal ready for approval*',
     `*Proposal:* ${proposal.title}`,
     `*Risk:* ${proposal.riskLevel}`,
-    `*Approval:* ${proposal.approvalQuestion}`,
-    `*Expected impact:* ${proposal.expectedImpact}`,
+    ...(decision ? [
+      `*Experiment:* ${decision.experiment}`,
+      `*Objective:* ${decision.objective}`,
+      `*Goal gap:* ${decision.distanceFromGoal}`,
+      `*Recommendation:* ${decision.recommendation}`,
+    ] : [
+      `*Expected impact:* ${proposal.expectedImpact}`,
+    ]),
+    `*Decision needed:* ${proposal.approvalQuestion}`,
     `*Work item:* ${input.workItemId}`,
     `*Approve / reject:* ${url}`,
   ].join('\n')

--- a/lib/vercel-deployment-research-approvals.ts
+++ b/lib/vercel-deployment-research-approvals.ts
@@ -110,14 +110,18 @@ export async function createVercelResearchApproval(input: {
   createdByUserId: string
 }) {
   const proposal = input.proposal
+  const decisionFrame = proposal.decisionFrame
   const workItem = await createAgentWorkItem({
     title: proposal.title,
     objective: [
-      proposal.hypothesis,
-      '',
-      `Expected impact: ${proposal.expectedImpact}`,
+      decisionFrame ? `Experiment: ${decisionFrame.experiment}` : proposal.hypothesis,
+      decisionFrame ? `Objective: ${decisionFrame.objective}` : '',
+      decisionFrame ? `Goal: ${decisionFrame.target}` : '',
+      decisionFrame ? `Current run: ${decisionFrame.currentRun}` : '',
+      decisionFrame ? `Distance from goal: ${decisionFrame.distanceFromGoal}` : '',
+      decisionFrame ? `Recommended action: ${decisionFrame.recommendation}` : `Expected impact: ${proposal.expectedImpact}`,
       `Approval question: ${proposal.approvalQuestion}`,
-    ].join('\n'),
+    ].filter(Boolean).join('\n'),
     priority: proposal.riskLevel === 'high' ? 'high' : 'medium',
     status: 'queued',
     ownerAgentKey: 'integration-captain',
@@ -134,6 +138,12 @@ export async function createVercelResearchApproval(input: {
       proposal,
       approval_type: VERCEL_RESEARCH_APPROVAL_TYPE,
       created_by_user_id: input.createdByUserId,
+      ...(decisionFrame ? {
+        experiment_objective: decisionFrame.objective,
+        goal_status: decisionFrame.goalStatus,
+        distance_from_goal: decisionFrame.distanceFromGoal,
+        recommendation: decisionFrame.recommendation,
+      } : {}),
     },
     idempotencyKey: `vercel-autoresearch:${proposal.id}`,
   })

--- a/lib/vercel-deployment-research.test.ts
+++ b/lib/vercel-deployment-research.test.ts
@@ -33,6 +33,10 @@ describe('buildVercelResearchPlan', () => {
       id: 'next-build-profile',
       riskLevel: 'low',
       approvalState: 'not_required',
+      decisionFrame: {
+        successMetric: 'Build duration and identified bottleneck',
+        goalStatus: 'on_track',
+      },
     })
     expect(plan.operatingRules.join(' ')).toContain('does not execute experiments automatically')
   })
@@ -54,6 +58,10 @@ describe('buildVercelResearchPlan', () => {
       riskLevel: 'high',
       approvalState: 'approval_required',
       touchedSettings: expect.arrayContaining(['Vercel project preview deployment setting']),
+      decisionFrame: {
+        goalStatus: 'blocked',
+        recommendedAction: 'approve',
+      },
     })
   })
 })

--- a/lib/vercel-deployment-research.ts
+++ b/lib/vercel-deployment-research.ts
@@ -13,6 +13,27 @@ export const VERCEL_RESEARCH_APPROVAL_TYPE = 'vercel_deployment_research_proposa
 
 export type VercelResearchRiskLevel = 'low' | 'medium' | 'high'
 export type VercelResearchApprovalState = 'not_required' | 'approval_required'
+export type VercelResearchGoalStatus = 'on_track' | 'watch' | 'blocked' | 'unknown'
+export type VercelResearchDecisionAction = 'approve' | 'reject' | 'run_another_test' | 'close'
+
+export type VercelResearchDecisionOption = {
+  action: VercelResearchDecisionAction
+  label: string
+  when: string
+}
+
+export type VercelResearchDecisionFrame = {
+  experiment: string
+  objective: string
+  successMetric: string
+  target: string
+  currentRun: string
+  distanceFromGoal: string
+  goalStatus: VercelResearchGoalStatus
+  recommendedAction: VercelResearchDecisionAction
+  recommendation: string
+  decisionOptions: VercelResearchDecisionOption[]
+}
 
 export type VercelResearchProposal = {
   id: string
@@ -33,6 +54,7 @@ export type VercelResearchProposal = {
   approvalQuestion: string
   rollbackPath: string
   evidence: string[]
+  decisionFrame?: VercelResearchDecisionFrame
 }
 
 export type VercelResearchPlan = {
@@ -90,6 +112,106 @@ function timingEvidence(metric: DeploymentMetric | null) {
   ]
 }
 
+function queueGoalFrame(metric: DeploymentMetric | null, thresholds: DeploymentMetricThresholds): VercelResearchDecisionFrame {
+  const queue = metric?.queueSeconds ?? null
+  const watchGap = queue === null ? null : queue - thresholds.queueWatchSeconds
+  const blockedGap = queue === null ? null : thresholds.queueBlockedSeconds - queue
+  const overWatch = watchGap !== null && watchGap > 0
+  const overBlocked = blockedGap !== null && blockedGap < 0
+
+  return {
+    experiment: 'Queue-pressure review for staging production deployments',
+    objective: 'Decide whether repeated staging queue time is an operating issue worth a deeper Vercel settings proposal.',
+    successMetric: 'Deployment queue time',
+    target: `Stay under the ${formatSeconds(thresholds.queueWatchSeconds)} queue watch threshold and avoid the ${formatSeconds(thresholds.queueBlockedSeconds)} blocked threshold.`,
+    currentRun: queue === null
+      ? 'No queue timing was available for the current run.'
+      : `${metric?.project ?? 'portfolio-staging'}/${metric?.target ?? 'production'} queued for ${formatSeconds(queue)}.`,
+    distanceFromGoal: queue === null
+      ? 'Unknown until another deployment records queue timing.'
+      : overBlocked
+        ? `${formatSeconds(Math.abs(blockedGap ?? 0))} beyond the blocked threshold.`
+        : overWatch
+          ? `${formatSeconds(watchGap)} over the watch goal and ${formatSeconds(Math.max(blockedGap ?? 0, 0))} under the blocked threshold.`
+          : `${formatSeconds(Math.abs(watchGap ?? 0))} inside the watch goal.`,
+    goalStatus: queue === null ? 'unknown' : overBlocked ? 'blocked' : overWatch ? 'watch' : 'on_track',
+    recommendedAction: overWatch ? 'approve' : 'close',
+    recommendation: overWatch
+      ? 'Approve preparing a settings proposal packet only. Do not change Vercel settings until that separate packet is reviewed.'
+      : 'Close this proposal unless the queue finding repeats in a later deployment cycle.',
+    decisionOptions: [
+      {
+        action: 'approve',
+        label: 'Approve proposal packet',
+        when: 'Use when the queue gap is real enough to justify a scoped settings proposal, without changing settings yet.',
+      },
+      {
+        action: 'run_another_test',
+        label: 'Run another deployment watch',
+        when: 'Use when the signal may be one noisy deployment and you want another timing sample before approval.',
+      },
+      {
+        action: 'reject',
+        label: 'Reject as not worth pursuing',
+        when: 'Use when queue time is acceptable or the proposed settings lane is too risky for the current operating need.',
+      },
+      {
+        action: 'close',
+        label: 'Close as informational',
+        when: 'Use when the run is useful evidence but should not create follow-up work.',
+      },
+    ],
+  }
+}
+
+function buildProfileGoalFrame(metric: DeploymentMetric | null, thresholds: DeploymentMetricThresholds): VercelResearchDecisionFrame {
+  const build = metric?.buildSeconds ?? null
+  const gap = build === null ? null : build - thresholds.buildWatchSeconds
+  const overWatch = gap !== null && gap > 0
+
+  return {
+    experiment: 'Local build-profile experiment before hosted deployment changes',
+    objective: 'Identify whether slow deployments are caused by app compilation, knowledge generation, tests, or asset work before proposing Vercel setting changes.',
+    successMetric: 'Build duration and identified bottleneck',
+    target: `Keep build time under the ${formatSeconds(thresholds.buildWatchSeconds)} build watch threshold or produce a named bottleneck to investigate.`,
+    currentRun: build === null
+      ? 'No build timing was available for the current run.'
+      : `${metric?.project ?? 'portfolio'}/${metric?.target ?? 'preview'} built in ${formatSeconds(build)}.`,
+    distanceFromGoal: build === null
+      ? 'Unknown until another deployment records build timing.'
+      : overWatch
+        ? `${formatSeconds(gap)} over the build watch goal.`
+        : `${formatSeconds(Math.abs(gap ?? 0))} inside the build watch goal.`,
+    goalStatus: build === null ? 'unknown' : overWatch ? 'watch' : 'on_track',
+    recommendedAction: overWatch ? 'approve' : 'run_another_test',
+    recommendation: overWatch
+      ? 'Approve a read-only build profile to isolate the bottleneck before changing hosted settings.'
+      : 'Run another timing sample or close unless build time crosses the watch threshold again.',
+    decisionOptions: [
+      {
+        action: 'approve',
+        label: 'Approve read-only profile',
+        when: 'Use when build time is above target or repeated enough to justify a scoped local profiling branch.',
+      },
+      {
+        action: 'run_another_test',
+        label: 'Collect another timing sample',
+        when: 'Use when the latest run is inside target but you want more evidence before closing.',
+      },
+      {
+        action: 'close',
+        label: 'Close as healthy',
+        when: 'Use when build timing is inside target and no bottleneck needs investigation.',
+      },
+      {
+        action: 'reject',
+        label: 'Reject this approach',
+        when: 'Use when profiling would add noise or the proposed files are not the right investigation surface.',
+      },
+    ],
+  }
+}
+
 function proposal(
   input: Omit<VercelResearchProposal, 'approvalState'>,
 ): VercelResearchProposal {
@@ -120,6 +242,7 @@ export function buildVercelResearchPlan(input: VercelResearchPlanInput): VercelR
       approvalQuestion: 'Approve a read-only/local build-profile experiment that does not change production Vercel configuration?',
       rollbackPath: 'Discard the experiment branch if build timing does not improve or the profile adds noisy instrumentation.',
       evidence: timingEvidence(slowestBuild),
+      decisionFrame: buildProfileGoalFrame(slowestBuild, thresholds),
     }),
   ]
 
@@ -136,6 +259,7 @@ export function buildVercelResearchPlan(input: VercelResearchPlanInput): VercelR
       approvalQuestion: 'Approve preparing a Vercel project-setting proposal packet without applying any hosted setting yet?',
       rollbackPath: 'Leave current Vercel project settings unchanged and continue using deploy:watch plus deploy:metrics.',
       evidence: findings.filter((finding) => finding.reason.includes('queue=')).map((finding) => `${finding.project}/${finding.target}: ${finding.reason}`),
+      decisionFrame: queueGoalFrame(slowestTotal, thresholds),
     }))
   }
 
@@ -188,6 +312,14 @@ export function formatVercelResearchPlanMarkdown(plan: VercelResearchPlan) {
       `- Approval: ${item.approvalState}`,
       `- Hypothesis: ${item.hypothesis}`,
       `- Expected impact: ${item.expectedImpact}`,
+      ...(item.decisionFrame ? [
+        `- Experiment: ${item.decisionFrame.experiment}`,
+        `- Objective: ${item.decisionFrame.objective}`,
+        `- Goal: ${item.decisionFrame.target}`,
+        `- Current run: ${item.decisionFrame.currentRun}`,
+        `- Distance from goal: ${item.decisionFrame.distanceFromGoal}`,
+        `- Recommendation: ${item.decisionFrame.recommendation}`,
+      ] : []),
       `- Approval question: ${item.approvalQuestion}`,
       `- Rollback: ${item.rollbackPath}`,
       `- Evidence: ${item.evidence.join('; ')}`,


### PR DESCRIPTION
## Summary
- Refines Vercel AutoResearch approval cards into a PM-oriented decision frame with experiment, objective, current run, distance from goal, recommendation, and decision options.
- Keeps the Paper-parity Decision Queue controller hierarchy from main while preserving approve/reject/evidence/Shaka controls.
- Adds supporting decision-frame helpers and focused test coverage for coordination and run-detail surfaces.

## Validation
- `npm test -- lib/vercel-deployment-research.test.ts lib/vercel-autoresearch-notification.test.ts lib/vercel-deployment-research-approvals.test.ts app/admin/agents/coordination/page.test.tsx app/admin/agents/runs/[runId]/page.test.tsx`
- `npx tsc --noEmit --pretty false`
- `npm run lint`
- `git diff --check origin/main...HEAD`
- `set -a; source /Users/vambahsillah/Projects/Portfolio/.env.local; set +a; npm run build`

## Integration Notes
- Rebases cleanly on top of the merged Mission Control polish, Standup Room, credential broker, and progress delivery PRs.
- No schema or production config changes.
- Build emitted the existing dev-env warning for `MOCK_N8N=false` / `N8N_DISABLE_OUTBOUND=false`; no live n8n workflow or production mutation smoke was run.
- Vercel contexts to verify after merge: `Vercel – portfolio` and `Vercel – portfolio-staging`.
