### PR TITLE
feat: add agent standup room

### DIFF
--- a/app/admin/agents/page.test.tsx
+++ b/app/admin/agents/page.test.tsx
@@ -217,7 +217,7 @@ describe('AgentOperationsPage mission control landing', () => {
     const actionBar = screen.getByLabelText('Mission Control actions')
     expect(within(actionBar).getByRole('button', { name: /Refresh/i })).toBeInTheDocument()
     expect(within(actionBar).getByRole('link', { name: /Open Kanban/i })).toHaveAttribute('href', '/admin/agents/swarm-board')
-    expect(within(actionBar).getByRole('button', { name: /Run standup/i })).toBeInTheDocument()
+    expect(within(actionBar).getByRole('link', { name: /Open standup/i })).toHaveAttribute('href', '/admin/agents/standup')
 
     const statusBlocks = screen.getByLabelText('Mission Control status blocks')
     expect(within(statusBlocks).getByRole('link', { name: /Decision Queue/i })).toHaveAttribute('href', '/admin/agents/coordination')
@@ -295,19 +295,11 @@ describe('AgentOperationsPage mission control landing', () => {
     }))
   })
 
-  it('runs the top-bar standup through the war-room POST action', async () => {
+  it('routes standup work into the interactive Standup Room', async () => {
     render(<AgentOperationsPage />)
 
     const actionBar = await screen.findByLabelText('Mission Control actions')
-    fireEvent.click(within(actionBar).getByRole('button', { name: /Run standup/i }))
-
-    expect(await screen.findByText('Standup complete.')).toBeInTheDocument()
-    expect(screen.getByText('War Room Standup')).toBeInTheDocument()
-
-    expect(fetch).toHaveBeenCalledWith('/api/admin/agents/war-room', expect.objectContaining({
-      method: 'POST',
-      headers: expect.objectContaining({ Authorization: 'Bearer admin-token' }),
-      body: JSON.stringify({ command: 'standup', message: '' }),
-    }))
+    expect(within(actionBar).getByRole('link', { name: /Open standup/i })).toHaveAttribute('href', '/admin/agents/standup')
+    expect(screen.getByRole('link', { name: /Open Standup Room/i })).toHaveAttribute('href', '/admin/agents/standup')
   })
 })

--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -763,15 +763,13 @@ export default function AgentOperationsPage() {
                   <Columns size={16} />
                   Open Kanban
                 </Link>
-                <button
-                  type="button"
-                  onClick={() => runWarRoom('standup')}
-                  disabled={warRoomLoading !== null}
-                  className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/60 bg-radiant-gold px-3 py-2 text-sm font-semibold text-silicon-slate hover:bg-radiant-gold/90 disabled:opacity-60"
+                <Link
+                  href="/admin/agents/standup"
+                  className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/60 bg-radiant-gold px-3 py-2 text-sm font-semibold text-silicon-slate hover:bg-radiant-gold/90"
                 >
-                  {warRoomLoading === 'standup' ? <RefreshCw size={16} className="animate-spin" /> : <Sparkles size={16} />}
-                  Run standup
-                </button>
+                  <MessageSquare size={16} />
+                  Open standup
+                </Link>
               </div>
             </div>
 
@@ -947,15 +945,10 @@ export default function AgentOperationsPage() {
                       <p className="font-semibold">Open Agent Kanban</p>
                       <p className="mt-1 text-sm text-muted-foreground">Review work lanes, roster, blockers, traces, validation, and PRs.</p>
                     </Link>
-                    <button
-                      type="button"
-                      onClick={() => runWarRoom('standup')}
-                      disabled={warRoomLoading !== null}
-                      className="rounded-lg border border-radiant-gold/60 bg-radiant-gold p-3 text-left text-silicon-slate hover:bg-radiant-gold/90 disabled:opacity-60"
-                    >
-                      <p className="font-semibold">Run standup</p>
-                      <p className="mt-1 text-sm">Generate brief and update queue context.</p>
-                    </button>
+                    <Link href="/admin/agents/standup" className="block rounded-lg border border-radiant-gold/60 bg-radiant-gold p-3 text-left text-silicon-slate hover:bg-radiant-gold/90">
+                      <p className="font-semibold">Open Standup Room</p>
+                      <p className="mt-1 text-sm">Ask agents, start standup, and turn goals into tracked work.</p>
+                    </Link>
                     <Link href="/admin/agents/runs" className="block rounded-lg border border-silicon-slate/60 bg-background/40 p-3 hover:border-radiant-gold/50">
                       <p className="font-semibold">Open Run Console</p>
                       <p className="mt-1 text-sm text-muted-foreground">Inspect traces, evaluations, dead letters, and artifacts.</p>

--- a/app/admin/agents/standup/page.test.tsx
+++ b/app/admin/agents/standup/page.test.tsx
@@ -1,0 +1,252 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import AgentStandupRoomPage from './page'
+
+vi.mock('@/components/ProtectedRoute', () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('@/components/admin/Breadcrumbs', () => ({
+  default: () => null,
+}))
+
+vi.mock('@/lib/auth', () => ({
+  getCurrentSession: vi.fn(async () => ({ access_token: 'admin-token' })),
+}))
+
+const organization = {
+  generated_at: '2026-05-14T10:00:00.000Z',
+  summary: {
+    agents: 2,
+    live_agents: 1,
+    active_work_items: 1,
+    unassigned_work_items: 0,
+    blocked_work_items: 1,
+    ready_for_merge: 0,
+    pending_approvals: 0,
+    activity_entries: 0,
+    active_goals: 1,
+    average_cycle_hours: 3.5,
+    oldest_in_flight_hours: 12,
+    wip: [{ laneKey: 'chief-of-staff', label: 'Shaka', count: 1, limit: 4, overLimit: false }],
+    goals: [{
+      id: 'goal-1',
+      title: 'Improve standup transparency',
+      total: 2,
+      completed: 1,
+      progress: 50,
+      blocked: 0,
+      open: 1,
+      burndown: [{ label: 'May 14', remaining: 1 }],
+    }],
+  },
+  agents: [
+    {
+      key: 'chief-of-staff',
+      name: 'Shaka (Zulu) - Chief of Staff',
+      podKey: 'chief_of_staff',
+      podName: 'Chief of Staff',
+      status: 'partial',
+      runtime: 'mixed',
+      live: true,
+      todayTurns: 2,
+      latestAction: 'Coordinated standup.',
+      latestRunId: 'run-1',
+    },
+    {
+      key: 'engineering-copilot',
+      name: 'Piye (Kush) - Engineering Copilot',
+      podKey: 'product_automation',
+      podName: 'Product & Automation Pod',
+      status: 'partial',
+      runtime: 'codex',
+      live: false,
+      todayTurns: 1,
+      latestAction: 'Prepared implementation.',
+      latestRunId: null,
+    },
+  ],
+  lanes: [
+    {
+      key: 'chief-of-staff',
+      label: 'Shaka',
+      agentKey: 'chief-of-staff',
+      agentName: 'Shaka (Zulu) - Chief of Staff',
+      status: 'live',
+      tasks: [{
+        id: 'task-1',
+        title: 'Draft standup room',
+        objective: 'Create an interactive room.',
+        status: 'in_progress',
+        priority: 'high',
+        ownerAgentKey: 'chief-of-staff',
+        ownerAgentName: 'Shaka (Zulu) - Chief of Staff',
+        ownerRuntime: 'mixed',
+        branchName: null,
+        worktreePath: null,
+        prNumber: null,
+        prUrl: null,
+        activeRunId: 'run-1',
+        blockerSummary: null,
+        validationSummary: null,
+        overlapGroup: null,
+        parentWorkItemId: 'goal-parent',
+        createdAt: '2026-05-14T08:00:00.000Z',
+        updatedAt: '2026-05-14T09:00:00.000Z',
+        completedAt: null,
+        goal: {
+          id: 'goal-1',
+          title: 'Improve standup transparency',
+          sequence: 1,
+          status: 'approved',
+          progressWeight: 1,
+          sessionHref: '/admin/agents/standup?goal=goal-1',
+        },
+      }],
+    },
+  ],
+  activity: [],
+  warRoom: {
+    roster: [],
+    commands: [],
+    suggestedPrompt: 'Ask for blockers.',
+  },
+}
+
+describe('AgentStandupRoomPage', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(async (url, init) => {
+      if (String(url).includes('/api/admin/agents/swarm-board')) {
+        return { ok: true, json: async () => ({ ok: true, organization }) }
+      }
+      if (String(url).includes('/api/admin/agents/war-room')) {
+        const body = JSON.parse(String((init as RequestInit).body ?? '{}'))
+        if (body.command === 'draft_goal') {
+          return {
+            ok: true,
+            json: async () => ({
+              ok: true,
+              run_id: 'goal-run',
+              command: 'draft_goal',
+              goal_draft: {
+                goal_id: 'goal-draft',
+                title: body.goal,
+                objective: `Accomplish: ${body.goal}`,
+                recommendation: 'Approve after review.',
+                risk_notes: 'Review gated.',
+                tasks: [{
+                  id: 'task-draft',
+                  title: 'Implement room',
+                  objective: 'Build it.',
+                  owner_agent_key: 'engineering-copilot',
+                  priority: 'high',
+                  dependencies: [],
+                  expected_files: ['app/admin/agents/standup/page.tsx'],
+                  acceptance_criteria: ['Renders'],
+                  risk_notes: 'Low',
+                  goal_progress_weight: 1,
+                }],
+              },
+              messages: [],
+            }),
+          }
+        }
+        if (body.command === 'approve_goal') {
+          return {
+            ok: true,
+            json: async () => ({
+              ok: true,
+              run_id: 'approval-run',
+              command: 'approve_goal',
+              messages: [],
+              created_work_items: {
+                parent: { id: 'parent', title: 'Goal: Improve standup' },
+                children: [{ id: 'child', title: 'Implement room' }],
+              },
+            }),
+          }
+        }
+        return {
+          ok: true,
+          json: async () => ({
+            ok: true,
+            run_id: 'room-run',
+            command: body.command,
+            messages: [{
+              id: `message-${body.command}`,
+              role: 'agent',
+              agent_key: body.target_agent_key ?? 'chief-of-staff',
+              agent_name: 'Shaka (Zulu) - Chief of Staff',
+              content: 'Scoped response ready.',
+              created_at: '2026-05-14T10:00:00.000Z',
+            }],
+          }),
+        }
+      }
+      return { ok: false, json: async () => ({ error: 'not found' }) }
+    }))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('renders participants, chat, goal planner, mini Kanban, metrics, and avatars', async () => {
+    render(<AgentStandupRoomPage />)
+
+    expect(await screen.findByRole('heading', { name: 'Standup Room' })).toBeInTheDocument()
+    expect(screen.getByText('Attendance')).toBeInTheDocument()
+    expect(screen.getAllByRole('img', { name: /Illustrated avatar for Shaka/i }).length).toBeGreaterThan(0)
+    expect(screen.getByRole('heading', { name: 'Swarm chat' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Goal planner' })).toBeInTheDocument()
+    expect(screen.getByText('Kanban preview')).toBeInTheDocument()
+    expect(screen.getByText('Info radiators')).toBeInTheDocument()
+    expect(screen.getAllByText('Improve standup transparency').length).toBeGreaterThan(0)
+  })
+
+  it('posts standup and direct agent asks through war-room commands', async () => {
+    render(<AgentStandupRoomPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /Start standup/i }))
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/admin/agents/war-room', expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ command: 'standup' }),
+      }))
+    })
+
+    fireEvent.change(screen.getByPlaceholderText(/Ask about blockers/i), { target: { value: '@Shaka what is blocked?' } })
+    fireEvent.click(screen.getByRole('button', { name: /Ask agent/i }))
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/admin/agents/war-room', expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ command: 'ask_agent', message: '@Shaka what is blocked?', target_agent_key: 'chief-of-staff' }),
+      }))
+    })
+  })
+
+  it('drafts a goal before approving work item creation', async () => {
+    render(<AgentStandupRoomPage />)
+
+    fireEvent.change(await screen.findByPlaceholderText('What should the swarm accomplish?'), { target: { value: 'Improve standup' } })
+    fireEvent.click(screen.getByRole('button', { name: /Draft plan/i }))
+
+    expect(await screen.findByText('Approve after review.')).toBeInTheDocument()
+    expect(fetch).toHaveBeenCalledWith('/api/admin/agents/war-room', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ command: 'draft_goal', goal: 'Improve standup' }),
+    }))
+
+    fireEvent.click(screen.getByRole('button', { name: /Approve goal/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/Created 1 child work item/i)).toBeInTheDocument()
+    })
+    expect(fetch).toHaveBeenCalledWith('/api/admin/agents/war-room', expect.objectContaining({
+      method: 'POST',
+      body: expect.stringContaining('"command":"approve_goal"'),
+    }))
+  })
+})

--- a/app/admin/agents/standup/page.test.tsx
+++ b/app/admin/agents/standup/page.test.tsx
@@ -146,6 +146,17 @@ describe('AgentStandupRoomPage', () => {
                   acceptance_criteria: ['Renders'],
                   risk_notes: 'Low',
                   goal_progress_weight: 1,
+                }, {
+                  id: 'task-validation',
+                  title: 'Validate room',
+                  objective: 'Test it.',
+                  owner_agent_key: 'chief-of-staff',
+                  priority: 'medium',
+                  dependencies: [],
+                  expected_files: ['app/admin/agents/standup/page.test.tsx'],
+                  acceptance_criteria: ['Covered'],
+                  risk_notes: 'Low',
+                  goal_progress_weight: 1,
                 }],
               },
               messages: [],
@@ -225,6 +236,16 @@ describe('AgentStandupRoomPage', () => {
         body: JSON.stringify({ command: 'ask_agent', message: '@Shaka what is blocked?', target_agent_key: 'chief-of-staff' }),
       }))
     })
+
+    fireEvent.change(screen.getByPlaceholderText(/Ask about blockers/i), { target: { value: '@Piye give me your implementation update' } })
+    fireEvent.click(screen.getByRole('button', { name: /Ask all/i }))
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/admin/agents/war-room', expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ command: 'ask_agent', message: '@Piye give me your implementation update', target_agent_key: 'engineering-copilot' }),
+      }))
+    })
   })
 
   it('drafts a goal before approving work item creation', async () => {
@@ -239,14 +260,17 @@ describe('AgentStandupRoomPage', () => {
       body: JSON.stringify({ command: 'draft_goal', goal: 'Improve standup' }),
     }))
 
+    fireEvent.change(screen.getByDisplayValue('Implement room'), { target: { value: 'Implement reviewed room' } })
+    fireEvent.click(screen.getByRole('button', { name: /Remove Validate room/i }))
     fireEvent.click(screen.getByRole('button', { name: /Approve goal/i }))
 
     await waitFor(() => {
       expect(screen.getByText(/Created 1 child work item/i)).toBeInTheDocument()
     })
-    expect(fetch).toHaveBeenCalledWith('/api/admin/agents/war-room', expect.objectContaining({
-      method: 'POST',
-      body: expect.stringContaining('"command":"approve_goal"'),
-    }))
+    const approveCall = vi.mocked(fetch).mock.calls.find(([, init]) => String((init as RequestInit)?.body ?? '').includes('"command":"approve_goal"'))
+    expect(approveCall).toBeTruthy()
+    const approveBody = JSON.parse(String((approveCall?.[1] as RequestInit).body))
+    expect(approveBody.draft.tasks).toHaveLength(1)
+    expect(approveBody.draft.tasks[0].title).toBe('Implement reviewed room')
   })
 })

--- a/app/admin/agents/standup/page.tsx
+++ b/app/admin/agents/standup/page.tsx
@@ -11,6 +11,7 @@ import {
   Play,
   Send,
   Sparkles,
+  Trash2,
   Users,
 } from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
@@ -43,6 +44,23 @@ type WarRoomResponse = {
     children: Array<{ id: string; title: string }>
   } | null
   error?: string
+}
+
+function agentMentionToken(agent: AgentOrgBoardAgent) {
+  return agent.name.split(' - ')[0].replace(/\s+/g, '').toLowerCase()
+}
+
+function findMentionedAgent(text: string, agents: AgentOrgBoardAgent[]) {
+  const match = text.match(/(?:^|\s)@([a-z0-9_-]+)/i)
+  if (!match) return null
+  const token = match[1].toLowerCase()
+  return agents.find((agent) => {
+    const display = agentMentionToken(agent)
+    return token === display ||
+      token === agent.key.toLowerCase() ||
+      token === agent.key.toLowerCase().replace(/-/g, '') ||
+      agent.name.toLowerCase().includes(token)
+  }) ?? null
 }
 
 export default function AgentStandupRoomPage() {
@@ -139,7 +157,13 @@ function StandupRoomContent() {
   async function askAll() {
     if (!message.trim()) return
     const text = message.trim()
+    const mentionedAgent = findMentionedAgent(text, participants)
     setMessage('')
+    if (mentionedAgent) {
+      setSelectedAgentKey(mentionedAgent.key)
+      await postWarRoom({ command: 'ask_agent', message: text, target_agent_key: mentionedAgent.key }, 'ask-agent')
+      return
+    }
     await postWarRoom({ command: 'discuss', message: text }, 'ask-all')
   }
 
@@ -158,6 +182,26 @@ function StandupRoomContent() {
   async function approveGoal() {
     if (!goalDraft) return
     await postWarRoom({ command: 'approve_goal', draft: goalDraft }, 'approve-goal')
+  }
+
+  function updateGoalTask(taskId: string, patch: Partial<AgentGoalDraft['tasks'][number]>) {
+    setGoalDraft((current) => {
+      if (!current) return current
+      return {
+        ...current,
+        tasks: current.tasks.map((task) => task.id === taskId ? { ...task, ...patch } : task),
+      }
+    })
+  }
+
+  function removeGoalTask(taskId: string) {
+    setGoalDraft((current) => {
+      if (!current) return current
+      return {
+        ...current,
+        tasks: current.tasks.filter((task) => task.id !== taskId),
+      }
+    })
   }
 
   return (
@@ -222,9 +266,12 @@ function StandupRoomContent() {
                 goalDraft={goalDraft}
                 createdItems={createdItems}
                 busy={busy}
+                participants={participants}
                 onGoalChange={setGoal}
                 onDraftGoal={draftGoal}
                 onApproveGoal={approveGoal}
+                onUpdateTask={updateGoalTask}
+                onRemoveTask={removeGoalTask}
               />
             </main>
             <aside className="space-y-5">
@@ -317,8 +364,8 @@ function ChatRoom({
       </div>
 
       <div className="max-h-[360px] space-y-3 overflow-y-auto rounded-lg border border-silicon-slate/60 bg-background/50 p-3">
-        {transcript.map((entry) => (
-          <div key={entry.id} className={`flex gap-3 ${entry.role === 'user' ? 'justify-end' : ''}`}>
+        {transcript.map((entry, index) => (
+          <div key={`${entry.id}-${index}`} className={`flex gap-3 ${entry.role === 'user' ? 'justify-end' : ''}`}>
             {entry.role !== 'user' && <AgentAvatar agentKey={entry.agent_key ?? 'chief-of-staff'} size="sm" />}
             <div className={`max-w-[85%] rounded-lg border px-3 py-2 text-sm ${
               entry.role === 'user'
@@ -365,17 +412,23 @@ function GoalPlanner({
   goalDraft,
   createdItems,
   busy,
+  participants,
   onGoalChange,
   onDraftGoal,
   onApproveGoal,
+  onUpdateTask,
+  onRemoveTask,
 }: {
   goal: string
   goalDraft: AgentGoalDraft | null
   createdItems: WarRoomResponse['created_work_items']
   busy: string | null
+  participants: AgentOrgBoardAgent[]
   onGoalChange: (value: string) => void
   onDraftGoal: () => void
   onApproveGoal: () => void
+  onUpdateTask: (taskId: string, patch: Partial<AgentGoalDraft['tasks'][number]>) => void
+  onRemoveTask: (taskId: string) => void
 }) {
   return (
     <section className="agent-ops-card rounded-lg border p-4">
@@ -403,7 +456,7 @@ function GoalPlanner({
               <h3 className="mt-1 text-lg font-semibold">{goalDraft.title}</h3>
               <p className="mt-1 text-sm text-muted-foreground">{goalDraft.recommendation}</p>
             </div>
-            <button onClick={onApproveGoal} disabled={busy != null} className="inline-flex items-center justify-center gap-2 rounded-lg bg-radiant-gold px-4 py-2 text-sm font-semibold text-obsidian hover:bg-radiant-gold/90 disabled:opacity-50">
+            <button onClick={onApproveGoal} disabled={busy != null || goalDraft.tasks.length === 0} className="inline-flex items-center justify-center gap-2 rounded-lg bg-radiant-gold px-4 py-2 text-sm font-semibold text-obsidian hover:bg-radiant-gold/90 disabled:opacity-50">
               <CheckCircle2 size={16} />
               Approve goal
             </button>
@@ -414,17 +467,75 @@ function GoalPlanner({
                 <div className="flex items-start gap-3">
                   <span className="rounded-full border border-radiant-gold/40 px-2 py-1 text-xs text-radiant-gold">{index + 1}</span>
                   <div className="min-w-0 flex-1">
-                    <p className="font-semibold">{task.title}</p>
-                    <p className="mt-1 text-sm text-muted-foreground">{task.objective}</p>
-                    <div className="mt-2 flex flex-wrap gap-2 text-xs">
-                      <span className="rounded-full border border-silicon-slate/60 px-2 py-1">Owner: {task.owner_agent_key}</span>
-                      <span className="rounded-full border border-silicon-slate/60 px-2 py-1">Priority: {task.priority}</span>
-                      <span className="rounded-full border border-silicon-slate/60 px-2 py-1">Weight: {task.goal_progress_weight}</span>
+                    <div className="grid gap-2 md:grid-cols-[minmax(0,1fr)_180px_120px_90px_auto]">
+                      <label className="text-xs text-muted-foreground">
+                        Task
+                        <input
+                          value={task.title}
+                          onChange={(event) => onUpdateTask(task.id, { title: event.target.value })}
+                          className="mt-1 w-full rounded-md border border-silicon-slate/60 bg-background/70 px-2 py-1.5 text-sm text-foreground outline-none focus:border-radiant-gold/70"
+                        />
+                      </label>
+                      <label className="text-xs text-muted-foreground">
+                        Owner
+                        <select
+                          value={task.owner_agent_key}
+                          onChange={(event) => onUpdateTask(task.id, { owner_agent_key: event.target.value })}
+                          className="mt-1 w-full rounded-md border border-silicon-slate/60 bg-background/70 px-2 py-1.5 text-sm text-foreground outline-none focus:border-radiant-gold/70"
+                        >
+                          {participants.map((agent) => (
+                            <option key={agent.key} value={agent.key}>{agent.name.split(' - ')[0]}</option>
+                          ))}
+                        </select>
+                      </label>
+                      <label className="text-xs text-muted-foreground">
+                        Priority
+                        <select
+                          value={task.priority}
+                          onChange={(event) => onUpdateTask(task.id, { priority: event.target.value as AgentGoalDraft['tasks'][number]['priority'] })}
+                          className="mt-1 w-full rounded-md border border-silicon-slate/60 bg-background/70 px-2 py-1.5 text-sm text-foreground outline-none focus:border-radiant-gold/70"
+                        >
+                          {['urgent', 'high', 'medium', 'low'].map((priority) => <option key={priority} value={priority}>{priority}</option>)}
+                        </select>
+                      </label>
+                      <label className="text-xs text-muted-foreground">
+                        Weight
+                        <input
+                          type="number"
+                          min={1}
+                          max={5}
+                          value={task.goal_progress_weight}
+                          onChange={(event) => onUpdateTask(task.id, { goal_progress_weight: Number(event.target.value) || 1 })}
+                          className="mt-1 w-full rounded-md border border-silicon-slate/60 bg-background/70 px-2 py-1.5 text-sm text-foreground outline-none focus:border-radiant-gold/70"
+                        />
+                      </label>
+                      <button
+                        type="button"
+                        onClick={() => onRemoveTask(task.id)}
+                        className="mt-5 inline-flex h-9 items-center justify-center rounded-md border border-red-400/40 px-2 text-red-200 hover:bg-red-500/10"
+                        aria-label={`Remove ${task.title}`}
+                      >
+                        <Trash2 size={15} />
+                      </button>
                     </div>
+                    <label className="mt-2 block text-xs text-muted-foreground">
+                      Objective
+                      <textarea
+                        value={task.objective}
+                        onChange={(event) => onUpdateTask(task.id, { objective: event.target.value })}
+                        rows={2}
+                        className="mt-1 w-full rounded-md border border-silicon-slate/60 bg-background/70 px-2 py-1.5 text-sm text-foreground outline-none focus:border-radiant-gold/70"
+                      />
+                    </label>
                   </div>
                 </div>
               </div>
             ))}
+            {!goalDraft.tasks.length && (
+              <div className="rounded-lg border border-dashed border-silicon-slate/60 p-4 text-sm text-muted-foreground">
+                No tasks are selected for creation. Draft the goal again or keep at least one task before approving.
+              </div>
+            )}
           </div>
         </div>
       )}
@@ -440,6 +551,7 @@ function GoalPlanner({
 
 function MetricsPanel({ organization }: { organization: AgentOrgBoardSnapshot }) {
   const goals = organization.summary.goals.slice(0, 2)
+  const wip = organization.summary.wip.slice(0, 4)
   return (
     <section className="agent-ops-card rounded-lg border p-4">
       <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-radiant-gold">Info radiators</h2>
@@ -453,6 +565,17 @@ function MetricsPanel({ organization }: { organization: AgentOrgBoardSnapshot })
         {goals.length ? goals.map((goal) => <GoalProgress key={goal.id} goal={goal} />) : (
           <p className="rounded-lg border border-dashed border-silicon-slate/60 p-3 text-sm text-muted-foreground">No goal-tagged work yet.</p>
         )}
+      </div>
+      <div className="mt-4 space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">WIP limits</p>
+        {wip.map((lane) => (
+          <div key={lane.laneKey} className={`rounded-md border px-2 py-1.5 text-xs ${lane.overLimit ? 'border-red-400/45 bg-red-500/10 text-red-100' : 'border-silicon-slate/60 bg-background/40 text-muted-foreground'}`}>
+            <div className="flex items-center justify-between gap-2">
+              <span className="truncate">{lane.label}</span>
+              <span>{lane.count}/{lane.limit}</span>
+            </div>
+          </div>
+        ))}
       </div>
       <Link href="/admin/agents/swarm-board" className="mt-4 inline-flex items-center gap-2 text-sm text-radiant-gold hover:underline">
         Full metrics
@@ -470,6 +593,21 @@ function GoalProgress({ goal }: { goal: AgentOrgBoardGoalMetric }) {
         <div className="h-full bg-radiant-gold" style={{ width: `${goal.progress}%` }} />
       </div>
       <p className="mt-2 text-xs text-muted-foreground">{goal.progress}% complete · {goal.open} open · {goal.blocked} blocked</p>
+      {goal.burndown.length > 0 && (
+        <div className="mt-3 flex h-12 items-end gap-1" aria-label={`Burndown for ${goal.title}`}>
+          {goal.burndown.map((point) => {
+            const max = Math.max(...goal.burndown.map((item) => item.remaining), 1)
+            return (
+              <span
+                key={point.label}
+                title={`${point.label}: ${point.remaining} remaining`}
+                className="flex-1 rounded-t bg-radiant-gold/55"
+                style={{ height: `${Math.max(18, (point.remaining / max) * 100)}%` }}
+              />
+            )
+          })}
+        </div>
+      )}
     </div>
   )
 }
@@ -501,14 +639,24 @@ function MiniKanban({ lanes }: { lanes: AgentOrgBoardLane[] }) {
 }
 
 function MiniTask({ task }: { task: AgentOrgBoardTask }) {
+  const ageHours = Math.max(0, Math.round((Date.now() - new Date(task.createdAt).getTime()) / 36e5))
   return (
     <div className="rounded-md border border-silicon-slate/50 bg-silicon-slate/15 p-2 text-xs">
       <p className="line-clamp-2 font-medium">{task.title}</p>
       <div className="mt-2 flex flex-wrap gap-1 text-muted-foreground">
         {task.goal && <span className="rounded-full border border-radiant-gold/35 px-2 py-0.5 text-radiant-gold">{task.goal.title}</span>}
+        <span>{task.ownerAgentName.split(' - ')[0]}</span>
+        <span>{ageHours}h</span>
         <span>{task.status.replace(/_/g, ' ')}</span>
         {task.prUrl && <GitPullRequest size={12} />}
+        {task.activeRunId && (
+          <Link href={`/admin/agents/runs/${task.activeRunId}`} className="text-radiant-gold hover:underline">
+            Trace
+          </Link>
+        )}
       </div>
+      {task.blockerSummary && <p className="mt-1 line-clamp-1 text-red-200">Blocked: {task.blockerSummary}</p>}
+      {task.validationSummary && <p className="mt-1 line-clamp-1 text-muted-foreground">Next: {task.validationSummary}</p>}
     </div>
   )
 }

--- a/app/admin/agents/standup/page.tsx
+++ b/app/admin/agents/standup/page.tsx
@@ -1,0 +1,523 @@
+'use client'
+
+import Link from 'next/link'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  ArrowRight,
+  CheckCircle2,
+  GitPullRequest,
+  KanbanSquare,
+  MessageSquare,
+  Play,
+  Send,
+  Sparkles,
+  Users,
+} from 'lucide-react'
+import ProtectedRoute from '@/components/ProtectedRoute'
+import Breadcrumbs from '@/components/admin/Breadcrumbs'
+import AgentAvatar from '@/components/admin/AgentAvatar'
+import { getCurrentSession } from '@/lib/auth'
+import type {
+  AgentOrgBoardAgent,
+  AgentOrgBoardGoalMetric,
+  AgentOrgBoardLane,
+  AgentOrgBoardSnapshot,
+  AgentOrgBoardTask,
+} from '@/lib/agent-swarm-board'
+import type { AgentGoalDraft, AgentWarRoomMessage } from '@/lib/agent-war-room'
+
+type BoardResponse = {
+  ok?: boolean
+  organization?: AgentOrgBoardSnapshot
+}
+
+type WarRoomResponse = {
+  ok: boolean
+  run_id: string
+  command: string
+  messages?: AgentWarRoomMessage[]
+  synthesis?: string
+  goal_draft?: AgentGoalDraft | null
+  created_work_items?: {
+    parent: { id: string; title: string }
+    children: Array<{ id: string; title: string }>
+  } | null
+  error?: string
+}
+
+export default function AgentStandupRoomPage() {
+  return (
+    <ProtectedRoute requireAdmin>
+      <StandupRoomContent />
+    </ProtectedRoute>
+  )
+}
+
+function StandupRoomContent() {
+  const [organization, setOrganization] = useState<AgentOrgBoardSnapshot | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [selectedAgentKey, setSelectedAgentKey] = useState('chief-of-staff')
+  const [message, setMessage] = useState('')
+  const [goal, setGoal] = useState('')
+  const [goalDraft, setGoalDraft] = useState<AgentGoalDraft | null>(null)
+  const [createdItems, setCreatedItems] = useState<WarRoomResponse['created_work_items']>(null)
+  const [transcript, setTranscript] = useState<AgentWarRoomMessage[]>([
+    {
+      id: 'system-ready',
+      role: 'system',
+      content: 'Standup Room is ready. Ask all agents, select one participant, or give Shaka a goal to break into tracked work.',
+      created_at: new Date().toISOString(),
+    },
+  ])
+  const [busy, setBusy] = useState<string | null>(null)
+
+  const fetchBoard = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Missing admin session')
+      const response = await fetch('/api/admin/agents/swarm-board', {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      })
+      const body = await response.json().catch(() => ({})) as BoardResponse
+      if (!response.ok || !body.organization) throw new Error('Unable to load Agent Kanban snapshot')
+      setOrganization(body.organization)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to load Standup Room')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchBoard()
+  }, [fetchBoard])
+
+  const participants = useMemo(() => {
+    const agents = organization?.agents ?? []
+    return agents.filter((agent) => agent.status !== 'planned').slice(0, 12)
+  }, [organization?.agents])
+  const selectedAgent = participants.find((agent) => agent.key === selectedAgentKey) ?? participants[0]
+
+  async function postWarRoom(payload: Record<string, unknown>, loadingKey: string) {
+    setBusy(loadingKey)
+    setError(null)
+    try {
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Missing admin session')
+      const response = await fetch('/api/admin/agents/war-room', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${session.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      })
+      const body = await response.json().catch(() => ({})) as WarRoomResponse
+      if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`)
+      if (body.messages?.length) setTranscript((current) => [...current, ...body.messages!])
+      if (body.goal_draft) setGoalDraft(body.goal_draft)
+      if (body.created_work_items) {
+        setCreatedItems(body.created_work_items)
+        await fetchBoard()
+      }
+      return body
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'War Room command failed')
+      return null
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  async function startStandup() {
+    await postWarRoom({ command: 'standup' }, 'standup')
+  }
+
+  async function askAll() {
+    if (!message.trim()) return
+    const text = message.trim()
+    setMessage('')
+    await postWarRoom({ command: 'discuss', message: text }, 'ask-all')
+  }
+
+  async function askSelectedAgent() {
+    if (!message.trim() || !selectedAgent) return
+    const text = message.trim()
+    setMessage('')
+    await postWarRoom({ command: 'ask_agent', message: text, target_agent_key: selectedAgent.key }, 'ask-agent')
+  }
+
+  async function draftGoal() {
+    if (!goal.trim()) return
+    await postWarRoom({ command: 'draft_goal', goal: goal.trim() }, 'draft-goal')
+  }
+
+  async function approveGoal() {
+    if (!goalDraft) return
+    await postWarRoom({ command: 'approve_goal', draft: goalDraft }, 'approve-goal')
+  }
+
+  return (
+    <div className="agent-ops-page min-h-screen p-5 text-foreground lg:p-7">
+      <div className="mx-auto max-w-7xl">
+        <Breadcrumbs items={[
+          { label: 'Admin Dashboard', href: '/admin' },
+          { label: 'Agent Operations', href: '/admin/agents' },
+          { label: 'Standup Room' },
+        ]} />
+
+        <header className="mt-5 flex flex-col gap-4 rounded-xl border border-radiant-gold/25 bg-silicon-slate/20 p-5 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <div className="mb-2 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-radiant-gold">
+              <Users size={15} />
+              Agent Ops
+            </div>
+            <h1 className="text-3xl font-bold">Standup Room</h1>
+            <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+              Ask Shaka or the swarm directly, inspect the active board, and turn goals into review-gated Agent Ops work items.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Link href="/admin/agents/swarm-board" className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/50 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/10">
+              <KanbanSquare size={16} />
+              Open full Kanban
+            </Link>
+            <button onClick={startStandup} disabled={busy != null} className="inline-flex items-center gap-2 rounded-lg bg-radiant-gold px-3 py-2 text-sm font-semibold text-obsidian hover:bg-radiant-gold/90 disabled:opacity-60">
+              <Play size={16} />
+              Start standup
+            </button>
+          </div>
+        </header>
+
+        {loading ? (
+          <div className="py-16 text-center text-muted-foreground">Loading Standup Room...</div>
+        ) : error && !organization ? (
+          <div className="mt-5 rounded-lg border border-red-500/40 bg-red-500/10 p-4 text-red-100">{error}</div>
+        ) : organization ? (
+          <div className="mt-5 grid gap-5 xl:grid-cols-[260px_minmax(0,1fr)_340px]">
+            <ParticipantRail
+              participants={participants}
+              selectedAgentKey={selectedAgent?.key ?? selectedAgentKey}
+              onSelect={(agent) => {
+                setSelectedAgentKey(agent.key)
+                setMessage((current) => current || `@${agent.name.split(' - ')[0]} `)
+              }}
+            />
+            <main className="space-y-5">
+              <ChatRoom
+                transcript={transcript}
+                message={message}
+                onMessageChange={setMessage}
+                selectedAgent={selectedAgent}
+                busy={busy}
+                onAskAll={askAll}
+                onAskAgent={askSelectedAgent}
+                onQuickPrompt={setMessage}
+              />
+              <GoalPlanner
+                goal={goal}
+                goalDraft={goalDraft}
+                createdItems={createdItems}
+                busy={busy}
+                onGoalChange={setGoal}
+                onDraftGoal={draftGoal}
+                onApproveGoal={approveGoal}
+              />
+            </main>
+            <aside className="space-y-5">
+              <MetricsPanel organization={organization} />
+              <MiniKanban lanes={organization.lanes} />
+            </aside>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function ParticipantRail({
+  participants,
+  selectedAgentKey,
+  onSelect,
+}: {
+  participants: AgentOrgBoardAgent[]
+  selectedAgentKey: string
+  onSelect: (agent: AgentOrgBoardAgent) => void
+}) {
+  return (
+    <aside className="agent-ops-card rounded-lg border p-3">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-radiant-gold">Attendance</h2>
+        <span className="rounded-full border border-silicon-slate/60 px-2 py-1 text-xs text-muted-foreground">{participants.length}</span>
+      </div>
+      <div className="space-y-2">
+        {participants.map((agent) => (
+          <button
+            key={agent.key}
+            type="button"
+            onClick={() => onSelect(agent)}
+            aria-pressed={selectedAgentKey === agent.key}
+            className={`flex w-full items-center gap-3 rounded-lg border p-2 text-left transition ${
+              selectedAgentKey === agent.key
+                ? 'border-radiant-gold/60 bg-radiant-gold/10'
+                : 'border-silicon-slate/60 bg-background/40 hover:border-radiant-gold/40'
+            }`}
+          >
+            <AgentAvatar agentKey={agent.key} size="sm" />
+            <span className="min-w-0">
+              <span className="block truncate text-sm font-medium">{agent.name.split(' - ')[0]}</span>
+              <span className="block truncate text-xs text-muted-foreground">{agent.podName}</span>
+            </span>
+            <span aria-hidden="true" className={`ml-auto h-2 w-2 rounded-full ${agent.live ? 'bg-green-400' : 'bg-silicon-slate'}`} />
+          </button>
+        ))}
+      </div>
+    </aside>
+  )
+}
+
+function ChatRoom({
+  transcript,
+  message,
+  selectedAgent,
+  busy,
+  onMessageChange,
+  onAskAll,
+  onAskAgent,
+  onQuickPrompt,
+}: {
+  transcript: AgentWarRoomMessage[]
+  message: string
+  selectedAgent?: AgentOrgBoardAgent
+  busy: string | null
+  onMessageChange: (value: string) => void
+  onAskAll: () => void
+  onAskAgent: () => void
+  onQuickPrompt: (value: string) => void
+}) {
+  return (
+    <section className="agent-ops-card rounded-lg border p-4">
+      <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="flex items-center gap-2 text-xl font-semibold">
+            <MessageSquare size={20} className="text-radiant-gold" />
+            Swarm chat
+          </h2>
+          <p className="mt-1 text-sm text-muted-foreground">Use @agent targeting or select a participant from attendance.</p>
+        </div>
+        {selectedAgent && (
+          <div className="flex items-center gap-2 rounded-full border border-silicon-slate/60 px-3 py-1 text-xs text-muted-foreground">
+            <AgentAvatar agentKey={selectedAgent.key} size="sm" />
+            Target: {selectedAgent.name.split(' - ')[0]}
+          </div>
+        )}
+      </div>
+
+      <div className="max-h-[360px] space-y-3 overflow-y-auto rounded-lg border border-silicon-slate/60 bg-background/50 p-3">
+        {transcript.map((entry) => (
+          <div key={entry.id} className={`flex gap-3 ${entry.role === 'user' ? 'justify-end' : ''}`}>
+            {entry.role !== 'user' && <AgentAvatar agentKey={entry.agent_key ?? 'chief-of-staff'} size="sm" />}
+            <div className={`max-w-[85%] rounded-lg border px-3 py-2 text-sm ${
+              entry.role === 'user'
+                ? 'border-radiant-gold/40 bg-radiant-gold/10'
+                : 'border-silicon-slate/60 bg-silicon-slate/15'
+            }`}>
+              {entry.agent_name && <p className="mb-1 text-xs font-semibold text-radiant-gold">{entry.agent_name}</p>}
+              <p className="leading-relaxed text-foreground/90">{entry.content}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-4 flex flex-col gap-2 lg:flex-row">
+        <input
+          value={message}
+          onChange={(event) => onMessageChange(event.target.value)}
+          className="min-h-11 flex-1 rounded-lg border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm outline-none focus:border-radiant-gold/70"
+          placeholder="Ask about blockers, owners, risk, next steps, or @Shaka for a direct update..."
+        />
+        <button onClick={onAskAll} disabled={busy != null || !message.trim()} className="inline-flex items-center justify-center gap-2 rounded-lg border border-radiant-gold/50 px-4 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/10 disabled:opacity-50">
+          <Send size={16} />
+          Ask all
+        </button>
+        <button onClick={onAskAgent} disabled={busy != null || !message.trim()} className="inline-flex items-center justify-center gap-2 rounded-lg bg-radiant-gold px-4 py-2 text-sm font-semibold text-obsidian hover:bg-radiant-gold/90 disabled:opacity-50">
+          <Send size={16} />
+          Ask agent
+        </button>
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-2">
+        {['Give me blockers only', 'Who owns the oldest work?', 'What changed since last standup?'].map((prompt) => (
+          <button key={prompt} type="button" onClick={() => onQuickPrompt(prompt)} className="rounded-full border border-radiant-gold/35 px-3 py-1 text-xs text-radiant-gold hover:bg-radiant-gold/10">
+            {prompt}
+          </button>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function GoalPlanner({
+  goal,
+  goalDraft,
+  createdItems,
+  busy,
+  onGoalChange,
+  onDraftGoal,
+  onApproveGoal,
+}: {
+  goal: string
+  goalDraft: AgentGoalDraft | null
+  createdItems: WarRoomResponse['created_work_items']
+  busy: string | null
+  onGoalChange: (value: string) => void
+  onDraftGoal: () => void
+  onApproveGoal: () => void
+}) {
+  return (
+    <section className="agent-ops-card rounded-lg border p-4">
+      <div className="mb-3 flex items-center gap-2">
+        <Sparkles size={18} className="text-radiant-gold" />
+        <h2 className="text-xl font-semibold">Goal planner</h2>
+      </div>
+      <div className="flex flex-col gap-2 lg:flex-row">
+        <input
+          value={goal}
+          onChange={(event) => onGoalChange(event.target.value)}
+          className="min-h-11 flex-1 rounded-lg border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm outline-none focus:border-radiant-gold/70"
+          placeholder="What should the swarm accomplish?"
+        />
+        <button onClick={onDraftGoal} disabled={busy != null || !goal.trim()} className="inline-flex items-center justify-center gap-2 rounded-lg border border-radiant-gold/50 px-4 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/10 disabled:opacity-50">
+          Draft plan
+        </button>
+      </div>
+
+      {goalDraft && (
+        <div className="mt-4 rounded-lg border border-radiant-gold/35 bg-radiant-gold/5 p-3">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-radiant-gold">Draft packet</p>
+              <h3 className="mt-1 text-lg font-semibold">{goalDraft.title}</h3>
+              <p className="mt-1 text-sm text-muted-foreground">{goalDraft.recommendation}</p>
+            </div>
+            <button onClick={onApproveGoal} disabled={busy != null} className="inline-flex items-center justify-center gap-2 rounded-lg bg-radiant-gold px-4 py-2 text-sm font-semibold text-obsidian hover:bg-radiant-gold/90 disabled:opacity-50">
+              <CheckCircle2 size={16} />
+              Approve goal
+            </button>
+          </div>
+          <div className="mt-4 grid gap-2">
+            {goalDraft.tasks.map((task, index) => (
+              <div key={task.id} className="rounded-lg border border-silicon-slate/60 bg-background/60 p-3">
+                <div className="flex items-start gap-3">
+                  <span className="rounded-full border border-radiant-gold/40 px-2 py-1 text-xs text-radiant-gold">{index + 1}</span>
+                  <div className="min-w-0 flex-1">
+                    <p className="font-semibold">{task.title}</p>
+                    <p className="mt-1 text-sm text-muted-foreground">{task.objective}</p>
+                    <div className="mt-2 flex flex-wrap gap-2 text-xs">
+                      <span className="rounded-full border border-silicon-slate/60 px-2 py-1">Owner: {task.owner_agent_key}</span>
+                      <span className="rounded-full border border-silicon-slate/60 px-2 py-1">Priority: {task.priority}</span>
+                      <span className="rounded-full border border-silicon-slate/60 px-2 py-1">Weight: {task.goal_progress_weight}</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {createdItems && (
+        <div className="mt-4 rounded-lg border border-green-500/30 bg-green-500/10 p-3 text-sm text-green-100">
+          Created {createdItems.children.length} child work item(s) under {createdItems.parent.title}.
+        </div>
+      )}
+    </section>
+  )
+}
+
+function MetricsPanel({ organization }: { organization: AgentOrgBoardSnapshot }) {
+  const goals = organization.summary.goals.slice(0, 2)
+  return (
+    <section className="agent-ops-card rounded-lg border p-4">
+      <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-radiant-gold">Info radiators</h2>
+      <div className="mt-3 grid grid-cols-2 gap-2">
+        <Metric label="Active goals" value={organization.summary.active_goals} />
+        <Metric label="Blocked" value={organization.summary.blocked_work_items} />
+        <Metric label="Cycle time" value={organization.summary.average_cycle_hours == null ? 'n/a' : `${organization.summary.average_cycle_hours}h`} />
+        <Metric label="Oldest WIP" value={organization.summary.oldest_in_flight_hours == null ? 'n/a' : `${organization.summary.oldest_in_flight_hours}h`} />
+      </div>
+      <div className="mt-4 space-y-3">
+        {goals.length ? goals.map((goal) => <GoalProgress key={goal.id} goal={goal} />) : (
+          <p className="rounded-lg border border-dashed border-silicon-slate/60 p-3 text-sm text-muted-foreground">No goal-tagged work yet.</p>
+        )}
+      </div>
+      <Link href="/admin/agents/swarm-board" className="mt-4 inline-flex items-center gap-2 text-sm text-radiant-gold hover:underline">
+        Full metrics
+        <ArrowRight size={14} />
+      </Link>
+    </section>
+  )
+}
+
+function GoalProgress({ goal }: { goal: AgentOrgBoardGoalMetric }) {
+  return (
+    <div className="rounded-lg border border-silicon-slate/60 bg-background/50 p-3">
+      <p className="line-clamp-1 text-sm font-semibold">{goal.title}</p>
+      <div className="mt-2 h-2 overflow-hidden rounded-full bg-silicon-slate/70">
+        <div className="h-full bg-radiant-gold" style={{ width: `${goal.progress}%` }} />
+      </div>
+      <p className="mt-2 text-xs text-muted-foreground">{goal.progress}% complete · {goal.open} open · {goal.blocked} blocked</p>
+    </div>
+  )
+}
+
+function MiniKanban({ lanes }: { lanes: AgentOrgBoardLane[] }) {
+  const visible = lanes.filter((lane) => lane.tasks.length > 0).slice(0, 3)
+  return (
+    <section className="agent-ops-card rounded-lg border p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-radiant-gold">Kanban preview</h2>
+        <Link href="/admin/agents/swarm-board" className="text-xs text-radiant-gold hover:underline">Open board</Link>
+      </div>
+      <div className="space-y-3">
+        {(visible.length ? visible : lanes.slice(0, 3)).map((lane) => (
+          <div key={lane.key} className="rounded-lg border border-silicon-slate/60 bg-background/50 p-3">
+            <div className="mb-2 flex items-center justify-between text-sm">
+              <span className="font-semibold">{lane.label}</span>
+              <span className="text-muted-foreground">{lane.tasks.length}</span>
+            </div>
+            <div className="space-y-2">
+              {lane.tasks.slice(0, 2).map((task) => <MiniTask key={task.id} task={task} />)}
+              {!lane.tasks.length && <p className="text-xs text-muted-foreground">No active cards.</p>}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function MiniTask({ task }: { task: AgentOrgBoardTask }) {
+  return (
+    <div className="rounded-md border border-silicon-slate/50 bg-silicon-slate/15 p-2 text-xs">
+      <p className="line-clamp-2 font-medium">{task.title}</p>
+      <div className="mt-2 flex flex-wrap gap-1 text-muted-foreground">
+        {task.goal && <span className="rounded-full border border-radiant-gold/35 px-2 py-0.5 text-radiant-gold">{task.goal.title}</span>}
+        <span>{task.status.replace(/_/g, ' ')}</span>
+        {task.prUrl && <GitPullRequest size={12} />}
+      </div>
+    </div>
+  )
+}
+
+function Metric({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="rounded-lg border border-silicon-slate/60 bg-background/50 p-3">
+      <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="mt-1 text-xl font-semibold">{value}</p>
+    </div>
+  )
+}

--- a/app/admin/agents/swarm-board/page.test.tsx
+++ b/app/admin/agents/swarm-board/page.test.tsx
@@ -41,6 +41,20 @@ const boardSnapshot = {
       ready_for_merge: 0,
       pending_approvals: 0,
       activity_entries: 1,
+      active_goals: 1,
+      average_cycle_hours: 4.5,
+      oldest_in_flight_hours: 12,
+      wip: [{ laneKey: 'operations', label: longLaneLabel, count: 1, limit: 4, overLimit: false }],
+      goals: [{
+        id: 'goal-1',
+        title: 'Launch Standup Room',
+        total: 1,
+        completed: 0,
+        progress: 35,
+        blocked: 1,
+        open: 1,
+        burndown: [{ label: 'May 13', remaining: 1 }],
+      }],
     },
     lanes: [
       {
@@ -67,7 +81,18 @@ const boardSnapshot = {
             blockerSummary: 'Waiting on staging smoke confirmation.',
             validationSummary: 'Focused route tests passed.',
             overlapGroup: 'agent-ops-redesign',
+            parentWorkItemId: 'goal-parent',
+            createdAt: '2026-05-13T08:00:00.000Z',
             updatedAt: '2026-05-13T11:50:00.000Z',
+            completedAt: null,
+            goal: {
+              id: 'goal-1',
+              title: 'Launch Standup Room',
+              sequence: 1,
+              status: 'approved',
+              progressWeight: 1,
+              sessionHref: '/admin/agents/standup?goal=goal-1',
+            },
           },
         ],
       },
@@ -134,6 +159,8 @@ describe('AgentSwarmBoardPage', () => {
     expect(screen.getByRole('heading', { name: 'Work by state, owner, and blocker' })).toBeInTheDocument()
     expect(screen.getAllByText(/Work by state, owner, and blocker/i).length).toBeGreaterThan(0)
     expect(screen.getByText(/Work-lane Kanban organized by agent ownership/i)).toBeInTheDocument()
+    expect(screen.getByText('Goal progress')).toBeInTheDocument()
+    expect(screen.getByText('Launch Standup Room')).toBeInTheDocument()
     expect(screen.getByRole('tab', { name: 'Kanban lanes' })).toHaveAttribute('aria-selected', 'true')
     expect(fetch).toHaveBeenCalledWith('/api/admin/agents/swarm-board', expect.objectContaining({
       headers: expect.objectContaining({ Authorization: 'Bearer admin-token' }),

--- a/app/admin/agents/swarm-board/page.tsx
+++ b/app/admin/agents/swarm-board/page.tsx
@@ -17,6 +17,7 @@ import {
 } from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
+import AgentAvatar from '@/components/admin/AgentAvatar'
 import { getCurrentSession } from '@/lib/auth'
 import type {
   AgentOrgBoardActivity,
@@ -194,6 +195,7 @@ function KanbanBoard({ organization }: { organization: AgentOrgBoardSnapshot }) 
   return (
     <div className="space-y-4" role="tabpanel" aria-label="Kanban lanes">
       <SummaryStrip organization={organization} />
+      <GoalRadiators organization={organization} />
       <section className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/15 p-4">
         <div className="flex flex-col gap-2 lg:flex-row lg:items-end lg:justify-between">
           <div>
@@ -214,9 +216,56 @@ function KanbanBoard({ organization }: { organization: AgentOrgBoardSnapshot }) 
   )
 }
 
+function GoalRadiators({ organization }: { organization: AgentOrgBoardSnapshot }) {
+  const wipAlerts = organization.summary.wip.filter((lane) => lane.overLimit).slice(0, 3)
+  const goals = organization.summary.goals.slice(0, 3)
+  return (
+    <section className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/15 p-4" aria-label="Goal and Kanban metrics">
+      <div className="grid gap-3 lg:grid-cols-[minmax(0,1.5fr)_minmax(260px,0.8fr)]">
+        <div>
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-radiant-gold">Goal progress</h2>
+            <Link href="/admin/agents/standup" className="text-xs text-radiant-gold hover:underline">Open Standup Room</Link>
+          </div>
+          <div className="grid gap-3 md:grid-cols-3">
+            {goals.length ? goals.map((goal) => (
+              <div key={goal.id} className="rounded-lg border border-silicon-slate/60 bg-background/60 p-3">
+                <p className="line-clamp-1 text-sm font-semibold">{goal.title}</p>
+                <div className="mt-2 h-2 overflow-hidden rounded-full bg-silicon-slate/70">
+                  <div className="h-full bg-radiant-gold" style={{ width: `${goal.progress}%` }} />
+                </div>
+                <p className="mt-2 text-xs text-muted-foreground">{goal.progress}% · {goal.open} open · {goal.blocked} blocked</p>
+              </div>
+            )) : (
+              <p className="rounded-lg border border-dashed border-silicon-slate/60 p-3 text-sm text-muted-foreground md:col-span-3">
+                Goal-tagged cards will appear after a Standup Room goal is approved.
+              </p>
+            )}
+          </div>
+        </div>
+        <div className="rounded-lg border border-silicon-slate/60 bg-background/60 p-3">
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-radiant-gold">WIP limits</h3>
+          <p className="mt-2 text-sm text-muted-foreground">
+            {wipAlerts.length
+              ? `${wipAlerts.length} lane(s) are above configured limit.`
+              : 'All visible lanes are within configured WIP limits.'}
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {organization.summary.wip.slice(0, 5).map((lane) => (
+              <span key={lane.laneKey} className={`rounded-full border px-2 py-1 text-xs ${lane.overLimit ? 'border-red-500/50 text-red-200' : 'border-silicon-slate/60 text-muted-foreground'}`}>
+                {lane.label}: {lane.count}/{lane.limit}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
 function SummaryStrip({ organization }: { organization: AgentOrgBoardSnapshot }) {
   return (
-    <div className="grid grid-cols-2 gap-3 md:grid-cols-4 xl:grid-cols-7">
+    <div className="grid grid-cols-2 gap-3 md:grid-cols-4 xl:grid-cols-8">
       <MetricCard label="Agents" value={organization.summary.agents} />
       <MetricCard label="Live" value={organization.summary.live_agents} tone="green" />
       <MetricCard label="Work items" value={organization.summary.active_work_items} />
@@ -224,6 +273,7 @@ function SummaryStrip({ organization }: { organization: AgentOrgBoardSnapshot })
       <MetricCard label="Blocked" value={organization.summary.blocked_work_items} tone={organization.summary.blocked_work_items ? 'red' : 'slate'} />
       <MetricCard label="Ready merge" value={organization.summary.ready_for_merge} tone={organization.summary.ready_for_merge ? 'yellow' : 'slate'} />
       <MetricCard label="Approvals" value={organization.summary.pending_approvals} tone={organization.summary.pending_approvals ? 'yellow' : 'slate'} />
+      <MetricCard label="Goals" value={organization.summary.active_goals} tone={organization.summary.active_goals ? 'yellow' : 'slate'} />
     </div>
   )
 }
@@ -267,6 +317,14 @@ function WorkItemCard({ task }: { task: AgentOrgBoardTask }) {
         </div>
         <span className={`rounded-full px-2 py-1 text-xs ${priorityClass(task.priority)}`}>{task.priority}</span>
       </div>
+      {task.goal && (
+        <Link
+          href={task.goal.sessionHref}
+          className="mb-3 inline-flex max-w-full items-center rounded-full border border-radiant-gold/40 bg-radiant-gold/10 px-2 py-1 text-xs text-radiant-gold hover:bg-radiant-gold/15"
+        >
+          <span className="truncate">Goal: {task.goal.title}</span>
+        </Link>
+      )}
       {task.objective && <p className="mb-3 line-clamp-2 text-xs text-muted-foreground">{task.objective}</p>}
       <dl className="grid gap-2 text-xs">
         <CardDetail label="Trace" value={task.activeRunId ?? 'No active trace'} />
@@ -290,7 +348,7 @@ function WorkItemCard({ task }: { task: AgentOrgBoardTask }) {
         </p>
       )}
       <div className="mt-3 flex items-center justify-between gap-2 text-xs text-muted-foreground">
-        <span>{formatRelative(task.updatedAt)}</span>
+        <span>{task.completedAt ? `Cycle ${formatHours(task.createdAt, task.completedAt)}` : `Age ${formatHours(task.createdAt)}`}</span>
         {task.prUrl ? (
           <a
             href={task.prUrl}
@@ -409,9 +467,7 @@ function AgentsGrid({ agents }: { agents: AgentOrgBoardAgent[] }) {
       {agents.map((agent) => (
         <article key={agent.key} className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/15 p-4">
           <div className="mb-4 flex items-start gap-3">
-            <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg border border-radiant-gold/30 bg-radiant-gold/10 text-radiant-gold">
-              <Bot size={22} />
-            </div>
+            <AgentAvatar agentKey={agent.key} size="lg" />
             <div className="min-w-0">
               <div className="flex items-center gap-2">
                 <h2 className="truncate font-semibold" title={agent.name}>{agent.name}</h2>
@@ -456,9 +512,7 @@ function WarRoom({ organization }: { organization: AgentOrgBoardSnapshot }) {
         {organization.warRoom.roster.map((agent) => (
           <article key={agent.key} className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/15 p-4">
             <div className="mb-2 flex items-center gap-3">
-              <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-silicon-slate/70 bg-background/60">
-                <Bot size={18} />
-              </div>
+              <AgentAvatar agentKey={agent.key} size="sm" />
               <div>
                 <p className="font-semibold" title={agent.name}>{agent.name}</p>
                 <p className="text-xs text-muted-foreground">{agent.podName}</p>
@@ -634,4 +688,12 @@ function formatRelative(value: string) {
   if (hours < 24) return `${hours}h ago`
   const days = Math.round(hours / 24)
   return `${days}d ago`
+}
+
+function formatHours(start: string, end?: string | null) {
+  const startTime = new Date(start).getTime()
+  const endTime = end ? new Date(end).getTime() : Date.now()
+  if (!Number.isFinite(startTime) || !Number.isFinite(endTime) || endTime < startTime) return formatRelative(start)
+  const hours = Math.round(((endTime - startTime) / 3_600_000) * 10) / 10
+  return hours < 24 ? `${hours}h` : `${Math.round((hours / 24) * 10) / 10}d`
 }

--- a/app/api/admin/agents/war-room/route.test.ts
+++ b/app/api/admin/agents/war-room/route.test.ts
@@ -76,6 +76,30 @@ describe('POST /api/admin/agents/war-room', () => {
     expect(mocks.runAgentWarRoom).not.toHaveBeenCalled()
   })
 
+  it('requires a target agent for ask_agent', async () => {
+    const response = await POST(request({ command: 'ask_agent', message: 'Status?' }) as never)
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'target_agent_key is required for ask_agent' })
+    expect(mocks.runAgentWarRoom).not.toHaveBeenCalled()
+  })
+
+  it('requires a goal for draft_goal', async () => {
+    const response = await POST(request({ command: 'draft_goal', goal: ' ' }) as never)
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'Goal is required for draft_goal' })
+    expect(mocks.runAgentWarRoom).not.toHaveBeenCalled()
+  })
+
+  it('requires a draft payload for approve_goal', async () => {
+    const response = await POST(request({ command: 'approve_goal' }) as never)
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'draft is required for approve_goal' })
+    expect(mocks.runAgentWarRoom).not.toHaveBeenCalled()
+  })
+
   it('runs a traced standup', async () => {
     const response = await POST(request({ command: 'standup' }) as never)
     const body = await response.json()
@@ -91,6 +115,46 @@ describe('POST /api/admin/agents/war-room', () => {
       command: 'standup',
       triggerSource: 'admin_agent_war_room',
       actor: expect.objectContaining({ id: 'admin-user' }),
+    }))
+  })
+
+  it('passes ask_agent payloads to the war room', async () => {
+    mocks.runAgentWarRoom.mockResolvedValue({
+      runId: 'ask-run',
+      command: 'ask_agent',
+      synthesis: 'Agent responded.',
+      updates: [],
+      messages: [],
+    })
+
+    const response = await POST(request({ command: 'ask_agent', message: 'What is blocked?', target_agent_key: 'chief-of-staff' }) as never)
+
+    expect(response.status).toBe(200)
+    expect(mocks.runAgentWarRoom).toHaveBeenCalledWith(expect.objectContaining({
+      command: 'ask_agent',
+      message: 'What is blocked?',
+      targetAgentKey: 'chief-of-staff',
+    }))
+  })
+
+  it('passes draft_goal without creating work items in the route layer', async () => {
+    mocks.runAgentWarRoom.mockResolvedValue({
+      runId: 'goal-run',
+      command: 'draft_goal',
+      synthesis: 'Goal draft ready.',
+      updates: [],
+      messages: [],
+      goalDraft: { goal_id: 'goal-1', title: 'Ship standup room', objective: 'Ship', recommendation: 'Approve', risk_notes: 'Low', tasks: [] },
+    })
+
+    const response = await POST(request({ command: 'draft_goal', goal: 'Ship standup room' }) as never)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.goal_draft.goal_id).toBe('goal-1')
+    expect(mocks.runAgentWarRoom).toHaveBeenCalledWith(expect.objectContaining({
+      command: 'draft_goal',
+      goal: 'Ship standup room',
     }))
   })
 })

--- a/app/api/admin/agents/war-room/route.ts
+++ b/app/api/admin/agents/war-room/route.ts
@@ -6,7 +6,13 @@ export const dynamic = 'force-dynamic'
 export const maxDuration = 30
 
 function parseCommand(value: unknown): AgentWarRoomCommand | null {
-  return value === 'standup' || value === 'discuss' ? value : null
+  return value === 'standup' ||
+    value === 'discuss' ||
+    value === 'ask_agent' ||
+    value === 'draft_goal' ||
+    value === 'approve_goal'
+    ? value
+    : null
 }
 
 /**
@@ -21,7 +27,14 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: auth.error }, { status: auth.status })
   }
 
-  let body: { command?: unknown; message?: unknown }
+  let body: {
+    command?: unknown
+    message?: unknown
+    target_agent_key?: unknown
+    targetAgentKey?: unknown
+    goal?: unknown
+    draft?: unknown
+  }
   try {
     body = await request.json()
   } catch {
@@ -34,14 +47,35 @@ export async function POST(request: NextRequest) {
   }
 
   const message = typeof body.message === 'string' ? body.message.trim() : ''
-  if (command === 'discuss' && !message) {
-    return NextResponse.json({ error: 'Message is required for discuss' }, { status: 400 })
+  if ((command === 'discuss' || command === 'ask_agent') && !message) {
+    return NextResponse.json({ error: `Message is required for ${command}` }, { status: 400 })
+  }
+
+  const targetAgentKey = typeof body.target_agent_key === 'string'
+    ? body.target_agent_key.trim()
+    : typeof body.targetAgentKey === 'string'
+      ? body.targetAgentKey.trim()
+      : ''
+  if (command === 'ask_agent' && !targetAgentKey) {
+    return NextResponse.json({ error: 'target_agent_key is required for ask_agent' }, { status: 400 })
+  }
+
+  const goal = typeof body.goal === 'string' ? body.goal.trim() : ''
+  if (command === 'draft_goal' && !goal) {
+    return NextResponse.json({ error: 'Goal is required for draft_goal' }, { status: 400 })
+  }
+
+  if (command === 'approve_goal' && (!body.draft || typeof body.draft !== 'object')) {
+    return NextResponse.json({ error: 'draft is required for approve_goal' }, { status: 400 })
   }
 
   try {
     const result = await runAgentWarRoom({
       command,
       message,
+      targetAgentKey,
+      goal,
+      draft: command === 'approve_goal' ? body.draft as never : null,
       triggerSource: 'admin_agent_war_room',
       actor: {
         id: auth.user.id,
@@ -56,6 +90,9 @@ export async function POST(request: NextRequest) {
       command: result.command,
       updates: result.updates,
       synthesis: result.synthesis,
+      messages: result.messages,
+      goal_draft: result.goalDraft,
+      created_work_items: result.createdWorkItems,
     })
   } catch (error) {
     console.error('[agent-war-room] command failed:', error)

--- a/components/admin/AdminSidebar.test.tsx
+++ b/components/admin/AdminSidebar.test.tsx
@@ -16,6 +16,7 @@ describe('AdminSidebar Agent Ops hierarchy', () => {
     const nav = screen.getByRole('navigation', { name: 'Admin navigation' })
     expect(within(nav).getByText('Agent Ops')).toBeInTheDocument()
     expect(within(nav).getByRole('link', { name: 'Mission Control' })).toHaveAttribute('href', '/admin/agents')
+    expect(within(nav).getByRole('link', { name: 'Standup Room' })).toHaveAttribute('href', '/admin/agents/standup')
     expect(within(nav).getByRole('link', { name: 'Decision Queue' })).toHaveAttribute('href', '/admin/agents/coordination')
     expect(within(nav).getByRole('link', { name: 'Agent Kanban' })).toHaveAttribute('href', '/admin/agents/swarm-board')
     expect(within(nav).getByRole('link', { name: 'Run Console' })).toHaveAttribute('href', '/admin/agents/runs')
@@ -30,6 +31,7 @@ describe('AdminSidebar Agent Ops hierarchy', () => {
     expect(qualityCategory?.items.map((item) => item.href)).not.toContain('/admin/agents')
     expect(agentOpsCategory?.items.map((item) => item.href)).toEqual([
       '/admin/agents',
+      '/admin/agents/standup',
       '/admin/agents/coordination',
       '/admin/agents/swarm-board',
       '/admin/agents/runs',

--- a/components/admin/AdminSidebar.tsx
+++ b/components/admin/AdminSidebar.tsx
@@ -49,6 +49,7 @@ import {
   ClipboardCheck,
   Columns,
   TerminalSquare,
+  MessagesSquare,
 } from 'lucide-react'
 import { ADMIN_NAV, isNavItemActive, isContentExpanded, isChatEvalExpanded } from '@/lib/admin-nav'
 import { useState, useEffect } from 'react'
@@ -86,6 +87,7 @@ const NAV_ITEM_ICONS: Record<string, LucideIcon> = {
   '/admin/analytics': BarChart3,
   '/admin/cost-revenue': DollarSign,
   '/admin/agents': Bot,
+  '/admin/agents/standup': MessagesSquare,
   '/admin/agents/coordination': ClipboardCheck,
   '/admin/agents/swarm-board': Columns,
   '/admin/agents/runs': TerminalSquare,

--- a/components/admin/AgentAvatar.tsx
+++ b/components/admin/AgentAvatar.tsx
@@ -1,0 +1,41 @@
+import { getAgentAvatar, getAvatarToneStyles } from '@/lib/agent-avatars'
+
+export default function AgentAvatar({
+  agentKey,
+  size = 'md',
+  className = '',
+}: {
+  agentKey?: string | null
+  size?: 'sm' | 'md' | 'lg'
+  className?: string
+}) {
+  const avatar = getAgentAvatar(agentKey)
+  const tone = getAvatarToneStyles(avatar.tone)
+  const sizeClass = size === 'sm' ? 'h-8 w-8 text-[10px]' : size === 'lg' ? 'h-14 w-14 text-sm' : 'h-11 w-11 text-xs'
+
+  return (
+    <div
+      role="img"
+      aria-label={avatar.label}
+      title={`${avatar.label} - ${avatar.culturalCue}`}
+      className={`relative flex shrink-0 items-center justify-center overflow-hidden rounded-xl border font-semibold tracking-wide shadow-[0_0_24px_rgba(216,180,44,0.12)] ${sizeClass} ${className}`}
+      style={{
+        borderColor: tone.ring,
+        background: `radial-gradient(circle at 35% 20%, ${tone.mark}44, transparent 35%), linear-gradient(145deg, ${tone.wash}, #07111f 78%)`,
+        color: tone.mark,
+      }}
+    >
+      <span
+        aria-hidden="true"
+        className="absolute inset-x-2 top-1 h-1 rounded-full opacity-75"
+        style={{ backgroundColor: tone.ring }}
+      />
+      <span
+        aria-hidden="true"
+        className="absolute bottom-1 right-1 h-3 w-3 rounded-full opacity-50"
+        style={{ backgroundColor: tone.mark }}
+      />
+      <span className="relative z-10">{avatar.initials}</span>
+    </div>
+  )
+}

--- a/lib/admin-nav.ts
+++ b/lib/admin-nav.ts
@@ -84,6 +84,7 @@ export const ADMIN_NAV: { dashboard: AdminNavItem; categories: AdminNavCategory[
       label: 'Agent Ops',
       items: [
         { label: 'Mission Control', href: '/admin/agents' },
+        { label: 'Standup Room', href: '/admin/agents/standup' },
         { label: 'Decision Queue', href: '/admin/agents/coordination' },
         { label: 'Agent Kanban', href: '/admin/agents/swarm-board' },
         { label: 'Run Console', href: '/admin/agents/runs' },

--- a/lib/agent-avatars.test.ts
+++ b/lib/agent-avatars.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { AGENT_ORGANIZATION } from '@/lib/agent-organization'
+import { AGENT_AVATARS, getMissingAgentAvatarKeys } from '@/lib/agent-avatars'
+
+describe('agent avatar manifest', () => {
+  it('covers every stable agent organization key', () => {
+    expect(getMissingAgentAvatarKeys()).toEqual([])
+  })
+
+  it('provides accessible labels for every organization avatar', () => {
+    for (const agent of AGENT_ORGANIZATION) {
+      expect(AGENT_AVATARS[agent.key]?.label).toContain('Illustrated avatar')
+      expect(AGENT_AVATARS[agent.key]?.initials.length).toBeGreaterThan(1)
+    }
+  })
+})

--- a/lib/agent-avatars.ts
+++ b/lib/agent-avatars.ts
@@ -1,0 +1,206 @@
+import { AGENT_ORGANIZATION } from '@/lib/agent-organization'
+
+export type AgentAvatarTone = 'gold' | 'emerald' | 'cyan' | 'violet' | 'rose' | 'amber'
+
+export interface AgentAvatarDefinition {
+  agentKey: string
+  label: string
+  initials: string
+  motif: string
+  tone: AgentAvatarTone
+  culturalCue: string
+}
+
+const AVATAR_TONES: Record<AgentAvatarTone, { ring: string; wash: string; mark: string }> = {
+  gold: { ring: '#d8b42c', wash: '#332a12', mark: '#f6d34c' },
+  emerald: { ring: '#40c58a', wash: '#123326', mark: '#82f0bd' },
+  cyan: { ring: '#4db7e8', wash: '#102c3b', mark: '#9ce3ff' },
+  violet: { ring: '#a78bfa', wash: '#241b3d', mark: '#c4b5fd' },
+  rose: { ring: '#fb7185', wash: '#3a1620', mark: '#fecdd3' },
+  amber: { ring: '#f59e0b', wash: '#3a260a', mark: '#fde68a' },
+}
+
+export const AGENT_AVATARS: Record<string, AgentAvatarDefinition> = {
+  'chief-of-staff': {
+    agentKey: 'chief-of-staff',
+    label: 'Illustrated avatar for Shaka, Chief of Staff',
+    initials: 'SZ',
+    motif: 'shield',
+    tone: 'gold',
+    culturalCue: 'Zulu command silhouette',
+  },
+  'strategic-narrative': {
+    agentKey: 'strategic-narrative',
+    label: 'Illustrated avatar for Amina, Strategic Narrative',
+    initials: 'AZ',
+    motif: 'star',
+    tone: 'rose',
+    culturalCue: 'Zazzau leadership cue',
+  },
+  'proposal-business-model': {
+    agentKey: 'proposal-business-model',
+    label: 'Illustrated avatar for Mansa Musa, Proposal and Business Model',
+    initials: 'MM',
+    motif: 'coin',
+    tone: 'amber',
+    culturalCue: 'Mali commerce cue',
+  },
+  'legacy-institution-builder': {
+    agentKey: 'legacy-institution-builder',
+    label: 'Illustrated avatar for Sundiata Keita, Legacy Institution Builder',
+    initials: 'SK',
+    motif: 'arch',
+    tone: 'emerald',
+    culturalCue: 'Mali institution cue',
+  },
+  'research-source-register': {
+    agentKey: 'research-source-register',
+    label: 'Illustrated avatar for Askia Muhammad, Research Source Register',
+    initials: 'AM',
+    motif: 'scroll',
+    tone: 'cyan',
+    culturalCue: 'Songhai scholarship cue',
+  },
+  'private-knowledge-librarian': {
+    agentKey: 'private-knowledge-librarian',
+    label: 'Illustrated avatar for Hatshepsut, Private Knowledge Librarian',
+    initials: 'HK',
+    motif: 'obelisk',
+    tone: 'violet',
+    culturalCue: 'Kemet archive cue',
+  },
+  'decision-journal': {
+    agentKey: 'decision-journal',
+    label: 'Illustrated avatar for Nzinga, Decision Journal',
+    initials: 'NM',
+    motif: 'crown',
+    tone: 'gold',
+    culturalCue: 'Ndongo and Matamba diplomacy cue',
+  },
+  'risk-compliance-intelligence': {
+    agentKey: 'risk-compliance-intelligence',
+    label: 'Illustrated avatar for Moremi, Risk and Compliance',
+    initials: 'MI',
+    motif: 'eye',
+    tone: 'rose',
+    culturalCue: 'Ife vigilance cue',
+  },
+  'voice-content-architect': {
+    agentKey: 'voice-content-architect',
+    label: 'Illustrated avatar for Nefertiti, Voice and Content Architect',
+    initials: 'NK',
+    motif: 'pen',
+    tone: 'violet',
+    culturalCue: 'Kemet voice cue',
+  },
+  'content-repurposing': {
+    agentKey: 'content-repurposing',
+    label: 'Illustrated avatar for Hannibal, Content Repurposing',
+    initials: 'HC',
+    motif: 'route',
+    tone: 'amber',
+    culturalCue: 'Carthage campaign cue',
+  },
+  'amadutown-brand': {
+    agentKey: 'amadutown-brand',
+    label: 'Illustrated avatar for Taharqa, AmaduTown Brand',
+    initials: 'TK',
+    motif: 'sun',
+    tone: 'gold',
+    culturalCue: 'Kush brand cue',
+  },
+  'course-curriculum-builder': {
+    agentKey: 'course-curriculum-builder',
+    label: 'Illustrated avatar for Menelik, Course and Curriculum Builder',
+    initials: 'ME',
+    motif: 'book',
+    tone: 'emerald',
+    culturalCue: 'Ethiopia curriculum cue',
+  },
+  'engineering-copilot': {
+    agentKey: 'engineering-copilot',
+    label: 'Illustrated avatar for Piye, Engineering Copilot',
+    initials: 'PK',
+    motif: 'forge',
+    tone: 'cyan',
+    culturalCue: 'Kush engineering cue',
+  },
+  'automation-systems': {
+    agentKey: 'automation-systems',
+    label: 'Illustrated avatar for Yaa Asantewaa, Automation Systems',
+    initials: 'YA',
+    motif: 'bolt',
+    tone: 'gold',
+    culturalCue: 'Ashanti operations cue',
+  },
+  'agent-tooling-parity': {
+    agentKey: 'agent-tooling-parity',
+    label: 'Illustrated avatar for Ezana, Agent Tooling Parity',
+    initials: 'EA',
+    motif: 'link',
+    tone: 'cyan',
+    culturalCue: 'Aksum tooling cue',
+  },
+  'website-product-copy': {
+    agentKey: 'website-product-copy',
+    label: 'Illustrated avatar for Makeda, Website and Product Copy',
+    initials: 'MS',
+    motif: 'diamond',
+    tone: 'violet',
+    culturalCue: 'Sheba clarity cue',
+  },
+  'inbox-follow-up': {
+    agentKey: 'inbox-follow-up',
+    label: 'Illustrated avatar for Samori Toure, Inbox and Follow-Up',
+    initials: 'ST',
+    motif: 'signal',
+    tone: 'emerald',
+    culturalCue: 'Wassoulou follow-up cue',
+  },
+  'warm-lead-capture': {
+    agentKey: 'warm-lead-capture',
+    label: 'Illustrated avatar for Behanzin, Warm Lead Capture',
+    initials: 'BD',
+    motif: 'net',
+    tone: 'amber',
+    culturalCue: 'Dahomey capture cue',
+  },
+  'meeting-intake-follow-up': {
+    agentKey: 'meeting-intake-follow-up',
+    label: 'Illustrated avatar for Amanirenas, Meeting Intake and Follow-Up',
+    initials: 'AK',
+    motif: 'moon',
+    tone: 'rose',
+    culturalCue: 'Kush meeting cue',
+  },
+  'integration-captain': {
+    agentKey: 'integration-captain',
+    label: 'Illustrated avatar for the Integration Captain lane',
+    initials: 'IC',
+    motif: 'helm',
+    tone: 'gold',
+    culturalCue: 'Integration command cue',
+  },
+}
+
+export function getAgentAvatar(agentKey: string | null | undefined): AgentAvatarDefinition {
+  if (agentKey && AGENT_AVATARS[agentKey]) return AGENT_AVATARS[agentKey]
+  return {
+    agentKey: agentKey ?? 'unknown',
+    label: 'Illustrated avatar for unassigned agent work',
+    initials: 'AI',
+    motif: 'node',
+    tone: 'cyan',
+    culturalCue: 'Unassigned work cue',
+  }
+}
+
+export function getAvatarToneStyles(tone: AgentAvatarTone) {
+  return AVATAR_TONES[tone]
+}
+
+export function getMissingAgentAvatarKeys() {
+  return AGENT_ORGANIZATION
+    .map((agent) => agent.key)
+    .filter((key) => !AGENT_AVATARS[key])
+}

--- a/lib/agent-swarm-board.ts
+++ b/lib/agent-swarm-board.ts
@@ -120,7 +120,37 @@ export type AgentOrgBoardTask = {
   blockerSummary: string | null
   validationSummary: string | null
   overlapGroup: string | null
+  parentWorkItemId: string | null
+  createdAt: string
   updatedAt: string
+  completedAt: string | null
+  goal: {
+    id: string
+    title: string
+    sequence: number | null
+    status: string | null
+    progressWeight: number
+    sessionHref: string
+  } | null
+}
+
+export type AgentOrgBoardGoalMetric = {
+  id: string
+  title: string
+  total: number
+  completed: number
+  progress: number
+  blocked: number
+  open: number
+  burndown: Array<{ label: string; remaining: number }>
+}
+
+export type AgentOrgBoardWipMetric = {
+  laneKey: string
+  label: string
+  count: number
+  limit: number
+  overLimit: boolean
 }
 
 export type AgentOrgBoardLane = {
@@ -176,6 +206,11 @@ export type AgentOrgBoardSnapshot = {
     ready_for_merge: number
     pending_approvals: number
     activity_entries: number
+    active_goals: number
+    average_cycle_hours: number | null
+    oldest_in_flight_hours: number | null
+    wip: AgentOrgBoardWipMetric[]
+    goals: AgentOrgBoardGoalMetric[]
   }
   agents: AgentOrgBoardAgent[]
   lanes: AgentOrgBoardLane[]
@@ -289,6 +324,9 @@ type AgentWorkItemRow = {
   blocker_summary: string | null
   validation_summary: string | null
   approval_id: string | null
+  parent_work_item_id?: string | null
+  metadata?: JsonRecord | null
+  completed_at?: string | null
   created_at: string
   updated_at: string
 }
@@ -754,6 +792,68 @@ function laneKeyForTask(task: AgentWorkItemRow) {
   return task.owner_agent_key
 }
 
+function numberValue(value: unknown, fallback = 0) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+function goalForTask(item: AgentWorkItemRow): AgentOrgBoardTask['goal'] {
+  const metadata = item.metadata ?? {}
+  const goalId = stringValue(metadata.goal_id)
+  const goalTitle = stringValue(metadata.goal_title)
+  if (!goalId || !goalTitle) return null
+  return {
+    id: goalId,
+    title: goalTitle,
+    sequence: typeof metadata.goal_sequence === 'number' ? metadata.goal_sequence : null,
+    status: stringValue(metadata.goal_status),
+    progressWeight: numberValue(metadata.goal_progress_weight, 1),
+    sessionHref: `/admin/agents/standup?goal=${encodeURIComponent(goalId)}`,
+  }
+}
+
+function hoursBetween(start: string | null | undefined, end: Date | string | null | undefined) {
+  if (!start) return null
+  const startMs = new Date(start).getTime()
+  const endMs = end ? new Date(end).getTime() : Date.now()
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs < startMs) return null
+  return Math.round(((endMs - startMs) / 3_600_000) * 10) / 10
+}
+
+function isCompletedWorkStatus(status: AgentOrgBoardTaskStatus) {
+  return status === 'merged' || status === 'deployed'
+}
+
+function buildGoalMetrics(tasks: AgentOrgBoardTask[]): AgentOrgBoardGoalMetric[] {
+  const grouped = new Map<string, AgentOrgBoardTask[]>()
+  for (const task of tasks) {
+    if (!task.goal) continue
+    grouped.set(task.goal.id, [...(grouped.get(task.goal.id) ?? []), task])
+  }
+
+  return [...grouped.entries()].map(([id, goalTasks]) => {
+    const title = goalTasks[0]?.goal?.title ?? id
+    const totalWeight = goalTasks.reduce((sum, task) => sum + (task.goal?.progressWeight ?? 1), 0) || goalTasks.length || 1
+    const completedWeight = goalTasks
+      .filter((task) => isCompletedWorkStatus(task.status))
+      .reduce((sum, task) => sum + (task.goal?.progressWeight ?? 1), 0)
+    const sorted = [...goalTasks].sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+    const burndown = sorted.slice(0, 6).map((task, index) => ({
+      label: task.completedAt ? new Date(task.completedAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) : `T${index + 1}`,
+      remaining: sorted.filter((candidate) => !isCompletedWorkStatus(candidate.status) || new Date(candidate.updatedAt).getTime() > new Date(task.updatedAt).getTime()).length,
+    }))
+    return {
+      id,
+      title,
+      total: goalTasks.length,
+      completed: goalTasks.filter((task) => isCompletedWorkStatus(task.status)).length,
+      progress: Math.round((completedWeight / totalWeight) * 100),
+      blocked: goalTasks.filter((task) => task.status === 'blocked').length,
+      open: goalTasks.filter((task) => isActiveWorkStatus(task.status)).length,
+      burndown,
+    }
+  })
+}
+
 function fallbackAgentForRun(run: AgentRunRow | undefined) {
   if (!run) return AGENT_ORGANIZATION[0]
   if (run.agent_key) return getAgentByKey(run.agent_key) ?? AGENT_ORGANIZATION[0]
@@ -811,7 +911,11 @@ export function buildAgentOrgBoardSnapshotFromRows(input: AgentOrgBoardBuildInpu
     blockerSummary: item.blocker_summary,
     validationSummary: item.validation_summary,
     overlapGroup: item.overlap_group,
+    parentWorkItemId: item.parent_work_item_id ?? null,
+    createdAt: item.created_at,
     updatedAt: item.updated_at,
+    completedAt: item.completed_at ?? null,
+    goal: goalForTask(item),
   }))
 
   const laneSeeds: AgentOrgBoardLane[] = [
@@ -887,6 +991,24 @@ export function buildAgentOrgBoardSnapshotFromRows(input: AgentOrgBoardBuildInpu
     }))
 
   const activeTasks = tasks.filter((task) => isActiveWorkStatus(task.status))
+  const completedCycleHours = tasks
+    .filter((task) => isCompletedWorkStatus(task.status))
+    .map((task) => hoursBetween(task.createdAt, task.completedAt ?? task.updatedAt))
+    .filter((value): value is number => value != null)
+  const activeAges = activeTasks
+    .map((task) => hoursBetween(task.createdAt, now))
+    .filter((value): value is number => value != null)
+  const wip = lanes.map((lane) => {
+    const limit = lane.key === 'integration-captain' ? 3 : lane.key === 'inbox' ? 6 : 4
+    return {
+      laneKey: lane.key,
+      label: lane.label,
+      count: lane.tasks.length,
+      limit,
+      overLimit: lane.tasks.length > limit,
+    }
+  })
+  const goals = buildGoalMetrics(tasks)
 
   return {
     generated_at: now.toISOString(),
@@ -899,6 +1021,13 @@ export function buildAgentOrgBoardSnapshotFromRows(input: AgentOrgBoardBuildInpu
       ready_for_merge: activeTasks.filter((task) => task.status === 'ready_for_merge').length,
       pending_approvals: pendingApprovals.length,
       activity_entries: activity.length,
+      active_goals: goals.filter((goal) => goal.open > 0).length,
+      average_cycle_hours: completedCycleHours.length
+        ? Math.round((completedCycleHours.reduce((sum, value) => sum + value, 0) / completedCycleHours.length) * 10) / 10
+        : null,
+      oldest_in_flight_hours: activeAges.length ? Math.max(...activeAges) : null,
+      wip,
+      goals,
     },
     agents,
     lanes,
@@ -1031,7 +1160,7 @@ export async function buildAgentOrgBoardSnapshot(): Promise<AgentOrgBoardSnapsho
       .limit(120),
     db
       .from('agent_work_items')
-      .select('id, title, objective, status, priority, owner_agent_key, owner_runtime, active_run_id, branch_name, worktree_path, pr_number, pr_url, overlap_group, blocker_summary, validation_summary, approval_id, created_at, updated_at')
+      .select('id, title, objective, status, priority, owner_agent_key, owner_runtime, active_run_id, parent_work_item_id, branch_name, worktree_path, pr_number, pr_url, overlap_group, blocker_summary, validation_summary, approval_id, metadata, completed_at, created_at, updated_at')
       .order('updated_at', { ascending: false })
       .limit(100),
     db

--- a/lib/agent-war-room.test.ts
+++ b/lib/agent-war-room.test.ts
@@ -12,6 +12,10 @@ const missionMocks = vi.hoisted(() => ({
   buildAgentMissionControlSnapshot: vi.fn(),
 }))
 
+const workItemMocks = vi.hoisted(() => ({
+  createAgentWorkItem: vi.fn(),
+}))
+
 vi.mock('@/lib/agent-run', () => ({
   startAgentRun: agentRunMocks.startAgentRun,
   recordAgentEvent: agentRunMocks.recordAgentEvent,
@@ -24,6 +28,10 @@ vi.mock('@/lib/agent-mission-control', () => ({
   buildAgentMissionControlSnapshot: missionMocks.buildAgentMissionControlSnapshot,
 }))
 
+vi.mock('@/lib/agent-work-items', () => ({
+  createAgentWorkItem: workItemMocks.createAgentWorkItem,
+}))
+
 import { runAgentWarRoom } from '@/lib/agent-war-room'
 
 describe('runAgentWarRoom', () => {
@@ -34,6 +42,30 @@ describe('runAgentWarRoom', () => {
     agentRunMocks.recordAgentEvent.mockResolvedValue({ id: 'event' })
     agentRunMocks.attachAgentArtifact.mockResolvedValue({ id: 'artifact' })
     agentRunMocks.endAgentRun.mockResolvedValue(undefined)
+    missionMocks.buildAgentMissionControlSnapshot.mockResolvedValue({
+      status_strip: {
+        active: 2,
+        running: 1,
+        failed: 0,
+        stale: 0,
+        waiting_for_approval: 0,
+        pending_approvals: 0,
+        cost_today: 0,
+      },
+      attention_queue: [],
+    })
+    workItemMocks.createAgentWorkItem.mockImplementation(async (input) => ({
+      id: input.parentWorkItemId ? `child-${input.title}` : 'parent-goal',
+      title: input.title,
+      objective: input.objective,
+      metadata: input.metadata ?? {},
+    }))
+    workItemMocks.createAgentWorkItem.mockImplementation(async (input) => ({
+      id: input.parentWorkItemId ? `child-${input.title}` : 'parent-goal',
+      title: input.title,
+      objective: input.objective,
+      metadata: input.metadata ?? {},
+    }))
     missionMocks.buildAgentMissionControlSnapshot.mockResolvedValue({
       status_strip: {
         active: 2,
@@ -59,7 +91,7 @@ describe('runAgentWarRoom', () => {
       agentKey: 'chief-of-staff',
       runtime: 'manual',
       kind: 'agent_war_room_standup',
-      title: 'Agent War Room standup',
+      title: 'Agent Standup Room session',
     }))
     expect(agentRunMocks.recordAgentStep).toHaveBeenCalledWith(expect.objectContaining({
       runId: 'war-room-run',
@@ -71,7 +103,7 @@ describe('runAgentWarRoom', () => {
     }))
     expect(agentRunMocks.attachAgentArtifact).toHaveBeenCalledWith(expect.objectContaining({
       runId: 'war-room-run',
-      artifactType: 'war_room_standup_transcript',
+      artifactType: 'war_room_transcript',
     }))
     expect(agentRunMocks.endAgentRun).toHaveBeenCalledWith(expect.objectContaining({
       runId: 'war-room-run',
@@ -90,5 +122,58 @@ describe('runAgentWarRoom', () => {
     ).rejects.toThrow('Message is required for discuss')
 
     expect(agentRunMocks.startAgentRun).not.toHaveBeenCalled()
+  })
+
+  it('returns a draft goal without creating work items', async () => {
+    const result = await runAgentWarRoom({
+      command: 'draft_goal',
+      goal: 'Build a transparent standup room',
+      triggerSource: 'test_war_room',
+    })
+
+    expect(result.goalDraft?.title).toBe('Build a transparent standup room')
+    expect(result.goalDraft?.tasks.length).toBeGreaterThan(2)
+    expect(workItemMocks.createAgentWorkItem).not.toHaveBeenCalled()
+    expect(agentRunMocks.attachAgentArtifact).toHaveBeenCalledWith(expect.objectContaining({
+      artifactType: 'war_room_goal_draft',
+    }))
+  })
+
+  it('creates parent and child work items when a goal draft is approved', async () => {
+    const draftResult = await runAgentWarRoom({
+      command: 'draft_goal',
+      goal: 'Add goal orchestration',
+      triggerSource: 'test_war_room',
+    })
+    vi.clearAllMocks()
+    agentRunMocks.startAgentRun.mockResolvedValue({ id: 'approval-run' })
+    agentRunMocks.recordAgentStep.mockResolvedValue({ id: 'step' })
+    agentRunMocks.recordAgentEvent.mockResolvedValue({ id: 'event' })
+    agentRunMocks.attachAgentArtifact.mockResolvedValue({ id: 'artifact' })
+    agentRunMocks.endAgentRun.mockResolvedValue(undefined)
+
+    const result = await runAgentWarRoom({
+      command: 'approve_goal',
+      draft: draftResult.goalDraft,
+      triggerSource: 'test_war_room',
+    })
+
+    expect(workItemMocks.createAgentWorkItem).toHaveBeenCalledTimes(1 + (draftResult.goalDraft?.tasks.length ?? 0))
+    expect(workItemMocks.createAgentWorkItem).toHaveBeenCalledWith(expect.objectContaining({
+      title: expect.stringContaining('Goal:'),
+      metadata: expect.objectContaining({ goal_role: 'parent' }),
+    }))
+    expect(result.createdWorkItems?.children.length).toBe(draftResult.goalDraft?.tasks.length)
+  })
+
+  it('rejects invalid direct agent asks', async () => {
+    await expect(
+      runAgentWarRoom({
+        command: 'ask_agent',
+        message: 'Status?',
+        targetAgentKey: 'missing-agent',
+        triggerSource: 'test_war_room',
+      }),
+    ).rejects.toThrow('Invalid agent key')
   })
 })

--- a/lib/agent-war-room.ts
+++ b/lib/agent-war-room.ts
@@ -5,14 +5,49 @@ import {
   recordAgentStep,
   startAgentRun,
 } from '@/lib/agent-run'
-import { AGENT_ORGANIZATION, AGENT_PODS } from '@/lib/agent-organization'
+import { AGENT_ORGANIZATION, AGENT_PODS, getAgentByKey, type AgentOrganizationNode } from '@/lib/agent-organization'
 import { buildAgentMissionControlSnapshot } from '@/lib/agent-mission-control'
+import { createAgentWorkItem, type AgentWorkItem, type AgentWorkItemPriority } from '@/lib/agent-work-items'
 
-export type AgentWarRoomCommand = 'standup' | 'discuss'
+export type AgentWarRoomCommand = 'standup' | 'discuss' | 'ask_agent' | 'draft_goal' | 'approve_goal'
+
+export interface AgentGoalDraftTask {
+  id: string
+  title: string
+  objective: string
+  owner_agent_key: string
+  priority: AgentWorkItemPriority
+  dependencies: string[]
+  expected_files: string[]
+  acceptance_criteria: string[]
+  risk_notes: string
+  goal_progress_weight: number
+}
+
+export interface AgentGoalDraft {
+  goal_id: string
+  title: string
+  objective: string
+  recommendation: string
+  risk_notes: string
+  tasks: AgentGoalDraftTask[]
+}
+
+export interface AgentWarRoomMessage {
+  id: string
+  role: 'system' | 'user' | 'agent'
+  agent_key?: string
+  agent_name?: string
+  content: string
+  created_at: string
+}
 
 export interface RunAgentWarRoomInput {
   command: AgentWarRoomCommand
   message?: string | null
+  targetAgentKey?: string | null
+  goal?: string | null
+  draft?: AgentGoalDraft | null
   triggerSource: string
   actor?: {
     id?: string | null
@@ -22,7 +57,7 @@ export interface RunAgentWarRoomInput {
 }
 
 function assertCommand(command: string): asserts command is AgentWarRoomCommand {
-  if (command !== 'standup' && command !== 'discuss') {
+  if (!['standup', 'discuss', 'ask_agent', 'draft_goal', 'approve_goal'].includes(command)) {
     throw new Error('Invalid war room command')
   }
 }
@@ -31,9 +66,28 @@ function podName(podKey: string) {
   return AGENT_PODS.find((pod) => pod.key === podKey)?.name ?? podKey
 }
 
-function selectAgents(command: AgentWarRoomCommand, message: string | null) {
-  const callable = AGENT_ORGANIZATION.filter((agent) => agent.status !== 'planned')
+function callableAgents() {
+  return AGENT_ORGANIZATION.filter((agent) => agent.status !== 'planned')
+}
+
+function selectAgents(command: AgentWarRoomCommand, message: string | null, targetAgentKey?: string | null) {
+  if (command === 'ask_agent') {
+    const agent = getAgentByKey(targetAgentKey ?? '')
+    if (!agent || agent.status === 'planned') throw new Error('Invalid agent key')
+    return [agent]
+  }
+
+  const callable = callableAgents()
   if (command === 'standup') return callable.slice(0, 8)
+  if (command === 'draft_goal' || command === 'approve_goal') {
+    return [
+      getAgentByKey('chief-of-staff'),
+      getAgentByKey('engineering-copilot'),
+      getAgentByKey('automation-systems'),
+      getAgentByKey('research-source-register'),
+      getAgentByKey('risk-compliance-intelligence'),
+    ].filter(Boolean) as AgentOrganizationNode[]
+  }
 
   const text = (message ?? '').toLowerCase()
   const ranked = callable
@@ -55,12 +109,14 @@ function selectAgents(command: AgentWarRoomCommand, message: string | null) {
   return (picked.length ? picked : callable).slice(0, 5)
 }
 
-function agentUpdate(agent: (typeof AGENT_ORGANIZATION)[number], command: AgentWarRoomCommand, message: string | null) {
+function agentUpdate(agent: AgentOrganizationNode, command: AgentWarRoomCommand, message: string | null) {
   const activeWorkflows = agent.n8nWorkflows.filter((workflow) => workflow.active).length
   const scope =
     command === 'standup'
       ? `Current posture: ${agent.status}; ${activeWorkflows} active mapped workflow(s).`
-      : `Perspective on "${message}": ${agent.responsibility}`
+      : command === 'ask_agent'
+        ? `Direct response: ${agent.responsibility}. Request: "${message}".`
+        : `Perspective on "${message}": ${agent.responsibility}`
 
   return {
     agent_key: agent.key,
@@ -71,7 +127,7 @@ function agentUpdate(agent: (typeof AGENT_ORGANIZATION)[number], command: AgentW
     update: scope,
     next_action: agent.status === 'active'
       ? 'Ready for read-only engagement through Agent Ops.'
-      : 'Use Chief of Staff routing before assigning production work.',
+      : 'Use Shaka routing before assigning production work.',
     approval_gate: agent.approvalGate,
   }
 }
@@ -80,50 +136,263 @@ function synthesize(command: AgentWarRoomCommand, updates: ReturnType<typeof age
   if (command === 'standup') {
     const ready = updates.filter((update) => update.status === 'active').length
     const partial = updates.filter((update) => update.status === 'partial').length
-    return `Standup complete: ${ready} active agent(s), ${partial} partial agent(s), and ${attentionCount} item(s) in the attention queue. Start with the attention queue, then route the next task through Chief of Staff.`
+    return `Standup complete: ${ready} active agent(s), ${partial} partial agent(s), and ${attentionCount} item(s) in the attention queue. Start with the attention queue, then route the next task through Shaka.`
+  }
+  if (command === 'ask_agent') {
+    return `${updates[0]?.agent_name ?? 'Selected agent'} responded with scoped Agent Ops context.`
+  }
+  if (command === 'draft_goal') {
+    return 'Goal draft ready for operator review. No work items were created.'
+  }
+  if (command === 'approve_goal') {
+    return 'Goal approved and converted into traceable Agent Ops work items.'
   }
 
   const pods = Array.from(new Set(updates.map((update) => update.pod))).join(', ')
-  return `Discussion complete across ${pods}. Treat this as advisory context: use Chief of Staff to convert it into one traced engagement or approval-gated action.`
+  return `Discussion complete across ${pods}. Treat this as advisory context until Shaka converts it into traced work.`
+}
+
+function messageFromUpdate(update: ReturnType<typeof agentUpdate>, index: number): AgentWarRoomMessage {
+  return {
+    id: `agent-${index}-${update.agent_key}`,
+    role: 'agent',
+    agent_key: update.agent_key,
+    agent_name: update.agent_name,
+    content: `${update.update} Next action: ${update.next_action}`,
+    created_at: new Date().toISOString(),
+  }
+}
+
+function goalIdFromTitle(title: string) {
+  const slug = title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 48) || 'goal'
+  return `goal-${slug}-${Date.now().toString(36)}`
+}
+
+function draftGoal(goal: string): AgentGoalDraft {
+  const title = goal.trim().replace(/\s+/g, ' ').slice(0, 120)
+  const goalId = goalIdFromTitle(title)
+  const tasks: AgentGoalDraftTask[] = [
+    {
+      id: `${goalId}-scope`,
+      title: `Frame the goal and acceptance gate`,
+      objective: `Shaka converts "${title}" into a reviewable execution packet with scope, owners, and approval boundaries.`,
+      owner_agent_key: 'chief-of-staff',
+      priority: 'high',
+      dependencies: [],
+      expected_files: ['app/admin/agents/**', 'lib/agent-*.ts'],
+      acceptance_criteria: ['Goal scope is explicit', 'Approval and rollback gates are named', 'Kanban owner lanes are assigned'],
+      risk_notes: 'Scope can sprawl if the goal is not constrained before worker assignment.',
+      goal_progress_weight: 1,
+    },
+    {
+      id: `${goalId}-implementation`,
+      title: `Implement the primary change set`,
+      objective: 'Piye owns the code path or product surface that most directly satisfies the approved goal.',
+      owner_agent_key: 'engineering-copilot',
+      priority: 'high',
+      dependencies: [`${goalId}-scope`],
+      expected_files: ['app/**', 'components/**', 'lib/**'],
+      acceptance_criteria: ['Feature works in the relevant admin surface', 'Focused tests cover the new behavior', 'No unrelated draft work is swept in'],
+      risk_notes: 'Implementation should remain in a feature branch until validation passes.',
+      goal_progress_weight: 2,
+    },
+    {
+      id: `${goalId}-automation`,
+      title: `Check workflow and trace impact`,
+      objective: 'Yaa Asantewaa verifies whether existing automation, trace, or operator workflows need updates for the goal.',
+      owner_agent_key: 'automation-systems',
+      priority: 'medium',
+      dependencies: [`${goalId}-scope`],
+      expected_files: ['app/api/admin/agents/**', 'lib/agent-run.ts', 'lib/agent-work-items.ts'],
+      acceptance_criteria: ['Trace behavior is visible', 'Mutation gates stay review-gated', 'Operator workflow has clear next steps'],
+      risk_notes: 'Avoid production workflow mutation unless a separate approval packet exists.',
+      goal_progress_weight: 1,
+    },
+    {
+      id: `${goalId}-evidence`,
+      title: `Attach supporting context and validation notes`,
+      objective: 'Askia Muhammad captures evidence, references, and validation notes so the goal can be audited later.',
+      owner_agent_key: 'research-source-register',
+      priority: 'medium',
+      dependencies: [`${goalId}-implementation`],
+      expected_files: ['docs/**', 'app/admin/agents/**.test.tsx', 'lib/**.test.ts'],
+      acceptance_criteria: ['Validation commands are documented', 'Known risks are recorded', 'Trace and PR links are preserved'],
+      risk_notes: 'Evidence should summarize private traces without exposing secrets or raw private data.',
+      goal_progress_weight: 1,
+    },
+    {
+      id: `${goalId}-risk`,
+      title: `Review risk, governance, and rollout path`,
+      objective: 'Moremi reviews blast radius, approval gates, and rollback path before merge or deployment.',
+      owner_agent_key: 'risk-compliance-intelligence',
+      priority: 'medium',
+      dependencies: [`${goalId}-implementation`, `${goalId}-automation`],
+      expected_files: ['docs/**', 'app/admin/agents/**'],
+      acceptance_criteria: ['Rollback path is clear', 'Production mutation remains gated', 'User-facing claims are supported'],
+      risk_notes: 'Risk review is advisory in V1 and should not imply deployment approval.',
+      goal_progress_weight: 1,
+    },
+  ]
+
+  return {
+    goal_id: goalId,
+    title,
+    objective: `Accomplish: ${title}`,
+    recommendation: 'Approve the packet if the scope is right, then track each child task on Agent Kanban with the shared goal tag.',
+    risk_notes: 'V1 creates reviewable work items only after approval; merge and deploy gates remain outside this room.',
+    tasks,
+  }
+}
+
+function assertDraft(value: AgentGoalDraft | null | undefined): AgentGoalDraft {
+  if (!value || typeof value.goal_id !== 'string' || typeof value.title !== 'string' || !Array.isArray(value.tasks)) {
+    throw new Error('Invalid goal draft')
+  }
+  for (const task of value.tasks) {
+    if (!task.title || !task.owner_agent_key || !getAgentByKey(task.owner_agent_key)) {
+      throw new Error('Invalid goal draft task')
+    }
+  }
+  return value
+}
+
+async function approveGoalDraft(runId: string, draft: AgentGoalDraft) {
+  const parent = await createAgentWorkItem({
+    title: `Goal: ${draft.title}`,
+    objective: draft.objective,
+    priority: 'high',
+    status: 'queued',
+    ownerAgentKey: 'chief-of-staff',
+    source: { type: 'agent_standup_goal', id: draft.goal_id, label: 'Standup Room goal' },
+    sourceRunId: runId,
+    metadata: {
+      goal_id: draft.goal_id,
+      goal_title: draft.title,
+      goal_status: 'approved',
+      goal_role: 'parent',
+      goal_created_by_run_id: runId,
+      goal_progress_weight: 0,
+      recommendation: draft.recommendation,
+    },
+    idempotencyKey: `agent-goal:${draft.goal_id}:parent`,
+  })
+
+  const children: AgentWorkItem[] = []
+  for (const [index, task] of draft.tasks.entries()) {
+    const child = await createAgentWorkItem({
+      title: task.title,
+      objective: task.objective,
+      priority: task.priority,
+      status: 'assigned',
+      ownerAgentKey: task.owner_agent_key,
+      source: { type: 'agent_standup_goal_task', id: task.id, label: draft.title },
+      sourceRunId: runId,
+      parentWorkItemId: parent.id,
+      expectedFiles: task.expected_files,
+      metadata: {
+        goal_id: draft.goal_id,
+        goal_title: draft.title,
+        goal_sequence: index + 1,
+        goal_status: 'approved',
+        goal_role: 'task',
+        goal_created_by_run_id: runId,
+        goal_progress_weight: task.goal_progress_weight,
+        goal_task_id: task.id,
+        goal_dependencies: task.dependencies,
+        acceptance_criteria: task.acceptance_criteria,
+        risk_notes: task.risk_notes,
+      },
+      idempotencyKey: `agent-goal:${draft.goal_id}:task:${index + 1}`,
+    })
+    children.push(child)
+  }
+
+  return { parent, children }
 }
 
 export async function runAgentWarRoom(input: RunAgentWarRoomInput) {
   assertCommand(input.command)
   const message = input.message?.trim().slice(0, 1000) || null
-  if (input.command === 'discuss' && !message) {
-    throw new Error('Message is required for discuss')
+  const goal = input.goal?.trim().slice(0, 1000) || null
+  if ((input.command === 'discuss' || input.command === 'ask_agent') && !message) {
+    throw new Error(`Message is required for ${input.command}`)
+  }
+  if (input.command === 'draft_goal' && !goal) {
+    throw new Error('Goal is required for draft_goal')
+  }
+  if (input.command === 'ask_agent') {
+    const agent = getAgentByKey(input.targetAgentKey ?? '')
+    if (!agent || agent.status === 'planned') throw new Error('Invalid agent key')
+  }
+  if (input.command === 'approve_goal') {
+    assertDraft(input.draft)
   }
 
-  const title = input.command === 'standup' ? 'Agent War Room standup' : 'Agent War Room discussion'
+  const titles: Record<AgentWarRoomCommand, string> = {
+    standup: 'Agent Standup Room session',
+    discuss: 'Agent Standup Room discussion',
+    ask_agent: 'Agent Standup Room direct ask',
+    draft_goal: 'Agent Standup Room goal draft',
+    approve_goal: 'Agent Standup Room goal approval',
+  }
   const run = await startAgentRun({
     agentKey: 'chief-of-staff',
     runtime: 'manual',
-    kind: input.command === 'standup' ? 'agent_war_room_standup' : 'agent_war_room_discussion',
-    title,
+    kind: `agent_war_room_${input.command}`,
+    title: titles[input.command],
     status: 'running',
     subject: {
       type: input.actor?.type ?? 'agent_war_room',
       id: input.actor?.id ?? input.command,
-      label: input.actor?.label ?? 'Agent War Room',
+      label: input.actor?.label ?? 'Agent Standup Room',
     },
     triggerSource: input.triggerSource,
-    currentStep: 'Collecting mission control state',
+    currentStep: 'Collecting Agent Ops context',
     metadata: {
       command: input.command,
       message_preview: message,
-      executes_action: false,
+      target_agent_key: input.targetAgentKey ?? null,
+      goal_preview: goal,
+      executes_action: input.command === 'approve_goal',
     },
   })
 
   const snapshot = await buildAgentMissionControlSnapshot()
-  const agents = selectAgents(input.command, message)
-  const updates = agents.map((agent) => agentUpdate(agent, input.command, message))
+  const agents = selectAgents(input.command, message ?? goal, input.targetAgentKey)
+  const updates = agents.map((agent) => agentUpdate(agent, input.command, message ?? goal))
   const synthesis = synthesize(input.command, updates, snapshot.attention_queue.length)
+  const messages: AgentWarRoomMessage[] = [
+    ...(message ? [{
+      id: 'operator-message',
+      role: 'user' as const,
+      content: message,
+      created_at: new Date().toISOString(),
+    }] : []),
+    ...updates.map(messageFromUpdate),
+    {
+      id: 'shaka-synthesis',
+      role: 'agent',
+      agent_key: 'chief-of-staff',
+      agent_name: 'Shaka (Zulu) - Chief of Staff',
+      content: synthesis,
+      created_at: new Date().toISOString(),
+    },
+  ]
+
+  let goalDraft: AgentGoalDraft | null = null
+  let createdWorkItems: { parent: AgentWorkItem; children: AgentWorkItem[] } | null = null
+  if (input.command === 'draft_goal') {
+    goalDraft = draftGoal(goal ?? '')
+  }
+  if (input.command === 'approve_goal') {
+    const draft = assertDraft(input.draft)
+    createdWorkItems = await approveGoalDraft(run.id, draft)
+  }
 
   await recordAgentStep({
     runId: run.id,
     stepKey: 'collect_war_room_context',
-    name: 'Collected mission control state',
+    name: 'Collected Agent Ops context',
     status: 'completed',
     outputSummary: `${snapshot.status_strip.active} active run(s), ${snapshot.attention_queue.length} attention item(s)`,
     metadata: {
@@ -134,47 +403,56 @@ export async function runAgentWarRoom(input: RunAgentWarRoomInput) {
 
   await recordAgentStep({
     runId: run.id,
-    stepKey: 'agent_updates',
-    name: input.command === 'standup' ? 'Collected agent standup updates' : 'Collected agent discussion updates',
+    stepKey: input.command === 'approve_goal' ? 'goal_work_items_created' : 'agent_updates',
+    name: input.command === 'approve_goal' ? 'Created approved goal work items' : 'Collected agent responses',
     status: 'completed',
-    outputSummary: `${updates.length} agent update(s)`,
-    metadata: { updates },
+    outputSummary: input.command === 'approve_goal'
+      ? `${createdWorkItems?.children.length ?? 0} child work item(s)`
+      : `${updates.length} agent response(s)`,
+    metadata: { updates, goalDraft, createdWorkItems },
   })
 
   await attachAgentArtifact({
     runId: run.id,
-    artifactType: input.command === 'standup' ? 'war_room_standup_transcript' : 'war_room_discussion_transcript',
-    title: input.command === 'standup' ? 'Agent standup transcript' : 'Agent discussion transcript',
+    artifactType: input.command === 'draft_goal' ? 'war_room_goal_draft' : 'war_room_transcript',
+    title: input.command === 'draft_goal' ? 'Standup Room goal draft' : 'Standup Room transcript',
     refType: 'agent_war_room',
     refId: input.command,
     metadata: {
       command: input.command,
       message,
+      goal,
+      target_agent_key: input.targetAgentKey ?? null,
       updates,
       synthesis,
+      messages,
+      goal_draft: goalDraft,
+      created_work_items: createdWorkItems,
       status_strip: snapshot.status_strip,
-      executes_action: false,
+      executes_action: input.command === 'approve_goal',
     },
-    idempotencyKey: `${run.id}:war-room-transcript`,
+    idempotencyKey: `${run.id}:war-room-artifact`,
   })
 
   await recordAgentEvent({
     runId: run.id,
-    eventType: input.command === 'standup' ? 'war_room_standup_completed' : 'war_room_discussion_completed',
+    eventType: `war_room_${input.command}_completed`,
     severity: 'info',
     message: synthesis,
-    metadata: { command: input.command, update_count: updates.length },
+    metadata: { command: input.command, update_count: updates.length, goal_id: goalDraft?.goal_id ?? input.draft?.goal_id ?? null },
   })
 
   await endAgentRun({
     runId: run.id,
     status: 'completed',
-    currentStep: input.command === 'standup' ? 'Standup synthesis ready' : 'Discussion synthesis ready',
+    currentStep: synthesis,
     outcome: {
       command: input.command,
       update_count: updates.length,
       synthesis,
-      executes_action: false,
+      executes_action: input.command === 'approve_goal',
+      goal_id: goalDraft?.goal_id ?? input.draft?.goal_id ?? null,
+      created_child_count: createdWorkItems?.children.length ?? 0,
     },
   })
 
@@ -183,5 +461,8 @@ export async function runAgentWarRoom(input: RunAgentWarRoomInput) {
     command: input.command,
     updates,
     synthesis,
+    messages,
+    goalDraft,
+    createdWorkItems,
   }
 }


### PR DESCRIPTION
Summary
- Adds /admin/agents/standup as an interactive Standup Room with participant rail, swarm chat, direct @agent asks, goal planner, and mini Kanban/metrics.
- Extends the Agent Ops war-room API with ask_agent, draft_goal, and approve_goal while keeping goal creation review-gated.
- Adds goal metadata projection, progress/WIP/cycle-time indicators, and shared illustrated agent avatars across Agent Ops navigation/board surfaces.
- Latest facilitation pass: @agent mentions typed into Ask all now auto-route to that agent; drafted goal tasks can be edited or removed before approval; Standup Room radiators now expose WIP limits, burndown, owner, age, trace, blocker, and next-step context.

Validation
- npm test -- app/admin/agents/standup/page.test.tsx
- npm test -- app/admin/agents/standup/page.test.tsx app/api/admin/agents/war-room/route.test.ts lib/agent-war-room.test.ts app/admin/agents/swarm-board/page.test.tsx app/admin/agents/page.test.tsx lib/agent-avatars.test.ts
- npx tsc --noEmit --pretty false
- npm run lint
- npm run build
- git diff --check
- Local smoke: http://localhost:3002/admin/agents/standup returned 200 from the feature worktree dev server; headless browser reached the expected auth screen without an admin session.

Integration Notes
- Built in sibling worktree /Users/vambahsillah/Projects/Portfolio.worktrees/agent-ops-standup-room.
- Branch was cut from the Agent Ops paper parity head while that PR was still being finalized; integration captain should merge/rebase after the paper parity PR lands.
- No database migration. Goal tags use agent_work_items.metadata and parent_work_item_id.
- Dev server emitted the existing warning that MOCK_N8N=false and N8N_DISABLE_OUTBOUND=false. No live workflow smoke was run.
- Vercel preview for this latest push is pending at the time of this update; leave merge/deploy to integration captain.
