### PR TITLE
feat: add autoresearch idea inbox controls

### DIFF
--- a/app/admin/agents/coordination/page.test.tsx
+++ b/app/admin/agents/coordination/page.test.tsx
@@ -80,6 +80,45 @@ const workItems = [
     updated_at: now,
     completed_at: null,
   },
+  {
+    id: 'work-autoresearch-1',
+    title: 'Build-profile attribution',
+    objective: 'Measure whether deploy time is dominated by Next build or generated knowledge work.',
+    status: 'proposed',
+    priority: 'high',
+    owner_agent_key: null,
+    owner_runtime: 'codex',
+    source_type: 'vercel_autoresearch_idea',
+    source_id: 'build-profile-attribution',
+    source_label: 'Vercel AutoResearch idea inbox',
+    source_run_id: null,
+    active_run_id: 'run-autoresearch-idea',
+    parent_work_item_id: null,
+    branch_name: null,
+    worktree_path: null,
+    pr_number: null,
+    pr_url: null,
+    expected_files: ['package.json'],
+    touched_files: [],
+    overlap_group: 'vercel-autoresearch-build-profile',
+    dependency_ids: [],
+    blocker_summary: null,
+    validation_summary: null,
+    approval_id: null,
+    metadata: {
+      autoresearch_idea: true,
+      recommendation: 'Start here because it produces the baseline every later idea needs.',
+      risk: 'low',
+      definition_of_ready: [
+        'Clear hypothesis tied to a deployment metric baseline.',
+        'Rollback path is explicit and low-friction.',
+      ],
+    },
+    idempotency_key: 'vercel-autoresearch-idea:build-profile-attribution',
+    created_at: now,
+    updated_at: now,
+    completed_at: null,
+  },
 ]
 
 const approvalCard = {
@@ -180,6 +219,14 @@ function setupFetch({ failWorkItems = false } = {}) {
       return { ok: true, json: async () => ({ ok: true }) }
     }
 
+    if (url.includes('/api/admin/agents/work-items/work-autoresearch-1/priority') && init?.method === 'POST') {
+      return { ok: true, json: async () => ({ ok: true }) }
+    }
+
+    if (url.includes('/api/admin/agents/work-items/work-autoresearch-1/ready') && init?.method === 'POST') {
+      return { ok: true, json: async () => ({ ok: true }) }
+    }
+
     if (url.startsWith('/api/admin/agents/work-items')) {
       if (failWorkItems) return { ok: false, status: 503, json: async () => ({ error: 'work item service unavailable' }) }
       const status = new URL(`http://localhost${url}`).searchParams.get('status')
@@ -234,8 +281,34 @@ describe('AgentCoordinationPage decision queue controller', () => {
     expect(screen.getAllByText('Controller recommendation').length).toBeGreaterThan(0)
     expect(screen.getByText('Approve validation after checking the trace and PR evidence.')).toBeInTheDocument()
     expect(screen.getByText('risk: medium')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Prioritize ideas before they enter the Kanban board.' })).toBeInTheDocument()
+    expect(screen.getAllByText('Build-profile attribution').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Start here because it produces the baseline every later idea needs.').length).toBeGreaterThan(0)
     expect(screen.getAllByText('Trace').length).toBeGreaterThan(0)
     expect(screen.getAllByText('Owner').length).toBeGreaterThan(0)
+  })
+
+  it('prioritizes AutoResearch ideas and marks them ready for the Kanban inbox', async () => {
+    render(<AgentCoordinationPage />)
+
+    expect(await screen.findByRole('heading', { name: 'Prioritize ideas before they enter the Kanban board.' })).toBeInTheDocument()
+    const select = screen.getByLabelText('Prioritize Build-profile attribution')
+    fireEvent.change(select, { target: { value: 'urgent' } })
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/admin/agents/work-items/work-autoresearch-1/priority', expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('"priority":"urgent"'),
+      }))
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mark Build-profile attribution ready for Kanban' }))
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/admin/agents/work-items/work-autoresearch-1/ready', expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('Clear hypothesis tied to a deployment metric baseline.'),
+      }))
+    })
   })
 
   it('shows pending Vercel AutoResearch approvals inline and approves from the card', async () => {

--- a/app/admin/agents/coordination/page.tsx
+++ b/app/admin/agents/coordination/page.tsx
@@ -22,6 +22,7 @@ import { getCurrentSession } from '@/lib/auth'
 import type { AgentRuntime } from '@/lib/agent-run'
 import type { AgentWorkItem, AgentWorkItemStatus } from '@/lib/agent-work-items'
 import type { VercelResearchProposal } from '@/lib/vercel-deployment-research'
+import { VERCEL_AUTORESEARCH_DEFINITION_OF_READY, VERCEL_AUTORESEARCH_IDEA_SOURCE_TYPE } from '@/lib/vercel-autoresearch-ideas'
 
 const STATUSES: Array<'all' | AgentWorkItemStatus> = [
   'all',
@@ -103,6 +104,22 @@ const DEFAULT_FORM: WorkItemForm = {
   expected_files: '',
 }
 
+const PRIORITIES = ['urgent', 'high', 'medium', 'low'] as const
+
+function isAutoResearchIdea(item: AgentWorkItem) {
+  return item.source_type === VERCEL_AUTORESEARCH_IDEA_SOURCE_TYPE || item.metadata?.autoresearch_idea === true
+}
+
+function textArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0) : []
+}
+
+function definitionOfReadyText(item: AgentWorkItem) {
+  const criteria = textArray(item.metadata?.definition_of_ready)
+  const source = criteria.length ? criteria : VERCEL_AUTORESEARCH_DEFINITION_OF_READY
+  return source.map((criterion) => `- ${criterion}`).join('\n')
+}
+
 export default function AgentCoordinationPage() {
   return (
     <ProtectedRoute requireAdmin>
@@ -178,6 +195,13 @@ function AgentCoordinationContent() {
     approvals: items.filter((item) => Boolean(item.approval_id)).length,
   }), [items])
 
+  const autoResearchIdeas = useMemo(() => {
+    const rank: Record<AgentWorkItem['priority'], number> = { urgent: 0, high: 1, medium: 2, low: 3 }
+    return items
+      .filter(isAutoResearchIdea)
+      .sort((a, b) => rank[a.priority] - rank[b.priority] || new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime())
+  }, [items])
+
   async function refreshAll() {
     await Promise.all([loadItems(), loadVercelResearchApprovals()])
   }
@@ -245,6 +269,47 @@ function AgentCoordinationContent() {
       await refreshAll()
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Action failed')
+    } finally {
+      setActionId(null)
+    }
+  }
+
+  async function prioritizeWorkItem(item: AgentWorkItem, priority: AgentWorkItem['priority']) {
+    setActionId(`priority:${item.id}`)
+    setError(null)
+    try {
+      const response = await authedFetch(`/api/admin/agents/work-items/${item.id}/priority`, {
+        method: 'POST',
+        body: JSON.stringify({
+          priority,
+          note: `AutoResearch idea priority set to ${priority} from Decision Queue Controller.`,
+        }),
+      })
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`)
+      await refreshAll()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Priority update failed')
+    } finally {
+      setActionId(null)
+    }
+  }
+
+  async function markReadyForKanban(item: AgentWorkItem) {
+    setActionId(`ready:${item.id}`)
+    setError(null)
+    try {
+      const response = await authedFetch(`/api/admin/agents/work-items/${item.id}/ready`, {
+        method: 'POST',
+        body: JSON.stringify({
+          definition_of_ready: definitionOfReadyText(item),
+        }),
+      })
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`)
+      await refreshAll()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Ready-for-Kanban update failed')
     } finally {
       setActionId(null)
     }
@@ -378,6 +443,17 @@ function AgentCoordinationContent() {
           onAskShaka={(card) => askShaka(
             'Should I approve, reject, run another test, or close this approval request? Summarize the experiment, objective, goal, current run, distance from goal, recommendation, risk, evidence, and safest next step.',
             { type: 'approval', id: card.approvalId },
+          )}
+        />
+
+        <AutoResearchIdeaInboxPanel
+          ideas={autoResearchIdeas}
+          actionId={actionId}
+          onPrioritize={prioritizeWorkItem}
+          onReadyForKanban={markReadyForKanban}
+          onAskShaka={(item) => askShaka(
+            'Should this AutoResearch idea be prioritized or marked ready for the Kanban inbox? Summarize the definition of ready, risk, owner lane, and safest next step.',
+            { type: 'work_item', id: item.id },
           )}
         />
 
@@ -560,6 +636,116 @@ function MoremiOperationalDrillPanel({
           </div>
         </div>
       ) : null}
+    </section>
+  )
+}
+
+function AutoResearchIdeaInboxPanel({
+  ideas,
+  actionId,
+  onPrioritize,
+  onReadyForKanban,
+  onAskShaka,
+}: {
+  ideas: AgentWorkItem[]
+  actionId: string | null
+  onPrioritize: (item: AgentWorkItem, priority: AgentWorkItem['priority']) => void
+  onReadyForKanban: (item: AgentWorkItem) => void
+  onAskShaka: (item: AgentWorkItem) => void
+}) {
+  const proposed = ideas.filter((item) => item.status === 'proposed').length
+  const queued = ideas.filter((item) => item.status === 'queued').length
+  return (
+    <section className="mb-6 rounded-lg border border-blue-400/30 bg-blue-400/5 p-4">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wider text-blue-100">AutoResearch idea inbox</p>
+          <h2 className="mt-1 font-semibold">Prioritize ideas before they enter the Kanban board.</h2>
+          <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+            Proposed ideas stay here for admin ordering. Marking one ready moves it to the Kanban inbox as queued work so agents can pick up the top item when current work clears.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2 text-xs">
+          <span className="rounded-full border border-blue-400/30 bg-blue-400/10 px-2 py-1 text-blue-100">{ideas.length} ideas</span>
+          <span className="rounded-full border border-silicon-slate/70 px-2 py-1 text-muted-foreground">{proposed} proposed</span>
+          <span className="rounded-full border border-green-500/30 bg-green-500/10 px-2 py-1 text-green-100">{queued} Kanban-ready</span>
+        </div>
+      </div>
+
+      {ideas.length === 0 ? (
+        <p className="rounded-lg border border-silicon-slate/60 bg-background/40 p-3 text-sm text-muted-foreground">
+          No Vercel AutoResearch ideas have been seeded yet. Run <code className="font-mono">npm run deploy:research:seed-ideas</code> to create the inbox items.
+        </p>
+      ) : (
+        <div className="grid gap-3">
+          {ideas.map((item) => {
+            const readyForKanban = item.status !== 'proposed'
+            const criteria = textArray(item.metadata?.definition_of_ready)
+            const recommendation = typeof item.metadata?.recommendation === 'string'
+              ? item.metadata.recommendation
+              : 'Review this idea against the definition of ready before moving it into Kanban.'
+            return (
+              <article key={item.id} className="rounded-lg border border-blue-400/20 bg-background/55 p-4">
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                  <div className="min-w-0">
+                    <div className="mb-2 flex flex-wrap items-center gap-2">
+                      <StatusBadge status={item.status} />
+                      <span className="rounded-full border border-radiant-gold/30 bg-radiant-gold/10 px-2 py-1 text-xs text-radiant-gold">
+                        {item.priority} priority
+                      </span>
+                      {readyForKanban ? (
+                        <span className="rounded-full border border-green-500/30 bg-green-500/10 px-2 py-1 text-xs text-green-100">
+                          ready for Kanban
+                        </span>
+                      ) : null}
+                    </div>
+                    <h3 className="text-lg font-semibold">{item.title}</h3>
+                    <p className="mt-1 max-w-4xl text-sm text-muted-foreground">{item.objective}</p>
+                    <div className="mt-3 grid gap-3 lg:grid-cols-2">
+                      <DecisionSummaryBlock label="Admin recommendation" value={recommendation} />
+                      <DecisionSummaryBlock label="Definition of ready" value={criteria.length ? criteria.join('\n') : VERCEL_AUTORESEARCH_DEFINITION_OF_READY.join('\n')} tone="yellow" />
+                    </div>
+                  </div>
+                  <div className="flex shrink-0 flex-wrap gap-2 lg:w-72 lg:justify-end">
+                    <label className="min-w-32 text-xs uppercase tracking-wide text-muted-foreground">
+                      Priority
+                      <select
+                        value={item.priority}
+                        onChange={(event) => onPrioritize(item, event.target.value as AgentWorkItem['priority'])}
+                        disabled={Boolean(actionId)}
+                        aria-label={`Prioritize ${item.title}`}
+                        className="mt-1 w-full rounded-lg border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm normal-case tracking-normal text-foreground"
+                      >
+                        {PRIORITIES.map((priority) => (
+                          <option key={priority} value={priority}>{priority}</option>
+                        ))}
+                      </select>
+                    </label>
+                    <button
+                      onClick={() => onReadyForKanban(item)}
+                      disabled={Boolean(actionId) || readyForKanban}
+                      aria-label={`Mark ${item.title} ready for Kanban`}
+                      className="inline-flex items-center gap-2 rounded-lg border border-green-500/40 bg-green-500/10 px-3 py-2 text-sm text-green-100 hover:bg-green-500/15 disabled:opacity-50"
+                    >
+                      <CheckCircle2 size={16} />
+                      Ready for Kanban
+                    </button>
+                    <button
+                      onClick={() => onAskShaka(item)}
+                      disabled={Boolean(actionId)}
+                      aria-label={`Ask Shaka about ${item.title}`}
+                      className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/50 bg-radiant-gold/10 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15 disabled:opacity-50"
+                    >
+                      <MessageSquare size={16} />
+                      Ask Shaka
+                    </button>
+                  </div>
+                </div>
+              </article>
+            )
+          })}
+        </div>
+      )}
     </section>
   )
 }

--- a/app/api/admin/agents/work-items/[id]/priority/route.test.ts
+++ b/app/api/admin/agents/work-items/[id]/priority/route.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  prioritizeAgentWorkItem: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-work-items', () => ({
+  AGENT_WORK_ITEM_PRIORITIES: ['low', 'medium', 'high', 'urgent'],
+  prioritizeAgentWorkItem: mocks.prioritizeAgentWorkItem,
+}))
+
+import { POST } from './route'
+
+function request(body: unknown) {
+  return new Request('http://localhost/api/admin/agents/work-items/work-1/priority', {
+    method: 'POST',
+    headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/admin/agents/work-items/[id]/priority', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.prioritizeAgentWorkItem.mockResolvedValue({ id: 'work-1', priority: 'urgent' })
+  })
+
+  it('updates work item priority', async () => {
+    const response = await POST(request({ priority: 'urgent', note: 'Move to top' }) as never, { params: { id: 'work-1' } })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({ ok: true, work_item: { id: 'work-1' } })
+    expect(mocks.prioritizeAgentWorkItem).toHaveBeenCalledWith({
+      id: 'work-1',
+      priority: 'urgent',
+      note: 'Move to top',
+    })
+  })
+
+  it('rejects invalid priority', async () => {
+    const response = await POST(request({ priority: 'later' }) as never, { params: { id: 'work-1' } })
+
+    expect(response.status).toBe(400)
+    expect(mocks.prioritizeAgentWorkItem).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/admin/agents/work-items/[id]/priority/route.ts
+++ b/app/api/admin/agents/work-items/[id]/priority/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import {
+  AGENT_WORK_ITEM_PRIORITIES,
+  prioritizeAgentWorkItem,
+  type AgentWorkItemPriority,
+} from '@/lib/agent-work-items'
+
+export const dynamic = 'force-dynamic'
+
+function isPriority(value: string): value is AgentWorkItemPriority {
+  return AGENT_WORK_ITEM_PRIORITIES.includes(value as AgentWorkItemPriority)
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as {
+    priority?: unknown
+    note?: unknown
+  }
+  const priority = typeof body.priority === 'string' ? body.priority : ''
+  if (!isPriority(priority)) {
+    return NextResponse.json({ error: 'Valid priority is required' }, { status: 400 })
+  }
+
+  try {
+    const work_item = await prioritizeAgentWorkItem({
+      id: params.id,
+      priority,
+      note: typeof body.note === 'string' ? body.note : null,
+    })
+    return NextResponse.json({ ok: true, work_item })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to prioritize work item'
+    const status = message === 'Agent work item not found' ? 404 : 500
+    console.error('[agent-work-item-priority] failed:', error)
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/app/api/admin/agents/work-items/[id]/ready/route.test.ts
+++ b/app/api/admin/agents/work-items/[id]/ready/route.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  markAgentWorkItemReadyForKanban: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-work-items', () => ({
+  markAgentWorkItemReadyForKanban: mocks.markAgentWorkItemReadyForKanban,
+}))
+
+import { POST } from './route'
+
+function request(body: unknown) {
+  return new Request('http://localhost/api/admin/agents/work-items/work-1/ready', {
+    method: 'POST',
+    headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/admin/agents/work-items/[id]/ready', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user', email: 'admin@example.com' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.markAgentWorkItemReadyForKanban.mockResolvedValue({ id: 'work-1', status: 'queued' })
+  })
+
+  it('marks a work item ready for the Kanban inbox', async () => {
+    const response = await POST(request({ definition_of_ready: '- Clear metric\n- Rollback path' }) as never, { params: { id: 'work-1' } })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({ ok: true, work_item: { id: 'work-1' } })
+    expect(mocks.markAgentWorkItemReadyForKanban).toHaveBeenCalledWith({
+      id: 'work-1',
+      definitionOfReady: '- Clear metric\n- Rollback path',
+      actorLabel: 'admin@example.com',
+    })
+  })
+
+  it('requires a definition of ready', async () => {
+    const response = await POST(request({ definition_of_ready: '' }) as never, { params: { id: 'work-1' } })
+
+    expect(response.status).toBe(400)
+    expect(mocks.markAgentWorkItemReadyForKanban).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/admin/agents/work-items/[id]/ready/route.ts
+++ b/app/api/admin/agents/work-items/[id]/ready/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { markAgentWorkItemReadyForKanban } from '@/lib/agent-work-items'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as {
+    definition_of_ready?: unknown
+  }
+  const definitionOfReady = typeof body.definition_of_ready === 'string'
+    ? body.definition_of_ready.trim()
+    : ''
+  if (!definitionOfReady) {
+    return NextResponse.json({ error: 'definition_of_ready is required' }, { status: 400 })
+  }
+
+  try {
+    const work_item = await markAgentWorkItemReadyForKanban({
+      id: params.id,
+      definitionOfReady,
+      actorLabel: ('email' in auth.user && typeof auth.user.email === 'string') ? auth.user.email : auth.user.id,
+    })
+    return NextResponse.json({ ok: true, work_item })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to mark work item ready'
+    const status = message === 'Agent work item not found' ? 404 : 500
+    console.error('[agent-work-item-ready] failed:', error)
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/lib/agent-work-items.ts
+++ b/lib/agent-work-items.ts
@@ -450,6 +450,58 @@ export async function updateAgentWorkItemStatus(input: {
   )
 }
 
+export async function prioritizeAgentWorkItem(input: {
+  id: string
+  priority: AgentWorkItemPriority
+  note?: string | null
+}) {
+  assertPriority(input.priority)
+  const item = await requireAgentWorkItem(input.id)
+  return updateWorkItem(
+    item,
+    { priority: input.priority },
+    {
+      type: 'agent_work_item_prioritized',
+      message: input.note ?? `${item.title}: priority set to ${input.priority}`,
+      metadata: { priority: input.priority },
+    },
+  )
+}
+
+export async function markAgentWorkItemReadyForKanban(input: {
+  id: string
+  definitionOfReady: string
+  actorLabel?: string | null
+}) {
+  const definitionOfReady = input.definitionOfReady.trim()
+  if (!definitionOfReady) throw new Error('Definition of ready is required')
+  const item = await requireAgentWorkItem(input.id)
+  const now = new Date().toISOString()
+  const metadata = {
+    ...(item.metadata ?? {}),
+    kanban_readiness: {
+      ready: true,
+      ready_at: now,
+      actor_label: input.actorLabel ?? 'Admin user',
+      definition_of_ready: definitionOfReady,
+    },
+  }
+  return updateWorkItem(
+    item,
+    {
+      status: 'queued',
+      blocker_summary: null,
+      validation_summary: definitionOfReady,
+      metadata,
+    },
+    {
+      type: 'agent_work_item_ready_for_kanban',
+      message: definitionOfReady,
+      metadata: { actor_label: input.actorLabel ?? 'Admin user' },
+    },
+  )
+}
+
 export async function recordAgentWorkItemBlocker(input: { id: string; blockerSummary: string }) {
   const item = await requireAgentWorkItem(input.id)
   return updateWorkItem(

--- a/lib/vercel-autoresearch-ideas.ts
+++ b/lib/vercel-autoresearch-ideas.ts
@@ -1,0 +1,139 @@
+import type { AgentWorkItemPriority } from '@/lib/agent-work-items'
+
+export type VercelAutoResearchIdea = {
+  id: string
+  title: string
+  objective: string
+  priority: AgentWorkItemPriority
+  expectedFiles: string[]
+  overlapGroup: string
+  recommendation: string
+  risk: string
+  definitionOfReady: string[]
+}
+
+export const VERCEL_AUTORESEARCH_IDEA_SOURCE_TYPE = 'vercel_autoresearch_idea'
+export const VERCEL_AUTORESEARCH_IDEA_SOURCE_LABEL = 'Vercel AutoResearch idea inbox'
+
+export const VERCEL_AUTORESEARCH_DEFINITION_OF_READY = [
+  'Clear hypothesis tied to a deployment metric baseline.',
+  'One bounded experiment scope with expected files or settings named.',
+  'Rollback path is explicit and low-friction.',
+  'No production Vercel config mutation is included unless a separate approval packet exists.',
+  'Owner lane can pick it up without needing hidden context.',
+]
+
+export const VERCEL_AUTORESEARCH_IDEAS: VercelAutoResearchIdea[] = [
+  {
+    id: 'build-profile-attribution',
+    title: 'Build-profile attribution',
+    objective: 'Measure whether deploy time is dominated by Next build, generated knowledge, static pages, dependency install, or asset work before changing hosted deployment settings.',
+    priority: 'high',
+    expectedFiles: ['package.json', 'scripts/build-chatbot-knowledge.ts', 'next.config.js'],
+    overlapGroup: 'vercel-autoresearch-build-profile',
+    recommendation: 'Start here because it produces the baseline every later build-performance idea needs.',
+    risk: 'low',
+    definitionOfReady: [
+      ...VERCEL_AUTORESEARCH_DEFINITION_OF_READY,
+      'Baseline includes at least one recent portfolio and portfolio-staging deployment timing sample.',
+    ],
+  },
+  {
+    id: 'staging-queue-pressure-diagnosis',
+    title: 'Staging queue-pressure diagnosis',
+    objective: 'Compare portfolio-staging queue patterns against production and preview so agents can separate Vercel queue delay from application build cost.',
+    priority: 'high',
+    expectedFiles: ['docs/vercel-deployment-runbook.md', 'scripts/vercel-deployment-metrics.ts'],
+    overlapGroup: 'vercel-autoresearch-queue-pressure',
+    recommendation: 'Prioritize when staging queue findings repeat or block captain sweeps.',
+    risk: 'medium',
+    definitionOfReady: [
+      ...VERCEL_AUTORESEARCH_DEFINITION_OF_READY,
+      'Queue findings repeat across at least two recent deployment checks or cross the blocked threshold once.',
+    ],
+  },
+  {
+    id: 'knowledge-generation-cost-control',
+    title: 'Knowledge generation cost control',
+    objective: 'Measure whether build-time knowledge generation adds enough deployment latency to justify caching, artifact reuse, or narrower rebuild triggers.',
+    priority: 'medium',
+    expectedFiles: ['scripts/build-chatbot-knowledge.ts', 'lib/chatbot-knowledge-content.generated.ts', 'package.json'],
+    overlapGroup: 'vercel-autoresearch-knowledge-build',
+    recommendation: 'Useful after build-profile attribution confirms generated knowledge is material.',
+    risk: 'low',
+    definitionOfReady: [
+      ...VERCEL_AUTORESEARCH_DEFINITION_OF_READY,
+      'Build-profile evidence shows generated knowledge work is a meaningful share of total build time.',
+    ],
+  },
+  {
+    id: 'admin-route-static-generation-audit',
+    title: 'Admin route static-generation audit',
+    objective: 'Identify admin pages that are statically generated unnecessarily and decide whether they should become dynamic to reduce build work.',
+    priority: 'medium',
+    expectedFiles: ['app/admin/**/page.tsx', 'next.config.js'],
+    overlapGroup: 'vercel-autoresearch-admin-build',
+    recommendation: 'Run after the build profile points at page-data collection or static generation overhead.',
+    risk: 'medium',
+    definitionOfReady: [
+      ...VERCEL_AUTORESEARCH_DEFINITION_OF_READY,
+      'Candidate admin routes are listed with build evidence and user-facing behavior risk.',
+    ],
+  },
+  {
+    id: 'bundle-first-load-regression-tracking',
+    title: 'Bundle and first-load regression tracking',
+    objective: 'Track whether admin and agent surfaces are growing shared JavaScript and propose scoped bundle reductions when regressions appear.',
+    priority: 'medium',
+    expectedFiles: ['app/admin/agents/**', 'components/**', 'package.json'],
+    overlapGroup: 'vercel-autoresearch-bundle-regression',
+    recommendation: 'Use this to keep Agent Ops growth from becoming hidden deployment and runtime debt.',
+    risk: 'low',
+    definitionOfReady: [
+      ...VERCEL_AUTORESEARCH_DEFINITION_OF_READY,
+      'A before/after route-size or first-load JS comparison is available from a recent build.',
+    ],
+  },
+  {
+    id: 'deployment-context-parity-check',
+    title: 'Deployment context parity check',
+    objective: 'Compare portfolio and portfolio-staging environment/build behavior so staging remains a trustworthy proxy instead of a slower or misleading path.',
+    priority: 'high',
+    expectedFiles: ['docs/deploy-context.md', 'docs/vercel-deployment-runbook.md'],
+    overlapGroup: 'vercel-autoresearch-context-parity',
+    recommendation: 'Prioritize when staging behaves materially slower than production after code-equivalent deploys.',
+    risk: 'medium',
+    definitionOfReady: [
+      ...VERCEL_AUTORESEARCH_DEFINITION_OF_READY,
+      'The packet distinguishes environment/config parity questions from app-code performance questions.',
+    ],
+  },
+  {
+    id: 'safe-instrumentation-bakeoff',
+    title: 'Safe instrumentation bakeoff',
+    objective: 'Evaluate low-noise ways to capture build phase timings without changing production Vercel project settings.',
+    priority: 'medium',
+    expectedFiles: ['scripts/**', 'docs/technology-bakeoff-surface-map.md', 'docs/vercel-deployment-runbook.md'],
+    overlapGroup: 'vercel-autoresearch-instrumentation-bakeoff',
+    recommendation: 'Use a scored bakeoff before adopting any build instrumentation pattern as a default.',
+    risk: 'low',
+    definitionOfReady: [
+      ...VERCEL_AUTORESEARCH_DEFINITION_OF_READY,
+      'Candidate instrumentation options have comparison criteria, expected overhead, and rollback notes.',
+    ],
+  },
+  {
+    id: 'vercel-settings-proposal-packet',
+    title: 'Vercel settings proposal packet',
+    objective: 'Prepare a review packet for Vercel preview policy, build concurrency, or related hosted settings only after repeated queue findings justify a settings-level discussion.',
+    priority: 'low',
+    expectedFiles: ['docs/vercel-deployment-runbook.md'],
+    overlapGroup: 'vercel-autoresearch-settings-packet',
+    recommendation: 'Keep low until queue findings repeat; this remains a separate approval gate because it touches production-adjacent settings.',
+    risk: 'high',
+    definitionOfReady: [
+      ...VERCEL_AUTORESEARCH_DEFINITION_OF_READY,
+      'Repeated queue evidence exists and the packet explicitly says it does not authorize hosted setting changes.',
+    ],
+  },
+]

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "deploy:watch:once": "tsx scripts/vercel-deployment-watch.ts --once",
     "deploy:metrics": "tsx scripts/vercel-deployment-metrics.ts",
     "deploy:research:plan": "tsx scripts/vercel-deployment-research-plan.ts",
+    "deploy:research:seed-ideas": "tsx scripts/seed-vercel-autoresearch-ideas.ts",
     "git:hygiene:report": "tsx scripts/git-hygiene-report.ts",
     "banned-books:report": "tsx scripts/banned-books-corpus-report.ts",
     "model-ops:snapshot": "tsx scripts/sync-model-ops-snapshot.ts",

--- a/scripts/seed-vercel-autoresearch-ideas.ts
+++ b/scripts/seed-vercel-autoresearch-ideas.ts
@@ -1,0 +1,111 @@
+#!/usr/bin/env tsx
+import { config } from 'dotenv'
+import { existsSync } from 'node:fs'
+import { resolve } from 'node:path'
+import {
+  VERCEL_AUTORESEARCH_IDEAS,
+  VERCEL_AUTORESEARCH_IDEA_SOURCE_LABEL,
+  VERCEL_AUTORESEARCH_IDEA_SOURCE_TYPE,
+} from '@/lib/vercel-autoresearch-ideas'
+
+const envPath = process.env.PORTFOLIO_ENV_FILE
+  ?? (existsSync(resolve(process.cwd(), '.env.local'))
+    ? resolve(process.cwd(), '.env.local')
+    : '/Users/vambahsillah/Projects/Portfolio/.env.local')
+config({ path: envPath })
+
+type Options = {
+  prod: boolean
+  dryRun: boolean
+}
+
+function parseArgs(argv: string[]): Options {
+  return {
+    prod: argv.includes('--prod'),
+    dryRun: argv.includes('--dry-run'),
+  }
+}
+
+function configureProdEnv() {
+  if (!process.env.PROD_SUPABASE_URL || !process.env.PROD_SUPABASE_SERVICE_ROLE_KEY) {
+    throw new Error('Missing PROD_SUPABASE_URL or PROD_SUPABASE_SERVICE_ROLE_KEY')
+  }
+  process.env.NEXT_PUBLIC_SUPABASE_URL = process.env.PROD_SUPABASE_URL
+  process.env.SUPABASE_SERVICE_ROLE_KEY = process.env.PROD_SUPABASE_SERVICE_ROLE_KEY
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  if (options.prod) configureProdEnv()
+  const createAgentWorkItem = options.dryRun
+    ? null
+    : (await import('@/lib/agent-work-items')).createAgentWorkItem
+
+  const results = []
+  for (const idea of VERCEL_AUTORESEARCH_IDEAS) {
+    const definitionOfReady = idea.definitionOfReady.map((item) => `- ${item}`).join('\n')
+    if (options.dryRun) {
+      results.push({
+        id: idea.id,
+        title: idea.title,
+        status: 'proposed',
+        priority: idea.priority,
+      })
+      continue
+    }
+    if (!createAgentWorkItem) throw new Error('createAgentWorkItem unavailable')
+    const workItem = await createAgentWorkItem({
+      title: idea.title,
+      objective: [
+        idea.objective,
+        '',
+        'Definition of ready:',
+        definitionOfReady,
+      ].join('\n'),
+      priority: idea.priority,
+      status: 'proposed',
+      ownerAgentKey: null,
+      ownerRuntime: 'codex',
+      source: {
+        type: VERCEL_AUTORESEARCH_IDEA_SOURCE_TYPE,
+        id: idea.id,
+        label: VERCEL_AUTORESEARCH_IDEA_SOURCE_LABEL,
+      },
+      expectedFiles: idea.expectedFiles,
+      overlapGroup: idea.overlapGroup,
+      metadata: {
+        autoresearch_idea: true,
+        idea_id: idea.id,
+        recommendation: idea.recommendation,
+        risk: idea.risk,
+        definition_of_ready: idea.definitionOfReady,
+        kanban_readiness: {
+          ready: false,
+        },
+      },
+      idempotencyKey: `vercel-autoresearch-idea:${idea.id}`,
+    })
+    results.push({
+      id: idea.id,
+      work_item_id: workItem.id,
+      title: workItem.title,
+      status: workItem.status,
+      priority: workItem.priority,
+    })
+  }
+
+  console.log(JSON.stringify({
+    ok: true,
+    dry_run: options.dryRun,
+    target: options.prod ? 'prod' : 'local',
+    seeded: results.length,
+    work_items: results,
+  }, null, 2))
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Summary
- Add eight Vercel AutoResearch project ideas as reusable seed definitions with definition-of-ready criteria.
- Add production-safe seeding script for proposed Agent Ops inbox work items, with dry-run and prod modes.
- Add Admin Decision Queue controls to prioritize AutoResearch ideas and mark them ready for the Kanban inbox.
- Add work-item priority and ready-for-Kanban API endpoints that record Agent Ops events and readiness metadata.

## Validation
- `npm run test -- app/admin/agents/coordination/page.test.tsx app/api/admin/agents/work-items/route.test.ts app/api/admin/agents/work-items/[id]/priority/route.test.ts app/api/admin/agents/work-items/[id]/ready/route.test.ts`
- `npx tsc --noEmit --pretty false`
- `npm run lint`
- `git diff --check origin/main...HEAD`
- `npm run deploy:research:seed-ideas -- --dry-run`
- `set -a; source /Users/vambahsillah/Projects/Portfolio/.env.local; set +a; npm run build`

## Integration Notes
- Rebases cleanly on top of the merged Agent Ops polish, Standup Room, credential broker, progress delivery, and AutoResearch decision framing PRs.
- The existing PR packet says the eight AutoResearch ideas were seeded into the production Agent Ops inbox before this captain pass; I did not rerun production seeding.
- `proposed` remains the admin prioritization state; `queued` means the idea is ready for the Kanban Inbox lane.
- No Vercel deployment config, env vars, build commands, branch protection, log drains, provider integrations, merge, or deploy action is included.
- Build emitted the existing local env warning that `MOCK_N8N=false` and `N8N_DISABLE_OUTBOUND=false`; this branch did not change n8n config.
- Local pre-push database health hook skipped because production Supabase credentials are not set locally.
