### PR TITLE
feat: ground standup room in agent work

### DIFF
--- a/app/admin/agents/standup/page.test.tsx
+++ b/app/admin/agents/standup/page.test.tsx
@@ -109,6 +109,7 @@ const organization = {
   activity: [],
   warRoom: {
     roster: [],
+    recentRuns: [],
     commands: [],
     suggestedPrompt: 'Ask for blockers.',
   },

--- a/app/admin/agents/swarm-board/page.test.tsx
+++ b/app/admin/agents/swarm-board/page.test.tsx
@@ -187,6 +187,17 @@ const boardSnapshot = {
     ],
     warRoom: {
       roster: [],
+      recentRuns: [
+        {
+          id: 'war-room-run-1',
+          title: 'Agent Standup Room direct ask',
+          command: 'ask_agent',
+          status: 'completed',
+          startedAt: '2026-05-14T11:00:00.000Z',
+          summary: 'Shaka answered with scoped work context.',
+          goalId: 'goal-1',
+        },
+      ],
       commands: ['/agent work'],
       suggestedPrompt: 'Ask for blockers.',
     },
@@ -297,6 +308,18 @@ describe('AgentSwarmBoardPage', () => {
     expect(await screen.findByRole('heading', { name: 'Hive Mind' })).toBeInTheDocument()
     expect(screen.getByRole('tab', { name: 'Activity board' })).toHaveAttribute('aria-selected', 'true')
     expect(screen.getByRole('tab', { name: 'Kanban lanes' })).toHaveAttribute('aria-selected', 'false')
+  })
+
+  it('shows recent standup-room traces in the War Room view', async () => {
+    render(<AgentSwarmBoardPage />)
+
+    fireEvent.click(await screen.findByRole('tab', { name: 'War room board' }))
+
+    expect(screen.getByRole('heading', { name: 'War Room' })).toBeInTheDocument()
+    expect(screen.getByText('Recent room traces')).toBeInTheDocument()
+    expect(screen.getByText('Agent Standup Room direct ask')).toBeInTheDocument()
+    expect(screen.getByText('Shaka answered with scoped work context.')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Open trace' })).toHaveAttribute('href', '/admin/agents/runs/war-room-run-1')
   })
 
   it('keeps lane order fixed while collapsing empty lanes', async () => {

--- a/app/admin/agents/swarm-board/page.tsx
+++ b/app/admin/agents/swarm-board/page.tsx
@@ -909,12 +909,12 @@ function WarRoom({ organization }: { organization: AgentOrgBoardSnapshot }) {
         <div className="flex items-center justify-between border-b border-silicon-slate/60 p-4">
           <div>
             <h2 className="text-xl font-semibold">War Room</h2>
-            <p className="text-sm text-muted-foreground">Coordinate through Agent Ops records and Slack commands.</p>
+            <p className="text-sm text-muted-foreground">Recent standup-room commands, traces, and team prompts.</p>
           </div>
-          <Badge label="text mode" />
+          <Badge label={`${organization.warRoom.recentRuns.length} trace(s)`} />
         </div>
-        <div className="flex flex-1 items-center justify-center p-8 text-center">
-          <div>
+        <div className="flex-1 space-y-4 p-4">
+          <div className="rounded-lg border border-silicon-slate/70 bg-background/55 p-4 text-center">
             <Sparkles className="mx-auto mb-4 text-radiant-gold" size={28} />
             <h3 className="text-lg font-semibold">Start with a specific question.</h3>
             <p className="mt-2 max-w-xl text-sm text-muted-foreground">{organization.warRoom.suggestedPrompt}</p>
@@ -922,10 +922,38 @@ function WarRoom({ organization }: { organization: AgentOrgBoardSnapshot }) {
               {organization.warRoom.commands.map((command) => <Badge key={command} label={command} />)}
             </div>
           </div>
+          <div className="rounded-lg border border-silicon-slate/70 bg-background/55 p-4">
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-radiant-gold">Recent room traces</h3>
+              <Link href="/admin/agents/runs" className="text-xs text-radiant-gold hover:underline">View all traces</Link>
+            </div>
+            <div className="space-y-2">
+              {organization.warRoom.recentRuns.length ? organization.warRoom.recentRuns.map((run) => (
+                <article key={run.id} className="grid gap-3 rounded-lg border border-silicon-slate/60 bg-silicon-slate/15 p-3 text-sm md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge label={run.command.replace(/_/g, ' ')} />
+                      <Badge label={run.status} />
+                      {run.goalId ? <Badge label={`goal ${run.goalId}`} /> : null}
+                    </div>
+                    <p className="mt-2 font-medium">{run.title}</p>
+                    <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">{run.summary}</p>
+                  </div>
+                  <Link href={`/admin/agents/runs/${run.id}`} className="inline-flex items-center justify-end gap-2 text-radiant-gold hover:underline">
+                    Open trace
+                  </Link>
+                </article>
+              )) : (
+                <div className="rounded-lg border border-dashed border-silicon-slate/60 p-4 text-sm text-muted-foreground">
+                  No standup-room traces yet. Start a standup or ask an agent to create the first room trace.
+                </div>
+              )}
+            </div>
+          </div>
         </div>
         <div className="border-t border-silicon-slate/60 p-4">
           <div className="flex items-center gap-2 rounded-lg border border-silicon-slate/70 bg-background/60 px-3 py-3 text-sm text-muted-foreground">
-            Message the team from Slack with /agent captain, /agent work, or /agent blockers.
+            Use the Standup Room for interactive questions; Slack commands remain available for mobile check-ins.
           </div>
         </div>
       </section>

--- a/app/api/admin/agents/swarm-board/route.test.ts
+++ b/app/api/admin/agents/swarm-board/route.test.ts
@@ -105,6 +105,7 @@ describe('GET /api/admin/agents/swarm-board', () => {
       activity: [],
       warRoom: {
         roster: [],
+        recentRuns: [],
         commands: ['/agent work'],
         suggestedPrompt: 'Ask for status.',
       },

--- a/lib/agent-swarm-board.ts
+++ b/lib/agent-swarm-board.ts
@@ -195,6 +195,16 @@ export type AgentOrgBoardWarRoomAgent = {
   latestAction: string
 }
 
+export type AgentOrgBoardWarRoomRun = {
+  id: string
+  title: string
+  command: string
+  status: string
+  startedAt: string
+  summary: string
+  goalId: string | null
+}
+
 export type AgentOrgBoardSnapshot = {
   generated_at: string
   summary: {
@@ -217,6 +227,7 @@ export type AgentOrgBoardSnapshot = {
   activity: AgentOrgBoardActivity[]
   warRoom: {
     roster: AgentOrgBoardWarRoomAgent[]
+    recentRuns: AgentOrgBoardWarRoomRun[]
     commands: string[]
     suggestedPrompt: string
   }
@@ -989,6 +1000,18 @@ export function buildAgentOrgBoardSnapshotFromRows(input: AgentOrgBoardBuildInpu
       status: agent.status === 'planned' ? 'planned' : agent.live ? 'live' : 'idle',
       latestAction: agent.latestAction,
     }))
+  const recentWarRoomRuns: AgentOrgBoardWarRoomRun[] = input.runs
+    .filter((run) => run.kind?.startsWith('agent_war_room_'))
+    .slice(0, 5)
+    .map((run) => ({
+      id: run.id,
+      title: run.title,
+      command: String(run.metadata?.command ?? run.kind?.replace(/^agent_war_room_/, '') ?? 'war_room'),
+      status: run.status,
+      startedAt: run.started_at,
+      summary: run.current_step ?? run.title,
+      goalId: stringValue(run.metadata?.goal_id) ?? stringValue(run.metadata?.goal_preview),
+    }))
 
   const activeTasks = tasks.filter((task) => isActiveWorkStatus(task.status))
   const completedCycleHours = tasks
@@ -1034,6 +1057,7 @@ export function buildAgentOrgBoardSnapshotFromRows(input: AgentOrgBoardBuildInpu
     activity,
     warRoom: {
       roster,
+      recentRuns: recentWarRoomRuns,
       commands: ['/agent work', '/agent blockers', '/agent prs', '/agent captain'],
       suggestedPrompt: 'Ask the team for status, blockers, overlap risk, or the next safe handoff.',
     },

--- a/lib/agent-war-room.test.ts
+++ b/lib/agent-war-room.test.ts
@@ -12,6 +12,10 @@ const missionMocks = vi.hoisted(() => ({
   buildAgentMissionControlSnapshot: vi.fn(),
 }))
 
+const orgBoardMocks = vi.hoisted(() => ({
+  buildAgentOrgBoardSnapshot: vi.fn(),
+}))
+
 const workItemMocks = vi.hoisted(() => ({
   createAgentWorkItem: vi.fn(),
 }))
@@ -26,6 +30,10 @@ vi.mock('@/lib/agent-run', () => ({
 
 vi.mock('@/lib/agent-mission-control', () => ({
   buildAgentMissionControlSnapshot: missionMocks.buildAgentMissionControlSnapshot,
+}))
+
+vi.mock('@/lib/agent-swarm-board', () => ({
+  buildAgentOrgBoardSnapshot: orgBoardMocks.buildAgentOrgBoardSnapshot,
 }))
 
 vi.mock('@/lib/agent-work-items', () => ({
@@ -54,30 +62,85 @@ describe('runAgentWarRoom', () => {
       },
       attention_queue: [],
     })
-    workItemMocks.createAgentWorkItem.mockImplementation(async (input) => ({
-      id: input.parentWorkItemId ? `child-${input.title}` : 'parent-goal',
-      title: input.title,
-      objective: input.objective,
-      metadata: input.metadata ?? {},
-    }))
-    workItemMocks.createAgentWorkItem.mockImplementation(async (input) => ({
-      id: input.parentWorkItemId ? `child-${input.title}` : 'parent-goal',
-      title: input.title,
-      objective: input.objective,
-      metadata: input.metadata ?? {},
-    }))
-    missionMocks.buildAgentMissionControlSnapshot.mockResolvedValue({
-      status_strip: {
-        active: 2,
-        running: 1,
-        failed: 0,
-        stale: 0,
-        waiting_for_approval: 0,
+    orgBoardMocks.buildAgentOrgBoardSnapshot.mockResolvedValue({
+      generated_at: '2026-05-14T12:00:00.000Z',
+      summary: {
+        agents: 1,
+        live_agents: 0,
+        active_work_items: 1,
+        unassigned_work_items: 0,
+        blocked_work_items: 1,
+        ready_for_merge: 0,
         pending_approvals: 0,
-        cost_today: 0,
+        activity_entries: 0,
+        active_goals: 0,
+        average_cycle_hours: null,
+        oldest_in_flight_hours: 12,
+        wip: [],
+        goals: [],
       },
-      attention_queue: [],
+      agents: [
+        {
+          key: 'chief-of-staff',
+          name: 'Shaka (Zulu) - Chief of Staff',
+          podKey: 'chief_of_staff',
+          podName: 'Command',
+          status: 'active',
+          runtime: 'codex',
+          live: false,
+          todayTurns: 1,
+          latestAction: 'Recent traced standup',
+          latestRunId: 'run-latest',
+        },
+      ],
+      lanes: [
+        {
+          key: 'chief-of-staff',
+          label: 'Shaka (Zulu) - Chief of Staff',
+          agentKey: 'chief-of-staff',
+          agentName: 'Shaka (Zulu) - Chief of Staff',
+          status: 'idle',
+          tasks: [
+            {
+              id: 'task-1',
+              title: 'Route blocked approval packet',
+              objective: 'Clarify the next approval step',
+              status: 'blocked',
+              priority: 'high',
+              ownerAgentKey: 'chief-of-staff',
+              ownerAgentName: 'Shaka (Zulu) - Chief of Staff',
+              ownerRuntime: 'codex',
+              branchName: null,
+              worktreePath: null,
+              prNumber: null,
+              prUrl: null,
+              activeRunId: 'run-task-1',
+              blockerSummary: 'Needs operator decision',
+              validationSummary: null,
+              overlapGroup: null,
+              parentWorkItemId: null,
+              createdAt: '2026-05-14T00:00:00.000Z',
+              updatedAt: '2026-05-14T10:00:00.000Z',
+              completedAt: null,
+              goal: null,
+            },
+          ],
+        },
+      ],
+      activity: [],
+      warRoom: {
+        roster: [],
+        recentRuns: [],
+        commands: [],
+        suggestedPrompt: 'Ask for blockers.',
+      },
     })
+    workItemMocks.createAgentWorkItem.mockImplementation(async (input) => ({
+      id: input.parentWorkItemId ? `child-${input.title}` : 'parent-goal',
+      title: input.title,
+      objective: input.objective,
+      metadata: input.metadata ?? {},
+    }))
   })
 
   it('creates a traced standup run with transcript artifact', async () => {
@@ -111,6 +174,8 @@ describe('runAgentWarRoom', () => {
     }))
     expect(result.synthesis).toContain('Standup complete')
     expect(result.updates.length).toBeGreaterThan(0)
+    expect(result.messages.map((message) => message.content).join(' ')).toContain('Route blocked approval packet')
+    expect(result.messages.map((message) => message.content).join(' ')).toContain('Needs operator decision')
   })
 
   it('rejects discuss without a message', async () => {

--- a/lib/agent-war-room.ts
+++ b/lib/agent-war-room.ts
@@ -7,6 +7,7 @@ import {
 } from '@/lib/agent-run'
 import { AGENT_ORGANIZATION, AGENT_PODS, getAgentByKey, type AgentOrganizationNode } from '@/lib/agent-organization'
 import { buildAgentMissionControlSnapshot } from '@/lib/agent-mission-control'
+import { buildAgentOrgBoardSnapshot, type AgentOrgBoardSnapshot, type AgentOrgBoardTask } from '@/lib/agent-swarm-board'
 import { createAgentWorkItem, type AgentWorkItem, type AgentWorkItemPriority } from '@/lib/agent-work-items'
 
 export type AgentWarRoomCommand = 'standup' | 'discuss' | 'ask_agent' | 'draft_goal' | 'approve_goal'
@@ -109,14 +110,58 @@ function selectAgents(command: AgentWarRoomCommand, message: string | null, targ
   return (picked.length ? picked : callable).slice(0, 5)
 }
 
-function agentUpdate(agent: AgentOrganizationNode, command: AgentWarRoomCommand, message: string | null) {
+function isOpenTask(task: AgentOrgBoardTask) {
+  return !['merged', 'deployed', 'cancelled'].includes(task.status)
+}
+
+function hoursSince(value: string, now = new Date()) {
+  const time = new Date(value).getTime()
+  if (!Number.isFinite(time)) return null
+  return Math.max(0, Math.round(((now.getTime() - time) / 36e5) * 10) / 10)
+}
+
+function workContextForAgent(agent: AgentOrganizationNode, snapshot: AgentOrgBoardSnapshot) {
+  const tasks = snapshot.lanes
+    .flatMap((lane) => lane.tasks)
+    .filter((task) => task.ownerAgentKey === agent.key && isOpenTask(task))
+  const blocked = tasks.filter((task) => task.status === 'blocked' || Boolean(task.blockerSummary))
+  const reviewReady = tasks.filter((task) => task.status === 'ready_for_review' || task.status === 'ready_for_merge')
+  const oldest = [...tasks].sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())[0] ?? null
+  const nextTask = blocked[0] ?? reviewReady[0] ?? oldest
+  const agentSnapshot = snapshot.agents.find((item) => item.key === agent.key)
+  const oldestHours = oldest ? hoursSince(oldest.createdAt) : null
+
+  return {
+    activeCount: tasks.length,
+    blockedCount: blocked.length,
+    reviewReadyCount: reviewReady.length,
+    oldestHours,
+    nextTask,
+    latestRunId: agentSnapshot?.latestRunId ?? null,
+    latestAction: agentSnapshot?.latestAction ?? 'No recent traced activity',
+  }
+}
+
+function summarizeWorkContext(context: ReturnType<typeof workContextForAgent>) {
+  if (!context.activeCount) return 'No active Kanban work is assigned right now.'
+
+  const age = context.oldestHours != null ? ` Oldest in-flight item: ${context.oldestHours}h.` : ''
+  const next = context.nextTask
+    ? ` Next: ${context.nextTask.title} (${context.nextTask.status.replace(/_/g, ' ')}).${context.nextTask.blockerSummary ? ` Blocker: ${context.nextTask.blockerSummary}.` : ''}`
+    : ''
+  return `${context.activeCount} active Kanban item(s), ${context.blockedCount} blocked, ${context.reviewReadyCount} review-ready.${age}${next}`
+}
+
+function agentUpdate(agent: AgentOrganizationNode, command: AgentWarRoomCommand, message: string | null, orgSnapshot: AgentOrgBoardSnapshot) {
   const activeWorkflows = agent.n8nWorkflows.filter((workflow) => workflow.active).length
+  const workContext = workContextForAgent(agent, orgSnapshot)
+  const workSummary = summarizeWorkContext(workContext)
   const scope =
     command === 'standup'
-      ? `Current posture: ${agent.status}; ${activeWorkflows} active mapped workflow(s).`
+      ? `Current posture: ${agent.status}; ${activeWorkflows} active mapped workflow(s). ${workSummary}`
       : command === 'ask_agent'
-        ? `Direct response: ${agent.responsibility}. Request: "${message}".`
-        : `Perspective on "${message}": ${agent.responsibility}`
+        ? `Direct update on "${message}": ${workSummary} Role scope: ${agent.responsibility}.`
+        : `Perspective on "${message}": ${workSummary} Role scope: ${agent.responsibility}.`
 
   return {
     agent_key: agent.key,
@@ -126,9 +171,15 @@ function agentUpdate(agent: AgentOrganizationNode, command: AgentWarRoomCommand,
     status: agent.status,
     update: scope,
     next_action: agent.status === 'active'
-      ? 'Ready for read-only engagement through Agent Ops.'
+      ? workContext.nextTask?.activeRunId
+        ? `Open trace ${workContext.nextTask.activeRunId} or ask for the next handoff.`
+        : 'Ready for read-only engagement through Agent Ops.'
       : 'Use Shaka routing before assigning production work.',
     approval_gate: agent.approvalGate,
+    active_work_count: workContext.activeCount,
+    blocked_work_count: workContext.blockedCount,
+    review_ready_count: workContext.reviewReadyCount,
+    latest_run_id: workContext.latestRunId,
   }
 }
 
@@ -335,6 +386,7 @@ export async function runAgentWarRoom(input: RunAgentWarRoomInput) {
     draft_goal: 'Agent Standup Room goal draft',
     approve_goal: 'Agent Standup Room goal approval',
   }
+  const draftGoalId = input.command === 'approve_goal' ? input.draft?.goal_id ?? null : null
   const run = await startAgentRun({
     agentKey: 'chief-of-staff',
     runtime: 'manual',
@@ -353,13 +405,17 @@ export async function runAgentWarRoom(input: RunAgentWarRoomInput) {
       message_preview: message,
       target_agent_key: input.targetAgentKey ?? null,
       goal_preview: goal,
+      goal_id: draftGoalId,
       executes_action: input.command === 'approve_goal',
     },
   })
 
-  const snapshot = await buildAgentMissionControlSnapshot()
+  const [snapshot, orgSnapshot] = await Promise.all([
+    buildAgentMissionControlSnapshot(),
+    buildAgentOrgBoardSnapshot(),
+  ])
   const agents = selectAgents(input.command, message ?? goal, input.targetAgentKey)
-  const updates = agents.map((agent) => agentUpdate(agent, input.command, message ?? goal))
+  const updates = agents.map((agent) => agentUpdate(agent, input.command, message ?? goal, orgSnapshot))
   const synthesis = synthesize(input.command, updates, snapshot.attention_queue.length)
   const messages: AgentWarRoomMessage[] = [
     ...(message ? [{


### PR DESCRIPTION
## Summary
- Grounds Standup Room agent responses in the live Agent Kanban workload snapshot, including active work counts, blockers, review-ready work, oldest in-flight work, and trace handoff guidance.
- Adds recent Standup Room command traces to the Agent Kanban War Room tab so the board shows actual room activity instead of only static Slack guidance.
- Extends focused tests for workload-aware standup messages and War Room trace rendering.

## Validation
- npm test -- lib/agent-war-room.test.ts app/admin/agents/swarm-board/page.test.tsx app/admin/agents/standup/page.test.tsx app/api/admin/agents/swarm-board/route.test.ts
- npx tsc --noEmit --pretty false
- npm run lint

## Integration Notes
- No schema or migration changes.
- No production mutations were run; the change reads existing Agent Ops snapshots and trace data.
- Vercel contexts for the prior merged PR #261 were verified green before this branch was started: Vercel – portfolio and Vercel – portfolio-staging.