### PR TITLE
feat: add goal audit traceability

### DIFF
--- a/app/admin/agents/standup/page.test.tsx
+++ b/app/admin/agents/standup/page.test.tsx
@@ -39,6 +39,13 @@ const organization = {
       blocked: 0,
       open: 1,
       burndown: [{ label: 'May 14', remaining: 1 }],
+      sessionHref: '/admin/agents/standup?goal=goal-1',
+      draftRunId: 'draft-run',
+      approvalRunId: 'approval-run',
+      latestRunId: 'room-run',
+      draftTraceHref: '/admin/agents/runs/draft-run',
+      approvalTraceHref: '/admin/agents/runs/approval-run',
+      latestTraceHref: '/admin/agents/runs/room-run',
     }],
   },
   agents: [
@@ -102,6 +109,13 @@ const organization = {
           status: 'approved',
           progressWeight: 1,
           sessionHref: '/admin/agents/standup?goal=goal-1',
+          draftRunId: 'draft-run',
+          approvalRunId: 'approval-run',
+          latestRunId: 'room-run',
+          parentWorkItemId: 'goal-parent',
+          draftTraceHref: '/admin/agents/runs/draft-run',
+          approvalTraceHref: '/admin/agents/runs/approval-run',
+          latestTraceHref: '/admin/agents/runs/room-run',
         },
       }],
     },
@@ -316,7 +330,19 @@ describe('AgentStandupRoomPage', () => {
     expect(screen.getAllByText('Draft standup room').length).toBeGreaterThan(0)
     expect(screen.getByRole('link', { name: 'Open Kanban focus' })).toHaveAttribute('href', '/admin/agents/swarm-board?goal=goal-1')
     expect(screen.getByRole('link', { name: 'Open board' })).toHaveAttribute('href', '/admin/agents/swarm-board?goal=goal-1')
+    expect(screen.getByRole('link', { name: 'Draft trace' })).toHaveAttribute('href', '/admin/agents/runs/draft-run')
+    expect(screen.getByRole('link', { name: 'Approval trace' })).toHaveAttribute('href', '/admin/agents/runs/approval-run')
+    expect(screen.getByRole('link', { name: 'Latest room trace' })).toHaveAttribute('href', '/admin/agents/runs/room-run')
     expect(screen.getByText('Goal Kanban preview')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /Start standup/i }))
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/admin/agents/war-room', expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ command: 'standup', goal_id: 'goal-1' }),
+      }))
+    })
 
     fireEvent.click(screen.getByRole('button', { name: 'Clear focus' }))
 

--- a/app/admin/agents/standup/page.tsx
+++ b/app/admin/agents/standup/page.tsx
@@ -211,6 +211,10 @@ function StandupRoomContent() {
   async function postWarRoom(payload: Record<string, unknown>, loadingKey: string, questionId?: string) {
     setBusy(loadingKey)
     setError(null)
+    const command = typeof payload.command === 'string' ? payload.command : null
+    const scopedPayload = focusedGoalId && command !== 'draft_goal'
+      ? { ...payload, goal_id: focusedGoalId }
+      : payload
     try {
       const session = await getCurrentSession()
       if (!session?.access_token) throw new Error('Missing admin session')
@@ -220,7 +224,7 @@ function StandupRoomContent() {
           Authorization: `Bearer ${session.access_token}`,
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify(payload),
+        body: JSON.stringify(scopedPayload),
       })
       const body = await response.json().catch(() => ({})) as WarRoomResponse
       if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`)
@@ -770,6 +774,14 @@ function GoalSessionPanel({
           <p className="mt-1 text-sm text-muted-foreground">
             {goal.completed}/{goal.total} complete · {goal.open} open · {goal.blocked} blocked
           </p>
+          <div className="mt-3 flex flex-wrap gap-2 text-xs">
+            {goal.draftTraceHref && <AuditLink href={goal.draftTraceHref} label="Draft trace" />}
+            {goal.approvalTraceHref && <AuditLink href={goal.approvalTraceHref} label="Approval trace" />}
+            {goal.latestTraceHref && <AuditLink href={goal.latestTraceHref} label="Latest room trace" />}
+            {!goal.draftTraceHref && !goal.approvalTraceHref && !goal.latestTraceHref ? (
+              <span className="rounded-full border border-silicon-slate/60 px-2 py-1 text-muted-foreground">Audit traces pending</span>
+            ) : null}
+          </div>
         </div>
         <div className="flex flex-wrap gap-2">
           <Link href={`/admin/agents/swarm-board?goal=${encodeURIComponent(goal.id)}`} className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/50 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/10">
@@ -807,6 +819,14 @@ function GoalSessionPanel({
         )}
       </div>
     </section>
+  )
+}
+
+function AuditLink({ href, label }: { href: string; label: string }) {
+  return (
+    <Link href={href} className="rounded-full border border-radiant-gold/35 bg-radiant-gold/10 px-2 py-1 text-radiant-gold hover:bg-radiant-gold/15">
+      {label}
+    </Link>
   )
 }
 

--- a/app/admin/agents/swarm-board/page.test.tsx
+++ b/app/admin/agents/swarm-board/page.test.tsx
@@ -54,6 +54,13 @@ const boardSnapshot = {
         blocked: 1,
         open: 2,
         burndown: [{ label: 'May 13', remaining: 2 }, { label: 'May 14', remaining: 1 }],
+        sessionHref: '/admin/agents/standup?goal=goal-1',
+        draftRunId: 'draft-run',
+        approvalRunId: 'approval-run',
+        latestRunId: 'war-room-run-1',
+        draftTraceHref: '/admin/agents/runs/draft-run',
+        approvalTraceHref: '/admin/agents/runs/approval-run',
+        latestTraceHref: '/admin/agents/runs/war-room-run-1',
       }],
     },
     lanes: [
@@ -92,6 +99,13 @@ const boardSnapshot = {
               status: 'approved',
               progressWeight: 1,
               sessionHref: '/admin/agents/standup?goal=goal-1',
+              draftRunId: 'draft-run',
+              approvalRunId: 'approval-run',
+              latestRunId: 'war-room-run-1',
+              parentWorkItemId: 'goal-parent',
+              draftTraceHref: '/admin/agents/runs/draft-run',
+              approvalTraceHref: '/admin/agents/runs/approval-run',
+              latestTraceHref: '/admin/agents/runs/war-room-run-1',
             },
           },
           {
@@ -122,6 +136,13 @@ const boardSnapshot = {
               status: 'approved',
               progressWeight: 1,
               sessionHref: '/admin/agents/standup?goal=goal-1',
+              draftRunId: 'draft-run',
+              approvalRunId: 'approval-run',
+              latestRunId: 'war-room-run-1',
+              parentWorkItemId: 'goal-parent',
+              draftTraceHref: '/admin/agents/runs/draft-run',
+              approvalTraceHref: '/admin/agents/runs/approval-run',
+              latestTraceHref: '/admin/agents/runs/war-room-run-1',
             },
           },
           {
@@ -262,6 +283,10 @@ describe('AgentSwarmBoardPage', () => {
 
     expect(screen.getByRole('region', { name: 'Selected goal work' })).toBeInTheDocument()
     expect(screen.getByText(/0\/2 complete/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Open goal session' })).toHaveAttribute('href', '/admin/agents/standup?goal=goal-1')
+    expect(screen.getByRole('link', { name: 'Draft trace' })).toHaveAttribute('href', '/admin/agents/runs/draft-run')
+    expect(screen.getByRole('link', { name: 'Approval trace' })).toHaveAttribute('href', '/admin/agents/runs/approval-run')
+    expect(screen.getByRole('link', { name: 'Latest room trace' })).toHaveAttribute('href', '/admin/agents/runs/war-room-run-1')
     expect(screen.queryByText('Maintain automation context outside the selected goal')).not.toBeInTheDocument()
     expect(screen.getAllByText('2/3 visible').length).toBeGreaterThan(0)
 

--- a/app/admin/agents/swarm-board/page.tsx
+++ b/app/admin/agents/swarm-board/page.tsx
@@ -524,9 +524,17 @@ function SelectedGoalPanel({ goal, tasks }: { goal: AgentOrgBoardSnapshot['summa
                 {goal.completed}/{goal.total} complete · {goal.open} open · {goal.blocked} blocked
               </p>
             </div>
-            <Link href={`/admin/agents/standup?goal=${encodeURIComponent(goal.id)}`} className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/50 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15">
+            <Link href={goal.sessionHref} className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/50 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15">
               Open goal session
             </Link>
+          </div>
+          <div className="mt-3 flex flex-wrap gap-2 text-xs">
+            {goal.draftTraceHref && <AuditLink href={goal.draftTraceHref} label="Draft trace" />}
+            {goal.approvalTraceHref && <AuditLink href={goal.approvalTraceHref} label="Approval trace" />}
+            {goal.latestTraceHref && <AuditLink href={goal.latestTraceHref} label="Latest room trace" />}
+            {!goal.draftTraceHref && !goal.approvalTraceHref && !goal.latestTraceHref ? (
+              <span className="rounded-full border border-silicon-slate/60 px-2 py-1 text-muted-foreground">Audit traces pending</span>
+            ) : null}
           </div>
           <div className="mt-4 h-3 overflow-hidden rounded-full bg-silicon-slate/70">
             <div className="h-full bg-radiant-gold" style={{ width: `${goal.progress}%` }} />
@@ -577,6 +585,14 @@ function SelectedGoalPanel({ goal, tasks }: { goal: AgentOrgBoardSnapshot['summa
         </div>
       </div>
     </section>
+  )
+}
+
+function AuditLink({ href, label }: { href: string; label: string }) {
+  return (
+    <Link href={href} className="rounded-full border border-radiant-gold/35 bg-radiant-gold/10 px-2 py-1 text-radiant-gold hover:bg-radiant-gold/15">
+      {label}
+    </Link>
   )
 }
 

--- a/app/api/admin/agents/war-room/route.test.ts
+++ b/app/api/admin/agents/war-room/route.test.ts
@@ -127,13 +127,14 @@ describe('POST /api/admin/agents/war-room', () => {
       messages: [],
     })
 
-    const response = await POST(request({ command: 'ask_agent', message: 'What is blocked?', target_agent_key: 'chief-of-staff' }) as never)
+    const response = await POST(request({ command: 'ask_agent', message: 'What is blocked?', target_agent_key: 'chief-of-staff', goal_id: 'goal-1' }) as never)
 
     expect(response.status).toBe(200)
     expect(mocks.runAgentWarRoom).toHaveBeenCalledWith(expect.objectContaining({
       command: 'ask_agent',
       message: 'What is blocked?',
       targetAgentKey: 'chief-of-staff',
+      goalId: 'goal-1',
     }))
   })
 
@@ -198,6 +199,7 @@ describe('POST /api/admin/agents/war-room', () => {
     expect(mocks.runAgentWarRoom).toHaveBeenCalledWith(expect.objectContaining({
       command: 'approve_goal',
       draft,
+      goalId: '',
     }))
   })
 })

--- a/app/api/admin/agents/war-room/route.ts
+++ b/app/api/admin/agents/war-room/route.ts
@@ -32,6 +32,8 @@ export async function POST(request: NextRequest) {
     message?: unknown
     target_agent_key?: unknown
     targetAgentKey?: unknown
+    goal_id?: unknown
+    goalId?: unknown
     goal?: unknown
     draft?: unknown
   }
@@ -61,6 +63,11 @@ export async function POST(request: NextRequest) {
   }
 
   const goal = typeof body.goal === 'string' ? body.goal.trim() : ''
+  const goalId = typeof body.goal_id === 'string'
+    ? body.goal_id.trim()
+    : typeof body.goalId === 'string'
+      ? body.goalId.trim()
+      : ''
   if (command === 'draft_goal' && !goal) {
     return NextResponse.json({ error: 'Goal is required for draft_goal' }, { status: 400 })
   }
@@ -74,6 +81,7 @@ export async function POST(request: NextRequest) {
       command,
       message,
       targetAgentKey,
+      goalId,
       goal,
       draft: command === 'approve_goal' ? body.draft as never : null,
       triggerSource: 'admin_agent_war_room',

--- a/lib/agent-swarm-board.test.ts
+++ b/lib/agent-swarm-board.test.ts
@@ -612,6 +612,9 @@ describe('buildAgentOrgBoardSnapshotFromRows', () => {
             goal_sequence: 1,
             goal_status: 'approved',
             goal_progress_weight: 2,
+            goal_draft_run_id: 'draft-run',
+            goal_approved_by_run_id: 'approval-run',
+            goal_session_href: '/admin/agents/standup?goal=goal%20kanban%20v1',
           },
         }),
         orgWorkItem({
@@ -627,7 +630,10 @@ describe('buildAgentOrgBoardSnapshotFromRows', () => {
             goal_sequence: 2,
             goal_status: 'approved',
             goal_progress_weight: 1,
-          },
+            goal_draft_run_id: 'draft-run',
+            goal_approved_by_run_id: 'approval-run',
+            goal_parent_work_item_id: 'goal-parent',
+            },
         }),
         orgWorkItem({
           id: 'goal-progress',
@@ -641,6 +647,8 @@ describe('buildAgentOrgBoardSnapshotFromRows', () => {
             goal_sequence: 3,
             goal_status: 'approved',
             goal_progress_weight: 1,
+            goal_draft_run_id: 'draft-run',
+            goal_approved_by_run_id: 'approval-run',
           },
         }),
       ],
@@ -656,12 +664,22 @@ describe('buildAgentOrgBoardSnapshotFromRows', () => {
       progress: 50,
       blocked: 1,
       open: 2,
+      sessionHref: '/admin/agents/standup?goal=goal%20kanban%20v1',
+      draftRunId: 'draft-run',
+      approvalRunId: 'approval-run',
+      latestRunId: 'approval-run',
+      draftTraceHref: '/admin/agents/runs/draft-run',
+      approvalTraceHref: '/admin/agents/runs/approval-run',
     })
     expect(snapshot.summary.goals[0].burndown.length).toBeGreaterThan(0)
     expect(snapshot.lanes.flatMap((lane) => lane.tasks).find((task) => task.id === 'goal-blocked')?.goal).toMatchObject({
       id: 'goal kanban v1',
       sessionHref: '/admin/agents/standup?goal=goal%20kanban%20v1',
       sequence: 2,
+      draftRunId: 'draft-run',
+      approvalRunId: 'approval-run',
+      draftTraceHref: '/admin/agents/runs/draft-run',
+      approvalTraceHref: '/admin/agents/runs/approval-run',
     })
   })
 

--- a/lib/agent-swarm-board.ts
+++ b/lib/agent-swarm-board.ts
@@ -131,6 +131,13 @@ export type AgentOrgBoardTask = {
     status: string | null
     progressWeight: number
     sessionHref: string
+    draftRunId: string | null
+    approvalRunId: string | null
+    latestRunId: string | null
+    parentWorkItemId: string | null
+    draftTraceHref: string | null
+    approvalTraceHref: string | null
+    latestTraceHref: string | null
   } | null
 }
 
@@ -143,6 +150,13 @@ export type AgentOrgBoardGoalMetric = {
   blocked: number
   open: number
   burndown: Array<{ label: string; remaining: number }>
+  sessionHref: string
+  draftRunId: string | null
+  approvalRunId: string | null
+  latestRunId: string | null
+  draftTraceHref: string | null
+  approvalTraceHref: string | null
+  latestTraceHref: string | null
 }
 
 export type AgentOrgBoardWipMetric = {
@@ -812,13 +826,24 @@ function goalForTask(item: AgentWorkItemRow): AgentOrgBoardTask['goal'] {
   const goalId = stringValue(metadata.goal_id)
   const goalTitle = stringValue(metadata.goal_title)
   if (!goalId || !goalTitle) return null
+  const draftRunId = stringValue(metadata.goal_draft_run_id) ?? stringValue(metadata.draft_run_id)
+  const approvalRunId = stringValue(metadata.goal_approved_by_run_id) ?? stringValue(metadata.approved_by_run_id) ?? stringValue(metadata.goal_created_by_run_id)
+  const latestRunId = item.active_run_id ?? approvalRunId ?? draftRunId
+  const sessionHref = stringValue(metadata.goal_session_href) ?? `/admin/agents/standup?goal=${encodeURIComponent(goalId)}`
   return {
     id: goalId,
     title: goalTitle,
     sequence: typeof metadata.goal_sequence === 'number' ? metadata.goal_sequence : null,
     status: stringValue(metadata.goal_status),
     progressWeight: numberValue(metadata.goal_progress_weight, 1),
-    sessionHref: `/admin/agents/standup?goal=${encodeURIComponent(goalId)}`,
+    sessionHref,
+    draftRunId,
+    approvalRunId,
+    latestRunId,
+    parentWorkItemId: stringValue(metadata.goal_parent_work_item_id) ?? item.parent_work_item_id ?? null,
+    draftTraceHref: draftRunId ? `/admin/agents/runs/${draftRunId}` : null,
+    approvalTraceHref: approvalRunId ? `/admin/agents/runs/${approvalRunId}` : null,
+    latestTraceHref: latestRunId ? `/admin/agents/runs/${latestRunId}` : null,
   }
 }
 
@@ -843,6 +868,10 @@ function buildGoalMetrics(tasks: AgentOrgBoardTask[]): AgentOrgBoardGoalMetric[]
 
   return [...grouped.entries()].map(([id, goalTasks]) => {
     const title = goalTasks[0]?.goal?.title ?? id
+    const firstGoal = goalTasks.find((task) => task.goal)?.goal ?? null
+    const draftRunId = goalTasks.find((task) => task.goal?.draftRunId)?.goal?.draftRunId ?? null
+    const approvalRunId = goalTasks.find((task) => task.goal?.approvalRunId)?.goal?.approvalRunId ?? null
+    const latestRunId = goalTasks.find((task) => task.goal?.latestRunId)?.goal?.latestRunId ?? approvalRunId ?? draftRunId
     const totalWeight = goalTasks.reduce((sum, task) => sum + (task.goal?.progressWeight ?? 1), 0) || goalTasks.length || 1
     const completedWeight = goalTasks
       .filter((task) => isCompletedWorkStatus(task.status))
@@ -861,6 +890,13 @@ function buildGoalMetrics(tasks: AgentOrgBoardTask[]): AgentOrgBoardGoalMetric[]
       blocked: goalTasks.filter((task) => task.status === 'blocked').length,
       open: goalTasks.filter((task) => isActiveWorkStatus(task.status)).length,
       burndown,
+      sessionHref: firstGoal?.sessionHref ?? `/admin/agents/standup?goal=${encodeURIComponent(id)}`,
+      draftRunId,
+      approvalRunId,
+      latestRunId,
+      draftTraceHref: draftRunId ? `/admin/agents/runs/${draftRunId}` : null,
+      approvalTraceHref: approvalRunId ? `/admin/agents/runs/${approvalRunId}` : null,
+      latestTraceHref: latestRunId ? `/admin/agents/runs/${latestRunId}` : null,
     }
   })
 }

--- a/lib/agent-war-room.test.ts
+++ b/lib/agent-war-room.test.ts
@@ -197,10 +197,22 @@ describe('runAgentWarRoom', () => {
     })
 
     expect(result.goalDraft?.title).toBe('Build a transparent standup room')
+    expect(result.goalDraft?.draft_run_id).toBe('war-room-run')
     expect(result.goalDraft?.tasks.length).toBeGreaterThan(2)
     expect(workItemMocks.createAgentWorkItem).not.toHaveBeenCalled()
+    expect(agentRunMocks.startAgentRun).toHaveBeenCalledWith(expect.objectContaining({
+      metadata: expect.objectContaining({
+        command: 'draft_goal',
+        goal_id: result.goalDraft?.goal_id,
+        goal_session_href: `/admin/agents/standup?goal=${encodeURIComponent(result.goalDraft?.goal_id ?? '')}`,
+      }),
+    }))
     expect(agentRunMocks.attachAgentArtifact).toHaveBeenCalledWith(expect.objectContaining({
       artifactType: 'war_room_goal_draft',
+      metadata: expect.objectContaining({
+        goal_id: result.goalDraft?.goal_id,
+        goal_draft_run_id: 'war-room-run',
+      }),
     }))
   })
 
@@ -226,9 +238,78 @@ describe('runAgentWarRoom', () => {
     expect(workItemMocks.createAgentWorkItem).toHaveBeenCalledTimes(1 + (draftResult.goalDraft?.tasks.length ?? 0))
     expect(workItemMocks.createAgentWorkItem).toHaveBeenCalledWith(expect.objectContaining({
       title: expect.stringContaining('Goal:'),
-      metadata: expect.objectContaining({ goal_role: 'parent' }),
+      sourceRunId: 'approval-run',
+      source: expect.objectContaining({ type: 'agent_standup_goal' }),
+      metadata: expect.objectContaining({
+        goal_role: 'parent',
+        goal_id: draftResult.goalDraft?.goal_id,
+        goal_draft_run_id: 'war-room-run',
+        goal_approved_by_run_id: 'approval-run',
+        goal_session_href: `/admin/agents/standup?goal=${encodeURIComponent(draftResult.goalDraft?.goal_id ?? '')}`,
+      }),
+    }))
+    expect(workItemMocks.createAgentWorkItem).toHaveBeenCalledWith(expect.objectContaining({
+      parentWorkItemId: 'parent-goal',
+      source: expect.objectContaining({ type: 'agent_standup_goal_task' }),
+      expectedFiles: expect.any(Array),
+      metadata: expect.objectContaining({
+        goal_role: 'task',
+        goal_draft_run_id: 'war-room-run',
+        goal_approved_by_run_id: 'approval-run',
+        goal_parent_work_item_id: 'parent-goal',
+        goal_sequence: expect.any(Number),
+        acceptance_criteria: expect.any(Array),
+        risk_notes: expect.any(String),
+      }),
+    }))
+    expect(agentRunMocks.recordAgentStep).toHaveBeenCalledWith(expect.objectContaining({
+      stepKey: 'goal_work_items_created',
+    }))
+    expect(agentRunMocks.attachAgentArtifact).toHaveBeenCalledWith(expect.objectContaining({
+      artifactType: 'war_room_transcript',
+      metadata: expect.objectContaining({
+        executes_action: true,
+        goal_id: draftResult.goalDraft?.goal_id,
+        goal_draft_run_id: 'war-room-run',
+        goal_approved_by_run_id: 'approval-run',
+        created_parent_work_item_id: 'parent-goal',
+        created_child_work_item_ids: expect.any(Array),
+      }),
+    }))
+    expect(agentRunMocks.endAgentRun).toHaveBeenCalledWith(expect.objectContaining({
+      outcome: expect.objectContaining({
+        goal_id: draftResult.goalDraft?.goal_id,
+        goal_draft_run_id: 'war-room-run',
+        goal_approved_by_run_id: 'approval-run',
+        created_child_count: draftResult.goalDraft?.tasks.length,
+      }),
     }))
     expect(result.createdWorkItems?.children.length).toBe(draftResult.goalDraft?.tasks.length)
+  })
+
+  it('records focused goal context on room asks without creating work items', async () => {
+    await runAgentWarRoom({
+      command: 'discuss',
+      message: 'What changed for this goal?',
+      goalId: 'goal-existing',
+      triggerSource: 'test_war_room',
+    })
+
+    expect(agentRunMocks.startAgentRun).toHaveBeenCalledWith(expect.objectContaining({
+      metadata: expect.objectContaining({
+        command: 'discuss',
+        goal_id: 'goal-existing',
+        goal_session_href: '/admin/agents/standup?goal=goal-existing',
+        executes_action: false,
+      }),
+    }))
+    expect(workItemMocks.createAgentWorkItem).not.toHaveBeenCalled()
+    expect(agentRunMocks.endAgentRun).toHaveBeenCalledWith(expect.objectContaining({
+      outcome: expect.objectContaining({
+        goal_id: 'goal-existing',
+        goal_session_href: '/admin/agents/standup?goal=goal-existing',
+      }),
+    }))
   })
 
   it('rejects invalid direct agent asks', async () => {

--- a/lib/agent-war-room.ts
+++ b/lib/agent-war-room.ts
@@ -31,6 +31,7 @@ export interface AgentGoalDraft {
   objective: string
   recommendation: string
   risk_notes: string
+  draft_run_id?: string | null
   tasks: AgentGoalDraftTask[]
 }
 
@@ -47,6 +48,7 @@ export interface RunAgentWarRoomInput {
   command: AgentWarRoomCommand
   message?: string | null
   targetAgentKey?: string | null
+  goalId?: string | null
   goal?: string | null
   draft?: AgentGoalDraft | null
   triggerSource: string
@@ -307,7 +309,13 @@ function assertDraft(value: AgentGoalDraft | null | undefined): AgentGoalDraft {
   return value
 }
 
+function goalSessionHref(goalId: string) {
+  return `/admin/agents/standup?goal=${encodeURIComponent(goalId)}`
+}
+
 async function approveGoalDraft(runId: string, draft: AgentGoalDraft) {
+  const draftRunId = draft.draft_run_id ?? null
+  const sessionHref = goalSessionHref(draft.goal_id)
   const parent = await createAgentWorkItem({
     title: `Goal: ${draft.title}`,
     objective: draft.objective,
@@ -322,6 +330,9 @@ async function approveGoalDraft(runId: string, draft: AgentGoalDraft) {
       goal_status: 'approved',
       goal_role: 'parent',
       goal_created_by_run_id: runId,
+      goal_draft_run_id: draftRunId,
+      goal_approved_by_run_id: runId,
+      goal_session_href: sessionHref,
       goal_progress_weight: 0,
       recommendation: draft.recommendation,
     },
@@ -347,6 +358,10 @@ async function approveGoalDraft(runId: string, draft: AgentGoalDraft) {
         goal_status: 'approved',
         goal_role: 'task',
         goal_created_by_run_id: runId,
+        goal_draft_run_id: draftRunId,
+        goal_approved_by_run_id: runId,
+        goal_parent_work_item_id: parent.id,
+        goal_session_href: sessionHref,
         goal_progress_weight: task.goal_progress_weight,
         goal_task_id: task.id,
         goal_dependencies: task.dependencies,
@@ -365,6 +380,7 @@ export async function runAgentWarRoom(input: RunAgentWarRoomInput) {
   assertCommand(input.command)
   const message = input.message?.trim().slice(0, 1000) || null
   const goal = input.goal?.trim().slice(0, 1000) || null
+  const contextGoalId = input.goalId?.trim().slice(0, 160) || null
   if ((input.command === 'discuss' || input.command === 'ask_agent') && !message) {
     throw new Error(`Message is required for ${input.command}`)
   }
@@ -386,7 +402,10 @@ export async function runAgentWarRoom(input: RunAgentWarRoomInput) {
     draft_goal: 'Agent Standup Room goal draft',
     approve_goal: 'Agent Standup Room goal approval',
   }
-  const draftGoalId = input.command === 'approve_goal' ? input.draft?.goal_id ?? null : null
+  const precomputedGoalDraft = input.command === 'draft_goal' ? draftGoal(goal ?? '') : null
+  const draftGoalId = input.command === 'approve_goal' ? input.draft?.goal_id ?? null : precomputedGoalDraft?.goal_id ?? null
+  const activeGoalId = draftGoalId ?? contextGoalId
+  const draftRunId = input.command === 'approve_goal' ? input.draft?.draft_run_id ?? null : null
   const run = await startAgentRun({
     agentKey: 'chief-of-staff',
     runtime: 'manual',
@@ -405,7 +424,10 @@ export async function runAgentWarRoom(input: RunAgentWarRoomInput) {
       message_preview: message,
       target_agent_key: input.targetAgentKey ?? null,
       goal_preview: goal,
-      goal_id: draftGoalId,
+      goal_id: activeGoalId,
+      goal_session_href: activeGoalId ? goalSessionHref(activeGoalId) : null,
+      goal_draft_run_id: draftRunId,
+      goal_approved_by_run_id: input.command === 'approve_goal' ? null : null,
       executes_action: input.command === 'approve_goal',
     },
   })
@@ -438,7 +460,7 @@ export async function runAgentWarRoom(input: RunAgentWarRoomInput) {
   let goalDraft: AgentGoalDraft | null = null
   let createdWorkItems: { parent: AgentWorkItem; children: AgentWorkItem[] } | null = null
   if (input.command === 'draft_goal') {
-    goalDraft = draftGoal(goal ?? '')
+    goalDraft = precomputedGoalDraft ? { ...precomputedGoalDraft, draft_run_id: run.id } : null
   }
   if (input.command === 'approve_goal') {
     const draft = assertDraft(input.draft)
@@ -468,6 +490,11 @@ export async function runAgentWarRoom(input: RunAgentWarRoomInput) {
     metadata: { updates, goalDraft, createdWorkItems },
   })
 
+  const finalGoalId = goalDraft?.goal_id ?? input.draft?.goal_id ?? contextGoalId
+  const finalGoalSessionHref = finalGoalId ? goalSessionHref(finalGoalId) : null
+  const createdParentId = createdWorkItems?.parent.id ?? null
+  const createdChildIds = createdWorkItems?.children.map((item) => item.id) ?? []
+
   await attachAgentArtifact({
     runId: run.id,
     artifactType: input.command === 'draft_goal' ? 'war_room_goal_draft' : 'war_room_transcript',
@@ -484,6 +511,12 @@ export async function runAgentWarRoom(input: RunAgentWarRoomInput) {
       messages,
       goal_draft: goalDraft,
       created_work_items: createdWorkItems,
+      goal_id: finalGoalId,
+      goal_session_href: finalGoalSessionHref,
+      goal_draft_run_id: goalDraft?.draft_run_id ?? input.draft?.draft_run_id ?? null,
+      goal_approved_by_run_id: input.command === 'approve_goal' ? run.id : null,
+      created_parent_work_item_id: createdParentId,
+      created_child_work_item_ids: createdChildIds,
       status_strip: snapshot.status_strip,
       executes_action: input.command === 'approve_goal',
     },
@@ -495,7 +528,14 @@ export async function runAgentWarRoom(input: RunAgentWarRoomInput) {
     eventType: `war_room_${input.command}_completed`,
     severity: 'info',
     message: synthesis,
-    metadata: { command: input.command, update_count: updates.length, goal_id: goalDraft?.goal_id ?? input.draft?.goal_id ?? null },
+    metadata: {
+      command: input.command,
+      update_count: updates.length,
+      goal_id: finalGoalId,
+      goal_session_href: finalGoalSessionHref,
+      goal_draft_run_id: goalDraft?.draft_run_id ?? input.draft?.draft_run_id ?? null,
+      goal_approved_by_run_id: input.command === 'approve_goal' ? run.id : null,
+    },
   })
 
   await endAgentRun({
@@ -507,7 +547,12 @@ export async function runAgentWarRoom(input: RunAgentWarRoomInput) {
       update_count: updates.length,
       synthesis,
       executes_action: input.command === 'approve_goal',
-      goal_id: goalDraft?.goal_id ?? input.draft?.goal_id ?? null,
+      goal_id: finalGoalId,
+      goal_session_href: finalGoalSessionHref,
+      goal_draft_run_id: goalDraft?.draft_run_id ?? input.draft?.draft_run_id ?? null,
+      goal_approved_by_run_id: input.command === 'approve_goal' ? run.id : null,
+      created_parent_work_item_id: createdParentId,
+      created_child_work_item_ids: createdChildIds,
       created_child_count: createdWorkItems?.children.length ?? 0,
     },
   })


### PR DESCRIPTION
## Summary
- carries focused Standup Room `goal_id` through standup, discuss, and direct agent asks
- preserves draft/approval trace IDs and goal session links in War Room run metadata, artifacts, outcomes, and created work-item metadata
- projects goal audit links into Standup Room goal sessions and Agent Kanban selected-goal panels

## Validation
- npm test -- lib/agent-war-room.test.ts app/api/admin/agents/war-room/route.test.ts
- npm test -- app/admin/agents/standup/page.test.tsx app/admin/agents/swarm-board/page.test.tsx lib/agent-swarm-board.test.ts app/api/admin/agents/swarm-board/route.test.ts
- npx tsc --noEmit --pretty false
- npm run lint
- npm run build

## Integration Notes
- no schema migration; all audit fields use existing metadata/outcome/artifact payloads
- historical goals without audit metadata render an Audit traces pending fallback
- approve_goal remains the only path here that creates work items
- build emitted the existing dev env warning about n8n outbound settings; no operator check or approve-goal mutation workflow was run
- Vercel – portfolio and Vercel – portfolio-staging require post-merge verification
