### PR TITLE
feat: add standup trace history

### DIFF
--- a/app/admin/agents/standup/page.test.tsx
+++ b/app/admin/agents/standup/page.test.tsx
@@ -131,7 +131,15 @@ const organization = {
   activity: [],
   warRoom: {
     roster: [],
-    recentRuns: [],
+    recentRuns: [{
+      id: 'war-room-run-1',
+      title: 'Agent Standup Room direct ask',
+      command: 'ask_agent',
+      status: 'completed',
+      startedAt: '2026-05-14T11:00:00.000Z',
+      summary: 'Shaka answered with scoped work context.',
+      goalId: 'goal-1',
+    }],
     commands: [],
     suggestedPrompt: 'Ask for blockers.',
   },
@@ -240,7 +248,27 @@ describe('AgentStandupRoomPage', () => {
     expect(screen.getByText('Fixed lane order · 1 active lane(s). Empty lanes collapse so the board stays scannable.')).toBeInTheDocument()
     expect(screen.getAllByText('Piye').length).toBeGreaterThan(0)
     expect(screen.getByText('Info radiators')).toBeInTheDocument()
+    expect(screen.getByText('Trace history')).toBeInTheDocument()
+    expect(screen.getByText('Agent Standup Room direct ask')).toBeInTheDocument()
+    expect(screen.getByText('Shaka answered with scoped work context.')).toBeInTheDocument()
+    expect(screen.getByText('ask agent')).toBeInTheDocument()
+    expect(screen.getAllByText('completed').length).toBeGreaterThan(0)
+    expect(screen.getByText('goal goal-1')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Open trace/i })).toHaveAttribute('href', '/admin/agents/runs/war-room-run-1')
     expect(screen.getAllByText('Improve standup transparency').length).toBeGreaterThan(0)
+  })
+
+  it('renders an empty persisted trace history state', async () => {
+    vi.mocked(fetch).mockImplementation(async (url) => {
+      if (String(url).includes('/api/admin/agents/swarm-board')) {
+        return { ok: true, json: async () => ({ ok: true, organization: { ...organization, warRoom: { ...organization.warRoom, recentRuns: [] } } }) } as Response
+      }
+      return { ok: false, json: async () => ({ error: 'not found' }) } as Response
+    })
+
+    render(<AgentStandupRoomPage />)
+
+    expect(await screen.findByText('No standup-room traces yet. Start a standup or ask an agent to create the first room trace.')).toBeInTheDocument()
   })
 
   it('posts standup and direct agent asks through war-room commands', async () => {
@@ -253,7 +281,9 @@ describe('AgentStandupRoomPage', () => {
         body: JSON.stringify({ command: 'standup' }),
       }))
     })
-    expect(await screen.findByRole('link', { name: /Open trace/i })).toHaveAttribute('href', '/admin/agents/runs/room-run')
+    await waitFor(() => {
+      expect(screen.getAllByRole('link', { name: /Open trace/i }).some((link) => link.getAttribute('href') === '/admin/agents/runs/room-run')).toBe(true)
+    })
     expect(screen.getByText('Question tracker')).toBeInTheDocument()
     expect(screen.getByText('1/1 answered')).toBeInTheDocument()
 
@@ -299,7 +329,7 @@ describe('AgentStandupRoomPage', () => {
     fireEvent.click(screen.getByRole('button', { name: /Draft plan/i }))
 
     expect(await screen.findByText('Approve after review.')).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /Open trace/i })).toHaveAttribute('href', '/admin/agents/runs/goal-run')
+    expect(screen.getAllByRole('link', { name: /Open trace/i }).some((link) => link.getAttribute('href') === '/admin/agents/runs/goal-run')).toBe(true)
     expect(fetch).toHaveBeenCalledWith('/api/admin/agents/war-room', expect.objectContaining({
       method: 'POST',
       body: JSON.stringify({ command: 'draft_goal', goal: 'Improve standup' }),

--- a/app/admin/agents/standup/page.tsx
+++ b/app/admin/agents/standup/page.tsx
@@ -416,6 +416,7 @@ function StandupRoomContent() {
             </main>
             <aside className="space-y-5">
               <MetricsPanel organization={organization} />
+              <TraceHistory runs={organization.warRoom.recentRuns} />
               <MiniKanban lanes={organization.lanes} focusedGoalId={focusedGoalId} />
             </aside>
           </div>
@@ -890,6 +891,39 @@ function GoalProgress({ goal }: { goal: AgentOrgBoardGoalMetric }) {
         </div>
       )}
     </div>
+  )
+}
+
+function TraceHistory({ runs }: { runs: AgentOrgBoardSnapshot['warRoom']['recentRuns'] }) {
+  return (
+    <section className="agent-ops-card rounded-lg border p-4">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-radiant-gold">Trace history</h2>
+        <span className="rounded-full border border-silicon-slate/60 px-2 py-1 text-xs text-muted-foreground">{runs.length} trace(s)</span>
+      </div>
+      {runs.length ? (
+        <div className="space-y-2">
+          {runs.slice(0, 5).map((run) => (
+            <div key={run.id} className="rounded-lg border border-silicon-slate/60 bg-background/50 p-3 text-sm">
+              <div className="flex flex-wrap items-center gap-2 text-xs">
+                <span className="rounded-full border border-radiant-gold/35 px-2 py-0.5 text-radiant-gold">{run.command.replace(/_/g, ' ')}</span>
+                <span className="rounded-full border border-silicon-slate/60 px-2 py-0.5 text-muted-foreground">{run.status}</span>
+                {run.goalId ? <span className="rounded-full border border-silicon-slate/60 px-2 py-0.5 text-muted-foreground">goal {run.goalId}</span> : null}
+              </div>
+              <p className="mt-2 font-medium">{run.title}</p>
+              <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">{run.summary}</p>
+              <Link href={`/admin/agents/runs/${run.id}`} className="mt-3 inline-flex text-xs text-radiant-gold hover:underline">
+                Open trace
+              </Link>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="rounded-lg border border-dashed border-silicon-slate/60 p-3 text-sm text-muted-foreground">
+          No standup-room traces yet. Start a standup or ask an agent to create the first room trace.
+        </p>
+      )}
+    </section>
   )
 }
 


### PR DESCRIPTION
Summary
- Adds a persisted trace-history card to the Standup Room right rail using existing war-room recent run data.
- Shows command, status, goal tag, summary, and direct trace links for the latest room traces.
- Covers the populated and empty trace-history states in the Standup Room tests.

Validation
- npm test -- app/admin/agents/standup/page.test.tsx
- npm test -- app/admin/agents/standup/page.test.tsx app/admin/agents/swarm-board/page.test.tsx lib/agent-swarm-board.test.ts lib/agent-war-room.test.ts app/api/admin/agents/war-room/route.test.ts
- npx tsc --noEmit --pretty false
- npm run lint
- rm -rf .next && npm run build
- git diff --check

Integration Notes
- UI-only change; no schema, environment, or route contract changes.
- Reuses existing /api/admin/agents/swarm-board snapshot data.
- Vercel contexts to verify after merge: Vercel – portfolio and Vercel – portfolio-staging.