### PR TITLE
feat: propagate agent avatars across ops

### DIFF
--- a/app/admin/agents/coordination/page.test.tsx
+++ b/app/admin/agents/coordination/page.test.tsx
@@ -281,6 +281,8 @@ describe('AgentCoordinationPage decision queue controller', () => {
     expect(screen.getAllByText('Controller recommendation').length).toBeGreaterThan(0)
     expect(screen.getByText('Approve validation after checking the trace and PR evidence.')).toBeInTheDocument()
     expect(screen.getByText('risk: medium')).toBeInTheDocument()
+    expect(screen.getAllByRole('img', { name: /Illustrated avatar for Shaka/i }).length).toBeGreaterThan(0)
+    expect(screen.getByRole('img', { name: /Illustrated avatar for Moremi/i })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: 'Prioritize ideas before they enter the Kanban board.' })).toBeInTheDocument()
     expect(screen.getAllByText('Build-profile attribution').length).toBeGreaterThan(0)
     expect(screen.getAllByText('Start here because it produces the baseline every later idea needs.').length).toBeGreaterThan(0)

--- a/app/admin/agents/coordination/page.tsx
+++ b/app/admin/agents/coordination/page.tsx
@@ -17,6 +17,7 @@ import {
   XCircle,
 } from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
+import AgentAvatar from '@/components/admin/AgentAvatar'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
 import { getCurrentSession } from '@/lib/auth'
 import type { AgentRuntime } from '@/lib/agent-run'
@@ -959,11 +960,14 @@ function WorkItemCard({
     : item.approval_id
       ? 'approval linked'
       : item.priority
+  const ownerAgentKey = item.owner_agent_key || null
 
   return (
     <article className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-        <div className="min-w-0">
+        <div className="flex min-w-0 gap-3">
+          {ownerAgentKey ? <AgentAvatar agentKey={ownerAgentKey} size="md" /> : null}
+          <div className="min-w-0">
           <div className="mb-2 flex flex-wrap items-center gap-2">
             <StatusBadge status={item.status} />
             <span className="rounded-full border border-silicon-slate/70 px-2 py-1 text-xs text-muted-foreground">
@@ -999,6 +1003,7 @@ function WorkItemCard({
               {item.validation_summary ? <Callout icon="check" label="Validation" value={item.validation_summary} /> : null}
             </div>
           ) : null}
+          </div>
         </div>
         <div className="flex flex-wrap gap-2 lg:min-w-64 lg:justify-end">
           {item.pr_url ? (

--- a/app/admin/agents/page.test.tsx
+++ b/app/admin/agents/page.test.tsx
@@ -228,6 +228,7 @@ describe('AgentOperationsPage mission control landing', () => {
     expect(screen.getByRole('heading', { name: 'What should I pay attention to before approving this queue?' })).toBeInTheDocument()
     expect(screen.getByRole('textbox', { name: 'Ask Shaka' })).toBeInTheDocument()
     expect(screen.getByLabelText('Ask Shaka quick prompts')).toBeInTheDocument()
+    expect(screen.getAllByRole('img', { name: /Illustrated avatar for Shaka/i }).length).toBeGreaterThan(0)
     expect(screen.queryByText('Active work')).not.toBeInTheDocument()
     expect(screen.getByText('Agent interaction')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /Expand chat/i })).toHaveAttribute('href', '/admin/agents/chief-of-staff')

--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -27,6 +27,7 @@ import {
   Users,
 } from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
+import AgentAvatar from '@/components/admin/AgentAvatar'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
 import { getCurrentSession } from '@/lib/auth'
 
@@ -1889,7 +1890,9 @@ function AgentEngagementRecommendations({
       {recommendations.slice(0, 4).map((agent) => (
         <div key={`${agent.agentKey}-${agent.label}`} className="rounded-lg border border-radiant-gold/20 bg-radiant-gold/5 p-3">
           <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-            <div className="min-w-0">
+            <div className="flex min-w-0 gap-3">
+              <AgentAvatar agentKey={agent.agentKey} size="sm" />
+              <div className="min-w-0">
               <div className="flex flex-wrap items-center gap-2">
                 <p className="font-medium">{agent.agentName}</p>
                 <span className="rounded-full border border-silicon-slate/50 bg-black/10 px-2 py-0.5 text-xs text-muted-foreground">
@@ -1900,6 +1903,7 @@ function AgentEngagementRecommendations({
                 </span>
               </div>
               <p className="mt-1 text-sm text-muted-foreground">{agent.rationale}</p>
+              </div>
             </div>
             <button
               type="button"
@@ -1991,6 +1995,7 @@ function EngagementQueuePanel({ items }: { items: MissionSnapshot['engagement_qu
             className="rounded-lg border border-silicon-slate/50 bg-black/10 p-3 text-sm hover:border-radiant-gold/50"
           >
             <div className="flex flex-wrap items-center gap-2">
+              <AgentAvatar agentKey={item.agent_key} size="sm" />
               <span className="font-medium">{item.agent_name}</span>
               <span className="rounded-full border border-silicon-slate/50 bg-black/10 px-2 py-0.5 text-xs text-muted-foreground">
                 {item.status.replace(/_/g, ' ')}
@@ -2188,7 +2193,9 @@ function InboxRow({
   return (
     <div className="rounded-lg border border-silicon-slate/50 bg-black/10 p-3 text-sm">
       <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
+        <div className="flex min-w-0 gap-3">
+          <AgentAvatar agentKey={item.agent_key} size="sm" />
+          <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
             <PriorityPill priority={item.priority} />
             <span className="text-xs text-muted-foreground">{item.agent_name}</span>
@@ -2196,6 +2203,7 @@ function InboxRow({
           <p className="mt-2 font-medium">{item.title}</p>
           <p className="mt-1 line-clamp-2 text-muted-foreground">{item.reason}</p>
           <p className="mt-2 text-xs text-muted-foreground">{item.pod}</p>
+          </div>
         </div>
         <div className="flex shrink-0 flex-col items-end gap-2">
           <button

--- a/app/admin/agents/runs/[runId]/page.test.tsx
+++ b/app/admin/agents/runs/[runId]/page.test.tsx
@@ -20,6 +20,7 @@ const runDetail = {
     id: 'run-1',
     title: 'Approval notification trace',
     kind: 'chief_of_staff_chat',
+    agent_key: 'chief-of-staff',
     runtime: 'codex',
     status: 'waiting_for_approval',
   },
@@ -138,6 +139,7 @@ describe('AgentRunDetailPage scoped Shaka context', () => {
     render(<AgentRunDetailPage params={{ runId: 'run-1' }} />)
 
     expect(await screen.findByRole('heading', { name: 'Approval notification trace' })).toBeInTheDocument()
+    expect(screen.getAllByRole('img', { name: /Illustrated avatar for Shaka/i }).length).toBeGreaterThan(0)
     fireEvent.click(screen.getByRole('button', { name: 'Ask Shaka about this run' }))
 
     expect(await screen.findByText('Shaka context answer')).toBeInTheDocument()

--- a/app/admin/agents/runs/[runId]/page.tsx
+++ b/app/admin/agents/runs/[runId]/page.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from 'react'
 import Link from 'next/link'
 import { AlertTriangle, ArrowLeft, Bot, CheckCircle2, DollarSign, FileText, Gauge, MessageSquare, RefreshCw, XCircle } from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
+import AgentAvatar from '@/components/admin/AgentAvatar'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
 import { getCurrentSession } from '@/lib/auth'
 
@@ -190,9 +191,15 @@ function AgentRunDetailContent({ runId }: { runId: string }) {
         ) : data ? (
           <>
             <div className="mb-6 flex items-start justify-between gap-4 flex-wrap">
-              <div>
+              <div className="flex min-w-0 gap-3">
+                {asString(data.run.agent_key) ? <AgentAvatar agentKey={asString(data.run.agent_key)} size="lg" /> : null}
+                <div className="min-w-0">
                 <h1 className="text-3xl font-bold mb-1">{String(data.run.title ?? 'Agent run')}</h1>
                 <p className="text-sm text-muted-foreground">{String(data.run.kind ?? 'run')} · {String(data.run.id)}</p>
+                {asString(data.run.agent_key) ? (
+                  <p className="mt-1 text-xs text-muted-foreground">Owner: {String(data.run.agent_key).replace(/-/g, ' ')}</p>
+                ) : null}
+                </div>
               </div>
               <div className="flex flex-wrap items-center gap-2">
                 <select
@@ -407,7 +414,8 @@ function EvaluationList({
                 {Number.isFinite(score) ? score.toFixed(1) : '-'} {passed ? 'pass' : 'review'}
               </span>
             </div>
-            <div className="mt-3 flex flex-wrap gap-2 text-xs text-muted-foreground">
+            <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+              <AgentAvatar agentKey={asString(row.agent_key)} size="sm" />
               <span>{String(row.agent_key ?? '-').replace(/-/g, ' ')}</span>
               <span>{String(row.judge_model ?? '-')}</span>
               <span>{formatDate(asString(row.created_at))}</span>


### PR DESCRIPTION
Summary
- Reuses the existing AgentAvatar manifest/component across Mission Control, Decision Queue, and Run Detail ownership surfaces.
- Adds avatars to agent engagement recommendations, Agent Inbox rows, engagement queue rows, decision work-item owner cards, run headers, and evaluation ownership rows.
- Extends focused UI tests to assert accessible avatar labels on the newly covered surfaces.

Validation
- npm test -- app/admin/agents/page.test.tsx app/admin/agents/coordination/page.test.tsx app/admin/agents/runs/[runId]/page.test.tsx
- npx tsc --noEmit --pretty false
- npm run lint
- rm -rf .next && npm run build
- git diff --check

Integration Notes
- UI-only change; no schema, API, environment, or generated asset changes.
- Uses the already-landed static avatar manifest rather than generating new image assets in this phase.
- Vercel contexts to verify after merge: Vercel – portfolio and Vercel – portfolio-staging.