### PR TITLE
feat: add generated agent avatar assets

### DIFF
--- a/components/admin/AgentAvatar.tsx
+++ b/components/admin/AgentAvatar.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image'
 import { getAgentAvatar, getAvatarToneStyles } from '@/lib/agent-avatars'
 
 export default function AgentAvatar({
@@ -26,10 +27,19 @@ export default function AgentAvatar({
         color: tone.mark,
       }}
     >
+      <Image
+        src={avatar.imagePath}
+        alt=""
+        aria-hidden="true"
+        fill
+        sizes="56px"
+        unoptimized
+        className="absolute inset-0 h-full w-full object-cover"
+      />
       <svg
         aria-hidden="true"
         viewBox="0 0 64 64"
-        className="absolute inset-0 h-full w-full"
+        className="absolute inset-0 h-full w-full opacity-0"
       >
         <circle cx="32" cy="27" r="13" fill="#0b1726" opacity="0.92" />
         <path d="M17 58c2.8-11.2 8.1-16.8 15-16.8S44.2 46.8 47 58" fill="#101f33" opacity="0.96" />

--- a/lib/agent-avatars.test.ts
+++ b/lib/agent-avatars.test.ts
@@ -1,3 +1,5 @@
+import { existsSync } from 'node:fs'
+import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { AGENT_ORGANIZATION } from '@/lib/agent-organization'
 import { AGENT_AVATARS, getMissingAgentAvatarKeys } from '@/lib/agent-avatars'
@@ -11,6 +13,16 @@ describe('agent avatar manifest', () => {
     for (const agent of AGENT_ORGANIZATION) {
       expect(AGENT_AVATARS[agent.key]?.label).toContain('Illustrated avatar')
       expect(AGENT_AVATARS[agent.key]?.initials.length).toBeGreaterThan(1)
+      expect(AGENT_AVATARS[agent.key]?.imagePath).toBe(`/agent-avatars/${agent.key}.svg`)
     }
+  })
+
+  it('has generated static portrait assets for every organization avatar', () => {
+    for (const agent of AGENT_ORGANIZATION) {
+      const assetPath = AGENT_AVATARS[agent.key]?.imagePath
+      expect(assetPath).toBeTruthy()
+      expect(existsSync(path.join(process.cwd(), 'public', assetPath))).toBe(true)
+    }
+    expect(existsSync(path.join(process.cwd(), 'public', 'agent-avatars', 'unknown.svg'))).toBe(true)
   })
 })

--- a/lib/agent-avatars.ts
+++ b/lib/agent-avatars.ts
@@ -9,6 +9,7 @@ export interface AgentAvatarDefinition {
   motif: string
   tone: AgentAvatarTone
   culturalCue: string
+  imagePath: string
 }
 
 const AVATAR_TONES: Record<AgentAvatarTone, { ring: string; wash: string; mark: string }> = {
@@ -20,7 +21,7 @@ const AVATAR_TONES: Record<AgentAvatarTone, { ring: string; wash: string; mark: 
   amber: { ring: '#f59e0b', wash: '#3a260a', mark: '#fde68a' },
 }
 
-export const AGENT_AVATARS: Record<string, AgentAvatarDefinition> = {
+const AGENT_AVATAR_SEEDS: Record<string, Omit<AgentAvatarDefinition, 'imagePath'>> = {
   'chief-of-staff': {
     agentKey: 'chief-of-staff',
     label: 'Illustrated avatar for Shaka, Chief of Staff',
@@ -183,6 +184,16 @@ export const AGENT_AVATARS: Record<string, AgentAvatarDefinition> = {
   },
 }
 
+export const AGENT_AVATARS: Record<string, AgentAvatarDefinition> = Object.fromEntries(
+  Object.entries(AGENT_AVATAR_SEEDS).map(([key, avatar]) => [
+    key,
+    {
+      ...avatar,
+      imagePath: `/agent-avatars/${key}.svg`,
+    },
+  ]),
+) as Record<string, AgentAvatarDefinition>
+
 export function getAgentAvatar(agentKey: string | null | undefined): AgentAvatarDefinition {
   if (agentKey && AGENT_AVATARS[agentKey]) return AGENT_AVATARS[agentKey]
   return {
@@ -192,6 +203,7 @@ export function getAgentAvatar(agentKey: string | null | undefined): AgentAvatar
     motif: 'node',
     tone: 'cyan',
     culturalCue: 'Unassigned work cue',
+    imagePath: '/agent-avatars/unknown.svg',
   }
 }
 

--- a/public/agent-avatars/agent-tooling-parity.svg
+++ b/public/agent-avatars/agent-tooling-parity.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Illustrated avatar for Ezana, Agent Tooling Parity</title>
+  <desc id="desc">Stylized animated-style portrait mark with Aksum tooling cue; historically inspired without claiming exact photographic likeness.</desc>
+  <defs>
+    <radialGradient id="halo" cx="32%" cy="18%" r="75%">
+      <stop offset="0%" stop-color="#9ce3ff" stop-opacity="0.55"/>
+      <stop offset="48%" stop-color="#4db7e8" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#07111f" stop-opacity="1"/>
+    </radialGradient>
+    <linearGradient id="body" x1="18" y1="16" x2="142" y2="152" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#102c3b"/>
+      <stop offset="62%" stop-color="#0d1b2d"/>
+      <stop offset="100%" stop-color="#050b14"/>
+    </linearGradient>
+    <filter id="softGlow" x="-25%" y="-25%" width="150%" height="150%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="1 0 0 0 0 0 0.82 0 0 0 0 0 0.38 0 0 0 0 0 0.45 0"/>
+      <feMerge>
+        <feMergeNode/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="url(#body)"/>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="url(#halo)" opacity="0.88"/>
+  <path d="M28 139c7-32 24-50 52-50s45 18 52 50" fill="#14243a" opacity="0.98"/>
+  <path d="M45 139c6-20 18-31 35-31s29 11 35 31" fill="#102c3b" opacity="0.65"/>
+  <ellipse cx="80" cy="70" rx="34" ry="38" fill="#111d2f"/>
+  <path d="M39 54c7-19 20-30 41-30s34 11 41 30c-12-6-26-9-41-9s-29 3-41 9Z" fill="#4db7e8" opacity="0.72"/>
+  <path d="M43 59c13-11 25-17 37-17s24 6 37 17" fill="none" stroke="#9ce3ff" stroke-width="5" stroke-linecap="round" opacity="0.65"/>
+  <circle cx="64" cy="71" r="3.7" fill="#9ce3ff" opacity="0.88"/>
+  <circle cx="96" cy="71" r="3.7" fill="#9ce3ff" opacity="0.88"/>
+  <path d="M36 89c14 8 28 8 42 0" fill="none" stroke="#9ce3ff" stroke-width="4" stroke-linecap="round" opacity="0.65"/>
+  <path d="M65 83c10 8 20 8 30 0" fill="none" stroke="#9ce3ff" stroke-width="4" stroke-linecap="round" opacity="0.58"/>
+  <path d="M39 112c14 11 28 17 41 17s27-6 41-17" fill="none" stroke="#4db7e8" stroke-width="3" opacity="0.38"/>
+  <circle cx="122" cy="37" r="21" fill="#07111f" stroke="#4db7e8" stroke-width="3" filter="url(#softGlow)"/>
+  <text x="122" y="44" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="21" font-weight="800" fill="#9ce3ff">L</text>
+  <rect x="18" y="120" width="45" height="24" rx="12" fill="#020817" opacity="0.72"/>
+  <text x="40.5" y="137" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="800" letter-spacing="1" fill="#9ce3ff">EA</text>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="none" stroke="#4db7e8" stroke-opacity="0.64" stroke-width="2"/>
+</svg>

--- a/public/agent-avatars/amadutown-brand.svg
+++ b/public/agent-avatars/amadutown-brand.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Illustrated avatar for Taharqa, AmaduTown Brand</title>
+  <desc id="desc">Stylized animated-style portrait mark with Kush brand cue; historically inspired without claiming exact photographic likeness.</desc>
+  <defs>
+    <radialGradient id="halo" cx="32%" cy="18%" r="75%">
+      <stop offset="0%" stop-color="#f6d34c" stop-opacity="0.55"/>
+      <stop offset="48%" stop-color="#d8b42c" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#07111f" stop-opacity="1"/>
+    </radialGradient>
+    <linearGradient id="body" x1="18" y1="16" x2="142" y2="152" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#332a12"/>
+      <stop offset="62%" stop-color="#0d1b2d"/>
+      <stop offset="100%" stop-color="#050b14"/>
+    </linearGradient>
+    <filter id="softGlow" x="-25%" y="-25%" width="150%" height="150%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="1 0 0 0 0 0 0.82 0 0 0 0 0 0.38 0 0 0 0 0 0.45 0"/>
+      <feMerge>
+        <feMergeNode/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="url(#body)"/>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="url(#halo)" opacity="0.88"/>
+  <path d="M28 139c7-32 24-50 52-50s45 18 52 50" fill="#14243a" opacity="0.98"/>
+  <path d="M45 139c6-20 18-31 35-31s29 11 35 31" fill="#332a12" opacity="0.65"/>
+  <ellipse cx="80" cy="70" rx="34" ry="38" fill="#111d2f"/>
+  <path d="M42 51c5-17 19-27 38-27s33 10 38 27c-8-4-20-8-38-8s-30 4-38 8Z" fill="#d8b42c" opacity="0.72"/>
+  <path d="M43 59c13-11 25-17 37-17s24 6 37 17" fill="none" stroke="#f6d34c" stroke-width="5" stroke-linecap="round" opacity="0.65"/>
+  <circle cx="64" cy="71" r="3.7" fill="#f6d34c" opacity="0.88"/>
+  <circle cx="96" cy="71" r="3.7" fill="#f6d34c" opacity="0.88"/>
+  <path d="M36 89c14 8 28 8 42 0" fill="none" stroke="#f6d34c" stroke-width="4" stroke-linecap="round" opacity="0.65"/>
+  <path d="M65 83c10 8 20 8 30 0" fill="none" stroke="#f6d34c" stroke-width="4" stroke-linecap="round" opacity="0.58"/>
+  <path d="M39 112c14 11 28 17 41 17s27-6 41-17" fill="none" stroke="#d8b42c" stroke-width="3" opacity="0.38"/>
+  <circle cx="122" cy="37" r="21" fill="#07111f" stroke="#d8b42c" stroke-width="3" filter="url(#softGlow)"/>
+  <text x="122" y="44" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="21" font-weight="800" fill="#f6d34c">S</text>
+  <rect x="18" y="120" width="45" height="24" rx="12" fill="#020817" opacity="0.72"/>
+  <text x="40.5" y="137" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="800" letter-spacing="1" fill="#f6d34c">TK</text>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="none" stroke="#d8b42c" stroke-opacity="0.64" stroke-width="2"/>
+</svg>

--- a/public/agent-avatars/automation-systems.svg
+++ b/public/agent-avatars/automation-systems.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Illustrated avatar for Yaa Asantewaa, Automation Systems</title>
+  <desc id="desc">Stylized animated-style portrait mark with Ashanti operations cue; historically inspired without claiming exact photographic likeness.</desc>
+  <defs>
+    <radialGradient id="halo" cx="32%" cy="18%" r="75%">
+      <stop offset="0%" stop-color="#f6d34c" stop-opacity="0.55"/>
+      <stop offset="48%" stop-color="#d8b42c" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#07111f" stop-opacity="1"/>
+    </radialGradient>
+    <linearGradient id="body" x1="18" y1="16" x2="142" y2="152" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#332a12"/>
+      <stop offset="62%" stop-color="#0d1b2d"/>
+      <stop offset="100%" stop-color="#050b14"/>
+    </linearGradient>
+    <filter id="softGlow" x="-25%" y="-25%" width="150%" height="150%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="1 0 0 0 0 0 0.82 0 0 0 0 0 0.38 0 0 0 0 0 0.45 0"/>
+      <feMerge>
+        <feMergeNode/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="url(#body)"/>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="url(#halo)" opacity="0.88"/>
+  <path d="M28 139c7-32 24-50 52-50s45 18 52 50" fill="#14243a" opacity="0.98"/>
+  <path d="M45 139c6-20 18-31 35-31s29 11 35 31" fill="#332a12" opacity="0.65"/>
+  <ellipse cx="80" cy="70" rx="34" ry="38" fill="#111d2f"/>
+  <path d="M39 54c7-19 20-30 41-30s34 11 41 30c-12-6-26-9-41-9s-29 3-41 9Z" fill="#d8b42c" opacity="0.72"/>
+  <path d="M43 59c13-11 25-17 37-17s24 6 37 17" fill="none" stroke="#f6d34c" stroke-width="5" stroke-linecap="round" opacity="0.65"/>
+  <circle cx="64" cy="71" r="3.7" fill="#f6d34c" opacity="0.88"/>
+  <circle cx="96" cy="71" r="3.7" fill="#f6d34c" opacity="0.88"/>
+  <path d="M36 89c14 8 28 8 42 0" fill="none" stroke="#f6d34c" stroke-width="4" stroke-linecap="round" opacity="0.65"/>
+  <path d="M65 83c10 8 20 8 30 0" fill="none" stroke="#f6d34c" stroke-width="4" stroke-linecap="round" opacity="0.58"/>
+  <path d="M39 112c14 11 28 17 41 17s27-6 41-17" fill="none" stroke="#d8b42c" stroke-width="3" opacity="0.38"/>
+  <circle cx="122" cy="37" r="21" fill="#07111f" stroke="#d8b42c" stroke-width="3" filter="url(#softGlow)"/>
+  <text x="122" y="44" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="21" font-weight="800" fill="#f6d34c">B</text>
+  <rect x="18" y="120" width="45" height="24" rx="12" fill="#020817" opacity="0.72"/>
+  <text x="40.5" y="137" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="800" letter-spacing="1" fill="#f6d34c">YA</text>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="none" stroke="#d8b42c" stroke-opacity="0.64" stroke-width="2"/>
+</svg>

--- a/public/agent-avatars/chief-of-staff.svg
+++ b/public/agent-avatars/chief-of-staff.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Illustrated avatar for Shaka, Chief of Staff</title>
+  <desc id="desc">Stylized animated-style portrait mark with Zulu command silhouette; historically inspired without claiming exact photographic likeness.</desc>
+  <defs>
+    <radialGradient id="halo" cx="32%" cy="18%" r="75%">
+      <stop offset="0%" stop-color="#f6d34c" stop-opacity="0.55"/>
+      <stop offset="48%" stop-color="#d8b42c" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#07111f" stop-opacity="1"/>
+    </radialGradient>
+    <linearGradient id="body" x1="18" y1="16" x2="142" y2="152" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#332a12"/>
+      <stop offset="62%" stop-color="#0d1b2d"/>
+      <stop offset="100%" stop-color="#050b14"/>
+    </linearGradient>
+    <filter id="softGlow" x="-25%" y="-25%" width="150%" height="150%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="1 0 0 0 0 0 0.82 0 0 0 0 0 0.38 0 0 0 0 0 0.45 0"/>
+      <feMerge>
+        <feMergeNode/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="url(#body)"/>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="url(#halo)" opacity="0.88"/>
+  <path d="M28 139c7-32 24-50 52-50s45 18 52 50" fill="#14243a" opacity="0.98"/>
+  <path d="M45 139c6-20 18-31 35-31s29 11 35 31" fill="#332a12" opacity="0.65"/>
+  <ellipse cx="80" cy="70" rx="34" ry="38" fill="#111d2f"/>
+  <path d="M35 57c9-22 23-34 45-34s36 12 45 34c-15-8-30-12-45-12s-30 4-45 12Z" fill="#d8b42c" opacity="0.72"/>
+  <path d="M43 59c13-11 25-17 37-17s24 6 37 17" fill="none" stroke="#f6d34c" stroke-width="5" stroke-linecap="round" opacity="0.65"/>
+  <circle cx="64" cy="71" r="3.7" fill="#f6d34c" opacity="0.88"/>
+  <circle cx="96" cy="71" r="3.7" fill="#f6d34c" opacity="0.88"/>
+  <path d="M36 89c14 8 28 8 42 0" fill="none" stroke="#f6d34c" stroke-width="4" stroke-linecap="round" opacity="0.65"/>
+  <path d="M65 83c10 8 20 8 30 0" fill="none" stroke="#f6d34c" stroke-width="4" stroke-linecap="round" opacity="0.58"/>
+  <path d="M39 112c14 11 28 17 41 17s27-6 41-17" fill="none" stroke="#d8b42c" stroke-width="3" opacity="0.38"/>
+  <circle cx="122" cy="37" r="21" fill="#07111f" stroke="#d8b42c" stroke-width="3" filter="url(#softGlow)"/>
+  <text x="122" y="44" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="21" font-weight="800" fill="#f6d34c">S</text>
+  <rect x="18" y="120" width="45" height="24" rx="12" fill="#020817" opacity="0.72"/>
+  <text x="40.5" y="137" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="800" letter-spacing="1" fill="#f6d34c">SZ</text>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="none" stroke="#d8b42c" stroke-opacity="0.64" stroke-width="2"/>
+</svg>

--- a/public/agent-avatars/content-repurposing.svg
+++ b/public/agent-avatars/content-repurposing.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Illustrated avatar for Hannibal, Content Repurposing</title>
+  <desc id="desc">Stylized animated-style portrait mark with Carthage campaign cue; historically inspired without claiming exact photographic likeness.</desc>
+  <defs>
+    <radialGradient id="halo" cx="32%" cy="18%" r="75%">
+      <stop offset="0%" stop-color="#fde68a" stop-opacity="0.55"/>
+      <stop offset="48%" stop-color="#f59e0b" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#07111f" stop-opacity="1"/>
+    </radialGradient>
+    <linearGradient id="body" x1="18" y1="16" x2="142" y2="152" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#3a260a"/>
+      <stop offset="62%" stop-color="#0d1b2d"/>
+      <stop offset="100%" stop-color="#050b14"/>
+    </linearGradient>
+    <filter id="softGlow" x="-25%" y="-25%" width="150%" height="150%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="1 0 0 0 0 0 0.82 0 0 0 0 0 0.38 0 0 0 0 0 0.45 0"/>
+      <feMerge>
+        <feMergeNode/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="url(#body)"/>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="url(#halo)" opacity="0.88"/>
+  <path d="M28 139c7-32 24-50 52-50s45 18 52 50" fill="#14243a" opacity="0.98"/>
+  <path d="M45 139c6-20 18-31 35-31s29 11 35 31" fill="#3a260a" opacity="0.65"/>
+  <ellipse cx="80" cy="70" rx="34" ry="38" fill="#111d2f"/>
+  <path d="M39 54c7-19 20-30 41-30s34 11 41 30c-12-6-26-9-41-9s-29 3-41 9Z" fill="#f59e0b" opacity="0.72"/>
+  <path d="M43 59c13-11 25-17 37-17s24 6 37 17" fill="none" stroke="#fde68a" stroke-width="5" stroke-linecap="round" opacity="0.65"/>
+  <circle cx="64" cy="71" r="3.7" fill="#fde68a" opacity="0.88"/>
+  <circle cx="96" cy="71" r="3.7" fill="#fde68a" opacity="0.88"/>
+  <path d="M36 89c14 8 28 8 42 0" fill="none" stroke="#fde68a" stroke-width="4" stroke-linecap="round" opacity="0.65"/>
+  <path d="M65 83c10 8 20 8 30 0" fill="none" stroke="#fde68a" stroke-width="4" stroke-linecap="round" opacity="0.58"/>
+  <path d="M39 112c14 11 28 17 41 17s27-6 41-17" fill="none" stroke="#f59e0b" stroke-width="3" opacity="0.38"/>
+  <circle cx="122" cy="37" r="21" fill="#07111f" stroke="#f59e0b" stroke-width="3" filter="url(#softGlow)"/>
+  <text x="122" y="44" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="21" font-weight="800" fill="#fde68a">R</text>
+  <rect x="18" y="120" width="45" height="24" rx="12" fill="#020817" opacity="0.72"/>
+  <text x="40.5" y="137" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="800" letter-spacing="1" fill="#fde68a">HC</text>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="none" stroke="#f59e0b" stroke-opacity="0.64" stroke-width="2"/>
+</svg>

--- a/public/agent-avatars/course-curriculum-builder.svg
+++ b/public/agent-avatars/course-curriculum-builder.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Illustrated avatar for Menelik, Course and Curriculum Builder</title>
+  <desc id="desc">Stylized animated-style portrait mark with Ethiopia curriculum cue; historically inspired without claiming exact photographic likeness.</desc>
+  <defs>
+    <radialGradient id="halo" cx="32%" cy="18%" r="75%">
+      <stop offset="0%" stop-color="#82f0bd" stop-opacity="0.55"/>
+      <stop offset="48%" stop-color="#40c58a" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#07111f" stop-opacity="1"/>
+    </radialGradient>
+    <linearGradient id="body" x1="18" y1="16" x2="142" y2="152" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#123326"/>
+      <stop offset="62%" stop-color="#0d1b2d"/>
+      <stop offset="100%" stop-color="#050b14"/>
+    </linearGradient>
+    <filter id="softGlow" x="-25%" y="-25%" width="150%" height="150%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="1 0 0 0 0 0 0.82 0 0 0 0 0 0.38 0 0 0 0 0 0.45 0"/>
+      <feMerge>
+        <feMergeNode/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="url(#body)"/>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="url(#halo)" opacity="0.88"/>
+  <path d="M28 139c7-32 24-50 52-50s45 18 52 50" fill="#14243a" opacity="0.98"/>
+  <path d="M45 139c6-20 18-31 35-31s29 11 35 31" fill="#123326" opacity="0.65"/>
+  <ellipse cx="80" cy="70" rx="34" ry="38" fill="#111d2f"/>
+  <path d="M39 54c7-19 20-30 41-30s34 11 41 30c-12-6-26-9-41-9s-29 3-41 9Z" fill="#40c58a" opacity="0.72"/>
+  <path d="M43 59c13-11 25-17 37-17s24 6 37 17" fill="none" stroke="#82f0bd" stroke-width="5" stroke-linecap="round" opacity="0.65"/>
+  <circle cx="64" cy="71" r="3.7" fill="#82f0bd" opacity="0.88"/>
+  <circle cx="96" cy="71" r="3.7" fill="#82f0bd" opacity="0.88"/>
+  <path d="M37 91c13 5 26 5 39-2" fill="none" stroke="#82f0bd" stroke-width="4" stroke-linecap="round" opacity="0.65"/>
+  <path d="M65 83c10 8 20 8 30 0" fill="none" stroke="#82f0bd" stroke-width="4" stroke-linecap="round" opacity="0.58"/>
+  <path d="M39 112c14 11 28 17 41 17s27-6 41-17" fill="none" stroke="#40c58a" stroke-width="3" opacity="0.38"/>
+  <circle cx="122" cy="37" r="21" fill="#07111f" stroke="#40c58a" stroke-width="3" filter="url(#softGlow)"/>
+  <text x="122" y="44" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="21" font-weight="800" fill="#82f0bd">B</text>
+  <rect x="18" y="120" width="45" height="24" rx="12" fill="#020817" opacity="0.72"/>
+  <text x="40.5" y="137" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="800" letter-spacing="1" fill="#82f0bd">ME</text>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="none" stroke="#40c58a" stroke-opacity="0.64" stroke-width="2"/>
+</svg>

--- a/public/agent-avatars/decision-journal.svg
+++ b/public/agent-avatars/decision-journal.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Illustrated avatar for Nzinga, Decision Journal</title>
+  <desc id="desc">Stylized animated-style portrait mark with Ndongo and Matamba diplomacy cue; historically inspired without claiming exact photographic likeness.</desc>
+  <defs>
+    <radialGradient id="halo" cx="32%" cy="18%" r="75%">
+      <stop offset="0%" stop-color="#f6d34c" stop-opacity="0.55"/>
+      <stop offset="48%" stop-color="#d8b42c" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#07111f" stop-opacity="1"/>
+    </radialGradient>
+    <linearGradient id="body" x1="18" y1="16" x2="142" y2="152" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#332a12"/>
+      <stop offset="62%" stop-color="#0d1b2d"/>
+      <stop offset="100%" stop-color="#050b14"/>
+    </linearGradient>
+    <filter id="softGlow" x="-25%" y="-25%" width="150%" height="150%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="1 0 0 0 0 0 0.82 0 0 0 0 0 0.38 0 0 0 0 0 0.45 0"/>
+      <feMerge>
+        <feMergeNode/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="url(#body)"/>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="url(#halo)" opacity="0.88"/>
+  <path d="M28 139c7-32 24-50 52-50s45 18 52 50" fill="#14243a" opacity="0.98"/>
+  <path d="M45 139c6-20 18-31 35-31s29 11 35 31" fill="#332a12" opacity="0.65"/>
+  <ellipse cx="80" cy="70" rx="34" ry="38" fill="#111d2f"/>
+  <path d="M42 51c5-17 19-27 38-27s33 10 38 27c-8-4-20-8-38-8s-30 4-38 8Z" fill="#d8b42c" opacity="0.72"/>
+  <path d="M43 59c13-11 25-17 37-17s24 6 37 17" fill="none" stroke="#f6d34c" stroke-width="5" stroke-linecap="round" opacity="0.65"/>
+  <circle cx="64" cy="71" r="3.7" fill="#f6d34c" opacity="0.88"/>
+  <circle cx="96" cy="71" r="3.7" fill="#f6d34c" opacity="0.88"/>
+  <path d="M36 89c14 8 28 8 42 0" fill="none" stroke="#f6d34c" stroke-width="4" stroke-linecap="round" opacity="0.65"/>
+  <path d="M65 83c10 8 20 8 30 0" fill="none" stroke="#f6d34c" stroke-width="4" stroke-linecap="round" opacity="0.58"/>
+  <path d="M39 112c14 11 28 17 41 17s27-6 41-17" fill="none" stroke="#d8b42c" stroke-width="3" opacity="0.38"/>
+  <circle cx="122" cy="37" r="21" fill="#07111f" stroke="#d8b42c" stroke-width="3" filter="url(#softGlow)"/>
+  <text x="122" y="44" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="21" font-weight="800" fill="#f6d34c">C</text>
+  <rect x="18" y="120" width="45" height="24" rx="12" fill="#020817" opacity="0.72"/>
+  <text x="40.5" y="137" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="800" letter-spacing="1" fill="#f6d34c">NM</text>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="none" stroke="#d8b42c" stroke-opacity="0.64" stroke-width="2"/>
+</svg>

--- a/public/agent-avatars/engineering-copilot.svg
+++ b/public/agent-avatars/engineering-copilot.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Illustrated avatar for Piye, Engineering Copilot</title>
+  <desc id="desc">Stylized animated-style portrait mark with Kush engineering cue; historically inspired without claiming exact photographic likeness.</desc>
+  <defs>
+    <radialGradient id="halo" cx="32%" cy="18%" r="75%">
+      <stop offset="0%" stop-color="#9ce3ff" stop-opacity="0.55"/>
+      <stop offset="48%" stop-color="#4db7e8" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#07111f" stop-opacity="1"/>
+    </radialGradient>
+    <linearGradient id="body" x1="18" y1="16" x2="142" y2="152" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#102c3b"/>
+      <stop offset="62%" stop-color="#0d1b2d"/>
+      <stop offset="100%" stop-color="#050b14"/>
+    </linearGradient>
+    <filter id="softGlow" x="-25%" y="-25%" width="150%" height="150%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="1 0 0 0 0 0 0.82 0 0 0 0 0 0.38 0 0 0 0 0 0.45 0"/>
+      <feMerge>
+        <feMergeNode/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="url(#body)"/>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="url(#halo)" opacity="0.88"/>
+  <path d="M28 139c7-32 24-50 52-50s45 18 52 50" fill="#14243a" opacity="0.98"/>
+  <path d="M45 139c6-20 18-31 35-31s29 11 35 31" fill="#102c3b" opacity="0.65"/>
+  <ellipse cx="80" cy="70" rx="34" ry="38" fill="#111d2f"/>
+  <path d="M35 57c9-22 23-34 45-34s36 12 45 34c-15-8-30-12-45-12s-30 4-45 12Z" fill="#4db7e8" opacity="0.72"/>
+  <path d="M43 59c13-11 25-17 37-17s24 6 37 17" fill="none" stroke="#9ce3ff" stroke-width="5" stroke-linecap="round" opacity="0.65"/>
+  <circle cx="64" cy="71" r="3.7" fill="#9ce3ff" opacity="0.88"/>
+  <circle cx="96" cy="71" r="3.7" fill="#9ce3ff" opacity="0.88"/>
+  <path d="M36 89c14 8 28 8 42 0" fill="none" stroke="#9ce3ff" stroke-width="4" stroke-linecap="round" opacity="0.65"/>
+  <path d="M65 83c10 8 20 8 30 0" fill="none" stroke="#9ce3ff" stroke-width="4" stroke-linecap="round" opacity="0.58"/>
+  <path d="M39 112c14 11 28 17 41 17s27-6 41-17" fill="none" stroke="#4db7e8" stroke-width="3" opacity="0.38"/>
+  <circle cx="122" cy="37" r="21" fill="#07111f" stroke="#4db7e8" stroke-width="3" filter="url(#softGlow)"/>
+  <text x="122" y="44" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="21" font-weight="800" fill="#9ce3ff">F</text>
+  <rect x="18" y="120" width="45" height="24" rx="12" fill="#020817" opacity="0.72"/>
+  <text x="40.5" y="137" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="800" letter-spacing="1" fill="#9ce3ff">PK</text>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="none" stroke="#4db7e8" stroke-opacity="0.64" stroke-width="2"/>
+</svg>

--- a/public/agent-avatars/inbox-follow-up.svg
+++ b/public/agent-avatars/inbox-follow-up.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Illustrated avatar for Samori Toure, Inbox and Follow-Up</title>
+  <desc id="desc">Stylized animated-style portrait mark with Wassoulou follow-up cue; historically inspired without claiming exact photographic likeness.</desc>
+  <defs>
+    <radialGradient id="halo" cx="32%" cy="18%" r="75%">
+      <stop offset="0%" stop-color="#82f0bd" stop-opacity="0.55"/>
+      <stop offset="48%" stop-color="#40c58a" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#07111f" stop-opacity="1"/>
+    </radialGradient>
+    <linearGradient id="body" x1="18" y1="16" x2="142" y2="152" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#123326"/>
+      <stop offset="62%" stop-color="#0d1b2d"/>
+      <stop offset="100%" stop-color="#050b14"/>
+    </linearGradient>
+    <filter id="softGlow" x="-25%" y="-25%" width="150%" height="150%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="1 0 0 0 0 0 0.82 0 0 0 0 0 0.38 0 0 0 0 0 0.45 0"/>
+      <feMerge>
+        <feMergeNode/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="url(#body)"/>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="url(#halo)" opacity="0.88"/>
+  <path d="M28 139c7-32 24-50 52-50s45 18 52 50" fill="#14243a" opacity="0.98"/>
+  <path d="M45 139c6-20 18-31 35-31s29 11 35 31" fill="#123326" opacity="0.65"/>
+  <ellipse cx="80" cy="70" rx="34" ry="38" fill="#111d2f"/>
+  <path d="M42 51c5-17 19-27 38-27s33 10 38 27c-8-4-20-8-38-8s-30 4-38 8Z" fill="#40c58a" opacity="0.72"/>
+  <path d="M43 59c13-11 25-17 37-17s24 6 37 17" fill="none" stroke="#82f0bd" stroke-width="5" stroke-linecap="round" opacity="0.65"/>
+  <circle cx="64" cy="71" r="3.7" fill="#82f0bd" opacity="0.88"/>
+  <circle cx="96" cy="71" r="3.7" fill="#82f0bd" opacity="0.88"/>
+  <path d="M36 89c14 8 28 8 42 0" fill="none" stroke="#82f0bd" stroke-width="4" stroke-linecap="round" opacity="0.65"/>
+  <path d="M65 83c10 8 20 8 30 0" fill="none" stroke="#82f0bd" stroke-width="4" stroke-linecap="round" opacity="0.58"/>
+  <path d="M39 112c14 11 28 17 41 17s27-6 41-17" fill="none" stroke="#40c58a" stroke-width="3" opacity="0.38"/>
+  <circle cx="122" cy="37" r="21" fill="#07111f" stroke="#40c58a" stroke-width="3" filter="url(#softGlow)"/>
+  <text x="122" y="44" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="21" font-weight="800" fill="#82f0bd">S</text>
+  <rect x="18" y="120" width="45" height="24" rx="12" fill="#020817" opacity="0.72"/>
+  <text x="40.5" y="137" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="800" letter-spacing="1" fill="#82f0bd">ST</text>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="none" stroke="#40c58a" stroke-opacity="0.64" stroke-width="2"/>
+</svg>

--- a/public/agent-avatars/integration-captain.svg
+++ b/public/agent-avatars/integration-captain.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Illustrated avatar for the Integration Captain lane</title>
+  <desc id="desc">Stylized animated-style portrait mark with Integration command cue; historically inspired without claiming exact photographic likeness.</desc>
+  <defs>
+    <radialGradient id="halo" cx="32%" cy="18%" r="75%">
+      <stop offset="0%" stop-color="#f6d34c" stop-opacity="0.55"/>
+      <stop offset="48%" stop-color="#d8b42c" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#07111f" stop-opacity="1"/>
+    </radialGradient>
+    <linearGradient id="body" x1="18" y1="16" x2="142" y2="152" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#332a12"/>
+      <stop offset="62%" stop-color="#0d1b2d"/>
+      <stop offset="100%" stop-color="#050b14"/>
+    </linearGradient>
+    <filter id="softGlow" x="-25%" y="-25%" width="150%" height="150%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="1 0 0 0 0 0 0.82 0 0 0 0 0 0.38 0 0 0 0 0 0.45 0"/>
+      <feMerge>
+        <feMergeNode/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="url(#body)"/>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="url(#halo)" opacity="0.88"/>
+  <path d="M28 139c7-32 24-50 52-50s45 18 52 50" fill="#14243a" opacity="0.98"/>
+  <path d="M45 139c6-20 18-31 35-31s29 11 35 31" fill="#332a12" opacity="0.65"/>
+  <ellipse cx="80" cy="70" rx="34" ry="38" fill="#111d2f"/>
+  <path d="M42 51c5-17 19-27 38-27s33 10 38 27c-8-4-20-8-38-8s-30 4-38 8Z" fill="#d8b42c" opacity="0.72"/>
+  <path d="M43 59c13-11 25-17 37-17s24 6 37 17" fill="none" stroke="#f6d34c" stroke-width="5" stroke-linecap="round" opacity="0.65"/>
+  <circle cx="64" cy="71" r="3.7" fill="#f6d34c" opacity="0.88"/>
+  <circle cx="96" cy="71" r="3.7" fill="#f6d34c" opacity="0.88"/>
+  <path d="M37 91c13 5 26 5 39-2" fill="none" stroke="#f6d34c" stroke-width="4" stroke-linecap="round" opacity="0.65"/>
+  <path d="M65 83c10 8 20 8 30 0" fill="none" stroke="#f6d34c" stroke-width="4" stroke-linecap="round" opacity="0.58"/>
+  <path d="M39 112c14 11 28 17 41 17s27-6 41-17" fill="none" stroke="#d8b42c" stroke-width="3" opacity="0.38"/>
+  <circle cx="122" cy="37" r="21" fill="#07111f" stroke="#d8b42c" stroke-width="3" filter="url(#softGlow)"/>
+  <text x="122" y="44" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="21" font-weight="800" fill="#f6d34c">H</text>
+  <rect x="18" y="120" width="45" height="24" rx="12" fill="#020817" opacity="0.72"/>
+  <text x="40.5" y="137" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="800" letter-spacing="1" fill="#f6d34c">IC</text>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="none" stroke="#d8b42c" stroke-opacity="0.64" stroke-width="2"/>
+</svg>

--- a/public/agent-avatars/legacy-institution-builder.svg
+++ b/public/agent-avatars/legacy-institution-builder.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Illustrated avatar for Sundiata Keita, Legacy Institution Builder</title>
+  <desc id="desc">Stylized animated-style portrait mark with Mali institution cue; historically inspired without claiming exact photographic likeness.</desc>
+  <defs>
+    <radialGradient id="halo" cx="32%" cy="18%" r="75%">
+      <stop offset="0%" stop-color="#82f0bd" stop-opacity="0.55"/>
+      <stop offset="48%" stop-color="#40c58a" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#07111f" stop-opacity="1"/>
+    </radialGradient>
+    <linearGradient id="body" x1="18" y1="16" x2="142" y2="152" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#123326"/>
+      <stop offset="62%" stop-color="#0d1b2d"/>
+      <stop offset="100%" stop-color="#050b14"/>
+    </linearGradient>
+    <filter id="softGlow" x="-25%" y="-25%" width="150%" height="150%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="1 0 0 0 0 0 0.82 0 0 0 0 0 0.38 0 0 0 0 0 0.45 0"/>
+      <feMerge>
+        <feMergeNode/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="url(#body)"/>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="url(#halo)" opacity="0.88"/>
+  <path d="M28 139c7-32 24-50 52-50s45 18 52 50" fill="#14243a" opacity="0.98"/>
+  <path d="M45 139c6-20 18-31 35-31s29 11 35 31" fill="#123326" opacity="0.65"/>
+  <ellipse cx="80" cy="70" rx="34" ry="38" fill="#111d2f"/>
+  <path d="M39 54c7-19 20-30 41-30s34 11 41 30c-12-6-26-9-41-9s-29 3-41 9Z" fill="#40c58a" opacity="0.72"/>
+  <path d="M43 59c13-11 25-17 37-17s24 6 37 17" fill="none" stroke="#82f0bd" stroke-width="5" stroke-linecap="round" opacity="0.65"/>
+  <circle cx="64" cy="71" r="3.7" fill="#82f0bd" opacity="0.88"/>
+  <circle cx="96" cy="71" r="3.7" fill="#82f0bd" opacity="0.88"/>
+  <path d="M36 89c14 8 28 8 42 0" fill="none" stroke="#82f0bd" stroke-width="4" stroke-linecap="round" opacity="0.65"/>
+  <path d="M65 83c10 8 20 8 30 0" fill="none" stroke="#82f0bd" stroke-width="4" stroke-linecap="round" opacity="0.58"/>
+  <path d="M39 112c14 11 28 17 41 17s27-6 41-17" fill="none" stroke="#40c58a" stroke-width="3" opacity="0.38"/>
+  <circle cx="122" cy="37" r="21" fill="#07111f" stroke="#40c58a" stroke-width="3" filter="url(#softGlow)"/>
+  <text x="122" y="44" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="21" font-weight="800" fill="#82f0bd">A</text>
+  <rect x="18" y="120" width="45" height="24" rx="12" fill="#020817" opacity="0.72"/>
+  <text x="40.5" y="137" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="800" letter-spacing="1" fill="#82f0bd">SK</text>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="none" stroke="#40c58a" stroke-opacity="0.64" stroke-width="2"/>
+</svg>

--- a/public/agent-avatars/meeting-intake-follow-up.svg
+++ b/public/agent-avatars/meeting-intake-follow-up.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Illustrated avatar for Amanirenas, Meeting Intake and Follow-Up</title>
+  <desc id="desc">Stylized animated-style portrait mark with Kush meeting cue; historically inspired without claiming exact photographic likeness.</desc>
+  <defs>
+    <radialGradient id="halo" cx="32%" cy="18%" r="75%">
+      <stop offset="0%" stop-color="#fecdd3" stop-opacity="0.55"/>
+      <stop offset="48%" stop-color="#fb7185" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#07111f" stop-opacity="1"/>
+    </radialGradient>
+    <linearGradient id="body" x1="18" y1="16" x2="142" y2="152" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#3a1620"/>
+      <stop offset="62%" stop-color="#0d1b2d"/>
+      <stop offset="100%" stop-color="#050b14"/>
+    </linearGradient>
+    <filter id="softGlow" x="-25%" y="-25%" width="150%" height="150%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="1 0 0 0 0 0 0.82 0 0 0 0 0 0.38 0 0 0 0 0 0.45 0"/>
+      <feMerge>
+        <feMergeNode/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="url(#body)"/>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="url(#halo)" opacity="0.88"/>
+  <path d="M28 139c7-32 24-50 52-50s45 18 52 50" fill="#14243a" opacity="0.98"/>
+  <path d="M45 139c6-20 18-31 35-31s29 11 35 31" fill="#3a1620" opacity="0.65"/>
+  <ellipse cx="80" cy="70" rx="34" ry="38" fill="#111d2f"/>
+  <path d="M42 51c5-17 19-27 38-27s33 10 38 27c-8-4-20-8-38-8s-30 4-38 8Z" fill="#fb7185" opacity="0.72"/>
+  <path d="M43 59c13-11 25-17 37-17s24 6 37 17" fill="none" stroke="#fecdd3" stroke-width="5" stroke-linecap="round" opacity="0.65"/>
+  <circle cx="64" cy="71" r="3.7" fill="#fecdd3" opacity="0.88"/>
+  <circle cx="96" cy="71" r="3.7" fill="#fecdd3" opacity="0.88"/>
+  <path d="M36 89c14 8 28 8 42 0" fill="none" stroke="#fecdd3" stroke-width="4" stroke-linecap="round" opacity="0.65"/>
+  <path d="M65 83c10 8 20 8 30 0" fill="none" stroke="#fecdd3" stroke-width="4" stroke-linecap="round" opacity="0.58"/>
+  <path d="M39 112c14 11 28 17 41 17s27-6 41-17" fill="none" stroke="#fb7185" stroke-width="3" opacity="0.38"/>
+  <circle cx="122" cy="37" r="21" fill="#07111f" stroke="#fb7185" stroke-width="3" filter="url(#softGlow)"/>
+  <text x="122" y="44" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="21" font-weight="800" fill="#fecdd3">M</text>
+  <rect x="18" y="120" width="45" height="24" rx="12" fill="#020817" opacity="0.72"/>
+  <text x="40.5" y="137" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="800" letter-spacing="1" fill="#fecdd3">AK</text>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="none" stroke="#fb7185" stroke-opacity="0.64" stroke-width="2"/>
+</svg>

--- a/public/agent-avatars/private-knowledge-librarian.svg
+++ b/public/agent-avatars/private-knowledge-librarian.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Illustrated avatar for Hatshepsut, Private Knowledge Librarian</title>
+  <desc id="desc">Stylized animated-style portrait mark with Kemet archive cue; historically inspired without claiming exact photographic likeness.</desc>
+  <defs>
+    <radialGradient id="halo" cx="32%" cy="18%" r="75%">
+      <stop offset="0%" stop-color="#c4b5fd" stop-opacity="0.55"/>
+      <stop offset="48%" stop-color="#a78bfa" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#07111f" stop-opacity="1"/>
+    </radialGradient>
+    <linearGradient id="body" x1="18" y1="16" x2="142" y2="152" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#241b3d"/>
+      <stop offset="62%" stop-color="#0d1b2d"/>
+      <stop offset="100%" stop-color="#050b14"/>
+    </linearGradient>
+    <filter id="softGlow" x="-25%" y="-25%" width="150%" height="150%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="1 0 0 0 0 0 0.82 0 0 0 0 0 0.38 0 0 0 0 0 0.45 0"/>
+      <feMerge>
+        <feMergeNode/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="url(#body)"/>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="url(#halo)" opacity="0.88"/>
+  <path d="M28 139c7-32 24-50 52-50s45 18 52 50" fill="#14243a" opacity="0.98"/>
+  <path d="M45 139c6-20 18-31 35-31s29 11 35 31" fill="#241b3d" opacity="0.65"/>
+  <ellipse cx="80" cy="70" rx="34" ry="38" fill="#111d2f"/>
+  <path d="M42 51c5-17 19-27 38-27s33 10 38 27c-8-4-20-8-38-8s-30 4-38 8Z" fill="#a78bfa" opacity="0.72"/>
+  <path d="M43 59c13-11 25-17 37-17s24 6 37 17" fill="none" stroke="#c4b5fd" stroke-width="5" stroke-linecap="round" opacity="0.65"/>
+  <circle cx="64" cy="71" r="3.7" fill="#c4b5fd" opacity="0.88"/>
+  <circle cx="96" cy="71" r="3.7" fill="#c4b5fd" opacity="0.88"/>
+  <path d="M37 91c13 5 26 5 39-2" fill="none" stroke="#c4b5fd" stroke-width="4" stroke-linecap="round" opacity="0.65"/>
+  <path d="M65 83c10 8 20 8 30 0" fill="none" stroke="#c4b5fd" stroke-width="4" stroke-linecap="round" opacity="0.58"/>
+  <path d="M39 112c14 11 28 17 41 17s27-6 41-17" fill="none" stroke="#a78bfa" stroke-width="3" opacity="0.38"/>
+  <circle cx="122" cy="37" r="21" fill="#07111f" stroke="#a78bfa" stroke-width="3" filter="url(#softGlow)"/>
+  <text x="122" y="44" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="21" font-weight="800" fill="#c4b5fd">O</text>
+  <rect x="18" y="120" width="45" height="24" rx="12" fill="#020817" opacity="0.72"/>
+  <text x="40.5" y="137" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="800" letter-spacing="1" fill="#c4b5fd">HK</text>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="none" stroke="#a78bfa" stroke-opacity="0.64" stroke-width="2"/>
+</svg>

--- a/public/agent-avatars/proposal-business-model.svg
+++ b/public/agent-avatars/proposal-business-model.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Illustrated avatar for Mansa Musa, Proposal and Business Model</title>
+  <desc id="desc">Stylized animated-style portrait mark with Mali commerce cue; historically inspired without claiming exact photographic likeness.</desc>
+  <defs>
+    <radialGradient id="halo" cx="32%" cy="18%" r="75%">
+      <stop offset="0%" stop-color="#fde68a" stop-opacity="0.55"/>
+      <stop offset="48%" stop-color="#f59e0b" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#07111f" stop-opacity="1"/>
+    </radialGradient>
+    <linearGradient id="body" x1="18" y1="16" x2="142" y2="152" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#3a260a"/>
+      <stop offset="62%" stop-color="#0d1b2d"/>
+      <stop offset="100%" stop-color="#050b14"/>
+    </linearGradient>
+    <filter id="softGlow" x="-25%" y="-25%" width="150%" height="150%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="1 0 0 0 0 0 0.82 0 0 0 0 0 0.38 0 0 0 0 0 0.45 0"/>
+      <feMerge>
+        <feMergeNode/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="url(#body)"/>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="url(#halo)" opacity="0.88"/>
+  <path d="M28 139c7-32 24-50 52-50s45 18 52 50" fill="#14243a" opacity="0.98"/>
+  <path d="M45 139c6-20 18-31 35-31s29 11 35 31" fill="#3a260a" opacity="0.65"/>
+  <ellipse cx="80" cy="70" rx="34" ry="38" fill="#111d2f"/>
+  <path d="M35 57c9-22 23-34 45-34s36 12 45 34c-15-8-30-12-45-12s-30 4-45 12Z" fill="#f59e0b" opacity="0.72"/>
+  <path d="M43 59c13-11 25-17 37-17s24 6 37 17" fill="none" stroke="#fde68a" stroke-width="5" stroke-linecap="round" opacity="0.65"/>
+  <circle cx="64" cy="71" r="3.7" fill="#fde68a" opacity="0.88"/>
+  <circle cx="96" cy="71" r="3.7" fill="#fde68a" opacity="0.88"/>
+  <path d="M37 91c13 5 26 5 39-2" fill="none" stroke="#fde68a" stroke-width="4" stroke-linecap="round" opacity="0.65"/>
+  <path d="M65 83c10 8 20 8 30 0" fill="none" stroke="#fde68a" stroke-width="4" stroke-linecap="round" opacity="0.58"/>
+  <path d="M39 112c14 11 28 17 41 17s27-6 41-17" fill="none" stroke="#f59e0b" stroke-width="3" opacity="0.38"/>
+  <circle cx="122" cy="37" r="21" fill="#07111f" stroke="#f59e0b" stroke-width="3" filter="url(#softGlow)"/>
+  <text x="122" y="44" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="21" font-weight="800" fill="#fde68a">C</text>
+  <rect x="18" y="120" width="45" height="24" rx="12" fill="#020817" opacity="0.72"/>
+  <text x="40.5" y="137" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="800" letter-spacing="1" fill="#fde68a">MM</text>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="none" stroke="#f59e0b" stroke-opacity="0.64" stroke-width="2"/>
+</svg>

--- a/public/agent-avatars/research-source-register.svg
+++ b/public/agent-avatars/research-source-register.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Illustrated avatar for Askia Muhammad, Research Source Register</title>
+  <desc id="desc">Stylized animated-style portrait mark with Songhai scholarship cue; historically inspired without claiming exact photographic likeness.</desc>
+  <defs>
+    <radialGradient id="halo" cx="32%" cy="18%" r="75%">
+      <stop offset="0%" stop-color="#9ce3ff" stop-opacity="0.55"/>
+      <stop offset="48%" stop-color="#4db7e8" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#07111f" stop-opacity="1"/>
+    </radialGradient>
+    <linearGradient id="body" x1="18" y1="16" x2="142" y2="152" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#102c3b"/>
+      <stop offset="62%" stop-color="#0d1b2d"/>
+      <stop offset="100%" stop-color="#050b14"/>
+    </linearGradient>
+    <filter id="softGlow" x="-25%" y="-25%" width="150%" height="150%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="1 0 0 0 0 0 0.82 0 0 0 0 0 0.38 0 0 0 0 0 0.45 0"/>
+      <feMerge>
+        <feMergeNode/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="url(#body)"/>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="url(#halo)" opacity="0.88"/>
+  <path d="M28 139c7-32 24-50 52-50s45 18 52 50" fill="#14243a" opacity="0.98"/>
+  <path d="M45 139c6-20 18-31 35-31s29 11 35 31" fill="#102c3b" opacity="0.65"/>
+  <ellipse cx="80" cy="70" rx="34" ry="38" fill="#111d2f"/>
+  <path d="M42 51c5-17 19-27 38-27s33 10 38 27c-8-4-20-8-38-8s-30 4-38 8Z" fill="#4db7e8" opacity="0.72"/>
+  <path d="M43 59c13-11 25-17 37-17s24 6 37 17" fill="none" stroke="#9ce3ff" stroke-width="5" stroke-linecap="round" opacity="0.65"/>
+  <circle cx="64" cy="71" r="3.7" fill="#9ce3ff" opacity="0.88"/>
+  <circle cx="96" cy="71" r="3.7" fill="#9ce3ff" opacity="0.88"/>
+  <path d="M37 91c13 5 26 5 39-2" fill="none" stroke="#9ce3ff" stroke-width="4" stroke-linecap="round" opacity="0.65"/>
+  <path d="M65 83c10 8 20 8 30 0" fill="none" stroke="#9ce3ff" stroke-width="4" stroke-linecap="round" opacity="0.58"/>
+  <path d="M39 112c14 11 28 17 41 17s27-6 41-17" fill="none" stroke="#4db7e8" stroke-width="3" opacity="0.38"/>
+  <circle cx="122" cy="37" r="21" fill="#07111f" stroke="#4db7e8" stroke-width="3" filter="url(#softGlow)"/>
+  <text x="122" y="44" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="21" font-weight="800" fill="#9ce3ff">S</text>
+  <rect x="18" y="120" width="45" height="24" rx="12" fill="#020817" opacity="0.72"/>
+  <text x="40.5" y="137" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="800" letter-spacing="1" fill="#9ce3ff">AM</text>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="none" stroke="#4db7e8" stroke-opacity="0.64" stroke-width="2"/>
+</svg>

--- a/public/agent-avatars/risk-compliance-intelligence.svg
+++ b/public/agent-avatars/risk-compliance-intelligence.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Illustrated avatar for Moremi, Risk and Compliance</title>
+  <desc id="desc">Stylized animated-style portrait mark with Ife vigilance cue; historically inspired without claiming exact photographic likeness.</desc>
+  <defs>
+    <radialGradient id="halo" cx="32%" cy="18%" r="75%">
+      <stop offset="0%" stop-color="#fecdd3" stop-opacity="0.55"/>
+      <stop offset="48%" stop-color="#fb7185" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#07111f" stop-opacity="1"/>
+    </radialGradient>
+    <linearGradient id="body" x1="18" y1="16" x2="142" y2="152" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#3a1620"/>
+      <stop offset="62%" stop-color="#0d1b2d"/>
+      <stop offset="100%" stop-color="#050b14"/>
+    </linearGradient>
+    <filter id="softGlow" x="-25%" y="-25%" width="150%" height="150%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="1 0 0 0 0 0 0.82 0 0 0 0 0 0.38 0 0 0 0 0 0.45 0"/>
+      <feMerge>
+        <feMergeNode/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="url(#body)"/>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="url(#halo)" opacity="0.88"/>
+  <path d="M28 139c7-32 24-50 52-50s45 18 52 50" fill="#14243a" opacity="0.98"/>
+  <path d="M45 139c6-20 18-31 35-31s29 11 35 31" fill="#3a1620" opacity="0.65"/>
+  <ellipse cx="80" cy="70" rx="34" ry="38" fill="#111d2f"/>
+  <path d="M35 57c9-22 23-34 45-34s36 12 45 34c-15-8-30-12-45-12s-30 4-45 12Z" fill="#fb7185" opacity="0.72"/>
+  <path d="M43 59c13-11 25-17 37-17s24 6 37 17" fill="none" stroke="#fecdd3" stroke-width="5" stroke-linecap="round" opacity="0.65"/>
+  <circle cx="64" cy="71" r="3.7" fill="#fecdd3" opacity="0.88"/>
+  <circle cx="96" cy="71" r="3.7" fill="#fecdd3" opacity="0.88"/>
+  <path d="M37 91c13 5 26 5 39-2" fill="none" stroke="#fecdd3" stroke-width="4" stroke-linecap="round" opacity="0.65"/>
+  <path d="M65 83c10 8 20 8 30 0" fill="none" stroke="#fecdd3" stroke-width="4" stroke-linecap="round" opacity="0.58"/>
+  <path d="M39 112c14 11 28 17 41 17s27-6 41-17" fill="none" stroke="#fb7185" stroke-width="3" opacity="0.38"/>
+  <circle cx="122" cy="37" r="21" fill="#07111f" stroke="#fb7185" stroke-width="3" filter="url(#softGlow)"/>
+  <text x="122" y="44" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="21" font-weight="800" fill="#fecdd3">E</text>
+  <rect x="18" y="120" width="45" height="24" rx="12" fill="#020817" opacity="0.72"/>
+  <text x="40.5" y="137" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="800" letter-spacing="1" fill="#fecdd3">MI</text>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="none" stroke="#fb7185" stroke-opacity="0.64" stroke-width="2"/>
+</svg>

--- a/public/agent-avatars/strategic-narrative.svg
+++ b/public/agent-avatars/strategic-narrative.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Illustrated avatar for Amina, Strategic Narrative</title>
+  <desc id="desc">Stylized animated-style portrait mark with Zazzau leadership cue; historically inspired without claiming exact photographic likeness.</desc>
+  <defs>
+    <radialGradient id="halo" cx="32%" cy="18%" r="75%">
+      <stop offset="0%" stop-color="#fecdd3" stop-opacity="0.55"/>
+      <stop offset="48%" stop-color="#fb7185" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#07111f" stop-opacity="1"/>
+    </radialGradient>
+    <linearGradient id="body" x1="18" y1="16" x2="142" y2="152" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#3a1620"/>
+      <stop offset="62%" stop-color="#0d1b2d"/>
+      <stop offset="100%" stop-color="#050b14"/>
+    </linearGradient>
+    <filter id="softGlow" x="-25%" y="-25%" width="150%" height="150%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="1 0 0 0 0 0 0.82 0 0 0 0 0 0.38 0 0 0 0 0 0.45 0"/>
+      <feMerge>
+        <feMergeNode/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="url(#body)"/>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="url(#halo)" opacity="0.88"/>
+  <path d="M28 139c7-32 24-50 52-50s45 18 52 50" fill="#14243a" opacity="0.98"/>
+  <path d="M45 139c6-20 18-31 35-31s29 11 35 31" fill="#3a1620" opacity="0.65"/>
+  <ellipse cx="80" cy="70" rx="34" ry="38" fill="#111d2f"/>
+  <path d="M39 54c7-19 20-30 41-30s34 11 41 30c-12-6-26-9-41-9s-29 3-41 9Z" fill="#fb7185" opacity="0.72"/>
+  <path d="M43 59c13-11 25-17 37-17s24 6 37 17" fill="none" stroke="#fecdd3" stroke-width="5" stroke-linecap="round" opacity="0.65"/>
+  <circle cx="64" cy="71" r="3.7" fill="#fecdd3" opacity="0.88"/>
+  <circle cx="96" cy="71" r="3.7" fill="#fecdd3" opacity="0.88"/>
+  <path d="M37 91c13 5 26 5 39-2" fill="none" stroke="#fecdd3" stroke-width="4" stroke-linecap="round" opacity="0.65"/>
+  <path d="M65 83c10 8 20 8 30 0" fill="none" stroke="#fecdd3" stroke-width="4" stroke-linecap="round" opacity="0.58"/>
+  <path d="M39 112c14 11 28 17 41 17s27-6 41-17" fill="none" stroke="#fb7185" stroke-width="3" opacity="0.38"/>
+  <circle cx="122" cy="37" r="21" fill="#07111f" stroke="#fb7185" stroke-width="3" filter="url(#softGlow)"/>
+  <text x="122" y="44" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="21" font-weight="800" fill="#fecdd3">*</text>
+  <rect x="18" y="120" width="45" height="24" rx="12" fill="#020817" opacity="0.72"/>
+  <text x="40.5" y="137" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="800" letter-spacing="1" fill="#fecdd3">AZ</text>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="none" stroke="#fb7185" stroke-opacity="0.64" stroke-width="2"/>
+</svg>

--- a/public/agent-avatars/unknown.svg
+++ b/public/agent-avatars/unknown.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Illustrated avatar for unassigned agent work</title>
+  <desc id="desc">Fallback stylized animated-style portrait mark for unassigned Agent Ops work.</desc>
+  <rect width="160" height="160" rx="32" fill="#07111f"/>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="#102c3b" opacity="0.88"/>
+  <circle cx="80" cy="70" r="36" fill="#111d2f"/>
+  <path d="M35 57c9-22 23-34 45-34s36 12 45 34c-15-8-30-12-45-12s-30 4-45 12Z" fill="#4db7e8" opacity="0.58"/>
+  <circle cx="64" cy="72" r="4" fill="#9ce3ff" opacity="0.8"/>
+  <circle cx="96" cy="72" r="4" fill="#9ce3ff" opacity="0.8"/>
+  <path d="M65 84c10 8 20 8 30 0" fill="none" stroke="#9ce3ff" stroke-width="4" stroke-linecap="round" opacity="0.58"/>
+  <circle cx="122" cy="37" r="21" fill="#07111f" stroke="#4db7e8" stroke-width="3"/>
+  <text x="122" y="44" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="21" font-weight="800" fill="#9ce3ff">N</text>
+  <rect x="18" y="120" width="45" height="24" rx="12" fill="#020817" opacity="0.72"/>
+  <text x="40.5" y="137" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="800" letter-spacing="1" fill="#9ce3ff">AI</text>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="none" stroke="#4db7e8" stroke-opacity="0.64" stroke-width="2"/>
+</svg>

--- a/public/agent-avatars/voice-content-architect.svg
+++ b/public/agent-avatars/voice-content-architect.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Illustrated avatar for Nefertiti, Voice and Content Architect</title>
+  <desc id="desc">Stylized animated-style portrait mark with Kemet voice cue; historically inspired without claiming exact photographic likeness.</desc>
+  <defs>
+    <radialGradient id="halo" cx="32%" cy="18%" r="75%">
+      <stop offset="0%" stop-color="#c4b5fd" stop-opacity="0.55"/>
+      <stop offset="48%" stop-color="#a78bfa" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#07111f" stop-opacity="1"/>
+    </radialGradient>
+    <linearGradient id="body" x1="18" y1="16" x2="142" y2="152" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#241b3d"/>
+      <stop offset="62%" stop-color="#0d1b2d"/>
+      <stop offset="100%" stop-color="#050b14"/>
+    </linearGradient>
+    <filter id="softGlow" x="-25%" y="-25%" width="150%" height="150%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="1 0 0 0 0 0 0.82 0 0 0 0 0 0.38 0 0 0 0 0 0.45 0"/>
+      <feMerge>
+        <feMergeNode/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="url(#body)"/>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="url(#halo)" opacity="0.88"/>
+  <path d="M28 139c7-32 24-50 52-50s45 18 52 50" fill="#14243a" opacity="0.98"/>
+  <path d="M45 139c6-20 18-31 35-31s29 11 35 31" fill="#241b3d" opacity="0.65"/>
+  <ellipse cx="80" cy="70" rx="34" ry="38" fill="#111d2f"/>
+  <path d="M42 51c5-17 19-27 38-27s33 10 38 27c-8-4-20-8-38-8s-30 4-38 8Z" fill="#a78bfa" opacity="0.72"/>
+  <path d="M43 59c13-11 25-17 37-17s24 6 37 17" fill="none" stroke="#c4b5fd" stroke-width="5" stroke-linecap="round" opacity="0.65"/>
+  <circle cx="64" cy="71" r="3.7" fill="#c4b5fd" opacity="0.88"/>
+  <circle cx="96" cy="71" r="3.7" fill="#c4b5fd" opacity="0.88"/>
+  <path d="M36 89c14 8 28 8 42 0" fill="none" stroke="#c4b5fd" stroke-width="4" stroke-linecap="round" opacity="0.65"/>
+  <path d="M65 83c10 8 20 8 30 0" fill="none" stroke="#c4b5fd" stroke-width="4" stroke-linecap="round" opacity="0.58"/>
+  <path d="M39 112c14 11 28 17 41 17s27-6 41-17" fill="none" stroke="#a78bfa" stroke-width="3" opacity="0.38"/>
+  <circle cx="122" cy="37" r="21" fill="#07111f" stroke="#a78bfa" stroke-width="3" filter="url(#softGlow)"/>
+  <text x="122" y="44" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="21" font-weight="800" fill="#c4b5fd">P</text>
+  <rect x="18" y="120" width="45" height="24" rx="12" fill="#020817" opacity="0.72"/>
+  <text x="40.5" y="137" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="800" letter-spacing="1" fill="#c4b5fd">NK</text>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="none" stroke="#a78bfa" stroke-opacity="0.64" stroke-width="2"/>
+</svg>

--- a/public/agent-avatars/warm-lead-capture.svg
+++ b/public/agent-avatars/warm-lead-capture.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Illustrated avatar for Behanzin, Warm Lead Capture</title>
+  <desc id="desc">Stylized animated-style portrait mark with Dahomey capture cue; historically inspired without claiming exact photographic likeness.</desc>
+  <defs>
+    <radialGradient id="halo" cx="32%" cy="18%" r="75%">
+      <stop offset="0%" stop-color="#fde68a" stop-opacity="0.55"/>
+      <stop offset="48%" stop-color="#f59e0b" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#07111f" stop-opacity="1"/>
+    </radialGradient>
+    <linearGradient id="body" x1="18" y1="16" x2="142" y2="152" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#3a260a"/>
+      <stop offset="62%" stop-color="#0d1b2d"/>
+      <stop offset="100%" stop-color="#050b14"/>
+    </linearGradient>
+    <filter id="softGlow" x="-25%" y="-25%" width="150%" height="150%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="1 0 0 0 0 0 0.82 0 0 0 0 0 0.38 0 0 0 0 0 0.45 0"/>
+      <feMerge>
+        <feMergeNode/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="url(#body)"/>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="url(#halo)" opacity="0.88"/>
+  <path d="M28 139c7-32 24-50 52-50s45 18 52 50" fill="#14243a" opacity="0.98"/>
+  <path d="M45 139c6-20 18-31 35-31s29 11 35 31" fill="#3a260a" opacity="0.65"/>
+  <ellipse cx="80" cy="70" rx="34" ry="38" fill="#111d2f"/>
+  <path d="M35 57c9-22 23-34 45-34s36 12 45 34c-15-8-30-12-45-12s-30 4-45 12Z" fill="#f59e0b" opacity="0.72"/>
+  <path d="M43 59c13-11 25-17 37-17s24 6 37 17" fill="none" stroke="#fde68a" stroke-width="5" stroke-linecap="round" opacity="0.65"/>
+  <circle cx="64" cy="71" r="3.7" fill="#fde68a" opacity="0.88"/>
+  <circle cx="96" cy="71" r="3.7" fill="#fde68a" opacity="0.88"/>
+  <path d="M37 91c13 5 26 5 39-2" fill="none" stroke="#fde68a" stroke-width="4" stroke-linecap="round" opacity="0.65"/>
+  <path d="M65 83c10 8 20 8 30 0" fill="none" stroke="#fde68a" stroke-width="4" stroke-linecap="round" opacity="0.58"/>
+  <path d="M39 112c14 11 28 17 41 17s27-6 41-17" fill="none" stroke="#f59e0b" stroke-width="3" opacity="0.38"/>
+  <circle cx="122" cy="37" r="21" fill="#07111f" stroke="#f59e0b" stroke-width="3" filter="url(#softGlow)"/>
+  <text x="122" y="44" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="21" font-weight="800" fill="#fde68a">N</text>
+  <rect x="18" y="120" width="45" height="24" rx="12" fill="#020817" opacity="0.72"/>
+  <text x="40.5" y="137" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="800" letter-spacing="1" fill="#fde68a">BD</text>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="none" stroke="#f59e0b" stroke-opacity="0.64" stroke-width="2"/>
+</svg>

--- a/public/agent-avatars/website-product-copy.svg
+++ b/public/agent-avatars/website-product-copy.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Illustrated avatar for Makeda, Website and Product Copy</title>
+  <desc id="desc">Stylized animated-style portrait mark with Sheba clarity cue; historically inspired without claiming exact photographic likeness.</desc>
+  <defs>
+    <radialGradient id="halo" cx="32%" cy="18%" r="75%">
+      <stop offset="0%" stop-color="#c4b5fd" stop-opacity="0.55"/>
+      <stop offset="48%" stop-color="#a78bfa" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#07111f" stop-opacity="1"/>
+    </radialGradient>
+    <linearGradient id="body" x1="18" y1="16" x2="142" y2="152" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#241b3d"/>
+      <stop offset="62%" stop-color="#0d1b2d"/>
+      <stop offset="100%" stop-color="#050b14"/>
+    </linearGradient>
+    <filter id="softGlow" x="-25%" y="-25%" width="150%" height="150%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="1 0 0 0 0 0 0.82 0 0 0 0 0 0.38 0 0 0 0 0 0.45 0"/>
+      <feMerge>
+        <feMergeNode/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="url(#body)"/>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="url(#halo)" opacity="0.88"/>
+  <path d="M28 139c7-32 24-50 52-50s45 18 52 50" fill="#14243a" opacity="0.98"/>
+  <path d="M45 139c6-20 18-31 35-31s29 11 35 31" fill="#241b3d" opacity="0.65"/>
+  <ellipse cx="80" cy="70" rx="34" ry="38" fill="#111d2f"/>
+  <path d="M35 57c9-22 23-34 45-34s36 12 45 34c-15-8-30-12-45-12s-30 4-45 12Z" fill="#a78bfa" opacity="0.72"/>
+  <path d="M43 59c13-11 25-17 37-17s24 6 37 17" fill="none" stroke="#c4b5fd" stroke-width="5" stroke-linecap="round" opacity="0.65"/>
+  <circle cx="64" cy="71" r="3.7" fill="#c4b5fd" opacity="0.88"/>
+  <circle cx="96" cy="71" r="3.7" fill="#c4b5fd" opacity="0.88"/>
+  <path d="M37 91c13 5 26 5 39-2" fill="none" stroke="#c4b5fd" stroke-width="4" stroke-linecap="round" opacity="0.65"/>
+  <path d="M65 83c10 8 20 8 30 0" fill="none" stroke="#c4b5fd" stroke-width="4" stroke-linecap="round" opacity="0.58"/>
+  <path d="M39 112c14 11 28 17 41 17s27-6 41-17" fill="none" stroke="#a78bfa" stroke-width="3" opacity="0.38"/>
+  <circle cx="122" cy="37" r="21" fill="#07111f" stroke="#a78bfa" stroke-width="3" filter="url(#softGlow)"/>
+  <text x="122" y="44" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="21" font-weight="800" fill="#c4b5fd">D</text>
+  <rect x="18" y="120" width="45" height="24" rx="12" fill="#020817" opacity="0.72"/>
+  <text x="40.5" y="137" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="800" letter-spacing="1" fill="#c4b5fd">MS</text>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="none" stroke="#a78bfa" stroke-opacity="0.64" stroke-width="2"/>
+</svg>

--- a/scripts/generate-agent-avatar-assets.ts
+++ b/scripts/generate-agent-avatar-assets.ts
@@ -1,0 +1,135 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { AGENT_AVATARS, getAvatarToneStyles } from '../lib/agent-avatars'
+
+const outputDir = path.join(process.cwd(), 'public', 'agent-avatars')
+
+const motifGlyphs: Record<string, string> = {
+  arch: 'A',
+  bolt: 'B',
+  book: 'B',
+  coin: 'C',
+  crown: 'C',
+  diamond: 'D',
+  eye: 'E',
+  forge: 'F',
+  helm: 'H',
+  link: 'L',
+  moon: 'M',
+  net: 'N',
+  node: 'N',
+  obelisk: 'O',
+  pen: 'P',
+  route: 'R',
+  scroll: 'S',
+  shield: 'S',
+  signal: 'S',
+  star: '*',
+  sun: 'S',
+}
+
+function escapeXml(value: string) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
+function avatarSvg(agentKey: string) {
+  const avatar = AGENT_AVATARS[agentKey]
+  const tone = getAvatarToneStyles(avatar.tone)
+  const glyph = motifGlyphs[avatar.motif] ?? avatar.motif.slice(0, 1).toUpperCase()
+  const label = escapeXml(avatar.label)
+  const cue = escapeXml(avatar.culturalCue)
+  const initials = escapeXml(avatar.initials)
+  const seed = Array.from(agentKey).reduce((sum, char) => sum + char.charCodeAt(0), 0)
+  const browTilt = seed % 2 === 0 ? 'M36 89c14 8 28 8 42 0' : 'M37 91c13 5 26 5 39-2'
+  const headWrap = seed % 3 === 0
+    ? 'M39 54c7-19 20-30 41-30s34 11 41 30c-12-6-26-9-41-9s-29 3-41 9Z'
+    : seed % 3 === 1
+      ? 'M42 51c5-17 19-27 38-27s33 10 38 27c-8-4-20-8-38-8s-30 4-38 8Z'
+      : 'M35 57c9-22 23-34 45-34s36 12 45 34c-15-8-30-12-45-12s-30 4-45 12Z'
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">${label}</title>
+  <desc id="desc">Stylized animated-style portrait mark with ${cue}; historically inspired without claiming exact photographic likeness.</desc>
+  <defs>
+    <radialGradient id="halo" cx="32%" cy="18%" r="75%">
+      <stop offset="0%" stop-color="${tone.mark}" stop-opacity="0.55"/>
+      <stop offset="48%" stop-color="${tone.ring}" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#07111f" stop-opacity="1"/>
+    </radialGradient>
+    <linearGradient id="body" x1="18" y1="16" x2="142" y2="152" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="${tone.wash}"/>
+      <stop offset="62%" stop-color="#0d1b2d"/>
+      <stop offset="100%" stop-color="#050b14"/>
+    </linearGradient>
+    <filter id="softGlow" x="-25%" y="-25%" width="150%" height="150%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="1 0 0 0 0 0 0.82 0 0 0 0 0 0.38 0 0 0 0 0 0.45 0"/>
+      <feMerge>
+        <feMergeNode/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="url(#body)"/>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="url(#halo)" opacity="0.88"/>
+  <path d="M28 139c7-32 24-50 52-50s45 18 52 50" fill="#14243a" opacity="0.98"/>
+  <path d="M45 139c6-20 18-31 35-31s29 11 35 31" fill="${tone.wash}" opacity="0.65"/>
+  <ellipse cx="80" cy="70" rx="34" ry="38" fill="#111d2f"/>
+  <path d="${headWrap}" fill="${tone.ring}" opacity="0.72"/>
+  <path d="M43 59c13-11 25-17 37-17s24 6 37 17" fill="none" stroke="${tone.mark}" stroke-width="5" stroke-linecap="round" opacity="0.65"/>
+  <circle cx="64" cy="71" r="3.7" fill="${tone.mark}" opacity="0.88"/>
+  <circle cx="96" cy="71" r="3.7" fill="${tone.mark}" opacity="0.88"/>
+  <path d="${browTilt}" fill="none" stroke="${tone.mark}" stroke-width="4" stroke-linecap="round" opacity="0.65"/>
+  <path d="M65 83c10 8 20 8 30 0" fill="none" stroke="${tone.mark}" stroke-width="4" stroke-linecap="round" opacity="0.58"/>
+  <path d="M39 112c14 11 28 17 41 17s27-6 41-17" fill="none" stroke="${tone.ring}" stroke-width="3" opacity="0.38"/>
+  <circle cx="122" cy="37" r="21" fill="#07111f" stroke="${tone.ring}" stroke-width="3" filter="url(#softGlow)"/>
+  <text x="122" y="44" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="21" font-weight="800" fill="${tone.mark}">${escapeXml(glyph)}</text>
+  <rect x="18" y="120" width="45" height="24" rx="12" fill="#020817" opacity="0.72"/>
+  <text x="40.5" y="137" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="800" letter-spacing="1" fill="${tone.mark}">${initials}</text>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="none" stroke="${tone.ring}" stroke-opacity="0.64" stroke-width="2"/>
+</svg>
+`
+}
+
+function unknownSvg() {
+  const tone = getAvatarToneStyles('cyan')
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Illustrated avatar for unassigned agent work</title>
+  <desc id="desc">Fallback stylized animated-style portrait mark for unassigned Agent Ops work.</desc>
+  <rect width="160" height="160" rx="32" fill="#07111f"/>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="${tone.wash}" opacity="0.88"/>
+  <circle cx="80" cy="70" r="36" fill="#111d2f"/>
+  <path d="M35 57c9-22 23-34 45-34s36 12 45 34c-15-8-30-12-45-12s-30 4-45 12Z" fill="${tone.ring}" opacity="0.58"/>
+  <circle cx="64" cy="72" r="4" fill="${tone.mark}" opacity="0.8"/>
+  <circle cx="96" cy="72" r="4" fill="${tone.mark}" opacity="0.8"/>
+  <path d="M65 84c10 8 20 8 30 0" fill="none" stroke="${tone.mark}" stroke-width="4" stroke-linecap="round" opacity="0.58"/>
+  <circle cx="122" cy="37" r="21" fill="#07111f" stroke="${tone.ring}" stroke-width="3"/>
+  <text x="122" y="44" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="21" font-weight="800" fill="${tone.mark}">N</text>
+  <rect x="18" y="120" width="45" height="24" rx="12" fill="#020817" opacity="0.72"/>
+  <text x="40.5" y="137" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="800" letter-spacing="1" fill="${tone.mark}">AI</text>
+  <rect x="8" y="8" width="144" height="144" rx="27" fill="none" stroke="${tone.ring}" stroke-opacity="0.64" stroke-width="2"/>
+</svg>
+`
+}
+
+async function main() {
+  await mkdir(outputDir, { recursive: true })
+  await Promise.all(
+    Object.keys(AGENT_AVATARS).map((agentKey) => (
+      writeFile(path.join(outputDir, `${agentKey}.svg`), avatarSvg(agentKey), 'utf8')
+    )),
+  )
+  await writeFile(path.join(outputDir, 'unknown.svg'), unknownSvg(), 'utf8')
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})


### PR DESCRIPTION
Summary
- Adds reproducible static SVG portrait assets for every Agent Ops avatar plus the fallback avatar.
- Wires the avatar manifest image paths into the shared AgentAvatar component so Mission Control, Standup Room, Kanban, Decision Queue, and run details render the same profile system.
- Adds generator and coverage tests so every AGENT_ORGANIZATION key has an asset path and file.

Validation
- npm test -- lib/agent-avatars.test.ts app/admin/agents/page.test.tsx app/admin/agents/coordination/page.test.tsx app/admin/agents/standup/page.test.tsx app/admin/agents/swarm-board/page.test.tsx app/admin/agents/runs/[runId]/page.test.tsx
- npx tsc --noEmit --pretty false
- npm run lint
- git diff --check
- rm -rf .next && npm run build

Integration Notes
- UI/static asset change only; no API, database, schema, or environment changes.
- Avatar artwork is stylized and historically inspired by the agent identity system; it avoids claims of exact photographic likeness.
- Vercel contexts to verify after merge: Vercel – portfolio and Vercel – portfolio-staging.