### PR TITLE
fix: harden sales script startup

### DIFF
--- a/app/admin/sales/[auditId]/page.tsx
+++ b/app/admin/sales/[auditId]/page.tsx
@@ -307,6 +307,7 @@ export default function ClientWalkthroughPage() {
   const [aiRecommendations, setAiRecommendations] = useState<AIRecommendation[]>([]);
   const [isLoadingRecommendations, setIsLoadingRecommendations] = useState(false);
   const [isLoadingNextStep, setIsLoadingNextStep] = useState(false);
+  const [scriptGenerationError, setScriptGenerationError] = useState<string | null>(null);
   /** Value evidence summary for script (pain points + total value) to guide the conversation */
   const [scriptValueEvidence, setScriptValueEvidence] = useState<{
     painPoints: { display_name: string | null; monetary_indicator: number; monetary_context: string | null }[];
@@ -793,10 +794,14 @@ export default function ClientWalkthroughPage() {
 
       if (res.ok) {
         const data = await res.json();
+        setScriptGenerationError(null);
         return data.step;
       }
+      const errorBody = await res.json().catch(() => null);
+      setScriptGenerationError(errorBody?.error || `Script generation failed with status ${res.status}.`);
     } catch (err) {
       console.error('Failed to generate step:', err);
+      setScriptGenerationError('Script generation failed before Portfolio received a response.');
     }
     return null;
   };
@@ -804,7 +809,7 @@ export default function ClientWalkthroughPage() {
   // Start the call - generate opening step
   const startCall = async () => {
     setIsLoadingNextStep(true);
-    setConversationState(prev => ({ ...prev, isCallActive: true }));
+    setScriptGenerationError(null);
 
     const openingStep = await generateStep('opening', []);
     
@@ -812,7 +817,15 @@ export default function ClientWalkthroughPage() {
       openingStep.status = 'active';
       setConversationState(prev => ({
         ...prev,
+        isCallActive: true,
         dynamicSteps: [openingStep],
+        currentStep: 0,
+      }));
+    } else {
+      setConversationState(prev => ({
+        ...prev,
+        isCallActive: false,
+        dynamicSteps: [],
         currentStep: 0,
       }));
     }
@@ -841,6 +854,12 @@ export default function ClientWalkthroughPage() {
         ...prev,
         dynamicSteps: [...stepsToUse, newStep],
         currentStep: stepsToUse.length,
+        offersPresented: offersToUse,
+      }));
+    } else {
+      setConversationState(prev => ({
+        ...prev,
+        dynamicSteps: stepsToUse,
         offersPresented: offersToUse,
       }));
     }
@@ -1667,6 +1686,7 @@ export default function ClientWalkthroughPage() {
                     aiRecommendations={aiRecommendations}
                     isLoadingRecommendations={isLoadingRecommendations}
                     isLoadingNextStep={isLoadingNextStep}
+                    generationError={scriptGenerationError}
                     isCallActive={conversationState.isCallActive}
                     onStartCall={startCall}
                     onRefreshRecommendations={refreshRecommendations}

--- a/app/admin/sales/[auditId]/page.tsx
+++ b/app/admin/sales/[auditId]/page.tsx
@@ -166,6 +166,7 @@ interface ContactInfo {
   name: string;
   email: string;
   company: string | null;
+  message?: string | null;
   phone?: string;
   industry?: string | null;
   employee_count?: string | null;
@@ -789,6 +790,8 @@ export default function ClientWalkthroughPage() {
           availableContent: content.filter(c => c.is_active),
           conversationHistory: conversationState.responseHistory,
           contactSubmissionId: contact?.id ? parseInt(contact.id, 10) : null,
+          contactNotes: contact?.message ?? null,
+          callNotes: notes,
         }),
       });
 

--- a/app/admin/sales/conversation/[sessionId]/page.tsx
+++ b/app/admin/sales/conversation/[sessionId]/page.tsx
@@ -182,6 +182,7 @@ export default function ConversationPage() {
   const [accumulatedProducts, setAccumulatedProducts] = useState<Array<{ id: number; name: string; reason: string }>>([]);
   const [isLoadingRecommendations, setIsLoadingRecommendations] = useState(false);
   const [isLoadingNextStep, setIsLoadingNextStep] = useState(false);
+  const [scriptGenerationError, setScriptGenerationError] = useState<string | null>(null);
 
   /* ---- in-person diagnostic ---- */
   const [auditData, setAuditData] = useState<Record<string, unknown> | null>(null);
@@ -688,11 +689,16 @@ export default function ConversationPage() {
     stepType: StepType, previousSteps: DynamicStep[],
     lastResponse?: ResponseType, chosenStrategy?: OfferStrategy,
   ): Promise<DynamicStep | null> => {
-    if (!authSession?.access_token) return null;
+    const currentSession = await getCurrentSession();
+    const accessToken = currentSession?.access_token ?? authSession?.access_token;
+    if (!accessToken) {
+      setScriptGenerationError('Your admin session is not available. Refresh the page and sign in again.');
+      return null;
+    }
     try {
       const res = await fetch('/api/admin/sales/generate-step', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${authSession.access_token}` },
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${accessToken}` },
         body: JSON.stringify({
           stepType, audit: auditData || null,
           clientName: contact?.name, clientCompany: contact?.company,
@@ -702,18 +708,34 @@ export default function ConversationPage() {
           contactSubmissionId: contact?.id ? parseInt(contact.id, 10) : null,
         }),
       });
-      if (res.ok) { const d = await res.json(); return d.step; }
-    } catch (err) { console.error('Failed to generate step:', err); }
+      if (res.ok) {
+        const d = await res.json();
+        setScriptGenerationError(null);
+        return d.step;
+      }
+      const errorBody = await res.json().catch(() => null);
+      setScriptGenerationError(errorBody?.error || `Script generation failed with status ${res.status}.`);
+    } catch (err) {
+      console.error('Failed to generate step:', err);
+      setScriptGenerationError('Script generation failed before Portfolio received a response.');
+    }
     return null;
   };
 
   const startCall = async () => {
     setIsLoadingNextStep(true);
-    setConversationState(prev => ({ ...prev, isCallActive: true }));
+    setScriptGenerationError(null);
     const openingStep = await generateStep('opening', []);
     if (openingStep) {
       openingStep.status = 'active';
-      setConversationState(prev => ({ ...prev, dynamicSteps: [openingStep], currentStep: 0 }));
+      setConversationState(prev => ({
+        ...prev,
+        isCallActive: true,
+        dynamicSteps: [openingStep],
+        currentStep: 0,
+      }));
+    } else {
+      setConversationState(prev => ({ ...prev, isCallActive: false, dynamicSteps: [], currentStep: 0 }));
     }
     setIsLoadingNextStep(false);
   };
@@ -782,6 +804,8 @@ export default function ConversationPage() {
     if (newStep) {
       newStep.status = 'active';
       setConversationState(prev => ({ ...prev, dynamicSteps: [...updatedSteps, newStep], currentStep: updatedSteps.length, offersPresented: newOffers }));
+    } else {
+      setConversationState(prev => ({ ...prev, dynamicSteps: updatedSteps, offersPresented: newOffers }));
     }
     setIsLoadingNextStep(false);
   };
@@ -1013,6 +1037,7 @@ export default function ConversationPage() {
                 aiRecommendations={aiRecommendations}
                 isLoadingRecommendations={isLoadingRecommendations}
                 isLoadingNextStep={isLoadingNextStep}
+                generationError={scriptGenerationError}
                 isCallActive={conversationState.isCallActive}
                 onStartCall={startCall}
                 onRefreshRecommendations={refreshRecommendations}

--- a/app/admin/sales/conversation/[sessionId]/page.tsx
+++ b/app/admin/sales/conversation/[sessionId]/page.tsx
@@ -61,6 +61,7 @@ interface ContactInfo {
   name: string;
   email: string;
   company: string | null;
+  message?: string | null;
   phone?: string;
   industry?: string | null;
   employee_count?: string | null;
@@ -272,6 +273,7 @@ export default function ConversationPage() {
             name: lead.name ?? '',
             email: lead.email ?? '',
             company: lead.company ?? null,
+            message: lead.message ?? null,
             phone: lead.phone_number,
             industry: lead.industry ?? null,
             employee_count: lead.employee_count ?? null,
@@ -286,6 +288,7 @@ export default function ConversationPage() {
           name: session.client_name ?? 'Client',
           email: session.client_email ?? '',
           company: session.client_company ?? null,
+          message: null,
         };
       }
       setContact(contactData);
@@ -706,6 +709,8 @@ export default function ConversationPage() {
           availableContent: content.filter(c => c.is_active),
           conversationHistory: conversationState.responseHistory,
           contactSubmissionId: contact?.id ? parseInt(contact.id, 10) : null,
+          contactNotes: contact?.message ?? null,
+          callNotes: notes,
         }),
       });
       if (res.ok) {

--- a/app/api/admin/sales/generate-step/route.test.ts
+++ b/app/api/admin/sales/generate-step/route.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  from: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import { POST } from './route'
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest('http://localhost/api/admin/sales/generate-step', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/admin/sales/generate-step', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({
+      user: { id: 'admin-user-1' },
+      isAdmin: true,
+    })
+    mocks.isAuthError.mockReturnValue(false)
+  })
+
+  it('carries lead and call notes into generated script steps', async () => {
+    const response = await POST(makeRequest({
+      stepType: 'opening',
+      audit: {
+        key_insights: ['manual follow-up is slowing revenue'],
+        business_challenges: { primary_challenges: ['missed lead follow-up'] },
+      },
+      clientName: 'Amina',
+      clientCompany: 'Northstar Studio',
+      previousSteps: [],
+      availableContent: [],
+      conversationHistory: [],
+      contactNotes: 'Mentioned they need a lighter first engagement.',
+      callNotes: 'Prefers examples tied to missed consultations.',
+    }))
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.step.talkingPoints).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('Contact: Mentioned they need a lighter first engagement.'),
+        expect.stringContaining('Call: Prefers examples tied to missed consultations.'),
+      ])
+    )
+    expect(body.step.suggestedActions).toContain(
+      'Use the contact and call notes when choosing language, examples, and next questions'
+    )
+  })
+})

--- a/app/api/admin/sales/generate-step/route.ts
+++ b/app/api/admin/sales/generate-step/route.ts
@@ -65,6 +65,10 @@ interface GenerateStepRequest {
   conversationHistory: ConversationResponse[];
   /** When set, value evidence (pain points + dollar impact) is fetched and used in script steps */
   contactSubmissionId?: number | null;
+  /** Lead/contact notes captured before or outside this sales session */
+  contactNotes?: string | null;
+  /** Current sales-session notes captured in the call workspace */
+  callNotes?: string | null;
 }
 
 export async function POST(request: NextRequest) {
@@ -88,6 +92,8 @@ export async function POST(request: NextRequest) {
       availableContent,
       conversationHistory,
       contactSubmissionId,
+      contactNotes,
+      callNotes,
     } = body;
 
     // Fetch value evidence for this contact so script steps can reference quantified pain and value
@@ -176,6 +182,8 @@ export async function POST(request: NextRequest) {
       availableProducts: products,
       conversationHistory,
       valueEvidenceSummary,
+      contactNotes,
+      callNotes,
     });
 
     return NextResponse.json({ step });
@@ -196,6 +204,8 @@ function generateStep(context: GenerateStepRequest & { valueEvidenceSummary?: st
     chosenStrategy,
     availableProducts,
     valueEvidenceSummary,
+    contactNotes,
+    callNotes,
   } = context;
 
   const stepNumber = previousSteps.length + 1;
@@ -216,6 +226,7 @@ function generateStep(context: GenerateStepRequest & { valueEvidenceSummary?: st
   const urgency = audit?.urgency_score || 5;
   const opportunity = audit?.opportunity_score || 5;
   const keyInsights = audit?.key_insights || [];
+  const operatorNotes = formatOperatorNotes(contactNotes, callNotes);
 
   // Get products by role
   const products = availableProducts || [];
@@ -485,6 +496,11 @@ function generateStep(context: GenerateStepRequest & { valueEvidenceSummary?: st
       suggestedActions = ['Listen actively and ask follow-up questions.'];
   }
 
+  if (operatorNotes.length > 0) {
+    talkingPoints.push(...operatorNotes.map(note => `[Operator note to incorporate: ${note}]`));
+    suggestedActions.push('Use the contact and call notes when choosing language, examples, and next questions');
+  }
+
   return {
     id: stepId,
     stepNumber,
@@ -499,6 +515,18 @@ function generateStep(context: GenerateStepRequest & { valueEvidenceSummary?: st
       : undefined,
     status: 'pending',
   };
+}
+
+function formatOperatorNotes(contactNotes?: string | null, callNotes?: string | null): string[] {
+  return [
+    ['Contact', contactNotes],
+    ['Call', callNotes],
+  ].flatMap(([label, value]) => {
+    if (typeof value !== 'string') return [];
+    const trimmed = value.replace(/\s+/g, ' ').trim();
+    if (!trimmed) return [];
+    return [`${label}: ${trimmed.slice(0, 600)}`];
+  });
 }
 
 function getObjectionContext(

--- a/app/api/admin/sales/route.ts
+++ b/app/api/admin/sales/route.ts
@@ -11,6 +11,7 @@ type ContactRow = {
   name: string | null;
   email: string | null;
   company: string | null;
+  message: string | null;
   industry: string | null;
   employee_count: string | null;
   created_at: string | null;
@@ -134,7 +135,7 @@ export async function GET(request: NextRequest) {
     // 3. Fetch contacts
     const { data: contacts, error: contactsError } = await supabaseAdmin
       .from('contact_submissions')
-      .select('id, name, email, company, industry, employee_count, created_at')
+      .select('id, name, email, company, message, industry, employee_count, created_at')
       .in('id', allContactIds);
 
     if (contactsError) {
@@ -276,7 +277,7 @@ export async function GET(request: NextRequest) {
         opportunity_score: a.opportunity_score,
         created_at: a.created_at,
         contact_submissions: contact
-          ? { id: contact.id, name: contact.name, email: contact.email, company: contact.company, created_at: contact.created_at }
+          ? { id: contact.id, name: contact.name, email: contact.email, company: contact.company, message: contact.message, created_at: contact.created_at }
           : null,
         sales_session: session
           ? { diagnostic_audit_id: session.diagnostic_audit_id, outcome: session.outcome, next_follow_up: session.next_follow_up, funnel_stage: session.funnel_stage }

--- a/components/admin/sales/DynamicScriptFlow.tsx
+++ b/components/admin/sales/DynamicScriptFlow.tsx
@@ -36,6 +36,7 @@ interface DynamicScriptFlowProps {
   aiRecommendations: AIRecommendation[];
   isLoadingRecommendations: boolean;
   isLoadingNextStep: boolean;
+  generationError?: string | null;
   isCallActive: boolean;
   onStartCall: () => void;
   onRefreshRecommendations: () => void;
@@ -50,6 +51,7 @@ export function DynamicScriptFlow({
   aiRecommendations,
   isLoadingRecommendations,
   isLoadingNextStep,
+  generationError,
   isCallActive,
   onStartCall,
   onRefreshRecommendations,
@@ -72,12 +74,18 @@ export function DynamicScriptFlow({
           Click below to generate your personalized opening based on the client&apos;s diagnostic data.
           The script will adapt to their responses throughout the conversation.
         </p>
+        {generationError && (
+          <div className="max-w-md mx-auto mb-4 rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+            {generationError}
+          </div>
+        )}
         <button
           onClick={onStartCall}
-          className="px-6 py-3 bg-emerald-600 text-white rounded-lg font-medium hover:bg-emerald-700 transition-colors flex items-center gap-2 mx-auto"
+          disabled={isLoadingNextStep}
+          className="px-6 py-3 bg-emerald-600 text-white rounded-lg font-medium hover:bg-emerald-700 transition-colors flex items-center gap-2 mx-auto disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          <Play className="w-5 h-5" />
-          Start Dynamic Script
+          {isLoadingNextStep ? <RefreshCw className="w-5 h-5 animate-spin" /> : <Play className="w-5 h-5" />}
+          {generationError ? 'Retry Dynamic Script' : 'Start Dynamic Script'}
         </button>
       </div>
     );
@@ -90,6 +98,27 @@ export function DynamicScriptFlow({
         <RefreshCw className="w-10 h-10 text-purple-400 animate-spin mx-auto mb-4" />
         <h3 className="text-lg font-medium text-white mb-2">Generating Your Opening...</h3>
         <p className="text-gray-400">Analyzing diagnostic data to create personalized talking points</p>
+      </div>
+    );
+  }
+
+  if (isCallActive && steps.length === 0) {
+    return (
+      <div className="text-center py-12">
+        <div className="w-20 h-20 mx-auto mb-4 bg-red-500/20 rounded-full flex items-center justify-center">
+          <RefreshCw className="w-10 h-10 text-red-300" />
+        </div>
+        <h3 className="text-lg font-medium text-white mb-2">Script could not start</h3>
+        <p className="text-gray-400 mb-4 max-w-md mx-auto">
+          {generationError || 'The opening step did not return. Retry after refreshing the admin session.'}
+        </p>
+        <button
+          onClick={onStartCall}
+          disabled={isLoadingNextStep}
+          className="px-4 py-2 bg-emerald-600 text-white rounded-lg font-medium hover:bg-emerald-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Retry
+        </button>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- Keeps the dynamic sales script inactive until the opening step is actually generated, preventing the blank "Step 1 of 0" state when script generation fails.
- Surfaces script generation failures in the Script Guide with a retry path instead of silently swallowing failed API responses.
- Uses a freshly restored Supabase session token for conversation script generation so expired provider state is less likely to break the process.
- Carries lead/contact notes from contact_submissions.message and current call notes from sales_sessions.internal_notes into generated script steps.

## Validation
- npm run build:knowledge
- npx tsc --noEmit --pretty false --skipLibCheck
- npm test -- --run app/api/admin/sales/generate-step/route.test.ts app/api/admin/sales/in-person-diagnostic/generate-insights/route.test.ts
- npm run lint
- git diff --check

## Integration Notes
- No database migrations or environment changes.
- Root Portfolio checkout had unrelated dirty subscription docs and local .codex artifacts, so this repair was isolated in /Users/vambahsillah/Projects/Portfolio.worktrees/repair-sales-script-process.
- Vercel contexts not checked in this non-captain repair lane: Vercel - portfolio and Vercel - portfolio-staging remain captain/deploy gates.
