### PR TITLE
docs: update subscription monitor status

### DIFF
--- a/docs/subscription-cancellation-audit.md
+++ b/docs/subscription-cancellation-audit.md
@@ -10,6 +10,172 @@ no meaningful usage signal, or after clear redundancy plus a lower-risk
 replacement path. Production changes require explicit approval in the form
 `Cancel <tool/vendor> for Portfolio`.
 
+## 2026-05-15 Daily Monitor Run
+
+Status: YELLOW
+
+Summary:
+
+- No cancellation approvals requested and no cancellation action taken.
+- The checkout at `/Users/vambahsillah/Projects/Portfolio` was on `codex/agent-ops-paper-parity` with the upstream branch reported as gone. Existing dirty subscription tracker changes from the 2026-05-14 run were present, plus untracked `.codex/` and `.codex_tmp/`; this run preserved those unrelated local items and only updated the subscription tracker, automation memory, and sanitized pending notification.
+- Core runtime signals moved again: Supabase production `agent_runs` increased to 56 with the latest row at 2026-05-14T14:15:45Z, `analytics_events` increased to 5049 with the latest row at 2026-05-14T18:45:34Z, and n8n Cloud reported 77 workflows, 72 active workflows, and a successful execution started at 2026-05-15T12:00:52Z.
+- Stripe remains a live revenue dependency: checkout sessions, charges, and payment intents were readable; the latest sampled charge/payment intent remained paid/succeeded on 2026-04-06, and the latest sampled checkout session remained a paid completed payment-mode session from 2026-02-23.
+- No vendor crossed the cancellation threshold. OpenRouter returned zero current-key usage again, and Vapi returned no calls in the current default call sample, but neither has confirmed active spend plus an approved replacement/deprecation packet.
+- Apify account evidence improved slightly: Starter plan remains visible and the latest account-level actor run sample was a succeeded run started 2026-05-13. Actor-level weak surfaces still need pause/replace work before any account-level cancellation decision.
+- BuiltWith remains a protected watch item during the outreach/client-volume ramp. Fireflies remains resolved as canceled per Vambah's 2026-05-01 confirmation unless new paid-plan evidence appears.
+
+Raw Findings
+
+- Prior automation memory file was missing at `$CODEX_HOME/automations/portfolio-subscription-cancellation-monitor/memory.md`; this run creates it. The durable tracker and admin status JSON were used as continuity state.
+- Action tracker feedback reported 21 open actions for `portfolio-subscription-cancellation-monitor`, with no in-progress, blocked, done, or progress-note signals. No completed or dismissed action was re-raised from tracker feedback.
+- Read-only provider checks ran at 2026-05-15T12:34Z. Secret values, raw account payloads, and raw logs are not included in this report.
+- Supabase production aggregates: `analytics_events` 5049, `meeting_records` 110, `orders` 26, `gamma_reports` 6, `social_content_queue` 29, `drive_video_queue` 35, `email_messages` 9, `documents_local_rag` 3434, `printful_sync_log` 0, `cost_events` 21, `video_generation_jobs` 4, `diagnostic_audits` 29, `outreach_queue` 9, `contact_submissions` 268, and `agent_runs` 56.
+- Supabase latest usage signals: latest `analytics_events` row at 2026-05-14, latest `agent_runs` row at 2026-05-14, latest `cost_events` row remains 2026-05-14, latest Gamma report remains 2026-05-02, latest social content row remains 2026-05-07, latest video generation job remains 2026-04-15, latest meeting record remains 2026-05-06, and `printful_sync_log` remains empty.
+- n8n Cloud API: the older `N8N_API_KEY` returned 403 again, but `N8N_CLOUD_API_KEY` was valid and returned 77 workflows, 72 active workflows, and a successful execution started at 2026-05-15T12:00:52Z.
+- Vercel CLI authentication was available; the current CLI no longer accepted `vercel ls <project> --json`, but plain `vercel ls portfolio` and `vercel ls portfolio-staging` returned current deployment URLs for both projects.
+- Stripe API: checkout sessions, charges, and payment intents were readable. Latest sampled charge was created 2026-04-06T19:37:14Z with paid/succeeded status; latest sampled payment intent was created 2026-04-06T19:35:48Z with succeeded status; latest sampled checkout session was created 2026-02-23T21:05:32Z with `payment` mode, `paid` payment status, and `complete` status.
+- Apify API: account still reports Starter; latest account-level actor run sample returned a succeeded run started 2026-05-13T13:01:31Z. The prior actor-level sample through 2026-05-06 remains the current replacement-analysis evidence.
+- ElevenLabs API: subscription remains active on Creator with 18,068 of 164,102 characters used; next character reset remains 2026-05-19T18:38:26Z.
+- OpenRouter API: current key again reports zero usage.
+- Vapi API: default calls sample returned 200 with zero calls; prior visible call evidence remains the 2026-04-30 `webCall`.
+- Pinecone API: one ready serverless index named `publications` exists in `aws/us-east-1`.
+- Printful API: two native stores remain visible; `printful_sync_log` remains empty.
+- Hunter.io API: account remains Free with 75 available calls.
+- HeyGen API: avatar catalog listing returned successfully with 1289 avatars; quota/billing still needs dashboard verification.
+- Slack bot auth was readable. OpenAI and Anthropic model-list endpoints were readable. Gemini model-list check returned 403. Gamma key was present locally, but no safe billing/usage endpoint was checked. Resend key was absent locally.
+- Read AI and Calendly direct checks both returned 401 again.
+- Local reference counts, excluding subscription tracker files: Supabase 4873, n8n 4629, Vercel 639, Stripe 638, OpenAI 811, Anthropic 273, Gamma 1222, HeyGen 724, Read.ai/Read AI 379, Vapi 332, Printful 504, Resend 146, Pinecone 317, BuiltWith 248, Fireflies 1, Apify 375, Hunter 65, OpenRouter 99, ElevenLabs 157, Calendly 584, Slack 1620, Gmail 546, Gemini 88, Google Cloud 23, Perplexity 54, Figma 2, Paper 23, Excalidraw 4, and Canva 2.
+- Local n8n export node footprint includes 90 Supabase nodes, 98 Slack nodes, 36 OpenAI nodes, 29 Gmail nodes, 29 Google nodes, 21 Apify nodes, 8 OpenRouter nodes, 6 Pinecone nodes, 37 Calendly references, 12 Stripe references, 4 Anthropic references, 5 Perplexity references, 3 Gemini references, 7 HeyGen references, 6 Hunter references, and 1 ElevenLabs reference.
+
+Derived Movement Since Prior Run
+
+| Tool/vendor | Latest evidence | Inactivity status | Recommendation |
+| --- | --- | --- | --- |
+| Supabase | `agent_runs` increased from 47 to 56; `analytics_events` increased from 5041 to 5049 | Active | Keep |
+| n8n Cloud | Successful execution on 2026-05-15 with 72 active workflows | Active | Keep; retire/replace stale `N8N_API_KEY` if safe |
+| Vercel | CLI authenticated; plain deployment listings returned URLs for both projects | Active hosting | Keep |
+| Stripe | Latest sampled charge/payment intent remains succeeded on 2026-04-06 | Revenue dependency | Keep |
+| OpenAI | Model list readable; code/cost/event references remain | Active | Keep; continue cost monitoring |
+| Anthropic | Model list readable; code and n8n fallback/eval references remain | Watch | Decide after next receipt/bakeoff refresh |
+| Gamma | Latest report remains 2026-05-02; admin/report code active | Active enough | Keep; watch deck alternatives |
+| HeyGen | Avatar API works; billing/quota still not API-verified | Campaign-dependent active | Keep; verify dashboard quota/billing |
+| Read.ai | Direct API check returned 401 again; meeting rows/docs remain | Auth unresolved | Keep; refresh auth |
+| BuiltWith | Protected outreach-ramp decision remains | Protected watch | Keep during outreach/client-volume ramp |
+| Fireflies.ai | No new paid evidence; previously confirmed canceled | Resolved canceled | Keep out of active queue |
+| Vapi | Default call sample returned zero calls; prior visible call remains 2026-04-30 | Quiet | Investigate billing/voice UX |
+| Printful | Two API stores visible; `printful_sync_log` still empty | Quiet sync | Investigate store/order strategy |
+| Resend | Local key absent; optional code/env references remain | Usage unresolved | Verify Vercel env/billing before deciding |
+| Pinecone | Ready `publications` serverless index remains | Active infrastructure exists | Investigate billing/API traffic |
+| Hunter.io | API reports Free plan with 75 available calls | Not a paid cancellation target | Keep/watch |
+| OpenRouter | Zero current-key usage again | Consecutive quiet key evidence | Watch; prepare deprecation packet only after bakeoff |
+| Apify | Starter plan; latest account-level run sample 2026-05-13 and prior actor evidence through 2026-05-06 | Account active, actor-level mixed | Keep; pause/replace weak actor surfaces first |
+| ElevenLabs | Active Creator subscription; reset date 2026-05-19 | Paid, low recent movement | Review before renewal against campaign plan |
+| Calendly | Direct API check returned 401 again; scheduling references remain | Auth unresolved | Refresh token; keep |
+| Gemini / Google AI | Repo/n8n references remain; model-list check returned 403 | Auth/config unresolved | Investigate key/project status before relying on it |
+| Slack | Bot auth readable; Slack/n8n references remain heavy | Active integration | Keep |
+
+Candidate Cancellations
+
+- **No automatic cancellation.**
+- **No current vendor meets the cancellation threshold in this daily run.**
+- OpenRouter, Vapi, Printful, Pinecone, Resend, Read.ai auth, Calendly auth, Gemini auth, and ElevenLabs remain decision/investigation items, not approved cancellation actions.
+- No approval phrase was given in this run.
+
+Next Audit Focus
+
+- Refresh Read AI and Calendly auth before using those providers as usage evidence.
+- Retire or rotate the stale n8n API key only after confirming which runtime still references it; `N8N_CLOUD_API_KEY` is the working read-only evidence path.
+- Confirm OpenRouter's role in the next media/model bakeoff; if unused again and no active spend exists, prepare a deprecation packet rather than canceling automatically.
+- Verify whether Resend exists in Vercel production env or billing, and whether Gmail/n8n is the only real outbound path.
+- Confirm Vapi dashboard billing and whether production voice UX is intended to stay enabled.
+- Check Pinecone billing/API traffic and compare with the Supabase/local RAG replacement path.
+- Check Printful dashboard/order history and decide whether both stores remain strategically active.
+- Check Gemini/Google AI key and project status before depending on Gemini image/social workflows.
+- Review ElevenLabs renewal before 2026-05-19T18:38:26Z against the next planned social/audio/video campaign.
+- Continue the Apify actor-level replacement bakeoff by pausing or replacing weak actor surfaces before considering account-level changes.
+
+## 2026-05-14 Daily Monitor Run
+
+Status: YELLOW
+
+Summary:
+
+- No cancellation approvals requested and no cancellation action taken.
+- The checkout at `/Users/vambahsillah/Projects/Portfolio` was clean on `codex/agent-ops-paper-parity` tracking `origin/codex/agent-ops-paper-parity`; no unrelated dirty work needed preservation. Because the checkout was not `main`, this run kept changes limited to the existing subscription tracker files.
+- Core runtime signals moved again: Supabase production `agent_runs` increased to 47 with the latest row at 2026-05-14T01:13:06Z, `cost_events` increased to 21 with the latest row at 2026-05-14T01:13:20Z, and n8n Cloud reported 77 workflows, 72 active workflows, and a successful execution started at 2026-05-14T12:00:52Z.
+- Stripe remains a live revenue dependency: checkout sessions, charges, and payment intents were readable; the latest sampled charge was paid/succeeded on 2026-04-06, and the latest sampled checkout session remains a paid completed payment-mode session from 2026-02-23.
+- No vendor crossed the cancellation threshold. OpenRouter has another zero-usage current-key signal, but there is still no confirmed active spend and no approved model-routing replacement/deprecation packet, so it remains watch/investigate rather than cancel.
+- Vapi, Printful, Pinecone, Resend, Read.ai auth, Calendly auth, and ElevenLabs renewal timing remain the unresolved decision queue. They need dashboard, billing-owner, or replacement-path evidence before any cancellation/deprecation packet is safe.
+- BuiltWith remains a protected watch item during the outreach/client-volume ramp. Fireflies remains resolved as canceled per Vambah's 2026-05-01 confirmation unless new paid-plan evidence appears.
+
+Raw Findings
+
+- Prior automation memory file was missing at `$CODEX_HOME/automations/portfolio-subscription-cancellation-monitor/memory.md`; it is being created by this run. The durable tracker and admin status JSON were used as continuity state.
+- Action tracker feedback reported 21 open actions for `portfolio-subscription-cancellation-monitor`, with no in-progress, blocked, done, or progress-note signals. No completed or dismissed action was re-raised from tracker feedback.
+- Read-only provider checks ran at 2026-05-14T12:34Z. Secret values, raw account payloads, and raw logs are not included in this report.
+- Supabase production aggregates: `analytics_events` 5041, `meeting_records` 110, `orders` 26, `gamma_reports` 6, `social_content_queue` 29, `drive_video_queue` 35, `email_messages` 9, `documents_local_rag` 3434, `printful_sync_log` 0, `cost_events` 21, `video_generation_jobs` 4, `diagnostic_audits` 29, `outreach_queue` 9, `contact_submissions` 268, and `agent_runs` 47.
+- Supabase latest usage signals: latest `agent_runs` row at 2026-05-14, latest `cost_events` row at 2026-05-14, latest `analytics_events` row at 2026-05-13, latest Gamma report remains 2026-05-02, latest social content row remains 2026-05-07, latest video generation job remains 2026-04-15, latest meeting record remains 2026-05-06, and `printful_sync_log` remains empty.
+- n8n Cloud API: the older `N8N_API_KEY` returned 403, but `N8N_CLOUD_API_KEY` was valid and returned 77 workflows, 72 active workflows, and a successful execution started at 2026-05-14T12:00:52Z.
+- Vercel CLI authentication was available as `vsillah`; listing returned current deployment URLs for both `portfolio` and `portfolio-staging`.
+- Stripe API: account-level KYC read was blocked by restricted-key permissions, but checkout sessions, charges, and payment intents were readable. Latest sampled charge was created 2026-04-06T19:37:14Z with paid/succeeded status; latest sampled payment intent was created 2026-04-06T19:35:48Z with succeeded status; latest sampled checkout session was created 2026-02-23T21:05:32Z with `payment` mode, `paid` payment status, and `complete` status.
+- Apify API: account still reports Starter; latest account-level actor run sample returned a succeeded run from 2026-04-13. The prior actor-level sample through 2026-05-06 remains the current replacement-analysis evidence.
+- ElevenLabs API: subscription remains active on Creator with 18,068 of 164,102 characters used; next character reset returned 2026-05-19T18:38:26Z.
+- OpenRouter API: current key again reports zero usage.
+- Vapi API: latest returned call remains a 2026-04-30 `webCall` with ended status.
+- Pinecone API: one ready serverless index named `publications` exists in `aws/us-east-1`.
+- Printful API: two native stores remain visible; `printful_sync_log` remains empty.
+- Hunter.io API: account remains Free with 75 available calls and reset date 2026-06-09.
+- HeyGen API: avatar catalog listing returned successfully with 1289 avatars; quota/billing still needs dashboard verification.
+- Slack bot auth was readable. OpenAI and Anthropic model-list endpoints were readable. Gamma key was present locally, but no safe billing/usage endpoint was checked. Resend key was absent locally.
+- Read AI and Calendly direct checks both returned 401 again.
+- Local reference counts, excluding subscription tracker files: Supabase 3481, n8n 3393, Vercel 557, Stripe 470, OpenAI 687, Anthropic 221, Gamma 835, HeyGen 567, Read.ai/Read AI 145, Vapi 111, Printful 317, Resend 127, Pinecone 236, BuiltWith 184, Fireflies 1, Apify 249, Hunter 26, OpenRouter 86, ElevenLabs 95, Calendly 403, Slack 1252, Gmail 434, Gemini 51, Google Cloud 20, and Perplexity 42.
+- Local n8n export node footprint includes 60 Supabase nodes, 40 Slack nodes, 25 OpenAI/OpenAI-chat nodes, 17 Gmail/Gmail-trigger nodes, 12 Google Drive/Docs/Sheets nodes, 4 OpenRouter chat nodes, 5 Apify nodes, 3 Pinecone vector-store nodes, 2 Calendly triggers, 1 Stripe trigger, 1 Slack trigger, 1 Anthropic node, and 3 Perplexity tool nodes.
+
+Derived Movement Since Prior Run
+
+| Tool/vendor | Latest evidence | Inactivity status | Recommendation |
+| --- | --- | --- | --- |
+| Supabase | `agent_runs` increased from 36 to 47; `cost_events` increased from 14 to 21 | Active | Keep |
+| n8n Cloud | Successful execution on 2026-05-14 with 72 active workflows | Active | Keep; retire/replace stale `N8N_API_KEY` if safe |
+| Vercel | CLI authenticated; deployment URLs listed for both projects | Active hosting | Keep |
+| Stripe | Latest sampled charge/payment intent succeeded on 2026-04-06 | Revenue dependency | Keep |
+| OpenAI | Model list readable; code/cost/event references remain | Active | Keep; continue cost monitoring |
+| Anthropic | Model list readable; code and n8n fallback/eval references remain | Watch | Decide after next receipt/bakeoff refresh |
+| Gamma | Latest report remains 2026-05-02; admin/report code active | Active enough | Keep; watch deck alternatives |
+| HeyGen | Avatar API works; billing/quota still not API-verified | Campaign-dependent active | Keep; verify dashboard quota/billing |
+| Read.ai | Direct API check returned 401 again; meeting rows/docs remain | Auth unresolved | Keep; refresh auth |
+| BuiltWith | Protected outreach-ramp decision remains | Protected watch | Keep during outreach/client-volume ramp |
+| Fireflies.ai | No new paid evidence; previously confirmed canceled | Resolved canceled | Keep out of active queue |
+| Vapi | Latest API-visible call remains 2026-04-30 | Quiet | Investigate billing/voice UX |
+| Printful | Two API stores visible; `printful_sync_log` still empty | Quiet sync | Investigate store/order strategy |
+| Resend | Local key absent; optional code/env references remain | Usage unresolved | Verify Vercel env/billing before deciding |
+| Pinecone | Ready `publications` serverless index remains | Active infrastructure exists | Investigate billing/API traffic |
+| Hunter.io | API reports Free plan | Not a paid cancellation target | Keep/watch |
+| OpenRouter | Zero current-key usage again | Consecutive quiet key evidence | Watch; prepare deprecation packet only after bakeoff |
+| Apify | Starter plan; latest account-level run sample 2026-04-13 and prior actor evidence through 2026-05-06 | Account active, actor-level mixed | Keep; pause/replace weak actor surfaces first |
+| ElevenLabs | Active Creator subscription; reset date 2026-05-19 | Paid, low recent movement | Review before renewal against campaign plan |
+| Calendly | Direct API check returned 401 again; scheduling references remain | Auth unresolved | Refresh token; keep |
+| Slack | Bot auth readable; Slack/n8n references remain heavy | Active integration | Keep |
+
+Candidate Cancellations
+
+- **No automatic cancellation.**
+- **No current vendor meets the cancellation threshold in this daily run.**
+- OpenRouter, Vapi, Printful, Pinecone, Resend, Read.ai auth, Calendly auth, and ElevenLabs remain decision/investigation items, not approved cancellation actions.
+- No approval phrase was given in this run.
+
+Next Audit Focus
+
+- Refresh Read AI and Calendly auth before using those providers as usage evidence.
+- Retire or rotate the stale n8n API key only after confirming which runtime still references it; `N8N_CLOUD_API_KEY` is the working read-only evidence path.
+- Confirm OpenRouter's role in the next media/model bakeoff; if unused again and no active spend exists, prepare a deprecation packet rather than canceling automatically.
+- Verify whether Resend exists in Vercel production env or billing, and whether Gmail/n8n is the only real outbound path.
+- Confirm Vapi dashboard billing and whether production voice UX is intended to stay enabled.
+- Check Pinecone billing/API traffic and compare with the Supabase/local RAG replacement path.
+- Check Printful dashboard/order history and decide whether both stores remain strategically active.
+- Review ElevenLabs renewal before 2026-05-19T18:38:26Z against the next planned social/audio/video campaign.
+- Continue the Apify actor-level replacement bakeoff by pausing or replacing weak actor surfaces before considering account-level changes.
+
 ## 2026-05-13 Daily Monitor Run
 
 Status: YELLOW

--- a/docs/subscription-status.json
+++ b/docs/subscription-status.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-13",
+  "generatedAt": "2026-05-15",
   "sourceDocument": "/docs/subscription-cancellation-audit.md",
   "weeklyReportAutomationId": "portfolio-subscription-weekly-report",
   "dailyMonitorAutomationId": "portfolio-subscription-cancellation-monitor",
@@ -25,7 +25,9 @@
       "2026-05-11 weekly refresh kept the budget status yellow: n8n, Supabase, and Vercel showed fresh operational movement; no vendor crossed the cancellation threshold.",
       "2026-05-12 daily refresh kept the budget status yellow: n8n and Supabase moved again, Vercel project metadata did not refresh from CLI output, and no vendor crossed the cancellation threshold.",
       "2026-05-13 daily refresh kept the budget status yellow: n8n, Supabase, Vercel, Stripe, and HeyGen had live read-only signals; OpenRouter stayed zero-usage and no vendor crossed the cancellation threshold.",
-      "Cancellation remains approval-gated; this budget view is read-only."
+      "Cancellation remains approval-gated; this budget view is read-only.",
+      "2026-05-14 daily refresh kept the budget status yellow: Supabase, n8n, Stripe, Slack, OpenAI, and Anthropic had live read-only signals; OpenRouter stayed zero-usage, Vapi stayed quiet since 2026-04-30, Read.ai/Calendly auth remained blocked, and no vendor crossed the cancellation threshold.",
+      "2026-05-15 daily refresh kept the budget status yellow: Supabase, n8n, Stripe, Slack, OpenAI, Anthropic, Apify, HeyGen, Pinecone, Printful, and ElevenLabs had live read-only signals; OpenRouter stayed zero-usage, Vapi returned no current sampled calls, Read.ai/Calendly auth remained blocked, Gemini returned 403, and no vendor crossed the cancellation threshold."
     ],
     "transitionAdjustments": [
       {
@@ -37,7 +39,7 @@
     ],
     "apifyCallAnalysis": {
       "configuredActorSurfaces": 12,
-      "lastMonitorExecution": "Direct provider refresh on 2026-05-13 still reports Apify STARTER; prior actor sample through 2026-05-06 remains the active replacement-analysis evidence.",
+      "lastMonitorExecution": "Direct provider refresh on 2026-05-15 still reports Apify STARTER; latest account-level run sample was 2026-05-13, and prior actor sample through 2026-05-06 remains the active replacement-analysis evidence.",
       "sampledRuns": 59,
       "succeededRuns": 40,
       "failedRuns": 19,
@@ -330,14 +332,16 @@
   },
   "summary": {
     "status": "yellow",
-    "headline": "Daily refresh: n8n, Supabase, Vercel, Stripe, and HeyGen showed live signals; quiet watch items stayed gated and no vendor reached the cancellation threshold.",
+    "headline": "Daily refresh: Supabase, n8n, Stripe, Slack, OpenAI, Anthropic, Apify, HeyGen, Pinecone, Printful, and ElevenLabs showed live readable signals; quiet watch items stayed gated and no vendor reached the cancellation threshold.",
     "nextReviewFocus": [
       "Refresh Read AI and Calendly auth before using those providers as usage evidence.",
+      "Retire or rotate the stale n8n API key only after confirming which runtime still references it.",
       "Confirm OpenRouter's role in the next media/model bakeoff before preparing any deprecation packet.",
       "Verify whether Resend exists in Vercel production env or billing.",
       "Confirm Vapi dashboard billing and intended production voice UX.",
       "Check Pinecone billing/API traffic against Supabase/local RAG.",
       "Check Printful dashboard order history and active store strategy.",
+      "Check Gemini/Google AI key and project status after the model-list check returned 403.",
       "Review ElevenLabs renewal before 2026-05-19 against the next planned campaign.",
       "Continue the Apify actor-level replacement bakeoff by pausing weak surfaces before account-level changes."
     ]
@@ -373,7 +377,8 @@
       "Resend",
       "Pinecone",
       "Read.ai auth",
-      "Calendly auth"
+      "Calendly auth",
+      "Gemini auth"
     ],
     "resolvedCanceled": [
       "Fireflies.ai"
@@ -387,7 +392,8 @@
       "Anthropic",
       "Read.ai",
       "Calendly",
-      "ElevenLabs"
+      "ElevenLabs",
+      "Gemini / Google AI"
     ]
   },
   "vendors": [
@@ -395,8 +401,8 @@
       "name": "Vapi",
       "status": "watch",
       "statusColor": "yellow",
-      "billingSignal": "Dashboard billing still needs verification; direct API returned the same 2026-04-30 call and no newer sampled calls in the 2026-05-13 refresh.",
-      "usageSignal": "Vapi Calls API returned a webCall created on 2026-04-30; code/env/webhook references remain.",
+      "billingSignal": "Dashboard billing still needs verification; direct API returned zero calls in the default 2026-05-15 sample; prior visible call remains 2026-04-30.",
+      "usageSignal": "Vapi Calls API returned no current sampled calls; prior visible evidence remains a 2026-04-30 webCall and code/env/webhook references remain.",
       "portfolioDependency": "Voice/audit experience risk if production voice UX is enabled.",
       "recommendation": "Investigate billing and intended voice UX; no cancellation action without a dashboard/billing decision.",
       "nextAction": "Check Vapi dashboard billing and decide whether the voice path should stay enabled.",
@@ -413,7 +419,7 @@
       "status": "watch",
       "statusColor": "yellow",
       "billingSignal": "Receipts found on 2026-04-10 in the prior billing pass.",
-      "usageSignal": "Local repo references remain active and the protected outreach-ramp watch decision still applies; 2026-05-12 repo scan found 189 non-tracker references.",
+      "usageSignal": "Local repo references remain active and the protected outreach-ramp watch decision still applies; 2026-05-15 repo scan found 248 non-tracker references.",
       "portfolioDependency": "Tech-stack lookup/enrichment supports lead prep, implementation strategy, and feasibility assessment.",
       "recommendation": "Keep active during outreach ramp; reassess after more leads, audits, proposals, and client outcomes.",
       "nextAction": "Compare outcomes where BuiltWith enrichment improves sales preparation or proposal quality.",
@@ -434,7 +440,7 @@
       "status": "resolved_canceled",
       "statusColor": "green",
       "billingSignal": "Refund found on 2026-03-20; Vambah confirmed canceled on 2026-05-01.",
-      "usageSignal": "No new paid-plan evidence appeared in this run.",
+      "usageSignal": "No new paid-plan evidence appeared in the 2026-05-15 audit.",
       "portfolioDependency": "No direct Portfolio repo integration found in the latest audit.",
       "recommendation": "Keep out of active cancellation queue unless new paid-plan evidence appears.",
       "nextAction": "No action unless a new Fireflies receipt or paid-plan signal appears.",
@@ -451,7 +457,7 @@
       "status": "keep",
       "statusColor": "green",
       "billingSignal": "Prior receipt evidence remains; CLI access is authenticated as vsillah.",
-      "usageSignal": "2026-05-13 project metadata refreshed for portfolio and portfolio-staging, with latest sampled deployments READY at 2026-05-13T12:29:19Z.",
+      "usageSignal": "2026-05-15 plain CLI listing returned current deployment URLs for both portfolio and portfolio-staging; the CLI no longer accepted the prior --json listing flag.",
       "portfolioDependency": "High-risk hosting/deployment dependency.",
       "recommendation": "Keep; operationally active hosting/deployment dependency.",
       "nextAction": "Keep deployment monitoring and billing-owner documentation current.",
@@ -468,7 +474,7 @@
       "status": "unresolved",
       "statusColor": "yellow",
       "billingSignal": "Likely usage/order based; no fixed subscription evidence confirmed.",
-      "usageSignal": "Printful API returned two native stores again; one historical Printful-linked order exists; printful_sync_log remains empty in the 2026-05-13 Supabase refresh.",
+      "usageSignal": "Printful API returned two native stores again; one historical Printful-linked order exists; printful_sync_log remains empty in the 2026-05-15 Supabase refresh.",
       "portfolioDependency": "Store fulfillment and merchandise sync risk.",
       "recommendation": "Investigate dashboard order history and merchandise strategy before any deprecation decision.",
       "nextAction": "Check Printful dashboard/store order history and whether both stores remain active.",
@@ -484,7 +490,7 @@
       "name": "Resend",
       "status": "unresolved",
       "statusColor": "yellow",
-      "billingSignal": "No live key or billing evidence confirmed in this run; local RESEND_API_KEY was absent and Vercel env listing did not return sanitized env names.",
+      "billingSignal": "No live key or billing evidence confirmed in this run; local RESEND_API_KEY was absent.",
       "usageSignal": "Optional transactional provider remains in env templates/code, but latest production email evidence still points to n8n/Gmail-era transport.",
       "portfolioDependency": "Transactional email delivery risk if production is configured to use Resend.",
       "recommendation": "Verify production env and billing before keeping as a paid dependency or removing.",
@@ -501,7 +507,7 @@
       "name": "Pinecone",
       "status": "unresolved",
       "statusColor": "yellow",
-      "billingSignal": "Billing/API traffic not confirmed; direct API showed active infrastructure again on 2026-05-13.",
+      "billingSignal": "Billing/API traffic not confirmed; direct API showed active infrastructure again on 2026-05-15.",
       "usageSignal": "One ready serverless publications index exists in aws/us-east-1; n8n RAG references and local/Supabase RAG rows also remain.",
       "portfolioDependency": "RAG/vector-store workflow risk.",
       "recommendation": "Investigate billing/API traffic and compare with Supabase/local RAG replacement path.",
@@ -518,8 +524,8 @@
       "name": "Apify",
       "status": "keep",
       "statusColor": "green",
-      "billingSignal": "Prior invoice evidence remains; direct API still reports STARTER plan on 2026-05-13.",
-      "usageSignal": "n8n exports include Apify nodes; prior direct run history still shows sampled runs through 2026-05-06, with four useful categories plus eight weak surfaces.",
+      "billingSignal": "Prior invoice evidence remains; direct API still reports STARTER plan on 2026-05-15.",
+      "usageSignal": "n8n exports include Apify nodes; direct account-level sample showed a succeeded actor run from 2026-05-13, and prior direct run history still shows actor-level sampled runs through 2026-05-06 with four useful categories plus eight weak surfaces.",
       "portfolioDependency": "Lead sourcing, scraping, and actor-monitor automation.",
       "recommendation": "Keep account-level subscription for now; pause or replace weak actor surfaces before any account-level decision.",
       "nextAction": "Continue actor-level replacement tests for no-run, failing, and empty-output surfaces before renewal.",
@@ -539,7 +545,7 @@
       "name": "Hunter.io",
       "status": "keep",
       "statusColor": "green",
-      "billingSignal": "Direct API returned plan Free with request quota visible and reset date 2026-06-09.",
+      "billingSignal": "Direct API returned plan Free with 75 available calls on 2026-05-15.",
       "usageSignal": "HUNTER_API_KEY, lead-source references, and n8n Hunter node-swap docs are present.",
       "portfolioDependency": "Lead discovery and email enrichment workflow risk.",
       "recommendation": "Keep/watch; not a paid cancellation target unless the account upgrades or becomes redundant.",
@@ -556,7 +562,7 @@
       "name": "OpenRouter",
       "status": "watch",
       "statusColor": "yellow",
-      "billingSignal": "Direct API returned zero current-key usage again on 2026-05-13 and no confirmed active spend.",
+      "billingSignal": "Direct API returned zero current-key usage again on 2026-05-15 and no confirmed active spend.",
       "usageSignal": "OPENROUTER_API_KEY, media bakeoff references, and n8n OpenRouter nodes remain present.",
       "portfolioDependency": "Specialist model-routing path for image/media and draft-reply workflows.",
       "recommendation": "Watch until bakeoff evidence confirms whether it is active, sandbox-only, or replaceable.",
@@ -573,7 +579,7 @@
       "name": "ElevenLabs",
       "status": "watch",
       "statusColor": "yellow",
-      "billingSignal": "Direct API reports active Creator subscription; prior receipt evidence remains; next character reset returned 2026-05-19T18:38:26Z.",
+      "billingSignal": "Direct API reports active Creator subscription on 2026-05-15; prior receipt evidence remains; next character reset remains 2026-05-19T18:38:26Z.",
       "usageSignal": "Direct API reports 18,068 of 164,102 characters used; social/audio workflow references remain.",
       "portfolioDependency": "Audio generation for social/video content campaigns.",
       "recommendation": "Watch through the next social content cycle before renewal review.",
@@ -596,7 +602,7 @@
       ],
       "status": "keep",
       "statusColor": "yellow",
-      "billingSignal": "Prior receipt evidence remains; 2026-05-13 direct API meeting-list check returned 401.",
+      "billingSignal": "Prior receipt evidence remains; 2026-05-15 direct API meeting-list check returned 401.",
       "usageSignal": "Supabase meeting rows, docs, and Read.ai workflow references remain; live provider usage needs auth refresh.",
       "portfolioDependency": "Meeting transcript and follow-up intelligence workflow risk.",
       "recommendation": "Keep while meeting transcript workflow is active; refresh auth before drawing new usage conclusions.",
@@ -613,11 +619,28 @@
       ],
       "status": "keep",
       "statusColor": "yellow",
-      "billingSignal": "Prior receipt evidence remains; 2026-05-13 direct API user lookup returned 401.",
+      "billingSignal": "Prior receipt evidence remains; 2026-05-15 direct API user lookup returned 401.",
       "usageSignal": "Scheduling links, n8n Calendly triggers, and report scheduling code remain active in the repo.",
       "portfolioDependency": "Client scheduling and lifecycle automation risk.",
       "recommendation": "Keep as low-cost scheduling infrastructure unless a replacement path is approved.",
       "nextAction": "Refresh Calendly token and re-run event-type usage check.",
+      "decisionRequired": true
+    },
+    {
+      "name": "Gemini / Google AI",
+      "links": [
+        {
+          "label": "Audit tracker",
+          "href": "https://github.com/vsillah/Portfolio/blob/main/docs/subscription-cancellation-audit.md"
+        }
+      ],
+      "status": "unresolved",
+      "statusColor": "yellow",
+      "billingSignal": "No direct billing evidence confirmed; 2026-05-15 model-list check returned 403.",
+      "usageSignal": "Gemini key is present locally and n8n/social image workflow references remain, but current API auth/project status needs verification.",
+      "portfolioDependency": "Image/social generation workflow risk if Gemini remains part of active n8n pipelines.",
+      "recommendation": "Investigate key/project status before treating Gemini as a reliable active provider or cancellation target.",
+      "nextAction": "Check Google AI Studio or Google Cloud project status and refresh the Gemini key if the image workflows stay active.",
       "decisionRequired": true
     },
     {
@@ -630,7 +653,7 @@
       ],
       "status": "watch",
       "statusColor": "yellow",
-      "billingSignal": "Receipt-backed current run-rate includes Anthropic, but the ChatGPT transition should remove it next cycle if cancellation holds.",
+      "billingSignal": "Receipt-backed current run-rate includes Anthropic, but the ChatGPT transition should remove it next cycle if cancellation holds; direct model-list endpoint was readable on 2026-05-15.",
       "usageSignal": "Anthropic code and n8n workflow references remain, including evaluation and social-listening paths.",
       "portfolioDependency": "LLM fallback/evaluation path risk if removed before bakeoff decisions settle.",
       "recommendation": "Watch through the next receipt and model bakeoff refresh before deprecation.",


### PR DESCRIPTION
## Summary
- add the 2026-05-15 subscription cancellation monitor run to the audit log
- refresh the admin subscription status JSON with current provider watch items and next review focus
- preserve the approval-gated cancellation posture; no vendor cancellation is requested

## Validation
- node -e 'JSON.parse(require("fs").readFileSync("docs/subscription-status.json","utf8")); console.log("subscription-status.json ok")'
- git diff --check

## Integration Notes
- Documentation/status update only.
- No live cancellation, billing mutation, provider config change, or customer-data smoke was run.
- Vercel contexts to verify after merge: Vercel – portfolio and Vercel – portfolio-staging.