### PR TITLE
feat: make run console action first

### DIFF
--- a/app/admin/agents/runs/page.test.tsx
+++ b/app/admin/agents/runs/page.test.tsx
@@ -1,0 +1,203 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import AgentRunsPage from './page'
+
+let currentSearchParams = new URLSearchParams()
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => currentSearchParams,
+}))
+
+vi.mock('@/components/ProtectedRoute', () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('@/components/admin/Breadcrumbs', () => ({
+  default: () => null,
+}))
+
+vi.mock('@/lib/auth', () => ({
+  getCurrentSession: vi.fn(async () => ({ access_token: 'admin-token' })),
+}))
+
+const runRows = [
+  {
+    id: 'failed-run',
+    agent_key: 'chief-of-staff',
+    runtime: 'codex',
+    kind: 'agent_work_item',
+    title: 'Production smoke failed',
+    status: 'failed',
+    subject_type: 'smoke',
+    subject_id: 'smoke-1',
+    subject_label: 'Smoke validation',
+    current_step: 'database check',
+    trigger_source: 'operator',
+    started_at: '2026-05-13T12:00:00.000Z',
+    completed_at: '2026-05-13T12:30:00.000Z',
+    stale_after: null,
+    error_message: 'Database write failed.',
+    stale: false,
+    cost_total: 0.0123,
+    approvals: { pending: 0, approved: 0, rejected: 0 },
+  },
+  {
+    id: 'running-stale-run',
+    agent_key: 'automation-systems',
+    runtime: 'n8n',
+    kind: 'runtime_evaluation',
+    title: 'Runtime probe timed out',
+    status: 'running',
+    subject_type: null,
+    subject_id: null,
+    subject_label: null,
+    current_step: 'waiting for heartbeat',
+    trigger_source: 'operator',
+    started_at: '2026-05-13T11:00:00.000Z',
+    completed_at: null,
+    stale_after: '2026-05-13T11:30:00.000Z',
+    error_message: null,
+    stale: true,
+    cost_total: 0,
+    approvals: { pending: 0, approved: 0, rejected: 0 },
+  },
+  {
+    id: 'approval-run',
+    agent_key: 'chief-of-staff',
+    runtime: 'codex',
+    kind: 'agent_work_item',
+    title: 'Approval packet waiting',
+    status: 'waiting_for_approval',
+    subject_type: 'approval',
+    subject_id: 'approval-1',
+    subject_label: 'Vercel proposal',
+    current_step: 'approval gate',
+    trigger_source: 'chief-of-staff',
+    started_at: '2026-05-13T13:00:00.000Z',
+    completed_at: null,
+    stale_after: null,
+    error_message: null,
+    stale: false,
+    cost_total: 0.0045,
+    approvals: { pending: 1, approved: 0, rejected: 0 },
+  },
+  {
+    id: 'completed-run',
+    agent_key: 'research-source-register',
+    runtime: 'codex',
+    kind: 'agent_work_item',
+    title: 'Research completed',
+    status: 'completed',
+    subject_type: 'research',
+    subject_id: 'research-1',
+    subject_label: 'Research packet',
+    current_step: 'done',
+    trigger_source: 'agent',
+    started_at: '2026-05-13T14:00:00.000Z',
+    completed_at: '2026-05-13T14:05:00.000Z',
+    stale_after: null,
+    error_message: null,
+    stale: false,
+    cost_total: 0.001,
+    approvals: { pending: 0, approved: 0, rejected: 0 },
+  },
+]
+
+function setupFetch(rows = runRows) {
+  vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input)
+    if (url.startsWith('/api/admin/agents/runs?') && !init?.method) {
+      return { ok: true, json: async () => ({ runs: rows }) }
+    }
+    if (url === '/api/admin/agents/runs/stale-sweep' && init?.method === 'POST') {
+      return { ok: true, json: async () => ({ checked: 2, marked: 1 }) }
+    }
+    if (url === '/api/admin/agents/runs/failed-run/retry' && init?.method === 'POST') {
+      return {
+        ok: true,
+        json: async () => ({
+          ok: true,
+          run_id: 'recovery-run',
+          source_run_id: 'failed-run',
+          retry_attempt: 1,
+        }),
+      }
+    }
+    return { ok: false, status: 404, json: async () => ({ error: 'not found' }) }
+  }))
+}
+
+describe('AgentRunsPage action-first console', () => {
+  beforeEach(() => {
+    currentSearchParams = new URLSearchParams()
+    setupFetch()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('renders action-first run cards and creates a read-only recovery request', async () => {
+    currentSearchParams = new URLSearchParams('status=needs_review')
+    render(<AgentRunsPage />)
+
+    expect(await screen.findByRole('heading', { name: 'Run Console' })).toBeInTheDocument()
+    expect(screen.getByText('Production smoke failed')).toBeInTheDocument()
+    expect(screen.getAllByText('Status context').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Next action').length).toBeGreaterThan(0)
+    expect(screen.getByText('Database write failed.')).toBeInTheDocument()
+    expect(screen.getByText('Sweep stale first')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Review approval/i })).toHaveAttribute('href', '/admin/agents/runs/approval-run')
+    expect(screen.getByRole('link', { name: /^View trace/i })).toHaveAttribute('href', '/admin/agents/runs/completed-run')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Request recovery' }))
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/admin/agents/runs/failed-run/retry', expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ Authorization: 'Bearer admin-token' }),
+        body: expect.stringContaining('Run Console action list'),
+      }))
+    })
+    expect(await screen.findByText('Recovery request recovery-run is queued for Production smoke failed.')).toBeInTheDocument()
+  })
+
+  it('initializes active, needs-review, and operator-check filters from Mission Control links', async () => {
+    currentSearchParams = new URLSearchParams('active=true')
+    const { unmount } = render(<AgentRunsPage />)
+    await screen.findByRole('heading', { name: 'Run Console' })
+    expect(fetch).toHaveBeenCalledWith('/api/admin/agents/runs?limit=75&active=true', expect.anything())
+    unmount()
+    vi.unstubAllGlobals()
+
+    setupFetch()
+    currentSearchParams = new URLSearchParams('status=needs_review')
+    const secondRender = render(<AgentRunsPage />)
+    await screen.findByRole('heading', { name: 'Run Console' })
+    expect(fetch).toHaveBeenCalledWith('/api/admin/agents/runs?limit=75&status=needs_review', expect.anything())
+    secondRender.unmount()
+    vi.unstubAllGlobals()
+
+    setupFetch()
+    currentSearchParams = new URLSearchParams('kind=operator_checks')
+    render(<AgentRunsPage />)
+    await screen.findByRole('heading', { name: 'Run Console' })
+    expect(fetch).toHaveBeenCalledWith('/api/admin/agents/runs?limit=75&kind=operator_checks', expect.anything())
+  })
+
+  it('runs stale sweep from computed-stale rows and refreshes the list', async () => {
+    render(<AgentRunsPage />)
+
+    expect(await screen.findByText('Runtime probe timed out')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Sweep stale first' }))
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/admin/agents/runs/stale-sweep', expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ Authorization: 'Bearer admin-token' }),
+      }))
+    })
+    expect(await screen.findByText('Checked 2 active run(s); marked 1 stale.')).toBeInTheDocument()
+  })
+})

--- a/app/admin/agents/runs/page.tsx
+++ b/app/admin/agents/runs/page.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import { Suspense, useCallback, useEffect, useState } from 'react'
+import type { ReactNode } from 'react'
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
-import { AlertTriangle, Bot, RefreshCw } from 'lucide-react'
+import { AlertTriangle, ArrowRight, Bot, CheckCircle2, FileText, RefreshCw, RotateCcw, ShieldAlert } from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
 import { getCurrentSession } from '@/lib/auth'
@@ -20,12 +21,24 @@ type RunRow = {
   subject_id: string | null
   subject_label: string | null
   current_step: string | null
+  trigger_source: string | null
   started_at: string
   completed_at: string | null
+  stale_after: string | null
   error_message: string | null
+  metadata?: Record<string, unknown> | null
   stale: boolean
   cost_total: number
   approvals: { pending: number; approved: number; rejected: number }
+}
+
+type RecoveryResult = {
+  ok?: boolean
+  error?: string
+  run_id?: string
+  recovery_run_id?: string
+  retry_attempt?: number
+  earliest_retry_at?: string
 }
 
 const RUNTIMES = ['all', 'codex', 'n8n', 'hermes', 'opencode', 'manual'] as const
@@ -50,6 +63,8 @@ function AgentRunsContent() {
   const [error, setError] = useState<string | null>(null)
   const [sweepLoading, setSweepLoading] = useState(false)
   const [sweepMessage, setSweepMessage] = useState<string | null>(null)
+  const [recoveryLoadingId, setRecoveryLoadingId] = useState<string | null>(null)
+  const [recoveryMessage, setRecoveryMessage] = useState<string | null>(null)
   const kindFilter = searchParams.get('kind')
 
   const fetchRuns = useCallback(async () => {
@@ -110,6 +125,41 @@ function AgentRunsContent() {
     }
   }
 
+  async function requestRecovery(run: RunRow) {
+    setRecoveryLoadingId(run.id)
+    setRecoveryMessage(null)
+    setError(null)
+    try {
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Missing admin session')
+      const res = await fetch(`/api/admin/agents/runs/${run.id}/retry`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${session.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          note: 'Requested from Run Console action list.',
+        }),
+      })
+      const body = await res.json().catch(() => ({})) as RecoveryResult
+      if (!res.ok && !body.recovery_run_id) {
+        throw new Error(body.error || `HTTP ${res.status}`)
+      }
+      const recoveryId = body.run_id ?? body.recovery_run_id
+      setRecoveryMessage(recoveryId
+        ? `Recovery request ${recoveryId} is queued for ${run.title}.`
+        : `Recovery request queued for ${run.title}.`)
+      if (res.ok) await fetchRuns()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create recovery request')
+    } finally {
+      setRecoveryLoadingId(null)
+    }
+  }
+
+  const summary = summarizeRuns(runs)
+
   return (
     <div className="agent-ops-page min-h-screen p-5 text-foreground lg:p-7">
       <div className="mx-auto max-w-7xl">
@@ -152,26 +202,41 @@ function AgentRunsContent() {
             {sweepMessage}
           </div>
         ) : null}
+        {recoveryMessage ? (
+          <div className="mb-4 rounded-lg border border-emerald-500/40 bg-emerald-500/10 p-3 text-sm text-emerald-100">
+            {recoveryMessage}
+          </div>
+        ) : null}
 
-        <div className="mb-5 flex gap-3 flex-wrap">
-          <select
-            value={runtime}
-            onChange={(e) => setRuntime(e.target.value as (typeof RUNTIMES)[number])}
-            className="rounded-lg border border-silicon-slate/70 bg-background px-3 py-2 text-sm"
-          >
-            {RUNTIMES.map((value) => (
-              <option key={value} value={value}>{value === 'all' ? 'All runtimes' : value}</option>
-            ))}
-          </select>
-          <select
-            value={status}
-            onChange={(e) => setStatus(e.target.value as (typeof STATUSES)[number])}
-            className="rounded-lg border border-silicon-slate/70 bg-background px-3 py-2 text-sm"
-          >
-            {STATUSES.map((value) => (
-              <option key={value} value={value}>{formatStatusOption(value)}</option>
-            ))}
-          </select>
+        <div className="mb-5 grid gap-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+          <div className="grid gap-3 sm:grid-cols-4">
+            <RunSummaryCard label="Needs review" value={summary.needsReview} detail="Failed, stale, or computed stale" tone={summary.needsReview ? 'red' : 'neutral'} />
+            <RunSummaryCard label="Approval waits" value={summary.waitingForApproval} detail="Review on trace detail" tone={summary.waitingForApproval ? 'yellow' : 'neutral'} />
+            <RunSummaryCard label="Active" value={summary.active} detail="Queued or running traces" tone={summary.active ? 'blue' : 'neutral'} />
+            <RunSummaryCard label="Cost" value={`$${summary.cost.toFixed(4)}`} detail="Visible rows" tone="neutral" />
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <select
+              aria-label="Runtime filter"
+              value={runtime}
+              onChange={(e) => setRuntime(e.target.value as (typeof RUNTIMES)[number])}
+              className="rounded-lg border border-silicon-slate/70 bg-background px-3 py-2 text-sm"
+            >
+              {RUNTIMES.map((value) => (
+                <option key={value} value={value}>{value === 'all' ? 'All runtimes' : value}</option>
+              ))}
+            </select>
+            <select
+              aria-label="Status filter"
+              value={status}
+              onChange={(e) => setStatus(e.target.value as (typeof STATUSES)[number])}
+              className="rounded-lg border border-silicon-slate/70 bg-background px-3 py-2 text-sm"
+            >
+              {STATUSES.map((value) => (
+                <option key={value} value={value}>{formatStatusOption(value)}</option>
+              ))}
+            </select>
+          </div>
         </div>
 
         {loading ? (
@@ -186,46 +251,246 @@ function AgentRunsContent() {
             No agent runs match the current filters.
           </div>
         ) : (
-          <div className="agent-ops-card overflow-hidden rounded-lg border">
-            <table className="w-full text-sm">
-              <thead className="bg-silicon-slate/40 text-muted-foreground">
-                <tr>
-                  <th className="text-left px-4 py-3 font-medium">Run</th>
-                  <th className="text-left px-4 py-3 font-medium">Runtime</th>
-                  <th className="text-left px-4 py-3 font-medium">Status</th>
-                  <th className="text-left px-4 py-3 font-medium">Current step</th>
-                  <th className="text-left px-4 py-3 font-medium">Subject</th>
-                  <th className="text-right px-4 py-3 font-medium">Cost</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-silicon-slate/60">
-                {runs.map((run) => (
-                  <tr key={run.id} className="hover:bg-silicon-slate/20">
-                    <td className="px-4 py-3">
-                      <Link href={`/admin/agents/runs/${run.id}`} className="font-medium hover:text-radiant-gold">
-                        {run.title}
-                      </Link>
-                      <div className="text-xs text-muted-foreground">{formatDate(run.started_at)} · {run.agent_key || run.kind}</div>
-                    </td>
-                    <td className="px-4 py-3">
-                      <span className="inline-flex items-center gap-1 rounded-full bg-black/20 px-2 py-1 text-xs">
-                        <Bot size={12} />
-                        {run.runtime}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3"><StatusBadge status={run.stale ? 'stale' : run.status} /></td>
-                    <td className="px-4 py-3 text-muted-foreground">{run.current_step || '-'}</td>
-                    <td className="px-4 py-3 text-muted-foreground">{run.subject_label || run.subject_id || '-'}</td>
-                    <td className="px-4 py-3 text-right tabular-nums">${run.cost_total.toFixed(4)}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+          <div className="grid gap-3">
+            {runs.map((run) => (
+              <RunActionCard
+                key={run.id}
+                run={run}
+                recoveryLoading={recoveryLoadingId === run.id}
+                sweepLoading={sweepLoading}
+                onRequestRecovery={() => requestRecovery(run)}
+                onSweepStale={sweepStaleRuns}
+              />
+            ))}
           </div>
         )}
       </div>
     </div>
   )
+}
+
+function summarizeRuns(runs: RunRow[]) {
+  return runs.reduce(
+    (summary, run) => {
+      const effectiveStatus = run.stale ? 'stale' : run.status
+      if (effectiveStatus === 'failed' || effectiveStatus === 'stale') summary.needsReview += 1
+      if (effectiveStatus === 'waiting_for_approval') summary.waitingForApproval += 1
+      if (effectiveStatus === 'queued' || effectiveStatus === 'running') summary.active += 1
+      summary.cost += run.cost_total
+      return summary
+    },
+    { needsReview: 0, waitingForApproval: 0, active: 0, cost: 0 },
+  )
+}
+
+function RunSummaryCard({
+  label,
+  value,
+  detail,
+  tone,
+}: {
+  label: string
+  value: string | number
+  detail: string
+  tone: 'blue' | 'red' | 'yellow' | 'neutral'
+}) {
+  const toneClass = {
+    blue: 'border-sky-400/30 bg-sky-500/10',
+    red: 'border-red-400/35 bg-red-500/10',
+    yellow: 'border-yellow-400/35 bg-yellow-500/10',
+    neutral: 'border-silicon-slate/60 bg-black/10',
+  }[tone]
+
+  return (
+    <div className={`rounded-lg border p-3 ${toneClass}`}>
+      <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">{label}</p>
+      <p className="mt-1 text-2xl font-semibold">{value}</p>
+      <p className="mt-1 text-xs text-muted-foreground">{detail}</p>
+    </div>
+  )
+}
+
+function RunActionCard({
+  run,
+  recoveryLoading,
+  sweepLoading,
+  onRequestRecovery,
+  onSweepStale,
+}: {
+  run: RunRow
+  recoveryLoading: boolean
+  sweepLoading: boolean
+  onRequestRecovery: () => void
+  onSweepStale: () => void
+}) {
+  const status = run.stale ? 'stale' : run.status
+  const action = runActionModel(run)
+
+  return (
+    <article className={`agent-ops-card rounded-lg border p-4 ${action.toneClass}`}>
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(260px,0.45fr)]">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <StatusBadge status={status} />
+            <span className="inline-flex items-center gap-1 rounded-full border border-silicon-slate/50 bg-black/10 px-2 py-1 text-xs text-muted-foreground">
+              <Bot size={12} />
+              {run.runtime}
+            </span>
+            <span className="rounded-full border border-silicon-slate/50 bg-black/10 px-2 py-1 text-xs text-muted-foreground">
+              {run.kind.replace(/_/g, ' ')}
+            </span>
+            {run.approvals.pending ? (
+              <span className="rounded-full border border-yellow-400/40 bg-yellow-500/10 px-2 py-1 text-xs text-yellow-100">
+                {run.approvals.pending} pending approval(s)
+              </span>
+            ) : null}
+          </div>
+          <Link href={`/admin/agents/runs/${run.id}`} className="mt-3 block text-lg font-semibold hover:text-radiant-gold">
+            {run.title}
+          </Link>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {formatDate(run.started_at)} · {run.agent_key?.replace(/-/g, ' ') || run.trigger_source || run.subject_label || 'Agent trace'}
+          </p>
+
+          <div className="mt-4 grid gap-3 md:grid-cols-3">
+            <RunFact icon={<ShieldAlert size={15} />} label="Status context" value={action.why} />
+            <RunFact icon={<CheckCircle2 size={15} />} label="Next action" value={action.nextAction} />
+            <RunFact icon={<FileText size={15} />} label="Evidence" value={action.evidence} />
+          </div>
+        </div>
+
+        <div className="flex flex-col justify-between gap-4 rounded-lg border border-silicon-slate/55 bg-black/10 p-3">
+          <div className="space-y-2 text-sm">
+            <RunDetailLine label="Current step" value={run.current_step || '-'} />
+            <RunDetailLine label="Subject" value={run.subject_label || run.subject_id || '-'} />
+            <RunDetailLine label="Cost" value={`$${run.cost_total.toFixed(4)}`} />
+            {run.stale_after ? <RunDetailLine label="Stale checkpoint" value={formatDate(run.stale_after)} /> : null}
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Link href={`/admin/agents/runs/${run.id}`} className="agent-ops-button-secondary">
+              {action.primaryLabel}
+              <ArrowRight size={15} />
+            </Link>
+            {action.canRecover ? (
+              <button
+                type="button"
+                onClick={onRequestRecovery}
+                disabled={recoveryLoading}
+                className="agent-ops-button-primary disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                <RotateCcw size={15} className={recoveryLoading ? 'animate-spin' : ''} />
+                {recoveryLoading ? 'Requesting...' : 'Request recovery'}
+              </button>
+            ) : action.needsSweep ? (
+              <button
+                type="button"
+                onClick={onSweepStale}
+                disabled={sweepLoading}
+                className="agent-ops-button-primary disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                <RefreshCw size={15} className={sweepLoading ? 'animate-spin' : ''} />
+                {sweepLoading ? 'Sweeping...' : 'Sweep stale first'}
+              </button>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </article>
+  )
+}
+
+function RunFact({ icon, label, value }: { icon: ReactNode; label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-silicon-slate/50 bg-black/10 p-3">
+      <p className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        {icon}
+        {label}
+      </p>
+      <p className="mt-2 text-sm text-foreground/90">{value}</p>
+    </div>
+  )
+}
+
+function RunDetailLine({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">{label}</p>
+      <p className="mt-0.5 break-words text-foreground/90">{value}</p>
+    </div>
+  )
+}
+
+function runActionModel(run: RunRow) {
+  const status = run.stale ? 'stale' : run.status
+  if (status === 'failed') {
+    return {
+      primaryLabel: 'Review trace',
+      why: run.error_message || 'The run ended in a failed state and needs an operator review before follow-up.',
+      nextAction: 'Inspect the failure, then create a read-only recovery request if the trace is complete.',
+      evidence: run.current_step || run.subject_label || 'Failure details are on the trace detail page.',
+      canRecover: run.status === 'failed',
+      needsSweep: false,
+      toneClass: 'border-red-400/35 bg-red-500/10',
+    }
+  }
+  if (status === 'stale') {
+    const persistedStale = run.status === 'stale'
+    return {
+      primaryLabel: 'Review stale trace',
+      why: run.stale_after
+        ? `The run crossed its stale checkpoint at ${formatDate(run.stale_after)}.`
+        : 'The run has stopped reporting progress and needs stale-run triage.',
+      nextAction: persistedStale
+        ? 'Create a read-only recovery request after confirming the original runtime is no longer active.'
+        : 'Run the stale sweep first so the trace is persisted as stale before recovery is requested.',
+      evidence: run.current_step || run.error_message || 'Latest step and events are on the trace detail page.',
+      canRecover: persistedStale,
+      needsSweep: !persistedStale,
+      toneClass: 'border-red-400/35 bg-red-500/10',
+    }
+  }
+  if (status === 'waiting_for_approval') {
+    return {
+      primaryLabel: 'Review approval',
+      why: `${run.approvals.pending || 1} approval checkpoint(s) are waiting for a human decision.`,
+      nextAction: 'Open the trace detail, review the recommendation and risk, then approve or decline there.',
+      evidence: run.subject_label || run.current_step || 'Approval packet is attached to the trace detail page.',
+      canRecover: false,
+      needsSweep: false,
+      toneClass: 'border-yellow-400/35 bg-yellow-500/10',
+    }
+  }
+  if (status === 'running' || status === 'queued') {
+    return {
+      primaryLabel: status === 'queued' ? 'Open queued trace' : 'Open live trace',
+      why: status === 'queued' ? 'The run is queued and has not produced terminal evidence yet.' : 'The run is still active and may still produce updates.',
+      nextAction: 'Monitor the live trace. Use Sweep stale only if the runtime has crossed its stale checkpoint.',
+      evidence: run.current_step || run.subject_label || 'Live events appear on the trace detail page.',
+      canRecover: false,
+      needsSweep: false,
+      toneClass: 'border-sky-400/30 bg-sky-500/10',
+    }
+  }
+  if (status === 'completed') {
+    return {
+      primaryLabel: 'View trace',
+      why: 'The run completed and is available for audit, artifact review, or evaluation.',
+      nextAction: 'Open the trace when you need evidence, cost, artifacts, or rubric evaluation.',
+      evidence: run.completed_at ? `Completed ${formatDate(run.completed_at)}.` : 'Completion evidence is on the trace detail page.',
+      canRecover: false,
+      needsSweep: false,
+      toneClass: '',
+    }
+  }
+  return {
+    primaryLabel: 'Open trace',
+    why: `The run is currently ${status.replace(/_/g, ' ')}.`,
+    nextAction: 'Open the trace detail for the next available action.',
+    evidence: run.current_step || run.subject_label || 'Trace detail owns the evidence.',
+    canRecover: ['cancelled'].includes(run.status),
+    needsSweep: false,
+    toneClass: '',
+  }
 }
 
 function normalizeStatusFilter(status: string | null, active: string | null): (typeof STATUSES)[number] {


### PR DESCRIPTION
## Summary
- redesigns the Run Console list into action-first trace cards with status context, next action, evidence, and trace links
- adds summary counts for needs-review, approval waits, active traces, and visible cost
- exposes stale sweep and read-only recovery requests directly from failed/stale run cards
- adds focused tests for Mission Control query links, recovery creation, and stale sweep behavior

## Validation
- npm test -- app/admin/agents/runs/page.test.tsx 'app/admin/agents/runs/[runId]/page.test.tsx' app/admin/agents/page.test.tsx
- npx tsc --noEmit --pretty false
- npm run lint
- git diff --check
- Local route smoke: http://localhost:3002/admin/agents/runs returned HTTP 200 after worktree env bootstrap

## Integration Notes
- Worktree environment bootstrapped with npm run worktree:env -- --source /Users/vambahsillah/Projects/Portfolio; linked local .env.local and .vercel only, not committed.
- No database schema, migration, or backend route changes.
- Vercel contexts not checked yet for this branch: Vercel – portfolio and Vercel – portfolio-staging remain captain-gated after merge approval.