### PR TITLE
feat: make governance drilldowns action first

### DIFF
--- a/app/admin/agents/automations/page.test.tsx
+++ b/app/admin/agents/automations/page.test.tsx
@@ -1,0 +1,201 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import AgentAutomationsPage from './page'
+
+vi.mock('@/components/ProtectedRoute', () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('@/components/admin/Breadcrumbs', () => ({
+  default: () => null,
+}))
+
+vi.mock('@/lib/auth', () => ({
+  getCurrentSession: vi.fn(async () => ({ access_token: 'admin-token' })),
+}))
+
+const automationProfile = {
+  id: 'morning-review',
+  name: 'Morning review',
+  kind: 'cron',
+  status: 'ACTIVE',
+  schedule: 'weekdays',
+  model: 'gpt-5.2',
+  reasoningEffort: 'medium',
+  executionEnvironment: 'local',
+  cwds: ['/Users/vambahsillah/Projects/Portfolio'],
+  createdAt: null,
+  updatedAt: null,
+  category: 'Operations',
+  riskLevel: 'medium',
+  portfolioRelated: true,
+  sourceFile: '/Users/vambahsillah/.codex/automations/morning-review/automation.toml',
+  controlDocs: [],
+  promptExcerpt: 'Review Agent Ops status.',
+  duplicateCandidate: false,
+  managementBoundary: 'read_only',
+  contextHealth: 'yellow',
+  contextGaps: ['missing governing docs'],
+  contextQuestions: [
+    {
+      id: 'purpose',
+      question: 'What is the purpose?',
+      answered: false,
+      answer: null,
+      recommendation: 'Add a purpose to the automation prompt.',
+    },
+  ],
+  contextProfile: {
+    purpose: null,
+    operatingRhythm: 'Morning',
+    recurringDecisions: null,
+    inputs: ['Agent Ops'],
+    dependencies: ['Portfolio'],
+    frictionPoints: ['Missing docs'],
+    authorityBoundary: 'read_only',
+    expectedOutputs: ['Brief'],
+    escalationTrigger: null,
+    governingDocs: [],
+  },
+}
+
+const inventoryResponse = {
+  available: true,
+  sourceDirectory: '/Users/vambahsillah/.codex/automations',
+  generatedAt: '2026-05-15T12:00:00.000Z',
+  automations: [automationProfile],
+  hiddenCount: 0,
+  overview: {
+    total: 1,
+    active: 1,
+    paused: 0,
+    duplicateCandidates: 0,
+    highRisk: 0,
+    missingContext: 1,
+  },
+  progress: {
+    label: 'Memory organization',
+    percent: 50,
+    completedTasks: 1,
+    totalTasks: 2,
+    tasks: [{
+      id: 'docs',
+      label: 'Docs',
+      description: 'Add governing docs.',
+      status: 'in_progress',
+      progress: 50,
+    }],
+  },
+  repairPackets: [{
+    automationId: 'morning-review',
+    automationName: 'Morning review',
+    priority: 'medium',
+    summary: 'Add governing docs.',
+    missingQuestions: ['purpose'],
+    recommendedActions: ['Reference the runbook.'],
+    governingDocCandidates: ['docs/agents/integration-captain.md'],
+    sourceFile: '/Users/vambahsillah/.codex/automations/morning-review/automation.toml',
+    operationalBoundary: 'Read-only packet.',
+  }],
+  workspaceRoots: {
+    available: true,
+    generatedAt: '2026-05-15T12:00:00.000Z',
+    expectedRoot: '/Users/vambahsillah/Projects/Portfolio',
+    stateDatabase: '/tmp/state.db',
+    globalStateFile: '/tmp/state.json',
+    savedWorkspaceRoots: ['/Users/vambahsillah/Projects/Portfolio'],
+    activeWorkspaceRoots: ['/Users/vambahsillah/Projects/Portfolio'],
+    projectOrderRoots: ['/Users/vambahsillah/Projects/Portfolio'],
+    threadRoots: [{
+      cwd: '/Users/vambahsillah/Projects/Portfolio',
+      activeCount: 1,
+      portfolioRoot: true,
+    }],
+    overview: {
+      activeThreads: 1,
+      portfolioThreads: 1,
+      nonPortfolioThreads: 0,
+      savedRootDrift: 0,
+      activeRootDrift: 0,
+      projectOrderDrift: 0,
+    },
+    health: 'green',
+    warnings: [],
+    operationalBoundary: 'Read-only root report.',
+  },
+}
+
+const actionsResponse = {
+  available: true,
+  generatedAt: '2026-05-15T12:00:00.000Z',
+  sourceDirectory: '/Users/vambahsillah/.codex/automation-notifications',
+  stateFile: '/tmp/action-tracker.json',
+  actions: [{
+    id: 'action-1',
+    automationId: 'morning-review',
+    automationName: 'Morning review',
+    statusColor: 'yellow',
+    headline: 'Review context',
+    summary: 'Morning review needs a governing doc.',
+    kind: 'blocker_or_approval',
+    text: 'Add governing context before next run',
+    priority: 'high',
+    actionStatus: 'open',
+    owner: null,
+    note: null,
+    linkedWorkItemId: null,
+    firstSeenAt: '2026-05-15T10:00:00.000Z',
+    lastSeenAt: '2026-05-15T11:00:00.000Z',
+    occurrenceCount: 2,
+    sourceFiles: ['/tmp/report.md'],
+    latestSourceFile: '/tmp/report.md',
+    codexThreadHint: null,
+  }],
+  recentNotifications: [],
+  summary: {
+    total: 1,
+    open: 1,
+    inProgress: 0,
+    blocked: 0,
+    done: 0,
+    dismissed: 0,
+    urgent: 0,
+    high: 1,
+  },
+}
+
+describe('AgentAutomationsPage', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/api/admin/agents/automation-actions')) {
+        return { ok: true, json: async () => actionsResponse }
+      }
+      return { ok: true, json: async () => inventoryResponse }
+    }))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('renders action-first automation controls and navigates to the relevant view', async () => {
+    render(<AgentAutomationsPage />)
+
+    expect(await screen.findByRole('region', { name: 'Automation next actions' })).toBeInTheDocument()
+    expect(screen.getByText('Automation actions need review')).toBeInTheDocument()
+    expect(screen.getByText('Action tracker')).toBeInTheDocument()
+    expect(screen.getByText('Context gaps')).toBeInTheDocument()
+    expect(screen.getByText('Repair packets')).toBeInTheDocument()
+    expect(screen.getByText('Workspace drift')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /Review gaps/i }))
+
+    expect(screen.getByText('Context Gaps Workflow')).toBeInTheDocument()
+    expect(screen.getByText('What is the purpose?')).toBeInTheDocument()
+    expect(fetch).toHaveBeenCalledWith('/api/admin/agents/automations', expect.objectContaining({
+      headers: expect.objectContaining({ Authorization: 'Bearer admin-token' }),
+    }))
+  })
+})

--- a/app/admin/agents/automations/page.tsx
+++ b/app/admin/agents/automations/page.tsx
@@ -384,6 +384,12 @@ function AgentAutomationsContent() {
               <MetricCard label="Missing context" value={inventory.overview.missingContext} tone={inventory.overview.missingContext ? 'yellow' : 'slate'} />
             </div>
 
+            <AutomationControlPanel
+              inventory={inventory}
+              tracker={actionTracker}
+              onViewModeChange={setViewMode}
+            />
+
             <WarningPanels
               hiddenCount={inventory.hiddenCount}
               duplicateWarnings={duplicateWarnings}
@@ -477,6 +483,124 @@ function AgentAutomationsContent() {
         ) : null}
       </div>
     </div>
+  )
+}
+
+function AutomationControlPanel({
+  inventory,
+  tracker,
+  onViewModeChange,
+}: {
+  inventory: AutomationInventoryResponse
+  tracker: AutomationActionTrackerResponse | null
+  onViewModeChange: (mode: ViewMode) => void
+}) {
+  const activeActions = (tracker?.summary.open ?? 0) + (tracker?.summary.inProgress ?? 0) + (tracker?.summary.blocked ?? 0)
+  const driftCount = inventory.workspaceRoots.available
+    ? inventory.workspaceRoots.overview.nonPortfolioThreads
+      + inventory.workspaceRoots.overview.savedRootDrift
+      + inventory.workspaceRoots.overview.activeRootDrift
+      + inventory.workspaceRoots.overview.projectOrderDrift
+    : 1
+  const primary = activeActions
+    ? {
+        label: 'Automation actions need review',
+        detail: `${activeActions} open, active, or blocked action(s) are waiting in the tracker.`,
+        action: 'Open action tracker',
+        mode: 'actions' as ViewMode,
+        tone: 'border-radiant-gold/40 bg-radiant-gold/10',
+      }
+    : inventory.overview.missingContext
+      ? {
+          label: 'Context gaps need routing',
+          detail: `${inventory.overview.missingContext} automation(s) are missing operating context before agents can safely act.`,
+          action: 'Review context gaps',
+          mode: 'context-gaps' as ViewMode,
+          tone: 'border-yellow-400/35 bg-yellow-500/10',
+        }
+      : inventory.repairPackets.length
+        ? {
+            label: 'Repair packets are available',
+            detail: `${inventory.repairPackets.length} packet(s) explain duplicate, governance, or missing-doc follow-up.`,
+            action: 'Open repair packets',
+            mode: 'repair-packets' as ViewMode,
+            tone: 'border-yellow-400/35 bg-yellow-500/10',
+          }
+        : {
+            label: 'Automation context is clear',
+            detail: 'No tracked automation action is currently waiting for operator review.',
+            action: 'Inspect inventory',
+            mode: 'inventory' as ViewMode,
+            tone: 'border-green-400/30 bg-green-500/10',
+          }
+
+  const cards = [
+    {
+      label: 'Action tracker',
+      value: String(activeActions),
+      detail: tracker ? `${tracker.summary.blocked} blocked, ${tracker.summary.inProgress} in progress` : 'Tracker unavailable',
+      action: 'Open actions',
+      mode: 'actions' as ViewMode,
+    },
+    {
+      label: 'Context gaps',
+      value: String(inventory.overview.missingContext),
+      detail: 'Missing purpose, boundary, inputs, or expected-output answers.',
+      action: 'Review gaps',
+      mode: 'context-gaps' as ViewMode,
+    },
+    {
+      label: 'Repair packets',
+      value: String(inventory.repairPackets.length),
+      detail: 'Read-only packets for duplicate, doc, authority, and context repair.',
+      action: 'Open packets',
+      mode: 'repair-packets' as ViewMode,
+    },
+    {
+      label: 'Workspace drift',
+      value: String(driftCount),
+      detail: inventory.workspaceRoots.available ? 'Codex root alignment signals.' : 'Workspace-root visibility unavailable.',
+      action: 'Inspect inventory',
+      mode: 'inventory' as ViewMode,
+    },
+  ]
+
+  return (
+    <section className={`mb-6 rounded-lg border p-5 ${primary.tone}`} aria-label="Automation next actions">
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.4fr)]">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wider text-radiant-gold">Next automation action</p>
+          <h2 className="mt-2 text-xl font-semibold">{primary.label}</h2>
+          <p className="mt-2 text-sm text-muted-foreground">{primary.detail}</p>
+          <button
+            type="button"
+            onClick={() => onViewModeChange(primary.mode)}
+            className="mt-4 inline-flex items-center gap-2 rounded-lg border border-radiant-gold/50 bg-radiant-gold/10 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15"
+          >
+            {primary.action}
+            <ArrowRight size={15} />
+          </button>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          {cards.map((card) => (
+            <button
+              key={card.label}
+              type="button"
+              onClick={() => onViewModeChange(card.mode)}
+              className="rounded-lg border border-silicon-slate/70 bg-background/55 p-3 text-left transition hover:border-radiant-gold/45"
+            >
+              <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">{card.label}</p>
+              <p className="mt-2 text-2xl font-bold tabular-nums">{card.value}</p>
+              <p className="mt-1 min-h-[42px] text-xs text-muted-foreground">{card.detail}</p>
+              <span className="mt-3 inline-flex items-center gap-1 text-xs text-radiant-gold">
+                {card.action}
+                <ArrowRight size={12} />
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </section>
   )
 }
 

--- a/app/admin/agents/open-brain/page.test.tsx
+++ b/app/admin/agents/open-brain/page.test.tsx
@@ -1,0 +1,195 @@
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import OpenBrainPage from './page'
+
+vi.mock('@/components/ProtectedRoute', () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('@/components/admin/Breadcrumbs', () => ({
+  default: () => null,
+}))
+
+vi.mock('@/lib/auth', () => ({
+  getCurrentSession: vi.fn(async () => ({ access_token: 'admin-token' })),
+}))
+
+const openBrainSnapshot = {
+  generatedAt: '2026-05-15T12:00:00.000Z',
+  service: {
+    available: true,
+    storage: 'local_jsonl',
+    home: '/Users/vambahsillah/.open-brain',
+    databaseConfigured: false,
+    mcpConfigured: true,
+    mcpUrl: 'http://localhost:4000/mcp',
+    reason: null,
+    operationalBoundary: 'Portfolio is a projection and approval surface.',
+  },
+  overview: {
+    sources: 2,
+    memories: 1,
+    pendingProposals: 1,
+    approvedProposals: 1,
+    rejectedProposals: 0,
+    wikiPages: 0,
+    events: 2,
+    links: 0,
+    ragProjectionDocuments: 1,
+    staleSources: 1,
+    privateRecords: 0,
+    producerGates: 2,
+    enabledProducerGates: 1,
+  },
+  health: {
+    sourceFreshness: 'yellow',
+    memoryHealth: 'green',
+    proposalHealth: 'yellow',
+    wikiOverlay: 'yellow',
+  },
+  sources: [{
+    id: 'source-1',
+    kind: 'automation',
+    title: 'Morning review source',
+    summary: 'Automation context source.',
+    path: '/tmp/source.json',
+    privacyTier: 'internal',
+    lastObservedAt: '2026-05-14T12:00:00.000Z',
+    confidence: 0.9,
+    metadata: {},
+  }],
+  events: [],
+  links: [],
+  memories: [],
+  proposals: [{
+    id: 'proposal-1',
+    status: 'pending',
+    proposedMemory: {
+      kind: 'workflow',
+      title: 'Adopt action-first governance reviews',
+      body: 'Governance pages should show the next action before the archive.',
+      privacyTier: 'internal',
+      confidence: 0.9,
+      sourceIds: ['source-1'],
+    },
+    sourceIds: ['source-1'],
+    reason: 'Captured from Agent Ops review.',
+    createdBy: 'codex',
+    createdAt: '2026-05-15T11:00:00.000Z',
+    reviewedAt: null,
+    reviewedBy: null,
+    reviewReason: null,
+  }],
+  wikiPages: [],
+  ragProjection: {
+    version: 'v1',
+    documents: [],
+    eligibleMemoryCount: 1,
+    excludedPrivateCount: 0,
+    pineconeWriteStatus: 'blocked_pending_approval',
+  },
+  runtimeParity: [
+    { runtime: 'Codex', status: 'connected', configPath: '/tmp/codex.toml', note: 'Connected.' },
+    { runtime: 'Hermes', status: 'blocked', configPath: '/tmp/hermes.toml', note: 'Bridge missing.' },
+  ],
+  producerGates: [
+    {
+      id: 'producer-1',
+      label: 'Automation reports',
+      status: 'enabled',
+      sourceKind: 'automation',
+      eventKind: 'automation_run',
+      privacyTier: 'internal',
+      envVar: null,
+      configuredValue: null,
+      note: 'Enabled.',
+    },
+    {
+      id: 'producer-2',
+      label: 'Private exports',
+      status: 'blocked',
+      sourceKind: 'codex_thread',
+      eventKind: null,
+      privacyTier: 'private',
+      envVar: 'OPEN_BRAIN_PRIVATE_EXPORTS',
+      configuredValue: null,
+      note: 'Approval required.',
+    },
+  ],
+  modelOps: {
+    available: true,
+    generatedAt: '2026-05-15T12:00:00.000Z',
+    projectName: 'Portfolio',
+    sourceRoot: '/Users/vambahsillah/Projects/Portfolio',
+    reason: null,
+    currentLocalDefault: 'local:model',
+    currentFrontierFallback: 'frontier:model',
+    currentEmbeddingModel: 'embedding',
+    monitor: {
+      name: 'Model Ops',
+      cadence: 'daily',
+      latestReportPath: null,
+      productionGate: 'approval required',
+    },
+    routerDecisions: [],
+    candidates: [],
+    benchmarkResults: [],
+    ragQualityRuns: [],
+    swapRequests: [],
+    culturalResourceReviews: [],
+  },
+  contextPacket: {
+    purpose: 'Use Open Brain as local memory source of truth.',
+    boundaries: ['Do not promote private raw data.'],
+    requiredInputs: ['Approved source records.'],
+    currentRisks: ['Stale source review.'],
+    expectedOutputs: ['Approved memory proposals.'],
+  },
+}
+
+describe('OpenBrainPage', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/wiki/compile')) {
+        return { ok: true, json: async () => ({ pages: [{ slug: 'one' }] }) }
+      }
+      return { ok: true, json: async () => openBrainSnapshot }
+    }))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('renders Open Brain next actions and routes operators to the right view', async () => {
+    render(<OpenBrainPage />)
+
+    const nextActions = await screen.findByRole('region', { name: 'Open Brain next actions' })
+    expect(nextActions).toBeInTheDocument()
+    expect(within(nextActions).getByText('Memory proposals need review')).toBeInTheDocument()
+    expect(within(nextActions).getByText('Pending proposals')).toBeInTheDocument()
+    expect(within(nextActions).getByText('Stale sources')).toBeInTheDocument()
+    expect(within(nextActions).getByText('Producer gates')).toBeInTheDocument()
+    expect(within(nextActions).getByText('Runtime parity')).toBeInTheDocument()
+
+    fireEvent.click(within(nextActions).getByRole('button', { name: /Review proposals/i }))
+
+    expect(screen.getByText('Adopt action-first governance reviews')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Approve' })).toBeInTheDocument()
+  })
+
+  it('keeps wiki compilation as an explicit gated action', async () => {
+    render(<OpenBrainPage />)
+
+    const nextActions = await screen.findByRole('region', { name: 'Open Brain next actions' })
+    fireEvent.click(within(nextActions).getByRole('button', { name: /Compile wiki preview/i }))
+
+    expect(await screen.findByText('1 wiki page preview(s) compiled. Approval is required before repo writes.')).toBeInTheDocument()
+    expect(fetch).toHaveBeenCalledWith('/api/admin/agents/open-brain/wiki/compile', expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({ Authorization: 'Bearer admin-token' }),
+    }))
+  })
+})

--- a/app/admin/agents/open-brain/page.tsx
+++ b/app/admin/agents/open-brain/page.tsx
@@ -171,6 +171,13 @@ function OpenBrainContent() {
               <MetricCard label="Producer gates" value={snapshot.overview.enabledProducerGates} tone={snapshot.overview.enabledProducerGates ? 'green' : 'yellow'} />
             </div>
 
+            <OpenBrainControlPanel
+              snapshot={snapshot}
+              pendingProposals={pendingProposals.length}
+              onViewModeChange={setViewMode}
+              onCompileWiki={compileWiki}
+            />
+
             <section className="mb-6 rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-5">
               <div className="mb-4 flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
                 <div>
@@ -238,6 +245,127 @@ function OpenBrainContent() {
         ) : null}
       </div>
     </div>
+  )
+}
+
+function OpenBrainControlPanel({
+  snapshot,
+  pendingProposals,
+  onViewModeChange,
+  onCompileWiki,
+}: {
+  snapshot: OpenBrainSnapshot
+  pendingProposals: number
+  onViewModeChange: (mode: ViewMode) => void
+  onCompileWiki: () => void
+}) {
+  const blockedProducerGates = snapshot.producerGates.filter((gate) => gate.status === 'blocked').length
+  const parityIssues = snapshot.runtimeParity.filter((runtime) => runtime.status !== 'connected').length
+  const primary = pendingProposals
+    ? {
+        label: 'Memory proposals need review',
+        detail: `${pendingProposals} proposal(s) are waiting for approve or reject before becoming durable Open Brain memory.`,
+        action: 'Review proposals',
+        mode: 'proposals' as ViewMode,
+        tone: 'border-radiant-gold/40 bg-radiant-gold/10',
+      }
+    : snapshot.overview.staleSources
+      ? {
+          label: 'Source freshness needs review',
+          detail: `${snapshot.overview.staleSources} source(s) are stale and should be inspected before RAG or wiki promotion.`,
+          action: 'Inspect sources',
+          mode: 'sources' as ViewMode,
+          tone: 'border-yellow-400/35 bg-yellow-500/10',
+        }
+      : blockedProducerGates
+        ? {
+            label: 'Producer gates are blocked',
+            detail: `${blockedProducerGates} producer gate(s) need context or configuration before emitting records.`,
+            action: 'Review producers',
+            mode: 'producers' as ViewMode,
+            tone: 'border-yellow-400/35 bg-yellow-500/10',
+          }
+        : {
+            label: 'Open Brain projection is ready',
+            detail: 'No pending proposal is waiting. Router, source, parity, and producer views remain available for audit.',
+            action: 'Inspect router',
+            mode: 'router' as ViewMode,
+            tone: 'border-green-400/30 bg-green-500/10',
+          }
+
+  const cards = [
+    {
+      label: 'Pending proposals',
+      value: String(pendingProposals),
+      detail: 'Approve or reject proposed durable memories.',
+      action: 'Review',
+      onClick: () => onViewModeChange('proposals'),
+    },
+    {
+      label: 'Stale sources',
+      value: String(snapshot.overview.staleSources),
+      detail: 'Inspect source freshness before RAG/wiki use.',
+      action: 'Inspect',
+      onClick: () => onViewModeChange('sources'),
+    },
+    {
+      label: 'Producer gates',
+      value: String(blockedProducerGates),
+      detail: 'Blocked producers cannot safely emit records.',
+      action: 'Open',
+      onClick: () => onViewModeChange('producers'),
+    },
+    {
+      label: 'Runtime parity',
+      value: String(parityIssues),
+      detail: 'Confirm Codex, Hermes, and bridge registration.',
+      action: 'Check',
+      onClick: () => onViewModeChange('parity'),
+    },
+  ]
+
+  return (
+    <section className={`mb-6 rounded-lg border p-5 ${primary.tone}`} aria-label="Open Brain next actions">
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.4fr)]">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wider text-radiant-gold">Next Open Brain action</p>
+          <h2 className="mt-2 text-xl font-semibold">{primary.label}</h2>
+          <p className="mt-2 text-sm text-muted-foreground">{primary.detail}</p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => onViewModeChange(primary.mode)}
+              className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/50 bg-radiant-gold/10 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15"
+            >
+              {primary.action}
+            </button>
+            <button
+              type="button"
+              onClick={onCompileWiki}
+              className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 bg-background/55 px-3 py-2 text-sm hover:border-radiant-gold/45"
+            >
+              <FileText size={15} />
+              Compile wiki preview
+            </button>
+          </div>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          {cards.map((card) => (
+            <button
+              key={card.label}
+              type="button"
+              onClick={card.onClick}
+              className="rounded-lg border border-silicon-slate/70 bg-background/55 p-3 text-left transition hover:border-radiant-gold/45"
+            >
+              <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">{card.label}</p>
+              <p className="mt-2 text-2xl font-bold tabular-nums">{card.value}</p>
+              <p className="mt-1 min-h-[42px] text-xs text-muted-foreground">{card.detail}</p>
+              <span className="mt-3 inline-flex text-xs text-radiant-gold">{card.action}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </section>
   )
 }
 


### PR DESCRIPTION
## Summary
- add action-first control panels to Automation Context and Open Brain
- route operators directly to action tracker, context gaps, repair packets, proposals, stale sources, producers, and runtime parity
- add focused page coverage for the new governance L2 action hierarchy

## Validation
- npm test -- app/admin/agents/automations/page.test.tsx app/admin/agents/open-brain/page.test.tsx
- npm test -- app/admin/agents/automations/page.test.tsx app/admin/agents/open-brain/page.test.tsx app/api/admin/agents/automations/route.test.ts app/api/admin/agents/automation-actions/route.test.ts app/api/admin/agents/open-brain/route.test.ts app/api/admin/agents/open-brain/proposals/route.test.ts 'app/api/admin/agents/open-brain/proposals/[id]/approve/route.test.ts' lib/codex-automation-inventory.test.ts lib/codex-automation-action-tracker.test.ts lib/open-brain.test.ts lib/model-ops-open-brain.test.ts
- npm run build:knowledge && npx tsc --noEmit --pretty false
- npm run lint
- git diff --check
- local route smoke on port 3005: HEAD /admin/agents/automations 200, HEAD /admin/agents/open-brain 200

## Integration Notes
- No schema or backend route changes.
- Worktree env bootstrapped from /Users/vambahsillah/Projects/Portfolio via npm run worktree:env.
- Local dev emitted the existing MOCK_N8N/N8N_DISABLE_OUTBOUND warning; smoke was limited to route loading.
- Vercel contexts to verify after merge: Vercel – portfolio and Vercel – portfolio-staging.