### PR TITLE
fix: polish agent kanban card metadata

### DIFF
--- a/app/admin/agents/swarm-board/page.test.tsx
+++ b/app/admin/agents/swarm-board/page.test.tsx
@@ -115,7 +115,7 @@ const boardSnapshot = {
             status: 'ready_for_merge',
             priority: 'medium',
             ownerAgentKey: 'automation-systems',
-            ownerAgentName: 'Amina - Automation Systems',
+            ownerAgentName: 'integration-captain',
             ownerRuntime: 'codex',
             branchName: 'codex/review-packet',
             worktreePath: '/Users/vambahsillah/Projects/Portfolio.worktrees/review-packet',
@@ -271,6 +271,7 @@ describe('AgentSwarmBoardPage', () => {
     expect(screen.getAllByText('Resolve blocker').length).toBeGreaterThan(0)
     expect(screen.getAllByText('Attach PR').length).toBeGreaterThan(0)
     expect(screen.getAllByText('Open trace').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Integration Captain').length).toBeGreaterThan(0)
     expect(screen.getByRole('link', { name: `Open pull request 203 for ${longTaskTitle}` })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: `Open trace run-1 for ${longTaskTitle}` })).toHaveAttribute('href', '/admin/agents/runs/run-1')
   })

--- a/app/admin/agents/swarm-board/page.tsx
+++ b/app/admin/agents/swarm-board/page.tsx
@@ -882,11 +882,29 @@ function nextActionForTask(task: AgentOrgBoardTask) {
   }
 }
 
+function displayDetailValue(label: string, value: string) {
+  if (label !== 'Owner') return value
+  if (value.includes(' - ')) return value
+  if (!/^[a-z0-9_-]+$/i.test(value)) return value
+
+  const minorWords = new Set(['and', 'for', 'in', 'of', 'the', 'to'])
+  return value
+    .replace(/[_-]+/g, ' ')
+    .split(' ')
+    .map((word, index) => {
+      const lower = word.toLowerCase()
+      if (index > 0 && minorWords.has(lower)) return lower
+      return `${lower.slice(0, 1).toUpperCase()}${lower.slice(1)}`
+    })
+    .join(' ')
+}
+
 function CardDetail({ label, value }: { label: string; value: string }) {
+  const displayValue = displayDetailValue(label, value)
   return (
-    <div className="grid grid-cols-[64px_minmax(0,1fr)] gap-2 rounded-lg border border-silicon-slate/60 bg-silicon-slate/10 px-2 py-1.5">
-      <dt className="text-muted-foreground">{label}</dt>
-      <dd className="min-w-0 break-words text-foreground/85" title={value}>{value}</dd>
+    <div className="rounded-lg border border-silicon-slate/60 bg-silicon-slate/10 px-2.5 py-2">
+      <dt className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{label}</dt>
+      <dd className="mt-1 min-w-0 break-words text-xs leading-snug text-foreground/85" title={value}>{displayValue}</dd>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Makes compact Agent Kanban card metadata easier to scan by stacking label/value details instead of forcing values into a narrow two-column row.
- Humanizes fallback owner keys such as `integration-captain` into readable labels while preserving the raw value in the title attribute.
- Adds focused coverage so technical owner keys render as readable labels in the board cards.

## Validation
- `npm test -- app/admin/agents/swarm-board/page.test.tsx`
- `npm run lint -- --file app/admin/agents/swarm-board/page.tsx --file app/admin/agents/swarm-board/page.test.tsx`
- `npx tsc --noEmit --pretty false`
- Local authenticated Playwright QA for `/admin/agents/swarm-board` desktop and mobile: no login redirect, no console/request failures, no horizontal overflow.
- Screenshot artifacts: `/tmp/agent-kanban-card-polish-qa/kanban-desktop.png`, `/tmp/agent-kanban-card-polish-qa/kanban-mobile.png`.

## Integration Notes
- Narrow UI-only polish; no schema, API, or data migration.
- Pre-push database health check passed from the local hook.
- Vercel contexts not checked yet: `Vercel – portfolio`, `Vercel – portfolio-staging`.