### PR TITLE
fix: load local env for n8n drift check

### DIFF
--- a/scripts/n8n-workflow-drift-check.ts
+++ b/scripts/n8n-workflow-drift-check.ts
@@ -17,8 +17,12 @@
  * Add/edit workflow pairs in WORKFLOW_PAIRS below.
  */
 
-import 'dotenv/config'
+import { config } from 'dotenv'
+import { resolve } from 'path'
 import { diffLines } from 'diff'
+
+config({ path: resolve(process.cwd(), '.env.local') })
+config()
 
 type WorkflowPair = {
   label: string


### PR DESCRIPTION
## Summary
- load .env.local explicitly before the default dotenv fallback in the n8n workflow drift checker
- keep the existing N8N_BASE_URL default behavior unchanged
- make local drift-check runs more reliable from Portfolio worktrees and local shells

## Validation
- npm run build:knowledge && npx tsc --noEmit --pretty false
- npm run lint -- --file scripts/n8n-workflow-drift-check.ts
- git diff --check

## Integration Notes
- Script-only change; no schema, API route, or production workflow mutation.
- The drift checker still performs read-only n8n API reads when invoked with credentials.
- Vercel contexts to verify after merge: Vercel – portfolio and Vercel – portfolio-staging.