### PR TITLE
fix: align agent ops governance shells

### DIFF
--- a/app/admin/agents/automations/page.tsx
+++ b/app/admin/agents/automations/page.tsx
@@ -332,7 +332,7 @@ function AgentAutomationsContent() {
   const docWarnings = automations.filter((automation) => automation.controlDocs.length === 0)
 
   return (
-    <div className="min-h-screen bg-background text-foreground p-6 lg:p-8">
+    <div className="agent-ops-page min-h-screen p-5 text-foreground lg:p-7">
       <div className="max-w-7xl mx-auto">
         <Breadcrumbs items={[
           { label: 'Admin Dashboard', href: '/admin' },
@@ -340,17 +340,18 @@ function AgentAutomationsContent() {
           { label: 'Automation Context' },
         ]} />
 
-        <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <header className="agent-ops-surface-header mb-6 mt-5 flex flex-col gap-4 rounded-xl border p-5 lg:flex-row lg:items-start lg:justify-between">
           <div>
+            <p className="agent-ops-eyebrow"><Bot size={16} /> Agent Ops Automation</p>
             <h1 className="text-3xl font-bold mb-1">Automation Context</h1>
             <p className="text-muted-foreground text-sm max-w-3xl">
               Local-first inventory for Portfolio-related Codex automations, their risk boundaries, and the context agents need before acting.
             </p>
           </div>
-          <div className="flex flex-wrap gap-2">
+          <div className="agent-ops-header-actions">
             <Link
               href="/admin/agents"
-              className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 bg-silicon-slate/30 px-3 py-2 text-sm hover:border-radiant-gold/60"
+              className="agent-ops-button-muted"
             >
               <Bot size={16} />
               Agent Operations
@@ -358,13 +359,13 @@ function AgentAutomationsContent() {
             <button
               onClick={fetchInventory}
               disabled={loading}
-              className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/50 bg-radiant-gold/10 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15 disabled:opacity-60"
+              className="agent-ops-button-secondary disabled:opacity-60"
             >
               <RefreshCw size={16} className={loading ? 'animate-spin' : ''} />
               Refresh
             </button>
           </div>
-        </div>
+        </header>
 
         {loading ? (
           <div className="py-16 text-center text-muted-foreground">Loading automation inventory...</div>
@@ -402,7 +403,8 @@ function AgentAutomationsContent() {
 
             <MemoryOrganizationProgress progress={inventory.progress} />
 
-            <div className="mb-6 inline-flex rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-1">
+            <div className="mb-6 max-w-full overflow-x-auto rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-1">
+              <div className="inline-flex min-w-max">
               <button
                 onClick={() => setViewMode('actions')}
                 className={`inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm ${viewMode === 'actions' ? 'bg-radiant-gold/15 text-radiant-gold' : 'text-muted-foreground hover:text-foreground'}`}
@@ -431,6 +433,7 @@ function AgentAutomationsContent() {
                 <ShieldAlert size={16} />
                 Repair Packets
               </button>
+              </div>
             </div>
 
             <section className="mb-6 rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
@@ -622,8 +625,8 @@ function AutomationTable({
   }
 
   return (
-    <div className="overflow-hidden rounded-lg border border-silicon-slate/70">
-      <table className="w-full text-sm">
+    <div className="overflow-x-auto rounded-lg border border-silicon-slate/70">
+      <table className="min-w-[860px] w-full text-sm">
         <thead className="bg-silicon-slate/40 text-muted-foreground">
           <tr>
             <th className="text-left px-4 py-3 font-medium">Automation</th>
@@ -911,8 +914,8 @@ function WorkspaceRootVisibility({ report }: { report: AutomationInventoryRespon
       )}
 
       <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_360px] gap-4">
-        <div className="overflow-hidden rounded-lg border border-silicon-slate/70">
-          <table className="w-full text-sm">
+        <div className="overflow-x-auto rounded-lg border border-silicon-slate/70">
+          <table className="min-w-[720px] w-full text-sm">
             <thead className="bg-silicon-slate/40 text-muted-foreground">
               <tr>
                 <th className="text-left px-4 py-3 font-medium">Thread root</th>

--- a/app/admin/agents/open-brain/page.tsx
+++ b/app/admin/agents/open-brain/page.tsx
@@ -104,7 +104,7 @@ function OpenBrainContent() {
   }
 
   return (
-    <div className="min-h-screen bg-background text-foreground p-6 lg:p-8">
+    <div className="agent-ops-page min-h-screen p-5 text-foreground lg:p-7">
       <div className="mx-auto max-w-7xl">
         <Breadcrumbs items={[
           { label: 'Admin Dashboard', href: '/admin' },
@@ -112,18 +112,18 @@ function OpenBrainContent() {
           { label: 'Open Brain' },
         ]} />
 
-        <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <header className="agent-ops-surface-header mb-6 mt-5 flex flex-col gap-4 rounded-xl border p-5 lg:flex-row lg:items-start lg:justify-between">
           <div>
-            <p className="text-xs font-semibold uppercase tracking-wider text-radiant-gold">Agent Operations</p>
+            <p className="agent-ops-eyebrow"><Brain size={16} /> Agent Ops Memory</p>
             <h1 className="mt-1 text-3xl font-bold">Open Brain</h1>
             <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
               Local-first memory projection for Portfolio Agent Ops. The local Open Brain remains the source of truth; Portfolio shows health, proposals, source freshness, producer gates, and generated wiki previews.
             </p>
           </div>
-          <div className="flex flex-wrap gap-2">
+          <div className="agent-ops-header-actions">
             <Link
               href="/admin/agents/automations"
-              className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 bg-silicon-slate/30 px-3 py-2 text-sm hover:border-radiant-gold/60"
+              className="agent-ops-button-muted"
             >
               <GitBranch size={16} />
               Automation Context
@@ -131,13 +131,13 @@ function OpenBrainContent() {
             <button
               onClick={fetchSnapshot}
               disabled={loading}
-              className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/50 bg-radiant-gold/10 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15 disabled:opacity-60"
+              className="agent-ops-button-secondary disabled:opacity-60"
             >
               <RefreshCw size={16} className={loading ? 'animate-spin' : ''} />
               Refresh
             </button>
           </div>
-        </div>
+        </header>
 
         {loading ? (
           <div className="py-16 text-center text-muted-foreground">Loading Open Brain status...</div>
@@ -202,17 +202,19 @@ function OpenBrainContent() {
             </section>
 
             <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
-              <div className="inline-flex rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-1">
+              <div className="max-w-full overflow-x-auto rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-1">
+                <div className="inline-flex min-w-max">
                 <ModeButton icon={<Route size={16} />} active={viewMode === 'router'} onClick={() => setViewMode('router')}>Router</ModeButton>
                 <ModeButton icon={<Database size={16} />} active={viewMode === 'sources'} onClick={() => setViewMode('sources')}>Sources</ModeButton>
                 <ModeButton icon={<ShieldCheck size={16} />} active={viewMode === 'proposals'} onClick={() => setViewMode('proposals')}>Proposals</ModeButton>
                 <ModeButton icon={<FileText size={16} />} active={viewMode === 'wiki'} onClick={() => setViewMode('wiki')}>Wiki Overlay</ModeButton>
                 <ModeButton icon={<Network size={16} />} active={viewMode === 'parity'} onClick={() => setViewMode('parity')}>Runtime Parity</ModeButton>
                 <ModeButton icon={<GitBranch size={16} />} active={viewMode === 'producers'} onClick={() => setViewMode('producers')}>Producers</ModeButton>
+                </div>
               </div>
               <button
                 onClick={compileWiki}
-                className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/50 bg-radiant-gold/10 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15"
+                className="agent-ops-button-secondary"
               >
                 <FileText size={16} />
                 Compile wiki preview
@@ -440,8 +442,8 @@ function RouterView({ snapshot }: { snapshot: OpenBrainSnapshot }) {
 
       <section className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-5">
         <h2 className="mb-3 font-semibold">Latest Benchmark Evidence</h2>
-        <div className="overflow-hidden rounded-lg border border-silicon-slate/70">
-          <table className="w-full text-sm">
+        <div className="overflow-x-auto rounded-lg border border-silicon-slate/70">
+          <table className="min-w-[720px] w-full text-sm">
             <thead className="bg-silicon-slate/40 text-muted-foreground">
               <tr>
                 <th className="px-4 py-3 text-left font-medium">Task</th>
@@ -488,8 +490,8 @@ function RouterView({ snapshot }: { snapshot: OpenBrainSnapshot }) {
 
 function SourcesView({ snapshot }: { snapshot: OpenBrainSnapshot }) {
   return (
-    <div className="overflow-hidden rounded-lg border border-silicon-slate/70">
-      <table className="w-full text-sm">
+    <div className="overflow-x-auto rounded-lg border border-silicon-slate/70">
+      <table className="min-w-[760px] w-full text-sm">
         <thead className="bg-silicon-slate/40 text-muted-foreground">
           <tr>
             <th className="px-4 py-3 text-left font-medium">Source</th>


### PR DESCRIPTION
## Summary
- Brings Automation Context and Open Brain onto the shared Agent Ops/Mission Control shell with `agent-ops-page`, `agent-ops-surface-header`, shared eyebrow styling, and shared header action buttons.
- Adds mobile-safe horizontal wrappers around mode tabs and dense tables so L2 governance pages do not create page-level horizontal overflow.
- Keeps the work UI-only: no API, schema, data, or workflow behavior changes.

## Validation
- `npm test -- app/admin/agents/open-brain/page.test.tsx app/admin/agents/automations/page.test.tsx`
- `npm run lint -- --file app/admin/agents/open-brain/page.tsx --file app/admin/agents/automations/page.tsx`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- Local authenticated Playwright QA on branch dev server `http://localhost:3006` for:
  - `/admin/agents/automations` desktop + mobile
  - `/admin/agents/open-brain` desktop + mobile
  - additional lower mobile scroll checks for both pages
- Visual QA results: no login redirects, no console/request failures, no horizontal overflow, shared shell classes present.
- Screenshot artifacts: `/tmp/agent-ops-l2-shell-polish-qa/automations-desktop.png`, `/tmp/agent-ops-l2-shell-polish-qa/automations-mobile.png`, `/tmp/agent-ops-l2-shell-polish-qa/open-brain-desktop.png`, `/tmp/agent-ops-l2-shell-polish-qa/open-brain-mobile.png`.

## Integration Notes
- UI-only L2 parity pass; rollback is reverting the two TSX files.
- Worktree env bootstrapped from `/Users/vambahsillah/Projects/Portfolio`; local generated validation-only files were not committed.
- Vercel contexts to verify after merge: `Vercel – portfolio`, `Vercel – portfolio-staging`.