### PR TITLE
fix: neutralize kanban action queue panel

### DIFF
--- a/app/admin/agents/swarm-board/page.tsx
+++ b/app/admin/agents/swarm-board/page.tsx
@@ -358,7 +358,7 @@ function BoardActionQueue({
   totalCount: number
 }) {
   return (
-    <section className="rounded-lg border border-radiant-gold/35 bg-radiant-gold/10 p-4" aria-label="Kanban action queue">
+    <section className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/15 p-4" aria-label="Kanban action queue">
       <div className="flex flex-col gap-2 lg:flex-row lg:items-start lg:justify-between">
         <div>
           <div className="flex items-center gap-2">


### PR DESCRIPTION
Summary
- Neutralizes the Agent Kanban Board Action Queue container so it no longer reads as a gold/disabled/warning panel.
- Keeps gold for the section label and executable/action accents while using the standard slate panel background for the work surface.

Validation
- npm test -- app/admin/agents/swarm-board/page.test.tsx
- npm run lint -- --file app/admin/agents/swarm-board/page.tsx --file app/admin/agents/swarm-board/page.test.tsx
- npx tsc --noEmit --pretty false
- Browser QA at http://localhost:3000/admin/agents/swarm-board: no login redirect, no horizontal overflow, no console/request failures; screenshot captured at /tmp/kanban-action-queue-neutral-qa/swarm-board-action-queue.png

Integration Notes
- One-line visual treatment change only; no API, schema, or route changes.
- Vercel contexts not checked yet: Vercel – portfolio and Vercel – portfolio-staging remain integration-captain gates.
- Rollback path: revert fd71623 to restore the previous gold panel treatment.