### PR TITLE
feat: add standup agent multiselect

### DIFF
--- a/app/admin/agents/standup/page.test.tsx
+++ b/app/admin/agents/standup/page.test.tsx
@@ -241,6 +241,9 @@ describe('AgentStandupRoomPage', () => {
 
     expect(await screen.findByRole('heading', { name: 'Standup Room' })).toBeInTheDocument()
     expect(screen.getByText('Attendance')).toBeInTheDocument()
+    expect(await screen.findByLabelText('2 of 2 selected')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Select all' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Clear' })).toBeInTheDocument()
     expect(screen.getAllByRole('img', { name: /Illustrated avatar for Shaka/i }).length).toBeGreaterThan(0)
     expect(screen.getByRole('heading', { name: 'Swarm chat' })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: 'Goal planner' })).toBeInTheDocument()
@@ -278,7 +281,7 @@ describe('AgentStandupRoomPage', () => {
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith('/api/admin/agents/war-room', expect.objectContaining({
         method: 'POST',
-        body: JSON.stringify({ command: 'standup' }),
+        body: JSON.stringify({ command: 'standup', target_agent_keys: ['chief-of-staff', 'engineering-copilot'] }),
       }))
     })
     await waitFor(() => {
@@ -288,7 +291,7 @@ describe('AgentStandupRoomPage', () => {
     expect(screen.getByText('1/1 answered')).toBeInTheDocument()
 
     fireEvent.change(screen.getByPlaceholderText(/Ask about blockers/i), { target: { value: '@Shaka what is blocked?' } })
-    fireEvent.click(screen.getByRole('button', { name: /Ask agent/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Ask all/i }))
 
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith('/api/admin/agents/war-room', expect.objectContaining({
@@ -297,8 +300,8 @@ describe('AgentStandupRoomPage', () => {
       }))
     })
 
-    fireEvent.click(screen.getByRole('button', { name: /Piye/i }))
-    expect(screen.getByText(/Target: Piye/i)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /Add Piye from standup selection/i }))
+    expect(screen.getByText(/Target: 2 selected/i)).toBeInTheDocument()
     expect(screen.getByPlaceholderText(/Ask about blockers/i)).toHaveValue('@Piye ')
 
     fireEvent.change(screen.getByPlaceholderText(/Ask about blockers/i), { target: { value: 'What changed since last standup?' } })
@@ -311,13 +314,17 @@ describe('AgentStandupRoomPage', () => {
       }))
     })
 
-    fireEvent.change(screen.getByPlaceholderText(/Ask about blockers/i), { target: { value: '@Piye give me your implementation update' } })
-    fireEvent.click(screen.getByRole('button', { name: /Ask all/i }))
+    fireEvent.change(screen.getByPlaceholderText(/Ask about blockers/i), { target: { value: 'Give us your implementation updates' } })
+    fireEvent.click(screen.getByRole('button', { name: /Ask 2 agents/i }))
 
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith('/api/admin/agents/war-room', expect.objectContaining({
         method: 'POST',
-        body: JSON.stringify({ command: 'ask_agent', message: '@Piye give me your implementation update', target_agent_key: 'engineering-copilot' }),
+        body: JSON.stringify({
+          command: 'discuss',
+          message: 'Give us your implementation updates',
+          target_agent_keys: ['chief-of-staff', 'engineering-copilot'],
+        }),
       }))
     })
   })
@@ -370,7 +377,7 @@ describe('AgentStandupRoomPage', () => {
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith('/api/admin/agents/war-room', expect.objectContaining({
         method: 'POST',
-        body: JSON.stringify({ command: 'standup', goal_id: 'goal-1' }),
+        body: JSON.stringify({ command: 'standup', target_agent_keys: ['chief-of-staff', 'engineering-copilot'], goal_id: 'goal-1' }),
       }))
     })
 

--- a/app/admin/agents/standup/page.tsx
+++ b/app/admin/agents/standup/page.tsx
@@ -105,7 +105,8 @@ function StandupRoomContent() {
   const [organization, setOrganization] = useState<AgentOrgBoardSnapshot | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [selectedAgentKey, setSelectedAgentKey] = useState('chief-of-staff')
+  const [selectedAgentKeys, setSelectedAgentKeys] = useState<string[]>([])
+  const [selectionInitialized, setSelectionInitialized] = useState(false)
   const [message, setMessage] = useState('')
   const [goal, setGoal] = useState('')
   const [focusedGoalId, setFocusedGoalId] = useState<string | null>(null)
@@ -156,7 +157,15 @@ function StandupRoomContent() {
     const agents = organization?.agents ?? []
     return agents.filter((agent) => agent.status !== 'planned').slice(0, 12)
   }, [organization?.agents])
-  const selectedAgent = participants.find((agent) => agent.key === selectedAgentKey) ?? participants[0]
+  useEffect(() => {
+    if (selectionInitialized || !participants.length) return
+    setSelectedAgentKeys(participants.map((agent) => agent.key))
+    setSelectionInitialized(true)
+  }, [participants, selectionInitialized])
+  const selectedAgents = useMemo(() => {
+    const selected = participants.filter((agent) => selectedAgentKeys.includes(agent.key))
+    return selected
+  }, [participants, selectedAgentKeys])
   const allTasks = useMemo(() => organization?.lanes.flatMap((lane) => lane.tasks) ?? [], [organization?.lanes])
   const focusedGoal = useMemo(() => {
     if (!focusedGoalId || !organization) return null
@@ -255,13 +264,16 @@ function StandupRoomContent() {
   }
 
   async function startStandup() {
+    const targetAgentKeys = selectedAgents.map((agent) => agent.key)
     const questionId = addQuestion({
       command: 'standup',
-      prompt: 'Start standup and ask every available agent for current posture.',
-      targetLabel: 'All available agents',
+      prompt: targetAgentKeys.length
+        ? `Start standup with ${targetAgentKeys.length} selected agent(s).`
+        : 'Start standup and ask every available agent for current posture.',
+      targetLabel: targetAgentKeys.length ? `${targetAgentKeys.length} selected agent(s)` : 'All available agents',
       targetAgentKey: null,
     })
-    await postWarRoom({ command: 'standup' }, 'standup', questionId)
+    await postWarRoom(targetAgentKeys.length ? { command: 'standup', target_agent_keys: targetAgentKeys } : { command: 'standup' }, 'standup', questionId)
   }
 
   async function askAll() {
@@ -270,7 +282,7 @@ function StandupRoomContent() {
     const mentionedAgent = findMentionedAgent(text, participants)
     setMessage('')
     if (mentionedAgent) {
-      setSelectedAgentKey(mentionedAgent.key)
+      setSelectedAgentKeys([mentionedAgent.key])
       const questionId = addQuestion({
         command: 'ask_agent',
         prompt: text,
@@ -289,17 +301,32 @@ function StandupRoomContent() {
     await postWarRoom({ command: 'discuss', message: text }, 'ask-all', questionId)
   }
 
-  async function askSelectedAgent() {
-    if (!message.trim() || !selectedAgent) return
+  async function askSelectedAgents() {
+    if (!message.trim() || !selectedAgents.length) return
     const text = message.trim()
     setMessage('')
+    if (selectedAgents.length === 1) {
+      const agent = selectedAgents[0]
+      const questionId = addQuestion({
+        command: 'ask_agent',
+        prompt: text,
+        targetLabel: agentShortName(agent.name),
+        targetAgentKey: agent.key,
+      })
+      await postWarRoom({ command: 'ask_agent', message: text, target_agent_key: agent.key }, 'ask-agent', questionId)
+      return
+    }
     const questionId = addQuestion({
-      command: 'ask_agent',
+      command: 'discuss',
       prompt: text,
-      targetLabel: agentShortName(selectedAgent.name),
-      targetAgentKey: selectedAgent.key,
+      targetLabel: `${selectedAgents.length} selected agents`,
+      targetAgentKey: null,
     })
-    await postWarRoom({ command: 'ask_agent', message: text, target_agent_key: selectedAgent.key }, 'ask-agent', questionId)
+    await postWarRoom({
+      command: 'discuss',
+      message: text,
+      target_agent_keys: selectedAgents.map((agent) => agent.key),
+    }, 'ask-agent', questionId)
   }
 
   async function draftGoal() {
@@ -374,12 +401,18 @@ function StandupRoomContent() {
           <div className="mt-5 grid gap-5 xl:grid-cols-[260px_minmax(0,1fr)_340px]">
             <ParticipantRail
               participants={participants}
-              selectedAgentKey={selectedAgent?.key ?? selectedAgentKey}
+              selectedAgentKeys={selectedAgents.map((agent) => agent.key)}
               session={participantSession}
-              onSelect={(agent) => {
-                setSelectedAgentKey(agent.key)
+              onToggle={(agent) => {
+                setSelectedAgentKeys((current) => (
+                  current.includes(agent.key)
+                    ? current.filter((key) => key !== agent.key)
+                    : [...current, agent.key]
+                ))
                 setMessage((current) => current || `@${agentShortName(agent.name)} `)
               }}
+              onSelectAll={() => setSelectedAgentKeys(participants.map((agent) => agent.key))}
+              onClear={() => setSelectedAgentKeys([])}
             />
             <main className="space-y-5">
               {focusedGoal && (
@@ -395,10 +428,10 @@ function StandupRoomContent() {
                 commandTraces={commandTraces}
                 message={message}
                 onMessageChange={setMessage}
-                selectedAgent={selectedAgent}
+                selectedAgents={selectedAgents}
                 busy={busy}
                 onAskAll={askAll}
-                onAskAgent={askSelectedAgent}
+                onAskAgent={askSelectedAgents}
                 onQuickPrompt={setMessage}
               />
               <GoalPlanner
@@ -428,34 +461,53 @@ function StandupRoomContent() {
 
 function ParticipantRail({
   participants,
-  selectedAgentKey,
+  selectedAgentKeys,
   session,
-  onSelect,
+  onToggle,
+  onSelectAll,
+  onClear,
 }: {
   participants: AgentOrgBoardAgent[]
-  selectedAgentKey: string
+  selectedAgentKeys: string[]
   session: Map<string, ParticipantSessionState>
-  onSelect: (agent: AgentOrgBoardAgent) => void
+  onToggle: (agent: AgentOrgBoardAgent) => void
+  onSelectAll: () => void
+  onClear: () => void
 }) {
   return (
     <aside className="agent-ops-card rounded-lg border p-3">
       <div className="mb-3 flex items-center justify-between gap-2">
         <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-radiant-gold">Attendance</h2>
-        <span className="rounded-full border border-silicon-slate/60 px-2 py-1 text-xs text-muted-foreground">{participants.length}</span>
+        <span
+          aria-label={`${selectedAgentKeys.length} of ${participants.length} selected`}
+          className="rounded-full border border-silicon-slate/60 px-2 py-1 text-xs text-muted-foreground"
+        >
+          {selectedAgentKeys.length}/{participants.length}
+        </span>
+      </div>
+      <div className="mb-3 grid grid-cols-2 gap-2">
+        <button type="button" onClick={onSelectAll} className="rounded-lg border border-silicon-slate/60 px-2 py-1 text-xs text-muted-foreground hover:border-radiant-gold/50 hover:text-radiant-gold">
+          Select all
+        </button>
+        <button type="button" onClick={onClear} className="rounded-lg border border-silicon-slate/60 px-2 py-1 text-xs text-muted-foreground hover:border-radiant-gold/50 hover:text-radiant-gold">
+          Clear
+        </button>
       </div>
       <div className="space-y-2">
         {participants.map((agent) => {
           const state = session.get(agent.key)
           const statusLabel = state?.responded ? 'Responded' : state?.asked ? 'Asked' : agent.live ? 'Available' : 'Idle'
+          const selected = selectedAgentKeys.includes(agent.key)
           return (
             <button
               key={agent.key}
               type="button"
-              onClick={() => onSelect(agent)}
-              aria-pressed={selectedAgentKey === agent.key}
+              onClick={() => onToggle(agent)}
+              aria-pressed={selected}
+              aria-label={`${selected ? 'Remove' : 'Add'} ${agentShortName(agent.name)} from standup selection`}
               className={`flex w-full items-center gap-3 rounded-lg border p-2 text-left transition ${
-                selectedAgentKey === agent.key
-                  ? 'border-radiant-gold/60 bg-radiant-gold/10'
+                selected
+                  ? 'border-silicon-slate/70 bg-silicon-slate/20 ring-1 ring-radiant-gold/25'
                   : 'border-silicon-slate/60 bg-background/40 hover:border-radiant-gold/40'
               }`}
             >
@@ -467,7 +519,17 @@ function ParticipantRail({
                   {statusLabel}{state?.messageCount ? ` · ${state.messageCount}` : ''}
                 </span>
               </span>
-              <span aria-hidden="true" className={`h-2 w-2 rounded-full ${state?.responded ? 'bg-radiant-gold' : agent.live ? 'bg-green-400' : 'bg-silicon-slate'}`} />
+              <span aria-hidden="true" className={`flex h-5 w-5 items-center justify-center rounded-full border ${
+                selected
+                  ? 'border-radiant-gold/70 text-radiant-gold'
+                  : state?.responded
+                    ? 'border-radiant-gold/50 bg-radiant-gold'
+                    : agent.live
+                      ? 'border-green-400/60 bg-green-400'
+                      : 'border-silicon-slate bg-silicon-slate'
+              }`}>
+                {selected && <CheckCircle2 size={14} />}
+              </span>
             </button>
           )
         })}
@@ -481,7 +543,7 @@ function ChatRoom({
   questions,
   commandTraces,
   message,
-  selectedAgent,
+  selectedAgents,
   busy,
   onMessageChange,
   onAskAll,
@@ -492,7 +554,7 @@ function ChatRoom({
   questions: StandupQuestion[]
   commandTraces: WarRoomCommandTrace[]
   message: string
-  selectedAgent?: AgentOrgBoardAgent
+  selectedAgents: AgentOrgBoardAgent[]
   busy: string | null
   onMessageChange: (value: string) => void
   onAskAll: () => void
@@ -508,12 +570,12 @@ function ChatRoom({
             <MessageSquare size={20} className="text-radiant-gold" />
             Swarm chat
           </h2>
-          <p className="mt-1 text-sm text-muted-foreground">Use @agent targeting or select a participant from attendance.</p>
+        <p className="mt-1 text-sm text-muted-foreground">Use @agent targeting or select one or more participants from attendance.</p>
         </div>
-        {selectedAgent && (
+        {selectedAgents.length > 0 && (
           <div className="flex items-center gap-2 rounded-full border border-silicon-slate/60 px-3 py-1 text-xs text-muted-foreground">
-            <AgentAvatar agentKey={selectedAgent.key} size="sm" />
-            Target: {agentShortName(selectedAgent.name)}
+            <AgentAvatar agentKey={selectedAgents[0].key} size="sm" />
+            Target: {selectedAgents.length === 1 ? agentShortName(selectedAgents[0].name) : `${selectedAgents.length} selected`}
           </div>
         )}
       </div>
@@ -577,16 +639,16 @@ function ChatRoom({
         <input
           value={message}
           onChange={(event) => onMessageChange(event.target.value)}
-          className="min-h-11 flex-1 rounded-lg border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm outline-none focus:border-radiant-gold/70"
+          className="min-h-11 flex-1 rounded-lg border border-silicon-slate/70 bg-silicon-slate/30 px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground/80 focus:border-radiant-gold/70"
           placeholder="Ask about blockers, owners, risk, next steps, or @Shaka for a direct update..."
         />
         <button onClick={onAskAll} disabled={busy != null || !message.trim()} className="inline-flex items-center justify-center gap-2 rounded-lg border border-radiant-gold/50 px-4 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/10 disabled:opacity-50">
           <Send size={16} />
           Ask all
         </button>
-        <button onClick={onAskAgent} disabled={busy != null || !message.trim()} className="inline-flex items-center justify-center gap-2 rounded-lg bg-radiant-gold px-4 py-2 text-sm font-semibold text-obsidian hover:bg-radiant-gold/90 disabled:opacity-50">
+        <button onClick={onAskAgent} disabled={busy != null || !message.trim() || selectedAgents.length === 0} className="inline-flex items-center justify-center gap-2 rounded-lg bg-radiant-gold px-4 py-2 text-sm font-semibold text-obsidian hover:bg-radiant-gold/90 disabled:opacity-50">
           <Send size={16} />
-          Ask agent
+          {selectedAgents.length > 1 ? `Ask ${selectedAgents.length} agents` : 'Ask selected'}
         </button>
       </div>
 
@@ -634,7 +696,7 @@ function GoalPlanner({
         <input
           value={goal}
           onChange={(event) => onGoalChange(event.target.value)}
-          className="min-h-11 flex-1 rounded-lg border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm outline-none focus:border-radiant-gold/70"
+          className="min-h-11 flex-1 rounded-lg border border-silicon-slate/70 bg-silicon-slate/30 px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground/80 focus:border-radiant-gold/70"
           placeholder="What should the swarm accomplish?"
         />
         <button onClick={onDraftGoal} disabled={busy != null || !goal.trim()} className="inline-flex items-center justify-center gap-2 rounded-lg border border-radiant-gold/50 px-4 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/10 disabled:opacity-50">

--- a/app/api/admin/agents/war-room/route.test.ts
+++ b/app/api/admin/agents/war-room/route.test.ts
@@ -118,6 +118,19 @@ describe('POST /api/admin/agents/war-room', () => {
     }))
   })
 
+  it('passes selected standup participants to the war room', async () => {
+    const response = await POST(request({
+      command: 'standup',
+      target_agent_keys: ['chief-of-staff', 'engineering-copilot'],
+    }) as never)
+
+    expect(response.status).toBe(200)
+    expect(mocks.runAgentWarRoom).toHaveBeenCalledWith(expect.objectContaining({
+      command: 'standup',
+      targetAgentKeys: ['chief-of-staff', 'engineering-copilot'],
+    }))
+  })
+
   it('passes ask_agent payloads to the war room', async () => {
     mocks.runAgentWarRoom.mockResolvedValue({
       runId: 'ask-run',

--- a/app/api/admin/agents/war-room/route.ts
+++ b/app/api/admin/agents/war-room/route.ts
@@ -31,7 +31,9 @@ export async function POST(request: NextRequest) {
     command?: unknown
     message?: unknown
     target_agent_key?: unknown
+    target_agent_keys?: unknown
     targetAgentKey?: unknown
+    targetAgentKeys?: unknown
     goal_id?: unknown
     goalId?: unknown
     goal?: unknown
@@ -58,6 +60,15 @@ export async function POST(request: NextRequest) {
     : typeof body.targetAgentKey === 'string'
       ? body.targetAgentKey.trim()
       : ''
+  const targetAgentKeysRaw = Array.isArray(body.target_agent_keys)
+    ? body.target_agent_keys
+    : Array.isArray(body.targetAgentKeys)
+      ? body.targetAgentKeys
+      : []
+  const targetAgentKeys = targetAgentKeysRaw
+    .filter((value): value is string => typeof value === 'string')
+    .map((value) => value.trim())
+    .filter(Boolean)
   if (command === 'ask_agent' && !targetAgentKey) {
     return NextResponse.json({ error: 'target_agent_key is required for ask_agent' }, { status: 400 })
   }
@@ -81,6 +92,7 @@ export async function POST(request: NextRequest) {
       command,
       message,
       targetAgentKey,
+      targetAgentKeys,
       goalId,
       goal,
       draft: command === 'approve_goal' ? body.draft as never : null,

--- a/lib/agent-war-room.test.ts
+++ b/lib/agent-war-room.test.ts
@@ -178,6 +178,22 @@ describe('runAgentWarRoom', () => {
     expect(result.messages.map((message) => message.content).join(' ')).toContain('Needs operator decision')
   })
 
+  it('limits standup updates to selected agent keys when provided', async () => {
+    const result = await runAgentWarRoom({
+      command: 'standup',
+      targetAgentKeys: ['engineering-copilot', 'chief-of-staff', 'engineering-copilot'],
+      triggerSource: 'test_war_room',
+      actor: { id: 'admin-user', label: 'Admin', type: 'admin_user' },
+    })
+
+    expect(result.updates.map((update) => update.agent_key)).toEqual(['engineering-copilot', 'chief-of-staff'])
+    expect(agentRunMocks.startAgentRun).toHaveBeenCalledWith(expect.objectContaining({
+      metadata: expect.objectContaining({
+        target_agent_keys: ['engineering-copilot', 'chief-of-staff', 'engineering-copilot'],
+      }),
+    }))
+  })
+
   it('rejects discuss without a message', async () => {
     await expect(
       runAgentWarRoom({

--- a/lib/agent-war-room.ts
+++ b/lib/agent-war-room.ts
@@ -48,6 +48,7 @@ export interface RunAgentWarRoomInput {
   command: AgentWarRoomCommand
   message?: string | null
   targetAgentKey?: string | null
+  targetAgentKeys?: string[] | null
   goalId?: string | null
   goal?: string | null
   draft?: AgentGoalDraft | null
@@ -73,11 +74,30 @@ function callableAgents() {
   return AGENT_ORGANIZATION.filter((agent) => agent.status !== 'planned')
 }
 
-function selectAgents(command: AgentWarRoomCommand, message: string | null, targetAgentKey?: string | null) {
+function selectedCallableAgents(targetAgentKeys?: string[] | null) {
+  if (!targetAgentKeys?.length) return []
+  const seen = new Set<string>()
+  return targetAgentKeys.map((key) => {
+    const agent = getAgentByKey(key)
+    if (!agent || agent.status === 'planned') throw new Error(`Invalid agent key: ${key}`)
+    return agent
+  }).filter((agent) => {
+    if (seen.has(agent.key)) return false
+    seen.add(agent.key)
+    return true
+  })
+}
+
+function selectAgents(command: AgentWarRoomCommand, message: string | null, targetAgentKey?: string | null, targetAgentKeys?: string[] | null) {
   if (command === 'ask_agent') {
     const agent = getAgentByKey(targetAgentKey ?? '')
     if (!agent || agent.status === 'planned') throw new Error('Invalid agent key')
     return [agent]
+  }
+
+  if (command === 'standup' || command === 'discuss') {
+    const selected = selectedCallableAgents(targetAgentKeys)
+    if (selected.length) return selected
   }
 
   const callable = callableAgents()
@@ -423,6 +443,7 @@ export async function runAgentWarRoom(input: RunAgentWarRoomInput) {
       command: input.command,
       message_preview: message,
       target_agent_key: input.targetAgentKey ?? null,
+      target_agent_keys: input.targetAgentKeys ?? null,
       goal_preview: goal,
       goal_id: activeGoalId,
       goal_session_href: activeGoalId ? goalSessionHref(activeGoalId) : null,
@@ -436,7 +457,7 @@ export async function runAgentWarRoom(input: RunAgentWarRoomInput) {
     buildAgentMissionControlSnapshot(),
     buildAgentOrgBoardSnapshot(),
   ])
-  const agents = selectAgents(input.command, message ?? goal, input.targetAgentKey)
+  const agents = selectAgents(input.command, message ?? goal, input.targetAgentKey, input.targetAgentKeys)
   const updates = agents.map((agent) => agentUpdate(agent, input.command, message ?? goal, orgSnapshot))
   const synthesis = synthesize(input.command, updates, snapshot.attention_queue.length)
   const messages: AgentWarRoomMessage[] = [


### PR DESCRIPTION
Summary
- Adds multi-select attendance controls to the Standup Room so selected agents can be brought into standup explicitly.
- Wires selected agents into standup and selected-agent chat payloads via target_agent_keys while preserving @agent direct asks.
- Updates Standup Room inputs and selection styling to stay aligned with the Mission Control operating-console aesthetic.

Validation
- npm test -- app/admin/agents/standup/page.test.tsx app/api/admin/agents/war-room/route.test.ts lib/agent-war-room.test.ts
- npm run lint -- --file app/admin/agents/standup/page.tsx --file app/admin/agents/standup/page.test.tsx --file app/api/admin/agents/war-room/route.ts --file app/api/admin/agents/war-room/route.test.ts --file lib/agent-war-room.ts --file lib/agent-war-room.test.ts
- npx tsc --noEmit --pretty false
- Browser QA fallback via Playwright at http://localhost:3000/admin/agents/standup: no login redirect, no horizontal overflow, no console/request failures; verified clear/select controls, 2 of 12 selected state, Target: 2 selected, and Ask 2 agents button. Screenshots: /tmp/standup-multiselect-qa/standup-default-selected-final.png and /tmp/standup-multiselect-qa/standup-chat-target-final.png

Integration Notes
- Adds optional target_agent_keys for standup/discuss commands; no database or schema changes.
- Browser plugin was available, but the required Node REPL browser-control tool was not exposed after discovery, so rendered QA used local Playwright.
- Vercel contexts not checked yet: Vercel – portfolio and Vercel – portfolio-staging remain integration-captain gates.
- Rollback path: revert dc86b18 to restore single-agent Standup Room targeting.