### PR TITLE
fix: lighten Open Brain operator packet

### DIFF
--- a/app/admin/agents/open-brain/page.tsx
+++ b/app/admin/agents/open-brain/page.tsx
@@ -266,7 +266,7 @@ function OpenBrainControlPanel({
         proof: 'Proposal review history and status live in the Proposals view.',
         action: 'Review proposals',
         mode: 'proposals' as ViewMode,
-        tone: 'border-radiant-gold/40 bg-radiant-gold/10',
+        tone: 'border-radiant-gold/45',
       }
     : snapshot.overview.staleSources
       ? {
@@ -278,7 +278,7 @@ function OpenBrainControlPanel({
           proof: 'Source timestamps and privacy tiers live in the Sources view.',
           action: 'Inspect sources',
           mode: 'sources' as ViewMode,
-          tone: 'border-yellow-400/35 bg-yellow-500/10',
+          tone: 'border-yellow-400/45',
         }
       : blockedProducerGates
         ? {
@@ -290,7 +290,7 @@ function OpenBrainControlPanel({
             proof: 'Producer status and required environment handles live in the Producers view.',
             action: 'Review producers',
             mode: 'producers' as ViewMode,
-            tone: 'border-yellow-400/35 bg-yellow-500/10',
+            tone: 'border-yellow-400/45',
           }
         : {
             label: 'Open Brain projection is ready',
@@ -301,11 +301,11 @@ function OpenBrainControlPanel({
             proof: 'Router decisions, parity status, and generated timestamps live in their drilldown views.',
             action: 'Inspect router',
             mode: 'router' as ViewMode,
-            tone: 'border-green-400/30 bg-green-500/10',
+            tone: 'border-green-400/45',
           }
 
   return (
-    <section className={`mb-6 rounded-lg border p-5 ${primary.tone}`} aria-label="Open Brain next actions">
+    <section className={`mb-6 rounded-lg border bg-background/20 p-5 ${primary.tone}`} aria-label="Open Brain next actions">
       <div className="grid gap-4 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.4fr)]">
         <div>
           <p className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-radiant-gold">
@@ -438,7 +438,7 @@ function OpenBrainActionMetrics({
 
 function OperatorPacketBlock({ title, value }: { title: string; value: string }) {
   return (
-    <div className="rounded-lg border border-silicon-slate/70 bg-background/55 p-3">
+    <div className="rounded-lg border border-silicon-slate/55 bg-background/20 p-3">
       <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">{title}</p>
       <p className="mt-2 text-sm leading-relaxed text-foreground/90">{value}</p>
     </div>

--- a/docs/design/amadutown-color-palette-audit.md
+++ b/docs/design/amadutown-color-palette-audit.md
@@ -16,6 +16,7 @@ The Agent Ops Mission Control surface at `/admin/agents` is the current referenc
 - **AmaduTown dark system:** Use the shared navy/gold palette from `app/globals.css` and `tailwind.config.ts`, anchored by `bg-background`, deep navy panels, radiant gold command accents, platinum text, and restrained slate support tones.
 - **Mission Control surfaces:** Prefer panel/card structures similar to the Agent Ops shared visual language: luminous but controlled backgrounds, fine borders, subtle glow, 8px-ish radii, dense spacing, and scannable headings.
 - **Action clarity:** Status blocks, counts, health labels, and read-only pills must be visually distinct from executable controls. Buttons should use clear verbs and should show consistent hover, focus, disabled, and loading states.
+- **Active surfaces over shaded boxes:** Operational panels should not rely on heavy blue, slate, gold, or semantic tinted fills for whole sections. If a panel is active and actionable, keep the background light/neutral within the dark system and carry state through border accents, labels, icons, and explicit controls. Reserve dense muted shading for disabled, archived, loading, or intentionally de-emphasized content.
 - **Subtle texture only:** Glow and depth can guide the eye, but noisy grain, high-contrast textures, and decorative effects should not compete with data or controls.
 - **Consistent drilldowns:** L1 command surfaces summarize and route. L2/L3 pages own detail, history, approvals, logs, charts, and full work boards.
 


### PR DESCRIPTION
## Summary
- reduce the shaded fill on the Open Brain operator packet so it reads as active, not disabled
- keep packet state visible through border accents and explicit action buttons
- add the active-surface shading rule to the AmaduTown design architecture doc

## Validation
- npm test -- app/admin/agents/open-brain/page.test.tsx app/api/admin/agents/open-brain/route.test.ts
- npm run lint -- --file app/admin/agents/open-brain/page.tsx
- npx tsc --noEmit --pretty false
- git diff --check -- app/admin/agents/open-brain/page.tsx docs/design/amadutown-color-palette-audit.md
- local Playwright smoke for /admin/agents/open-brain at 937x838

## Integration Notes
- UI and design-doc only; no API, database, or schema changes.
- Vercel contexts not checked yet: Vercel – portfolio, Vercel – portfolio-staging.