### PR TITLE
feat: seed automation goals for Agent Ops

### DIFF
--- a/app/admin/agents/page.test.tsx
+++ b/app/admin/agents/page.test.tsx
@@ -156,6 +156,54 @@ const moremiReview = {
   linked_work_items: [],
 }
 
+const automationGoals = [
+  {
+    id: 'meeting-intake-follow-up-drafts',
+    tier: 1,
+    title: 'Automate meeting intake to follow-up drafts',
+    objective: 'Convert meeting signals into records and follow-up drafts.',
+    workflowFamily: 'meeting_follow_up',
+    automationLevel: 'draft_to_review',
+    ownerAgentKey: 'meeting-intake-follow-up',
+    collaboratorAgentKeys: ['chief-of-staff'],
+    sourceRoutes: ['/admin/meetings'],
+    sourceDocs: ['docs/meeting-follow-up-communications-guide.md'],
+    n8nWorkflows: ['WF-MCH'],
+    approvalGate: 'External sends require approval.',
+    nextAction: 'Confirm every meeting can route into a draft follow-up.',
+    requiresNewWorkflow: false,
+    seeded: false,
+    seeded_child_count: 0,
+    seeded_parent_work_item: null,
+  },
+  {
+    id: 'warm-lead-review-ready-outreach',
+    tier: 1,
+    title: 'Automate warm lead capture to review-ready outreach',
+    objective: 'Ingest and draft outreach.',
+    workflowFamily: 'warm_lead_capture',
+    automationLevel: 'draft_to_review',
+    ownerAgentKey: 'warm-lead-capture',
+    collaboratorAgentKeys: ['inbox-follow-up'],
+    sourceRoutes: ['/admin/outreach'],
+    sourceDocs: ['docs/warm-lead-workflow-integration.md'],
+    n8nWorkflows: ['WF-WRM-001', 'WF-WRM-002'],
+    approvalGate: 'Outbound use requires approval.',
+    nextAction: 'Seed source-specific exception tasks.',
+    requiresNewWorkflow: false,
+    seeded: true,
+    seeded_child_count: 2,
+    seeded_parent_work_item: {
+      id: 'automation-parent-2',
+      status: 'queued',
+      metadata: {
+        goal_session_href: '/admin/agents/standup?goal=automation%3Awarm-lead-review-ready-outreach',
+        goal_kanban_href: '/admin/agents/swarm-board?goal=automation%3Awarm-lead-review-ready-outreach',
+      },
+    },
+  },
+]
+
 function formatExpectedPageTime(value: string) {
   return new Intl.DateTimeFormat('en', {
     month: 'short',
@@ -174,6 +222,23 @@ describe('AgentOperationsPage mission control landing', () => {
       }
       if (url === '/api/admin/agents/risk-compliance/monitor?review=latest') {
         return { ok: true, json: async () => ({ review: moremiReview }) }
+      }
+      if (url === '/api/admin/agents/automation-goals?tier=1') {
+        return { ok: true, json: async () => ({ goals: automationGoals }) }
+      }
+      if (url === '/api/admin/agents/automation-goals/seed' && init?.method === 'POST') {
+        return {
+          ok: true,
+          json: async () => ({
+            ok: true,
+            seeded_goals: [
+              {
+                seed_id: 'meeting-intake-follow-up-drafts',
+                parent_work_item: { id: 'automation-parent-1', active_run_id: 'automation-run-1' },
+              },
+            ],
+          }),
+        }
       }
       if (url === '/api/admin/agents/chief-of-staff/chat' && init?.method === 'POST') {
         return {
@@ -247,6 +312,13 @@ describe('AgentOperationsPage mission control landing', () => {
     expect(screen.getByLabelText('Operator checks')).toBeInTheDocument()
     expect(screen.getByLabelText('Operator checks pagination')).toHaveTextContent('Showing 1-2 of 4 · 1/2')
     expect(screen.getByText('Scheduled manual triggers with duplicate-run guards.')).toBeInTheDocument()
+    const automationPanel = screen.getByLabelText('Automation to-do')
+    expect(automationPanel).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Seed Tier 1/i })).toBeInTheDocument()
+    expect(screen.getByText('Automate meeting intake to follow-up drafts')).toBeInTheDocument()
+    expect(screen.getByText('1/2 seeded')).toBeInTheDocument()
+    expect(within(automationPanel).getAllByRole('link', { name: /Standup/i })[0]).toHaveAttribute('href', '/admin/agents/standup?goal=automation%3Ameeting-intake-follow-up-drafts')
+    expect(within(automationPanel).getAllByRole('link', { name: /Kanban/i })[0]).toHaveAttribute('href', '/admin/agents/swarm-board?goal=automation%3Ameeting-intake-follow-up-drafts')
     expect(screen.getByText('Morning review')).toBeInTheDocument()
     expect(screen.getByText('Hermes health')).toBeInTheDocument()
     expect(screen.getAllByRole('button', { name: /^Run$/ }).length).toBeGreaterThan(0)
@@ -319,5 +391,22 @@ describe('AgentOperationsPage mission control landing', () => {
     const actionBar = await screen.findByLabelText('Mission Control actions')
     expect(within(actionBar).queryByRole('link', { name: /Open standup/i })).not.toBeInTheDocument()
     expect(screen.getByRole('link', { name: /Open Standup Room/i })).toHaveAttribute('href', '/admin/agents/standup')
+  })
+
+  it('seeds Tier 1 automation goals from Mission Control', async () => {
+    render(<AgentOperationsPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /Seed Tier 1/i }))
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/admin/agents/automation-goals/seed', expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ Authorization: 'Bearer admin-token' }),
+        body: JSON.stringify({
+          tier: 1,
+          confirmation: 'seed_agent_automation_goals',
+        }),
+      }))
+    })
   })
 })

--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -300,6 +300,30 @@ type MoremiMonitorReview = {
   }>
 }
 
+type AutomationGoalSummary = {
+  id: string
+  tier: 1 | 2
+  title: string
+  objective: string
+  workflowFamily: string
+  automationLevel: 'full_internal' | 'draft_to_review' | 'approval_gated' | 'discovery_only'
+  ownerAgentKey: string
+  collaboratorAgentKeys: string[]
+  sourceRoutes: string[]
+  sourceDocs: string[]
+  n8nWorkflows: string[]
+  approvalGate: string
+  nextAction: string
+  requiresNewWorkflow: boolean
+  seeded: boolean
+  seeded_child_count: number
+  seeded_parent_work_item: {
+    id: string
+    status: string
+    metadata?: Record<string, unknown>
+  } | null
+}
+
 type OperatorActionKind = 'morning-review' | 'hermes' | 'approval-drill' | 'runtime-evaluation'
 
 const OPERATOR_ACTIONS: Array<{
@@ -367,6 +391,10 @@ export default function AgentOperationsPage() {
   const [moremiReviewConfirm, setMoremiReviewConfirm] = useState(false)
   const [inboxPage, setInboxPage] = useState(0)
   const [operatorRuns, setOperatorRuns] = useState<OperatorRun[]>([])
+  const [automationGoals, setAutomationGoals] = useState<AutomationGoalSummary[]>([])
+  const [automationGoalsLoading, setAutomationGoalsLoading] = useState(false)
+  const [automationSeedLoading, setAutomationSeedLoading] = useState(false)
+  const [automationGoalPage, setAutomationGoalPage] = useState(0)
 
   const authedFetch = useCallback(async (path: string, init: RequestInit = {}) => {
     const session = await getCurrentSession()
@@ -421,14 +449,29 @@ export default function AgentOperationsPage() {
     }
   }, [authedFetch])
 
+  const loadAutomationGoals = useCallback(async () => {
+    setAutomationGoalsLoading(true)
+    try {
+      const response = await authedFetch('/api/admin/agents/automation-goals?tier=1')
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`)
+      setAutomationGoals(Array.isArray(body.goals) ? body.goals : [])
+    } catch {
+      setAutomationGoals([])
+    } finally {
+      setAutomationGoalsLoading(false)
+    }
+  }, [authedFetch])
+
   useEffect(() => {
     loadMissionControl()
     loadMoremiReview()
     loadOperatorRuns()
-  }, [loadMissionControl, loadMoremiReview, loadOperatorRuns])
+    loadAutomationGoals()
+  }, [loadMissionControl, loadMoremiReview, loadOperatorRuns, loadAutomationGoals])
 
   async function refreshMissionControl() {
-    await Promise.all([loadMissionControl(), loadMoremiReview(), loadOperatorRuns()])
+    await Promise.all([loadMissionControl(), loadMoremiReview(), loadOperatorRuns(), loadAutomationGoals()])
   }
 
   async function askChiefOfStaff(message: string) {
@@ -595,6 +638,29 @@ export default function AgentOperationsPage() {
     }
   }
 
+  async function seedTierOneAutomationGoals() {
+    setAutomationSeedLoading(true)
+    setActionResult(null)
+    setError(null)
+    try {
+      const response = await authedFetch('/api/admin/agents/automation-goals/seed', {
+        method: 'POST',
+        body: JSON.stringify({
+          tier: 1,
+          confirmation: 'seed_agent_automation_goals',
+        }),
+      })
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`)
+      setActionResult({ label: `seeded ${body.seeded_goals?.length ?? 0} automation goal(s)`, runId: body.seeded_goals?.[0]?.parent_work_item?.active_run_id ?? 'automation-goals' })
+      await Promise.all([loadAutomationGoals(), loadMissionControl()])
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Automation goal seeding failed')
+    } finally {
+      setAutomationSeedLoading(false)
+    }
+  }
+
   const rosterCount = snapshot?.roster.flatMap((pod) => pod.agents).filter((agent) => agent.status !== 'planned').length ?? 0
   const decisionQueueCount = snapshot?.status_strip.pending_approvals ?? snapshot?.status_strip.waiting_for_approval ?? 0
   const kanbanSignalCount = (snapshot?.status_strip.running ?? 0) + (snapshot?.status_strip.queued ?? 0)
@@ -616,6 +682,8 @@ export default function AgentOperationsPage() {
   const inboxItems = snapshot?.agent_inbox ?? []
   const inboxPageCount = Math.max(1, Math.ceil(inboxItems.length / 3))
   const visibleInboxItems = inboxItems.slice(inboxPage * 3, inboxPage * 3 + 3)
+  const automationGoalPageCount = Math.max(1, Math.ceil(automationGoals.length / 3))
+  const visibleAutomationGoals = automationGoals.slice(automationGoalPage * 3, automationGoalPage * 3 + 3)
   const primaryWorkHomes = [
     {
       eyebrow: 'Decision Queue',
@@ -695,6 +763,10 @@ export default function AgentOperationsPage() {
   useEffect(() => {
     setInboxPage((page) => Math.min(page, Math.max(inboxPageCount - 1, 0)))
   }, [inboxPageCount])
+
+  useEffect(() => {
+    setAutomationGoalPage((page) => Math.min(page, Math.max(automationGoalPageCount - 1, 0)))
+  }, [automationGoalPageCount])
 
   return (
     <ProtectedRoute requireAdmin>
@@ -884,6 +956,17 @@ export default function AgentOperationsPage() {
                       result={actionResult?.kind ? actionResult : null}
                       runs={operatorRuns}
                       onRun={runOperatorAction}
+                    />
+                    <AutomationGoalsPanel
+                      goals={visibleAutomationGoals}
+                      allGoals={automationGoals}
+                      loading={automationGoalsLoading}
+                      seeding={automationSeedLoading}
+                      page={automationGoalPage}
+                      pageCount={automationGoalPageCount}
+                      onSeedTierOne={seedTierOneAutomationGoals}
+                      onPrevious={() => setAutomationGoalPage((page) => Math.max(page - 1, 0))}
+                      onNext={() => setAutomationGoalPage((page) => Math.min(page + 1, automationGoalPageCount - 1))}
                     />
                     {moremiReview?.has_monitor ? (
                       <button
@@ -1181,6 +1264,123 @@ function OperatorChecksPanel({
             </div>
           )
         })}
+      </div>
+    </div>
+  )
+}
+
+function AutomationGoalsPanel({
+  goals,
+  allGoals,
+  loading,
+  seeding,
+  page,
+  pageCount,
+  onSeedTierOne,
+  onPrevious,
+  onNext,
+}: {
+  goals: AutomationGoalSummary[]
+  allGoals: AutomationGoalSummary[]
+  loading: boolean
+  seeding: boolean
+  page: number
+  pageCount: number
+  onSeedTierOne: () => void
+  onPrevious: () => void
+  onNext: () => void
+}) {
+  const seededCount = allGoals.filter((goal) => goal.seeded).length
+  const allSeeded = allGoals.length > 0 && seededCount === allGoals.length
+
+  return (
+    <div className="rounded-lg border border-silicon-slate/60 bg-background/35 p-3" aria-label="Automation to-do">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wider text-radiant-gold">Automation to-do</p>
+          <p className="mt-1 text-xs text-muted-foreground">Seed reviewable goals for workflows agents can automate.</p>
+        </div>
+        <button
+          type="button"
+          onClick={onSeedTierOne}
+          disabled={loading || seeding || allSeeded}
+          className="inline-flex items-center gap-1 rounded-md border border-radiant-gold/50 bg-radiant-gold/10 px-2.5 py-1.5 text-xs font-medium text-radiant-gold hover:bg-radiant-gold/15 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {seeding ? <RefreshCw size={13} className="animate-spin" /> : <Sparkles size={13} />}
+          Seed Tier 1
+        </button>
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
+        <StatusOnlyPill tone={allSeeded ? 'green' : 'yellow'}>
+          {seededCount}/{allGoals.length} seeded
+        </StatusOnlyPill>
+        <PagerControls
+          label="Automation goals"
+          page={page}
+          pageCount={pageCount}
+          itemCount={allGoals.length}
+          pageSize={3}
+          onPrevious={onPrevious}
+          onNext={onNext}
+        />
+      </div>
+
+      <div className="mt-3 space-y-2">
+        {loading ? (
+          <p className="rounded-lg border border-silicon-slate/50 bg-black/10 p-3 text-sm text-muted-foreground">
+            Loading automation goals.
+          </p>
+        ) : goals.length ? goals.map((goal) => (
+          <AutomationGoalRow key={goal.id} goal={goal} />
+        )) : (
+          <p className="rounded-lg border border-silicon-slate/50 bg-black/10 p-3 text-sm text-muted-foreground">
+            No automation goal seeds are available.
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function AutomationGoalRow({ goal }: { goal: AutomationGoalSummary }) {
+  const goalId = `automation:${goal.id}`
+  const metadata = goal.seeded_parent_work_item?.metadata ?? {}
+  const standupHref = typeof metadata.goal_session_href === 'string'
+    ? metadata.goal_session_href
+    : `/admin/agents/standup?goal=${encodeURIComponent(goalId)}`
+  const kanbanHref = typeof metadata.goal_kanban_href === 'string'
+    ? metadata.goal_kanban_href
+    : `/admin/agents/swarm-board?goal=${encodeURIComponent(goalId)}`
+  const tone = goal.seeded ? 'green' : goal.requiresNewWorkflow ? 'yellow' : 'blue'
+
+  return (
+    <div className="rounded-lg border border-silicon-slate/55 bg-black/10 p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-[11px] font-semibold uppercase tracking-wider text-radiant-gold">{goal.workflowFamily.replace(/_/g, ' ')}</p>
+          <p className="mt-1 line-clamp-2 text-sm font-semibold">{goal.title}</p>
+        </div>
+        <StatusOnlyPill tone={tone}>{goal.seeded ? 'Seeded' : goal.requiresNewWorkflow ? 'Needs workflow' : 'Ready'}</StatusOnlyPill>
+      </div>
+      <p className="mt-2 line-clamp-2 text-xs leading-5 text-muted-foreground">{goal.nextAction}</p>
+      <div className="mt-2 flex flex-wrap gap-1.5 text-[11px] text-muted-foreground">
+        <span className="rounded-full border border-silicon-slate/50 bg-background/40 px-2 py-0.5">{goal.ownerAgentKey.replace(/-/g, ' ')}</span>
+        <span className="rounded-full border border-silicon-slate/50 bg-background/40 px-2 py-0.5">{goal.automationLevel.replace(/_/g, ' ')}</span>
+        {goal.n8nWorkflows.length ? (
+          <span className="rounded-full border border-silicon-slate/50 bg-background/40 px-2 py-0.5">{goal.n8nWorkflows.length} n8n workflow(s)</span>
+        ) : null}
+      </div>
+      <div className="mt-3 flex flex-wrap items-center justify-between gap-2 text-xs">
+        <span className="text-muted-foreground">{goal.seeded_child_count} task(s)</span>
+        <div className="flex gap-3">
+          <Link href={standupHref} className="text-radiant-gold hover:underline">
+            Standup
+          </Link>
+          <Link href={kanbanHref} className="text-radiant-gold hover:underline">
+            Kanban
+          </Link>
+        </div>
       </div>
     </div>
   )

--- a/app/api/admin/agents/automation-goals/route.test.ts
+++ b/app/api/admin/agents/automation-goals/route.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  listAutomationGoalSeedStates: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-automation-goal-seeding', () => ({
+  listAutomationGoalSeedStates: mocks.listAutomationGoalSeedStates,
+}))
+
+import { GET } from './route'
+
+function request(url = 'http://localhost/api/admin/agents/automation-goals') {
+  return new Request(url, {
+    headers: { authorization: 'Bearer token' },
+  })
+}
+
+describe('GET /api/admin/agents/automation-goals', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.listAutomationGoalSeedStates.mockResolvedValue([
+      {
+        seedId: 'meeting-intake-follow-up-drafts',
+        parent: { id: 'parent-work-item' },
+        children: [{ id: 'child-1' }, { id: 'child-2' }],
+      },
+    ])
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await GET(request() as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+  })
+
+  it('returns catalog goals with seeded state', async () => {
+    const response = await GET(request('http://localhost/api/admin/agents/automation-goals?tier=1') as never)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.goals).toHaveLength(5)
+    expect(body.goals[0]).toMatchObject({
+      id: 'meeting-intake-follow-up-drafts',
+      seeded: true,
+      seeded_parent_work_item: { id: 'parent-work-item' },
+      seeded_child_count: 2,
+    })
+  })
+})

--- a/app/api/admin/agents/automation-goals/route.ts
+++ b/app/api/admin/agents/automation-goals/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { listAutomationGoalSeeds } from '@/lib/agent-automation-goals'
+import { listAutomationGoalSeedStates } from '@/lib/agent-automation-goal-seeding'
+
+export const dynamic = 'force-dynamic'
+
+function parseTier(value: string | null): 1 | 2 | undefined {
+  if (value === '1') return 1
+  if (value === '2') return 2
+  return undefined
+}
+
+export async function GET(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const tier = parseTier(new URL(request.url).searchParams.get('tier'))
+  const seeds = listAutomationGoalSeeds(tier)
+  const states = await listAutomationGoalSeedStates()
+  const statesBySeed = new Map(states.map((state) => [state.seedId, state]))
+
+  return NextResponse.json({
+    goals: seeds.map((seed) => {
+      const state = statesBySeed.get(seed.id)
+      return {
+        ...seed,
+        seeded: Boolean(state?.parent),
+        seeded_parent_work_item: state?.parent ?? null,
+        seeded_child_count: state?.children.length ?? 0,
+      }
+    }),
+  })
+}

--- a/app/api/admin/agents/automation-goals/seed/route.test.ts
+++ b/app/api/admin/agents/automation-goals/seed/route.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  seedAutomationGoals: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-automation-goal-seeding', () => ({
+  seedAutomationGoals: mocks.seedAutomationGoals,
+}))
+
+import { POST } from './route'
+
+function request(body: unknown) {
+  return new Request('http://localhost/api/admin/agents/automation-goals/seed', {
+    method: 'POST',
+    headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/admin/agents/automation-goals/seed', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.seedAutomationGoals.mockResolvedValue([
+      {
+        seed: { id: 'meeting-intake-follow-up-drafts', title: 'Automate meeting intake to follow-up drafts' },
+        parent: { id: 'parent-work-item' },
+        children: [{ id: 'child-1' }],
+      },
+    ])
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(request({ confirmation: 'seed_agent_automation_goals' }) as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.seedAutomationGoals).not.toHaveBeenCalled()
+  })
+
+  it('requires confirmation before seeding', async () => {
+    const response = await POST(request({ tier: 1 }) as never)
+
+    expect(response.status).toBe(400)
+    expect(mocks.seedAutomationGoals).not.toHaveBeenCalled()
+  })
+
+  it('seeds selected or Tier 1 automation goals', async () => {
+    const response = await POST(request({
+      tier: 1,
+      seed_ids: ['meeting-intake-follow-up-drafts'],
+      confirmation: 'seed_agent_automation_goals',
+    }) as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      seeded_goals: [{ seed_id: 'meeting-intake-follow-up-drafts', parent_work_item: { id: 'parent-work-item' } }],
+    })
+    expect(mocks.seedAutomationGoals).toHaveBeenCalledWith({
+      seedIds: ['meeting-intake-follow-up-drafts'],
+      tier: 1,
+      triggeredByUserId: 'admin-user',
+    })
+  })
+})

--- a/app/api/admin/agents/automation-goals/seed/route.ts
+++ b/app/api/admin/agents/automation-goals/seed/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { seedAutomationGoals } from '@/lib/agent-automation-goal-seeding'
+
+export const dynamic = 'force-dynamic'
+
+function parseTier(value: unknown): 1 | 2 | undefined {
+  if (value === 1 || value === '1') return 1
+  if (value === 2 || value === '2') return 2
+  return undefined
+}
+
+function stringArray(value: unknown) {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : undefined
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as Record<string, unknown>
+  if (body.confirmation !== 'seed_agent_automation_goals') {
+    return NextResponse.json({ error: 'confirmation is required' }, { status: 400 })
+  }
+
+  try {
+    const seeded = await seedAutomationGoals({
+      seedIds: stringArray(body.seed_ids),
+      tier: parseTier(body.tier) ?? 1,
+      triggeredByUserId: auth.user.id,
+    })
+
+    return NextResponse.json({
+      ok: true,
+      seeded_goals: seeded.map(({ seed, parent, children }) => ({
+        seed_id: seed.id,
+        title: seed.title,
+        parent_work_item: parent,
+        child_work_items: children,
+      })),
+    })
+  } catch (error) {
+    console.error('[automation-goals] seed failed:', error)
+    const message = error instanceof Error ? error.message : 'Failed to seed automation goals'
+    const status = message.startsWith('Unknown automation goal seed') ? 400 : 500
+    return NextResponse.json(
+      { error: message },
+      { status },
+    )
+  }
+}

--- a/app/api/admin/agents/n8n-workflow-proposals/route.test.ts
+++ b/app/api/admin/agents/n8n-workflow-proposals/route.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  createN8nWorkflowProposal: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-n8n-workflow-proposals', () => ({
+  createN8nWorkflowProposal: mocks.createN8nWorkflowProposal,
+  isN8nWorkflowProposalAction: (value: string) => [
+    'inspect_workflow',
+    'draft_workflow',
+    'stage_workflow',
+    'request_activation',
+  ].includes(value),
+}))
+
+import { POST } from './route'
+
+function request(body: unknown) {
+  return new Request('http://localhost/api/admin/agents/n8n-workflow-proposals', {
+    method: 'POST',
+    headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/admin/agents/n8n-workflow-proposals', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.createN8nWorkflowProposal.mockResolvedValue({ id: 'proposal-work-item' })
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(request({ action: 'draft_workflow', title: 'Draft', objective: 'Draft' }) as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+  })
+
+  it('creates draft workflow proposals', async () => {
+    const response = await POST(request({
+      action: 'draft_workflow',
+      title: 'Meeting follow-up workflow',
+      objective: 'Draft the n8n workflow.',
+      workflow_family: 'meeting_follow_up',
+      automation_goal_seed_id: 'meeting-intake-follow-up-drafts',
+      required_env_vars: ['N8N_INGEST_SECRET'],
+      credential_needs: ['Supabase API'],
+      node_plan: ['Webhook trigger'],
+      ingest_callbacks: ['/api/admin/meetings/ingest'],
+    }) as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ ok: true, work_item: { id: 'proposal-work-item' } })
+    expect(mocks.createN8nWorkflowProposal).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'draft_workflow',
+      title: 'Meeting follow-up workflow',
+      requestedByUserId: 'admin-user',
+      requiredEnvVars: ['N8N_INGEST_SECRET'],
+    }))
+  })
+
+  it('requires confirmation for staging and activation requests', async () => {
+    const response = await POST(request({
+      action: 'stage_workflow',
+      title: 'Stage workflow',
+      objective: 'Stage inactive workflow.',
+    }) as never)
+
+    expect(response.status).toBe(400)
+    expect(mocks.createN8nWorkflowProposal).not.toHaveBeenCalled()
+  })
+
+  it('rejects invalid actions', async () => {
+    const response = await POST(request({
+      action: 'activate_now',
+      title: 'Bad',
+      objective: 'Bad',
+    }) as never)
+
+    expect(response.status).toBe(400)
+  })
+})

--- a/app/api/admin/agents/n8n-workflow-proposals/route.ts
+++ b/app/api/admin/agents/n8n-workflow-proposals/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import {
+  createN8nWorkflowProposal,
+  isN8nWorkflowProposalAction,
+} from '@/lib/agent-n8n-workflow-proposals'
+
+export const dynamic = 'force-dynamic'
+
+function stringArray(value: unknown) {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
+}
+
+function nullableString(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as Record<string, unknown>
+  const action = nullableString(body.action)
+  if (!action || !isN8nWorkflowProposalAction(action)) {
+    return NextResponse.json({ error: 'Invalid n8n workflow proposal action' }, { status: 400 })
+  }
+
+  if ((action === 'stage_workflow' || action === 'request_activation') && body.confirmation !== 'create_n8n_workflow_proposal') {
+    return NextResponse.json({ error: 'confirmation is required before staging or activation requests' }, { status: 400 })
+  }
+
+  const title = nullableString(body.title)
+  const objective = nullableString(body.objective)
+  if (!title || !objective) {
+    return NextResponse.json({ error: 'title and objective are required' }, { status: 400 })
+  }
+
+  try {
+    const workItem = await createN8nWorkflowProposal({
+      action,
+      title,
+      objective,
+      workflowFamily: nullableString(body.workflow_family),
+      automationGoalSeedId: nullableString(body.automation_goal_seed_id),
+      existingWorkflowId: nullableString(body.existing_workflow_id),
+      proposedWorkflowName: nullableString(body.proposed_workflow_name),
+      trigger: nullableString(body.trigger),
+      requiredEnvVars: stringArray(body.required_env_vars),
+      credentialNeeds: stringArray(body.credential_needs),
+      nodePlan: stringArray(body.node_plan),
+      ingestCallbacks: stringArray(body.ingest_callbacks),
+      testEvidence: nullableString(body.test_evidence),
+      rollbackPath: nullableString(body.rollback_path),
+      requestedByUserId: auth.user.id,
+    })
+
+    return NextResponse.json({ ok: true, work_item: workItem })
+  } catch (error) {
+    console.error('[n8n-workflow-proposals] create failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to create n8n workflow proposal' },
+      { status: 500 },
+    )
+  }
+}

--- a/lib/agent-automation-goal-seeding.test.ts
+++ b/lib/agent-automation-goal-seeding.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  createAgentWorkItem: vi.fn(),
+  listAgentWorkItems: vi.fn(),
+}))
+
+vi.mock('@/lib/agent-work-items', () => ({
+  createAgentWorkItem: mocks.createAgentWorkItem,
+  listAgentWorkItems: mocks.listAgentWorkItems,
+}))
+
+import { listAutomationGoalSeedStates, seedAutomationGoals } from './agent-automation-goal-seeding'
+
+type MockCreateWorkItemInput = {
+  idempotencyKey: string | null
+  title: string
+  status?: string
+  ownerAgentKey?: string | null
+  parentWorkItemId?: string | null
+  metadata?: Record<string, unknown>
+}
+
+describe('agent automation goal seeding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.createAgentWorkItem.mockImplementation(async (input: MockCreateWorkItemInput) => ({
+      id: input.idempotencyKey,
+      title: input.title,
+      status: input.status,
+      owner_agent_key: input.ownerAgentKey,
+      parent_work_item_id: input.parentWorkItemId ?? null,
+      metadata: input.metadata,
+      idempotency_key: input.idempotencyKey,
+    }))
+    mocks.listAgentWorkItems.mockResolvedValue([])
+  })
+
+  it('creates a parent goal and child tasks with automation metadata', async () => {
+    const result = await seedAutomationGoals({
+      seedIds: ['meeting-intake-follow-up-drafts'],
+      triggeredByUserId: 'admin-user',
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.children).toHaveLength(2)
+    expect(mocks.createAgentWorkItem).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'Goal: Automate meeting intake to follow-up drafts',
+      ownerAgentKey: 'chief-of-staff',
+      status: 'queued',
+      idempotencyKey: 'automation-goal:meeting-intake-follow-up-drafts:parent',
+      metadata: expect.objectContaining({
+        automation_seed: true,
+        automation_goal_seed_id: 'meeting-intake-follow-up-drafts',
+        goal_role: 'parent',
+        goal_id: 'automation:meeting-intake-follow-up-drafts',
+      }),
+    }))
+    expect(mocks.createAgentWorkItem).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'assigned',
+      parentWorkItemId: 'automation-goal:meeting-intake-follow-up-drafts:parent',
+      idempotencyKey: 'automation-goal:meeting-intake-follow-up-drafts:task:1',
+      metadata: expect.objectContaining({
+        goal_role: 'task',
+        requires_approval: true,
+        goal_parent_work_item_id: 'automation-goal:meeting-intake-follow-up-drafts:parent',
+      }),
+    }))
+  })
+
+  it('defaults to Tier 1 seeds and rejects unknown selected seeds', async () => {
+    const seeded = await seedAutomationGoals({ triggeredByUserId: 'admin-user' })
+
+    expect(seeded).toHaveLength(5)
+    expect(mocks.createAgentWorkItem).toHaveBeenCalled()
+
+    await expect(seedAutomationGoals({ seedIds: ['missing-seed'] })).rejects.toThrow('Unknown automation goal seed')
+  })
+
+  it('reports existing seeded state by parent and children', async () => {
+    mocks.listAgentWorkItems.mockResolvedValue([
+      {
+        id: 'parent',
+        idempotency_key: 'automation-goal:meeting-intake-follow-up-drafts:parent',
+        metadata: { automation_seed: true, automation_goal_seed_id: 'meeting-intake-follow-up-drafts', goal_role: 'parent' },
+      },
+      {
+        id: 'child-2',
+        idempotency_key: 'automation-goal:meeting-intake-follow-up-drafts:task:2',
+        metadata: { automation_seed: true, automation_goal_seed_id: 'meeting-intake-follow-up-drafts', goal_role: 'task', goal_sequence: 2 },
+      },
+      {
+        id: 'child-1',
+        idempotency_key: 'automation-goal:meeting-intake-follow-up-drafts:task:1',
+        metadata: { automation_seed: true, automation_goal_seed_id: 'meeting-intake-follow-up-drafts', goal_role: 'task', goal_sequence: 1 },
+      },
+    ])
+
+    const states = await listAutomationGoalSeedStates()
+    const state = states.find((item) => item.seedId === 'meeting-intake-follow-up-drafts')
+
+    expect(state?.parent?.id).toBe('parent')
+    expect(state?.children.map((item) => item.id)).toEqual(['child-1', 'child-2'])
+  })
+})

--- a/lib/agent-automation-goal-seeding.ts
+++ b/lib/agent-automation-goal-seeding.ts
@@ -1,0 +1,155 @@
+import {
+  getAutomationGoalSeed,
+  listAutomationGoalSeeds,
+  type AutomationGoalSeed,
+} from '@/lib/agent-automation-goals'
+import {
+  createAgentWorkItem,
+  listAgentWorkItems,
+  type AgentWorkItem,
+} from '@/lib/agent-work-items'
+
+export type AutomationGoalSeedState = {
+  seedId: string
+  parent: AgentWorkItem | null
+  children: AgentWorkItem[]
+}
+
+export type SeedAutomationGoalsInput = {
+  seedIds?: string[]
+  tier?: 1 | 2
+  triggeredByUserId?: string | null
+}
+
+export type SeededAutomationGoal = {
+  seed: AutomationGoalSeed
+  parent: AgentWorkItem
+  children: AgentWorkItem[]
+}
+
+const GOAL_SOURCE_TYPE = 'automation_goal_seed'
+const GOAL_TASK_SOURCE_TYPE = 'automation_goal_seed_task'
+
+function goalIdForSeed(seed: AutomationGoalSeed) {
+  return `automation:${seed.id}`
+}
+
+function goalSessionHref(seed: AutomationGoalSeed) {
+  return `/admin/agents/standup?goal=${encodeURIComponent(goalIdForSeed(seed))}`
+}
+
+function kanbanGoalHref(seed: AutomationGoalSeed) {
+  return `/admin/agents/swarm-board?goal=${encodeURIComponent(goalIdForSeed(seed))}`
+}
+
+function parentIdempotencyKey(seed: AutomationGoalSeed) {
+  return `automation-goal:${seed.id}:parent`
+}
+
+function taskIdempotencyKey(seed: AutomationGoalSeed, index: number) {
+  return `automation-goal:${seed.id}:task:${index + 1}`
+}
+
+function baseMetadata(seed: AutomationGoalSeed, triggeredByUserId?: string | null) {
+  const goalId = goalIdForSeed(seed)
+  return {
+    automation_seed: true,
+    automation_goal_seed_id: seed.id,
+    workflow_family: seed.workflowFamily,
+    automation_level: seed.automationLevel,
+    source_routes: seed.sourceRoutes,
+    source_docs: seed.sourceDocs,
+    n8n_workflows: seed.n8nWorkflows,
+    requires_new_workflow: seed.requiresNewWorkflow,
+    approval_gate: seed.approvalGate,
+    goal_id: goalId,
+    goal_title: seed.title,
+    goal_status: 'seeded',
+    goal_session_href: goalSessionHref(seed),
+    goal_kanban_href: kanbanGoalHref(seed),
+    seeded_by_user_id: triggeredByUserId ?? null,
+  }
+}
+
+export async function listAutomationGoalSeedStates(limit = 250): Promise<AutomationGoalSeedState[]> {
+  const items = await listAgentWorkItems({ limit })
+  const seededItems = items.filter((item) => item.metadata?.automation_seed === true)
+
+  return listAutomationGoalSeeds().map((seed) => {
+    const parent = seededItems.find((item) => item.idempotency_key === parentIdempotencyKey(seed)) ?? null
+    const children = seededItems
+      .filter((item) => item.metadata?.automation_goal_seed_id === seed.id && item.metadata?.goal_role === 'task')
+      .sort((a, b) => Number(a.metadata?.goal_sequence ?? 0) - Number(b.metadata?.goal_sequence ?? 0))
+    return { seedId: seed.id, parent, children }
+  })
+}
+
+export async function seedAutomationGoals(input: SeedAutomationGoalsInput = {}): Promise<SeededAutomationGoal[]> {
+  const seeds = resolveSeeds(input)
+  const seeded: SeededAutomationGoal[] = []
+
+  for (const seed of seeds) {
+    const metadata = baseMetadata(seed, input.triggeredByUserId)
+    const parent = await createAgentWorkItem({
+      title: `Goal: ${seed.title}`,
+      objective: seed.objective,
+      priority: 'high',
+      status: 'queued',
+      ownerAgentKey: 'chief-of-staff',
+      source: { type: GOAL_SOURCE_TYPE, id: seed.id, label: 'Automation goal seed' },
+      expectedFiles: seed.sourceRoutes,
+      metadata: {
+        ...metadata,
+        goal_role: 'parent',
+        goal_progress_weight: 0,
+        owner_agent_key: seed.ownerAgentKey,
+        collaborator_agent_keys: seed.collaboratorAgentKeys,
+        next_action: seed.nextAction,
+      },
+      idempotencyKey: parentIdempotencyKey(seed),
+    })
+
+    const children: AgentWorkItem[] = []
+    for (const [index, task] of seed.tasks.entries()) {
+      const child = await createAgentWorkItem({
+        title: task.title,
+        objective: task.objective,
+        priority: task.priority,
+        status: 'assigned',
+        ownerAgentKey: task.ownerAgentKey,
+        parentWorkItemId: parent.id,
+        source: { type: GOAL_TASK_SOURCE_TYPE, id: `${seed.id}:${index + 1}`, label: seed.title },
+        expectedFiles: task.expectedFiles ?? [],
+        metadata: {
+          ...metadata,
+          goal_role: 'task',
+          goal_parent_work_item_id: parent.id,
+          goal_sequence: index + 1,
+          goal_progress_weight: task.progressWeight,
+          acceptance_criteria: task.acceptanceCriteria,
+          risk_notes: task.riskNotes,
+          requires_approval: task.requiresApproval,
+          task_owner_agent_key: task.ownerAgentKey,
+        },
+        idempotencyKey: taskIdempotencyKey(seed, index),
+      })
+      children.push(child)
+    }
+
+    seeded.push({ seed, parent, children })
+  }
+
+  return seeded
+}
+
+function resolveSeeds(input: SeedAutomationGoalsInput) {
+  if (input.seedIds?.length) {
+    return input.seedIds.map((seedId) => {
+      const seed = getAutomationGoalSeed(seedId)
+      if (!seed) throw new Error(`Unknown automation goal seed: ${seedId}`)
+      return seed
+    })
+  }
+
+  return listAutomationGoalSeeds(input.tier ?? 1)
+}

--- a/lib/agent-automation-goals.test.ts
+++ b/lib/agent-automation-goals.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { AUTOMATION_GOAL_SEEDS, validateAutomationGoalCatalog } from './agent-automation-goals'
+
+describe('agent automation goal catalog', () => {
+  it('has valid owners and task definitions', () => {
+    expect(validateAutomationGoalCatalog()).toEqual([])
+  })
+
+  it('prioritizes Tier 1 goals that can create tracked work immediately', () => {
+    const tierOne = AUTOMATION_GOAL_SEEDS.filter((goal) => goal.tier === 1)
+
+    expect(tierOne.map((goal) => goal.id)).toEqual([
+      'meeting-intake-follow-up-drafts',
+      'warm-lead-review-ready-outreach',
+      'cold-lead-draft-sequence',
+      'meeting-to-social-drafts',
+      'value-evidence-presentation-package',
+    ])
+    expect(tierOne.every((goal) => goal.tasks.length > 0)).toBe(true)
+    expect(tierOne.every((goal) => goal.approvalGate.length > 0)).toBe(true)
+  })
+
+  it('marks workflow-generation candidates without treating them as production activation', () => {
+    const workflowCandidates = AUTOMATION_GOAL_SEEDS.filter((goal) => goal.requiresNewWorkflow)
+
+    expect(workflowCandidates.length).toBeGreaterThan(0)
+    expect(workflowCandidates.every((goal) => goal.approvalGate.toLowerCase().includes('approval'))).toBe(true)
+  })
+})

--- a/lib/agent-automation-goals.ts
+++ b/lib/agent-automation-goals.ts
@@ -1,0 +1,334 @@
+import { getAgentByKey } from '@/lib/agent-organization'
+import type { AgentWorkItemPriority } from '@/lib/agent-work-items'
+
+export type AutomationLevel = 'full_internal' | 'draft_to_review' | 'approval_gated' | 'discovery_only'
+
+export type AutomationGoalTaskSeed = {
+  title: string
+  objective: string
+  ownerAgentKey: string
+  priority: AgentWorkItemPriority
+  expectedFiles?: string[]
+  acceptanceCriteria: string[]
+  riskNotes: string
+  requiresApproval: boolean
+  progressWeight: number
+}
+
+export type AutomationGoalSeed = {
+  id: string
+  tier: 1 | 2
+  title: string
+  objective: string
+  workflowFamily: string
+  automationLevel: AutomationLevel
+  ownerAgentKey: string
+  collaboratorAgentKeys: string[]
+  sourceRoutes: string[]
+  sourceDocs: string[]
+  n8nWorkflows: string[]
+  approvalGate: string
+  nextAction: string
+  requiresNewWorkflow: boolean
+  tasks: AutomationGoalTaskSeed[]
+}
+
+export const AUTOMATION_GOAL_SEEDS: AutomationGoalSeed[] = [
+  {
+    id: 'meeting-intake-follow-up-drafts',
+    tier: 1,
+    title: 'Automate meeting intake to follow-up drafts',
+    objective: 'Convert meeting signals into records, action tasks, reply drafts, follow-up scheduling recommendations, and Mission Control exceptions.',
+    workflowFamily: 'meeting_follow_up',
+    automationLevel: 'draft_to_review',
+    ownerAgentKey: 'meeting-intake-follow-up',
+    collaboratorAgentKeys: ['chief-of-staff', 'inbox-follow-up', 'automation-systems'],
+    sourceRoutes: ['/admin/meetings', '/admin/meeting-tasks', '/admin/outreach'],
+    sourceDocs: ['docs/meeting-follow-up-communications-guide.md', 'docs/admin-sales-lead-pipeline-sop.md'],
+    n8nWorkflows: ['WF-SLK', 'WF-CAL', 'WF-MCH', 'WF-AGB', 'WF-FUP'],
+    approvalGate: 'External emails and calendar invitations stay approval-gated.',
+    nextAction: 'Confirm every meeting with action items can route into a draft follow-up or scheduling task.',
+    requiresNewWorkflow: false,
+    tasks: [
+      {
+        title: 'Map meeting signals into action-ready follow-up tasks',
+        objective: 'Audit the meeting intake, meeting task, and outreach handoff path so every captured meeting creates traceable follow-up work.',
+        ownerAgentKey: 'meeting-intake-follow-up',
+        priority: 'high',
+        expectedFiles: ['app/admin/meetings', 'app/admin/meeting-tasks', 'lib/meeting-action-tasks.ts'],
+        acceptanceCriteria: ['Meeting records have clear attribution.', 'Action items route to meeting tasks without duplicate manual entry.', 'Missing lead or project attribution becomes a Mission Control exception.'],
+        riskNotes: 'External sends must remain behind the existing outreach and calendar approval gates.',
+        requiresApproval: true,
+        progressWeight: 2,
+      },
+      {
+        title: 'Draft follow-up replies from meeting tasks',
+        objective: 'Route reply-ready meeting tasks into the outreach draft queue with owner, source meeting, and review status preserved.',
+        ownerAgentKey: 'inbox-follow-up',
+        priority: 'high',
+        expectedFiles: ['app/api/admin/meeting-action-tasks', 'app/api/admin/outreach', 'lib/communications.ts'],
+        acceptanceCriteria: ['Drafts preserve source meeting context.', 'The user can review, edit, approve, or reject before sending.', 'Sent drafts close the originating task when appropriate.'],
+        riskNotes: 'No autonomous external email send in V1.',
+        requiresApproval: true,
+        progressWeight: 2,
+      },
+    ],
+  },
+  {
+    id: 'warm-lead-review-ready-outreach',
+    tier: 1,
+    title: 'Automate warm lead capture to review-ready outreach',
+    objective: 'Ingest warm relationship leads, dedupe, enrich, qualify, draft outreach, and route source/auth exceptions.',
+    workflowFamily: 'warm_lead_capture',
+    automationLevel: 'draft_to_review',
+    ownerAgentKey: 'warm-lead-capture',
+    collaboratorAgentKeys: ['research-source-register', 'inbox-follow-up', 'automation-systems'],
+    sourceRoutes: ['/admin/outreach', '/admin/lead-dashboards'],
+    sourceDocs: ['docs/warm-lead-workflow-integration.md', 'docs/admin-sales-lead-pipeline-sop.md'],
+    n8nWorkflows: ['WF-WRM-001', 'WF-WRM-002', 'WF-WRM-003'],
+    approvalGate: 'Known warm-source ingestion is allowed; outbound use and new source expansion require approval.',
+    nextAction: 'Seed source-specific exception tasks for warm lead sources that cannot produce review-ready outreach.',
+    requiresNewWorkflow: false,
+    tasks: [
+      {
+        title: 'Normalize warm lead source ingestion',
+        objective: 'Verify Facebook, Google Contacts, and LinkedIn warm lead workflows write consistent contact records with source traceability.',
+        ownerAgentKey: 'warm-lead-capture',
+        priority: 'high',
+        expectedFiles: ['lib/n8n.ts', 'app/api/admin/outreach', 'n8n-exports'],
+        acceptanceCriteria: ['Each source preserves source labels and trace IDs.', 'Duplicate leads are suppressed or merged.', 'Auth/source failures become Agent Ops exceptions.'],
+        riskNotes: 'Live scrape drills and new source expansion need explicit approval.',
+        requiresApproval: true,
+        progressWeight: 2,
+      },
+      {
+        title: 'Route warm leads into review-ready drafts',
+        objective: 'Connect enriched warm leads to reviewable outreach drafts with owner, source, and next action visible.',
+        ownerAgentKey: 'inbox-follow-up',
+        priority: 'high',
+        expectedFiles: ['app/admin/outreach', 'lib/outreach-queue-generator.ts'],
+        acceptanceCriteria: ['High-fit warm leads get outreach drafts.', 'Drafts stay editable before send.', 'Low-confidence leads route to a triage queue.'],
+        riskNotes: 'Outbound email remains user-approved.',
+        requiresApproval: true,
+        progressWeight: 2,
+      },
+    ],
+  },
+  {
+    id: 'cold-lead-draft-sequence',
+    tier: 1,
+    title: 'Automate cold lead sourcing to draft sequence',
+    objective: 'Find leads, qualify them, generate draft sequences, detect replies, and escalate reply-required items.',
+    workflowFamily: 'cold_outreach',
+    automationLevel: 'draft_to_review',
+    ownerAgentKey: 'inbox-follow-up',
+    collaboratorAgentKeys: ['research-source-register', 'chief-of-staff'],
+    sourceRoutes: ['/admin/outreach', '/admin/email-center'],
+    sourceDocs: ['docs/admin-sales-lead-pipeline-sop.md'],
+    n8nWorkflows: ['WF-CLG-001', 'WF-CLG-003', 'WF-CLG-004', 'WF-GDR'],
+    approvalGate: 'Send Now remains approval-gated unless a future sequence policy explicitly authorizes sends.',
+    nextAction: 'Confirm the first cold sequence can be produced as a draft-only queue with reply escalation.',
+    requiresNewWorkflow: false,
+    tasks: [
+      {
+        title: 'Audit cold lead sourcing and qualification handoff',
+        objective: 'Confirm sourced leads include enough qualification evidence to create safe draft outreach.',
+        ownerAgentKey: 'research-source-register',
+        priority: 'medium',
+        expectedFiles: ['n8n-exports/WF-CLG-001-Cold-Lead-Sourcing.json', 'app/admin/outreach'],
+        acceptanceCriteria: ['Lead source, fit reason, and evidence are visible.', 'Weak evidence routes to review instead of drafting.', 'No production customer data enters non-production validation.'],
+        riskNotes: 'Lead enrichment providers and scrape sources may require separate bakeoff or approval.',
+        requiresApproval: true,
+        progressWeight: 1,
+      },
+      {
+        title: 'Create cold outreach draft sequence queue',
+        objective: 'Generate draft sequences and reply detection handoffs without automatic sending.',
+        ownerAgentKey: 'inbox-follow-up',
+        priority: 'high',
+        expectedFiles: ['app/api/admin/outreach', 'lib/outreach-queue-generator.ts', 'lib/n8n.ts'],
+        acceptanceCriteria: ['Draft sequence is reviewable before send.', 'Reply detection creates an Agent Ops item.', 'Rejected drafts do not trigger follow-up.'],
+        riskNotes: 'Autonomous sending is out of scope for this seed.',
+        requiresApproval: true,
+        progressWeight: 2,
+      },
+    ],
+  },
+  {
+    id: 'meeting-to-social-drafts',
+    tier: 1,
+    title: 'Automate meeting-to-social content drafts',
+    objective: 'Extract source-backed ideas, generate LinkedIn drafts, create image/audio variants, and queue review-ready posts.',
+    workflowFamily: 'social_content',
+    automationLevel: 'draft_to_review',
+    ownerAgentKey: 'voice-content-architect',
+    collaboratorAgentKeys: ['content-repurposing', 'website-product-copy', 'private-knowledge-librarian'],
+    sourceRoutes: ['/admin/social-content', '/admin/content/video-generation', '/admin/meetings'],
+    sourceDocs: ['docs/admin-sales-lead-pipeline-sop.md'],
+    n8nWorkflows: ['WF-SOC-001', 'WF-SOC-002', 'WF-SOC-003'],
+    approvalGate: 'Public publishing requires review and approval.',
+    nextAction: 'Make the meeting-to-LinkedIn draft lane explicit before adding YouTube publishing.',
+    requiresNewWorkflow: false,
+    tasks: [
+      {
+        title: 'Extract approved content ideas from meeting context',
+        objective: 'Pull source-safe content prompts from meetings and source registers into the social content queue.',
+        ownerAgentKey: 'voice-content-architect',
+        priority: 'high',
+        expectedFiles: ['app/admin/social-content', 'lib/meeting-action-tasks.ts'],
+        acceptanceCriteria: ['Each draft has source context.', 'Private material is flagged before use.', 'Drafts keep Vambah voice guidance visible.'],
+        riskNotes: 'Private meeting material must not become public copy without review.',
+        requiresApproval: true,
+        progressWeight: 2,
+      },
+      {
+        title: 'Prepare repurposed media variants',
+        objective: 'Generate image, audio, and short-form variants as reviewable assets attached to the social draft.',
+        ownerAgentKey: 'content-repurposing',
+        priority: 'medium',
+        expectedFiles: ['app/api/admin/social-content', 'app/admin/content/video-generation'],
+        acceptanceCriteria: ['Variants attach to the draft.', 'Failed media generation has a retry path.', 'Publishing remains separate from draft generation.'],
+        riskNotes: 'Voice/avatar/video providers are fast-moving and may need a bakeoff before promotion.',
+        requiresApproval: true,
+        progressWeight: 1,
+      },
+    ],
+  },
+  {
+    id: 'value-evidence-presentation-package',
+    tier: 1,
+    title: 'Automate value evidence to lead presentation package',
+    objective: 'Gather evidence, classify pain points, create value calculations, draft Gamma reports, and attach packages to lead records.',
+    workflowFamily: 'lead_value_package',
+    automationLevel: 'draft_to_review',
+    ownerAgentKey: 'research-source-register',
+    collaboratorAgentKeys: ['proposal-business-model', 'voice-content-architect', 'automation-systems'],
+    sourceRoutes: ['/admin/value-evidence', '/admin/reports/gamma', '/admin/lead-dashboards'],
+    sourceDocs: ['docs/value-evidence-pipeline-setup.md', 'docs/admin-sales-lead-pipeline-sop.md'],
+    n8nWorkflows: ['WF-VEP-001', 'WF-VEP-002'],
+    approvalGate: 'Client-facing delivery and proposal terms require approval.',
+    nextAction: 'Create a lead package path that moves evidence into a reviewable deck without manual copying.',
+    requiresNewWorkflow: false,
+    tasks: [
+      {
+        title: 'Run evidence extraction into lead package context',
+        objective: 'Connect internal evidence and social listening outputs to lead-specific value package readiness.',
+        ownerAgentKey: 'research-source-register',
+        priority: 'high',
+        expectedFiles: ['app/admin/value-evidence', 'app/api/admin/value-evidence', 'lib/n8n.ts'],
+        acceptanceCriteria: ['Selected leads can trigger evidence extraction.', 'Evidence counts and failures are visible.', 'Source provenance is retained.'],
+        riskNotes: 'Ingest secrets and source-provider credentials must not be exposed in traces.',
+        requiresApproval: true,
+        progressWeight: 2,
+      },
+      {
+        title: 'Draft lead presentation package',
+        objective: 'Use value evidence and meeting context to draft a Gamma report package linked to the lead.',
+        ownerAgentKey: 'proposal-business-model',
+        priority: 'high',
+        expectedFiles: ['app/admin/reports/gamma', 'lib/gamma-report-builder.ts'],
+        acceptanceCriteria: ['Deck has value calculation context.', 'Lead record links to generated package.', 'Client-facing send remains a separate approval.'],
+        riskNotes: 'Pricing/proposal claims require human review before delivery.',
+        requiresApproval: true,
+        progressWeight: 2,
+      },
+    ],
+  },
+  {
+    id: 'script-to-video-draft-queue',
+    tier: 2,
+    title: 'Automate script-to-video draft queue',
+    objective: 'Turn approved scripts and meeting ideas into reviewable YouTube or short-form video drafts.',
+    workflowFamily: 'video_content',
+    automationLevel: 'draft_to_review',
+    ownerAgentKey: 'content-repurposing',
+    collaboratorAgentKeys: ['voice-content-architect', 'amadutown-brand', 'automation-systems'],
+    sourceRoutes: ['/admin/content/video-generation', '/admin/content/videos'],
+    sourceDocs: ['docs/about-page-video-storyboard.md'],
+    n8nWorkflows: [],
+    approvalGate: 'Public video publishing and brand approval remain gated.',
+    nextAction: 'Draft the workflow proposal for script intake, media generation, and review queueing.',
+    requiresNewWorkflow: true,
+    tasks: [],
+  },
+  {
+    id: 'client-onboarding-progress-updates',
+    tier: 2,
+    title: 'Automate client onboarding and progress updates',
+    objective: 'Move client onboarding, milestone, blocker, and progress-update workflows into a single reviewable automation lane.',
+    workflowFamily: 'client_delivery',
+    automationLevel: 'approval_gated',
+    ownerAgentKey: 'automation-systems',
+    collaboratorAgentKeys: ['chief-of-staff', 'meeting-intake-follow-up'],
+    sourceRoutes: ['/admin/client-projects', '/admin/meeting-tasks'],
+    sourceDocs: ['docs/admin-sales-lead-pipeline-sop.md'],
+    n8nWorkflows: ['WF-000', 'WF-001', 'WF-002', 'WF-004', 'WF-005', 'WF-006', 'WF-007', 'WF-008', 'WF-009', 'WF-010', 'WF-011', 'WF-012'],
+    approvalGate: 'Client-visible sends and production project mutation remain gated.',
+    nextAction: 'Audit the existing client lifecycle workflows before seeding execution tasks.',
+    requiresNewWorkflow: false,
+    tasks: [],
+  },
+  {
+    id: 'rag-source-governance-exceptions',
+    tier: 2,
+    title: 'Automate RAG and source-governance exceptions',
+    objective: 'Route RAG freshness, privacy, source approval, and retrieval health exceptions into Agent Ops.',
+    workflowFamily: 'knowledge_governance',
+    automationLevel: 'approval_gated',
+    ownerAgentKey: 'private-knowledge-librarian',
+    collaboratorAgentKeys: ['research-source-register', 'risk-compliance-intelligence'],
+    sourceRoutes: ['/admin/agents/open-brain', '/api/admin/rag-health'],
+    sourceDocs: ['docs/n8n-rag-chatbot-troubleshooting.md'],
+    n8nWorkflows: ['WF-RAG-INGEST', 'WF-RAG-QUERY', 'WF-RAG-CHAT', 'WF-RAG-DIAGNOSTIC'],
+    approvalGate: 'Private source promotion and public chatbot policy changes require approval.',
+    nextAction: 'Create exception cards for RAG freshness and source policy gaps.',
+    requiresNewWorkflow: false,
+    tasks: [],
+  },
+  {
+    id: 'risk-compliance-signal-triage',
+    tier: 2,
+    title: 'Automate risk and compliance signal triage',
+    objective: 'Convert AI risk, privacy, security, and regulatory signals into proposed work items with reviewable remediation paths.',
+    workflowFamily: 'risk_compliance',
+    automationLevel: 'approval_gated',
+    ownerAgentKey: 'risk-compliance-intelligence',
+    collaboratorAgentKeys: ['chief-of-staff', 'engineering-copilot'],
+    sourceRoutes: ['/admin/agents/coordination', '/admin/agents/open-brain'],
+    sourceDocs: ['docs/ai-risk-compliance-agent.md'],
+    n8nWorkflows: [],
+    approvalGate: 'Policy, credential, production config, and remediation changes require approval.',
+    nextAction: 'Wire Moremi warning review into an automation-goal backlog lane.',
+    requiresNewWorkflow: true,
+    tasks: [],
+  },
+]
+
+export function listAutomationGoalSeeds(tier?: 1 | 2) {
+  return tier ? AUTOMATION_GOAL_SEEDS.filter((goal) => goal.tier === tier) : AUTOMATION_GOAL_SEEDS
+}
+
+export function getAutomationGoalSeed(seedId: string) {
+  return AUTOMATION_GOAL_SEEDS.find((goal) => goal.id === seedId) ?? null
+}
+
+export function validateAutomationGoalCatalog() {
+  const errors: string[] = []
+  const ids = new Set<string>()
+
+  for (const goal of AUTOMATION_GOAL_SEEDS) {
+    if (ids.has(goal.id)) errors.push(`Duplicate goal seed id: ${goal.id}`)
+    ids.add(goal.id)
+    if (!getAgentByKey(goal.ownerAgentKey)) errors.push(`${goal.id} has invalid owner agent ${goal.ownerAgentKey}`)
+    for (const collaborator of goal.collaboratorAgentKeys) {
+      if (!getAgentByKey(collaborator)) errors.push(`${goal.id} has invalid collaborator agent ${collaborator}`)
+    }
+    if (goal.tier === 1 && goal.tasks.length === 0) errors.push(`${goal.id} is Tier 1 but has no task seeds`)
+    for (const task of goal.tasks) {
+      if (!getAgentByKey(task.ownerAgentKey)) errors.push(`${goal.id} task "${task.title}" has invalid owner agent ${task.ownerAgentKey}`)
+      if (task.progressWeight <= 0) errors.push(`${goal.id} task "${task.title}" must have positive progress weight`)
+    }
+  }
+
+  return errors
+}

--- a/lib/agent-n8n-workflow-proposals.test.ts
+++ b/lib/agent-n8n-workflow-proposals.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  createAgentWorkItem: vi.fn(),
+}))
+
+vi.mock('@/lib/agent-work-items', () => ({
+  createAgentWorkItem: mocks.createAgentWorkItem,
+}))
+
+import { createN8nWorkflowProposal, isN8nWorkflowProposalAction } from './agent-n8n-workflow-proposals'
+
+describe('agent n8n workflow proposals', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.createAgentWorkItem.mockResolvedValue({ id: 'work-item-1' })
+  })
+
+  it('validates proposal actions', () => {
+    expect(isN8nWorkflowProposalAction('draft_workflow')).toBe(true)
+    expect(isN8nWorkflowProposalAction('delete_production_workflow')).toBe(false)
+  })
+
+  it('creates approval-gated n8n proposal work items', async () => {
+    const result = await createN8nWorkflowProposal({
+      action: 'draft_workflow',
+      title: 'Draft meeting follow-up workflow',
+      objective: 'Create a staging-safe workflow proposal.',
+      workflowFamily: 'meeting_follow_up',
+      automationGoalSeedId: 'meeting-intake-follow-up-drafts',
+      requiredEnvVars: ['N8N_INGEST_SECRET'],
+      credentialNeeds: ['Supabase API'],
+      nodePlan: ['Webhook trigger', 'HTTP callback'],
+      ingestCallbacks: ['/api/admin/meetings/ingest'],
+      rollbackPath: 'Delete inactive workflow proposal.',
+      requestedByUserId: 'admin-user',
+    })
+
+    expect(result).toEqual({ id: 'work-item-1' })
+    expect(mocks.createAgentWorkItem).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'n8n proposal: Draft meeting follow-up workflow',
+      status: 'proposed',
+      ownerAgentKey: 'automation-systems',
+      ownerRuntime: 'n8n',
+      metadata: expect.objectContaining({
+        n8n_workflow_proposal: true,
+        n8n_proposal_action: 'draft_workflow',
+        automation_goal_seed_id: 'meeting-intake-follow-up-drafts',
+        approval_gate: expect.stringContaining('Production activation'),
+      }),
+    }))
+  })
+
+  it('rejects malformed proposals', async () => {
+    await expect(createN8nWorkflowProposal({
+      action: 'inspect_workflow',
+      title: '',
+      objective: 'Missing title.',
+    })).rejects.toThrow('title and objective are required')
+  })
+})

--- a/lib/agent-n8n-workflow-proposals.ts
+++ b/lib/agent-n8n-workflow-proposals.ts
@@ -1,0 +1,76 @@
+import { createAgentWorkItem, type AgentWorkItem } from '@/lib/agent-work-items'
+
+export type N8nWorkflowProposalAction = 'inspect_workflow' | 'draft_workflow' | 'stage_workflow' | 'request_activation'
+
+export type CreateN8nWorkflowProposalInput = {
+  action: N8nWorkflowProposalAction
+  title: string
+  objective: string
+  workflowFamily?: string | null
+  automationGoalSeedId?: string | null
+  existingWorkflowId?: string | null
+  proposedWorkflowName?: string | null
+  trigger?: string | null
+  requiredEnvVars?: string[]
+  credentialNeeds?: string[]
+  nodePlan?: string[]
+  ingestCallbacks?: string[]
+  testEvidence?: string | null
+  rollbackPath?: string | null
+  requestedByUserId?: string | null
+}
+
+const ALLOWED_ACTIONS: N8nWorkflowProposalAction[] = [
+  'inspect_workflow',
+  'draft_workflow',
+  'stage_workflow',
+  'request_activation',
+]
+
+export function isN8nWorkflowProposalAction(value: string): value is N8nWorkflowProposalAction {
+  return ALLOWED_ACTIONS.includes(value as N8nWorkflowProposalAction)
+}
+
+export async function createN8nWorkflowProposal(input: CreateN8nWorkflowProposalInput): Promise<AgentWorkItem> {
+  if (!isN8nWorkflowProposalAction(input.action)) {
+    throw new Error('Invalid n8n workflow proposal action')
+  }
+
+  const title = input.title.trim()
+  const objective = input.objective.trim()
+  if (!title || !objective) {
+    throw new Error('title and objective are required')
+  }
+
+  return createAgentWorkItem({
+    title: `n8n proposal: ${title}`,
+    objective,
+    priority: input.action === 'request_activation' ? 'high' : 'medium',
+    status: 'proposed',
+    ownerAgentKey: 'automation-systems',
+    ownerRuntime: 'n8n',
+    source: {
+      type: 'n8n_workflow_proposal',
+      id: input.automationGoalSeedId ?? input.existingWorkflowId ?? title,
+      label: 'n8n workflow proposal',
+    },
+    metadata: {
+      n8n_workflow_proposal: true,
+      n8n_proposal_action: input.action,
+      workflow_family: input.workflowFamily ?? null,
+      automation_goal_seed_id: input.automationGoalSeedId ?? null,
+      existing_workflow_id: input.existingWorkflowId ?? null,
+      proposed_workflow_name: input.proposedWorkflowName ?? null,
+      trigger: input.trigger ?? null,
+      required_env_vars: input.requiredEnvVars ?? [],
+      credential_needs: input.credentialNeeds ?? [],
+      node_plan: input.nodePlan ?? [],
+      ingest_callbacks: input.ingestCallbacks ?? [],
+      test_evidence: input.testEvidence ?? null,
+      rollback_path: input.rollbackPath ?? null,
+      approval_gate: 'Production activation, credential changes, outbound sends, public publishing, and client-visible mutation require approval.',
+      requested_by_user_id: input.requestedByUserId ?? null,
+    },
+    idempotencyKey: `n8n-workflow-proposal:${input.action}:${input.automationGoalSeedId ?? input.existingWorkflowId ?? title}`,
+  })
+}


### PR DESCRIPTION
## Summary
- Adds a governed automation-goal catalog covering Tier 1 portfolio workflows: meeting follow-up, warm lead outreach, cold lead drafting, meeting-to-social drafts, and value-evidence presentation packages.
- Adds idempotent seeding that creates parent goal work items plus child tasks with goal metadata, Standup/Kanban links, owner assignments, progress weights, and approval-gate context.
- Adds guarded admin endpoints for listing/seeding automation goals and creating n8n workflow proposals without production activation or credential/outbound mutation.
- Surfaces the automation goal to-do panel in Mission Control with compact progress, next action, owner, n8n/workflow indicators, and links into Standup Room and Agent Kanban.

## Validation
- Conflict preflight: `git status --short --branch`, `git fetch --all --prune`, `gh pr list --state open --limit 100`, and open PR file-overlap review. Only active PR was #299 touching Open Brain/design docs; no Mission Control chat/redesign overlap was found.
- Environment bootstrap: `.env.local` and `.vercel` linked from `/Users/vambahsillah/Projects/Portfolio`; `.env.staging` source was not present. Local ignored chatbot knowledge bundle regenerated for validation.
- `npm test -- app/admin/agents/page.test.tsx app/api/admin/agents/automation-goals/route.test.ts app/api/admin/agents/automation-goals/seed/route.test.ts app/api/admin/agents/n8n-workflow-proposals/route.test.ts lib/agent-automation-goals.test.ts lib/agent-automation-goal-seeding.test.ts lib/agent-n8n-workflow-proposals.test.ts`
- `npx tsc --noEmit --pretty false`
- `npm run lint`
- Browser QA: local dev server started on `http://localhost:3010`; unauthenticated headless browser reached `/auth/login?redirect=%2Fadmin%2Fagents`, so authenticated visual QA was blocked. Component and API tests cover the rendered Mission Control panel and guarded endpoint behavior.
- Seeding smoke: ran the idempotent Tier 1 seeder against the configured local/dev environment; result was 5 parent automation goals and 10 child tasks.
- GitHub/Vercel checks: `Vercel – portfolio` passed on the PR. `Vercel – portfolio-staging` was not present in the PR check rollup at handoff.

## Integration Notes
- No schema migration. Goal metadata uses existing Agent Ops work-item fields and `parent_work_item_id`.
- n8n proposal support creates Agent Ops proposal work items only; production activation, credential changes, outbound sends, public publishing, and client-visible mutation remain approval-gated.
- Dev server emitted the existing env-check warning that `MOCK_N8N=false` and `N8N_DISABLE_OUTBOUND=false`; this change does not fire outbound n8n calls, but integration should keep that warning in mind for live smoke work.
- Rollback: revert this PR and, if needed, remove seeded work items by the idempotency key prefix `automation-goal:`.