### PR TITLE
feat: project n8n proposal state in Mission Control

### DIFF
--- a/app/admin/agents/page.test.tsx
+++ b/app/admin/agents/page.test.tsx
@@ -175,6 +175,8 @@ const automationGoals = [
     seeded: false,
     seeded_child_count: 0,
     seeded_parent_work_item: null,
+    n8n_proposal_count: 0,
+    latest_n8n_proposal: null,
   },
   {
     id: 'warm-lead-review-ready-outreach',
@@ -199,6 +201,17 @@ const automationGoals = [
       metadata: {
         goal_session_href: '/admin/agents/standup?goal=automation%3Awarm-lead-review-ready-outreach',
         goal_kanban_href: '/admin/agents/swarm-board?goal=automation%3Awarm-lead-review-ready-outreach',
+      },
+    },
+    n8n_proposal_count: 1,
+    latest_n8n_proposal: {
+      id: 'n8n-proposal-warm-lead',
+      title: 'n8n proposal: Warm lead review-ready outreach',
+      status: 'proposed',
+      priority: 'medium',
+      metadata: {
+        n8n_workflow_proposal: true,
+        goal_id: 'automation:warm-lead-review-ready-outreach',
       },
     },
   },
@@ -319,6 +332,9 @@ describe('AgentOperationsPage mission control landing', () => {
     expect(screen.getByText('1/2 seeded')).toBeInTheDocument()
     expect(within(automationPanel).getAllByRole('link', { name: /Standup/i })[0]).toHaveAttribute('href', '/admin/agents/standup?goal=automation%3Ameeting-intake-follow-up-drafts')
     expect(within(automationPanel).getAllByRole('link', { name: /Kanban/i })[0]).toHaveAttribute('href', '/admin/agents/swarm-board?goal=automation%3Ameeting-intake-follow-up-drafts')
+    expect(within(automationPanel).getByText('n8n proposal in controller')).toBeInTheDocument()
+    expect(within(automationPanel).getByText('n8n proposal: Warm lead review-ready outreach')).toBeInTheDocument()
+    expect(within(automationPanel).getByRole('link', { name: /Review proposal/i })).toHaveAttribute('href', '/admin/agents/coordination')
     expect(screen.getByText('Morning review')).toBeInTheDocument()
     expect(screen.getByText('Hermes health')).toBeInTheDocument()
     expect(screen.getAllByRole('button', { name: /^Run$/ }).length).toBeGreaterThan(0)

--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -322,6 +322,14 @@ type AutomationGoalSummary = {
     status: string
     metadata?: Record<string, unknown>
   } | null
+  n8n_proposal_count?: number
+  latest_n8n_proposal?: {
+    id: string
+    title: string
+    status: string
+    priority?: string
+    metadata?: Record<string, unknown>
+  } | null
 }
 
 type OperatorActionKind = 'morning-review' | 'hermes' | 'approval-drill' | 'runtime-evaluation'
@@ -1346,6 +1354,8 @@ function AutomationGoalsPanel({
 function AutomationGoalRow({ goal }: { goal: AutomationGoalSummary }) {
   const goalId = `automation:${goal.id}`
   const metadata = goal.seeded_parent_work_item?.metadata ?? {}
+  const proposal = goal.latest_n8n_proposal ?? null
+  const proposalCount = goal.n8n_proposal_count ?? 0
   const standupHref = typeof metadata.goal_session_href === 'string'
     ? metadata.goal_session_href
     : `/admin/agents/standup?goal=${encodeURIComponent(goalId)}`
@@ -1370,13 +1380,38 @@ function AutomationGoalRow({ goal }: { goal: AutomationGoalSummary }) {
         {goal.n8nWorkflows.length ? (
           <span className="rounded-full border border-silicon-slate/50 bg-background/40 px-2 py-0.5">{goal.n8nWorkflows.length} n8n workflow(s)</span>
         ) : null}
+        {proposalCount ? (
+          <span className="rounded-full border border-green-500/30 bg-green-500/10 px-2 py-0.5 text-green-100">
+            {proposalCount} proposal{proposalCount === 1 ? '' : 's'}
+          </span>
+        ) : goal.requiresNewWorkflow ? (
+          <span className="rounded-full border border-radiant-gold/35 bg-radiant-gold/10 px-2 py-0.5 text-radiant-gold">
+            proposal needed
+          </span>
+        ) : null}
       </div>
+      {proposal ? (
+        <div className="mt-3 rounded-md border border-green-500/25 bg-green-500/5 p-2 text-xs">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <p className="font-medium text-green-100">n8n proposal in controller</p>
+            <StatusOnlyPill tone={proposal.status === 'blocked' ? 'red' : proposal.status === 'ready_for_review' || proposal.status === 'ready_for_merge' ? 'yellow' : 'green'}>
+              {proposal.status.replace(/_/g, ' ')}
+            </StatusOnlyPill>
+          </div>
+          <p className="mt-1 line-clamp-1 text-muted-foreground">{proposal.title}</p>
+        </div>
+      ) : null}
       <div className="mt-3 flex flex-wrap items-center justify-between gap-2 text-xs">
         <span className="text-muted-foreground">{goal.seeded_child_count} task(s)</span>
         <div className="flex gap-3">
           <Link href={standupHref} className="text-radiant-gold hover:underline">
             Standup
           </Link>
+          {proposal ? (
+            <Link href="/admin/agents/coordination" className="text-radiant-gold hover:underline">
+              Review proposal
+            </Link>
+          ) : null}
           <Link href={kanbanHref} className="text-radiant-gold hover:underline">
             Kanban
           </Link>

--- a/app/api/admin/agents/automation-goals/route.test.ts
+++ b/app/api/admin/agents/automation-goals/route.test.ts
@@ -33,6 +33,7 @@ describe('GET /api/admin/agents/automation-goals', () => {
         seedId: 'meeting-intake-follow-up-drafts',
         parent: { id: 'parent-work-item' },
         children: [{ id: 'child-1' }, { id: 'child-2' }],
+        n8nProposals: [{ id: 'proposal-1', status: 'proposed', title: 'n8n proposal: Meeting follow-up draft' }],
       },
     ])
   })
@@ -58,6 +59,8 @@ describe('GET /api/admin/agents/automation-goals', () => {
       seeded: true,
       seeded_parent_work_item: { id: 'parent-work-item' },
       seeded_child_count: 2,
+      n8n_proposal_count: 1,
+      latest_n8n_proposal: { id: 'proposal-1', status: 'proposed' },
     })
   })
 })

--- a/app/api/admin/agents/automation-goals/route.ts
+++ b/app/api/admin/agents/automation-goals/route.ts
@@ -30,6 +30,8 @@ export async function GET(request: NextRequest) {
         seeded: Boolean(state?.parent),
         seeded_parent_work_item: state?.parent ?? null,
         seeded_child_count: state?.children.length ?? 0,
+        n8n_proposal_count: state?.n8nProposals?.length ?? 0,
+        latest_n8n_proposal: state?.n8nProposals?.[0] ?? null,
       }
     }),
   })

--- a/lib/agent-automation-goal-seeding.test.ts
+++ b/lib/agent-automation-goal-seeding.test.ts
@@ -94,6 +94,25 @@ describe('agent automation goal seeding', () => {
         idempotency_key: 'automation-goal:meeting-intake-follow-up-drafts:task:1',
         metadata: { automation_seed: true, automation_goal_seed_id: 'meeting-intake-follow-up-drafts', goal_role: 'task', goal_sequence: 1 },
       },
+      {
+        id: 'n8n-proposal-1',
+        source_type: 'n8n_workflow_proposal',
+        updated_at: '2026-05-12T12:00:00.000Z',
+        metadata: {
+          n8n_workflow_proposal: true,
+          automation_goal_seed_id: 'meeting-intake-follow-up-drafts',
+          goal_id: 'automation:meeting-intake-follow-up-drafts',
+        },
+      },
+      {
+        id: 'n8n-proposal-2',
+        source_type: 'n8n_workflow_proposal',
+        updated_at: '2026-05-13T12:00:00.000Z',
+        metadata: {
+          n8n_workflow_proposal: true,
+          goal_id: 'automation:meeting-intake-follow-up-drafts',
+        },
+      },
     ])
 
     const states = await listAutomationGoalSeedStates()
@@ -101,5 +120,6 @@ describe('agent automation goal seeding', () => {
 
     expect(state?.parent?.id).toBe('parent')
     expect(state?.children.map((item) => item.id)).toEqual(['child-1', 'child-2'])
+    expect(state?.n8nProposals.map((item) => item.id)).toEqual(['n8n-proposal-2', 'n8n-proposal-1'])
   })
 })

--- a/lib/agent-automation-goal-seeding.ts
+++ b/lib/agent-automation-goal-seeding.ts
@@ -13,6 +13,7 @@ export type AutomationGoalSeedState = {
   seedId: string
   parent: AgentWorkItem | null
   children: AgentWorkItem[]
+  n8nProposals: AgentWorkItem[]
 }
 
 export type SeedAutomationGoalsInput = {
@@ -74,13 +75,18 @@ function baseMetadata(seed: AutomationGoalSeed, triggeredByUserId?: string | nul
 export async function listAutomationGoalSeedStates(limit = 250): Promise<AutomationGoalSeedState[]> {
   const items = await listAgentWorkItems({ limit })
   const seededItems = items.filter((item) => item.metadata?.automation_seed === true)
+  const n8nProposalItems = items.filter((item) => item.source_type === 'n8n_workflow_proposal' || item.metadata?.n8n_workflow_proposal === true)
 
   return listAutomationGoalSeeds().map((seed) => {
+    const goalId = goalIdForSeed(seed)
     const parent = seededItems.find((item) => item.idempotency_key === parentIdempotencyKey(seed)) ?? null
     const children = seededItems
       .filter((item) => item.metadata?.automation_goal_seed_id === seed.id && item.metadata?.goal_role === 'task')
       .sort((a, b) => Number(a.metadata?.goal_sequence ?? 0) - Number(b.metadata?.goal_sequence ?? 0))
-    return { seedId: seed.id, parent, children }
+    const n8nProposals = n8nProposalItems
+      .filter((item) => item.metadata?.automation_goal_seed_id === seed.id || item.metadata?.goal_id === goalId)
+      .sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime())
+    return { seedId: seed.id, parent, children, n8nProposals }
   })
 }
 


### PR DESCRIPTION
Summary
- Extends automation goal seed state with related n8n workflow proposal work items.
- Returns n8n proposal count and latest proposal from the automation goals API.
- Shows proposal state inside Mission Control automation to-do rows with a direct Decision Queue review link.

Validation
- npm test -- app/admin/agents/page.test.tsx app/api/admin/agents/automation-goals/route.test.ts lib/agent-automation-goal-seeding.test.ts lib/agent-automation-goals.test.ts
- npm run build:knowledge
- npx tsc --noEmit --pretty false
- npm run lint
- git diff --check
- Local dev smoke on http://localhost:3007/admin/agents compiled and routed, but Playwright landed on the login guard so authenticated visual QA was not completed.

Integration Notes
- Preflight: root main clean, remotes fetched/pruned, no open PRs.
- Env bootstrap: linked .env.local and .vercel from Portfolio root; .env.staging absent.
- No schema changes. Existing n8n proposal work items are projected by metadata goal id / automation seed id.
- Vercel contexts not yet checked for this PR.