### PR TITLE
feat: deep link n8n proposals

### DIFF
--- a/app/admin/agents/coordination/page.test.tsx
+++ b/app/admin/agents/coordination/page.test.tsx
@@ -354,6 +354,7 @@ function setupFetch({ failWorkItems = false } = {}) {
 
 describe('AgentCoordinationPage decision queue controller', () => {
   beforeEach(() => {
+    window.history.replaceState({}, '', '/admin/agents/coordination')
     setupFetch()
   })
 
@@ -456,6 +457,24 @@ describe('AgentCoordinationPage decision queue controller', () => {
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith('/api/admin/agents/work-items/work-n8n-proposal-1/validation', expect.objectContaining({ method: 'POST' }))
     })
+  })
+
+  it('highlights a linked n8n proposal from query params', async () => {
+    window.history.replaceState({}, '', '/admin/agents/coordination?proposal=work-n8n-proposal-1')
+    render(<AgentCoordinationPage />)
+
+    const linkedProposal = await screen.findByLabelText('n8n proposal n8n proposal: Automate meeting intake to follow-up drafts')
+    expect(linkedProposal).toHaveAttribute('id', 'n8n-proposal-work-n8n-proposal-1')
+    expect(within(linkedProposal).getByText('linked from Mission Control')).toBeInTheDocument()
+  })
+
+  it('highlights the first n8n proposal that matches a linked goal', async () => {
+    window.history.replaceState({}, '', '/admin/agents/coordination?goal=automation%3Ameeting-intake-follow-up-drafts')
+    render(<AgentCoordinationPage />)
+
+    const linkedProposal = await screen.findByLabelText('n8n proposal n8n proposal: Automate meeting intake to follow-up drafts')
+    expect(linkedProposal).toHaveAttribute('data-n8n-goal-id', 'automation:meeting-intake-follow-up-drafts')
+    expect(within(linkedProposal).getByText('linked from Mission Control')).toBeInTheDocument()
   })
 
   it('shows pending Vercel AutoResearch approvals inline and approves from the card', async () => {

--- a/app/admin/agents/coordination/page.tsx
+++ b/app/admin/agents/coordination/page.tsx
@@ -211,6 +211,10 @@ function stringValue(value: unknown): string | null {
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
 }
 
+function n8nProposalElementId(proposalId: string) {
+  return `n8n-proposal-${proposalId}`
+}
+
 function definitionOfReadyText(item: AgentWorkItem) {
   const criteria = textArray(item.metadata?.definition_of_ready)
   const source = criteria.length ? criteria : VERCEL_AUTORESEARCH_DEFINITION_OF_READY
@@ -257,6 +261,10 @@ function AgentCoordinationContent() {
   const [moremiDrillResult, setMoremiDrillResult] = useState<MoremiOperationalDrillResult | null>(null)
   const [shakaReply, setShakaReply] = useState<ShakaContextReply | null>(null)
   const [shakaContextRef, setShakaContextRef] = useState<ShakaContextRef | null>(null)
+  const [n8nDeepLink, setN8nDeepLink] = useState<{ proposalId: string | null; goalId: string | null }>({
+    proposalId: null,
+    goalId: null,
+  })
 
   const authedFetch = useCallback(async (path: string, init: RequestInit = {}) => {
     const session = await getCurrentSession()
@@ -304,6 +312,14 @@ function AgentCoordinationContent() {
     loadItems()
     loadVercelResearchApprovals()
   }, [loadItems, loadVercelResearchApprovals])
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    setN8nDeepLink({
+      proposalId: params.get('proposal'),
+      goalId: params.get('goal'),
+    })
+  }, [])
 
   const summary = useMemo(() => ({
     active: items.filter((item) => !['merged', 'deployed', 'cancelled'].includes(item.status)).length,
@@ -613,6 +629,8 @@ function AgentCoordinationContent() {
 
         <N8nWorkflowProposalPanel
           proposals={n8nWorkflowProposals}
+          highlightedProposalId={n8nDeepLink.proposalId}
+          highlightedGoalId={n8nDeepLink.goalId}
           actionId={actionId}
           onAction={quickAction}
           onAskShaka={(workItem) => askShaka(
@@ -1211,15 +1229,35 @@ function ShakaContextResponse({
 
 function N8nWorkflowProposalPanel({
   proposals,
+  highlightedProposalId,
+  highlightedGoalId,
   actionId,
   onAction,
   onAskShaka,
 }: {
   proposals: AgentWorkItem[]
+  highlightedProposalId: string | null
+  highlightedGoalId: string | null
   actionId: string | null
   onAction: (item: AgentWorkItem, action: 'block' | 'validation' | 'handoff') => void
   onAskShaka: (item: AgentWorkItem) => void
 }) {
+  const highlightedProposal = useMemo(() => {
+    if (highlightedProposalId) {
+      return proposals.find((item) => item.id === highlightedProposalId) ?? null
+    }
+    if (highlightedGoalId) {
+      return proposals.find((item) => item.metadata?.goal_id === highlightedGoalId) ?? null
+    }
+    return null
+  }, [highlightedGoalId, highlightedProposalId, proposals])
+
+  useEffect(() => {
+    if (!highlightedProposal) return
+    const target = document.getElementById(n8nProposalElementId(highlightedProposal.id))
+    target?.scrollIntoView?.({ block: 'center', behavior: 'smooth' })
+  }, [highlightedProposal])
+
   return (
     <section className="agent-ops-card mb-6 rounded-lg border border-green-500/25 p-4">
       <div className="mb-4 flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
@@ -1260,12 +1298,29 @@ function N8nWorkflowProposalPanel({
             const recommendation = item.status === 'ready_for_review' || item.status === 'ready_for_merge'
               ? 'Validate the draft packet and route the next gate through the controller. Do not activate production from this review.'
               : 'Review the proposal as draft-only. Move to validation only after the trigger, credentials, callbacks, and rollback path are clear.'
+            const highlighted = highlightedProposal?.id === item.id
 
             return (
-              <article key={item.id} className="rounded-lg border border-green-500/25 bg-background/55 p-4">
+              <article
+                key={item.id}
+                id={n8nProposalElementId(item.id)}
+                data-n8n-proposal-id={item.id}
+                data-n8n-goal-id={goalId ?? undefined}
+                aria-label={`n8n proposal ${item.title}`}
+                className={`rounded-lg border bg-background/55 p-4 scroll-mt-24 ${
+                  highlighted
+                    ? 'border-radiant-gold/70 shadow-[0_0_0_1px_rgba(221,184,65,0.35),0_0_32px_rgba(221,184,65,0.16)]'
+                    : 'border-green-500/25'
+                }`}
+              >
                 <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
                   <div className="min-w-0">
                     <div className="mb-2 flex flex-wrap items-center gap-2">
+                      {highlighted ? (
+                        <span className="rounded-full border border-radiant-gold/40 bg-radiant-gold/15 px-2 py-1 text-xs text-radiant-gold">
+                          linked from Mission Control
+                        </span>
+                      ) : null}
                       <StatusBadge status={item.status} />
                       <span className="rounded-full border border-green-500/30 bg-green-500/10 px-2 py-1 text-xs text-green-100">
                         {action}

--- a/app/admin/agents/page.test.tsx
+++ b/app/admin/agents/page.test.tsx
@@ -334,7 +334,7 @@ describe('AgentOperationsPage mission control landing', () => {
     expect(within(automationPanel).getAllByRole('link', { name: /Kanban/i })[0]).toHaveAttribute('href', '/admin/agents/swarm-board?goal=automation%3Ameeting-intake-follow-up-drafts')
     expect(within(automationPanel).getByText('n8n proposal in controller')).toBeInTheDocument()
     expect(within(automationPanel).getByText('n8n proposal: Warm lead review-ready outreach')).toBeInTheDocument()
-    expect(within(automationPanel).getByRole('link', { name: /Review proposal/i })).toHaveAttribute('href', '/admin/agents/coordination')
+    expect(within(automationPanel).getByRole('link', { name: /Review proposal/i })).toHaveAttribute('href', '/admin/agents/coordination?proposal=n8n-proposal-warm-lead')
     expect(screen.getByText('Morning review')).toBeInTheDocument()
     expect(screen.getByText('Hermes health')).toBeInTheDocument()
     expect(screen.getAllByRole('button', { name: /^Run$/ }).length).toBeGreaterThan(0)

--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -1362,6 +1362,9 @@ function AutomationGoalRow({ goal }: { goal: AutomationGoalSummary }) {
   const kanbanHref = typeof metadata.goal_kanban_href === 'string'
     ? metadata.goal_kanban_href
     : `/admin/agents/swarm-board?goal=${encodeURIComponent(goalId)}`
+  const proposalHref = proposal
+    ? `/admin/agents/coordination?proposal=${encodeURIComponent(proposal.id)}`
+    : `/admin/agents/coordination?goal=${encodeURIComponent(goalId)}`
   const tone = goal.seeded ? 'green' : goal.requiresNewWorkflow ? 'yellow' : 'blue'
 
   return (
@@ -1408,7 +1411,7 @@ function AutomationGoalRow({ goal }: { goal: AutomationGoalSummary }) {
             Standup
           </Link>
           {proposal ? (
-            <Link href="/admin/agents/coordination" className="text-radiant-gold hover:underline">
+            <Link href={proposalHref} className="text-radiant-gold hover:underline">
               Review proposal
             </Link>
           ) : null}


### PR DESCRIPTION
## Summary
- Deep-links Mission Control automation-goal proposal rows into the matching Decision Queue n8n proposal with `?proposal=`.
- Adds Decision Queue handling for `?proposal=` and `?goal=` links, including scroll targeting, highlighted card styling, and a `linked from Mission Control` marker.
- Keeps the phase UI-only: no schema, database, or backend route changes.

## Validation
- `npm test -- app/admin/agents/page.test.tsx app/admin/agents/coordination/page.test.tsx`
- `npm run build:knowledge`
- `npx tsc --noEmit --pretty false`
- `npm run lint`
- `git diff --check`
- Local route smoke on `3008`:
  - `HEAD /admin/agents` -> `200 OK`
  - `HEAD /admin/agents/coordination?proposal=work-n8n-proposal-1` -> `200 OK`

## Integration Notes
- Preflight completed before edits: root `main` was clean, fetch/prune completed, `gh pr list --state open --limit 100` returned no open PRs, and there was no active worktree overlap.
- Worktree env was bootstrapped from `/Users/vambahsillah/Projects/Portfolio` with `.env.local`, `.vercel`, and symlinked `node_modules`; `.env.staging` was not present in the source checkout.
- Browser MCP tools were not available in this session, so local QA is route/compile smoke rather than authenticated visual QA.
- Local dev emitted an existing environment warning: `MOCK_N8N=false` and `N8N_DISABLE_OUTBOUND=false`; this phase does not execute n8n webhooks.
- Vercel contexts to verify after merge: `Vercel – portfolio` and `Vercel – portfolio-staging`.
