### PR TITLE
feat: surface n8n proposals on agent kanban

### DIFF
--- a/app/admin/agents/swarm-board/page.test.tsx
+++ b/app/admin/agents/swarm-board/page.test.tsx
@@ -363,6 +363,16 @@ describe('AgentSwarmBoardPage', () => {
         n8nWorkflows: automationGoal.n8nWorkflows,
         approvalGate: automationGoal.approvalGate,
         nextAction: automationGoal.nextAction,
+        n8nProposal: index === 0 ? {
+          action: 'draft_workflow',
+          proposedWorkflowName: 'Automate meeting intake to follow-up drafts',
+          requiredEnvVars: ['N8N_INGEST_SECRET'],
+          credentialNeeds: ['Confirm required source credentials before staging.'],
+          nodePlan: ['Webhook trigger', 'Agent Ops callback'],
+          ingestCallbacks: ['/api/admin/agents/work-items'],
+          rollbackPath: 'Delete the inactive draft workflow.',
+          controllerHref: '/admin/agents/coordination?proposal=work-n8n-proposal-1',
+        } : null,
       },
     }))
     vi.stubGlobal('fetch', vi.fn(async () => ({
@@ -385,6 +395,8 @@ describe('AgentSwarmBoardPage', () => {
     expect(screen.getByText(/2 known n8n workflow/i)).toBeInTheDocument()
     expect(screen.getByText(/External sends stay approval-gated/i)).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Draft proposal in Standup' })).toHaveAttribute('href', '/admin/agents/standup?goal=automation%3Ameeting-intake-follow-up-drafts')
+    expect(screen.getAllByText(/n8n proposal/i).length).toBeGreaterThan(0)
+    expect(screen.getByRole('link', { name: 'Controller' })).toHaveAttribute('href', '/admin/agents/coordination?proposal=work-n8n-proposal-1')
   })
 
   it('filters visible cards by status and attention state', async () => {

--- a/app/admin/agents/swarm-board/page.tsx
+++ b/app/admin/agents/swarm-board/page.tsx
@@ -696,6 +696,11 @@ function SelectedGoalPanel({ goal, tasks }: { goal: AgentOrgBoardSnapshot['summa
                 <div className="min-w-0">
                   <p className="break-words font-medium">{task.title}</p>
                   <p className="mt-1 text-xs text-muted-foreground">{task.ownerAgentName} · {task.status.replace(/_/g, ' ')}</p>
+                  {task.goal?.n8nProposal ? (
+                    <Link href={task.goal.n8nProposal.controllerHref} className="mt-1 inline-flex text-xs text-radiant-gold hover:underline">
+                      n8n proposal · open controller
+                    </Link>
+                  ) : null}
                 </div>
                 <div className="flex gap-2 md:justify-end">
                   {task.activeRunId ? <Link href={`/admin/agents/runs/${task.activeRunId}`} className="text-xs text-radiant-gold hover:underline">Trace</Link> : null}
@@ -822,6 +827,7 @@ function actionRank(task: AgentOrgBoardTask) {
 
 function WorkItemCard({ task }: { task: AgentOrgBoardTask }) {
   const nextAction = nextActionForTask(task)
+  const n8nProposal = task.goal?.n8nProposal ?? null
   return (
     <article className="rounded-lg border border-silicon-slate/70 bg-background/70 p-2">
       <div className="flex items-start justify-between gap-2">
@@ -856,6 +862,21 @@ function WorkItemCard({ task }: { task: AgentOrgBoardTask }) {
           <span className="truncate">Goal: {task.goal.title}</span>
         </Link>
       )}
+      {n8nProposal ? (
+        <div className="mt-1.5 flex items-center gap-1.5 rounded-md border border-radiant-gold/35 bg-radiant-gold/10 px-1.5 py-1 text-[11px] text-radiant-gold">
+          <Workflow size={12} className="shrink-0" />
+          <span className="min-w-0 flex-1 truncate" title={n8nProposal.proposedWorkflowName ?? undefined}>
+            n8n proposal · {formatProposalAction(n8nProposal.action)}
+            {n8nProposal.proposedWorkflowName ? ` · ${n8nProposal.proposedWorkflowName}` : ''}
+          </span>
+          <Link
+            href={n8nProposal.controllerHref}
+            className="shrink-0 rounded border border-radiant-gold/40 px-1.5 py-0.5 hover:bg-radiant-gold/15"
+          >
+            Controller
+          </Link>
+        </div>
+      ) : null}
 
       <div className="mt-1.5 flex items-center gap-1.5 text-[11px]">
         <span className={`min-w-0 flex-1 truncate rounded-md border px-1.5 py-1 ${nextAction.tone}`} title={nextAction.detail}>
@@ -1310,6 +1331,10 @@ function FailureState({ message }: { message: string }) {
       <p className="text-sm text-red-100/80">{message}</p>
     </div>
   )
+}
+
+function formatProposalAction(action: string | null) {
+  return action ? action.replace(/_/g, ' ') : 'review'
 }
 
 function priorityClass(priority: SwarmBoardCard['priority'] | AgentOrgBoardTask['priority']) {

--- a/lib/agent-swarm-board.test.ts
+++ b/lib/agent-swarm-board.test.ts
@@ -697,6 +697,61 @@ describe('buildAgentOrgBoardSnapshotFromRows', () => {
     })
   })
 
+  it('projects n8n proposal context onto goal-tagged Kanban cards', () => {
+    const snapshot = buildAgentOrgBoardSnapshotFromRows({
+      now: new Date('2026-05-05T16:00:00.000Z'),
+      runs: [],
+      events: [],
+      workItems: [
+        orgWorkItem({
+          id: 'work-n8n-proposal-1',
+          title: 'n8n proposal: Automate meeting intake to follow-up drafts',
+          status: 'proposed',
+          priority: 'medium',
+          owner_agent_key: 'automation-systems',
+          owner_runtime: 'n8n',
+          source_type: 'n8n_workflow_proposal',
+          metadata: {
+            n8n_workflow_proposal: true,
+            n8n_proposal_action: 'draft_workflow',
+            proposed_workflow_name: 'Automate meeting intake to follow-up drafts',
+            required_env_vars: ['N8N_INGEST_SECRET'],
+            credential_needs: ['Confirm calendar and email source credentials before staging.'],
+            node_plan: ['Webhook trigger', 'Agent Ops work-item callback'],
+            ingest_callbacks: ['/api/admin/agents/work-items'],
+            rollback_path: 'Delete the inactive draft workflow and close the proposal work item.',
+            goal_id: 'automation:meeting-intake-follow-up-drafts',
+            goal_title: 'Automate meeting intake to follow-up drafts',
+            goal_sequence: 1,
+            goal_status: 'proposed',
+            goal_progress_weight: 1,
+            goal_session_href: '/admin/agents/standup?goal=automation%3Ameeting-intake-follow-up-drafts',
+            automation_goal_seed_id: 'meeting-intake-follow-up-drafts',
+            workflow_family: 'meeting_follow_up',
+            automation_level: 'draft_to_review',
+            requires_new_workflow: true,
+            approval_gate: 'Activation remains approval-gated.',
+            next_action: 'Review the n8n proposal packet.',
+          },
+        }),
+      ],
+      approvals: [],
+    })
+
+    const proposalTask = snapshot.lanes.flatMap((lane) => lane.tasks).find((task) => task.id === 'work-n8n-proposal-1')
+
+    expect(proposalTask?.goal?.n8nProposal).toMatchObject({
+      action: 'draft_workflow',
+      proposedWorkflowName: 'Automate meeting intake to follow-up drafts',
+      requiredEnvVars: ['N8N_INGEST_SECRET'],
+      credentialNeeds: ['Confirm calendar and email source credentials before staging.'],
+      nodePlan: ['Webhook trigger', 'Agent Ops work-item callback'],
+      ingestCallbacks: ['/api/admin/agents/work-items'],
+      rollbackPath: 'Delete the inactive draft workflow and close the proposal work item.',
+      controllerHref: '/admin/agents/coordination?proposal=work-n8n-proposal-1',
+    })
+  })
+
   it('flags WIP limit pressure and preserves priority ordering inside lanes', () => {
     const workItems = [
       orgWorkItem({ id: 'low-old', title: 'Low old', status: 'in_progress', priority: 'low', owner_agent_key: 'automation-systems', updated_at: '2026-05-05T11:00:00.000Z' }),

--- a/lib/agent-swarm-board.ts
+++ b/lib/agent-swarm-board.ts
@@ -103,6 +103,17 @@ export type AgentOrgBoardTaskStatus =
   | 'deployed'
   | 'cancelled'
 
+export type AgentOrgBoardN8nProposalContext = {
+  action: string | null
+  proposedWorkflowName: string | null
+  requiredEnvVars: string[]
+  credentialNeeds: string[]
+  nodePlan: string[]
+  ingestCallbacks: string[]
+  rollbackPath: string | null
+  controllerHref: string
+}
+
 export type AgentOrgBoardTask = {
   id: string
   title: string
@@ -145,6 +156,7 @@ export type AgentOrgBoardTask = {
     n8nWorkflows: string[]
     approvalGate: string | null
     nextAction: string | null
+    n8nProposal: AgentOrgBoardN8nProposalContext | null
   } | null
 }
 
@@ -364,6 +376,7 @@ type AgentWorkItemRow = {
   validation_summary: string | null
   approval_id: string | null
   parent_work_item_id?: string | null
+  source_type?: string | null
   metadata?: JsonRecord | null
   completed_at?: string | null
   created_at: string
@@ -848,6 +861,7 @@ function goalForTask(item: AgentWorkItemRow): AgentOrgBoardTask['goal'] {
   const approvalRunId = stringValue(metadata.goal_approved_by_run_id) ?? stringValue(metadata.approved_by_run_id) ?? stringValue(metadata.goal_created_by_run_id)
   const latestRunId = item.active_run_id ?? approvalRunId ?? draftRunId
   const sessionHref = stringValue(metadata.goal_session_href) ?? `/admin/agents/standup?goal=${encodeURIComponent(goalId)}`
+  const isN8nProposal = item.source_type === 'n8n_workflow_proposal' || metadata.n8n_workflow_proposal === true
   return {
     id: goalId,
     title: goalTitle,
@@ -869,6 +883,16 @@ function goalForTask(item: AgentWorkItemRow): AgentOrgBoardTask['goal'] {
     n8nWorkflows: stringArrayValue(metadata.n8n_workflows),
     approvalGate: stringValue(metadata.approval_gate),
     nextAction: stringValue(metadata.next_action),
+    n8nProposal: isN8nProposal ? {
+      action: stringValue(metadata.n8n_proposal_action),
+      proposedWorkflowName: stringValue(metadata.proposed_workflow_name),
+      requiredEnvVars: stringArrayValue(metadata.required_env_vars),
+      credentialNeeds: stringArrayValue(metadata.credential_needs),
+      nodePlan: stringArrayValue(metadata.node_plan),
+      ingestCallbacks: stringArrayValue(metadata.ingest_callbacks),
+      rollbackPath: stringValue(metadata.rollback_path),
+      controllerHref: `/admin/agents/coordination?proposal=${encodeURIComponent(item.id)}`,
+    } : null,
   }
 }
 
@@ -1252,7 +1276,7 @@ export async function buildAgentOrgBoardSnapshot(): Promise<AgentOrgBoardSnapsho
       .limit(120),
     db
       .from('agent_work_items')
-      .select('id, title, objective, status, priority, owner_agent_key, owner_runtime, active_run_id, parent_work_item_id, branch_name, worktree_path, pr_number, pr_url, overlap_group, blocker_summary, validation_summary, approval_id, metadata, completed_at, created_at, updated_at')
+      .select('id, title, objective, status, priority, owner_agent_key, owner_runtime, active_run_id, parent_work_item_id, source_type, branch_name, worktree_path, pr_number, pr_url, overlap_group, blocker_summary, validation_summary, approval_id, metadata, completed_at, created_at, updated_at')
       .order('updated_at', { ascending: false })
       .limit(100),
     db


### PR DESCRIPTION
## Summary
- project n8n proposal metadata into Agent Kanban goal-tagged cards
- add compact proposal context and a Decision Queue controller deep link on Kanban cards
- add focused board snapshot and render coverage

## Validation
- npm test -- lib/agent-swarm-board.test.ts app/admin/agents/swarm-board/page.test.tsx
- npm run build:knowledge
- npx tsc --noEmit --pretty false
- npm run lint
- git diff --check
- local route smoke: curl -I http://localhost:3011/admin/agents/swarm-board returned 200

## Integration Notes
- No schema or API changes; reads existing work-item source_type and metadata only.
- Browser visual QA was limited because the in-app Browser navigation/screenshot tools were not exposed in this turn; route smoke and focused UI tests passed.
- Vercel contexts to verify after merge: Vercel – portfolio and Vercel – portfolio-staging.