### PR TITLE
feat: add n8n mcp handoff packets

### DIFF
--- a/app/admin/agents/coordination/page.test.tsx
+++ b/app/admin/agents/coordination/page.test.tsx
@@ -451,6 +451,13 @@ describe('AgentCoordinationPage decision queue controller', () => {
     expect(screen.getByText('Delete the inactive draft workflow.')).toBeInTheDocument()
     expect(screen.getByText('Identify the source trigger and dedupe/idempotency key.')).toBeInTheDocument()
     expect(screen.getByText('Env: N8N_INGEST_SECRET')).toBeInTheDocument()
+    expect(screen.getByText('n8n MCP handoff packet')).toBeInTheDocument()
+    expect(screen.getByText(/Use this structured packet when an agent asks the n8n MCP/i)).toBeInTheDocument()
+    expect(screen.getByText('MCP guardrails')).toBeInTheDocument()
+    expect(screen.getAllByText(/Do not send outbound email/i).length).toBeGreaterThan(0)
+    expect(screen.getByText('Builder return contract')).toBeInTheDocument()
+    expect(screen.getAllByText(/Return the n8n workflow id/i).length).toBeGreaterThan(0)
+    expect(screen.getByText('View JSON handoff packet')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /Goal session/ })).toHaveAttribute('href', '/admin/agents/standup?goal=automation%3Ameeting-intake-follow-up-drafts')
     expect(screen.getByRole('link', { name: /Goal Kanban/ })).toHaveAttribute('href', '/admin/agents/swarm-board?goal=automation%3Ameeting-intake-follow-up-drafts')
 

--- a/app/admin/agents/coordination/page.tsx
+++ b/app/admin/agents/coordination/page.tsx
@@ -15,6 +15,7 @@ import {
   RefreshCw,
   ShieldCheck,
   ShieldAlert,
+  Workflow,
   XCircle,
 } from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
@@ -109,6 +110,31 @@ type ShakaContextReply = {
 }
 
 type WorkItemQuickAction = 'block' | 'validation' | 'handoff' | 'ready' | 'proposal_validation'
+
+type N8nMcpHandoffPacketView = {
+  version: string
+  action: string
+  workflowFamily: string | null
+  automationGoalSeedId: string | null
+  goalId: string | null
+  goalTitle: string | null
+  workflow: {
+    proposedName: string | null
+    existingWorkflowId: string | null
+    trigger: string | null
+    nodePlan: string[]
+  }
+  requirements: {
+    requiredEnvVars: string[]
+    credentialNeeds: string[]
+    ingestCallbacks: string[]
+    testEvidence: string | null
+  }
+  approvalGate: string
+  rollbackPath: string | null
+  guardrails: string[]
+  handoffInstructions: string[]
+}
 
 const DEFAULT_FORM: WorkItemForm = {
   title: 'Review controller decision packet',
@@ -211,6 +237,63 @@ function textArray(value: unknown): string[] {
 
 function stringValue(value: unknown): string | null {
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+}
+
+function recordValue(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null
+}
+
+function n8nMcpHandoffPacketForProposal(input: {
+  item: AgentWorkItem
+  action: string
+  workflowFamily: string
+  goalId: string | null
+  goalTitle: string
+  requiredEnvVars: string[]
+  credentialNeeds: string[]
+  nodePlan: string[]
+  ingestCallbacks: string[]
+  testEvidence: string | null
+  rollbackPath: string | null
+  approvalGate: string
+}): N8nMcpHandoffPacketView {
+  const metadata = input.item.metadata ?? {}
+  const stored = recordValue(metadata.mcp_handoff_packet)
+  const storedWorkflow = recordValue(stored?.workflow)
+  const storedRequirements = recordValue(stored?.requirements)
+  return {
+    version: stringValue(stored?.version) ?? 'agent-ops-n8n-mcp-handoff/v1',
+    action: stringValue(stored?.action) ?? input.action.replace(/\s+/g, '_'),
+    workflowFamily: stringValue(stored?.workflowFamily) ?? stringValue(metadata.workflow_family) ?? input.workflowFamily.replace(/\s+/g, '_'),
+    automationGoalSeedId: stringValue(stored?.automationGoalSeedId) ?? stringValue(metadata.automation_goal_seed_id),
+    goalId: stringValue(stored?.goalId) ?? input.goalId,
+    goalTitle: stringValue(stored?.goalTitle) ?? input.goalTitle,
+    workflow: {
+      proposedName: stringValue(storedWorkflow?.proposedName) ?? stringValue(metadata.proposed_workflow_name) ?? input.goalTitle,
+      existingWorkflowId: stringValue(storedWorkflow?.existingWorkflowId) ?? stringValue(metadata.existing_workflow_id),
+      trigger: stringValue(storedWorkflow?.trigger) ?? stringValue(metadata.trigger),
+      nodePlan: textArray(storedWorkflow?.nodePlan).length ? textArray(storedWorkflow?.nodePlan) : input.nodePlan,
+    },
+    requirements: {
+      requiredEnvVars: textArray(storedRequirements?.requiredEnvVars).length ? textArray(storedRequirements?.requiredEnvVars) : input.requiredEnvVars,
+      credentialNeeds: textArray(storedRequirements?.credentialNeeds).length ? textArray(storedRequirements?.credentialNeeds) : input.credentialNeeds,
+      ingestCallbacks: textArray(storedRequirements?.ingestCallbacks).length ? textArray(storedRequirements?.ingestCallbacks) : input.ingestCallbacks,
+      testEvidence: stringValue(storedRequirements?.testEvidence) ?? input.testEvidence,
+    },
+    approvalGate: stringValue(stored?.approvalGate) ?? input.approvalGate,
+    rollbackPath: stringValue(stored?.rollbackPath) ?? input.rollbackPath,
+    guardrails: textArray(stored?.guardrails).length ? textArray(stored?.guardrails) : [
+      'Use staging, inactive, or inspection-only n8n workflows until the controller explicitly approves activation.',
+      'Do not create or rotate credentials from this packet; report credential needs back to Agent Ops.',
+      'Do not send outbound email, publish content, mutate production customer data, or enable live schedules without approval.',
+      'Use synthetic or test-owned validation data unless the controller approves a narrower live-data drill.',
+    ],
+    handoffInstructions: textArray(stored?.handoffInstructions).length ? textArray(stored?.handoffInstructions) : [
+      'Create or inspect the workflow using the workflow name, trigger, node plan, credential needs, and callback routes in this packet.',
+      'Return the n8n workflow id, validation result, test evidence, and rollback notes to the Decision Queue controller.',
+      'Attach trace evidence before asking for staging, production activation, credential, outbound, or client-visible approval.',
+    ],
+  }
 }
 
 function n8nProposalElementId(proposalId: string) {
@@ -1307,6 +1390,20 @@ function N8nWorkflowProposalPanel({
             const rollbackPath = stringValue(item.metadata?.rollback_path) ?? 'Delete the inactive draft workflow and leave production unchanged.'
             const approvalGate = stringValue(item.metadata?.approval_gate)
               ?? 'Production activation, credential changes, outbound sends, public publishing, and client-visible mutation require approval.'
+            const mcpHandoffPacket = n8nMcpHandoffPacketForProposal({
+              item,
+              action,
+              workflowFamily,
+              goalId,
+              goalTitle,
+              requiredEnvVars,
+              credentialNeeds,
+              nodePlan,
+              ingestCallbacks,
+              testEvidence,
+              rollbackPath,
+              approvalGate,
+            })
             const recommendation = item.status === 'ready_for_review' || item.status === 'ready_for_merge'
               ? 'Validate the draft packet and route the next gate through the controller. Do not activate production from this review.'
               : 'Review the proposal as draft-only. Move to validation only after the trigger, credentials, callbacks, and rollback path are clear.'
@@ -1381,6 +1478,8 @@ function N8nWorkflowProposalPanel({
                       <ListField label="Ingest callbacks" values={ingestCallbacks} fallback="No callback endpoints have been declared." />
                       <DecisionSummaryBlock label="Test evidence" value={testEvidence ?? 'No test evidence has been attached yet.'} />
                     </div>
+
+                    <McpHandoffPacketPanel packet={mcpHandoffPacket} />
 
                     <div className="mt-3 grid gap-2 text-xs text-muted-foreground sm:grid-cols-2 xl:grid-cols-4">
                       <SmallField label="Owner" value={item.owner_agent_key ?? item.owner_runtime} />
@@ -1889,6 +1988,42 @@ function ListField({ label, values, fallback }: { label: string; values: string[
       ) : (
         <p className="mt-1 text-muted-foreground">{fallback}</p>
       )}
+    </div>
+  )
+}
+
+function McpHandoffPacketPanel({ packet }: { packet: N8nMcpHandoffPacketView }) {
+  return (
+    <div className="mt-3 rounded-lg border border-radiant-gold/35 bg-radiant-gold/10 p-3 text-sm">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <div className="flex items-center gap-2 text-radiant-gold">
+            <Workflow size={16} />
+            <p className="text-xs font-semibold uppercase tracking-wide">n8n MCP handoff packet</p>
+          </div>
+          <p className="mt-2 text-foreground">
+            Use this structured packet when an agent asks the n8n MCP to create, inspect, or stage the workflow.
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {packet.workflow.proposedName ?? 'Unnamed workflow'} · {packet.workflowFamily?.replace(/_/g, ' ') ?? 'workflow family pending'} · {packet.action.replace(/_/g, ' ')}
+          </p>
+        </div>
+        <span className="inline-flex w-fit rounded-full border border-yellow-500/35 bg-yellow-500/10 px-2 py-1 text-xs text-yellow-100">
+          activation approval required
+        </span>
+      </div>
+      <div className="mt-3 grid gap-3 md:grid-cols-2">
+        <ListField label="MCP guardrails" values={packet.guardrails.slice(0, 4)} fallback="No guardrails have been declared." />
+        <ListField label="Builder return contract" values={packet.handoffInstructions.slice(0, 3)} fallback="No handoff instructions have been declared." />
+      </div>
+      <details className="mt-3 rounded-lg border border-silicon-slate/60 bg-background/60 p-3">
+        <summary className="cursor-pointer text-xs font-semibold uppercase tracking-wide text-radiant-gold">
+          View JSON handoff packet
+        </summary>
+        <pre className="mt-3 max-h-80 overflow-auto rounded-md bg-black/25 p-3 text-xs text-muted-foreground">
+          {JSON.stringify(packet, null, 2)}
+        </pre>
+      </details>
     </div>
   )
 }

--- a/lib/agent-n8n-workflow-proposals.test.ts
+++ b/lib/agent-n8n-workflow-proposals.test.ts
@@ -8,7 +8,11 @@ vi.mock('@/lib/agent-work-items', () => ({
   createAgentWorkItem: mocks.createAgentWorkItem,
 }))
 
-import { createN8nWorkflowProposal, isN8nWorkflowProposalAction } from './agent-n8n-workflow-proposals'
+import {
+  buildN8nMcpHandoffPacket,
+  createN8nWorkflowProposal,
+  isN8nWorkflowProposalAction,
+} from './agent-n8n-workflow-proposals'
 
 describe('agent n8n workflow proposals', () => {
   beforeEach(() => {
@@ -54,8 +58,60 @@ describe('agent n8n workflow proposals', () => {
         goal_role: 'task',
         goal_progress_weight: 1,
         approval_gate: expect.stringContaining('Production activation'),
+        mcp_handoff_packet: expect.objectContaining({
+          version: 'agent-ops-n8n-mcp-handoff/v1',
+          action: 'draft_workflow',
+          workflowFamily: 'meeting_follow_up',
+          workflow: expect.objectContaining({
+            nodePlan: ['Webhook trigger', 'HTTP callback'],
+          }),
+          guardrails: expect.arrayContaining([
+            expect.stringContaining('inactive'),
+          ]),
+        }),
       }),
     }))
+  })
+
+  it('builds a governed MCP handoff packet for workflow builders', () => {
+    const packet = buildN8nMcpHandoffPacket({
+      action: 'stage_workflow',
+      title: 'Stage warm lead workflow',
+      objective: 'Create a staging-safe workflow.',
+      workflowFamily: 'warm_lead_capture',
+      automationGoalSeedId: 'warm-lead-review-ready-outreach',
+      proposedWorkflowName: 'Warm lead review-ready outreach',
+      trigger: 'Manual Agent Ops controller approval',
+      requiredEnvVars: ['N8N_INGEST_SECRET'],
+      credentialNeeds: ['Supabase API'],
+      nodePlan: ['Webhook trigger', 'Dedupe lead', 'Create work item'],
+      ingestCallbacks: ['/api/admin/agents/work-items'],
+      testEvidence: 'Synthetic lead fixture pending.',
+      rollbackPath: 'Delete inactive staging workflow.',
+    })
+
+    expect(packet).toMatchObject({
+      version: 'agent-ops-n8n-mcp-handoff/v1',
+      action: 'stage_workflow',
+      workflowFamily: 'warm_lead_capture',
+      automationGoalSeedId: 'warm-lead-review-ready-outreach',
+      goalId: 'automation:warm-lead-review-ready-outreach',
+      workflow: {
+        proposedName: 'Warm lead review-ready outreach',
+        existingWorkflowId: null,
+        trigger: 'Manual Agent Ops controller approval',
+        nodePlan: ['Webhook trigger', 'Dedupe lead', 'Create work item'],
+      },
+      requirements: {
+        requiredEnvVars: ['N8N_INGEST_SECRET'],
+        credentialNeeds: ['Supabase API'],
+        ingestCallbacks: ['/api/admin/agents/work-items'],
+        testEvidence: 'Synthetic lead fixture pending.',
+      },
+      rollbackPath: 'Delete inactive staging workflow.',
+    })
+    expect(packet.guardrails.join(' ')).toContain('Do not send outbound email')
+    expect(packet.handoffInstructions.join(' ')).toContain('Return the n8n workflow id')
   })
 
   it('rejects malformed proposals', async () => {

--- a/lib/agent-n8n-workflow-proposals.ts
+++ b/lib/agent-n8n-workflow-proposals.ts
@@ -23,6 +23,31 @@ export type CreateN8nWorkflowProposalInput = {
   requestedByUserId?: string | null
 }
 
+export type N8nMcpHandoffPacket = {
+  version: 'agent-ops-n8n-mcp-handoff/v1'
+  action: N8nWorkflowProposalAction
+  workflowFamily: string | null
+  automationGoalSeedId: string | null
+  goalId: string | null
+  goalTitle: string | null
+  workflow: {
+    proposedName: string | null
+    existingWorkflowId: string | null
+    trigger: string | null
+    nodePlan: string[]
+  }
+  requirements: {
+    requiredEnvVars: string[]
+    credentialNeeds: string[]
+    ingestCallbacks: string[]
+    testEvidence: string | null
+  }
+  approvalGate: string
+  rollbackPath: string | null
+  guardrails: string[]
+  handoffInstructions: string[]
+}
+
 const ALLOWED_ACTIONS: N8nWorkflowProposalAction[] = [
   'inspect_workflow',
   'draft_workflow',
@@ -32,6 +57,43 @@ const ALLOWED_ACTIONS: N8nWorkflowProposalAction[] = [
 
 export function isN8nWorkflowProposalAction(value: string): value is N8nWorkflowProposalAction {
   return ALLOWED_ACTIONS.includes(value as N8nWorkflowProposalAction)
+}
+
+export function buildN8nMcpHandoffPacket(input: CreateN8nWorkflowProposalInput): N8nMcpHandoffPacket {
+  const approvalGate = 'Production activation, credential changes, outbound sends, public publishing, and client-visible mutation require approval.'
+  return {
+    version: 'agent-ops-n8n-mcp-handoff/v1',
+    action: input.action,
+    workflowFamily: input.workflowFamily ?? null,
+    automationGoalSeedId: input.automationGoalSeedId ?? null,
+    goalId: input.goalId ?? (input.automationGoalSeedId ? `automation:${input.automationGoalSeedId}` : null),
+    goalTitle: input.goalTitle ?? null,
+    workflow: {
+      proposedName: input.proposedWorkflowName ?? input.title.trim() ?? null,
+      existingWorkflowId: input.existingWorkflowId ?? null,
+      trigger: input.trigger ?? null,
+      nodePlan: input.nodePlan ?? [],
+    },
+    requirements: {
+      requiredEnvVars: input.requiredEnvVars ?? [],
+      credentialNeeds: input.credentialNeeds ?? [],
+      ingestCallbacks: input.ingestCallbacks ?? [],
+      testEvidence: input.testEvidence ?? null,
+    },
+    approvalGate,
+    rollbackPath: input.rollbackPath ?? null,
+    guardrails: [
+      'Use staging, inactive, or inspection-only n8n workflows until the controller explicitly approves activation.',
+      'Do not create or rotate credentials from this packet; report credential needs back to Agent Ops.',
+      'Do not send outbound email, publish content, mutate production customer data, or enable live schedules without approval.',
+      'Use synthetic or test-owned validation data unless the controller approves a narrower live-data drill.',
+    ],
+    handoffInstructions: [
+      'Create or inspect the workflow using the workflow name, trigger, node plan, credential needs, and callback routes in this packet.',
+      'Return the n8n workflow id, validation result, test evidence, and rollback notes to the Decision Queue controller.',
+      'Attach trace evidence before asking for staging, production activation, credential, outbound, or client-visible approval.',
+    ],
+  }
 }
 
 export async function createN8nWorkflowProposal(input: CreateN8nWorkflowProposalInput): Promise<AgentWorkItem> {
@@ -44,6 +106,7 @@ export async function createN8nWorkflowProposal(input: CreateN8nWorkflowProposal
   if (!title || !objective) {
     throw new Error('title and objective are required')
   }
+  const mcpHandoffPacket = buildN8nMcpHandoffPacket(input)
 
   return createAgentWorkItem({
     title: `n8n proposal: ${title}`,
@@ -78,6 +141,7 @@ export async function createN8nWorkflowProposal(input: CreateN8nWorkflowProposal
       test_evidence: input.testEvidence ?? null,
       rollback_path: input.rollbackPath ?? null,
       approval_gate: 'Production activation, credential changes, outbound sends, public publishing, and client-visible mutation require approval.',
+      mcp_handoff_packet: mcpHandoffPacket,
       requested_by_user_id: input.requestedByUserId ?? null,
     },
     idempotencyKey: `n8n-workflow-proposal:${input.action}:${input.automationGoalSeedId ?? input.existingWorkflowId ?? title}`,


### PR DESCRIPTION
## Summary
- add a structured n8n MCP handoff packet to new workflow proposal work items
- show the MCP handoff packet inside Decision Queue proposal cards with guardrails, return contract, and collapsed JSON
- keep activation, credentials, outbound sends, and client-visible mutation approval-gated

## Validation
- npm test -- lib/agent-n8n-workflow-proposals.test.ts app/api/admin/agents/n8n-workflow-proposals/route.test.ts app/admin/agents/coordination/page.test.tsx
- npm run build:knowledge
- npx tsc --noEmit --pretty false
- npm run lint
- git diff --check
- local route smoke: curl -I 'http://localhost:3012/admin/agents/coordination?proposal=work-n8n-proposal-1' returned 200

## Integration Notes
- No schema changes. The packet is stored in existing work-item metadata for new proposals and computed from existing metadata for older proposal cards.
- This does not call n8n or activate workflows; it creates the governed packet future agents/MCP calls should use.
- Worktree env bootstrap linked .env.local and .vercel from the root checkout; .env.staging was not present in the source checkout.
- Vercel contexts to verify after merge: Vercel – portfolio and Vercel – portfolio-staging.