### PR TITLE
feat: request n8n mcp builds from queue

### DIFF
--- a/app/admin/agents/coordination/page.test.tsx
+++ b/app/admin/agents/coordination/page.test.tsx
@@ -317,6 +317,10 @@ function setupFetch({ failWorkItems = false } = {}) {
       return { ok: true, json: async () => ({ ok: true }) }
     }
 
+    if (url.includes('/api/admin/agents/work-items/work-n8n-proposal-1/mcp-build-request') && init?.method === 'POST') {
+      return { ok: true, json: async () => ({ ok: true }) }
+    }
+
     if (url.includes('/api/admin/agents/work-items/work-n8n-proposal-1/block') && init?.method === 'POST') {
       return { ok: true, json: async () => ({ ok: true }) }
     }
@@ -481,6 +485,14 @@ describe('AgentCoordinationPage decision queue controller', () => {
       expect(fetch).toHaveBeenCalledWith('/api/admin/agents/work-items/work-n8n-proposal-1/validation', expect.objectContaining({
         method: 'POST',
         body: expect.stringContaining('"ready_for_merge":false'),
+      }))
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Request n8n MCP build for proposal n8n proposal: Automate meeting intake to follow-up drafts' }))
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/admin/agents/work-items/work-n8n-proposal-1/mcp-build-request', expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('Create or inspect an inactive staging workflow only'),
       }))
     })
 

--- a/app/admin/agents/coordination/page.tsx
+++ b/app/admin/agents/coordination/page.tsx
@@ -109,7 +109,7 @@ type ShakaContextReply = {
   suggested_actions: string[]
 }
 
-type WorkItemQuickAction = 'block' | 'validation' | 'handoff' | 'ready' | 'proposal_validation'
+type WorkItemQuickAction = 'block' | 'validation' | 'handoff' | 'ready' | 'proposal_validation' | 'mcp_build_request'
 
 type N8nMcpHandoffPacketView = {
   version: string
@@ -515,6 +515,8 @@ function AgentCoordinationContent() {
         ? 'Needs Integration Captain review before proceeding.'
         : action === 'validation'
           ? 'Validation packet recorded from Agent Coordination.'
+          : action === 'mcp_build_request'
+            ? 'n8n MCP build requested from the structured handoff packet. Create or inspect an inactive staging workflow only; return workflow id, validation evidence, credential gaps, and rollback notes to this controller before activation.'
           : action === 'proposal_validation'
             ? 'n8n proposal packet reviewed. Trigger, credential boundary, callbacks, rollback path, and approval gate are ready for the next controller step.'
             : action === 'ready'
@@ -526,6 +528,8 @@ function AgentCoordinationContent() {
       const path =
         action === 'block'
           ? `/api/admin/agents/work-items/${item.id}/block`
+          : action === 'mcp_build_request'
+            ? `/api/admin/agents/work-items/${item.id}/mcp-build-request`
           : action === 'validation' || action === 'proposal_validation'
             ? `/api/admin/agents/work-items/${item.id}/validation`
             : action === 'ready'
@@ -534,6 +538,8 @@ function AgentCoordinationContent() {
       const body =
         action === 'block'
           ? { blocker_summary: note }
+          : action === 'mcp_build_request'
+            ? { request_summary: note }
           : action === 'validation'
             ? { validation_summary: note, ready_for_merge: true }
             : action === 'proposal_validation'
@@ -1535,6 +1541,16 @@ function N8nWorkflowProposalPanel({
                     >
                       <ShieldCheck size={16} />
                       Validate packet
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onAction(item, 'mcp_build_request')}
+                      disabled={Boolean(actionId)}
+                      aria-label={`Request n8n MCP build for proposal ${item.title}`}
+                      className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/50 bg-radiant-gold/10 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15 disabled:opacity-50"
+                    >
+                      <Workflow size={16} />
+                      Request MCP build
                     </button>
                     <button
                       type="button"

--- a/app/api/admin/agents/work-items/[id]/mcp-build-request/route.test.ts
+++ b/app/api/admin/agents/work-items/[id]/mcp-build-request/route.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  requestAgentWorkItemMcpBuild: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-work-items', () => ({
+  requestAgentWorkItemMcpBuild: mocks.requestAgentWorkItemMcpBuild,
+}))
+
+import { POST } from './route'
+
+function request(body: unknown) {
+  return new Request('http://localhost/api/admin/agents/work-items/work-1/mcp-build-request', {
+    method: 'POST',
+    headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/admin/agents/work-items/[id]/mcp-build-request', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user', email: 'admin@example.com' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.requestAgentWorkItemMcpBuild.mockResolvedValue({ id: 'work-1', status: 'queued' })
+  })
+
+  it('records an MCP build request for a work item', async () => {
+    const response = await POST(request({ request_summary: 'Use the handoff packet to create an inactive staging workflow.' }) as never, { params: { id: 'work-1' } })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({ ok: true, work_item: { id: 'work-1' } })
+    expect(mocks.requestAgentWorkItemMcpBuild).toHaveBeenCalledWith({
+      id: 'work-1',
+      requestSummary: 'Use the handoff packet to create an inactive staging workflow.',
+      actorLabel: 'admin@example.com',
+    })
+  })
+
+  it('requires a request summary', async () => {
+    const response = await POST(request({ request_summary: '' }) as never, { params: { id: 'work-1' } })
+
+    expect(response.status).toBe(400)
+    expect(mocks.requestAgentWorkItemMcpBuild).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/admin/agents/work-items/[id]/mcp-build-request/route.ts
+++ b/app/api/admin/agents/work-items/[id]/mcp-build-request/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { requestAgentWorkItemMcpBuild } from '@/lib/agent-work-items'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as {
+    request_summary?: unknown
+  }
+  const requestSummary = typeof body.request_summary === 'string' ? body.request_summary.trim() : ''
+  if (!requestSummary) {
+    return NextResponse.json({ error: 'request_summary is required' }, { status: 400 })
+  }
+
+  try {
+    const work_item = await requestAgentWorkItemMcpBuild({
+      id: params.id,
+      requestSummary,
+      actorLabel: auth.user.email,
+    })
+    return NextResponse.json({ ok: true, work_item })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to request MCP build'
+    const status = message === 'Agent work item not found' ? 404 : 500
+    console.error('[agent-work-item-mcp-build-request] failed:', error)
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/lib/agent-work-items.test.ts
+++ b/lib/agent-work-items.test.ts
@@ -32,6 +32,7 @@ import {
   listAgentWorkItems,
   recordAgentWorkItemBlocker,
   recordAgentWorkItemValidation,
+  requestAgentWorkItemMcpBuild,
 } from './agent-work-items'
 
 function chain() {
@@ -183,6 +184,56 @@ describe('agent work item helpers', () => {
     expect(mocks.fromMock).toHaveBeenCalledWith('agent_approvals')
     expect(mocks.updateMock).toHaveBeenCalledWith(expect.objectContaining({
       status: 'waiting_for_approval',
+    }))
+  })
+
+  it('records MCP build requests without activating external workflows', async () => {
+    queueExistingItem({
+      ...baseItem,
+      status: 'proposed',
+      metadata: {
+        mcp_handoff_packet: {
+          version: 'agent-ops-n8n-mcp-handoff/v1',
+        },
+      },
+    })
+    mocks.singleQueue.push({
+      data: {
+        ...baseItem,
+        status: 'queued',
+        validation_summary: 'Create inactive staging workflow from the handoff packet.',
+        metadata: {
+          mcp_handoff_packet: { version: 'agent-ops-n8n-mcp-handoff/v1' },
+          mcp_build_request: {
+            requested: true,
+            packet_version: 'agent-ops-n8n-mcp-handoff/v1',
+          },
+        },
+      },
+      error: null,
+    })
+
+    const result = await requestAgentWorkItemMcpBuild({
+      id: 'work-1',
+      requestSummary: 'Create inactive staging workflow from the handoff packet.',
+      actorLabel: 'admin@example.com',
+    })
+
+    expect(result.status).toBe('queued')
+    expect(mocks.updateMock).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'queued',
+      validation_summary: 'Create inactive staging workflow from the handoff packet.',
+      metadata: expect.objectContaining({
+        mcp_build_request: expect.objectContaining({
+          requested: true,
+          actor_label: 'admin@example.com',
+          expected_return: expect.arrayContaining(['n8n workflow id or inspection result']),
+        }),
+      }),
+    }))
+    expect(mocks.recordAgentEvent).toHaveBeenCalledWith(expect.objectContaining({
+      eventType: 'agent_work_item_mcp_build_requested',
+      message: 'Create inactive staging workflow from the handoff packet.',
     }))
   })
 

--- a/lib/agent-work-items.ts
+++ b/lib/agent-work-items.ts
@@ -638,6 +638,53 @@ export async function completeAgentWorkItem(input: {
   )
 }
 
+export async function requestAgentWorkItemMcpBuild(input: {
+  id: string
+  requestSummary: string
+  actorLabel?: string | null
+}) {
+  const requestSummary = input.requestSummary.trim()
+  if (!requestSummary) throw new Error('MCP build request summary is required')
+  const item = await requireAgentWorkItem(input.id)
+  const now = new Date().toISOString()
+  const metadata = {
+    ...(item.metadata ?? {}),
+    mcp_build_request: {
+      requested: true,
+      requested_at: now,
+      actor_label: input.actorLabel ?? 'Admin user',
+      summary: requestSummary,
+      packet_version: typeof item.metadata?.mcp_handoff_packet === 'object'
+        && item.metadata.mcp_handoff_packet
+        && !Array.isArray(item.metadata.mcp_handoff_packet)
+        ? String((item.metadata.mcp_handoff_packet as Record<string, unknown>).version ?? 'agent-ops-n8n-mcp-handoff/v1')
+        : 'agent-ops-n8n-mcp-handoff/v1',
+      expected_return: [
+        'n8n workflow id or inspection result',
+        'validation result and test evidence',
+        'credential/env gaps',
+        'rollback notes',
+      ],
+    },
+  }
+  return updateWorkItem(
+    item,
+    {
+      status: item.status === 'proposed' ? 'queued' : item.status,
+      validation_summary: requestSummary,
+      metadata,
+    },
+    {
+      type: 'agent_work_item_mcp_build_requested',
+      message: requestSummary,
+      metadata: {
+        actor_label: input.actorLabel ?? 'Admin user',
+        expected_return: metadata.mcp_build_request.expected_return,
+      },
+    },
+  )
+}
+
 export async function cancelAgentWorkItem(input: { id: string; reason?: string | null }) {
   const item = await requireAgentWorkItem(input.id)
   return updateWorkItem(


### PR DESCRIPTION
## Summary
- add a guarded work-item endpoint for requesting an n8n MCP build from a reviewed handoff packet
- record MCP build request metadata and expected return evidence without activating external workflows
- add a Decision Queue action for n8n proposal cards: Request MCP build

## Validation
- npm test -- lib/agent-work-items.test.ts 'app/api/admin/agents/work-items/[id]/mcp-build-request/route.test.ts' app/admin/agents/coordination/page.test.tsx
- npm run build:knowledge
- npx tsc --noEmit --pretty false
- npm run lint
- git diff --check
- local route smoke: curl -I 'http://localhost:3013/admin/agents/coordination?proposal=work-n8n-proposal-1' returned 200

## Integration Notes
- No schema changes. MCP build requests are recorded in existing work-item metadata as `mcp_build_request`.
- This does not call n8n, create workflows, activate schedules, send outbound messages, or mutate client-visible data.
- The request explicitly requires the builder/MCP lane to return workflow id or inspection result, validation evidence, credential/env gaps, and rollback notes to the controller before activation.
- Worktree env bootstrap linked .env.local and .vercel from root; .env.staging was not present in the source checkout.
- Vercel contexts to verify after merge: Vercel – portfolio and Vercel – portfolio-staging.
