### PR TITLE
feat: record n8n mcp build results

### DIFF
--- a/app/admin/agents/coordination/page.test.tsx
+++ b/app/admin/agents/coordination/page.test.tsx
@@ -164,6 +164,34 @@ const workItems = [
       test_evidence: 'No staging test has run yet.',
       rollback_path: 'Delete the inactive draft workflow.',
       approval_gate: 'Production activation, credential changes, outbound sends, public publishing, and client-visible mutation require approval.',
+      mcp_build_request: {
+        requested: true,
+        requested_at: now,
+        actor_label: 'admin@example.com',
+        summary: 'Create or inspect an inactive staging workflow only.',
+        packet_version: 'agent-ops-n8n-mcp-handoff/v1',
+        expected_return: [
+          'n8n workflow id or inspection result',
+          'validation result and test evidence',
+          'credential/env gaps',
+          'rollback notes',
+        ],
+      },
+      mcp_build_result: {
+        recorded: true,
+        recorded_at: now,
+        actor_label: 'automation-systems',
+        result_summary: 'Inactive staging workflow created; credential mapping remains blocked.',
+        workflow_id: 'wf_meeting_followup_draft',
+        inspection_result: 'Inactive workflow inspected with no outbound activation.',
+        validation_result: 'Static validation passed; dry run blocked by missing credential.',
+        test_evidence: 'Synthetic payload reached the draft-email node with sends disabled.',
+        credential_gaps: ['Gmail OAuth staging credential'],
+        env_gaps: ['N8N_INGEST_SECRET'],
+        rollback_notes: 'Delete inactive workflow wf_meeting_followup_draft.',
+        activation_requested: true,
+        activation_gate: 'Production activation remains approval-gated and is not performed by this result update.',
+      },
     },
     idempotency_key: 'n8n-workflow-proposal:draft_workflow:meeting-intake-follow-up-drafts',
     created_at: now,
@@ -454,7 +482,7 @@ describe('AgentCoordinationPage decision queue controller', () => {
     expect(screen.getByText('Production activation, credential changes, outbound sends, public publishing, and client-visible mutation require approval.')).toBeInTheDocument()
     expect(screen.getByText('Delete the inactive draft workflow.')).toBeInTheDocument()
     expect(screen.getByText('Identify the source trigger and dedupe/idempotency key.')).toBeInTheDocument()
-    expect(screen.getByText('Env: N8N_INGEST_SECRET')).toBeInTheDocument()
+    expect(screen.getAllByText('Env: N8N_INGEST_SECRET').length).toBeGreaterThan(0)
     expect(screen.getByText('n8n MCP handoff packet')).toBeInTheDocument()
     expect(screen.getByText(/Use this structured packet when an agent asks the n8n MCP/i)).toBeInTheDocument()
     expect(screen.getByText('MCP guardrails')).toBeInTheDocument()
@@ -462,6 +490,16 @@ describe('AgentCoordinationPage decision queue controller', () => {
     expect(screen.getByText('Builder return contract')).toBeInTheDocument()
     expect(screen.getAllByText(/Return the n8n workflow id/i).length).toBeGreaterThan(0)
     expect(screen.getByText('View JSON handoff packet')).toBeInTheDocument()
+    expect(screen.getByText('MCP build status')).toBeInTheDocument()
+    expect(screen.getByText('Returned build evidence is attached to this controller packet.')).toBeInTheDocument()
+    expect(screen.getByText('gaps returned')).toBeInTheDocument()
+    expect(screen.getByText('Create or inspect an inactive staging workflow only.')).toBeInTheDocument()
+    expect(screen.getByText('Inactive staging workflow created; credential mapping remains blocked.')).toBeInTheDocument()
+    expect(screen.getByText('wf_meeting_followup_draft')).toBeInTheDocument()
+    expect(screen.getByText('Static validation passed; dry run blocked by missing credential.')).toBeInTheDocument()
+    expect(screen.getByText('Credential: Gmail OAuth staging credential')).toBeInTheDocument()
+    expect(screen.getAllByText('Env: N8N_INGEST_SECRET').length).toBeGreaterThan(0)
+    expect(screen.getByText(/Activation was requested but still requires controller approval/i)).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /Goal session/ })).toHaveAttribute('href', '/admin/agents/standup?goal=automation%3Ameeting-intake-follow-up-drafts')
     expect(screen.getByRole('link', { name: /Goal Kanban/ })).toHaveAttribute('href', '/admin/agents/swarm-board?goal=automation%3Ameeting-intake-follow-up-drafts')
 

--- a/app/admin/agents/coordination/page.tsx
+++ b/app/admin/agents/coordination/page.tsx
@@ -136,6 +136,29 @@ type N8nMcpHandoffPacketView = {
   handoffInstructions: string[]
 }
 
+type N8nMcpBuildRequestView = {
+  requestedAt: string | null
+  actorLabel: string | null
+  summary: string | null
+  packetVersion: string | null
+  expectedReturn: string[]
+}
+
+type N8nMcpBuildResultView = {
+  recordedAt: string | null
+  actorLabel: string | null
+  resultSummary: string
+  workflowId: string | null
+  inspectionResult: string | null
+  validationResult: string | null
+  testEvidence: string | null
+  credentialGaps: string[]
+  envGaps: string[]
+  rollbackNotes: string | null
+  activationRequested: boolean
+  activationGate: string | null
+}
+
 const DEFAULT_FORM: WorkItemForm = {
   title: 'Review controller decision packet',
   objective: 'Summarize the decision needed, confirm the evidence source, state the safest next step, and route the packet through the controller before execution continues.',
@@ -293,6 +316,38 @@ function n8nMcpHandoffPacketForProposal(input: {
       'Return the n8n workflow id, validation result, test evidence, and rollback notes to the Decision Queue controller.',
       'Attach trace evidence before asking for staging, production activation, credential, outbound, or client-visible approval.',
     ],
+  }
+}
+
+function n8nMcpBuildRequestForItem(item: AgentWorkItem): N8nMcpBuildRequestView | null {
+  const request = recordValue(item.metadata?.mcp_build_request)
+  if (!request) return null
+  return {
+    requestedAt: stringValue(request.requested_at),
+    actorLabel: stringValue(request.actor_label),
+    summary: stringValue(request.summary),
+    packetVersion: stringValue(request.packet_version),
+    expectedReturn: textArray(request.expected_return),
+  }
+}
+
+function n8nMcpBuildResultForItem(item: AgentWorkItem): N8nMcpBuildResultView | null {
+  const result = recordValue(item.metadata?.mcp_build_result)
+  const resultSummary = stringValue(result?.result_summary)
+  if (!result || !resultSummary) return null
+  return {
+    recordedAt: stringValue(result.recorded_at),
+    actorLabel: stringValue(result.actor_label),
+    resultSummary,
+    workflowId: stringValue(result.workflow_id),
+    inspectionResult: stringValue(result.inspection_result),
+    validationResult: stringValue(result.validation_result),
+    testEvidence: stringValue(result.test_evidence),
+    credentialGaps: textArray(result.credential_gaps),
+    envGaps: textArray(result.env_gaps),
+    rollbackNotes: stringValue(result.rollback_notes),
+    activationRequested: result.activation_requested === true,
+    activationGate: stringValue(result.activation_gate),
   }
 }
 
@@ -1396,6 +1451,8 @@ function N8nWorkflowProposalPanel({
             const rollbackPath = stringValue(item.metadata?.rollback_path) ?? 'Delete the inactive draft workflow and leave production unchanged.'
             const approvalGate = stringValue(item.metadata?.approval_gate)
               ?? 'Production activation, credential changes, outbound sends, public publishing, and client-visible mutation require approval.'
+            const mcpBuildRequest = n8nMcpBuildRequestForItem(item)
+            const mcpBuildResult = n8nMcpBuildResultForItem(item)
             const mcpHandoffPacket = n8nMcpHandoffPacketForProposal({
               item,
               action,
@@ -1486,6 +1543,7 @@ function N8nWorkflowProposalPanel({
                     </div>
 
                     <McpHandoffPacketPanel packet={mcpHandoffPacket} />
+                    <McpBuildStatusPanel request={mcpBuildRequest} result={mcpBuildResult} />
 
                     <div className="mt-3 grid gap-2 text-xs text-muted-foreground sm:grid-cols-2 xl:grid-cols-4">
                       <SmallField label="Owner" value={item.owner_agent_key ?? item.owner_runtime} />
@@ -2040,6 +2098,96 @@ function McpHandoffPacketPanel({ packet }: { packet: N8nMcpHandoffPacketView }) 
           {JSON.stringify(packet, null, 2)}
         </pre>
       </details>
+    </div>
+  )
+}
+
+function McpBuildStatusPanel({
+  request,
+  result,
+}: {
+  request: N8nMcpBuildRequestView | null
+  result: N8nMcpBuildResultView | null
+}) {
+  if (!request && !result) return null
+
+  const gaps = result ? [...result.credentialGaps, ...result.envGaps] : []
+  return (
+    <div className="mt-3 rounded-lg border border-blue-400/30 bg-blue-500/10 p-3 text-sm">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <div className="flex items-center gap-2 text-blue-100">
+            <Workflow size={16} />
+            <p className="text-xs font-semibold uppercase tracking-wide">MCP build status</p>
+          </div>
+          <p className="mt-2 text-foreground">
+            {result
+              ? 'Returned build evidence is attached to this controller packet.'
+              : 'Build request is waiting for an n8n MCP result packet.'}
+          </p>
+        </div>
+        <span className={`inline-flex w-fit rounded-full border px-2 py-1 text-xs ${
+          result
+            ? gaps.length
+              ? 'border-red-500/35 bg-red-500/10 text-red-100'
+              : 'border-green-500/35 bg-green-500/10 text-green-100'
+            : 'border-yellow-500/35 bg-yellow-500/10 text-yellow-100'
+        }`}>
+          {result ? (gaps.length ? 'gaps returned' : 'ready for review') : 'requested'}
+        </span>
+      </div>
+
+      {request ? (
+        <div className="mt-3 rounded-lg border border-silicon-slate/60 bg-background/45 p-3">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground/70">Build request</p>
+          <p className="mt-1 text-foreground">{request.summary ?? 'No request summary was attached.'}</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {request.actorLabel ?? 'Unknown requester'}
+            {request.requestedAt ? ` · ${new Date(request.requestedAt).toLocaleString()}` : ''}
+            {request.packetVersion ? ` · ${request.packetVersion}` : ''}
+          </p>
+          {request.expectedReturn.length ? (
+            <p className="mt-2 text-xs text-muted-foreground">
+              Expected return: {request.expectedReturn.join(', ')}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+
+      {result ? (
+        <div className="mt-3 grid gap-3 lg:grid-cols-2">
+          <DecisionSummaryBlock
+            label="Result summary"
+            value={result.resultSummary}
+            tone={gaps.length ? 'yellow' : 'green'}
+          />
+          <DecisionSummaryBlock
+            label="Workflow or inspection"
+            value={result.workflowId ?? result.inspectionResult ?? 'No workflow id or inspection result returned.'}
+          />
+          <DecisionSummaryBlock
+            label="Validation"
+            value={result.validationResult ?? 'No validation result returned.'}
+          />
+          <DecisionSummaryBlock
+            label="Test evidence"
+            value={result.testEvidence ?? 'No test evidence returned.'}
+          />
+          <ListField
+            label="Credential and env gaps"
+            values={[
+              ...result.credentialGaps.map((gap) => `Credential: ${gap}`),
+              ...result.envGaps.map((gap) => `Env: ${gap}`),
+            ]}
+            fallback="No credential or env gaps were returned."
+          />
+          <DecisionSummaryBlock
+            label="Rollback and activation gate"
+            value={`${result.rollbackNotes ?? 'Rollback notes were not returned.'} ${result.activationRequested ? 'Activation was requested but still requires controller approval.' : result.activationGate ?? 'Activation remains approval-gated.'}`}
+            tone={result.activationRequested ? 'yellow' : 'slate'}
+          />
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/app/api/admin/agents/work-items/[id]/mcp-build-result/route.test.ts
+++ b/app/api/admin/agents/work-items/[id]/mcp-build-result/route.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  recordAgentWorkItemMcpBuildResult: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-work-items', () => ({
+  recordAgentWorkItemMcpBuildResult: mocks.recordAgentWorkItemMcpBuildResult,
+}))
+
+import { POST } from './route'
+
+function request(body: unknown) {
+  return new Request('http://localhost/api/admin/agents/work-items/work-1/mcp-build-result', {
+    method: 'POST',
+    headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/admin/agents/work-items/[id]/mcp-build-result', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user', email: 'admin@example.com' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.recordAgentWorkItemMcpBuildResult.mockResolvedValue({ id: 'work-1', status: 'ready_for_review' })
+  })
+
+  it('records returned MCP build evidence for a work item', async () => {
+    const response = await POST(request({
+      result_summary: 'Inactive staging workflow created and inspected.',
+      workflow_id: 'wf_123',
+      validation_result: 'Static inspection passed.',
+      test_evidence: 'Dry-run fixture completed.',
+      credential_gaps: ['MAILGUN_API_KEY'],
+      env_gaps: ['N8N_INGEST_SECRET'],
+      rollback_notes: 'Delete inactive workflow wf_123.',
+      activation_requested: true,
+    }) as never, { params: { id: 'work-1' } })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({ ok: true, work_item: { id: 'work-1' } })
+    expect(mocks.recordAgentWorkItemMcpBuildResult).toHaveBeenCalledWith({
+      id: 'work-1',
+      resultSummary: 'Inactive staging workflow created and inspected.',
+      workflowId: 'wf_123',
+      inspectionResult: null,
+      validationResult: 'Static inspection passed.',
+      testEvidence: 'Dry-run fixture completed.',
+      credentialGaps: ['MAILGUN_API_KEY'],
+      envGaps: ['N8N_INGEST_SECRET'],
+      rollbackNotes: 'Delete inactive workflow wf_123.',
+      activationRequested: true,
+      actorLabel: 'admin@example.com',
+    })
+  })
+
+  it('requires a result summary', async () => {
+    const response = await POST(request({ result_summary: '' }) as never, { params: { id: 'work-1' } })
+
+    expect(response.status).toBe(400)
+    expect(mocks.recordAgentWorkItemMcpBuildResult).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/admin/agents/work-items/[id]/mcp-build-result/route.ts
+++ b/app/api/admin/agents/work-items/[id]/mcp-build-result/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { recordAgentWorkItemMcpBuildResult } from '@/lib/agent-work-items'
+
+export const dynamic = 'force-dynamic'
+
+function stringArray(value: unknown) {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+    : []
+}
+
+function optionalString(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as Record<string, unknown>
+  const resultSummary = optionalString(body.result_summary)
+  if (!resultSummary) {
+    return NextResponse.json({ error: 'result_summary is required' }, { status: 400 })
+  }
+
+  try {
+    const work_item = await recordAgentWorkItemMcpBuildResult({
+      id: params.id,
+      resultSummary,
+      workflowId: optionalString(body.workflow_id) || null,
+      inspectionResult: optionalString(body.inspection_result) || null,
+      validationResult: optionalString(body.validation_result) || null,
+      testEvidence: optionalString(body.test_evidence) || null,
+      credentialGaps: stringArray(body.credential_gaps),
+      envGaps: stringArray(body.env_gaps),
+      rollbackNotes: optionalString(body.rollback_notes) || null,
+      activationRequested: body.activation_requested === true,
+      actorLabel: auth.user.email,
+    })
+    return NextResponse.json({ ok: true, work_item })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to record MCP build result'
+    const status = message === 'Agent work item not found' ? 404 : 500
+    console.error('[agent-work-item-mcp-build-result] failed:', error)
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/lib/agent-work-items.test.ts
+++ b/lib/agent-work-items.test.ts
@@ -31,6 +31,7 @@ import {
   handoffAgentWorkItem,
   listAgentWorkItems,
   recordAgentWorkItemBlocker,
+  recordAgentWorkItemMcpBuildResult,
   recordAgentWorkItemValidation,
   requestAgentWorkItemMcpBuild,
 } from './agent-work-items'
@@ -234,6 +235,104 @@ describe('agent work item helpers', () => {
     expect(mocks.recordAgentEvent).toHaveBeenCalledWith(expect.objectContaining({
       eventType: 'agent_work_item_mcp_build_requested',
       message: 'Create inactive staging workflow from the handoff packet.',
+    }))
+  })
+
+  it('records MCP build results and blocks work when gaps remain', async () => {
+    queueExistingItem({
+      ...baseItem,
+      status: 'queued',
+      metadata: {
+        mcp_build_request: {
+          requested: true,
+          requested_at: '2026-05-09T01:00:00.000Z',
+        },
+      },
+    })
+    mocks.singleQueue.push({
+      data: {
+        ...baseItem,
+        status: 'blocked',
+        blocker_summary: 'MCP build returned unresolved gaps: N8N_INGEST_SECRET',
+        validation_summary: 'Inactive staging workflow was created but cannot run until secrets are mapped.',
+        metadata: {
+          mcp_build_request: { requested: true },
+          mcp_build_result: {
+            recorded: true,
+            workflow_id: 'wf_123',
+            env_gaps: ['N8N_INGEST_SECRET'],
+          },
+        },
+      },
+      error: null,
+    })
+
+    const result = await recordAgentWorkItemMcpBuildResult({
+      id: 'work-1',
+      resultSummary: 'Inactive staging workflow was created but cannot run until secrets are mapped.',
+      workflowId: 'wf_123',
+      validationResult: 'Inspection passed; dry run blocked by missing env.',
+      testEvidence: 'Fixture dry run stopped before outbound execution.',
+      envGaps: ['N8N_INGEST_SECRET'],
+      rollbackNotes: 'Delete inactive workflow wf_123.',
+      activationRequested: true,
+      actorLabel: 'admin@example.com',
+    })
+
+    expect(result.status).toBe('blocked')
+    expect(mocks.updateMock).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'blocked',
+      blocker_summary: 'MCP build returned unresolved gaps: N8N_INGEST_SECRET',
+      validation_summary: 'Inactive staging workflow was created but cannot run until secrets are mapped.',
+      metadata: expect.objectContaining({
+        mcp_build_request: expect.objectContaining({ requested: true }),
+        mcp_build_result: expect.objectContaining({
+          workflow_id: 'wf_123',
+          env_gaps: ['N8N_INGEST_SECRET'],
+          activation_requested: true,
+          activation_gate: expect.stringContaining('approval-gated'),
+        }),
+      }),
+    }))
+    expect(mocks.recordAgentEvent).toHaveBeenCalledWith(expect.objectContaining({
+      eventType: 'agent_work_item_mcp_build_result_recorded',
+      message: 'Inactive staging workflow was created but cannot run until secrets are mapped.',
+    }))
+  })
+
+  it('marks MCP build results ready for review when no gaps remain', async () => {
+    queueExistingItem({ ...baseItem, status: 'queued' })
+    mocks.singleQueue.push({
+      data: {
+        ...baseItem,
+        status: 'ready_for_review',
+        validation_summary: 'Inactive workflow passed dry-run validation.',
+        metadata: {
+          mcp_build_result: {
+            recorded: true,
+            workflow_id: 'wf_456',
+            credential_gaps: [],
+            env_gaps: [],
+          },
+        },
+      },
+      error: null,
+    })
+
+    const result = await recordAgentWorkItemMcpBuildResult({
+      id: 'work-1',
+      resultSummary: 'Inactive workflow passed dry-run validation.',
+      workflowId: 'wf_456',
+      validationResult: 'Dry run passed.',
+      testEvidence: 'No outbound calls were made.',
+      credentialGaps: [],
+      envGaps: [],
+    })
+
+    expect(result.status).toBe('ready_for_review')
+    expect(mocks.updateMock).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'ready_for_review',
+      blocker_summary: null,
     }))
   })
 

--- a/lib/agent-work-items.ts
+++ b/lib/agent-work-items.ts
@@ -685,6 +685,74 @@ export async function requestAgentWorkItemMcpBuild(input: {
   )
 }
 
+export async function recordAgentWorkItemMcpBuildResult(input: {
+  id: string
+  resultSummary: string
+  workflowId?: string | null
+  inspectionResult?: string | null
+  validationResult?: string | null
+  testEvidence?: string | null
+  credentialGaps?: string[]
+  envGaps?: string[]
+  rollbackNotes?: string | null
+  activationRequested?: boolean
+  actorLabel?: string | null
+}) {
+  const resultSummary = input.resultSummary.trim()
+  if (!resultSummary) throw new Error('MCP build result summary is required')
+
+  const item = await requireAgentWorkItem(input.id)
+  if (['merged', 'deployed', 'cancelled'].includes(item.status)) {
+    throw new Error(`Cannot record MCP build result for ${item.status} work item`)
+  }
+
+  const credentialGaps = normalizeStringArray(input.credentialGaps)
+  const envGaps = normalizeStringArray(input.envGaps)
+  const unresolvedGaps = [...credentialGaps, ...envGaps]
+  const now = new Date().toISOString()
+  const metadata = {
+    ...(item.metadata ?? {}),
+    mcp_build_result: {
+      recorded: true,
+      recorded_at: now,
+      actor_label: input.actorLabel ?? 'Admin user',
+      result_summary: resultSummary,
+      workflow_id: input.workflowId?.trim() || null,
+      inspection_result: input.inspectionResult?.trim() || null,
+      validation_result: input.validationResult?.trim() || null,
+      test_evidence: input.testEvidence?.trim() || null,
+      credential_gaps: credentialGaps,
+      env_gaps: envGaps,
+      rollback_notes: input.rollbackNotes?.trim() || null,
+      activation_requested: input.activationRequested === true,
+      activation_gate: 'Production activation remains approval-gated and is not performed by this result update.',
+    },
+  }
+  const blockerSummary = unresolvedGaps.length
+    ? `MCP build returned unresolved gaps: ${unresolvedGaps.slice(0, 4).join(', ')}`
+    : null
+
+  return updateWorkItem(
+    item,
+    {
+      status: unresolvedGaps.length ? 'blocked' : 'ready_for_review',
+      blocker_summary: blockerSummary,
+      validation_summary: resultSummary,
+      metadata,
+    },
+    {
+      type: 'agent_work_item_mcp_build_result_recorded',
+      message: resultSummary,
+      metadata: {
+        actor_label: input.actorLabel ?? 'Admin user',
+        workflow_id: metadata.mcp_build_result.workflow_id,
+        has_unresolved_gaps: unresolvedGaps.length > 0,
+        activation_requested: metadata.mcp_build_result.activation_requested,
+      },
+    },
+  )
+}
+
 export async function cancelAgentWorkItem(input: { id: string; reason?: string | null }) {
   const item = await requireAgentWorkItem(input.id)
   return updateWorkItem(


### PR DESCRIPTION
## Summary
- add a guarded MCP build-result endpoint for Agent Ops work items
- record returned workflow ids, validation evidence, credential/env gaps, rollback notes, and activation intent as metadata only
- show MCP build request/result status inside Decision Queue n8n proposal cards

## Validation
- npm test -- lib/agent-work-items.test.ts 'app/api/admin/agents/work-items/[id]/mcp-build-result/route.test.ts' app/admin/agents/coordination/page.test.tsx
- npm run build:knowledge
- npx tsc --noEmit --pretty false
- npm run lint
- git diff --check
- curl -I 'http://localhost:3014/admin/agents/coordination?proposal=work-n8n-proposal-1' -> 200 OK

## Integration Notes
- No schema migration; uses existing work item metadata.
- No n8n workflow creation, activation, credential mutation, outbound send, or production data mutation.
- Activation remains controller approval-gated.
- Worktree env was bootstrapped from /Users/vambahsillah/Projects/Portfolio; .env.staging was not present in the root source.
- Vercel contexts to verify after merge: Vercel – portfolio and Vercel – portfolio-staging.