### PR TITLE
feat: gate n8n activation review

### DIFF
--- a/app/admin/agents/coordination/page.test.tsx
+++ b/app/admin/agents/coordination/page.test.tsx
@@ -181,15 +181,15 @@ const workItems = [
         recorded: true,
         recorded_at: now,
         actor_label: 'automation-systems',
-        result_summary: 'Inactive staging workflow created; credential mapping remains blocked.',
+        result_summary: 'Inactive staging workflow created and validated with synthetic data.',
         workflow_id: 'wf_meeting_followup_draft',
         inspection_result: 'Inactive workflow inspected with no outbound activation.',
-        validation_result: 'Static validation passed; dry run blocked by missing credential.',
-        test_evidence: 'Synthetic payload reached the draft-email node with sends disabled.',
-        credential_gaps: ['Gmail OAuth staging credential'],
-        env_gaps: ['N8N_INGEST_SECRET'],
+        validation_result: 'Static validation and synthetic dry run passed.',
+        test_evidence: 'Synthetic payload reached the draft-email node with sends disabled and no outbound calls.',
+        credential_gaps: [],
+        env_gaps: [],
         rollback_notes: 'Delete inactive workflow wf_meeting_followup_draft.',
-        activation_requested: true,
+        activation_requested: false,
         activation_gate: 'Production activation remains approval-gated and is not performed by this result update.',
       },
     },
@@ -349,6 +349,10 @@ function setupFetch({ failWorkItems = false } = {}) {
       return { ok: true, json: async () => ({ ok: true }) }
     }
 
+    if (url.includes('/api/admin/agents/work-items/work-n8n-proposal-1/n8n-activation-review') && init?.method === 'POST') {
+      return { ok: true, json: async () => ({ ok: true }) }
+    }
+
     if (url.includes('/api/admin/agents/work-items/work-n8n-proposal-1/block') && init?.method === 'POST') {
       return { ok: true, json: async () => ({ ok: true }) }
     }
@@ -492,14 +496,14 @@ describe('AgentCoordinationPage decision queue controller', () => {
     expect(screen.getByText('View JSON handoff packet')).toBeInTheDocument()
     expect(screen.getByText('MCP build status')).toBeInTheDocument()
     expect(screen.getByText('Returned build evidence is attached to this controller packet.')).toBeInTheDocument()
-    expect(screen.getByText('gaps returned')).toBeInTheDocument()
+    expect(screen.getAllByText('ready for review').length).toBeGreaterThan(0)
     expect(screen.getByText('Create or inspect an inactive staging workflow only.')).toBeInTheDocument()
-    expect(screen.getByText('Inactive staging workflow created; credential mapping remains blocked.')).toBeInTheDocument()
+    expect(screen.getByText('Inactive staging workflow created and validated with synthetic data.')).toBeInTheDocument()
     expect(screen.getByText('wf_meeting_followup_draft')).toBeInTheDocument()
-    expect(screen.getByText('Static validation passed; dry run blocked by missing credential.')).toBeInTheDocument()
-    expect(screen.getByText('Credential: Gmail OAuth staging credential')).toBeInTheDocument()
+    expect(screen.getByText('Static validation and synthetic dry run passed.')).toBeInTheDocument()
+    expect(screen.getByText('No credential or env gaps were returned.')).toBeInTheDocument()
     expect(screen.getAllByText('Env: N8N_INGEST_SECRET').length).toBeGreaterThan(0)
-    expect(screen.getByText(/Activation was requested but still requires controller approval/i)).toBeInTheDocument()
+    expect(screen.getByText(/Production activation remains approval-gated/i)).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /Goal session/ })).toHaveAttribute('href', '/admin/agents/standup?goal=automation%3Ameeting-intake-follow-up-drafts')
     expect(screen.getByRole('link', { name: /Goal Kanban/ })).toHaveAttribute('href', '/admin/agents/swarm-board?goal=automation%3Ameeting-intake-follow-up-drafts')
 
@@ -531,6 +535,14 @@ describe('AgentCoordinationPage decision queue controller', () => {
       expect(fetch).toHaveBeenCalledWith('/api/admin/agents/work-items/work-n8n-proposal-1/mcp-build-request', expect.objectContaining({
         method: 'POST',
         body: expect.stringContaining('Create or inspect an inactive staging workflow only'),
+      }))
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Request activation review for n8n proposal n8n proposal: Automate meeting intake to follow-up drafts' }))
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/admin/agents/work-items/work-n8n-proposal-1/n8n-activation-review', expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('n8n activation review requested from returned MCP build evidence'),
       }))
     })
 

--- a/app/admin/agents/coordination/page.tsx
+++ b/app/admin/agents/coordination/page.tsx
@@ -109,7 +109,14 @@ type ShakaContextReply = {
   suggested_actions: string[]
 }
 
-type WorkItemQuickAction = 'block' | 'validation' | 'handoff' | 'ready' | 'proposal_validation' | 'mcp_build_request'
+type WorkItemQuickAction =
+  | 'block'
+  | 'validation'
+  | 'handoff'
+  | 'ready'
+  | 'proposal_validation'
+  | 'mcp_build_request'
+  | 'n8n_activation_review'
 
 type N8nMcpHandoffPacketView = {
   version: string
@@ -157,6 +164,14 @@ type N8nMcpBuildResultView = {
   rollbackNotes: string | null
   activationRequested: boolean
   activationGate: string | null
+}
+
+type N8nActivationReviewRequestView = {
+  requestedAt: string | null
+  actorLabel: string | null
+  summary: string | null
+  workflowId: string | null
+  approvalBoundary: string[]
 }
 
 const DEFAULT_FORM: WorkItemForm = {
@@ -348,6 +363,18 @@ function n8nMcpBuildResultForItem(item: AgentWorkItem): N8nMcpBuildResultView | 
     rollbackNotes: stringValue(result.rollback_notes),
     activationRequested: result.activation_requested === true,
     activationGate: stringValue(result.activation_gate),
+  }
+}
+
+function n8nActivationReviewRequestForItem(item: AgentWorkItem): N8nActivationReviewRequestView | null {
+  const request = recordValue(item.metadata?.n8n_activation_review_request)
+  if (!request) return null
+  return {
+    requestedAt: stringValue(request.requested_at),
+    actorLabel: stringValue(request.actor_label),
+    summary: stringValue(request.summary),
+    workflowId: stringValue(request.workflow_id),
+    approvalBoundary: textArray(request.approval_boundary),
   }
 }
 
@@ -570,19 +597,23 @@ function AgentCoordinationContent() {
         ? 'Needs Integration Captain review before proceeding.'
         : action === 'validation'
           ? 'Validation packet recorded from Agent Coordination.'
-          : action === 'mcp_build_request'
-            ? 'n8n MCP build requested from the structured handoff packet. Create or inspect an inactive staging workflow only; return workflow id, validation evidence, credential gaps, and rollback notes to this controller before activation.'
-          : action === 'proposal_validation'
-            ? 'n8n proposal packet reviewed. Trigger, credential boundary, callbacks, rollback path, and approval gate are ready for the next controller step.'
-            : action === 'ready'
-              ? 'n8n proposal is ready for Kanban execution planning. Keep staging and production activation behind the controller approval gate.'
-              : 'Hand off to Integration Captain for gated review.'
+          : action === 'n8n_activation_review'
+            ? 'n8n activation review requested from returned MCP build evidence. Inspect workflow id, validation evidence, credential/env boundary, rollback notes, and approval gate before any workflow activation.'
+            : action === 'mcp_build_request'
+              ? 'n8n MCP build requested from the structured handoff packet. Create or inspect an inactive staging workflow only; return workflow id, validation evidence, credential gaps, and rollback notes to this controller before activation.'
+              : action === 'proposal_validation'
+                ? 'n8n proposal packet reviewed. Trigger, credential boundary, callbacks, rollback path, and approval gate are ready for the next controller step.'
+                : action === 'ready'
+                  ? 'n8n proposal is ready for Kanban execution planning. Keep staging and production activation behind the controller approval gate.'
+                  : 'Hand off to Integration Captain for gated review.'
     setActionId(`${action}:${item.id}`)
     setError(null)
     try {
       const path =
         action === 'block'
           ? `/api/admin/agents/work-items/${item.id}/block`
+          : action === 'n8n_activation_review'
+            ? `/api/admin/agents/work-items/${item.id}/n8n-activation-review`
           : action === 'mcp_build_request'
             ? `/api/admin/agents/work-items/${item.id}/mcp-build-request`
           : action === 'validation' || action === 'proposal_validation'
@@ -593,6 +624,8 @@ function AgentCoordinationContent() {
       const body =
         action === 'block'
           ? { blocker_summary: note }
+          : action === 'n8n_activation_review'
+            ? { review_summary: note }
           : action === 'mcp_build_request'
             ? { request_summary: note }
           : action === 'validation'
@@ -1453,6 +1486,10 @@ function N8nWorkflowProposalPanel({
               ?? 'Production activation, credential changes, outbound sends, public publishing, and client-visible mutation require approval.'
             const mcpBuildRequest = n8nMcpBuildRequestForItem(item)
             const mcpBuildResult = n8nMcpBuildResultForItem(item)
+            const activationReviewRequest = n8nActivationReviewRequestForItem(item)
+            const mcpBuildGaps = mcpBuildResult
+              ? [...mcpBuildResult.credentialGaps, ...mcpBuildResult.envGaps]
+              : []
             const mcpHandoffPacket = n8nMcpHandoffPacketForProposal({
               item,
               action,
@@ -1543,7 +1580,7 @@ function N8nWorkflowProposalPanel({
                     </div>
 
                     <McpHandoffPacketPanel packet={mcpHandoffPacket} />
-                    <McpBuildStatusPanel request={mcpBuildRequest} result={mcpBuildResult} />
+                    <McpBuildStatusPanel request={mcpBuildRequest} result={mcpBuildResult} activationReview={activationReviewRequest} />
 
                     <div className="mt-3 grid gap-2 text-xs text-muted-foreground sm:grid-cols-2 xl:grid-cols-4">
                       <SmallField label="Owner" value={item.owner_agent_key ?? item.owner_runtime} />
@@ -1610,6 +1647,18 @@ function N8nWorkflowProposalPanel({
                       <Workflow size={16} />
                       Request MCP build
                     </button>
+                    {mcpBuildResult && mcpBuildGaps.length === 0 && !activationReviewRequest ? (
+                      <button
+                        type="button"
+                        onClick={() => onAction(item, 'n8n_activation_review')}
+                        disabled={Boolean(actionId)}
+                        aria-label={`Request activation review for n8n proposal ${item.title}`}
+                        className="inline-flex items-center gap-2 rounded-lg border border-yellow-500/45 bg-yellow-500/10 px-3 py-2 text-sm text-yellow-100 hover:bg-yellow-500/15 disabled:opacity-50"
+                      >
+                        <ShieldCheck size={16} />
+                        Request activation review
+                      </button>
+                    ) : null}
                     <button
                       type="button"
                       onClick={() => onAction(item, 'block')}
@@ -2105,9 +2154,11 @@ function McpHandoffPacketPanel({ packet }: { packet: N8nMcpHandoffPacketView }) 
 function McpBuildStatusPanel({
   request,
   result,
+  activationReview,
 }: {
   request: N8nMcpBuildRequestView | null
   result: N8nMcpBuildResultView | null
+  activationReview: N8nActivationReviewRequestView | null
 }) {
   if (!request && !result) return null
 
@@ -2185,6 +2236,23 @@ function McpBuildStatusPanel({
             label="Rollback and activation gate"
             value={`${result.rollbackNotes ?? 'Rollback notes were not returned.'} ${result.activationRequested ? 'Activation was requested but still requires controller approval.' : result.activationGate ?? 'Activation remains approval-gated.'}`}
             tone={result.activationRequested ? 'yellow' : 'slate'}
+          />
+        </div>
+      ) : null}
+
+      {activationReview ? (
+        <div className="mt-3 rounded-lg border border-yellow-500/35 bg-yellow-500/10 p-3">
+          <p className="text-xs uppercase tracking-wide text-yellow-100">Activation review requested</p>
+          <p className="mt-1 text-foreground">{activationReview.summary ?? 'Review returned MCP build evidence before any activation decision.'}</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {activationReview.actorLabel ?? 'Unknown requester'}
+            {activationReview.requestedAt ? ` · ${new Date(activationReview.requestedAt).toLocaleString()}` : ''}
+            {activationReview.workflowId ? ` · ${activationReview.workflowId}` : ''}
+          </p>
+          <ListField
+            label="Approval boundary"
+            values={activationReview.approvalBoundary}
+            fallback="Production activation, credentials, outbound sends, schedules, and client-visible mutation remain approval-gated."
           />
         </div>
       ) : null}

--- a/app/api/admin/agents/work-items/[id]/n8n-activation-review/route.test.ts
+++ b/app/api/admin/agents/work-items/[id]/n8n-activation-review/route.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  requestAgentWorkItemN8nActivationReview: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-work-items', () => ({
+  requestAgentWorkItemN8nActivationReview: mocks.requestAgentWorkItemN8nActivationReview,
+}))
+
+import { POST } from './route'
+
+function request(body: unknown) {
+  return new Request('http://localhost/api/admin/agents/work-items/work-1/n8n-activation-review', {
+    method: 'POST',
+    headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/admin/agents/work-items/[id]/n8n-activation-review', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user', email: 'admin@example.com' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.requestAgentWorkItemN8nActivationReview.mockResolvedValue({ id: 'work-1', status: 'ready_for_review' })
+  })
+
+  it('requests activation review without activating n8n', async () => {
+    const response = await POST(request({
+      review_summary: 'Review inactive workflow evidence before any activation decision.',
+    }) as never, { params: { id: 'work-1' } })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({ ok: true, work_item: { id: 'work-1' } })
+    expect(mocks.requestAgentWorkItemN8nActivationReview).toHaveBeenCalledWith({
+      id: 'work-1',
+      reviewSummary: 'Review inactive workflow evidence before any activation decision.',
+      actorLabel: 'admin@example.com',
+    })
+  })
+
+  it('requires a review summary', async () => {
+    const response = await POST(request({ review_summary: '' }) as never, { params: { id: 'work-1' } })
+
+    expect(response.status).toBe(400)
+    expect(mocks.requestAgentWorkItemN8nActivationReview).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/admin/agents/work-items/[id]/n8n-activation-review/route.ts
+++ b/app/api/admin/agents/work-items/[id]/n8n-activation-review/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { requestAgentWorkItemN8nActivationReview } from '@/lib/agent-work-items'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as {
+    review_summary?: unknown
+  }
+  const reviewSummary = typeof body.review_summary === 'string' ? body.review_summary.trim() : ''
+  if (!reviewSummary) {
+    return NextResponse.json({ error: 'review_summary is required' }, { status: 400 })
+  }
+
+  try {
+    const work_item = await requestAgentWorkItemN8nActivationReview({
+      id: params.id,
+      reviewSummary,
+      actorLabel: auth.user.email,
+    })
+    return NextResponse.json({ ok: true, work_item })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to request n8n activation review'
+    const status = message === 'Agent work item not found' ? 404 : 500
+    console.error('[agent-work-item-n8n-activation-review] failed:', error)
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/lib/agent-work-items.test.ts
+++ b/lib/agent-work-items.test.ts
@@ -34,6 +34,7 @@ import {
   recordAgentWorkItemMcpBuildResult,
   recordAgentWorkItemValidation,
   requestAgentWorkItemMcpBuild,
+  requestAgentWorkItemN8nActivationReview,
 } from './agent-work-items'
 
 function chain() {
@@ -334,6 +335,87 @@ describe('agent work item helpers', () => {
       status: 'ready_for_review',
       blocker_summary: null,
     }))
+  })
+
+  it('requests n8n activation review only after a clean MCP build result', async () => {
+    queueExistingItem({
+      ...baseItem,
+      status: 'ready_for_review',
+      metadata: {
+        mcp_build_result: {
+          recorded: true,
+          result_summary: 'Inactive workflow passed dry-run validation.',
+          workflow_id: 'wf_456',
+          validation_result: 'Dry run passed.',
+          test_evidence: 'Synthetic fixture completed without outbound sends.',
+          credential_gaps: [],
+          env_gaps: [],
+          rollback_notes: 'Disable or delete inactive workflow wf_456.',
+        },
+      },
+    })
+    mocks.singleQueue.push({
+      data: {
+        ...baseItem,
+        status: 'ready_for_review',
+        validation_summary: 'Review inactive workflow evidence before any activation decision.',
+        metadata: {
+          mcp_build_result: { recorded: true, workflow_id: 'wf_456' },
+          n8n_activation_review_request: {
+            requested: true,
+            workflow_id: 'wf_456',
+          },
+        },
+      },
+      error: null,
+    })
+
+    const result = await requestAgentWorkItemN8nActivationReview({
+      id: 'work-1',
+      reviewSummary: 'Review inactive workflow evidence before any activation decision.',
+      actorLabel: 'admin@example.com',
+    })
+
+    expect(result.status).toBe('ready_for_review')
+    expect(mocks.updateMock).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'ready_for_review',
+      blocker_summary: null,
+      validation_summary: 'Review inactive workflow evidence before any activation decision.',
+      metadata: expect.objectContaining({
+        n8n_activation_review_request: expect.objectContaining({
+          requested: true,
+          actor_label: 'admin@example.com',
+          workflow_id: 'wf_456',
+          approval_boundary: expect.arrayContaining([
+            expect.stringContaining('No n8n workflow is activated'),
+          ]),
+        }),
+      }),
+    }))
+    expect(mocks.recordAgentEvent).toHaveBeenCalledWith(expect.objectContaining({
+      eventType: 'agent_work_item_n8n_activation_review_requested',
+      message: 'Review inactive workflow evidence before any activation decision.',
+    }))
+  })
+
+  it('rejects n8n activation review when MCP build gaps remain', async () => {
+    queueExistingItem({
+      ...baseItem,
+      status: 'blocked',
+      metadata: {
+        mcp_build_result: {
+          recorded: true,
+          workflow_id: 'wf_456',
+          credential_gaps: ['Gmail OAuth staging credential'],
+          env_gaps: [],
+        },
+      },
+    })
+
+    await expect(requestAgentWorkItemN8nActivationReview({
+      id: 'work-1',
+      reviewSummary: 'Review inactive workflow evidence before any activation decision.',
+    })).rejects.toThrow('Resolve MCP build gaps before requesting activation review')
   })
 
   it('records handoffs through agent_handoffs', async () => {

--- a/lib/agent-work-items.ts
+++ b/lib/agent-work-items.ts
@@ -753,6 +753,82 @@ export async function recordAgentWorkItemMcpBuildResult(input: {
   )
 }
 
+function recordValue(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null
+}
+
+function metadataString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+export async function requestAgentWorkItemN8nActivationReview(input: {
+  id: string
+  reviewSummary: string
+  actorLabel?: string | null
+}) {
+  const reviewSummary = input.reviewSummary.trim()
+  if (!reviewSummary) throw new Error('n8n activation review summary is required')
+  const item = await requireAgentWorkItem(input.id)
+  if (['merged', 'deployed', 'cancelled'].includes(item.status)) {
+    throw new Error(`Cannot request n8n activation review for ${item.status} work item`)
+  }
+
+  const buildResult = recordValue(item.metadata?.mcp_build_result)
+  if (!buildResult) throw new Error('MCP build result is required before requesting activation review')
+  const credentialGaps = normalizeStringArray(Array.isArray(buildResult.credential_gaps) ? buildResult.credential_gaps : [])
+  const envGaps = normalizeStringArray(Array.isArray(buildResult.env_gaps) ? buildResult.env_gaps : [])
+  const unresolvedGaps = [...credentialGaps, ...envGaps]
+  if (unresolvedGaps.length) {
+    throw new Error(`Resolve MCP build gaps before requesting activation review: ${unresolvedGaps.join(', ')}`)
+  }
+
+  const workflowId = metadataString(buildResult.workflow_id)
+  const inspectionResult = metadataString(buildResult.inspection_result)
+  if (!workflowId && !inspectionResult) {
+    throw new Error('MCP build result must include a workflow id or inspection result before activation review')
+  }
+
+  const now = new Date().toISOString()
+  const metadata = {
+    ...(item.metadata ?? {}),
+    n8n_activation_review_request: {
+      requested: true,
+      requested_at: now,
+      actor_label: input.actorLabel ?? 'Admin user',
+      summary: reviewSummary,
+      workflow_id: workflowId,
+      inspection_result: inspectionResult,
+      result_summary: metadataString(buildResult.result_summary),
+      validation_result: metadataString(buildResult.validation_result),
+      test_evidence: metadataString(buildResult.test_evidence),
+      rollback_notes: metadataString(buildResult.rollback_notes),
+      approval_boundary: [
+        'No n8n workflow is activated by this request.',
+        'Production activation, credentials, outbound sends, public publishing, live schedules, and client-visible mutation remain approval-gated.',
+        'Controller must inspect workflow id, validation evidence, rollback notes, and data boundary before any activation action.',
+      ],
+    },
+  }
+
+  return updateWorkItem(
+    item,
+    {
+      status: 'ready_for_review',
+      blocker_summary: null,
+      validation_summary: reviewSummary,
+      metadata,
+    },
+    {
+      type: 'agent_work_item_n8n_activation_review_requested',
+      message: reviewSummary,
+      metadata: {
+        actor_label: input.actorLabel ?? 'Admin user',
+        workflow_id: workflowId,
+      },
+    },
+  )
+}
+
 export async function cancelAgentWorkItem(input: { id: string; reason?: string | null }) {
   const item = await requireAgentWorkItem(input.id)
   return updateWorkItem(


### PR DESCRIPTION
## Summary
- add a guarded n8n activation-review request endpoint for Agent Ops work items
- require a clean MCP build result before activation review can be requested
- surface the activation-review control and returned approval boundary in the Decision Queue n8n proposal packet

## Validation
- npm test -- lib/agent-work-items.test.ts 'app/api/admin/agents/work-items/[id]/n8n-activation-review/route.test.ts' app/admin/agents/coordination/page.test.tsx
- npm run build:knowledge
- npx tsc --noEmit --pretty false
- npm run lint
- git diff --check
- curl -I 'http://localhost:3015/admin/agents/coordination?proposal=work-n8n-proposal-1' -> 200 OK

## Integration Notes
- No schema migration; uses existing work item metadata.
- No n8n workflow activation, workflow mutation, credential mutation, outbound send, or production data mutation.
- The activation-review request is a controller checkpoint only and explicitly preserves approval gates.
- Worktree env was bootstrapped from /Users/vambahsillah/Projects/Portfolio; .env.staging was not present in the root source.
- Vercel contexts to verify after merge: Vercel – portfolio and Vercel – portfolio-staging.