### PR TITLE
Refresh Model Ops snapshot

### DIFF
--- a/data/model-ops/reports/latest-dashboard-data.json
+++ b/data/model-ops/reports/latest-dashboard-data.json
@@ -1,6 +1,6 @@
 {
   "projectName": "Local LLM Model Ops & Hermes Automation",
-  "generatedAt": "2026-05-04T13:11:08.027Z",
+  "generatedAt": "2026-05-18T13:31:03.074Z",
   "recommendations": {
     "replyIntentDefault": "Keep qwen3-4b-instruct-2507 for reply-intent classification. It has the best current accuracy/latency balance.",
     "ragDefault": "Use routed local RAG as the leading local/shadow candidate, with Pinecone/OpenAI fallback until larger answer-level evals pass.",
@@ -65,6 +65,37 @@
         "portfolio_test_fixture": {
           "scored": 200,
           "correct": 200,
+          "accuracy": 1
+        }
+      }
+    },
+    {
+      "file": "eval-results/reply-intent-review/lmstudio-review-results-gpt-oss-20b-2026-05-18.json",
+      "model": "openai/gpt-oss-20b",
+      "observedModel": "openai/gpt-oss-20b",
+      "total": 211,
+      "scored": 203,
+      "correct": 203,
+      "accuracy": 1,
+      "avgLatencyMs": 1387.4549763033176,
+      "medianLatencyMs": 1332,
+      "estimated200Minutes": 4.624849921011059,
+      "status": "fixture_pipeline_timing_only",
+      "caveat": "Fixture/synthetic examples are useful for runner timing and failure discovery, but do not satisfy the production 200-example significance gate.",
+      "sourceAccuracy": {
+        "n8n_execution": {
+          "scored": 4,
+          "correct": 4,
+          "accuracy": 1
+        },
+        "gmail_backfill": {
+          "scored": 5,
+          "correct": 5,
+          "accuracy": 1
+        },
+        "portfolio_test_fixture": {
+          "scored": 194,
+          "correct": 194,
           "accuracy": 1
         }
       }


### PR DESCRIPTION
## Summary

- Refreshes the sanitized Model Ops admin snapshot from the 2026-05-18 Local LLM Model Ops & Hermes Automation monitor run.
- Adds the full `openai/gpt-oss-20b` reply-intent shadow result to the dashboard snapshot.
- Keeps the existing recommendation to prefer `qwen3-4b-instruct-2507` for reply-intent classification.

## Key Result

`openai/gpt-oss-20b` is installed and benchmarked locally, but it is not recommended for strict JSON reply-intent routing yet because 8 of 211 outputs failed strict JSON parsing. No production swap packet was created.

## Validation

- `npm --prefix /Users/vambahsillah/Projects/Portfolio run model-ops:snapshot`
- `npm --prefix /Users/vambahsillah/Projects/Portfolio run model-ops:research:plan -- --repo-snapshot`

## Notes

- This PR is snapshot-only and should be reviewed by the Integration Captain before merge.
- Labels `codex` and `codex-automation` were requested, but those labels are not currently available in this repository.
