### PR TITLE
feat: create n8n activation approval packets

### DIFF
--- a/app/admin/agents/coordination/page.test.tsx
+++ b/app/admin/agents/coordination/page.test.tsx
@@ -131,7 +131,7 @@ const workItems = [
     source_id: 'meeting-intake-follow-up-drafts',
     source_label: 'n8n workflow proposal',
     source_run_id: null,
-    active_run_id: null,
+    active_run_id: 'run-n8n-proposal-1',
     parent_work_item_id: null,
     branch_name: null,
     worktree_path: null,

--- a/app/admin/agents/coordination/page.tsx
+++ b/app/admin/agents/coordination/page.tsx
@@ -170,6 +170,8 @@ type N8nActivationReviewRequestView = {
   requestedAt: string | null
   actorLabel: string | null
   summary: string | null
+  approvalId: string | null
+  approvalType: string | null
   workflowId: string | null
   approvalBoundary: string[]
 }
@@ -373,6 +375,8 @@ function n8nActivationReviewRequestForItem(item: AgentWorkItem): N8nActivationRe
     requestedAt: stringValue(request.requested_at),
     actorLabel: stringValue(request.actor_label),
     summary: stringValue(request.summary),
+    approvalId: stringValue(request.approval_id),
+    approvalType: stringValue(request.approval_type),
     workflowId: stringValue(request.workflow_id),
     approvalBoundary: textArray(request.approval_boundary),
   }
@@ -2247,6 +2251,8 @@ function McpBuildStatusPanel({
           <p className="mt-1 text-xs text-muted-foreground">
             {activationReview.actorLabel ?? 'Unknown requester'}
             {activationReview.requestedAt ? ` · ${new Date(activationReview.requestedAt).toLocaleString()}` : ''}
+            {activationReview.approvalId ? ` · approval ${activationReview.approvalId}` : ''}
+            {activationReview.approvalType ? ` · ${activationReview.approvalType}` : ''}
             {activationReview.workflowId ? ` · ${activationReview.workflowId}` : ''}
           </p>
           <ListField

--- a/lib/agent-work-items.test.ts
+++ b/lib/agent-work-items.test.ts
@@ -84,7 +84,7 @@ const baseItem = {
   completed_at: null,
 }
 
-function queueExistingItem(item = baseItem) {
+function queueExistingItem(item: unknown = baseItem) {
   mocks.maybeSingleQueue.push({ data: item, error: null })
   mocks.listQueue.push({ data: [], error: null })
 }
@@ -366,21 +366,27 @@ describe('agent work item helpers', () => {
         },
       },
     })
-    mocks.singleQueue.push({
-      data: {
-        ...baseItem,
-        status: 'ready_for_review',
-        validation_summary: 'Review inactive workflow evidence before any activation decision.',
-        metadata: {
-          mcp_build_result: { recorded: true, workflow_id: 'wf_456' },
-          n8n_activation_review_request: {
-            requested: true,
-            workflow_id: 'wf_456',
+    mocks.singleQueue.push(
+      { data: { id: 'approval-n8n-1' }, error: null },
+      {
+        data: {
+          ...baseItem,
+          status: 'ready_for_review',
+          validation_summary: 'Review inactive workflow evidence before any activation decision.',
+          approval_id: 'approval-n8n-1',
+          metadata: {
+            mcp_build_result: { recorded: true, workflow_id: 'wf_456' },
+            n8n_activation_review_request: {
+              requested: true,
+              workflow_id: 'wf_456',
+              approval_id: 'approval-n8n-1',
+              approval_type: 'n8n_workflow_activation',
+            },
           },
         },
+        error: null,
       },
-      error: null,
-    })
+    )
 
     const result = await requestAgentWorkItemN8nActivationReview({
       id: 'work-1',
@@ -389,14 +395,40 @@ describe('agent work item helpers', () => {
     })
 
     expect(result.status).toBe('ready_for_review')
+    expect(result.approval_id).toBe('approval-n8n-1')
+    expect(mocks.fromMock).toHaveBeenCalledWith('agent_approvals')
+    expect(mocks.insertMock).toHaveBeenCalledWith(expect.objectContaining({
+      run_id: 'run-1',
+      approval_type: 'n8n_workflow_activation',
+      status: 'pending',
+      requested_by_agent_key: 'chief-of-staff',
+      metadata: expect.objectContaining({
+        work_item_id: 'work-1',
+        workflow_id: 'wf_456',
+        validation_result: 'Dry run passed.',
+        test_evidence: 'Synthetic fixture completed without outbound sends.',
+        rollback_notes: 'Disable or delete inactive workflow wf_456.',
+        action_payload: expect.objectContaining({
+          action: 'review_n8n_workflow_activation',
+          non_mutating: true,
+        }),
+      }),
+    }))
+    expect(mocks.updateMock).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'waiting_for_approval',
+      current_step: 'Approval required: n8n workflow activation',
+    }))
     expect(mocks.updateMock).toHaveBeenCalledWith(expect.objectContaining({
       status: 'ready_for_review',
       blocker_summary: null,
       validation_summary: 'Review inactive workflow evidence before any activation decision.',
+      approval_id: 'approval-n8n-1',
       metadata: expect.objectContaining({
         n8n_activation_review_request: expect.objectContaining({
           requested: true,
           actor_label: 'admin@example.com',
+          approval_id: 'approval-n8n-1',
+          approval_type: 'n8n_workflow_activation',
           workflow_id: 'wf_456',
           approval_boundary: expect.arrayContaining([
             expect.stringContaining('No n8n workflow is activated'),
@@ -407,7 +439,39 @@ describe('agent work item helpers', () => {
     expect(mocks.recordAgentEvent).toHaveBeenCalledWith(expect.objectContaining({
       eventType: 'agent_work_item_n8n_activation_review_requested',
       message: 'Review inactive workflow evidence before any activation decision.',
+      metadata: expect.objectContaining({
+        approval_id: 'approval-n8n-1',
+        approval_type: 'n8n_workflow_activation',
+      }),
     }))
+  })
+
+  it('requires a trace-linked run before n8n activation approval can be requested', async () => {
+    queueExistingItem({
+      ...baseItem,
+      active_run_id: null,
+      status: 'ready_for_review',
+      metadata: {
+        mcp_build_result: {
+          recorded: true,
+          result_summary: 'Inactive workflow passed dry-run validation.',
+          workflow_id: 'wf_456',
+          validation_result: 'Dry run passed.',
+          test_evidence: 'Synthetic fixture completed without outbound sends.',
+          credential_gaps: [],
+          env_gaps: [],
+          rollback_notes: 'Disable or delete inactive workflow wf_456.',
+        },
+      },
+    })
+
+    await expect(requestAgentWorkItemN8nActivationReview({
+      id: 'work-1',
+      reviewSummary: 'Review inactive workflow evidence before any activation decision.',
+    })).rejects.toThrow('Trace-linked run is required before requesting n8n activation approval')
+
+    expect(mocks.insertMock).not.toHaveBeenCalled()
+    expect(mocks.updateMock).not.toHaveBeenCalled()
   })
 
   it('requires an MCP build result before n8n activation review', async () => {

--- a/lib/agent-work-items.ts
+++ b/lib/agent-work-items.ts
@@ -134,6 +134,8 @@ const APPROVAL_GATED_STATUSES: ReadonlySet<AgentWorkItemStatus> = new Set([
   'deployed',
 ])
 
+export const N8N_WORKFLOW_ACTIVATION_APPROVAL_TYPE = 'n8n_workflow_activation'
+
 function db() {
   if (!supabaseAdmin) throw new Error('Database not available')
   return supabaseAdmin
@@ -271,6 +273,67 @@ async function createApprovalCheckpoint(item: AgentWorkItem, status: AgentWorkIt
       updated_at: new Date().toISOString(),
     })
     .eq('id', item.active_run_id)
+    .in('status', ['queued', 'running'])
+
+  return data.id as string
+}
+
+async function createN8nActivationApprovalCheckpoint(input: {
+  item: AgentWorkItem
+  reviewSummary: string
+  actorLabel: string
+  workflowId: string | null
+  inspectionResult: string | null
+  buildResult: Record<string, unknown>
+  approvalBoundary: string[]
+  existingApprovalId?: string | null
+}) {
+  const existingApprovalId = metadataString(input.existingApprovalId)
+  if (existingApprovalId) return existingApprovalId
+  if (!input.item.active_run_id) {
+    throw new Error('Trace-linked run is required before requesting n8n activation approval')
+  }
+
+  const { data, error } = await db()
+    .from('agent_approvals')
+    .insert({
+      run_id: input.item.active_run_id,
+      approval_type: N8N_WORKFLOW_ACTIVATION_APPROVAL_TYPE,
+      status: 'pending',
+      requested_by_agent_key: input.item.owner_agent_key ?? null,
+      metadata: {
+        work_item_id: input.item.id,
+        requested_status: 'n8n_activation_review',
+        workflow_id: input.workflowId,
+        inspection_result: input.inspectionResult,
+        review_summary: input.reviewSummary,
+        result_summary: metadataString(input.buildResult.result_summary),
+        validation_result: metadataString(input.buildResult.validation_result),
+        test_evidence: metadataString(input.buildResult.test_evidence),
+        rollback_notes: metadataString(input.buildResult.rollback_notes),
+        approval_boundary: input.approvalBoundary,
+        requested_by: input.actorLabel,
+        action_payload: {
+          action: 'review_n8n_workflow_activation',
+          workflow_id: input.workflowId,
+          work_item_id: input.item.id,
+          non_mutating: true,
+        },
+      },
+    })
+    .select('id')
+    .single()
+
+  if (error || !data?.id) throw new Error(error?.message ?? 'Failed to create n8n activation approval')
+
+  await db()
+    .from('agent_runs')
+    .update({
+      status: 'waiting_for_approval',
+      current_step: 'Approval required: n8n workflow activation',
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', input.item.active_run_id)
     .in('status', ['queued', 'running'])
 
   return data.id as string
@@ -789,6 +852,22 @@ export async function requestAgentWorkItemN8nActivationReview(input: {
   }
 
   const now = new Date().toISOString()
+  const existingActivationRequest = recordValue(item.metadata?.n8n_activation_review_request)
+  const approvalBoundary = [
+    'No n8n workflow is activated by this request.',
+    'Production activation, credentials, outbound sends, public publishing, live schedules, and client-visible mutation remain approval-gated.',
+    'Controller must inspect workflow id, validation evidence, rollback notes, and data boundary before any activation action.',
+  ]
+  const approvalId = await createN8nActivationApprovalCheckpoint({
+    item,
+    reviewSummary,
+    actorLabel: input.actorLabel ?? 'Admin user',
+    workflowId,
+    inspectionResult,
+    buildResult,
+    approvalBoundary,
+    existingApprovalId: metadataString(existingActivationRequest?.approval_id),
+  })
   const metadata = {
     ...(item.metadata ?? {}),
     n8n_activation_review_request: {
@@ -796,17 +875,15 @@ export async function requestAgentWorkItemN8nActivationReview(input: {
       requested_at: now,
       actor_label: input.actorLabel ?? 'Admin user',
       summary: reviewSummary,
+      approval_id: approvalId,
+      approval_type: N8N_WORKFLOW_ACTIVATION_APPROVAL_TYPE,
       workflow_id: workflowId,
       inspection_result: inspectionResult,
       result_summary: metadataString(buildResult.result_summary),
       validation_result: metadataString(buildResult.validation_result),
       test_evidence: metadataString(buildResult.test_evidence),
       rollback_notes: metadataString(buildResult.rollback_notes),
-      approval_boundary: [
-        'No n8n workflow is activated by this request.',
-        'Production activation, credentials, outbound sends, public publishing, live schedules, and client-visible mutation remain approval-gated.',
-        'Controller must inspect workflow id, validation evidence, rollback notes, and data boundary before any activation action.',
-      ],
+      approval_boundary: approvalBoundary,
     },
   }
 
@@ -816,6 +893,7 @@ export async function requestAgentWorkItemN8nActivationReview(input: {
       status: 'ready_for_review',
       blocker_summary: null,
       validation_summary: reviewSummary,
+      approval_id: approvalId,
       metadata,
     },
     {
@@ -824,6 +902,8 @@ export async function requestAgentWorkItemN8nActivationReview(input: {
       metadata: {
         actor_label: input.actorLabel ?? 'Admin user',
         workflow_id: workflowId,
+        approval_id: approvalId,
+        approval_type: N8N_WORKFLOW_ACTIVATION_APPROVAL_TYPE,
       },
     },
   )


### PR DESCRIPTION
## Summary
- create a pending Agent Ops approval packet when an n8n activation review is requested
- attach the approval id/type back to the work item metadata and Decision Queue status panel
- require a trace-linked run before activation approval can be requested, keeping activation non-mutating and approval-gated

## Validation
- npm test -- lib/agent-work-items.test.ts "app/api/admin/agents/work-items/[id]/n8n-activation-review/route.test.ts" app/admin/agents/coordination/page.test.tsx lib/agent-n8n-workflow-proposals.test.ts
- npm run build:knowledge
- npx tsc --noEmit --pretty false
- npm run lint
- git diff --check
- local route smoke: PORT=3016 npm run dev -- -p 3016, then curl -I http://localhost:3016/admin/agents/coordination?proposal=work-n8n-proposal-1 => 200 OK

## Integration Notes
- Preflight: open PR #313 touches subscription docs, PR #314 touches model-ops data; no overlap with Agent Ops n8n activation files.
- Root checkout dirty files preserved: docs/subscription-cancellation-audit.md and docs/subscription-status.json.
- No schema migration, no n8n workflow activation, no credential mutation, no outbound sends, and no production data mutation.
- Dev server emitted the existing n8n outbound warning because env has MOCK_N8N=false/N8N_DISABLE_OUTBOUND=false; this phase did not call outbound routes.
- Vercel contexts not checked locally: Vercel – portfolio and Vercel – portfolio-staging should be verified by Integration Captain after merge.