### PR TITLE
feat: add agent dependency tracing

### DIFF
--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -233,6 +233,23 @@ type MissionSnapshot = {
     next_action: string
     href: string
   }>
+  dependency_blockers?: Array<{
+    id: string
+    title: string
+    status: string
+    priority: string
+    owner_agent_key: string | null
+    owner_name: string
+    waiting_on: Array<{
+      id: string
+      title: string
+      status: string
+      owner_name: string
+      href: string
+    }>
+    href: string
+    updated_at: string
+  }>
 }
 
 type WarRoomResult = {
@@ -723,6 +740,8 @@ export default function AgentOperationsPage() {
   const deadLetterCount = snapshot?.dead_letter_queue.length ?? 0
   const engagementCount = snapshot?.engagement_queue.length ?? 0
   const operatingSignalCount = snapshot?.operating_signals.length ?? 0
+  const dependencyBlockers = snapshot?.dependency_blockers ?? []
+  const dependencyBlockerCount = dependencyBlockers.length
   const moremiWarningCount = moremiReview?.warning_count ?? 0
   const qualityScore = snapshot?.quality_summary.average_score === null || snapshot?.quality_summary.average_score === undefined
     ? 'No score'
@@ -805,6 +824,12 @@ export default function AgentOperationsPage() {
       detail: engagementCount ? `${engagementCount} request(s)` : 'Kanban and traces',
       href: engagementCount ? '/admin/agents/runs' : '/admin/agents/swarm-board',
       icon: <ClipboardList size={16} />,
+    },
+    {
+      title: 'Dependency Blockers',
+      detail: dependencyBlockerCount ? `${dependencyBlockerCount} waiting on upstream` : 'No dependency blockers',
+      href: dependencyBlockerCount ? '/admin/agents/swarm-board' : '/admin/agents/swarm-board',
+      icon: dependencyBlockerCount ? <Network size={16} /> : <CheckCircle2 size={16} />,
     },
     {
       title: 'Dead-Letter Monitor',

--- a/app/admin/agents/standup/page.tsx
+++ b/app/admin/agents/standup/page.tsx
@@ -1143,6 +1143,8 @@ function MetricsPanel({ organization }: { organization: AgentOrgBoardSnapshot })
       <div className="mt-3 grid grid-cols-2 gap-2">
         <Metric label="Active goals" value={organization.summary.active_goals} />
         <Metric label="Blocked" value={organization.summary.blocked_work_items} />
+        <Metric label="Waiting on" value={organization.summary.dependencies?.waiting_on ?? 0} />
+        <Metric label="Handoffs" value={organization.summary.dependencies?.pending_handoffs ?? 0} />
         <Metric label="Cycle time" value={organization.summary.average_cycle_hours == null ? 'n/a' : `${organization.summary.average_cycle_hours}h`} />
         <Metric label="Oldest WIP" value={organization.summary.oldest_in_flight_hours == null ? 'n/a' : `${organization.summary.oldest_in_flight_hours}h`} />
       </div>
@@ -1294,6 +1296,8 @@ function MiniKanban({ lanes, focusedGoalId }: { lanes: AgentOrgBoardLane[]; focu
 function MiniTask({ task }: { task: AgentOrgBoardTask }) {
   const ageHours = Math.max(0, Math.round((Date.now() - new Date(task.createdAt).getTime()) / 36e5))
   const dependencyIds = task.dependencyIds ?? []
+  const dependencies = task.dependencies ?? []
+  const pendingHandoffs = (task.handoffs ?? []).filter((handoff) => handoff.status === 'pending')
   const acceptanceCriteria = task.acceptanceCriteria ?? []
   return (
     <div className="rounded-md border border-silicon-slate/50 bg-silicon-slate/15 p-2 text-xs">
@@ -1305,6 +1309,7 @@ function MiniTask({ task }: { task: AgentOrgBoardTask }) {
         <span>{task.status.replace(/_/g, ' ')}</span>
         <span>{task.priority}</span>
         {dependencyIds.length ? <span>{dependencyIds.length} dep.</span> : null}
+        {pendingHandoffs.length ? <span>{pendingHandoffs.length} handoff</span> : null}
         {task.prUrl && <GitPullRequest size={12} />}
         {task.activeRunId && (
           <Link href={`/admin/agents/runs/${task.activeRunId}`} className="text-radiant-gold hover:underline">
@@ -1313,6 +1318,7 @@ function MiniTask({ task }: { task: AgentOrgBoardTask }) {
         )}
       </div>
       {task.objective && <p className="mt-1 line-clamp-1 text-muted-foreground">Action: {task.objective}</p>}
+      {dependencies.length ? <p className="mt-1 line-clamp-1 text-yellow-100">Waiting on: {dependencies[0].title}</p> : null}
       {task.blockerSummary && <p className="mt-1 line-clamp-1 text-red-200">Blocked: {task.blockerSummary}</p>}
       {task.validationSummary && <p className="mt-1 line-clamp-1 text-muted-foreground">Next: {task.validationSummary}</p>}
       {acceptanceCriteria.length ? <p className="mt-1 line-clamp-1 text-muted-foreground">Done when: {acceptanceCriteria[0]}</p> : null}

--- a/app/admin/agents/swarm-board/page.test.tsx
+++ b/app/admin/agents/swarm-board/page.test.tsx
@@ -45,6 +45,12 @@ const boardSnapshot = {
       average_cycle_hours: 4.5,
       oldest_in_flight_hours: 12,
       wip: [{ laneKey: 'operations', label: longLaneLabel, count: 5, limit: 4, overLimit: true }],
+      dependencies: {
+        waiting_on: 1,
+        blocking_downstream: 1,
+        pending_handoffs: 1,
+        blocked_by_dependency: 1,
+      },
       goals: [{
         id: 'goal-1',
         title: 'Launch Standup Room',
@@ -89,6 +95,32 @@ const boardSnapshot = {
             validationSummary: 'Focused route tests passed.',
             overlapGroup: 'agent-ops-redesign',
             parentWorkItemId: 'goal-parent',
+            expectedFiles: ['app/admin/agents/swarm-board/page.tsx'],
+            dependencyIds: ['work-2'],
+            dependencies: [{
+              id: 'work-2',
+              title: 'Prepare review packet without an attached PR',
+              status: 'ready_for_merge',
+              ownerAgentKey: 'automation-systems',
+              ownerAgentName: 'integration-captain',
+              href: '/admin/agents/swarm-board?work_item=work-2',
+              blocking: true,
+            }],
+            dependents: [],
+            handoffs: [{
+              id: 'handoff-1',
+              direction: 'incoming',
+              fromAgentKey: 'chief-of-staff',
+              fromAgentName: 'Shaka (Zulu) - Chief of Staff',
+              toAgentKey: 'automation-systems',
+              toAgentName: 'Amina - Automation Systems',
+              handoffType: 'agent_work_item_handoff',
+              summary: 'Confirm the dependency before merge.',
+              status: 'pending',
+              runId: 'handoff-run',
+              createdAt: '2026-05-13T11:00:00.000Z',
+            }],
+            acceptanceCriteria: ['Dependency is cleared before merge.'],
             createdAt: '2026-05-13T08:00:00.000Z',
             updatedAt: '2026-05-13T11:50:00.000Z',
             completedAt: null,
@@ -126,6 +158,20 @@ const boardSnapshot = {
             validationSummary: 'Focused validation passed.',
             overlapGroup: 'agent-ops-redesign',
             parentWorkItemId: 'goal-parent',
+            expectedFiles: [],
+            dependencyIds: [],
+            dependencies: [],
+            dependents: [{
+              id: 'work-1',
+              title: longTaskTitle,
+              status: 'blocked',
+              ownerAgentKey: 'automation-systems',
+              ownerAgentName: 'Amina - Automation Systems',
+              href: '/admin/agents/runs/run-1',
+              blocking: true,
+            }],
+            handoffs: [],
+            acceptanceCriteria: [],
             createdAt: '2026-05-13T09:00:00.000Z',
             updatedAt: '2026-05-13T12:00:00.000Z',
             completedAt: null,
@@ -163,6 +209,12 @@ const boardSnapshot = {
             validationSummary: null,
             overlapGroup: null,
             parentWorkItemId: null,
+            expectedFiles: [],
+            dependencyIds: [],
+            dependencies: [],
+            dependents: [],
+            handoffs: [],
+            acceptanceCriteria: [],
             createdAt: '2026-05-13T10:00:00.000Z',
             updatedAt: '2026-05-13T12:10:00.000Z',
             completedAt: null,
@@ -253,6 +305,8 @@ describe('AgentSwarmBoardPage', () => {
     expect(screen.getByRole('region', { name: 'Complete lane' })).toBeInTheDocument()
     expect(screen.getByText('Goal progress')).toBeInTheDocument()
     expect(screen.getByRole('region', { name: 'Kanban action queue' })).toBeInTheDocument()
+    expect(screen.getByRole('region', { name: 'Dependency tracing' })).toBeInTheDocument()
+    expect(screen.getByText('Blocked by dependency')).toBeInTheDocument()
     expect(screen.getAllByText('Launch Standup Room').length).toBeGreaterThan(0)
     expect(screen.getByText('1 lane(s) are above configured limit.')).toBeInTheDocument()
     expect(screen.getByText(`${longLaneLabel}: 5/4`)).toBeInTheDocument()
@@ -274,7 +328,9 @@ describe('AgentSwarmBoardPage', () => {
     expect(screen.getAllByText('Owner').length).toBeGreaterThan(0)
     expect(screen.getByText('Blocker:')).toBeInTheDocument()
     expect(screen.getAllByText('Validation:').length).toBeGreaterThan(0)
-    expect(screen.getAllByText('Resolve blocker').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Check dependencies').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Dependencies').length).toBeGreaterThan(0)
+    expect(screen.getByRole('button', { name: `Open dependency details for ${longTaskTitle}` })).toBeInTheDocument()
     expect(screen.getAllByText('Attach PR').length).toBeGreaterThan(0)
     expect(screen.getAllByText('Open trace').length).toBeGreaterThan(0)
     expect(screen.getAllByText('Integration Captain').length).toBeGreaterThan(0)
@@ -285,6 +341,24 @@ describe('AgentSwarmBoardPage', () => {
     expect(screen.getByLabelText('Pull request unavailable for Prepare review packet without an attached PR')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: `Open pull request 203 for ${longTaskTitle}` })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: `Open trace run-1 for ${longTaskTitle}` })).toHaveAttribute('href', '/admin/agents/runs/run-1')
+  })
+
+  it('opens dependency details and filters dependency-linked work', async () => {
+    render(<AgentSwarmBoardPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: `Open dependency details for ${longTaskTitle}` }))
+
+    expect(screen.getByRole('region', { name: 'Dependency detail drawer' })).toBeInTheDocument()
+    expect(screen.getAllByText('Waiting on').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Prepare review packet without an attached PR').length).toBeGreaterThan(0)
+    expect(screen.getByText('Agent handoffs')).toBeInTheDocument()
+    expect(screen.getAllByText(/Shaka \(Zulu\) - Chief of Staff to Amina - Automation Systems/i).length).toBeGreaterThan(0)
+    expect(screen.getByText(/Confirm the dependency before merge/i)).toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText('Dependencies'), { target: { value: 'waiting' } })
+
+    expect(screen.getAllByText(longTaskTitle).length).toBeGreaterThan(0)
+    expect(screen.queryByText('Maintain automation context outside the selected goal')).not.toBeInTheDocument()
   })
 
   it('surfaces the top Kanban actions before the lanes', async () => {
@@ -332,6 +406,16 @@ describe('AgentSwarmBoardPage', () => {
     expect(screen.getByText(/0\/2 complete/)).toBeInTheDocument()
     expect(screen.queryByText('Maintain automation context outside the selected goal')).not.toBeInTheDocument()
     expect(screen.getByLabelText('Goal')).toHaveValue('goal-1')
+  })
+
+  it('opens the dependency drawer from a work item query parameter', async () => {
+    window.history.pushState({}, '', '/admin/agents/swarm-board?work_item=work-1')
+
+    render(<AgentSwarmBoardPage />)
+
+    expect(await screen.findByRole('region', { name: 'Dependency detail drawer' })).toBeInTheDocument()
+    expect(screen.getAllByText('Prepare review packet without an attached PR').length).toBeGreaterThan(0)
+    expect(screen.getByText(/Confirm the dependency before merge/i)).toBeInTheDocument()
   })
 
   it('routes automation goals to Standup for n8n workflow proposal drafting', async () => {
@@ -407,13 +491,13 @@ describe('AgentSwarmBoardPage', () => {
     fireEvent.change(screen.getByLabelText('Status'), { target: { value: 'ready_for_merge' } })
 
     expect(screen.getAllByText('Prepare review packet without an attached PR').length).toBeGreaterThan(0)
-    expect(screen.queryByText(longTaskTitle)).not.toBeInTheDocument()
+    expect(document.querySelectorAll(`p[title="${longTaskTitle}"]`).length).toBe(0)
 
     fireEvent.change(screen.getByLabelText('Status'), { target: { value: 'all' } })
     fireEvent.change(screen.getByLabelText('Attention'), { target: { value: 'blocked' } })
 
     expect(screen.getAllByText(longTaskTitle).length).toBeGreaterThan(0)
-    expect(screen.queryByText('Prepare review packet without an attached PR')).not.toBeInTheDocument()
+    expect(document.querySelectorAll('p[title="Prepare review packet without an attached PR"]').length).toBe(0)
   })
 
   it('switches secondary modes as board views', async () => {

--- a/app/admin/agents/swarm-board/page.tsx
+++ b/app/admin/agents/swarm-board/page.tsx
@@ -12,6 +12,7 @@ import {
   GitPullRequest,
   LayoutDashboard,
   MessageSquare,
+  Network,
   RefreshCw,
   ShieldCheck,
   Sparkles,
@@ -40,6 +41,7 @@ type BoardSnapshot = AgentSwarmBoardSnapshot & {
 
 type BoardMode = 'kanban' | 'hive' | 'agents' | 'war-room' | 'client-builder'
 type AttentionFilter = 'all' | 'blocked' | 'review' | 'unassigned'
+type DependencyFilter = 'all' | 'waiting' | 'blocking' | 'handoffs'
 type BoardAction = {
   task: AgentOrgBoardTask
   lane: Pick<AgentOrgBoardLane, 'key' | 'label' | 'tasks'>
@@ -106,6 +108,13 @@ const ATTENTION_FILTERS: Array<{ key: AttentionFilter; label: string }> = [
   { key: 'unassigned', label: 'Unassigned' },
 ]
 
+const DEPENDENCY_FILTERS: Array<{ key: DependencyFilter; label: string }> = [
+  { key: 'all', label: 'All dependencies' },
+  { key: 'waiting', label: 'Waiting on upstream' },
+  { key: 'blocking', label: 'Blocking downstream' },
+  { key: 'handoffs', label: 'Handoffs pending' },
+]
+
 export default function AgentSwarmBoardPage() {
   return (
     <ProtectedRoute requireAdmin>
@@ -124,6 +133,7 @@ function AgentSwarmBoardContent() {
   const [ownerFilter, setOwnerFilter] = useState('all')
   const [statusFilter, setStatusFilter] = useState<'all' | AgentOrgBoardTask['status']>('all')
   const [attentionFilter, setAttentionFilter] = useState<AttentionFilter>('all')
+  const [dependencyFilter, setDependencyFilter] = useState<DependencyFilter>('all')
 
   const fetchBoard = useCallback(async () => {
     setLoading(true)
@@ -248,15 +258,18 @@ function AgentSwarmBoardContent() {
                   ownerFilter={ownerFilter}
                   statusFilter={statusFilter}
                   attentionFilter={attentionFilter}
+                  dependencyFilter={dependencyFilter}
                   onGoalChange={setSelectedGoalId}
                   onOwnerChange={setOwnerFilter}
                   onStatusChange={setStatusFilter}
                   onAttentionChange={setAttentionFilter}
+                  onDependencyChange={setDependencyFilter}
                   onClearFilters={() => {
                     setSelectedGoalId('all')
                     setOwnerFilter('all')
                     setStatusFilter('all')
                     setAttentionFilter('all')
+                    setDependencyFilter('all')
                   }}
                 />
               )}
@@ -285,10 +298,12 @@ function KanbanBoard({
   ownerFilter,
   statusFilter,
   attentionFilter,
+  dependencyFilter,
   onGoalChange,
   onOwnerChange,
   onStatusChange,
   onAttentionChange,
+  onDependencyChange,
   onClearFilters,
 }: {
   organization: AgentOrgBoardSnapshot
@@ -296,13 +311,23 @@ function KanbanBoard({
   ownerFilter: string
   statusFilter: 'all' | AgentOrgBoardTask['status']
   attentionFilter: AttentionFilter
+  dependencyFilter: DependencyFilter
   onGoalChange: (value: string) => void
   onOwnerChange: (value: string) => void
   onStatusChange: (value: 'all' | AgentOrgBoardTask['status']) => void
   onAttentionChange: (value: AttentionFilter) => void
+  onDependencyChange: (value: DependencyFilter) => void
   onClearFilters: () => void
 }) {
+  const [dependencyDrawerTaskId, setDependencyDrawerTaskId] = useState<string | null>(null)
   const allTasks = useMemo(() => organization.lanes.flatMap((lane) => lane.tasks), [organization.lanes])
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const workItemId = params.get('work_item')
+    if (workItemId && allTasks.some((task) => task.id === workItemId)) {
+      setDependencyDrawerTaskId(workItemId)
+    }
+  }, [allTasks])
   const ownerOptions = useMemo(() => {
     const options = new Map<string, string>()
     for (const task of allTasks) {
@@ -324,9 +349,12 @@ function KanbanBoard({
         if (attentionFilter === 'blocked' && task.status !== 'blocked') return false
         if (attentionFilter === 'review' && task.status !== 'ready_for_review' && task.status !== 'ready_for_merge') return false
         if (attentionFilter === 'unassigned' && task.ownerAgentKey) return false
+        if (dependencyFilter === 'waiting' && !((task.dependencyIds ?? []).length || (task.dependencies ?? []).length)) return false
+        if (dependencyFilter === 'blocking' && !(task.dependents ?? []).some((dependent) => dependent.blocking)) return false
+        if (dependencyFilter === 'handoffs' && !(task.handoffs ?? []).some((handoff) => handoff.status === 'pending')) return false
         return true
     })
-  }, [allTasks, attentionFilter, ownerFilter, selectedGoalId, statusFilter])
+  }, [allTasks, attentionFilter, dependencyFilter, ownerFilter, selectedGoalId, statusFilter])
   const statusLanes = useMemo(() => {
     return STATUS_SWIMLANES.map((lane) => ({
       ...lane,
@@ -337,13 +365,21 @@ function KanbanBoard({
   }, [visibleTasks])
   const filteredTasks = visibleTasks
   const boardActions = useMemo(() => buildBoardActions(statusLanes), [statusLanes])
+  const dependencyDrawerTask = allTasks.find((task) => task.id === dependencyDrawerTaskId) ?? null
   const selectedGoal = organization.summary.goals.find((goal) => goal.id === selectedGoalId) ?? null
-  const filtersActive = selectedGoalId !== 'all' || ownerFilter !== 'all' || statusFilter !== 'all' || attentionFilter !== 'all'
+  const filtersActive = selectedGoalId !== 'all' || ownerFilter !== 'all' || statusFilter !== 'all' || attentionFilter !== 'all' || dependencyFilter !== 'all'
 
   return (
     <div className="space-y-4" role="tabpanel" aria-label="Kanban lanes">
       <SummaryStrip organization={organization} />
       <BoardActionQueue actions={boardActions} filtersActive={filtersActive} totalCount={filteredTasks.length} />
+      <DependencyRadiators organization={organization} onOpenFirst={() => {
+        const firstDependencyTask = allTasks.find((task) => (task.dependencyIds ?? []).length || (task.dependents ?? []).length || (task.handoffs ?? []).length)
+        if (firstDependencyTask) setDependencyDrawerTaskId(firstDependencyTask.id)
+      }} />
+      {dependencyDrawerTask ? (
+        <DependencyDrawer task={dependencyDrawerTask} onClose={() => setDependencyDrawerTaskId(null)} />
+      ) : null}
       <GoalRadiators
         organization={organization}
         selectedGoalId={selectedGoalId}
@@ -356,12 +392,14 @@ function KanbanBoard({
         ownerFilter={ownerFilter}
         statusFilter={statusFilter}
         attentionFilter={attentionFilter}
+        dependencyFilter={dependencyFilter}
         filteredCount={filteredTasks.length}
         totalCount={allTasks.length}
         onGoalChange={onGoalChange}
         onOwnerChange={onOwnerChange}
         onStatusChange={onStatusChange}
         onAttentionChange={onAttentionChange}
+        onDependencyChange={onDependencyChange}
         onClearFilters={onClearFilters}
       />
       {selectedGoal ? <SelectedGoalPanel goal={selectedGoal} tasks={filteredTasks} /> : null}
@@ -381,7 +419,7 @@ function KanbanBoard({
       </section>
       <div className="grid items-start gap-3 xl:grid-cols-4">
         {statusLanes.map((lane) => (
-          <TaskLane key={lane.key} lane={lane} />
+          <TaskLane key={lane.key} lane={lane} onOpenDependencies={setDependencyDrawerTaskId} />
         ))}
       </div>
     </div>
@@ -466,6 +504,153 @@ function BoardActionQueue({
   )
 }
 
+function DependencyRadiators({
+  organization,
+  onOpenFirst,
+}: {
+  organization: AgentOrgBoardSnapshot
+  onOpenFirst: () => void
+}) {
+  const metrics = organization.summary.dependencies ?? {
+    waiting_on: 0,
+    blocking_downstream: 0,
+    pending_handoffs: 0,
+    blocked_by_dependency: 0,
+  }
+  const totalSignals = metrics.waiting_on + metrics.blocking_downstream + metrics.pending_handoffs
+  return (
+    <section className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/15 p-4" aria-label="Dependency tracing">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <div className="flex items-center gap-2">
+            <Network size={16} className="text-radiant-gold" />
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-radiant-gold">Dependency tracing</h2>
+          </div>
+          <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+            Shows work waiting on upstream cards, cards blocking downstream work, and open handoffs between agents.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onOpenFirst}
+          disabled={!totalSignals}
+          className="inline-flex items-center justify-center gap-2 rounded-lg border border-radiant-gold/50 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15 disabled:border-silicon-slate/60 disabled:text-muted-foreground disabled:opacity-60"
+        >
+          Inspect dependency
+        </button>
+      </div>
+      <div className="mt-3 grid gap-2 sm:grid-cols-4">
+        <MetricCard label="Waiting on" value={metrics.waiting_on} tone={metrics.waiting_on ? 'yellow' : 'slate'} />
+        <MetricCard label="Blocking" value={metrics.blocking_downstream} tone={metrics.blocking_downstream ? 'yellow' : 'slate'} />
+        <MetricCard label="Handoffs" value={metrics.pending_handoffs} tone={metrics.pending_handoffs ? 'yellow' : 'slate'} />
+        <MetricCard label="Blocked by dependency" value={metrics.blocked_by_dependency} tone={metrics.blocked_by_dependency ? 'red' : 'slate'} />
+      </div>
+    </section>
+  )
+}
+
+function DependencyDrawer({ task, onClose }: { task: AgentOrgBoardTask; onClose: () => void }) {
+  const dependencies = task.dependencies ?? []
+  const dependents = task.dependents ?? []
+  const handoffs = task.handoffs ?? []
+  const unresolvedIds = (task.dependencyIds ?? []).filter((id) => !dependencies.some((dependency) => dependency.id === id))
+  return (
+    <section className="rounded-lg border border-radiant-gold/45 bg-radiant-gold/10 p-4" aria-label="Dependency detail drawer">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-radiant-gold">Dependency detail</p>
+          <h2 className="mt-1 text-lg font-semibold">{task.title}</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {task.ownerAgentName} · {task.status.replace(/_/g, ' ')}
+          </p>
+        </div>
+        <button type="button" onClick={onClose} className="rounded-lg border border-silicon-slate/70 px-3 py-2 text-sm hover:border-radiant-gold/60">
+          Close
+        </button>
+      </div>
+      <div className="mt-4 grid gap-3 lg:grid-cols-3">
+        <DependencyColumn
+          title="Waiting on"
+          empty="No resolved upstream dependencies."
+          items={dependencies.map((dependency) => ({
+            id: dependency.id,
+            title: dependency.title,
+            detail: `${dependency.ownerAgentName} · ${dependency.status.replace(/_/g, ' ')}`,
+            href: dependency.href,
+            tone: dependency.blocking ? 'yellow' : 'slate',
+          }))}
+        />
+        <DependencyColumn
+          title="Blocking downstream"
+          empty="No downstream cards depend on this work."
+          items={dependents.map((dependent) => ({
+            id: dependent.id,
+            title: dependent.title,
+            detail: `${dependent.ownerAgentName} · ${dependent.status.replace(/_/g, ' ')}`,
+            href: dependent.href,
+            tone: dependent.blocking ? 'yellow' : 'slate',
+          }))}
+        />
+        <DependencyColumn
+          title="Agent handoffs"
+          empty="No handoffs recorded for this card."
+          items={handoffs.map((handoff) => ({
+            id: handoff.id,
+            title: `${handoff.fromAgentName} to ${handoff.toAgentName}`,
+            detail: `${handoff.status}${handoff.summary ? ` · ${handoff.summary}` : ''}`,
+            href: handoff.runId ? `/admin/agents/runs/${handoff.runId}` : null,
+            tone: handoff.status === 'pending' ? 'yellow' : 'slate',
+          }))}
+        />
+      </div>
+      {unresolvedIds.length ? (
+        <div className="mt-3 rounded-lg border border-silicon-slate/60 bg-background/55 p-3 text-xs text-muted-foreground">
+          <span className="font-semibold text-radiant-gold">Unresolved dependency IDs: </span>
+          {unresolvedIds.join(', ')}
+        </div>
+      ) : null}
+    </section>
+  )
+}
+
+function DependencyColumn({
+  title,
+  empty,
+  items,
+}: {
+  title: string
+  empty: string
+  items: Array<{ id: string; title: string; detail: string; href: string | null; tone: 'yellow' | 'slate' }>
+}) {
+  return (
+    <div className="rounded-lg border border-silicon-slate/60 bg-background/55 p-3">
+      <h3 className="text-xs font-semibold uppercase tracking-wide text-radiant-gold">{title}</h3>
+      <div className="mt-3 space-y-2">
+        {items.length ? items.map((item) => {
+          const className = `block rounded-lg border p-2 text-sm ${
+            item.tone === 'yellow'
+              ? 'border-yellow-500/35 bg-yellow-500/10 text-yellow-100'
+              : 'border-silicon-slate/60 bg-silicon-slate/10 text-foreground'
+          }`
+          const content = (
+            <>
+              <p className="font-semibold">{item.title}</p>
+              <p className="mt-1 text-xs text-muted-foreground">{item.detail}</p>
+            </>
+          )
+          return item.href ? (
+            <Link key={item.id} href={item.href} className={className}>
+              {content}
+            </Link>
+          ) : (
+            <div key={item.id} className={className}>{content}</div>
+          )
+        }) : <p className="text-sm text-muted-foreground">{empty}</p>}
+      </div>
+    </div>
+  )
+}
+
 function GoalRadiators({
   organization,
   selectedGoalId,
@@ -538,12 +723,14 @@ function KanbanFilterPanel({
   ownerFilter,
   statusFilter,
   attentionFilter,
+  dependencyFilter,
   filteredCount,
   totalCount,
   onGoalChange,
   onOwnerChange,
   onStatusChange,
   onAttentionChange,
+  onDependencyChange,
   onClearFilters,
 }: {
   goals: AgentOrgBoardSnapshot['summary']['goals']
@@ -552,12 +739,14 @@ function KanbanFilterPanel({
   ownerFilter: string
   statusFilter: 'all' | AgentOrgBoardTask['status']
   attentionFilter: AttentionFilter
+  dependencyFilter: DependencyFilter
   filteredCount: number
   totalCount: number
   onGoalChange: (value: string) => void
   onOwnerChange: (value: string) => void
   onStatusChange: (value: 'all' | AgentOrgBoardTask['status']) => void
   onAttentionChange: (value: AttentionFilter) => void
+  onDependencyChange: (value: DependencyFilter) => void
   onClearFilters: () => void
 }) {
   return (
@@ -567,7 +756,7 @@ function KanbanFilterPanel({
           <Filter size={16} className="text-radiant-gold" />
           <div>
             <h2 className="text-sm font-semibold uppercase tracking-wide text-radiant-gold">Board scope</h2>
-            <p className="text-sm text-muted-foreground">Filter by goal, owner, status, or attention state without leaving the Kanban surface.</p>
+            <p className="text-sm text-muted-foreground">Filter by goal, owner, status, attention state, or dependency relationship without leaving the Kanban surface.</p>
           </div>
         </div>
         <div className="flex items-center gap-3 text-xs text-muted-foreground">
@@ -577,7 +766,7 @@ function KanbanFilterPanel({
           </button>
         </div>
       </div>
-      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
         <label className="text-xs uppercase tracking-wide text-muted-foreground">
           Goal
           <select
@@ -625,6 +814,18 @@ function KanbanFilterPanel({
             className="mt-1 w-full rounded-lg border border-silicon-slate/70 bg-silicon-slate/30 px-3 py-2 text-sm normal-case tracking-normal text-foreground outline-none focus:border-radiant-gold/70"
           >
             {ATTENTION_FILTERS.map((filter) => (
+              <option key={filter.key} value={filter.key}>{filter.label}</option>
+            ))}
+          </select>
+        </label>
+        <label className="text-xs uppercase tracking-wide text-muted-foreground">
+          Dependencies
+          <select
+            value={dependencyFilter}
+            onChange={(event) => onDependencyChange(event.target.value as DependencyFilter)}
+            className="mt-1 w-full rounded-lg border border-silicon-slate/70 bg-silicon-slate/30 px-3 py-2 text-sm normal-case tracking-normal text-foreground outline-none focus:border-radiant-gold/70"
+          >
+            {DEPENDENCY_FILTERS.map((filter) => (
               <option key={filter.key} value={filter.key}>{filter.label}</option>
             ))}
           </select>
@@ -764,7 +965,7 @@ function SummaryStrip({ organization }: { organization: AgentOrgBoardSnapshot })
   )
 }
 
-function TaskLane({ lane }: { lane: StatusSwimlane }) {
+function TaskLane({ lane, onOpenDependencies }: { lane: StatusSwimlane; onOpenDependencies: (taskId: string) => void }) {
   const isEmpty = lane.tasks.length === 0
   const blocked = lane.tasks.filter((task) => task.status === 'blocked').length
   const review = lane.tasks.filter((task) => task.status === 'ready_for_review' || task.status === 'ready_for_merge').length
@@ -791,7 +992,7 @@ function TaskLane({ lane }: { lane: StatusSwimlane }) {
       </div>
       {!isEmpty ? (
         <div className="space-y-3 p-3">
-          {lane.tasks.map((task) => <WorkItemCard key={task.id} task={task} />)}
+          {lane.tasks.map((task) => <WorkItemCard key={task.id} task={task} onOpenDependencies={onOpenDependencies} />)}
         </div>
       ) : null}
     </section>
@@ -809,6 +1010,8 @@ function buildBoardActions(lanes: Array<Pick<AgentOrgBoardLane, 'key' | 'label' 
     .filter(({ task }) => {
       if (task.status === 'blocked' || task.status === 'ready_for_review' || task.status === 'ready_for_merge') return true
       if (!task.ownerAgentKey) return true
+      if ((task.dependencies ?? []).some((dependency) => dependency.blocking)) return true
+      if ((task.handoffs ?? []).some((handoff) => handoff.status === 'pending')) return true
       if (!task.validationSummary && (task.status === 'in_progress' || task.status === 'assigned')) return true
       return false
     })
@@ -820,15 +1023,20 @@ function actionRank(task: AgentOrgBoardTask) {
   if (task.status === 'blocked') return 0
   if (task.status === 'ready_for_merge') return 1
   if (task.status === 'ready_for_review') return 2
-  if (!task.ownerAgentKey) return 3
-  if (!task.validationSummary) return 4
-  return 5
+  if ((task.dependencies ?? []).some((dependency) => dependency.blocking)) return 3
+  if ((task.handoffs ?? []).some((handoff) => handoff.status === 'pending')) return 4
+  if (!task.ownerAgentKey) return 5
+  if (!task.validationSummary) return 6
+  return 7
 }
 
-function WorkItemCard({ task }: { task: AgentOrgBoardTask }) {
+function WorkItemCard({ task, onOpenDependencies }: { task: AgentOrgBoardTask; onOpenDependencies: (taskId: string) => void }) {
   const nextAction = nextActionForTask(task)
   const n8nProposal = task.goal?.n8nProposal ?? null
   const dependencyIds = task.dependencyIds ?? []
+  const resolvedDependencies = task.dependencies ?? []
+  const dependents = task.dependents ?? []
+  const pendingHandoffs = (task.handoffs ?? []).filter((handoff) => handoff.status === 'pending')
   const expectedFiles = task.expectedFiles ?? []
   const acceptanceCriteria = task.acceptanceCriteria ?? []
   return (
@@ -880,11 +1088,19 @@ function WorkItemCard({ task }: { task: AgentOrgBoardTask }) {
           </Link>
         </div>
       ) : null}
-      {dependencyIds.length ? (
-        <div className="mt-1.5 flex items-center gap-1.5 rounded-md border border-silicon-slate/60 bg-silicon-slate/15 px-1.5 py-1 text-[11px] text-muted-foreground">
+      {dependencyIds.length || dependents.length || pendingHandoffs.length ? (
+        <button
+          type="button"
+          onClick={() => onOpenDependencies(task.id)}
+          className="mt-1.5 flex w-full items-center gap-1.5 rounded-md border border-silicon-slate/60 bg-silicon-slate/15 px-1.5 py-1 text-left text-[11px] text-muted-foreground hover:border-radiant-gold/45 hover:text-foreground"
+          aria-label={`Open dependency details for ${task.title}`}
+        >
+          <Network size={12} className="shrink-0 text-radiant-gold" />
           <span className="font-semibold text-radiant-gold">Dependencies</span>
-          <span>{dependencyIds.length} upstream</span>
-        </div>
+          {dependencyIds.length ? <span>{dependencyIds.length} upstream</span> : null}
+          {dependents.length ? <span>{dependents.length} downstream</span> : null}
+          {pendingHandoffs.length ? <span>{pendingHandoffs.length} handoff</span> : null}
+        </button>
       ) : null}
 
       <div className="mt-1.5 flex items-center gap-1.5 text-[11px]">
@@ -934,7 +1150,9 @@ function WorkItemCard({ task }: { task: AgentOrgBoardTask }) {
             {task.ownerRuntime && <CardDetail label="Runtime" value={task.ownerRuntime} />}
             {task.branchName && <CardDetail label="Branch" value={task.branchName} />}
             {task.overlapGroup && <CardDetail label="Overlap" value={task.overlapGroup} />}
-            {dependencyIds.length ? <CardDetail label="Waiting on" value={dependencyIds.join(', ')} /> : null}
+            {dependencyIds.length ? <CardDetail label="Waiting on" value={resolvedDependencies.length ? resolvedDependencies.map((dependency) => dependency.title).join(', ') : dependencyIds.join(', ')} /> : null}
+            {dependents.length ? <CardDetail label="Blocking" value={dependents.map((dependent) => dependent.title).join(', ')} /> : null}
+            {pendingHandoffs.length ? <CardDetail label="Handoffs" value={pendingHandoffs.map((handoff) => `${handoff.fromAgentName} to ${handoff.toAgentName}`).join(', ')} /> : null}
             {expectedFiles.length ? <CardDetail label="Expected files" value={expectedFiles.slice(0, 4).join(', ')} /> : null}
           </dl>
           {acceptanceCriteria.length ? (
@@ -965,10 +1183,26 @@ function WorkItemCard({ task }: { task: AgentOrgBoardTask }) {
 
 function nextActionForTask(task: AgentOrgBoardTask) {
   const dependencyIds = task.dependencyIds ?? []
-  if (dependencyIds.length && !['merged', 'deployed', 'cancelled'].includes(task.status)) {
+  const blockingDependencies = (task.dependencies ?? []).filter((dependency) => dependency.blocking)
+  const pendingHandoffs = (task.handoffs ?? []).filter((handoff) => handoff.status === 'pending')
+  if (blockingDependencies.length && !['merged', 'deployed', 'cancelled'].includes(task.status)) {
     return {
       label: 'Check dependencies',
-      detail: `This card is linked to ${dependencyIds.length} upstream dependency${dependencyIds.length === 1 ? '' : 'ies'} before handoff.`,
+      detail: `Waiting on ${blockingDependencies.map((dependency) => dependency.title).slice(0, 2).join(', ')} before handoff.`,
+      tone: 'border-yellow-500/35 bg-yellow-500/10 text-yellow-100',
+    }
+  }
+  if (dependencyIds.length && !['merged', 'deployed', 'cancelled'].includes(task.status)) {
+    return {
+      label: 'Verify dependency',
+      detail: `This card references ${dependencyIds.length} upstream dependency${dependencyIds.length === 1 ? '' : 'ies'}; confirm the dependency link before handoff.`,
+      tone: 'border-yellow-500/35 bg-yellow-500/10 text-yellow-100',
+    }
+  }
+  if (pendingHandoffs.length) {
+    return {
+      label: 'Accept handoff',
+      detail: `${pendingHandoffs[0].fromAgentName} handed this to ${pendingHandoffs[0].toAgentName}. Confirm ownership and next step.`,
       tone: 'border-yellow-500/35 bg-yellow-500/10 text-yellow-100',
     }
   }

--- a/lib/agent-mission-control.ts
+++ b/lib/agent-mission-control.ts
@@ -44,6 +44,17 @@ type EventRow = {
   occurred_at: string
 }
 
+type MissionWorkItemRow = {
+  id: string
+  title: string
+  status: string
+  priority: string
+  owner_agent_key: string | null
+  dependency_ids: string[] | null
+  active_run_id: string | null
+  updated_at: string
+}
+
 export type AgentMissionControlSnapshot = Awaited<ReturnType<typeof buildAgentMissionControlSnapshot>>
 
 export type AgentInboxItem = {
@@ -142,6 +153,24 @@ export type AgentOperatingSignal = {
   updated_at: string
   href: string
   details: string[]
+}
+
+export type AgentDependencyBlocker = {
+  id: string
+  title: string
+  status: string
+  priority: string
+  owner_agent_key: string | null
+  owner_name: string
+  waiting_on: Array<{
+    id: string
+    title: string
+    status: string
+    owner_name: string
+    href: string
+  }>
+  href: string
+  updated_at: string
 }
 
 function sinceHours(hours: number) {
@@ -556,6 +585,48 @@ function inboxItemForApproval(approval: ApprovalRow, runsById: Map<string, Agent
   }
 }
 
+function buildDependencyBlockers(workItems: MissionWorkItemRow[]): AgentDependencyBlocker[] {
+  const rowsById = new Map(workItems.map((item) => [item.id, item]))
+  const ownerName = (agentKey: string | null) => agentKey ? findAgent(agentKey)?.name ?? agentKey : 'Unassigned'
+  return workItems
+    .filter((item) => Array.isArray(item.dependency_ids) && item.dependency_ids.length > 0 && !['merged', 'deployed', 'cancelled'].includes(item.status))
+    .map((item) => {
+      const waitingOn = (item.dependency_ids ?? [])
+        .map((id) => rowsById.get(id))
+        .filter((dependency): dependency is MissionWorkItemRow => Boolean(dependency))
+        .filter((dependency) => !['merged', 'deployed', 'cancelled'].includes(dependency.status))
+        .map((dependency) => ({
+          id: dependency.id,
+          title: dependency.title,
+          status: dependency.status,
+          owner_name: ownerName(dependency.owner_agent_key),
+          href: dependency.active_run_id
+            ? `/admin/agents/runs/${dependency.active_run_id}`
+            : `/admin/agents/swarm-board?work_item=${encodeURIComponent(dependency.id)}`,
+        }))
+
+      return {
+        id: item.id,
+        title: item.title,
+        status: item.status,
+        priority: item.priority,
+        owner_agent_key: item.owner_agent_key,
+        owner_name: ownerName(item.owner_agent_key),
+        waiting_on: waitingOn,
+        href: item.active_run_id
+          ? `/admin/agents/runs/${item.active_run_id}`
+          : `/admin/agents/swarm-board?work_item=${encodeURIComponent(item.id)}`,
+        updated_at: item.updated_at,
+      }
+    })
+    .filter((item) => item.waiting_on.length > 0)
+    .sort((a, b) => {
+      const rank: Record<string, number> = { urgent: 0, high: 1, medium: 2, low: 3 }
+      return (rank[a.priority] ?? 4) - (rank[b.priority] ?? 4) || new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
+    })
+    .slice(0, 5)
+}
+
 export function buildAgentInbox(input: {
   runs: AgentRunRow[]
   approvals: ApprovalRow[]
@@ -747,7 +818,7 @@ export async function buildAgentMissionControlSnapshot() {
   const db = assertDatabase()
   const since = sinceHours(24)
 
-  const [runsRes, costsRes, approvalsRes, eventsRes] = await Promise.all([
+  const [runsRes, costsRes, approvalsRes, eventsRes, workItemsRes] = await Promise.all([
     db
       .from('agent_runs')
       .select('id, agent_key, runtime, kind, title, status, subject_label, current_step, error_message, started_at, completed_at, outcome, metadata')
@@ -769,6 +840,11 @@ export async function buildAgentMissionControlSnapshot() {
       .select('run_id, event_type, severity, message, occurred_at')
       .order('occurred_at', { ascending: false })
       .limit(12),
+    db
+      .from('agent_work_items')
+      .select('id, title, status, priority, owner_agent_key, dependency_ids, active_run_id, updated_at')
+      .order('updated_at', { ascending: false })
+      .limit(100),
   ])
 
   for (const result of [runsRes, costsRes, approvalsRes, eventsRes]) {
@@ -777,10 +853,15 @@ export async function buildAgentMissionControlSnapshot() {
     }
   }
 
+  if (workItemsRes.error) {
+    console.warn('[agent-mission-control] dependency blocker projection unavailable:', workItemsRes.error.message)
+  }
+
   const runs = (runsRes.data ?? []) as AgentRunRow[]
   const costs = (costsRes.data ?? []) as CostEventRow[]
   const approvals = (approvalsRes.data ?? []) as ApprovalRow[]
   const events = (eventsRes.data ?? []) as EventRow[]
+  const workItems = workItemsRes.error ? [] : (workItemsRes.data ?? []) as MissionWorkItemRow[]
   const costByRun = new Map<string, number>()
   const runsById = new Map(runs.map((run) => [run.id, run]))
 
@@ -813,6 +894,7 @@ export async function buildAgentMissionControlSnapshot() {
   const engagementQueue = buildAgentEngagementQueue(runs)
   const deadLetterQueue = buildAgentDeadLetterQueue(runs)
   const operatingSignals = buildAgentOperatingSignals(runs)
+  const dependencyBlockers = buildDependencyBlockers(workItems)
   const costToday = Number(costs.reduce((sum, row) => sum + Number(row.amount ?? 0), 0).toFixed(4))
   const costSummary = buildAgentCostSummary({ costs, runsById, windowHours: 24 })
   const dailyBrief = buildDailyOperatingBrief({
@@ -873,6 +955,7 @@ export async function buildAgentMissionControlSnapshot() {
     cost_summary: costSummary,
     quality_summary: qualitySummary,
     operating_signals: operatingSignals,
+    dependency_blockers: dependencyBlockers,
     knowledge_governance: KNOWLEDGE_GOVERNANCE_STATUS,
     agent_inbox: agentInbox,
     engagement_queue: engagementQueue,

--- a/lib/agent-swarm-board.test.ts
+++ b/lib/agent-swarm-board.test.ts
@@ -752,6 +752,75 @@ describe('buildAgentOrgBoardSnapshotFromRows', () => {
     })
   })
 
+  it('resolves dependency and handoff relationships without a schema migration', () => {
+    const snapshot = buildAgentOrgBoardSnapshotFromRows({
+      now: new Date('2026-05-05T16:00:00.000Z'),
+      runs: [],
+      events: [],
+      workItems: [
+        orgWorkItem({
+          id: 'work-upstream',
+          title: 'Finish upstream validation',
+          status: 'in_progress',
+          priority: 'high',
+          owner_agent_key: 'engineering-copilot',
+        }),
+        orgWorkItem({
+          id: 'work-downstream',
+          title: 'Merge dependent board changes',
+          status: 'ready_for_merge',
+          priority: 'urgent',
+          owner_agent_key: 'integration-captain',
+          dependency_ids: ['work-upstream'],
+        }),
+      ],
+      handoffs: [
+        {
+          id: 'handoff-1',
+          run_id: 'run-handoff',
+          work_item_id: 'work-downstream',
+          from_agent_key: 'engineering-copilot',
+          to_agent_key: 'integration-captain',
+          handoff_type: 'agent_work_item_handoff',
+          summary: 'Review once validation lands.',
+          status: 'pending',
+          created_at: '2026-05-05T15:30:00.000Z',
+        },
+      ],
+      approvals: [],
+    })
+
+    const upstream = snapshot.lanes.flatMap((lane) => lane.tasks).find((task) => task.id === 'work-upstream')
+    const downstream = snapshot.lanes.flatMap((lane) => lane.tasks).find((task) => task.id === 'work-downstream')
+
+    expect(downstream?.dependencies[0]).toMatchObject({
+      id: 'work-upstream',
+      title: 'Finish upstream validation',
+      status: 'in_progress',
+      blocking: true,
+      ownerAgentName: 'Piye (Kush) - Engineering Copilot',
+    })
+    expect(upstream?.dependents[0]).toMatchObject({
+      id: 'work-downstream',
+      title: 'Merge dependent board changes',
+      status: 'ready_for_merge',
+      blocking: true,
+    })
+    expect(downstream?.handoffs[0]).toMatchObject({
+      id: 'handoff-1',
+      direction: 'incoming',
+      fromAgentName: 'Piye (Kush) - Engineering Copilot',
+      toAgentName: 'Integration Captain',
+      status: 'pending',
+    })
+    expect(snapshot.summary.dependencies).toEqual({
+      waiting_on: 1,
+      blocking_downstream: 1,
+      pending_handoffs: 1,
+      blocked_by_dependency: 1,
+    })
+  })
+
   it('flags WIP limit pressure and preserves priority ordering inside lanes', () => {
     const workItems = [
       orgWorkItem({ id: 'low-old', title: 'Low old', status: 'in_progress', priority: 'low', owner_agent_key: 'automation-systems', updated_at: '2026-05-05T11:00:00.000Z' }),

--- a/lib/agent-swarm-board.ts
+++ b/lib/agent-swarm-board.ts
@@ -114,6 +114,30 @@ export type AgentOrgBoardN8nProposalContext = {
   controllerHref: string
 }
 
+export type AgentOrgBoardDependencyLink = {
+  id: string
+  title: string
+  status: AgentOrgBoardTaskStatus
+  ownerAgentKey: string | null
+  ownerAgentName: string
+  href: string
+  blocking: boolean
+}
+
+export type AgentOrgBoardHandoffLink = {
+  id: string
+  direction: 'incoming' | 'outgoing'
+  fromAgentKey: string | null
+  fromAgentName: string
+  toAgentKey: string | null
+  toAgentName: string
+  handoffType: string | null
+  summary: string | null
+  status: string
+  runId: string | null
+  createdAt: string
+}
+
 export type AgentOrgBoardTask = {
   id: string
   title: string
@@ -134,6 +158,9 @@ export type AgentOrgBoardTask = {
   parentWorkItemId: string | null
   expectedFiles: string[]
   dependencyIds: string[]
+  dependencies: AgentOrgBoardDependencyLink[]
+  dependents: AgentOrgBoardDependencyLink[]
+  handoffs: AgentOrgBoardHandoffLink[]
   acceptanceCriteria: string[]
   createdAt: string
   updatedAt: string
@@ -194,6 +221,13 @@ export type AgentOrgBoardWipMetric = {
   count: number
   limit: number
   overLimit: boolean
+}
+
+export type AgentOrgBoardDependencyMetric = {
+  waiting_on: number
+  blocking_downstream: number
+  pending_handoffs: number
+  blocked_by_dependency: number
 }
 
 export type AgentOrgBoardLane = {
@@ -264,6 +298,7 @@ export type AgentOrgBoardSnapshot = {
     oldest_in_flight_hours: number | null
     wip: AgentOrgBoardWipMetric[]
     goals: AgentOrgBoardGoalMetric[]
+    dependencies: AgentOrgBoardDependencyMetric
   }
   agents: AgentOrgBoardAgent[]
   lanes: AgentOrgBoardLane[]
@@ -388,6 +423,18 @@ type AgentWorkItemRow = {
   updated_at: string
 }
 
+type AgentHandoffRow = {
+  id: string
+  run_id: string | null
+  work_item_id: string | null
+  from_agent_key: string | null
+  to_agent_key: string | null
+  handoff_type: string | null
+  summary: string | null
+  status: string
+  created_at: string
+}
+
 type ContactSubmissionRow = {
   id: number
   email: string | null
@@ -419,6 +466,7 @@ type AgentOrgBoardBuildInput = {
   runs: AgentRunRow[]
   events: AgentRunEventRow[]
   workItems: AgentWorkItemRow[]
+  handoffs?: AgentHandoffRow[]
   approvals: ApprovalRow[]
   now?: Date
 }
@@ -811,6 +859,7 @@ function podName(podKey: AgentPodKey) {
 
 function agentName(agentKey: string | null) {
   if (!agentKey) return 'Unassigned'
+  if (agentKey === 'integration-captain') return 'Integration Captain'
   return getAgentByKey(agentKey)?.name ?? agentKey
 }
 
@@ -1022,12 +1071,59 @@ export function buildAgentOrgBoardSnapshotFromRows(input: AgentOrgBoardBuildInpu
     parentWorkItemId: item.parent_work_item_id ?? null,
     expectedFiles: stringArrayValue(item.expected_files),
     dependencyIds: stringArrayValue(item.dependency_ids),
+    dependencies: [],
+    dependents: [],
+    handoffs: [],
     acceptanceCriteria: stringArrayValue(item.metadata?.acceptance_criteria),
     createdAt: item.created_at,
     updatedAt: item.updated_at,
     completedAt: item.completed_at ?? null,
     goal: goalForTask(item),
   }))
+  const tasksById = new Map(tasks.map((task) => [task.id, task]))
+  const dependencyLinkForTask = (task: AgentOrgBoardTask): AgentOrgBoardDependencyLink => ({
+    id: task.id,
+    title: task.title,
+    status: task.status,
+    ownerAgentKey: task.ownerAgentKey,
+    ownerAgentName: task.ownerAgentName,
+    href: task.activeRunId ? `/admin/agents/runs/${task.activeRunId}` : `/admin/agents/swarm-board?work_item=${encodeURIComponent(task.id)}`,
+    blocking: isActiveWorkStatus(task.status),
+  })
+
+  for (const task of tasks) {
+    task.dependencies = task.dependencyIds
+      .map((id) => tasksById.get(id))
+      .filter((dependency): dependency is AgentOrgBoardTask => Boolean(dependency))
+      .map(dependencyLinkForTask)
+  }
+
+  for (const task of tasks) {
+    for (const dependency of task.dependencies) {
+      const upstream = tasksById.get(dependency.id)
+      if (!upstream) continue
+      upstream.dependents.push(dependencyLinkForTask(task))
+    }
+  }
+
+  for (const handoff of input.handoffs ?? []) {
+    if (!handoff.work_item_id) continue
+    const task = tasksById.get(handoff.work_item_id)
+    if (!task) continue
+    task.handoffs.push({
+      id: handoff.id,
+      direction: handoff.to_agent_key === task.ownerAgentKey ? 'incoming' : 'outgoing',
+      fromAgentKey: handoff.from_agent_key,
+      fromAgentName: agentName(handoff.from_agent_key),
+      toAgentKey: handoff.to_agent_key,
+      toAgentName: agentName(handoff.to_agent_key),
+      handoffType: handoff.handoff_type,
+      summary: handoff.summary,
+      status: handoff.status,
+      runId: handoff.run_id,
+      createdAt: handoff.created_at,
+    })
+  }
 
   const laneSeeds: AgentOrgBoardLane[] = [
     {
@@ -1132,6 +1228,16 @@ export function buildAgentOrgBoardSnapshotFromRows(input: AgentOrgBoardBuildInpu
     }
   })
   const goals = buildGoalMetrics(tasks)
+  const dependencyMetrics: AgentOrgBoardDependencyMetric = {
+    waiting_on: activeTasks.filter((task) => {
+      const resolvedIds = new Set(task.dependencies.map((dependency) => dependency.id))
+      const unresolvedIds = task.dependencyIds.filter((id) => !resolvedIds.has(id))
+      return task.dependencies.some((dependency) => dependency.blocking) || unresolvedIds.length > 0
+    }).length,
+    blocking_downstream: activeTasks.filter((task) => task.dependents.some((dependent) => dependent.blocking)).length,
+    pending_handoffs: activeTasks.filter((task) => task.handoffs.some((handoff) => handoff.status === 'pending')).length,
+    blocked_by_dependency: activeTasks.filter((task) => task.dependencies.some((dependency) => dependency.blocking)).length,
+  }
 
   return {
     generated_at: now.toISOString(),
@@ -1151,6 +1257,7 @@ export function buildAgentOrgBoardSnapshotFromRows(input: AgentOrgBoardBuildInpu
       oldest_in_flight_hours: activeAges.length ? Math.max(...activeAges) : null,
       wip,
       goals,
+      dependencies: dependencyMetrics,
     },
     agents,
     lanes,
@@ -1299,10 +1406,25 @@ export async function buildAgentOrgBoardSnapshot(): Promise<AgentOrgBoardSnapsho
     if (result.error) throw new Error(result.error.message)
   }
 
+  const workItemIds = ((workItemsRes.data ?? []) as AgentWorkItemRow[]).map((item) => item.id)
+  const handoffsRes = workItemIds.length
+    ? await db
+        .from('agent_handoffs')
+        .select('id, run_id, work_item_id, from_agent_key, to_agent_key, handoff_type, summary, status, created_at')
+        .in('work_item_id', workItemIds)
+        .order('created_at', { ascending: false })
+        .limit(150)
+    : { data: [], error: null }
+
+  if (handoffsRes.error) {
+    console.warn('[agent-swarm-board] handoff projection unavailable:', handoffsRes.error.message)
+  }
+
   return buildAgentOrgBoardSnapshotFromRows({
     runs: (runsRes.data ?? []) as AgentRunRow[],
     events: (eventsRes.data ?? []) as AgentRunEventRow[],
     workItems: (workItemsRes.data ?? []) as AgentWorkItemRow[],
+    handoffs: handoffsRes.error ? [] : (handoffsRes.data ?? []) as AgentHandoffRow[],
     approvals: (approvalsRes.data ?? []) as ApprovalRow[],
   })
 }


### PR DESCRIPTION
## Summary
- Adds Phase 4B dependency tracing across Agent Ops using existing work item `dependency_ids` and `agent_handoffs` data, with no schema migration.
- Resolves upstream/downstream dependency links, pending handoffs, and dependency metrics in the swarm-board snapshot.
- Surfaces dependency blockers in Kanban, Standup Room, and Mission Control operating signals.
- Adds dependency filters, deep-linkable dependency drawer support, owner/trace context, and updated focused tests.

## Validation
- `npm test -- lib/agent-swarm-board.test.ts app/admin/agents/swarm-board/page.test.tsx app/admin/agents/standup/page.test.tsx app/admin/agents/page.test.tsx lib/agent-mission-control.test.ts app/api/admin/agents/swarm-board/route.test.ts app/api/admin/agents/mission-control/route.test.ts`
- `npm run build:knowledge && npx tsc --noEmit --pretty false`
- `npm run lint`
- `npm run build`
- `git diff --check`
- Pre-push database health check passed.

## Integration Notes
- Conflict preflight found open PR #317 (`automation/vercel-autoresearch-notify-guard`) touching subscription docs and `lib/vercel-deployment-research-approvals.ts`; no overlap with Agent Ops dependency tracing files.
- Worktree env bootstrap completed from `/Users/vambahsillah/Projects/Portfolio`; `.env.local` and `.vercel` linked, `.env.staging` was not present in the source checkout.
- Dependency blocking is visibility/advisory in this phase. It does not yet enforce merge, deployment, or approval gates.
- Handoff/dependency reads fail open if the table or query is unavailable, so existing Agent Ops pages should not hard-fail on environments missing handoff data.
- `npm run build` emitted the existing dev env warning about `MOCK_N8N=false` and `N8N_DISABLE_OUTBOUND=false`; no outbound workflow was executed by the build.
- Vercel contexts to verify after merge: `Vercel – portfolio` and `Vercel – portfolio-staging`.
