### PR TITLE
feat: extend admin console visual standard

### DIFF
--- a/app/admin/cost-revenue/page.tsx
+++ b/app/admin/cost-revenue/page.tsx
@@ -6,6 +6,7 @@ import { DollarSign, TrendingUp, TrendingDown, Percent } from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
 import AdminPieChart from '@/components/admin/AdminPieChart'
+import { getCurrentSession } from '@/lib/auth'
 
 type DatePreset = 'mtd' | 'qtd' | 'ytd'
 
@@ -87,7 +88,11 @@ function CostRevenuePageContent() {
     setError(null)
     const { from, to } = getDateRange(preset)
     try {
-      const res = await fetch(`/api/admin/cost-revenue/summary?from=${from}&to=${to}`)
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Missing admin session')
+      const res = await fetch(`/api/admin/cost-revenue/summary?from=${from}&to=${to}`, {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      })
       if (!res.ok) {
         const body = await res.json().catch(() => ({}))
         throw new Error(body.error || `HTTP ${res.status}`)
@@ -113,17 +118,20 @@ function CostRevenuePageContent() {
   }
 
   return (
-    <div className="min-h-screen bg-background text-foreground p-8">
+    <div className="admin-console-page min-h-screen p-6 text-foreground lg:p-8">
       <div className="max-w-7xl mx-auto">
         <Breadcrumbs items={[
           { label: 'Admin Dashboard', href: '/admin' },
           { label: 'Cost & Revenue' },
         ]} />
 
-        <div className="mb-6 flex items-center justify-between flex-wrap gap-4">
+        <header className="admin-console-surface-header mb-6 mt-5 flex flex-wrap items-start justify-between gap-4 rounded-xl border p-5">
           <div>
-            <h1 className="text-3xl font-bold mb-1">Cost & Revenue</h1>
-            <p className="text-muted-foreground text-sm">Portfolio cost and revenue summary by period.</p>
+            <div className="admin-console-eyebrow mb-2">Financial Operations</div>
+            <h1 className="text-3xl font-bold">Cost & Revenue</h1>
+            <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+              Portfolio cost and revenue summary by period, with spend signals separated from command actions.
+            </p>
           </div>
 
           <div className="flex gap-2">
@@ -133,15 +141,15 @@ function CostRevenuePageContent() {
                 onClick={() => setPreset(p)}
                 className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
                   preset === p
-                    ? 'bg-radiant-gold/20 text-radiant-gold border border-radiant-gold/50'
-                    : 'bg-silicon-slate/40 text-muted-foreground border border-silicon-slate/60 hover:border-silicon-slate/80'
+                    ? 'border border-radiant-gold/50 bg-radiant-gold/20 text-radiant-gold'
+                    : 'border border-silicon-slate/60 bg-background/45 text-muted-foreground hover:border-radiant-gold/45 hover:text-foreground'
                 }`}
               >
                 {presetLabels[p]}
               </button>
             ))}
           </div>
-        </div>
+        </header>
 
         {loading ? (
           <div className="flex items-center justify-center py-16 text-muted-foreground">
@@ -198,15 +206,15 @@ function CostRevenuePageContent() {
             <div className="mb-8">
               <h2 className="text-lg font-semibold mb-3 text-foreground/90">Revenue breakdown</h2>
               <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-                <div className="rounded-lg bg-silicon-slate/40 border border-silicon-slate/60 p-4">
+                <div className="admin-console-metric rounded-lg border p-4">
                   <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground mb-1">Orders</p>
                   <p className="text-xl font-bold tabular-nums text-radiant-gold">{formatCurrency(data.revenue.orders)}</p>
                 </div>
-                <div className="rounded-lg bg-silicon-slate/40 border border-silicon-slate/60 p-4">
+                <div className="admin-console-metric rounded-lg border p-4">
                   <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground mb-1">Proposals (no order)</p>
                   <p className="text-xl font-bold tabular-nums text-radiant-gold">{formatCurrency(data.revenue.proposals)}</p>
                 </div>
-                <div className="rounded-lg bg-silicon-slate/40 border border-silicon-slate/60 p-4">
+                <div className="admin-console-metric rounded-lg border p-4">
                   <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground mb-1">Subscriptions</p>
                   <p className="text-xl font-bold tabular-nums text-radiant-gold">{formatCurrency(data.revenue.subscriptions)}</p>
                 </div>
@@ -217,7 +225,7 @@ function CostRevenuePageContent() {
             <div>
               <h2 className="text-lg font-semibold mb-3 text-foreground/90">Cost by source</h2>
               <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                <div className="rounded-lg border border-silicon-slate/60 bg-silicon-slate/20 p-4">
+                <div className="admin-console-card rounded-lg border p-4">
                   <AdminPieChart
                     data={data.cost.bySource.map(({ source, amount }) => ({
                       name: source,
@@ -228,7 +236,7 @@ function CostRevenuePageContent() {
                     title="Cost by source"
                   />
                 </div>
-                <div className="rounded-lg border border-silicon-slate/60 bg-silicon-slate/20 p-4">
+                <div className="admin-console-card rounded-lg border p-4">
                   <p className="text-xs font-medium text-muted-foreground mb-3">Cost by source (list)</p>
                   <ul className="space-y-2">
                     {data.cost.bySource.length > 0 ? (
@@ -277,7 +285,7 @@ function SummaryCard({
     <motion.div
       initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
-      className="rounded-lg bg-silicon-slate/40 border border-silicon-slate/60 p-5"
+      className="admin-console-metric rounded-lg border p-5"
     >
       <div className="flex items-start justify-between gap-2">
         <div className={`${accentClasses[accent]} opacity-90`}>{icon}</div>

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -164,13 +164,16 @@ function AdminDashboardContent() {
   useEffect(() => { fetchAll() }, [fetchAll])
 
   return (
-    <div className="min-h-screen bg-background text-foreground p-6 lg:p-8">
+    <div className="admin-console-page min-h-screen p-6 text-foreground lg:p-8">
       <div className="max-w-6xl mx-auto">
         <Breadcrumbs items={[{ label: 'Admin Dashboard' }]} />
-        <div className="mb-6">
-          <h1 className="text-3xl font-bold mb-1">Admin Dashboard</h1>
-          <p className="text-muted-foreground text-sm">Snapshot by category — use the sidebar or links below for details.</p>
-        </div>
+        <header className="admin-console-surface-header mb-6 mt-5 rounded-xl border p-5">
+          <div className="admin-console-eyebrow mb-2">Portfolio Operations</div>
+          <h1 className="text-3xl font-bold">Admin Dashboard</h1>
+          <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+            Snapshot by category. Use each panel to inspect the operating signal, then move into the owning surface.
+          </p>
+        </header>
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
           {/* Pipeline: Lead Pipeline */}
@@ -573,7 +576,7 @@ function CategoryCard({
   children: React.ReactNode
 }) {
   return (
-    <div className="p-5 rounded-xl border border-silicon-slate bg-silicon-slate/30 flex flex-col">
+    <div className="admin-console-card admin-console-interactive flex flex-col rounded-xl border p-5">
       <div className="flex items-center gap-3 mb-3">
         <div className="w-10 h-10 rounded-lg bg-radiant-gold/20 flex items-center justify-center text-radiant-gold">
           {icon}

--- a/app/admin/subscriptions/page.tsx
+++ b/app/admin/subscriptions/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { AlertTriangle, CheckCircle2, CircleDollarSign, Clock3, FileText, ShieldCheck } from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
+import { getCurrentSession } from '@/lib/auth'
 
 type StatusKey = 'keep' | 'watch' | 'unresolved' | 'resolved_canceled'
 type StatusColor = 'green' | 'yellow' | 'red'
@@ -154,7 +155,11 @@ function AdminSubscriptionsPageContent() {
       setLoading(true)
       setError(null)
       try {
-        const res = await fetch('/api/admin/subscriptions/status')
+        const session = await getCurrentSession()
+        if (!session?.access_token) throw new Error('Missing admin session')
+        const res = await fetch('/api/admin/subscriptions/status', {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+        })
         if (!res.ok) {
           const body = await res.json().catch(() => ({}))
           throw new Error(body.error || `HTTP ${res.status}`)
@@ -184,7 +189,11 @@ function AdminSubscriptionsPageContent() {
     setQueryLoading(true)
     setError(null)
     try {
-      const res = await fetch(`/api/admin/subscriptions/status?q=${encodeURIComponent(query)}`)
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Missing admin session')
+      const res = await fetch(`/api/admin/subscriptions/status?q=${encodeURIComponent(query)}`, {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      })
       if (!res.ok) {
         const body = await res.json().catch(() => ({}))
         throw new Error(body.error || `HTTP ${res.status}`)
@@ -198,22 +207,25 @@ function AdminSubscriptionsPageContent() {
   }
 
   return (
-    <div className="min-h-screen bg-background text-foreground p-6 lg:p-8">
+    <div className="admin-console-page min-h-screen p-6 text-foreground lg:p-8">
       <div className="max-w-7xl mx-auto">
         <Breadcrumbs items={[
           { label: 'Admin Dashboard', href: '/admin' },
           { label: 'Subscription Watch' },
         ]} />
 
-        <div className="mb-6 flex flex-wrap items-start justify-between gap-4">
+        <header className="admin-console-surface-header mb-6 mt-5 flex flex-wrap items-start justify-between gap-4 rounded-xl border p-5">
           <div>
-            <h1 className="text-3xl font-bold mb-1">Subscription Watch</h1>
-            <p className="text-muted-foreground text-sm">Read-only view of paid tools, watch items, unresolved vendors, and cancellation gates.</p>
+            <div className="admin-console-eyebrow mb-2">Cost Governance</div>
+            <h1 className="text-3xl font-bold">Subscription Watch</h1>
+            <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+              Read-only view of paid tools, watch items, unresolved vendors, and cancellation gates.
+            </p>
           </div>
-          <div className="rounded-lg border border-silicon-slate bg-silicon-slate/30 px-4 py-3 text-sm text-muted-foreground">
+          <div className="admin-console-metric rounded-lg border px-4 py-3 text-sm text-muted-foreground">
             Approval phrase: <span className="text-foreground font-medium">Cancel &lt;tool/vendor&gt; for Portfolio</span>
           </div>
-        </div>
+        </header>
 
         {loading ? (
           <div className="flex items-center justify-center py-16 text-muted-foreground">Loading…</div>
@@ -224,7 +236,7 @@ function AdminSubscriptionsPageContent() {
           </div>
         ) : data ? (
           <>
-            <section className="mb-6 rounded-lg border border-silicon-slate bg-silicon-slate/30 p-5">
+            <section className="admin-console-card mb-6 rounded-lg border p-5">
               <div className="flex flex-wrap items-start justify-between gap-4">
                 <div>
                   <div className="flex items-center gap-2 mb-2">
@@ -240,7 +252,7 @@ function AdminSubscriptionsPageContent() {
             </section>
 
             {budget && (
-              <section className="mb-6 rounded-lg border border-silicon-slate bg-silicon-slate/30 p-5">
+              <section className="admin-console-card mb-6 rounded-lg border p-5">
                 <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
                   <div>
                     <div className="flex items-center gap-2 mb-2">
@@ -271,7 +283,7 @@ function AdminSubscriptionsPageContent() {
                     value={query}
                     onChange={(event) => setQuery(event.target.value)}
                     placeholder="Ask a budget question"
-                    className="min-w-0 flex-1 rounded-lg border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm"
+                    className="min-w-0 flex-1 rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground"
                   />
                   <button
                     type="button"
@@ -348,7 +360,7 @@ function AdminSubscriptionsPageContent() {
             </section>
 
             {decisionItems.length > 0 && (
-              <section className="mb-6 rounded-lg border border-amber-500/40 bg-amber-500/10 p-5">
+              <section className="admin-console-card mb-6 rounded-lg border border-amber-500/40 p-5">
                 <h2 className="text-lg font-semibold text-amber-200 mb-3">Needs attention</h2>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                   {decisionItems.map((vendor) => (
@@ -367,8 +379,8 @@ function AdminSubscriptionsPageContent() {
             <section className="mb-6">
               <h2 className="text-lg font-semibold mb-3">Vendor status</h2>
               {budget && (
-                <div className="mb-3 overflow-hidden rounded-lg border border-silicon-slate">
-                  <div className="hidden lg:grid grid-cols-[180px_120px_1fr_1fr] gap-4 bg-silicon-slate/60 px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                <div className="mb-3 overflow-hidden rounded-lg border border-radiant-gold/15 bg-background/30">
+                  <div className="hidden lg:grid grid-cols-[180px_120px_1fr_1fr] gap-4 bg-background/55 px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                     <span>Vendor</span>
                     <span>Monthly</span>
                     <span>Evidence</span>
@@ -386,8 +398,8 @@ function AdminSubscriptionsPageContent() {
                   </div>
                 </div>
               )}
-              <div className="overflow-hidden rounded-lg border border-silicon-slate">
-                <div className="hidden lg:grid grid-cols-[160px_130px_1fr_1fr_1fr] gap-4 bg-silicon-slate/60 px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              <div className="overflow-hidden rounded-lg border border-radiant-gold/15 bg-background/30">
+                <div className="hidden lg:grid grid-cols-[160px_130px_1fr_1fr_1fr] gap-4 bg-background/55 px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                   <span>Vendor</span>
                   <span>Status</span>
                   <span>Billing signal</span>
@@ -422,7 +434,7 @@ function AdminSubscriptionsPageContent() {
             </section>
 
             <section className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-              <div className="rounded-lg border border-silicon-slate bg-silicon-slate/30 p-5">
+              <div className="admin-console-card rounded-lg border p-5">
                 <h2 className="text-lg font-semibold mb-3">Next review focus</h2>
                 <ul className="space-y-2 text-sm text-muted-foreground">
                   {data.summary.nextReviewFocus.map((item) => (
@@ -430,7 +442,7 @@ function AdminSubscriptionsPageContent() {
                   ))}
                 </ul>
               </div>
-              <div className="rounded-lg border border-silicon-slate bg-silicon-slate/30 p-5">
+              <div className="admin-console-card rounded-lg border p-5">
                 <h2 className="text-lg font-semibold mb-3">Automation</h2>
                 <dl className="space-y-2 text-sm">
                   <KeyValue label="Daily monitor" value={data.dailyMonitorAutomationId} />
@@ -449,7 +461,7 @@ function AdminSubscriptionsPageContent() {
 
 function BucketStat({ icon, label, count }: { icon: React.ReactNode; label: string; count: number }) {
   return (
-    <div className="rounded-lg border border-silicon-slate bg-silicon-slate/30 p-4">
+    <div className="admin-console-metric rounded-lg border p-4">
       <div className="flex items-center gap-2 text-muted-foreground mb-2">
         {icon}
         <span className="text-xs font-semibold uppercase tracking-wide">{label}</span>
@@ -478,7 +490,7 @@ function SignalBlock({ label, value }: { label: string; value: string }) {
 
 function Signal({ label, value }: { label: string; value: string }) {
   return (
-    <div className="rounded-lg border border-silicon-slate/60 bg-background/35 p-4">
+    <div className="admin-console-metric rounded-lg border p-4">
       <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
       <p className="mt-2 text-sm font-medium">{value}</p>
     </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -534,6 +534,137 @@ html.dark .card-brand {
 }
 
 /* ========================================
+   Shared Admin Console Standard
+   ======================================== */
+
+.admin-console-page {
+  position: relative;
+  background:
+    radial-gradient(circle at 18% 0%, rgba(212, 175, 55, 0.04), transparent 28rem),
+    linear-gradient(180deg, #121e31 0%, #0f1a2b 100%);
+}
+
+.admin-console-panel,
+.admin-console-surface-header,
+.admin-console-card,
+.admin-console-metric,
+.admin-console-command-card {
+  position: relative;
+  overflow: hidden;
+}
+
+.admin-console-panel > *,
+.admin-console-surface-header > *,
+.admin-console-card > *,
+.admin-console-metric > *,
+.admin-console-command-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.admin-console-panel,
+.admin-console-surface-header,
+.admin-console-card,
+.admin-console-metric {
+  border-color: rgba(212, 175, 55, 0.16);
+  background: rgba(18, 30, 49, 0.72);
+  box-shadow:
+    inset 0 1px 0 rgba(234, 236, 238, 0.045),
+    0 12px 28px rgba(0, 0, 0, 0.16);
+}
+
+.admin-console-panel::before,
+.admin-console-surface-header::before,
+.admin-console-card::before,
+.admin-console-command-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(circle at 18% 0%, rgba(212, 175, 55, 0.045), transparent 13rem),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.026), transparent 46%);
+  opacity: 0.5;
+}
+
+.admin-console-surface-header {
+  border-color: rgba(212, 175, 55, 0.24);
+  background:
+    radial-gradient(circle at 12% 0%, rgba(212, 175, 55, 0.06), transparent 18rem),
+    rgba(18, 30, 49, 0.78);
+  box-shadow:
+    0 18px 46px rgba(0, 0, 0, 0.22),
+    inset 0 1px 0 rgba(234, 236, 238, 0.065);
+}
+
+.admin-console-interactive:hover,
+a.admin-console-card:hover,
+button.admin-console-card:hover,
+a.admin-console-metric:hover,
+button.admin-console-metric:hover {
+  border-color: rgba(245, 208, 96, 0.5);
+  box-shadow:
+    0 0 0 1px rgba(212, 175, 55, 0.08),
+    0 0 30px rgba(212, 175, 55, 0.09),
+    0 16px 42px rgba(0, 0, 0, 0.22);
+}
+
+.admin-console-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--radiant-gold);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.admin-console-button-primary,
+.admin-console-button-secondary,
+.admin-console-button-muted {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  transition: border-color 160ms ease, background 160ms ease, color 160ms ease, opacity 160ms ease;
+}
+
+.admin-console-button-primary {
+  border: 1px solid rgba(212, 175, 55, 0.62);
+  background: var(--radiant-gold);
+  color: #121e31;
+  font-weight: 700;
+}
+
+.admin-console-button-primary:hover {
+  background: rgba(245, 208, 96, 0.94);
+}
+
+.admin-console-button-secondary {
+  border: 1px solid rgba(212, 175, 55, 0.5);
+  background: rgba(212, 175, 55, 0.1);
+  color: var(--radiant-gold);
+}
+
+.admin-console-button-secondary:hover {
+  background: rgba(212, 175, 55, 0.15);
+}
+
+.admin-console-button-muted {
+  border: 1px solid rgba(100, 116, 139, 0.7);
+  background: rgba(18, 30, 49, 0.52);
+  color: var(--foreground);
+}
+
+.admin-console-button-muted:hover {
+  border-color: rgba(245, 208, 96, 0.6);
+}
+
+/* ========================================
    Circuit Mesh Animation Classes
    ======================================== */
 

--- a/docs/design/amadutown-color-palette-audit.md
+++ b/docs/design/amadutown-color-palette-audit.md
@@ -22,10 +22,16 @@ The Agent Ops Mission Control surface at `/admin/agents` is the current referenc
 
 ### Implementation guidance
 
-- Reuse or extract shared styling from the Agent Ops visual layer (`agent-ops-page`, `agent-ops-panel`, `agent-ops-card`, and related token usage) instead of recreating one-off page-specific CSS.
+- Reuse the shared admin console layer (`admin-console-page`, `admin-console-surface-header`, `admin-console-card`, `admin-console-metric`, and `admin-console-button-*`) for admin/dashboard/control-plane pages. The older Agent Ops classes remain valid for Agent Ops-specific surfaces, but new cross-admin styling should use the `admin-console-*` primitives.
 - New admin pages should match Mission Control's density, command hierarchy, palette discipline, and action/status separation unless there is an explicit product reason to diverge.
 - Public, commerce, and client-facing pages may adapt the structure for their audience, but should remain recognizably AmaduTown: navy/gold first, polished operational clarity, and no unrelated gray, purple, cyan, or generic SaaS palette drift.
 - When a page is redesigned, check this audit table for known off-palette areas and update the table if the implementation resolves or changes the design debt.
+
+### Current extraction status
+
+- **Shared admin primitives:** `app/globals.css` now includes `admin-console-*` primitives extracted from the Mission Control visual language for non-Agent-Ops admin surfaces.
+- **First applied slice:** `/admin`, `/admin/cost-revenue`, and `/admin/subscriptions` use the shared page/header/card/metric treatment as the first bounded Phase 6 rollout.
+- **Next rollout candidates:** high-traffic admin content and outreach pages still carry older gray, blue, purple, and cyan styling and should move to the same primitives in smaller follow-up PRs.
 
 ---
 
@@ -44,7 +50,7 @@ The Agent Ops Mission Control surface at `/admin/agents` is the current referenc
 | Lead magnets (public) | Gray text | `app/lead-magnets/page.tsx` (text-gray-400) | Low |
 | Purchases | Blue–purple gradients, green semantic | `app/purchases/page.tsx` (from-blue-600 to-purple-600, green-* semantic) | Medium |
 | Proposal | Green/orange/indigo type badges, green CTAs | `app/proposal/[id]/page.tsx` (green-*, orange-*, indigo-*) | Medium |
-| Admin dashboard | Slate–indigo, sky–blue, violet–purple, cyan–blue, purple–pink gradients | `app/admin/page.tsx` (from-slate-*, from-sky-*, from-violet-*, from-cyan-*, from-purple-*) | High |
+| Admin dashboard | Partially remediated: shared `admin-console-*` page/header/card treatment applied; nested chart and feed details may still need follow-up polish | `app/admin/page.tsx` | Medium |
 | Admin content – products | Gray UI, blue–purple gradients, purple/blue/cyan badges, purple focus | `app/admin/content/products/page.tsx`, `[id]/page.tsx` (gray-*, from-blue-600 to-purple-600, purple-*, blue-*, cyan-*, focus:border-purple-500) | High |
 | Admin content – discount codes | Gray inputs, purple focus, blue–purple gradient CTAs, purple/green badges | `app/admin/content/discount-codes/page.tsx` | High |
 | Admin content – merchandise | Gray inputs, purple focus/gradients, purple–blue card gradient | `app/admin/content/merchandise/page.tsx` | High |


### PR DESCRIPTION
## Summary
- Adds shared `admin-console-*` visual primitives in `app/globals.css` based on the accepted Mission Control operating-console aesthetic.
- Applies the first standardization slice to `/admin`, `/admin/cost-revenue`, and `/admin/subscriptions`.
- Fixes missing admin bearer headers on cost/revenue and subscription status fetches discovered during local visual QA.
- Updates the AmaduTown design audit with the new shared primitives and rollout status.

## Validation
- `git diff --check`
- `npm run lint -- --file app/admin/page.tsx --file app/admin/cost-revenue/page.tsx --file app/admin/subscriptions/page.tsx`
- `npm run build:knowledge`
- `npx tsc --noEmit --pretty false`
- `npm run build`
- Local Playwright visual QA on `http://localhost:3012/admin`, `/admin/cost-revenue`, and `/admin/subscriptions` at desktop and mobile widths. Screenshot evidence is local-only under `.tmp/phase6-visual-qa/` and is not committed.

## Integration Notes
- Conflict preflight passed: the only open PR found was #317, which touches unrelated Vercel approval notification/subscription docs files.
- Worktree env bootstrap linked `.env.local` and `.vercel`; `.env.staging` was not present in the source checkout.
- Local build emitted the existing n8n outbound-env warning, but no outbound workflow or production mutation was executed.
- The shared hover affordance is restricted to explicit interactive variants/links/buttons so read-only metrics do not look clickable.
- Vercel contexts to verify after merge: `Vercel – portfolio` and `Vercel – portfolio-staging`.
