### PR TITLE
feat: extend admin console workflow surfaces

### DIFF
--- a/app/admin/email-center/page.tsx
+++ b/app/admin/email-center/page.tsx
@@ -186,7 +186,7 @@ function EmailCenterContent() {
   }, [load])
 
   return (
-    <div className="min-h-screen bg-background text-foreground p-8">
+    <div className="admin-console-page min-h-screen p-6 text-foreground lg:p-8">
       <div className="max-w-7xl mx-auto space-y-6">
         <Breadcrumbs
           items={[
@@ -195,13 +195,14 @@ function EmailCenterContent() {
           ]}
         />
 
-        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+        <div className="admin-console-surface-header flex flex-col gap-4 rounded-xl border p-5 md:flex-row md:items-center md:justify-between">
           <div className="flex items-center gap-4">
-            <div className="w-12 h-12 rounded-lg bg-gradient-to-r from-amber-600 to-orange-600 flex items-center justify-center">
-              <Inbox size={24} className="text-white" />
+            <div className="flex h-12 w-12 items-center justify-center rounded-lg border border-radiant-gold/40 bg-radiant-gold/15 text-radiant-gold">
+              <Inbox size={24} />
             </div>
             <div>
-              <h1 className="text-3xl font-bold gradient-text">Email Center</h1>
+              <div className="admin-console-eyebrow mb-2">Pipeline Messaging</div>
+              <h1 className="text-3xl font-bold text-foreground">Email Center</h1>
               <p className="text-muted-foreground text-sm mt-0.5">
                 One place to see what was sent, how it went out, and where the source row lives.
               </p>
@@ -217,7 +218,7 @@ function EmailCenterContent() {
             <button
               type="button"
               onClick={() => void load()}
-              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-silicon-slate hover:bg-silicon-slate/50 text-sm"
+              className="admin-console-button-muted"
             >
               <RefreshCw size={16} className={loading ? 'animate-spin' : ''} />
               Refresh
@@ -225,7 +226,7 @@ function EmailCenterContent() {
           </div>
         </div>
 
-        <div className="space-y-3">
+        <div className="admin-console-card space-y-3 rounded-lg border p-4">
           {contactFromUrl && !Number.isNaN(Number(contactFromUrl)) && (
             <div className="flex items-center gap-2 flex-wrap">
               <span className="text-xs text-muted-foreground">Lead filter (from your link):</span>
@@ -337,7 +338,7 @@ function EmailCenterContent() {
           Showing {items.length} of {total} rows (most recent first).
         </div>
 
-        <div className="overflow-x-auto rounded-xl border border-silicon-slate bg-silicon-slate/20">
+        <div className="admin-console-card overflow-x-auto rounded-xl border">
           <table className="min-w-full text-sm">
             <thead>
               <tr className="text-left text-xs uppercase tracking-wide text-muted-foreground border-b border-silicon-slate">

--- a/app/admin/social-content/page.tsx
+++ b/app/admin/social-content/page.tsx
@@ -264,26 +264,27 @@ function SocialContentQueuePage() {
   }
 
   return (
-    <div className="min-h-screen bg-background text-foreground p-8">
+    <div className="admin-console-page min-h-screen p-6 text-foreground lg:p-8">
       <Breadcrumbs items={[{ label: 'Admin', href: '/admin' }, { label: 'Social Content' }]} />
 
       {/* Header */}
-      <div className="flex items-center gap-4 mb-8">
-        <div className="w-12 h-12 rounded-lg bg-gradient-to-r from-amber-600 to-orange-600 flex items-center justify-center">
-          <Share2 className="w-6 h-6 text-white" />
+      <div className="admin-console-surface-header mb-6 mt-5 flex items-center gap-4 rounded-xl border p-5">
+        <div className="flex h-12 w-12 items-center justify-center rounded-lg border border-radiant-gold/40 bg-radiant-gold/15 text-radiant-gold">
+          <Share2 className="h-6 w-6" />
         </div>
         <div className="flex-1">
-          <h1 className="text-2xl font-bold">Social Content Queue</h1>
-          <p className="text-gray-400 text-sm">AI-generated posts from meeting transcripts — review, edit, and publish</p>
+          <div className="admin-console-eyebrow mb-2">Content Operations</div>
+          <h1 className="text-2xl font-bold text-foreground">Social Content Queue</h1>
+          <p className="text-muted-foreground text-sm">AI-generated posts from meeting transcripts, ready for review, edit, and publish.</p>
         </div>
       </div>
 
       {/* Extraction Trigger */}
-      <div className="mb-6">
+      <div className="admin-console-card mb-6 rounded-lg border p-4">
         <div className="flex items-center gap-3">
           <button
             onClick={() => setShowTriggerPanel((p) => !p)}
-            className="inline-flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-amber-600 to-orange-600 text-white rounded-lg text-sm font-medium hover:from-amber-500 hover:to-orange-500 transition-all"
+            className="admin-console-button-primary"
           >
             <Zap className="w-4 h-4" />
             Run Extraction
@@ -309,7 +310,7 @@ function SocialContentQueuePage() {
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
             exit={{ opacity: 0, height: 0 }}
-            className="mt-3 bg-gray-900 border border-gray-800 rounded-xl p-5 space-y-4"
+            className="mt-3 rounded-lg border border-silicon-slate bg-imperial-navy/55 p-5 space-y-4"
           >
             <div className="flex items-center gap-2">
               <h3 className="text-sm font-semibold text-gray-200">Trigger Content Extraction (WF-SOC-001)</h3>
@@ -332,24 +333,24 @@ function SocialContentQueuePage() {
                     value={meetingSearch}
                     onChange={(e) => setMeetingSearch(e.target.value)}
                     placeholder="Type, transcript, topic..."
-                    className="w-full bg-gray-800 text-gray-300 border border-gray-700 rounded-lg pl-8 pr-3 py-2 text-sm focus:outline-none focus:border-amber-600 transition-colors"
+                    className="w-full rounded-lg border border-silicon-slate bg-imperial-navy/70 py-2 pl-8 pr-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:border-radiant-gold/60 transition-colors"
                   />
                 </div>
               </div>
-              <div className="flex items-center gap-2">
+              <div className="flex flex-wrap items-center gap-2">
                 <Calendar className="w-3.5 h-3.5 text-gray-500 shrink-0" />
                 <input
                   type="date"
                   value={meetingDateFrom}
                   onChange={(e) => setMeetingDateFrom(e.target.value)}
-                  className="bg-gray-800 text-gray-300 border border-gray-700 rounded-lg px-2 py-2 text-sm w-32 focus:outline-none focus:border-amber-600"
+                  className="w-full rounded-lg border border-silicon-slate bg-imperial-navy/70 px-2 py-2 text-sm text-foreground focus:outline-none focus:border-radiant-gold/60 sm:w-32"
                 />
                 <span className="text-xs text-gray-500">to</span>
                 <input
                   type="date"
                   value={meetingDateTo}
                   onChange={(e) => setMeetingDateTo(e.target.value)}
-                  className="bg-gray-800 text-gray-300 border border-gray-700 rounded-lg px-2 py-2 text-sm w-32 focus:outline-none focus:border-amber-600"
+                  className="w-full rounded-lg border border-silicon-slate bg-imperial-navy/70 px-2 py-2 text-sm text-foreground focus:outline-none focus:border-radiant-gold/60 sm:w-32"
                 />
                 {(meetingDateFrom || meetingDateTo) && (
                   <button onClick={() => { setMeetingDateFrom(''); setMeetingDateTo('') }} className="text-xs text-gray-400 hover:text-white">Clear</button>
@@ -515,7 +516,7 @@ function SocialContentQueuePage() {
                 <button
                   onClick={() => handleTriggerExtraction()}
                   disabled={triggerLoading}
-                  className="inline-flex items-center gap-2 px-5 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  className="admin-console-button-primary disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {triggerLoading ? (
                     <Loader2 className="w-4 h-4 animate-spin" />
@@ -570,7 +571,7 @@ function SocialContentQueuePage() {
           { label: 'Published', value: stats.published, color: 'text-green-400' },
           { label: 'Rejected', value: stats.rejected, color: 'text-red-400' },
         ].map((stat) => (
-          <div key={stat.label} className="bg-gray-900 border border-gray-800 rounded-xl p-3 text-center">
+          <div key={stat.label} className="admin-console-metric rounded-xl border p-3 text-center">
             <div className={`text-xl font-bold ${stat.color}`}>{stat.value}</div>
             <div className="text-xs text-gray-500">{stat.label}</div>
           </div>
@@ -578,12 +579,12 @@ function SocialContentQueuePage() {
       </div>
 
       {/* Filters */}
-      <div className="flex flex-wrap items-center gap-3 mb-6">
+      <div className="admin-console-card mb-6 flex flex-wrap items-center gap-3 rounded-lg border p-4">
         <Filter className="w-4 h-4 text-gray-500" />
         <select
           value={statusFilter}
           onChange={(e) => setStatusFilter(e.target.value as ContentStatus | 'all')}
-          className="bg-gray-800 text-gray-300 border border-gray-700 rounded-lg px-3 py-1.5 text-sm"
+          className="rounded-lg border border-silicon-slate bg-imperial-navy/70 px-3 py-1.5 text-sm text-foreground"
         >
           <option value="all">All Statuses</option>
           {CONTENT_STATUSES.map((s) => (
@@ -593,7 +594,7 @@ function SocialContentQueuePage() {
         <select
           value={platformFilter}
           onChange={(e) => setPlatformFilter(e.target.value as SocialPlatform | 'all')}
-          className="bg-gray-800 text-gray-300 border border-gray-700 rounded-lg px-3 py-1.5 text-sm"
+          className="rounded-lg border border-silicon-slate bg-imperial-navy/70 px-3 py-1.5 text-sm text-foreground"
         >
           <option value="all">All Platforms</option>
           {PLATFORMS.map((p) => (
@@ -605,7 +606,7 @@ function SocialContentQueuePage() {
           placeholder="Search posts..."
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          className="bg-gray-800 text-gray-300 border border-gray-700 rounded-lg px-3 py-1.5 text-sm flex-1 min-w-[200px]"
+          className="min-w-[200px] flex-1 rounded-lg border border-silicon-slate bg-imperial-navy/70 px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground"
         />
       </div>
 
@@ -633,11 +634,11 @@ function SocialContentQueuePage() {
               >
                 <Link
                   href={buildLinkWithReturn(`/admin/social-content/${item.id}`, '/admin/social-content')}
-                  className="block bg-gray-900 border border-gray-800 rounded-xl p-4 hover:border-gray-700 transition-colors"
+                  className="admin-console-card admin-console-interactive block rounded-xl border p-4 transition-colors"
                 >
                   <div className="flex items-start gap-4">
                     {/* Image thumbnail */}
-                    <div className="w-16 h-16 rounded-lg bg-gray-800 flex-shrink-0 overflow-hidden flex items-center justify-center relative">
+                    <div className="w-16 h-16 rounded-lg border border-silicon-slate bg-imperial-navy/70 flex-shrink-0 overflow-hidden flex items-center justify-center relative">
                       {item.image_url ? (
                         <Image src={item.image_url} alt="" className="object-cover" fill sizes="64px" />
                       ) : (

--- a/app/admin/value-evidence/page.tsx
+++ b/app/admin/value-evidence/page.tsx
@@ -382,7 +382,7 @@ export default function ValueEvidencePage() {
 
   return (
     <ProtectedRoute requireAdmin>
-      <div className="min-h-screen bg-background text-foreground p-6 pb-24">
+      <div className="admin-console-page min-h-screen p-6 pb-24 text-foreground">
         <Breadcrumbs items={[
           { label: 'Admin', href: '/admin' },
           { label: 'Value Evidence Pipeline', href: '/admin/value-evidence' },
@@ -400,9 +400,10 @@ export default function ValueEvidencePage() {
           className="max-w-7xl mx-auto"
         >
           {/* Header */}
-          <div className="flex items-center justify-between mb-8">
+          <div className="admin-console-surface-header mb-6 mt-5 flex flex-col gap-4 rounded-xl border p-5 sm:flex-row sm:items-center sm:justify-between">
             <div>
-              <h1 className="text-3xl font-bold gradient-text">
+              <div className="admin-console-eyebrow mb-2">Pipeline Evidence</div>
+              <h1 className="text-3xl font-bold text-foreground">
                 Value Evidence Pipeline
               </h1>
               <p className="text-muted-foreground mt-1">
@@ -415,7 +416,7 @@ export default function ValueEvidencePage() {
                 whileTap={{ scale: 0.95 }}
                 onClick={handleHeaderRefresh}
                 title="Refresh dashboard and the current tab’s data"
-                className="p-2 bg-silicon-slate border border-silicon-slate rounded-lg hover:bg-silicon-slate/80"
+                className="admin-console-button-muted p-2"
               >
                 <RefreshCw size={18} className={loading ? 'animate-spin' : ''} />
               </motion.button>
@@ -423,7 +424,7 @@ export default function ValueEvidencePage() {
           </div>
 
           {/* Tab Navigation with count badges */}
-          <div className="flex gap-1 bg-silicon-slate/50 border border-silicon-slate rounded-xl p-1 mb-2 overflow-x-auto">
+          <div className="admin-console-card mb-2 flex gap-1 overflow-x-auto rounded-xl border p-1">
             {tabs.map(tab => {
               const Icon = tab.icon
               const isActive = activeTab === tab.id
@@ -497,7 +498,7 @@ export default function ValueEvidencePage() {
                 {eitherRunning ? (
                   <button
                     onClick={handleCancelAll}
-                    className="inline-flex items-center gap-2 px-4 py-2 bg-red-600 text-white rounded-lg text-sm font-medium hover:bg-red-500 transition-colors"
+                    className="inline-flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-500"
                   >
                     <Square className="w-4 h-4" />
                     Cancel Pipeline
@@ -506,7 +507,7 @@ export default function ValueEvidencePage() {
                   <button
                     onClick={handleTriggerAll}
                     disabled={triggerAllLoading}
-                    className="inline-flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-amber-600 to-orange-600 text-white rounded-lg text-sm font-medium hover:from-amber-500 hover:to-orange-500 disabled:opacity-50 transition-all"
+                    className="admin-console-button-primary disabled:opacity-50"
                   >
                     {triggerAllLoading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Zap className="w-4 h-4" />}
                     Run Full Pipeline
@@ -593,7 +594,7 @@ export default function ValueEvidencePage() {
                 {/* Left column */}
                 <div className="space-y-6">
                   {/* Top Pain Points — clickable */}
-                  <div className="bg-silicon-slate/50 border border-silicon-slate rounded-xl p-5">
+                  <div className="admin-console-card rounded-xl border p-5">
                     <div className="flex items-center justify-between mb-4">
                       <h3 className="text-lg font-semibold flex items-center gap-2">
                         <Target size={18} className="text-purple-400" />
@@ -611,11 +612,11 @@ export default function ValueEvidencePage() {
                         <button
                           key={pp.id}
                           onClick={() => { setFocusPainPointId(pp.id); setActiveTab('pain-points') }}
-                          className="w-full flex items-center justify-between p-3 bg-silicon-slate/30 rounded-lg cursor-pointer hover:bg-silicon-slate/60 transition-colors group focus-visible:ring-2 focus-visible:ring-radiant-gold/50 focus-visible:outline-none text-left"
+                          className="w-full flex flex-col gap-2 p-3 bg-imperial-navy/45 rounded-lg cursor-pointer hover:bg-imperial-navy/70 transition-colors group focus-visible:ring-2 focus-visible:ring-radiant-gold/50 focus-visible:outline-none text-left sm:flex-row sm:items-center sm:justify-between"
                         >
                           <div className="min-w-0">
                             <span className="font-medium block truncate">{pp.display_name}</span>
-                            <div className="flex gap-2 mt-1">
+                            <div className="flex flex-wrap gap-2 mt-1">
                               {pp.industry_tags.slice(0, 3).map(tag => (
                                 <span
                                   key={tag}
@@ -626,8 +627,8 @@ export default function ValueEvidencePage() {
                               ))}
                             </div>
                           </div>
-                          <div className="flex items-center gap-3 flex-shrink-0 ml-3">
-                            <div className="text-right">
+                          <div className="flex w-full items-center justify-between gap-3 sm:ml-3 sm:w-auto sm:flex-shrink-0">
+                            <div className="text-left sm:text-right">
                               <span className={`text-sm ${pp.evidence_count > 0 ? 'text-green-400 font-medium' : 'text-muted-foreground/90'}`}>{pp.evidence_count} evidence</span>
                               {pp.avg_monetary_impact && (
                                 <div className="text-green-400 text-sm font-medium">
@@ -651,7 +652,7 @@ export default function ValueEvidencePage() {
                 {/* Right column */}
                 <div className="space-y-6">
                   {/* Top Calculations — clickable */}
-                  <div className="bg-silicon-slate/50 border border-silicon-slate rounded-xl p-5">
+                  <div className="admin-console-card rounded-xl border p-5">
                     <div className="flex items-center justify-between mb-4">
                       <h3 className="text-lg font-semibold flex items-center gap-2">
                         <DollarSign size={18} className="text-green-400" />
@@ -675,7 +676,7 @@ export default function ValueEvidencePage() {
                               if (ppName) setFocusCalculationPainPointId(ppName)
                               setActiveTab('calculations')
                             }}
-                            className="w-full flex items-center justify-between p-3 bg-silicon-slate/30 rounded-lg cursor-pointer hover:bg-silicon-slate/60 transition-colors group focus-visible:ring-2 focus-visible:ring-radiant-gold/50 focus-visible:outline-none text-left"
+                            className="w-full flex flex-col gap-2 p-3 bg-imperial-navy/45 rounded-lg cursor-pointer hover:bg-imperial-navy/70 transition-colors group focus-visible:ring-2 focus-visible:ring-radiant-gold/50 focus-visible:outline-none text-left sm:flex-row sm:items-center sm:justify-between"
                           >
                             <div className="flex items-center gap-3 min-w-0">
                               <div className="w-8 h-8 rounded bg-green-600/20 flex items-center justify-center flex-shrink-0">
@@ -688,12 +689,12 @@ export default function ValueEvidencePage() {
                                 </div>
                               </div>
                             </div>
-                            <div className="flex items-center gap-3 flex-shrink-0 ml-3">
-                              <div className="text-right">
+                            <div className="flex w-full items-center justify-between gap-3 sm:ml-3 sm:w-auto sm:flex-shrink-0">
+                              <div className="text-left sm:text-right">
                                 <span className="text-green-400 font-semibold">
                                   {formatCurrency(calc.annual_value)}/yr
                                 </span>
-                                <div className="flex items-center gap-1 justify-end mt-0.5">
+                                <div className="flex items-center gap-1 mt-0.5 sm:justify-end">
                                   <span className={`text-xs px-1.5 py-0.5 rounded ${CONFIDENCE_COLORS[calc.confidence_level] || ''}`}>
                                     {calc.confidence_level}
                                   </span>

--- a/docs/design/amadutown-color-palette-audit.md
+++ b/docs/design/amadutown-color-palette-audit.md
@@ -31,7 +31,8 @@ The Agent Ops Mission Control surface at `/admin/agents` is the current referenc
 
 - **Shared admin primitives:** `app/globals.css` now includes `admin-console-*` primitives extracted from the Mission Control visual language for non-Agent-Ops admin surfaces.
 - **First applied slice:** `/admin`, `/admin/cost-revenue`, and `/admin/subscriptions` use the shared page/header/card/metric treatment as the first bounded Phase 6 rollout.
-- **Next rollout candidates:** high-traffic admin content and outreach pages still carry older gray, blue, purple, and cyan styling and should move to the same primitives in smaller follow-up PRs.
+- **Second applied slice:** `/admin/value-evidence`, `/admin/email-center`, and `/admin/social-content` now use the shared admin page/header/card treatment for their workflow shells while preserving their existing pipeline controls.
+- **Next rollout candidates:** deeper content, outreach, sales, and detail pages still carry older gray, blue, purple, and cyan styling and should move to the same primitives in smaller follow-up PRs.
 
 ---
 


### PR DESCRIPTION
## Summary
- Extends the shared Mission Control `admin-console-*` visual standard to `/admin/value-evidence`, `/admin/email-center`, and `/admin/social-content`.
- Updates the workflow page shells, headers, major cards, table shell, and primary command controls while preserving existing pipeline behavior.
- Fixes the Value Evidence mobile dashboard row overflow caught during visual QA.
- Fixes the Social Content extraction panel mobile layout and removes the nested admin-console-card pattern flagged by Integration Captain review.
- Updates the AmaduTown design audit with the second applied Phase 6 rollout slice.

## Validation
- Conflict preflight: clean for these files; open PRs #320 and #317 do not overlap.
- `git diff --check`
- `npm run lint -- --file app/admin/value-evidence/page.tsx --file app/admin/email-center/page.tsx --file app/admin/social-content/page.tsx`
- `npm run build:knowledge`
- `npx tsc --noEmit --pretty false`
- `npm run build`
- Local Playwright visual QA on `http://localhost:3013/admin/value-evidence`, `/admin/email-center`, and `/admin/social-content` at desktop and mobile widths.
- Local Playwright mobile smoke with Social Content extraction panel open confirmed `overflowX: 0`.

## Integration Notes
- Worktree env bootstrap linked `.env.local` and `.vercel`; `.env.staging` was not present in the source checkout.
- Local build emitted the existing n8n outbound-env warning, but no outbound workflow or production mutation was executed.
- Screenshot evidence is local-only under `.tmp/phase6-rollout-2-visual-qa/` and is not committed.
- Sidebar redesign is intentionally out of scope for this PR and should be the next Phase 6 slice because it affects the global admin shell.
- Vercel contexts to verify after merge: `Vercel – portfolio` and `Vercel – portfolio-staging`.
