### PR TITLE
feat: redesign admin sidebar shell

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -64,7 +64,7 @@ export default function AdminLayout({
   }, [drawerOpen])
 
   return (
-    <div className="dark min-h-screen bg-background text-foreground flex">
+    <div className="dark flex min-h-screen bg-background text-foreground">
       {/* Desktop sidebar */}
       <aside className="hidden lg:flex shrink-0 sticky top-0 h-screen">
         <AdminSidebar />
@@ -73,7 +73,7 @@ export default function AdminLayout({
       {/* Mobile drawer overlay */}
       {drawerOpen && (
         <div
-          className="fixed inset-0 z-40 bg-black/50 lg:hidden"
+          className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm lg:hidden"
           aria-hidden
           onClick={closeDrawer}
         />
@@ -82,7 +82,7 @@ export default function AdminLayout({
       {/* Mobile drawer */}
       <aside
         ref={drawerRef}
-        className={`fixed top-0 left-0 z-50 h-full w-[280px] bg-silicon-slate/95 border-r border-silicon-slate transform transition-transform duration-200 ease-out lg:hidden ${
+        className={`fixed left-0 top-0 z-50 h-full w-[284px] transform overflow-hidden bg-[linear-gradient(180deg,rgba(18,30,49,0.99)_0%,rgba(15,26,43,0.99)_100%)] shadow-[16px_0_48px_rgba(0,0,0,0.28)] transition-transform duration-200 ease-out lg:hidden ${
           drawerOpen ? 'translate-x-0' : '-translate-x-full'
         }`}
         aria-label="Admin navigation"
@@ -90,29 +90,34 @@ export default function AdminLayout({
         role="dialog"
         hidden={!drawerOpen}
       >
-        <div className="flex items-center justify-between p-3 border-b border-silicon-slate">
-          <span className="text-sm font-medium text-muted-foreground">Menu</span>
+        <div className="flex items-center justify-between border-b border-radiant-gold/10 bg-imperial-navy/70 p-4">
+          <div>
+            <div className="mb-0.5 block text-[11px] font-bold uppercase tracking-[0.16em] text-radiant-gold">
+              Admin
+            </div>
+            <span className="text-base font-semibold text-foreground">Command Center</span>
+          </div>
           <button
             type="button"
             onClick={closeDrawer}
-            className="p-2 rounded-lg text-muted-foreground hover:bg-silicon-slate hover:text-foreground focus:outline-none focus:ring-2 focus:ring-radiant-gold"
+            className="rounded-lg border border-radiant-gold/10 p-2 text-muted-foreground transition-colors hover:border-radiant-gold/30 hover:bg-radiant-gold/10 hover:text-foreground focus:outline-none focus:ring-2 focus:ring-radiant-gold"
             aria-label="Close menu"
           >
             <X size={20} />
           </button>
         </div>
-        <div className="overflow-y-auto h-[calc(100%-52px)]">
-          <AdminSidebar />
+        <div className="h-[calc(100%-73px)] overflow-y-auto">
+          <AdminSidebar showHeader={false} />
         </div>
       </aside>
 
-      <div className="flex-1 flex flex-col min-w-0">
-        <header className="sticky top-0 z-10 flex items-center justify-between border-b border-silicon-slate bg-background px-4 py-3 lg:px-6">
+      <div className="flex min-w-0 flex-1 flex-col">
+        <header className="sticky top-0 z-10 flex items-center justify-between border-b border-radiant-gold/10 bg-background/90 px-4 py-3 backdrop-blur lg:px-6">
           <button
             ref={hamburgerRef}
             type="button"
             onClick={() => setDrawerOpen(true)}
-            className="lg:hidden p-2 rounded-lg text-muted-foreground hover:bg-silicon-slate hover:text-foreground focus:outline-none focus:ring-2 focus:ring-radiant-gold"
+            className="rounded-lg border border-radiant-gold/10 p-2 text-muted-foreground transition-colors hover:border-radiant-gold/30 hover:bg-radiant-gold/10 hover:text-foreground focus:outline-none focus:ring-2 focus:ring-radiant-gold lg:hidden"
             aria-label="Open admin menu"
           >
             <Menu size={22} />
@@ -120,7 +125,7 @@ export default function AdminLayout({
           <div className="flex-1 lg:flex-initial" />
           <Link
             href="/admin/help"
-            className="flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+            className="flex items-center gap-2 rounded-lg border border-transparent px-2 py-1.5 text-sm text-muted-foreground transition-colors hover:border-radiant-gold/20 hover:bg-radiant-gold/10 hover:text-foreground"
           >
             <HelpCircle size={18} />
             Help

--- a/components/admin/AdminSidebar.tsx
+++ b/components/admin/AdminSidebar.tsx
@@ -57,6 +57,15 @@ const CONTENT_HUB_CHILDREN_ID = 'admin-nav-content-children'
 const CHAT_EVAL_CHILDREN_ID = 'admin-nav-chat-eval-children'
 const ITEM_ICON_SIZE = 16
 
+function navItemClass(active: boolean, depth: 'root' | 'item' | 'child' = 'item') {
+  const depthPadding = depth === 'root' ? 'px-3' : depth === 'child' ? 'pl-7 pr-3' : 'pl-4 pr-3'
+  return `group flex items-center gap-2 rounded-lg ${depthPadding} py-2 text-sm transition-colors ${
+    active
+      ? 'border border-radiant-gold/35 bg-radiant-gold/15 text-radiant-gold shadow-[0_0_22px_rgba(212,175,55,0.08)]'
+      : 'border border-transparent text-foreground/85 hover:border-radiant-gold/20 hover:bg-radiant-gold/10 hover:text-foreground'
+  }`
+}
+
 /** Small icon per nav item so category items have clear hierarchy. */
 const NAV_ITEM_ICONS: Record<string, LucideIcon> = {
   '/admin/outreach': Send,
@@ -114,13 +123,20 @@ const NAV_ITEM_ICONS: Record<string, LucideIcon> = {
   '/admin/content/store-settings': Settings,
 }
 
-function NavItemIcon({ href }: { href: string }) {
+function NavItemIcon({ href, active = false }: { href: string; active?: boolean }) {
   const Icon = NAV_ITEM_ICONS[href]
   if (!Icon) return null
-  return <Icon size={ITEM_ICON_SIZE} className="shrink-0 text-muted-foreground" />
+  return (
+    <Icon
+      size={ITEM_ICON_SIZE}
+      className={`shrink-0 transition-colors ${
+        active ? 'text-radiant-gold' : 'text-muted-foreground group-hover:text-radiant-gold/80'
+      }`}
+    />
+  )
 }
 
-export default function AdminSidebar() {
+export default function AdminSidebar({ showHeader = true }: { showHeader?: boolean }) {
   const pathname = usePathname()
   const [contentOpen, setContentOpen] = useState(false)
   const [chatEvalOpen, setChatEvalOpen] = useState(false)
@@ -136,7 +152,7 @@ export default function AdminSidebar() {
 
   return (
     <nav
-      className="flex flex-col h-full bg-silicon-slate/50 border-r border-silicon-slate text-foreground"
+      className="flex h-full min-w-[264px] flex-col border-r border-radiant-gold/10 bg-[linear-gradient(180deg,rgba(18,30,49,0.97)_0%,rgba(15,26,43,0.98)_100%)] text-foreground shadow-[8px_0_32px_rgba(0,0,0,0.18)]"
       aria-label="Admin navigation"
     >
       <a
@@ -145,24 +161,33 @@ export default function AdminSidebar() {
       >
         Skip to main content
       </a>
-      <div className="flex flex-col gap-1 py-4 pl-3 pr-4 min-w-[220px] overflow-y-auto">
+      {showHeader && (
+        <div className="border-b border-radiant-gold/10 px-4 py-4">
+          <div className="mb-1 block text-[11px] font-bold uppercase tracking-[0.16em] text-radiant-gold">
+            Admin
+          </div>
+          <div className="text-lg font-semibold text-foreground">Command Center</div>
+        </div>
+      )}
+      <div className="flex min-w-[240px] flex-col gap-4 overflow-y-auto px-3 py-4">
         {/* Dashboard */}
         <Link
           href={ADMIN_NAV.dashboard.href}
-          className={`flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
-            pathname === ADMIN_NAV.dashboard.href
-              ? 'bg-radiant-gold/20 text-radiant-gold border-l-2 border-radiant-gold -ml-0.5 pl-3.5'
-              : 'text-foreground/90 hover:bg-silicon-slate hover:text-foreground'
-          }`}
+          className={navItemClass(pathname === ADMIN_NAV.dashboard.href, 'root')}
           aria-current={pathname === ADMIN_NAV.dashboard.href ? 'page' : undefined}
         >
-          <LayoutDashboard size={18} className="shrink-0" />
+          <LayoutDashboard
+            size={18}
+            className={`shrink-0 ${
+              pathname === ADMIN_NAV.dashboard.href ? 'text-radiant-gold' : 'text-muted-foreground'
+            }`}
+          />
           {ADMIN_NAV.dashboard.label}
         </Link>
 
         {ADMIN_NAV.categories.map((cat) => (
-          <div key={cat.label} className="flex flex-col gap-0.5">
-            <div className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          <div key={cat.label} className="flex flex-col gap-1">
+            <div className="px-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground/78">
               {cat.label}
             </div>
             {cat.children && cat.expandableItemHref ? (
@@ -181,7 +206,7 @@ export default function AdminSidebar() {
                             <button
                               type="button"
                               onClick={() => setExpanded((o: boolean) => !o)}
-                              className="flex w-full items-center gap-2 rounded-lg pl-5 pr-3 py-2 text-sm font-medium transition-colors text-left text-foreground/90 hover:bg-silicon-slate hover:text-foreground"
+                              className="group flex w-full items-center gap-2 rounded-lg border border-transparent py-2 pl-3 pr-3 text-left text-sm font-medium text-foreground/85 transition-colors hover:border-radiant-gold/20 hover:bg-radiant-gold/10 hover:text-foreground"
                               aria-expanded={expanded}
                               aria-controls={childrenId}
                             >
@@ -195,7 +220,7 @@ export default function AdminSidebar() {
                             </button>
                             <div
                               id={childrenId}
-                              className="flex flex-col gap-0.5 overflow-hidden"
+                              className="mt-1 flex flex-col gap-0.5 overflow-hidden border-l border-radiant-gold/10 pl-2"
                               hidden={!expanded}
                             >
                               {expanded &&
@@ -205,14 +230,10 @@ export default function AdminSidebar() {
                                     <Link
                                       key={child.href}
                                       href={child.href}
-                                      className={`flex items-center gap-2 ml-5 pl-6 rounded-lg pr-3 py-2 text-sm transition-colors ${
-                                        childActive
-                                          ? 'bg-radiant-gold/20 text-radiant-gold border-l-2 border-radiant-gold -ml-0.5 pl-5'
-                                          : 'text-muted-foreground hover:bg-silicon-slate hover:text-foreground'
-                                      }`}
+                                      className={navItemClass(childActive, 'child')}
                                       aria-current={childActive ? 'page' : undefined}
                                     >
-                                      <NavItemIcon href={child.href} />
+                                      <NavItemIcon href={child.href} active={childActive} />
                                       {child.label}
                                     </Link>
                                   )
@@ -222,14 +243,10 @@ export default function AdminSidebar() {
                         ) : (
                           <Link
                             href={item.href}
-                            className={`flex items-center gap-2 rounded-lg pl-5 pr-3 py-2 text-sm font-medium transition-colors ${
-                              active
-                                ? 'bg-radiant-gold/20 text-radiant-gold border-l-2 border-radiant-gold -ml-0.5 pl-5'
-                                : 'text-foreground/90 hover:bg-silicon-slate hover:text-foreground'
-                            }`}
+                            className={navItemClass(active)}
                             aria-current={active ? 'page' : undefined}
                           >
-                            <NavItemIcon href={item.href} />
+                            <NavItemIcon href={item.href} active={active} />
                             {item.label}
                           </Link>
                         )}
@@ -245,14 +262,10 @@ export default function AdminSidebar() {
                   <Link
                     key={item.href}
                     href={item.href}
-                    className={`flex items-center gap-2 rounded-lg pl-5 pr-3 py-2 text-sm font-medium transition-colors ${
-                      active
-                        ? 'bg-radiant-gold/20 text-radiant-gold border-l-2 border-radiant-gold -ml-0.5 pl-5'
-                        : 'text-foreground/90 hover:bg-silicon-slate hover:text-foreground'
-                    }`}
+                    className={navItemClass(active)}
                     aria-current={active ? 'page' : undefined}
                   >
-                    <NavItemIcon href={item.href} />
+                    <NavItemIcon href={item.href} active={active} />
                     {item.label}
                   </Link>
                 )

--- a/docs/design/amadutown-color-palette-audit.md
+++ b/docs/design/amadutown-color-palette-audit.md
@@ -32,6 +32,7 @@ The Agent Ops Mission Control surface at `/admin/agents` is the current referenc
 - **Shared admin primitives:** `app/globals.css` now includes `admin-console-*` primitives extracted from the Mission Control visual language for non-Agent-Ops admin surfaces.
 - **First applied slice:** `/admin`, `/admin/cost-revenue`, and `/admin/subscriptions` use the shared page/header/card/metric treatment as the first bounded Phase 6 rollout.
 - **Second applied slice:** `/admin/value-evidence`, `/admin/email-center`, and `/admin/social-content` now use the shared admin page/header/card treatment for their workflow shells while preserving their existing pipeline controls.
+- **Global shell slice:** `AdminSidebar` and the admin mobile drawer now use the same operating-console frame: navy depth, gold active state, restrained hover/focus treatment, and clearer section hierarchy around the page-level work surfaces.
 - **Next rollout candidates:** deeper content, outreach, sales, and detail pages still carry older gray, blue, purple, and cyan styling and should move to the same primitives in smaller follow-up PRs.
 
 ---


### PR DESCRIPTION
## Summary
- Redesign the global AdminSidebar with the Mission Control operating-console aesthetic: navy depth, gold active state, clearer section hierarchy, and restrained hover/focus treatment.
- Update the admin mobile drawer and top bar controls to match the same shell treatment.
- Record the global shell slice in the AmaduTown design architecture audit.

## Validation
- Conflict preflight: root checkout had unrelated subscription docs and open PRs #320/#317 did not overlap planned sidebar/layout files.
- Environment bootstrap: ran npm run worktree:env -- --source /Users/vambahsillah/Projects/Portfolio in the dedicated worktree.
- git diff --check
- npm run lint -- --file components/admin/AdminSidebar.tsx --file app/admin/layout.tsx
- npm test -- components/admin/AdminSidebar.test.tsx
- npm run build:knowledge
- npx tsc --noEmit --pretty false
- npm run build
- Local Playwright visual QA on http://localhost:3014 for /admin/agents desktop, /admin/agents mobile drawer, and /admin/value-evidence desktop.
- Keyboard smoke: mobile drawer tabs into nav, Escape closes, route click closes drawer and restores focus to the hamburger.

## Integration Notes
- No database/schema changes.
- No production mutation or outbound workflow executed.
- Local build emitted the existing dev env warning about MOCK_N8N=false and N8N_DISABLE_OUTBOUND=false; this PR does not touch n8n runtime behavior.
- Vercel contexts to verify after merge: Vercel – portfolio and Vercel – portfolio-staging.