### PR TITLE
feat: standardize content admin surfaces

### DIFF
--- a/app/admin/content/page.tsx
+++ b/app/admin/content/page.tsx
@@ -13,109 +13,102 @@ export default function ContentManagementPage() {
       href: '/admin/content/outcome-groups',
       icon: <Target size={32} />,
       description: 'Group content by outcome (pricing chart)',
-      color: 'from-teal-500 to-cyan-500',
     },
     {
       name: 'Projects',
       href: '/admin/content/projects',
       icon: <FolderOpen size={32} />,
       description: 'Manage portfolio projects',
-      color: 'from-blue-500 to-cyan-500',
     },
     {
       name: 'Videos',
       href: '/admin/content/videos',
       icon: <Video size={32} />,
       description: 'Manage video content',
-      color: 'from-red-500 to-pink-500',
     },
     {
       name: 'Publications',
       href: '/admin/content/publications',
       icon: <BookOpen size={32} />,
       description: 'Manage publications',
-      color: 'from-green-500 to-emerald-500',
     },
     {
       name: 'Music',
       href: '/admin/content/music',
       icon: <Music size={32} />,
       description: 'Manage music projects',
-      color: 'from-purple-500 to-pink-500',
     },
     {
       name: 'Services',
       href: '/admin/content/services',
       icon: <Briefcase size={32} />,
       description: 'Manage services and offerings',
-      color: 'from-teal-500 to-cyan-500',
     },
     {
       name: 'Products',
       href: '/admin/products',
       icon: <ShoppingBag size={32} />,
       description: 'Products, templates, and lead magnets',
-      color: 'from-emerald-500 to-teal-500',
     },
     {
       name: 'Prototypes',
       href: '/admin/content/prototypes',
       icon: <Sparkles size={32} />,
       description: 'Manage app prototype demos',
-      color: 'from-purple-500 to-pink-500',
     },
     {
       name: 'Merchandise',
       href: '/admin/content/merchandise',
       icon: <Package size={32} />,
       description: 'Manage print-on-demand products',
-      color: 'from-indigo-500 to-purple-500',
     },
     {
       name: 'Discount Codes',
       href: '/admin/content/discount-codes',
       icon: <Tag size={32} />,
       description: 'Manage discount codes and promotions',
-      color: 'from-green-500 to-teal-500',
     },
     {
       name: 'Bundles',
       href: '/admin/sales/bundles',
       icon: <Layers size={32} />,
       description: 'Manage product bundles',
-      color: 'from-amber-500 to-orange-500',
     },
   ]
 
   return (
     <ProtectedRoute requireAdmin>
-      <div className="min-h-screen bg-background text-foreground p-8">
+      <div className="admin-console-page min-h-screen px-4 py-6 text-foreground sm:px-6 lg:px-8">
         <div className="max-w-7xl mx-auto">
           <Breadcrumbs items={[
             { label: 'Admin Dashboard', href: '/admin' },
             { label: 'Content Management' }
           ]} />
           
-          <div className="mb-8">
-            <h1 className="text-4xl font-bold mb-2">Content Management</h1>
-            <p className="text-muted-foreground">Manage your portfolio content</p>
+          <div className="admin-console-surface-header mb-6 rounded-xl border p-5 sm:p-6">
+            <div className="admin-console-eyebrow mb-2">Content Hub</div>
+            <h1 className="text-3xl font-bold text-foreground">Content Management</h1>
+            <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+              Route publishing assets, product materials, prototypes, and offer content from one operating surface.
+            </p>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
             {contentTypes.map((type, index) => (
               <Link key={type.name} href={type.href}>
                 <motion.div
                   initial={{ opacity: 0, y: 20 }}
                   animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: index * 0.1 }}
-                  whileHover={{ scale: 1.05, y: -5 }}
-                  className="p-6 bg-silicon-slate border border-silicon-slate rounded-xl hover:border-radiant-gold/50 transition-all cursor-pointer"
+                  transition={{ delay: index * 0.03 }}
+                  className="admin-console-card admin-console-interactive flex h-full gap-4 rounded-lg border p-5 transition-all"
                 >
-                  <div className="w-16 h-16 rounded-lg bg-gradient-to-r from-bronze to-radiant-gold flex items-center justify-center text-imperial-navy mb-4">
+                  <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg border border-radiant-gold/25 bg-radiant-gold/12 text-radiant-gold">
                     {type.icon}
                   </div>
-                  <h3 className="text-xl font-bold text-foreground mb-2">{type.name}</h3>
-                  <p className="text-muted-foreground text-sm">{type.description}</p>
+                  <div className="min-w-0">
+                    <h3 className="text-lg font-semibold text-foreground">{type.name}</h3>
+                    <p className="mt-1 text-sm text-muted-foreground">{type.description}</p>
+                  </div>
                 </motion.div>
               </Link>
             ))}

--- a/app/admin/content/products/page.tsx
+++ b/app/admin/content/products/page.tsx
@@ -158,7 +158,7 @@ export default function ProductsManagementPage() {
 
   return (
     <ProtectedRoute requireAdmin>
-      <div className="min-h-screen bg-background text-foreground p-8">
+      <div className="admin-console-page min-h-screen px-4 py-6 text-foreground sm:px-6 lg:px-8">
         <div className="max-w-7xl mx-auto">
           <Breadcrumbs items={[
             { label: 'Admin Dashboard', href: '/admin' },
@@ -166,16 +166,18 @@ export default function ProductsManagementPage() {
             { label: 'Products' }
           ]} />
           
-          <div className="mb-8 flex items-center justify-between">
+          <div className="admin-console-surface-header mb-6 flex flex-col gap-4 rounded-xl border p-5 sm:flex-row sm:items-center sm:justify-between sm:p-6">
             <div>
-              <h1 className="text-4xl font-bold mb-2">Products Management</h1>
-              <p className="text-muted-foreground">Manage lead magnets and products</p>
+              <div className="admin-console-eyebrow mb-2">Catalog Operations</div>
+              <h1 className="text-3xl font-bold text-foreground">Products Management</h1>
+              <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+                Review digital products, templates, pricing, file readiness, and public catalog visibility.
+              </p>
             </div>
             <Link href="/admin/content/products/new">
               <motion.span
-                whileHover={{ scale: 1.05 }}
                 whileTap={{ scale: 0.95 }}
-                className="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r btn-gold font-semibold rounded-lg inline-flex items-center gap-2"
+                className="admin-console-button-primary"
               >
                 <Plus size={20} />
                 Add Product
@@ -184,17 +186,16 @@ export default function ProductsManagementPage() {
           </div>
 
           {loading ? (
-            <div className="text-center py-12">
+            <div className="admin-console-card rounded-lg border py-12 text-center">
               <div className="text-muted-foreground">Loading products...</div>
             </div>
           ) : products.length === 0 ? (
-            <div className="text-center py-12 text-muted-foreground">
-              <p className="mb-4">No products found. Add your first one!</p>
+            <div className="admin-console-card rounded-lg border py-12 text-center text-muted-foreground">
+              <p className="mb-4">No products found. Add the first catalog item.</p>
               <Link href="/admin/content/products/new">
                 <motion.span
-                  whileHover={{ scale: 1.05 }}
                   whileTap={{ scale: 0.95 }}
-                  className="inline-flex items-center gap-2 px-6 py-3 btn-ghost rounded-lg inline-flex items-center gap-2 transition-colors"
+                  className="admin-console-button-secondary"
                 >
                   <Plus size={20} />
                   Add New Product
@@ -208,7 +209,7 @@ export default function ProductsManagementPage() {
                   key={product.id}
                   initial={{ opacity: 0, y: 20 }}
                   animate={{ opacity: 1, y: 0 }}
-                  className="p-6 bg-silicon-slate border border-silicon-slate/80 rounded-xl flex flex-col md:flex-row items-start md:items-center justify-between gap-4"
+                  className="admin-console-card flex flex-col gap-4 rounded-lg border p-5 md:flex-row md:items-center md:justify-between"
                 >
                   <div className="flex-grow">
                     <div className="flex items-center gap-3 mb-2">
@@ -264,7 +265,7 @@ export default function ProductsManagementPage() {
                       {product.type === 'template' && product.instructions_file_path && (
                         <>
                           <span>•</span>
-                          <span className="flex items-center gap-1 text-green-400">Install guide</span>
+                          <span className="flex items-center gap-1 text-radiant-gold">Install guide</span>
                         </>
                       )}
                     </div>
@@ -272,28 +273,28 @@ export default function ProductsManagementPage() {
                   <div className="flex items-center gap-2">
                     <button
                       onClick={() => handleMoveOrder(product, 'up')}
-                      className="p-2 bg-silicon-slate rounded-lg hover:bg-radiant-gold/20"
+                      className="admin-console-button-muted p-2"
                       title="Move up"
                     >
                       <ArrowUp size={18} />
                     </button>
                     <button
                       onClick={() => handleMoveOrder(product, 'down')}
-                      className="p-2 bg-silicon-slate rounded-lg hover:bg-radiant-gold/20"
+                      className="admin-console-button-muted p-2"
                       title="Move down"
                     >
                       <ArrowDown size={18} />
                     </button>
                     <button
                       onClick={() => handleToggleActive(product)}
-                      className="p-2 bg-silicon-slate rounded-lg hover:bg-radiant-gold/20"
+                      className="admin-console-button-muted p-2"
                       title={product.is_active ? 'Deactivate' : 'Activate'}
                     >
                       {product.is_active ? <EyeOff size={18} /> : <Eye size={18} />}
                     </button>
                     <Link
                       href={buildLinkWithReturn(`/admin/content/products/${product.id}`, '/admin/content/products')}
-                      className="p-2 bg-silicon-slate rounded-lg hover:bg-radiant-gold/20 inline-flex"
+                      className="admin-console-button-secondary p-2"
                       title="Edit"
                     >
                       <Edit size={18} />

--- a/app/admin/products/page.tsx
+++ b/app/admin/products/page.tsx
@@ -13,20 +13,18 @@ export default function ProductsHubPage() {
       href: '/admin/content/products',
       icon: <ShoppingBag size={32} />,
       description: 'Ebooks, templates, calculators, apps, and digital products',
-      color: 'from-emerald-500 to-teal-500',
     },
     {
       name: 'Lead Magnets',
       href: '/admin/content/lead-magnets',
       icon: <Download size={32} />,
       description: 'Manage downloadable resources and lead capture',
-      color: 'from-orange-500 to-amber-500',
     },
   ]
 
   return (
     <ProtectedRoute requireAdmin>
-      <div className="min-h-screen bg-background text-foreground p-8">
+      <div className="admin-console-page min-h-screen px-4 py-6 text-foreground sm:px-6 lg:px-8">
         <div className="max-w-7xl mx-auto">
           <Breadcrumbs items={[
             { label: 'Admin Dashboard', href: '/admin' },
@@ -34,29 +32,31 @@ export default function ProductsHubPage() {
             { label: 'Products' },
           ]} />
 
-          <div className="mb-8">
-            <h1 className="text-4xl font-bold mb-2">Products</h1>
-            <p className="text-gray-400">Manage products, templates, and lead magnets</p>
+          <div className="admin-console-surface-header mb-6 rounded-xl border p-5 sm:p-6">
+            <div className="admin-console-eyebrow mb-2">Content Hub</div>
+            <h1 className="text-3xl font-bold text-foreground">Products</h1>
+            <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+              Manage the product catalog and lead capture assets that feed the public store and sales workflows.
+            </p>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
             {sections.map((section, index) => (
               <Link key={section.name} href={section.href}>
                 <motion.div
                   initial={{ opacity: 0, y: 20 }}
                   animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: index * 0.1 }}
-                  whileHover={{ scale: 1.02, y: -2 }}
-                  className="p-6 bg-gray-900 border border-gray-800 rounded-xl hover:border-emerald-500/30 transition-all cursor-pointer flex items-center gap-4"
+                  transition={{ delay: index * 0.04 }}
+                  className="admin-console-card admin-console-interactive flex h-full items-center gap-4 rounded-lg border p-5 transition-all"
                 >
-                  <div className={`w-16 h-16 rounded-lg bg-gradient-to-r ${section.color} flex items-center justify-center text-white shrink-0`}>
+                  <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg border border-radiant-gold/25 bg-radiant-gold/12 text-radiant-gold">
                     {section.icon}
                   </div>
                   <div className="flex-1 min-w-0">
-                    <h3 className="text-xl font-bold text-white mb-1">{section.name}</h3>
-                    <p className="text-gray-400 text-sm">{section.description}</p>
+                    <h3 className="text-lg font-semibold text-foreground">{section.name}</h3>
+                    <p className="mt-1 text-sm text-muted-foreground">{section.description}</p>
                   </div>
-                  <ArrowRight className="w-5 h-5 text-gray-500 shrink-0" />
+                  <ArrowRight className="h-5 w-5 shrink-0 text-radiant-gold" />
                 </motion.div>
               </Link>
             ))}

--- a/components/admin/AdminSidebar.test.tsx
+++ b/components/admin/AdminSidebar.test.tsx
@@ -44,4 +44,19 @@ describe('AdminSidebar Agent Ops hierarchy', () => {
     expect(isNavItemActive('/admin/agents/runs', '/admin/agents/runs/run-1')).toBe(true)
     expect(isNavItemActive('/admin/agents', '/admin/agents/runs/run-1')).toBe(false)
   })
+
+  it('keeps Content Hub expanded and product management active for nested catalog routes', () => {
+    usePathnameMock.mockReturnValue('/admin/content/products')
+
+    render(<AdminSidebar />)
+
+    const nav = screen.getByRole('navigation', { name: 'Admin navigation' })
+    const productHubLink = within(nav)
+      .getAllByRole('link', { name: 'Products' })
+      .find((link) => link.getAttribute('href') === '/admin/products')
+
+    expect(within(nav).getByRole('button', { name: /Content Hub/i })).toHaveAttribute('aria-current', 'page')
+    expect(productHubLink).toHaveAttribute('aria-current', 'page')
+    expect(isNavItemActive('/admin/products', '/admin/content/products')).toBe(true)
+  })
 })

--- a/components/admin/AdminSidebar.tsx
+++ b/components/admin/AdminSidebar.tsx
@@ -206,16 +206,23 @@ export default function AdminSidebar({ showHeader = true }: { showHeader?: boole
                             <button
                               type="button"
                               onClick={() => setExpanded((o: boolean) => !o)}
-                              className="group flex w-full items-center gap-2 rounded-lg border border-transparent py-2 pl-3 pr-3 text-left text-sm font-medium text-foreground/85 transition-colors hover:border-radiant-gold/20 hover:bg-radiant-gold/10 hover:text-foreground"
+                              className={`${navItemClass(active)} w-full text-left font-medium`}
                               aria-expanded={expanded}
                               aria-controls={childrenId}
+                              aria-current={active ? 'page' : undefined}
                             >
                               {expanded ? (
-                                <ChevronDown size={ITEM_ICON_SIZE} className="shrink-0" />
+                                <ChevronDown
+                                  size={ITEM_ICON_SIZE}
+                                  className={`shrink-0 ${active ? 'text-radiant-gold' : ''}`}
+                                />
                               ) : (
-                                <ChevronRight size={ITEM_ICON_SIZE} className="shrink-0" />
+                                <ChevronRight
+                                  size={ITEM_ICON_SIZE}
+                                  className={`shrink-0 ${active ? 'text-radiant-gold' : ''}`}
+                                />
                               )}
-                              <NavItemIcon href={item.href} />
+                              <NavItemIcon href={item.href} active={active} />
                               {item.label}
                             </button>
                             <div

--- a/docs/design/amadutown-color-palette-audit.md
+++ b/docs/design/amadutown-color-palette-audit.md
@@ -33,6 +33,7 @@ The Agent Ops Mission Control surface at `/admin/agents` is the current referenc
 - **First applied slice:** `/admin`, `/admin/cost-revenue`, and `/admin/subscriptions` use the shared page/header/card/metric treatment as the first bounded Phase 6 rollout.
 - **Second applied slice:** `/admin/value-evidence`, `/admin/email-center`, and `/admin/social-content` now use the shared admin page/header/card treatment for their workflow shells while preserving their existing pipeline controls.
 - **Global shell slice:** `AdminSidebar` and the admin mobile drawer now use the same operating-console frame: navy depth, gold active state, restrained hover/focus treatment, and clearer section hierarchy around the page-level work surfaces.
+- **Content Hub slice:** `/admin/content`, `/admin/products`, and `/admin/content/products` now use the shared admin console shell and card language for the content routing and catalog management surfaces.
 - **Next rollout candidates:** deeper content, outreach, sales, and detail pages still carry older gray, blue, purple, and cyan styling and should move to the same primitives in smaller follow-up PRs.
 
 ---

--- a/lib/admin-nav.ts
+++ b/lib/admin-nav.ts
@@ -127,6 +127,9 @@ export const ADMIN_NAV: { dashboard: AdminNavItem; categories: AdminNavCategory[
  */
 export function isNavItemActive(href: string, pathname: string): boolean {
   if (href === '/admin/agents') return pathname === href
+  if (href === '/admin/products') {
+    return pathname === href || pathname === '/admin/content/products' || pathname.startsWith('/admin/content/products/')
+  }
   if (pathname === href) return true
   if (href !== '/admin' && pathname.startsWith(href + '/')) return true
   return false


### PR DESCRIPTION
## Summary
- Standardizes `/admin/content`, `/admin/products`, and `/admin/content/products` on the shared Mission Control admin-console visual language.
- Removes the older bright per-card gradient styling from Content Hub routing/catalog surfaces and replaces it with navy console surfaces, gold command accents, fine borders, and denser operational hierarchy.
- Keeps Content Hub navigation expanded for `/admin/content/products` and marks the Products child active so catalog routes have consistent sidebar orientation.
- Updates the AmaduTown design audit with the Content Hub rollout status.

## Validation
- `npm test -- components/admin/AdminSidebar.test.tsx`
- `npm run lint -- --file app/admin/content/page.tsx --file app/admin/products/page.tsx --file app/admin/content/products/page.tsx --file components/admin/AdminSidebar.tsx --file components/admin/AdminSidebar.test.tsx --file lib/admin-nav.ts`
- `npx tsc --noEmit --pretty false`
- `npm run build`
- `git diff --check`
- Local Playwright smoke on `http://localhost:3015` for `/admin/content`, `/admin/products`, and `/admin/content/products` at desktop/mobile; no horizontal overflow detected and active nav state verified after the sidebar fix.

## Integration Notes
- Conflict preflight was clean for planned files. Open PRs were unrelated to these Content Hub/sidebar files.
- Worktree env bootstrap ran from `/Users/vambahsillah/Projects/Portfolio`; `.env.local` and `.vercel` were linked, `.env.staging` was not present in the source checkout.
- `npm run build` emitted the existing local env warning about `MOCK_N8N=false` and `N8N_DISABLE_OUTBOUND=false`; this slice did not run n8n workflows.
- Vercel contexts to verify after merge: `Vercel – portfolio` and `Vercel – portfolio-staging`.
