### PR TITLE
feat: standardize sales detail admin surfaces

### DIFF
--- a/app/admin/campaigns/[id]/enrollments/[enrollmentId]/page.tsx
+++ b/app/admin/campaigns/[id]/enrollments/[enrollmentId]/page.tsx
@@ -102,16 +102,18 @@ export default function EnrollmentDetailPage() {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-gray-950 text-white flex items-center justify-center">
-        <Loader2 size={32} className="animate-spin text-gray-400" />
+      <div className="admin-console-page min-h-screen flex items-center justify-center text-foreground">
+        <Loader2 size={32} className="animate-spin text-muted-foreground" />
       </div>
     );
   }
 
   if (!enrollment) {
     return (
-      <div className="min-h-screen bg-gray-950 text-white p-6">
-        <p className="text-gray-400">Enrollment not found.</p>
+      <div className="admin-console-page min-h-screen px-4 py-6 text-foreground sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-7xl">
+          <div className="admin-console-card rounded-lg border p-6 text-muted-foreground">Enrollment not found.</div>
+        </div>
       </div>
     );
   }
@@ -123,7 +125,8 @@ export default function EnrollmentDetailPage() {
   const isTerminal = ['refund_issued', 'credit_issued', 'rollover_applied', 'expired', 'withdrawn'].includes(enrollment.status);
 
   return (
-    <div className="min-h-screen bg-gray-950 text-white p-6">
+    <div className="admin-console-page min-h-screen px-4 py-6 text-foreground sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl">
       <Breadcrumbs items={[
         { label: 'Admin', href: '/admin' },
         { label: 'Campaigns', href: '/admin/campaigns' },
@@ -131,16 +134,17 @@ export default function EnrollmentDetailPage() {
         { label: enrollment.client_name || enrollment.client_email },
       ]} />
 
-      <Link href={backUrl} className="text-gray-400 hover:text-white text-sm flex items-center gap-1 mb-4">
+      <Link href={backUrl} className="mb-4 mt-4 inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground">
         <ArrowLeft size={14} /> Back
       </Link>
 
       {/* Client Header */}
-      <div className="mb-8 p-6 bg-gray-900 border border-gray-700 rounded-xl">
-        <div className="flex items-center justify-between mb-4">
-          <div>
-            <h1 className="text-2xl font-bold">{enrollment.client_name || enrollment.client_email}</h1>
-            <p className="text-gray-400 text-sm">{enrollment.client_email}</p>
+      <div className="admin-console-surface-header mb-8 rounded-xl border p-5 sm:p-6">
+        <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="min-w-0">
+            <div className="admin-console-eyebrow mb-2">Campaign Enrollment</div>
+            <h1 className="break-words text-2xl font-bold tracking-tight">{enrollment.client_name || enrollment.client_email}</h1>
+            <p className="break-all text-sm text-muted-foreground">{enrollment.client_email}</p>
           </div>
           <span className={`px-3 py-1 text-sm rounded-full border ${ENROLLMENT_STATUS_COLORS[enrollment.status as keyof typeof ENROLLMENT_STATUS_COLORS] || ''}`}>
             {ENROLLMENT_STATUS_LABELS[enrollment.status as keyof typeof ENROLLMENT_STATUS_LABELS] || enrollment.status}
@@ -148,29 +152,29 @@ export default function EnrollmentDetailPage() {
         </div>
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
           <div>
-            <span className="text-gray-500">Source</span>
+            <span className="text-muted-foreground">Source</span>
             <p>{ENROLLMENT_SOURCE_LABELS[enrollment.enrollment_source as keyof typeof ENROLLMENT_SOURCE_LABELS] || enrollment.enrollment_source}</p>
           </div>
           <div>
-            <span className="text-gray-500">Enrolled</span>
+            <span className="text-muted-foreground">Enrolled</span>
             <p>{new Date(enrollment.enrolled_at).toLocaleDateString()}</p>
           </div>
           <div>
-            <span className="text-gray-500">Deadline</span>
+            <span className="text-muted-foreground">Deadline</span>
             <p className={daysLeft <= 7 ? 'text-red-400' : ''}>{new Date(enrollment.deadline_at).toLocaleDateString()} ({daysLeft}d left)</p>
           </div>
           <div>
-            <span className="text-gray-500">Purchase</span>
+            <span className="text-muted-foreground">Purchase</span>
             <p>{enrollment.purchase_amount ? `$${enrollment.purchase_amount}` : '—'}</p>
           </div>
         </div>
         <div className="mt-4">
           <div className="flex items-center justify-between text-sm mb-1">
-            <span className="text-gray-400">Overall Progress</span>
+            <span className="text-muted-foreground">Overall Progress</span>
             <span className="font-medium">{overallProgress}%</span>
           </div>
-          <div className="h-3 bg-gray-700 rounded-full overflow-hidden">
-            <div className="h-full bg-amber-500 rounded-full transition-all" style={{ width: `${overallProgress}%` }} />
+          <div className="h-3 overflow-hidden rounded-full bg-silicon-slate/70">
+            <div className="h-full rounded-full bg-radiant-gold transition-all" style={{ width: `${overallProgress}%` }} />
           </div>
         </div>
       </div>
@@ -182,20 +186,22 @@ export default function EnrollmentDetailPage() {
           const progress = progressMap.get(c.id);
           const pStatus = (progress?.status || 'pending') as ProgressStatus;
           return (
-            <div key={c.id} className="p-4 bg-gray-900 border border-gray-700 rounded-xl">
-              <div className="flex items-center justify-between mb-2">
-                <div className="flex items-center gap-3">
-                  <span className="text-xs text-gray-500">#{i + 1}</span>
-                  <span className="font-medium">{c.label}</span>
+            <div key={c.id} className="admin-console-card rounded-lg border p-4">
+              <div className="mb-2 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                <div className="min-w-0 flex-1">
+                  <div className="flex min-w-0 flex-wrap items-center gap-3">
+                  <span className="text-xs text-muted-foreground">#{i + 1}</span>
+                  <span className="min-w-0 break-words font-medium">{c.label}</span>
                   {c.required && <span className="text-xs text-red-400">Required</span>}
                   <span className={`px-2 py-0.5 text-xs rounded-full border ${PROGRESS_STATUS_COLORS[pStatus]}`}>
                     {PROGRESS_STATUS_LABELS[pStatus]}
                   </span>
+                  </div>
                 </div>
-                {c.target_value && <span className="text-sm text-gray-400">Target: {c.target_value}</span>}
+                {c.target_value && <span className="text-sm text-muted-foreground">Target: {c.target_value}</span>}
               </div>
-              {c.description && <p className="text-sm text-gray-400 mb-2">{c.description}</p>}
-              <div className="flex items-center gap-3 text-xs text-gray-500 mb-3">
+              {c.description && <p className="mb-2 text-sm text-muted-foreground">{c.description}</p>}
+              <div className="mb-3 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
                 <span>{CRITERIA_TYPE_LABELS[c.criteria_type as keyof typeof CRITERIA_TYPE_LABELS]}</span>
                 <span>{TRACKING_SOURCE_LABELS[c.tracking_source as keyof typeof TRACKING_SOURCE_LABELS]}</span>
                 {progress?.auto_tracked && <span className="text-blue-400">Auto-tracked</span>}
@@ -203,44 +209,44 @@ export default function EnrollmentDetailPage() {
 
               {/* Client evidence */}
               {progress?.client_evidence && (
-                <div className="mb-3 p-3 bg-gray-800 rounded-lg">
-                  <div className="flex items-center gap-1 text-xs text-gray-400 mb-1">
+                <div className="mb-3 rounded-lg border border-white/10 bg-silicon-slate/40 p-3">
+                  <div className="mb-1 flex items-center gap-1 text-xs text-muted-foreground">
                     <MessageSquare size={12} /> Client evidence ({progress.client_submitted_at ? new Date(progress.client_submitted_at).toLocaleDateString() : ''})
                   </div>
                   <p className="text-sm">{progress.client_evidence}</p>
-                  {progress.current_value && <p className="text-sm text-gray-400 mt-1">Current value: {progress.current_value}</p>}
+                  {progress.current_value && <p className="mt-1 text-sm text-muted-foreground">Current value: {progress.current_value}</p>}
                 </div>
               )}
 
               {/* Admin verification */}
               {progress?.admin_verified_at && (
-                <div className="mb-3 p-3 bg-gray-800 rounded-lg">
-                  <div className="text-xs text-gray-400 mb-1">Admin verified: {new Date(progress.admin_verified_at).toLocaleDateString()}</div>
+                <div className="mb-3 rounded-lg border border-white/10 bg-silicon-slate/40 p-3">
+                  <div className="mb-1 text-xs text-muted-foreground">Admin verified: {new Date(progress.admin_verified_at).toLocaleDateString()}</div>
                   {progress.admin_notes && <p className="text-sm">{progress.admin_notes}</p>}
                 </div>
               )}
 
               {/* Verify buttons */}
               {!isTerminal && pStatus !== 'met' && pStatus !== 'waived' && (
-                <div className="flex items-center gap-2">
+                <div className="flex flex-wrap items-center gap-2">
                   <button
                     onClick={() => handleVerify(c.id, 'met')}
                     disabled={verifyingId === c.id}
-                    className="flex items-center gap-1 px-3 py-1 text-xs bg-green-600/20 text-green-300 border border-green-500/50 rounded-lg hover:bg-green-600/30"
+                    className="flex items-center gap-1 rounded-lg border border-green-500/50 bg-green-600/20 px-3 py-1 text-xs text-green-300 hover:bg-green-600/30"
                   >
                     <CheckCircle2 size={12} /> Mark Met
                   </button>
                   <button
                     onClick={() => handleVerify(c.id, 'not_met')}
                     disabled={verifyingId === c.id}
-                    className="flex items-center gap-1 px-3 py-1 text-xs bg-red-600/20 text-red-300 border border-red-500/50 rounded-lg hover:bg-red-600/30"
+                    className="flex items-center gap-1 rounded-lg border border-red-500/50 bg-red-600/20 px-3 py-1 text-xs text-red-300 hover:bg-red-600/30"
                   >
                     <XCircle size={12} /> Not Met
                   </button>
                   <button
                     onClick={() => handleVerify(c.id, 'waived')}
                     disabled={verifyingId === c.id}
-                    className="flex items-center gap-1 px-3 py-1 text-xs bg-yellow-600/20 text-yellow-300 border border-yellow-500/50 rounded-lg hover:bg-yellow-600/30"
+                    className="flex items-center gap-1 rounded-lg border border-radiant-gold/40 bg-radiant-gold/10 px-3 py-1 text-xs text-radiant-gold hover:bg-radiant-gold/20"
                   >
                     <Shield size={12} /> Waive
                   </button>
@@ -253,7 +259,7 @@ export default function EnrollmentDetailPage() {
 
       {/* Resolve Payout */}
       {enrollment.status === 'criteria_met' && (
-        <div className="p-6 bg-gradient-to-r from-green-900/30 to-amber-900/30 border border-green-500/50 rounded-xl">
+        <div className="admin-console-card rounded-lg border border-green-500/40 p-6">
           <h3 className="text-lg font-semibold flex items-center gap-2 mb-3">
             <DollarSign size={20} className="text-green-400" />
             All Criteria Met — Resolve Payout
@@ -261,14 +267,14 @@ export default function EnrollmentDetailPage() {
           <p className="text-sm text-gray-300 mb-4">
             Campaign payout type: <strong>{enrollment.attraction_campaigns?.payout_type}</strong>. Choose how to resolve:
           </p>
-          <div className="flex items-center gap-3">
-            <button onClick={() => handleResolve('refund')} disabled={resolving} className="px-4 py-2 bg-green-600 hover:bg-green-500 disabled:opacity-50 rounded-lg text-sm">
+          <div className="flex flex-wrap items-center gap-3">
+            <button onClick={() => handleResolve('refund')} disabled={resolving} className="rounded-lg bg-green-600 px-4 py-2 text-sm hover:bg-green-500 disabled:opacity-50">
               Issue Refund
             </button>
-            <button onClick={() => handleResolve('credit')} disabled={resolving} className="px-4 py-2 bg-purple-600 hover:bg-purple-500 disabled:opacity-50 rounded-lg text-sm">
+            <button onClick={() => handleResolve('credit')} disabled={resolving} className="admin-console-button-secondary disabled:opacity-50">
               Issue Credit
             </button>
-            <button onClick={() => handleResolve('rollover_upsell')} disabled={resolving} className="px-4 py-2 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 rounded-lg text-sm">
+            <button onClick={() => handleResolve('rollover_upsell')} disabled={resolving} className="admin-console-button-primary disabled:opacity-50">
               Rollover to Upsell
             </button>
           </div>
@@ -276,20 +282,21 @@ export default function EnrollmentDetailPage() {
       )}
 
       {enrollment.status === 'payout_pending' && (
-        <div className="p-4 bg-yellow-900/30 border border-yellow-500/50 rounded-xl">
+        <div className="admin-console-card rounded-lg border border-radiant-gold/40 p-4">
           <p className="text-sm text-yellow-300 flex items-center gap-2">
             <Clock size={16} /> Client has chosen their payout. {enrollment.resolution_notes}
           </p>
-          <div className="flex items-center gap-3 mt-3">
-            <button onClick={() => handleResolve('refund')} disabled={resolving} className="px-4 py-2 bg-green-600 hover:bg-green-500 disabled:opacity-50 rounded-lg text-sm">
+          <div className="mt-3 flex flex-wrap items-center gap-3">
+            <button onClick={() => handleResolve('refund')} disabled={resolving} className="rounded-lg bg-green-600 px-4 py-2 text-sm hover:bg-green-500 disabled:opacity-50">
               Process Refund
             </button>
-            <button onClick={() => handleResolve('credit')} disabled={resolving} className="px-4 py-2 bg-purple-600 hover:bg-purple-500 disabled:opacity-50 rounded-lg text-sm">
+            <button onClick={() => handleResolve('credit')} disabled={resolving} className="admin-console-button-secondary disabled:opacity-50">
               Process Credit
             </button>
           </div>
         </div>
       )}
+      </div>
     </div>
   );
 }

--- a/app/admin/campaigns/[id]/page.tsx
+++ b/app/admin/campaigns/[id]/page.tsx
@@ -190,17 +190,21 @@ export default function CampaignDetailPage() {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-gray-950 text-white flex items-center justify-center">
-        <Loader2 size={32} className="animate-spin text-gray-400" />
+      <div className="admin-console-page min-h-screen flex items-center justify-center text-foreground">
+        <Loader2 size={32} className="animate-spin text-muted-foreground" />
       </div>
     );
   }
 
   if (!campaign) {
     return (
-      <div className="min-h-screen bg-gray-950 text-white p-6">
-        <p className="text-gray-400">Campaign not found.</p>
-        <Link href={backUrl} className="text-amber-400 hover:underline mt-2 inline-block">Back</Link>
+      <div className="admin-console-page min-h-screen px-4 py-6 text-foreground sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-7xl">
+          <div className="admin-console-card rounded-lg border p-6">
+            <p className="text-muted-foreground">Campaign not found.</p>
+            <Link href={backUrl} className="admin-console-button-secondary mt-4 inline-flex">Back</Link>
+          </div>
+        </div>
       </div>
     );
   }
@@ -212,7 +216,8 @@ export default function CampaignDetailPage() {
   ];
 
   return (
-    <div className="min-h-screen bg-gray-950 text-white p-6">
+    <div className="admin-console-page min-h-screen px-4 py-6 text-foreground sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl">
       <Breadcrumbs items={[
         { label: 'Admin', href: '/admin' },
         { label: 'Campaigns', href: '/admin/campaigns' },
@@ -220,41 +225,42 @@ export default function CampaignDetailPage() {
       ]} />
 
       {/* Header */}
-      <div className="mb-8">
-        <Link href={backUrl} className="text-gray-400 hover:text-white text-sm flex items-center gap-1 mb-4">
+      <div className="admin-console-surface-header mb-6 mt-4 rounded-xl border p-5 sm:p-6">
+        <Link href={backUrl} className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground">
           <ArrowLeft size={14} /> Back
         </Link>
-        <div className="flex items-center gap-4">
-          <h1 className="text-3xl font-bold">{campaign.name}</h1>
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="admin-console-eyebrow w-full">Campaign Detail</div>
+          <h1 className="text-3xl font-bold tracking-tight">{campaign.name}</h1>
           <span className={`px-3 py-1 text-sm rounded-full border ${CAMPAIGN_STATUS_COLORS[campaign.status]}`}>
             {CAMPAIGN_STATUS_LABELS[campaign.status]}
           </span>
-          <span className="px-3 py-1 text-sm rounded-full bg-gray-700 text-gray-300">
+          <span className="rounded-full border border-white/10 bg-silicon-slate/50 px-3 py-1 text-sm text-muted-foreground">
             {CAMPAIGN_TYPE_LABELS[campaign.campaign_type]}
           </span>
         </div>
-        {campaign.description && <p className="text-gray-400 mt-2">{campaign.description}</p>}
-        <div className="flex items-center gap-6 mt-3 text-sm text-gray-400">
+        {campaign.description && <p className="mt-2 max-w-3xl text-muted-foreground">{campaign.description}</p>}
+        <div className="mt-4 flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
           <span className="flex items-center gap-1"><Clock size={14} /> {campaign.completion_window_days} day window</span>
           <span className="flex items-center gap-1"><Calendar size={14} /> {campaign.starts_at ? new Date(campaign.starts_at).toLocaleDateString() : '—'} to {campaign.ends_at ? new Date(campaign.ends_at).toLocaleDateString() : '—'}</span>
         </div>
       </div>
 
       {/* Tabs */}
-      <div className="flex gap-1 mb-6 border-b border-gray-700">
+      <div className="admin-console-card mb-6 flex gap-1 overflow-x-auto rounded-lg border p-1">
         {tabs.map((tab) => (
           <button
             key={tab.key}
             onClick={() => setActiveTab(tab.key)}
-            className={`flex items-center gap-2 px-4 py-3 text-sm font-medium border-b-2 transition-colors ${
+            className={`flex items-center gap-2 rounded-md px-4 py-3 text-sm font-medium transition-colors ${
               activeTab === tab.key
-                ? 'border-amber-400 text-amber-400'
-                : 'border-transparent text-gray-400 hover:text-white'
+                ? 'bg-radiant-gold text-imperial-navy'
+                : 'text-muted-foreground hover:bg-silicon-slate/60 hover:text-foreground'
             }`}
           >
             <tab.icon size={16} />
             {tab.label}
-            <span className="px-1.5 py-0.5 text-xs bg-gray-700 rounded-full">{tab.count}</span>
+            <span className="rounded-full border border-current/20 px-1.5 py-0.5 text-xs">{tab.count}</span>
           </button>
         ))}
       </div>
@@ -264,50 +270,50 @@ export default function CampaignDetailPage() {
         <div>
           <div className="flex items-center justify-between mb-4">
             <h2 className="text-xl font-semibold">Criteria Templates</h2>
-            <button onClick={() => setShowCriteriaForm(!showCriteriaForm)} className="flex items-center gap-1 px-3 py-1.5 bg-amber-600 hover:bg-amber-500 rounded-lg text-sm">
+            <button onClick={() => setShowCriteriaForm(!showCriteriaForm)} className={showCriteriaForm ? 'admin-console-button-secondary' : 'admin-console-button-primary'}>
               {showCriteriaForm ? <X size={14} /> : <Plus size={14} />}
               {showCriteriaForm ? 'Cancel' : 'Add Criterion'}
             </button>
           </div>
 
           {showCriteriaForm && (
-            <div className="mb-6 p-4 bg-gray-900 border border-gray-700 rounded-xl space-y-3">
+            <div className="admin-console-card mb-6 space-y-3 rounded-lg border p-4">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                 <div className="md:col-span-2">
-                  <label className="block text-xs text-gray-400 mb-1">Label Template *</label>
+                  <label className="mb-1 block text-xs text-muted-foreground">Label Template *</label>
                   <input type="text" value={criteriaForm.label_template} onChange={(e) => setCriteriaForm({ ...criteriaForm, label_template: e.target.value })}
-                    className="w-full px-3 py-2 bg-gray-800 border border-gray-600 rounded-lg text-white text-sm" placeholder='Achieve {{revenue_target}} monthly revenue' />
+                    className="w-full rounded-lg border border-white/10 bg-silicon-slate/50 px-3 py-2 text-sm text-foreground" placeholder='Achieve {{revenue_target}} monthly revenue' />
                 </div>
                 <div>
-                  <label className="block text-xs text-gray-400 mb-1">Type</label>
+                  <label className="mb-1 block text-xs text-muted-foreground">Type</label>
                   <select value={criteriaForm.criteria_type} onChange={(e) => setCriteriaForm({ ...criteriaForm, criteria_type: e.target.value as CriteriaType })}
-                    className="w-full px-3 py-2 bg-gray-800 border border-gray-600 rounded-lg text-white text-sm">
+                    className="w-full rounded-lg border border-white/10 bg-silicon-slate/50 px-3 py-2 text-sm text-foreground">
                     {Object.entries(CRITERIA_TYPE_LABELS).map(([k, v]) => <option key={k} value={k}>{v}</option>)}
                   </select>
                 </div>
                 <div>
-                  <label className="block text-xs text-gray-400 mb-1">Tracking Source</label>
+                  <label className="mb-1 block text-xs text-muted-foreground">Tracking Source</label>
                   <select value={criteriaForm.tracking_source} onChange={(e) => setCriteriaForm({ ...criteriaForm, tracking_source: e.target.value as TrackingSource })}
-                    className="w-full px-3 py-2 bg-gray-800 border border-gray-600 rounded-lg text-white text-sm">
+                    className="w-full rounded-lg border border-white/10 bg-silicon-slate/50 px-3 py-2 text-sm text-foreground">
                     {Object.entries(TRACKING_SOURCE_LABELS).map(([k, v]) => <option key={k} value={k}>{v}</option>)}
                   </select>
                 </div>
                 <div>
-                  <label className="block text-xs text-gray-400 mb-1">Threshold Source</label>
+                  <label className="mb-1 block text-xs text-muted-foreground">Threshold Source</label>
                   <input type="text" value={criteriaForm.threshold_source} onChange={(e) => setCriteriaForm({ ...criteriaForm, threshold_source: e.target.value })}
-                    className="w-full px-3 py-2 bg-gray-800 border border-gray-600 rounded-lg text-white text-sm" placeholder="audit.desired_monthly_revenue" />
+                    className="w-full rounded-lg border border-white/10 bg-silicon-slate/50 px-3 py-2 text-sm text-foreground" placeholder="audit.desired_monthly_revenue" />
                 </div>
                 <div>
-                  <label className="block text-xs text-gray-400 mb-1">Threshold Default</label>
+                  <label className="mb-1 block text-xs text-muted-foreground">Threshold Default</label>
                   <input type="text" value={criteriaForm.threshold_default} onChange={(e) => setCriteriaForm({ ...criteriaForm, threshold_default: e.target.value })}
-                    className="w-full px-3 py-2 bg-gray-800 border border-gray-600 rounded-lg text-white text-sm" placeholder="50000" />
+                    className="w-full rounded-lg border border-white/10 bg-silicon-slate/50 px-3 py-2 text-sm text-foreground" placeholder="50000" />
                 </div>
                 <div className="flex items-center gap-2">
                   <input type="checkbox" checked={criteriaForm.required} onChange={(e) => setCriteriaForm({ ...criteriaForm, required: e.target.checked })} className="rounded" />
-                  <label className="text-sm text-gray-300">Required</label>
+                  <label className="text-sm text-muted-foreground">Required</label>
                 </div>
               </div>
-              <button onClick={handleAddCriterion} disabled={!criteriaForm.label_template.trim()} className="px-4 py-1.5 bg-amber-600 hover:bg-amber-500 disabled:opacity-50 rounded-lg text-sm">
+              <button onClick={handleAddCriterion} disabled={!criteriaForm.label_template.trim()} className="admin-console-button-primary disabled:cursor-not-allowed disabled:opacity-50">
                 Add Criterion
               </button>
             </div>
@@ -315,25 +321,29 @@ export default function CampaignDetailPage() {
 
           <div className="space-y-3">
             {campaign.campaign_criteria_templates.length === 0 ? (
-              <p className="text-gray-500 text-center py-8">No criteria templates yet. Add criteria that clients must meet.</p>
+              <p className="admin-console-card rounded-lg border py-8 text-center text-muted-foreground">No criteria templates yet. Add criteria that clients must meet.</p>
             ) : (
               campaign.campaign_criteria_templates
                 .sort((a, b) => a.display_order - b.display_order)
                 .map((ct, i) => (
-                  <div key={ct.id} className="p-4 bg-gray-900 border border-gray-700 rounded-lg flex items-center justify-between">
-                    <div>
-                      <div className="flex items-center gap-2 mb-1">
+                  <div key={ct.id} className="admin-console-card flex flex-col gap-3 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="min-w-0">
+                      <div className="mb-1 flex min-w-0 flex-wrap items-center gap-2">
                         <span className="text-xs text-gray-500">#{i + 1}</span>
-                        <span className="font-medium">{ct.label_template}</span>
+                        <span className="min-w-0 break-words font-medium">{ct.label_template}</span>
                         {ct.required && <span className="text-xs text-red-400">Required</span>}
                       </div>
-                      <div className="flex items-center gap-3 text-xs text-gray-400">
+                      <div className="flex min-w-0 flex-wrap items-center gap-3 text-xs text-gray-400">
                         <span>{CRITERIA_TYPE_LABELS[ct.criteria_type]}</span>
                         <span>{TRACKING_SOURCE_LABELS[ct.tracking_source]}</span>
-                        {ct.threshold_source && <span>Source: {ct.threshold_source}</span>}
+                        {ct.threshold_source && <span className="break-all">Source: {ct.threshold_source}</span>}
                       </div>
                     </div>
-                    <button onClick={() => handleDeleteCriterion(ct.id)} className="p-1.5 text-gray-500 hover:text-red-400 transition-colors">
+                    <button
+                      onClick={() => handleDeleteCriterion(ct.id)}
+                      aria-label={`Delete criterion ${ct.label_template}`}
+                      className="self-start rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-red-500/10 hover:text-red-300 sm:self-center"
+                    >
                       <Trash2 size={16} />
                     </button>
                   </div>
@@ -348,25 +358,25 @@ export default function CampaignDetailPage() {
         <div>
           <div className="flex items-center justify-between mb-4">
             <h2 className="text-xl font-semibold">Eligible Bundles</h2>
-            <button onClick={() => setShowBundleForm(!showBundleForm)} className="flex items-center gap-1 px-3 py-1.5 bg-amber-600 hover:bg-amber-500 rounded-lg text-sm">
+            <button onClick={() => setShowBundleForm(!showBundleForm)} className={showBundleForm ? 'admin-console-button-secondary' : 'admin-console-button-primary'}>
               {showBundleForm ? <X size={14} /> : <Plus size={14} />}
               {showBundleForm ? 'Cancel' : 'Add Bundle'}
             </button>
           </div>
 
           {showBundleForm && (
-            <div className="mb-6 p-4 bg-gray-900 border border-gray-700 rounded-xl flex items-end gap-3">
+            <div className="admin-console-card mb-6 flex flex-col gap-3 rounded-lg border p-4 sm:flex-row sm:items-end">
               <div className="flex-1">
-                <label className="block text-xs text-gray-400 mb-1">Bundle</label>
+                <label className="mb-1 block text-xs text-muted-foreground">Bundle</label>
                 <select value={selectedBundleId} onChange={(e) => setSelectedBundleId(e.target.value)}
-                  className="w-full px-3 py-2 bg-gray-800 border border-gray-600 rounded-lg text-white text-sm">
+                  className="w-full rounded-lg border border-white/10 bg-silicon-slate/50 px-3 py-2 text-sm text-foreground">
                   <option value="">Select a bundle...</option>
                   {availableBundles.map((b) => (
                     <option key={b.id} value={b.id}>{b.name} {b.pricing_tier_slug ? `(${b.pricing_tier_slug})` : ''} — ${b.bundle_price}</option>
                   ))}
                 </select>
               </div>
-              <button onClick={handleAddBundle} disabled={!selectedBundleId} className="px-4 py-2 bg-amber-600 hover:bg-amber-500 disabled:opacity-50 rounded-lg text-sm">
+              <button onClick={handleAddBundle} disabled={!selectedBundleId} className="admin-console-button-primary disabled:cursor-not-allowed disabled:opacity-50">
                 Add
               </button>
             </div>
@@ -374,18 +384,22 @@ export default function CampaignDetailPage() {
 
           <div className="space-y-3">
             {campaign.campaign_eligible_bundles.length === 0 ? (
-              <p className="text-gray-500 text-center py-8">No eligible bundles yet. Add bundles that qualify for this campaign.</p>
+              <p className="admin-console-card rounded-lg border py-8 text-center text-muted-foreground">No eligible bundles yet. Add bundles that qualify for this campaign.</p>
             ) : (
               campaign.campaign_eligible_bundles.map((eb) => (
-                <div key={eb.id} className="p-4 bg-gray-900 border border-gray-700 rounded-lg flex items-center justify-between">
-                  <div>
-                    <span className="font-medium">{eb.offer_bundles?.name || 'Unknown bundle'}</span>
-                    <div className="flex items-center gap-3 text-xs text-gray-400 mt-1">
+                <div key={eb.id} className="admin-console-card flex flex-col gap-3 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="min-w-0">
+                    <span className="block min-w-0 break-words font-medium">{eb.offer_bundles?.name || 'Unknown bundle'}</span>
+                    <div className="mt-1 flex min-w-0 flex-wrap items-center gap-3 text-xs text-gray-400">
                       {eb.offer_bundles?.pricing_tier_slug && <span>Tier: {eb.offer_bundles.pricing_tier_slug}</span>}
                       {eb.offer_bundles?.bundle_price != null && <span>${eb.offer_bundles.bundle_price}</span>}
                     </div>
                   </div>
-                  <button onClick={() => handleRemoveBundle(eb.bundle_id)} className="p-1.5 text-gray-500 hover:text-red-400 transition-colors">
+                  <button
+                    onClick={() => handleRemoveBundle(eb.bundle_id)}
+                    aria-label={`Remove bundle ${eb.offer_bundles?.name || eb.bundle_id}`}
+                    className="self-start rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-red-500/10 hover:text-red-300 sm:self-center"
+                  >
                     <Trash2 size={16} />
                   </button>
                 </div>
@@ -400,14 +414,14 @@ export default function CampaignDetailPage() {
         <div>
           <div className="flex items-center justify-between mb-4">
             <h2 className="text-xl font-semibold">Enrollments</h2>
-            <button onClick={() => setShowEnrollForm(!showEnrollForm)} className="flex items-center gap-1 px-3 py-1.5 bg-amber-600 hover:bg-amber-500 rounded-lg text-sm">
+            <button onClick={() => setShowEnrollForm(!showEnrollForm)} className={showEnrollForm ? 'admin-console-button-secondary' : 'admin-console-button-primary'}>
               {showEnrollForm ? <X size={14} /> : <UserPlus size={14} />}
               {showEnrollForm ? 'Cancel' : 'Enroll Client'}
             </button>
           </div>
 
           {showEnrollForm && (
-            <div className="mb-6 p-4 bg-gray-900 border border-gray-700 rounded-xl space-y-3">
+            <div className="admin-console-card mb-6 space-y-3 rounded-lg border p-4">
               {enrollError && (
                 <div className="flex items-center gap-2 p-3 bg-red-900/30 border border-red-500/50 rounded-lg text-sm text-red-300">
                   <AlertCircle size={16} /> {enrollError}
@@ -415,18 +429,18 @@ export default function CampaignDetailPage() {
               )}
               <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                 <div>
-                  <label className="block text-xs text-gray-400 mb-1">Client Email *</label>
+                  <label className="mb-1 block text-xs text-muted-foreground">Client Email *</label>
                   <input type="email" value={enrollForm.client_email} onChange={(e) => setEnrollForm({ ...enrollForm, client_email: e.target.value })}
-                    className="w-full px-3 py-2 bg-gray-800 border border-gray-600 rounded-lg text-white text-sm" placeholder="client@example.com" />
+                    className="w-full rounded-lg border border-white/10 bg-silicon-slate/50 px-3 py-2 text-sm text-foreground" placeholder="client@example.com" />
                 </div>
                 <div>
-                  <label className="block text-xs text-gray-400 mb-1">Client Name</label>
+                  <label className="mb-1 block text-xs text-muted-foreground">Client Name</label>
                   <input type="text" value={enrollForm.client_name} onChange={(e) => setEnrollForm({ ...enrollForm, client_name: e.target.value })}
-                    className="w-full px-3 py-2 bg-gray-800 border border-gray-600 rounded-lg text-white text-sm" placeholder="John Doe" />
+                    className="w-full rounded-lg border border-white/10 bg-silicon-slate/50 px-3 py-2 text-sm text-foreground" placeholder="John Doe" />
                 </div>
               </div>
-              <p className="text-xs text-gray-500">Client must have completed the AI Audit Calculator. The system will look up their audit data by email.</p>
-              <button onClick={handleEnroll} disabled={!enrollForm.client_email.trim()} className="px-4 py-1.5 bg-amber-600 hover:bg-amber-500 disabled:opacity-50 rounded-lg text-sm">
+              <p className="text-xs text-muted-foreground">Client must have completed the AI Audit Calculator. The system will look up their audit data by email.</p>
+              <button onClick={handleEnroll} disabled={!enrollForm.client_email.trim()} className="admin-console-button-primary disabled:cursor-not-allowed disabled:opacity-50">
                 Enroll
               </button>
             </div>
@@ -434,13 +448,13 @@ export default function CampaignDetailPage() {
 
           <div className="space-y-3">
             {enrollments.length === 0 ? (
-              <p className="text-gray-500 text-center py-8">No enrollments yet.</p>
+              <p className="admin-console-card rounded-lg border py-8 text-center text-muted-foreground">No enrollments yet.</p>
             ) : (
               enrollments.map((e) => {
                 const progress = calculateOverallProgress(e.campaign_progress || []);
                 return (
                   <Link key={e.id} href={buildLinkWithReturn(`/admin/campaigns/${campaignId}/enrollments/${e.id}`, `/admin/campaigns/${campaignId}`)}>
-                    <motion.div whileHover={{ scale: 1.002 }} className="p-4 bg-gray-900 border border-gray-700 rounded-lg hover:border-amber-500/50 transition-colors cursor-pointer">
+                    <motion.div whileHover={{ scale: 1.002 }} className="admin-console-card admin-console-interactive cursor-pointer rounded-lg border p-4 transition-colors">
                       <div className="flex items-center justify-between">
                         <div className="flex-1">
                           <div className="flex items-center gap-3 mb-1">
@@ -448,21 +462,21 @@ export default function CampaignDetailPage() {
                             <span className={`px-2 py-0.5 text-xs rounded-full border ${ENROLLMENT_STATUS_COLORS[e.status as keyof typeof ENROLLMENT_STATUS_COLORS] || ''}`}>
                               {ENROLLMENT_STATUS_LABELS[e.status as keyof typeof ENROLLMENT_STATUS_LABELS] || e.status}
                             </span>
-                            <span className="text-xs text-gray-500">{ENROLLMENT_SOURCE_LABELS[e.enrollment_source as keyof typeof ENROLLMENT_SOURCE_LABELS] || e.enrollment_source}</span>
+                            <span className="text-xs text-muted-foreground">{ENROLLMENT_SOURCE_LABELS[e.enrollment_source as keyof typeof ENROLLMENT_SOURCE_LABELS] || e.enrollment_source}</span>
                           </div>
-                          <div className="flex items-center gap-4 text-xs text-gray-400">
+                          <div className="flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
                             <span>{e.client_email}</span>
                             <span>Enrolled: {new Date(e.enrolled_at).toLocaleDateString()}</span>
                             <span>Deadline: {new Date(e.deadline_at).toLocaleDateString()}</span>
                           </div>
                           <div className="mt-2 flex items-center gap-2">
-                            <div className="flex-1 h-2 bg-gray-700 rounded-full overflow-hidden">
-                              <div className="h-full bg-amber-500 rounded-full transition-all" style={{ width: `${progress}%` }} />
+                            <div className="h-2 flex-1 overflow-hidden rounded-full bg-silicon-slate/70">
+                              <div className="h-full rounded-full bg-radiant-gold transition-all" style={{ width: `${progress}%` }} />
                             </div>
-                            <span className="text-xs text-gray-400">{progress}%</span>
+                            <span className="text-xs text-muted-foreground">{progress}%</span>
                           </div>
                         </div>
-                        <ChevronRight size={20} className="text-gray-500" />
+                        <ChevronRight size={20} className="text-muted-foreground" />
                       </div>
                     </motion.div>
                   </Link>
@@ -472,6 +486,7 @@ export default function CampaignDetailPage() {
           </div>
         </div>
       )}
+      </div>
     </div>
   );
 }

--- a/app/admin/outreach/escalations/[id]/page.tsx
+++ b/app/admin/outreach/escalations/[id]/page.tsx
@@ -131,7 +131,7 @@ function EscalationDetailContent() {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-background p-6">
+      <div className="admin-console-page min-h-screen p-6 text-foreground">
         <div className="flex items-center justify-center py-12">
           <RefreshCw size={32} className="animate-spin text-muted-foreground" />
         </div>
@@ -141,12 +141,14 @@ function EscalationDetailContent() {
 
   if (!escalation) {
     return (
-      <div className="min-h-screen bg-background p-6">
+      <div className="admin-console-page min-h-screen p-6 text-foreground">
         <div className="max-w-4xl mx-auto">
-          <p className="text-muted-foreground">Escalation not found.</p>
-          <Link href={backUrl} className="mt-4 inline-flex items-center gap-2 text-radiant-gold hover:text-amber-400">
+          <div className="admin-console-card rounded-lg border p-6">
+            <p className="text-muted-foreground">Escalation not found.</p>
+          <Link href={backUrl} className="admin-console-button-secondary mt-4 inline-flex">
             <ArrowLeft size={16} /> Back
           </Link>
+          </div>
         </div>
       </div>
     )
@@ -155,7 +157,7 @@ function EscalationDetailContent() {
   const linkedLead = escalation.contact_submissions
 
   return (
-    <div className="min-h-screen bg-background p-6">
+    <div className="admin-console-page min-h-screen px-4 py-6 text-foreground sm:px-6 lg:px-8">
       <div className="max-w-4xl mx-auto">
         <Breadcrumbs
           items={[
@@ -169,7 +171,7 @@ function EscalationDetailContent() {
         <div className="mt-6 flex items-center justify-between">
           <Link
             href={backUrl}
-            className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors"
+            className="inline-flex items-center gap-2 text-muted-foreground transition-colors hover:text-foreground"
           >
             <ArrowLeft size={18} />
             Back
@@ -177,11 +179,12 @@ function EscalationDetailContent() {
         </div>
 
         <div className="mt-8 space-y-6">
-          <div className="p-4 rounded-lg border border-silicon-slate bg-silicon-slate/30">
-            <h1 className="text-xl font-semibold flex items-center gap-2">
-              <AlertTriangle size={22} className="text-orange-400" />
-              Chat escalation
-            </h1>
+          <div className="admin-console-surface-header rounded-xl border p-5 sm:p-6">
+            <div className="admin-console-eyebrow mb-2 flex items-center gap-2">
+              <AlertTriangle size={16} className="text-radiant-gold" />
+              Outreach Escalation
+            </div>
+            <h1 className="text-2xl font-semibold tracking-tight">Chat escalation #{escalation.id}</h1>
             <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
               <div className="flex items-center gap-2 text-muted-foreground">
                 <User size={14} />
@@ -205,7 +208,7 @@ function EscalationDetailContent() {
               </div>
               <div>
                 <span className="text-muted-foreground">Session:</span>{' '}
-                <Link href={`/admin/chat-eval/${escalation.session_id}`} className="text-purple-400 hover:text-purple-300 text-xs">
+                <Link href={`/admin/chat-eval/${escalation.session_id}`} className="text-radiant-gold hover:text-amber-300 text-xs">
                   {escalation.session_id}
                 </Link>
               </div>
@@ -217,13 +220,13 @@ function EscalationDetailContent() {
             </div>
           </div>
 
-          <div className="p-4 rounded-lg border border-silicon-slate bg-silicon-slate/30">
-            <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide mb-2">Link to lead</h2>
+          <div className="admin-console-card rounded-lg border p-4">
+            <h2 className="admin-console-eyebrow mb-2">Link to lead</h2>
             <div className="flex flex-wrap items-center gap-3">
               <select
                 value={linkSelect}
                 onChange={(e) => setLinkSelect(e.target.value)}
-                className="bg-silicon-slate border border-silicon-slate rounded-lg px-3 py-2 text-foreground min-w-[200px]"
+                className="min-w-[200px] rounded-lg border border-white/10 bg-silicon-slate/50 px-3 py-2 text-foreground"
                 disabled={leadsLoading}
               >
                 <option value="">Not linked</option>
@@ -236,14 +239,14 @@ function EscalationDetailContent() {
               <button
                 onClick={handleSaveLink}
                 disabled={saving || (linkSelect === '' ? escalation.contact_submission_id === null : String(escalation.contact_submission_id) === linkSelect)}
-                className="px-4 py-2 bg-radiant-gold text-imperial-navy rounded-lg font-medium hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="admin-console-button-primary disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {saving ? 'Saving…' : 'Save'}
               </button>
               {linkedLead && (
                 <Link
                   href={`/admin/outreach?tab=leads&id=${escalation.contact_submission_id}`}
-                  className="text-sm text-purple-400 hover:text-purple-300"
+                  className="text-sm text-radiant-gold hover:text-amber-300"
                 >
                   View lead →
                 </Link>
@@ -252,12 +255,12 @@ function EscalationDetailContent() {
             {saveError && <p className="mt-2 text-sm text-red-400">{saveError}</p>}
           </div>
 
-          <div className="p-4 rounded-lg border border-silicon-slate bg-silicon-slate/30">
-            <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide mb-2 flex items-center gap-2">
+          <div className="admin-console-card rounded-lg border p-4">
+            <h2 className="admin-console-eyebrow mb-2 flex items-center gap-2">
               <MessageSquare size={14} />
               Transcript
             </h2>
-            <pre className="text-sm text-foreground/90 whitespace-pre-wrap font-sans max-h-[400px] overflow-y-auto p-3 rounded bg-background/50 border border-silicon-slate">
+            <pre className="max-h-[400px] overflow-y-auto whitespace-pre-wrap rounded border border-white/10 bg-background/50 p-3 font-sans text-sm text-foreground/90">
               {escalation.transcript || '(No transcript)'}
             </pre>
           </div>

--- a/app/admin/sales/[auditId]/page.tsx
+++ b/app/admin/sales/[auditId]/page.tsx
@@ -991,7 +991,7 @@ export default function ClientWalkthroughPage() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-background text-foreground flex items-center justify-center">
+      <div className="admin-console-page min-h-screen flex items-center justify-center text-foreground">
         <div className="text-center">
           <RefreshCw className="w-8 h-8 text-gray-500 animate-spin mx-auto mb-3" />
           <p className="text-gray-400">Loading client information...</p>
@@ -1002,7 +1002,7 @@ export default function ClientWalkthroughPage() {
 
   if (error) {
     return (
-      <div className="min-h-screen bg-background text-foreground flex items-center justify-center">
+      <div className="admin-console-page min-h-screen flex items-center justify-center text-foreground">
         <div className="text-center">
           <AlertCircle className="w-12 h-12 text-red-500 mx-auto mb-3" />
           <h2 className="text-lg font-medium text-white mb-2">Error Loading Data</h2>
@@ -1019,8 +1019,8 @@ export default function ClientWalkthroughPage() {
   }
 
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      <div className="max-w-7xl mx-auto px-4 py-6">
+    <div className="admin-console-page min-h-screen text-foreground">
+      <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
         <Breadcrumbs 
           items={[
             { label: 'Admin', href: '/admin' },
@@ -1039,23 +1039,25 @@ export default function ClientWalkthroughPage() {
         </div>
 
         {/* Header */}
-        <div className="flex items-center justify-between mb-6">
+        <div className="admin-console-surface-header mb-6 flex flex-col gap-4 rounded-xl border p-5 lg:flex-row lg:items-center lg:justify-between lg:p-6">
           <div className="flex items-center gap-4">
             <button
               onClick={() => router.push(backUrl)}
-              className="p-2 hover:bg-gray-800 rounded-lg text-gray-400 hover:text-white"
+              aria-label="Back to sales dashboard"
+              className="admin-console-button-muted p-2"
             >
               <ArrowLeft className="w-5 h-5" />
             </button>
             <div>
-              <h1 className="text-xl font-bold text-white">
+              <div className="admin-console-eyebrow mb-2">Sales Call Workbench</div>
+              <h1 className="text-2xl font-bold tracking-tight text-foreground">
                 Sales Call: {contact?.name}
               </h1>
-              <p className="text-gray-400">{contact?.company || contact?.email}</p>
+              <p className="text-muted-foreground">{contact?.company || contact?.email}</p>
             </div>
           </div>
 
-          <div className="flex items-center gap-3">
+          <div className="flex flex-wrap items-center gap-3">
             {isSaving && (
               <span className="text-sm text-gray-400 flex items-center gap-1">
                 <RefreshCw className="w-4 h-4 animate-spin" />
@@ -1072,7 +1074,7 @@ export default function ClientWalkthroughPage() {
                       href={leadDashboardUrl}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="px-3 py-2 bg-blue-600/20 border border-blue-500/50 rounded-lg text-blue-300 text-sm hover:bg-blue-600/30 flex items-center gap-2"
+                      className="admin-console-button-secondary text-sm"
                     >
                       <ExternalLink className="w-4 h-4" />
                       Open dashboard
@@ -1084,7 +1086,7 @@ export default function ClientWalkthroughPage() {
                         setLeadDashboardCopied(true);
                         setTimeout(() => setLeadDashboardCopied(false), 2000);
                       }}
-                      className="px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-gray-300 text-sm hover:bg-gray-700 flex items-center gap-2"
+                      className="admin-console-button-muted text-sm"
                     >
                       <Copy className="w-4 h-4" />
                       {leadDashboardCopied ? 'Copied' : 'Copy link'}
@@ -1115,7 +1117,7 @@ export default function ClientWalkthroughPage() {
                         setIsCreatingLeadDashboard(false);
                       }
                     }}
-                    className="px-3 py-2 bg-blue-600/20 border border-blue-500/50 rounded-lg text-blue-300 text-sm hover:bg-blue-600/30 flex items-center gap-2 disabled:opacity-50"
+                    className="admin-console-button-secondary text-sm disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     {isCreatingLeadDashboard ? (
                       <Loader2 className="w-4 h-4 animate-spin" />
@@ -1132,7 +1134,7 @@ export default function ClientWalkthroughPage() {
             <select
               value={salesSession?.outcome || 'in_progress'}
               onChange={(e) => handleOutcomeChange(e.target.value as SessionOutcome)}
-              className="px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white"
+              className="rounded-lg border border-white/10 bg-silicon-slate/50 px-3 py-2 text-foreground"
             >
               <option value="in_progress">In Progress</option>
               <option value="converted">Converted</option>
@@ -1146,7 +1148,7 @@ export default function ClientWalkthroughPage() {
               <select
                 value={salesSession?.loss_reason || ''}
                 onChange={(e) => handleLossReasonChange(e.target.value || null)}
-                className="px-3 py-2 bg-gray-800 border border-red-700/50 rounded-lg text-white"
+                className="rounded-lg border border-red-500/40 bg-silicon-slate/50 px-3 py-2 text-foreground"
               >
                 <option value="">Select reason...</option>
                 <option value="price">Price Too High</option>
@@ -1163,8 +1165,8 @@ export default function ClientWalkthroughPage() {
         </div>
 
         {/* Funnel Stage */}
-        <div className="bg-gray-900 rounded-lg border border-gray-800 p-4 mb-6">
-          <h3 className="text-sm font-medium text-gray-400 mb-3">Client Stage</h3>
+        <div className="admin-console-card mb-6 rounded-lg border p-4">
+          <h3 className="admin-console-eyebrow mb-3">Client Stage</h3>
           <FunnelStageSelector
             currentStage={salesSession?.funnel_stage || 'prospect'}
             onChange={handleStageChange}
@@ -1175,9 +1177,9 @@ export default function ClientWalkthroughPage() {
           {/* Left Panel - Client Context */}
           <div className="space-y-6">
             {/* Contact Info */}
-            <div className="bg-gray-900 rounded-lg border border-gray-800 p-4">
-              <h3 className="font-medium text-white mb-4 flex items-center gap-2">
-                <User className="w-5 h-5 text-blue-500" />
+            <div className="admin-console-card rounded-lg border p-4">
+              <h3 className="mb-4 flex items-center gap-2 font-medium text-foreground">
+                <User className="w-5 h-5 text-radiant-gold" />
                 Client Information
               </h3>
               

--- a/app/admin/sales/conversation/[sessionId]/page.tsx
+++ b/app/admin/sales/conversation/[sessionId]/page.tsx
@@ -908,7 +908,7 @@ export default function ConversationPage() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-background text-foreground flex items-center justify-center">
+      <div className="admin-console-page min-h-screen flex items-center justify-center text-foreground">
         <div className="text-center">
           <RefreshCw className="w-8 h-8 text-gray-500 animate-spin mx-auto mb-3" />
           <p className="text-gray-400">Loading conversation...</p>
@@ -919,7 +919,7 @@ export default function ConversationPage() {
 
   if (error || !salesSession) {
     return (
-      <div className="min-h-screen bg-background text-foreground flex items-center justify-center">
+      <div className="admin-console-page min-h-screen flex items-center justify-center text-foreground">
         <div className="text-center">
           <AlertCircle className="w-12 h-12 text-red-500 mx-auto mb-3" />
           <h2 className="text-lg font-medium text-white mb-2">Error</h2>
@@ -944,8 +944,8 @@ export default function ConversationPage() {
   /* ================================================================ */
 
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      <div className="max-w-7xl mx-auto px-4 py-6">
+    <div className="admin-console-page min-h-screen text-foreground">
+      <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
         <Breadcrumbs items={[{ label: 'Admin', href: '/admin' }, { label: 'Sales', href: '/admin/sales' }, { label: contact?.name || 'Conversation' }]} />
 
         <div className="mb-4">
@@ -958,19 +958,20 @@ export default function ConversationPage() {
         </div>
 
         {/* Header */}
-        <div className="flex items-center justify-between mb-6">
+        <div className="admin-console-surface-header mb-6 flex flex-col gap-4 rounded-xl border p-5 lg:flex-row lg:items-center lg:justify-between lg:p-6">
           <div className="flex items-center gap-4">
-            <button onClick={() => router.push(backUrl)} className="p-2 hover:bg-gray-800 rounded-lg text-gray-400 hover:text-white">
+            <button onClick={() => router.push(backUrl)} aria-label="Back to sales dashboard" className="admin-console-button-muted p-2">
               <ArrowLeft className="w-5 h-5" />
             </button>
             <div>
-              <h1 className="text-xl font-bold text-white">Conversation: {contact?.name}</h1>
-              <p className="text-gray-400">{contact?.company || contact?.email}</p>
+              <div className="admin-console-eyebrow mb-2">Sales Conversation</div>
+              <h1 className="text-2xl font-bold tracking-tight text-foreground">Conversation: {contact?.name}</h1>
+              <p className="text-muted-foreground">{contact?.company || contact?.email}</p>
             </div>
           </div>
-          <div className="flex items-center gap-3">
+          <div className="flex flex-wrap items-center gap-3">
             {isSaving && <span className="text-sm text-gray-400 flex items-center gap-1"><RefreshCw className="w-4 h-4 animate-spin" /> Saving...</span>}
-            <select value={salesSession.outcome || 'in_progress'} onChange={e => handleOutcomeChange(e.target.value as SessionOutcome)} className="px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white">
+            <select value={salesSession.outcome || 'in_progress'} onChange={e => handleOutcomeChange(e.target.value as SessionOutcome)} className="rounded-lg border border-white/10 bg-silicon-slate/50 px-3 py-2 text-foreground">
               <option value="in_progress">In Progress</option>
               <option value="converted">Converted</option>
               <option value="downsold">Downsold</option>
@@ -981,23 +982,23 @@ export default function ConversationPage() {
         </div>
 
         {/* Funnel Stage */}
-        <div className="bg-gray-900 rounded-lg border border-gray-800 p-4 mb-4">
-          <h3 className="text-sm font-medium text-gray-400 mb-3">Client Stage</h3>
+        <div className="admin-console-card mb-4 rounded-lg border p-4">
+          <h3 className="admin-console-eyebrow mb-3">Client Stage</h3>
           <FunnelStageSelector currentStage={salesSession.funnel_stage || 'prospect'} onChange={handleStageChange} />
         </div>
 
         {/* Context strip: compact contact + expand toggle */}
-        <div className="flex flex-wrap items-center gap-4 py-3 px-4 bg-gray-900 rounded-lg border border-gray-800 mb-4">
+        <div className="admin-console-card mb-4 flex flex-wrap items-center gap-4 rounded-lg border px-4 py-3">
           <div className="flex items-center gap-3 min-w-0 flex-1">
-            <User className="w-4 h-4 text-gray-500 shrink-0" />
-            <span className="text-sm font-medium text-white truncate">{contact?.name || 'Client'}</span>
-            <span className="text-sm text-gray-400 truncate hidden sm:inline">{contact?.email}</span>
-            {contact?.company && <span className="text-xs text-gray-500 truncate hidden md:inline">· {contact.company}</span>}
+            <User className="w-4 h-4 text-radiant-gold shrink-0" />
+            <span className="truncate text-sm font-medium text-foreground">{contact?.name || 'Client'}</span>
+            <span className="hidden truncate text-sm text-muted-foreground sm:inline">{contact?.email}</span>
+            {contact?.company && <span className="hidden truncate text-xs text-muted-foreground md:inline">· {contact.company}</span>}
           </div>
           <button
             type="button"
             onClick={() => setContextExpanded((e) => !e)}
-            className="flex items-center gap-2 px-3 py-1.5 text-sm text-gray-400 hover:text-white bg-gray-800 hover:bg-gray-700 rounded-lg border border-gray-700"
+            className="admin-console-button-muted text-sm"
           >
             {contextExpanded ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
             Context &amp; tools
@@ -1007,7 +1008,7 @@ export default function ConversationPage() {
         {/* Main row: Timeline | Script + objections | Unified offer panel */}
         <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_minmax(0,1.15fr)_minmax(320px,480px)] gap-4 mb-6">
           {/* ---- Col 1: Conversation Timeline ---- */}
-          <div className="bg-gray-900 rounded-lg border border-gray-800 flex flex-col h-[678px] min-h-[320px] overflow-hidden">
+          <div className="admin-console-card flex h-[678px] min-h-[320px] flex-col overflow-hidden rounded-lg border">
             <div className="flex-1 min-h-0 overflow-y-auto p-4">
               {conversationState.responseHistory.length > 0 ? (
                 <ConversationTimeline responses={conversationState.responseHistory} currentStep={0} compact={false} />
@@ -1023,7 +1024,7 @@ export default function ConversationPage() {
 
           {/* ---- Col 2: Script Guide + objection help ---- */}
           <div className="flex flex-col min-h-[320px] max-h-[min(75vh,720px)] xl:max-h-[calc(100vh-10rem)] overflow-hidden">
-            <div className="flex-1 min-h-0 overflow-y-auto bg-gray-900 rounded-lg border border-gray-800 p-6">
+            <div className="admin-console-card min-h-0 flex-1 overflow-y-auto rounded-lg border p-6">
               <div className="flex items-center justify-between gap-2 mb-4">
                 <div className="flex items-center gap-2 min-w-0">
                   <FileText className="w-5 h-5 text-emerald-400 shrink-0" />

--- a/docs/design/amadutown-color-palette-audit.md
+++ b/docs/design/amadutown-color-palette-audit.md
@@ -183,6 +183,11 @@ The Agent Ops Mission Control surface at `/admin/agents` is the current referenc
 - **`app/admin/outreach/dashboard/page.tsx`** — Title gradient orange–green–blue; cold leads from-blue-600 to-cyan-500; orange–purple CTA; blue/purple card gradients.
 - **`app/admin/value-evidence/page.tsx`** — Blue–cyan and purple–pink gradient cards/borders.
 
+### Remediation notes
+
+- **Outreach/Sales L1 slice complete:** `/admin/outreach`, `/admin/outreach/dashboard`, `/admin/sales`, `/admin/lead-dashboards`, and `/admin/campaigns` now use the shared admin console shell/header treatment, with the noisiest sales/outreach gradients replaced by restrained command surfaces.
+- **Outreach/Sales detail slice in progress:** `/admin/campaigns/[id]`, `/admin/campaigns/[id]/enrollments/[enrollmentId]`, `/admin/outreach/escalations/[id]`, `/admin/sales/[auditId]`, and `/admin/sales/conversation/[sessionId]` carry the same console shell, operational headers, command buttons, and muted form/card treatment so the L2/L3 sales workflow no longer falls back to gray SaaS panels.
+
 ### Admin – Client projects, guarantees, analytics, prompts, meeting-tasks, users
 
 - **`app/admin/client-projects/page.tsx`** — Blue–cyan button; progress bar from-blue-500 to-emerald-500.


### PR DESCRIPTION
Summary
- Standardizes the sales/outreach L2 detail surfaces with the shared admin console shell, operational headers, muted cards, and gold command affordances.
- Updates campaign detail, campaign enrollment detail, outreach escalation detail, sales audit, and sales conversation pages.
- Records the detail-slice remediation note in the AmaduTown design audit.

Validation
- npm run lint -- --file app/admin/campaigns/[id]/page.tsx --file app/admin/campaigns/[id]/enrollments/[enrollmentId]/page.tsx --file app/admin/outreach/escalations/[id]/page.tsx --file app/admin/sales/[auditId]/page.tsx --file app/admin/sales/conversation/[sessionId]/page.tsx
- npm run build:knowledge && npx tsc --noEmit --pretty false
- npm run build
- Local Playwright smoke on localhost:3017 for the touched route shells at desktop and mobile widths; no horizontal overflow found. Local data did not expose populated campaign/enrollment/sales/escalation records, so populated-record QA remains recommended on staging.

Integration Notes
- UI-only change. No schema, API, n8n, credential, or outbound workflow changes.
- Build emitted the existing local n8n env warning that outbound webhooks are enabled in this dev environment; no webhook or workflow was invoked.
- Vercel contexts to verify after merge: Vercel – portfolio and Vercel – portfolio-staging.