### PR TITLE
feat: standardize sales subpage admin surfaces

### DIFF
--- a/app/admin/sales/bundles/BundleCard.tsx
+++ b/app/admin/sales/bundles/BundleCard.tsx
@@ -32,35 +32,35 @@ export function BundleCard({ bundle, onView, onEdit, onDuplicate, onDelete }: Bu
   const previewItems = bundle.preview_items || [];
   const hasMoreItems = bundle.item_count > previewItems.length;
   const cardClassName =
-    'bg-gray-900 rounded-lg border ' +
-    (bundle.is_active ? 'border-gray-800' : 'border-gray-700 opacity-60') +
-    ' p-4 hover:border-gray-700 transition-colors';
+    'admin-console-card rounded-lg border ' +
+    (bundle.is_active ? '' : 'opacity-60') +
+    ' p-4 transition-colors admin-console-interactive';
 
   return (
     <div className={cardClassName}>
       <div className="flex items-start justify-between mb-3">
         <div>
-          <h3 className="font-semibold text-white">{bundle.name}</h3>
+          <h3 className="font-semibold text-foreground">{bundle.name}</h3>
           {bundle.parent_name && (
-            <p className="text-xs text-purple-400 flex items-center gap-1 mt-1">
+            <p className="text-xs text-radiant-gold flex items-center gap-1 mt-1">
               <GitFork className="w-3 h-3" />
               Forked from {bundle.parent_name}
             </p>
           )}
           {bundle.base_bundle_name && (
-            <p className="text-xs text-blue-400 flex items-center gap-1 mt-1">
+            <p className="text-xs text-sky-200 flex items-center gap-1 mt-1">
               <Layers className="w-3 h-3" />
               Builds on: {bundle.base_bundle_name}
             </p>
           )}
           {bundle.bundle_type !== 'custom' && (
             <>
-              <p className="text-xs text-gray-500 mt-1">
+              <p className="text-xs text-muted-foreground mt-1">
                 Tier: {bundle.pricing_tier_slug
                   ? (TIER_OPTIONS.find((t) => t.value === bundle.pricing_tier_slug)?.label ?? bundle.pricing_tier_slug)
                   : '—'}
               </p>
-              <p className="text-xs text-gray-500 mt-0.5">
+              <p className="text-xs text-muted-foreground mt-0.5">
                 Pricing segments: {(() => {
                   const segs = bundle.pricing_page_segments;
                   if (!Array.isArray(segs) || segs.length === 0) return 'Not on pricing page';
@@ -72,7 +72,7 @@ export function BundleCard({ bundle, onView, onEdit, onDuplicate, onDelete }: Bu
             </>
           )}
           {bundle.is_decoy && (
-            <p className="text-xs text-emerald-400 flex items-center gap-1 mt-1">
+            <p className="text-xs text-emerald-200 flex items-center gap-1 mt-1">
               <Heart className="w-3 h-3" />
               Community Impact{bundle.mirrors_tier_id ? ` · mirrors ${bundle.mirrors_tier_id}` : ''}
             </p>
@@ -80,16 +80,16 @@ export function BundleCard({ bundle, onView, onEdit, onDuplicate, onDelete }: Bu
         </div>
         <div className="flex items-center gap-1.5">
           {bundle.has_guarantee && (
-            <div className="px-2 py-1 text-xs font-medium rounded bg-gray-700/50 text-gray-300" title={bundle.guarantee_name ?? 'Has guarantee'}>
+            <div className="px-2 py-1 text-xs font-medium rounded border border-white/10 bg-white/5 text-muted-foreground" title={bundle.guarantee_name ?? 'Has guarantee'}>
               <Shield className="w-3 h-3" />
             </div>
           )}
           <div className={`px-2 py-1 text-xs font-medium rounded ${
             bundle.bundle_type === 'standard'
-              ? 'bg-green-900/50 text-green-300'
+              ? 'bg-emerald-500/10 text-emerald-200 border border-emerald-500/30'
               : bundle.bundle_type === 'decoy'
-              ? 'bg-emerald-900/50 text-emerald-300'
-              : 'bg-purple-900/50 text-purple-300'
+              ? 'bg-radiant-gold/10 text-radiant-gold border border-radiant-gold/35'
+              : 'bg-sky-500/10 text-sky-200 border border-sky-500/30'
           }`}>
             {bundle.bundle_type}
           </div>
@@ -97,11 +97,11 @@ export function BundleCard({ bundle, onView, onEdit, onDuplicate, onDelete }: Bu
       </div>
 
       {bundle.description && (
-        <p className="text-sm text-gray-400 mb-3 line-clamp-2">{bundle.description}</p>
+        <p className="text-sm text-muted-foreground mb-3 line-clamp-2">{bundle.description}</p>
       )}
 
       <div className="mb-3">
-        <div className="flex items-center gap-2 text-xs text-gray-500 mb-2">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground mb-2">
           <Package className="w-3 h-3" />
           <span>Contents ({bundle.item_count} items)</span>
         </div>
@@ -110,7 +110,7 @@ export function BundleCard({ bundle, onView, onEdit, onDuplicate, onDelete }: Bu
             {previewItems.map((item) => (
               <div
                 key={`${item.content_type}:${item.content_id}`}
-                className="flex items-center gap-2 text-sm text-gray-300"
+                className="flex items-center gap-2 text-sm text-muted-foreground"
               >
                 <span className="text-base">{CONTENT_TYPE_ICONS[item.content_type]}</span>
                 <span className="truncate">{item.title}</span>
@@ -119,7 +119,7 @@ export function BundleCard({ bundle, onView, onEdit, onDuplicate, onDelete }: Bu
             {hasMoreItems && (
               <button
                 onClick={onView}
-                className="text-xs text-blue-400 hover:text-blue-300 mt-1 flex items-center gap-1"
+                className="text-xs text-radiant-gold hover:text-gold-light mt-1 flex items-center gap-1"
               >
                 <ChevronRight className="w-3 h-3" />
                 +{bundle.item_count - previewItems.length} more...
@@ -127,47 +127,49 @@ export function BundleCard({ bundle, onView, onEdit, onDuplicate, onDelete }: Bu
             )}
           </div>
         ) : (
-          <p className="text-xs text-gray-500 italic">No items added yet</p>
+          <p className="text-xs text-muted-foreground italic">No items added yet</p>
         )}
       </div>
 
       <div className="flex items-center gap-2 text-sm mb-4">
-        <span className="flex items-center gap-1 text-green-400">
+        <span className="flex items-center gap-1 text-emerald-200">
           <DollarSign className="w-4 h-4" />
           {formatPrice(bundle.bundle_price ?? bundle.total_retail_value ?? 0)}
         </span>
         {bundle.total_perceived_value != null && bundle.total_perceived_value > (bundle.bundle_price ?? bundle.total_retail_value ?? 0) && (
-          <span className="text-gray-500 line-through text-xs">
+          <span className="text-muted-foreground line-through text-xs">
             ${formatPrice(bundle.total_perceived_value)} value
           </span>
         )}
         {bundle.fork_count > 0 && (
-          <span className="flex items-center gap-1 text-gray-400 ml-auto">
+          <span className="flex items-center gap-1 text-muted-foreground ml-auto">
             <GitFork className="w-4 h-4" />
             {bundle.fork_count} forks
           </span>
         )}
       </div>
 
-      <div className="flex items-center gap-2 border-t border-gray-800 pt-3">
+      <div className="flex items-center gap-2 border-t border-white/10 pt-3">
         <button
           onClick={onView}
-          className="flex-1 flex items-center justify-center gap-1 px-3 py-2 bg-gray-800 hover:bg-gray-700 rounded-lg text-sm transition-colors"
+          className="admin-console-button-muted flex-1"
         >
           <Eye className="w-4 h-4" />
           View
         </button>
         <button
           onClick={onDuplicate}
-          className="p-2 text-gray-400 hover:text-white hover:bg-gray-800 rounded-lg transition-colors"
+          className="rounded-lg p-2 text-muted-foreground transition-colors hover:bg-white/5 hover:text-foreground"
           title="Duplicate"
+          aria-label={`Duplicate ${bundle.name}`}
         >
           <Copy className="w-4 h-4" />
         </button>
         <button
           onClick={onDelete}
-          className="p-2 text-gray-400 hover:text-red-400 hover:bg-gray-800 rounded-lg transition-colors"
+          className="rounded-lg p-2 text-muted-foreground transition-colors hover:bg-red-500/10 hover:text-red-300"
           title="Delete"
+          aria-label={`Delete ${bundle.name}`}
         >
           <Trash2 className="w-4 h-4" />
         </button>

--- a/app/admin/sales/bundles/page.tsx
+++ b/app/admin/sales/bundles/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { useRouter } from 'next/navigation';
 import { TIER_OPTIONS, PRICING_SEGMENT_OPTIONS } from '@/lib/constants/bundle-tiers';
 import { BundleCard } from './BundleCard';
 import { useAuth } from '@/components/AuthProvider';
@@ -43,7 +42,6 @@ import {
 } from 'lucide-react';
 
 export default function BundleManagementPage() {
-  const router = useRouter();
   const { user } = useAuth();
   const [bundles, setBundles] = useState<OfferBundleWithStats[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -179,7 +177,7 @@ export default function BundleManagementPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-950 text-white p-6">
+    <div className="admin-console-page min-h-screen p-6 text-foreground lg:p-8">
       <div className="max-w-7xl mx-auto">
         {/* Breadcrumbs */}
         <Breadcrumbs 
@@ -191,86 +189,91 @@ export default function BundleManagementPage() {
         />
 
         {/* Header */}
-        <div className="flex items-center justify-between mb-6">
+        <header className="admin-console-surface-header mb-6 mt-5 flex flex-wrap items-start justify-between gap-4 rounded-xl border p-5">
           <div>
-            <h1 className="text-2xl font-bold">Offer Bundles</h1>
-            <p className="text-gray-400 mt-1">
+            <div className="admin-console-eyebrow mb-2">
+              <Package className="h-4 w-4" />
+              Sales Operations
+            </div>
+            <h1 className="text-3xl font-bold">Offer Bundles</h1>
+            <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
               Pre-configured offer templates for sales calls
             </p>
           </div>
-          <div className="flex items-center gap-3">
+          <div className="flex flex-wrap items-center gap-3">
             <button
               onClick={() => fetchBundles()}
-              className="p-2 text-gray-400 hover:text-white transition-colors"
+              className="admin-console-button-muted"
               title="Refresh"
+              aria-label="Refresh bundles"
             >
               <RefreshCw className="w-5 h-5" />
             </button>
             <button
               onClick={() => setShowCreateModal(true)}
-              className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors"
+              className="admin-console-button-primary"
             >
               <Plus className="w-4 h-4" />
               Create Bundle
             </button>
           </div>
-        </div>
+        </header>
 
         {/* Stats */}
         <div className="grid grid-cols-3 gap-4 mb-6">
-          <div className="bg-gray-900 rounded-lg border border-gray-800 p-4">
+          <div className="admin-console-metric rounded-lg border p-4">
             <div className="flex items-center gap-3">
-              <div className="p-2 bg-blue-900/50 rounded-lg">
-                <Package className="w-5 h-5 text-blue-400" />
+              <div className="rounded-lg border border-radiant-gold/25 bg-radiant-gold/10 p-2">
+                <Package className="w-5 h-5 text-radiant-gold" />
               </div>
               <div>
                 <p className="text-2xl font-bold">{stats.total}</p>
-                <p className="text-sm text-gray-400">Total Bundles</p>
+                <p className="text-sm text-muted-foreground">Total Bundles</p>
               </div>
             </div>
           </div>
-          <div className="bg-gray-900 rounded-lg border border-gray-800 p-4">
+          <div className="admin-console-metric rounded-lg border p-4">
             <div className="flex items-center gap-3">
-              <div className="p-2 bg-green-900/50 rounded-lg">
-                <Layers className="w-5 h-5 text-green-400" />
+              <div className="rounded-lg border border-emerald-500/25 bg-emerald-500/10 p-2">
+                <Layers className="w-5 h-5 text-emerald-200" />
               </div>
               <div>
                 <p className="text-2xl font-bold">{stats.standard}</p>
-                <p className="text-sm text-gray-400">Standard Templates</p>
+                <p className="text-sm text-muted-foreground">Standard Templates</p>
               </div>
             </div>
           </div>
-          <div className="bg-gray-900 rounded-lg border border-gray-800 p-4">
+          <div className="admin-console-metric rounded-lg border p-4">
             <div className="flex items-center gap-3">
-              <div className="p-2 bg-purple-900/50 rounded-lg">
-                <GitFork className="w-5 h-5 text-purple-400" />
+              <div className="rounded-lg border border-sky-500/25 bg-sky-500/10 p-2">
+                <GitFork className="w-5 h-5 text-sky-200" />
               </div>
               <div>
                 <p className="text-2xl font-bold">{stats.custom}</p>
-                <p className="text-sm text-gray-400">Custom (Forked)</p>
+                <p className="text-sm text-muted-foreground">Custom (Forked)</p>
               </div>
             </div>
           </div>
         </div>
 
         {/* Filters */}
-        <div className="flex items-center gap-4 mb-6">
+        <div className="admin-console-card mb-6 flex flex-col gap-4 rounded-lg border p-4 sm:flex-row sm:items-center">
           <div className="relative flex-1 max-w-md">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500" />
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
             <input
               type="text"
               placeholder="Search bundles..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="w-full pl-10 pr-4 py-2 bg-gray-900 border border-gray-800 rounded-lg focus:outline-none focus:border-blue-500"
+              className="w-full rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 py-2 pl-10 pr-4 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none"
             />
           </div>
-          <label className="flex items-center gap-2 text-sm text-gray-400">
+          <label className="flex items-center gap-2 text-sm text-muted-foreground">
             <input
               type="checkbox"
               checked={showInactive}
               onChange={(e) => setShowInactive(e.target.checked)}
-              className="rounded border-gray-600"
+              className="rounded border-silicon-slate bg-imperial-navy"
             />
             Show inactive
           </label>
@@ -278,10 +281,10 @@ export default function BundleManagementPage() {
 
         {/* Error */}
         {error && (
-          <div className="mb-6 p-4 bg-red-900/50 border border-red-800 rounded-lg flex items-center gap-3">
+          <div className="mb-6 p-4 bg-red-500/10 border border-red-500/50 rounded-lg flex items-center gap-3">
             <AlertCircle className="w-5 h-5 text-red-400" />
-            <p className="text-red-200">{error}</p>
-            <button onClick={() => setError(null)} className="ml-auto text-red-400 hover:text-red-300">
+            <p className="text-red-300">{error}</p>
+            <button onClick={() => setError(null)} className="ml-auto text-red-300 hover:text-red-200" aria-label="Dismiss error">
               <X className="w-4 h-4" />
             </button>
           </div>
@@ -290,7 +293,7 @@ export default function BundleManagementPage() {
         {/* Loading */}
         {isLoading && (
           <div className="flex items-center justify-center py-12">
-            <RefreshCw className="w-6 h-6 text-gray-400 animate-spin" />
+            <RefreshCw className="w-6 h-6 text-muted-foreground animate-spin" />
           </div>
         )}
 
@@ -309,13 +312,13 @@ export default function BundleManagementPage() {
             ))}
             
             {filteredBundles.length === 0 && (
-              <div className="col-span-full flex flex-col items-center justify-center py-12 text-gray-400">
+              <div className="admin-console-card col-span-full flex flex-col items-center justify-center rounded-lg border py-12 text-muted-foreground">
                 <Package className="w-12 h-12 mb-4 opacity-50" />
                 <p className="text-lg font-medium">No bundles found</p>
                 <p className="text-sm mt-1">Create your first bundle to get started</p>
                 <button
                   onClick={() => setShowCreateModal(true)}
-                  className="mt-4 px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors text-white"
+                  className="admin-console-button-primary mt-4"
                 >
                   Create Bundle
                 </button>
@@ -468,24 +471,24 @@ function CreateBundleModal({
   };
 
   return (
-    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50">
-      <div className="bg-gray-900 rounded-xl border border-gray-800 w-full max-w-md p-6">
+    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
+      <div className="admin-console-card rounded-xl border w-full max-w-md p-6">
         <div className="flex items-center justify-between mb-6">
           <h2 className="text-xl font-semibold">Create New Bundle</h2>
-          <button onClick={onClose} className="text-gray-400 hover:text-white">
+          <button onClick={onClose} className="text-muted-foreground hover:text-foreground" aria-label="Close create bundle modal">
             <X className="w-5 h-5" />
           </button>
         </div>
 
         {error && (
-          <div className="mb-4 p-3 bg-red-900/50 border border-red-800 rounded-lg text-sm text-red-200">
+          <div className="mb-4 p-3 bg-red-500/10 border border-red-500/50 rounded-lg text-sm text-red-300">
             {error}
           </div>
         )}
 
         <div className="space-y-4">
           <div>
-            <label className="block text-sm font-medium text-gray-300 mb-2">
+            <label className="block text-sm font-medium text-muted-foreground mb-2">
               Bundle Name *
             </label>
             <input
@@ -493,12 +496,12 @@ function CreateBundleModal({
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="e.g., Enterprise Starter Pack"
-              className="w-full px-4 py-2 bg-gray-800 border border-gray-700 rounded-lg focus:outline-none focus:border-blue-500"
+              className="w-full rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-4 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none"
             />
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-300 mb-2">
+            <label className="block text-sm font-medium text-muted-foreground mb-2">
               Description
             </label>
             <textarea
@@ -506,22 +509,22 @@ function CreateBundleModal({
               onChange={(e) => setDescription(e.target.value)}
               placeholder="Describe what this bundle includes and who it's for..."
               rows={3}
-              className="w-full px-4 py-2 bg-gray-800 border border-gray-700 rounded-lg focus:outline-none focus:border-blue-500 resize-none"
+              className="w-full rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-4 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none resize-none"
             />
           </div>
 
           {/* Community Impact / Decoy toggle */}
-          <div className="border-t border-gray-800 pt-4">
+          <div className="border-t border-white/10 pt-4">
             <label className="flex items-center gap-3 cursor-pointer">
-              <div className={`relative w-10 h-5 rounded-full transition-colors ${isDecoy ? 'bg-emerald-600' : 'bg-gray-700'}`}>
+              <div className={`relative w-10 h-5 rounded-full transition-colors ${isDecoy ? 'bg-emerald-600' : 'bg-imperial-navy/80'}`}>
                 <div className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white transition-transform ${isDecoy ? 'translate-x-5' : ''}`} />
               </div>
               <div>
-                <span className="text-sm font-medium text-gray-300 flex items-center gap-1.5">
+                <span className="text-sm font-medium text-muted-foreground flex items-center gap-1.5">
                   <Heart className="w-3.5 h-3.5 text-emerald-400" />
                   Community Impact (Decoy) Offer
                 </span>
-                <span className="text-xs text-gray-500 block mt-0.5">
+                <span className="text-xs text-muted-foreground block mt-0.5">
                   Lower price, self-serve delivery, no guarantee
                 </span>
               </div>
@@ -530,7 +533,7 @@ function CreateBundleModal({
             {isDecoy && (
               <div className="mt-4 space-y-3 pl-1">
                 <div>
-                  <label className="block text-xs font-medium text-gray-400 mb-1.5">
+                  <label className="block text-xs font-medium text-muted-foreground mb-1.5">
                     Target Audience
                   </label>
                   <div className="flex gap-2">
@@ -541,8 +544,8 @@ function CreateBundleModal({
                         onClick={() => toggleAudience(audience)}
                         className={`px-3 py-1.5 text-xs rounded-lg border transition-colors ${
                           targetAudience.includes(audience)
-                            ? 'bg-emerald-900/50 text-emerald-300 border-emerald-700'
-                            : 'bg-gray-800 text-gray-400 border-gray-700 hover:border-gray-600'
+                            ? 'bg-radiant-gold/10 text-radiant-gold border-radiant-gold/45'
+                            : 'bg-imperial-navy/70 text-muted-foreground border-silicon-slate/70 hover:border-radiant-gold/40'
                         }`}
                       >
                         {audience.charAt(0).toUpperCase() + audience.slice(1)}
@@ -552,13 +555,13 @@ function CreateBundleModal({
                 </div>
 
                 <div>
-                  <label className="block text-xs font-medium text-gray-400 mb-1.5">
+                  <label className="block text-xs font-medium text-muted-foreground mb-1.5">
                     Mirrors Premium Tier
                   </label>
                   <select
                     value={mirrorsTierId}
                     onChange={(e) => setMirrorsTierId(e.target.value)}
-                    className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-sm focus:outline-none focus:border-emerald-500"
+                    className="w-full rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-sm text-foreground focus:border-radiant-gold/70 focus:outline-none"
                   >
                     <option value="">None (standalone)</option>
                     {TIER_OPTIONS.map(tier => (
@@ -571,8 +574,8 @@ function CreateBundleModal({
           </div>
 
           {/* Service Term */}
-          <div className="border-t border-gray-800 pt-4">
-            <label className="block text-sm font-medium text-gray-300 mb-2">
+          <div className="border-t border-white/10 pt-4">
+            <label className="block text-sm font-medium text-muted-foreground mb-2">
               Default Service Term (months)
             </label>
             <input
@@ -582,29 +585,29 @@ function CreateBundleModal({
               value={defaultServiceTermMonths}
               onChange={(e) => setDefaultServiceTermMonths(e.target.value ? parseInt(e.target.value, 10) : '')}
               placeholder="e.g. 3, 6, 12"
-              className="w-full px-4 py-2 bg-gray-800 border border-gray-700 rounded-lg focus:outline-none focus:border-blue-500"
+              className="w-full rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-4 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none"
             />
-            <p className="text-xs text-gray-500 mt-1">
+            <p className="text-xs text-muted-foreground mt-1">
               Used as the default number of installments when clients choose to pay in installments.
             </p>
           </div>
 
           {/* Pricing page (standard/decoy only; custom comes from save-as) */}
-          <div className="border-t border-gray-800 pt-4">
-            <h3 className="text-sm font-medium text-gray-300 mb-3">Pricing Page</h3>
+          <div className="border-t border-white/10 pt-4">
+            <h3 className="text-sm font-medium text-muted-foreground mb-3">Pricing Page</h3>
             <label className="flex items-center gap-3 cursor-pointer mb-3">
               <input
                 type="checkbox"
                 checked={showOnPricingPage}
                 onChange={(e) => setShowOnPricingPage(e.target.checked)}
-                className="rounded border-gray-600"
+                className="rounded border-silicon-slate"
               />
-              <span className="text-sm text-gray-300">Show on pricing page</span>
+              <span className="text-sm text-muted-foreground">Show on pricing page</span>
             </label>
             {showOnPricingPage && (
               <div className="space-y-3 pl-1">
                 <div>
-                  <label className="block text-xs font-medium text-gray-400 mb-1.5">
+                  <label className="block text-xs font-medium text-muted-foreground mb-1.5">
                     Show on which pricing tab(s)
                   </label>
                   <div className="flex flex-wrap gap-2">
@@ -615,8 +618,8 @@ function CreateBundleModal({
                         onClick={() => togglePricingSegment(opt.value)}
                         className={`px-3 py-1.5 text-xs rounded-lg border transition-colors ${
                           pricingSegments.includes(opt.value)
-                            ? 'bg-blue-900/50 text-blue-300 border-blue-700'
-                            : 'bg-gray-800 text-gray-400 border-gray-700'
+                            ? 'bg-radiant-gold/10 text-radiant-gold border-radiant-gold/45'
+                            : 'bg-imperial-navy/70 text-muted-foreground border-silicon-slate/70'
                         }`}
                       >
                         {opt.label}
@@ -625,13 +628,13 @@ function CreateBundleModal({
                   </div>
                 </div>
                 <div>
-                  <label className="block text-xs font-medium text-gray-400 mb-1.5">
+                  <label className="block text-xs font-medium text-muted-foreground mb-1.5">
                     Tier
                   </label>
                   <select
                     value={pricingTierSlug}
                     onChange={(e) => setPricingTierSlug(e.target.value)}
-                    className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-sm focus:outline-none focus:border-blue-500"
+                    className="w-full rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-sm text-foreground focus:border-radiant-gold/70 focus:outline-none"
                   >
                     <option value="">— No tier</option>
                     {TIER_OPTIONS.map((tier) => (
@@ -640,16 +643,16 @@ function CreateBundleModal({
                   </select>
                 </div>
                 <div>
-                  <label className="block text-xs font-medium text-gray-400 mb-1.5">Tagline</label>
+                  <label className="block text-xs font-medium text-muted-foreground mb-1.5">Tagline</label>
                   <input
                     type="text"
                     value={tagline}
                     onChange={(e) => setTagline(e.target.value)}
-                    className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-sm focus:outline-none focus:border-blue-500"
+                    className="w-full rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-sm text-foreground focus:border-radiant-gold/70 focus:outline-none"
                   />
                 </div>
                 <div>
-                  <label className="block text-xs font-medium text-gray-400 mb-1.5">
+                  <label className="block text-xs font-medium text-muted-foreground mb-1.5">
                     Target audience (display)
                   </label>
                   <input
@@ -657,11 +660,11 @@ function CreateBundleModal({
                     value={targetAudienceDisplay}
                     onChange={(e) => setTargetAudienceDisplay(e.target.value)}
                     placeholder="e.g. Nonprofits & educational institutions"
-                    className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-sm focus:outline-none focus:border-blue-500"
+                    className="w-full rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none"
                   />
                 </div>
                 <div>
-                  <label className="block text-xs font-medium text-gray-400 mb-1.5">
+                  <label className="block text-xs font-medium text-muted-foreground mb-1.5">
                     Display order
                   </label>
                   <input
@@ -671,7 +674,7 @@ function CreateBundleModal({
                       setPricingDisplayOrder(parseInt(e.target.value, 10) || 0)
                     }
                     min={0}
-                    className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-sm focus:outline-none focus:border-blue-500"
+                    className="w-full rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-sm text-foreground focus:border-radiant-gold/70 focus:outline-none"
                   />
                 </div>
                 <label className="flex items-center gap-3 cursor-pointer">
@@ -679,9 +682,9 @@ function CreateBundleModal({
                     type="checkbox"
                     checked={isFeatured}
                     onChange={(e) => setIsFeatured(e.target.checked)}
-                    className="rounded border-gray-600"
+                    className="rounded border-silicon-slate"
                   />
-                  <span className="text-sm text-gray-300">Featured (Most Popular)</span>
+                  <span className="text-sm text-muted-foreground">Featured (Most Popular)</span>
                 </label>
               </div>
             )}
@@ -691,14 +694,14 @@ function CreateBundleModal({
         <div className="flex items-center gap-3 mt-6">
           <button
             onClick={onClose}
-            className="flex-1 px-4 py-2 bg-gray-800 hover:bg-gray-700 rounded-lg transition-colors"
+            className="admin-console-button-muted flex-1"
           >
             Cancel
           </button>
           <button
             onClick={handleSave}
             disabled={isSaving}
-            className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-800 disabled:cursor-not-allowed rounded-lg transition-colors"
+            className="admin-console-button-primary flex-1 disabled:cursor-not-allowed disabled:opacity-60"
           >
             {isSaving ? (
               <RefreshCw className="w-4 h-4 animate-spin" />
@@ -709,7 +712,7 @@ function CreateBundleModal({
           </button>
         </div>
 
-        <p className="text-xs text-gray-500 mt-4 text-center">
+        <p className="text-xs text-muted-foreground mt-4 text-center">
           You can add items to this bundle after creating it
         </p>
       </div>
@@ -817,45 +820,45 @@ function EditBundleModal({
   };
 
   return (
-    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50">
-      <div className="bg-gray-900 rounded-xl border border-gray-800 w-full max-w-lg max-h-[90vh] overflow-y-auto p-6">
+    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
+      <div className="admin-console-card rounded-xl border w-full max-w-lg max-h-[90vh] overflow-y-auto p-6">
         <div className="flex items-center justify-between mb-6">
           <h2 className="text-xl font-semibold">Edit Bundle</h2>
-          <button onClick={onClose} className="text-gray-400 hover:text-white">
+          <button onClick={onClose} className="text-muted-foreground hover:text-foreground" aria-label="Close edit bundle modal">
             <X className="w-5 h-5" />
           </button>
         </div>
 
         {error && (
-          <div className="mb-4 p-3 bg-red-900/50 border border-red-800 rounded-lg text-sm text-red-200">
+          <div className="mb-4 p-3 bg-red-500/10 border border-red-500/50 rounded-lg text-sm text-red-300">
             {error}
           </div>
         )}
 
         <div className="space-y-4">
           <div>
-            <label className="block text-sm font-medium text-gray-300 mb-2">Bundle Name *</label>
+            <label className="block text-sm font-medium text-muted-foreground mb-2">Bundle Name *</label>
             <input
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              className="w-full px-4 py-2 bg-gray-800 border border-gray-700 rounded-lg focus:outline-none focus:border-blue-500"
+              className="w-full rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-4 py-2 text-sm text-foreground focus:border-radiant-gold/70 focus:outline-none"
             />
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-300 mb-2">Description</label>
+            <label className="block text-sm font-medium text-muted-foreground mb-2">Description</label>
             <textarea
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               rows={3}
-              className="w-full px-4 py-2 bg-gray-800 border border-gray-700 rounded-lg focus:outline-none focus:border-blue-500 resize-none"
+              className="w-full rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-4 py-2 text-sm text-foreground focus:border-radiant-gold/70 focus:outline-none resize-none"
             />
           </div>
 
           {/* Service Term */}
           <div>
-            <label className="block text-sm font-medium text-gray-300 mb-2">
+            <label className="block text-sm font-medium text-muted-foreground mb-2">
               Default Service Term (months)
             </label>
             <input
@@ -865,9 +868,9 @@ function EditBundleModal({
               value={editServiceTermMonths}
               onChange={(e) => setEditServiceTermMonths(e.target.value ? parseInt(e.target.value, 10) : '')}
               placeholder="e.g. 3, 6, 12"
-              className="w-full px-4 py-2 bg-gray-800 border border-gray-700 rounded-lg focus:outline-none focus:border-blue-500"
+              className="w-full rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-4 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none"
             />
-            <p className="text-xs text-gray-500 mt-1">
+            <p className="text-xs text-muted-foreground mt-1">
               Default installment count for proposals using this bundle.
             </p>
           </div>
@@ -875,14 +878,14 @@ function EditBundleModal({
           {/* Base bundle - hidden for custom bundles */}
           {!isCustom && (
             <div>
-              <label className="block text-sm font-medium text-gray-300 mb-2">Base bundle</label>
-              <p className="text-xs text-gray-500 mb-2">
+              <label className="block text-sm font-medium text-muted-foreground mb-2">Base bundle</label>
+              <p className="text-xs text-muted-foreground mb-2">
                 {bundle.base_bundle_name ? `Currently based on: ${bundle.base_bundle_name}` : 'Currently: None'}
               </p>
               <select
                 value={baseBundleId}
                 onChange={(e) => setBaseBundleId(e.target.value)}
-                className="w-full px-4 py-2 bg-gray-800 border border-gray-700 rounded-lg focus:outline-none focus:border-blue-500"
+                className="w-full rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-4 py-2 text-sm text-foreground focus:border-radiant-gold/70 focus:outline-none"
               >
                 <option value="">— None</option>
                 {allBundles
@@ -896,18 +899,18 @@ function EditBundleModal({
 
           {/* Pricing page section - hidden for custom bundles */}
           {!isCustom && (
-            <div className="border-t border-gray-800 pt-4 space-y-4">
-              <h3 className="text-sm font-medium text-gray-300">Pricing Page</h3>
+            <div className="border-t border-white/10 pt-4 space-y-4">
+              <h3 className="text-sm font-medium text-muted-foreground">Pricing Page</h3>
 
               <div>
-                <label className="block text-xs font-medium text-gray-400 mb-1.5">Tier</label>
-                <p className="text-xs text-gray-500 mb-1.5">
+                <label className="block text-xs font-medium text-muted-foreground mb-1.5">Tier</label>
+                <p className="text-xs text-muted-foreground mb-1.5">
                   Which pricing tier this bundle belongs to (e.g. Quick Win, Accelerator). Used when shown on the pricing page.
                 </p>
                 <select
                   value={pricingTierSlug}
                   onChange={(e) => setPricingTierSlug(e.target.value)}
-                  className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-sm focus:outline-none focus:border-blue-500"
+                  className="w-full px-3 py-2 rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 text-sm text-foreground focus:border-radiant-gold/70 focus:outline-none"
                 >
                   <option value="">— No tier</option>
                   {TIER_OPTIONS.map((tier) => (
@@ -921,15 +924,15 @@ function EditBundleModal({
                   type="checkbox"
                   checked={showOnPricingPage}
                   onChange={(e) => setShowOnPricingPage(e.target.checked)}
-                  className="rounded border-gray-600"
+                  className="rounded border-silicon-slate"
                 />
-                <span className="text-sm text-gray-300">Show on pricing page</span>
+                <span className="text-sm text-muted-foreground">Show on pricing page</span>
               </label>
 
               {showOnPricingPage && (
                 <>
                   <div>
-                    <label className="block text-xs font-medium text-gray-400 mb-1.5">
+                    <label className="block text-xs font-medium text-muted-foreground mb-1.5">
                       Show on which pricing tab(s)
                     </label>
                     <div className="flex flex-wrap gap-2">
@@ -940,8 +943,8 @@ function EditBundleModal({
                           onClick={() => toggleSegment(opt.value)}
                           className={`px-3 py-1.5 text-xs rounded-lg border transition-colors ${
                             pricingSegments.includes(opt.value)
-                              ? 'bg-blue-900/50 text-blue-300 border-blue-700'
-                              : 'bg-gray-800 text-gray-400 border-gray-700'
+                              ? 'bg-radiant-gold/10 text-radiant-gold border-radiant-gold/45'
+                              : 'bg-imperial-navy/70 text-muted-foreground border-silicon-slate/70'
                           }`}
                         >
                           {opt.label}
@@ -951,17 +954,17 @@ function EditBundleModal({
                   </div>
 
                   <div>
-                    <label className="block text-xs font-medium text-gray-400 mb-1.5">Tagline</label>
+                    <label className="block text-xs font-medium text-muted-foreground mb-1.5">Tagline</label>
                     <input
                       type="text"
                       value={tagline}
                       onChange={(e) => setTagline(e.target.value)}
-                      className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-sm focus:outline-none focus:border-blue-500"
+                      className="w-full px-3 py-2 rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 text-sm text-foreground focus:border-radiant-gold/70 focus:outline-none"
                     />
                   </div>
 
                   <div>
-                    <label className="block text-xs font-medium text-gray-400 mb-1.5">
+                    <label className="block text-xs font-medium text-muted-foreground mb-1.5">
                       Target audience (display)
                     </label>
                     <input
@@ -969,12 +972,12 @@ function EditBundleModal({
                       value={targetAudienceDisplay}
                       onChange={(e) => setTargetAudienceDisplay(e.target.value)}
                       placeholder="e.g. Nonprofits & educational institutions"
-                      className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-sm focus:outline-none focus:border-blue-500"
+                      className="w-full px-3 py-2 rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 text-sm text-foreground focus:border-radiant-gold/70 focus:outline-none"
                     />
                   </div>
 
                   <div>
-                    <label className="block text-xs font-medium text-gray-400 mb-1.5">
+                    <label className="block text-xs font-medium text-muted-foreground mb-1.5">
                       Display order
                     </label>
                     <input
@@ -982,7 +985,7 @@ function EditBundleModal({
                       value={pricingDisplayOrder}
                       onChange={(e) => setPricingDisplayOrder(parseInt(e.target.value, 10) || 0)}
                       min={0}
-                      className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-sm focus:outline-none focus:border-blue-500"
+                      className="w-full px-3 py-2 rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 text-sm text-foreground focus:border-radiant-gold/70 focus:outline-none"
                     />
                   </div>
 
@@ -991,61 +994,61 @@ function EditBundleModal({
                       type="checkbox"
                       checked={isFeatured}
                       onChange={(e) => setIsFeatured(e.target.checked)}
-                      className="rounded border-gray-600"
+                      className="rounded border-silicon-slate"
                     />
-                    <span className="text-sm text-gray-300">Featured (Most Popular)</span>
+                    <span className="text-sm text-muted-foreground">Featured (Most Popular)</span>
                   </label>
                 </>
               )}
 
               <div>
-                <label className="block text-xs font-medium text-gray-400 mb-1.5">
+                <label className="block text-xs font-medium text-muted-foreground mb-1.5">
                   Guarantee name
                 </label>
                 <input
                   type="text"
                   value={guaranteeName}
                   onChange={(e) => setGuaranteeName(e.target.value)}
-                  className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-sm focus:outline-none focus:border-blue-500"
+                  className="w-full px-3 py-2 rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 text-sm text-foreground focus:border-radiant-gold/70 focus:outline-none"
                 />
               </div>
 
               <div>
-                <label className="block text-xs font-medium text-gray-400 mb-1.5">
+                <label className="block text-xs font-medium text-muted-foreground mb-1.5">
                   Guarantee description
                 </label>
                 <input
                   type="text"
                   value={guaranteeDescription}
                   onChange={(e) => setGuaranteeDescription(e.target.value)}
-                  className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-sm focus:outline-none focus:border-blue-500"
+                  className="w-full px-3 py-2 rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 text-sm text-foreground focus:border-radiant-gold/70 focus:outline-none"
                 />
               </div>
 
               <div>
-                <label className="block text-xs font-medium text-gray-400 mb-1.5">CTA text</label>
+                <label className="block text-xs font-medium text-muted-foreground mb-1.5">CTA text</label>
                 <input
                   type="text"
                   value={ctaText}
                   onChange={(e) => setCtaText(e.target.value)}
-                  className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-sm focus:outline-none focus:border-blue-500"
+                  className="w-full px-3 py-2 rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 text-sm text-foreground focus:border-radiant-gold/70 focus:outline-none"
                 />
               </div>
 
               <div>
-                <label className="block text-xs font-medium text-gray-400 mb-1.5">CTA href</label>
+                <label className="block text-xs font-medium text-muted-foreground mb-1.5">CTA href</label>
                 <input
                   type="text"
                   value={ctaHref}
                   onChange={(e) => setCtaHref(e.target.value)}
-                  className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-sm focus:outline-none focus:border-blue-500"
+                  className="w-full px-3 py-2 rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 text-sm text-foreground focus:border-radiant-gold/70 focus:outline-none"
                 />
               </div>
             </div>
           )}
 
           {isCustom && (
-            <p className="text-xs text-gray-500 italic">
+            <p className="text-xs text-muted-foreground italic">
               Custom bundles do not appear on the pricing page.
             </p>
           )}
@@ -1054,14 +1057,14 @@ function EditBundleModal({
         <div className="flex items-center gap-3 mt-6">
           <button
             onClick={onClose}
-            className="flex-1 px-4 py-2 bg-gray-800 hover:bg-gray-700 rounded-lg transition-colors"
+            className="admin-console-button-muted flex-1"
           >
             Cancel
           </button>
           <button
             onClick={handleSave}
             disabled={isSaving}
-            className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-800 disabled:cursor-not-allowed rounded-lg transition-colors"
+            className="admin-console-button-primary flex-1 disabled:cursor-not-allowed disabled:opacity-60"
           >
             {isSaving ? (
               <RefreshCw className="w-4 h-4 animate-spin" />
@@ -1173,35 +1176,35 @@ function ViewBundleModal({
   };
 
   return (
-    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50">
-      <div className="bg-gray-900 rounded-xl border border-gray-800 w-full max-w-3xl max-h-[85vh] overflow-hidden flex flex-col">
+    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
+      <div className="admin-console-card rounded-xl border w-full max-w-3xl max-h-[85vh] overflow-hidden flex flex-col">
         {/* Header */}
-        <div className="flex items-start justify-between p-6 border-b border-gray-800">
+        <div className="flex items-start justify-between p-6 border-b border-white/10">
           {isEditingHeader ? (
             <div className="flex-1 mr-4 space-y-3">
               <div>
-                <label className="block text-xs font-medium text-gray-400 mb-1">Bundle Name</label>
+                <label className="block text-xs font-medium text-muted-foreground mb-1">Bundle Name</label>
                 <input
                   type="text"
                   value={bundleName}
                   onChange={(e) => setBundleName(e.target.value)}
-                  className="w-full px-3 py-2 bg-gray-800 border border-gray-600 rounded-lg focus:outline-none focus:border-blue-500 text-lg font-semibold"
+                  className="w-full rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-lg font-semibold text-foreground focus:border-radiant-gold/70 focus:outline-none"
                   autoFocus
                 />
               </div>
               <div>
-                <label className="block text-xs font-medium text-gray-400 mb-1">Description</label>
+                <label className="block text-xs font-medium text-muted-foreground mb-1">Description</label>
                 <textarea
                   value={bundleDescription}
                   onChange={(e) => setBundleDescription(e.target.value)}
                   placeholder="Enter bundle description..."
                   rows={2}
-                  className="w-full px-3 py-2 bg-gray-800 border border-gray-600 rounded-lg focus:outline-none focus:border-blue-500 text-sm text-gray-300 resize-y"
+                  className="w-full rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none resize-y"
                 />
               </div>
               <button
                 onClick={handleHeaderChange}
-                className="px-3 py-1.5 bg-blue-600 hover:bg-blue-700 rounded-lg text-sm transition-colors"
+                className="admin-console-button-primary px-3 py-1.5"
               >
                 Done
               </button>
@@ -1210,12 +1213,12 @@ function ViewBundleModal({
             <div className="flex-1 min-w-0 group cursor-pointer" onClick={() => setIsEditingHeader(true)}>
               <div className="flex items-center gap-2">
                 <h2 className="text-xl font-semibold">{bundleName}</h2>
-                <Edit className="w-4 h-4 text-gray-500 opacity-0 group-hover:opacity-100 transition-opacity" />
+                <Edit className="w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
               </div>
               {bundleDescription ? (
-                <p className="text-sm text-gray-400 mt-1">{bundleDescription}</p>
+                <p className="text-sm text-muted-foreground mt-1">{bundleDescription}</p>
               ) : (
-                <p className="text-sm text-gray-600 mt-1 italic opacity-0 group-hover:opacity-100 transition-opacity">Click to add description...</p>
+                <p className="text-sm text-muted-foreground mt-1 italic opacity-0 group-hover:opacity-100 transition-opacity">Click to add description...</p>
               )}
             </div>
           )}
@@ -1223,13 +1226,13 @@ function ViewBundleModal({
             {onEditSettings && (
               <button
                 onClick={onEditSettings}
-                className="px-3 py-1.5 text-sm bg-gray-700 hover:bg-gray-600 rounded-lg transition-colors"
+                className="admin-console-button-muted px-3 py-1.5"
                 title="Edit tier, pricing page, and other bundle settings"
               >
                 Edit bundle settings
               </button>
             )}
-            <button onClick={onClose} className="text-gray-400 hover:text-white">
+            <button onClick={onClose} className="text-muted-foreground hover:text-foreground" aria-label="Close bundle detail modal">
               <X className="w-5 h-5" />
             </button>
           </div>
@@ -1237,37 +1240,37 @@ function ViewBundleModal({
 
         {/* Base bundle info */}
         {bundle.base_bundle_name && (
-          <div className="px-6 py-2 bg-gray-950/50 border-b border-gray-800">
-            <p className="text-sm text-blue-400">
+          <div className="px-6 py-2 bg-imperial-navy/55 border-b border-white/10">
+            <p className="text-sm text-sky-200">
               <Layers className="w-4 h-4 inline-block mr-1.5 align-middle" />
               Based on: {bundle.base_bundle_name}
             </p>
-            <p className="text-xs text-gray-500 mt-1">This bundle includes all items from the base bundle plus the items below.</p>
+            <p className="text-xs text-muted-foreground mt-1">This bundle includes all items from the base bundle plus the items below.</p>
           </div>
         )}
 
         {/* Stats */}
-        <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 gap-4 p-4 bg-gray-950 border-b border-gray-800">
+        <div className="grid grid-cols-2 gap-4 border-b border-white/10 bg-imperial-navy/55 p-4 sm:grid-cols-4 lg:grid-cols-6">
           <div className="text-center">
-            <p className="text-2xl font-bold text-white">{items.length}</p>
-            <p className="text-xs text-gray-400">Items</p>
+            <p className="text-2xl font-bold text-foreground">{items.length}</p>
+            <p className="text-xs text-muted-foreground">Items</p>
           </div>
           <div className="text-center">
-            <p className="text-2xl font-bold text-green-400">${Math.round(totals.totalRetailValue).toLocaleString()}</p>
-            <p className="text-xs text-gray-400">Retail Value</p>
+            <p className="text-2xl font-bold text-emerald-200">${Math.round(totals.totalRetailValue).toLocaleString()}</p>
+            <p className="text-xs text-muted-foreground">Retail Value</p>
           </div>
           <div className="text-center">
-            <p className="text-2xl font-bold text-blue-400">${Math.round(totals.totalPerceivedValue).toLocaleString()}</p>
-            <p className="text-xs text-gray-400">Perceived Value</p>
+            <p className="text-2xl font-bold text-sky-200">${Math.round(totals.totalPerceivedValue).toLocaleString()}</p>
+            <p className="text-xs text-muted-foreground">Perceived Value</p>
           </div>
           <div className="text-center">
-            <p className="text-2xl font-bold text-purple-400">{totals.coreOfferCount}</p>
-            <p className="text-xs text-gray-400">Core Offers</p>
+            <p className="text-2xl font-bold text-radiant-gold">{totals.coreOfferCount}</p>
+            <p className="text-xs text-muted-foreground">Core Offers</p>
           </div>
           <div className="text-center">
             <div className="flex flex-col items-center gap-1">
               <p className="text-2xl font-bold text-amber-400">${Math.round(effectiveCost).toLocaleString()}</p>
-              <p className="text-xs text-gray-400">Blended Cost</p>
+              <p className="text-xs text-muted-foreground">Blended Cost</p>
               <input
                 type="number"
                 value={blendedCostOverride}
@@ -1275,7 +1278,7 @@ function ViewBundleModal({
                 placeholder="Override"
                 min={0}
                 step={0.01}
-                className="w-20 px-1.5 py-0.5 text-xs bg-gray-800 border border-gray-600 rounded text-center"
+                className="w-20 rounded border border-silicon-slate/70 bg-imperial-navy/70 px-1.5 py-0.5 text-center text-xs text-foreground focus:border-radiant-gold/70 focus:outline-none"
                 title="Override blended cost (leave empty to use sum of line costs)"
               />
             </div>
@@ -1284,16 +1287,16 @@ function ViewBundleModal({
             <p className="text-2xl font-bold text-radiant-gold">
               {totals.totalRetailValue > 0 ? formatMarginPercent(totals.totalRetailValue, effectiveCost) : '—'}
             </p>
-            <p className="text-xs text-gray-400">Blended Margin</p>
+            <p className="text-xs text-muted-foreground">Blended Margin</p>
           </div>
         </div>
         
         {/* Error */}
         {error && (
-          <div className="mx-4 mt-4 p-3 bg-red-900/50 border border-red-800 rounded-lg flex items-center gap-2 text-sm text-red-200">
+          <div className="mx-4 mt-4 p-3 bg-red-500/10 border border-red-500/50 rounded-lg flex items-center gap-2 text-sm text-red-300">
             <AlertCircle className="w-4 h-4 flex-shrink-0" />
             {error}
-            <button onClick={() => setError(null)} className="ml-auto text-red-400 hover:text-red-300">
+            <button onClick={() => setError(null)} className="ml-auto text-red-300 hover:text-red-200" aria-label="Dismiss error">
               <X className="w-4 h-4" />
             </button>
           </div>
@@ -1309,10 +1312,10 @@ function ViewBundleModal({
         </div>
 
         {/* Footer */}
-        <div className="p-4 border-t border-gray-800 bg-gray-950 flex items-center gap-3">
+        <div className="p-4 border-t border-white/10 bg-imperial-navy/70 flex items-center gap-3">
           <button
             onClick={onClose}
-            className="flex-1 px-4 py-2 bg-gray-800 hover:bg-gray-700 rounded-lg transition-colors"
+            className="admin-console-button-muted flex-1"
           >
             {hasChanges ? 'Cancel' : 'Close'}
           </button>
@@ -1320,7 +1323,7 @@ function ViewBundleModal({
             <button
               onClick={handleSave}
               disabled={isSaving}
-              className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-800 disabled:cursor-not-allowed rounded-lg transition-colors"
+              className="admin-console-button-primary flex-1 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {isSaving ? (
                 <RefreshCw className="w-4 h-4 animate-spin" />

--- a/app/admin/sales/implementation-roadmap/page.tsx
+++ b/app/admin/sales/implementation-roadmap/page.tsx
@@ -56,7 +56,7 @@ function ImplementationRoadmapBuilder() {
   }
 
   return (
-    <div className="min-h-screen bg-background text-foreground p-6 lg:p-8">
+    <div className="admin-console-page min-h-screen p-6 text-foreground lg:p-8">
       <div className="max-w-5xl mx-auto">
         <Breadcrumbs
           items={[
@@ -66,29 +66,30 @@ function ImplementationRoadmapBuilder() {
           ]}
         />
 
-        <div className="mb-8">
-          <div className="flex items-center gap-2 mb-2">
-            <ClipboardList className="text-emerald-400" />
-            <h1 className="text-3xl font-bold">Implementation Roadmap & Startup Costs</h1>
+        <header className="admin-console-surface-header mb-6 mt-5 rounded-xl border p-5">
+          <div className="admin-console-eyebrow mb-2">
+            <ClipboardList className="h-4 w-4" />
+            Sales Operations
           </div>
-          <p className="text-sm text-muted-foreground">
+          <h1 className="text-3xl font-bold">Implementation Roadmap & Startup Costs</h1>
+          <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
             Attach a client-owned AI Ops roadmap snapshot to a proposal before sending it.
           </p>
-        </div>
+        </header>
 
-        <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/25 p-5 mb-6">
+        <div className="admin-console-card mb-6 rounded-lg border p-5">
           <label className="block text-sm font-medium mb-2">Proposal ID</label>
           <div className="flex flex-col sm:flex-row gap-3">
             <input
               value={proposalId}
               onChange={(e) => setProposalId(e.target.value)}
               placeholder="Paste proposal UUID"
-              className="flex-1 rounded-lg border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm"
+              className="flex-1 rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none"
             />
             <button
               onClick={generateSnapshot}
               disabled={loading || proposalId.trim().length < 8}
-              className="inline-flex items-center justify-center gap-2 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-60"
+              className="admin-console-button-primary disabled:opacity-60"
             >
               {loading ? <Loader2 size={16} className="animate-spin" /> : <RefreshCw size={16} />}
               Generate Snapshot
@@ -98,7 +99,7 @@ function ImplementationRoadmapBuilder() {
         </div>
 
         {snapshot && (
-          <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-5">
+          <div className="admin-console-card rounded-lg border p-5">
             <h2 className="text-xl font-semibold mb-4">{snapshot.title}</h2>
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-5">
               <Metric label="Startup" value={`$${snapshot.costSummary.oneTimeClientOwned}`} />
@@ -107,7 +108,7 @@ function ImplementationRoadmapBuilder() {
             </div>
             <div className="space-y-3">
               {snapshot.phases.map((phase, index) => (
-                <div key={`${phase.title}-${index}`} className="rounded-lg border border-silicon-slate/60 bg-background/35 p-4">
+                <div key={`${phase.title}-${index}`} className="rounded-lg border border-silicon-slate/60 bg-imperial-navy/45 p-4">
                   <p className="text-xs text-muted-foreground uppercase tracking-wide">Phase {index + 1}</p>
                   <p className="font-medium">{phase.title}</p>
                   <p className="text-sm text-muted-foreground mt-1">{phase.objective}</p>
@@ -123,7 +124,7 @@ function ImplementationRoadmapBuilder() {
 
 function Metric({ label, value }: { label: string; value: string }) {
   return (
-    <div className="rounded-lg border border-silicon-slate/60 bg-background/35 p-4">
+    <div className="admin-console-metric rounded-lg border p-4">
       <p className="text-xs text-muted-foreground uppercase tracking-wide">{label}</p>
       <p className="text-xl font-semibold mt-1">{value}</p>
     </div>

--- a/app/admin/sales/products/page.tsx
+++ b/app/admin/sales/products/page.tsx
@@ -1,10 +1,9 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { useRouter } from 'next/navigation';
 import { useAuth } from '@/components/AuthProvider';
 import { getCurrentSession } from '@/lib/auth';
-import { 
+import {
   ContentWithRole,
   ContentType,
   OfferRole,
@@ -12,17 +11,16 @@ import {
   OFFER_ROLE_COLORS,
   CONTENT_TYPE_LABELS,
   CONTENT_TYPE_ICONS,
-  CONTENT_TYPE_COLORS,
   buildGrandSlamOffer,
   ProductWithRole,
 } from '@/lib/sales-scripts';
 import { ContentClassifier, ContentOfferRoleInput } from '@/components/admin/sales/ProductClassifier';
 import { OfferStack } from '@/components/admin/sales/OfferCard';
 import Breadcrumbs from '@/components/admin/Breadcrumbs';
-import { 
-  Package, 
-  Filter, 
-  Search, 
+import {
+  Package,
+  Filter,
+  Search,
   RefreshCw,
   Eye,
   AlertCircle,
@@ -54,13 +52,12 @@ const CONTENT_TYPES: ContentType[] = [
 ];
 
 export default function ProductClassificationPage() {
-  const router = useRouter();
   const { user } = useAuth();
   const [content, setContent] = useState<ContentWithRole[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [expandedContent, setExpandedContent] = useState<string | null>(null);
-  
+
   // Filters
   const [searchQuery, setSearchQuery] = useState('');
   const [roleFilter, setRoleFilter] = useState<OfferRole | 'all' | 'unclassified'>('all');
@@ -70,10 +67,10 @@ export default function ProductClassificationPage() {
   const fetchContent = useCallback(async () => {
     const session = await getCurrentSession();
     if (!session?.access_token) return;
-    
+
     setIsLoading(true);
     setError(null);
-    
+
     try {
       const params = new URLSearchParams();
       if (roleFilter !== 'all' && roleFilter !== 'unclassified') {
@@ -82,14 +79,14 @@ export default function ProductClassificationPage() {
       if (contentTypeFilter !== 'all') {
         params.append('content_type', contentTypeFilter);
       }
-      
+
       const response = await fetch(`/api/admin/sales/products?${params}`, {
         headers: {
           Authorization: `Bearer ${session.access_token}`,
         },
       });
       if (!response.ok) throw new Error('Failed to fetch content');
-      
+
       const data = await response.json();
       setContent(data.content || []);
     } catch (err) {
@@ -110,7 +107,7 @@ export default function ProductClassificationPage() {
     const session = await getCurrentSession();
     const response = await fetch('/api/admin/sales/products', {
       method: 'POST',
-      headers: { 
+      headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${session?.access_token}`,
       },
@@ -150,17 +147,17 @@ export default function ProductClassificationPage() {
     // Search filter
     if (searchQuery) {
       const query = searchQuery.toLowerCase();
-      if (!item.title.toLowerCase().includes(query) && 
+      if (!item.title.toLowerCase().includes(query) &&
           !item.description?.toLowerCase().includes(query)) {
         return false;
       }
     }
-    
+
     // Role filter
     if (roleFilter === 'unclassified' && item.offer_role) {
       return false;
     }
-    
+
     return true;
   });
 
@@ -210,35 +207,38 @@ export default function ProductClassificationPage() {
   };
 
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      <div className="max-w-7xl mx-auto px-4 py-8">
-        <Breadcrumbs 
+    <div className="admin-console-page min-h-screen p-6 text-foreground lg:p-8">
+      <div className="max-w-7xl mx-auto">
+        <Breadcrumbs
           items={[
             { label: 'Admin', href: '/admin' },
             { label: 'Sales', href: '/admin/sales' },
             { label: 'Content Classification' },
-          ]} 
+          ]}
         />
 
         {/* Header */}
-        <div className="flex items-center justify-between mb-8">
+        <header className="admin-console-surface-header mb-6 mt-5 flex flex-wrap items-start justify-between gap-4 rounded-xl border p-5">
           <div>
-            <h1 className="text-2xl font-bold text-white flex items-center gap-3">
-              <Layers className="w-7 h-7 text-emerald-500" />
+            <div className="admin-console-eyebrow mb-2">
+              <Layers className="h-4 w-4" />
+              Sales Operations
+            </div>
+            <h1 className="text-3xl font-bold text-foreground">
               Content Classification
             </h1>
-            <p className="text-gray-400 mt-1">
-              Classify your products using Alex Hormozi&apos;s offer framework
+            <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+              Assign offer roles, classify content types, and inspect the offer stack before sales calls.
             </p>
           </div>
 
-          <div className="flex items-center gap-3">
+          <div className="flex flex-wrap items-center gap-3">
             <button
               onClick={() => setShowPreview(!showPreview)}
-              className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-colors ${
-                showPreview 
-                  ? 'bg-emerald-600 text-white' 
-                  : 'bg-gray-900 border border-gray-700 text-white hover:border-purple-500/50'
+              className={`admin-console-button-secondary ${
+                showPreview
+                  ? 'bg-radiant-gold text-background hover:bg-radiant-gold/90'
+                  : ''
               }`}
             >
               <Eye className="w-4 h-4" />
@@ -248,68 +248,68 @@ export default function ProductClassificationPage() {
             <button
               onClick={fetchContent}
               disabled={isLoading}
-              className="flex items-center gap-2 px-4 py-2 bg-gray-900 border border-gray-700 rounded-lg text-white hover:border-purple-500/50"
+              className="admin-console-button-muted disabled:opacity-60"
             >
               <RefreshCw className={`w-4 h-4 ${isLoading ? 'animate-spin' : ''}`} />
               Refresh
             </button>
           </div>
-        </div>
+        </header>
 
         {/* Stats */}
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-          <div className="bg-gray-900 rounded-lg border border-gray-800 p-4">
-            <div className="text-sm text-gray-400">Total Products</div>
-            <div className="text-2xl font-bold text-white">{stats.total}</div>
+          <div className="admin-console-metric rounded-lg border p-4">
+            <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Total Products</div>
+            <div className="mt-2 text-2xl font-bold text-foreground">{stats.total}</div>
           </div>
-          <div className="bg-green-500/20 rounded-lg border border-green-500/50 p-4">
-            <div className="text-sm text-gray-400 flex items-center gap-1">
-              <CheckCircle className="w-4 h-4 text-green-500" />
+          <div className="admin-console-metric rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-4">
+            <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground flex items-center gap-1">
+              <CheckCircle className="w-4 h-4 text-emerald-300" />
               Classified
             </div>
-            <div className="text-2xl font-bold text-green-400">{stats.classified}</div>
+            <div className="mt-2 text-2xl font-bold text-emerald-200">{stats.classified}</div>
           </div>
-          <div className="bg-orange-500/20 rounded-lg border border-orange-500/50 p-4">
-            <div className="text-sm text-gray-400 flex items-center gap-1">
-              <AlertCircle className="w-4 h-4 text-orange-500" />
+          <div className="admin-console-metric rounded-lg border border-amber-500/35 bg-amber-500/10 p-4">
+            <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground flex items-center gap-1">
+              <AlertCircle className="w-4 h-4 text-radiant-gold" />
               Unclassified
             </div>
-            <div className="text-2xl font-bold text-orange-400">{stats.unclassified}</div>
+            <div className="mt-2 text-2xl font-bold text-radiant-gold">{stats.unclassified}</div>
           </div>
-          <div className="bg-blue-500/20 rounded-lg border border-blue-500/50 p-4">
-            <div className="text-sm text-gray-400 flex items-center gap-1">
-              <Tag className="w-4 h-4 text-blue-500" />
+          <div className="admin-console-metric rounded-lg border border-sky-500/30 bg-sky-500/10 p-4">
+            <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground flex items-center gap-1">
+              <Tag className="w-4 h-4 text-sky-300" />
               Core Offers
             </div>
-            <div className="text-2xl font-bold text-blue-400">{stats.byRole.core_offer}</div>
+            <div className="mt-2 text-2xl font-bold text-sky-100">{stats.byRole.core_offer}</div>
           </div>
         </div>
 
-        <div className="flex gap-6">
+        <div className="flex flex-col gap-6 xl:flex-row">
           {/* Main content */}
-          <div className={`flex-1 ${showPreview ? 'max-w-3xl' : ''}`}>
+          <div className={`min-w-0 flex-1 ${showPreview ? 'xl:max-w-3xl' : ''}`}>
             {/* Filters */}
-            <div className="bg-gray-900 rounded-lg border border-gray-800 p-4 mb-6">
+            <div className="admin-console-card rounded-lg border p-4 mb-6">
               <div className="flex flex-col md:flex-row gap-4">
                 {/* Search */}
                 <div className="flex-1 relative">
-                  <Search className="absolute left-3 top-2.5 w-5 h-5 text-gray-500" />
+                  <Search className="absolute left-3 top-2.5 w-5 h-5 text-muted-foreground" />
                   <input
                     type="text"
                     placeholder="Search products..."
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
-                    className="w-full pl-10 pr-4 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-500"
+                    className="w-full rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 py-2 pl-10 pr-4 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none"
                   />
                 </div>
 
                 {/* Content type filter */}
                 <div className="flex items-center gap-2">
-                  <Layers className="w-5 h-5 text-gray-500" />
+                  <Layers className="w-5 h-5 text-muted-foreground" />
                   <select
                     value={contentTypeFilter}
                     onChange={(e) => setContentTypeFilter(e.target.value as ContentType | 'all')}
-                    className="px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white"
+                    className="rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-sm text-foreground focus:border-radiant-gold/70 focus:outline-none"
                   >
                     <option value="all">All Content Types</option>
                     {CONTENT_TYPES.map((type) => (
@@ -322,11 +322,11 @@ export default function ProductClassificationPage() {
 
                 {/* Role filter */}
                 <div className="flex items-center gap-2">
-                  <Filter className="w-5 h-5 text-gray-500" />
+                  <Filter className="w-5 h-5 text-muted-foreground" />
                   <select
                     value={roleFilter}
                     onChange={(e) => setRoleFilter(e.target.value as OfferRole | 'all' | 'unclassified')}
-                    className="px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white"
+                    className="rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-sm text-foreground focus:border-radiant-gold/70 focus:outline-none"
                   >
                     <option value="all">All Products</option>
                     <option value="unclassified">Unclassified Only</option>
@@ -344,7 +344,7 @@ export default function ProductClassificationPage() {
 
             {/* Error */}
             {error && (
-              <div className="bg-red-500/20 text-red-400 p-4 rounded-lg border border-red-500/50 mb-6">
+              <div className="rounded-lg border border-red-500/50 bg-red-500/10 p-4 text-red-300 mb-6">
                 {error}
               </div>
             )}
@@ -352,16 +352,16 @@ export default function ProductClassificationPage() {
             {/* Content list */}
             {isLoading ? (
               <div className="text-center py-12">
-                <RefreshCw className="w-8 h-8 text-gray-500 animate-spin mx-auto mb-3" />
-                <p className="text-gray-400">Loading content...</p>
+                <RefreshCw className="w-8 h-8 text-muted-foreground animate-spin mx-auto mb-3" />
+                <p className="text-muted-foreground">Loading content...</p>
               </div>
             ) : filteredContent.length === 0 ? (
-              <div className="text-center py-12 bg-gray-900 rounded-lg border border-gray-800">
-                <Layers className="w-12 h-12 text-gray-600 mx-auto mb-3" />
-                <h3 className="text-lg font-medium text-white mb-1">No content found</h3>
-                <p className="text-gray-400">
+              <div className="admin-console-card rounded-lg border py-12 text-center">
+                <Layers className="w-12 h-12 text-muted-foreground mx-auto mb-3" />
+                <h3 className="text-lg font-medium text-foreground mb-1">No content found</h3>
+                <p className="text-muted-foreground">
                   {searchQuery || roleFilter !== 'all' || contentTypeFilter !== 'all'
-                    ? 'Try adjusting your filters' 
+                    ? 'Try adjusting your filters'
                     : 'Add content to classify'}
                 </p>
               </div>
@@ -388,14 +388,14 @@ export default function ProductClassificationPage() {
 
           {/* Offer Preview Panel */}
           {showPreview && (
-            <div className="w-96 flex-shrink-0">
+            <div className="w-full flex-shrink-0 xl:w-96">
               <div className="sticky top-4">
-                <h3 className="font-semibold text-white mb-4">Grand Slam Offer Preview</h3>
-                
+                <h3 className="font-semibold text-foreground mb-4">Grand Slam Offer Preview</h3>
+
                 {stats.classified === 0 ? (
-                  <div className="bg-gray-900 rounded-lg border border-gray-800 p-6 text-center">
-                    <Package className="w-12 h-12 text-gray-600 mx-auto mb-3" />
-                    <p className="text-gray-400">
+                  <div className="admin-console-card rounded-lg border p-6 text-center">
+                    <Package className="w-12 h-12 text-muted-foreground mx-auto mb-3" />
+                    <p className="text-muted-foreground">
                       Classify content to see your offer preview
                     </p>
                   </div>
@@ -411,8 +411,8 @@ export default function ProductClassificationPage() {
                 )}
 
                 {/* Role breakdown */}
-                <div className="mt-6 bg-gray-900 rounded-lg border border-gray-800 p-4">
-                  <h4 className="font-medium text-white mb-3">Offer Composition</h4>
+                <div className="admin-console-card mt-6 rounded-lg border p-4">
+                  <h4 className="font-medium text-foreground mb-3">Offer Composition</h4>
                   <div className="space-y-2">
                     {OFFER_ROLES.map((role) => {
                       const count = stats.byRole[role];
@@ -422,7 +422,7 @@ export default function ProductClassificationPage() {
                           <span className={`px-2 py-0.5 rounded-full text-xs font-medium border ${OFFER_ROLE_COLORS[role]}`}>
                             {OFFER_ROLE_LABELS[role]}
                           </span>
-                          <span className="text-gray-400">{count} product{count !== 1 ? 's' : ''}</span>
+                          <span className="text-muted-foreground">{count} product{count !== 1 ? 's' : ''}</span>
                         </div>
                       );
                     })}

--- a/app/admin/sales/scripts/page.tsx
+++ b/app/admin/sales/scripts/page.tsx
@@ -3,19 +3,19 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '@/components/AuthProvider';
 import { getCurrentSession } from '@/lib/auth';
-import { 
+import {
   SalesScript,
   OfferType,
   FunnelStage,
   FUNNEL_STAGE_LABELS,
 } from '@/lib/sales-scripts';
 import Breadcrumbs from '@/components/admin/Breadcrumbs';
-import { 
-  FileText, 
-  Plus, 
-  Edit, 
-  Trash2, 
-  ChevronDown, 
+import {
+  FileText,
+  Plus,
+  Edit,
+  Trash2,
+  ChevronDown,
   ChevronUp,
   Save,
   X,
@@ -36,12 +36,12 @@ const OFFER_TYPE_LABELS: Record<OfferType, string> = {
 };
 
 const OFFER_TYPE_COLORS: Record<OfferType, string> = {
-  attraction: 'bg-pink-100 text-pink-700 border-pink-300',
-  upsell: 'bg-purple-100 text-purple-700 border-purple-300',
-  downsell: 'bg-orange-100 text-orange-700 border-orange-300',
-  continuity: 'bg-teal-100 text-teal-700 border-teal-300',
-  core: 'bg-blue-100 text-blue-700 border-blue-300',
-  objection: 'bg-red-100 text-red-700 border-red-300',
+  attraction: 'bg-radiant-gold/10 text-radiant-gold border-radiant-gold/35',
+  upsell: 'bg-sky-500/10 text-sky-200 border-sky-500/30',
+  downsell: 'bg-amber-500/10 text-amber-200 border-amber-500/30',
+  continuity: 'bg-emerald-500/10 text-emerald-200 border-emerald-500/30',
+  core: 'bg-sky-500/10 text-sky-200 border-sky-500/30',
+  objection: 'bg-red-500/10 text-red-200 border-red-500/30',
 };
 
 const FUNNEL_STAGES: FunnelStage[] = [
@@ -84,7 +84,7 @@ export default function ScriptsManagementPage() {
   const [scripts, setScripts] = useState<SalesScript[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  
+
   // UI state
   const [searchQuery, setSearchQuery] = useState('');
   const [typeFilter, setTypeFilter] = useState<OfferType | 'all'>('all');
@@ -97,24 +97,24 @@ export default function ScriptsManagementPage() {
   const fetchScripts = useCallback(async () => {
     const session = await getCurrentSession();
     if (!session?.access_token) return;
-    
+
     setIsLoading(true);
     setError(null);
-    
+
     try {
       const params = new URLSearchParams();
       params.append('active', 'false'); // Get all scripts including inactive
       if (typeFilter !== 'all') {
         params.append('offer_type', typeFilter);
       }
-      
+
       const response = await fetch(`/api/admin/sales/scripts?${params}`, {
         headers: {
           Authorization: `Bearer ${session.access_token}`,
         },
       });
       if (!response.ok) throw new Error('Failed to fetch scripts');
-      
+
       const data = await response.json();
       setScripts(data.scripts || []);
     } catch (err) {
@@ -134,17 +134,17 @@ export default function ScriptsManagementPage() {
   const handleSave = async () => {
     setIsSaving(true);
     setError(null);
-    
+
     try {
       const session = await getCurrentSession();
       const method = editingScript ? 'PUT' : 'POST';
-      const body = editingScript 
+      const body = editingScript
         ? { id: editingScript, ...formData }
         : formData;
-      
+
       const response = await fetch('/api/admin/sales/scripts', {
         method,
-        headers: { 
+        headers: {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${session?.access_token}`,
         },
@@ -169,7 +169,7 @@ export default function ScriptsManagementPage() {
 
   const handleDelete = async (id: string) => {
     if (!confirm('Are you sure you want to delete this script?')) return;
-    
+
     try {
       const session = await getCurrentSession();
       const response = await fetch(`/api/admin/sales/scripts?id=${id}`, {
@@ -180,7 +180,7 @@ export default function ScriptsManagementPage() {
       });
 
       if (!response.ok) throw new Error('Failed to delete');
-      
+
       await fetchScripts();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to delete');
@@ -192,18 +192,18 @@ export default function ScriptsManagementPage() {
       const session = await getCurrentSession();
       const response = await fetch('/api/admin/sales/scripts', {
         method: 'PUT',
-        headers: { 
+        headers: {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${session?.access_token}`,
         },
-        body: JSON.stringify({ 
-          id: script.id, 
-          is_active: !script.is_active 
+        body: JSON.stringify({
+          id: script.id,
+          is_active: !script.is_active
         }),
       });
 
       if (!response.ok) throw new Error('Failed to update');
-      
+
       await fetchScripts();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to toggle status');
@@ -294,24 +294,27 @@ export default function ScriptsManagementPage() {
   });
 
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      <div className="max-w-6xl mx-auto px-4 py-8">
-        <Breadcrumbs 
+    <div className="admin-console-page min-h-screen p-6 text-foreground lg:p-8">
+      <div className="max-w-6xl mx-auto">
+        <Breadcrumbs
           items={[
             { label: 'Admin', href: '/admin' },
             { label: 'Sales', href: '/admin/sales' },
             { label: 'Scripts' },
-          ]} 
+          ]}
         />
 
         {/* Header */}
-        <div className="flex items-center justify-between mb-8">
+        <header className="admin-console-surface-header mb-6 mt-5 flex flex-wrap items-start justify-between gap-4 rounded-xl border p-5">
           <div>
-            <h1 className="text-2xl font-bold text-white flex items-center gap-3">
-              <FileText className="w-7 h-7 text-emerald-500" />
+            <div className="admin-console-eyebrow mb-2">
+              <FileText className="h-4 w-4" />
+              Sales Operations
+            </div>
+            <h1 className="text-3xl font-bold text-foreground">
               Sales Scripts
             </h1>
-            <p className="text-gray-400 mt-1">
+            <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
               Create and manage guided sales conversation scripts
             </p>
           </div>
@@ -322,33 +325,33 @@ export default function ScriptsManagementPage() {
               setEditingScript(null);
               setFormData(EMPTY_SCRIPT);
             }}
-            className="flex items-center gap-2 px-4 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700"
+            className="admin-console-button-primary"
           >
             <Plus className="w-4 h-4" />
             New Script
           </button>
-        </div>
+        </header>
 
         {/* Filters */}
-        <div className="bg-gray-900 rounded-lg border border-gray-800 p-4 mb-6">
+        <div className="admin-console-card rounded-lg border p-4 mb-6">
           <div className="flex flex-col md:flex-row gap-4">
             <div className="flex-1 relative">
-              <Search className="absolute left-3 top-2.5 w-5 h-5 text-gray-500" />
+              <Search className="absolute left-3 top-2.5 w-5 h-5 text-muted-foreground" />
               <input
                 type="text"
                 placeholder="Search scripts..."
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                className="w-full pl-10 pr-4 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-500"
+                className="w-full rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 py-2 pl-10 pr-4 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none"
               />
             </div>
 
             <div className="flex items-center gap-2">
-              <Filter className="w-5 h-5 text-gray-500" />
+              <Filter className="w-5 h-5 text-muted-foreground" />
               <select
                 value={typeFilter}
                 onChange={(e) => setTypeFilter(e.target.value as OfferType | 'all')}
-                className="px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white"
+                className="rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-sm text-foreground focus:border-radiant-gold/70 focus:outline-none"
               >
                 <option value="all">All Types</option>
                 {Object.entries(OFFER_TYPE_LABELS).map(([type, label]) => (
@@ -361,19 +364,19 @@ export default function ScriptsManagementPage() {
 
         {/* Error */}
         {error && (
-          <div className="bg-red-500/20 text-red-400 p-4 rounded-lg border border-red-500/50 mb-6">
+          <div className="rounded-lg border border-red-500/50 bg-red-500/10 p-4 text-red-300 mb-6">
             {error}
           </div>
         )}
 
         {/* Create/Edit Form */}
         {(isCreating || editingScript) && (
-          <div className="bg-gray-900 rounded-lg border border-gray-800 p-6 mb-6">
+          <div className="admin-console-card rounded-lg border p-6 mb-6">
             <div className="flex items-center justify-between mb-6">
-              <h2 className="text-lg font-medium text-white">
+              <h2 className="text-lg font-medium text-foreground">
                 {editingScript ? 'Edit Script' : 'Create New Script'}
               </h2>
-              <button onClick={cancelEdit} className="p-2 hover:bg-gray-800 rounded-lg text-gray-400 hover:text-white">
+              <button onClick={cancelEdit} className="rounded-lg p-2 text-muted-foreground hover:bg-white/5 hover:text-foreground" aria-label="Close script form">
                 <X className="w-5 h-5" />
               </button>
             </div>
@@ -382,7 +385,7 @@ export default function ScriptsManagementPage() {
               {/* Basic Info */}
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
-                  <label className="block text-sm font-medium text-gray-300 mb-1">
+                  <label className="block text-sm font-medium text-muted-foreground mb-1">
                     Script Name *
                   </label>
                   <input
@@ -390,18 +393,18 @@ export default function ScriptsManagementPage() {
                     value={formData.name}
                     onChange={(e) => setFormData({ ...formData, name: e.target.value })}
                     placeholder="e.g., Core Offer Presentation"
-                    className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-500"
+                    className="w-full rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none"
                   />
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-gray-300 mb-1">
+                  <label className="block text-sm font-medium text-muted-foreground mb-1">
                     Offer Type *
                   </label>
                   <select
                     value={formData.offer_type}
                     onChange={(e) => setFormData({ ...formData, offer_type: e.target.value as OfferType })}
-                    className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white"
+                    className="w-full rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-sm text-foreground focus:border-radiant-gold/70 focus:outline-none"
                   >
                     {Object.entries(OFFER_TYPE_LABELS).map(([type, label]) => (
                       <option key={type} value={type}>{label}</option>
@@ -411,20 +414,20 @@ export default function ScriptsManagementPage() {
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-300 mb-1">
+                <label className="block text-sm font-medium text-muted-foreground mb-1">
                   Description
                 </label>
                 <textarea
                   value={formData.description}
                   onChange={(e) => setFormData({ ...formData, description: e.target.value })}
                   placeholder="What is this script used for?"
-                  className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-500"
+                  className="w-full rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none"
                   rows={2}
                 />
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-300 mb-2">
+                <label className="block text-sm font-medium text-muted-foreground mb-2">
                   Target Funnel Stages
                 </label>
                 <div className="flex flex-wrap gap-2">
@@ -440,8 +443,8 @@ export default function ScriptsManagementPage() {
                       }}
                       className={`px-3 py-1.5 rounded-full text-sm font-medium transition-colors ${
                         formData.target_funnel_stage.includes(stage)
-                          ? 'bg-emerald-600 text-white'
-                          : 'bg-gray-800 text-gray-400 hover:bg-gray-700'
+                          ? 'border border-radiant-gold/60 bg-radiant-gold text-background'
+                          : 'border border-silicon-slate/70 bg-imperial-navy/70 text-muted-foreground hover:border-radiant-gold/50'
                       }`}
                     >
                       {FUNNEL_STAGE_LABELS[stage]}
@@ -453,13 +456,13 @@ export default function ScriptsManagementPage() {
               {/* Script Steps */}
               <div>
                 <div className="flex items-center justify-between mb-3">
-                  <label className="block text-sm font-medium text-gray-300">
+                  <label className="block text-sm font-medium text-muted-foreground">
                     Script Steps
                   </label>
                   <button
                     type="button"
                     onClick={addStep}
-                    className="text-sm text-emerald-500 hover:text-emerald-400 flex items-center gap-1"
+                    className="text-sm text-radiant-gold hover:text-gold-light flex items-center gap-1"
                   >
                     <Plus className="w-4 h-4" />
                     Add Step
@@ -468,14 +471,15 @@ export default function ScriptsManagementPage() {
 
                 <div className="space-y-4">
                   {formData.script_content.steps.map((step, index) => (
-                    <div key={step.id} className="border border-gray-700 bg-gray-800 rounded-lg p-4">
+                    <div key={step.id} className="rounded-lg border border-silicon-slate/70 bg-imperial-navy/55 p-4">
                       <div className="flex items-center justify-between mb-3">
-                        <span className="text-sm font-medium text-gray-400">Step {index + 1}</span>
+                        <span className="text-sm font-medium text-muted-foreground">Step {index + 1}</span>
                         {formData.script_content.steps.length > 1 && (
                           <button
                             type="button"
                             onClick={() => removeStep(step.id)}
-                            className="text-red-500 hover:text-red-400"
+                            className="text-red-300 hover:text-red-200"
+                            aria-label={`Remove step ${index + 1}`}
                           >
                             <Trash2 className="w-4 h-4" />
                           </button>
@@ -487,17 +491,17 @@ export default function ScriptsManagementPage() {
                         value={step.title}
                         onChange={(e) => updateStep(step.id, 'title', e.target.value)}
                         placeholder="Step title"
-                        className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg mb-3 text-white placeholder-gray-500"
+                        className="mb-3 w-full rounded-lg border border-silicon-slate/70 bg-background/35 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none"
                       />
 
-                      <label className="block text-xs text-gray-500 mb-1">
+                      <label className="block text-xs text-muted-foreground mb-1">
                         Talking Points (one per line)
                       </label>
                       <textarea
                         value={step.talking_points.join('\n')}
                         onChange={(e) => updateStep(step.id, 'talking_points', e.target.value.split('\n'))}
                         placeholder="Enter talking points, one per line..."
-                        className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-sm text-white placeholder-gray-500"
+                        className="w-full rounded-lg border border-silicon-slate/70 bg-background/35 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none"
                         rows={3}
                       />
                     </div>
@@ -512,25 +516,25 @@ export default function ScriptsManagementPage() {
                   id="is_active"
                   checked={formData.is_active}
                   onChange={(e) => setFormData({ ...formData, is_active: e.target.checked })}
-                  className="rounded border-gray-600 bg-gray-800"
+                  className="rounded border-silicon-slate bg-imperial-navy/70"
                 />
-                <label htmlFor="is_active" className="text-sm text-gray-300">
+                <label htmlFor="is_active" className="text-sm text-muted-foreground">
                   Active (visible in sales calls)
                 </label>
               </div>
 
               {/* Actions */}
-              <div className="flex items-center justify-end gap-3 pt-4 border-t border-gray-700">
+              <div className="flex items-center justify-end gap-3 pt-4 border-t border-white/10">
                 <button
                   onClick={cancelEdit}
-                  className="px-4 py-2 text-gray-400 hover:bg-gray-800 rounded-lg"
+                  className="admin-console-button-muted"
                 >
                   Cancel
                 </button>
                 <button
                   onClick={handleSave}
                   disabled={isSaving || !formData.name}
-                  className="flex items-center gap-2 px-4 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 disabled:opacity-50"
+                  className="admin-console-button-primary disabled:opacity-50"
                 >
                   <Save className="w-4 h-4" />
                   {isSaving ? 'Saving...' : 'Save Script'}
@@ -543,22 +547,22 @@ export default function ScriptsManagementPage() {
         {/* Scripts List */}
         {isLoading ? (
           <div className="text-center py-12">
-            <RefreshCw className="w-8 h-8 text-gray-500 animate-spin mx-auto mb-3" />
-            <p className="text-gray-400">Loading scripts...</p>
+            <RefreshCw className="w-8 h-8 text-muted-foreground animate-spin mx-auto mb-3" />
+            <p className="text-muted-foreground">Loading scripts...</p>
           </div>
         ) : filteredScripts.length === 0 ? (
-          <div className="text-center py-12 bg-gray-900 rounded-lg border border-gray-800">
-            <FileText className="w-12 h-12 text-gray-600 mx-auto mb-3" />
-            <h3 className="text-lg font-medium text-white mb-1">No scripts found</h3>
-            <p className="text-gray-400 mb-4">
-              {searchQuery || typeFilter !== 'all' 
-                ? 'Try adjusting your filters' 
+          <div className="admin-console-card rounded-lg border py-12 text-center">
+            <FileText className="w-12 h-12 text-muted-foreground mx-auto mb-3" />
+            <h3 className="text-lg font-medium text-foreground mb-1">No scripts found</h3>
+            <p className="text-muted-foreground mb-4">
+              {searchQuery || typeFilter !== 'all'
+                ? 'Try adjusting your filters'
                 : 'Create your first sales script to get started'}
             </p>
             {!isCreating && (
               <button
                 onClick={() => setIsCreating(true)}
-                className="px-4 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700"
+                className="admin-console-button-primary"
               >
                 Create Script
               </button>
@@ -567,53 +571,53 @@ export default function ScriptsManagementPage() {
         ) : (
           <div className="space-y-3">
             {filteredScripts.map((script) => (
-              <div 
-                key={script.id} 
-                className="bg-gray-900 rounded-lg border border-gray-800 overflow-hidden"
+              <div
+                key={script.id}
+                className="admin-console-card rounded-lg border overflow-hidden"
               >
-                <div 
-                  className="p-4 flex items-center justify-between cursor-pointer hover:bg-gray-800/50"
+                <div
+                  className="p-4 flex items-center justify-between cursor-pointer hover:bg-white/5"
                   onClick={() => setExpandedScript(expandedScript === script.id ? null : script.id)}
                 >
                   <div className="flex items-center gap-4">
                     <div>
                       <div className="flex items-center gap-2">
-                        <h3 className="font-medium text-white">{script.name}</h3>
+                        <h3 className="font-medium text-foreground">{script.name}</h3>
                         <span className={`px-2 py-0.5 rounded-full text-xs font-medium border ${OFFER_TYPE_COLORS[script.offer_type]}`}>
                           {OFFER_TYPE_LABELS[script.offer_type]}
                         </span>
                         {!script.is_active && (
-                          <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-gray-700 text-gray-400">
+                          <span className="px-2 py-0.5 rounded-full text-xs font-medium border border-white/10 bg-white/5 text-muted-foreground">
                             Inactive
                           </span>
                         )}
                       </div>
                       {script.description && (
-                        <p className="text-sm text-gray-400 mt-1">{script.description}</p>
+                        <p className="text-sm text-muted-foreground mt-1">{script.description}</p>
                       )}
                     </div>
                   </div>
 
                   <div className="flex items-center gap-2">
-                    <span className="text-sm text-gray-500">
+                    <span className="text-sm text-muted-foreground">
                       {script.script_content.steps.length} steps
                     </span>
                     {expandedScript === script.id ? (
-                      <ChevronUp className="w-5 h-5 text-gray-500" />
+                      <ChevronUp className="w-5 h-5 text-muted-foreground" />
                     ) : (
-                      <ChevronDown className="w-5 h-5 text-gray-500" />
+                      <ChevronDown className="w-5 h-5 text-muted-foreground" />
                     )}
                   </div>
                 </div>
 
                 {expandedScript === script.id && (
-                  <div className="border-t border-gray-800 p-4 bg-gray-800/50">
+                  <div className="border-t border-white/10 p-4 bg-imperial-navy/40">
                     {/* Target stages */}
                     {script.target_funnel_stage.length > 0 && (
                       <div className="mb-4">
-                        <span className="text-sm text-gray-500">Target stages: </span>
+                        <span className="text-sm text-muted-foreground">Target stages: </span>
                         {script.target_funnel_stage.map(stage => (
-                          <span key={stage} className="inline-block px-2 py-0.5 bg-gray-700 text-gray-300 rounded text-xs mr-1">
+                          <span key={stage} className="inline-block px-2 py-0.5 border border-white/10 bg-white/5 text-muted-foreground rounded text-xs mr-1">
                             {FUNNEL_STAGE_LABELS[stage]}
                           </span>
                         ))}
@@ -624,12 +628,12 @@ export default function ScriptsManagementPage() {
                     <div className="space-y-2 mb-4">
                       {script.script_content.steps.map((step, i) => (
                         <div key={step.id} className="flex items-start gap-2 text-sm">
-                          <span className="w-6 h-6 bg-emerald-500/20 text-emerald-400 rounded-full flex items-center justify-center text-xs font-medium flex-shrink-0">
+                          <span className="w-6 h-6 border border-radiant-gold/35 bg-radiant-gold/10 text-radiant-gold rounded-full flex items-center justify-center text-xs font-medium flex-shrink-0">
                             {i + 1}
                           </span>
                           <div>
-                            <span className="font-medium text-white">{step.title}</span>
-                            <span className="text-gray-500 ml-2">
+                            <span className="font-medium text-foreground">{step.title}</span>
+                            <span className="text-muted-foreground ml-2">
                               ({step.talking_points.filter(p => p.trim()).length} talking points)
                             </span>
                           </div>
@@ -638,16 +642,16 @@ export default function ScriptsManagementPage() {
                     </div>
 
                     {/* Actions */}
-                    <div className="flex items-center gap-2 pt-3 border-t border-gray-700">
+                    <div className="flex flex-wrap items-center gap-2 pt-3 border-t border-white/10">
                       <button
                         onClick={(e) => {
                           e.stopPropagation();
                           handleToggleActive(script);
                         }}
                         className={`flex items-center gap-1 px-3 py-1.5 text-sm rounded-lg ${
-                          script.is_active 
-                            ? 'text-orange-400 hover:bg-orange-500/20' 
-                            : 'text-emerald-400 hover:bg-emerald-500/20'
+                          script.is_active
+                            ? 'text-amber-200 hover:bg-amber-500/10'
+                            : 'text-radiant-gold hover:bg-radiant-gold/10'
                         }`}
                       >
                         {script.is_active ? (
@@ -667,7 +671,7 @@ export default function ScriptsManagementPage() {
                           e.stopPropagation();
                           handleEdit(script);
                         }}
-                        className="flex items-center gap-1 px-3 py-1.5 text-sm text-gray-300 hover:bg-gray-700 rounded-lg"
+                        className="flex items-center gap-1 px-3 py-1.5 text-sm text-muted-foreground hover:bg-white/5 hover:text-foreground rounded-lg"
                       >
                         <Edit className="w-4 h-4" />
                         Edit
@@ -677,7 +681,7 @@ export default function ScriptsManagementPage() {
                           e.stopPropagation();
                           handleDuplicate(script);
                         }}
-                        className="flex items-center gap-1 px-3 py-1.5 text-sm text-gray-300 hover:bg-gray-700 rounded-lg"
+                        className="flex items-center gap-1 px-3 py-1.5 text-sm text-muted-foreground hover:bg-white/5 hover:text-foreground rounded-lg"
                       >
                         <Copy className="w-4 h-4" />
                         Duplicate

--- a/app/admin/sales/upsell-paths/page.tsx
+++ b/app/admin/sales/upsell-paths/page.tsx
@@ -83,12 +83,12 @@ const CONTENT_TYPES = [
 ];
 
 const TIER_COLORS: Record<string, string> = {
-  'ci-starter': 'bg-green-500/20 text-green-400 border-green-500/30',
-  'ci-accelerator': 'bg-blue-500/20 text-blue-400 border-blue-500/30',
-  'ci-growth': 'bg-purple-500/20 text-purple-400 border-purple-500/30',
-  'quick-win': 'bg-amber-500/20 text-amber-400 border-amber-500/30',
-  'accelerator': 'bg-cyan-500/20 text-cyan-400 border-cyan-500/30',
-  'growth-engine': 'bg-rose-500/20 text-rose-400 border-rose-500/30',
+  'ci-starter': 'bg-emerald-500/10 text-emerald-200 border-emerald-500/30',
+  'ci-accelerator': 'bg-sky-500/10 text-sky-200 border-sky-500/30',
+  'ci-growth': 'bg-radiant-gold/10 text-radiant-gold border-radiant-gold/35',
+  'quick-win': 'bg-amber-500/10 text-amber-200 border-amber-500/30',
+  'accelerator': 'bg-sky-500/10 text-sky-200 border-sky-500/30',
+  'growth-engine': 'bg-red-500/10 text-red-200 border-red-500/30',
 };
 
 // ============================================================================
@@ -205,7 +205,7 @@ export default function UpsellPathsPage() {
   // ============================================================================
 
   return (
-    <div className="min-h-screen bg-background text-foreground p-6">
+    <div className="admin-console-page min-h-screen p-6 text-foreground lg:p-8">
       <div className="max-w-7xl mx-auto">
         <Breadcrumbs
           items={[
@@ -216,20 +216,23 @@ export default function UpsellPathsPage() {
         />
 
         {/* Header */}
-        <div className="flex items-center justify-between mb-8">
+        <header className="admin-console-surface-header mb-6 mt-5 flex flex-wrap items-start justify-between gap-4 rounded-xl border p-5">
           <div>
-            <h1 className="text-3xl font-bold flex items-center gap-3">
-              <ArrowUpRight className="w-8 h-8 text-amber-500" />
+            <div className="admin-console-eyebrow mb-2">
+              <ArrowUpRight className="h-4 w-4" />
+              Sales Operations
+            </div>
+            <h1 className="text-3xl font-bold">
               Offer Upsell Paths
             </h1>
-            <p className="text-gray-400 mt-1">
+            <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
               Configure decoy-to-premium pairings and the two-touch prescription model
             </p>
           </div>
-          <div className="flex items-center gap-3">
+          <div className="flex flex-wrap items-center gap-3">
             <button
               onClick={() => setShowCreateModal(true)}
-              className="flex items-center gap-2 px-4 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-700 transition-colors"
+              className="admin-console-button-primary"
             >
               <Plus className="w-4 h-4" />
               New Path
@@ -237,40 +240,41 @@ export default function UpsellPathsPage() {
             <button
               onClick={fetchPaths}
               disabled={isLoading}
-              className="flex items-center gap-2 px-4 py-2 bg-gray-800 text-white rounded-lg hover:bg-gray-700 transition-colors"
+              className="admin-console-button-muted disabled:opacity-60"
+              aria-label="Refresh upsell paths"
             >
               <RefreshCw className={`w-4 h-4 ${isLoading ? 'animate-spin' : ''}`} />
             </button>
           </div>
-        </div>
+        </header>
 
         {/* Filters */}
-        <div className="flex flex-wrap items-center gap-4 mb-6">
+        <div className="admin-console-card mb-6 flex flex-wrap items-center gap-4 rounded-lg border p-4">
           <div className="relative flex-1 min-w-[200px]">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500" />
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
             <input
               type="text"
               placeholder="Search by source, upsell, or problem..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="w-full pl-10 pr-4 py-2 bg-gray-900 border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:border-amber-500/50 focus:outline-none"
+              className="w-full rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 py-2 pl-10 pr-4 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none"
             />
           </div>
           <select
             value={tierFilter}
             onChange={(e) => setTierFilter(e.target.value)}
-            className="px-4 py-2 bg-gray-900 border border-gray-700 rounded-lg text-white focus:border-amber-500/50 focus:outline-none"
+            className="rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-4 py-2 text-sm text-foreground focus:border-radiant-gold/70 focus:outline-none"
           >
             {TIER_OPTIONS.map((opt) => (
               <option key={opt.value} value={opt.value}>{opt.label}</option>
             ))}
           </select>
-          <label className="flex items-center gap-2 text-sm text-gray-400">
+          <label className="flex items-center gap-2 text-sm text-muted-foreground">
             <input
               type="checkbox"
               checked={showInactive}
               onChange={(e) => setShowInactive(e.target.checked)}
-              className="rounded border-gray-600"
+              className="rounded border-silicon-slate bg-imperial-navy"
             />
             Show inactive
           </label>
@@ -278,10 +282,10 @@ export default function UpsellPathsPage() {
 
         {/* Error */}
         {error && (
-          <div className="mb-6 p-4 bg-red-900/20 border border-red-500/30 rounded-lg flex items-center gap-3">
+          <div className="mb-6 p-4 bg-red-500/10 border border-red-500/50 rounded-lg flex items-center gap-3">
             <AlertCircle className="w-5 h-5 text-red-400 flex-shrink-0" />
-            <p className="text-red-400">{error}</p>
-            <button onClick={() => setError(null)} className="ml-auto text-red-400 hover:text-red-300">
+            <p className="text-red-300">{error}</p>
+            <button onClick={() => setError(null)} className="ml-auto text-red-300 hover:text-red-200" aria-label="Dismiss error">
               <X className="w-4 h-4" />
             </button>
           </div>
@@ -289,35 +293,35 @@ export default function UpsellPathsPage() {
 
         {/* Stats */}
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-          <div className="p-4 bg-gray-900/50 border border-gray-800 rounded-lg">
-            <p className="text-2xl font-bold text-amber-400">{paths.length}</p>
-            <p className="text-sm text-gray-400">Total Paths</p>
+          <div className="admin-console-metric rounded-lg border p-4">
+            <p className="text-2xl font-bold text-radiant-gold">{paths.length}</p>
+            <p className="text-sm text-muted-foreground">Total Paths</p>
           </div>
-          <div className="p-4 bg-gray-900/50 border border-gray-800 rounded-lg">
+          <div className="admin-console-metric rounded-lg border p-4">
             <p className="text-2xl font-bold text-green-400">
               {paths.filter((p) => p.point_of_sale_steps.length > 0).length}
             </p>
-            <p className="text-sm text-gray-400">With PoS Scripts</p>
+            <p className="text-sm text-muted-foreground">With PoS Scripts</p>
           </div>
-          <div className="p-4 bg-gray-900/50 border border-gray-800 rounded-lg">
-            <p className="text-2xl font-bold text-blue-400">
+          <div className="admin-console-metric rounded-lg border p-4">
+            <p className="text-2xl font-bold text-sky-200">
               {paths.filter((p) => p.point_of_pain_steps.length > 0).length}
             </p>
-            <p className="text-sm text-gray-400">With PoP Scripts</p>
+            <p className="text-sm text-muted-foreground">With PoP Scripts</p>
           </div>
-          <div className="p-4 bg-gray-900/50 border border-gray-800 rounded-lg">
-            <p className="text-2xl font-bold text-purple-400">
+          <div className="admin-console-metric rounded-lg border p-4">
+            <p className="text-2xl font-bold text-emerald-200">
               {paths.filter((p) => p.credit_previous_investment).length}
             </p>
-            <p className="text-sm text-gray-400">Credit Eligible</p>
+            <p className="text-sm text-muted-foreground">Credit Eligible</p>
           </div>
         </div>
 
         {/* Path List */}
         {isLoading ? (
-          <div className="text-center py-12 text-gray-500">Loading upsell paths...</div>
+          <div className="text-center py-12 text-muted-foreground">Loading upsell paths...</div>
         ) : paths.length === 0 ? (
-          <div className="text-center py-12 text-gray-500">
+          <div className="admin-console-card rounded-lg border py-12 text-center text-muted-foreground">
             No upsell paths found. Create one to get started.
           </div>
         ) : (
@@ -371,19 +375,19 @@ function UpsellPathCard({
   onDelete: () => void;
 }) {
   const tierColor = path.source_tier_slug
-    ? TIER_COLORS[path.source_tier_slug] || 'bg-gray-500/20 text-gray-400 border-gray-500/30'
-    : 'bg-gray-500/20 text-gray-400 border-gray-500/30';
+    ? TIER_COLORS[path.source_tier_slug] || 'bg-white/5 text-muted-foreground border-white/10'
+    : 'bg-white/5 text-muted-foreground border-white/10';
 
   const upsellTierColor = path.upsell_tier_slug
-    ? TIER_COLORS[path.upsell_tier_slug] || 'bg-gray-500/20 text-gray-400 border-gray-500/30'
-    : 'bg-gray-500/20 text-gray-400 border-gray-500/30';
+    ? TIER_COLORS[path.upsell_tier_slug] || 'bg-white/5 text-muted-foreground border-white/10'
+    : 'bg-white/5 text-muted-foreground border-white/10';
 
   return (
     <div
-      className={`border rounded-xl transition-all ${
+      className={`rounded-xl border transition-all ${
         path.is_active
-          ? 'bg-gray-900/50 border-gray-800 hover:border-amber-500/30'
-          : 'bg-gray-900/30 border-gray-800/50 opacity-60'
+          ? 'admin-console-card admin-console-interactive'
+          : 'admin-console-card opacity-60'
       }`}
     >
       {/* Summary Row */}
@@ -394,31 +398,31 @@ function UpsellPathCard({
             <span className={`text-xs px-2 py-0.5 rounded border ${tierColor}`}>
               {path.source_tier_slug || 'standalone'}
             </span>
-            <span className="font-medium text-white truncate">{path.source_title}</span>
+            <span className="font-medium text-foreground truncate">{path.source_title}</span>
             <ArrowRight className="w-4 h-4 text-amber-500 flex-shrink-0" />
             <span className={`text-xs px-2 py-0.5 rounded border ${upsellTierColor}`}>
               {path.upsell_tier_slug || 'standalone'}
             </span>
             <span className="font-medium text-amber-400 truncate">{path.upsell_title}</span>
           </div>
-          <p className="text-sm text-gray-500 mt-1 line-clamp-1">{path.next_problem}</p>
+          <p className="text-sm text-muted-foreground mt-1 line-clamp-1">{path.next_problem}</p>
         </div>
 
         {/* Metrics */}
         <div className="hidden md:flex items-center gap-4 text-sm">
           {path.incremental_cost && (
-            <div className="flex items-center gap-1 text-green-400">
+          <div className="flex items-center gap-1 text-emerald-200">
               <DollarSign className="w-3.5 h-3.5" />
               {path.incremental_cost.toLocaleString()}
             </div>
           )}
-          <div className="flex items-center gap-1 text-gray-400">
+          <div className="flex items-center gap-1 text-muted-foreground">
             <Clock className="w-3.5 h-3.5" />
             {path.next_problem_timing}
           </div>
           <div className="flex items-center gap-1">
             <Zap className="w-3.5 h-3.5 text-amber-400" />
-            <span className="text-gray-400">
+              <span className="text-muted-foreground">
               {path.point_of_sale_steps.length}/{path.point_of_pain_steps.length}
             </span>
           </div>
@@ -428,22 +432,25 @@ function UpsellPathCard({
         <div className="flex items-center gap-2">
           <button
             onClick={onToggleExpand}
-            className="p-1.5 text-gray-400 hover:text-white transition-colors"
+            className="p-1.5 text-muted-foreground hover:text-foreground transition-colors"
             title="View details"
+            aria-label={isExpanded ? 'Collapse upsell path details' : 'Expand upsell path details'}
           >
             {isExpanded ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
           </button>
           <button
             onClick={onEdit}
-            className="p-1.5 text-gray-400 hover:text-amber-400 transition-colors"
+            className="p-1.5 text-muted-foreground hover:text-radiant-gold transition-colors"
             title="Edit"
+            aria-label="Edit upsell path"
           >
             <Edit className="w-4 h-4" />
           </button>
           <button
             onClick={onDelete}
-            className="p-1.5 text-gray-400 hover:text-red-400 transition-colors"
+            className="p-1.5 text-muted-foreground hover:text-red-300 transition-colors"
             title="Deactivate"
+            aria-label="Deactivate upsell path"
           >
             <Trash2 className="w-4 h-4" />
           </button>
@@ -452,22 +459,22 @@ function UpsellPathCard({
 
       {/* Expanded Details */}
       {isExpanded && (
-        <div className="border-t border-gray-800 p-4 space-y-4">
+        <div className="border-t border-white/10 p-4 space-y-4">
           {/* Next Problem */}
           <div>
-            <h4 className="text-sm font-semibold text-gray-300 mb-1">Next Problem (Client Voice)</h4>
-            <p className="text-sm text-gray-400 italic">&ldquo;{path.next_problem}&rdquo;</p>
+            <h4 className="text-sm font-semibold text-foreground mb-1">Next Problem (Client Voice)</h4>
+            <p className="text-sm text-muted-foreground italic">&ldquo;{path.next_problem}&rdquo;</p>
           </div>
 
           {/* Timing & Signals */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <h4 className="text-sm font-semibold text-gray-300 mb-1">Timing</h4>
-              <p className="text-sm text-gray-400">{path.next_problem_timing}</p>
+              <h4 className="text-sm font-semibold text-foreground mb-1">Timing</h4>
+              <p className="text-sm text-muted-foreground">{path.next_problem_timing}</p>
             </div>
             <div>
-              <h4 className="text-sm font-semibold text-gray-300 mb-1">Observable Signals</h4>
-              <ul className="text-sm text-gray-400 space-y-1">
+              <h4 className="text-sm font-semibold text-foreground mb-1">Observable Signals</h4>
+              <ul className="text-sm text-muted-foreground space-y-1">
                 {(path.next_problem_signals || []).map((signal, i) => (
                   <li key={i} className="flex items-start gap-2">
                     <Eye className="w-3.5 h-3.5 mt-0.5 text-amber-500 flex-shrink-0" />
@@ -482,26 +489,26 @@ function UpsellPathCard({
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {path.value_frame_text && (
               <div>
-                <h4 className="text-sm font-semibold text-gray-300 mb-1">Value Frame</h4>
-                <p className="text-sm text-gray-400">{path.value_frame_text}</p>
+                <h4 className="text-sm font-semibold text-foreground mb-1">Value Frame</h4>
+                <p className="text-sm text-muted-foreground">{path.value_frame_text}</p>
               </div>
             )}
             {path.risk_reversal_text && (
               <div>
-                <h4 className="text-sm font-semibold text-gray-300 mb-1 flex items-center gap-1">
-                  <Shield className="w-3.5 h-3.5 text-green-400" />
+                <h4 className="text-sm font-semibold text-muted-foreground mb-1 flex items-center gap-1">
+                  <Shield className="w-3.5 h-3.5 text-emerald-200" />
                   Risk Reversal
                 </h4>
-                <p className="text-sm text-gray-400">{path.risk_reversal_text}</p>
+                <p className="text-sm text-muted-foreground">{path.risk_reversal_text}</p>
               </div>
             )}
           </div>
 
           {/* Credit Policy */}
           {path.credit_previous_investment && (
-            <div className="p-3 bg-green-900/20 border border-green-500/20 rounded-lg">
-              <h4 className="text-sm font-semibold text-green-400 mb-1">Credit Policy</h4>
-              <p className="text-sm text-gray-400">
+            <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-3">
+              <h4 className="text-sm font-semibold text-emerald-200 mb-1">Credit Policy</h4>
+              <p className="text-sm text-muted-foreground">
                 {path.credit_note || 'Previous investment applies as credit toward the upsell.'}
               </p>
             </div>
@@ -515,11 +522,11 @@ function UpsellPathCard({
               </h4>
               <div className="space-y-2">
                 {path.point_of_sale_steps.map((step) => (
-                  <div key={step.id} className="p-3 bg-gray-800/50 rounded-lg">
-                    <p className="text-sm font-medium text-white">{step.title}</p>
+                  <div key={step.id} className="rounded-lg border border-white/10 bg-imperial-navy/55 p-3">
+                    <p className="text-sm font-medium text-foreground">{step.title}</p>
                     <ul className="mt-1 space-y-0.5">
                       {step.talking_points.map((tp, i) => (
-                        <li key={i} className="text-xs text-gray-400 pl-3 border-l border-amber-500/30">
+                        <li key={i} className="text-xs text-muted-foreground pl-3 border-l border-amber-500/30">
                           {tp}
                         </li>
                       ))}
@@ -533,16 +540,16 @@ function UpsellPathCard({
           {/* Point of Pain Steps */}
           {path.point_of_pain_steps.length > 0 && (
             <div>
-              <h4 className="text-sm font-semibold text-blue-400 mb-2">
+              <h4 className="text-sm font-semibold text-sky-200 mb-2">
                 Point of Pain Script ({path.point_of_pain_steps.length} steps)
               </h4>
               <div className="space-y-2">
                 {path.point_of_pain_steps.map((step) => (
-                  <div key={step.id} className="p-3 bg-gray-800/50 rounded-lg">
-                    <p className="text-sm font-medium text-white">{step.title}</p>
+                  <div key={step.id} className="rounded-lg border border-white/10 bg-imperial-navy/55 p-3">
+                    <p className="text-sm font-medium text-foreground">{step.title}</p>
                     <ul className="mt-1 space-y-0.5">
                       {step.talking_points.map((tp, i) => (
-                        <li key={i} className="text-xs text-gray-400 pl-3 border-l border-blue-500/30">
+                        <li key={i} className="text-xs text-muted-foreground pl-3 border-l border-sky-500/30">
                           {tp}
                         </li>
                       ))}
@@ -555,7 +562,7 @@ function UpsellPathCard({
 
           {/* Admin Notes */}
           {path.notes && (
-            <div className="text-xs text-gray-500 italic">Notes: {path.notes}</div>
+            <div className="text-xs text-muted-foreground italic">Notes: {path.notes}</div>
           )}
         </div>
       )}
@@ -663,13 +670,13 @@ function UpsellPathModal({
 
   return (
     <div className="fixed inset-0 bg-black/70 flex items-start justify-center z-50 overflow-y-auto py-8">
-      <div className="bg-gray-900 border border-gray-700 rounded-xl w-full max-w-3xl mx-4">
+      <div className="admin-console-card rounded-xl border w-full max-w-3xl mx-4">
         {/* Header */}
-        <div className="flex items-center justify-between p-6 border-b border-gray-800">
+        <div className="flex items-center justify-between p-6 border-b border-white/10">
           <h2 className="text-xl font-bold">
             {path ? 'Edit Upsell Path' : 'Create Upsell Path'}
           </h2>
-          <button onClick={onClose} className="text-gray-400 hover:text-white">
+          <button onClick={onClose} className="text-muted-foreground hover:text-foreground" aria-label="Close upsell path modal">
             <X className="w-5 h-5" />
           </button>
         </div>
@@ -677,7 +684,7 @@ function UpsellPathModal({
         {/* Body */}
         <div className="p-6 space-y-6 max-h-[70vh] overflow-y-auto">
           {formError && (
-            <div className="p-3 bg-red-900/20 border border-red-500/30 rounded-lg text-red-400 text-sm">
+            <div className="p-3 bg-red-500/10 border border-red-500/50 rounded-lg text-red-300 text-sm">
               {formError}
             </div>
           )}
@@ -689,11 +696,11 @@ function UpsellPathModal({
             </legend>
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <label className="text-xs text-gray-400">Content Type</label>
+                <label className="text-xs text-muted-foreground">Content Type</label>
                 <select
                   value={sourceContentType}
                   onChange={(e) => setSourceContentType(e.target.value)}
-                  className="w-full mt-1 px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm focus:border-amber-500/50 focus:outline-none"
+                  className="w-full mt-1 rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none"
                 >
                   {CONTENT_TYPES.map((t) => (
                     <option key={t} value={t}>{t}</option>
@@ -701,35 +708,35 @@ function UpsellPathModal({
                 </select>
               </div>
               <div>
-                <label className="text-xs text-gray-400">Content ID</label>
+                <label className="text-xs text-muted-foreground">Content ID</label>
                 <input
                   type="text"
                   value={sourceContentId}
                   onChange={(e) => setSourceContentId(e.target.value)}
                   placeholder="e.g. ci-chatbot-template"
-                  className="w-full mt-1 px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm focus:border-amber-500/50 focus:outline-none"
+                  className="w-full mt-1 rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none"
                 />
               </div>
             </div>
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <label className="text-xs text-gray-400">Display Title</label>
+                <label className="text-xs text-muted-foreground">Display Title</label>
                 <input
                   type="text"
                   value={sourceTitle}
                   onChange={(e) => setSourceTitle(e.target.value)}
                   placeholder="Pre-Built Chatbot Template"
-                  className="w-full mt-1 px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm focus:border-amber-500/50 focus:outline-none"
+                  className="w-full mt-1 rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none"
                 />
               </div>
               <div>
-                <label className="text-xs text-gray-400">Tier Slug (optional)</label>
+                <label className="text-xs text-muted-foreground">Tier Slug (optional)</label>
                 <input
                   type="text"
                   value={sourceTierSlug}
                   onChange={(e) => setSourceTierSlug(e.target.value)}
                   placeholder="ci-accelerator"
-                  className="w-full mt-1 px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm focus:border-amber-500/50 focus:outline-none"
+                  className="w-full mt-1 rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none"
                 />
               </div>
             </div>
@@ -741,38 +748,39 @@ function UpsellPathModal({
               Predicted Next Problem
             </legend>
             <div>
-              <label className="text-xs text-gray-400">Problem Description (Client Voice)</label>
+              <label className="text-xs text-muted-foreground">Problem Description (Client Voice)</label>
               <textarea
                 value={nextProblem}
                 onChange={(e) => setNextProblem(e.target.value)}
                 rows={3}
                 placeholder="The template is generic — it does not know my products..."
-                className="w-full mt-1 px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm focus:border-amber-500/50 focus:outline-none"
+                className="w-full mt-1 rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none"
               />
             </div>
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <label className="text-xs text-gray-400">Timing</label>
+                <label className="text-xs text-muted-foreground">Timing</label>
                 <input
                   type="text"
                   value={nextProblemTiming}
                   onChange={(e) => setNextProblemTiming(e.target.value)}
                   placeholder="2-4 weeks after install"
-                  className="w-full mt-1 px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm focus:border-amber-500/50 focus:outline-none"
+                  className="w-full mt-1 rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none"
                 />
               </div>
             </div>
             <div>
-              <label className="text-xs text-gray-400">Observable Signals</label>
+              <label className="text-xs text-muted-foreground">Observable Signals</label>
               <div className="space-y-2 mt-1">
                 {nextProblemSignals.map((signal, i) => (
                   <div key={i} className="flex items-center gap-2">
-                    <span className="flex-1 text-sm text-gray-300 bg-gray-800 px-3 py-1.5 rounded-lg">
+                    <span className="flex-1 text-sm text-muted-foreground bg-imperial-navy/70 border border-white/10 px-3 py-1.5 rounded-lg">
                       {signal}
                     </span>
                     <button
                       onClick={() => removeSignal(i)}
-                      className="text-gray-500 hover:text-red-400"
+                      className="text-muted-foreground hover:text-red-400"
+                      aria-label={`Remove signal ${i + 1}`}
                     >
                       <X className="w-3.5 h-3.5" />
                     </button>
@@ -785,11 +793,11 @@ function UpsellPathModal({
                     onChange={(e) => setNewSignal(e.target.value)}
                     onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), addSignal())}
                     placeholder="Add a signal..."
-                    className="flex-1 px-3 py-1.5 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm focus:border-amber-500/50 focus:outline-none"
+                    className="flex-1 rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none"
                   />
                   <button
                     onClick={addSignal}
-                    className="px-3 py-1.5 bg-gray-700 text-white rounded-lg text-sm hover:bg-gray-600"
+                    className="admin-console-button-muted px-3 py-1.5"
                   >
                     Add
                   </button>
@@ -805,11 +813,11 @@ function UpsellPathModal({
             </legend>
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <label className="text-xs text-gray-400">Content Type</label>
+                <label className="text-xs text-muted-foreground">Content Type</label>
                 <select
                   value={upsellContentType}
                   onChange={(e) => setUpsellContentType(e.target.value)}
-                  className="w-full mt-1 px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm focus:border-amber-500/50 focus:outline-none"
+                  className="w-full mt-1 rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none"
                 >
                   {CONTENT_TYPES.map((t) => (
                     <option key={t} value={t}>{t}</option>
@@ -817,35 +825,35 @@ function UpsellPathModal({
                 </select>
               </div>
               <div>
-                <label className="text-xs text-gray-400">Content ID</label>
+                <label className="text-xs text-muted-foreground">Content ID</label>
                 <input
                   type="text"
                   value={upsellContentId}
                   onChange={(e) => setUpsellContentId(e.target.value)}
                   placeholder="e.g. acc-deployed-chatbot"
-                  className="w-full mt-1 px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm focus:border-amber-500/50 focus:outline-none"
+                  className="w-full mt-1 rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none"
                 />
               </div>
             </div>
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <label className="text-xs text-gray-400">Display Title</label>
+                <label className="text-xs text-muted-foreground">Display Title</label>
                 <input
                   type="text"
                   value={upsellTitle}
                   onChange={(e) => setUpsellTitle(e.target.value)}
                   placeholder="AI Customer Support Chatbot (Deployed)"
-                  className="w-full mt-1 px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm focus:border-amber-500/50 focus:outline-none"
+                  className="w-full mt-1 rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none"
                 />
               </div>
               <div>
-                <label className="text-xs text-gray-400">Tier Slug (optional)</label>
+                <label className="text-xs text-muted-foreground">Tier Slug (optional)</label>
                 <input
                   type="text"
                   value={upsellTierSlug}
                   onChange={(e) => setUpsellTierSlug(e.target.value)}
                   placeholder="accelerator"
-                  className="w-full mt-1 px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm focus:border-amber-500/50 focus:outline-none"
+                  className="w-full mt-1 rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none"
                 />
               </div>
             </div>
@@ -853,86 +861,86 @@ function UpsellPathModal({
 
           {/* Value & Pricing */}
           <fieldset className="space-y-3">
-            <legend className="text-sm font-semibold text-purple-400 uppercase tracking-wider">
+            <legend className="text-sm font-semibold text-radiant-gold uppercase tracking-wider">
               Value & Pricing
             </legend>
             <div className="grid grid-cols-3 gap-3">
               <div>
-                <label className="text-xs text-gray-400">Perceived Value ($)</label>
+                <label className="text-xs text-muted-foreground">Perceived Value ($)</label>
                 <input
                   type="number"
                   value={upsellPerceivedValue}
                   onChange={(e) => setUpsellPerceivedValue(e.target.value)}
                   placeholder="15000"
-                  className="w-full mt-1 px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm focus:border-amber-500/50 focus:outline-none"
+                  className="w-full mt-1 rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none"
                 />
               </div>
               <div>
-                <label className="text-xs text-gray-400">Incremental Cost ($)</label>
+                <label className="text-xs text-muted-foreground">Incremental Cost ($)</label>
                 <input
                   type="number"
                   value={incrementalCost}
                   onChange={(e) => setIncrementalCost(e.target.value)}
                   placeholder="5500"
-                  className="w-full mt-1 px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm focus:border-amber-500/50 focus:outline-none"
+                  className="w-full mt-1 rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none"
                 />
               </div>
               <div>
-                <label className="text-xs text-gray-400">Incremental Value ($)</label>
+                <label className="text-xs text-muted-foreground">Incremental Value ($)</label>
                 <input
                   type="number"
                   value={incrementalValue}
                   onChange={(e) => setIncrementalValue(e.target.value)}
                   placeholder="15000"
-                  className="w-full mt-1 px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm focus:border-amber-500/50 focus:outline-none"
+                  className="w-full mt-1 rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none"
                 />
               </div>
             </div>
             <div>
-              <label className="text-xs text-gray-400">Value Frame Text</label>
+              <label className="text-xs text-muted-foreground">Value Frame Text</label>
               <textarea
                 value={valueFrameText}
                 onChange={(e) => setValueFrameText(e.target.value)}
                 rows={2}
                 placeholder="The template is $1,997. The deployed chatbot is part of the Accelerator at $7,497..."
-                className="w-full mt-1 px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm focus:border-amber-500/50 focus:outline-none"
+                className="w-full mt-1 rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none"
               />
             </div>
             <div>
-              <label className="text-xs text-gray-400">Risk Reversal Text</label>
+              <label className="text-xs text-muted-foreground">Risk Reversal Text</label>
               <textarea
                 value={riskReversalText}
                 onChange={(e) => setRiskReversalText(e.target.value)}
                 rows={2}
                 placeholder="Accelerator Guarantee: Save 10+ hours per week within 90 days..."
-                className="w-full mt-1 px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm focus:border-amber-500/50 focus:outline-none"
+                className="w-full mt-1 rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none"
               />
             </div>
           </fieldset>
 
           {/* Credit Policy */}
           <fieldset className="space-y-3">
-            <legend className="text-sm font-semibold text-cyan-400 uppercase tracking-wider">
+            <legend className="text-sm font-semibold text-sky-200 uppercase tracking-wider">
               Credit Policy
             </legend>
-            <label className="flex items-center gap-2 text-sm text-gray-300">
+            <label className="flex items-center gap-2 text-sm text-muted-foreground">
               <input
                 type="checkbox"
                 checked={creditPreviousInvestment}
                 onChange={(e) => setCreditPreviousInvestment(e.target.checked)}
-                className="rounded border-gray-600"
+                className="rounded border-silicon-slate"
               />
               Previous investment applies as credit toward the upsell
             </label>
             {creditPreviousInvestment && (
               <div>
-                <label className="text-xs text-gray-400">Credit Note</label>
+                <label className="text-xs text-muted-foreground">Credit Note</label>
                 <input
                   type="text"
                   value={creditNote}
                   onChange={(e) => setCreditNote(e.target.value)}
                   placeholder="Your $1,997 CI Accelerator investment applies as credit..."
-                  className="w-full mt-1 px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm focus:border-amber-500/50 focus:outline-none"
+                  className="w-full mt-1 rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none"
                 />
               </div>
             )}
@@ -940,28 +948,28 @@ function UpsellPathModal({
 
           {/* Notes */}
           <div>
-            <label className="text-xs text-gray-400">Internal Notes (admin only)</label>
+            <label className="text-xs text-muted-foreground">Internal Notes (admin only)</label>
             <textarea
               value={notes}
               onChange={(e) => setNotes(e.target.value)}
               rows={2}
-              className="w-full mt-1 px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm focus:border-amber-500/50 focus:outline-none"
+              className="w-full mt-1 rounded-lg border border-silicon-slate/70 bg-imperial-navy/70 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-radiant-gold/70 focus:outline-none"
             />
           </div>
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-end gap-3 p-6 border-t border-gray-800">
+        <div className="flex items-center justify-end gap-3 p-6 border-t border-white/10">
           <button
             onClick={onClose}
-            className="px-4 py-2 text-gray-400 hover:text-white transition-colors"
+            className="admin-console-button-muted"
           >
             Cancel
           </button>
           <button
             onClick={handleSubmit}
             disabled={isSaving}
-            className="flex items-center gap-2 px-6 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-700 disabled:opacity-50 transition-colors"
+            className="admin-console-button-primary disabled:opacity-50"
           >
             <Save className="w-4 h-4" />
             {isSaving ? 'Saving...' : path ? 'Update' : 'Create'}

--- a/docs/design/amadutown-color-palette-audit.md
+++ b/docs/design/amadutown-color-palette-audit.md
@@ -35,6 +35,7 @@ The Agent Ops Mission Control surface at `/admin/agents` is the current referenc
 - **Global shell slice:** `AdminSidebar` and the admin mobile drawer now use the same operating-console frame: navy depth, gold active state, restrained hover/focus treatment, and clearer section hierarchy around the page-level work surfaces.
 - **Content Hub slice:** `/admin/content`, `/admin/products`, and `/admin/content/products` now use the shared admin console shell and card language for the content routing and catalog management surfaces.
 - **Outreach/Sales slice:** `/admin/outreach`, `/admin/outreach/dashboard`, `/admin/sales`, `/admin/lead-dashboards`, and `/admin/campaigns` now use the shared admin console shell/header treatment, with the noisiest sales/outreach gradients replaced by restrained command surfaces.
+- **Sales subpage slice:** `/admin/sales/products`, `/admin/sales/bundles`, `/admin/sales/scripts`, `/admin/sales/upsell-paths`, and `/admin/sales/implementation-roadmap` now use the shared admin console shell, surface headers, metric cards, muted form controls, and gold command actions.
 - **Next rollout candidates:** deeper content, outreach, sales, and detail pages still carry older gray, blue, purple, and cyan styling and should move to the same primitives in smaller follow-up PRs.
 
 ---


### PR DESCRIPTION
Summary
- Standardizes Sales Products, Bundles, Scripts, Upsell Paths, and Implementation Roadmap admin surfaces on the Mission Control / AmaduTown console styling.
- Cleans residual light/pastel form, modal, card, and button styling from the target Sales subpages.
- Updates the AmaduTown design audit with the Sales subpage standardization slice.

Validation
- npm run lint -- --file app/admin/sales/products/page.tsx --file app/admin/sales/bundles/page.tsx --file app/admin/sales/bundles/BundleCard.tsx --file app/admin/sales/scripts/page.tsx --file app/admin/sales/upsell-paths/page.tsx --file app/admin/sales/implementation-roadmap/page.tsx
- git diff --check
- npm run build:knowledge && npx tsc --noEmit --pretty false
- npm run build
- Browser smoke on local dev at http://localhost:3020 for /admin/sales/products, /admin/sales/bundles, /admin/sales/scripts, /admin/sales/upsell-paths, and /admin/sales/implementation-roadmap at desktop 1440x1100 and mobile 390x900. Verified admin console shell/header presence and no horizontal overflow.
- Modal smoke on desktop and mobile for bundle create, bundle detail, script create form, and upsell path create modal.

Integration Notes
- Conflict preflight: open PRs #317 and #320 do not overlap the Sales subpage files. The root checkout has unrelated subscription docs dirty and was not touched.
- Worktree environment bootstrap linked .env.local and .vercel from /Users/vambahsillah/Projects/Portfolio; .env.staging was not present in the source checkout.
- Build emitted the existing local n8n outbound warning because MOCK_N8N=false and N8N_DISABLE_OUTBOUND=false, but no n8n mutation/webhook path was executed.
- Vercel – portfolio and Vercel – portfolio-staging should be verified after merge.
- Rollback: revert this UI-only commit to restore the prior Sales subpage styling.