### PR TITLE
feat: polish outreach sales workflow surfaces

### DIFF
--- a/app/admin/outreach/dashboard/page.tsx
+++ b/app/admin/outreach/dashboard/page.tsx
@@ -149,10 +149,10 @@ function formatSourceLabel(source: string): string {
  * Get the icon and color for a platform/source
  */
 function getSourceIcon(source: string) {
-  if (source.includes('facebook')) return { Icon: Facebook, color: 'text-blue-500' }
+  if (source.includes('facebook')) return { Icon: Facebook, color: 'text-sky-300' }
   if (source.includes('linkedin')) return { Icon: Linkedin, color: 'text-sky-400' }
   if (source.includes('google_contacts')) return { Icon: Phone, color: 'text-green-400' }
-  if (source.includes('apollo')) return { Icon: Search, color: 'text-purple-400' }
+  if (source.includes('apollo')) return { Icon: Search, color: 'text-radiant-gold' }
   if (source.includes('google_maps')) return { Icon: Building2, color: 'text-yellow-400' }
   if (source.includes('referral')) return { Icon: Users, color: 'text-pink-400' }
   return { Icon: Search, color: 'text-muted-foreground' }
@@ -356,7 +356,7 @@ function DashboardContent() {
               className={`flex items-center gap-2 px-4 py-2 rounded-lg border transition-all ${
                 tempFilter === key
                   ? 'border-radiant-gold/50 bg-radiant-gold/15 text-radiant-gold'
-                  : 'border-white/10 bg-white/5 text-muted-foreground hover:border-radiant-gold/30 hover:text-foreground'
+                  : 'border-white/10 bg-silicon-slate/45 text-muted-foreground hover:border-radiant-gold/30 hover:text-foreground'
               }`}
             >
               <FilterIcon size={16} />
@@ -374,7 +374,7 @@ function DashboardContent() {
         <div className="admin-console-card mb-8 rounded-lg border overflow-hidden">
           <button
             onClick={() => setShowTriggerSection(!showTriggerSection)}
-            className="w-full p-4 flex items-center justify-between hover:bg-white/[0.03] transition-colors"
+            className="flex w-full items-center justify-between p-4 transition-colors hover:bg-silicon-slate/45"
           >
             <div className="flex items-center gap-3">
               <Zap size={20} className="text-radiant-gold" />
@@ -410,7 +410,7 @@ function DashboardContent() {
                 {/* Facebook */}
                 <div className="admin-console-metric rounded-lg border p-4">
                   <div className="flex items-center gap-2 mb-2">
-                    <Facebook size={20} className="text-blue-400" />
+                    <Facebook size={20} className="text-sky-300" />
                     <h3 className="font-semibold">Facebook</h3>
                   </div>
                   <p className="text-sm text-muted-foreground mb-3">
@@ -586,19 +586,19 @@ function DashboardContent() {
             >
               <div className="flex items-center justify-between mb-3">
                 <div className="flex items-center gap-2">
-                  <Snowflake size={20} className="text-blue-400" />
-                  <span className="font-semibold text-blue-300">Cold Leads</span>
+                  <Snowflake size={20} className="text-sky-300" />
+                  <span className="font-semibold text-sky-200">Cold Leads</span>
                 </div>
                 <span className="text-2xl font-bold">{data.coldFunnel.total}</span>
               </div>
             <div className="grid grid-cols-4 gap-3 text-xs">
               <div>
                 <div className="text-muted-foreground">Enriched</div>
-                <div className="font-medium text-blue-200">{data.coldFunnel.enriched}</div>
+                <div className="font-medium text-sky-100">{data.coldFunnel.enriched}</div>
               </div>
               <div>
                 <div className="text-muted-foreground">Contacted</div>
-                <div className="font-medium text-blue-200">{data.coldFunnel.contacted}</div>
+                <div className="font-medium text-sky-100">{data.coldFunnel.contacted}</div>
               </div>
               <div>
                 <div className="text-muted-foreground">Reply Rate</div>
@@ -616,13 +616,13 @@ function DashboardContent() {
         {/* Funnel Visualization */}
         <div className="mb-8">
           <h2 className="text-lg font-semibold mb-4 flex items-center gap-2">
-            <TrendingUp size={20} className="text-blue-400" />
+            <TrendingUp size={20} className="text-sky-300" />
             Pipeline Funnel
             {tempFilter !== 'all' && (
               <span className={`text-xs px-2 py-0.5 rounded ${
                 tempFilter === 'warm'
                   ? 'bg-orange-900/50 text-orange-400'
-                  : 'bg-blue-900/50 text-blue-400'
+                  : 'bg-sky-500/10 text-sky-300'
               }`}>
                 {tempFilter === 'warm' ? 'Warm Only' : 'Cold Only'}
               </span>
@@ -671,7 +671,7 @@ function DashboardContent() {
         {/* Key Metrics */}
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
           <div className="admin-console-metric rounded-lg border p-4">
-            <div className="text-sm text-blue-400">Reply Rate</div>
+            <div className="text-sm text-sky-300">Reply Rate</div>
             <div className="text-3xl font-bold mt-1">{activeFunnel.reply_rate}%</div>
           </div>
           <div className="admin-console-metric rounded-lg border p-4">
@@ -683,7 +683,7 @@ function DashboardContent() {
             <div className="text-3xl font-bold mt-1">{data.queueStats.draft || 0}</div>
           </div>
           <div className="admin-console-metric rounded-lg border p-4">
-            <div className="text-sm text-purple-400">Active Sequences</div>
+            <div className="text-sm text-radiant-gold">Active Sequences</div>
             <div className="text-3xl font-bold mt-1">
               {activeFunnel.contacted}
             </div>
@@ -694,13 +694,13 @@ function DashboardContent() {
           {/* Channel Performance */}
           <div className="admin-console-card rounded-lg border p-6">
             <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
-              <BarChart3 size={20} className="text-purple-400" />
+              <BarChart3 size={20} className="text-radiant-gold" />
               Channel Performance
             </h3>
             <div className="space-y-4">
               <div className="flex items-center justify-between p-3 bg-silicon-slate/50 rounded-lg">
                 <div className="flex items-center gap-3">
-                  <Mail size={20} className="text-blue-400" />
+                  <Mail size={20} className="text-sky-300" />
                   <div>
                     <div className="font-medium">Email</div>
                     <div className="text-xs text-muted-foreground">
@@ -837,7 +837,7 @@ function DashboardContent() {
           {/* Lead Sources */}
           <div className="admin-console-card rounded-lg border p-6">
             <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
-              <Search size={20} className="text-blue-400" />
+              <Search size={20} className="text-sky-300" />
               Lead Sources
             </h3>
             {data.leadSources.length > 0 ? (
@@ -865,7 +865,7 @@ function DashboardContent() {
                         <span className={`px-1.5 py-0.5 rounded ${
                           isWarmPlatform
                             ? 'bg-orange-900/30 text-orange-400'
-                            : 'bg-blue-900/30 text-blue-400'
+                            : 'bg-sky-500/10 text-sky-300'
                         }`}>
                           {source.platform}
                         </span>
@@ -901,7 +901,7 @@ function DashboardContent() {
                   <div className="flex items-center justify-between p-3 bg-silicon-slate/50 rounded-lg hover:bg-silicon-slate/70 cursor-pointer transition-all hover:border hover:border-radiant-gold/50">
                     <div className="flex items-center gap-3">
                       {activity.channel === 'email' ? (
-                        <Mail size={16} className="text-blue-400" />
+                        <Mail size={16} className="text-sky-300" />
                       ) : (
                         <Linkedin size={16} className="text-sky-400" />
                       )}
@@ -918,7 +918,7 @@ function DashboardContent() {
                     <span className={`px-2 py-0.5 rounded ${
                       activity.status === 'replied'
                         ? 'bg-green-900/50 text-green-400'
-                        : 'bg-purple-900/50 text-purple-400'
+                        : 'bg-radiant-gold/10 text-radiant-gold'
                     }`}>
                       {activity.status}
                     </span>

--- a/app/admin/outreach/page.tsx
+++ b/app/admin/outreach/page.tsx
@@ -845,7 +845,7 @@ function OutreachContent() {
             <AlertTriangle size={18} />
             <span className="font-medium">Escalations</span>
             {escalationsTotal > 0 && (
-              <span className="px-2 py-0.5 bg-orange-500/80 text-white text-xs font-semibold rounded-full">
+              <span className="rounded-full border border-radiant-gold/50 bg-radiant-gold/20 px-2 py-0.5 text-xs font-semibold text-radiant-gold">
                 {escalationsTotal}
               </span>
             )}
@@ -1032,7 +1032,7 @@ function OutreachContent() {
                       <button
                         type="button"
                         onClick={() => setSelectedLeadIds(new Set())}
-                        className="text-sm text-muted-foreground hover:text-white"
+                        className="text-sm text-muted-foreground hover:text-foreground"
                       >
                         Clear selection
                       </button>
@@ -1064,7 +1064,7 @@ function OutreachContent() {
                         initial={{ opacity: 0, y: 10 }}
                         animate={{ opacity: 1, y: 0 }}
                         exit={{ opacity: 0, y: -10 }}
-                        className={`rounded-xl border border-radiant-gold/12 bg-gradient-to-br from-white/[0.055] via-white/[0.025] to-transparent shadow-[0_18px_50px_rgba(0,0,0,0.18)] overflow-visible ${
+                        className={`admin-console-card admin-console-interactive overflow-visible rounded-xl border ${
                           leadRowMenuOpenId === lead.id ? 'relative z-20' : ''
                         }`}
                       >
@@ -1093,7 +1093,7 @@ function OutreachContent() {
                             className={`p-2 rounded-lg ${
                               isWarmLeadSource(lead.lead_source)
                                 ? 'bg-orange-900/30 text-orange-400'
-                                : 'bg-blue-900/30 text-blue-400'
+                                : 'bg-sky-500/10 text-sky-300'
                             }`}
                           >
                             {isWarmLeadSource(lead.lead_source) ? (
@@ -1106,10 +1106,10 @@ function OutreachContent() {
                           {/* Lead Info */}
                           <div className="flex-1 min-w-0">
                             <div className="flex items-center gap-2 flex-wrap">
-                              <h3 className="font-semibold text-white">
+                              <h3 className="font-semibold text-foreground">
                                 <Link
                                   href={`/admin/contacts/${lead.id}`}
-                                  className="inline-flex items-center gap-1.5 text-white hover:text-teal-300 transition-colors underline decoration-dotted decoration-teal-400/70 underline-offset-4 hover:decoration-teal-300"
+                                  className="inline-flex items-center gap-1.5 text-foreground hover:text-teal-300 transition-colors underline decoration-dotted decoration-teal-400/70 underline-offset-4 hover:decoration-teal-300"
                                   title="Open contact record"
                                 >
                                   <span>{lead.name}</span>
@@ -1121,7 +1121,7 @@ function OutreachContent() {
                                   Score: {lead.lead_score}
                                 </span>
                               )}
-                              <span className="px-2 py-0.5 border border-white/10 bg-white/5 text-foreground rounded text-xs">
+                              <span className="rounded border border-white/10 bg-silicon-slate/50 px-2 py-0.5 text-xs text-foreground">
                                 {lead.lead_source
                                   ?.replace(/^(warm|cold)_/i, '') // Remove warm_ or cold_ prefix
                                   .replace(/_/g, ' ') // Replace all underscores with spaces
@@ -1150,7 +1150,7 @@ function OutreachContent() {
                               )}
                               <Link
                                 href={`/admin/email-center?contact=${lead.id}`}
-                                className="inline-flex items-center gap-1 text-muted-foreground hover:text-blue-300 transition-colors underline decoration-dotted decoration-blue-400/50 underline-offset-2 hover:decoration-blue-300"
+                                className="inline-flex items-center gap-1 text-muted-foreground hover:text-sky-300 transition-colors underline decoration-dotted decoration-sky-400/50 underline-offset-2 hover:decoration-sky-300"
                                 title={`Open Email center for this lead (${lead.messages_count} messages, ${lead.messages_sent} sent)`}
                                 aria-label={`Open Email center for ${lead.name}`}
                               >
@@ -1255,12 +1255,12 @@ function OutreachContent() {
                                     onClick={() => openReviewEnrichModal([lead.id])}
                                     title={pushTitle}
                                     aria-label={pushTitle}
-                                    className={`group inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-medium border transition-colors focus:outline-none focus:ring-2 focus:ring-purple-500/40 ${
+                                    className={`group inline-flex items-center gap-1 rounded border px-2 py-1 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-radiant-gold/40 ${
                                       failed
-                                        ? 'bg-red-900/35 text-red-200 border-red-700/60 enabled:hover:bg-purple-600/85 enabled:hover:text-white enabled:hover:border-purple-400'
+                                        ? 'bg-red-900/35 text-red-200 border-red-700/60 enabled:hover:bg-radiant-gold/20 enabled:hover:text-radiant-gold enabled:hover:border-radiant-gold/50'
                                         : isVepStalePending
-                                          ? 'bg-amber-900/35 text-amber-200 border-amber-700/60 enabled:hover:bg-purple-600/85 enabled:hover:text-white enabled:hover:border-purple-400'
-                                          : 'bg-gray-700/90 text-foreground/85 border-gray-600 enabled:hover:bg-purple-600/85 enabled:hover:text-white enabled:hover:border-purple-400'
+                                          ? 'bg-amber-900/35 text-amber-200 border-amber-700/60 enabled:hover:bg-radiant-gold/20 enabled:hover:text-radiant-gold enabled:hover:border-radiant-gold/50'
+                                          : 'bg-silicon-slate/80 text-foreground/85 border-white/10 enabled:hover:bg-radiant-gold/20 enabled:hover:text-radiant-gold enabled:hover:border-radiant-gold/50'
                                     } disabled:opacity-55 disabled:cursor-not-allowed`}
                                   >
                                     <span>{chipLabel}</span>
@@ -1318,7 +1318,7 @@ function OutreachContent() {
                               {leadRowMenuOpenId === lead.id && (
                                 <div
                                   role="menu"
-                                  className="absolute right-0 top-full mt-1 z-50 min-w-[14rem] py-1 rounded-lg border border-silicon-slate bg-background shadow-xl"
+                                  className="absolute right-0 top-full mt-1 z-50 min-w-[14rem] rounded-lg border border-white/10 bg-background py-1 shadow-[0_18px_50px_rgba(0,0,0,0.35)]"
                                 >
                                   {/* Compose & in-app generation live on the lead row (OutreachEmailGenerateRow). */}
 
@@ -1585,7 +1585,7 @@ function OutreachContent() {
                                     {lead.email && (
                                       <div className="flex items-center gap-2">
                                         <Mail size={14} className="text-muted-foreground" />
-                                        <a href={`mailto:${lead.email}`} className="text-blue-400 hover:text-blue-300">
+                                        <a href={`mailto:${lead.email}`} className="text-sky-300 hover:text-sky-200">
                                           {lead.email}
                                         </a>
                                       </div>
@@ -1613,7 +1613,7 @@ function OutreachContent() {
                                     {lead.phone_number && (
                                       <div className="flex items-center gap-2">
                                         <Phone size={14} className="text-muted-foreground" />
-                                        <a href={`tel:${lead.phone_number}`} className="text-foreground hover:text-white">
+                                        <a href={`tel:${lead.phone_number}`} className="text-foreground hover:text-radiant-gold">
                                           {lead.phone_number}
                                         </a>
                                       </div>
@@ -1631,7 +1631,7 @@ function OutreachContent() {
                                           href={lead.company_domain.startsWith('http') ? lead.company_domain : `https://${lead.company_domain}`}
                                           target="_blank"
                                           rel="noopener noreferrer"
-                                          className="text-blue-400 hover:text-blue-300 flex items-center gap-1"
+                                          className="flex items-center gap-1 text-sky-300 hover:text-sky-200"
                                         >
                                           {lead.company_domain}
                                           <ExternalLink size={12} />
@@ -1806,7 +1806,7 @@ function OutreachContent() {
                                             `/admin/meeting-tasks?contact_submission_id=${lead.id}`,
                                             `/admin/outreach?tab=leads&id=${lead.id}`
                                           )}
-                                          className="text-[11px] text-violet-400 hover:text-violet-300"
+                                          className="text-[11px] text-radiant-gold hover:text-amber-300"
                                         >
                                           Manage →
                                         </Link>
@@ -1821,8 +1821,8 @@ function OutreachContent() {
                                             <li key={t.id} className="flex items-center gap-2 text-xs">
                                               <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${
                                                 t.status === 'complete' ? 'bg-emerald-500'
-                                                  : t.status === 'cancelled' ? 'bg-gray-600'
-                                                  : t.status === 'in_progress' ? 'bg-blue-500'
+                                                  : t.status === 'cancelled' ? 'bg-silicon-slate'
+                                                  : t.status === 'in_progress' ? 'bg-sky-400'
                                                   : 'bg-amber-500'
                                               }`} />
                                               <span className={`truncate flex-1 ${
@@ -1833,7 +1833,7 @@ function OutreachContent() {
                                                 {t.title}
                                               </span>
                                               {t.task_category === 'outreach' && (
-                                                <span className="text-[10px] px-1 py-0.5 rounded bg-violet-500/10 text-violet-300 border border-violet-500/20">
+                                                <span className="rounded border border-radiant-gold/30 bg-radiant-gold/10 px-1 py-0.5 text-[10px] text-radiant-gold">
                                                   outreach
                                                 </span>
                                               )}
@@ -1873,11 +1873,11 @@ function OutreachContent() {
                                             <Link
                                               key={m.id}
                                               href={buildLinkWithReturn(`/admin/meetings/${m.id}`, `/admin/outreach?tab=leads&id=${lead.id}`)}
-                                              className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md bg-violet-900/30 text-violet-300 border border-violet-800/50 text-xs hover:bg-violet-800/40 transition-colors"
+                                              className="inline-flex items-center gap-1.5 rounded-md border border-radiant-gold/30 bg-radiant-gold/10 px-2.5 py-1 text-xs text-radiant-gold transition-colors hover:bg-radiant-gold/20"
                                             >
                                               <Video size={12} />
                                               {m.meeting_type.replace(/_/g, ' ')}
-                                              <span className="text-violet-400/70">
+                                              <span className="text-radiant-gold/70">
                                                 {new Date(m.meeting_date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
                                               </span>
                                             </Link>
@@ -1927,7 +1927,7 @@ function OutreachContent() {
                                             console.error('Failed to start conversation:', err)
                                           }
                                         }}
-                                        className="flex items-center gap-2 text-sm text-purple-400 hover:text-purple-300"
+                                        className="flex items-center gap-2 text-sm text-radiant-gold hover:text-amber-300"
                                       >
                                         <MessageSquare size={14} />
                                         Start Conversation
@@ -2053,7 +2053,7 @@ function OutreachContent() {
                         </td>
                         <td className="px-4 py-3 text-sm">
                           {e.contact_submissions ? (
-                            <Link href={`/admin/outreach?tab=leads&id=${e.contact_submission_id}`} className="text-purple-400 hover:text-purple-300">
+                            <Link href={`/admin/outreach?tab=leads&id=${e.contact_submission_id}`} className="text-radiant-gold hover:text-amber-300">
                               {e.contact_submissions.name || e.contact_submissions.email || 'Lead'}
                             </Link>
                           ) : (

--- a/app/admin/sales/page.tsx
+++ b/app/admin/sales/page.tsx
@@ -505,7 +505,7 @@ export default function SalesDashboardPage() {
                   <th className="text-right px-4 py-3 text-sm font-medium text-muted-foreground">Action</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-gray-800">
+              <tbody className="divide-y divide-white/10">
                 {filteredLeads.map((lead) => {
                   const primaryDate = lead.audit?.created_at ?? lead.session?.created_at ?? '';
                   return (
@@ -515,7 +515,7 @@ export default function SalesDashboardPage() {
                           <div className="font-medium text-foreground flex items-center gap-2">
                             <Link
                               href={buildLinkWithReturn(`/admin/contacts/${lead.contact_id}`, '/admin/sales')}
-                              className="inline-flex items-center gap-1.5 text-white hover:text-teal-300 transition-colors underline decoration-dotted decoration-teal-400/70 underline-offset-4 hover:decoration-teal-300"
+                              className="inline-flex items-center gap-1.5 text-foreground hover:text-teal-300 transition-colors underline decoration-dotted decoration-teal-400/70 underline-offset-4 hover:decoration-teal-300"
                               title="Open contact record"
                             >
                               <span>{lead.name || 'Unknown'}</span>
@@ -528,7 +528,7 @@ export default function SalesDashboardPage() {
                                 <span className="inline-flex items-center gap-1">
                                   <span className="w-2 h-2 rounded-full bg-emerald-400" title="Value report generated" />
                                   {status.gammaUrl && (
-                                    <span className="w-2 h-2 rounded-full bg-purple-400" title="Gamma deck ready" />
+                                    <span className="w-2 h-2 rounded-full bg-radiant-gold" title="Gamma deck ready" />
                                   )}
                                 </span>
                               );
@@ -611,7 +611,7 @@ export default function SalesDashboardPage() {
                       <td className="px-4 py-4 text-sm text-muted-foreground">
                         {primaryDate ? formatDate(primaryDate) : '—'}
                         {lead.session?.next_follow_up && (
-                          <div className="text-xs text-blue-400 mt-1 flex items-center gap-1">
+                          <div className="mt-1 flex items-center gap-1 text-xs text-sky-300">
                             <Calendar className="w-3 h-3" />
                             Follow-up: {formatDate(lead.session.next_follow_up)}
                           </div>
@@ -658,7 +658,7 @@ export default function SalesDashboardPage() {
                           })()}
                           <Link
                             href={buildLinkWithReturn(`/admin/outreach?tab=leads&id=${lead.contact_id}`, '/admin/sales')}
-                            className="inline-flex items-center gap-1 px-3 py-1.5 bg-purple-900/30 hover:bg-purple-800/50 text-purple-400 rounded-lg text-sm transition-colors"
+                            className="inline-flex items-center gap-1 rounded-lg border border-radiant-gold/30 bg-radiant-gold/10 px-3 py-1.5 text-sm text-radiant-gold transition-colors hover:bg-radiant-gold/20"
                           >
                             <Users className="w-4 h-4" />
                             View Lead
@@ -694,7 +694,7 @@ export default function SalesDashboardPage() {
         {conversationSessions.length > 0 && (
           <div className="mt-8">
             <h2 className="text-lg font-semibold text-foreground mb-4 flex items-center gap-2">
-              <Phone className="w-5 h-5 text-purple-500" />
+              <Phone className="w-5 h-5 text-radiant-gold" />
               Active Conversations
               <span className="text-sm font-normal text-muted-foreground">({filteredConversationSessions.length})</span>
             </h2>
@@ -709,7 +709,7 @@ export default function SalesDashboardPage() {
                     <th className="text-right px-4 py-3 text-sm font-medium text-muted-foreground">Action</th>
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-gray-800">
+                <tbody className="divide-y divide-white/10">
                   {filteredConversationSessions.map(s => (
                     <tr key={s.id} className="hover:bg-silicon-slate/50">
                       <td className="px-4 py-4">
@@ -729,7 +729,7 @@ export default function SalesDashboardPage() {
                       <td className="px-4 py-4 text-sm text-muted-foreground">
                         {formatDate(s.created_at)}
                         {s.next_follow_up && (
-                          <div className="text-xs text-blue-400 mt-1 flex items-center gap-1">
+                          <div className="mt-1 flex items-center gap-1 text-xs text-sky-300">
                             <Calendar className="w-3 h-3" />
                             Follow-up: {formatDate(s.next_follow_up)}
                           </div>

--- a/docs/design/amadutown-color-palette-audit.md
+++ b/docs/design/amadutown-color-palette-audit.md
@@ -35,8 +35,10 @@ The Agent Ops Mission Control surface at `/admin/agents` is the current referenc
 - **Global shell slice:** `AdminSidebar` and the admin mobile drawer now use the same operating-console frame: navy depth, gold active state, restrained hover/focus treatment, and clearer section hierarchy around the page-level work surfaces.
 - **Content Hub slice:** `/admin/content`, `/admin/products`, and `/admin/content/products` now use the shared admin console shell and card language for the content routing and catalog management surfaces.
 - **Outreach/Sales slice:** `/admin/outreach`, `/admin/outreach/dashboard`, `/admin/sales`, `/admin/lead-dashboards`, and `/admin/campaigns` now use the shared admin console shell/header treatment, with the noisiest sales/outreach gradients replaced by restrained command surfaces.
+- **Outreach/Sales workflow polish:** Lead Pipeline rows, Outreach Dashboard metrics/activity, escalation links, and Sales Dashboard table actions now use the shared console palette for their nested workflow controls and status affordances.
 - **Sales subpage slice:** `/admin/sales/products`, `/admin/sales/bundles`, `/admin/sales/scripts`, `/admin/sales/upsell-paths`, and `/admin/sales/implementation-roadmap` now use the shared admin console shell, surface headers, metric cards, muted form controls, and gold command actions.
-- **Next rollout candidates:** deeper content, outreach, sales, and detail pages still carry older gray, blue, purple, and cyan styling and should move to the same primitives in smaller follow-up PRs.
+- **Future auth slice:** Login, signup, forgot-password, and reset-password should be redesigned around the same AmaduTown operating-console language so the entry point no longer feels visually disconnected from admin.
+- **Next rollout candidates:** deeper content, auth, public commerce, checkout, and client-facing detail pages still carry older gray, blue, purple, and cyan styling and should move to the same primitives in smaller follow-up PRs.
 
 ---
 


### PR DESCRIPTION
Summary
- Polishes nested Lead Pipeline, Outreach Dashboard, and Sales Dashboard workflow controls to better match the Mission Control / AmaduTown console standard.
- Removes remaining legacy blue/purple/gray styling from the targeted Outreach/Sales workflow files and replaces it with console primitives, sky support accents, gold command accents, and restrained borders.
- Captures auth redesign as a future design-standard slice in the AmaduTown palette audit.

Validation
- Conflict preflight: root checkout is on automation/vercel-autoresearch-notify-guard with unrelated subscription docs and .tmp; open PRs #317 and #320 do not overlap this work.
- Worktree env bootstrap: .env.local and .vercel present; .env.staging absent in source checkout.
- npm run lint -- --file app/admin/outreach/page.tsx --file app/admin/outreach/dashboard/page.tsx --file app/admin/outreach/escalations/[id]/page.tsx --file app/admin/sales/page.tsx
- git diff --check
- npm run build:knowledge && npx tsc --noEmit --pretty false
- npm run build (first run hit stale .next /_error PageNotFound after static generation; rerun after rm -rf .next passed)
- Authenticated Playwright smoke at http://localhost:3021 for /admin/outreach, /admin/outreach/dashboard, /admin/outreach?tab=escalations, and /admin/sales on desktop 1440x1100 and mobile 390x900. Verified console page/header presence and no horizontal overflow.
- Legacy palette scan returned no matches for old gray/blue/purple/cyan utility classes in the targeted Outreach/Sales files.

Integration Notes
- UI-only change; no database, API, outbound workflow, or production mutation path changed.
- Build emitted the existing local n8n outbound warning because MOCK_N8N=false and N8N_DISABLE_OUTBOUND=false, but no n8n mutation/webhook path was executed.
- Vercel – portfolio and Vercel – portfolio-staging should be verified after merge.
- Rollback: revert this UI-only commit to restore the prior nested Outreach/Sales styling.