### PR TITLE
feat: redesign auth entry surfaces

### DIFF
--- a/app/auth/forgot-password/page.tsx
+++ b/app/auth/forgot-password/page.tsx
@@ -5,7 +5,7 @@ import { motion } from 'framer-motion'
 import { Mail } from 'lucide-react'
 import { resetPassword } from '@/lib/auth'
 import Link from 'next/link'
-import SiteThemeCorner from '@/components/SiteThemeCorner'
+import AuthShell from '@/components/auth/AuthShell'
 
 export default function ForgotPasswordPage() {
   const [email, setEmail] = useState('')
@@ -33,71 +33,69 @@ export default function ForgotPasswordPage() {
   }
 
   return (
-    <>
-      <SiteThemeCorner />
-    <div className="min-h-screen bg-background text-foreground flex items-center justify-center px-4 py-12">
-      <div className="w-full max-w-md">
-        <motion.form
-          onSubmit={handleSubmit}
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          className="space-y-6 bg-silicon-slate border border-silicon-slate rounded-xl p-8"
-        >
-          <div>
-            <h2 className="text-3xl font-bold text-foreground mb-2">Reset password</h2>
-            <p className="text-muted-foreground">Enter your account email and we&apos;ll send a link to set a new password.</p>
-          </div>
-
-          {error && (
-            <div className="p-4 bg-red-500/20 border border-red-500/50 rounded-lg text-red-400 text-sm">
-              {error}
-            </div>
-          )}
-
-          {sent ? (
-            <div className="p-4 bg-green-500/20 border border-green-500/50 rounded-lg text-green-400 text-sm">
-              Check your email for the reset link. It may take a few minutes. Click the link to set a new password.
-            </div>
-          ) : (
-            <>
-              <div>
-                <label htmlFor="email" className="block text-sm font-medium text-foreground mb-2">
-                  Email
-                </label>
-                <div className="relative">
-                  <Mail className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground" size={20} />
-                  <input
-                    id="email"
-                    type="email"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    required
-                    className="w-full pl-10 pr-4 py-3 input-brand transition-colors"
-                    placeholder="you@example.com"
-                  />
-                </div>
-              </div>
-
-              <motion.button
-                type="submit"
-                disabled={loading}
-                whileHover={{ scale: 1.02 }}
-                whileTap={{ scale: 0.98 }}
-                className="w-full py-3 btn-gold text-imperial-navy font-semibold disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {loading ? 'Sending…' : 'Send reset link'}
-              </motion.button>
-            </>
-          )}
-
-          <p className="text-center text-sm text-muted-foreground">
-            <Link href="/auth/login" className="text-radiant-gold hover:text-gold-light transition-colors">
-              Back to sign in
-            </Link>
+    <AuthShell>
+      <motion.form
+        onSubmit={handleSubmit}
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="admin-console-command-card space-y-6 rounded-xl border p-6 sm:p-8"
+      >
+        <div>
+          <div className="admin-console-eyebrow mb-3">Account recovery</div>
+          <h2 className="text-3xl font-bold text-foreground">Reset password</h2>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            Enter your account email. We will send a secure link to set a new password.
           </p>
-        </motion.form>
-      </div>
-    </div>
-    </>
+        </div>
+
+        {error && (
+          <div className="rounded-lg border border-red-500/45 bg-red-500/15 p-4 text-sm text-red-200">
+            {error}
+          </div>
+        )}
+
+        {sent ? (
+          <div className="rounded-lg border border-green-500/40 bg-green-500/15 p-4 text-sm text-green-100">
+            Check your email for the reset link. It may take a few minutes.
+          </div>
+        ) : (
+          <>
+            <div>
+              <label htmlFor="email" className="mb-2 block text-sm font-medium text-foreground">
+                Email
+              </label>
+              <div className="relative">
+                <Mail className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" size={20} />
+                <input
+                  id="email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
+                  className="input-brand w-full py-3 pl-10 pr-4 transition-colors"
+                  placeholder="you@example.com"
+                />
+              </div>
+            </div>
+
+            <motion.button
+              type="submit"
+              disabled={loading}
+              whileHover={{ scale: 1.02 }}
+              whileTap={{ scale: 0.98 }}
+              className="admin-console-button-primary h-12 w-full text-base disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {loading ? 'Sending...' : 'Send reset link'}
+            </motion.button>
+          </>
+        )}
+
+        <p className="text-center text-sm text-muted-foreground">
+          <Link href="/auth/login" className="text-radiant-gold transition-colors hover:text-gold-light">
+            Back to sign in
+          </Link>
+        </p>
+      </motion.form>
+    </AuthShell>
   )
 }

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -1,20 +1,15 @@
 'use client'
 
 import { Suspense } from 'react'
+import AuthShell from '@/components/auth/AuthShell'
 import LoginForm from '@/components/auth/LoginForm'
-import SiteThemeCorner from '@/components/SiteThemeCorner'
 
 export default function LoginPage() {
   return (
-    <>
-      <SiteThemeCorner />
-    <div className="min-h-screen bg-background text-foreground flex items-center justify-center px-4 py-12">
-      <div className="w-full max-w-md">
-        <Suspense fallback={<div className="text-muted-foreground text-center py-8">Loading...</div>}>
-          <LoginForm />
-        </Suspense>
-      </div>
-    </div>
-    </>
+    <AuthShell>
+      <Suspense fallback={<div className="py-8 text-center text-muted-foreground">Loading...</div>}>
+        <LoginForm />
+      </Suspense>
+    </AuthShell>
   )
 }

--- a/app/auth/reset-password/page.tsx
+++ b/app/auth/reset-password/page.tsx
@@ -6,7 +6,7 @@ import { Lock } from 'lucide-react'
 import { updatePassword } from '@/lib/auth'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
-import SiteThemeCorner from '@/components/SiteThemeCorner'
+import AuthShell from '@/components/auth/AuthShell'
 
 export default function ResetPasswordPage() {
   const [password, setPassword] = useState('')
@@ -55,99 +55,95 @@ export default function ResetPasswordPage() {
 
   if (!ready) {
     return (
-      <>
-        <SiteThemeCorner />
-      <div className="min-h-screen bg-background text-foreground flex items-center justify-center px-4 py-12">
-        <div className="w-full max-w-md bg-silicon-slate border border-silicon-slate rounded-xl p-8 text-center">
-          <p className="text-muted-foreground mb-4">Checking your reset link…</p>
-          <p className="text-muted-foreground text-sm">
+      <AuthShell>
+        <div className="admin-console-card rounded-xl border p-8 text-center">
+          <div className="admin-console-eyebrow mb-3 justify-center">Recovery link</div>
+          <p className="mb-4 text-muted-foreground">Checking your reset link...</p>
+          <p className="text-sm leading-6 text-muted-foreground">
             If this page doesn’t update, the link may be invalid or expired.{' '}
             <Link href="/auth/forgot-password" className="text-radiant-gold hover:text-gold-light">Request a new one</Link>.
           </p>
         </div>
-      </div>
-      </>
+      </AuthShell>
     )
   }
 
   return (
-    <>
-      <SiteThemeCorner />
-    <div className="min-h-screen bg-background text-foreground flex items-center justify-center px-4 py-12">
-      <div className="w-full max-w-md">
-        <motion.form
-          onSubmit={handleSubmit}
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          className="space-y-6 bg-silicon-slate border border-silicon-slate rounded-xl p-8"
-        >
-          <div>
-            <h2 className="text-3xl font-bold text-foreground mb-2">Set new password</h2>
-            <p className="text-muted-foreground">Choose a password you’ll use to sign in with email.</p>
-          </div>
-
-          {error && (
-            <div className="p-4 bg-red-500/20 border border-red-500/50 rounded-lg text-red-400 text-sm">
-              {error}
-            </div>
-          )}
-
-          <div>
-            <label htmlFor="password" className="block text-sm font-medium text-foreground mb-2">
-              New password
-            </label>
-            <div className="relative">
-              <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground" size={20} />
-              <input
-                id="password"
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-                minLength={6}
-                className="w-full pl-10 pr-4 py-3 input-brand transition-colors"
-                placeholder="••••••••"
-              />
-            </div>
-          </div>
-
-          <div>
-            <label htmlFor="confirm" className="block text-sm font-medium text-foreground mb-2">
-              Confirm password
-            </label>
-            <div className="relative">
-              <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground" size={20} />
-              <input
-                id="confirm"
-                type="password"
-                value={confirm}
-                onChange={(e) => setConfirm(e.target.value)}
-                required
-                minLength={6}
-                className="w-full pl-10 pr-4 py-3 input-brand transition-colors"
-                placeholder="••••••••"
-              />
-            </div>
-          </div>
-
-          <motion.button
-            type="submit"
-            disabled={loading}
-            whileHover={{ scale: 1.02 }}
-            whileTap={{ scale: 0.98 }}
-            className="w-full py-3 btn-gold text-imperial-navy font-semibold disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {loading ? 'Saving…' : 'Set password'}
-          </motion.button>
-
-          <p className="text-center text-sm text-muted-foreground">
-            <Link href="/auth/login" className="text-radiant-gold hover:text-gold-light transition-colors">
-              Back to sign in
-            </Link>
+    <AuthShell>
+      <motion.form
+        onSubmit={handleSubmit}
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="admin-console-command-card space-y-6 rounded-xl border p-6 sm:p-8"
+      >
+        <div>
+          <div className="admin-console-eyebrow mb-3">Account recovery</div>
+          <h2 className="text-3xl font-bold text-foreground">Set new password</h2>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            Choose the password you will use to sign in with email.
           </p>
-        </motion.form>
-      </div>
-    </div>
-    </>
+        </div>
+
+        {error && (
+          <div className="rounded-lg border border-red-500/45 bg-red-500/15 p-4 text-sm text-red-200">
+            {error}
+          </div>
+        )}
+
+        <div>
+          <label htmlFor="password" className="mb-2 block text-sm font-medium text-foreground">
+            New password
+          </label>
+          <div className="relative">
+            <Lock className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" size={20} />
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              minLength={6}
+              className="input-brand w-full py-3 pl-10 pr-4 transition-colors"
+              placeholder="••••••••"
+            />
+          </div>
+        </div>
+
+        <div>
+          <label htmlFor="confirm" className="mb-2 block text-sm font-medium text-foreground">
+            Confirm password
+          </label>
+          <div className="relative">
+            <Lock className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" size={20} />
+            <input
+              id="confirm"
+              type="password"
+              value={confirm}
+              onChange={(e) => setConfirm(e.target.value)}
+              required
+              minLength={6}
+              className="input-brand w-full py-3 pl-10 pr-4 transition-colors"
+              placeholder="••••••••"
+            />
+          </div>
+        </div>
+
+        <motion.button
+          type="submit"
+          disabled={loading}
+          whileHover={{ scale: 1.02 }}
+          whileTap={{ scale: 0.98 }}
+          className="admin-console-button-primary h-12 w-full text-base disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {loading ? 'Saving...' : 'Set password'}
+        </motion.button>
+
+        <p className="text-center text-sm text-muted-foreground">
+          <Link href="/auth/login" className="text-radiant-gold transition-colors hover:text-gold-light">
+            Back to sign in
+          </Link>
+        </p>
+      </motion.form>
+    </AuthShell>
   )
 }

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -1,20 +1,15 @@
 'use client'
 
 import { Suspense } from 'react'
+import AuthShell from '@/components/auth/AuthShell'
 import SignupForm from '@/components/auth/SignupForm'
-import SiteThemeCorner from '@/components/SiteThemeCorner'
 
 export default function SignupPage() {
   return (
-    <>
-      <SiteThemeCorner />
-    <div className="min-h-screen bg-background text-foreground flex items-center justify-center px-4 py-12">
-      <div className="w-full max-w-md">
-        <Suspense fallback={<div className="text-muted-foreground text-center py-8">Loading...</div>}>
-          <SignupForm />
-        </Suspense>
-      </div>
-    </div>
-    </>
+    <AuthShell>
+      <Suspense fallback={<div className="py-8 text-center text-muted-foreground">Loading...</div>}>
+        <SignupForm />
+      </Suspense>
+    </AuthShell>
   )
 }

--- a/components/auth/AuthShell.tsx
+++ b/components/auth/AuthShell.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import SiteThemeCorner from '@/components/SiteThemeCorner'
+import { Briefcase, ShieldCheck, Sparkles } from 'lucide-react'
+import type { ReactNode } from 'react'
+
+type AuthShellProps = {
+  children: ReactNode
+}
+
+const accessPoints = [
+  {
+    label: 'Admin operations',
+    description: 'Dashboards, agent control, and delivery workflows',
+    icon: Briefcase,
+  },
+  {
+    label: 'Secure session',
+    description: 'Account access stays behind the auth boundary',
+    icon: ShieldCheck,
+  },
+  {
+    label: 'Portfolio workspace',
+    description: 'Lead evidence, reports, and client-facing tools',
+    icon: Sparkles,
+  },
+]
+
+export default function AuthShell({ children }: AuthShellProps) {
+  return (
+    <>
+      <SiteThemeCorner />
+      <main className="admin-console-page dark min-h-screen text-foreground">
+        <div className="mx-auto flex min-h-screen w-full max-w-6xl items-center px-4 py-20 sm:px-6 lg:px-8">
+          <div className="grid w-full gap-6 lg:grid-cols-[0.95fr_1.05fr] lg:items-center">
+            <section className="admin-console-surface-header hidden rounded-xl border p-8 lg:block">
+              <div className="admin-console-eyebrow mb-4">
+                <ShieldCheck className="h-4 w-4" />
+                AmaduTown Portfolio
+              </div>
+              <h1 className="max-w-xl text-4xl font-bold leading-tight text-foreground">
+                One secure entry point for the operating workspace.
+              </h1>
+              <p className="mt-4 max-w-lg text-base leading-7 text-muted-foreground">
+                Sign in once, then move through admin operations, client delivery,
+                and agent control surfaces from the same workspace.
+              </p>
+
+              <div className="mt-8 grid gap-3">
+                {accessPoints.map(({ label, description, icon: Icon }) => (
+                  <div key={label} className="rounded-lg border border-white/10 bg-silicon-slate/35 p-4">
+                    <div className="flex items-start gap-3">
+                      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-radiant-gold/25 bg-radiant-gold/10 text-radiant-gold">
+                        <Icon className="h-4 w-4" />
+                      </div>
+                      <div>
+                        <h2 className="text-sm font-semibold text-foreground">{label}</h2>
+                        <p className="mt-1 text-sm leading-6 text-muted-foreground">{description}</p>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            <div className="mx-auto w-full max-w-md">{children}</div>
+          </div>
+        </div>
+      </main>
+    </>
+  )
+}

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { Mail, Lock, LogIn, Github } from 'lucide-react'
+import { Github, Lock, LogIn, Mail } from 'lucide-react'
 import { signIn, signInWithOAuth } from '@/lib/auth'
 import { useRouter, useSearchParams } from 'next/navigation'
 
@@ -50,54 +50,57 @@ export default function LoginForm() {
   }
 
   return (
-    <div className="w-full max-w-md mx-auto">
+    <div className="mx-auto w-full max-w-md">
       <form
         onSubmit={handleSubmit}
-        className="space-y-6 bg-silicon-slate border border-silicon-slate rounded-xl p-8 animate-fade-in-up"
+        className="admin-console-command-card animate-fade-in-up space-y-6 rounded-xl border p-6 sm:p-8"
       >
         <div>
-          <h2 className="text-3xl font-bold text-foreground mb-2">Welcome Back</h2>
-          <p className="text-muted-foreground">Sign in to access exclusive content</p>
+          <div className="admin-console-eyebrow mb-3">Secure access</div>
+          <h2 className="text-3xl font-bold text-foreground">Sign in</h2>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            Access Portfolio operations, client workspaces, and saved admin context.
+          </p>
         </div>
 
         {error && (
-          <div className="p-4 bg-red-500/20 border border-red-500/50 rounded-lg text-red-400 text-sm animate-fade-in">
+          <div className="animate-fade-in rounded-lg border border-red-500/45 bg-red-500/15 p-4 text-sm text-red-200">
             {error}
           </div>
         )}
 
         <div className="space-y-4">
           <div>
-            <label htmlFor="email" className="block text-sm font-medium text-foreground mb-2">
+            <label htmlFor="email" className="mb-2 block text-sm font-medium text-foreground">
               Email
             </label>
             <div className="relative">
-              <Mail className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground" size={20} />
+              <Mail className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" size={20} />
               <input
                 id="email"
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 required
-                className="w-full pl-10 pr-4 py-3 input-brand transition-colors"
+                className="input-brand w-full py-3 pl-10 pr-4 transition-colors"
                 placeholder="you@example.com"
               />
             </div>
           </div>
 
           <div>
-            <label htmlFor="password" className="block text-sm font-medium text-foreground mb-2">
+            <label htmlFor="password" className="mb-2 block text-sm font-medium text-foreground">
               Password
             </label>
             <div className="relative">
-              <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground" size={20} />
+              <Lock className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" size={20} />
               <input
                 id="password"
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 required
-                className="w-full pl-10 pr-4 py-3 input-brand transition-colors"
+                className="input-brand w-full py-3 pl-10 pr-4 transition-colors"
                 placeholder="••••••••"
               />
             </div>
@@ -107,7 +110,7 @@ export default function LoginForm() {
         <button
           type="submit"
           disabled={loading}
-          className="w-full py-3 btn-gold text-imperial-navy font-semibold flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed transition-transform duration-150 hover:scale-[1.02] active:scale-[0.98]"
+          className="admin-console-button-primary h-12 w-full text-base transition-transform duration-150 active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-50"
         >
           {loading ? (
             'Signing in...'
@@ -121,10 +124,10 @@ export default function LoginForm() {
 
         <div className="relative">
           <div className="absolute inset-0 flex items-center">
-            <div className="w-full border-t border-silicon-slate"></div>
+            <div className="w-full border-t border-white/10"></div>
           </div>
           <div className="relative flex justify-center text-sm">
-            <span className="px-2 bg-silicon-slate text-muted-foreground">Or continue with</span>
+            <span className="bg-[#121e31] px-3 text-muted-foreground">Or continue with</span>
           </div>
         </div>
 
@@ -133,7 +136,7 @@ export default function LoginForm() {
             type="button"
             onClick={() => handleOAuth('github')}
             disabled={loading}
-            className="py-3 btn-ghost flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed transition-transform duration-150 hover:scale-[1.02] active:scale-[0.98]"
+            className="admin-console-button-secondary h-11 w-full disabled:cursor-not-allowed disabled:opacity-50"
           >
             <Github size={20} />
             GitHub
@@ -143,7 +146,7 @@ export default function LoginForm() {
             type="button"
             onClick={() => handleOAuth('google')}
             disabled={loading}
-            className="py-3 btn-ghost flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed transition-transform duration-150 hover:scale-[1.02] active:scale-[0.98]"
+            className="admin-console-button-secondary h-11 w-full disabled:cursor-not-allowed disabled:opacity-50"
           >
             <svg className="w-5 h-5" viewBox="0 0 24 24">
               <path
@@ -169,13 +172,13 @@ export default function LoginForm() {
 
         <p className="text-center text-sm text-muted-foreground">
           Don&apos;t have an account?{' '}
-          <a href={redirectTo ? `/auth/signup?redirect=${encodeURIComponent(redirectTo)}` : '/auth/signup'} className="text-radiant-gold hover:text-gold-light transition-colors">
+          <a href={redirectTo ? `/auth/signup?redirect=${encodeURIComponent(redirectTo)}` : '/auth/signup'} className="text-radiant-gold transition-colors hover:text-gold-light">
             Sign up
           </a>
         </p>
 
         <p className="text-center text-sm text-muted-foreground">
-          <a href="/auth/forgot-password" className="text-radiant-gold hover:text-gold-light transition-colors">
+          <a href="/auth/forgot-password" className="text-radiant-gold transition-colors hover:text-gold-light">
             Forgot password?
           </a>
         </p>

--- a/components/auth/SignupForm.tsx
+++ b/components/auth/SignupForm.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import { motion } from 'framer-motion'
-import { Mail, Lock, UserPlus, Github } from 'lucide-react'
+import { Github, Lock, Mail, UserPlus } from 'lucide-react'
 import { signUp, signInWithOAuth } from '@/lib/auth'
 import { useRouter, useSearchParams } from 'next/navigation'
 
@@ -72,12 +72,12 @@ export default function SignupForm() {
       <motion.div
         initial={{ opacity: 0, scale: 0.9 }}
         animate={{ opacity: 1, scale: 1 }}
-        className="w-full max-w-md mx-auto text-center"
+        className="mx-auto w-full max-w-md text-center"
       >
-        <div className="p-8 bg-green-500/20 border border-green-500/50 rounded-lg">
-          <h2 className="text-2xl font-bold text-foreground mb-2">Check your email!</h2>
-          <p className="text-foreground">
-            We&apos;ve sent you a confirmation link. Please check your inbox to verify your account.
+        <div className="admin-console-card rounded-xl border border-green-500/40 p-8">
+          <h2 className="mb-2 text-2xl font-bold text-foreground">Check your email</h2>
+          <p className="text-muted-foreground">
+            We sent a confirmation link. Verify the account, then return to Portfolio.
           </p>
         </div>
       </motion.div>
@@ -85,23 +85,26 @@ export default function SignupForm() {
   }
 
   return (
-    <div className="w-full max-w-md mx-auto">
+    <div className="mx-auto w-full max-w-md">
       <motion.form
         onSubmit={handleSubmit}
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
-        className="space-y-6 bg-silicon-slate border border-silicon-slate rounded-xl p-8"
+        className="admin-console-command-card space-y-6 rounded-xl border p-6 sm:p-8"
       >
         <div>
-          <h2 className="text-3xl font-bold text-foreground mb-2">Create Account</h2>
-          <p className="text-muted-foreground">Sign up to access exclusive content</p>
+          <div className="admin-console-eyebrow mb-3">Account setup</div>
+          <h2 className="text-3xl font-bold text-foreground">Create account</h2>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            Create secure access for Portfolio operations and client workspaces.
+          </p>
         </div>
 
         {error && (
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
-            className="p-4 bg-red-500/20 border border-red-500/50 rounded-lg text-red-400 text-sm"
+            className="rounded-lg border border-red-500/45 bg-red-500/15 p-4 text-sm text-red-200"
           >
             {error}
           </motion.div>
@@ -109,29 +112,29 @@ export default function SignupForm() {
 
         <div className="space-y-4">
           <div>
-            <label htmlFor="email" className="block text-sm font-medium text-foreground mb-2">
+            <label htmlFor="email" className="mb-2 block text-sm font-medium text-foreground">
               Email
             </label>
             <div className="relative">
-              <Mail className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground" size={20} />
+              <Mail className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" size={20} />
               <input
                 id="email"
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 required
-                className="w-full pl-10 pr-4 py-3 input-brand"
+                className="input-brand w-full py-3 pl-10 pr-4"
                 placeholder="you@example.com"
               />
             </div>
           </div>
 
           <div>
-            <label htmlFor="password" className="block text-sm font-medium text-foreground mb-2">
+            <label htmlFor="password" className="mb-2 block text-sm font-medium text-foreground">
               Password
             </label>
             <div className="relative">
-              <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground" size={20} />
+              <Lock className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" size={20} />
               <input
                 id="password"
                 type="password"
@@ -139,18 +142,18 @@ export default function SignupForm() {
                 onChange={(e) => setPassword(e.target.value)}
                 required
                 minLength={6}
-                className="w-full pl-10 pr-4 py-3 input-brand"
+                className="input-brand w-full py-3 pl-10 pr-4"
                 placeholder="••••••••"
               />
             </div>
           </div>
 
           <div>
-            <label htmlFor="confirmPassword" className="block text-sm font-medium text-foreground mb-2">
+            <label htmlFor="confirmPassword" className="mb-2 block text-sm font-medium text-foreground">
               Confirm Password
             </label>
             <div className="relative">
-              <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground" size={20} />
+              <Lock className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" size={20} />
               <input
                 id="confirmPassword"
                 type="password"
@@ -158,7 +161,7 @@ export default function SignupForm() {
                 onChange={(e) => setConfirmPassword(e.target.value)}
                 required
                 minLength={6}
-                className="w-full pl-10 pr-4 py-3 input-brand"
+                className="input-brand w-full py-3 pl-10 pr-4"
                 placeholder="••••••••"
               />
             </div>
@@ -170,7 +173,7 @@ export default function SignupForm() {
           disabled={loading}
           whileHover={{ scale: 1.02 }}
           whileTap={{ scale: 0.98 }}
-          className="w-full py-3 btn-gold text-imperial-navy font-semibold flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+          className="admin-console-button-primary h-12 w-full text-base disabled:cursor-not-allowed disabled:opacity-50"
         >
           {loading ? (
             'Creating account...'
@@ -184,10 +187,10 @@ export default function SignupForm() {
 
         <div className="relative">
           <div className="absolute inset-0 flex items-center">
-            <div className="w-full border-t border-silicon-slate"></div>
+            <div className="w-full border-t border-white/10"></div>
           </div>
           <div className="relative flex justify-center text-sm">
-            <span className="px-2 bg-silicon-slate text-muted-foreground">Or continue with</span>
+            <span className="bg-[#121e31] px-3 text-muted-foreground">Or continue with</span>
           </div>
         </div>
 
@@ -198,7 +201,7 @@ export default function SignupForm() {
             disabled={loading}
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
-            className="py-3 btn-ghost flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="admin-console-button-secondary h-11 w-full disabled:cursor-not-allowed disabled:opacity-50"
           >
             <Github size={20} />
             GitHub
@@ -210,7 +213,7 @@ export default function SignupForm() {
             disabled={loading}
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
-            className="py-3 btn-ghost flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="admin-console-button-secondary h-11 w-full disabled:cursor-not-allowed disabled:opacity-50"
           >
             <svg className="w-5 h-5" viewBox="0 0 24 24">
               <path
@@ -236,7 +239,7 @@ export default function SignupForm() {
 
         <p className="text-center text-sm text-muted-foreground">
           Already have an account?{' '}
-          <a href={redirectTo ? `/auth/login?redirect=${encodeURIComponent(redirectTo)}` : '/auth/login'} className="text-radiant-gold hover:text-gold-light transition-colors">
+          <a href={redirectTo ? `/auth/login?redirect=${encodeURIComponent(redirectTo)}` : '/auth/login'} className="text-radiant-gold transition-colors hover:text-gold-light">
             Sign in
           </a>
         </p>


### PR DESCRIPTION
## Summary
- add a shared AuthShell that brings login and recovery flows into the Portfolio admin-console visual standard
- update login, signup, forgot-password, and reset-password surfaces with dark operating-console panels, gold command accents, and clearer operational copy
- preserve existing email/password and OAuth auth handlers without backend or schema changes

## Validation
- `git diff --check`
- `npm run lint -- --file components/auth/AuthShell.tsx --file components/auth/LoginForm.tsx --file components/auth/SignupForm.tsx --file app/auth/login/page.tsx --file app/auth/signup/page.tsx --file app/auth/forgot-password/page.tsx --file app/auth/reset-password/page.tsx`
- `npm run build:knowledge && npx tsc --noEmit --pretty false`
- `npm run build`
- Playwright browser QA on `http://localhost:3021/auth/login`, `/auth/signup`, `/auth/forgot-password`, `/auth/reset-password` at desktop 1440x1100 and mobile 390x900; no horizontal overflow detected
- `npm test -- --run app/auth` was attempted; no auth test files exist for that filter

## Integration Notes
- Conflict preflight: open PRs #317 and #320 do not overlap auth files; root dirty subscription docs and `.tmp/` were preserved outside this worktree
- Environment bootstrap: `.env.local` and `.vercel` linked from `/Users/vambahsillah/Projects/Portfolio` using `npm run worktree:env` after installing worktree dependencies
- Build warning: local env check reports `MOCK_N8N=false` and `N8N_DISABLE_OUTBOUND=false`; this PR does not execute n8n or outbound workflows
- Vercel contexts to verify after merge: `Vercel – portfolio`, `Vercel – portfolio-staging`
- Rollback: revert commit `60d498c` to restore previous auth page/card styling
