### PR TITLE
fix: reserve auth input icon spacing

### DIFF
--- a/app/auth/forgot-password/page.tsx
+++ b/app/auth/forgot-password/page.tsx
@@ -65,14 +65,15 @@ export default function ForgotPasswordPage() {
                 Email
               </label>
               <div className="relative">
-                <Mail className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" size={20} />
+                <Mail className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-muted-foreground" size={20} />
                 <input
                   id="email"
                   type="email"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   required
-                  className="input-brand w-full py-3 pl-10 pr-4 transition-colors"
+                  className="input-brand w-full py-3 pr-4 transition-colors"
+                  style={{ paddingLeft: '3.25rem' }}
                   placeholder="you@example.com"
                 />
               </div>

--- a/app/auth/reset-password/page.tsx
+++ b/app/auth/reset-password/page.tsx
@@ -95,7 +95,7 @@ export default function ResetPasswordPage() {
             New password
           </label>
           <div className="relative">
-            <Lock className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" size={20} />
+            <Lock className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-muted-foreground" size={20} />
             <input
               id="password"
               type="password"
@@ -103,7 +103,8 @@ export default function ResetPasswordPage() {
               onChange={(e) => setPassword(e.target.value)}
               required
               minLength={6}
-              className="input-brand w-full py-3 pl-10 pr-4 transition-colors"
+              className="input-brand w-full py-3 pr-4 transition-colors"
+              style={{ paddingLeft: '3.25rem' }}
               placeholder="••••••••"
             />
           </div>
@@ -114,7 +115,7 @@ export default function ResetPasswordPage() {
             Confirm password
           </label>
           <div className="relative">
-            <Lock className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" size={20} />
+            <Lock className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-muted-foreground" size={20} />
             <input
               id="confirm"
               type="password"
@@ -122,7 +123,8 @@ export default function ResetPasswordPage() {
               onChange={(e) => setConfirm(e.target.value)}
               required
               minLength={6}
-              className="input-brand w-full py-3 pl-10 pr-4 transition-colors"
+              className="input-brand w-full py-3 pr-4 transition-colors"
+              style={{ paddingLeft: '3.25rem' }}
               placeholder="••••••••"
             />
           </div>

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -75,14 +75,15 @@ export default function LoginForm() {
               Email
             </label>
             <div className="relative">
-              <Mail className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" size={20} />
+              <Mail className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-muted-foreground" size={20} />
               <input
                 id="email"
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 required
-                className="input-brand w-full py-3 pl-10 pr-4 transition-colors"
+                className="input-brand w-full py-3 pr-4 transition-colors"
+                style={{ paddingLeft: '3.25rem' }}
                 placeholder="you@example.com"
               />
             </div>
@@ -93,14 +94,15 @@ export default function LoginForm() {
               Password
             </label>
             <div className="relative">
-              <Lock className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" size={20} />
+              <Lock className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-muted-foreground" size={20} />
               <input
                 id="password"
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 required
-                className="input-brand w-full py-3 pl-10 pr-4 transition-colors"
+                className="input-brand w-full py-3 pr-4 transition-colors"
+                style={{ paddingLeft: '3.25rem' }}
                 placeholder="••••••••"
               />
             </div>

--- a/components/auth/SignupForm.tsx
+++ b/components/auth/SignupForm.tsx
@@ -116,14 +116,15 @@ export default function SignupForm() {
               Email
             </label>
             <div className="relative">
-              <Mail className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" size={20} />
+              <Mail className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-muted-foreground" size={20} />
               <input
                 id="email"
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 required
-                className="input-brand w-full py-3 pl-10 pr-4"
+                className="input-brand w-full py-3 pr-4"
+                style={{ paddingLeft: '3.25rem' }}
                 placeholder="you@example.com"
               />
             </div>
@@ -134,7 +135,7 @@ export default function SignupForm() {
               Password
             </label>
             <div className="relative">
-              <Lock className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" size={20} />
+              <Lock className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-muted-foreground" size={20} />
               <input
                 id="password"
                 type="password"
@@ -142,7 +143,8 @@ export default function SignupForm() {
                 onChange={(e) => setPassword(e.target.value)}
                 required
                 minLength={6}
-                className="input-brand w-full py-3 pl-10 pr-4"
+                className="input-brand w-full py-3 pr-4"
+                style={{ paddingLeft: '3.25rem' }}
                 placeholder="••••••••"
               />
             </div>
@@ -153,7 +155,7 @@ export default function SignupForm() {
               Confirm Password
             </label>
             <div className="relative">
-              <Lock className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" size={20} />
+              <Lock className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-muted-foreground" size={20} />
               <input
                 id="confirmPassword"
                 type="password"
@@ -161,7 +163,8 @@ export default function SignupForm() {
                 onChange={(e) => setConfirmPassword(e.target.value)}
                 required
                 minLength={6}
-                className="input-brand w-full py-3 pl-10 pr-4"
+                className="input-brand w-full py-3 pr-4"
+                style={{ paddingLeft: '3.25rem' }}
                 placeholder="••••••••"
               />
             </div>


### PR DESCRIPTION
## Summary
- reserve explicit left padding for auth inputs with leading icons
- move leading icons to a stable left offset and make them pointer-events none
- apply the fix across login, signup, forgot-password, and reset-password auth fields

## Validation
- `git diff --check`
- `npm run lint -- --file components/auth/LoginForm.tsx --file components/auth/SignupForm.tsx --file app/auth/forgot-password/page.tsx --file app/auth/reset-password/page.tsx`
- `npx tsc --noEmit --pretty false`
- Playwright QA on `/auth/login`, `/auth/signup`, `/auth/forgot-password`, `/auth/reset-password` at 1021x998 and 390x900; each visible input reports 52px left padding and no horizontal overflow
- Local screenshot checked at `/tmp/auth-spacing-desktop-auth-login.png`

## Integration Notes
- Conflict preflight: open PRs #317 and #320 do not overlap auth input files
- No backend, schema, auth handler, or global CSS changes
- Vercel contexts to verify after merge: `Vercel – portfolio`, `Vercel – portfolio-staging`
