### PR TITLE
feat: polish admin sidebar chrome

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -665,6 +665,96 @@ button.admin-console-metric:hover {
 }
 
 /* ========================================
+   Shared Admin Sidebar Standard
+   ======================================== */
+
+nav[aria-label="Admin navigation"] {
+  position: relative;
+  isolation: isolate;
+  border-right-color: rgba(212, 175, 55, 0.16) !important;
+  background:
+    radial-gradient(circle at 22% 0%, rgba(212, 175, 55, 0.07), transparent 18rem),
+    linear-gradient(180deg, rgba(18, 30, 49, 0.98) 0%, rgba(12, 22, 37, 0.99) 100%) !important;
+  box-shadow:
+    1px 0 0 rgba(234, 236, 238, 0.04) inset,
+    14px 0 38px rgba(0, 0, 0, 0.22) !important;
+}
+
+nav[aria-label="Admin navigation"]::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background:
+    linear-gradient(rgba(234, 236, 238, 0.018) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(234, 236, 238, 0.014) 1px, transparent 1px);
+  background-size: 38px 38px;
+  opacity: 0.28;
+  mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.52), transparent 76%);
+}
+
+nav[aria-label="Admin navigation"] > div:first-of-type:not(:last-child) {
+  border-bottom-color: rgba(212, 175, 55, 0.16) !important;
+  background:
+    linear-gradient(135deg, rgba(212, 175, 55, 0.055), transparent 48%),
+    rgba(18, 30, 49, 0.72);
+}
+
+nav[aria-label="Admin navigation"] > div:last-child {
+  scrollbar-color: rgba(212, 175, 55, 0.38) rgba(18, 30, 49, 0.42);
+  scrollbar-width: thin;
+}
+
+nav[aria-label="Admin navigation"] > div:last-child::-webkit-scrollbar {
+  width: 0.55rem;
+}
+
+nav[aria-label="Admin navigation"] > div:last-child::-webkit-scrollbar-track {
+  background: rgba(18, 30, 49, 0.45);
+}
+
+nav[aria-label="Admin navigation"] > div:last-child::-webkit-scrollbar-thumb {
+  background: rgba(212, 175, 55, 0.36);
+  border-radius: 999px;
+}
+
+nav[aria-label="Admin navigation"] > div:last-child > div > div:first-child {
+  color: rgba(234, 236, 238, 0.58) !important;
+  letter-spacing: 0.2em !important;
+}
+
+nav[aria-label="Admin navigation"] a[href]:not([href="#admin-main"]),
+nav[aria-label="Admin navigation"] button[aria-controls] {
+  min-height: 2.35rem;
+  border-color: transparent !important;
+  background: transparent;
+}
+
+nav[aria-label="Admin navigation"] a[href]:not([href="#admin-main"]):hover,
+nav[aria-label="Admin navigation"] button[aria-controls]:hover {
+  border-color: rgba(212, 175, 55, 0.2) !important;
+  background: rgba(212, 175, 55, 0.085) !important;
+}
+
+nav[aria-label="Admin navigation"] a[aria-current="page"],
+nav[aria-label="Admin navigation"] button[aria-current="page"] {
+  border-color: rgba(212, 175, 55, 0.42) !important;
+  background:
+    linear-gradient(90deg, rgba(212, 175, 55, 0.16), rgba(212, 175, 55, 0.06)),
+    rgba(44, 62, 80, 0.62) !important;
+  color: var(--radiant-gold) !important;
+  box-shadow:
+    inset 3px 0 0 rgba(245, 208, 96, 0.92),
+    0 0 24px rgba(212, 175, 55, 0.1) !important;
+}
+
+nav[aria-label="Admin navigation"] a[aria-current="page"] svg,
+nav[aria-label="Admin navigation"] button[aria-current="page"] svg {
+  color: var(--radiant-gold) !important;
+}
+
+/* ========================================
    Circuit Mesh Animation Classes
    ======================================== */
 


### PR DESCRIPTION
## Summary
- Adds a shared admin sidebar CSS polish layer for `nav[aria-label=\"Admin navigation\"]`.
- Aligns the side panel with the Mission Control operating-console aesthetic: navy depth, subtle gold accents, fine borders, restrained grid texture, improved active state, hover state, and scrollbar treatment.
- Keeps this slice CSS-only because PR #330 currently owns `AdminSidebar.tsx`, sidebar tests, and admin nav files.

## Validation
- `git diff --check`
- `npx tsc --noEmit --pretty false`
- `npm run lint`
- `npm test -- --run components/admin/AdminSidebar.test.tsx lib/admin-nav.test.ts` — `components/admin/AdminSidebar.test.tsx` passed; `lib/admin-nav.test.ts` is not present on current `main` and appears to be introduced by PR #330.
- `npm run build`
- Push hook database health check passed.
- Headless admin visual smoke attempted on `/admin`, `/admin/agents`, and `/admin/outreach`; unauthenticated browser context redirected to `/auth/login`, so authenticated sidebar screenshot QA remains the follow-up check.

## Integration Notes
- Conflict preflight found open PR #330 (`test: cover admin navigation regression contracts`) touching `components/admin/AdminSidebar.tsx`, `components/admin/AdminSidebar.test.tsx`, and nav test/config files. This PR avoids those files and limits scope to `app/globals.css`.
- Build emitted the existing development n8n outbound warning; this slice did not execute n8n, outbound sends, production activation, or credential changes.
- After merge, verify both Vercel contexts: `Vercel – portfolio` and `Vercel – portfolio-staging`.