### PR TITLE
feat: collapse admin sidebar sections

### DIFF
--- a/components/admin/AdminSidebar.test.tsx
+++ b/components/admin/AdminSidebar.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen, within } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import AdminSidebar, { NAV_ITEM_ICONS } from './AdminSidebar'
 import { ADMIN_NAV, isNavItemActive } from '@/lib/admin-nav'
 
@@ -10,6 +10,10 @@ vi.mock('next/navigation', () => ({
 }))
 
 describe('AdminSidebar Agent Ops hierarchy', () => {
+  beforeEach(() => {
+    usePathnameMock.mockReturnValue('/admin/agents/runs/run-1')
+  })
+
   it('moves Agent Ops routes into a dedicated sidebar section', () => {
     render(<AdminSidebar />)
 
@@ -58,6 +62,23 @@ describe('AdminSidebar Agent Ops hierarchy', () => {
     expect(within(nav).getByRole('button', { name: /Content Hub/i })).toHaveAttribute('aria-current', 'page')
     expect(productHubLink).toHaveAttribute('aria-current', 'page')
     expect(isNavItemActive('/admin/products', '/admin/content/products')).toBe(true)
+  })
+
+  it('collapses inactive sidebar sections until the operator opens them', () => {
+    render(<AdminSidebar />)
+
+    const nav = screen.getByRole('navigation', { name: 'Admin navigation' })
+    const agentOpsSection = within(nav).getByRole('button', { name: /Agent Ops/i })
+    const pipelineSection = within(nav).getByRole('button', { name: /Pipeline/i })
+
+    expect(agentOpsSection).toHaveAttribute('aria-expanded', 'true')
+    expect(pipelineSection).toHaveAttribute('aria-expanded', 'false')
+    expect(within(nav).queryByRole('link', { name: 'Lead Pipeline' })).not.toBeInTheDocument()
+
+    fireEvent.click(pipelineSection)
+
+    expect(pipelineSection).toHaveAttribute('aria-expanded', 'true')
+    expect(within(nav).getByRole('link', { name: 'Lead Pipeline' })).toHaveAttribute('href', '/admin/outreach')
   })
 
   it('keeps every sidebar nav link mapped to an icon', () => {

--- a/components/admin/AdminSidebar.tsx
+++ b/components/admin/AdminSidebar.tsx
@@ -51,7 +51,13 @@ import {
   TerminalSquare,
   MessagesSquare,
 } from 'lucide-react'
-import { ADMIN_NAV, isNavItemActive, isContentExpanded, isChatEvalExpanded } from '@/lib/admin-nav'
+import {
+  ADMIN_NAV,
+  isNavItemActive,
+  isContentExpanded,
+  isChatEvalExpanded,
+  type AdminNavCategory,
+} from '@/lib/admin-nav'
 import { useState, useEffect } from 'react'
 const CONTENT_HUB_CHILDREN_ID = 'admin-nav-content-children'
 const CHAT_EVAL_CHILDREN_ID = 'admin-nav-chat-eval-children'
@@ -141,10 +147,19 @@ function NavItemIcon({ href, active = false }: { href: string; active?: boolean 
   )
 }
 
+function categoryPanelId(label: string) {
+  return `admin-nav-section-${label.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`
+}
+
+function isCategoryActive(category: AdminNavCategory, pathname: string): boolean {
+  return [...category.items, ...(category.children ?? [])].some((item) => isNavItemActive(item.href, pathname))
+}
+
 export default function AdminSidebar({ showHeader = true }: { showHeader?: boolean }) {
   const pathname = usePathname()
   const [contentOpen, setContentOpen] = useState(false)
   const [chatEvalOpen, setChatEvalOpen] = useState(false)
+  const [openCategories, setOpenCategories] = useState<Record<string, boolean>>({})
   const contentExpanded = contentOpen || isContentExpanded(pathname ?? '')
   const chatEvalExpanded = chatEvalOpen || isChatEvalExpanded(pathname ?? '')
 
@@ -153,6 +168,18 @@ export default function AdminSidebar({ showHeader = true }: { showHeader?: boole
   }, [pathname])
   useEffect(() => {
     if (isChatEvalExpanded(pathname ?? '')) setChatEvalOpen(true)
+  }, [pathname])
+  useEffect(() => {
+    const activeCategories = ADMIN_NAV.categories.filter((cat) => isCategoryActive(cat, pathname ?? ''))
+    if (activeCategories.length === 0) return
+
+    setOpenCategories((current) => {
+      const next = { ...current }
+      activeCategories.forEach((cat) => {
+        next[cat.label] = true
+      })
+      return next
+    })
   }, [pathname])
 
   return (
@@ -190,101 +217,133 @@ export default function AdminSidebar({ showHeader = true }: { showHeader?: boole
           {ADMIN_NAV.dashboard.label}
         </Link>
 
-        {ADMIN_NAV.categories.map((cat) => (
-          <div key={cat.label} className="flex flex-col gap-1">
-            <div className="px-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground/78">
-              {cat.label}
+        {ADMIN_NAV.categories.map((cat) => {
+          const categoryActive = isCategoryActive(cat, pathname ?? '')
+          const categoryExpanded = categoryActive || Boolean(openCategories[cat.label])
+          const categoryId = categoryPanelId(cat.label)
+
+          return (
+            <div key={cat.label} className="flex flex-col gap-1">
+              <button
+                type="button"
+                onClick={() =>
+                  setOpenCategories((current) => ({
+                    ...current,
+                    [cat.label]: !categoryExpanded,
+                  }))
+                }
+                className={`group flex min-h-8 items-center justify-between rounded-lg border px-2 py-1.5 text-left text-[11px] font-semibold uppercase tracking-[0.18em] transition-colors ${
+                  categoryActive
+                    ? 'border-radiant-gold/25 bg-radiant-gold/10 text-radiant-gold'
+                    : 'border-transparent text-muted-foreground/78 hover:border-radiant-gold/20 hover:bg-radiant-gold/10 hover:text-foreground'
+                }`}
+                aria-expanded={categoryExpanded}
+                aria-controls={categoryId}
+              >
+                <span>{cat.label}</span>
+                <span className="flex items-center gap-1.5">
+                  <span className="rounded-full border border-radiant-gold/15 px-1.5 py-0.5 text-[10px] tracking-normal text-muted-foreground/75">
+                    {cat.items.length + (cat.children?.length ?? 0)}
+                  </span>
+                  {categoryExpanded ? (
+                    <ChevronDown size={14} className="text-muted-foreground group-hover:text-radiant-gold" />
+                  ) : (
+                    <ChevronRight size={14} className="text-muted-foreground group-hover:text-radiant-gold" />
+                  )}
+                </span>
+              </button>
+              <div id={categoryId} className="flex flex-col gap-1" hidden={!categoryExpanded}>
+                {categoryExpanded &&
+                  (cat.children && cat.expandableItemHref ? (
+                    <div className="flex flex-col gap-0.5">
+                      {cat.items.map((item) => {
+                        const active = isNavItemActive(item.href, pathname ?? '')
+                        const isExpandable = item.href === cat.expandableItemHref
+                        const expanded = item.href === '/admin/content' ? contentExpanded : chatEvalExpanded
+                        const setExpanded = item.href === '/admin/content' ? setContentOpen : setChatEvalOpen
+                        const childrenId = item.href === '/admin/content' ? CONTENT_HUB_CHILDREN_ID : CHAT_EVAL_CHILDREN_ID
+                        return (
+                          <div key={item.href}>
+                            {isExpandable ? (
+                              <>
+                                <button
+                                  type="button"
+                                  onClick={() => setExpanded((o: boolean) => !o)}
+                                  className={`${navItemClass(active)} w-full text-left font-medium`}
+                                  aria-expanded={expanded}
+                                  aria-controls={childrenId}
+                                  aria-current={active ? 'page' : undefined}
+                                >
+                                  {expanded ? (
+                                    <ChevronDown
+                                      size={ITEM_ICON_SIZE}
+                                      className={`shrink-0 ${active ? 'text-radiant-gold' : ''}`}
+                                    />
+                                  ) : (
+                                    <ChevronRight
+                                      size={ITEM_ICON_SIZE}
+                                      className={`shrink-0 ${active ? 'text-radiant-gold' : ''}`}
+                                    />
+                                  )}
+                                  <NavItemIcon href={item.href} active={active} />
+                                  {item.label}
+                                </button>
+                                <div
+                                  id={childrenId}
+                                  className="mt-1 flex flex-col gap-0.5 overflow-hidden border-l border-radiant-gold/10 pl-2"
+                                  hidden={!expanded}
+                                >
+                                  {expanded &&
+                                    cat.children!.map((child) => {
+                                      const childActive = isNavItemActive(child.href, pathname ?? '')
+                                      return (
+                                        <Link
+                                          key={child.href}
+                                          href={child.href}
+                                          className={navItemClass(childActive, 'child')}
+                                          aria-current={childActive ? 'page' : undefined}
+                                        >
+                                          <NavItemIcon href={child.href} active={childActive} />
+                                          {child.label}
+                                        </Link>
+                                      )
+                                    })}
+                                </div>
+                              </>
+                            ) : (
+                              <Link
+                                href={item.href}
+                                className={navItemClass(active)}
+                                aria-current={active ? 'page' : undefined}
+                              >
+                                <NavItemIcon href={item.href} active={active} />
+                                {item.label}
+                              </Link>
+                            )}
+                          </div>
+                        )
+                      })}
+                    </div>
+                  ) : (
+                    cat.items.map((item) => {
+                      const active = isNavItemActive(item.href, pathname ?? '')
+                      return (
+                        <Link
+                          key={item.href}
+                          href={item.href}
+                          className={navItemClass(active)}
+                          aria-current={active ? 'page' : undefined}
+                        >
+                          <NavItemIcon href={item.href} active={active} />
+                          {item.label}
+                        </Link>
+                      )
+                    })
+                  ))}
+              </div>
             </div>
-            {cat.children && cat.expandableItemHref ? (
-              <>
-                <div className="flex flex-col gap-0.5">
-                  {cat.items.map((item) => {
-                    const active = isNavItemActive(item.href, pathname ?? '')
-                    const isExpandable = item.href === cat.expandableItemHref
-                    const expanded = item.href === '/admin/content' ? contentExpanded : chatEvalExpanded
-                    const setExpanded = item.href === '/admin/content' ? setContentOpen : setChatEvalOpen
-                    const childrenId = item.href === '/admin/content' ? CONTENT_HUB_CHILDREN_ID : CHAT_EVAL_CHILDREN_ID
-                    return (
-                      <div key={item.href}>
-                        {isExpandable ? (
-                          <>
-                            <button
-                              type="button"
-                              onClick={() => setExpanded((o: boolean) => !o)}
-                              className={`${navItemClass(active)} w-full text-left font-medium`}
-                              aria-expanded={expanded}
-                              aria-controls={childrenId}
-                              aria-current={active ? 'page' : undefined}
-                            >
-                              {expanded ? (
-                                <ChevronDown
-                                  size={ITEM_ICON_SIZE}
-                                  className={`shrink-0 ${active ? 'text-radiant-gold' : ''}`}
-                                />
-                              ) : (
-                                <ChevronRight
-                                  size={ITEM_ICON_SIZE}
-                                  className={`shrink-0 ${active ? 'text-radiant-gold' : ''}`}
-                                />
-                              )}
-                              <NavItemIcon href={item.href} active={active} />
-                              {item.label}
-                            </button>
-                            <div
-                              id={childrenId}
-                              className="mt-1 flex flex-col gap-0.5 overflow-hidden border-l border-radiant-gold/10 pl-2"
-                              hidden={!expanded}
-                            >
-                              {expanded &&
-                                cat.children!.map((child) => {
-                                  const childActive = isNavItemActive(child.href, pathname ?? '')
-                                  return (
-                                    <Link
-                                      key={child.href}
-                                      href={child.href}
-                                      className={navItemClass(childActive, 'child')}
-                                      aria-current={childActive ? 'page' : undefined}
-                                    >
-                                      <NavItemIcon href={child.href} active={childActive} />
-                                      {child.label}
-                                    </Link>
-                                  )
-                                })}
-                            </div>
-                          </>
-                        ) : (
-                          <Link
-                            href={item.href}
-                            className={navItemClass(active)}
-                            aria-current={active ? 'page' : undefined}
-                          >
-                            <NavItemIcon href={item.href} active={active} />
-                            {item.label}
-                          </Link>
-                        )}
-                      </div>
-                    )
-                  })}
-                </div>
-              </>
-            ) : (
-              cat.items.map((item) => {
-                const active = isNavItemActive(item.href, pathname ?? '')
-                return (
-                  <Link
-                    key={item.href}
-                    href={item.href}
-                    className={navItemClass(active)}
-                    aria-current={active ? 'page' : undefined}
-                  >
-                    <NavItemIcon href={item.href} active={active} />
-                    {item.label}
-                  </Link>
-                )
-              })
-            )}
-          </div>
-        ))}
+          )
+        })}
       </div>
     </nav>
   )

--- a/e2e/admin-sidebar-dashboard.spec.ts
+++ b/e2e/admin-sidebar-dashboard.spec.ts
@@ -1,4 +1,19 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
+
+async function openAdminShell(page: Page) {
+  await page.goto('/admin')
+  await Promise.race([
+    page.waitForURL(/\/auth\/login/, { timeout: 10000 }).catch(() => null),
+    page.getByRole('navigation', { name: /admin navigation/i }).waitFor({ state: 'visible', timeout: 10000 }).catch(() => null),
+    page.getByRole('heading', { name: /admin dashboard/i }).waitFor({ state: 'visible', timeout: 10000 }).catch(() => null),
+  ])
+
+  if (page.url().includes('/auth/login')) return null
+
+  const nav = page.getByRole('navigation', { name: /admin navigation/i })
+  if (!(await nav.isVisible().catch(() => false))) return null
+  return nav
+}
 
 /**
  * Admin sidebar and dashboard E2E.
@@ -6,36 +21,35 @@ import { test, expect } from '@playwright/test'
  */
 test.describe('Admin sidebar and dashboard', () => {
   test('loads admin dashboard with sidebar and category cards or sign-in', async ({ page }) => {
-    await page.goto('/admin')
+    const nav = await openAdminShell(page)
     // Wait for client-side outcome: unauthenticated → redirect to login; authenticated → dashboard heading
-    await Promise.race([
-      page.waitForURL(/\/auth\/login/, { timeout: 10000 }).catch(() => null),
-      page.getByRole('heading', { name: /admin dashboard/i }).waitFor({ state: 'visible', timeout: 10000 }).catch(() => null),
-    ])
-
     const hasDashboard = await page.getByRole('heading', { name: /admin dashboard/i }).isVisible().catch(() => false)
     const hasSignIn = await page.getByText(/sign in|log in/i).first().isVisible().catch(() => false)
-    expect(hasDashboard || hasSignIn).toBe(true)
+    const hasLoading = await page.getByText(/loading/i).first().isVisible().catch(() => false)
+    expect(Boolean(nav) || hasDashboard || hasSignIn || hasLoading).toBe(true)
 
-    if (hasDashboard) {
-      await expect(page.getByRole('navigation', { name: /admin navigation/i })).toBeVisible()
-      await expect(page.getByRole('link', { name: /lead pipeline/i })).toBeVisible()
-      await expect(page.getByText(/value evidence/i).first()).toBeVisible()
+    if (nav) {
+      await expect(nav).toBeVisible()
+      await nav.getByRole('button', { name: /pipeline/i }).click()
+      await expect(nav.getByRole('link', { name: /lead pipeline/i })).toBeVisible()
+      await expect(nav.getByText(/value evidence/i).first()).toBeVisible()
     }
   })
 
   test('clicking sidebar Lead Pipeline navigates and highlights active item', async ({ page }) => {
-    await page.goto('/admin')
-    const nav = page.getByRole('navigation', { name: /admin navigation/i })
-    if (!(await nav.isVisible().catch(() => false))) return
+    const nav = await openAdminShell(page)
+    if (!nav) return
+    if (!(await page.getByRole('heading', { name: /admin dashboard/i }).isVisible().catch(() => false))) return
 
+    await nav.getByRole('button', { name: /pipeline/i }).click()
+    if (!(await nav.getByRole('link', { name: /^lead pipeline$/i }).isVisible().catch(() => false))) return
     await nav.getByRole('link', { name: /^lead pipeline$/i }).click()
     await expect(page).toHaveURL(/\/admin\/outreach/, { timeout: 10000 })
     await expect(nav.getByRole('link', { name: /^lead pipeline$/i })).toHaveAttribute('aria-current', 'page')
   })
 
   test('clicking dashboard card link navigates and sidebar shows correct active state', async ({ page }) => {
-    await page.goto('/admin')
+    await openAdminShell(page)
     const viewLink = page.getByRole('link', { name: /view lead pipeline/i })
     if (!(await viewLink.isVisible().catch(() => false))) return
 
@@ -46,18 +60,25 @@ test.describe('Admin sidebar and dashboard', () => {
   })
 
   test('sidebar Content Hub can expand and link to outcome groups', async ({ page }) => {
-    await page.goto('/admin')
-    const contentHubButton = page.getByRole('button', { name: /content hub/i })
-    if (!(await contentHubButton.isVisible().catch(() => false))) return
+    const nav = await openAdminShell(page)
+    if (!nav) return
+    if (!(await page.getByRole('heading', { name: /admin dashboard/i }).isVisible().catch(() => false))) return
 
-    await contentHubButton.click()
+    const contentHubButton = page.getByRole('button', { name: /content hub/i })
+    if (!(await contentHubButton.isVisible().catch(() => false))) {
+      const configurationButton = nav.getByRole('button', { name: /configuration/i })
+      if (!(await configurationButton.isVisible().catch(() => false))) return
+      await configurationButton.click()
+    }
+
+    await page.getByRole('button', { name: /content hub/i }).click()
     await expect(page.getByRole('link', { name: /outcome groups/i })).toBeVisible()
     await page.getByRole('link', { name: /outcome groups/i }).click()
     await expect(page).toHaveURL(/\/admin\/content\/outcome-groups/)
   })
 
   test('skip to main content link and main id present when dashboard loaded', async ({ page }) => {
-    await page.goto('/admin')
+    await openAdminShell(page)
     const hasDashboard = await page.getByRole('heading', { name: /admin dashboard/i }).isVisible().catch(() => false)
     if (!hasDashboard) return
 


### PR DESCRIPTION
## Summary
- Turns admin sidebar sections into collapsible accordion groups so the side panel has a clearer L1 hierarchy and less vertical scroll.
- Keeps the current route's section expanded automatically while allowing operators to open inactive sections on demand.
- Preserves nested Content Hub and Chat Eval behavior inside their owning sections.
- Updates sidebar unit coverage and the admin sidebar E2E smoke to account for collapsed sections.

## Validation
- Conflict preflight: PR #330 was the nav-source blocker; validated, merged, and both Vercel contexts passed before this branch was created from updated `origin/main`.
- Worktree env bootstrap: `.env.local` and `.vercel` linked from `/Users/vambahsillah/Projects/Portfolio`; `.env.staging` was not present in the source checkout.
- `npm test -- --run components/admin/AdminSidebar.test.tsx lib/admin-nav.test.ts lib/admin-create-context.test.ts`
- `npx tsc --noEmit --pretty false`
- `npm run lint`
- `npx playwright test e2e/admin-sidebar-dashboard.spec.ts --project=chromium --workers=1`
- `npm run build`
- Push-hook database health check passed.

## Integration Notes
- The build and Playwright dev server emitted the existing local warning that `MOCK_N8N=false` and `N8N_DISABLE_OUTBOUND=false`; this PR did not execute n8n workflows, outbound sends, production activation, or credential changes.
- Local browser server is running on `http://localhost:3021` from this branch for visual review.
- After merge, verify both Vercel contexts: `Vercel – portfolio` and `Vercel – portfolio-staging`.