### PR TITLE
feat: add agent governance controls

### DIFF
--- a/app/admin/agents/page.test.tsx
+++ b/app/admin/agents/page.test.tsx
@@ -120,6 +120,81 @@ const missionSnapshot = {
   },
   operating_signals: [],
   knowledge_governance: null,
+  governance: {
+    generated_at: '2026-05-13T12:00:00.000Z',
+    summary: {
+      total_agents: 3,
+      reviewed_agents: 2,
+      planned_agents: 1,
+      least_privilege_attention: 1,
+      pending_authority_approvals: 1,
+      payment_authority_actions: 6,
+    },
+    capability_profiles: [
+      {
+        agent_key: 'chief-of-staff',
+        display_name: 'Shaka (Zulu) - Chief of Staff',
+        pod: 'Chief of Staff',
+        status: 'partial',
+        primary_runtime: 'mixed',
+        allowed_tools: ['Agent Ops traces', 'Mission Control context', 'Shaka routing catalog'],
+        allowed_data_classes: ['agent_ops_traces', 'cross_agent_status'],
+        allowed_write_classes: ['agent_run_events', 'agent_work_items'],
+        outbound_authority: 'draft_only',
+        spend_authority: 'none',
+        approval_required_for: ['production_config_change'],
+        sensitive_boundaries: ['Read-only status by default; production config changes require approval.'],
+        last_reviewed_at: '2026-05-21',
+        review_status: 'reviewed',
+        governance_status: 'green',
+      },
+      {
+        agent_key: 'automation-systems',
+        display_name: 'Yaa Asantewaa (Ashanti) - Automation Systems',
+        pod: 'Product & Automation Pod',
+        status: 'active',
+        primary_runtime: 'n8n',
+        allowed_tools: ['Agent Ops traces', 'Mission Control context', 'n8n workflow hooks'],
+        allowed_data_classes: ['agent_ops_traces', 'workflow_config'],
+        allowed_write_classes: ['agent_run_events', 'agent_work_items', 'known_workflow_records'],
+        outbound_authority: 'known_workflow',
+        spend_authority: 'approval_required',
+        approval_required_for: ['create_checkout_session', 'create_refund'],
+        sensitive_boundaries: ['Known workflow writes allowed; config and unknown production writes require approval.'],
+        last_reviewed_at: '2026-05-21',
+        review_status: 'reviewed',
+        governance_status: 'yellow',
+      },
+    ],
+    payment_authority_actions: [
+      {
+        action: 'create_checkout_session',
+        approval_type: 'payment_create_checkout_session',
+        label: 'Create checkout session',
+        description: 'Creating a payment checkout session that could collect funds from a client or customer.',
+      },
+    ],
+    pending_authority_approvals: [
+      {
+        run_id: 'payment-run',
+        approval_type: 'payment_create_refund',
+        status: 'pending',
+        requested_at: '2026-05-13T11:30:00.000Z',
+      },
+    ],
+    recent_delegation_decisions: [
+      {
+        run_id: 'delegation-run',
+        selected_agent_key: 'automation-systems',
+        selected_agent_name: 'Yaa Asantewaa (Ashanti) - Automation Systems',
+        task_type: 'payment',
+        risk_class: 'payment_spend',
+        confidence: 0.9,
+        occurred_at: '2026-05-13T11:40:00.000Z',
+        reason: 'Yaa Asantewaa matches payment work.',
+      },
+    ],
+  },
   agent_inbox: [
     {
       id: 'chief-of-staff:standup',
@@ -389,6 +464,14 @@ describe('AgentOperationsPage mission control landing', () => {
     expect(within(dailyBrief).queryByText('Recommended next actions')).not.toBeInTheDocument()
     expect(within(dailyBrief).queryByText('Open brief trace')).not.toBeInTheDocument()
     expect(within(dailyBrief).getAllByText(/Current traces/i).length).toBeGreaterThan(0)
+    const governancePanel = screen.getByLabelText('Agent Governance')
+    expect(governancePanel).toBeInTheDocument()
+    expect(within(governancePanel).getByText('Scope, delegation, spend authority, and audit state for the agentic operating system.')).toBeInTheDocument()
+    expect(within(governancePanel).getByText('2/3')).toBeInTheDocument()
+    expect(within(governancePanel).getAllByText('Yaa Asantewaa (Ashanti) - Automation Systems').length).toBeGreaterThan(0)
+    expect(within(governancePanel).getByText('Spend gated')).toBeInTheDocument()
+    expect(within(governancePanel).getByText(/payment · 90% confidence/i)).toBeInTheDocument()
+    expect(within(governancePanel).getByText(/1 pending authority checkpoint/i)).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /Active runs/i })).toHaveAttribute('href', '/admin/agents/runs?active=true')
     expect(screen.getByRole('link', { name: /Failed or stale runs/i })).toHaveAttribute('href', '/admin/agents/runs?status=needs_review')
     expect(screen.getByRole('link', { name: /Pending approvals/i })).toHaveAttribute('href', '/admin/agents/coordination')

--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -181,6 +181,56 @@ type MissionSnapshot = {
       publicUnsafeApprovedCount: number
     }
   }
+  governance?: {
+    generated_at: string
+    summary: {
+      total_agents: number
+      reviewed_agents: number
+      planned_agents: number
+      least_privilege_attention: number
+      pending_authority_approvals: number
+      payment_authority_actions: number
+    }
+    capability_profiles: Array<{
+      agent_key: string
+      display_name: string
+      pod: string
+      status: 'active' | 'partial' | 'planned'
+      primary_runtime: string
+      allowed_tools: string[]
+      allowed_data_classes: string[]
+      allowed_write_classes: string[]
+      outbound_authority: 'none' | 'draft_only' | 'known_workflow' | 'approval_required'
+      spend_authority: 'none' | 'approval_required'
+      approval_required_for: string[]
+      sensitive_boundaries: string[]
+      last_reviewed_at: string
+      review_status: 'reviewed' | 'planned'
+      governance_status: 'green' | 'yellow' | 'red'
+    }>
+    payment_authority_actions: Array<{
+      action: string
+      approval_type: string
+      label: string
+      description: string
+    }>
+    pending_authority_approvals: Array<{
+      run_id: string
+      approval_type: string
+      status: string
+      requested_at: string
+    }>
+    recent_delegation_decisions: Array<{
+      run_id: string
+      selected_agent_key: string
+      selected_agent_name: string
+      task_type: string
+      risk_class: string
+      confidence: number
+      occurred_at: string
+      reason: string
+    }>
+  }
   agent_inbox: Array<{
     id: string
     priority: 'high' | 'medium' | 'low'
@@ -933,6 +983,8 @@ export default function AgentOperationsPage() {
                   pendingApprovals={decisionQueueCount}
                   costToday={snapshot?.status_strip.cost_today ?? 0}
                 />
+
+                <AgentGovernancePanel governance={snapshot?.governance ?? null} />
 
                 <div className="agent-ops-command-card mt-5 rounded-lg border p-4">
                   <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
@@ -1849,6 +1901,103 @@ function DailyBriefPanel({
           {routeCards.map((card) => (
             <BriefRouteCard key={card.label} {...card} />
           ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function AgentGovernancePanel({ governance }: { governance: MissionSnapshot['governance'] | null }) {
+  if (!governance) return null
+
+  const profiles = governance.capability_profiles.slice(0, 4)
+  const latestDelegation = governance.recent_delegation_decisions[0]
+  const latestPaymentAction = governance.payment_authority_actions[0]
+  const statusTone = governance.summary.pending_authority_approvals > 0
+    ? 'yellow'
+    : governance.summary.least_privilege_attention > 0
+      ? 'blue'
+      : 'green'
+
+  return (
+    <section className="agent-ops-card mt-5 rounded-lg border p-4" aria-label="Agent Governance">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <div className="flex items-center gap-2 text-radiant-gold">
+            <ShieldCheck size={18} />
+            <h2 className="font-semibold">Agent Governance</h2>
+          </div>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            Scope, delegation, spend authority, and audit state for the agentic operating system.
+          </p>
+        </div>
+        <StatusOnlyPill tone={statusTone}>
+          {governance.summary.pending_authority_approvals
+            ? `${governance.summary.pending_authority_approvals} authority approval(s)`
+            : `${governance.summary.reviewed_agents} reviewed`}
+        </StatusOnlyPill>
+      </div>
+
+      <div className="mt-4 grid grid-cols-2 gap-2 lg:grid-cols-4">
+        <MiniMetric label="Profiles" value={`${governance.summary.reviewed_agents}/${governance.summary.total_agents}`} tone="green" />
+        <MiniMetric label="Needs review" value={governance.summary.least_privilege_attention} tone={governance.summary.least_privilege_attention ? 'yellow' : 'green'} />
+        <MiniMetric label="Payment gates" value={governance.summary.payment_authority_actions} />
+        <MiniMetric label="Planned agents" value={governance.summary.planned_agents} />
+      </div>
+
+      <div className="mt-4 grid gap-3 lg:grid-cols-[minmax(0,1.2fr)_minmax(240px,0.8fr)]">
+        <div className="rounded-lg border border-silicon-slate/55 bg-black/10 p-3">
+          <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Capability inventory</p>
+          <div className="mt-3 space-y-2">
+            {profiles.map((profile) => (
+              <div key={profile.agent_key} className="rounded-md border border-silicon-slate/45 bg-background/35 p-3">
+                <div className="flex flex-wrap items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <p className="font-medium">{profile.display_name}</p>
+                    <p className="mt-1 text-xs text-muted-foreground">{profile.primary_runtime} · {profile.pod}</p>
+                  </div>
+                  <StatusOnlyPill tone={profile.governance_status}>
+                    {profile.spend_authority === 'approval_required' ? 'Spend gated' : profile.review_status}
+                  </StatusOnlyPill>
+                </div>
+                <p className="mt-2 text-xs leading-5 text-muted-foreground">
+                  Tools: {profile.allowed_tools.slice(0, 3).join(', ')}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <Link
+            href={latestDelegation ? `/admin/agents/runs/${latestDelegation.run_id}` : '/admin/agents/runs'}
+            className="block rounded-lg border border-radiant-gold/35 bg-radiant-gold/10 p-3 hover:border-radiant-gold/60"
+          >
+            <p className="text-xs font-semibold uppercase tracking-wider text-radiant-gold">Delegation trace</p>
+            <p className="mt-2 text-sm font-semibold">
+              {latestDelegation ? latestDelegation.selected_agent_name : 'No recent delegation decisions'}
+            </p>
+            <p className="mt-1 text-xs leading-5 text-muted-foreground">
+              {latestDelegation
+                ? `${latestDelegation.task_type.replace(/_/g, ' ')} · ${Math.round(latestDelegation.confidence * 100)}% confidence`
+                : 'Shaka will record deterministic delegation events when routed engagements are proposed.'}
+            </p>
+          </Link>
+
+          <Link
+            href={governance.pending_authority_approvals[0]?.run_id ? `/admin/agents/runs/${governance.pending_authority_approvals[0].run_id}` : '/admin/agents/coordination'}
+            className="block rounded-lg border border-silicon-slate/60 bg-background/40 p-3 hover:border-radiant-gold/50"
+          >
+            <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Payment authority</p>
+            <p className="mt-2 text-sm font-semibold">
+              {governance.pending_authority_approvals.length
+                ? `${governance.pending_authority_approvals.length} pending authority checkpoint(s)`
+                : latestPaymentAction?.label ?? 'Payment gates ready'}
+            </p>
+            <p className="mt-1 text-xs leading-5 text-muted-foreground">
+              Payment, refund, subscription, vendor spend, paid API, and paid external job actions require trace-linked approval.
+            </p>
+          </Link>
         </div>
       </div>
     </section>

--- a/app/api/admin/agents/chief-of-staff/actions/route.test.ts
+++ b/app/api/admin/agents/chief-of-staff/actions/route.test.ts
@@ -132,6 +132,35 @@ describe('POST /api/admin/agents/chief-of-staff/actions', () => {
     }))
   })
 
+  it('creates trace-linked payment authority checkpoints without executing side effects', async () => {
+    const response = await POST(makeRequest({
+      source_run_id: 'chief-run-1',
+      proposal: {
+        label: 'Approve refund',
+        description: 'Create a checkpoint before issuing a client refund.',
+        action: 'create_refund',
+        riskLevel: 'high',
+      },
+    }) as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      approval_type: 'payment_create_refund',
+      approval_required: true,
+    })
+    expect(mocks.insert).toHaveBeenCalledWith(expect.objectContaining({
+      approval_type: 'payment_create_refund',
+      metadata: expect.objectContaining({
+        action_payload: expect.objectContaining({
+          action: 'create_refund',
+          approval_type: 'payment_create_refund',
+          executes_action: false,
+          side_effect_boundary: expect.stringContaining('No refund is issued'),
+        }),
+      }),
+    }))
+  })
+
   it('rejects non-gated proposals', async () => {
     const response = await POST(makeRequest({
       source_run_id: 'chief-run-1',

--- a/app/api/admin/agents/chief-of-staff/actions/route.ts
+++ b/app/api/admin/agents/chief-of-staff/actions/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
 import { attachAgentArtifact, recordAgentEvent, startAgentRun } from '@/lib/agent-run'
 import {
+  AGENT_ACTIONS,
   actionRequiresApproval,
   getApprovalGate,
   type AgentAction,
@@ -11,18 +12,7 @@ import type { ChiefOfStaffActionProposal } from '@/lib/chief-of-staff-chat'
 
 export const dynamic = 'force-dynamic'
 
-const ACTIONS: AgentAction[] = [
-  'read_files',
-  'write_files',
-  'external_api_call',
-  'client_data_access',
-  'known_workflow_db_write',
-  'unknown_db_write',
-  'publish_public_content',
-  'send_email',
-  'production_config_change',
-  'public_content_from_private_material',
-]
+const ACTIONS: readonly AgentAction[] = AGENT_ACTIONS
 
 function isAgentAction(value: unknown): value is AgentAction {
   return typeof value === 'string' && ACTIONS.includes(value as AgentAction)
@@ -68,6 +58,18 @@ function sideEffectBoundary(action: AgentAction) {
       return 'No database write outside known workflows is performed until this approval checkpoint is approved.'
     case 'public_content_from_private_material':
       return 'No private-derived material is moved to a public channel until this approval checkpoint is approved.'
+    case 'create_checkout_session':
+      return 'No checkout session is created until this payment authority checkpoint is approved and linked to a trace.'
+    case 'create_subscription':
+      return 'No subscription is created until this payment authority checkpoint is approved and linked to a trace.'
+    case 'create_refund':
+      return 'No refund is issued until this payment authority checkpoint is approved and linked to a trace.'
+    case 'make_vendor_payment':
+      return 'No vendor payment is sent until this payment authority checkpoint is approved and linked to a trace.'
+    case 'increase_paid_api_budget':
+      return 'No paid API budget is increased until this payment authority checkpoint is approved and linked to a trace.'
+    case 'start_paid_external_job':
+      return 'No paid external job is started until this payment authority checkpoint is approved and linked to a trace.'
     default:
       return 'The proposed action is recorded for review; no side effect is executed by this checkpoint.'
   }

--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -382,3 +382,4 @@ These items are explicitly maintenance or operational backlog, not new rollout p
 2. Refine Mission Control recovery wording if real usage shows that stale/expired recovery packets need sharper guidance.
 3. Keep both Vercel contexts checked after future Agent Operations merges: `Vercel – portfolio` and `Vercel – portfolio-staging`.
 4. Preserve the scope guard: no new chat channel, queue table, autonomous remediation loop, runtime mutation, vendor dependency, or merge-authority change without explicit approval.
+5. Use `docs/agentic-operating-system-governance.md` as the governance hardening backlog for agent scope inventory, Shaka delegation transparency, payment/spend authority, and the Mission Control audit view.

--- a/docs/agentic-operating-system-governance.md
+++ b/docs/agentic-operating-system-governance.md
@@ -170,3 +170,14 @@ The client value is not novelty. It is confidence: a nonprofit, small business, 
 5. Create a client-safe audit export and a short sales/advisory explainer.
 
 This sequence is reversible until payment authority is introduced. Payment/spend controls should ship behind explicit approval and test-mode validation before any production use.
+
+## Implementation Status
+
+Phase 1 through Phase 4 have a v1 implementation in Portfolio:
+
+- `lib/agent-governance.ts` derives a read-only agent capability inventory from the current agent organization and policy records.
+- `lib/agent-delegation-policy.ts` applies deterministic Shaka delegation routing and records `delegation_decision_recorded` trace events.
+- `lib/agent-policy.ts` now treats payment and paid-job actions as approval-gated authority events across runtimes.
+- `/admin/agents` includes an Agent Governance section with capability inventory, delegation trace, payment authority, and governance status signals.
+
+Phase 5 remains open: client-safe audit exports and the advisory/sales explainer should be packaged after operators have reviewed the v1 governance surface against real runs.

--- a/docs/agentic-operating-system-governance.md
+++ b/docs/agentic-operating-system-governance.md
@@ -1,0 +1,172 @@
+# Agentic Operating System Governance
+
+Portfolio already has the base of an agentic operating system: named agents, runtime policies, shared traces, approvals, work items, budget checks, Slack commands, and Mission Control. This document formalizes the missing governance layer so the system can be operated internally and explained to clients without overselling autonomy.
+
+Input source: Vambah's May 20, 2026 notes from the YouTube video [Google Spent a Year Stitching MCP, A2A, AG-UI Together. I/O Today.](https://www.youtube.com/watch?v=zP6TnEiueEc). The four-component model below follows Vambah's summary: agents and tools, delegation, payment authorization, and traceable UI/audit.
+
+## CTO Recommendation
+
+Build this as a governance hardening track inside existing Agent Ops, not as a separate product surface.
+
+Why: Portfolio already has `agent_runs`, `agent_run_steps`, `agent_run_events`, `agent_run_artifacts`, `agent_approvals`, `agent_work_items`, `agent_handoffs`, `cost_events.agent_run_id`, Mission Control, and Shaka. The highest-leverage move is to make the rules more explicit and auditable, then project them through `/admin/agents`, `/admin/agents/runs/[runId]`, and client-facing advisory material.
+
+Do not start by giving agents more authority. Start by proving that scope, delegation, authorization, and payment intent are visible and reviewable.
+
+## Governance Components
+
+| Component | What Portfolio Has Today | Gap | Recommended Hardening |
+| --- | --- | --- | --- |
+| Agent, scope, and tools | `lib/agent-organization.ts` maps named agents, responsibilities, runtimes, workflow refs, and approval gates. `lib/agent-policy.ts` defines runtime-level permissions. | Permissions are runtime-level, not agent-specialty-level. Tool access is implied through runtime/workflow descriptions rather than inventory-scored per agent. | Add an agent capability inventory that scores each agent on tools, data access, write authority, outbound authority, spend authority, and required approval gates. |
+| Delegation and monitoring | Shaka uses the routing catalog from `AGENT_ORGANIZATION`, returns typed `agent_engagements`, prefers active/partial agents, and traces each chat. | Delegation policy lives inside the prompt and parser. It is inspectable in code but not yet exposed as deterministic routing rules or a decision record. | Add a deterministic delegation policy layer: task taxonomy, routing criteria, required context checks, confidence, fallback, and a trace event recording why Shaka chose the agent. |
+| Payment and spend authorization | Stripe helpers, checkout routes, subscription/refund helpers, cost events, and per-runtime LLM budget checks exist. Agent approvals cover production config, outbound email, publishing, unknown DB writes, and private-to-public content. | There is no first-class `make_payment`, `create_checkout_session`, `create_subscription`, or `refund_payment` agent action gate that ties payment intent to user authorization, amount, counterparty, and trace evidence. | Add payment/spend approval gates before any agent-triggered purchase, subscription, checkout creation, refund, vendor spend, or external paid API escalation. |
+| UI, validation, and audit | Mission Control, run detail, work items, approvals, cost summaries, stale/dead-letter handling, and artifacts provide strong traceability. | The UI does not yet show one consolidated "why this agent / why this permission / why this approval" view for agentic OS governance. | Add an Agent Governance tab or section under Mission Control with agent capability inventory, delegation rules, pending authority decisions, payment authority ledger, and audit export. |
+
+## Current Inventory Findings
+
+### Strong Foundations
+
+- Agent identities and specialties are already concrete: Shaka, Amina, Mansa Musa, Askia Muhammad, Hatshepsut, Nzinga, Moremi, Nefertiti, Hannibal, Taharqa, Menelik II, Piye, Yaa Asantewaa, and other mapped agents have responsibilities and approval gates in `lib/agent-organization.ts`.
+- Runtime policy exists in `lib/agent-policy.ts` for file reads/writes, external APIs, client data, production writes, publishing, email, config changes, and private-to-public material.
+- Shaka records traced runs and typed proposals through `lib/chief-of-staff-chat.ts` and the Chief of Staff API routes.
+- Approval checkpoints are durable in `agent_approvals` and decisions are written back to `agent_run_events`.
+- Budget controls exist for LLM spend in `lib/agent-budget-policy.ts`.
+- Cross-runtime coordination has durable fields for expected files, touched files, branches, PRs, blockers, validation, approvals, and handoffs through `agent_work_items` and `agent_handoffs`.
+
+### Gaps To Close
+
+- Agent scope is not yet a least-privilege matrix. The current policy answers "what can this runtime do?" more clearly than "what should this specialist agent be allowed to do?"
+- Shaka's delegation logic is partially deterministic, but the routing criteria are still embedded in the prompt. Operators can inspect the trace result, but they cannot yet see a stable rule table that explains the decision before dispatch.
+- Payment authority is present in product code through Stripe utilities, but agent authority around payments is not explicit. That matters because client-facing trust depends on proving who authorized money movement, what amount was approved, and what action actually executed.
+- The UI has trace detail, but it needs a governance narrative view that answers the user's practical questions: who acted, why that agent, what authority was granted, what was blocked, what cost or payment was involved, and what evidence supports the decision.
+
+## Target Control Model
+
+Every agentic action should resolve into this envelope:
+
+| Field | Purpose |
+| --- | --- |
+| `agent_key` | Which named agent is responsible. |
+| `runtime` | Which execution environment acted. |
+| `scope_profile` | The agent's approved tools, data classes, write classes, outbound authority, and spend boundary. |
+| `delegation_reason` | Why Shaka or another controller routed the work there. |
+| `operator_intent` | The user/admin request that authorized the run or proposal. |
+| `approval_checkpoint_id` | The approval record when side effects are possible. |
+| `payment_authority_id` | The spend/payment authorization record when money can move or a paid session is created. |
+| `trace_id` | The `agent_runs.id` tying together steps, events, artifacts, costs, approvals, and handoffs. |
+| `audit_summary` | Human-readable explanation for admin review and client-safe export. |
+
+## Implementation Backlog
+
+### 1. Agent Capability Inventory
+
+Objective: Turn current agent descriptions into a least-privilege matrix.
+
+Recommended fields:
+
+- `agent_key`
+- `display_name`
+- `pod`
+- `primary_runtime`
+- `allowed_tools`
+- `allowed_data_classes`
+- `allowed_write_classes`
+- `outbound_authority`
+- `spend_authority`
+- `approval_required_for`
+- `sensitive_boundaries`
+- `last_reviewed_at`
+- `review_status`
+
+Validation gate: every active or partial agent has a reviewed scope profile; Shaka can have broad visibility, but specialist agents should not inherit broad authority by default.
+
+### 2. Shaka Delegation Policy
+
+Objective: Make delegation explainable before and after dispatch.
+
+Recommended policy inputs:
+
+- task type: status, recovery, research, content, code, automation, payment, approval, client delivery, publishing
+- risk class: read-only, internal write, client-data access, outbound send, production mutation, payment/spend
+- required evidence: source run, work item, approval, client project, proposal, cost event, payment object
+- preferred agent keys
+- fallback agent key
+- approval gate
+- confidence threshold
+
+Trace requirement: each routed engagement should write an event like `delegation_decision_recorded` with selected agent, alternatives considered, required evidence, confidence, and fallback.
+
+### 3. Payment And Spend Authority Layer
+
+Objective: Separate "agent recommends spending" from "money can move."
+
+New approval actions to add:
+
+- `create_checkout_session`
+- `create_subscription`
+- `create_refund`
+- `make_vendor_payment`
+- `increase_paid_api_budget`
+- `start_paid_external_job`
+
+Required payment authority fields:
+
+- requesting agent
+- approving user
+- amount
+- currency
+- counterparty
+- purpose
+- payment rail: Stripe, vendor API, subscription, refund, paid job
+- allowed execution window
+- maximum retries
+- revocation status
+- resulting Stripe/vendor object ids
+- linked trace id
+
+Validation gate: no agent-triggered payment, refund, subscription, or paid external job can execute without a linked approval and trace event. Test mode checkout creation remains explicitly marked as testing.
+
+### 4. Agent Governance UI
+
+Objective: Give the operator and future clients a single proof surface.
+
+Recommended surface: `/admin/agents` Governance section or a one-click L2 page from Mission Control.
+
+Views:
+
+- capability inventory by agent
+- delegation policy table and recent delegation decisions
+- approval queue with authority boundaries
+- payment/spend ledger
+- audit trail export by run, work item, client project, or time window
+- red/yellow/green governance status for each agent
+
+Validation gate: an operator can answer these questions without reading code: what can this agent do, who gave it authority, what did it actually do, how much did it cost, did money move, and where is the evidence?
+
+## Client-Facing Positioning
+
+Use this as the advisory framing:
+
+We do not sell "agents that do everything." We build governed agent operating systems.
+
+That means every agent has a role, every role has a scope, every side effect has an approval boundary, every delegation has a reason, every dollar has authorization, and every action leaves a trace.
+
+The client value is not novelty. It is confidence: a nonprofit, small business, or executive team can use AI agents without guessing whether the system is acting inside the boundaries they intended.
+
+## Non-Negotiable Boundaries
+
+- Background agents do not approve their own work.
+- Shaka may coordinate broadly, but side effects still pass through approval checkpoints.
+- Specialist agents should receive least-privilege profiles.
+- Payment authority must be amount-bound, purpose-bound, time-bound, and trace-bound.
+- Test payment flows must stay marked as test data and must not touch production customer payment records.
+- Client-facing exports summarize traces and governance decisions; they do not expose raw private logs, secrets, private reasoning, or sensitive records.
+
+## Recommended Rollout
+
+1. Add the capability inventory and expose it read-only.
+2. Extract Shaka's delegation logic into deterministic policy helpers while keeping the LLM for synthesis.
+3. Add payment/spend approval action types and payment authority records.
+4. Add the Mission Control governance view.
+5. Create a client-safe audit export and a short sales/advisory explainer.
+
+This sequence is reversible until payment authority is introduced. Payment/spend controls should ship behind explicit approval and test-mode validation before any production use.

--- a/docs/agentic-patterns.md
+++ b/docs/agentic-patterns.md
@@ -4,6 +4,12 @@ Single source of truth for how this repo applies the 20 agentic AI design patter
 
 Keep this doc in sync with reality: any PR that touches an agentic flow must update the relevant section.
 
+## Agentic OS Governance Overlay
+
+The operating-system layer is tracked in [`docs/agentic-operating-system-governance.md`](agentic-operating-system-governance.md). Use that companion doc when the work touches agent scope, least-privilege permissions, Shaka delegation rules, payment/spend authorization, or the user-facing audit trail.
+
+Current recommendation: keep these improvements inside existing Agent Ops rather than adding a separate control plane. The next hardening step is to move from runtime-level permissions to agent-specialty capability profiles, then record deterministic delegation decisions and payment authority as trace-linked approvals.
+
 ## Canonical list (4 buckets)
 
 Our pinned 20 patterns, grouped the same way as the talk:

--- a/lib/agent-delegation-policy.test.ts
+++ b/lib/agent-delegation-policy.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyDelegationDecisionToEngagements,
+  evaluateAgentDelegationPolicy,
+  inferDelegationRule,
+} from './agent-delegation-policy'
+
+describe('agent delegation policy', () => {
+  it('routes payment and spend work to the automation systems owner with payment risk', () => {
+    const decision = evaluateAgentDelegationPolicy({
+      message: 'Can an agent create a refund or checkout session for this client?',
+      proposedAgentKeys: ['research-source-register'],
+    })
+
+    expect(decision.task_type).toBe('payment')
+    expect(decision.risk_class).toBe('payment_spend')
+    expect(decision.selected_agent_key).toBe('automation-systems')
+    expect(decision.required_evidence).toContain('approval')
+  })
+
+  it('keeps research requests on the source-register lane', () => {
+    const rule = inferDelegationRule('Find source-backed evidence for this claim before publishing.')
+    expect(rule.taskType).toBe('research')
+  })
+
+  it('places the deterministic selected agent first in engagement proposals', () => {
+    const decision = evaluateAgentDelegationPolicy({
+      message: 'Route this n8n workflow proposal.',
+      proposedAgentKeys: ['engineering-copilot'],
+    })
+    const engagements = applyDelegationDecisionToEngagements([
+      {
+        agentKey: 'engineering-copilot',
+        agentName: 'Piye (Kush) - Engineering Copilot',
+        label: 'Run Piye',
+        rationale: 'Implement code.',
+        status: 'partial',
+        executionMode: 'read_only',
+      },
+    ], decision)
+
+    expect(engagements[0]?.agentKey).toBe('automation-systems')
+    expect(engagements[1]?.agentKey).toBe('engineering-copilot')
+  })
+})

--- a/lib/agent-delegation-policy.ts
+++ b/lib/agent-delegation-policy.ts
@@ -1,0 +1,216 @@
+import { AGENT_ORGANIZATION, getAgentByKey } from '@/lib/agent-organization'
+import type { ChiefOfStaffAgentEngagementProposal } from '@/lib/chief-of-staff-chat'
+
+export type DelegationTaskType =
+  | 'status'
+  | 'recovery'
+  | 'research'
+  | 'content'
+  | 'code'
+  | 'automation'
+  | 'payment'
+  | 'approval'
+  | 'client_delivery'
+  | 'publishing'
+
+export type DelegationRiskClass =
+  | 'read_only'
+  | 'internal_write'
+  | 'client_data_access'
+  | 'outbound_send'
+  | 'production_mutation'
+  | 'payment_spend'
+
+export type AgentDelegationDecision = {
+  task_type: DelegationTaskType
+  risk_class: DelegationRiskClass
+  selected_agent_key: string
+  selected_agent_name: string
+  alternatives_considered: string[]
+  required_evidence: string[]
+  fallback_agent_key: string
+  approval_gate: string
+  confidence: number
+  reason: string
+}
+
+type DelegationRule = {
+  taskType: DelegationTaskType
+  riskClass: DelegationRiskClass
+  preferredAgentKeys: string[]
+  fallbackAgentKey: string
+  requiredEvidence: string[]
+}
+
+const DELEGATION_RULES: DelegationRule[] = [
+  {
+    taskType: 'payment',
+    riskClass: 'payment_spend',
+    preferredAgentKeys: ['automation-systems', 'proposal-business-model', 'chief-of-staff'],
+    fallbackAgentKey: 'chief-of-staff',
+    requiredEvidence: ['approval', 'payment_object', 'trace_id'],
+  },
+  {
+    taskType: 'automation',
+    riskClass: 'production_mutation',
+    preferredAgentKeys: ['automation-systems', 'agent-tooling-parity', 'engineering-copilot'],
+    fallbackAgentKey: 'chief-of-staff',
+    requiredEvidence: ['work_item', 'run_trace', 'approval_if_mutating'],
+  },
+  {
+    taskType: 'code',
+    riskClass: 'internal_write',
+    preferredAgentKeys: ['engineering-copilot', 'agent-tooling-parity'],
+    fallbackAgentKey: 'chief-of-staff',
+    requiredEvidence: ['branch', 'worktree', 'validation_summary'],
+  },
+  {
+    taskType: 'research',
+    riskClass: 'read_only',
+    preferredAgentKeys: ['research-source-register', 'risk-compliance-intelligence', 'private-knowledge-librarian'],
+    fallbackAgentKey: 'chief-of-staff',
+    requiredEvidence: ['source_register', 'trace_id'],
+  },
+  {
+    taskType: 'content',
+    riskClass: 'client_data_access',
+    preferredAgentKeys: ['voice-content-architect', 'amadutown-brand', 'strategic-narrative'],
+    fallbackAgentKey: 'chief-of-staff',
+    requiredEvidence: ['source_context', 'approval_if_public'],
+  },
+  {
+    taskType: 'publishing',
+    riskClass: 'outbound_send',
+    preferredAgentKeys: ['website-product-copy', 'inbox-follow-up', 'voice-content-architect'],
+    fallbackAgentKey: 'chief-of-staff',
+    requiredEvidence: ['approved_content', 'approval'],
+  },
+  {
+    taskType: 'client_delivery',
+    riskClass: 'client_data_access',
+    preferredAgentKeys: ['meeting-intake-follow-up', 'automation-systems', 'inbox-follow-up'],
+    fallbackAgentKey: 'chief-of-staff',
+    requiredEvidence: ['client_project', 'work_item', 'approval_if_external'],
+  },
+  {
+    taskType: 'approval',
+    riskClass: 'production_mutation',
+    preferredAgentKeys: ['chief-of-staff', 'risk-compliance-intelligence', 'automation-systems'],
+    fallbackAgentKey: 'chief-of-staff',
+    requiredEvidence: ['approval', 'run_trace'],
+  },
+  {
+    taskType: 'recovery',
+    riskClass: 'read_only',
+    preferredAgentKeys: ['chief-of-staff', 'engineering-copilot', 'automation-systems'],
+    fallbackAgentKey: 'chief-of-staff',
+    requiredEvidence: ['failed_or_stale_run', 'recovery_packet'],
+  },
+  {
+    taskType: 'status',
+    riskClass: 'read_only',
+    preferredAgentKeys: ['chief-of-staff'],
+    fallbackAgentKey: 'chief-of-staff',
+    requiredEvidence: ['agent_ops_context'],
+  },
+]
+
+function includesAny(value: string, terms: string[]) {
+  return terms.some((term) => value.includes(term))
+}
+
+export function inferDelegationRule(message: string): DelegationRule {
+  const text = message.toLowerCase()
+
+  if (includesAny(text, ['payment', 'checkout', 'subscription', 'refund', 'vendor', 'spend', 'paid api', 'budget increase'])) {
+    return DELEGATION_RULES[0]
+  }
+  if (includesAny(text, ['n8n', 'workflow', 'automation', 'webhook', 'mcp', 'schedule'])) {
+    return DELEGATION_RULES[1]
+  }
+  if (includesAny(text, ['code', 'build', 'implement', 'pr ', 'pull request', 'branch', 'worktree'])) {
+    return DELEGATION_RULES[2]
+  }
+  if (includesAny(text, ['research', 'source', 'evidence', 'risk', 'compliance', 'regulation', 'news'])) {
+    return DELEGATION_RULES[3]
+  }
+  if (includesAny(text, ['content', 'copy', 'post', 'deck', 'script', 'brand', 'course'])) {
+    return DELEGATION_RULES[4]
+  }
+  if (includesAny(text, ['publish', 'send', 'email', 'outreach', 'follow-up', 'follow up'])) {
+    return DELEGATION_RULES[5]
+  }
+  if (includesAny(text, ['client', 'delivery', 'meeting', 'onboarding', 'project'])) {
+    return DELEGATION_RULES[6]
+  }
+  if (includesAny(text, ['approve', 'approval', 'authorize', 'reject'])) {
+    return DELEGATION_RULES[7]
+  }
+  if (includesAny(text, ['failed', 'stale', 'retry', 'recover', 'dead-letter', 'dead letter', 'blocker'])) {
+    return DELEGATION_RULES[8]
+  }
+  return DELEGATION_RULES[9]
+}
+
+function isImmediateAgent(agentKey: string) {
+  const agent = getAgentByKey(agentKey)
+  return agent?.status === 'active' || agent?.status === 'partial'
+}
+
+function firstImmediate(keys: string[]) {
+  return keys.find((key) => isImmediateAgent(key)) ?? keys[0]
+}
+
+export function evaluateAgentDelegationPolicy(input: {
+  message: string
+  proposedAgentKeys?: string[]
+}): AgentDelegationDecision {
+  const rule = inferDelegationRule(input.message)
+  const validProposedKeys = (input.proposedAgentKeys ?? []).filter((key) => Boolean(getAgentByKey(key)))
+  const preferredSet = new Set(rule.preferredAgentKeys)
+  const selectedKey =
+    firstImmediate(rule.preferredAgentKeys) ??
+    validProposedKeys.find((key) => preferredSet.has(key) && isImmediateAgent(key)) ??
+    rule.fallbackAgentKey
+  const selectedAgent = getAgentByKey(selectedKey) ?? AGENT_ORGANIZATION[0]
+  const alternatives = Array.from(new Set([...validProposedKeys, ...rule.preferredAgentKeys]))
+    .filter((key) => key !== selectedAgent.key)
+    .slice(0, 4)
+
+  return {
+    task_type: rule.taskType,
+    risk_class: rule.riskClass,
+    selected_agent_key: selectedAgent.key,
+    selected_agent_name: selectedAgent.name,
+    alternatives_considered: alternatives,
+    required_evidence: rule.requiredEvidence,
+    fallback_agent_key: rule.fallbackAgentKey,
+    approval_gate: selectedAgent.approvalGate,
+    confidence: rule.preferredAgentKeys.includes(selectedAgent.key) ? 0.9 : 0.65,
+    reason: `${selectedAgent.name} matches ${rule.taskType.replace(/_/g, ' ')} work with ${rule.riskClass.replace(/_/g, ' ')} risk.`,
+  }
+}
+
+export function applyDelegationDecisionToEngagements(
+  engagements: ChiefOfStaffAgentEngagementProposal[],
+  decision: AgentDelegationDecision | null,
+): ChiefOfStaffAgentEngagementProposal[] {
+  if (!decision || engagements.length === 0) return engagements
+  const selectedAgent = getAgentByKey(decision.selected_agent_key)
+  if (!selectedAgent) return engagements
+
+  const existing = engagements.find((engagement) => engagement.agentKey === selectedAgent.key)
+  const primary: ChiefOfStaffAgentEngagementProposal = existing ?? {
+    agentKey: selectedAgent.key,
+    agentName: selectedAgent.name,
+    label: `Run ${selectedAgent.name}`,
+    rationale: decision.reason,
+    status: selectedAgent.status,
+    executionMode: selectedAgent.status === 'planned' ? 'queued_for_review' : 'read_only',
+  }
+
+  return [
+    primary,
+    ...engagements.filter((engagement) => engagement.agentKey !== selectedAgent.key),
+  ].slice(0, 3)
+}

--- a/lib/agent-governance.test.ts
+++ b/lib/agent-governance.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { buildAgentCapabilityProfiles, buildAgentGovernanceSnapshot } from './agent-governance'
+
+describe('agent governance', () => {
+  it('derives least-privilege capability profiles from the agent organization', () => {
+    const profiles = buildAgentCapabilityProfiles()
+    const shaka = profiles.find((profile) => profile.agent_key === 'chief-of-staff')
+    const automation = profiles.find((profile) => profile.agent_key === 'automation-systems')
+    const planned = profiles.find((profile) => profile.agent_key === 'proposal-business-model')
+
+    expect(shaka).toMatchObject({
+      display_name: 'Shaka (Zulu) - Chief of Staff',
+      review_status: 'reviewed',
+    })
+    expect(shaka?.allowed_data_classes).toContain('cross_agent_status')
+    expect(automation?.spend_authority).toBe('approval_required')
+    expect(automation?.approval_required_for).toContain('create_checkout_session')
+    expect(planned?.allowed_write_classes).toEqual(['none_until_reviewed'])
+  })
+
+  it('builds a mission-control governance snapshot with payment and delegation signals', () => {
+    const snapshot = buildAgentGovernanceSnapshot({
+      approvals: [
+        {
+          run_id: 'run-payment',
+          approval_type: 'payment_create_refund',
+          status: 'pending',
+          requested_at: '2026-05-21T00:00:00.000Z',
+        },
+      ],
+      events: [
+        {
+          run_id: 'run-shaka',
+          event_type: 'delegation_decision_recorded',
+          severity: 'warning',
+          message: 'Yaa Asantewaa matches payment work.',
+          occurred_at: '2026-05-21T00:01:00.000Z',
+          metadata: {
+            selected_agent_key: 'automation-systems',
+            selected_agent_name: 'Yaa Asantewaa (Ashanti) - Automation Systems',
+            task_type: 'payment',
+            risk_class: 'payment_spend',
+            confidence: 0.9,
+          },
+        },
+      ],
+    })
+
+    expect(snapshot.summary.payment_authority_actions).toBe(6)
+    expect(snapshot.summary.pending_authority_approvals).toBe(1)
+    expect(snapshot.pending_authority_approvals[0]?.approval_type).toBe('payment_create_refund')
+    expect(snapshot.recent_delegation_decisions[0]).toMatchObject({
+      selected_agent_key: 'automation-systems',
+      task_type: 'payment',
+      risk_class: 'payment_spend',
+    })
+  })
+})

--- a/lib/agent-governance.ts
+++ b/lib/agent-governance.ts
@@ -1,0 +1,246 @@
+import { AGENT_ORGANIZATION, AGENT_PODS, type AgentOrganizationNode } from '@/lib/agent-organization'
+import {
+  APPROVAL_GATES,
+  PAYMENT_AUTHORITY_ACTIONS,
+  getApprovalGate,
+  isPaymentAuthorityAction,
+  type AgentAction,
+} from '@/lib/agent-policy'
+
+export type AgentCapabilityProfile = {
+  agent_key: string
+  display_name: string
+  pod: string
+  status: AgentOrganizationNode['status']
+  primary_runtime: AgentOrganizationNode['primaryRuntime']
+  allowed_tools: string[]
+  allowed_data_classes: string[]
+  allowed_write_classes: string[]
+  outbound_authority: 'none' | 'draft_only' | 'known_workflow' | 'approval_required'
+  spend_authority: 'none' | 'approval_required'
+  approval_required_for: AgentAction[]
+  sensitive_boundaries: string[]
+  last_reviewed_at: string
+  review_status: 'reviewed' | 'planned'
+  governance_status: 'green' | 'yellow' | 'red'
+}
+
+export type GovernanceApprovalSummary = {
+  run_id: string
+  approval_type: string
+  status: string
+  requested_at: string
+}
+
+export type GovernanceEventSummary = {
+  run_id: string
+  event_type: string
+  severity: string
+  message: string | null
+  occurred_at: string
+  metadata?: Record<string, unknown> | null
+}
+
+export type AgentGovernanceSnapshot = {
+  generated_at: string
+  summary: {
+    total_agents: number
+    reviewed_agents: number
+    planned_agents: number
+    least_privilege_attention: number
+    pending_authority_approvals: number
+    payment_authority_actions: number
+  }
+  capability_profiles: AgentCapabilityProfile[]
+  payment_authority_actions: Array<{
+    action: AgentAction
+    approval_type: string
+    label: string
+    description: string
+  }>
+  pending_authority_approvals: GovernanceApprovalSummary[]
+  recent_delegation_decisions: Array<{
+    run_id: string
+    selected_agent_key: string
+    selected_agent_name: string
+    task_type: string
+    risk_class: string
+    confidence: number
+    occurred_at: string
+    reason: string
+  }>
+}
+
+const GOVERNANCE_REVIEWED_AT = '2026-05-21'
+
+function podName(agent: AgentOrganizationNode) {
+  return AGENT_PODS.find((pod) => pod.key === agent.podKey)?.name ?? agent.podKey
+}
+
+function baseTools(agent: AgentOrganizationNode) {
+  const tools = ['Agent Ops traces', 'Mission Control context']
+  if (agent.primaryRuntime === 'codex' || agent.primaryRuntime === 'mixed') {
+    tools.push('Codex repo/worktree tools')
+  }
+  if (agent.primaryRuntime === 'n8n' || agent.primaryRuntime === 'mixed' || agent.n8nWorkflows.length > 0) {
+    tools.push('n8n workflow hooks')
+  }
+  if (agent.key === 'chief-of-staff') {
+    tools.push('Shaka routing catalog')
+  }
+  if (agent.n8nWorkflows.some((workflow) => workflow.active)) {
+    tools.push(`${agent.n8nWorkflows.filter((workflow) => workflow.active).length} active workflow(s)`)
+  }
+  return tools
+}
+
+function dataClasses(agent: AgentOrganizationNode) {
+  const classes = ['agent_ops_traces']
+  if (agent.podKey === 'chief_of_staff') classes.push('cross_agent_status', 'approvals', 'work_items')
+  if (agent.podKey === 'research_knowledge') classes.push('source_registers', 'knowledge_records', 'rag_metadata')
+  if (agent.podKey === 'content_production') classes.push('content_drafts', 'private_source_summaries')
+  if (agent.podKey === 'product_automation') classes.push('workflow_config', 'client_project_state', 'runtime_health')
+  if (agent.podKey === 'publishing_follow_up') classes.push('outreach_records', 'meeting_records', 'publishing_queue')
+  return Array.from(new Set(classes))
+}
+
+function writeClasses(agent: AgentOrganizationNode) {
+  if (agent.status === 'planned') return ['none_until_reviewed']
+  const classes = ['agent_run_events', 'agent_work_items']
+  if (agent.primaryRuntime === 'codex') classes.push('repo_branch_files')
+  if (agent.primaryRuntime === 'n8n' || agent.primaryRuntime === 'mixed') classes.push('known_workflow_records')
+  return Array.from(new Set(classes))
+}
+
+function approvalActions(agent: AgentOrganizationNode): AgentAction[] {
+  const actions = new Set<AgentAction>(['production_config_change', 'public_content_from_private_material'])
+  const gate = agent.approvalGate.toLowerCase()
+
+  if (gate.includes('publishing') || agent.podKey === 'content_production') actions.add('publish_public_content')
+  if (gate.includes('send') || gate.includes('email') || agent.podKey === 'publishing_follow_up') actions.add('send_email')
+  if (gate.includes('unknown') || gate.includes('config') || agent.podKey === 'product_automation') actions.add('unknown_db_write')
+  if (agent.key === 'automation-systems' || agent.key === 'proposal-business-model') {
+    PAYMENT_AUTHORITY_ACTIONS.forEach((action) => actions.add(action))
+  }
+
+  return Array.from(actions)
+}
+
+function outboundAuthority(agent: AgentOrganizationNode): AgentCapabilityProfile['outbound_authority'] {
+  if (agent.status === 'planned') return 'none'
+  if (agent.approvalGate.toLowerCase().includes('approval') && (agent.podKey === 'publishing_follow_up' || agent.podKey === 'content_production')) {
+    return 'approval_required'
+  }
+  if (agent.primaryRuntime === 'n8n' && agent.n8nWorkflows.length > 0) return 'known_workflow'
+  return 'draft_only'
+}
+
+function spendAuthority(agent: AgentOrganizationNode): AgentCapabilityProfile['spend_authority'] {
+  return agent.key === 'automation-systems' || agent.key === 'proposal-business-model'
+    ? 'approval_required'
+    : 'none'
+}
+
+function governanceStatus(profile: Omit<AgentCapabilityProfile, 'governance_status'>): AgentCapabilityProfile['governance_status'] {
+  if (profile.status === 'planned') return 'yellow'
+  if (profile.spend_authority === 'approval_required' || profile.outbound_authority === 'approval_required') return 'yellow'
+  if (profile.allowed_write_classes.includes('none_until_reviewed')) return 'red'
+  return 'green'
+}
+
+export function buildAgentCapabilityProfiles(): AgentCapabilityProfile[] {
+  return AGENT_ORGANIZATION.map((agent) => {
+    const profile = {
+      agent_key: agent.key,
+      display_name: agent.name,
+      pod: podName(agent),
+      status: agent.status,
+      primary_runtime: agent.primaryRuntime,
+      allowed_tools: baseTools(agent),
+      allowed_data_classes: dataClasses(agent),
+      allowed_write_classes: writeClasses(agent),
+      outbound_authority: outboundAuthority(agent),
+      spend_authority: spendAuthority(agent),
+      approval_required_for: approvalActions(agent),
+      sensitive_boundaries: [agent.approvalGate],
+      last_reviewed_at: GOVERNANCE_REVIEWED_AT,
+      review_status: agent.status === 'planned' ? 'planned' : 'reviewed',
+    } satisfies Omit<AgentCapabilityProfile, 'governance_status'>
+
+    return {
+      ...profile,
+      governance_status: governanceStatus(profile),
+    }
+  })
+}
+
+function isAuthorityApproval(approvalType: string) {
+  const action = APPROVAL_GATES.find((gate) => gate.approvalType === approvalType)?.action
+  return approvalType.includes('payment_') ||
+    approvalType.includes('production_config') ||
+    approvalType.includes('private_material') ||
+    approvalType.includes('send_email') ||
+    approvalType.includes('publishing') ||
+    (action ? isPaymentAuthorityAction(action) : false)
+}
+
+function metadataRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null
+}
+
+function recentDelegationDecisions(events: GovernanceEventSummary[]): AgentGovernanceSnapshot['recent_delegation_decisions'] {
+  return events
+    .filter((event) => event.event_type === 'delegation_decision_recorded')
+    .flatMap((event) => {
+      const metadata = metadataRecord(event.metadata)
+      const selectedAgentKey = typeof metadata?.selected_agent_key === 'string' ? metadata.selected_agent_key : ''
+      const selectedAgentName = typeof metadata?.selected_agent_name === 'string' ? metadata.selected_agent_name : selectedAgentKey
+      if (!selectedAgentKey) return []
+
+      return [{
+        run_id: event.run_id,
+        selected_agent_key: selectedAgentKey,
+        selected_agent_name: selectedAgentName,
+        task_type: typeof metadata?.task_type === 'string' ? metadata.task_type : 'unknown',
+        risk_class: typeof metadata?.risk_class === 'string' ? metadata.risk_class : 'read_only',
+        confidence: typeof metadata?.confidence === 'number' ? metadata.confidence : 0,
+        occurred_at: event.occurred_at,
+        reason: event.message ?? 'Delegation decision recorded.',
+      }]
+    })
+    .slice(0, 5)
+}
+
+export function buildAgentGovernanceSnapshot(input?: {
+  approvals?: GovernanceApprovalSummary[]
+  events?: GovernanceEventSummary[]
+}): AgentGovernanceSnapshot {
+  const capabilityProfiles = buildAgentCapabilityProfiles()
+  const pendingAuthorityApprovals = (input?.approvals ?? []).filter((approval) =>
+    approval.status === 'pending' && isAuthorityApproval(approval.approval_type),
+  )
+
+  return {
+    generated_at: new Date().toISOString(),
+    summary: {
+      total_agents: capabilityProfiles.length,
+      reviewed_agents: capabilityProfiles.filter((profile) => profile.review_status === 'reviewed').length,
+      planned_agents: capabilityProfiles.filter((profile) => profile.review_status === 'planned').length,
+      least_privilege_attention: capabilityProfiles.filter((profile) => profile.governance_status !== 'green').length,
+      pending_authority_approvals: pendingAuthorityApprovals.length,
+      payment_authority_actions: PAYMENT_AUTHORITY_ACTIONS.length,
+    },
+    capability_profiles: capabilityProfiles,
+    payment_authority_actions: PAYMENT_AUTHORITY_ACTIONS.map((action) => {
+      const gate = getApprovalGate(action)
+      return {
+        action,
+        approval_type: gate?.approvalType ?? action,
+        label: gate?.label ?? action.replace(/_/g, ' '),
+        description: gate?.description ?? 'Payment authority action.',
+      }
+    }),
+    pending_authority_approvals: pendingAuthorityApprovals.slice(0, 8),
+    recent_delegation_decisions: recentDelegationDecisions(input?.events ?? []),
+  }
+}

--- a/lib/agent-mission-control.ts
+++ b/lib/agent-mission-control.ts
@@ -1,4 +1,5 @@
 import { AGENT_ORGANIZATION, AGENT_PODS } from '@/lib/agent-organization'
+import { buildAgentGovernanceSnapshot } from '@/lib/agent-governance'
 import { getAgentQualitySummary, getEmptyAgentQualitySummary } from '@/lib/agent-evaluations'
 import { KNOWLEDGE_GOVERNANCE_STATUS } from '@/lib/knowledge-source-manifest'
 import { supabaseAdmin } from '@/lib/supabase'
@@ -42,6 +43,7 @@ type EventRow = {
   severity: string
   message: string | null
   occurred_at: string
+  metadata: Record<string, unknown> | null
 }
 
 type MissionWorkItemRow = {
@@ -837,7 +839,7 @@ export async function buildAgentMissionControlSnapshot() {
       .limit(20),
     db
       .from('agent_run_events')
-      .select('run_id, event_type, severity, message, occurred_at')
+      .select('run_id, event_type, severity, message, occurred_at, metadata')
       .order('occurred_at', { ascending: false })
       .limit(12),
     db
@@ -897,6 +899,7 @@ export async function buildAgentMissionControlSnapshot() {
   const dependencyBlockers = buildDependencyBlockers(workItems)
   const costToday = Number(costs.reduce((sum, row) => sum + Number(row.amount ?? 0), 0).toFixed(4))
   const costSummary = buildAgentCostSummary({ costs, runsById, windowHours: 24 })
+  const governance = buildAgentGovernanceSnapshot({ approvals, events })
   const dailyBrief = buildDailyOperatingBrief({
     approvals,
     costToday,
@@ -954,6 +957,7 @@ export async function buildAgentMissionControlSnapshot() {
     daily_brief: dailyBrief,
     cost_summary: costSummary,
     quality_summary: qualitySummary,
+    governance,
     operating_signals: operatingSignals,
     dependency_blockers: dependencyBlockers,
     knowledge_governance: KNOWLEDGE_GOVERNANCE_STATUS,

--- a/lib/agent-policy.test.ts
+++ b/lib/agent-policy.test.ts
@@ -18,4 +18,12 @@ describe('agent runtime policies', () => {
     expect(actionRequiresApproval('n8n', 'publish_public_content')).toBe(true)
     expect(actionRequiresApproval('n8n', 'send_email')).toBe(true)
   })
+
+  it('requires payment authority approvals across runtimes', () => {
+    expect(getApprovalGate('create_checkout_session')?.approvalType).toBe('payment_create_checkout_session')
+    expect(getApprovalGate('create_refund')?.approvalType).toBe('payment_create_refund')
+    expect(actionRequiresApproval('codex', 'start_paid_external_job')).toBe(true)
+    expect(actionRequiresApproval('n8n', 'create_subscription')).toBe(true)
+    expect(actionRequiresApproval('manual', 'make_vendor_payment')).toBe(true)
+  })
 })

--- a/lib/agent-policy.ts
+++ b/lib/agent-policy.ts
@@ -1,16 +1,34 @@
 import type { AgentRuntime } from '@/lib/agent-run'
 
-export type AgentAction =
-  | 'read_files'
-  | 'write_files'
-  | 'external_api_call'
-  | 'client_data_access'
-  | 'known_workflow_db_write'
-  | 'unknown_db_write'
-  | 'publish_public_content'
-  | 'send_email'
-  | 'production_config_change'
-  | 'public_content_from_private_material'
+export const AGENT_ACTIONS = [
+  'read_files',
+  'write_files',
+  'external_api_call',
+  'client_data_access',
+  'known_workflow_db_write',
+  'unknown_db_write',
+  'publish_public_content',
+  'send_email',
+  'production_config_change',
+  'public_content_from_private_material',
+  'create_checkout_session',
+  'create_subscription',
+  'create_refund',
+  'make_vendor_payment',
+  'increase_paid_api_budget',
+  'start_paid_external_job',
+] as const
+
+export type AgentAction = (typeof AGENT_ACTIONS)[number]
+
+export const PAYMENT_AUTHORITY_ACTIONS = [
+  'create_checkout_session',
+  'create_subscription',
+  'create_refund',
+  'make_vendor_payment',
+  'increase_paid_api_budget',
+  'start_paid_external_job',
+] as const satisfies readonly AgentAction[]
 
 export type RuntimePolicy = {
   runtime: AgentRuntime
@@ -62,6 +80,42 @@ export const APPROVAL_GATES: ApprovalGate[] = [
     approvalType: 'private_material_public_content',
     description: 'Public content derived from private notes, chats, transcripts, or client material.',
   },
+  {
+    action: 'create_checkout_session',
+    label: 'Create checkout session',
+    approvalType: 'payment_create_checkout_session',
+    description: 'Creating a payment checkout session that could collect funds from a client or customer.',
+  },
+  {
+    action: 'create_subscription',
+    label: 'Create subscription',
+    approvalType: 'payment_create_subscription',
+    description: 'Creating or activating a recurring paid subscription.',
+  },
+  {
+    action: 'create_refund',
+    label: 'Create refund',
+    approvalType: 'payment_create_refund',
+    description: 'Issuing a refund, credit, or payment reversal.',
+  },
+  {
+    action: 'make_vendor_payment',
+    label: 'Make vendor payment',
+    approvalType: 'payment_make_vendor_payment',
+    description: 'Sending money to a vendor, contractor, marketplace, or external payee.',
+  },
+  {
+    action: 'increase_paid_api_budget',
+    label: 'Increase paid API budget',
+    approvalType: 'payment_increase_paid_api_budget',
+    description: 'Increasing paid API, model, scraping, media, or automation spend limits.',
+  },
+  {
+    action: 'start_paid_external_job',
+    label: 'Start paid external job',
+    approvalType: 'payment_start_paid_external_job',
+    description: 'Starting a paid external job such as media generation, scraping, enrichment, or hosted execution.',
+  },
 ]
 
 export const RUNTIME_POLICIES: RuntimePolicy[] = [
@@ -79,6 +133,7 @@ export const RUNTIME_POLICIES: RuntimePolicy[] = [
       'publish_public_content',
       'send_email',
       'public_content_from_private_material',
+      ...PAYMENT_AUTHORITY_ACTIONS,
     ],
     notes: 'Primary engineering runtime. Repo writes are allowed; production side effects need approval.',
   },
@@ -96,6 +151,7 @@ export const RUNTIME_POLICIES: RuntimePolicy[] = [
       'publish_public_content',
       'send_email',
       'public_content_from_private_material',
+      ...PAYMENT_AUTHORITY_ACTIONS,
     ],
     notes: 'Production automation runtime. Known workflow writes are allowed; outbound actions stay gated.',
   },
@@ -117,6 +173,7 @@ export const RUNTIME_POLICIES: RuntimePolicy[] = [
       'publish_public_content',
       'send_email',
       'public_content_from_private_material',
+      ...PAYMENT_AUTHORITY_ACTIONS,
     ],
     notes: 'Read-only in v1. Any mutation or client-data access must create an approval checkpoint first.',
   },
@@ -138,6 +195,7 @@ export const RUNTIME_POLICIES: RuntimePolicy[] = [
       'publish_public_content',
       'send_email',
       'public_content_from_private_material',
+      ...PAYMENT_AUTHORITY_ACTIONS,
     ],
     notes: 'Deferred evaluation runtime. Isolated review only until trace and rollback behavior are proven.',
   },
@@ -149,7 +207,11 @@ export const RUNTIME_POLICIES: RuntimePolicy[] = [
     canCallExternalApis: true,
     canTouchClientData: true,
     canWriteProductionData: 'known_workflows',
-    requiresApprovalFor: ['production_config_change', 'public_content_from_private_material'],
+    requiresApprovalFor: [
+      'production_config_change',
+      'public_content_from_private_material',
+      ...PAYMENT_AUTHORITY_ACTIONS,
+    ],
     notes: 'Human-triggered admin actions. Existing admin auth remains the approval boundary for known workflows.',
   },
 ]
@@ -164,4 +226,8 @@ export function getApprovalGate(action: AgentAction): ApprovalGate | undefined {
 
 export function actionRequiresApproval(runtime: AgentRuntime, action: AgentAction): boolean {
   return getRuntimePolicy(runtime).requiresApprovalFor.includes(action)
+}
+
+export function isPaymentAuthorityAction(action: AgentAction): boolean {
+  return PAYMENT_AUTHORITY_ACTIONS.includes(action as (typeof PAYMENT_AUTHORITY_ACTIONS)[number])
 }

--- a/lib/chief-of-staff-chat.ts
+++ b/lib/chief-of-staff-chat.ts
@@ -7,10 +7,15 @@ import {
   startAgentRun,
 } from '@/lib/agent-run'
 import {
+  AGENT_ACTIONS,
   actionRequiresApproval,
   getApprovalGate,
   type AgentAction,
 } from '@/lib/agent-policy'
+import {
+  applyDelegationDecisionToEngagements,
+  evaluateAgentDelegationPolicy,
+} from '@/lib/agent-delegation-policy'
 import {
   evaluateAgentBudget,
   type AgentBudgetDecision,
@@ -166,18 +171,7 @@ export type ChiefOfStaffScopedContext = {
 
 const DEFAULT_MODEL = 'gpt-4o-mini'
 const DEFAULT_MAX_TOKENS = 900
-const CHIEF_OF_STAFF_ACTIONS: AgentAction[] = [
-  'read_files',
-  'write_files',
-  'external_api_call',
-  'client_data_access',
-  'known_workflow_db_write',
-  'unknown_db_write',
-  'publish_public_content',
-  'send_email',
-  'production_config_change',
-  'public_content_from_private_material',
-]
+const CHIEF_OF_STAFF_ACTIONS: readonly AgentAction[] = AGENT_ACTIONS
 
 function sinceHours(hours: number) {
   return new Date(Date.now() - hours * 60 * 60 * 1000).toISOString()
@@ -709,6 +703,7 @@ export function buildChiefOfStaffPrompt(context: ChiefOfStaffContext, history: C
       'When proposing an executable next step, include a typed action proposal. The proposal is only a recommendation; it does not execute work.',
       'You are the front-door router for the agent organization. When the user asks who should handle work, choose the best mapped agent from the routing catalog.',
       'When the next step should be handled by one of the mapped agents, include an agent_engagements proposal with the exact agent_key.',
+      'Agent engagement proposals are checked against deterministic governance routing before they are surfaced.',
       'Prefer active or partial agents for immediate read-only engagement. Planned agents can be recommended, but label them as queued for review in your reply.',
       'If several agents could help, pick one primary next agent and at most two supporting agents.',
       'Use only these action ids: read_files, write_files, external_api_call, client_data_access, known_workflow_db_write, unknown_db_write, publish_public_content, send_email, production_config_change, public_content_from_private_material.',
@@ -861,6 +856,36 @@ export async function runChiefOfStaffChat(input: ChiefOfStaffChatRequest): Promi
     })
 
     const parsed = parseChiefOfStaffJson(completion.content)
+    const delegationDecision = parsed.agentEngagements.length
+      ? evaluateAgentDelegationPolicy({
+          message,
+          proposedAgentKeys: parsed.agentEngagements.map((engagement) => engagement.agentKey),
+        })
+      : null
+    const agentEngagements = applyDelegationDecisionToEngagements(parsed.agentEngagements, delegationDecision)
+
+    if (delegationDecision) {
+      await recordAgentEvent({
+        runId: run.id,
+        eventType: 'delegation_decision_recorded',
+        severity: delegationDecision.risk_class === 'payment_spend' || delegationDecision.risk_class === 'production_mutation'
+          ? 'warning'
+          : 'info',
+        message: delegationDecision.reason,
+        metadata: {
+          selected_agent_key: delegationDecision.selected_agent_key,
+          selected_agent_name: delegationDecision.selected_agent_name,
+          alternatives_considered: delegationDecision.alternatives_considered,
+          task_type: delegationDecision.task_type,
+          risk_class: delegationDecision.risk_class,
+          required_evidence: delegationDecision.required_evidence,
+          fallback_agent_key: delegationDecision.fallback_agent_key,
+          approval_gate: delegationDecision.approval_gate,
+          confidence: delegationDecision.confidence,
+        },
+      }).catch(() => {})
+    }
+
     await recordAgentStep({
       runId: run.id,
       stepKey: 'generate_reply',
@@ -878,7 +903,8 @@ export async function runChiefOfStaffChat(input: ChiefOfStaffChatRequest): Promi
         },
         suggested_actions: parsed.suggestedActions,
         action_proposals: parsed.actionProposals,
-        agent_engagements: parsed.agentEngagements,
+        agent_engagements: agentEngagements,
+        delegation_decision: delegationDecision,
         context_ref: contextRef,
       },
     })
@@ -896,7 +922,8 @@ export async function runChiefOfStaffChat(input: ChiefOfStaffChatRequest): Promi
         },
         suggested_actions: parsed.suggestedActions,
         action_proposals: parsed.actionProposals,
-        agent_engagements: parsed.agentEngagements,
+        agent_engagements: agentEngagements,
+        delegation_decision: delegationDecision,
         context_ref: contextRef,
       },
     })
@@ -906,7 +933,7 @@ export async function runChiefOfStaffChat(input: ChiefOfStaffChatRequest): Promi
       reply: parsed.reply,
       suggestedActions: parsed.suggestedActions,
       actionProposals: parsed.actionProposals,
-      agentEngagements: parsed.agentEngagements,
+      agentEngagements,
       model,
       budgetDecision,
     }


### PR DESCRIPTION
## Summary
- Adds a derived Agent Governance snapshot for capability inventory, payment authority gates, recent delegation decisions, and least-privilege attention signals.
- Adds deterministic Shaka delegation policy helpers and records `delegation_decision_recorded` trace metadata when governed engagements are proposed.
- Expands agent policy with approval-gated payment/spend actions and surfaces the v1 governance proof panel in `/admin/agents`.
- Updates the governance blueprint with implementation status for Phases 1-4 and leaves Phase 5 client-safe audit/export packaging as the next open phase.

## Validation
- `git diff --check`
- `npm test -- --run lib/agent-policy.test.ts lib/agent-governance.test.ts lib/agent-delegation-policy.test.ts lib/chief-of-staff-chat.test.ts app/api/admin/agents/chief-of-staff/actions/route.test.ts app/admin/agents/page.test.tsx app/api/admin/agents/mission-control/route.test.ts lib/agent-mission-control.test.ts`
- `npx tsc --noEmit`
- `npm run build`
- Authenticated local smoke at `http://127.0.0.1:3011/admin/agents` verified the Agent Governance panel, Capability Inventory, Delegation Trace, and Payment Authority sections. Integrated browser hit the login/localStorage guard, so the authenticated smoke used Playwright storage state generated from the local E2E auth helper.
- Merge-gate check on 2026-05-21: `gh pr checks 335` passed for `Vercel – portfolio`; `npm run deploy:watch:once -- --ref 79870c34997ba827353a7784e7ca90f56b068875 --contexts "Vercel – portfolio,Vercel – portfolio-staging"` reported `Vercel – portfolio-staging` missing.

## Integration Notes
- Branch: `codex/agentic-os-governance`
- Worktree: `/Users/vambahsillah/Projects/Portfolio.worktrees/agentic-os-governance`
- Conflict preflight: open PRs #334, #320, and #317 did not overlap the implementation files; shared root worktree has unrelated dirty work and was not modified.
- Environment bootstrap: `.env.local` and `.vercel` were linked from the root checkout via worktree env bootstrap; `.env.staging` was missing at the source; ignored generated/runtime artifacts were not committed.
- Build note: `npm run build` passed but repeated the existing dev-environment warning that `MOCK_N8N=false` and `N8N_DISABLE_OUTBOUND=false`; no n8n trigger actions were clicked during smoke.
- Merge gate: PR remains draft because `Vercel – portfolio-staging` is not attached to the PR branch/SHA. Vercel metrics show recent `portfolio-staging` deployments for `main`, but not for PR #335. Integration Captain should either trigger/verify staging for commit `79870c34997ba827353a7784e7ca90f56b068875` or explicitly approve manual staging evidence before making the PR ready and merging.
