### PR TITLE
feat: align public commerce catalog surfaces

### DIFF
--- a/app/store/[id]/page.tsx
+++ b/app/store/[id]/page.tsx
@@ -135,7 +135,7 @@ export default function ProductDetailPage() {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-background text-foreground">
+      <div className="dark agent-ops-page min-h-screen text-foreground">
         <Navigation />
         <div className="pt-24 pb-12 px-4 flex items-center justify-center">
           <div className="text-muted-foreground">Loading product...</div>
@@ -146,7 +146,7 @@ export default function ProductDetailPage() {
 
   if (!product) {
     return (
-      <div className="min-h-screen bg-background text-foreground">
+      <div className="dark agent-ops-page min-h-screen text-foreground">
         <Navigation />
         <div className="pt-24 pb-12 px-4">
           <div className="max-w-7xl mx-auto text-center">
@@ -197,7 +197,7 @@ export default function ProductDetailPage() {
   ]
 
   return (
-    <div className="min-h-screen bg-background text-foreground">
+    <div className="dark agent-ops-page min-h-screen text-foreground">
       <Navigation />
       <div className="pt-24 pb-12 px-4 sm:px-6 lg:px-8">
         <div className="max-w-4xl mx-auto">
@@ -281,7 +281,7 @@ export default function ProductDetailPage() {
                   </span>
                 )}
                 {bundles.some((b) => getCampaignForBundle(b.bundleId)) && (
-                  <span className="ml-2 inline-flex items-center gap-1 px-3 py-1 bg-gradient-to-r from-amber-500 to-orange-500 text-white rounded-full text-xs font-bold">
+                  <span className="ml-2 inline-flex items-center gap-1 rounded-full border border-radiant-gold/50 bg-radiant-gold/15 px-3 py-1 text-xs font-bold text-radiant-gold">
                     <Sparkles className="w-3 h-3" />
                     Campaign Eligible
                   </span>
@@ -401,7 +401,7 @@ export default function ProductDetailPage() {
                           {campaign && (
                             <Link
                               href={`/campaigns/${campaign.slug}`}
-                              className="inline-flex items-center gap-1 px-2 py-1 bg-gradient-to-r from-amber-500/20 to-orange-500/20 border border-amber-500/40 rounded text-amber-400 text-xs hover:bg-amber-500/30 transition-colors"
+                              className="inline-flex items-center gap-1 rounded border border-radiant-gold/40 bg-radiant-gold/10 px-2 py-1 text-xs text-radiant-gold transition-colors hover:bg-radiant-gold/20"
                             >
                               <Sparkles className="w-3 h-3" />
                               {campaign.campaign_type === 'win_money_back' ? 'Win $ Back' : campaign.name}

--- a/app/store/page.tsx
+++ b/app/store/page.tsx
@@ -41,7 +41,7 @@ const SERVICE_TYPES = [
 // Loading fallback component
 function StoreLoading() {
   return (
-    <div className="min-h-screen bg-background text-foreground pt-24 pb-12 px-4">
+    <div className="dark agent-ops-page min-h-screen text-foreground pt-24 pb-12 px-4">
       <div className="max-w-7xl mx-auto">
         <div className="text-center py-12">
           <div className="text-muted-foreground">Loading store...</div>
@@ -243,7 +243,7 @@ function StoreContent() {
   const totalItems = filteredProducts.length + filteredServices.length
 
   return (
-    <div className="min-h-screen bg-background text-foreground pt-24 pb-12 px-4">
+    <div className="dark agent-ops-page min-h-screen text-foreground pt-24 pb-12 px-4">
       <div className="max-w-7xl mx-auto">
         {/* Header */}
         <motion.div
@@ -254,42 +254,120 @@ function StoreContent() {
           {/* Back to Home Link */}
           <button
             onClick={() => router.push('/')}
-            className="flex items-center gap-2 text-muted-foreground hover:text-foreground mb-4 transition-colors"
+            className="mb-4 flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors"
           >
             <ArrowLeft size={20} />
             Back to Home
           </button>
-          
-          <div className="flex items-center justify-between mb-6">
-            <div>
-              <h1 className="text-4xl font-bold mb-2">Store</h1>
-              <p className="text-muted-foreground">Browse our collection of products, merchandise, and services</p>
-            </div>
-            <div className="flex items-center gap-3">
-              <ThemeToggle />
-              <Link href="/help" className="text-muted-foreground hover:text-foreground transition-colors" aria-label="Help">
-                <HelpCircle size={20} />
-              </Link>
-            {cartCount > 0 && (
-              <motion.button
-                onClick={handleViewCart}
-                initial={{ scale: 0 }}
-                animate={{ scale: 1 }}
-                whileHover={{ scale: 1.05 }}
-                whileTap={{ scale: 0.95 }}
-                className="relative px-6 py-3 btn-gold font-semibold rounded-lg flex items-center gap-2"
-              >
-                <ShoppingCart size={20} />
-                View Cart
+
+          <section className="agent-ops-surface-header rounded-xl border p-5 sm:p-6">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+              <div className="min-w-0">
+                <p className="agent-ops-eyebrow">AmaduTown store</p>
+                <h1 className="mt-2 text-3xl font-bold sm:text-4xl">Products and services</h1>
+                <p className="mt-2 max-w-2xl text-muted-foreground">
+                  Browse digital products, implementation resources, merchandise, and advisory services.
+                </p>
+              </div>
+              <div className="flex items-center gap-3">
+                <ThemeToggle />
+                <Link href="/help" className="agent-ops-button-muted" aria-label="Help">
+                  <HelpCircle size={18} />
+                </Link>
                 {cartCount > 0 && (
-                  <span className="absolute -top-2 -right-2 bg-red-500 text-white text-xs font-bold rounded-full w-6 h-6 flex items-center justify-center">
-                    {cartCount}
-                  </span>
+                  <motion.button
+                    onClick={handleViewCart}
+                    initial={{ scale: 0 }}
+                    animate={{ scale: 1 }}
+                    whileHover={{ scale: 1.03 }}
+                    whileTap={{ scale: 0.97 }}
+                    className="agent-ops-button-primary relative px-4 py-3"
+                  >
+                    <ShoppingCart size={18} />
+                    View Cart
+                    {cartCount > 0 && (
+                      <span className="absolute -right-2 -top-2 flex h-6 w-6 items-center justify-center rounded-full bg-platinum-white text-xs font-bold text-imperial-navy">
+                        {cartCount}
+                      </span>
+                    )}
+                  </motion.button>
                 )}
-              </motion.button>
-            )}
+              </div>
             </div>
-          </div>
+
+            <div className="mt-6 grid gap-4">
+              {/* Category Toggle */}
+              <div className="flex flex-wrap gap-2 rounded-lg border border-radiant-gold/15 bg-background/25 p-1">
+                {([
+                  { value: 'all', label: 'All' },
+                  { value: 'products', label: 'Products' },
+                  { value: 'services', label: 'Services' },
+                ] as { value: ItemCategory; label: string }[]).map((cat) => (
+                  <button
+                    key={cat.value}
+                    onClick={() => handleCategoryChange(cat.value)}
+                    className={`rounded-md border px-4 py-2 text-sm font-medium transition-colors ${
+                      itemCategory === cat.value
+                        ? 'border-radiant-gold bg-radiant-gold text-imperial-navy'
+                        : 'border-transparent text-muted-foreground hover:border-radiant-gold/40 hover:text-foreground'
+                    }`}
+                  >
+                    {cat.label}
+                  </button>
+                ))}
+              </div>
+
+              {/* Search and Filters */}
+              <div className="flex flex-col gap-4 md:flex-row">
+                <div className="relative flex-1">
+                  <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" size={20} />
+                  <input
+                    type="text"
+                    placeholder="Search store..."
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    className="w-full pl-10 pr-4 py-2 input-brand"
+                  />
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {itemCategory !== 'all' && (
+                    <select
+                      value={selectedType}
+                      onChange={(e) => {
+                        const newType = e.target.value
+                        setSelectedType(newType)
+                        const url = new URL(window.location.href)
+                        if (newType === 'all') {
+                          url.searchParams.delete('type')
+                        } else {
+                          url.searchParams.set('type', newType)
+                        }
+                        router.replace(url.pathname + url.search, { scroll: false })
+                      }}
+                      className="px-4 py-2 input-brand"
+                    >
+                      {activeTypeFilters.map(type => (
+                        <option key={type.value} value={type.value}>{type.label}</option>
+                      ))}
+                    </select>
+                  )}
+                  <motion.button
+                    onClick={() => setShowFeaturedOnly(!showFeaturedOnly)}
+                    whileHover={{ scale: 1.03 }}
+                    whileTap={{ scale: 0.97 }}
+                    className={`inline-flex items-center rounded-lg border px-4 py-2 text-sm transition-colors ${
+                      showFeaturedOnly
+                        ? 'border-radiant-gold bg-radiant-gold text-imperial-navy'
+                        : 'border-radiant-gold/25 bg-background/30 text-muted-foreground hover:border-radiant-gold/60 hover:text-foreground'
+                    }`}
+                  >
+                    <Filter size={18} className="mr-2" />
+                    Featured
+                  </motion.button>
+                </div>
+              </div>
+            </div>
+          </section>
 
           {/* Error Banner */}
           {fetchError && (
@@ -304,77 +382,6 @@ function StoreContent() {
               </button>
             </div>
           )}
-
-          {/* Category Toggle */}
-          <div className="flex gap-2 mb-4">
-            {([
-              { value: 'all', label: 'All' },
-              { value: 'products', label: 'Products' },
-              { value: 'services', label: 'Services' },
-            ] as { value: ItemCategory; label: string }[]).map((cat) => (
-              <button
-                key={cat.value}
-                onClick={() => handleCategoryChange(cat.value)}
-                className={`px-4 py-2 rounded-lg border text-sm font-medium transition-colors ${
-                  itemCategory === cat.value
-                    ? 'bg-radiant-gold border-radiant-gold text-imperial-navy'
-                    : 'bg-silicon-slate border-silicon-slate text-muted-foreground hover:border-radiant-gold/50 hover:text-foreground'
-                }`}
-              >
-                {cat.label}
-              </button>
-            ))}
-          </div>
-
-          {/* Search and Filters */}
-          <div className="flex flex-col md:flex-row gap-4">
-            <div className="flex-1 relative">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground" size={20} />
-              <input
-                type="text"
-                placeholder="Search store..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                className="w-full pl-10 pr-4 py-2 input-brand"
-              />
-            </div>
-            <div className="flex gap-2">
-              {itemCategory !== 'all' && (
-                <select
-                  value={selectedType}
-                  onChange={(e) => {
-                    const newType = e.target.value
-                    setSelectedType(newType)
-                    const url = new URL(window.location.href)
-                    if (newType === 'all') {
-                      url.searchParams.delete('type')
-                    } else {
-                      url.searchParams.set('type', newType)
-                    }
-                    router.replace(url.pathname + url.search, { scroll: false })
-                  }}
-                  className="px-4 py-2 input-brand"
-                >
-                  {activeTypeFilters.map(type => (
-                    <option key={type.value} value={type.value}>{type.label}</option>
-                  ))}
-                </select>
-              )}
-              <motion.button
-                onClick={() => setShowFeaturedOnly(!showFeaturedOnly)}
-                whileHover={{ scale: 1.05 }}
-                whileTap={{ scale: 0.95 }}
-                className={`px-4 py-2 rounded-lg border transition-colors ${
-                  showFeaturedOnly
-                    ? 'bg-radiant-gold border-radiant-gold text-imperial-navy'
-                    : 'bg-silicon-slate border-silicon-slate text-muted-foreground hover:border-radiant-gold/50'
-                }`}
-              >
-                <Filter size={18} className="inline mr-2" />
-                Featured
-              </motion.button>
-            </div>
-          </div>
         </motion.div>
 
         {/* Store Items */}

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -51,11 +51,11 @@ export default function ProductCard({ product, onAddToCart, campaignBadge }: Pro
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       whileHover={{ y: -5 }}
-      className="bg-silicon-slate border border-silicon-slate rounded-xl overflow-hidden hover:border-radiant-gold/50 transition-colors cursor-pointer"
+      className="agent-ops-card group flex h-full cursor-pointer flex-col rounded-xl border transition-colors hover:border-radiant-gold/50"
       onClick={handleCardClick}
     >
       {/* Image */}
-      <div className="relative h-48 bg-gradient-to-br from-bronze/20 to-radiant-gold/20">
+      <div className="relative h-48 overflow-hidden border-b border-radiant-gold/10 bg-[radial-gradient(circle_at_20%_0%,rgba(212,175,55,0.14),transparent_14rem),rgba(18,30,49,0.62)]">
         {product.image_url && !imageError ? (
           <Image
             src={product.image_url}
@@ -76,7 +76,7 @@ export default function ProductCard({ product, onAddToCart, campaignBadge }: Pro
           </div>
         )}
         {campaignBadge && !product.is_featured && (
-          <div className="absolute top-2 right-2 flex items-center gap-1 px-2 py-1 bg-gradient-to-r from-amber-500 to-orange-500 text-white text-xs font-semibold rounded">
+          <div className="absolute top-2 right-2 flex items-center gap-1 rounded border border-radiant-gold/50 bg-radiant-gold/15 px-2 py-1 text-xs font-semibold text-radiant-gold">
             <Sparkles className="w-3 h-3" />
             {campaignBadge}
           </div>
@@ -87,14 +87,14 @@ export default function ProductCard({ product, onAddToCart, campaignBadge }: Pro
       </div>
 
       {/* Content */}
-      <div className="p-4">
+      <div className="flex flex-1 flex-col p-4">
         <h3 className="text-xl font-bold text-white mb-2 line-clamp-2">{product.title}</h3>
         {product.description && (
           <p className="text-muted-foreground text-sm mb-4 line-clamp-3">{product.description}</p>
         )}
 
         {/* Price and Add to Cart */}
-        <div className="flex items-center justify-between">
+        <div className="mt-auto flex items-center justify-between gap-3">
           <div className="flex items-center gap-2">
             {product.price !== null ? (
               <>
@@ -112,7 +112,7 @@ export default function ProductCard({ product, onAddToCart, campaignBadge }: Pro
             }}
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
-            className="px-4 py-2 bg-gradient-to-r btn-gold font-semibold rounded-lg flex items-center gap-2 transition-colors"
+            className="agent-ops-button-primary shrink-0"
           >
             {showAdded ? <Check size={18} /> : <ShoppingCart size={18} />}
             {showAdded ? 'Added!' : product.type === 'merchandise' ? 'View Details' : 'Add to Cart'}

--- a/components/ServiceCard.tsx
+++ b/components/ServiceCard.tsx
@@ -61,10 +61,10 @@ export default function ServiceCard({ service, onAddToCart, onRequestQuote, view
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       whileHover={{ y: -5 }}
-      className="bg-silicon-slate border border-silicon-slate rounded-xl overflow-hidden hover:border-radiant-gold/50 transition-colors"
+      className="agent-ops-card group flex h-full flex-col rounded-xl border transition-colors hover:border-radiant-gold/50"
     >
       {/* Image */}
-      <div className="relative h-48 bg-gradient-to-br from-bronze/20 to-radiant-gold/20">
+      <div className="relative h-48 overflow-hidden border-b border-radiant-gold/10 bg-[radial-gradient(circle_at_20%_0%,rgba(212,175,55,0.14),transparent_14rem),rgba(18,30,49,0.62)]">
         {service.image_url && !imageError ? (
           <Image
             src={service.image_url}
@@ -93,7 +93,7 @@ export default function ServiceCard({ service, onAddToCart, onRequestQuote, view
       </div>
 
       {/* Content */}
-      <div className="p-4">
+      <div className="flex flex-1 flex-col p-4">
         <h3 className="text-xl font-bold text-white mb-2 line-clamp-2">{service.title}</h3>
         
         {/* Service Details */}
@@ -154,28 +154,24 @@ export default function ServiceCard({ service, onAddToCart, onRequestQuote, view
         )}
 
         {/* Price and Action Button */}
-        <div className="flex items-center justify-between">
+        <div className="mt-auto flex items-center justify-between gap-3">
           <div className="flex items-center gap-2">
             {service.is_quote_based ? (
-              <span className="text-lg font-semibold text-yellow-400">Contact for Pricing</span>
+              <span className="text-lg font-semibold text-radiant-gold">Contact for Pricing</span>
             ) : service.price !== null ? (
               <>
-                <DollarSign className="text-green-400" size={20} />
+                <DollarSign className="text-radiant-gold" size={20} />
                 <span className="text-2xl font-bold text-white">{formatDollarAmount(service.price)}</span>
               </>
             ) : (
-              <span className="text-lg font-semibold text-green-400">Free</span>
+              <span className="text-lg font-semibold text-radiant-gold">Free</span>
             )}
           </div>
           <motion.button
             onClick={handleAction}
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
-            className={`px-4 py-2 font-semibold rounded-lg flex items-center gap-2 transition-colors ${
-              service.is_quote_based
-                ? 'bg-gradient-to-r from-yellow-600 to-orange-600 text-white hover:from-yellow-700 hover:to-orange-700'
-                : 'btn-gold'
-            }`}
+            className="agent-ops-button-primary shrink-0"
           >
             {service.is_quote_based ? (
               <>

--- a/components/ShoppingCart.tsx
+++ b/components/ShoppingCart.tsx
@@ -210,12 +210,12 @@ export default function ShoppingCart({ isOpen, onClose, onCheckout }: ShoppingCa
             animate={{ x: 0 }}
             exit={{ x: '100%' }}
             transition={{ type: 'spring', damping: 25, stiffness: 200 }}
-            className="fixed right-0 top-0 h-full w-full max-w-md bg-silicon-slate border-l border-silicon-slate z-50 flex flex-col"
+            className="fixed right-0 top-0 z-50 flex h-full w-full max-w-md flex-col border-l border-radiant-gold/25 bg-background/95 shadow-2xl backdrop-blur-xl"
           >
             {/* Header */}
-            <div className="p-6 border-b border-silicon-slate flex items-center justify-between">
+            <div className="flex items-center justify-between border-b border-radiant-gold/15 p-6">
               <div className="flex items-center gap-3">
-                <CartIcon size={24} />
+                <CartIcon className="text-radiant-gold" size={24} />
                 <h2 className="text-2xl font-bold">Shopping Cart</h2>
                 {cartItems.length > 0 && (
                   <span className="px-2 py-1 bg-radiant-gold text-imperial-navy text-xs font-semibold rounded">
@@ -225,7 +225,7 @@ export default function ShoppingCart({ isOpen, onClose, onCheckout }: ShoppingCa
               </div>
               <button
                 onClick={onClose}
-                className="p-2 hover:bg-silicon-slate/80 rounded-lg transition-colors"
+                className="rounded-lg border border-transparent p-2 text-muted-foreground transition-colors hover:border-radiant-gold/30 hover:text-foreground"
               >
                 <X size={20} />
               </button>
@@ -243,7 +243,7 @@ export default function ShoppingCart({ isOpen, onClose, onCheckout }: ShoppingCa
                   <p className="text-muted-foreground mb-4">Your cart is empty</p>
                   <button
                     onClick={onClose}
-                    className="px-4 py-2 bg-silicon-slate border border-silicon-slate rounded-lg btn-ghost transition-colors"
+                    className="agent-ops-button-secondary"
                   >
                     Continue Shopping
                   </button>
@@ -261,11 +261,11 @@ export default function ShoppingCart({ isOpen, onClose, onCheckout }: ShoppingCa
                           key={`product-${item.productId}`}
                           initial={{ opacity: 0, x: 20 }}
                           animate={{ opacity: 1, x: 0 }}
-                          className="bg-silicon-slate border border-silicon-slate rounded-lg p-4"
+                          className="agent-ops-card rounded-lg border p-4"
                         >
                           <div className="flex gap-4">
                             {/* Product Image */}
-                            <div className="w-20 h-20 bg-gradient-to-br from-bronze/20 to-radiant-gold/20 rounded-lg flex-shrink-0 flex items-center justify-center overflow-hidden relative">
+                            <div className="relative flex h-20 w-20 flex-shrink-0 items-center justify-center overflow-hidden rounded-lg border border-radiant-gold/10 bg-radiant-gold/10">
                               {product.image_url ? (
                                 <Image
                                   src={product.image_url}
@@ -338,11 +338,11 @@ export default function ShoppingCart({ isOpen, onClose, onCheckout }: ShoppingCa
                           key={`service-${item.serviceId}`}
                           initial={{ opacity: 0, x: 20 }}
                           animate={{ opacity: 1, x: 0 }}
-                          className="bg-silicon-slate border border-silicon-slate rounded-lg p-4"
+                          className="agent-ops-card rounded-lg border p-4"
                         >
                           <div className="flex gap-4">
                             {/* Service Image */}
-                            <div className="w-20 h-20 bg-gradient-to-br from-bronze/20 to-radiant-gold/20 rounded-lg flex-shrink-0 flex items-center justify-center overflow-hidden relative">
+                            <div className="relative flex h-20 w-20 flex-shrink-0 items-center justify-center overflow-hidden rounded-lg border border-radiant-gold/10 bg-radiant-gold/10">
                               {service.image_url ? (
                                 <Image
                                   src={service.image_url}
@@ -432,7 +432,7 @@ export default function ShoppingCart({ isOpen, onClose, onCheckout }: ShoppingCa
 
             {/* Footer */}
             {cartItems.length > 0 && (
-              <div className="p-6 border-t border-silicon-slate space-y-4">
+              <div className="space-y-4 border-t border-radiant-gold/15 p-6">
                 {hasQuoteBasedItems && (
                   <div className="p-3 bg-radiant-gold/10 border border-radiant-gold/30 rounded-lg">
                     <p className="text-sm text-radiant-gold">
@@ -454,14 +454,14 @@ export default function ShoppingCart({ isOpen, onClose, onCheckout }: ShoppingCa
                   {cartItems.length > 0 && (
                     <button
                       onClick={handleClear}
-                      className="flex-1 px-4 py-2 bg-silicon-slate border border-silicon-slate rounded-lg btn-ghost hover:border-red-500 transition-colors"
+                      className="agent-ops-button-muted flex-1 hover:border-red-500"
                     >
                       Clear Cart
                     </button>
                   )}
                   <button
                     onClick={onCheckout}
-                    className="flex-1 px-6 py-2 bg-gradient-to-r btn-gold font-semibold rounded-lg transition-colors"
+                    className="agent-ops-button-primary flex-1 px-6 py-2"
                   >
                     {hasQuoteBasedItems ? 'Request Quote' : 'Proceed to Checkout'}
                   </button>

--- a/docs/design/amadutown-color-palette-audit.md
+++ b/docs/design/amadutown-color-palette-audit.md
@@ -37,8 +37,9 @@ The Agent Ops Mission Control surface at `/admin/agents` is the current referenc
 - **Outreach/Sales slice:** `/admin/outreach`, `/admin/outreach/dashboard`, `/admin/sales`, `/admin/lead-dashboards`, and `/admin/campaigns` now use the shared admin console shell/header treatment, with the noisiest sales/outreach gradients replaced by restrained command surfaces.
 - **Outreach/Sales workflow polish:** Lead Pipeline rows, Outreach Dashboard metrics/activity, escalation links, and Sales Dashboard table actions now use the shared console palette for their nested workflow controls and status affordances.
 - **Sales subpage slice:** `/admin/sales/products`, `/admin/sales/bundles`, `/admin/sales/scripts`, `/admin/sales/upsell-paths`, and `/admin/sales/implementation-roadmap` now use the shared admin console shell, surface headers, metric cards, muted form controls, and gold command actions.
-- **Future auth slice:** Login, signup, forgot-password, and reset-password should be redesigned around the same AmaduTown operating-console language so the entry point no longer feels visually disconnected from admin.
-- **Next rollout candidates:** deeper content, auth, public commerce, checkout, and client-facing detail pages still carry older gray, blue, purple, and cyan styling and should move to the same primitives in smaller follow-up PRs.
+- **Auth slice:** Login, signup, forgot-password, and reset-password now use the AmaduTown operating-console language so the entry point no longer feels visually disconnected from admin.
+- **Public commerce catalog slice:** `/store`, `/store/[id]`, `ProductCard`, `ServiceCard`, and `ShoppingCart` now use the Mission Control navy/gold surface language, gold command affordances, and restrained status badges. Checkout remains a separate commerce-flow pass.
+- **Next rollout candidates:** deeper content, checkout, public services, and client-facing detail pages still carry older gray, blue, purple, and cyan styling and should move to the same primitives in smaller follow-up PRs.
 
 ---
 


### PR DESCRIPTION
## Summary
- Align `/store` and `/store/[id]` with the Mission Control navy/gold surface language.
- Update shared `ProductCard`, `ServiceCard`, and `ShoppingCart` treatments to remove cyan/purple/orange commerce gradients and clarify command affordances.
- Update the AmaduTown design audit with the public commerce catalog remediation status.

## Validation
- `npm run worktree:env -- --source /Users/vambahsillah/Projects/Portfolio` (linked `.env.local` and `.vercel`; `.env.staging` source absent)
- `npx tsx scripts/build-chatbot-knowledge.ts`
- `npx tsc --noEmit --pretty false`
- `npm run lint`
- Playwright screenshot QA: `/store` desktop, `/store` mobile, `/store/1` product detail
- `npm run build` (passes; existing env warning notes `MOCK_N8N=false` and `N8N_DISABLE_OUTBOUND=false`, no n8n workflow was executed)
- Push hook database health check passed

## Integration Notes
- No API, database, checkout, pricing, or cart persistence logic changed.
- Generated `lib/chatbot-knowledge-content.generated.ts` was regenerated locally for validation only and remains ignored/uncommitted.
- Browser review URL while dev server is running: `http://localhost:3022/store`.
- Vercel contexts to verify after merge: `Vercel – portfolio`, `Vercel – portfolio-staging`.
