### PR TITLE
docs: add branch tracing commands

### DIFF
--- a/commands/captain-sweep.md
+++ b/commands/captain-sweep.md
@@ -103,9 +103,13 @@ After each merge:
 Clean conservatively:
 
 - Delete merged remote branches when GitHub did not already delete them.
-- Delete local branches only after confirming they have no commits missing from `origin/main`.
+- Delete local branches only after checking both GitHub PR state and local commit state. Squash-merged PR branches can still show commits missing from `origin/main`.
+- Treat a closed-unmerged PR as a product decision, not routine cleanup. Preserve it until the owner decides revive, archive, or delete.
+- Classify dirty worktree files as temporary evidence, normalized proposal, approved durable artifact, or stale debris before removing the worktree.
 - Preserve recovery stashes and unknown worktrees unless Vambah explicitly approves cleanup.
 - Leave watch/debt items documented instead of guessing ownership.
+
+If a branch or worktree origin is unclear, run the RCA sequence in `docs/terminal-command-cheatsheet.md` and use the postmortem protocol in `docs/postmortems/2026-05-21-branch-worktree-residue-and-traceability.md` before deleting anything.
 
 ## Agent Coordination Gate
 

--- a/docs/agents/integration-captain.md
+++ b/docs/agents/integration-captain.md
@@ -121,7 +121,7 @@ Use these methods when they reduce future merge noise or make parallel work easi
 - Prefer short-lived branches named by owner and purpose, such as `codex/agent-command-room`.
 - Keep one branch to one feature, fix, or docs update.
 - Delete remote branches after their PR is merged and post-merge verification passes.
-- Delete local branches only when they have no commits missing from `origin/main`.
+- Delete local branches only after checking GitHub PR state and local commit state. Because Portfolio normally uses squash merges, a branch can have commits missing from `origin/main` even though GitHub already merged the PR.
 - Leave recovery stashes and unknown local branches in place until their owner or purpose is clear.
 
 Before deleting a local branch with a gone upstream, check:
@@ -130,7 +130,20 @@ Before deleting a local branch with a gone upstream, check:
 git log --oneline <branch> --not origin/main
 ```
 
-If that command returns commits, classify the branch as `watch` or `debt` instead of deleting it.
+If that command returns commits, check the related PR before deleting:
+
+```bash
+gh pr list --state all --search "<branch-or-feature-name>" --json number,title,state,mergedAt,headRefName,url --limit 20
+```
+
+Classify the branch before acting:
+
+- `merged-pr residue`: GitHub PR is merged; remove the clean worktree and delete the branch after post-merge verification.
+- `closed-unmerged`: PR was closed without merge; preserve until the owner decides revive, archive, or delete.
+- `local-only`: no PR found; trace reflog, changed files, and likely owner before cleanup.
+- `dirty-worktree`: classify uncommitted files before removing anything.
+
+Use `docs/postmortems/2026-05-21-branch-worktree-residue-and-traceability.md` and `docs/terminal-command-cheatsheet.md` for the full branch-origin RCA sequence.
 
 ### PR Queue Discipline
 

--- a/docs/postmortems/2026-05-21-branch-worktree-residue-and-traceability.md
+++ b/docs/postmortems/2026-05-21-branch-worktree-residue-and-traceability.md
@@ -1,0 +1,163 @@
+# Postmortem: Branch And Worktree Residue After Parallel Agent Sweeps (2026-05-21)
+
+## Summary
+
+After a heavy Integration Captain sweep, the Portfolio repo still had many local branches and sibling worktrees even though their PRs had already been merged. The repo itself was healthy: `main` was clean, `origin/main` matched local `main`, and Vercel deploy gates were green. The issue was operational noise: stale local branches and worktrees made it harder to tell which work was active, which work was already shipped, and which work still needed a decision.
+
+The cleanup confirmed that almost all residue came from already-merged PRs. One branch, `codex/decision-queue-structured-intake`, was intentionally left because PR #288 had been closed without merging and still represented a real product decision.
+
+## Impact
+
+- Increased cognitive load during captain sweeps.
+- Made normal Git residue look like possible unmerged work.
+- Created risk that a future agent might revive or delete a branch without understanding its origin.
+- Made it harder for Vambah to distinguish normal integration mechanics from poor Git hygiene.
+
+No production code regression, deployment failure, or data loss occurred.
+
+## Timeline
+
+| Time | Event |
+| --- | --- |
+| 2026-05-21 | Captain sweep merged and verified several PRs, leaving `main` clean. |
+| 2026-05-21 | Local branch review found many merged branches still present locally, plus stale worktrees. |
+| 2026-05-21 | Branches were classified by PR status, worktree ownership, and unique commits instead of raw Git ancestry alone. |
+| 2026-05-21 | Merged-PR branches and clean worktrees were removed. Temporary visual QA screenshots were preserved in a named stash before deleting their worktree. |
+| 2026-05-21 | `codex/decision-queue-structured-intake` was preserved because its PR was closed, not merged, and its changes were superseded rather than shipped. |
+
+## Root Cause
+
+The primary root cause was a mismatch between GitHub PR state and local Git ancestry after squash merges.
+
+Portfolio uses squash merges. A squash merge creates a new commit on `main` instead of preserving the exact branch commits. GitHub correctly marks the PR as merged, but local Git can still show the old branch commit as not reachable from `origin/main`. That makes a branch look unmerged locally even though its feature has already landed.
+
+## Contributing Factors
+
+- Several implementation lanes used sibling worktrees, which keep branches checked out and prevent local branch deletion until the worktree is removed.
+- Some merged remote branches were not automatically deleted by GitHub or the merge command.
+- The existing cleanup rule protected branches with unique commits, which is conservative but noisy when squash merges are normal.
+- Closed-but-unmerged branches were not always documented with a clear disposition after closure.
+- Temporary visual QA artifacts stayed in `.tmp/` inside a worktree after the PR had already landed.
+
+## What Went Well
+
+- The captain did not bulk-delete blindly.
+- Branches were cross-checked against GitHub PR state before deletion.
+- Dirty temporary artifacts were stashed before removing their worktree.
+- The closed-but-unmerged branch was preserved for an explicit product decision.
+- The cleanup left the shared checkout clean on `main`.
+
+## What Could Improve
+
+- Post-merge cleanup should include GitHub PR-state-aware branch classification, not only `git log <branch> --not origin/main`.
+- Every closed-unmerged branch should receive an explicit disposition: `revive`, `superseded`, `archive`, or `delete`.
+- Temporary QA output should be classified at merge time as `discard`, `stash`, or `promote to durable evidence`.
+- The terminal command cheatsheet should include a branch-origin tracing sequence, so future residue can be diagnosed quickly.
+
+## Prevention Protocol
+
+Run this sequence during every captain sweep before deleting local branches or worktrees:
+
+```bash
+git fetch --prune origin
+git status --short --branch
+git branch -vv --sort=-committerdate
+git worktree list --porcelain
+gh pr list --state all --json number,title,headRefName,state,mergedAt,closedAt,url --limit 120
+```
+
+Classify every non-`main` branch:
+
+| Classification | Meaning | Action |
+| --- | --- | --- |
+| `merged-pr residue` | GitHub PR is merged, but branch still exists locally/remotely. | Delete branch after post-merge deploy verification. Remove clean worktree. |
+| `closed-unmerged` | PR was closed without merge. | Preserve until owner decides revive, archive, or delete. |
+| `active-pr` | PR is open. | Leave branch/worktree in place unless owner asks for cleanup. |
+| `local-only` | No recent PR found. | Trace origin before deciding. |
+| `dirty-worktree` | Worktree has uncommitted files. | Classify files before removing anything. |
+| `temporary evidence` | Raw screenshots, traces, or generated artifacts. | Stash or normalize into docs before cleanup. |
+
+## Root-Cause Analysis Commands
+
+Use these commands when a branch origin is unclear:
+
+```bash
+git branch -vv
+git reflog show --date=iso codex/name-of-branch
+git merge-base origin/main codex/name-of-branch
+git log --oneline --graph codex/name-of-branch --not origin/main
+git diff --stat origin/main...codex/name-of-branch
+git diff --name-status origin/main...codex/name-of-branch
+gh pr list --state all --search "feature phrase" --json number,title,state,mergedAt,headRefName,url --limit 20
+gh pr view <number> --json title,state,body,comments,files,commits
+```
+
+Interpretation:
+
+- If GitHub says the PR is `MERGED`, prefer PR state over raw ancestry for cleanup because squash merge rewrites branch ancestry.
+- If GitHub says the PR is `CLOSED` and `mergedAt` is null, treat the branch as a product decision, not cleanup noise.
+- If the branch has no PR, use reflog, commit author/date, and changed files to reconstruct the likely owner and intent.
+
+## Remediation If Preliminary Steps Are Circumvented
+
+If someone deletes, closes, or overwrites a branch before classification:
+
+1. Check GitHub PR history:
+
+   ```bash
+   gh pr list --state all --search "branch-or-feature-name" --json number,title,state,mergedAt,headRefName,url --limit 20
+   ```
+
+2. Check local reflogs:
+
+   ```bash
+   git reflog --date=iso --all | rg "branch-or-feature-name|commit-sha"
+   ```
+
+3. Check recovery stashes:
+
+   ```bash
+   git stash list --date=local
+   ```
+
+4. Check whether the remote branch still exists:
+
+   ```bash
+   git ls-remote --heads origin branch-name
+   ```
+
+5. Recreate a recovery branch when a commit SHA is known:
+
+   ```bash
+   git checkout -B recovery/branch-name <commit-sha>
+   ```
+
+6. If the branch is superseded, extract only the still-useful idea into a fresh branch from current `main`.
+
+7. Record the final disposition in the captain report or a postmortem if the cleanup created confusion.
+
+## Durable Rules Added
+
+- Branch cleanup must be PR-state-aware when squash merges are normal.
+- Closed-unmerged PRs are product decisions, not automatic cleanup candidates.
+- Dirty worktree artifacts must be classified before deletion.
+- Temporary generated artifacts should be stashed, normalized, or explicitly discarded.
+- The branch-origin tracing commands belong in `docs/terminal-command-cheatsheet.md`.
+
+## Action Items
+
+| Priority | Action | Owner |
+| --- | --- | --- |
+| High | Add branch-origin tracing commands to the terminal cheatsheet. | Integration Captain |
+| High | Update captain sweep guidance to classify branches by GitHub PR state before deletion. | Integration Captain |
+| Medium | Add a stale branch/worktree report that labels `merged-pr residue`, `closed-unmerged`, `local-only`, and `dirty-worktree`. | Future automation |
+| Medium | Require a disposition note when closing a PR without merge. | PR owner / Captain |
+| Low | Periodically retire old recovery stashes after their normalized evidence has landed. | Captain |
+
+## References
+
+- Terminal commands: `docs/terminal-command-cheatsheet.md`
+- Captain protocol: `commands/captain-sweep.md`
+- Integration role: `docs/agents/integration-captain.md`
+- Preserved visual QA screenshots: `stash@{Thu May 21 05:19:47 2026}`
+- Preserved AutoResearch temp artifacts: `stash@{Wed May 20 23:28:52 2026}`

--- a/docs/terminal-command-cheatsheet.md
+++ b/docs/terminal-command-cheatsheet.md
@@ -157,6 +157,58 @@ Push the branch:
 git push -u origin codex/name-of-change
 ```
 
+## Trace Branch Origin
+
+Use these when a local branch is still hanging around and you need to understand where it came from, what it changed, and whether it should be revived or retired.
+
+List local branches, tracking branches, and latest commit messages:
+
+```bash
+git branch -vv
+```
+
+Show when a branch was created and how it moved locally:
+
+```bash
+git reflog show --date=iso codex/name-of-branch
+```
+
+Find the branch point against current `main`:
+
+```bash
+git merge-base origin/main codex/name-of-branch
+```
+
+Show commits that exist on the branch but not on `main`:
+
+```bash
+git log --oneline --graph codex/name-of-branch --not origin/main
+```
+
+Summarize the files changed by the branch:
+
+```bash
+git diff --stat origin/main...codex/name-of-branch
+```
+
+Show the exact changed files:
+
+```bash
+git diff --name-status origin/main...codex/name-of-branch
+```
+
+Inspect the related GitHub PR when you know the PR number:
+
+```bash
+gh pr view 288 --json title,state,body,comments,files,commits
+```
+
+Search recent PRs by feature phrase when you do not know the PR number:
+
+```bash
+gh pr list --state all --search "decision queue" --json number,title,state,mergedAt,headRefName,url --limit 20
+```
+
 ## Validation
 
 Run one focused test file:


### PR DESCRIPTION
## Summary
- Add branch-origin tracing commands to the Portfolio terminal command cheatsheet.
- Cover local branch tracking, reflog, merge-base, branch-only commits, changed files, and related PR lookup.

## Validation
- git diff --check HEAD~1..HEAD

## Integration Notes
- Docs-only change.
- No runtime, schema, environment, or deployment behavior changes.
- Vercel contexts not checked for this draft docs PR.