### PR TITLE
feat: scope agent governance audit exports

### DIFF
--- a/app/api/admin/agents/governance/export/route.test.ts
+++ b/app/api/admin/agents/governance/export/route.test.ts
@@ -4,6 +4,8 @@ const mocks = vi.hoisted(() => ({
   verifyAdmin: vi.fn(),
   isAuthError: vi.fn(),
   buildAgentMissionControlSnapshot: vi.fn(),
+  parseAgentGovernanceExportScope: vi.fn(),
+  buildScopedAgentGovernanceSnapshot: vi.fn(),
 }))
 
 vi.mock('@/lib/auth-server', () => ({
@@ -13,6 +15,11 @@ vi.mock('@/lib/auth-server', () => ({
 
 vi.mock('@/lib/agent-mission-control', () => ({
   buildAgentMissionControlSnapshot: mocks.buildAgentMissionControlSnapshot,
+}))
+
+vi.mock('@/lib/agent-governance-scope', () => ({
+  parseAgentGovernanceExportScope: mocks.parseAgentGovernanceExportScope,
+  buildScopedAgentGovernanceSnapshot: mocks.buildScopedAgentGovernanceSnapshot,
 }))
 
 import { GET } from './route'
@@ -72,6 +79,15 @@ describe('GET /api/admin/agents/governance/export', () => {
     mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
     mocks.isAuthError.mockReturnValue(false)
     mocks.buildAgentMissionControlSnapshot.mockResolvedValue({ governance })
+    mocks.parseAgentGovernanceExportScope.mockReturnValue({
+      scope: {},
+      has_scope: false,
+      errors: [],
+    })
+    mocks.buildScopedAgentGovernanceSnapshot.mockResolvedValue({
+      governance,
+      scope: {},
+    })
   })
 
   it('requires admin auth', async () => {
@@ -94,6 +110,7 @@ describe('GET /api/admin/agents/governance/export', () => {
     expect(body.ok).toBe(true)
     expect(body.export.classification).toBe('client_safe')
     expect(body.export.capability_inventory[0].agent).toBe('Shaka (Zulu) - Chief of Staff')
+    expect(body.export.scope.description).toBe('Current governance snapshot.')
   })
 
   it('returns markdown when requested', async () => {
@@ -105,5 +122,61 @@ describe('GET /api/admin/agents/governance/export', () => {
     expect(response.headers.get('Content-Disposition')).toMatch(/agent-governance-audit-\d{4}-\d{2}-\d{2}\.md/)
     expect(text).toContain('# Agentic Operating System Governance Audit')
     expect(text).toContain('## Audit Boundaries')
+  })
+
+  it('returns a scoped export when filters are provided', async () => {
+    mocks.parseAgentGovernanceExportScope.mockReturnValue({
+      scope: {
+        run_id: 'run-123',
+        client_project_id: 'client-456',
+        from: '2026-05-01T00:00:00.000Z',
+        to: '2026-05-21T23:59:59.999Z',
+      },
+      has_scope: true,
+      errors: [],
+    })
+    mocks.buildScopedAgentGovernanceSnapshot.mockResolvedValue({
+      governance,
+      scope: {
+        run_id: 'run-123',
+        client_project_id: 'client-456',
+        from: '2026-05-01T00:00:00.000Z',
+        to: '2026-05-21T23:59:59.999Z',
+        matching_run_count: 1,
+      },
+    })
+
+    const response = await GET(request('json') as never)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.export.scope).toMatchObject({
+      description: 'Scoped governance export.',
+      run_id: 'run-123',
+      client_project_id: 'client-456',
+      matching_run_count: 1,
+    })
+    expect(mocks.buildScopedAgentGovernanceSnapshot).toHaveBeenCalledWith({
+      run_id: 'run-123',
+      client_project_id: 'client-456',
+      from: '2026-05-01T00:00:00.000Z',
+      to: '2026-05-21T23:59:59.999Z',
+    })
+    expect(mocks.buildAgentMissionControlSnapshot).not.toHaveBeenCalled()
+  })
+
+  it('returns validation errors for invalid scope filters', async () => {
+    mocks.parseAgentGovernanceExportScope.mockReturnValue({
+      scope: {},
+      has_scope: false,
+      errors: ['from must be before or equal to to'],
+    })
+
+    const response = await GET(request() as never)
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'from must be before or equal to to' })
+    expect(mocks.buildAgentMissionControlSnapshot).not.toHaveBeenCalled()
+    expect(mocks.buildScopedAgentGovernanceSnapshot).not.toHaveBeenCalled()
   })
 })

--- a/app/api/admin/agents/governance/export/route.ts
+++ b/app/api/admin/agents/governance/export/route.ts
@@ -5,6 +5,7 @@ import {
   buildAgentGovernanceClientExport,
   formatAgentGovernanceClientMarkdown,
 } from '@/lib/agent-governance-export'
+import { buildScopedAgentGovernanceSnapshot, parseAgentGovernanceExportScope } from '@/lib/agent-governance-scope'
 
 export const dynamic = 'force-dynamic'
 
@@ -21,8 +22,16 @@ export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url)
     const format = searchParams.get('format') === 'markdown' ? 'markdown' : 'json'
-    const snapshot = await buildAgentMissionControlSnapshot()
-    const clientExport = buildAgentGovernanceClientExport(snapshot.governance)
+    const parsedScope = parseAgentGovernanceExportScope(searchParams)
+    if (parsedScope.errors.length > 0) {
+      return NextResponse.json({ error: parsedScope.errors.join('; ') }, { status: 400 })
+    }
+
+    const scoped = parsedScope.has_scope
+      ? await buildScopedAgentGovernanceSnapshot(parsedScope.scope)
+      : null
+    const governance = scoped?.governance ?? (await buildAgentMissionControlSnapshot()).governance
+    const clientExport = buildAgentGovernanceClientExport(governance, scoped?.scope ?? parsedScope.scope)
 
     if (format === 'markdown') {
       return new NextResponse(formatAgentGovernanceClientMarkdown(clientExport), {

--- a/docs/agentic-operating-system-governance.md
+++ b/docs/agentic-operating-system-governance.md
@@ -188,3 +188,10 @@ Phase 5 has a v1 implementation:
 - `docs/agentic-os-client-advisory-explainer.md` provides the first advisory/sales framing for client conversations.
 
 The next refinement is to add scoped exports by run, client project, or date range after operators review the v1 report against real governance traces.
+
+Scoped exports are now the next implementation slice:
+
+- `runId` or `run_id` should restrict delegation and authority evidence to one trace. The value must be an Agent Ops run UUID.
+- `clientProjectId` or `client_project_id` should restrict evidence to matching Agent Ops runs.
+- `from`/`to` should restrict evidence by ISO timestamp or `YYYY-MM-DD` date.
+- Capability inventory remains visible because it describes the operating system boundary; trace and authority evidence are the scoped parts.

--- a/docs/agentic-os-client-advisory-explainer.md
+++ b/docs/agentic-os-client-advisory-explainer.md
@@ -21,6 +21,14 @@ The governance export is designed for review, not raw discovery. It includes sco
 
 It excludes raw prompts, private run logs, secrets, credentials, private reasoning, private source material, and sensitive records. Operators can use the trace references to inspect full evidence inside Portfolio Admin when they have the right permission.
 
+Exports can be scoped with query parameters when a client or internal reviewer only needs one slice of evidence:
+
+- `runId` for one Agent Ops trace. Use the Agent Ops run UUID.
+- `clientProjectId` for one client/project lane.
+- `from` and `to` for a date window.
+
+The scope filters affect delegation and authority evidence. The capability inventory remains included so the reviewer can see the governing role boundaries behind the filtered trace.
+
 ## Advisory Talk Track
 
 Most organizations do not need more automation first. They need a way to know what the automation is allowed to do.

--- a/lib/agent-governance-export.test.ts
+++ b/lib/agent-governance-export.test.ts
@@ -83,6 +83,7 @@ describe('agent governance client export', () => {
     const clientExport = buildAgentGovernanceClientExport(governance)
 
     expect(clientExport.classification).toBe('client_safe')
+    expect(clientExport.scope.description).toBe('Current governance snapshot.')
     expect(clientExport.summary.pending_authority_approvals).toBe(1)
     expect(clientExport.capability_inventory[1]).toMatchObject({
       agent: 'Yaa Asantewaa (Ashanti) - Automation Systems',
@@ -100,9 +101,32 @@ describe('agent governance client export', () => {
     const markdown = formatAgentGovernanceClientMarkdown(buildAgentGovernanceClientExport(governance))
 
     expect(markdown).toContain('# Agentic Operating System Governance Audit')
+    expect(markdown).toContain('## Export Scope')
+    expect(markdown).toContain('- Run ID: All visible governance runs')
     expect(markdown).toContain('## Capability Inventory')
     expect(markdown).toContain('| Yaa Asantewaa (Ashanti) - Automation Systems | active | n8n | yellow | approval_required | known_workflow |')
     expect(markdown).toContain('| run-delegation | Yaa Asantewaa (Ashanti) - Automation Systems | payment | payment_spend | 90% |')
     expect(markdown).toContain('Payment and paid-job actions are represented as approval gates')
+  })
+
+  it('includes run, client, and date scope in exports', () => {
+    const clientExport = buildAgentGovernanceClientExport(governance, {
+      run_id: 'run-delegation',
+      client_project_id: 'client-123',
+      from: '2026-05-01T00:00:00.000Z',
+      to: '2026-05-21T23:59:59.999Z',
+      matching_run_count: 1,
+    })
+    const markdown = formatAgentGovernanceClientMarkdown(clientExport)
+
+    expect(clientExport.scope).toMatchObject({
+      description: 'Scoped governance export.',
+      run_id: 'run-delegation',
+      client_project_id: 'client-123',
+      matching_run_count: 1,
+    })
+    expect(markdown).toContain('- Run ID: run-delegation')
+    expect(markdown).toContain('- Client project ID: client-123')
+    expect(markdown).toContain('- Matching runs: 1')
   })
 })

--- a/lib/agent-governance-export.ts
+++ b/lib/agent-governance-export.ts
@@ -1,10 +1,14 @@
 import type { AgentGovernanceSnapshot } from '@/lib/agent-governance'
+import type { AgentGovernanceExportScope } from '@/lib/agent-governance-scope'
 
 export type AgentGovernanceClientExport = {
   export_type: 'agent_governance_client_audit'
   generated_at: string
   classification: 'client_safe'
   title: string
+  scope: AgentGovernanceExportScope & {
+    description: string
+  }
   summary: {
     total_agents: number
     reviewed_agents: number
@@ -69,12 +73,18 @@ function percent(value: number) {
 
 export function buildAgentGovernanceClientExport(
   governance: AgentGovernanceSnapshot,
+  scope: AgentGovernanceExportScope = {},
 ): AgentGovernanceClientExport {
+  const scoped = Boolean(scope.run_id || scope.client_project_id || scope.from || scope.to)
   return {
     export_type: 'agent_governance_client_audit',
     generated_at: new Date().toISOString(),
     classification: 'client_safe',
     title: 'Agentic Operating System Governance Audit',
+    scope: {
+      ...scope,
+      description: scoped ? 'Scoped governance export.' : 'Current governance snapshot.',
+    },
     summary: governance.summary,
     client_positioning: {
       headline: 'Governed agents, not unchecked automation.',
@@ -162,6 +172,15 @@ export function formatAgentGovernanceClientMarkdown(clientExport: AgentGovernanc
     clientExport.client_positioning.headline,
     '',
     list(clientExport.client_positioning.proof_points),
+    '',
+    '## Export Scope',
+    '',
+    `- Scope: ${clientExport.scope.description}`,
+    `- Run ID: ${clientExport.scope.run_id ?? 'All visible governance runs'}`,
+    `- Client project ID: ${clientExport.scope.client_project_id ?? 'All visible client projects'}`,
+    `- From: ${clientExport.scope.from ?? 'No lower bound'}`,
+    `- To: ${clientExport.scope.to ?? 'No upper bound'}`,
+    `- Matching runs: ${clientExport.scope.matching_run_count ?? 'Not scoped by run set'}`,
     '',
     '## Governance Snapshot',
     '',

--- a/lib/agent-governance-scope.test.ts
+++ b/lib/agent-governance-scope.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { parseAgentGovernanceExportScope } from './agent-governance-scope'
+
+describe('agent governance export scope parsing', () => {
+  it('accepts run, client project, and date filters', () => {
+    const result = parseAgentGovernanceExportScope(new URLSearchParams({
+      runId: '11111111-1111-4111-8111-111111111111',
+      clientProjectId: 'client-456',
+      from: '2026-05-01',
+      to: '2026-05-21',
+    }))
+
+    expect(result.errors).toEqual([])
+    expect(result.has_scope).toBe(true)
+    expect(result.scope).toMatchObject({
+      run_id: '11111111-1111-4111-8111-111111111111',
+      client_project_id: 'client-456',
+      from: '2026-05-01T00:00:00.000Z',
+      to: '2026-05-21T23:59:59.999Z',
+    })
+  })
+
+  it('accepts snake-case aliases', () => {
+    const result = parseAgentGovernanceExportScope(new URLSearchParams({
+      run_id: '22222222-2222-4222-8222-222222222222',
+      client_project_id: 'client-snake',
+    }))
+
+    expect(result.errors).toEqual([])
+    expect(result.scope.run_id).toBe('22222222-2222-4222-8222-222222222222')
+    expect(result.scope.client_project_id).toBe('client-snake')
+  })
+
+  it('rejects invalid date windows and run IDs', () => {
+    const invalidDate = parseAgentGovernanceExportScope(new URLSearchParams({ from: 'not-a-date' }))
+    const invertedRange = parseAgentGovernanceExportScope(new URLSearchParams({
+      from: '2026-05-22',
+      to: '2026-05-21',
+    }))
+    const invalidRunId = parseAgentGovernanceExportScope(new URLSearchParams({ runId: 'run-123' }))
+
+    expect(invalidDate.errors[0]).toContain('from must be an ISO date')
+    expect(invertedRange.errors).toContain('from must be before or equal to to')
+    expect(invalidRunId.errors).toContain('runId must be a UUID')
+  })
+})

--- a/lib/agent-governance-scope.ts
+++ b/lib/agent-governance-scope.ts
@@ -1,0 +1,181 @@
+import { buildAgentGovernanceSnapshot, type AgentGovernanceSnapshot } from '@/lib/agent-governance'
+
+export type AgentGovernanceExportScope = {
+  run_id?: string
+  client_project_id?: string
+  from?: string
+  to?: string
+  matching_run_count?: number
+}
+
+type ScopedRunRow = {
+  id: string
+  subject_id: string | null
+  subject_label: string | null
+  started_at: string
+  metadata: Record<string, unknown> | null
+}
+
+type ScopedApprovalRow = {
+  run_id: string
+  approval_type: string
+  status: string
+  requested_at: string
+}
+
+type ScopedEventRow = {
+  run_id: string
+  event_type: string
+  severity: string
+  message: string | null
+  occurred_at: string
+  metadata: Record<string, unknown> | null
+}
+
+const CLIENT_PROJECT_METADATA_KEYS = [
+  'client_project_id',
+  'clientProjectId',
+  'project_id',
+  'projectId',
+  'client_id',
+  'clientId',
+]
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+function queryValue(searchParams: URLSearchParams, ...keys: string[]) {
+  for (const key of keys) {
+    const value = searchParams.get(key)?.trim()
+    if (value) return value
+  }
+  return undefined
+}
+
+function normalizeDate(value: string | undefined, key: 'from' | 'to', errors: string[]) {
+  if (!value) return undefined
+  const dateOnly = /^\d{4}-\d{2}-\d{2}$/.test(value)
+  const normalized = dateOnly && key === 'from'
+    ? `${value}T00:00:00.000Z`
+    : dateOnly && key === 'to'
+      ? `${value}T23:59:59.999Z`
+      : value
+  const date = new Date(normalized)
+  if (Number.isNaN(date.getTime())) {
+    errors.push(`${key} must be an ISO date or YYYY-MM-DD value`)
+    return undefined
+  }
+  return date.toISOString()
+}
+
+export function parseAgentGovernanceExportScope(searchParams: URLSearchParams) {
+  const errors: string[] = []
+  const runId = queryValue(searchParams, 'runId', 'run_id')
+  const from = normalizeDate(queryValue(searchParams, 'from', 'start'), 'from', errors)
+  const to = normalizeDate(queryValue(searchParams, 'to', 'end'), 'to', errors)
+
+  if (from && to && new Date(from).getTime() > new Date(to).getTime()) {
+    errors.push('from must be before or equal to to')
+  }
+  if (runId && !UUID_PATTERN.test(runId)) {
+    errors.push('runId must be a UUID')
+  }
+
+  const scope: AgentGovernanceExportScope = {
+    run_id: runId,
+    client_project_id: queryValue(searchParams, 'clientProjectId', 'client_project_id'),
+    from,
+    to,
+  }
+  const has_scope = Boolean(scope.run_id || scope.client_project_id || scope.from || scope.to)
+
+  return { scope, has_scope, errors }
+}
+
+function metadataValue(metadata: Record<string, unknown> | null, keys: string[]) {
+  for (const key of keys) {
+    const value = metadata?.[key]
+    if (typeof value === 'string' || typeof value === 'number') return String(value)
+  }
+  return undefined
+}
+
+function matchesClientProject(run: ScopedRunRow, clientProjectId: string) {
+  const expected = clientProjectId.toLowerCase()
+  return [
+    run.subject_id,
+    run.subject_label,
+    metadataValue(run.metadata, CLIENT_PROJECT_METADATA_KEYS),
+  ].some((value) => String(value ?? '').toLowerCase() === expected)
+}
+
+function applyDateRange<T extends { gte: (column: string, value: string) => T; lte: (column: string, value: string) => T }>(
+  query: T,
+  column: string,
+  scope: AgentGovernanceExportScope,
+) {
+  let next = query
+  if (scope.from) next = next.gte(column, scope.from)
+  if (scope.to) next = next.lte(column, scope.to)
+  return next
+}
+
+export async function buildScopedAgentGovernanceSnapshot(
+  scope: AgentGovernanceExportScope,
+): Promise<{ governance: AgentGovernanceSnapshot; scope: AgentGovernanceExportScope }> {
+  const { supabaseAdmin } = await import('@/lib/supabase')
+  let runsQuery = supabaseAdmin
+    .from('agent_runs')
+    .select('id, subject_id, subject_label, started_at, metadata')
+    .order('started_at', { ascending: false })
+    .limit(250)
+
+  if (scope.run_id) runsQuery = runsQuery.eq('id', scope.run_id)
+  runsQuery = applyDateRange(runsQuery, 'started_at', scope)
+
+  const runsRes = await runsQuery
+  if (runsRes.error) throw new Error(runsRes.error.message)
+
+  const runs = ((runsRes.data ?? []) as ScopedRunRow[])
+    .filter((run) => !scope.client_project_id || matchesClientProject(run, scope.client_project_id))
+  const runIds = runs.map((run) => run.id)
+  const shouldQueryScopedRuns = Boolean(scope.run_id || scope.client_project_id)
+
+  let approvals: ScopedApprovalRow[] = []
+  let events: ScopedEventRow[] = []
+
+  if (!shouldQueryScopedRuns || runIds.length > 0) {
+    let approvalsQuery = supabaseAdmin
+      .from('agent_approvals')
+      .select('run_id, approval_type, status, requested_at')
+      .eq('status', 'pending')
+      .order('requested_at', { ascending: false })
+      .limit(50)
+    let eventsQuery = supabaseAdmin
+      .from('agent_run_events')
+      .select('run_id, event_type, severity, message, occurred_at, metadata')
+      .eq('event_type', 'delegation_decision_recorded')
+      .order('occurred_at', { ascending: false })
+      .limit(50)
+
+    if (runIds.length > 0) {
+      approvalsQuery = approvalsQuery.in('run_id', runIds)
+      eventsQuery = eventsQuery.in('run_id', runIds)
+    }
+
+    approvalsQuery = applyDateRange(approvalsQuery, 'requested_at', scope)
+    eventsQuery = applyDateRange(eventsQuery, 'occurred_at', scope)
+
+    const [approvalsRes, eventsRes] = await Promise.all([approvalsQuery, eventsQuery])
+    if (approvalsRes.error) throw new Error(approvalsRes.error.message)
+    if (eventsRes.error) throw new Error(eventsRes.error.message)
+    approvals = (approvalsRes.data ?? []) as ScopedApprovalRow[]
+    events = (eventsRes.data ?? []) as ScopedEventRow[]
+  }
+
+  return {
+    governance: buildAgentGovernanceSnapshot({ approvals, events }),
+    scope: {
+      ...scope,
+      matching_run_count: runIds.length,
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- Adds scoped Agent Governance audit exports for `runId`/`run_id`, `clientProjectId`/`client_project_id`, and `from`/`to` query filters.
- Keeps the capability inventory visible as the operating boundary while restricting delegation and authority evidence to the requested run/client/date slice.
- Adds validation so malformed run IDs and inverted date windows return `400` instead of surfacing database errors.
- Updates the governance and client advisory docs with the scoped export contract.

## Validation
- `npm test -- --run lib/agent-governance-export.test.ts lib/agent-governance-scope.test.ts app/api/admin/agents/governance/export/route.test.ts lib/agent-governance.test.ts app/admin/agents/page.test.tsx app/api/admin/agents/mission-control/route.test.ts`
- `npm run build:knowledge && npx tsc --noEmit`
- `npm run build`
- Authenticated local smoke against `http://127.0.0.1:3013` with `MOCK_N8N=true N8N_DISABLE_OUTBOUND=true`: scoped JSON export, scoped Markdown export, inverted date `400`, malformed runId `400`, and no `selected_agent_key` leakage in export bodies.
- `git diff --check`

## Integration Notes
- Worktree: `/Users/vambahsillah/Projects/Portfolio.worktrees/agent-governance-scoped-export`
- Branch: `codex/agent-governance-scoped-export`
- Conflict preflight: root checkout was clean on `main...origin/main`; no open PRs were present at worktree creation.
- Environment bootstrap: `.env.local` and `.vercel` linked from Portfolio; `.env.staging` was not present in the source checkout.
- Build emitted the existing env warning that outbound n8n webhooks are enabled when `MOCK_N8N=false` and `N8N_DISABLE_OUTBOUND=false`; no n8n trigger was run, and the local smoke used both guards.
- Vercel contexts were not checked on this draft PR. Integration captain should verify `Vercel – portfolio` and `Vercel – portfolio-staging` before merge.