### PR TITLE
feat: add scoped governance export links

### DIFF
--- a/app/admin/agents/page.test.tsx
+++ b/app/admin/agents/page.test.tsx
@@ -474,6 +474,8 @@ describe('AgentOperationsPage mission control landing', () => {
     expect(within(governancePanel).getByText(/1 pending authority checkpoint/i)).toBeInTheDocument()
     expect(within(governancePanel).getByRole('link', { name: /Export client audit/i })).toHaveAttribute('href', '/api/admin/agents/governance/export?format=markdown')
     expect(within(governancePanel).getByRole('link', { name: /Export audit JSON/i })).toHaveAttribute('href', '/api/admin/agents/governance/export?format=json')
+    expect(within(governancePanel).getByRole('link', { name: /Export latest trace/i })).toHaveAttribute('href', '/api/admin/agents/governance/export?format=markdown&runId=delegation-run')
+    expect(within(governancePanel).getByRole('link', { name: /Export authority trace/i })).toHaveAttribute('href', '/api/admin/agents/governance/export?format=markdown&runId=payment-run')
     expect(screen.getByRole('link', { name: /Active runs/i })).toHaveAttribute('href', '/admin/agents/runs?active=true')
     expect(screen.getByRole('link', { name: /Failed or stale runs/i })).toHaveAttribute('href', '/admin/agents/runs?status=needs_review')
     expect(screen.getByRole('link', { name: /Pending approvals/i })).toHaveAttribute('href', '/admin/agents/coordination')

--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -1913,6 +1913,7 @@ function AgentGovernancePanel({ governance }: { governance: MissionSnapshot['gov
   const profiles = governance.capability_profiles.slice(0, 4)
   const latestDelegation = governance.recent_delegation_decisions[0]
   const latestPaymentAction = governance.payment_authority_actions[0]
+  const pendingAuthority = governance.pending_authority_approvals[0]
   const statusTone = governance.summary.pending_authority_approvals > 0
     ? 'yellow'
     : governance.summary.least_privilege_attention > 0
@@ -1953,6 +1954,24 @@ function AgentGovernancePanel({ governance }: { governance: MissionSnapshot['gov
           <ShieldCheck size={15} />
           Export audit JSON
         </Link>
+        {latestDelegation ? (
+          <Link
+            href={governanceExportHref('markdown', { runId: latestDelegation.run_id })}
+            className="inline-flex items-center gap-2 rounded-md border border-sky-400/40 bg-sky-500/10 px-3 py-2 text-sm font-medium text-sky-100 hover:border-sky-300/70"
+          >
+            <ClipboardList size={15} />
+            Export latest trace
+          </Link>
+        ) : null}
+        {pendingAuthority ? (
+          <Link
+            href={governanceExportHref('markdown', { runId: pendingAuthority.run_id })}
+            className="inline-flex items-center gap-2 rounded-md border border-yellow-400/40 bg-yellow-500/10 px-3 py-2 text-sm font-medium text-yellow-100 hover:border-yellow-300/70"
+          >
+            <ShieldCheck size={15} />
+            Export authority trace
+          </Link>
+        ) : null}
       </div>
 
       <div className="mt-4 grid grid-cols-2 gap-2 lg:grid-cols-4">
@@ -2002,7 +2021,7 @@ function AgentGovernancePanel({ governance }: { governance: MissionSnapshot['gov
           </Link>
 
           <Link
-            href={governance.pending_authority_approvals[0]?.run_id ? `/admin/agents/runs/${governance.pending_authority_approvals[0].run_id}` : '/admin/agents/coordination'}
+            href={pendingAuthority?.run_id ? `/admin/agents/runs/${pendingAuthority.run_id}` : '/admin/agents/coordination'}
             className="block rounded-lg border border-silicon-slate/60 bg-background/40 p-3 hover:border-radiant-gold/50"
           >
             <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Payment authority</p>
@@ -2019,6 +2038,16 @@ function AgentGovernancePanel({ governance }: { governance: MissionSnapshot['gov
       </div>
     </section>
   )
+}
+
+function governanceExportHref(
+  format: 'json' | 'markdown',
+  scope: { runId?: string; clientProjectId?: string } = {},
+) {
+  const params = new URLSearchParams({ format })
+  if (scope.runId) params.set('runId', scope.runId)
+  if (scope.clientProjectId) params.set('clientProjectId', scope.clientProjectId)
+  return `/api/admin/agents/governance/export?${params.toString()}`
 }
 
 function BriefRouteCard({

--- a/app/admin/agents/runs/[runId]/page.test.tsx
+++ b/app/admin/agents/runs/[runId]/page.test.tsx
@@ -23,6 +23,9 @@ const runDetail = {
     agent_key: 'chief-of-staff',
     runtime: 'codex',
     status: 'waiting_for_approval',
+    subject_type: 'client_project',
+    subject_id: 'client-123',
+    subject_label: 'Client 123',
   },
   steps: [
     {
@@ -197,6 +200,8 @@ describe('AgentRunDetailPage scoped Shaka context', () => {
 
     expect(await screen.findByRole('heading', { name: 'Approval notification trace' })).toBeInTheDocument()
     expect(screen.getAllByRole('img', { name: /Illustrated avatar for Shaka/i }).length).toBeGreaterThan(0)
+    expect(screen.getByRole('link', { name: 'Export run audit' })).toHaveAttribute('href', '/api/admin/agents/governance/export?format=markdown&runId=run-1&clientProjectId=client-123')
+    expect(screen.getByRole('link', { name: 'Export JSON' })).toHaveAttribute('href', '/api/admin/agents/governance/export?format=json&runId=run-1&clientProjectId=client-123')
     fireEvent.click(screen.getByRole('button', { name: 'Ask Shaka about this run' }))
 
     expect(await screen.findByText('Shaka context answer')).toBeInTheDocument()

--- a/app/admin/agents/runs/[runId]/page.tsx
+++ b/app/admin/agents/runs/[runId]/page.tsx
@@ -275,6 +275,20 @@ function AgentRunDetailContent({ runId }: { runId: string }) {
                   <MessageSquare size={16} />
                   {shakaLoading === `run:${runId}` ? 'Asking...' : 'Ask Shaka'}
                 </button>
+                <Link
+                  href={runGovernanceExportHref('markdown', runId, data.run)}
+                  className="agent-ops-button-secondary"
+                >
+                  <FileText size={16} />
+                  Export run audit
+                </Link>
+                <Link
+                  href={runGovernanceExportHref('json', runId, data.run)}
+                  className="agent-ops-button-muted"
+                >
+                  <ShieldAlert size={16} />
+                  Export JSON
+                </Link>
                 <button
                   onClick={evaluateRun}
                   disabled={evaluating}
@@ -397,6 +411,29 @@ function AgentRunDetailContent({ runId }: { runId: string }) {
       </div>
     </div>
   )
+}
+
+function runGovernanceExportHref(format: 'json' | 'markdown', runId: string, run: AnyRow) {
+  const params = new URLSearchParams({ format, runId })
+  const clientProjectId = clientProjectIdForRun(run)
+  if (clientProjectId) params.set('clientProjectId', clientProjectId)
+  return `/api/admin/agents/governance/export?${params.toString()}`
+}
+
+function clientProjectIdForRun(run: AnyRow) {
+  if (asString(run.subject_type) === 'client_project') {
+    const subjectId = asString(run.subject_id)
+    if (subjectId) return subjectId
+  }
+
+  const metadata = typeof run.metadata === 'object' && run.metadata !== null
+    ? run.metadata as Record<string, unknown>
+    : null
+  return asString(metadata?.clientProjectId)
+    ?? asString(metadata?.client_project_id)
+    ?? asString(metadata?.projectId)
+    ?? asString(metadata?.project_id)
+    ?? null
 }
 
 function Metric({ icon, label, value }: { icon: ReactNode; label: string; value: string }) {


### PR DESCRIPTION
## Summary
- Adds Mission Control Agent Governance links for exporting the latest delegation trace and pending authority trace with scoped `runId` parameters.
- Adds Run Console detail header actions for scoped Markdown and JSON governance exports.
- Carries `clientProjectId` into run-detail export links when the run is tied to a client project or matching metadata key.

## Validation
- `npm test -- --run app/admin/agents/page.test.tsx app/admin/agents/runs/[runId]/page.test.tsx`
- `npm run build:knowledge && npx tsc --noEmit`
- `npm run build`
- Authenticated local UI smoke against `http://127.0.0.1:3015` with `MOCK_N8N=true N8N_DISABLE_OUTBOUND=true`: Mission Control global export links, optional latest-trace scoped link handling, and a real Run Console detail scoped Markdown/JSON export link using live run UUID `eade25e1-dadb-4ca7-be0b-2ac099e343e1`.
- `git diff --check`

## Integration Notes
- Worktree: `/Users/vambahsillah/Projects/Portfolio.worktrees/scoped-governance-export-ui`
- Branch: `codex/scoped-governance-export-ui`
- Preflight: PR #340 was merged; both `portfolio` and `portfolio-staging` production deployments were manually verified READY on merge commit `686a8318bcfade4d667e93ca2b111521e0d29b91`; no open PRs were present before this phase started.
- Environment bootstrap: `.env.local` and `.vercel` linked from Portfolio; `.env.staging` was not present in the source checkout.
- Build emitted the existing n8n outbound warning for unguarded environments; local smoke used `MOCK_N8N=true` and `N8N_DISABLE_OUTBOUND=true`.
- Vercel contexts for this PR have not been merge-gate verified yet. Integration captain should verify `Vercel – portfolio` and `Vercel – portfolio-staging` before merge.