### PR TITLE
feat: audit scoped governance exports

### DIFF
--- a/app/api/admin/agents/governance/export/route.test.ts
+++ b/app/api/admin/agents/governance/export/route.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   buildAgentMissionControlSnapshot: vi.fn(),
   parseAgentGovernanceExportScope: vi.fn(),
   buildScopedAgentGovernanceSnapshot: vi.fn(),
+  recordAgentEvent: vi.fn(),
 }))
 
 vi.mock('@/lib/auth-server', () => ({
@@ -20,6 +21,10 @@ vi.mock('@/lib/agent-mission-control', () => ({
 vi.mock('@/lib/agent-governance-scope', () => ({
   parseAgentGovernanceExportScope: mocks.parseAgentGovernanceExportScope,
   buildScopedAgentGovernanceSnapshot: mocks.buildScopedAgentGovernanceSnapshot,
+}))
+
+vi.mock('@/lib/agent-run', () => ({
+  recordAgentEvent: mocks.recordAgentEvent,
 }))
 
 import { GET } from './route'
@@ -111,6 +116,7 @@ describe('GET /api/admin/agents/governance/export', () => {
     expect(body.export.classification).toBe('client_safe')
     expect(body.export.capability_inventory[0].agent).toBe('Shaka (Zulu) - Chief of Staff')
     expect(body.export.scope.description).toBe('Current governance snapshot.')
+    expect(mocks.recordAgentEvent).not.toHaveBeenCalled()
   })
 
   it('returns markdown when requested', async () => {
@@ -162,7 +168,47 @@ describe('GET /api/admin/agents/governance/export', () => {
       from: '2026-05-01T00:00:00.000Z',
       to: '2026-05-21T23:59:59.999Z',
     })
+    expect(mocks.recordAgentEvent).toHaveBeenCalledWith(expect.objectContaining({
+      runId: 'run-123',
+      eventType: 'agent_governance_exported',
+      severity: 'info',
+      message: 'Agent governance json export generated.',
+      metadata: expect.objectContaining({
+        export_type: 'agent_governance_client_audit',
+        classification: 'client_safe',
+        format: 'json',
+        requested_by_user_id: 'admin-user',
+        scope: expect.objectContaining({
+          run_id: 'run-123',
+          client_project_id: 'client-456',
+          matching_run_count: 1,
+          description: 'Scoped governance export.',
+        }),
+      }),
+    }))
     expect(mocks.buildAgentMissionControlSnapshot).not.toHaveBeenCalled()
+  })
+
+  it('does not record an export event when the scoped run does not exist', async () => {
+    mocks.parseAgentGovernanceExportScope.mockReturnValue({
+      scope: {
+        run_id: 'run-missing',
+      },
+      has_scope: true,
+      errors: [],
+    })
+    mocks.buildScopedAgentGovernanceSnapshot.mockResolvedValue({
+      governance,
+      scope: {
+        run_id: 'run-missing',
+        matching_run_count: 0,
+      },
+    })
+
+    const response = await GET(request('markdown') as never)
+
+    expect(response.status).toBe(200)
+    expect(mocks.recordAgentEvent).not.toHaveBeenCalled()
   })
 
   it('returns validation errors for invalid scope filters', async () => {

--- a/app/api/admin/agents/governance/export/route.ts
+++ b/app/api/admin/agents/governance/export/route.ts
@@ -6,11 +6,38 @@ import {
   formatAgentGovernanceClientMarkdown,
 } from '@/lib/agent-governance-export'
 import { buildScopedAgentGovernanceSnapshot, parseAgentGovernanceExportScope } from '@/lib/agent-governance-scope'
+import { recordAgentEvent } from '@/lib/agent-run'
 
 export const dynamic = 'force-dynamic'
 
 function exportFilename(extension: 'json' | 'md') {
   return `agent-governance-audit-${new Date().toISOString().slice(0, 10)}.${extension}`
+}
+
+async function recordGovernanceExportEvent(input: {
+  runId?: string
+  matchingRunCount?: number
+  format: 'json' | 'markdown'
+  userId: string
+  scope: Record<string, unknown>
+  generatedAt: string
+}) {
+  if (!input.runId || !input.matchingRunCount) return
+
+  await recordAgentEvent({
+    runId: input.runId,
+    eventType: 'agent_governance_exported',
+    severity: 'info',
+    message: `Agent governance ${input.format} export generated.`,
+    metadata: {
+      export_type: 'agent_governance_client_audit',
+      classification: 'client_safe',
+      format: input.format,
+      scope: input.scope,
+      generated_at: input.generatedAt,
+      requested_by_user_id: input.userId,
+    },
+  })
 }
 
 export async function GET(request: NextRequest) {
@@ -32,6 +59,15 @@ export async function GET(request: NextRequest) {
       : null
     const governance = scoped?.governance ?? (await buildAgentMissionControlSnapshot()).governance
     const clientExport = buildAgentGovernanceClientExport(governance, scoped?.scope ?? parsedScope.scope)
+
+    await recordGovernanceExportEvent({
+      runId: scoped?.scope.run_id,
+      matchingRunCount: scoped?.scope.matching_run_count,
+      format,
+      userId: auth.user.id,
+      scope: clientExport.scope,
+      generatedAt: clientExport.generated_at,
+    })
 
     if (format === 'markdown') {
       return new NextResponse(formatAgentGovernanceClientMarkdown(clientExport), {


### PR DESCRIPTION
## Summary
- Records `agent_governance_exported` run events when a governance export is scoped to a matched `runId`.
- Includes client-safe export metadata: format, scope, generated timestamp, classification, and requesting admin user ID.
- Preserves existing behavior for unscoped exports and valid UUID scopes that match no run by avoiding audit inserts when no run exists.

## Validation
- `npm test -- --run app/api/admin/agents/governance/export/route.test.ts lib/agent-governance-export.test.ts lib/agent-governance-scope.test.ts`
- `npm run build:knowledge && npx tsc --noEmit`
- `npm run build`
- Authenticated local no-write route smoke against `http://127.0.0.1:3017` with `MOCK_N8N=true N8N_DISABLE_OUTBOUND=true`: valid UUID-shaped missing `runId` returned a scoped export with `matching_run_count: 0` and no raw `selected_agent_key` leakage.
- `git diff --check`

## Integration Notes
- Worktree: `/Users/vambahsillah/Projects/Portfolio.worktrees/governance-export-audit-events`
- Branch: `codex/governance-export-audit-events`
- Preflight: PR #342 was merged and both required Vercel contexts passed on merge commit `9354ac3377198f5c39774287c527624b83014268`; root checkout was clean and no open PRs were present before this phase started.
- This v1 audit path only records run-scoped exports because `agent_run_events.run_id` is non-null. Global/unscoped export auditing should use a future global audit table or generated export-run envelope.
- Environment bootstrap: `.env.local` and `.vercel` linked from Portfolio; `.env.staging` was not present in the source checkout.
- Build emitted the existing n8n outbound warning for unguarded environments; local smoke used `MOCK_N8N=true` and `N8N_DISABLE_OUTBOUND=true`.
- Vercel contexts for this PR have not been merge-gate verified yet. Integration captain should verify `Vercel – portfolio` and `Vercel – portfolio-staging` before merge.