### PR TITLE
Fix Open Brain producer gate metric

### DIFF
--- a/app/admin/agents/open-brain/page.test.tsx
+++ b/app/admin/agents/open-brain/page.test.tsx
@@ -174,6 +174,7 @@ describe('OpenBrainPage', () => {
     expect(within(metrics).getByText('Producer gates')).toBeInTheDocument()
     expect(within(metrics).getByText('Runtime parity')).toBeInTheDocument()
     expect(within(metrics).getAllByText('1/2')).toHaveLength(2)
+    expect(within(metrics).getByRole('button', { name: 'Open producer gate status' })).toHaveTextContent('1/2')
     expect(within(metrics).queryByText('Approved')).not.toBeInTheDocument()
     expect(within(metrics).queryByText('Rejected')).not.toBeInTheDocument()
     expect(within(metrics).queryByText('RAG docs')).not.toBeInTheDocument()

--- a/app/admin/agents/open-brain/page.tsx
+++ b/app/admin/agents/open-brain/page.tsx
@@ -352,7 +352,7 @@ function OpenBrainActionMetrics({
   pendingProposals: number
   onViewModeChange: (mode: ViewMode) => void
 }) {
-  const blockedProducerGates = snapshot.producerGates.filter((gate) => gate.status === 'blocked').length
+  const enabledProducerGates = snapshot.producerGates.filter((gate) => gate.status === 'enabled').length
   const parityIssues = snapshot.runtimeParity.filter((runtime) => runtime.status !== 'connected').length
   const metricCards = [
     {
@@ -377,12 +377,12 @@ function OpenBrainActionMetrics({
     },
     {
       label: 'Producer gates',
-      value: `${blockedProducerGates}/${snapshot.producerGates.length}`,
+      value: `${enabledProducerGates}/${snapshot.producerGates.length}`,
       detail: 'See which producers can safely emit records.',
       action: 'Review gates',
       mode: 'producers' as ViewMode,
       icon: <GitBranch size={17} />,
-      tone: blockedProducerGates ? 'border-yellow-400/45 bg-yellow-500/10' : 'border-green-400/35 bg-green-500/10',
+      tone: enabledProducerGates === snapshot.producerGates.length ? 'border-green-400/35 bg-green-500/10' : 'border-yellow-400/45 bg-yellow-500/10',
       ariaLabel: 'Open producer gate status',
     },
     {


### PR DESCRIPTION
## Summary
- correct the Open Brain actionable Producer Gates card to show enabled producer gates over total gates
- keep the operator packet's blocked-producer logic unchanged
- add targeted component assertion for the producer gate metric card

## Browser QA
- validated /admin/agents/open-brain in the integrated Browser against local dev
- confirmed Producer Gates now shows 3/5 while the Producers tab lists 3 enabled, 1 disabled, and 1 approval-gated
- confirmed Runtime Parity shows Codex and Hermes connected, OpenCode skipped, ChatGPT/Claude/Cursor blocked

## Validation
- npm test -- --run app/admin/agents/open-brain/page.test.tsx lib/open-brain.test.ts app/api/admin/rag-ingest/route.test.ts
- npx tsc --noEmit --pretty false
- npm run lint
- pre-push database health check passed