### PR TITLE
feat: add governance export ledger

### DIFF
--- a/app/admin/agents/page.test.tsx
+++ b/app/admin/agents/page.test.tsx
@@ -194,6 +194,22 @@ const missionSnapshot = {
         reason: 'Yaa Asantewaa matches payment work.',
       },
     ],
+    recent_governance_exports: [
+      {
+        id: 'export-1',
+        export_type: 'agent_governance_client_audit',
+        format: 'markdown',
+        classification: 'client_safe',
+        run_id: 'delegation-run',
+        client_project_id: 'client-456',
+        from_at: '2026-05-01T00:00:00.000Z',
+        to_at: '2026-05-21T23:59:59.999Z',
+        matching_run_count: 1,
+        requested_by_user_id: 'admin-user',
+        generated_at: '2026-05-21T00:00:00.000Z',
+        created_at: '2026-05-21T00:01:00.000Z',
+      },
+    ],
   },
   agent_inbox: [
     {
@@ -488,6 +504,11 @@ describe('AgentOperationsPage mission control landing', () => {
     expect(within(exportBuilder).queryByRole('link', { name: /Export scoped audit/i })).not.toBeInTheDocument()
     fireEvent.click(within(exportBuilder).getByRole('button', { name: 'Reset' }))
     expect(within(exportBuilder).getByLabelText('Run ID')).toHaveValue('')
+    const exportLedger = within(governancePanel).getByLabelText('Recent governance exports')
+    expect(within(exportLedger).getByText('Client audit')).toBeInTheDocument()
+    expect(within(exportLedger).getByText(/client_safe/i)).toBeInTheDocument()
+    expect(within(exportLedger).getByText(/Run delegati · Client client-456 · From 2026-05-01 · To 2026-05-21/i)).toBeInTheDocument()
+    expect(within(exportLedger).getByRole('link', { name: /Open trace/i })).toHaveAttribute('href', '/admin/agents/runs/delegation-run')
     expect(screen.getByRole('link', { name: /Active runs/i })).toHaveAttribute('href', '/admin/agents/runs?active=true')
     expect(screen.getByRole('link', { name: /Failed or stale runs/i })).toHaveAttribute('href', '/admin/agents/runs?status=needs_review')
     expect(screen.getByRole('link', { name: /Pending approvals/i })).toHaveAttribute('href', '/admin/agents/coordination')

--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -230,6 +230,20 @@ type MissionSnapshot = {
       occurred_at: string
       reason: string
     }>
+    recent_governance_exports: Array<{
+      id: string
+      export_type: string
+      format: 'json' | 'markdown'
+      classification: string
+      run_id: string | null
+      client_project_id: string | null
+      from_at: string | null
+      to_at: string | null
+      matching_run_count: number | null
+      requested_by_user_id: string | null
+      generated_at: string
+      created_at: string
+    }>
   }
   agent_inbox: Array<{
     id: string
@@ -1975,6 +1989,7 @@ function AgentGovernancePanel({ governance }: { governance: MissionSnapshot['gov
       </div>
 
       <GovernanceExportBuilder />
+      <GovernanceExportLedger exports={governance.recent_governance_exports ?? []} />
 
       <div className="mt-4 grid grid-cols-2 gap-2 lg:grid-cols-4">
         <MiniMetric label="Profiles" value={`${governance.summary.reviewed_agents}/${governance.summary.total_agents}`} tone="green" />
@@ -2040,6 +2055,55 @@ function AgentGovernancePanel({ governance }: { governance: MissionSnapshot['gov
       </div>
     </section>
   )
+}
+
+function GovernanceExportLedger({ exports }: { exports: NonNullable<MissionSnapshot['governance']>['recent_governance_exports'] }) {
+  if (!exports.length) return null
+
+  return (
+    <div className="mt-4 border-t border-silicon-slate/55 pt-4" aria-label="Recent governance exports">
+      <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Recent governance exports</p>
+      <div className="mt-3 grid gap-2 lg:grid-cols-2">
+        {exports.slice(0, 4).map((item) => (
+          <div key={item.id} className="rounded-md border border-silicon-slate/50 bg-background/35 p-3">
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div>
+                <p className="text-sm font-semibold">{item.format === 'markdown' ? 'Client audit' : 'Audit JSON'}</p>
+                <p className="mt-1 text-xs text-muted-foreground">{formatTime(item.created_at)} · {item.classification}</p>
+              </div>
+              <StatusOnlyPill tone={item.matching_run_count ? 'green' : 'blue'}>
+                {typeof item.matching_run_count === 'number' ? `${item.matching_run_count} run(s)` : 'snapshot'}
+              </StatusOnlyPill>
+            </div>
+            <p className="mt-2 text-xs leading-5 text-muted-foreground">
+              {governanceExportScopeLabel(item)}
+            </p>
+            {item.run_id ? (
+              <Link href={`/admin/agents/runs/${item.run_id}`} className="mt-2 inline-flex items-center gap-2 text-xs font-semibold text-radiant-gold hover:underline">
+                Open trace
+                <ArrowRight size={12} />
+              </Link>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function governanceExportScopeLabel(item: NonNullable<MissionSnapshot['governance']>['recent_governance_exports'][number]) {
+  const parts = [
+    item.run_id ? `Run ${shortId(item.run_id)}` : null,
+    item.client_project_id ? `Client ${item.client_project_id}` : null,
+    item.from_at ? `From ${item.from_at.slice(0, 10)}` : null,
+    item.to_at ? `To ${item.to_at.slice(0, 10)}` : null,
+  ].filter(Boolean)
+
+  return parts.length ? parts.join(' · ') : 'Current governance snapshot'
+}
+
+function shortId(value: string) {
+  return value.length > 8 ? value.slice(0, 8) : value
 }
 
 function GovernanceExportBuilder() {

--- a/app/api/admin/agents/governance/export/route.test.ts
+++ b/app/api/admin/agents/governance/export/route.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   parseAgentGovernanceExportScope: vi.fn(),
   buildScopedAgentGovernanceSnapshot: vi.fn(),
   recordAgentEvent: vi.fn(),
+  recordAgentGovernanceExport: vi.fn(),
 }))
 
 vi.mock('@/lib/auth-server', () => ({
@@ -25,6 +26,10 @@ vi.mock('@/lib/agent-governance-scope', () => ({
 
 vi.mock('@/lib/agent-run', () => ({
   recordAgentEvent: mocks.recordAgentEvent,
+}))
+
+vi.mock('@/lib/agent-governance-export-ledger', () => ({
+  recordAgentGovernanceExport: mocks.recordAgentGovernanceExport,
 }))
 
 import { GET } from './route'
@@ -68,6 +73,7 @@ const governance = {
   ],
   pending_authority_approvals: [],
   recent_delegation_decisions: [],
+  recent_governance_exports: [],
 }
 
 function request(format?: string) {
@@ -93,6 +99,7 @@ describe('GET /api/admin/agents/governance/export', () => {
       governance,
       scope: {},
     })
+    mocks.recordAgentGovernanceExport.mockResolvedValue({ id: 'export-1' })
   })
 
   it('requires admin auth', async () => {
@@ -116,6 +123,14 @@ describe('GET /api/admin/agents/governance/export', () => {
     expect(body.export.classification).toBe('client_safe')
     expect(body.export.capability_inventory[0].agent).toBe('Shaka (Zulu) - Chief of Staff')
     expect(body.export.scope.description).toBe('Current governance snapshot.')
+    expect(mocks.recordAgentGovernanceExport).toHaveBeenCalledWith(expect.objectContaining({
+      format: 'json',
+      userId: 'admin-user',
+      clientExport: expect.objectContaining({
+        export_type: 'agent_governance_client_audit',
+        classification: 'client_safe',
+      }),
+    }))
     expect(mocks.recordAgentEvent).not.toHaveBeenCalled()
   })
 
@@ -128,6 +143,19 @@ describe('GET /api/admin/agents/governance/export', () => {
     expect(response.headers.get('Content-Disposition')).toMatch(/agent-governance-audit-\d{4}-\d{2}-\d{2}\.md/)
     expect(text).toContain('# Agentic Operating System Governance Audit')
     expect(text).toContain('## Audit Boundaries')
+  })
+
+  it('does not fail the export if ledger recording is unavailable', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    mocks.recordAgentGovernanceExport.mockRejectedValueOnce(new Error('ledger missing'))
+
+    const response = await GET(request('markdown') as never)
+    const text = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(text).toContain('# Agentic Operating System Governance Audit')
+    expect(warn).toHaveBeenCalledWith('[agent-governance-export] ledger insert failed:', 'ledger missing')
+    warn.mockRestore()
   })
 
   it('returns a scoped export when filters are provided', async () => {
@@ -186,6 +214,17 @@ describe('GET /api/admin/agents/governance/export', () => {
         }),
       }),
     }))
+    expect(mocks.recordAgentGovernanceExport).toHaveBeenCalledWith(expect.objectContaining({
+      format: 'json',
+      userId: 'admin-user',
+      clientExport: expect.objectContaining({
+        scope: expect.objectContaining({
+          run_id: 'run-123',
+          client_project_id: 'client-456',
+          matching_run_count: 1,
+        }),
+      }),
+    }))
     expect(mocks.buildAgentMissionControlSnapshot).not.toHaveBeenCalled()
   })
 
@@ -208,6 +247,7 @@ describe('GET /api/admin/agents/governance/export', () => {
     const response = await GET(request('markdown') as never)
 
     expect(response.status).toBe(200)
+    expect(mocks.recordAgentGovernanceExport).toHaveBeenCalled()
     expect(mocks.recordAgentEvent).not.toHaveBeenCalled()
   })
 
@@ -224,5 +264,6 @@ describe('GET /api/admin/agents/governance/export', () => {
     expect(await response.json()).toEqual({ error: 'from must be before or equal to to' })
     expect(mocks.buildAgentMissionControlSnapshot).not.toHaveBeenCalled()
     expect(mocks.buildScopedAgentGovernanceSnapshot).not.toHaveBeenCalled()
+    expect(mocks.recordAgentGovernanceExport).not.toHaveBeenCalled()
   })
 })

--- a/app/api/admin/agents/governance/export/route.ts
+++ b/app/api/admin/agents/governance/export/route.ts
@@ -7,6 +7,7 @@ import {
 } from '@/lib/agent-governance-export'
 import { buildScopedAgentGovernanceSnapshot, parseAgentGovernanceExportScope } from '@/lib/agent-governance-scope'
 import { recordAgentEvent } from '@/lib/agent-run'
+import { recordAgentGovernanceExport } from '@/lib/agent-governance-export-ledger'
 
 export const dynamic = 'force-dynamic'
 
@@ -59,6 +60,14 @@ export async function GET(request: NextRequest) {
       : null
     const governance = scoped?.governance ?? (await buildAgentMissionControlSnapshot()).governance
     const clientExport = buildAgentGovernanceClientExport(governance, scoped?.scope ?? parsedScope.scope)
+
+    await recordAgentGovernanceExport({
+      clientExport,
+      format,
+      userId: auth.user.id,
+    }).catch((error) => {
+      console.warn('[agent-governance-export] ledger insert failed:', error instanceof Error ? error.message : error)
+    })
 
     await recordGovernanceExportEvent({
       runId: scoped?.scope.run_id,

--- a/lib/agent-governance-export-ledger.ts
+++ b/lib/agent-governance-export-ledger.ts
@@ -1,0 +1,58 @@
+import { supabaseAdmin } from '@/lib/supabase'
+import type { AgentGovernanceClientExport } from '@/lib/agent-governance-export'
+
+export type AgentGovernanceExportLedgerRow = {
+  id: string
+  export_type: string
+  format: 'json' | 'markdown'
+  classification: string
+  scope: Record<string, unknown>
+  run_id: string | null
+  client_project_id: string | null
+  from_at: string | null
+  to_at: string | null
+  matching_run_count: number | null
+  requested_by_user_id: string | null
+  generated_at: string
+  created_at: string
+}
+
+export type RecordAgentGovernanceExportInput = {
+  clientExport: AgentGovernanceClientExport
+  format: 'json' | 'markdown'
+  userId: string
+}
+
+function stringValue(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function numberValue(value: unknown) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+export async function recordAgentGovernanceExport(input: RecordAgentGovernanceExportInput): Promise<{ id: string } | null> {
+  if (!supabaseAdmin) return null
+
+  const scope = input.clientExport.scope
+  const { data, error } = await supabaseAdmin
+    .from('agent_governance_exports')
+    .insert({
+      export_type: input.clientExport.export_type,
+      format: input.format,
+      classification: input.clientExport.classification,
+      scope,
+      run_id: stringValue(scope.run_id),
+      client_project_id: stringValue(scope.client_project_id),
+      from_at: stringValue(scope.from),
+      to_at: stringValue(scope.to),
+      matching_run_count: numberValue(scope.matching_run_count),
+      requested_by_user_id: input.userId,
+      generated_at: input.clientExport.generated_at,
+    })
+    .select('id')
+    .single()
+
+  if (error) throw new Error(`Failed to record agent governance export: ${error.message}`)
+  return data?.id ? { id: data.id as string } : null
+}

--- a/lib/agent-governance-export.test.ts
+++ b/lib/agent-governance-export.test.ts
@@ -76,6 +76,7 @@ const governance = {
       reason: 'Payment work routes to automation systems.',
     },
   ],
+  recent_governance_exports: [],
 } satisfies AgentGovernanceSnapshot
 
 describe('agent governance client export', () => {

--- a/lib/agent-governance.test.ts
+++ b/lib/agent-governance.test.ts
@@ -44,6 +44,22 @@ describe('agent governance', () => {
           },
         },
       ],
+      exports: [
+        {
+          id: 'export-1',
+          export_type: 'agent_governance_client_audit',
+          format: 'markdown',
+          classification: 'client_safe',
+          run_id: 'run-shaka',
+          client_project_id: 'client-456',
+          from_at: '2026-05-01T00:00:00.000Z',
+          to_at: '2026-05-21T23:59:59.999Z',
+          matching_run_count: 1,
+          requested_by_user_id: 'admin-user',
+          generated_at: '2026-05-21T00:02:00.000Z',
+          created_at: '2026-05-21T00:02:01.000Z',
+        },
+      ],
     })
 
     expect(snapshot.summary.payment_authority_actions).toBe(6)
@@ -53,6 +69,12 @@ describe('agent governance', () => {
       selected_agent_key: 'automation-systems',
       task_type: 'payment',
       risk_class: 'payment_spend',
+    })
+    expect(snapshot.recent_governance_exports[0]).toMatchObject({
+      id: 'export-1',
+      format: 'markdown',
+      run_id: 'run-shaka',
+      client_project_id: 'client-456',
     })
   })
 })

--- a/lib/agent-governance.ts
+++ b/lib/agent-governance.ts
@@ -41,6 +41,21 @@ export type GovernanceEventSummary = {
   metadata?: Record<string, unknown> | null
 }
 
+export type GovernanceExportSummary = {
+  id: string
+  export_type: string
+  format: 'json' | 'markdown'
+  classification: string
+  run_id: string | null
+  client_project_id: string | null
+  from_at: string | null
+  to_at: string | null
+  matching_run_count: number | null
+  requested_by_user_id: string | null
+  generated_at: string
+  created_at: string
+}
+
 export type AgentGovernanceSnapshot = {
   generated_at: string
   summary: {
@@ -69,6 +84,7 @@ export type AgentGovernanceSnapshot = {
     occurred_at: string
     reason: string
   }>
+  recent_governance_exports: GovernanceExportSummary[]
 }
 
 const GOVERNANCE_REVIEWED_AT = '2026-05-21'
@@ -214,6 +230,7 @@ function recentDelegationDecisions(events: GovernanceEventSummary[]): AgentGover
 export function buildAgentGovernanceSnapshot(input?: {
   approvals?: GovernanceApprovalSummary[]
   events?: GovernanceEventSummary[]
+  exports?: GovernanceExportSummary[]
 }): AgentGovernanceSnapshot {
   const capabilityProfiles = buildAgentCapabilityProfiles()
   const pendingAuthorityApprovals = (input?.approvals ?? []).filter((approval) =>
@@ -242,5 +259,6 @@ export function buildAgentGovernanceSnapshot(input?: {
     }),
     pending_authority_approvals: pendingAuthorityApprovals.slice(0, 8),
     recent_delegation_decisions: recentDelegationDecisions(input?.events ?? []),
+    recent_governance_exports: (input?.exports ?? []).slice(0, 8),
   }
 }

--- a/lib/agent-mission-control.ts
+++ b/lib/agent-mission-control.ts
@@ -1,5 +1,5 @@
 import { AGENT_ORGANIZATION, AGENT_PODS } from '@/lib/agent-organization'
-import { buildAgentGovernanceSnapshot } from '@/lib/agent-governance'
+import { buildAgentGovernanceSnapshot, type GovernanceExportSummary } from '@/lib/agent-governance'
 import { getAgentQualitySummary, getEmptyAgentQualitySummary } from '@/lib/agent-evaluations'
 import { KNOWLEDGE_GOVERNANCE_STATUS } from '@/lib/knowledge-source-manifest'
 import { supabaseAdmin } from '@/lib/supabase'
@@ -820,7 +820,7 @@ export async function buildAgentMissionControlSnapshot() {
   const db = assertDatabase()
   const since = sinceHours(24)
 
-  const [runsRes, costsRes, approvalsRes, eventsRes, workItemsRes] = await Promise.all([
+  const [runsRes, costsRes, approvalsRes, eventsRes, workItemsRes, governanceExportsRes] = await Promise.all([
     db
       .from('agent_runs')
       .select('id, agent_key, runtime, kind, title, status, subject_label, current_step, error_message, started_at, completed_at, outcome, metadata')
@@ -847,6 +847,11 @@ export async function buildAgentMissionControlSnapshot() {
       .select('id, title, status, priority, owner_agent_key, dependency_ids, active_run_id, updated_at')
       .order('updated_at', { ascending: false })
       .limit(100),
+    db
+      .from('agent_governance_exports')
+      .select('id, export_type, format, classification, run_id, client_project_id, from_at, to_at, matching_run_count, requested_by_user_id, generated_at, created_at')
+      .order('created_at', { ascending: false })
+      .limit(8),
   ])
 
   for (const result of [runsRes, costsRes, approvalsRes, eventsRes]) {
@@ -858,12 +863,16 @@ export async function buildAgentMissionControlSnapshot() {
   if (workItemsRes.error) {
     console.warn('[agent-mission-control] dependency blocker projection unavailable:', workItemsRes.error.message)
   }
+  if (governanceExportsRes.error) {
+    console.warn('[agent-mission-control] governance export ledger unavailable:', governanceExportsRes.error.message)
+  }
 
   const runs = (runsRes.data ?? []) as AgentRunRow[]
   const costs = (costsRes.data ?? []) as CostEventRow[]
   const approvals = (approvalsRes.data ?? []) as ApprovalRow[]
   const events = (eventsRes.data ?? []) as EventRow[]
   const workItems = workItemsRes.error ? [] : (workItemsRes.data ?? []) as MissionWorkItemRow[]
+  const governanceExports = governanceExportsRes.error ? [] : (governanceExportsRes.data ?? []) as GovernanceExportSummary[]
   const costByRun = new Map<string, number>()
   const runsById = new Map(runs.map((run) => [run.id, run]))
 
@@ -899,7 +908,7 @@ export async function buildAgentMissionControlSnapshot() {
   const dependencyBlockers = buildDependencyBlockers(workItems)
   const costToday = Number(costs.reduce((sum, row) => sum + Number(row.amount ?? 0), 0).toFixed(4))
   const costSummary = buildAgentCostSummary({ costs, runsById, windowHours: 24 })
-  const governance = buildAgentGovernanceSnapshot({ approvals, events })
+  const governance = buildAgentGovernanceSnapshot({ approvals, events, exports: governanceExports })
   const dailyBrief = buildDailyOperatingBrief({
     approvals,
     costToday,

--- a/migrations/2026_05_21_agent_governance_exports.sql
+++ b/migrations/2026_05_21_agent_governance_exports.sql
@@ -1,0 +1,33 @@
+CREATE TABLE IF NOT EXISTS agent_governance_exports (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  export_type TEXT NOT NULL DEFAULT 'agent_governance_client_audit',
+  format TEXT NOT NULL CHECK (format IN ('json', 'markdown')),
+  classification TEXT NOT NULL DEFAULT 'client_safe',
+  scope JSONB NOT NULL DEFAULT '{}'::jsonb,
+  run_id UUID REFERENCES agent_runs(id) ON DELETE SET NULL,
+  client_project_id TEXT,
+  from_at TIMESTAMPTZ,
+  to_at TIMESTAMPTZ,
+  matching_run_count INTEGER,
+  requested_by_user_id UUID REFERENCES user_profiles(id) ON DELETE SET NULL,
+  generated_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_governance_exports_created_at
+  ON agent_governance_exports (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_agent_governance_exports_run_id
+  ON agent_governance_exports (run_id);
+
+CREATE INDEX IF NOT EXISTS idx_agent_governance_exports_client_project_id
+  ON agent_governance_exports (client_project_id)
+  WHERE client_project_id IS NOT NULL;
+
+ALTER TABLE agent_governance_exports ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Admins can manage agent_governance_exports" ON agent_governance_exports;
+CREATE POLICY "Admins can manage agent_governance_exports"
+  ON agent_governance_exports FOR ALL TO authenticated
+  USING (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'))
+  WITH CHECK (EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin'));


### PR DESCRIPTION
## Summary
- Adds an `agent_governance_exports` ledger table for client-safe governance export metadata, without storing the raw export payload.
- Records JSON and Markdown governance exports through a best-effort ledger insert while preserving the existing run-scoped `agent_governance_exported` trace event.
- Projects recent governance export metadata into Mission Control's Agent Governance panel with scope labels and trace links when a run is attached.

## Validation
- `npm test -- --run app/api/admin/agents/governance/export/route.test.ts lib/agent-governance.test.ts lib/agent-governance-export.test.ts app/admin/agents/page.test.tsx` (4 files, 19 tests)
- `npm run build:knowledge && npx tsc --noEmit`
- `npm run build` (passes; existing build-time n8n outbound guard warning still appears when `MOCK_N8N=false` / `N8N_DISABLE_OUTBOUND=false`)
- Authenticated read-only smoke on `http://127.0.0.1:3018/admin/agents` with `MOCK_N8N=true N8N_DISABLE_OUTBOUND=true`: Agent Governance panel and export controls rendered. Recent export ledger did not render locally because the migration table is not present in this environment yet; Mission Control logged the missing table and continued successfully.
- `git diff --check`

## Integration Notes
- Branch: `codex/governance-export-ledger`
- Worktree: `/Users/vambahsillah/Projects/Portfolio.worktrees/governance-export-ledger`
- Preflight before branching: root `main` was at `83cebb0`, clean, with no open PRs. Both Vercel contexts passed for `83cebb0`: `Vercel – portfolio` and `Vercel – portfolio-staging`.
- Environment bootstrap: `.env.local` and `.vercel` were available/ignored in the worktree; `.env.staging` was not present.
- Migration required: `migrations/2026_05_21_agent_governance_exports.sql`.
- The ledger insert is best-effort so exports do not fail before the migration is applied or if the ledger is temporarily unavailable.
- This implementation lane did not merge or deploy. Integration captain should verify `Vercel – portfolio` and `Vercel – portfolio-staging` before and after merge.

## Integration Captain Update
- Production migration applied and verified on 2026-05-21: `agent_governance_exports` exists, RLS is enabled, and policy/indexes are present.
- Dev/staging database migration was not applied in this session because `.env.local` only has a working production DB password; the dev project rejected `SUPABASE_DB_PASSWORD`. Code degrades safely if the ledger table is missing.
