### PR TITLE
feat: add guarded infisical bootstrap import

### DIFF
--- a/docs/credential-prod-source-gap-2026-05-21.md
+++ b/docs/credential-prod-source-gap-2026-05-21.md
@@ -4,27 +4,28 @@ Date: 2026-05-21
 
 ## Summary
 
-The production credential broker can reach both configured source-of-truth providers, but Infisical production is not yet populated enough to be treated as the runtime/API credential authority.
+The production credential broker can reach the configured source-of-truth providers. Infisical production was initially only partially populated, then bootstrapped from the local production runtime sink on 2026-05-21 after an explicit approval.
 
 Verified value-free checks:
 
 - `npm run credentials:smoke -- --env prod --require-provider-access` passes for provider reachability.
 - 1Password scoped read works for `LINKEDIN_COOKIE`.
 - Infisical scoped read works for `N8N_INGEST_SECRET`.
-- A value-free provider presence scan found 33 empty Infisical-backed production secrets.
-- The two 1Password-backed production entries are present.
+- A guarded dry-run found 34 tracked Infisical-backed production entries available in `.env.local`.
+- `bootstrap-infisical --env prod --source .env.local --apply` populated 34 Infisical-backed production entries without printing values.
+- A value-free provider presence scan after import found 34 Infisical-backed production entries present, 0 empty, and 0 failed.
 
 No secret values were printed, copied, or committed.
 
 ## Impact
 
-Do not treat Infisical `prod:/portfolio` as complete yet.
+Infisical `prod:/portfolio` is now populated enough to act as the runtime/API source of truth for tracked Infisical-backed production secrets.
 
-Current production deploys may still work because Vercel, n8n, Supabase, and local env files remain runtime sinks. The governance gap is that the intended source of truth is only partially populated, so agents cannot safely use Infisical to sync missing runtime sinks or prove rotation baselines for most production secrets.
+This import fixes source-of-truth availability. It does not prove provider rotation history and does not by itself rotate credentials. Provider-confirmed baselines are still required before the inventory can report these secrets as rotation-governed.
 
-## Empty Infisical-Backed Production Entries
+## Bootstrapped Infisical-Backed Production Entries
 
-The following tracked prod entries returned an empty value from Infisical at `prod:/portfolio`:
+The following tracked prod entries were bootstrapped into Infisical at `prod:/portfolio` from `.env.local`:
 
 - `SUPABASE_SERVICE_ROLE_KEY`
 - `OPENAI_API_KEY`
@@ -62,22 +63,22 @@ The following tracked prod entries returned an empty value from Infisical at `pr
 
 ## Runtime Sink Gaps
 
-`npm run credentials:report -- --env prod --check-sinks` also reported:
+After importing `N8N_API_KEY`, `credentials:report -- --env prod --check-sinks` can inspect n8n credential metadata and reports:
 
-- Runtime sinks present: 48
+- Runtime sinks present: 52
 - Runtime sinks missing: 16
-- Runtime sinks unknown/unavailable: 13
+- Runtime sinks unknown/unavailable: 9
 - Missing provider-confirmed baselines: 36
 
-The Vercel missing-key findings should not be auto-remediated from Infisical until the corresponding Infisical values are provider-confirmed and populated.
+The remaining missing sink findings are Vercel production key-name gaps. The remaining unknowns are n8n Variables because the current broker intentionally avoids reading variable values without a key-only metadata path.
 
 ## CTO Recommendation
 
-Use a three-step closeout instead of direct runtime mutation:
+Use a three-step closeout from here:
 
-1. Populate Infisical production from provider-confirmed production sources or approved rotation packets, not from ambiguous local env values.
-2. Record provider-confirmed rotation baselines in `docs/credential-inventory.json`.
-3. Run runtime sink sync packets only after the source-of-truth values are complete, then verify with `credentials:report -- --env prod --check-sinks`.
+1. Record provider-confirmed rotation baselines in `docs/credential-inventory.json`.
+2. Prepare explicit runtime-sync packets for the 16 missing Vercel production keys.
+3. Add a key-only n8n Variables metadata adapter or approved sanitized evidence path before treating n8n Variable unknowns as verified.
 
 This keeps production safe while moving the system toward the intended credential architecture.
 
@@ -89,6 +90,12 @@ Run these from `/Users/vambahsillah/Projects/Portfolio`:
 npm run credentials:smoke -- --env prod --require-provider-access
 npm run credentials:report -- --env prod --check-sinks
 npm run credentials:baseline-template -- --env prod
+npm run credentials:inject -- --env prod --secret N8N_API_KEY -- npm run credentials:report -- --env prod --check-sinks
 ```
 
-When Infisical production is fully populated, rerun a value-free provider presence scan before syncing runtime sinks.
+Use `bootstrap-infisical` for future guarded imports:
+
+```bash
+npx tsx scripts/credential-broker.ts bootstrap-infisical --env prod --source .env.local
+npx tsx scripts/credential-broker.ts bootstrap-infisical --env prod --source .env.local --apply
+```

--- a/docs/infisical-secret-map.md
+++ b/docs/infisical-secret-map.md
@@ -19,7 +19,7 @@ As of 2026-05-21:
 | --- | --- |
 | `dev` | `/portfolio` exists and inventory-owned machine secrets are synced from the local runtime sink. Rotation baselines still need provider confirmation. |
 | `staging` | `/portfolio` exists and inventory-owned machine secrets are synced. Existing staging baseline evidence remains in `docs/credential-inventory.json`; newly mapped secrets need provider confirmation. |
-| `prod` | `/portfolio` exists and provider access is working, but production is only partially populated. A value-free scan on 2026-05-21 found `N8N_INGEST_SECRET` populated and 33 tracked Infisical-backed production secrets empty. See `docs/credential-prod-source-gap-2026-05-21.md`. |
+| `prod` | `/portfolio` exists and provider access is working. On 2026-05-21, 34 tracked Infisical-backed production secrets were bootstrapped from `.env.local` after approval; a value-free follow-up scan found 34 present, 0 empty, and 0 failed. Rotation baselines still require provider confirmation. See `docs/credential-prod-source-gap-2026-05-21.md`. |
 
 ## Source-Of-Truth Rules
 

--- a/scripts/credential-broker.ts
+++ b/scripts/credential-broker.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env tsx
 import { spawnSync } from 'node:child_process'
 import { createHash, randomBytes } from 'node:crypto'
-import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import * as path from 'node:path'
 import {
   buildCredentialBaselineTemplate,
@@ -92,6 +93,7 @@ const INVENTORY_PATH = path.join(ROOT, 'docs', 'credential-inventory.json')
 const AUDIT_DIR = path.join(ROOT, '.credential-rotation-audits')
 const VALID_ENVS: EnvironmentName[] = ['dev', 'staging', 'prod']
 const PROVIDER_READ_TIMEOUT_MS = 10_000
+const PROVIDER_WRITE_TIMEOUT_MS = 60_000
 const VERCEL_METADATA_TIMEOUT_MS = 15_000
 const N8N_METADATA_TIMEOUT_MS = 15_000
 
@@ -108,6 +110,9 @@ function main() {
       break
     case 'baseline-template':
       baselineTemplate(inventory, args)
+      break
+    case 'bootstrap-infisical':
+      bootstrapInfisical(inventory, args)
       break
     case 'inject':
       inject(inventory, args)
@@ -238,6 +243,55 @@ function baselineTemplate(inventory: CredentialInventory, args: ParsedArgs) {
   }
 
   console.log(renderCredentialBaselineTemplateMarkdown(env, entries))
+}
+
+function bootstrapInfisical(inventory: CredentialInventory, args: ParsedArgs) {
+  const env = getEnv(args)
+  const sourceFile = String(args.options.source || '.env.local')
+  const apply = Boolean(args.options.apply)
+  const localValues = readLocalEnvValues(sourceFile)
+  const selected = selectSecrets(inventory, args, env)
+    .filter((secret) => secret.sourceOfTruth === 'infisical')
+
+  const rows = selected.map((secret) => {
+    const value = localValues.get(secret.envVar)?.trim() ?? ''
+    return {
+      envVar: secret.envVar,
+      secretId: secret.id,
+      runtimeSinks: secret.runtimeSinks,
+      action: value ? apply ? 'will-import' : 'would-import' : 'skipped-missing-or-empty',
+      hasValue: Boolean(value),
+      value,
+    }
+  })
+  const importable = rows.filter((row) => row.hasValue)
+  const skipped = rows.filter((row) => !row.hasValue)
+
+  console.log(`Infisical bootstrap ${apply ? 'apply' : 'dry-run'} for ${env}`)
+  console.log(`source=${sourceFile}`)
+  console.log(`tracked-infisical-secrets=${selected.length}`)
+  console.log(`importable=${importable.length}`)
+  console.log(`skipped-missing-or-empty=${skipped.length}`)
+  console.log('')
+  for (const row of rows) {
+    console.log(`${row.action.padEnd(24)} ${row.envVar}`)
+  }
+
+  if (!apply) {
+    console.log('')
+    console.log('No values were written. Re-run with --apply to populate Infisical from the local runtime sink.')
+    return
+  }
+
+  if (importable.length === 0) {
+    console.log('No importable values found; Infisical was not changed.')
+    return
+  }
+
+  const imported = writeInfisicalSecretsFile(inventory, env, importable.map((row) => [row.envVar, row.value]))
+  console.log('')
+  console.log(`Infisical populated for ${imported} key(s). Values were not printed.`)
+  console.log('Baseline evidence remains pending-provider-confirmation until provider history or approved rotation packets are recorded.')
 }
 
 function inject(inventory: CredentialInventory, args: ParsedArgs) {
@@ -471,6 +525,67 @@ function writeLocalEnv(filePath: string, envVar: string, value: string) {
   })
   if (!replaced) next.push(nextLine)
   writeFileSync(resolved, `${next.filter((line, index) => line.length > 0 || index < next.length - 1).join('\n')}\n`)
+}
+
+function readLocalEnvValues(filePath: string): Map<string, string> {
+  const resolved = path.resolve(ROOT, filePath)
+  if (!resolved.startsWith(ROOT)) fail(`Refusing to read outside repo: ${filePath}`)
+  if (!existsSync(resolved)) fail(`Local env source not found: ${filePath}`)
+
+  const values = new Map<string, string>()
+  for (const line of readFileSync(resolved, 'utf8').split(/\r?\n/)) {
+    const match = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/)
+    if (!match) continue
+    const key = match[1]
+    let value = match[2] ?? ''
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1)
+    }
+    values.set(key, value)
+  }
+  return values
+}
+
+function writeInfisicalSecretsFile(
+  inventory: CredentialInventory,
+  env: EnvironmentName,
+  entries: Array<[string, string]>
+): number {
+  const infisicalEnv = inventory.providers.infisical.envMap[env]
+  const secretPath = inventory.providers.infisical.secretPath
+  const tempDir = mkdtempSync(path.join(tmpdir(), 'portfolio-infisical-bootstrap-'))
+  const tempFile = path.join(tempDir, 'secrets.env')
+
+  try {
+    const content = entries.map(([key, value]) => `${key}=${formatEnvValue(value)}`).join('\n')
+    writeFileSync(tempFile, `${content}\n`, { mode: 0o600 })
+
+    const command = ['secrets', 'set', '--file', tempFile, '--env', infisicalEnv, '--path', secretPath, '--silent']
+    if (inventory.providers.infisical.projectId) command.push('--projectId', inventory.providers.infisical.projectId)
+    const result = spawnSync('infisical', command, {
+      cwd: ROOT,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: process.env,
+      timeout: PROVIDER_WRITE_TIMEOUT_MS,
+    })
+
+    if (result.status !== 0) {
+      fail(`Infisical bootstrap failed for ${env}. Confirm CLI authentication and ${infisicalEnv}${secretPath} write access.`)
+    }
+
+    return entries.length
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true })
+  }
+}
+
+function formatEnvValue(value: string): string {
+  if (/^[A-Za-z0-9_./:@%+=,-]*$/.test(value)) return value
+  return JSON.stringify(value)
 }
 
 function buildPacket(input: {
@@ -892,6 +1007,7 @@ Commands:
   list-due      --env <dev|staging|prod> [--as-of YYYY-MM-DD] [--json]
   report        --env <dev|staging|prod> [--as-of YYYY-MM-DD] [--check-sinks] [--json]
   baseline-template --env <dev|staging|prod> [--updated-at YYYY-MM-DD] [--json]
+  bootstrap-infisical --env <dev|staging|prod> [--source .env.local] [--secret id-or-envVar[,..]] [--apply]
   inject        --env <dev|staging|prod> [--secret id-or-envVar[,..]] -- <command>
   rotate        --env <dev|staging|prod> --secret <id-or-envVar> [--local-env .env.staging] [--length 48]
   sync-runtime  --env <dev|staging|prod> --secret <id-or-envVar> [--local-env .env.staging]


### PR DESCRIPTION
## Summary
- Adds `bootstrap-infisical` to the credential broker for guarded Infisical imports from ignored local env sinks.
- Keeps imports dry-run by default, reports key names only, and uses a temporary env file for `infisical secrets set --file` so values are not printed or passed as visible command arguments.
- Updates the production credential gap docs after bootstrapping 34 Infisical-backed prod keys from `.env.local` with explicit approval.

## Validation
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- `npx tsx scripts/credential-broker.ts bootstrap-infisical --env prod --source .env.local --secret N8N_INGEST_SECRET`
- Applied guarded import: `npx tsx scripts/credential-broker.ts bootstrap-infisical --env prod --source .env.local --apply`
- Value-free verification scan: 34 Infisical-backed prod keys present, 0 empty, 0 failed.
- `npm run credentials:inject -- --env prod --secret N8N_API_KEY -- npm run credentials:report -- --env prod --check-sinks`
- Push hook `npm run db:health-check` passed.

## Integration Notes
- This populated Infisical prod from `.env.local` as a bootstrap source, not provider-confirmed rotation evidence.
- Rotation baselines remain `pending-provider-confirmation` until provider history or approved rotation packets are recorded.
- Strict `credentials:smoke -- --env prod --require-provider-access` currently fails on the 1Password `LINKEDIN_COOKIE` scoped read in this shell even though Infisical scoped reads pass; reconnect 1Password CLI before relying on full provider smoke.
- Remaining runtime sink gaps are Vercel production key-name gaps and n8n Variables unknowns.
