### PR TITLE
feat: standardize checkout commerce surfaces

### DIFF
--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
 import { motion } from 'framer-motion'
-import { ArrowLeft, Lock, HelpCircle, LogIn } from 'lucide-react'
+import { ArrowLeft, CheckCircle2, HelpCircle, LogIn, Lock, PackageCheck, ShieldCheck } from 'lucide-react'
 import Link from 'next/link'
 import { useAuth } from '@/components/AuthProvider'
 import { getCart, clearCart, saveCart, updateCartItemQuantity, updateServiceQuantity, removeFromCart, removeServiceFromCart, isServiceItem, type CartItem } from '@/lib/cart'
@@ -615,8 +615,8 @@ export default function CheckoutPage() {
   // Wait for both cart and auth to be ready before showing sign-in gate or checkout
   if (loading || authLoading) {
     return (
-      <div className="min-h-screen bg-background text-foreground flex items-center justify-center">
-        <div className="text-muted-foreground">Loading checkout...</div>
+      <div className="dark agent-ops-page flex min-h-screen items-center justify-center text-foreground">
+        <div className="agent-ops-card rounded-lg border px-6 py-4 text-muted-foreground">Loading checkout...</div>
       </div>
     )
   }
@@ -624,12 +624,12 @@ export default function CheckoutPage() {
   // Require sign-in so we can deliver orders and follow up / upsell
   if (!user) {
     return (
-      <div className="min-h-screen bg-background text-foreground pt-24 pb-12 px-4">
+      <div className="dark agent-ops-page min-h-screen px-4 pb-12 pt-24 text-foreground">
         <div className="max-w-5xl mx-auto">
           <div className="flex items-center justify-between mb-8">
             <button
               onClick={() => router.push('/store')}
-              className="flex items-center gap-2 text-muted-foreground hover:text-white transition-colors"
+              className="agent-ops-button-muted"
             >
               <ArrowLeft size={20} />
               Back to Store
@@ -638,11 +638,14 @@ export default function CheckoutPage() {
           <motion.div
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
-            className="bg-silicon-slate border border-silicon-slate rounded-xl p-8 max-w-xl"
+            className="agent-ops-command-card max-w-xl rounded-xl border p-6 sm:p-8"
           >
-            <div className="flex items-center gap-3 mb-4">
-              <Lock className="text-radiant-gold flex-shrink-0" size={28} />
-              <h2 className="text-2xl font-bold">Sign in to checkout</h2>
+            <div className="mb-4 flex items-center gap-3">
+              <Lock className="flex-shrink-0 text-radiant-gold" size={28} />
+              <div>
+                <p className="agent-ops-eyebrow">Secure checkout</p>
+                <h2 className="mt-2 text-2xl font-bold">Sign in to continue</h2>
+              </div>
             </div>
             <p className="text-muted-foreground mb-6">
               We require an account so we can deliver your order and follow up with you. Sign in or create an account to continue.
@@ -650,14 +653,14 @@ export default function CheckoutPage() {
             <div className="flex flex-wrap gap-3">
               <Link
                 href="/auth/login?redirect=/checkout"
-                className="inline-flex items-center gap-2 px-6 py-3 rounded-lg bg-gradient-to-r btn-gold transition-colors"
+                className="agent-ops-button-primary px-6 py-3"
               >
                 <LogIn size={20} />
                 Sign in
               </Link>
               <Link
                 href="/auth/signup?redirect=/checkout"
-                className="inline-flex items-center gap-2 px-6 py-3 rounded-lg btn-ghost transition-colors"
+                className="agent-ops-button-muted px-6 py-3"
               >
                 Create account
               </Link>
@@ -672,18 +675,18 @@ export default function CheckoutPage() {
   const hasPaidItems = subtotal > 0 || hasQuoteBasedItems
 
   return (
-    <div className="min-h-screen bg-background text-foreground pt-24 pb-12 px-4">
+    <div className="dark agent-ops-page min-h-screen px-4 pb-12 pt-24 text-foreground">
       <div className="max-w-5xl mx-auto">
         {/* Header */}
         <motion.div
           initial={{ opacity: 0, y: -20 }}
           animate={{ opacity: 1, y: 0 }}
-          className="mb-8"
+          className="agent-ops-surface-header mb-6 rounded-xl border p-5 sm:p-6"
         >
-          <div className="flex items-center justify-between mb-4">
+          <div className="mb-5 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <button
               onClick={() => router.push('/store')}
-              className="flex items-center gap-2 text-muted-foreground hover:text-white transition-colors"
+              className="agent-ops-button-muted w-fit"
             >
               <ArrowLeft size={20} />
               Back to Store
@@ -695,8 +698,38 @@ export default function CheckoutPage() {
               </Link>
             </div>
           </div>
-          <h1 className="text-4xl font-bold mb-2">Checkout</h1>
-          <p className="text-muted-foreground">Review your order and complete your purchase</p>
+          <p className="agent-ops-eyebrow">AmaduTown checkout</p>
+          <div className="mt-3 grid gap-5 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
+            <div>
+              <h1 className="text-3xl font-bold sm:text-4xl">Review order and payment path</h1>
+              <p className="mt-2 max-w-3xl text-muted-foreground">
+                Confirm delivery details, apply any discount, and choose how this purchase should be paid.
+              </p>
+            </div>
+            <div className="grid gap-2 text-sm sm:grid-cols-3 lg:min-w-[24rem]">
+              <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 px-3 py-2">
+                <div className="flex items-center gap-2 text-radiant-gold">
+                  <CheckCircle2 size={14} />
+                  <span className="font-semibold">Cart ready</span>
+                </div>
+                <p className="mt-1 text-muted-foreground">{cartItems.length} item{cartItems.length === 1 ? '' : 's'}</p>
+              </div>
+              <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 px-3 py-2">
+                <div className="flex items-center gap-2 text-radiant-gold">
+                  <ShieldCheck size={14} />
+                  <span className="font-semibold">Account</span>
+                </div>
+                <p className="mt-1 text-muted-foreground">Signed in</p>
+              </div>
+              <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 px-3 py-2">
+                <div className="flex items-center gap-2 text-radiant-gold">
+                  <PackageCheck size={14} />
+                  <span className="font-semibold">Delivery</span>
+                </div>
+                <p className="mt-1 text-muted-foreground">{hasMerchandise ? 'Address required' : 'Digital/service'}</p>
+              </div>
+            </div>
+          </div>
         </motion.div>
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
@@ -715,8 +748,9 @@ export default function CheckoutPage() {
                 />
 
                 {hasMerchandise && (
-                  <div className="bg-silicon-slate border border-silicon-slate rounded-xl p-6">
-                    <h2 className="text-xl font-bold mb-4">Shipping address</h2>
+                  <div className="agent-ops-card rounded-xl border p-5 sm:p-6">
+                    <p className="agent-ops-eyebrow mb-2">Delivery</p>
+                    <h2 className="text-xl font-bold mb-3">Shipping address</h2>
                     <p className="text-muted-foreground text-sm mb-4">
                       Required for physical products. We’ll deliver your order to this address.
                     </p>
@@ -740,7 +774,7 @@ export default function CheckoutPage() {
                             setAddressValidateResult(null)
                           }}
                           placeholder="Start typing your address…"
-                          className="w-full px-4 py-2 rounded-lg bg-background border border-silicon-slate text-foreground placeholder:text-muted-foreground/90"
+                          className="w-full rounded-lg border border-silicon-slate/70 bg-silicon-slate/25 px-4 py-2 text-foreground placeholder:text-muted-foreground/90 outline-none transition-colors focus:border-radiant-gold/70"
                           countryRestriction={['US', 'CA', 'GB'].includes(shippingAddress.country_code) ? shippingAddress.country_code : undefined}
                         />
                       </div>
@@ -750,7 +784,7 @@ export default function CheckoutPage() {
                           value={shippingAddress.address2}
                           onChange={(e) => setShippingAddress((a) => ({ ...a, address2: e.target.value }))}
                           placeholder="Address line 2 (optional)"
-                          className="w-full px-4 py-2 rounded-lg bg-background border border-silicon-slate text-foreground placeholder:text-muted-foreground/90"
+                          className="w-full rounded-lg border border-silicon-slate/70 bg-silicon-slate/25 px-4 py-2 text-foreground placeholder:text-muted-foreground/90 outline-none transition-colors focus:border-radiant-gold/70"
                         />
                       </div>
                       <div>
@@ -760,7 +794,7 @@ export default function CheckoutPage() {
                           value={shippingAddress.city}
                           onChange={(e) => setShippingAddress((a) => ({ ...a, city: e.target.value }))}
                           placeholder="City"
-                          className="w-full px-4 py-2 rounded-lg bg-background border border-silicon-slate text-foreground placeholder:text-muted-foreground/90"
+                          className="w-full rounded-lg border border-silicon-slate/70 bg-silicon-slate/25 px-4 py-2 text-foreground placeholder:text-muted-foreground/90 outline-none transition-colors focus:border-radiant-gold/70"
                         />
                       </div>
                       <div>
@@ -770,7 +804,7 @@ export default function CheckoutPage() {
                           value={shippingAddress.state_code}
                           onChange={(e) => setShippingAddress((a) => ({ ...a, state_code: e.target.value }))}
                           placeholder="e.g. CA"
-                          className="w-full px-4 py-2 rounded-lg bg-background border border-silicon-slate text-foreground placeholder:text-muted-foreground/90"
+                          className="w-full rounded-lg border border-silicon-slate/70 bg-silicon-slate/25 px-4 py-2 text-foreground placeholder:text-muted-foreground/90 outline-none transition-colors focus:border-radiant-gold/70"
                         />
                       </div>
                       <div>
@@ -780,7 +814,7 @@ export default function CheckoutPage() {
                           value={shippingAddress.zip}
                           onChange={(e) => setShippingAddress((a) => ({ ...a, zip: e.target.value }))}
                           placeholder="ZIP code"
-                          className="w-full px-4 py-2 rounded-lg bg-background border border-silicon-slate text-foreground placeholder:text-muted-foreground/90"
+                          className="w-full rounded-lg border border-silicon-slate/70 bg-silicon-slate/25 px-4 py-2 text-foreground placeholder:text-muted-foreground/90 outline-none transition-colors focus:border-radiant-gold/70"
                         />
                         {shippingAddress.country_code === 'US' && (
                           <p className="text-xs text-muted-foreground/90 mt-1">City & state suggested when you enter a 5-digit ZIP.</p>
@@ -794,7 +828,7 @@ export default function CheckoutPage() {
                             setShippingAddress((a) => ({ ...a, country_code: e.target.value }))
                             setAddressValidateResult(null)
                           }}
-                          className="w-full px-4 py-2 rounded-lg bg-background border border-silicon-slate text-foreground"
+                          className="w-full rounded-lg border border-silicon-slate/70 bg-silicon-slate/25 px-4 py-2 text-foreground outline-none transition-colors focus:border-radiant-gold/70"
                         >
                           <option value="US">United States</option>
                           <option value="CA">Canada</option>
@@ -809,7 +843,7 @@ export default function CheckoutPage() {
                           type="button"
                           onClick={handleValidateAddress}
                           disabled={addressValidateLoading || !isShippingAddressComplete()}
-                          className="text-sm px-3 py-1.5 rounded-lg border border-silicon-slate text-foreground/90 hover:bg-silicon-slate/50 disabled:opacity-50 disabled:pointer-events-none"
+                          className="agent-ops-button-secondary text-sm disabled:pointer-events-none disabled:opacity-50"
                         >
                           {addressValidateLoading ? 'Validating…' : 'Validate with USPS'}
                         </button>
@@ -832,7 +866,7 @@ export default function CheckoutPage() {
                             <button
                               type="button"
                               onClick={handleUseValidatedAddress}
-                              className="text-sm px-3 py-1.5 rounded-lg bg-gold text-imperial-navy font-medium hover:opacity-90"
+                              className="agent-ops-button-primary text-sm"
                             >
                               Use this address
                             </button>
@@ -852,8 +886,9 @@ export default function CheckoutPage() {
                 )}
 
                 {/* Discount Code */}
-                <div className="bg-silicon-slate border border-silicon-slate rounded-xl p-6">
-                  <h2 className="text-xl font-bold mb-4">Discount Code</h2>
+                <div className="agent-ops-card rounded-xl border p-5 sm:p-6">
+                  <p className="agent-ops-eyebrow mb-2">Adjustment</p>
+                  <h2 className="text-xl font-bold mb-4">Discount code</h2>
                   <DiscountCodeForm
                     onApply={handleDiscountApply}
                     appliedCode={appliedDiscountCode}
@@ -864,8 +899,9 @@ export default function CheckoutPage() {
 
                 {/* Payment Options */}
                 {hasPaidItems && effectiveFinalTotal > 0 && (
-                  <div className="bg-silicon-slate border border-silicon-slate rounded-xl p-6">
-                    <h2 className="text-xl font-bold mb-4">Payment Options</h2>
+                  <div className="agent-ops-card rounded-xl border p-5 sm:p-6">
+                    <p className="agent-ops-eyebrow mb-2">Payment path</p>
+                    <h2 className="text-xl font-bold mb-4">Payment options</h2>
                     <InstallmentOption
                       baseAmount={effectiveFinalTotal}
                       defaultInstallments={3}
@@ -881,10 +917,10 @@ export default function CheckoutPage() {
                 )}
 
                 {/* Checkout Button */}
-                <div className="bg-silicon-slate border border-silicon-slate rounded-xl p-6">
+                <div className="agent-ops-command-card rounded-xl border p-5 sm:p-6">
                   <button
                     onClick={handleCheckout}
-                    className="w-full px-6 py-4 btn-gold text-imperial-navy font-semibold rounded-lg transition-colors flex items-center justify-center gap-2"
+                    className="agent-ops-button-primary w-full px-6 py-4 text-base"
                   >
                     {hasPaidItems ? (
                       <>

--- a/app/checkout/payment/page.tsx
+++ b/app/checkout/payment/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback, Suspense } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { motion } from 'framer-motion'
-import { ArrowLeft, CheckCircle, Loader } from 'lucide-react'
+import { ArrowLeft, CheckCircle, CreditCard, Loader, ShieldCheck } from 'lucide-react'
 import StripeCheckout from '@/components/checkout/StripeCheckout'
 import { getCurrentSession } from '@/lib/auth'
 import SiteThemeCorner from '@/components/SiteThemeCorner'
@@ -70,8 +70,8 @@ function PaymentContent() {
     return (
       <>
         <SiteThemeCorner />
-        <div className="min-h-screen bg-background text-foreground flex items-center justify-center">
-          <div className="text-center">
+        <div className="dark agent-ops-page flex min-h-screen items-center justify-center text-foreground">
+          <div className="agent-ops-card rounded-lg border p-6 text-center">
             <Loader className="animate-spin mx-auto mb-4 text-radiant-gold" size={48} />
             <div className="text-muted-foreground">Initializing payment...</div>
           </div>
@@ -84,13 +84,13 @@ function PaymentContent() {
     return (
       <>
         <SiteThemeCorner />
-        <div className="min-h-screen bg-background text-foreground pt-24 pb-12 px-4">
+        <div className="dark agent-ops-page min-h-screen px-4 pb-12 pt-24 text-foreground">
           <div className="max-w-2xl mx-auto">
-            <div className="bg-red-600/20 border border-red-600/50 rounded-xl p-6 text-center">
+            <div className="agent-ops-card rounded-xl border border-red-400/35 bg-red-500/10 p-6 text-center">
               <p className="text-red-400 mb-4">{error}</p>
               <button
                 onClick={() => router.push('/checkout')}
-                className="px-6 py-2 btn-gold text-imperial-navy font-semibold rounded-lg transition-colors"
+                className="agent-ops-button-primary px-6 py-2"
               >
                 Back to Checkout
               </button>
@@ -105,11 +105,11 @@ function PaymentContent() {
     return (
       <>
         <SiteThemeCorner />
-        <div className="min-h-screen bg-background text-foreground flex items-center justify-center">
+        <div className="dark agent-ops-page flex min-h-screen items-center justify-center text-foreground">
           <motion.div
             initial={{ opacity: 0, scale: 0.9 }}
             animate={{ opacity: 1, scale: 1 }}
-            className="text-center"
+            className="agent-ops-command-card rounded-xl border p-8 text-center"
           >
             <CheckCircle className="mx-auto mb-4 text-radiant-gold" size={64} />
             <h2 className="text-3xl font-bold mb-2">Payment Successful!</h2>
@@ -123,7 +123,7 @@ function PaymentContent() {
   return (
     <>
       <SiteThemeCorner />
-    <div className="min-h-screen bg-background text-foreground pt-24 pb-12 px-4">
+    <div className="dark agent-ops-page min-h-screen px-4 pb-12 pt-24 text-foreground">
       <div className="max-w-2xl mx-auto">
         <motion.div
           initial={{ opacity: 0, y: -20 }}
@@ -131,22 +131,36 @@ function PaymentContent() {
         >
           <button
             onClick={() => router.push('/checkout')}
-            className="flex items-center gap-2 text-muted-foreground hover:text-foreground mb-6 transition-colors"
+            className="agent-ops-button-muted mb-6"
           >
             <ArrowLeft size={20} />
             Back to Checkout
           </button>
 
-          <h1 className="text-4xl font-bold mb-2">Complete Payment</h1>
-          <p className="text-muted-foreground mb-8">Enter your payment details to complete your purchase</p>
+          <section className="agent-ops-surface-header mb-6 rounded-xl border p-5 sm:p-6">
+            <p className="agent-ops-eyebrow"><CreditCard size={16} /> Secure payment</p>
+            <h1 className="mt-3 text-3xl font-bold sm:text-4xl">Complete payment</h1>
+            <p className="mt-2 text-muted-foreground">Enter your payment details to complete your purchase.</p>
+            <div className="mt-4 flex flex-wrap gap-2 text-sm text-muted-foreground">
+              <span className="inline-flex items-center gap-2 rounded-full border border-silicon-slate/70 bg-silicon-slate/25 px-3 py-1">
+                <ShieldCheck size={14} className="text-radiant-gold" />
+                Secured by Stripe
+              </span>
+              {orderId && (
+                <span className="rounded-full border border-silicon-slate/70 bg-silicon-slate/25 px-3 py-1">
+                  Order #{orderId}
+                </span>
+              )}
+            </div>
+          </section>
 
-          <div className="bg-silicon-slate border border-silicon-slate rounded-xl p-6">
+          <div className="agent-ops-card rounded-xl border p-5 sm:p-6">
             {clientSecret && orderId && (() => {
               const pubKey = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY || ''
               const pubMode = pubKey.startsWith('pk_live') ? 'live' : pubKey.startsWith('pk_test') ? 'test' : null
               if (keyMode && pubMode && keyMode !== pubMode) {
                 return (
-                  <div className="p-4 bg-amber-600/20 border border-amber-600/50 rounded-lg text-amber-200">
+                  <div className="rounded-lg border border-amber-500/45 bg-amber-500/10 p-4 text-amber-200">
                     <p className="font-semibold">Payment form could not load</p>
                     <p className="mt-2 text-sm">
                       Your Stripe publishable key and secret key must use the same mode. You have a{' '}
@@ -166,14 +180,14 @@ function PaymentContent() {
               )
             })()}
             {error && (
-              <div className="mt-4 p-4 bg-red-600/20 border border-red-600/50 rounded-lg text-red-400">
+              <div className="mt-4 rounded-lg border border-red-400/40 bg-red-500/10 p-4 text-red-400">
                 {error}
               </div>
             )}
           </div>
 
           <div className="mt-6 text-center text-sm text-muted-foreground">
-            <p>Your payment is secured by Stripe</p>
+            <p>Payment details are handled securely by Stripe.</p>
           </div>
         </motion.div>
       </div>
@@ -187,8 +201,8 @@ export default function PaymentPage() {
     <Suspense fallback={
       <>
         <SiteThemeCorner />
-      <div className="min-h-screen bg-background text-foreground flex items-center justify-center">
-        <div className="text-center">
+      <div className="dark agent-ops-page flex min-h-screen items-center justify-center text-foreground">
+        <div className="agent-ops-card rounded-lg border p-6 text-center">
           <Loader className="animate-spin mx-auto mb-4 text-radiant-gold" size={48} />
           <div className="text-muted-foreground">Loading...</div>
         </div>

--- a/components/checkout/CampaignEnrollmentBanner.tsx
+++ b/components/checkout/CampaignEnrollmentBanner.tsx
@@ -23,13 +23,13 @@ export default function CampaignEnrollmentBanner({ campaign }: CampaignEnrollmen
   const primary = campaign
 
   return (
-    <div className="bg-gradient-to-r from-amber-600/10 to-orange-600/10 border border-amber-500/30 rounded-xl p-5">
+    <div className="agent-ops-command-card rounded-xl border p-5">
       <div className="flex items-start gap-3">
-        <div className="w-8 h-8 rounded-lg bg-gradient-to-r from-amber-500 to-orange-500 flex items-center justify-center flex-shrink-0">
-          <Sparkles className="w-4 h-4 text-white" />
+        <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg border border-radiant-gold/45 bg-radiant-gold/15">
+          <Sparkles className="h-4 w-4 text-radiant-gold" />
         </div>
         <div className="flex-1">
-          <h3 className="text-sm font-bold text-amber-300 mb-1">
+          <h3 className="mb-1 text-sm font-bold text-radiant-gold">
             {CAMPAIGN_TYPE_LABELS[primary.campaign_type] || primary.name}
           </h3>
           <p className="text-xs text-muted-foreground mb-2">
@@ -38,13 +38,13 @@ export default function CampaignEnrollmentBanner({ campaign }: CampaignEnrollmen
             Meet the criteria and earn back your investment.
           </p>
           {primary.enrollment_deadline && (
-            <p className="text-xs text-gray-500 mb-2">
+            <p className="mb-2 text-xs text-muted-foreground/80">
               Enrollment deadline: {new Date(primary.enrollment_deadline).toLocaleDateString()}
             </p>
           )}
           <Link
             href={`/campaigns/${primary.slug}`}
-            className="inline-flex items-center gap-1 text-xs text-amber-400 hover:text-amber-300 transition-colors"
+            className="inline-flex items-center gap-1 text-xs text-radiant-gold transition-colors hover:text-gold-light"
           >
             Learn more about this campaign
             <ArrowRight className="w-3 h-3" />

--- a/components/checkout/ContactForm.tsx
+++ b/components/checkout/ContactForm.tsx
@@ -85,7 +85,7 @@ export default function ContactForm({ onSubmit, initialData }: ContactFormProps)
 
       <button
         type="submit"
-        className="w-full px-6 py-3 btn-gold text-imperial-navy font-semibold rounded-lg transition-colors"
+        className="agent-ops-button-primary w-full px-6 py-3"
       >
         Continue to Checkout
       </button>

--- a/components/checkout/DiscountCodeForm.tsx
+++ b/components/checkout/DiscountCodeForm.tsx
@@ -50,7 +50,7 @@ export default function DiscountCodeForm({
         animate={{ opacity: 1, y: 0 }}
         className="space-y-2"
       >
-        <div className="p-4 bg-green-600/20 border border-green-600/50 rounded-lg">
+        <div className="rounded-lg border border-green-400/40 bg-green-500/10 p-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <Check className="text-green-400" size={20} />
@@ -86,7 +86,7 @@ export default function DiscountCodeForm({
       <label className="block text-sm font-medium">
         Discount Code
       </label>
-      <div className="flex gap-2">
+      <div className="flex flex-col gap-2 sm:flex-row">
         <div className="relative flex-1">
           <Tag className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground" size={20} />
           <input
@@ -106,7 +106,7 @@ export default function DiscountCodeForm({
         <button
           type="submit"
           disabled={loading || !code.trim()}
-          className="px-6 py-2 btn-ghost font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          className="agent-ops-button-secondary justify-center px-6 py-2 font-semibold disabled:cursor-not-allowed disabled:opacity-50"
         >
           {loading ? 'Applying...' : 'Apply'}
         </button>

--- a/components/checkout/InstallmentOption.tsx
+++ b/components/checkout/InstallmentOption.tsx
@@ -83,21 +83,21 @@ export default function InstallmentOption({
         onClick={() => onSelect('full')}
         className={`w-full flex items-center gap-4 p-4 rounded-xl border transition-all text-left ${
           selectedMode === 'full'
-            ? 'border-green-500 bg-green-900/20 ring-1 ring-green-500/30'
-            : 'border-gray-700 bg-gray-800/50 hover:border-gray-600'
+            ? 'border-radiant-gold/60 bg-radiant-gold/10 ring-1 ring-radiant-gold/25'
+            : 'border-silicon-slate/70 bg-silicon-slate/20 hover:border-radiant-gold/35'
         }`}
       >
         <div className={`w-5 h-5 rounded-full border-2 flex items-center justify-center flex-shrink-0 ${
-          selectedMode === 'full' ? 'border-green-500' : 'border-gray-600'
+          selectedMode === 'full' ? 'border-radiant-gold' : 'border-silicon-slate'
         }`}>
-          {selectedMode === 'full' && <div className="w-2.5 h-2.5 rounded-full bg-green-500" />}
+          {selectedMode === 'full' && <div className="w-2.5 h-2.5 rounded-full bg-radiant-gold" />}
         </div>
         <div className="flex-1">
           <div className="flex items-center gap-2">
-            <CreditCard className="w-4 h-4 text-gray-400" />
+            <CreditCard className="w-4 h-4 text-radiant-gold" />
             <span className="font-medium text-white">Pay in Full</span>
           </div>
-          <p className="text-sm text-gray-400 mt-0.5">One-time payment of {formatCurrency(baseAmount)}</p>
+          <p className="text-sm text-muted-foreground mt-0.5">One-time payment of {formatCurrency(baseAmount)}</p>
         </div>
         <span className="text-lg font-bold text-white">{formatCurrency(baseAmount)}</span>
       </button>
@@ -106,8 +106,8 @@ export default function InstallmentOption({
       <div
         className={`rounded-xl border transition-all ${
           selectedMode === 'installments'
-            ? 'border-blue-500 bg-blue-900/20 ring-1 ring-blue-500/30'
-            : 'border-gray-700 bg-gray-800/50 hover:border-gray-600'
+            ? 'border-radiant-gold/60 bg-radiant-gold/10 ring-1 ring-radiant-gold/25'
+            : 'border-silicon-slate/70 bg-silicon-slate/20 hover:border-radiant-gold/35'
         }`}
       >
         <button
@@ -116,16 +116,16 @@ export default function InstallmentOption({
           className="w-full flex items-center gap-4 p-4 text-left"
         >
           <div className={`w-5 h-5 rounded-full border-2 flex items-center justify-center flex-shrink-0 ${
-            selectedMode === 'installments' ? 'border-blue-500' : 'border-gray-600'
+            selectedMode === 'installments' ? 'border-radiant-gold' : 'border-silicon-slate'
           }`}>
-            {selectedMode === 'installments' && <div className="w-2.5 h-2.5 rounded-full bg-blue-500" />}
+            {selectedMode === 'installments' && <div className="w-2.5 h-2.5 rounded-full bg-radiant-gold" />}
           </div>
           <div className="flex-1">
             <div className="flex items-center gap-2">
-              <Calendar className="w-4 h-4 text-gray-400" />
+              <Calendar className="w-4 h-4 text-radiant-gold" />
               <span className="font-medium text-white">Pay in Installments</span>
             </div>
-            <p className="text-sm text-gray-400 mt-0.5">
+            <p className="text-sm text-muted-foreground mt-0.5">
               {numInstallments} monthly payments of {formatCurrency(calc.installmentAmount)}
             </p>
           </div>
@@ -133,10 +133,10 @@ export default function InstallmentOption({
         </button>
 
         {selectedMode === 'installments' && (
-          <div className="px-4 pb-4 space-y-3 border-t border-gray-700/50 pt-3 ml-9">
+          <div className="ml-9 space-y-3 border-t border-silicon-slate/70 px-4 pb-4 pt-3">
             {/* Installment count selector */}
             <div>
-              <label className="block text-xs text-gray-500 mb-1.5">Number of Payments</label>
+              <label className="mb-1.5 block text-xs text-muted-foreground">Number of payments</label>
               <div className="flex items-center gap-2">
                 <input
                   type="range"
@@ -144,7 +144,7 @@ export default function InstallmentOption({
                   max={maxInstallments}
                   value={numInstallments}
                   onChange={(e) => handleInstallmentCountChange(parseInt(e.target.value, 10))}
-                  className="flex-1 accent-blue-500"
+                  className="flex-1 accent-radiant-gold"
                 />
                 <span className="text-sm font-medium text-white w-8 text-center">{numInstallments}</span>
               </div>
@@ -152,19 +152,19 @@ export default function InstallmentOption({
 
             {/* Fee breakdown */}
             <div className="space-y-1.5 text-sm">
-              <div className="flex justify-between text-gray-400">
+              <div className="flex justify-between text-muted-foreground">
                 <span>Base amount</span>
                 <span>{formatCurrency(baseAmount)}</span>
               </div>
-              <div className="flex justify-between text-gray-400">
+              <div className="flex justify-between text-muted-foreground">
                 <span>Installment fee ({feePercent}%)</span>
                 <span>+{formatCurrency(calc.feeAmount)}</span>
               </div>
-              <div className="flex justify-between text-white font-medium pt-1.5 border-t border-gray-700/50">
+              <div className="flex justify-between border-t border-silicon-slate/70 pt-1.5 font-medium text-white">
                 <span>Total</span>
                 <span>{formatCurrency(calc.totalWithFee)}</span>
               </div>
-              <div className="flex justify-between text-blue-400 font-medium">
+              <div className="flex justify-between font-medium text-radiant-gold">
                 <span>{numInstallments} monthly payments of</span>
                 <span>{formatCurrency(calc.installmentAmount)}/mo</span>
               </div>
@@ -174,7 +174,7 @@ export default function InstallmentOption({
             <button
               type="button"
               onClick={() => setShowSchedule(!showSchedule)}
-              className="flex items-center gap-1.5 text-xs text-gray-500 hover:text-gray-300 transition-colors"
+              className="flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
             >
               <DollarSign className="w-3 h-3" />
               View payment schedule
@@ -184,7 +184,7 @@ export default function InstallmentOption({
             {showSchedule && (
               <div className="space-y-1">
                 {schedule.map((item) => (
-                  <div key={item.number} className="flex justify-between text-xs text-gray-400">
+                  <div key={item.number} className="flex justify-between text-xs text-muted-foreground">
                     <span>
                       Payment {item.number} &middot;{' '}
                       {item.date.toLocaleDateString('en-US', { month: 'short', year: 'numeric' })}
@@ -195,7 +195,7 @@ export default function InstallmentOption({
               </div>
             )}
 
-            <p className="text-[11px] text-gray-600">
+            <p className="text-[11px] text-muted-foreground/70">
               A card will be saved on file and charged automatically each month.
             </p>
           </div>

--- a/components/checkout/OrderSummary.tsx
+++ b/components/checkout/OrderSummary.tsx
@@ -159,11 +159,12 @@ export default function OrderSummary({
   }
 
   return (
-    <div className="bg-silicon-slate border border-silicon-slate rounded-xl p-6">
-      <h2 className="text-xl font-bold mb-4">Order Summary</h2>
+    <div className="agent-ops-card rounded-xl border p-5 sm:p-6 lg:sticky lg:top-24">
+      <p className="agent-ops-eyebrow mb-2">Order</p>
+      <h2 className="text-xl font-bold mb-4">Order summary</h2>
 
       {/* Items */}
-      <div className="space-y-4 mb-4 max-h-96 overflow-y-auto">
+      <div className="mb-4 max-h-96 space-y-4 overflow-y-auto pr-1">
         {cartItems.map((item) => {
           // Render service item
           if (item.itemType === 'service' && item.serviceId) {
@@ -176,7 +177,7 @@ export default function OrderSummary({
               <motion.div
                 key={getUniqueKey(item)}
                 layout
-                className="bg-silicon-slate/50 rounded-lg p-3"
+                className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-3"
               >
                 <div className="flex items-start gap-3">
                   {/* Service Image */}
@@ -198,7 +199,7 @@ export default function OrderSummary({
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2">
                       <p className="text-white font-medium text-sm line-clamp-1">{service.title}</p>
-                      <span className="px-1.5 py-0.5 text-[10px] bg-radiant-gold/20 text-radiant-gold rounded">
+                      <span className="rounded border border-radiant-gold/35 bg-radiant-gold/10 px-1.5 py-0.5 text-[10px] text-radiant-gold">
                         Service
                       </span>
                     </div>
@@ -224,10 +225,10 @@ export default function OrderSummary({
                     {editable ? (
                       <div className="flex items-center gap-2 mt-2">
                         {/* Quantity Controls */}
-                        <div className="flex items-center gap-1 bg-silicon-slate rounded">
+                        <div className="flex items-center gap-1 rounded border border-silicon-slate/70 bg-silicon-slate/30">
                           <button
                             onClick={() => onServiceQuantityChange?.(item.serviceId!, Math.max(1, item.quantity - 1))}
-                            className="p-1 hover:bg-radiant-gold/30 rounded-l transition-colors"
+                            className="rounded-l p-1 transition-colors hover:bg-radiant-gold/20"
                             title="Decrease quantity"
                           >
                             <Minus size={12} />
@@ -237,7 +238,7 @@ export default function OrderSummary({
                           </span>
                           <button
                             onClick={() => onServiceQuantityChange?.(item.serviceId!, item.quantity + 1)}
-                            className="p-1 hover:bg-radiant-gold/30 rounded-r transition-colors"
+                            className="rounded-r p-1 transition-colors hover:bg-radiant-gold/20"
                             title="Increase quantity"
                           >
                             <Plus size={12} />
@@ -247,7 +248,7 @@ export default function OrderSummary({
                         {/* Delete Button */}
                         <button
                           onClick={() => onRemoveService?.(item.serviceId!)}
-                          className="p-1.5 bg-silicon-slate hover:bg-red-600/20 text-muted-foreground hover:text-red-400 rounded transition-colors ml-auto"
+                          className="ml-auto rounded border border-silicon-slate/70 bg-silicon-slate/20 p-1.5 text-muted-foreground transition-colors hover:border-red-400/40 hover:bg-red-500/10 hover:text-red-300"
                           title="Remove item"
                         >
                           <Trash2 size={12} />
@@ -286,7 +287,7 @@ export default function OrderSummary({
               <motion.div
                 key={getUniqueKey(item)}
                 layout
-                className="bg-silicon-slate/50 rounded-lg p-3"
+                className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-3"
               >
                 <div className="flex items-start gap-3">
                   {/* Product Image */}
@@ -326,10 +327,10 @@ export default function OrderSummary({
                     {editable ? (
                       <div className="flex items-center gap-2 mt-2">
                         {/* Quantity Controls */}
-                        <div className="flex items-center gap-1 bg-silicon-slate rounded">
+                        <div className="flex items-center gap-1 rounded border border-silicon-slate/70 bg-silicon-slate/30">
                           <button
                             onClick={() => onQuantityChange?.(item.productId!, Math.max(1, item.quantity - 1), item.variantId)}
-                            className="p-1 hover:bg-radiant-gold/30 rounded-l transition-colors"
+                            className="rounded-l p-1 transition-colors hover:bg-radiant-gold/20"
                             title="Decrease quantity"
                           >
                             <Minus size={12} />
@@ -339,7 +340,7 @@ export default function OrderSummary({
                           </span>
                           <button
                             onClick={() => onQuantityChange?.(item.productId!, item.quantity + 1, item.variantId)}
-                            className="p-1 hover:bg-radiant-gold/30 rounded-r transition-colors"
+                            className="rounded-r p-1 transition-colors hover:bg-radiant-gold/20"
                             title="Increase quantity"
                           >
                             <Plus size={12} />
@@ -351,7 +352,7 @@ export default function OrderSummary({
                           <button
                             onClick={() => setEditingItem(isEditing ? null : { productId: item.productId!, variantId: item.variantId })}
                             className={`p-1.5 rounded transition-colors ${
-                              isEditing ? 'bg-radiant-gold text-imperial-navy' : 'bg-silicon-slate hover:bg-radiant-gold/30 text-foreground'
+                              isEditing ? 'bg-radiant-gold text-imperial-navy' : 'border border-silicon-slate/70 bg-silicon-slate/20 text-foreground hover:bg-radiant-gold/20'
                             }`}
                             title="Edit size/color"
                           >
@@ -362,7 +363,7 @@ export default function OrderSummary({
                         {/* Delete Button */}
                         <button
                           onClick={() => onRemoveItem?.(item.productId!, item.variantId)}
-                          className="p-1.5 bg-silicon-slate hover:bg-red-600/20 text-muted-foreground hover:text-red-400 rounded transition-colors ml-auto"
+                          className="ml-auto rounded border border-silicon-slate/70 bg-silicon-slate/20 p-1.5 text-muted-foreground transition-colors hover:border-red-400/40 hover:bg-red-500/10 hover:text-red-300"
                           title="Remove item"
                         >
                           <Trash2 size={12} />
@@ -404,9 +405,9 @@ export default function OrderSummary({
       </div>
 
       {/* Totals */}
-      <div className="border-t border-silicon-slate pt-4 space-y-2">
+      <div className="space-y-2 border-t border-silicon-slate/70 pt-4">
         {hasQuoteBasedItems && (
-          <div className="p-2 bg-yellow-600/10 border border-yellow-600/30 rounded text-xs text-yellow-400 mb-2">
+          <div className="mb-2 rounded border border-yellow-500/35 bg-yellow-500/10 p-2 text-xs text-yellow-300">
             Some items require a custom quote
           </div>
         )}
@@ -443,7 +444,7 @@ export default function OrderSummary({
         {activeCampaign && (
           <Link
             href={`/campaigns/${activeCampaign.slug}`}
-            className="mt-3 flex items-center gap-2 p-2 bg-amber-600/10 border border-amber-600/30 rounded text-xs text-amber-400 hover:bg-amber-600/20 transition-colors"
+            className="mt-3 flex items-center gap-2 rounded border border-radiant-gold/35 bg-radiant-gold/10 p-2 text-xs text-radiant-gold transition-colors hover:bg-radiant-gold/15"
           >
             <Sparkles className="w-3.5 h-3.5 flex-shrink-0" />
             <span>Eligible for: <strong>{activeCampaign.name}</strong></span>
@@ -517,13 +518,13 @@ function VariantEditor({
       initial={{ opacity: 0, height: 0 }}
       animate={{ opacity: 1, height: 'auto' }}
       exit={{ opacity: 0, height: 0 }}
-      className="mt-3 pt-3 border-t border-silicon-slate"
+      className="mt-3 border-t border-silicon-slate/70 pt-3"
     >
       <div className="flex items-center justify-between mb-3">
         <span className="text-xs font-medium text-muted-foreground">Edit Options</span>
         <button
           onClick={onClose}
-          className="p-1 hover:bg-silicon-slate rounded transition-colors"
+          className="rounded border border-transparent p-1 transition-colors hover:border-silicon-slate/70 hover:bg-silicon-slate/25"
         >
           <X size={14} className="text-muted-foreground" />
         </button>
@@ -547,8 +548,8 @@ function VariantEditor({
                     isSelected
                       ? 'bg-radiant-gold text-imperial-navy'
                       : isAvailable
-                      ? 'bg-silicon-slate text-foreground hover:bg-radiant-gold/30'
-                      : 'bg-silicon-slate text-muted-foreground cursor-not-allowed'
+                      ? 'border border-silicon-slate/70 bg-silicon-slate/20 text-foreground hover:bg-radiant-gold/20'
+                      : 'border border-silicon-slate/50 bg-silicon-slate/10 text-muted-foreground cursor-not-allowed'
                   }`}
                 >
                   {size}
@@ -577,8 +578,8 @@ function VariantEditor({
                     isSelected
                       ? 'bg-radiant-gold text-imperial-navy'
                       : isAvailable
-                      ? 'bg-silicon-slate text-foreground hover:bg-radiant-gold/30'
-                      : 'bg-silicon-slate text-muted-foreground cursor-not-allowed'
+                      ? 'border border-silicon-slate/70 bg-silicon-slate/20 text-foreground hover:bg-radiant-gold/20'
+                      : 'border border-silicon-slate/50 bg-silicon-slate/10 text-muted-foreground cursor-not-allowed'
                   }`}
                 >
                   {color}
@@ -596,7 +597,7 @@ function VariantEditor({
         className={`w-full py-2 text-xs font-medium rounded transition-colors flex items-center justify-center gap-1.5 ${
           selectedVariant && selectedVariant.id !== currentVariantId
             ? 'btn-gold'
-            : 'bg-silicon-slate text-muted-foreground cursor-not-allowed'
+            : 'border border-silicon-slate/70 bg-silicon-slate/20 text-muted-foreground cursor-not-allowed'
         }`}
       >
         <Check size={14} />

--- a/docs/design/amadutown-color-palette-audit.md
+++ b/docs/design/amadutown-color-palette-audit.md
@@ -38,8 +38,9 @@ The Agent Ops Mission Control surface at `/admin/agents` is the current referenc
 - **Outreach/Sales workflow polish:** Lead Pipeline rows, Outreach Dashboard metrics/activity, escalation links, and Sales Dashboard table actions now use the shared console palette for their nested workflow controls and status affordances.
 - **Sales subpage slice:** `/admin/sales/products`, `/admin/sales/bundles`, `/admin/sales/scripts`, `/admin/sales/upsell-paths`, and `/admin/sales/implementation-roadmap` now use the shared admin console shell, surface headers, metric cards, muted form controls, and gold command actions.
 - **Auth slice:** Login, signup, forgot-password, and reset-password now use the AmaduTown operating-console language so the entry point no longer feels visually disconnected from admin.
-- **Public commerce catalog slice:** `/store`, `/store/[id]`, `ProductCard`, `ServiceCard`, and `ShoppingCart` now use the Mission Control navy/gold surface language, gold command affordances, and restrained status badges. Checkout remains a separate commerce-flow pass.
-- **Next rollout candidates:** deeper content, checkout, public services, and client-facing detail pages still carry older gray, blue, purple, and cyan styling and should move to the same primitives in smaller follow-up PRs.
+- **Public commerce catalog slice:** `/store`, `/store/[id]`, `ProductCard`, `ServiceCard`, and `ShoppingCart` now use the Mission Control navy/gold surface language, gold command affordances, and restrained status badges.
+- **Checkout/payment slice:** `/checkout`, `/checkout/payment`, and the shared checkout subcomponents now use the same dark operating-console shell, command-card hierarchy, navy/gold payment controls, and restrained semantic states.
+- **Next rollout candidates:** deeper content, public services, purchases, and client-facing detail pages still carry older gray, blue, purple, and cyan styling and should move to the same primitives in smaller follow-up PRs.
 
 ---
 
@@ -49,7 +50,7 @@ The Agent Ops Mission Control surface at `/admin/agents` is the current referenc
 |---------------------------|---------------|----------------------------|----------|
 | Store product detail | Gray-based UI, Cyan/blue accents, Cyan–blue gradient CTA | `app/store/[id]/page.tsx` (gray-*, cyan-*, from-cyan-600 to-blue-600) | High |
 | Store listing | Gray, blue–purple gradient CTA | `app/store/page.tsx` (gray-400, from-blue-600 to-purple-600) | High |
-| Checkout | Gray-based UI, blue–purple gradients, purple hover, amber icon | `app/checkout/page.tsx` (gray-*, from-blue-600 to-purple-600, border-purple-500, amber-400) | High |
+| Checkout | Remediated: Mission Control checkout shell, navy/gold command cards, restrained payment and delivery controls | `app/checkout/page.tsx`, `app/checkout/payment/page.tsx` | Done |
 | Auth (login/signup) | Gray-based UI, purple focus, purple–pink gradient CTAs, purple links | `components/auth/LoginForm.tsx`, `SignupForm.tsx` (gray-*, focus:border-purple-500, from-purple-600 to-pink-600, text-purple-400) | High |
 | Auth pages (suspense) | Gray loading text | `app/auth/login/page.tsx`, `app/auth/signup/page.tsx` (text-gray-400) | Low |
 | Services (public) | Gray search icon, cyan–blue gradients | `app/services/page.tsx`, `app/services/[id]/page.tsx` (gray-400, from-cyan-*, to-blue-*) | Medium |
@@ -83,10 +84,10 @@ The Agent Ops Mission Control surface at `/admin/agents` is the current referenc
 | Product classifier (admin) | Light gray/white UI (full off-palette), blue/purple/emerald accents | `components/admin/sales/ProductClassifier.tsx` (gray-100, white, blue-600, purple-600, emerald-600) | High |
 | Referral program | Gray inputs, purple/blue/green icons | `components/ReferralProgram.tsx` | Low |
 | Proposal modal | Blue accent blocks and CTA | `components/admin/sales/ProposalModal.tsx` | Medium |
-| Discount code form (checkout) | Gray icon, purple focus/hover, green success | `components/checkout/DiscountCodeForm.tsx` | Medium |
-| Contact form (checkout) | Gray icons | `components/checkout/ContactForm.tsx` (text-gray-400) | Low |
-| Order summary | Blue–green/purple–blue item gradients | `components/checkout/OrderSummary.tsx` | Low |
-| Stripe/checkout CTAs | (see Checkout page) | — | — |
+| Discount code form (checkout) | Remediated: responsive navy/gold form controls with semantic success state | `components/checkout/DiscountCodeForm.tsx` | Done |
+| Contact form (checkout) | Remediated: shared command button treatment | `components/checkout/ContactForm.tsx` | Done |
+| Order summary | Remediated: agent-ops summary card, restrained item rows, navy/gold quantity and variant controls | `components/checkout/OrderSummary.tsx` | Done |
+| Stripe/checkout CTAs | Remediated in checkout/payment slice | `app/checkout/payment/page.tsx`, `components/checkout/StripeCheckout.tsx` | Done |
 | Shopping cart | Blue–purple gradient CTA, blue–green/purple–blue item gradients | `components/ShoppingCart.tsx` | Medium |
 | Product card | Purple–blue card gradient, blue–purple CTA, green price | `components/ProductCard.tsx` | Medium |
 | Service card | Cyan–blue gradient, cyan–blue CTA | `components/ServiceCard.tsx` | Medium |
@@ -107,8 +108,8 @@ The Agent Ops Mission Control surface at `/admin/agents` is the current referenc
 
 - **`app/store/[id]/page.tsx`** — Product detail: gray backgrounds/borders/text (gray-400, gray-800, gray-900, etc.), cyan/blue hero gradient (from-cyan-900/20 to-blue-900/20), cyan badges and links (text-cyan-400, bg-cyan-500/90), primary CTA as cyan–blue gradient (from-cyan-600 to-blue-600). Whole page is off-palette.
 - **`app/store/page.tsx`** — Store listing: gray-400 search icon, primary CTA as blue–purple gradient (from-blue-600 to-purple-600).
-- **`app/checkout/page.tsx`** — Checkout: gray containers and text (gray-400, gray-800, gray-900), Lock icon amber-400, primary pay CTA blue–purple gradient, secondary CTA purple hover (hover:border-purple-500).
-- **`app/checkout/payment/page.tsx`** — (Included in files list; same checkout flow.)
+- **`app/checkout/page.tsx`** — Remediated in the checkout/payment slice: dark operating-console shell, command-card sign-in gate, surface header, delivery/payment cards, and navy/gold controls.
+- **`app/checkout/payment/page.tsx`** — Remediated in the checkout/payment slice: secure payment surface, restrained error state, and agent-ops cards around Stripe payment content.
 - **`app/purchases/page.tsx`** — Blue–purple gradient CTAs; green used for success/status (semantic).
 - **`app/lead-magnets/page.tsx`** — Gray loading/empty text (text-gray-400).
 
@@ -133,9 +134,9 @@ The Agent Ops Mission Control surface at `/admin/agents` is the current referenc
 
 ### Shared – Checkout & cart components
 
-- **`components/checkout/DiscountCodeForm.tsx`** — Gray-400 icon, focus:border-purple-500, hover:border-purple-500; green success box (semantic).
-- **`components/checkout/ContactForm.tsx`** — Gray-400 icons.
-- **`components/checkout/OrderSummary.tsx`** — Item thumbnails: from-blue-900/20 to-green-900/20 and from-purple-900/20 to-blue-900/20; green price text.
+- **`components/checkout/DiscountCodeForm.tsx`** — Remediated in checkout/payment slice with responsive navy/gold controls and restrained semantic success/error states.
+- **`components/checkout/ContactForm.tsx`** — Remediated in checkout/payment slice by using the shared command-button treatment.
+- **`components/checkout/OrderSummary.tsx`** — Remediated in checkout/payment slice with agent-ops card treatment, subdued item rows, and gold-focused editable controls.
 - **`components/ShoppingCart.tsx`** — Same thumbnail gradients; primary CTA from-blue-600 to-purple-600.
 - **`components/ProductCard.tsx`** — Card hero from-purple-900/20 to-blue-900/20; CTA from-blue-600 to-purple-600; green for price/Free.
 - **`components/ServiceCard.tsx`** — Card from-cyan-900/20 to-blue-900/20; CTA from-cyan-600 to-blue-600.


### PR DESCRIPTION
## Summary
- Align `/checkout` and `/checkout/payment` with the Mission Control / AmaduTown operating-console design language.
- Update checkout cards, payment options, discount form, campaign banner, and order summary to use navy/gold command surfaces with restrained semantic states.
- Mark the checkout/payment slice as remediated in the AmaduTown color palette audit.

## Validation
- `npm run worktree:env -- --source /Users/vambahsillah/Projects/Portfolio` linked `.env.local` and `.vercel`; `.env.staging` was absent in the source checkout.
- `npm run lint -- --file app/checkout/page.tsx --file app/checkout/payment/page.tsx --file components/checkout/OrderSummary.tsx --file components/checkout/DiscountCodeForm.tsx --file components/checkout/InstallmentOption.tsx --file components/checkout/CampaignEnrollmentBanner.tsx --file components/checkout/ContactForm.tsx`
- `npx tsx scripts/build-chatbot-knowledge.ts`
- `npx tsc --noEmit --pretty false`
- `npm run lint`
- Browser QA on `http://127.0.0.1:3023/store`, `/checkout`, and `/checkout/payment`:
  - added a store item to cart,
  - verified the checkout sign-in gate renders in the new visual system,
  - verified the missing-order payment error state renders without console errors.
- `npm run build`

## Integration Notes
- No database, schema, API, payment, Stripe, n8n, or production workflow behavior changed.
- Build emitted the existing local env warning: `MOCK_N8N=false` and `N8N_DISABLE_OUTBOUND=false`; no n8n workflow or outbound webhook was executed.
- Vercel checks pending after merge: `Vercel – portfolio` and `Vercel – portfolio-staging`.
