### PR TITLE
fix: reserve store search icon spacing

### DIFF
--- a/app/store/page.tsx
+++ b/app/store/page.tsx
@@ -320,13 +320,13 @@ function StoreContent() {
               {/* Search and Filters */}
               <div className="flex flex-col gap-4 md:flex-row">
                 <div className="relative flex-1">
-                  <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" size={20} />
+                  <Search className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-muted-foreground" size={20} />
                   <input
                     type="text"
                     placeholder="Search store..."
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
-                    className="w-full pl-10 pr-4 py-2 input-brand"
+                    className="w-full py-2 !pl-12 pr-4 input-brand"
                   />
                 </div>
                 <div className="flex flex-wrap gap-2">


### PR DESCRIPTION
## Summary
- reserve enough left padding in the public store search input so placeholder/value text no longer overlaps the search icon
- make the search icon non-interactive and align it with the updated input spacing

## Validation
- Pre-implementation conflict preflight: clean root `main`, no open PRs, no sibling worktree overlap
- Environment bootstrap: linked `.env.local` and `.vercel` from Portfolio root via `npm run worktree:env`; `.env.staging` was not present in the source checkout
- Playwright QA on `http://127.0.0.1:3024/store` at 987x998: rendered input padding-left `48px`, icon right edge `77px`, text start `89px`, 12px gap, no console errors
- `npm run lint -- --file app/store/page.tsx`
- `npx tsc --noEmit --pretty false` after regenerating the local ignored chatbot knowledge artifact
- `npm run lint`
- `npm run build`
- Push hook database health check passed

## Integration Notes
- UI-only hotfix; no schema, API, or data mutation changes
- Build emitted the existing local env warning that `MOCK_N8N=false` and `N8N_DISABLE_OUTBOUND=false`; no n8n workflow or outbound webhook was executed
- Vercel contexts to verify after merge: `Vercel – portfolio` and `Vercel – portfolio-staging`
