### PR TITLE
feat: expose delegation governance evidence

### DIFF
--- a/app/admin/agents/page.test.tsx
+++ b/app/admin/agents/page.test.tsx
@@ -176,10 +176,23 @@ const missionSnapshot = {
     ],
     pending_authority_approvals: [
       {
+        id: 'approval-payment',
         run_id: 'payment-run',
         approval_type: 'payment_create_refund',
         status: 'pending',
         requested_at: '2026-05-13T11:30:00.000Z',
+        requested_by_agent_key: 'chief-of-staff',
+        metadata: {
+          authority_packet: {
+            approval_id: 'approval-payment',
+            source_run_id: 'delegation-run',
+            action: 'create_refund',
+            label: 'Create refund',
+            risk_level: 'high',
+            side_effect_boundary: 'No refund is issued until this payment authority checkpoint is approved and linked to a trace.',
+            executes_action: false,
+          },
+        },
       },
     ],
     recent_delegation_decisions: [
@@ -493,7 +506,9 @@ describe('AgentOperationsPage mission control landing', () => {
     expect(within(governancePanel).getByText(/payment · 90% confidence/i)).toBeInTheDocument()
     expect(within(governancePanel).getByText(/Evidence: approval_record, payment_object, trace_id/i)).toBeInTheDocument()
     expect(within(governancePanel).getByText(/Approval: payment_create_refund · Fallback: chief-of-staff/i)).toBeInTheDocument()
-    expect(within(governancePanel).getByText(/1 pending authority checkpoint/i)).toBeInTheDocument()
+    expect(within(governancePanel).getByText('Create refund')).toBeInTheDocument()
+    expect(within(governancePanel).getByText('No refund is issued until this payment authority checkpoint is approved and linked to a trace.')).toBeInTheDocument()
+    expect(within(governancePanel).getByText(/Risk: high · Executes now: no/i)).toBeInTheDocument()
     expect(within(governancePanel).getByRole('link', { name: /Export client audit/i })).toHaveAttribute('href', '/api/admin/agents/governance/export?format=markdown')
     expect(within(governancePanel).getByRole('link', { name: /Export audit JSON/i })).toHaveAttribute('href', '/api/admin/agents/governance/export?format=json')
     expect(within(governancePanel).getByRole('link', { name: /Export latest trace/i })).toHaveAttribute('href', '/api/admin/agents/governance/export?format=markdown&runId=delegation-run')

--- a/app/admin/agents/page.test.tsx
+++ b/app/admin/agents/page.test.tsx
@@ -192,6 +192,10 @@ const missionSnapshot = {
         confidence: 0.9,
         occurred_at: '2026-05-13T11:40:00.000Z',
         reason: 'Yaa Asantewaa matches payment work.',
+        required_evidence: ['approval_record', 'payment_object', 'trace_id'],
+        approval_gate: 'payment_create_refund',
+        fallback_agent_key: 'chief-of-staff',
+        alternatives_considered: ['chief-of-staff'],
       },
     ],
     recent_governance_exports: [
@@ -487,6 +491,8 @@ describe('AgentOperationsPage mission control landing', () => {
     expect(within(governancePanel).getAllByText('Yaa Asantewaa (Ashanti) - Automation Systems').length).toBeGreaterThan(0)
     expect(within(governancePanel).getByText('Spend gated')).toBeInTheDocument()
     expect(within(governancePanel).getByText(/payment · 90% confidence/i)).toBeInTheDocument()
+    expect(within(governancePanel).getByText(/Evidence: approval_record, payment_object, trace_id/i)).toBeInTheDocument()
+    expect(within(governancePanel).getByText(/Approval: payment_create_refund · Fallback: chief-of-staff/i)).toBeInTheDocument()
     expect(within(governancePanel).getByText(/1 pending authority checkpoint/i)).toBeInTheDocument()
     expect(within(governancePanel).getByRole('link', { name: /Export client audit/i })).toHaveAttribute('href', '/api/admin/agents/governance/export?format=markdown')
     expect(within(governancePanel).getByRole('link', { name: /Export audit JSON/i })).toHaveAttribute('href', '/api/admin/agents/governance/export?format=json')

--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -215,10 +215,13 @@ type MissionSnapshot = {
       description: string
     }>
     pending_authority_approvals: Array<{
+      id?: string
       run_id: string
       approval_type: string
       status: string
       requested_at: string
+      requested_by_agent_key?: string | null
+      metadata?: Record<string, unknown> | null
     }>
     recent_delegation_decisions: Array<{
       run_id: string
@@ -1932,6 +1935,7 @@ function AgentGovernancePanel({ governance }: { governance: MissionSnapshot['gov
   const latestDelegation = governance.recent_delegation_decisions[0]
   const latestPaymentAction = governance.payment_authority_actions[0]
   const pendingAuthority = governance.pending_authority_approvals[0]
+  const pendingAuthorityPacket = authorityPacket(pendingAuthority?.metadata)
   const statusTone = governance.summary.pending_authority_approvals > 0
     ? 'yellow'
     : governance.summary.least_privilege_attention > 0
@@ -2060,17 +2064,37 @@ function AgentGovernancePanel({ governance }: { governance: MissionSnapshot['gov
             <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Payment authority</p>
             <p className="mt-2 text-sm font-semibold">
               {governance.pending_authority_approvals.length
-                ? `${governance.pending_authority_approvals.length} pending authority checkpoint(s)`
+                ? pendingAuthorityPacket?.label ?? `${governance.pending_authority_approvals.length} pending authority checkpoint(s)`
                 : latestPaymentAction?.label ?? 'Payment gates ready'}
             </p>
             <p className="mt-1 text-xs leading-5 text-muted-foreground">
-              Payment, refund, subscription, vendor spend, paid API, and paid external job actions require trace-linked approval.
+              {pendingAuthorityPacket?.side_effect_boundary ??
+                'Payment, refund, subscription, vendor spend, paid API, and paid external job actions require trace-linked approval.'}
             </p>
+            {pendingAuthority ? (
+              <p className="mt-2 text-xs leading-5 text-muted-foreground">
+                {pendingAuthorityPacket?.risk_level ? `Risk: ${pendingAuthorityPacket.risk_level}` : `Approval: ${pendingAuthority.approval_type}`}
+                {' · '}
+                {pendingAuthorityPacket?.executes_action ? 'Executes now: yes' : 'Executes now: no'}
+              </p>
+            ) : null}
           </Link>
         </div>
       </div>
     </section>
   )
+}
+
+function authorityPacket(metadata: Record<string, unknown> | null | undefined) {
+  const value = metadata?.authority_packet
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const record = value as Record<string, unknown>
+  return {
+    label: typeof record.label === 'string' ? record.label : null,
+    risk_level: typeof record.risk_level === 'string' ? record.risk_level : null,
+    side_effect_boundary: typeof record.side_effect_boundary === 'string' ? record.side_effect_boundary : null,
+    executes_action: record.executes_action === true,
+  }
 }
 
 function GovernanceExportLedger({ exports }: { exports: NonNullable<MissionSnapshot['governance']>['recent_governance_exports'] }) {

--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -229,6 +229,10 @@ type MissionSnapshot = {
       confidence: number
       occurred_at: string
       reason: string
+      required_evidence: string[]
+      approval_gate: string | null
+      fallback_agent_key: string | null
+      alternatives_considered: string[]
     }>
     recent_governance_exports: Array<{
       id: string
@@ -2035,6 +2039,18 @@ function AgentGovernancePanel({ governance }: { governance: MissionSnapshot['gov
                 ? `${latestDelegation.task_type.replace(/_/g, ' ')} · ${Math.round(latestDelegation.confidence * 100)}% confidence`
                 : 'Shaka will record deterministic delegation events when routed engagements are proposed.'}
             </p>
+            {latestDelegation?.required_evidence.length ? (
+              <p className="mt-2 text-xs leading-5 text-muted-foreground">
+                Evidence: {latestDelegation.required_evidence.slice(0, 3).join(', ')}
+              </p>
+            ) : null}
+            {latestDelegation?.approval_gate || latestDelegation?.fallback_agent_key ? (
+              <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                {latestDelegation.approval_gate ? `Approval: ${latestDelegation.approval_gate}` : 'Approval: none'}
+                {' · '}
+                {latestDelegation.fallback_agent_key ? `Fallback: ${latestDelegation.fallback_agent_key}` : 'Fallback: none'}
+              </p>
+            ) : null}
           </Link>
 
           <Link

--- a/lib/agent-governance-export.test.ts
+++ b/lib/agent-governance-export.test.ts
@@ -58,10 +58,23 @@ const governance = {
   ],
   pending_authority_approvals: [
     {
+      id: 'approval-payment',
       run_id: 'run-payment',
       approval_type: 'payment_create_refund',
       status: 'pending',
       requested_at: '2026-05-21T00:01:00.000Z',
+      requested_by_agent_key: 'chief-of-staff',
+      metadata: {
+        authority_packet: {
+          approval_id: 'approval-payment',
+          source_run_id: 'run-source',
+          action: 'create_refund',
+          label: 'Create refund',
+          risk_level: 'high',
+          side_effect_boundary: 'No refund is issued until this payment authority checkpoint is approved and linked to a trace.',
+          executes_action: false,
+        },
+      },
     },
   ],
   recent_delegation_decisions: [
@@ -90,6 +103,14 @@ describe('agent governance client export', () => {
     expect(clientExport.classification).toBe('client_safe')
     expect(clientExport.scope.description).toBe('Current governance snapshot.')
     expect(clientExport.summary.pending_authority_approvals).toBe(1)
+    expect(clientExport.authority_controls.pending_authority_checkpoints[0]).toMatchObject({
+      approval_id: 'approval-payment',
+      label: 'Create refund',
+      action: 'create_refund',
+      risk_level: 'high',
+      source_run_id: 'run-source',
+      executes_action: false,
+    })
     expect(clientExport.capability_inventory[1]).toMatchObject({
       agent: 'Yaa Asantewaa (Ashanti) - Automation Systems',
       spend_authority: 'approval_required',
@@ -114,6 +135,7 @@ describe('agent governance client export', () => {
     expect(markdown).toContain('## Capability Inventory')
     expect(markdown).toContain('| Yaa Asantewaa (Ashanti) - Automation Systems | active | n8n | yellow | approval_required | known_workflow |')
     expect(markdown).toContain('| run-delegation | Yaa Asantewaa (Ashanti) - Automation Systems | payment | payment_spend | 90% | approval_record, payment_object, trace_id | payment_create_refund | chief-of-staff |')
+    expect(markdown).toContain('| approval-payment | run-payment | Create refund | payment_create_refund | high | No | run-source | No refund is issued until this payment authority checkpoint is approved and linked to a trace. |')
     expect(markdown).toContain('Payment and paid-job actions are represented as approval gates')
   })
 

--- a/lib/agent-governance-export.test.ts
+++ b/lib/agent-governance-export.test.ts
@@ -74,6 +74,10 @@ const governance = {
       confidence: 0.9,
       occurred_at: '2026-05-21T00:02:00.000Z',
       reason: 'Payment work routes to automation systems.',
+      required_evidence: ['approval_record', 'payment_object', 'trace_id'],
+      approval_gate: 'payment_create_refund',
+      fallback_agent_key: 'chief-of-staff',
+      alternatives_considered: ['chief-of-staff'],
     },
   ],
   recent_governance_exports: [],
@@ -93,6 +97,9 @@ describe('agent governance client export', () => {
     expect(clientExport.delegation_trace[0]).toMatchObject({
       trace_reference: 'run-delegation',
       confidence: '90%',
+      required_evidence: ['approval_record', 'payment_object', 'trace_id'],
+      approval_gate: 'payment_create_refund',
+      fallback_agent: 'chief-of-staff',
     })
     expect(JSON.stringify(clientExport)).not.toContain('selected_agent_key')
     expect(clientExport.audit_boundaries.join(' ')).toContain('excludes raw prompts')
@@ -106,7 +113,7 @@ describe('agent governance client export', () => {
     expect(markdown).toContain('- Run ID: All visible governance runs')
     expect(markdown).toContain('## Capability Inventory')
     expect(markdown).toContain('| Yaa Asantewaa (Ashanti) - Automation Systems | active | n8n | yellow | approval_required | known_workflow |')
-    expect(markdown).toContain('| run-delegation | Yaa Asantewaa (Ashanti) - Automation Systems | payment | payment_spend | 90% |')
+    expect(markdown).toContain('| run-delegation | Yaa Asantewaa (Ashanti) - Automation Systems | payment | payment_spend | 90% | approval_record, payment_object, trace_id | payment_create_refund | chief-of-staff |')
     expect(markdown).toContain('Payment and paid-job actions are represented as approval gates')
   })
 

--- a/lib/agent-governance-export.ts
+++ b/lib/agent-governance-export.ts
@@ -42,6 +42,10 @@ export type AgentGovernanceClientExport = {
     confidence: string
     occurred_at: string
     reason: string
+    required_evidence: string[]
+    approval_gate: string | null
+    fallback_agent: string | null
+    alternatives_considered: string[]
   }>
   authority_controls: {
     payment_gates: Array<{
@@ -116,6 +120,10 @@ export function buildAgentGovernanceClientExport(
       confidence: percent(decision.confidence),
       occurred_at: decision.occurred_at,
       reason: decision.reason,
+      required_evidence: decision.required_evidence,
+      approval_gate: decision.approval_gate,
+      fallback_agent: decision.fallback_agent_key,
+      alternatives_considered: decision.alternatives_considered,
     })),
     authority_controls: {
       payment_gates: governance.payment_authority_actions.map((gate) => ({
@@ -147,9 +155,9 @@ export function formatAgentGovernanceClientMarkdown(clientExport: AgentGovernanc
 
   const delegationRows = clientExport.delegation_trace.length
     ? clientExport.delegation_trace.map((decision) =>
-        `| ${decision.trace_reference} | ${decision.selected_agent} | ${decision.task_type} | ${decision.risk_class} | ${decision.confidence} |`,
+        `| ${decision.trace_reference} | ${decision.selected_agent} | ${decision.task_type} | ${decision.risk_class} | ${decision.confidence} | ${decision.required_evidence.length ? decision.required_evidence.join(', ') : 'None recorded'} | ${decision.approval_gate ?? 'None'} | ${decision.fallback_agent ?? 'None'} |`,
       )
-    : ['| No recent delegation decisions recorded. | - | - | - | - |']
+    : ['| No recent delegation decisions recorded. | - | - | - | - | - | - | - |']
 
   const paymentRows = clientExport.authority_controls.payment_gates.map((gate) =>
     `| ${gate.label} | ${gate.approval_type} | ${gate.description} |`,
@@ -198,8 +206,8 @@ export function formatAgentGovernanceClientMarkdown(clientExport: AgentGovernanc
     '',
     '## Delegation Trace',
     '',
-    '| Trace | Selected Agent | Task | Risk | Confidence |',
-    '| --- | --- | --- | --- | --- |',
+    '| Trace | Selected Agent | Task | Risk | Confidence | Required Evidence | Approval Gate | Fallback |',
+    '| --- | --- | --- | --- | --- | --- | --- | --- |',
     ...delegationRows,
     '',
     '## Payment And Spend Authority',

--- a/lib/agent-governance-export.ts
+++ b/lib/agent-governance-export.ts
@@ -55,10 +55,17 @@ export type AgentGovernanceClientExport = {
       description: string
     }>
     pending_authority_checkpoints: Array<{
+      approval_id: string | null
       trace_reference: string
       approval_type: string
+      label: string
+      action: string | null
+      risk_level: string | null
       status: string
       requested_at: string
+      source_run_id: string | null
+      side_effect_boundary: string | null
+      executes_action: boolean
     }>
   }
   audit_boundaries: string[]
@@ -73,6 +80,16 @@ const AUDIT_BOUNDARIES = [
 
 function percent(value: number) {
   return `${Math.round(value * 100)}%`
+}
+
+function recordValue(record: Record<string, unknown> | null | undefined, key: string) {
+  const value = record?.[key]
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+}
+
+function authorityPacket(metadata: Record<string, unknown> | null | undefined) {
+  const value = metadata?.authority_packet
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null
 }
 
 export function buildAgentGovernanceClientExport(
@@ -133,10 +150,17 @@ export function buildAgentGovernanceClientExport(
         description: gate.description,
       })),
       pending_authority_checkpoints: governance.pending_authority_approvals.map((approval) => ({
+        approval_id: approval.id ?? recordValue(authorityPacket(approval.metadata), 'approval_id'),
         trace_reference: approval.run_id,
         approval_type: approval.approval_type,
+        label: recordValue(authorityPacket(approval.metadata), 'label') ?? approval.approval_type.replace(/_/g, ' '),
+        action: recordValue(authorityPacket(approval.metadata), 'action'),
+        risk_level: recordValue(authorityPacket(approval.metadata), 'risk_level'),
         status: approval.status,
         requested_at: approval.requested_at,
+        source_run_id: recordValue(authorityPacket(approval.metadata), 'source_run_id'),
+        side_effect_boundary: recordValue(authorityPacket(approval.metadata), 'side_effect_boundary'),
+        executes_action: authorityPacket(approval.metadata)?.executes_action === true,
       })),
     },
     audit_boundaries: AUDIT_BOUNDARIES,
@@ -165,9 +189,9 @@ export function formatAgentGovernanceClientMarkdown(clientExport: AgentGovernanc
 
   const pendingRows = clientExport.authority_controls.pending_authority_checkpoints.length
     ? clientExport.authority_controls.pending_authority_checkpoints.map((approval) =>
-        `| ${approval.trace_reference} | ${approval.approval_type} | ${approval.status} | ${approval.requested_at} |`,
+        `| ${approval.approval_id ?? 'None'} | ${approval.trace_reference} | ${approval.label} | ${approval.approval_type} | ${approval.risk_level ?? 'Not recorded'} | ${approval.executes_action ? 'Yes' : 'No'} | ${approval.source_run_id ?? 'None'} | ${approval.side_effect_boundary ?? 'Not recorded'} |`,
       )
-    : ['| No pending authority checkpoints. | - | - | - |']
+    : ['| No pending authority checkpoints. | - | - | - | - | - | - | - |']
 
   return [
     `# ${clientExport.title}`,
@@ -218,8 +242,8 @@ export function formatAgentGovernanceClientMarkdown(clientExport: AgentGovernanc
     '',
     '## Pending Authority Checkpoints',
     '',
-    '| Trace | Approval Type | Status | Requested At |',
-    '| --- | --- | --- | --- |',
+    '| Approval | Trace | Label | Approval Type | Risk | Executes Now | Source Run | Boundary |',
+    '| --- | --- | --- | --- | --- | --- | --- | --- |',
     ...pendingRows,
     '',
     '## Audit Boundaries',

--- a/lib/agent-governance-scope.ts
+++ b/lib/agent-governance-scope.ts
@@ -17,10 +17,13 @@ type ScopedRunRow = {
 }
 
 type ScopedApprovalRow = {
+  id: string
   run_id: string
   approval_type: string
   status: string
   requested_at: string
+  requested_by_agent_key: string | null
+  metadata: Record<string, unknown> | null
 }
 
 type ScopedEventRow = {
@@ -145,7 +148,7 @@ export async function buildScopedAgentGovernanceSnapshot(
   if (!shouldQueryScopedRuns || runIds.length > 0) {
     let approvalsQuery = supabaseAdmin
       .from('agent_approvals')
-      .select('run_id, approval_type, status, requested_at')
+      .select('id, run_id, approval_type, status, requested_at, requested_by_agent_key, metadata')
       .eq('status', 'pending')
       .order('requested_at', { ascending: false })
       .limit(50)

--- a/lib/agent-governance.test.ts
+++ b/lib/agent-governance.test.ts
@@ -41,6 +41,10 @@ describe('agent governance', () => {
             task_type: 'payment',
             risk_class: 'payment_spend',
             confidence: 0.9,
+            required_evidence: ['approval_record', 'payment_object', 'trace_id'],
+            approval_gate: 'payment_create_refund',
+            fallback_agent_key: 'chief-of-staff',
+            alternatives_considered: ['chief-of-staff'],
           },
         },
       ],
@@ -69,6 +73,10 @@ describe('agent governance', () => {
       selected_agent_key: 'automation-systems',
       task_type: 'payment',
       risk_class: 'payment_spend',
+      required_evidence: ['approval_record', 'payment_object', 'trace_id'],
+      approval_gate: 'payment_create_refund',
+      fallback_agent_key: 'chief-of-staff',
+      alternatives_considered: ['chief-of-staff'],
     })
     expect(snapshot.recent_governance_exports[0]).toMatchObject({
       id: 'export-1',

--- a/lib/agent-governance.test.ts
+++ b/lib/agent-governance.test.ts
@@ -22,10 +22,22 @@ describe('agent governance', () => {
     const snapshot = buildAgentGovernanceSnapshot({
       approvals: [
         {
+          id: 'approval-payment',
           run_id: 'run-payment',
           approval_type: 'payment_create_refund',
           status: 'pending',
           requested_at: '2026-05-21T00:00:00.000Z',
+          requested_by_agent_key: 'chief-of-staff',
+          metadata: {
+            action_payload: {
+              source_run_id: 'run-source',
+              action: 'create_refund',
+              label: 'Create refund',
+              risk_level: 'high',
+              side_effect_boundary: 'No refund is issued until this payment authority checkpoint is approved and linked to a trace.',
+              executes_action: false,
+            },
+          },
         },
       ],
       events: [
@@ -69,6 +81,14 @@ describe('agent governance', () => {
     expect(snapshot.summary.payment_authority_actions).toBe(6)
     expect(snapshot.summary.pending_authority_approvals).toBe(1)
     expect(snapshot.pending_authority_approvals[0]?.approval_type).toBe('payment_create_refund')
+    expect(snapshot.pending_authority_approvals[0]?.metadata?.authority_packet).toMatchObject({
+      approval_id: 'approval-payment',
+      source_run_id: 'run-source',
+      action: 'create_refund',
+      label: 'Create refund',
+      risk_level: 'high',
+      executes_action: false,
+    })
     expect(snapshot.recent_delegation_decisions[0]).toMatchObject({
       selected_agent_key: 'automation-systems',
       task_type: 'payment',

--- a/lib/agent-governance.ts
+++ b/lib/agent-governance.ts
@@ -26,10 +26,13 @@ export type AgentCapabilityProfile = {
 }
 
 export type GovernanceApprovalSummary = {
+  id?: string
   run_id: string
   approval_type: string
   status: string
   requested_at: string
+  requested_by_agent_key?: string | null
+  metadata?: Record<string, unknown> | null
 }
 
 export type GovernanceEventSummary = {
@@ -221,6 +224,32 @@ function metadataString(metadata: Record<string, unknown> | null, key: string) {
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
 }
 
+function nestedMetadataRecord(metadata: Record<string, unknown> | null, key: string) {
+  return metadataRecord(metadata?.[key])
+}
+
+function authorityApprovalSummary(approval: GovernanceApprovalSummary): GovernanceApprovalSummary {
+  const metadata = metadataRecord(approval.metadata)
+  const actionPayload = nestedMetadataRecord(metadata, 'action_payload')
+  const proposal = nestedMetadataRecord(metadata, 'proposal')
+
+  return {
+    ...approval,
+    metadata: {
+      ...(metadata ?? {}),
+      authority_packet: {
+        approval_id: approval.id ?? null,
+        source_run_id: metadataString(actionPayload, 'source_run_id') ?? metadataString(metadata, 'source_run_id'),
+        action: metadataString(actionPayload, 'action') ?? metadataString(proposal, 'action'),
+        label: metadataString(actionPayload, 'label') ?? metadataString(proposal, 'label') ?? approval.approval_type.replace(/_/g, ' '),
+        risk_level: metadataString(actionPayload, 'risk_level') ?? metadataString(proposal, 'riskLevel'),
+        side_effect_boundary: metadataString(actionPayload, 'side_effect_boundary'),
+        executes_action: actionPayload?.executes_action === true,
+      },
+    },
+  }
+}
+
 function recentDelegationDecisions(events: GovernanceEventSummary[]): AgentGovernanceSnapshot['recent_delegation_decisions'] {
   return events
     .filter((event) => event.event_type === 'delegation_decision_recorded')
@@ -278,7 +307,7 @@ export function buildAgentGovernanceSnapshot(input?: {
         description: gate?.description ?? 'Payment authority action.',
       }
     }),
-    pending_authority_approvals: pendingAuthorityApprovals.slice(0, 8),
+    pending_authority_approvals: pendingAuthorityApprovals.slice(0, 8).map(authorityApprovalSummary),
     recent_delegation_decisions: recentDelegationDecisions(input?.events ?? []),
     recent_governance_exports: (input?.exports ?? []).slice(0, 8),
   }

--- a/lib/agent-governance.ts
+++ b/lib/agent-governance.ts
@@ -83,6 +83,10 @@ export type AgentGovernanceSnapshot = {
     confidence: number
     occurred_at: string
     reason: string
+    required_evidence: string[]
+    approval_gate: string | null
+    fallback_agent_key: string | null
+    alternatives_considered: string[]
   }>
   recent_governance_exports: GovernanceExportSummary[]
 }
@@ -204,6 +208,19 @@ function metadataRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null
 }
 
+function metadataStringArray(metadata: Record<string, unknown> | null, key: string) {
+  const value = metadata?.[key]
+  if (!Array.isArray(value)) return []
+  return value
+    .filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+    .map((item) => item.trim())
+}
+
+function metadataString(metadata: Record<string, unknown> | null, key: string) {
+  const value = metadata?.[key]
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+}
+
 function recentDelegationDecisions(events: GovernanceEventSummary[]): AgentGovernanceSnapshot['recent_delegation_decisions'] {
   return events
     .filter((event) => event.event_type === 'delegation_decision_recorded')
@@ -222,6 +239,10 @@ function recentDelegationDecisions(events: GovernanceEventSummary[]): AgentGover
         confidence: typeof metadata?.confidence === 'number' ? metadata.confidence : 0,
         occurred_at: event.occurred_at,
         reason: event.message ?? 'Delegation decision recorded.',
+        required_evidence: metadataStringArray(metadata, 'required_evidence'),
+        approval_gate: metadataString(metadata, 'approval_gate'),
+        fallback_agent_key: metadataString(metadata, 'fallback_agent_key'),
+        alternatives_considered: metadataStringArray(metadata, 'alternatives_considered'),
       }]
     })
     .slice(0, 5)

--- a/lib/agent-mission-control.test.ts
+++ b/lib/agent-mission-control.test.ts
@@ -45,6 +45,8 @@ function approval(overrides: Partial<ApprovalRow>): ApprovalRow {
     approval_type: 'send_email',
     status: 'pending',
     requested_at: now,
+    requested_by_agent_key: 'chief-of-staff',
+    metadata: null,
     ...overrides,
   }
 }

--- a/lib/agent-mission-control.ts
+++ b/lib/agent-mission-control.ts
@@ -35,6 +35,8 @@ type ApprovalRow = {
   approval_type: string
   status: string
   requested_at: string
+  requested_by_agent_key: string | null
+  metadata: Record<string, unknown> | null
 }
 
 type EventRow = {
@@ -833,7 +835,7 @@ export async function buildAgentMissionControlSnapshot() {
       .limit(500),
     db
       .from('agent_approvals')
-      .select('id, run_id, approval_type, status, requested_at')
+      .select('id, run_id, approval_type, status, requested_at, requested_by_agent_key, metadata')
       .eq('status', 'pending')
       .order('requested_at', { ascending: false })
       .limit(20),


### PR DESCRIPTION
## Summary
- preserve Shaka delegation evidence metadata in the Agent Ops governance snapshot
- show required evidence, approval gate, fallback agent, and pending authority packet details in the Mission Control governance card
- include delegation evidence and authority approval packet columns in client-safe governance exports
- carry approval metadata through scoped governance exports and Mission Control snapshots without a schema change

## Validation
- npm test -- lib/agent-governance.test.ts lib/agent-governance-export.test.ts lib/agent-mission-control.test.ts app/admin/agents/page.test.tsx app/api/admin/agents/governance/export/route.test.ts
- npm run lint -- --file app/admin/agents/page.tsx --file lib/agent-governance.ts --file lib/agent-governance-export.ts --file lib/agent-governance-scope.ts --file lib/agent-mission-control.ts
- npx tsc --noEmit --pretty false
- git diff --check
- local dev smoke from first commit: npm run dev, curl -I http://localhost:3000/admin/agents returned 200; headless browser redirected to /auth/login, so no authenticated visual smoke was claimed
- push hook database health check passed after each push

## Integration Notes
- No schema or database migration. Uses metadata already recorded on delegation_decision_recorded events and agent_approvals metadata/action_payload records.
- Vercel contexts not checked from this lane; captain should verify Vercel – portfolio and Vercel – portfolio-staging before merge.
- Rollback: revert commits 46b2ec1 and 678082e to remove the export/UI evidence fields.