### PR TITLE
feat: harden n8n agent callbacks

### DIFF
--- a/app/api/admin/agents/runs/[runId]/events/route.test.ts
+++ b/app/api/admin/agents/runs/[runId]/events/route.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   verifyAdmin: vi.fn(),
   isAuthError: vi.fn(),
+  endAgentRun: vi.fn(),
+  markAgentRunFailed: vi.fn(),
   recordAgentEvent: vi.fn(),
   recordAgentStep: vi.fn(),
 }))
@@ -15,6 +17,8 @@ vi.mock('@/lib/auth-server', () => ({
 vi.mock('@/lib/agent-run', () => ({
   AGENT_EVENT_SEVERITIES: ['debug', 'info', 'warning', 'error'],
   AGENT_RUN_STATUSES: ['queued', 'running', 'waiting_for_approval', 'completed', 'failed', 'cancelled', 'stale'],
+  endAgentRun: mocks.endAgentRun,
+  markAgentRunFailed: mocks.markAgentRunFailed,
   recordAgentEvent: mocks.recordAgentEvent,
   recordAgentStep: mocks.recordAgentStep,
 }))
@@ -38,6 +42,8 @@ describe('POST /api/admin/agents/runs/[runId]/events', () => {
     process.env.N8N_INGEST_SECRET = 'test-n8n-secret'
     mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
     mocks.isAuthError.mockReturnValue(false)
+    mocks.endAgentRun.mockResolvedValue(undefined)
+    mocks.markAgentRunFailed.mockResolvedValue(undefined)
     mocks.recordAgentEvent.mockResolvedValue({ id: 'event-1' })
     mocks.recordAgentStep.mockResolvedValue({ id: 'step-1' })
   })
@@ -77,9 +83,11 @@ describe('POST /api/admin/agents/runs/[runId]/events', () => {
       outputSummary: '12 item(s)',
       idempotencyKey: 'n8n-run-1:linkedin:scrape:step',
     }))
+    expect(mocks.markAgentRunFailed).not.toHaveBeenCalled()
+    expect(mocks.endAgentRun).not.toHaveBeenCalled()
   })
 
-  it('normalizes n8n failure callbacks into failed steps and error events', async () => {
+  it('normalizes n8n failure callbacks into failed steps, error events, and failed runs', async () => {
     const response = await POST(makeRequest({
       workflow_id: 'WF-SOC-001',
       stage: 'Generate draft',
@@ -99,6 +107,59 @@ describe('POST /api/admin/agents/runs/[runId]/events', () => {
       status: 'failed',
       outputSummary: 'LLM node timed out',
     }))
+    expect(mocks.markAgentRunFailed).toHaveBeenCalledWith(
+      'run-2',
+      'LLM node timed out',
+      expect.objectContaining({
+        workflow_id: 'WF-SOC-001',
+        stage: 'Generate draft',
+        n8n_status: 'error',
+        error_message: 'LLM node timed out',
+      }),
+    )
+  })
+
+  it('normalizes final n8n completion callbacks into completion events and completed runs', async () => {
+    const response = await POST(makeRequest({
+      workflow_id: 'WF-VEP-002',
+      stage: 'Write summary artifact',
+      status: 'success',
+      items_count: 3,
+      final: true,
+    }) as never, { params: { runId: 'run-3' } })
+
+    expect(response.status).toBe(200)
+    expect(mocks.recordAgentEvent).toHaveBeenCalledWith(expect.objectContaining({
+      runId: 'run-3',
+      eventType: 'n8n_completion',
+      severity: 'info',
+      message: 'Write summary artifact',
+      metadata: expect.objectContaining({
+        workflow_id: 'WF-VEP-002',
+        stage: 'Write summary artifact',
+        n8n_status: 'success',
+        items_count: 3,
+        final: true,
+      }),
+    }))
+    expect(mocks.recordAgentStep).toHaveBeenCalledWith(expect.objectContaining({
+      runId: 'run-3',
+      stepKey: 'n8n_wf_vep_002_write_summary_artifact',
+      name: 'Write summary artifact',
+      status: 'completed',
+      outputSummary: '3 item(s)',
+    }))
+    expect(mocks.endAgentRun).toHaveBeenCalledWith(expect.objectContaining({
+      runId: 'run-3',
+      status: 'completed',
+      currentStep: 'Write summary artifact',
+      outcome: expect.objectContaining({
+        workflow_id: 'WF-VEP-002',
+        stage: 'Write summary artifact',
+        final: true,
+      }),
+    }))
+    expect(mocks.markAgentRunFailed).not.toHaveBeenCalled()
   })
 
   it('rejects invalid n8n bearer tokens when the request is not from an admin', async () => {

--- a/app/api/admin/agents/runs/[runId]/events/route.ts
+++ b/app/api/admin/agents/runs/[runId]/events/route.ts
@@ -3,6 +3,8 @@ import { verifyAdmin, isAuthError } from '@/lib/auth-server'
 import {
   AGENT_EVENT_SEVERITIES,
   AGENT_RUN_STATUSES,
+  endAgentRun,
+  markAgentRunFailed,
   recordAgentEvent,
   recordAgentStep,
   type AgentEventSeverity,
@@ -78,6 +80,7 @@ export async function POST(
     status?: string
     items_count?: number
     error_message?: string
+    final?: boolean
     record_step?: boolean
     step_key?: string
     step_name?: string
@@ -95,7 +98,13 @@ export async function POST(
     const severity =
       (body.severity as AgentEventSeverity | undefined) ??
       (callbackStatus === 'failed' ? 'error' : 'info')
-    const eventType = body.event_type ?? (callbackStatus === 'failed' ? 'n8n_failure' : 'n8n_progress')
+    const eventType =
+      body.event_type ??
+      (callbackStatus === 'failed'
+        ? 'n8n_failure'
+        : callbackStatus === 'completed'
+          ? 'n8n_completion'
+          : 'n8n_progress')
     const metadata = {
       ...(body.metadata ?? {}),
       workflow_id: body.workflow_id ?? null,
@@ -103,6 +112,7 @@ export async function POST(
       n8n_status: body.status ?? null,
       items_count: body.items_count ?? null,
       error_message: body.error_message ?? null,
+      final: body.final === true,
     }
 
     const result = await recordAgentEvent({
@@ -127,6 +137,21 @@ export async function POST(
         idempotencyKey: body.idempotency_key ? `${body.idempotency_key}:step` : null,
       })
       stepId = step?.id ?? null
+    }
+
+    if (callbackStatus === 'failed') {
+      await markAgentRunFailed(
+        params.runId,
+        body.error_message ?? body.message ?? 'n8n workflow failed',
+        metadata,
+      )
+    } else if (body.final === true && callbackStatus === 'completed') {
+      await endAgentRun({
+        runId: params.runId,
+        status: 'completed',
+        outcome: metadata,
+        currentStep: body.stage ?? body.step_name ?? 'n8n completed',
+      })
     }
 
     return NextResponse.json({ ok: true, event_id: result?.id ?? null, step_id: stepId })

--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -160,6 +160,8 @@ Status: Partial.
 
 Goal: Make production automations visible through the shared trace model.
 
+Latest hardening: app-triggered n8n payloads now carry a shared callback contract, and the generic Agent Ops callback route can classify progress, final completion, and failure callbacks for operator visibility.
+
 Definition of done:
 
 - App-triggered n8n calls include `agent_run_id`.

--- a/lib/__tests__/n8n-social-content-extraction.test.ts
+++ b/lib/__tests__/n8n-social-content-extraction.test.ts
@@ -61,6 +61,25 @@ describe('triggerSocialContentExtraction', () => {
       workflow_id: 'WF-SOC-001',
       events_url: 'https://portfolio.example.com/api/admin/agents/runs/agent-run-1/events',
     })
+    expect(payload.agent_callback_contract).toMatchObject({
+      version: 1,
+      runtime: 'n8n',
+      events_url: 'https://portfolio.example.com/api/admin/agents/runs/agent-run-1/events',
+      auth_header: 'Authorization: Bearer N8N_INGEST_SECRET',
+      required_fields: ['workflow_id', 'stage', 'status'],
+      final_completion_payload: {
+        workflow_id: 'WF-SOC-001',
+        status: 'completed',
+        final: true,
+      },
+      failure_payload: {
+        workflow_id: 'WF-SOC-001',
+        status: 'failed',
+      },
+    })
+    expect(payload.agent_trace).toMatchObject({
+      callback_contract: payload.agent_callback_contract,
+    })
     expect(payload.meeting_record_id).toBe('meeting-123')
     expect(payload.prompts).toEqual({
       topicExtraction: 'topic prompt',

--- a/lib/__tests__/n8n-value-evidence.test.ts
+++ b/lib/__tests__/n8n-value-evidence.test.ts
@@ -51,6 +51,23 @@ describe('n8n value-evidence triggers', () => {
       workflow_id: 'WF-VEP-002',
       events_url: 'https://portfolio.example.com/api/admin/agents/runs/agent-run-1/events',
     })
+    expect(body.agent_callback_contract).toMatchObject({
+      version: 1,
+      runtime: 'n8n',
+      events_url: 'https://portfolio.example.com/api/admin/agents/runs/agent-run-1/events',
+      auth_header: 'Authorization: Bearer N8N_INGEST_SECRET',
+      required_fields: ['workflow_id', 'stage', 'status'],
+      final_completion_payload: {
+        workflow_id: 'WF-VEP-002',
+        status: 'completed',
+        final: true,
+      },
+      failure_payload: {
+        workflow_id: 'WF-VEP-002',
+        status: 'failed',
+      },
+    })
+    expect(body.agent_trace.callback_contract).toMatchObject(body.agent_callback_contract)
   })
 
   it('omits maxResults when not provided', async () => {

--- a/lib/__tests__/n8n-warm-lead-scrape.test.ts
+++ b/lib/__tests__/n8n-warm-lead-scrape.test.ts
@@ -52,6 +52,23 @@ describe('triggerWarmLeadScrape', () => {
       workflow_id: 'WRM-facebook',
       events_url: 'https://portfolio.example.com/api/admin/agents/runs/agent-run-1/events',
     })
+    expect(body.agent_callback_contract).toMatchObject({
+      version: 1,
+      runtime: 'n8n',
+      events_url: 'https://portfolio.example.com/api/admin/agents/runs/agent-run-1/events',
+      auth_header: 'Authorization: Bearer N8N_INGEST_SECRET',
+      required_fields: ['workflow_id', 'stage', 'status'],
+      final_completion_payload: {
+        workflow_id: 'WRM-facebook',
+        status: 'completed',
+        final: true,
+      },
+      failure_payload: {
+        workflow_id: 'WRM-facebook',
+        status: 'failed',
+      },
+    })
+    expect(body.agent_trace.callback_contract).toMatchObject(body.agent_callback_contract)
     expect(body.max_leads).toBe(10)
     expect(body.triggered_at).toBeDefined()
   })

--- a/lib/__tests__/wrm-smoke-gate.test.ts
+++ b/lib/__tests__/wrm-smoke-gate.test.ts
@@ -17,16 +17,38 @@ describe('WRM smoke gate helpers', () => {
       callbackBaseUrl: 'https://amadutown.com/',
     })
 
-    expect(payload).toEqual({
+    expect(payload).toMatchObject({
       mode: 'smoke',
       is_test_data: true,
       callbackBaseUrl: 'https://amadutown.com',
       agent_run_id: 'run-123',
       agent_event_callback_url: 'https://amadutown.com/api/admin/agents/runs/run-123/events',
+      agent_callback_contract: {
+        version: 1,
+        runtime: 'n8n',
+        events_url: 'https://amadutown.com/api/admin/agents/runs/run-123/events',
+        auth_header: 'Authorization: Bearer N8N_INGEST_SECRET',
+        final_completion_payload: {
+          workflow_id: 'WF-WRM-001',
+          status: 'completed',
+          final: true,
+        },
+        failure_payload: {
+          workflow_id: 'WF-WRM-001',
+          status: 'failed',
+        },
+      },
       agent_trace: {
+        version: 1,
+        runtime: 'n8n',
+        agent_run_id: 'run-123',
         mode: 'smoke',
         source: 'facebook',
         workflow_id: 'WF-WRM-001',
+        events_url: 'https://amadutown.com/api/admin/agents/runs/run-123/events',
+        callback_contract: {
+          events_url: 'https://amadutown.com/api/admin/agents/runs/run-123/events',
+        },
       },
     })
   })

--- a/lib/n8n-agent-callback.ts
+++ b/lib/n8n-agent-callback.ts
@@ -1,0 +1,84 @@
+export interface N8nAgentCallbackContract {
+  version: 1
+  runtime: 'n8n'
+  events_url: string
+  auth_header: string
+  required_fields: string[]
+  progress_statuses: string[]
+  completion_statuses: string[]
+  failure_statuses: string[]
+  final_completion_payload: {
+    workflow_id: string
+    stage: string
+    status: 'completed'
+    final: true
+  }
+  failure_payload: {
+    workflow_id: string
+    stage: string
+    status: 'failed'
+    error_message: string
+  }
+}
+
+export interface N8nAgentCallbackEnvelope {
+  agent_run_id: string
+  agent_event_callback_url: string
+  agent_callback_contract: N8nAgentCallbackContract
+  agent_trace: Record<string, unknown>
+}
+
+export function buildN8nAgentCallbackContract(
+  eventsUrl: string,
+  workflowId?: string | null,
+): N8nAgentCallbackContract {
+  const workflow = workflowId ?? '<workflow-id>'
+
+  return {
+    version: 1,
+    runtime: 'n8n',
+    events_url: eventsUrl,
+    auth_header: 'Authorization: Bearer N8N_INGEST_SECRET',
+    required_fields: ['workflow_id', 'stage', 'status'],
+    progress_statuses: ['running', 'in_progress', 'started'],
+    completion_statuses: ['completed', 'complete', 'success'],
+    failure_statuses: ['failed', 'error', 'failure'],
+    final_completion_payload: {
+      workflow_id: workflow,
+      stage: '<final-stage-name>',
+      status: 'completed',
+      final: true,
+    },
+    failure_payload: {
+      workflow_id: workflow,
+      stage: '<failed-stage-name>',
+      status: 'failed',
+      error_message: '<required failure summary>',
+    },
+  }
+}
+
+export function buildN8nAgentCallbackEnvelope(input: {
+  agentRunId: string
+  eventsUrl: string
+  workflowId?: string | null
+  trace?: Record<string, unknown>
+}): N8nAgentCallbackEnvelope {
+  const callbackContract = buildN8nAgentCallbackContract(input.eventsUrl, input.workflowId)
+
+  return {
+    agent_run_id: input.agentRunId,
+    agent_event_callback_url: input.eventsUrl,
+    agent_callback_contract: callbackContract,
+    agent_trace: {
+      version: 1,
+      runtime: 'n8n',
+      agent_run_id: input.agentRunId,
+      workflow_id: input.workflowId ?? null,
+      events_url: input.eventsUrl,
+      auth: 'Bearer N8N_INGEST_SECRET',
+      callback_contract: callbackContract,
+      ...(input.trace ?? {}),
+    },
+  }
+}

--- a/lib/n8n.ts
+++ b/lib/n8n.ts
@@ -10,6 +10,7 @@ import {
 } from './n8n-runtime-flags'
 import type { AgentReadinessAssessment } from './agent-readiness-assessment'
 import { isLikelyTransientError, withRetry } from './llm/with-retry'
+import { buildN8nAgentCallbackEnvelope } from './n8n-agent-callback'
 
 export { isMockN8nEnabled, isN8nOutboundDisabled }
 
@@ -46,22 +47,19 @@ function n8nAgentTracePayload(agentRunId?: string, workflowId?: string): Record<
 
   const eventsUrl = `${n8nCallbackBaseUrl()}/api/admin/agents/runs/${agentRunId}/events`
   return {
-    agent_run_id: agentRunId,
-    agent_event_callback_url: eventsUrl,
-    agent_trace: {
-      version: 1,
-      runtime: 'n8n',
-      agent_run_id: agentRunId,
-      workflow_id: workflowId ?? null,
-      events_url: eventsUrl,
-      auth: 'Bearer N8N_INGEST_SECRET',
-      progress_payload: {
-        workflow_id: workflowId ?? '<workflow-id>',
-        stage: '<node-or-stage-name>',
-        status: 'running | completed | failed',
-        items_count: '<optional-number>',
+    ...buildN8nAgentCallbackEnvelope({
+      agentRunId,
+      eventsUrl,
+      workflowId,
+      trace: {
+        progress_payload: {
+          workflow_id: workflowId ?? '<workflow-id>',
+          stage: '<node-or-stage-name>',
+          status: 'running | completed | failed',
+          items_count: '<optional-number>',
+        },
       },
-    },
+    }),
   }
 }
 

--- a/lib/progress-update-templates.test.ts
+++ b/lib/progress-update-templates.test.ts
@@ -23,6 +23,7 @@ describe('progress update agent trace payloads', () => {
     expect(buildProgressUpdateAgentTracePayload(null)).toEqual({
       agent_run_id: null,
       agent_event_callback_url: null,
+      agent_callback_contract: null,
       agent_trace: null,
     })
   })
@@ -33,6 +34,22 @@ describe('progress update agent trace payloads', () => {
     expect(buildProgressUpdateAgentTracePayload('agent-run-1')).toMatchObject({
       agent_run_id: 'agent-run-1',
       agent_event_callback_url: 'https://portfolio.example.com/api/admin/agents/runs/agent-run-1/events',
+      agent_callback_contract: {
+        version: 1,
+        runtime: 'n8n',
+        events_url: 'https://portfolio.example.com/api/admin/agents/runs/agent-run-1/events',
+        auth_header: 'Authorization: Bearer N8N_INGEST_SECRET',
+        required_fields: ['workflow_id', 'stage', 'status'],
+        final_completion_payload: {
+          workflow_id: 'client-progress-update-router',
+          status: 'completed',
+          final: true,
+        },
+        failure_payload: {
+          workflow_id: 'client-progress-update-router',
+          status: 'failed',
+        },
+      },
       agent_trace: {
         version: 1,
         runtime: 'n8n',
@@ -40,6 +57,10 @@ describe('progress update agent trace payloads', () => {
         workflow_id: 'client-progress-update-router',
         events_url: 'https://portfolio.example.com/api/admin/agents/runs/agent-run-1/events',
         auth: 'Bearer N8N_INGEST_SECRET',
+        callback_contract: {
+          events_url: 'https://portfolio.example.com/api/admin/agents/runs/agent-run-1/events',
+          auth_header: 'Authorization: Bearer N8N_INGEST_SECRET',
+        },
       },
     })
   })

--- a/lib/progress-update-templates.ts
+++ b/lib/progress-update-templates.ts
@@ -9,6 +9,10 @@
 import { supabaseAdmin } from './supabase'
 import { n8nWebhookUrl } from './n8n'
 import {
+  buildN8nAgentCallbackEnvelope,
+  type N8nAgentCallbackContract,
+} from './n8n-agent-callback'
+import {
   attachAgentArtifact,
   endAgentRun,
   markAgentRunFailed,
@@ -105,6 +109,7 @@ export interface ProgressUpdateWebhookPayload {
   callback_url: string
   agent_run_id?: string | null
   agent_event_callback_url?: string | null
+  agent_callback_contract?: N8nAgentCallbackContract | null
   agent_trace?: Record<string, unknown> | null
 }
 
@@ -136,29 +141,25 @@ function portfolioBaseUrl(): string {
 export function buildProgressUpdateAgentTracePayload(
   agentRunId: string | null,
   workflowId = PROGRESS_UPDATE_WORKFLOW_ID,
-): Pick<ProgressUpdateWebhookPayload, 'agent_run_id' | 'agent_event_callback_url' | 'agent_trace'> {
+): Pick<ProgressUpdateWebhookPayload, 'agent_run_id' | 'agent_event_callback_url' | 'agent_callback_contract' | 'agent_trace'> {
   if (!agentRunId) {
     return {
       agent_run_id: null,
       agent_event_callback_url: null,
+      agent_callback_contract: null,
       agent_trace: null,
     }
   }
 
   const eventsUrl = `${portfolioBaseUrl()}/api/admin/agents/runs/${agentRunId}/events`
-  return {
-    agent_run_id: agentRunId,
-    agent_event_callback_url: eventsUrl,
-    agent_trace: {
-      version: 1,
-      runtime: 'n8n',
-      agent_run_id: agentRunId,
-      workflow_id: workflowId,
-      events_url: eventsUrl,
-      auth: 'Bearer N8N_INGEST_SECRET',
+  return buildN8nAgentCallbackEnvelope({
+    agentRunId,
+    eventsUrl,
+    workflowId,
+    trace: {
       completion_callback: 'n8n should echo agent_run_id to callback_url after delivery.',
     },
-  }
+  })
 }
 
 // ============================================================================

--- a/lib/wrm-smoke-gate.ts
+++ b/lib/wrm-smoke-gate.ts
@@ -1,3 +1,5 @@
+import { buildN8nAgentCallbackEnvelope } from './n8n-agent-callback'
+
 export type WrmSmokeSource = 'facebook' | 'google_contacts' | 'linkedin'
 
 export interface WrmSmokeWorkflow {
@@ -51,17 +53,21 @@ export function agentEventCallbackUrl(callbackBaseUrl: string, runId: string): s
 }
 
 export function buildWrmSmokePayload(input: WrmSmokePayloadInput): Record<string, unknown> {
+  const eventsUrl = agentEventCallbackUrl(input.callbackBaseUrl, input.runId)
+
   return {
     mode: 'smoke',
     is_test_data: true,
     callbackBaseUrl: normalizeBaseUrl(input.callbackBaseUrl),
-    agent_run_id: input.runId,
-    agent_event_callback_url: agentEventCallbackUrl(input.callbackBaseUrl, input.runId),
-    agent_trace: {
-      mode: 'smoke',
-      source: input.workflow.source,
-      workflow_id: input.workflow.workflowId,
-    },
+    ...buildN8nAgentCallbackEnvelope({
+      agentRunId: input.runId,
+      eventsUrl,
+      workflowId: input.workflow.workflowId,
+      trace: {
+        mode: 'smoke',
+        source: input.workflow.source,
+      },
+    }),
   }
 }
 


### PR DESCRIPTION
## Summary
- add a shared n8n Agent Ops callback contract for outbound automation payloads
- make the generic Agent Ops run callback route classify progress, completion, and failure callbacks
- mark failed callbacks as failed runs and allow final completed callbacks to close runs
- document the Phase 6 hardening status in the Agent Operations roadmap

## Validation
- npm test -- app/api/admin/agents/runs/[runId]/events/route.test.ts lib/__tests__/n8n-warm-lead-scrape.test.ts lib/__tests__/n8n-value-evidence.test.ts lib/__tests__/n8n-social-content-extraction.test.ts lib/__tests__/wrm-smoke-gate.test.ts lib/progress-update-templates.test.ts
- npx tsc --noEmit --pretty false
- npm run lint
- git diff --check
- pre-push database health check passed

## Integration Notes
- No schema migration.
- No workflow mutation was executed; this only hardens Portfolio payloads and callback handling.
- Vercel contexts not checked in this implementation lane; integration captain should verify `Vercel – portfolio` and `Vercel – portfolio-staging` after merge.
- Rollback: revert commit `aa42898` to restore previous callback payload and event-route behavior.