### PR TITLE
feat: add progress update trace callbacks

### DIFF
--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -160,7 +160,7 @@ Status: Partial.
 
 Goal: Make production automations visible through the shared trace model.
 
-Latest hardening: app-triggered n8n payloads now carry a shared callback contract, and the generic Agent Ops callback route can classify progress, final completion, and failure callbacks for operator visibility.
+Latest hardening: app-triggered n8n payloads now carry a shared callback contract, the generic Agent Ops callback route can classify progress, final completion, and failure callbacks for operator visibility, and the Client Progress Update Router export records Agent Ops trace events after Slack/email delivery callbacks when an `agent_event_callback_url` is present.
 
 Definition of done:
 

--- a/lib/__tests__/n8n-progress-update-workflow-export.test.ts
+++ b/lib/__tests__/n8n-progress-update-workflow-export.test.ts
@@ -8,13 +8,48 @@ function loadWorkflow() {
   return JSON.parse(fs.readFileSync(WORKFLOW_PATH, 'utf8')) as {
     nodes: Array<{
       name: string
+      type?: string
       parameters?: {
         sendHeaders?: boolean
+        url?: string
+        specifyBody?: string
+        jsonBody?: string
+        conditions?: {
+          conditions?: Array<{
+            leftValue?: string
+            operator?: { operation?: string }
+          }>
+        }
         headerParameters?: { parameters?: Array<{ name: string; value: string }> }
         bodyParameters?: { parameters?: Array<{ name: string; value: string }> }
       }
     }>
+    connections?: Record<string, { main?: Array<Array<{ node?: string }>> }>
+    activeVersion?: {
+      nodes?: Array<{
+        name: string
+        parameters?: {
+          url?: string
+        }
+      }>
+      connections?: Record<string, { main?: Array<Array<{ node?: string }>> }>
+    }
   }
+}
+
+function getNode(workflow: ReturnType<typeof loadWorkflow>, name: string) {
+  const node = workflow.nodes.find((item) => item.name === name)
+  expect(node, `Expected workflow node "${name}" to exist`).toBeDefined()
+  return node
+}
+
+function expectConnection(
+  workflow: ReturnType<typeof loadWorkflow>,
+  from: string,
+  to: string,
+): void {
+  const target = workflow.connections?.[from]?.main?.[0]?.find((connection) => connection.node === to)
+  expect(target, `Expected "${from}" to connect to "${to}"`).toBeDefined()
 }
 
 describe('Client Progress Update Router export', () => {
@@ -22,7 +57,7 @@ describe('Client Progress Update Router export', () => {
     '%s echoes Agent Ops trace metadata and authenticates callbacks',
     (nodeName) => {
       const workflow = loadWorkflow()
-      const node = workflow.nodes.find((item) => item.name === nodeName)
+      const node = getNode(workflow, nodeName)
 
       expect(node?.parameters?.sendHeaders).toBe(true)
       expect(node?.parameters?.headerParameters?.parameters).toEqual(
@@ -45,6 +80,58 @@ describe('Client Progress Update Router export', () => {
           },
         ]),
       )
+    },
+  )
+
+  it.each([
+    {
+      channel: 'slack',
+      guard: 'Has Slack Agent Event Callback URL',
+      callback: 'Slack Agent Trace Event',
+      source: 'Slack Delivery Callback',
+      stage: 'slack_delivery_complete',
+    },
+    {
+      channel: 'email',
+      guard: 'Has Email Agent Event Callback URL',
+      callback: 'Email Agent Trace Event',
+      source: 'Email Delivery Callback',
+      stage: 'email_delivery_complete',
+    },
+  ])(
+    '$callback records a generic Agent Ops trace event after delivery callbacks',
+    ({ channel, guard, callback, source, stage }) => {
+      const workflow = loadWorkflow()
+      const guardNode = getNode(workflow, guard)
+      const callbackNode = getNode(workflow, callback)
+
+      expect(guardNode?.type).toBe('n8n-nodes-base.if')
+      expect(guardNode?.parameters?.conditions?.conditions?.[0]).toMatchObject({
+        leftValue: "={{ $('Progress Update Webhook').item.json.body.agent_event_callback_url || '' }}",
+        operator: { operation: 'notEmpty' },
+      })
+
+      expect(callbackNode?.parameters?.url).toBe("={{ $('Progress Update Webhook').item.json.body.agent_event_callback_url }}")
+      expect(callbackNode?.parameters?.sendHeaders).toBe(true)
+      expect(callbackNode?.parameters?.headerParameters?.parameters).toEqual(
+        expect.arrayContaining([
+          { name: 'Content-Type', value: 'application/json' },
+          { name: 'Authorization', value: '=Bearer {{ $vars.N8N_INGEST_SECRET || $env.N8N_INGEST_SECRET }}' },
+        ]),
+      )
+      expect(callbackNode?.parameters?.specifyBody).toBe('json')
+      expect(callbackNode?.parameters?.jsonBody).toContain("workflow_id: 'client-progress-update-router'")
+      expect(callbackNode?.parameters?.jsonBody).toContain(`stage: '${stage}'`)
+      expect(callbackNode?.parameters?.jsonBody).toContain("status: 'completed'")
+      expect(callbackNode?.parameters?.jsonBody).toContain(`channel: '${channel}'`)
+      expect(callbackNode?.parameters?.jsonBody).toContain(`':client-progress-update-router:${stage}'`)
+
+      expectConnection(workflow, source, guard)
+      expectConnection(workflow, guard, callback)
+
+      const activeCallback = workflow.activeVersion?.nodes?.find((node) => node.name === callback)
+      expect(activeCallback?.parameters?.url).toBe("={{ $('Progress Update Webhook').item.json.body.agent_event_callback_url }}")
+      expect(workflow.activeVersion?.connections?.[source]?.main?.[0]?.[0]?.node).toBe(guard)
     },
   )
 })

--- a/n8n-exports/Client-Progress-Update-Router.json
+++ b/n8n-exports/Client-Progress-Update-Router.json
@@ -210,6 +210,140 @@
         112
       ],
       "type": "n8n-nodes-base.stickyNote"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "version": 2,
+            "leftValue": "",
+            "caseSensitive": true,
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "slack-agent-event-callback-url-present",
+              "leftValue": "={{ $('Progress Update Webhook').item.json.body.agent_event_callback_url || '' }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "name": "Has Slack Agent Event Callback URL",
+      "id": "has-slack-agent-event-callback-url",
+      "typeVersion": 2,
+      "position": [
+        896,
+        208
+      ],
+      "type": "n8n-nodes-base.if"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $('Progress Update Webhook').item.json.body.agent_event_callback_url }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $vars.N8N_INGEST_SECRET || $env.N8N_INGEST_SECRET }}"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ workflow_id: 'client-progress-update-router', stage: 'slack_delivery_complete', status: 'completed', items_count: 1, metadata: { channel: 'slack', delivery_status: 'sent' }, idempotency_key: ($('Progress Update Webhook').item.json.body.agent_run_id || 'missing-run') + ':client-progress-update-router:slack_delivery_complete' }) }}"
+      },
+      "name": "Slack Agent Trace Event",
+      "waitBetweenTries": 2000,
+      "retryOnFail": true,
+      "id": "slack-agent-trace-event",
+      "typeVersion": 4.2,
+      "maxTries": 3,
+      "position": [
+        1120,
+        208
+      ],
+      "type": "n8n-nodes-base.httpRequest"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "version": 2,
+            "leftValue": "",
+            "caseSensitive": true,
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "email-agent-event-callback-url-present",
+              "leftValue": "={{ $('Progress Update Webhook').item.json.body.agent_event_callback_url || '' }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "name": "Has Email Agent Event Callback URL",
+      "id": "has-email-agent-event-callback-url",
+      "typeVersion": 2,
+      "position": [
+        896,
+        400
+      ],
+      "type": "n8n-nodes-base.if"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $('Progress Update Webhook').item.json.body.agent_event_callback_url }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $vars.N8N_INGEST_SECRET || $env.N8N_INGEST_SECRET }}"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ workflow_id: 'client-progress-update-router', stage: 'email_delivery_complete', status: 'completed', items_count: 1, metadata: { channel: 'email', delivery_status: 'sent' }, idempotency_key: ($('Progress Update Webhook').item.json.body.agent_run_id || 'missing-run') + ':client-progress-update-router:email_delivery_complete' }) }}"
+      },
+      "name": "Email Agent Trace Event",
+      "waitBetweenTries": 2000,
+      "retryOnFail": true,
+      "id": "email-agent-trace-event",
+      "typeVersion": 4.2,
+      "maxTries": 3,
+      "position": [
+        1120,
+        400
+      ],
+      "type": "n8n-nodes-base.httpRequest"
     }
   ],
   "connections": {
@@ -258,6 +392,50 @@
         [
           {
             "node": "Email Delivery Callback",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Slack Delivery Callback": {
+      "main": [
+        [
+          {
+            "node": "Has Slack Agent Event Callback URL",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Slack Agent Event Callback URL": {
+      "main": [
+        [
+          {
+            "node": "Slack Agent Trace Event",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Email Delivery Callback": {
+      "main": [
+        [
+          {
+            "node": "Has Email Agent Event Callback URL",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Email Agent Event Callback URL": {
+      "main": [
+        [
+          {
+            "node": "Email Agent Trace Event",
             "type": "main",
             "index": 0
           }
@@ -511,6 +689,140 @@
           112
         ],
         "type": "n8n-nodes-base.stickyNote"
+      },
+      {
+        "parameters": {
+          "conditions": {
+            "options": {
+              "version": 2,
+              "leftValue": "",
+              "caseSensitive": true,
+              "typeValidation": "strict"
+            },
+            "conditions": [
+              {
+                "id": "slack-agent-event-callback-url-present",
+                "leftValue": "={{ $('Progress Update Webhook').item.json.body.agent_event_callback_url || '' }}",
+                "rightValue": "",
+                "operator": {
+                  "type": "string",
+                  "operation": "notEmpty",
+                  "singleValue": true
+                }
+              }
+            ],
+            "combinator": "and"
+          },
+          "options": {}
+        },
+        "name": "Has Slack Agent Event Callback URL",
+        "id": "has-slack-agent-event-callback-url",
+        "typeVersion": 2,
+        "position": [
+          896,
+          208
+        ],
+        "type": "n8n-nodes-base.if"
+      },
+      {
+        "parameters": {
+          "method": "POST",
+          "url": "={{ $('Progress Update Webhook').item.json.body.agent_event_callback_url }}",
+          "sendHeaders": true,
+          "headerParameters": {
+            "parameters": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "name": "Authorization",
+                "value": "=Bearer {{ $vars.N8N_INGEST_SECRET || $env.N8N_INGEST_SECRET }}"
+              }
+            ]
+          },
+          "sendBody": true,
+          "specifyBody": "json",
+          "jsonBody": "={{ JSON.stringify({ workflow_id: 'client-progress-update-router', stage: 'slack_delivery_complete', status: 'completed', items_count: 1, metadata: { channel: 'slack', delivery_status: 'sent' }, idempotency_key: ($('Progress Update Webhook').item.json.body.agent_run_id || 'missing-run') + ':client-progress-update-router:slack_delivery_complete' }) }}"
+        },
+        "name": "Slack Agent Trace Event",
+        "waitBetweenTries": 2000,
+        "retryOnFail": true,
+        "id": "slack-agent-trace-event",
+        "typeVersion": 4.2,
+        "maxTries": 3,
+        "position": [
+          1120,
+          208
+        ],
+        "type": "n8n-nodes-base.httpRequest"
+      },
+      {
+        "parameters": {
+          "conditions": {
+            "options": {
+              "version": 2,
+              "leftValue": "",
+              "caseSensitive": true,
+              "typeValidation": "strict"
+            },
+            "conditions": [
+              {
+                "id": "email-agent-event-callback-url-present",
+                "leftValue": "={{ $('Progress Update Webhook').item.json.body.agent_event_callback_url || '' }}",
+                "rightValue": "",
+                "operator": {
+                  "type": "string",
+                  "operation": "notEmpty",
+                  "singleValue": true
+                }
+              }
+            ],
+            "combinator": "and"
+          },
+          "options": {}
+        },
+        "name": "Has Email Agent Event Callback URL",
+        "id": "has-email-agent-event-callback-url",
+        "typeVersion": 2,
+        "position": [
+          896,
+          400
+        ],
+        "type": "n8n-nodes-base.if"
+      },
+      {
+        "parameters": {
+          "method": "POST",
+          "url": "={{ $('Progress Update Webhook').item.json.body.agent_event_callback_url }}",
+          "sendHeaders": true,
+          "headerParameters": {
+            "parameters": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "name": "Authorization",
+                "value": "=Bearer {{ $vars.N8N_INGEST_SECRET || $env.N8N_INGEST_SECRET }}"
+              }
+            ]
+          },
+          "sendBody": true,
+          "specifyBody": "json",
+          "jsonBody": "={{ JSON.stringify({ workflow_id: 'client-progress-update-router', stage: 'email_delivery_complete', status: 'completed', items_count: 1, metadata: { channel: 'email', delivery_status: 'sent' }, idempotency_key: ($('Progress Update Webhook').item.json.body.agent_run_id || 'missing-run') + ':client-progress-update-router:email_delivery_complete' }) }}"
+        },
+        "name": "Email Agent Trace Event",
+        "waitBetweenTries": 2000,
+        "retryOnFail": true,
+        "id": "email-agent-trace-event",
+        "typeVersion": 4.2,
+        "maxTries": 3,
+        "position": [
+          1120,
+          400
+        ],
+        "type": "n8n-nodes-base.httpRequest"
       }
     ],
     "connections": {
@@ -559,6 +871,50 @@
           [
             {
               "node": "Email Delivery Callback",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Slack Delivery Callback": {
+        "main": [
+          [
+            {
+              "node": "Has Slack Agent Event Callback URL",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Has Slack Agent Event Callback URL": {
+        "main": [
+          [
+            {
+              "node": "Slack Agent Trace Event",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Email Delivery Callback": {
+        "main": [
+          [
+            {
+              "node": "Has Email Agent Event Callback URL",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Has Email Agent Event Callback URL": {
+        "main": [
+          [
+            {
+              "node": "Email Agent Trace Event",
               "type": "main",
               "index": 0
             }


### PR DESCRIPTION
## Summary
- add guarded Agent Ops trace event callbacks to the Client Progress Update Router n8n export after Slack and email delivery callbacks
- keep the legacy delivered callback intact while emitting generic Agent Ops completion events when `agent_event_callback_url` is present
- extend the export regression test to verify guard nodes, callback auth, payload shape, connections, and activeVersion parity
- update the Agent Operations roadmap Phase 6 note

## Validation
- npm test -- lib/__tests__/n8n-progress-update-workflow-export.test.ts lib/__tests__/n8n-warm-lead-workflow-export.test.ts lib/__tests__/n8n-vep002-workflow-export.test.ts lib/progress-update-templates.test.ts lib/__tests__/n8n-warm-lead-scrape.test.ts lib/__tests__/n8n-value-evidence.test.ts lib/__tests__/n8n-social-content-extraction.test.ts
- npx tsc --noEmit --pretty false
- npm run lint -- --file lib/__tests__/n8n-progress-update-workflow-export.test.ts
- git diff --check
- pre-push database health check passed

## Integration Notes
- No schema migration.
- No live n8n workflow import/activation or customer-data smoke was run; this updates the tracked sanitized export only.
- The callback nodes are guarded so workflows without `agent_event_callback_url` continue through the legacy delivered callback without attempting a blank Agent Ops callback.
- Integration captain should verify both Vercel contexts after merge.
- Rollback: revert commit `f9efda3` to restore the previous Client Progress Update Router export and tests.