### PR TITLE
feat: add provisioning reminder trace callbacks

### DIFF
--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -160,7 +160,7 @@ Status: Partial.
 
 Goal: Make production automations visible through the shared trace model.
 
-Latest hardening: app-triggered n8n payloads now carry a shared callback contract, the generic Agent Ops callback route can classify progress, final completion, and failure callbacks for operator visibility, and the Client Progress Update Router export records Agent Ops trace events after Slack/email delivery callbacks when an `agent_event_callback_url` is present.
+Latest hardening: app-triggered n8n payloads now carry a shared callback contract, the generic Agent Ops callback route can classify progress, final completion, and failure callbacks for operator visibility, the Client Progress Update Router export records Agent Ops trace events after Slack/email delivery callbacks when an `agent_event_callback_url` is present, and the Provisioning Reminder export now reports a guarded final completion event when Agent Ops trace context is supplied.
 
 Definition of done:
 

--- a/lib/__tests__/n8n-provisioning-reminder-workflow-export.test.ts
+++ b/lib/__tests__/n8n-provisioning-reminder-workflow-export.test.ts
@@ -1,0 +1,117 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+type N8nConnection = {
+  node?: string
+  type?: string
+  index?: number
+}
+
+type N8nNode = {
+  name?: string
+  type?: string
+  parameters?: {
+    jsonBody?: string
+    url?: string
+    sendHeaders?: boolean
+    conditions?: {
+      conditions?: Array<{
+        leftValue?: string
+        operator?: { operation?: string }
+      }>
+    }
+    assignments?: {
+      assignments?: Array<{ name?: string; value?: string }>
+    }
+    headerParameters?: {
+      parameters?: Array<{ name?: string; value?: string }>
+    }
+  }
+}
+
+type N8nWorkflow = {
+  nodes?: N8nNode[]
+  connections?: Record<string, { main?: N8nConnection[][] }>
+}
+
+const WORKFLOW_PATH = path.join(process.cwd(), 'n8n-exports', 'WF-PROV-Provisioning-Reminder.json')
+
+function loadWorkflow(): N8nWorkflow {
+  return JSON.parse(readFileSync(WORKFLOW_PATH, 'utf8')) as N8nWorkflow
+}
+
+function getNode(workflow: N8nWorkflow, name: string): N8nNode {
+  const node = workflow.nodes?.find((entry) => entry.name === name)
+  expect(node, `Expected workflow node "${name}" to exist`).toBeDefined()
+  return node as N8nNode
+}
+
+function expectConnection(workflow: N8nWorkflow, from: string, to: string, outputIndex = 0): void {
+  const outputs = workflow.connections?.[from]?.main ?? []
+  const target = outputs[outputIndex]?.find((connection) => connection.node === to)
+  expect(target, `Expected "${from}" output ${outputIndex} to connect to "${to}"`).toBeDefined()
+}
+
+function getHeader(node: N8nNode, name: string): string | undefined {
+  return node.parameters?.headerParameters?.parameters?.find((header) => header.name === name)?.value
+}
+
+describe('WF-PROV provisioning reminder export trace callbacks', () => {
+  it('preserves Agent Ops trace fields from the webhook payload', () => {
+    const workflow = loadWorkflow()
+    const node = getNode(workflow, 'Extract Payload')
+
+    expect(node.parameters?.assignments?.assignments).toEqual(
+      expect.arrayContaining([
+        {
+          id: 'a7',
+          name: 'agent_run_id',
+          type: 'string',
+          value: '={{ $json.body.agent_run_id || \'\' }}',
+        },
+        {
+          id: 'a8',
+          name: 'agent_event_callback_url',
+          type: 'string',
+          value: '={{ $json.body.agent_event_callback_url || \'\' }}',
+        },
+      ]),
+    )
+  })
+
+  it('guards generic Agent Ops callbacks so reminders still respond when no trace URL is supplied', () => {
+    const workflow = loadWorkflow()
+    const guard = getNode(workflow, 'Has Agent Event Callback URL')
+
+    expect(guard.type).toBe('n8n-nodes-base.if')
+    expect(guard.parameters?.conditions?.conditions?.[0]).toMatchObject({
+      leftValue: '={{ $node["Extract Payload"].json.agent_event_callback_url }}',
+      operator: { operation: 'notEmpty' },
+    })
+
+    expectConnection(workflow, 'Send Slack Reminder', 'Has Agent Event Callback URL')
+    expectConnection(workflow, 'Send Email Reminder', 'Has Agent Event Callback URL')
+    expectConnection(workflow, 'Has Agent Event Callback URL', 'Report Agent Trace Event', 0)
+    expectConnection(workflow, 'Has Agent Event Callback URL', 'Respond OK', 1)
+  })
+
+  it('records a final completion event after reminder delivery when Agent Ops context is present', () => {
+    const workflow = loadWorkflow()
+    const eventNode = getNode(workflow, 'Report Agent Trace Event')
+
+    expect(eventNode.parameters?.url).toBe('={{ $node["Extract Payload"].json.agent_event_callback_url }}')
+    expect(eventNode.parameters?.sendHeaders).toBe(true)
+    expect(getHeader(eventNode, 'Content-Type')).toBe('application/json')
+    expect(getHeader(eventNode, 'Authorization')).toBe('=Bearer {{ $vars.N8N_INGEST_SECRET || $env.N8N_INGEST_SECRET }}')
+    expect(eventNode.parameters?.jsonBody).toContain("workflow_id: 'WF-PROV'")
+    expect(eventNode.parameters?.jsonBody).toContain("stage: 'provisioning_reminder_sent'")
+    expect(eventNode.parameters?.jsonBody).toContain("status: 'completed'")
+    expect(eventNode.parameters?.jsonBody).toContain('final: true')
+    expect(eventNode.parameters?.jsonBody).toContain('delivery_channel')
+    expect(eventNode.parameters?.jsonBody).toContain('agent_run_id')
+    expect(eventNode.parameters?.jsonBody).toContain('WF-PROV:provisioning_reminder_sent')
+
+    expectConnection(workflow, 'Report Agent Trace Event', 'Respond OK')
+  })
+})

--- a/n8n-exports/WF-PROV-Provisioning-Reminder.json
+++ b/n8n-exports/WF-PROV-Provisioning-Reminder.json
@@ -35,7 +35,9 @@
             {"id": "a3", "name": "project_name", "type": "string", "value": "={{ $json.body.project_name }}"},
             {"id": "a4", "name": "pending_items", "type": "string", "value": "={{ $json.body.pending_items }}"},
             {"id": "a5", "name": "slack_channel", "type": "string", "value": "={{ $json.body.slack_channel || '' }}"},
-            {"id": "a6", "name": "callback_url", "type": "string", "value": "={{ $json.body.callback_url || '' }}"}
+            {"id": "a6", "name": "callback_url", "type": "string", "value": "={{ $json.body.callback_url || '' }}"},
+            {"id": "a7", "name": "agent_run_id", "type": "string", "value": "={{ $json.body.agent_run_id || '' }}"},
+            {"id": "a8", "name": "agent_event_callback_url", "type": "string", "value": "={{ $json.body.agent_event_callback_url || '' }}"}
           ]
         },
         "options": {}
@@ -109,10 +111,59 @@
       "waitBetweenTries": 3000
     },
     {
+      "name": "Has Agent Event Callback URL",
+      "id": "check-agent-event-callback",
+      "typeVersion": 2.3,
+      "position": [1000, 300],
+      "type": "n8n-nodes-base.if",
+      "parameters": {
+        "conditions": {
+          "options": {"version": 2, "leftValue": "", "caseSensitive": true, "typeValidation": "strict"},
+          "combinator": "and",
+          "conditions": [
+            {
+              "id": "cond-agent-event-callback",
+              "operator": {"type": "string", "operation": "notEmpty"},
+              "leftValue": "={{ $node[\"Extract Payload\"].json.agent_event_callback_url }}",
+              "rightValue": ""
+            }
+          ]
+        },
+        "options": {}
+      }
+    },
+    {
+      "name": "Report Agent Trace Event",
+      "id": "report-agent-trace-event",
+      "typeVersion": 4.4,
+      "position": [1250, 220],
+      "type": "n8n-nodes-base.httpRequest",
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $node[\"Extract Payload\"].json.agent_event_callback_url }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {"name": "Content-Type", "value": "application/json"},
+            {"name": "Authorization", "value": "=Bearer {{ $vars.N8N_INGEST_SECRET || $env.N8N_INGEST_SECRET }}"}
+          ]
+        },
+        "specifyBody": "json",
+        "jsonBody": "={\n  workflow_id: 'WF-PROV',\n  stage: 'provisioning_reminder_sent',\n  status: 'completed',\n  final: true,\n  items_count: 1,\n  metadata: {\n    project_name: $node[\"Extract Payload\"].json.project_name || null,\n    client_email: $node[\"Extract Payload\"].json.client_email || null,\n    delivery_channel: $node[\"Extract Payload\"].json.slack_channel ? 'slack' : 'email'\n  },\n  idempotency_key: `${$node[\"Extract Payload\"].json.agent_run_id || 'no-agent-run'}:WF-PROV:provisioning_reminder_sent`\n}",
+        "options": {},
+        "authentication": "none",
+        "contentType": "json"
+      },
+      "onError": "continueRegularOutput",
+      "retryOnFail": true,
+      "maxTries": 2,
+      "waitBetweenTries": 3000
+    },
+    {
       "name": "Respond OK",
       "id": "respond-ok",
       "typeVersion": 1.5,
-      "position": [1000, 300],
+      "position": [1500, 300],
       "type": "n8n-nodes-base.respondToWebhook",
       "parameters": {
         "respondWith": "json",
@@ -135,9 +186,18 @@
       ]
     },
     "Send Slack Reminder": {
-      "main": [[{"node": "Respond OK", "type": "main", "index": 0}]]
+      "main": [[{"node": "Has Agent Event Callback URL", "type": "main", "index": 0}]]
     },
     "Send Email Reminder": {
+      "main": [[{"node": "Has Agent Event Callback URL", "type": "main", "index": 0}]]
+    },
+    "Has Agent Event Callback URL": {
+      "main": [
+        [{"node": "Report Agent Trace Event", "type": "main", "index": 0}],
+        [{"node": "Respond OK", "type": "main", "index": 0}]
+      ]
+    },
+    "Report Agent Trace Event": {
       "main": [[{"node": "Respond OK", "type": "main", "index": 0}]]
     }
   },


### PR DESCRIPTION
Summary
- Preserve Agent Ops trace fields in the WF-PROV provisioning reminder export.
- Add a guarded Agent Ops final completion callback after Slack/email reminder delivery when `agent_event_callback_url` is supplied.
- Add an export regression test and update the Agent Operations roadmap hardening note.

Validation
- `npm test -- lib/__tests__/n8n-provisioning-reminder-workflow-export.test.ts 'app/api/admin/agents/runs/[runId]/events/route.test.ts'`\n- `npx tsc --noEmit --pretty false`\n- `npm run lint -- --file lib/__tests__/n8n-provisioning-reminder-workflow-export.test.ts`\n- `git diff --check`\n- `npm run build`\n\nIntegration Notes\n- No migration.\n- No live n8n execution or customer-data smoke was run.\n- Worktree env bootstrapped from `/Users/vambahsillah/Projects/Portfolio`; `.env.staging` was not present in the source checkout.\n- Build passed with the existing local warning that outbound n8n webhooks are enabled in `.env.local`.\n- Post-merge captain gate should verify both `Vercel – portfolio` and `Vercel – portfolio-staging`.