### PR TITLE
feat: add social outreach goal pilot

### DIFF
--- a/app/admin/agents/standup/page.test.tsx
+++ b/app/admin/agents/standup/page.test.tsx
@@ -155,6 +155,55 @@ describe('AgentStandupRoomPage', () => {
       if (String(url).includes('/api/admin/agents/war-room')) {
         const body = JSON.parse(String((init as RequestInit).body ?? '{}'))
         if (body.command === 'draft_goal') {
+          if (body.goal_type === 'social_outreach_linkedin_post') {
+            return {
+              ok: true,
+              json: async () => ({
+                ok: true,
+                run_id: 'social-goal-run',
+                command: 'draft_goal',
+                goal_draft: {
+                  goal_id: 'goal-social',
+                  goal_type: 'social_outreach_linkedin_post',
+                  title: body.goal,
+                  objective: `Produce one draft-only LinkedIn content packet for: ${body.goal}`,
+                  recommendation: 'Approve this pilot only if the output should stop at a Social Content draft.',
+                  risk_notes: 'Manual Chronicle evidence and approved Open Brain context are required.',
+                  publish_gate: 'draft_only',
+                  source_requirements: ['One source-backed industry signal'],
+                  chronicle_packet_status: 'manual_packet_required',
+                  content_packet_id: 'packet-goal-social',
+                  content_packet: {
+                    id: 'packet-goal-social',
+                    goal_statement: body.goal,
+                    target_audience: 'LinkedIn audience: small business, nonprofit, and product leaders.',
+                    industry_signal_summary: 'Pending research: capture one current industry signal.',
+                    amadutown_proof_points: ['Agent Ops proves the workflow.'],
+                    open_brain_references: ['Approved Open Brain references only.'],
+                    chronicle_evidence_notes: ['Manual Chronicle packet required in V1.'],
+                    draft_linkedin_post: 'A small business does not need another AI demo.',
+                    visual_concept: 'Mission Control routes one social outreach goal into accountable work.',
+                    image_prompt: 'Dark operating-console illustration with gold command accents.',
+                    source_provenance_checklist: ['Open Brain references are approved/public-safe.', 'Chronicle notes are manually sanitized.'],
+                    approval_checklist: ['Social Content item remains draft-only until separately approved.'],
+                  },
+                  tasks: [{
+                    id: 'goal-social-post-draft',
+                    title: 'Draft the LinkedIn post',
+                    objective: 'Turn source evidence into one Vambah-aligned LinkedIn draft.',
+                    owner_agent_key: 'voice-content-architect',
+                    priority: 'high',
+                    dependencies: [],
+                    expected_files: ['docs/linkedin-voice.md'],
+                    acceptance_criteria: ['Draft opens with a concrete tension'],
+                    risk_notes: 'No raw private material.',
+                    goal_progress_weight: 3,
+                  }],
+                },
+                messages: [],
+              }),
+            }
+          }
           return {
             ok: true,
             json: async () => ({
@@ -203,6 +252,9 @@ describe('AgentStandupRoomPage', () => {
               run_id: 'approval-run',
               command: 'approve_goal',
               messages: [],
+              social_content_draft: body.draft?.goal_type === 'social_outreach_linkedin_post'
+                ? { id: 'social-draft-1', href: '/admin/social-content/social-draft-1' }
+                : null,
               created_work_items: {
                 parent: { id: 'parent', title: 'Goal: Improve standup' },
                 children: [{ id: 'child', title: 'Implement room' }],
@@ -359,7 +411,7 @@ describe('AgentStandupRoomPage', () => {
     expect(screen.getAllByRole('link', { name: /Open trace/i }).some((link) => link.getAttribute('href') === '/admin/agents/runs/goal-run')).toBe(true)
     expect(fetch).toHaveBeenCalledWith('/api/admin/agents/war-room', expect.objectContaining({
       method: 'POST',
-      body: JSON.stringify({ command: 'draft_goal', goal: 'Improve standup' }),
+      body: JSON.stringify({ command: 'draft_goal', goal: 'Improve standup', goal_type: 'general' }),
     }))
 
     fireEvent.change(screen.getByDisplayValue('Implement room'), { target: { value: 'Implement reviewed room' } })
@@ -375,6 +427,35 @@ describe('AgentStandupRoomPage', () => {
     const approveBody = JSON.parse(String((approveCall?.[1] as RequestInit).body))
     expect(approveBody.draft.tasks).toHaveLength(1)
     expect(approveBody.draft.tasks[0].title).toBe('Implement reviewed room')
+  })
+
+  it('renders the LinkedIn pilot template and draft-only packet before approval', async () => {
+    render(<AgentStandupRoomPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'LinkedIn pilot' }))
+    expect(screen.getByPlaceholderText('What should the swarm accomplish?')).toHaveValue('Create one LinkedIn post package showing how AmaduTown applies AI and automation to reduce operational burden for small businesses.')
+
+    fireEvent.click(screen.getByRole('button', { name: /Draft plan/i }))
+
+    expect(await screen.findByText('LinkedIn content packet')).toBeInTheDocument()
+    expect(screen.getByText('Publish gate: draft only')).toBeInTheDocument()
+    expect(screen.getByText('Chronicle: manual packet')).toBeInTheDocument()
+    expect(screen.getByText('LinkedIn audience: small business, nonprofit, and product leaders.')).toBeInTheDocument()
+    expect(screen.getByText('Pending research: capture one current industry signal.')).toBeInTheDocument()
+    expect(screen.getByText(/Open Brain references are approved\/public-safe/i)).toBeInTheDocument()
+    expect(screen.getByText('Mission Control routes one social outreach goal into accountable work.')).toBeInTheDocument()
+    expect(fetch).toHaveBeenCalledWith('/api/admin/agents/war-room', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({
+        command: 'draft_goal',
+        goal: 'Create one LinkedIn post package showing how AmaduTown applies AI and automation to reduce operational burden for small businesses.',
+        goal_type: 'social_outreach_linkedin_post',
+      }),
+    }))
+
+    fireEvent.click(screen.getByRole('button', { name: /Approve goal/i }))
+
+    expect(await screen.findByRole('link', { name: /Open linked Social Content draft/i })).toHaveAttribute('href', '/admin/social-content/social-draft-1')
   })
 
   it('opens a linked goal session from the query string', async () => {

--- a/app/admin/agents/standup/page.tsx
+++ b/app/admin/agents/standup/page.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import {
   ArrowRight,
   CheckCircle2,
+  ExternalLink,
   GitPullRequest,
   KanbanSquare,
   MessageSquare,
@@ -45,6 +46,7 @@ type WarRoomResponse = {
     parent: { id: string; title: string }
     children: Array<{ id: string; title: string }>
   } | null
+  social_content_draft?: { id: string; href: string } | null
   error?: string
 }
 
@@ -118,6 +120,7 @@ function StandupRoomContent() {
   const [selectionInitialized, setSelectionInitialized] = useState(false)
   const [message, setMessage] = useState('')
   const [goal, setGoal] = useState('')
+  const [goalType, setGoalType] = useState<'general' | 'social_outreach_linkedin_post'>('general')
   const [focusedGoalId, setFocusedGoalId] = useState<string | null>(null)
   const [goalDraft, setGoalDraft] = useState<AgentGoalDraft | null>(null)
   const [createdItems, setCreatedItems] = useState<WarRoomResponse['created_work_items']>(null)
@@ -250,6 +253,16 @@ function StandupRoomContent() {
       if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`)
       if (body.messages?.length) setTranscript((current) => [...current, ...body.messages!])
       if (body.goal_draft) setGoalDraft(body.goal_draft)
+      if (body.social_content_draft) {
+        setGoalDraft((current) => current?.content_packet ? {
+          ...current,
+          content_packet: {
+            ...current.content_packet,
+            social_content_draft_id: body.social_content_draft?.id ?? null,
+            social_content_draft_href: body.social_content_draft?.href ?? null,
+          },
+        } : current)
+      }
       if (body.run_id) {
         setCommandTraces((current) => {
           const nextTrace = {
@@ -351,7 +364,12 @@ function StandupRoomContent() {
 
   async function draftGoal() {
     if (!goal.trim()) return
-    await postWarRoom({ command: 'draft_goal', goal: goal.trim() }, 'draft-goal')
+    await postWarRoom({ command: 'draft_goal', goal: goal.trim(), goal_type: goalType }, 'draft-goal')
+  }
+
+  function applySocialOutreachTemplate() {
+    setGoalType('social_outreach_linkedin_post')
+    setGoal('Create one LinkedIn post package showing how AmaduTown applies AI and automation to reduce operational burden for small businesses.')
   }
 
   async function approveGoal() {
@@ -517,6 +535,9 @@ function StandupRoomContent() {
                 busy={busy}
                 participants={participants}
                 onGoalChange={setGoal}
+                goalType={goalType}
+                onGoalTypeChange={setGoalType}
+                onApplySocialOutreachTemplate={applySocialOutreachTemplate}
                 onDraftGoal={draftGoal}
                 onApproveGoal={approveGoal}
                 onUpdateTask={updateGoalTask}
@@ -813,22 +834,28 @@ function ChatRoom({
 
 function GoalPlanner({
   goal,
+  goalType,
   goalDraft,
   createdItems,
   busy,
   participants,
   onGoalChange,
+  onGoalTypeChange,
+  onApplySocialOutreachTemplate,
   onDraftGoal,
   onApproveGoal,
   onUpdateTask,
   onRemoveTask,
 }: {
   goal: string
+  goalType: 'general' | 'social_outreach_linkedin_post'
   goalDraft: AgentGoalDraft | null
   createdItems: WarRoomResponse['created_work_items']
   busy: string | null
   participants: AgentOrgBoardAgent[]
   onGoalChange: (value: string) => void
+  onGoalTypeChange: (value: 'general' | 'social_outreach_linkedin_post') => void
+  onApplySocialOutreachTemplate: () => void
   onDraftGoal: () => void
   onApproveGoal: () => void
   onUpdateTask: (taskId: string, patch: Partial<AgentGoalDraft['tasks'][number]>) => void
@@ -839,6 +866,32 @@ function GoalPlanner({
       <div className="mb-3 flex items-center gap-2">
         <Sparkles size={18} className="text-radiant-gold" />
         <h2 className="text-xl font-semibold">Goal planner</h2>
+      </div>
+      <div className="mb-3 rounded-lg border border-silicon-slate/60 bg-background/45 p-3">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-radiant-gold">Pilot template</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Use the LinkedIn social outreach pilot when Shaka should create a draft-only content packet, Kanban tasks, and a Social Content draft.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => onGoalTypeChange('general')}
+              className={`rounded-full border px-3 py-1.5 text-xs ${goalType === 'general' ? 'border-radiant-gold/70 text-radiant-gold' : 'border-silicon-slate/60 text-muted-foreground hover:text-foreground'}`}
+            >
+              General goal
+            </button>
+            <button
+              type="button"
+              onClick={onApplySocialOutreachTemplate}
+              className={`rounded-full border px-3 py-1.5 text-xs ${goalType === 'social_outreach_linkedin_post' ? 'border-radiant-gold/70 bg-radiant-gold/10 text-radiant-gold' : 'border-silicon-slate/60 text-muted-foreground hover:text-foreground'}`}
+            >
+              LinkedIn pilot
+            </button>
+          </div>
+        </div>
       </div>
       <div className="flex flex-col gap-2 lg:flex-row">
         <input
@@ -859,12 +912,42 @@ function GoalPlanner({
               <p className="text-xs font-semibold uppercase tracking-[0.16em] text-radiant-gold">Draft packet</p>
               <h3 className="mt-1 text-lg font-semibold">{goalDraft.title}</h3>
               <p className="mt-1 text-sm text-muted-foreground">{goalDraft.recommendation}</p>
+              <div className="mt-3 flex flex-wrap gap-2 text-xs">
+                {goalDraft.goal_type === 'social_outreach_linkedin_post' && (
+                  <>
+                    <span className="rounded-full border border-radiant-gold/35 px-2 py-1 text-radiant-gold">LinkedIn content packet</span>
+                    <span className="rounded-full border border-silicon-slate/60 px-2 py-1 text-muted-foreground">Publish gate: draft only</span>
+                    <span className="rounded-full border border-silicon-slate/60 px-2 py-1 text-muted-foreground">Chronicle: manual packet</span>
+                  </>
+                )}
+              </div>
             </div>
             <button onClick={onApproveGoal} disabled={busy != null || goalDraft.tasks.length === 0} className="inline-flex items-center justify-center gap-2 rounded-lg bg-radiant-gold px-4 py-2 text-sm font-semibold text-obsidian hover:bg-radiant-gold/90 disabled:opacity-50">
               <CheckCircle2 size={16} />
               Approve goal
             </button>
           </div>
+          {goalDraft.content_packet && (
+            <div className="mt-4 grid gap-3 lg:grid-cols-2">
+              <div className="rounded-lg border border-silicon-slate/60 bg-background/60 p-3">
+                <p className="text-xs font-semibold uppercase tracking-[0.14em] text-radiant-gold">LinkedIn Content Packet</p>
+                <p className="mt-2 text-sm font-medium">{goalDraft.content_packet.target_audience}</p>
+                <p className="mt-2 text-sm text-muted-foreground">{goalDraft.content_packet.industry_signal_summary}</p>
+                <div className="mt-3 grid gap-1 text-xs text-muted-foreground">
+                  {goalDraft.content_packet.source_provenance_checklist.slice(0, 3).map((item) => (
+                    <span key={item}>• {item}</span>
+                  ))}
+                </div>
+              </div>
+              <div className="rounded-lg border border-silicon-slate/60 bg-background/60 p-3">
+                <p className="text-xs font-semibold uppercase tracking-[0.14em] text-radiant-gold">Visual brief</p>
+                <p className="mt-2 text-sm text-muted-foreground">{goalDraft.content_packet.visual_concept}</p>
+                <p className="mt-3 line-clamp-3 rounded-md border border-silicon-slate/50 bg-black/10 p-2 text-xs text-muted-foreground">
+                  {goalDraft.content_packet.image_prompt}
+                </p>
+              </div>
+            </div>
+          )}
           <div className="mt-4 grid gap-2">
             {goalDraft.tasks.map((task, index) => (
               <div key={task.id} className="rounded-lg border border-silicon-slate/60 bg-background/60 p-3">
@@ -995,6 +1078,12 @@ function GoalPlanner({
               </Link>
             )}
           </div>
+          {goalDraft?.content_packet?.social_content_draft_href && (
+            <Link href={goalDraft.content_packet.social_content_draft_href} className="mt-2 inline-flex items-center gap-2 text-xs text-radiant-gold hover:underline">
+              Open linked Social Content draft
+              <ExternalLink size={13} />
+            </Link>
+          )}
           <div className="mt-2 grid gap-1">
             {createdItems.children.slice(0, 4).map((item, index) => (
               <p key={item.id} className="text-xs text-green-100/80">{index + 1}. {item.title}</p>

--- a/app/admin/social-content/[id]/page.tsx
+++ b/app/admin/social-content/[id]/page.tsx
@@ -64,6 +64,18 @@ const PLATFORM_COLORS: Record<string, { active: string; inactive: string }> = {
   facebook: { active: 'bg-blue-600/20 border-blue-500 text-blue-300', inactive: 'bg-gray-800 border-gray-700 text-gray-500 hover:border-gray-600' },
 }
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null
+}
+
+function asString(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
+}
+
 function SocialContentDetailPage() {
   const { id } = useParams<{ id: string }>()
   const router = useRouter()
@@ -440,6 +452,17 @@ function SocialContentDetailPage() {
   const enabledPlatformLabels = targetPlatforms
     .map(p => PLATFORMS.find(pl => pl.value === p)?.label || p)
     .join(', ')
+  const ragContext = asRecord(item.rag_context)
+  const isAgentSocialPilot = ragContext?.source === 'agent_ops_social_outreach_goal'
+  const agentPilotGoalId = asString(ragContext?.goal_id)
+  const agentPilotPacketId = asString(ragContext?.content_packet_id)
+  const agentPilotPublishGate = asString(ragContext?.publish_gate)
+  const agentPilotChronicleStatus = asString(ragContext?.chronicle_packet_status)
+  const agentPilotVisualBrief = asString(ragContext?.visual_brief)
+  const agentPilotProvenance = asStringArray(ragContext?.source_provenance_checklist)
+  const agentPilotApprovalChecklist = asStringArray(ragContext?.approval_checklist)
+  const agentPilotOpenBrainReferences = asStringArray(ragContext?.open_brain_references)
+  const isDraftOnlyPilot = isAgentSocialPilot && agentPilotPublishGate === 'draft_only'
 
   return (
     <div className="min-h-screen bg-background text-foreground">
@@ -494,6 +517,101 @@ function SocialContentDetailPage() {
       </div>
 
       <div className="p-8 max-w-6xl mx-auto space-y-6">
+        {isAgentSocialPilot && (
+          <section className="rounded-xl border border-amber-500/30 bg-gray-900/80 p-5 shadow-[0_0_28px_rgba(212,175,55,0.08)]">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+              <div className="min-w-0">
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-amber-300">
+                  Agent Ops LinkedIn Pilot
+                </p>
+                <h2 className="mt-2 text-xl font-semibold text-gray-100">
+                  Draft-only content packet
+                </h2>
+                <p className="mt-2 max-w-3xl text-sm leading-6 text-gray-300">
+                  This post was created from an approved Standup Room goal. Goal approval created the work items and this draft; publishing still requires the separate Social Content approval gate.
+                </p>
+              </div>
+              <div className="flex shrink-0 flex-wrap gap-2 text-xs">
+                <span className="rounded-full border border-amber-500/40 bg-amber-500/10 px-3 py-1 text-amber-200">
+                  {isDraftOnlyPilot ? 'Publish gate: draft only' : `Publish gate: ${agentPilotPublishGate || 'review required'}`}
+                </span>
+                {agentPilotChronicleStatus && (
+                  <span className="rounded-full border border-blue-500/30 bg-blue-500/10 px-3 py-1 text-blue-200">
+                    Chronicle: {agentPilotChronicleStatus.replace(/_/g, ' ')}
+                  </span>
+                )}
+                {agentPilotPacketId && (
+                  <span className="rounded-full border border-gray-700 bg-gray-800 px-3 py-1 text-gray-300">
+                    Packet {agentPilotPacketId}
+                  </span>
+                )}
+              </div>
+            </div>
+
+            <div className="mt-4 grid gap-3 lg:grid-cols-3">
+              <div className="rounded-lg border border-gray-800 bg-gray-950/40 p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.14em] text-gray-500">Provenance</p>
+                <ul className="mt-3 space-y-2 text-sm text-gray-300">
+                  {agentPilotProvenance.slice(0, 4).map((entry) => (
+                    <li key={entry} className="flex gap-2">
+                      <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-300" />
+                      <span>{entry}</span>
+                    </li>
+                  ))}
+                  {agentPilotProvenance.length === 0 && (
+                    <li className="text-gray-500">No provenance checklist attached.</li>
+                  )}
+                </ul>
+              </div>
+              <div className="rounded-lg border border-gray-800 bg-gray-950/40 p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.14em] text-gray-500">Review Checklist</p>
+                <ul className="mt-3 space-y-2 text-sm text-gray-300">
+                  {agentPilotApprovalChecklist.slice(0, 4).map((entry) => (
+                    <li key={entry} className="flex gap-2">
+                      <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-amber-300" />
+                      <span>{entry}</span>
+                    </li>
+                  ))}
+                  {agentPilotApprovalChecklist.length === 0 && (
+                    <li className="text-gray-500">No approval checklist attached.</li>
+                  )}
+                </ul>
+              </div>
+              <div className="rounded-lg border border-gray-800 bg-gray-950/40 p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.14em] text-gray-500">Visual Brief</p>
+                <p className="mt-3 text-sm leading-6 text-gray-300">
+                  {agentPilotVisualBrief || 'No visual brief attached.'}
+                </p>
+              </div>
+            </div>
+
+            <div className="mt-4 flex flex-wrap items-center gap-3 text-sm">
+              {agentPilotGoalId && (
+                <Link
+                  href={`/admin/agents/standup?goal=${encodeURIComponent(agentPilotGoalId)}`}
+                  className="inline-flex items-center gap-2 rounded-lg border border-amber-500/40 px-3 py-2 text-amber-200 transition-colors hover:bg-amber-500/10"
+                >
+                  Open goal session <ExternalLink className="h-3.5 w-3.5" />
+                </Link>
+              )}
+              <Link
+                href="/admin/agents/swarm-board"
+                className="inline-flex items-center gap-2 rounded-lg border border-gray-700 px-3 py-2 text-gray-300 transition-colors hover:border-gray-600 hover:bg-gray-800"
+              >
+                View Kanban tasks <ExternalLink className="h-3.5 w-3.5" />
+              </Link>
+              {agentPilotOpenBrainReferences.length > 0 && (
+                <Link
+                  href="/admin/agents/open-brain"
+                  className="inline-flex items-center gap-2 rounded-lg border border-gray-700 px-3 py-2 text-gray-300 transition-colors hover:border-gray-600 hover:bg-gray-800"
+                >
+                  Open Brain references <ExternalLink className="h-3.5 w-3.5" />
+                </Link>
+              )}
+            </div>
+          </section>
+        )}
+
         {/* ================================================================ */}
         {/* SECTION 1: Content (two-col on lg: edit fields + preview)        */}
         {/* ================================================================ */}
@@ -1211,6 +1329,11 @@ function SocialContentDetailPage() {
               <h3 className="text-lg font-semibold text-gray-200 mb-4">Confirm Publishing</h3>
 
               <div className="space-y-3 mb-6">
+                {isDraftOnlyPilot && (
+                  <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-100">
+                    This draft came from a draft-only Agent Ops pilot. Goal approval did not publish it; this confirmation is the separate Social Content approval gate.
+                  </div>
+                )}
                 <div className="flex items-center justify-between text-sm">
                   <span className="text-gray-400">Platforms</span>
                   <span className="text-gray-200">{enabledPlatformLabels}</span>

--- a/app/api/admin/agents/war-room/route.test.ts
+++ b/app/api/admin/agents/war-room/route.test.ts
@@ -172,6 +172,41 @@ describe('POST /api/admin/agents/war-room', () => {
     }))
   })
 
+  it('passes social outreach goal type to the war room executor', async () => {
+    mocks.runAgentWarRoom.mockResolvedValue({
+      runId: 'goal-run',
+      command: 'draft_goal',
+      synthesis: 'Goal draft ready.',
+      updates: [],
+      messages: [],
+      goalDraft: {
+        goal_id: 'goal-social',
+        goal_type: 'social_outreach_linkedin_post',
+        title: 'Create LinkedIn post',
+        objective: 'Draft only',
+        recommendation: 'Approve draft-only pilot.',
+        risk_notes: 'No publishing.',
+        publish_gate: 'draft_only',
+        tasks: [],
+      },
+    })
+
+    const response = await POST(request({
+      command: 'draft_goal',
+      goal: 'Create LinkedIn post',
+      goal_type: 'social_outreach_linkedin_post',
+    }) as never)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.goal_draft.goal_type).toBe('social_outreach_linkedin_post')
+    expect(mocks.runAgentWarRoom).toHaveBeenCalledWith(expect.objectContaining({
+      command: 'draft_goal',
+      goal: 'Create LinkedIn post',
+      goalType: 'social_outreach_linkedin_post',
+    }))
+  })
+
   it('passes approved goal drafts to the war room executor', async () => {
     const draft = {
       goal_id: 'goal-1',

--- a/app/api/admin/agents/war-room/route.ts
+++ b/app/api/admin/agents/war-room/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
-import { runAgentWarRoom, type AgentWarRoomCommand } from '@/lib/agent-war-room'
+import { runAgentWarRoom, type AgentGoalType, type AgentWarRoomCommand } from '@/lib/agent-war-room'
 
 export const dynamic = 'force-dynamic'
 export const maxDuration = 30
@@ -37,6 +37,8 @@ export async function POST(request: NextRequest) {
     goal_id?: unknown
     goalId?: unknown
     goal?: unknown
+    goal_type?: unknown
+    goalType?: unknown
     draft?: unknown
   }
   try {
@@ -82,6 +84,14 @@ export async function POST(request: NextRequest) {
   if (command === 'draft_goal' && !goal) {
     return NextResponse.json({ error: 'Goal is required for draft_goal' }, { status: 400 })
   }
+  const goalTypeRaw = typeof body.goal_type === 'string'
+    ? body.goal_type.trim()
+    : typeof body.goalType === 'string'
+      ? body.goalType.trim()
+      : ''
+  const goalType: AgentGoalType = goalTypeRaw === 'social_outreach_linkedin_post'
+    ? 'social_outreach_linkedin_post'
+    : 'general'
 
   if (command === 'approve_goal' && (!body.draft || typeof body.draft !== 'object')) {
     return NextResponse.json({ error: 'draft is required for approve_goal' }, { status: 400 })
@@ -95,6 +105,7 @@ export async function POST(request: NextRequest) {
       targetAgentKeys,
       goalId,
       goal,
+      goalType,
       draft: command === 'approve_goal' ? body.draft as never : null,
       triggerSource: 'admin_agent_war_room',
       actor: {
@@ -113,6 +124,12 @@ export async function POST(request: NextRequest) {
       messages: result.messages,
       goal_draft: result.goalDraft,
       created_work_items: result.createdWorkItems,
+      social_content_draft: result.createdWorkItems?.parent.metadata?.social_content_draft_id
+        ? {
+          id: result.createdWorkItems.parent.metadata.social_content_draft_id,
+          href: result.createdWorkItems.parent.metadata.social_content_draft_href,
+        }
+        : null,
     })
   } catch (error) {
     console.error('[agent-war-room] command failed:', error)

--- a/docs/agent-operations-roadmap.md
+++ b/docs/agent-operations-roadmap.md
@@ -341,6 +341,29 @@ Current progress:
 - Mission Control dead-letter items now show routed recovery status, retry attempt, earliest retry time, and whether the retry packet is still waiting inside the backoff window.
 - The Agent Operations rollout is capped after Phase 12. Remaining improvements move to the maintenance backlog unless Vambah explicitly opens a new roadmap.
 
+## Approved Pilot Overlay: LinkedIn Social Outreach
+
+Status: In implementation.
+
+Target: One prepare-only LinkedIn content packet by Friday, May 29, 2026.
+
+Goal: Pilot the Standup Room goal flow on one AmaduTown social outreach use case without autonomous publishing, scheduling, DMs, or external outreach.
+
+Definition of done:
+
+- Standup Room includes a `social_outreach_linkedin_post` goal template.
+- Shaka drafts the goal plan first; approving the draft creates one parent Agent Ops goal work item and child work items for research, Open Brain context, Chronicle evidence, AmaduTown proof, post drafting, visual brief, governance QA, and Social Content handoff.
+- Goal and child cards appear on Agent Kanban with goal tags, owner, status, blockers, age, and packet links.
+- The linked Social Content item remains `draft` and includes the content packet, visual brief, provenance checklist, Chronicle manual packet status, and approval checklist.
+- Open Brain context projected into the packet is public-safe or proposal-summary level; raw private records are not copied into the content draft.
+
+Out of scope:
+
+- Autonomous publishing, scheduling, DMs, or external outreach.
+- Direct Chronicle ingestion.
+- A campaign batch or recurring social calendar.
+- New database tables or schema migration for the pilot.
+
 ## Cross-Phase Definition Of Done
 
 Every implementation phase must satisfy these gates before it is considered done:

--- a/lib/agent-swarm-board.test.ts
+++ b/lib/agent-swarm-board.test.ts
@@ -752,6 +752,56 @@ describe('buildAgentOrgBoardSnapshotFromRows', () => {
     })
   })
 
+  it('projects social outreach packet metadata onto goal-tagged Kanban cards', () => {
+    const snapshot = buildAgentOrgBoardSnapshotFromRows({
+      now: new Date('2026-05-05T16:00:00.000Z'),
+      runs: [],
+      events: [],
+      workItems: [
+        orgWorkItem({
+          id: 'work-social-draft',
+          title: 'Create the Social Content draft handoff',
+          status: 'assigned',
+          priority: 'high',
+          owner_agent_key: 'content-repurposing',
+          metadata: {
+            goal_id: 'goal-social',
+            goal_title: 'Create one LinkedIn post package',
+            goal_type: 'social_outreach_linkedin_post',
+            goal_sequence: 8,
+            goal_status: 'approved',
+            goal_progress_weight: 1,
+            publish_gate: 'draft_only',
+            chronicle_packet_status: 'manual_packet_required',
+            content_packet_id: 'packet-goal-social',
+            social_content_draft_id: 'social-draft-1',
+            social_content_draft_href: '/admin/social-content/social-draft-1',
+          },
+        }),
+      ],
+      approvals: [],
+    })
+
+    const socialTask = snapshot.lanes.flatMap((lane) => lane.tasks).find((task) => task.id === 'work-social-draft')
+
+    expect(socialTask?.goal).toMatchObject({
+      id: 'goal-social',
+      title: 'Create one LinkedIn post package',
+      goalType: 'social_outreach_linkedin_post',
+      publishGate: 'draft_only',
+      chroniclePacketStatus: 'manual_packet_required',
+      contentPacketId: 'packet-goal-social',
+      socialContentDraftId: 'social-draft-1',
+      socialContentDraftHref: '/admin/social-content/social-draft-1',
+    })
+    expect(snapshot.summary.goals[0]).toMatchObject({
+      id: 'goal-social',
+      goalType: 'social_outreach_linkedin_post',
+      publishGate: 'draft_only',
+      socialContentDraftHref: '/admin/social-content/social-draft-1',
+    })
+  })
+
   it('resolves dependency and handoff relationships without a schema migration', () => {
     const snapshot = buildAgentOrgBoardSnapshotFromRows({
       now: new Date('2026-05-05T16:00:00.000Z'),

--- a/lib/agent-swarm-board.ts
+++ b/lib/agent-swarm-board.ts
@@ -186,6 +186,12 @@ export type AgentOrgBoardTask = {
     n8nWorkflows: string[]
     approvalGate: string | null
     nextAction: string | null
+    goalType: string | null
+    contentPacketId: string | null
+    publishGate: string | null
+    chroniclePacketStatus: string | null
+    socialContentDraftId: string | null
+    socialContentDraftHref: string | null
     n8nProposal: AgentOrgBoardN8nProposalContext | null
   } | null
 }
@@ -213,6 +219,12 @@ export type AgentOrgBoardGoalMetric = {
   n8nWorkflows: string[]
   approvalGate: string | null
   nextAction: string | null
+  goalType: string | null
+  contentPacketId: string | null
+  publishGate: string | null
+  chroniclePacketStatus: string | null
+  socialContentDraftId: string | null
+  socialContentDraftHref: string | null
 }
 
 export type AgentOrgBoardWipMetric = {
@@ -937,6 +949,12 @@ function goalForTask(item: AgentWorkItemRow): AgentOrgBoardTask['goal'] {
     n8nWorkflows: stringArrayValue(metadata.n8n_workflows),
     approvalGate: stringValue(metadata.approval_gate),
     nextAction: stringValue(metadata.next_action),
+    goalType: stringValue(metadata.goal_type),
+    contentPacketId: stringValue(metadata.content_packet_id),
+    publishGate: stringValue(metadata.publish_gate),
+    chroniclePacketStatus: stringValue(metadata.chronicle_packet_status),
+    socialContentDraftId: stringValue(metadata.social_content_draft_id),
+    socialContentDraftHref: stringValue(metadata.social_content_draft_href),
     n8nProposal: isN8nProposal ? {
       action: stringValue(metadata.n8n_proposal_action),
       proposedWorkflowName: stringValue(metadata.proposed_workflow_name),
@@ -1007,6 +1025,12 @@ function buildGoalMetrics(tasks: AgentOrgBoardTask[]): AgentOrgBoardGoalMetric[]
       n8nWorkflows: firstGoal?.n8nWorkflows ?? [],
       approvalGate: firstGoal?.approvalGate ?? null,
       nextAction: firstGoal?.nextAction ?? null,
+      goalType: firstGoal?.goalType ?? null,
+      contentPacketId: firstGoal?.contentPacketId ?? null,
+      publishGate: firstGoal?.publishGate ?? null,
+      chroniclePacketStatus: firstGoal?.chroniclePacketStatus ?? null,
+      socialContentDraftId: firstGoal?.socialContentDraftId ?? null,
+      socialContentDraftHref: firstGoal?.socialContentDraftHref ?? null,
     }
   })
 }

--- a/lib/agent-war-room.test.ts
+++ b/lib/agent-war-room.test.ts
@@ -20,6 +20,11 @@ const workItemMocks = vi.hoisted(() => ({
   createAgentWorkItem: vi.fn(),
 }))
 
+const supabaseMocks = vi.hoisted(() => ({
+  from: vi.fn(),
+  socialContentDraftId: 'social-draft-1',
+}))
+
 vi.mock('@/lib/agent-run', () => ({
   startAgentRun: agentRunMocks.startAgentRun,
   recordAgentEvent: agentRunMocks.recordAgentEvent,
@@ -38,6 +43,10 @@ vi.mock('@/lib/agent-swarm-board', () => ({
 
 vi.mock('@/lib/agent-work-items', () => ({
   createAgentWorkItem: workItemMocks.createAgentWorkItem,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: { from: supabaseMocks.from },
 }))
 
 import { runAgentWarRoom } from '@/lib/agent-war-room'
@@ -141,6 +150,27 @@ describe('runAgentWarRoom', () => {
       objective: input.objective,
       metadata: input.metadata ?? {},
     }))
+    supabaseMocks.from.mockImplementation((table: string) => {
+      if (table !== 'social_content_queue') {
+        throw new Error(`Unexpected table ${table}`)
+      }
+      return {
+        select: vi.fn(() => ({
+          contains: vi.fn(() => ({
+            maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+          })),
+        })),
+        insert: vi.fn((payload) => ({
+          select: vi.fn(() => ({
+            single: vi.fn(async () => ({
+              data: { id: supabaseMocks.socialContentDraftId },
+              error: null,
+              payload,
+            })),
+          })),
+        })),
+      }
+    })
   })
 
   it('creates a traced standup run with transcript artifact', async () => {
@@ -315,6 +345,81 @@ describe('runAgentWarRoom', () => {
       }),
     }))
     expect(result.createdWorkItems?.children.length).toBe(draftResult.goalDraft?.tasks.length)
+  })
+
+  it('drafts and approves a draft-only LinkedIn social outreach pilot', async () => {
+    const draftResult = await runAgentWarRoom({
+      command: 'draft_goal',
+      goal: 'Create one LinkedIn post about AmaduTown Agent Ops',
+      goalType: 'social_outreach_linkedin_post',
+      triggerSource: 'test_war_room',
+    })
+
+    expect(draftResult.goalDraft).toMatchObject({
+      goal_type: 'social_outreach_linkedin_post',
+      publish_gate: 'draft_only',
+      chronicle_packet_status: 'manual_packet_required',
+      content_packet: expect.objectContaining({
+        target_audience: expect.stringContaining('LinkedIn audience'),
+        source_provenance_checklist: expect.arrayContaining([
+          'Open Brain references are approved/public-safe.',
+        ]),
+      }),
+    })
+    expect(draftResult.goalDraft?.tasks.map((task) => task.title)).toEqual([
+      'Capture the industry signal',
+      'Pull approved Open Brain context',
+      'Attach manual Chronicle evidence packet',
+      'Select AmaduTown proof points',
+      'Draft the LinkedIn post',
+      'Create the visual brief',
+      'Run content QA and governance review',
+      'Create the Social Content draft handoff',
+    ])
+    expect(workItemMocks.createAgentWorkItem).not.toHaveBeenCalled()
+
+    vi.clearAllMocks()
+    agentRunMocks.startAgentRun.mockResolvedValue({ id: 'approval-run' })
+    agentRunMocks.recordAgentStep.mockResolvedValue({ id: 'step' })
+    agentRunMocks.recordAgentEvent.mockResolvedValue({ id: 'event' })
+    agentRunMocks.attachAgentArtifact.mockResolvedValue({ id: 'artifact' })
+    agentRunMocks.endAgentRun.mockResolvedValue(undefined)
+    supabaseMocks.from.mockClear()
+
+    const result = await runAgentWarRoom({
+      command: 'approve_goal',
+      draft: draftResult.goalDraft,
+      triggerSource: 'test_war_room',
+    })
+
+    expect(supabaseMocks.from).toHaveBeenCalledWith('social_content_queue')
+    expect(workItemMocks.createAgentWorkItem).toHaveBeenCalledWith(expect.objectContaining({
+      title: expect.stringContaining('Goal:'),
+      metadata: expect.objectContaining({
+        goal_type: 'social_outreach_linkedin_post',
+        publish_gate: 'draft_only',
+        chronicle_packet_status: 'manual_packet_required',
+        content_packet_id: draftResult.goalDraft?.content_packet_id,
+        social_content_draft_id: 'social-draft-1',
+        social_content_draft_href: '/admin/social-content/social-draft-1',
+      }),
+    }))
+    expect(workItemMocks.createAgentWorkItem).toHaveBeenCalledWith(expect.objectContaining({
+      source: expect.objectContaining({ id: expect.stringContaining('-social-content-draft') }),
+      metadata: expect.objectContaining({
+        publish_gate: 'draft_only',
+        social_content_draft_id: 'social-draft-1',
+      }),
+    }))
+    expect(agentRunMocks.attachAgentArtifact).toHaveBeenCalledWith(expect.objectContaining({
+      metadata: expect.objectContaining({
+        social_content_draft_id: 'social-draft-1',
+      }),
+    }))
+    expect(result.createdWorkItems?.parent.metadata).toMatchObject({
+      social_content_draft_id: 'social-draft-1',
+      publish_gate: 'draft_only',
+    })
   })
 
   it('records focused goal context on room asks without creating work items', async () => {

--- a/lib/agent-war-room.ts
+++ b/lib/agent-war-room.ts
@@ -9,8 +9,27 @@ import { AGENT_ORGANIZATION, AGENT_PODS, getAgentByKey, type AgentOrganizationNo
 import { buildAgentMissionControlSnapshot } from '@/lib/agent-mission-control'
 import { buildAgentOrgBoardSnapshot, type AgentOrgBoardSnapshot, type AgentOrgBoardTask } from '@/lib/agent-swarm-board'
 import { createAgentWorkItem, type AgentWorkItem, type AgentWorkItemPriority } from '@/lib/agent-work-items'
+import { supabaseAdmin } from '@/lib/supabase'
 
 export type AgentWarRoomCommand = 'standup' | 'discuss' | 'ask_agent' | 'draft_goal' | 'approve_goal'
+export type AgentGoalType = 'general' | 'social_outreach_linkedin_post'
+
+export interface LinkedInContentPacket {
+  id: string
+  goal_statement: string
+  target_audience: string
+  industry_signal_summary: string
+  amadutown_proof_points: string[]
+  open_brain_references: string[]
+  chronicle_evidence_notes: string[]
+  draft_linkedin_post: string
+  visual_concept: string
+  image_prompt: string
+  source_provenance_checklist: string[]
+  approval_checklist: string[]
+  social_content_draft_id?: string | null
+  social_content_draft_href?: string | null
+}
 
 export interface AgentGoalDraftTask {
   id: string
@@ -27,11 +46,17 @@ export interface AgentGoalDraftTask {
 
 export interface AgentGoalDraft {
   goal_id: string
+  goal_type?: AgentGoalType
   title: string
   objective: string
   recommendation: string
   risk_notes: string
   draft_run_id?: string | null
+  publish_gate?: 'draft_only' | 'manual_approval_required'
+  source_requirements?: string[]
+  chronicle_packet_status?: 'manual_packet_required' | 'attached' | 'not_required'
+  content_packet_id?: string | null
+  content_packet?: LinkedInContentPacket | null
   tasks: AgentGoalDraftTask[]
 }
 
@@ -51,6 +76,7 @@ export interface RunAgentWarRoomInput {
   targetAgentKeys?: string[] | null
   goalId?: string | null
   goal?: string | null
+  goalType?: AgentGoalType | null
   draft?: AgentGoalDraft | null
   triggerSource: string
   actor?: {
@@ -241,9 +267,185 @@ function goalIdFromTitle(title: string) {
   return `goal-${slug}-${Date.now().toString(36)}`
 }
 
-function draftGoal(goal: string): AgentGoalDraft {
+function buildLinkedInPacket(goalId: string, title: string): LinkedInContentPacket {
+  const packetId = `packet-${goalId}`
+  return {
+    id: packetId,
+    goal_statement: title,
+    target_audience: 'LinkedIn audience: small business, nonprofit, and product leaders evaluating practical AI and automation adoption.',
+    industry_signal_summary: 'Pending research: capture one current industry signal about operational pressure, AI adoption, or workflow automation before final copy approval.',
+    amadutown_proof_points: [
+      'AmaduTown has built Portfolio Agent Ops as a working control plane for governed AI and automation work.',
+      'Mission Control, Standup Room, Agent Kanban, Open Brain, and Social Content surfaces show the operating model in practice.',
+      'The post should frame the lesson as applied work, not abstract AI commentary.',
+    ],
+    open_brain_references: [
+      'Use approved Open Brain memories or proposal summaries only.',
+      'Do not copy raw private records, source exports, or unapproved inference into public copy.',
+    ],
+    chronicle_evidence_notes: [
+      'Manual Chronicle packet required in V1.',
+      'Attach sanitized screen notes, artifact titles, or workflow observations; do not ingest raw screen history into Portfolio.',
+    ],
+    draft_linkedin_post: [
+      'A small business does not need another AI demo.',
+      '',
+      'It needs a way to see what is stuck, who owns the next step, what evidence supports the decision, and which actions still need a human approval.',
+      '',
+      'That is the real lesson from building AmaduTown Agent Ops: the value is not only in asking an agent for help. The value is in turning the answer into accountable work.',
+      '',
+      'The first draft should be revised after the research, Open Brain, and Chronicle evidence tasks are complete.',
+    ].join('\n'),
+    visual_concept: 'A dark operating-console illustration showing Mission Control routing a goal into research, evidence, draft, visual, QA, and approval lanes.',
+    image_prompt: 'Polished AmaduTown dark operating-console illustration, navy depth, gold command accents, agent swarm turning one LinkedIn outreach goal into tracked Kanban tasks, no logos besides AmaduTown if supplied, executive dashboard composition.',
+    source_provenance_checklist: [
+      'Industry signal is sourced or marked pending.',
+      'Open Brain references are approved/public-safe.',
+      'Chronicle notes are manually sanitized.',
+      'AmaduTown proof points link to Portfolio/Admin evidence where possible.',
+      'No private raw exports, credentials, client data, or unsupported claims are included.',
+    ],
+    approval_checklist: [
+      'Post matches Vambah LinkedIn voice guidance.',
+      'Visual concept supports the argument instead of decorating it.',
+      'CTA invites discussion without overpromising.',
+      'Social Content item remains draft-only until separately approved.',
+    ],
+    social_content_draft_id: null,
+    social_content_draft_href: null,
+  }
+}
+
+function socialOutreachTasks(goalId: string, title: string): AgentGoalDraftTask[] {
+  return [
+    {
+      id: `${goalId}-industry-research`,
+      title: 'Capture the industry signal',
+      objective: `Find the timely market or industry signal that makes "${title}" relevant now, and summarize it without overclaiming.`,
+      owner_agent_key: 'research-source-register',
+      priority: 'high',
+      dependencies: [],
+      expected_files: ['/admin/value-evidence', '/admin/social-content', 'docs/linkedin-voice.md'],
+      acceptance_criteria: ['One source-backed industry signal is attached', 'Unsupported claims are marked pending', 'The packet states why this matters now'],
+      risk_notes: 'Do not infer industry traction without a cited source or approved internal evidence.',
+      goal_progress_weight: 2,
+    },
+    {
+      id: `${goalId}-open-brain-context`,
+      title: 'Pull approved Open Brain context',
+      objective: 'Identify approved public-safe memories, proposals, or wiki overlays that support the post angle.',
+      owner_agent_key: 'private-knowledge-librarian',
+      priority: 'high',
+      dependencies: [],
+      expected_files: ['/admin/agents/open-brain'],
+      acceptance_criteria: ['Only approved or proposal-summary context is used', 'Raw private records stay out of the packet', 'Each reference has a traceable source label'],
+      risk_notes: 'Open Brain remains the memory source of truth; Portfolio only projects approved context.',
+      goal_progress_weight: 2,
+    },
+    {
+      id: `${goalId}-chronicle-packet`,
+      title: 'Attach manual Chronicle evidence packet',
+      objective: 'Capture sanitized Chronicle evidence notes that show how the concept has been applied without importing raw screen history.',
+      owner_agent_key: 'research-source-register',
+      priority: 'medium',
+      dependencies: [],
+      expected_files: ['Manual Chronicle packet', '/admin/agents/standup'],
+      acceptance_criteria: ['Chronicle evidence is manually summarized', 'Sensitive screen details are excluded', 'Packet notes distinguish observed evidence from interpretation'],
+      risk_notes: 'Direct Chronicle ingestion is out of scope for V1.',
+      goal_progress_weight: 1,
+    },
+    {
+      id: `${goalId}-amadutown-proof`,
+      title: 'Select AmaduTown proof points',
+      objective: 'Choose the Portfolio, Agent Ops, Open Brain, or Social Content proof points that demonstrate the applied operating model.',
+      owner_agent_key: 'voice-content-architect',
+      priority: 'high',
+      dependencies: [`${goalId}-industry-research`, `${goalId}-open-brain-context`],
+      expected_files: ['/admin/agents', '/admin/agents/swarm-board', '/admin/social-content'],
+      acceptance_criteria: ['Proof points are specific to AmaduTown work', 'Each proof point has a route or artifact home', 'The post avoids generic AI hype'],
+      risk_notes: 'Public copy should not expose admin-only operational details that are not safe to share.',
+      goal_progress_weight: 2,
+    },
+    {
+      id: `${goalId}-post-draft`,
+      title: 'Draft the LinkedIn post',
+      objective: 'Turn the approved signal and proof points into one Vambah-aligned LinkedIn draft.',
+      owner_agent_key: 'voice-content-architect',
+      priority: 'high',
+      dependencies: [`${goalId}-amadutown-proof`, `${goalId}-chronicle-packet`],
+      expected_files: ['docs/linkedin-voice.md', '/admin/social-content'],
+      acceptance_criteria: ['Draft opens with a concrete tension', 'One idea is developed clearly', 'CTA invites a specific response', '3 to 5 hashtags are suggested'],
+      risk_notes: 'Private-derived voice guidance can shape the draft but raw private material must not be quoted.',
+      goal_progress_weight: 3,
+    },
+    {
+      id: `${goalId}-visual-brief`,
+      title: 'Create the visual brief',
+      objective: 'Write a visual concept and image prompt that illustrates the operating model behind the post.',
+      owner_agent_key: 'content-repurposing',
+      priority: 'medium',
+      dependencies: [`${goalId}-post-draft`],
+      expected_files: ['/admin/social-content'],
+      acceptance_criteria: ['Visual prompt matches the Mission Control aesthetic', 'Visual supports the argument', 'Generated asset remains reviewable before use'],
+      risk_notes: 'Do not imply a generated image is evidence; label it as an illustration.',
+      goal_progress_weight: 1,
+    },
+    {
+      id: `${goalId}-qa-governance`,
+      title: 'Run content QA and governance review',
+      objective: 'Check voice fit, source support, privacy, claims, and draft-only publishing boundary.',
+      owner_agent_key: 'risk-compliance-intelligence',
+      priority: 'high',
+      dependencies: [`${goalId}-post-draft`, `${goalId}-visual-brief`],
+      expected_files: ['/admin/social-content', '/admin/agents/coordination'],
+      acceptance_criteria: ['No private leakage', 'Claims are source-backed or softened', 'Publish remains separately approval-gated'],
+      risk_notes: 'Approval to create a draft is not approval to publish.',
+      goal_progress_weight: 2,
+    },
+    {
+      id: `${goalId}-social-content-draft`,
+      title: 'Create the Social Content draft handoff',
+      objective: 'Create or link the draft-only Social Content item with the packet, visual brief, provenance, and approval notes.',
+      owner_agent_key: 'content-repurposing',
+      priority: 'high',
+      dependencies: [`${goalId}-qa-governance`],
+      expected_files: ['/admin/social-content'],
+      acceptance_criteria: ['Social Content item is draft status', 'Packet id and goal id are traceable', 'No publish, schedule, DM, or external outreach is triggered'],
+      risk_notes: 'Publishing remains manual and separately approved outside this goal approval.',
+      goal_progress_weight: 1,
+    },
+  ]
+}
+
+function draftSocialOutreachGoal(goal: string, title: string, goalId: string): AgentGoalDraft {
+  const packet = buildLinkedInPacket(goalId, title)
+  return {
+    goal_id: goalId,
+    goal_type: 'social_outreach_linkedin_post',
+    title,
+    objective: `Produce one draft-only LinkedIn content packet for: ${goal.trim()}`,
+    recommendation: 'Approve this pilot only if the output should stop at a Social Content draft. Publishing, scheduling, DMs, and outbound engagement remain outside this approval.',
+    risk_notes: 'Manual Chronicle evidence and approved Open Brain context are required before public copy is approved.',
+    publish_gate: 'draft_only',
+    source_requirements: [
+      'One source-backed industry signal',
+      'Approved Open Brain reference or proposal summary',
+      'Manual sanitized Chronicle packet',
+      'AmaduTown proof point with an internal route or artifact home',
+    ],
+    chronicle_packet_status: 'manual_packet_required',
+    content_packet_id: packet.id,
+    content_packet: packet,
+    tasks: socialOutreachTasks(goalId, title),
+  }
+}
+
+function draftGoal(goal: string, goalType: AgentGoalType = 'general'): AgentGoalDraft {
   const title = goal.trim().replace(/\s+/g, ' ').slice(0, 120)
   const goalId = goalIdFromTitle(title)
+  if (goalType === 'social_outreach_linkedin_post') {
+    return draftSocialOutreachGoal(goal, title, goalId)
+  }
   const tasks: AgentGoalDraftTask[] = [
     {
       id: `${goalId}-scope`,
@@ -309,6 +511,7 @@ function draftGoal(goal: string): AgentGoalDraft {
 
   return {
     goal_id: goalId,
+    goal_type: 'general',
     title,
     objective: `Accomplish: ${title}`,
     recommendation: 'Approve the packet if the scope is right, then track each child task on Agent Kanban with the shared goal tag.',
@@ -329,6 +532,16 @@ function assertDraft(value: AgentGoalDraft | null | undefined): AgentGoalDraft {
     task.expected_files = normalizeDraftStringArray(task.expected_files)
     task.acceptance_criteria = normalizeDraftStringArray(task.acceptance_criteria)
     task.risk_notes = typeof task.risk_notes === 'string' ? task.risk_notes : ''
+  }
+  if (value.goal_type && value.goal_type !== 'general' && value.goal_type !== 'social_outreach_linkedin_post') {
+    throw new Error('Invalid goal draft type')
+  }
+  if (value.publish_gate && value.publish_gate !== 'draft_only' && value.publish_gate !== 'manual_approval_required') {
+    throw new Error('Invalid goal draft publish gate')
+  }
+  value.source_requirements = normalizeDraftStringArray(value.source_requirements)
+  if (value.content_packet && typeof value.content_packet.id !== 'string') {
+    throw new Error('Invalid LinkedIn content packet')
   }
   return value
 }
@@ -356,9 +569,99 @@ function goalSessionHref(goalId: string) {
   return `/admin/agents/standup?goal=${encodeURIComponent(goalId)}`
 }
 
+async function createSocialContentDraftForGoal(draft: AgentGoalDraft) {
+  if (draft.goal_type !== 'social_outreach_linkedin_post' || !draft.content_packet) return null
+  if (!supabaseAdmin) throw new Error('Database not available')
+
+  const packet = draft.content_packet
+  const existing = await supabaseAdmin
+    .from('social_content_queue')
+    .select('id')
+    .contains('rag_context', { content_packet_id: packet.id })
+    .maybeSingle()
+
+  if (existing.error) throw new Error(`Failed to read social content draft: ${existing.error.message}`)
+  if (existing.data?.id) {
+    return {
+      id: String(existing.data.id),
+      href: `/admin/social-content/${existing.data.id}`,
+    }
+  }
+
+  const adminNotes = [
+    'Draft-only Agent Ops social outreach pilot.',
+    `Goal: ${draft.title}`,
+    `Packet: ${packet.id}`,
+    'Publish gate: draft_only. Do not publish or schedule from goal approval.',
+    'Chronicle evidence is manual/sanitized in V1.',
+    'Approval checklist:',
+    ...packet.approval_checklist.map((item) => `- ${item}`),
+  ].join('\n')
+
+  const { data, error } = await supabaseAdmin
+    .from('social_content_queue')
+    .insert({
+      platform: 'linkedin',
+      status: 'draft',
+      post_text: packet.draft_linkedin_post,
+      cta_text: 'What part of AI adoption still feels harder than it should for your team?',
+      cta_url: null,
+      hashtags: ['#AIProduct', '#ProductManagement', '#AmadutownAdvisory'],
+      image_prompt: packet.image_prompt,
+      framework_visual_type: 'architecture',
+      topic_extracted: {
+        topic: 'AmaduTown agent swarm social outreach pilot',
+        angle: draft.title,
+        key_insight: packet.industry_signal_summary,
+        personal_tie_in: 'Applied AmaduTown operating-system proof from Agent Ops, Open Brain, and Chronicle evidence.',
+        framework_visual: 'architecture',
+      },
+      hormozi_framework: {
+        framework_type: 'source_backed_operating_proof',
+        hook_type: 'practical_tension',
+        proof_pattern: 'AmaduTown applied workflow evidence',
+        cta_pattern: 'specific operator question',
+      },
+      rag_context: {
+        source: 'agent_ops_social_outreach_goal',
+        goal_id: draft.goal_id,
+        goal_type: draft.goal_type,
+        content_packet_id: packet.id,
+        publish_gate: draft.publish_gate ?? 'draft_only',
+        open_brain_references: packet.open_brain_references,
+        chronicle_packet_status: draft.chronicle_packet_status ?? 'manual_packet_required',
+        chronicle_evidence_notes: packet.chronicle_evidence_notes,
+        source_provenance_checklist: packet.source_provenance_checklist,
+        approval_checklist: packet.approval_checklist,
+      },
+      admin_notes: adminNotes,
+      target_platforms: ['linkedin'],
+      video_generation_method: 'none',
+      content_format: 'single_image',
+      content_pillar: 'technology_as_equalizer',
+      companion_post_text: null,
+    })
+    .select('id')
+    .single()
+
+  if (error || !data?.id) throw new Error(error?.message ?? 'Failed to create Social Content draft')
+  return {
+    id: String(data.id),
+    href: `/admin/social-content/${data.id}`,
+  }
+}
+
 async function approveGoalDraft(runId: string, draft: AgentGoalDraft) {
   const draftRunId = draft.draft_run_id ?? null
   const sessionHref = goalSessionHref(draft.goal_id)
+  const socialContentDraft = await createSocialContentDraftForGoal(draft)
+  const contentPacket = draft.content_packet && socialContentDraft
+    ? {
+      ...draft.content_packet,
+      social_content_draft_id: socialContentDraft.id,
+      social_content_draft_href: socialContentDraft.href,
+    }
+    : draft.content_packet ?? null
   const parent = await createAgentWorkItem({
     title: `Goal: ${draft.title}`,
     objective: draft.objective,
@@ -368,6 +671,7 @@ async function approveGoalDraft(runId: string, draft: AgentGoalDraft) {
     source: { type: 'agent_standup_goal', id: draft.goal_id, label: 'Standup Room goal' },
     sourceRunId: runId,
     metadata: {
+      goal_type: draft.goal_type ?? 'general',
       goal_id: draft.goal_id,
       goal_title: draft.title,
       goal_status: 'approved',
@@ -378,6 +682,13 @@ async function approveGoalDraft(runId: string, draft: AgentGoalDraft) {
       goal_session_href: sessionHref,
       goal_progress_weight: 0,
       recommendation: draft.recommendation,
+      publish_gate: draft.publish_gate ?? null,
+      source_requirements: draft.source_requirements ?? [],
+      chronicle_packet_status: draft.chronicle_packet_status ?? null,
+      content_packet_id: draft.content_packet_id ?? contentPacket?.id ?? null,
+      content_packet: contentPacket,
+      social_content_draft_id: socialContentDraft?.id ?? null,
+      social_content_draft_href: socialContentDraft?.href ?? null,
     },
     idempotencyKey: `agent-goal:${draft.goal_id}:parent`,
   })
@@ -397,6 +708,7 @@ async function approveGoalDraft(runId: string, draft: AgentGoalDraft) {
       expectedFiles: task.expected_files,
       dependencyIds: resolveGoalDependencyIds(task.dependencies, draftTaskIdToWorkItemId),
       metadata: {
+        goal_type: draft.goal_type ?? 'general',
         goal_id: draft.goal_id,
         goal_title: draft.title,
         goal_sequence: index + 1,
@@ -412,6 +724,10 @@ async function approveGoalDraft(runId: string, draft: AgentGoalDraft) {
         goal_dependencies: task.dependencies,
         acceptance_criteria: task.acceptance_criteria,
         risk_notes: task.risk_notes,
+        publish_gate: draft.publish_gate ?? null,
+        content_packet_id: draft.content_packet_id ?? contentPacket?.id ?? null,
+        social_content_draft_id: socialContentDraft?.id ?? null,
+        social_content_draft_href: socialContentDraft?.href ?? null,
       },
       idempotencyKey: `agent-goal:${draft.goal_id}:task:${index + 1}`,
     })
@@ -426,6 +742,7 @@ export async function runAgentWarRoom(input: RunAgentWarRoomInput) {
   assertCommand(input.command)
   const message = input.message?.trim().slice(0, 1000) || null
   const goal = input.goal?.trim().slice(0, 1000) || null
+  const goalType = input.goalType === 'social_outreach_linkedin_post' ? input.goalType : 'general'
   const contextGoalId = input.goalId?.trim().slice(0, 160) || null
   if ((input.command === 'discuss' || input.command === 'ask_agent') && !message) {
     throw new Error(`Message is required for ${input.command}`)
@@ -448,7 +765,7 @@ export async function runAgentWarRoom(input: RunAgentWarRoomInput) {
     draft_goal: 'Agent Standup Room goal draft',
     approve_goal: 'Agent Standup Room goal approval',
   }
-  const precomputedGoalDraft = input.command === 'draft_goal' ? draftGoal(goal ?? '') : null
+  const precomputedGoalDraft = input.command === 'draft_goal' ? draftGoal(goal ?? '', goalType) : null
   const draftGoalId = input.command === 'approve_goal' ? input.draft?.goal_id ?? null : precomputedGoalDraft?.goal_id ?? null
   const activeGoalId = draftGoalId ?? contextGoalId
   const draftRunId = input.command === 'approve_goal' ? input.draft?.draft_run_id ?? null : null
@@ -471,6 +788,7 @@ export async function runAgentWarRoom(input: RunAgentWarRoomInput) {
       target_agent_key: input.targetAgentKey ?? null,
       target_agent_keys: input.targetAgentKeys ?? null,
       goal_preview: goal,
+      goal_type: input.command === 'draft_goal' ? goalType : input.draft?.goal_type ?? null,
       goal_id: activeGoalId,
       goal_session_href: activeGoalId ? goalSessionHref(activeGoalId) : null,
       goal_draft_run_id: draftRunId,
@@ -558,6 +876,7 @@ export async function runAgentWarRoom(input: RunAgentWarRoomInput) {
       messages,
       goal_draft: goalDraft,
       created_work_items: createdWorkItems,
+      social_content_draft_id: createdWorkItems?.parent.metadata?.social_content_draft_id ?? null,
       goal_id: finalGoalId,
       goal_session_href: finalGoalSessionHref,
       goal_draft_run_id: goalDraft?.draft_run_id ?? input.draft?.draft_run_id ?? null,
@@ -582,6 +901,7 @@ export async function runAgentWarRoom(input: RunAgentWarRoomInput) {
       goal_session_href: finalGoalSessionHref,
       goal_draft_run_id: goalDraft?.draft_run_id ?? input.draft?.draft_run_id ?? null,
       goal_approved_by_run_id: input.command === 'approve_goal' ? run.id : null,
+      social_content_draft_id: createdWorkItems?.parent.metadata?.social_content_draft_id ?? null,
     },
   })
 
@@ -601,6 +921,7 @@ export async function runAgentWarRoom(input: RunAgentWarRoomInput) {
       created_parent_work_item_id: createdParentId,
       created_child_work_item_ids: createdChildIds,
       created_child_count: createdWorkItems?.children.length ?? 0,
+      social_content_draft_id: createdWorkItems?.parent.metadata?.social_content_draft_id ?? null,
     },
   })
 


### PR DESCRIPTION
Summary
- Add the draft-only LinkedIn social outreach goal template to Standup Room, including packet preview, publish gate, Chronicle manual packet status, and linked Social Content draft handoff.
- Extend Agent War Room goal approval to create traceable parent/child Agent Ops work items plus one draft Social Content item with provenance, visual brief, approval checklist, and Open Brain/Chronicle safety metadata.
- Project social outreach goal metadata onto Agent Kanban and document the approved pilot overlay in the Agent Operations roadmap.

Validation
- npm test -- app/admin/agents/standup/page.test.tsx app/api/admin/agents/war-room/route.test.ts lib/agent-war-room.test.ts lib/agent-swarm-board.test.ts
- npx tsc --noEmit --pretty false
- npm run lint
- git diff --check
- npm run build (passes; existing local env warning: MOCK_N8N=false and N8N_DISABLE_OUTBOUND=false means outbound n8n is enabled in .env.local)

Integration Notes
- No schema migration; reuses agent_work_items metadata, run artifacts, and social_content_queue.
- Goal approval creates only a draft Social Content item; publish/schedule/DM/external outreach remain outside the pilot and require the existing Social Content approval path.
- Browser QA was not run in this handoff because the in-app browser automation tool was not available in this session; local build/type/test gates passed.
- Vercel contexts were not checked from this feature lane; Integration Captain should verify Vercel – portfolio and Vercel – portfolio-staging after merge.