### PR TITLE
feat: add goal readiness gate

### DIFF
--- a/app/admin/agents/page.test.tsx
+++ b/app/admin/agents/page.test.tsx
@@ -346,6 +346,40 @@ const automationGoals = [
   },
 ]
 
+const activeGoalSummary = [{
+  id: 'goal-social',
+  title: 'Create one LinkedIn post package showing how AmaduTown applies AI',
+  total: 3,
+  completed: 1,
+  progress: 33,
+  blocked: 1,
+  open: 2,
+  burndown: [],
+  sessionHref: '/admin/agents/standup?goal=goal-social',
+  draftRunId: 'draft-run',
+  approvalRunId: 'approval-run',
+  latestRunId: 'latest-run',
+  draftTraceHref: '/admin/agents/runs/draft-run',
+  approvalTraceHref: '/admin/agents/runs/approval-run',
+  latestTraceHref: '/admin/agents/runs/latest-run',
+  automationGoalSeedId: null,
+  workflowFamily: null,
+  automationLevel: null,
+  requiresNewWorkflow: false,
+  n8nWorkflows: [],
+  approvalGate: null,
+  nextAction: null,
+  readinessStatus: 'delegated',
+  stageGates: [{ key: 'voice_review', label: 'Voice and visual review', ownerAgentKey: 'voice-content-architect', requiredBefore: 'social_content_handoff', status: 'pending', approvalRequired: false }],
+  nextStageGate: { key: 'voice_review', label: 'Voice and visual review', ownerAgentKey: 'voice-content-architect', requiredBefore: 'social_content_handoff', status: 'pending', approvalRequired: false },
+  goalType: 'social_outreach_linkedin_post',
+  contentPacketId: 'packet-goal-social',
+  publishGate: 'draft_only',
+  chroniclePacketStatus: 'manual_packet_required',
+  socialContentDraftId: 'social-draft-1',
+  socialContentDraftHref: '/admin/social-content/social-draft-1',
+}]
+
 function formatExpectedPageTime(value: string) {
   return new Intl.DateTimeFormat('en', {
     month: 'short',
@@ -367,6 +401,19 @@ describe('AgentOperationsPage mission control landing', () => {
       }
       if (url === '/api/admin/agents/automation-goals') {
         return { ok: true, json: async () => ({ goals: automationGoals }) }
+      }
+      if (url === '/api/admin/agents/swarm-board') {
+        return {
+          ok: true,
+          json: async () => ({
+            ok: true,
+            organization: {
+              summary: {
+                goals: activeGoalSummary,
+              },
+            },
+          }),
+        }
       }
       if (url === '/api/admin/agents/automation-goals/seed' && init?.method === 'POST') {
         return {
@@ -530,6 +577,14 @@ describe('AgentOperationsPage mission control landing', () => {
     expect(within(exportLedger).getByText(/client_safe/i)).toBeInTheDocument()
     expect(within(exportLedger).getByText(/Run delegati · Client client-456 · From 2026-05-01 · To 2026-05-21/i)).toBeInTheDocument()
     expect(within(exportLedger).getByRole('link', { name: /Open trace/i })).toHaveAttribute('href', '/admin/agents/runs/delegation-run')
+    const activeGoals = screen.getByLabelText('Active Goals')
+    expect(activeGoals).toBeInTheDocument()
+    expect(within(activeGoals).getByText('Create one LinkedIn post package showing how AmaduTown applies AI')).toBeInTheDocument()
+    expect(within(activeGoals).getByText(/33% complete · 2 open · 1 blocked/i)).toBeInTheDocument()
+    expect(within(activeGoals).getByText(/Next gate: Voice and visual review before social content handoff/i)).toBeInTheDocument()
+    expect(within(activeGoals).getByRole('link', { name: 'Standup' })).toHaveAttribute('href', '/admin/agents/standup?goal=goal-social')
+    expect(within(activeGoals).getByRole('link', { name: 'Kanban' })).toHaveAttribute('href', '/admin/agents/swarm-board?goal=goal-social')
+    expect(within(activeGoals).getByRole('link', { name: 'Draft' })).toHaveAttribute('href', '/admin/social-content/social-draft-1')
     expect(screen.getByRole('link', { name: /Active runs/i })).toHaveAttribute('href', '/admin/agents/runs?active=true')
     expect(screen.getByRole('link', { name: /Failed or stale runs/i })).toHaveAttribute('href', '/admin/agents/runs?status=needs_review')
     expect(screen.getByRole('link', { name: /Pending approvals/i })).toHaveAttribute('href', '/admin/agents/coordination')

--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -23,6 +23,7 @@ import {
   Send,
   ShieldCheck,
   Sparkles,
+  Target,
   TrendingDown,
   Users,
 } from 'lucide-react'
@@ -30,6 +31,7 @@ import ProtectedRoute from '@/components/ProtectedRoute'
 import AgentAvatar from '@/components/admin/AgentAvatar'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
 import { getCurrentSession } from '@/lib/auth'
+import type { AgentOrgBoardGoalMetric } from '@/lib/agent-swarm-board'
 
 type MissionRun = {
   id: string
@@ -487,6 +489,7 @@ export default function AgentOperationsPage() {
   const [moremiReviewConfirm, setMoremiReviewConfirm] = useState(false)
   const [inboxPage, setInboxPage] = useState(0)
   const [operatorRuns, setOperatorRuns] = useState<OperatorRun[]>([])
+  const [activeGoals, setActiveGoals] = useState<AgentOrgBoardGoalMetric[]>([])
   const [automationGoals, setAutomationGoals] = useState<AutomationGoalSummary[]>([])
   const [automationGoalsLoading, setAutomationGoalsLoading] = useState(false)
   const [automationSeedLoading, setAutomationSeedLoading] = useState(false)
@@ -546,6 +549,18 @@ export default function AgentOperationsPage() {
     }
   }, [authedFetch])
 
+  const loadActiveGoals = useCallback(async () => {
+    try {
+      const response = await authedFetch('/api/admin/agents/swarm-board')
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`)
+      const goals = body.organization?.summary?.goals
+      setActiveGoals(Array.isArray(goals) ? goals : [])
+    } catch {
+      setActiveGoals([])
+    }
+  }, [authedFetch])
+
   const loadAutomationGoals = useCallback(async () => {
     setAutomationGoalsLoading(true)
     try {
@@ -564,11 +579,12 @@ export default function AgentOperationsPage() {
     loadMissionControl()
     loadMoremiReview()
     loadOperatorRuns()
+    loadActiveGoals()
     loadAutomationGoals()
-  }, [loadMissionControl, loadMoremiReview, loadOperatorRuns, loadAutomationGoals])
+  }, [loadMissionControl, loadMoremiReview, loadOperatorRuns, loadActiveGoals, loadAutomationGoals])
 
   async function refreshMissionControl() {
-    await Promise.all([loadMissionControl(), loadMoremiReview(), loadOperatorRuns(), loadAutomationGoals()])
+    await Promise.all([loadMissionControl(), loadMoremiReview(), loadOperatorRuns(), loadActiveGoals(), loadAutomationGoals()])
   }
 
   async function askChiefOfStaff(message: string) {
@@ -1006,6 +1022,8 @@ export default function AgentOperationsPage() {
                 />
 
                 <AgentGovernancePanel governance={snapshot?.governance ?? null} />
+
+                <ActiveGoalsPanel goals={activeGoals} />
 
                 <div className="agent-ops-command-card mt-5 rounded-lg border p-4">
                   <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
@@ -2293,6 +2311,81 @@ function BriefRouteCard({
         <ArrowRight size={14} className="mt-1 shrink-0 text-muted-foreground group-hover:text-radiant-gold" />
       </div>
     </Link>
+  )
+}
+
+function ActiveGoalsPanel({ goals }: { goals: AgentOrgBoardGoalMetric[] }) {
+  const visibleGoals = goals.slice(0, 3)
+  return (
+    <section className="agent-ops-card mt-5 rounded-lg border p-4" aria-label="Active Goals">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <div className="flex items-center gap-2 text-radiant-gold">
+            <Target size={17} />
+            <h2 className="font-semibold">Active Goals</h2>
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Goal status, next gate, blockers, and the right L2 surface for follow-up.
+          </p>
+        </div>
+        <Link href="/admin/agents/standup" className="inline-flex w-fit items-center gap-2 rounded-lg border border-radiant-gold/50 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/10">
+          Plan a goal
+          <ArrowRight size={14} />
+        </Link>
+      </div>
+
+      <div className="mt-3 grid gap-3">
+        {visibleGoals.length ? visibleGoals.map((goal) => (
+          <article key={goal.id} className="rounded-lg border border-silicon-slate/60 bg-background/55 p-3">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <StatusOnlyPill tone={goal.blocked ? 'red' : goal.open ? 'yellow' : 'green'}>
+                    {goal.readinessStatus === 'delegated' ? 'Delegated' : goal.readinessStatus?.replace(/_/g, ' ') ?? 'Active'}
+                  </StatusOnlyPill>
+                  {goal.publishGate ? <StatusOnlyPill tone={goal.publishGate === 'draft_only' ? 'yellow' : 'neutral'}>{goal.publishGate.replace(/_/g, ' ')}</StatusOnlyPill> : null}
+                </div>
+                <h3 className="mt-2 line-clamp-2 font-semibold">{goal.title}</h3>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {goal.progress}% complete · {goal.open} open · {goal.blocked} blocked
+                </p>
+                {goal.nextStageGate ? (
+                  <p className="mt-2 text-sm text-radiant-gold">
+                    Next gate: {goal.nextStageGate.label} before {goal.nextStageGate.requiredBefore.replace(/_/g, ' ')}
+                  </p>
+                ) : (
+                  <p className="mt-2 text-sm text-muted-foreground">No open stage gate is recorded.</p>
+                )}
+              </div>
+              <div className="flex shrink-0 flex-wrap gap-2">
+                <Link href={goal.sessionHref} className="rounded-lg border border-radiant-gold/45 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/10">
+                  Standup
+                </Link>
+                <Link href={`/admin/agents/swarm-board?goal=${encodeURIComponent(goal.id)}`} className="rounded-lg border border-silicon-slate/60 px-3 py-2 text-sm hover:border-radiant-gold/50">
+                  Kanban
+                </Link>
+                {goal.socialContentDraftHref ? (
+                  <Link href={goal.socialContentDraftHref} className="rounded-lg border border-silicon-slate/60 px-3 py-2 text-sm hover:border-radiant-gold/50">
+                    Draft
+                  </Link>
+                ) : goal.latestTraceHref ? (
+                  <Link href={goal.latestTraceHref} className="rounded-lg border border-silicon-slate/60 px-3 py-2 text-sm hover:border-radiant-gold/50">
+                    Trace
+                  </Link>
+                ) : null}
+              </div>
+            </div>
+            <div className="mt-3 h-2 overflow-hidden rounded-full bg-silicon-slate/70">
+              <div className="h-full bg-radiant-gold" style={{ width: `${goal.progress}%` }} />
+            </div>
+          </article>
+        )) : (
+          <div className="rounded-lg border border-dashed border-silicon-slate/60 p-4 text-sm text-muted-foreground">
+            No active delegated goals yet. Start in the Standup Room when Shaka needs to turn a goal into tracked work.
+          </div>
+        )}
+      </div>
+    </section>
   )
 }
 

--- a/app/admin/agents/standup/page.test.tsx
+++ b/app/admin/agents/standup/page.test.tsx
@@ -46,6 +46,9 @@ const organization = {
       draftTraceHref: '/admin/agents/runs/draft-run',
       approvalTraceHref: '/admin/agents/runs/approval-run',
       latestTraceHref: '/admin/agents/runs/room-run',
+      readinessStatus: 'delegated',
+      stageGates: [{ key: 'review', label: 'Review gate', ownerAgentKey: 'chief-of-staff', requiredBefore: 'handoff', status: 'pending', approvalRequired: true }],
+      nextStageGate: { key: 'review', label: 'Review gate', ownerAgentKey: 'chief-of-staff', requiredBefore: 'handoff', status: 'pending', approvalRequired: true },
     }],
   },
   agents: [
@@ -116,6 +119,9 @@ const organization = {
           draftTraceHref: '/admin/agents/runs/draft-run',
           approvalTraceHref: '/admin/agents/runs/approval-run',
           latestTraceHref: '/admin/agents/runs/room-run',
+          readinessStatus: 'delegated',
+          stageGates: [{ key: 'review', label: 'Review gate', ownerAgentKey: 'chief-of-staff', requiredBefore: 'handoff', status: 'pending', approvalRequired: true }],
+          nextStageGate: { key: 'review', label: 'Review gate', ownerAgentKey: 'chief-of-staff', requiredBefore: 'handoff', status: 'pending', approvalRequired: true },
         },
       }],
     },
@@ -145,6 +151,19 @@ const organization = {
   },
 }
 
+const readinessPacket = {
+  readiness_status: 'ready_for_delegation',
+  readiness_checklist: [
+    { key: 'outcome_clear', label: 'Outcome is clear', status: 'ready', required: true, evidence: 'Goal objective is stated.' },
+    { key: 'stage_gates_named', label: 'Stage gates are named', status: 'ready', required: true, evidence: 'Planning, review, and approval gates are named.' },
+  ],
+  acceptance_criteria: ['Goal scope is clear before delegation.'],
+  stage_gates: [{ key: 'ready_to_delegate', label: 'Ready to delegate', owner_agent_key: 'chief-of-staff', required_before: 'work_item_creation', status: 'pending', approval_required: true }],
+  authority_boundary: { publish: 'manual_approval_required', send: 'manual_approval_required', deploy: 'manual_approval_required', merge: 'manual_approval_required', notes: 'Work creation only; merge and deploy remain approval-gated.' },
+  missing_context: [],
+  planning_participants: ['chief-of-staff', 'engineering-copilot'],
+}
+
 describe('AgentStandupRoomPage', () => {
   beforeEach(() => {
     window.history.pushState({}, '', '/admin/agents/standup')
@@ -169,6 +188,9 @@ describe('AgentStandupRoomPage', () => {
                   objective: `Produce one draft-only LinkedIn content packet for: ${body.goal}`,
                   recommendation: 'Approve this pilot only if the output should stop at a Social Content draft.',
                   risk_notes: 'Manual Chronicle evidence and approved Open Brain context are required.',
+                  ...readinessPacket,
+                  authority_boundary: { ...readinessPacket.authority_boundary, publish: 'not_allowed', send: 'not_allowed' },
+                  missing_context: ['Attach manual Chronicle evidence packet before final content approval.'],
                   publish_gate: 'draft_only',
                   source_requirements: ['One source-backed industry signal'],
                   chronicle_packet_status: 'manual_packet_required',
@@ -216,6 +238,7 @@ describe('AgentStandupRoomPage', () => {
                 objective: `Accomplish: ${body.goal}`,
                 recommendation: 'Approve after review.',
                 risk_notes: 'Review gated.',
+                ...readinessPacket,
                 tasks: [{
                   id: 'task-draft',
                   title: 'Implement room',
@@ -244,13 +267,13 @@ describe('AgentStandupRoomPage', () => {
             }),
           }
         }
-        if (body.command === 'approve_goal') {
+        if (body.command === 'approve_goal' || body.command === 'approve_readiness') {
           return {
             ok: true,
             json: async () => ({
               ok: true,
               run_id: 'approval-run',
-              command: 'approve_goal',
+              command: body.command,
               messages: [],
               social_content_draft: body.draft?.goal_type === 'social_outreach_linkedin_post'
                 ? { id: 'social-draft-1', href: '/admin/social-content/social-draft-1' }
@@ -408,6 +431,9 @@ describe('AgentStandupRoomPage', () => {
     fireEvent.click(screen.getByRole('button', { name: /Draft plan/i }))
 
     expect(await screen.findByText('Approve after review.')).toBeInTheDocument()
+    expect(screen.getByText('Definition of Ready')).toBeInTheDocument()
+    expect(screen.getAllByText('Ready to delegate').length).toBeGreaterThan(0)
+    expect(screen.getByText('Goal acceptance criteria')).toBeInTheDocument()
     expect(screen.getAllByRole('link', { name: /Open trace/i }).some((link) => link.getAttribute('href') === '/admin/agents/runs/goal-run')).toBe(true)
     expect(fetch).toHaveBeenCalledWith('/api/admin/agents/war-room', expect.objectContaining({
       method: 'POST',
@@ -416,13 +442,13 @@ describe('AgentStandupRoomPage', () => {
 
     fireEvent.change(screen.getByDisplayValue('Implement room'), { target: { value: 'Implement reviewed room' } })
     fireEvent.click(screen.getByRole('button', { name: /Remove Validate room/i }))
-    fireEvent.click(screen.getByRole('button', { name: /Approve goal/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Approve readiness & delegate/i }))
 
     await waitFor(() => {
       expect(screen.getByText(/Created 1 child work item/i)).toBeInTheDocument()
     })
     expect(screen.getByRole('link', { name: /Open goal on Kanban/i })).toHaveAttribute('href', '/admin/agents/swarm-board?goal=goal-draft')
-    const approveCall = vi.mocked(fetch).mock.calls.find(([, init]) => String((init as RequestInit)?.body ?? '').includes('"command":"approve_goal"'))
+    const approveCall = vi.mocked(fetch).mock.calls.find(([, init]) => String((init as RequestInit)?.body ?? '').includes('"command":"approve_readiness"'))
     expect(approveCall).toBeTruthy()
     const approveBody = JSON.parse(String((approveCall?.[1] as RequestInit).body))
     expect(approveBody.draft.tasks).toHaveLength(1)
@@ -453,7 +479,7 @@ describe('AgentStandupRoomPage', () => {
       }),
     }))
 
-    fireEvent.click(screen.getByRole('button', { name: /Approve goal/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Approve readiness & delegate/i }))
 
     expect(await screen.findByRole('link', { name: /Open linked Social Content draft/i })).toHaveAttribute('href', '/admin/social-content/social-draft-1')
   })

--- a/app/admin/agents/standup/page.tsx
+++ b/app/admin/agents/standup/page.tsx
@@ -375,7 +375,7 @@ function StandupRoomContent() {
   async function approveGoal() {
     if (!goalDraft) return
     const approvedGoalId = goalDraft.goal_id
-    const result = await postWarRoom({ command: 'approve_goal', draft: goalDraft }, 'approve-goal')
+    const result = await postWarRoom({ command: 'approve_readiness', draft: goalDraft }, 'approve-goal')
     if (result?.created_work_items) focusGoal(approvedGoalId)
   }
 
@@ -861,6 +861,17 @@ function GoalPlanner({
   onUpdateTask: (taskId: string, patch: Partial<AgentGoalDraft['tasks'][number]>) => void
   onRemoveTask: (taskId: string) => void
 }) {
+  const requiredReadiness = goalDraft?.readiness_checklist?.filter((item) => item.required) ?? []
+  const incompleteReadiness = requiredReadiness.filter((item) => item.status !== 'ready')
+  const readyToDelegate = Boolean(
+    goalDraft &&
+    goalDraft.readiness_status === 'ready_for_delegation' &&
+    incompleteReadiness.length === 0 &&
+    (goalDraft.acceptance_criteria?.length ?? 0) > 0 &&
+    (goalDraft.stage_gates?.length ?? 0) > 0 &&
+    goalDraft.tasks.length > 0,
+  )
+
   return (
     <section className="agent-ops-card rounded-lg border p-4">
       <div className="mb-3 flex items-center gap-2">
@@ -922,11 +933,73 @@ function GoalPlanner({
                 )}
               </div>
             </div>
-            <button onClick={onApproveGoal} disabled={busy != null || goalDraft.tasks.length === 0} className="inline-flex items-center justify-center gap-2 rounded-lg bg-radiant-gold px-4 py-2 text-sm font-semibold text-obsidian hover:bg-radiant-gold/90 disabled:opacity-50">
+            <button onClick={onApproveGoal} disabled={busy != null || !readyToDelegate} className="inline-flex items-center justify-center gap-2 rounded-lg bg-radiant-gold px-4 py-2 text-sm font-semibold text-obsidian hover:bg-radiant-gold/90 disabled:opacity-50" title={readyToDelegate ? 'Create the approved goal and child work items' : 'Complete the required readiness packet before delegation'}>
               <CheckCircle2 size={16} />
-              Approve goal
+              Approve readiness & delegate
             </button>
           </div>
+          <div className="mt-4 grid gap-3 xl:grid-cols-[minmax(0,1.1fr)_minmax(260px,0.9fr)]">
+            <div className="rounded-lg border border-silicon-slate/60 bg-background/60 p-3">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <p className="text-xs font-semibold uppercase tracking-[0.14em] text-radiant-gold">Definition of Ready</p>
+                <span className={`rounded-full border px-2 py-1 text-xs ${readyToDelegate ? 'border-green-500/35 bg-green-500/10 text-green-100' : 'border-yellow-500/40 bg-yellow-500/10 text-yellow-100'}`}>
+                  {readyToDelegate ? 'Ready to delegate' : `${incompleteReadiness.length} required open`}
+                </span>
+              </div>
+              <div className="mt-3 grid gap-2 md:grid-cols-2">
+                {(goalDraft.readiness_checklist ?? []).map((item) => (
+                  <div key={item.key} className={`rounded-md border p-2 text-xs ${item.status === 'ready' ? 'border-green-500/25 bg-green-500/5' : item.status === 'blocked' ? 'border-red-500/35 bg-red-500/10 text-red-100' : 'border-yellow-500/35 bg-yellow-500/10 text-yellow-100'}`}>
+                    <div className="flex items-start gap-2">
+                      <CheckCircle2 size={13} className={item.status === 'ready' ? 'mt-0.5 shrink-0 text-green-200' : 'mt-0.5 shrink-0 text-muted-foreground'} />
+                      <div>
+                        <p className="font-medium">{item.label}</p>
+                        {item.evidence ? <p className="mt-1 text-muted-foreground">{item.evidence}</p> : null}
+                        {item.blocker ? <p className="mt-1 text-red-100">{item.blocker}</p> : null}
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+              {goalDraft.missing_context?.length ? (
+                <div className="mt-3 rounded-md border border-yellow-500/35 bg-yellow-500/10 p-2 text-xs text-yellow-100">
+                  <p className="font-semibold">Known context still needed before final approval</p>
+                  <ul className="mt-1 space-y-1">
+                    {goalDraft.missing_context.map((item) => <li key={item}>{item}</li>)}
+                  </ul>
+                </div>
+              ) : null}
+            </div>
+            <div className="rounded-lg border border-silicon-slate/60 bg-background/60 p-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-radiant-gold">Stage Gates</p>
+              <div className="mt-3 space-y-2">
+                {(goalDraft.stage_gates ?? []).map((gate) => (
+                  <div key={gate.key} className="rounded-md border border-silicon-slate/55 bg-background/45 p-2 text-xs">
+                    <div className="flex items-center justify-between gap-2">
+                      <p className="font-medium">{gate.label}</p>
+                      <span className="rounded-full border border-silicon-slate/50 px-2 py-0.5 text-muted-foreground">{gate.status.replace(/_/g, ' ')}</span>
+                    </div>
+                    <p className="mt-1 text-muted-foreground">
+                      Before {gate.required_before.replace(/_/g, ' ')}{gate.approval_required ? ' · approval required' : ''}
+                    </p>
+                  </div>
+                ))}
+              </div>
+              {goalDraft.authority_boundary ? (
+                <div className="mt-3 rounded-md border border-silicon-slate/55 bg-black/10 p-2 text-xs text-muted-foreground">
+                  <p className="font-semibold uppercase tracking-wide text-radiant-gold">Authority boundary</p>
+                  <p className="mt-1">{goalDraft.authority_boundary.notes}</p>
+                </div>
+              ) : null}
+            </div>
+          </div>
+          {goalDraft.acceptance_criteria?.length ? (
+            <div className="mt-3 rounded-lg border border-silicon-slate/60 bg-background/60 p-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-radiant-gold">Goal acceptance criteria</p>
+              <ul className="mt-2 grid gap-1 text-sm text-muted-foreground md:grid-cols-2">
+                {goalDraft.acceptance_criteria.map((criterion) => <li key={criterion}>{criterion}</li>)}
+              </ul>
+            </div>
+          ) : null}
           {goalDraft.content_packet && (
             <div className="mt-4 grid gap-3 lg:grid-cols-2">
               <div className="rounded-lg border border-silicon-slate/60 bg-background/60 p-3">
@@ -1060,7 +1133,7 @@ function GoalPlanner({
             ))}
             {!goalDraft.tasks.length && (
               <div className="rounded-lg border border-dashed border-silicon-slate/60 p-4 text-sm text-muted-foreground">
-                No tasks are selected for creation. Draft the goal again or keep at least one task before approving.
+                No tasks are selected for creation. Draft the goal again or keep at least one task before readiness can be delegated.
               </div>
             )}
           </div>
@@ -1128,6 +1201,11 @@ function GoalSessionPanel({
           <p className="mt-1 text-sm text-muted-foreground">
             {goal.completed}/{goal.total} complete · {goal.open} open · {goal.blocked} blocked
           </p>
+          {goal.nextStageGate ? (
+            <p className="mt-2 text-sm text-radiant-gold">
+              Next gate: {goal.nextStageGate.label} · before {goal.nextStageGate.requiredBefore.replace(/_/g, ' ')}
+            </p>
+          ) : null}
           <div className="mt-3 flex flex-wrap gap-2 text-xs">
             {goal.draftTraceHref && <AuditLink href={goal.draftTraceHref} label="Draft trace" />}
             {goal.approvalTraceHref && <AuditLink href={goal.approvalTraceHref} label="Approval trace" />}
@@ -1149,6 +1227,21 @@ function GoalSessionPanel({
       <div className="mt-4 h-2 overflow-hidden rounded-full bg-silicon-slate/70">
         <div className="h-full bg-radiant-gold" style={{ width: `${goal.progress}%` }} />
       </div>
+      {(goal.stageGates ?? []).length ? (
+        <div className="mt-4 grid gap-2 md:grid-cols-2">
+          {(goal.stageGates ?? []).slice(0, 4).map((gate) => (
+            <div key={gate.key} className="rounded-lg border border-silicon-slate/60 bg-background/55 p-2 text-xs">
+              <div className="flex items-center justify-between gap-2">
+                <span className="font-medium">{gate.label}</span>
+                <span className="text-muted-foreground">{gate.status.replace(/_/g, ' ')}</span>
+              </div>
+              <p className="mt-1 text-muted-foreground">
+                Before {gate.requiredBefore.replace(/_/g, ' ')}{gate.approvalRequired ? ' · approval gate' : ''}
+              </p>
+            </div>
+          ))}
+        </div>
+      ) : null}
       {isAutomationGoal && (
         <div className="mt-4 rounded-lg border border-silicon-slate/60 bg-background/55 p-3" aria-label="Automation workflow proposal">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">

--- a/app/admin/agents/swarm-board/page.tsx
+++ b/app/admin/agents/swarm-board/page.tsx
@@ -688,6 +688,9 @@ function GoalRadiators({
                   <div className="h-full bg-radiant-gold" style={{ width: `${goal.progress}%` }} />
                 </div>
                 <p className="mt-2 text-xs text-muted-foreground">{goal.progress}% · {goal.open} open · {goal.blocked} blocked</p>
+                {goal.nextStageGate ? (
+                  <p className="mt-1 line-clamp-1 text-xs text-radiant-gold">Next gate: {goal.nextStageGate.label}</p>
+                ) : null}
               </button>
             )) : (
               <p className="rounded-lg border border-dashed border-silicon-slate/60 p-3 text-sm text-muted-foreground md:col-span-3">
@@ -851,6 +854,11 @@ function SelectedGoalPanel({ goal, tasks }: { goal: AgentOrgBoardSnapshot['summa
               <p className="mt-1 text-sm text-muted-foreground">
                 {goal.completed}/{goal.total} complete · {goal.open} open · {goal.blocked} blocked
               </p>
+              {goal.nextStageGate ? (
+                <p className="mt-2 text-sm text-radiant-gold">
+                  Next gate: {goal.nextStageGate.label} · before {goal.nextStageGate.requiredBefore.replace(/_/g, ' ')}
+                </p>
+              ) : null}
             </div>
             <Link href={goal.sessionHref} className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/50 px-3 py-2 text-sm text-radiant-gold hover:bg-radiant-gold/15">
               Open goal session
@@ -936,6 +944,22 @@ function SelectedGoalPanel({ goal, tasks }: { goal: AgentOrgBoardSnapshot['summa
               <p className="text-sm text-muted-foreground">Burndown appears after goal-tagged work starts moving.</p>
             )}
           </div>
+          {(goal.stageGates ?? []).length ? (
+            <div className="mt-4 border-t border-silicon-slate/50 pt-3">
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-radiant-gold">Stage gates</h3>
+              <div className="mt-2 space-y-2">
+                {(goal.stageGates ?? []).slice(0, 4).map((gate) => (
+                  <div key={gate.key} className="rounded-md border border-silicon-slate/55 bg-background/45 p-2 text-xs">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="font-medium">{gate.label}</span>
+                      <span className="text-muted-foreground">{gate.status.replace(/_/g, ' ')}</span>
+                    </div>
+                    <p className="mt-1 text-muted-foreground">Before {gate.requiredBefore.replace(/_/g, ' ')}{gate.approvalRequired ? ' · approval gate' : ''}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
         </div>
       </div>
     </section>
@@ -1073,6 +1097,11 @@ function WorkItemCard({ task, onOpenDependencies }: { task: AgentOrgBoardTask; o
           <span className="truncate">Goal: {task.goal.title}</span>
         </Link>
       )}
+      {task.goal?.nextStageGate ? (
+        <div className="mt-1.5 inline-flex max-w-full rounded-full border border-silicon-slate/60 bg-silicon-slate/15 px-1.5 py-0.5 text-[11px] text-muted-foreground">
+          <span className="truncate">Next gate: {task.goal.nextStageGate.label}</span>
+        </div>
+      ) : null}
       {n8nProposal ? (
         <div className="mt-1.5 flex items-center gap-1.5 rounded-md border border-radiant-gold/35 bg-radiant-gold/10 px-1.5 py-1 text-[11px] text-radiant-gold">
           <Workflow size={12} className="shrink-0" />

--- a/app/api/admin/agents/war-room/route.test.ts
+++ b/app/api/admin/agents/war-room/route.test.ts
@@ -100,6 +100,14 @@ describe('POST /api/admin/agents/war-room', () => {
     expect(mocks.runAgentWarRoom).not.toHaveBeenCalled()
   })
 
+  it('requires a draft payload for approve_readiness', async () => {
+    const response = await POST(request({ command: 'approve_readiness' }) as never)
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'draft is required for approve_readiness' })
+    expect(mocks.runAgentWarRoom).not.toHaveBeenCalled()
+  })
+
   it('runs a traced standup', async () => {
     const response = await POST(request({ command: 'standup' }) as never)
     const body = await response.json()
@@ -246,6 +254,44 @@ describe('POST /api/admin/agents/war-room', () => {
     expect(body.created_work_items.children).toHaveLength(1)
     expect(mocks.runAgentWarRoom).toHaveBeenCalledWith(expect.objectContaining({
       command: 'approve_goal',
+      draft,
+      goalId: '',
+    }))
+  })
+
+  it('passes readiness approvals to the war room executor', async () => {
+    const draft = {
+      goal_id: 'goal-1',
+      title: 'Ship standup room',
+      objective: 'Ship the reviewed room',
+      recommendation: 'Approve',
+      risk_notes: 'Low',
+      readiness_status: 'ready_for_delegation',
+      readiness_checklist: [{ key: 'outcome_clear', label: 'Outcome is clear', status: 'ready', required: true }],
+      acceptance_criteria: ['Works'],
+      stage_gates: [{ key: 'ready_to_delegate', label: 'Ready to delegate', owner_agent_key: 'chief-of-staff', required_before: 'work_item_creation', status: 'pending', approval_required: true }],
+      authority_boundary: { publish: 'manual_approval_required', send: 'manual_approval_required', deploy: 'manual_approval_required', merge: 'manual_approval_required', notes: 'Work items only.' },
+      tasks: [],
+    }
+    mocks.runAgentWarRoom.mockResolvedValue({
+      runId: 'approval-run',
+      command: 'approve_readiness',
+      synthesis: 'Goal readiness approved and delegated.',
+      updates: [],
+      messages: [],
+      createdWorkItems: {
+        parent: { id: 'parent', title: 'Goal: Ship standup room', metadata: {} },
+        children: [],
+      },
+    })
+
+    const response = await POST(request({ command: 'approve_readiness', draft }) as never)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.command).toBe('approve_readiness')
+    expect(mocks.runAgentWarRoom).toHaveBeenCalledWith(expect.objectContaining({
+      command: 'approve_readiness',
       draft,
       goalId: '',
     }))

--- a/app/api/admin/agents/war-room/route.ts
+++ b/app/api/admin/agents/war-room/route.ts
@@ -10,6 +10,7 @@ function parseCommand(value: unknown): AgentWarRoomCommand | null {
     value === 'discuss' ||
     value === 'ask_agent' ||
     value === 'draft_goal' ||
+    value === 'approve_readiness' ||
     value === 'approve_goal'
     ? value
     : null
@@ -93,8 +94,8 @@ export async function POST(request: NextRequest) {
     ? 'social_outreach_linkedin_post'
     : 'general'
 
-  if (command === 'approve_goal' && (!body.draft || typeof body.draft !== 'object')) {
-    return NextResponse.json({ error: 'draft is required for approve_goal' }, { status: 400 })
+  if ((command === 'approve_goal' || command === 'approve_readiness') && (!body.draft || typeof body.draft !== 'object')) {
+    return NextResponse.json({ error: `draft is required for ${command}` }, { status: 400 })
   }
 
   try {
@@ -106,7 +107,7 @@ export async function POST(request: NextRequest) {
       goalId,
       goal,
       goalType,
-      draft: command === 'approve_goal' ? body.draft as never : null,
+      draft: command === 'approve_goal' || command === 'approve_readiness' ? body.draft as never : null,
       triggerSource: 'admin_agent_war_room',
       actor: {
         id: auth.user.id,

--- a/lib/agent-swarm-board.ts
+++ b/lib/agent-swarm-board.ts
@@ -186,6 +186,23 @@ export type AgentOrgBoardTask = {
     n8nWorkflows: string[]
     approvalGate: string | null
     nextAction: string | null
+    readinessStatus: string | null
+    stageGates: Array<{
+      key: string
+      label: string
+      ownerAgentKey: string | null
+      requiredBefore: string
+      status: string
+      approvalRequired: boolean
+    }>
+    nextStageGate: {
+      key: string
+      label: string
+      ownerAgentKey: string | null
+      requiredBefore: string
+      status: string
+      approvalRequired: boolean
+    } | null
     goalType: string | null
     contentPacketId: string | null
     publishGate: string | null
@@ -219,6 +236,23 @@ export type AgentOrgBoardGoalMetric = {
   n8nWorkflows: string[]
   approvalGate: string | null
   nextAction: string | null
+  readinessStatus: string | null
+  stageGates: Array<{
+    key: string
+    label: string
+    ownerAgentKey: string | null
+    requiredBefore: string
+    status: string
+    approvalRequired: boolean
+  }>
+  nextStageGate: {
+    key: string
+    label: string
+    ownerAgentKey: string | null
+    requiredBefore: string
+    status: string
+    approvalRequired: boolean
+  } | null
   goalType: string | null
   contentPacketId: string | null
   publishGate: string | null
@@ -918,6 +952,30 @@ function stringArrayValue(value: unknown) {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
 }
 
+function stageGateArrayValue(value: unknown): NonNullable<AgentOrgBoardTask['goal']>['stageGates'] {
+  if (!Array.isArray(value)) return []
+  return value
+    .map((item) => {
+      const record = item && typeof item === 'object' ? item as Record<string, unknown> : {}
+      const key = stringValue(record.key)
+      const label = stringValue(record.label)
+      if (!key || !label) return null
+      return {
+        key,
+        label,
+        ownerAgentKey: stringValue(record.owner_agent_key),
+        requiredBefore: stringValue(record.required_before) ?? 'next_gate',
+        status: stringValue(record.status) ?? 'pending',
+        approvalRequired: record.approval_required === true,
+      }
+    })
+    .filter((item): item is NonNullable<AgentOrgBoardTask['goal']>['stageGates'][number] => Boolean(item))
+}
+
+function nextStageGate(stageGates: NonNullable<AgentOrgBoardTask['goal']>['stageGates']) {
+  return stageGates.find((gate) => gate.status !== 'complete') ?? null
+}
+
 function goalForTask(item: AgentWorkItemRow): AgentOrgBoardTask['goal'] {
   const metadata = item.metadata ?? {}
   const goalId = stringValue(metadata.goal_id)
@@ -928,6 +986,7 @@ function goalForTask(item: AgentWorkItemRow): AgentOrgBoardTask['goal'] {
   const latestRunId = item.active_run_id ?? approvalRunId ?? draftRunId
   const sessionHref = stringValue(metadata.goal_session_href) ?? `/admin/agents/standup?goal=${encodeURIComponent(goalId)}`
   const isN8nProposal = item.source_type === 'n8n_workflow_proposal' || metadata.n8n_workflow_proposal === true
+  const stageGates = stageGateArrayValue(metadata.stage_gates)
   return {
     id: goalId,
     title: goalTitle,
@@ -949,6 +1008,9 @@ function goalForTask(item: AgentWorkItemRow): AgentOrgBoardTask['goal'] {
     n8nWorkflows: stringArrayValue(metadata.n8n_workflows),
     approvalGate: stringValue(metadata.approval_gate),
     nextAction: stringValue(metadata.next_action),
+    readinessStatus: stringValue(metadata.readiness_status),
+    stageGates,
+    nextStageGate: nextStageGate(stageGates),
     goalType: stringValue(metadata.goal_type),
     contentPacketId: stringValue(metadata.content_packet_id),
     publishGate: stringValue(metadata.publish_gate),
@@ -1025,6 +1087,9 @@ function buildGoalMetrics(tasks: AgentOrgBoardTask[]): AgentOrgBoardGoalMetric[]
       n8nWorkflows: firstGoal?.n8nWorkflows ?? [],
       approvalGate: firstGoal?.approvalGate ?? null,
       nextAction: firstGoal?.nextAction ?? null,
+      readinessStatus: firstGoal?.readinessStatus ?? null,
+      stageGates: firstGoal?.stageGates ?? [],
+      nextStageGate: firstGoal?.nextStageGate ?? null,
       goalType: firstGoal?.goalType ?? null,
       contentPacketId: firstGoal?.contentPacketId ?? null,
       publishGate: firstGoal?.publishGate ?? null,
@@ -1098,7 +1163,9 @@ export function buildAgentOrgBoardSnapshotFromRows(input: AgentOrgBoardBuildInpu
     dependencies: [],
     dependents: [],
     handoffs: [],
-    acceptanceCriteria: stringArrayValue(item.metadata?.acceptance_criteria),
+    acceptanceCriteria: stringArrayValue(item.metadata?.task_acceptance_criteria).length
+      ? stringArrayValue(item.metadata?.task_acceptance_criteria)
+      : stringArrayValue(item.metadata?.acceptance_criteria),
     createdAt: item.created_at,
     updatedAt: item.updated_at,
     completedAt: item.completed_at ?? null,

--- a/lib/agent-war-room.test.ts
+++ b/lib/agent-war-room.test.ts
@@ -244,6 +244,18 @@ describe('runAgentWarRoom', () => {
 
     expect(result.goalDraft?.title).toBe('Build a transparent standup room')
     expect(result.goalDraft?.draft_run_id).toBe('war-room-run')
+    expect(result.goalDraft?.readiness_status).toBe('ready_for_delegation')
+    expect(result.goalDraft?.readiness_checklist?.map((item) => item.label)).toEqual(expect.arrayContaining([
+      'Outcome is clear',
+      'Stage gates are named',
+      'Authority boundaries are explicit',
+    ]))
+    expect(result.goalDraft?.acceptance_criteria?.length).toBeGreaterThan(0)
+    expect(result.goalDraft?.stage_gates?.map((gate) => gate.label)).toEqual(expect.arrayContaining([
+      'Ready to delegate',
+      'Merge/deploy approval',
+    ]))
+    expect(result.goalDraft?.authority_boundary?.notes).toContain('approval gates')
     expect(result.goalDraft?.tasks.length).toBeGreaterThan(2)
     expect(workItemMocks.createAgentWorkItem).not.toHaveBeenCalled()
     expect(agentRunMocks.startAgentRun).toHaveBeenCalledWith(expect.objectContaining({
@@ -262,7 +274,7 @@ describe('runAgentWarRoom', () => {
     }))
   })
 
-  it('creates parent and child work items when a goal draft is approved', async () => {
+  it('creates parent and child work items when readiness is approved', async () => {
     const draftResult = await runAgentWarRoom({
       command: 'draft_goal',
       goal: 'Add goal orchestration',
@@ -276,7 +288,7 @@ describe('runAgentWarRoom', () => {
     agentRunMocks.endAgentRun.mockResolvedValue(undefined)
 
     const result = await runAgentWarRoom({
-      command: 'approve_goal',
+      command: 'approve_readiness',
       draft: draftResult.goalDraft,
       triggerSource: 'test_war_room',
     })
@@ -292,6 +304,10 @@ describe('runAgentWarRoom', () => {
         goal_draft_run_id: 'war-room-run',
         goal_approved_by_run_id: 'approval-run',
         goal_session_href: `/admin/agents/standup?goal=${encodeURIComponent(draftResult.goalDraft?.goal_id ?? '')}`,
+        readiness_status: 'delegated',
+        readiness_checklist: expect.any(Array),
+        stage_gates: expect.any(Array),
+        authority_boundary: expect.any(Object),
       }),
     }))
     expect(workItemMocks.createAgentWorkItem).toHaveBeenCalledWith(expect.objectContaining({
@@ -304,6 +320,8 @@ describe('runAgentWarRoom', () => {
         goal_approved_by_run_id: 'approval-run',
         goal_parent_work_item_id: 'parent-goal',
         goal_sequence: expect.any(Number),
+        readiness_status: 'delegated',
+        stage_gates: expect.any(Array),
         acceptance_criteria: expect.any(Array),
         risk_notes: expect.any(String),
       }),
@@ -347,6 +365,50 @@ describe('runAgentWarRoom', () => {
     expect(result.createdWorkItems?.children.length).toBe(draftResult.goalDraft?.tasks.length)
   })
 
+  it('blocks delegation when required readiness is incomplete', async () => {
+    const draftResult = await runAgentWarRoom({
+      command: 'draft_goal',
+      goal: 'Add goal readiness checks',
+      triggerSource: 'test_war_room',
+    })
+    vi.clearAllMocks()
+
+    await expect(runAgentWarRoom({
+      command: 'approve_readiness',
+      draft: {
+        ...draftResult.goalDraft!,
+        readiness_status: 'needs_context',
+        readiness_checklist: [
+          ...(draftResult.goalDraft?.readiness_checklist ?? []).slice(0, 1).map((item) => ({ ...item, status: 'missing' as const })),
+        ],
+      },
+      triggerSource: 'test_war_room',
+    })).rejects.toThrow('Goal readiness must be ready_for_delegation before delegation')
+
+    expect(workItemMocks.createAgentWorkItem).not.toHaveBeenCalled()
+  })
+
+  it('keeps approve_goal as a compatibility alias for readiness approval', async () => {
+    const draftResult = await runAgentWarRoom({
+      command: 'draft_goal',
+      goal: 'Keep old clients working',
+      triggerSource: 'test_war_room',
+    })
+    vi.clearAllMocks()
+    agentRunMocks.startAgentRun.mockResolvedValue({ id: 'approval-run' })
+
+    await runAgentWarRoom({
+      command: 'approve_goal',
+      draft: draftResult.goalDraft,
+      triggerSource: 'test_war_room',
+    })
+
+    expect(workItemMocks.createAgentWorkItem).toHaveBeenCalled()
+    expect(agentRunMocks.endAgentRun).toHaveBeenCalledWith(expect.objectContaining({
+      outcome: expect.objectContaining({ executes_action: true }),
+    }))
+  })
+
   it('drafts and approves a draft-only LinkedIn social outreach pilot', async () => {
     const draftResult = await runAgentWarRoom({
       command: 'draft_goal',
@@ -387,7 +449,7 @@ describe('runAgentWarRoom', () => {
     supabaseMocks.from.mockClear()
 
     const result = await runAgentWarRoom({
-      command: 'approve_goal',
+      command: 'approve_readiness',
       draft: draftResult.goalDraft,
       triggerSource: 'test_war_room',
     })

--- a/lib/agent-war-room.ts
+++ b/lib/agent-war-room.ts
@@ -11,8 +11,37 @@ import { buildAgentOrgBoardSnapshot, type AgentOrgBoardSnapshot, type AgentOrgBo
 import { createAgentWorkItem, type AgentWorkItem, type AgentWorkItemPriority } from '@/lib/agent-work-items'
 import { supabaseAdmin } from '@/lib/supabase'
 
-export type AgentWarRoomCommand = 'standup' | 'discuss' | 'ask_agent' | 'draft_goal' | 'approve_goal'
+export type AgentWarRoomCommand = 'standup' | 'discuss' | 'ask_agent' | 'draft_goal' | 'approve_readiness' | 'approve_goal'
 export type AgentGoalType = 'general' | 'social_outreach_linkedin_post'
+export type AgentGoalReadinessStatus = 'drafting' | 'needs_context' | 'ready_for_delegation' | 'delegated'
+export type AgentGoalReadinessItemStatus = 'ready' | 'missing' | 'blocked'
+export type AgentGoalStageGateStatus = 'pending' | 'in_progress' | 'complete' | 'blocked'
+
+export interface AgentGoalReadinessItem {
+  key: string
+  label: string
+  status: AgentGoalReadinessItemStatus
+  required: boolean
+  evidence?: string | null
+  blocker?: string | null
+}
+
+export interface AgentGoalStageGate {
+  key: string
+  label: string
+  owner_agent_key?: string | null
+  required_before: string
+  status: AgentGoalStageGateStatus
+  approval_required: boolean
+}
+
+export interface AgentGoalAuthorityBoundary {
+  publish: 'not_allowed' | 'manual_approval_required'
+  send: 'not_allowed' | 'manual_approval_required'
+  deploy: 'not_allowed' | 'manual_approval_required'
+  merge: 'not_allowed' | 'manual_approval_required'
+  notes: string
+}
 
 export interface LinkedInContentPacket {
   id: string
@@ -51,6 +80,13 @@ export interface AgentGoalDraft {
   objective: string
   recommendation: string
   risk_notes: string
+  readiness_status?: AgentGoalReadinessStatus
+  readiness_checklist?: AgentGoalReadinessItem[]
+  acceptance_criteria?: string[]
+  stage_gates?: AgentGoalStageGate[]
+  authority_boundary?: AgentGoalAuthorityBoundary
+  missing_context?: string[]
+  planning_participants?: string[]
   draft_run_id?: string | null
   publish_gate?: 'draft_only' | 'manual_approval_required'
   source_requirements?: string[]
@@ -87,9 +123,13 @@ export interface RunAgentWarRoomInput {
 }
 
 function assertCommand(command: string): asserts command is AgentWarRoomCommand {
-  if (!['standup', 'discuss', 'ask_agent', 'draft_goal', 'approve_goal'].includes(command)) {
+  if (!['standup', 'discuss', 'ask_agent', 'draft_goal', 'approve_readiness', 'approve_goal'].includes(command)) {
     throw new Error('Invalid war room command')
   }
+}
+
+function isApprovalCommand(command: AgentWarRoomCommand) {
+  return command === 'approve_readiness' || command === 'approve_goal'
 }
 
 function podName(podKey: string) {
@@ -128,7 +168,7 @@ function selectAgents(command: AgentWarRoomCommand, message: string | null, targ
 
   const callable = callableAgents()
   if (command === 'standup') return callable.slice(0, 8)
-  if (command === 'draft_goal' || command === 'approve_goal') {
+  if (command === 'draft_goal' || isApprovalCommand(command)) {
     return [
       getAgentByKey('chief-of-staff'),
       getAgentByKey('engineering-copilot'),
@@ -241,10 +281,10 @@ function synthesize(command: AgentWarRoomCommand, updates: ReturnType<typeof age
     return `${updates[0]?.agent_name ?? 'Selected agent'} responded with scoped Agent Ops context.`
   }
   if (command === 'draft_goal') {
-    return 'Goal draft ready for operator review. No work items were created.'
+    return 'Goal readiness packet is ready for operator review. No work items were created.'
   }
-  if (command === 'approve_goal') {
-    return 'Goal approved and converted into traceable Agent Ops work items.'
+  if (isApprovalCommand(command)) {
+    return 'Goal readiness approved and delegated into traceable Agent Ops work items.'
   }
 
   const pods = Array.from(new Set(updates.map((update) => update.pod))).join(', ')
@@ -314,6 +354,81 @@ function buildLinkedInPacket(goalId: string, title: string): LinkedInContentPack
     social_content_draft_id: null,
     social_content_draft_href: null,
   }
+}
+
+function defaultAuthorityBoundary(goalType: AgentGoalType): AgentGoalAuthorityBoundary {
+  return goalType === 'social_outreach_linkedin_post'
+    ? {
+        publish: 'not_allowed',
+        send: 'not_allowed',
+        deploy: 'not_allowed',
+        merge: 'manual_approval_required',
+        notes: 'Approving readiness can create draft work and a Social Content draft only. Publishing, scheduling, DMs, sends, deploys, and production mutation stay outside this approval.',
+      }
+    : {
+        publish: 'manual_approval_required',
+        send: 'manual_approval_required',
+        deploy: 'manual_approval_required',
+        merge: 'manual_approval_required',
+        notes: 'Approving readiness creates Agent Ops work items only. Merge, deploy, publish, send, credential, and production changes require their existing approval gates.',
+      }
+}
+
+function readinessChecklist(goalType: AgentGoalType): AgentGoalReadinessItem[] {
+  const publicBoundary = goalType === 'social_outreach_linkedin_post'
+    ? 'Draft-only content boundary is explicit; no publishing or outbound engagement is authorized.'
+    : 'Merge, deploy, publish, send, credential, and production mutation authority remains explicitly approval-gated.'
+  return [
+    { key: 'outcome_clear', label: 'Outcome is clear', status: 'ready', required: true, evidence: 'The goal objective is stated before delegation.' },
+    { key: 'audience_clear', label: 'Audience or user is clear', status: 'ready', required: true, evidence: goalType === 'social_outreach_linkedin_post' ? 'Audience is LinkedIn readers evaluating practical AI and automation adoption.' : 'Audience is the Agent Ops operator and the owner lanes receiving work.' },
+    { key: 'source_context_identified', label: 'Source and context inputs are identified', status: 'ready', required: true, evidence: goalType === 'social_outreach_linkedin_post' ? 'Industry signal, Open Brain, Chronicle packet, and AmaduTown proof requirements are named.' : 'Agent Ops traces, Kanban, implementation surfaces, and validation notes are named.' },
+    { key: 'safety_boundary_stated', label: 'Privacy and safety boundaries are stated', status: 'ready', required: true, evidence: publicBoundary },
+    { key: 'acceptance_criteria_explicit', label: 'Acceptance criteria are explicit', status: 'ready', required: true, evidence: 'Goal-level and task-level acceptance criteria are attached.' },
+    { key: 'dependencies_known', label: 'Dependencies are known', status: 'ready', required: true, evidence: 'Dependencies are represented on child task drafts before creation.' },
+    { key: 'owners_proposed', label: 'Owner workstreams are proposed', status: 'ready', required: true, evidence: 'Each draft task has a proposed agent owner.' },
+    { key: 'stage_gates_named', label: 'Stage gates are named', status: 'ready', required: true, evidence: 'Planning, delegation, review, and final approval gates are listed.' },
+    { key: 'authority_boundaries_explicit', label: 'Authority boundaries are explicit', status: 'ready', required: true, evidence: 'The authority boundary is attached to the readiness packet.' },
+  ]
+}
+
+function defaultStageGates(goalType: AgentGoalType): AgentGoalStageGate[] {
+  if (goalType === 'social_outreach_linkedin_post') {
+    return [
+      { key: 'ready_to_delegate', label: 'Ready to delegate', owner_agent_key: 'chief-of-staff', required_before: 'work_item_creation', status: 'pending', approval_required: true },
+      { key: 'evidence_packet', label: 'Evidence packet complete', owner_agent_key: 'research-source-register', required_before: 'content_draft_review', status: 'pending', approval_required: false },
+      { key: 'voice_and_visual_review', label: 'Voice and visual review', owner_agent_key: 'voice-content-architect', required_before: 'social_content_handoff', status: 'pending', approval_required: false },
+      { key: 'publish_approval', label: 'Separate publish approval', owner_agent_key: 'risk-compliance-intelligence', required_before: 'publish_or_schedule', status: 'pending', approval_required: true },
+    ]
+  }
+  return [
+    { key: 'ready_to_delegate', label: 'Ready to delegate', owner_agent_key: 'chief-of-staff', required_before: 'work_item_creation', status: 'pending', approval_required: true },
+    { key: 'implementation_review', label: 'Implementation review', owner_agent_key: 'engineering-copilot', required_before: 'handoff', status: 'pending', approval_required: false },
+    { key: 'validation_packet', label: 'Validation packet', owner_agent_key: 'research-source-register', required_before: 'review_or_merge', status: 'pending', approval_required: false },
+    { key: 'merge_deploy_gate', label: 'Merge/deploy approval', owner_agent_key: 'risk-compliance-intelligence', required_before: 'merge_or_deploy', status: 'pending', approval_required: true },
+  ]
+}
+
+function defaultGoalAcceptanceCriteria(goalType: AgentGoalType) {
+  return goalType === 'social_outreach_linkedin_post'
+    ? [
+        'Shaka creates a draft-only LinkedIn content packet before work is delegated.',
+        'Child tasks are owned by named agents and tagged to the parent goal.',
+        'Open Brain and Chronicle evidence boundaries are visible before public copy review.',
+        'Social Content handoff remains draft-only until a separate publish approval.',
+      ]
+    : [
+        'Goal scope, success criteria, and authority boundaries are visible before delegation.',
+        'Child tasks are owned by named agents and tagged to the parent goal.',
+        'Stage gates and validation expectations are traceable from Standup Room and Kanban.',
+        'Merge, deploy, publish, send, credential, and production mutation remain behind existing approval gates.',
+      ]
+}
+
+function planningParticipants(goalType: AgentGoalType) {
+  const keys = goalType === 'social_outreach_linkedin_post'
+    ? ['chief-of-staff', 'research-source-register', 'private-knowledge-librarian', 'voice-content-architect', 'content-repurposing', 'risk-compliance-intelligence']
+    : ['chief-of-staff', 'engineering-copilot', 'automation-systems', 'research-source-register', 'risk-compliance-intelligence']
+  return keys.filter((key) => Boolean(getAgentByKey(key)))
 }
 
 function socialOutreachTasks(goalId: string, title: string): AgentGoalDraftTask[] {
@@ -419,13 +534,24 @@ function socialOutreachTasks(goalId: string, title: string): AgentGoalDraftTask[
 
 function draftSocialOutreachGoal(goal: string, title: string, goalId: string): AgentGoalDraft {
   const packet = buildLinkedInPacket(goalId, title)
+  const goalType: AgentGoalType = 'social_outreach_linkedin_post'
   return {
     goal_id: goalId,
-    goal_type: 'social_outreach_linkedin_post',
+    goal_type: goalType,
     title,
     objective: `Produce one draft-only LinkedIn content packet for: ${goal.trim()}`,
     recommendation: 'Approve this pilot only if the output should stop at a Social Content draft. Publishing, scheduling, DMs, and outbound engagement remain outside this approval.',
     risk_notes: 'Manual Chronicle evidence and approved Open Brain context are required before public copy is approved.',
+    readiness_status: 'ready_for_delegation',
+    readiness_checklist: readinessChecklist(goalType),
+    acceptance_criteria: defaultGoalAcceptanceCriteria(goalType),
+    stage_gates: defaultStageGates(goalType),
+    authority_boundary: defaultAuthorityBoundary(goalType),
+    missing_context: [
+      'Attach the manual Chronicle evidence packet before final content approval.',
+      'Replace the pending industry signal before publishing review.',
+    ],
+    planning_participants: planningParticipants(goalType),
     publish_gate: 'draft_only',
     source_requirements: [
       'One source-backed industry signal',
@@ -511,11 +637,18 @@ function draftGoal(goal: string, goalType: AgentGoalType = 'general'): AgentGoal
 
   return {
     goal_id: goalId,
-    goal_type: 'general',
+    goal_type: goalType,
     title,
     objective: `Accomplish: ${title}`,
     recommendation: 'Approve the packet if the scope is right, then track each child task on Agent Kanban with the shared goal tag.',
     risk_notes: 'V1 creates reviewable work items only after approval; merge and deploy gates remain outside this room.',
+    readiness_status: 'ready_for_delegation',
+    readiness_checklist: readinessChecklist(goalType),
+    acceptance_criteria: defaultGoalAcceptanceCriteria(goalType),
+    stage_gates: defaultStageGates(goalType),
+    authority_boundary: defaultAuthorityBoundary(goalType),
+    missing_context: [],
+    planning_participants: planningParticipants(goalType),
     tasks,
   }
 }
@@ -524,6 +657,7 @@ function assertDraft(value: AgentGoalDraft | null | undefined): AgentGoalDraft {
   if (!value || typeof value.goal_id !== 'string' || typeof value.title !== 'string' || !Array.isArray(value.tasks)) {
     throw new Error('Invalid goal draft')
   }
+  const goalType: AgentGoalType = value.goal_type === 'social_outreach_linkedin_post' ? 'social_outreach_linkedin_post' : 'general'
   for (const task of value.tasks) {
     if (!task.title || !task.owner_agent_key || !getAgentByKey(task.owner_agent_key)) {
       throw new Error('Invalid goal draft task')
@@ -540,10 +674,98 @@ function assertDraft(value: AgentGoalDraft | null | undefined): AgentGoalDraft {
     throw new Error('Invalid goal draft publish gate')
   }
   value.source_requirements = normalizeDraftStringArray(value.source_requirements)
+  value.acceptance_criteria = normalizeDraftStringArray(value.acceptance_criteria)
+  value.missing_context = normalizeDraftStringArray(value.missing_context)
+  value.planning_participants = normalizeDraftStringArray(value.planning_participants)
+  value.readiness_status = normalizeReadinessStatus(value.readiness_status)
+  value.readiness_checklist = normalizeReadinessChecklist(value.readiness_checklist, goalType)
+  value.stage_gates = normalizeStageGates(value.stage_gates, goalType)
+  value.authority_boundary = normalizeAuthorityBoundary(value.authority_boundary, goalType)
   if (value.content_packet && typeof value.content_packet.id !== 'string') {
     throw new Error('Invalid LinkedIn content packet')
   }
   return value
+}
+
+function normalizeReadinessStatus(value: unknown): AgentGoalReadinessStatus {
+  return value === 'drafting' || value === 'needs_context' || value === 'delegated' || value === 'ready_for_delegation'
+    ? value
+    : 'needs_context'
+}
+
+function normalizeReadinessChecklist(value: unknown, goalType: AgentGoalType): AgentGoalReadinessItem[] {
+  const fallback = readinessChecklist(goalType)
+  if (!Array.isArray(value)) return fallback
+  return value.map((item, index) => {
+    const record = item && typeof item === 'object' ? item as Record<string, unknown> : {}
+    const fallbackItem = fallback[index] ?? fallback[0]
+    const status = record.status === 'ready' || record.status === 'missing' || record.status === 'blocked'
+      ? record.status
+      : 'missing'
+    return {
+      key: typeof record.key === 'string' && record.key.trim() ? record.key.trim() : fallbackItem.key,
+      label: typeof record.label === 'string' && record.label.trim() ? record.label.trim() : fallbackItem.label,
+      status,
+      required: typeof record.required === 'boolean' ? record.required : true,
+      evidence: typeof record.evidence === 'string' && record.evidence.trim() ? record.evidence.trim() : null,
+      blocker: typeof record.blocker === 'string' && record.blocker.trim() ? record.blocker.trim() : null,
+    }
+  })
+}
+
+function normalizeStageGates(value: unknown, goalType: AgentGoalType): AgentGoalStageGate[] {
+  const fallback = defaultStageGates(goalType)
+  if (!Array.isArray(value)) return fallback
+  return value.map((item, index) => {
+    const record = item && typeof item === 'object' ? item as Record<string, unknown> : {}
+    const fallbackGate = fallback[index] ?? fallback[0]
+    const status = record.status === 'pending' || record.status === 'in_progress' || record.status === 'complete' || record.status === 'blocked'
+      ? record.status
+      : 'pending'
+    return {
+      key: typeof record.key === 'string' && record.key.trim() ? record.key.trim() : fallbackGate.key,
+      label: typeof record.label === 'string' && record.label.trim() ? record.label.trim() : fallbackGate.label,
+      owner_agent_key: typeof record.owner_agent_key === 'string' && record.owner_agent_key.trim() ? record.owner_agent_key.trim() : fallbackGate.owner_agent_key ?? null,
+      required_before: typeof record.required_before === 'string' && record.required_before.trim() ? record.required_before.trim() : fallbackGate.required_before,
+      status,
+      approval_required: typeof record.approval_required === 'boolean' ? record.approval_required : fallbackGate.approval_required,
+    }
+  })
+}
+
+function normalizeAuthorityBoundary(value: unknown, goalType: AgentGoalType): AgentGoalAuthorityBoundary {
+  const fallback = defaultAuthorityBoundary(goalType)
+  const record = value && typeof value === 'object' ? value as Record<string, unknown> : {}
+  const boundaryValue = (item: unknown, fallbackValue: 'not_allowed' | 'manual_approval_required') => {
+    return item === 'not_allowed' || item === 'manual_approval_required' ? item : fallbackValue
+  }
+  return {
+    publish: boundaryValue(record.publish, fallback.publish),
+    send: boundaryValue(record.send, fallback.send),
+    deploy: boundaryValue(record.deploy, fallback.deploy),
+    merge: boundaryValue(record.merge, fallback.merge),
+    notes: typeof record.notes === 'string' && record.notes.trim() ? record.notes.trim() : fallback.notes,
+  }
+}
+
+function assertDraftReadyForDelegation(draft: AgentGoalDraft) {
+  const requiredItems = draft.readiness_checklist?.filter((item) => item.required) ?? []
+  const incomplete = requiredItems.filter((item) => item.status !== 'ready')
+  if (draft.readiness_status !== 'ready_for_delegation') {
+    throw new Error('Goal readiness must be ready_for_delegation before delegation')
+  }
+  if (incomplete.length) {
+    throw new Error(`Goal readiness is incomplete: ${incomplete.map((item) => item.label).join(', ')}`)
+  }
+  if (!draft.acceptance_criteria?.length) {
+    throw new Error('Goal acceptance criteria are required before delegation')
+  }
+  if (!draft.stage_gates?.length) {
+    throw new Error('Goal stage gates are required before delegation')
+  }
+  if (!draft.authority_boundary?.notes) {
+    throw new Error('Goal authority boundary is required before delegation')
+  }
 }
 
 function normalizeDraftStringArray(value: unknown): string[] {
@@ -652,6 +874,7 @@ async function createSocialContentDraftForGoal(draft: AgentGoalDraft) {
 }
 
 async function approveGoalDraft(runId: string, draft: AgentGoalDraft) {
+  assertDraftReadyForDelegation(draft)
   const draftRunId = draft.draft_run_id ?? null
   const sessionHref = goalSessionHref(draft.goal_id)
   const socialContentDraft = await createSocialContentDraftForGoal(draft)
@@ -675,6 +898,13 @@ async function approveGoalDraft(runId: string, draft: AgentGoalDraft) {
       goal_id: draft.goal_id,
       goal_title: draft.title,
       goal_status: 'approved',
+      readiness_status: 'delegated',
+      readiness_checklist: draft.readiness_checklist ?? [],
+      stage_gates: draft.stage_gates ?? [],
+      acceptance_criteria: draft.acceptance_criteria ?? [],
+      authority_boundary: draft.authority_boundary ?? null,
+      missing_context: draft.missing_context ?? [],
+      planning_participants: draft.planning_participants ?? [],
       goal_role: 'parent',
       goal_created_by_run_id: runId,
       goal_draft_run_id: draftRunId,
@@ -713,6 +943,13 @@ async function approveGoalDraft(runId: string, draft: AgentGoalDraft) {
         goal_title: draft.title,
         goal_sequence: index + 1,
         goal_status: 'approved',
+        readiness_status: 'delegated',
+        readiness_checklist: draft.readiness_checklist ?? [],
+        stage_gates: draft.stage_gates ?? [],
+        acceptance_criteria: draft.acceptance_criteria ?? [],
+        authority_boundary: draft.authority_boundary ?? null,
+        missing_context: draft.missing_context ?? [],
+        planning_participants: draft.planning_participants ?? [],
         goal_role: 'task',
         goal_created_by_run_id: runId,
         goal_draft_run_id: draftRunId,
@@ -722,7 +959,7 @@ async function approveGoalDraft(runId: string, draft: AgentGoalDraft) {
         goal_progress_weight: task.goal_progress_weight,
         goal_task_id: task.id,
         goal_dependencies: task.dependencies,
-        acceptance_criteria: task.acceptance_criteria,
+        task_acceptance_criteria: task.acceptance_criteria,
         risk_notes: task.risk_notes,
         publish_gate: draft.publish_gate ?? null,
         content_packet_id: draft.content_packet_id ?? contentPacket?.id ?? null,
@@ -754,7 +991,7 @@ export async function runAgentWarRoom(input: RunAgentWarRoomInput) {
     const agent = getAgentByKey(input.targetAgentKey ?? '')
     if (!agent || agent.status === 'planned') throw new Error('Invalid agent key')
   }
-  if (input.command === 'approve_goal') {
+  if (isApprovalCommand(input.command)) {
     assertDraft(input.draft)
   }
 
@@ -763,12 +1000,13 @@ export async function runAgentWarRoom(input: RunAgentWarRoomInput) {
     discuss: 'Agent Standup Room discussion',
     ask_agent: 'Agent Standup Room direct ask',
     draft_goal: 'Agent Standup Room goal draft',
+    approve_readiness: 'Agent Standup Room readiness approval',
     approve_goal: 'Agent Standup Room goal approval',
   }
   const precomputedGoalDraft = input.command === 'draft_goal' ? draftGoal(goal ?? '', goalType) : null
-  const draftGoalId = input.command === 'approve_goal' ? input.draft?.goal_id ?? null : precomputedGoalDraft?.goal_id ?? null
+  const draftGoalId = isApprovalCommand(input.command) ? input.draft?.goal_id ?? null : precomputedGoalDraft?.goal_id ?? null
   const activeGoalId = draftGoalId ?? contextGoalId
-  const draftRunId = input.command === 'approve_goal' ? input.draft?.draft_run_id ?? null : null
+  const draftRunId = isApprovalCommand(input.command) ? input.draft?.draft_run_id ?? null : null
   const run = await startAgentRun({
     agentKey: 'chief-of-staff',
     runtime: 'manual',
@@ -792,8 +1030,8 @@ export async function runAgentWarRoom(input: RunAgentWarRoomInput) {
       goal_id: activeGoalId,
       goal_session_href: activeGoalId ? goalSessionHref(activeGoalId) : null,
       goal_draft_run_id: draftRunId,
-      goal_approved_by_run_id: input.command === 'approve_goal' ? null : null,
-      executes_action: input.command === 'approve_goal',
+      goal_approved_by_run_id: isApprovalCommand(input.command) ? null : null,
+      executes_action: isApprovalCommand(input.command),
     },
   })
 
@@ -827,7 +1065,7 @@ export async function runAgentWarRoom(input: RunAgentWarRoomInput) {
   if (input.command === 'draft_goal') {
     goalDraft = precomputedGoalDraft ? { ...precomputedGoalDraft, draft_run_id: run.id } : null
   }
-  if (input.command === 'approve_goal') {
+  if (isApprovalCommand(input.command)) {
     const draft = assertDraft(input.draft)
     createdWorkItems = await approveGoalDraft(run.id, draft)
   }
@@ -846,10 +1084,10 @@ export async function runAgentWarRoom(input: RunAgentWarRoomInput) {
 
   await recordAgentStep({
     runId: run.id,
-    stepKey: input.command === 'approve_goal' ? 'goal_work_items_created' : 'agent_updates',
-    name: input.command === 'approve_goal' ? 'Created approved goal work items' : 'Collected agent responses',
+    stepKey: isApprovalCommand(input.command) ? 'goal_work_items_created' : 'agent_updates',
+    name: isApprovalCommand(input.command) ? 'Created readiness-approved goal work items' : 'Collected agent responses',
     status: 'completed',
-    outputSummary: input.command === 'approve_goal'
+    outputSummary: isApprovalCommand(input.command)
       ? `${createdWorkItems?.children.length ?? 0} child work item(s)`
       : `${updates.length} agent response(s)`,
     metadata: { updates, goalDraft, createdWorkItems },
@@ -880,11 +1118,11 @@ export async function runAgentWarRoom(input: RunAgentWarRoomInput) {
       goal_id: finalGoalId,
       goal_session_href: finalGoalSessionHref,
       goal_draft_run_id: goalDraft?.draft_run_id ?? input.draft?.draft_run_id ?? null,
-      goal_approved_by_run_id: input.command === 'approve_goal' ? run.id : null,
+      goal_approved_by_run_id: isApprovalCommand(input.command) ? run.id : null,
       created_parent_work_item_id: createdParentId,
       created_child_work_item_ids: createdChildIds,
       status_strip: snapshot.status_strip,
-      executes_action: input.command === 'approve_goal',
+      executes_action: isApprovalCommand(input.command),
     },
     idempotencyKey: `${run.id}:war-room-artifact`,
   })
@@ -900,7 +1138,7 @@ export async function runAgentWarRoom(input: RunAgentWarRoomInput) {
       goal_id: finalGoalId,
       goal_session_href: finalGoalSessionHref,
       goal_draft_run_id: goalDraft?.draft_run_id ?? input.draft?.draft_run_id ?? null,
-      goal_approved_by_run_id: input.command === 'approve_goal' ? run.id : null,
+      goal_approved_by_run_id: isApprovalCommand(input.command) ? run.id : null,
       social_content_draft_id: createdWorkItems?.parent.metadata?.social_content_draft_id ?? null,
     },
   })
@@ -913,11 +1151,11 @@ export async function runAgentWarRoom(input: RunAgentWarRoomInput) {
       command: input.command,
       update_count: updates.length,
       synthesis,
-      executes_action: input.command === 'approve_goal',
+      executes_action: isApprovalCommand(input.command),
       goal_id: finalGoalId,
       goal_session_href: finalGoalSessionHref,
       goal_draft_run_id: goalDraft?.draft_run_id ?? input.draft?.draft_run_id ?? null,
-      goal_approved_by_run_id: input.command === 'approve_goal' ? run.id : null,
+      goal_approved_by_run_id: isApprovalCommand(input.command) ? run.id : null,
       created_parent_work_item_id: createdParentId,
       created_child_work_item_ids: createdChildIds,
       created_child_count: createdWorkItems?.children.length ?? 0,


### PR DESCRIPTION
## Summary
- adds a Goal Readiness Packet to Standup Room goal drafting with Definition of Ready, acceptance criteria, stage gates, authority boundaries, missing context, and planning participants
- adds `approve_readiness` to the war-room API while preserving `approve_goal` as a compatibility alias
- projects delegated goals into Mission Control and Agent Kanban with progress, next stage gate, blockers, and artifact/session links

## Validation
- `npm test -- app/admin/agents/standup/page.test.tsx app/admin/agents/page.test.tsx app/admin/agents/swarm-board/page.test.tsx app/api/admin/agents/war-room/route.test.ts lib/agent-war-room.test.ts lib/agent-swarm-board.test.ts`
- `npx tsc --noEmit --pretty false`
- `npm run lint`
- `git diff --check`
- `npm run build`
- Local route smoke against `http://localhost:3010/admin/agents`, `/admin/agents/standup`, `/admin/agents/swarm-board`, and goal-scoped URLs reached the auth guard in a fresh Playwright context; authenticated browser QA still needs to be run in the logged-in admin session.

## Integration Notes
- No schema migration; V1 stores readiness and stage-gate data in existing work item metadata.
- No autonomous publish/send/deploy/merge path was added. Social outreach remains `publish_gate: draft_only`.
- Worktree env bootstrap completed from `/Users/vambahsillah/Projects/Portfolio`; `.env.local` and `.vercel` linked, `.env.staging` was absent in the source checkout.
- Build emitted the existing local env warning that outbound n8n webhooks are enabled (`MOCK_N8N=false`, `N8N_DISABLE_OUTBOUND=false`); no live n8n workflow/customer-data smoke was run.
- Vercel `portfolio` preview check is green. `portfolio-staging` has not appeared on the PR branch check rollup yet.
