### PR TITLE
feat: add Slack mobile unblock actions

### DIFF
--- a/app/api/slack/agent/actions/route.test.ts
+++ b/app/api/slack/agent/actions/route.test.ts
@@ -1,0 +1,107 @@
+import { createHmac } from 'crypto'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  handleSlackAgentAction: vi.fn(),
+}))
+
+vi.mock('@/lib/agent-slack-actions', () => ({
+  handleSlackAgentAction: mocks.handleSlackAgentAction,
+}))
+
+import { POST } from './route'
+
+const ORIGINAL_ENV = process.env
+
+function signedRequest(payload: unknown, secret = 'test-slack-secret', extraHeaders: Record<string, string> = {}) {
+  const rawBody = new URLSearchParams({ payload: JSON.stringify(payload) }).toString()
+  const timestamp = Math.floor(Date.now() / 1000).toString()
+  const signature = `v0=${createHmac('sha256', secret).update(`v0:${timestamp}:${rawBody}`).digest('hex')}`
+
+  return new Request('http://localhost/api/slack/agent/actions', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/x-www-form-urlencoded',
+      'x-slack-request-timestamp': timestamp,
+      'x-slack-signature': signature,
+      ...extraHeaders,
+    },
+    body: rawBody,
+  })
+}
+
+describe('POST /api/slack/agent/actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env = { ...ORIGINAL_ENV, SLACK_SIGNING_SECRET: 'test-slack-secret' }
+    mocks.handleSlackAgentAction.mockResolvedValue({
+      responseType: 'ephemeral',
+      text: 'Approved from Slack.',
+    })
+  })
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV
+  })
+
+  it('rejects invalid Slack signatures', async () => {
+    const response = await POST(signedRequest({ type: 'block_actions' }, 'wrong-secret') as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Invalid Slack signature' })
+    expect(mocks.handleSlackAgentAction).not.toHaveBeenCalled()
+  })
+
+  it('rejects malformed interactive payloads', async () => {
+    const rawBody = new URLSearchParams({ payload: '{bad json' }).toString()
+    const timestamp = Math.floor(Date.now() / 1000).toString()
+    const signature = `v0=${createHmac('sha256', 'test-slack-secret').update(`v0:${timestamp}:${rawBody}`).digest('hex')}`
+
+    const response = await POST(new Request('http://localhost/api/slack/agent/actions', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        'x-slack-request-timestamp': timestamp,
+        'x-slack-signature': signature,
+      },
+      body: rawBody,
+    }) as never)
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'Invalid Slack payload' })
+    expect(mocks.handleSlackAgentAction).not.toHaveBeenCalled()
+  })
+
+  it('acknowledges Slack retries without running the action again', async () => {
+    const response = await POST(signedRequest(
+      { type: 'block_actions' },
+      'test-slack-secret',
+      { 'x-slack-retry-num': '1' },
+    ) as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      response_type: 'ephemeral',
+      text: 'Agent Ops already received this Slack action.',
+    })
+    expect(mocks.handleSlackAgentAction).not.toHaveBeenCalled()
+  })
+
+  it('passes block action payloads to the action service', async () => {
+    const payload = {
+      type: 'block_actions',
+      user: { id: 'U123', username: 'vambah' },
+      actions: [{ action_id: 'agent_approval_approve', value: '{"action":"approval.approve","approvalId":"approval-1"}' }],
+    }
+
+    const response = await POST(signedRequest(payload) as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      response_type: 'ephemeral',
+      text: 'Approved from Slack.',
+      replace_original: false,
+    })
+    expect(mocks.handleSlackAgentAction).toHaveBeenCalledWith(payload)
+  })
+})

--- a/app/api/slack/agent/actions/route.ts
+++ b/app/api/slack/agent/actions/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifySlackSignature } from '@/lib/slack-signature'
+import { handleSlackAgentAction, type SlackInteractivePayload } from '@/lib/agent-slack-actions'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * POST /api/slack/agent/actions
+ *
+ * Slack interactivity endpoint for Agent Ops mobile unblock controls.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const rawBody = await request.text()
+    const isValid = verifySlackSignature(request, rawBody)
+    if (!isValid) {
+      return NextResponse.json({ error: 'Invalid Slack signature' }, { status: 401 })
+    }
+
+    if (request.headers.get('x-slack-retry-num')) {
+      return NextResponse.json({
+        response_type: 'ephemeral',
+        text: 'Agent Ops already received this Slack action.',
+      })
+    }
+
+    const formData = new URLSearchParams(rawBody)
+    const payloadRaw = formData.get('payload')
+    if (!payloadRaw) {
+      return NextResponse.json({ error: 'Missing Slack payload' }, { status: 400 })
+    }
+
+    let payload: SlackInteractivePayload
+    try {
+      payload = JSON.parse(payloadRaw) as SlackInteractivePayload
+    } catch {
+      return NextResponse.json({ error: 'Invalid Slack payload' }, { status: 400 })
+    }
+
+    if (payload.type !== 'block_actions' && payload.type !== 'view_submission') {
+      return NextResponse.json({
+        response_type: 'ephemeral',
+        text: 'Unsupported Agent Ops Slack interaction.',
+      })
+    }
+
+    const result = await handleSlackAgentAction(payload)
+    return NextResponse.json({
+      response_type: result.responseType,
+      text: result.text,
+      replace_original: result.replaceOriginal ?? false,
+    })
+  } catch (error) {
+    console.error('Error in Slack agent action handler:', error)
+    return NextResponse.json({
+      response_type: 'ephemeral',
+      text: 'Agent Ops could not complete that Slack action. Check Portfolio logs and try again.',
+    })
+  }
+}

--- a/app/api/slack/agent/route.test.ts
+++ b/app/api/slack/agent/route.test.ts
@@ -105,6 +105,30 @@ describe('POST /api/slack/agent', () => {
     })
   })
 
+  it('returns Block Kit payloads when the command handler supplies mobile actions', async () => {
+    mocks.handleAgentSlackCommand.mockResolvedValueOnce({
+      responseType: 'ephemeral',
+      text: 'Pending approvals',
+      blocks: [{ type: 'section', text: { type: 'mrkdwn', text: '*Pending approvals*' } }],
+    })
+    const request = signedRequest(
+      new URLSearchParams({
+        text: 'approvals',
+        user_id: 'U123',
+        user_name: 'vambah',
+      }),
+    )
+
+    const response = await POST(request as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      response_type: 'ephemeral',
+      text: 'Pending approvals',
+      blocks: [{ type: 'section', text: { type: 'mrkdwn', text: '*Pending approvals*' } }],
+    })
+  })
+
   it('returns detailed command output directly when it completes inside Slack response window', async () => {
     const request = signedRequest(
       new URLSearchParams({

--- a/app/api/slack/agent/route.ts
+++ b/app/api/slack/agent/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { waitUntil } from '@vercel/functions'
 import { verifySlackSignature } from '@/lib/slack-signature'
+import type { AgentSlackCommandResult } from '@/lib/agent-slack-command'
 
 export const dynamic = 'force-dynamic'
 
@@ -31,6 +32,7 @@ export async function POST(request: NextRequest) {
         return NextResponse.json({
           response_type: result.responseType,
           text: result.text,
+          ...(result.blocks ? { blocks: result.blocks } : {}),
         })
       }
 
@@ -47,6 +49,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({
       response_type: result.responseType,
       text: result.text,
+      ...(result.blocks ? { blocks: result.blocks } : {}),
     })
   } catch (error) {
     console.error('Error in Slack agent command:', error)
@@ -81,7 +84,7 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T | nul
 
 async function postDelayedAgentResponse(
   responseUrl: string,
-  commandResult: Promise<{ responseType: string; text: string }>,
+  commandResult: Promise<AgentSlackCommandResult>,
 ) {
   try {
     const result = await commandResult
@@ -92,6 +95,7 @@ async function postDelayedAgentResponse(
         response_type: result.responseType,
         replace_original: false,
         text: result.text,
+        ...(result.blocks ? { blocks: result.blocks } : {}),
       }),
     })
   } catch (error) {

--- a/docs/agent-ops-slack-mobile-unblock.md
+++ b/docs/agent-ops-slack-mobile-unblock.md
@@ -1,0 +1,32 @@
+# Agent Ops Slack Mobile Unblock
+
+Slack is the mobile action surface for Agent Ops. Mission Control remains the full operating console; Slack is for quick, governed unblocks when the packet is safe enough to decide away from Portfolio.
+
+## Slack App Configuration
+
+- Slash command request URL: `/api/slack/agent`
+- Interactivity request URL: `/api/slack/agent/actions`
+- Event subscription URL: `/api/slack/agent/events`
+- Required signing secret: `SLACK_SIGNING_SECRET`
+- Required operator allowlist for non-local environments: `SLACK_AGENT_OPS_ALLOWED_USER_IDS`
+- Existing Shaka/Event replies use the Slack bot token path already configured for Agent Ops.
+
+`SLACK_AGENT_OPS_ALLOWED_USER_IDS` is a comma-separated list of Slack user IDs that may trigger Agent Ops mobile actions. If the allowlist is missing outside local development, the action endpoint rejects mutations.
+
+## Allowed Mobile Actions
+
+Slack can show Agent Ops cards for approvals, work items, blockers, and inbox entries. Safe buttons include:
+
+- approve or decline low-risk approval packets,
+- request revision,
+- assign or hand off a work item,
+- mark a work item ready,
+- route an inbox item,
+- ask Shaka for a context summary,
+- open Portfolio trace, Kanban, Decision Queue, or Run Console links.
+
+## Governance Boundary
+
+Slack must not directly perform production workflow activation, credential changes, outbound sends, customer-data mutation, publishing, payments, or n8n workflow activation. Those actions deep-link back to Portfolio for review.
+
+Every accepted Slack action should write an Agent Ops event so Mission Control, Run Console, and Kanban can reflect the mobile decision trail.

--- a/lib/agent-slack-actions.test.ts
+++ b/lib/agent-slack-actions.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  from: vi.fn(),
+  runChiefOfStaffChat: vi.fn(),
+  recordAgentEvent: vi.fn(),
+  claimAgentWorkItem: vi.fn(),
+  getAgentWorkItem: vi.fn(),
+  handoffAgentWorkItem: vi.fn(),
+  markAgentWorkItemReadyForKanban: vi.fn(),
+  recordAgentWorkItemBlocker: vi.fn(),
+  routeAgentInboxItem: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: { from: mocks.from },
+}))
+
+vi.mock('@/lib/chief-of-staff-chat', () => ({
+  runChiefOfStaffChat: mocks.runChiefOfStaffChat,
+}))
+
+vi.mock('@/lib/agent-run', () => ({
+  recordAgentEvent: mocks.recordAgentEvent,
+}))
+
+vi.mock('@/lib/agent-work-items', () => ({
+  claimAgentWorkItem: mocks.claimAgentWorkItem,
+  getAgentWorkItem: mocks.getAgentWorkItem,
+  handoffAgentWorkItem: mocks.handoffAgentWorkItem,
+  markAgentWorkItemReadyForKanban: mocks.markAgentWorkItemReadyForKanban,
+  recordAgentWorkItemBlocker: mocks.recordAgentWorkItemBlocker,
+}))
+
+vi.mock('@/lib/agent-inbox-routing', () => ({
+  routeAgentInboxItem: mocks.routeAgentInboxItem,
+}))
+
+import { handleSlackAgentAction } from '@/lib/agent-slack-actions'
+
+const ORIGINAL_ENV = process.env
+
+function queryResult(result: unknown) {
+  const query: Record<string, unknown> = {
+    select: vi.fn(() => query),
+    eq: vi.fn(() => query),
+    maybeSingle: vi.fn(() => Promise.resolve(result)),
+    update: vi.fn(() => query),
+    insert: vi.fn(() => Promise.resolve(result)),
+    limit: vi.fn(() => Promise.resolve(result)),
+    then: (resolve: (value: unknown) => unknown, reject: (reason?: unknown) => unknown) =>
+      Promise.resolve(result).then(resolve, reject),
+  }
+  return query
+}
+
+function payload(value: Record<string, unknown>, userId = 'U123') {
+  return {
+    type: 'block_actions',
+    user: { id: userId, username: 'vambah' },
+    action_ts: '1716400000.000',
+    container: { message_ts: '1716400000.000' },
+    actions: [{ value: JSON.stringify(value) }],
+  }
+}
+
+describe('Agent Ops Slack actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env = {
+      ...ORIGINAL_ENV,
+      SLACK_AGENT_OPS_ALLOWED_USER_IDS: 'U123',
+    }
+  })
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV
+  })
+
+  it('rejects unauthorized Slack users before mutation', async () => {
+    const result = await handleSlackAgentAction(payload({ action: 'work.assign', workItemId: 'work-1', agentKey: 'chief-of-staff' }, 'U999'))
+
+    expect(result.text).toContain('not configured')
+    expect(mocks.from).not.toHaveBeenCalled()
+  })
+
+  it('requires Portfolio review for high-risk approvals', async () => {
+    mocks.from
+      .mockReturnValueOnce(queryResult({ data: null, error: null }))
+      .mockReturnValueOnce(queryResult({
+        data: {
+          id: 'approval-1',
+          run_id: 'run-1',
+          approval_type: 'n8n_workflow_activation',
+          status: 'pending',
+          metadata: { work_item_id: 'work-1' },
+        },
+        error: null,
+      }))
+
+    const result = await handleSlackAgentAction(payload({
+      action: 'approval.approve',
+      approvalId: 'approval-1',
+      runId: 'run-1',
+    }))
+
+    expect(result.text).toContain('Portfolio review required')
+    expect(mocks.from).toHaveBeenCalledWith('agent_approvals')
+  })
+
+  it('approves low-risk proposal approvals and records a Slack trace event', async () => {
+    const approvalUpdate = queryResult({ error: null })
+    const workItemUpdate = queryResult({ error: null })
+    const runUpdate = queryResult({ error: null })
+
+    mocks.from
+      .mockReturnValueOnce(queryResult({ data: null, error: null }))
+      .mockReturnValueOnce(queryResult({
+        data: {
+          id: 'approval-1',
+          run_id: 'run-1',
+          approval_type: 'vercel_deployment_research_proposal',
+          status: 'pending',
+          metadata: { work_item_id: 'work-1' },
+        },
+        error: null,
+      }))
+      .mockReturnValueOnce(approvalUpdate)
+      .mockReturnValueOnce(queryResult({ error: null }))
+      .mockReturnValueOnce(workItemUpdate)
+      .mockReturnValueOnce(queryResult({ data: [], error: null }))
+      .mockReturnValueOnce(runUpdate)
+
+    const result = await handleSlackAgentAction(payload({
+      action: 'approval.approve',
+      approvalId: 'approval-1',
+      runId: 'run-1',
+      note: 'Looks good from mobile.',
+    }))
+
+    expect(result.text).toContain('Approval approved from Slack')
+    expect(approvalUpdate.update).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'approved',
+      decision_notes: 'Looks good from mobile.',
+    }))
+    expect(workItemUpdate.update).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'assigned',
+      blocker_summary: null,
+    }))
+    expect(runUpdate.update).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'running',
+      current_step: 'Approval granted from Slack',
+    }))
+  })
+
+  it('assigns Kanban work items through the shared work-item service', async () => {
+    mocks.from.mockReturnValueOnce(queryResult({ data: null, error: null }))
+    mocks.claimAgentWorkItem.mockResolvedValue({
+      id: 'work-1',
+      title: 'Unowned blocker',
+      active_run_id: 'run-1',
+    })
+    mocks.recordAgentEvent.mockResolvedValue({ id: 'event-1' })
+
+    const result = await handleSlackAgentAction(payload({
+      action: 'work.assign',
+      workItemId: 'work-1',
+      agentKey: 'integration-captain',
+    }))
+
+    expect(mocks.claimAgentWorkItem).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'work-1',
+      ownerAgentKey: 'integration-captain',
+      actorLabel: 'vambah',
+    }))
+    expect(mocks.recordAgentEvent).toHaveBeenCalledWith(expect.objectContaining({
+      runId: 'run-1',
+      eventType: 'slack_work_item_assigned',
+    }))
+    expect(result.text).toContain('Assigned to integration-captain')
+  })
+})

--- a/lib/agent-slack-actions.ts
+++ b/lib/agent-slack-actions.ts
@@ -1,0 +1,436 @@
+import { runChiefOfStaffChat } from '@/lib/chief-of-staff-chat'
+import { recordAgentEvent } from '@/lib/agent-run'
+import {
+  claimAgentWorkItem,
+  getAgentWorkItem,
+  handoffAgentWorkItem,
+  markAgentWorkItemReadyForKanban,
+  recordAgentWorkItemBlocker,
+} from '@/lib/agent-work-items'
+import { routeAgentInboxItem } from '@/lib/agent-inbox-routing'
+import { supabaseAdmin } from '@/lib/supabase'
+import { decodeSlackActionValue, type SlackAgentActionValue } from '@/lib/agent-slack-blocks'
+
+export type SlackInteractivePayload = {
+  type?: string
+  user?: {
+    id?: string
+    username?: string
+    name?: string
+  }
+  actions?: Array<{
+    action_id?: string
+    value?: string
+  }>
+  callback_id?: string
+  trigger_id?: string
+  response_url?: string
+  action_ts?: string
+  message?: {
+    ts?: string
+  }
+  container?: {
+    message_ts?: string
+  }
+}
+
+export type SlackAgentActionResult = {
+  responseType: 'ephemeral' | 'in_channel'
+  text: string
+  replaceOriginal?: boolean
+}
+
+type ApprovalRow = {
+  id: string
+  run_id: string
+  approval_type: string
+  status: string
+  metadata: Record<string, unknown> | null
+}
+
+type RunRow = {
+  id: string
+  status: string
+}
+
+function baseUrl() {
+  return (
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    process.env.PORTFOLIO_BASE_URL ||
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    'https://amadutown.com'
+  ).replace(/\/$/, '')
+}
+
+function agentRunsUrl(runId?: string | null) {
+  return `${baseUrl()}/admin/agents/runs${runId ? `/${runId}` : ''}`
+}
+
+function allowedSlackUserIds() {
+  const raw =
+    process.env.SLACK_AGENT_OPS_ALLOWED_USER_IDS ||
+    process.env.SLACK_AGENT_ALLOWED_USER_IDS ||
+    ''
+  return new Set(raw.split(',').map((value) => value.trim()).filter(Boolean))
+}
+
+function requireAuthorizedSlackUser(payload: SlackInteractivePayload) {
+  const userId = payload.user?.id
+  const allowed = allowedSlackUserIds()
+  const localMode =
+    process.env.NODE_ENV !== 'production' &&
+    !process.env.VERCEL &&
+    process.env.NEXT_PUBLIC_APP_ENV !== 'staging'
+
+  if (!userId) {
+    return { ok: false as const, text: 'Slack action rejected: missing Slack user id.' }
+  }
+  if (allowed.size === 0 && localMode) {
+    return { ok: true as const, userId, actorLabel: payload.user?.username || payload.user?.name || userId }
+  }
+  if (allowed.has(userId)) {
+    return { ok: true as const, userId, actorLabel: payload.user?.username || payload.user?.name || userId }
+  }
+  return {
+    ok: false as const,
+    text: 'Slack action rejected: this Slack user is not configured for Agent Ops mobile approvals.',
+  }
+}
+
+function isSlackDecidableApproval(approvalType: string) {
+  return approvalType === 'vercel_deployment_research_proposal'
+}
+
+function actionFromPayload(payload: SlackInteractivePayload): SlackAgentActionValue | null {
+  const action = payload.actions?.[0]
+  return decodeSlackActionValue(action?.value)
+}
+
+function idempotencyKey(payload: SlackInteractivePayload, value: SlackAgentActionValue) {
+  return [
+    'slack-agent-action',
+    payload.user?.id ?? 'unknown-user',
+    payload.container?.message_ts ?? payload.message?.ts ?? payload.action_ts ?? 'unknown-ts',
+    value.action,
+    value.approvalId ?? value.workItemId ?? value.runId ?? 'unknown-target',
+  ].join(':')
+}
+
+async function hasRecordedSlackAction(key: string) {
+  if (!supabaseAdmin) return false
+  const { data, error } = await supabaseAdmin
+    .from('agent_run_events')
+    .select('id')
+    .eq('idempotency_key', key)
+    .maybeSingle()
+  if (error) return false
+  return Boolean(data?.id)
+}
+
+async function recordSlackActionEvent(input: {
+  key: string
+  runId?: string | null
+  eventType: string
+  message: string
+  metadata?: Record<string, unknown>
+}) {
+  if (!input.runId) return
+  await recordAgentEvent({
+    runId: input.runId,
+    eventType: input.eventType,
+    severity: 'info',
+    message: input.message,
+    metadata: input.metadata,
+    idempotencyKey: input.key,
+  }).catch(() => {})
+}
+
+async function decideApprovalFromSlack(input: {
+  approvalId: string
+  status: 'approved' | 'rejected'
+  actorLabel: string
+  slackUserId: string
+  decisionNotes: string
+  idempotencyKey: string
+}) {
+  if (!supabaseAdmin) throw new Error('Database not available')
+
+  const { data: approval, error } = await supabaseAdmin
+    .from('agent_approvals')
+    .select('id, run_id, approval_type, status, metadata')
+    .eq('id', input.approvalId)
+    .maybeSingle()
+
+  if (error || !approval?.id) throw new Error('Approval not found')
+  const row = approval as ApprovalRow
+  if (row.status !== 'pending') {
+    return `Approval already ${row.status}. Trace: ${agentRunsUrl(row.run_id)}`
+  }
+  if (!isSlackDecidableApproval(row.approval_type)) {
+    return `Portfolio review required for \`${row.approval_type}\`. Open trace: ${agentRunsUrl(row.run_id)}`
+  }
+
+  const metadata = row.metadata && typeof row.metadata === 'object' ? row.metadata : {}
+  const decision = {
+    status: input.status,
+    decision_notes: input.decisionNotes,
+    decided_by_slack_user_id: input.slackUserId,
+    decided_by_label: input.actorLabel,
+    decided_at: new Date().toISOString(),
+  }
+
+  const { error: updateError } = await supabaseAdmin
+    .from('agent_approvals')
+    .update({
+      status: input.status,
+      decided_at: decision.decided_at,
+      decision_notes: input.decisionNotes,
+      metadata: {
+        ...metadata,
+        slack_decision: decision,
+      },
+    })
+    .eq('id', row.id)
+    .eq('status', 'pending')
+
+  if (updateError) throw new Error(`Failed to update approval: ${updateError.message}`)
+
+  await supabaseAdmin.from('agent_run_events').insert({
+    run_id: row.run_id,
+    event_type: 'slack_approval_decided',
+    severity: input.status === 'rejected' ? 'warning' : 'info',
+    message: `${row.approval_type}: ${input.status} from Slack`,
+    metadata: {
+      approval_id: row.id,
+      approval_type: row.approval_type,
+      slack_user_id: input.slackUserId,
+      actor_label: input.actorLabel,
+      decision_notes: input.decisionNotes,
+    },
+    idempotency_key: input.idempotencyKey,
+  })
+
+  const workItemId = typeof metadata.work_item_id === 'string' ? metadata.work_item_id : null
+  if (workItemId) {
+    await supabaseAdmin
+      .from('agent_work_items')
+      .update({
+        status: input.status === 'approved' ? 'assigned' : 'blocked',
+        blocker_summary: input.status === 'approved' ? null : input.decisionNotes,
+        validation_summary:
+          input.status === 'approved'
+            ? 'Mobile Slack approval recorded. Continue with the next governed Agent Ops action.'
+            : input.decisionNotes,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', workItemId)
+  }
+
+  if (input.status === 'rejected') {
+    await supabaseAdmin
+      .from('agent_runs')
+      .update({
+        status: 'failed',
+        current_step: 'Approval rejected from Slack',
+        error_message: input.decisionNotes,
+        completed_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', row.run_id)
+  } else {
+    const { data: pending } = await supabaseAdmin
+      .from('agent_approvals')
+      .select('id')
+      .eq('run_id', row.run_id)
+      .eq('status', 'pending')
+      .limit(1)
+    if (!pending || pending.length === 0) {
+      await supabaseAdmin
+        .from('agent_runs')
+        .update({
+          status: 'running',
+          current_step: 'Approval granted from Slack',
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', row.run_id)
+        .eq('status', 'waiting_for_approval')
+    }
+  }
+
+  return `Approval ${input.status} from Slack. Trace: ${agentRunsUrl(row.run_id)}`
+}
+
+async function runIdForWorkItem(workItemId: string) {
+  const item = await getAgentWorkItem(workItemId)
+  return item?.active_run_id ?? item?.source_run_id ?? null
+}
+
+export async function handleSlackAgentAction(payload: SlackInteractivePayload): Promise<SlackAgentActionResult> {
+  const authorization = requireAuthorizedSlackUser(payload)
+  if (!authorization.ok) return { responseType: 'ephemeral', text: authorization.text }
+
+  const value = actionFromPayload(payload)
+  if (!value) {
+    return { responseType: 'ephemeral', text: 'Slack action rejected: missing or invalid action payload.' }
+  }
+
+  const key = idempotencyKey(payload, value)
+  if (await hasRecordedSlackAction(key)) {
+    return { responseType: 'ephemeral', text: 'Already handled this Slack action.' }
+  }
+
+  if (value.action === 'approval.approve' || value.action === 'approval.reject' || value.action === 'approval.revision') {
+    if (!value.approvalId) return { responseType: 'ephemeral', text: 'Missing approval id.' }
+    const status = value.action === 'approval.approve' ? 'approved' : 'rejected'
+    const text = await decideApprovalFromSlack({
+      approvalId: value.approvalId,
+      status,
+      actorLabel: authorization.actorLabel,
+      slackUserId: authorization.userId,
+      decisionNotes: value.note || (status === 'approved' ? 'Approved from Slack.' : 'Revision requested from Slack.'),
+      idempotencyKey: key,
+    })
+    return { responseType: 'ephemeral', text }
+  }
+
+  if (value.action === 'approval.ask_shaka') {
+    if (!value.approvalId) return { responseType: 'ephemeral', text: 'Missing approval id.' }
+    const result = await runChiefOfStaffChat({
+      message: 'Summarize this approval for a mobile decision. Include recommendation, risk, and what happens if I approve or reject.',
+      userId: `slack:${authorization.userId}`,
+      triggerSource: 'slack_agent_action',
+      contextRef: { type: 'approval', id: value.approvalId },
+    })
+    return { responseType: 'ephemeral', text: `${result.reply}\n\nTrace: ${agentRunsUrl(result.runId)}` }
+  }
+
+  if (value.action === 'work.assign') {
+    if (!value.workItemId || !value.agentKey) return { responseType: 'ephemeral', text: 'Missing work item or agent key.' }
+    const item = await claimAgentWorkItem({
+      id: value.workItemId,
+      ownerAgentKey: value.agentKey,
+      actorLabel: authorization.actorLabel,
+    })
+    await recordSlackActionEvent({
+      key,
+      runId: item.active_run_id,
+      eventType: 'slack_work_item_assigned',
+      message: `${authorization.actorLabel} assigned ${item.title} to ${value.agentKey} from Slack`,
+      metadata: { work_item_id: item.id, owner_agent_key: value.agentKey, slack_user_id: authorization.userId },
+    })
+    return { responseType: 'ephemeral', text: `Assigned to ${value.agentKey}. Kanban: ${baseUrl()}/admin/agents/swarm-board` }
+  }
+
+  if (value.action === 'work.handoff') {
+    if (!value.workItemId || !value.agentKey) return { responseType: 'ephemeral', text: 'Missing work item or agent key.' }
+    const result = await handoffAgentWorkItem({
+      id: value.workItemId,
+      toAgentKey: value.agentKey,
+      fromAgentKey: 'manual-admin',
+      summary: value.note || `${authorization.actorLabel} requested handoff from Slack.`,
+      acceptanceCriteria: 'Review the work packet, update status, and attach trace evidence before handoff completion.',
+      idempotencyKey: key,
+    })
+    await recordSlackActionEvent({
+      key,
+      runId: result.workItem.active_run_id,
+      eventType: 'slack_work_item_handed_off',
+      message: `${authorization.actorLabel} handed off ${result.workItem.title} to ${value.agentKey} from Slack`,
+      metadata: { work_item_id: result.workItem.id, handoff_id: result.handoffId, slack_user_id: authorization.userId },
+    })
+    return { responseType: 'ephemeral', text: `Handoff requested for ${value.agentKey}. Kanban: ${baseUrl()}/admin/agents/swarm-board` }
+  }
+
+  if (value.action === 'work.ready') {
+    if (!value.workItemId) return { responseType: 'ephemeral', text: 'Missing work item id.' }
+    const item = await markAgentWorkItemReadyForKanban({
+      id: value.workItemId,
+      definitionOfReady: value.note || 'Marked ready from Slack.',
+      actorLabel: authorization.actorLabel,
+    })
+    await recordSlackActionEvent({
+      key,
+      runId: item.active_run_id,
+      eventType: 'slack_work_item_ready',
+      message: `${authorization.actorLabel} marked ${item.title} ready from Slack`,
+      metadata: { work_item_id: item.id, slack_user_id: authorization.userId },
+    })
+    return { responseType: 'ephemeral', text: `Marked ready. Kanban: ${baseUrl()}/admin/agents/swarm-board` }
+  }
+
+  if (value.action === 'work.revision') {
+    if (!value.workItemId) return { responseType: 'ephemeral', text: 'Missing work item id.' }
+    const item = await recordAgentWorkItemBlocker({
+      id: value.workItemId,
+      blockerSummary: value.note || 'Revision requested from Slack.',
+    })
+    await recordSlackActionEvent({
+      key,
+      runId: item.active_run_id,
+      eventType: 'slack_work_item_revision_requested',
+      message: `${authorization.actorLabel} requested revision for ${item.title} from Slack`,
+      metadata: { work_item_id: item.id, slack_user_id: authorization.userId },
+    })
+    return { responseType: 'ephemeral', text: `Revision requested. Kanban: ${baseUrl()}/admin/agents/swarm-board` }
+  }
+
+  if (value.action === 'work.ask_shaka') {
+    if (!value.workItemId) return { responseType: 'ephemeral', text: 'Missing work item id.' }
+    const result = await runChiefOfStaffChat({
+      message: 'Summarize this work item for mobile unblock. Include owner, blocker, next action, and recommendation.',
+      userId: `slack:${authorization.userId}`,
+      triggerSource: 'slack_agent_action',
+      contextRef: { type: 'work_item', id: value.workItemId },
+    })
+    return { responseType: 'ephemeral', text: `${result.reply}\n\nTrace: ${agentRunsUrl(result.runId)}` }
+  }
+
+  if (value.action === 'inbox.route') {
+    const itemRef = value.workItemId
+    if (!itemRef) return { responseType: 'ephemeral', text: 'Missing inbox item reference.' }
+    const result = await routeAgentInboxItem({
+      itemRef,
+      actor: {
+        id: authorization.userId,
+        label: authorization.actorLabel,
+        type: 'slack_command',
+      },
+      triggerSource: 'slack_agent_inbox_action',
+    })
+    return {
+      responseType: 'ephemeral',
+      text: `Routed inbox item: ${result.item.title}. Trace: ${agentRunsUrl(result.runId)}`,
+    }
+  }
+
+  if (value.action === 'inbox.ask_shaka') {
+    const contextRef = value.runId
+      ? { type: 'run' as const, id: value.runId }
+      : undefined
+    const result = await runChiefOfStaffChat({
+      message: 'Explain what this inbox item needs and the fastest safe way to unblock it from mobile.',
+      userId: `slack:${authorization.userId}`,
+      triggerSource: 'slack_agent_action',
+      contextRef,
+    })
+    return { responseType: 'ephemeral', text: `${result.reply}\n\nTrace: ${agentRunsUrl(result.runId)}` }
+  }
+
+  if (value.workItemId) {
+    await recordSlackActionEvent({
+      key,
+      runId: await runIdForWorkItem(value.workItemId),
+      eventType: 'slack_work_item_action_rejected',
+      message: `Unsupported Slack action: ${value.action}`,
+      metadata: { work_item_id: value.workItemId, slack_user_id: authorization.userId },
+    })
+  }
+
+  return { responseType: 'ephemeral', text: 'Unsupported Agent Ops Slack action.' }
+}
+
+export const agentSlackActionInternals = {
+  allowedSlackUserIds,
+  idempotencyKey,
+  isSlackDecidableApproval,
+}

--- a/lib/agent-slack-blocks.ts
+++ b/lib/agent-slack-blocks.ts
@@ -1,0 +1,108 @@
+export type SlackTextObject = {
+  type: 'mrkdwn' | 'plain_text'
+  text: string
+  emoji?: boolean
+}
+
+export type SlackBlock =
+  | {
+      type: 'section'
+      text?: SlackTextObject
+      fields?: SlackTextObject[]
+      accessory?: SlackButtonElement
+    }
+  | {
+      type: 'context'
+      elements: SlackTextObject[]
+    }
+  | {
+      type: 'actions'
+      elements: SlackButtonElement[]
+    }
+  | {
+      type: 'divider'
+    }
+
+export type SlackButtonElement = {
+  type: 'button'
+  text: SlackTextObject
+  action_id: string
+  value?: string
+  url?: string
+  style?: 'primary' | 'danger'
+  confirm?: {
+    title: SlackTextObject
+    text: SlackTextObject
+    confirm: SlackTextObject
+    deny: SlackTextObject
+  }
+}
+
+export type SlackCommandResponsePayload = {
+  response_type: 'ephemeral' | 'in_channel'
+  text: string
+  blocks?: SlackBlock[]
+}
+
+export type SlackAgentActionValue = {
+  action: string
+  approvalId?: string
+  runId?: string
+  workItemId?: string
+  agentKey?: string
+  note?: string
+}
+
+export function mrkdwn(text: string): SlackTextObject {
+  return { type: 'mrkdwn', text: text.slice(0, 3000) }
+}
+
+export function plainText(text: string): SlackTextObject {
+  return { type: 'plain_text', text: text.slice(0, 75), emoji: true }
+}
+
+export function encodeSlackActionValue(value: SlackAgentActionValue) {
+  return JSON.stringify(value)
+}
+
+export function decodeSlackActionValue(value: string | undefined): SlackAgentActionValue | null {
+  if (!value) return null
+  try {
+    const parsed = JSON.parse(value) as SlackAgentActionValue
+    return parsed && typeof parsed.action === 'string' ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+export function slackButton(input: {
+  label: string
+  actionId: string
+  value?: SlackAgentActionValue
+  url?: string
+  style?: 'primary' | 'danger'
+  confirmText?: string
+}): SlackButtonElement {
+  return {
+    type: 'button',
+    text: plainText(input.label),
+    action_id: input.actionId,
+    value: input.value ? encodeSlackActionValue(input.value) : undefined,
+    url: input.url,
+    style: input.style,
+    confirm: input.confirmText
+      ? {
+          title: plainText('Confirm action'),
+          text: mrkdwn(input.confirmText),
+          confirm: plainText('Confirm'),
+          deny: plainText('Cancel'),
+        }
+      : undefined,
+  }
+}
+
+export function truncateSlack(text: string | null | undefined, length = 220) {
+  const value = (text ?? '').trim()
+  if (value.length <= length) return value
+  return `${value.slice(0, Math.max(0, length - 1)).trim()}…`
+}

--- a/lib/agent-slack-command.test.ts
+++ b/lib/agent-slack-command.test.ts
@@ -83,6 +83,7 @@ import {
   buildAgentInboxSlackText,
   createAgentEngagementSlackText,
   handoffAgentWorkItemSlackText,
+  handleAgentSlackCommand,
   routeAgentInboxSlackText,
   runWarRoomStandupSlackText,
 } from '@/lib/agent-slack-command'
@@ -425,6 +426,35 @@ describe('agent Slack command parsing', () => {
     expect(text).toContain('Coordinate feature')
     expect(text).toContain('PR 1')
     expect(text).toContain('/admin/agents/coordination')
+  })
+
+  it('returns actionable Block Kit controls for mobile work item commands', async () => {
+    workItemMocks.listAgentWorkItems.mockResolvedValue([
+      {
+        id: 'work-1',
+        title: 'Unblock mobile approval',
+        objective: 'Let Slack unblock the Kanban',
+        status: 'blocked',
+        priority: 'high',
+        owner_agent_key: null,
+        owner_runtime: 'codex',
+        branch_name: null,
+        pr_url: null,
+        pr_number: null,
+        approval_id: null,
+        active_run_id: 'run-1',
+        blocker_summary: 'Needs owner',
+      },
+    ])
+
+    const result = await handleAgentSlackCommand({ text: 'work' })
+
+    expect(result.text).toContain('Agent coordination work')
+    expect(result.blocks).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: 'actions' }),
+    ]))
+    expect(JSON.stringify(result.blocks)).toContain('work.assign')
+    expect(JSON.stringify(result.blocks)).toContain('Open trace')
   })
 
   it('formats one coordination work item for Slack', async () => {

--- a/lib/agent-slack-command.ts
+++ b/lib/agent-slack-command.ts
@@ -13,6 +13,12 @@ import {
   type AgentWorkItem,
 } from '@/lib/agent-work-items'
 import {
+  mrkdwn,
+  slackButton,
+  truncateSlack,
+  type SlackBlock,
+} from '@/lib/agent-slack-blocks'
+import {
   createMoremiWarningWorkItems,
   getLatestMoremiMonitorReview,
   MOREMI_WARNING_WORK_ITEMS_CONFIRMATION,
@@ -49,6 +55,7 @@ export type AgentSlackCommandInput = {
 export type AgentSlackCommandResult = {
   responseType: 'ephemeral'
   text: string
+  blocks?: SlackBlock[]
 }
 
 type CountQueryResult = {
@@ -73,6 +80,7 @@ type AgentApprovalRow = {
   approval_type: string
   status: string
   requested_at: string
+  metadata?: Record<string, unknown> | null
 }
 
 function baseUrl() {
@@ -90,6 +98,10 @@ function agentRunsUrl(runId?: string) {
 
 function agentCoordinationUrl() {
   return `${baseUrl()}/admin/agents/coordination`
+}
+
+function agentKanbanUrl() {
+  return `${baseUrl()}/admin/agents/swarm-board`
 }
 
 function since24h() {
@@ -160,6 +172,233 @@ function formatWorkItemLine(item: AgentWorkItem, index?: number) {
   return `${number}*${item.title}* [${item.status}/${owner}]${branch}${pr}${approval}\n   ${item.objective}`
 }
 
+function riskLabelForApproval(approvalType: string) {
+  if (approvalType === 'vercel_deployment_research_proposal') return 'low'
+  if (approvalType === 'n8n_workflow_activation') return 'high'
+  if (
+    approvalType.includes('payment') ||
+    approvalType.includes('production_config') ||
+    approvalType.includes('send_email') ||
+    approvalType.includes('publishing') ||
+    approvalType.includes('private_material') ||
+    approvalType.includes('merge')
+  ) {
+    return 'high'
+  }
+  return 'review'
+}
+
+function canDecideApprovalInSlack(approvalType: string) {
+  return approvalType === 'vercel_deployment_research_proposal'
+}
+
+function approvalBlocks(input: {
+  approvals: AgentApprovalRow[]
+  runsById: Map<string, AgentRunRow>
+}): SlackBlock[] {
+  if (!input.approvals.length) {
+    return [
+      {
+        type: 'section',
+        text: mrkdwn(`*Pending agent approvals*\nNo pending approvals need mobile action.`),
+      },
+      {
+        type: 'actions',
+        elements: [
+          slackButton({ label: 'Open Run Console', actionId: 'agent_open_runs', url: agentRunsUrl() }),
+        ],
+      },
+    ]
+  }
+
+  const blocks: SlackBlock[] = [
+    {
+      type: 'section',
+      text: mrkdwn('*Pending agent approvals*\nReview low-risk decisions here. High-risk changes deep-link back to Portfolio.'),
+    },
+  ]
+
+  input.approvals.slice(0, 5).forEach((approval) => {
+    const run = input.runsById.get(approval.run_id)
+    const title = run?.title ?? approval.run_id
+    const risk = riskLabelForApproval(approval.approval_type)
+    const safe = canDecideApprovalInSlack(approval.approval_type)
+    blocks.push({
+      type: 'section',
+      text: mrkdwn([
+        `*${truncateSlack(title, 120)}*`,
+        `Type: \`${approval.approval_type}\` · Risk: *${risk}*`,
+        run?.current_step ? `Step: ${truncateSlack(run.current_step, 140)}` : null,
+        safe
+          ? 'Slack can record this decision.'
+          : 'Portfolio review required before this action can change production-impacting state.',
+      ].filter(Boolean).join('\n')),
+    })
+    blocks.push({
+      type: 'actions',
+      elements: [
+        ...(safe ? [
+          slackButton({
+            label: 'Approve',
+            actionId: 'agent_approval_approve',
+            style: 'primary',
+            value: { action: 'approval.approve', approvalId: approval.id, runId: approval.run_id },
+            confirmText: `Approve ${title}?`,
+          }),
+          slackButton({
+            label: 'Decline',
+            actionId: 'agent_approval_decline',
+            style: 'danger',
+            value: {
+              action: 'approval.reject',
+              approvalId: approval.id,
+              runId: approval.run_id,
+              note: 'Declined from Slack.',
+            },
+            confirmText: `Decline ${title}?`,
+          }),
+          slackButton({
+            label: 'Request revision',
+            actionId: 'agent_approval_revision',
+            value: {
+              action: 'approval.revision',
+              approvalId: approval.id,
+              runId: approval.run_id,
+              note: 'Revision requested from Slack.',
+            },
+          }),
+        ] : []),
+        slackButton({
+          label: 'Ask Shaka',
+          actionId: 'agent_approval_ask_shaka',
+          value: { action: 'approval.ask_shaka', approvalId: approval.id, runId: approval.run_id },
+        }),
+        slackButton({ label: 'Open trace', actionId: 'agent_open_trace', url: agentRunsUrl(approval.run_id) }),
+      ].slice(0, 5),
+    })
+  })
+
+  return blocks
+}
+
+function workItemBlocks(input: {
+  title: string
+  items: AgentWorkItem[]
+  emptyText: string
+}): SlackBlock[] {
+  if (!input.items.length) {
+    return [
+      { type: 'section', text: mrkdwn(`*${input.title}*\n${input.emptyText}`) },
+      { type: 'actions', elements: [slackButton({ label: 'Open Kanban', actionId: 'agent_open_kanban', url: agentKanbanUrl() })] },
+    ]
+  }
+
+  const blocks: SlackBlock[] = [
+    { type: 'section', text: mrkdwn(`*${input.title}*\nUse these buttons for safe mobile routing. Merge, deploy, activation, outbound, and credential work stays in Portfolio.`) },
+  ]
+
+  input.items.slice(0, 5).forEach((item) => {
+    const owner = item.owner_agent_key ?? 'unassigned'
+    const blocker = item.blocker_summary ? `\nBlocker: ${truncateSlack(item.blocker_summary, 140)}` : ''
+    blocks.push({
+      type: 'section',
+      text: mrkdwn(`*${truncateSlack(item.title, 120)}*\nStatus: \`${item.status}\` · Owner: \`${owner}\` · Priority: \`${item.priority}\`${blocker}`),
+    })
+    blocks.push({
+      type: 'actions',
+      elements: [
+        ...(item.owner_agent_key ? [] : [
+          slackButton({
+            label: 'Assign captain',
+            actionId: 'agent_work_assign_captain',
+            value: { action: 'work.assign', workItemId: item.id, agentKey: 'integration-captain' },
+          }),
+        ]),
+        slackButton({
+          label: 'Handoff captain',
+          actionId: 'agent_work_handoff_captain',
+          value: { action: 'work.handoff', workItemId: item.id, agentKey: 'integration-captain' },
+        }),
+        slackButton({
+          label: 'Mark ready',
+          actionId: 'agent_work_ready',
+          value: {
+            action: 'work.ready',
+            workItemId: item.id,
+            note: 'Marked ready from Slack. Review trace and continue from Kanban.',
+          },
+        }),
+        slackButton({
+          label: 'Ask Shaka',
+          actionId: 'agent_work_ask_shaka',
+          value: { action: 'work.ask_shaka', workItemId: item.id, runId: item.active_run_id ?? undefined },
+        }),
+        slackButton({
+          label: item.active_run_id ? 'Open trace' : 'Open Kanban',
+          actionId: item.active_run_id ? 'agent_open_trace' : 'agent_open_kanban',
+          url: item.active_run_id ? agentRunsUrl(item.active_run_id) : agentKanbanUrl(),
+        }),
+      ].slice(0, 5),
+    })
+  })
+
+  return blocks
+}
+
+function inboxBlocks(items: Array<{
+  id?: string
+  priority: string
+  agent_name: string
+  title: string
+  reason: string
+  source_run_id?: string | null
+}>): SlackBlock[] {
+  if (!items.length) {
+    return [
+      { type: 'section', text: mrkdwn('*Agent Inbox*\nNo inbox items need mobile action.') },
+      { type: 'actions', elements: [slackButton({ label: 'Open Mission Control', actionId: 'agent_open_mission_control', url: `${baseUrl()}/admin/agents` })] },
+    ]
+  }
+
+  const blocks: SlackBlock[] = [
+    { type: 'section', text: mrkdwn('*Agent Inbox*\nRoute failures, stale runs, and attention items without waiting to get back to Mission Control.') },
+  ]
+
+  items.slice(0, 5).forEach((item, index) => {
+    blocks.push({
+      type: 'section',
+      text: mrkdwn(`*${item.priority.toUpperCase()}* ${truncateSlack(item.title, 120)}\n${truncateSlack(item.reason, 180)}\nAgent: ${item.agent_name}`),
+    })
+    blocks.push({
+      type: 'actions',
+      elements: [
+        slackButton({
+          label: 'Route',
+          actionId: 'agent_inbox_route',
+          value: { action: 'inbox.route', workItemId: String(index + 1) },
+          style: 'primary',
+        }),
+        slackButton({
+          label: 'Ask Shaka',
+          actionId: 'agent_inbox_ask_shaka',
+          value: {
+            action: 'inbox.ask_shaka',
+            workItemId: item.id ?? String(index + 1),
+            runId: item.source_run_id ?? undefined,
+          },
+        }),
+        slackButton({
+          label: item.source_run_id ? 'Open trace' : 'Open Mission Control',
+          actionId: item.source_run_id ? 'agent_open_trace' : 'agent_open_mission_control',
+          url: item.source_run_id ? agentRunsUrl(item.source_run_id) : `${baseUrl()}/admin/agents`,
+        }),
+      ],
+    })
+  })
+
+  return blocks
+}
+
 export async function buildAgentWorkItemsSlackText(input: AgentSlackCommandInput) {
   const [itemId] = commandArgs(input.text)
   try {
@@ -184,6 +423,41 @@ export async function buildAgentWorkItemsSlackText(input: AgentSlackCommandInput
     return ['*Agent coordination work*', ...items.map(formatWorkItemLine), `Review: ${agentCoordinationUrl()}`].join('\n')
   } catch (error) {
     return `Agent work lookup failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+  }
+}
+
+export async function buildAgentWorkItemsSlackResult(input: AgentSlackCommandInput): Promise<AgentSlackCommandResult> {
+  const text = await buildAgentWorkItemsSlackText(input)
+  const [itemId] = commandArgs(input.text)
+  try {
+    if (itemId) {
+      const item = await getAgentWorkItem(itemId)
+      return {
+        responseType: 'ephemeral',
+        text,
+        blocks: item
+          ? workItemBlocks({
+              title: 'Agent work item',
+              items: [item],
+              emptyText: `Work item not found: ${itemId}`,
+            })
+          : undefined,
+      }
+    }
+    const items = (await listAgentWorkItems({ limit: 8 }))
+      .filter((item) => !['merged', 'deployed', 'cancelled'].includes(item.status))
+      .slice(0, 5)
+    return {
+      responseType: 'ephemeral',
+      text,
+      blocks: workItemBlocks({
+        title: 'Agent coordination work',
+        items,
+        emptyText: 'No active coordination work needs mobile action.',
+      }),
+    }
+  } catch {
+    return { responseType: 'ephemeral', text }
   }
 }
 
@@ -238,6 +512,24 @@ export async function buildAgentBlockersSlackText() {
     return ['*Blocked agent coordination work*', ...items.map(formatWorkItemLine), `Review: ${agentCoordinationUrl()}`].join('\n')
   } catch (error) {
     return `Agent blocker lookup failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+  }
+}
+
+export async function buildAgentBlockersSlackResult(): Promise<AgentSlackCommandResult> {
+  const text = await buildAgentBlockersSlackText()
+  try {
+    const items = await listAgentWorkItems({ status: 'blocked', limit: 5 })
+    return {
+      responseType: 'ephemeral',
+      text,
+      blocks: workItemBlocks({
+        title: 'Blocked agent coordination work',
+        items,
+        emptyText: 'No blocked coordination work needs mobile action.',
+      }),
+    }
+  } catch {
+    return { responseType: 'ephemeral', text }
   }
 }
 
@@ -317,6 +609,20 @@ export async function buildAgentInboxSlackText(limit = 5) {
     ].join('\n')
   } catch (error) {
     return `Agent Inbox lookup failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+  }
+}
+
+export async function buildAgentInboxSlackResult(limit = 5): Promise<AgentSlackCommandResult> {
+  const text = await buildAgentInboxSlackText(limit)
+  try {
+    const snapshot = await buildAgentMissionControlSnapshot()
+    return {
+      responseType: 'ephemeral',
+      text,
+      blocks: inboxBlocks(snapshot.agent_inbox.slice(0, limit)),
+    }
+  } catch {
+    return { responseType: 'ephemeral', text }
   }
 }
 
@@ -536,7 +842,7 @@ export async function buildApprovalsSlackText(limit = 5) {
 
   const { data: approvals, error } = await supabaseAdmin
     .from('agent_approvals')
-    .select('id, run_id, approval_type, status, requested_at')
+    .select('id, run_id, approval_type, status, requested_at, metadata')
     .eq('status', 'pending')
     .order('requested_at', { ascending: false })
     .limit(limit)
@@ -564,6 +870,41 @@ export async function buildApprovalsSlackText(limit = 5) {
   })
 
   return ['*Pending agent approvals*', ...lines].join('\n')
+}
+
+export async function buildApprovalsSlackResult(limit = 5): Promise<AgentSlackCommandResult> {
+  const text = await buildApprovalsSlackText(limit)
+  if (!supabaseAdmin) return { responseType: 'ephemeral', text }
+
+  try {
+    const { data: approvals, error } = await supabaseAdmin
+      .from('agent_approvals')
+      .select('id, run_id, approval_type, status, requested_at, metadata')
+      .eq('status', 'pending')
+      .order('requested_at', { ascending: false })
+      .limit(limit)
+    if (error) return { responseType: 'ephemeral', text }
+
+    const pending = (approvals || []) as AgentApprovalRow[]
+    const runIds = pending.map((approval) => approval.run_id)
+    const { data: runs } = runIds.length
+      ? await supabaseAdmin
+          .from('agent_runs')
+          .select('id, title, runtime, status, subject_label, current_step, error_message, started_at')
+          .in('id', runIds)
+      : { data: [] }
+    const typedRuns = (runs || []) as AgentRunRow[]
+    return {
+      responseType: 'ephemeral',
+      text,
+      blocks: approvalBlocks({
+        approvals: pending,
+        runsById: new Map(typedRuns.map((run) => [run.id, run])),
+      }),
+    }
+  } catch {
+    return { responseType: 'ephemeral', text }
+  }
 }
 
 export async function runMorningReviewSlackText(input: AgentSlackCommandInput) {
@@ -711,46 +1052,43 @@ export async function runWarRoomDiscussSlackText(input: AgentSlackCommandInput) 
 
 export async function handleAgentSlackCommand(input: AgentSlackCommandInput): Promise<AgentSlackCommandResult> {
   const command = commandFromText(input.text)
+  if (command === 'approvals') return buildApprovalsSlackResult()
+  if (command === 'work-items') return buildAgentWorkItemsSlackResult(input)
+  if (command === 'blockers') return buildAgentBlockersSlackResult()
+  if (command === 'inbox') return buildAgentInboxSlackResult()
+
   const text =
     command === 'status'
       ? await buildAgentStatusSlackText()
       : command === 'failed'
         ? await buildFailedRunsSlackText()
-        : command === 'approvals'
-          ? await buildApprovalsSlackText()
-          : command === 'morning-review'
-            ? await runMorningReviewSlackText(input)
-            : command === 'risk'
-              ? await buildAgentRiskMonitorSlackText(input)
-              : command === 'agents'
-                ? formatAgentListSlackText()
-                : command === 'engagements'
-                  ? await buildAgentEngagementQueueSlackText()
-                  : command === 'work-items'
-                    ? await buildAgentWorkItemsSlackText(input)
-                    : command === 'claim'
-                      ? await claimAgentWorkItemSlackText(input)
-                      : command === 'handoff'
-                        ? await handoffAgentWorkItemSlackText(input)
-                        : command === 'blockers'
-                          ? await buildAgentBlockersSlackText()
-                          : command === 'prs'
-                            ? await buildAgentPrsSlackText()
-                            : command === 'captain'
-                              ? await buildCaptainQueueSlackText()
-                              : command === 'inbox'
-                                ? await buildAgentInboxSlackText()
-                                : command === 'brief'
-                                  ? await buildAgentBriefSlackText()
-                                  : command === 'route'
-                                    ? await routeAgentInboxSlackText(input)
-                                    : command === 'run'
-                                      ? await createAgentEngagementSlackText(input)
-                                      : command === 'standup'
-                                        ? await runWarRoomStandupSlackText(input)
-                                        : command === 'discuss'
-                                          ? await runWarRoomDiscussSlackText(input)
-                                          : formatHelp()
+        : command === 'morning-review'
+          ? await runMorningReviewSlackText(input)
+          : command === 'risk'
+            ? await buildAgentRiskMonitorSlackText(input)
+            : command === 'agents'
+              ? formatAgentListSlackText()
+              : command === 'engagements'
+                ? await buildAgentEngagementQueueSlackText()
+                : command === 'claim'
+                  ? await claimAgentWorkItemSlackText(input)
+                  : command === 'handoff'
+                    ? await handoffAgentWorkItemSlackText(input)
+                    : command === 'prs'
+                      ? await buildAgentPrsSlackText()
+                      : command === 'captain'
+                        ? await buildCaptainQueueSlackText()
+                        : command === 'brief'
+                          ? await buildAgentBriefSlackText()
+                          : command === 'route'
+                            ? await routeAgentInboxSlackText(input)
+                            : command === 'run'
+                              ? await createAgentEngagementSlackText(input)
+                              : command === 'standup'
+                                ? await runWarRoomStandupSlackText(input)
+                                : command === 'discuss'
+                                  ? await runWarRoomDiscussSlackText(input)
+                                  : formatHelp()
 
   return { responseType: 'ephemeral', text }
 }


### PR DESCRIPTION
## Summary
- Upgrade `/agent approvals`, `/agent work`, `/agent blockers`, and `/agent inbox` to return Slack Block Kit cards with text fallbacks.
- Add `POST /api/slack/agent/actions` for signed Slack interactivity payloads, operator allowlisting, retry/idempotency handling, approval decisions, work-item assignment/handoff/ready actions, inbox routing, and Shaka context asks.
- Document Slack mobile-unblock setup and governance boundaries in `docs/agent-ops-slack-mobile-unblock.md`.

## Validation
- `npm test -- lib/agent-slack-command.test.ts lib/agent-slack-actions.test.ts app/api/slack/agent/route.test.ts app/api/slack/agent/actions/route.test.ts app/api/slack/agent/events/route.test.ts lib/agent-slack-events.test.ts`
- `npx tsc --noEmit --pretty false`
- `npm run lint -- --file app/api/slack/agent/route.ts --file app/api/slack/agent/actions/route.ts --file lib/agent-slack-command.ts --file lib/agent-slack-actions.ts --file lib/agent-slack-blocks.ts`
- `npm run lint`
- `npm run build`
- Pre-push `npm run db:health-check` passed.

## Integration Notes
- Slack app interactivity request URL must point to `/api/slack/agent/actions`.
- Required env/config before live Slack smoke: `SLACK_SIGNING_SECRET` and `SLACK_AGENT_OPS_ALLOWED_USER_IDS` in non-local environments. Existing slash command URL remains `/api/slack/agent`; event subscription remains `/api/slack/agent/events`.
- High-risk actions still deep-link to Portfolio; Slack does not activate n8n, change credentials, send outbound messages, publish, mutate customer data, or trigger payments.
- Build emitted the existing local warning that `MOCK_N8N=false` and `N8N_DISABLE_OUTBOUND=false`; no live n8n or outbound workflow was run.
- Vercel contexts checked before merge: not run from this feature lane. Integration captain should verify `Vercel – portfolio` and `Vercel – portfolio-staging` after merge.