### PR TITLE
feat: add Slack mobile notification bridge

### DIFF
--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -423,6 +423,7 @@ type AutomationGoalSummary = {
 }
 
 type OperatorActionKind = 'morning-review' | 'hermes' | 'approval-drill' | 'runtime-evaluation'
+type SlackNotificationKind = 'pending_approvals' | 'blockers' | 'review_ready' | 'goal_decisions'
 
 const OPERATOR_ACTIONS: Array<{
   kind: OperatorActionKind
@@ -495,6 +496,8 @@ export default function AgentOperationsPage() {
   const [automationSeedLoading, setAutomationSeedLoading] = useState(false)
   const [automationProposalLoadingId, setAutomationProposalLoadingId] = useState<string | null>(null)
   const [automationGoalPage, setAutomationGoalPage] = useState(0)
+  const [slackNotificationLoading, setSlackNotificationLoading] = useState<SlackNotificationKind | null>(null)
+  const [slackNotificationResult, setSlackNotificationResult] = useState<{ text: string; runId?: string } | null>(null)
 
   const authedFetch = useCallback(async (path: string, init: RequestInit = {}) => {
     const session = await getCurrentSession()
@@ -675,6 +678,33 @@ export default function AgentOperationsPage() {
       setError(err instanceof Error ? err.message : `${kind} failed`)
     } finally {
       setActionLoading(null)
+    }
+  }
+
+  async function sendSlackNotification(kind: SlackNotificationKind) {
+    setSlackNotificationLoading(kind)
+    setSlackNotificationResult(null)
+    setError(null)
+    try {
+      const response = await authedFetch('/api/admin/agents/slack-notifications', {
+        method: 'POST',
+        body: JSON.stringify({ kind }),
+      })
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`)
+      const prefix = body.sent
+        ? 'Sent to Slack'
+        : body.deduped
+          ? 'Already sent recently'
+          : 'Slack not sent'
+      setSlackNotificationResult({
+        text: `${prefix}: ${body.text || body.reason || kind.replace(/_/g, ' ')}`,
+        runId: body.runId,
+      })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Slack notification failed')
+    } finally {
+      setSlackNotificationLoading(null)
     }
   }
 
@@ -1120,6 +1150,11 @@ export default function AgentOperationsPage() {
                       <p className="font-semibold">Open Run Console</p>
                       <p className="mt-1 text-sm text-muted-foreground">Inspect traces, evaluations, dead letters, and artifacts.</p>
                     </Link>
+                    <SlackMobileBridgePanel
+                      loadingKind={slackNotificationLoading}
+                      result={slackNotificationResult}
+                      onSend={sendSlackNotification}
+                    />
                     <OperatorChecksPanel
                       actions={OPERATOR_ACTIONS}
                       loadingKind={actionLoading as OperatorActionKind | null}
@@ -1437,6 +1472,55 @@ function OperatorChecksPanel({
           )
         })}
       </div>
+    </div>
+  )
+}
+
+function SlackMobileBridgePanel({
+  loadingKind,
+  result,
+  onSend,
+}: {
+  loadingKind: SlackNotificationKind | null
+  result: { text: string; runId?: string } | null
+  onSend: (kind: SlackNotificationKind) => void
+}) {
+  const actions: Array<{ kind: SlackNotificationKind; label: string; description: string }> = [
+    { kind: 'pending_approvals', label: 'Send approvals', description: 'Mobile approval cards and trace links.' },
+    { kind: 'blockers', label: 'Send blockers', description: 'Blocked work with owner and next step context.' },
+    { kind: 'goal_decisions', label: 'Send goal decisions', description: 'Goal-tagged tasks waiting on a human call.' },
+  ]
+
+  return (
+    <div className="rounded-lg border border-silicon-slate/60 bg-background/40 p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wider text-radiant-gold">Slack mobile bridge</p>
+          <p className="mt-1 text-sm text-muted-foreground">Push the current unblock packet to Slack without leaving Mission Control.</p>
+        </div>
+        <Send size={16} className="mt-1 text-radiant-gold" aria-hidden="true" />
+      </div>
+      <div className="mt-3 grid gap-2">
+        {actions.map((action) => (
+          <button
+            key={action.kind}
+            type="button"
+            onClick={() => onSend(action.kind)}
+            disabled={loadingKind != null}
+            className="rounded-lg border border-silicon-slate/60 bg-black/10 p-2 text-left transition hover:border-radiant-gold/50 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <span className="block text-sm font-semibold">
+              {loadingKind === action.kind ? 'Sending...' : action.label}
+            </span>
+            <span className="mt-0.5 block text-xs text-muted-foreground">{action.description}</span>
+          </button>
+        ))}
+      </div>
+      {result ? (
+        <Link href={result.runId ? `/admin/agents/runs/${result.runId}` : '/admin/agents/runs'} className="mt-3 block rounded-lg border border-emerald-400/30 bg-emerald-500/10 p-2 text-xs text-emerald-100 hover:underline">
+          {result.text}
+        </Link>
+      ) : null}
     </div>
   )
 }

--- a/app/admin/agents/standup/page.tsx
+++ b/app/admin/agents/standup/page.tsx
@@ -136,6 +136,7 @@ function StandupRoomContent() {
     },
   ])
   const [busy, setBusy] = useState<string | null>(null)
+  const [slackNotice, setSlackNotice] = useState<{ text: string; runId?: string } | null>(null)
 
   const fetchBoard = useCallback(async () => {
     setLoading(true)
@@ -429,6 +430,48 @@ function StandupRoomContent() {
     }
   }
 
+  async function sendStandupToSlack(kind: 'standup_blockers' | 'selected_agent_question') {
+    if (kind === 'selected_agent_question' && !message.trim()) {
+      setError('Add a question before sending selected agents to Slack.')
+      return
+    }
+    setBusy(`slack-${kind}`)
+    setSlackNotice(null)
+    setError(null)
+    try {
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Missing admin session')
+      const response = await fetch('/api/admin/agents/slack-notifications', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${session.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          kind,
+          message: kind === 'selected_agent_question' ? message.trim() : undefined,
+          target_agent_keys: selectedAgents.map((agent) => agent.key),
+          goal_id: focusedGoalId,
+        }),
+      })
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`)
+      const prefix = body.sent
+        ? 'Sent to Slack'
+        : body.deduped
+          ? 'Already sent recently'
+          : 'Slack not sent'
+      setSlackNotice({
+        text: `${prefix}: ${body.text || body.reason || 'Standup packet'}`,
+        runId: body.runId,
+      })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to send Standup Room packet to Slack')
+    } finally {
+      setBusy(null)
+    }
+  }
+
   function updateGoalTask(taskId: string, patch: Partial<AgentGoalDraft['tasks'][number]>) {
     setGoalDraft((current) => {
       if (!current) return current
@@ -515,6 +558,9 @@ function StandupRoomContent() {
                 latestTrace={commandTraces[0] ?? null}
                 busy={busy}
                 onStartStandup={startStandup}
+                onSendBlockersToSlack={() => sendStandupToSlack('standup_blockers')}
+                onSendQuestionToSlack={() => sendStandupToSlack('selected_agent_question')}
+                slackNotice={slackNotice}
               />
               <ChatRoom
                 transcript={transcript}
@@ -641,12 +687,18 @@ function StandupControlPanel({
   latestTrace,
   busy,
   onStartStandup,
+  onSendBlockersToSlack,
+  onSendQuestionToSlack,
+  slackNotice,
 }: {
   selectedAgents: AgentOrgBoardAgent[]
   focusedGoal: AgentOrgBoardGoalMetric | null
   latestTrace: WarRoomCommandTrace | null
   busy: string | null
   onStartStandup: () => void
+  onSendBlockersToSlack: () => void
+  onSendQuestionToSlack: () => void
+  slackNotice: { text: string; runId?: string } | null
 }) {
   const hasSelection = selectedAgents.length > 0
   return (
@@ -689,6 +741,42 @@ function StandupControlPanel({
           title="Output"
           value={latestTrace ? `Latest trace is ready: ${latestTrace.synthesis ?? latestTrace.command}.` : 'The next run will appear in Trace History and link back to this room.'}
         />
+      </div>
+
+      <div className="mt-4 rounded-lg border border-silicon-slate/60 bg-background/40 p-3">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wider text-radiant-gold">Slack handoff</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Send the current standup context to Slack for mobile follow-up. State changes still route through Portfolio controls.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={onSendBlockersToSlack}
+              disabled={busy != null}
+              className="agent-ops-button-secondary disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <Send size={16} />
+              {busy === 'slack-standup_blockers' ? 'Sending...' : 'Send blockers'}
+            </button>
+            <button
+              type="button"
+              onClick={onSendQuestionToSlack}
+              disabled={busy != null || !hasSelection}
+              className="agent-ops-button-muted disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <Send size={16} />
+              {busy === 'slack-selected_agent_question' ? 'Sending...' : 'Send selected question'}
+            </button>
+          </div>
+        </div>
+        {slackNotice ? (
+          <Link href={slackNotice.runId ? `/admin/agents/runs/${slackNotice.runId}` : '/admin/agents/runs'} className="mt-3 block rounded-lg border border-emerald-400/30 bg-emerald-500/10 p-2 text-sm text-emerald-100 hover:underline">
+            {slackNotice.text}
+          </Link>
+        ) : null}
       </div>
     </section>
   )

--- a/app/api/admin/agents/slack-notifications/route.test.ts
+++ b/app/api/admin/agents/slack-notifications/route.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  sendAgentSlackNotification: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-slack-notifications', () => ({
+  sendAgentSlackNotification: mocks.sendAgentSlackNotification,
+}))
+
+import { POST } from './route'
+
+function request(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/admin/agents/slack-notifications', {
+    method: 'POST',
+    headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/admin/agents/slack-notifications', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user', email: 'admin@example.com' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.sendAgentSlackNotification.mockResolvedValue({
+      ok: true,
+      runId: 'run-1',
+      sent: true,
+      skipped: false,
+      deduped: false,
+      itemCount: 2,
+      text: 'Sent packet',
+    })
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(request({ kind: 'blockers' }) as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.sendAgentSlackNotification).not.toHaveBeenCalled()
+  })
+
+  it('rejects unknown notification kinds', async () => {
+    const response = await POST(request({ kind: 'publish_everything' }) as never)
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'Invalid Slack notification kind' })
+  })
+
+  it('requires a message for selected-agent question packets', async () => {
+    const response = await POST(request({ kind: 'selected_agent_question' }) as never)
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'message is required for selected_agent_question' })
+  })
+
+  it('sends a governed Slack mobile packet', async () => {
+    const response = await POST(request({
+      kind: 'selected_agent_question',
+      message: 'What is blocked?',
+      target_agent_keys: ['chief-of-staff'],
+      goal_id: 'goal-1',
+    }) as never)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({ ok: true, runId: 'run-1', sent: true })
+    expect(mocks.sendAgentSlackNotification).toHaveBeenCalledWith(expect.objectContaining({
+      kind: 'selected_agent_question',
+      message: 'What is blocked?',
+      targetAgentKeys: ['chief-of-staff'],
+      goalId: 'goal-1',
+      actorLabel: 'admin@example.com',
+      triggerSource: 'admin_agent_slack_notification',
+    }))
+  })
+})

--- a/app/api/admin/agents/slack-notifications/route.ts
+++ b/app/api/admin/agents/slack-notifications/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import {
+  sendAgentSlackNotification,
+  type AgentSlackNotificationKind,
+} from '@/lib/agent-slack-notifications'
+
+export const dynamic = 'force-dynamic'
+
+const VALID_KINDS = new Set<AgentSlackNotificationKind>([
+  'pending_approvals',
+  'blockers',
+  'review_ready',
+  'goal_decisions',
+  'standup_blockers',
+  'selected_agent_question',
+])
+
+function parseKind(value: unknown): AgentSlackNotificationKind | null {
+  return typeof value === 'string' && VALID_KINDS.has(value as AgentSlackNotificationKind)
+    ? value as AgentSlackNotificationKind
+    : null
+}
+
+function parseStringArray(value: unknown) {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string').map((item) => item.trim()).filter(Boolean)
+    : []
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const kind = parseKind(body.kind)
+  if (!kind) {
+    return NextResponse.json({ error: 'Invalid Slack notification kind' }, { status: 400 })
+  }
+
+  if (kind === 'selected_agent_question' && typeof body.message !== 'string') {
+    return NextResponse.json({ error: 'message is required for selected_agent_question' }, { status: 400 })
+  }
+
+  try {
+    const result = await sendAgentSlackNotification({
+      kind,
+      message: typeof body.message === 'string' ? body.message : '',
+      targetAgentKeys: parseStringArray(body.target_agent_keys ?? body.targetAgentKeys),
+      goalId: typeof body.goal_id === 'string'
+        ? body.goal_id
+        : typeof body.goalId === 'string'
+          ? body.goalId
+          : null,
+      force: body.force === true,
+      actorLabel: auth.user.email ?? auth.user.id,
+      triggerSource: 'admin_agent_slack_notification',
+    })
+    return NextResponse.json(result)
+  } catch (error) {
+    console.error('[agent-slack-notifications] failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Slack notification failed' },
+      { status: 500 },
+    )
+  }
+}

--- a/docs/agent-ops-slack-mobile-unblock.md
+++ b/docs/agent-ops-slack-mobile-unblock.md
@@ -30,3 +30,18 @@ Slack can show Agent Ops cards for approvals, work items, blockers, and inbox en
 Slack must not directly perform production workflow activation, credential changes, outbound sends, customer-data mutation, publishing, payments, or n8n workflow activation. Those actions deep-link back to Portfolio for review.
 
 Every accepted Slack action should write an Agent Ops event so Mission Control, Run Console, and Kanban can reflect the mobile decision trail.
+
+## Mobile Notification Bridge
+
+Portfolio can also push a compact unblock packet into Slack from Mission Control or the Standup Room through `POST /api/admin/agents/slack-notifications`.
+
+Supported packet kinds:
+
+- `pending_approvals`
+- `blockers`
+- `review_ready`
+- `goal_decisions`
+- `standup_blockers`
+- `selected_agent_question`
+
+The route requires admin authentication, builds Block Kit payloads with Portfolio deep links, posts through `SLACK_AGENT_OPS_WEBHOOK_URL`, and records a `slack_mobile_notification` run. Packets are deduped within an hourly window by kind, goal, and selected agents unless an explicit force flag is sent.

--- a/lib/agent-slack-notifications.test.ts
+++ b/lib/agent-slack-notifications.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  from: vi.fn(),
+  listAgentWorkItems: vi.fn(),
+  startAgentRun: vi.fn(),
+  recordAgentEvent: vi.fn(),
+  endAgentRun: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: { from: mocks.from },
+}))
+
+vi.mock('@/lib/agent-work-items', () => ({
+  listAgentWorkItems: mocks.listAgentWorkItems,
+}))
+
+vi.mock('@/lib/agent-run', () => ({
+  startAgentRun: mocks.startAgentRun,
+  recordAgentEvent: mocks.recordAgentEvent,
+  endAgentRun: mocks.endAgentRun,
+}))
+
+import { sendAgentSlackNotification } from '@/lib/agent-slack-notifications'
+
+const ORIGINAL_ENV = process.env
+
+function queryResult(result: unknown) {
+  const query: Record<string, unknown> = {
+    select: vi.fn(() => query),
+    eq: vi.fn(() => query),
+    maybeSingle: vi.fn(() => Promise.resolve(result)),
+  }
+  return query
+}
+
+describe('Agent Ops Slack notifications', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env = { ...ORIGINAL_ENV }
+    mocks.from.mockReturnValue(queryResult({ data: null, error: null }))
+    mocks.startAgentRun.mockResolvedValue({ id: 'run-1' })
+    mocks.recordAgentEvent.mockResolvedValue({ id: 'event-1' })
+    mocks.endAgentRun.mockResolvedValue(undefined)
+    mocks.listAgentWorkItems.mockResolvedValue([
+      {
+        id: 'work-1',
+        title: 'Blocked staging approval',
+        objective: 'Resolve the blocker',
+        status: 'blocked',
+        priority: 'high',
+        owner_agent_key: null,
+        active_run_id: 'trace-1',
+        source_run_id: null,
+        blocker_summary: 'Needs owner decision',
+        validation_summary: 'Assign owner',
+        metadata: {},
+        updated_at: '2026-05-23T10:00:00.000Z',
+      },
+    ])
+  })
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV
+    vi.unstubAllGlobals()
+  })
+
+  it('builds a trace and skips delivery when the Slack webhook is not configured', async () => {
+    const result = await sendAgentSlackNotification({ kind: 'blockers', actorLabel: 'admin' })
+
+    expect(result).toMatchObject({
+      ok: true,
+      sent: false,
+      skipped: true,
+      deduped: false,
+      itemCount: 1,
+    })
+    expect(mocks.startAgentRun).toHaveBeenCalledWith(expect.objectContaining({
+      kind: 'slack_mobile_notification',
+      metadata: expect.objectContaining({ notification_kind: 'blockers', item_count: 1 }),
+    }))
+    expect(mocks.recordAgentEvent).toHaveBeenCalledWith(expect.objectContaining({
+      eventType: 'slack_mobile_notification_skipped',
+    }))
+  })
+
+  it('dedupes repeated mobile notification packets in the same window', async () => {
+    mocks.from.mockReturnValueOnce(queryResult({
+      data: {
+        id: 'existing-run',
+        status: 'completed',
+        metadata: { item_count: 2, text: 'Existing Slack packet' },
+      },
+      error: null,
+    }))
+
+    const result = await sendAgentSlackNotification({ kind: 'goal_decisions' })
+
+    expect(result).toMatchObject({
+      runId: 'existing-run',
+      skipped: true,
+      deduped: true,
+      itemCount: 2,
+      text: 'Existing Slack packet',
+    })
+    expect(mocks.listAgentWorkItems).not.toHaveBeenCalled()
+    expect(mocks.startAgentRun).not.toHaveBeenCalled()
+  })
+
+  it('posts Block Kit payloads when the Slack webhook is configured', async () => {
+    process.env.SLACK_AGENT_OPS_WEBHOOK_URL = 'https://hooks.slack.test/agent'
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await sendAgentSlackNotification({ kind: 'standup_blockers', targetAgentKeys: [] })
+
+    expect(result.sent).toBe(true)
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://hooks.slack.test/agent',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining("Today's standup blockers"),
+      }),
+    )
+    expect(mocks.endAgentRun).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'completed',
+    }))
+  })
+})

--- a/lib/agent-slack-notifications.ts
+++ b/lib/agent-slack-notifications.ts
@@ -1,0 +1,338 @@
+import { endAgentRun, recordAgentEvent, startAgentRun } from '@/lib/agent-run'
+import { listAgentWorkItems, type AgentWorkItem } from '@/lib/agent-work-items'
+import { mrkdwn, slackButton, truncateSlack, type SlackBlock } from '@/lib/agent-slack-blocks'
+import { supabaseAdmin } from '@/lib/supabase'
+
+export type AgentSlackNotificationKind =
+  | 'pending_approvals'
+  | 'blockers'
+  | 'review_ready'
+  | 'goal_decisions'
+  | 'standup_blockers'
+  | 'selected_agent_question'
+
+export type AgentSlackNotificationInput = {
+  kind: AgentSlackNotificationKind
+  message?: string
+  targetAgentKeys?: string[]
+  goalId?: string | null
+  force?: boolean
+  actorLabel?: string | null
+  triggerSource?: string | null
+}
+
+export type AgentSlackNotificationResult = {
+  ok: boolean
+  runId: string
+  sent: boolean
+  skipped: boolean
+  deduped: boolean
+  reason?: string
+  itemCount: number
+  text: string
+}
+
+type PendingApprovalRow = {
+  id: string
+  run_id: string
+  approval_type: string
+  status: string
+  metadata: Record<string, unknown> | null
+}
+
+type AgentRunSummaryRow = {
+  id: string
+  title: string | null
+  current_step: string | null
+  status: string | null
+}
+
+function baseUrl() {
+  return (
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    process.env.PORTFOLIO_BASE_URL ||
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    'https://amadutown.com'
+  ).replace(/\/$/, '')
+}
+
+function agentUrl(path: string) {
+  return `${baseUrl()}${path}`
+}
+
+function dedupeWindowKey() {
+  const now = new Date()
+  return now.toISOString().slice(0, 13)
+}
+
+function normalizeTargetAgentKeys(keys?: string[]) {
+  return [...new Set((keys ?? []).map((key) => key.trim()).filter(Boolean))].sort()
+}
+
+function notificationIdempotencyKey(input: AgentSlackNotificationInput) {
+  const targetKey = normalizeTargetAgentKeys(input.targetAgentKeys).join(',') || 'all'
+  const goalKey = input.goalId || 'no-goal'
+  return `slack-mobile-notification:${input.kind}:${goalKey}:${targetKey}:${dedupeWindowKey()}`
+}
+
+async function existingNotificationRun(idempotencyKey: string) {
+  if (!supabaseAdmin) return null
+  const { data, error } = await supabaseAdmin
+    .from('agent_runs')
+    .select('id, status, metadata')
+    .eq('idempotency_key', idempotencyKey)
+    .maybeSingle()
+  if (error) return null
+  return data as { id: string; status?: string | null; metadata?: Record<string, unknown> | null } | null
+}
+
+async function pendingApprovals(limit = 5) {
+  if (!supabaseAdmin) throw new Error('Database not available')
+  const { data, error } = await supabaseAdmin
+    .from('agent_approvals')
+    .select('id, run_id, approval_type, status, metadata')
+    .eq('status', 'pending')
+    .order('requested_at', { ascending: true })
+    .limit(limit)
+  if (error) throw new Error(`Failed to read pending approvals: ${error.message}`)
+  return (data ?? []) as PendingApprovalRow[]
+}
+
+async function runsById(runIds: string[]) {
+  if (!supabaseAdmin || !runIds.length) return new Map<string, AgentRunSummaryRow>()
+  const { data } = await supabaseAdmin
+    .from('agent_runs')
+    .select('id, title, current_step, status')
+    .in('id', runIds)
+  const rows = (data ?? []) as AgentRunSummaryRow[]
+  return new Map(rows.map((row) => [row.id, row]))
+}
+
+function workItemHref(item: AgentWorkItem) {
+  if (item.active_run_id) return agentUrl(`/admin/agents/runs/${item.active_run_id}`)
+  if (item.source_run_id) return agentUrl(`/admin/agents/runs/${item.source_run_id}`)
+  return agentUrl(`/admin/agents/swarm-board?work_item=${encodeURIComponent(item.id)}`)
+}
+
+function prioritySort(left: AgentWorkItem, right: AgentWorkItem) {
+  const weight = { urgent: 4, high: 3, medium: 2, low: 1 }
+  return weight[right.priority] - weight[left.priority] || right.updated_at.localeCompare(left.updated_at)
+}
+
+function filterTargetAgents(items: AgentWorkItem[], targetAgentKeys: string[]) {
+  if (!targetAgentKeys.length) return items
+  return items.filter((item) => item.owner_agent_key && targetAgentKeys.includes(item.owner_agent_key))
+}
+
+function itemSummary(item: AgentWorkItem) {
+  const owner = item.owner_agent_key ?? 'unassigned'
+  const blocker = item.blocker_summary ? `\nBlocker: ${truncateSlack(item.blocker_summary, 140)}` : ''
+  const next = item.validation_summary ? `\nNext: ${truncateSlack(item.validation_summary, 140)}` : ''
+  return `*${truncateSlack(item.title, 110)}*\nOwner: \`${owner}\` - Status: \`${item.status}\` - Priority: \`${item.priority}\`${blocker}${next}`
+}
+
+function workItemBlocks(title: string, intro: string, items: AgentWorkItem[]) {
+  const blocks: SlackBlock[] = [
+    { type: 'section', text: mrkdwn(`*${title}*\n${intro}`) },
+  ]
+  if (!items.length) {
+    blocks.push({ type: 'section', text: mrkdwn('No matching Agent Ops work items need mobile attention.') })
+    blocks.push({
+      type: 'actions',
+      elements: [slackButton({ label: 'Open Mission Control', actionId: 'open_mission_control', url: agentUrl('/admin/agents') })],
+    })
+    return blocks
+  }
+  for (const item of items.slice(0, 5)) {
+    blocks.push({ type: 'section', text: mrkdwn(itemSummary(item)) })
+    blocks.push({
+      type: 'actions',
+      elements: [
+        slackButton({ label: 'Open trace', actionId: 'open_trace', url: workItemHref(item) }),
+        slackButton({
+          label: 'Ask Shaka',
+          actionId: 'agent_work_ask_shaka',
+          value: { action: 'work.ask_shaka', workItemId: item.id, runId: item.active_run_id ?? undefined },
+        }),
+      ],
+    })
+  }
+  blocks.push({
+    type: 'actions',
+    elements: [slackButton({ label: 'Open Kanban', actionId: 'open_kanban', url: agentUrl('/admin/agents/swarm-board') })],
+  })
+  return blocks
+}
+
+async function buildPendingApprovalPayload() {
+  const approvals = await pendingApprovals()
+  const runs = await runsById(approvals.map((approval) => approval.run_id))
+  const blocks: SlackBlock[] = [
+    { type: 'section', text: mrkdwn('*Pending Agent Ops approvals*\nUse Slack for low-risk decisions. High-risk packets stay in Portfolio.') },
+  ]
+  if (!approvals.length) {
+    blocks.push({ type: 'section', text: mrkdwn('No pending approvals need mobile action.') })
+  }
+  for (const approval of approvals) {
+    const run = runs.get(approval.run_id)
+    blocks.push({
+      type: 'section',
+      text: mrkdwn([
+        `*${truncateSlack(run?.title ?? approval.run_id, 120)}*`,
+        `Type: \`${approval.approval_type}\` - Status: \`${approval.status}\``,
+        run?.current_step ? `Step: ${truncateSlack(run.current_step, 140)}` : null,
+      ].filter(Boolean).join('\n')),
+    })
+    blocks.push({
+      type: 'actions',
+      elements: [
+        slackButton({
+          label: 'Ask Shaka',
+          actionId: 'agent_approval_ask_shaka',
+          value: { action: 'approval.ask_shaka', approvalId: approval.id, runId: approval.run_id },
+        }),
+        slackButton({ label: 'Open decision', actionId: 'open_decision', url: agentUrl(`/admin/agents/coordination?approvalRunId=${approval.run_id}`) }),
+        slackButton({ label: 'Open trace', actionId: 'open_trace', url: agentUrl(`/admin/agents/runs/${approval.run_id}`) }),
+      ],
+    })
+  }
+  return {
+    text: `${approvals.length} pending Agent Ops approval(s) need review.`,
+    blocks,
+    itemCount: approvals.length,
+  }
+}
+
+async function buildWorkItemPayload(input: AgentSlackNotificationInput) {
+  const targetAgentKeys = normalizeTargetAgentKeys(input.targetAgentKeys)
+  const allItems = await listAgentWorkItems({ limit: 75 })
+  let items: AgentWorkItem[] = []
+  let title = 'Agent Ops mobile unblock'
+  let intro = 'Review the items that need a quick mobile decision.'
+
+  if (input.kind === 'blockers' || input.kind === 'standup_blockers') {
+    items = allItems.filter((item) => item.status === 'blocked' || Boolean(item.blocker_summary))
+    title = input.kind === 'standup_blockers' ? "Today's standup blockers" : 'Agent Ops blockers'
+    intro = 'Start here when work is stuck or waiting on an owner decision.'
+  } else if (input.kind === 'review_ready') {
+    items = allItems.filter((item) => item.status === 'ready_for_review' || item.status === 'ready_for_merge')
+    title = 'Review-ready Agent Ops work'
+    intro = 'These cards are waiting for review, trace inspection, or merge readiness.'
+  } else if (input.kind === 'goal_decisions') {
+    items = allItems.filter((item) => {
+      const metadata = item.metadata ?? {}
+      const goalId = typeof metadata.goal_id === 'string' ? metadata.goal_id : null
+      const needsDecision = Boolean(item.blocker_summary) || item.status === 'blocked' || item.status === 'proposed'
+      return Boolean(goalId) && (!input.goalId || goalId === input.goalId) && needsDecision
+    })
+    title = 'Goal tasks needing a decision'
+    intro = 'These goal-tagged tasks need an owner, unblock decision, or Shaka follow-up.'
+  } else if (input.kind === 'selected_agent_question') {
+    title = 'Standup question for selected agents'
+    intro = input.message?.trim() || 'Selected agents need a quick mobile standup response.'
+    items = filterTargetAgents(allItems, targetAgentKeys)
+      .filter((item) => !['merged', 'deployed', 'cancelled'].includes(item.status))
+  }
+
+  items = filterTargetAgents(items, targetAgentKeys).sort(prioritySort).slice(0, 5)
+  return {
+    text: `${title}: ${items.length} item(s).`,
+    blocks: workItemBlocks(title, intro, items),
+    itemCount: items.length,
+  }
+}
+
+export async function buildAgentSlackNotificationPayload(input: AgentSlackNotificationInput) {
+  if (input.kind === 'pending_approvals') return buildPendingApprovalPayload()
+  return buildWorkItemPayload(input)
+}
+
+async function postToSlack(text: string, blocks: SlackBlock[]) {
+  const webhookUrl = process.env.SLACK_AGENT_OPS_WEBHOOK_URL
+  if (!webhookUrl || !webhookUrl.startsWith('https://')) {
+    return { sent: false, reason: 'SLACK_AGENT_OPS_WEBHOOK_URL is not configured.' }
+  }
+  const response = await fetch(webhookUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text, blocks }),
+  })
+  if (!response.ok) {
+    return { sent: false, reason: `Slack webhook returned HTTP ${response.status}.` }
+  }
+  return { sent: true, reason: null }
+}
+
+export async function sendAgentSlackNotification(input: AgentSlackNotificationInput): Promise<AgentSlackNotificationResult> {
+  const idempotencyKey = notificationIdempotencyKey(input)
+  const existing = input.force ? null : await existingNotificationRun(idempotencyKey)
+  if (existing?.id) {
+    return {
+      ok: true,
+      runId: existing.id,
+      sent: false,
+      skipped: true,
+      deduped: true,
+      reason: 'A matching Slack mobile notification was already prepared in this hourly window.',
+      itemCount: Number(existing.metadata?.item_count ?? 0),
+      text: String(existing.metadata?.text ?? 'Agent Ops Slack notification already prepared.'),
+    }
+  }
+
+  const payload = await buildAgentSlackNotificationPayload(input)
+  const run = await startAgentRun({
+    agentKey: 'chief-of-staff',
+    runtime: 'manual',
+    kind: 'slack_mobile_notification',
+    title: `Send Slack mobile notification: ${input.kind.replace(/_/g, ' ')}`,
+    status: 'running',
+    triggerSource: input.triggerSource ?? 'admin_agent_slack_mobile_bridge',
+    currentStep: 'Preparing Slack payload',
+    metadata: {
+      notification_kind: input.kind,
+      target_agent_keys: normalizeTargetAgentKeys(input.targetAgentKeys),
+      goal_id: input.goalId ?? null,
+      actor_label: input.actorLabel ?? null,
+      item_count: payload.itemCount,
+      text: payload.text,
+    },
+    idempotencyKey,
+  })
+
+  const delivery = await postToSlack(payload.text, payload.blocks)
+  await recordAgentEvent({
+    runId: run.id,
+    eventType: delivery.sent ? 'slack_mobile_notification_sent' : 'slack_mobile_notification_skipped',
+    severity: delivery.sent ? 'info' : 'warning',
+    message: delivery.sent ? payload.text : delivery.reason,
+    metadata: {
+      notification_kind: input.kind,
+      item_count: payload.itemCount,
+      reason: delivery.reason,
+      blocks: payload.blocks,
+    },
+    idempotencyKey: `${idempotencyKey}:delivery`,
+  })
+  await endAgentRun({
+    runId: run.id,
+    status: delivery.sent ? 'completed' : 'cancelled',
+    currentStep: delivery.sent ? 'Slack notification sent' : 'Slack notification skipped',
+    outcome: {
+      sent: delivery.sent,
+      skipped: !delivery.sent,
+      reason: delivery.reason,
+      item_count: payload.itemCount,
+    },
+  })
+
+  return {
+    ok: true,
+    runId: run.id,
+    sent: delivery.sent,
+    skipped: !delivery.sent,
+    deduped: false,
+    reason: delivery.reason ?? undefined,
+    itemCount: payload.itemCount,
+    text: payload.text,
+  }
+}


### PR DESCRIPTION
## Summary
- Add a governed Slack mobile notification bridge for Agent Ops packets: pending approvals, blockers, review-ready work, goal decisions, standup blockers, and selected-agent questions.
- Add `POST /api/admin/agents/slack-notifications` with admin auth, hourly dedupe by kind/goal/selected agents, Slack webhook delivery, and `slack_mobile_notification` run/event tracing.
- Add Mission Control and Standup Room controls for sending mobile unblock packets to Slack without making Slack the source of truth.
- Extend Slack mobile-unblock docs with the notification bridge contract.

## Validation
- `npm test -- lib/agent-slack-notifications.test.ts app/api/admin/agents/slack-notifications/route.test.ts lib/agent-slack-actions.test.ts app/api/slack/agent/actions/route.test.ts`
- `npm test -- app/admin/agents/page.test.tsx app/admin/agents/standup/page.test.tsx app/api/admin/agents/slack-notifications/route.test.ts lib/agent-slack-notifications.test.ts lib/agent-slack-command.test.ts`
- `npx tsc --noEmit --pretty false`
- `npm run lint -- --file lib/agent-slack-notifications.ts --file app/api/admin/agents/slack-notifications/route.ts --file app/admin/agents/page.tsx --file app/admin/agents/standup/page.tsx`
- `npm run lint`
- `npm run build`
- Pre-push `npm run db:health-check` passed.

## Integration Notes
- Requires `SLACK_AGENT_OPS_WEBHOOK_URL` for actual outbound Slack posting. Without it, the route records a skipped trace rather than failing the page.
- Existing action endpoint requirements from PR #360 still apply: `SLACK_SIGNING_SECRET` and `SLACK_AGENT_OPS_ALLOWED_USER_IDS` for live interactive Slack buttons.
- Hourly dedupe prevents repeated mobile notification spam for the same kind, goal, and selected-agent set unless `force: true` is sent.
- Build emitted the existing local warning that `MOCK_N8N=false` and `N8N_DISABLE_OUTBOUND=false`; no live n8n or outbound workflow was run.
- Local dev URL used for smoke availability: `http://localhost:3026`. Authenticated browser QA was not completed in this lane because the automated Browser tool was unavailable here.
- Vercel contexts checked before merge: not run from this feature lane. Integration captain should verify `Vercel – portfolio` and `Vercel – portfolio-staging` after merge.