### PR TITLE
feat: add Model Ops reply-intent review queue

### DIFF
--- a/app/admin/model-ops/reply-intent-review/page.test.tsx
+++ b/app/admin/model-ops/reply-intent-review/page.test.tsx
@@ -1,0 +1,136 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ADMIN_NAV } from '@/lib/admin-nav'
+import ReplyIntentReviewPage from './page'
+
+vi.mock('@/components/ProtectedRoute', () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('@/components/admin/Breadcrumbs', () => ({
+  default: ({ items }: { items: Array<{ label: string }> }) => (
+    <nav aria-label="Breadcrumb">
+      {items.map((item) => (
+        <span key={item.label}>{item.label}</span>
+      ))}
+    </nav>
+  ),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  getCurrentSession: vi.fn(async () => ({ access_token: 'test-admin-token' })),
+}))
+
+const queueResponse = {
+  available: true,
+  items: [
+    {
+      source_id: '11111111-1111-4111-8111-111111111111',
+      source_hash: 'abc123',
+      reply_hash: 'def456',
+      channel: 'email',
+      replied_at: '2026-05-24T10:00:00.000Z',
+      outreach_status: 'replied',
+      sequence_step: 1,
+      redacted_reply: 'Can we schedule a quick call next week?',
+      suggested_labels: {
+        scheduling_intent: true,
+        ooo: false,
+        not_interested: false,
+        interested: true,
+        needs_followup: false,
+      },
+      review_status: 'pending',
+      human_scheduling_intent: null,
+      notes: '',
+      reviewed_at: null,
+      existing_review_id: null,
+    },
+  ],
+  summary: {
+    target: 200,
+    total_real_replies: 1,
+    reviewed_real: 0,
+    pending: 1,
+    unsure: 0,
+    skipped: 0,
+    remaining_to_gate: 200,
+  },
+  pagination: {
+    page: 1,
+    limit: 30,
+    total: 1,
+    totalPages: 1,
+  },
+  schema: {
+    reviews_table_available: true,
+  },
+}
+
+describe('ReplyIntentReviewPage', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input)
+        if (url.includes('/bulk')) {
+          return {
+            ok: true,
+            json: async () => ({ updated: 1, reviews: [] }),
+          }
+        }
+        if (init?.method === 'POST') {
+          return {
+            ok: true,
+            json: async () => ({ review: { ...queueResponse.items[0], review_status: 'reviewed', human_scheduling_intent: true } }),
+          }
+        }
+        return {
+          ok: true,
+          json: async () => queueResponse,
+        }
+      })
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('renders the operator review queue and saves a scheduling label', async () => {
+    render(<ReplyIntentReviewPage />)
+
+    expect(await screen.findByRole('heading', { name: 'Reply Intent Review' })).toBeInTheDocument()
+    expect(screen.getAllByText('Can we schedule a quick call next week?').length).toBeGreaterThan(0)
+    expect(screen.getByText('0/200')).toBeInTheDocument()
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Yes' })).not.toBeDisabled())
+    fireEvent.click(screen.getByRole('button', { name: 'Yes' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Save' })).not.toBeDisabled())
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/admin/model-ops/reply-intent-reviews',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.stringContaining('"human_scheduling_intent":true'),
+        })
+      )
+    })
+  })
+
+  it('is linked from Quality & insights admin navigation', () => {
+    const qualityCategory = ADMIN_NAV.categories.find((category) => category.label === 'Quality & insights')
+
+    expect(qualityCategory?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: 'Model Ops',
+          href: '/admin/model-ops/reply-intent-review',
+        }),
+      ])
+    )
+  })
+})

--- a/app/admin/model-ops/reply-intent-review/page.tsx
+++ b/app/admin/model-ops/reply-intent-review/page.tsx
@@ -1,0 +1,621 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import ProtectedRoute from '@/components/ProtectedRoute'
+import Breadcrumbs from '@/components/admin/Breadcrumbs'
+import { getCurrentSession } from '@/lib/auth'
+import {
+  AlertTriangle,
+  Check,
+  ChevronLeft,
+  ChevronRight,
+  CircleDot,
+  Clock,
+  Loader2,
+  MinusCircle,
+  RotateCw,
+  Search,
+  SkipForward,
+  Square,
+  CheckSquare,
+  Wand2,
+  X,
+} from 'lucide-react'
+
+type ReviewStatus = 'pending' | 'reviewed' | 'unsure' | 'skipped'
+
+type SuggestedLabels = {
+  scheduling_intent: boolean
+  ooo: boolean
+  not_interested: boolean
+  interested: boolean
+  needs_followup: boolean
+}
+
+type QueueItem = {
+  source_id: string
+  source_hash: string
+  reply_hash: string
+  channel: string | null
+  replied_at: string | null
+  outreach_status: string | null
+  sequence_step: number | null
+  redacted_reply: string
+  suggested_labels: SuggestedLabels
+  review_status: ReviewStatus
+  human_scheduling_intent: boolean | null
+  notes: string
+  reviewed_at: string | null
+  existing_review_id: string | null
+}
+
+type QueueResponse = {
+  available: boolean
+  items: QueueItem[]
+  summary: {
+    target: number
+    total_real_replies: number
+    reviewed_real: number
+    pending: number
+    unsure: number
+    skipped: number
+    remaining_to_gate: number
+  }
+  pagination: {
+    page: number
+    limit: number
+    total: number
+    totalPages: number
+  }
+  schema?: {
+    reviews_table_available: boolean
+  }
+  reason?: string
+}
+
+const STATUS_OPTIONS: Array<{ label: string; value: ReviewStatus | 'all' }> = [
+  { label: 'Pending', value: 'pending' },
+  { label: 'Reviewed', value: 'reviewed' },
+  { label: 'Unsure', value: 'unsure' },
+  { label: 'Skipped', value: 'skipped' },
+  { label: 'All', value: 'all' },
+]
+
+const DECISION_OPTIONS = [
+  { label: 'Yes', value: true, icon: Check },
+  { label: 'No', value: false, icon: X },
+] as const
+
+function formatDate(value: string | null) {
+  if (!value) return 'No reply timestamp'
+  try {
+    return new Intl.DateTimeFormat('en', {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    }).format(new Date(value))
+  } catch {
+    return value
+  }
+}
+
+function labelClass(active: boolean) {
+  return active
+    ? 'border-radiant-gold/40 bg-radiant-gold/15 text-radiant-gold'
+    : 'border-radiant-gold/10 bg-silicon-slate/20 text-muted-foreground'
+}
+
+export default function ReplyIntentReviewPage() {
+  return (
+    <ProtectedRoute requireAdmin>
+      <ReplyIntentReviewContent />
+    </ProtectedRoute>
+  )
+}
+
+function ReplyIntentReviewContent() {
+  const [items, setItems] = useState<QueueItem[]>([])
+  const [summary, setSummary] = useState<QueueResponse['summary'] | null>(null)
+  const [pagination, setPagination] = useState<QueueResponse['pagination'] | null>(null)
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [status, setStatus] = useState<ReviewStatus | 'all'>('pending')
+  const [search, setSearch] = useState('')
+  const [page, setPage] = useState(1)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [bulkSaving, setBulkSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [schemaReady, setSchemaReady] = useState(true)
+  const [selectedForBulk, setSelectedForBulk] = useState<Set<string>>(new Set())
+  const [draftIntent, setDraftIntent] = useState<boolean | null>(null)
+  const [draftUnsure, setDraftUnsure] = useState(false)
+  const [draftNotes, setDraftNotes] = useState('')
+
+  const selectedItem = useMemo(
+    () => items.find((item) => item.source_id === selectedId) ?? items[0] ?? null,
+    [items, selectedId]
+  )
+
+  const fetchQueue = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const session = await getCurrentSession()
+      const params = new URLSearchParams({
+        status,
+        page: String(page),
+        limit: '30',
+      })
+      if (search.trim()) params.set('search', search.trim())
+
+      const response = await fetch(`/api/admin/model-ops/reply-intent-reviews?${params.toString()}`, {
+        headers: {
+          Authorization: `Bearer ${session?.access_token}`,
+        },
+      })
+      const data = (await response.json()) as QueueResponse | { error?: string }
+
+      if (!response.ok) {
+        throw new Error('error' in data && data.error ? data.error : 'Failed to load reply-intent queue')
+      }
+
+      const queue = data as QueueResponse
+      setItems(queue.items)
+      setSummary(queue.summary)
+      setPagination(queue.pagination)
+      setSchemaReady(Boolean(queue.schema?.reviews_table_available ?? true))
+      setSelectedId((current) => (queue.items.some((item) => item.source_id === current) ? current : queue.items[0]?.source_id ?? null))
+      setSelectedForBulk((current) => new Set([...current].filter((id) => queue.items.some((item) => item.source_id === id))))
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Failed to load reply-intent queue')
+    } finally {
+      setLoading(false)
+    }
+  }, [page, search, status])
+
+  useEffect(() => {
+    fetchQueue()
+  }, [fetchQueue])
+
+  useEffect(() => {
+    if (!selectedItem) {
+      setDraftIntent(null)
+      setDraftUnsure(false)
+      setDraftNotes('')
+      return
+    }
+    setDraftIntent(selectedItem.human_scheduling_intent)
+    setDraftUnsure(selectedItem.review_status === 'unsure')
+    setDraftNotes(selectedItem.notes || '')
+  }, [selectedItem])
+
+  const saveReview = useCallback(
+    async (reviewStatus: ReviewStatus, schedulingIntent: boolean | null = draftIntent) => {
+      if (!selectedItem) return
+      setSaving(true)
+      setError(null)
+      try {
+        const session = await getCurrentSession()
+        const response = await fetch('/api/admin/model-ops/reply-intent-reviews', {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${session?.access_token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            source_id: selectedItem.source_id,
+            review_status: reviewStatus,
+            human_scheduling_intent: schedulingIntent,
+            notes: draftNotes,
+          }),
+        })
+
+        const body = await response.json()
+        if (!response.ok) {
+          throw new Error(body?.error || 'Failed to save reply-intent review')
+        }
+
+        await fetchQueue()
+      } catch (caught) {
+        setError(caught instanceof Error ? caught.message : 'Failed to save reply-intent review')
+      } finally {
+        setSaving(false)
+      }
+    },
+    [draftIntent, draftNotes, fetchQueue, selectedItem]
+  )
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null
+      if (target?.tagName === 'TEXTAREA' || target?.tagName === 'INPUT') return
+      if (!selectedItem || saving) return
+
+      if (event.key.toLowerCase() === 'y') {
+        event.preventDefault()
+        setDraftIntent(true)
+        setDraftUnsure(false)
+      } else if (event.key.toLowerCase() === 'n') {
+        event.preventDefault()
+        setDraftIntent(false)
+        setDraftUnsure(false)
+      } else if (event.key.toLowerCase() === 'u') {
+        event.preventDefault()
+        setDraftIntent(null)
+        setDraftUnsure(true)
+      } else if (event.key === 'Enter' && (draftUnsure || typeof draftIntent === 'boolean')) {
+        event.preventDefault()
+        saveReview(draftUnsure ? 'unsure' : 'reviewed', draftUnsure ? null : draftIntent)
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [draftIntent, draftUnsure, saveReview, saving, selectedItem])
+
+  const progressPercent = summary ? Math.min(100, Math.round((summary.reviewed_real / summary.target) * 100)) : 0
+
+  const toggleBulkSelection = (sourceId: string) => {
+    setSelectedForBulk((current) => {
+      const next = new Set(current)
+      if (next.has(sourceId)) next.delete(sourceId)
+      else next.add(sourceId)
+      return next
+    })
+  }
+
+  const bulkAcceptSuggested = async () => {
+    if (selectedForBulk.size === 0) return
+    setBulkSaving(true)
+    setError(null)
+    try {
+      const session = await getCurrentSession()
+      const response = await fetch('/api/admin/model-ops/reply-intent-reviews/bulk', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${session?.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          action: 'accept_suggested',
+          source_ids: [...selectedForBulk],
+        }),
+      })
+      const body = await response.json()
+      if (!response.ok) throw new Error(body?.error || 'Failed to apply bulk review')
+      setSelectedForBulk(new Set())
+      await fetchQueue()
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Failed to apply bulk review')
+    } finally {
+      setBulkSaving(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="border-b border-radiant-gold/10 px-5 py-4">
+        <Breadcrumbs
+          items={[
+            { label: 'Model Ops', href: '/admin/model-ops/reply-intent-review' },
+            { label: 'Reply Intent Review' },
+          ]}
+        />
+        <div className="mt-4 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-radiant-gold">Model Ops</p>
+            <h1 className="font-heading text-2xl text-foreground">Reply Intent Review</h1>
+          </div>
+          <div className="grid min-w-[300px] gap-2">
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-muted-foreground">Reviewed real examples</span>
+              <span className="font-mono text-radiant-gold">
+                {summary?.reviewed_real ?? 0}/{summary?.target ?? 200}
+              </span>
+            </div>
+            <div className="h-2 overflow-hidden rounded-full bg-silicon-slate/40">
+              <div className="h-full bg-radiant-gold transition-all" style={{ width: `${progressPercent}%` }} />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mx-5 mt-4 flex items-center gap-2 rounded-lg border border-red-400/30 bg-red-950/20 px-3 py-2 text-sm text-red-100">
+          <AlertTriangle size={16} className="text-red-300" />
+          {error}
+        </div>
+      )}
+
+      {!schemaReady && (
+        <div className="mx-5 mt-4 flex items-center gap-2 rounded-lg border border-radiant-gold/25 bg-radiant-gold/10 px-3 py-2 text-sm text-radiant-gold">
+          <AlertTriangle size={16} />
+          Review storage is pending migration. The queue can load, but saves require the new Model Ops table.
+        </div>
+      )}
+
+      <div className="grid min-h-[calc(100vh-145px)] grid-cols-1 lg:grid-cols-[360px_minmax(0,1fr)_340px]">
+        <aside className="border-r border-radiant-gold/10">
+          <div className="space-y-3 border-b border-radiant-gold/10 p-4">
+            <div className="relative">
+              <Search size={16} className="absolute left-3 top-2.5 text-muted-foreground" />
+              <input
+                value={search}
+                onChange={(event) => {
+                  setSearch(event.target.value)
+                  setPage(1)
+                }}
+                className="w-full rounded-lg border border-radiant-gold/10 bg-silicon-slate/20 py-2 pl-9 pr-3 text-sm outline-none focus:border-radiant-gold/45"
+                placeholder="Search reviewed text"
+              />
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              {STATUS_OPTIONS.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => {
+                    setStatus(option.value)
+                    setPage(1)
+                  }}
+                  className={`rounded-lg border px-3 py-1.5 text-xs transition-colors ${labelClass(status === option.value)}`}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+
+            <button
+              type="button"
+              onClick={fetchQueue}
+              className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/10 px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:border-radiant-gold/30 hover:text-foreground"
+            >
+              <RotateCw size={14} />
+              Refresh
+            </button>
+          </div>
+
+          <div className="flex items-center justify-between border-b border-radiant-gold/10 px-4 py-3 text-sm">
+            <span className="text-muted-foreground">{pagination?.total ?? 0} rows</span>
+            <button
+              type="button"
+              disabled={selectedForBulk.size === 0 || bulkSaving}
+              onClick={bulkAcceptSuggested}
+              className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/20 px-3 py-1.5 text-radiant-gold disabled:cursor-not-allowed disabled:opacity-45"
+            >
+              {bulkSaving ? <Loader2 size={14} className="animate-spin" /> : <Wand2 size={14} />}
+              Accept {selectedForBulk.size || ''}
+            </button>
+          </div>
+
+          <div className="max-h-[calc(100vh-320px)] overflow-y-auto p-2">
+            {loading ? (
+              <div className="flex items-center justify-center py-10">
+                <Loader2 className="h-6 w-6 animate-spin text-radiant-gold" />
+              </div>
+            ) : items.length === 0 ? (
+              <div className="px-3 py-8 text-center text-sm text-muted-foreground">No replies match this view.</div>
+            ) : (
+              <div className="space-y-2">
+                {items.map((item) => {
+                  const active = selectedItem?.source_id === item.source_id
+                  const checked = selectedForBulk.has(item.source_id)
+                  return (
+                    <div
+                      key={item.source_id}
+                      className={`rounded-lg border p-3 transition-colors ${
+                        active
+                          ? 'border-radiant-gold/40 bg-radiant-gold/10'
+                          : 'border-radiant-gold/10 bg-silicon-slate/10 hover:border-radiant-gold/25'
+                      }`}
+                    >
+                      <div className="flex items-start gap-2">
+                        <button
+                          type="button"
+                          onClick={() => toggleBulkSelection(item.source_id)}
+                          className="mt-0.5 text-radiant-gold"
+                          aria-label={checked ? 'Remove from bulk selection' : 'Add to bulk selection'}
+                        >
+                          {checked ? <CheckSquare size={16} /> : <Square size={16} />}
+                        </button>
+                        <button type="button" onClick={() => setSelectedId(item.source_id)} className="min-w-0 flex-1 text-left">
+                          <div className="flex items-center justify-between gap-2">
+                            <span className="font-mono text-xs text-muted-foreground">{item.source_hash}</span>
+                            <span className={`rounded-full border px-2 py-0.5 text-[11px] ${labelClass(item.review_status === 'reviewed')}`}>
+                              {item.review_status}
+                            </span>
+                          </div>
+                          <p className="mt-2 line-clamp-3 text-sm text-foreground/88">{item.redacted_reply}</p>
+                          <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+                            <Clock size={12} />
+                            <span>{formatDate(item.replied_at)}</span>
+                          </div>
+                        </button>
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+
+          <div className="flex items-center justify-between border-t border-radiant-gold/10 p-3">
+            <button
+              type="button"
+              disabled={page <= 1}
+              onClick={() => setPage((current) => Math.max(1, current - 1))}
+              className="rounded-lg border border-radiant-gold/10 p-2 disabled:opacity-35"
+              aria-label="Previous page"
+            >
+              <ChevronLeft size={16} />
+            </button>
+            <span className="text-xs text-muted-foreground">
+              Page {pagination?.page ?? page} of {pagination?.totalPages || 1}
+            </span>
+            <button
+              type="button"
+              disabled={!pagination || page >= pagination.totalPages}
+              onClick={() => setPage((current) => current + 1)}
+              className="rounded-lg border border-radiant-gold/10 p-2 disabled:opacity-35"
+              aria-label="Next page"
+            >
+              <ChevronRight size={16} />
+            </button>
+          </div>
+        </aside>
+
+        <main className="min-w-0 border-r border-radiant-gold/10 p-5">
+          {selectedItem ? (
+            <div className="space-y-5">
+              <div className="flex flex-wrap items-center gap-2 text-xs">
+                <span className="rounded-full border border-radiant-gold/15 bg-silicon-slate/20 px-2 py-1 text-muted-foreground">
+                  {selectedItem.channel || 'unknown channel'}
+                </span>
+                <span className="rounded-full border border-radiant-gold/15 bg-silicon-slate/20 px-2 py-1 text-muted-foreground">
+                  {selectedItem.outreach_status || 'unknown status'}
+                </span>
+                <span className="rounded-full border border-radiant-gold/15 bg-silicon-slate/20 px-2 py-1 text-muted-foreground">
+                  Step {selectedItem.sequence_step ?? '-'}
+                </span>
+              </div>
+
+              <div>
+                <h2 className="font-heading text-lg text-foreground">Redacted Reply</h2>
+                <p className="mt-1 text-sm text-muted-foreground">{formatDate(selectedItem.replied_at)}</p>
+              </div>
+
+              <div className="min-h-[220px] rounded-lg border border-radiant-gold/10 bg-silicon-slate/15 p-5 text-base leading-7 text-foreground/90">
+                {selectedItem.redacted_reply}
+              </div>
+
+              <div>
+                <h3 className="mb-3 text-sm font-semibold uppercase tracking-[0.16em] text-radiant-gold">Signals</h3>
+                <div className="flex flex-wrap gap-2">
+                  {Object.entries(selectedItem.suggested_labels).map(([key, value]) => (
+                    <span key={key} className={`rounded-full border px-3 py-1 text-xs ${labelClass(value)}`}>
+                      {key.replaceAll('_', ' ')}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">Select a reply.</div>
+          )}
+        </main>
+
+        <section className="p-5">
+          <div className="space-y-5">
+            <div>
+              <h2 className="font-heading text-lg text-foreground">Scheduling Intent</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Decide whether the reply is trying to book, move, or confirm a meeting.
+              </p>
+            </div>
+
+            <div className="grid grid-cols-2 gap-2">
+              {DECISION_OPTIONS.map(({ label, value, icon: Icon }) => (
+                <button
+                  key={label}
+                  type="button"
+                  disabled={!selectedItem || saving}
+                  onClick={() => {
+                    setDraftIntent(value)
+                    setDraftUnsure(false)
+                  }}
+                  className={`flex min-h-14 items-center justify-center gap-2 rounded-lg border text-sm font-semibold transition-colors ${
+                    draftIntent === value && !draftUnsure
+                      ? 'border-radiant-gold/45 bg-radiant-gold/15 text-radiant-gold'
+                      : 'border-radiant-gold/10 bg-silicon-slate/20 text-foreground/85 hover:border-radiant-gold/30'
+                  } disabled:cursor-not-allowed disabled:opacity-50`}
+                >
+                  <Icon size={18} />
+                  {label}
+                </button>
+              ))}
+            </div>
+
+            <button
+              type="button"
+              disabled={!selectedItem || saving}
+              onClick={() => {
+                setDraftUnsure(true)
+                setDraftIntent(null)
+              }}
+              className={`flex min-h-11 w-full items-center justify-center gap-2 rounded-lg border text-sm font-semibold transition-colors ${
+                draftUnsure
+                  ? 'border-radiant-gold/45 bg-radiant-gold/15 text-radiant-gold'
+                  : 'border-radiant-gold/10 bg-silicon-slate/20 text-foreground/85 hover:border-radiant-gold/30'
+              } disabled:cursor-not-allowed disabled:opacity-50`}
+            >
+              <CircleDot size={16} />
+              Unsure
+            </button>
+
+            <textarea
+              value={draftNotes}
+              onChange={(event) => setDraftNotes(event.target.value)}
+              className="min-h-[120px] w-full rounded-lg border border-radiant-gold/10 bg-silicon-slate/20 p-3 text-sm outline-none focus:border-radiant-gold/45"
+              placeholder="Review notes"
+            />
+
+            <div className="grid gap-2">
+              <button
+                type="button"
+                disabled={!selectedItem || saving || (!draftUnsure && typeof draftIntent !== 'boolean')}
+                onClick={() => saveReview(draftUnsure ? 'unsure' : 'reviewed', draftUnsure ? null : draftIntent)}
+                className="flex min-h-11 items-center justify-center gap-2 rounded-lg bg-radiant-gold px-4 py-2 text-sm font-semibold text-imperial-navy disabled:cursor-not-allowed disabled:opacity-45"
+              >
+                {saving ? <Loader2 size={16} className="animate-spin" /> : <Check size={16} />}
+                Save
+              </button>
+              <button
+                type="button"
+                disabled={!selectedItem || saving}
+                onClick={() => saveReview('skipped', null)}
+                className="flex min-h-11 items-center justify-center gap-2 rounded-lg border border-radiant-gold/10 bg-silicon-slate/20 px-4 py-2 text-sm text-foreground/85 disabled:cursor-not-allowed disabled:opacity-45"
+              >
+                <SkipForward size={16} />
+                Skip
+              </button>
+            </div>
+
+            <div className="grid gap-2 rounded-lg border border-radiant-gold/10 bg-silicon-slate/15 p-3 text-sm">
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Pending</span>
+                <span className="font-mono">{summary?.pending ?? 0}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Unsure</span>
+                <span className="font-mono">{summary?.unsure ?? 0}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Skipped</span>
+                <span className="font-mono">{summary?.skipped ?? 0}</span>
+              </div>
+              <div className="flex items-center justify-between border-t border-radiant-gold/10 pt-2">
+                <span className="text-muted-foreground">Gate gap</span>
+                <span className="font-mono text-radiant-gold">{summary?.remaining_to_gate ?? 0}</span>
+              </div>
+            </div>
+
+            <button
+              type="button"
+              onClick={() => {
+                setDraftIntent(selectedItem?.suggested_labels.scheduling_intent ?? null)
+                setDraftUnsure(false)
+              }}
+              disabled={!selectedItem || saving}
+              className="flex min-h-10 w-full items-center justify-center gap-2 rounded-lg border border-radiant-gold/10 text-sm text-muted-foreground transition-colors hover:border-radiant-gold/30 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-45"
+            >
+              <MinusCircle size={16} />
+              Use suggestion
+            </button>
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/app/api/admin/model-ops/reply-intent-reviews/bulk/route.test.ts
+++ b/app/api/admin/model-ops/reply-intent-reviews/bulk/route.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  from: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import { POST } from './route'
+
+const sourceRows = [
+  {
+    id: '11111111-1111-4111-8111-111111111111',
+    channel: 'email',
+    sequence_step: 1,
+    status: 'replied',
+    replied_at: '2026-05-24T10:00:00.000Z',
+    created_at: '2026-05-24T09:00:00.000Z',
+    reply_content: 'Can we schedule a quick call?',
+  },
+]
+
+function sourceListQuery() {
+  return {
+    select: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    not: vi.fn().mockResolvedValue({ data: sourceRows, error: null }),
+  }
+}
+
+function upsertQuery() {
+  return {
+    upsert: vi.fn().mockReturnThis(),
+    select: vi.fn().mockResolvedValue({
+      data: [
+        {
+          source_table: 'outreach_queue',
+          source_id: sourceRows[0].id,
+          source_hash: 'source-hash',
+          reply_hash: 'reply-hash',
+          redacted_reply: 'Can we schedule a quick call?',
+          suggested_labels: {
+            scheduling_intent: true,
+            interested: true,
+            not_interested: false,
+            ooo: false,
+            needs_followup: false,
+          },
+          review_status: 'reviewed',
+          human_scheduling_intent: true,
+        },
+      ],
+      error: null,
+    }),
+  }
+}
+
+function post(body: unknown) {
+  return POST(
+    new Request('http://localhost/api/admin/model-ops/reply-intent-reviews/bulk', {
+      method: 'POST',
+      headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }) as never
+  )
+}
+
+describe('bulk reply-intent review API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+  })
+
+  it('requires a supported bulk action', async () => {
+    const response = await post({ action: 'delete', source_ids: [sourceRows[0].id] })
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'Unsupported bulk action' })
+    expect(mocks.from).not.toHaveBeenCalled()
+  })
+
+  it('accepts suggested scheduling labels for selected replies', async () => {
+    const reviewQuery = upsertQuery()
+    mocks.from.mockImplementation((table: string) => {
+      if (table === 'outreach_queue') return sourceListQuery()
+      return reviewQuery
+    })
+
+    const response = await post({ action: 'accept_suggested', source_ids: [sourceRows[0].id] })
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(reviewQuery.upsert).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          source_id: sourceRows[0].id,
+          review_status: 'reviewed',
+          human_scheduling_intent: true,
+        }),
+      ],
+      { onConflict: 'source_table,source_id' }
+    )
+    expect(body.updated).toBe(1)
+    expect(body.reviews[0]).toMatchObject({
+      source_id: sourceRows[0].id,
+      review_status: 'reviewed',
+      human_scheduling_intent: true,
+    })
+  })
+})

--- a/app/api/admin/model-ops/reply-intent-reviews/bulk/route.ts
+++ b/app/api/admin/model-ops/reply-intent-reviews/bulk/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { supabaseAdmin } from '@/lib/supabase'
+import {
+  buildReviewUpsertPayload,
+  suggestReplyIntentLabels,
+  type OutreachReplySourceRow,
+  type ReplyIntentReviewRow,
+  toReplyIntentQueueItem,
+} from '@/lib/model-ops-reply-intent'
+
+export const dynamic = 'force-dynamic'
+
+const MAX_BULK_ROWS = 100
+
+function isMissingTableError(error: unknown) {
+  return Boolean(
+    error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      ((error as { code?: string }).code === '42P01' || (error as { code?: string }).code === 'PGRST205')
+  )
+}
+
+export async function POST(request: NextRequest) {
+  const authResult = await verifyAdmin(request)
+  if (isAuthError(authResult)) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status })
+  }
+
+  if (!supabaseAdmin) {
+    return NextResponse.json({ error: 'Supabase admin client unavailable' }, { status: 500 })
+  }
+
+  try {
+    const body = await request.json()
+    const action = typeof body?.action === 'string' ? body.action : ''
+    const sourceIds = Array.isArray(body?.source_ids)
+      ? Array.from(new Set(body.source_ids.filter((id: unknown) => typeof id === 'string' && id.trim()).map(String)))
+      : []
+
+    if (action !== 'accept_suggested') {
+      return NextResponse.json({ error: 'Unsupported bulk action' }, { status: 400 })
+    }
+
+    if (sourceIds.length === 0) {
+      return NextResponse.json({ error: 'source_ids must include at least one outreach reply id' }, { status: 400 })
+    }
+
+    if (sourceIds.length > MAX_BULK_ROWS) {
+      return NextResponse.json({ error: `Bulk review is limited to ${MAX_BULK_ROWS} rows at a time` }, { status: 400 })
+    }
+
+    const { data: sourceRows, error: sourceError } = await supabaseAdmin
+      .from('outreach_queue')
+      .select('id,channel,sequence_step,status,replied_at,created_at,reply_content')
+      .in('id', sourceIds)
+      .not('reply_content', 'is', null)
+
+    if (sourceError) {
+      console.error('Error fetching bulk reply-intent source rows:', sourceError)
+      return NextResponse.json({ error: 'Failed to fetch outreach replies' }, { status: 500 })
+    }
+
+    const rows = ((sourceRows || []) as OutreachReplySourceRow[]).filter(
+      (row) => String(row.reply_content || '').trim().length >= 8
+    )
+
+    if (rows.length === 0) {
+      return NextResponse.json({ error: 'No matching outreach replies found' }, { status: 404 })
+    }
+
+    const reviewedAt = new Date().toISOString()
+    const payloads = rows.map((source) => {
+      const labels = suggestReplyIntentLabels(source.reply_content)
+      return buildReviewUpsertPayload({
+        source,
+        reviewStatus: 'reviewed',
+        humanSchedulingIntent: labels.scheduling_intent,
+        notes: 'Accepted suggested scheduling_intent via Model Ops bulk review.',
+        reviewedBy: authResult.user.id,
+        reviewedAt,
+      })
+    })
+
+    const { data: reviews, error: reviewError } = await supabaseAdmin
+      .from('model_ops_reply_intent_reviews')
+      .upsert(payloads, { onConflict: 'source_table,source_id' })
+      .select()
+
+    if (reviewError) {
+      if (isMissingTableError(reviewError)) {
+        return NextResponse.json(
+          { error: 'Model Ops reply-intent review schema has not been applied in this environment.' },
+          { status: 503 }
+        )
+      }
+      console.error('Error bulk saving reply-intent reviews:', reviewError)
+      return NextResponse.json({ error: 'Failed to save reply-intent reviews' }, { status: 500 })
+    }
+
+    const reviewsBySource = new Map(((reviews || []) as ReplyIntentReviewRow[]).map((review) => [review.source_id, review]))
+
+    return NextResponse.json({
+      updated: rows.length,
+      reviews: rows.map((source) => toReplyIntentQueueItem(source, reviewsBySource.get(source.id))),
+    })
+  } catch (error) {
+    console.error('Reply-intent bulk review error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/app/api/admin/model-ops/reply-intent-reviews/route.test.ts
+++ b/app/api/admin/model-ops/reply-intent-reviews/route.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  from: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import { GET, POST } from './route'
+
+const sourceRow = {
+  id: '11111111-1111-4111-8111-111111111111',
+  channel: 'email',
+  sequence_step: 1,
+  status: 'replied',
+  replied_at: '2026-05-24T10:00:00.000Z',
+  created_at: '2026-05-24T09:00:00.000Z',
+  reply_content: 'Jane Carter can meet next week at jane@example.com.',
+}
+
+function listQuery(result: { data: unknown[]; error: unknown }) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    not: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue(result),
+  }
+}
+
+function sourceSingleQuery(result: { data: unknown; error: unknown }) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    not: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue(result),
+  }
+}
+
+function upsertQuery(result: { data: unknown; error: unknown }) {
+  return {
+    upsert: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue(result),
+  }
+}
+
+function request(url = 'http://localhost/api/admin/model-ops/reply-intent-reviews') {
+  return new Request(url, {
+    headers: { authorization: 'Bearer token' },
+  })
+}
+
+describe('reply-intent review API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+  })
+
+  it('requires admin auth before listing reviews', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await GET(request() as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.from).not.toHaveBeenCalled()
+  })
+
+  it('returns virtual pending queue rows from outreach replies', async () => {
+    mocks.from.mockImplementation((table: string) => {
+      if (table === 'outreach_queue') return listQuery({ data: [sourceRow], error: null })
+      return listQuery({ data: [], error: null })
+    })
+
+    const response = await GET(request() as never)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.summary).toMatchObject({
+      total_real_replies: 1,
+      reviewed_real: 0,
+      pending: 1,
+      target: 200,
+    })
+    expect(body.items[0].redacted_reply).toContain('[email:')
+    expect(body.items[0].redacted_reply).not.toContain('jane@example.com')
+  })
+
+  it('validates reviewed saves require a boolean scheduling label', async () => {
+    const response = await POST(
+      new Request('http://localhost/api/admin/model-ops/reply-intent-reviews', {
+        method: 'POST',
+        headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+        body: JSON.stringify({
+          source_id: sourceRow.id,
+          review_status: 'reviewed',
+        }),
+      }) as never
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: 'human_scheduling_intent must be true or false when review_status is reviewed',
+    })
+    expect(mocks.from).not.toHaveBeenCalled()
+  })
+
+  it('upserts a reviewed label from the source outreach reply', async () => {
+    const savedReview = {
+      source_table: 'outreach_queue',
+      source_id: sourceRow.id,
+      source_hash: 'source-hash',
+      reply_hash: 'reply-hash',
+      redacted_reply: 'redacted reply',
+      suggested_labels: {
+        scheduling_intent: true,
+        interested: true,
+        not_interested: false,
+        ooo: false,
+        needs_followup: false,
+      },
+      review_status: 'reviewed',
+      human_scheduling_intent: true,
+    }
+    const reviewQuery = upsertQuery({ data: savedReview, error: null })
+
+    mocks.from.mockImplementation((table: string) => {
+      if (table === 'outreach_queue') return sourceSingleQuery({ data: sourceRow, error: null })
+      return reviewQuery
+    })
+
+    const response = await POST(
+      new Request('http://localhost/api/admin/model-ops/reply-intent-reviews', {
+        method: 'POST',
+        headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+        body: JSON.stringify({
+          source_id: sourceRow.id,
+          review_status: 'reviewed',
+          human_scheduling_intent: true,
+          notes: 'confirmed',
+        }),
+      }) as never
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(reviewQuery.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source_id: sourceRow.id,
+        review_status: 'reviewed',
+        human_scheduling_intent: true,
+        notes: 'confirmed',
+      }),
+      { onConflict: 'source_table,source_id' }
+    )
+    expect(body.review).toMatchObject({
+      source_id: sourceRow.id,
+      review_status: 'reviewed',
+      human_scheduling_intent: true,
+    })
+  })
+})

--- a/app/api/admin/model-ops/reply-intent-reviews/route.ts
+++ b/app/api/admin/model-ops/reply-intent-reviews/route.ts
@@ -1,0 +1,266 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { supabaseAdmin } from '@/lib/supabase'
+import {
+  MODEL_OPS_REPLY_INTENT_TARGET,
+  buildReviewUpsertPayload,
+  normalizeReviewStatus,
+  type OutreachReplySourceRow,
+  type ReplyIntentQueueItem,
+  type ReplyIntentReviewRow,
+  toReplyIntentQueueItem,
+} from '@/lib/model-ops-reply-intent'
+
+export const dynamic = 'force-dynamic'
+
+const MAX_SOURCE_ROWS = 750
+
+type QueueResponse = {
+  available: boolean
+  items: ReplyIntentQueueItem[]
+  summary: {
+    target: number
+    total_real_replies: number
+    reviewed_real: number
+    pending: number
+    unsure: number
+    skipped: number
+    remaining_to_gate: number
+  }
+  pagination: {
+    page: number
+    limit: number
+    total: number
+    totalPages: number
+  }
+  schema?: {
+    reviews_table_available: boolean
+  }
+}
+
+function intParam(value: string | null, fallback: number, min: number, max: number) {
+  const parsed = Number.parseInt(value || '', 10)
+  if (!Number.isFinite(parsed)) return fallback
+  return Math.max(min, Math.min(max, parsed))
+}
+
+function isMissingTableError(error: unknown) {
+  return Boolean(
+    error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      ((error as { code?: string }).code === '42P01' || (error as { code?: string }).code === 'PGRST205')
+  )
+}
+
+function summarize(items: ReplyIntentQueueItem[]) {
+  const reviewedReal = items.filter(
+    (item) => item.review_status === 'reviewed' && typeof item.human_scheduling_intent === 'boolean'
+  ).length
+  return {
+    target: MODEL_OPS_REPLY_INTENT_TARGET,
+    total_real_replies: items.length,
+    reviewed_real: reviewedReal,
+    pending: items.filter((item) => item.review_status === 'pending').length,
+    unsure: items.filter((item) => item.review_status === 'unsure').length,
+    skipped: items.filter((item) => item.review_status === 'skipped').length,
+    remaining_to_gate: Math.max(0, MODEL_OPS_REPLY_INTENT_TARGET - reviewedReal),
+  }
+}
+
+function filterItems(items: ReplyIntentQueueItem[], status: string, search: string) {
+  let filtered = items
+
+  if (status !== 'all') {
+    filtered = filtered.filter((item) => item.review_status === status)
+  }
+
+  const query = search.trim().toLowerCase()
+  if (query) {
+    filtered = filtered.filter((item) => {
+      const haystack = [
+        item.source_id,
+        item.source_hash,
+        item.channel,
+        item.outreach_status,
+        item.redacted_reply,
+      ]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase()
+      return haystack.includes(query)
+    })
+  }
+
+  return filtered
+}
+
+function mapQueueItems(sourceRows: OutreachReplySourceRow[], reviewRows: ReplyIntentReviewRow[]) {
+  const reviewsBySourceId = new Map(reviewRows.map((review) => [review.source_id, review]))
+  return sourceRows.map((source) => toReplyIntentQueueItem(source, reviewsBySourceId.get(source.id)))
+}
+
+export async function GET(request: NextRequest) {
+  const authResult = await verifyAdmin(request)
+  if (isAuthError(authResult)) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status })
+  }
+
+  if (!supabaseAdmin) {
+    return NextResponse.json({ error: 'Supabase admin client unavailable' }, { status: 500 })
+  }
+
+  try {
+    const { searchParams } = new URL(request.url)
+    const page = intParam(searchParams.get('page'), 1, 1, 1000)
+    const limit = intParam(searchParams.get('limit'), 25, 1, 100)
+    const status = normalizeReviewStatus(searchParams.get('status') || 'pending')
+    const normalizedStatus = searchParams.get('status') === 'all' ? 'all' : status
+    const search = searchParams.get('search') || ''
+
+    const [{ data: sourceRows, error: sourceError }, reviewResult] = await Promise.all([
+      supabaseAdmin
+        .from('outreach_queue')
+        .select('id,channel,sequence_step,status,replied_at,created_at,reply_content')
+        .not('reply_content', 'is', null)
+        .order('replied_at', { ascending: false, nullsFirst: false })
+        .limit(MAX_SOURCE_ROWS),
+      supabaseAdmin
+        .from('model_ops_reply_intent_reviews')
+        .select('*')
+        .eq('source_table', 'outreach_queue')
+        .order('reviewed_at', { ascending: false, nullsFirst: false })
+        .limit(MAX_SOURCE_ROWS),
+    ])
+
+    if (sourceError) {
+      if (isMissingTableError(sourceError)) {
+        return NextResponse.json({
+          available: false,
+          reason: 'Outreach queue schema has not been applied in this environment.',
+          items: [],
+          summary: summarize([]),
+          pagination: { page, limit, total: 0, totalPages: 0 },
+        })
+      }
+      console.error('Error fetching reply-intent source rows:', sourceError)
+      return NextResponse.json({ error: 'Failed to fetch outreach replies' }, { status: 500 })
+    }
+
+    const reviewsTableAvailable = !isMissingTableError(reviewResult.error)
+    if (reviewResult.error && reviewsTableAvailable) {
+      console.error('Error fetching reply-intent review rows:', reviewResult.error)
+      return NextResponse.json({ error: 'Failed to fetch reply-intent reviews' }, { status: 500 })
+    }
+
+    const allItems = mapQueueItems(
+      (sourceRows || []).filter((row: OutreachReplySourceRow) => String(row.reply_content || '').trim().length >= 8),
+      reviewsTableAvailable ? ((reviewResult.data || []) as ReplyIntentReviewRow[]) : []
+    )
+    const filtered = filterItems(allItems, normalizedStatus, search)
+    const offset = (page - 1) * limit
+    const items = filtered.slice(offset, offset + limit)
+
+    const response: QueueResponse = {
+      available: true,
+      items,
+      summary: summarize(allItems),
+      pagination: {
+        page,
+        limit,
+        total: filtered.length,
+        totalPages: Math.ceil(filtered.length / limit),
+      },
+      schema: {
+        reviews_table_available: reviewsTableAvailable,
+      },
+    }
+
+    return NextResponse.json(response)
+  } catch (error) {
+    console.error('Reply-intent review list error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const authResult = await verifyAdmin(request)
+  if (isAuthError(authResult)) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status })
+  }
+
+  if (!supabaseAdmin) {
+    return NextResponse.json({ error: 'Supabase admin client unavailable' }, { status: 500 })
+  }
+
+  try {
+    const body = await request.json()
+    const sourceId = typeof body?.source_id === 'string' ? body.source_id.trim() : ''
+    const reviewStatus = normalizeReviewStatus(body?.review_status)
+    const humanSchedulingIntent = body?.human_scheduling_intent
+    const notes = typeof body?.notes === 'string' ? body.notes : ''
+
+    if (!sourceId) {
+      return NextResponse.json({ error: 'source_id is required' }, { status: 400 })
+    }
+
+    if (reviewStatus === 'pending') {
+      return NextResponse.json({ error: 'review_status must be reviewed, unsure, or skipped' }, { status: 400 })
+    }
+
+    if (reviewStatus === 'reviewed' && typeof humanSchedulingIntent !== 'boolean') {
+      return NextResponse.json(
+        { error: 'human_scheduling_intent must be true or false when review_status is reviewed' },
+        { status: 400 }
+      )
+    }
+
+    const { data: source, error: sourceError } = await supabaseAdmin
+      .from('outreach_queue')
+      .select('id,channel,sequence_step,status,replied_at,created_at,reply_content')
+      .eq('id', sourceId)
+      .not('reply_content', 'is', null)
+      .maybeSingle()
+
+    if (sourceError) {
+      console.error('Error fetching reply-intent source row:', sourceError)
+      return NextResponse.json({ error: 'Failed to fetch outreach reply' }, { status: 500 })
+    }
+
+    if (!source || String((source as OutreachReplySourceRow).reply_content || '').trim().length < 8) {
+      return NextResponse.json({ error: 'Outreach reply not found' }, { status: 404 })
+    }
+
+    const payload = buildReviewUpsertPayload({
+      source: source as OutreachReplySourceRow,
+      reviewStatus,
+      humanSchedulingIntent: reviewStatus === 'reviewed' ? humanSchedulingIntent : null,
+      notes,
+      reviewedBy: authResult.user.id,
+    })
+
+    const { data: review, error: reviewError } = await supabaseAdmin
+      .from('model_ops_reply_intent_reviews')
+      .upsert(payload, { onConflict: 'source_table,source_id' })
+      .select()
+      .single()
+
+    if (reviewError) {
+      if (isMissingTableError(reviewError)) {
+        return NextResponse.json(
+          { error: 'Model Ops reply-intent review schema has not been applied in this environment.' },
+          { status: 503 }
+        )
+      }
+      console.error('Error saving reply-intent review:', reviewError)
+      return NextResponse.json({ error: 'Failed to save reply-intent review' }, { status: 500 })
+    }
+
+    return NextResponse.json({
+      review: toReplyIntentQueueItem(source as OutreachReplySourceRow, review as ReplyIntentReviewRow),
+    })
+  } catch (error) {
+    console.error('Reply-intent review save error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/components/admin/AdminSidebar.tsx
+++ b/components/admin/AdminSidebar.tsx
@@ -94,6 +94,7 @@ export const NAV_ITEM_ICONS: Record<string, LucideIcon> = {
   '/admin/continuity-plans': RefreshCw,
   '/admin/onboarding-templates': ClipboardList,
   '/admin/guarantees': ShieldCheck,
+  '/admin/model-ops/reply-intent-review': Brain,
   '/admin/chat-eval': MessageSquare,
   '/admin/chat-eval/queues': LayoutList,
   '/admin/chat-eval/alignment': BarChart3,

--- a/lib/admin-nav.ts
+++ b/lib/admin-nav.ts
@@ -62,6 +62,7 @@ export const ADMIN_NAV: { dashboard: AdminNavItem; categories: AdminNavCategory[
     {
       label: 'Quality & insights',
       items: [
+        { label: 'Model Ops', href: '/admin/model-ops/reply-intent-review' },
         { label: 'Chat Eval', href: '/admin/chat-eval' },
         { label: 'Analytics', href: '/admin/analytics' },
         { label: 'Cost & Revenue', href: '/admin/cost-revenue' },

--- a/lib/model-ops-reply-intent.test.ts
+++ b/lib/model-ops-reply-intent.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildReviewUpsertPayload,
+  redactReplyText,
+  stableHash,
+  suggestReplyIntentLabels,
+  toReplyIntentQueueItem,
+} from './model-ops-reply-intent'
+
+describe('model ops reply-intent helpers', () => {
+  it('redacts emails, phones, urls, and likely full names', () => {
+    const redacted = redactReplyText(
+      'Jane Carter can meet Tuesday. Email jane@example.com or call (404) 555-0101. https://example.com/book'
+    )
+
+    expect(redacted).toContain('[name:')
+    expect(redacted).toContain('[email:')
+    expect(redacted).toContain('[phone:')
+    expect(redacted).toContain('[url:example.com:')
+    expect(redacted).not.toContain('jane@example.com')
+    expect(redacted).not.toContain('(404) 555-0101')
+  })
+
+  it('suggests scheduling intent for meeting replies', () => {
+    expect(suggestReplyIntentLabels('Can we set up a time for a quick call next week?')).toMatchObject({
+      scheduling_intent: true,
+      interested: true,
+      not_interested: false,
+    })
+  })
+
+  it('maps a source row and persisted review into a queue item without raw text', () => {
+    const item = toReplyIntentQueueItem(
+      {
+        id: '11111111-1111-4111-8111-111111111111',
+        channel: 'email',
+        status: 'replied',
+        sequence_step: 2,
+        replied_at: '2026-05-24T10:00:00.000Z',
+        reply_content: 'Let us meet Friday.',
+      },
+      {
+        id: 'review-1',
+        source_table: 'outreach_queue',
+        source_id: '11111111-1111-4111-8111-111111111111',
+        source_hash: 'source-hash',
+        reply_hash: 'reply-hash',
+        redacted_reply: 'Let us meet Friday.',
+        suggested_labels: {
+          scheduling_intent: true,
+          interested: true,
+          not_interested: false,
+          ooo: false,
+          needs_followup: false,
+        },
+        review_status: 'reviewed',
+        human_scheduling_intent: true,
+      }
+    )
+
+    expect(item).toMatchObject({
+      source_hash: 'source-hash',
+      reply_hash: 'reply-hash',
+      review_status: 'reviewed',
+      human_scheduling_intent: true,
+      existing_review_id: 'review-1',
+    })
+  })
+
+  it('builds reviewed upsert payloads with null labels for unsure rows', () => {
+    const payload = buildReviewUpsertPayload({
+      source: {
+        id: '11111111-1111-4111-8111-111111111111',
+        reply_content: 'Not sure yet, follow up later.',
+      },
+      reviewStatus: 'unsure',
+      humanSchedulingIntent: true,
+      reviewedBy: 'admin-user',
+      reviewedAt: '2026-05-24T12:00:00.000Z',
+    })
+
+    expect(payload.human_scheduling_intent).toBeNull()
+    expect(payload.reviewed_by).toBe('admin-user')
+    expect(payload.source_hash).toBe(stableHash('11111111-1111-4111-8111-111111111111'))
+  })
+})

--- a/lib/model-ops-reply-intent.ts
+++ b/lib/model-ops-reply-intent.ts
@@ -1,0 +1,241 @@
+import crypto from 'node:crypto'
+
+export const MODEL_OPS_REPLY_INTENT_TARGET = 200
+
+export type ReplyIntentReviewStatus = 'pending' | 'reviewed' | 'unsure' | 'skipped'
+
+export type ReplyIntentSuggestedLabels = {
+  scheduling_intent: boolean
+  ooo: boolean
+  not_interested: boolean
+  interested: boolean
+  needs_followup: boolean
+}
+
+export type OutreachReplySourceRow = {
+  id: string
+  channel?: string | null
+  sequence_step?: number | null
+  status?: string | null
+  replied_at?: string | null
+  created_at?: string | null
+  reply_content?: string | null
+}
+
+export type ReplyIntentReviewRow = {
+  id?: string
+  source_table: 'outreach_queue'
+  source_id: string
+  source_hash: string
+  reply_hash: string
+  channel?: string | null
+  replied_at?: string | null
+  outreach_status?: string | null
+  sequence_step?: number | null
+  redacted_reply: string
+  suggested_labels: ReplyIntentSuggestedLabels
+  review_status: ReplyIntentReviewStatus
+  human_scheduling_intent?: boolean | null
+  notes?: string | null
+  reviewed_by?: string | null
+  reviewed_at?: string | null
+  created_at?: string | null
+  updated_at?: string | null
+}
+
+export type ReplyIntentQueueItem = {
+  source_id: string
+  source_table: 'outreach_queue'
+  source_hash: string
+  reply_hash: string
+  channel: string | null
+  replied_at: string | null
+  outreach_status: string | null
+  sequence_step: number | null
+  redacted_reply: string
+  suggested_labels: ReplyIntentSuggestedLabels
+  review_status: ReplyIntentReviewStatus
+  human_scheduling_intent: boolean | null
+  notes: string
+  reviewed_at: string | null
+  existing_review_id: string | null
+}
+
+const NAME_PATTERN = /\b[A-Z][a-z]+ [A-Z][a-z]+\b/g
+const EMAIL_PATTERN = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi
+const PHONE_PATTERN = /\b(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b/g
+const URL_PATTERN = /https?:\/\/[^\s"'<>]+/gi
+
+const SCHEDULING_PATTERNS = [
+  /\bscheduled zoom\b/,
+  /\bzoom meeting\b/,
+  /\bzoom invite\b/,
+  /\bcalendar\b/,
+  /\bcalendly\b/,
+  /\bbook a call\b/,
+  /\bschedule\b/,
+  /\bavailable\b/,
+  /\bavailability\b/,
+  /\bmeet with\b/,
+  /\bcan your team meet\b/,
+  /\bwant to meet\b/,
+  /\bmeeting\b/,
+  /\bdiscovery call\b/,
+  /\bshort call\b/,
+  /\bquick call\b/,
+  /\bset up a time\b/,
+  /\bsend (me )?(a few )?times\b/,
+  /\btimes that work\b/,
+  /\blet'?s chat\b/,
+  /\blet'?s talk\b/,
+  /\bfree this week\b/,
+  /\bwhat time\b/,
+  /\bmove this to\b/,
+  /\bput something on the calendar\b/,
+]
+
+const OUT_OF_OFFICE_PHRASES = [
+  'out of office',
+  'ooo',
+  'on vacation',
+  'annual leave',
+  'away from the office',
+  'traveling until',
+  'unavailable until',
+  'back on',
+]
+
+const NOT_INTERESTED_PHRASES = [
+  'not interested',
+  'unsubscribe',
+  'remove me',
+  'no thanks',
+  'not a fit',
+  'stop emailing',
+]
+
+const FOLLOW_UP_PHRASES = [
+  "i'll get back",
+  'i will get back',
+  'on my list',
+  'circle back',
+  'review this',
+  'reconnect after',
+  'follow up later',
+  'respond when i return',
+]
+
+export function stableHash(value: unknown) {
+  return crypto.createHash('sha256').update(String(value || '')).digest('hex').slice(0, 12)
+}
+
+export function redactReplyText(value: unknown) {
+  let out = String(value || '')
+  out = out.replace(EMAIL_PATTERN, (match) => `[email:${stableHash(match.toLowerCase())}]`)
+  out = out.replace(URL_PATTERN, (match) => {
+    try {
+      const url = new URL(match)
+      return `[url:${url.hostname}:${stableHash(match)}]`
+    } catch {
+      return `[url:${stableHash(match)}]`
+    }
+  })
+  out = out.replace(PHONE_PATTERN, (match) => `[phone:${stableHash(match)}]`)
+  out = out.replace(NAME_PATTERN, (match) => `[name:${stableHash(match)}]`)
+  return out.replace(/\s+/g, ' ').trim()
+}
+
+export function suggestReplyIntentLabels(text: unknown): ReplyIntentSuggestedLabels {
+  const raw = String(text || '')
+  const lower = raw.toLowerCase()
+  const schedulingIntent = SCHEDULING_PATTERNS.some((pattern) => pattern.test(lower))
+  const ooo = OUT_OF_OFFICE_PHRASES.some((phrase) => lower.includes(phrase))
+  const notInterested = NOT_INTERESTED_PHRASES.some((phrase) => lower.includes(phrase))
+  const genericFollowup = FOLLOW_UP_PHRASES.some((phrase) => lower.includes(phrase))
+
+  return {
+    scheduling_intent: schedulingIntent,
+    ooo,
+    not_interested: notInterested,
+    interested: schedulingIntent || (/\b(interested|sounds good|tell me more)\b/i.test(raw) && !notInterested),
+    needs_followup: genericFollowup && !schedulingIntent && !notInterested,
+  }
+}
+
+export function normalizeReviewStatus(value: unknown): ReplyIntentReviewStatus {
+  if (value === 'reviewed' || value === 'unsure' || value === 'skipped') return value
+  return 'pending'
+}
+
+export function toReplyIntentQueueItem(
+  source: OutreachReplySourceRow,
+  review?: Partial<ReplyIntentReviewRow> | null
+): ReplyIntentQueueItem {
+  const redactedReply = review?.redacted_reply || redactReplyText(source.reply_content)
+  const suggestedLabels = normalizeSuggestedLabels(review?.suggested_labels, suggestReplyIntentLabels(redactedReply))
+
+  return {
+    source_id: source.id,
+    source_table: 'outreach_queue',
+    source_hash: review?.source_hash || stableHash(source.id),
+    reply_hash: review?.reply_hash || stableHash(source.reply_content || redactedReply),
+    channel: source.channel ?? review?.channel ?? null,
+    replied_at: source.replied_at ?? review?.replied_at ?? source.created_at ?? null,
+    outreach_status: source.status ?? review?.outreach_status ?? null,
+    sequence_step: source.sequence_step ?? review?.sequence_step ?? null,
+    redacted_reply: redactedReply,
+    suggested_labels: suggestedLabels,
+    review_status: normalizeReviewStatus(review?.review_status),
+    human_scheduling_intent:
+      typeof review?.human_scheduling_intent === 'boolean' ? review.human_scheduling_intent : null,
+    notes: typeof review?.notes === 'string' ? review.notes : '',
+    reviewed_at: review?.reviewed_at ?? null,
+    existing_review_id: review?.id ?? null,
+  }
+}
+
+export function buildReviewUpsertPayload(args: {
+  source: OutreachReplySourceRow
+  reviewStatus: ReplyIntentReviewStatus
+  humanSchedulingIntent: boolean | null
+  notes?: string | null
+  reviewedBy: string
+  reviewedAt?: string
+}) {
+  const redactedReply = redactReplyText(args.source.reply_content)
+  const reviewedAt = args.reviewedAt || new Date().toISOString()
+  const isReviewed = args.reviewStatus === 'reviewed'
+
+  return {
+    source_table: 'outreach_queue' as const,
+    source_id: args.source.id,
+    source_hash: stableHash(args.source.id),
+    reply_hash: stableHash(args.source.reply_content || redactedReply),
+    channel: args.source.channel ?? null,
+    replied_at: args.source.replied_at ?? args.source.created_at ?? null,
+    outreach_status: args.source.status ?? null,
+    sequence_step: args.source.sequence_step ?? null,
+    redacted_reply: redactedReply,
+    suggested_labels: suggestReplyIntentLabels(redactedReply),
+    review_status: args.reviewStatus,
+    human_scheduling_intent: isReviewed ? args.humanSchedulingIntent : null,
+    notes: typeof args.notes === 'string' ? args.notes.slice(0, 2000) : '',
+    reviewed_by: args.reviewedBy,
+    reviewed_at: reviewedAt,
+  }
+}
+
+export function normalizeSuggestedLabels(
+  value: unknown,
+  fallback: ReplyIntentSuggestedLabels = suggestReplyIntentLabels('')
+): ReplyIntentSuggestedLabels {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return fallback
+  const record = value as Record<string, unknown>
+  return {
+    scheduling_intent: Boolean(record.scheduling_intent),
+    ooo: Boolean(record.ooo),
+    not_interested: Boolean(record.not_interested),
+    interested: Boolean(record.interested),
+    needs_followup: Boolean(record.needs_followup),
+  }
+}

--- a/migrations/2026_05_24_model_ops_reply_intent_reviews.sql
+++ b/migrations/2026_05_24_model_ops_reply_intent_reviews.sql
@@ -1,0 +1,80 @@
+-- Model Ops reply-intent review ledger.
+-- Stores sanitized labels for real outreach replies. Raw reply content remains
+-- in outreach_queue and is not duplicated here.
+
+CREATE TABLE IF NOT EXISTS public.model_ops_reply_intent_reviews (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  source_table TEXT NOT NULL DEFAULT 'outreach_queue'
+    CHECK (source_table = 'outreach_queue'),
+  source_id UUID NOT NULL,
+  source_hash TEXT NOT NULL,
+  reply_hash TEXT NOT NULL,
+  channel TEXT,
+  replied_at TIMESTAMPTZ,
+  outreach_status TEXT,
+  sequence_step INTEGER,
+  redacted_reply TEXT NOT NULL,
+  suggested_labels JSONB NOT NULL DEFAULT '{}'::jsonb,
+  review_status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (review_status IN ('pending', 'reviewed', 'unsure', 'skipped')),
+  human_scheduling_intent BOOLEAN,
+  notes TEXT,
+  reviewed_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  reviewed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT model_ops_reply_intent_reviews_unique_source
+    UNIQUE (source_table, source_id),
+  CONSTRAINT model_ops_reply_intent_reviews_reviewed_label_check
+    CHECK (review_status <> 'reviewed' OR human_scheduling_intent IS NOT NULL)
+);
+
+CREATE INDEX IF NOT EXISTS idx_model_ops_reply_intent_reviews_status
+ON public.model_ops_reply_intent_reviews(review_status, reviewed_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_model_ops_reply_intent_reviews_source
+ON public.model_ops_reply_intent_reviews(source_table, source_id);
+
+CREATE INDEX IF NOT EXISTS idx_model_ops_reply_intent_reviews_reply_hash
+ON public.model_ops_reply_intent_reviews(reply_hash);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.model_ops_reply_intent_reviews TO service_role;
+
+ALTER TABLE public.model_ops_reply_intent_reviews ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Admins can manage model ops reply intent reviews"
+ON public.model_ops_reply_intent_reviews;
+CREATE POLICY "Admins can manage model ops reply intent reviews"
+  ON public.model_ops_reply_intent_reviews FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.user_profiles
+      WHERE id = auth.uid() AND role = 'admin'
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.user_profiles
+      WHERE id = auth.uid() AND role = 'admin'
+    )
+  );
+
+DROP POLICY IF EXISTS "Service role can manage model ops reply intent reviews"
+ON public.model_ops_reply_intent_reviews;
+CREATE POLICY "Service role can manage model ops reply intent reviews"
+  ON public.model_ops_reply_intent_reviews FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+DROP TRIGGER IF EXISTS model_ops_reply_intent_reviews_updated_at
+ON public.model_ops_reply_intent_reviews;
+CREATE TRIGGER model_ops_reply_intent_reviews_updated_at
+  BEFORE UPDATE ON public.model_ops_reply_intent_reviews
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_cold_pipeline_updated_at();
+
+COMMENT ON TABLE public.model_ops_reply_intent_reviews
+IS 'Sanitized human review ledger for Model Ops reply-intent evaluation labels.';
+
+COMMENT ON COLUMN public.model_ops_reply_intent_reviews.redacted_reply
+IS 'PII-redacted reply text used for admin review and benchmark export. Raw reply content stays in outreach_queue.';

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "banned-books:report": "tsx scripts/banned-books-corpus-report.ts",
     "model-ops:snapshot": "tsx scripts/sync-model-ops-snapshot.ts",
     "model-ops:snapshot:check": "tsx scripts/sync-model-ops-snapshot.ts --check",
+    "model-ops:reply-intent:export": "tsx scripts/export-reply-intent-reviews.ts",
     "model-ops:research:plan": "tsx scripts/model-ops-research-plan.ts",
     "open-brain:mcp": "tsx scripts/open-brain-mcp-server.ts",
     "wrm:smoke-gate": "tsx scripts/wrm-production-smoke-gate.ts",

--- a/scripts/export-reply-intent-reviews.test.ts
+++ b/scripts/export-reply-intent-reviews.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { parseArgs, toJsonlExample } from './export-reply-intent-reviews'
+
+describe('export reply-intent reviews script', () => {
+  it('parses export options', () => {
+    expect(parseArgs(['--output', '/tmp/replies.jsonl', '--limit', '25', '--env-file', '.env.test'])).toMatchObject({
+      output: '/tmp/replies.jsonl',
+      limit: 25,
+      envFile: '.env.test',
+    })
+  })
+
+  it('exports reviewed rows in sanitized benchmark JSONL shape', () => {
+    const example = toJsonlExample({
+      source_table: 'outreach_queue',
+      source_id: '11111111-1111-4111-8111-111111111111',
+      source_hash: 'source-hash',
+      reply_hash: 'reply-hash',
+      channel: 'email',
+      sequence_step: 1,
+      redacted_reply: 'Can we schedule next week?',
+      suggested_labels: {
+        scheduling_intent: true,
+        interested: true,
+        not_interested: false,
+        ooo: false,
+        needs_followup: false,
+      },
+      review_status: 'reviewed',
+      human_scheduling_intent: true,
+      notes: 'confirmed',
+      reviewed_at: '2026-05-24T12:00:00.000Z',
+    })
+
+    expect(example).toMatchObject({
+      source: 'portfolio_model_ops_reply_intent_reviews',
+      source_ref: {
+        table: 'outreach_queue',
+        row_hash: 'source-hash',
+        reply_hash: 'reply-hash',
+      },
+      text_redacted: 'Can we schedule next week?',
+      review: {
+        scheduling_intent: true,
+        notes: 'confirmed',
+      },
+    })
+    expect(JSON.stringify(example)).not.toContain('11111111-1111-4111-8111-111111111111')
+  })
+})

--- a/scripts/export-reply-intent-reviews.ts
+++ b/scripts/export-reply-intent-reviews.ts
@@ -1,0 +1,153 @@
+#!/usr/bin/env tsx
+import { mkdir, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { createClient } from '@supabase/supabase-js'
+import { config as loadDotenv } from 'dotenv'
+import { normalizeSuggestedLabels, stableHash, type ReplyIntentReviewRow } from '../lib/model-ops-reply-intent'
+
+const DEFAULT_OUTPUT =
+  '/Users/vambahsillah/Documents/Codex/2026-04-29/hey-can-you-confirm-that-i/eval-data/reply-intent-review/sources/portfolio-model-ops-reviewed-replies.jsonl'
+
+type ExportOptions = {
+  output: string
+  limit: number
+  envFile: string
+}
+
+type ReviewedRow = ReplyIntentReviewRow & {
+  human_scheduling_intent: boolean
+  reviewed_at: string
+}
+
+export function parseArgs(argv: string[]): ExportOptions {
+  const options: ExportOptions = {
+    output: process.env.MODEL_OPS_REPLY_INTENT_EXPORT || DEFAULT_OUTPUT,
+    limit: Number.parseInt(process.env.MODEL_OPS_REPLY_INTENT_EXPORT_LIMIT || '1000', 10),
+    envFile: '.env.local',
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    const next = argv[index + 1]
+
+    if (arg === '--output' && next) {
+      options.output = next
+      index += 1
+    } else if (arg === '--limit' && next) {
+      options.limit = Math.max(1, Number.parseInt(next, 10))
+      index += 1
+    } else if (arg === '--env-file' && next) {
+      options.envFile = next
+      index += 1
+    } else if (arg === '--help' || arg === '-h') {
+      printHelp()
+      process.exit(0)
+    } else {
+      throw new Error(`Unknown option: ${arg}`)
+    }
+  }
+
+  if (!Number.isFinite(options.limit) || options.limit < 1) options.limit = 1000
+  return options
+}
+
+export function toJsonlExample(row: ReviewedRow) {
+  return {
+    id: `portfolio-model-ops:${stableHash(`${row.source_table}:${row.source_id}`)}`,
+    source: 'portfolio_model_ops_reply_intent_reviews',
+    source_ref: {
+      table: row.source_table,
+      row_hash: row.source_hash,
+      reply_hash: row.reply_hash,
+      reviewed_at: row.reviewed_at,
+      channel: row.channel || null,
+      sequence_step: row.sequence_step ?? null,
+    },
+    text_redacted: row.redacted_reply,
+    suggested_labels: normalizeSuggestedLabels(row.suggested_labels),
+    review: {
+      scheduling_intent: row.human_scheduling_intent,
+      interested: '',
+      not_interested: '',
+      ooo: '',
+      needs_followup: '',
+      notes: row.notes || '',
+    },
+  }
+}
+
+export async function exportReplyIntentReviews(options: ExportOptions) {
+  loadDotenv({ path: path.resolve(process.cwd(), options.envFile), override: false })
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.PROD_SUPABASE_SERVICE_ROLE_KEY
+
+  if (!url || !key || /YOUR_|your-|your_/i.test(`${url} ${key}`)) {
+    await mkdir(path.dirname(path.resolve(options.output)), { recursive: true })
+    await writeFile(path.resolve(options.output), '', 'utf8')
+    return {
+      ok: true,
+      skipped: true,
+      reason: 'No usable Supabase URL/service role key found.',
+      output: path.resolve(options.output),
+      count: 0,
+    }
+  }
+
+  const supabase = createClient(url, key, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+    global: {
+      headers: {
+        Authorization: `Bearer ${key}`,
+      },
+    },
+  })
+
+  const { data, error } = await supabase
+    .from('model_ops_reply_intent_reviews')
+    .select('*')
+    .eq('source_table', 'outreach_queue')
+    .eq('review_status', 'reviewed')
+    .not('human_scheduling_intent', 'is', null)
+    .order('reviewed_at', { ascending: false, nullsFirst: false })
+    .limit(options.limit)
+
+  if (error) {
+    throw new Error(`Failed to export reply-intent reviews: ${error.message}`)
+  }
+
+  const examples = ((data || []) as ReviewedRow[]).map(toJsonlExample)
+  const output = path.resolve(options.output)
+  await mkdir(path.dirname(output), { recursive: true })
+  await writeFile(output, examples.map((item) => JSON.stringify(item)).join('\n') + (examples.length ? '\n' : ''), 'utf8')
+
+  return {
+    ok: true,
+    skipped: false,
+    output,
+    count: examples.length,
+  }
+}
+
+function printHelp() {
+  console.log(`Usage:
+  npm run model-ops:reply-intent:export -- [options]
+
+Options:
+  --output <path>     JSONL output path.
+  --limit <number>    Maximum reviewed rows to export.
+  --env-file <path>   Environment file to load before querying Supabase.
+`)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  exportReplyIntentReviews(parseArgs(process.argv.slice(2)))
+    .then((result) => console.log(JSON.stringify(result, null, 2)))
+    .catch((error) => {
+      console.error(error instanceof Error ? error.message : error)
+      process.exit(1)
+    })
+}


### PR DESCRIPTION
## Summary
- Adds an admin Model Ops reply-intent review queue at `/admin/model-ops/reply-intent-review` for real `outreach_queue.reply_content` examples.
- Adds an admin-only Supabase review ledger migration for sanitized labels without duplicating raw reply content.
- Adds admin APIs for listing, saving, and bulk accepting suggested reply-intent labels.
- Adds `npm run model-ops:reply-intent:export` to export reviewed, sanitized JSONL examples for the local benchmark monitor.

## Safety / Governance
- No production model routing, n8n logic, hosted flags, secrets, or default model settings changed.
- Skipped/unsure rows store null `human_scheduling_intent` and do not count toward the 200-example gate.
- Raw reply content remains in `outreach_queue`; the new ledger stores redacted text and hashes.

## Validation
- `npm run test -- lib/model-ops-reply-intent.test.ts app/api/admin/model-ops/reply-intent-reviews/route.test.ts app/api/admin/model-ops/reply-intent-reviews/bulk/route.test.ts app/admin/model-ops/reply-intent-review/page.test.tsx scripts/export-reply-intent-reviews.test.ts`
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build` (passes after linking `.env.local`; emits existing dev env warnings about `MOCK_N8N=false` / `N8N_DISABLE_OUTBOUND=false`)
- Local route smoke: `curl -I http://localhost:3024/admin/model-ops/reply-intent-review` returned `200 OK`; unauthenticated API smoke returned `401`.

## Follow-up after merge
- Apply the Supabase migration before using the save/bulk actions in production.
- Review real inbound/outreach replies in Portfolio until the Model Ops 200-real-example gate is met.
- Use the export script from the benchmark monitor run to refresh sanitized reviewed examples.
