### PR TITLE
Expand banned books corpus outreach readiness

### DIFF
--- a/app/admin/source-protocol/page.test.tsx
+++ b/app/admin/source-protocol/page.test.tsx
@@ -64,7 +64,7 @@ const overview = {
   disputes: [],
   modelReviews: [],
   bannedBooksCorpus: {
-    generatedAt: '2026-05-12T00:00:00.000Z',
+    generatedAt: '2026-05-24T00:00:00.000Z',
     scope: 'U.S. school and library bans/challenges first.',
     licenseModel: 'RAG only.',
     sourceSpine: [
@@ -86,12 +86,45 @@ const overview = {
     summary: {
       stagedRecords: 1,
       sourceSpineCount: 1,
+      outreachPacketCount: 3,
       rightsReadyRecords: 1,
       outreachReadyRecords: 1,
       activeLicenseRecords: 0,
       retrievableRecords: 0,
       blockedRecords: 0,
     },
+    outreachPackets: [
+      {
+        key: 'author_direct_rag_permission',
+        audience: 'author',
+        subject: 'Permission request: rights-cleared retrieval for your challenged work',
+        purpose: 'Ask the author for RAG-only participation.',
+        permissionAsk: ['Allow retrieval and citation.'],
+        guardrails: ['No fine-tuning in v1.'],
+        approvalGate: 'Human approval required before sending.',
+        followUpCadenceDays: [7, 21, 45],
+      },
+      {
+        key: 'publisher_permissions_rag_license',
+        audience: 'publisher',
+        subject: 'Permissions inquiry: RAG-only access license for challenged-title preservation',
+        purpose: 'Ask publisher permissions staff to confirm rights path.',
+        permissionAsk: ['Confirm digital excerpt rights.'],
+        guardrails: ['No production retrieval before active grant.'],
+        approvalGate: 'Governance review required.',
+        followUpCadenceDays: [10, 30, 60],
+      },
+      {
+        key: 'estate_permissions_rag_license',
+        audience: 'estate',
+        subject: 'Estate permissions inquiry: preserving access with revocable RAG-only use',
+        purpose: 'Ask the estate for cautious permission.',
+        permissionAsk: ['Confirm estate authority.'],
+        guardrails: ['Chain of title required.'],
+        approvalGate: 'Shaka governance review required.',
+        followUpCadenceDays: [14, 45, 90],
+      },
+    ],
     records: [
       {
         id: 'demo-book',
@@ -131,6 +164,7 @@ describe('SourceProtocolPage', () => {
     expect(await screen.findByRole('heading', { name: 'Source Protocol' })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: 'Banned Books Rights-Ready Corpus' })).toBeInTheDocument()
     expect(screen.getByText('Amina, Source Registry Lead')).toBeInTheDocument()
+    expect(screen.getByText('Permission request: rights-cleared retrieval for your challenged work')).toBeInTheDocument()
     expect(screen.getByText('Demo Challenged Book')).toBeInTheDocument()
 
     fireEvent.click(screen.getAllByRole('button', { name: /Portal Access/i })[0])

--- a/app/admin/source-protocol/page.tsx
+++ b/app/admin/source-protocol/page.tsx
@@ -49,9 +49,11 @@ type SourceProtocolOverview = {
     licenseModel: string
     sourceSpine: any[]
     swarmAgents: any[]
+    outreachPackets: any[]
     summary: {
       stagedRecords: number
       sourceSpineCount: number
+      outreachPacketCount: number
       rightsReadyRecords: number
       outreachReadyRecords: number
       activeLicenseRecords: number
@@ -622,12 +624,13 @@ function BannedBooksCorpusPanel({ corpus }: { corpus: SourceProtocolOverview['ba
           </div>
         </div>
 
-        <div className="grid grid-cols-2 gap-3 lg:grid-cols-6">
+        <div className="grid grid-cols-2 gap-3 lg:grid-cols-4 xl:grid-cols-7">
           <Stat icon={<FileText size={18} />} label="Staged" value={corpus.summary.stagedRecords} />
           <Stat icon={<Database size={18} />} label="Sources" value={corpus.summary.sourceSpineCount} />
           <Stat icon={<ShieldCheck size={18} />} label="Rights-ready" value={corpus.summary.rightsReadyRecords} />
           <Stat icon={<Users size={18} />} label="Outreach-ready" value={corpus.summary.outreachReadyRecords} />
           <Stat icon={<CircleDollarSign size={18} />} label="Active licenses" value={corpus.summary.activeLicenseRecords} />
+          <Stat icon={<Users size={18} />} label="Packets" value={corpus.summary.outreachPacketCount} />
           <Stat icon={<BookOpenCheck size={18} />} label="Retrievable" value={corpus.summary.retrievableRecords} />
         </div>
       </section>
@@ -660,6 +663,34 @@ function BannedBooksCorpusPanel({ corpus }: { corpus: SourceProtocolOverview['ba
               <div className="text-muted-foreground">{agent.output}</div>
               <div className="text-muted-foreground">{agent.boundary}</div>
               <div className="text-muted-foreground">{agent.approvalGate}</div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-lg border border-silicon-slate">
+        <div className="bg-silicon-slate/60 px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Permission packet templates
+        </div>
+        <div className="divide-y divide-silicon-slate">
+          {corpus.outreachPackets.map((packet) => (
+            <div key={packet.key} className="grid grid-cols-1 gap-3 px-4 py-4 text-sm lg:grid-cols-4 lg:gap-4">
+              <div>
+                <p className="font-medium text-foreground">{packet.subject}</p>
+                <p className="font-mono text-xs text-muted-foreground">{packet.key}</p>
+              </div>
+              <div className="text-muted-foreground">
+                <p className="font-medium text-foreground">{packet.audience}</p>
+                <p>{packet.purpose}</p>
+              </div>
+              <div className="text-muted-foreground">
+                <p>Ask: {list(packet.permissionAsk)}</p>
+                <p className="mt-2">Follow-up days: {list(packet.followUpCadenceDays)}</p>
+              </div>
+              <div className="text-muted-foreground">
+                <p>{packet.approvalGate}</p>
+                <p className="mt-2">Guardrails: {list(packet.guardrails)}</p>
+              </div>
             </div>
           ))}
         </div>

--- a/app/api/admin/source-protocol/overview/route.test.ts
+++ b/app/api/admin/source-protocol/overview/route.test.ts
@@ -195,9 +195,15 @@ describe('GET /api/admin/source-protocol/overview', () => {
       bannedBooksCorpus: {
         summary: {
           stagedRecords: expect.any(Number),
+          outreachPacketCount: 3,
           rightsReadyRecords: expect.any(Number),
           retrievableRecords: 0,
         },
+        outreachPackets: expect.arrayContaining([
+          expect.objectContaining({ key: 'author_direct_rag_permission' }),
+          expect.objectContaining({ key: 'publisher_permissions_rag_license' }),
+          expect.objectContaining({ key: 'estate_permissions_rag_license' }),
+        ]),
         swarmAgents: expect.arrayContaining([
           expect.objectContaining({ key: 'banned-book-source-registry' }),
           expect.objectContaining({ key: 'rights-governance-review' }),

--- a/data/source-protocol/banned-books-rights-ready-corpus.json
+++ b/data/source-protocol/banned-books-rights-ready-corpus.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-12T00:00:00.000Z",
+  "generatedAt": "2026-05-24T00:00:00.000Z",
   "scope": "U.S. school and library bans/challenges first; rights-ready shortlist before maximum title volume.",
   "licenseModel": "RAG only: retrieval, citation, summarization, educational use, optional commercial use, limited excerpt allowance, revocation, payout participation; fine-tuning excluded for v1.",
   "sourceSpine": [
@@ -216,6 +216,360 @@
       "chainOfTitleStatus": "unknown",
       "sensitivityFlags": ["sexual_content", "substance_use"],
       "notes": "Include in outreach sequencing after rights-holder contact verification."
+    },
+    {
+      "id": "the-perks-of-being-a-wallflower-stephen-chbosky",
+      "canonicalTitle": "The Perks of Being a Wallflower",
+      "authors": ["Stephen Chbosky"],
+      "editionAliases": [],
+      "isbnCandidates": [],
+      "banStatus": "challenged",
+      "jurisdictionContext": "U.S. libraries and schools; ALA 2025 Most Challenged Books list.",
+      "affectedAudience": "K-12 students and public library patrons",
+      "evidence": [
+        {
+          "sourceName": "ALA Most Challenged Books",
+          "sourceUrl": "https://www.ala.org/bbooks/frequentlychallengedbooks/top10",
+          "evidenceType": "challenge_list",
+          "note": "Included in ALA's 2025 Most Challenged Books page."
+        }
+      ],
+      "rightsholderCandidate": {
+        "name": "Stephen Chbosky or publisher/agent",
+        "type": "author",
+        "contactPath": "Author/publisher permissions inquiry",
+        "confidence": "medium"
+      },
+      "outreachStatus": "not_started",
+      "licenseStatus": "not_requested",
+      "ingestionStatus": "not_started",
+      "chainOfTitleStatus": "unknown",
+      "sensitivityFlags": ["sexual_content", "substance_use", "mental_health"],
+      "notes": "High-priority rights mapping candidate because it recurs across challenged-book lists."
+    },
+    {
+      "id": "empire-of-storms-sarah-j-maas",
+      "canonicalTitle": "Empire of Storms",
+      "authors": ["Sarah J. Maas"],
+      "editionAliases": ["Throne of Glass: Empire of Storms"],
+      "isbnCandidates": [],
+      "banStatus": "challenged",
+      "jurisdictionContext": "U.S. libraries and schools; ALA 2025 Most Challenged Books list.",
+      "affectedAudience": "K-12 students and public library patrons",
+      "evidence": [
+        {
+          "sourceName": "ALA Most Challenged Books",
+          "sourceUrl": "https://www.ala.org/bbooks/frequentlychallengedbooks/top10",
+          "evidenceType": "challenge_list",
+          "note": "Included in ALA's 2025 Most Challenged Books page."
+        }
+      ],
+      "rightsholderCandidate": {
+        "name": "Sarah J. Maas or publisher/agent",
+        "type": "author",
+        "contactPath": "Author/publisher permissions inquiry",
+        "confidence": "medium"
+      },
+      "outreachStatus": "not_started",
+      "licenseStatus": "not_requested",
+      "ingestionStatus": "not_started",
+      "chainOfTitleStatus": "unknown",
+      "sensitivityFlags": ["sexual_content", "fantasy_violence"],
+      "notes": "Series relationship requires edition and rights-holder normalization before outreach."
+    },
+    {
+      "id": "tricks-ellen-hopkins",
+      "canonicalTitle": "Tricks",
+      "authors": ["Ellen Hopkins"],
+      "editionAliases": [],
+      "isbnCandidates": [],
+      "banStatus": "challenged",
+      "jurisdictionContext": "U.S. libraries and schools; ALA 2025 Most Challenged Books list.",
+      "affectedAudience": "K-12 students and public library patrons",
+      "evidence": [
+        {
+          "sourceName": "ALA Most Challenged Books",
+          "sourceUrl": "https://www.ala.org/bbooks/frequentlychallengedbooks/top10",
+          "evidenceType": "challenge_list",
+          "note": "Included in ALA's 2025 Most Challenged Books page."
+        }
+      ],
+      "rightsholderCandidate": {
+        "name": "Ellen Hopkins or publisher/agent",
+        "type": "author",
+        "contactPath": "Author/publisher permissions inquiry",
+        "confidence": "medium"
+      },
+      "outreachStatus": "not_started",
+      "licenseStatus": "not_requested",
+      "ingestionStatus": "not_started",
+      "chainOfTitleStatus": "unknown",
+      "sensitivityFlags": ["sexual_content", "substance_use", "sexual_exploitation"],
+      "notes": "Sensitive subject matter requires strong excerpt limits and blocked-use language."
+    },
+    {
+      "id": "a-court-of-thorns-and-roses-sarah-j-maas",
+      "canonicalTitle": "A Court of Thorns and Roses",
+      "authors": ["Sarah J. Maas"],
+      "editionAliases": ["ACOTAR"],
+      "isbnCandidates": [],
+      "banStatus": "challenged",
+      "jurisdictionContext": "U.S. libraries and schools; ALA 2025 Most Challenged Books list.",
+      "affectedAudience": "K-12 students and public library patrons",
+      "evidence": [
+        {
+          "sourceName": "ALA Most Challenged Books",
+          "sourceUrl": "https://www.ala.org/bbooks/frequentlychallengedbooks/top10",
+          "evidenceType": "challenge_list",
+          "note": "Included in ALA's 2025 Most Challenged Books page."
+        },
+        {
+          "sourceName": "PEN America Index of School Book Bans",
+          "sourceUrl": "https://pen.org/book-bans/pen-america-index-of-school-book-bans-2024-2025/",
+          "evidenceType": "school_ban_index",
+          "note": "Use PEN index enrichment to confirm district-level evidence before outreach."
+        }
+      ],
+      "rightsholderCandidate": {
+        "name": "Sarah J. Maas or publisher/agent",
+        "type": "author",
+        "contactPath": "Author/publisher permissions inquiry",
+        "confidence": "medium"
+      },
+      "outreachStatus": "not_started",
+      "licenseStatus": "not_requested",
+      "ingestionStatus": "not_started",
+      "chainOfTitleStatus": "unknown",
+      "sensitivityFlags": ["sexual_content", "fantasy_violence"],
+      "notes": "Series-level permissions may need publisher coordination rather than title-by-title author outreach."
+    },
+    {
+      "id": "a-clockwork-orange-anthony-burgess",
+      "canonicalTitle": "A Clockwork Orange",
+      "authors": ["Anthony Burgess"],
+      "editionAliases": [],
+      "isbnCandidates": [],
+      "banStatus": "challenged",
+      "jurisdictionContext": "U.S. libraries and schools; ALA 2025 Most Challenged Books list and PEN 2024-2025 ban-index context.",
+      "affectedAudience": "K-12 students and public library patrons",
+      "evidence": [
+        {
+          "sourceName": "ALA Most Challenged Books",
+          "sourceUrl": "https://www.ala.org/bbooks/frequentlychallengedbooks/top10",
+          "evidenceType": "challenge_list",
+          "note": "Included in ALA's 2025 Most Challenged Books page."
+        },
+        {
+          "sourceName": "PEN America Index of School Book Bans",
+          "sourceUrl": "https://pen.org/book-bans/pen-america-index-of-school-book-bans-2024-2025/",
+          "evidenceType": "school_ban_index",
+          "note": "Use PEN index enrichment to confirm district-level evidence before outreach."
+        }
+      ],
+      "rightsholderCandidate": {
+        "name": "Anthony Burgess estate or publisher",
+        "type": "estate",
+        "contactPath": "Estate/publisher permissions inquiry",
+        "confidence": "medium"
+      },
+      "outreachStatus": "not_started",
+      "licenseStatus": "not_requested",
+      "ingestionStatus": "not_started",
+      "chainOfTitleStatus": "unknown",
+      "sensitivityFlags": ["sexual_violence", "violence"],
+      "notes": "Estate-controlled rights path should be reviewed by governance before any creator-facing packet is sent."
+    },
+    {
+      "id": "identical-ellen-hopkins",
+      "canonicalTitle": "Identical",
+      "authors": ["Ellen Hopkins"],
+      "editionAliases": [],
+      "isbnCandidates": [],
+      "banStatus": "challenged",
+      "jurisdictionContext": "U.S. libraries and schools; ALA 2025 Most Challenged Books list.",
+      "affectedAudience": "K-12 students and public library patrons",
+      "evidence": [
+        {
+          "sourceName": "ALA Most Challenged Books",
+          "sourceUrl": "https://www.ala.org/bbooks/frequentlychallengedbooks/top10",
+          "evidenceType": "challenge_list",
+          "note": "Included in ALA's 2025 Most Challenged Books page."
+        }
+      ],
+      "rightsholderCandidate": {
+        "name": "Ellen Hopkins or publisher/agent",
+        "type": "author",
+        "contactPath": "Author/publisher permissions inquiry",
+        "confidence": "medium"
+      },
+      "outreachStatus": "not_started",
+      "licenseStatus": "not_requested",
+      "ingestionStatus": "not_started",
+      "chainOfTitleStatus": "unknown",
+      "sensitivityFlags": ["sexual_abuse", "minors", "trauma"],
+      "notes": "Hold for sensitivity review language before outreach packet approval."
+    },
+    {
+      "id": "storm-and-fury-jennifer-l-armentrout",
+      "canonicalTitle": "Storm and Fury",
+      "authors": ["Jennifer L. Armentrout"],
+      "editionAliases": ["The Harbinger: Storm and Fury"],
+      "isbnCandidates": [],
+      "banStatus": "challenged",
+      "jurisdictionContext": "U.S. libraries and schools; ALA 2025 Most Challenged Books list.",
+      "affectedAudience": "K-12 students and public library patrons",
+      "evidence": [
+        {
+          "sourceName": "ALA Most Challenged Books",
+          "sourceUrl": "https://www.ala.org/bbooks/frequentlychallengedbooks/top10",
+          "evidenceType": "challenge_list",
+          "note": "Included in ALA's 2025 Most Challenged Books page."
+        }
+      ],
+      "rightsholderCandidate": {
+        "name": "Jennifer L. Armentrout or publisher/agent",
+        "type": "author",
+        "contactPath": "Author/publisher permissions inquiry",
+        "confidence": "medium"
+      },
+      "outreachStatus": "not_started",
+      "licenseStatus": "not_requested",
+      "ingestionStatus": "not_started",
+      "chainOfTitleStatus": "unknown",
+      "sensitivityFlags": ["sexual_content", "fantasy_violence"],
+      "notes": "Series alias should be normalized before any ISBN or edition-level enrichment."
+    },
+    {
+      "id": "breathless-jennifer-niven",
+      "canonicalTitle": "Breathless",
+      "authors": ["Jennifer Niven"],
+      "editionAliases": [],
+      "isbnCandidates": [],
+      "banStatus": "banned",
+      "jurisdictionContext": "U.S. school-ban index context; PEN America 2024-2025 title-level discovery.",
+      "affectedAudience": "K-12 students",
+      "evidence": [
+        {
+          "sourceName": "PEN America Index of School Book Bans",
+          "sourceUrl": "https://pen.org/book-bans/pen-america-index-of-school-book-bans-2024-2025/",
+          "evidenceType": "school_ban_index",
+          "note": "Use PEN index enrichment to confirm district-level evidence before outreach."
+        }
+      ],
+      "rightsholderCandidate": {
+        "name": "Jennifer Niven or publisher/agent",
+        "type": "author",
+        "contactPath": "Author/publisher permissions inquiry",
+        "confidence": "medium"
+      },
+      "outreachStatus": "not_started",
+      "licenseStatus": "not_requested",
+      "ingestionStatus": "not_started",
+      "chainOfTitleStatus": "unknown",
+      "sensitivityFlags": ["sexual_content", "young_adult"],
+      "notes": "PEN-index-first candidate; district-level rows should be attached before prioritizing outreach."
+    },
+    {
+      "id": "a-court-of-mist-and-fury-sarah-j-maas",
+      "canonicalTitle": "A Court of Mist and Fury",
+      "authors": ["Sarah J. Maas"],
+      "editionAliases": ["ACOMAF"],
+      "isbnCandidates": [],
+      "banStatus": "banned",
+      "jurisdictionContext": "U.S. school-ban index context; PEN America 2024-2025 title-level discovery.",
+      "affectedAudience": "K-12 students",
+      "evidence": [
+        {
+          "sourceName": "PEN America Index of School Book Bans",
+          "sourceUrl": "https://pen.org/book-bans/pen-america-index-of-school-book-bans-2024-2025/",
+          "evidenceType": "school_ban_index",
+          "note": "Use PEN index enrichment to confirm district-level evidence before outreach."
+        }
+      ],
+      "rightsholderCandidate": {
+        "name": "Sarah J. Maas or publisher/agent",
+        "type": "author",
+        "contactPath": "Author/publisher permissions inquiry",
+        "confidence": "medium"
+      },
+      "outreachStatus": "not_started",
+      "licenseStatus": "not_requested",
+      "ingestionStatus": "not_started",
+      "chainOfTitleStatus": "unknown",
+      "sensitivityFlags": ["sexual_content", "fantasy_violence"],
+      "notes": "Keep grouped with other Sarah J. Maas records for series-level rights mapping."
+    },
+    {
+      "id": "all-boys-arent-blue-george-m-johnson",
+      "canonicalTitle": "All Boys Aren't Blue",
+      "authors": ["George M. Johnson"],
+      "editionAliases": ["All Boys Aren't Blue: A Memoir-Manifesto"],
+      "isbnCandidates": [],
+      "banStatus": "challenged",
+      "jurisdictionContext": "Recurring U.S. school and library challenge subject; ALA and PEN context.",
+      "affectedAudience": "K-12 students and public library patrons",
+      "evidence": [
+        {
+          "sourceName": "ALA Most Challenged Books",
+          "sourceUrl": "https://www.ala.org/bbooks/frequentlychallengedbooks/top10",
+          "evidenceType": "challenge_context",
+          "note": "Use ALA yearly list enrichment to confirm current challenge-list placement before outreach."
+        },
+        {
+          "sourceName": "PEN America Index of School Book Bans",
+          "sourceUrl": "https://pen.org/book-bans/pen-america-index-of-school-book-bans-2024-2025/",
+          "evidenceType": "school_ban_index",
+          "note": "Use PEN index enrichment to confirm district-level evidence before outreach."
+        }
+      ],
+      "rightsholderCandidate": {
+        "name": "George M. Johnson or publisher/agent",
+        "type": "author",
+        "contactPath": "Author/publisher permissions inquiry",
+        "confidence": "medium"
+      },
+      "outreachStatus": "not_started",
+      "licenseStatus": "not_requested",
+      "ingestionStatus": "not_started",
+      "chainOfTitleStatus": "unknown",
+      "sensitivityFlags": ["lgbtqia", "race", "sexual_content"],
+      "notes": "Mission-aligned but sensitive outreach should make author control, revocation, and attribution clear."
+    },
+    {
+      "id": "flamer-mike-curato",
+      "canonicalTitle": "Flamer",
+      "authors": ["Mike Curato"],
+      "editionAliases": [],
+      "isbnCandidates": [],
+      "banStatus": "challenged",
+      "jurisdictionContext": "Recurring U.S. school and library challenge subject; ALA and PEN context.",
+      "affectedAudience": "K-12 students and public library patrons",
+      "evidence": [
+        {
+          "sourceName": "ALA Most Challenged Books",
+          "sourceUrl": "https://www.ala.org/bbooks/frequentlychallengedbooks/top10",
+          "evidenceType": "challenge_context",
+          "note": "Use ALA yearly list enrichment to confirm current challenge-list placement before outreach."
+        },
+        {
+          "sourceName": "PEN America Index of School Book Bans",
+          "sourceUrl": "https://pen.org/book-bans/pen-america-index-of-school-book-bans-2024-2025/",
+          "evidenceType": "school_ban_index",
+          "note": "Use PEN index enrichment to confirm district-level evidence before outreach."
+        }
+      ],
+      "rightsholderCandidate": {
+        "name": "Mike Curato or publisher/agent",
+        "type": "author",
+        "contactPath": "Author/publisher permissions inquiry",
+        "confidence": "medium"
+      },
+      "outreachStatus": "not_started",
+      "licenseStatus": "not_requested",
+      "ingestionStatus": "not_started",
+      "chainOfTitleStatus": "unknown",
+      "sensitivityFlags": ["lgbtqia", "mental_health", "bullying"],
+      "notes": "Graphic-novel format requires later illustration rights review before any ingestion."
     }
   ]
 }

--- a/docs/banned-books-rights-ready-corpus.md
+++ b/docs/banned-books-rights-ready-corpus.md
@@ -8,6 +8,10 @@ not a claim that every globally banned book has been captured.
 
 The registry is staged in `data/source-protocol/banned-books-rights-ready-corpus.json`
 and projected into `/admin/source-protocol` under the `Banned Books` tab.
+The May 24, 2026 batch expands the staged shortlist to 17 records using the
+ALA 2025 challenged-books list and PEN America 2024-2025 school-ban index as
+the primary source spine. These records remain metadata and rights-readiness
+records only; they do not include copyrighted full text.
 
 ```bash
 npm run banned-books:report
@@ -49,6 +53,20 @@ retrievable until all of these are true:
 - verified chain of title,
 - sensitivity review complete,
 - governance approval recorded.
+
+## Outreach Packets
+
+The projection now includes three read-only permission-packet templates:
+
+- author direct RAG permission,
+- publisher permissions RAG license,
+- estate permissions RAG license.
+
+These packets define the subject, purpose, permission ask, guardrails, approval
+gate, and follow-up cadence for each outreach path. They are templates for
+review, not an outbound messaging automation. Human approval is still required
+before first contact, follow-up, license conversion, ingestion, retrieval, or
+payout activation.
 
 ## Review Loop
 

--- a/docs/source-respecting-llm-protocol.md
+++ b/docs/source-respecting-llm-protocol.md
@@ -125,8 +125,8 @@ Banned-books corpus foundation:
 
 - `data/source-protocol/banned-books-rights-ready-corpus.json` stages the U.S.-first banned/challenged books shortlist, source evidence, rightsholder candidates, outreach status, license status, and ingestion status.
 - `lib/banned-books-corpus.ts` projects that staged inventory into Source Protocol draft records and enforces the v1 guardrail: no full text, OCR, embeddings, or retrievable chunks until an active RAG-only license grant and verified chain of title exist.
-- `/admin/source-protocol` includes a `Banned Books` tab for the MECE agent lanes, staged shortlist, source spine, and safeguards.
-- `npm run banned-books:report` prints the current staged registry, swarm lanes, next actions, and safeguards for recurring review.
+- `/admin/source-protocol` includes a `Banned Books` tab for the MECE agent lanes, staged shortlist, source spine, read-only outreach packet templates, and safeguards.
+- `npm run banned-books:report` prints the current staged registry, swarm lanes, outreach packet templates, next actions, and safeguards for recurring review.
 
 Smoke test:
 

--- a/lib/banned-books-corpus.test.ts
+++ b/lib/banned-books-corpus.test.ts
@@ -47,10 +47,17 @@ describe('banned books corpus projection', () => {
   it('builds a staged rights-ready projection with MECE swarm lanes', () => {
     const projection = buildBannedBooksCorpusProjection()
 
-    expect(projection.summary.stagedRecords).toBeGreaterThan(0)
+    expect(projection.summary.stagedRecords).toBe(17)
     expect(projection.summary.sourceSpineCount).toBeGreaterThanOrEqual(3)
+    expect(projection.summary.outreachPacketCount).toBe(3)
     expect(projection.summary.outreachReadyRecords).toBeGreaterThan(0)
     expect(projection.summary.retrievableRecords).toBe(0)
+    expect(projection.outreachPackets.map((packet) => packet.audience).sort()).toEqual(['author', 'estate', 'publisher'])
+    expect(projection.outreachPackets.map((packet) => packet.key)).toEqual([
+      'author_direct_rag_permission',
+      'publisher_permissions_rag_license',
+      'estate_permissions_rag_license',
+    ])
     expect(projection.swarmAgents.map((agent) => agent.key)).toEqual([
       'banned-book-source-registry',
       'book-normalization',

--- a/lib/banned-books-corpus.ts
+++ b/lib/banned-books-corpus.ts
@@ -79,15 +79,33 @@ export type BannedBookSwarmAgent = {
   approvalGate: string
 }
 
+export type BannedBookOutreachPacketKey =
+  | 'author_direct_rag_permission'
+  | 'publisher_permissions_rag_license'
+  | 'estate_permissions_rag_license'
+
+export type BannedBookOutreachPacket = {
+  key: BannedBookOutreachPacketKey
+  audience: 'author' | 'publisher' | 'estate'
+  subject: string
+  purpose: string
+  permissionAsk: string[]
+  guardrails: string[]
+  approvalGate: string
+  followUpCadenceDays: number[]
+}
+
 export type BannedBooksCorpusProjection = {
   generatedAt: string
   scope: string
   licenseModel: string
   sourceSpine: BannedBookSourceSpineEntry[]
   swarmAgents: BannedBookSwarmAgent[]
+  outreachPackets: BannedBookOutreachPacket[]
   summary: {
     stagedRecords: number
     sourceSpineCount: number
+    outreachPacketCount: number
     rightsReadyRecords: number
     outreachReadyRecords: number
     activeLicenseRecords: number
@@ -204,6 +222,63 @@ export const BANNED_BOOKS_SWARM_AGENTS: BannedBookSwarmAgent[] = [
     output: 'Evidence QA notes and recurring report inputs.',
     boundary: 'No mutation of rights status without governance review.',
     approvalGate: 'All records need source evidence before outreach or ingestion.',
+  },
+]
+
+export const BANNED_BOOKS_OUTREACH_PACKETS: BannedBookOutreachPacket[] = [
+  {
+    key: 'author_direct_rag_permission',
+    audience: 'author',
+    subject: 'Permission request: rights-cleared retrieval for your challenged work',
+    purpose: 'Ask the author for RAG-only participation in a rights-respecting corpus that preserves access, citation, revocation, and payout visibility.',
+    permissionAsk: [
+      'Allow retrieval, citation, summarization, educational use, and approved commercial RAG use.',
+      'Allow limited excerpts up to the approved quote limit with citation labels and answer receipts.',
+      'Participate in monthly payout simulation before any real payout activation.',
+    ],
+    guardrails: [
+      'No fine-tuning in v1.',
+      'No full-text ingestion until a license grant is active and chain of title is verified.',
+      'Author can revoke or dispute use through the creator portal process.',
+    ],
+    approvalGate: 'Human approval is required before sending the first author email or any follow-up.',
+    followUpCadenceDays: [7, 21, 45],
+  },
+  {
+    key: 'publisher_permissions_rag_license',
+    audience: 'publisher',
+    subject: 'Permissions inquiry: RAG-only access license for challenged-title preservation',
+    purpose: 'Ask publisher permissions staff to confirm rights path, blocked uses, quote limits, territory, revocation, reporting, and payout participation.',
+    permissionAsk: [
+      'Confirm whether publisher controls digital excerpt, retrieval, citation, and summarization rights.',
+      'Approve RAG-only use with citation labels, answer receipts, and monthly usage statements.',
+      'Identify co-rightsholders such as illustrators, translators, estates, or agents.',
+    ],
+    guardrails: [
+      'No production retrieval before active grant and governance review.',
+      'No model training rights are requested in v1.',
+      'Ambiguous chain-of-title responses remain blocked from ingestion.',
+    ],
+    approvalGate: 'Governance review is required before any publisher response becomes a license grant.',
+    followUpCadenceDays: [10, 30, 60],
+  },
+  {
+    key: 'estate_permissions_rag_license',
+    audience: 'estate',
+    subject: 'Estate permissions inquiry: preserving access with revocable RAG-only use',
+    purpose: 'Ask the estate or estate-controlled publisher path for cautious permission where the author is deceased or rights ownership needs verification.',
+    permissionAsk: [
+      'Confirm estate or publisher authority for retrieval, citation, summarization, and limited excerpts.',
+      'Approve revocable RAG-only use after chain-of-title and sensitivity review.',
+      'Confirm reporting, attribution, and payout-recipient requirements.',
+    ],
+    guardrails: [
+      'Estate-controlled works cannot enter retrieval on author inference alone.',
+      'Sensitive-history or community-consent issues remain approval-gated.',
+      'Any dispute immediately blocks retrieval and payout attribution.',
+    ],
+    approvalGate: 'Shaka governance review and chain-of-title verification are required before outreach is marked approved.',
+    followUpCadenceDays: [14, 45, 90],
   },
 ]
 
@@ -344,9 +419,11 @@ export function buildBannedBooksCorpusProjection(): BannedBooksCorpusProjection 
     licenseModel: stagedCorpus.licenseModel,
     sourceSpine: stagedCorpus.sourceSpine,
     swarmAgents: BANNED_BOOKS_SWARM_AGENTS,
+    outreachPackets: BANNED_BOOKS_OUTREACH_PACKETS,
     summary: {
       stagedRecords: projectedRecords.length,
       sourceSpineCount: stagedCorpus.sourceSpine.length,
+      outreachPacketCount: BANNED_BOOKS_OUTREACH_PACKETS.length,
       rightsReadyRecords: projectedRecords.filter((record) => record.rightsReady).length,
       outreachReadyRecords: projectedRecords.filter((record) => record.outreachReady).length,
       activeLicenseRecords: projectedRecords.filter((record) => record.licenseStatus === 'active').length,
@@ -385,6 +462,10 @@ export function formatBannedBooksCorpusReport(projection = buildBannedBooksCorpu
     '## Swarm Lanes',
     '',
     ...projection.swarmAgents.map((agent) => `- ${agent.name} (${agent.key}): ${agent.output}`),
+    '',
+    '## Outreach Packets',
+    '',
+    ...projection.outreachPackets.map((packet) => `- ${packet.audience}: ${packet.subject} (${packet.key})`),
     '',
     '## Staged Works',
     '',


### PR DESCRIPTION
## Summary
- expand the staged banned/challenged books registry to 17 metadata-only records using the ALA 2025 and PEN America 2024-2025 source spine
- add read-only author, publisher, and estate RAG-only permission packet templates to the banned-books projection and report
- surface packet templates in the Source Protocol admin Banned Books tab while preserving no-ingestion/no-retrieval gates

## Validation
- npm test -- --run lib/banned-books-corpus.test.ts app/api/admin/source-protocol/overview/route.test.ts app/admin/source-protocol/page.test.tsx
- npm test -- --run app/admin/source-protocol/page.test.tsx lib/banned-books-corpus.test.ts
- npm run banned-books:report
- npm run banned-books:report -- --json
- npm run build:knowledge
- npx tsc --noEmit --pretty false
- npm run lint
- git diff --check
- pre-push database health check passed

## Governance notes
- No copyrighted full text was added.
- No OCR, embeddings, retrievable chunks, outreach sends, license grants, production defaults, or payout activation were created.
- Production ingestion and creator communications remain approval-gated.

## Integration Captain
- Stop before merge. Please review and merge from the captain lane.