### PR TITLE
fix: preserve auth redirect deep links

### DIFF
--- a/components/ProtectedRoute.tsx
+++ b/components/ProtectedRoute.tsx
@@ -17,7 +17,8 @@ export default function ProtectedRoute({ children, requireAdmin = false }: Prote
     // Wait for loading to complete AND profile to be fetched (if user exists)
     if (!loading) {
       if (!user) {
-        router.push('/auth/login?redirect=' + encodeURIComponent(window.location.pathname))
+        const redirectPath = `${window.location.pathname}${window.location.search}${window.location.hash}`
+        router.push('/auth/login?redirect=' + encodeURIComponent(redirectPath))
       } else if (requireAdmin) {
         // If we have a user but no profile yet, wait a bit longer (profile might still be loading)
         if (profile === null && user) {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -100,10 +100,11 @@ const AUTH_NEXT_PATH_KEY = 'auth_next_path'
 
 // Sign in with OAuth provider. Pass nextPath to land on that page after OAuth (e.g. /admin, /checkout).
 // Supabase redirect URLs are matched exactly; we never add ?next= so dev/prod callback URLs match the allowlist.
-// Post-login path is stored in sessionStorage and read in the callback page.
+// Post-login path is stored in browser storage and read in the callback page.
 export async function signInWithOAuth(provider: 'google' | 'github', nextPath?: string) {
   if (typeof window !== 'undefined' && nextPath && nextPath !== '/') {
     sessionStorage.setItem(AUTH_NEXT_PATH_KEY, nextPath)
+    localStorage.setItem(AUTH_NEXT_PATH_KEY, nextPath)
   }
   const redirectTo = typeof window !== 'undefined' ? `${window.location.origin}/auth/callback` : '/auth/callback'
   const { data, error } = await supabase.auth.signInWithOAuth({
@@ -117,9 +118,10 @@ export async function signInWithOAuth(provider: 'google' | 'github', nextPath?: 
 
 export function getStoredAuthNextPath(): string | null {
   if (typeof window === 'undefined') return null
-  const path = sessionStorage.getItem(AUTH_NEXT_PATH_KEY)
+  const path = sessionStorage.getItem(AUTH_NEXT_PATH_KEY) || localStorage.getItem(AUTH_NEXT_PATH_KEY)
   if (path) {
     sessionStorage.removeItem(AUTH_NEXT_PATH_KEY)
+    localStorage.removeItem(AUTH_NEXT_PATH_KEY)
     return path
   }
   return null


### PR DESCRIPTION
## Summary
- Preserves pathname, query string, and hash when ProtectedRoute redirects unauthenticated users to login.
- Stores OAuth post-login paths in both sessionStorage and localStorage so the callback can recover the intended path more reliably after provider redirects.
- Keeps Supabase OAuth callback URLs unchanged; only the local post-auth next path changes.

## Validation
- npx tsc --noEmit --pretty false
- npm test -- app/auth/callback/page.tsx components/ProtectedRoute.tsx lib/auth.ts (no matching test files found; command exited 1 before running tests)
- git push pre-push hook: npm run db:health-check passed against PROD

## Integration Notes
- Scoped to auth redirect behavior only.
- Existing dirty subscription tracker docs and tmp artifacts were intentionally not included.
- Vercel contexts to verify before merge: Vercel – portfolio and Vercel – portfolio-staging.