### PR TITLE
Add banned books source ingestion queue

### DIFF
--- a/app/admin/source-protocol/page.test.tsx
+++ b/app/admin/source-protocol/page.test.tsx
@@ -125,6 +125,47 @@ const overview = {
         followUpCadenceDays: [14, 45, 90],
       },
     ],
+    sourceIngestionQueue: {
+      generatedAt: '2026-05-24T00:00:00.000Z',
+      mode: 'metadata_only_dry_run',
+      policy: 'Source discovery may stage title metadata and evidence only.',
+      sources: [],
+      summary: {
+        sourceCount: 3,
+        candidateCount: 2,
+        existingRecordMatches: 1,
+        stageableCandidates: 0,
+        evidenceReviewRequired: 1,
+        blockedFullTextActions: 5,
+      },
+      candidates: [
+        {
+          sourceKey: 'ala-most-challenged-2025',
+          externalId: 'ala-demo-book',
+          canonicalTitle: 'Demo Challenged Book',
+          authors: ['Demo Author'],
+          status: 'existing_record',
+          evidenceQuality: 'confirmed_source',
+          evidenceType: 'challenge_list',
+          existingRecordId: 'demo-book',
+          stagedRecordDraft: null,
+          nextAction: 'Attach source evidence to existing staged record if it adds provenance.',
+        },
+        {
+          sourceKey: 'pen-school-book-bans-2024-2025',
+          externalId: 'pen-held-book',
+          canonicalTitle: 'Held Candidate Book',
+          authors: ['Held Author'],
+          status: 'needs_evidence_review',
+          evidenceQuality: 'needs_district_row',
+          evidenceType: 'school_ban_index',
+          existingRecordId: null,
+          stagedRecordDraft: null,
+          nextAction: 'Hold until district rows or cross-source evidence are attached.',
+        },
+      ],
+      blockedActions: ['Fetch or store copyrighted full text.'],
+    },
     records: [
       {
         id: 'demo-book',
@@ -165,7 +206,9 @@ describe('SourceProtocolPage', () => {
     expect(screen.getByRole('heading', { name: 'Banned Books Rights-Ready Corpus' })).toBeInTheDocument()
     expect(screen.getByText('Amina, Source Registry Lead')).toBeInTheDocument()
     expect(screen.getByText('Permission request: rights-cleared retrieval for your challenged work')).toBeInTheDocument()
-    expect(screen.getByText('Demo Challenged Book')).toBeInTheDocument()
+    expect(screen.getByText('Source ingestion queue')).toBeInTheDocument()
+    expect(screen.getByText('Held Candidate Book')).toBeInTheDocument()
+    expect(screen.getAllByText('Demo Challenged Book').length).toBeGreaterThanOrEqual(1)
 
     fireEvent.click(screen.getAllByRole('button', { name: /Portal Access/i })[0])
 

--- a/app/admin/source-protocol/page.tsx
+++ b/app/admin/source-protocol/page.tsx
@@ -50,6 +50,22 @@ type SourceProtocolOverview = {
     sourceSpine: any[]
     swarmAgents: any[]
     outreachPackets: any[]
+    sourceIngestionQueue?: {
+      generatedAt: string
+      mode: string
+      policy: string
+      sources: any[]
+      summary: {
+        sourceCount: number
+        candidateCount: number
+        existingRecordMatches: number
+        stageableCandidates: number
+        evidenceReviewRequired: number
+        blockedFullTextActions: number
+      }
+      candidates: any[]
+      blockedActions: string[]
+    }
     summary: {
       stagedRecords: number
       sourceSpineCount: number
@@ -647,6 +663,48 @@ function BannedBooksCorpusPanel({ corpus }: { corpus: SourceProtocolOverview['ba
           ))}
         </Panel>
       </section>
+
+      {corpus.sourceIngestionQueue && (
+        <section className="overflow-hidden rounded-lg border border-silicon-slate">
+          <div className="bg-silicon-slate/60 px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Source ingestion queue
+          </div>
+          <div className="grid grid-cols-2 gap-3 border-b border-silicon-slate p-4 lg:grid-cols-6">
+            <Stat icon={<Database size={18} />} label="Sources" value={corpus.sourceIngestionQueue.summary.sourceCount} />
+            <Stat icon={<Search size={18} />} label="Candidates" value={corpus.sourceIngestionQueue.summary.candidateCount} />
+            <Stat icon={<BookOpenCheck size={18} />} label="Matched" value={corpus.sourceIngestionQueue.summary.existingRecordMatches} />
+            <Stat icon={<ShieldCheck size={18} />} label="Stageable" value={corpus.sourceIngestionQueue.summary.stageableCandidates} />
+            <Stat icon={<AlertTriangle size={18} />} label="Needs QA" value={corpus.sourceIngestionQueue.summary.evidenceReviewRequired} />
+            <Stat icon={<AlertTriangle size={18} />} label="Blocked" value={corpus.sourceIngestionQueue.summary.blockedFullTextActions} />
+          </div>
+          <div className="border-b border-silicon-slate px-4 py-3 text-sm text-muted-foreground">
+            {corpus.sourceIngestionQueue.policy}
+          </div>
+          <div className="divide-y divide-silicon-slate">
+            {corpus.sourceIngestionQueue.candidates.map((candidate) => (
+              <div key={candidate.externalId} className="grid grid-cols-1 gap-3 px-4 py-4 text-sm lg:grid-cols-5 lg:gap-4">
+                <div>
+                  <p className="font-medium text-foreground">{candidate.canonicalTitle}</p>
+                  <p className="text-muted-foreground">{list(candidate.authors)}</p>
+                </div>
+                <div className="text-muted-foreground">
+                  <p>{candidate.status}</p>
+                  <p>{candidate.evidenceQuality}</p>
+                </div>
+                <div className="text-muted-foreground">
+                  <p>{candidate.sourceKey}</p>
+                  <p>{candidate.evidenceType}</p>
+                </div>
+                <div className="text-muted-foreground">
+                  <p>Existing: {candidate.existingRecordId ?? 'None'}</p>
+                  <p>Draft: {candidate.stagedRecordDraft ? candidate.stagedRecordDraft.id : 'Held'}</p>
+                </div>
+                <div className="text-muted-foreground">{candidate.nextAction}</div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
 
       <section className="overflow-hidden rounded-lg border border-silicon-slate">
         <div className="bg-silicon-slate/60 px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">

--- a/app/api/admin/source-protocol/overview/route.test.ts
+++ b/app/api/admin/source-protocol/overview/route.test.ts
@@ -204,6 +204,17 @@ describe('GET /api/admin/source-protocol/overview', () => {
           expect.objectContaining({ key: 'publisher_permissions_rag_license' }),
           expect.objectContaining({ key: 'estate_permissions_rag_license' }),
         ]),
+        sourceIngestionQueue: {
+          mode: 'metadata_only_dry_run',
+          summary: {
+            sourceCount: 3,
+            candidateCount: 5,
+            existingRecordMatches: 1,
+            stageableCandidates: 0,
+            evidenceReviewRequired: 4,
+            blockedFullTextActions: 5,
+          },
+        },
         swarmAgents: expect.arrayContaining([
           expect.objectContaining({ key: 'banned-book-source-registry' }),
           expect.objectContaining({ key: 'rights-governance-review' }),

--- a/data/source-protocol/banned-books-source-ingestion-queue.json
+++ b/data/source-protocol/banned-books-source-ingestion-queue.json
@@ -1,0 +1,113 @@
+{
+  "generatedAt": "2026-05-24T00:00:00.000Z",
+  "mode": "metadata_only_dry_run",
+  "policy": "Source discovery may stage title metadata and evidence only. It must not fetch, store, OCR, embed, retrieve, or summarize copyrighted full text.",
+  "sources": [
+    {
+      "key": "ala-most-challenged-2025",
+      "name": "ALA Most Challenged Books 2025",
+      "url": "https://www.ala.org/bbooks/frequentlychallengedbooks/top10",
+      "refreshCadenceDays": 30,
+      "fetchMode": "public_page_or_manual_export",
+      "ownerLane": "banned-book-source-registry"
+    },
+    {
+      "key": "pen-school-book-bans-2024-2025",
+      "name": "PEN America Index of School Book Bans 2024-2025",
+      "url": "https://pen.org/book-bans/pen-america-index-of-school-book-bans-2024-2025/",
+      "refreshCadenceDays": 30,
+      "fetchMode": "public_index_or_manual_export",
+      "ownerLane": "banned-book-source-registry"
+    },
+    {
+      "key": "everylibrary-banned-book-database",
+      "name": "EveryLibrary Banned Book Database",
+      "url": "https://action.everylibrary.org/everylibrary_s_banned_book_database",
+      "refreshCadenceDays": 60,
+      "fetchMode": "public_database_or_manual_export",
+      "ownerLane": "evidence-qa-audit"
+    }
+  ],
+  "candidates": [
+    {
+      "sourceKey": "ala-most-challenged-2025",
+      "externalId": "ala-2025-gender-queer",
+      "canonicalTitle": "Gender Queer",
+      "authors": ["Maia Kobabe"],
+      "banStatus": "challenged",
+      "sourceUrl": "https://www.ala.org/bbooks/frequentlychallengedbooks/top10",
+      "evidenceType": "challenge_list",
+      "evidenceNote": "Appears in the ALA 2025 Most Challenged Books source page.",
+      "jurisdictionContext": "U.S. libraries and schools; ALA 2025 Most Challenged Books list.",
+      "affectedAudience": "K-12 students and public library patrons",
+      "evidenceQuality": "confirmed_source",
+      "rightsholderHint": "author_or_publisher",
+      "editionAliases": ["Gender Queer: A Memoir"],
+      "sensitivityFlags": ["lgbtqia"]
+    },
+    {
+      "sourceKey": "pen-school-book-bans-2024-2025",
+      "externalId": "pen-2024-2025-push",
+      "canonicalTitle": "Push",
+      "authors": ["Sapphire"],
+      "banStatus": "banned",
+      "sourceUrl": "https://pen.org/book-bans/pen-america-index-of-school-book-bans-2024-2025/",
+      "evidenceType": "school_ban_index",
+      "evidenceNote": "Candidate discovered from the PEN 2024-2025 school-ban index source spine; district rows require attachment before outreach.",
+      "jurisdictionContext": "U.S. school-ban index context; PEN America 2024-2025 title-level discovery.",
+      "affectedAudience": "K-12 students",
+      "evidenceQuality": "needs_district_row",
+      "rightsholderHint": "author_or_publisher",
+      "editionAliases": ["Push: A Novel"],
+      "sensitivityFlags": ["race", "sexual_abuse", "trauma"]
+    },
+    {
+      "sourceKey": "pen-school-book-bans-2024-2025",
+      "externalId": "pen-2024-2025-crank",
+      "canonicalTitle": "Crank",
+      "authors": ["Ellen Hopkins"],
+      "banStatus": "banned",
+      "sourceUrl": "https://pen.org/book-bans/pen-america-index-of-school-book-bans-2024-2025/",
+      "evidenceType": "school_ban_index",
+      "evidenceNote": "Candidate discovered from the PEN 2024-2025 school-ban index source spine; district rows require attachment before outreach.",
+      "jurisdictionContext": "U.S. school-ban index context; PEN America 2024-2025 title-level discovery.",
+      "affectedAudience": "K-12 students",
+      "evidenceQuality": "needs_district_row",
+      "rightsholderHint": "author_or_publisher",
+      "editionAliases": [],
+      "sensitivityFlags": ["substance_use", "young_adult"]
+    },
+    {
+      "sourceKey": "everylibrary-banned-book-database",
+      "externalId": "everylibrary-lawn-boy",
+      "canonicalTitle": "Lawn Boy",
+      "authors": ["Jonathan Evison"],
+      "banStatus": "challenged",
+      "sourceUrl": "https://action.everylibrary.org/everylibrary_s_banned_book_database",
+      "evidenceType": "challenge_context",
+      "evidenceNote": "Candidate queued for cross-check against EveryLibrary and primary district or library evidence.",
+      "jurisdictionContext": "U.S. library and school challenge context pending jurisdiction enrichment.",
+      "affectedAudience": "K-12 students and public library patrons",
+      "evidenceQuality": "needs_cross_check",
+      "rightsholderHint": "author_or_publisher",
+      "editionAliases": [],
+      "sensitivityFlags": ["lgbtqia", "sexual_content"]
+    },
+    {
+      "sourceKey": "everylibrary-banned-book-database",
+      "externalId": "everylibrary-me-and-earl-and-the-dying-girl",
+      "canonicalTitle": "Me and Earl and the Dying Girl",
+      "authors": ["Jesse Andrews"],
+      "banStatus": "challenged",
+      "sourceUrl": "https://action.everylibrary.org/everylibrary_s_banned_book_database",
+      "evidenceType": "challenge_context",
+      "evidenceNote": "Candidate queued for cross-check against EveryLibrary and primary district or library evidence.",
+      "jurisdictionContext": "U.S. library and school challenge context pending jurisdiction enrichment.",
+      "affectedAudience": "K-12 students and public library patrons",
+      "evidenceQuality": "needs_cross_check",
+      "rightsholderHint": "author_or_publisher",
+      "editionAliases": [],
+      "sensitivityFlags": ["illness", "young_adult"]
+    }
+  ]
+}

--- a/docs/banned-books-rights-ready-corpus.md
+++ b/docs/banned-books-rights-ready-corpus.md
@@ -16,6 +16,8 @@ records only; they do not include copyrighted full text.
 ```bash
 npm run banned-books:report
 npm run banned-books:report -- --json
+npm run banned-books:ingestion:report
+npm run banned-books:ingestion:report -- --json
 ```
 
 The projection reuses the existing Source-Respecting LLM Protocol:
@@ -67,6 +69,22 @@ gate, and follow-up cadence for each outreach path. They are templates for
 review, not an outbound messaging automation. Human approval is still required
 before first contact, follow-up, license conversion, ingestion, retrieval, or
 payout activation.
+
+## Source Ingestion Queue
+
+The source ingestion queue is staged in
+`data/source-protocol/banned-books-source-ingestion-queue.json`. It is an
+automation-ready contract for recurring ALA, PEN America, and EveryLibrary
+metadata refreshes. It can classify source candidates as:
+
+- existing staged records,
+- stageable metadata-only candidates,
+- candidates that need evidence QA before promotion.
+
+The queue is deliberately dry-run only. It may propose a staged metadata draft,
+but it cannot write to `licensed_works`, `license_grants`, `source_chunks`,
+retrieval indexes, outreach tools, or payout tables. Promotion still requires
+evidence QA and governance approval.
 
 ## Review Loop
 

--- a/docs/source-respecting-llm-protocol.md
+++ b/docs/source-respecting-llm-protocol.md
@@ -124,9 +124,11 @@ Creator portal foundation:
 Banned-books corpus foundation:
 
 - `data/source-protocol/banned-books-rights-ready-corpus.json` stages the U.S.-first banned/challenged books shortlist, source evidence, rightsholder candidates, outreach status, license status, and ingestion status.
+- `data/source-protocol/banned-books-source-ingestion-queue.json` stages metadata-only source refresh jobs and candidate rows for ALA, PEN America, and EveryLibrary discovery.
 - `lib/banned-books-corpus.ts` projects that staged inventory into Source Protocol draft records and enforces the v1 guardrail: no full text, OCR, embeddings, or retrievable chunks until an active RAG-only license grant and verified chain of title exist.
-- `/admin/source-protocol` includes a `Banned Books` tab for the MECE agent lanes, staged shortlist, source spine, read-only outreach packet templates, and safeguards.
-- `npm run banned-books:report` prints the current staged registry, swarm lanes, outreach packet templates, next actions, and safeguards for recurring review.
+- `/admin/source-protocol` includes a `Banned Books` tab for the MECE agent lanes, source ingestion queue, staged shortlist, source spine, read-only outreach packet templates, and safeguards.
+- `npm run banned-books:report` prints the current staged registry, swarm lanes, source ingestion queue, outreach packet templates, next actions, and safeguards for recurring review.
+- `npm run banned-books:ingestion:report` prints the source refresh queue, candidate classifications, evidence QA holds, and blocked full-text actions.
 
 Smoke test:
 

--- a/lib/banned-books-corpus.test.ts
+++ b/lib/banned-books-corpus.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildBannedBooksCorpusProjection,
+  buildBannedBooksSourceIngestionProjection,
   buildSourceProtocolDraft,
   canCreateRetrievableChunks,
   dedupeBannedBookRecords,
@@ -52,6 +53,14 @@ describe('banned books corpus projection', () => {
     expect(projection.summary.outreachPacketCount).toBe(3)
     expect(projection.summary.outreachReadyRecords).toBeGreaterThan(0)
     expect(projection.summary.retrievableRecords).toBe(0)
+    expect(projection.sourceIngestionQueue.summary).toMatchObject({
+      sourceCount: 3,
+      candidateCount: 5,
+      existingRecordMatches: 1,
+      stageableCandidates: 0,
+      evidenceReviewRequired: 4,
+      blockedFullTextActions: 5,
+    })
     expect(projection.outreachPackets.map((packet) => packet.audience).sort()).toEqual(['author', 'estate', 'publisher'])
     expect(projection.outreachPackets.map((packet) => packet.key)).toEqual([
       'author_direct_rag_permission',
@@ -121,5 +130,19 @@ describe('banned books corpus projection', () => {
     expect(normalizeBannedBookKey(record({ canonicalTitle: 'The Hate U Give', authors: ['Angie Thomas'] }))).toBe(
       'the-hate-u-give:angie-thomas'
     )
+  })
+
+  it('keeps source ingestion metadata-only and evidence-gated', () => {
+    const projection = buildBannedBooksSourceIngestionProjection()
+
+    expect(projection.mode).toBe('metadata_only_dry_run')
+    expect(projection.candidates.find((candidate) => candidate.canonicalTitle === 'Gender Queer')).toMatchObject({
+      status: 'existing_record',
+      existingRecordId: 'gender-queer-maia-kobabe',
+      stagedRecordDraft: null,
+    })
+    expect(projection.candidates.filter((candidate) => candidate.status === 'needs_evidence_review')).toHaveLength(4)
+    expect(projection.blockedActions.join(' ')).toContain('Fetch or store copyrighted full text')
+    expect(projection.candidates.every((candidate) => !candidate.stagedRecordDraft || !canCreateRetrievableChunks(candidate.stagedRecordDraft))).toBe(true)
   })
 })

--- a/lib/banned-books-corpus.ts
+++ b/lib/banned-books-corpus.ts
@@ -1,4 +1,5 @@
 import stagedCorpus from '@/data/source-protocol/banned-books-rights-ready-corpus.json'
+import sourceIngestionQueue from '@/data/source-protocol/banned-books-source-ingestion-queue.json'
 import type {
   CreatorCategory,
   LicenseUse,
@@ -29,6 +30,13 @@ export type BannedBookOutreachStatus = 'not_started' | 'ready' | 'drafted' | 'se
 export type BannedBookLicenseStatus = 'not_requested' | 'pending_review' | 'active' | 'revoked' | 'disputed'
 export type BannedBookIngestionStatus = 'not_started' | 'blocked' | 'staged' | 'indexed_shadow' | 'retrievable'
 export type BannedBookRightsConfidence = 'low' | 'medium' | 'high'
+export type BannedBookSourceIngestionMode = 'metadata_only_dry_run'
+export type BannedBookSourceFetchMode =
+  | 'public_page_or_manual_export'
+  | 'public_index_or_manual_export'
+  | 'public_database_or_manual_export'
+export type BannedBookEvidenceQuality = 'confirmed_source' | 'needs_district_row' | 'needs_cross_check' | 'blocked_missing_source'
+export type BannedBookSourceCandidateStatus = 'existing_record' | 'stageable_candidate' | 'needs_evidence_review'
 
 export type BannedBookSourceSpineEntry = {
   name: string
@@ -95,6 +103,55 @@ export type BannedBookOutreachPacket = {
   followUpCadenceDays: number[]
 }
 
+export type BannedBookSourceIngestionSource = {
+  key: string
+  name: string
+  url: string
+  refreshCadenceDays: number
+  fetchMode: BannedBookSourceFetchMode
+  ownerLane: BannedBookSwarmLaneKey
+}
+
+export type BannedBookSourceIngestionCandidate = {
+  sourceKey: string
+  externalId: string
+  canonicalTitle: string
+  authors: string[]
+  banStatus: BannedBookBanStatus
+  sourceUrl: string
+  evidenceType: BannedBookEvidenceType
+  evidenceNote: string
+  jurisdictionContext: string
+  affectedAudience: string
+  evidenceQuality: BannedBookEvidenceQuality
+  rightsholderHint: 'author_or_publisher' | 'publisher' | 'estate' | 'unknown'
+  editionAliases: string[]
+  sensitivityFlags: string[]
+}
+
+export type BannedBookSourceIngestionProjection = {
+  generatedAt: string
+  mode: BannedBookSourceIngestionMode
+  policy: string
+  sources: BannedBookSourceIngestionSource[]
+  summary: {
+    sourceCount: number
+    candidateCount: number
+    existingRecordMatches: number
+    stageableCandidates: number
+    evidenceReviewRequired: number
+    blockedFullTextActions: number
+  }
+  candidates: Array<BannedBookSourceIngestionCandidate & {
+    normalizedKey: string
+    status: BannedBookSourceCandidateStatus
+    existingRecordId: string | null
+    stagedRecordDraft: BannedBookStagedRecord | null
+    nextAction: string
+  }>
+  blockedActions: string[]
+}
+
 export type BannedBooksCorpusProjection = {
   generatedAt: string
   scope: string
@@ -102,6 +159,7 @@ export type BannedBooksCorpusProjection = {
   sourceSpine: BannedBookSourceSpineEntry[]
   swarmAgents: BannedBookSwarmAgent[]
   outreachPackets: BannedBookOutreachPacket[]
+  sourceIngestionQueue: BannedBookSourceIngestionProjection
   summary: {
     stagedRecords: number
     sourceSpineCount: number
@@ -284,6 +342,14 @@ export const BANNED_BOOKS_OUTREACH_PACKETS: BannedBookOutreachPacket[] = [
 
 const RAG_ONLY_ALLOWED_USES: LicenseUse[] = ['retrieval', 'citation', 'summarization', 'educational', 'commercial']
 
+const BLOCKED_SOURCE_INGESTION_ACTIONS = [
+  'Fetch or store copyrighted full text.',
+  'Run OCR or text extraction against unlicensed files.',
+  'Create embeddings, source chunks, or retrievable records.',
+  'Send creator outreach or convert responses into license grants.',
+  'Activate payout attribution outside simulation mode.',
+]
+
 function normalizeValue(value: string): string {
   return value
     .toLowerCase()
@@ -322,6 +388,116 @@ export function dedupeBannedBookRecords(records: BannedBookStagedRecord[]): Bann
     })
   }
   return [...byKey.values()]
+}
+
+function draftRightsholderCandidate(candidate: BannedBookSourceIngestionCandidate): BannedBookRightsholderCandidate {
+  if (candidate.rightsholderHint === 'estate') {
+    return {
+      name: `${candidate.authors.join(', ')} estate or publisher`,
+      type: 'estate',
+      contactPath: 'Estate/publisher permissions inquiry',
+      confidence: 'low',
+    }
+  }
+
+  if (candidate.rightsholderHint === 'publisher') {
+    return {
+      name: `${candidate.canonicalTitle} publisher permissions contact`,
+      type: 'publisher',
+      contactPath: 'Publisher permissions inquiry',
+      confidence: 'low',
+    }
+  }
+
+  return {
+    name: `${candidate.authors.join(', ')} or publisher/agent`,
+    type: 'author',
+    contactPath: 'Author/publisher permissions inquiry',
+    confidence: candidate.evidenceQuality === 'confirmed_source' ? 'medium' : 'low',
+  }
+}
+
+export function draftStagedRecordFromSourceCandidate(
+  candidate: BannedBookSourceIngestionCandidate
+): BannedBookStagedRecord {
+  return {
+    id: normalizeValue(`${candidate.canonicalTitle}-${candidate.authors.join('-')}`),
+    canonicalTitle: candidate.canonicalTitle,
+    authors: candidate.authors,
+    editionAliases: candidate.editionAliases,
+    isbnCandidates: [],
+    banStatus: candidate.banStatus,
+    jurisdictionContext: candidate.jurisdictionContext,
+    affectedAudience: candidate.affectedAudience,
+    evidence: [
+      {
+        sourceName: sourceIngestionQueue.sources.find((source) => source.key === candidate.sourceKey)?.name ?? candidate.sourceKey,
+        sourceUrl: candidate.sourceUrl,
+        evidenceType: candidate.evidenceType,
+        note: candidate.evidenceNote,
+      },
+    ],
+    rightsholderCandidate: draftRightsholderCandidate(candidate),
+    outreachStatus: 'not_started',
+    licenseStatus: 'not_requested',
+    ingestionStatus: 'not_started',
+    chainOfTitleStatus: 'unknown',
+    sensitivityFlags: candidate.sensitivityFlags,
+    notes: 'Generated by the metadata-only source ingestion dry run; requires evidence QA before registry promotion.',
+  }
+}
+
+function sourceCandidateStatus(
+  candidate: BannedBookSourceIngestionCandidate,
+  existingRecordsByKey: Map<string, BannedBookStagedRecord>
+): BannedBookSourceCandidateStatus {
+  if (existingRecordsByKey.has(normalizeBannedBookKey(candidate))) return 'existing_record'
+  if (candidate.evidenceQuality === 'confirmed_source') return 'stageable_candidate'
+  return 'needs_evidence_review'
+}
+
+function nextSourceCandidateAction(status: BannedBookSourceCandidateStatus): string {
+  if (status === 'existing_record') return 'Attach source evidence to existing staged record if it adds provenance.'
+  if (status === 'stageable_candidate') return 'Promote metadata-only staged record draft after evidence QA approval.'
+  return 'Hold until district rows or cross-source evidence are attached.'
+}
+
+export function buildBannedBooksSourceIngestionProjection(
+  existingRecords = dedupeBannedBookRecords(stagedCorpus.records as BannedBookStagedRecord[])
+): BannedBookSourceIngestionProjection {
+  const existingRecordsByKey = new Map(existingRecords.map((record) => [normalizeBannedBookKey(record), record]))
+  const candidates = (sourceIngestionQueue.candidates as BannedBookSourceIngestionCandidate[]).map((candidate) => {
+    const normalizedKey = normalizeBannedBookKey(candidate)
+    const status = sourceCandidateStatus(candidate, existingRecordsByKey)
+    const existingRecord = existingRecordsByKey.get(normalizedKey) ?? null
+    const stagedRecordDraft = status === 'stageable_candidate' ? draftStagedRecordFromSourceCandidate(candidate) : null
+
+    return {
+      ...candidate,
+      normalizedKey,
+      status,
+      existingRecordId: existingRecord?.id ?? null,
+      stagedRecordDraft,
+      nextAction: nextSourceCandidateAction(status),
+    }
+  })
+
+  return {
+    generatedAt: sourceIngestionQueue.generatedAt,
+    mode: sourceIngestionQueue.mode as BannedBookSourceIngestionMode,
+    policy: sourceIngestionQueue.policy,
+    sources: sourceIngestionQueue.sources as BannedBookSourceIngestionSource[],
+    summary: {
+      sourceCount: sourceIngestionQueue.sources.length,
+      candidateCount: candidates.length,
+      existingRecordMatches: candidates.filter((candidate) => candidate.status === 'existing_record').length,
+      stageableCandidates: candidates.filter((candidate) => candidate.status === 'stageable_candidate').length,
+      evidenceReviewRequired: candidates.filter((candidate) => candidate.status === 'needs_evidence_review').length,
+      blockedFullTextActions: BLOCKED_SOURCE_INGESTION_ACTIONS.length,
+    },
+    candidates,
+    blockedActions: BLOCKED_SOURCE_INGESTION_ACTIONS,
+  }
 }
 
 function uniqueEvidence(evidence: BannedBookEvidence[]): BannedBookEvidence[] {
@@ -420,6 +596,7 @@ export function buildBannedBooksCorpusProjection(): BannedBooksCorpusProjection 
     sourceSpine: stagedCorpus.sourceSpine,
     swarmAgents: BANNED_BOOKS_SWARM_AGENTS,
     outreachPackets: BANNED_BOOKS_OUTREACH_PACKETS,
+    sourceIngestionQueue: buildBannedBooksSourceIngestionProjection(records),
     summary: {
       stagedRecords: projectedRecords.length,
       sourceSpineCount: stagedCorpus.sourceSpine.length,
@@ -466,6 +643,14 @@ export function formatBannedBooksCorpusReport(projection = buildBannedBooksCorpu
     '## Outreach Packets',
     '',
     ...projection.outreachPackets.map((packet) => `- ${packet.audience}: ${packet.subject} (${packet.key})`),
+    '',
+    '## Source Ingestion Queue',
+    '',
+    `- Sources queued: ${projection.sourceIngestionQueue.summary.sourceCount}`,
+    `- Discovery candidates: ${projection.sourceIngestionQueue.summary.candidateCount}`,
+    `- Existing record matches: ${projection.sourceIngestionQueue.summary.existingRecordMatches}`,
+    `- Stageable candidates: ${projection.sourceIngestionQueue.summary.stageableCandidates}`,
+    `- Evidence review required: ${projection.sourceIngestionQueue.summary.evidenceReviewRequired}`,
     '',
     '## Staged Works',
     '',

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "deploy:research:seed-ideas": "tsx scripts/seed-vercel-autoresearch-ideas.ts",
     "git:hygiene:report": "tsx scripts/git-hygiene-report.ts",
     "banned-books:report": "tsx scripts/banned-books-corpus-report.ts",
+    "banned-books:ingestion:report": "tsx scripts/banned-books-source-ingestion-report.ts",
     "model-ops:snapshot": "tsx scripts/sync-model-ops-snapshot.ts",
     "model-ops:snapshot:check": "tsx scripts/sync-model-ops-snapshot.ts --check",
     "model-ops:reply-intent:export": "tsx scripts/export-reply-intent-reviews.ts",

--- a/scripts/banned-books-source-ingestion-report.ts
+++ b/scripts/banned-books-source-ingestion-report.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env tsx
+import { buildBannedBooksSourceIngestionProjection } from '../lib/banned-books-corpus'
+
+export function parseArgs(argv: string[]) {
+  const options = {
+    json: false,
+  }
+
+  for (const arg of argv) {
+    if (arg === '--json') {
+      options.json = true
+    } else if (arg === '--help' || arg === '-h') {
+      console.log(`Usage:
+  npm run banned-books:ingestion:report -- [options]
+
+Options:
+  --json  Print machine-readable output.
+`)
+      process.exit(0)
+    } else {
+      throw new Error(`Unknown option: ${arg}`)
+    }
+  }
+
+  return options
+}
+
+export function formatBannedBooksSourceIngestionReport(
+  projection = buildBannedBooksSourceIngestionProjection()
+): string {
+  return [
+    '# Banned Books Source Ingestion Queue',
+    '',
+    `Generated: ${projection.generatedAt}`,
+    `Mode: ${projection.mode}`,
+    `Policy: ${projection.policy}`,
+    '',
+    '## Summary',
+    '',
+    `- Sources queued: ${projection.summary.sourceCount}`,
+    `- Discovery candidates: ${projection.summary.candidateCount}`,
+    `- Existing record matches: ${projection.summary.existingRecordMatches}`,
+    `- Stageable candidates: ${projection.summary.stageableCandidates}`,
+    `- Evidence review required: ${projection.summary.evidenceReviewRequired}`,
+    `- Blocked full-text actions: ${projection.summary.blockedFullTextActions}`,
+    '',
+    '## Sources',
+    '',
+    ...projection.sources.map((source) =>
+      `- ${source.name} (${source.key}): refresh every ${source.refreshCadenceDays} days via ${source.fetchMode}`
+    ),
+    '',
+    '## Candidates',
+    '',
+    ...projection.candidates.map((candidate) =>
+      `- ${candidate.canonicalTitle} by ${candidate.authors.join(', ')}: ${candidate.status}; ${candidate.nextAction}`
+    ),
+    '',
+    '## Blocked Actions',
+    '',
+    ...projection.blockedActions.map((action) => `- ${action}`),
+  ].join('\n')
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  const projection = buildBannedBooksSourceIngestionProjection()
+
+  if (options.json) {
+    console.log(JSON.stringify(projection, null, 2))
+    return
+  }
+
+  console.log(formatBannedBooksSourceIngestionReport(projection))
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Summary
- add a metadata-only source ingestion queue for ALA, PEN America, and EveryLibrary banned/challenged book discovery
- classify discovery candidates as existing records, stageable metadata drafts, or evidence-QA holds
- expose queue status in the Source Protocol Banned Books admin tab and reports
- add npm run banned-books:ingestion:report for human-readable and JSON queue output

## Validation
- npm test -- --run lib/banned-books-corpus.test.ts app/api/admin/source-protocol/overview/route.test.ts app/admin/source-protocol/page.test.tsx
- npm run banned-books:report
- npm run banned-books:report -- --json
- npm run banned-books:ingestion:report
- npm run banned-books:ingestion:report -- --json
- npm run build:knowledge
- npx tsc --noEmit --pretty false
- npm run lint
- git diff --check
- pre-push database health check passed

## Governance notes
- No copyrighted full text was added.
- No crawler writes, OCR, embeddings, source chunks, retrievable records, outreach sends, license grants, production defaults, or payout activation were created.
- Candidate promotion remains evidence-QA and governance-gated.

## Integration Captain
- Rebasing onto current main resolved the inherited typecheck blocker from lib/agent-war-room.test.ts.
- Vercel preview is expected to re-run after the force-with-lease update; verify before merge.
