### PR TITLE
test: fix agent war room readiness fixture

### DIFF
--- a/lib/agent-war-room.test.ts
+++ b/lib/agent-war-room.test.ts
@@ -431,7 +431,7 @@ describe('runAgentWarRoom', () => {
       draft: {
         ...draftResult.goalDraft!,
         readiness_status: 'ship_it_now',
-      } as typeof draftResult.goalDraft,
+      } as unknown as typeof draftResult.goalDraft,
       triggerSource: 'test_war_room',
     })).rejects.toThrow('Goal readiness must be ready_for_delegation before delegation')
 


### PR DESCRIPTION
## Summary
- fixes the intentionally malformed readiness-status fixture so TypeScript accepts the test cast
- preserves the tampered-status regression coverage for the delegation gate

## Validation
- npm test -- --run lib/agent-war-room.test.ts
- npm run build:knowledge
- npx tsc --noEmit --pretty false
- git diff --check

## Integration Notes
- Test-only unblocker for current main typecheck validation.
- No runtime, schema, production config, or customer-data changes.
- Vercel contexts to verify after merge: Vercel – portfolio and Vercel – portfolio-staging.