### PR TITLE
Add Apify replacement bakeoff harness

### DIFF
--- a/docs/apify-call-bakeoff-analysis.md
+++ b/docs/apify-call-bakeoff-analysis.md
@@ -53,9 +53,35 @@ proves the campaign still needs that source.
 
 Source notes for the bakeoff packet:
 
-- Google Maps Platform pricing should be checked from the official pricing page before each run; as of the 2026-05-09 check, Places API Text Search Pro and Nearby Search Pro list 5,000 free monthly calls and then $32 per 1,000 in the first paid tier.
-- Brave Search API pricing should be checked from Brave before each run; as of the 2026-05-09 check, Search is listed at $5 per 1,000 requests with $5 monthly credits.
+- Google Maps Platform pricing should be checked from the official pricing page before each run; as of the 2026-05-24 check, Places API Text Search Pro and Nearby Search Pro list 5,000 free monthly calls and then $32 per 1,000 in the first paid tier.
+- Brave Search API pricing should be checked from Brave before each run; as of the 2026-05-24 check, Search is listed at $5 per 1,000 requests with $5 monthly credits.
 - Reddit source use must be reviewed against Reddit's Data API Wiki and Data API Terms before any commercial workflow uses official Reddit API data. The official wiki lists 100 QPM free-access limits for eligible OAuth clients; the terms say commercial or out-of-scope use may require a separate agreement.
+
+### Executable Test Packet
+
+Use the replacement bakeoff harness to keep this gate repeatable:
+
+```bash
+npm run apify:replacement-bakeoff
+```
+
+Dry-run mode reports which challengers are ready and which are blocked by
+missing read-only credentials. Live API mode is intentionally explicit:
+
+```bash
+npm run apify:replacement-bakeoff -- --run --out=docs/apify-replacement-bakeoff-latest.json
+```
+
+Current credential gate from the 2026-05-24 worktree check:
+
+- `APIFY_TOKEN` and `APIFY_API_TOKEN` exist locally.
+- `BRAVE_SEARCH_API_KEY` is missing, so Reddit/Capterra replacement API tests
+  are blocked.
+- `GOOGLE_MAPS_API_KEY` is missing, so Google Places replacement tests are
+  blocked.
+- LinkedIn post-search replacement remains manual/browser-agent ready because
+  it should be evaluated on accepted leads and account-risk burden, not API
+  result count alone.
 
 ## Configured Apify Call Surfaces
 

--- a/docs/subscription-cancellation-audit.md
+++ b/docs/subscription-cancellation-audit.md
@@ -1125,7 +1125,32 @@ Raw Findings
 - Evidence source updated: `/docs/apify-call-bakeoff-analysis.md`.
 - Dashboard data updated: `/docs/subscription-status.json`.
 - Pricing/terms checked from Brave Search API, Google Maps Platform pricing,
-  Reddit Data API Wiki, and Reddit Data API Terms on 2026-05-09.
+  Reddit Data API Wiki, and Reddit Data API Terms on 2026-05-24.
+- No shared cost-event schema changes and no production write actions.
+
+## 2026-05-24 Apify Replacement Harness Update
+
+Status: YELLOW
+
+Summary:
+
+- No cancellation approvals requested and no cancellation action taken.
+- Added a repeatable replacement bakeoff harness for the productive Apify
+  categories. The harness can dry-run credential readiness now and run live
+  low-volume Brave Search / Google Places challenger calls once read-only keys
+  are available.
+- Current credential check found local Apify tokens, but no
+  `BRAVE_SEARCH_API_KEY` and no `GOOGLE_MAPS_API_KEY`; live replacement API
+  tests are therefore blocked rather than inferred.
+- LinkedIn post-search replacement remains manual/browser-agent ready because
+  the decision depends on accepted lead quality and account-risk burden.
+
+Raw Findings
+
+- New planner: `/lib/apify-replacement-bakeoff.ts`.
+- New CLI harness: `/scripts/apify-replacement-bakeoff.ts`.
+- New command: `npm run apify:replacement-bakeoff`.
+- New tests: `/lib/apify-replacement-bakeoff.test.ts`.
 - No shared cost-event schema changes and no production write actions.
 
 ## 2026-05-09 Budget Query Readiness Update

--- a/lib/apify-replacement-bakeoff.test.ts
+++ b/lib/apify-replacement-bakeoff.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { buildApifyReplacementBakeoffPlan } from './apify-replacement-bakeoff'
+
+describe('buildApifyReplacementBakeoffPlan', () => {
+  it('blocks live API replacement tests when keys are missing', () => {
+    const plan = buildApifyReplacementBakeoffPlan({}, '2026-05-24T00:00:00.000Z')
+
+    expect(plan.tests).toHaveLength(4)
+    expect(plan.blockedCount).toBe(3)
+    expect(plan.manualReadyCount).toBe(1)
+    expect(plan.tests.find((test) => test.category === 'LinkedIn post search')?.status).toBe('manual_ready')
+    expect(plan.nextAction).toContain('missing read-only replacement credentials')
+  })
+
+  it('marks Brave and Google challengers ready when replacement keys exist', () => {
+    const plan = buildApifyReplacementBakeoffPlan({
+      BRAVE_SEARCH_API_KEY: 'brave-test-key',
+      GOOGLE_MAPS_API_KEY: 'google-test-key',
+    }, '2026-05-24T00:00:00.000Z')
+
+    expect(plan.readyCount).toBe(3)
+    expect(plan.blockedCount).toBe(0)
+    expect(plan.tests.map((test) => test.status)).toEqual(
+      expect.arrayContaining(['ready', 'manual_ready'])
+    )
+  })
+})

--- a/lib/apify-replacement-bakeoff.ts
+++ b/lib/apify-replacement-bakeoff.ts
@@ -1,0 +1,92 @@
+export type ReplacementTestStatus = 'ready' | 'blocked' | 'manual_ready'
+
+export interface ReplacementTestSpec {
+  category: string
+  currentApifySignal: string
+  challenger: string
+  requiredEnv: string[]
+  sampleQuery: string
+  acceptanceGate: string
+  status: ReplacementTestStatus
+  missingEnv: string[]
+}
+
+export interface ApifyReplacementBakeoffPlan {
+  generatedAt: string
+  readyCount: number
+  blockedCount: number
+  manualReadyCount: number
+  tests: ReplacementTestSpec[]
+  nextAction: string
+}
+
+const TEST_DEFINITIONS = [
+  {
+    category: 'Reddit listening',
+    currentApifySignal: '72 items / $0.47360 sampled actor cost',
+    challenger: 'Brave Search API with Reddit/source filters',
+    requiredEnv: ['BRAVE_SEARCH_API_KEY'],
+    sampleQuery: 'site:reddit.com nonprofit website migration pain points',
+    acceptanceGate: 'Capture comparable conversations with source URLs, lower review burden, and acceptable attribution.',
+  },
+  {
+    category: 'Google Maps',
+    currentApifySignal: '68 items / $0.58600 sampled actor cost',
+    challenger: 'Google Places API Text Search with field masks and strict quotas',
+    requiredEnv: ['GOOGLE_MAPS_API_KEY'],
+    sampleQuery: 'nonprofit organizations near Omaha NE',
+    acceptanceGate: 'Return enough qualified businesses with required fields while staying inside free or low-tier quota.',
+  },
+  {
+    category: 'LinkedIn post search',
+    currentApifySignal: '135 items / $0.27220 sampled actor cost',
+    challenger: 'Browser-agent sampling plus manual review packet',
+    requiredEnv: [],
+    sampleQuery: 'LinkedIn posts about nonprofit website migration',
+    acceptanceGate: 'Return comparable accepted leads without increasing account risk or manual review time.',
+  },
+  {
+    category: 'Capterra reviews',
+    currentApifySignal: '40 items / $0.62400 sampled actor cost',
+    challenger: 'Brave Search or browser capture into a source register',
+    requiredEnv: ['BRAVE_SEARCH_API_KEY'],
+    sampleQuery: 'site:capterra.com nonprofit CRM reviews implementation',
+    acceptanceGate: 'Match accepted evidence quality while preserving reviewable source URLs and snippets.',
+  },
+] as const
+
+export function buildApifyReplacementBakeoffPlan(
+  env: Record<string, string | undefined> = process.env,
+  generatedAt = new Date().toISOString()
+): ApifyReplacementBakeoffPlan {
+  const tests = TEST_DEFINITIONS.map((definition) => {
+    const missingEnv = definition.requiredEnv.filter((key) => !env[key]?.trim())
+    const status: ReplacementTestStatus = definition.requiredEnv.length === 0
+      ? 'manual_ready'
+      : missingEnv.length === 0
+        ? 'ready'
+        : 'blocked'
+
+    return {
+      ...definition,
+      requiredEnv: [...definition.requiredEnv],
+      missingEnv,
+      status,
+    }
+  })
+
+  const readyCount = tests.filter((test) => test.status === 'ready').length
+  const blockedCount = tests.filter((test) => test.status === 'blocked').length
+  const manualReadyCount = tests.filter((test) => test.status === 'manual_ready').length
+
+  return {
+    generatedAt,
+    readyCount,
+    blockedCount,
+    manualReadyCount,
+    tests,
+    nextAction: blockedCount > 0
+      ? 'Add the missing read-only replacement credentials, then rerun scripts/apify-replacement-bakeoff.ts --run.'
+      : 'Run scripts/apify-replacement-bakeoff.ts --run and compare accepted-result rate against the Apify baseline.',
+  }
+}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "deploy:metrics": "tsx scripts/vercel-deployment-metrics.ts",
     "deploy:research:plan": "tsx scripts/vercel-deployment-research-plan.ts",
     "deploy:research:seed-ideas": "tsx scripts/seed-vercel-autoresearch-ideas.ts",
+    "apify:replacement-bakeoff": "tsx scripts/apify-replacement-bakeoff.ts",
     "git:hygiene:report": "tsx scripts/git-hygiene-report.ts",
     "banned-books:report": "tsx scripts/banned-books-corpus-report.ts",
     "banned-books:ingestion:report": "tsx scripts/banned-books-source-ingestion-report.ts",

--- a/scripts/apify-replacement-bakeoff.ts
+++ b/scripts/apify-replacement-bakeoff.ts
@@ -1,0 +1,133 @@
+import { config } from 'dotenv'
+import { mkdirSync, writeFileSync } from 'fs'
+import { dirname, resolve } from 'path'
+import { buildApifyReplacementBakeoffPlan } from '../lib/apify-replacement-bakeoff'
+
+config({ path: resolve(process.cwd(), '.env.local') })
+
+const args = new Set(process.argv.slice(2))
+const shouldRun = args.has('--run')
+const outputArg = process.argv.find((arg) => arg.startsWith('--out='))
+const outputPath = outputArg?.slice('--out='.length)
+
+async function runBraveSearch(query: string) {
+  const key = process.env.BRAVE_SEARCH_API_KEY
+  if (!key) return null
+
+  const url = new URL('https://api.search.brave.com/res/v1/web/search')
+  url.searchParams.set('q', query)
+  url.searchParams.set('count', '5')
+
+  const response = await fetch(url, {
+    headers: {
+      Accept: 'application/json',
+      'X-Subscription-Token': key,
+    },
+  })
+
+  if (!response.ok) {
+    return { ok: false, status: response.status, resultCount: 0 }
+  }
+
+  const body = await response.json() as { web?: { results?: unknown[] } }
+  return { ok: true, status: response.status, resultCount: body.web?.results?.length ?? 0 }
+}
+
+async function runGooglePlacesTextSearch(query: string) {
+  const key = process.env.GOOGLE_MAPS_API_KEY
+  if (!key) return null
+
+  const response = await fetch('https://places.googleapis.com/v1/places:searchText', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Goog-Api-Key': key,
+      'X-Goog-FieldMask': 'places.id,places.displayName,places.formattedAddress,places.websiteUri',
+    },
+    body: JSON.stringify({ textQuery: query, maxResultCount: 5 }),
+  })
+
+  if (!response.ok) {
+    return { ok: false, status: response.status, resultCount: 0 }
+  }
+
+  const body = await response.json() as { places?: unknown[] }
+  return { ok: true, status: response.status, resultCount: body.places?.length ?? 0 }
+}
+
+async function main() {
+  const plan = buildApifyReplacementBakeoffPlan()
+  const liveResults: Array<{
+    category: string
+    challenger: string
+    status: 'skipped' | 'ready' | 'ok' | 'failed'
+    resultCount: number
+    note: string
+  }> = []
+
+  for (const test of plan.tests) {
+    if (!shouldRun || test.status === 'blocked') {
+      liveResults.push({
+        category: test.category,
+        challenger: test.challenger,
+        status: test.status === 'blocked' ? 'skipped' : 'ready',
+        resultCount: 0,
+        note: test.status === 'blocked'
+          ? `Missing env: ${test.missingEnv.join(', ')}`
+          : 'Ready for manual/browser review.',
+      })
+      continue
+    }
+
+    if (test.challenger.startsWith('Brave Search')) {
+      const result = await runBraveSearch(test.sampleQuery)
+      liveResults.push({
+        category: test.category,
+        challenger: test.challenger,
+        status: result?.ok ? 'ok' : 'failed',
+        resultCount: result?.resultCount ?? 0,
+        note: result ? `HTTP ${result.status}` : 'Missing Brave key',
+      })
+      continue
+    }
+
+    if (test.challenger.startsWith('Google Places')) {
+      const result = await runGooglePlacesTextSearch(test.sampleQuery)
+      liveResults.push({
+        category: test.category,
+        challenger: test.challenger,
+        status: result?.ok ? 'ok' : 'failed',
+        resultCount: result?.resultCount ?? 0,
+        note: result ? `HTTP ${result.status}` : 'Missing Google Maps key',
+      })
+      continue
+    }
+
+    liveResults.push({
+      category: test.category,
+      challenger: test.challenger,
+      status: 'ready',
+      resultCount: 0,
+      note: 'Manual/browser-agent packet; no API call made by this script.',
+    })
+  }
+
+  const report = {
+    ...plan,
+    mode: shouldRun ? 'run' : 'dry_run',
+    liveResults,
+  }
+
+  const serialized = JSON.stringify(report, null, 2)
+  if (outputPath) {
+    mkdirSync(dirname(outputPath), { recursive: true })
+    writeFileSync(outputPath, `${serialized}\n`)
+  }
+
+  console.log(serialized)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- adds a repeatable Apify replacement bakeoff planner and CLI harness
- wires the command as npm run apify:replacement-bakeoff
- documents the May 24 credential gate: Apify tokens exist, Brave Search and Google Maps keys are missing, LinkedIn replacement is manual/browser-agent ready

## What this enables
- Dry-run readiness checks without provider calls
- Future live low-volume Brave Search and Google Places challenger calls via --run once read-only keys exist
- Repeatable accepted-result comparison against the productive Apify categories without touching shared cost-event schema

## Validation
- git diff --check
- npm test -- --run lib/apify-replacement-bakeoff.test.ts lib/subscription-status.test.ts lib/technology-bakeoff.test.ts
- npm run apify:replacement-bakeoff
- npm run lint -- --file lib/apify-replacement-bakeoff.ts --file scripts/apify-replacement-bakeoff.ts
- npm run db:health-check

## Sources rechecked 2026-05-24
- Brave Search API: https://brave.com/search/api/
- Google Maps Platform pricing: https://developers.google.com/maps/billing-and-pricing/pricing
- Reddit Data API Wiki: https://support.reddithelp.com/hc/en-us/articles/16160319875092-Reddit-Data-API-Wiki
- Reddit Data API Terms: https://redditinc.com/policies/data-api-terms

## Notes
- No cancellation action taken.
- No shared cost-event schema changes.
- Live replacement calls are intentionally blocked until BRAVE_SEARCH_API_KEY and GOOGLE_MAPS_API_KEY are available.