### PR TITLE
feat: add client ai ops projection status

### DIFF
--- a/app/api/admin/client-projects/[id]/ai-ops/route.test.ts
+++ b/app/api/admin/client-projects/[id]/ai-ops/route.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  getRoadmapBundleForProject: vi.fn(),
+  ensureRoadmapForProject: vi.fn(),
+  projectRoadmapTasks: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/client-ai-ops-roadmap-db', () => ({
+  getRoadmapBundleForProject: mocks.getRoadmapBundleForProject,
+  ensureRoadmapForProject: mocks.ensureRoadmapForProject,
+  projectRoadmapTasks: mocks.projectRoadmapTasks,
+}))
+
+import { GET } from './route'
+
+function request() {
+  return new Request('http://localhost/api/admin/client-projects/project-1/ai-ops', {
+    headers: { authorization: 'Bearer token' },
+  })
+}
+
+describe('GET /api/admin/client-projects/[id]/ai-ops', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.getRoadmapBundleForProject.mockResolvedValue({
+      clientView: {
+        title: 'Acme AI Ops Roadmap',
+        projectionStatus: {
+          tasksTotal: 2,
+          tasksComplete: 1,
+          blockedTasks: 0,
+          clientActionCount: 1,
+          amadutownActionCount: 0,
+          sharedActionCount: 0,
+          approvalNeededCount: 1,
+          isolationRequiredCount: 1,
+          overdueTasks: 0,
+          staleCostItems: 0,
+          reportMissing: false,
+          nextReportingAction: 'Review approval-gated roadmap work',
+        },
+      },
+    })
+  })
+
+  it('returns the roadmap projection status in the admin AI Ops response', async () => {
+    const response = await GET(request() as never, { params: Promise.resolve({ id: 'project-1' }) })
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(mocks.getRoadmapBundleForProject).toHaveBeenCalledWith('project-1')
+    expect(body.roadmap.clientView.projectionStatus).toMatchObject({
+      approvalNeededCount: 1,
+      isolationRequiredCount: 1,
+      nextReportingAction: 'Review approval-gated roadmap work',
+    })
+  })
+
+  it('requires admin auth before reading the roadmap bundle', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await GET(request() as never, { params: Promise.resolve({ id: 'project-1' }) })
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.getRoadmapBundleForProject).not.toHaveBeenCalled()
+  })
+})

--- a/docs/client-ai-ops-roadmap-sop.md
+++ b/docs/client-ai-ops-roadmap-sop.md
@@ -74,6 +74,22 @@ Monthly reports should separate:
 
 Client-facing summaries should be understandable and avoid exposing private logs, agent traces, credentials, or internal-only notes.
 
+## Roadmap Projection Status
+
+The client roadmap read model exposes a compact projection status for dashboards and admin monitoring. It is derived from existing roadmap tasks, org-board metadata, cost items, and the latest roadmap report.
+
+Projection status may show:
+
+- total and completed client-visible tasks,
+- blocked tasks,
+- open client, AmaduTown, and shared actions,
+- approval-gated and isolation-required work counts,
+- overdue task and stale cost counts from the latest monitor report,
+- whether the first report is missing,
+- the next reporting action.
+
+Keep this projection read-only. It can recommend follow-up, escalation, cost refreshes, or approval review, but it must not create credentials, connect OAuth, activate workflows, send outbound messages, publish client-facing reports, mutate client data, or change production configuration without the normal approval path.
+
 ## Roadmap Rule Checklist
 
 Use this checklist whenever a roadmap feature, monitor, report, or client implementation phase changes:
@@ -84,6 +100,7 @@ Use this checklist whenever a roadmap feature, monitor, report, or client implem
 - Status updates from either projection sync back to the roadmap task.
 - Phase rollups and cost summaries refresh after task or cost changes.
 - The monitor can create a roadmap report and follow-up task when drift, stale pricing, missing reports, or blockers appear.
+- Roadmap projection status is visible from the same source data and remains read-only.
 - Client-facing output excludes private logs, agent traces, credentials, and internal-only notes.
 
 ## Real Client Pilot Checklist

--- a/lib/client-ai-ops-roadmap-db.ts
+++ b/lib/client-ai-ops-roadmap-db.ts
@@ -129,6 +129,7 @@ export async function getRoadmapBundleForProject(clientProjectId: string): Promi
         status: task.status as never,
         due_date: task.due_date as string | null,
         client_visible: Boolean(task.client_visible),
+        metadata: task.metadata as Record<string, unknown> | null,
       })),
       costItems: costItems.map((item) => ({
         payer: item.payer as never,

--- a/lib/client-ai-ops-roadmap.test.ts
+++ b/lib/client-ai-ops-roadmap.test.ts
@@ -140,6 +140,27 @@ describe('client AI ops roadmap', () => {
           status: 'pending',
           due_date: null,
           client_visible: true,
+          metadata: {
+            org_board: {
+              approval_posture: 'required',
+              isolation_required: false,
+            },
+          },
+        },
+        {
+          phase_id: 'phase-1',
+          title: 'Run synthetic QA',
+          owner_type: 'amadutown',
+          priority: 'high',
+          status: 'blocked',
+          due_date: null,
+          client_visible: true,
+          metadata: {
+            org_board: {
+              approval_posture: 'none',
+              isolation_required: true,
+            },
+          },
         },
       ],
       costItems: [],
@@ -180,6 +201,19 @@ describe('client AI ops roadmap', () => {
       'cloud_runtime',
       'hybrid_local_cloud',
     ])
+    expect(view.projectionStatus).toMatchObject({
+      tasksTotal: 2,
+      tasksComplete: 0,
+      blockedTasks: 1,
+      clientActionCount: 1,
+      amadutownActionCount: 1,
+      approvalNeededCount: 2,
+      isolationRequiredCount: 1,
+      overdueTasks: 1,
+      staleCostItems: 2,
+      reportMissing: false,
+      nextReportingAction: 'Resolve blocked roadmap tasks',
+    })
     expect(JSON.stringify(view.latestReport)).not.toContain('Internal escalation note')
   })
 })

--- a/lib/client-ai-ops-roadmap.ts
+++ b/lib/client-ai-ops-roadmap.ts
@@ -152,6 +152,21 @@ export interface RoadmapClientReportSummary {
   } | null
 }
 
+export interface RoadmapClientProjectionStatus {
+  tasksTotal: number
+  tasksComplete: number
+  blockedTasks: number
+  clientActionCount: number
+  amadutownActionCount: number
+  sharedActionCount: number
+  approvalNeededCount: number
+  isolationRequiredCount: number
+  overdueTasks: number
+  staleCostItems: number
+  reportMissing: boolean
+  nextReportingAction: string
+}
+
 export interface RoadmapClientView {
   title: string
   status: RoadmapStatus
@@ -159,6 +174,7 @@ export interface RoadmapClientView {
   runtimePlacementOptions: RoadmapRuntimePlacementOption[]
   phases: RoadmapClientPhase[]
   costSummary: RoadmapCostRollup
+  projectionStatus: RoadmapClientProjectionStatus
   nextActions: Array<{ title: string; ownerType: RoadmapTaskOwner; priority: RoadmapPriority; dueDate: string | null }>
   latestReport: RoadmapClientReportSummary | null
 }
@@ -569,7 +585,16 @@ export function buildClientRoadmapView(input: {
     estimated_client_startup_cost?: number | string | null
     estimated_monthly_operating_cost?: number | string | null
   }>
-  tasks: Array<{ phase_id: string; title: string; owner_type: RoadmapTaskOwner; priority: RoadmapPriority; status: RoadmapTaskStatus; due_date: string | null; client_visible: boolean }>
+  tasks: Array<{
+    phase_id: string
+    title: string
+    owner_type: RoadmapTaskOwner
+    priority: RoadmapPriority
+    status: RoadmapTaskStatus
+    due_date: string | null
+    client_visible: boolean
+    metadata?: Record<string, unknown> | null
+  }>
   costItems: Array<Pick<RoadmapCostItemDraft, 'payer' | 'costType' | 'amount' | 'category'>>
   reports?: Array<{
     title: string
@@ -585,6 +610,33 @@ export function buildClientRoadmapView(input: {
 }): RoadmapClientView {
   const visibleTasks = input.tasks.filter((task) => task.client_visible)
   const latestReport = input.reports?.[0]
+  const monitoringSummary = latestReport?.monitoring_summary
+  const overdueTasks = typeof monitoringSummary?.overdue_tasks === 'number' ? monitoringSummary.overdue_tasks : 0
+  const staleCostItems = typeof monitoringSummary?.stale_cost_items === 'number' ? monitoringSummary.stale_cost_items : 0
+  const reportMissing = typeof monitoringSummary?.report_missing === 'boolean' ? monitoringSummary.report_missing : !latestReport
+  const approvalNeededCount = input.tasks.filter(taskRequiresApproval).length
+    + (Array.isArray(latestReport?.approval_needed) ? latestReport.approval_needed.length : 0)
+  const projectionStatus: RoadmapClientProjectionStatus = {
+    tasksTotal: visibleTasks.length,
+    tasksComplete: visibleTasks.filter((task) => task.status === 'complete').length,
+    blockedTasks: visibleTasks.filter((task) => task.status === 'blocked').length,
+    clientActionCount: visibleTasks.filter((task) => task.owner_type === 'client' && task.status !== 'complete' && task.status !== 'cancelled').length,
+    amadutownActionCount: visibleTasks.filter((task) => task.owner_type === 'amadutown' && task.status !== 'complete' && task.status !== 'cancelled').length,
+    sharedActionCount: visibleTasks.filter((task) => task.owner_type === 'shared' && task.status !== 'complete' && task.status !== 'cancelled').length,
+    approvalNeededCount,
+    isolationRequiredCount: input.tasks.filter(taskRequiresIsolation).length,
+    overdueTasks,
+    staleCostItems,
+    reportMissing,
+    nextReportingAction: nextRoadmapReportingAction({
+      blockedTasks: visibleTasks.filter((task) => task.status === 'blocked').length,
+      approvalNeededCount,
+      overdueTasks,
+      staleCostItems,
+      reportMissing,
+      clientActionCount: visibleTasks.filter((task) => task.owner_type === 'client' && task.status !== 'complete' && task.status !== 'cancelled').length,
+    }),
+  }
   const phases = input.phases.map((phase) => {
     const phaseTasks = visibleTasks.filter((task) => task.phase_id === phase.id)
     return {
@@ -610,6 +662,7 @@ export function buildClientRoadmapView(input: {
       : DEFAULT_RUNTIME_PLACEMENT_OPTIONS.map((option) => ({ ...option })),
     phases,
     costSummary: rollUpRoadmapCosts(input.costItems),
+    projectionStatus,
     nextActions: visibleTasks
       .filter((task) => task.status !== 'complete' && task.status !== 'cancelled')
       .slice(0, 5)
@@ -640,4 +693,35 @@ export function buildClientRoadmapView(input: {
         }
       : null,
   }
+}
+
+function taskOrgBoard(task: { metadata?: Record<string, unknown> | null }): Record<string, unknown> | null {
+  const orgBoard = task.metadata?.org_board
+  return orgBoard && typeof orgBoard === 'object' ? orgBoard as Record<string, unknown> : null
+}
+
+function taskRequiresApproval(task: { metadata?: Record<string, unknown> | null }): boolean {
+  const approvalPosture = taskOrgBoard(task)?.approval_posture
+  return approvalPosture === 'required' || approvalPosture === 'pending'
+}
+
+function taskRequiresIsolation(task: { metadata?: Record<string, unknown> | null }): boolean {
+  return taskOrgBoard(task)?.isolation_required === true
+}
+
+function nextRoadmapReportingAction(input: {
+  blockedTasks: number
+  approvalNeededCount: number
+  overdueTasks: number
+  staleCostItems: number
+  reportMissing: boolean
+  clientActionCount: number
+}): string {
+  if (input.reportMissing) return 'Generate first roadmap report'
+  if (input.blockedTasks > 0) return 'Resolve blocked roadmap tasks'
+  if (input.approvalNeededCount > 0) return 'Review approval-gated roadmap work'
+  if (input.overdueTasks > 0) return 'Escalate overdue roadmap tasks'
+  if (input.staleCostItems > 0) return 'Refresh stale roadmap cost assumptions'
+  if (input.clientActionCount > 0) return 'Follow up on client-owned roadmap actions'
+  return 'Continue scheduled roadmap monitoring'
 }


### PR DESCRIPTION
Summary
- Add a read-only projection status to the Client AI Ops roadmap client view.
- Derive progress, blocker, approval, isolation, monitoring, and next reporting action counts from existing roadmap task/report data.
- Pass task metadata into the read model and cover the admin AI Ops API response boundary.
- Document the projection as read-only and approval-gated in the roadmap SOP.

Validation
- npm run worktree:env -- --source /Users/vambahsillah/Projects/Portfolio
- npm test -- lib/client-ai-ops-roadmap.test.ts app/api/admin/client-projects/[id]/ai-ops/route.test.ts app/api/cron/client-ai-ops-monitor/route.test.ts lib/client-ai-ops-technology-registry.test.ts
- npm run build:knowledge
- npx tsc --noEmit --pretty false
- git diff --check
- Push hook ran npm run db:health-check successfully.

Integration Notes
- No migrations or environment changes.
- V1 remains read-only: no credential sync, OAuth connection, provider write, outbound send, publishing, deploy, or client-data mutation was added.
- Open PR overlap check: PR #369 touches Agent Governance UI/tests only; this PR is scoped to Client AI Ops roadmap/read-model/API test/docs.
- Vercel contexts not checked from this non-captain lane: Vercel – portfolio and Vercel – portfolio-staging remain integration-captain gates.
