### PR TITLE
Add banned books source import dry run

### DIFF
--- a/data/source-protocol/banned-books-source-import-sample.json
+++ b/data/source-protocol/banned-books-source-import-sample.json
@@ -1,0 +1,65 @@
+{
+  "generatedAt": "2026-05-24T00:00:00.000Z",
+  "sourceKey": "ala-most-challenged-2025",
+  "sourceName": "ALA Most Challenged Books 2025",
+  "sourceUrl": "https://www.ala.org/bbooks/frequentlychallengedbooks/top10",
+  "rows": [
+    {
+      "externalId": "ala-2025-gender-queer",
+      "canonicalTitle": "Gender Queer",
+      "authors": ["Maia Kobabe"],
+      "banStatus": "challenged",
+      "evidenceType": "challenge_list",
+      "evidenceNote": "Appears in the ALA 2025 Most Challenged Books source page.",
+      "jurisdictionContext": "U.S. libraries and schools; ALA 2025 Most Challenged Books list.",
+      "affectedAudience": "K-12 students and public library patrons",
+      "evidenceQuality": "confirmed_source",
+      "rightsholderHint": "author_or_publisher",
+      "editionAliases": ["Gender Queer: A Memoir"],
+      "sensitivityFlags": ["lgbtqia"]
+    },
+    {
+      "externalId": "ala-2025-the-57-bus",
+      "canonicalTitle": "The 57 Bus",
+      "authors": ["Dashka Slater"],
+      "banStatus": "challenged",
+      "evidenceType": "challenge_list",
+      "evidenceNote": "Manual export row from ALA challenged-book source review; source URL retained for QA.",
+      "jurisdictionContext": "U.S. libraries and schools; challenged-book source review.",
+      "affectedAudience": "K-12 students and public library patrons",
+      "evidenceQuality": "confirmed_source",
+      "rightsholderHint": "author_or_publisher",
+      "editionAliases": ["The 57 Bus: A True Story of Two Teenagers and the Crime That Changed Their Lives"],
+      "sensitivityFlags": ["lgbtqia", "race", "juvenile_justice"]
+    },
+    {
+      "externalId": "manual-missing-evidence",
+      "canonicalTitle": "Manual Row Missing Evidence",
+      "authors": ["Example Author"],
+      "banStatus": "unknown",
+      "evidenceType": "challenge_context",
+      "evidenceNote": "",
+      "jurisdictionContext": "Manual import row without enough source evidence.",
+      "affectedAudience": "Unknown",
+      "evidenceQuality": "needs_cross_check",
+      "rightsholderHint": "unknown",
+      "editionAliases": [],
+      "sensitivityFlags": []
+    },
+    {
+      "externalId": "manual-full-text-rejected",
+      "canonicalTitle": "Full Text Should Be Rejected",
+      "authors": ["Example Author"],
+      "banStatus": "challenged",
+      "evidenceType": "challenge_context",
+      "evidenceNote": "This row intentionally contains a forbidden fullText field for importer validation.",
+      "jurisdictionContext": "Manual import validation fixture.",
+      "affectedAudience": "K-12 students",
+      "evidenceQuality": "confirmed_source",
+      "rightsholderHint": "author_or_publisher",
+      "editionAliases": [],
+      "sensitivityFlags": [],
+      "fullText": "This field must not be accepted into the source queue."
+    }
+  ]
+}

--- a/docs/banned-books-rights-ready-corpus.md
+++ b/docs/banned-books-rights-ready-corpus.md
@@ -18,6 +18,8 @@ npm run banned-books:report
 npm run banned-books:report -- --json
 npm run banned-books:ingestion:report
 npm run banned-books:ingestion:report -- --json
+npm run banned-books:source:import
+npm run banned-books:source:import -- --input data/source-protocol/banned-books-source-import-sample.json --json
 ```
 
 The projection reuses the existing Source-Respecting LLM Protocol:
@@ -85,6 +87,18 @@ The queue is deliberately dry-run only. It may propose a staged metadata draft,
 but it cannot write to `licensed_works`, `license_grants`, `source_chunks`,
 retrieval indexes, outreach tools, or payout tables. Promotion still requires
 evidence QA and governance approval.
+
+## Source Import Dry Run
+
+`npm run banned-books:source:import` consumes a manual or public metadata export
+and produces an import plan. The importer rejects unknown sources and any row
+that contains full-text-like fields such as `fullText`, `content`, `body`,
+`excerptText`, or `ocrText`.
+
+Rows that are not duplicates and have confirmed source evidence become
+`ready_for_qa` queue append drafts. The importer still performs no writes; the
+append draft must be reviewed by Evidence QA before it is copied into the source
+ingestion queue.
 
 ## Review Loop
 

--- a/docs/source-respecting-llm-protocol.md
+++ b/docs/source-respecting-llm-protocol.md
@@ -129,6 +129,7 @@ Banned-books corpus foundation:
 - `/admin/source-protocol` includes a `Banned Books` tab for the MECE agent lanes, source ingestion queue, staged shortlist, source spine, read-only outreach packet templates, and safeguards.
 - `npm run banned-books:report` prints the current staged registry, swarm lanes, source ingestion queue, outreach packet templates, next actions, and safeguards for recurring review.
 - `npm run banned-books:ingestion:report` prints the source refresh queue, candidate classifications, evidence QA holds, and blocked full-text actions.
+- `npm run banned-books:source:import` consumes manual/public source metadata exports in dry-run mode, rejects full-text-like fields, and emits Evidence QA-gated queue append drafts.
 
 Smoke test:
 

--- a/lib/banned-books-source-importer.test.ts
+++ b/lib/banned-books-source-importer.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildBannedBooksSourceImportPlan,
+  type BannedBookSourceImportFile,
+} from './banned-books-source-importer'
+
+const importFile: BannedBookSourceImportFile = {
+  generatedAt: '2026-05-24T00:00:00.000Z',
+  sourceKey: 'ala-most-challenged-2025',
+  sourceUrl: 'https://www.ala.org/bbooks/frequentlychallengedbooks/top10',
+  rows: [
+    {
+      externalId: 'ala-2025-gender-queer',
+      canonicalTitle: 'Gender Queer',
+      authors: ['Maia Kobabe'],
+      banStatus: 'challenged',
+      evidenceType: 'challenge_list',
+      evidenceNote: 'Existing staged record.',
+      jurisdictionContext: 'ALA 2025 source page.',
+      affectedAudience: 'K-12 students',
+      evidenceQuality: 'confirmed_source',
+      rightsholderHint: 'author_or_publisher',
+      editionAliases: [],
+      sensitivityFlags: ['lgbtqia'],
+    },
+    {
+      externalId: 'ala-2025-new-ready-title',
+      canonicalTitle: 'New Ready Title',
+      authors: ['Example Author'],
+      banStatus: 'challenged',
+      evidenceType: 'challenge_list',
+      evidenceNote: 'Confirmed source evidence.',
+      jurisdictionContext: 'ALA 2025 source page.',
+      affectedAudience: 'K-12 students',
+      evidenceQuality: 'confirmed_source',
+      rightsholderHint: 'author_or_publisher',
+      editionAliases: [],
+      sensitivityFlags: [],
+    },
+    {
+      externalId: 'manual-missing-evidence',
+      canonicalTitle: 'Missing Evidence',
+      authors: ['Example Author'],
+      banStatus: 'unknown',
+      evidenceType: 'challenge_context',
+      evidenceNote: '',
+      jurisdictionContext: 'Manual import row.',
+      affectedAudience: 'Unknown',
+      evidenceQuality: 'needs_cross_check',
+      rightsholderHint: 'unknown',
+      editionAliases: [],
+      sensitivityFlags: [],
+    },
+    {
+      externalId: 'manual-full-text-rejected',
+      canonicalTitle: 'Full Text Rejected',
+      authors: ['Example Author'],
+      banStatus: 'challenged',
+      evidenceType: 'challenge_context',
+      evidenceNote: 'Forbidden field validation.',
+      jurisdictionContext: 'Manual import row.',
+      affectedAudience: 'K-12 students',
+      evidenceQuality: 'confirmed_source',
+      rightsholderHint: 'author_or_publisher',
+      editionAliases: [],
+      sensitivityFlags: [],
+      fullText: 'Reject this row.',
+    },
+  ],
+}
+
+describe('banned books source importer', () => {
+  it('builds a dry-run queue import plan with approval-gated append drafts', () => {
+    const plan = buildBannedBooksSourceImportPlan(importFile)
+
+    expect(plan.dryRun).toBe(true)
+    expect(plan.summary).toMatchObject({
+      rows: 4,
+      existingRecords: 1,
+      duplicateQueueRows: 0,
+      readyForQa: 1,
+      needsEvidenceReview: 1,
+      rejectedRows: 1,
+      queueAppendDrafts: 1,
+    })
+    expect(plan.rows.find((row) => row.canonicalTitle === 'New Ready Title')).toMatchObject({
+      status: 'ready_for_qa',
+      approvalRoute: 'evidence_qa_audit',
+      queueAppendDraft: expect.objectContaining({
+        canonicalTitle: 'New Ready Title',
+        sourceKey: 'ala-most-challenged-2025',
+      }),
+    })
+  })
+
+  it('rejects unknown source keys before queue append drafting', () => {
+    const plan = buildBannedBooksSourceImportPlan({
+      ...importFile,
+      sourceKey: 'unknown-source',
+      rows: [importFile.rows[1]],
+    })
+
+    expect(plan.summary.rejectedRows).toBe(1)
+    expect(plan.summary.queueAppendDrafts).toBe(0)
+    expect(plan.rows[0]).toMatchObject({
+      status: 'rejected_invalid_source',
+      approvalRoute: 'blocked',
+    })
+  })
+
+  it('rejects rows containing full text or OCR-like fields', () => {
+    const plan = buildBannedBooksSourceImportPlan(importFile)
+    const rejected = plan.rows.find((row) => row.externalId === 'manual-full-text-rejected')
+
+    expect(rejected).toMatchObject({
+      status: 'rejected_for_full_text',
+      approvalRoute: 'blocked',
+      queueAppendDraft: null,
+    })
+    expect(plan.blockedActions.join(' ')).toContain('No full text')
+  })
+})

--- a/lib/banned-books-source-importer.ts
+++ b/lib/banned-books-source-importer.ts
@@ -1,0 +1,219 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import sourceIngestionQueue from '@/data/source-protocol/banned-books-source-ingestion-queue.json'
+import {
+  buildBannedBooksSourceIngestionProjection,
+  buildBannedBooksCorpusProjection,
+  normalizeBannedBookKey,
+  type BannedBookBanStatus,
+  type BannedBookEvidenceQuality,
+  type BannedBookEvidenceType,
+  type BannedBookSourceIngestionCandidate,
+} from './banned-books-corpus'
+
+const FORBIDDEN_TEXT_FIELDS = ['fullText', 'text', 'content', 'body', 'excerptText', 'ocrText']
+
+export type BannedBookSourceImportRow = {
+  externalId: string
+  canonicalTitle: string
+  authors: string[]
+  banStatus: BannedBookBanStatus
+  sourceUrl?: string
+  evidenceType: BannedBookEvidenceType
+  evidenceNote: string
+  jurisdictionContext: string
+  affectedAudience: string
+  evidenceQuality: BannedBookEvidenceQuality
+  rightsholderHint: BannedBookSourceIngestionCandidate['rightsholderHint']
+  editionAliases: string[]
+  sensitivityFlags: string[]
+  [key: string]: unknown
+}
+
+export type BannedBookSourceImportFile = {
+  generatedAt: string
+  sourceKey: string
+  sourceName?: string
+  sourceUrl: string
+  rows: BannedBookSourceImportRow[]
+}
+
+export type BannedBookSourceImportStatus =
+  | 'existing_record'
+  | 'duplicate_in_queue'
+  | 'ready_for_qa'
+  | 'needs_evidence_review'
+  | 'rejected_for_full_text'
+  | 'rejected_invalid_source'
+
+export type BannedBookSourceImportPlan = {
+  generatedAt: string
+  sourceKey: string
+  sourceUrl: string
+  dryRun: true
+  summary: {
+    rows: number
+    existingRecords: number
+    duplicateQueueRows: number
+    readyForQa: number
+    needsEvidenceReview: number
+    rejectedRows: number
+    queueAppendDrafts: number
+  }
+  rows: Array<{
+    externalId: string
+    canonicalTitle: string
+    authors: string[]
+    normalizedKey: string
+    status: BannedBookSourceImportStatus
+    reason: string
+    approvalRoute: 'evidence_qa_audit' | 'blocked'
+    queueAppendDraft: BannedBookSourceIngestionCandidate | null
+  }>
+  blockedActions: string[]
+}
+
+export function loadBannedBooksSourceImportFile(inputPath: string): BannedBookSourceImportFile {
+  const resolvedPath = path.resolve(inputPath)
+  const parsed = JSON.parse(fs.readFileSync(resolvedPath, 'utf8')) as BannedBookSourceImportFile
+  if (!parsed.sourceKey || !parsed.sourceUrl || !Array.isArray(parsed.rows)) {
+    throw new Error('Import file must include sourceKey, sourceUrl, and rows.')
+  }
+  return parsed
+}
+
+function rowHasForbiddenText(row: BannedBookSourceImportRow): boolean {
+  return FORBIDDEN_TEXT_FIELDS.some((field) => typeof row[field] === 'string' && String(row[field]).trim().length > 0)
+}
+
+function rowHasMinimumEvidence(row: BannedBookSourceImportRow, sourceUrl: string): boolean {
+  return Boolean(
+    row.externalId &&
+    row.canonicalTitle &&
+    row.authors?.length > 0 &&
+    (row.sourceUrl || sourceUrl) &&
+    row.evidenceType &&
+    row.evidenceNote?.trim()
+  )
+}
+
+function toQueueCandidate(
+  sourceKey: string,
+  sourceUrl: string,
+  row: BannedBookSourceImportRow
+): BannedBookSourceIngestionCandidate {
+  return {
+    sourceKey,
+    externalId: row.externalId,
+    canonicalTitle: row.canonicalTitle,
+    authors: row.authors,
+    banStatus: row.banStatus,
+    sourceUrl: row.sourceUrl ?? sourceUrl,
+    evidenceType: row.evidenceType,
+    evidenceNote: row.evidenceNote,
+    jurisdictionContext: row.jurisdictionContext,
+    affectedAudience: row.affectedAudience,
+    evidenceQuality: row.evidenceQuality,
+    rightsholderHint: row.rightsholderHint,
+    editionAliases: row.editionAliases ?? [],
+    sensitivityFlags: row.sensitivityFlags ?? [],
+  }
+}
+
+export function buildBannedBooksSourceImportPlan(
+  importFile: BannedBookSourceImportFile
+): BannedBookSourceImportPlan {
+  const knownSourceKeys = new Set(sourceIngestionQueue.sources.map((source) => source.key))
+  const existingCorpus = buildBannedBooksCorpusProjection()
+  const existingRecordKeys = new Set(existingCorpus.records.map((record) => record.normalizedKey))
+  const existingQueue = buildBannedBooksSourceIngestionProjection()
+  const queuedExternalIds = new Set(existingQueue.candidates.map((candidate) => candidate.externalId))
+  const queuedKeys = new Set(existingQueue.candidates.map((candidate) => candidate.normalizedKey))
+
+  const rows = importFile.rows.map((row) => {
+    const normalizedKey = normalizeBannedBookKey(row)
+    const base = {
+      externalId: row.externalId,
+      canonicalTitle: row.canonicalTitle,
+      authors: row.authors ?? [],
+      normalizedKey,
+      approvalRoute: 'evidence_qa_audit' as const,
+    }
+
+    if (!knownSourceKeys.has(importFile.sourceKey)) {
+      return {
+        ...base,
+        status: 'rejected_invalid_source' as const,
+        reason: 'Source key is not registered in the ingestion queue.',
+        approvalRoute: 'blocked' as const,
+        queueAppendDraft: null,
+      }
+    }
+
+    if (rowHasForbiddenText(row)) {
+      return {
+        ...base,
+        status: 'rejected_for_full_text' as const,
+        reason: 'Importer rejected a row containing forbidden full-text-like fields.',
+        approvalRoute: 'blocked' as const,
+        queueAppendDraft: null,
+      }
+    }
+
+    if (existingRecordKeys.has(normalizedKey)) {
+      return {
+        ...base,
+        status: 'existing_record' as const,
+        reason: 'Candidate already exists in the staged rights-ready corpus.',
+        queueAppendDraft: null,
+      }
+    }
+
+    if (queuedExternalIds.has(row.externalId) || queuedKeys.has(normalizedKey)) {
+      return {
+        ...base,
+        status: 'duplicate_in_queue' as const,
+        reason: 'Candidate already exists in the source ingestion queue.',
+        queueAppendDraft: null,
+      }
+    }
+
+    if (!rowHasMinimumEvidence(row, importFile.sourceUrl) || row.evidenceQuality !== 'confirmed_source') {
+      return {
+        ...base,
+        status: 'needs_evidence_review' as const,
+        reason: 'Candidate is missing source evidence or needs cross-source/district-row confirmation.',
+        queueAppendDraft: null,
+      }
+    }
+
+    return {
+      ...base,
+      status: 'ready_for_qa' as const,
+      reason: 'Candidate can be queued as metadata-only after Evidence QA approval.',
+      queueAppendDraft: toQueueCandidate(importFile.sourceKey, importFile.sourceUrl, row),
+    }
+  })
+
+  return {
+    generatedAt: importFile.generatedAt,
+    sourceKey: importFile.sourceKey,
+    sourceUrl: importFile.sourceUrl,
+    dryRun: true,
+    summary: {
+      rows: rows.length,
+      existingRecords: rows.filter((row) => row.status === 'existing_record').length,
+      duplicateQueueRows: rows.filter((row) => row.status === 'duplicate_in_queue').length,
+      readyForQa: rows.filter((row) => row.status === 'ready_for_qa').length,
+      needsEvidenceReview: rows.filter((row) => row.status === 'needs_evidence_review').length,
+      rejectedRows: rows.filter((row) => row.status.startsWith('rejected_')).length,
+      queueAppendDrafts: rows.filter((row) => row.queueAppendDraft).length,
+    },
+    rows,
+    blockedActions: [
+      'No writes are performed by this importer.',
+      'No full text, OCR, embeddings, source chunks, retrieval flags, outreach sends, license grants, or payout records are created.',
+      'Queue append drafts require Evidence QA approval before they are copied into the staged ingestion queue.',
+    ],
+  }
+}

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "git:hygiene:report": "tsx scripts/git-hygiene-report.ts",
     "banned-books:report": "tsx scripts/banned-books-corpus-report.ts",
     "banned-books:ingestion:report": "tsx scripts/banned-books-source-ingestion-report.ts",
+    "banned-books:source:import": "tsx scripts/import-banned-books-source-candidates.ts",
     "model-ops:snapshot": "tsx scripts/sync-model-ops-snapshot.ts",
     "model-ops:snapshot:check": "tsx scripts/sync-model-ops-snapshot.ts --check",
     "model-ops:reply-intent:export": "tsx scripts/export-reply-intent-reviews.ts",

--- a/scripts/import-banned-books-source-candidates.ts
+++ b/scripts/import-banned-books-source-candidates.ts
@@ -1,0 +1,85 @@
+#!/usr/bin/env tsx
+import {
+  buildBannedBooksSourceImportPlan,
+  loadBannedBooksSourceImportFile,
+} from '../lib/banned-books-source-importer'
+
+export function parseArgs(argv: string[]) {
+  const options = {
+    input: 'data/source-protocol/banned-books-source-import-sample.json',
+    json: false,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--input') {
+      const value = argv[index + 1]
+      if (!value) throw new Error('--input requires a path')
+      options.input = value
+      index += 1
+    } else if (arg === '--json') {
+      options.json = true
+    } else if (arg === '--help' || arg === '-h') {
+      console.log(`Usage:
+  npm run banned-books:source:import -- [options]
+
+Options:
+  --input <path>  Manual/public metadata export JSON file.
+  --json          Print machine-readable dry-run output.
+`)
+      process.exit(0)
+    } else {
+      throw new Error(`Unknown option: ${arg}`)
+    }
+  }
+
+  return options
+}
+
+export function formatBannedBooksSourceImportPlan(plan: ReturnType<typeof buildBannedBooksSourceImportPlan>): string {
+  return [
+    '# Banned Books Source Import Dry Run',
+    '',
+    `Generated: ${plan.generatedAt}`,
+    `Source: ${plan.sourceKey}`,
+    `Dry run: ${String(plan.dryRun)}`,
+    '',
+    '## Summary',
+    '',
+    `- Rows: ${plan.summary.rows}`,
+    `- Existing records: ${plan.summary.existingRecords}`,
+    `- Duplicate queue rows: ${plan.summary.duplicateQueueRows}`,
+    `- Ready for QA: ${plan.summary.readyForQa}`,
+    `- Needs evidence review: ${plan.summary.needsEvidenceReview}`,
+    `- Rejected rows: ${plan.summary.rejectedRows}`,
+    `- Queue append drafts: ${plan.summary.queueAppendDrafts}`,
+    '',
+    '## Rows',
+    '',
+    ...plan.rows.map((row) => `- ${row.canonicalTitle} by ${row.authors.join(', ')}: ${row.status}; ${row.reason}`),
+    '',
+    '## Blocked Actions',
+    '',
+    ...plan.blockedActions.map((action) => `- ${action}`),
+  ].join('\n')
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  const importFile = loadBannedBooksSourceImportFile(options.input)
+  const plan = buildBannedBooksSourceImportPlan(importFile)
+
+  if (options.json) {
+    console.log(JSON.stringify(plan, null, 2))
+    return
+  }
+
+  console.log(formatBannedBooksSourceImportPlan(plan))
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Summary
- add a dry-run importer for manual/public banned-book metadata exports
- reject rows from unknown sources and rows containing full-text-like fields such as fullText, content, body, excerptText, or ocrText
- classify imported rows as existing records, duplicate queue rows, ready for Evidence QA, needs evidence review, or rejected
- emit queue append drafts only in dry-run output; no writes are performed
- add a sample metadata export and npm run banned-books:source:import

## Validation
- npm test -- --run lib/banned-books-source-importer.test.ts lib/banned-books-corpus.test.ts app/api/admin/source-protocol/overview/route.test.ts app/admin/source-protocol/page.test.tsx
- npm run banned-books:source:import
- npm run banned-books:source:import -- --json
- npm run banned-books:ingestion:report
- npm run banned-books:report
- npm run build:knowledge
- npx tsc --noEmit --pretty false
- npm run lint
- git diff --check
- pre-push database health check passed

## Governance notes
- No copyrighted full text was added.
- The importer performs no writes.
- No OCR, embeddings, source chunks, retrievable records, outreach sends, license grants, production defaults, or payout activation were created.
- Queue append drafts remain Evidence QA-gated before promotion.

## Integration Captain
- Stop before merge. Please review and merge from the captain lane.