### PR TITLE
docs: track staging n8n secret variables

### DIFF
--- a/docs/credential-inventory.json
+++ b/docs/credential-inventory.json
@@ -1739,6 +1739,151 @@
           "updatedAt": "2026-05-20"
         }
       }
+    },
+    {
+      "id": "stag-n8n-ingest-secret",
+      "envVar": "STAG_N8N_INGEST_SECRET",
+      "displayName": "n8n staging ingest bearer secret",
+      "category": "webhook-auth",
+      "risk": "critical-production",
+      "sourceOfTruth": "infisical",
+      "rotationMode": "generated-shared-secret",
+      "rotationCadenceDays": 30,
+      "environments": [
+        "staging"
+      ],
+      "runtimeSinks": [
+        "n8n Variables"
+      ],
+      "verification": [
+        "npm run credentials:smoke -- --env staging",
+        "Run affected STAG n8n workflow smoke with synthetic/test-owned data"
+      ],
+      "rollback": "Rotate together with the staging app-side N8N_INGEST_SECRET so n8n and Vercel continue to match.",
+      "baseline": {
+        "staging": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Staging n8n variable mapping added 2026-05-24; value and last rotation date require n8n Variables or provider-confirmed evidence. Do not infer from .env.local.",
+          "updatedAt": "2026-05-24"
+        }
+      }
+    },
+    {
+      "id": "stag-supabase-service-role-key",
+      "envVar": "STAG_SUPABASE_SERVICE_ROLE_KEY",
+      "displayName": "n8n staging Supabase service role key",
+      "category": "database-admin",
+      "risk": "service-role",
+      "sourceOfTruth": "infisical",
+      "rotationMode": "provider-dashboard-or-api",
+      "rotationCadenceDays": 60,
+      "environments": [
+        "staging"
+      ],
+      "runtimeSinks": [
+        "n8n Variables"
+      ],
+      "verification": [
+        "npm run credentials:smoke -- --env staging",
+        "Run affected STAG n8n workflow smoke with synthetic/test-owned data"
+      ],
+      "rollback": "Rotate together with the staging Supabase project service role key and rerun staging workflow smoke.",
+      "baseline": {
+        "staging": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Staging n8n variable mapping added 2026-05-24; value and last rotation date require n8n Variables or provider-confirmed evidence. Do not infer from .env.local.",
+          "updatedAt": "2026-05-24"
+        }
+      }
+    },
+    {
+      "id": "stag-gemini-api-key",
+      "envVar": "STAG_GEMINI_API_KEY",
+      "displayName": "n8n staging Gemini API key",
+      "category": "llm",
+      "risk": "standard-api",
+      "sourceOfTruth": "infisical",
+      "rotationMode": "provider-dashboard-or-api",
+      "rotationCadenceDays": 90,
+      "environments": [
+        "staging"
+      ],
+      "runtimeSinks": [
+        "n8n Variables"
+      ],
+      "verification": [
+        "npm run credentials:smoke -- --env staging",
+        "Run affected STAG n8n workflow smoke with synthetic/test-owned data"
+      ],
+      "rollback": "Rotate in Google AI Studio, update Infisical and n8n Variables, rerun staging social extraction smoke.",
+      "baseline": {
+        "staging": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Staging n8n variable mapping added 2026-05-24; value and last rotation date require n8n Variables or provider-confirmed evidence. Do not infer from .env.local.",
+          "updatedAt": "2026-05-24"
+        }
+      }
+    },
+    {
+      "id": "stag-elevenlabs-api-key",
+      "envVar": "STAG_ELEVENLABS_API_KEY",
+      "displayName": "n8n staging ElevenLabs API key",
+      "category": "voice-generation",
+      "risk": "standard-api",
+      "sourceOfTruth": "infisical",
+      "rotationMode": "provider-dashboard-or-api",
+      "rotationCadenceDays": 90,
+      "environments": [
+        "staging"
+      ],
+      "runtimeSinks": [
+        "n8n Variables"
+      ],
+      "verification": [
+        "npm run credentials:smoke -- --env staging",
+        "Run affected STAG n8n workflow smoke with synthetic/test-owned data"
+      ],
+      "rollback": "Rotate in ElevenLabs, update Infisical and n8n Variables, rerun staging voiceover smoke.",
+      "baseline": {
+        "staging": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Staging n8n variable mapping added 2026-05-24; value and last rotation date require n8n Variables or provider-confirmed evidence. Do not infer from .env.local.",
+          "updatedAt": "2026-05-24"
+        }
+      }
+    },
+    {
+      "id": "stag-openrouter-api-key",
+      "envVar": "STAG_OPENROUTER_API_KEY",
+      "displayName": "n8n staging OpenRouter API key",
+      "category": "llm-router",
+      "risk": "standard-api",
+      "sourceOfTruth": "infisical",
+      "rotationMode": "provider-dashboard-or-api",
+      "rotationCadenceDays": 90,
+      "environments": [
+        "staging"
+      ],
+      "runtimeSinks": [
+        "n8n Variables"
+      ],
+      "verification": [
+        "npm run credentials:smoke -- --env staging",
+        "Run affected STAG n8n workflow smoke with synthetic/test-owned data"
+      ],
+      "rollback": "Rotate in OpenRouter, update Infisical and n8n Variables, rerun staging RAG/query smoke.",
+      "baseline": {
+        "staging": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Staging n8n variable mapping added 2026-05-24; value and last rotation date require n8n Variables or provider-confirmed evidence. Do not infer from .env.local.",
+          "updatedAt": "2026-05-24"
+        }
+      }
     }
   ]
 }

--- a/docs/infisical-secret-map.md
+++ b/docs/infisical-secret-map.md
@@ -29,6 +29,20 @@ As of 2026-05-21:
 - `APIFY_TOKEN` is a legacy/local alias for the canonical `APIFY_API_TOKEN` shape. Normalize new workflows to `APIFY_API_TOKEN`.
 - `LINKEDIN_COOKIE`, `GMAIL_APP_PASSWORD`, and admin E2E login material remain 1Password-side credentials.
 
+## Staging n8n Variable Names
+
+Staging n8n workflows use STAG-prefixed Variables, while the Next.js staging runtime may still expose app-side names such as `N8N_INGEST_SECRET`. Track the STAG-prefixed n8n Variables as separate staging-only inventory entries so rotation packets can update both sides deliberately.
+
+| n8n staging variable | Coupled app/provider secret |
+| --- | --- |
+| `STAG_N8N_INGEST_SECRET` | App-side `N8N_INGEST_SECRET` for staging ingest auth |
+| `STAG_SUPABASE_SERVICE_ROLE_KEY` | Staging Supabase service role key |
+| `STAG_GEMINI_API_KEY` | Gemini key used by STAG social workflows |
+| `STAG_ELEVENLABS_API_KEY` | ElevenLabs key used by STAG voice workflows |
+| `STAG_OPENROUTER_API_KEY` | OpenRouter key used by STAG RAG/query workflows |
+
+Do not rotate only one side of a coupled staging secret. Update Infisical, Vercel/app runtime sinks, and n8n Variables in the same staged packet, then verify with synthetic or test-owned workflow inputs.
+
 ## Operator Checks
 
 Use these commands for key-name and access validation. They must not print values.


### PR DESCRIPTION
## Summary

- Adds STAG-prefixed n8n Variables as staging-only credential inventory entries:
  - `STAG_N8N_INGEST_SECRET`
  - `STAG_SUPABASE_SERVICE_ROLE_KEY`
  - `STAG_GEMINI_API_KEY`
  - `STAG_ELEVENLABS_API_KEY`
  - `STAG_OPENROUTER_API_KEY`
- Documents the staging n8n variable naming model in `docs/infisical-secret-map.md`.
- Clarifies that coupled staging secrets must be rotated together across app runtime, Infisical, Vercel, and n8n Variables.

## Validation

- `node -e "JSON.parse(require('fs').readFileSync('docs/credential-inventory.json','utf8')); console.log('credential-inventory json ok')"`
- `npm run credentials:report -- --env staging --check-sinks`
- `npx vitest run lib/credential-report.test.ts scripts/credential-broker.test.ts app/api/admin/credentials/report/route.test.ts app/admin/credentials/page.test.tsx`
- `git diff --check`

## Integration Notes

- No secret values are committed or printed.
- This PR intentionally does not rotate `N8N_INGEST_SECRET` yet. The preflight found staging n8n workflows use `STAG_N8N_INGEST_SECRET`, so rotating only the app-side `N8N_INGEST_SECRET` would risk a staging auth mismatch.
- After this lands, the next rotation packet should update the coupled staging ingest pair deliberately:
  - app/Vercel-side `N8N_INGEST_SECRET`
  - n8n-side `STAG_N8N_INGEST_SECRET`
  - Infisical staging source entries
  - local ignored runtime sink if used for staging smoke
