### PR TITLE
feat: surface client ai ops projection status

### DIFF
--- a/app/admin/client-projects/[id]/page.tsx
+++ b/app/admin/client-projects/[id]/page.tsx
@@ -221,6 +221,20 @@ interface ProjectDetail {
     costItems: Array<{ id: string; category: string; label: string; payer: string; cost_type: string; amount: number | string | null }>
     clientView: {
       costSummary: { oneTimeClientOwned: number; monthlyClientOwned: number; quoteRequiredCount: number }
+      projectionStatus: {
+        tasksTotal: number
+        tasksComplete: number
+        blockedTasks: number
+        clientActionCount: number
+        amadutownActionCount: number
+        sharedActionCount: number
+        approvalNeededCount: number
+        isolationRequiredCount: number
+        overdueTasks: number
+        staleCostItems: number
+        reportMissing: boolean
+        nextReportingAction: string
+      }
     }
   } | null
 }
@@ -1216,6 +1230,13 @@ function AiOpsRoadmapAdminSection({
   const tasks = roadmap?.tasks ?? []
   const completed = tasks.filter((task) => task.status === 'complete').length
   const progress = tasks.length > 0 ? Math.round((completed / tasks.length) * 100) : 0
+  const projection = roadmap?.clientView?.projectionStatus
+  const monitoringFlags = projection
+    ? projection.overdueTasks + projection.staleCostItems + (projection.reportMissing ? 1 : 0)
+    : 0
+  const openActions = projection
+    ? projection.clientActionCount + projection.amadutownActionCount + projection.sharedActionCount
+    : 0
 
   return (
     <div className="mb-8 p-5 bg-gray-900 border border-gray-800 rounded-xl">
@@ -1261,6 +1282,35 @@ function AiOpsRoadmapAdminSection({
               <p className="text-sm text-gray-200">${costs?.monthlyClientOwned ?? 0}</p>
             </div>
           </div>
+
+          {projection && (
+            <div className="rounded-lg bg-gray-950/50 border border-gray-800 p-4 mb-4">
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                <div>
+                  <p className="text-xs text-gray-500 uppercase tracking-wide">Projection next action</p>
+                  <p className="text-sm font-medium text-gray-100 mt-1">{projection.nextReportingAction}</p>
+                </div>
+                <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 min-w-full lg:min-w-[520px]">
+                  <div>
+                    <p className="text-xs text-gray-500 uppercase tracking-wide">Open actions</p>
+                    <p className="text-sm text-gray-200">{openActions}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-gray-500 uppercase tracking-wide">Approvals</p>
+                    <p className="text-sm text-gray-200">{projection.approvalNeededCount}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-gray-500 uppercase tracking-wide">Isolation</p>
+                    <p className="text-sm text-gray-200">{projection.isolationRequiredCount}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-gray-500 uppercase tracking-wide">Monitor flags</p>
+                    <p className="text-sm text-gray-200">{monitoringFlags}</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
 
           <div className="grid grid-cols-1 lg:grid-cols-5 gap-2">
             {phases.map((phase) => (

--- a/components/client-dashboard/AiOpsRoadmapSection.test.tsx
+++ b/components/client-dashboard/AiOpsRoadmapSection.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import AiOpsRoadmapSection from './AiOpsRoadmapSection'
+import type { RoadmapClientView } from '@/lib/client-ai-ops-roadmap'
+
+const roadmap: RoadmapClientView = {
+  title: 'Acme AI Ops Roadmap',
+  status: 'active',
+  clientSummary: 'Implementation is underway.',
+  runtimePlacementOptions: [],
+  phases: [
+    {
+      id: 'phase-1',
+      title: 'Discovery',
+      objective: 'Confirm ownership and access.',
+      status: 'in_progress',
+      phaseOrder: 1,
+      acceptanceCriteria: [],
+      tasksTotal: 2,
+      tasksComplete: 1,
+      estimatedClientStartupCost: 0,
+      estimatedMonthlyOperatingCost: 0,
+    },
+  ],
+  costSummary: {
+    oneTimeClientOwned: 1200,
+    monthlyClientOwned: 95,
+    amadutownSetup: 0,
+    quoteRequiredCount: 1,
+    byCategory: {},
+  },
+  projectionStatus: {
+    tasksTotal: 2,
+    tasksComplete: 1,
+    blockedTasks: 1,
+    clientActionCount: 1,
+    amadutownActionCount: 1,
+    sharedActionCount: 0,
+    approvalNeededCount: 2,
+    isolationRequiredCount: 1,
+    overdueTasks: 1,
+    staleCostItems: 1,
+    reportMissing: false,
+    nextReportingAction: 'Resolve blocked roadmap tasks',
+  },
+  nextActions: [
+    {
+      title: 'Approve secure access plan',
+      ownerType: 'client',
+      priority: 'high',
+      dueDate: null,
+    },
+  ],
+  latestReport: null,
+}
+
+describe('AiOpsRoadmapSection', () => {
+  it('surfaces the read-only roadmap projection status', () => {
+    render(<AiOpsRoadmapSection roadmap={roadmap} />)
+
+    expect(screen.getByText('Roadmap projection')).toBeInTheDocument()
+    expect(screen.getByText('Resolve blocked roadmap tasks')).toBeInTheDocument()
+    expect(screen.getByText('Open actions')).toBeInTheDocument()
+    expect(screen.getByText('Approvals')).toBeInTheDocument()
+    expect(screen.getByText('Isolation checks')).toBeInTheDocument()
+    expect(screen.getByText('Monitor flags')).toBeInTheDocument()
+    expect(screen.getByText('Approve secure access plan')).toBeInTheDocument()
+  })
+})

--- a/components/client-dashboard/AiOpsRoadmapSection.tsx
+++ b/components/client-dashboard/AiOpsRoadmapSection.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Activity, ClipboardList, DollarSign, ShieldCheck } from 'lucide-react'
+import { Activity, AlertTriangle, CheckCircle2, ClipboardList, DollarSign, ShieldCheck } from 'lucide-react'
 import type { RoadmapClientView } from '@/lib/client-ai-ops-roadmap'
 
 interface Props {
@@ -25,6 +25,13 @@ function formatDate(value: string | null): string {
 }
 
 export default function AiOpsRoadmapSection({ roadmap }: Props) {
+  const projection = roadmap.projectionStatus
+  const monitoringFlags = projection.overdueTasks + projection.staleCostItems + (projection.reportMissing ? 1 : 0)
+  const openActions = projection.clientActionCount + projection.amadutownActionCount + projection.sharedActionCount
+  const projectionTone = projection.blockedTasks > 0 || monitoringFlags > 0 || projection.approvalNeededCount > 0
+    ? 'border-amber-900/60 bg-amber-950/10 text-amber-200'
+    : 'border-emerald-900/60 bg-emerald-950/10 text-emerald-200'
+
   return (
     <div className="bg-gray-900 rounded-xl border border-gray-800 p-5">
       <div className="flex items-start justify-between gap-4 mb-5">
@@ -65,6 +72,40 @@ export default function AiOpsRoadmapSection({ roadmap }: Props) {
           <p className="text-lg font-semibold text-gray-100">
             {roadmap.costSummary.quoteRequiredCount}
           </p>
+        </div>
+      </div>
+
+      <div className={`rounded-lg border p-4 mb-5 ${projectionTone}`}>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <div className="flex items-center gap-2">
+              {projection.blockedTasks > 0 || monitoringFlags > 0 || projection.approvalNeededCount > 0 ? (
+                <AlertTriangle className="w-4 h-4" />
+              ) : (
+                <CheckCircle2 className="w-4 h-4" />
+              )}
+              <p className="text-xs uppercase tracking-wide text-gray-400">Roadmap projection</p>
+            </div>
+            <p className="mt-1 text-sm font-medium text-gray-100">{projection.nextReportingAction}</p>
+          </div>
+          <div className="grid grid-cols-2 gap-3 text-sm sm:grid-cols-4">
+            <div>
+              <p className="text-xs uppercase tracking-wide text-gray-500">Open actions</p>
+              <p className="font-semibold text-gray-100">{openActions}</p>
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-wide text-gray-500">Approvals</p>
+              <p className="font-semibold text-gray-100">{projection.approvalNeededCount}</p>
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-wide text-gray-500">Isolation checks</p>
+              <p className="font-semibold text-gray-100">{projection.isolationRequiredCount}</p>
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-wide text-gray-500">Monitor flags</p>
+              <p className="font-semibold text-gray-100">{monitoringFlags}</p>
+            </div>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
Summary
- Surface the Client AI Ops roadmap projection status in the client dashboard roadmap section.
- Add the same projection next-action and count summary to the admin client project roadmap block.
- Cover the client-facing projection UI with a focused React test using synthetic roadmap data.

Validation
- npm run worktree:env -- --source /Users/vambahsillah/Projects/Portfolio
- npm test -- components/client-dashboard/AiOpsRoadmapSection.test.tsx lib/client-ai-ops-roadmap.test.ts app/api/admin/client-projects/[id]/ai-ops/route.test.ts
- npm run build:knowledge
- npx tsc --noEmit --pretty false
- git diff --check
- Local Browser smoke: http://localhost:3024/client/dashboard/synthetic-client-ai-ops-smoke compiled and rendered the expected invalid-token state with no framework overlay or console errors. Real client dashboard data was not opened.
- Push hook ran npm run db:health-check successfully.

Integration Notes
- No migrations or environment changes.
- UI is read-only and does not add credential sync, OAuth connection, provider writes, outbound sends, publishing, deploys, or client-data mutation.
- Enhancement preflight: no open PRs at start; overlap rating GREEN.
- Vercel contexts not checked from this non-captain lane: Vercel – portfolio and Vercel – portfolio-staging remain integration-captain gates.
