### PR TITLE
feat: align ai ops roadmap with amadutown style

### DIFF
--- a/app/admin/client-projects/[id]/page.tsx
+++ b/app/admin/client-projects/[id]/page.tsx
@@ -1239,21 +1239,21 @@ function AiOpsRoadmapAdminSection({
     : 0
 
   return (
-    <div className="mb-8 p-5 bg-gray-900 border border-gray-800 rounded-xl">
+    <div className="mb-8 rounded-lg border border-silicon-slate/70 bg-imperial-navy/85 p-5 shadow-[0_0_32px_rgba(0,0,0,0.18)]">
       <div className="flex items-start justify-between gap-4 mb-4">
         <div>
           <div className="flex items-center gap-2 mb-1">
-            <ClipboardList size={18} className="text-emerald-400" />
-            <h2 className="text-lg font-semibold">AI Ops Roadmap</h2>
+            <ClipboardList size={18} className="text-radiant-gold" />
+            <h2 className="text-lg font-semibold text-foreground">AI Ops Roadmap</h2>
           </div>
-          <p className="text-sm text-gray-400">
+          <p className="text-sm text-muted-foreground">
             Sales-to-delivery phases, task projections, client-owned costs, and reporting gates.
           </p>
         </div>
         <button
           onClick={createRoadmap}
           disabled={loading || !accessToken}
-          className="inline-flex items-center gap-2 px-3 py-2 rounded-lg border border-gray-700 bg-gray-800 hover:border-emerald-500/60 text-sm disabled:opacity-60"
+          className="inline-flex items-center gap-2 rounded-lg border border-radiant-gold/45 bg-radiant-gold/10 px-3 py-2 text-sm font-medium text-radiant-gold hover:bg-radiant-gold/15 disabled:opacity-60"
         >
           <RefreshCw size={14} className={loading ? 'animate-spin' : ''} />
           {roadmap ? 'Sync Tasks' : 'Create Roadmap'}
@@ -1265,47 +1265,47 @@ function AiOpsRoadmapAdminSection({
       {roadmap ? (
         <>
           <div className="grid grid-cols-1 sm:grid-cols-4 gap-3 mb-4">
-            <div className="rounded-lg bg-gray-950/50 border border-gray-800 p-3">
-              <p className="text-xs text-gray-500 uppercase tracking-wide">Status</p>
-              <p className="text-sm text-gray-200 capitalize">{roadmap.roadmap?.status}</p>
+            <div className="rounded-lg bg-background/45 border border-silicon-slate/60 p-3">
+              <p className="text-xs font-semibold text-radiant-gold/85 uppercase tracking-[0.14em]">Status</p>
+              <p className="text-sm text-foreground capitalize">{roadmap.roadmap?.status}</p>
             </div>
-            <div className="rounded-lg bg-gray-950/50 border border-gray-800 p-3">
-              <p className="text-xs text-gray-500 uppercase tracking-wide">Progress</p>
-              <p className="text-sm text-gray-200">{completed}/{tasks.length} tasks ({progress}%)</p>
+            <div className="rounded-lg bg-background/45 border border-silicon-slate/60 p-3">
+              <p className="text-xs font-semibold text-radiant-gold/85 uppercase tracking-[0.14em]">Progress</p>
+              <p className="text-sm text-foreground">{completed}/{tasks.length} tasks ({progress}%)</p>
             </div>
-            <div className="rounded-lg bg-gray-950/50 border border-gray-800 p-3">
-              <p className="text-xs text-gray-500 uppercase tracking-wide">Startup</p>
-              <p className="text-sm text-gray-200">${costs?.oneTimeClientOwned ?? 0}</p>
+            <div className="rounded-lg bg-background/45 border border-silicon-slate/60 p-3">
+              <p className="text-xs font-semibold text-radiant-gold/85 uppercase tracking-[0.14em]">Startup</p>
+              <p className="text-sm text-foreground">${costs?.oneTimeClientOwned ?? 0}</p>
             </div>
-            <div className="rounded-lg bg-gray-950/50 border border-gray-800 p-3">
-              <p className="text-xs text-gray-500 uppercase tracking-wide">Monthly</p>
-              <p className="text-sm text-gray-200">${costs?.monthlyClientOwned ?? 0}</p>
+            <div className="rounded-lg bg-background/45 border border-silicon-slate/60 p-3">
+              <p className="text-xs font-semibold text-radiant-gold/85 uppercase tracking-[0.14em]">Monthly</p>
+              <p className="text-sm text-foreground">${costs?.monthlyClientOwned ?? 0}</p>
             </div>
           </div>
 
           {projection && (
-            <div className="rounded-lg bg-gray-950/50 border border-gray-800 p-4 mb-4">
+            <div className="rounded-lg bg-radiant-gold/10 border border-radiant-gold/40 p-4 mb-4 shadow-[0_0_28px_rgba(212,175,55,0.10)]">
               <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
                 <div>
-                  <p className="text-xs text-gray-500 uppercase tracking-wide">Projection next action</p>
-                  <p className="text-sm font-medium text-gray-100 mt-1">{projection.nextReportingAction}</p>
+                  <p className="text-xs font-semibold text-radiant-gold uppercase tracking-[0.14em]">Projection next action</p>
+                  <p className="text-sm font-medium text-foreground mt-1">{projection.nextReportingAction}</p>
                 </div>
                 <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 min-w-full lg:min-w-[520px]">
                   <div>
-                    <p className="text-xs text-gray-500 uppercase tracking-wide">Open actions</p>
-                    <p className="text-sm text-gray-200">{openActions}</p>
+                    <p className="text-xs text-muted-foreground uppercase tracking-wide">Open actions</p>
+                    <p className="text-sm text-foreground">{openActions}</p>
                   </div>
                   <div>
-                    <p className="text-xs text-gray-500 uppercase tracking-wide">Approvals</p>
-                    <p className="text-sm text-gray-200">{projection.approvalNeededCount}</p>
+                    <p className="text-xs text-muted-foreground uppercase tracking-wide">Approvals</p>
+                    <p className="text-sm text-foreground">{projection.approvalNeededCount}</p>
                   </div>
                   <div>
-                    <p className="text-xs text-gray-500 uppercase tracking-wide">Isolation</p>
-                    <p className="text-sm text-gray-200">{projection.isolationRequiredCount}</p>
+                    <p className="text-xs text-muted-foreground uppercase tracking-wide">Isolation</p>
+                    <p className="text-sm text-foreground">{projection.isolationRequiredCount}</p>
                   </div>
                   <div>
-                    <p className="text-xs text-gray-500 uppercase tracking-wide">Monitor flags</p>
-                    <p className="text-sm text-gray-200">{monitoringFlags}</p>
+                    <p className="text-xs text-muted-foreground uppercase tracking-wide">Monitor flags</p>
+                    <p className="text-sm text-foreground">{monitoringFlags}</p>
                   </div>
                 </div>
               </div>
@@ -1314,17 +1314,17 @@ function AiOpsRoadmapAdminSection({
 
           <div className="grid grid-cols-1 lg:grid-cols-5 gap-2">
             {phases.map((phase) => (
-              <div key={phase.id} className="rounded-lg border border-gray-800 bg-gray-950/40 p-3">
-                <p className="text-xs text-gray-500 uppercase tracking-wide">Phase {phase.phase_order}</p>
-                <p className="text-sm font-medium text-gray-200">{phase.title}</p>
-                <p className="text-xs text-gray-500 mt-1 capitalize">{phase.status.replace(/_/g, ' ')}</p>
+              <div key={phase.id} className="rounded-lg border border-silicon-slate/60 bg-background/40 p-3">
+                <p className="text-xs font-semibold text-radiant-gold/85 uppercase tracking-[0.14em]">Phase {phase.phase_order}</p>
+                <p className="text-sm font-medium text-foreground">{phase.title}</p>
+                <p className="text-xs text-muted-foreground mt-1 capitalize">{phase.status.replace(/_/g, ' ')}</p>
               </div>
             ))}
           </div>
         </>
       ) : (
-        <div className="rounded-lg border border-dashed border-gray-700 bg-gray-950/30 p-4">
-          <p className="text-sm text-gray-400">
+        <div className="rounded-lg border border-dashed border-radiant-gold/35 bg-background/35 p-4">
+          <p className="text-sm text-muted-foreground">
             No AI Ops roadmap exists yet. Create one to generate phased delivery tasks for the client dashboard and admin meeting task queue.
           </p>
         </div>

--- a/components/client-dashboard/AiOpsRoadmapSection.tsx
+++ b/components/client-dashboard/AiOpsRoadmapSection.tsx
@@ -29,47 +29,49 @@ export default function AiOpsRoadmapSection({ roadmap }: Props) {
   const monitoringFlags = projection.overdueTasks + projection.staleCostItems + (projection.reportMissing ? 1 : 0)
   const openActions = projection.clientActionCount + projection.amadutownActionCount + projection.sharedActionCount
   const projectionTone = projection.blockedTasks > 0 || monitoringFlags > 0 || projection.approvalNeededCount > 0
-    ? 'border-amber-900/60 bg-amber-950/10 text-amber-200'
-    : 'border-emerald-900/60 bg-emerald-950/10 text-emerald-200'
+    ? 'border-radiant-gold/45 bg-radiant-gold/10 text-radiant-gold shadow-[0_0_28px_rgba(212,175,55,0.10)]'
+    : 'border-radiant-gold/30 bg-background/45 text-radiant-gold'
+  const metricCardClass = 'rounded-lg border border-silicon-slate/60 bg-background/45 p-3'
+  const eyebrowClass = 'text-xs font-semibold uppercase tracking-[0.14em] text-radiant-gold/85'
 
   return (
-    <div className="bg-gray-900 rounded-xl border border-gray-800 p-5">
+    <div className="rounded-lg border border-silicon-slate/70 bg-imperial-navy/85 p-5 shadow-[0_0_32px_rgba(0,0,0,0.18)]">
       <div className="flex items-start justify-between gap-4 mb-5">
         <div>
           <div className="flex items-center gap-2 mb-1">
-            <ClipboardList className="w-5 h-5 text-emerald-400" />
-            <h3 className="text-sm font-medium text-gray-200 uppercase tracking-wider">
+            <ClipboardList className="w-5 h-5 text-radiant-gold" />
+            <h3 className="text-sm font-semibold text-foreground uppercase tracking-[0.16em]">
               Implementation Roadmap
             </h3>
           </div>
           {roadmap.clientSummary && (
-            <p className="text-sm text-gray-400 max-w-3xl">{roadmap.clientSummary}</p>
+            <p className="text-sm text-muted-foreground max-w-3xl">{roadmap.clientSummary}</p>
           )}
         </div>
-        <span className="text-xs px-2 py-1 rounded border border-gray-700 bg-gray-800 text-gray-300 capitalize">
+        <span className="rounded-full border border-radiant-gold/35 bg-radiant-gold/10 px-2.5 py-1 text-xs font-medium text-radiant-gold capitalize">
           {roadmap.status}
         </span>
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-5">
-        <div className="rounded-lg border border-emerald-900/60 bg-emerald-950/20 p-3">
-          <DollarSign className="w-4 h-4 text-emerald-300 mb-2" />
-          <p className="text-xs text-gray-500 uppercase tracking-wide">Startup costs</p>
-          <p className="text-lg font-semibold text-gray-100">
+        <div className={metricCardClass}>
+          <DollarSign className="w-4 h-4 text-radiant-gold mb-2" />
+          <p className={eyebrowClass}>Startup costs</p>
+          <p className="text-lg font-semibold text-foreground">
             {formatCurrency(roadmap.costSummary.oneTimeClientOwned)}
           </p>
         </div>
-        <div className="rounded-lg border border-blue-900/60 bg-blue-950/20 p-3">
-          <DollarSign className="w-4 h-4 text-blue-300 mb-2" />
-          <p className="text-xs text-gray-500 uppercase tracking-wide">Monthly operating</p>
-          <p className="text-lg font-semibold text-gray-100">
+        <div className={metricCardClass}>
+          <DollarSign className="w-4 h-4 text-radiant-gold mb-2" />
+          <p className={eyebrowClass}>Monthly operating</p>
+          <p className="text-lg font-semibold text-foreground">
             {formatCurrency(roadmap.costSummary.monthlyClientOwned)}
           </p>
         </div>
-        <div className="rounded-lg border border-amber-900/60 bg-amber-950/20 p-3">
-          <ShieldCheck className="w-4 h-4 text-amber-300 mb-2" />
-          <p className="text-xs text-gray-500 uppercase tracking-wide">Quote-required</p>
-          <p className="text-lg font-semibold text-gray-100">
+        <div className={metricCardClass}>
+          <ShieldCheck className="w-4 h-4 text-radiant-gold mb-2" />
+          <p className={eyebrowClass}>Quote-required</p>
+          <p className="text-lg font-semibold text-foreground">
             {roadmap.costSummary.quoteRequiredCount}
           </p>
         </div>
@@ -84,26 +86,26 @@ export default function AiOpsRoadmapSection({ roadmap }: Props) {
               ) : (
                 <CheckCircle2 className="w-4 h-4" />
               )}
-              <p className="text-xs uppercase tracking-wide text-gray-400">Roadmap projection</p>
+              <p className={eyebrowClass}>Roadmap projection</p>
             </div>
-            <p className="mt-1 text-sm font-medium text-gray-100">{projection.nextReportingAction}</p>
+            <p className="mt-1 text-sm font-semibold text-foreground">{projection.nextReportingAction}</p>
           </div>
           <div className="grid grid-cols-2 gap-3 text-sm sm:grid-cols-4">
             <div>
-              <p className="text-xs uppercase tracking-wide text-gray-500">Open actions</p>
-              <p className="font-semibold text-gray-100">{openActions}</p>
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">Open actions</p>
+              <p className="font-semibold text-foreground">{openActions}</p>
             </div>
             <div>
-              <p className="text-xs uppercase tracking-wide text-gray-500">Approvals</p>
-              <p className="font-semibold text-gray-100">{projection.approvalNeededCount}</p>
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">Approvals</p>
+              <p className="font-semibold text-foreground">{projection.approvalNeededCount}</p>
             </div>
             <div>
-              <p className="text-xs uppercase tracking-wide text-gray-500">Isolation checks</p>
-              <p className="font-semibold text-gray-100">{projection.isolationRequiredCount}</p>
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">Isolation checks</p>
+              <p className="font-semibold text-foreground">{projection.isolationRequiredCount}</p>
             </div>
             <div>
-              <p className="text-xs uppercase tracking-wide text-gray-500">Monitor flags</p>
-              <p className="font-semibold text-gray-100">{monitoringFlags}</p>
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">Monitor flags</p>
+              <p className="font-semibold text-foreground">{monitoringFlags}</p>
             </div>
           </div>
         </div>
@@ -113,21 +115,21 @@ export default function AiOpsRoadmapSection({ roadmap }: Props) {
         {roadmap.phases.map((phase) => {
           const pct = phase.tasksTotal > 0 ? Math.round((phase.tasksComplete / phase.tasksTotal) * 100) : 0
           return (
-            <div key={phase.id || phase.title} className="rounded-lg border border-gray-800 bg-gray-950/40 p-4">
+            <div key={phase.id || phase.title} className="rounded-lg border border-silicon-slate/60 bg-background/40 p-4">
               <div className="flex items-start justify-between gap-3">
                 <div>
-                  <p className="text-xs text-gray-500 uppercase tracking-wide">Phase {phase.phaseOrder}</p>
-                  <h4 className="font-medium text-gray-100">{phase.title}</h4>
-                  <p className="text-sm text-gray-500 mt-1">{phase.objective}</p>
+                  <p className={eyebrowClass}>Phase {phase.phaseOrder}</p>
+                  <h4 className="font-medium text-foreground">{phase.title}</h4>
+                  <p className="text-sm text-muted-foreground mt-1">{phase.objective}</p>
                 </div>
-                <span className="text-xs px-2 py-1 rounded border border-gray-700 bg-gray-800 text-gray-300 capitalize">
+                <span className="rounded-full border border-silicon-slate/60 bg-background/60 px-2.5 py-1 text-xs text-muted-foreground capitalize">
                   {phase.status.replace(/_/g, ' ')}
                 </span>
               </div>
-              <div className="mt-3 h-2 rounded-full bg-gray-800 overflow-hidden">
-                <div className="h-full bg-emerald-500" style={{ width: `${pct}%` }} />
+              <div className="mt-3 h-2 rounded-full bg-silicon-slate/45 overflow-hidden">
+                <div className="h-full bg-radiant-gold" style={{ width: `${pct}%` }} />
               </div>
-              <p className="text-xs text-gray-500 mt-1">
+              <p className="text-xs text-muted-foreground mt-1">
                 {phase.tasksComplete}/{phase.tasksTotal} visible tasks complete
               </p>
             </div>
@@ -136,13 +138,13 @@ export default function AiOpsRoadmapSection({ roadmap }: Props) {
       </div>
 
       {roadmap.nextActions.length > 0 && (
-        <div className="mt-5 rounded-lg border border-gray-800 bg-gray-950/40 p-4">
-          <p className="text-xs text-gray-500 uppercase tracking-wide mb-2">Next actions</p>
+        <div className="mt-5 rounded-lg border border-silicon-slate/60 bg-background/40 p-4">
+          <p className={`${eyebrowClass} mb-2`}>Next actions</p>
           <ul className="space-y-2">
             {roadmap.nextActions.map((action, index) => (
               <li key={`${action.title}-${index}`} className="flex items-center justify-between gap-3 text-sm">
-                <span className="text-gray-300">{action.title}</span>
-                <span className="text-gray-500 capitalize">{action.ownerType}</span>
+                <span className="text-foreground">{action.title}</span>
+                <span className="text-muted-foreground capitalize">{action.ownerType}</span>
               </li>
             ))}
           </ul>
@@ -150,38 +152,38 @@ export default function AiOpsRoadmapSection({ roadmap }: Props) {
       )}
 
       {roadmap.latestReport && (
-        <div className="mt-5 rounded-lg border border-cyan-900/60 bg-cyan-950/10 p-4">
+        <div className="mt-5 rounded-lg border border-silicon-slate/60 bg-background/40 p-4">
           <div className="flex items-start justify-between gap-3">
             <div>
               <div className="flex items-center gap-2 mb-1">
-                <Activity className="w-4 h-4 text-cyan-300" />
-                <p className="text-xs text-gray-500 uppercase tracking-wide">Latest report</p>
+                <Activity className="w-4 h-4 text-radiant-gold" />
+                <p className={eyebrowClass}>Latest report</p>
               </div>
-              <h4 className="font-medium text-gray-100">{roadmap.latestReport.title}</h4>
+              <h4 className="font-medium text-foreground">{roadmap.latestReport.title}</h4>
               {roadmap.latestReport.summary && (
-                <p className="text-sm text-gray-400 mt-1">{roadmap.latestReport.summary}</p>
+                <p className="text-sm text-muted-foreground mt-1">{roadmap.latestReport.summary}</p>
               )}
             </div>
-            <span className="text-xs px-2 py-1 rounded border border-gray-700 bg-gray-800 text-gray-300 capitalize">
+            <span className="rounded-full border border-silicon-slate/60 bg-background/60 px-2.5 py-1 text-xs text-muted-foreground capitalize">
               {roadmap.latestReport.status.replace(/_/g, ' ')}
             </span>
           </div>
           <div className="grid grid-cols-1 sm:grid-cols-4 gap-3 mt-4 text-sm">
             <div>
-              <p className="text-xs text-gray-500 uppercase tracking-wide">Generated</p>
-              <p className="text-gray-300">{formatDate(roadmap.latestReport.generatedAt)}</p>
+              <p className="text-xs text-muted-foreground uppercase tracking-wide">Generated</p>
+              <p className="text-foreground">{formatDate(roadmap.latestReport.generatedAt)}</p>
             </div>
             <div>
-              <p className="text-xs text-gray-500 uppercase tracking-wide">Client actions</p>
-              <p className="text-gray-300">{roadmap.latestReport.clientActions.length}</p>
+              <p className="text-xs text-muted-foreground uppercase tracking-wide">Client actions</p>
+              <p className="text-foreground">{roadmap.latestReport.clientActions.length}</p>
             </div>
             <div>
-              <p className="text-xs text-gray-500 uppercase tracking-wide">Approvals</p>
-              <p className="text-gray-300">{roadmap.latestReport.approvalNeededCount}</p>
+              <p className="text-xs text-muted-foreground uppercase tracking-wide">Approvals</p>
+              <p className="text-foreground">{roadmap.latestReport.approvalNeededCount}</p>
             </div>
             <div>
-              <p className="text-xs text-gray-500 uppercase tracking-wide">Monitoring flags</p>
-              <p className="text-gray-300">
+              <p className="text-xs text-muted-foreground uppercase tracking-wide">Monitoring flags</p>
+              <p className="text-foreground">
                 {(roadmap.latestReport.monitoringSummary?.overdueTasks ?? 0) +
                   (roadmap.latestReport.monitoringSummary?.staleCostItems ?? 0) +
                   (roadmap.latestReport.monitoringSummary?.reportMissing ? 1 : 0)}


### PR DESCRIPTION
Summary
- Restyle the client dashboard AI Ops roadmap section with the AmaduTown navy/gold operating-console language.
- Restyle the admin client project AI Ops roadmap block with the same brand tokens, gold command action, and restrained projection panel.
- Keep all projection behavior read-only; this is visual treatment only.

Validation
- npm test -- components/client-dashboard/AiOpsRoadmapSection.test.tsx lib/client-ai-ops-roadmap.test.ts app/api/admin/client-projects/[id]/ai-ops/route.test.ts
- npx tsc --noEmit --pretty false
- git diff --check
- In-app browser screenshot pass using synthetic non-client preview data.
- Push hook ran npm run db:health-check successfully.

Integration Notes
- No migrations, API changes, or environment changes.
- Existing untracked tmp/ in the main checkout was left untouched.
- Enhancement preflight: no open PRs; overlap rating GREEN.
- Vercel contexts not checked from this non-captain lane: Vercel – portfolio and Vercel – portfolio-staging remain integration-captain gates.
