### PR TITLE
feat: add client ai ops connector readiness

### DIFF
--- a/app/admin/client-projects/[id]/page.tsx
+++ b/app/admin/client-projects/[id]/page.tsx
@@ -221,6 +221,15 @@ interface ProjectDetail {
     costItems: Array<{ id: string; category: string; label: string; payer: string; cost_type: string; amount: number | string | null }>
     clientView: {
       costSummary: { oneTimeClientOwned: number; monthlyClientOwned: number; quoteRequiredCount: number }
+      connectorReadiness: {
+        summary: string
+        requiredConnectorCount: number
+        readyConnectorCount: number
+        approvalBlockedConnectorCount: number
+        missingCriticalConnectorCount: number
+        connectorNextAction: string
+        items: Array<{ key: string; label: string; status: string }>
+      }
       projectionStatus: {
         tasksTotal: number
         tasksComplete: number
@@ -1231,6 +1240,7 @@ function AiOpsRoadmapAdminSection({
   const completed = tasks.filter((task) => task.status === 'complete').length
   const progress = tasks.length > 0 ? Math.round((completed / tasks.length) * 100) : 0
   const projection = roadmap?.clientView?.projectionStatus
+  const connectors = roadmap?.clientView?.connectorReadiness
   const monitoringFlags = projection
     ? projection.overdueTasks + projection.staleCostItems + (projection.reportMissing ? 1 : 0)
     : 0
@@ -1309,6 +1319,48 @@ function AiOpsRoadmapAdminSection({
                   </div>
                 </div>
               </div>
+            </div>
+          )}
+
+          {connectors && (
+            <div className="rounded-lg bg-background/40 border border-silicon-slate/60 p-4 mb-4">
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                <div>
+                  <p className="text-xs font-semibold text-radiant-gold uppercase tracking-[0.14em]">Connector readiness</p>
+                  <p className="text-sm font-medium text-foreground mt-1">{connectors.connectorNextAction}</p>
+                  <p className="text-xs text-muted-foreground mt-1">{connectors.summary}</p>
+                </div>
+                <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 min-w-full lg:min-w-[520px]">
+                  <div>
+                    <p className="text-xs text-muted-foreground uppercase tracking-wide">Required</p>
+                    <p className="text-sm text-foreground">{connectors.requiredConnectorCount}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-muted-foreground uppercase tracking-wide">Ready</p>
+                    <p className="text-sm text-foreground">{connectors.readyConnectorCount}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-muted-foreground uppercase tracking-wide">Approval blocked</p>
+                    <p className="text-sm text-foreground">{connectors.approvalBlockedConnectorCount}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-muted-foreground uppercase tracking-wide">Critical missing</p>
+                    <p className="text-sm text-foreground">{connectors.missingCriticalConnectorCount}</p>
+                  </div>
+                </div>
+              </div>
+              {connectors.items.length > 0 && (
+                <div className="mt-4 flex flex-wrap gap-2">
+                  {connectors.items.slice(0, 6).map((connector) => (
+                    <span
+                      key={connector.key}
+                      className="rounded-full border border-radiant-gold/30 bg-radiant-gold/10 px-2.5 py-1 text-xs text-radiant-gold"
+                    >
+                      {connector.label} · {connector.status.replace(/_/g, ' ')}
+                    </span>
+                  ))}
+                </div>
+              )}
             </div>
           )}
 

--- a/components/client-dashboard/AiOpsRoadmapSection.test.tsx
+++ b/components/client-dashboard/AiOpsRoadmapSection.test.tsx
@@ -29,6 +29,33 @@ const roadmap: RoadmapClientView = {
     quoteRequiredCount: 1,
     byCategory: {},
   },
+  connectorReadiness: {
+    summary: '5 required, 0 ready, 4 need auth, 0 approval-blocked',
+    requiredConnectorCount: 5,
+    readyConnectorCount: 0,
+    approvalBlockedConnectorCount: 0,
+    missingCriticalConnectorCount: 0,
+    connectorNextAction: 'Prepare oauth setup packet for HubSpot; do not connect until approved.',
+    conflicts: [],
+    items: [
+      {
+        key: 'hubspot',
+        label: 'HubSpot',
+        category: 'crm',
+        status: 'needs_auth',
+        source: 'audit',
+        authMethod: 'oauth',
+        setupOwner: 'shared',
+        requiredScopes: [],
+        approvalActions: [],
+        healthChecks: [],
+        fallbackPath: 'Use CSV exports until OAuth approval.',
+        critical: true,
+        evidence: 'Audit CRM: hubspot',
+        nextAction: 'Prepare oauth setup packet for HubSpot; do not connect until approved.',
+      },
+    ],
+  },
   projectionStatus: {
     tasksTotal: 2,
     tasksComplete: 1,
@@ -59,6 +86,9 @@ describe('AiOpsRoadmapSection', () => {
     render(<AiOpsRoadmapSection roadmap={roadmap} />)
 
     expect(screen.getByText('Roadmap projection')).toBeInTheDocument()
+    expect(screen.getByText('Connector readiness')).toBeInTheDocument()
+    expect(screen.getByText('Prepare oauth setup packet for HubSpot; do not connect until approved.')).toBeInTheDocument()
+    expect(screen.getByText('HubSpot · needs auth')).toBeInTheDocument()
     expect(screen.getByText('Resolve blocked roadmap tasks')).toBeInTheDocument()
     expect(screen.getByText('Open actions')).toBeInTheDocument()
     expect(screen.getByText('Approvals')).toBeInTheDocument()

--- a/components/client-dashboard/AiOpsRoadmapSection.tsx
+++ b/components/client-dashboard/AiOpsRoadmapSection.tsx
@@ -26,6 +26,7 @@ function formatDate(value: string | null): string {
 
 export default function AiOpsRoadmapSection({ roadmap }: Props) {
   const projection = roadmap.projectionStatus
+  const connectors = roadmap.connectorReadiness
   const monitoringFlags = projection.overdueTasks + projection.staleCostItems + (projection.reportMissing ? 1 : 0)
   const openActions = projection.clientActionCount + projection.amadutownActionCount + projection.sharedActionCount
   const projectionTone = projection.blockedTasks > 0 || monitoringFlags > 0 || projection.approvalNeededCount > 0
@@ -109,6 +110,46 @@ export default function AiOpsRoadmapSection({ roadmap }: Props) {
             </div>
           </div>
         </div>
+      </div>
+
+      <div className="mb-5 rounded-lg border border-silicon-slate/60 bg-background/40 p-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <p className={eyebrowClass}>Connector readiness</p>
+            <p className="mt-1 text-sm font-semibold text-foreground">{connectors.connectorNextAction}</p>
+            <p className="mt-1 text-xs text-muted-foreground">{connectors.summary}</p>
+          </div>
+          <div className="grid grid-cols-2 gap-3 text-sm sm:grid-cols-4">
+            <div>
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">Required</p>
+              <p className="font-semibold text-foreground">{connectors.requiredConnectorCount}</p>
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">Ready</p>
+              <p className="font-semibold text-foreground">{connectors.readyConnectorCount}</p>
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">Approval blocked</p>
+              <p className="font-semibold text-foreground">{connectors.approvalBlockedConnectorCount}</p>
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">Critical missing</p>
+              <p className="font-semibold text-foreground">{connectors.missingCriticalConnectorCount}</p>
+            </div>
+          </div>
+        </div>
+        {connectors.items.length > 0 && (
+          <div className="mt-4 flex flex-wrap gap-2">
+            {connectors.items.slice(0, 6).map((connector) => (
+              <span
+                key={connector.key}
+                className="rounded-full border border-radiant-gold/30 bg-radiant-gold/10 px-2.5 py-1 text-xs text-radiant-gold"
+              >
+                {connector.label} · {connector.status.replace(/_/g, ' ')}
+              </span>
+            ))}
+          </div>
+        )}
       </div>
 
       <div className="space-y-3">

--- a/docs/client-ai-ops-roadmap-sop.md
+++ b/docs/client-ai-ops-roadmap-sop.md
@@ -90,6 +90,18 @@ Projection status may show:
 
 Keep this projection read-only. It can recommend follow-up, escalation, cost refreshes, or approval review, but it must not create credentials, connect OAuth, activate workflows, send outbound messages, publish client-facing reports, mutate client data, or change production configuration without the normal approval path.
 
+## Connector Readiness
+
+Connector readiness is part of the roadmap snapshot and client/admin read model. It uses the shared connector catalog and source precedence from Agent Swarm Board work:
+
+1. Admin/client-verified tech stack.
+2. Audit tech stack and audit enrichment.
+3. Meeting-derived audit notes.
+4. BuiltWith/domain lookup.
+5. Roadmap/client project metadata.
+
+Connector readiness may show required connectors, ready connectors, approval-blocked connectors, missing critical connectors, detected providers, and the next setup action. Treat these as planning signals only. OAuth, API keys, service accounts, webhook setup, workflow activation, outbound sends, publishing, production deploys, and client-data mutation remain approval-gated.
+
 ## Roadmap Rule Checklist
 
 Use this checklist whenever a roadmap feature, monitor, report, or client implementation phase changes:
@@ -101,6 +113,7 @@ Use this checklist whenever a roadmap feature, monitor, report, or client implem
 - Phase rollups and cost summaries refresh after task or cost changes.
 - The monitor can create a roadmap report and follow-up task when drift, stale pricing, missing reports, or blockers appear.
 - Roadmap projection status is visible from the same source data and remains read-only.
+- Connector readiness is visible from verified stack, audit, BuiltWith, and roadmap signals without live credential setup.
 - Client-facing output excludes private logs, agent traces, credentials, and internal-only notes.
 
 ## Real Client Pilot Checklist

--- a/lib/client-ai-ops-roadmap-db.ts
+++ b/lib/client-ai-ops-roadmap-db.ts
@@ -6,6 +6,7 @@ import {
   meetingTaskStatusFromRoadmap,
   roadmapStatusFromProjectedTask,
   rollUpRoadmapCosts,
+  type RoadmapContext,
   type RoadmapClientView,
   type RoadmapOrgBoardProjection,
   type RoadmapTaskStatus,
@@ -159,20 +160,23 @@ export async function ensureRoadmapForProject(clientProjectId: string, options?:
   const db = requireDb()
   const { data: project, error: projectError } = await db
     .from('client_projects')
-    .select('id, project_name, client_name, client_company, contact_submission_id, proposal_id')
+    .select('id, project_name, client_name, client_company, client_email, contact_submission_id, proposal_id')
     .eq('id', clientProjectId)
     .single()
 
   if (projectError || !project) throw new Error('Client project not found')
 
-  const draft = buildDefaultClientAiOpsRoadmap({
+  const context = await buildRoadmapContextForProject({
+    id: project.id,
+    projectName: project.project_name,
     clientName: project.client_name,
     clientCompany: project.client_company,
-    projectName: project.project_name,
+    clientEmail: project.client_email,
     clientProjectId,
     proposalId: project.proposal_id,
     contactSubmissionId: project.contact_submission_id,
   })
+  const draft = buildDefaultClientAiOpsRoadmap(context)
 
   const { data: roadmap, error: roadmapError } = await db
     .from('client_ai_ops_roadmaps')
@@ -187,6 +191,7 @@ export async function ensureRoadmapForProject(clientProjectId: string, options?:
       snapshot: {
         input_hash: draft.inputHash,
         runtime_placement_options: draft.runtimePlacementOptions,
+        connector_readiness: draft.connectorReadiness,
       },
       created_by: options?.userId ?? null,
     })
@@ -261,6 +266,81 @@ export async function ensureRoadmapForProject(clientProjectId: string, options?:
 
   await refreshRoadmapPhaseRollups(roadmap.id)
   return (await getRoadmapBundleForProject(clientProjectId)) as RoadmapBundle
+}
+
+async function buildRoadmapContextForProject(project: {
+  id: string
+  projectName: string | null
+  clientName: string | null
+  clientCompany: string | null
+  clientEmail: string | null
+  clientProjectId: string
+  proposalId: string | null
+  contactSubmissionId: number | null
+}): Promise<RoadmapContext> {
+  const db = requireDb()
+  const contactId = project.contactSubmissionId
+  const contactPromise = contactId
+    ? db
+      .from('contact_submissions')
+      .select('id, email, website_tech_stack, client_verified_tech_stack')
+      .eq('id', contactId)
+      .maybeSingle()
+    : Promise.resolve({ data: null, error: null })
+
+  const auditsByContactPromise = contactId
+    ? db
+      .from('diagnostic_audits')
+      .select('id, contact_submission_id, contact_email, audit_type, tech_stack, automation_needs, ai_readiness, budget_timeline, decision_making, enriched_tech_stack, completed_at, updated_at, created_at')
+      .eq('contact_submission_id', contactId)
+      .order('completed_at', { ascending: false, nullsFirst: false })
+      .limit(3)
+    : Promise.resolve({ data: [], error: null })
+
+  const auditsByEmailPromise = project.clientEmail
+    ? db
+      .from('diagnostic_audits')
+      .select('id, contact_submission_id, contact_email, audit_type, tech_stack, automation_needs, ai_readiness, budget_timeline, decision_making, enriched_tech_stack, completed_at, updated_at, created_at')
+      .eq('contact_email', project.clientEmail)
+      .order('completed_at', { ascending: false, nullsFirst: false })
+      .limit(3)
+    : Promise.resolve({ data: [], error: null })
+
+  const [contactRes, auditsByContactRes, auditsByEmailRes] = await Promise.all([
+    contactPromise,
+    auditsByContactPromise,
+    auditsByEmailPromise,
+  ])
+
+  if (contactRes.error) console.warn('[client-ai-ops-roadmap] contact connector context unavailable:', contactRes.error.message)
+  if (auditsByContactRes.error) console.warn('[client-ai-ops-roadmap] contact audit connector context unavailable:', auditsByContactRes.error.message)
+  if (auditsByEmailRes.error) console.warn('[client-ai-ops-roadmap] email audit connector context unavailable:', auditsByEmailRes.error.message)
+
+  const contact = contactRes.data as JsonRecord | null
+  const auditSignals = [...((auditsByContactRes.data ?? []) as JsonRecord[]), ...((auditsByEmailRes.data ?? []) as JsonRecord[])]
+    .filter((audit, index, rows) => rows.findIndex((item) => String(item.id) === String(audit.id)) === index)
+    .map((audit) => ({
+      id: audit.id as string | number | null,
+      audit_type: audit.audit_type as string | null,
+      tech_stack: audit.tech_stack as JsonRecord | null,
+      automation_needs: audit.automation_needs as JsonRecord | null,
+      ai_readiness: audit.ai_readiness as JsonRecord | null,
+      budget_timeline: audit.budget_timeline as JsonRecord | null,
+      decision_making: audit.decision_making as JsonRecord | null,
+      enriched_tech_stack: audit.enriched_tech_stack as JsonRecord | null,
+    }))
+
+  return {
+    clientName: project.clientName,
+    clientCompany: project.clientCompany,
+    projectName: project.projectName,
+    clientProjectId: project.clientProjectId,
+    proposalId: project.proposalId,
+    contactSubmissionId: project.contactSubmissionId,
+    verifiedStack: contact?.client_verified_tech_stack as JsonRecord | null,
+    builtWithStack: contact?.website_tech_stack as JsonRecord | null,
+    auditSignals,
+  }
 }
 
 export async function projectRoadmapTasks(clientProjectId: string): Promise<{ dashboardCreated: number; meetingCreated: number }> {

--- a/lib/client-ai-ops-roadmap.test.ts
+++ b/lib/client-ai-ops-roadmap.test.ts
@@ -166,6 +166,37 @@ describe('client AI ops roadmap', () => {
       .toContain('workflow copilots')
   })
 
+  it('maps audit and stack signals into connector readiness without live setup', () => {
+    const snapshot = buildProposalRoadmapSnapshot({
+      clientCompany: 'Acme Co',
+      verifiedStack: { technologies: [{ name: 'Webflow' }] },
+      auditSignals: [
+        {
+          audit_type: 'standalone',
+          tech_stack: {
+            crm: 'hubspot',
+            email: 'gmail',
+            other_tools: ['Slack'],
+          },
+          automation_needs: { priority_areas: ['lead_follow_up'] },
+          ai_readiness: { data_quality: 'integrated' },
+          decision_making: { decision_maker: true, approval_process: 'solo' },
+          enriched_tech_stack: { technologies: [{ name: 'Pinecone' }] },
+        },
+      ],
+    })
+
+    expect(snapshot.connectorReadiness.items.map((item) => item.key)).toEqual(expect.arrayContaining([
+      'webflow',
+      'hubspot',
+      'google_workspace',
+      'slack',
+      'pinecone',
+    ]))
+    expect(snapshot.connectorReadiness.requiredConnectorCount).toBeGreaterThanOrEqual(5)
+    expect(snapshot.connectorReadiness.connectorNextAction).toContain('setup packet')
+  })
+
   it('maps statuses between roadmap and projected task tables', () => {
     expect(dashboardStatusFromRoadmap('blocked')).toBe('in_progress')
     expect(meetingTaskStatusFromRoadmap('cancelled')).toBe('cancelled')
@@ -179,6 +210,35 @@ describe('client AI ops roadmap', () => {
         title: 'Acme AI Ops Roadmap',
         status: 'active',
         client_summary: 'Implementation is underway.',
+        snapshot: {
+          connector_readiness: {
+            summary: '5 required, 0 ready, 4 need auth, 0 approval-blocked',
+            requiredConnectorCount: 5,
+            readyConnectorCount: 0,
+            approvalBlockedConnectorCount: 0,
+            missingCriticalConnectorCount: 0,
+            connectorNextAction: 'Prepare oauth setup packet for HubSpot; do not connect until approved.',
+            conflicts: [],
+            items: [
+              {
+                key: 'hubspot',
+                label: 'HubSpot',
+                category: 'crm',
+                status: 'needs_auth',
+                source: 'audit',
+                authMethod: 'oauth',
+                setupOwner: 'shared',
+                requiredScopes: [],
+                approvalActions: [],
+                healthChecks: [],
+                fallbackPath: 'Use CSV exports until OAuth approval.',
+                critical: true,
+                evidence: 'Audit CRM: hubspot',
+                nextAction: 'Prepare oauth setup packet for HubSpot; do not connect until approved.',
+              },
+            ],
+          },
+        },
       },
       phases: [
         {
@@ -271,6 +331,11 @@ describe('client AI ops roadmap', () => {
       staleCostItems: 2,
       reportMissing: false,
       nextReportingAction: 'Resolve blocked roadmap tasks',
+    })
+    expect(view.connectorReadiness).toMatchObject({
+      requiredConnectorCount: 5,
+      readyConnectorCount: 0,
+      connectorNextAction: 'Prepare oauth setup packet for HubSpot; do not connect until approved.',
     })
     expect(JSON.stringify(view.latestReport)).not.toContain('Internal escalation note')
   })

--- a/lib/client-ai-ops-roadmap.ts
+++ b/lib/client-ai-ops-roadmap.ts
@@ -1,6 +1,12 @@
 import { createHash } from 'node:crypto'
 import type { AgentReadinessAssessment, AgentReadinessLevel } from './agent-readiness-assessment'
 import type { SwarmBoardColumnKey, SwarmHandoffStage } from './agent-swarm-board'
+import {
+  buildClientConnectorReadiness,
+  type BuildClientConnectorReadinessInput,
+  type ClientConnectorAuditSignal,
+  type ClientConnectorReadiness,
+} from './client-connector-readiness'
 
 export const ROADMAP_PHASES = [
   'discovery_ownership',
@@ -39,6 +45,9 @@ export interface RoadmapContext {
   clientProjectId?: string | null
   contactSubmissionId?: number | null
   stackSignals?: string[]
+  verifiedStack?: Record<string, unknown> | null
+  builtWithStack?: Record<string, unknown> | null
+  auditSignals?: ClientConnectorAuditSignal[]
   implementationRequirements?: Record<string, unknown> | null
 }
 
@@ -109,6 +118,7 @@ export interface RoadmapDraft {
   clientSummary: string
   inputHash: string
   runtimePlacementOptions: RoadmapRuntimePlacementOption[]
+  connectorReadiness: ClientConnectorReadiness
   phases: RoadmapPhaseDraft[]
   tasks: RoadmapTaskDraft[]
   costItems: RoadmapCostItemDraft[]
@@ -172,6 +182,7 @@ export interface RoadmapClientView {
   status: RoadmapStatus
   clientSummary: string | null
   runtimePlacementOptions: RoadmapRuntimePlacementOption[]
+  connectorReadiness: ClientConnectorReadiness
   phases: RoadmapClientPhase[]
   costSummary: RoadmapCostRollup
   projectionStatus: RoadmapClientProjectionStatus
@@ -503,6 +514,7 @@ export function buildDefaultClientAiOpsRoadmap(context: RoadmapContext = {}): Ro
   const name = context.clientCompany || context.clientName || 'Client'
   const agentReadiness = getAgentReadinessAssessment(context)
   const adjustments = agentReadiness ? phaseAdjustmentsForReadiness(agentReadiness.overallLevel) : {}
+  const connectorReadiness = buildRoadmapConnectorReadiness(context)
 
   return {
     title: `${name} AI Ops Roadmap`,
@@ -511,6 +523,7 @@ export function buildDefaultClientAiOpsRoadmap(context: RoadmapContext = {}): Ro
       : 'A phased implementation plan for client-owned AI infrastructure, 24/7 data and local LLM repository placement, transparent setup costs, agent deployment, monitoring, and continuity reporting.',
     inputHash: hashContext(context),
     runtimePlacementOptions: DEFAULT_RUNTIME_PLACEMENT_OPTIONS.map((option) => ({ ...option })),
+    connectorReadiness,
     phases: DEFAULT_PHASES.map((phase) => {
       const adjustment = adjustments[phase.phaseKey]
       return {
@@ -571,6 +584,40 @@ export function roadmapStatusFromProjectedTask(status: string): RoadmapTaskStatu
 export function buildProposalRoadmapSnapshot(context: RoadmapContext = {}): RoadmapDraft & { costSummary: RoadmapCostRollup } {
   const draft = buildDefaultClientAiOpsRoadmap(context)
   return { ...draft, costSummary: rollUpRoadmapCosts(draft.costItems) }
+}
+
+function buildRoadmapConnectorReadiness(context: RoadmapContext): ClientConnectorReadiness {
+  const requirements = context.implementationRequirements ?? {}
+  const connectorInput = requirements.connectorReadinessInput && typeof requirements.connectorReadinessInput === 'object'
+    ? requirements.connectorReadinessInput as Partial<BuildClientConnectorReadinessInput>
+    : {}
+  const auditSignals = context.auditSignals
+    ?? (Array.isArray(requirements.auditSignals) ? requirements.auditSignals as ClientConnectorAuditSignal[] : [])
+
+  return buildClientConnectorReadiness({
+    verifiedStack: context.verifiedStack
+      ?? (requirements.verifiedStack && typeof requirements.verifiedStack === 'object' ? requirements.verifiedStack as Record<string, unknown> : null)
+      ?? connectorInput.verifiedStack
+      ?? null,
+    auditSignals: auditSignals.length > 0 ? auditSignals : connectorInput.auditSignals ?? [],
+    builtWithStack: context.builtWithStack
+      ?? (requirements.builtWithStack && typeof requirements.builtWithStack === 'object' ? requirements.builtWithStack as Record<string, unknown> : null)
+      ?? connectorInput.builtWithStack
+      ?? null,
+    roadmapSnapshot: {
+      stackSignals: context.stackSignals ?? [],
+      projectName: context.projectName ?? null,
+      clientName: context.clientName ?? null,
+      ...connectorInput.roadmapSnapshot,
+    },
+    roadmapTasks: connectorInput.roadmapTasks ?? [],
+    projectMetadata: {
+      project_name: context.projectName ?? null,
+      client_name: context.clientName ?? null,
+      client_company: context.clientCompany ?? null,
+      ...connectorInput.projectMetadata,
+    },
+  })
 }
 
 export function buildClientRoadmapView(input: {
@@ -660,6 +707,7 @@ export function buildClientRoadmapView(input: {
     runtimePlacementOptions: Array.isArray(input.roadmap.snapshot?.runtime_placement_options)
       ? input.roadmap.snapshot.runtime_placement_options as RoadmapRuntimePlacementOption[]
       : DEFAULT_RUNTIME_PLACEMENT_OPTIONS.map((option) => ({ ...option })),
+    connectorReadiness: connectorReadinessFromSnapshot(input.roadmap.snapshot),
     phases,
     costSummary: rollUpRoadmapCosts(input.costItems),
     projectionStatus,
@@ -693,6 +741,17 @@ export function buildClientRoadmapView(input: {
         }
       : null,
   }
+}
+
+function connectorReadinessFromSnapshot(snapshot: Record<string, unknown> | null | undefined): ClientConnectorReadiness {
+  const connectorReadiness = snapshot?.connector_readiness
+  if (connectorReadiness && typeof connectorReadiness === 'object') {
+    const readiness = connectorReadiness as Partial<ClientConnectorReadiness>
+    if (Array.isArray(readiness.items) && typeof readiness.requiredConnectorCount === 'number') {
+      return readiness as ClientConnectorReadiness
+    }
+  }
+  return buildClientConnectorReadiness({ roadmapSnapshot: snapshot ?? null })
 }
 
 function taskOrgBoard(task: { metadata?: Record<string, unknown> | null }): Record<string, unknown> | null {


### PR DESCRIPTION
## Summary
- adds connector readiness to Client AI Ops roadmap drafts and client/admin read models using the shared connector catalog
- pulls read-only stack evidence from client-verified stack data, diagnostic audits, audit enrichment, BuiltWith/domain stack data, and roadmap/project metadata
- surfaces connector readiness counts, next setup action, and detected connector chips in the client dashboard and admin project roadmap section
- documents connector readiness as planning-only, with live setup and credential/provider actions remaining approval-gated

## Validation
- npm test -- lib/client-ai-ops-roadmap.test.ts components/client-dashboard/AiOpsRoadmapSection.test.tsx app/api/admin/client-projects/[id]/ai-ops/route.test.ts lib/agent-swarm-board.test.ts
- npx tsc --noEmit --pretty false
- git diff --cached --check
- push hook database health check passed

## Integration Notes
- Preflight was green after PR #375 merged: no open PR overlap and this branch was created from fresh main.
- Existing unrelated untracked tmp/ directory was left untouched.
- No migrations or live connector setup are included. No OAuth, API key sync, provider write, workflow activation, outbound send, publishing, deploy, or client-data mutation is performed.
- Vercel contexts checked before this slice: Vercel – portfolio passed for PR #375. This branch still needs normal captain/deployment verification for Vercel – portfolio and Vercel – portfolio-staging before merge.