### PR TITLE
docs: add agentic content research PRDs

### DIFF
--- a/docs/agentic-content-research-prds/01-agentic-operating-system-overview.md
+++ b/docs/agentic-content-research-prds/01-agentic-operating-system-overview.md
@@ -1,0 +1,68 @@
+# PRD 01: Agentic Operating System Overview
+
+## Objective
+
+Research the full lifecycle of a governed agentic solution as proven by Portfolio: harness, brain, memory, evaluation, swarms, permissions, delegation, Mission Control, Slack, approval gates, and audit exports.
+
+This is the opening chapter. It should give readers a map before the series goes deep.
+
+## Research Questions
+
+- What makes Portfolio more than a collection of AI features?
+- Which implemented surfaces prove an operating model exists?
+- Where does the system still choose governance over autonomy?
+- What would a nonprofit, founder, or product leader need to see before trusting this pattern?
+
+## Portfolio Evidence To Inspect
+
+- `docs/agentic-operating-system-governance.md`
+- `docs/agent-operations-roadmap.md`
+- `docs/agentic-patterns.md`
+- `lib/agent-organization.ts`
+- `lib/agent-mission-control.ts`
+- `app/admin/agents/page.tsx`
+- `app/admin/agents/coordination/page.tsx`
+- `app/admin/agents/swarm-board/page.tsx`
+
+## Public-Safe Claim Boundaries
+
+- State that Portfolio has a v1 implementation of Agent Ops, governance snapshots, delegation policy, approvals, work items, and audit exports.
+- Avoid claiming fully autonomous production execution.
+- Avoid quoting raw private traces, private chats, credentials, or client records.
+- Frame the system as proof-in-progress, not a finished platform claim.
+
+## LinkedIn Output Target
+
+- Format: standard post or carousel opener.
+- Hook direction: "Anyone can build an agent demo. The hard part is building the operating system around it."
+- Core point: the wave rewards builders who can turn model output into governed work.
+- Close: invite builders to think past the demo and into authority, memory, traceability, and trust.
+
+## Phase 2 Video Expansion
+
+- YouTube angle: "The Agentic Operating System We Are Building Inside Portfolio."
+- Target runtime: 6 to 8 minutes.
+- Opening scene: screen share of Mission Control, then cut to the idea that speed without governance becomes risk.
+- Script framework fit: scene, system diagnosis, lifecycle map, operating principle, next action.
+- HeyGen suitability: strong. Use avatar narration over Mission Control and diagram B-roll.
+- ElevenLabs suitability: use for short clips or carousel companion audio, not as the primary final video until the script is locked.
+- Storyboard/B-roll ideas: `/admin/agents`, `/admin/agents/coordination`, `/admin/agents/swarm-board`, governance docs, Agent Ops trace detail.
+- Evidence needed before recording: one confirmed local or staging screen recording of Mission Control loading with current labels.
+
+## Acceptance Criteria
+
+- Research memo names at least eight implemented Portfolio capabilities.
+- Output distinguishes built proof from planned or partial capabilities.
+- Messaging uses Vambah's practical builder voice and avoids generic AI hype.
+- Final recommendation identifies the next 3 posts in the series.
+
+## UI Seeding Packet
+
+Title: `Research PRD: Agentic operating system overview`
+
+Owner: Research Source Register
+
+Runtime: codex
+
+Narrative:
+Research the full lifecycle of Portfolio as a governed agentic operating system. Inspect Agent Ops governance docs, roadmap, patterns scorecard, Mission Control, Agent Coordination, and swarm board surfaces. Produce source-backed notes for a LinkedIn opening post and Phase 2 YouTube overview. Keep claims public-safe, avoid raw private traces, and separate implemented proof from planned capabilities. Acceptance: name at least eight real Portfolio capabilities, provide a post angle, video angle, and evidence checklist.

--- a/docs/agentic-content-research-prds/02-harness-trace-foundation.md
+++ b/docs/agentic-content-research-prds/02-harness-trace-foundation.md
@@ -1,0 +1,67 @@
+# PRD 02: Harness And Trace Foundation
+
+## Objective
+
+Research the harness that makes agent work observable: run records, steps, events, artifacts, approvals, handoffs, work items, stale recovery, and linked costs.
+
+This chapter should make the case that the first layer of agentic maturity is not intelligence. It is traceability.
+
+## Research Questions
+
+- What is the minimum trace envelope an agentic system needs before it can be trusted?
+- How does Portfolio connect runs, artifacts, approvals, handoffs, work items, and costs?
+- Which surfaces show status and failure states without reading database rows?
+- Where do legacy workflow tables still coexist with shared Agent Ops traces?
+
+## Portfolio Evidence To Inspect
+
+- `docs/agent-operations-roadmap.md`
+- `lib/agent-run.ts`
+- `lib/agent-mission-control.ts`
+- `lib/agent-work-items.ts`
+- `lib/agent-stale-runs.ts`
+- `app/admin/agents/runs/page.tsx`
+- `app/admin/agents/runs/[runId]/page.tsx`
+- `app/api/admin/agents/runs/[runId]/route.ts`
+
+## Public-Safe Claim Boundaries
+
+- Discuss trace structure and operating model, not private run contents.
+- Use route and table names as implementation proof.
+- Avoid publishing internal error messages or any sensitive artifact body.
+
+## LinkedIn Output Target
+
+- Format: builder insight post.
+- Hook direction: "The first thing I want from an AI agent is not creativity. I want a receipt."
+- Core point: agents need a harness that records who acted, what happened, where the artifact lives, and what still needs approval.
+- Close: ask what trace evidence readers would require before letting an agent touch real work.
+
+## Phase 2 Video Expansion
+
+- YouTube angle: "Build The Harness Before You Trust The Agent."
+- Target runtime: 5 to 7 minutes.
+- Opening scene: a failed agent run or stale work item, followed by the trace detail page.
+- Script framework fit: problem, cost of invisible work, trace envelope, example, operating rule.
+- HeyGen suitability: strong for narration; pair with screen capture of run detail.
+- ElevenLabs suitability: optional short-form clip voiceover for a "receipt for agent work" excerpt.
+- Storyboard/B-roll ideas: run list, run detail timeline, artifacts, approvals, cost summary, stale sweep.
+- Evidence needed before recording: sanitized screenshot or recording of a run detail page with no private content exposed.
+
+## Acceptance Criteria
+
+- Research memo defines the trace envelope in plain language.
+- Output lists concrete Portfolio files/routes and what each proves.
+- LinkedIn angle avoids abstract observability jargon.
+- Phase 2 notes identify safe B-roll and sensitive areas to blur or avoid.
+
+## UI Seeding Packet
+
+Title: `Research PRD: Harness and trace foundation`
+
+Owner: Research Source Register
+
+Runtime: codex
+
+Narrative:
+Research Portfolio's Agent Ops trace harness: runs, steps, events, artifacts, handoffs, approvals, work items, stale recovery, and costs. Inspect the roadmap, agent-run helpers, Mission Control snapshot, work item helpers, and run detail routes. Produce public-safe notes for a LinkedIn builder post and Phase 2 YouTube segment. Acceptance: define the trace envelope, cite concrete repo evidence, name safe screenshots/B-roll, and avoid private run content.

--- a/docs/agentic-content-research-prds/03-shaka-controller-brain.md
+++ b/docs/agentic-content-research-prds/03-shaka-controller-brain.md
@@ -1,0 +1,65 @@
+# PRD 03: Shaka Controller Brain
+
+## Objective
+
+Research Shaka as the controller layer: the Chief of Staff that interprets intent, routes work, recommends agent engagements, and keeps side effects gated.
+
+This chapter should explain why a governed system needs a brain that coordinates before agents execute.
+
+## Research Questions
+
+- What does Shaka do that a generic chat interface does not?
+- How does deterministic delegation reduce risk and improve explainability?
+- Which task types, risk classes, evidence requirements, and fallback rules exist today?
+- How should this be explained to a nontechnical operator?
+
+## Portfolio Evidence To Inspect
+
+- `lib/chief-of-staff-chat.ts`
+- `lib/agent-delegation-policy.ts`
+- `app/admin/agents/chief-of-staff/page.tsx`
+- `app/api/admin/agents/chief-of-staff/chat/route.ts`
+- `app/api/admin/agents/chief-of-staff/actions/route.ts`
+- `docs/agentic-operating-system-governance.md`
+
+## Public-Safe Claim Boundaries
+
+- Describe Shaka's routing and recommendation role.
+- Avoid implying Shaka can independently mutate production systems.
+- Do not expose private operator prompts or raw model replies.
+
+## LinkedIn Output Target
+
+- Format: standard post.
+- Hook direction: "In an agentic system, the controller matters as much as the agents."
+- Core point: delegation should be visible, explainable, and tied to evidence.
+- Close: ask readers whether their agents can explain why work went to a specific runtime or specialist.
+
+## Phase 2 Video Expansion
+
+- YouTube angle: "Why Every Agent Swarm Needs A Chief Of Staff."
+- Target runtime: 5 to 6 minutes.
+- Opening scene: ask Shaka a status/routing question, then show the recommended engagement path.
+- Script framework fit: familiar workplace analogy, technical mapping, governance rule, demo.
+- HeyGen suitability: strong. Avatar narration can introduce the concept, then switch to screen share.
+- ElevenLabs suitability: good for a short companion audio clip explaining "controller before execution."
+- Storyboard/B-roll ideas: Chief of Staff page, delegation policy code snippets, Agent Coordination queue, run trace events.
+- Evidence needed before recording: one safe Shaka interaction that does not reveal private client data.
+
+## Acceptance Criteria
+
+- Research memo describes Shaka's role without overclaiming autonomy.
+- Output explains task type, risk class, required evidence, fallback, and confidence in plain language.
+- Messaging includes one workplace analogy and one concrete Portfolio example.
+- Phase 2 notes identify a safe demo interaction.
+
+## UI Seeding Packet
+
+Title: `Research PRD: Shaka controller brain`
+
+Owner: Research Source Register
+
+Runtime: codex
+
+Narrative:
+Research Shaka as Portfolio's controller layer for Agent Ops. Inspect Chief of Staff chat/action routes, deterministic delegation policy, governance docs, and admin surfaces. Produce source-backed notes for a LinkedIn post explaining why agent systems need a controller that routes work, requires evidence, and keeps side effects gated. Acceptance: explain task types, risk classes, fallback, confidence, and approval boundaries in plain language, plus a Phase 2 video demo idea.

--- a/docs/agentic-content-research-prds/04-open-brain-memory-architecture.md
+++ b/docs/agentic-content-research-prds/04-open-brain-memory-architecture.md
@@ -1,0 +1,66 @@
+# PRD 04: Open Brain Memory Architecture
+
+## Objective
+
+Research the memory architecture behind Portfolio Agent Ops: local-first Open Brain records, source records, events, memories, links, proposals, runtime parity, producer gates, and compiled wiki overlays.
+
+This chapter should make memory feel like governance, not magic.
+
+## Research Questions
+
+- Why does durable memory need source records and approval proposals?
+- How does Portfolio separate local Open Brain truth from dashboard projection?
+- Which privacy tiers and source kinds matter for public-facing content?
+- How should the system decide what becomes public-safe, client-safe, internal, or private?
+
+## Portfolio Evidence To Inspect
+
+- `lib/open-brain.ts`
+- `app/admin/agents/open-brain/page.tsx`
+- `app/api/admin/agents/open-brain/route.ts`
+- `app/api/admin/agents/open-brain/proposals/route.ts`
+- `app/api/admin/agents/open-brain/wiki/compile/route.ts`
+- `docs/vambah-personality-public-safe.md`
+- `docs/agentic-operating-system-governance.md`
+
+## Public-Safe Claim Boundaries
+
+- Discuss memory structure, privacy tiers, producer gates, and approval proposals.
+- Do not quote raw private corpus, private AI chats, client data, or sensitive Open Brain records.
+- Treat compiled wiki pages as overlays, not the source of truth.
+
+## LinkedIn Output Target
+
+- Format: reflective systems post.
+- Hook direction: "Agent memory gets dangerous when every note becomes truth."
+- Core point: memory needs provenance, privacy, review, and revocation.
+- Close: ask what a system should be allowed to remember and who gets to approve it.
+
+## Phase 2 Video Expansion
+
+- YouTube angle: "How To Think About Memory In Agentic Systems."
+- Target runtime: 6 to 8 minutes.
+- Opening scene: a clean Open Brain dashboard, then a simple diagram of source -> proposal -> memory -> wiki overlay.
+- Script framework fit: tension, operating model, example, privacy boundary, principle.
+- HeyGen suitability: strong with diagram B-roll and dashboard screen share.
+- ElevenLabs suitability: useful for a short voiceover clip on "memory is governance."
+- Storyboard/B-roll ideas: Open Brain router, proposals, wiki compile preview, producer gates, runtime parity.
+- Evidence needed before recording: current Open Brain dashboard screenshot with private details excluded.
+
+## Acceptance Criteria
+
+- Research memo explains the memory flow without treating memory as a black box.
+- Output names privacy tiers and why they matter.
+- Messaging connects memory to dignity, consent, and operational trust.
+- Phase 2 notes include a simple diagram brief.
+
+## UI Seeding Packet
+
+Title: `Research PRD: Open Brain memory architecture`
+
+Owner: Research Source Register
+
+Runtime: codex
+
+Narrative:
+Research Portfolio's Open Brain memory architecture for agentic systems. Inspect open-brain types, admin page, proposal routes, wiki compile route, public-safe personality pack, and governance docs. Produce public-safe notes for a LinkedIn post and Phase 2 video explaining source records, proposals, memories, links, privacy tiers, producer gates, and compiled wiki overlays. Acceptance: distinguish source of truth from projection, avoid raw private material, and provide a diagram-friendly video outline.

--- a/docs/agentic-content-research-prds/05-self-evaluation-quality-loops.md
+++ b/docs/agentic-content-research-prds/05-self-evaluation-quality-loops.md
@@ -1,0 +1,67 @@
+# PRD 05: Self-Evaluation And Quality Loops
+
+## Objective
+
+Research the evaluation and feedback loops that let agents improve safely: rubrics, run scoring, budget checks, LLM judge surfaces, source validation, and coaching signals.
+
+This chapter should argue that quality loops come before expanded authority.
+
+## Research Questions
+
+- Which self-evaluation patterns exist in Portfolio today?
+- What is deterministic evaluation versus LLM-assisted evaluation?
+- How do budget checks, failed runs, stale runs, and rubric scores create coaching signals?
+- Which gaps remain before agents can revise outputs inline?
+
+## Portfolio Evidence To Inspect
+
+- `docs/agentic-patterns.md`
+- `lib/agent-evaluations.ts`
+- `app/api/admin/agents/runs/[runId]/evaluate/route.ts`
+- `lib/llm-judge.ts`
+- `lib/source-validator/llm-judge.ts`
+- `app/admin/chat-eval`
+- `lib/video-ideas-generation.ts`
+- `lib/agent-budget-policy.ts`
+
+## Public-Safe Claim Boundaries
+
+- Do not publish private evaluation content, transcript excerpts, or raw chat sessions.
+- Keep examples structural: rubric dimensions, score thresholds, pass/fail signals, budget decisions.
+- Be clear that inline reflection is still minimal or planned where the scorecard says so.
+
+## LinkedIn Output Target
+
+- Format: builder insight post.
+- Hook direction: "If an agent cannot evaluate its work, it should not get more power."
+- Core point: self-evaluation is a promotion gate, not a decorative feature.
+- Close: ask what quality evidence readers would require before trusting an agent with higher-risk work.
+
+## Phase 2 Video Expansion
+
+- YouTube angle: "The Evaluation Loop That Keeps Agents Honest."
+- Target runtime: 5 to 7 minutes.
+- Opening scene: a quality summary or run evaluation, then the rule that agents earn authority through evidence.
+- Script framework fit: problem, quality loop, example, gap, recommendation.
+- HeyGen suitability: strong with UI and chart B-roll.
+- ElevenLabs suitability: optional audio for short clips.
+- Storyboard/B-roll ideas: evaluation route, agent quality summary, Chat Eval, source validator, budget check events.
+- Evidence needed before recording: a sanitized quality/evaluation example that does not expose private content.
+
+## Acceptance Criteria
+
+- Research memo separates built eval loops from planned reflection/debate/self-consistency work.
+- Output includes at least one concrete quality gate and one remaining gap.
+- LinkedIn recommendation ties evaluation to authority, not vanity metrics.
+- Phase 2 notes include a screen-safe visual plan.
+
+## UI Seeding Packet
+
+Title: `Research PRD: Self-evaluation and quality loops`
+
+Owner: Research Source Register
+
+Runtime: codex
+
+Narrative:
+Research Portfolio's agent evaluation and feedback loops. Inspect the agentic patterns scorecard, agent evaluations, run evaluate route, LLM judge, source validator, Chat Eval, video ideas budget checks, and Agent Ops budget policy. Produce public-safe notes for a LinkedIn post and Phase 2 video on why agents should earn authority through evaluation. Acceptance: distinguish implemented quality loops from planned reflection work, name concrete gates, and avoid private transcript or chat content.

--- a/docs/agentic-content-research-prds/06-agent-swarms-delegation.md
+++ b/docs/agentic-content-research-prds/06-agent-swarms-delegation.md
@@ -1,0 +1,66 @@
+# PRD 06: Agent Swarms And Delegation
+
+## Objective
+
+Research Portfolio's agent organization as a practical swarm: named agents, pods, responsibilities, active/partial/planned states, work items, handoffs, standups, and Kanban.
+
+This chapter should make the point that swarms need structure before they need more agents.
+
+## Research Questions
+
+- How does Portfolio define agent pods and responsibilities?
+- What makes a swarm accountable instead of chaotic?
+- How do work items, handoffs, standups, and Kanban turn agents into an operating team?
+- Which agent names and roles are most useful for public explanation?
+
+## Portfolio Evidence To Inspect
+
+- `lib/agent-organization.ts`
+- `lib/agent-swarm-board.ts`
+- `lib/agent-work-items.ts`
+- `app/admin/agents/swarm-board/page.tsx`
+- `app/admin/agents/standup/page.tsx`
+- `app/api/admin/agents/work-items/route.ts`
+- `app/api/admin/agents/war-room/route.ts`
+
+## Public-Safe Claim Boundaries
+
+- Use agent display names and roles that already exist in code.
+- Avoid claiming every planned agent is production-ready.
+- Do not expose private work item details or private standup transcripts.
+
+## LinkedIn Output Target
+
+- Format: list post or carousel.
+- Hook direction: "An agent swarm without roles is just noise moving faster."
+- Core point: the swarm needs pods, owners, handoff rules, and one operating board.
+- Close: ask how readers assign responsibility when more than one agent touches a workflow.
+
+## Phase 2 Video Expansion
+
+- YouTube angle: "How We Structure Agent Swarms Without Losing Control."
+- Target runtime: 6 to 8 minutes.
+- Opening scene: Agent Kanban with owners and swimlanes.
+- Script framework fit: team analogy, org map, handoff flow, risk boundary, lesson.
+- HeyGen suitability: strong; use avatar narration over board and roster B-roll.
+- ElevenLabs suitability: good for short summaries of each pod.
+- Storyboard/B-roll ideas: agent roster, swarm board lanes, standup page, work item detail, handoff actions.
+- Evidence needed before recording: safe board state with no sensitive work item text.
+
+## Acceptance Criteria
+
+- Research memo maps the pods and at least six agents to their responsibilities.
+- Output explains active, partial, and planned statuses.
+- Messaging avoids shallow novelty around agent names and focuses on operating discipline.
+- Phase 2 notes include a board-walkthrough structure.
+
+## UI Seeding Packet
+
+Title: `Research PRD: Agent swarms and delegation`
+
+Owner: Research Source Register
+
+Runtime: codex
+
+Narrative:
+Research Portfolio's agent swarm model: pods, named agents, statuses, responsibilities, work items, handoffs, standups, and Kanban. Inspect agent organization, swarm board helpers, work item helpers, Agent Kanban, standup page, work item routes, and War Room route. Produce public-safe notes for a LinkedIn post or carousel plus Phase 2 board-walkthrough video. Acceptance: map at least six agents to roles, explain swarm accountability, and avoid private work item content.

--- a/docs/agentic-content-research-prds/07-permission-scopes-risk-boundaries.md
+++ b/docs/agentic-content-research-prds/07-permission-scopes-risk-boundaries.md
@@ -1,0 +1,65 @@
+# PRD 07: Permission Scopes And Risk Boundaries
+
+## Objective
+
+Research how Portfolio limits agent risk through runtime policies, capability profiles, data classes, write classes, outbound authority, spend authority, and approval-required actions.
+
+This chapter should make least privilege feel like a product feature, not a security footnote.
+
+## Research Questions
+
+- What permissions exist at the runtime level?
+- How are those permissions translated into agent capability profiles?
+- What does the system allow by default, and what requires approval?
+- Which boundaries matter most for client trust?
+
+## Portfolio Evidence To Inspect
+
+- `lib/agent-policy.ts`
+- `lib/agent-governance.ts`
+- `app/api/admin/agents/policies/route.ts`
+- `app/admin/agents/page.tsx`
+- `docs/agentic-operating-system-governance.md`
+- `docs/agentic-patterns.md`
+
+## Public-Safe Claim Boundaries
+
+- Discuss policy categories and approval actions.
+- Do not expose secrets, env values, private data samples, or sensitive admin-only content.
+- Be careful not to imply that planned agents inherit broad authority.
+
+## LinkedIn Output Target
+
+- Format: standard post.
+- Hook direction: "Agent access should look less like a blank check and more like a permission slip."
+- Core point: trust comes from knowing what an agent can read, write, send, spend, and change.
+- Close: ask whether readers can explain their agent permissions without opening code.
+
+## Phase 2 Video Expansion
+
+- YouTube angle: "The Permission Model Behind Governed Agents."
+- Target runtime: 5 to 7 minutes.
+- Opening scene: governance status and capability inventory.
+- Script framework fit: risk scenario, permission map, live proof, principle.
+- HeyGen suitability: strong with capability table B-roll.
+- ElevenLabs suitability: optional narration for short educational clips.
+- Storyboard/B-roll ideas: runtime policies, governance profiles, approval required actions, Agent Governance panel.
+- Evidence needed before recording: safe view of capability inventory with no sensitive data.
+
+## Acceptance Criteria
+
+- Research memo explains runtime policy and agent capability profile as separate layers.
+- Output names read, write, client data, production write, outbound, and spend boundaries.
+- LinkedIn angle treats governance as practical trust, not fear.
+- Phase 2 notes include a simple permission-map visual.
+
+## UI Seeding Packet
+
+Title: `Research PRD: Permission scopes and risk boundaries`
+
+Owner: Research Source Register
+
+Runtime: codex
+
+Narrative:
+Research Portfolio's permission and risk boundary model. Inspect agent policy, governance profile builder, policies route, Agent Governance UI, governance docs, and agentic patterns scorecard. Produce public-safe notes for a LinkedIn post and Phase 2 video explaining runtime policies, agent capability profiles, data classes, write classes, outbound authority, spend authority, and approval-required actions. Acceptance: separate runtime policy from agent scope, name the major permission categories, and avoid secrets or private data.

--- a/docs/agentic-content-research-prds/08-human-in-the-loop-approvals.md
+++ b/docs/agentic-content-research-prds/08-human-in-the-loop-approvals.md
@@ -1,0 +1,66 @@
+# PRD 08: Human-In-The-Loop Approvals
+
+## Objective
+
+Research Portfolio's human approval controls: approval checkpoints, run detail decisions, Slack-safe mobile actions, publishing gates, email gates, production mutation gates, and private-to-public content gates.
+
+This chapter should frame human review as the trust layer that lets automation move safely.
+
+## Research Questions
+
+- Which actions require approval before side effects?
+- Where can a human approve, reject, request revision, or route work?
+- How does the system keep Slack mobile actions bounded?
+- How should this be explained without making governance sound like slowdown?
+
+## Portfolio Evidence To Inspect
+
+- `lib/agent-policy.ts`
+- `app/api/admin/agents/runs/[runId]/approval/route.ts`
+- `app/api/admin/agents/chief-of-staff/actions/route.ts`
+- `lib/agent-slack-actions.ts`
+- `docs/agent-ops-slack-mobile-unblock.md`
+- `docs/agentic-patterns.md`
+- `app/admin/social-content/[id]/page.tsx`
+
+## Public-Safe Claim Boundaries
+
+- Discuss approval types and decision flow.
+- Do not publish approval payloads that include private work, client data, or internal decision notes.
+- Be clear that Slack is an unblock surface, not a direct production mutation lane.
+
+## LinkedIn Output Target
+
+- Format: reflective builder post.
+- Hook direction: "Human-in-the-loop is not where automation stops. It is where authority becomes clear."
+- Core point: agents can prepare, route, recommend, and package work; humans approve side effects.
+- Close: ask where readers draw the line between recommendation and execution.
+
+## Phase 2 Video Expansion
+
+- YouTube angle: "Human Review Is The Trust Layer For Agentic AI."
+- Target runtime: 5 to 7 minutes.
+- Opening scene: pending approval packet, then a run event after decision.
+- Script framework fit: common objection, reframe, control model, demo, principle.
+- HeyGen suitability: strong if paired with approval UI B-roll.
+- ElevenLabs suitability: optional short voiceover for approval explainer clips.
+- Storyboard/B-roll ideas: run detail approvals, Agent Coordination, Slack card examples, social content approval queue.
+- Evidence needed before recording: sanitized approval example or test/local approval drill.
+
+## Acceptance Criteria
+
+- Research memo lists approval-gated actions and where decisions are recorded.
+- Output explains why human review increases operating speed over time by reducing risk.
+- Phase 2 notes specify what should be blurred or avoided in approval screens.
+- Messaging avoids treating humans as blockers.
+
+## UI Seeding Packet
+
+Title: `Research PRD: Human-in-the-loop approvals`
+
+Owner: Research Source Register
+
+Runtime: codex
+
+Narrative:
+Research Portfolio's human-in-the-loop approval model. Inspect agent policy, run approval route, Chief of Staff action route, Slack actions, Slack mobile unblock doc, agentic patterns scorecard, and social content review surface. Produce public-safe notes for a LinkedIn post and Phase 2 video explaining approval checkpoints, side-effect gates, Slack boundaries, and private-to-public content controls. Acceptance: list gated actions, decision surfaces, trace events, and safe demo options.

--- a/docs/agentic-content-research-prds/09-mission-control-slack-traceability.md
+++ b/docs/agentic-content-research-prds/09-mission-control-slack-traceability.md
@@ -1,0 +1,67 @@
+# PRD 09: Mission Control And Slack Traceability
+
+## Objective
+
+Research the operator interface for agentic work: Mission Control as the main cockpit, Agent Coordination as the controller queue, Agent Kanban as the work board, run detail as trace view, and Slack as the mobile unblock lane.
+
+This chapter should show that agent systems need a visible operating surface.
+
+## Research Questions
+
+- What belongs in Mission Control versus drilldown pages?
+- How does Agent Coordination turn vague work into controller packets?
+- How does Slack support mobile decisions without bypassing Portfolio?
+- Which trace links let an operator move from summary to evidence?
+
+## Portfolio Evidence To Inspect
+
+- `app/admin/agents/page.tsx`
+- `app/admin/agents/coordination/page.tsx`
+- `app/admin/agents/swarm-board/page.tsx`
+- `app/admin/agents/runs/[runId]/page.tsx`
+- `lib/agent-mission-control.ts`
+- `lib/agent-slack-blocks.ts`
+- `lib/agent-slack-actions.ts`
+- `docs/agent-ops-slack-mobile-unblock.md`
+
+## Public-Safe Claim Boundaries
+
+- Use UI structure and workflow descriptions, not private queue content.
+- Keep Slack examples generic or sanitized.
+- Avoid promising mobile actions can perform high-risk production mutations.
+
+## LinkedIn Output Target
+
+- Format: carousel or standard post.
+- Hook direction: "If agents are doing work, operators need a cockpit."
+- Core point: Mission Control is the proof surface. Slack is the mobile unblock lane. The trace remains the source of truth.
+- Close: ask what interface readers would need before trusting an agent team.
+
+## Phase 2 Video Expansion
+
+- YouTube angle: "Mission Control For Agentic Work."
+- Target runtime: 6 to 8 minutes.
+- Opening scene: Mission Control first viewport, then click into Coordination, Kanban, and run detail.
+- Script framework fit: operator pain, interface map, walkthrough, governance boundary.
+- HeyGen suitability: excellent for narrated product walkthrough.
+- ElevenLabs suitability: use for short social cutdowns if the screen recording drives the main video.
+- Storyboard/B-roll ideas: Mission Control, Agent Coordination create packet form, Kanban lanes, run trace, Slack command/card mock.
+- Evidence needed before recording: authenticated local browser session and sanitized queue state.
+
+## Acceptance Criteria
+
+- Research memo maps each operator surface to its job.
+- Output explains why Slack is limited by design.
+- LinkedIn angle uses cockpit/control-plane language without hype.
+- Phase 2 notes include a click path for video recording.
+
+## UI Seeding Packet
+
+Title: `Research PRD: Mission Control and Slack traceability`
+
+Owner: Research Source Register
+
+Runtime: codex
+
+Narrative:
+Research Portfolio's operator surfaces for agentic work: Mission Control, Agent Coordination, Agent Kanban, run detail, and Slack mobile unblock. Inspect admin pages, Mission Control read model, Slack blocks/actions, and Slack mobile unblock doc. Produce public-safe notes for a LinkedIn post or carousel plus Phase 2 product walkthrough video. Acceptance: map each surface to its operating job, explain Slack limits, name trace paths, and avoid private queue content.

--- a/docs/agentic-content-research-prds/10-cost-spend-payment-authority.md
+++ b/docs/agentic-content-research-prds/10-cost-spend-payment-authority.md
@@ -1,0 +1,66 @@
+# PRD 10: Cost, Spend, And Payment Authority
+
+## Objective
+
+Research how Portfolio handles cost visibility and payment/spend authority: LLM budget checks, cost events, payment approval action types, checkout/subscription/refund/vendor spend gates, and paid external job gates.
+
+This chapter should explain why agentic systems need financial boundaries before they touch money or paid infrastructure.
+
+## Research Questions
+
+- How does Portfolio track or estimate AI/model spend?
+- Which payment and spend actions are approval-gated?
+- How does the system separate recommending spend from executing spend?
+- What should clients expect before trusting agents near money movement?
+
+## Portfolio Evidence To Inspect
+
+- `lib/agent-budget-policy.ts`
+- `lib/agent-policy.ts`
+- `lib/agent-governance.ts`
+- `lib/cost-calculator.ts`
+- `app/api/admin/cost-events/ingest/route.ts`
+- `lib/video-ideas-generation.ts`
+- `docs/agentic-operating-system-governance.md`
+
+## Public-Safe Claim Boundaries
+
+- Discuss action categories and governance design.
+- Do not publish real customer payment records, Stripe object IDs, cost event details, or vendor account data.
+- Be explicit that payment execution authority is not expanded in this content phase.
+
+## LinkedIn Output Target
+
+- Format: standard post.
+- Hook direction: "The scariest agent is not the one that writes code. It is the one that can spend money without a receipt."
+- Core point: cost and payment authority need approval, scope, purpose, amount, time window, and trace evidence.
+- Close: ask what financial boundary readers would require before using paid autonomous workflows.
+
+## Phase 2 Video Expansion
+
+- YouTube angle: "How To Keep Agents Away From Blank-Check Spending."
+- Target runtime: 5 to 7 minutes.
+- Opening scene: budget check or payment authority actions list.
+- Script framework fit: risk story, policy model, live proof, client trust frame.
+- HeyGen suitability: strong with governance and cost UI B-roll.
+- ElevenLabs suitability: optional short clip narration.
+- Storyboard/B-roll ideas: budget policy, cost summary, payment approval action types, governance pending approvals.
+- Evidence needed before recording: sanitized cost/budget example without real payment or customer data.
+
+## Acceptance Criteria
+
+- Research memo explains the difference between cost tracking, budget checking, and payment authority.
+- Output names all payment/spend approval action categories.
+- Messaging makes financial controls feel practical and client-centered.
+- Phase 2 notes identify safe visuals and excluded sensitive data.
+
+## UI Seeding Packet
+
+Title: `Research PRD: Cost, spend, and payment authority`
+
+Owner: Research Source Register
+
+Runtime: codex
+
+Narrative:
+Research Portfolio's cost, spend, and payment authority model. Inspect budget policy, agent policy, governance snapshot builder, cost calculator, cost ingest route, video ideas budget checks, and governance docs. Produce public-safe notes for a LinkedIn post and Phase 2 video explaining model spend visibility, budget gates, payment authority actions, and why agents should recommend spend separately from executing spend. Acceptance: list payment/spend gates, explain trace-bound authority, and avoid customer/payment data.

--- a/docs/agentic-content-research-prds/11-client-safe-audit-export.md
+++ b/docs/agentic-content-research-prds/11-client-safe-audit-export.md
@@ -1,0 +1,67 @@
+# PRD 11: Client-Safe Audit Export
+
+## Objective
+
+Research the client-safe governance export layer: capability inventory, scoped delegation evidence, authority approvals, export formats, export ledger metadata, and privacy exclusions.
+
+This chapter should show how an agentic system can prove governance without dumping raw logs on a client.
+
+## Research Questions
+
+- What information belongs in a client-safe governance export?
+- How do run, client project, and date-window scopes work?
+- What should be excluded from exports by default?
+- How does the ledger prove that an export happened without storing raw report payloads?
+
+## Portfolio Evidence To Inspect
+
+- `lib/agent-governance-export.ts`
+- `lib/agent-governance-export-ledger.ts`
+- `lib/agent-governance-scope.ts`
+- `app/api/admin/agents/governance/export/route.ts`
+- `app/api/admin/agents/governance/export/route.test.ts`
+- `docs/agentic-os-client-advisory-explainer.md`
+- `docs/agentic-operating-system-governance.md`
+
+## Public-Safe Claim Boundaries
+
+- Explain export shape and privacy exclusions.
+- Do not include raw export contents from private runs.
+- Avoid claiming exports are a compliance certification.
+- Treat exports as review evidence and advisory proof.
+
+## LinkedIn Output Target
+
+- Format: standard post or carousel.
+- Hook direction: "A client should not have to take your word that the agent stayed inside the guardrails."
+- Core point: client-safe proof needs role boundaries, scoped trace references, authority decisions, and privacy filters.
+- Close: ask what proof readers would want before letting an AI system into client operations.
+
+## Phase 2 Video Expansion
+
+- YouTube angle: "Client-Safe Audit Trails For AI Agents."
+- Target runtime: 5 to 7 minutes.
+- Opening scene: governance export button, then explain what leaves and what stays private.
+- Script framework fit: trust gap, export model, privacy boundary, client value.
+- HeyGen suitability: strong with sanitized UI and markdown export B-roll.
+- ElevenLabs suitability: good for a short voiceover explaining "proof without raw logs."
+- Storyboard/B-roll ideas: governance export route, scoped query examples, ledger summary, advisory explainer.
+- Evidence needed before recording: one safe local/dev export or mocked export with no private payload.
+
+## Acceptance Criteria
+
+- Research memo explains export contents and exclusions.
+- Output names scope filters and why capability inventory remains included.
+- Messaging connects audit proof to client confidence.
+- Phase 2 notes include safe export demo requirements.
+
+## UI Seeding Packet
+
+Title: `Research PRD: Client-safe audit export`
+
+Owner: Research Source Register
+
+Runtime: codex
+
+Narrative:
+Research Portfolio's client-safe governance export layer. Inspect governance export builder, export ledger, scope parser, export API route/tests, advisory explainer, and governance docs. Produce public-safe notes for a LinkedIn post or carousel plus Phase 2 video explaining scoped evidence, capability inventory, authority approvals, ledger metadata, and privacy exclusions. Acceptance: name export contents/exclusions, explain run/client/date scopes, and avoid raw private payloads.

--- a/docs/agentic-content-research-prds/12-messaging-synthesis.md
+++ b/docs/agentic-content-research-prds/12-messaging-synthesis.md
@@ -1,0 +1,71 @@
+# PRD 12: Messaging Synthesis
+
+## Objective
+
+Synthesize the research outputs into a content plan for LinkedIn posts, carousels, and Phase 2 YouTube scripts. This packet should translate implementation proof into Vambah's voice without flattening it into generic AI commentary.
+
+This is the bridge from research to public narrative.
+
+## Research Questions
+
+- What is the strongest overall thesis from the series?
+- Which chapters should become standalone LinkedIn posts versus carousel concepts?
+- Which claims are ready for public use, and which need more evidence?
+- Which episodes are strong enough for YouTube video production in Phase 2?
+
+## Portfolio Evidence To Inspect
+
+- All PRDs in `docs/agentic-content-research-prds/`
+- `docs/linkedin-voice.md`
+- `/Users/vambahsillah/Documents/Codex/2026-04-30/i-have-quite-a-bit-of/personality-corpus/voice_and_style_guide.md`
+- `/Users/vambahsillah/Documents/Codex/2026-04-30/i-have-quite-a-bit-of/personality-corpus/personality_profile.md`
+- `/Users/vambahsillah/.hermes/hermes-agent/skills/creative/humanizer/SKILL.md`
+- `app/api/admin/video-generation/generate-ideas/route.ts`
+- `docs/heygen-template-brand-setup.md`
+
+## Public-Safe Claim Boundaries
+
+- Use private-derived voice guidance as calibration only.
+- Do not quote private corpus material, private chats, private traces, or client records.
+- Keep any public claims tied to repo evidence or approved public-safe summaries.
+- Do not publish or schedule content in this phase.
+
+## LinkedIn Output Target
+
+- Format: content map, not final posts.
+- Deliverable should recommend:
+  - 8 to 12 LinkedIn post topics
+  - 3 to 5 carousel candidates
+  - 3 YouTube episode candidates
+  - suggested sequencing
+  - evidence still needed before drafting
+- Opening thesis direction: "The agentic AI wave will reward builders who can turn autonomy into governed work."
+
+## Phase 2 Video Expansion
+
+- YouTube angle: choose the top 3 episodes from the research set.
+- Target runtime: 6 to 10 minutes each.
+- Opening scene: one real operating surface per episode.
+- Script framework fit: lived scene or builder tension, system diagnosis, proof walkthrough, practical principle.
+- HeyGen suitability: select based on whether screen walkthrough or talking-head narration carries the idea.
+- ElevenLabs suitability: use for short promotional clips or alternate narration drafts.
+- Storyboard/B-roll ideas: Mission Control, Coordination, Open Brain, governance export, Agent Kanban, video generation queue.
+- Evidence needed before recording: safe screen recordings and final source-backed claims.
+
+## Acceptance Criteria
+
+- Synthesis produces a prioritized content roadmap, not polished final copy.
+- Recommendations preserve Vambah's grounded, practical, morally clear voice.
+- Every recommended post or video maps back to one or more PRDs.
+- Phase 2 candidates include script angle, runtime, B-roll, and production readiness.
+
+## UI Seeding Packet
+
+Title: `Research PRD: Agentic messaging synthesis`
+
+Owner: Research Source Register
+
+Runtime: codex
+
+Narrative:
+Synthesize the completed agentic content research PRDs into a LinkedIn and Phase 2 YouTube roadmap. Inspect all PRDs, LinkedIn voice guidance, public-safe personality guidance, humanizer instructions, video generation route, and HeyGen setup doc. Produce a prioritized content map with LinkedIn post topics, carousel candidates, YouTube episode candidates, sequencing, and evidence gaps. Keep this draft-only; do not publish, schedule, start HeyGen jobs, or generate ElevenLabs audio. Downstream review should involve Nefertiti, the Voice & Content Architect.

--- a/docs/agentic-content-research-prds/README.md
+++ b/docs/agentic-content-research-prds/README.md
@@ -1,0 +1,73 @@
+# Agentic Content Research PRD Pack
+
+This pack turns the Portfolio Agent Ops build into a research backlog for a LinkedIn-first thought leadership series. Each PRD is also prepared for a Phase 2 YouTube/video expansion using the existing Portfolio video generation, HeyGen, ElevenLabs, storyboard, and B-roll surfaces.
+
+## Operating Rule
+
+Research first. Draft later. Publishing stays gated.
+
+The first pass should produce research notes, source-backed claims, narrative angles, and content recommendations. It should not publish LinkedIn posts, start HeyGen jobs, regenerate audio, send outbound messages, or write directly to Supabase. Backlog seeding should happen through `/admin/agents/coordination`.
+
+## Series Backlog
+
+| # | PRD | Working LinkedIn angle | Phase 2 video angle |
+| --- | --- | --- | --- |
+| 1 | [Agentic Operating System Overview](01-agentic-operating-system-overview.md) | The website is becoming proof of a governed agentic operating system. | Walk through the whole lifecycle from harness to audit. |
+| 2 | [Harness And Trace Foundation](02-harness-trace-foundation.md) | Fast AI demos are easy; traceable systems are the hard part. | Show the run, step, event, artifact, handoff, approval, and cost envelope. |
+| 3 | [Shaka Controller Brain](03-shaka-controller-brain.md) | The most important agent may be the one that says where work should go. | Explain Shaka as controller, router, and executive interface. |
+| 4 | [Open Brain Memory Architecture](04-open-brain-memory-architecture.md) | Memory needs ownership, privacy tiers, and approval before it becomes truth. | Explain local-first memory and compiled wiki overlays. |
+| 5 | [Self-Evaluation And Quality Loops](05-self-evaluation-quality-loops.md) | Agents need review loops before they earn more authority. | Show rubrics, budget checks, evals, and coaching signals. |
+| 6 | [Agent Swarms And Delegation](06-agent-swarms-delegation.md) | Swarms only help when each agent has a role, owner, and handoff rule. | Map the pods and work queue as an operating team. |
+| 7 | [Permission Scopes And Risk Boundaries](07-permission-scopes-risk-boundaries.md) | Agent access should look more like least privilege than blank-check autonomy. | Show capability profiles and runtime policies. |
+| 8 | [Human-In-The-Loop Approvals](08-human-in-the-loop-approvals.md) | Human review is not a brake. It is the trust layer. | Walk through approval checkpoints and side-effect gates. |
+| 9 | [Mission Control And Slack Traceability](09-mission-control-slack-traceability.md) | Operators need one cockpit and one mobile unblock lane. | Demo Mission Control, Kanban, run detail, and Slack boundaries. |
+| 10 | [Cost, Spend, And Payment Authority](10-cost-spend-payment-authority.md) | Agents should not move money without trace-bound authority. | Explain cost intelligence and payment/spend gates. |
+| 11 | [Client-Safe Audit Export](11-client-safe-audit-export.md) | Clients need proof without raw private logs. | Explain scoped governance exports and evidence boundaries. |
+| 12 | [Messaging Synthesis](12-messaging-synthesis.md) | The story is practical: build agents that people can trust. | Convert the research into LinkedIn posts, carousels, and video scripts. |
+
+## Shared Evidence Sources
+
+- `docs/agentic-operating-system-governance.md`
+- `docs/agent-operations-roadmap.md`
+- `docs/agentic-patterns.md`
+- `docs/agentic-os-client-advisory-explainer.md`
+- `docs/agent-ops-slack-mobile-unblock.md`
+- `docs/linkedin-voice.md`
+- `docs/heygen-template-brand-setup.md`
+- `lib/agent-organization.ts`
+- `lib/agent-governance.ts`
+- `lib/agent-delegation-policy.ts`
+- `lib/agent-policy.ts`
+- `lib/agent-evaluations.ts`
+- `lib/open-brain.ts`
+- `lib/agent-mission-control.ts`
+- `lib/agent-swarm-board.ts`
+- `lib/video-ideas-generation.ts`
+- `app/api/admin/video-generation/generate-ideas/route.ts`
+- `app/api/admin/video-generation/ideas-queue/[id]/generate/route.ts`
+- `app/api/admin/social-content/[id]/regenerate-audio/route.ts`
+
+## PRD Format
+
+Each PRD uses the same structure:
+
+- Objective
+- Research questions
+- Portfolio evidence to inspect
+- Public-safe claim boundaries
+- LinkedIn output target
+- Phase 2 video expansion
+- Acceptance criteria
+- UI seeding packet
+
+## UI Seeding Defaults
+
+Use `/admin/agents/coordination`.
+
+- Template: Agent follow-up
+- Owner: Research Source Register
+- Runtime: codex
+- Title: `Research PRD: <chapter title>`
+- Narrative: copy the UI seeding packet from the PRD
+
+If a packet is primarily about content shaping, keep the UI owner as Research Source Register and name Nefertiti, the Voice & Content Architect, as the downstream reviewer in the narrative. The current owner dropdown does not expose every agent.


### PR DESCRIPTION
## Summary
- Add a LinkedIn-first research PRD pack for the agentic AI content series.
- Cover the full operating-system lifecycle: harness, Shaka controller brain, Open Brain memory, evaluation loops, swarms, scoped permissions, HITL approvals, Mission Control/Slack traceability, spend authority, client-safe exports, and messaging synthesis.
- Include Phase 2 video expansion guidance for YouTube, HeyGen avatar use, ElevenLabs voice use, storyboard needs, and proof requirements.
- Seeded the backlog through the Admin → Agent Operations → Coordination UI, not direct database seeding.

## Validation
- `git diff --check`
- ASCII/style scan for PRD files
- `npm run lint`
- Authenticated local UI read-back confirmed 12 seeded work items with owner `research-source-register` and runtime `codex`.
- Pre-push database health check passed.
- No live Vercel deployment workflow was run for this docs-only branch.

## Integration Notes
- No migrations or env changes required.
- UI-seeded backlog item IDs are recorded in the handoff summary, not committed to code.
- Vercel – portfolio: not checked for this docs-only branch.
- Vercel – portfolio-staging: not checked for this docs-only branch.