### PR TITLE
Refresh Model Ops snapshot

### DIFF
--- a/data/model-ops/reports/latest-dashboard-data.json
+++ b/data/model-ops/reports/latest-dashboard-data.json
@@ -1,6 +1,6 @@
 {
   "projectName": "Local LLM Model Ops & Hermes Automation",
-  "generatedAt": "2026-05-25T12:03:38.588Z",
+  "generatedAt": "2026-05-25T12:19:54.415Z",
   "recommendations": {
     "replyIntentDefault": "Keep qwen3-4b-instruct-2507 for reply-intent classification. It has the best current accuracy/latency balance.",
     "ragDefault": "Use routed local RAG as the leading local/shadow candidate, with Pinecone/OpenAI fallback until larger answer-level evals pass.",

--- a/data/model-ops/reports/latest-dashboard-data.json
+++ b/data/model-ops/reports/latest-dashboard-data.json
@@ -1,6 +1,6 @@
 {
   "projectName": "Local LLM Model Ops & Hermes Automation",
-  "generatedAt": "2026-05-18T13:31:03.074Z",
+  "generatedAt": "2026-05-25T12:03:38.588Z",
   "recommendations": {
     "replyIntentDefault": "Keep qwen3-4b-instruct-2507 for reply-intent classification. It has the best current accuracy/latency balance.",
     "ragDefault": "Use routed local RAG as the leading local/shadow candidate, with Pinecone/OpenAI fallback until larger answer-level evals pass.",


### PR DESCRIPTION
## Summary
- Refreshes the sanitized Model Ops dashboard snapshot after the 2026-05-25 Hermes benchmark monitor run.
- Snapshot content only changed the generatedAt timestamp; recommendation and metric contents remain aligned with the current local artifacts.
- Local report records the interrupted Gemma 4 E4B install attempt; no benchmarkable new model was added to the snapshot.

## Validation
- node scripts/build_model_ops_dashboard.js
- npm --prefix /Users/vambahsillah/Projects/Portfolio run model-ops:snapshot
- npm --prefix /Users/vambahsillah/Projects/Portfolio run model-ops:snapshot:check
- npm --prefix /Users/vambahsillah/Projects/Portfolio run model-ops:research:plan -- --repo-snapshot
- pre-push hook: npm run db:health-check

## Notes
- No production routing, model defaults, n8n production logic, hosted flags, secrets, Supabase/Pinecone resources, merge, or deploy changes were made.
- Repository labels named codex or codex-automation were not available when checked.