### PR TITLE
docs: add agentic content research briefs

### DIFF
--- a/docs/agentic-content-research-briefs/README.md
+++ b/docs/agentic-content-research-briefs/README.md
@@ -1,0 +1,23 @@
+# Agentic Content Research Briefs
+
+This folder contains the research execution layer for the agentic content series.
+
+The PRDs in `docs/agentic-content-research-prds/` define what to research. These briefs turn that backlog into source-backed content material that can become LinkedIn posts, carousels, talks, and Phase 2 YouTube scripts.
+
+## Operating Rule
+
+Research is allowed to shape public claims. It should not publish, send, generate avatar video, regenerate audio, or mutate production workflows.
+
+Public-facing content should separate three things:
+
+- What the broader market is doing.
+- What Portfolio can prove through local code, docs, traces, and admin surfaces.
+- What remains an opinion, recommendation, or next hardening step.
+
+## Current Output
+
+- `phase-2-research-dossier.md`: consolidated research dossier for all 12 PRDs.
+
+## Next Review Gate
+
+Nefertiti, the Voice & Content Architect, should turn the strongest briefs into first-pass LinkedIn drafts only after the research claims are accepted. Shaka should keep publication and video generation behind approval.

--- a/docs/agentic-content-research-briefs/phase-2-research-dossier.md
+++ b/docs/agentic-content-research-briefs/phase-2-research-dossier.md
@@ -1,0 +1,325 @@
+# Agentic AI Content Research Dossier
+
+Date: 2026-05-25
+Branch: `codex/agentic-content-research-phase`
+Source PRDs: `docs/agentic-content-research-prds/`
+
+## Executive Read
+
+The strongest story is simple: the agentic AI wave is moving from demos into operating systems.
+
+The visible market pattern is clear. Tool access, MCP-style interoperability, trace capture, evals, guardrails, orchestration, and human approval are becoming normal building blocks. The practical gap is also clear. Most organizations still talk about agents as intelligence. Portfolio shows the less glamorous layer: the harness, memory, scope, handoffs, approvals, cost boundaries, UI, and audit trail that make an agent worth trusting.
+
+This series should not claim that Portfolio is a finished autonomous enterprise platform. The public-safe claim is stronger and more honest:
+
+We are building the operating discipline around agents before we give them more authority.
+
+## Source Register
+
+Public sources used:
+
+- OpenAI Agents SDK tracing docs: `https://openai.github.io/openai-agents-python/tracing/`
+- OpenAI Agents SDK guardrails docs: `https://openai.github.io/openai-agents-js/guides/guardrails/`
+- OpenAI agent evals guide: `https://platform.openai.com/docs/guides/agent-evals`
+- Microsoft Agent Framework orchestration docs: `https://learn.microsoft.com/en-us/agent-framework/workflows/orchestrations/`
+- Model Context Protocol intro: `https://modelcontextprotocol.io/docs/getting-started/intro`
+- MCP authorization specification: `https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization`
+- NIST AI Risk Management Framework: `https://www.nist.gov/itl/ai-risk-management-framework`
+- LangGraph human-in-the-loop interrupt docs: `https://langchain-ai.github.io/langgraph/how-tos/human_in_the_loop/wait-user-input/`
+
+Internal evidence used:
+
+- `docs/agentic-operating-system-governance.md`
+- `docs/agent-operations-roadmap.md`
+- `docs/agentic-patterns.md`
+- `docs/agentic-os-client-advisory-explainer.md`
+- `docs/agent-ops-slack-mobile-unblock.md`
+- `docs/linkedin-voice.md`
+- `docs/heygen-template-brand-setup.md`
+- `lib/agent-organization.ts`
+- `lib/agent-governance.ts`
+- `lib/agent-delegation-policy.ts`
+- `lib/agent-policy.ts`
+- `lib/agent-evaluations.ts`
+- `lib/open-brain.ts`
+- `lib/agent-mission-control.ts`
+- `lib/agent-swarm-board.ts`
+- `lib/video-ideas-generation.ts`
+
+## Market Claims We Can Safely Make
+
+- Tracing is now a core agent building block. OpenAI's Agents SDK records model generations, tool calls, handoffs, guardrails, and custom events during a run.
+- Guardrails are becoming more precise than generic policy text. Modern agent SDKs distinguish input, output, and tool guardrails, and tool guardrails can run before and after function calls.
+- Multi-agent orchestration is becoming productized. Microsoft documents sequential, concurrent, handoff, group chat, and manager-led orchestration patterns.
+- MCP is becoming a common integration layer for connecting AI applications to data sources, tools, and workflows.
+- MCP authorization now centers on OAuth-style resource scoping and bearer-token handling for HTTP transports.
+- Agent evaluation is moving from final-answer grading toward trace grading: tool choice, handoff behavior, safety policy compliance, and routing changes.
+- NIST frames AI risk management around design, development, use, evaluation, and trustworthiness. That gives this series a credible governance anchor without pretending there is one universal agentic standard.
+- Human-in-the-loop agent design is moving toward resumable execution: pause, persist state, surface a decision, then continue from the same thread or checkpoint.
+
+## Public-Safe Portfolio Claims
+
+- Portfolio has a real Agent Ops control plane, with prompts sitting inside a broader operating system.
+- Portfolio uses named agents, runtime policies, trace tables, work items, handoffs, approvals, budget checks, Slack command surfaces, Mission Control, and governance exports.
+- Shaka is the controller identity for routing, synthesis, and operator-facing decisions, while specialist agents stay scoped.
+- Open Brain is positioned as the local-first memory core; Portfolio projects approved memory and admin views rather than becoming the canonical private memory store.
+- Side-effecting work is framed as approval-gated. Publishing, outbound email, production writes, private-to-public movement, config changes, and payment/spend authority require review boundaries.
+- Client-safe export work exists so proof can be shared without raw logs, secrets, private reasoning, or sensitive records.
+
+## Claims To Avoid
+
+- Avoid saying agents are fully autonomous in production.
+- Avoid saying the system replaces human judgment.
+- Avoid implying payment movement is enabled for agents today.
+- Avoid claiming every workflow already emits perfect trace coverage.
+- Avoid saying MCP alone solves security, governance, or interoperability.
+- Avoid presenting private memory, raw chats, or private reasoning as public proof.
+
+## Brief 1: Agentic Operating System Overview
+
+Core thesis: The next AI advantage belongs to teams that can turn agents into governed work, not teams that can make the flashiest demo.
+
+Market context: Agent frameworks now expose traces, guardrails, handoffs, evals, and orchestration as first-class concepts. MCP creates a common language for connecting tools and data. The missing business layer is operational trust.
+
+Portfolio proof: `docs/agentic-operating-system-governance.md` already defines the system as named agents, scope, delegation, approval checkpoints, traces, costs, payment authority boundaries, and audit summaries. `docs/agent-operations-roadmap.md` makes Portfolio admin the control plane and Slack the mobile command lane.
+
+LinkedIn angle: "Anyone can wire a model to a tool. The harder question is what happens after the model says yes."
+
+Best supporting points:
+
+- Agentic systems need a harness before they need more autonomy.
+- The operating system includes roles, memory, permissions, evaluation, handoffs, approvals, and audit.
+- Trust comes from knowing who acted, why they acted, what they touched, and where the evidence lives.
+
+Phase 2 video hook: Start in Mission Control, then zoom out to the lifecycle map: harness, brain, memory, evals, swarm, permission, approval, UI, audit.
+
+## Brief 2: Harness And Trace Foundation
+
+Core thesis: Fast AI demos are easy because they skip the harness. Production-adjacent agents need traceable runs.
+
+Market context: OpenAI's tracing docs describe traces as end-to-end workflow records made of spans, with default spans for agents, model generations, function tools, guardrails, and handoffs. The docs also warn that spans can capture sensitive data and need explicit handling.
+
+Portfolio proof: `docs/agent-operations-roadmap.md` defines shared trace tables: runs, steps, events, artifacts, handoffs, approvals, and cost events. The product definition says Vambah should see agent runs, handoffs, artifacts, approvals, and costs in one place.
+
+LinkedIn angle: "The first thing I built around agents was not the agent. It was the receipt."
+
+Best supporting points:
+
+- A trace is the difference between "the agent did something" and "we can review what happened."
+- Trace design should include sensitive-data boundaries from the start.
+- The harness lets the system learn without hiding side effects.
+
+Phase 2 video hook: Screen-record a run detail view and label the evidence envelope: run, step, event, artifact, approval, cost.
+
+## Brief 3: Shaka Controller Brain
+
+Core thesis: The most important agent may be the one that decides where work should go.
+
+Market context: Microsoft Agent Framework documents orchestration patterns that include handoff and manager-led coordination. That supports the idea that multi-agent systems need a controller layer above the specialized workers.
+
+Portfolio proof: `lib/agent-organization.ts` maps Shaka as the Chief of Staff identity. `lib/agent-delegation-policy.ts` and the governance docs describe deterministic routing, task taxonomy, risk class, fallback, confidence, and trace events for delegation decisions.
+
+LinkedIn angle: "A swarm without a chief of staff becomes noise."
+
+Best supporting points:
+
+- Shaka is the operator interface, not a blank-check executor.
+- Routing should be explainable before and after dispatch.
+- The controller should know when to assign, when to ask for evidence, and when to stop.
+
+Phase 2 video hook: Show a sample operator request and narrate how Shaka routes it through task type, risk class, evidence, owner, and approval gate.
+
+## Brief 4: Open Brain Memory Architecture
+
+Core thesis: Memory is where agent systems become dangerous or useful. The difference is ownership and approval.
+
+Market context: MCP and agent frameworks make it easier to connect tools and data. That increases the importance of deciding what becomes durable memory, what remains a trace, and what can be projected into public or client-facing surfaces.
+
+Portfolio proof: `lib/open-brain.ts` and the project instructions define Open Brain as the user-owned memory core. New memory producers should emit source records or approval-gated memory proposals before becoming durable memory. The compiled wiki layer is a projection, not the canonical store.
+
+LinkedIn angle: "Agent memory should not be a junk drawer. It should be a governed library."
+
+Best supporting points:
+
+- Raw private material, unapproved inference, and public knowledge need separate lanes.
+- Memory promotion should require provenance and approval.
+- The most useful memory system is the one that can explain why it remembers something.
+
+Phase 2 video hook: Use a three-layer visual: raw source, approved memory, compiled wiki overlay.
+
+## Brief 5: Self-Evaluation And Quality Loops
+
+Core thesis: Agents earn more authority through review loops, not through confidence.
+
+Market context: OpenAI's agent eval guidance emphasizes trace grading for workflow-level issues: tool choice, handoff timing, instruction violations, safety-policy compliance, and routing changes. This is closer to operations QA than final-answer scoring.
+
+Portfolio proof: `lib/agent-evaluations.ts`, `docs/agentic-patterns.md`, and Agent Ops approvals create a path for evaluation, coaching signals, budget checks, and quality review before expanding authority.
+
+LinkedIn angle: "The agent does not get promoted because it sounded confident. It gets promoted because the evidence held up."
+
+Best supporting points:
+
+- Evaluate the workflow and the final answer.
+- Tool calls, routing decisions, and handoffs need their own scoring.
+- Quality loops should lead to narrower prompts, clearer tools, or stricter gates.
+
+Phase 2 video hook: Explain "agent promotion" as a review board: traces, evals, failures, coaching notes, then authority changes.
+
+## Brief 6: Agent Swarms And Delegation
+
+Core thesis: Swarms are useful only when each agent has a job, a boundary, and a handoff rule.
+
+Market context: Microsoft lists several orchestration patterns: sequential, concurrent, handoff, group chat, and manager-led coordination. This gives the content a language for explaining when a swarm should be a pipeline, a parallel team, or a manager-routed organization.
+
+Portfolio proof: `lib/agent-organization.ts` maps pods and named roles. `docs/agentic-patterns.md` says multi-agent collaboration is partial and org-mapped, with handoffs still needing wider adoption.
+
+LinkedIn angle: "A swarm is not a room full of agents talking. It is an operating model."
+
+Best supporting points:
+
+- Sequential work is good for dependent steps.
+- Parallel work is good when tasks share no mutable state.
+- Handoff work needs a clear owner, output contract, and stop condition.
+
+Phase 2 video hook: Show the organization map as an operating team: Shaka routes, research gathers, content shapes, compliance checks, captain integrates.
+
+## Brief 7: Permission Scopes And Risk Boundaries
+
+Core thesis: Agent permissions should look like least privilege, not trust by enthusiasm.
+
+Market context: MCP authorization requires bearer tokens in authorization headers for HTTP requests and says tokens should be validated for the intended audience. OpenAI guardrails distinguish checks at the input, output, and tool-call level. Together, this supports a practical permission story: identity, audience, tool boundary, and guardrail.
+
+Portfolio proof: `lib/agent-policy.ts` defines runtime permissions and approval-gated authority. `docs/agentic-operating-system-governance.md` identifies the next hardening step as agent-specialty capability profiles with tools, data classes, write classes, outbound authority, spend authority, and approval gates.
+
+LinkedIn angle: "The fastest way to make an agent risky is to give it every key because it passed one demo."
+
+Best supporting points:
+
+- Scope should be tied to the agent role.
+- Tool calls need validation before and after execution.
+- Payment, outbound, production write, and private-to-public actions belong behind gates.
+
+Phase 2 video hook: Use a permission matrix, then show how one task changes when the agent has read-only, draft-only, or execution authority.
+
+## Brief 8: Human-In-The-Loop Approvals
+
+Core thesis: Human review is not a brake. It is the trust layer that lets the system move faster in the right places.
+
+Market context: LangGraph's interrupt pattern pauses execution, persists state, surfaces a decision, and resumes with the same thread. Microsoft also describes approval-required tools that pause a workflow for human review.
+
+Portfolio proof: Agent Ops uses `agent_approvals`, approval decisions, work items, and handoffs. The roadmap says publishing, sending, production writes, config changes, and private-to-public content require approvals.
+
+LinkedIn angle: "The point of human-in-the-loop is not to slow down every action. It is to know which actions deserve a human."
+
+Best supporting points:
+
+- Human review should attach to a specific run and action.
+- Approval should include the decision, evidence, owner, risk, and rollback path.
+- The best HITL systems let safe work continue while sensitive work pauses.
+
+Phase 2 video hook: Show a side-effect gate: draft generated, approval requested, human approves or rejects, trace records outcome.
+
+## Brief 9: Mission Control And Slack Traceability
+
+Core thesis: Agent systems fail operators when the work is invisible. Mission Control and Slack solve different parts of the same traceability problem.
+
+Market context: The public agent tooling market is converging on dashboards, traces, approvals, and orchestration views. The operator still needs a human interface that answers what needs attention now.
+
+Portfolio proof: `docs/agent-operations-roadmap.md` names Portfolio admin as the control plane and Slack as the mobile lane. `docs/agent-ops-slack-mobile-unblock.md` frames Slack as a command surface, while Mission Control remains the main proof surface.
+
+LinkedIn angle: "If I need five tabs to understand what my agents did, I do not have an agent system. I have scattered automation."
+
+Best supporting points:
+
+- Mission Control should show status, queue, traces, approvals, costs, and activity.
+- Slack should unblock simple mobile decisions, not become a second source of truth.
+- Trace links keep mobile commands from becoming vague instructions.
+
+Phase 2 video hook: Split screen: Mission Control for full proof, Slack for a small unblock action tied back to the trace.
+
+## Brief 10: Cost, Spend, And Payment Authority
+
+Core thesis: Agent cost includes token spend and authority over paid actions.
+
+Market context: Agent evals and traces help teams understand behavior, but money movement needs a separate authorization model. NIST's AI RMF gives a broad risk-management frame for design, development, use, and evaluation; Portfolio can translate that into practical spend gates.
+
+Portfolio proof: The governance docs separate recommendations from money movement. Payment authority fields include requesting agent, approving user, amount, currency, counterparty, purpose, payment rail, execution window, retries, revocation status, resulting object IDs, and linked trace ID.
+
+LinkedIn angle: "An agent should never be able to spend money because the prompt sounded reasonable."
+
+Best supporting points:
+
+- Cost dashboards are useful, but payment authority needs explicit approval.
+- Amount, purpose, counterparty, and execution window should be trace-bound.
+- Paid external jobs and API budget increases deserve the same review discipline as payments.
+
+Phase 2 video hook: Walk through a payment authority ledger without showing real customer or secret data.
+
+## Brief 11: Client-Safe Audit Export
+
+Core thesis: Clients need proof, not raw logs.
+
+Market context: Trace systems capture more detail than clients should ever see. OpenAI's tracing docs explicitly flag sensitive data risk in spans. That supports Portfolio's choice to summarize evidence instead of exposing raw prompts, private logs, secrets, or sensitive records.
+
+Portfolio proof: `lib/agent-governance-export.ts` and `docs/agentic-operating-system-governance.md` describe client-safe JSON and Markdown exports. The export ledger records metadata without storing raw report payloads.
+
+LinkedIn angle: "The audit trail has to protect the client from the system and from the proof itself."
+
+Best supporting points:
+
+- Raw traces are for operators.
+- Client exports should show scope, decisions, evidence, and outcomes.
+- Privacy boundaries make governance more credible, not weaker.
+
+Phase 2 video hook: Show the difference between an internal trace and a client-safe report using synthetic or redacted examples.
+
+## Brief 12: Messaging Synthesis
+
+Core thesis: The story is practical: build agents that people can trust.
+
+Series spine:
+
+1. We are moving from AI demos to agent operating systems.
+2. The harness matters before the model gets more authority.
+3. Shaka turns agent work into routed, reviewable decisions.
+4. Memory needs ownership and promotion rules.
+5. Evals are how agents earn trust.
+6. Swarms need operating design.
+7. Permissions need least-privilege discipline.
+8. Human review creates trust at the edge of side effects.
+9. Mission Control and Slack give operators traceability.
+10. Money movement needs a stronger gate than confidence.
+11. Clients deserve proof without exposure.
+12. The future belongs to builders who make AI useful, accountable, and human.
+
+Recommended first five LinkedIn posts:
+
+1. "The first thing I built around agents was the receipt."
+2. "A swarm is not an operating model until somebody owns the handoff."
+3. "Agent memory should be a governed library."
+4. "The agent does not get promoted because it sounded confident."
+5. "Human review is the trust layer."
+
+Phase 2 YouTube structure:
+
+- Episode 1: The Agentic Operating System, from demo to governed work.
+- Episode 2: Building the Harness, trace, evidence, cost, and approvals.
+- Episode 3: The Brain and the Swarm, Shaka, delegation, pods, and handoffs.
+- Episode 4: Memory and Evaluation, Open Brain, source records, eval loops.
+- Episode 5: Trust Boundaries, permissions, HITL, spend authority, audit exports.
+
+## Recommended Next Agent Actions
+
+- Research Source Register should attach short source notes to each seeded work item, using this dossier as the first artifact.
+- Shaka should prioritize the first three LinkedIn angles: harness, Shaka controller brain, and human-in-the-loop approvals.
+- Nefertiti should draft posts only after the claim boundaries are accepted.
+- Phase 2 video production should wait until at least three LinkedIn posts have audience signal or operator approval.
+
+## Acceptance Gate
+
+This dossier is ready for content drafting when:
+
+- Each topic has a public source, a Portfolio proof point, and a clear claim boundary.
+- No topic depends on private chat excerpts or raw sensitive records.
+- Claims avoid overpromising autonomy.
+- Video notes stay extensible without starting HeyGen, ElevenLabs, or render jobs.


### PR DESCRIPTION
## Summary
- Add the Phase 2 research dossier for the agentic content series.
- Convert the 12 seeded PRDs into source-backed claim maps, Portfolio proof points, LinkedIn angles, and video expansion hooks.
- Keep Phase 2 extensible for YouTube, HeyGen, and ElevenLabs without starting any publishing, avatar, audio, or render jobs.

## Validation
- Preflight checked root branch, dirty state, open PRs, worktrees, and touched-file overlap.
- `git diff --check`
- ASCII/style scan for research brief docs
- `npm run lint`
- Pre-push database health check was skipped by hook because this fresh worktree did not have production Supabase env values copied in.
- No live workflow/customer-data smoke was run.

## Integration Notes
- No migrations or env changes required.
- This branch only adds docs under `docs/agentic-content-research-briefs/`.
- Avoids active dirty work in `voice-note-content-swarm` and PR #380 model-ops snapshot data.
- Vercel – portfolio: not checked for this docs-only branch.
- Vercel – portfolio-staging: not checked for this docs-only branch.