### PR TITLE
feat: add agent decision trust frames

### DIFF
--- a/app/admin/agents/governance/page.test.tsx
+++ b/app/admin/agents/governance/page.test.tsx
@@ -102,6 +102,29 @@ const governance = {
       alternatives_considered: [],
     },
   ],
+  recent_decision_trust_frames: [
+    {
+      run_id: 'trust-run',
+      decision_id: 'decision-trust-1',
+      agent_key: 'chief-of-staff',
+      decision_type: 'spend',
+      objective: 'Create approval checkpoint for vendor payment.',
+      selected_candidate: 'make_vendor_payment',
+      candidates_considered: ['make_vendor_payment'],
+      trust_signals: ['Agent Ops source run linked', 'Existing agent approval gate selected'],
+      risk_signals: ['Payment or spend authority requested'],
+      missing_evidence: ['Human approval decision', 'Post-approval execution trace'],
+      scores: {
+        relationshipTrust: 0.57,
+        decisionRisk: 0.62,
+        evidenceCompleteness: 0.6,
+      },
+      recommended_gate: 'human_review',
+      approval_type: 'payment_make_vendor_payment',
+      reversibility: 'hard',
+      occurred_at: '2026-05-13T12:00:00.000Z',
+    },
+  ],
   recent_governance_exports: [
     {
       id: 'export-1',
@@ -151,6 +174,17 @@ describe('AgentGovernancePage', () => {
     expect(within(governancePanel).getByText('Create refund')).toBeInTheDocument()
     expect(within(governancePanel).getByText('No refund is issued until this payment authority checkpoint is approved and linked to a trace.')).toBeInTheDocument()
     expect(within(governancePanel).getByText(/Risk: high · Executes now: no/i)).toBeInTheDocument()
+    const decisionTrust = within(governancePanel).getByLabelText('Decision Trust')
+    expect(within(decisionTrust).getByText('make_vendor_payment')).toBeInTheDocument()
+    expect(within(decisionTrust).getByText(/spend · Create approval checkpoint for vendor payment/i)).toBeInTheDocument()
+    expect(within(decisionTrust).getAllByText('human review').length).toBeGreaterThan(0)
+    expect(within(decisionTrust).getByText('Trust')).toBeInTheDocument()
+    expect(within(decisionTrust).getByText('57%')).toBeInTheDocument()
+    expect(within(decisionTrust).getByText('62%')).toBeInTheDocument()
+    expect(within(decisionTrust).getByText('60%')).toBeInTheDocument()
+    expect(within(decisionTrust).getByText(/Missing evidence: Human approval decision, Post-approval execution trace/i)).toBeInTheDocument()
+    expect(within(decisionTrust).getByText(/Approval: payment_make_vendor_payment · Reversibility: hard/i)).toBeInTheDocument()
+    expect(within(decisionTrust).getByRole('link', { name: /make_vendor_payment/i })).toHaveAttribute('href', '/admin/agents/runs/trust-run')
     expect(within(governancePanel).getByRole('link', { name: /Export client audit/i })).toHaveAttribute('href', '/api/admin/agents/governance/export?format=markdown')
     expect(within(governancePanel).getByRole('link', { name: /Export audit JSON/i })).toHaveAttribute('href', '/api/admin/agents/governance/export?format=json')
     expect(within(governancePanel).getByRole('link', { name: /Export latest trace/i })).toHaveAttribute('href', '/api/admin/agents/governance/export?format=markdown&runId=delegation-run')
@@ -178,5 +212,24 @@ describe('AgentGovernancePage', () => {
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/api/admin/agents/mission-control', {
       headers: { Authorization: 'Bearer admin-token' },
     }))
+  })
+
+  it('renders a decision trust empty state when no frames exist', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        governance: {
+          ...governance,
+          recent_decision_trust_frames: [],
+        },
+      }),
+    })
+
+    render(<AgentGovernancePage />)
+
+    const governancePanel = await screen.findByLabelText('Agent Governance')
+    const decisionTrust = within(governancePanel).getByLabelText('Decision Trust')
+    expect(within(decisionTrust).getByText('shadow mode')).toBeInTheDocument()
+    expect(within(decisionTrust).getByText(/No decision trust frames recorded yet/i)).toBeInTheDocument()
   })
 })

--- a/app/api/admin/agents/chief-of-staff/actions/route.test.ts
+++ b/app/api/admin/agents/chief-of-staff/actions/route.test.ts
@@ -103,6 +103,11 @@ describe('POST /api/admin/agents/chief-of-staff/actions', () => {
           requested_by_user_id: 'admin-user',
           executes_action: false,
         }),
+        decision_trust_frame: expect.objectContaining({
+          decision_type: 'action',
+          recommended_gate: 'human_review',
+          selected_candidate: 'send_email',
+        }),
       }),
     }))
     expect(mocks.insert).toHaveBeenCalledWith(expect.objectContaining({
@@ -115,6 +120,19 @@ describe('POST /api/admin/agents/chief-of-staff/actions', () => {
           action: 'send_email',
           executes_action: false,
         }),
+        decision_trust_frame: expect.objectContaining({
+          recommended_gate: 'human_review',
+          approval_type: 'send_email',
+        }),
+      }),
+    }))
+    expect(mocks.recordAgentEvent).toHaveBeenCalledWith(expect.objectContaining({
+      runId: 'approval-run-1',
+      eventType: 'agent_decision_trust_recorded',
+      message: 'send_email: human_review',
+      metadata: expect.objectContaining({
+        decision_type: 'action',
+        selected_candidate: 'send_email',
       }),
     }))
     expect(mocks.attachAgentArtifact).toHaveBeenCalledWith(expect.objectContaining({
@@ -127,6 +145,10 @@ describe('POST /api/admin/agents/chief-of-staff/actions', () => {
         action_payload: expect.objectContaining({
           action: 'send_email',
           executes_action: false,
+        }),
+        decision_trust_frame: expect.objectContaining({
+          selected_candidate: 'send_email',
+          recommended_gate: 'human_review',
         }),
       }),
     }))
@@ -156,6 +178,11 @@ describe('POST /api/admin/agents/chief-of-staff/actions', () => {
           approval_type: 'payment_create_refund',
           executes_action: false,
           side_effect_boundary: expect.stringContaining('No refund is issued'),
+        }),
+        decision_trust_frame: expect.objectContaining({
+          decision_type: 'spend',
+          recommended_gate: 'human_review',
+          selected_candidate: 'create_refund',
         }),
       }),
     }))

--- a/app/api/admin/agents/chief-of-staff/actions/route.ts
+++ b/app/api/admin/agents/chief-of-staff/actions/route.ts
@@ -7,6 +7,10 @@ import {
   getApprovalGate,
   type AgentAction,
 } from '@/lib/agent-policy'
+import {
+  AGENT_DECISION_TRUST_EVENT,
+  buildPaymentAuthorityDecisionTrustFrame,
+} from '@/lib/agent-decision-trust'
 import { supabaseAdmin } from '@/lib/supabase'
 import type { ChiefOfStaffActionProposal } from '@/lib/chief-of-staff-chat'
 
@@ -153,6 +157,12 @@ export async function POST(request: NextRequest) {
       sourceRunId,
       userId: auth.user.id,
     })
+    const decisionTrustFrame = buildPaymentAuthorityDecisionTrustFrame({
+      action: proposal.action,
+      label: proposal.label,
+      sourceRunId,
+      approvalType,
+    })
 
     const run = await startAgentRun({
       agentKey: 'chief-of-staff',
@@ -172,6 +182,7 @@ export async function POST(request: NextRequest) {
         source_run_id: sourceRunId,
         proposal,
         action_payload: actionPayload,
+        decision_trust_frame: decisionTrustFrame,
         executes_action: false,
       },
       idempotencyKey: `chief-of-staff-action:${sourceRunId}:${proposal.action}:${auth.user.id}:${Date.now()}`,
@@ -188,6 +199,7 @@ export async function POST(request: NextRequest) {
           source_run_id: sourceRunId,
           proposal,
           action_payload: actionPayload,
+          decision_trust_frame: decisionTrustFrame,
           executes_action: false,
         },
       })
@@ -200,6 +212,19 @@ export async function POST(request: NextRequest) {
 
     await recordAgentEvent({
       runId: run.id,
+      eventType: AGENT_DECISION_TRUST_EVENT,
+      severity: decisionTrustFrame.recommended_gate === 'block'
+        ? 'error'
+        : decisionTrustFrame.recommended_gate === 'human_review'
+          ? 'warning'
+          : 'info',
+      message: `${proposal.action}: ${decisionTrustFrame.recommended_gate}`,
+      metadata: decisionTrustFrame,
+      idempotencyKey: `${run.id}:decision-trust-recorded`,
+    }).catch(() => {})
+
+    await recordAgentEvent({
+      runId: run.id,
       eventType: 'chief_of_staff_approval_created',
       severity: 'info',
       message: `${approvalType}: ${proposal.label}`,
@@ -208,6 +233,7 @@ export async function POST(request: NextRequest) {
         source_run_id: sourceRunId,
         proposal,
         action_payload: actionPayload,
+        decision_trust_frame: decisionTrustFrame,
       },
       idempotencyKey: `${run.id}:chief-of-staff-approval-created`,
     }).catch(() => {})
@@ -224,6 +250,7 @@ export async function POST(request: NextRequest) {
         approval_type: approvalType,
         source_run_id: sourceRunId,
         action_payload: actionPayload,
+        decision_trust_frame: decisionTrustFrame,
       },
       idempotencyKey: `${run.id}:approval-action-payload`,
     }).catch(() => {})

--- a/components/admin/agents/AgentGovernancePanel.tsx
+++ b/components/admin/agents/AgentGovernancePanel.tsx
@@ -61,6 +61,27 @@ export type AgentGovernanceSnapshot = {
     fallback_agent_key: string | null
     alternatives_considered: string[]
   }>
+  recent_decision_trust_frames: Array<{
+    run_id: string
+    decision_id: string
+    agent_key: string
+    decision_type: 'information' | 'tool' | 'vendor' | 'spend' | 'data' | 'action' | 'oauth' | 'app_install'
+    objective: string
+    selected_candidate: string
+    candidates_considered: string[]
+    trust_signals: string[]
+    risk_signals: string[]
+    missing_evidence: string[]
+    scores: {
+      relationshipTrust: number
+      decisionRisk: number
+      evidenceCompleteness: number
+    }
+    recommended_gate: 'allow' | 'sandbox' | 'human_review' | 'block'
+    approval_type: string | null
+    reversibility: string
+    occurred_at: string
+  }>
   recent_governance_exports: Array<{
     id: string
     export_type: string
@@ -147,6 +168,7 @@ export function AgentGovernancePanel({ governance }: { governance: AgentGovernan
 
       <GovernanceExportBuilder />
       <GovernanceExportLedger exports={governance.recent_governance_exports ?? []} />
+      <DecisionTrustPanel frames={governance.recent_decision_trust_frames ?? []} />
 
       <div className="mt-4 grid grid-cols-2 gap-2 lg:grid-cols-4">
         <MiniMetric label="Profiles" value={`${governance.summary.reviewed_agents}/${governance.summary.total_agents}`} tone="green" />
@@ -234,6 +256,70 @@ export function AgentGovernancePanel({ governance }: { governance: AgentGovernan
   )
 }
 
+function DecisionTrustPanel({ frames }: { frames: AgentGovernanceSnapshot['recent_decision_trust_frames'] }) {
+  const latest = frames[0]
+
+  return (
+    <div className="mt-4 border-t border-silicon-slate/55 pt-4" aria-label="Decision Trust">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Decision Trust</p>
+          <p className="mt-1 text-sm leading-6 text-muted-foreground">
+            Shadow-mode frames explain why an agent trusted a source, tool, vendor, app, or spend path before action.
+          </p>
+        </div>
+        <StatusOnlyPill tone={latest ? gateTone(latest.recommended_gate) : 'neutral'}>
+          {latest ? latest.recommended_gate.replace(/_/g, ' ') : 'shadow mode'}
+        </StatusOnlyPill>
+      </div>
+
+      {latest ? (
+        <Link
+          href={`/admin/agents/runs/${latest.run_id}`}
+          className="mt-3 block rounded-lg border border-silicon-slate/55 bg-background/35 p-3 hover:border-radiant-gold/50"
+        >
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="text-sm font-semibold">{latest.selected_candidate}</p>
+              <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                {latest.decision_type.replace(/_/g, ' ')} · {latest.objective}
+              </p>
+            </div>
+            <StatusOnlyPill tone={gateTone(latest.recommended_gate)}>
+              {latest.recommended_gate.replace(/_/g, ' ')}
+            </StatusOnlyPill>
+          </div>
+
+          <div className="mt-3 grid gap-2 sm:grid-cols-3">
+            <MiniMetric label="Trust" value={formatTrustScore(latest.scores.relationshipTrust)} tone={latest.scores.relationshipTrust >= 0.65 ? 'green' : 'yellow'} />
+            <MiniMetric label="Risk" value={formatTrustScore(latest.scores.decisionRisk)} tone={latest.scores.decisionRisk >= 0.55 ? 'yellow' : 'green'} />
+            <MiniMetric label="Evidence" value={formatTrustScore(latest.scores.evidenceCompleteness)} tone={latest.scores.evidenceCompleteness >= 0.65 ? 'green' : 'yellow'} />
+          </div>
+
+          <p className="mt-3 text-xs leading-5 text-muted-foreground">
+            Trust: {latest.trust_signals.slice(0, 2).join(', ') || 'No trust signals recorded.'}
+          </p>
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">
+            Risk: {latest.risk_signals.slice(0, 2).join(', ') || 'No risk signals recorded.'}
+          </p>
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">
+            Missing evidence: {latest.missing_evidence.slice(0, 3).join(', ') || 'No missing evidence recorded.'}
+          </p>
+          {latest.approval_type ? (
+            <p className="mt-1 text-xs leading-5 text-muted-foreground">
+              Approval: {latest.approval_type} · Reversibility: {latest.reversibility}
+            </p>
+          ) : null}
+        </Link>
+      ) : (
+        <div className="mt-3 rounded-lg border border-silicon-slate/55 bg-background/35 p-3 text-sm text-muted-foreground">
+          No decision trust frames recorded yet. V1 will log frames as Agent Ops events before any enforcement is added.
+        </div>
+      )}
+    </div>
+  )
+}
+
 function authorityPacket(metadata: Record<string, unknown> | null | undefined) {
   const value = metadata?.authority_packet
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null
@@ -293,6 +379,17 @@ function governanceExportScopeLabel(item: AgentGovernanceSnapshot['recent_govern
 
 function shortId(value: string) {
   return value.length > 8 ? value.slice(0, 8) : value
+}
+
+function gateTone(gate: AgentGovernanceSnapshot['recent_decision_trust_frames'][number]['recommended_gate']): 'green' | 'yellow' | 'red' | 'blue' {
+  if (gate === 'allow') return 'green'
+  if (gate === 'block') return 'red'
+  if (gate === 'human_review') return 'yellow'
+  return 'blue'
+}
+
+function formatTrustScore(value: number) {
+  return `${Math.round(value * 100)}%`
 }
 
 function GovernanceExportBuilder() {

--- a/lib/agent-decision-trust.test.ts
+++ b/lib/agent-decision-trust.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildAgentDecisionFrame,
+  buildPaymentAuthorityDecisionTrustFrame,
+  scoreAgentDecisionTrust,
+} from './agent-decision-trust'
+
+describe('agent decision trust', () => {
+  it('allows official read-only source use when evidence is complete', () => {
+    const frame = buildAgentDecisionFrame({
+      agentKey: 'research-source-register',
+      decisionType: 'information',
+      objective: 'Use official vendor docs for a read-only comparison.',
+      selectedCandidate: 'official-docs',
+      candidatesConsidered: ['official-docs', 'blog-summary'],
+      trustSignals: ['Official source verified', 'Domain match confirmed', 'Source evidence linked'],
+      riskSignals: ['Read-only source review'],
+      missingEvidence: [],
+      reversibility: 'easy',
+    })
+
+    expect(frame.recommended_gate).toBe('allow')
+    expect(frame.scores.relationshipTrust).toBeGreaterThanOrEqual(0.65)
+    expect(frame.scores.evidenceCompleteness).toBeGreaterThanOrEqual(0.9)
+  })
+
+  it('routes unknown paid vendor decisions to human review', () => {
+    const frame = buildAgentDecisionFrame({
+      agentKey: 'automation-systems',
+      decisionType: 'spend',
+      objective: 'Start a paid external scraping job.',
+      selectedCandidate: 'unknown-vendor',
+      trustSignals: ['Vendor website found'],
+      riskSignals: ['Unknown vendor', 'Paid external job requested'],
+      missingEvidence: ['Official docs', 'Pricing terms', 'Cancellation terms'],
+      reversibility: 'hard',
+      approvalType: 'payment_start_paid_external_job',
+    })
+
+    expect(frame.recommended_gate).toBe('human_review')
+    expect(frame.scores.decisionRisk).toBeGreaterThanOrEqual(0.55)
+  })
+
+  it('blocks suspicious domain mismatch decisions', () => {
+    const frame = buildAgentDecisionFrame({
+      agentKey: 'chief-of-staff',
+      decisionType: 'vendor',
+      objective: 'Choose a payment destination.',
+      selectedCandidate: 'stripe-support-payments.example',
+      trustSignals: ['Search result appeared high on the page'],
+      riskSignals: ['Domain mismatch', 'Possible impersonation', 'Payment requested'],
+      missingEvidence: ['Official source confirmation'],
+      reversibility: 'irreversible',
+    })
+
+    expect(frame.recommended_gate).toBe('block')
+  })
+
+  it('uses prior approval as trust evidence without bypassing payment review', () => {
+    const frame = buildAgentDecisionFrame({
+      agentKey: 'chief-of-staff',
+      decisionType: 'spend',
+      objective: 'Create a vendor payment checkpoint.',
+      selectedCandidate: 'known-vendor',
+      trustSignals: ['Prior approval recorded', 'Prior successful use recorded', 'Official source verified'],
+      riskSignals: ['Vendor payment requested'],
+      missingEvidence: [],
+      reversibility: 'hard',
+      approvalType: 'payment_make_vendor_payment',
+    })
+
+    expect(frame.scores.relationshipTrust).toBeGreaterThanOrEqual(0.8)
+    expect(frame.recommended_gate).toBe('human_review')
+  })
+
+  it('lowers evidence completeness when evidence is stale or missing', () => {
+    const complete = buildAgentDecisionFrame({
+      agentKey: 'technology-bakeoff',
+      decisionType: 'tool',
+      objective: 'Compare tooling candidates.',
+      selectedCandidate: 'current-default',
+      trustSignals: ['Known internal source'],
+      riskSignals: ['Read-only planning'],
+      missingEvidence: [],
+    })
+    const incomplete = buildAgentDecisionFrame({
+      agentKey: 'technology-bakeoff',
+      decisionType: 'tool',
+      objective: 'Compare tooling candidates.',
+      selectedCandidate: 'new-tool',
+      trustSignals: ['Candidate suggested'],
+      riskSignals: ['Unknown source'],
+      missingEvidence: ['Official docs', 'Current pricing', 'Source freshness', 'Rollback evidence'],
+    })
+
+    expect(incomplete.scores.evidenceCompleteness).toBeLessThan(complete.scores.evidenceCompleteness)
+    expect(incomplete.recommended_gate).toBe('sandbox')
+  })
+
+  it('routes OAuth and broad app permissions to human review', () => {
+    const result = scoreAgentDecisionTrust({
+      decision_type: 'oauth',
+      trust_signals: ['Official source verified'],
+      risk_signals: ['OAuth app install requested', 'Broad access permissions requested'],
+      missing_evidence: ['Permission minimization proof'],
+      approval_type: null,
+      reversibility: 'hard',
+    })
+
+    expect(result.recommended_gate).toBe('human_review')
+  })
+
+  it('builds payment authority frames with human review as the minimum gate', () => {
+    const frame = buildPaymentAuthorityDecisionTrustFrame({
+      action: 'create_refund',
+      label: 'Create refund',
+      sourceRunId: 'run-source',
+      approvalType: 'payment_create_refund',
+    })
+
+    expect(frame.decision_type).toBe('spend')
+    expect(frame.linked_run_id).toBe('run-source')
+    expect(frame.recommended_gate).toBe('human_review')
+  })
+})

--- a/lib/agent-decision-trust.ts
+++ b/lib/agent-decision-trust.ts
@@ -1,0 +1,299 @@
+import { isPaymentAuthorityAction, type AgentAction } from '@/lib/agent-policy'
+import type { TechnologyBakeoffCandidate, TechnologyBakeoffInput } from '@/lib/technology-bakeoff'
+import type { AgentDelegationDecision } from '@/lib/agent-delegation-policy'
+
+export const AGENT_DECISION_TRUST_EVENT = 'agent_decision_trust_recorded'
+
+export type AgentDecisionType =
+  | 'information'
+  | 'tool'
+  | 'vendor'
+  | 'spend'
+  | 'data'
+  | 'action'
+  | 'oauth'
+  | 'app_install'
+
+export type DecisionTrustGate = 'allow' | 'sandbox' | 'human_review' | 'block'
+export type DecisionTrustConfidence = 'low' | 'medium' | 'high'
+export type DecisionTrustReversibility = 'easy' | 'moderate' | 'hard' | 'irreversible'
+
+export type DecisionTrustScore = {
+  relationshipTrust: number
+  decisionRisk: number
+  evidenceCompleteness: number
+}
+
+export type AgentDecisionFrame = {
+  decision_id: string
+  agent_key: string
+  decision_type: AgentDecisionType
+  objective: string
+  selected_candidate: string
+  candidates_considered: string[]
+  rejected_candidates: Array<{
+    candidate: string
+    reason: string
+  }>
+  trust_signals: string[]
+  risk_signals: string[]
+  missing_evidence: string[]
+  confidence: DecisionTrustConfidence
+  reversibility: DecisionTrustReversibility
+  scores: DecisionTrustScore
+  recommended_gate: DecisionTrustGate
+  approval_type: string | null
+  linked_run_id: string | null
+}
+
+export type BuildAgentDecisionFrameInput = {
+  agentKey: string
+  decisionType: AgentDecisionType
+  objective: string
+  selectedCandidate: string
+  candidatesConsidered?: string[]
+  rejectedCandidates?: AgentDecisionFrame['rejected_candidates']
+  trustSignals?: string[]
+  riskSignals?: string[]
+  missingEvidence?: string[]
+  confidence?: DecisionTrustConfidence
+  reversibility?: DecisionTrustReversibility
+  approvalType?: string | null
+  linkedRunId?: string | null
+}
+
+const TRUST_SIGNAL_WEIGHTS: Array<[RegExp, number]> = [
+  [/official|first.?party|domain.?match|verified/i, 0.25],
+  [/prior approval|approved/i, 0.2],
+  [/prior successful|used successfully|successful use/i, 0.2],
+  [/known internal|internal source|trusted domain|agent ops/i, 0.18],
+  [/source evidence|trace|provenance|audit/i, 0.12],
+]
+
+const RISK_SIGNAL_WEIGHTS: Array<[RegExp, number]> = [
+  [/scam|known.?bad|impersonat|typosquat|domain mismatch|contradict/i, 1],
+  [/payment|spend|subscription|refund|checkout|paid|vendor/i, 0.5],
+  [/oauth|app install|install app|permission|broad access/i, 0.45],
+  [/production|config|mutation|database write/i, 0.45],
+  [/private|client data|secret|credential/i, 0.4],
+  [/publish|email|outbound|public/i, 0.35],
+  [/irreversible|hard to reverse/i, 0.3],
+  [/unknown vendor|unknown source|unverified/i, 0.25],
+]
+
+const HUMAN_REVIEW_RISK = /(payment|spend|subscription|refund|checkout|paid|vendor|oauth|app install|permission|production|config|private|client data|publish|email|outbound|irreversible)/i
+const BLOCK_RISK = /(scam|known.?bad|impersonat|typosquat|domain mismatch|contradict|excessive unexplained permission)/i
+
+function clampScore(value: number) {
+  return Number(Math.max(0, Math.min(1, value)).toFixed(2))
+}
+
+function uniqueStrings(values: string[] | undefined, fallback: string[] = []) {
+  return Array.from(new Set([...(values ?? []), ...fallback]
+    .map((value) => value.trim())
+    .filter(Boolean)))
+}
+
+function signalScore(signals: string[], weights: Array<[RegExp, number]>, base: number) {
+  return clampScore(signals.reduce((score, signal) => {
+    const match = weights.find(([pattern]) => pattern.test(signal))
+    return score + (match?.[1] ?? 0.06)
+  }, base))
+}
+
+function confidenceFromScores(scores: DecisionTrustScore): DecisionTrustConfidence {
+  if (scores.evidenceCompleteness >= 0.75 && scores.relationshipTrust >= 0.65 && scores.decisionRisk < 0.55) return 'high'
+  if (scores.evidenceCompleteness >= 0.45 && scores.relationshipTrust >= 0.4 && scores.decisionRisk < 0.75) return 'medium'
+  return 'low'
+}
+
+function gateFromScores(input: {
+  decisionType: AgentDecisionType
+  scores: DecisionTrustScore
+  riskSignals: string[]
+  approvalType: string | null
+  reversibility: DecisionTrustReversibility
+}): DecisionTrustGate {
+  const riskText = input.riskSignals.join(' ')
+  if (BLOCK_RISK.test(riskText)) return 'block'
+  if (
+    input.approvalType ||
+    input.decisionType === 'spend' ||
+    input.decisionType === 'oauth' ||
+    input.decisionType === 'app_install' ||
+    input.reversibility === 'irreversible' ||
+    HUMAN_REVIEW_RISK.test(riskText)
+  ) {
+    return 'human_review'
+  }
+  if (input.scores.decisionRisk >= 0.55 || input.scores.evidenceCompleteness < 0.65 || input.scores.relationshipTrust < 0.55) {
+    return 'sandbox'
+  }
+  return 'allow'
+}
+
+export function scoreAgentDecisionTrust(frame: Pick<
+  AgentDecisionFrame,
+  'decision_type' | 'trust_signals' | 'risk_signals' | 'missing_evidence' | 'approval_type' | 'reversibility'
+>): { scores: DecisionTrustScore; recommended_gate: DecisionTrustGate } {
+  const scores = {
+    relationshipTrust: signalScore(frame.trust_signals, TRUST_SIGNAL_WEIGHTS, 0.25),
+    decisionRisk: signalScore(frame.risk_signals, RISK_SIGNAL_WEIGHTS, 0.12),
+    evidenceCompleteness: clampScore(0.92 - (frame.missing_evidence.length * 0.16)),
+  }
+
+  return {
+    scores,
+    recommended_gate: gateFromScores({
+      decisionType: frame.decision_type,
+      scores,
+      riskSignals: frame.risk_signals,
+      approvalType: frame.approval_type,
+      reversibility: frame.reversibility,
+    }),
+  }
+}
+
+export function buildAgentDecisionFrame(input: BuildAgentDecisionFrameInput): AgentDecisionFrame {
+  const candidatesConsidered = uniqueStrings(input.candidatesConsidered, [input.selectedCandidate])
+  const trustSignals = uniqueStrings(input.trustSignals)
+  const riskSignals = uniqueStrings(input.riskSignals)
+  const missingEvidence = uniqueStrings(input.missingEvidence)
+  const baseFrame = {
+    decision_id: stableDecisionId([
+      input.agentKey,
+      input.decisionType,
+      input.objective,
+      input.selectedCandidate,
+      candidatesConsidered.join('|'),
+    ]),
+    agent_key: input.agentKey,
+    decision_type: input.decisionType,
+    objective: input.objective,
+    selected_candidate: input.selectedCandidate,
+    candidates_considered: candidatesConsidered,
+    rejected_candidates: input.rejectedCandidates ?? candidatesConsidered
+      .filter((candidate) => candidate !== input.selectedCandidate)
+      .map((candidate) => ({ candidate, reason: 'Not selected for this decision frame.' })),
+    trust_signals: trustSignals,
+    risk_signals: riskSignals,
+    missing_evidence: missingEvidence,
+    confidence: input.confidence ?? 'medium',
+    reversibility: input.reversibility ?? 'moderate',
+    approval_type: input.approvalType ?? null,
+    linked_run_id: input.linkedRunId ?? null,
+  }
+  const scored = scoreAgentDecisionTrust(baseFrame)
+
+  return {
+    ...baseFrame,
+    scores: scored.scores,
+    recommended_gate: scored.recommended_gate,
+    confidence: input.confidence ?? confidenceFromScores(scored.scores),
+  }
+}
+
+export function buildDelegationDecisionTrustFrame(input: {
+  decision: AgentDelegationDecision
+  runId?: string | null
+}) {
+  const decision = input.decision
+  return buildAgentDecisionFrame({
+    agentKey: 'chief-of-staff',
+    decisionType: decision.risk_class === 'payment_spend' ? 'spend' : 'tool',
+    objective: `Route ${decision.task_type.replace(/_/g, ' ')} work to the right agent.`,
+    selectedCandidate: decision.selected_agent_key,
+    candidatesConsidered: [decision.selected_agent_key, ...decision.alternatives_considered],
+    trustSignals: [
+      'Agent Ops trace available',
+      'Known internal agent routing catalog',
+      ...decision.required_evidence.map((item) => `Required evidence: ${item}`),
+    ],
+    riskSignals: [
+      `Risk class: ${decision.risk_class}`,
+      ...(decision.approval_gate ? [`Approval gate required: ${decision.approval_gate}`] : []),
+    ],
+    missingEvidence: [],
+    confidence: decision.confidence >= 0.8 ? 'high' : decision.confidence >= 0.55 ? 'medium' : 'low',
+    reversibility: decision.risk_class === 'payment_spend' || decision.risk_class === 'production_mutation' ? 'hard' : 'easy',
+    approvalType: decision.approval_gate,
+    linkedRunId: input.runId ?? null,
+  })
+}
+
+export function buildTechnologyBakeoffDecisionTrustFrame(input: {
+  bakeoff: TechnologyBakeoffInput
+  selectedCandidate: TechnologyBakeoffCandidate
+  candidates: TechnologyBakeoffCandidate[]
+  missingEvidence: string[]
+}) {
+  const decisionType: AgentDecisionType = input.bakeoff.surface === 'commerce' || input.bakeoff.priority === 'cost'
+    ? 'vendor'
+    : input.bakeoff.surface === 'agent_runtimes'
+      ? 'tool'
+      : 'information'
+
+  return buildAgentDecisionFrame({
+    agentKey: 'technology-bakeoff',
+    decisionType,
+    objective: input.bakeoff.objective,
+    selectedCandidate: input.selectedCandidate.id,
+    candidatesConsidered: input.candidates.map((candidate) => candidate.id),
+    rejectedCandidates: input.candidates
+      .filter((candidate) => candidate.id !== input.selectedCandidate.id)
+      .map((candidate) => ({ candidate: candidate.id, reason: candidate.watchOutFor })),
+    trustSignals: [
+      'Technology bakeoff evaluator evidence',
+      'Alternatives considered before promotion',
+      'Rollback path required before default change',
+    ],
+    riskSignals: [
+      `Surface: ${input.bakeoff.surface}`,
+      `Priority: ${input.bakeoff.priority}`,
+      ...(input.bakeoff.knownFailure ? [`Known failure: ${input.bakeoff.knownFailure}`] : []),
+    ],
+    missingEvidence: input.missingEvidence,
+    reversibility: 'moderate',
+  })
+}
+
+export function buildPaymentAuthorityDecisionTrustFrame(input: {
+  action: AgentAction
+  label: string
+  sourceRunId: string
+  approvalType: string | null
+}) {
+  const paymentAuthority = isPaymentAuthorityAction(input.action)
+  return buildAgentDecisionFrame({
+    agentKey: 'chief-of-staff',
+    decisionType: paymentAuthority ? 'spend' : 'action',
+    objective: `Create approval checkpoint for ${input.label}.`,
+    selectedCandidate: input.action,
+    candidatesConsidered: [input.action],
+    trustSignals: [
+      'Agent Ops source run linked',
+      'Existing agent approval gate selected',
+    ],
+    riskSignals: [
+      paymentAuthority ? 'Payment or spend authority requested' : 'Approval-gated side effect requested',
+      'Action does not execute during checkpoint creation',
+    ],
+    missingEvidence: [
+      'Human approval decision',
+      'Post-approval execution trace',
+    ],
+    confidence: 'medium',
+    reversibility: paymentAuthority ? 'hard' : 'moderate',
+    approvalType: input.approvalType,
+    linkedRunId: input.sourceRunId,
+  })
+}
+
+function stableDecisionId(parts: string[]) {
+  const input = parts.join('::')
+  let hash = 0
+  for (let index = 0; index < input.length; index += 1) {
+    hash = ((hash << 5) - hash + input.charCodeAt(index)) | 0
+  }
+  return `decision_${Math.abs(hash).toString(36)}`
+}

--- a/lib/agent-governance-export.test.ts
+++ b/lib/agent-governance-export.test.ts
@@ -93,6 +93,7 @@ const governance = {
       alternatives_considered: ['chief-of-staff'],
     },
   ],
+  recent_decision_trust_frames: [],
   recent_governance_exports: [],
 } satisfies AgentGovernanceSnapshot
 

--- a/lib/agent-governance.test.ts
+++ b/lib/agent-governance.test.ts
@@ -59,6 +59,43 @@ describe('agent governance', () => {
             alternatives_considered: ['chief-of-staff'],
           },
         },
+        {
+          run_id: 'run-trust',
+          event_type: 'agent_decision_trust_recorded',
+          severity: 'warning',
+          message: 'payment_make_vendor_payment: human_review',
+          occurred_at: '2026-05-21T00:01:30.000Z',
+          metadata: {
+            decision_id: 'decision-payment',
+            agent_key: 'chief-of-staff',
+            decision_type: 'spend',
+            objective: 'Create a vendor payment checkpoint.',
+            selected_candidate: 'make_vendor_payment',
+            candidates_considered: ['make_vendor_payment'],
+            trust_signals: ['Agent Ops source run linked', 'Existing agent approval gate selected'],
+            risk_signals: ['Payment or spend authority requested'],
+            missing_evidence: ['Human approval decision', 'private chat export abc123'],
+            scores: {
+              relationshipTrust: 0.57,
+              decisionRisk: 0.62,
+              evidenceCompleteness: 0.6,
+            },
+            recommended_gate: 'human_review',
+            approval_type: 'payment_make_vendor_payment',
+            reversibility: 'hard',
+          },
+        },
+        {
+          run_id: 'run-malformed',
+          event_type: 'agent_decision_trust_recorded',
+          severity: 'info',
+          message: 'Malformed frame ignored.',
+          occurred_at: '2026-05-21T00:01:20.000Z',
+          metadata: {
+            decision_id: 'decision-bad',
+            decision_type: 'not_real',
+          },
+        },
       ],
       exports: [
         {
@@ -98,6 +135,18 @@ describe('agent governance', () => {
       fallback_agent_key: 'chief-of-staff',
       alternatives_considered: ['chief-of-staff'],
     })
+    expect(snapshot.recent_decision_trust_frames).toHaveLength(1)
+    expect(snapshot.recent_decision_trust_frames[0]).toMatchObject({
+      run_id: 'run-trust',
+      decision_id: 'decision-payment',
+      agent_key: 'chief-of-staff',
+      decision_type: 'spend',
+      selected_candidate: 'make_vendor_payment',
+      recommended_gate: 'human_review',
+      approval_type: 'payment_make_vendor_payment',
+    })
+    expect(snapshot.recent_decision_trust_frames[0]?.missing_evidence.join(' ')).toContain('private source summary')
+    expect(snapshot.recent_decision_trust_frames[0]?.missing_evidence.join(' ')).not.toContain('private chat export')
     expect(snapshot.recent_governance_exports[0]).toMatchObject({
       id: 'export-1',
       format: 'markdown',

--- a/lib/agent-governance.ts
+++ b/lib/agent-governance.ts
@@ -6,6 +6,12 @@ import {
   isPaymentAuthorityAction,
   type AgentAction,
 } from '@/lib/agent-policy'
+import {
+  AGENT_DECISION_TRUST_EVENT,
+  type AgentDecisionType,
+  type DecisionTrustGate,
+  type DecisionTrustScore,
+} from '@/lib/agent-decision-trust'
 
 export type AgentCapabilityProfile = {
   agent_key: string
@@ -90,6 +96,23 @@ export type AgentGovernanceSnapshot = {
     approval_gate: string | null
     fallback_agent_key: string | null
     alternatives_considered: string[]
+  }>
+  recent_decision_trust_frames: Array<{
+    run_id: string
+    decision_id: string
+    agent_key: string
+    decision_type: AgentDecisionType
+    objective: string
+    selected_candidate: string
+    candidates_considered: string[]
+    trust_signals: string[]
+    risk_signals: string[]
+    missing_evidence: string[]
+    scores: DecisionTrustScore
+    recommended_gate: DecisionTrustGate
+    approval_type: string | null
+    reversibility: string
+    occurred_at: string
   }>
   recent_governance_exports: GovernanceExportSummary[]
 }
@@ -224,8 +247,29 @@ function metadataString(metadata: Record<string, unknown> | null, key: string) {
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
 }
 
+function safeMetadataString(metadata: Record<string, unknown> | null, key: string) {
+  const value = metadataString(metadata, key)
+  return value ? sanitizeDecisionTrustText(value) : null
+}
+
 function nestedMetadataRecord(metadata: Record<string, unknown> | null, key: string) {
   return metadataRecord(metadata?.[key])
+}
+
+function sanitizeDecisionTrustText(value: string) {
+  return value
+    .replace(/(sk-[A-Za-z0-9_-]{8,}|github_pat_[A-Za-z0-9_]{8,}|[A-Za-z0-9_]*(?:TOKEN|SECRET|KEY|PASSWORD)[A-Za-z0-9_]*\s*[:=]\s*["']?[^"'\s,}]+)/gi, '[redacted]')
+    .replace(/private (chat|message|transcript|export)[^,.]*/gi, 'private source summary')
+    .slice(0, 220)
+}
+
+function metadataSafeStringArray(metadata: Record<string, unknown> | null, key: string) {
+  return metadataStringArray(metadata, key).map(sanitizeDecisionTrustText)
+}
+
+function metadataNumber(record: Record<string, unknown> | null, key: string) {
+  const value = record?.[key]
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0
 }
 
 function authorityApprovalSummary(approval: GovernanceApprovalSummary): GovernanceApprovalSummary {
@@ -277,6 +321,67 @@ function recentDelegationDecisions(events: GovernanceEventSummary[]): AgentGover
     .slice(0, 5)
 }
 
+function decisionTrustScores(value: unknown): DecisionTrustScore | null {
+  const record = metadataRecord(value)
+  if (!record) return null
+  return {
+    relationshipTrust: metadataNumber(record, 'relationshipTrust'),
+    decisionRisk: metadataNumber(record, 'decisionRisk'),
+    evidenceCompleteness: metadataNumber(record, 'evidenceCompleteness'),
+  }
+}
+
+function isDecisionType(value: string | null): value is AgentDecisionType {
+  return value === 'information' ||
+    value === 'tool' ||
+    value === 'vendor' ||
+    value === 'spend' ||
+    value === 'data' ||
+    value === 'action' ||
+    value === 'oauth' ||
+    value === 'app_install'
+}
+
+function isDecisionTrustGate(value: string | null): value is DecisionTrustGate {
+  return value === 'allow' || value === 'sandbox' || value === 'human_review' || value === 'block'
+}
+
+function recentDecisionTrustFrames(events: GovernanceEventSummary[]): AgentGovernanceSnapshot['recent_decision_trust_frames'] {
+  return events
+    .filter((event) => event.event_type === AGENT_DECISION_TRUST_EVENT)
+    .flatMap((event) => {
+      const metadata = metadataRecord(event.metadata)
+      const decisionId = safeMetadataString(metadata, 'decision_id')
+      const agentKey = safeMetadataString(metadata, 'agent_key')
+      const decisionType = safeMetadataString(metadata, 'decision_type')
+      const selectedCandidate = safeMetadataString(metadata, 'selected_candidate')
+      const scores = decisionTrustScores(metadata?.scores)
+      const recommendedGate = safeMetadataString(metadata, 'recommended_gate')
+      if (!decisionId || !agentKey || !isDecisionType(decisionType) || !selectedCandidate || !scores || !isDecisionTrustGate(recommendedGate)) {
+        return []
+      }
+
+      return [{
+        run_id: event.run_id,
+        decision_id: decisionId,
+        agent_key: agentKey,
+        decision_type: decisionType,
+        objective: safeMetadataString(metadata, 'objective') ?? 'Decision trust frame recorded.',
+        selected_candidate: selectedCandidate,
+        candidates_considered: metadataSafeStringArray(metadata, 'candidates_considered'),
+        trust_signals: metadataSafeStringArray(metadata, 'trust_signals'),
+        risk_signals: metadataSafeStringArray(metadata, 'risk_signals'),
+        missing_evidence: metadataSafeStringArray(metadata, 'missing_evidence'),
+        scores,
+        recommended_gate: recommendedGate,
+        approval_type: safeMetadataString(metadata, 'approval_type'),
+        reversibility: safeMetadataString(metadata, 'reversibility') ?? 'unknown',
+        occurred_at: event.occurred_at,
+      }]
+    })
+    .slice(0, 5)
+}
+
 export function buildAgentGovernanceSnapshot(input?: {
   approvals?: GovernanceApprovalSummary[]
   events?: GovernanceEventSummary[]
@@ -309,6 +414,7 @@ export function buildAgentGovernanceSnapshot(input?: {
     }),
     pending_authority_approvals: pendingAuthorityApprovals.slice(0, 8).map(authorityApprovalSummary),
     recent_delegation_decisions: recentDelegationDecisions(input?.events ?? []),
+    recent_decision_trust_frames: recentDecisionTrustFrames(input?.events ?? []),
     recent_governance_exports: (input?.exports ?? []).slice(0, 8),
   }
 }

--- a/lib/agent-mission-control.ts
+++ b/lib/agent-mission-control.ts
@@ -843,7 +843,7 @@ export async function buildAgentMissionControlSnapshot() {
       .from('agent_run_events')
       .select('run_id, event_type, severity, message, occurred_at, metadata')
       .order('occurred_at', { ascending: false })
-      .limit(12),
+      .limit(30),
     db
       .from('agent_work_items')
       .select('id, title, status, priority, owner_agent_key, dependency_ids, active_run_id, updated_at')

--- a/lib/chief-of-staff-chat.ts
+++ b/lib/chief-of-staff-chat.ts
@@ -17,6 +17,10 @@ import {
   evaluateAgentDelegationPolicy,
 } from '@/lib/agent-delegation-policy'
 import {
+  AGENT_DECISION_TRUST_EVENT,
+  buildDelegationDecisionTrustFrame,
+} from '@/lib/agent-decision-trust'
+import {
   evaluateAgentBudget,
   type AgentBudgetDecision,
 } from '@/lib/agent-budget-policy'
@@ -865,6 +869,10 @@ export async function runChiefOfStaffChat(input: ChiefOfStaffChatRequest): Promi
     const agentEngagements = applyDelegationDecisionToEngagements(parsed.agentEngagements, delegationDecision)
 
     if (delegationDecision) {
+      const decisionTrustFrame = buildDelegationDecisionTrustFrame({
+        decision: delegationDecision,
+        runId: run.id,
+      })
       await recordAgentEvent({
         runId: run.id,
         eventType: 'delegation_decision_recorded',
@@ -883,6 +891,17 @@ export async function runChiefOfStaffChat(input: ChiefOfStaffChatRequest): Promi
           approval_gate: delegationDecision.approval_gate,
           confidence: delegationDecision.confidence,
         },
+      }).catch(() => {})
+      await recordAgentEvent({
+        runId: run.id,
+        eventType: AGENT_DECISION_TRUST_EVENT,
+        severity: decisionTrustFrame.recommended_gate === 'block'
+          ? 'error'
+          : decisionTrustFrame.recommended_gate === 'human_review'
+            ? 'warning'
+            : 'info',
+        message: `${decisionTrustFrame.selected_candidate}: ${decisionTrustFrame.recommended_gate}`,
+        metadata: decisionTrustFrame,
       }).catch(() => {})
     }
 

--- a/lib/technology-bakeoff.test.ts
+++ b/lib/technology-bakeoff.test.ts
@@ -21,6 +21,8 @@ describe('buildTechnologyBakeoffPlan', () => {
       expect(plan.benchmarkRunbook.join(' ')).toContain('Decision question')
       expect(plan.promotionGate.length).toBeGreaterThan(0)
       expect(plan.rollbackPlan.length).toBeGreaterThan(0)
+      expect(plan.decisionTrustFrame.objective).toBe(`Evaluate ${TECHNOLOGY_BAKEOFF_PROFILES[surface].label}`)
+      expect(plan.decisionTrustFrame.candidates_considered.length).toBeGreaterThan(0)
       expect(plan.nextImplementationStep).toContain(plan.surfaceLabel)
     }
   })
@@ -86,6 +88,7 @@ describe('buildTechnologyBakeoffPlan', () => {
 
     expect(plan.candidates[0].label).toBe('New Analytics Tool')
     expect(plan.candidates[0].role).toBe('User-supplied candidate')
+    expect(plan.decisionTrustFrame.selected_candidate).toBe('new_analytics_tool')
   })
 
   it('uses Apify call evidence for lead enrichment bakeoffs', () => {
@@ -99,5 +102,8 @@ describe('buildTechnologyBakeoffPlan', () => {
     expect(plan.candidates.map((candidate) => candidate.id)).toEqual(expect.arrayContaining(['apify_actors', 'browser_agents']))
     expect(plan.benchmarkRunbook.join(' ')).toContain('docs/apify-call-bakeoff-analysis.md')
     expect(plan.missingEvidence.join(' ')).toContain('Direct Apify run history')
+    expect(plan.decisionTrustFrame.decision_type).toBe('vendor')
+    expect(plan.decisionTrustFrame.missing_evidence).toContain('Direct Apify run history')
+    expect(plan.decisionTrustFrame.recommended_gate).toMatch(/sandbox|human_review/)
   })
 })

--- a/lib/technology-bakeoff.ts
+++ b/lib/technology-bakeoff.ts
@@ -6,6 +6,10 @@ import {
   buildPresentationBakeoffPlan,
   type PresentationBakeoffInput,
 } from './presentation-bakeoff'
+import {
+  buildTechnologyBakeoffDecisionTrustFrame,
+  type AgentDecisionFrame,
+} from './agent-decision-trust'
 
 export const TECHNOLOGY_BAKEOFF_SURFACES = [
   'media_generation',
@@ -85,6 +89,7 @@ export interface TechnologyBakeoffPlan {
   rollbackPlan: string[]
   integrationNotes: string[]
   missingEvidence: string[]
+  decisionTrustFrame: AgentDecisionFrame
   nextImplementationStep: string
   specialistSource?: 'media_generation' | 'presentation' | 'agent_runtime'
 }
@@ -597,6 +602,14 @@ export function buildTechnologyBakeoffPlan(input: TechnologyBakeoffInput): Techn
   const specialist = specialistPlan(input, profile)
   const candidates = specialist.candidates ?? applyCandidateOverrides(profile, input.candidateOverrides)
   const currentDefault = input.currentDefault?.trim() || 'Current Portfolio default'
+  const selectedCandidate = candidates[0] ?? profile.candidates[0]
+  const missingEvidence = profile.missingEvidence
+  const decisionTrustFrame = buildTechnologyBakeoffDecisionTrustFrame({
+    bakeoff: input,
+    selectedCandidate,
+    candidates,
+    missingEvidence,
+  })
 
   return {
     generatedAt: new Date().toISOString(),
@@ -620,7 +633,8 @@ export function buildTechnologyBakeoffPlan(input: TechnologyBakeoffInput): Techn
     promotionGate: specialist.promotionGate ?? profile.promotionGate,
     rollbackPlan: profile.rollbackPlan,
     integrationNotes: specialist.integrationNotes ?? profile.integrationNotes,
-    missingEvidence: profile.missingEvidence,
+    missingEvidence,
+    decisionTrustFrame,
     nextImplementationStep: `Create a small evidence packet for ${profile.label} in ${profile.adminArea}, then compare candidates with the scoring plan.`,
     specialistSource: specialist.specialistSource,
   }


### PR DESCRIPTION
## Summary
- Add a shadow-mode Agent Decision Trust frame builder and deterministic scoring/gate recommendations.
- Record trust frames from Shaka delegation and Chief-of-Staff approval checkpoint creation without adding new tables or enforcement.
- Surface recent trust frames in the Agent Governance panel and add bakeoff trust frames to technology bakeoff plans.

## Validation
- npm test -- --run lib/agent-decision-trust.test.ts lib/agent-governance.test.ts lib/technology-bakeoff.test.ts app/admin/agents/governance/page.test.tsx app/admin/agents/page.test.tsx app/api/admin/agents/chief-of-staff/actions/route.test.ts lib/agent-governance-export.test.ts
- npx tsc --noEmit --pretty false
- git diff --check
- Browser smoke: opened http://127.0.0.1:3031/admin/agents/governance in the Codex in-app browser; auth boundary rendered with no console errors. Authenticated panel rendering covered by React tests.
- npm run typecheck was not available because package.json has no typecheck script.

## Integration Notes
- No Supabase migration, production default change, or new approval system.
- V1 is shadow-mode only; high-risk actions still use existing agent_approvals gates.
- Vercel – portfolio: not checked for this draft PR.
- Vercel – portfolio-staging: not checked for this draft PR.