### PR TITLE
feat: add voice-note content package workflow

### DIFF
--- a/app/admin/social-content/page.tsx
+++ b/app/admin/social-content/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback, useRef } from 'react'
 import Image from 'next/image'
 import { motion } from 'framer-motion'
 import { buildLinkWithReturn } from '@/lib/admin-return-context'
@@ -27,6 +27,10 @@ import {
   Search,
   Calendar,
   CheckSquare,
+  Mic,
+  MicOff,
+  Sparkles,
+  Plus,
 } from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
@@ -73,6 +77,32 @@ interface MeetingRecord {
   has_transcript: boolean
 }
 
+interface ContentFrameworkOption {
+  id: string
+  display_name: string
+  creator_name: string
+  summary: string
+}
+
+interface VoiceNoteIntake {
+  id: string
+  title: string
+  status: string
+  target_outputs: string[]
+  audio_file_name: string | null
+  created_at: string
+}
+
+const VOICE_NOTE_OUTPUTS = [
+  { value: 'linkedin_post', label: 'LinkedIn' },
+  { value: 'linkedin_carousel', label: 'Carousel' },
+  { value: 'pptx_deck', label: 'PowerPoint' },
+  { value: 'video_script', label: 'Script' },
+  { value: 'heygen_video', label: 'HeyGen' },
+  { value: 'elevenlabs_audio', label: 'Audio' },
+  { value: 'short_caption', label: 'Captions' },
+]
+
 const MEETINGS_PER_PAGE = 5
 
 function SocialContentQueuePage() {
@@ -97,6 +127,24 @@ function SocialContentQueuePage() {
   const [triggerLoading, setTriggerLoading] = useState(false)
   const [triggerResult, setTriggerResult] = useState<{ success: boolean; message: string } | null>(null)
   const [showTriggerPanel, setShowTriggerPanel] = useState(false)
+
+  const [showVoicePanel, setShowVoicePanel] = useState(false)
+  const [voiceIntakes, setVoiceIntakes] = useState<VoiceNoteIntake[]>([])
+  const [contentFrameworks, setContentFrameworks] = useState<ContentFrameworkOption[]>([])
+  const [voiceTitle, setVoiceTitle] = useState('')
+  const [voiceTopic, setVoiceTopic] = useState('')
+  const [voiceAudience, setVoiceAudience] = useState('')
+  const [voiceTranscript, setVoiceTranscript] = useState('')
+  const [voiceOutputs, setVoiceOutputs] = useState<string[]>(['linkedin_post', 'linkedin_carousel', 'pptx_deck', 'video_script', 'heygen_video', 'elevenlabs_audio'])
+  const [voiceFrameworks, setVoiceFrameworks] = useState<string[]>(['alex-hormozi-value-equation', 'nick-saraev-ai-content-engine'])
+  const [voiceAudioFile, setVoiceAudioFile] = useState<File | null>(null)
+  const [voiceLoading, setVoiceLoading] = useState(false)
+  const [voiceSubmitting, setVoiceSubmitting] = useState(false)
+  const [voiceGeneratingId, setVoiceGeneratingId] = useState<string | null>(null)
+  const [voiceResult, setVoiceResult] = useState<{ success: boolean; message: string; href?: string | null } | null>(null)
+  const [isRecording, setIsRecording] = useState(false)
+  const recorderRef = useRef<MediaRecorder | null>(null)
+  const audioChunksRef = useRef<BlobPart[]>([])
 
   const fetchItems = useCallback(async (page = 1) => {
     setLoading(true)
@@ -164,6 +212,30 @@ function SocialContentQueuePage() {
     if (showTriggerPanel) fetchMeetings()
   }, [showTriggerPanel, fetchMeetings])
 
+  const fetchVoiceIntakes = useCallback(async () => {
+    setVoiceLoading(true)
+    try {
+      const session = await getCurrentSession()
+      if (!session) return
+      const res = await fetch('/api/admin/social-content/voice-notes?limit=8', {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      })
+      if (res.ok) {
+        const data = await res.json()
+        setVoiceIntakes(data.intakes ?? [])
+        setContentFrameworks(data.frameworks ?? [])
+      }
+    } catch (err) {
+      console.error('Failed to fetch voice-note intakes:', err)
+    } finally {
+      setVoiceLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (showVoicePanel) fetchVoiceIntakes()
+  }, [showVoicePanel, fetchVoiceIntakes])
+
   // Debounced meeting search — reset to page 1 on filter change
   useEffect(() => {
     if (!showTriggerPanel) return
@@ -210,6 +282,115 @@ function SocialContentQueuePage() {
       .map(r => r.meeting_record_id!)
     if (failedMeetingIds.length === 0) return
     await handleTriggerExtraction(failedMeetingIds)
+  }
+
+  const toggleVoiceOutput = (output: string) => {
+    setVoiceOutputs((current) =>
+      current.includes(output) ? current.filter((item) => item !== output) : [...current, output]
+    )
+  }
+
+  const toggleVoiceFramework = (frameworkId: string) => {
+    setVoiceFrameworks((current) =>
+      current.includes(frameworkId) ? current.filter((item) => item !== frameworkId) : [...current, frameworkId]
+    )
+  }
+
+  const startVoiceRecording = async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+      const recorder = new MediaRecorder(stream)
+      audioChunksRef.current = []
+      recorder.ondataavailable = (event) => {
+        if (event.data.size > 0) audioChunksRef.current.push(event.data)
+      }
+      recorder.onstop = () => {
+        const blob = new Blob(audioChunksRef.current, { type: recorder.mimeType || 'audio/webm' })
+        const file = new File([blob], `voice-note-${new Date().toISOString().replace(/[:.]/g, '-')}.webm`, { type: blob.type })
+        setVoiceAudioFile(file)
+        stream.getTracks().forEach((track) => track.stop())
+        setIsRecording(false)
+      }
+      recorderRef.current = recorder
+      recorder.start()
+      setIsRecording(true)
+      setVoiceResult(null)
+    } catch (err) {
+      console.error('Recording failed:', err)
+      setVoiceResult({ success: false, message: 'Microphone access failed. Paste rough notes or use the audio fallback.' })
+    }
+  }
+
+  const stopVoiceRecording = () => {
+    recorderRef.current?.stop()
+  }
+
+  const submitVoiceIntake = async () => {
+    setVoiceSubmitting(true)
+    setVoiceResult(null)
+    try {
+      const session = await getCurrentSession()
+      if (!session) return
+      if (!voiceAudioFile && voiceTranscript.trim().length < 10) {
+        throw new Error('Record a voice note or add at least a short rough note.')
+      }
+      const formData = new FormData()
+      if (voiceTitle.trim()) formData.append('title', voiceTitle.trim())
+      if (voiceTopic.trim()) formData.append('topic_hint', voiceTopic.trim())
+      if (voiceAudience.trim()) formData.append('target_audience', voiceAudience.trim())
+      if (voiceTranscript.trim()) formData.append('transcript_text', voiceTranscript.trim())
+      for (const output of voiceOutputs) formData.append('target_outputs', output)
+      for (const framework of voiceFrameworks) formData.append('framework_ids', framework)
+      if (voiceAudioFile) formData.append('audio', voiceAudioFile)
+
+      const res = await fetch('/api/admin/social-content/voice-notes', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${session.access_token}` },
+        body: formData,
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to create voice-note intake')
+      setVoiceResult({ success: true, message: 'Voice note captured. Generate the package when ready.' })
+      setVoiceTitle('')
+      setVoiceTopic('')
+      setVoiceAudience('')
+      setVoiceTranscript('')
+      setVoiceAudioFile(null)
+      await fetchVoiceIntakes()
+    } catch (err) {
+      setVoiceResult({ success: false, message: err instanceof Error ? err.message : 'Failed to create voice-note intake.' })
+    } finally {
+      setVoiceSubmitting(false)
+    }
+  }
+
+  const generateVoicePackage = async (intakeId: string) => {
+    setVoiceGeneratingId(intakeId)
+    setVoiceResult(null)
+    try {
+      const session = await getCurrentSession()
+      if (!session) return
+      const res = await fetch(`/api/admin/social-content/voice-notes/${intakeId}/generate`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${session.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ create_downstream_drafts: true }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to generate content package')
+      setVoiceResult({
+        success: true,
+        message: `Package generated with ${data.outputs?.length ?? 0} drafts and ${data.approvals?.length ?? 0} approval gates.`,
+        href: data.downstream?.socialContentId ? `/admin/social-content/${data.downstream.socialContentId}` : null,
+      })
+      await Promise.all([fetchVoiceIntakes(), fetchItems()])
+    } catch (err) {
+      setVoiceResult({ success: false, message: err instanceof Error ? err.message : 'Failed to generate content package.' })
+    } finally {
+      setVoiceGeneratingId(null)
+    }
   }
 
   const handleQuickApprove = async (e: React.MouseEvent, itemId: string) => {
@@ -557,6 +738,202 @@ function SocialContentQueuePage() {
                 {triggerResult.message}
               </div>
             )}
+          </motion.div>
+        )}
+      </div>
+
+      {/* Voice-note Package Intake */}
+      <div className="admin-console-card mb-6 rounded-lg border p-4">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <div className="flex items-center gap-2 text-sm font-semibold text-gray-200">
+              <Mic className="h-4 w-4 text-radiant-gold" />
+              Voice-note content packages
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Record a brainstorming note and generate LinkedIn, carousel, PowerPoint, script, audio, and HeyGen-ready drafts.
+            </p>
+          </div>
+          <button
+            onClick={() => setShowVoicePanel((p) => !p)}
+            className="admin-console-button-primary"
+          >
+            <Sparkles className="h-4 w-4" />
+            Build Package
+          </button>
+        </div>
+
+        {showVoicePanel && (
+          <motion.div
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: 'auto' }}
+            exit={{ opacity: 0, height: 0 }}
+            className="mt-4 grid gap-4 rounded-lg border border-silicon-slate bg-imperial-navy/55 p-5 xl:grid-cols-[minmax(0,1.1fr)_minmax(320px,0.9fr)]"
+          >
+            <div className="space-y-4">
+              <div className="grid gap-3 md:grid-cols-2">
+                <label className="block">
+                  <span className="mb-1 block text-xs text-gray-500">Title</span>
+                  <input
+                    value={voiceTitle}
+                    onChange={(e) => setVoiceTitle(e.target.value)}
+                    placeholder="Optional package title"
+                    className="w-full rounded-lg border border-silicon-slate bg-imperial-navy/70 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:border-radiant-gold/60"
+                  />
+                </label>
+                <label className="block">
+                  <span className="mb-1 block text-xs text-gray-500">Topic</span>
+                  <input
+                    value={voiceTopic}
+                    onChange={(e) => setVoiceTopic(e.target.value)}
+                    placeholder="Main idea or angle"
+                    className="w-full rounded-lg border border-silicon-slate bg-imperial-navy/70 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:border-radiant-gold/60"
+                  />
+                </label>
+              </div>
+
+              <input
+                value={voiceAudience}
+                onChange={(e) => setVoiceAudience(e.target.value)}
+                placeholder="Audience: founders, operators, nonprofit leaders, product teams..."
+                className="w-full rounded-lg border border-silicon-slate bg-imperial-navy/70 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:border-radiant-gold/60"
+              />
+
+              <textarea
+                value={voiceTranscript}
+                onChange={(e) => setVoiceTranscript(e.target.value)}
+                rows={6}
+                placeholder="Optional while recording. If left blank, the captured audio is transcribed server-side when OPENAI_API_KEY is configured."
+                className="w-full rounded-lg border border-silicon-slate bg-imperial-navy/70 px-3 py-2 text-sm leading-6 text-foreground placeholder:text-muted-foreground focus:outline-none focus:border-radiant-gold/60"
+              />
+
+              <div className="flex flex-wrap items-center gap-2">
+                <button
+                  type="button"
+                  onClick={isRecording ? stopVoiceRecording : startVoiceRecording}
+                  className={`inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-xs font-medium transition-colors ${
+                    isRecording
+                      ? 'border-red-500/50 bg-red-500/15 text-red-300'
+                      : 'border-radiant-gold/40 bg-radiant-gold/10 text-radiant-gold hover:bg-radiant-gold/20'
+                  }`}
+                >
+                  {isRecording ? <MicOff className="h-3.5 w-3.5" /> : <Mic className="h-3.5 w-3.5" />}
+                  {isRecording ? 'Stop Recording' : 'Record Natively'}
+                </button>
+                {voiceAudioFile && (
+                  <span className="truncate text-xs text-emerald-400">Captured: {voiceAudioFile.name}</span>
+                )}
+              </div>
+
+              <div>
+                <div className="mb-2 text-xs text-gray-500">Outputs</div>
+                <div className="flex flex-wrap gap-2">
+                  {VOICE_NOTE_OUTPUTS.map((output) => (
+                    <button
+                      key={output.value}
+                      type="button"
+                      onClick={() => toggleVoiceOutput(output.value)}
+                      className={`rounded-full border px-3 py-1 text-xs transition-colors ${
+                        voiceOutputs.includes(output.value)
+                          ? 'border-radiant-gold/60 bg-radiant-gold/15 text-radiant-gold'
+                          : 'border-silicon-slate text-gray-400 hover:border-gray-500'
+                      }`}
+                    >
+                      {output.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <div className="mb-2 text-xs text-gray-500">Frameworks</div>
+                <div className="grid gap-2 md:grid-cols-2">
+                  {contentFrameworks.map((framework) => (
+                    <button
+                      key={framework.id}
+                      type="button"
+                      onClick={() => toggleVoiceFramework(framework.id)}
+                      className={`rounded-lg border p-3 text-left transition-colors ${
+                        voiceFrameworks.includes(framework.id)
+                          ? 'border-radiant-gold/60 bg-radiant-gold/10'
+                          : 'border-silicon-slate hover:border-gray-500'
+                      }`}
+                    >
+                      <div className="text-xs font-semibold text-gray-200">{framework.creator_name}</div>
+                      <div className="mt-1 text-xs text-muted-foreground">{framework.display_name}</div>
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <button
+                onClick={submitVoiceIntake}
+                disabled={voiceSubmitting || (!voiceAudioFile && voiceTranscript.trim().length < 10) || voiceOutputs.length === 0}
+                className="admin-console-button-primary disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {voiceSubmitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+                Create Intake
+              </button>
+            </div>
+
+            <div className="space-y-3">
+              {voiceResult && (
+                <div className={`rounded-lg border px-3 py-2 text-sm ${
+                  voiceResult.success
+                    ? 'border-green-500/30 bg-green-500/10 text-green-300'
+                    : 'border-red-500/30 bg-red-500/10 text-red-300'
+                }`}>
+                  <div>{voiceResult.message}</div>
+                  {voiceResult.href && (
+                    <Link href={voiceResult.href} className="mt-2 inline-flex items-center gap-1 text-xs text-radiant-gold hover:underline">
+                      Open generated draft <Eye className="h-3 w-3" />
+                    </Link>
+                  )}
+                </div>
+              )}
+
+              <div className="rounded-lg border border-silicon-slate bg-background/30 p-3">
+                <div className="mb-3 flex items-center justify-between">
+                  <h3 className="text-sm font-semibold text-gray-200">Recent intakes</h3>
+                  <button onClick={fetchVoiceIntakes} className="text-xs text-radiant-gold hover:underline">Refresh</button>
+                </div>
+                {voiceLoading ? (
+                  <div className="flex justify-center py-6"><Loader2 className="h-5 w-5 animate-spin text-gray-500" /></div>
+                ) : voiceIntakes.length === 0 ? (
+                  <p className="py-6 text-center text-xs text-muted-foreground">No voice-note intakes yet.</p>
+                ) : (
+                  <div className="space-y-2">
+                    {voiceIntakes.map((intake) => (
+                      <div key={intake.id} className="rounded-lg border border-silicon-slate/80 bg-imperial-navy/50 p-3">
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <div className="truncate text-sm font-medium text-gray-200">{intake.title}</div>
+                            <div className="mt-1 flex flex-wrap gap-2 text-[10px] text-gray-500">
+                              <span>{intake.status.replace(/_/g, ' ')}</span>
+                              {intake.audio_file_name && <span>audio captured</span>}
+                              <span>{new Date(intake.created_at).toLocaleDateString()}</span>
+                            </div>
+                            <div className="mt-2 flex flex-wrap gap-1">
+                              {(intake.target_outputs ?? []).slice(0, 5).map((output) => (
+                                <span key={output} className="rounded-full bg-silicon-slate/70 px-2 py-0.5 text-[10px] text-gray-300">{output.replace(/_/g, ' ')}</span>
+                              ))}
+                            </div>
+                          </div>
+                          <button
+                            onClick={() => generateVoicePackage(intake.id)}
+                            disabled={voiceGeneratingId === intake.id}
+                            className="inline-flex shrink-0 items-center gap-1 rounded-lg border border-radiant-gold/40 px-2.5 py-1.5 text-xs text-radiant-gold hover:bg-radiant-gold/10 disabled:opacity-50"
+                          >
+                            {voiceGeneratingId === intake.id ? <Loader2 className="h-3 w-3 animate-spin" /> : <Sparkles className="h-3 w-3" />}
+                            Generate
+                          </button>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
           </motion.div>
         )}
       </div>

--- a/app/admin/social-content/page.tsx
+++ b/app/admin/social-content/page.tsx
@@ -141,7 +141,15 @@ function SocialContentQueuePage() {
   const [voiceLoading, setVoiceLoading] = useState(false)
   const [voiceSubmitting, setVoiceSubmitting] = useState(false)
   const [voiceGeneratingId, setVoiceGeneratingId] = useState<string | null>(null)
-  const [voiceResult, setVoiceResult] = useState<{ success: boolean; message: string; href?: string | null } | null>(null)
+  const [pptxGeneratingPackageId, setPptxGeneratingPackageId] = useState<string | null>(null)
+  const [voiceResult, setVoiceResult] = useState<{
+    success: boolean
+    message: string
+    href?: string | null
+    packageId?: string | null
+    agentRunId?: string | null
+    pptxUrl?: string | null
+  } | null>(null)
   const [isRecording, setIsRecording] = useState(false)
   const recorderRef = useRef<MediaRecorder | null>(null)
   const audioChunksRef = useRef<BlobPart[]>([])
@@ -384,12 +392,54 @@ function SocialContentQueuePage() {
         success: true,
         message: `Package generated with ${data.outputs?.length ?? 0} drafts and ${data.approvals?.length ?? 0} approval gates.`,
         href: data.downstream?.socialContentId ? `/admin/social-content/${data.downstream.socialContentId}` : null,
+        packageId: data.package?.id ?? null,
+        agentRunId: data.agentRunId ?? null,
       })
       await Promise.all([fetchVoiceIntakes(), fetchItems()])
     } catch (err) {
       setVoiceResult({ success: false, message: err instanceof Error ? err.message : 'Failed to generate content package.' })
     } finally {
       setVoiceGeneratingId(null)
+    }
+  }
+
+  const generatePptxArtifact = async (packageId: string) => {
+    setPptxGeneratingPackageId(packageId)
+    try {
+      const session = await getCurrentSession()
+      if (!session) return
+      const res = await fetch(`/api/admin/social-content/content-packages/${packageId}/pptx`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${session.access_token}`,
+          'Content-Type': 'application/json',
+        },
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        if (res.status === 403 && data.agentRunId) {
+          throw new Error('Media generation approval is required before creating the PPTX. Review the Agent Ops gate first.')
+        }
+        throw new Error(data.error || 'Failed to generate PPTX artifact')
+      }
+      setVoiceResult((current) => ({
+        success: true,
+        message: `PowerPoint generated: ${data.fileName ?? 'content-package.pptx'}`,
+        href: current?.href ?? null,
+        packageId,
+        agentRunId: current?.agentRunId ?? null,
+        pptxUrl: data.signedUrl ?? null,
+      }))
+    } catch (err) {
+      setVoiceResult((current) => ({
+        success: false,
+        message: err instanceof Error ? err.message : 'Failed to generate PPTX artifact.',
+        href: current?.href ?? null,
+        packageId,
+        agentRunId: current?.agentRunId ?? null,
+      }))
+    } finally {
+      setPptxGeneratingPackageId(null)
     }
   }
 
@@ -884,11 +934,34 @@ function SocialContentQueuePage() {
                     : 'border-red-500/30 bg-red-500/10 text-red-300'
                 }`}>
                   <div>{voiceResult.message}</div>
-                  {voiceResult.href && (
-                    <Link href={voiceResult.href} className="mt-2 inline-flex items-center gap-1 text-xs text-radiant-gold hover:underline">
-                      Open generated draft <Eye className="h-3 w-3" />
-                    </Link>
-                  )}
+                  <div className="mt-2 flex flex-wrap items-center gap-3">
+                    {voiceResult.href && (
+                      <Link href={voiceResult.href} className="inline-flex items-center gap-1 text-xs text-radiant-gold hover:underline">
+                        Open generated draft <Eye className="h-3 w-3" />
+                      </Link>
+                    )}
+                    {voiceResult.agentRunId && (
+                      <Link href={`/admin/agents?run=${voiceResult.agentRunId}`} className="inline-flex items-center gap-1 text-xs text-radiant-gold hover:underline">
+                        Review gates <CheckCircle2 className="h-3 w-3" />
+                      </Link>
+                    )}
+                    {voiceResult.packageId && !voiceResult.pptxUrl && (
+                      <button
+                        type="button"
+                        onClick={() => generatePptxArtifact(voiceResult.packageId!)}
+                        disabled={pptxGeneratingPackageId === voiceResult.packageId}
+                        className="inline-flex items-center gap-1 text-xs text-radiant-gold hover:underline disabled:opacity-50"
+                      >
+                        {pptxGeneratingPackageId === voiceResult.packageId ? <Loader2 className="h-3 w-3 animate-spin" /> : <FileText className="h-3 w-3" />}
+                        Generate PPTX
+                      </button>
+                    )}
+                    {voiceResult.pptxUrl && (
+                      <a href={voiceResult.pptxUrl} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1 text-xs text-radiant-gold hover:underline">
+                        Open PowerPoint <FileText className="h-3 w-3" />
+                      </a>
+                    )}
+                  </div>
                 </div>
               )}
 

--- a/app/admin/social-content/page.tsx
+++ b/app/admin/social-content/page.tsx
@@ -390,7 +390,9 @@ function SocialContentQueuePage() {
       if (!res.ok) throw new Error(data.error || 'Failed to generate content package')
       setVoiceResult({
         success: true,
-        message: `Package generated with ${data.outputs?.length ?? 0} drafts and ${data.approvals?.length ?? 0} approval gates.`,
+        message: data.alreadyGenerated
+          ? 'Package already generated for this intake. Review the existing gates or artifact.'
+          : `Package generated with ${data.outputs?.length ?? 0} drafts and ${data.approvals?.length ?? 0} approval gates.`,
         href: data.downstream?.socialContentId ? `/admin/social-content/${data.downstream.socialContentId}` : null,
         packageId: data.package?.id ?? null,
         agentRunId: data.agentRunId ?? null,
@@ -992,6 +994,11 @@ function SocialContentQueuePage() {
                               ))}
                             </div>
                           </div>
+                          {intake.status === 'packet_generated' ? (
+                            <span className="inline-flex shrink-0 items-center gap-1 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-1.5 text-xs text-emerald-300">
+                              Generated
+                            </span>
+                          ) : (
                           <button
                             onClick={() => generateVoicePackage(intake.id)}
                             disabled={voiceGeneratingId === intake.id}
@@ -1000,6 +1007,7 @@ function SocialContentQueuePage() {
                             {voiceGeneratingId === intake.id ? <Loader2 className="h-3 w-3 animate-spin" /> : <Sparkles className="h-3 w-3" />}
                             Generate
                           </button>
+                          )}
                         </div>
                       </div>
                     ))}

--- a/app/admin/social-content/page.tsx
+++ b/app/admin/social-content/page.tsx
@@ -941,7 +941,7 @@ function SocialContentQueuePage() {
                       </Link>
                     )}
                     {voiceResult.agentRunId && (
-                      <Link href={`/admin/agents?run=${voiceResult.agentRunId}`} className="inline-flex items-center gap-1 text-xs text-radiant-gold hover:underline">
+                      <Link href={`/admin/agents/runs/${voiceResult.agentRunId}`} className="inline-flex items-center gap-1 text-xs text-radiant-gold hover:underline">
                         Review gates <CheckCircle2 className="h-3 w-3" />
                       </Link>
                     )}

--- a/app/api/admin/social-content/content-packages/[id]/pptx/route.ts
+++ b/app/api/admin/social-content/content-packages/[id]/pptx/route.ts
@@ -1,0 +1,166 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { supabaseAdmin } from '@/lib/supabase'
+import { CONTENT_PACKAGE_APPROVAL_TYPES } from '@/lib/content-packages'
+import {
+  buildContentPackagePptxBuffer,
+  contentPackagePptxFileName,
+  type ContentPackagePptxOutput,
+} from '@/lib/content-package-pptx'
+
+export const dynamic = 'force-dynamic'
+
+interface PackageOutputRow {
+  id: string
+  output_type: string
+  title: string | null
+  body: string | null
+  payload: unknown
+  status: string | null
+  metadata: unknown
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const auth = await verifyAdmin(request)
+    if (isAuthError(auth)) {
+      return NextResponse.json({ error: auth.error }, { status: auth.status })
+    }
+
+    const { data: contentPackage, error: packageError } = await supabaseAdmin
+      .from('content_packages')
+      .select('id, title, agent_run_id, source_packet, research_packet, presentation_plan, metadata')
+      .eq('id', params.id)
+      .single()
+
+    if (packageError || !contentPackage?.id) {
+      return NextResponse.json({ error: 'Content package not found' }, { status: 404 })
+    }
+
+    const { data: approval, error: approvalError } = await supabaseAdmin
+      .from('agent_approvals')
+      .select('id, status, approval_type')
+      .eq('run_id', contentPackage.agent_run_id)
+      .eq('approval_type', CONTENT_PACKAGE_APPROVAL_TYPES.media)
+      .maybeSingle()
+
+    if (approvalError) {
+      console.error('[content-packages:pptx] approval lookup failed:', approvalError)
+      return NextResponse.json({ error: 'Failed to verify media-generation approval' }, { status: 500 })
+    }
+
+    if (approval?.status !== 'approved') {
+      return NextResponse.json({
+        error: 'Media generation approval is required before creating the PPTX artifact.',
+        approvalRequired: CONTENT_PACKAGE_APPROVAL_TYPES.media,
+        agentRunId: contentPackage.agent_run_id,
+      }, { status: 403 })
+    }
+
+    const { data: outputs, error: outputsError } = await supabaseAdmin
+      .from('content_package_outputs')
+      .select('id, output_type, title, body, payload, status, metadata')
+      .eq('package_id', contentPackage.id)
+      .order('created_at', { ascending: true })
+
+    if (outputsError) {
+      console.error('[content-packages:pptx] outputs lookup failed:', outputsError)
+      return NextResponse.json({ error: 'Failed to load content package outputs' }, { status: 500 })
+    }
+
+    const outputRows = (outputs ?? []) as PackageOutputRow[]
+    const deckOutput = outputRows.find((output) => output.output_type === 'pptx_deck')
+    if (!deckOutput) {
+      return NextResponse.json({ error: 'This package did not request a PowerPoint output.' }, { status: 400 })
+    }
+
+    const fileName = contentPackagePptxFileName(contentPackage.title)
+    const buffer = await buildContentPackagePptxBuffer({
+      title: contentPackage.title,
+      sourcePacket: asRecord(contentPackage.source_packet),
+      researchPacket: asRecord(contentPackage.research_packet),
+      presentationPlan: asRecord(contentPackage.presentation_plan),
+      outputs: outputRows.map((output) => ({
+        output_type: String(output.output_type),
+        title: String(output.title ?? output.output_type),
+        body: typeof output.body === 'string' ? output.body : null,
+        payload: asRecord(output.payload),
+      })) satisfies ContentPackagePptxOutput[],
+    })
+
+    const storagePath = `content-packages/${contentPackage.id}/${Date.now()}-${fileName}`
+    const { data: upload, error: uploadError } = await supabaseAdmin.storage
+      .from('documents')
+      .upload(storagePath, buffer, {
+        contentType: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+        cacheControl: '3600',
+        upsert: false,
+      })
+
+    if (uploadError || !upload?.path) {
+      console.error('[content-packages:pptx] upload failed:', uploadError)
+      return NextResponse.json({ error: 'Failed to upload generated PPTX' }, { status: 500 })
+    }
+
+    const payload = asRecord(deckOutput.payload)
+    const metadata = asRecord(deckOutput.metadata)
+    const { error: updateError } = await supabaseAdmin
+      .from('content_package_outputs')
+      .update({
+        status: 'generated',
+        approval_id: approval.id,
+        downstream_type: 'documents',
+        downstream_id: upload.path,
+        payload: {
+          ...payload,
+          pptx_storage_path: upload.path,
+          pptx_file_name: fileName,
+          generated_at: new Date().toISOString(),
+          generated_by_user_id: auth.user.id,
+        },
+        metadata: {
+          ...metadata,
+          generated_artifact_type: 'pptx',
+          approval_id: approval.id,
+        },
+      })
+      .eq('id', deckOutput.id)
+
+    if (updateError) {
+      console.error('[content-packages:pptx] output update failed:', updateError)
+      return NextResponse.json({ error: 'PPTX created but package output update failed' }, { status: 500 })
+    }
+
+    const { data: signed, error: signedError } = await supabaseAdmin.storage
+      .from('documents')
+      .createSignedUrl(upload.path, 3600)
+
+    if (signedError || !signed?.signedUrl) {
+      console.error('[content-packages:pptx] signed URL failed:', signedError)
+      return NextResponse.json({
+        packageId: contentPackage.id,
+        storagePath: upload.path,
+        fileName,
+      })
+    }
+
+    return NextResponse.json({
+      packageId: contentPackage.id,
+      storagePath: upload.path,
+      fileName,
+      signedUrl: signed.signedUrl,
+    })
+  } catch (error) {
+    console.error('[content-packages:pptx] generate error:', error)
+    const message = error instanceof Error ? error.message : String(error)
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return value as Record<string, unknown>
+}

--- a/app/api/admin/social-content/voice-notes/[id]/generate/route.ts
+++ b/app/api/admin/social-content/voice-notes/[id]/generate/route.ts
@@ -1,0 +1,353 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { supabaseAdmin } from '@/lib/supabase'
+import {
+  buildContentPackage,
+  CONTENT_PACKAGE_APPROVAL_TYPES,
+  type ContentPackageOutputDraft,
+} from '@/lib/content-packages'
+import {
+  recordAgentStep,
+  startAgentRun,
+} from '@/lib/agent-run'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  let runId: string | null = null
+  try {
+    const auth = await verifyAdmin(request)
+    if (isAuthError(auth)) {
+      return NextResponse.json({ error: auth.error }, { status: auth.status })
+    }
+
+    const body = await request.json().catch(() => ({})) as {
+      chronicle_notes?: string[]
+      create_downstream_drafts?: boolean
+    }
+
+    const { data: intake, error: intakeError } = await supabaseAdmin
+      .from('social_idea_intakes')
+      .select('*')
+      .eq('id', params.id)
+      .single()
+
+    if (intakeError || !intake?.id) {
+      return NextResponse.json({ error: 'Voice-note intake not found' }, { status: 404 })
+    }
+
+    const run = await startAgentRun({
+      agentKey: 'voice-content-architect',
+      runtime: 'manual',
+      kind: 'voice_note_content_package',
+      title: `Generate content package: ${intake.title}`,
+      subject: { type: 'social_idea_intake', id: intake.id, label: intake.title },
+      triggerSource: 'admin_social_content_voice_note_generate',
+      triggeredByUserId: auth.user.id,
+      currentStep: 'Building source-backed content package',
+      metadata: {
+        intake_id: intake.id,
+        target_outputs: intake.target_outputs ?? [],
+        framework_ids: intake.framework_ids ?? [],
+      },
+      idempotencyKey: `voice-note-content-package:${intake.id}`,
+    })
+    runId = run.id
+
+    const generated = buildContentPackage({
+      title: intake.title,
+      transcriptText: intake.transcript_text,
+      topicHint: intake.topic_hint,
+      targetAudience: intake.target_audience,
+      targetOutputs: intake.target_outputs,
+      frameworkIds: intake.framework_ids,
+      audioStoragePath: intake.audio_storage_path,
+      audioFileName: intake.audio_file_name,
+      chronicleNotes: Array.isArray(body.chronicle_notes) ? body.chronicle_notes : [],
+    })
+
+    await recordAgentStep({
+      runId,
+      stepKey: 'content_package_built',
+      name: 'Content package built',
+      status: 'completed',
+      inputSummary: String(intake.transcript_text ?? '').slice(0, 240),
+      outputSummary: `${generated.outputs.length} output draft(s): ${generated.targetOutputs.join(', ')}`,
+      metadata: {
+        title: generated.title,
+        output_types: generated.outputs.map((output) => output.outputType),
+        framework_ids: generated.frameworkIds,
+      },
+      idempotencyKey: `${runId}:content_package_built`,
+    }).catch((error) => console.warn('[voice-notes] agent step failed:', error))
+
+    const downstream = body.create_downstream_drafts === false
+      ? {}
+      : await createDownstreamDrafts(generated.outputs, generated.title, intake.id)
+
+    const approvalIds = await createApprovalGates({
+      runId,
+      title: generated.title,
+      intakeId: intake.id,
+      outputTypes: generated.outputs.map((output) => output.outputType),
+      createdByAgentKey: 'voice-content-architect',
+    })
+
+    const { data: contentPackage, error: packageError } = await supabaseAdmin
+      .from('content_packages')
+      .insert({
+        intake_id: intake.id,
+        agent_run_id: runId,
+        title: generated.title,
+        status: 'waiting_script_approval',
+        source_packet: generated.sourcePacket,
+        research_packet: generated.researchPacket,
+        framework_ids: generated.frameworkIds,
+        target_outputs: generated.targetOutputs,
+        approval_ids: approvalIds,
+        social_content_id: downstream.socialContentId ?? null,
+        video_idea_id: downstream.videoIdeaId ?? null,
+        presentation_plan: generated.presentationPlan,
+        created_by: auth.user.id,
+        metadata: {
+          downstream_created: Boolean(body.create_downstream_drafts !== false),
+          approval_types: CONTENT_PACKAGE_APPROVAL_TYPES,
+        },
+      })
+      .select('id, title, status, social_content_id, video_idea_id, created_at')
+      .single()
+
+    if (packageError || !contentPackage?.id) {
+      console.error('[voice-notes] package insert failed:', packageError)
+      return NextResponse.json({ error: 'Failed to create content package' }, { status: 500 })
+    }
+
+    const outputs = generated.outputs.map((output) => ({
+      package_id: contentPackage.id,
+      output_type: output.outputType,
+      status: 'waiting_approval',
+      title: output.title,
+      body: output.body,
+      payload: output.payload,
+      downstream_type: output.downstreamType ?? null,
+      downstream_id: downstreamIdForOutput(output, downstream),
+      metadata: {
+        required_approval: output.requiredApproval,
+        approval_type: CONTENT_PACKAGE_APPROVAL_TYPES[output.requiredApproval],
+      },
+    }))
+
+    const { error: outputsError } = await supabaseAdmin
+      .from('content_package_outputs')
+      .insert(outputs)
+
+    if (outputsError) {
+      console.error('[voice-notes] output insert failed:', outputsError)
+      return NextResponse.json({ error: 'Failed to create package outputs' }, { status: 500 })
+    }
+
+    await Promise.all([
+      supabaseAdmin
+        .from('social_idea_intakes')
+        .update({ status: 'packet_generated', updated_at: new Date().toISOString() })
+        .eq('id', intake.id),
+      supabaseAdmin
+        .from('agent_runs')
+        .update({
+          status: 'waiting_for_approval',
+          current_step: 'Approval required: content package script packet',
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', runId),
+    ])
+
+    return NextResponse.json({
+      package: contentPackage,
+      agentRunId: runId,
+      approvals: approvalIds,
+      downstream,
+      outputs: generated.outputs.map((output) => ({
+        outputType: output.outputType,
+        title: output.title,
+      })),
+    })
+  } catch (error) {
+    console.error('[voice-notes] generate error:', error)
+    const message = error instanceof Error ? error.message : String(error)
+    if (runId) {
+      await supabaseAdmin
+        .from('agent_runs')
+        .update({
+          status: 'failed',
+          current_step: 'Content package generation failed',
+          error_message: message,
+          completed_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', runId)
+        .catch(() => {})
+    }
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}
+
+async function createDownstreamDrafts(
+  outputs: ContentPackageOutputDraft[],
+  title: string,
+  intakeId: string,
+): Promise<{ socialContentId?: string; videoIdeaId?: string }> {
+  const linkedin = outputs.find((output) => output.outputType === 'linkedin_post')
+  const carousel = outputs.find((output) => output.outputType === 'linkedin_carousel')
+  const video = outputs.find((output) => output.outputType === 'video_script')
+  const downstream: { socialContentId?: string; videoIdeaId?: string } = {}
+
+  if (linkedin || carousel) {
+    const source = linkedin ?? carousel!
+    const payload = source.payload
+    const { data, error } = await supabaseAdmin
+      .from('social_content_queue')
+      .insert({
+        platform: 'linkedin',
+        status: 'draft',
+        post_text: source.body,
+        companion_post_text: carousel?.body ?? null,
+        cta_text: typeof payload.cta_text === 'string' ? payload.cta_text : 'Where could this kind of system remove burden in your work right now?',
+        cta_url: null,
+        hashtags: Array.isArray(payload.hashtags) ? payload.hashtags : ['#AIProduct', '#ProductManagement', '#AmadutownAdvisory'],
+        image_prompt: `Create an AmaduTown-branded framework visual for: ${title}`,
+        framework_visual_type: 'cycle',
+        voiceover_text: video?.body ?? source.body,
+        topic_extracted: {
+          topic: title,
+          angle: 'Voice-note content package',
+          key_insight: 'One source idea can become governed multi-format content.',
+          personal_tie_in: 'Uses Vambah voice guidance, AmaduTown proof surfaces, and Agent Ops approvals.',
+          framework_visual: 'cycle',
+        },
+        hormozi_framework: {
+          framework_type: 'value_equation',
+          hook_type: 'practical_tension',
+          proof_pattern: 'source_packet_to_outputs',
+          cta_pattern: 'operator_question',
+        },
+        rag_context: {
+          source: 'voice_note_content_package',
+          intake_id: intakeId,
+          approval_required_for: ['script_packet', 'media_generation', 'publish'],
+        },
+        admin_notes: [
+          'Generated from voice-note content package.',
+          'Draft only. Publishing requires content_package_publish approval.',
+          'Media generation requires content_package_media_generation approval.',
+        ].join('\n'),
+        target_platforms: ['linkedin'],
+        video_generation_method: video ? 'heygen_avatar' : 'none',
+        content_format: carousel ? 'carousel' : 'single_image',
+        content_pillar: 'ai_product_management',
+        carousel_slides: carousel?.payload?.slides ?? null,
+      })
+      .select('id')
+      .single()
+
+    if (error) {
+      console.error('[voice-notes] social draft insert failed:', error)
+    } else if (data?.id) {
+      downstream.socialContentId = String(data.id)
+    }
+  }
+
+  if (video) {
+    const { data, error } = await supabaseAdmin
+      .from('video_ideas_queue')
+      .insert({
+        title,
+        script_text: video.body,
+        storyboard_json: video.payload.storyboard ?? { scenes: [] },
+        source: 'manual',
+        status: 'pending',
+        custom_prompt: `Voice-note content package ${intakeId}`,
+      })
+      .select('id')
+      .single()
+
+    if (error) {
+      console.error('[voice-notes] video idea insert failed:', error)
+    } else if (data?.id) {
+      downstream.videoIdeaId = String(data.id)
+    }
+  }
+
+  return downstream
+}
+
+async function createApprovalGates(input: {
+  runId: string
+  title: string
+  intakeId: string
+  outputTypes: string[]
+  createdByAgentKey: string
+}): Promise<string[]> {
+  const rows = [
+    {
+      approval_type: CONTENT_PACKAGE_APPROVAL_TYPES.script,
+      label: 'Approve script and source packet',
+      risk_level: 'medium',
+      side_effect_boundary: 'Approves editorial source packet only. Does not call paid media providers or publish.',
+      executes_action: false,
+    },
+    {
+      approval_type: CONTENT_PACKAGE_APPROVAL_TYPES.media,
+      label: 'Approve media and deck generation',
+      risk_level: 'high',
+      side_effect_boundary: 'Allows generation jobs such as PPTX/deck packaging, ElevenLabs audio, and HeyGen video. Does not publish.',
+      executes_action: true,
+    },
+    {
+      approval_type: CONTENT_PACKAGE_APPROVAL_TYPES.publish,
+      label: 'Approve public publishing',
+      risk_level: 'high',
+      side_effect_boundary: 'Allows final outbound publishing or delivery after review.',
+      executes_action: true,
+    },
+  ]
+
+  const { data, error } = await supabaseAdmin
+    .from('agent_approvals')
+    .insert(rows.map((row) => ({
+      run_id: input.runId,
+      approval_type: row.approval_type,
+      status: 'pending',
+      requested_by_agent_key: input.createdByAgentKey,
+      metadata: {
+        label: row.label,
+        risk_level: row.risk_level,
+        executes_action: row.executes_action,
+        side_effect_boundary: row.side_effect_boundary,
+        action_payload: {
+          content_package_title: input.title,
+          intake_id: input.intakeId,
+          output_types: input.outputTypes,
+          approval_type: row.approval_type,
+        },
+      },
+    })))
+    .select('id')
+
+  if (error) {
+    console.error('[voice-notes] approval insert failed:', error)
+    throw new Error('Failed to create content package approvals.')
+  }
+  return (data ?? []).map((row: { id: string }) => row.id)
+}
+
+function downstreamIdForOutput(
+  output: ContentPackageOutputDraft,
+  downstream: { socialContentId?: string; videoIdeaId?: string },
+) {
+  if (output.downstreamType === 'social_content_queue') return downstream.socialContentId ?? null
+  if (output.downstreamType === 'video_ideas_queue') return downstream.videoIdeaId ?? null
+  return null
+}

--- a/app/api/admin/social-content/voice-notes/[id]/generate/route.ts
+++ b/app/api/admin/social-content/voice-notes/[id]/generate/route.ts
@@ -39,6 +39,31 @@ export async function POST(
       return NextResponse.json({ error: 'Voice-note intake not found' }, { status: 404 })
     }
 
+    const { data: existingPackage, error: existingPackageError } = await supabaseAdmin
+      .from('content_packages')
+      .select('id, title, status, social_content_id, video_idea_id, agent_run_id, created_at')
+      .eq('intake_id', intake.id)
+      .maybeSingle()
+
+    if (existingPackageError) {
+      console.error('[voice-notes] package lookup failed:', existingPackageError)
+      return NextResponse.json({ error: 'Failed to check existing content package' }, { status: 500 })
+    }
+
+    if (existingPackage?.id) {
+      return NextResponse.json({
+        package: existingPackage,
+        agentRunId: existingPackage.agent_run_id ?? null,
+        alreadyGenerated: true,
+        approvals: [],
+        downstream: {
+          socialContentId: existingPackage.social_content_id ?? undefined,
+          videoIdeaId: existingPackage.video_idea_id ?? undefined,
+        },
+        outputs: [],
+      })
+    }
+
     const run = await startAgentRun({
       agentKey: 'voice-content-architect',
       runtime: 'manual',

--- a/app/api/admin/social-content/voice-notes/route.ts
+++ b/app/api/admin/social-content/voice-notes/route.ts
@@ -1,0 +1,246 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { supabaseAdmin } from '@/lib/supabase'
+import {
+  DEFAULT_CONTENT_FRAMEWORKS,
+  normalizeContentPackageOutputs,
+} from '@/lib/content-packages'
+
+export const dynamic = 'force-dynamic'
+
+const MAX_AUDIO_BYTES = 50 * 1024 * 1024
+const AUDIO_TYPES = new Set([
+  'audio/mpeg',
+  'audio/mp3',
+  'audio/mp4',
+  'audio/wav',
+  'audio/x-wav',
+  'audio/webm',
+  'audio/ogg',
+  'video/webm',
+])
+
+export async function GET(request: NextRequest) {
+  try {
+    const auth = await verifyAdmin(request)
+    if (isAuthError(auth)) {
+      return NextResponse.json({ error: auth.error }, { status: auth.status })
+    }
+
+    const limit = Math.min(Math.max(Number(request.nextUrl.searchParams.get('limit')) || 10, 1), 50)
+
+    const [intakesResult, frameworksResult] = await Promise.all([
+      supabaseAdmin
+        .from('social_idea_intakes')
+        .select('id, title, source_type, topic_hint, target_audience, target_outputs, framework_ids, status, audio_file_name, created_at')
+        .order('created_at', { ascending: false })
+        .limit(limit),
+      supabaseAdmin
+        .from('content_frameworks')
+        .select('id, display_name, creator_name, category, summary, usage_guidance, source_urls, is_active, metadata')
+        .eq('is_active', true)
+        .order('display_name', { ascending: true }),
+    ])
+
+    if (intakesResult.error) {
+      console.error('[voice-notes] intake list failed:', intakesResult.error)
+      return NextResponse.json({ error: 'Failed to list voice-note intakes' }, { status: 500 })
+    }
+
+    const frameworks = frameworksResult.error || !frameworksResult.data?.length
+      ? DEFAULT_CONTENT_FRAMEWORKS.map((framework) => ({
+          id: framework.id,
+          display_name: framework.displayName,
+          creator_name: framework.creatorName,
+          category: framework.category,
+          summary: framework.summary,
+          usage_guidance: framework.usageGuidance,
+          source_urls: framework.sourceUrls,
+          is_active: true,
+          metadata: framework.metadata ?? {},
+        }))
+      : frameworksResult.data
+
+    return NextResponse.json({
+      intakes: intakesResult.data ?? [],
+      frameworks,
+    })
+  } catch (error) {
+    console.error('[voice-notes] list error:', error)
+    const message = error instanceof Error ? error.message : String(error)
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await verifyAdmin(request)
+    if (isAuthError(auth)) {
+      return NextResponse.json({ error: auth.error }, { status: auth.status })
+    }
+
+    const contentType = request.headers.get('content-type') ?? ''
+    const payload = contentType.includes('multipart/form-data')
+      ? await parseMultipart(request, auth.user.id)
+      : await parseJson(request)
+
+    const transcriptText = String(payload.transcript_text ?? '').trim()
+    if (transcriptText.length < 10) {
+      return NextResponse.json({ error: 'Transcript or notes must be at least 10 characters.' }, { status: 400 })
+    }
+
+    const title = String(payload.title || payload.topic_hint || transcriptText.slice(0, 72)).trim()
+    const targetOutputs = normalizeContentPackageOutputs(payload.target_outputs)
+    const frameworkIds = normalizeStringArray(payload.framework_ids)
+
+    const { data, error } = await supabaseAdmin
+      .from('social_idea_intakes')
+      .insert({
+        title,
+        source_type: payload.audio_storage_path ? 'voice_note' : 'text_note',
+        transcript_text: transcriptText,
+        audio_storage_path: payload.audio_storage_path ?? null,
+        audio_file_name: payload.audio_file_name ?? null,
+        topic_hint: payload.topic_hint ?? null,
+        target_audience: payload.target_audience ?? null,
+        target_outputs: targetOutputs,
+        framework_ids: frameworkIds,
+        created_by: auth.user.id,
+        metadata: {
+          intake_surface: 'admin_social_content_voice_notes',
+          audio_content_type: payload.audio_content_type ?? null,
+        },
+      })
+      .select('id, title, status, target_outputs, framework_ids, created_at')
+      .single()
+
+    if (error || !data?.id) {
+      console.error('[voice-notes] create failed:', error)
+      return NextResponse.json({ error: 'Failed to create voice-note intake' }, { status: 500 })
+    }
+
+    return NextResponse.json({ intake: data })
+  } catch (error) {
+    console.error('[voice-notes] create error:', error)
+    const message = error instanceof Error ? error.message : String(error)
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}
+
+async function parseJson(request: NextRequest) {
+  const body = await request.json().catch(() => ({}))
+  return {
+    title: stringOrNull(body.title),
+    transcript_text: stringOrNull(body.transcript_text),
+    topic_hint: stringOrNull(body.topic_hint),
+    target_audience: stringOrNull(body.target_audience),
+    target_outputs: normalizeStringArray(body.target_outputs),
+    framework_ids: normalizeStringArray(body.framework_ids),
+    audio_storage_path: stringOrNull(body.audio_storage_path),
+    audio_file_name: stringOrNull(body.audio_file_name),
+    audio_content_type: stringOrNull(body.audio_content_type),
+  }
+}
+
+async function parseMultipart(request: NextRequest, userId: string) {
+  const formData = await request.formData()
+  const file = formData.get('audio')
+  let transcriptText = stringOrNull(formData.get('transcript_text'))
+  let audioStoragePath: string | null = null
+  let audioFileName: string | null = null
+  let audioContentType: string | null = null
+
+  if (file instanceof File && file.size > 0) {
+    if (file.size > MAX_AUDIO_BYTES) {
+      throw new Error('Audio file must be less than 50MB.')
+    }
+    if (!AUDIO_TYPES.has(file.type)) {
+      throw new Error('Unsupported audio type. Use mp3, wav, m4a, webm, or ogg.')
+    }
+
+    const extension = file.name.split('.').pop()?.replace(/[^a-zA-Z0-9]/g, '').toLowerCase() || 'webm'
+    const safeName = file.name.replace(/[^a-zA-Z0-9.-]/g, '_').slice(0, 120)
+    const storagePath = `social-voice-notes/${userId}/${Date.now()}-${safeName || `voice-note.${extension}`}`
+    const buffer = Buffer.from(await file.arrayBuffer())
+    if (!transcriptText) {
+      transcriptText = await transcribeAudioBuffer(buffer, file.name, file.type)
+    }
+    const { data, error } = await supabaseAdmin.storage
+      .from('documents')
+      .upload(storagePath, buffer, {
+        contentType: file.type,
+        cacheControl: '3600',
+        upsert: false,
+      })
+
+    if (error || !data?.path) {
+      console.error('[voice-notes] audio upload failed:', error)
+      throw new Error('Failed to upload voice-note audio.')
+    }
+
+    audioStoragePath = data.path
+    audioFileName = file.name
+    audioContentType = file.type
+  }
+
+  return {
+    title: stringOrNull(formData.get('title')),
+    transcript_text: transcriptText,
+    topic_hint: stringOrNull(formData.get('topic_hint')),
+    target_audience: stringOrNull(formData.get('target_audience')),
+    target_outputs: normalizeStringArray(formData.getAll('target_outputs')),
+    framework_ids: normalizeStringArray(formData.getAll('framework_ids')),
+    audio_storage_path: audioStoragePath,
+    audio_file_name: audioFileName,
+    audio_content_type: audioContentType,
+  }
+}
+
+async function transcribeAudioBuffer(buffer: Buffer, fileName: string, contentType: string): Promise<string> {
+  const apiKey = process.env.OPENAI_API_KEY
+  if (!apiKey) {
+    throw new Error('OPENAI_API_KEY is required to transcribe audio-only voice notes. Add rough notes or configure transcription.')
+  }
+
+  const form = new FormData()
+  form.append('model', process.env.OPENAI_TRANSCRIBE_MODEL || 'gpt-4o-mini-transcribe')
+  form.append('response_format', 'json')
+  form.append(
+    'file',
+    new Blob([new Uint8Array(buffer)], { type: contentType || 'audio/webm' }),
+    fileName || 'voice-note.webm',
+  )
+
+  const response = await fetch('https://api.openai.com/v1/audio/transcriptions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: form,
+  })
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '')
+    console.error('[voice-notes] transcription failed:', text.slice(0, 500))
+    throw new Error('Audio transcription failed. Add rough notes and try again.')
+  }
+
+  const data = await response.json() as { text?: string }
+  const transcript = typeof data.text === 'string' ? data.text.trim() : ''
+  if (!transcript) {
+    throw new Error('Audio transcription returned no text. Add rough notes and try again.')
+  }
+  return transcript
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function normalizeStringArray(value: unknown): string[] {
+  if (Array.isArray(value)) return value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0).map((item) => item.trim())
+  if (typeof value === 'string' && value.trim()) {
+    return value.split(',').map((item) => item.trim()).filter(Boolean)
+  }
+  return []
+}

--- a/lib/content-package-pptx.test.ts
+++ b/lib/content-package-pptx.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildContentPackagePptxBuffer,
+  contentPackagePptxFileName,
+} from './content-package-pptx'
+
+describe('content package pptx builder', () => {
+  it('generates a non-empty PowerPoint buffer', async () => {
+    const buffer = await buildContentPackagePptxBuffer({
+      title: 'Voice Notes Should Become Content Systems',
+      sourcePacket: {
+        source_type: 'voice_note',
+        topic: 'Voice-note content workflow',
+        transcript_excerpt: 'A raw voice note can become a LinkedIn post, a PowerPoint deck, a video script, and a governed approval packet.',
+        target_audience: 'operators and founders',
+        target_outputs: ['linkedin_post', 'pptx_deck', 'video_script'],
+        transcript_characters: 132,
+      },
+      researchPacket: {
+        framework_summary: [
+          { creator_name: 'Alex Hormozi', display_name: 'Value Equation' },
+          { creator_name: 'Nick Saraev', display_name: 'AI Content Engine' },
+        ],
+        amadutown_proof_routes: [
+          { label: 'Agent Ops Mission Control', route: '/admin/agents' },
+          { label: 'Social Content Queue', route: '/admin/social-content' },
+        ],
+        source_candidates: ['https://amadutown.com/'],
+        broll_hints: ['agent ops', 'social content'],
+      },
+      presentationPlan: {
+        requiredAssets: ['Agent Ops screenshot', 'Social Content Queue screenshot'],
+      },
+      outputs: [
+        {
+          output_type: 'linkedin_post',
+          title: 'LinkedIn',
+          body: 'A voice note is not just a reminder. It can be the first draft of a system.',
+          payload: {},
+        },
+        {
+          output_type: 'pptx_deck',
+          title: 'Deck',
+          body: 'Deck brief',
+          payload: {},
+        },
+        {
+          output_type: 'video_script',
+          title: 'Script',
+          body: 'At AmaduTown, the system has to capture the note and hold the publishing gate until a human approves it.',
+          payload: {},
+        },
+      ],
+    })
+
+    expect(buffer.length).toBeGreaterThan(40_000)
+    expect(buffer.subarray(0, 2).toString()).toBe('PK')
+  })
+
+  it('creates a safe deck filename', () => {
+    expect(contentPackagePptxFileName('Voice Notes: Content Systems!')).toBe('voice-notes-content-systems.pptx')
+  })
+})

--- a/lib/content-package-pptx.ts
+++ b/lib/content-package-pptx.ts
@@ -1,0 +1,262 @@
+import PptxGenJS from 'pptxgenjs'
+
+export interface ContentPackagePptxOutput {
+  output_type: string
+  title: string
+  body: string | null
+  payload: Record<string, unknown> | null
+}
+
+export interface ContentPackagePptxInput {
+  title: string
+  sourcePacket: Record<string, unknown>
+  researchPacket: Record<string, unknown>
+  presentationPlan: Record<string, unknown>
+  outputs: ContentPackagePptxOutput[]
+}
+
+const COLORS = {
+  navy: '071525',
+  ink: '111827',
+  slate: '334155',
+  muted: '64748B',
+  gold: 'D4AF37',
+  cream: 'F8F3E8',
+  white: 'FFFFFF',
+  line: 'CBD5E1',
+}
+
+export async function buildContentPackagePptxBuffer(input: ContentPackagePptxInput): Promise<Buffer> {
+  const pptx = new PptxGenJS()
+  pptx.layout = 'LAYOUT_WIDE'
+  pptx.author = 'AmaduTown Advisory'
+  pptx.company = 'AmaduTown Advisory'
+  pptx.subject = 'Voice-note content package'
+  pptx.title = input.title
+  pptx.theme = {
+    headFontFace: 'Aptos Display',
+    bodyFontFace: 'Aptos',
+  }
+
+  addCoverSlide(pptx, input)
+  addSourceSlide(pptx, input)
+  addFrameworkSlide(pptx, input)
+  addContentSlide(pptx, input)
+  addMediaSlide(pptx, input)
+  addApprovalSlide(pptx, input)
+  addAppendixSlide(pptx, input)
+
+  const stream = await pptx.write({ outputType: 'nodebuffer' })
+  if (Buffer.isBuffer(stream)) return stream
+  if (stream instanceof Uint8Array) return Buffer.from(stream)
+  if (stream instanceof ArrayBuffer) return Buffer.from(stream)
+  throw new Error('PPTX generation returned an unsupported output type.')
+}
+
+export function contentPackagePptxFileName(title: string): string {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 72) || 'content-package'
+  return `${slug}.pptx`
+}
+
+function addCoverSlide(pptx: PptxGenJS, input: ContentPackagePptxInput) {
+  const slide = pptx.addSlide()
+  paintHeader(slide, 'Voice-note content package')
+  slide.addText(input.title, {
+    x: 0.75,
+    y: 1.25,
+    w: 7.2,
+    h: 1.4,
+    fontFace: 'Aptos Display',
+    fontSize: 34,
+    bold: true,
+    color: COLORS.white,
+    breakLine: false,
+    fit: 'shrink',
+  })
+  slide.addText(String(input.sourcePacket.topic ?? input.sourcePacket.title ?? 'Source-backed content system'), {
+    x: 0.8,
+    y: 2.75,
+    w: 7.5,
+    h: 0.65,
+    fontSize: 15,
+    color: COLORS.cream,
+    fit: 'shrink',
+  })
+  slide.addShape(pptx.ShapeType.rect, {
+    x: 8.65,
+    y: 1.15,
+    w: 3.75,
+    h: 4.9,
+    fill: { color: COLORS.cream },
+    line: { color: COLORS.gold, width: 1 },
+  })
+  addStat(slide, 'Source', String(input.sourcePacket.source_type ?? 'voice_note'), 9, 1.55)
+  addStat(slide, 'Outputs', String(input.sourcePacket.target_outputs ? asList(input.sourcePacket.target_outputs).length : input.outputs.length), 9, 2.45)
+  addStat(slide, 'Approval gates', '3', 9, 3.35)
+  addStat(slide, 'Deck status', 'Draft', 9, 4.25)
+  addFooter(slide, 1)
+}
+
+function addSourceSlide(pptx: PptxGenJS, input: ContentPackagePptxInput) {
+  const slide = baseSlide(pptx, '01', 'The raw note stays attached to the work')
+  const excerpt = String(input.sourcePacket.transcript_excerpt ?? '')
+  slide.addText('Source excerpt', headingBox(0.8, 1.25, 4.8))
+  slide.addText(truncate(excerpt, 800), bodyBox(0.8, 1.75, 5.15, 4.5))
+  slide.addText('Operating boundary', headingBox(6.35, 1.25, 4.8))
+  slide.addText([
+    'Private corpus and Chronicle material inform framing.',
+    'Raw private material should not be quoted in public output without explicit approval.',
+    'The transcript, framework context, proof routes, and drafts remain separable.',
+  ].join('\n'), bulletBox(6.35, 1.75, 5.6, 2.35))
+  addMiniTable(slide, 6.35, 4.45, [
+    ['Audience', String(input.sourcePacket.target_audience ?? 'operators and builders')],
+    ['Audio', input.sourcePacket.audio_file_name ? String(input.sourcePacket.audio_file_name) : 'No audio file attached'],
+    ['Characters', String(input.sourcePacket.transcript_characters ?? 'n/a')],
+  ])
+  addFooter(slide, 2)
+}
+
+function addFrameworkSlide(pptx: PptxGenJS, input: ContentPackagePptxInput) {
+  const slide = baseSlide(pptx, '02', 'Frameworks structure the idea without erasing the voice')
+  const frameworks = asRecordArray(input.researchPacket.framework_summary)
+  const routes = asRecordArray(input.researchPacket.amadutown_proof_routes)
+  addSectionCard(slide, 0.8, 1.2, 5.45, 4.85, 'Framework influence', frameworks.length
+    ? frameworks.map((item) => `${item.creator_name ?? 'Framework'}: ${item.display_name ?? item.summary ?? ''}`).join('\n')
+    : 'Vambah voice system and AmaduTown operating proof.')
+  addSectionCard(slide, 6.65, 1.2, 5.45, 4.85, 'Portfolio proof routes', routes.length
+    ? routes.map((item) => `${item.label ?? 'Route'} - ${item.route ?? ''}`).join('\n')
+    : 'Agent Ops, Social Content Queue, Presentation Generator, and Video Generation surfaces.')
+  addFooter(slide, 3)
+}
+
+function addContentSlide(pptx: PptxGenJS, input: ContentPackagePptxInput) {
+  const slide = baseSlide(pptx, '03', 'One idea becomes platform-specific drafts')
+  const linkedin = input.outputs.find((output) => output.output_type === 'linkedin_post')
+  const carousel = input.outputs.find((output) => output.output_type === 'linkedin_carousel')
+  addSectionCard(slide, 0.75, 1.15, 5.75, 5.1, 'LinkedIn post', linkedin?.body ? truncate(linkedin.body, 900) : 'LinkedIn draft was not requested.')
+  const slides = asRecordArray(carousel?.payload?.slides)
+  addSectionCard(slide, 6.85, 1.15, 5.75, 5.1, 'Carousel spine', slides.length
+    ? slides.map((item, index) => `${index + 1}. ${item.headline ?? item.type ?? 'Slide'}`).join('\n')
+    : carousel?.body ?? 'Carousel draft was not requested.')
+  addFooter(slide, 4)
+}
+
+function addMediaSlide(pptx: PptxGenJS, input: ContentPackagePptxInput) {
+  const slide = baseSlide(pptx, '04', 'Media handoffs are ready, but provider calls stay gated')
+  const video = input.outputs.find((output) => output.output_type === 'video_script')
+  const heygen = input.outputs.find((output) => output.output_type === 'heygen_video')
+  const audio = input.outputs.find((output) => output.output_type === 'elevenlabs_audio')
+  addSectionCard(slide, 0.75, 1.15, 5.75, 5.1, 'Script excerpt', video?.body ? truncate(video.body, 850) : 'Video script was not requested.')
+  addSectionCard(slide, 6.85, 1.15, 5.75, 2.35, 'HeyGen handoff', heygen?.body ?? 'HeyGen handoff was not requested.')
+  addSectionCard(slide, 6.85, 3.9, 5.75, 2.35, 'ElevenLabs handoff', audio?.body ?? 'Audio handoff was not requested.')
+  addFooter(slide, 5)
+}
+
+function addApprovalSlide(pptx: PptxGenJS, input: ContentPackagePptxInput) {
+  const slide = baseSlide(pptx, '05', 'The swarm pauses at the right gates')
+  const steps = [
+    ['Script packet', 'Approve source packet, narrative, claims, and editorial direction.'],
+    ['Media generation', 'Allow PPTX storage, avatar/audio jobs, and render preparation.'],
+    ['Publishing', 'Approve public posting, sending, or delivery after final review.'],
+  ]
+  steps.forEach(([title, body], index) => {
+    const x = 0.85 + index * 4.15
+    slide.addShape(pptx.ShapeType.rect, {
+      x,
+      y: 1.55,
+      w: 3.65,
+      h: 3.65,
+      fill: { color: index === 1 ? COLORS.cream : COLORS.white },
+      line: { color: index === 1 ? COLORS.gold : COLORS.line, width: 1 },
+    })
+    slide.addText(`0${index + 1}`, { x: x + 0.25, y: 1.85, w: 0.75, h: 0.45, fontSize: 15, bold: true, color: COLORS.gold })
+    slide.addText(title, { x: x + 0.25, y: 2.35, w: 3.05, h: 0.45, fontSize: 17, bold: true, color: COLORS.ink, fit: 'shrink' })
+    slide.addText(body, { x: x + 0.25, y: 3.05, w: 3.05, h: 1.45, fontSize: 11, color: COLORS.slate, fit: 'shrink', breakLine: false })
+  })
+  const requested = input.outputs.map((output) => output.output_type.replace(/_/g, ' ')).join(', ')
+  slide.addText(`Requested outputs: ${requested}`, { x: 0.85, y: 5.75, w: 11.2, h: 0.4, fontSize: 10.5, color: COLORS.muted, fit: 'shrink' })
+  addFooter(slide, 6)
+}
+
+function addAppendixSlide(pptx: PptxGenJS, input: ContentPackagePptxInput) {
+  const slide = baseSlide(pptx, 'A', 'Source appendix for review')
+  const candidates = asList(input.researchPacket.source_candidates)
+  const broll = asList(input.researchPacket.broll_hints)
+  const planItems = asList(input.presentationPlan.requiredAssets)
+  addSectionCard(slide, 0.75, 1.15, 3.8, 5.1, 'Research candidates', candidates.length ? candidates.join('\n') : 'No source candidates attached.')
+  addSectionCard(slide, 4.75, 1.15, 3.8, 5.1, 'B-roll hints', broll.length ? broll.join('\n') : 'No b-roll hints attached.')
+  addSectionCard(slide, 8.75, 1.15, 3.8, 5.1, 'Deck proof assets', planItems.length ? planItems.join('\n') : 'No required assets attached.')
+  addFooter(slide, 7)
+}
+
+function paintHeader(slide: PptxGenJS.Slide, eyebrow: string) {
+  slide.background = { color: COLORS.navy }
+  slide.addShape('rect', { x: 0, y: 0, w: 13.33, h: 0.32, fill: { color: COLORS.gold }, line: { color: COLORS.gold } })
+  slide.addText('AMADUTOWN ADVISORY', { x: 0.75, y: 0.5, w: 3.2, h: 0.28, fontSize: 8.5, bold: true, color: COLORS.gold })
+  slide.addText(eyebrow.toUpperCase(), { x: 8.5, y: 0.5, w: 4.1, h: 0.28, fontSize: 8.5, color: COLORS.cream, align: 'right' })
+}
+
+function baseSlide(pptx: PptxGenJS, section: string, title: string) {
+  const slide = pptx.addSlide()
+  slide.background = { color: 'F8FAFC' }
+  slide.addShape('rect', { x: 0, y: 0, w: 13.33, h: 0.22, fill: { color: COLORS.gold }, line: { color: COLORS.gold } })
+  slide.addText(section, { x: 0.75, y: 0.48, w: 0.55, h: 0.35, fontSize: 10, bold: true, color: COLORS.gold })
+  slide.addText(title, { x: 1.35, y: 0.42, w: 10.8, h: 0.5, fontSize: 19, bold: true, color: COLORS.ink, fit: 'shrink' })
+  return slide
+}
+
+function addSectionCard(slide: PptxGenJS.Slide, x: number, y: number, w: number, h: number, title: string, body: string) {
+  slide.addShape('rect', { x, y, w, h, fill: { color: COLORS.white }, line: { color: COLORS.line, width: 1 } })
+  slide.addText(title, { x: x + 0.25, y: y + 0.25, w: w - 0.5, h: 0.38, fontSize: 12, bold: true, color: COLORS.ink, fit: 'shrink' })
+  slide.addShape('line', { x: x + 0.25, y: y + 0.78, w: w - 0.5, h: 0, line: { color: COLORS.gold, width: 1 } })
+  slide.addText(body, { x: x + 0.25, y: y + 1, w: w - 0.5, h: h - 1.25, fontSize: 10.5, color: COLORS.slate, fit: 'shrink', breakLine: false })
+}
+
+function addStat(slide: PptxGenJS.Slide, label: string, value: string, x: number, y: number) {
+  slide.addText(label.toUpperCase(), { x, y, w: 2.7, h: 0.25, fontSize: 7.5, bold: true, color: COLORS.muted })
+  slide.addText(value, { x, y: y + 0.28, w: 2.85, h: 0.45, fontSize: 16, bold: true, color: COLORS.ink, fit: 'shrink' })
+}
+
+function addMiniTable(slide: PptxGenJS.Slide, x: number, y: number, rows: Array<[string, string]>) {
+  rows.forEach(([label, value], index) => {
+    const rowY = y + index * 0.5
+    slide.addText(label, { x, y: rowY, w: 1.5, h: 0.3, fontSize: 9, bold: true, color: COLORS.muted })
+    slide.addText(value, { x: x + 1.65, y: rowY, w: 4, h: 0.3, fontSize: 9, color: COLORS.slate, fit: 'shrink' })
+  })
+}
+
+function addFooter(slide: PptxGenJS.Slide, page: number) {
+  slide.addText('Private draft - approval required before public use', { x: 0.75, y: 7.03, w: 6, h: 0.22, fontSize: 7.5, color: COLORS.muted })
+  slide.addText(String(page).padStart(2, '0'), { x: 12.2, y: 7.03, w: 0.45, h: 0.22, fontSize: 7.5, color: COLORS.muted, align: 'right' })
+}
+
+function headingBox(x: number, y: number, w: number) {
+  return { x, y, w, h: 0.35, fontSize: 13, bold: true, color: COLORS.ink, fit: 'shrink' as const }
+}
+
+function bodyBox(x: number, y: number, w: number, h: number) {
+  return { x, y, w, h, fontSize: 11, color: COLORS.slate, fit: 'shrink' as const, breakLine: false }
+}
+
+function bulletBox(x: number, y: number, w: number, h: number) {
+  return { x, y, w, h, fontSize: 11, color: COLORS.slate, fit: 'shrink' as const, breakLine: false, bullet: { type: 'bullet' as const } }
+}
+
+function asList(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value.map((item) => String(item ?? '').trim()).filter(Boolean)
+}
+
+function asRecordArray(value: unknown): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) return []
+  return value.filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === 'object' && !Array.isArray(item))
+}
+
+function truncate(value: string, max: number): string {
+  if (value.length <= max) return value
+  return `${value.slice(0, Math.max(0, max - 3)).trimEnd()}...`
+}

--- a/lib/content-packages.test.ts
+++ b/lib/content-packages.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildContentPackage,
+  CONTENT_PACKAGE_APPROVAL_TYPES,
+  normalizeContentPackageOutputs,
+} from './content-packages'
+
+describe('content package builder', () => {
+  it('normalizes requested outputs and falls back to defaults', () => {
+    expect(normalizeContentPackageOutputs(['linkedin_post', 'bogus', 'pptx_deck'])).toEqual([
+      'linkedin_post',
+      'pptx_deck',
+    ])
+    expect(normalizeContentPackageOutputs([])).toContain('linkedin_post')
+  })
+
+  it('builds a multi-format package from a voice-note transcript', () => {
+    const pkg = buildContentPackage({
+      title: 'Voice notes should become content systems',
+      transcriptText:
+        'I keep having ideas while I am moving between workstreams. The problem is that the insight stays trapped in a voice note instead of becoming a LinkedIn post, a PowerPoint, a script, and a governed approval packet.',
+      topicHint: 'Voice note content workflow',
+      targetOutputs: ['linkedin_post', 'pptx_deck', 'video_script', 'heygen_video', 'elevenlabs_audio'],
+      frameworkIds: ['alex-hormozi-value-equation', 'nick-saraev-ai-content-engine'],
+      chronicleNotes: ['Recent Portfolio work showed Agent Ops and video generation as useful proof surfaces.'],
+    })
+
+    expect(pkg.title).toBe('Voice notes should become content systems')
+    expect(pkg.frameworkIds).toEqual([
+      'alex-hormozi-value-equation',
+      'nick-saraev-ai-content-engine',
+    ])
+    expect(pkg.outputs.map((output) => output.outputType)).toEqual(expect.arrayContaining([
+      'linkedin_post',
+      'pptx_deck',
+      'video_script',
+      'heygen_video',
+      'elevenlabs_audio',
+    ]))
+    expect(pkg.researchPacket.chronicle).toMatchObject({ status: 'sanitized_notes_attached' })
+    expect(pkg.presentationPlan).toMatchObject({ recommendedTool: 'codex_pptx' })
+  })
+
+  it('keeps media and publishing actions behind explicit approval types', () => {
+    expect(CONTENT_PACKAGE_APPROVAL_TYPES).toEqual({
+      script: 'content_package_script_packet',
+      media: 'content_package_media_generation',
+      publish: 'content_package_publish',
+    })
+  })
+})

--- a/lib/content-packages.ts
+++ b/lib/content-packages.ts
@@ -1,0 +1,494 @@
+import {
+  buildPresentationBakeoffPlan,
+  type PresentationBakeoffInput,
+} from './presentation-bakeoff'
+
+export const CONTENT_PACKAGE_OUTPUT_TYPES = [
+  'linkedin_post',
+  'linkedin_carousel',
+  'pptx_deck',
+  'video_script',
+  'heygen_video',
+  'elevenlabs_audio',
+  'newsletter_blurb',
+  'email_draft',
+  'short_caption',
+] as const
+
+export type ContentPackageOutputType = (typeof CONTENT_PACKAGE_OUTPUT_TYPES)[number]
+
+export const CONTENT_PACKAGE_APPROVAL_TYPES = {
+  script: 'content_package_script_packet',
+  media: 'content_package_media_generation',
+  publish: 'content_package_publish',
+} as const
+
+export interface ContentFramework {
+  id: string
+  displayName: string
+  creatorName: string
+  category: string
+  summary: string
+  usageGuidance: string
+  sourceUrls: string[]
+  metadata?: Record<string, unknown>
+}
+
+export interface BuildContentPackageInput {
+  title?: string | null
+  transcriptText: string
+  topicHint?: string | null
+  targetAudience?: string | null
+  targetOutputs?: ContentPackageOutputType[]
+  frameworkIds?: string[]
+  chronicleNotes?: string[]
+  audioStoragePath?: string | null
+  audioFileName?: string | null
+}
+
+export interface ContentPackageOutputDraft {
+  outputType: ContentPackageOutputType
+  title: string
+  body: string
+  payload: Record<string, unknown>
+  requiredApproval: keyof typeof CONTENT_PACKAGE_APPROVAL_TYPES
+  downstreamType?: 'social_content_queue' | 'video_ideas_queue' | 'presentation_plan' | null
+}
+
+export interface GeneratedContentPackage {
+  title: string
+  sourcePacket: Record<string, unknown>
+  researchPacket: Record<string, unknown>
+  frameworkIds: string[]
+  targetOutputs: ContentPackageOutputType[]
+  outputs: ContentPackageOutputDraft[]
+  presentationPlan: Record<string, unknown>
+}
+
+export const DEFAULT_CONTENT_FRAMEWORKS: ContentFramework[] = [
+  {
+    id: 'alex-hormozi-value-equation',
+    displayName: 'Value Equation / Grand Slam Offer',
+    creatorName: 'Alex Hormozi',
+    category: 'offer_strategy',
+    summary: 'Frame value through dream outcome, perceived likelihood, time delay, and effort or sacrifice.',
+    usageGuidance: 'Use when an idea needs an offer, proof stack, guarantee, or business case.',
+    sourceUrls: ['https://www.acquisition.com/'],
+    metadata: { defaultVisual: 'equation' },
+  },
+  {
+    id: 'nick-saraev-ai-content-engine',
+    displayName: 'AI Content Engine / Creator Systems',
+    creatorName: 'Nick Saraev',
+    category: 'content_systems',
+    summary: 'Frame content production as a repeatable AI-assisted system from raw idea to platform-specific assets.',
+    usageGuidance: 'Use when one source idea should become posts, decks, scripts, audio, and short-form clips.',
+    sourceUrls: ['https://nicksaraev.com/', 'https://makerschoolcommunity.com/'],
+    metadata: {
+      defaultVisual: 'cycle',
+      nameNote: 'User referenced Nick Saerev; public sources indicate Nick Saraev is the likely intended creator.',
+    },
+  },
+]
+
+const DEFAULT_OUTPUTS: ContentPackageOutputType[] = [
+  'linkedin_post',
+  'linkedin_carousel',
+  'pptx_deck',
+  'video_script',
+  'heygen_video',
+  'elevenlabs_audio',
+]
+
+const AMADUTOWN_PROOF_ROUTES = [
+  { route: '/admin/agents', label: 'Agent Ops Mission Control', hint: 'agent ops' },
+  { route: '/admin/social-content', label: 'Social Content Queue', hint: 'social content' },
+  { route: '/admin/content/video-generation', label: 'Video Generation', hint: 'video generation' },
+  { route: '/admin/presentations', label: 'Presentation Generator', hint: 'presentation' },
+  { route: '/admin/agents/open-brain', label: 'Open Brain', hint: 'open brain' },
+  { route: '/tools/audit', label: 'AI Audit Tool', hint: 'audit' },
+]
+
+const VOICE_RULES = [
+  'Open with a concrete moment, tension, or practical problem.',
+  'Move from lived observation to system diagnosis and a practical path forward.',
+  'Keep private-derived context as influence only; do not quote raw private material.',
+  'Avoid generic AI hype, formulaic signposting, and empty uplift language.',
+  'End with a specific question or next action.',
+]
+
+export function normalizeContentPackageOutputs(value?: string[] | ContentPackageOutputType[] | null): ContentPackageOutputType[] {
+  const incoming = Array.isArray(value) ? value : DEFAULT_OUTPUTS
+  const valid = incoming.filter((item): item is ContentPackageOutputType =>
+    CONTENT_PACKAGE_OUTPUT_TYPES.includes(item as ContentPackageOutputType)
+  )
+  return [...new Set(valid.length ? valid : DEFAULT_OUTPUTS)]
+}
+
+export function buildContentPackage(input: BuildContentPackageInput): GeneratedContentPackage {
+  const transcriptText = cleanText(input.transcriptText)
+  if (transcriptText.length < 10) {
+    throw new Error('Transcript or notes must be at least 10 characters.')
+  }
+
+  const targetOutputs = normalizeContentPackageOutputs(input.targetOutputs)
+  const frameworkIds = normalizeFrameworkIds(input.frameworkIds)
+  const frameworks = frameworkIds
+    .map((id) => DEFAULT_CONTENT_FRAMEWORKS.find((framework) => framework.id === id))
+    .filter((framework): framework is ContentFramework => Boolean(framework))
+
+  const title = deriveTitle(input.title, input.topicHint, transcriptText)
+  const audience = cleanText(input.targetAudience || 'founders, operators, product leaders, nonprofit leaders, and builders')
+  const topic = cleanText(input.topicHint || firstSentence(transcriptText))
+  const keyInsight = deriveKeyInsight(transcriptText, topic)
+  const proofRoutes = selectProofRoutes(transcriptText, targetOutputs)
+  const brollHints = proofRoutes.map((route) => route.hint)
+  const hook = buildHook(topic)
+  const cta = 'Where could this kind of system remove burden in your work right now?'
+
+  const frameworkSummary = frameworks.map((framework) => ({
+    id: framework.id,
+    display_name: framework.displayName,
+    creator_name: framework.creatorName,
+    category: framework.category,
+    summary: framework.summary,
+    usage_guidance: framework.usageGuidance,
+    source_urls: framework.sourceUrls,
+  }))
+
+  const sourcePacket = {
+    source_type: input.audioStoragePath ? 'voice_note' : 'text_note',
+    title,
+    topic,
+    transcript_excerpt: truncate(transcriptText, 1200),
+    transcript_characters: transcriptText.length,
+    audio_storage_path: input.audioStoragePath ?? null,
+    audio_file_name: input.audioFileName ?? null,
+    target_audience: audience,
+    target_outputs: targetOutputs,
+    framework_ids: frameworkIds,
+    voice_rules: VOICE_RULES,
+    privacy_boundary:
+      'Private corpus and Chronicle can inform framing, but public outputs must not quote raw private material without explicit approval.',
+  }
+
+  const researchPacket = {
+    generated_without_live_research: true,
+    research_instructions:
+      'Before final publishing, Askia should add current public sources for time-sensitive claims and attach citations to this packet.',
+    source_candidates: [
+      ...frameworks.flatMap((framework) => framework.sourceUrls),
+      'https://amadutown.com/',
+    ],
+    framework_summary: frameworkSummary,
+    chronicle: {
+      status: input.chronicleNotes?.length ? 'sanitized_notes_attached' : 'not_checked_or_unavailable',
+      notes: input.chronicleNotes ?? [],
+      boundary: 'Use only sanitized derived observations and route-level proof notes, not raw screen text or screenshots.',
+    },
+    amadutown_proof_routes: proofRoutes,
+    broll_hints: brollHints,
+  }
+
+  const outputs = buildOutputs({
+    title,
+    topic,
+    keyInsight,
+    hook,
+    cta,
+    transcriptText,
+    audience,
+    targetOutputs,
+    frameworks,
+    proofRoutes,
+    brollHints,
+  })
+
+  const presentationPlan = targetOutputs.includes('pptx_deck')
+    ? buildPresentationPlan(title, keyInsight, proofRoutes)
+    : {}
+
+  return {
+    title,
+    sourcePacket,
+    researchPacket,
+    frameworkIds,
+    targetOutputs,
+    outputs,
+    presentationPlan,
+  }
+}
+
+interface OutputContext {
+  title: string
+  topic: string
+  keyInsight: string
+  hook: string
+  cta: string
+  transcriptText: string
+  audience: string
+  targetOutputs: ContentPackageOutputType[]
+  frameworks: ContentFramework[]
+  proofRoutes: Array<{ route: string; label: string; hint: string }>
+  brollHints: string[]
+}
+
+function buildOutputs(ctx: OutputContext): ContentPackageOutputDraft[] {
+  const outputs: ContentPackageOutputDraft[] = []
+  const frameworkLine = ctx.frameworks.length
+    ? `Framework influence: ${ctx.frameworks.map((framework) => `${framework.creatorName} - ${framework.displayName}`).join('; ')}.`
+    : 'Framework influence: Vambah voice system and AmaduTown operating proof.'
+  const proofLine = ctx.proofRoutes.map((route) => `${route.label} (${route.route})`).join(', ')
+
+  if (ctx.targetOutputs.includes('linkedin_post')) {
+    const body = [
+      ctx.hook,
+      '',
+      firstParagraph(ctx.transcriptText),
+      '',
+      `That is the system hiding underneath this idea: ${ctx.keyInsight}`,
+      '',
+      `For AmaduTown, the practical move is to turn one raw note into a governed content package. Transcript. Framework. Research. Proof routes. Approval gates. Then the format can change without losing the source.`,
+      '',
+      frameworkLine,
+      '',
+      `The point is simple: technology should reduce the distance between insight and useful action. It should not create another workflow that depends on memory, screenshots, and scattered notes.`,
+      '',
+      ctx.cta,
+      '',
+      '#AIProduct #ProductManagement #AmadutownAdvisory #DigitalEquity',
+    ].join('\n')
+    outputs.push({
+      outputType: 'linkedin_post',
+      title: `${ctx.title} - LinkedIn post`,
+      body,
+      downstreamType: 'social_content_queue',
+      requiredApproval: 'script',
+      payload: {
+        platform: 'linkedin',
+        cta_text: ctx.cta,
+        hashtags: ['#AIProduct', '#ProductManagement', '#AmadutownAdvisory', '#DigitalEquity'],
+        content_pillar: 'ai_product_management',
+        proof_routes: ctx.proofRoutes,
+      },
+    })
+  }
+
+  if (ctx.targetOutputs.includes('linkedin_carousel')) {
+    const slides = [
+      { type: 'cover', headline: truncate(ctx.title, 64), subhead: ctx.keyInsight },
+      { type: 'hook', headline: 'One Note, Many Assets', body: 'The raw idea is the source. The outputs are just packaging.' },
+      { type: 'principle', number: 1, headline: 'Capture the source', body: 'Record the note, preserve the transcript, and keep raw material separate from public copy.' },
+      { type: 'principle', number: 2, headline: 'Apply the frame', body: 'Use frameworks to structure the idea, not to erase the original voice.' },
+      { type: 'principle', number: 3, headline: 'Attach proof', body: `Tie the claim back to Portfolio routes like ${proofLine || 'Agent Ops and content generation surfaces'}.` },
+      { type: 'principle', number: 4, headline: 'Gate the action', body: 'Approve the packet, then media, then publishing. Agents should not approve their own work.' },
+      { type: 'cta', headline: 'Build the system', body: ctx.cta },
+    ]
+    outputs.push({
+      outputType: 'linkedin_carousel',
+      title: `${ctx.title} - LinkedIn carousel`,
+      body: slides.map((slide) => `${slide.headline}: ${slide.body ?? slide.subhead ?? ''}`).join('\n'),
+      downstreamType: 'social_content_queue',
+      requiredApproval: 'script',
+      payload: { slides, proof_routes: ctx.proofRoutes },
+    })
+  }
+
+  if (ctx.targetOutputs.includes('pptx_deck')) {
+    const plan = buildPresentationPlan(ctx.title, ctx.keyInsight, ctx.proofRoutes)
+    outputs.push({
+      outputType: 'pptx_deck',
+      title: `${ctx.title} - PPTX deck brief`,
+      body: [
+        `Thesis: ${ctx.keyInsight}`,
+        '',
+        'Slide spine:',
+        ...(plan.coursePlan as string[]).map((item, index) => `${index + 1}. ${item}`),
+        '',
+        'Required proof:',
+        ...(plan.requiredAssets as string[]).map((item) => `- ${item}`),
+      ].join('\n'),
+      downstreamType: 'presentation_plan',
+      requiredApproval: 'media',
+      payload: plan,
+    })
+  }
+
+  if (ctx.targetOutputs.includes('video_script') || ctx.targetOutputs.includes('heygen_video') || ctx.targetOutputs.includes('elevenlabs_audio')) {
+    const script = [
+      ctx.hook,
+      '',
+      `I was thinking through this idea from a voice note: ${ctx.topic}.`,
+      '',
+      firstParagraph(ctx.transcriptText),
+      '',
+      `The practical lesson is this: ${ctx.keyInsight}`,
+      '',
+      `At AmaduTown, the system has to capture the note, add the right framework, pull in source-backed context, map the proof to real Portfolio surfaces, and hold the publishing gate until a human approves it.`,
+      '',
+      `That is how AI becomes leverage without becoming noise.`,
+      '',
+      ctx.cta,
+    ].join('\n')
+
+    outputs.push({
+      outputType: 'video_script',
+      title: `${ctx.title} - video script`,
+      body: script,
+      downstreamType: 'video_ideas_queue',
+      requiredApproval: 'script',
+      payload: {
+        storyboard: {
+          scenes: [
+            { sceneNumber: 1, description: 'Open on the raw voice-note idea.', brollHint: 'home' },
+            { sceneNumber: 2, description: 'Show source packet and approval workflow.', brollHint: 'agent ops' },
+            { sceneNumber: 3, description: 'Show social and presentation output paths.', brollHint: 'social content' },
+            { sceneNumber: 4, description: 'Close with AmaduTown proof and call to action.', brollHint: ctx.brollHints[0] ?? 'services' },
+          ],
+        },
+        broll_hints: ctx.brollHints,
+      },
+    })
+  }
+
+  if (ctx.targetOutputs.includes('heygen_video')) {
+    outputs.push({
+      outputType: 'heygen_video',
+      title: `${ctx.title} - HeyGen handoff`,
+      body: 'Generate a HeyGen avatar video only after the script packet and media generation approval are approved.',
+      downstreamType: 'video_ideas_queue',
+      requiredApproval: 'media',
+      payload: {
+        provider: 'heygen',
+        required_inputs: ['approved video script', 'avatar_id or default avatar', 'voice_id or default voice', 'broll_asset_ids'],
+        approval_boundary: 'No HeyGen job should be created until content_package_media_generation is approved.',
+      },
+    })
+  }
+
+  if (ctx.targetOutputs.includes('elevenlabs_audio')) {
+    outputs.push({
+      outputType: 'elevenlabs_audio',
+      title: `${ctx.title} - ElevenLabs audio handoff`,
+      body: 'Generate voiceover audio only after the script packet and media generation approval are approved.',
+      requiredApproval: 'media',
+      payload: {
+        provider: 'elevenlabs',
+        voice: 'default personal voice',
+        approval_boundary: 'No ElevenLabs generation should run until content_package_media_generation is approved.',
+      },
+    })
+  }
+
+  if (ctx.targetOutputs.includes('newsletter_blurb')) {
+    outputs.push({
+      outputType: 'newsletter_blurb',
+      title: `${ctx.title} - newsletter blurb`,
+      body: `${ctx.keyInsight} This started as a voice-note idea and became a source-backed content package with proof routes, framework context, and approval gates.`,
+      requiredApproval: 'publish',
+      payload: { cta: ctx.cta },
+    })
+  }
+
+  if (ctx.targetOutputs.includes('email_draft')) {
+    outputs.push({
+      outputType: 'email_draft',
+      title: `${ctx.title} - email draft`,
+      body: `Subject: ${ctx.title}\n\n${ctx.keyInsight}\n\nI am building this as a repeatable content system: capture the idea, structure it, attach proof, and only publish once the packet is approved.\n\n${ctx.cta}`,
+      requiredApproval: 'publish',
+      payload: { audience: ctx.audience },
+    })
+  }
+
+  if (ctx.targetOutputs.includes('short_caption')) {
+    outputs.push({
+      outputType: 'short_caption',
+      title: `${ctx.title} - short caption`,
+      body: `${ctx.keyInsight} One voice note should be enough to create the post, deck, script, and proof packet - with approval before anything ships.`,
+      requiredApproval: 'publish',
+      payload: { max_length: 280 },
+    })
+  }
+
+  return outputs
+}
+
+function buildPresentationPlan(title: string, thesis: string, proofRoutes: Array<{ route: string; label: string }>): Record<string, unknown> {
+  const input: PresentationBakeoffInput = {
+    title,
+    thesis,
+    audience: 'public_audience',
+    format: 'thought_leadership',
+    durationMinutes: 20,
+    proofAssets: proofRoutes.map((route) => route.label),
+    demoRoutes: proofRoutes.map((route) => route.route),
+    sourceAnchors: ['Voice-note transcript', 'Framework registry', 'AmaduTown proof routes'],
+    brandSystem: 'amadutown',
+    needsEditablePptx: true,
+    needsLiveDemos: true,
+    needsSourceValidation: true,
+    needsFacilitatorNotes: true,
+  }
+  return buildPresentationBakeoffPlan(input) as unknown as Record<string, unknown>
+}
+
+function normalizeFrameworkIds(ids?: string[] | null): string[] {
+  const incoming = Array.isArray(ids) && ids.length > 0
+    ? ids
+    : ['alex-hormozi-value-equation', 'nick-saraev-ai-content-engine']
+  const valid = incoming.filter((id) => DEFAULT_CONTENT_FRAMEWORKS.some((framework) => framework.id === id))
+  return [...new Set(valid.length ? valid : ['alex-hormozi-value-equation'])]
+}
+
+function selectProofRoutes(text: string, outputs: ContentPackageOutputType[]) {
+  const lower = text.toLowerCase()
+  const selected = AMADUTOWN_PROOF_ROUTES.filter((route) => lower.includes(route.hint))
+  if (outputs.includes('pptx_deck')) selected.push(AMADUTOWN_PROOF_ROUTES[3])
+  if (outputs.includes('heygen_video') || outputs.includes('video_script')) selected.push(AMADUTOWN_PROOF_ROUTES[2])
+  selected.push(AMADUTOWN_PROOF_ROUTES[0], AMADUTOWN_PROOF_ROUTES[1])
+  const seen = new Set<string>()
+  return selected.filter((route) => {
+    if (seen.has(route.route)) return false
+    seen.add(route.route)
+    return true
+  }).slice(0, 5)
+}
+
+function deriveTitle(title: string | null | undefined, topicHint: string | null | undefined, text: string): string {
+  const candidate = cleanText(title || topicHint || firstSentence(text))
+  const clipped = truncate(candidate, 72).replace(/[.?!]+$/, '')
+  return clipped || 'Voice-note content package'
+}
+
+function deriveKeyInsight(text: string, topic: string): string {
+  const sentences = text
+    .split(/(?<=[.!?])\s+/)
+    .map(cleanText)
+    .filter((sentence) => sentence.length > 20)
+  const source = sentences.find((sentence) => /system|access|ai|automation|content|client|community|workflow/i.test(sentence))
+    ?? sentences[0]
+    ?? topic
+  return `Raw ideas become useful when they are captured, structured, grounded in proof, and routed through the right approval gate. ${truncate(source, 180)}`
+}
+
+function buildHook(topic: string): string {
+  return `A voice note is not just a reminder. It can be the first draft of a system.`
+}
+
+function firstSentence(text: string): string {
+  return cleanText(text.split(/(?<=[.!?])\s+/)[0] ?? text)
+}
+
+function firstParagraph(text: string): string {
+  const paragraph = text.split(/\n{2,}/).map(cleanText).find(Boolean) ?? text
+  return truncate(paragraph, 420)
+}
+
+function cleanText(value: string | null | undefined): string {
+  return String(value ?? '').replace(/\s+/g, ' ').trim()
+}
+
+function truncate(value: string, max: number): string {
+  if (value.length <= max) return value
+  return value.slice(0, Math.max(0, max - 3)).trimEnd() + '...'
+}

--- a/migrations/2026_05_25_voice_note_content_packages.sql
+++ b/migrations/2026_05_25_voice_note_content_packages.sql
@@ -93,6 +93,9 @@ CREATE INDEX IF NOT EXISTS idx_content_packages_status
   ON public.content_packages(status, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_content_packages_intake
   ON public.content_packages(intake_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_content_packages_intake_unique
+  ON public.content_packages(intake_id)
+  WHERE intake_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_content_package_outputs_package
   ON public.content_package_outputs(package_id, output_type);
 

--- a/migrations/2026_05_25_voice_note_content_packages.sql
+++ b/migrations/2026_05_25_voice_note_content_packages.sql
@@ -1,0 +1,173 @@
+-- Voice-note content package system.
+-- Turns rough voice-note ideas into governed, multi-format content packets.
+
+CREATE TABLE IF NOT EXISTS public.content_frameworks (
+  id TEXT PRIMARY KEY,
+  display_name TEXT NOT NULL,
+  creator_name TEXT NOT NULL,
+  category TEXT NOT NULL,
+  summary TEXT NOT NULL,
+  usage_guidance TEXT NOT NULL,
+  source_urls TEXT[] NOT NULL DEFAULT '{}',
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.social_idea_intakes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  title TEXT NOT NULL,
+  source_type TEXT NOT NULL DEFAULT 'voice_note'
+    CHECK (source_type IN ('voice_note', 'text_note', 'meeting', 'manual')),
+  transcript_text TEXT NOT NULL,
+  audio_storage_path TEXT,
+  audio_file_name TEXT,
+  topic_hint TEXT,
+  target_audience TEXT,
+  target_outputs TEXT[] NOT NULL DEFAULT ARRAY['linkedin_post']::TEXT[],
+  framework_ids TEXT[] NOT NULL DEFAULT '{}',
+  status TEXT NOT NULL DEFAULT 'draft'
+    CHECK (status IN ('draft', 'packet_generated', 'approved', 'rejected', 'archived')),
+  created_by UUID REFERENCES public.user_profiles(id),
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.content_packages (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  intake_id UUID REFERENCES public.social_idea_intakes(id) ON DELETE SET NULL,
+  agent_run_id UUID REFERENCES public.agent_runs(id) ON DELETE SET NULL,
+  title TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'draft'
+    CHECK (status IN (
+      'draft',
+      'waiting_script_approval',
+      'script_approved',
+      'waiting_media_approval',
+      'media_ready',
+      'waiting_publish_approval',
+      'published',
+      'rejected',
+      'archived'
+    )),
+  source_packet JSONB NOT NULL DEFAULT '{}'::jsonb,
+  research_packet JSONB NOT NULL DEFAULT '{}'::jsonb,
+  framework_ids TEXT[] NOT NULL DEFAULT '{}',
+  target_outputs TEXT[] NOT NULL DEFAULT '{}',
+  approval_ids UUID[] NOT NULL DEFAULT '{}',
+  social_content_id UUID REFERENCES public.social_content_queue(id) ON DELETE SET NULL,
+  video_idea_id UUID REFERENCES public.video_ideas_queue(id) ON DELETE SET NULL,
+  presentation_plan JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_by UUID REFERENCES public.user_profiles(id),
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.content_package_outputs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  package_id UUID NOT NULL REFERENCES public.content_packages(id) ON DELETE CASCADE,
+  output_type TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'draft'
+    CHECK (status IN ('draft', 'waiting_approval', 'approved', 'generated', 'published', 'rejected', 'blocked')),
+  title TEXT NOT NULL,
+  body TEXT NOT NULL,
+  payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+  approval_id UUID REFERENCES public.agent_approvals(id) ON DELETE SET NULL,
+  downstream_type TEXT,
+  downstream_id TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_social_idea_intakes_created
+  ON public.social_idea_intakes(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_social_idea_intakes_status
+  ON public.social_idea_intakes(status, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_content_packages_created
+  ON public.content_packages(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_content_packages_status
+  ON public.content_packages(status, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_content_packages_intake
+  ON public.content_packages(intake_id);
+CREATE INDEX IF NOT EXISTS idx_content_package_outputs_package
+  ON public.content_package_outputs(package_id, output_type);
+
+ALTER TABLE public.content_frameworks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.social_idea_intakes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.content_packages ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.content_package_outputs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Admins can manage content_frameworks" ON public.content_frameworks;
+CREATE POLICY "Admins can manage content_frameworks"
+  ON public.content_frameworks FOR ALL TO authenticated
+  USING (EXISTS (SELECT 1 FROM public.user_profiles WHERE id = auth.uid() AND role = 'admin'))
+  WITH CHECK (EXISTS (SELECT 1 FROM public.user_profiles WHERE id = auth.uid() AND role = 'admin'));
+
+DROP POLICY IF EXISTS "Admins can manage social_idea_intakes" ON public.social_idea_intakes;
+CREATE POLICY "Admins can manage social_idea_intakes"
+  ON public.social_idea_intakes FOR ALL TO authenticated
+  USING (EXISTS (SELECT 1 FROM public.user_profiles WHERE id = auth.uid() AND role = 'admin'))
+  WITH CHECK (EXISTS (SELECT 1 FROM public.user_profiles WHERE id = auth.uid() AND role = 'admin'));
+
+DROP POLICY IF EXISTS "Admins can manage content_packages" ON public.content_packages;
+CREATE POLICY "Admins can manage content_packages"
+  ON public.content_packages FOR ALL TO authenticated
+  USING (EXISTS (SELECT 1 FROM public.user_profiles WHERE id = auth.uid() AND role = 'admin'))
+  WITH CHECK (EXISTS (SELECT 1 FROM public.user_profiles WHERE id = auth.uid() AND role = 'admin'));
+
+DROP POLICY IF EXISTS "Admins can manage content_package_outputs" ON public.content_package_outputs;
+CREATE POLICY "Admins can manage content_package_outputs"
+  ON public.content_package_outputs FOR ALL TO authenticated
+  USING (EXISTS (SELECT 1 FROM public.user_profiles WHERE id = auth.uid() AND role = 'admin'))
+  WITH CHECK (EXISTS (SELECT 1 FROM public.user_profiles WHERE id = auth.uid() AND role = 'admin'));
+
+INSERT INTO public.content_frameworks (
+  id,
+  display_name,
+  creator_name,
+  category,
+  summary,
+  usage_guidance,
+  source_urls,
+  metadata
+) VALUES
+  (
+    'alex-hormozi-value-equation',
+    'Value Equation / Grand Slam Offer',
+    'Alex Hormozi',
+    'offer_strategy',
+    'Frame value through dream outcome, perceived likelihood, time delay, and effort or sacrifice.',
+    'Use for posts, decks, and videos that need to turn an idea into a clear offer, guarantee, proof stack, or practical business case.',
+    ARRAY['https://www.acquisition.com/'],
+    '{"default_visual":"equation","public_claim_boundary":"Use as a structural influence; avoid implying endorsement."}'::jsonb
+  ),
+  (
+    'nick-saraev-ai-content-engine',
+    'AI Content Engine / Creator Systems',
+    'Nick Saraev',
+    'content_systems',
+    'Frame content production as a repeatable AI-assisted system that converts raw ideas into platform-specific assets.',
+    'Use for multi-format repurposing, creator operating systems, and packaging one source idea into posts, decks, scripts, and short-form clips.',
+    ARRAY['https://nicksaraev.com/','https://makerschoolcommunity.com/'],
+    '{"default_visual":"cycle","name_note":"User referenced Nick Saerev; public sources indicate Nick Saraev is the likely intended creator."}'::jsonb
+  )
+ON CONFLICT (id) DO UPDATE SET
+  display_name = EXCLUDED.display_name,
+  creator_name = EXCLUDED.creator_name,
+  category = EXCLUDED.category,
+  summary = EXCLUDED.summary,
+  usage_guidance = EXCLUDED.usage_guidance,
+  source_urls = EXCLUDED.source_urls,
+  metadata = EXCLUDED.metadata,
+  updated_at = now();
+
+COMMENT ON TABLE public.social_idea_intakes IS
+  'Raw brainstorming intakes, including voice-note transcripts, before public-facing content is generated.';
+COMMENT ON TABLE public.content_packages IS
+  'Governed multi-format content packages generated from one source packet and linked to Agent Ops approvals.';
+COMMENT ON TABLE public.content_package_outputs IS
+  'Individual output drafts such as LinkedIn posts, carousels, decks, video scripts, audio prompts, and captions.';

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "pdf-lib": "^1.17.1",
         "pdf-parse": "^1.1.1",
         "playwright-core": "^1.58.2",
+        "pptxgenjs": "^4.0.1",
         "react": "^18.2.0",
         "react-calendly": "^4.4.0",
         "react-dom": "^18.2.0",
@@ -8464,6 +8465,12 @@
         "node": ">= 14"
       }
     },
+    "node_modules/https": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https/-/https-1.0.0.tgz",
+      "integrity": "sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg==",
+      "license": "ISC"
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -8528,6 +8535,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/image-size": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+      "license": "MIT",
+      "dependencies": {
+        "queue": "6.0.2"
+      },
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
       }
     },
     "node_modules/immediate": {
@@ -11862,6 +11884,27 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pptxgenjs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pptxgenjs/-/pptxgenjs-4.0.1.tgz",
+      "integrity": "sha512-TeJISr8wouAuXw4C1F/mC33xbZs/FuEG6nH9FG1Zj+nuPcGMP5YRHl6X+j3HSUnS1f3at6k75ZZXPMZlA5Lj9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^22.8.1",
+        "https": "^1.0.0",
+        "image-size": "^1.2.1",
+        "jszip": "^3.10.1"
+      }
+    },
+    "node_modules/pptxgenjs/node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "pdf-lib": "^1.17.1",
     "pdf-parse": "^1.1.1",
     "playwright-core": "^1.58.2",
+    "pptxgenjs": "^4.0.1",
     "react": "^18.2.0",
     "react-calendly": "^4.4.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
## Summary
- Adds native browser voice-note intake for social content brainstorming, including optional server-side transcription and source-packet persistence.
- Creates governed content packages with LinkedIn, carousel, script, HeyGen, ElevenLabs, and PowerPoint outputs behind script/media/publish approval gates.
- Adds approval-gated PPTX generation that stores editable decks in the private documents bucket and returns a signed URL.

## Validation
- npm test -- --run lib/content-packages.test.ts lib/content-package-pptx.test.ts
- npx tsc --noEmit --pretty false
- npm run lint
- git diff --check
- No live workflow/customer-data smoke was run.

## Integration Notes
- Requires migration: migrations/2026_05_25_voice_note_content_packages.sql
- Requires OPENAI_API_KEY only when submitting audio without typed transcript/rough notes.
- Adds runtime dependency: pptxgenjs. npm install reported existing audit findings; no audit fix was run to avoid unrelated churn.
- Vercel – portfolio: not checked in this implementation branch.
- Vercel – portfolio-staging: not checked in this implementation branch.