### PR TITLE
feat: add open brain relationship map

### DIFF
--- a/app/admin/agents/open-brain/page.test.tsx
+++ b/app/admin/agents/open-brain/page.test.tsx
@@ -117,6 +117,89 @@ const openBrainSnapshot = {
       note: 'Approval required.',
     },
   ],
+  relationshipMap: {
+    overview: {
+      relationships: 3,
+      strongRelationships: 1,
+      weakRelationships: 1,
+      orphanedRecords: 1,
+      staleSources: 1,
+      proposalSuggestions: 2,
+    },
+    nodes: [
+      {
+        id: 'source-1',
+        label: 'Morning review source',
+        type: 'source',
+        kind: 'codex_automation',
+        privacyTier: 'internal_ops',
+        summary: 'Automation context source.',
+        path: '/tmp/source.json',
+        health: 'yellow',
+        x: 20,
+        y: 40,
+      },
+      {
+        id: 'memory-1',
+        label: 'Action-first operating rule',
+        type: 'memory',
+        kind: 'operating_rule',
+        privacyTier: 'internal_ops',
+        summary: 'Next steps name the owner.',
+        path: null,
+        health: 'green',
+        x: 76,
+        y: 36,
+      },
+      {
+        id: 'proposal-node:proposal-1',
+        label: 'Adopt action-first governance reviews',
+        type: 'proposal',
+        kind: 'workflow',
+        privacyTier: 'internal_ops',
+        summary: 'Review pending proposal.',
+        path: null,
+        health: 'yellow',
+        x: 65,
+        y: 76,
+      },
+    ],
+    edges: [
+      {
+        id: 'edge-1',
+        fromId: 'source-1',
+        toId: 'memory-1',
+        relationship: 'supports_memory',
+        strength: 'strong',
+        confidence: 0.9,
+        evidence: 'Memory cites source.',
+        status: 'inferred',
+      },
+      {
+        id: 'edge-2',
+        fromId: 'source-1',
+        toId: 'proposal-node:proposal-1',
+        relationship: 'proposes_context',
+        strength: 'weak',
+        confidence: 0.5,
+        evidence: 'Proposal cites source.',
+        status: 'inferred',
+      },
+    ],
+    insights: [
+      {
+        id: 'insight-1',
+        kind: 'strengthen',
+        severity: 'medium',
+        title: 'Strengthen automation-to-runbook governance',
+        detail: 'Automation source needs an explicit governing runbook link.',
+        recommendation: 'Create a relationship proposal before future agents act on it.',
+        actionLabel: 'Propose link',
+        sourceNodeId: 'source-1',
+        targetNodeId: null,
+      },
+    ],
+  },
   modelOps: {
     available: true,
     generatedAt: '2026-05-15T12:00:00.000Z',
@@ -219,5 +302,24 @@ describe('OpenBrainPage', () => {
       method: 'POST',
       headers: expect.objectContaining({ Authorization: 'Bearer admin-token' }),
     }))
+  })
+
+  it('renders the relationship map as a proposal-only Open Brain view', async () => {
+    render(<OpenBrainPage />)
+
+    const tabs = await screen.findByRole('button', { name: 'Map' })
+    fireEvent.click(tabs)
+
+    const map = await screen.findByRole('region', { name: 'Open Brain relationship map' })
+    expect(within(map).getByText('Relationships')).toBeInTheDocument()
+    expect(within(map).getByText('Weak links')).toBeInTheDocument()
+    expect(within(map).getByText('Orphaned records')).toBeInTheDocument()
+    expect(within(map).getByText('Relationship insights')).toBeInTheDocument()
+    expect(within(map).getByText('Strengthen automation-to-runbook governance')).toBeInTheDocument()
+    expect(within(map).getByText('Morning review source')).toBeInTheDocument()
+
+    fireEvent.click(within(map).getByRole('button', { name: 'Propose link' }))
+
+    expect(screen.getByText('Propose link is proposal-only in v1. No Open Brain link was changed from this map.')).toBeInTheDocument()
   })
 })

--- a/app/admin/agents/open-brain/page.tsx
+++ b/app/admin/agents/open-brain/page.tsx
@@ -20,9 +20,9 @@ import {
 import ProtectedRoute from '@/components/ProtectedRoute'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
 import { getCurrentSession } from '@/lib/auth'
-import type { OpenBrainSnapshot } from '@/lib/open-brain'
+import type { OpenBrainRelationshipNodeType, OpenBrainSnapshot } from '@/lib/open-brain'
 
-type ViewMode = 'router' | 'sources' | 'proposals' | 'wiki' | 'parity' | 'producers'
+type ViewMode = 'router' | 'sources' | 'proposals' | 'wiki' | 'parity' | 'producers' | 'map'
 
 export default function OpenBrainPage() {
   return (
@@ -103,6 +103,10 @@ function OpenBrainContent() {
     } finally {
       setReviewingProposalId(null)
     }
+  }
+
+  function handleRelationshipSuggestion(actionLabel: string) {
+    setActionMessage(`${actionLabel} is proposal-only in v1. No Open Brain link was changed from this map.`)
   }
 
   return (
@@ -203,6 +207,7 @@ function OpenBrainContent() {
                 <ModeButton icon={<FileText size={16} />} active={viewMode === 'wiki'} onClick={() => setViewMode('wiki')}>Wiki Overlay</ModeButton>
                 <ModeButton icon={<Network size={16} />} active={viewMode === 'parity'} onClick={() => setViewMode('parity')}>Runtime Parity</ModeButton>
                 <ModeButton icon={<GitBranch size={16} />} active={viewMode === 'producers'} onClick={() => setViewMode('producers')}>Producers</ModeButton>
+                <ModeButton icon={<Network size={16} />} active={viewMode === 'map'} onClick={() => setViewMode('map')}>Map</ModeButton>
                 </div>
               </div>
               <button
@@ -232,6 +237,7 @@ function OpenBrainContent() {
             {viewMode === 'wiki' ? <WikiView pages={snapshot.wikiPages} /> : null}
             {viewMode === 'parity' ? <ParityView snapshot={snapshot} /> : null}
             {viewMode === 'producers' ? <ProducerView snapshot={snapshot} /> : null}
+            {viewMode === 'map' ? <RelationshipMapView snapshot={snapshot} onSuggestionAction={handleRelationshipSuggestion} /> : null}
 
             <p className="mt-5 text-xs text-muted-foreground">
               Generated {formatDateTime(snapshot.generatedAt)}. {snapshot.service.operationalBoundary}
@@ -560,6 +566,207 @@ function RouterView({ snapshot }: { snapshot: OpenBrainSnapshot }) {
       </section>
     </section>
   )
+}
+
+function RelationshipMapView({
+  snapshot,
+  onSuggestionAction,
+}: {
+  snapshot: OpenBrainSnapshot
+  onSuggestionAction: (actionLabel: string) => void
+}) {
+  const [typeFilter, setTypeFilter] = useState<OpenBrainRelationshipNodeType | 'all'>('all')
+  const map = snapshot.relationshipMap
+  const visibleNodes = typeFilter === 'all' ? map.nodes : map.nodes.filter((node) => node.type === typeFilter)
+  const visibleNodeIds = new Set(visibleNodes.map((node) => node.id))
+  const visibleEdges = map.edges.filter((edge) => visibleNodeIds.has(edge.fromId) && visibleNodeIds.has(edge.toId))
+  const nodeById = new Map(visibleNodes.map((node) => [node.id, node]))
+  const nodeTypes: Array<OpenBrainRelationshipNodeType | 'all'> = ['all', 'source', 'memory', 'event', 'wiki', 'proposal']
+  const selectedPath = visibleEdges.find((edge) => edge.strength === 'strong') || visibleEdges[0]
+  const selectedFrom = selectedPath ? nodeById.get(selectedPath.fromId) : null
+  const selectedTo = selectedPath ? nodeById.get(selectedPath.toId) : null
+
+  return (
+    <section className="space-y-5" aria-label="Open Brain relationship map">
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+        <RelationshipMetric label="Relationships" value={map.overview.relationships} detail={`${map.overview.strongRelationships} strong`} />
+        <RelationshipMetric label="Weak links" value={map.overview.weakRelationships} detail="Need more evidence" tone="yellow" />
+        <RelationshipMetric label="Orphaned records" value={map.overview.orphanedRecords} detail="No visible edge" tone="red" />
+        <RelationshipMetric label="Stale sources" value={map.overview.staleSources} detail="Refresh before promotion" tone="yellow" />
+        <RelationshipMetric label="Suggestions" value={map.overview.proposalSuggestions} detail="Proposal-only actions" />
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-[250px_minmax(0,1fr)_340px]">
+        <aside className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
+          <div className="mb-4 flex items-center justify-between gap-3">
+            <p className="agent-ops-eyebrow"><Network size={14} /> Filters</p>
+            <span className="text-xs text-muted-foreground">{visibleNodes.length}/{map.nodes.length}</span>
+          </div>
+          <div className="space-y-2">
+            {nodeTypes.map((type) => {
+              const count = type === 'all' ? map.nodes.length : map.nodes.filter((node) => node.type === type).length
+              return (
+                <button
+                  key={type}
+                  type="button"
+                  onClick={() => setTypeFilter(type)}
+                  className={`flex w-full items-center justify-between rounded-lg border px-3 py-2 text-left text-sm transition ${
+                    typeFilter === type
+                      ? 'border-radiant-gold/55 bg-radiant-gold/10 text-radiant-gold'
+                      : 'border-silicon-slate/60 bg-background/20 text-muted-foreground hover:border-radiant-gold/35 hover:text-foreground'
+                  }`}
+                >
+                  <span className="capitalize">{type === 'all' ? 'All records' : type}</span>
+                  <span className="tabular-nums">{count}</span>
+                </button>
+              )
+            })}
+          </div>
+          <div className="mt-5 space-y-2 border-t border-silicon-slate/60 pt-4 text-xs text-muted-foreground">
+            <RelationshipLegend color="bg-radiant-gold" label="Strong/persisted" />
+            <RelationshipLegend color="bg-platinum-white" label="Inferred medium" />
+            <RelationshipLegend color="bg-red-300" label="Weak or risky" />
+            <RelationshipLegend color="border border-radiant-gold bg-transparent" label="Proposal-only action" />
+          </div>
+        </aside>
+
+        <div className="relative min-h-[620px] overflow-hidden rounded-lg border border-radiant-gold/20 bg-[radial-gradient(circle_at_50%_45%,rgba(212,175,55,0.08),transparent_34%),linear-gradient(180deg,rgba(12,23,39,0.94),rgba(7,14,25,0.98))] shadow-2xl">
+          <div className="absolute left-5 top-5 z-10">
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-radiant-gold">Memory Graph</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {selectedFrom && selectedTo
+                ? `Selected path: ${selectedFrom.label} -> ${selectedTo.label}`
+                : 'No visible relationship path for this filter.'}
+            </p>
+          </div>
+          <svg className="absolute inset-0 h-full w-full" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
+            {visibleEdges.map((edge) => {
+              const from = nodeById.get(edge.fromId)
+              const to = nodeById.get(edge.toId)
+              if (!from || !to) return null
+              return (
+                <line
+                  key={edge.id}
+                  x1={from.x}
+                  y1={from.y}
+                  x2={to.x}
+                  y2={to.y}
+                  stroke={relationshipEdgeColor(edge.strength, edge.status)}
+                  strokeWidth={edge.strength === 'strong' ? 0.6 : edge.strength === 'medium' ? 0.38 : 0.28}
+                  strokeDasharray={edge.status === 'inferred' ? '1.4 1.1' : undefined}
+                  strokeLinecap="round"
+                  vectorEffect="non-scaling-stroke"
+                />
+              )
+            })}
+          </svg>
+          {visibleNodes.map((node) => (
+            <div
+              key={node.id}
+              className={`absolute z-10 flex max-w-[150px] -translate-x-1/2 -translate-y-1/2 flex-col items-center justify-center rounded-lg border px-3 py-2 text-center shadow-xl ${relationshipNodeTone(node.type, node.health)}`}
+              style={{ left: `${node.x}%`, top: `${node.y}%` }}
+              title={node.summary}
+            >
+              <span className="text-[10px] font-extrabold uppercase tracking-[0.12em] opacity-75">{node.type}</span>
+              <span className="mt-1 line-clamp-2 text-xs font-semibold leading-4">{node.label}</span>
+              <span className="mt-1 text-[10px] opacity-70">{node.kind.replace(/_/g, ' ')}</span>
+            </div>
+          ))}
+          <div className="absolute bottom-5 left-5 z-10 flex flex-wrap gap-3 rounded-lg border border-silicon-slate/60 bg-black/30 p-3 text-xs text-muted-foreground backdrop-blur">
+            <RelationshipLegend color="bg-radiant-gold" label="Strong" />
+            <RelationshipLegend color="bg-platinum-white" label="Inferred" />
+            <RelationshipLegend color="bg-red-300" label="Weak" />
+          </div>
+        </div>
+
+        <aside className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
+          <p className="agent-ops-eyebrow"><Target size={14} /> Relationship insights</p>
+          <h2 className="mt-2 text-xl font-semibold">What I will review before action</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            These controls do not mutate Open Brain. They identify relationship changes that should become explicit proposals.
+          </p>
+          <div className="mt-4 space-y-3">
+            {map.insights.length > 0 ? map.insights.map((insight) => (
+              <article key={insight.id} className={`rounded-lg border border-l-4 bg-background/20 p-3 ${relationshipInsightTone(insight.severity)}`}>
+                <div className="flex items-start justify-between gap-3">
+                  <h3 className="text-sm font-semibold">{insight.title}</h3>
+                  <span className="rounded-full border border-silicon-slate/60 px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+                    {insight.kind.replace(/_/g, ' ')}
+                  </span>
+                </div>
+                <p className="mt-2 text-xs leading-relaxed text-muted-foreground">{insight.detail}</p>
+                <p className="mt-2 text-xs leading-relaxed text-foreground/85">{insight.recommendation}</p>
+                <button
+                  type="button"
+                  onClick={() => onSuggestionAction(insight.actionLabel)}
+                  className="mt-3 inline-flex items-center gap-2 rounded-lg border border-radiant-gold/40 bg-radiant-gold/10 px-3 py-2 text-xs font-medium text-radiant-gold hover:bg-radiant-gold/15"
+                >
+                  {insight.actionLabel}
+                </button>
+              </article>
+            )) : (
+              <EmptyState message="No relationship issues are visible for the current graph." />
+            )}
+          </div>
+        </aside>
+      </div>
+    </section>
+  )
+}
+
+function RelationshipMetric({
+  label,
+  value,
+  detail,
+  tone = 'gold',
+}: {
+  label: string
+  value: number
+  detail: string
+  tone?: 'gold' | 'yellow' | 'red'
+}) {
+  const valueTone = tone === 'red' ? 'text-red-200' : tone === 'yellow' ? 'text-yellow-100' : 'text-foreground'
+  const borderTone = tone === 'red' ? 'border-red-400/35' : tone === 'yellow' ? 'border-yellow-400/40' : 'border-radiant-gold/20'
+  return (
+    <div className={`rounded-lg border bg-silicon-slate/20 p-4 ${borderTone}`}>
+      <p className={`text-3xl font-bold tabular-nums ${valueTone}`}>{value}</p>
+      <p className="mt-2 text-xs font-semibold uppercase tracking-[0.14em] text-radiant-gold">{label}</p>
+      <p className="mt-1 text-xs text-muted-foreground">{detail}</p>
+    </div>
+  )
+}
+
+function RelationshipLegend({ color, label }: { color: string; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-2">
+      <span className={`h-2.5 w-2.5 rounded-full ${color}`} />
+      {label}
+    </span>
+  )
+}
+
+function relationshipEdgeColor(strength: 'strong' | 'medium' | 'weak', status: string) {
+  if (strength === 'weak') return 'rgba(252,165,165,0.7)'
+  if (status === 'persisted') return 'rgba(212,175,55,0.95)'
+  if (strength === 'strong') return 'rgba(245,208,96,0.82)'
+  return 'rgba(234,236,238,0.5)'
+}
+
+function relationshipNodeTone(type: OpenBrainRelationshipNodeType, health: 'green' | 'yellow' | 'red') {
+  if (health === 'red') return 'border-red-300/70 bg-red-950/80 text-red-100'
+  if (type === 'source') return 'border-radiant-gold/50 bg-radiant-gold text-imperial-navy'
+  if (type === 'memory') return 'border-radiant-gold/45 bg-platinum-white text-imperial-navy'
+  if (type === 'wiki') return 'border-radiant-gold/45 bg-bronze text-platinum-white'
+  if (type === 'proposal') return 'border-yellow-300/60 bg-imperial-navy text-yellow-100'
+  return health === 'yellow'
+    ? 'border-yellow-300/55 bg-yellow-500/15 text-yellow-100'
+    : 'border-silicon-slate/70 bg-silicon-slate text-platinum-white'
+}
+
+function relationshipInsightTone(severity: 'low' | 'medium' | 'high') {
+  if (severity === 'high') return 'border-l-red-300'
+  if (severity === 'medium') return 'border-l-radiant-gold'
+  return 'border-l-platinum-white'
 }
 
 function SourcesView({ snapshot }: { snapshot: OpenBrainSnapshot }) {

--- a/lib/open-brain.test.ts
+++ b/lib/open-brain.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'os'
 import path from 'path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  buildOpenBrainRelationshipMap,
   compileKarpathyWikiOverlay,
   createOpenBrainProposal,
   fingerprintOpenBrainRecord,
@@ -103,6 +104,11 @@ describe('Open Brain projection', () => {
       'producer:rag-pinecone',
     ]))
     expect(snapshot.overview.producerGates).toBe(snapshot.producerGates.length)
+    expect(snapshot.relationshipMap.nodes.map((node) => node.type)).toEqual(expect.arrayContaining([
+      'source',
+      'proposal',
+    ]))
+    expect(snapshot.relationshipMap.insights.map((insight) => insight.kind)).toContain('strengthen')
   })
 
   it('keeps AutoResearch producer traces disabled until explicitly configured', async () => {
@@ -269,6 +275,151 @@ describe('Open Brain projection', () => {
     }))
     expect(projection.pineconeWriteStatus).toBe('blocked_pending_approval')
     expect(projection.excludedPrivateCount).toBe(1)
+  })
+
+  it('builds a relationship map from sources, memories, proposals, events, wiki pages, and persisted links', () => {
+    const generatedAt = '2026-05-25T12:00:00.000Z'
+    const sources = [
+      {
+        id: 'source:automation',
+        kind: 'codex_automation' as const,
+        title: 'Portfolio automation',
+        summary: 'Checks Portfolio memory readiness.',
+        path: '/Users/vambahsillah/.codex/automations/portfolio/automation.toml',
+        privacyTier: 'internal_ops' as const,
+        confidence: 0.86,
+        lastObservedAt: generatedAt,
+        fingerprint: fingerprintOpenBrainRecord(['source:automation']),
+      },
+      {
+        id: 'source:runbook',
+        kind: 'runbook' as const,
+        title: 'Memory organization runbook',
+        summary: 'Governs local memory organization.',
+        path: 'docs/agents/memory-organization.md',
+        privacyTier: 'internal_ops' as const,
+        confidence: 0.9,
+        lastObservedAt: generatedAt,
+        fingerprint: fingerprintOpenBrainRecord(['source:runbook']),
+      },
+      {
+        id: 'source:stale',
+        kind: 'workspace_root_report' as const,
+        title: 'Stale workspace-root report',
+        summary: 'Old workspace evidence.',
+        path: '/Users/vambahsillah/.codex/state_5.sqlite',
+        privacyTier: 'internal_ops' as const,
+        confidence: 0.7,
+        lastObservedAt: '2026-04-01T12:00:00.000Z',
+        fingerprint: fingerprintOpenBrainRecord(['source:stale']),
+      },
+    ]
+    const memories = [
+      {
+        id: 'memory:governance',
+        kind: 'operating_rule' as const,
+        title: 'Proposal-gated relationship changes',
+        body: 'The map recommends relationship changes but does not mutate Open Brain directly.',
+        privacyTier: 'internal_ops' as const,
+        confidence: 0.91,
+        sourceIds: ['source:automation'],
+        createdAt: generatedAt,
+        updatedAt: generatedAt,
+        fingerprint: fingerprintOpenBrainRecord(['memory:governance']),
+      },
+    ]
+    const proposals = [
+      {
+        id: 'proposal:link-runbook',
+        status: 'pending' as const,
+        proposedMemory: {
+          kind: 'workflow' as const,
+          title: 'Link automation to governing runbook',
+          body: 'Automation context should name its governing runbook before future agents act.',
+          privacyTier: 'internal_ops' as const,
+          confidence: 0.74,
+          sourceIds: ['source:automation'],
+        },
+        sourceIds: ['source:automation'],
+        reason: 'Context gap surfaced by map.',
+        createdBy: 'test',
+        createdAt: generatedAt,
+        reviewedAt: null,
+        reviewedBy: null,
+        reviewReason: null,
+      },
+    ]
+    const events = [
+      {
+        id: 'event:proposal-created',
+        kind: 'proposal_created' as const,
+        title: 'Proposal created',
+        summary: 'Relationship proposal entered review.',
+        privacyTier: 'internal_ops' as const,
+        confidence: 0.8,
+        sourceIds: ['source:automation'],
+        createdAt: generatedAt,
+        fingerprint: fingerprintOpenBrainRecord(['event:proposal-created']),
+      },
+    ]
+    const wikiPages = [
+      {
+        slug: 'operating-rules',
+        title: 'Operating Rules',
+        path: 'docs/open-brain/wiki/operating-rules.md',
+        markdown: '# Operating Rules',
+        sourceMemoryIds: ['memory:governance'],
+        privacyTier: 'internal_ops' as const,
+      },
+    ]
+
+    const relationshipMap = buildOpenBrainRelationshipMap({
+      sources,
+      events,
+      links: [
+        {
+          id: 'link:automation-runbook',
+          fromId: 'source:automation',
+          toId: 'source:runbook',
+          relationship: 'governed_by',
+          createdAt: generatedAt,
+        },
+      ],
+      memories,
+      proposals,
+      wikiPages,
+      generatedAt,
+    })
+
+    expect(relationshipMap.nodes.map((node) => node.id)).toEqual(expect.arrayContaining([
+      'source:automation',
+      'memory:governance',
+      'proposal-node:proposal:link-runbook',
+      'wiki:operating-rules',
+    ]))
+    expect(relationshipMap.edges).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'link:automation-runbook',
+        status: 'persisted',
+        strength: 'strong',
+      }),
+      expect.objectContaining({
+        fromId: 'source:automation',
+        toId: 'memory:governance',
+        relationship: 'supports_memory',
+      }),
+      expect.objectContaining({
+        fromId: 'memory:governance',
+        toId: 'wiki:operating-rules',
+        relationship: 'compiled_overlay',
+      }),
+    ]))
+    expect(relationshipMap.overview.staleSources).toBe(1)
+    expect(relationshipMap.overview.orphanedRecords).toBeGreaterThanOrEqual(1)
+    expect(relationshipMap.insights.map((insight) => insight.kind)).toEqual(expect.arrayContaining([
+      'review',
+      'missing_governance',
+    ]))
   })
 
   it('sanitizes secret-like content', () => {

--- a/lib/open-brain.ts
+++ b/lib/open-brain.ts
@@ -140,6 +140,60 @@ export interface OpenBrainProducerGate {
   note: string
 }
 
+export type OpenBrainRelationshipNodeType = 'source' | 'memory' | 'event' | 'wiki' | 'proposal'
+export type OpenBrainRelationshipEdgeStrength = 'strong' | 'medium' | 'weak'
+export type OpenBrainRelationshipInsightKind = 'strengthen' | 'review' | 'missing_governance' | 'merge_duplicate'
+
+export interface OpenBrainRelationshipNode {
+  id: string
+  label: string
+  type: OpenBrainRelationshipNodeType
+  kind: string
+  privacyTier: OpenBrainPrivacyTier
+  summary: string
+  path: string | null
+  health: 'green' | 'yellow' | 'red'
+  x: number
+  y: number
+}
+
+export interface OpenBrainRelationshipEdge {
+  id: string
+  fromId: string
+  toId: string
+  relationship: string
+  strength: OpenBrainRelationshipEdgeStrength
+  confidence: number
+  evidence: string
+  status: 'persisted' | 'inferred' | 'recommended'
+}
+
+export interface OpenBrainRelationshipInsight {
+  id: string
+  kind: OpenBrainRelationshipInsightKind
+  severity: 'low' | 'medium' | 'high'
+  title: string
+  detail: string
+  recommendation: string
+  actionLabel: string
+  sourceNodeId: string | null
+  targetNodeId: string | null
+}
+
+export interface OpenBrainRelationshipMap {
+  overview: {
+    relationships: number
+    strongRelationships: number
+    weakRelationships: number
+    orphanedRecords: number
+    staleSources: number
+    proposalSuggestions: number
+  }
+  nodes: OpenBrainRelationshipNode[]
+  edges: OpenBrainRelationshipEdge[]
+  insights: OpenBrainRelationshipInsight[]
+}
+
 export interface OpenBrainSnapshot {
   generatedAt: string
   service: {
@@ -189,6 +243,7 @@ export interface OpenBrainSnapshot {
   runtimeParity: OpenBrainRuntimeParity[]
   producerGates: OpenBrainProducerGate[]
   modelOps: ModelOpsProjection
+  relationshipMap: OpenBrainRelationshipMap
   contextPacket: {
     purpose: string
     boundaries: string[]
@@ -331,6 +386,15 @@ export async function getOpenBrainSnapshot(openBrainHome = getOpenBrainHome()): 
   const ragProjection = buildOpenBrainRagProjection(memories)
   const runtimeParity = await buildRuntimeParity(openBrainHome)
   const producerGates = buildProducerGates(modelOps)
+  const relationshipMap = buildOpenBrainRelationshipMap({
+    sources,
+    events,
+    links,
+    memories,
+    proposals,
+    wikiPages,
+    generatedAt,
+  })
   const pendingProposals = proposals.filter((proposal) => proposal.status === 'pending').length
   const approvedProposals = proposals.filter((proposal) => proposal.status === 'approved').length
   const rejectedProposals = proposals.filter((proposal) => proposal.status === 'rejected').length
@@ -375,6 +439,7 @@ export async function getOpenBrainSnapshot(openBrainHome = getOpenBrainHome()): 
     runtimeParity,
     producerGates,
     modelOps,
+    relationshipMap,
     contextPacket: buildContextPacket(sources, memories, proposals, modelOps, producerGates),
   }
 }
@@ -655,6 +720,149 @@ export function compileKarpathyWikiOverlay(
     })
   }
   return pages.sort((a, b) => a.slug.localeCompare(b.slug))
+}
+
+export function buildOpenBrainRelationshipMap({
+  sources,
+  events,
+  links,
+  memories,
+  proposals,
+  wikiPages,
+  generatedAt,
+}: {
+  sources: OpenBrainSourceRecord[]
+  events: OpenBrainEventRecord[]
+  links: OpenBrainLinkRecord[]
+  memories: OpenBrainMemoryRecord[]
+  proposals: OpenBrainProposalRecord[]
+  wikiPages: OpenBrainWikiPage[]
+  generatedAt: string
+}): OpenBrainRelationshipMap {
+  const visibleEvents = events.filter((event) => event.kind !== 'source_observed')
+  const nodes: OpenBrainRelationshipNode[] = [
+    ...sources.map((source, index) => sourceToRelationshipNode(source, index, generatedAt)),
+    ...memories.map((memory, index) => memoryToRelationshipNode(memory, index)),
+    ...visibleEvents.map((event, index) => eventToRelationshipNode(event, index)),
+    ...wikiPages.map((page, index) => wikiToRelationshipNode(page, index)),
+    ...proposals.map((proposal, index) => proposalToRelationshipNode(proposal, index)),
+  ]
+  const nodeIds = new Set(nodes.map((node) => node.id))
+  const edgeMap = new Map<string, OpenBrainRelationshipEdge>()
+
+  for (const link of links) {
+    if (!nodeIds.has(link.fromId) || !nodeIds.has(link.toId)) continue
+    addRelationshipEdge(edgeMap, {
+      id: link.id,
+      fromId: link.fromId,
+      toId: link.toId,
+      relationship: link.relationship,
+      strength: 'strong',
+      confidence: 0.94,
+      evidence: 'Persisted local Open Brain link record.',
+      status: 'persisted',
+    })
+  }
+
+  for (const memory of memories) {
+    for (const sourceId of memory.sourceIds) {
+      if (!nodeIds.has(sourceId)) continue
+      addRelationshipEdge(edgeMap, {
+        id: `edge:memory-source:${fingerprintOpenBrainRecord([memory.id, sourceId]).slice(0, 16)}`,
+        fromId: sourceId,
+        toId: memory.id,
+        relationship: 'supports_memory',
+        strength: memory.confidence >= 0.8 ? 'strong' : 'medium',
+        confidence: memory.confidence,
+        evidence: 'Memory record cites this source id.',
+        status: 'inferred',
+      })
+    }
+  }
+
+  for (const proposal of proposals) {
+    const proposalNodeId = relationshipProposalNodeId(proposal.id)
+    for (const sourceId of proposal.sourceIds) {
+      if (!nodeIds.has(sourceId)) continue
+      addRelationshipEdge(edgeMap, {
+        id: `edge:proposal-source:${fingerprintOpenBrainRecord([proposal.id, sourceId]).slice(0, 16)}`,
+        fromId: sourceId,
+        toId: proposalNodeId,
+        relationship: 'proposes_context',
+        strength: proposal.status === 'pending' ? 'medium' : 'weak',
+        confidence: proposal.proposedMemory.confidence,
+        evidence: 'Memory proposal cites this source id and still requires review.',
+        status: 'inferred',
+      })
+    }
+  }
+
+  for (const page of wikiPages) {
+    const wikiNodeId = relationshipWikiNodeId(page.slug)
+    for (const memoryId of page.sourceMemoryIds) {
+      if (!nodeIds.has(memoryId)) continue
+      addRelationshipEdge(edgeMap, {
+        id: `edge:wiki-memory:${fingerprintOpenBrainRecord([page.slug, memoryId]).slice(0, 16)}`,
+        fromId: memoryId,
+        toId: wikiNodeId,
+        relationship: 'compiled_overlay',
+        strength: 'strong',
+        confidence: 0.86,
+        evidence: 'Wiki overlay is compiled from this approved memory.',
+        status: 'inferred',
+      })
+    }
+  }
+
+  for (const event of visibleEvents) {
+    for (const sourceId of event.sourceIds) {
+      if (!nodeIds.has(sourceId)) continue
+      addRelationshipEdge(edgeMap, {
+        id: `edge:event-source:${fingerprintOpenBrainRecord([event.id, sourceId]).slice(0, 16)}`,
+        fromId: sourceId,
+        toId: event.id,
+        relationship: 'observed_event',
+        strength: event.confidence >= 0.75 ? 'medium' : 'weak',
+        confidence: event.confidence,
+        evidence: 'Event record cites this source id.',
+        status: 'inferred',
+      })
+    }
+  }
+
+  const edges = [...edgeMap.values()]
+  const connectedNodeIds = new Set<string>()
+  for (const edge of edges) {
+    connectedNodeIds.add(edge.fromId)
+    connectedNodeIds.add(edge.toId)
+  }
+
+  const staleSources = sources.filter((source) => isStale(source.lastObservedAt, generatedAt))
+  const orphanedNodes = nodes.filter((node) => !connectedNodeIds.has(node.id))
+  const weakEdges = edges.filter((edge) => edge.strength === 'weak')
+  const insights = buildRelationshipInsights({
+    nodes,
+    edges,
+    orphanedNodes,
+    staleSources,
+    sources,
+    memories,
+    proposals,
+  })
+
+  return {
+    overview: {
+      relationships: edges.length,
+      strongRelationships: edges.filter((edge) => edge.strength === 'strong').length,
+      weakRelationships: weakEdges.length,
+      orphanedRecords: orphanedNodes.length,
+      staleSources: staleSources.length,
+      proposalSuggestions: insights.length,
+    },
+    nodes,
+    edges,
+    insights,
+  }
 }
 
 export function fingerprintOpenBrainRecord(parts: unknown[]) {
@@ -990,6 +1198,281 @@ function buildContextPacket(
       'Unified router decision before local, frontier, hybrid, tool, or approval-gated model execution',
     ],
   }
+}
+
+function sourceToRelationshipNode(source: OpenBrainSourceRecord, index: number, generatedAt: string): OpenBrainRelationshipNode {
+  const point = relationshipPoint('source', source.kind, index)
+  return {
+    id: source.id,
+    label: source.title,
+    type: 'source',
+    kind: source.kind,
+    privacyTier: source.privacyTier,
+    summary: source.summary,
+    path: source.path,
+    health: source.privacyTier === 'private' ? 'red' : isStale(source.lastObservedAt, generatedAt) ? 'yellow' : 'green',
+    x: point.x,
+    y: point.y,
+  }
+}
+
+function memoryToRelationshipNode(memory: OpenBrainMemoryRecord, index: number): OpenBrainRelationshipNode {
+  const point = relationshipPoint('memory', memory.kind, index)
+  return {
+    id: memory.id,
+    label: memory.title,
+    type: 'memory',
+    kind: memory.kind,
+    privacyTier: memory.privacyTier,
+    summary: memory.body,
+    path: null,
+    health: memory.privacyTier === 'private' ? 'red' : memory.confidence >= 0.75 ? 'green' : 'yellow',
+    x: point.x,
+    y: point.y,
+  }
+}
+
+function eventToRelationshipNode(event: OpenBrainEventRecord, index: number): OpenBrainRelationshipNode {
+  const point = relationshipPoint('event', event.kind, index)
+  return {
+    id: event.id,
+    label: event.title,
+    type: 'event',
+    kind: event.kind,
+    privacyTier: event.privacyTier,
+    summary: event.summary,
+    path: typeof event.metadata?.path === 'string' ? event.metadata.path : null,
+    health: event.privacyTier === 'private' ? 'red' : event.confidence >= 0.75 ? 'green' : 'yellow',
+    x: point.x,
+    y: point.y,
+  }
+}
+
+function wikiToRelationshipNode(page: OpenBrainWikiPage, index: number): OpenBrainRelationshipNode {
+  const point = relationshipPoint('wiki', page.slug, index)
+  return {
+    id: relationshipWikiNodeId(page.slug),
+    label: page.title,
+    type: 'wiki',
+    kind: 'wiki_page',
+    privacyTier: page.privacyTier,
+    summary: `Compiled wiki overlay at ${page.path}.`,
+    path: page.path,
+    health: page.privacyTier === 'private' ? 'red' : page.sourceMemoryIds.length > 0 ? 'green' : 'yellow',
+    x: point.x,
+    y: point.y,
+  }
+}
+
+function proposalToRelationshipNode(proposal: OpenBrainProposalRecord, index: number): OpenBrainRelationshipNode {
+  const point = relationshipPoint('proposal', proposal.status, index)
+  return {
+    id: relationshipProposalNodeId(proposal.id),
+    label: proposal.proposedMemory.title,
+    type: 'proposal',
+    kind: proposal.proposedMemory.kind,
+    privacyTier: proposal.proposedMemory.privacyTier,
+    summary: proposal.reason,
+    path: null,
+    health: proposal.status === 'approved' ? 'green' : proposal.status === 'pending' ? 'yellow' : 'red',
+    x: point.x,
+    y: point.y,
+  }
+}
+
+function relationshipPoint(type: OpenBrainRelationshipNodeType, kind: string, index: number) {
+  const sourcePoints = kind === 'workspace_root_report'
+    ? [{ x: 12, y: 48 }]
+    : kind === 'codex_automation'
+      ? [
+          { x: 34, y: 31 },
+          { x: 23, y: 58 },
+          { x: 42, y: 62 },
+        ]
+      : kind === 'runbook'
+        ? [
+            { x: 55, y: 43 },
+            { x: 49, y: 72 },
+            { x: 66, y: 65 },
+          ]
+        : [
+            { x: 20, y: 23 },
+            { x: 29, y: 75 },
+            { x: 43, y: 17 },
+            { x: 58, y: 27 },
+            { x: 62, y: 80 },
+          ]
+  const points: Record<OpenBrainRelationshipNodeType, { x: number; y: number }[]> = {
+    source: sourcePoints,
+    memory: [
+      { x: 78, y: 25 },
+      { x: 82, y: 43 },
+      { x: 72, y: 62 },
+      { x: 88, y: 70 },
+    ],
+    event: [
+      { x: 22, y: 84 },
+      { x: 41, y: 86 },
+      { x: 60, y: 88 },
+      { x: 72, y: 82 },
+    ],
+    wiki: [
+      { x: 84, y: 58 },
+      { x: 90, y: 36 },
+      { x: 73, y: 80 },
+    ],
+    proposal: [
+      { x: 68, y: 88 },
+      { x: 52, y: 86 },
+      { x: 86, y: 86 },
+      { x: 76, y: 76 },
+    ],
+  }
+  const selected = points[type][index % points[type].length]
+  const rowOffset = Math.floor(index / points[type].length) * 4
+  return {
+    x: Math.max(8, Math.min(92, selected.x + rowOffset)),
+    y: Math.max(12, Math.min(92, selected.y - rowOffset)),
+  }
+}
+
+function relationshipWikiNodeId(slug: string) {
+  return `wiki:${slug}`
+}
+
+function relationshipProposalNodeId(id: string) {
+  return `proposal-node:${id}`
+}
+
+function addRelationshipEdge(map: Map<string, OpenBrainRelationshipEdge>, edge: OpenBrainRelationshipEdge) {
+  const existing = map.get(edge.id)
+  if (!existing || relationshipStrengthRank(edge.strength) > relationshipStrengthRank(existing.strength)) {
+    map.set(edge.id, edge)
+  }
+}
+
+function relationshipStrengthRank(strength: OpenBrainRelationshipEdgeStrength) {
+  return strength === 'strong' ? 3 : strength === 'medium' ? 2 : 1
+}
+
+function buildRelationshipInsights({
+  nodes,
+  edges,
+  orphanedNodes,
+  staleSources,
+  sources,
+  memories,
+  proposals,
+}: {
+  nodes: OpenBrainRelationshipNode[]
+  edges: OpenBrainRelationshipEdge[]
+  orphanedNodes: OpenBrainRelationshipNode[]
+  staleSources: OpenBrainSourceRecord[]
+  sources: OpenBrainSourceRecord[]
+  memories: OpenBrainMemoryRecord[]
+  proposals: OpenBrainProposalRecord[]
+}): OpenBrainRelationshipInsight[] {
+  const insights: OpenBrainRelationshipInsight[] = []
+  const runbookNode = nodes.find((node) => node.type === 'source' && node.kind === 'runbook')
+  const automationNode = nodes.find((node) => node.type === 'source' && node.kind === 'codex_automation')
+  const workspaceNode = nodes.find((node) => node.type === 'source' && node.kind === 'workspace_root_report')
+
+  if (automationNode && runbookNode && !edges.some((edge) => edge.fromId === automationNode.id && edge.toId === runbookNode.id)) {
+    insights.push({
+      id: 'insight:strengthen:automation-runbook',
+      kind: 'strengthen',
+      severity: 'medium',
+      title: 'Strengthen automation-to-runbook governance',
+      detail: 'Codex automation sources and Portfolio runbooks appear in the same Open Brain projection but do not have a persisted relationship.',
+      recommendation: 'Create a relationship proposal linking the automation source to the governing runbook before future agents act on it.',
+      actionLabel: 'Propose link',
+      sourceNodeId: automationNode.id,
+      targetNodeId: runbookNode.id,
+    })
+  }
+
+  if (workspaceNode && runbookNode && !edges.some((edge) => edge.fromId === workspaceNode.id && edge.toId === runbookNode.id)) {
+    insights.push({
+      id: 'insight:strengthen:workspace-runbook',
+      kind: 'strengthen',
+      severity: 'medium',
+      title: 'Tie workspace-root state to its governing runbook',
+      detail: 'The workspace-root report is central to current Codex context, but its governing document is not explicitly linked.',
+      recommendation: 'Propose a durable link from workspace-root state to the memory/context organization workflow.',
+      actionLabel: 'Propose link',
+      sourceNodeId: workspaceNode.id,
+      targetNodeId: runbookNode.id,
+    })
+  }
+
+  for (const source of staleSources.slice(0, 2)) {
+    insights.push({
+      id: `insight:review:stale:${source.id}`,
+      kind: 'review',
+      severity: 'medium',
+      title: `Review stale source: ${source.title}`,
+      detail: 'This source is older than the freshness threshold and may make wiki or RAG overlays look more current than they are.',
+      recommendation: 'Refresh the source through its owning producer before promoting related context.',
+      actionLabel: 'Review source',
+      sourceNodeId: source.id,
+      targetNodeId: null,
+    })
+  }
+
+  for (const orphan of orphanedNodes.filter((node) => node.type !== 'wiki').slice(0, 2)) {
+    insights.push({
+      id: `insight:missing-governance:${orphan.id}`,
+      kind: 'missing_governance',
+      severity: orphan.type === 'proposal' ? 'high' : 'medium',
+      title: `Connect orphaned ${orphan.type}: ${orphan.label}`,
+      detail: 'This record has no visible relationship edge in the current projection.',
+      recommendation: 'Add a source, governing document, or explicit persisted link before relying on it as agent context.',
+      actionLabel: 'Open source',
+      sourceNodeId: orphan.id,
+      targetNodeId: runbookNode?.id || null,
+    })
+  }
+
+  const duplicateTitle = findDuplicateMemoryTitle(memories)
+  if (duplicateTitle) {
+    insights.push({
+      id: `insight:merge:${fingerprintOpenBrainRecord([duplicateTitle]).slice(0, 12)}`,
+      kind: 'merge_duplicate',
+      severity: 'low',
+      title: `Review duplicate memory title: ${duplicateTitle}`,
+      detail: 'Multiple durable memories share a normalized title and may describe the same operating rule.',
+      recommendation: 'Review the memories and propose a merge only after confirming they share the same source basis.',
+      actionLabel: 'Review duplicate',
+      sourceNodeId: null,
+      targetNodeId: null,
+    })
+  }
+
+  if (insights.length === 0 && proposals.some((proposal) => proposal.status === 'pending')) {
+    const proposal = proposals.find((candidate) => candidate.status === 'pending')
+    insights.push({
+      id: 'insight:review:pending-proposals',
+      kind: 'review',
+      severity: 'medium',
+      title: 'Review pending memory proposals',
+      detail: 'Pending memory proposals are visible in the relationship map but are not durable memory yet.',
+      recommendation: 'Approve or reject sourced proposals before compiling wiki overlays.',
+      actionLabel: 'Review proposals',
+      sourceNodeId: proposal ? relationshipProposalNodeId(proposal.id) : null,
+      targetNodeId: null,
+    })
+  }
+
+  return insights.slice(0, 6)
+}
+
+function findDuplicateMemoryTitle(memories: OpenBrainMemoryRecord[]) {
+  const titles = new Map<string, number>()
+  for (const memory of memories) {
+    const normalized = memory.title.toLowerCase().replace(/\s+/g, ' ').trim()
+    titles.set(normalized, (titles.get(normalized) || 0) + 1)
+  }
+  return [...titles.entries()].find(([, count]) => count > 1)?.[0] || null
 }
 
 async function readOptionalText(filePath: string) {


### PR DESCRIPTION
## Summary
- Adds a read-only Map tab to `/admin/agents/open-brain` for Open Brain relationship visibility.
- Projects sources, memories, events, proposals, wiki overlays, and persisted links into a relationship map with overview counts, graph nodes/edges, filters, and proposal-only insights.
- Keeps relationship changes governance-aligned: insight actions only explain that changes must become proposals; they do not mutate Open Brain.

## Validation
- `npm test -- --run lib/open-brain.test.ts app/admin/agents/open-brain/page.test.tsx`
- `npm run lint`
- `npm run build`
- Browser smoke: `http://localhost:3011/admin/agents/open-brain` served successfully, but in-app browser was stopped at the auth screen, so authenticated visual QA was not completed.
- Pre-push hook: `npm run db:health-check` passed against configured `.env.local` values.

## Integration Notes
- No migrations or env changes required.
- V1 remains read-only/proposal-gated; no direct writes to `~/.codex/memories`, `~/.codex/automations`, Open Brain local state, or Portfolio database records.
- Build emitted existing local env warnings that `MOCK_N8N=false` and `N8N_DISABLE_OUTBOUND=false`; no outbound n8n workflow was invoked by this change.
- Vercel contexts not checked by this non-captain lane: `Vercel – portfolio`, `Vercel – portfolio-staging`.