### PR TITLE
docs: record staging ingest rotation evidence

### DIFF
--- a/docs/credential-baseline-evidence.md
+++ b/docs/credential-baseline-evidence.md
@@ -1,6 +1,6 @@
 # Credential Baseline Evidence
 
-Last updated: 2026-05-13
+Last updated: 2026-05-25
 
 This note records the value-free evidence used to replace the staging `pending-provider-confirmation` baselines in `docs/credential-inventory.json`.
 
@@ -21,6 +21,8 @@ No secret values were read, printed, committed, or copied into this file. The ev
 | `STRIPE_SECRET_KEY` | 2026-05-13 | Approved staging-only rotation drill: Infisical staging `/portfolio` secret synced, local and `portfolio-staging` Vercel runtime sinks updated, staging redeployed, and Stripe API smokes returned 200. |
 | `STRIPE_WEBHOOK_SECRET` | 2026-05-13 | Approved staging-only rotation drill: Infisical staging `/portfolio` secret synced, local and `portfolio-staging` Vercel runtime sinks updated, Stripe destination URL corrected to `/api/payments/webhook`, and a signed staging webhook probe returned 200. |
 | `GITHUB_TOKEN` | 2026-05-13 | Approved staging-only rotation drill: Infisical staging `/portfolio` secret synced, local and `portfolio-staging` Vercel runtime sinks updated, and GitHub repo-read smoke returned 200. |
+| `N8N_INGEST_SECRET` | 2026-05-25 | Approved staging-only coupled ingest rotation: Infisical staging `/portfolio` entries `N8N_INGEST_SECRET` and `STAG_N8N_INGEST_SECRET` synced, `portfolio-staging` Vercel runtime sink updated, n8n `ATAS Staging` variable `STAG_N8N_INGEST_SECRET` updated via API, staging redeployed, and hash-only verification matched. |
+| `STAG_N8N_INGEST_SECRET` | 2026-05-25 | Approved staging-only coupled ingest rotation: n8n `ATAS Staging` variable updated via API with the same generated value as the staging app-side ingest secret; hash-only verification matched. |
 | `GOOGLE_SERVICE_ACCOUNT_KEY` | 2026-05-13 | Vercel Preview metadata after approved preview sync on 2026-05-13T13:27:32Z. |
 | `LINKEDIN_COOKIE` | 2026-05-13 | Operator added a current LinkedIn `li_at` session cookie to local env on 2026-05-13. |
 | `GMAIL_APP_PASSWORD` | 2026-05-01 | 1Password `Portfolio / staging` item metadata for `GMAIL_APP_PASSWORD`, created/updated 2026-05-01T14:48:30Z. |

--- a/docs/credential-inventory.json
+++ b/docs/credential-inventory.json
@@ -79,9 +79,9 @@
         },
         "staging": {
           "status": "confirmed",
-          "lastRotatedAt": "2026-04-16",
-          "evidence": "n8n Credentials metadata: ATAS Ingest Bearer Auth updated 2026-04-16T03:44:21Z; value not read.",
-          "updatedAt": "2026-05-13"
+          "lastRotatedAt": "2026-05-25",
+          "evidence": "Approved staging-only coupled ingest rotation: Infisical staging /portfolio entries N8N_INGEST_SECRET and STAG_N8N_INGEST_SECRET synced, portfolio-staging Vercel runtime sink updated, n8n ATAS Staging variable STAG_N8N_INGEST_SECRET updated via API, staging redeployed, and hash-only verification matched; value not printed.",
+          "updatedAt": "2026-05-25"
         },
         "prod": {
           "status": "pending-provider-confirmation",
@@ -1762,10 +1762,10 @@
       "rollback": "Rotate together with the staging app-side N8N_INGEST_SECRET so n8n and Vercel continue to match.",
       "baseline": {
         "staging": {
-          "status": "pending-provider-confirmation",
-          "lastRotatedAt": null,
-          "evidence": "Staging n8n variable mapping added 2026-05-24; value and last rotation date require n8n Variables or provider-confirmed evidence. Do not infer from .env.local.",
-          "updatedAt": "2026-05-24"
+          "status": "confirmed",
+          "lastRotatedAt": "2026-05-25",
+          "evidence": "Approved staging-only coupled ingest rotation: n8n ATAS Staging variable STAG_N8N_INGEST_SECRET updated via API with the same generated value as Infisical staging /portfolio N8N_INGEST_SECRET; hash-only verification matched; value not printed.",
+          "updatedAt": "2026-05-25"
         }
       }
     },


### PR DESCRIPTION
## Summary
- records the approved staging-only coupled rotation for N8N_INGEST_SECRET and STAG_N8N_INGEST_SECRET
- updates staging rotation baselines with value-free evidence after Infisical, Vercel, n8n, local staging sync, and redeploy
- keeps production untouched and notes no secret values were printed or committed

## Validation
- Infisical CLI scoped read for staging /portfolio N8N_INGEST_SECRET
- Hash-only verification matched Infisical, n8n ATAS Staging variable, and local .env.staging
- Vercel portfolio-staging production redeploy: dpl_66e6XkZz8k1v8GXq2zVC7xQ9Jjp1, READY, aliased to https://portfolio-staging-ten.vercel.app
- npm run credentials:smoke -- --env staging
- npm run credentials:report -- --env staging --check-sinks
- node -e "JSON.parse(require('fs').readFileSync('docs/credential-inventory.json','utf8')); console.log('credential-inventory-json-ok')"
- git diff --check -- docs/credential-inventory.json docs/credential-baseline-evidence.md

## Integration Notes
- Production was not touched.
- Strict provider smoke with --require-provider-access still fails because 1Password lacks an item titled LINKEDIN_COOKIE in vault Portfolio / staging; this is a separate 1Password inventory gap.
- Runtime sink report still shows remaining baseline and Vercel/n8n metadata gaps unrelated to this rotation.
- Vercel contexts: portfolio not redeployed; portfolio-staging redeployed and READY.