### PR TITLE
feat: propose open brain relationship reviews

### DIFF
--- a/app/admin/agents/open-brain/page.test.tsx
+++ b/app/admin/agents/open-brain/page.test.tsx
@@ -233,10 +233,24 @@ const openBrainSnapshot = {
 
 describe('OpenBrainPage', () => {
   beforeEach(() => {
-    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input)
       if (url.includes('/wiki/compile')) {
         return { ok: true, json: async () => ({ pages: [{ slug: 'one' }] }) }
+      }
+      if (url.endsWith('/api/admin/agents/open-brain/proposals') && init?.method === 'POST') {
+        return {
+          ok: true,
+          json: async () => ({
+            proposal: {
+              id: 'proposal:relationship-1',
+              status: 'pending',
+              proposedMemory: {
+                title: 'Relationship proposal: Strengthen automation-to-runbook governance',
+              },
+            },
+          }),
+        }
       }
       return { ok: true, json: async () => openBrainSnapshot }
     }))
@@ -304,7 +318,7 @@ describe('OpenBrainPage', () => {
     }))
   })
 
-  it('renders the relationship map as a proposal-only Open Brain view', async () => {
+  it('creates an approval-gated relationship proposal from a map insight', async () => {
     render(<OpenBrainPage />)
 
     const tabs = await screen.findByRole('button', { name: 'Map' })
@@ -320,6 +334,23 @@ describe('OpenBrainPage', () => {
 
     fireEvent.click(within(map).getByRole('button', { name: 'Propose link' }))
 
-    expect(screen.getByText('Propose link is proposal-only in v1. No Open Brain link was changed from this map.')).toBeInTheDocument()
+    expect(await screen.findByText('Relationship proposal created for review: Relationship proposal: Strengthen automation-to-runbook governance. No Open Brain link was changed.')).toBeInTheDocument()
+    expect(fetch).toHaveBeenCalledWith('/api/admin/agents/open-brain/proposals', expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({ Authorization: 'Bearer admin-token' }),
+      body: expect.any(String),
+    }))
+
+    const proposalCall = vi.mocked(fetch).mock.calls.find(([url, init]) => (
+      String(url).endsWith('/api/admin/agents/open-brain/proposals') && init?.method === 'POST'
+    ))
+    expect(proposalCall).toBeTruthy()
+    expect(JSON.parse(String(proposalCall?.[1]?.body))).toEqual(expect.objectContaining({
+      kind: 'workflow',
+      title: 'Relationship proposal: Strengthen automation-to-runbook governance',
+      privacyTier: 'internal_ops',
+      sourceIds: ['source-1'],
+      reason: expect.stringContaining('insight-1'),
+    }))
   })
 })

--- a/app/admin/agents/open-brain/page.tsx
+++ b/app/admin/agents/open-brain/page.tsx
@@ -20,7 +20,12 @@ import {
 import ProtectedRoute from '@/components/ProtectedRoute'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
 import { getCurrentSession } from '@/lib/auth'
-import type { OpenBrainRelationshipNodeType, OpenBrainSnapshot } from '@/lib/open-brain'
+import type {
+  OpenBrainPrivacyTier,
+  OpenBrainRelationshipInsight,
+  OpenBrainRelationshipNodeType,
+  OpenBrainSnapshot,
+} from '@/lib/open-brain'
 
 type ViewMode = 'router' | 'sources' | 'proposals' | 'wiki' | 'parity' | 'producers' | 'map'
 
@@ -39,6 +44,7 @@ function OpenBrainContent() {
   const [viewMode, setViewMode] = useState<ViewMode>('router')
   const [actionMessage, setActionMessage] = useState<string | null>(null)
   const [reviewingProposalId, setReviewingProposalId] = useState<string | null>(null)
+  const [proposingInsightId, setProposingInsightId] = useState<string | null>(null)
 
   const authedFetch = useCallback(async (url: string, init: RequestInit = {}) => {
     const session = await getCurrentSession()
@@ -105,8 +111,24 @@ function OpenBrainContent() {
     }
   }
 
-  function handleRelationshipSuggestion(actionLabel: string) {
-    setActionMessage(`${actionLabel} is proposal-only in v1. No Open Brain link was changed from this map.`)
+  async function handleRelationshipSuggestion(insight: OpenBrainRelationshipInsight) {
+    if (!snapshot) return
+    setActionMessage(null)
+    setProposingInsightId(insight.id)
+    try {
+      const payload = buildRelationshipProposalPayload(snapshot, insight)
+      const body = await authedFetch('/api/admin/agents/open-brain/proposals', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      })
+      setActionMessage(`Relationship proposal created for review: ${body.proposal?.proposedMemory?.title || insight.title}. No Open Brain link was changed.`)
+      setViewMode('proposals')
+      await fetchSnapshot()
+    } catch (err) {
+      setActionMessage(err instanceof Error ? err.message : 'Relationship proposal creation failed')
+    } finally {
+      setProposingInsightId(null)
+    }
   }
 
   return (
@@ -237,7 +259,13 @@ function OpenBrainContent() {
             {viewMode === 'wiki' ? <WikiView pages={snapshot.wikiPages} /> : null}
             {viewMode === 'parity' ? <ParityView snapshot={snapshot} /> : null}
             {viewMode === 'producers' ? <ProducerView snapshot={snapshot} /> : null}
-            {viewMode === 'map' ? <RelationshipMapView snapshot={snapshot} onSuggestionAction={handleRelationshipSuggestion} /> : null}
+            {viewMode === 'map' ? (
+              <RelationshipMapView
+                snapshot={snapshot}
+                proposingInsightId={proposingInsightId}
+                onSuggestionAction={handleRelationshipSuggestion}
+              />
+            ) : null}
 
             <p className="mt-5 text-xs text-muted-foreground">
               Generated {formatDateTime(snapshot.generatedAt)}. {snapshot.service.operationalBoundary}
@@ -570,10 +598,12 @@ function RouterView({ snapshot }: { snapshot: OpenBrainSnapshot }) {
 
 function RelationshipMapView({
   snapshot,
+  proposingInsightId,
   onSuggestionAction,
 }: {
   snapshot: OpenBrainSnapshot
-  onSuggestionAction: (actionLabel: string) => void
+  proposingInsightId: string | null
+  onSuggestionAction: (insight: OpenBrainRelationshipInsight) => void
 }) {
   const [typeFilter, setTypeFilter] = useState<OpenBrainRelationshipNodeType | 'all'>('all')
   const map = snapshot.relationshipMap
@@ -702,10 +732,11 @@ function RelationshipMapView({
                 <p className="mt-2 text-xs leading-relaxed text-foreground/85">{insight.recommendation}</p>
                 <button
                   type="button"
-                  onClick={() => onSuggestionAction(insight.actionLabel)}
-                  className="mt-3 inline-flex items-center gap-2 rounded-lg border border-radiant-gold/40 bg-radiant-gold/10 px-3 py-2 text-xs font-medium text-radiant-gold hover:bg-radiant-gold/15"
+                  onClick={() => onSuggestionAction(insight)}
+                  disabled={proposingInsightId === insight.id}
+                  className="mt-3 inline-flex items-center gap-2 rounded-lg border border-radiant-gold/40 bg-radiant-gold/10 px-3 py-2 text-xs font-medium text-radiant-gold hover:bg-radiant-gold/15 disabled:cursor-not-allowed disabled:opacity-60"
                 >
-                  {insight.actionLabel}
+                  {proposingInsightId === insight.id ? 'Creating proposal...' : insight.actionLabel}
                 </button>
               </article>
             )) : (
@@ -716,6 +747,47 @@ function RelationshipMapView({
       </div>
     </section>
   )
+}
+
+function buildRelationshipProposalPayload(snapshot: OpenBrainSnapshot, insight: OpenBrainRelationshipInsight) {
+  const nodes = snapshot.relationshipMap.nodes
+  const sourceNode = insight.sourceNodeId ? nodes.find((node) => node.id === insight.sourceNodeId) : null
+  const targetNode = insight.targetNodeId ? nodes.find((node) => node.id === insight.targetNodeId) : null
+  const sourceIds = [sourceNode, targetNode]
+    .filter((node): node is NonNullable<typeof node> => Boolean(node && node.type === 'source'))
+    .map((node) => node.id)
+  const relationshipLabel = sourceNode && targetNode
+    ? `${sourceNode.label} -> ${targetNode.label}`
+    : sourceNode
+      ? sourceNode.label
+      : targetNode
+        ? targetNode.label
+        : 'Unscoped relationship insight'
+  const title = `Relationship proposal: ${insight.title}`
+  const body = [
+    `Relationship insight: ${insight.detail}`,
+    `Recommended change: ${insight.recommendation}`,
+    `Relationship path: ${relationshipLabel}`,
+    `Insight kind: ${insight.kind.replace(/_/g, ' ')}`,
+    'Authority boundary: this proposal records the recommended relationship context for review; approval does not directly write Open Brain link records.',
+  ].join('\n')
+
+  return {
+    kind: 'workflow',
+    title,
+    body,
+    privacyTier: strongestPrivacyTier([sourceNode?.privacyTier, targetNode?.privacyTier]),
+    confidence: insight.severity === 'high' ? 0.84 : insight.severity === 'medium' ? 0.78 : 0.72,
+    sourceIds,
+    reason: `Created from Open Brain relationship map insight ${insight.id}. Review before durable memory or link changes.`,
+  }
+}
+
+function strongestPrivacyTier(tiers: Array<OpenBrainPrivacyTier | undefined>): OpenBrainPrivacyTier {
+  if (tiers.includes('private')) return 'private'
+  if (tiers.includes('internal_ops')) return 'internal_ops'
+  if (tiers.includes('client_safe')) return 'client_safe'
+  return 'public_safe'
 }
 
 function RelationshipMetric({


### PR DESCRIPTION
## Summary
- Turns Open Brain Map insight actions into approval-gated relationship review proposals.
- Clicking a relationship insight now creates a sourced Open Brain memory proposal through the existing admin proposal API, then routes the operator to the Proposals queue.
- Keeps the map governance boundary intact: no Open Brain link record is written directly from the graph.

## Enhancement Impact Preflight
- Enhancement: Open Brain relationship-map insight actions create proposal-review records.
- User-facing surface: `/admin/agents/open-brain` Map and Proposals tabs.
- Predicted files: `app/admin/agents/open-brain/page.tsx`, `app/admin/agents/open-brain/page.test.tsx`, with possible read-only use of existing `/api/admin/agents/open-brain/proposals`.
- Shared routes/APIs/tables/helpers: reuses existing `POST /api/admin/agents/open-brain/proposals`; no schema, table, or Open Brain link-write changes.
- Active PRs or branches checked: #384 `codex/voice-note-content-swarm`, #387 `codex/apify-staging-rotation-evidence`.
- Dirty worktree files checked: root checkout has unrelated `tmp/`; this worktree was clean before edits.
- Overlap rating: green.
- Coordination decision: proceed independently; no active PR touches the Open Brain admin files.
- Merge-order note: can merge after PR #385, which is already merged into `origin/main` and is this branch base.

## Validation
- `npm test -- --run app/admin/agents/open-brain/page.test.tsx lib/open-brain.test.ts app/api/admin/agents/open-brain/proposals/route.test.ts`
- `npm run lint`
- `npm run build`
- Pre-push hook: `npm run db:health-check` passed against configured `.env.local` values.

## Integration Notes
- No migrations or environment changes required.
- No direct edits to `~/.codex/memories`, `~/.codex/automations`, `~/.open-brain`, or Portfolio database records.
- The relationship review proposal is a durable memory proposal only after approval; approval still does not write link records directly.
- Build emitted the existing local env warning that `MOCK_N8N=false` and `N8N_DISABLE_OUTBOUND=false`; this change did not invoke outbound n8n workflows.
- Vercel contexts not checked by this non-captain lane: `Vercel – portfolio`, `Vercel – portfolio-staging`.