### PR TITLE
Add banned books Evidence QA approval flow

### DIFF
--- a/app/admin/source-protocol/page.test.tsx
+++ b/app/admin/source-protocol/page.test.tsx
@@ -185,6 +185,51 @@ const overview = {
     ],
     safeguards: ['Do not ingest full text before license approval.'],
   },
+  bannedBooksEvidenceQa: {
+    generatedAt: '2026-05-25T00:00:00.000Z',
+    reviewer: 'Timbuktu Scribe',
+    sourceImportPath: 'data/source-protocol/banned-books-source-import-sample.json',
+    dryRun: true,
+    summary: {
+      importRows: 3,
+      decisions: 3,
+      approvedQueueAppends: 1,
+      needsMoreEvidence: 1,
+      rejected: 1,
+      blocked: 2,
+      alreadyQueued: 0,
+    },
+    rows: [
+      {
+        externalId: 'ala-2025-the-57-bus',
+        canonicalTitle: 'The 57 Bus',
+        importStatus: 'ready_for_qa',
+        decision: 'approved',
+        approved: true,
+        blocked: false,
+        reason: 'Metadata-only source evidence approved.',
+        queueAppendDraft: {
+          externalId: 'ala-2025-the-57-bus',
+        },
+      },
+      {
+        externalId: 'manual-missing-evidence',
+        canonicalTitle: 'Manual Row Missing Evidence',
+        importStatus: 'needs_evidence_review',
+        decision: 'needs_more_evidence',
+        approved: false,
+        blocked: true,
+        reason: 'Hold for evidence.',
+        queueAppendDraft: null,
+      },
+    ],
+    queueAppendDrafts: [
+      {
+        externalId: 'ala-2025-the-57-bus',
+      },
+    ],
+    blockedActions: ['It does not write licensed works.'],
+  },
 }
 
 describe('SourceProtocolPage', () => {
@@ -207,6 +252,8 @@ describe('SourceProtocolPage', () => {
     expect(screen.getByText('Amina, Source Registry Lead')).toBeInTheDocument()
     expect(screen.getByText('Permission request: rights-cleared retrieval for your challenged work')).toBeInTheDocument()
     expect(screen.getByText('Source ingestion queue')).toBeInTheDocument()
+    expect(screen.getByText('Evidence QA approval queue')).toBeInTheDocument()
+    expect(screen.getByText('The 57 Bus')).toBeInTheDocument()
     expect(screen.getByText('Held Candidate Book')).toBeInTheDocument()
     expect(screen.getAllByText('Demo Challenged Book').length).toBeGreaterThanOrEqual(1)
 

--- a/app/admin/source-protocol/page.tsx
+++ b/app/admin/source-protocol/page.tsx
@@ -79,6 +79,24 @@ type SourceProtocolOverview = {
     records: any[]
     safeguards: string[]
   }
+  bannedBooksEvidenceQa?: {
+    generatedAt: string
+    reviewer: string
+    sourceImportPath: string
+    dryRun: boolean
+    summary: {
+      importRows: number
+      decisions: number
+      approvedQueueAppends: number
+      needsMoreEvidence: number
+      rejected: number
+      blocked: number
+      alreadyQueued: number
+    }
+    rows: any[]
+    queueAppendDrafts: any[]
+    blockedActions: string[]
+  }
 }
 
 type AdminUserOption = {
@@ -363,7 +381,12 @@ function SourceProtocolContent() {
                   onUpdate={updatePortalAccount}
                 />
               )}
-              {tab === 'bannedBooks' && <BannedBooksCorpusPanel corpus={overview.bannedBooksCorpus} />}
+              {tab === 'bannedBooks' && (
+                <BannedBooksCorpusPanel
+                  corpus={overview.bannedBooksCorpus}
+                  evidenceQa={overview.bannedBooksEvidenceQa}
+                />
+              )}
               {tab === 'creators' && <CreatorsTable rows={overview.creators ?? []} />}
               {tab === 'works' && <WorksTable rows={overview.works ?? []} />}
               {tab === 'grants' && <GrantsTable rows={overview.licenseGrants ?? []} />}
@@ -614,7 +637,13 @@ function PortalAccountsPanel({
   )
 }
 
-function BannedBooksCorpusPanel({ corpus }: { corpus: SourceProtocolOverview['bannedBooksCorpus'] }) {
+function BannedBooksCorpusPanel({
+  corpus,
+  evidenceQa,
+}: {
+  corpus: SourceProtocolOverview['bannedBooksCorpus']
+  evidenceQa?: SourceProtocolOverview['bannedBooksEvidenceQa']
+}) {
   if (!corpus) {
     return (
       <div className="rounded-lg border border-silicon-slate px-4 py-8 text-center text-sm text-muted-foreground">
@@ -700,6 +729,48 @@ function BannedBooksCorpusPanel({ corpus }: { corpus: SourceProtocolOverview['ba
                   <p>Draft: {candidate.stagedRecordDraft ? candidate.stagedRecordDraft.id : 'Held'}</p>
                 </div>
                 <div className="text-muted-foreground">{candidate.nextAction}</div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {evidenceQa && (
+        <section className="overflow-hidden rounded-lg border border-silicon-slate">
+          <div className="bg-silicon-slate/60 px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Evidence QA approval queue
+          </div>
+          <div className="grid grid-cols-2 gap-3 border-b border-silicon-slate p-4 lg:grid-cols-7">
+            <Stat icon={<FileText size={18} />} label="Import rows" value={evidenceQa.summary.importRows} />
+            <Stat icon={<ShieldCheck size={18} />} label="Decisions" value={evidenceQa.summary.decisions} />
+            <Stat icon={<BookOpenCheck size={18} />} label="Approved" value={evidenceQa.summary.approvedQueueAppends} />
+            <Stat icon={<AlertTriangle size={18} />} label="Needs evidence" value={evidenceQa.summary.needsMoreEvidence} />
+            <Stat icon={<AlertTriangle size={18} />} label="Rejected" value={evidenceQa.summary.rejected} />
+            <Stat icon={<AlertTriangle size={18} />} label="Blocked" value={evidenceQa.summary.blocked} />
+            <Stat icon={<Database size={18} />} label="Already queued" value={evidenceQa.summary.alreadyQueued} />
+          </div>
+          <div className="border-b border-silicon-slate px-4 py-3 text-sm text-muted-foreground">
+            Reviewer: {evidenceQa.reviewer}. Dry run: {String(evidenceQa.dryRun)}. Source import: {evidenceQa.sourceImportPath}.
+          </div>
+          <div className="divide-y divide-silicon-slate">
+            {evidenceQa.rows.map((row) => (
+              <div key={row.externalId} className="grid grid-cols-1 gap-3 px-4 py-4 text-sm lg:grid-cols-5 lg:gap-4">
+                <div>
+                  <p className="font-medium text-foreground">{row.canonicalTitle}</p>
+                  <p className="font-mono text-xs text-muted-foreground">{row.externalId}</p>
+                </div>
+                <div className="text-muted-foreground">
+                  <p>{row.importStatus}</p>
+                  <p>{row.decision}</p>
+                </div>
+                <div className="text-muted-foreground">
+                  <p>Approved: {String(row.approved)}</p>
+                  <p>Blocked: {String(row.blocked)}</p>
+                </div>
+                <div className="text-muted-foreground">
+                  <p>Draft: {row.queueAppendDraft ? row.queueAppendDraft.externalId : 'None'}</p>
+                </div>
+                <div className="text-muted-foreground">{row.reason}</div>
               </div>
             ))}
           </div>

--- a/app/api/admin/source-protocol/overview/route.test.ts
+++ b/app/api/admin/source-protocol/overview/route.test.ts
@@ -220,6 +220,19 @@ describe('GET /api/admin/source-protocol/overview', () => {
           expect.objectContaining({ key: 'rights-governance-review' }),
         ]),
       },
+      bannedBooksEvidenceQa: {
+        reviewer: 'Timbuktu Scribe',
+        dryRun: true,
+        summary: {
+          importRows: 4,
+          decisions: 3,
+          approvedQueueAppends: 1,
+          needsMoreEvidence: 1,
+          rejected: 1,
+          blocked: 3,
+          alreadyQueued: 0,
+        },
+      },
     })
     expect(mocks.from).toHaveBeenCalledWith('source_creators')
     expect(mocks.from).toHaveBeenCalledWith('answer_receipt_chunks')

--- a/app/api/admin/source-protocol/overview/route.ts
+++ b/app/api/admin/source-protocol/overview/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
 import { supabaseAdmin } from '@/lib/supabase'
 import { buildBannedBooksCorpusProjection } from '@/lib/banned-books-corpus'
+import { buildEvidenceQaApprovalPlanFromFiles } from '@/lib/banned-books-evidence-qa'
 
 export const dynamic = 'force-dynamic'
 
@@ -193,6 +194,10 @@ export async function GET(request: NextRequest) {
       disputes: disputeRows,
       modelReviews: modelReviewRows,
       bannedBooksCorpus: buildBannedBooksCorpusProjection(),
+      bannedBooksEvidenceQa: buildEvidenceQaApprovalPlanFromFiles(
+        'data/source-protocol/banned-books-source-import-sample.json',
+        'data/source-protocol/banned-books-evidence-qa-approvals.sample.json'
+      ),
     })
   } catch (error: any) {
     if (isMissingSourceProtocolSchema(error)) {

--- a/data/source-protocol/banned-books-evidence-qa-approvals.sample.json
+++ b/data/source-protocol/banned-books-evidence-qa-approvals.sample.json
@@ -1,0 +1,26 @@
+{
+  "generatedAt": "2026-05-25T00:00:00.000Z",
+  "reviewer": "Timbuktu Scribe",
+  "approvalType": "evidence_qa_queue_append",
+  "sourceImportPath": "data/source-protocol/banned-books-source-import-sample.json",
+  "decisions": [
+    {
+      "externalId": "ala-2025-the-57-bus",
+      "decision": "approved",
+      "approvedAt": "2026-05-25T00:00:00.000Z",
+      "notes": "Metadata-only candidate has source URL, challenge-list evidence, author, title, affected audience, and no full-text fields."
+    },
+    {
+      "externalId": "manual-missing-evidence",
+      "decision": "needs_more_evidence",
+      "approvedAt": null,
+      "notes": "Hold until source evidence note and cross-source confirmation are attached."
+    },
+    {
+      "externalId": "manual-full-text-rejected",
+      "decision": "rejected",
+      "approvedAt": null,
+      "notes": "Rejected because importer detected a forbidden fullText field."
+    }
+  ]
+}

--- a/docs/banned-books-rights-ready-corpus.md
+++ b/docs/banned-books-rights-ready-corpus.md
@@ -20,6 +20,8 @@ npm run banned-books:ingestion:report
 npm run banned-books:ingestion:report -- --json
 npm run banned-books:source:import
 npm run banned-books:source:import -- --input data/source-protocol/banned-books-source-import-sample.json --json
+npx tsx scripts/approve-banned-books-source-candidates.ts
+npx tsx scripts/approve-banned-books-source-candidates.ts --json
 ```
 
 The projection reuses the existing Source-Respecting LLM Protocol:
@@ -99,6 +101,21 @@ Rows that are not duplicates and have confirmed source evidence become
 `ready_for_qa` queue append drafts. The importer still performs no writes; the
 append draft must be reviewed by Evidence QA before it is copied into the source
 ingestion queue.
+
+## Evidence QA Approval
+
+`npx tsx scripts/approve-banned-books-source-candidates.ts` reads a source
+import file and an Evidence QA approval packet. By default it is dry-run only.
+It approves only rows that the importer classified as `ready_for_qa`, have an
+`approved` Evidence QA decision, include `approvedAt`, and produce a metadata
+queue append draft.
+
+The approval packet cannot override importer rejections. Rows with full-text
+fields, unknown source keys, duplicates, or missing evidence remain blocked.
+`--apply` is intentionally explicit and only appends approved metadata-only
+candidates to `data/source-protocol/banned-books-source-ingestion-queue.json`.
+It does not write licensed works, license grants, source chunks, embeddings,
+retrieval flags, outreach messages, or payout records.
 
 ## Review Loop
 

--- a/docs/source-respecting-llm-protocol.md
+++ b/docs/source-respecting-llm-protocol.md
@@ -130,6 +130,7 @@ Banned-books corpus foundation:
 - `npm run banned-books:report` prints the current staged registry, swarm lanes, source ingestion queue, outreach packet templates, next actions, and safeguards for recurring review.
 - `npm run banned-books:ingestion:report` prints the source refresh queue, candidate classifications, evidence QA holds, and blocked full-text actions.
 - `npm run banned-books:source:import` consumes manual/public source metadata exports in dry-run mode, rejects full-text-like fields, and emits Evidence QA-gated queue append drafts.
+- `npx tsx scripts/approve-banned-books-source-candidates.ts` reads an Evidence QA approval packet and can dry-run approved metadata-only queue appends; `--apply` is explicit and still limited to the source ingestion queue JSON.
 
 Smoke test:
 

--- a/lib/banned-books-evidence-qa.test.ts
+++ b/lib/banned-books-evidence-qa.test.ts
@@ -1,0 +1,159 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  applyEvidenceQaQueueAppends,
+  buildEvidenceQaApprovalPlan,
+  type EvidenceQaApprovalPacket,
+} from './banned-books-evidence-qa'
+import { buildBannedBooksSourceImportPlan, type BannedBookSourceImportFile } from './banned-books-source-importer'
+
+const importFile: BannedBookSourceImportFile = {
+  generatedAt: '2026-05-25T00:00:00.000Z',
+  sourceKey: 'ala-most-challenged-2025',
+  sourceUrl: 'https://www.ala.org/bbooks/frequentlychallengedbooks/top10',
+  rows: [
+    {
+      externalId: 'ala-2025-the-57-bus-test',
+      canonicalTitle: 'The 57 Bus Test',
+      authors: ['Dashka Slater'],
+      banStatus: 'challenged',
+      evidenceType: 'challenge_list',
+      evidenceNote: 'Confirmed source evidence.',
+      jurisdictionContext: 'ALA 2025 source page.',
+      affectedAudience: 'K-12 students',
+      evidenceQuality: 'confirmed_source',
+      rightsholderHint: 'author_or_publisher',
+      editionAliases: [],
+      sensitivityFlags: ['lgbtqia'],
+    },
+    {
+      externalId: 'manual-missing-evidence-test',
+      canonicalTitle: 'Manual Missing Evidence Test',
+      authors: ['Example Author'],
+      banStatus: 'unknown',
+      evidenceType: 'challenge_context',
+      evidenceNote: '',
+      jurisdictionContext: 'Manual row.',
+      affectedAudience: 'Unknown',
+      evidenceQuality: 'needs_cross_check',
+      rightsholderHint: 'unknown',
+      editionAliases: [],
+      sensitivityFlags: [],
+    },
+    {
+      externalId: 'manual-full-text-rejected-test',
+      canonicalTitle: 'Manual Full Text Rejected Test',
+      authors: ['Example Author'],
+      banStatus: 'challenged',
+      evidenceType: 'challenge_context',
+      evidenceNote: 'Forbidden field validation.',
+      jurisdictionContext: 'Manual row.',
+      affectedAudience: 'K-12 students',
+      evidenceQuality: 'confirmed_source',
+      rightsholderHint: 'author_or_publisher',
+      editionAliases: [],
+      sensitivityFlags: [],
+      fullText: 'Reject this row.',
+    },
+  ],
+}
+
+const approvalPacket: EvidenceQaApprovalPacket = {
+  generatedAt: '2026-05-25T00:00:00.000Z',
+  reviewer: 'Timbuktu Scribe',
+  approvalType: 'evidence_qa_queue_append',
+  sourceImportPath: 'data/source-protocol/banned-books-source-import-sample.json',
+  decisions: [
+    {
+      externalId: 'ala-2025-the-57-bus-test',
+      decision: 'approved',
+      approvedAt: '2026-05-25T00:00:00.000Z',
+      notes: 'Confirmed metadata-only source evidence.',
+    },
+    {
+      externalId: 'manual-missing-evidence-test',
+      decision: 'needs_more_evidence',
+      approvedAt: null,
+      notes: 'Hold for evidence.',
+    },
+    {
+      externalId: 'manual-full-text-rejected-test',
+      decision: 'approved',
+      approvedAt: '2026-05-25T00:00:00.000Z',
+      notes: 'This approval must not override importer rejection.',
+    },
+  ],
+}
+
+describe('banned books Evidence QA approvals', () => {
+  it('approves only ready-for-QA metadata rows for queue append', () => {
+    const importPlan = buildBannedBooksSourceImportPlan(importFile)
+    const approvalPlan = buildEvidenceQaApprovalPlan(importPlan, approvalPacket)
+
+    expect(approvalPlan.summary).toMatchObject({
+      importRows: 3,
+      decisions: 3,
+      approvedQueueAppends: 1,
+      needsMoreEvidence: 1,
+      rejected: 0,
+      blocked: 2,
+    })
+    expect(approvalPlan.queueAppendDrafts).toEqual([
+      expect.objectContaining({
+        externalId: 'ala-2025-the-57-bus-test',
+        canonicalTitle: 'The 57 Bus Test',
+      }),
+    ])
+    expect(approvalPlan.rows.find((row) => row.externalId === 'manual-full-text-rejected-test')).toMatchObject({
+      approved: false,
+      blocked: true,
+      reason: 'Approval cannot override importer status rejected_for_full_text.',
+      queueAppendDraft: null,
+    })
+  })
+
+  it('requires approvedAt metadata before appending an approved decision', () => {
+    const importPlan = buildBannedBooksSourceImportPlan(importFile)
+    const approvalPlan = buildEvidenceQaApprovalPlan(importPlan, {
+      ...approvalPacket,
+      decisions: [
+        {
+          externalId: 'ala-2025-the-57-bus-test',
+          decision: 'approved',
+          approvedAt: null,
+          notes: 'Missing approvedAt.',
+        },
+      ],
+    })
+
+    expect(approvalPlan.summary.approvedQueueAppends).toBe(0)
+    expect(approvalPlan.rows[0]).toMatchObject({
+      approved: false,
+      reason: 'Approved decisions must include approvedAt metadata.',
+    })
+  })
+
+  it('applies approved queue appends only when dryRun is false', () => {
+    const importPlan = buildBannedBooksSourceImportPlan(importFile)
+    const dryRunPlan = buildEvidenceQaApprovalPlan(importPlan, approvalPacket)
+    expect(() => applyEvidenceQaQueueAppends(dryRunPlan)).toThrow('Cannot apply an Evidence QA plan while dryRun is true.')
+
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'banned-books-evidence-qa-'))
+    const queuePath = path.join(tempDir, 'queue.json')
+    fs.writeFileSync(queuePath, JSON.stringify({ generatedAt: '2026-05-24T00:00:00.000Z', candidates: [] }, null, 2))
+
+    const applyPlan = buildEvidenceQaApprovalPlan(importPlan, approvalPacket, { dryRun: false })
+    const result = applyEvidenceQaQueueAppends(applyPlan, queuePath)
+    const updated = JSON.parse(fs.readFileSync(queuePath, 'utf8'))
+
+    expect(result.appended).toBe(1)
+    expect(updated.candidates).toEqual([
+      expect.objectContaining({
+        externalId: 'ala-2025-the-57-bus-test',
+        canonicalTitle: 'The 57 Bus Test',
+      }),
+    ])
+  })
+})

--- a/lib/banned-books-evidence-qa.ts
+++ b/lib/banned-books-evidence-qa.ts
@@ -1,0 +1,168 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import sourceIngestionQueue from '@/data/source-protocol/banned-books-source-ingestion-queue.json'
+import {
+  buildBannedBooksSourceImportPlan,
+  loadBannedBooksSourceImportFile,
+  type BannedBookSourceImportPlan,
+} from './banned-books-source-importer'
+import type { BannedBookSourceIngestionCandidate } from './banned-books-corpus'
+
+export type EvidenceQaDecision = 'approved' | 'needs_more_evidence' | 'rejected'
+
+export type EvidenceQaApprovalDecision = {
+  externalId: string
+  decision: EvidenceQaDecision
+  approvedAt: string | null
+  notes: string
+}
+
+export type EvidenceQaApprovalPacket = {
+  generatedAt: string
+  reviewer: string
+  approvalType: 'evidence_qa_queue_append'
+  sourceImportPath: string
+  decisions: EvidenceQaApprovalDecision[]
+}
+
+export type EvidenceQaApprovalPlan = {
+  generatedAt: string
+  reviewer: string
+  sourceImportPath: string
+  dryRun: boolean
+  summary: {
+    importRows: number
+    decisions: number
+    approvedQueueAppends: number
+    needsMoreEvidence: number
+    rejected: number
+    blocked: number
+    alreadyQueued: number
+  }
+  rows: Array<{
+    externalId: string
+    canonicalTitle: string
+    importStatus: string
+    decision: EvidenceQaDecision | 'missing_decision'
+    approved: boolean
+    blocked: boolean
+    reason: string
+    queueAppendDraft: BannedBookSourceIngestionCandidate | null
+  }>
+  queueAppendDrafts: BannedBookSourceIngestionCandidate[]
+  blockedActions: string[]
+}
+
+export function loadEvidenceQaApprovalPacket(inputPath: string): EvidenceQaApprovalPacket {
+  const resolvedPath = path.resolve(inputPath)
+  const parsed = JSON.parse(fs.readFileSync(resolvedPath, 'utf8')) as EvidenceQaApprovalPacket
+  if (parsed.approvalType !== 'evidence_qa_queue_append' || !parsed.reviewer || !Array.isArray(parsed.decisions)) {
+    throw new Error('Approval packet must include reviewer, approvalType=evidence_qa_queue_append, and decisions.')
+  }
+  return parsed
+}
+
+function approvalReason(row: BannedBookSourceImportPlan['rows'][number], decision: EvidenceQaApprovalDecision | undefined): string {
+  if (!decision) return 'No Evidence QA decision was provided for this import row.'
+  if (decision.decision !== 'approved') return decision.notes || `Evidence QA marked this row ${decision.decision}.`
+  if (row.status !== 'ready_for_qa') return `Approval cannot override importer status ${row.status}.`
+  if (!decision.approvedAt) return 'Approved decisions must include approvedAt metadata.'
+  if (!row.queueAppendDraft) return 'Importer did not produce a queue append draft for this row.'
+  return decision.notes || 'Approved for metadata-only queue append.'
+}
+
+export function buildEvidenceQaApprovalPlan(
+  importPlan: BannedBookSourceImportPlan,
+  approvalPacket: EvidenceQaApprovalPacket,
+  options: { dryRun?: boolean } = {}
+): EvidenceQaApprovalPlan {
+  const decisionsByExternalId = new Map(approvalPacket.decisions.map((decision) => [decision.externalId, decision]))
+  const queuedExternalIds = new Set(sourceIngestionQueue.candidates.map((candidate) => candidate.externalId))
+  const rows = importPlan.rows.map((row) => {
+    const decision = decisionsByExternalId.get(row.externalId)
+    const alreadyQueued = row.queueAppendDraft ? queuedExternalIds.has(row.queueAppendDraft.externalId) : false
+    const approved = Boolean(
+      decision?.decision === 'approved' &&
+      decision.approvedAt &&
+      row.status === 'ready_for_qa' &&
+      row.queueAppendDraft &&
+      !alreadyQueued
+    )
+    const blocked = !approved
+    const reason = alreadyQueued
+      ? 'Candidate is already present in the source ingestion queue.'
+      : approvalReason(row, decision)
+
+    const rowDecision: EvidenceQaDecision | 'missing_decision' = decision?.decision ?? 'missing_decision'
+
+    return {
+      externalId: row.externalId,
+      canonicalTitle: row.canonicalTitle,
+      importStatus: row.status,
+      decision: rowDecision,
+      approved,
+      blocked,
+      reason,
+      queueAppendDraft: approved ? row.queueAppendDraft : null,
+    }
+  })
+  const queueAppendDrafts = rows
+    .map((row) => row.queueAppendDraft)
+    .filter((candidate): candidate is BannedBookSourceIngestionCandidate => Boolean(candidate))
+
+  return {
+    generatedAt: approvalPacket.generatedAt,
+    reviewer: approvalPacket.reviewer,
+    sourceImportPath: approvalPacket.sourceImportPath,
+    dryRun: options.dryRun ?? true,
+    summary: {
+      importRows: importPlan.rows.length,
+      decisions: approvalPacket.decisions.length,
+      approvedQueueAppends: queueAppendDrafts.length,
+      needsMoreEvidence: rows.filter((row) => row.decision === 'needs_more_evidence').length,
+      rejected: rows.filter((row) => row.decision === 'rejected').length,
+      blocked: rows.filter((row) => row.blocked).length,
+      alreadyQueued: rows.filter((row) => row.reason.includes('already present')).length,
+    },
+    rows,
+    queueAppendDrafts,
+    blockedActions: [
+      'Evidence QA approval appends metadata-only candidates to the source ingestion queue only.',
+      'It does not write licensed works, license grants, source chunks, embeddings, retrieval flags, outreach sends, or payout records.',
+      'Rows rejected by the importer cannot be overridden by an approval packet.',
+    ],
+  }
+}
+
+export function buildEvidenceQaApprovalPlanFromFiles(
+  importPath: string,
+  approvalPath: string,
+  options: { dryRun?: boolean } = {}
+): EvidenceQaApprovalPlan {
+  const importFile = loadBannedBooksSourceImportFile(importPath)
+  const approvalPacket = loadEvidenceQaApprovalPacket(approvalPath)
+  const importPlan = buildBannedBooksSourceImportPlan(importFile)
+  return buildEvidenceQaApprovalPlan(importPlan, approvalPacket, options)
+}
+
+export function applyEvidenceQaQueueAppends(
+  plan: EvidenceQaApprovalPlan,
+  queuePath = 'data/source-protocol/banned-books-source-ingestion-queue.json'
+) {
+  if (plan.dryRun) throw new Error('Cannot apply an Evidence QA plan while dryRun is true.')
+  const resolvedPath = path.resolve(queuePath)
+  const current = JSON.parse(fs.readFileSync(resolvedPath, 'utf8')) as typeof sourceIngestionQueue
+  const existingExternalIds = new Set(current.candidates.map((candidate) => candidate.externalId))
+  const appendDrafts = plan.queueAppendDrafts.filter((candidate) => !existingExternalIds.has(candidate.externalId))
+  const updated = {
+    ...current,
+    generatedAt: plan.generatedAt,
+    candidates: [...current.candidates, ...appendDrafts],
+  }
+  fs.writeFileSync(resolvedPath, `${JSON.stringify(updated, null, 2)}\n`)
+  return {
+    queuePath: resolvedPath,
+    appended: appendDrafts.length,
+    skippedExisting: plan.queueAppendDrafts.length - appendDrafts.length,
+  }
+}

--- a/scripts/approve-banned-books-source-candidates.ts
+++ b/scripts/approve-banned-books-source-candidates.ts
@@ -1,0 +1,110 @@
+#!/usr/bin/env tsx
+import {
+  applyEvidenceQaQueueAppends,
+  buildEvidenceQaApprovalPlanFromFiles,
+  type EvidenceQaApprovalPlan,
+} from '../lib/banned-books-evidence-qa'
+
+export function parseArgs(argv: string[]) {
+  const options = {
+    input: 'data/source-protocol/banned-books-source-import-sample.json',
+    approvals: 'data/source-protocol/banned-books-evidence-qa-approvals.sample.json',
+    queue: 'data/source-protocol/banned-books-source-ingestion-queue.json',
+    apply: false,
+    json: false,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--input') {
+      const value = argv[index + 1]
+      if (!value) throw new Error('--input requires a path')
+      options.input = value
+      index += 1
+    } else if (arg === '--approvals') {
+      const value = argv[index + 1]
+      if (!value) throw new Error('--approvals requires a path')
+      options.approvals = value
+      index += 1
+    } else if (arg === '--queue') {
+      const value = argv[index + 1]
+      if (!value) throw new Error('--queue requires a path')
+      options.queue = value
+      index += 1
+    } else if (arg === '--apply') {
+      options.apply = true
+    } else if (arg === '--json') {
+      options.json = true
+    } else if (arg === '--help' || arg === '-h') {
+      console.log(`Usage:
+  npx tsx scripts/approve-banned-books-source-candidates.ts [options]
+
+Options:
+  --input <path>      Source metadata import JSON file.
+  --approvals <path>  Evidence QA approval packet JSON file.
+  --queue <path>      Source ingestion queue JSON file for --apply.
+  --apply             Append approved metadata-only candidates to the local queue JSON.
+  --json              Print machine-readable output.
+`)
+      process.exit(0)
+    } else {
+      throw new Error(`Unknown option: ${arg}`)
+    }
+  }
+
+  return options
+}
+
+export function formatEvidenceQaApprovalPlan(plan: EvidenceQaApprovalPlan): string {
+  return [
+    '# Banned Books Evidence QA Approval Plan',
+    '',
+    `Generated: ${plan.generatedAt}`,
+    `Reviewer: ${plan.reviewer}`,
+    `Dry run: ${String(plan.dryRun)}`,
+    '',
+    '## Summary',
+    '',
+    `- Import rows: ${plan.summary.importRows}`,
+    `- Decisions: ${plan.summary.decisions}`,
+    `- Approved queue appends: ${plan.summary.approvedQueueAppends}`,
+    `- Needs more evidence: ${plan.summary.needsMoreEvidence}`,
+    `- Rejected: ${plan.summary.rejected}`,
+    `- Blocked: ${plan.summary.blocked}`,
+    `- Already queued: ${plan.summary.alreadyQueued}`,
+    '',
+    '## Rows',
+    '',
+    ...plan.rows.map((row) =>
+      `- ${row.canonicalTitle} (${row.externalId}): ${row.decision}; ${row.approved ? 'append draft ready' : row.reason}`
+    ),
+    '',
+    '## Blocked Actions',
+    '',
+    ...plan.blockedActions.map((action) => `- ${action}`),
+  ].join('\n')
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  const plan = buildEvidenceQaApprovalPlanFromFiles(options.input, options.approvals, { dryRun: !options.apply })
+  const applyResult = options.apply ? applyEvidenceQaQueueAppends(plan, options.queue) : null
+
+  if (options.json) {
+    console.log(JSON.stringify({ plan, applyResult }, null, 2))
+    return
+  }
+
+  console.log(formatEvidenceQaApprovalPlan(plan))
+  if (applyResult) {
+    console.log('')
+    console.log(`Applied: appended ${applyResult.appended}; skipped existing ${applyResult.skippedExisting}; queue ${applyResult.queuePath}`)
+  }
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Summary
- add an Evidence QA approval packet for banned-books source candidate promotion
- add a dry-run approval planner and explicit --apply path limited to metadata-only queue JSON appends
- surface the Evidence QA approval queue in the Source Protocol Banned Books admin tab
- document the approval boundary and keep package.json untouched to avoid open PR overlap

## Validation
- npm test -- --run lib/banned-books-evidence-qa.test.ts lib/banned-books-source-importer.test.ts lib/banned-books-corpus.test.ts app/api/admin/source-protocol/overview/route.test.ts app/admin/source-protocol/page.test.tsx
- npx tsx scripts/approve-banned-books-source-candidates.ts
- npx tsx scripts/approve-banned-books-source-candidates.ts --json
- npm run banned-books:source:import
- npm run banned-books:ingestion:report
- npm run banned-books:report
- npm run build:knowledge
- npx tsc --noEmit --pretty false
- npm run lint
- git diff --check
- pre-push database health check passed

## Governance notes
- Default approval behavior is dry-run.
- --apply is explicit and only appends approved metadata-only candidates to data/source-protocol/banned-books-source-ingestion-queue.json.
- Approval packets cannot override importer rejections or missing evidence.
- No copyrighted full text, OCR, embeddings, source chunks, retrievable records, outreach sends, license grants, production defaults, or payout activation were created.

## Integration Captain
- Stop before merge. Please review and merge from the captain lane.