### PR TITLE
Fix Open Brain relationship map layout

### DIFF
--- a/app/admin/agents/open-brain/page.tsx
+++ b/app/admin/agents/open-brain/page.tsx
@@ -585,6 +585,7 @@ function RelationshipMapView({
   const selectedPath = visibleEdges.find((edge) => edge.strength === 'strong') || visibleEdges[0]
   const selectedFrom = selectedPath ? nodeById.get(selectedPath.fromId) : null
   const selectedTo = selectedPath ? nodeById.get(selectedPath.toId) : null
+  const graphMinHeight = Math.max(620, Math.ceil(visibleNodes.length / 4) * 132)
 
   return (
     <section className="space-y-5" aria-label="Open Brain relationship map">
@@ -596,7 +597,7 @@ function RelationshipMapView({
         <RelationshipMetric label="Suggestions" value={map.overview.proposalSuggestions} detail="Proposal-only actions" />
       </div>
 
-      <div className="grid gap-4 xl:grid-cols-[250px_minmax(0,1fr)_340px]">
+      <div className="grid gap-4 2xl:grid-cols-[250px_minmax(0,1fr)_340px]">
         <aside className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
           <div className="mb-4 flex items-center justify-between gap-3">
             <p className="agent-ops-eyebrow"><Network size={14} /> Filters</p>
@@ -630,7 +631,10 @@ function RelationshipMapView({
           </div>
         </aside>
 
-        <div className="relative min-h-[620px] overflow-hidden rounded-lg border border-radiant-gold/20 bg-[radial-gradient(circle_at_50%_45%,rgba(212,175,55,0.08),transparent_34%),linear-gradient(180deg,rgba(12,23,39,0.94),rgba(7,14,25,0.98))] shadow-2xl">
+        <div
+          className="relative overflow-hidden rounded-lg border border-radiant-gold/20 bg-[radial-gradient(circle_at_50%_45%,rgba(212,175,55,0.08),transparent_34%),linear-gradient(180deg,rgba(12,23,39,0.94),rgba(7,14,25,0.98))] shadow-2xl"
+          style={{ minHeight: `${graphMinHeight}px` }}
+        >
           <div className="absolute left-5 top-5 z-10">
             <p className="text-xs font-semibold uppercase tracking-[0.16em] text-radiant-gold">Memory Graph</p>
             <p className="mt-1 text-sm text-muted-foreground">
@@ -663,7 +667,7 @@ function RelationshipMapView({
           {visibleNodes.map((node) => (
             <div
               key={node.id}
-              className={`absolute z-10 flex max-w-[150px] -translate-x-1/2 -translate-y-1/2 flex-col items-center justify-center rounded-lg border px-3 py-2 text-center shadow-xl ${relationshipNodeTone(node.type, node.health)}`}
+              className={`absolute z-10 flex max-w-[132px] -translate-x-1/2 -translate-y-1/2 flex-col items-center justify-center rounded-lg border px-2.5 py-2 text-center shadow-xl ${relationshipNodeTone(node.type, node.health)}`}
               style={{ left: `${node.x}%`, top: `${node.y}%` }}
               title={node.summary}
             >

--- a/lib/open-brain.ts
+++ b/lib/open-brain.ts
@@ -1281,51 +1281,32 @@ function proposalToRelationshipNode(proposal: OpenBrainProposalRecord, index: nu
 }
 
 function relationshipPoint(type: OpenBrainRelationshipNodeType, kind: string, index: number) {
-  const sourcePoints = kind === 'workspace_root_report'
-    ? [{ x: 12, y: 48 }]
-    : kind === 'codex_automation'
-      ? [
-          { x: 34, y: 31 },
-          { x: 23, y: 58 },
-          { x: 42, y: 62 },
-        ]
-      : kind === 'runbook'
-        ? [
-            { x: 55, y: 43 },
-            { x: 49, y: 72 },
-            { x: 66, y: 65 },
-          ]
-        : [
-            { x: 20, y: 23 },
-            { x: 29, y: 75 },
-            { x: 43, y: 17 },
-            { x: 58, y: 27 },
-            { x: 62, y: 80 },
-          ]
+  if (type === 'source') return sourceRelationshipPoint(kind, index)
+
   const points: Record<OpenBrainRelationshipNodeType, { x: number; y: number }[]> = {
-    source: sourcePoints,
+    source: [{ x: 50, y: 50 }],
     memory: [
-      { x: 78, y: 25 },
-      { x: 82, y: 43 },
-      { x: 72, y: 62 },
-      { x: 88, y: 70 },
+      { x: 36, y: 82 },
+      { x: 52, y: 82 },
+      { x: 68, y: 82 },
+      { x: 84, y: 82 },
     ],
     event: [
-      { x: 22, y: 84 },
-      { x: 41, y: 86 },
-      { x: 60, y: 88 },
-      { x: 72, y: 82 },
+      { x: 12, y: 90 },
+      { x: 28, y: 90 },
+      { x: 44, y: 90 },
+      { x: 60, y: 90 },
     ],
     wiki: [
-      { x: 84, y: 58 },
-      { x: 90, y: 36 },
-      { x: 73, y: 80 },
+      { x: 12, y: 72 },
+      { x: 28, y: 72 },
+      { x: 44, y: 72 },
     ],
     proposal: [
-      { x: 68, y: 88 },
-      { x: 52, y: 86 },
-      { x: 86, y: 86 },
-      { x: 76, y: 76 },
+      { x: 36, y: 90 },
+      { x: 56, y: 90 },
+      { x: 76, y: 90 },
+      { x: 92, y: 82 },
     ],
   }
   const selected = points[type][index % points[type].length]
@@ -1333,6 +1314,18 @@ function relationshipPoint(type: OpenBrainRelationshipNodeType, kind: string, in
   return {
     x: Math.max(8, Math.min(92, selected.x + rowOffset)),
     y: Math.max(12, Math.min(92, selected.y - rowOffset)),
+  }
+}
+
+function sourceRelationshipPoint(kind: string, index: number) {
+  const columns = [12, 31, 50, 69, 88]
+  const row = Math.floor(index / columns.length)
+  const kindNudge = kind === 'runbook' ? 2 : kind === 'repair_packet' ? -2 : 0
+  const x = columns[index % columns.length] + (row % 2 === 1 ? 2 : 0) + kindNudge
+  const y = 12 + row * 10
+  return {
+    x: Math.max(8, Math.min(92, x)),
+    y: Math.max(12, Math.min(92, y)),
   }
 }
 


### PR DESCRIPTION
## Summary
- make the Open Brain relationship map use a full-width layout at normal desktop widths instead of compressing the graph between side panels
- scale graph height with visible node count
- distribute source nodes on a global grid and move non-source nodes into separate rails to avoid overlap

## Browser QA
- validated /admin/agents/open-brain in the integrated Browser against local dev
- confirmed Map tab renders relationship metrics, filters, insights, 36 titled nodes, and 9 SVG edges
- confirmed proposal-only copy remains visible
- canvas/node overlap check reports 0 overlapping node pairs at the desktop viewport

## Validation
- npm test -- --run app/admin/agents/open-brain/page.test.tsx lib/open-brain.test.ts
- npx tsc --noEmit --pretty false
- npm run lint
- pre-push database health check passed