### PR TITLE
docs: add LinkedIn Apify replacement packet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -193,6 +193,11 @@ HEYGEN_TEMPLATE_ID=
 # ── Apify ────────────────────────────────────────────────────────────────────
 APIFY_TOKEN=
 
+# ── Apify Replacement Bakeoff Challengers ────────────────────────────────────
+# Read-only keys used by `npm run apify:replacement-bakeoff -- --run`.
+BRAVE_SEARCH_API_KEY=
+GOOGLE_MAPS_API_KEY=
+
 # ── BuiltWith ────────────────────────────────────────────────────────────────
 BUILTWITH_API_KEY=
 

--- a/docs/apify-call-bakeoff-analysis.md
+++ b/docs/apify-call-bakeoff-analysis.md
@@ -48,7 +48,7 @@ proves the campaign still needs that source.
 | --- | ---: | --- | --- | --- |
 | Reddit listening | 72 items / $0.47360 | Brave Search API with Reddit/source filters, then official Reddit Data API only if terms fit | Brave is $5 per 1,000 search requests with $5 monthly credits, which is enough for a low-volume evidence monitor. Reddit's official free API has rate limits and commercial use can require a separate agreement. | Promote replacement only if it captures the same conversations with lower review burden and acceptable source attribution. |
 | Google Maps | 68 items / $0.58600 | Google Places API Text Search/Nearby Search with field masks and strict quotas | Google Places pricing is transparent; Text Search/Nearby Search Pro list 5,000 free monthly calls, then $32 per 1,000 for the first paid tier. This can beat Apify if the workflow needs verified place data instead of broad scraping. | Promote only if Places returns enough qualified businesses with required fields while staying inside the free/low-tier quota. |
-| LinkedIn post search | 135 items / $0.27220 | Browser-agent sampling plus manual review packet | This is the strongest current Apify value signal, but LinkedIn-style extraction has account and compliance risk. A browser/manual packet should test whether smaller sampled searches produce enough accepted leads. | Keep Apify unless the replacement returns comparable accepted leads without increasing account risk or manual time. |
+| LinkedIn post search | 135 items / $0.27220 | Manual review packet, not automated scraping | This is the strongest current Apify value signal, but LinkedIn's current help guidance prohibits scraping and automated activity. The replacement packet must test human review and source registration, not a bot. | Keep Apify unless the replacement returns comparable accepted leads without increasing account risk or manual time. |
 | Capterra reviews | 40 items / $0.62400 | Brave Search or browser capture into a source register | Review-site evidence is usually sparse and source-sensitive. A search/browser capture may be cheaper if it preserves URLs, snippets, and review context without needing a dedicated actor. | Promote only if accepted evidence quality matches Apify and source URLs remain reviewable. |
 
 Source notes for the bakeoff packet:
@@ -82,6 +82,11 @@ Current credential gate from the 2026-05-24 worktree check:
 - LinkedIn post-search replacement remains manual/browser-agent ready because
   it should be evaluated on accepted leads and account-risk burden, not API
   result count alone.
+
+The LinkedIn-specific replacement packet lives at
+`docs/apify-linkedin-manual-replacement-packet.md`. Use it for a 30-minute
+manual review sprint before deciding whether the LinkedIn post-search actor can
+be paused, kept, or replaced.
 
 ## Configured Apify Call Surfaces
 

--- a/docs/apify-call-bakeoff-analysis.md
+++ b/docs/apify-call-bakeoff-analysis.md
@@ -72,13 +72,16 @@ missing read-only credentials. Live API mode is intentionally explicit:
 npm run apify:replacement-bakeoff -- --run --out=docs/apify-replacement-bakeoff-latest.json
 ```
 
-Current credential gate from the 2026-05-24 worktree check:
+Credential gate history:
 
 - `APIFY_TOKEN` and `APIFY_API_TOKEN` exist locally.
-- `BRAVE_SEARCH_API_KEY` is missing, so Reddit/Capterra replacement API tests
-  are blocked.
-- `GOOGLE_MAPS_API_KEY` is missing, so Google Places replacement tests are
-  blocked.
+- 2026-05-24: `BRAVE_SEARCH_API_KEY` was missing, so Reddit/Capterra
+  replacement API tests were blocked.
+- 2026-05-24: `GOOGLE_MAPS_API_KEY` was missing, so Google Places replacement
+  tests were blocked.
+- 2026-05-25: `BRAVE_SEARCH_API_KEY` and `GOOGLE_MAPS_API_KEY` were present in
+  local runtime sinks. The live replacement bakeoff wrote sanitized evidence to
+  `docs/apify-replacement-bakeoff-latest.json`.
 - LinkedIn post-search replacement remains manual/browser-agent ready because
   it should be evaluated on accepted leads and account-risk burden, not API
   result count alone.
@@ -87,6 +90,26 @@ Credential slots for `BRAVE_SEARCH_API_KEY` and `GOOGLE_MAPS_API_KEY` are now
 tracked in `.env.example`, `docs/credential-inventory.json`, and the credential
 rotation docs. The real values should be added only to local/Vercel/secret
 manager sinks, never to git.
+
+### Google Places Production Restriction Gate
+
+The current Google Places key is API-restricted to Places API (New), which is
+acceptable for the short bakeoff window because the local/Codex execution path
+does not have a stable outbound IP. Do not promote this key as the durable
+production credential until the execution host and outbound egress path are
+confirmed.
+
+Follow-up task:
+
+- Create or promote a separate `portfolio-apify-replacement-google-places-prod`
+  key after the production execution host is confirmed.
+- Apply API restrictions to Places API (New) before use.
+- Apply IP address restrictions if the production runner has stable outbound
+  egress. If it does not, keep this as a temporary API-only key with strict
+  quota limits, billing alerts, and a rotation review date.
+- Sync only the approved production key to Vercel/Infisical runtime sinks.
+- Rerun `npm run apify:replacement-bakeoff -- --run` from the production-like
+  runner before replacing any Apify Google Maps workflow.
 
 The LinkedIn-specific replacement packet lives at
 `docs/apify-linkedin-manual-replacement-packet.md`. Use it for a 30-minute

--- a/docs/apify-call-bakeoff-analysis.md
+++ b/docs/apify-call-bakeoff-analysis.md
@@ -83,6 +83,11 @@ Current credential gate from the 2026-05-24 worktree check:
   it should be evaluated on accepted leads and account-risk burden, not API
   result count alone.
 
+Credential slots for `BRAVE_SEARCH_API_KEY` and `GOOGLE_MAPS_API_KEY` are now
+tracked in `.env.example`, `docs/credential-inventory.json`, and the credential
+rotation docs. The real values should be added only to local/Vercel/secret
+manager sinks, never to git.
+
 The LinkedIn-specific replacement packet lives at
 `docs/apify-linkedin-manual-replacement-packet.md`. Use it for a 30-minute
 manual review sprint before deciding whether the LinkedIn post-search actor can

--- a/docs/apify-linkedin-manual-replacement-packet.md
+++ b/docs/apify-linkedin-manual-replacement-packet.md
@@ -1,0 +1,89 @@
+# LinkedIn Post Search Replacement Packet
+
+Date: 2026-05-25
+
+Purpose: test whether the productive Apify LinkedIn post-search surface can be
+replaced with a lower-risk manual or browser-assisted review packet before
+making any spend decision about Apify.
+
+## Boundary
+
+This packet does not authorize LinkedIn scraping, auto-viewing, auto-messaging,
+profile copying, or automated browser activity against LinkedIn. LinkedIn's
+current help guidance says automated tools, crawlers, browser plug-ins, and
+extensions that scrape or automate activity on LinkedIn are not permitted. The
+replacement test therefore uses human review and source registration, not a bot
+that extracts LinkedIn data.
+
+Primary references checked on 2026-05-25:
+
+- LinkedIn Help: Prohibited software and extensions.
+- LinkedIn Help: Automated activity on LinkedIn.
+- LinkedIn Professional Community Policies.
+
+## Baseline To Beat
+
+Current Apify signal from the latest run-history sample:
+
+| Surface | Actor | Runs | Items | Sample cost | Signal |
+| --- | --- | ---: | ---: | ---: | --- |
+| LinkedIn post search | `harvestapi~linkedin-post-search` | 4 | 135 | $0.27220 | Strongest current Apify value signal, but still needs accepted-result review. |
+
+Apify should stay for this category unless the replacement returns comparable
+accepted leads or evidence with lower account risk and acceptable manual effort.
+
+## Test Design
+
+Run a 30-minute manual review sprint using the same campaign intent that the
+Apify actor is meant to support.
+
+Suggested search prompts:
+
+- `nonprofit website migration`
+- `website redesign nonprofit CRM`
+- `donor experience website migration`
+- `nonprofit digital transformation website`
+
+For each useful post, record only review-safe metadata:
+
+| Field | Rule |
+| --- | --- |
+| `source_url` | Link to the post or search result if manually opened and relevant. |
+| `author_or_org` | Publicly visible name only; no hidden profile data. |
+| `snippet` | Short paraphrase of the relevant pain point or buying signal. |
+| `signal_type` | One of `migration_pain`, `crm_donor_ops`, `website_redesign`, `fundraising_ops`, `other`. |
+| `fit_score` | `1` to `5`, based on relevance to Portfolio outreach or value-evidence work. |
+| `next_action` | `ignore`, `source_register`, `manual_follow_up`, or `needs_review`. |
+
+Do not record private contact details, scrape profile fields, export connection
+lists, or use automated actions.
+
+## Acceptance Gate
+
+The manual replacement wins only if it satisfies all of these:
+
+- Produces at least 15 accepted evidence items or leads in a 30-minute sprint.
+- Maintains a fit-score average of 3.5 or higher.
+- Preserves source URLs and short human-written signal summaries.
+- Avoids automated LinkedIn access and account-risky extraction.
+- Requires less than 2 minutes of review time per accepted item.
+
+If it cannot meet those gates, keep Apify for LinkedIn post search while
+continuing to look for an approved lower-risk source.
+
+## Decision Outcomes
+
+| Outcome | Meaning | Action |
+| --- | --- | --- |
+| `replace` | Manual/browser review beats Apify on accepted-result quality and risk. | Pause Apify LinkedIn post-search actor and route the workflow to the source register. |
+| `keep_apify` | Apify remains materially more efficient or comprehensive. | Keep Apify for this one category; continue pausing weaker actors. |
+| `needs_official_api` | Manual review is too slow and Apify is too risky. | Investigate LinkedIn-approved partner/API paths before spending more. |
+| `pause_category` | Neither path produces useful accepted results. | Pause LinkedIn post-search sourcing until a campaign owner proves need. |
+
+## Next Run
+
+After the sprint, append a result table here:
+
+| Date | Reviewer | Minutes | Items reviewed | Accepted items | Avg fit score | Avg minutes per accepted item | Outcome |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
+| Pending | Pending | 30 | Pending | Pending | Pending | Pending | Pending |

--- a/docs/apify-replacement-bakeoff-latest.json
+++ b/docs/apify-replacement-bakeoff-latest.json
@@ -1,0 +1,86 @@
+{
+  "generatedAt": "2026-05-26T03:40:18.650Z",
+  "readyCount": 3,
+  "blockedCount": 0,
+  "manualReadyCount": 1,
+  "tests": [
+    {
+      "category": "Reddit listening",
+      "currentApifySignal": "72 items / $0.47360 sampled actor cost",
+      "challenger": "Brave Search API with Reddit/source filters",
+      "requiredEnv": [
+        "BRAVE_SEARCH_API_KEY"
+      ],
+      "sampleQuery": "site:reddit.com nonprofit website migration pain points",
+      "acceptanceGate": "Capture comparable conversations with source URLs, lower review burden, and acceptable attribution.",
+      "missingEnv": [],
+      "status": "ready"
+    },
+    {
+      "category": "Google Maps",
+      "currentApifySignal": "68 items / $0.58600 sampled actor cost",
+      "challenger": "Google Places API Text Search with field masks and strict quotas",
+      "requiredEnv": [
+        "GOOGLE_MAPS_API_KEY"
+      ],
+      "sampleQuery": "nonprofit organizations near Omaha NE",
+      "acceptanceGate": "Return enough qualified businesses with required fields while staying inside free or low-tier quota.",
+      "missingEnv": [],
+      "status": "ready"
+    },
+    {
+      "category": "LinkedIn post search",
+      "currentApifySignal": "135 items / $0.27220 sampled actor cost",
+      "challenger": "Browser-agent sampling plus manual review packet",
+      "requiredEnv": [],
+      "sampleQuery": "LinkedIn posts about nonprofit website migration",
+      "acceptanceGate": "Return comparable accepted leads without increasing account risk or manual review time.",
+      "missingEnv": [],
+      "status": "manual_ready"
+    },
+    {
+      "category": "Capterra reviews",
+      "currentApifySignal": "40 items / $0.62400 sampled actor cost",
+      "challenger": "Brave Search or browser capture into a source register",
+      "requiredEnv": [
+        "BRAVE_SEARCH_API_KEY"
+      ],
+      "sampleQuery": "site:capterra.com nonprofit CRM reviews implementation",
+      "acceptanceGate": "Match accepted evidence quality while preserving reviewable source URLs and snippets.",
+      "missingEnv": [],
+      "status": "ready"
+    }
+  ],
+  "nextAction": "Run scripts/apify-replacement-bakeoff.ts --run and compare accepted-result rate against the Apify baseline.",
+  "mode": "run",
+  "liveResults": [
+    {
+      "category": "Reddit listening",
+      "challenger": "Brave Search API with Reddit/source filters",
+      "status": "ok",
+      "resultCount": 5,
+      "note": "HTTP 200"
+    },
+    {
+      "category": "Google Maps",
+      "challenger": "Google Places API Text Search with field masks and strict quotas",
+      "status": "ok",
+      "resultCount": 5,
+      "note": "HTTP 200"
+    },
+    {
+      "category": "LinkedIn post search",
+      "challenger": "Browser-agent sampling plus manual review packet",
+      "status": "ready",
+      "resultCount": 0,
+      "note": "Manual/browser-agent packet; no API call made by this script."
+    },
+    {
+      "category": "Capterra reviews",
+      "challenger": "Brave Search or browser capture into a source register",
+      "status": "ok",
+      "resultCount": 5,
+      "note": "HTTP 200"
+    }
+  ]
+}

--- a/docs/apify-replacement-bakeoff-latest.json
+++ b/docs/apify-replacement-bakeoff-latest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-26T03:40:18.650Z",
+  "generatedAt": "2026-05-26T18:32:53.819Z",
   "readyCount": 3,
   "blockedCount": 0,
   "manualReadyCount": 1,

--- a/docs/credential-inventory.json
+++ b/docs/credential-inventory.json
@@ -428,6 +428,100 @@
       }
     },
     {
+      "id": "brave-search-api-key",
+      "envVar": "BRAVE_SEARCH_API_KEY",
+      "displayName": "Brave Search API key",
+      "category": "search",
+      "risk": "read-only-research",
+      "sourceOfTruth": "infisical",
+      "rotationMode": "provider-dashboard-or-api",
+      "rotationCadenceDays": 90,
+      "environments": [
+        "dev",
+        "staging",
+        "prod"
+      ],
+      "runtimeSinks": [
+        "local-env",
+        "Vercel"
+      ],
+      "verification": [
+        "npm run apify:replacement-bakeoff",
+        "npm run apify:replacement-bakeoff -- --run"
+      ],
+      "rollback": "Remove the key from local/Vercel secret sinks and keep Apify as the fallback for Reddit/Capterra replacement testing.",
+      "approvalRequired": [
+        "prod"
+      ],
+      "baseline": {
+        "dev": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Credential slot added for Apify replacement bakeoff; value not stored in git.",
+          "updatedAt": "2026-05-25"
+        },
+        "staging": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Credential slot added for Apify replacement bakeoff; value not stored in git.",
+          "updatedAt": "2026-05-25"
+        },
+        "prod": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Credential slot added for Apify replacement bakeoff; value not stored in git.",
+          "updatedAt": "2026-05-25"
+        }
+      }
+    },
+    {
+      "id": "google-maps-api-key",
+      "envVar": "GOOGLE_MAPS_API_KEY",
+      "displayName": "Google Maps / Places API key",
+      "category": "search",
+      "risk": "read-only-research",
+      "sourceOfTruth": "infisical",
+      "rotationMode": "provider-dashboard-or-api",
+      "rotationCadenceDays": 90,
+      "environments": [
+        "dev",
+        "staging",
+        "prod"
+      ],
+      "runtimeSinks": [
+        "local-env",
+        "Vercel"
+      ],
+      "verification": [
+        "npm run apify:replacement-bakeoff",
+        "npm run apify:replacement-bakeoff -- --run"
+      ],
+      "rollback": "Remove the key from local/Vercel secret sinks and keep Apify as the fallback for Google Maps replacement testing.",
+      "approvalRequired": [
+        "prod"
+      ],
+      "baseline": {
+        "dev": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Credential slot added for Apify replacement bakeoff; value not stored in git.",
+          "updatedAt": "2026-05-25"
+        },
+        "staging": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Credential slot added for Apify replacement bakeoff; value not stored in git.",
+          "updatedAt": "2026-05-25"
+        },
+        "prod": {
+          "status": "pending-provider-confirmation",
+          "lastRotatedAt": null,
+          "evidence": "Credential slot added for Apify replacement bakeoff; value not stored in git.",
+          "updatedAt": "2026-05-25"
+        }
+      }
+    },
+    {
       "id": "stripe-secret-key",
       "envVar": "STRIPE_SECRET_KEY",
       "displayName": "Stripe secret key",

--- a/docs/credential-rotation-map.md
+++ b/docs/credential-rotation-map.md
@@ -190,6 +190,17 @@ Credentials in n8n are either hardcoded in nodes or in n8n Credentials. When rot
 
 ---
 
+### Apify Replacement Bakeoff Challenger Keys
+
+| Credential | Usage |
+|------------|-------|
+| `BRAVE_SEARCH_API_KEY` | `npm run apify:replacement-bakeoff -- --run` Reddit and Capterra challenger tests |
+| `GOOGLE_MAPS_API_KEY` | `npm run apify:replacement-bakeoff -- --run` Google Places challenger test |
+
+**Rotate:** Update local/Vercel secret source, rerun `npm run apify:replacement-bakeoff`, then run the live replacement packet with `-- --run`. These keys are for read-only comparison tests; they do not replace Apify until accepted-result quality is reviewed.
+
+---
+
 ### Supabase Service Role Key
 
 | Workflow | Usage |

--- a/docs/credential-rotation-runbook.md
+++ b/docs/credential-rotation-runbook.md
@@ -76,6 +76,23 @@ For credentials used by n8n workflows (OpenAI, Anthropic, Apify, Hunter, Pinecon
 | `STRIPE_WEBHOOK_SECRET` | WF-001 (payment intake) |
 | `SUPABASE_SERVICE_ROLE_KEY` | WF-SOC-001, WF-SOC-002, WF-CLG-004, all ingest routes |
 
+## Google Places Promotion Gate
+
+The Apify replacement bakeoff may use a local `GOOGLE_MAPS_API_KEY` while the
+execution host is still undecided. Before promoting Google Places into a
+production replacement workflow:
+
+1. Confirm the production runner and whether it has stable outbound IP egress.
+2. Create or promote a separate production key named
+   `portfolio-apify-replacement-google-places-prod`.
+3. Restrict the key to Places API (New).
+4. Add IP address restrictions if the runner has stable outbound egress. If the
+   runner does not have stable egress yet, keep the key API-only temporarily and
+   pair it with strict quota limits, billing alerts, and a rotation review date.
+5. Sync the approved key to Infisical and the relevant runtime sink.
+6. Rerun `npm run apify:replacement-bakeoff -- --run` from the production-like
+   runner before replacing the Apify Google Maps actor.
+
 ## After Rotation Checklist
 
 - [ ] Updated credential in source (n8n / .env.local / Vercel)

--- a/docs/credential-rotation-runbook.md
+++ b/docs/credential-rotation-runbook.md
@@ -11,6 +11,8 @@ After rotating any API credential used by n8n workflows or the Next.js app, foll
 | Anthropic | `ANTHROPIC_API_KEY` | - | `anthropicApi` |
 | OpenRouter | `OPENROUTER_API_KEY` | - | `openRouterApi` |
 | Apify | `APIFY_API_TOKEN` | `APIFY_API_TOKEN` | `apifyApi` |
+| Brave Search | `BRAVE_SEARCH_API_KEY` | - | - |
+| Google Maps / Places | `GOOGLE_MAPS_API_KEY` | - | - |
 | Hunter.io | - | - | `hunterApi` |
 | Pinecone | - | - | `pineconeApi` |
 | Stripe | `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET` | `STRIPE_WEBHOOK_SECRET` | - |
@@ -67,6 +69,8 @@ For credentials used by n8n workflows (OpenAI, Anthropic, Apify, Hunter, Pinecon
 | `anthropicApi` | WF-CLG-002 (fallback LLM) |
 | `openRouterApi` | WF-CLG-002 (model routing) |
 | `apifyApi` | WF-CLG-001 (cold lead sourcing), WF-VEP-002 (social listening) |
+| `BRAVE_SEARCH_API_KEY` | `npm run apify:replacement-bakeoff -- --run` Reddit/Capterra challenger tests |
+| `GOOGLE_MAPS_API_KEY` | `npm run apify:replacement-bakeoff -- --run` Google Places challenger test |
 | `hunterApi` | WF-CLG-001 (email verification) |
 | `pineconeApi` | WF-RAG-INGEST (knowledge base), Chat workflow (RAG retrieval) |
 | `STRIPE_WEBHOOK_SECRET` | WF-001 (payment intake) |

--- a/docs/subscription-cancellation-audit.md
+++ b/docs/subscription-cancellation-audit.md
@@ -1358,6 +1358,32 @@ Raw Findings
 - New tests: `/lib/apify-replacement-bakeoff.test.ts`.
 - No shared cost-event schema changes and no production write actions.
 
+## 2026-05-25 LinkedIn Manual Replacement Packet
+
+Status: YELLOW
+
+Summary:
+
+- No cancellation approvals requested and no cancellation action taken.
+- Added a LinkedIn post-search replacement packet for the one Apify LinkedIn
+  surface that currently has the strongest value signal.
+- Current LinkedIn guidance was checked before writing the packet. The packet
+  keeps the replacement test manual and source-register based; it does not
+  authorize scraping, auto-viewing, auto-messaging, profile copying, or
+  automated browser activity against LinkedIn.
+- The acceptance gate requires at least 15 accepted evidence items or leads in
+  a 30-minute sprint, fit-score average of 3.5 or higher, reviewable source
+  URLs, and less than 2 minutes of review time per accepted item.
+
+Raw Findings
+
+- New packet: `/docs/apify-linkedin-manual-replacement-packet.md`.
+- Updated source map: `/docs/apify-call-bakeoff-analysis.md`.
+- LinkedIn references checked on 2026-05-25: Prohibited software and
+  extensions, Automated activity on LinkedIn, and Professional Community
+  Policies.
+- No shared cost-event schema changes and no production write actions.
+
 ## 2026-05-09 Budget Query Readiness Update
 
 Status: YELLOW


### PR DESCRIPTION
## Summary
- adds a LinkedIn post-search manual replacement packet for the productive Apify LinkedIn actor category
- updates the Apify bakeoff analysis to point LinkedIn replacement away from automated scraping and toward manual source registration
- records the May 25 subscription audit update with explicit no-cancellation/no-schema-change boundaries
- adds credential slots for BRAVE_SEARCH_API_KEY and GOOGLE_MAPS_API_KEY across .env.example, credential inventory, and rotation docs
- records a live Apify replacement bakeoff result after enabling Google Places for the My Portfolio Google Cloud project
- adds the Google Places production promotion gate so the API-only local key is not treated as the durable production credential before runner/egress is confirmed
- surfaces the Google Places production gate through `docs/subscription-status.json` and subscription budget queries for admin reporting

## Boundary
- No cancellation action taken
- No shared cost-event schema changes
- No LinkedIn scraping, auto-viewing, auto-messaging, profile copying, or automated browser activity authorized
- Secret values were not added to git; only variable names, governance slots, sanitized run evidence, production-promotion instructions, and query/report metadata were added
- Google Maps key value was stored only in local `.env.local`; the committed evidence contains no API key material
- Production Google Places promotion remains gated on execution host, outbound egress, runtime sink sync, and a production-like bakeoff rerun

## Validation
- credential inventory JSON parse check
- npm run apify:replacement-bakeoff
- npm run apify:replacement-bakeoff -- --run --out=docs/apify-replacement-bakeoff-latest.json
- npm test -- --run lib/apify-replacement-bakeoff.test.ts
- npm test -- --run lib/subscription-status.test.ts lib/apify-replacement-bakeoff.test.ts
- git diff --check
- npm run db:health-check
- push hook database health check passed

## Live bakeoff result
- readyCount: 3
- blockedCount: 0
- manualReadyCount: 1
- Reddit listening: HTTP 200, 5 results
- Google Maps / Places API: HTTP 200, 5 results
- Capterra reviews: HTTP 200, 5 results
- LinkedIn post search: manual/browser-agent packet only; no API call made

## Sources checked 2026-05-25
- LinkedIn Help: Prohibited software and extensions https://www.linkedin.com/help/linkedin/answer/a1341387/prohibited-software-and-extensions
- LinkedIn Help: Automated activity on LinkedIn https://www.linkedin.com/help/linkedin/answer/a1341543
- LinkedIn Professional Community Policies https://www.linkedin.com/legal/professional-community-policies
