### PR TITLE
feat: approve open brain relationship links

### DIFF
--- a/app/admin/agents/open-brain/page.test.tsx
+++ b/app/admin/agents/open-brain/page.test.tsx
@@ -80,6 +80,17 @@ const openBrainSnapshot = {
     reviewedAt: null,
     reviewedBy: null,
     reviewReason: null,
+    metadata: {
+      relationship: {
+        fromId: 'source-1',
+        toId: 'memory-1',
+        relationship: 'governed_by',
+        insightId: 'insight-1',
+        insightKind: 'strengthen',
+        sourceLabel: 'Morning review source',
+        targetLabel: 'Action-first operating rule',
+      },
+    },
   }],
   wikiPages: [],
   ragProjection: {
@@ -196,7 +207,7 @@ const openBrainSnapshot = {
         recommendation: 'Create a relationship proposal before future agents act on it.',
         actionLabel: 'Propose link',
         sourceNodeId: 'source-1',
-        targetNodeId: null,
+        targetNodeId: 'memory-1',
       },
     ],
   },
@@ -237,6 +248,24 @@ describe('OpenBrainPage', () => {
       const url = String(input)
       if (url.includes('/wiki/compile')) {
         return { ok: true, json: async () => ({ pages: [{ slug: 'one' }] }) }
+      }
+      if (url.includes('/approve')) {
+        return {
+          ok: true,
+          json: async () => ({
+            proposal: {
+              id: 'proposal-1',
+              status: 'approved',
+              metadata: {
+                relationship: {
+                  fromId: 'source-1',
+                  toId: 'memory-1',
+                  relationship: 'governed_by',
+                },
+              },
+            },
+          }),
+        }
       }
       if (url.endsWith('/api/admin/agents/open-brain/proposals') && init?.method === 'POST') {
         return {
@@ -350,7 +379,29 @@ describe('OpenBrainPage', () => {
       title: 'Relationship proposal: Strengthen automation-to-runbook governance',
       privacyTier: 'internal_ops',
       sourceIds: ['source-1'],
+      metadata: {
+        relationship: expect.objectContaining({
+          fromId: 'source-1',
+          toId: 'memory-1',
+          relationship: 'governed_by',
+          insightId: 'insight-1',
+        }),
+      },
       reason: expect.stringContaining('insight-1'),
     }))
+  })
+
+  it('shows relationship-link impact and reports durable link creation after approval', async () => {
+    render(<OpenBrainPage />)
+
+    const nextActions = await screen.findByRole('region', { name: 'Open Brain next actions' })
+    fireEvent.click(within(nextActions).getByRole('button', { name: /Review proposals/i }))
+
+    expect(await screen.findByText('Link on approval')).toBeInTheDocument()
+    expect(screen.getByText(/Approving this proposal creates a durable link/i)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }))
+
+    expect(await screen.findByText('Relationship proposal approved. A durable Open Brain link record was created.')).toBeInTheDocument()
   })
 })

--- a/app/admin/agents/open-brain/page.tsx
+++ b/app/admin/agents/open-brain/page.tsx
@@ -98,11 +98,14 @@ function OpenBrainContent() {
     setActionMessage(null)
     setReviewingProposalId(id)
     try {
-      await authedFetch(`/api/admin/agents/open-brain/proposals/${encodeURIComponent(id)}/${action}`, {
+      const body = await authedFetch(`/api/admin/agents/open-brain/proposals/${encodeURIComponent(id)}/${action}`, {
         method: 'POST',
         body: JSON.stringify({ reason: `${action === 'approve' ? 'Approved' : 'Rejected'} from Portfolio Admin.` }),
       })
-      setActionMessage(`Proposal ${action === 'approve' ? 'approved' : 'rejected'}.`)
+      const createdRelationshipLink = action === 'approve' && Boolean(body.proposal?.metadata?.relationship)
+      setActionMessage(createdRelationshipLink
+        ? 'Relationship proposal approved. A durable Open Brain link record was created.'
+        : `Proposal ${action === 'approve' ? 'approved' : 'rejected'}.`)
       await fetchSnapshot()
     } catch (err) {
       setActionMessage(err instanceof Error ? err.message : `Proposal ${action} failed`)
@@ -769,7 +772,9 @@ function buildRelationshipProposalPayload(snapshot: OpenBrainSnapshot, insight: 
     `Recommended change: ${insight.recommendation}`,
     `Relationship path: ${relationshipLabel}`,
     `Insight kind: ${insight.kind.replace(/_/g, ' ')}`,
-    'Authority boundary: this proposal records the recommended relationship context for review; approval does not directly write Open Brain link records.',
+    sourceNode && targetNode
+      ? 'Authority boundary: approval creates one durable Open Brain link record for the relationship path shown here.'
+      : 'Authority boundary: this proposal records the recommended relationship context for review; no link record is created unless a target relationship is explicit.',
   ].join('\n')
 
   return {
@@ -780,7 +785,25 @@ function buildRelationshipProposalPayload(snapshot: OpenBrainSnapshot, insight: 
     confidence: insight.severity === 'high' ? 0.84 : insight.severity === 'medium' ? 0.78 : 0.72,
     sourceIds,
     reason: `Created from Open Brain relationship map insight ${insight.id}. Review before durable memory or link changes.`,
+    metadata: sourceNode && targetNode ? {
+      relationship: {
+        fromId: sourceNode.id,
+        toId: targetNode.id,
+        relationship: relationshipNameForInsight(insight),
+        insightId: insight.id,
+        insightKind: insight.kind,
+        sourceLabel: sourceNode.label,
+        targetLabel: targetNode.label,
+      },
+    } : undefined,
   }
+}
+
+function relationshipNameForInsight(insight: OpenBrainRelationshipInsight) {
+  if (insight.kind === 'strengthen') return 'governed_by'
+  if (insight.kind === 'missing_governance') return 'needs_governing_context'
+  if (insight.kind === 'merge_duplicate') return 'possible_duplicate'
+  return 'needs_review'
 }
 
 function strongestPrivacyTier(tiers: Array<OpenBrainPrivacyTier | undefined>): OpenBrainPrivacyTier {
@@ -892,41 +915,60 @@ function ProposalsView({
   }
   return (
     <section className="grid grid-cols-1 xl:grid-cols-2 gap-4">
-      {proposals.map((proposal) => (
-        <article key={proposal.id} className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-5">
-          <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
-            <h3 className="font-semibold">{proposal.proposedMemory.title}</h3>
-            <StatusBadge value={proposal.status} />
-          </div>
-          <p className="mb-3 text-sm text-muted-foreground">{proposal.proposedMemory.body}</p>
-          <div className="grid grid-cols-2 gap-2 text-xs">
-            <Detail label="Kind" value={proposal.proposedMemory.kind} />
-            <Detail label="Privacy" value={proposal.proposedMemory.privacyTier} />
-            <Detail label="Confidence" value={`${Math.round(proposal.proposedMemory.confidence * 100)}%`} />
-            <Detail label="Created" value={formatDateTime(proposal.createdAt)} />
-          </div>
-          <p className="mt-3 text-xs text-muted-foreground">{proposal.reason}</p>
-          {proposal.status === 'pending' ? (
-            <div className="mt-4 flex flex-wrap gap-2">
-              <button
-                onClick={() => onReview(proposal.id, 'approve')}
-                disabled={reviewingProposalId === proposal.id}
-                className="inline-flex items-center gap-2 rounded-lg border border-green-400/40 bg-green-500/10 px-3 py-2 text-sm text-green-200 hover:bg-green-500/15 disabled:opacity-60"
-              >
-                <CheckCircle2 size={16} />
-                Approve
-              </button>
-              <button
-                onClick={() => onReview(proposal.id, 'reject')}
-                disabled={reviewingProposalId === proposal.id}
-                className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 bg-background px-3 py-2 text-sm text-muted-foreground hover:border-radiant-gold/60 disabled:opacity-60"
-              >
-                Reject
-              </button>
+      {proposals.map((proposal) => {
+        const relationship = proposal.metadata?.relationship
+        return (
+          <article key={proposal.id} className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-5">
+            <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+              <h3 className="font-semibold">{proposal.proposedMemory.title}</h3>
+              <div className="flex flex-wrap gap-2">
+                {relationship ? (
+                  <span className="rounded-full border border-radiant-gold/45 bg-radiant-gold/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-radiant-gold">
+                    Link on approval
+                  </span>
+                ) : null}
+                <StatusBadge value={proposal.status} />
+              </div>
             </div>
-          ) : null}
-        </article>
-      ))}
+            <p className="mb-3 text-sm text-muted-foreground">{proposal.proposedMemory.body}</p>
+            {relationship ? (
+              <div className="mb-3 rounded-lg border border-radiant-gold/25 bg-radiant-gold/10 p-3 text-xs">
+                <p className="font-semibold uppercase tracking-[0.12em] text-radiant-gold">Relationship link approval</p>
+                <p className="mt-2 text-muted-foreground">
+                  Approving this proposal creates a durable link: {relationship.sourceLabel} {'->'} {relationship.targetLabel}
+                </p>
+                <p className="mt-1 text-muted-foreground">Relationship: {relationship.relationship}</p>
+              </div>
+            ) : null}
+            <div className="grid grid-cols-2 gap-2 text-xs">
+              <Detail label="Kind" value={proposal.proposedMemory.kind} />
+              <Detail label="Privacy" value={proposal.proposedMemory.privacyTier} />
+              <Detail label="Confidence" value={`${Math.round(proposal.proposedMemory.confidence * 100)}%`} />
+              <Detail label="Created" value={formatDateTime(proposal.createdAt)} />
+            </div>
+            <p className="mt-3 text-xs text-muted-foreground">{proposal.reason}</p>
+            {proposal.status === 'pending' ? (
+              <div className="mt-4 flex flex-wrap gap-2">
+                <button
+                  onClick={() => onReview(proposal.id, 'approve')}
+                  disabled={reviewingProposalId === proposal.id}
+                  className="inline-flex items-center gap-2 rounded-lg border border-green-400/40 bg-green-500/10 px-3 py-2 text-sm text-green-200 hover:bg-green-500/15 disabled:opacity-60"
+                >
+                  <CheckCircle2 size={16} />
+                  Approve
+                </button>
+                <button
+                  onClick={() => onReview(proposal.id, 'reject')}
+                  disabled={reviewingProposalId === proposal.id}
+                  className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/70 bg-background px-3 py-2 text-sm text-muted-foreground hover:border-radiant-gold/60 disabled:opacity-60"
+                >
+                  Reject
+                </button>
+              </div>
+            ) : null}
+          </article>
+        )
+      })}
     </section>
   )
 }

--- a/lib/open-brain.test.ts
+++ b/lib/open-brain.test.ts
@@ -167,6 +167,93 @@ describe('Open Brain projection', () => {
     expect(snapshot.wikiPages[0].markdown).toContain('Portfolio owns projection only')
   })
 
+  it('creates a durable link only after approving a relationship proposal', async () => {
+    const root = await makeTempRoot()
+    const proposal = await createOpenBrainProposal({
+      kind: 'workflow',
+      title: 'Connect automation to runbook',
+      body: 'The Portfolio automation should be explicitly governed by the memory organization runbook.',
+      privacyTier: 'internal_ops',
+      confidence: 0.86,
+      sourceIds: ['automation:portfolio-operations-manager', 'runbook:docs/memory-context-organization-workflow.md'],
+      reason: 'Relationship insight needs approval.',
+      metadata: {
+        relationship: {
+          fromId: 'automation:portfolio-operations-manager',
+          toId: 'runbook:docs/memory-context-organization-workflow.md',
+          relationship: 'governed_by',
+          insightId: 'insight:strengthen:automation-runbook',
+          insightKind: 'strengthen',
+          sourceLabel: 'Portfolio Operations Manager',
+          targetLabel: 'Memory context organization workflow',
+        },
+      },
+    }, root)
+
+    let snapshot = await getOpenBrainSnapshot(root)
+    expect(snapshot.links).toHaveLength(0)
+
+    const approved = await reviewOpenBrainProposal(proposal.id, 'approved', 'Relationship accepted', 'admin', root)
+    snapshot = await getOpenBrainSnapshot(root)
+
+    expect(approved.metadata?.relationship).toEqual(expect.objectContaining({
+      fromId: 'automation:portfolio-operations-manager',
+      toId: 'runbook:docs/memory-context-organization-workflow.md',
+      relationship: 'governed_by',
+    }))
+    expect(snapshot.links).toEqual([
+      expect.objectContaining({
+        fromId: 'automation:portfolio-operations-manager',
+        toId: 'runbook:docs/memory-context-organization-workflow.md',
+        relationship: 'governed_by',
+      }),
+    ])
+    expect(snapshot.events).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        kind: 'proposal_approved',
+        metadata: expect.objectContaining({
+          relationshipLinkId: expect.stringMatching(/^link:/),
+        }),
+      }),
+    ]))
+  })
+
+  it('does not create a durable link when a relationship proposal is rejected', async () => {
+    const root = await makeTempRoot()
+    const proposal = await createOpenBrainProposal({
+      kind: 'workflow',
+      title: 'Reject automation relationship',
+      body: 'This proposed relationship should stay audit-only when rejected.',
+      privacyTier: 'internal_ops',
+      sourceIds: ['automation:portfolio-operations-manager'],
+      reason: 'test',
+      metadata: {
+        relationship: {
+          fromId: 'automation:portfolio-operations-manager',
+          toId: 'runbook:docs/memory-context-organization-workflow.md',
+          relationship: 'governed_by',
+          insightId: 'insight:test',
+          insightKind: 'strengthen',
+          sourceLabel: 'Portfolio Operations Manager',
+          targetLabel: 'Memory context organization workflow',
+        },
+      },
+    }, root)
+
+    await reviewOpenBrainProposal(proposal.id, 'rejected', 'Not the right runbook.', 'admin', root)
+    const snapshot = await getOpenBrainSnapshot(root)
+
+    expect(snapshot.links).toHaveLength(0)
+    expect(snapshot.events).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        kind: 'proposal_rejected',
+        metadata: expect.objectContaining({
+          relationship: expect.objectContaining({ relationship: 'governed_by' }),
+        }),
+      }),
+    ]))
+  })
+
   it('can approve a generated repair proposal after persisting it locally', async () => {
     const root = await makeTempRoot()
 

--- a/lib/open-brain.ts
+++ b/lib/open-brain.ts
@@ -95,6 +95,21 @@ export interface OpenBrainProposalRecord {
   reviewedAt: string | null
   reviewedBy: string | null
   reviewReason: string | null
+  metadata?: OpenBrainProposalMetadata
+}
+
+export interface OpenBrainProposalMetadata {
+  relationship?: OpenBrainRelationshipProposalMetadata
+}
+
+export interface OpenBrainRelationshipProposalMetadata {
+  fromId: string
+  toId: string
+  relationship: string
+  insightId: string
+  insightKind: OpenBrainRelationshipInsightKind
+  sourceLabel: string
+  targetLabel: string
 }
 
 export interface OpenBrainWikiPage {
@@ -262,6 +277,7 @@ export interface OpenBrainProposalInput {
   sourceIds?: string[]
   reason: string
   createdBy?: string
+  metadata?: OpenBrainProposalMetadata
 }
 
 const DEFAULT_OPEN_BRAIN_HOME = path.join(homedir(), '.open-brain')
@@ -484,6 +500,7 @@ export async function createOpenBrainProposal(
     reviewedAt: null,
     reviewedBy: null,
     reviewReason: null,
+    metadata: normalizeOpenBrainProposalMetadata(input.metadata),
   }
   await writeJsonArray(proposalsPath, [...proposals, proposal])
   await recordOpenBrainEvent({
@@ -497,6 +514,7 @@ export async function createOpenBrainProposal(
       proposalId: proposal.id,
       createdBy: proposal.createdBy,
       memoryKind: proposal.proposedMemory.kind,
+      relationship: proposal.metadata?.relationship,
     },
   }, openBrainHome)
   return proposal
@@ -527,10 +545,15 @@ export async function reviewOpenBrainProposal(
   }
   proposals[index] = reviewed
   await writeJsonArray(proposalsPath, proposals)
+  let approvedRelationshipLink: OpenBrainLinkRecord | null = null
   if (status === 'approved') {
     const memoriesPath = path.join(openBrainHome, MEMORIES_FILE)
     const memories = await readJsonArray<OpenBrainMemoryRecord>(memoriesPath)
     await writeJsonArray(memoriesPath, dedupeMemories([...memories, proposalToMemory(reviewed)]))
+    const relationshipLinkInput = relationshipLinkFromProposal(reviewed)
+    if (relationshipLinkInput) {
+      approvedRelationshipLink = await linkOpenBrainRecords(relationshipLinkInput, openBrainHome)
+    }
   }
   await recordOpenBrainEvent({
     kind: status === 'approved' ? 'proposal_approved' : 'proposal_rejected',
@@ -543,6 +566,8 @@ export async function reviewOpenBrainProposal(
       proposalId: reviewed.id,
       reviewedBy: reviewed.reviewedBy,
       memoryKind: reviewed.proposedMemory.kind,
+      relationship: reviewed.metadata?.relationship,
+      relationshipLinkId: approvedRelationshipLink?.id,
     },
   }, openBrainHome)
   return reviewed
@@ -1503,6 +1528,36 @@ function proposalToMemory(proposal: OpenBrainProposalRecord): OpenBrainMemoryRec
       proposal.proposedMemory.body,
       proposal.proposedMemory.privacyTier,
     ]),
+  }
+}
+
+function normalizeOpenBrainProposalMetadata(metadata: OpenBrainProposalMetadata | undefined): OpenBrainProposalMetadata | undefined {
+  if (!metadata?.relationship) return undefined
+  const relationship = metadata.relationship
+  if (!relationship.fromId?.trim() || !relationship.toId?.trim() || !relationship.relationship?.trim()) return undefined
+  if (!['strengthen', 'review', 'missing_governance', 'merge_duplicate'].includes(relationship.insightKind)) return undefined
+  return {
+    relationship: {
+      fromId: sanitizeOpenBrainText(relationship.fromId, 220),
+      toId: sanitizeOpenBrainText(relationship.toId, 220),
+      relationship: sanitizeOpenBrainText(relationship.relationship, 160),
+      insightId: sanitizeOpenBrainText(relationship.insightId || 'relationship-map-insight', 220),
+      insightKind: relationship.insightKind,
+      sourceLabel: sanitizeOpenBrainText(relationship.sourceLabel || relationship.fromId, 180),
+      targetLabel: sanitizeOpenBrainText(relationship.targetLabel || relationship.toId, 180),
+    },
+  }
+}
+
+function relationshipLinkFromProposal(proposal: OpenBrainProposalRecord) {
+  const relationship = proposal.metadata?.relationship
+  if (!relationship?.fromId || !relationship.toId || !relationship.relationship) return null
+  if (proposal.proposedMemory.privacyTier === 'private') return null
+  return {
+    id: `link:${fingerprintOpenBrainRecord([relationship.fromId, relationship.toId, relationship.relationship]).slice(0, 16)}`,
+    fromId: relationship.fromId,
+    toId: relationship.toId,
+    relationship: relationship.relationship,
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds structured relationship metadata to Open Brain memory proposals.
- Approving a relationship proposal now writes a deduped durable Open Brain link record; rejecting one remains audit-only.
- Updates the Open Brain admin proposal cards to show when approval will create a link and confirms link creation after approval.

## Enhancement Impact Preflight
- Enhancement: durable relationship-link approval lifecycle for Open Brain relationship map proposals.
- User-facing surface: `/admin/agents/open-brain` Proposals and Map flow.
- Predicted files: `lib/open-brain.ts`, `lib/open-brain.test.ts`, `app/admin/agents/open-brain/page.tsx`, `app/admin/agents/open-brain/page.test.tsx`.
- Shared routes/APIs/tables/helpers: existing `POST /api/admin/agents/open-brain/proposals/[id]/approve`, `reviewOpenBrainProposal`, and `linkOpenBrainRecords`; no database schema changes.
- Active PRs or branches checked: #384 `codex/voice-note-content-swarm`, #387 `codex/apify-staging-rotation-evidence`; PR #388 was confirmed merged before this work began.
- Dirty worktree files checked: root checkout has unrelated untracked `tmp/`; this worktree was clean before edits.
- Overlap rating: green.
- Coordination decision: proceed independently in a fresh sibling worktree because active PRs do not touch Open Brain files.
- Merge-order note: base includes merged PR #388; this PR should merge after normal review and deployment checks.

## Validation
- `npm test -- --run lib/open-brain.test.ts app/admin/agents/open-brain/page.test.tsx app/api/admin/agents/open-brain/proposals/route.test.ts 'app/api/admin/agents/open-brain/proposals/[id]/approve/route.test.ts'`
- `npm run lint`
- `npm run build`
- Browser smoke: `http://localhost:3012/admin/agents/open-brain` served with no console errors or framework overlay, but the in-app browser was unauthenticated and stopped at the login screen before Open Brain content.
- Pre-push hook: `npm run db:health-check` passed against configured `.env.local` values.

## Integration Notes
- No migrations or env changes required.
- This change writes Open Brain link records only through proposal approval and only when the proposal includes structured relationship metadata.
- No direct edits to `~/.codex/memories`, `~/.codex/automations`, or `~/.open-brain` were made during implementation.
- Build emitted the existing local env warning that `MOCK_N8N=false` and `N8N_DISABLE_OUTBOUND=false`; this change did not invoke outbound n8n workflows.
- Vercel contexts not checked by this non-captain lane: `Vercel – portfolio`, `Vercel – portfolio-staging`.