### PR TITLE
Surface reply-intent evidence gate

### DIFF
--- a/app/admin/model-ops/reply-intent-review/page.test.tsx
+++ b/app/admin/model-ops/reply-intent-review/page.test.tsx
@@ -66,6 +66,17 @@ const queueResponse = {
   schema: {
     reviews_table_available: true,
   },
+  evidence: {
+    artifact_path:
+      '/Users/vambahsillah/Documents/Codex/2026-04-29/hey-can-you-confirm-that-i/eval-data/reply-intent-review/sources/portfolio-model-ops-reviewed-replies.jsonl',
+    export_command: 'npm run model-ops:reply-intent:export',
+    exported_real: 0,
+    exported_at: null,
+    status: 'stale',
+    benchmark_actionable_real: 0,
+    remaining_to_actionable_gate: 200,
+    invalid_lines: 0,
+  },
 }
 
 describe('ReplyIntentReviewPage', () => {
@@ -103,7 +114,11 @@ describe('ReplyIntentReviewPage', () => {
 
     expect(await screen.findByRole('heading', { name: 'Reply Intent Review' })).toBeInTheDocument()
     expect(screen.getAllByText('Can we schedule a quick call next week?').length).toBeGreaterThan(0)
-    expect(screen.getByText('0/200')).toBeInTheDocument()
+    expect(screen.getAllByText('0/200').length).toBeGreaterThan(0)
+    expect(screen.getByText('Evidence Gate')).toBeInTheDocument()
+    expect(screen.getByText('Export stale')).toBeInTheDocument()
+    expect(screen.getByText('Ledger gap')).toBeInTheDocument()
+    expect(screen.getByText('npm run model-ops:reply-intent:export')).toBeInTheDocument()
 
     await waitFor(() => expect(screen.getByRole('button', { name: 'Yes' })).not.toBeDisabled())
     fireEvent.click(screen.getByRole('button', { name: 'Yes' }))

--- a/app/admin/model-ops/reply-intent-review/page.tsx
+++ b/app/admin/model-ops/reply-intent-review/page.tsx
@@ -23,6 +23,7 @@ import {
 } from 'lucide-react'
 
 type ReviewStatus = 'pending' | 'reviewed' | 'unsure' | 'skipped'
+type EvidenceStatus = 'missing' | 'stale' | 'current' | 'gate_met' | 'invalid'
 
 type SuggestedLabels = {
   scheduling_intent: boolean
@@ -70,6 +71,16 @@ type QueueResponse = {
   schema?: {
     reviews_table_available: boolean
   }
+  evidence: {
+    artifact_path: string
+    export_command: string
+    exported_real: number
+    exported_at: string | null
+    status: EvidenceStatus
+    benchmark_actionable_real: number
+    remaining_to_actionable_gate: number
+    invalid_lines: number
+  }
   reason?: string
 }
 
@@ -106,6 +117,25 @@ function labelClass(active: boolean) {
     : 'border-radiant-gold/10 bg-silicon-slate/20 text-muted-foreground'
 }
 
+function evidenceStatusLabel(status: EvidenceStatus | undefined) {
+  if (status === 'gate_met') return 'Gate met'
+  if (status === 'current') return 'Current'
+  if (status === 'stale') return 'Export stale'
+  if (status === 'invalid') return 'Invalid export'
+  return 'No export yet'
+}
+
+function evidenceStatusClass(status: EvidenceStatus | undefined) {
+  if (status === 'gate_met' || status === 'current') return 'border-emerald-400/30 bg-emerald-950/25 text-emerald-200'
+  if (status === 'stale' || status === 'missing') return 'border-radiant-gold/30 bg-radiant-gold/10 text-radiant-gold'
+  return 'border-red-400/30 bg-red-950/20 text-red-100'
+}
+
+function artifactName(value: string | undefined) {
+  if (!value) return 'reviewed replies JSONL'
+  return value.split('/').filter(Boolean).pop() || value
+}
+
 export default function ReplyIntentReviewPage() {
   return (
     <ProtectedRoute requireAdmin>
@@ -117,6 +147,7 @@ export default function ReplyIntentReviewPage() {
 function ReplyIntentReviewContent() {
   const [items, setItems] = useState<QueueItem[]>([])
   const [summary, setSummary] = useState<QueueResponse['summary'] | null>(null)
+  const [evidence, setEvidence] = useState<QueueResponse['evidence'] | null>(null)
   const [pagination, setPagination] = useState<QueueResponse['pagination'] | null>(null)
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [status, setStatus] = useState<ReviewStatus | 'all'>('pending')
@@ -163,6 +194,7 @@ function ReplyIntentReviewContent() {
       const queue = data as QueueResponse
       setItems(queue.items)
       setSummary(queue.summary)
+      setEvidence(queue.evidence)
       setPagination(queue.pagination)
       setSchemaReady(Boolean(queue.schema?.reviews_table_available ?? true))
       setSelectedId((current) => (queue.items.some((item) => item.source_id === current) ? current : queue.items[0]?.source_id ?? null))
@@ -309,7 +341,7 @@ function ReplyIntentReviewContent() {
           </div>
           <div className="grid min-w-[300px] gap-2">
             <div className="flex items-center justify-between text-sm">
-              <span className="text-muted-foreground">Reviewed real examples</span>
+              <span className="text-muted-foreground">Ledger reviewed</span>
               <span className="font-mono text-radiant-gold">
                 {summary?.reviewed_real ?? 0}/{summary?.target ?? 200}
               </span>
@@ -596,8 +628,37 @@ function ReplyIntentReviewContent() {
                 <span className="font-mono">{summary?.skipped ?? 0}</span>
               </div>
               <div className="flex items-center justify-between border-t border-radiant-gold/10 pt-2">
-                <span className="text-muted-foreground">Gate gap</span>
-                <span className="font-mono text-radiant-gold">{summary?.remaining_to_gate ?? 0}</span>
+                <span className="text-muted-foreground">Ledger gap</span>
+                <span className="font-mono text-radiant-gold">{summary?.remaining_to_gate ?? summary?.target ?? 200}</span>
+              </div>
+            </div>
+
+            <div className="grid gap-2 rounded-lg border border-radiant-gold/10 bg-silicon-slate/15 p-3 text-sm">
+              <div className="flex items-center justify-between gap-3">
+                <span className="font-semibold text-foreground">Evidence Gate</span>
+                <span className={`rounded-full border px-2 py-0.5 text-[11px] ${evidenceStatusClass(evidence?.status)}`}>
+                  {evidenceStatusLabel(evidence?.status)}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Exported evidence</span>
+                <span className="font-mono">
+                  {evidence?.benchmark_actionable_real ?? 0}/{summary?.target ?? 200}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Benchmark gap</span>
+                <span className="font-mono text-radiant-gold">{evidence?.remaining_to_actionable_gate ?? summary?.target ?? 200}</span>
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-muted-foreground">Artifact</span>
+                <span className="truncate font-mono text-xs text-foreground/80">{artifactName(evidence?.artifact_path)}</span>
+              </div>
+              <div className="grid gap-1 border-t border-radiant-gold/10 pt-2">
+                <span className="text-muted-foreground">Next export</span>
+                <code className="overflow-hidden text-ellipsis rounded border border-radiant-gold/10 bg-background/40 px-2 py-1 text-xs text-foreground/85">
+                  {evidence?.export_command ?? 'npm run model-ops:reply-intent:export'}
+                </code>
               </div>
             </div>
 

--- a/app/api/admin/model-ops/reply-intent-reviews/route.test.ts
+++ b/app/api/admin/model-ops/reply-intent-reviews/route.test.ts
@@ -4,6 +4,8 @@ const mocks = vi.hoisted(() => ({
   verifyAdmin: vi.fn(),
   isAuthError: vi.fn(),
   from: vi.fn(),
+  readFile: vi.fn(),
+  stat: vi.fn(),
 }))
 
 vi.mock('@/lib/auth-server', () => ({
@@ -15,6 +17,15 @@ vi.mock('@/lib/supabase', () => ({
   supabaseAdmin: {
     from: mocks.from,
   },
+}))
+
+vi.mock('node:fs/promises', () => ({
+  default: {
+    readFile: mocks.readFile,
+    stat: mocks.stat,
+  },
+  readFile: mocks.readFile,
+  stat: mocks.stat,
 }))
 
 import { GET, POST } from './route'
@@ -67,6 +78,9 @@ describe('reply-intent review API', () => {
     vi.clearAllMocks()
     mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
     mocks.isAuthError.mockReturnValue(false)
+    const missingFile = Object.assign(new Error('missing export'), { code: 'ENOENT' })
+    mocks.readFile.mockRejectedValue(missingFile)
+    mocks.stat.mockRejectedValue(missingFile)
   })
 
   it('requires admin auth before listing reviews', async () => {
@@ -96,8 +110,49 @@ describe('reply-intent review API', () => {
       pending: 1,
       target: 200,
     })
+    expect(body.evidence).toMatchObject({
+      exported_real: 0,
+      status: 'missing',
+      remaining_to_actionable_gate: 200,
+    })
     expect(body.items[0].redacted_reply).toContain('[email:')
     expect(body.items[0].redacted_reply).not.toContain('jane@example.com')
+  })
+
+  it('marks the exported benchmark artifact as stale when ledger reviews are ahead', async () => {
+    const reviewedRow = {
+      source_table: 'outreach_queue',
+      source_id: sourceRow.id,
+      source_hash: 'source-hash',
+      reply_hash: 'reply-hash',
+      redacted_reply: 'redacted reply',
+      suggested_labels: {
+        scheduling_intent: true,
+        interested: true,
+        not_interested: false,
+        ooo: false,
+        needs_followup: false,
+      },
+      review_status: 'reviewed',
+      human_scheduling_intent: true,
+    }
+    mocks.readFile.mockResolvedValue('')
+    mocks.stat.mockResolvedValue({ mtime: new Date('2026-05-24T11:00:00.000Z') })
+    mocks.from.mockImplementation((table: string) => {
+      if (table === 'outreach_queue') return listQuery({ data: [sourceRow], error: null })
+      return listQuery({ data: [reviewedRow], error: null })
+    })
+
+    const response = await GET(request() as never)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.summary.reviewed_real).toBe(1)
+    expect(body.evidence).toMatchObject({
+      exported_real: 0,
+      status: 'stale',
+      benchmark_actionable_real: 0,
+    })
   })
 
   it('validates reviewed saves require a boolean scheduling label', async () => {

--- a/app/api/admin/model-ops/reply-intent-reviews/route.ts
+++ b/app/api/admin/model-ops/reply-intent-reviews/route.ts
@@ -1,10 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { readFile, stat } from 'node:fs/promises'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
 import { supabaseAdmin } from '@/lib/supabase'
 import {
+  MODEL_OPS_REPLY_INTENT_DEFAULT_EXPORT,
+  MODEL_OPS_REPLY_INTENT_EXPORT_COMMAND,
   MODEL_OPS_REPLY_INTENT_TARGET,
   buildReviewUpsertPayload,
   normalizeReviewStatus,
+  type ReplyIntentEvidenceSummary,
   type OutreachReplySourceRow,
   type ReplyIntentQueueItem,
   type ReplyIntentReviewRow,
@@ -36,6 +40,7 @@ type QueueResponse = {
   schema?: {
     reviews_table_available: boolean
   }
+  evidence: ReplyIntentEvidenceSummary
 }
 
 function intParam(value: string | null, fallback: number, min: number, max: number) {
@@ -100,6 +105,69 @@ function mapQueueItems(sourceRows: OutreachReplySourceRow[], reviewRows: ReplyIn
   return sourceRows.map((source) => toReplyIntentQueueItem(source, reviewsBySourceId.get(source.id)))
 }
 
+function countExportedReviewedExamples(raw: string) {
+  let exportedReal = 0
+  let invalidLines = 0
+
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+
+    try {
+      const parsed = JSON.parse(trimmed) as { review?: { scheduling_intent?: unknown } }
+      if (typeof parsed.review?.scheduling_intent === 'boolean') exportedReal += 1
+    } catch {
+      invalidLines += 1
+    }
+  }
+
+  return { exportedReal, invalidLines }
+}
+
+async function getEvidenceSummary(reviewedReal: number): Promise<ReplyIntentEvidenceSummary> {
+  const artifactPath = process.env.MODEL_OPS_REPLY_INTENT_EXPORT || MODEL_OPS_REPLY_INTENT_DEFAULT_EXPORT
+  const base = {
+    artifact_path: artifactPath,
+    export_command: MODEL_OPS_REPLY_INTENT_EXPORT_COMMAND,
+    exported_real: 0,
+    exported_at: null,
+    benchmark_actionable_real: 0,
+    remaining_to_actionable_gate: MODEL_OPS_REPLY_INTENT_TARGET,
+    invalid_lines: 0,
+  }
+
+  try {
+    const [raw, artifactStat] = await Promise.all([readFile(artifactPath, 'utf8'), stat(artifactPath)])
+    const { exportedReal, invalidLines } = countExportedReviewedExamples(raw)
+    const status =
+      invalidLines > 0
+        ? 'invalid'
+        : exportedReal >= MODEL_OPS_REPLY_INTENT_TARGET
+          ? 'gate_met'
+          : exportedReal < reviewedReal
+            ? 'stale'
+            : 'current'
+
+    return {
+      ...base,
+      exported_real: exportedReal,
+      exported_at: artifactStat.mtime.toISOString(),
+      status,
+      benchmark_actionable_real: invalidLines > 0 ? 0 : exportedReal,
+      remaining_to_actionable_gate:
+        invalidLines > 0 ? MODEL_OPS_REPLY_INTENT_TARGET : Math.max(0, MODEL_OPS_REPLY_INTENT_TARGET - exportedReal),
+      invalid_lines: invalidLines,
+    }
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && (error as { code?: string }).code === 'ENOENT') {
+      return { ...base, status: 'missing' }
+    }
+
+    console.error('Error reading reply-intent benchmark export:', error)
+    return { ...base, status: 'invalid' }
+  }
+}
+
 export async function GET(request: NextRequest) {
   const authResult = await verifyAdmin(request)
   if (isAuthError(authResult)) {
@@ -135,12 +203,14 @@ export async function GET(request: NextRequest) {
 
     if (sourceError) {
       if (isMissingTableError(sourceError)) {
+        const emptySummary = summarize([])
         return NextResponse.json({
           available: false,
           reason: 'Outreach queue schema has not been applied in this environment.',
           items: [],
-          summary: summarize([]),
+          summary: emptySummary,
           pagination: { page, limit, total: 0, totalPages: 0 },
+          evidence: await getEvidenceSummary(emptySummary.reviewed_real),
         })
       }
       console.error('Error fetching reply-intent source rows:', sourceError)
@@ -157,6 +227,8 @@ export async function GET(request: NextRequest) {
       (sourceRows || []).filter((row: OutreachReplySourceRow) => String(row.reply_content || '').trim().length >= 8),
       reviewsTableAvailable ? ((reviewResult.data || []) as ReplyIntentReviewRow[]) : []
     )
+    const queueSummary = summarize(allItems)
+    const evidence = await getEvidenceSummary(queueSummary.reviewed_real)
     const filtered = filterItems(allItems, normalizedStatus, search)
     const offset = (page - 1) * limit
     const items = filtered.slice(offset, offset + limit)
@@ -164,7 +236,7 @@ export async function GET(request: NextRequest) {
     const response: QueueResponse = {
       available: true,
       items,
-      summary: summarize(allItems),
+      summary: queueSummary,
       pagination: {
         page,
         limit,
@@ -174,6 +246,7 @@ export async function GET(request: NextRequest) {
       schema: {
         reviews_table_available: reviewsTableAvailable,
       },
+      evidence,
     }
 
     return NextResponse.json(response)

--- a/lib/model-ops-reply-intent.ts
+++ b/lib/model-ops-reply-intent.ts
@@ -1,8 +1,12 @@
 import crypto from 'node:crypto'
 
 export const MODEL_OPS_REPLY_INTENT_TARGET = 200
+export const MODEL_OPS_REPLY_INTENT_DEFAULT_EXPORT =
+  '/Users/vambahsillah/Documents/Codex/2026-04-29/hey-can-you-confirm-that-i/eval-data/reply-intent-review/sources/portfolio-model-ops-reviewed-replies.jsonl'
+export const MODEL_OPS_REPLY_INTENT_EXPORT_COMMAND = 'npm run model-ops:reply-intent:export'
 
 export type ReplyIntentReviewStatus = 'pending' | 'reviewed' | 'unsure' | 'skipped'
+export type ReplyIntentEvidenceStatus = 'missing' | 'stale' | 'current' | 'gate_met' | 'invalid'
 
 export type ReplyIntentSuggestedLabels = {
   scheduling_intent: boolean
@@ -59,6 +63,17 @@ export type ReplyIntentQueueItem = {
   notes: string
   reviewed_at: string | null
   existing_review_id: string | null
+}
+
+export type ReplyIntentEvidenceSummary = {
+  artifact_path: string
+  export_command: string
+  exported_real: number
+  exported_at: string | null
+  status: ReplyIntentEvidenceStatus
+  benchmark_actionable_real: number
+  remaining_to_actionable_gate: number
+  invalid_lines: number
 }
 
 const NAME_PATTERN = /\b[A-Z][a-z]+ [A-Z][a-z]+\b/g

--- a/scripts/export-reply-intent-reviews.ts
+++ b/scripts/export-reply-intent-reviews.ts
@@ -3,10 +3,12 @@ import { mkdir, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import { createClient } from '@supabase/supabase-js'
 import { config as loadDotenv } from 'dotenv'
-import { normalizeSuggestedLabels, stableHash, type ReplyIntentReviewRow } from '../lib/model-ops-reply-intent'
-
-const DEFAULT_OUTPUT =
-  '/Users/vambahsillah/Documents/Codex/2026-04-29/hey-can-you-confirm-that-i/eval-data/reply-intent-review/sources/portfolio-model-ops-reviewed-replies.jsonl'
+import {
+  MODEL_OPS_REPLY_INTENT_DEFAULT_EXPORT,
+  normalizeSuggestedLabels,
+  stableHash,
+  type ReplyIntentReviewRow,
+} from '../lib/model-ops-reply-intent'
 
 type ExportOptions = {
   output: string
@@ -21,7 +23,7 @@ type ReviewedRow = ReplyIntentReviewRow & {
 
 export function parseArgs(argv: string[]): ExportOptions {
   const options: ExportOptions = {
-    output: process.env.MODEL_OPS_REPLY_INTENT_EXPORT || DEFAULT_OUTPUT,
+    output: process.env.MODEL_OPS_REPLY_INTENT_EXPORT || MODEL_OPS_REPLY_INTENT_DEFAULT_EXPORT,
     limit: Number.parseInt(process.env.MODEL_OPS_REPLY_INTENT_EXPORT_LIMIT || '1000', 10),
     envFile: '.env.local',
   }


### PR DESCRIPTION
## Summary
- add exported benchmark artifact status to the reply-intent review API
- show a Portfolio evidence gate that separates live ledger progress from exported benchmark evidence
- share the default export path/command between the API and export script

## Validation
- npm test -- --run app/api/admin/model-ops/reply-intent-reviews/route.test.ts app/admin/model-ops/reply-intent-review/page.test.tsx lib/model-ops-reply-intent.test.ts scripts/export-reply-intent-reviews.test.ts
- npm run lint -- --file app/admin/model-ops/reply-intent-review/page.tsx --file app/api/admin/model-ops/reply-intent-reviews/route.ts --file lib/model-ops-reply-intent.ts --file scripts/export-reply-intent-reviews.ts
- npm run build
- inline Browser visual check at http://localhost:3024/admin/model-ops/reply-intent-review

## Notes
- The UI currently shows the review-table migration gate in this environment; saves still require the existing Model Ops review migration to be applied.
- No model routing, hosted production behavior, secrets, or Supabase data were changed by this PR.