### PR TITLE
Refresh Model Ops snapshot with challenger results

### DIFF
--- a/data/model-ops/reports/latest-dashboard-data.json
+++ b/data/model-ops/reports/latest-dashboard-data.json
@@ -1,6 +1,6 @@
 {
   "projectName": "Local LLM Model Ops & Hermes Automation",
-  "generatedAt": "2026-05-25T12:19:54.415Z",
+  "generatedAt": "2026-05-26T03:30:17.419Z",
   "recommendations": {
     "replyIntentDefault": "Keep qwen3-4b-instruct-2507 for reply-intent classification. It has the best current accuracy/latency balance.",
     "ragDefault": "Use routed local RAG as the leading local/shadow candidate, with Pinecone/OpenAI fallback until larger answer-level evals pass.",
@@ -159,6 +159,57 @@
           "scored": 200,
           "correct": 200,
           "accuracy": 1
+        }
+      }
+    },
+    {
+      "file": "eval-results/reply-intent-review/lmstudio-review-results-gemma-4-e4b-it-2026-05-25.json",
+      "model": "gemma-4-e4b-it",
+      "observedModel": "gemma-4-e4b-it",
+      "total": 211,
+      "scored": 211,
+      "correct": 205,
+      "accuracy": 0.9715639810426541,
+      "avgLatencyMs": 667.9241706161138,
+      "medianLatencyMs": 658,
+      "estimated200Minutes": 2.226413902053712,
+      "status": "fixture_pipeline_timing_only",
+      "caveat": "Fixture/synthetic examples are useful for runner timing and failure discovery, but do not satisfy the production 200-example significance gate.",
+      "sourceAccuracy": {
+        "n8n_execution": {
+          "scored": 5,
+          "correct": 5,
+          "accuracy": 1
+        },
+        "gmail_backfill": {
+          "scored": 6,
+          "correct": 6,
+          "accuracy": 1
+        },
+        "portfolio_test_fixture": {
+          "scored": 200,
+          "correct": 194,
+          "accuracy": 0.97
+        }
+      }
+    },
+    {
+      "file": "eval-results/reply-intent-review/lmstudio-review-results-qwen3.6-27b-optiq-smoke-2026-05-25.json",
+      "model": "qwen3.6-27b-optiq",
+      "observedModel": "qwen3.6-27b-optiq",
+      "total": 5,
+      "scored": 0,
+      "correct": 0,
+      "avgLatencyMs": 9477.8,
+      "medianLatencyMs": 8898,
+      "estimated200Minutes": 31.592666666666663,
+      "status": "fixture_pipeline_timing_only",
+      "caveat": "Fixture/synthetic examples are useful for runner timing and failure discovery, but do not satisfy the production 200-example significance gate.",
+      "sourceAccuracy": {
+        "n8n_execution": {
+          "scored": 0,
+          "correct": 0,
+          "accuracy": null
         }
       }
     }


### PR DESCRIPTION
## Summary\n- Refreshes the sanitized Model Ops dashboard snapshot after Qwen3.6 and Gemma 4 E4B local challenger checks.\n- Adds Gemma 4 E4B full reply-intent benchmark: 205/211 correct, 211/211 scored, 668 ms average latency.\n- Adds Qwen3.6 27B smoke result: 0/5 scored due to empty outputs, 9.48s average latency.\n\n## Decision\n- Keep qwen3-4b-instruct-2507 as the local reply-intent default.\n- No production swap packet, hosted routing change, n8n production mutation, Vercel flag change, Supabase/Pinecone production mutation, secret change, merge, or deploy change is included.\n\n## Validation\n- EVAL_LIMIT=5 LMSTUDIO_MODEL=qwen3.6-27b-optiq LMSTUDIO_REQUEST_TIMEOUT_MS=30000 node scripts/run_reply_review_eval.js eval-data/reply-intent-review/review-queue.jsonl eval-results/reply-intent-review/lmstudio-review-results-qwen3.6-27b-optiq-smoke-2026-05-25.json\n- LMSTUDIO_MODEL=gemma-4-e4b-it LMSTUDIO_REQUEST_TIMEOUT_MS=30000 node scripts/run_reply_review_eval.js eval-data/reply-intent-review/review-queue.jsonl eval-results/reply-intent-review/lmstudio-review-results-gemma-4-e4b-it-2026-05-25.json\n- node scripts/build_model_ops_dashboard.js\n- npm --prefix /Users/vambahsillah/Projects/Portfolio run model-ops:snapshot\n- npm --prefix /Users/vambahsillah/Projects/Portfolio run model-ops:research:plan -- --repo-snapshot\n- npm --prefix /Users/vambahsillah/Projects/Portfolio run model-ops:snapshot:check\n- pre-push hook: npm run db:health-check