### PR TITLE
test: add client ai ops synthetic pilot

### DIFF
--- a/app/api/admin/client-projects/[id]/ai-ops/route.test.ts
+++ b/app/api/admin/client-projects/[id]/ai-ops/route.test.ts
@@ -35,6 +35,33 @@ describe('GET /api/admin/client-projects/[id]/ai-ops', () => {
     mocks.getRoadmapBundleForProject.mockResolvedValue({
       clientView: {
         title: 'Acme AI Ops Roadmap',
+        connectorReadiness: {
+          summary: '5 required, 0 ready, 4 need auth, 0 approval-blocked',
+          requiredConnectorCount: 5,
+          readyConnectorCount: 0,
+          approvalBlockedConnectorCount: 0,
+          missingCriticalConnectorCount: 0,
+          connectorNextAction: 'Prepare oauth setup packet for HubSpot; do not connect until approved.',
+          conflicts: [],
+          items: [
+            {
+              key: 'hubspot',
+              label: 'HubSpot',
+              category: 'crm',
+              status: 'needs_auth',
+              source: 'audit',
+              authMethod: 'oauth',
+              setupOwner: 'shared',
+              requiredScopes: [],
+              approvalActions: [],
+              healthChecks: [],
+              fallbackPath: 'Use CSV exports until OAuth approval.',
+              critical: true,
+              evidence: 'Audit CRM: hubspot',
+              nextAction: 'Prepare oauth setup packet for HubSpot; do not connect until approved.',
+            },
+          ],
+        },
         projectionStatus: {
           tasksTotal: 2,
           tasksComplete: 1,
@@ -63,6 +90,10 @@ describe('GET /api/admin/client-projects/[id]/ai-ops', () => {
       approvalNeededCount: 1,
       isolationRequiredCount: 1,
       nextReportingAction: 'Review approval-gated roadmap work',
+    })
+    expect(body.roadmap.clientView.connectorReadiness).toMatchObject({
+      requiredConnectorCount: 5,
+      connectorNextAction: 'Prepare oauth setup packet for HubSpot; do not connect until approved.',
     })
   })
 

--- a/docs/client-ai-ops-roadmap-sop.md
+++ b/docs/client-ai-ops-roadmap-sop.md
@@ -102,6 +102,18 @@ Connector readiness is part of the roadmap snapshot and client/admin read model.
 
 Connector readiness may show required connectors, ready connectors, approval-blocked connectors, missing critical connectors, detected providers, and the next setup action. Treat these as planning signals only. OAuth, API keys, service accounts, webhook setup, workflow activation, outbound sends, publishing, production deploys, and client-data mutation remain approval-gated.
 
+## Synthetic Pilot Fixture
+
+Use `buildSyntheticClientAiOpsPilot` from `lib/client-ai-ops-synthetic-pilot.ts` as the no-side-effect regression path for new roadmap, connector, and swarm-board changes. It proves the current MVP flow with synthetic data only:
+
+1. Audit and verified stack signals produce connector readiness.
+2. The roadmap snapshot carries connector readiness into the client/admin read model.
+3. The swarm board can project the same synthetic client into the correct operational column.
+4. Discovery, technology decision, provisioning planning, and QA handoffs stay autonomous only for read-only work.
+5. Credential sync, live OAuth/API setup, outbound sends, provider writes, deploys, publishing, and client-data mutation route to approval boundaries.
+
+The fixture is not a seed script and must not create client records, credentials, OAuth connections, provider resources, live workflows, outbound messages, or production configuration.
+
 ## Roadmap Rule Checklist
 
 Use this checklist whenever a roadmap feature, monitor, report, or client implementation phase changes:
@@ -114,6 +126,7 @@ Use this checklist whenever a roadmap feature, monitor, report, or client implem
 - The monitor can create a roadmap report and follow-up task when drift, stale pricing, missing reports, or blockers appear.
 - Roadmap projection status is visible from the same source data and remains read-only.
 - Connector readiness is visible from verified stack, audit, BuiltWith, and roadmap signals without live credential setup.
+- The synthetic pilot fixture still proves audit-to-roadmap-to-client/admin projection and read-only autonomous handoff boundaries.
 - Client-facing output excludes private logs, agent traces, credentials, and internal-only notes.
 
 ## Real Client Pilot Checklist

--- a/lib/client-ai-ops-synthetic-pilot.test.ts
+++ b/lib/client-ai-ops-synthetic-pilot.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/supabase', () => ({ supabaseAdmin: null }))
+
+import { buildSyntheticClientAiOpsPilot } from './client-ai-ops-synthetic-pilot'
+
+describe('buildSyntheticClientAiOpsPilot', () => {
+  it('proves audit-to-roadmap-to-client-view connector readiness with synthetic data only', () => {
+    const pilot = buildSyntheticClientAiOpsPilot()
+    const connectorKeys = pilot.clientView.connectorReadiness.items.map((item) => item.key)
+
+    expect(pilot.context.auditSignals?.[0]?.tech_stack).toMatchObject({
+      crm: 'hubspot',
+      email: 'gmail',
+      marketing: 'mailchimp',
+    })
+    expect(connectorKeys).toEqual(expect.arrayContaining([
+      'webflow',
+      'hubspot',
+      'google_workspace',
+      'slack',
+      'pinecone',
+      'google_analytics',
+    ]))
+    expect(pilot.clientView.connectorReadiness.requiredConnectorCount).toBeGreaterThanOrEqual(6)
+    expect(pilot.clientView.connectorReadiness.connectorNextAction).toContain('do not connect until approved')
+    expect(JSON.stringify(pilot)).not.toContain('access_token')
+    expect(JSON.stringify(pilot)).not.toContain('api_secret')
+  })
+
+  it('keeps discovery, tech decision, provisioning, and QA handoffs autonomous only for read-only work', () => {
+    const pilot = buildSyntheticClientAiOpsPilot()
+
+    expect(pilot.autonomousHandoffPath.map((step) => step.stage)).toEqual([
+      'discovery',
+      'technology_decision',
+      'provisioning_plan',
+      'qa_isolation',
+    ])
+    for (const step of pilot.autonomousHandoffPath) {
+      expect(step.decision).toMatchObject({
+        autonomousAllowed: true,
+        requiresApproval: false,
+      })
+    }
+  })
+
+  it('routes credential sync and outbound sends to approval boundaries', () => {
+    const pilot = buildSyntheticClientAiOpsPilot()
+
+    expect(pilot.approvalBoundary.credentialSync).toMatchObject({
+      autonomousAllowed: false,
+      requiresApproval: true,
+      nextColumn: 'waiting_approval',
+    })
+    expect(pilot.approvalBoundary.credentialSync.approvalActions).toEqual(expect.arrayContaining([
+      'client_data_access',
+      'production_config_change',
+    ]))
+    expect(pilot.approvalBoundary.outboundSend).toMatchObject({
+      autonomousAllowed: false,
+      requiresApproval: true,
+      nextColumn: 'waiting_approval',
+      approvalActions: ['send_email'],
+    })
+  })
+
+  it('projects the synthetic pilot into the swarm board without pending approvals or failed runs', () => {
+    const pilot = buildSyntheticClientAiOpsPilot()
+    const cards = pilot.swarmSnapshot.columns.flatMap((column) => column.cards)
+    const card = cards.find((item) => item.clientProjectId === 'synthetic-client-ai-ops-project')
+
+    expect(card).toBeTruthy()
+    expect(card).toMatchObject({
+      moduleHealth: 'green',
+      approvalState: 'none',
+      failedOrStaleRuns: 0,
+      pendingApprovals: 0,
+    })
+    expect(card?.requiredConnectorCount).toBeGreaterThanOrEqual(6)
+    expect(['provisioning_plan', 'qa_isolation', 'active_monitoring']).toContain(card?.column)
+    expect(pilot.swarmSnapshot.summary).toMatchObject({
+      clients: 1,
+      failed_or_stale: 0,
+      pending_approvals: 0,
+      isolation_failures: 0,
+      autonomous_ready: 1,
+    })
+  })
+})

--- a/lib/client-ai-ops-synthetic-pilot.ts
+++ b/lib/client-ai-ops-synthetic-pilot.ts
@@ -1,0 +1,309 @@
+import {
+  buildAgentSwarmBoardSnapshotFromRows,
+  evaluateSwarmHandoffPolicy,
+  type AgentSwarmBoardSnapshot,
+  type SwarmHandoffPolicyDecision,
+  type SwarmHandoffStage,
+} from './agent-swarm-board'
+import {
+  buildClientRoadmapView,
+  buildProposalRoadmapSnapshot,
+  type RoadmapClientView,
+  type RoadmapContext,
+  type RoadmapDraft,
+  type RoadmapTaskDraft,
+} from './client-ai-ops-roadmap'
+
+type SwarmRows = Parameters<typeof buildAgentSwarmBoardSnapshotFromRows>[0]
+
+const GENERATED_AT = '2026-05-26T12:00:00.000Z'
+const PROJECT_ID = 'synthetic-client-ai-ops-project'
+const ROADMAP_ID = 'synthetic-client-ai-ops-roadmap'
+const CONTACT_ID = 9001
+
+export type SyntheticClientAiOpsPilot = {
+  context: RoadmapContext
+  draft: RoadmapDraft
+  clientView: RoadmapClientView
+  swarmRows: SwarmRows
+  swarmSnapshot: AgentSwarmBoardSnapshot
+  autonomousHandoffPath: Array<{
+    stage: SwarmHandoffStage
+    decision: SwarmHandoffPolicyDecision
+  }>
+  approvalBoundary: {
+    credentialSync: SwarmHandoffPolicyDecision
+    outboundSend: SwarmHandoffPolicyDecision
+  }
+}
+
+export function buildSyntheticClientAiOpsPilot(): SyntheticClientAiOpsPilot {
+  const context = syntheticRoadmapContext()
+  const draft = buildProposalRoadmapSnapshot(context)
+  const phases = draft.phases.map((phase) => ({
+    id: `phase-${phase.phaseOrder}`,
+    title: phase.title,
+    objective: phase.objective,
+    status: phase.phaseOrder === 1 ? 'complete' as const : phase.status,
+    phase_order: phase.phaseOrder,
+    acceptance_criteria: phase.acceptanceCriteria,
+  }))
+  const tasks = draft.tasks.map((task) => ({
+    phase_id: `phase-${draft.phases.find((phase) => phase.phaseKey === task.phaseKey)?.phaseOrder ?? 1}`,
+    title: task.title,
+    owner_type: task.ownerType,
+    priority: task.priority,
+    status: statusForSyntheticTask(task),
+    due_date: null,
+    client_visible: task.clientVisible,
+    metadata: task.orgBoard ? { org_board: orgBoardMetadata(task) } : null,
+  }))
+  const clientView = buildClientRoadmapView({
+    roadmap: {
+      title: draft.title,
+      status: 'active',
+      client_summary: draft.clientSummary,
+      snapshot: {
+        input_hash: draft.inputHash,
+        runtime_placement_options: draft.runtimePlacementOptions,
+        connector_readiness: draft.connectorReadiness,
+      },
+    },
+    phases,
+    tasks,
+    costItems: draft.costItems.map((item) => ({
+      payer: item.payer,
+      costType: item.costType,
+      amount: item.amount,
+      category: item.category,
+    })),
+    reports: [
+      {
+        title: 'Synthetic Client AI Ops readiness report',
+        report_type: 'synthetic_pilot',
+        status: 'draft',
+        generated_at: GENERATED_AT,
+        summary: 'Synthetic data only. Connector setup is represented as planning work and approval packets.',
+        client_actions: ['Approve the connector setup packet before any OAuth, API key, or provider action.'],
+        amadutown_actions: ['Run synthetic QA and prepare the provisioning plan.'],
+        approval_needed: [],
+        monitoring_summary: {
+          overdue_tasks: 0,
+          stale_cost_items: 0,
+          report_missing: false,
+          checked_at: GENERATED_AT,
+        },
+      },
+    ],
+  })
+  const swarmRows = syntheticSwarmRows(draft)
+
+  return {
+    context,
+    draft,
+    clientView,
+    swarmRows,
+    swarmSnapshot: buildAgentSwarmBoardSnapshotFromRows(swarmRows),
+    autonomousHandoffPath: [
+      policyStep('discovery'),
+      policyStep('technology_decision'),
+      policyStep('provisioning_plan'),
+      policyStep('qa_isolation'),
+    ],
+    approvalBoundary: {
+      credentialSync: evaluateSwarmHandoffPolicy({
+        stage: 'provisioning_plan',
+        requestedActions: ['client_data_access', 'external_api_call', 'production_config_change'],
+        riskLevel: 'medium',
+      }),
+      outboundSend: evaluateSwarmHandoffPolicy({
+        stage: 'reporting',
+        requestedActions: ['send_email'],
+        riskLevel: 'medium',
+      }),
+    },
+  }
+}
+
+function syntheticRoadmapContext(): RoadmapContext {
+  return {
+    clientName: 'Synthetic Pilot',
+    clientCompany: 'Synthetic Ops Co',
+    projectName: 'Synthetic Client AI Ops MVP',
+    clientProjectId: PROJECT_ID,
+    contactSubmissionId: CONTACT_ID,
+    verifiedStack: { technologies: [{ name: 'Webflow' }] },
+    builtWithStack: { technologies: [{ name: 'Google Analytics' }] },
+    stackSignals: ['24/7 cloud runtime', 'local llm fallback', 'client-owned approvals'],
+    auditSignals: [
+      {
+        id: 'synthetic-audit-1',
+        audit_type: 'standalone',
+        tech_stack: {
+          crm: 'hubspot',
+          email: 'gmail',
+          marketing: 'mailchimp',
+          analytics: 'google analytics',
+          other_tools: ['Slack', 'Pinecone'],
+          integration_readiness: 'documented but not connected',
+        },
+        automation_needs: { priority_areas: ['lead_follow_up', 'client_reporting'] },
+        ai_readiness: { data_quality: 'integrated', previous_ai_experience: 'light experimentation' },
+        budget_timeline: { budget_range: 'mvp', timeline: '30 days' },
+        decision_making: { decision_maker: true, approval_process: 'solo' },
+        enriched_tech_stack: { technologies: [{ name: 'Pinecone' }, { name: 'n8n' }] },
+      },
+    ],
+  }
+}
+
+function syntheticSwarmRows(draft: RoadmapDraft): SwarmRows {
+  return {
+    projects: [
+      {
+        id: PROJECT_ID,
+        project_name: 'Synthetic Client AI Ops MVP',
+        client_name: 'Synthetic Pilot',
+        client_email: 'pilot@example.test',
+        contact_submission_id: CONTACT_ID,
+        project_status: 'active',
+        estimated_end_date: '2026-06-30',
+        created_at: GENERATED_AT,
+      },
+    ],
+    roadmaps: [
+      {
+        id: ROADMAP_ID,
+        client_project_id: PROJECT_ID,
+        title: draft.title,
+        status: 'active',
+        snapshot: {
+          input_hash: draft.inputHash,
+          runtime_placement_options: draft.runtimePlacementOptions,
+          connector_readiness: draft.connectorReadiness,
+          isolation_status: 'passed',
+        },
+        updated_at: GENERATED_AT,
+      },
+    ],
+    tasks: [
+      swarmTask('data-source-map', draft, 'complete'),
+      swarmTask('ai-runtime-selection', draft, 'complete'),
+      swarmTask('hardware-decision', draft, 'complete'),
+      swarmTask('backup-monitoring', draft, 'pending'),
+      swarmTask('workflow-validation', draft, 'pending'),
+    ],
+    reports: [
+      {
+        roadmap_id: ROADMAP_ID,
+        report_type: 'synthetic_pilot',
+        status: 'draft',
+        generated_at: GENERATED_AT,
+        monitoring_summary: {
+          overdue_tasks: 0,
+          stale_cost_items: 0,
+          report_missing: false,
+          checked_at: GENERATED_AT,
+        },
+      },
+    ],
+    runs: [
+      run('synthetic-run-discovery', 'research-source-register', 'Discover client stack', 'completed', 'Discovery complete'),
+      run('synthetic-run-decision', 'technology-evaluator', 'Prepare LLM, RAG, and auth decision packet', 'completed', 'Decision packet complete'),
+      run('synthetic-run-provisioning', 'automation-systems', 'Prepare provisioning plan', 'completed', 'Provisioning plan prepared without live setup'),
+      run('synthetic-run-qa', 'engineering-copilot', 'Run synthetic QA', 'running', 'Synthetic QA in progress'),
+    ],
+    approvals: [],
+    contacts: [
+      {
+        id: CONTACT_ID,
+        email: 'pilot@example.test',
+        client_verified_tech_stack: { technologies: [{ name: 'Webflow' }] },
+        website_tech_stack: { technologies: [{ name: 'Google Analytics' }] },
+      },
+    ],
+    audits: syntheticRoadmapContext().auditSignals!.map((audit) => ({
+      ...audit,
+      id: audit.id ?? 'synthetic-audit-1',
+      contact_submission_id: CONTACT_ID,
+      contact_email: 'pilot@example.test',
+      completed_at: GENERATED_AT,
+      updated_at: GENERATED_AT,
+      created_at: GENERATED_AT,
+    })),
+  }
+}
+
+function swarmTask(taskKey: string, draft: RoadmapDraft, status: string): SwarmRows['tasks'][number] {
+  const task = draft.tasks.find((item) => item.taskKey === taskKey)
+  if (!task) throw new Error(`Synthetic pilot task missing from roadmap draft: ${taskKey}`)
+  return {
+    id: `synthetic-task-${task.taskKey}`,
+    roadmap_id: ROADMAP_ID,
+    task_key: task.taskKey,
+    title: task.title,
+    status,
+    priority: task.priority,
+    owner_type: task.ownerType,
+    due_date: null,
+    metadata: task.orgBoard ? { org_board: orgBoardMetadata(task) } : null,
+  }
+}
+
+function orgBoardMetadata(task: RoadmapTaskDraft) {
+  return task.orgBoard
+    ? {
+        column: task.orgBoard.column,
+        stage: task.orgBoard.stage,
+        owner_agent_key: task.orgBoard.ownerAgentKey,
+        owner_agent_label: task.orgBoard.ownerAgentLabel,
+        approval_posture: task.orgBoard.approvalPosture,
+        isolation_required: task.orgBoard.isolationRequired,
+        client_visible_label: task.orgBoard.clientVisibleLabel ?? null,
+        internal_handoff_label: task.orgBoard.internalHandoffLabel ?? null,
+      }
+    : null
+}
+
+function statusForSyntheticTask(task: RoadmapTaskDraft) {
+  if (['client-vault', 'ownership-map', 'hardware-decision', 'data-source-map', 'ai-runtime-selection'].includes(task.taskKey)) {
+    return 'complete' as const
+  }
+  return task.status
+}
+
+function policyStep(stage: SwarmHandoffStage) {
+  return {
+    stage,
+    decision: evaluateSwarmHandoffPolicy({
+      stage,
+      requestedActions: ['read_files'],
+      riskLevel: 'medium',
+    }),
+  }
+}
+
+function run(
+  id: string,
+  agentKey: string,
+  title: string,
+  status: string,
+  currentStep: string,
+): SwarmRows['runs'][number] {
+  return {
+    id,
+    agent_key: agentKey,
+    runtime: 'codex',
+    kind: 'agent_handoff',
+    title,
+    status,
+    subject_type: 'client_project',
+    subject_id: PROJECT_ID,
+    subject_label: 'Synthetic Client AI Ops MVP',
+    current_step: currentStep,
+    error_message: null,
+    started_at: GENERATED_AT,
+    completed_at: status === 'completed' ? GENERATED_AT : null,
+    metadata: { client_project_id: PROJECT_ID, synthetic: true },
+  }
+}


### PR DESCRIPTION
## Summary
- adds a pure synthetic Client AI Ops pilot fixture covering audit signals, verified stack, connector readiness, roadmap projection, and swarm-board projection
- proves discovery → technology decision → provisioning planning → QA handoffs can stay autonomous for read-only work
- adds approval-boundary regressions for credential/provider setup and outbound sends
- extends the admin AI Ops API test to verify connector readiness stays present in the response
- documents the synthetic fixture as the no-side-effect regression path in the Client AI Ops roadmap SOP

## Enhancement Impact Preflight
- Enhancement: Synthetic Client AI Ops pilot fixture for audit-to-roadmap-to-board regression coverage.
- User-facing surface: Client AI Ops roadmap/admin projection and Agent Swarm Board readiness flow.
- Predicted files: lib/client-ai-ops-synthetic-pilot.ts, lib/client-ai-ops-synthetic-pilot.test.ts, app/api/admin/client-projects/[id]/ai-ops/route.test.ts, docs/client-ai-ops-roadmap-sop.md.
- Shared routes/APIs/tables/helpers: read-only use of existing Client AI Ops roadmap helpers, connector readiness catalog, and Agent Swarm Board policy/read model. No database schema or live route behavior changes.
- Active PRs or branches checked: #391 subscription-watch, #387 apify staging rotation evidence, #384 voice-note content swarm; worktrees checked under Portfolio.worktrees.
- Dirty worktree files checked: root Portfolio had only unrelated untracked tmp/ at preflight; current implementation used a fresh sibling worktree.
- Overlap rating: green.
- Coordination decision: proceed independently in codex/client-ai-ops-synthetic-pilot.
- Merge-order note: can merge after normal captain checks; no dependency on open credential/content PRs.

## Validation
- npm ci
- npm run worktree:env -- --source /Users/vambahsillah/Projects/Portfolio
- npm test -- lib/client-ai-ops-synthetic-pilot.test.ts lib/client-ai-ops-roadmap.test.ts lib/client-connector-readiness.test.ts lib/agent-swarm-board.test.ts app/api/admin/client-projects/[id]/ai-ops/route.test.ts components/client-dashboard/AiOpsRoadmapSection.test.tsx
- npm run build:knowledge
- npx tsc --noEmit --pretty false
- git diff --cached --check
- push hook database health check passed

## Integration Notes
- This is test/fixture/docs only plus an API response regression assertion; it does not add a live seed, endpoint, migration, OAuth flow, credential sync, provider write, workflow activation, outbound send, publish, deploy, or client-data mutation.
- The fixture uses synthetic client/audit data only.
- Vercel contexts still need the normal Integration Captain verification before merge: Vercel – portfolio and Vercel – portfolio-staging.