### PR TITLE
feat: surface open brain link audit history

### DIFF
--- a/app/admin/agents/open-brain/page.test.tsx
+++ b/app/admin/agents/open-brain/page.test.tsx
@@ -210,6 +210,22 @@ const openBrainSnapshot = {
         targetNodeId: 'memory-1',
       },
     ],
+    audit: [
+      {
+        linkId: 'link:source-memory',
+        fromId: 'source-1',
+        toId: 'memory-1',
+        relationship: 'governed_by',
+        sourceLabel: 'Morning review source',
+        targetLabel: 'Action-first operating rule',
+        sourceProposalId: 'proposal-1',
+        reviewedBy: 'admin-user',
+        reviewedAt: '2026-05-15T11:30:00.000Z',
+        eventId: 'event:proposal-approved',
+        createdAt: '2026-05-15T11:30:00.000Z',
+        evidence: 'Approval event recorded the relationship link id.',
+      },
+    ],
   },
   modelOps: {
     available: true,
@@ -358,6 +374,8 @@ describe('OpenBrainPage', () => {
     expect(within(map).getByText('Weak links')).toBeInTheDocument()
     expect(within(map).getByText('Orphaned records')).toBeInTheDocument()
     expect(within(map).getByText('Relationship insights')).toBeInTheDocument()
+    expect(within(map).getByText('Persisted link audit')).toBeInTheDocument()
+    expect(within(map).getByText('link:source-memory')).toBeInTheDocument()
     expect(within(map).getByText('Strengthen automation-to-runbook governance')).toBeInTheDocument()
     expect(within(map).getByText('Morning review source')).toBeInTheDocument()
 
@@ -398,6 +416,9 @@ describe('OpenBrainPage', () => {
     fireEvent.click(within(nextActions).getByRole('button', { name: /Review proposals/i }))
 
     expect(await screen.findByText('Link on approval')).toBeInTheDocument()
+    expect(screen.getByText('Persisted relationship audit')).toBeInTheDocument()
+    expect(screen.getByText('Approved links now in Open Brain')).toBeInTheDocument()
+    expect(screen.getAllByText('link:source-memory').length).toBeGreaterThan(0)
     expect(screen.getByText(/Approving this proposal creates a durable link/i)).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Approve' }))

--- a/app/admin/agents/open-brain/page.tsx
+++ b/app/admin/agents/open-brain/page.tsx
@@ -22,6 +22,7 @@ import Breadcrumbs from '@/components/admin/Breadcrumbs'
 import { getCurrentSession } from '@/lib/auth'
 import type {
   OpenBrainPrivacyTier,
+  OpenBrainRelationshipAuditRecord,
   OpenBrainRelationshipInsight,
   OpenBrainRelationshipNodeType,
   OpenBrainSnapshot,
@@ -255,6 +256,7 @@ function OpenBrainContent() {
             {viewMode === 'proposals' ? (
               <ProposalsView
                 proposals={pendingProposals.length ? pendingProposals : snapshot.proposals}
+                relationshipAudit={snapshot.relationshipMap.audit}
                 reviewingProposalId={reviewingProposalId}
                 onReview={reviewProposal}
               />
@@ -746,6 +748,18 @@ function RelationshipMapView({
               <EmptyState message="No relationship issues are visible for the current graph." />
             )}
           </div>
+          <div className="mt-5 border-t border-silicon-slate/60 pt-4">
+            <p className="agent-ops-eyebrow"><ShieldCheck size={14} /> Persisted link audit</p>
+            <div className="mt-3 space-y-3">
+              {map.audit.length > 0 ? map.audit.slice(0, 4).map((record) => (
+                <RelationshipAuditCard key={record.linkId} record={record} compact />
+              )) : (
+                <p className="rounded-lg border border-silicon-slate/60 bg-background/20 p-3 text-xs text-muted-foreground">
+                  No approved relationship links are persisted yet.
+                </p>
+              )}
+            </div>
+          </div>
         </aside>
       </div>
     </section>
@@ -903,26 +917,57 @@ function SourcesView({ snapshot }: { snapshot: OpenBrainSnapshot }) {
 
 function ProposalsView({
   proposals,
+  relationshipAudit,
   reviewingProposalId,
   onReview,
 }: {
   proposals: OpenBrainSnapshot['proposals']
+  relationshipAudit: OpenBrainRelationshipAuditRecord[]
   reviewingProposalId: string | null
   onReview: (id: string, action: 'approve' | 'reject') => void
 }) {
-  if (proposals.length === 0) {
+  if (proposals.length === 0 && relationshipAudit.length === 0) {
     return <EmptyState message="No Open Brain memory proposals are pending or stored locally." />
   }
   return (
-    <section className="grid grid-cols-1 xl:grid-cols-2 gap-4">
-      {proposals.map((proposal) => {
+    <section className="space-y-5">
+      {relationshipAudit.length > 0 ? (
+        <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-5">
+          <div className="mb-3 flex flex-col gap-2 lg:flex-row lg:items-start lg:justify-between">
+            <div>
+              <p className="agent-ops-eyebrow"><ShieldCheck size={14} /> Persisted relationship audit</p>
+              <h2 className="mt-2 text-xl font-semibold">Approved links now in Open Brain</h2>
+            </div>
+            <span className="rounded-full border border-radiant-gold/35 bg-radiant-gold/10 px-2 py-1 text-xs text-radiant-gold">
+              {relationshipAudit.length} durable link(s)
+            </span>
+          </div>
+          <div className="grid gap-3 xl:grid-cols-2">
+            {relationshipAudit.slice(0, 4).map((record) => (
+              <RelationshipAuditCard key={record.linkId} record={record} />
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {proposals.length === 0 ? (
+        <EmptyState message="No Open Brain memory proposals are pending or stored locally." />
+      ) : null}
+
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
+        {proposals.map((proposal) => {
         const relationship = proposal.metadata?.relationship
+        const auditRecord = relationship ? findRelationshipAuditForProposal(relationshipAudit, proposal) : null
         return (
           <article key={proposal.id} className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-5">
             <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
               <h3 className="font-semibold">{proposal.proposedMemory.title}</h3>
               <div className="flex flex-wrap gap-2">
-                {relationship ? (
+                {auditRecord ? (
+                  <span className="rounded-full border border-green-400/35 bg-green-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-green-200">
+                    Durable link recorded
+                  </span>
+                ) : relationship ? (
                   <span className="rounded-full border border-radiant-gold/45 bg-radiant-gold/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-radiant-gold">
                     Link on approval
                   </span>
@@ -938,6 +983,11 @@ function ProposalsView({
                   Approving this proposal creates a durable link: {relationship.sourceLabel} {'->'} {relationship.targetLabel}
                 </p>
                 <p className="mt-1 text-muted-foreground">Relationship: {relationship.relationship}</p>
+                {auditRecord ? (
+                  <p className="mt-1 text-green-200">
+                    Durable link recorded as {auditRecord.linkId} from {auditRecord.eventId || 'local link store'}.
+                  </p>
+                ) : null}
               </div>
             ) : null}
             <div className="grid grid-cols-2 gap-2 text-xs">
@@ -968,9 +1018,60 @@ function ProposalsView({
             ) : null}
           </article>
         )
-      })}
+        })}
+      </div>
     </section>
   )
+}
+
+function RelationshipAuditCard({
+  record,
+  compact = false,
+}: {
+  record: OpenBrainRelationshipAuditRecord
+  compact?: boolean
+}) {
+  return (
+    <article className="rounded-lg border border-green-400/25 bg-green-500/10 p-3 text-xs">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <p className="font-semibold text-green-100">{record.sourceLabel} {'->'} {record.targetLabel}</p>
+        <span className="rounded-full border border-green-400/30 px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] text-green-200">
+          {record.relationship}
+        </span>
+      </div>
+      <p className="mt-2 break-all text-muted-foreground">{record.linkId}</p>
+      {!compact ? (
+        <div className="mt-3 grid gap-2 sm:grid-cols-2">
+          <Detail label="Approved by" value={record.reviewedBy || 'unknown'} />
+          <Detail label="Approved" value={record.reviewedAt ? formatDateTime(record.reviewedAt) : 'unknown'} />
+          <Detail label="Proposal" value={record.sourceProposalId || 'not linked'} />
+          <Detail label="Event" value={record.eventId || 'not linked'} />
+        </div>
+      ) : (
+        <p className="mt-2 text-muted-foreground">
+          {record.reviewedAt ? formatDateTime(record.reviewedAt) : 'Approval time unknown'} · {record.sourceProposalId || 'proposal not linked'}
+        </p>
+      )}
+      <p className="mt-2 text-muted-foreground">{record.evidence}</p>
+    </article>
+  )
+}
+
+function findRelationshipAuditForProposal(
+  relationshipAudit: OpenBrainRelationshipAuditRecord[],
+  proposal: OpenBrainSnapshot['proposals'][number],
+) {
+  const relationship = proposal.metadata?.relationship
+  if (!relationship) return null
+  return relationshipAudit.find((record) =>
+    (proposal.status === 'approved' && record.sourceProposalId === proposal.id) ||
+    (
+      proposal.status === 'approved' &&
+      record.fromId === relationship.fromId &&
+      record.toId === relationship.toId &&
+      record.relationship === relationship.relationship
+    )
+  ) || null
 }
 
 function WikiView({ pages }: { pages: OpenBrainSnapshot['wikiPages'] }) {

--- a/lib/open-brain.test.ts
+++ b/lib/open-brain.test.ts
@@ -216,6 +216,19 @@ describe('Open Brain projection', () => {
         }),
       }),
     ]))
+    expect(snapshot.relationshipMap.audit).toEqual([
+      expect.objectContaining({
+        linkId: expect.stringMatching(/^link:/),
+        fromId: 'automation:portfolio-operations-manager',
+        toId: 'runbook:docs/memory-context-organization-workflow.md',
+        relationship: 'governed_by',
+        sourceLabel: 'Portfolio Operations Manager',
+        targetLabel: 'Memory context organization workflow',
+        sourceProposalId: proposal.id,
+        reviewedBy: 'admin',
+        eventId: expect.stringMatching(/^event:/),
+      }),
+    ])
   })
 
   it('does not create a durable link when a relationship proposal is rejected', async () => {
@@ -507,6 +520,14 @@ describe('Open Brain projection', () => {
       'review',
       'missing_governance',
     ]))
+    expect(relationshipMap.audit).toEqual([
+      expect.objectContaining({
+        linkId: 'link:automation-runbook',
+        sourceLabel: 'Portfolio automation',
+        targetLabel: 'Memory organization runbook',
+        evidence: 'Persisted local Open Brain link record.',
+      }),
+    ])
   })
 
   it('sanitizes secret-like content', () => {

--- a/lib/open-brain.ts
+++ b/lib/open-brain.ts
@@ -195,6 +195,21 @@ export interface OpenBrainRelationshipInsight {
   targetNodeId: string | null
 }
 
+export interface OpenBrainRelationshipAuditRecord {
+  linkId: string
+  fromId: string
+  toId: string
+  relationship: string
+  sourceLabel: string
+  targetLabel: string
+  sourceProposalId: string | null
+  reviewedBy: string | null
+  reviewedAt: string | null
+  eventId: string | null
+  createdAt: string
+  evidence: string
+}
+
 export interface OpenBrainRelationshipMap {
   overview: {
     relationships: number
@@ -207,6 +222,7 @@ export interface OpenBrainRelationshipMap {
   nodes: OpenBrainRelationshipNode[]
   edges: OpenBrainRelationshipEdge[]
   insights: OpenBrainRelationshipInsight[]
+  audit: OpenBrainRelationshipAuditRecord[]
 }
 
 export interface OpenBrainSnapshot {
@@ -874,6 +890,7 @@ export function buildOpenBrainRelationshipMap({
     memories,
     proposals,
   })
+  const audit = buildRelationshipAudit({ links, proposals, events, nodes })
 
   return {
     overview: {
@@ -887,7 +904,100 @@ export function buildOpenBrainRelationshipMap({
     nodes,
     edges,
     insights,
+    audit,
   }
+}
+
+function buildRelationshipAudit({
+  links,
+  proposals,
+  events,
+  nodes,
+}: {
+  links: OpenBrainLinkRecord[]
+  proposals: OpenBrainProposalRecord[]
+  events: OpenBrainEventRecord[]
+  nodes: OpenBrainRelationshipNode[]
+}): OpenBrainRelationshipAuditRecord[] {
+  const nodeLabels = new Map(nodes.map((node) => [node.id, node.label]))
+  const approvalEvents = events.filter((event) => event.kind === 'proposal_approved')
+
+  return links
+    .map((link): OpenBrainRelationshipAuditRecord => {
+      const approvalEvent = approvalEvents.find((event) => eventApprovesLink(event, link))
+      const sourceProposalId = stringFromMetadata(approvalEvent?.metadata?.proposalId)
+      const proposal = sourceProposalId
+        ? proposals.find((candidate) => candidate.id === sourceProposalId)
+        : proposals.find((candidate) => proposalMatchesLink(candidate, link))
+      const relationship = proposal?.metadata?.relationship
+
+      return {
+        linkId: link.id,
+        fromId: link.fromId,
+        toId: link.toId,
+        relationship: link.relationship,
+        sourceLabel: relationship?.sourceLabel || nodeLabels.get(link.fromId) || link.fromId,
+        targetLabel: relationship?.targetLabel || nodeLabels.get(link.toId) || link.toId,
+        sourceProposalId: proposal?.id || sourceProposalId || null,
+        reviewedBy: proposal?.reviewedBy || stringFromMetadata(approvalEvent?.metadata?.reviewedBy),
+        reviewedAt: proposal?.reviewedAt || approvalEvent?.createdAt || null,
+        eventId: approvalEvent?.id || null,
+        createdAt: link.createdAt,
+        evidence: approvalEvent
+          ? 'Approval event recorded the relationship link id.'
+          : proposal
+            ? 'Approved relationship proposal matches this persisted link.'
+            : 'Persisted local Open Brain link record.',
+      }
+    })
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+}
+
+function eventApprovesLink(event: OpenBrainEventRecord, link: OpenBrainLinkRecord) {
+  const metadata = event.metadata || {}
+  if (stringFromMetadata(metadata.relationshipLinkId) === link.id) return true
+  const relationship = relationshipMetadataFromUnknown(metadata.relationship)
+  return Boolean(
+    relationship &&
+    relationship.fromId === link.fromId &&
+    relationship.toId === link.toId &&
+    relationship.relationship === link.relationship,
+  )
+}
+
+function proposalMatchesLink(proposal: OpenBrainProposalRecord, link: OpenBrainLinkRecord) {
+  const relationship = proposal.metadata?.relationship
+  return Boolean(
+    proposal.status === 'approved' &&
+    relationship &&
+    relationship.fromId === link.fromId &&
+    relationship.toId === link.toId &&
+    relationship.relationship === link.relationship,
+  )
+}
+
+function relationshipMetadataFromUnknown(value: unknown): OpenBrainRelationshipProposalMetadata | null {
+  if (!value || typeof value !== 'object') return null
+  const candidate = value as Record<string, unknown>
+  const insightKind = stringFromMetadata(candidate.insightKind)
+  if (!['strengthen', 'review', 'missing_governance', 'merge_duplicate'].includes(insightKind || '')) return null
+  const fromId = stringFromMetadata(candidate.fromId)
+  const toId = stringFromMetadata(candidate.toId)
+  const relationship = stringFromMetadata(candidate.relationship)
+  if (!fromId || !toId || !relationship) return null
+  return {
+    fromId,
+    toId,
+    relationship,
+    insightId: stringFromMetadata(candidate.insightId) || 'relationship-map-insight',
+    insightKind: insightKind as OpenBrainRelationshipInsightKind,
+    sourceLabel: stringFromMetadata(candidate.sourceLabel) || fromId,
+    targetLabel: stringFromMetadata(candidate.targetLabel) || toId,
+  }
+}
+
+function stringFromMetadata(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value : null
 }
 
 export function fingerprintOpenBrainRecord(parts: unknown[]) {


### PR DESCRIPTION
## Summary

- Adds read-only relationship link audit records to the Open Brain relationship map projection.
- Surfaces persisted link audit history in the Map insight panel and the Proposals view.
- Marks approved relationship proposals with durable-link provenance when a persisted Open Brain link can be traced back to approval metadata.

## Enhancement Impact Preflight

- Enhancement: Surface persisted relationship-link audit history directly in the Open Brain Map and Proposals views.
- User-facing surface: `/admin/agents/open-brain` Map and Proposals tabs.
- Predicted files: `lib/open-brain.ts`, `lib/open-brain.test.ts`, `app/admin/agents/open-brain/page.tsx`, `app/admin/agents/open-brain/page.test.tsx`.
- Shared routes/APIs/tables/helpers: Open Brain snapshot model and relationship map projection only; no database tables or mutating API routes added.
- Active PRs or branches checked: #391 `codex/subscription-watch-next`, #387 `codex/apify-staging-rotation-evidence`, #384 `codex/voice-note-content-swarm`.
- Dirty worktree files checked: root `main` had only untracked `tmp/`; new worktree started clean.
- Overlap rating: green.
- Coordination decision: Proceed independently; active PRs do not touch Open Brain map files.
- Merge-order note: Can merge after the current Open Brain base on `origin/main`; no dependency on subscription, Apify, or voice-note lanes.

## Validation

- `npm test -- --run lib/open-brain.test.ts app/admin/agents/open-brain/page.test.tsx app/api/admin/agents/open-brain/route.test.ts app/api/admin/agents/open-brain/proposals/route.test.ts 'app/api/admin/agents/open-brain/proposals/[id]/approve/route.test.ts'`
- `npm run lint`
- `npm run build`
- `git diff --check`
- Browser smoke: opened `http://localhost:3017/admin/agents/open-brain` in the Codex in-app browser; route reached the admin auth screen with no console errors. Authenticated Map-tab inspection was blocked by missing admin session in that browser context.
- Pre-push database health hook passed.

## Integration Notes

- V1 remains read-only/proposal-gated in the dashboard. This PR does not add new mutating controls.
- No migrations, env changes, or non-git operational state writes.
- Build emitted existing local env warnings about `MOCK_N8N=false` and `N8N_DISABLE_OUTBOUND=false`; no outbound workflow smoke was run.
- Vercel contexts not checked by this non-captain lane: `Vercel – portfolio`, `Vercel – portfolio-staging`.
