### PR TITLE
Add reply-intent source sync diagnostics

### DIFF
--- a/app/admin/model-ops/reply-intent-review/page.test.tsx
+++ b/app/admin/model-ops/reply-intent-review/page.test.tsx
@@ -77,6 +77,16 @@ const queueResponse = {
     remaining_to_actionable_gate: 200,
     invalid_lines: 0,
   },
+  source_diagnostics: {
+    source_table: 'outreach_queue',
+    source_limit: 750,
+    candidate_replies: 1,
+    ledger_rows: 0,
+    virtual_pending: 1,
+    reviewed_real: 0,
+    review_storage_available: true,
+    sync_command: 'npm run model-ops:reply-intent:sync',
+  },
 }
 
 describe('ReplyIntentReviewPage', () => {
@@ -116,9 +126,11 @@ describe('ReplyIntentReviewPage', () => {
     expect(screen.getAllByText('Can we schedule a quick call next week?').length).toBeGreaterThan(0)
     expect(screen.getAllByText('0/200').length).toBeGreaterThan(0)
     expect(screen.getByText('Evidence Gate')).toBeInTheDocument()
+    expect(screen.getByText('Source Coverage')).toBeInTheDocument()
     expect(screen.getByText('Export stale')).toBeInTheDocument()
     expect(screen.getByText('Ledger gap')).toBeInTheDocument()
     expect(screen.getByText('npm run model-ops:reply-intent:export')).toBeInTheDocument()
+    expect(screen.getByText('npm run model-ops:reply-intent:sync')).toBeInTheDocument()
 
     await waitFor(() => expect(screen.getByRole('button', { name: 'Yes' })).not.toBeDisabled())
     fireEvent.click(screen.getByRole('button', { name: 'Yes' }))

--- a/app/admin/model-ops/reply-intent-review/page.tsx
+++ b/app/admin/model-ops/reply-intent-review/page.tsx
@@ -81,6 +81,16 @@ type QueueResponse = {
     remaining_to_actionable_gate: number
     invalid_lines: number
   }
+  source_diagnostics: {
+    source_table: 'outreach_queue'
+    source_limit: number
+    candidate_replies: number
+    ledger_rows: number
+    virtual_pending: number
+    reviewed_real: number
+    review_storage_available: boolean
+    sync_command: string
+  }
   reason?: string
 }
 
@@ -148,6 +158,7 @@ function ReplyIntentReviewContent() {
   const [items, setItems] = useState<QueueItem[]>([])
   const [summary, setSummary] = useState<QueueResponse['summary'] | null>(null)
   const [evidence, setEvidence] = useState<QueueResponse['evidence'] | null>(null)
+  const [sourceDiagnostics, setSourceDiagnostics] = useState<QueueResponse['source_diagnostics'] | null>(null)
   const [pagination, setPagination] = useState<QueueResponse['pagination'] | null>(null)
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [status, setStatus] = useState<ReviewStatus | 'all'>('pending')
@@ -195,6 +206,7 @@ function ReplyIntentReviewContent() {
       setItems(queue.items)
       setSummary(queue.summary)
       setEvidence(queue.evidence)
+      setSourceDiagnostics(queue.source_diagnostics)
       setPagination(queue.pagination)
       setSchemaReady(Boolean(queue.schema?.reviews_table_available ?? true))
       setSelectedId((current) => (queue.items.some((item) => item.source_id === current) ? current : queue.items[0]?.source_id ?? null))
@@ -612,6 +624,33 @@ function ReplyIntentReviewContent() {
                 <SkipForward size={16} />
                 Skip
               </button>
+            </div>
+
+            <div className="grid gap-2 rounded-lg border border-radiant-gold/10 bg-silicon-slate/15 p-3 text-sm">
+              <div className="flex items-center justify-between gap-3">
+                <span className="font-semibold text-foreground">Source Coverage</span>
+                <span className="rounded-full border border-radiant-gold/20 bg-radiant-gold/10 px-2 py-0.5 text-[11px] text-radiant-gold">
+                  {sourceDiagnostics?.source_table ?? 'outreach_queue'}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Candidate replies</span>
+                <span className="font-mono">{sourceDiagnostics?.candidate_replies ?? summary?.total_real_replies ?? 0}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Ledger rows</span>
+                <span className="font-mono">{sourceDiagnostics?.ledger_rows ?? 0}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Virtual pending</span>
+                <span className="font-mono text-radiant-gold">{sourceDiagnostics?.virtual_pending ?? 0}</span>
+              </div>
+              <div className="grid gap-1 border-t border-radiant-gold/10 pt-2">
+                <span className="text-muted-foreground">Seed missing ledger rows</span>
+                <code className="overflow-hidden text-ellipsis rounded border border-radiant-gold/10 bg-background/40 px-2 py-1 text-xs text-foreground/85">
+                  {sourceDiagnostics?.sync_command ?? 'npm run model-ops:reply-intent:sync'}
+                </code>
+              </div>
             </div>
 
             <div className="grid gap-2 rounded-lg border border-radiant-gold/10 bg-silicon-slate/15 p-3 text-sm">

--- a/app/api/admin/model-ops/reply-intent-reviews/bulk/route.ts
+++ b/app/api/admin/model-ops/reply-intent-reviews/bulk/route.ts
@@ -3,6 +3,7 @@ import { verifyAdmin, isAuthError } from '@/lib/auth-server'
 import { supabaseAdmin } from '@/lib/supabase'
 import {
   buildReviewUpsertPayload,
+  hasReviewableReplyContent,
   suggestReplyIntentLabels,
   type OutreachReplySourceRow,
   type ReplyIntentReviewRow,
@@ -62,9 +63,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Failed to fetch outreach replies' }, { status: 500 })
     }
 
-    const rows = ((sourceRows || []) as OutreachReplySourceRow[]).filter(
-      (row) => String(row.reply_content || '').trim().length >= 8
-    )
+    const rows = ((sourceRows || []) as OutreachReplySourceRow[]).filter((row) => hasReviewableReplyContent(row))
 
     if (rows.length === 0) {
       return NextResponse.json({ error: 'No matching outreach replies found' }, { status: 404 })

--- a/app/api/admin/model-ops/reply-intent-reviews/route.test.ts
+++ b/app/api/admin/model-ops/reply-intent-reviews/route.test.ts
@@ -115,6 +115,13 @@ describe('reply-intent review API', () => {
       status: 'missing',
       remaining_to_actionable_gate: 200,
     })
+    expect(body.source_diagnostics).toMatchObject({
+      source_table: 'outreach_queue',
+      candidate_replies: 1,
+      ledger_rows: 0,
+      virtual_pending: 1,
+      sync_command: 'npm run model-ops:reply-intent:sync',
+    })
     expect(body.items[0].redacted_reply).toContain('[email:')
     expect(body.items[0].redacted_reply).not.toContain('jane@example.com')
   })
@@ -148,6 +155,12 @@ describe('reply-intent review API', () => {
 
     expect(response.status).toBe(200)
     expect(body.summary.reviewed_real).toBe(1)
+    expect(body.source_diagnostics).toMatchObject({
+      candidate_replies: 1,
+      ledger_rows: 1,
+      virtual_pending: 0,
+      reviewed_real: 1,
+    })
     expect(body.evidence).toMatchObject({
       exported_real: 0,
       status: 'stale',

--- a/app/api/admin/model-ops/reply-intent-reviews/route.ts
+++ b/app/api/admin/model-ops/reply-intent-reviews/route.ts
@@ -5,10 +5,14 @@ import { supabaseAdmin } from '@/lib/supabase'
 import {
   MODEL_OPS_REPLY_INTENT_DEFAULT_EXPORT,
   MODEL_OPS_REPLY_INTENT_EXPORT_COMMAND,
+  MODEL_OPS_REPLY_INTENT_MAX_SOURCE_ROWS,
   MODEL_OPS_REPLY_INTENT_TARGET,
+  buildReplyIntentSourceDiagnostics,
   buildReviewUpsertPayload,
+  hasReviewableReplyContent,
   normalizeReviewStatus,
   type ReplyIntentEvidenceSummary,
+  type ReplyIntentSourceDiagnostics,
   type OutreachReplySourceRow,
   type ReplyIntentQueueItem,
   type ReplyIntentReviewRow,
@@ -16,8 +20,6 @@ import {
 } from '@/lib/model-ops-reply-intent'
 
 export const dynamic = 'force-dynamic'
-
-const MAX_SOURCE_ROWS = 750
 
 type QueueResponse = {
   available: boolean
@@ -41,6 +43,7 @@ type QueueResponse = {
     reviews_table_available: boolean
   }
   evidence: ReplyIntentEvidenceSummary
+  source_diagnostics: ReplyIntentSourceDiagnostics
 }
 
 function intParam(value: string | null, fallback: number, min: number, max: number) {
@@ -192,13 +195,13 @@ export async function GET(request: NextRequest) {
         .select('id,channel,sequence_step,status,replied_at,created_at,reply_content')
         .not('reply_content', 'is', null)
         .order('replied_at', { ascending: false, nullsFirst: false })
-        .limit(MAX_SOURCE_ROWS),
+        .limit(MODEL_OPS_REPLY_INTENT_MAX_SOURCE_ROWS),
       supabaseAdmin
         .from('model_ops_reply_intent_reviews')
         .select('*')
         .eq('source_table', 'outreach_queue')
         .order('reviewed_at', { ascending: false, nullsFirst: false })
-        .limit(MAX_SOURCE_ROWS),
+        .limit(MODEL_OPS_REPLY_INTENT_MAX_SOURCE_ROWS),
     ])
 
     if (sourceError) {
@@ -211,6 +214,12 @@ export async function GET(request: NextRequest) {
           summary: emptySummary,
           pagination: { page, limit, total: 0, totalPages: 0 },
           evidence: await getEvidenceSummary(emptySummary.reviewed_real),
+          source_diagnostics: buildReplyIntentSourceDiagnostics({
+            sourceRows: [],
+            reviewRows: [],
+            reviewStorageAvailable: false,
+            sourceLimit: MODEL_OPS_REPLY_INTENT_MAX_SOURCE_ROWS,
+          }),
         })
       }
       console.error('Error fetching reply-intent source rows:', sourceError)
@@ -223,12 +232,19 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Failed to fetch reply-intent reviews' }, { status: 500 })
     }
 
-    const allItems = mapQueueItems(
-      (sourceRows || []).filter((row: OutreachReplySourceRow) => String(row.reply_content || '').trim().length >= 8),
-      reviewsTableAvailable ? ((reviewResult.data || []) as ReplyIntentReviewRow[]) : []
+    const candidateSourceRows = ((sourceRows || []) as OutreachReplySourceRow[]).filter((row) =>
+      hasReviewableReplyContent(row)
     )
+    const reviewRows = reviewsTableAvailable ? ((reviewResult.data || []) as ReplyIntentReviewRow[]) : []
+    const allItems = mapQueueItems(candidateSourceRows, reviewRows)
     const queueSummary = summarize(allItems)
     const evidence = await getEvidenceSummary(queueSummary.reviewed_real)
+    const sourceDiagnostics = buildReplyIntentSourceDiagnostics({
+      sourceRows: candidateSourceRows,
+      reviewRows,
+      reviewStorageAvailable: reviewsTableAvailable,
+      sourceLimit: MODEL_OPS_REPLY_INTENT_MAX_SOURCE_ROWS,
+    })
     const filtered = filterItems(allItems, normalizedStatus, search)
     const offset = (page - 1) * limit
     const items = filtered.slice(offset, offset + limit)
@@ -247,6 +263,7 @@ export async function GET(request: NextRequest) {
         reviews_table_available: reviewsTableAvailable,
       },
       evidence,
+      source_diagnostics: sourceDiagnostics,
     }
 
     return NextResponse.json(response)
@@ -300,7 +317,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Failed to fetch outreach reply' }, { status: 500 })
     }
 
-    if (!source || String((source as OutreachReplySourceRow).reply_content || '').trim().length < 8) {
+    if (!source || !hasReviewableReplyContent(source as OutreachReplySourceRow)) {
       return NextResponse.json({ error: 'Outreach reply not found' }, { status: 404 })
     }
 

--- a/lib/model-ops-reply-intent.test.ts
+++ b/lib/model-ops-reply-intent.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import {
+  MODEL_OPS_REPLY_INTENT_SYNC_COMMAND,
+  buildPendingReviewSeedPayload,
+  buildReplyIntentSourceDiagnostics,
   buildReviewUpsertPayload,
+  hasReviewableReplyContent,
   redactReplyText,
   stableHash,
   suggestReplyIntentLabels,
@@ -82,5 +86,71 @@ describe('model ops reply-intent helpers', () => {
     expect(payload.human_scheduling_intent).toBeNull()
     expect(payload.reviewed_by).toBe('admin-user')
     expect(payload.source_hash).toBe(stableHash('11111111-1111-4111-8111-111111111111'))
+  })
+
+  it('builds pending seed payloads without claiming human review', () => {
+    const payload = buildPendingReviewSeedPayload({
+      id: '11111111-1111-4111-8111-111111111111',
+      channel: 'email',
+      status: 'replied',
+      sequence_step: 3,
+      replied_at: '2026-05-24T10:00:00.000Z',
+      reply_content: 'Jane Carter can meet Friday at jane@example.com.',
+    })
+
+    expect(payload).toMatchObject({
+      source_table: 'outreach_queue',
+      source_id: '11111111-1111-4111-8111-111111111111',
+      review_status: 'pending',
+      human_scheduling_intent: null,
+      reviewed_by: null,
+      reviewed_at: null,
+    })
+    expect(payload.redacted_reply).toContain('[email:')
+    expect(payload.redacted_reply).not.toContain('jane@example.com')
+  })
+
+  it('summarizes source diagnostics and virtual pending rows', () => {
+    const sourceRows = [
+      { id: 'a', reply_content: 'Can we meet?' },
+      { id: 'b', reply_content: 'No thanks.' },
+    ]
+    const diagnostics = buildReplyIntentSourceDiagnostics({
+      sourceRows,
+      reviewRows: [
+        {
+          source_table: 'outreach_queue',
+          source_id: 'a',
+          source_hash: 'source-hash',
+          reply_hash: 'reply-hash',
+          redacted_reply: 'Can we meet?',
+          suggested_labels: {
+            scheduling_intent: true,
+            interested: true,
+            not_interested: false,
+            ooo: false,
+            needs_followup: false,
+          },
+          review_status: 'reviewed',
+          human_scheduling_intent: true,
+        },
+      ],
+      reviewStorageAvailable: true,
+      sourceLimit: 25,
+    })
+
+    expect(diagnostics).toMatchObject({
+      candidate_replies: 2,
+      ledger_rows: 1,
+      virtual_pending: 1,
+      reviewed_real: 1,
+      source_limit: 25,
+      sync_command: MODEL_OPS_REPLY_INTENT_SYNC_COMMAND,
+    })
+  })
+
+  it('detects reviewable reply text by minimum length', () => {
+    expect(hasReviewableReplyContent({ reply_content: 'short' })).toBe(false)
+    expect(hasReviewableReplyContent({ reply_content: 'Can we meet next week?' })).toBe(true)
   })
 })

--- a/lib/model-ops-reply-intent.ts
+++ b/lib/model-ops-reply-intent.ts
@@ -1,9 +1,11 @@
 import crypto from 'node:crypto'
 
 export const MODEL_OPS_REPLY_INTENT_TARGET = 200
+export const MODEL_OPS_REPLY_INTENT_MAX_SOURCE_ROWS = 750
 export const MODEL_OPS_REPLY_INTENT_DEFAULT_EXPORT =
   '/Users/vambahsillah/Documents/Codex/2026-04-29/hey-can-you-confirm-that-i/eval-data/reply-intent-review/sources/portfolio-model-ops-reviewed-replies.jsonl'
 export const MODEL_OPS_REPLY_INTENT_EXPORT_COMMAND = 'npm run model-ops:reply-intent:export'
+export const MODEL_OPS_REPLY_INTENT_SYNC_COMMAND = 'npm run model-ops:reply-intent:sync'
 
 export type ReplyIntentReviewStatus = 'pending' | 'reviewed' | 'unsure' | 'skipped'
 export type ReplyIntentEvidenceStatus = 'missing' | 'stale' | 'current' | 'gate_met' | 'invalid'
@@ -74,6 +76,17 @@ export type ReplyIntentEvidenceSummary = {
   benchmark_actionable_real: number
   remaining_to_actionable_gate: number
   invalid_lines: number
+}
+
+export type ReplyIntentSourceDiagnostics = {
+  source_table: 'outreach_queue'
+  source_limit: number
+  candidate_replies: number
+  ledger_rows: number
+  virtual_pending: number
+  reviewed_real: number
+  review_storage_available: boolean
+  sync_command: string
 }
 
 const NAME_PATTERN = /\b[A-Z][a-z]+ [A-Z][a-z]+\b/g
@@ -237,6 +250,57 @@ export function buildReviewUpsertPayload(args: {
     notes: typeof args.notes === 'string' ? args.notes.slice(0, 2000) : '',
     reviewed_by: args.reviewedBy,
     reviewed_at: reviewedAt,
+  }
+}
+
+export function buildPendingReviewSeedPayload(source: OutreachReplySourceRow) {
+  const redactedReply = redactReplyText(source.reply_content)
+
+  return {
+    source_table: 'outreach_queue' as const,
+    source_id: source.id,
+    source_hash: stableHash(source.id),
+    reply_hash: stableHash(source.reply_content || redactedReply),
+    channel: source.channel ?? null,
+    replied_at: source.replied_at ?? source.created_at ?? null,
+    outreach_status: source.status ?? null,
+    sequence_step: source.sequence_step ?? null,
+    redacted_reply: redactedReply,
+    suggested_labels: suggestReplyIntentLabels(redactedReply),
+    review_status: 'pending' as const,
+    human_scheduling_intent: null,
+    notes: '',
+    reviewed_by: null,
+    reviewed_at: null,
+  }
+}
+
+export function hasReviewableReplyContent(source: Pick<OutreachReplySourceRow, 'reply_content'>, minLength = 8) {
+  return String(source.reply_content || '').trim().length >= minLength
+}
+
+export function buildReplyIntentSourceDiagnostics(args: {
+  sourceRows: OutreachReplySourceRow[]
+  reviewRows: ReplyIntentReviewRow[]
+  reviewStorageAvailable: boolean
+  sourceLimit?: number
+}): ReplyIntentSourceDiagnostics {
+  const sourceIds = new Set(args.sourceRows.map((row) => row.id))
+  const ledgerRows = args.reviewRows.filter((row) => sourceIds.has(row.source_id))
+  const ledgerSourceIds = new Set(ledgerRows.map((row) => row.source_id))
+  const reviewedReal = ledgerRows.filter(
+    (row) => row.review_status === 'reviewed' && typeof row.human_scheduling_intent === 'boolean'
+  ).length
+
+  return {
+    source_table: 'outreach_queue',
+    source_limit: args.sourceLimit ?? MODEL_OPS_REPLY_INTENT_MAX_SOURCE_ROWS,
+    candidate_replies: args.sourceRows.length,
+    ledger_rows: ledgerRows.length,
+    virtual_pending: args.sourceRows.filter((row) => !ledgerSourceIds.has(row.id)).length,
+    reviewed_real: reviewedReal,
+    review_storage_available: args.reviewStorageAvailable,
+    sync_command: MODEL_OPS_REPLY_INTENT_SYNC_COMMAND,
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "model-ops:snapshot": "tsx scripts/sync-model-ops-snapshot.ts",
     "model-ops:snapshot:check": "tsx scripts/sync-model-ops-snapshot.ts --check",
     "model-ops:reply-intent:export": "tsx scripts/export-reply-intent-reviews.ts",
+    "model-ops:reply-intent:sync": "tsx scripts/sync-reply-intent-review-candidates.ts",
     "model-ops:research:plan": "tsx scripts/model-ops-research-plan.ts",
     "open-brain:mcp": "tsx scripts/open-brain-mcp-server.ts",
     "wrm:smoke-gate": "tsx scripts/wrm-production-smoke-gate.ts",

--- a/scripts/sync-reply-intent-review-candidates.test.ts
+++ b/scripts/sync-reply-intent-review-candidates.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { parseArgs, planReplyIntentReviewSync } from './sync-reply-intent-review-candidates'
+
+describe('sync reply-intent review candidates script', () => {
+  it('parses dry-run and apply options', () => {
+    expect(parseArgs(['--apply', '--limit', '25', '--min-length', '12', '--env-file', '.env.test'])).toMatchObject({
+      apply: true,
+      limit: 25,
+      minLength: 12,
+      envFile: '.env.test',
+    })
+
+    expect(parseArgs([]).apply).toBe(false)
+  })
+
+  it('plans only missing reviewable outreach replies for seeding', () => {
+    const sourceRows = [
+      { id: '11111111-1111-4111-8111-111111111111', reply_content: 'Can we schedule a call?' },
+      { id: '22222222-2222-4222-8222-222222222222', reply_content: 'No' },
+      { id: '33333333-3333-4333-8333-333333333333', reply_content: 'Tell me more about this.' },
+    ]
+    const reviewRows = [
+      {
+        source_table: 'outreach_queue' as const,
+        source_id: '11111111-1111-4111-8111-111111111111',
+        source_hash: 'source-hash',
+        reply_hash: 'reply-hash',
+        redacted_reply: 'Can we schedule a call?',
+        suggested_labels: {
+          scheduling_intent: true,
+          interested: true,
+          not_interested: false,
+          ooo: false,
+          needs_followup: false,
+        },
+        review_status: 'pending' as const,
+      },
+    ]
+
+    const plan = planReplyIntentReviewSync(sourceRows, reviewRows)
+
+    expect(plan).toMatchObject({
+      candidateReplies: 2,
+      existingLedgerRows: 1,
+      skippedShortReplies: 1,
+    })
+    expect(plan.pendingToSeed).toEqual([
+      expect.objectContaining({ id: '33333333-3333-4333-8333-333333333333' }),
+    ])
+  })
+})

--- a/scripts/sync-reply-intent-review-candidates.test.ts
+++ b/scripts/sync-reply-intent-review-candidates.test.ts
@@ -48,4 +48,52 @@ describe('sync reply-intent review candidates script', () => {
       expect.objectContaining({ id: '33333333-3333-4333-8333-333333333333' }),
     ])
   })
+
+  it('does not count unrelated ledger rows as existing candidate reviews', () => {
+    const sourceRows = [
+      { id: '11111111-1111-4111-8111-111111111111', reply_content: 'Can we schedule a call?' },
+      { id: '22222222-2222-4222-8222-222222222222', reply_content: 'Tell me more about this.' },
+    ]
+    const reviewRows = [
+      {
+        source_table: 'outreach_queue' as const,
+        source_id: '99999999-9999-4999-8999-999999999999',
+        source_hash: 'unrelated-source-hash',
+        reply_hash: 'unrelated-reply-hash',
+        redacted_reply: 'Unrelated reply',
+        suggested_labels: {
+          scheduling_intent: false,
+          interested: false,
+          not_interested: false,
+          ooo: false,
+          needs_followup: false,
+        },
+        review_status: 'reviewed' as const,
+        human_scheduling_intent: false,
+      },
+      {
+        source_table: 'outreach_queue' as const,
+        source_id: '11111111-1111-4111-8111-111111111111',
+        source_hash: 'source-hash',
+        reply_hash: 'reply-hash',
+        redacted_reply: 'Can we schedule a call?',
+        suggested_labels: {
+          scheduling_intent: true,
+          interested: true,
+          not_interested: false,
+          ooo: false,
+          needs_followup: false,
+        },
+        review_status: 'reviewed' as const,
+        human_scheduling_intent: true,
+      },
+    ]
+
+    const plan = planReplyIntentReviewSync(sourceRows, reviewRows)
+
+    expect(plan.existingLedgerRows).toBe(1)
+    expect(plan.pendingToSeed).toEqual([
+      expect.objectContaining({ id: '22222222-2222-4222-8222-222222222222' }),
+    ])
+  })
 })

--- a/scripts/sync-reply-intent-review-candidates.ts
+++ b/scripts/sync-reply-intent-review-candidates.ts
@@ -115,25 +115,35 @@ export async function syncReplyIntentReviewCandidates(options: SyncOptions) {
     },
   })
 
-  const [{ data: sourceRows, error: sourceError }, { data: reviewRows, error: reviewError }] = await Promise.all([
-    supabase
-      .from('outreach_queue')
-      .select('id,channel,sequence_step,status,replied_at,created_at,reply_content')
-      .not('reply_content', 'is', null)
-      .order('replied_at', { ascending: false, nullsFirst: false })
-      .limit(options.limit),
-    supabase
-      .from('model_ops_reply_intent_reviews')
-      .select('source_id,source_table,source_hash,reply_hash,redacted_reply,suggested_labels,review_status,human_scheduling_intent')
-      .eq('source_table', 'outreach_queue')
-      .limit(options.limit),
-  ])
+  const { data: sourceRows, error: sourceError } = await supabase
+    .from('outreach_queue')
+    .select('id,channel,sequence_step,status,replied_at,created_at,reply_content')
+    .not('reply_content', 'is', null)
+    .order('replied_at', { ascending: false, nullsFirst: false })
+    .limit(options.limit)
 
   if (sourceError) throw new Error(`Failed to fetch outreach replies: ${sourceError.message}`)
+
+  const sourceList = (sourceRows || []) as OutreachReplySourceRow[]
+  const candidateSourceIds = sourceList
+    .filter((row) => hasReviewableReplyContent(row, options.minLength))
+    .map((row) => row.id)
+
+  const { data: reviewRows, error: reviewError } =
+    candidateSourceIds.length > 0
+      ? await supabase
+          .from('model_ops_reply_intent_reviews')
+          .select(
+            'source_id,source_table,source_hash,reply_hash,redacted_reply,suggested_labels,review_status,human_scheduling_intent'
+          )
+          .eq('source_table', 'outreach_queue')
+          .in('source_id', candidateSourceIds)
+      : { data: [], error: null }
+
   if (reviewError) throw new Error(`Failed to fetch existing reply-intent reviews: ${reviewError.message}`)
 
   const plan = planReplyIntentReviewSync(
-    (sourceRows || []) as OutreachReplySourceRow[],
+    sourceList,
     (reviewRows || []) as ReplyIntentReviewRow[],
     options.minLength
   )
@@ -157,7 +167,7 @@ export async function syncReplyIntentReviewCandidates(options: SyncOptions) {
   const payloads = plan.pendingToSeed.map(buildPendingReviewSeedPayload)
   const { error: upsertError } = await supabase
     .from('model_ops_reply_intent_reviews')
-    .upsert(payloads, { onConflict: 'source_table,source_id' })
+    .upsert(payloads, { onConflict: 'source_table,source_id', ignoreDuplicates: true })
 
   if (upsertError) throw new Error(`Failed to seed reply-intent review candidates: ${upsertError.message}`)
 

--- a/scripts/sync-reply-intent-review-candidates.ts
+++ b/scripts/sync-reply-intent-review-candidates.ts
@@ -1,0 +1,196 @@
+#!/usr/bin/env tsx
+import path from 'node:path'
+import { createClient } from '@supabase/supabase-js'
+import { config as loadDotenv } from 'dotenv'
+import {
+  MODEL_OPS_REPLY_INTENT_MAX_SOURCE_ROWS,
+  buildPendingReviewSeedPayload,
+  hasReviewableReplyContent,
+  type OutreachReplySourceRow,
+  type ReplyIntentReviewRow,
+} from '../lib/model-ops-reply-intent'
+
+type SyncOptions = {
+  apply: boolean
+  envFile: string
+  limit: number
+  minLength: number
+}
+
+type SyncPlan = {
+  candidateReplies: number
+  existingLedgerRows: number
+  pendingToSeed: OutreachReplySourceRow[]
+  skippedShortReplies: number
+}
+
+export function parseArgs(argv: string[]): SyncOptions {
+  const options: SyncOptions = {
+    apply: false,
+    envFile: '.env.local',
+    limit: Number.parseInt(process.env.MODEL_OPS_REPLY_INTENT_SYNC_LIMIT || String(MODEL_OPS_REPLY_INTENT_MAX_SOURCE_ROWS), 10),
+    minLength: Number.parseInt(process.env.MODEL_OPS_REPLY_INTENT_MIN_LENGTH || '8', 10),
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    const next = argv[index + 1]
+
+    if (arg === '--apply') {
+      options.apply = true
+    } else if (arg === '--env-file' && next) {
+      options.envFile = next
+      index += 1
+    } else if (arg === '--limit' && next) {
+      options.limit = Math.max(1, Number.parseInt(next, 10))
+      index += 1
+    } else if (arg === '--min-length' && next) {
+      options.minLength = Math.max(1, Number.parseInt(next, 10))
+      index += 1
+    } else if (arg === '--help' || arg === '-h') {
+      printHelp()
+      process.exit(0)
+    } else {
+      throw new Error(`Unknown option: ${arg}`)
+    }
+  }
+
+  if (!Number.isFinite(options.limit) || options.limit < 1) options.limit = MODEL_OPS_REPLY_INTENT_MAX_SOURCE_ROWS
+  if (!Number.isFinite(options.minLength) || options.minLength < 1) options.minLength = 8
+  return options
+}
+
+export function planReplyIntentReviewSync(
+  sourceRows: OutreachReplySourceRow[],
+  reviewRows: ReplyIntentReviewRow[],
+  minLength = 8
+): SyncPlan {
+  const reviewableRows = sourceRows.filter((row) => hasReviewableReplyContent(row, minLength))
+  const sourceIds = new Set(reviewableRows.map((row) => row.id))
+  const reviewedSourceIds = new Set(reviewRows.map((row) => row.source_id))
+
+  return {
+    candidateReplies: reviewableRows.length,
+    existingLedgerRows: reviewRows.filter((row) => sourceIds.has(row.source_id)).length,
+    pendingToSeed: reviewableRows.filter((row) => !reviewedSourceIds.has(row.id)),
+    skippedShortReplies: sourceRows.length - reviewableRows.length,
+  }
+}
+
+function hasUsableSupabaseCredentials() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.PROD_SUPABASE_SERVICE_ROLE_KEY
+  return Boolean(url && key && !/YOUR_|your-|your_/i.test(`${url} ${key}`))
+}
+
+export async function syncReplyIntentReviewCandidates(options: SyncOptions) {
+  loadDotenv({ path: path.resolve(process.cwd(), options.envFile), override: false })
+
+  if (!hasUsableSupabaseCredentials()) {
+    return {
+      ok: true,
+      skipped: true,
+      applied: false,
+      reason: 'No usable Supabase URL/service role key found.',
+      source_table: 'outreach_queue',
+      candidate_replies: 0,
+      existing_ledger_rows: 0,
+      pending_to_seed: 0,
+      seeded: 0,
+      skipped_short_replies: 0,
+    }
+  }
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.PROD_SUPABASE_SERVICE_ROLE_KEY
+  const supabase = createClient(url!, key!, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+    global: {
+      headers: {
+        Authorization: `Bearer ${key}`,
+      },
+    },
+  })
+
+  const [{ data: sourceRows, error: sourceError }, { data: reviewRows, error: reviewError }] = await Promise.all([
+    supabase
+      .from('outreach_queue')
+      .select('id,channel,sequence_step,status,replied_at,created_at,reply_content')
+      .not('reply_content', 'is', null)
+      .order('replied_at', { ascending: false, nullsFirst: false })
+      .limit(options.limit),
+    supabase
+      .from('model_ops_reply_intent_reviews')
+      .select('source_id,source_table,source_hash,reply_hash,redacted_reply,suggested_labels,review_status,human_scheduling_intent')
+      .eq('source_table', 'outreach_queue')
+      .limit(options.limit),
+  ])
+
+  if (sourceError) throw new Error(`Failed to fetch outreach replies: ${sourceError.message}`)
+  if (reviewError) throw new Error(`Failed to fetch existing reply-intent reviews: ${reviewError.message}`)
+
+  const plan = planReplyIntentReviewSync(
+    (sourceRows || []) as OutreachReplySourceRow[],
+    (reviewRows || []) as ReplyIntentReviewRow[],
+    options.minLength
+  )
+
+  if (!options.apply || plan.pendingToSeed.length === 0) {
+    return {
+      ok: true,
+      skipped: false,
+      applied: false,
+      source_table: 'outreach_queue',
+      candidate_replies: plan.candidateReplies,
+      existing_ledger_rows: plan.existingLedgerRows,
+      pending_to_seed: plan.pendingToSeed.length,
+      seeded: 0,
+      skipped_short_replies: plan.skippedShortReplies,
+      next_command:
+        plan.pendingToSeed.length > 0 ? 'npm run model-ops:reply-intent:sync -- --apply' : 'No pending seed rows.',
+    }
+  }
+
+  const payloads = plan.pendingToSeed.map(buildPendingReviewSeedPayload)
+  const { error: upsertError } = await supabase
+    .from('model_ops_reply_intent_reviews')
+    .upsert(payloads, { onConflict: 'source_table,source_id' })
+
+  if (upsertError) throw new Error(`Failed to seed reply-intent review candidates: ${upsertError.message}`)
+
+  return {
+    ok: true,
+    skipped: false,
+    applied: true,
+    source_table: 'outreach_queue',
+    candidate_replies: plan.candidateReplies,
+    existing_ledger_rows: plan.existingLedgerRows,
+    pending_to_seed: plan.pendingToSeed.length,
+    seeded: payloads.length,
+    skipped_short_replies: plan.skippedShortReplies,
+  }
+}
+
+function printHelp() {
+  console.log(`Usage:
+  npm run model-ops:reply-intent:sync -- [options]
+
+Options:
+  --apply             Upsert missing outreach replies as pending review rows. Omit for dry-run.
+  --env-file <path>   Environment file to load before querying Supabase.
+  --limit <number>    Maximum source/review rows to inspect.
+  --min-length <n>    Minimum reply_content length to seed.
+`)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  syncReplyIntentReviewCandidates(parseArgs(process.argv.slice(2)))
+    .then((result) => console.log(JSON.stringify(result, null, 2)))
+    .catch((error) => {
+      console.error(error instanceof Error ? error.message : error)
+      process.exit(1)
+    })
+}


### PR DESCRIPTION
## Summary\n- Adds a dry-run/apply Model Ops command to seed missing reply-intent review ledger rows from real outreach replies.\n- Surfaces source coverage diagnostics in the reply-intent admin API and UI: candidate replies, ledger rows, virtual pending rows, and the sync command.\n- Keeps export evidence and source-ledger readiness separate so the 200 reviewed-real-example gate is visible.\n\n## Validation\n- npm test -- --run lib/model-ops-reply-intent.test.ts scripts/sync-reply-intent-review-candidates.test.ts app/api/admin/model-ops/reply-intent-reviews/route.test.ts app/api/admin/model-ops/reply-intent-reviews/bulk/route.test.ts app/admin/model-ops/reply-intent-review/page.test.tsx\n- npm run model-ops:reply-intent:sync -- --limit 10\n- npm run lint\n- npm run build:knowledge && npx tsc --noEmit\n\n## Safety\n- The sync command is dry-run by default. It only upserts pending ledger rows when run with --apply.\n- No production model swap, hosted routing, n8n production logic, Vercel flag, Supabase/Pinecone resource, secret, merge, or deploy change is included.