### PR TITLE
Tint reply-intent decision buttons

### DIFF
--- a/app/admin/model-ops/reply-intent-review/page.test.tsx
+++ b/app/admin/model-ops/reply-intent-review/page.test.tsx
@@ -134,6 +134,7 @@ describe('ReplyIntentReviewPage', () => {
 
     await waitFor(() => expect(screen.getByRole('button', { name: 'Yes' })).not.toBeDisabled())
     fireEvent.click(screen.getByRole('button', { name: 'Yes' }))
+    expect(screen.getByRole('button', { name: 'Yes' })).toHaveClass('text-emerald-200')
     await waitFor(() => expect(screen.getByRole('button', { name: 'Save' })).not.toBeDisabled())
     fireEvent.click(screen.getByRole('button', { name: 'Save' }))
 
@@ -146,6 +147,16 @@ describe('ReplyIntentReviewPage', () => {
         })
       )
     })
+  })
+
+  it('uses distinct subtle decision colors for yes and no selections', async () => {
+    render(<ReplyIntentReviewPage />)
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'No' })).not.toBeDisabled())
+    fireEvent.click(screen.getByRole('button', { name: 'No' }))
+
+    expect(screen.getByRole('button', { name: 'No' })).toHaveClass('text-red-200')
+    expect(screen.getByRole('button', { name: 'Yes' })).toHaveClass('bg-emerald-950/10')
   })
 
   it('is linked from Quality & insights admin navigation', () => {

--- a/app/admin/model-ops/reply-intent-review/page.tsx
+++ b/app/admin/model-ops/reply-intent-review/page.tsx
@@ -103,8 +103,22 @@ const STATUS_OPTIONS: Array<{ label: string; value: ReviewStatus | 'all' }> = [
 ]
 
 const DECISION_OPTIONS = [
-  { label: 'Yes', value: true, icon: Check },
-  { label: 'No', value: false, icon: X },
+  {
+    label: 'Yes',
+    value: true,
+    icon: Check,
+    activeClass: 'border-emerald-400/35 bg-emerald-950/25 text-emerald-200',
+    inactiveClass:
+      'border-emerald-400/20 bg-emerald-950/10 text-emerald-100/90 hover:border-emerald-400/30 hover:bg-emerald-950/15',
+  },
+  {
+    label: 'No',
+    value: false,
+    icon: X,
+    activeClass: 'border-red-400/35 bg-red-950/20 text-red-200',
+    inactiveClass:
+      'border-red-400/20 bg-red-950/10 text-red-100/90 hover:border-red-400/30 hover:bg-red-950/15',
+  },
 ] as const
 
 function formatDate(value: string | null) {
@@ -560,7 +574,7 @@ function ReplyIntentReviewContent() {
             </div>
 
             <div className="grid grid-cols-2 gap-2">
-              {DECISION_OPTIONS.map(({ label, value, icon: Icon }) => (
+              {DECISION_OPTIONS.map(({ label, value, icon: Icon, activeClass, inactiveClass }) => (
                 <button
                   key={label}
                   type="button"
@@ -570,9 +584,7 @@ function ReplyIntentReviewContent() {
                     setDraftUnsure(false)
                   }}
                   className={`flex min-h-14 items-center justify-center gap-2 rounded-lg border text-sm font-semibold transition-colors ${
-                    draftIntent === value && !draftUnsure
-                      ? 'border-radiant-gold/45 bg-radiant-gold/15 text-radiant-gold'
-                      : 'border-radiant-gold/10 bg-silicon-slate/20 text-foreground/85 hover:border-radiant-gold/30'
+                    draftIntent === value && !draftUnsure ? activeClass : inactiveClass
                   } disabled:cursor-not-allowed disabled:opacity-50`}
                 >
                   <Icon size={18} />


### PR DESCRIPTION
## Summary
- make the reply-intent Yes decision use a subtle green treatment
- make the No decision use a subtle red treatment
- add focused assertions so the distinct decision colors stay covered

## Validation
- npm test -- --run app/admin/model-ops/reply-intent-review/page.test.tsx
- npm run lint -- --file app/admin/model-ops/reply-intent-review/page.tsx
- inline Browser visual check at http://localhost:3024/admin/model-ops/reply-intent-review