### PR TITLE
docs: record supabase staging rotation evidence

### DIFF
--- a/docs/credential-baseline-evidence.md
+++ b/docs/credential-baseline-evidence.md
@@ -1,6 +1,6 @@
 # Credential Baseline Evidence
 
-Last updated: 2026-05-25
+Last updated: 2026-05-26
 
 This note records the value-free evidence used to replace the staging `pending-provider-confirmation` baselines in `docs/credential-inventory.json`.
 
@@ -23,6 +23,8 @@ No secret values were read, printed, committed, or copied into this file. The ev
 | `GITHUB_TOKEN` | 2026-05-13 | Approved staging-only rotation drill: Infisical staging `/portfolio` secret synced, local and `portfolio-staging` Vercel runtime sinks updated, and GitHub repo-read smoke returned 200. |
 | `N8N_INGEST_SECRET` | 2026-05-25 | Approved staging-only coupled ingest rotation: Infisical staging `/portfolio` entries `N8N_INGEST_SECRET` and `STAG_N8N_INGEST_SECRET` synced, `portfolio-staging` Vercel runtime sink updated, n8n `ATAS Staging` variable `STAG_N8N_INGEST_SECRET` updated via API, staging redeployed, and hash-only verification matched. |
 | `STAG_N8N_INGEST_SECRET` | 2026-05-25 | Approved staging-only coupled ingest rotation: n8n `ATAS Staging` variable updated via API with the same generated value as the staging app-side ingest secret; hash-only verification matched. |
+| `SUPABASE_SERVICE_ROLE_KEY` | 2026-05-26 | Approved staging-only Supabase secret key rotation: Supabase secret API key `portfolio_staging_rotation_20260526` created, prior exposed/unused staging keys deleted, Infisical staging `/portfolio`, n8n `ATAS Staging`, local staging aliases, and `portfolio-staging` Vercel runtime sink synced, staging redeployed, and hash-only verification matched. |
+| `STAG_SUPABASE_SERVICE_ROLE_KEY` | 2026-05-26 | Approved staging-only Supabase secret key rotation: n8n `ATAS Staging` variable updated via API with the same replacement key as the staging app-side Supabase secret; hash-only verification matched. |
 | `GOOGLE_SERVICE_ACCOUNT_KEY` | 2026-05-13 | Vercel Preview metadata after approved preview sync on 2026-05-13T13:27:32Z. |
 | `LINKEDIN_COOKIE` | 2026-05-13 | Operator added a current LinkedIn `li_at` session cookie to local env on 2026-05-13. |
 | `GMAIL_APP_PASSWORD` | 2026-05-01 | 1Password `Portfolio / staging` item metadata for `GMAIL_APP_PASSWORD`, created/updated 2026-05-01T14:48:30Z. |

--- a/docs/credential-inventory.json
+++ b/docs/credential-inventory.json
@@ -128,9 +128,9 @@
         },
         "staging": {
           "status": "confirmed",
-          "lastRotatedAt": "2026-03-22",
-          "evidence": "n8n Credentials metadata: Supabase Service Role updated 2026-03-22T00:38:59Z; value not read.",
-          "updatedAt": "2026-05-13"
+          "lastRotatedAt": "2026-05-26",
+          "evidence": "Approved staging-only Supabase secret key rotation: Supabase secret API key portfolio_staging_rotation_20260526 created, prior exposed/unused staging keys deleted, Infisical staging /portfolio SUPABASE_SERVICE_ROLE_KEY synced, n8n ATAS Staging variable STAG_SUPABASE_SERVICE_ROLE_KEY synced, local staging aliases updated, portfolio-staging Vercel runtime sink updated and redeployed, and hash-only verification matched; value not printed.",
+          "updatedAt": "2026-05-26"
         },
         "prod": {
           "status": "pending-provider-confirmation",
@@ -1791,10 +1791,10 @@
       "rollback": "Rotate together with the staging Supabase project service role key and rerun staging workflow smoke.",
       "baseline": {
         "staging": {
-          "status": "pending-provider-confirmation",
-          "lastRotatedAt": null,
-          "evidence": "Staging n8n variable mapping added 2026-05-24; value and last rotation date require n8n Variables or provider-confirmed evidence. Do not infer from .env.local.",
-          "updatedAt": "2026-05-24"
+          "status": "confirmed",
+          "lastRotatedAt": "2026-05-26",
+          "evidence": "Approved staging-only Supabase secret key rotation: n8n ATAS Staging variable STAG_SUPABASE_SERVICE_ROLE_KEY updated via API with the same replacement Supabase secret API key as Infisical staging /portfolio SUPABASE_SERVICE_ROLE_KEY; hash-only verification matched; value not printed.",
+          "updatedAt": "2026-05-26"
         }
       }
     },


### PR DESCRIPTION
Summary
- Records the approved Supabase staging secret key rotation baseline for SUPABASE_SERVICE_ROLE_KEY.
- Marks STAG_SUPABASE_SERVICE_ROLE_KEY staging baseline confirmed from the same rotation.
- Adds value-free evidence for Infisical, n8n ATAS Staging, local staging aliases, and portfolio-staging Vercel redeploy.

Validation
- Supabase REST compatibility: apikey-only 200; current apikey + Authorization bearer pattern 200.
- Hash-only sink check matched expected/Infisical/local-staging/n8n: 1d4ff0ece07e9c6c.
- portfolio-staging Vercel redeployed: dpl_5t3FiimNVPCr44iGU7ZGBX2ULTNN, READY, aliased to https://portfolio-staging-ten.vercel.app.
- npm run credentials:smoke -- --env staging --require-provider-access.
- npm run credentials:report -- --env staging --check-sinks: SUPABASE_SERVICE_ROLE_KEY and STAG_SUPABASE_SERVICE_ROLE_KEY now OK; one remaining due item is APIFY_API_TOKEN from separate PR #387.
- node JSON parse for docs/credential-inventory.json.
- git diff --check for changed docs.
- Pre-push database health check passed.

Integration Notes
- Staging-only credential rotation evidence; no production revocation or production config change.
- Vercel – portfolio-staging checked via redeploy; Vercel – portfolio not checked because this was a staging-only rotation.
- Potential overlap: PR #387 also edits credential inventory/evidence for Apify staging rotation; integration captain should merge/rebase these docs carefully.
- Raw secret values were not committed or documented; temporary key file was deleted and browser clipboard was cleared.