### PR TITLE
chore: ignore generated tmp artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 # testing
 /coverage
 test-results/
+/tmp/
 
 # next.js
 /.next/


### PR DESCRIPTION
## Summary
- Adds `/tmp/` to `.gitignore` so generated local evidence, screenshots, logs, and AutoResearch traces do not appear as root checkout noise.
- Retires the existing untracked root `tmp/` folder by moving it to `/private/tmp/portfolio-tmp-retired-20260526T191956Z` for short-term recovery.
- Keeps raw generated artifacts out of the repo and treats them as temporary evidence rather than durable payload.

## Validation
- `git diff --check`: passed.
- `node -e` check confirmed `.gitignore` contains `/tmp/`.
- Root checkout verified clean after moving `tmp/` aside.

## Integration Notes
- No runtime code changed.
- No generated artifacts or screenshots are committed.
- Post-merge gate remains both Vercel contexts: `Vercel – portfolio` and `Vercel – portfolio-staging`.