### PR TITLE
feat: surface Google Places promotion gate

### DIFF
--- a/docs/subscription-status.json
+++ b/docs/subscription-status.json
@@ -59,6 +59,22 @@
       "pauseOrReplaceActorSurfaces": 8,
       "analysisDocument": "/docs/apify-call-bakeoff-analysis.md",
       "nextAction": "Keep productive evidence actors under watch, pause or replace no-run/failing/empty-output actors, and compare the remaining productive categories against cheaper alternatives before renewal.",
+      "googlePlacesPromotionGate": {
+        "status": "gated",
+        "localKeyStatus": "API-restricted to Places API (New); acceptable for the short local/Codex bakeoff window.",
+        "productionRequirement": "Do not promote Google Places as the durable Apify Google Maps replacement until the production runner and outbound egress path are confirmed.",
+        "recommendedProductionKeyName": "portfolio-apify-replacement-google-places-prod",
+        "requiredControls": [
+          "Separate production key from the local bakeoff key.",
+          "API restriction to Places API (New).",
+          "IP address restriction if the production runner has stable outbound egress.",
+          "Strict quota limits, billing alerts, and a rotation review date if stable egress is not available yet.",
+          "Infisical/Vercel runtime sink sync only after the production key is approved.",
+          "Production-like rerun of npm run apify:replacement-bakeoff -- --run before replacing the Apify Google Maps actor."
+        ],
+        "decisionOwner": "subscription-watch / integration captain",
+        "decisionRequired": true
+      },
       "actorRunHistory": [
         {
           "actor": "alien_force~facebook-scraper-pro",

--- a/lib/subscription-status.test.ts
+++ b/lib/subscription-status.test.ts
@@ -32,6 +32,14 @@ describe('subscription status budget queries', () => {
     expect(result.answer).toContain('315 dataset items')
   })
 
+  it('surfaces the Google Places production promotion gate', () => {
+    const result = answerSubscriptionBudgetQuery('Can we promote Google Places to production as the Apify Google Maps replacement?')
+
+    expect(result.answer).toContain('Google Places production gate')
+    expect(result.answer).toContain('portfolio-apify-replacement-google-places-prod')
+    expect(result.apifyCallAnalysis?.googlePlacesPromotionGate?.decisionRequired).toBe(true)
+  })
+
   it('handles transition spend from the Anthropic to ChatGPT switch', () => {
     const result = answerSubscriptionBudgetQuery('Will spend go down next month after switching from Anthropic to ChatGPT?')
 

--- a/lib/subscription-status.ts
+++ b/lib/subscription-status.ts
@@ -55,7 +55,18 @@ export interface SubscriptionApifyCallAnalysis {
   pauseOrReplaceActorSurfaces?: number
   analysisDocument: string
   nextAction: string
+  googlePlacesPromotionGate?: SubscriptionGooglePlacesPromotionGate
   actorRunHistory?: SubscriptionApifyActorRunHistory[]
+}
+
+export interface SubscriptionGooglePlacesPromotionGate {
+  status: 'gated' | 'ready' | 'blocked' | string
+  localKeyStatus: string
+  productionRequirement: string
+  recommendedProductionKeyName: string
+  requiredControls: string[]
+  decisionOwner: string
+  decisionRequired: boolean
 }
 
 export interface SubscriptionApifyActorRunHistory {
@@ -187,6 +198,20 @@ export function answerSubscriptionBudgetQuery(query: string): SubscriptionQueryR
         answer = `${answer} Direct Apify run-history sampled ${analysis.sampledRuns ?? 0} runs across ${analysis.configuredActorSurfaces} actor surfaces: ${analysis.productiveActorSurfaces ?? 0} look productive, ${analysis.pauseOrReplaceActorSurfaces ?? 0} should be paused/replaced, ${analysis.datasetItems ?? 0} dataset items cost $${(analysis.sampledActorCostUsd ?? 0).toFixed(2)} in actor usage. ${analysis.nextAction}`
       } else {
         answer = `${answer} Apify has ${analysis.configuredActorSurfaces} configured actor surfaces in the current analysis; ${analysis.nextAction}`
+      }
+      if (
+        analysis.googlePlacesPromotionGate
+        && (
+          normalized.includes('google places')
+          || normalized.includes('google maps')
+          || normalized.includes('production')
+          || normalized.includes('promote')
+          || normalized.includes('restriction')
+          || normalized.includes('egress')
+        )
+      ) {
+        const gate = analysis.googlePlacesPromotionGate
+        answer = `${answer} Google Places production gate: ${gate.productionRequirement} Recommended key: ${gate.recommendedProductionKeyName}. Required controls: ${gate.requiredControls.join(' ')}`
       }
     }
   }


### PR DESCRIPTION
## Summary
- surfaces the Google Places production promotion gate in the subscription status registry
- teaches subscription budget queries to call out the gate when asked about Google Places, Google Maps, production, restrictions, or egress
- adds focused test coverage so the admin query path keeps exposing the decision gate

## Validation
- git diff --check
- npm test -- --run lib/subscription-status.test.ts lib/apify-replacement-bakeoff.test.ts
- npm run apify:replacement-bakeoff
- npm run db:health-check
- push hook database health check passed

## Integration Notes
- Follow-up to merged PR #391; that PR merged before this reporting-surface commit was included.
- No secrets or API key values are committed.
- No shared cost-event schema changes.
- Google Places production promotion remains gated on execution host, outbound egress, runtime sink sync, and a production-like bakeoff rerun.
- Vercel contexts not checked in this non-captain docs/query lane: Vercel – portfolio, Vercel – portfolio-staging.