### PR TITLE
feat: add client ai ops readiness contract

### DIFF
--- a/app/api/admin/client-projects/[id]/ai-ops/route.test.ts
+++ b/app/api/admin/client-projects/[id]/ai-ops/route.test.ts
@@ -19,11 +19,13 @@ vi.mock('@/lib/client-ai-ops-roadmap-db', () => ({
   projectRoadmapTasks: mocks.projectRoadmapTasks,
 }))
 
-import { GET } from './route'
+import { GET, POST } from './route'
 
-function request() {
+function request(method = 'GET', body?: Record<string, unknown>) {
   return new Request('http://localhost/api/admin/client-projects/project-1/ai-ops', {
+    method,
     headers: { authorization: 'Bearer token' },
+    body: body ? JSON.stringify(body) : undefined,
   })
 }
 
@@ -95,6 +97,22 @@ describe('GET /api/admin/client-projects/[id]/ai-ops', () => {
       requiredConnectorCount: 5,
       connectorNextAction: 'Prepare oauth setup packet for HubSpot; do not connect until approved.',
     })
+    expect(body.readiness).toMatchObject({
+      status: 'waiting_approval',
+      sideEffectsEnabled: false,
+      connector: {
+        required: 5,
+      },
+      projection: {
+        approvals: 1,
+        isolationChecks: 1,
+      },
+      approvalBoundaries: {
+        credentialSync: 'waiting_approval',
+        outboundSend: 'waiting_approval',
+        productionDeploy: 'waiting_approval',
+      },
+    })
   })
 
   it('requires admin auth before reading the roadmap bundle', async () => {
@@ -106,5 +124,57 @@ describe('GET /api/admin/client-projects/[id]/ai-ops', () => {
     expect(response.status).toBe(401)
     expect(await response.json()).toEqual({ error: 'Unauthorized' })
     expect(mocks.getRoadmapBundleForProject).not.toHaveBeenCalled()
+  })
+
+  it('returns a readiness contract after creating and projecting roadmap tasks', async () => {
+    const roadmap = {
+      clientView: {
+        title: 'Acme AI Ops Roadmap',
+        connectorReadiness: {
+          summary: '1 required, 0 ready, 1 need auth, 0 approval-blocked',
+          requiredConnectorCount: 1,
+          readyConnectorCount: 0,
+          approvalBlockedConnectorCount: 0,
+          missingCriticalConnectorCount: 0,
+          connectorNextAction: 'Prepare oauth setup packet for HubSpot; do not connect until approved.',
+          conflicts: [],
+          items: [],
+        },
+        projectionStatus: {
+          tasksTotal: 1,
+          tasksComplete: 0,
+          blockedTasks: 0,
+          clientActionCount: 0,
+          amadutownActionCount: 1,
+          sharedActionCount: 0,
+          approvalNeededCount: 0,
+          isolationRequiredCount: 0,
+          overdueTasks: 0,
+          staleCostItems: 0,
+          reportMissing: false,
+          nextReportingAction: 'Continue scheduled roadmap monitoring',
+        },
+      },
+    }
+    mocks.ensureRoadmapForProject.mockResolvedValue(roadmap)
+    mocks.projectRoadmapTasks.mockResolvedValue({ dashboardCreated: 1, meetingCreated: 1 })
+
+    const response = await POST(request('POST', { project_tasks: true }) as never, { params: Promise.resolve({ id: 'project-1' }) })
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(mocks.ensureRoadmapForProject).toHaveBeenCalledWith('project-1', {
+      generatedFrom: 'manual',
+      userId: 'admin-user',
+    })
+    expect(mocks.projectRoadmapTasks).toHaveBeenCalledWith('project-1')
+    expect(body.projection).toEqual({ dashboardCreated: 1, meetingCreated: 1 })
+    expect(body.readiness).toMatchObject({
+      status: 'ready_for_planning',
+      sideEffectsEnabled: false,
+      projection: {
+        openActions: 1,
+      },
+    })
   })
 })

--- a/app/api/admin/client-projects/[id]/ai-ops/route.ts
+++ b/app/api/admin/client-projects/[id]/ai-ops/route.ts
@@ -5,6 +5,7 @@ import {
   getRoadmapBundleForProject,
   projectRoadmapTasks,
 } from '@/lib/client-ai-ops-roadmap-db'
+import { buildClientAiOpsReadinessContract } from '@/lib/client-ai-ops-readiness-contract'
 
 export const dynamic = 'force-dynamic'
 
@@ -19,7 +20,10 @@ export async function GET(
 
   const { id } = await params
   const bundle = await getRoadmapBundleForProject(id)
-  return NextResponse.json({ roadmap: bundle })
+  return NextResponse.json({
+    roadmap: bundle,
+    readiness: buildClientAiOpsReadinessContract(bundle?.clientView, { clientProjectId: id }),
+  })
 }
 
 export async function POST(
@@ -36,5 +40,9 @@ export async function POST(
   const roadmap = await ensureRoadmapForProject(id, { generatedFrom: 'manual', userId: auth.user.id })
   const projection = body.project_tasks ? await projectRoadmapTasks(id) : { dashboardCreated: 0, meetingCreated: 0 }
 
-  return NextResponse.json({ roadmap, projection })
+  return NextResponse.json({
+    roadmap,
+    projection,
+    readiness: buildClientAiOpsReadinessContract(roadmap.clientView, { clientProjectId: id }),
+  })
 }

--- a/docs/client-ai-ops-roadmap-sop.md
+++ b/docs/client-ai-ops-roadmap-sop.md
@@ -114,6 +114,12 @@ Use `buildSyntheticClientAiOpsPilot` from `lib/client-ai-ops-synthetic-pilot.ts`
 
 The fixture is not a seed script and must not create client records, credentials, OAuth connections, provider resources, live workflows, outbound messages, or production configuration.
 
+## Readiness Contract
+
+Use `buildClientAiOpsReadinessContract` from `lib/client-ai-ops-readiness-contract.ts` when an admin/API surface needs a compact readiness packet. The contract summarizes connector readiness, roadmap projection status, optional swarm-board health, and fixed approval boundaries while keeping `sideEffectsEnabled` false.
+
+`GET` and `POST` on `/api/admin/client-projects/[id]/ai-ops` return this readiness packet alongside the existing roadmap response. Consumers should treat it as a read-only decision surface. It can tell an admin what needs approval or planning next, but it must not be used as permission to connect OAuth, sync credentials, call providers, send outbound messages, deploy production changes, or mutate client data.
+
 ## Roadmap Rule Checklist
 
 Use this checklist whenever a roadmap feature, monitor, report, or client implementation phase changes:
@@ -127,6 +133,7 @@ Use this checklist whenever a roadmap feature, monitor, report, or client implem
 - Roadmap projection status is visible from the same source data and remains read-only.
 - Connector readiness is visible from verified stack, audit, BuiltWith, and roadmap signals without live credential setup.
 - The synthetic pilot fixture still proves audit-to-roadmap-to-client/admin projection and read-only autonomous handoff boundaries.
+- The admin AI Ops readiness contract stays present and keeps `sideEffectsEnabled` false.
 - Client-facing output excludes private logs, agent traces, credentials, and internal-only notes.
 
 ## Real Client Pilot Checklist

--- a/lib/client-ai-ops-readiness-contract.test.ts
+++ b/lib/client-ai-ops-readiness-contract.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/supabase', () => ({ supabaseAdmin: null }))
+
+import { buildClientAiOpsReadinessContract } from './client-ai-ops-readiness-contract'
+import { buildSyntheticClientAiOpsPilot } from './client-ai-ops-synthetic-pilot'
+
+describe('buildClientAiOpsReadinessContract', () => {
+  it('summarizes the synthetic pilot into a stable approval-gated contract', () => {
+    const pilot = buildSyntheticClientAiOpsPilot()
+    const contract = buildClientAiOpsReadinessContract(pilot.clientView, {
+      swarmSnapshot: pilot.swarmSnapshot,
+      clientProjectId: 'synthetic-client-ai-ops-project',
+    })
+
+    expect(contract).toMatchObject({
+      status: 'waiting_approval',
+      sideEffectsEnabled: false,
+      connector: {
+        required: expect.any(Number),
+        approvalBlocked: 0,
+        missingCritical: 0,
+      },
+      projection: {
+        approvals: expect.any(Number),
+        monitorFlags: 0,
+      },
+      swarm: {
+        moduleHealth: 'green',
+        approvalState: 'none',
+        autonomousReady: true,
+      },
+      approvalBoundaries: {
+        credentialSync: 'waiting_approval',
+        providerSetup: 'waiting_approval',
+        outboundSend: 'waiting_approval',
+        productionDeploy: 'waiting_approval',
+        clientDataMutation: 'waiting_approval',
+      },
+    })
+    expect(contract.projection.approvals).toBeGreaterThan(0)
+    expect(contract.connector.required).toBeGreaterThanOrEqual(6)
+  })
+
+  it('routes approval-heavy roadmap state to waiting approval', () => {
+    const pilot = buildSyntheticClientAiOpsPilot()
+    const contract = buildClientAiOpsReadinessContract({
+      ...pilot.clientView,
+      projectionStatus: {
+        ...pilot.clientView.projectionStatus,
+        approvalNeededCount: 2,
+      },
+    })
+
+    expect(contract).toMatchObject({
+      status: 'waiting_approval',
+      nextAction: 'Review approval-gated AI Ops work before any live setup or outbound action.',
+      sideEffectsEnabled: false,
+    })
+  })
+
+  it('handles missing roadmap state without inventing setup readiness', () => {
+    const contract = buildClientAiOpsReadinessContract(null)
+
+    expect(contract).toMatchObject({
+      status: 'needs_roadmap',
+      sideEffectsEnabled: false,
+      connector: {
+        required: 0,
+        nextAction: 'Create the Client AI Ops roadmap first.',
+      },
+      swarm: {
+        column: null,
+        autonomousReady: false,
+      },
+    })
+  })
+})

--- a/lib/client-ai-ops-readiness-contract.ts
+++ b/lib/client-ai-ops-readiness-contract.ts
@@ -1,0 +1,169 @@
+import type { AgentSwarmBoardSnapshot, SwarmBoardCard } from './agent-swarm-board'
+import type { RoadmapClientView } from './client-ai-ops-roadmap'
+
+export type ClientAiOpsReadinessStatus =
+  | 'needs_roadmap'
+  | 'waiting_approval'
+  | 'needs_connector_decision'
+  | 'blocked'
+  | 'ready_for_planning'
+
+export type ClientAiOpsReadinessContract = {
+  status: ClientAiOpsReadinessStatus
+  nextAction: string
+  sideEffectsEnabled: false
+  connector: {
+    summary: string
+    required: number
+    ready: number
+    approvalBlocked: number
+    missingCritical: number
+    nextAction: string
+  }
+  projection: {
+    openActions: number
+    approvals: number
+    isolationChecks: number
+    monitorFlags: number
+    nextAction: string
+  }
+  swarm: {
+    column: string | null
+    moduleHealth: string | null
+    approvalState: string | null
+    autonomousReady: boolean
+  }
+  approvalBoundaries: {
+    credentialSync: 'waiting_approval'
+    providerSetup: 'waiting_approval'
+    outboundSend: 'waiting_approval'
+    productionDeploy: 'waiting_approval'
+    clientDataMutation: 'waiting_approval'
+  }
+}
+
+export function buildClientAiOpsReadinessContract(
+  clientView: RoadmapClientView | null | undefined,
+  options: {
+    swarmSnapshot?: AgentSwarmBoardSnapshot | null
+    clientProjectId?: string | null
+  } = {},
+): ClientAiOpsReadinessContract {
+  const card = findSwarmCard(options.swarmSnapshot, options.clientProjectId)
+  if (!clientView) {
+    return {
+      status: 'needs_roadmap',
+      nextAction: 'Create the Client AI Ops roadmap before connector or agent-swarm planning.',
+      sideEffectsEnabled: false,
+      connector: {
+        summary: 'No roadmap available',
+        required: 0,
+        ready: 0,
+        approvalBlocked: 0,
+        missingCritical: 0,
+        nextAction: 'Create the Client AI Ops roadmap first.',
+      },
+      projection: {
+        openActions: 0,
+        approvals: 0,
+        isolationChecks: 0,
+        monitorFlags: 0,
+        nextAction: 'Create the Client AI Ops roadmap first.',
+      },
+      swarm: swarmState(card),
+      approvalBoundaries: approvalBoundaries(),
+    }
+  }
+
+  const connector = clientView.connectorReadiness
+  const projection = clientView.projectionStatus
+  const monitorFlags = projection.overdueTasks + projection.staleCostItems + (projection.reportMissing ? 1 : 0)
+  const openActions = projection.clientActionCount + projection.amadutownActionCount + projection.sharedActionCount
+  const status = readinessStatus({
+    connectorApprovals: connector.approvalBlockedConnectorCount,
+    missingCritical: connector.missingCriticalConnectorCount,
+    blockedTasks: projection.blockedTasks,
+    approvals: projection.approvalNeededCount,
+    monitorFlags,
+    card,
+  })
+
+  return {
+    status,
+    nextAction: readinessNextAction({
+      status,
+      connectorNextAction: connector.connectorNextAction,
+      projectionNextAction: projection.nextReportingAction,
+      cardNextAction: card?.nextAction ?? null,
+    }),
+    sideEffectsEnabled: false,
+    connector: {
+      summary: connector.summary,
+      required: connector.requiredConnectorCount,
+      ready: connector.readyConnectorCount,
+      approvalBlocked: connector.approvalBlockedConnectorCount,
+      missingCritical: connector.missingCriticalConnectorCount,
+      nextAction: connector.connectorNextAction,
+    },
+    projection: {
+      openActions,
+      approvals: projection.approvalNeededCount,
+      isolationChecks: projection.isolationRequiredCount,
+      monitorFlags,
+      nextAction: projection.nextReportingAction,
+    },
+    swarm: swarmState(card),
+    approvalBoundaries: approvalBoundaries(),
+  }
+}
+
+function findSwarmCard(snapshot: AgentSwarmBoardSnapshot | null | undefined, clientProjectId: string | null | undefined): SwarmBoardCard | null {
+  if (!snapshot || !clientProjectId) return null
+  return snapshot.columns.flatMap((column) => column.cards).find((card) => card.clientProjectId === clientProjectId) ?? null
+}
+
+function readinessStatus(input: {
+  connectorApprovals: number
+  missingCritical: number
+  blockedTasks: number
+  approvals: number
+  monitorFlags: number
+  card: SwarmBoardCard | null
+}): ClientAiOpsReadinessStatus {
+  if (input.card?.moduleHealth === 'red' || input.blockedTasks > 0) return 'blocked'
+  if (input.connectorApprovals > 0 || input.approvals > 0 || input.card?.approvalState === 'pending') return 'waiting_approval'
+  if (input.missingCritical > 0) return 'needs_connector_decision'
+  return 'ready_for_planning'
+}
+
+function readinessNextAction(input: {
+  status: ClientAiOpsReadinessStatus
+  connectorNextAction: string
+  projectionNextAction: string
+  cardNextAction: string | null
+}) {
+  if (input.status === 'blocked') return input.cardNextAction ?? input.projectionNextAction
+  if (input.status === 'waiting_approval') return 'Review approval-gated AI Ops work before any live setup or outbound action.'
+  if (input.status === 'needs_connector_decision') return input.connectorNextAction
+  if (input.status === 'needs_roadmap') return 'Create the Client AI Ops roadmap first.'
+  return input.cardNextAction ?? input.projectionNextAction
+}
+
+function swarmState(card: SwarmBoardCard | null) {
+  return {
+    column: card?.column ?? null,
+    moduleHealth: card?.moduleHealth ?? null,
+    approvalState: card?.approvalState ?? null,
+    autonomousReady: Boolean(card && card.approvalState === 'none' && card.moduleHealth !== 'red'),
+  }
+}
+
+function approvalBoundaries(): ClientAiOpsReadinessContract['approvalBoundaries'] {
+  return {
+    credentialSync: 'waiting_approval',
+    providerSetup: 'waiting_approval',
+    outboundSend: 'waiting_approval',
+    productionDeploy: 'waiting_approval',
+    clientDataMutation: 'waiting_approval',
+  }
+}

--- a/lib/client-ai-ops-synthetic-pilot.ts
+++ b/lib/client-ai-ops-synthetic-pilot.ts
@@ -13,6 +13,10 @@ import {
   type RoadmapDraft,
   type RoadmapTaskDraft,
 } from './client-ai-ops-roadmap'
+import {
+  buildClientAiOpsReadinessContract,
+  type ClientAiOpsReadinessContract,
+} from './client-ai-ops-readiness-contract'
 
 type SwarmRows = Parameters<typeof buildAgentSwarmBoardSnapshotFromRows>[0]
 
@@ -25,6 +29,7 @@ export type SyntheticClientAiOpsPilot = {
   context: RoadmapContext
   draft: RoadmapDraft
   clientView: RoadmapClientView
+  readinessContract: ClientAiOpsReadinessContract
   swarmRows: SwarmRows
   swarmSnapshot: AgentSwarmBoardSnapshot
   autonomousHandoffPath: Array<{
@@ -97,13 +102,18 @@ export function buildSyntheticClientAiOpsPilot(): SyntheticClientAiOpsPilot {
     ],
   })
   const swarmRows = syntheticSwarmRows(draft)
+  const swarmSnapshot = buildAgentSwarmBoardSnapshotFromRows(swarmRows)
 
   return {
     context,
     draft,
     clientView,
+    readinessContract: buildClientAiOpsReadinessContract(clientView, {
+      swarmSnapshot,
+      clientProjectId: PROJECT_ID,
+    }),
     swarmRows,
-    swarmSnapshot: buildAgentSwarmBoardSnapshotFromRows(swarmRows),
+    swarmSnapshot,
     autonomousHandoffPath: [
       policyStep('discovery'),
       policyStep('technology_decision'),


### PR DESCRIPTION
## Summary
- adds a compact Client AI Ops readiness contract that summarizes connector readiness, roadmap projection status, optional swarm-board health, and fixed approval boundaries
- returns the readiness packet from admin AI Ops GET and POST responses alongside the existing roadmap payload
- wires the synthetic pilot fixture through the same contract so future roadmap/connector/swarm changes have one no-side-effect regression target
- documents the readiness contract as read-only with sideEffectsEnabled=false

## Enhancement Impact Preflight
- Enhancement: Client AI Ops readiness contract for admin API/read-model hardening.
- User-facing surface: /api/admin/client-projects/[id]/ai-ops and downstream admin roadmap consumers.
- Predicted files: lib/client-ai-ops-readiness-contract.ts, lib/client-ai-ops-readiness-contract.test.ts, lib/client-ai-ops-synthetic-pilot.ts, app/api/admin/client-projects/[id]/ai-ops/route.ts, app/api/admin/client-projects/[id]/ai-ops/route.test.ts, docs/client-ai-ops-roadmap-sop.md.
- Shared routes/APIs/tables/helpers: adds fields to existing AI Ops API response; uses existing roadmap, connector, and swarm-board read models. No database schema changes.
- Active PRs or branches checked: #405 open-brain-map-filters and #404 subscription-watch-google-places-gate; worktrees checked.
- Dirty worktree files checked: main checkout was clean before starting; this ran in a fresh sibling worktree.
- Overlap rating: green.
- Coordination decision: proceed independently.
- Merge-order note: can merge after normal captain checks; no dependency on Open Brain or subscription-watch PRs.

## Validation
- npm ci
- npm run worktree:env -- --source /Users/vambahsillah/Projects/Portfolio
- npm test -- lib/client-ai-ops-readiness-contract.test.ts lib/client-ai-ops-synthetic-pilot.test.ts lib/client-ai-ops-roadmap.test.ts lib/client-connector-readiness.test.ts lib/agent-swarm-board.test.ts app/api/admin/client-projects/[id]/ai-ops/route.test.ts components/client-dashboard/AiOpsRoadmapSection.test.tsx
- npm run build:knowledge
- npx tsc --noEmit --pretty false
- git diff --cached --check
- push hook database health check passed

## Integration Notes
- API compatibility is additive: existing roadmap payload remains present and readiness is returned as a sibling field.
- sideEffectsEnabled is always false; approval boundaries remain waiting_approval for credential sync, provider setup, outbound sends, production deploys, and client-data mutation.
- No OAuth, credential sync, provider write, workflow activation, outbound send, publishing, deploy, migration, or client-data mutation is included.
- Vercel contexts still need the normal Integration Captain verification before merge: Vercel – portfolio and Vercel – portfolio-staging.