### PR TITLE
fix: log safe Slack command signature diagnostics

### DIFF
--- a/app/api/slack/agent/route.test.ts
+++ b/app/api/slack/agent/route.test.ts
@@ -66,6 +66,48 @@ describe('POST /api/slack/agent', () => {
     expect(mocks.handleAgentSlackCommand).not.toHaveBeenCalled()
   })
 
+  it('logs safe Slack app diagnostics for invalid signatures', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const request = signedRequest(
+      new URLSearchParams({
+        api_app_id: 'A_TEST_APP',
+        channel_id: 'C_TEST_CHANNEL',
+        command: '/agent',
+        response_url: 'https://hooks.slack.com/commands/test-response',
+        team_domain: 'amadutown',
+        team_id: 'T_TEST_TEAM',
+        text: 'help',
+        token: 'legacy-token',
+        user_id: 'U_TEST_USER',
+        user_name: 'vambah',
+      }),
+      'wrong-secret',
+    )
+
+    const response = await POST(request as never)
+
+    expect(response.status).toBe(401)
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Invalid Slack agent command signature',
+      expect.objectContaining({
+        api_app_id: 'A_TEST_APP',
+        channel_id: 'C_TEST_CHANNEL',
+        command: '/agent',
+        team_domain: 'amadutown',
+        team_id: 'T_TEST_TEAM',
+        user_id: 'U_TEST_USER',
+        has_signature: true,
+        has_timestamp: true,
+        body_length: expect.any(Number),
+      }),
+    )
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toContain('legacy-token')
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toContain('test-response')
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toContain('help')
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toContain('vambah')
+    expect(mocks.handleAgentSlackCommand).not.toHaveBeenCalled()
+  })
+
   it('rejects unsigned production requests when the signing secret is missing', async () => {
     process.env = { ...ORIGINAL_ENV, NODE_ENV: 'production', VERCEL: '1', SLACK_SIGNING_SECRET: '' }
 

--- a/app/api/slack/agent/route.ts
+++ b/app/api/slack/agent/route.ts
@@ -14,6 +14,7 @@ export async function POST(request: NextRequest) {
     const rawBody = await request.text()
     const isValid = verifySlackSignature(request, rawBody)
     if (!isValid) {
+      logInvalidSlackCommandSignature(request, rawBody)
       return NextResponse.json({ error: 'Invalid Slack signature' }, { status: 401 })
     }
 
@@ -58,6 +59,29 @@ export async function POST(request: NextRequest) {
       text: 'An error occurred processing the Agent Ops command. Check the Portfolio logs and try again.',
     })
   }
+}
+
+function logInvalidSlackCommandSignature(request: NextRequest, rawBody: string) {
+  const formData = new URLSearchParams(rawBody)
+  const timestamp = request.headers.get('x-slack-request-timestamp')
+  const timestampSeconds = timestamp ? Number(timestamp) : null
+  const timestampSkewSeconds =
+    timestampSeconds !== null && Number.isFinite(timestampSeconds)
+      ? Math.floor(Date.now() / 1000) - timestampSeconds
+      : null
+
+  console.warn('Invalid Slack agent command signature', {
+    api_app_id: formData.get('api_app_id') || null,
+    team_id: formData.get('team_id') || null,
+    team_domain: formData.get('team_domain') || null,
+    command: formData.get('command') || null,
+    channel_id: formData.get('channel_id') || null,
+    user_id: formData.get('user_id') || null,
+    has_signature: Boolean(request.headers.get('x-slack-signature')),
+    has_timestamp: Boolean(timestamp),
+    timestamp_skew_seconds: timestampSkewSeconds,
+    body_length: rawBody.length,
+  })
 }
 
 async function runAgentCommand(


### PR DESCRIPTION
## Summary
- Add safe diagnostic logging when Slack /agent slash command signature verification fails
- Log only non-secret routing metadata such as Slack app id, team id, command, channel/user ids, timestamp health, and body length
- Keep Slack token, response URL, message text, username, signature, raw body, and signing secret out of logs

## Validation
- npm test -- app/api/slack/agent/route.test.ts

## Integration Notes
- Temporary production diagnostic for identifying whether real /agent requests are coming from the expected Slack app/signing secret pair.
- Vercel contexts not yet checked in this PR; production deploy is needed to capture the next real Slack request.