### PR TITLE
fix: reduce Slack signature diagnostic metadata

### DIFF
--- a/app/api/slack/agent/route.test.ts
+++ b/app/api/slack/agent/route.test.ts
@@ -91,11 +91,8 @@ describe('POST /api/slack/agent', () => {
       'Invalid Slack agent command signature',
       expect.objectContaining({
         api_app_id: 'A_TEST_APP',
-        channel_id: 'C_TEST_CHANNEL',
         command: '/agent',
-        team_domain: 'amadutown',
         team_id: 'T_TEST_TEAM',
-        user_id: 'U_TEST_USER',
         has_signature: true,
         has_timestamp: true,
         body_length: expect.any(Number),
@@ -105,6 +102,8 @@ describe('POST /api/slack/agent', () => {
     expect(JSON.stringify(warnSpy.mock.calls)).not.toContain('test-response')
     expect(JSON.stringify(warnSpy.mock.calls)).not.toContain('help')
     expect(JSON.stringify(warnSpy.mock.calls)).not.toContain('vambah')
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toContain('C_TEST_CHANNEL')
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toContain('U_TEST_USER')
     expect(mocks.handleAgentSlackCommand).not.toHaveBeenCalled()
   })
 

--- a/app/api/slack/agent/route.ts
+++ b/app/api/slack/agent/route.ts
@@ -73,10 +73,7 @@ function logInvalidSlackCommandSignature(request: NextRequest, rawBody: string) 
   console.warn('Invalid Slack agent command signature', {
     api_app_id: formData.get('api_app_id') || null,
     team_id: formData.get('team_id') || null,
-    team_domain: formData.get('team_domain') || null,
     command: formData.get('command') || null,
-    channel_id: formData.get('channel_id') || null,
-    user_id: formData.get('user_id') || null,
     has_signature: Boolean(request.headers.get('x-slack-signature')),
     has_timestamp: Boolean(timestamp),
     timestamp_skew_seconds: timestampSkewSeconds,


### PR DESCRIPTION
## Summary
- Reduce invalid Slack signature diagnostic logs to non-sensitive routing/debug fields.
- Stop logging Slack channel/user/domain identifiers on signature failures.
- Keep enough metadata to debug app id, team id, command, missing headers, timestamp skew, and body size.

## Validation
- `npm test -- app/api/slack/agent/route.test.ts`
- Push preflight database health check passed.

## Integration Notes
- No schema or env changes.
- Production `/agent help` was already verified after correcting `SLACK_SIGNING_SECRET`; this PR only narrows failure diagnostics.
- Unrelated untracked file preserved locally: `docs/pixel-wireless-screen-mirroring.md`.
- Vercel contexts not checked yet for this PR: `Vercel – portfolio`, `Vercel – portfolio-staging`.
