### PR TITLE
feat: add proactive Slack stale-run notifications

### DIFF
--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -354,7 +354,7 @@ type AutomationGoalSummary = {
 }
 
 type OperatorActionKind = 'morning-review' | 'hermes' | 'approval-drill' | 'runtime-evaluation'
-type SlackNotificationKind = 'pending_approvals' | 'blockers' | 'review_ready' | 'goal_decisions'
+type SlackNotificationKind = 'pending_approvals' | 'blockers' | 'stale_runs' | 'review_ready' | 'goal_decisions'
 
 const OPERATOR_ACTIONS: Array<{
   kind: OperatorActionKind
@@ -1410,6 +1410,7 @@ function SlackMobileBridgePanel({
   const actions: Array<{ kind: SlackNotificationKind; label: string; description: string }> = [
     { kind: 'pending_approvals', label: 'Send approvals', description: 'Mobile approval cards and trace links.' },
     { kind: 'blockers', label: 'Send blockers', description: 'Blocked work with owner and next step context.' },
+    { kind: 'stale_runs', label: 'Send stale runs', description: 'Failed or stale traces with recovery triage.' },
     { kind: 'goal_decisions', label: 'Send goal decisions', description: 'Goal-tagged tasks waiting on a human call.' },
   ]
 

--- a/app/api/admin/agents/slack-notifications/route.test.ts
+++ b/app/api/admin/agents/slack-notifications/route.test.ts
@@ -86,4 +86,15 @@ describe('POST /api/admin/agents/slack-notifications', () => {
       triggerSource: 'admin_agent_slack_notification',
     }))
   })
+
+  it('accepts stale-run mobile packets', async () => {
+    const response = await POST(request({ kind: 'stale_runs' }) as never)
+
+    expect(response.status).toBe(200)
+    expect(mocks.sendAgentSlackNotification).toHaveBeenCalledWith(expect.objectContaining({
+      kind: 'stale_runs',
+      actorLabel: 'admin@example.com',
+      triggerSource: 'admin_agent_slack_notification',
+    }))
+  })
 })

--- a/app/api/admin/agents/slack-notifications/route.ts
+++ b/app/api/admin/agents/slack-notifications/route.ts
@@ -10,6 +10,7 @@ export const dynamic = 'force-dynamic'
 const VALID_KINDS = new Set<AgentSlackNotificationKind>([
   'pending_approvals',
   'blockers',
+  'stale_runs',
   'review_ready',
   'goal_decisions',
   'standup_blockers',

--- a/lib/agent-slack-actions.test.ts
+++ b/lib/agent-slack-actions.test.ts
@@ -207,4 +207,24 @@ describe('Agent Ops Slack actions', () => {
     expect(mocks.recordAgentWorkItemBlocker).not.toHaveBeenCalled()
     expect(result.text).toContain('Blocker acknowledged')
   })
+
+  it('asks Shaka for stale-run mobile recovery context', async () => {
+    mocks.from.mockReturnValueOnce(queryResult({ data: null, error: null }))
+    mocks.runChiefOfStaffChat.mockResolvedValue({
+      reply: 'The run is stale because the heartbeat stopped. Open Portfolio before mutating recovery state.',
+      runId: 'shaka-run',
+    })
+
+    const result = await handleSlackAgentAction(payload({
+      action: 'run.ask_shaka',
+      runId: 'run-stale',
+    }))
+
+    expect(mocks.runChiefOfStaffChat).toHaveBeenCalledWith(expect.objectContaining({
+      triggerSource: 'slack_agent_action',
+      contextRef: { type: 'run', id: 'run-stale' },
+    }))
+    expect(result.text).toContain('heartbeat stopped')
+    expect(result.text).toContain('/admin/agents/runs/shaka-run')
+  })
 })

--- a/lib/agent-slack-actions.ts
+++ b/lib/agent-slack-actions.ts
@@ -405,6 +405,17 @@ export async function handleSlackAgentAction(payload: SlackInteractivePayload): 
     return { responseType: 'ephemeral', text: `${result.reply}\n\nTrace: ${agentRunsUrl(result.runId)}` }
   }
 
+  if (value.action === 'run.ask_shaka') {
+    if (!value.runId) return { responseType: 'ephemeral', text: 'Missing run id.' }
+    const result = await runChiefOfStaffChat({
+      message: 'Summarize this run for mobile recovery. Include why it is stale or failed, the safest next action, and what must stay in Portfolio.',
+      userId: `slack:${authorization.userId}`,
+      triggerSource: 'slack_agent_action',
+      contextRef: { type: 'run', id: value.runId },
+    })
+    return { responseType: 'ephemeral', text: `${result.reply}\n\nTrace: ${agentRunsUrl(result.runId)}` }
+  }
+
   if (value.action === 'inbox.route') {
     const itemRef = value.workItemId
     if (!itemRef) return { responseType: 'ephemeral', text: 'Missing inbox item reference.' }

--- a/lib/agent-slack-notifications.test.ts
+++ b/lib/agent-slack-notifications.test.ts
@@ -30,6 +30,9 @@ function queryResult(result: unknown) {
   const query: Record<string, unknown> = {
     select: vi.fn(() => query),
     eq: vi.fn(() => query),
+    in: vi.fn(() => query),
+    order: vi.fn(() => query),
+    limit: vi.fn(() => Promise.resolve(result)),
     maybeSingle: vi.fn(() => Promise.resolve(result)),
   }
   return query
@@ -126,5 +129,49 @@ describe('Agent Ops Slack notifications', () => {
     expect(mocks.endAgentRun).toHaveBeenCalledWith(expect.objectContaining({
       status: 'completed',
     }))
+  })
+
+  it('limits work item notification cards to one primary action and one context action', async () => {
+    process.env.SLACK_AGENT_OPS_WEBHOOK_URL = 'https://hooks.slack.test/agent'
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await sendAgentSlackNotification({ kind: 'blockers' })
+
+    const payload = JSON.parse(fetchMock.mock.calls[0][1].body)
+    const actionBlock = payload.blocks.find((block: { type?: string; elements?: unknown[] }) => block.type === 'actions')
+    expect(actionBlock.elements).toHaveLength(2)
+    expect(JSON.stringify(actionBlock)).toContain('work.assign')
+    expect(JSON.stringify(actionBlock)).toContain('Open trace')
+  })
+
+  it('builds stale-run Slack cards with mobile triage and trace links', async () => {
+    process.env.SLACK_AGENT_OPS_WEBHOOK_URL = 'https://hooks.slack.test/agent'
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+    vi.stubGlobal('fetch', fetchMock)
+    mocks.from
+      .mockReturnValueOnce(queryResult({ data: null, error: null }))
+      .mockReturnValueOnce(queryResult({
+        data: [
+          {
+            id: 'run-stale',
+            title: 'Production smoke stale',
+            runtime: 'codex',
+            status: 'stale',
+            current_step: 'Waiting on recovery',
+            error_message: 'No heartbeat',
+            started_at: '2026-05-25T10:00:00.000Z',
+          },
+        ],
+        error: null,
+      }))
+
+    const result = await sendAgentSlackNotification({ kind: 'stale_runs', actorLabel: 'admin' })
+
+    expect(result).toMatchObject({ sent: true, itemCount: 1 })
+    const body = fetchMock.mock.calls[0][1].body as string
+    expect(body).toContain('Stale or failed Agent Ops runs')
+    expect(body).toContain('run.ask_shaka')
+    expect(body).toContain('/admin/agents/runs/run-stale')
   })
 })

--- a/lib/agent-slack-notifications.ts
+++ b/lib/agent-slack-notifications.ts
@@ -6,6 +6,7 @@ import { supabaseAdmin } from '@/lib/supabase'
 export type AgentSlackNotificationKind =
   | 'pending_approvals'
   | 'blockers'
+  | 'stale_runs'
   | 'review_ready'
   | 'goal_decisions'
   | 'standup_blockers'
@@ -45,6 +46,9 @@ type AgentRunSummaryRow = {
   title: string | null
   current_step: string | null
   status: string | null
+  runtime?: string | null
+  error_message?: string | null
+  started_at?: string | null
 }
 
 function baseUrl() {
@@ -131,7 +135,55 @@ function itemSummary(item: AgentWorkItem) {
   return `*${truncateSlack(item.title, 110)}*\nOwner: \`${owner}\` - Status: \`${item.status}\` - Priority: \`${item.priority}\`${blocker}${next}`
 }
 
-function workItemBlocks(title: string, intro: string, items: AgentWorkItem[]) {
+function workItemPrimaryButton(item: AgentWorkItem, kind: AgentSlackNotificationKind) {
+  if (!item.owner_agent_key) {
+    return slackButton({
+      label: 'Assign owner',
+      actionId: 'agent_work_assign_captain',
+      value: { action: 'work.assign', workItemId: item.id, agentKey: 'integration-captain' },
+      style: 'primary',
+    })
+  }
+  if (kind === 'review_ready' || item.status === 'ready_for_review' || item.status === 'ready_for_merge') {
+    return slackButton({
+      label: 'Request revision',
+      actionId: 'agent_work_revision',
+      value: {
+        action: 'work.revision',
+        workItemId: item.id,
+        runId: item.active_run_id ?? undefined,
+        note: 'Revision requested from Slack notification.',
+      },
+    })
+  }
+  if (item.status === 'blocked' || item.blocker_summary) {
+    return slackButton({
+      label: 'Acknowledge',
+      actionId: 'agent_work_acknowledge_blocker',
+      value: {
+        action: 'work.acknowledge',
+        workItemId: item.id,
+        runId: item.active_run_id ?? undefined,
+        note: 'Blocker acknowledged from Slack notification.',
+      },
+    })
+  }
+  return slackButton({
+    label: 'Ask Shaka',
+    actionId: 'agent_work_ask_shaka',
+    value: { action: 'work.ask_shaka', workItemId: item.id, runId: item.active_run_id ?? undefined },
+  })
+}
+
+function workItemContextButton(item: AgentWorkItem) {
+  return slackButton({
+    label: item.active_run_id || item.source_run_id ? 'Open trace' : 'Open Kanban',
+    actionId: item.active_run_id || item.source_run_id ? 'open_trace' : 'open_kanban',
+    url: workItemHref(item),
+  })
+}
+
+function workItemBlocks(title: string, intro: string, items: AgentWorkItem[], kind: AgentSlackNotificationKind) {
   const blocks: SlackBlock[] = [
     { type: 'section', text: mrkdwn(`*${title}*\n${intro}`) },
   ]
@@ -148,12 +200,8 @@ function workItemBlocks(title: string, intro: string, items: AgentWorkItem[]) {
     blocks.push({
       type: 'actions',
       elements: [
-        slackButton({ label: 'Open trace', actionId: 'open_trace', url: workItemHref(item) }),
-        slackButton({
-          label: 'Ask Shaka',
-          actionId: 'agent_work_ask_shaka',
-          value: { action: 'work.ask_shaka', workItemId: item.id, runId: item.active_run_id ?? undefined },
-        }),
+        workItemPrimaryButton(item, kind),
+        workItemContextButton(item),
       ],
     })
   }
@@ -175,24 +223,39 @@ async function buildPendingApprovalPayload() {
   }
   for (const approval of approvals) {
     const run = runs.get(approval.run_id)
+    const canDecideInSlack = approval.approval_type === 'vercel_deployment_research_proposal'
     blocks.push({
       type: 'section',
       text: mrkdwn([
         `*${truncateSlack(run?.title ?? approval.run_id, 120)}*`,
         `Type: \`${approval.approval_type}\` - Status: \`${approval.status}\``,
         run?.current_step ? `Step: ${truncateSlack(run.current_step, 140)}` : null,
+        canDecideInSlack
+          ? 'Primary action: approve only after the trace evidence matches the packet.'
+          : 'Primary action: open Portfolio because this approval crosses a protected boundary.',
       ].filter(Boolean).join('\n')),
     })
     blocks.push({
       type: 'actions',
       elements: [
+        canDecideInSlack
+          ? slackButton({
+              label: 'Approve',
+              actionId: 'agent_approval_approve',
+              style: 'primary',
+              value: { action: 'approval.approve', approvalId: approval.id, runId: approval.run_id },
+              confirmText: `Approve ${run?.title ?? approval.run_id}?`,
+            })
+          : slackButton({
+              label: 'Open decision',
+              actionId: 'open_decision',
+              url: agentUrl(`/admin/agents/coordination?approvalRunId=${approval.run_id}`),
+            }),
         slackButton({
           label: 'Ask Shaka',
           actionId: 'agent_approval_ask_shaka',
           value: { action: 'approval.ask_shaka', approvalId: approval.id, runId: approval.run_id },
         }),
-        slackButton({ label: 'Open decision', actionId: 'open_decision', url: agentUrl(`/admin/agents/coordination?approvalRunId=${approval.run_id}`) }),
-        slackButton({ label: 'Open trace', actionId: 'open_trace', url: agentUrl(`/admin/agents/runs/${approval.run_id}`) }),
       ],
     })
   }
@@ -200,6 +263,59 @@ async function buildPendingApprovalPayload() {
     text: `${approvals.length} pending Agent Ops approval(s) need review.`,
     blocks,
     itemCount: approvals.length,
+  }
+}
+
+async function staleRuns(limit = 5) {
+  if (!supabaseAdmin) throw new Error('Database not available')
+  const { data, error } = await supabaseAdmin
+    .from('agent_runs')
+    .select('id, title, runtime, status, current_step, error_message, started_at')
+    .in('status', ['failed', 'stale'])
+    .order('started_at', { ascending: false })
+    .limit(limit)
+  if (error) throw new Error(`Failed to read stale runs: ${error.message}`)
+  return (data ?? []) as AgentRunSummaryRow[]
+}
+
+async function buildStaleRunsPayload() {
+  const runs = await staleRuns()
+  const blocks: SlackBlock[] = [
+    { type: 'section', text: mrkdwn('*Stale or failed Agent Ops runs*\nUse this when a trace needs mobile recovery triage. Slack can summarize the next step; recovery mutations stay in Portfolio.') },
+  ]
+  if (!runs.length) {
+    blocks.push({ type: 'section', text: mrkdwn('No stale or failed runs need mobile action.') })
+    blocks.push({
+      type: 'actions',
+      elements: [slackButton({ label: 'Open Run Console', actionId: 'open_run_console', url: agentUrl('/admin/agents/runs') })],
+    })
+  }
+  for (const run of runs) {
+    blocks.push({
+      type: 'section',
+      text: mrkdwn([
+        `*${truncateSlack(run.title ?? run.id, 120)}*`,
+        `Status: \`${run.status ?? 'unknown'}\` - Runtime: \`${run.runtime ?? 'unknown'}\``,
+        run.current_step ? `Step: ${truncateSlack(run.current_step, 140)}` : null,
+        run.error_message ? `Problem: ${truncateSlack(run.error_message, 160)}` : null,
+      ].filter(Boolean).join('\n')),
+    })
+    blocks.push({
+      type: 'actions',
+      elements: [
+        slackButton({
+          label: 'Ask Shaka',
+          actionId: 'agent_run_ask_shaka',
+          value: { action: 'run.ask_shaka', runId: run.id },
+        }),
+        slackButton({ label: 'Open trace', actionId: 'open_trace', url: agentUrl(`/admin/agents/runs/${run.id}`) }),
+      ],
+    })
+  }
+  return {
+    text: `${runs.length} stale or failed Agent Ops run(s) need mobile triage.`,
+    blocks,
+    itemCount: runs.length,
   }
 }
 
@@ -237,13 +353,14 @@ async function buildWorkItemPayload(input: AgentSlackNotificationInput) {
   items = filterTargetAgents(items, targetAgentKeys).sort(prioritySort).slice(0, 5)
   return {
     text: `${title}: ${items.length} item(s).`,
-    blocks: workItemBlocks(title, intro, items),
+    blocks: workItemBlocks(title, intro, items, input.kind),
     itemCount: items.length,
   }
 }
 
 export async function buildAgentSlackNotificationPayload(input: AgentSlackNotificationInput) {
   if (input.kind === 'pending_approvals') return buildPendingApprovalPayload()
+  if (input.kind === 'stale_runs') return buildStaleRunsPayload()
   return buildWorkItemPayload(input)
 }
 


### PR DESCRIPTION
Summary
- Adds stale/failed run packets to the Agent Ops Slack mobile bridge so Mission Control can push recovery triage to Slack.
- Adds a Slack `run.ask_shaka` action that returns run-scoped recovery guidance without mutating Portfolio state.
- Tightens Slack work-item notification cards to one primary CTA plus one context CTA, and keeps high-risk approval decisions routed through Portfolio.

Validation
- npm test -- lib/agent-slack-notifications.test.ts lib/agent-slack-actions.test.ts app/api/admin/agents/slack-notifications/route.test.ts app/admin/agents/page.test.tsx
- npx tsc --noEmit --pretty false
- npm run lint
- Push hook database health check passed.

Integration Notes
- Conflict preflight: branch was created from main after fetch; open PRs #406, #405, and #404 did not overlap this Slack notification slice.
- Unrelated local files preserved and not committed: docs/pixel-wireless-screen-mirroring.md, scripts/mirror-pixel.sh.
- No Slack app config, credential, production activation, outbound customer-data mutation, or Vercel setting changes are included.
- Vercel – portfolio and Vercel – portfolio-staging should be verified by the Integration Captain after merge/deploy.