### PR TITLE
docs: add Pixel mirroring runbook

### DIFF
--- a/docs/pixel-wireless-screen-mirroring.md
+++ b/docs/pixel-wireless-screen-mirroring.md
@@ -1,0 +1,157 @@
+# Google Pixel Wireless Screen Mirroring On Mac
+
+Use `scrcpy` and Android Debug Bridge (`adb`) to mirror a Google Pixel screen on this Mac without a USB cable.
+
+## One-Time Install
+
+```bash
+brew install scrcpy android-platform-tools
+```
+
+## Pixel Setup
+
+1. Connect the Pixel and Mac to the same normal Wi-Fi network.
+2. On the Pixel, open **Settings -> About phone**.
+3. Tap **Build number** 7 times to enable Developer options.
+4. Open **Settings -> System -> Developer options**.
+5. Turn on **Wireless debugging**.
+6. Tap **Wireless debugging**.
+7. Tap **Pair device with pairing code** and leave that screen open.
+
+## Pair Wirelessly
+
+On the Mac, use the IP address and pairing port shown on the Pixel:
+
+```bash
+adb pair PHONE_IP:PAIRING_PORT
+```
+
+Enter the 6-digit pairing code from the Pixel.
+
+Example:
+
+```bash
+adb pair 192.168.4.26:38981
+```
+
+After pairing, return to the main **Wireless debugging** screen on the Pixel. Use the regular **IP address & Port** value, not the temporary pairing port:
+
+```bash
+adb connect PHONE_IP:CONNECT_PORT
+```
+
+Example:
+
+```bash
+adb connect 192.168.4.26:43343
+```
+
+Confirm the device is visible:
+
+```bash
+adb devices
+```
+
+Expected result:
+
+```text
+List of devices attached
+192.168.4.26:43343    device
+```
+
+## Start Mirroring
+
+```bash
+scrcpy -s 192.168.4.26:43343
+```
+
+If the IP or port changes, replace `192.168.4.26:43343` with the current **IP address & Port** from the Pixel's Wireless debugging screen.
+
+## If Scrcpy Says Multiple Devices
+
+If `scrcpy` reports multiple ADB devices, choose the Pixel explicitly:
+
+```bash
+scrcpy -s 192.168.4.26:43343
+```
+
+This happens when ADB sees the same Pixel twice, once by IP and once by the mDNS name.
+
+Optional cleanup:
+
+```bash
+adb disconnect 192.168.4.26:43343
+adb devices
+```
+
+Then use the remaining serial shown by `adb devices`:
+
+```bash
+scrcpy -s SERIAL_FROM_ADB_DEVICES
+```
+
+## Tailscale Or VPN Gotcha
+
+If pairing fails with an error like this:
+
+```text
+error: protocol fault (couldn't read status message): Undefined error: 0
+```
+
+Check whether the Pixel IP starts with `100.x.x.x`, such as `100.66.105.99`. That is usually a Tailscale or VPN address. Wireless ADB pairing can fail through that interface.
+
+Fix:
+
+1. Temporarily turn off Tailscale or VPN on the Pixel.
+2. Temporarily turn off Tailscale or VPN on the Mac.
+3. Toggle **Wireless debugging** off and back on.
+4. Pair again using the normal Wi-Fi IP, usually `192.168.x.x`, `10.x.x.x`, or `172.16-31.x.x`.
+
+## Fast Repeat Flow
+
+When already paired and the port has not changed:
+
+```bash
+adb connect 192.168.4.26:43343
+scrcpy -s 192.168.4.26:43343
+```
+
+## Agent Activation Rule
+
+Use this rule in project or global agent instructions:
+
+```text
+When Vambah asks to mirror, open, cast, or control his Google Pixel from this Mac, run:
+
+  bash /Users/vambahsillah/Projects/Portfolio/scripts/mirror-pixel.sh
+
+Do not walk through the full setup unless the script fails. If ADB cannot see the Pixel, ask Vambah to turn on Pixel Wireless debugging and provide the current IP address & Port from Settings -> System -> Developer options -> Wireless debugging. If pairing fails or the IP starts with 100.x.x.x, have Vambah disable Tailscale/VPN and use the normal Wi-Fi IP.
+```
+
+## Scripted Agent Flow
+
+The helper script lives at:
+
+```bash
+/Users/vambahsillah/Projects/Portfolio/scripts/mirror-pixel.sh
+```
+
+Default command:
+
+```bash
+bash /Users/vambahsillah/Projects/Portfolio/scripts/mirror-pixel.sh
+```
+
+If the wireless debugging port changes, reconnect first:
+
+```bash
+adb connect PHONE_IP:CONNECT_PORT
+bash /Users/vambahsillah/Projects/Portfolio/scripts/mirror-pixel.sh
+```
+
+To pin a known endpoint for a single run:
+
+```bash
+PIXEL_ADB_ENDPOINT=192.168.4.26:43343 \
+  bash /Users/vambahsillah/Projects/Portfolio/scripts/mirror-pixel.sh
+```

--- a/scripts/mirror-pixel.sh
+++ b/scripts/mirror-pixel.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Mirror a paired Google Pixel on this Mac with scrcpy.
+
+Usage:
+  scripts/mirror-pixel.sh [scrcpy args...]
+
+Optional environment:
+  PIXEL_ADB_ENDPOINT=192.168.4.26:43343
+  PIXEL_ADB_SERIAL=adb-..._adb-tls-connect._tcp
+
+If no endpoint or serial is provided, the script selects a connected ADB device,
+preferring a normal IP:port serial when duplicate mDNS entries exist.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+for command in adb scrcpy; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    echo "Missing required command: $command" >&2
+    echo "Install with: brew install scrcpy android-platform-tools" >&2
+    exit 1
+  fi
+done
+
+adb start-server >/dev/null
+
+if [[ -n "${PIXEL_ADB_ENDPOINT:-}" ]]; then
+  adb connect "$PIXEL_ADB_ENDPOINT" >/dev/null || true
+fi
+
+devices=()
+while IFS= read -r serial; do
+  [[ -n "$serial" ]] && devices+=("$serial")
+done < <(adb devices | awk 'NR > 1 && $2 == "device" { print $1 }')
+
+target="${PIXEL_ADB_SERIAL:-}"
+
+if [[ -z "$target" && -n "${PIXEL_ADB_ENDPOINT:-}" ]]; then
+  target="$PIXEL_ADB_ENDPOINT"
+fi
+
+if [[ -z "$target" && "${#devices[@]}" -eq 1 ]]; then
+  target="${devices[0]}"
+fi
+
+if [[ -z "$target" && "${#devices[@]}" -gt 1 ]]; then
+  for serial in "${devices[@]}"; do
+    if [[ "$serial" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+:[0-9]+$ ]]; then
+      target="$serial"
+      break
+    fi
+  done
+fi
+
+if [[ -z "$target" && "${#devices[@]}" -gt 0 ]]; then
+  target="${devices[0]}"
+fi
+
+if [[ -z "$target" ]]; then
+  cat >&2 <<'ERROR'
+No paired Pixel is currently visible to ADB.
+
+On the Pixel:
+  1. Open Settings -> System -> Developer options -> Wireless debugging.
+  2. Make sure Wireless debugging is on.
+  3. If already paired, copy the current IP address & Port.
+
+Then run:
+  adb connect PHONE_IP:CONNECT_PORT
+  scripts/mirror-pixel.sh
+
+Avoid Tailscale/VPN 100.x.x.x addresses for pairing. Use the normal Wi-Fi IP.
+ERROR
+  exit 1
+fi
+
+echo "Starting Pixel mirror with ADB target: $target"
+exec scrcpy -s "$target" "$@"
+


### PR DESCRIPTION
## Summary
- add a local runbook for mirroring a Google Pixel from this Mac with adb and scrcpy
- add an executable helper script that selects a connected Pixel target and launches scrcpy
- retire the empty temporary proposal_id residue locally instead of committing it

## Validation
- bash -n scripts/mirror-pixel.sh
- bash scripts/mirror-pixel.sh --help
- push-hook database health check passed

## Integration Notes
- Docs/local tooling only; no app runtime, schema, credential, workflow, or production data mutation.
- The helper requires local adb and scrcpy installation before use.
- Vercel contexts should still be checked after merge per Portfolio policy.