### PR TITLE
feat: project decision trust into open brain

### DIFF
--- a/app/admin/agents/governance/page.test.tsx
+++ b/app/admin/agents/governance/page.test.tsx
@@ -184,6 +184,7 @@ describe('AgentGovernancePage', () => {
     expect(within(decisionTrust).getByText('60%')).toBeInTheDocument()
     expect(within(decisionTrust).getByText(/Missing evidence: Human approval decision, Post-approval execution trace/i)).toBeInTheDocument()
     expect(within(decisionTrust).getByText(/Approval: payment_make_vendor_payment · Reversibility: hard/i)).toBeInTheDocument()
+    expect(within(decisionTrust).getByRole('link', { name: /Inspect in Open Brain/i })).toHaveAttribute('href', '/admin/agents/open-brain')
     expect(within(decisionTrust).getByRole('link', { name: /make_vendor_payment/i })).toHaveAttribute('href', '/admin/agents/runs/trust-run')
     expect(within(governancePanel).getByRole('link', { name: /Export client audit/i })).toHaveAttribute('href', '/api/admin/agents/governance/export?format=markdown')
     expect(within(governancePanel).getByRole('link', { name: /Export audit JSON/i })).toHaveAttribute('href', '/api/admin/agents/governance/export?format=json')

--- a/app/admin/agents/open-brain/page.test.tsx
+++ b/app/admin/agents/open-brain/page.test.tsx
@@ -382,6 +382,7 @@ describe('OpenBrainPage', () => {
     expect(within(map).getByText('Context health')).toBeInTheDocument()
     expect(within(map).getByText('Relationship strength')).toBeInTheDocument()
     expect(within(map).getByText('Edge status')).toBeInTheDocument()
+    expect(within(map).getAllByText('Decision Trust').length).toBeGreaterThan(0)
 
     fireEvent.click(within(map).getByRole('button', { name: 'weak 1' }))
 
@@ -422,6 +423,91 @@ describe('OpenBrainPage', () => {
         }),
       },
       reason: expect.stringContaining('insight-1'),
+    }))
+  })
+
+  it('renders decision trust graph insights and keeps review proposals approval-gated', async () => {
+    const snapshot = JSON.parse(JSON.stringify(openBrainSnapshot))
+    snapshot.relationshipMap.nodes.push({
+      id: 'event:decision-trust:decision-payment',
+      label: 'Decision trust: make_vendor_payment',
+      type: 'event',
+      kind: 'agent_decision_trust_observed',
+      privacyTier: 'internal_ops',
+      summary: 'Spend decision recommended human review.',
+      path: '/admin/agents/runs/run-trust',
+      health: 'yellow',
+      decisionTrustGate: 'human_review',
+      x: 28,
+      y: 82,
+    })
+    snapshot.relationshipMap.insights.unshift({
+      id: 'insight:decision-trust:decision-payment',
+      kind: 'decision_trust_review',
+      severity: 'medium',
+      title: 'Review decision trust: make_vendor_payment',
+      detail: 'Decision decision-payment recommended human_review for spend.',
+      recommendation: 'Resolve the candidate before relying on this decision as trust evidence.',
+      actionLabel: 'Record review proposal',
+      sourceNodeId: 'event:decision-trust:decision-payment',
+      targetNodeId: null,
+      decisionTrust: {
+        decisionId: 'decision-payment',
+        linkedRunId: 'run-trust',
+        selectedCandidate: 'make_vendor_payment',
+        recommendedGate: 'human_review',
+        scores: {
+          relationshipTrust: 0.57,
+          decisionRisk: 0.72,
+          evidenceCompleteness: 0.6,
+        },
+        evidenceSummary: 'Trust 57%. Risk 72%. Evidence 60%.',
+      },
+    })
+
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith('/api/admin/agents/open-brain/proposals') && init?.method === 'POST') {
+        return {
+          ok: true,
+          json: async () => ({
+            proposal: {
+              id: 'proposal:decision-trust-review',
+              status: 'pending',
+              proposedMemory: {
+                title: 'Relationship proposal: Review decision trust: make_vendor_payment',
+              },
+            },
+          }),
+        }
+      }
+      return { ok: true, json: async () => snapshot }
+    }))
+
+    render(<OpenBrainPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Map' }))
+    const map = await screen.findByRole('region', { name: 'Open Brain relationship map' })
+    expect(within(map).getByText('Review decision trust: make_vendor_payment')).toBeInTheDocument()
+    expect(within(map).getByText('human review')).toBeInTheDocument()
+
+    fireEvent.click(within(map).getByRole('button', { name: 'Human/block gate 1' }))
+    expect(within(map).getByText('1 active filter(s)')).toBeInTheDocument()
+    expect(within(map).getByText('Showing 1 node(s) and 0 relationship(s).')).toBeInTheDocument()
+
+    fireEvent.click(within(map).getByRole('button', { name: 'Record review proposal' }))
+    expect(await screen.findByText('Relationship proposal created for review: Relationship proposal: Review decision trust: make_vendor_payment. No Open Brain link was changed.')).toBeInTheDocument()
+
+    const proposalCall = vi.mocked(fetch).mock.calls.find(([url, init]) => (
+      String(url).endsWith('/api/admin/agents/open-brain/proposals') && init?.method === 'POST'
+    ))
+    expect(JSON.parse(String(proposalCall?.[1]?.body))).toEqual(expect.objectContaining({
+      metadata: {
+        decisionTrust: expect.objectContaining({
+          decisionId: 'decision-payment',
+          recommendedGate: 'human_review',
+        }),
+      },
     }))
   })
 

--- a/app/admin/agents/open-brain/page.tsx
+++ b/app/admin/agents/open-brain/page.tsx
@@ -33,6 +33,7 @@ type RelationshipFilterValue = 'all'
 type RelationshipHealthFilter = RelationshipFilterValue | 'green' | 'yellow' | 'red'
 type RelationshipStrengthFilter = RelationshipFilterValue | 'strong' | 'medium' | 'weak'
 type RelationshipStatusFilter = RelationshipFilterValue | 'persisted' | 'inferred' | 'recommended'
+type DecisionTrustFilter = RelationshipFilterValue | 'decision_trust' | 'high_risk_gate'
 
 export default function OpenBrainPage() {
   return (
@@ -619,11 +620,15 @@ function RelationshipMapView({
   const [healthFilter, setHealthFilter] = useState<RelationshipHealthFilter>('all')
   const [strengthFilter, setStrengthFilter] = useState<RelationshipStrengthFilter>('all')
   const [statusFilter, setStatusFilter] = useState<RelationshipStatusFilter>('all')
+  const [decisionTrustFilter, setDecisionTrustFilter] = useState<DecisionTrustFilter>('all')
   const map = snapshot.relationshipMap
   const visibleNodes = map.nodes.filter((node) => (
     (typeFilter === 'all' || node.type === typeFilter) &&
     (privacyFilter === 'all' || node.privacyTier === privacyFilter) &&
-    (healthFilter === 'all' || node.health === healthFilter)
+    (healthFilter === 'all' || node.health === healthFilter) &&
+    (decisionTrustFilter === 'all' ||
+      (decisionTrustFilter === 'decision_trust' && node.kind === 'agent_decision_trust_observed') ||
+      (decisionTrustFilter === 'high_risk_gate' && (node.decisionTrustGate === 'human_review' || node.decisionTrustGate === 'block')))
   ))
   const visibleNodeIds = new Set(visibleNodes.map((node) => node.id))
   const visibleEdges = map.edges.filter((edge) => (
@@ -638,11 +643,12 @@ function RelationshipMapView({
   const healthValues: RelationshipHealthFilter[] = ['all', 'green', 'yellow', 'red']
   const strengthValues: RelationshipStrengthFilter[] = ['all', 'strong', 'medium', 'weak']
   const statusValues: RelationshipStatusFilter[] = ['all', 'persisted', 'inferred', 'recommended']
+  const decisionTrustValues: DecisionTrustFilter[] = ['all', 'decision_trust', 'high_risk_gate']
   const selectedPath = visibleEdges.find((edge) => edge.strength === 'strong') || visibleEdges[0]
   const selectedFrom = selectedPath ? nodeById.get(selectedPath.fromId) : null
   const selectedTo = selectedPath ? nodeById.get(selectedPath.toId) : null
   const graphMinHeight = Math.max(620, Math.ceil(visibleNodes.length / 4) * 132)
-  const activeFilterCount = [typeFilter, privacyFilter, healthFilter, strengthFilter, statusFilter].filter((value) => value !== 'all').length
+  const activeFilterCount = [typeFilter, privacyFilter, healthFilter, strengthFilter, statusFilter, decisionTrustFilter].filter((value) => value !== 'all').length
 
   function resetFilters() {
     setTypeFilter('all')
@@ -650,6 +656,7 @@ function RelationshipMapView({
     setHealthFilter('all')
     setStrengthFilter('all')
     setStatusFilter('all')
+    setDecisionTrustFilter('all')
   }
 
   return (
@@ -731,6 +738,18 @@ function RelationshipMapView({
               />
             ))}
             </RelationshipFilterGroup>
+
+            <RelationshipFilterGroup label="Decision Trust">
+            {decisionTrustValues.map((value) => (
+              <RelationshipFilterButton
+                key={value}
+                active={decisionTrustFilter === value}
+                count={decisionTrustCount(map.nodes, value)}
+                onClick={() => setDecisionTrustFilter(value)}
+                label={decisionTrustLabel(value)}
+              />
+            ))}
+            </RelationshipFilterGroup>
           </div>
           <div className="mt-5 rounded-lg border border-silicon-slate/60 bg-background/20 p-3 text-xs text-muted-foreground">
             <div className="flex items-center justify-between gap-3">
@@ -800,6 +819,11 @@ function RelationshipMapView({
               <span className="text-[10px] font-extrabold uppercase tracking-[0.12em] opacity-75">{node.type}</span>
               <span className="mt-1 line-clamp-2 text-xs font-semibold leading-4">{node.label}</span>
               <span className="mt-1 text-[10px] opacity-70">{node.kind.replace(/_/g, ' ')}</span>
+              {node.decisionTrustGate ? (
+                <span className="mt-1 text-[10px] font-semibold uppercase tracking-[0.08em] opacity-80">
+                  {node.decisionTrustGate.replace(/_/g, ' ')}
+                </span>
+              ) : null}
             </div>
           ))}
           <div className="absolute bottom-5 left-5 z-10 flex flex-wrap gap-3 rounded-lg border border-silicon-slate/60 bg-black/30 p-3 text-xs text-muted-foreground backdrop-blur">
@@ -882,15 +906,8 @@ function buildRelationshipProposalPayload(snapshot: OpenBrainSnapshot, insight: 
       : 'Authority boundary: this proposal records the recommended relationship context for review; no link record is created unless a target relationship is explicit.',
   ].join('\n')
 
-  return {
-    kind: 'workflow',
-    title,
-    body,
-    privacyTier: strongestPrivacyTier([sourceNode?.privacyTier, targetNode?.privacyTier]),
-    confidence: insight.severity === 'high' ? 0.84 : insight.severity === 'medium' ? 0.78 : 0.72,
-    sourceIds,
-    reason: `Created from Open Brain relationship map insight ${insight.id}. Review before durable memory or link changes.`,
-    metadata: sourceNode && targetNode ? {
+  const metadata = {
+    ...(sourceNode && targetNode ? {
       relationship: {
         fromId: sourceNode.id,
         toId: targetNode.id,
@@ -900,7 +917,19 @@ function buildRelationshipProposalPayload(snapshot: OpenBrainSnapshot, insight: 
         sourceLabel: sourceNode.label,
         targetLabel: targetNode.label,
       },
-    } : undefined,
+    } : {}),
+    ...(insight.decisionTrust ? { decisionTrust: insight.decisionTrust } : {}),
+  }
+
+  return {
+    kind: 'workflow',
+    title,
+    body,
+    privacyTier: insight.decisionTrust ? 'internal_ops' : strongestPrivacyTier([sourceNode?.privacyTier, targetNode?.privacyTier]),
+    confidence: insight.severity === 'high' ? 0.84 : insight.severity === 'medium' ? 0.78 : 0.72,
+    sourceIds,
+    reason: `Created from Open Brain relationship map insight ${insight.id}. Review before durable memory or link changes.`,
+    metadata: Object.keys(metadata).length ? metadata : undefined,
   }
 }
 
@@ -908,7 +937,20 @@ function relationshipNameForInsight(insight: OpenBrainRelationshipInsight) {
   if (insight.kind === 'strengthen') return 'governed_by'
   if (insight.kind === 'missing_governance') return 'needs_governing_context'
   if (insight.kind === 'merge_duplicate') return 'possible_duplicate'
+  if (insight.kind === 'decision_trust_review') return 'requires_trust_review'
   return 'needs_review'
+}
+
+function decisionTrustLabel(value: DecisionTrustFilter) {
+  if (value === 'decision_trust') return 'Decision Trust'
+  if (value === 'high_risk_gate') return 'Human/block gate'
+  return 'All decisions'
+}
+
+function decisionTrustCount(nodes: OpenBrainSnapshot['relationshipMap']['nodes'], value: DecisionTrustFilter) {
+  if (value === 'decision_trust') return nodes.filter((node) => node.kind === 'agent_decision_trust_observed').length
+  if (value === 'high_risk_gate') return nodes.filter((node) => node.decisionTrustGate === 'human_review' || node.decisionTrustGate === 'block').length
+  return nodes.length
 }
 
 function strongestPrivacyTier(tiers: Array<OpenBrainPrivacyTier | undefined>): OpenBrainPrivacyTier {

--- a/app/api/admin/agents/open-brain/route.test.ts
+++ b/app/api/admin/agents/open-brain/route.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   verifyAdmin: vi.fn(),
   isAuthError: vi.fn(),
   getOpenBrainSnapshot: vi.fn(),
+  supabaseFrom: vi.fn(),
 }))
 
 vi.mock('@/lib/auth-server', () => ({
@@ -13,6 +14,12 @@ vi.mock('@/lib/auth-server', () => ({
 
 vi.mock('@/lib/open-brain', () => ({
   getOpenBrainSnapshot: mocks.getOpenBrainSnapshot,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.supabaseFrom,
+  },
 }))
 
 import { GET } from './route'
@@ -32,6 +39,15 @@ describe('GET /api/admin/agents/open-brain', () => {
       generatedAt: '2026-05-10T12:00:00.000Z',
       service: { available: true, storage: 'local_jsonl' },
       overview: { sources: 3, memories: 1, pendingProposals: 2 },
+    })
+    mocks.supabaseFrom.mockReturnValue({
+      select: () => ({
+        eq: () => ({
+          order: () => ({
+            limit: async () => ({ data: [], error: null }),
+          }),
+        }),
+      }),
     })
   })
 
@@ -54,5 +70,60 @@ describe('GET /api/admin/agents/open-brain', () => {
       generatedAt: '2026-05-10T12:00:00.000Z',
       overview: expect.objectContaining({ sources: 3 }),
     }))
+    expect(mocks.supabaseFrom).toHaveBeenCalledWith('agent_run_events')
+  })
+
+  it('passes recent decision trust frames into the Open Brain snapshot', async () => {
+    mocks.supabaseFrom.mockReturnValueOnce({
+      select: () => ({
+        eq: () => ({
+          order: () => ({
+            limit: async () => ({
+              data: [
+                {
+                  run_id: 'run-trust',
+                  event_type: 'agent_decision_trust_recorded',
+                  severity: 'warning',
+                  message: 'Decision trust recorded.',
+                  occurred_at: '2026-05-27T12:00:00.000Z',
+                  metadata: {
+                    decision_id: 'decision-payment',
+                    agent_key: 'chief-of-staff',
+                    decision_type: 'spend',
+                    objective: 'Create a payment checkpoint.',
+                    selected_candidate: 'make_vendor_payment',
+                    candidates_considered: ['make_vendor_payment'],
+                    trust_signals: ['Agent Ops source run linked'],
+                    risk_signals: ['Payment or spend authority requested'],
+                    missing_evidence: ['Human approval decision'],
+                    scores: {
+                      relationshipTrust: 0.57,
+                      decisionRisk: 0.72,
+                      evidenceCompleteness: 0.6,
+                    },
+                    recommended_gate: 'human_review',
+                    approval_type: 'payment_make_vendor_payment',
+                    reversibility: 'hard',
+                  },
+                },
+              ],
+              error: null,
+            }),
+          }),
+        }),
+      }),
+    })
+
+    await GET(makeRequest() as never)
+
+    expect(mocks.getOpenBrainSnapshot).toHaveBeenCalledWith(undefined, {
+      decisionTrustFrames: [
+        expect.objectContaining({
+          run_id: 'run-trust',
+          decision_id: 'decision-payment',
+          recommended_gate: 'human_review',
+        }),
+      ],
+    })
   })
 })

--- a/app/api/admin/agents/open-brain/route.ts
+++ b/app/api/admin/agents/open-brain/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { AGENT_DECISION_TRUST_EVENT } from '@/lib/agent-decision-trust'
+import { parseDecisionTrustFrames, type GovernanceEventSummary } from '@/lib/agent-governance'
 import { getOpenBrainSnapshot } from '@/lib/open-brain'
 
 export const dynamic = 'force-dynamic'
@@ -11,6 +13,32 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: auth.error }, { status: auth.status })
   }
 
-  const snapshot = await getOpenBrainSnapshot()
+  const decisionTrustFrames = await loadDecisionTrustFrames()
+  const snapshot = decisionTrustFrames.length
+    ? await getOpenBrainSnapshot(undefined, { decisionTrustFrames })
+    : await getOpenBrainSnapshot()
   return NextResponse.json(snapshot)
+}
+
+async function loadDecisionTrustFrames() {
+  try {
+    const { supabaseAdmin } = await import('@/lib/supabase')
+    if (!supabaseAdmin) return []
+    const { data, error } = await supabaseAdmin
+      .from('agent_run_events')
+      .select('run_id, event_type, severity, message, occurred_at, metadata')
+      .eq('event_type', AGENT_DECISION_TRUST_EVENT)
+      .order('occurred_at', { ascending: false })
+      .limit(25)
+
+    if (error) {
+      console.warn('[open-brain] decision trust projection unavailable:', error.message)
+      return []
+    }
+
+    return parseDecisionTrustFrames((data ?? []) as GovernanceEventSummary[], 25)
+  } catch (error) {
+    console.warn('[open-brain] decision trust projection skipped:', error)
+    return []
+  }
 }

--- a/components/admin/agents/AgentGovernancePanel.tsx
+++ b/components/admin/agents/AgentGovernancePanel.tsx
@@ -272,6 +272,15 @@ function DecisionTrustPanel({ frames }: { frames: AgentGovernanceSnapshot['recen
           {latest ? latest.recommended_gate.replace(/_/g, ' ') : 'shadow mode'}
         </StatusOnlyPill>
       </div>
+      {latest ? (
+        <Link
+          href="/admin/agents/open-brain"
+          className="mt-3 inline-flex items-center gap-2 rounded-md border border-radiant-gold/35 bg-radiant-gold/10 px-3 py-2 text-xs font-medium text-radiant-gold hover:border-radiant-gold/60"
+        >
+          <ArrowRight size={14} />
+          Inspect in Open Brain
+        </Link>
+      ) : null}
 
       {latest ? (
         <Link

--- a/lib/agent-governance.test.ts
+++ b/lib/agent-governance.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildAgentCapabilityProfiles, buildAgentGovernanceSnapshot } from './agent-governance'
+import { buildAgentCapabilityProfiles, buildAgentGovernanceSnapshot, parseDecisionTrustFrames } from './agent-governance'
 
 describe('agent governance', () => {
   it('derives least-privilege capability profiles from the agent organization', () => {
@@ -153,5 +153,46 @@ describe('agent governance', () => {
       run_id: 'run-shaka',
       client_project_id: 'client-456',
     })
+  })
+
+  it('exports a safe decision trust parser with configurable limits', () => {
+    const events = Array.from({ length: 7 }, (_, index) => ({
+      run_id: `run-${index}`,
+      event_type: 'agent_decision_trust_recorded',
+      severity: 'info',
+      message: 'Decision trust recorded.',
+      occurred_at: `2026-05-21T00:0${index}:00.000Z`,
+      metadata: {
+        decision_id: `decision-${index}`,
+        agent_key: 'chief-of-staff',
+        decision_type: 'tool',
+        objective: 'Choose a tool.',
+        selected_candidate: `tool-${index}`,
+        candidates_considered: [`tool-${index}`],
+        trust_signals: ['Official source match'],
+        risk_signals: ['Read-only use'],
+        missing_evidence: [],
+        scores: {
+          relationshipTrust: 0.75,
+          decisionRisk: 0.2,
+          evidenceCompleteness: 0.88,
+        },
+        recommended_gate: 'allow',
+        approval_type: null,
+        reversibility: 'easy',
+      },
+    }))
+
+    expect(parseDecisionTrustFrames(events, 3)).toHaveLength(3)
+    expect(parseDecisionTrustFrames([
+      {
+        run_id: 'run-bad',
+        event_type: 'agent_decision_trust_recorded',
+        severity: 'info',
+        message: 'Malformed frame ignored.',
+        occurred_at: '2026-05-21T00:00:00.000Z',
+        metadata: { decision_id: 'bad', recommended_gate: 'allow' },
+      },
+    ])).toEqual([])
   })
 })

--- a/lib/agent-governance.ts
+++ b/lib/agent-governance.ts
@@ -346,7 +346,10 @@ function isDecisionTrustGate(value: string | null): value is DecisionTrustGate {
   return value === 'allow' || value === 'sandbox' || value === 'human_review' || value === 'block'
 }
 
-function recentDecisionTrustFrames(events: GovernanceEventSummary[]): AgentGovernanceSnapshot['recent_decision_trust_frames'] {
+export function parseDecisionTrustFrames(
+  events: GovernanceEventSummary[],
+  limit = 5,
+): AgentGovernanceSnapshot['recent_decision_trust_frames'] {
   return events
     .filter((event) => event.event_type === AGENT_DECISION_TRUST_EVENT)
     .flatMap((event) => {
@@ -379,7 +382,7 @@ function recentDecisionTrustFrames(events: GovernanceEventSummary[]): AgentGover
         occurred_at: event.occurred_at,
       }]
     })
-    .slice(0, 5)
+    .slice(0, limit)
 }
 
 export function buildAgentGovernanceSnapshot(input?: {
@@ -414,7 +417,7 @@ export function buildAgentGovernanceSnapshot(input?: {
     }),
     pending_authority_approvals: pendingAuthorityApprovals.slice(0, 8).map(authorityApprovalSummary),
     recent_delegation_decisions: recentDelegationDecisions(input?.events ?? []),
-    recent_decision_trust_frames: recentDecisionTrustFrames(input?.events ?? []),
+    recent_decision_trust_frames: parseDecisionTrustFrames(input?.events ?? []),
     recent_governance_exports: (input?.exports ?? []).slice(0, 8),
   }
 }

--- a/lib/decision-trust-open-brain.test.ts
+++ b/lib/decision-trust-open-brain.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildDecisionTrustOpenBrainProjection,
+  buildDecisionTrustRelationshipEdges,
+  buildDecisionTrustRelationshipInsights,
+  type DecisionTrustOpenBrainFrame,
+} from './decision-trust-open-brain'
+import type { OpenBrainRelationshipNode } from './open-brain'
+
+const generatedAt = '2026-05-27T12:00:00.000Z'
+
+function frame(overrides: Partial<DecisionTrustOpenBrainFrame> = {}): DecisionTrustOpenBrainFrame {
+  return {
+    run_id: 'run-trust-1',
+    decision_id: 'decision-trust-1',
+    agent_key: 'chief-of-staff',
+    decision_type: 'tool',
+    objective: 'Choose the official runtime documentation.',
+    selected_candidate: 'source:official-docs',
+    candidates_considered: ['source:official-docs', 'source:blog-post'],
+    trust_signals: ['Official source match', 'Trusted domain'],
+    risk_signals: ['Read-only information use'],
+    missing_evidence: [],
+    scores: {
+      relationshipTrust: 0.82,
+      decisionRisk: 0.18,
+      evidenceCompleteness: 0.9,
+    },
+    recommended_gate: 'allow',
+    approval_type: null,
+    reversibility: 'easy',
+    occurred_at: generatedAt,
+    ...overrides,
+  }
+}
+
+function nodes(): OpenBrainRelationshipNode[] {
+  return [
+    {
+      id: 'event:decision-trust:decision-trust-1',
+      label: 'Decision trust: source:official-docs',
+      type: 'event',
+      kind: 'agent_decision_trust_observed',
+      privacyTier: 'internal_ops',
+      summary: 'Decision trust event.',
+      path: null,
+      health: 'green',
+      x: 10,
+      y: 10,
+    },
+    {
+      id: 'source:official-docs',
+      label: 'Official Docs',
+      type: 'source',
+      kind: 'runbook',
+      privacyTier: 'public_safe',
+      summary: 'Official documentation.',
+      path: 'https://example.com/docs',
+      health: 'green',
+      x: 20,
+      y: 20,
+    },
+  ]
+}
+
+describe('decision trust Open Brain projection', () => {
+  it('turns an allow frame into an Open Brain event node and evidence edge', () => {
+    const projection = buildDecisionTrustOpenBrainProjection([frame()], { generatedAt })
+    const edges = buildDecisionTrustRelationshipEdges(projection.events, nodes())
+
+    expect(projection.sources[0]).toEqual(expect.objectContaining({
+      kind: 'agent_run',
+      path: '/admin/agents/runs/run-trust-1',
+    }))
+    expect(projection.events[0]).toEqual(expect.objectContaining({
+      kind: 'agent_decision_trust_observed',
+      sourceIds: ['agent-run:run-trust-1:decision-trust'],
+    }))
+    expect(edges).toEqual([
+      expect.objectContaining({
+        fromId: 'event:decision-trust:decision-trust-1',
+        toId: 'source:official-docs',
+        relationship: 'trusted_for_decision',
+        strength: 'medium',
+        status: 'inferred',
+      }),
+    ])
+  })
+
+  it('creates a review insight for a human-review frame', () => {
+    const projection = buildDecisionTrustOpenBrainProjection([
+      frame({
+        decision_type: 'spend',
+        recommended_gate: 'human_review',
+        risk_signals: ['Payment or spend authority requested'],
+        missing_evidence: ['Human approval decision'],
+        scores: {
+          relationshipTrust: 0.78,
+          decisionRisk: 0.72,
+          evidenceCompleteness: 0.62,
+        },
+      }),
+    ], { generatedAt })
+    const insights = buildDecisionTrustRelationshipInsights(projection.events, nodes())
+
+    expect(insights[0]).toEqual(expect.objectContaining({
+      kind: 'decision_trust_review',
+      severity: 'medium',
+      sourceNodeId: 'event:decision-trust:decision-trust-1',
+      targetNodeId: 'source:official-docs',
+      decisionTrust: expect.objectContaining({
+        decisionId: 'decision-trust-1',
+        recommendedGate: 'human_review',
+      }),
+    }))
+  })
+
+  it('does not create a positive edge for a blocked frame', () => {
+    const projection = buildDecisionTrustOpenBrainProjection([
+      frame({
+        recommended_gate: 'block',
+        risk_signals: ['Domain mismatch and impersonation marker'],
+        scores: {
+          relationshipTrust: 0.2,
+          decisionRisk: 0.98,
+          evidenceCompleteness: 0.7,
+        },
+      }),
+    ], { generatedAt })
+
+    expect(buildDecisionTrustRelationshipEdges(projection.events, nodes())).toEqual([])
+    expect(buildDecisionTrustRelationshipInsights(projection.events, nodes())[0]).toEqual(expect.objectContaining({
+      kind: 'decision_trust_review',
+      severity: 'high',
+    }))
+  })
+
+  it('creates an insight instead of a fake node for an unresolved candidate', () => {
+    const projection = buildDecisionTrustOpenBrainProjection([
+      frame({
+        selected_candidate: 'unknown-vendor',
+        recommended_gate: 'sandbox',
+        missing_evidence: ['Official docs not found'],
+      }),
+    ], { generatedAt })
+    const graphNodes = nodes().filter((node) => node.id !== 'source:official-docs')
+
+    expect(buildDecisionTrustRelationshipEdges(projection.events, graphNodes)).toEqual([])
+    expect(buildDecisionTrustRelationshipInsights(projection.events, graphNodes)[0]).toEqual(expect.objectContaining({
+      targetNodeId: null,
+      recommendation: expect.stringContaining('Resolve the candidate'),
+    }))
+  })
+
+  it('sanitizes private evidence and secret-like text', () => {
+    const projection = buildDecisionTrustOpenBrainProjection([
+      frame({
+        trust_signals: ['Credential marker API_KEY=secret-value'],
+        missing_evidence: ['private chat export with API_KEY=secret-value'],
+      }),
+    ], { generatedAt })
+    const serialized = JSON.stringify(projection)
+
+    expect(serialized).toContain('private source summary')
+    expect(serialized).toContain('[redacted]')
+    expect(serialized).not.toContain('private chat export')
+    expect(serialized).not.toContain('secret-value')
+  })
+})

--- a/lib/decision-trust-open-brain.ts
+++ b/lib/decision-trust-open-brain.ts
@@ -1,0 +1,301 @@
+import { createHash } from 'crypto'
+import { AGENT_DECISION_TRUST_EVENT } from '@/lib/agent-decision-trust'
+import type { AgentGovernanceSnapshot } from '@/lib/agent-governance'
+import type {
+  OpenBrainEventRecord,
+  OpenBrainRelationshipEdge,
+  OpenBrainRelationshipInsight,
+  OpenBrainRelationshipNode,
+  OpenBrainSourceRecord,
+} from '@/lib/open-brain'
+
+export type DecisionTrustOpenBrainFrame = AgentGovernanceSnapshot['recent_decision_trust_frames'][number]
+
+export type DecisionTrustOpenBrainProjection = {
+  sources: OpenBrainSourceRecord[]
+  events: OpenBrainEventRecord[]
+}
+
+const SECRETISH_PATTERN =
+  /(sk-[A-Za-z0-9_-]{8,}|github_pat_[A-Za-z0-9_]{8,}|[A-Za-z0-9_]*(?:TOKEN|SECRET|KEY|PASSWORD)[A-Za-z0-9_]*\s*[:=]\s*["']?[^"'\s,}]+)/gi
+
+export function buildDecisionTrustOpenBrainProjection(
+  frames: DecisionTrustOpenBrainFrame[],
+  options: { generatedAt?: string; maxFrames?: number } = {},
+): DecisionTrustOpenBrainProjection {
+  const generatedAt = options.generatedAt ?? new Date().toISOString()
+  const frameLimit = options.maxFrames ?? 25
+  const validFrames = frames.filter(isDecisionTrustFrame).slice(0, frameLimit)
+
+  return {
+    sources: validFrames.map((frame) => decisionTrustSource(frame, generatedAt)),
+    events: validFrames.map((frame) => decisionTrustEvent(frame)),
+  }
+}
+
+export function buildDecisionTrustRelationshipEdges(
+  events: OpenBrainEventRecord[],
+  nodes: OpenBrainRelationshipNode[],
+): OpenBrainRelationshipEdge[] {
+  return decisionTrustEvents(events).flatMap((event) => {
+    const metadata = decisionTrustMetadata(event)
+    if (!metadata || metadata.recommended_gate === 'block') return []
+
+    const candidateNode = findCandidateNode(nodes, metadata.selected_candidate)
+    if (!candidateNode) return []
+    if (
+      metadata.recommended_gate === 'allow' &&
+      (metadata.scores.relationshipTrust < 0.65 || metadata.scores.evidenceCompleteness < 0.75)
+    ) {
+      return []
+    }
+
+    const relationship = metadata.recommended_gate === 'allow'
+      ? 'trusted_for_decision'
+      : metadata.recommended_gate === 'sandbox'
+        ? 'sandbox_candidate_for'
+        : 'requires_review_for_decision'
+    const strength = metadata.recommended_gate === 'allow' ? 'medium' : 'weak'
+
+    return [{
+      id: `edge:decision-trust:${fingerprint([event.id, candidateNode.id, relationship]).slice(0, 16)}`,
+      fromId: event.id,
+      toId: candidateNode.id,
+      relationship,
+      strength,
+      confidence: clampScore(Math.min(metadata.scores.relationshipTrust, metadata.scores.evidenceCompleteness)),
+      evidence: sanitizeDecisionTrustText([
+        `Decision ${metadata.decision_id} selected ${metadata.selected_candidate}.`,
+        `Gate: ${metadata.recommended_gate}.`,
+        metadata.evidence_summary,
+      ].join(' '), 280),
+      status: metadata.recommended_gate === 'allow' ? 'inferred' : 'recommended',
+    } satisfies OpenBrainRelationshipEdge]
+  })
+}
+
+export function buildDecisionTrustRelationshipInsights(
+  events: OpenBrainEventRecord[],
+  nodes: OpenBrainRelationshipNode[],
+): OpenBrainRelationshipInsight[] {
+  return decisionTrustEvents(events)
+    .flatMap((event) => {
+      const metadata = decisionTrustMetadata(event)
+      if (!metadata) return []
+      const candidateNode = findCandidateNode(nodes, metadata.selected_candidate)
+      const needsReview = metadata.recommended_gate === 'human_review' ||
+        metadata.recommended_gate === 'block' ||
+        !candidateNode ||
+        metadata.missing_evidence.length > 0
+
+      if (!needsReview) return []
+
+      const severity = metadata.recommended_gate === 'block'
+        ? 'high'
+        : metadata.recommended_gate === 'human_review' || metadata.scores.decisionRisk >= 0.55
+          ? 'medium'
+          : 'low'
+      const missingEvidence = metadata.missing_evidence.length
+        ? ` Missing evidence: ${metadata.missing_evidence.slice(0, 3).join(', ')}.`
+        : ''
+
+      return [{
+        id: `insight:decision-trust:${metadata.decision_id}`,
+        kind: 'decision_trust_review',
+        severity,
+        title: `Review decision trust: ${metadata.selected_candidate}`,
+        detail: sanitizeDecisionTrustText(
+          `Decision ${metadata.decision_id} recommended ${metadata.recommended_gate} for ${metadata.decision_type}. ${metadata.evidence_summary}${missingEvidence}`,
+          360,
+        ),
+        recommendation: candidateNode
+          ? 'Keep this relationship proposal-gated until the linked run and missing evidence are reviewed.'
+          : 'Resolve the candidate to a durable Open Brain source, vendor, tool, or approval record before relying on this decision as trust evidence.',
+        actionLabel: candidateNode ? 'Propose review link' : 'Record review proposal',
+        sourceNodeId: event.id,
+        targetNodeId: candidateNode?.id ?? null,
+        decisionTrust: {
+          decisionId: metadata.decision_id,
+          linkedRunId: metadata.linked_run_id,
+          selectedCandidate: metadata.selected_candidate,
+          recommendedGate: metadata.recommended_gate,
+          scores: metadata.scores,
+          evidenceSummary: metadata.evidence_summary,
+        },
+      } satisfies OpenBrainRelationshipInsight]
+    })
+    .slice(0, 10)
+}
+
+function decisionTrustSource(frame: DecisionTrustOpenBrainFrame, generatedAt: string): OpenBrainSourceRecord {
+  return {
+    id: decisionTrustSourceId(frame),
+    kind: 'agent_run',
+    title: `Decision trust run ${shortId(frame.run_id)}`,
+    summary: sanitizeDecisionTrustText(`${frame.agent_key} recorded ${frame.recommended_gate} for ${frame.selected_candidate}. ${evidenceSummary(frame)}`),
+    path: `/admin/agents/runs/${encodeURIComponent(frame.run_id)}`,
+    privacyTier: 'internal_ops',
+    confidence: clampScore(frame.scores.evidenceCompleteness),
+    lastObservedAt: frame.occurred_at || generatedAt,
+    fingerprint: fingerprint(['decision-trust-source', frame.run_id, frame.decision_id, frame.occurred_at]),
+  }
+}
+
+function decisionTrustEvent(frame: DecisionTrustOpenBrainFrame): OpenBrainEventRecord {
+  return {
+    id: decisionTrustEventId(frame.decision_id),
+    kind: 'agent_decision_trust_observed',
+    title: `Decision trust: ${frame.selected_candidate}`,
+    summary: sanitizeDecisionTrustText(`${frame.decision_type.replace(/_/g, ' ')} decision recommended ${frame.recommended_gate}. ${evidenceSummary(frame)}`),
+    privacyTier: 'internal_ops',
+    confidence: clampScore(frame.scores.evidenceCompleteness),
+    sourceIds: [decisionTrustSourceId(frame)],
+    createdAt: frame.occurred_at,
+    fingerprint: fingerprint(['decision-trust-event', frame.decision_id, frame.run_id, frame.occurred_at]),
+    metadata: {
+      agentRunEventType: AGENT_DECISION_TRUST_EVENT,
+      decisionTrust: {
+        decision_id: frame.decision_id,
+        linked_run_id: frame.run_id,
+        agent_key: frame.agent_key,
+        decision_type: frame.decision_type,
+        objective: sanitizeDecisionTrustText(frame.objective),
+        selected_candidate: sanitizeDecisionTrustText(frame.selected_candidate, 180),
+        candidates_considered: frame.candidates_considered.map((candidate) => sanitizeDecisionTrustText(candidate, 140)).slice(0, 8),
+        recommended_gate: frame.recommended_gate,
+        approval_type: frame.approval_type ? sanitizeDecisionTrustText(frame.approval_type, 140) : null,
+        reversibility: sanitizeDecisionTrustText(frame.reversibility, 80),
+        scores: frame.scores,
+        trust_signals: frame.trust_signals.map((signal) => sanitizeDecisionTrustText(signal, 160)).slice(0, 6),
+        risk_signals: frame.risk_signals.map((signal) => sanitizeDecisionTrustText(signal, 160)).slice(0, 6),
+        missing_evidence: frame.missing_evidence.map((item) => sanitizeDecisionTrustText(item, 160)).slice(0, 6),
+        evidence_summary: evidenceSummary(frame),
+      },
+    },
+  }
+}
+
+function decisionTrustEvents(events: OpenBrainEventRecord[]) {
+  return events.filter((event) => event.kind === 'agent_decision_trust_observed')
+}
+
+function decisionTrustMetadata(event: OpenBrainEventRecord) {
+  const value = event.metadata?.decisionTrust
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const record = value as Record<string, unknown>
+  const scores = scoreRecord(record.scores)
+  const recommendedGate = stringField(record.recommended_gate)
+  const decisionId = stringField(record.decision_id)
+  const selectedCandidate = stringField(record.selected_candidate)
+  const decisionType = stringField(record.decision_type)
+  if (!scores || !decisionId || !selectedCandidate || !decisionType || !isDecisionTrustGate(recommendedGate)) return null
+  return {
+    decision_id: decisionId,
+    linked_run_id: stringField(record.linked_run_id),
+    agent_key: stringField(record.agent_key),
+    decision_type: decisionType,
+    objective: stringField(record.objective) || 'Decision trust frame recorded.',
+    selected_candidate: selectedCandidate,
+    candidates_considered: stringArrayField(record.candidates_considered),
+    recommended_gate: recommendedGate,
+    approval_type: stringField(record.approval_type),
+    reversibility: stringField(record.reversibility) || 'unknown',
+    scores,
+    trust_signals: stringArrayField(record.trust_signals),
+    risk_signals: stringArrayField(record.risk_signals),
+    missing_evidence: stringArrayField(record.missing_evidence),
+    evidence_summary: stringField(record.evidence_summary) || event.summary,
+  }
+}
+
+function findCandidateNode(nodes: OpenBrainRelationshipNode[], candidate: string) {
+  const normalizedCandidate = normalizeIdentifier(candidate)
+  if (!normalizedCandidate) return null
+  return nodes.find((node) => (
+    node.id === candidate ||
+    normalizeIdentifier(node.id) === normalizedCandidate ||
+    normalizeIdentifier(node.label) === normalizedCandidate ||
+    normalizeIdentifier(node.id.split(':').at(-1) || '') === normalizedCandidate
+  )) ?? null
+}
+
+function evidenceSummary(frame: DecisionTrustOpenBrainFrame) {
+  return sanitizeDecisionTrustText([
+    `Trust ${Math.round(frame.scores.relationshipTrust * 100)}%.`,
+    `Risk ${Math.round(frame.scores.decisionRisk * 100)}%.`,
+    `Evidence ${Math.round(frame.scores.evidenceCompleteness * 100)}%.`,
+    frame.missing_evidence.length ? `Missing: ${frame.missing_evidence.slice(0, 3).join(', ')}.` : 'No missing evidence recorded.',
+  ].join(' '), 320)
+}
+
+function isDecisionTrustFrame(frame: DecisionTrustOpenBrainFrame) {
+  return Boolean(
+    frame?.decision_id &&
+    frame.run_id &&
+    frame.selected_candidate &&
+    isDecisionTrustGate(frame.recommended_gate) &&
+    scoreRecord(frame.scores),
+  )
+}
+
+function isDecisionTrustGate(value: unknown): value is 'allow' | 'sandbox' | 'human_review' | 'block' {
+  return value === 'allow' || value === 'sandbox' || value === 'human_review' || value === 'block'
+}
+
+function scoreRecord(value: unknown) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const record = value as Record<string, unknown>
+  const relationshipTrust = Number(record.relationshipTrust)
+  const decisionRisk = Number(record.decisionRisk)
+  const evidenceCompleteness = Number(record.evidenceCompleteness)
+  if (![relationshipTrust, decisionRisk, evidenceCompleteness].every(Number.isFinite)) return null
+  return {
+    relationshipTrust: clampScore(relationshipTrust),
+    decisionRisk: clampScore(decisionRisk),
+    evidenceCompleteness: clampScore(evidenceCompleteness),
+  }
+}
+
+function stringField(value: unknown) {
+  return typeof value === 'string' && value.trim() ? sanitizeDecisionTrustText(value) : null
+}
+
+function stringArrayField(value: unknown) {
+  if (!Array.isArray(value)) return []
+  return value
+    .filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+    .map((item) => sanitizeDecisionTrustText(item))
+}
+
+function decisionTrustSourceId(frame: DecisionTrustOpenBrainFrame) {
+  return `agent-run:${frame.run_id}:decision-trust`
+}
+
+function decisionTrustEventId(decisionId: string) {
+  return `event:decision-trust:${decisionId}`
+}
+
+function shortId(value: string) {
+  return value.slice(0, 8)
+}
+
+function normalizeIdentifier(value: string) {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '')
+}
+
+function clampScore(value: number) {
+  return Number(Math.max(0, Math.min(1, value)).toFixed(2))
+}
+
+function sanitizeDecisionTrustText(value: string, maxLength = 220) {
+  return value
+    .replace(SECRETISH_PATTERN, '[redacted]')
+    .replace(/private (chat|message|transcript|export)[^,.]*/gi, 'private source summary')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, maxLength)
+}
+
+function fingerprint(parts: unknown[]) {
+  return createHash('sha256').update(parts.map((part) => String(part)).join('\u001f')).digest('hex')
+}

--- a/lib/open-brain.test.ts
+++ b/lib/open-brain.test.ts
@@ -102,6 +102,7 @@ describe('Open Brain projection', () => {
       'producer:autoresearch',
       'producer:model-ops',
       'producer:rag-pinecone',
+      'producer:decision-trust',
     ]))
     expect(snapshot.overview.producerGates).toBe(snapshot.producerGates.length)
     expect(snapshot.relationshipMap.nodes.map((node) => node.type)).toEqual(expect.arrayContaining([
@@ -109,6 +110,100 @@ describe('Open Brain projection', () => {
       'proposal',
     ]))
     expect(snapshot.relationshipMap.insights.map((insight) => insight.kind)).toContain('strengthen')
+  })
+
+  it('projects decision trust frames into Open Brain events and map insights', async () => {
+    const root = await makeTempRoot()
+    const snapshot = await getOpenBrainSnapshot(root, {
+      decisionTrustFrames: [
+        {
+          run_id: 'run-trust',
+          decision_id: 'decision-payment',
+          agent_key: 'chief-of-staff',
+          decision_type: 'spend',
+          objective: 'Create a vendor payment checkpoint.',
+          selected_candidate: 'make_vendor_payment',
+          candidates_considered: ['make_vendor_payment'],
+          trust_signals: ['Agent Ops source run linked'],
+          risk_signals: ['Payment or spend authority requested'],
+          missing_evidence: ['Human approval decision', 'private chat export with API_KEY=secret-value'],
+          scores: {
+            relationshipTrust: 0.57,
+            decisionRisk: 0.72,
+            evidenceCompleteness: 0.6,
+          },
+          recommended_gate: 'human_review',
+          approval_type: 'payment_make_vendor_payment',
+          reversibility: 'hard',
+          occurred_at: '2026-05-27T12:00:00.000Z',
+        },
+      ],
+    })
+
+    expect(snapshot.events).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'event:decision-trust:decision-payment',
+        kind: 'agent_decision_trust_observed',
+      }),
+    ]))
+    expect(snapshot.relationshipMap.nodes).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'event:decision-trust:decision-payment',
+        type: 'event',
+        kind: 'agent_decision_trust_observed',
+        decisionTrustGate: 'human_review',
+      }),
+    ]))
+    expect(snapshot.relationshipMap.insights).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        kind: 'decision_trust_review',
+        title: 'Review decision trust: make_vendor_payment',
+        decisionTrust: expect.objectContaining({
+          decisionId: 'decision-payment',
+          recommendedGate: 'human_review',
+          scores: expect.objectContaining({ decisionRisk: 0.72 }),
+        }),
+      }),
+    ]))
+    expect(JSON.stringify(snapshot.relationshipMap.insights)).toContain('private source summary')
+    expect(JSON.stringify(snapshot.relationshipMap.insights)).not.toContain('private chat export')
+    expect(JSON.stringify(snapshot.relationshipMap.insights)).not.toContain('secret-value')
+  })
+
+  it('keeps decision trust metadata on review proposals without creating a link unless a path is explicit', async () => {
+    const root = await makeTempRoot()
+    const proposal = await createOpenBrainProposal({
+      kind: 'workflow',
+      title: 'Review blocked decision trust frame',
+      body: 'A blocked decision trust frame needs source review before future agent action.',
+      privacyTier: 'internal_ops',
+      confidence: 0.84,
+      sourceIds: [],
+      reason: 'Decision trust review insight.',
+      metadata: {
+        decisionTrust: {
+          decisionId: 'decision-blocked',
+          linkedRunId: 'run-blocked',
+          selectedCandidate: 'unknown-vendor',
+          recommendedGate: 'block',
+          scores: {
+            relationshipTrust: 0.2,
+            decisionRisk: 0.96,
+            evidenceCompleteness: 0.42,
+          },
+          evidenceSummary: 'Domain mismatch with known-bad signal.',
+        },
+      },
+    }, root)
+
+    const approved = await reviewOpenBrainProposal(proposal.id, 'approved', 'Review captured only', 'admin', root)
+    const snapshot = await getOpenBrainSnapshot(root)
+
+    expect(approved.metadata?.decisionTrust).toEqual(expect.objectContaining({
+      decisionId: 'decision-blocked',
+      recommendedGate: 'block',
+    }))
+    expect(snapshot.links).toHaveLength(0)
   })
 
   it('keeps AutoResearch producer traces disabled until explicitly configured', async () => {

--- a/lib/open-brain.ts
+++ b/lib/open-brain.ts
@@ -5,6 +5,12 @@ import { homedir } from 'os'
 import path from 'path'
 import { listCodexAutomationInventory } from './codex-automation-inventory'
 import { getCodexWorkspaceRootReport } from './codex-workspace-roots'
+import {
+  buildDecisionTrustOpenBrainProjection,
+  buildDecisionTrustRelationshipEdges,
+  buildDecisionTrustRelationshipInsights,
+  type DecisionTrustOpenBrainFrame,
+} from './decision-trust-open-brain'
 import { getModelOpsProjection, type ModelOpsProjection } from './model-ops-open-brain'
 
 export type OpenBrainPrivacyTier = 'public_safe' | 'client_safe' | 'internal_ops' | 'private'
@@ -37,6 +43,7 @@ export type OpenBrainEventKind =
   | 'projection_compiled'
   | 'autoresearch_proposal_created'
   | 'rag_projection_staged'
+  | 'agent_decision_trust_observed'
 
 export interface OpenBrainSourceRecord {
   id: string
@@ -100,6 +107,7 @@ export interface OpenBrainProposalRecord {
 
 export interface OpenBrainProposalMetadata {
   relationship?: OpenBrainRelationshipProposalMetadata
+  decisionTrust?: OpenBrainDecisionTrustProposalMetadata
 }
 
 export interface OpenBrainRelationshipProposalMetadata {
@@ -110,6 +118,19 @@ export interface OpenBrainRelationshipProposalMetadata {
   insightKind: OpenBrainRelationshipInsightKind
   sourceLabel: string
   targetLabel: string
+}
+
+export interface OpenBrainDecisionTrustProposalMetadata {
+  decisionId: string
+  linkedRunId: string | null
+  selectedCandidate: string
+  recommendedGate: string
+  scores: {
+    relationshipTrust: number
+    decisionRisk: number
+    evidenceCompleteness: number
+  }
+  evidenceSummary: string
 }
 
 export interface OpenBrainWikiPage {
@@ -157,7 +178,7 @@ export interface OpenBrainProducerGate {
 
 export type OpenBrainRelationshipNodeType = 'source' | 'memory' | 'event' | 'wiki' | 'proposal'
 export type OpenBrainRelationshipEdgeStrength = 'strong' | 'medium' | 'weak'
-export type OpenBrainRelationshipInsightKind = 'strengthen' | 'review' | 'missing_governance' | 'merge_duplicate'
+export type OpenBrainRelationshipInsightKind = 'strengthen' | 'review' | 'missing_governance' | 'merge_duplicate' | 'decision_trust_review'
 
 export interface OpenBrainRelationshipNode {
   id: string
@@ -168,6 +189,7 @@ export interface OpenBrainRelationshipNode {
   summary: string
   path: string | null
   health: 'green' | 'yellow' | 'red'
+  decisionTrustGate?: string | null
   x: number
   y: number
 }
@@ -193,6 +215,7 @@ export interface OpenBrainRelationshipInsight {
   actionLabel: string
   sourceNodeId: string | null
   targetNodeId: string | null
+  decisionTrust?: OpenBrainDecisionTrustProposalMetadata
 }
 
 export interface OpenBrainRelationshipAuditRecord {
@@ -296,6 +319,10 @@ export interface OpenBrainProposalInput {
   metadata?: OpenBrainProposalMetadata
 }
 
+export interface OpenBrainSnapshotOptions {
+  decisionTrustFrames?: DecisionTrustOpenBrainFrame[]
+}
+
 const DEFAULT_OPEN_BRAIN_HOME = path.join(homedir(), '.open-brain')
 const PORTFOLIO_ROOT = path.resolve(process.env.OPEN_BRAIN_PORTFOLIO_ROOT || process.cwd())
 const PROPOSALS_FILE = 'proposals.json'
@@ -311,7 +338,10 @@ export function getOpenBrainHome() {
   return process.env.OPEN_BRAIN_HOME || DEFAULT_OPEN_BRAIN_HOME
 }
 
-export async function getOpenBrainSnapshot(openBrainHome = getOpenBrainHome()): Promise<OpenBrainSnapshot> {
+export async function getOpenBrainSnapshot(
+  openBrainHome = getOpenBrainHome(),
+  options: OpenBrainSnapshotOptions = {},
+): Promise<OpenBrainSnapshot> {
   const generatedAt = new Date().toISOString()
   const [
     inventory,
@@ -332,6 +362,10 @@ export async function getOpenBrainSnapshot(openBrainHome = getOpenBrainHome()): 
     readJsonArray<OpenBrainLinkRecord>(path.join(openBrainHome, LINKS_FILE)),
     getModelOpsProjection(),
   ])
+  const decisionTrustProjection = buildDecisionTrustOpenBrainProjection(options.decisionTrustFrames ?? [], {
+    generatedAt,
+    maxFrames: 25,
+  })
 
   const sources = dedupeSources([
     ...inventory.automations.map((automation): OpenBrainSourceRecord => ({
@@ -372,6 +406,7 @@ export async function getOpenBrainSnapshot(openBrainHome = getOpenBrainHome()): 
     ...buildRunbookSources(generatedAt),
     ...buildModelOpsSources(modelOps),
     ...(await buildKnowledgeProjectionSources(generatedAt)),
+    ...decisionTrustProjection.sources,
     ...persistedSources,
   ])
 
@@ -411,6 +446,7 @@ export async function getOpenBrainSnapshot(openBrainHome = getOpenBrainHome()): 
   ])
   const events = dedupeEvents([
     ...buildObservedSourceEvents(sources, generatedAt),
+    ...decisionTrustProjection.events,
     ...persistedEvents,
   ])
   const links = dedupeLinks(persistedLinks)
@@ -871,6 +907,11 @@ export function buildOpenBrainRelationshipMap({
     }
   }
 
+  for (const edge of buildDecisionTrustRelationshipEdges(visibleEvents, nodes)) {
+    if (!nodeIds.has(edge.fromId) || !nodeIds.has(edge.toId)) continue
+    addRelationshipEdge(edgeMap, edge)
+  }
+
   const edges = [...edgeMap.values()]
   const connectedNodeIds = new Set<string>()
   for (const edge of edges) {
@@ -881,15 +922,18 @@ export function buildOpenBrainRelationshipMap({
   const staleSources = sources.filter((source) => isStale(source.lastObservedAt, generatedAt))
   const orphanedNodes = nodes.filter((node) => !connectedNodeIds.has(node.id))
   const weakEdges = edges.filter((edge) => edge.strength === 'weak')
-  const insights = buildRelationshipInsights({
-    nodes,
-    edges,
-    orphanedNodes,
-    staleSources,
-    sources,
-    memories,
-    proposals,
-  })
+  const insights = [
+    ...buildDecisionTrustRelationshipInsights(visibleEvents, nodes),
+    ...buildRelationshipInsights({
+      nodes,
+      edges,
+      orphanedNodes,
+      staleSources,
+      sources,
+      memories,
+      proposals,
+    }),
+  ].slice(0, 10)
   const audit = buildRelationshipAudit({ links, proposals, events, nodes })
 
   return {
@@ -980,7 +1024,7 @@ function relationshipMetadataFromUnknown(value: unknown): OpenBrainRelationshipP
   if (!value || typeof value !== 'object') return null
   const candidate = value as Record<string, unknown>
   const insightKind = stringFromMetadata(candidate.insightKind)
-  if (!['strengthen', 'review', 'missing_governance', 'merge_duplicate'].includes(insightKind || '')) return null
+  if (!isRelationshipInsightKind(insightKind)) return null
   const fromId = stringFromMetadata(candidate.fromId)
   const toId = stringFromMetadata(candidate.toId)
   const relationship = stringFromMetadata(candidate.relationship)
@@ -994,6 +1038,43 @@ function relationshipMetadataFromUnknown(value: unknown): OpenBrainRelationshipP
     sourceLabel: stringFromMetadata(candidate.sourceLabel) || fromId,
     targetLabel: stringFromMetadata(candidate.targetLabel) || toId,
   }
+}
+
+function decisionTrustMetadataFromUnknown(value: unknown): OpenBrainDecisionTrustProposalMetadata | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const candidate = value as Record<string, unknown>
+  const scores = scoreMetadataFromUnknown(candidate.scores)
+  const decisionId = stringFromMetadata(candidate.decisionId)
+  const selectedCandidate = stringFromMetadata(candidate.selectedCandidate)
+  const recommendedGate = stringFromMetadata(candidate.recommendedGate)
+  const evidenceSummary = stringFromMetadata(candidate.evidenceSummary)
+  if (!decisionId || !selectedCandidate || !recommendedGate || !scores || !evidenceSummary) return null
+  return {
+    decisionId,
+    linkedRunId: stringFromMetadata(candidate.linkedRunId),
+    selectedCandidate,
+    recommendedGate,
+    scores,
+    evidenceSummary,
+  }
+}
+
+function scoreMetadataFromUnknown(value: unknown): OpenBrainDecisionTrustProposalMetadata['scores'] | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const record = value as Record<string, unknown>
+  const relationshipTrust = Number(record.relationshipTrust)
+  const decisionRisk = Number(record.decisionRisk)
+  const evidenceCompleteness = Number(record.evidenceCompleteness)
+  if (![relationshipTrust, decisionRisk, evidenceCompleteness].every(Number.isFinite)) return null
+  return { relationshipTrust, decisionRisk, evidenceCompleteness }
+}
+
+function isRelationshipInsightKind(value: string | null): value is OpenBrainRelationshipInsightKind {
+  return value === 'strengthen' ||
+    value === 'review' ||
+    value === 'missing_governance' ||
+    value === 'merge_duplicate' ||
+    value === 'decision_trust_review'
 }
 
 function stringFromMetadata(value: unknown) {
@@ -1295,6 +1376,17 @@ function buildProducerGates(modelOps: ModelOpsProjection): OpenBrainProducerGate
       configuredValue: null,
       note: 'RAG staging can use approved public-safe projections. Pinecone writes remain blocked until a separate approval step.',
     },
+    {
+      id: 'producer:decision-trust',
+      label: 'Decision Trust frames',
+      status: 'shadow_only',
+      sourceKind: 'agent_run',
+      eventKind: 'agent_decision_trust_observed',
+      privacyTier: 'internal_ops',
+      envVar: null,
+      configuredValue: null,
+      note: 'Agent decision trust frames may be projected into the relationship map as read-only evidence. Enforcement remains off.',
+    },
   ]
 }
 
@@ -1369,6 +1461,7 @@ function memoryToRelationshipNode(memory: OpenBrainMemoryRecord, index: number):
 
 function eventToRelationshipNode(event: OpenBrainEventRecord, index: number): OpenBrainRelationshipNode {
   const point = relationshipPoint('event', event.kind, index)
+  const decisionTrust = decisionTrustMetadataFromEvent(event)
   return {
     id: event.id,
     label: event.title,
@@ -1377,10 +1470,26 @@ function eventToRelationshipNode(event: OpenBrainEventRecord, index: number): Op
     privacyTier: event.privacyTier,
     summary: event.summary,
     path: typeof event.metadata?.path === 'string' ? event.metadata.path : null,
-    health: event.privacyTier === 'private' ? 'red' : event.confidence >= 0.75 ? 'green' : 'yellow',
+    health: event.privacyTier === 'private'
+      ? 'red'
+      : decisionTrust?.recommendedGate === 'block'
+        ? 'red'
+        : decisionTrust?.recommendedGate === 'human_review'
+          ? 'yellow'
+          : event.confidence >= 0.75 ? 'green' : 'yellow',
+    decisionTrustGate: decisionTrust?.recommendedGate ?? null,
     x: point.x,
     y: point.y,
   }
+}
+
+function decisionTrustMetadataFromEvent(event: OpenBrainEventRecord) {
+  const value = event.metadata?.decisionTrust
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const record = value as Record<string, unknown>
+  const recommendedGate = stringFromMetadata(record.recommended_gate)
+  if (!recommendedGate) return null
+  return { recommendedGate }
 }
 
 function wikiToRelationshipNode(page: OpenBrainWikiPage, index: number): OpenBrainRelationshipNode {
@@ -1642,12 +1751,14 @@ function proposalToMemory(proposal: OpenBrainProposalRecord): OpenBrainMemoryRec
 }
 
 function normalizeOpenBrainProposalMetadata(metadata: OpenBrainProposalMetadata | undefined): OpenBrainProposalMetadata | undefined {
-  if (!metadata?.relationship) return undefined
+  if (!metadata?.relationship && !metadata?.decisionTrust) return undefined
   const relationship = metadata.relationship
-  if (!relationship.fromId?.trim() || !relationship.toId?.trim() || !relationship.relationship?.trim()) return undefined
-  if (!['strengthen', 'review', 'missing_governance', 'merge_duplicate'].includes(relationship.insightKind)) return undefined
-  return {
-    relationship: {
+  const decisionTrust = metadata.decisionTrust
+  const normalizedRelationship = relationship?.fromId?.trim() &&
+    relationship.toId?.trim() &&
+    relationship.relationship?.trim() &&
+    isRelationshipInsightKind(relationship.insightKind)
+    ? {
       fromId: sanitizeOpenBrainText(relationship.fromId, 220),
       toId: sanitizeOpenBrainText(relationship.toId, 220),
       relationship: sanitizeOpenBrainText(relationship.relationship, 160),
@@ -1655,7 +1766,22 @@ function normalizeOpenBrainProposalMetadata(metadata: OpenBrainProposalMetadata 
       insightKind: relationship.insightKind,
       sourceLabel: sanitizeOpenBrainText(relationship.sourceLabel || relationship.fromId, 180),
       targetLabel: sanitizeOpenBrainText(relationship.targetLabel || relationship.toId, 180),
-    },
+    }
+    : undefined
+  const normalizedDecisionTrust = decisionTrustMetadataFromUnknown(decisionTrust)
+  if (!normalizedRelationship && !normalizedDecisionTrust) return undefined
+  return {
+    ...(normalizedRelationship ? { relationship: normalizedRelationship } : {}),
+    ...(normalizedDecisionTrust ? {
+      decisionTrust: {
+        decisionId: sanitizeOpenBrainText(normalizedDecisionTrust.decisionId, 220),
+        linkedRunId: normalizedDecisionTrust.linkedRunId ? sanitizeOpenBrainText(normalizedDecisionTrust.linkedRunId, 220) : null,
+        selectedCandidate: sanitizeOpenBrainText(normalizedDecisionTrust.selectedCandidate, 180),
+        recommendedGate: sanitizeOpenBrainText(normalizedDecisionTrust.recommendedGate, 80),
+        scores: normalizedDecisionTrust.scores,
+        evidenceSummary: sanitizeOpenBrainText(normalizedDecisionTrust.evidenceSummary, 360),
+      },
+    } : {}),
   }
 }
 


### PR DESCRIPTION
## Summary
- Projects V1 Decision Trust frames into the Open Brain snapshot as read-only source/event records.
- Adds decision-trust relationship edges, review insights, proposal metadata, and map filters for high-risk gates.
- Links Agent Governance Decision Trust cards to Open Brain while keeping all relationship changes proposal-gated.

## Validation
- `npm test -- --run lib/decision-trust-open-brain.test.ts lib/agent-decision-trust.test.ts lib/agent-governance.test.ts lib/open-brain.test.ts app/admin/agents/open-brain/page.test.tsx app/admin/agents/governance/page.test.tsx app/api/admin/agents/open-brain/route.test.ts`
- `npm run build:knowledge`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- Browser QA: started local dev server on `http://localhost:3001`; `/admin/agents` and `/admin/agents/open-brain` compiled and redirected to login without a framework overlay after env bootstrap. Protected panel inspection was not completed because the in-app browser did not have an authenticated admin session.

## Integration Notes
- No Supabase migration.
- No new approval system or enforcement behavior.
- Decision Trust remains shadow/proposal-gated; approving a relationship proposal is still the only durable Open Brain link path.
- Vercel contexts not checked from this non-captain lane:
  - Vercel – portfolio
  - Vercel – portfolio-staging
