### PR TITLE
docs: add agentic linkedin draft wave

### DIFF
--- a/docs/agentic-content-linkedin-drafts/README.md
+++ b/docs/agentic-content-linkedin-drafts/README.md
@@ -1,0 +1,21 @@
+# Agentic Content LinkedIn Drafts
+
+This folder contains first-pass LinkedIn draft material from the agentic content research dossier.
+
+## Status
+
+Phase: LinkedIn drafting
+Date: 2026-05-27
+Source dossier: `docs/agentic-content-research-briefs/phase-2-research-dossier.md`
+
+## Operating Rule
+
+These are draft artifacts only. Do not publish, schedule, generate avatar video, regenerate audio, or start outbound promotion from this folder.
+
+## Files
+
+- `wave-1-drafts.md`: five LinkedIn-ready drafts plus proof notes and next-post queue.
+
+## Review Gate
+
+Nefertiti should review voice and public-claim boundaries. Shaka should approve any move from draft to publishing workflow. Video production should wait until the post set is approved or has audience signal.

--- a/docs/agentic-content-linkedin-drafts/wave-1-drafts.md
+++ b/docs/agentic-content-linkedin-drafts/wave-1-drafts.md
@@ -1,0 +1,394 @@
+# Agentic AI LinkedIn Drafts: Wave 1
+
+Date: 2026-05-27
+Status: Draft for review
+Source: `docs/agentic-content-research-briefs/phase-2-research-dossier.md`
+
+## Series Frame
+
+The series should make one argument over time:
+
+AI agents are moving from demos into operating systems. The advantage will belong to builders who can make agent work visible, scoped, evaluated, approved, and useful to real people.
+
+Public-safe boundary: these posts should describe Portfolio as a live operating discipline and proof surface, not as a finished autonomous enterprise platform.
+
+## Draft 1: The Receipt
+
+Pillar: AI and product management
+Topic: Harness and trace foundation
+Primary proof: Agent Ops trace model, OpenAI tracing source note, Portfolio Mission Control
+Status: LinkedIn draft
+
+### Post
+
+The first thing I built around agents was the receipt.
+
+That probably sounds backwards.
+
+Most people start with the agent. The prompt. The tool call. The demo where something magical happens in a browser tab and everybody leans forward.
+
+I get it. I love that part too.
+
+But the more I build with agents, the more I care about what happens after the model says yes.
+
+Who asked it to act?
+
+Which tool did it touch?
+
+What evidence did it use?
+
+Where did the output go?
+
+Did it cost money?
+
+Did it cross a line that should have required approval?
+
+That is the part most demos skip.
+
+For my Portfolio site, I have been building Agent Ops like an operating room, not a magic trick. Runs. Steps. Events. Artifacts. Handoffs. Approvals. Costs. Work items. Mission Control. Slack unblocks. A client-safe audit path.
+
+That sounds less exciting than "an AI agent built this for me."
+
+Good.
+
+Because the real product is not the moment an agent does something impressive. The real product is the confidence to review what happened, explain why it happened, and decide whether the system deserves more authority next time.
+
+I keep thinking about the communities and organizations that are about to inherit this technology.
+
+Small businesses.
+
+Nonprofits.
+
+Teams already carrying too much work.
+
+They do not need AI that creates a new kind of chaos. They need systems that reduce burden and leave proof behind.
+
+That is the part I care about most.
+
+The people with the least room for error are often the ones being sold the most abstract version of innovation. More tools. More dashboards. More promises. More work to manage the work.
+
+Agents should move in the opposite direction.
+
+They should make the invisible work visible. They should turn activity into evidence. They should give the operator clarity to say yes, no, pause, or route this elsewhere.
+
+So I am building the receipt first.
+
+The agent can get smarter later.
+
+The operating discipline has to come now.
+
+What would you need to see before you trusted an agent to act on your behalf?
+
+#AIProduct #ProductManagement #EnterpriseAI #AmadutownAdvisory
+
+### Review Notes
+
+- Keep this as the opening post for the series.
+- It introduces the moral and practical frame without overclaiming autonomy.
+- Good candidate for a carousel: "The receipt every agent needs."
+
+## Draft 2: The Swarm Needs A Handoff
+
+Pillar: AI and product management
+Topic: Agent swarms and delegation
+Primary proof: Agent organization map, Shaka routing, Microsoft orchestration source note
+Status: LinkedIn draft
+
+### Post
+
+A swarm is not a room full of agents talking.
+
+It is an operating model.
+
+That distinction matters more than people think.
+
+Right now, it is easy to spin up a research agent, a writing agent, a critic, a reviewer, and a few tool-using assistants. The demo looks alive because every part is producing output.
+
+Then the real questions show up.
+
+Who owns the next step?
+
+Which agent is allowed to touch client context?
+
+What happens when two agents disagree?
+
+Who stops the work when the risk changes?
+
+Where does the handoff live?
+
+That is where a swarm becomes either useful or noisy.
+
+In my own Agent Ops build, I am treating the swarm like an organization. Shaka is the Chief of Staff. Research has a lane. Content has a lane. Compliance has a lane. Integration has a lane. Each agent needs a role, scope, evidence, and a handoff rule.
+
+That is less glamorous than saying "the agents collaborate."
+
+But collaboration without operating design becomes a meeting with no agenda.
+
+I have been in enough rooms like that.
+
+The loudest person leaves with the decision. The quietest risk goes unspoken. The follow-up gets assumed instead of assigned. Then a week later, everybody remembers the meeting differently.
+
+Agent systems can recreate that same pattern at machine speed.
+
+More output does not fix unclear ownership.
+
+The real work is deciding when a task should be sequential, when it can run in parallel, when it needs a manager, and when the safest answer is to pause for a human.
+
+This is where product management and agent design start to overlap.
+
+You need ownership.
+
+You need decision rights.
+
+You need a clear path from idea to output to review.
+
+The technology is new. The operating problem is familiar.
+
+A team without handoffs drops work.
+
+An agent swarm without handoffs drops accountability.
+
+Where do you think agent systems will break first: tool access, memory, handoffs, or approvals?
+
+#AIProduct #ProductManagement #EnterpriseAI #AmadutownAdvisory
+
+### Review Notes
+
+- Use this after the receipt post.
+- Strong fit for a visual org-map carousel.
+- Avoid claiming all handoffs are fully automated across every workflow.
+
+## Draft 3: Memory Is A Governed Library
+
+Pillar: Technology as equalizer
+Topic: Open Brain memory architecture
+Primary proof: Open Brain local-first memory rules, source records, approved memory proposals
+Status: LinkedIn draft
+
+### Post
+
+Agent memory should feel more like a governed library than a junk drawer.
+
+That is where my thinking has landed.
+
+A lot of AI products talk about memory like it is automatically good. The system remembers you. It remembers your work. It remembers your preferences. It gets more personal over time.
+
+That can be helpful.
+
+It can also get messy fast.
+
+What did it remember?
+
+Where did that memory come from?
+
+Was it a fact, an inference, or a private moment that should have stayed temporary?
+
+Who approved it as durable knowledge?
+
+Can it be corrected?
+
+Can it be kept out of public-facing content?
+
+Those questions matter to me because I am building across personal work, client work, public thought leadership, and community-centered advisory work. Those lanes cannot collapse into one pile of context.
+
+So I have been treating Open Brain as the memory core.
+
+Raw sources stay raw.
+
+Events become records.
+
+Useful patterns become proposals.
+
+Approved memories become durable.
+
+Public content only sees what is safe to project.
+
+That structure may sound heavy until you imagine the alternative: an agent confidently blending private notes, client context, half-formed thoughts, and public claims because nobody gave memory a governance model.
+
+I do not want AI that remembers everything.
+
+I want AI that knows what deserves to become memory.
+
+That is the difference between personalization and stewardship.
+
+The communities I care about have had enough systems extract from them, mislabel them, and speak for them without consent.
+
+If AI is going to remember, it should remember with provenance.
+
+It should remember with boundaries.
+
+It should remember in a way that can be challenged.
+
+What kind of memory would you actually trust an AI system to keep?
+
+#AIProduct #DigitalEquity #TechForGood #AmadutownAdvisory
+
+### Review Notes
+
+- This is the strongest access/equity bridge in the first wave.
+- Keep "stewardship" as the center word.
+- Good candidate for a YouTube segment on Open Brain.
+
+## Draft 4: The Agent Does Not Get Promoted By Confidence
+
+Pillar: AI and product management
+Topic: Self-evaluation and quality loops
+Primary proof: agent evals, workflow trace grading, Agent Ops evaluation posture
+Status: LinkedIn draft
+
+### Post
+
+The agent does not get promoted because it sounded confident.
+
+It gets promoted because the evidence held up.
+
+That is the management model I keep coming back to as I build out Agent Ops.
+
+We would never give a new employee production access because they spoke well in one meeting. We would give them a bounded task. Review the work. Watch how they handle edge cases. See whether they ask for help at the right moment.
+
+Agents need the same discipline.
+
+A good final answer is not enough.
+
+I want to know:
+
+Did it choose the right tool?
+
+Did it stay inside scope?
+
+Did it route the work to the right owner?
+
+Did it ask for approval when the task became sensitive?
+
+Did it preserve the evidence?
+
+Did the cost make sense for the value of the work?
+
+This is why evals matter.
+
+And I do not mean evals as a spreadsheet trophy. I mean evals as an operating loop. A way to decide whether the agent needs a better prompt, a narrower tool, a clearer handoff, a stricter guardrail, or less authority.
+
+That last one matters.
+
+Sometimes the lesson is that the agent should do less.
+
+That is uncomfortable because the market rewards bigger claims. More autonomy. More speed. More agents working while you sleep.
+
+But in real operations, maturity often looks like restraint.
+
+The system learns where it is strong. It learns where it is weak. Then the operator changes the boundary.
+
+That is management.
+
+That is hard to say in an AI market obsessed with autonomy. But it is how trust gets built.
+
+The goal is not to create agents that always sound impressive.
+
+The goal is to create systems that know when impressive is not enough.
+
+That is the difference between demo confidence and operational trust.
+
+What would you measure before giving an agent more authority?
+
+#AIProduct #ProductManagement #LLM #AmadutownAdvisory
+
+### Review Notes
+
+- Strong PM/operator framing.
+- Good follow-up after Shaka/swarm post.
+- Could become a carousel titled "How an agent earns more authority."
+
+## Draft 5: Human Review Is The Trust Layer
+
+Pillar: AI and product management
+Topic: Human-in-the-loop approvals
+Primary proof: Agent approvals, approval-gated side effects, resumable HITL research note
+Status: LinkedIn draft
+
+### Post
+
+Human review is the trust layer.
+
+I have been thinking about that a lot while building approval flows into my agent system.
+
+There is a version of the AI future where humans become the annoying checkpoint. The slow part. The blocker. The person the system has to route around so the automation can keep moving.
+
+That future does not interest me.
+
+The better version is more precise.
+
+Let the system move quickly where the risk is low.
+
+Pause when the work touches a client, a public channel, production data, money, private context, or someone else's reputation.
+
+Then make the approval specific.
+
+What action is being approved?
+
+What evidence supports it?
+
+Who owns the decision?
+
+What happens if we reject it?
+
+Where is the trace?
+
+That is very different from asking a human to babysit every step.
+
+Human-in-the-loop should not mean "make the person read everything."
+
+It should mean "bring the person in where judgment, consent, authority, or accountability matter."
+
+That is how I am thinking about Agent Ops.
+
+Publishing needs a gate.
+
+Outbound email needs a gate.
+
+Production writes need a gate.
+
+Private-to-public movement needs a gate.
+
+Payment authority needs an even stronger one.
+
+The point is not to slow the system down.
+
+The point is to let safe work move without pretending every action is safe.
+
+That distinction matters inside real teams.
+
+A vague approval process turns into theater. Everybody clicks yes because the request is unclear and the work has already moved too far.
+
+A good approval flow gives the human a real decision: approve this action, reject it, ask for evidence, or route it to the right owner.
+
+That is how AI becomes useful inside real organizations.
+
+Speed where it is earned.
+
+Human judgment where it is required.
+
+Where would you draw the approval line for agents in your work?
+
+#AIProduct #ProductManagement #EnterpriseAI #AmadutownAdvisory
+
+### Review Notes
+
+- Strong closing post for the first wave.
+- Keep this one practical and governance-centered.
+- This is the best candidate to bridge into client advisory positioning.
+
+## Next Draft Queue
+
+1. Permission scopes: "The fastest way to make an agent risky is to give it every key."
+2. Client-safe audit export: "Clients need proof, not raw logs."
+3. Mission Control and Slack: "If I need five tabs to understand what my agents did, I have scattered automation."
+4. Cost and payment authority: "An agent should never spend money because the prompt sounded reasonable."
+5. Agentic operating system overview: "Anyone can wire a model to a tool."
+
+## Phase 2 Video Hooks To Preserve
+
+- Turn Draft 1 into a walkthrough of the trace envelope.
+- Turn Draft 2 into an agent org-map explainer with Shaka as controller.
+- Turn Draft 3 into an Open Brain memory governance segment.
+- Turn Draft 4 into an "agent promotion board" segment.
+- Turn Draft 5 into a side-effect approval demo.


### PR DESCRIPTION
## Summary
- Add Phase 2 LinkedIn draft artifacts for the agentic AI content series.
- Include five first-wave LinkedIn drafts: trace receipt, swarm handoff, governed memory, agent evaluation, and human-in-the-loop approvals.
- Preserve review gates for Nefertiti/Shaka and keep video production extensible without starting publishing, HeyGen, ElevenLabs, or render jobs.

## Validation
- Preflight checked root branch, dirty state, open PRs, worktrees, and prior research merge state.
- `git diff --check`
- ASCII scan
- Anti-AI/style scan
- LinkedIn body character-count check: all five drafts are 1,800-2,100 characters.
- `npm run lint`
- `npm run worktree:env` linked `.env.local`, `.env.staging`, and `.vercel` from the main Portfolio checkout.
- `npm run db:health-check` passed after env linkage.
- No publishing, workflow, customer-data, HeyGen, ElevenLabs, or Vercel smoke was run.

## Integration Notes
- No migrations or env changes required.
- This branch only adds docs under `docs/agentic-content-linkedin-drafts/`.
- Vercel – portfolio: not checked for this docs-only branch.
- Vercel – portfolio-staging: not checked for this docs-only branch.