### PR TITLE
feat: schedule proactive Slack unblock notifications

### DIFF
--- a/app/api/cron/agent-ops-slack-notifications/route.test.ts
+++ b/app/api/cron/agent-ops-slack-notifications/route.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({
+  runAgentSlackNotificationSweep: vi.fn(),
+}))
+
+vi.mock('@/lib/agent-slack-notification-sweep', () => ({
+  PROACTIVE_SLACK_NOTIFICATION_RULES: [
+    { kind: 'pending_approvals' },
+    { kind: 'blockers' },
+    { kind: 'stale_runs' },
+    { kind: 'review_ready' },
+    { kind: 'goal_decisions' },
+  ],
+  runAgentSlackNotificationSweep: mocks.runAgentSlackNotificationSweep,
+}))
+
+import { GET, POST } from './route'
+
+const ORIGINAL_ENV = process.env
+
+function request(method: 'GET' | 'POST', token?: string, body?: Record<string, unknown>, url = 'http://localhost/api/cron/agent-ops-slack-notifications') {
+  return new NextRequest(url, {
+    method,
+    headers: {
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+      ...(body ? { 'content-type': 'application/json' } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  })
+}
+
+describe('/api/cron/agent-ops-slack-notifications', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env = {
+      ...ORIGINAL_ENV,
+      CRON_SECRET: 'cron-secret',
+      N8N_INGEST_SECRET: 'n8n-secret',
+    }
+    mocks.runAgentSlackNotificationSweep.mockResolvedValue({
+      ok: true,
+      dryRun: false,
+      totalRules: 5,
+      sentCount: 1,
+      dedupedCount: 1,
+      skippedCount: 3,
+      errorCount: 0,
+      itemCount: 2,
+      results: [],
+    })
+  })
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV
+  })
+
+  it('rejects unauthenticated cron requests', async () => {
+    const response = await GET(request('GET') as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.runAgentSlackNotificationSweep).not.toHaveBeenCalled()
+  })
+
+  it('runs the proactive sweep from Vercel cron', async () => {
+    const response = await GET(request('GET', 'cron-secret') as never)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({
+      ok: true,
+      sentCount: 1,
+      side_effects: {
+        slack_messages_sent: 1,
+        production_mutation_allowed: false,
+      },
+    })
+    expect(mocks.runAgentSlackNotificationSweep).toHaveBeenCalledWith(expect.objectContaining({
+      actorLabel: 'Vercel cron',
+      triggerSource: 'vercel_cron_agent_ops_slack_notifications',
+    }))
+  })
+
+  it('supports manual dry-run slices with selected rule kinds', async () => {
+    const response = await POST(request('POST', 'n8n-secret', {
+      dry_run: true,
+      force: true,
+      kinds: ['stale_runs', 'blockers', 'publish_everything'],
+    }) as never)
+
+    expect(response.status).toBe(200)
+    expect(mocks.runAgentSlackNotificationSweep).toHaveBeenCalledWith(expect.objectContaining({
+      dryRun: true,
+      force: true,
+      kinds: ['stale_runs', 'blockers'],
+      actorLabel: 'Manual cron trigger',
+      triggerSource: 'manual_cron_agent_ops_slack_notifications',
+    }))
+  })
+
+  it('returns a failing status when one or more rules fail', async () => {
+    mocks.runAgentSlackNotificationSweep.mockResolvedValue({
+      ok: false,
+      dryRun: false,
+      totalRules: 1,
+      sentCount: 0,
+      dedupedCount: 0,
+      skippedCount: 0,
+      errorCount: 1,
+      itemCount: 0,
+      results: [{ kind: 'blockers', error: 'database unavailable' }],
+    })
+
+    const response = await GET(request('GET', 'cron-secret') as never)
+
+    expect(response.status).toBe(500)
+    expect(await response.json()).toMatchObject({ ok: false, errorCount: 1 })
+  })
+})

--- a/app/api/cron/agent-ops-slack-notifications/route.ts
+++ b/app/api/cron/agent-ops-slack-notifications/route.ts
@@ -1,0 +1,80 @@
+/**
+ * GET/POST /api/cron/agent-ops-slack-notifications
+ *
+ * Runs governed Agent Ops Slack mobile notification rules.
+ * Auth: Bearer CRON_SECRET or N8N_INGEST_SECRET.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  PROACTIVE_SLACK_NOTIFICATION_RULES,
+  runAgentSlackNotificationSweep,
+  type ProactiveSlackNotificationKind,
+} from '@/lib/agent-slack-notification-sweep'
+
+export const dynamic = 'force-dynamic'
+
+const VALID_KINDS = new Set<ProactiveSlackNotificationKind>(
+  PROACTIVE_SLACK_NOTIFICATION_RULES.map((rule) => rule.kind),
+)
+
+function isAuthorizedCronRequest(request: NextRequest): boolean {
+  const token = request.headers.get('authorization')?.replace(/^Bearer\s+/i, '')
+  const allowedTokens = [process.env.CRON_SECRET, process.env.N8N_INGEST_SECRET].filter(Boolean)
+  return Boolean(token && allowedTokens.includes(token))
+}
+
+function parseKinds(value: unknown): ProactiveSlackNotificationKind[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const kinds = value
+    .filter((item): item is string => typeof item === 'string')
+    .filter((item): item is ProactiveSlackNotificationKind => VALID_KINDS.has(item as ProactiveSlackNotificationKind))
+  return kinds.length ? [...new Set(kinds)] : undefined
+}
+
+async function parsePostBody(request: NextRequest) {
+  try {
+    return await request.json() as Record<string, unknown>
+  } catch {
+    return {}
+  }
+}
+
+async function runSweep(request: NextRequest, body: Record<string, unknown> = {}) {
+  if (!isAuthorizedCronRequest(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const searchParams = request.nextUrl.searchParams
+  const dryRun = body.dry_run === true || body.dryRun === true || searchParams.get('dry_run') === '1'
+  const force = body.force === true || searchParams.get('force') === '1'
+  const kinds = parseKinds(body.kinds)
+
+  const result = await runAgentSlackNotificationSweep({
+    kinds,
+    dryRun,
+    force,
+    actorLabel: request.method === 'GET' ? 'Vercel cron' : 'Manual cron trigger',
+    triggerSource: request.method === 'GET'
+      ? 'vercel_cron_agent_ops_slack_notifications'
+      : 'manual_cron_agent_ops_slack_notifications',
+  })
+
+  return NextResponse.json({
+    ...result,
+    side_effects: {
+      slack_messages_sent: result.sentCount,
+      production_mutation_allowed: false,
+      credential_change_allowed: false,
+      external_customer_data_mutation: false,
+    },
+  }, { status: result.ok ? 200 : 500 })
+}
+
+export async function GET(request: NextRequest) {
+  return runSweep(request)
+}
+
+export async function POST(request: NextRequest) {
+  return runSweep(request, await parsePostBody(request))
+}

--- a/lib/agent-slack-notification-sweep.test.ts
+++ b/lib/agent-slack-notification-sweep.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  buildAgentSlackNotificationPayload: vi.fn(),
+  sendAgentSlackNotification: vi.fn(),
+}))
+
+vi.mock('@/lib/agent-slack-notifications', () => ({
+  buildAgentSlackNotificationPayload: mocks.buildAgentSlackNotificationPayload,
+  sendAgentSlackNotification: mocks.sendAgentSlackNotification,
+}))
+
+import { runAgentSlackNotificationSweep } from '@/lib/agent-slack-notification-sweep'
+
+describe('Agent Ops proactive Slack notification sweep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.buildAgentSlackNotificationPayload.mockResolvedValue({
+      text: 'No work',
+      blocks: [],
+      itemCount: 0,
+    })
+    mocks.sendAgentSlackNotification.mockResolvedValue({
+      ok: true,
+      runId: 'run-1',
+      sent: true,
+      skipped: false,
+      deduped: false,
+      itemCount: 2,
+      text: 'Sent packet',
+    })
+  })
+
+  it('skips empty rules without creating Slack notification runs', async () => {
+    const result = await runAgentSlackNotificationSweep({ kinds: ['blockers'] })
+
+    expect(result).toMatchObject({
+      ok: true,
+      totalRules: 1,
+      sentCount: 0,
+      skippedCount: 1,
+      itemCount: 0,
+    })
+    expect(mocks.sendAgentSlackNotification).not.toHaveBeenCalled()
+    expect(result.results[0]).toMatchObject({
+      kind: 'blockers',
+      skipped: true,
+      reason: 'No matching Agent Ops work needs mobile attention.',
+    })
+  })
+
+  it('evaluates dry runs without sending to Slack', async () => {
+    mocks.buildAgentSlackNotificationPayload.mockResolvedValue({
+      text: '2 stale runs',
+      blocks: [{ type: 'section', text: { type: 'mrkdwn', text: 'Stale runs' } }],
+      itemCount: 2,
+    })
+
+    const result = await runAgentSlackNotificationSweep({ kinds: ['stale_runs'], dryRun: true })
+
+    expect(result).toMatchObject({
+      ok: true,
+      dryRun: true,
+      sentCount: 0,
+      skippedCount: 1,
+      itemCount: 2,
+    })
+    expect(mocks.sendAgentSlackNotification).not.toHaveBeenCalled()
+    expect(result.results[0].reason).toBe('Dry run only.')
+  })
+
+  it('sends non-empty packets with content-aware dedupe metadata', async () => {
+    mocks.buildAgentSlackNotificationPayload.mockResolvedValue({
+      text: '2 stale runs',
+      blocks: [{ type: 'section', text: { type: 'mrkdwn', text: 'Stale runs' } }],
+      itemCount: 2,
+    })
+
+    const result = await runAgentSlackNotificationSweep({
+      kinds: ['stale_runs'],
+      actorLabel: 'cron',
+      triggerSource: 'test_sweep',
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      sentCount: 1,
+      itemCount: 2,
+    })
+    expect(mocks.sendAgentSlackNotification).toHaveBeenCalledWith(expect.objectContaining({
+      kind: 'stale_runs',
+      actorLabel: 'cron',
+      triggerSource: 'test_sweep',
+      dedupeKey: expect.stringMatching(/^stale_runs:2:[a-f0-9]{16}$/),
+      dedupeWindowHours: 4,
+    }))
+  })
+
+  it('continues evaluating later rules when one rule fails', async () => {
+    mocks.buildAgentSlackNotificationPayload
+      .mockRejectedValueOnce(new Error('database unavailable'))
+      .mockResolvedValueOnce({
+        text: '1 review item',
+        blocks: [{ type: 'section', text: { type: 'mrkdwn', text: 'Review' } }],
+        itemCount: 1,
+      })
+
+    const result = await runAgentSlackNotificationSweep({ kinds: ['blockers', 'review_ready'] })
+
+    expect(result.ok).toBe(false)
+    expect(result.errorCount).toBe(1)
+    expect(result.sentCount).toBe(1)
+    expect(result.results[0]).toMatchObject({ kind: 'blockers', error: 'database unavailable' })
+    expect(result.results[1]).toMatchObject({ kind: 'review_ready', sent: true })
+  })
+})

--- a/lib/agent-slack-notification-sweep.ts
+++ b/lib/agent-slack-notification-sweep.ts
@@ -1,0 +1,193 @@
+import { createHash } from 'crypto'
+import {
+  buildAgentSlackNotificationPayload,
+  sendAgentSlackNotification,
+  type AgentSlackNotificationKind,
+  type AgentSlackNotificationResult,
+} from '@/lib/agent-slack-notifications'
+
+export type ProactiveSlackNotificationKind = Extract<
+  AgentSlackNotificationKind,
+  'pending_approvals' | 'blockers' | 'stale_runs' | 'review_ready' | 'goal_decisions'
+>
+
+export type ProactiveSlackNotificationRule = {
+  kind: ProactiveSlackNotificationKind
+  label: string
+  description: string
+  minimumItemCount: number
+  dedupeWindowHours: number
+}
+
+export type AgentSlackNotificationSweepInput = {
+  kinds?: ProactiveSlackNotificationKind[]
+  dryRun?: boolean
+  force?: boolean
+  actorLabel?: string | null
+  triggerSource?: string | null
+}
+
+export type AgentSlackNotificationSweepRuleResult = {
+  kind: ProactiveSlackNotificationKind
+  label: string
+  itemCount: number
+  sent: boolean
+  skipped: boolean
+  deduped: boolean
+  dryRun: boolean
+  runId?: string
+  text: string
+  reason?: string
+  error?: string
+}
+
+export const PROACTIVE_SLACK_NOTIFICATION_RULES: ProactiveSlackNotificationRule[] = [
+  {
+    kind: 'pending_approvals',
+    label: 'Pending approvals',
+    description: 'Human approval packets that can be reviewed from mobile or opened in Portfolio.',
+    minimumItemCount: 1,
+    dedupeWindowHours: 1,
+  },
+  {
+    kind: 'blockers',
+    label: 'Blocked work',
+    description: 'Blocked Kanban work that needs acknowledgement, owner assignment, or Shaka guidance.',
+    minimumItemCount: 1,
+    dedupeWindowHours: 4,
+  },
+  {
+    kind: 'stale_runs',
+    label: 'Stale or failed runs',
+    description: 'Failed or stale traces that need recovery triage.',
+    minimumItemCount: 1,
+    dedupeWindowHours: 4,
+  },
+  {
+    kind: 'review_ready',
+    label: 'Review-ready work',
+    description: 'Cards waiting for review, revision request, or trace inspection.',
+    minimumItemCount: 1,
+    dedupeWindowHours: 4,
+  },
+  {
+    kind: 'goal_decisions',
+    label: 'Goal decisions',
+    description: 'Goal-tagged tasks waiting on a human decision.',
+    minimumItemCount: 1,
+    dedupeWindowHours: 4,
+  },
+]
+
+function selectedRules(kinds?: ProactiveSlackNotificationKind[]) {
+  if (!kinds?.length) return PROACTIVE_SLACK_NOTIFICATION_RULES
+  const allowed = new Set(kinds)
+  return PROACTIVE_SLACK_NOTIFICATION_RULES.filter((rule) => allowed.has(rule.kind))
+}
+
+function payloadDedupeKey(kind: ProactiveSlackNotificationKind, payload: Awaited<ReturnType<typeof buildAgentSlackNotificationPayload>>) {
+  const fingerprint = createHash('sha256')
+    .update(payload.text)
+    .update(JSON.stringify(payload.blocks))
+    .digest('hex')
+    .slice(0, 16)
+  return `${kind}:${payload.itemCount}:${fingerprint}`
+}
+
+function sweepResultFromNotification(
+  rule: ProactiveSlackNotificationRule,
+  notification: AgentSlackNotificationResult,
+): AgentSlackNotificationSweepRuleResult {
+  return {
+    kind: rule.kind,
+    label: rule.label,
+    itemCount: notification.itemCount,
+    sent: notification.sent,
+    skipped: notification.skipped,
+    deduped: notification.deduped,
+    dryRun: false,
+    runId: notification.runId,
+    text: notification.text,
+    reason: notification.reason,
+  }
+}
+
+export async function runAgentSlackNotificationSweep(input: AgentSlackNotificationSweepInput = {}) {
+  const results: AgentSlackNotificationSweepRuleResult[] = []
+
+  for (const rule of selectedRules(input.kinds)) {
+    try {
+      const payload = await buildAgentSlackNotificationPayload({ kind: rule.kind })
+
+      if (payload.itemCount < rule.minimumItemCount) {
+        results.push({
+          kind: rule.kind,
+          label: rule.label,
+          itemCount: payload.itemCount,
+          sent: false,
+          skipped: true,
+          deduped: false,
+          dryRun: Boolean(input.dryRun),
+          text: payload.text,
+          reason: 'No matching Agent Ops work needs mobile attention.',
+        })
+        continue
+      }
+
+      const dedupeKey = payloadDedupeKey(rule.kind, payload)
+      if (input.dryRun) {
+        results.push({
+          kind: rule.kind,
+          label: rule.label,
+          itemCount: payload.itemCount,
+          sent: false,
+          skipped: true,
+          deduped: false,
+          dryRun: true,
+          text: payload.text,
+          reason: 'Dry run only.',
+        })
+        continue
+      }
+
+      const notification = await sendAgentSlackNotification({
+        kind: rule.kind,
+        force: input.force,
+        actorLabel: input.actorLabel ?? 'Agent Ops notification sweep',
+        triggerSource: input.triggerSource ?? 'cron_agent_ops_slack_notifications',
+        dedupeKey,
+        dedupeWindowHours: rule.dedupeWindowHours,
+      })
+      results.push(sweepResultFromNotification(rule, notification))
+    } catch (error) {
+      results.push({
+        kind: rule.kind,
+        label: rule.label,
+        itemCount: 0,
+        sent: false,
+        skipped: false,
+        deduped: false,
+        dryRun: Boolean(input.dryRun),
+        text: `${rule.label} failed.`,
+        error: error instanceof Error ? error.message : 'Unknown Slack notification sweep error',
+      })
+    }
+  }
+
+  const sentCount = results.filter((result) => result.sent).length
+  const dedupedCount = results.filter((result) => result.deduped).length
+  const skippedCount = results.filter((result) => result.skipped).length
+  const errorCount = results.filter((result) => result.error).length
+
+  return {
+    ok: errorCount === 0,
+    dryRun: Boolean(input.dryRun),
+    totalRules: results.length,
+    sentCount,
+    dedupedCount,
+    skippedCount,
+    errorCount,
+    itemCount: results.reduce((sum, result) => sum + result.itemCount, 0),
+    results,
+  }
+}

--- a/lib/agent-slack-notifications.ts
+++ b/lib/agent-slack-notifications.ts
@@ -18,6 +18,8 @@ export type AgentSlackNotificationInput = {
   targetAgentKeys?: string[]
   goalId?: string | null
   force?: boolean
+  dedupeKey?: string | null
+  dedupeWindowHours?: number | null
   actorLabel?: string | null
   triggerSource?: string | null
 }
@@ -64,9 +66,10 @@ function agentUrl(path: string) {
   return `${baseUrl()}${path}`
 }
 
-function dedupeWindowKey() {
-  const now = new Date()
-  return now.toISOString().slice(0, 13)
+function dedupeWindowKey(windowHours = 1) {
+  const hours = Number.isFinite(windowHours) && windowHours > 0 ? windowHours : 1
+  const windowMs = hours * 60 * 60 * 1000
+  return new Date(Math.floor(Date.now() / windowMs) * windowMs).toISOString()
 }
 
 function normalizeTargetAgentKeys(keys?: string[]) {
@@ -76,7 +79,8 @@ function normalizeTargetAgentKeys(keys?: string[]) {
 function notificationIdempotencyKey(input: AgentSlackNotificationInput) {
   const targetKey = normalizeTargetAgentKeys(input.targetAgentKeys).join(',') || 'all'
   const goalKey = input.goalId || 'no-goal'
-  return `slack-mobile-notification:${input.kind}:${goalKey}:${targetKey}:${dedupeWindowKey()}`
+  const contentKey = input.dedupeKey?.trim() || 'default'
+  return `slack-mobile-notification:${input.kind}:${goalKey}:${targetKey}:${contentKey}:${dedupeWindowKey(input.dedupeWindowHours ?? 1)}`
 }
 
 async function existingNotificationRun(idempotencyKey: string) {
@@ -410,6 +414,8 @@ export async function sendAgentSlackNotification(input: AgentSlackNotificationIn
       target_agent_keys: normalizeTargetAgentKeys(input.targetAgentKeys),
       goal_id: input.goalId ?? null,
       actor_label: input.actorLabel ?? null,
+      notification_dedupe_key: input.dedupeKey ?? null,
+      dedupe_window_hours: input.dedupeWindowHours ?? 1,
       item_count: payload.itemCount,
       text: payload.text,
     },

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,10 @@
     {
       "path": "/api/cron/moremi-risk-monitor",
       "schedule": "0 14 * * 1"
+    },
+    {
+      "path": "/api/cron/agent-ops-slack-notifications",
+      "schedule": "0 15 * * *"
     }
   ]
 }


### PR DESCRIPTION
Summary
- Adds a proactive Agent Ops Slack notification sweep for pending approvals, blockers, stale runs, review-ready work, and goal decisions.
- Adds content-aware dedupe keys and configurable dedupe windows so repeated packets are suppressed while changed packets can still notify.
- Adds a guarded cron endpoint at `/api/cron/agent-ops-slack-notifications` and schedules it daily at 15:00 UTC in `vercel.json` to stay inside the current Vercel cron limits; the endpoint still supports manual or n8n-triggered runs for higher-frequency use.

Validation
- npm test -- lib/agent-slack-notification-sweep.test.ts app/api/cron/agent-ops-slack-notifications/route.test.ts lib/agent-slack-notifications.test.ts lib/agent-slack-actions.test.ts app/api/admin/agents/slack-notifications/route.test.ts app/admin/agents/page.test.tsx
- npx tsc --noEmit --pretty false
- npm run lint
- git diff --check
- Push hook database health check passed.

Integration Notes
- Conflict preflight: PR #411 is merged; open PRs #420 and #419 do not overlap Slack Agent Ops notification files.
- Cron auth accepts Bearer `CRON_SECRET` or `N8N_INGEST_SECRET`, matching existing cron patterns.
- Empty notification categories are skipped without creating Slack notification runs.
- Side effects are limited to Slack messages and Agent Ops traces; no credential changes, production activation, customer data mutation, publishing, payments, or n8n activation.
- Integration Captain adjusted the built-in Vercel cron from hourly to daily after Vercel preview rejected the hourly schedule with the Cron usage/pricing gate. Verify `Vercel – portfolio` plus `Vercel – portfolio-staging` after merge/deploy; use n8n/manual triggering if higher-frequency sweeps are needed later.