### PR TITLE
feat: trace Slack notification threads

### DIFF
--- a/lib/agent-slack-events.test.ts
+++ b/lib/agent-slack-events.test.ts
@@ -2,10 +2,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   runChiefOfStaffChat: vi.fn(),
+  from: vi.fn(),
 }))
 
 vi.mock('@/lib/chief-of-staff-chat', () => ({
   runChiefOfStaffChat: mocks.runChiefOfStaffChat,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: { from: mocks.from },
 }))
 
 import {
@@ -16,6 +21,18 @@ import {
 } from './agent-slack-events'
 
 const ORIGINAL_ENV = process.env
+
+function queryResult(result: unknown) {
+  const query: Record<string, unknown> = {
+    select: vi.fn(() => query),
+    eq: vi.fn(() => query),
+    filter: vi.fn(() => query),
+    order: vi.fn(() => query),
+    limit: vi.fn(() => query),
+    maybeSingle: vi.fn(() => Promise.resolve(result)),
+  }
+  return query
+}
 
 describe('agent Slack events', () => {
   beforeEach(() => {
@@ -32,6 +49,7 @@ describe('agent Slack events', () => {
       NEXT_PUBLIC_APP_URL: 'https://amadutown.test',
       SLACK_BOT_TOKEN: 'xoxb-test',
     }
+    mocks.from.mockReturnValue(queryResult({ data: null, error: null }))
     mocks.runChiefOfStaffChat.mockResolvedValue({
       runId: 'run-123',
       reply: 'Two items need attention.',
@@ -130,6 +148,31 @@ describe('agent Slack events', () => {
       }),
     )
     expect((fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0]?.[1]?.body).toContain('"thread_ts":"1700000000.000000"')
+  })
+
+  it('uses matching Slack notification thread context for Shaka replies', async () => {
+    mocks.from.mockReturnValueOnce(queryResult({ data: { id: 'notification-run' }, error: null }))
+
+    const result = await handleSlackAgentEvent({
+      type: 'event_callback',
+      event_id: 'Ev456',
+      event: {
+        type: 'app_mention',
+        user: 'U123',
+        channel: 'C123',
+        text: '<@UAGENT> summarize this blocker',
+        ts: '1700000000.000002',
+        thread_ts: '1700000000.000001',
+      },
+    })
+
+    expect(result).toEqual({ handled: true, runId: 'run-123' })
+    expect(mocks.runChiefOfStaffChat).toHaveBeenCalledWith({
+      message: 'summarize this blocker',
+      userId: 'slack:U123',
+      triggerSource: 'slack_agent_thread_reply',
+      contextRef: { type: 'run', id: 'notification-run' },
+    })
   })
 
   it('formats Chief of Staff replies with trace links', () => {

--- a/lib/agent-slack-events.ts
+++ b/lib/agent-slack-events.ts
@@ -1,4 +1,5 @@
 import { runChiefOfStaffChat } from '@/lib/chief-of-staff-chat'
+import { supabaseAdmin } from '@/lib/supabase'
 
 export type SlackAgentEvent = {
   type?: string
@@ -62,6 +63,23 @@ export function formatChiefOfStaffSlackReply(result: Awaited<ReturnType<typeof r
   return parts.filter(Boolean).join('\n\n')
 }
 
+async function findSlackThreadContextRef(channel: string, threadTs: string) {
+  if (!supabaseAdmin) return null
+
+  const { data, error } = await supabaseAdmin
+    .from('agent_runs')
+    .select('id')
+    .eq('kind', 'slack_mobile_notification')
+    .filter('outcome->>slack_channel', 'eq', channel)
+    .filter('outcome->>slack_thread_ts', 'eq', threadTs)
+    .order('completed_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (error || !data?.id) return null
+  return { type: 'run' as const, id: data.id as string }
+}
+
 export async function handleSlackAgentEvent(payload: SlackAgentEventPayload) {
   const event = payload.event
   if (!shouldHandleSlackAgentEvent(event)) {
@@ -80,10 +98,14 @@ export async function handleSlackAgentEvent(payload: SlackAgentEventPayload) {
     return { handled: true as const, reason: 'empty_message' }
   }
 
+  const contextRef = event.thread_ts
+    ? await findSlackThreadContextRef(channel, event.thread_ts)
+    : null
   const result = await runChiefOfStaffChat({
     message,
     userId: `slack:${user}`,
-    triggerSource: 'slack_agent_chat',
+    triggerSource: contextRef ? 'slack_agent_thread_reply' : 'slack_agent_chat',
+    ...(contextRef ? { contextRef } : {}),
   })
 
   await postSlackAgentMessage({

--- a/lib/agent-slack-notifications.test.ts
+++ b/lib/agent-slack-notifications.test.ts
@@ -131,6 +131,44 @@ describe('Agent Ops Slack notifications', () => {
     }))
   })
 
+  it('prefers bot-token delivery so Slack threads can be traced back to Portfolio', async () => {
+    process.env.SLACK_BOT_TOKEN = 'xoxb-test'
+    process.env.SLACK_AGENT_OPS_CHANNEL_ID = 'CAGENTOPS'
+    process.env.SLACK_AGENT_OPS_WEBHOOK_URL = 'https://hooks.slack.test/agent'
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true, channel: 'CAGENTOPS', ts: '1770000000.000001' }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await sendAgentSlackNotification({ kind: 'blockers', actorLabel: 'admin' })
+
+    expect(result.sent).toBe(true)
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://slack.com/api/chat.postMessage',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ Authorization: 'Bearer xoxb-test' }),
+        body: expect.stringContaining('"channel":"CAGENTOPS"'),
+      }),
+    )
+    expect(mocks.recordAgentEvent).toHaveBeenCalledWith(expect.objectContaining({
+      metadata: expect.objectContaining({
+        delivery_mode: 'bot',
+        slack_channel: 'CAGENTOPS',
+        slack_message_ts: '1770000000.000001',
+        slack_thread_ts: '1770000000.000001',
+      }),
+    }))
+    expect(mocks.endAgentRun).toHaveBeenCalledWith(expect.objectContaining({
+      outcome: expect.objectContaining({
+        delivery_mode: 'bot',
+        slack_channel: 'CAGENTOPS',
+        slack_thread_ts: '1770000000.000001',
+      }),
+    }))
+  })
+
   it('limits work item notification cards to one primary action and one context action', async () => {
     process.env.SLACK_AGENT_OPS_WEBHOOK_URL = 'https://hooks.slack.test/agent'
     const fetchMock = vi.fn().mockResolvedValue({ ok: true })

--- a/lib/agent-slack-notifications.ts
+++ b/lib/agent-slack-notifications.ts
@@ -53,6 +53,14 @@ type AgentRunSummaryRow = {
   started_at?: string | null
 }
 
+type SlackDeliveryResult = {
+  sent: boolean
+  reason: string | null
+  mode: 'bot' | 'webhook' | 'none'
+  channel?: string | null
+  ts?: string | null
+}
+
 function baseUrl() {
   return (
     process.env.NEXT_PUBLIC_BASE_URL ||
@@ -368,10 +376,48 @@ export async function buildAgentSlackNotificationPayload(input: AgentSlackNotifi
   return buildWorkItemPayload(input)
 }
 
-async function postToSlack(text: string, blocks: SlackBlock[]) {
+async function postWithBotToken(text: string, blocks: SlackBlock[]): Promise<SlackDeliveryResult | null> {
+  const token = process.env.SLACK_BOT_TOKEN
+  const channel = process.env.SLACK_AGENT_OPS_CHANNEL_ID || process.env.SLACK_AGENT_OPS_CHANNEL
+  if (!token || !channel) return null
+
+  const response = await fetch('https://slack.com/api/chat.postMessage', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+    body: JSON.stringify({
+      channel,
+      text,
+      blocks,
+      unfurl_links: false,
+      unfurl_media: false,
+    }),
+  })
+  const body = await response.json().catch(() => null) as { ok?: boolean; error?: string; channel?: string; ts?: string } | null
+  if (!response.ok || body?.ok === false) {
+    return {
+      sent: false,
+      reason: `Slack bot delivery returned ${body?.error ?? `HTTP ${response.status}`}.`,
+      mode: 'bot',
+      channel,
+      ts: null,
+    }
+  }
+  return {
+    sent: true,
+    reason: null,
+    mode: 'bot',
+    channel: body?.channel ?? channel,
+    ts: body?.ts ?? null,
+  }
+}
+
+async function postWithWebhook(text: string, blocks: SlackBlock[]): Promise<SlackDeliveryResult> {
   const webhookUrl = process.env.SLACK_AGENT_OPS_WEBHOOK_URL
   if (!webhookUrl || !webhookUrl.startsWith('https://')) {
-    return { sent: false, reason: 'SLACK_AGENT_OPS_WEBHOOK_URL is not configured.' }
+    return { sent: false, reason: 'Slack bot channel and webhook are not configured.', mode: 'none' }
   }
   const response = await fetch(webhookUrl, {
     method: 'POST',
@@ -379,9 +425,22 @@ async function postToSlack(text: string, blocks: SlackBlock[]) {
     body: JSON.stringify({ text, blocks }),
   })
   if (!response.ok) {
-    return { sent: false, reason: `Slack webhook returned HTTP ${response.status}.` }
+    return { sent: false, reason: `Slack webhook returned HTTP ${response.status}.`, mode: 'webhook' }
   }
-  return { sent: true, reason: null }
+  return { sent: true, reason: null, mode: 'webhook' }
+}
+
+async function postToSlack(text: string, blocks: SlackBlock[]): Promise<SlackDeliveryResult> {
+  const botDelivery = await postWithBotToken(text, blocks)
+  if (botDelivery?.sent) return botDelivery
+
+  const webhookDelivery = await postWithWebhook(text, blocks)
+  if (webhookDelivery.sent || !botDelivery) return webhookDelivery
+
+  return {
+    ...botDelivery,
+    reason: `${botDelivery.reason} Webhook fallback also failed: ${webhookDelivery.reason}`,
+  }
 }
 
 export async function sendAgentSlackNotification(input: AgentSlackNotificationInput): Promise<AgentSlackNotificationResult> {
@@ -432,6 +491,10 @@ export async function sendAgentSlackNotification(input: AgentSlackNotificationIn
       notification_kind: input.kind,
       item_count: payload.itemCount,
       reason: delivery.reason,
+      delivery_mode: delivery.mode,
+      slack_channel: delivery.channel ?? null,
+      slack_message_ts: delivery.ts ?? null,
+      slack_thread_ts: delivery.ts ?? null,
       blocks: payload.blocks,
     },
     idempotencyKey: `${idempotencyKey}:delivery`,
@@ -445,6 +508,10 @@ export async function sendAgentSlackNotification(input: AgentSlackNotificationIn
       skipped: !delivery.sent,
       reason: delivery.reason,
       item_count: payload.itemCount,
+      delivery_mode: delivery.mode,
+      slack_channel: delivery.channel ?? null,
+      slack_message_ts: delivery.ts ?? null,
+      slack_thread_ts: delivery.ts ?? null,
     },
   })
 


### PR DESCRIPTION
Summary
- Prefer Slack bot-token delivery for Agent Ops mobile notifications when `SLACK_BOT_TOKEN` and `SLACK_AGENT_OPS_CHANNEL_ID` are configured.
- Record Slack channel/message/thread timestamps on notification traces so Portfolio can connect Slack follow-up back to the originating run.
- Scope Slack thread replies to the matching notification run when Shaka answers in-channel.

Validation
- `npm test -- lib/agent-slack-notifications.test.ts lib/agent-slack-events.test.ts app/api/slack/agent/events/route.test.ts app/api/admin/agents/slack-notifications/route.test.ts`
- `npx tsc --noEmit --pretty false`
- `npm run lint`
- `git diff --check`
- Push hook database health check passed.

Integration Notes
- Requires `SLACK_BOT_TOKEN` plus `SLACK_AGENT_OPS_CHANNEL_ID` to enable thread-trace continuity. Existing webhook delivery remains as fallback.
- No production activation, credential mutation, outbound customer send, or approval bypass was added.
- Vercel contexts were not checked yet from this draft PR; Integration Captain should verify `Vercel – portfolio` and `Vercel – portfolio-staging` before merge.