### PR TITLE
feat: add n8n variable visibility checks

### DIFF
--- a/docs/credential-management-system.md
+++ b/docs/credential-management-system.md
@@ -43,7 +43,7 @@ Use plain `credentials:smoke` for local registry checks. Use `--require-provider
 
 Use `credentials:report` for rotation visibility. It is read-only and summarizes the inventory by status, source of truth, risk, runtime sink, approval boundary, and next action. It does not fetch or print secret values. The same report is exposed to admins at `/admin/credentials` through `/api/admin/credentials/report`.
 
-Use `credentials:report -- --check-sinks` when the operator needs runtime sink presence visibility. This mode inspects local env files and Vercel environment metadata by key name only. It also checks n8n credential metadata names/types through the n8n API when `N8N_API_KEY` is available; n8n Variables remain `unknown` until a key-only path exists because the variables API may include values. It never reads or prints secret values, and unknown/unavailable sink states should be treated as visibility gaps, not proof that a credential is absent.
+Use `credentials:report -- --check-sinks` when the operator needs runtime sink presence visibility. This mode inspects local env files, Vercel environment metadata, n8n credential names/types, and n8n Variable keys by metadata only. n8n Variable values are reduced away before the broker records evidence, so values are not printed or stored. If `N8N_API_KEY` lacks read access to `/api/v1/variables`, n8n Variable sinks are reported as `unavailable` with the missing scope action instead of remaining `unknown`. Unknown/unavailable sink states should be treated as visibility gaps, not proof that a credential is absent.
 
 The report includes runtime sink gap actions for `missing`, `unknown`, and `unavailable` sink states. These are operator tasks, not automatic mutations: sync missing sinks from the source of truth, restore read-only metadata access when checks are unavailable, or add a key-only adapter before treating unknown states as verified.
 
@@ -89,6 +89,7 @@ Use `credentials:baseline-template` when `credentials:report` shows `needs-basel
 - Keep production imports gated: do not populate `prod:/portfolio` from unprefixed local env values unless a production source/approval packet confirms the value.
 - Replace each `pending-provider-confirmation` baseline with a verified `lastRotatedAt` date and evidence note.
 - Configure runtime sinks from the source of truth: Vercel env vars, n8n Variables/Credentials, and local ignored env files.
+- Grant reporting-only n8n API keys the read scopes needed for metadata checks, including credential metadata list access and `variable:list`; do not grant write/delete scopes for reporting-only keys.
 - Run `npm run credentials:smoke -- --env staging` after the first sync.
 - Run `npm run credentials:smoke -- --env staging --require-provider-access` before calling the system operational.
 

--- a/scripts/credential-broker.test.ts
+++ b/scripts/credential-broker.test.ts
@@ -48,18 +48,26 @@ describe('credential broker CLI runtime sink checks', () => {
       envs: [{ key: 'OPENAI_API_KEY' }, { key: 'STRIPE_SECRET_KEY' }],
     })
     const n8n = await startN8nMetadataServer({
-      data: [
-        {
-          name: 'OpenAI Staging Account',
-          type: 'openAiApi',
-          data: { apiKey: 'must-not-leak-provider-secret' },
-        },
-        {
-          name: 'Anthropic Staging Account',
-          type: 'anthropicApi',
-          data: { apiKey: 'also-must-not-leak' },
-        },
-      ],
+      credentials: {
+        data: [
+          {
+            name: 'OpenAI Staging Account',
+            type: 'openAiApi',
+            data: { apiKey: 'must-not-leak-provider-secret' },
+          },
+          {
+            name: 'Anthropic Staging Account',
+            type: 'anthropicApi',
+            data: { apiKey: 'also-must-not-leak' },
+          },
+        ],
+      },
+      variables: {
+        data: [
+          { key: 'OPENROUTER_API_KEY', value: 'must-not-leak-variable-secret' },
+          { key: 'LINKEDIN_COOKIE', value: 'also-must-not-leak-variable-secret' },
+        ],
+      },
     })
 
     try {
@@ -92,10 +100,17 @@ describe('credential broker CLI runtime sink checks', () => {
       })
       expect(presenceFor(openAi, 'n8n Credentials').evidence).toContain('OpenAI Staging Account:openAiApi')
 
+      expect(presenceFor(rowFor(report, 'OPENROUTER_API_KEY'), 'n8n Variables')).toMatchObject({
+        status: 'present',
+        evidence: 'Found n8n variable key metadata for OPENROUTER_API_KEY; values were not printed or stored.',
+      })
+
       const serialized = JSON.stringify(report)
       expect(serialized).not.toContain('test-n8n-api-key')
       expect(serialized).not.toContain('must-not-leak-provider-secret')
       expect(serialized).not.toContain('also-must-not-leak')
+      expect(serialized).not.toContain('must-not-leak-variable-secret')
+      expect(serialized).not.toContain('also-must-not-leak-variable-secret')
     } finally {
       await n8n.close()
     }
@@ -126,6 +141,10 @@ describe('credential broker CLI runtime sink checks', () => {
     expect(presenceFor(openAi, 'n8n Credentials')).toMatchObject({
       status: 'unavailable',
       evidence: 'n8n credential metadata unavailable because N8N_API_KEY is not set.',
+    })
+    expect(presenceFor(rowFor(report, 'OPENROUTER_API_KEY'), 'n8n Variables')).toMatchObject({
+      status: 'unavailable',
+      evidence: 'n8n variable metadata unavailable because N8N_API_KEY is not set.',
     })
     expect(report.sinkGapActions).toEqual(expect.arrayContaining([
       expect.objectContaining({
@@ -180,12 +199,21 @@ async function runBroker(args: string[], env: Record<string, string>): Promise<B
   })
 }
 
-async function startN8nMetadataServer(payload: unknown): Promise<{ baseUrl: string; close: () => Promise<void> }> {
+async function startN8nMetadataServer(payload: { credentials: unknown; variables?: unknown }): Promise<{ baseUrl: string; close: () => Promise<void> }> {
   const server = http.createServer((request, response) => {
-    expect(request.url).toBe('/api/v1/credentials')
     expect(request.headers['x-n8n-api-key']).toBe('test-n8n-api-key')
-    response.writeHead(200, { 'Content-Type': 'application/json' })
-    response.end(JSON.stringify(payload))
+    if (request.url === '/api/v1/credentials') {
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(JSON.stringify(payload.credentials))
+      return
+    }
+    if (request.url === '/api/v1/variables') {
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(JSON.stringify(payload.variables ?? { data: [] }))
+      return
+    }
+    response.writeHead(404, { 'Content-Type': 'application/json' })
+    response.end(JSON.stringify({ message: 'not found' }))
   })
 
   await new Promise<void>((resolve) => {

--- a/scripts/credential-broker.ts
+++ b/scripts/credential-broker.ts
@@ -93,7 +93,7 @@ const ROOT = path.resolve(__dirname, '..')
 const INVENTORY_PATH = path.join(ROOT, 'docs', 'credential-inventory.json')
 const AUDIT_DIR = path.join(ROOT, '.credential-rotation-audits')
 const VALID_ENVS: EnvironmentName[] = ['dev', 'staging', 'prod']
-const PROVIDER_READ_TIMEOUT_MS = 10_000
+const PROVIDER_READ_TIMEOUT_MS = 30_000
 const PROVIDER_WRITE_TIMEOUT_MS = 60_000
 const VERCEL_METADATA_TIMEOUT_MS = 15_000
 const N8N_METADATA_TIMEOUT_MS = 15_000
@@ -668,6 +668,7 @@ function collectRuntimeSinkPresence(
   const localEnvKeys = readLocalEnvKeys(env)
   const vercelEnvKeys = readVercelEnvKeys(env)
   const n8nCredentialMetadata = readN8nCredentialMetadata()
+  const n8nVariableMetadata = readN8nVariableMetadata()
 
   return envSecrets(inventory, env).flatMap((secret) => secret.runtimeSinks.map((sink) => {
     if (sink === 'local-env') {
@@ -677,7 +678,7 @@ function collectRuntimeSinkPresence(
       return vercelPresenceObservation(secret, sink, checkedAt, vercelEnvKeys)
     }
     if (sink === 'n8n Variables') {
-      return n8nVariablePresenceObservation(secret, sink, checkedAt)
+      return n8nVariablePresenceObservation(secret, sink, checkedAt, n8nVariableMetadata)
     }
     if (sink === 'n8n Credentials') {
       return n8nCredentialPresenceObservation(secret, sink, checkedAt, n8nCredentialMetadata)
@@ -697,6 +698,11 @@ function collectRuntimeSinkPresence(
 type N8nCredentialMetadata = {
   unavailableReason: string | null
   credentials: Array<{ name: string; type: string }>
+}
+
+type N8nVariableMetadata = {
+  unavailableReason: string | null
+  keys: Set<string>
 }
 
 function readN8nCredentialMetadata(): N8nCredentialMetadata {
@@ -759,15 +765,102 @@ const apiKey = process.env.N8N_API_KEY;
 function n8nVariablePresenceObservation(
   secret: CredentialSecret,
   sink: string,
-  checkedAt: string
+  checkedAt: string,
+  metadata: N8nVariableMetadata
 ): CredentialSinkPresenceObservation {
+  if (metadata.unavailableReason) {
+    return {
+      secretId: secret.id,
+      envVar: secret.envVar,
+      sink,
+      status: 'unavailable',
+      evidence: metadata.unavailableReason,
+      checkedAt,
+    }
+  }
+
+  if (metadata.keys.has(secret.envVar.toLowerCase())) {
+    return {
+      secretId: secret.id,
+      envVar: secret.envVar,
+      sink,
+      status: 'present',
+      evidence: `Found n8n variable key metadata for ${secret.envVar}; values were not printed or stored.`,
+      checkedAt,
+    }
+  }
+
   return {
     secretId: secret.id,
     envVar: secret.envVar,
     sink,
-    status: 'unknown',
-    evidence: 'n8n variable metadata was not checked because the variables API may include secret values. Use a future key-only adapter or approved sanitized export.',
+    status: 'missing',
+    evidence: `No n8n variable key metadata matched ${secret.envVar}.`,
     checkedAt,
+  }
+}
+
+function readN8nVariableMetadata(): N8nVariableMetadata {
+  const apiKey = process.env.N8N_API_KEY
+  const baseUrl = (process.env.N8N_BASE_URL || 'https://amadutown.app.n8n.cloud').replace(/\/$/, '')
+
+  if (!apiKey) {
+    return {
+      unavailableReason: 'n8n variable metadata unavailable because N8N_API_KEY is not set.',
+      keys: new Set(),
+    }
+  }
+
+  const script = `
+const baseUrl = process.env.N8N_BASE_URL || 'https://amadutown.app.n8n.cloud';
+const apiKey = process.env.N8N_API_KEY;
+(async () => {
+  const response = await fetch(baseUrl.replace(/\\/$/, '') + '/api/v1/variables', {
+    headers: { 'X-N8N-API-KEY': apiKey, Accept: 'application/json' },
+  });
+  if (response.status === 403) {
+    console.log(JSON.stringify({ forbidden: true, keys: [] }));
+    return;
+  }
+  if (!response.ok) process.exit(1);
+  const body = await response.json();
+  const items = Array.isArray(body) ? body : Array.isArray(body.data) ? body.data : [];
+  const keys = items.map((item) => String(item.key || item.name || item.variableKey || '')).filter(Boolean);
+  console.log(JSON.stringify({ keys }));
+})().catch(() => process.exit(1));
+`
+  const result = spawnSync(process.execPath, ['-e', script], {
+    cwd: ROOT,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, N8N_BASE_URL: baseUrl, N8N_API_KEY: apiKey },
+    timeout: N8N_METADATA_TIMEOUT_MS,
+  })
+
+  if (result.status !== 0) {
+    return {
+      unavailableReason: 'n8n variable metadata unavailable. Authenticate N8N_API_KEY and confirm read access to /api/v1/variables.',
+      keys: new Set(),
+    }
+  }
+
+  try {
+    const parsed = JSON.parse(result.stdout) as { forbidden?: boolean; keys?: string[] }
+    if (parsed.forbidden) {
+      return {
+        unavailableReason: 'n8n variable metadata unavailable. N8N_API_KEY needs variable:list scope for /api/v1/variables.',
+        keys: new Set(),
+      }
+    }
+    return {
+      unavailableReason: null,
+      keys: new Set((parsed.keys ?? []).map((key) => key.toLowerCase())),
+    }
+  } catch {
+    return {
+      unavailableReason: 'n8n variable metadata returned invalid JSON after key-only reduction.',
+      keys: new Set(),
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Add key-only n8n Variables metadata checks to the credential broker so `credentials:report -- --check-sinks` can classify n8n Variable sinks as present, missing, or unavailable without storing or printing values.
- Preserve n8n credential metadata checks and extend tests to prove variable values are redacted from report output.
- Document the reporting API-key requirement for n8n variable metadata visibility.
- Increase provider read timeout to tolerate slower 1Password CLI reads observed during provider-access smoke.

## Validation
- `git diff --check -- scripts/credential-broker.ts scripts/credential-broker.test.ts docs/credential-management-system.md`
- `npm test -- --run scripts/credential-broker.test.ts`
- `npm --silent run credentials:smoke -- --env staging --require-provider-access`
- `npm --silent run credentials:report -- --env staging --check-sinks --json` summarized as: present 57, missing 15, unknown 0, unavailable 14; all 14 n8n Variable sinks are explicitly unavailable because the current `N8N_API_KEY` lacks `variable:list` for `/api/v1/variables`.
- Pre-push `npm run db:health-check` passed.

## Integration Notes
- No secret values are committed, printed, or stored by the new n8n Variables path; it records key names only.
- This PR improves visibility semantics but does not grant n8n access. Full n8n Variable sink verification still requires a reporting API key with `variable:list`.
- Vercel contexts not manually checked in this lane; Integration Captain should verify `Vercel – portfolio` and `Vercel – portfolio-staging` during merge/deploy sequencing.
