### PR TITLE
feat: gate video renders on approval

### DIFF
--- a/app/admin/content/video-generation/page.tsx
+++ b/app/admin/content/video-generation/page.tsx
@@ -18,6 +18,7 @@ import ProgressPanel, { type ProgressStep } from '@/components/admin/ProgressPan
 import { readSSEStream } from '@/lib/sse-reader'
 import { getCurrentSession } from '@/lib/auth'
 import { VIDEO_CHANNEL_CONFIGS, type VideoChannel } from '@/lib/constants/video-channel'
+import { buildVideoRenderApproval, VIDEO_RENDER_APPROVAL_PACKET_PATH } from '@/lib/video-render-approval'
 
 /* ───────────── Types ───────────── */
 
@@ -233,6 +234,8 @@ export default function VideoGenerationPage() {
   const [savingDraftId, setSavingDraftId] = useState<string | null>(null)
   const [draftEditForms, setDraftEditForms] = useState<Record<string, DraftEditForm>>({})
   const [draftEditError, setDraftEditError] = useState<string | null>(null)
+  const [renderApprovalDrafts, setRenderApprovalDrafts] = useState<Record<string, boolean>>({})
+  const [batchRenderApprovalConfirmed, setBatchRenderApprovalConfirmed] = useState(false)
 
   /* --- Progress panels --- */
   const [scratchProgress, setScratchProgress] = useState<ProgressStep[] | null>(null)
@@ -1070,14 +1073,15 @@ export default function VideoGenerationPage() {
       const res = await fetch(`/api/admin/video-generation/ideas-queue/${draftId}/generate`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-        body: JSON.stringify({
-          channel, aspectRatio, useTemplate,
-          templateId: useTemplate ? selectedTemplateId || undefined : undefined,
-          brandVoiceId: useTemplate ? selectedBrandVoiceId || undefined : undefined,
-          avatarId: !useTemplate ? selectedAvatarId || undefined : undefined,
-          brollAssetIds: brollIds && brollIds.length > 0 ? brollIds : undefined,
-        }),
-      })
+	        body: JSON.stringify({
+	          channel, aspectRatio, useTemplate,
+	          templateId: useTemplate ? selectedTemplateId || undefined : undefined,
+	          brandVoiceId: useTemplate ? selectedBrandVoiceId || undefined : undefined,
+	          avatarId: !useTemplate ? selectedAvatarId || undefined : undefined,
+	          brollAssetIds: brollIds && brollIds.length > 0 ? brollIds : undefined,
+	          renderApproval: buildVideoRenderApproval(Boolean(renderApprovalDrafts[draftId])),
+	        }),
+	      })
       const data = await res.json().catch(() => ({}))
       timers.forEach(clearTimeout)
       if (!res.ok) {
@@ -1300,10 +1304,11 @@ export default function VideoGenerationPage() {
   const selectAll = () => setSelectedDraftIds(new Set(filteredDrafts.map(d => d.id)))
   const deselectAll = () => setSelectedDraftIds(new Set())
 
-  const exitSelectionMode = () => {
-    setSelectionMode(false)
-    setSelectedDraftIds(new Set())
-  }
+	  const exitSelectionMode = () => {
+	    setSelectionMode(false)
+	    setSelectedDraftIds(new Set())
+	    setBatchRenderApprovalConfirmed(false)
+	  }
 
   const changeDraftsPage = (p: number) => {
     setDraftsPage(p)
@@ -1474,14 +1479,15 @@ export default function VideoGenerationPage() {
       const res = await fetch('/api/admin/video-generation/ideas-queue/batch', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-        body: JSON.stringify({
-          items,
-          channel, aspectRatio, useTemplate,
-          templateId: useTemplate ? selectedTemplateId || undefined : undefined,
-          brandVoiceId: useTemplate ? selectedBrandVoiceId || undefined : undefined,
-          avatarId: !useTemplate ? selectedAvatarId || undefined : undefined,
-        }),
-      })
+	        body: JSON.stringify({
+	          items,
+	          channel, aspectRatio, useTemplate,
+	          templateId: useTemplate ? selectedTemplateId || undefined : undefined,
+	          brandVoiceId: useTemplate ? selectedBrandVoiceId || undefined : undefined,
+	          avatarId: !useTemplate ? selectedAvatarId || undefined : undefined,
+	          renderApproval: buildVideoRenderApproval(batchRenderApprovalConfirmed),
+	        }),
+	      })
       const data = await res.json().catch(() => ({}))
       if (!res.ok) {
         setBatchMessage(data?.error || 'Batch failed')
@@ -1494,7 +1500,8 @@ export default function VideoGenerationPage() {
         ? { ...s, status: 'done' as const, detail: `${started} video(s) started` }
         : { ...s, status: 'done' as const }
       ) : null)
-      exitSelectionMode()
+	      setBatchRenderApprovalConfirmed(false)
+	      exitSelectionMode()
       fetchDrafts()
       fetchJobs()
     } catch (err) {
@@ -2131,22 +2138,31 @@ export default function VideoGenerationPage() {
                   {selectedCount === filteredDrafts.length ? 'Deselect All' : 'Select All'}
                 </button>
                 <div className="flex-1" />
-                <button
-                  onClick={batchGenerateVideos}
-                  disabled={selectedEligibleCount === 0 || generatingBatch}
-                  className={btnSmall + ' bg-radiant-gold text-imperial-navy hover:bg-gold-light disabled:bg-gray-600 disabled:text-gray-400'}
-                >
-                  {generatingBatch ? <Loader2 className="w-3 h-3 animate-spin" /> : <Play className="w-3 h-3" />}
-                  Generate Videos ({selectedEligibleCount})
-                </button>
+	                <button
+	                  onClick={batchGenerateVideos}
+	                  disabled={selectedEligibleCount === 0 || generatingBatch || !batchRenderApprovalConfirmed}
+	                  className={btnSmall + ' bg-radiant-gold text-imperial-navy hover:bg-gold-light disabled:bg-gray-600 disabled:text-gray-400'}
+	                >
+	                  {generatingBatch ? <Loader2 className="w-3 h-3 animate-spin" /> : <Play className="w-3 h-3" />}
+	                  {batchRenderApprovalConfirmed ? `Generate Videos (${selectedEligibleCount})` : 'Confirm render gate'}
+	                </button>
                 <button
                   onClick={batchCreatePresentations}
                   disabled={selectedCount === 0 || generatingGamma}
                   className={btnSmall + ' bg-amber-500/20 text-amber-400 hover:bg-amber-500/30 disabled:opacity-50'}
                 >
-                  {generatingGamma ? <Loader2 className="w-3 h-3 animate-spin" /> : <FileText className="w-3 h-3" />}
-                  Create Presentations ({selectedCount})
-                </button>
+	                  {generatingGamma ? <Loader2 className="w-3 h-3 animate-spin" /> : <FileText className="w-3 h-3" />}
+	                  Create Presentations ({selectedCount})
+	                </button>
+	                <label className="flex max-w-md items-start gap-2 text-[10px] leading-4 text-gray-400">
+	                  <input
+	                    type="checkbox"
+	                    checked={batchRenderApprovalConfirmed}
+	                    onChange={e => setBatchRenderApprovalConfirmed(e.target.checked)}
+	                    className="mt-0.5"
+	                  />
+	                  <span>Shaka render approval confirmed for selected drafts. One internal review render each; publishing stays separate.</span>
+	                </label>
               </div>
             )}
 
@@ -2174,9 +2190,10 @@ export default function VideoGenerationPage() {
                     const draftBrollIds = getDraftBroll(draft)
                     const isSelected = selectedDraftIds.has(draft.id)
                     const isExpanded = expandedDraftId === draft.id
-                    const sceneCount = draft.storyboard_json?.scenes?.length ?? 0
-                    const isEditing = editingDraftId === draft.id
-                    const editForm = draftEditForms[draft.id] ?? {
+	                    const sceneCount = draft.storyboard_json?.scenes?.length ?? 0
+	                    const isEditing = editingDraftId === draft.id
+	                    const renderApprovalConfirmed = Boolean(renderApprovalDrafts[draft.id])
+	                    const editForm = draftEditForms[draft.id] ?? {
                       title: draft.title,
                       scriptText: draft.script_text,
                       storyboardText: formatStoryboardForEdit(draft),
@@ -2442,12 +2459,23 @@ export default function VideoGenerationPage() {
                                                   <option value="9:16">9:16</option>
                                                 </select>
                                               </div>
-                                            </div>
-                                          </details>
-                                          <button onClick={() => generateFromDraft(draft.id)} disabled={overLimit || isEditing || !!generatingDraftId || !!generatingBatch || generatingGamma} className={btnPrimary + ' text-xs' + (overLimit || isEditing ? ' opacity-50 cursor-not-allowed' : '')}>
-                                            {generatingDraftId === draft.id ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Play className="w-3.5 h-3.5" />}
-                                            {isEditing ? 'Save review first' : generatingDraftId && generatingDraftId !== draft.id ? 'Busy...' : 'Generate Video'}
-                                          </button>
+	                                            </div>
+	                                          </details>
+	                                          <label className="flex items-start gap-2 rounded-lg border border-silicon-slate bg-background/50 p-2 text-[10px] leading-4 text-gray-400">
+	                                            <input
+	                                              type="checkbox"
+	                                              checked={renderApprovalConfirmed}
+	                                              onChange={e => setRenderApprovalDrafts(prev => ({ ...prev, [draft.id]: e.target.checked }))}
+	                                              className="mt-0.5"
+	                                            />
+	                                            <span>
+	                                              Shaka render approval confirmed from <code className="text-radiant-gold">{VIDEO_RENDER_APPROVAL_PACKET_PATH}</code>. One internal HeyGen review render only; publishing, ElevenLabs, n8n audio, and social queues remain separate approvals.
+	                                            </span>
+	                                          </label>
+	                                          <button onClick={() => generateFromDraft(draft.id)} disabled={overLimit || isEditing || !renderApprovalConfirmed || !!generatingDraftId || !!generatingBatch || generatingGamma} className={btnPrimary + ' text-xs' + (overLimit || isEditing || !renderApprovalConfirmed ? ' opacity-50 cursor-not-allowed' : '')}>
+	                                            {generatingDraftId === draft.id ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Play className="w-3.5 h-3.5" />}
+	                                            {isEditing ? 'Save review first' : !renderApprovalConfirmed ? 'Confirm render gate' : generatingDraftId && generatingDraftId !== draft.id ? 'Busy...' : 'Generate Video'}
+	                                          </button>
                                           {heygenProgress && heygenProgress.draftId === draft.id && (
                                             <ProgressPanel title="Generating Video" steps={heygenProgress.steps} variant="inline" onCancel={() => setHeygenProgress(null)} />
                                           )}

--- a/app/api/admin/video-generation/ideas-queue/[id]/generate/route.test.ts
+++ b/app/api/admin/video-generation/ideas-queue/[id]/generate/route.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { buildVideoRenderApproval } from '@/lib/video-render-approval'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  from: vi.fn(),
+  createVideo: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+vi.mock('@/lib/heygen', () => ({
+  createVideo: mocks.createVideo,
+}))
+
+import { POST } from './route'
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest('http://localhost/api/admin/video-generation/ideas-queue/draft-1/generate', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+function queueFetchBuilder() {
+  const single = vi.fn().mockResolvedValue({
+    data: {
+      id: 'draft-1',
+      title: 'The Receipt Every Agent Needs',
+      script_text: 'The first thing I built around agents was the receipt.',
+      storyboard_json: { scenes: [{ brollHint: 'admin' }] },
+      status: 'pending',
+      source: 'manual',
+    },
+    error: null,
+  })
+  return {
+    select: vi.fn(() => ({
+      eq: vi.fn(() => ({ single })),
+    })),
+  }
+}
+
+function brollBuilder() {
+  return {
+    select: vi.fn().mockResolvedValue({ data: [], error: null }),
+  }
+}
+
+function jobInsertBuilder() {
+  const single = vi.fn().mockResolvedValue({
+    data: {
+      id: 'job-1',
+      heygen_video_id: 'heygen-1',
+      heygen_status: 'pending',
+      created_at: '2026-05-27T22:30:00.000Z',
+    },
+    error: null,
+  })
+  return {
+    insert: vi.fn(() => ({
+      select: vi.fn(() => ({ single })),
+    })),
+  }
+}
+
+function queueUpdateBuilder() {
+  return {
+    update: vi.fn(() => ({
+      eq: vi.fn().mockResolvedValue({ data: null, error: null }),
+    })),
+  }
+}
+
+describe('POST /api/admin/video-generation/ideas-queue/[id]/generate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user-1' }, isAdmin: true })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.createVideo.mockResolvedValue({ videoId: 'heygen-1' })
+  })
+
+  it('requires render approval before reading the queue or calling HeyGen', async () => {
+    const response = await POST(makeRequest({ channel: 'youtube' }), { params: { id: 'draft-1' } })
+
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.error).toContain('Render approval confirmation')
+    expect(mocks.from).not.toHaveBeenCalled()
+    expect(mocks.createVideo).not.toHaveBeenCalled()
+  })
+
+  it('starts one HeyGen job when render approval is confirmed', async () => {
+    mocks.from
+      .mockReturnValueOnce(queueFetchBuilder())
+      .mockReturnValueOnce(brollBuilder())
+      .mockReturnValueOnce(jobInsertBuilder())
+      .mockReturnValueOnce(queueUpdateBuilder())
+
+    const response = await POST(
+      makeRequest({
+        channel: 'youtube',
+        aspectRatio: '16:9',
+        templateId: 'template-1',
+        renderApproval: buildVideoRenderApproval(true),
+      }),
+      { params: { id: 'draft-1' } }
+    )
+
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({
+      jobId: 'job-1',
+      heygenVideoId: 'heygen-1',
+      status: 'pending',
+    })
+    expect(mocks.createVideo).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'The Receipt Every Agent Needs',
+      channel: 'youtube',
+      templateId: 'template-1',
+    }))
+  })
+})

--- a/app/api/admin/video-generation/ideas-queue/[id]/generate/route.ts
+++ b/app/api/admin/video-generation/ideas-queue/[id]/generate/route.ts
@@ -10,6 +10,7 @@ import { supabaseAdmin } from '@/lib/supabase'
 import { createVideo } from '@/lib/heygen'
 import { channelToAspectRatio } from '@/lib/constants/video-channel'
 import type { VideoChannel, VideoAspectRatio } from '@/lib/constants/video-channel'
+import { videoRenderApprovalError } from '@/lib/video-render-approval'
 
 export const dynamic = 'force-dynamic'
 
@@ -31,6 +32,11 @@ export async function POST(
 
     const queueId = params.id
     const body = await request.json().catch(() => ({}))
+    const approvalError = videoRenderApprovalError(body.renderApproval)
+    if (approvalError) {
+      return NextResponse.json({ error: approvalError }, { status: 400 })
+    }
+
     const channel = (body.channel as VideoChannel) ?? 'youtube'
     const aspectRatio =
       (body.aspectRatio as VideoAspectRatio) ?? channelToAspectRatio(channel)

--- a/app/api/admin/video-generation/ideas-queue/batch/route.test.ts
+++ b/app/api/admin/video-generation/ideas-queue/batch/route.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  from: vi.fn(),
+  createVideo: vi.fn(),
+  isOverVideoGenerationLimit: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+vi.mock('@/lib/heygen', () => ({
+  createVideo: mocks.createVideo,
+}))
+
+vi.mock('@/lib/video-generation-rate-limit', () => ({
+  isOverVideoGenerationLimit: mocks.isOverVideoGenerationLimit,
+}))
+
+import { POST } from './route'
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest('http://localhost/api/admin/video-generation/ideas-queue/batch', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/admin/video-generation/ideas-queue/batch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user-1' }, isAdmin: true })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.isOverVideoGenerationLimit.mockResolvedValue(false)
+  })
+
+  it('requires render approval before batch generation can touch HeyGen', async () => {
+    const response = await POST(makeRequest({ items: [{ id: 'draft-1' }] }))
+
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.error).toContain('Render approval confirmation')
+    expect(mocks.from).not.toHaveBeenCalled()
+    expect(mocks.createVideo).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/admin/video-generation/ideas-queue/batch/route.ts
+++ b/app/api/admin/video-generation/ideas-queue/batch/route.ts
@@ -11,6 +11,7 @@ import { createVideo } from '@/lib/heygen'
 import { isOverVideoGenerationLimit } from '@/lib/video-generation-rate-limit'
 import { channelToAspectRatio } from '@/lib/constants/video-channel'
 import type { VideoChannel, VideoAspectRatio } from '@/lib/constants/video-channel'
+import { videoRenderApprovalError } from '@/lib/video-render-approval'
 
 export const dynamic = 'force-dynamic'
 export const maxDuration = 300
@@ -44,6 +45,10 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json().catch(() => ({}))
+    const approvalError = videoRenderApprovalError(body.renderApproval)
+    if (approvalError) {
+      return NextResponse.json({ error: approvalError }, { status: 400 })
+    }
 
     // Accept either { items: [...] } (new) or { limit } (legacy)
     const itemsPayload = Array.isArray(body.items) ? body.items as Array<{ id: string; brollAssetIds?: string[] }> : null

--- a/docs/agentic-content-video-scripts/render-approval-packet.md
+++ b/docs/agentic-content-video-scripts/render-approval-packet.md
@@ -138,6 +138,15 @@ Render can proceed only when all are true:
 - The script is still under 5000 characters.
 - B-roll assets, if attached, are public-safe.
 
+## Execution Gate
+
+The Admin Video Generation render path now requires the operator to confirm this Shaka approval packet before HeyGen starts:
+
+- The single-draft Generate Video button stays disabled until the render gate checkbox is checked.
+- The selected-draft batch Generate Videos button stays disabled until the batch render gate checkbox is checked.
+- The single-draft and batch API routes reject requests without the render approval payload before reading draft queue records or calling HeyGen.
+- The approval payload is scoped to one internal review render and explicitly excludes publishing approval.
+
 ## Stop Criteria
 
 Stop before render if any are true:

--- a/lib/video-render-approval.test.ts
+++ b/lib/video-render-approval.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildVideoRenderApproval,
+  VIDEO_RENDER_APPROVAL_PACKET_PATH,
+  VIDEO_RENDER_APPROVAL_SCOPE,
+  videoRenderApprovalError,
+} from './video-render-approval'
+
+describe('video render approval', () => {
+  it('accepts the controlled internal render approval payload', () => {
+    expect(videoRenderApprovalError(buildVideoRenderApproval(true))).toBeNull()
+  })
+
+  it('rejects missing confirmation', () => {
+    expect(videoRenderApprovalError(buildVideoRenderApproval(false))).toContain('required')
+  })
+
+  it('rejects bundled publishing approval', () => {
+    expect(videoRenderApprovalError({
+      confirmed: true,
+      approvedBy: 'Shaka',
+      packetPath: VIDEO_RENDER_APPROVAL_PACKET_PATH,
+      scope: VIDEO_RENDER_APPROVAL_SCOPE,
+      publishingApproved: true,
+    })).toContain('Publishing approval')
+  })
+})

--- a/lib/video-render-approval.ts
+++ b/lib/video-render-approval.ts
@@ -1,0 +1,52 @@
+export const VIDEO_RENDER_APPROVAL_PACKET_PATH = 'docs/agentic-content-video-scripts/render-approval-packet.md'
+export const VIDEO_RENDER_APPROVAL_SCOPE = 'internal_review_render_only'
+
+export interface VideoRenderApproval {
+  confirmed: boolean
+  approvedBy: string
+  packetPath: string
+  scope: string
+  publishingApproved?: boolean
+}
+
+export function buildVideoRenderApproval(confirmed: boolean): VideoRenderApproval {
+  return {
+    confirmed,
+    approvedBy: 'Shaka',
+    packetPath: VIDEO_RENDER_APPROVAL_PACKET_PATH,
+    scope: VIDEO_RENDER_APPROVAL_SCOPE,
+    publishingApproved: false,
+  }
+}
+
+export function parseVideoRenderApproval(input: unknown): VideoRenderApproval | null {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return null
+  const record = input as Record<string, unknown>
+  return {
+    confirmed: record.confirmed === true,
+    approvedBy: typeof record.approvedBy === 'string' ? record.approvedBy.trim() : '',
+    packetPath: typeof record.packetPath === 'string' ? record.packetPath.trim() : '',
+    scope: typeof record.scope === 'string' ? record.scope.trim() : '',
+    publishingApproved: record.publishingApproved === true,
+  }
+}
+
+export function videoRenderApprovalError(input: unknown): string | null {
+  const approval = parseVideoRenderApproval(input)
+  if (!approval?.confirmed) {
+    return 'Render approval confirmation is required before starting HeyGen.'
+  }
+  if (approval.approvedBy !== 'Shaka') {
+    return 'Render approval must be confirmed as Shaka-approved.'
+  }
+  if (approval.packetPath !== VIDEO_RENDER_APPROVAL_PACKET_PATH) {
+    return `Render approval must reference ${VIDEO_RENDER_APPROVAL_PACKET_PATH}.`
+  }
+  if (approval.scope !== VIDEO_RENDER_APPROVAL_SCOPE) {
+    return `Render approval scope must be ${VIDEO_RENDER_APPROVAL_SCOPE}.`
+  }
+  if (approval.publishingApproved) {
+    return 'Publishing approval cannot be bundled with the render approval.'
+  }
+  return null
+}


### PR DESCRIPTION
## Summary
- Require a render approval payload before single-draft or batch video generation can call HeyGen.
- Add Admin Video Generation UI confirmations that keep Generate Video / Generate Videos disabled until Shaka render approval is confirmed.
- Add shared render approval validation plus focused tests for the helper, single-draft route, and batch route.
- Update the render approval packet to document the enforced execution gate.

## Validation
- Polled PR #423 and confirmed it landed before starting from current `origin/main`.
- Preflight checked root branch, dirty state, open PRs, and worktrees; shared root is occupied by `codex/n8n-variable-visibility`, so this used a sibling worktree from `origin/main`.
- `npm ci`
- `npm run worktree:env -- --source /Users/vambahsillah/Projects/Portfolio`
- `npm run build:knowledge`
- `npm test -- lib/video-render-approval.test.ts 'app/api/admin/video-generation/ideas-queue/[id]/generate/route.test.ts' app/api/admin/video-generation/ideas-queue/batch/route.test.ts`
- `npx tsc --noEmit --pretty false`
- `npm run lint`
- `npm run db:health-check`
- `git diff --check`
- Added-line ASCII scan
- Anti-AI/style scan on new helper/docs text
- Visual smoke: pilot draft shows the Shaka render gate; Generate Video is disabled before confirmation and enabled after checking the gate.
- Pre-push database health check passed.
- No HeyGen job, ElevenLabs job, n8n audio regeneration, B-roll capture, publishing, customer-data smoke, or Vercel smoke was run.

## Integration Notes
- No migrations or env changes required.
- This changes the existing generation behavior: admin video renders now require explicit render-gate confirmation in the request body before HeyGen is called.
- Publishing remains a separate approval and is explicitly rejected by the render approval payload validator.
- Vercel - portfolio: not checked before this draft PR.
- Vercel - portfolio-staging: not checked before this draft PR.
