### PR TITLE
feat: add strict credential sink gate

### DIFF
--- a/docs/credential-management-system.md
+++ b/docs/credential-management-system.md
@@ -27,6 +27,8 @@ All commands read `docs/credential-inventory.json`.
 npm run credentials:list-due -- --env staging
 npm run credentials:report -- --env staging
 npm run credentials:report -- --env staging --check-sinks
+npm run credentials:report:strict-sinks -- --env staging
+npm run credentials:report -- --env staging --strict-sinks missing,unavailable
 npm run credentials:report -- --env staging --json
 npm run credentials:baseline-template -- --env staging
 npm run credentials:baseline-template -- --env staging --json
@@ -44,6 +46,8 @@ Use plain `credentials:smoke` for local registry checks. Use `--require-provider
 Use `credentials:report` for rotation visibility. It is read-only and summarizes the inventory by status, source of truth, risk, runtime sink, approval boundary, and next action. It does not fetch or print secret values. The same report is exposed to admins at `/admin/credentials` through `/api/admin/credentials/report`.
 
 Use `credentials:report -- --check-sinks` when the operator needs runtime sink presence visibility. This mode inspects local env files, Vercel environment metadata, n8n credential names/types, and n8n Variable keys by metadata only. n8n Variable values are reduced away before the broker records evidence, so values are not printed or stored. If `N8N_API_KEY` lacks read access to `/api/v1/variables`, n8n Variable sinks are reported as `unavailable` with the missing scope action instead of remaining `unknown`. Unknown/unavailable sink states should be treated as visibility gaps, not proof that a credential is absent.
+
+Use `credentials:report:strict-sinks` for monitor gates. It performs the same value-free sink checks and exits nonzero when any `missing`, `unknown`, or `unavailable` sink gaps remain. To gate on only specific statuses, use `credentials:report -- --env staging --strict-sinks missing,unavailable`; this implies sink checks even when `--check-sinks` is omitted.
 
 The report includes runtime sink gap actions for `missing`, `unknown`, and `unavailable` sink states. These are operator tasks, not automatic mutations: sync missing sinks from the source of truth, restore read-only metadata access when checks are unavailable, or add a key-only adapter before treating unknown states as verified.
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "n8n:drift-check:warn": "tsx scripts/n8n-workflow-drift-check.ts -- --warn",
     "credentials:list-due": "tsx scripts/credential-broker.ts list-due",
     "credentials:report": "tsx scripts/credential-broker.ts report",
+    "credentials:report:strict-sinks": "tsx scripts/credential-broker.ts report --check-sinks --strict-sinks",
     "credentials:baseline-template": "tsx scripts/credential-broker.ts baseline-template",
     "credentials:inject": "tsx scripts/credential-broker.ts inject",
     "credentials:rotate": "tsx scripts/credential-broker.ts rotate",

--- a/scripts/credential-broker.test.ts
+++ b/scripts/credential-broker.test.ts
@@ -277,6 +277,29 @@ describe('credential broker CLI runtime sink checks', () => {
       await n8n.close()
     }
   })
+
+  it('fails strict sink reports when selected runtime sink gaps remain', async () => {
+    const emptyPathDir = makeTempDir()
+    const result = await runBroker([
+      'report',
+      '--env',
+      'staging',
+      '--as-of',
+      '2026-05-14',
+      '--strict-sinks',
+      'unavailable',
+      '--json',
+    ], {
+      PATH: emptyPathDir,
+    })
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('Strict runtime sink gate failed:')
+    expect(result.stdout).toContain('"sinkGapActions"')
+    expect(result.stdout).toContain('"envVar": "OPENAI_API_KEY"')
+    expect(result.stdout).toContain('"sink": "n8n Credentials"')
+    expect(result.stdout).toContain('"status": "unavailable"')
+  })
 })
 
 function makeTempDir(): string {

--- a/scripts/credential-broker.ts
+++ b/scripts/credential-broker.ts
@@ -241,15 +241,37 @@ function report(inventory: CredentialInventory, args: ParsedArgs) {
   const env = getEnv(args)
   loadRuntimeEnv(env)
   const asOf = String(args.options['as-of'] || new Date().toISOString())
-  const sinkPresence = args.options['check-sinks'] ? collectRuntimeSinkPresence(inventory, env) : []
+  const strictSinkStatuses = strictSinkGapStatuses(args)
+  const sinkPresence = args.options['check-sinks'] || strictSinkStatuses.size > 0 ? collectRuntimeSinkPresence(inventory, env) : []
   const credentialReport = buildCredentialReport(inventory, env, asOf, readRotationPackets(), sinkPresence)
 
   if (args.options.json) {
     console.log(JSON.stringify(credentialReport, null, 2))
-    return
+  } else {
+    console.log(renderCredentialReportMarkdown(credentialReport))
   }
 
-  console.log(renderCredentialReportMarkdown(credentialReport))
+  if (strictSinkStatuses.size > 0) {
+    const strictGaps = credentialReport.sinkGapActions.filter((gap) => strictSinkStatuses.has(gap.status))
+    if (strictGaps.length > 0) {
+      fail(`Strict runtime sink gate failed: ${strictGaps.length} ${env} sink gap(s) matched ${Array.from(strictSinkStatuses).join(', ')}.`)
+    }
+  }
+}
+
+function strictSinkGapStatuses(args: ParsedArgs): Set<'missing' | 'unknown' | 'unavailable'> {
+  const raw = args.options['strict-sinks']
+  if (!raw) return new Set()
+  if (raw === true) return new Set(['missing', 'unknown', 'unavailable'])
+
+  const statuses = String(raw).split(',').map((item) => item.trim()).filter(Boolean)
+  const allowed = new Set(['missing', 'unknown', 'unavailable'])
+  for (const status of statuses) {
+    if (!allowed.has(status)) {
+      fail(`Invalid --strict-sinks status: ${status}. Expected missing, unknown, unavailable, or a comma-separated subset.`)
+    }
+  }
+  return new Set(statuses as Array<'missing' | 'unknown' | 'unavailable'>)
 }
 
 function baselineTemplate(inventory: CredentialInventory, args: ParsedArgs) {
@@ -1124,7 +1146,7 @@ function printHelp() {
 
 Commands:
   list-due      --env <dev|staging|prod> [--as-of YYYY-MM-DD] [--json]
-  report        --env <dev|staging|prod> [--as-of YYYY-MM-DD] [--check-sinks] [--json]
+  report        --env <dev|staging|prod> [--as-of YYYY-MM-DD] [--check-sinks] [--strict-sinks [missing,unknown,unavailable]] [--json]
   baseline-template --env <dev|staging|prod> [--updated-at YYYY-MM-DD] [--json]
   bootstrap-infisical --env <dev|staging|prod> [--source .env.local] [--secret id-or-envVar[,..]] [--apply]
   inject        --env <dev|staging|prod> [--secret id-or-envVar[,..]] -- <command>


### PR DESCRIPTION
## Summary
- Add `credentials:report:strict-sinks` for monitor/CI-style credential sink gates.
- Let `credentials:report -- --strict-sinks` imply value-free runtime sink checks and fail when selected sink gap statuses remain.
- Cover strict failure behavior in broker tests and document the command in the credential management guide.

## Boundary
- Read-only metadata checks only.
- No credential values printed or stored.
- No runtime sink mutation, rotation, revocation, or provider write.

## Validation
- `git diff --check -- package.json scripts/credential-broker.ts scripts/credential-broker.test.ts docs/credential-management-system.md`
- `npm test -- --run scripts/credential-broker.test.ts`
- `npm --silent run credentials:smoke -- --env staging --require-provider-access`
- `npm --silent run credentials:report:strict-sinks -- --env staging --json` exits 1 as expected with current known staging gaps: present 57, missing 15, unknown 0, unavailable 14; gapCount 29.
- Pre-push `npm run db:health-check` passed.

## Integration Notes
- Current staging strict gate intentionally fails until the 15 Vercel sink gaps and 14 n8n Variables metadata gaps are resolved. That is monitor signal, not a feature regression.
- Integration Captain should decide where to wire the strict command into scheduled credential visibility monitors after merge.
- Vercel contexts not manually checked in this lane; Integration Captain should verify `Vercel – portfolio` and `Vercel – portfolio-staging` during merge/deploy sequencing.
