### PR TITLE
feat: add video render readiness check

### DIFF
--- a/app/admin/content/video-generation/page.tsx
+++ b/app/admin/content/video-generation/page.tsx
@@ -44,6 +44,19 @@ interface DraftEditForm {
   storyboardText: string
 }
 
+interface RenderReadinessReport {
+  ready: boolean
+  blockingIssues: string[]
+  warnings: string[]
+  details: {
+    scriptCharacters: number
+    storyboardScenes: number
+    brollAssetIds: string[]
+    heygenMode: 'template' | 'avatar_voice' | 'missing'
+    approvalBoundary: string
+  }
+}
+
 interface DriveQueueItem {
   id: string
   drive_file_id: string
@@ -236,6 +249,8 @@ export default function VideoGenerationPage() {
   const [draftEditError, setDraftEditError] = useState<string | null>(null)
   const [renderApprovalDrafts, setRenderApprovalDrafts] = useState<Record<string, boolean>>({})
   const [batchRenderApprovalConfirmed, setBatchRenderApprovalConfirmed] = useState(false)
+  const [renderReadinessDrafts, setRenderReadinessDrafts] = useState<Record<string, RenderReadinessReport>>({})
+  const [checkingReadinessDraftId, setCheckingReadinessDraftId] = useState<string | null>(null)
 
   /* --- Progress panels --- */
   const [scratchProgress, setScratchProgress] = useState<ProgressStep[] | null>(null)
@@ -1041,6 +1056,53 @@ export default function VideoGenerationPage() {
     { id: 'sending', label: 'Sending to HeyGen', status: 'pending' },
     { id: 'saving', label: 'Creating job record', status: 'pending' },
   ]
+
+  const checkRenderReadiness = async (draftId: string) => {
+    setCheckingReadinessDraftId(draftId)
+    try {
+      const token = await getToken()
+      if (!token) return
+      const draft = drafts.find(d => d.id === draftId)
+      const brollIds = draft ? getDraftBroll(draft) : undefined
+      const res = await fetch(`/api/admin/video-generation/ideas-queue/${draftId}/render-readiness`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          channel,
+          aspectRatio,
+          useTemplate,
+          templateId: useTemplate ? selectedTemplateId || undefined : undefined,
+          brandVoiceId: useTemplate ? selectedBrandVoiceId || undefined : undefined,
+          avatarId: !useTemplate ? selectedAvatarId || undefined : undefined,
+          brollAssetIds: brollIds && brollIds.length > 0 ? brollIds : undefined,
+        }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        setRenderReadinessDrafts(prev => ({
+          ...prev,
+          [draftId]: {
+            ready: false,
+            blockingIssues: [data?.error ?? 'Readiness check failed.'],
+            warnings: [],
+            details: {
+              scriptCharacters: draft?.script_text.length ?? 0,
+              storyboardScenes: draft?.storyboard_json?.scenes?.length ?? 0,
+              brollAssetIds: brollIds ?? [],
+              heygenMode: 'missing',
+              approvalBoundary: 'Readiness failed before approval could be evaluated.',
+            },
+          },
+        }))
+        return
+      }
+      if (data?.report) {
+        setRenderReadinessDrafts(prev => ({ ...prev, [draftId]: data.report as RenderReadinessReport }))
+      }
+    } finally {
+      setCheckingReadinessDraftId(null)
+    }
+  }
 
   const generateFromDraft = async (draftId: string) => {
     setGeneratingDraftId(draftId)
@@ -2191,9 +2253,11 @@ export default function VideoGenerationPage() {
                     const isSelected = selectedDraftIds.has(draft.id)
                     const isExpanded = expandedDraftId === draft.id
 	                    const sceneCount = draft.storyboard_json?.scenes?.length ?? 0
-	                    const isEditing = editingDraftId === draft.id
-	                    const renderApprovalConfirmed = Boolean(renderApprovalDrafts[draft.id])
-	                    const editForm = draftEditForms[draft.id] ?? {
+                    const isEditing = editingDraftId === draft.id
+                    const renderApprovalConfirmed = Boolean(renderApprovalDrafts[draft.id])
+                    const renderReadiness = renderReadinessDrafts[draft.id]
+                    const checkingReadiness = checkingReadinessDraftId === draft.id
+                    const editForm = draftEditForms[draft.id] ?? {
                       title: draft.title,
                       scriptText: draft.script_text,
                       storyboardText: formatStoryboardForEdit(draft),
@@ -2461,6 +2525,46 @@ export default function VideoGenerationPage() {
                                               </div>
 	                                            </div>
 	                                          </details>
+                                          <div className="rounded-lg border border-silicon-slate bg-background/50 p-2">
+                                            <div className="flex flex-wrap items-center justify-between gap-2">
+                                              <div>
+                                                <div className="text-[10px] font-medium text-foreground">Render readiness</div>
+                                                <div className="text-[10px] text-gray-500">Read-only check for draft status, HeyGen config, script length, and B-roll matches.</div>
+                                              </div>
+                                              <button
+                                                onClick={() => checkRenderReadiness(draft.id)}
+                                                disabled={checkingReadiness || isEditing || !!generatingDraftId || !!generatingBatch || generatingGamma}
+                                                className="flex items-center gap-1.5 rounded-lg border border-silicon-slate px-2.5 py-1.5 text-[10px] text-gray-300 hover:border-radiant-gold/50 hover:text-radiant-gold disabled:opacity-50"
+                                              >
+                                                {checkingReadiness ? <Loader2 className="h-3 w-3 animate-spin" /> : <CheckCircle className="h-3 w-3" />}
+                                                Check readiness
+                                              </button>
+                                            </div>
+                                            {renderReadiness && (
+                                              <div className="mt-2 space-y-1 text-[10px]">
+                                                <div className={renderReadiness.ready ? 'text-emerald-400' : 'text-amber-400'}>
+                                                  {renderReadiness.ready ? 'Ready for approval-gated internal render.' : 'Resolve blocking issues before render.'}
+                                                </div>
+                                                <div className="flex flex-wrap gap-2 text-gray-500">
+                                                  <span>{renderReadiness.details.scriptCharacters.toLocaleString()} chars</span>
+                                                  <span>{renderReadiness.details.storyboardScenes} scenes</span>
+                                                  <span>{renderReadiness.details.brollAssetIds.length} B-roll</span>
+                                                  <span>{renderReadiness.details.heygenMode === 'template' ? 'Template' : renderReadiness.details.heygenMode === 'avatar_voice' ? 'Avatar + voice' : 'Missing HeyGen config'}</span>
+                                                </div>
+                                                {renderReadiness.blockingIssues.length > 0 && (
+                                                  <ul className="space-y-0.5 text-amber-300">
+                                                    {renderReadiness.blockingIssues.map((issue, index) => <li key={index}>{issue}</li>)}
+                                                  </ul>
+                                                )}
+                                                {renderReadiness.warnings.length > 0 && (
+                                                  <ul className="space-y-0.5 text-gray-400">
+                                                    {renderReadiness.warnings.map((warning, index) => <li key={index}>{warning}</li>)}
+                                                  </ul>
+                                                )}
+                                                <div className="text-gray-500">{renderReadiness.details.approvalBoundary}</div>
+                                              </div>
+                                            )}
+                                          </div>
 	                                          <label className="flex items-start gap-2 rounded-lg border border-silicon-slate bg-background/50 p-2 text-[10px] leading-4 text-gray-400">
 	                                            <input
 	                                              type="checkbox"

--- a/app/api/admin/video-generation/ideas-queue/[id]/render-readiness/route.test.ts
+++ b/app/api/admin/video-generation/ideas-queue/[id]/render-readiness/route.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  from: vi.fn(),
+  getHeyGenDefaults: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+vi.mock('@/lib/heygen-config', () => ({
+  getHeyGenDefaults: mocks.getHeyGenDefaults,
+}))
+
+import { POST } from './route'
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest('http://localhost/api/admin/video-generation/ideas-queue/draft-1/render-readiness', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+function queueFetchBuilder(overrides: Record<string, unknown> = {}) {
+  const single = vi.fn().mockResolvedValue({
+    data: {
+      id: 'draft-1',
+      title: 'The Receipt Every Agent Needs',
+      script_text: 'The first thing I built around agents was the receipt.',
+      storyboard_json: { scenes: [{ brollHint: 'admin' }] },
+      status: 'pending',
+      video_generation_job_id: null,
+      ...overrides,
+    },
+    error: null,
+  })
+  return {
+    select: vi.fn(() => ({
+      eq: vi.fn(() => ({ single })),
+    })),
+  }
+}
+
+function brollBuilder() {
+  return {
+    select: vi.fn().mockResolvedValue({
+      data: [{ id: 'asset-1', filename: 'admin-dashboard.mp4', route_description: 'Admin mission control' }],
+      error: null,
+    }),
+  }
+}
+
+describe('POST /api/admin/video-generation/ideas-queue/[id]/render-readiness', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubEnv('HEYGEN_TEMPLATE_ID', '')
+    vi.stubEnv('HEYGEN_AVATAR_ID', '')
+    vi.stubEnv('HEYGEN_VOICE_ID', '')
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user-1' }, isAdmin: true })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.getHeyGenDefaults.mockResolvedValue({ avatarId: null, voiceId: null })
+  })
+
+  it('returns a ready report without calling HeyGen or mutating jobs', async () => {
+    mocks.from
+      .mockReturnValueOnce(queueFetchBuilder())
+      .mockReturnValueOnce(brollBuilder())
+
+    const response = await POST(
+      makeRequest({
+        channel: 'youtube',
+        aspectRatio: '16:9',
+        templateId: 'template-1',
+      }),
+      { params: { id: 'draft-1' } }
+    )
+
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.report.ready).toBe(true)
+    expect(body.report.details.brollAssetIds).toEqual(['asset-1'])
+    expect(body.report.details.approvalBoundary).toContain('does not start a render')
+    expect(mocks.from).toHaveBeenCalledTimes(2)
+  })
+
+  it('reports blocked readiness when HeyGen config is missing', async () => {
+    mocks.from
+      .mockReturnValueOnce(queueFetchBuilder({ storyboard_json: { scenes: [] } }))
+
+    const response = await POST(
+      makeRequest({ channel: 'youtube', aspectRatio: '16:9' }),
+      { params: { id: 'draft-1' } }
+    )
+
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.report.ready).toBe(false)
+    expect(body.report.blockingIssues.join(' ')).toContain('HeyGen template or avatar and voice')
+    expect(body.report.warnings).toContain('No storyboard scenes are attached for visual direction.')
+  })
+})

--- a/app/api/admin/video-generation/ideas-queue/[id]/render-readiness/route.ts
+++ b/app/api/admin/video-generation/ideas-queue/[id]/render-readiness/route.ts
@@ -1,0 +1,116 @@
+/**
+ * POST /api/admin/video-generation/ideas-queue/[id]/render-readiness
+ * Read-only preflight for a draft render. Does not call HeyGen or mutate jobs.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { supabaseAdmin } from '@/lib/supabase'
+import { channelToAspectRatio } from '@/lib/constants/video-channel'
+import type { VideoChannel, VideoAspectRatio } from '@/lib/constants/video-channel'
+import { buildVideoRenderReadinessReport } from '@/lib/video-render-readiness'
+
+export const dynamic = 'force-dynamic'
+
+interface StoryboardScene {
+  brollHint?: string
+}
+
+function cleanIdArray(input: unknown): string[] {
+  if (!Array.isArray(input)) return []
+  return input.filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const auth = await verifyAdmin(request)
+    if (isAuthError(auth)) {
+      return NextResponse.json({ error: auth.error }, { status: auth.status })
+    }
+
+    const queueId = params.id
+    const body = await request.json().catch(() => ({}))
+    const channel = (body.channel as VideoChannel) ?? 'youtube'
+    const aspectRatio =
+      (body.aspectRatio as VideoAspectRatio) ?? channelToAspectRatio(channel)
+    const templateId =
+      (body.templateId as string)?.trim() || process.env.HEYGEN_TEMPLATE_ID || null
+    let avatarId =
+      (body.avatarId as string)?.trim() || process.env.HEYGEN_AVATAR_ID || null
+    let voiceId =
+      (body.voiceId as string)?.trim() || process.env.HEYGEN_VOICE_ID || null
+
+    const { data: queueItem, error: fetchErr } = await supabaseAdmin
+      .from('video_ideas_queue')
+      .select('id, title, script_text, storyboard_json, status, video_generation_job_id')
+      .eq('id', queueId)
+      .single()
+
+    if (fetchErr || !queueItem) {
+      return NextResponse.json(
+        { error: 'Draft queue item not found' },
+        { status: 404 }
+      )
+    }
+
+    if (!templateId && (!avatarId || !voiceId)) {
+      const { getHeyGenDefaults } = await import('@/lib/heygen-config')
+      const defaults = await getHeyGenDefaults()
+      if (!avatarId && defaults.avatarId) avatarId = defaults.avatarId
+      if (!voiceId && defaults.voiceId) voiceId = defaults.voiceId
+    }
+
+    let brollAssetIds = cleanIdArray(body.brollAssetIds)
+    const storyboard = queueItem.storyboard_json as { scenes?: StoryboardScene[] } | null
+    const scenes = Array.isArray(storyboard?.scenes) ? storyboard.scenes : []
+
+    if (brollAssetIds.length === 0) {
+      const brollHints = scenes
+        .map((scene) => scene.brollHint)
+        .filter((hint): hint is string => Boolean(hint?.trim()))
+
+      if (brollHints.length > 0) {
+        const { data: libraryAssets } = await supabaseAdmin
+          .from('broll_library')
+          .select('id, filename, route_description')
+
+        if (libraryAssets && libraryAssets.length > 0) {
+          for (const hint of brollHints) {
+            const lower = hint.toLowerCase()
+            const match = libraryAssets.find(
+              (asset: { id: string; filename: string; route_description: string | null }) =>
+                asset.filename.toLowerCase().includes(lower) ||
+                (asset.route_description ?? '').toLowerCase().includes(lower)
+            )
+            if (match && !brollAssetIds.includes(match.id)) {
+              brollAssetIds.push(match.id)
+            }
+          }
+        }
+      }
+    }
+
+    const report = buildVideoRenderReadinessReport({
+      title: queueItem.title,
+      status: queueItem.status,
+      scriptText: queueItem.script_text,
+      storyboardScenes: scenes.length,
+      videoGenerationJobId: queueItem.video_generation_job_id,
+      templateId,
+      avatarId,
+      voiceId,
+      channel,
+      aspectRatio,
+      brollAssetIds,
+    })
+
+    return NextResponse.json({ report })
+  } catch (error) {
+    console.error('[Video generation] Render readiness error:', error)
+    const message = error instanceof Error ? error.message : String(error)
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/docs/agentic-content-video-scripts/render-approval-packet.md
+++ b/docs/agentic-content-video-scripts/render-approval-packet.md
@@ -84,7 +84,8 @@ Recommended capture order:
 2. Re-open the pending draft in Admin Video Generation.
 3. Confirm the draft still shows `2386 / 5000` characters and 5 scenes.
 4. Confirm B-roll assets are linked only to approved hints.
-5. Then request Shaka approval to render.
+5. Run the read-only Render readiness check.
+6. Then request Shaka approval to render.
 
 ## Risk Review
 
@@ -142,6 +143,8 @@ Render can proceed only when all are true:
 
 The Admin Video Generation render path now requires the operator to confirm this Shaka approval packet before HeyGen starts:
 
+- Each expanded draft includes a read-only Render readiness check for draft status, script length, HeyGen config, storyboard count, and B-roll matches.
+- The readiness check does not create a job, update the queue, call HeyGen, approve publishing, or replace Shaka approval.
 - The single-draft Generate Video button stays disabled until the render gate checkbox is checked.
 - The selected-draft batch Generate Videos button stays disabled until the batch render gate checkbox is checked.
 - The single-draft and batch API routes reject requests without the render approval payload before reading draft queue records or calling HeyGen.
@@ -160,4 +163,4 @@ Stop before render if any are true:
 
 ## Roadmap Position
 
-This packet closes the gap between a reviewed script and a renderable pilot. The next phase after approval is a controlled HeyGen render, followed by final MP4 review and a separate publishing packet.
+This packet now closes the gap between a reviewed script and a render-ready pilot. The next phase after Shaka approval is a controlled HeyGen render, followed by final MP4 review and a separate publishing packet.

--- a/lib/video-render-readiness.test.ts
+++ b/lib/video-render-readiness.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { buildVideoRenderReadinessReport, VIDEO_RENDER_SCRIPT_MAX } from './video-render-readiness'
+
+describe('video render readiness', () => {
+  it('marks a pending draft with template config as ready', () => {
+    const report = buildVideoRenderReadinessReport({
+      title: 'The Receipt Every Agent Needs',
+      status: 'pending',
+      scriptText: 'A receipt is the difference between motion and trust.',
+      storyboardScenes: 5,
+      videoGenerationJobId: null,
+      templateId: 'template-1',
+      avatarId: null,
+      voiceId: null,
+      channel: 'youtube',
+      aspectRatio: '16:9',
+      brollAssetIds: ['asset-1'],
+    })
+
+    expect(report.ready).toBe(true)
+    expect(report.blockingIssues).toEqual([])
+    expect(report.details.heygenMode).toBe('template')
+  })
+
+  it('blocks render when the script exceeds HeyGen limits', () => {
+    const report = buildVideoRenderReadinessReport({
+      title: 'Long draft',
+      status: 'pending',
+      scriptText: 'x'.repeat(VIDEO_RENDER_SCRIPT_MAX + 1),
+      storyboardScenes: 1,
+      videoGenerationJobId: null,
+      templateId: 'template-1',
+      avatarId: null,
+      voiceId: null,
+      channel: 'youtube',
+      aspectRatio: '16:9',
+      brollAssetIds: [],
+    })
+
+    expect(report.ready).toBe(false)
+    expect(report.blockingIssues.join(' ')).toContain('Script exceeds HeyGen limit')
+  })
+
+  it('keeps approval separate from readiness', () => {
+    const report = buildVideoRenderReadinessReport({
+      title: 'Ready draft',
+      status: 'pending',
+      scriptText: 'Ready for review.',
+      storyboardScenes: 0,
+      videoGenerationJobId: null,
+      templateId: null,
+      avatarId: 'avatar-1',
+      voiceId: 'voice-1',
+      channel: 'linkedin',
+      aspectRatio: '9:16',
+      brollAssetIds: [],
+    })
+
+    expect(report.ready).toBe(true)
+    expect(report.details.approvalBoundary).toContain('does not start a render')
+    expect(report.warnings).toContain('No storyboard scenes are attached for visual direction.')
+  })
+})

--- a/lib/video-render-readiness.ts
+++ b/lib/video-render-readiness.ts
@@ -1,0 +1,89 @@
+export const VIDEO_RENDER_SCRIPT_MAX = 5000
+
+export interface VideoRenderReadinessInput {
+  title: string | null
+  status: string | null
+  scriptText: string | null
+  storyboardScenes: number
+  videoGenerationJobId: string | null
+  templateId: string | null
+  avatarId: string | null
+  voiceId: string | null
+  channel: string
+  aspectRatio: string
+  brollAssetIds: string[]
+}
+
+export interface VideoRenderReadinessReport {
+  ready: boolean
+  blockingIssues: string[]
+  warnings: string[]
+  details: {
+    title: string
+    scriptCharacters: number
+    storyboardScenes: number
+    brollAssetIds: string[]
+    heygenMode: 'template' | 'avatar_voice' | 'missing'
+    templateId: string | null
+    avatarId: string | null
+    voiceId: string | null
+    channel: string
+    aspectRatio: string
+    approvalBoundary: string
+  }
+}
+
+export function buildVideoRenderReadinessReport(input: VideoRenderReadinessInput): VideoRenderReadinessReport {
+  const blockingIssues: string[] = []
+  const warnings: string[] = []
+  const scriptText = (input.scriptText ?? '').trim()
+  const title = (input.title ?? '').trim() || 'Untitled draft'
+  const hasTemplate = Boolean(input.templateId)
+  const hasAvatarVoice = Boolean(input.avatarId && input.voiceId)
+  const heygenMode = hasTemplate ? 'template' : hasAvatarVoice ? 'avatar_voice' : 'missing'
+
+  if (input.status !== 'pending') {
+    blockingIssues.push(`Draft must be pending before render. Current status: ${input.status ?? 'unknown'}.`)
+  }
+  if (input.videoGenerationJobId) {
+    blockingIssues.push('Draft already has a video generation job linked.')
+  }
+  if (!scriptText) {
+    blockingIssues.push('Draft has no script text.')
+  }
+  if (scriptText.length > VIDEO_RENDER_SCRIPT_MAX) {
+    blockingIssues.push(`Script exceeds HeyGen limit of ${VIDEO_RENDER_SCRIPT_MAX.toLocaleString()} characters (${scriptText.length.toLocaleString()}).`)
+  }
+  if (!hasTemplate && !hasAvatarVoice) {
+    blockingIssues.push('HeyGen template or avatar and voice must be configured before render.')
+  }
+
+  if (input.storyboardScenes === 0) {
+    warnings.push('No storyboard scenes are attached for visual direction.')
+  }
+  if (input.brollAssetIds.length === 0) {
+    warnings.push('No B-roll assets are linked or matched for this draft.')
+  }
+  if (!hasTemplate && hasAvatarVoice) {
+    warnings.push('Render will use direct avatar and voice settings instead of a HeyGen template.')
+  }
+
+  return {
+    ready: blockingIssues.length === 0,
+    blockingIssues,
+    warnings,
+    details: {
+      title,
+      scriptCharacters: scriptText.length,
+      storyboardScenes: input.storyboardScenes,
+      brollAssetIds: input.brollAssetIds,
+      heygenMode,
+      templateId: input.templateId,
+      avatarId: input.avatarId,
+      voiceId: input.voiceId,
+      channel: input.channel,
+      aspectRatio: input.aspectRatio,
+      approvalBoundary: 'Readiness does not start a render. Shaka render approval is still required before HeyGen is called.',
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- Add a read-only render readiness report for video draft queue items.
- Surface a Check readiness control in Admin Video Generation before the Shaka render gate.
- Document that readiness checks do not call HeyGen, mutate jobs, approve publishing, or replace Shaka approval.

## Validation
- npm ci
- npm run worktree:env -- --source /Users/vambahsillah/Projects/Portfolio
- npm run build:knowledge
- npm test -- lib/video-render-readiness.test.ts 'app/api/admin/video-generation/ideas-queue/[id]/render-readiness/route.test.ts' lib/video-render-approval.test.ts 'app/api/admin/video-generation/ideas-queue/[id]/generate/route.test.ts' app/api/admin/video-generation/ideas-queue/batch/route.test.ts
- npx tsc --noEmit --pretty false
- npm run lint
- npm run db:health-check
- git diff --check
- Playwright smoke on /admin/content/video-generation: expanded The Receipt Every Agent Needs, clicked Check readiness, confirmed Ready for approval-gated internal render, and confirmed Generate Video remained disabled behind Confirm render gate.
- No HeyGen render, ElevenLabs generation, n8n workflow, B-roll capture, social queue insert, or publishing action was started.

## Integration Notes
- No migrations or env changes.
- Vercel – portfolio: not checked by this non-captain phase.
- Vercel – portfolio-staging: not checked by this non-captain phase.
- Existing workflow-status 500 remains visible in local dev because video_generation_workflow_runs.agent_run_id is missing; unrelated to this route.