### PR TITLE
feat: improve Slack standup question handoff

### DIFF
--- a/lib/agent-slack-notifications.test.ts
+++ b/lib/agent-slack-notifications.test.ts
@@ -212,4 +212,29 @@ describe('Agent Ops Slack notifications', () => {
     expect(body).toContain('run.ask_shaka')
     expect(body).toContain('/admin/agents/runs/run-stale')
   })
+
+  it('sends selected-agent standup questions even when no work cards match', async () => {
+    process.env.SLACK_AGENT_OPS_WEBHOOK_URL = 'https://hooks.slack.test/agent'
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+    vi.stubGlobal('fetch', fetchMock)
+    mocks.listAgentWorkItems.mockResolvedValue([])
+
+    const result = await sendAgentSlackNotification({
+      kind: 'selected_agent_question',
+      message: 'What changed since the last standup?',
+      targetAgentKeys: ['chief-of-staff', 'research-source-register'],
+    })
+
+    expect(result).toMatchObject({
+      sent: true,
+      itemCount: 0,
+      text: 'Standup question for selected agents: 2 agent(s) asked.',
+    })
+    const payload = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(JSON.stringify(payload.blocks)).toContain('What changed since the last standup?')
+    expect(JSON.stringify(payload.blocks)).toContain('Shaka (Zulu) - Chief of Staff')
+    expect(JSON.stringify(payload.blocks)).toContain('Askia Muhammad (Songhai) - Research Source Register')
+    expect(JSON.stringify(payload.blocks)).toContain('No active Kanban cards are currently assigned')
+    expect(JSON.stringify(payload.blocks)).toContain('/admin/agents/standup')
+  })
 })

--- a/lib/agent-slack-notifications.ts
+++ b/lib/agent-slack-notifications.ts
@@ -1,5 +1,6 @@
 import { endAgentRun, recordAgentEvent, startAgentRun } from '@/lib/agent-run'
 import { listAgentWorkItems, type AgentWorkItem } from '@/lib/agent-work-items'
+import { AGENT_ORGANIZATION } from '@/lib/agent-organization'
 import { mrkdwn, slackButton, truncateSlack, type SlackBlock } from '@/lib/agent-slack-blocks'
 import { supabaseAdmin } from '@/lib/supabase'
 
@@ -72,6 +73,10 @@ function baseUrl() {
 
 function agentUrl(path: string) {
   return `${baseUrl()}${path}`
+}
+
+function agentDisplayName(agentKey: string) {
+  return AGENT_ORGANIZATION.find((agent) => agent.key === agentKey)?.name ?? agentKey
 }
 
 function dedupeWindowKey(windowHours = 1) {
@@ -224,6 +229,61 @@ function workItemBlocks(title: string, intro: string, items: AgentWorkItem[], ki
   return blocks
 }
 
+function selectedAgentQuestionBlocks(input: AgentSlackNotificationInput, items: AgentWorkItem[]) {
+  const targetAgentKeys = normalizeTargetAgentKeys(input.targetAgentKeys)
+  const selectedAgentText = targetAgentKeys.length
+    ? targetAgentKeys.map((key) => `• ${agentDisplayName(key)} (\`${key}\`)`).join('\n')
+    : '• No specific agents selected. Shaka can route this from the thread.'
+  const question = truncateSlack(input.message?.trim() || 'No question provided.', 900)
+  const blocks: SlackBlock[] = [
+    {
+      type: 'section',
+      text: mrkdwn([
+        '*Standup question for selected agents*',
+        `*Question:* ${question}`,
+        '*Participants:*',
+        selectedAgentText,
+      ].join('\n')),
+    },
+    {
+      type: 'context',
+      elements: [
+        mrkdwn('Reply in this thread to continue with Shaka. Use `acknowledge`, `ready`, `request revision`, `assign <agent>`, or `handoff to <agent>` when the thread includes one clear work card.'),
+      ],
+    },
+  ]
+
+  if (items.length) {
+    blocks.push({ type: 'divider' })
+    blocks.push({ type: 'section', text: mrkdwn('*Current work context*') })
+    for (const item of items.slice(0, 5)) {
+      blocks.push({ type: 'section', text: mrkdwn(itemSummary(item)) })
+      blocks.push({
+        type: 'actions',
+        elements: [
+          workItemPrimaryButton(item, 'selected_agent_question'),
+          workItemContextButton(item),
+        ],
+      })
+    }
+  } else {
+    blocks.push({
+      type: 'section',
+      text: mrkdwn('No active Kanban cards are currently assigned to the selected agents. The question is still posted as a standup thread so Shaka can capture the mobile follow-up.'),
+    })
+  }
+
+  blocks.push({
+    type: 'actions',
+    elements: [
+      slackButton({ label: 'Open Standup Room', actionId: 'open_standup_room', url: agentUrl('/admin/agents/standup') }),
+      slackButton({ label: 'Open Kanban', actionId: 'open_kanban', url: agentUrl('/admin/agents/swarm-board') }),
+    ],
+  })
+
+  return blocks
+}
+
 async function buildPendingApprovalPayload() {
   const approvals = await pendingApprovals()
   const runs = await runsById(approvals.map((approval) => approval.run_id))
@@ -363,6 +423,14 @@ async function buildWorkItemPayload(input: AgentSlackNotificationInput) {
   }
 
   items = filterTargetAgents(items, targetAgentKeys).sort(prioritySort).slice(0, 5)
+  if (input.kind === 'selected_agent_question') {
+    return {
+      text: `${title}: ${targetAgentKeys.length || 'all'} agent(s) asked.`,
+      blocks: selectedAgentQuestionBlocks(input, items),
+      itemCount: items.length,
+    }
+  }
+
   return {
     text: `${title}: ${items.length} item(s).`,
     blocks: workItemBlocks(title, intro, items, input.kind),


### PR DESCRIPTION
## Summary
- Improves Standup Room selected-agent Slack handoffs so the Slack packet foregrounds the question and selected participants, even when no active Kanban cards match.
- Adds direct Standup Room and Kanban context links to the selected-agent question packet.
- Preserves existing work-card actions when selected agents do have active work context.

## Validation
- `npm test -- lib/agent-slack-notifications.test.ts lib/agent-slack-notification-sweep.test.ts app/api/admin/agents/slack-notifications/route.test.ts app/api/cron/agent-ops-slack-notifications/route.test.ts`
- `npm run build:knowledge && npx tsc --noEmit --pretty false`
- `npm run lint`
- `git diff --check`

## Integration Notes
- This is the Standup Room Slack bridge polish slice after PR #428.
- No production activation, credential changes, customer-data mutation, external sends outside the existing Slack notification bridge, or n8n activation is introduced.
- Fresh worktree needed `npm run build:knowledge` before typecheck so the generated ignored knowledge module existed locally.
- Vercel contexts not yet checked: `Vercel – portfolio`, `Vercel – portfolio-staging`.
