### PR TITLE
feat: add Open Brain runtime registration packet

### DIFF
--- a/docs/open-brain-local-service.md
+++ b/docs/open-brain-local-service.md
@@ -100,6 +100,31 @@ The first production MCP registration is an operational-state step. It should be
 
 The repo-owned MCP server prototype is `scripts/open-brain-mcp-server.ts`. It exposes the tool names above and stores local JSON records under `OPEN_BRAIN_HOME`, but registering it with Codex, Hermes, OpenCode, Claude, Cursor, or ChatGPT remains a separate local-state change.
 
+## Runtime Registration Packet
+
+Phase 2 uses a dry-run registration packet before any agent config is edited:
+
+```bash
+npm run open-brain:runtime-registration
+```
+
+The packet reports:
+
+- the resolved `OPEN_BRAIN_HOME`,
+- the Portfolio root used by the MCP server,
+- the exact stdio MCP command,
+- runtime-specific config snippets for Codex, Hermes, OpenCode/OpenClaw-style agents, Claude Desktop, and Cursor,
+- per-runtime registration status,
+- and verification commands for each runtime.
+
+To save a reviewable packet without changing agent configs:
+
+```bash
+npm run open-brain:runtime-registration -- --write tmp/open-brain-runtime-registration.md
+```
+
+The planner is intentionally non-mutating. It does not create or edit `~/.codex/config.toml`, `~/.hermes/config.yaml`, Cursor/Claude/OpenCode config files, or durable Open Brain memory records. Actual runtime registration remains a local-state approval step and should be performed one runtime at a time, followed by that runtime's own doctor/list/manual MCP verification.
+
 ## Karpathy Wiki Overlay
 
 Karpathy Wiki pages are compiled views from approved, non-private Open Brain records. Initial pages:

--- a/lib/open-brain-runtime-registration.test.ts
+++ b/lib/open-brain-runtime-registration.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildOpenBrainRuntimeRegistrationPlan,
+  renderOpenBrainRuntimeRegistrationMarkdown,
+  resolveDefaultPortfolioRoot,
+} from './open-brain-runtime-registration'
+
+describe('Open Brain runtime registration planner', () => {
+  it('builds approval-gated registration snippets for each runtime', () => {
+    const plan = buildOpenBrainRuntimeRegistrationPlan({
+      generatedAt: '2026-05-27T12:00:00.000Z',
+      homeDir: '/Users/example',
+      openBrainHome: '/Users/example/.open-brain',
+      portfolioRoot: '/Users/example/Projects/Portfolio',
+      configTextByRuntime: {
+        codex: '[mcp_servers.open-brain]\nOPEN_BRAIN_HOME = "/Users/example/.open-brain"\nOPEN_BRAIN_PORTFOLIO_ROOT = "/Users/example/Projects/Portfolio"',
+        hermes: '',
+        opencode: null,
+        claude: null,
+        cursor: null,
+      },
+    })
+
+    expect(plan.openBrainHome).toBe('/Users/example/.open-brain')
+    expect(plan.mcpCommand).toEqual({
+      command: 'npm',
+      args: ['--prefix', '/Users/example/Projects/Portfolio', 'run', 'open-brain:mcp'],
+      env: {
+        OPEN_BRAIN_HOME: '/Users/example/.open-brain',
+        OPEN_BRAIN_PORTFOLIO_ROOT: '/Users/example/Projects/Portfolio',
+      },
+    })
+    expect(plan.safetyBoundary.join(' ')).toContain('no agent config files are edited')
+    expect(plan.targets.map((target) => target.runtime)).toEqual([
+      'codex',
+      'hermes',
+      'opencode',
+      'claude',
+      'cursor',
+    ])
+    expect(plan.targets.find((target) => target.runtime === 'codex')?.status).toBe('already_registered')
+    expect(plan.targets.find((target) => target.runtime === 'hermes')?.status).toBe('ready_to_register')
+    expect(plan.targets.find((target) => target.runtime === 'claude')?.status).toBe('config_missing')
+  })
+
+  it('renders a reviewable markdown packet without secret values', () => {
+    const plan = buildOpenBrainRuntimeRegistrationPlan({
+      generatedAt: '2026-05-27T12:00:00.000Z',
+      homeDir: '/Users/example',
+      openBrainHome: '/Users/example/.open-brain',
+      portfolioRoot: '/Users/example/Projects/Portfolio',
+      configTextByRuntime: {},
+    })
+
+    const markdown = renderOpenBrainRuntimeRegistrationMarkdown(plan)
+
+    expect(markdown).toContain('# Open Brain Runtime Registration Packet')
+    expect(markdown).toContain('## Safety Boundary')
+    expect(markdown).toContain('### Codex')
+    expect(markdown).toContain('OPEN_BRAIN_HOME')
+    expect(markdown).not.toMatch(/sk-[A-Za-z0-9]/)
+    expect(markdown).not.toContain('SUPABASE_SERVICE_ROLE_KEY')
+  })
+
+  it('resolves known Portfolio worktree paths back to the canonical checkout when present', () => {
+    const resolved = resolveDefaultPortfolioRoot('/Users/vambahsillah/Projects/Portfolio.worktrees/open-brain-runtime-registration')
+
+    expect(resolved).toBe('/Users/vambahsillah/Projects/Portfolio')
+  })
+})

--- a/lib/open-brain-runtime-registration.ts
+++ b/lib/open-brain-runtime-registration.ts
@@ -1,0 +1,252 @@
+import { existsSync } from 'fs'
+import { homedir } from 'os'
+import path from 'path'
+
+export type OpenBrainRuntimeKey = 'codex' | 'hermes' | 'opencode' | 'claude' | 'cursor'
+export type OpenBrainRuntimeRegistrationStatus = 'already_registered' | 'ready_to_register' | 'config_missing'
+
+export interface OpenBrainRuntimeRegistrationTarget {
+  runtime: OpenBrainRuntimeKey
+  label: string
+  status: OpenBrainRuntimeRegistrationStatus
+  configPath: string
+  registrationFormat: 'toml' | 'yaml' | 'json'
+  snippet: string
+  verifyCommand: string
+  note: string
+}
+
+export interface OpenBrainRuntimeRegistrationPlan {
+  generatedAt: string
+  openBrainHome: string
+  portfolioRoot: string
+  mcpCommand: {
+    command: string
+    args: string[]
+    env: Record<string, string>
+  }
+  safetyBoundary: string[]
+  setupCommands: string[]
+  targets: OpenBrainRuntimeRegistrationTarget[]
+  nextAction: string
+}
+
+export interface OpenBrainRuntimeRegistrationOptions {
+  generatedAt?: string
+  homeDir?: string
+  openBrainHome?: string
+  portfolioRoot?: string
+  currentWorkingDirectory?: string
+  configTextByRuntime?: Partial<Record<OpenBrainRuntimeKey, string | null>>
+}
+
+const DEFAULT_TARGETS: Array<{
+  runtime: OpenBrainRuntimeKey
+  label: string
+  configPath: (homeDir: string) => string
+  registrationFormat: OpenBrainRuntimeRegistrationTarget['registrationFormat']
+}> = [
+  {
+    runtime: 'codex',
+    label: 'Codex',
+    configPath: (homeDir) => path.join(homeDir, '.codex', 'config.toml'),
+    registrationFormat: 'toml',
+  },
+  {
+    runtime: 'hermes',
+    label: 'Hermes',
+    configPath: (homeDir) => path.join(homeDir, '.hermes', 'config.yaml'),
+    registrationFormat: 'yaml',
+  },
+  {
+    runtime: 'opencode',
+    label: 'OpenCode / OpenClaw-style agents',
+    configPath: (homeDir) => path.join(homeDir, '.config', 'opencode', 'mcp.json'),
+    registrationFormat: 'json',
+  },
+  {
+    runtime: 'claude',
+    label: 'Claude Desktop',
+    configPath: (homeDir) => path.join(homeDir, 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json'),
+    registrationFormat: 'json',
+  },
+  {
+    runtime: 'cursor',
+    label: 'Cursor',
+    configPath: (homeDir) => path.join(homeDir, '.cursor', 'mcp.json'),
+    registrationFormat: 'json',
+  },
+]
+
+export function buildOpenBrainRuntimeRegistrationPlan(
+  options: OpenBrainRuntimeRegistrationOptions = {},
+): OpenBrainRuntimeRegistrationPlan {
+  const homeDir = options.homeDir || homedir()
+  const openBrainHome = options.openBrainHome || process.env.OPEN_BRAIN_HOME || path.join(homeDir, '.open-brain')
+  const portfolioRoot = options.portfolioRoot ||
+    process.env.OPEN_BRAIN_PORTFOLIO_ROOT ||
+    resolveDefaultPortfolioRoot(options.currentWorkingDirectory || process.cwd())
+  const mcpCommand = {
+    command: 'npm',
+    args: ['--prefix', portfolioRoot, 'run', 'open-brain:mcp'],
+    env: {
+      OPEN_BRAIN_HOME: openBrainHome,
+      OPEN_BRAIN_PORTFOLIO_ROOT: portfolioRoot,
+    },
+  }
+
+  const targets = DEFAULT_TARGETS.map((target) => {
+    const configPath = target.configPath(homeDir)
+    const configText = options.configTextByRuntime?.[target.runtime]
+    const hasConfig = configText !== undefined ? configText !== null : existsSync(configPath)
+    const alreadyRegistered = Boolean(configText && hasOpenBrainRegistration(configText, openBrainHome, portfolioRoot))
+    const status: OpenBrainRuntimeRegistrationStatus = alreadyRegistered
+      ? 'already_registered'
+      : hasConfig
+        ? 'ready_to_register'
+        : 'config_missing'
+
+    return {
+      runtime: target.runtime,
+      label: target.label,
+      status,
+      configPath,
+      registrationFormat: target.registrationFormat,
+      snippet: registrationSnippet(target.registrationFormat, mcpCommand),
+      verifyCommand: verificationCommand(target.runtime, configPath),
+      note: statusNote(status, target.label),
+    }
+  })
+
+  return {
+    generatedAt: options.generatedAt || new Date().toISOString(),
+    openBrainHome,
+    portfolioRoot,
+    mcpCommand,
+    safetyBoundary: [
+      'Dry-run packet only; no agent config files are edited by this planner.',
+      'Create OPEN_BRAIN_HOME before registration, but do not promote durable memories without approval.',
+      'Register each runtime in its own native config surface; Codex config is not inherited by Hermes, Claude, Cursor, OpenCode, or OpenClaw.',
+      'After registration, verify each runtime with its own list, doctor, or manual MCP tool call before marking it connected.',
+    ],
+    setupCommands: [
+      `mkdir -p ${shellQuote(openBrainHome)}`,
+      `OPEN_BRAIN_HOME=${shellQuote(openBrainHome)} OPEN_BRAIN_PORTFOLIO_ROOT=${shellQuote(portfolioRoot)} npm --prefix ${shellQuote(portfolioRoot)} test -- --run scripts/open-brain-mcp-server.test.ts lib/open-brain.test.ts`,
+      `OPEN_BRAIN_HOME=${shellQuote(openBrainHome)} OPEN_BRAIN_PORTFOLIO_ROOT=${shellQuote(portfolioRoot)} npm --prefix ${shellQuote(portfolioRoot)} run open-brain:runtime-registration`,
+    ],
+    targets,
+    nextAction: 'Review the target snippets, approve one runtime registration at a time, then run the matching verify command.',
+  }
+}
+
+export function renderOpenBrainRuntimeRegistrationMarkdown(plan: OpenBrainRuntimeRegistrationPlan): string {
+  return [
+    '# Open Brain Runtime Registration Packet',
+    '',
+    `Generated: ${plan.generatedAt}`,
+    '',
+    '## Runtime',
+    '',
+    `- Open Brain home: \`${plan.openBrainHome}\``,
+    `- Portfolio root: \`${plan.portfolioRoot}\``,
+    `- MCP command: \`${plan.mcpCommand.command} ${plan.mcpCommand.args.map(shellQuote).join(' ')}\``,
+    '',
+    '## Safety Boundary',
+    '',
+    ...plan.safetyBoundary.map((item) => `- ${item}`),
+    '',
+    '## Setup Checks',
+    '',
+    ...plan.setupCommands.map((command) => `- \`${command}\``),
+    '',
+    '## Targets',
+    '',
+    ...plan.targets.flatMap((target) => [
+      `### ${target.label}`,
+      '',
+      `- Status: \`${target.status}\``,
+      `- Config path: \`${target.configPath}\``,
+      `- Format: \`${target.registrationFormat}\``,
+      `- Verify: \`${target.verifyCommand}\``,
+      `- Note: ${target.note}`,
+      '',
+      '```' + target.registrationFormat,
+      target.snippet,
+      '```',
+      '',
+    ]),
+    '## Next Action',
+    '',
+    plan.nextAction,
+    '',
+  ].join('\n')
+}
+
+function registrationSnippet(
+  format: OpenBrainRuntimeRegistrationTarget['registrationFormat'],
+  command: OpenBrainRuntimeRegistrationPlan['mcpCommand'],
+) {
+  if (format === 'toml') {
+    return [
+      '[mcp_servers.open-brain]',
+      `command = "${command.command}"`,
+      `args = ${JSON.stringify(command.args)}`,
+      `[mcp_servers.open-brain.env]`,
+      `OPEN_BRAIN_HOME = "${command.env.OPEN_BRAIN_HOME}"`,
+      `OPEN_BRAIN_PORTFOLIO_ROOT = "${command.env.OPEN_BRAIN_PORTFOLIO_ROOT}"`,
+    ].join('\n')
+  }
+
+  if (format === 'yaml') {
+    return [
+      'mcpServers:',
+      '  open-brain:',
+      `    command: ${command.command}`,
+      `    args: ${JSON.stringify(command.args)}`,
+      '    env:',
+      `      OPEN_BRAIN_HOME: ${command.env.OPEN_BRAIN_HOME}`,
+      `      OPEN_BRAIN_PORTFOLIO_ROOT: ${command.env.OPEN_BRAIN_PORTFOLIO_ROOT}`,
+    ].join('\n')
+  }
+
+  return JSON.stringify({
+    mcpServers: {
+      'open-brain': {
+        command: command.command,
+        args: command.args,
+        env: command.env,
+      },
+    },
+  }, null, 2)
+}
+
+function verificationCommand(runtime: OpenBrainRuntimeKey, configPath: string) {
+  if (runtime === 'codex') return `rg -n "open-brain|OPEN_BRAIN_HOME" ${shellQuote(configPath)}`
+  if (runtime === 'hermes') return `rg -n "open-brain|OPEN_BRAIN_HOME" ${shellQuote(configPath)}`
+  return `test -f ${shellQuote(configPath)} && rg -n "open-brain|OPEN_BRAIN_HOME" ${shellQuote(configPath)}`
+}
+
+function statusNote(status: OpenBrainRuntimeRegistrationStatus, label: string) {
+  if (status === 'already_registered') return `${label} already appears to reference the local Open Brain MCP server.`
+  if (status === 'ready_to_register') return `${label} config exists; append or merge the snippet after approval.`
+  return `${label} config was not found at the expected path; create it only if this runtime is installed and should connect.`
+}
+
+function hasOpenBrainRegistration(configText: string, openBrainHome: string, portfolioRoot: string) {
+  return configText.includes('open-brain') &&
+    configText.includes('OPEN_BRAIN_HOME') &&
+    configText.includes(openBrainHome) &&
+    configText.includes(portfolioRoot)
+}
+
+export function resolveDefaultPortfolioRoot(cwd: string) {
+  const marker = `${path.sep}Portfolio.worktrees${path.sep}`
+  if (!cwd.includes(marker)) return cwd
+  const projectsRoot = cwd.slice(0, cwd.indexOf(marker))
+  const canonicalPortfolioRoot = path.join(projectsRoot, 'Portfolio')
+  return existsSync(canonicalPortfolioRoot) ? canonicalPortfolioRoot : cwd
+}
+
+function shellQuote(value: string) {
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}

--- a/lib/open-brain.ts
+++ b/lib/open-brain.ts
@@ -1108,6 +1108,7 @@ function getServiceStatus(openBrainHome: string, runtimeMcpConfigured = false): 
 
 function buildRunbookSources(generatedAt: string): OpenBrainSourceRecord[] {
   const runbooks = [
+    'docs/open-brain-local-service.md',
     'docs/memory-context-organization-workflow.md',
     'docs/automations/README.md',
     'docs/automations/organization-runbook.md',

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "model-ops:reply-intent:sync": "tsx scripts/sync-reply-intent-review-candidates.ts",
     "model-ops:research:plan": "tsx scripts/model-ops-research-plan.ts",
     "open-brain:mcp": "tsx scripts/open-brain-mcp-server.ts",
+    "open-brain:runtime-registration": "tsx scripts/open-brain-runtime-registration.ts",
     "wrm:smoke-gate": "tsx scripts/wrm-production-smoke-gate.ts",
     "source-protocol:smoke": "tsx scripts/source-protocol-smoke.ts",
     "staging:publications-parity": "tsx scripts/ensure-publications-experience-parity.ts --env-file .env.staging",

--- a/scripts/open-brain-runtime-registration.ts
+++ b/scripts/open-brain-runtime-registration.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env tsx
+import { mkdir, readFile, writeFile } from 'fs/promises'
+import path from 'path'
+import {
+  buildOpenBrainRuntimeRegistrationPlan,
+  renderOpenBrainRuntimeRegistrationMarkdown,
+  type OpenBrainRuntimeKey,
+} from '../lib/open-brain-runtime-registration'
+
+async function main() {
+  const args = process.argv.slice(2)
+  const format = args.includes('--json') ? 'json' : 'markdown'
+  const writeIndex = args.indexOf('--write')
+  const outPath = writeIndex >= 0 ? args[writeIndex + 1] : null
+  const homeDir = process.env.HOME || undefined
+  const configTextByRuntime = await loadConfigText(homeDir)
+  const plan = buildOpenBrainRuntimeRegistrationPlan({ configTextByRuntime })
+  const output = format === 'json'
+    ? `${JSON.stringify(plan, null, 2)}\n`
+    : renderOpenBrainRuntimeRegistrationMarkdown(plan)
+
+  if (outPath) {
+    const resolved = path.resolve(outPath)
+    await mkdir(path.dirname(resolved), { recursive: true })
+    await writeFile(resolved, output, 'utf8')
+    console.log(`Wrote Open Brain runtime registration packet to ${resolved}`)
+    return
+  }
+
+  process.stdout.write(output)
+}
+
+async function loadConfigText(homeDir?: string): Promise<Partial<Record<OpenBrainRuntimeKey, string | null>>> {
+  if (!homeDir) return {}
+  const paths: Record<OpenBrainRuntimeKey, string> = {
+    codex: path.join(homeDir, '.codex', 'config.toml'),
+    hermes: path.join(homeDir, '.hermes', 'config.yaml'),
+    opencode: path.join(homeDir, '.config', 'opencode', 'mcp.json'),
+    claude: path.join(homeDir, 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json'),
+    cursor: path.join(homeDir, '.cursor', 'mcp.json'),
+  }
+  const entries = await Promise.all(
+    Object.entries(paths).map(async ([runtime, configPath]) => {
+      const text = await readFile(configPath, 'utf8').catch(() => null)
+      return [runtime, text] as const
+    }),
+  )
+  return Object.fromEntries(entries) as Partial<Record<OpenBrainRuntimeKey, string | null>>
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('[open-brain-runtime-registration] failed:', error instanceof Error ? error.message : error)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Summary\n- Add a dry-run Open Brain runtime registration planner for Codex, Hermes, OpenCode/OpenClaw-style agents, Claude Desktop, and Cursor.\n- Add an npm entrypoint that prints JSON/Markdown registration packets without mutating agent configs.\n- Document the Phase 2 registration flow and include the Open Brain service doc as a runtime source in the Open Brain snapshot.\n\n## Safety Boundary\n- No agent config files are edited.\n- No durable Open Brain memories are promoted.\n- Runtime registration remains a separate local-state approval step, one runtime at a time.\n- Generated snippets point at the canonical Portfolio checkout, not an ephemeral sibling worktree.\n\n## Validation\n- npm test -- --run lib/open-brain-runtime-registration.test.ts scripts/open-brain-mcp-server.test.ts lib/open-brain.test.ts\n- npm --silent run open-brain:runtime-registration -- --json | node parser smoke\n- npm --silent run open-brain:runtime-registration -- --write tmp/open-brain-runtime-registration.md\n- npx tsc --noEmit --pretty false\n- npm run lint\n- git diff --check\n- npm run build (passed after linking ignored .env.local from main Portfolio checkout; first attempt failed on missing Supabase public env vars in the fresh worktree)\n- pre-push npm run db:health-check passed\n\n## Integration Notes\n- Draft PR; do not merge from this lane.\n- No migrations.\n- No production config changes.\n- Actual Codex/Hermes/Claude/Cursor/OpenCode MCP registration should happen only after approval and should be verified in each runtime's own tool surface.