### PR TITLE
feat: add social content calibration packet

### DIFF
--- a/app/admin/agents/standup/page.test.tsx
+++ b/app/admin/agents/standup/page.test.tsx
@@ -208,6 +208,20 @@ describe('AgentStandupRoomPage', () => {
                     image_prompt: 'Dark operating-console illustration with gold command accents.',
                     source_provenance_checklist: ['Open Brain references are approved/public-safe.', 'Chronicle notes are manually sanitized.'],
                     approval_checklist: ['Social Content item remains draft-only until separately approved.'],
+                    content_calibration: {
+                      status: 'needs_operator_context',
+                      prior_success_patterns: [{
+                        label: 'Builder proof post',
+                        pattern: 'Open with a concrete build observation.',
+                        why_it_worked: 'It referenced actual builder work and named the risk.',
+                        reuse_guidance: 'Use when the draft needs more practical proof.',
+                      }],
+                      voice_principles: ['Open with a concrete scene, tension, or practical problem.'],
+                      audience_notes: ['Speak to leaders trying to reduce burden.'],
+                      revision_questions: ['Does the draft sound like a point Vambah would stand behind publicly?'],
+                      missing_context_prompts: ['Paste or link one high-performing LinkedIn post.'],
+                      comparison_prompt: 'Compare this draft against Vambah LinkedIn voice guidance.',
+                    },
                   },
                   tasks: [{
                     id: 'goal-social-post-draft',
@@ -470,6 +484,10 @@ describe('AgentStandupRoomPage', () => {
     expect(screen.getByText('Pending research: capture one current industry signal.')).toBeInTheDocument()
     expect(screen.getByText(/Open Brain references are approved\/public-safe/i)).toBeInTheDocument()
     expect(screen.getByText('Mission Control routes one social outreach goal into accountable work.')).toBeInTheDocument()
+    expect(screen.getByText('Content calibration')).toBeInTheDocument()
+    expect(screen.getByText('Builder proof post')).toBeInTheDocument()
+    expect(screen.getByText(/Paste or link one high-performing LinkedIn post/i)).toBeInTheDocument()
+    expect(screen.getByText(/Compare this draft against Vambah LinkedIn voice guidance/i)).toBeInTheDocument()
     expect(fetch).toHaveBeenCalledWith('/api/admin/agents/war-room', expect.objectContaining({
       method: 'POST',
       body: JSON.stringify({

--- a/app/admin/agents/standup/page.tsx
+++ b/app/admin/agents/standup/page.tsx
@@ -1089,23 +1089,67 @@ function GoalPlanner({
             </div>
           ) : null}
           {goalDraft.content_packet && (
-            <div className="mt-4 grid gap-3 lg:grid-cols-2">
-              <div className="rounded-lg border border-silicon-slate/60 bg-background/60 p-3">
-                <p className="text-xs font-semibold uppercase tracking-[0.14em] text-radiant-gold">LinkedIn Content Packet</p>
-                <p className="mt-2 text-sm font-medium">{goalDraft.content_packet.target_audience}</p>
-                <p className="mt-2 text-sm text-muted-foreground">{goalDraft.content_packet.industry_signal_summary}</p>
-                <div className="mt-3 grid gap-1 text-xs text-muted-foreground">
-                  {goalDraft.content_packet.source_provenance_checklist.slice(0, 3).map((item) => (
-                    <span key={item}>• {item}</span>
-                  ))}
+            <div className="mt-4 space-y-3">
+              <div className="grid gap-3 lg:grid-cols-2">
+                <div className="rounded-lg border border-silicon-slate/60 bg-background/60 p-3">
+                  <p className="text-xs font-semibold uppercase tracking-[0.14em] text-radiant-gold">LinkedIn Content Packet</p>
+                  <p className="mt-2 text-sm font-medium">{goalDraft.content_packet.target_audience}</p>
+                  <p className="mt-2 text-sm text-muted-foreground">{goalDraft.content_packet.industry_signal_summary}</p>
+                  <div className="mt-3 grid gap-1 text-xs text-muted-foreground">
+                    {goalDraft.content_packet.source_provenance_checklist.slice(0, 3).map((item) => (
+                      <span key={item}>• {item}</span>
+                    ))}
+                  </div>
+                </div>
+                <div className="rounded-lg border border-silicon-slate/60 bg-background/60 p-3">
+                  <p className="text-xs font-semibold uppercase tracking-[0.14em] text-radiant-gold">Visual brief</p>
+                  <p className="mt-2 text-sm text-muted-foreground">{goalDraft.content_packet.visual_concept}</p>
+                  <p className="mt-3 line-clamp-3 rounded-md border border-silicon-slate/50 bg-black/10 p-2 text-xs text-muted-foreground">
+                    {goalDraft.content_packet.image_prompt}
+                  </p>
                 </div>
               </div>
               <div className="rounded-lg border border-silicon-slate/60 bg-background/60 p-3">
-                <p className="text-xs font-semibold uppercase tracking-[0.14em] text-radiant-gold">Visual brief</p>
-                <p className="mt-2 text-sm text-muted-foreground">{goalDraft.content_packet.visual_concept}</p>
-                <p className="mt-3 line-clamp-3 rounded-md border border-silicon-slate/50 bg-black/10 p-2 text-xs text-muted-foreground">
-                  {goalDraft.content_packet.image_prompt}
-                </p>
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-[0.14em] text-radiant-gold">Content calibration</p>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      Use this before delegation to compare the draft against prior strong posts, voice guardrails, and the extra context Shaka still needs.
+                    </p>
+                  </div>
+                  <span className="w-fit rounded-full border border-yellow-500/35 bg-yellow-500/10 px-2 py-1 text-xs text-yellow-100">
+                    {goalDraft.content_packet.content_calibration.status.replace(/_/g, ' ')}
+                  </span>
+                </div>
+                <div className="mt-3 grid gap-3 xl:grid-cols-[minmax(0,1.15fr)_minmax(260px,0.85fr)]">
+                  <div className="grid gap-2">
+                    {goalDraft.content_packet.content_calibration.prior_success_patterns.map((pattern) => (
+                      <div key={pattern.label} className="rounded-md border border-silicon-slate/55 bg-background/45 p-2 text-xs">
+                        <p className="font-semibold text-foreground">{pattern.label}</p>
+                        <p className="mt-1 text-muted-foreground">{pattern.pattern}</p>
+                        <p className="mt-1 text-muted-foreground"><span className="text-radiant-gold">Why it worked:</span> {pattern.why_it_worked}</p>
+                        <p className="mt-1 text-muted-foreground"><span className="text-radiant-gold">Use now:</span> {pattern.reuse_guidance}</p>
+                      </div>
+                    ))}
+                  </div>
+                  <div className="grid gap-2">
+                    <div className="rounded-md border border-silicon-slate/55 bg-background/45 p-2">
+                      <p className="text-xs font-semibold uppercase tracking-[0.12em] text-radiant-gold">Voice checks</p>
+                      <ul className="mt-2 space-y-1 text-xs text-muted-foreground">
+                        {goalDraft.content_packet.content_calibration.voice_principles.slice(0, 4).map((item) => <li key={item}>• {item}</li>)}
+                      </ul>
+                    </div>
+                    <div className="rounded-md border border-yellow-500/30 bg-yellow-500/10 p-2">
+                      <p className="text-xs font-semibold uppercase tracking-[0.12em] text-yellow-100">Context to add</p>
+                      <ul className="mt-2 space-y-1 text-xs text-yellow-50/90">
+                        {goalDraft.content_packet.content_calibration.missing_context_prompts.slice(0, 4).map((item) => <li key={item}>• {item}</li>)}
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+                <div className="mt-3 rounded-md border border-radiant-gold/30 bg-radiant-gold/10 p-2 text-xs text-radiant-gold">
+                  {goalDraft.content_packet.content_calibration.comparison_prompt}
+                </div>
               </div>
             </div>
           )}

--- a/app/admin/social-content/[id]/page.tsx
+++ b/app/admin/social-content/[id]/page.tsx
@@ -76,6 +76,12 @@ function asStringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
 }
 
+function asRecordArray(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is Record<string, unknown> => Boolean(asRecord(item)))
+    : []
+}
+
 function SocialContentDetailPage() {
   const { id } = useParams<{ id: string }>()
   const router = useRouter()
@@ -462,6 +468,12 @@ function SocialContentDetailPage() {
   const agentPilotProvenance = asStringArray(ragContext?.source_provenance_checklist)
   const agentPilotApprovalChecklist = asStringArray(ragContext?.approval_checklist)
   const agentPilotOpenBrainReferences = asStringArray(ragContext?.open_brain_references)
+  const agentPilotCalibration = asRecord(ragContext?.content_calibration)
+  const agentPilotCalibrationStatus = asString(agentPilotCalibration?.status)
+  const agentPilotPriorPatterns = asRecordArray(agentPilotCalibration?.prior_success_patterns)
+  const agentPilotVoicePrinciples = asStringArray(agentPilotCalibration?.voice_principles)
+  const agentPilotMissingContextPrompts = asStringArray(agentPilotCalibration?.missing_context_prompts)
+  const agentPilotComparisonPrompt = asString(agentPilotCalibration?.comparison_prompt)
   const isDraftOnlyPilot = isAgentSocialPilot && agentPilotPublishGate === 'draft_only'
 
   return (
@@ -586,6 +598,58 @@ function SocialContentDetailPage() {
                 </p>
               </div>
             </div>
+
+            {agentPilotCalibration && (
+              <div className="mt-4 rounded-lg border border-gray-800 bg-gray-950/35 p-4">
+                <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-[0.14em] text-amber-300">Content Calibration</p>
+                    <p className="mt-1 text-sm leading-6 text-gray-300">
+                      Use this section to revise the draft against prior successful post patterns before it reaches publish review.
+                    </p>
+                  </div>
+                  {agentPilotCalibrationStatus && (
+                    <span className="w-fit rounded-full border border-amber-500/35 bg-amber-500/10 px-3 py-1 text-xs text-amber-200">
+                      {agentPilotCalibrationStatus.replace(/_/g, ' ')}
+                    </span>
+                  )}
+                </div>
+                <div className="mt-3 grid gap-3 xl:grid-cols-[minmax(0,1.2fr)_minmax(280px,0.8fr)]">
+                  <div className="grid gap-2">
+                    {agentPilotPriorPatterns.slice(0, 3).map((pattern) => {
+                      const label = asString(pattern.label)
+                      return (
+                        <div key={label || asString(pattern.pattern)} className="rounded-md border border-gray-800 bg-gray-900/55 p-3">
+                          <p className="text-sm font-semibold text-gray-100">{label || 'Prior success pattern'}</p>
+                          <p className="mt-1 text-sm leading-6 text-gray-300">{asString(pattern.pattern)}</p>
+                          <p className="mt-2 text-xs leading-5 text-gray-400"><span className="text-amber-300">Why it worked:</span> {asString(pattern.why_it_worked)}</p>
+                          <p className="mt-1 text-xs leading-5 text-gray-400"><span className="text-amber-300">Use now:</span> {asString(pattern.reuse_guidance)}</p>
+                        </div>
+                      )
+                    })}
+                  </div>
+                  <div className="grid gap-3">
+                    <div className="rounded-md border border-gray-800 bg-gray-900/55 p-3">
+                      <p className="text-xs font-semibold uppercase tracking-[0.14em] text-gray-500">Voice Checks</p>
+                      <ul className="mt-2 space-y-1 text-sm text-gray-300">
+                        {agentPilotVoicePrinciples.slice(0, 5).map((entry) => <li key={entry}>• {entry}</li>)}
+                      </ul>
+                    </div>
+                    <div className="rounded-md border border-amber-500/25 bg-amber-500/10 p-3">
+                      <p className="text-xs font-semibold uppercase tracking-[0.14em] text-amber-200">Context to Add</p>
+                      <ul className="mt-2 space-y-1 text-sm text-amber-50/90">
+                        {agentPilotMissingContextPrompts.slice(0, 4).map((entry) => <li key={entry}>• {entry}</li>)}
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+                {agentPilotComparisonPrompt && (
+                  <div className="mt-3 rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-sm leading-6 text-amber-100">
+                    {agentPilotComparisonPrompt}
+                  </div>
+                )}
+              </div>
+            )}
 
             <div className="mt-4 flex flex-wrap items-center gap-3 text-sm">
               {agentPilotGoalId && (

--- a/app/admin/social-content/[id]/page.tsx
+++ b/app/admin/social-content/[id]/page.tsx
@@ -82,6 +82,22 @@ function asRecordArray(value: unknown): Record<string, unknown>[] {
     : []
 }
 
+type CalibrationFeedback = {
+  prior_post_excerpt: string
+  engagement_signal: string
+  audience_context: string
+  revision_request: string
+  claim_boundaries: string
+}
+
+const EMPTY_CALIBRATION_FEEDBACK: CalibrationFeedback = {
+  prior_post_excerpt: '',
+  engagement_signal: '',
+  audience_context: '',
+  revision_request: '',
+  claim_boundaries: '',
+}
+
 function SocialContentDetailPage() {
   const { id } = useParams<{ id: string }>()
   const router = useRouter()
@@ -96,11 +112,13 @@ function SocialContentDetailPage() {
   const [convertingFormat, setConvertingFormat] = useState(false)
   const [selectedSlide, setSelectedSlide] = useState(0)
   const [publishing, setPublishing] = useState(false)
+  const [savingCalibration, setSavingCalibration] = useState(false)
   const [showSource, setShowSource] = useState(false)
   const [expandedSection, setExpandedSection] = useState<'rag' | 'transcript' | null>(null)
   const [showConfirmModal, setShowConfirmModal] = useState(false)
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
   const [targetPlatforms, setTargetPlatforms] = useState<SocialPlatform[]>(['linkedin'])
+  const [calibrationFeedback, setCalibrationFeedback] = useState<CalibrationFeedback>(EMPTY_CALIBRATION_FEEDBACK)
 
   const [postText, setPostText] = useState('')
   const [ctaText, setCtaText] = useState('')
@@ -136,6 +154,16 @@ function SocialContentDetailPage() {
         setScheduledFor(i.scheduled_for ? new Date(i.scheduled_for).toISOString().slice(0, 16) : '')
         setAdminNotes(i.admin_notes || '')
         setTargetPlatforms(i.target_platforms?.length ? i.target_platforms : ['linkedin'])
+        const rag = asRecord(i.rag_context)
+        const calibration = asRecord(rag?.content_calibration)
+        const operatorFeedback = asRecord(calibration?.operator_feedback)
+        setCalibrationFeedback({
+          prior_post_excerpt: asString(operatorFeedback?.prior_post_excerpt),
+          engagement_signal: asString(operatorFeedback?.engagement_signal),
+          audience_context: asString(operatorFeedback?.audience_context),
+          revision_request: asString(operatorFeedback?.revision_request),
+          claim_boundaries: asString(operatorFeedback?.claim_boundaries),
+        })
       }
     } catch (err) {
       console.error('Failed to fetch item:', err)
@@ -196,6 +224,63 @@ function SocialContentDetailPage() {
     const saved = await saveForm()
     showMsg(saved ? 'success' : 'error', saved ? 'Saved successfully' : 'Failed to save')
     setSaving(false)
+  }
+
+  const updateCalibrationFeedback = (key: keyof CalibrationFeedback, value: string) => {
+    setCalibrationFeedback((current) => ({ ...current, [key]: value }))
+  }
+
+  const handleSaveCalibrationFeedback = async () => {
+    if (!item) return
+    setSavingCalibration(true)
+    try {
+      const session = await getCurrentSession()
+      if (!session) return
+
+      const existingRag = asRecord(item.rag_context) ?? {}
+      const existingCalibration = asRecord(existingRag.content_calibration) ?? {}
+      const feedback = {
+        prior_post_excerpt: calibrationFeedback.prior_post_excerpt.trim(),
+        engagement_signal: calibrationFeedback.engagement_signal.trim(),
+        audience_context: calibrationFeedback.audience_context.trim(),
+        revision_request: calibrationFeedback.revision_request.trim(),
+        claim_boundaries: calibrationFeedback.claim_boundaries.trim(),
+        updated_at: new Date().toISOString(),
+      }
+      const hasFeedback = Object.entries(feedback)
+        .filter(([key]) => key !== 'updated_at')
+        .some(([, value]) => Boolean(value))
+      const rag_context = {
+        ...existingRag,
+        content_calibration: {
+          ...existingCalibration,
+          status: hasFeedback ? 'ready_for_draft_review' : asString(existingCalibration.status) || 'needs_operator_context',
+          operator_feedback: feedback,
+        },
+      }
+
+      const res = await fetch(`/api/admin/social-content/${id}`, {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${session.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ rag_context }),
+      })
+
+      if (res.ok) {
+        const data = await res.json()
+        setItem(prev => prev ? { ...prev, ...data.item } : prev)
+        showMsg('success', 'Calibration feedback saved')
+      } else {
+        const data = await res.json()
+        showMsg('error', data.error || 'Failed to save calibration feedback')
+      }
+    } catch {
+      showMsg('error', 'Failed to save calibration feedback')
+    } finally {
+      setSavingCalibration(false)
+    }
   }
 
   const handleApprove = async () => {
@@ -474,6 +559,8 @@ function SocialContentDetailPage() {
   const agentPilotVoicePrinciples = asStringArray(agentPilotCalibration?.voice_principles)
   const agentPilotMissingContextPrompts = asStringArray(agentPilotCalibration?.missing_context_prompts)
   const agentPilotComparisonPrompt = asString(agentPilotCalibration?.comparison_prompt)
+  const agentPilotOperatorFeedback = asRecord(agentPilotCalibration?.operator_feedback)
+  const agentPilotFeedbackUpdatedAt = asString(agentPilotOperatorFeedback?.updated_at)
   const isDraftOnlyPilot = isAgentSocialPilot && agentPilotPublishGate === 'draft_only'
 
   return (
@@ -648,6 +735,92 @@ function SocialContentDetailPage() {
                     {agentPilotComparisonPrompt}
                   </div>
                 )}
+                <div className="mt-4 rounded-lg border border-gray-800 bg-gray-900/55 p-4">
+                  <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.14em] text-amber-300">Operator Feedback Loop</p>
+                      <p className="mt-1 text-sm leading-6 text-gray-300">
+                        Add the context Shaka should use to compare this draft against posts that already sounded right and performed well.
+                      </p>
+                    </div>
+                    {agentPilotFeedbackUpdatedAt && (
+                      <span className="w-fit rounded-full border border-gray-700 px-3 py-1 text-xs text-gray-400">
+                        Saved {new Date(agentPilotFeedbackUpdatedAt).toLocaleString()}
+                      </span>
+                    )}
+                  </div>
+                  <div className="mt-3 grid gap-3 lg:grid-cols-2">
+                    <label className="block text-xs font-medium uppercase tracking-[0.12em] text-gray-500">
+                      Prior post or sample excerpt
+                      <textarea
+                        value={calibrationFeedback.prior_post_excerpt}
+                        onChange={(event) => updateCalibrationFeedback('prior_post_excerpt', event.target.value)}
+                        disabled={!isEditable}
+                        rows={4}
+                        className="mt-2 w-full rounded-lg border border-gray-700 bg-gray-950/70 px-3 py-2 text-sm normal-case leading-6 tracking-normal text-gray-200 disabled:opacity-60"
+                        placeholder="Paste the post, excerpt, or link that this draft should learn from."
+                      />
+                    </label>
+                    <label className="block text-xs font-medium uppercase tracking-[0.12em] text-gray-500">
+                      Engagement signal
+                      <textarea
+                        value={calibrationFeedback.engagement_signal}
+                        onChange={(event) => updateCalibrationFeedback('engagement_signal', event.target.value)}
+                        disabled={!isEditable}
+                        rows={4}
+                        className="mt-2 w-full rounded-lg border border-gray-700 bg-gray-950/70 px-3 py-2 text-sm normal-case leading-6 tracking-normal text-gray-200 disabled:opacity-60"
+                        placeholder="Views, likes, comments, or why the post felt strong enough to publish."
+                      />
+                    </label>
+                    <label className="block text-xs font-medium uppercase tracking-[0.12em] text-gray-500">
+                      Audience and desired reaction
+                      <textarea
+                        value={calibrationFeedback.audience_context}
+                        onChange={(event) => updateCalibrationFeedback('audience_context', event.target.value)}
+                        disabled={!isEditable}
+                        rows={3}
+                        className="mt-2 w-full rounded-lg border border-gray-700 bg-gray-950/70 px-3 py-2 text-sm normal-case leading-6 tracking-normal text-gray-200 disabled:opacity-60"
+                        placeholder="Who should this speak to, and what should they feel or do after reading?"
+                      />
+                    </label>
+                    <label className="block text-xs font-medium uppercase tracking-[0.12em] text-gray-500">
+                      Revision request
+                      <textarea
+                        value={calibrationFeedback.revision_request}
+                        onChange={(event) => updateCalibrationFeedback('revision_request', event.target.value)}
+                        disabled={!isEditable}
+                        rows={3}
+                        className="mt-2 w-full rounded-lg border border-gray-700 bg-gray-950/70 px-3 py-2 text-sm normal-case leading-6 tracking-normal text-gray-200 disabled:opacity-60"
+                        placeholder="What should Shaka change in the next draft?"
+                      />
+                    </label>
+                    <label className="block text-xs font-medium uppercase tracking-[0.12em] text-gray-500 lg:col-span-2">
+                      Claims or boundaries to avoid
+                      <textarea
+                        value={calibrationFeedback.claim_boundaries}
+                        onChange={(event) => updateCalibrationFeedback('claim_boundaries', event.target.value)}
+                        disabled={!isEditable}
+                        rows={3}
+                        className="mt-2 w-full rounded-lg border border-gray-700 bg-gray-950/70 px-3 py-2 text-sm normal-case leading-6 tracking-normal text-gray-200 disabled:opacity-60"
+                        placeholder="Private details, unsupported claims, client references, or angles that should stay out."
+                      />
+                    </label>
+                  </div>
+                  <div className="mt-3 flex flex-wrap items-center justify-between gap-3">
+                    <p className="text-xs leading-5 text-gray-500">
+                      Saved feedback stays inside this draft packet and does not publish, schedule, DM, or send anything externally.
+                    </p>
+                    <button
+                      type="button"
+                      onClick={handleSaveCalibrationFeedback}
+                      disabled={!isEditable || savingCalibration}
+                      className="inline-flex items-center gap-2 rounded-lg border border-amber-500/40 px-3 py-2 text-sm text-amber-200 transition-colors hover:bg-amber-500/10 disabled:opacity-50"
+                    >
+                      {savingCalibration ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
+                      Save feedback to packet
+                    </button>
+                  </div>
+                </div>
               </div>
             )}
 

--- a/app/admin/social-content/[id]/page.tsx
+++ b/app/admin/social-content/[id]/page.tsx
@@ -113,6 +113,7 @@ function SocialContentDetailPage() {
   const [selectedSlide, setSelectedSlide] = useState(0)
   const [publishing, setPublishing] = useState(false)
   const [savingCalibration, setSavingCalibration] = useState(false)
+  const [revisingCalibration, setRevisingCalibration] = useState(false)
   const [showSource, setShowSource] = useState(false)
   const [expandedSection, setExpandedSection] = useState<'rag' | 'transcript' | null>(null)
   const [showConfirmModal, setShowConfirmModal] = useState(false)
@@ -280,6 +281,49 @@ function SocialContentDetailPage() {
       showMsg('error', 'Failed to save calibration feedback')
     } finally {
       setSavingCalibration(false)
+    }
+  }
+
+  const handleGenerateCalibrationRevision = async () => {
+    if (!item) return
+    setRevisingCalibration(true)
+    try {
+      const saved = await saveForm()
+      if (!saved) {
+        showMsg('error', 'Save the current draft before generating a calibrated revision')
+        return
+      }
+
+      const session = await getCurrentSession()
+      if (!session) return
+
+      const res = await fetch(`/api/admin/social-content/${id}/calibration-revision`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${session.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ operator_feedback: calibrationFeedback }),
+      })
+
+      const data = await res.json()
+      if (!res.ok) {
+        showMsg('error', data.error || 'Failed to generate calibrated revision')
+        return
+      }
+
+      const updated = data.item as SocialContentItem
+      setItem(updated)
+      setPostText(updated.post_text || '')
+      setCtaText(updated.cta_text || '')
+      setHashtags(updated.hashtags?.join(', ') || '')
+      setImagePrompt(updated.image_prompt || '')
+      setAdminNotes(updated.admin_notes || '')
+      showMsg('success', 'Calibrated revision generated')
+    } catch {
+      showMsg('error', 'Failed to generate calibrated revision')
+    } finally {
+      setRevisingCalibration(false)
     }
   }
 
@@ -810,15 +854,26 @@ function SocialContentDetailPage() {
                     <p className="text-xs leading-5 text-gray-500">
                       Saved feedback stays inside this draft packet and does not publish, schedule, DM, or send anything externally.
                     </p>
-                    <button
-                      type="button"
-                      onClick={handleSaveCalibrationFeedback}
-                      disabled={!isEditable || savingCalibration}
-                      className="inline-flex items-center gap-2 rounded-lg border border-amber-500/40 px-3 py-2 text-sm text-amber-200 transition-colors hover:bg-amber-500/10 disabled:opacity-50"
-                    >
-                      {savingCalibration ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
-                      Save feedback to packet
-                    </button>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={handleSaveCalibrationFeedback}
+                        disabled={!isEditable || savingCalibration}
+                        className="inline-flex items-center gap-2 rounded-lg border border-amber-500/40 px-3 py-2 text-sm text-amber-200 transition-colors hover:bg-amber-500/10 disabled:opacity-50"
+                      >
+                        {savingCalibration ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
+                        Save feedback
+                      </button>
+                      <button
+                        type="button"
+                        onClick={handleGenerateCalibrationRevision}
+                        disabled={!isEditable || savingCalibration || revisingCalibration}
+                        className="inline-flex items-center gap-2 rounded-lg bg-amber-400 px-3 py-2 text-sm font-semibold text-slate-950 transition-colors hover:bg-amber-300 disabled:opacity-50"
+                      >
+                        {revisingCalibration ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Sparkles className="h-3.5 w-3.5" />}
+                        Revise with feedback
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/app/api/admin/social-content/[id]/calibration-revision/route.test.ts
+++ b/app/api/admin/social-content/[id]/calibration-revision/route.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  generateJsonCompletion: vi.fn(),
+  getSocialCopywritingPrompt: vi.fn(),
+  from: vi.fn(),
+  select: vi.fn(),
+  eq: vi.fn(),
+  single: vi.fn(),
+  update: vi.fn(),
+  updateEq: vi.fn(),
+  updateSelect: vi.fn(),
+  updateSingle: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/llm-dispatch', () => ({
+  generateJsonCompletion: mocks.generateJsonCompletion,
+}))
+
+vi.mock('@/lib/system-prompts', () => ({
+  getSocialCopywritingPrompt: mocks.getSocialCopywritingPrompt,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import { POST } from './route'
+
+function request(body: unknown = {}) {
+  return new NextRequest('http://localhost/api/admin/social-content/social-1/calibration-revision', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+const agentOpsRagContext = {
+  source: 'agent_ops_social_outreach_goal',
+  goal_id: 'goal-1',
+  content_packet_id: 'packet-1',
+  publish_gate: 'draft_only',
+  content_calibration: {
+    status: 'ready_for_draft_review',
+    voice_principles: ['Start from a real operational tension.'],
+    prior_success_patterns: [
+      {
+        label: 'Dogfooding post',
+        pattern: 'Show the work before naming the product claim.',
+        why_it_worked: 'It felt specific.',
+        reuse_guidance: 'Lead with the workflow.',
+      },
+    ],
+    operator_feedback: {
+      prior_post_excerpt: 'A previous post about practical AI adoption.',
+      engagement_signal: 'Strong comments from operators.',
+      audience_context: 'Small business owners carrying operational load.',
+      revision_request: 'Make the hook more concrete.',
+      claim_boundaries: 'No private client details.',
+      updated_at: '2026-05-28T04:30:00.000Z',
+    },
+  },
+}
+
+describe('POST /api/admin/social-content/[id]/calibration-revision', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-1' }, isAdmin: true })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.getSocialCopywritingPrompt.mockResolvedValue('Write in Vambah voice.')
+    mocks.generateJsonCompletion.mockResolvedValue({
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      content: JSON.stringify({
+        post_text: 'A small business owner does not need another AI demo. They need the work to get lighter.',
+        cta_text: 'Where is AI still adding work instead of removing it?',
+        hashtags: ['#AIProduct', 'ProductManagement'],
+        image_prompt: 'A mission-control style operating board.',
+        revision_notes: ['Reworked the hook around a concrete operator tension.'],
+      }),
+    })
+    mocks.single.mockResolvedValue({
+      data: {
+        id: 'social-1',
+        status: 'draft',
+        post_text: 'Original draft',
+        cta_text: 'Original CTA',
+        hashtags: ['#AI'],
+        image_prompt: 'Original image prompt',
+        topic_extracted: { topic: 'AI adoption' },
+        hormozi_framework: { framework_type: 'proof_stacking' },
+        rag_context: agentOpsRagContext,
+        admin_notes: 'Existing notes',
+      },
+      error: null,
+    })
+    mocks.updateSingle.mockResolvedValue({
+      data: {
+        id: 'social-1',
+        status: 'draft',
+        post_text: 'A small business owner does not need another AI demo. They need the work to get lighter.',
+        rag_context: {
+          ...agentOpsRagContext,
+          content_calibration: {
+            ...agentOpsRagContext.content_calibration,
+            status: 'revision_generated',
+          },
+        },
+      },
+      error: null,
+    })
+    mocks.eq.mockReturnValue({ single: mocks.single })
+    mocks.select.mockReturnValue({ eq: mocks.eq })
+    mocks.updateSelect.mockReturnValue({ single: mocks.updateSingle })
+    mocks.updateEq.mockReturnValue({ select: mocks.updateSelect })
+    mocks.update.mockReturnValue({ eq: mocks.updateEq })
+    mocks.from.mockReturnValue({ select: mocks.select, update: mocks.update })
+  })
+
+  it('requires admin auth before reading content', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Authentication required', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(request(), { params: { id: 'social-1' } })
+
+    expect(response.status).toBe(401)
+    expect(mocks.from).not.toHaveBeenCalled()
+    expect(mocks.generateJsonCompletion).not.toHaveBeenCalled()
+  })
+
+  it('generates a calibrated draft revision and keeps the item draft-only', async () => {
+    const response = await POST(request(), { params: { id: 'social-1' } })
+
+    expect(response.status).toBe(200)
+    const json = await response.json()
+    expect(json.item.id).toBe('social-1')
+    expect(mocks.generateJsonCompletion).toHaveBeenCalledWith(expect.objectContaining({
+      model: 'gpt-4o-mini',
+      costContext: expect.objectContaining({
+        reference: { type: 'social_content_queue', id: 'social-1' },
+      }),
+    }))
+    expect(mocks.update).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'draft',
+      post_text: expect.stringContaining('small business owner'),
+      cta_text: 'Where is AI still adding work instead of removing it?',
+      hashtags: ['#AIProduct', '#ProductManagement'],
+      rag_context: expect.objectContaining({
+        content_calibration: expect.objectContaining({
+          status: 'revision_generated',
+          revision_history: expect.any(Array),
+        }),
+      }),
+    }))
+  })
+
+  it('accepts unsaved operator feedback in the request body', async () => {
+    const response = await POST(request({
+      operator_feedback: {
+        prior_post_excerpt: 'A stronger sample post.',
+        revision_request: 'Add more lived operator detail.',
+      },
+    }), { params: { id: 'social-1' } })
+
+    expect(response.status).toBe(200)
+    expect(mocks.update).toHaveBeenCalledWith(expect.objectContaining({
+      rag_context: expect.objectContaining({
+        content_calibration: expect.objectContaining({
+          operator_feedback: expect.objectContaining({
+            prior_post_excerpt: 'A stronger sample post.',
+            revision_request: 'Add more lived operator detail.',
+          }),
+        }),
+      }),
+    }))
+  })
+
+  it('blocks revision when no operator feedback exists', async () => {
+    mocks.single.mockResolvedValueOnce({
+      data: {
+        id: 'social-1',
+        status: 'draft',
+        post_text: 'Original draft',
+        cta_text: null,
+        hashtags: [],
+        image_prompt: null,
+        topic_extracted: {},
+        hormozi_framework: {},
+        rag_context: {
+          source: 'agent_ops_social_outreach_goal',
+          content_calibration: {},
+        },
+        admin_notes: null,
+      },
+      error: null,
+    })
+
+    const response = await POST(request(), { params: { id: 'social-1' } })
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: 'Save operator feedback before generating a calibrated revision',
+    })
+    expect(mocks.generateJsonCompletion).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/admin/social-content/[id]/calibration-revision/route.ts
+++ b/app/api/admin/social-content/[id]/calibration-revision/route.ts
@@ -1,0 +1,302 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { generateJsonCompletion } from '@/lib/llm-dispatch'
+import { supabaseAdmin } from '@/lib/supabase'
+import { getSocialCopywritingPrompt } from '@/lib/system-prompts'
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 60
+
+type SocialContentRow = {
+  id: string
+  status: string
+  post_text: string | null
+  cta_text: string | null
+  hashtags: string[] | null
+  image_prompt: string | null
+  topic_extracted: unknown
+  hormozi_framework: unknown
+  rag_context: Record<string, unknown> | null
+  admin_notes: string | null
+}
+
+type CalibrationRevision = {
+  post_text?: unknown
+  cta_text?: unknown
+  hashtags?: unknown
+  image_prompt?: unknown
+  revision_notes?: unknown
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null
+}
+
+function asString(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
+}
+
+function hasOperatorFeedback(feedback: Record<string, unknown> | null): boolean {
+  if (!feedback) return false
+  return [
+    'prior_post_excerpt',
+    'engagement_signal',
+    'audience_context',
+    'revision_request',
+    'claim_boundaries',
+  ].some((key) => Boolean(asString(feedback[key]).trim()))
+}
+
+function buildRevisionPrompt(row: SocialContentRow) {
+  const ragContext = asRecord(row.rag_context) ?? {}
+  const calibration = asRecord(ragContext.content_calibration) ?? {}
+  const feedback = asRecord(calibration.operator_feedback) ?? {}
+  const priorPatterns = Array.isArray(calibration.prior_success_patterns)
+    ? calibration.prior_success_patterns
+    : []
+  const voicePrinciples = asStringArray(calibration.voice_principles)
+  const missingContextPrompts = asStringArray(calibration.missing_context_prompts)
+
+  return `Revise this LinkedIn draft as Shaka, Vambah's Chief of Staff.
+
+Keep the output draft-only. Do not publish, schedule, DM, or create external outreach.
+
+Return JSON only:
+{
+  "post_text": "revised LinkedIn post text",
+  "cta_text": "specific closing question",
+  "hashtags": ["#AIProduct", "#ProductManagement"],
+  "image_prompt": "optional revised visual brief",
+  "revision_notes": ["what changed and why"]
+}
+
+Current draft:
+${row.post_text ?? ''}
+
+Current CTA:
+${row.cta_text ?? ''}
+
+Current hashtags:
+${(row.hashtags ?? []).join(', ')}
+
+Topic metadata:
+${JSON.stringify(row.topic_extracted ?? {}, null, 2)}
+
+Framework metadata:
+${JSON.stringify(row.hormozi_framework ?? {}, null, 2)}
+
+Content packet context:
+${JSON.stringify({
+    goal_id: ragContext.goal_id,
+    goal_type: ragContext.goal_type,
+    content_packet_id: ragContext.content_packet_id,
+    publish_gate: ragContext.publish_gate,
+    open_brain_references: ragContext.open_brain_references,
+    chronicle_packet_status: ragContext.chronicle_packet_status,
+    chronicle_evidence_notes: ragContext.chronicle_evidence_notes,
+    source_provenance_checklist: ragContext.source_provenance_checklist,
+    visual_brief: ragContext.visual_brief,
+  }, null, 2)}
+
+Prior success patterns to compare against:
+${JSON.stringify(priorPatterns, null, 2)}
+
+Voice principles:
+${voicePrinciples.map((item) => `- ${item}`).join('\n')}
+
+Operator feedback:
+Prior post/sample excerpt:
+${asString(feedback.prior_post_excerpt)}
+
+Engagement signal:
+${asString(feedback.engagement_signal)}
+
+Audience and desired reaction:
+${asString(feedback.audience_context)}
+
+Revision request:
+${asString(feedback.revision_request)}
+
+Claim boundaries:
+${asString(feedback.claim_boundaries)}
+
+If context is still missing, make the best draft from the available packet and mention the missing input in revision_notes, not in the post.
+
+Context prompts Shaka wanted answered:
+${missingContextPrompts.map((item) => `- ${item}`).join('\n')}`
+}
+
+function normalizeRevision(parsed: CalibrationRevision) {
+  const postText = asString(parsed.post_text).trim()
+  if (!postText) {
+    throw new Error('Revision response did not include post_text')
+  }
+
+  const ctaText = asString(parsed.cta_text).trim()
+  const imagePrompt = asString(parsed.image_prompt).trim()
+  const revisionNotes = asStringArray(parsed.revision_notes).map((item) => item.trim()).filter(Boolean)
+  const hashtags = asStringArray(parsed.hashtags)
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .map((item) => item.startsWith('#') ? item : `#${item}`)
+
+  return {
+    post_text: postText,
+    cta_text: ctaText || null,
+    image_prompt: imagePrompt || null,
+    hashtags,
+    revision_notes: revisionNotes,
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const authResult = await verifyAdmin(request)
+    if (isAuthError(authResult)) {
+      return NextResponse.json({ error: authResult.error }, { status: authResult.status })
+    }
+
+    const body = await request.json().catch(() => ({})) as {
+      operator_feedback?: Record<string, unknown>
+    }
+
+    const { data: row, error: fetchError } = await supabaseAdmin
+      .from('social_content_queue')
+      .select('id, status, post_text, cta_text, hashtags, image_prompt, topic_extracted, hormozi_framework, rag_context, admin_notes')
+      .eq('id', params.id)
+      .single()
+
+    if (fetchError || !row) {
+      return NextResponse.json({ error: 'Content not found' }, { status: 404 })
+    }
+
+    const content = row as SocialContentRow
+    if (content.status !== 'draft' && content.status !== 'rejected') {
+      return NextResponse.json({ error: 'Calibration revision is only available for draft or rejected content' }, { status: 409 })
+    }
+
+    const ragContext = asRecord(content.rag_context) ?? {}
+    if (ragContext.source !== 'agent_ops_social_outreach_goal') {
+      return NextResponse.json({ error: 'Calibration revision is only available for Agent Ops social pilot drafts' }, { status: 400 })
+    }
+
+    const calibration = asRecord(ragContext.content_calibration) ?? {}
+    const requestedFeedback = asRecord(body.operator_feedback)
+    const operatorFeedback = hasOperatorFeedback(requestedFeedback)
+      ? {
+        prior_post_excerpt: asString(requestedFeedback?.prior_post_excerpt).trim(),
+        engagement_signal: asString(requestedFeedback?.engagement_signal).trim(),
+        audience_context: asString(requestedFeedback?.audience_context).trim(),
+        revision_request: asString(requestedFeedback?.revision_request).trim(),
+        claim_boundaries: asString(requestedFeedback?.claim_boundaries).trim(),
+        updated_at: new Date().toISOString(),
+      }
+      : asRecord(calibration.operator_feedback)
+    if (!hasOperatorFeedback(operatorFeedback)) {
+      return NextResponse.json({ error: 'Save operator feedback before generating a calibrated revision' }, { status: 400 })
+    }
+
+    const promptRagContext: Record<string, unknown> = {
+      ...ragContext,
+      content_calibration: {
+        ...calibration,
+        operator_feedback: operatorFeedback,
+      },
+    }
+
+    const basePrompt = await getSocialCopywritingPrompt()
+    const model = process.env.SOCIAL_CALIBRATION_REVISION_MODEL || 'gpt-4o-mini'
+    const promptContent = { ...content, rag_context: promptRagContext }
+    const aiResponse = await generateJsonCompletion({
+      model,
+      systemPrompt: `${basePrompt}
+
+Additional role: You are Shaka, the Agent Ops Chief of Staff. Use the operator feedback and calibration packet to revise the draft in Vambah's voice. Stay source-backed, concrete, and draft-only.`,
+      userPrompt: buildRevisionPrompt(promptContent),
+      temperature: 0.55,
+      maxTokens: 1400,
+      costContext: {
+        reference: { type: 'social_content_queue', id: params.id },
+        metadata: {
+          operation: 'social_content_calibration_revision',
+          goal_id: asString(promptRagContext.goal_id) || null,
+          content_packet_id: asString(promptRagContext.content_packet_id) || null,
+        },
+      },
+    })
+
+    let parsed: CalibrationRevision
+    try {
+      parsed = JSON.parse(aiResponse.content) as CalibrationRevision
+    } catch {
+      return NextResponse.json({ error: 'Calibration revision returned invalid JSON' }, { status: 502 })
+    }
+
+    const revision = normalizeRevision(parsed)
+    const createdAt = new Date().toISOString()
+    const revisionEntry = {
+      created_at: createdAt,
+      created_by: authResult.user.id,
+      model: aiResponse.model,
+      provider: aiResponse.provider,
+      revision_notes: revision.revision_notes,
+      operator_feedback_updated_at: asString(operatorFeedback?.updated_at) || null,
+    }
+    const revisionHistory = Array.isArray(calibration.revision_history)
+      ? calibration.revision_history
+      : []
+    const nextRagContext = {
+      ...promptRagContext,
+      content_calibration: {
+        ...calibration,
+        status: 'revision_generated',
+        operator_feedback: operatorFeedback,
+        latest_revision: revisionEntry,
+        revision_history: [...revisionHistory, revisionEntry].slice(-10),
+      },
+    }
+
+    const notesBlock = [
+      `Calibration revision generated by Shaka on ${createdAt}.`,
+      ...revision.revision_notes.map((note) => `- ${note}`),
+    ].join('\n')
+
+    const { data: updated, error: updateError } = await supabaseAdmin
+      .from('social_content_queue')
+      .update({
+        post_text: revision.post_text,
+        cta_text: revision.cta_text,
+        hashtags: revision.hashtags.length ? revision.hashtags : content.hashtags ?? [],
+        image_prompt: revision.image_prompt ?? content.image_prompt,
+        status: 'draft',
+        rag_context: nextRagContext,
+        admin_notes: [content.admin_notes, notesBlock].filter(Boolean).join('\n\n'),
+      })
+      .eq('id', params.id)
+      .select('*')
+      .single()
+
+    if (updateError || !updated) {
+      console.error('[calibration-revision] update failed:', updateError)
+      return NextResponse.json({ error: 'Failed to save calibrated revision' }, { status: 500 })
+    }
+
+    return NextResponse.json({
+      item: updated,
+      revision: revisionEntry,
+    })
+  } catch (error) {
+    console.error('[calibration-revision] error:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Internal server error' },
+      { status: 500 },
+    )
+  }
+}

--- a/app/api/admin/social-content/[id]/route.test.ts
+++ b/app/api/admin/social-content/[id]/route.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  from: vi.fn(),
+  update: vi.fn(),
+  eq: vi.fn(),
+  select: vi.fn(),
+  single: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import { PUT } from './route'
+
+function request(body: unknown) {
+  return new NextRequest('http://localhost/api/admin/social-content/social-1', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('PUT /api/admin/social-content/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-1' }, isAdmin: true })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.single.mockResolvedValue({
+      data: { id: 'social-1', rag_context: { source: 'agent_ops_social_outreach_goal' } },
+      error: null,
+    })
+    mocks.select.mockReturnValue({ single: mocks.single })
+    mocks.eq.mockReturnValue({ select: mocks.select })
+    mocks.update.mockReturnValue({ eq: mocks.eq })
+    mocks.from.mockReturnValue({ update: mocks.update })
+  })
+
+  it('allows Agent Ops calibration feedback to be saved in rag_context', async () => {
+    const ragContext = {
+      source: 'agent_ops_social_outreach_goal',
+      content_calibration: {
+        status: 'ready_for_draft_review',
+        operator_feedback: {
+          prior_post_excerpt: 'A prior post about practical AI adoption.',
+          engagement_signal: 'Strong comments from operators.',
+          audience_context: 'Small business owners carrying operational load.',
+          revision_request: 'Make the hook more concrete.',
+          claim_boundaries: 'Do not mention private client data.',
+          updated_at: '2026-05-28T04:30:00.000Z',
+        },
+      },
+    }
+
+    const response = await PUT(request({ rag_context: ragContext, unknown: 'ignored' }) as never, {
+      params: { id: 'social-1' },
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      item: { id: 'social-1', rag_context: { source: 'agent_ops_social_outreach_goal' } },
+    })
+    expect(mocks.from).toHaveBeenCalledWith('social_content_queue')
+    expect(mocks.update).toHaveBeenCalledWith({ rag_context: ragContext })
+    expect(mocks.eq).toHaveBeenCalledWith('id', 'social-1')
+  })
+
+  it('still rejects empty update payloads', async () => {
+    const response = await PUT(request({ unknown: 'ignored' }) as never, {
+      params: { id: 'social-1' },
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'No valid fields to update' })
+    expect(mocks.update).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/admin/social-content/[id]/route.ts
+++ b/app/api/admin/social-content/[id]/route.ts
@@ -85,6 +85,7 @@ export async function PUT(
       'post_text', 'cta_text', 'cta_url', 'hashtags',
       'image_prompt', 'voiceover_text', 'platform',
       'status', 'scheduled_for', 'admin_notes',
+      'rag_context',
       'framework_visual_type', 'target_platforms',
       'video_generation_method', 'youtube_title', 'youtube_description',
     ]

--- a/lib/agent-war-room.test.ts
+++ b/lib/agent-war-room.test.ts
@@ -550,6 +550,16 @@ describe('runAgentWarRoom', () => {
         source_provenance_checklist: expect.arrayContaining([
           'Open Brain references are approved/public-safe.',
         ]),
+        content_calibration: expect.objectContaining({
+          status: 'needs_operator_context',
+          prior_success_patterns: expect.arrayContaining([
+            expect.objectContaining({ label: 'Builder proof post' }),
+          ]),
+          missing_context_prompts: expect.arrayContaining([
+            'Paste or link one high-performing LinkedIn post that felt representative of Vambah voice.',
+          ]),
+          comparison_prompt: expect.stringContaining('Compare this draft against Vambah LinkedIn voice guidance'),
+        }),
       }),
     })
     expect(draftResult.goalDraft?.tasks.map((task) => task.title)).toEqual([
@@ -588,6 +598,11 @@ describe('runAgentWarRoom', () => {
         content_packet_id: draftResult.goalDraft?.content_packet_id,
         social_content_draft_id: 'social-draft-1',
         social_content_draft_href: '/admin/social-content/social-draft-1',
+        content_packet: expect.objectContaining({
+          content_calibration: expect.objectContaining({
+            status: 'needs_operator_context',
+          }),
+        }),
       }),
     }))
     expect(workItemMocks.createAgentWorkItem).toHaveBeenCalledWith(expect.objectContaining({

--- a/lib/agent-war-room.ts
+++ b/lib/agent-war-room.ts
@@ -58,6 +58,14 @@ export interface LinkedInContentCalibration {
   revision_questions: string[]
   missing_context_prompts: string[]
   comparison_prompt: string
+  operator_feedback?: {
+    prior_post_excerpt?: string
+    engagement_signal?: string
+    audience_context?: string
+    revision_request?: string
+    claim_boundaries?: string
+    updated_at?: string
+  }
 }
 
 export interface LinkedInContentPacket {

--- a/lib/agent-war-room.ts
+++ b/lib/agent-war-room.ts
@@ -43,6 +43,23 @@ export interface AgentGoalAuthorityBoundary {
   notes: string
 }
 
+export interface LinkedInContentCalibrationExample {
+  label: string
+  pattern: string
+  why_it_worked: string
+  reuse_guidance: string
+}
+
+export interface LinkedInContentCalibration {
+  status: 'needs_operator_context' | 'ready_for_draft_review'
+  prior_success_patterns: LinkedInContentCalibrationExample[]
+  voice_principles: string[]
+  audience_notes: string[]
+  revision_questions: string[]
+  missing_context_prompts: string[]
+  comparison_prompt: string
+}
+
 export interface LinkedInContentPacket {
   id: string
   goal_statement: string
@@ -56,6 +73,7 @@ export interface LinkedInContentPacket {
   image_prompt: string
   source_provenance_checklist: string[]
   approval_checklist: string[]
+  content_calibration: LinkedInContentCalibration
   social_content_draft_id?: string | null
   social_content_draft_href?: string | null
 }
@@ -307,6 +325,60 @@ function goalIdFromTitle(title: string) {
   return `goal-${slug}-${Date.now().toString(36)}`
 }
 
+function buildLinkedInContentCalibration(): LinkedInContentCalibration {
+  return {
+    status: 'needs_operator_context',
+    prior_success_patterns: [
+      {
+        label: 'Builder proof post',
+        pattern: 'Open with a concrete build observation, then name the operational gap between a fast prototype and something safe to hand to another person.',
+        why_it_worked: 'It sounded earned because the post referenced actual builder work, named the risk, and ended with a question other builders could answer.',
+        reuse_guidance: 'Use when the draft needs more practical evidence from Portfolio, Agent Ops, Open Brain, or Social Content.',
+      },
+      {
+        label: 'Access and burden post',
+        pattern: 'Start from a lived or operator-level burden, then connect the point to access, systems, and the work required to make technology useful.',
+        why_it_worked: 'It made the technology argument human without turning the story into abstract inspiration.',
+        reuse_guidance: 'Use when the post should speak to small businesses, nonprofits, or communities carrying too much operational load.',
+      },
+      {
+        label: 'Dogfooding AmaduTown post',
+        pattern: 'Name the system being built, show what changed in the workflow, and explain why the operating model matters more than the tool demo.',
+        why_it_worked: 'It gave readers proof that the idea had been tested in AmaduTown work instead of only described.',
+        reuse_guidance: 'Use when the draft needs to compare the current claim against work Vambah has already been willing to publish.',
+      },
+    ],
+    voice_principles: [
+      'Open with a concrete scene, tension, or practical problem.',
+      'Develop one idea instead of stacking several AI claims.',
+      'Name the tool, workflow, audience, or artifact when it is safe to do so.',
+      'Pair critique with a practical path forward.',
+      'Avoid generic AI hype, corporate filler, and formulaic signposting.',
+      'End with a specific question that invites a real operator response.',
+    ],
+    audience_notes: [
+      'Speak to leaders trying to reduce burden, not people shopping for another AI demo.',
+      'Make the post legible to small business and nonprofit operators who care about proof, governance, and time saved.',
+      'Keep the AmaduTown claim grounded in applied operating-system work.',
+    ],
+    revision_questions: [
+      'Does the draft sound like a point Vambah would stand behind publicly?',
+      'Which successful-post pattern is this draft borrowing from, and is the borrowing intentional?',
+      'Where is the strongest proof point, and is it safe to reference?',
+      'What context from a prior post, Chronicle packet, or Open Brain record would make this sharper?',
+      'What should be softened because the evidence is still pending?',
+    ],
+    missing_context_prompts: [
+      'Paste or link one high-performing LinkedIn post that felt representative of Vambah voice.',
+      'Add any engagement signal that matters, such as views, likes, comments, or the reason the post felt worth publishing.',
+      'Name the specific audience for this post and the reaction you want from them.',
+      'Attach sanitized Chronicle notes showing the workflow or artifact that inspired the point.',
+      'Flag any claims, client details, or personal references that should stay out of the draft.',
+    ],
+    comparison_prompt: 'Compare this draft against Vambah LinkedIn voice guidance and the prior successful-post patterns. Identify what already sounds authentic, what feels generic, what evidence is missing, and the next revision to make before public review.',
+  }
+}
+
 function buildLinkedInPacket(goalId: string, title: string): LinkedInContentPacket {
   const packetId = `packet-${goalId}`
   return {
@@ -351,6 +423,7 @@ function buildLinkedInPacket(goalId: string, title: string): LinkedInContentPack
       'CTA invites discussion without overpromising.',
       'Social Content item remains draft-only until separately approved.',
     ],
+    content_calibration: buildLinkedInContentCalibration(),
     social_content_draft_id: null,
     social_content_draft_href: null,
   }
@@ -816,6 +889,10 @@ async function createSocialContentDraftForGoal(draft: AgentGoalDraft) {
     `Packet: ${packet.id}`,
     'Publish gate: draft_only. Do not publish or schedule from goal approval.',
     'Chronicle evidence is manual/sanitized in V1.',
+    'Content calibration:',
+    ...packet.content_calibration.voice_principles.map((item) => `- ${item}`),
+    'Operator context prompts:',
+    ...packet.content_calibration.missing_context_prompts.slice(0, 3).map((item) => `- ${item}`),
     'Approval checklist:',
     ...packet.approval_checklist.map((item) => `- ${item}`),
   ].join('\n')
@@ -855,6 +932,8 @@ async function createSocialContentDraftForGoal(draft: AgentGoalDraft) {
         chronicle_evidence_notes: packet.chronicle_evidence_notes,
         source_provenance_checklist: packet.source_provenance_checklist,
         approval_checklist: packet.approval_checklist,
+        visual_brief: packet.visual_concept,
+        content_calibration: packet.content_calibration,
       },
       admin_notes: adminNotes,
       target_platforms: ['linkedin'],


### PR DESCRIPTION
## Summary
- add a LinkedIn content calibration packet to social outreach goal drafts
- surface prior successful-post patterns, voice checks, missing context prompts, and comparison guidance in Standup Room before delegation
- carry calibration metadata into Social Content draft handoff and display it on draft detail pages
- add an operator feedback loop on Social Content drafts so prior-post examples, engagement signals, audience context, revision requests, and claim boundaries can be saved back into the packet metadata
- add a draft-only calibrated revision action that uses saved or currently typed operator feedback to revise the LinkedIn draft, update CTA/hashtags/visual prompt, and append revision history to `rag_context`

## Validation
- npm test -- app/api/admin/social-content/[id]/calibration-revision/route.test.ts app/api/admin/social-content/[id]/route.test.ts
- npm test -- app/admin/agents/standup/page.test.tsx app/api/admin/agents/war-room/route.test.ts lib/agent-war-room.test.ts app/api/admin/social-content/[id]/route.test.ts app/api/admin/social-content/[id]/calibration-revision/route.test.ts
- npx tsc --noEmit --pretty false
- npm run lint
- npm run build
- Playwright local smoke on http://127.0.0.1:3006/admin/agents/standup and http://127.0.0.1:3006/admin/social-content/smoke-id: both returned 200 with zero page errors

## Integration Notes
- No schema migration. Uses existing Agent Ops goal metadata, content packet metadata, and Social Content rag_context.
- Calibration revision uses the existing LLM dispatcher and cost reference metadata; it remains draft-only and does not publish, schedule, DM, or send external outreach.
- Build passed with the existing local env warning that outbound n8n webhooks are enabled in .env.local.
- Vercel contexts need to be rechecked for the latest commit: Vercel – portfolio, Vercel – portfolio-staging.