### PR TITLE
feat: add ai ops readiness to monitor reports

### DIFF
--- a/app/api/cron/client-ai-ops-monitor/route.test.ts
+++ b/app/api/cron/client-ai-ops-monitor/route.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   from: vi.fn(),
+  getRoadmapBundleForProject: vi.fn(),
   refreshRoadmapPhaseRollups: vi.fn(),
   projectRoadmapTaskToMeetingTask: vi.fn(),
 }))
@@ -13,6 +14,7 @@ vi.mock('@/lib/supabase', () => ({
 }))
 
 vi.mock('@/lib/client-ai-ops-roadmap-db', () => ({
+  getRoadmapBundleForProject: mocks.getRoadmapBundleForProject,
   refreshRoadmapPhaseRollups: mocks.refreshRoadmapPhaseRollups,
   projectRoadmapTaskToMeetingTask: mocks.projectRoadmapTaskToMeetingTask,
 }))
@@ -71,6 +73,7 @@ describe('client AI Ops monitor cron route', () => {
     process.env.N8N_INGEST_SECRET = 'n8n-secret'
     process.env.CRON_SECRET = 'cron-secret'
     mocks.from.mockReturnValue(roadmapQuery([]))
+    mocks.getRoadmapBundleForProject.mockResolvedValue(null)
   })
 
   afterEach(() => {
@@ -111,6 +114,34 @@ describe('client AI Ops monitor cron route', () => {
 
     const reportInsert = supabaseQueryResult({ data: { id: 'report-1' }, error: null })
     const followupInsert = supabaseQueryResult({ data: { id: 'followup-task-1', title: 'Review AI Ops monitoring findings' }, error: null })
+    mocks.getRoadmapBundleForProject.mockResolvedValue({
+      clientView: {
+        connectorReadiness: {
+          summary: '1 required, 0 ready, 1 need auth, 0 approval-blocked',
+          requiredConnectorCount: 1,
+          readyConnectorCount: 0,
+          approvalBlockedConnectorCount: 0,
+          missingCriticalConnectorCount: 0,
+          connectorNextAction: 'Prepare oauth setup packet for HubSpot; do not connect until approved.',
+          conflicts: [],
+          items: [],
+        },
+        projectionStatus: {
+          tasksTotal: 2,
+          tasksComplete: 1,
+          blockedTasks: 0,
+          clientActionCount: 1,
+          amadutownActionCount: 0,
+          sharedActionCount: 0,
+          approvalNeededCount: 1,
+          isolationRequiredCount: 1,
+          overdueTasks: 0,
+          staleCostItems: 0,
+          reportMissing: false,
+          nextReportingAction: 'Review approval-gated roadmap work',
+        },
+      },
+    })
 
     mockTableResponses({
       client_ai_ops_roadmaps: [
@@ -167,11 +198,19 @@ describe('client AI Ops monitor cron route', () => {
         'Review overdue roadmap task: Finish client vault',
         'Refresh pricing/source for: Network switch',
         'Generate monthly AI Ops report',
+        'Review AI Ops readiness: Review approval-gated AI Ops work before any live setup or outbound action.',
       ],
       monitoring_summary: {
         overdue_tasks: 1,
         stale_cost_items: 1,
         report_missing: true,
+        readiness_status: 'waiting_approval',
+        readiness_next_action: 'Review approval-gated AI Ops work before any live setup or outbound action.',
+        readiness_side_effects_enabled: false,
+        connector_required: 1,
+        connector_ready: 0,
+        connector_approval_blocked: 0,
+        connector_missing_critical: 0,
         checked_at: '2026-05-02T10:00:00.000Z',
       },
     }))
@@ -185,6 +224,13 @@ describe('client AI Ops monitor cron route', () => {
           overdue_tasks: 1,
           stale_cost_items: 1,
           report_missing: true,
+          readiness_status: 'waiting_approval',
+          readiness_next_action: 'Review approval-gated AI Ops work before any live setup or outbound action.',
+          readiness_side_effects_enabled: false,
+          connector_required: 1,
+          connector_ready: 0,
+          connector_approval_blocked: 0,
+          connector_missing_critical: 0,
           checked_at: '2026-05-02T10:00:00.000Z',
         },
       },
@@ -232,6 +278,89 @@ describe('client AI Ops monitor cron route', () => {
       owner_type: 'amadutown',
       priority: 'high',
       meeting_task_visible: true,
+    }))
+  })
+
+  it('creates a monitoring review when readiness needs approval even without task or cost drift', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-02T10:00:00Z'))
+
+    const reportInsert = supabaseQueryResult({ data: { id: 'report-readiness' }, error: null })
+    const followupInsert = supabaseQueryResult({ data: { id: 'followup-readiness', title: 'Review AI Ops monitoring findings' }, error: null })
+    mocks.getRoadmapBundleForProject.mockResolvedValue({
+      clientView: {
+        connectorReadiness: {
+          summary: '1 required, 0 ready, 0 need auth, 1 approval-blocked',
+          requiredConnectorCount: 1,
+          readyConnectorCount: 0,
+          approvalBlockedConnectorCount: 1,
+          missingCriticalConnectorCount: 0,
+          connectorNextAction: 'Create approval checkpoint before connecting HubSpot.',
+          conflicts: [],
+          items: [],
+        },
+        projectionStatus: {
+          tasksTotal: 1,
+          tasksComplete: 0,
+          blockedTasks: 0,
+          clientActionCount: 0,
+          amadutownActionCount: 1,
+          sharedActionCount: 0,
+          approvalNeededCount: 0,
+          isolationRequiredCount: 0,
+          overdueTasks: 0,
+          staleCostItems: 0,
+          reportMissing: false,
+          nextReportingAction: 'Continue scheduled roadmap monitoring',
+        },
+      },
+    })
+
+    mockTableResponses({
+      client_ai_ops_roadmaps: [
+        roadmapQuery([
+          {
+            id: 'roadmap-1',
+            client_project_id: 'project-1',
+            title: 'Acme AI Ops',
+            status: 'active',
+          },
+        ]),
+      ],
+      client_ai_ops_roadmap_tasks: [
+        supabaseQueryResult({ data: [], error: null }),
+        supabaseQueryResult({ data: null, error: null }),
+        followupInsert,
+      ],
+      client_ai_ops_roadmap_cost_items: [
+        supabaseQueryResult({ data: [], error: null }),
+      ],
+      client_ai_ops_roadmap_reports: [
+        supabaseQueryResult({ data: [{ id: 'recent-report', generated_at: '2026-05-01T10:00:00Z' }], error: null }),
+        reportInsert,
+      ],
+      client_ai_ops_roadmap_phases: [
+        supabaseQueryResult({ data: { id: 'phase-1' }, error: null }),
+      ],
+    })
+
+    const response = await POST(request('POST', 'cron-secret') as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({ reports_created: 1, followup_tasks_created: 1 })
+    expect(reportInsert.insert).toHaveBeenCalledWith(expect.objectContaining({
+      amadutown_actions: [
+        'Review AI Ops readiness: Review approval-gated AI Ops work before any live setup or outbound action.',
+      ],
+      monitoring_summary: expect.objectContaining({
+        overdue_tasks: 0,
+        stale_cost_items: 0,
+        report_missing: false,
+        readiness_status: 'waiting_approval',
+        readiness_side_effects_enabled: false,
+        connector_required: 1,
+        connector_approval_blocked: 1,
+      }),
     }))
   })
 })

--- a/app/api/cron/client-ai-ops-monitor/route.ts
+++ b/app/api/cron/client-ai-ops-monitor/route.ts
@@ -1,9 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
 import {
+  getRoadmapBundleForProject,
   projectRoadmapTaskToMeetingTask,
   refreshRoadmapPhaseRollups,
 } from '@/lib/client-ai-ops-roadmap-db'
+import { buildClientAiOpsReadinessContract } from '@/lib/client-ai-ops-readiness-contract'
 
 export const dynamic = 'force-dynamic'
 
@@ -63,15 +65,26 @@ async function runMonitor(request: NextRequest) {
     const staleCostItems = ((costsRes.data || []) as MonitorCostRow[]).filter((item) => item.pricing_state !== 'fresh')
     const lastReportAt = reportsRes.data?.[0]?.generated_at ? new Date(reportsRes.data[0].generated_at).getTime() : 0
     const reportMissing = !lastReportAt || Date.now() - lastReportAt > 32 * 24 * 60 * 60 * 1000
+    const readiness = await getRoadmapBundleForProject(roadmap.client_project_id)
+      .then((bundle) => buildClientAiOpsReadinessContract(bundle?.clientView, { clientProjectId: roadmap.client_project_id }))
+      .catch(() => null)
+    const readinessNeedsReview = Boolean(readiness && readiness.status !== 'ready_for_planning')
 
     const monitoringSummary = {
       overdue_tasks: overdueTasks.length,
       stale_cost_items: staleCostItems.length,
       report_missing: reportMissing,
+      readiness_status: readiness?.status ?? 'unavailable',
+      readiness_next_action: readiness?.nextAction ?? null,
+      readiness_side_effects_enabled: readiness?.sideEffectsEnabled ?? false,
+      connector_required: readiness?.connector.required ?? 0,
+      connector_ready: readiness?.connector.ready ?? 0,
+      connector_approval_blocked: readiness?.connector.approvalBlocked ?? 0,
+      connector_missing_critical: readiness?.connector.missingCritical ?? 0,
       checked_at: nowIso,
     }
 
-    if (overdueTasks.length > 0 || staleCostItems.length > 0 || reportMissing) {
+    if (overdueTasks.length > 0 || staleCostItems.length > 0 || reportMissing || readinessNeedsReview) {
       const { data: report } = await supabaseAdmin
         .from('client_ai_ops_roadmap_reports')
         .insert({
@@ -86,6 +99,7 @@ async function runMonitor(request: NextRequest) {
             ...overdueTasks.map((task) => `Review overdue roadmap task: ${task.title}`),
             ...staleCostItems.map((item) => `Refresh pricing/source for: ${item.label}`),
             ...(reportMissing ? ['Generate monthly AI Ops report'] : []),
+            ...(readinessNeedsReview && readiness?.nextAction ? [`Review AI Ops readiness: ${readiness.nextAction}`] : []),
           ],
           approval_needed: [],
           monitoring_summary: monitoringSummary,

--- a/docs/client-ai-ops-roadmap-sop.md
+++ b/docs/client-ai-ops-roadmap-sop.md
@@ -40,6 +40,7 @@ The daily monitor runs through `/api/cron/client-ai-ops-monitor`.
 - n8n/manual triggers can still use `POST` with `Authorization: Bearer <N8N_INGEST_SECRET>`.
 - The monitor checks active and approved roadmaps for overdue tasks, stale pricing, missing reports, and open monitoring findings.
 - When findings exist, the monitor creates a roadmap report and an internal follow-up roadmap task.
+- The monitor also records the AI Ops readiness contract status in the monitoring summary. If readiness needs approval or connector decisions, it can create the same internal monitoring review without attempting live setup.
 - Monitoring follow-up tasks are also projected into Meeting Tasks so the admin work queue shows the issue immediately.
 
 ## Technology Registry
@@ -132,6 +133,7 @@ Use this checklist whenever a roadmap feature, monitor, report, or client implem
 - Status updates from either projection sync back to the roadmap task.
 - Phase rollups and cost summaries refresh after task or cost changes.
 - The monitor can create a roadmap report and follow-up task when drift, stale pricing, missing reports, or blockers appear.
+- The monitor records readiness status, next action, connector counts, and side-effect lock state in monitoring summaries.
 - Roadmap projection status is visible from the same source data and remains read-only.
 - Connector readiness is visible from verified stack, audit, BuiltWith, and roadmap signals without live credential setup.
 - The synthetic pilot fixture still proves audit-to-roadmap-to-client/admin projection and read-only autonomous handoff boundaries.


### PR DESCRIPTION
## Summary
- records the Client AI Ops readiness contract status in monitor `monitoring_summary` payloads
- includes readiness next action, side-effect lock state, and connector readiness counts in monitor reports/follow-up task metadata
- creates the existing internal monitoring review when readiness needs approval or connector decisions, even without task/cost drift
- updates the Client AI Ops roadmap SOP to document readiness-aware monitoring

## Enhancement Impact Preflight
- Enhancement: Client AI Ops monitor/report readiness visibility.
- User-facing surface: internal AI Ops monitor reports and Meeting Task follow-up path.
- Predicted files: app/api/cron/client-ai-ops-monitor/route.ts, app/api/cron/client-ai-ops-monitor/route.test.ts, docs/client-ai-ops-roadmap-sop.md.
- Shared routes/APIs/tables/helpers: extends existing monitor summaries and uses the existing readiness contract; no schema changes.
- Active PRs or branches checked: #437 touches AiOpsRoadmapSection.test.tsx, #436 content calibration, #435 Open Brain runtime, #433 decision trust, #432 video render readiness, #430 credential gate. This slice avoids their file areas.
- Dirty worktree files checked: fresh sibling worktree was clean after bootstrap.
- Overlap rating: green.
- Coordination decision: proceed independently.
- Merge-order note: can merge after normal captain checks; no dependency on current Client Dashboard test PR.

## Validation
- npm ci
- npm run worktree:env -- --source /Users/vambahsillah/Projects/Portfolio
- npm test -- app/api/cron/client-ai-ops-monitor/route.test.ts lib/client-ai-ops-readiness-contract.test.ts lib/client-ai-ops-roadmap.test.ts
- npm run build:knowledge
- npx tsc --noEmit --pretty false
- git diff --cached --check
- push hook database health check passed

## Integration Notes
- This uses the existing internal monitor report/task path. No OAuth, credential sync, provider write, workflow activation, outbound send, publishing, deploy mutation, migration, or client-data mutation is included.
- Readiness review is internal-only and projected to Meeting Tasks through the existing follow-up path.
- Vercel contexts still need normal Integration Captain verification before merge: Vercel – portfolio and Vercel – portfolio-staging.