### PR TITLE
docs: record Google Places runner decision

### DIFF
--- a/docs/google-places-production-runner-decision.md
+++ b/docs/google-places-production-runner-decision.md
@@ -1,0 +1,70 @@
+# Google Places Production Runner Decision
+
+Date: 2026-05-28
+
+Purpose: close the Google Places production-runner decision gate for the Apify Google Maps replacement path without assuming static outbound egress exists.
+
+## Decision
+
+Use `WF-VEP-002: Social Listening Pipeline` as the production-like runner for Google Places replacement validation. Portfolio/Vercel remains the admin trigger and reporting surface, not the place where the Google Places replacement should be promoted first.
+
+Do not apply IP address application restrictions to the Google Places production key yet. Static outbound egress is not confirmed for the current n8n runner, and Vercel outbound traffic is dynamic unless Static IPs or Secure Compute are enabled.
+
+## Evidence
+
+- Repo workflow export: `n8n-exports/WF-VEP-002-Social-Listening-Pipeline.json` contains `Scrape Google Maps` as an Apify node inside the social-listening workflow.
+- Setup guide: `docs/value-evidence-pipeline-setup.md` describes Portfolio as calling `N8N_VEP002_WEBHOOK_URL`, which means the app triggers n8n rather than directly running the scraping/replacement flow.
+- Vercel docs: Vercel Static IPs provide fixed outbound egress for deployments on Pro and Enterprise plans.
+- Vercel docs: Secure Compute provides dedicated static IPs and private networking for Enterprise plans.
+
+Reference URLs:
+
+- https://vercel.com/docs/connectivity/static-ips/
+- https://vercel.com/docs/secure-compute
+- https://vercel.com/guides/how-to-allowlist-deployment-ip-address
+
+## Recommendation
+
+Create or promote a separate production key only when the Google Places replacement is ready to be wired into the production-like runner.
+
+Recommended production key name:
+
+```text
+portfolio-apify-replacement-google-places-prod
+```
+
+Required controls:
+
+- Restrict the key to Places API (New).
+- Keep application restrictions API-only until the runner has stable outbound egress.
+- Add IP address restrictions only after the production runner's outbound IPs are stable and documented.
+- Set strict Google Maps quota limits and billing alerts before the key is synced to any runtime sink.
+- Add a rotation review date because API-only application posture is temporary.
+- Sync to Infisical and Vercel/n8n runtime sinks only after approval.
+- Rerun `npm run apify:replacement-bakeoff -- --run` from the production-like runner before replacing the Apify Google Maps actor.
+
+## Rejected Options
+
+### Use the local/Codex key as production
+
+Rejected. The local key is acceptable for bakeoff, but it should not become the durable production credential.
+
+### Add IP restrictions now
+
+Rejected for now. IP restrictions can break the replacement workflow if the actual runner uses dynamic egress.
+
+### Move the first production replacement into Vercel Functions
+
+Not recommended as the first move. Portfolio currently triggers n8n for this social-listening workflow. Moving the workflow into Vercel would expand scope and still would not solve static egress unless Static IPs or Secure Compute are enabled.
+
+## Validation Gate
+
+Before replacing Apify's Google Maps actor:
+
+1. Confirm where the production-like replacement run executes.
+2. Confirm whether that runner has stable outbound egress.
+3. Create or promote the production key with Places API (New) restriction.
+4. Add IP restrictions only if stable outbound egress is available.
+5. Run the live bakeoff from the production-like runner.
+6. Compare accepted-result rate, cost, source quality, and operator review burden against the Apify baseline.
+7. Keep Apify as rollback until the replacement meets or beats the baseline.

--- a/docs/subscription-status.json
+++ b/docs/subscription-status.json
@@ -60,14 +60,21 @@
       "analysisDocument": "/docs/apify-call-bakeoff-analysis.md",
       "nextAction": "Keep productive evidence actors under watch, pause or replace no-run/failing/empty-output actors, and compare the remaining productive categories against cheaper alternatives before renewal.",
       "googlePlacesPromotionGate": {
-        "status": "gated",
+        "status": "runner_selected_api_only_until_static_egress",
         "localKeyStatus": "API-restricted to Places API (New); acceptable for the short local/Codex bakeoff window.",
-        "productionRequirement": "Do not promote Google Places as the durable Apify Google Maps replacement until the production runner and outbound egress path are confirmed.",
+        "productionRequirement": "Use the production-like n8n social-listening runner for replacement validation, but do not add IP address application restrictions until static outbound egress is confirmed.",
         "recommendedProductionKeyName": "portfolio-apify-replacement-google-places-prod",
+        "productionRunnerDecision": {
+          "selectedRunner": "WF-VEP-002 n8n Social Listening Pipeline, with Portfolio/Vercel remaining the admin trigger and reporting surface.",
+          "egressPosture": "Static outbound egress is not confirmed for the current runner; Vercel also uses dynamic outbound IPs unless Static IPs or Secure Compute are enabled.",
+          "ctORecommendation": "Create a separate production Google Places key only when ready to wire the replacement workflow, restrict it to Places API (New), keep application restrictions API-only until static egress is available, and control spend with quotas, alerts, and rotation review.",
+          "validationGate": "Rerun the bakeoff from the production-like runner and compare accepted-result rate before replacing the Apify Google Maps actor.",
+          "decisionPacket": "/docs/google-places-production-runner-decision.md"
+        },
         "requiredControls": [
           "Separate production key from the local bakeoff key.",
           "API restriction to Places API (New).",
-          "IP address restriction if the production runner has stable outbound egress.",
+          "IP address restriction only if the production runner has stable outbound egress.",
           "Strict quota limits, billing alerts, and a rotation review date if stable egress is not available yet.",
           "Infisical/Vercel runtime sink sync only after the production key is approved.",
           "Production-like rerun of npm run apify:replacement-bakeoff -- --run before replacing the Apify Google Maps actor."

--- a/lib/subscription-status.test.ts
+++ b/lib/subscription-status.test.ts
@@ -36,8 +36,11 @@ describe('subscription status budget queries', () => {
     const result = answerSubscriptionBudgetQuery('Can we promote Google Places to production as the Apify Google Maps replacement?')
 
     expect(result.answer).toContain('Google Places production gate')
+    expect(result.answer).toContain('WF-VEP-002 n8n Social Listening Pipeline')
+    expect(result.answer).toContain('Static outbound egress is not confirmed')
     expect(result.answer).toContain('portfolio-apify-replacement-google-places-prod')
     expect(result.apifyCallAnalysis?.googlePlacesPromotionGate?.decisionRequired).toBe(true)
+    expect(result.apifyCallAnalysis?.googlePlacesPromotionGate?.productionRunnerDecision?.decisionPacket).toBe('/docs/google-places-production-runner-decision.md')
   })
 
   it('handles transition spend from the Anthropic to ChatGPT switch', () => {

--- a/lib/subscription-status.ts
+++ b/lib/subscription-status.ts
@@ -64,9 +64,18 @@ export interface SubscriptionGooglePlacesPromotionGate {
   localKeyStatus: string
   productionRequirement: string
   recommendedProductionKeyName: string
+  productionRunnerDecision?: SubscriptionGooglePlacesRunnerDecision
   requiredControls: string[]
   decisionOwner: string
   decisionRequired: boolean
+}
+
+export interface SubscriptionGooglePlacesRunnerDecision {
+  selectedRunner: string
+  egressPosture: string
+  ctORecommendation: string
+  validationGate: string
+  decisionPacket: string
 }
 
 export interface SubscriptionApifyActorRunHistory {
@@ -211,7 +220,10 @@ export function answerSubscriptionBudgetQuery(query: string): SubscriptionQueryR
         )
       ) {
         const gate = analysis.googlePlacesPromotionGate
-        answer = `${answer} Google Places production gate: ${gate.productionRequirement} Recommended key: ${gate.recommendedProductionKeyName}. Required controls: ${gate.requiredControls.join(' ')}`
+        const runnerDecision = gate.productionRunnerDecision
+          ? ` Runner decision: ${gate.productionRunnerDecision.selectedRunner} ${gate.productionRunnerDecision.egressPosture} ${gate.productionRunnerDecision.ctORecommendation}`
+          : ''
+        answer = `${answer} Google Places production gate: ${gate.productionRequirement}${runnerDecision} Recommended key: ${gate.recommendedProductionKeyName}. Required controls: ${gate.requiredControls.join(' ')}`
       }
     }
   }


### PR DESCRIPTION
## Summary
- records the Google Places production-runner decision packet for the Apify Google Maps replacement path
- updates subscription status/query metadata to show WF-VEP-002 n8n as the selected production-like validation runner
- keeps IP restrictions gated until static outbound egress is confirmed, with Vercel Static IP/Secure Compute called out as paid upgrade paths

## Validation
- npm run worktree:env -- --source /Users/vambahsillah/Projects/Portfolio
- npm test -- --run lib/subscription-status.test.ts lib/apify-replacement-bakeoff.test.ts
- npm run apify:replacement-bakeoff
- npm run db:health-check
- git diff --check
- push hook database health check passed

## Integration Notes
- No secrets or API key values committed.
- No shared cost-event schema changes.
- No production key creation or runtime sink mutation performed.
- Vercel contexts not checked in this non-captain docs/query lane: Vercel – portfolio, Vercel – portfolio-staging.