### PR TITLE
feat: tune Slack notification trigger policy

### DIFF
--- a/app/api/cron/agent-ops-slack-notifications/route.test.ts
+++ b/app/api/cron/agent-ops-slack-notifications/route.test.ts
@@ -7,11 +7,11 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@/lib/agent-slack-notification-sweep', () => ({
   PROACTIVE_SLACK_NOTIFICATION_RULES: [
-    { kind: 'pending_approvals' },
-    { kind: 'blockers' },
-    { kind: 'stale_runs' },
-    { kind: 'review_ready' },
-    { kind: 'goal_decisions' },
+    { kind: 'pending_approvals', triggerModes: ['immediate', 'scheduled'] },
+    { kind: 'blockers', triggerModes: ['scheduled'] },
+    { kind: 'stale_runs', triggerModes: ['scheduled'] },
+    { kind: 'review_ready', triggerModes: ['scheduled'] },
+    { kind: 'goal_decisions', triggerModes: ['immediate', 'scheduled'] },
   ],
   runAgentSlackNotificationSweep: mocks.runAgentSlackNotificationSweep,
 }))
@@ -42,6 +42,7 @@ describe('/api/cron/agent-ops-slack-notifications', () => {
     mocks.runAgentSlackNotificationSweep.mockResolvedValue({
       ok: true,
       dryRun: false,
+      mode: 'scheduled',
       totalRules: 5,
       sentCount: 1,
       dedupedCount: 1,
@@ -78,6 +79,7 @@ describe('/api/cron/agent-ops-slack-notifications', () => {
       },
     })
     expect(mocks.runAgentSlackNotificationSweep).toHaveBeenCalledWith(expect.objectContaining({
+      mode: 'scheduled',
       actorLabel: 'Vercel cron',
       triggerSource: 'vercel_cron_agent_ops_slack_notifications',
     }))
@@ -87,6 +89,7 @@ describe('/api/cron/agent-ops-slack-notifications', () => {
     const response = await POST(request('POST', 'n8n-secret', {
       dry_run: true,
       force: true,
+      mode: 'immediate',
       kinds: ['stale_runs', 'blockers', 'publish_everything'],
     }) as never)
 
@@ -94,6 +97,7 @@ describe('/api/cron/agent-ops-slack-notifications', () => {
     expect(mocks.runAgentSlackNotificationSweep).toHaveBeenCalledWith(expect.objectContaining({
       dryRun: true,
       force: true,
+      mode: 'immediate',
       kinds: ['stale_runs', 'blockers'],
       actorLabel: 'Manual cron trigger',
       triggerSource: 'manual_cron_agent_ops_slack_notifications',

--- a/app/api/cron/agent-ops-slack-notifications/route.ts
+++ b/app/api/cron/agent-ops-slack-notifications/route.ts
@@ -10,6 +10,7 @@ import {
   PROACTIVE_SLACK_NOTIFICATION_RULES,
   runAgentSlackNotificationSweep,
   type ProactiveSlackNotificationKind,
+  type ProactiveSlackNotificationMode,
 } from '@/lib/agent-slack-notification-sweep'
 
 export const dynamic = 'force-dynamic'
@@ -17,6 +18,7 @@ export const dynamic = 'force-dynamic'
 const VALID_KINDS = new Set<ProactiveSlackNotificationKind>(
   PROACTIVE_SLACK_NOTIFICATION_RULES.map((rule) => rule.kind),
 )
+const VALID_MODES = new Set<ProactiveSlackNotificationMode>(['scheduled', 'immediate', 'all'])
 
 function isAuthorizedCronRequest(request: NextRequest): boolean {
   const token = request.headers.get('authorization')?.replace(/^Bearer\s+/i, '')
@@ -30,6 +32,12 @@ function parseKinds(value: unknown): ProactiveSlackNotificationKind[] | undefine
     .filter((item): item is string => typeof item === 'string')
     .filter((item): item is ProactiveSlackNotificationKind => VALID_KINDS.has(item as ProactiveSlackNotificationKind))
   return kinds.length ? [...new Set(kinds)] : undefined
+}
+
+function parseMode(value: unknown): ProactiveSlackNotificationMode | undefined {
+  return typeof value === 'string' && VALID_MODES.has(value as ProactiveSlackNotificationMode)
+    ? value as ProactiveSlackNotificationMode
+    : undefined
 }
 
 async function parsePostBody(request: NextRequest) {
@@ -49,9 +57,11 @@ async function runSweep(request: NextRequest, body: Record<string, unknown> = {}
   const dryRun = body.dry_run === true || body.dryRun === true || searchParams.get('dry_run') === '1'
   const force = body.force === true || searchParams.get('force') === '1'
   const kinds = parseKinds(body.kinds)
+  const mode = parseMode(body.mode) ?? parseMode(searchParams.get('mode')) ?? 'scheduled'
 
   const result = await runAgentSlackNotificationSweep({
     kinds,
+    mode,
     dryRun,
     force,
     actorLabel: request.method === 'GET' ? 'Vercel cron' : 'Manual cron trigger',

--- a/lib/agent-slack-notification-sweep.test.ts
+++ b/lib/agent-slack-notification-sweep.test.ts
@@ -45,6 +45,8 @@ describe('Agent Ops proactive Slack notification sweep', () => {
     expect(result.results[0]).toMatchObject({
       kind: 'blockers',
       skipped: true,
+      mode: 'scheduled',
+      priority: 'high',
       reason: 'No matching Agent Ops work needs mobile attention.',
     })
   })
@@ -67,6 +69,34 @@ describe('Agent Ops proactive Slack notification sweep', () => {
     })
     expect(mocks.sendAgentSlackNotification).not.toHaveBeenCalled()
     expect(result.results[0].reason).toBe('Dry run only.')
+  })
+
+  it('runs only immediate-push candidates when requested', async () => {
+    mocks.buildAgentSlackNotificationPayload.mockResolvedValue({
+      text: 'Mobile decision needed',
+      blocks: [{ type: 'section', text: { type: 'mrkdwn', text: 'Decision' } }],
+      itemCount: 1,
+    })
+
+    const result = await runAgentSlackNotificationSweep({ mode: 'immediate' })
+
+    expect(result).toMatchObject({
+      ok: true,
+      mode: 'immediate',
+      totalRules: 2,
+      sentCount: 2,
+      itemCount: 4,
+    })
+    expect(mocks.sendAgentSlackNotification).toHaveBeenCalledTimes(2)
+    expect(mocks.sendAgentSlackNotification).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      kind: 'pending_approvals',
+      dedupeWindowHours: 1,
+    }))
+    expect(mocks.sendAgentSlackNotification).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      kind: 'goal_decisions',
+      dedupeWindowHours: 4,
+    }))
+    expect(result.results.every((item) => item.triggerModes.includes('immediate'))).toBe(true)
   })
 
   it('sends non-empty packets with content-aware dedupe metadata', async () => {

--- a/lib/agent-slack-notification-sweep.ts
+++ b/lib/agent-slack-notification-sweep.ts
@@ -11,16 +11,21 @@ export type ProactiveSlackNotificationKind = Extract<
   'pending_approvals' | 'blockers' | 'stale_runs' | 'review_ready' | 'goal_decisions'
 >
 
+export type ProactiveSlackNotificationMode = 'scheduled' | 'immediate' | 'all'
+
 export type ProactiveSlackNotificationRule = {
   kind: ProactiveSlackNotificationKind
   label: string
   description: string
+  triggerModes: Exclude<ProactiveSlackNotificationMode, 'all'>[]
+  priority: 'normal' | 'high' | 'urgent'
   minimumItemCount: number
   dedupeWindowHours: number
 }
 
 export type AgentSlackNotificationSweepInput = {
   kinds?: ProactiveSlackNotificationKind[]
+  mode?: ProactiveSlackNotificationMode
   dryRun?: boolean
   force?: boolean
   actorLabel?: string | null
@@ -35,6 +40,9 @@ export type AgentSlackNotificationSweepRuleResult = {
   skipped: boolean
   deduped: boolean
   dryRun: boolean
+  mode: ProactiveSlackNotificationMode
+  priority: ProactiveSlackNotificationRule['priority']
+  triggerModes: ProactiveSlackNotificationRule['triggerModes']
   runId?: string
   text: string
   reason?: string
@@ -46,13 +54,17 @@ export const PROACTIVE_SLACK_NOTIFICATION_RULES: ProactiveSlackNotificationRule[
     kind: 'pending_approvals',
     label: 'Pending approvals',
     description: 'Human approval packets that can be reviewed from mobile or opened in Portfolio.',
+    triggerModes: ['immediate', 'scheduled'],
+    priority: 'urgent',
     minimumItemCount: 1,
     dedupeWindowHours: 1,
   },
   {
     kind: 'blockers',
     label: 'Blocked work',
-    description: 'Blocked Kanban work that needs acknowledgement, owner assignment, or Shaka guidance.',
+    description: 'Blocked Kanban work that needs acknowledgement, owner assignment, or Shaka guidance. Routine blocker packets stay in the scheduled sweep; urgent blockers should be sent from Mission Control or Standup Room with context.',
+    triggerModes: ['scheduled'],
+    priority: 'high',
     minimumItemCount: 1,
     dedupeWindowHours: 4,
   },
@@ -60,6 +72,8 @@ export const PROACTIVE_SLACK_NOTIFICATION_RULES: ProactiveSlackNotificationRule[
     kind: 'stale_runs',
     label: 'Stale or failed runs',
     description: 'Failed or stale traces that need recovery triage.',
+    triggerModes: ['scheduled'],
+    priority: 'high',
     minimumItemCount: 1,
     dedupeWindowHours: 4,
   },
@@ -67,6 +81,8 @@ export const PROACTIVE_SLACK_NOTIFICATION_RULES: ProactiveSlackNotificationRule[
     kind: 'review_ready',
     label: 'Review-ready work',
     description: 'Cards waiting for review, revision request, or trace inspection.',
+    triggerModes: ['scheduled'],
+    priority: 'normal',
     minimumItemCount: 1,
     dedupeWindowHours: 4,
   },
@@ -74,15 +90,20 @@ export const PROACTIVE_SLACK_NOTIFICATION_RULES: ProactiveSlackNotificationRule[
     kind: 'goal_decisions',
     label: 'Goal decisions',
     description: 'Goal-tagged tasks waiting on a human decision.',
+    triggerModes: ['immediate', 'scheduled'],
+    priority: 'urgent',
     minimumItemCount: 1,
     dedupeWindowHours: 4,
   },
 ]
 
-function selectedRules(kinds?: ProactiveSlackNotificationKind[]) {
-  if (!kinds?.length) return PROACTIVE_SLACK_NOTIFICATION_RULES
+function selectedRules(kinds?: ProactiveSlackNotificationKind[], mode: ProactiveSlackNotificationMode = 'scheduled') {
+  const modeFilteredRules = mode === 'all'
+    ? PROACTIVE_SLACK_NOTIFICATION_RULES
+    : PROACTIVE_SLACK_NOTIFICATION_RULES.filter((rule) => rule.triggerModes.includes(mode))
+  if (!kinds?.length) return modeFilteredRules
   const allowed = new Set(kinds)
-  return PROACTIVE_SLACK_NOTIFICATION_RULES.filter((rule) => allowed.has(rule.kind))
+  return modeFilteredRules.filter((rule) => allowed.has(rule.kind))
 }
 
 function payloadDedupeKey(kind: ProactiveSlackNotificationKind, payload: Awaited<ReturnType<typeof buildAgentSlackNotificationPayload>>) {
@@ -97,6 +118,7 @@ function payloadDedupeKey(kind: ProactiveSlackNotificationKind, payload: Awaited
 function sweepResultFromNotification(
   rule: ProactiveSlackNotificationRule,
   notification: AgentSlackNotificationResult,
+  mode: ProactiveSlackNotificationMode,
 ): AgentSlackNotificationSweepRuleResult {
   return {
     kind: rule.kind,
@@ -106,6 +128,9 @@ function sweepResultFromNotification(
     skipped: notification.skipped,
     deduped: notification.deduped,
     dryRun: false,
+    mode,
+    priority: rule.priority,
+    triggerModes: rule.triggerModes,
     runId: notification.runId,
     text: notification.text,
     reason: notification.reason,
@@ -114,8 +139,9 @@ function sweepResultFromNotification(
 
 export async function runAgentSlackNotificationSweep(input: AgentSlackNotificationSweepInput = {}) {
   const results: AgentSlackNotificationSweepRuleResult[] = []
+  const mode = input.mode ?? 'scheduled'
 
-  for (const rule of selectedRules(input.kinds)) {
+  for (const rule of selectedRules(input.kinds, mode)) {
     try {
       const payload = await buildAgentSlackNotificationPayload({ kind: rule.kind })
 
@@ -128,6 +154,9 @@ export async function runAgentSlackNotificationSweep(input: AgentSlackNotificati
           skipped: true,
           deduped: false,
           dryRun: Boolean(input.dryRun),
+          mode,
+          priority: rule.priority,
+          triggerModes: rule.triggerModes,
           text: payload.text,
           reason: 'No matching Agent Ops work needs mobile attention.',
         })
@@ -144,6 +173,9 @@ export async function runAgentSlackNotificationSweep(input: AgentSlackNotificati
           skipped: true,
           deduped: false,
           dryRun: true,
+          mode,
+          priority: rule.priority,
+          triggerModes: rule.triggerModes,
           text: payload.text,
           reason: 'Dry run only.',
         })
@@ -158,7 +190,7 @@ export async function runAgentSlackNotificationSweep(input: AgentSlackNotificati
         dedupeKey,
         dedupeWindowHours: rule.dedupeWindowHours,
       })
-      results.push(sweepResultFromNotification(rule, notification))
+      results.push(sweepResultFromNotification(rule, notification, mode))
     } catch (error) {
       results.push({
         kind: rule.kind,
@@ -168,6 +200,9 @@ export async function runAgentSlackNotificationSweep(input: AgentSlackNotificati
         skipped: false,
         deduped: false,
         dryRun: Boolean(input.dryRun),
+        mode,
+        priority: rule.priority,
+        triggerModes: rule.triggerModes,
         text: `${rule.label} failed.`,
         error: error instanceof Error ? error.message : 'Unknown Slack notification sweep error',
       })
@@ -182,6 +217,7 @@ export async function runAgentSlackNotificationSweep(input: AgentSlackNotificati
   return {
     ok: errorCount === 0,
     dryRun: Boolean(input.dryRun),
+    mode,
     totalRules: results.length,
     sentCount,
     dedupedCount,


### PR DESCRIPTION
## Summary
- Adds explicit trigger policy metadata to Agent Ops Slack notification rules: `scheduled`, `immediate`, or both.
- Keeps default cron behavior scheduled-safe while allowing authorized manual/cron calls to request `mode: "immediate"` for urgent mobile push candidates.
- Marks pending approvals and goal decisions as immediate candidates; keeps routine blockers, stale runs, and review-ready work on scheduled sweep unless sent manually from Mission Control or Standup Room with context.

## Validation
- `npm test -- lib/agent-slack-notification-sweep.test.ts app/api/cron/agent-ops-slack-notifications/route.test.ts lib/agent-slack-notifications.test.ts app/api/admin/agents/slack-notifications/route.test.ts`
- `npm run build:knowledge && npx tsc --noEmit --pretty false`
- `npm run lint`
- `git diff --check`

## Integration Notes
- Scoped to Slack notification sweep policy and cron parsing. No Standup Room UI files touched, avoiding overlap with PR #436.
- No production activation, credential changes, customer-data mutation, outbound channel expansion, or n8n activation introduced.
- Fresh worktree required `npm run build:knowledge` before typecheck so the ignored generated knowledge module existed locally.
- Vercel contexts not yet checked: `Vercel – portfolio`, `Vercel – portfolio-staging`.
