### PR TITLE
docs: map agentic value communications

### DIFF
--- a/docs/agentic-content-challenger-loop.md
+++ b/docs/agentic-content-challenger-loop.md
@@ -1,0 +1,116 @@
+# Agentic Content Challenger Loop
+
+Status: Review packet standard for agentic content assets
+Primary plan: [`docs/agentic-value-communications-plan.md`](agentic-value-communications-plan.md)
+
+## Purpose
+
+Use this packet before any agentic content asset reaches Vambah for human-in-the-loop approval.
+
+The loop is simple:
+
+1. Build from an approved source packet.
+2. Draft against a channel spec.
+3. Send the draft to Amina, the Agentic Challenger role.
+4. Repair only the challenger findings.
+5. Re-run the challenger.
+6. Route to human review only after `pass_to_human=true`.
+
+This follows the same discipline as Portfolio AutoResearch: bounded proposal, evidence check, iteration trace, and approval gate. The challenger is not the approver. The challenger decides whether the work is ready to ask a human for approval.
+
+## Role Contract
+
+| Role | Responsibility | Boundary |
+| --- | --- | --- |
+| Creator | Drafts or adapts the asset from approved sources and the channel spec. | Does not send to human review directly. |
+| Amina, Agentic Challenger | Enumerates unsupported claims, implementation drift, source gaps, privacy risk, duplicated work, weak logic, and channel mismatch. | Does not rewrite or approve publication. |
+| Repair agent | Fixes only the challenger issue list and records what changed. | Does not hide unresolved findings. |
+| Verifier | Confirms required fixes were applied and sets challenger status. | Does not override privacy or source conflicts. |
+| Vambah / Shaka approval surface | Makes the final human decision after challenger clearance. | Approval still controls publication, rendering, provider calls, and public/client release. |
+
+## Packet Template
+
+```yaml
+asset_id:
+channel:
+source_ids: []
+draft_version:
+loop_round:
+creator_agent:
+challenger_agent: Amina
+challenger_prompt_version:
+challenge_findings: []
+unsupported_claims: []
+source_conflicts: []
+privacy_flags: []
+implementation_drift: []
+required_fixes: []
+fixes_applied: []
+residual_risks_for_human: []
+challenger_status: needs_revision # needs_revision | passed | blocked
+pass_to_human: false
+approval_status: not_ready # not_ready | human_review_ready | approved | revise | held
+```
+
+## Gate Rules
+
+- `pass_to_human=true` only when unsupported claims, source conflicts, critical privacy flags, and implementation drift are resolved or explicitly marked as residual human decisions.
+- `approval_status=human_review_ready` only when `challenger_status=passed`.
+- Provider work for HeyGen, ElevenLabs, Remotion, HyperFrames, or publishing remains blocked until both challenger clearance and the existing render or publishing approval packet are complete.
+- Private source material can shape voice and structure, but it should not appear in public copy unless Vambah explicitly approves it.
+- If a draft duplicates an existing PRD, brief, LinkedIn draft, or script, create an adaptation note instead of a new content item.
+
+## Challenger Prompt
+
+Use this prompt pattern for the first simulated reviewer pass:
+
+```text
+You are Amina, the Agentic Challenger for Portfolio's agentic content system.
+
+Review the attached source packet, channel spec, and draft. Do not rewrite the draft. Enumerate issues only.
+
+Find:
+- unsupported claims
+- implementation drift
+- source gaps
+- source conflicts
+- privacy or public-safety risks
+- duplicated work that should be adapted instead
+- channel mismatch
+- weak logic or unclear value framing
+- provider/render/publishing steps that need approval first
+
+Return:
+- challenger_status: needs_revision, blocked, or passed
+- pass_to_human: true or false
+- challenge_findings
+- required_fixes
+- residual_risks_for_human
+
+Set pass_to_human=true only if the draft is sourced, public-safe, channel-fit, and free of blocking implementation drift.
+```
+
+## Acceptance Scenarios
+
+| Scenario | Expected challenger status | Human review? |
+| --- | --- | --- |
+| Draft claims autonomous production mutation without source proof. | `blocked` | No |
+| Draft repeats existing content without a new channel adaptation purpose. | `needs_revision` | No |
+| Draft includes private logs, raw chat exports, client data, or secrets. | `blocked` | No |
+| Draft has one unresolved positioning choice but no factual/privacy risk. | `passed` with residual risk | Yes |
+| Draft is source-backed, public-safe, channel-fit, and verified after repair. | `passed` | Yes |
+| Script requests HeyGen or ElevenLabs generation before clearance. | `blocked` | No |
+
+## Human Review Packet
+
+When the loop passes, send only the compact packet unless Vambah asks for the full trace:
+
+- final draft or asset outline,
+- source IDs and proof notes,
+- challenger status,
+- findings summary,
+- fixes applied,
+- residual human decisions,
+- approval request.
+
+The goal is not to make the human do the agent's QA work. The goal is to make the human decision clearer.

--- a/docs/agentic-enterprise-value-map.md
+++ b/docs/agentic-enterprise-value-map.md
@@ -28,7 +28,7 @@ Portfolio now demonstrates that operating layer. It is not a loose set of automa
 | Human approval | Where does autonomy stop? | Approval checkpoints, Mission Control, Slack mobile unblocks | Lets people approve side effects without losing traceability. |
 | Compliance | What needs review before it moves? | Moremi risk monitor, policy gates, governance export | Converts risk into reviewable work instead of silent exposure. |
 | Transaction authority | Can the agent spend, refund, publish, or send? | Payment and paid-job approval gates | Separates recommendation from authority to act. |
-| QA loop | How do we know the output is good? | Agent evaluations, rubrics, quality summaries, coaching signals | Makes quality measurable and improvable over time. |
+| QA loop | How do we know the output is good before a person is asked to approve it? | Agent evaluations, rubrics, quality summaries, coaching signals, challenger review packets | Makes quality measurable and keeps first-pass work out of human approval. |
 | Client-safe proof | What can we show without exposing private material? | Governance export and advisory explainer | Makes the system explainable to clients without leaking raw logs. |
 
 ## The Frame For Open CLAW-Style Enterprise Launches
@@ -52,6 +52,7 @@ The better questions are:
 - What did it hand off?
 - What did the human approve?
 - What evidence can we show later?
+- Did the work pass an agentic challenger before a person was asked to approve it?
 - How does the system learn from the quality of the result?
 
 That is the difference between an agent demo and an agent operating model.
@@ -66,15 +67,16 @@ flowchart LR
   B --> C["Scope<br/>Tools, data, write authority, spend boundary"]
   C --> D["Execution<br/>Agent run, steps, artifacts, cost events"]
   D --> E["Evaluation<br/>Rubric score, pass/fail, coaching signal"]
-  E --> F["Handoff<br/>Next owner, summary, acceptance criteria"]
-  F --> G["Approval<br/>Human decision for side effects"]
-  G --> H["Audit<br/>Client-safe receipt and governance export"]
-  H --> B
+  E --> F["Challenge<br/>Unsupported claims, drift, privacy, source gaps"]
+  F --> G["Handoff<br/>Next owner, summary, acceptance criteria"]
+  G --> H["Approval<br/>Human decision for side effects"]
+  H --> I["Audit<br/>Client-safe receipt and governance export"]
+  I --> B
 ```
 
 Narrative:
 
-An enterprise agent is not one run. It is a loop. Intent enters the system, Shaka routes it, the agent acts inside scope, the work is evaluated, a handoff is recorded, a human approves side effects, and the audit trail becomes the memory for the next decision.
+An enterprise agent is not one run. It is a loop. Intent enters the system, Shaka routes it, the agent acts inside scope, the work is evaluated, a challenger tests whether the work is ready for a person, a handoff is recorded, a human approves side effects, and the audit trail becomes the memory for the next decision.
 
 ## Visual 2: Agent-To-Agent Handoff
 
@@ -166,6 +168,26 @@ flowchart LR
 What this explains:
 
 Human-in-the-loop is not a person hovering over every action. It is a designed checkpoint. The operator sees the decision, the evidence, the risk boundary, and the next action. Slack can unblock low-risk items, but production-impacting work goes back to Portfolio.
+
+## Visual 6: Ralph Loop / Agentic Challenger Gate
+
+```mermaid
+flowchart LR
+  Source["Source packet"] --> Spec["Channel spec"]
+  Spec --> Draft["Constrained draft"]
+  Draft --> Challenger["Amina<br/>Agentic Challenger"]
+  Challenger --> Findings["Issue list<br/>No fixes"]
+  Findings --> Repair["Repair pass"]
+  Repair --> Recheck["Challenger re-check"]
+  Recheck -->|needs_revision| Repair
+  Recheck -->|blocked| Hold["Hold or exception packet"]
+  Recheck -->|passed| Human["Human review packet"]
+  Human --> Approval["Approve, revise, hold, or publish gate"]
+```
+
+What this explains:
+
+The human should not be the first quality filter. The challenger tests the draft for unsupported claims, implementation drift, source gaps, privacy risk, duplicated work, and channel mismatch. Only challenger-cleared work becomes a human approval packet.
 
 ## Component Narratives
 
@@ -437,9 +459,9 @@ The hard work starts after the first demo. Who decides which agent gets the task
 
 This is what we have been building into Portfolio.
 
-Not just agents.
+Agents are only the visible layer.
 
-The operating system around the agents.
+The operating system around them is where the value compounds.
 
 Agent runs leave traces. Handoffs carry summaries and acceptance criteria. Runtime policies define scope. Approval gates stop side effects. Mission Control gives the operator a full view. Slack supports mobile unblocks without turning convenience into uncontrolled authority. Evaluations turn quality into a loop instead of a feeling.
 

--- a/docs/agentic-enterprise-value-map.md
+++ b/docs/agentic-enterprise-value-map.md
@@ -1,0 +1,478 @@
+# Enterprise Agentic Value Map
+
+Status: Master source map for channel-specific deliverables
+Audience: executives, product leaders, operators, nonprofit and small business leaders, enterprise AI teams
+Primary use: Source-of-truth narrative, component map, proof register, and script raw material
+
+This is not intended to be the only public artifact. Use it as the source map for the channel plan in [`docs/agentic-value-communications-plan.md`](agentic-value-communications-plan.md).
+
+## Core Message
+
+Most people think launching an enterprise agent starts when the model can take an action.
+
+That is where the risk starts.
+
+The real work is the operating system around the agent: the trace, the handoff, the scope, the approval gate, the evaluation loop, the human review surface, and the audit trail that proves what happened after the demo ended.
+
+Portfolio now demonstrates that operating layer. It is not a loose set of automations. It is a governed agent control plane.
+
+## What We Built In Plain Language
+
+| Layer | Plain-language question | Portfolio proof surface | Value |
+| --- | --- | --- | --- |
+| Agent registry | Who is allowed to work? | Named agent organization, pods, runtime policy, governance inventory | Turns "the AI did it" into accountable ownership. |
+| Scope profile | What can this agent touch? | Runtime policy, capability profiles, approval-gated actions | Keeps each agent inside a known boundary. |
+| Delegation | Why did this agent get the job? | Shaka routing, engagement queue, delegation decision events | Makes handoffs explainable instead of vibes-based. |
+| Handoff | What does the next agent need to know? | `agent_handoffs`, work item ownership, acceptance criteria | Prevents context loss between agents and runtimes. |
+| Observability | What happened, in what order? | `agent_runs`, steps, events, artifacts, costs, approvals, handoffs | Gives operators a receipt for every run. |
+| Human approval | Where does autonomy stop? | Approval checkpoints, Mission Control, Slack mobile unblocks | Lets people approve side effects without losing traceability. |
+| Compliance | What needs review before it moves? | Moremi risk monitor, policy gates, governance export | Converts risk into reviewable work instead of silent exposure. |
+| Transaction authority | Can the agent spend, refund, publish, or send? | Payment and paid-job approval gates | Separates recommendation from authority to act. |
+| QA loop | How do we know the output is good? | Agent evaluations, rubrics, quality summaries, coaching signals | Makes quality measurable and improvable over time. |
+| Client-safe proof | What can we show without exposing private material? | Governance export and advisory explainer | Makes the system explainable to clients without leaking raw logs. |
+
+## The Frame For Open CLAW-Style Enterprise Launches
+
+Open CLAW, OpenCode, Hermes, n8n, Codex, and similar runtimes solve only part of the problem.
+
+They give you execution capacity.
+
+Enterprise value comes from the control system around that capacity.
+
+The common question is: "Can this agent complete the task?"
+
+The better questions are:
+
+- Who assigned the task?
+- Why was this agent selected?
+- What data was it allowed to use?
+- What tools could it call?
+- What side effects were blocked?
+- What did it cost?
+- What did it hand off?
+- What did the human approve?
+- What evidence can we show later?
+- How does the system learn from the quality of the result?
+
+That is the difference between an agent demo and an agent operating model.
+
+## Visual 1: The Enterprise Agent Lifecycle
+
+Use this as the first carousel/deck diagram.
+
+```mermaid
+flowchart LR
+  A["Intent<br/>What does the operator need?"] --> B["Routing<br/>Shaka selects the right agent"]
+  B --> C["Scope<br/>Tools, data, write authority, spend boundary"]
+  C --> D["Execution<br/>Agent run, steps, artifacts, cost events"]
+  D --> E["Evaluation<br/>Rubric score, pass/fail, coaching signal"]
+  E --> F["Handoff<br/>Next owner, summary, acceptance criteria"]
+  F --> G["Approval<br/>Human decision for side effects"]
+  G --> H["Audit<br/>Client-safe receipt and governance export"]
+  H --> B
+```
+
+Narrative:
+
+An enterprise agent is not one run. It is a loop. Intent enters the system, Shaka routes it, the agent acts inside scope, the work is evaluated, a handoff is recorded, a human approves side effects, and the audit trail becomes the memory for the next decision.
+
+## Visual 2: Agent-To-Agent Handoff
+
+```mermaid
+sequenceDiagram
+  participant Operator
+  participant Shaka
+  participant AgentA as Specialist Agent A
+  participant WorkItem as Agent Work Item
+  participant AgentB as Specialist Agent B
+  participant Trace as Agent Ops Trace
+
+  Operator->>Shaka: Request outcome
+  Shaka->>Trace: Record delegation decision
+  Shaka->>AgentA: Assign scoped work
+  AgentA->>Trace: Write steps, events, artifacts
+  AgentA->>WorkItem: Add handoff summary
+  AgentA->>WorkItem: Add acceptance criteria
+  WorkItem->>AgentB: Transfer ownership
+  AgentB->>Trace: Continue with linked evidence
+```
+
+What this explains:
+
+The handoff is not a chat message. It is a work packet. It needs an owner, a summary, criteria for acceptance, a linked run, and a trace event. Without that structure, the next agent inherits confusion.
+
+## Visual 3: Scope And Permission Boundary
+
+```mermaid
+flowchart TB
+  Agent["Named Agent"] --> Tools["Allowed tools"]
+  Agent --> Data["Allowed data classes"]
+  Agent --> Writes["Allowed write classes"]
+  Agent --> Outbound["Outbound authority"]
+  Agent --> Spend["Spend authority"]
+
+  Tools --> Gate["Approval gate when risk rises"]
+  Data --> Gate
+  Writes --> Gate
+  Outbound --> Gate
+  Spend --> Gate
+
+  Gate --> Human["Human decision"]
+  Human --> Trace["Trace event and audit receipt"]
+```
+
+What this explains:
+
+Scope is not a prompt instruction. Scope is an operating boundary. The agent should know what it can read, what it can write, what it can send, what it can spend, and where a person must step in.
+
+## Visual 4: Observability Receipt
+
+```mermaid
+flowchart LR
+  Run["agent_runs"] --> Steps["steps"]
+  Run --> Events["events"]
+  Run --> Artifacts["artifacts"]
+  Run --> Costs["costs"]
+  Run --> Approvals["approvals"]
+  Run --> Handoffs["handoffs"]
+  Run --> Evaluations["evaluations"]
+  Steps --> Receipt["Run detail receipt"]
+  Events --> Receipt
+  Artifacts --> Receipt
+  Costs --> Receipt
+  Approvals --> Receipt
+  Handoffs --> Receipt
+  Evaluations --> Receipt
+```
+
+What this explains:
+
+Observability means an operator can reconstruct the work without guessing. The run detail should answer what happened, what was produced, what it cost, who approved it, where it was handed off, and how quality was scored.
+
+## Visual 5: Human-In-The-Loop Surface
+
+```mermaid
+flowchart LR
+  Signal["Agent needs a decision"] --> Packet["Approval packet"]
+  Packet --> Mission["Mission Control"]
+  Packet --> Slack["Slack mobile unblock"]
+  Slack --> Safe["Low-risk decision or deep link"]
+  Mission --> Decision["Approve, reject, revise, assign, hand off"]
+  Safe --> Trace["Decision event"]
+  Decision --> Trace
+  Trace --> Resume["Resume, stop, or route work"]
+```
+
+What this explains:
+
+Human-in-the-loop is not a person hovering over every action. It is a designed checkpoint. The operator sees the decision, the evidence, the risk boundary, and the next action. Slack can unblock low-risk items, but production-impacting work goes back to Portfolio.
+
+## Component Narratives
+
+### 1. Agent-To-Agent Handoff
+
+The value is continuity.
+
+Agents fail quietly when work moves from one runtime to another without a packet. Portfolio uses work items and handoff records so the next agent receives the summary, owner, runtime, active trace, and acceptance criteria.
+
+What this gives an enterprise team:
+
+- less context loss,
+- clearer ownership,
+- cleaner escalation,
+- and a way to tell whether the second agent inherited the right problem.
+
+### 2. Observability
+
+The value is trust.
+
+Agentic systems need a receipt. Portfolio records runs, steps, events, artifacts, approvals, costs, handoffs, and evaluations. The operator can inspect a run instead of relying on the agent's last message.
+
+What this gives an enterprise team:
+
+- incident review,
+- cost review,
+- compliance review,
+- training review,
+- and a practical way to debug bad work.
+
+### 3. Scope
+
+The value is restraint.
+
+Each agent needs a boundary. Portfolio separates runtime policy, agent capability profiles, allowed data, allowed writes, outbound authority, spend authority, and approval gates. That matters because agents should not inherit broad authority just because the tool can technically do something.
+
+What this gives an enterprise team:
+
+- least-privilege agent roles,
+- safer runtime adoption,
+- clearer security review,
+- and a path to expand autonomy one boundary at a time.
+
+### 4. Compliance And Traceability For Transactions
+
+The value is evidence.
+
+Publishing, sending, production writes, config changes, private-to-public content, payment actions, refunds, subscriptions, vendor payments, paid API increases, and paid external jobs need a different standard. Portfolio treats these as approval-gated authority events, not casual tool calls.
+
+What this gives an enterprise team:
+
+- a chain from operator intent to agent action,
+- proof of authorization,
+- separation between recommendation and execution,
+- and client-safe exports that summarize the evidence without exposing private logs.
+
+### 5. QA And Continuous Improvement
+
+The value is learning.
+
+Agents will not become reliable through belief. They become reliable when their outputs are evaluated against rubrics, scored, trended, and turned into coaching signals. Portfolio has trace-linked evaluations and quality summaries so performance can improve over time.
+
+What this gives an enterprise team:
+
+- scorecards instead of vibes,
+- targeted prompt or process changes,
+- evidence that a change improved quality,
+- and a way to compare agents, workflows, and runtimes.
+
+### 6. Agent-To-Human Handoff
+
+The value is control.
+
+The human should receive a decision packet, not a vague alert. Portfolio uses Mission Control as the full operator surface and Slack as the mobile unblock surface. The system can ask for approval, revision, assignment, handoff, or context while preserving the decision trail.
+
+What this gives an enterprise team:
+
+- faster decisions,
+- fewer buried blockers,
+- safer mobile approvals,
+- and a record that shows who decided what.
+
+## The Portfolio Value Stack
+
+| What buyers see | What we actually built | Why it matters |
+| --- | --- | --- |
+| "AI agents" | Named agents with roles, pods, runtimes, and scope | Accountability starts with identity. |
+| "Automation" | Trace-linked runs with artifacts, approvals, costs, and events | Operators need to see the work, not trust the output. |
+| "Multi-agent workflows" | Handoff packets and work item ownership | Collaboration needs state, context, and ownership across chained prompts. |
+| "Governance" | Approval gates, policy boundaries, risk monitor, client-safe exports | Trust needs proof. |
+| "Human review" | Mission Control plus Slack unblock surfaces | Review has to fit the way operators actually work. |
+| "Quality" | Evaluations, rubrics, trends, coaching signals | Agent performance must improve through feedback loops. |
+| "Enterprise readiness" | Runtime evaluation and tooling parity checks | New runtimes need install, auth, trace, rollback, and audit proof before production use. |
+
+## Script: "The Part Of Agentic AI Most Teams Skip"
+
+Target length: 6 to 8 minutes
+Tone: plain, reflective, builder-to-builder
+Visual style: Portfolio UI captures, simple diagrams, operator receipts, blurred/private-safe admin surfaces
+
+### Opening
+
+Most teams are asking the wrong first question about agents.
+
+They ask: can the agent do the work?
+
+That question matters. But in an enterprise setting, it is only the beginning.
+
+The harder question is this:
+
+When the agent does the work, who can explain what happened?
+
+Who gave it the task? Why did that agent get selected? What tools could it touch? What data was out of bounds? Where did the handoff happen? Who approved the side effect? What did it cost? How do we know the output was any good?
+
+That is the layer most demos skip.
+
+And that is the layer we have been building into Portfolio.
+
+### Section 1: The Demo Is Not The Operating Model
+
+It is easy to get impressed by an agent that can open a tool, write code, draft an email, search a database, or trigger a workflow.
+
+I get impressed too. I build with these tools every day.
+
+But I keep coming back to the same tension.
+
+The same capability that makes agents powerful also makes them risky. They answer questions, then they move work. They can touch systems. They can create records. They can spend money. They can publish. They can make a mistake while looking confident.
+
+So the enterprise problem is governed execution.
+
+The enterprise problem is governed execution.
+
+### Section 2: The Agent Needs A Receipt
+
+In Portfolio, every serious agentic workflow starts with traceability.
+
+We built Agent Ops around the idea that an agent run should leave a receipt. A run has steps. Events. Artifacts. Costs. Approvals. Handoffs. Evaluations.
+
+That receipt matters because operators should not have to reconstruct the system from screenshots and Slack messages.
+
+If an agent drafts something, we need to know where the source came from.
+
+If it routes work, we need to know why that agent was chosen.
+
+If it creates a paid job or touches a public channel, we need to know who approved it.
+
+This is where observability becomes more than logs.
+
+Observability becomes accountability.
+
+### Section 3: Handoff Is A Product Feature
+
+A lot of multi-agent talk makes handoff sound magical.
+
+One agent finishes. Another agent starts. The workflow continues.
+
+That is not enough.
+
+In the real world, a handoff needs structure. The next agent needs the summary, the acceptance criteria, the owner, the runtime, and the trace that explains what happened before.
+
+That is why Portfolio uses work items and `agent_handoffs`.
+
+The handoff is not buried in a conversation. It becomes part of the operating record.
+
+That changes the quality of the system. Agents can specialize without losing continuity. Humans can inspect where work changed hands. The Integration Captain can own merge and deployment without losing the context from the feature agent.
+
+That is how agent swarms become manageable.
+
+### Section 4: Scope Is The Safety Model
+
+The next piece is scope.
+
+Every agent needs a job description that the system can enforce.
+
+What can it read? What can it write? What tools can it call? Can it touch client data? Can it send an email? Can it publish? Can it spend money? Can it start a paid external job?
+
+Portfolio separates those questions into runtime policy and agent capability profiles.
+
+That is important because a coding agent, an automation runtime, a research agent, and a publishing agent should not have the same authority.
+
+The goal is not to make every agent powerful.
+
+The goal is to make every agent appropriately bounded.
+
+That is what enterprise teams need when they start evaluating tools like Open CLAW or any other agent runtime. The runtime may be capable. The operating model still has to decide what capability is allowed in this environment.
+
+### Section 5: Compliance Lives In The Workflow
+
+Compliance cannot be a PDF that sits outside the system.
+
+It has to live in the workflow.
+
+Portfolio does this through approval gates, risk monitoring, and governance exports.
+
+Moremi watches for AI risk and compliance signals, then converts relevant concerns into exposure checks or proposed work. Payment and spend authority are treated as approval-gated events. Publishing and outbound sends require checkpoints. Private material cannot casually become public content.
+
+That gives us a way to explain the system to a client without exposing raw private logs.
+
+We can say: here is the agent role, here is the scope, here is the delegation trail, here is the approval boundary, here is the audit export.
+
+That is the language enterprises understand.
+
+### Section 6: QA Is A Loop
+
+The final piece is quality.
+
+Agent quality cannot depend on someone saying, "Looks good to me," every once in a while.
+
+Portfolio supports evaluations and rubrics tied back to agent runs. The system can score an output, record whether it passed, surface coaching signals, and track trends over time.
+
+That creates a real improvement loop.
+
+If an agent keeps failing on attribution, we can see that.
+
+If a workflow produces weaker handoffs, we can see that.
+
+If a prompt change improves quality, we can prove it with the next set of runs.
+
+That is how you slowly tune an agentic system without pretending it became reliable overnight.
+
+### Section 7: Human-In-The-Loop Has To Be Designed
+
+Human-in-the-loop is often described like a checkbox.
+
+In practice, it is an interface problem.
+
+The human needs the right packet at the right moment.
+
+Mission Control is the full operator surface. Slack is the mobile unblock surface. Slack can help with low-risk approvals, assignments, handoffs, and context requests. Higher-risk actions deep-link back into Portfolio.
+
+That matters because people do not work from one screen all day.
+
+The system has to meet the operator where they are without letting convenience erase governance.
+
+### Close
+
+So when I talk about what we have built in Portfolio, I am talking about more than a website.
+
+I am talking about a working blueprint for governed agentic operations.
+
+Agent registry.
+Scope.
+Delegation.
+Handoff.
+Observability.
+Approval.
+Compliance.
+QA.
+Human review.
+Client-safe proof.
+
+That is the part of agentic AI many teams will discover after the first demo.
+
+We are building it now because the organizations that need AI the most often have the least room for chaotic automation.
+
+Speed matters.
+
+But trust is what lets speed survive contact with real people, real money, real clients, and real work.
+
+## LinkedIn Post Seed
+
+Anyone can launch an agent now.
+
+That is the exciting part.
+
+It is also the dangerous part.
+
+The hard work starts after the first demo. Who decides which agent gets the task? What is the agent allowed to touch? What happens when one agent hands work to another? Who approves a public send, a payment action, or a production change? Where does the receipt live when something goes wrong?
+
+This is what we have been building into Portfolio.
+
+Not just agents.
+
+The operating system around the agents.
+
+Agent runs leave traces. Handoffs carry summaries and acceptance criteria. Runtime policies define scope. Approval gates stop side effects. Mission Control gives the operator a full view. Slack supports mobile unblocks without turning convenience into uncontrolled authority. Evaluations turn quality into a loop instead of a feeling.
+
+That is the part many enterprise teams will have to confront as tools like Open CLAW and other agent runtimes get easier to deploy.
+
+Execution is becoming cheap.
+
+Governed execution is where the value is.
+
+If your AI agent can act on behalf of the business, the business needs a way to answer:
+
+- who gave it the work,
+- what it was allowed to do,
+- what evidence it used,
+- what it handed off,
+- who approved the side effect,
+- what it cost,
+- and how the quality improves next time.
+
+That is the difference between an impressive demo and something you can trust inside real operations.
+
+What part of agent governance do you think most teams are underestimating right now?
+
+## Source Map
+
+- `docs/agent-operations-roadmap.md` - Agent Ops phases, trace model, approval-backed execution, Slack surface, runtime evaluation.
+- `docs/agentic-operating-system-governance.md` - agent scope, delegation, payment authority, governance UI, client-safe export framing.
+- `docs/agentic-patterns.md` - pattern coverage, handoffs, observability, QA, memory, production constraints.
+- `docs/ai-risk-compliance-agent.md` - Moremi risk/compliance monitor, exposure checks, approval-gated remediation.
+- `docs/agent-ops-slack-mobile-unblock.md` - Slack mobile action boundaries and Mission Control deep links.
+- `docs/agentic-os-client-advisory-explainer.md` - client-safe governance positioning.
+- `lib/agent-policy.ts` - runtime policy, approval gates, payment and paid-job authority actions.
+- `lib/agent-governance.ts` and `lib/agent-governance-export.ts` - capability inventory and client-safe audit export.
+- `lib/agent-work-items.ts` - handoff records, ownership transfer, acceptance criteria.
+- `lib/agent-evaluations.ts` - rubrics, trace-linked scoring, quality summaries.
+- `app/api/admin/agents/runs/[runId]/route.ts` - run detail receipt with timeline, artifacts, approvals, handoffs, costs, evaluations.

--- a/docs/agentic-value-communications-plan.md
+++ b/docs/agentic-value-communications-plan.md
@@ -1,0 +1,429 @@
+# Agentic Value Communications Plan
+
+Status: Draft channel architecture
+Source map: [`docs/agentic-enterprise-value-map.md`](agentic-enterprise-value-map.md)
+
+## Relationship To The Existing Agentic Backlog
+
+This plan is additive. It should not recreate the agentic backlog, research PRDs, research dossier, LinkedIn drafts, or YouTube scripts already produced.
+
+Existing work to reuse:
+
+| Existing asset | What it already covers | How this plan should use it |
+| --- | --- | --- |
+| `docs/agentic-content-research-prds/` | The 12 research PRDs for the agentic content series. | Treat as the research backlog and source assignment layer. Do not create another PRD set for the same topics. |
+| `docs/agentic-content-research-briefs/phase-2-research-dossier.md` | Source-backed research notes across the PRD set. | Pull evidence, claims, and proof references from it when drafting channel assets. |
+| `docs/agentic-content-linkedin-drafts/wave-1-drafts.md` | First-pass LinkedIn drafts for the initial wave. | Reuse, revise, or split these drafts rather than starting from scratch. |
+| `docs/agentic-content-video-scripts/wave-1-youtube-scripts.md` | First YouTube-ready script set and storyboard ideas. | Use as raw material for long-form and short-form scripts. |
+| `docs/agentic-content-video-scripts/render-approval-packet.md` | Render gate, readiness, and publishing boundary for the pilot video. | Keep live rendering and publishing behind the existing approval path. |
+| `docs/agentic-os-client-advisory-explainer.md` | Client-safe advisory positioning. | Reuse when building the client one-pager and website proof page. |
+
+What this plan adds:
+
+- A channel map that decides which idea belongs on LinkedIn, carousel, YouTube, Shorts/TikTok/Reels, website, client packet, or technical appendix.
+- A component library that lets one concept become multiple channel-native assets without changing the source claim.
+- A sequencing recommendation so the public language can be tested before the client-facing packet is locked.
+- A measurement loop for deciding which assets to expand, clip, revise, or retire.
+
+Rule for future work: if a deliverable already exists, create a revision brief, channel adaptation, or packaging layer. Do not duplicate the source backlog.
+
+## Source-Grounded Production Harness
+
+Source inspiration: [I Built a Deck With AI, Then Made a Second AI Attack It.](https://youtu.be/MFzxIT88zfg) by Nate B. Jones.
+
+The useful takeaway is the workflow shape: serious AI-assisted knowledge work should move through a source packet, a specification, constrained artifact creation, and hostile review before it is treated as ready.
+
+Apply that pattern to the agentic content backlog:
+
+| Stage | Purpose | Portfolio adaptation | Output |
+| --- | --- | --- | --- |
+| 1. Source inventory | Know what the model is allowed to use. | Index existing PRDs, briefs, drafts, scripts, governance docs, implementation files, and transcript-derived references. | Source register with IDs, dates, owners, status, and privacy boundary. |
+| 2. Artifact specification | Define what the asset must become before drafting. | For each LinkedIn post, carousel, video, one-pager, or appendix, write the audience, claim, proof, channel, length, and source IDs. | Channel spec or creative brief. |
+| 3. Constrained creation | Generate only against the approved source packet and spec. | Adapt existing drafts/scripts instead of asking the model to invent a new strategy. | Draft asset with source IDs attached. |
+| 4. Hostile review | Attack the artifact before polishing it. | Use a separate reviewer pass to find unsupported claims, missing attribution, weak logic, duplicated material, privacy leaks, and channel mismatch. | Issue list only, not fixes. |
+| 5. Revision loop | Repair the draft against the issue list. | Update the asset and preserve what changed. | Revised draft with resolved issues. |
+| 6. Human editorial gate | Make the final judgment. | Vambah reviews the voice, moral clarity, business value, and publication risk. | Approved, revise, hold, or split. |
+
+This turns the existing content backlog into a governed content production system.
+
+## Meta-Agent Review Roles
+
+These roles should evaluate the content before it becomes public or client-facing. They can be simulated by Codex prompts at first and later implemented as Agent Ops work items.
+
+| Review role | Job | Questions it must answer |
+| --- | --- | --- |
+| Source Librarian | Checks whether the draft maps back to approved sources. | Which source IDs support each claim? Are any claims unsupported? |
+| Fact Auditor | Looks for factual, numerical, architectural, or implementation drift. | Does the draft claim something Portfolio has not actually built? |
+| Privacy Reviewer | Checks whether private material could leak into public content. | Does this expose clients, raw logs, secrets, private chats, or internal-only traces? |
+| Channel Editor | Tests fit for LinkedIn, carousel, YouTube, Shorts, website, or client packet. | Is this the right format, length, hook, and level of detail for the channel? |
+| Voice Editor | Applies Vambah voice and anti-AI cleanup. | Does it sound grounded, practical, and human? Are there AI-isms or generic claims? |
+| Conversion Strategist | Checks whether the asset has a clear next action. | Is this for conversation, trust-building, sales, technical proof, or video expansion? |
+
+Minimum review rule:
+
+- Public LinkedIn post: Source Librarian, Fact Auditor, Voice Editor.
+- Carousel: Source Librarian, Channel Editor, Voice Editor.
+- YouTube long-form: Source Librarian, Fact Auditor, Privacy Reviewer, Voice Editor.
+- Client one-pager: Source Librarian, Fact Auditor, Privacy Reviewer, Conversion Strategist.
+- Technical appendix: Source Librarian, Fact Auditor, Privacy Reviewer.
+
+## Claim-Level Attribution Standard
+
+Every channel asset should carry a private source map before publication. The public asset does not need footnotes everywhere, but the working file should preserve attribution.
+
+Recommended fields:
+
+- `asset_id`
+- `channel`
+- `primary_claim`
+- `supporting_claims`
+- `source_ids`
+- `implementation_proof`
+- `privacy_classification`
+- `review_roles_completed`
+- `open_issues`
+- `approval_status`
+
+Example:
+
+| Claim | Source IDs | Proof type | Public-safe? |
+| --- | --- | --- | --- |
+| Agent runs need a receipt. | `agent-operations-roadmap`, `agentic-patterns`, `run-detail-route` | Docs and route implementation | Yes |
+| Handoffs need ownership and acceptance criteria. | `agent-work-items`, `agentic-patterns`, `agent-swarms-prd` | Helper implementation and PRD | Yes |
+| Payment and paid external jobs need approval gates. | `agent-policy`, `agentic-operating-system-governance` | Policy implementation | Yes, if no transaction data is shown |
+
+## Why This Needs Multiple Deliverables
+
+The value of Portfolio is too broad for one post, one video, or one packet.
+
+People enter this topic from different levels of maturity:
+
+- Some people are still impressed that an agent can use a tool.
+- Some are trying to bring Open CLAW, OpenCode, n8n, or another agent runtime into an enterprise setting.
+- Some are worried about compliance, audit, spend, and customer data.
+- Some need to see the operator interface before the architecture makes sense.
+- Some need a short story they can repeat to a board, funder, buyer, or internal sponsor.
+
+So the communication strategy should work like the product itself: modular, traceable, and channel-aware.
+
+The master source map holds the full system. The public communication should break that system into smaller doors people can walk through.
+
+## Communication Principle
+
+Do not lead with "agentic AI architecture."
+
+Lead with the operational anxiety people already feel:
+
+- "I launched an agent. Now how do I know what it did?"
+- "What happens when one agent hands work to another?"
+- "Who approves an agent before it sends, spends, publishes, or changes production?"
+- "How do I explain this to compliance?"
+- "How do I know the output is getting better?"
+
+Then show the operating layer Portfolio already built.
+
+## Channel Roles
+
+| Channel | Job | Best format | What it should prove |
+| --- | --- | --- | --- |
+| LinkedIn text post | Create the sharp framing and invite discussion | 900-1,800 character post | The reader recognizes the hidden enterprise problem. |
+| LinkedIn carousel | Make the system scannable | 7-10 slides | The reader sees the component model. |
+| LinkedIn article/newsletter | Teach the full framework | 1,200-2,000 words | The reader understands why the operating layer matters. |
+| YouTube long-form | Tell the full story with receipts | 6-10 minute scripted walkthrough | The viewer sees proof surfaces and understands the lifecycle. |
+| YouTube Shorts / TikTok / Reels | Isolate one memorable idea | 30-60 second clip | One concept sticks: receipt, scope, handoff, approval, QA. |
+| Client one-pager | Support advisory/sales conversations | PDF or webpage | A buyer understands the business value without needing technical depth. |
+| Technical appendix | Support due diligence | Markdown/PDF proof register | A technical reviewer can inspect the implementation surfaces. |
+| Website proof page | Turn the portfolio into an explainer | Public/private page | The website communicates the system behind the features. |
+| Workshop/webinar | Convert attention into authority | 30-45 minute teaching session | The audience can evaluate their own agent readiness gaps. |
+
+## Component Library
+
+Each component should become its own reusable content object. Some objects become posts. Some become slides. Some become short videos. Some become sections in a client packet.
+
+| Component | Core idea | Best first channel | Secondary channels |
+| --- | --- | --- | --- |
+| The receipt | Every agent run needs a record of what happened. | LinkedIn post | YouTube section, carousel slide, client one-pager |
+| Agent-to-agent handoff | A handoff is a work packet, not a chat message. | Carousel | Short video, technical appendix |
+| Scope and permission | Scope is the safety model. | LinkedIn post | YouTube section, client one-pager |
+| Human-in-the-loop | Human review needs a designed surface. | Short video | LinkedIn post, carousel |
+| Compliance and transactions | Spending, publishing, sending, and production changes need authority. | LinkedIn article | Client one-pager, technical appendix |
+| QA and coaching | Agent quality improves through rubrics and traces. | YouTube section | LinkedIn post, workshop |
+| Slack and Mission Control | Operators need both full review and mobile unblock. | Carousel | Short video, client demo |
+| Runtime readiness | New runtimes need install, auth, trace, rollback, and audit proof before production. | LinkedIn post | Technical appendix, webinar |
+| Client-safe proof | Governance exports explain the system without leaking private material. | Client one-pager | Website page, YouTube close |
+
+## Recommended Content Arc
+
+### Wave 1: Awareness
+
+Purpose: make people feel the gap between agent demos and enterprise operations.
+
+Deliverables:
+
+1. LinkedIn post: "Anyone can launch an agent now. That is the exciting part. It is also the dangerous part."
+2. Carousel: "The 7 things your agent needs after the demo."
+3. Short video: "The agent needs a receipt."
+
+Why this works:
+
+This wave does not require the audience to understand the full architecture. It gives them language for the problem.
+
+### Wave 2: System Education
+
+Purpose: explain the lifecycle in plain language.
+
+Deliverables:
+
+1. YouTube video: "The Part of Agentic AI Most Teams Skip."
+2. LinkedIn article: "The Enterprise Agent Lifecycle: scope, trace, handoff, approval, QA."
+3. Carousel: "From model action to governed operation."
+
+Why this works:
+
+This wave moves from attention to authority. It teaches the full lifecycle and positions Portfolio as proof, not theory.
+
+### Wave 3: Component Deep Dives
+
+Purpose: turn each hidden layer into a reusable thought-leadership asset.
+
+Deliverables:
+
+1. LinkedIn post: "A handoff is not a message. It is a work packet."
+2. LinkedIn post: "Scope is not a prompt. Scope is the safety model."
+3. LinkedIn post: "Human-in-the-loop is an interface problem."
+4. LinkedIn post: "Compliance belongs inside the workflow."
+5. LinkedIn post: "Agent QA needs scorecards, not vibes."
+6. Short video set: one 45-second clip for each idea.
+
+Why this works:
+
+Each component can stand alone. Together, they build the full operating system narrative.
+
+### Wave 4: Proof And Conversion
+
+Purpose: convert the narrative into client-facing and enterprise-facing proof.
+
+Deliverables:
+
+1. Client one-pager: "Governed Agentic Operations."
+2. Technical appendix: implementation proof map with source references.
+3. Website proof page: "How Portfolio runs governed agents."
+4. Advisory workshop outline: "Enterprise Agent Readiness Audit."
+
+Why this works:
+
+This wave gives buyers, partners, and internal stakeholders something concrete to evaluate.
+
+## Channel-Specific Deliverable Specs
+
+### LinkedIn Text Posts
+
+Best for: sharp framing, market education, conversation.
+
+Format:
+
+- 900-1,800 characters for most posts.
+- One concept per post.
+- Open with a tension, not a definition.
+- Use Portfolio proof after the reader feels the problem.
+- End with a question that asks for operational experience, not generic opinion.
+
+Example series:
+
+1. The agent needs a receipt.
+2. A handoff is a work packet.
+3. Scope is the safety model.
+4. Human-in-the-loop is an interface problem.
+5. Compliance belongs in the workflow.
+6. Agent QA needs scorecards.
+7. New runtimes need an operating model before production authority.
+
+### LinkedIn Carousel
+
+Best for: the component model.
+
+Format:
+
+1. Cover: "The 7 things your enterprise agent needs after the demo"
+2. Receipt: observability and trace
+3. Scope: tools, data, writes, spend
+4. Handoff: summary, owner, acceptance criteria
+5. Approval: human checkpoint for side effects
+6. Compliance: risk monitor and governance export
+7. QA: rubrics and coaching signals
+8. Operator surface: Mission Control and Slack
+9. Close: "Execution is becoming cheap. Governed execution is where the value is."
+
+Design direction:
+
+- Use simple system diagrams, not decorative AI imagery.
+- Keep each slide to one idea.
+- Use Portfolio UI proof only when it can be shown without private details.
+
+### YouTube Long-Form
+
+Best for: full architecture, story, receipts.
+
+Format:
+
+- 6-10 minutes.
+- Start with the wrong question: "Can the agent do the work?"
+- Move into the better question: "Can the business explain what happened?"
+- Use the lifecycle diagram as the spine.
+- Show or describe Portfolio proof surfaces at each phase.
+- End with a practical readiness checklist.
+
+Reusable chapters:
+
+1. The demo is not the operating model.
+2. The agent needs a receipt.
+3. Handoff is a product feature.
+4. Scope is the safety model.
+5. Compliance lives in the workflow.
+6. QA is a loop.
+7. Human-in-the-loop has to be designed.
+
+Phase 2 video extensibility:
+
+- This script can later feed HeyGen avatar generation.
+- Shorts can be cut from each chapter.
+- ElevenLabs should only be used when there is a separate approved audio plan.
+- Any rendered video should remain internal until a publishing packet is approved.
+
+### Short-Form Video
+
+Best for: memorable single ideas.
+
+Format:
+
+- 30-60 seconds.
+- One punchy concept.
+- No broad intro.
+- One practical example.
+- One closing line.
+
+Short ideas:
+
+1. "Your agent needs a receipt."
+2. "A handoff is not a Slack message."
+3. "Scope is not a prompt instruction."
+4. "Human-in-the-loop is an interface problem."
+5. "Compliance cannot live in a PDF."
+6. "Agent QA cannot be vibes."
+
+### Client One-Pager
+
+Best for: advisory and sales conversations.
+
+Format:
+
+- One page.
+- Plain language.
+- No deep code references.
+- Focus on business risk and operator confidence.
+
+Sections:
+
+1. The problem: agents can act faster than organizations can govern.
+2. The model: registry, scope, trace, handoff, approval, QA, audit.
+3. The proof: Portfolio implements the control plane.
+4. The value: safer adoption, clearer ownership, better compliance, measurable quality.
+5. The ask: run an agent readiness audit.
+
+### Technical Appendix
+
+Best for: enterprise due diligence and internal credibility.
+
+Format:
+
+- Markdown or PDF.
+- Source-mapped.
+- Evidence-first.
+
+Sections:
+
+1. Agent registry and scope.
+2. Runtime policies.
+3. Handoff schema.
+4. Observability tables.
+5. Approval gates.
+6. Risk/compliance monitor.
+7. Evaluation rubrics.
+8. Governance export boundaries.
+
+### Website Proof Page
+
+Best for: making the portfolio communicate the value without a live walkthrough.
+
+Format:
+
+- Public-safe.
+- Visual-first.
+- Structured around the lifecycle.
+
+Sections:
+
+1. Governed agents, not unchecked automation.
+2. Enterprise agent lifecycle diagram.
+3. What Portfolio proves.
+4. Component cards.
+5. Client-safe audit/export framing.
+6. Call to action: advisory, audit, or workshop.
+
+## Priority Recommendation
+
+Start with three assets:
+
+1. LinkedIn flagship post: creates the framing and tests market resonance.
+2. Carousel: makes the component model visual and shareable.
+3. YouTube script: becomes the long-form source for clips, Shorts, and future HeyGen production.
+
+Then build the client one-pager and technical appendix once the public language is calibrated.
+
+Reasoning:
+
+The public channels will tell us which language lands. The client packet should benefit from that learning instead of locking the language too early.
+
+## First Production Backlog
+
+| Priority | Deliverable | Channel | Source component | Output |
+| --- | --- | --- | --- | --- |
+| P0 | Flagship post: "Anyone can launch an agent now" | LinkedIn | Core message | Text post |
+| P0 | Carousel: "7 things your enterprise agent needs after the demo" | LinkedIn | Component library | Slide outline |
+| P0 | YouTube script: "The Part of Agentic AI Most Teams Skip" | YouTube | Full lifecycle | 6-10 minute script |
+| P1 | Short: "The agent needs a receipt" | TikTok/Reels/Shorts | Observability | 45-second script |
+| P1 | Short: "A handoff is a work packet" | TikTok/Reels/Shorts | Handoff | 45-second script |
+| P1 | Post: "Scope is the safety model" | LinkedIn | Scope | Text post |
+| P1 | Post: "Agent QA needs scorecards" | LinkedIn | QA loop | Text post |
+| P2 | Client one-pager | PDF/web | Value stack | Advisory asset |
+| P2 | Technical appendix | PDF/Markdown | Source map | Due diligence asset |
+| P2 | Website proof page | Portfolio | Full system | Webpage |
+
+## Measurement
+
+| Asset | Signal to watch | Decision |
+| --- | --- | --- |
+| LinkedIn flagship post | Comments from builders/operators asking about implementation | Expand into article and carousel. |
+| Carousel | Saves and shares | Turn into website proof page. |
+| YouTube long-form | Watch retention through lifecycle sections | Cut the strongest section into Shorts. |
+| Shorts | Repeat comments or direct messages | Turn repeated questions into LinkedIn posts. |
+| Client one-pager | Buyer confusion or repeated objections | Add examples or simplify the language. |
+| Technical appendix | Review questions from technical stakeholders | Add missing source references or proof screenshots. |
+
+## Editorial Guardrails
+
+- Do not make the story sound like AI hype.
+- Do not imply agents are fully autonomous in production.
+- Do not show private admin data, client records, secrets, raw logs, or private source material.
+- Do not collapse governance into fear. The point is confidence.
+- Keep the language operational: role, scope, trace, handoff, approval, quality, audit.
+- Use Open CLAW/OpenCode-style runtime references as examples of execution capacity, not as the whole operating model.
+
+## Working Tagline Options
+
+- Execution is becoming cheap. Governed execution is where the value is.
+- The agent is only as trustworthy as the operating system around it.
+- Your agent needs a receipt.
+- A demo proves capability. A trace proves control.
+- Scope is the safety model.
+- Human-in-the-loop is an interface, not a checkbox.

--- a/docs/agentic-value-communications-plan.md
+++ b/docs/agentic-value-communications-plan.md
@@ -24,6 +24,7 @@ What this plan adds:
 - A component library that lets one concept become multiple channel-native assets without changing the source claim.
 - A sequencing recommendation so the public language can be tested before the client-facing packet is locked.
 - A measurement loop for deciding which assets to expand, clip, revise, or retire.
+- A challenger gate that keeps first-pass drafts away from human approval until a skeptical agent review has tested the claims, source map, privacy boundary, and channel fit.
 
 Rule for future work: if a deliverable already exists, create a revision brief, channel adaptation, or packaging layer. Do not duplicate the source backlog.
 
@@ -31,7 +32,9 @@ Rule for future work: if a deliverable already exists, create a revision brief, 
 
 Source inspiration: [I Built a Deck With AI, Then Made a Second AI Attack It.](https://youtu.be/MFzxIT88zfg) by Nate B. Jones.
 
-The useful takeaway is the workflow shape: serious AI-assisted knowledge work should move through a source packet, a specification, constrained artifact creation, and hostile review before it is treated as ready.
+The useful takeaway is the workflow shape: serious AI-assisted knowledge work should move through a source packet, a specification, constrained artifact creation, and a Ralph Loop-style challenger pass before it is treated as ready.
+
+This mirrors the Portfolio AutoResearch pattern: create a bounded proposal, test it against evidence, record the iteration, and only then ask for human approval. The human should see a decision packet, not the first draft.
 
 Apply that pattern to the agentic content backlog:
 
@@ -40,11 +43,61 @@ Apply that pattern to the agentic content backlog:
 | 1. Source inventory | Know what the model is allowed to use. | Index existing PRDs, briefs, drafts, scripts, governance docs, implementation files, and transcript-derived references. | Source register with IDs, dates, owners, status, and privacy boundary. |
 | 2. Artifact specification | Define what the asset must become before drafting. | For each LinkedIn post, carousel, video, one-pager, or appendix, write the audience, claim, proof, channel, length, and source IDs. | Channel spec or creative brief. |
 | 3. Constrained creation | Generate only against the approved source packet and spec. | Adapt existing drafts/scripts instead of asking the model to invent a new strategy. | Draft asset with source IDs attached. |
-| 4. Hostile review | Attack the artifact before polishing it. | Use a separate reviewer pass to find unsupported claims, missing attribution, weak logic, duplicated material, privacy leaks, and channel mismatch. | Issue list only, not fixes. |
-| 5. Revision loop | Repair the draft against the issue list. | Update the asset and preserve what changed. | Revised draft with resolved issues. |
-| 6. Human editorial gate | Make the final judgment. | Vambah reviews the voice, moral clarity, business value, and publication risk. | Approved, revise, hold, or split. |
+| 4. Agentic Challenger Loop | Attack the artifact before polishing it. | Amina, the Agentic Challenger role, enumerates unsupported claims, implementation drift, source gaps, privacy risk, channel mismatch, weak logic, and duplicated material. | Issue list only, not fixes. |
+| 5. Repair pass | Repair only the challenger issue list. | The creator updates the asset, records fixes, and preserves unresolved questions. | Revised draft with resolved issues. |
+| 6. Challenger re-check | Decide whether the draft is ready for a human. | Amina verifies fixes and sets `pass_to_human`. | `passed`, `needs_revision`, or `blocked`. |
+| 7. Human editorial gate | Make the final judgment only after challenger clearance. | Vambah reviews voice, moral clarity, business value, and publication risk from a compact packet. | Approved, revise, hold, or split. |
 
 This turns the existing content backlog into a governed content production system.
+
+Default gate: a draft does not route to Vambah for human-in-the-loop approval unless `pass_to_human=true`. The only exception is an explicit human-decision packet for an unresolved risk the challenger cannot resolve, such as a source conflict, privacy judgment, or strategic positioning choice.
+
+## Ralph Loop / Agentic Challenger Standard
+
+The loop is creator -> challenger -> repair -> challenger re-check -> human review.
+
+The challenger does not fix the artifact. It only produces findings. This keeps critique and repair separate, which makes the review trace easier to trust.
+
+Required challenger questions:
+
+- Which claims are unsupported by the attached source IDs?
+- Where does the artifact imply Portfolio has built something that is only planned?
+- Does the artifact expose private logs, client information, raw chat exports, secrets, or internal-only traces?
+- Is this duplicating an existing PRD, brief, LinkedIn draft, or script instead of adapting it?
+- Does the format fit the intended channel and audience?
+- What must be fixed before a human should spend time reviewing it?
+
+Review packet statuses:
+
+| Status | Meaning | Next step |
+| --- | --- | --- |
+| `needs_revision` | The draft has fixable issues. | Repair the issue list and re-run the challenger. |
+| `blocked` | The draft has a source, privacy, or implementation conflict that cannot be safely repaired by the agent. | Create an exception packet for Vambah or hold the asset. |
+| `passed` | The challenger found no blocking issues and verified required fixes. | Route a compact HITL packet for human approval. |
+
+Review packet fields:
+
+- `asset_id`
+- `channel`
+- `source_ids`
+- `draft_version`
+- `loop_round`
+- `creator_agent`
+- `challenger_agent`
+- `challenger_prompt_version`
+- `challenge_findings`
+- `unsupported_claims`
+- `source_conflicts`
+- `privacy_flags`
+- `implementation_drift`
+- `required_fixes`
+- `fixes_applied`
+- `residual_risks_for_human`
+- `challenger_status`
+- `pass_to_human`
+- `approval_status`
+
+`pass_to_human=true` only when unsupported claims, source conflicts, critical privacy flags, and implementation drift are resolved or explicitly marked as residual human decisions.
 
 ## Meta-Agent Review Roles
 
@@ -52,6 +105,7 @@ These roles should evaluate the content before it becomes public or client-facin
 
 | Review role | Job | Questions it must answer |
 | --- | --- | --- |
+| Amina / Agentic Challenger | Performs the mandatory pre-HITL attack pass. | Should this asset be routed to a human yet, or does it need repair, source work, privacy cleanup, or a hold? |
 | Source Librarian | Checks whether the draft maps back to approved sources. | Which source IDs support each claim? Are any claims unsupported? |
 | Fact Auditor | Looks for factual, numerical, architectural, or implementation drift. | Does the draft claim something Portfolio has not actually built? |
 | Privacy Reviewer | Checks whether private material could leak into public content. | Does this expose clients, raw logs, secrets, private chats, or internal-only traces? |
@@ -61,11 +115,11 @@ These roles should evaluate the content before it becomes public or client-facin
 
 Minimum review rule:
 
-- Public LinkedIn post: Source Librarian, Fact Auditor, Voice Editor.
-- Carousel: Source Librarian, Channel Editor, Voice Editor.
-- YouTube long-form: Source Librarian, Fact Auditor, Privacy Reviewer, Voice Editor.
-- Client one-pager: Source Librarian, Fact Auditor, Privacy Reviewer, Conversion Strategist.
-- Technical appendix: Source Librarian, Fact Auditor, Privacy Reviewer.
+- Public LinkedIn post: Amina / Agentic Challenger, Source Librarian, Fact Auditor, Voice Editor.
+- Carousel: Amina / Agentic Challenger, Source Librarian, Channel Editor, Voice Editor.
+- YouTube long-form: Amina / Agentic Challenger, Source Librarian, Fact Auditor, Privacy Reviewer, Voice Editor.
+- Client one-pager: Amina / Agentic Challenger, Source Librarian, Fact Auditor, Privacy Reviewer, Conversion Strategist.
+- Technical appendix: Amina / Agentic Challenger, Source Librarian, Fact Auditor, Privacy Reviewer.
 
 ## Claim-Level Attribution Standard
 
@@ -82,6 +136,9 @@ Recommended fields:
 - `privacy_classification`
 - `review_roles_completed`
 - `open_issues`
+- `challenger_status`
+- `pass_to_human`
+- `residual_risks_for_human`
 - `approval_status`
 
 Example:
@@ -91,6 +148,25 @@ Example:
 | Agent runs need a receipt. | `agent-operations-roadmap`, `agentic-patterns`, `run-detail-route` | Docs and route implementation | Yes |
 | Handoffs need ownership and acceptance criteria. | `agent-work-items`, `agentic-patterns`, `agent-swarms-prd` | Helper implementation and PRD | Yes |
 | Payment and paid external jobs need approval gates. | `agent-policy`, `agentic-operating-system-governance` | Policy implementation | Yes, if no transaction data is shown |
+
+## Channel Adaptation Matrix
+
+Use this matrix to convert the existing backlog into channel-native assets without creating duplicate work. Every row starts with `approval_status=not_ready` until the challenger loop sets `pass_to_human=true`.
+
+| Asset | Reuse source | Channel | Challenger requirement | Human packet |
+| --- | --- | --- | --- | --- |
+| Flagship post: "Anyone can launch an agent now" | `wave-1-drafts.md`, value map core message | LinkedIn | Check for hype, unsupported autonomy claims, and duplicated wording. | Final post, source IDs, challenger findings, residual risks. |
+| Carousel: "7 things your enterprise agent needs after the demo" | PRDs 02-09, component library | LinkedIn carousel | Check each slide has one source-backed idea and no private UI detail. | Slide outline, visual notes, source map, privacy notes. |
+| YouTube script: "The Part of Agentic AI Most Teams Skip" | `wave-1-youtube-scripts.md`, value map lifecycle | YouTube | Check implementation claims, story logic, and proof-screen safety. | Script, storyboard, source map, blur/avoid list. |
+| Short: "The agent needs a receipt" | Observability component, PRD 02 | Shorts/TikTok/Reels | Check the hook is accurate and does not overclaim live autonomy. | 45-second script and proof note. |
+| Short: "A handoff is a work packet" | Handoff component, PRD 06 | Shorts/TikTok/Reels | Check handoff language matches existing work-item and trace behavior. | 45-second script and source note. |
+| Post: "Scope is the safety model" | PRD 07, `agent-policy` evidence | LinkedIn | Check permission examples do not imply broad production authority. | Final post and claim map. |
+| Post: "Agent QA needs scorecards" | PRD 05, evaluation route evidence | LinkedIn | Check the difference between implemented scoring and planned reflection loops. | Final post, built/planned distinction, source IDs. |
+| Client one-pager | advisory explainer, value stack | PDF/web | Check client-safe language and remove internal swarm/provider detail. | One-pager draft, buyer-risk framing, privacy notes. |
+| Technical appendix | value map, PRD evidence, implementation paths | PDF/Markdown | Check source paths and proof statements for drift. | Appendix draft, proof register, unresolved evidence gaps. |
+| Website proof page | value map, channel plan | Portfolio page | Check public-safe screenshots, privacy boundary, and call-to-action fit. | Page brief, section map, proof-safe asset list. |
+
+Phase 2 video rule: HeyGen, ElevenLabs, Remotion, HyperFrames, or other provider/render work cannot begin until the script has challenger clearance and the existing render approval packet is approved. Challenger clearance is a precondition for render-readiness, not the render approval itself.
 
 ## Why This Needs Multiple Deliverables
 
@@ -386,18 +462,32 @@ The public channels will tell us which language lands. The client packet should 
 
 ## First Production Backlog
 
-| Priority | Deliverable | Channel | Source component | Output |
-| --- | --- | --- | --- | --- |
-| P0 | Flagship post: "Anyone can launch an agent now" | LinkedIn | Core message | Text post |
-| P0 | Carousel: "7 things your enterprise agent needs after the demo" | LinkedIn | Component library | Slide outline |
-| P0 | YouTube script: "The Part of Agentic AI Most Teams Skip" | YouTube | Full lifecycle | 6-10 minute script |
-| P1 | Short: "The agent needs a receipt" | TikTok/Reels/Shorts | Observability | 45-second script |
-| P1 | Short: "A handoff is a work packet" | TikTok/Reels/Shorts | Handoff | 45-second script |
-| P1 | Post: "Scope is the safety model" | LinkedIn | Scope | Text post |
-| P1 | Post: "Agent QA needs scorecards" | LinkedIn | QA loop | Text post |
-| P2 | Client one-pager | PDF/web | Value stack | Advisory asset |
-| P2 | Technical appendix | PDF/Markdown | Source map | Due diligence asset |
-| P2 | Website proof page | Portfolio | Full system | Webpage |
+| Priority | Deliverable | Channel | Source component | Output | Approval status | Human review |
+| --- | --- | --- | --- | --- | --- | --- |
+| P0 | Flagship post: "Anyone can launch an agent now" | LinkedIn | Core message | Text post | `not_ready` until Ralph Loop pass | Blocked until `pass_to_human=true` |
+| P0 | Carousel: "7 things your enterprise agent needs after the demo" | LinkedIn | Component library | Slide outline | `not_ready` until Ralph Loop pass | Blocked until `pass_to_human=true` |
+| P0 | YouTube script: "The Part of Agentic AI Most Teams Skip" | YouTube | Full lifecycle | 6-10 minute script | `not_ready` until Ralph Loop pass | Blocked until `pass_to_human=true` |
+| P1 | Short: "The agent needs a receipt" | TikTok/Reels/Shorts | Observability | 45-second script | `not_ready` until Ralph Loop pass | Blocked until `pass_to_human=true` |
+| P1 | Short: "A handoff is a work packet" | TikTok/Reels/Shorts | Handoff | 45-second script | `not_ready` until Ralph Loop pass | Blocked until `pass_to_human=true` |
+| P1 | Post: "Scope is the safety model" | LinkedIn | Scope | Text post | `not_ready` until Ralph Loop pass | Blocked until `pass_to_human=true` |
+| P1 | Post: "Agent QA needs scorecards" | LinkedIn | QA loop | Text post | `not_ready` until Ralph Loop pass | Blocked until `pass_to_human=true` |
+| P2 | Client one-pager | PDF/web | Value stack | Advisory asset | `not_ready` until Ralph Loop pass | Blocked until `pass_to_human=true` |
+| P2 | Technical appendix | PDF/Markdown | Source map | Due diligence asset | `not_ready` until Ralph Loop pass | Blocked until `pass_to_human=true` |
+| P2 | Website proof page | Portfolio | Full system | Webpage | `not_ready` until Ralph Loop pass | Blocked until `pass_to_human=true` |
+
+## Challenger Test Scenarios
+
+Use these scenarios when validating the first challenger prompts or future Agent Ops implementation:
+
+| Scenario | Challenger finding | Expected routing |
+| --- | --- | --- |
+| Unsupported claim | Draft says Portfolio has autonomous production mutation without proof. | `blocked` until claim is removed or a source proves it. |
+| Duplicate work | Draft repeats an existing LinkedIn script without a new channel purpose. | `needs_revision`; route to adaptation, not new creation. |
+| Privacy risk | Draft references private run logs, raw chat exports, client records, or secrets. | `blocked` until removed or escalated as a human decision. |
+| Source conflict | Two sources disagree on whether a capability is built or planned. | `needs_revision` with residual-risk note if unresolved. |
+| Channel mismatch | Long technical explainer is marked as short-form-ready. | `needs_revision`; rewrite to channel constraints. |
+| Valid pass | Draft is sourced, public-safe, channel-fit, and all fixes are verified. | `passed`; compact HITL packet can route to Vambah. |
+| Provider gate | YouTube or avatar script asks for HeyGen/ElevenLabs work before review. | `blocked`; script must pass challenger and render approval first. |
 
 ## Measurement
 


### PR DESCRIPTION
## Summary
- Add a master source map for explaining Portfolio's governed agentic operating system value.
- Add a channel-specific communications plan that breaks the story into LinkedIn, carousel, YouTube, short-form, client one-pager, technical appendix, website, and workshop deliverables.
- Add a Ralph Loop / Amina Agentic Challenger gate so drafts must pass source, privacy, implementation, duplication, and channel-fit review before human approval.
- Add a reusable challenger-loop packet template with required fields, statuses, gate rules, prompt pattern, and acceptance scenarios.

## Validation
- git diff --check
- ASCII scan for new docs
- Anti-AI phrase scan over new docs
- Docs-only change; no app build or runtime smoke run

## Integration Notes
- No migrations or env changes.
- No live generation, rendering, publishing, n8n workflow, or external send was started.
- Challenger clearance is a precondition for HITL review; it does not replace Vambah/Shaka approval or provider render approval.
- Vercel – portfolio: pending after latest push.
- Vercel – portfolio-staging: not checked by this non-captain docs phase.