### PR TITLE
feat: trigger immediate Slack unblock notifications

### DIFF
--- a/app/api/admin/agents/approval-drill/route.test.ts
+++ b/app/api/admin/agents/approval-drill/route.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   isAuthError: vi.fn(),
   startAgentRun: vi.fn(),
   recordAgentEvent: vi.fn(),
+  runAgentSlackNotificationSweep: vi.fn(),
   from: vi.fn(),
   insert: vi.fn(),
 }))
@@ -17,6 +18,10 @@ vi.mock('@/lib/auth-server', () => ({
 vi.mock('@/lib/agent-run', () => ({
   startAgentRun: mocks.startAgentRun,
   recordAgentEvent: mocks.recordAgentEvent,
+}))
+
+vi.mock('@/lib/agent-slack-notification-sweep', () => ({
+  runAgentSlackNotificationSweep: mocks.runAgentSlackNotificationSweep,
 }))
 
 vi.mock('@/lib/supabase', () => ({
@@ -49,6 +54,7 @@ describe('POST /api/admin/agents/approval-drill', () => {
     mocks.isAuthError.mockReturnValue(false)
     mocks.startAgentRun.mockResolvedValue({ id: 'run-1' })
     mocks.recordAgentEvent.mockResolvedValue({ id: 'event-1' })
+    mocks.runAgentSlackNotificationSweep.mockResolvedValue({ ok: true, sentCount: 1 })
     approvalInsertChain()
   })
 
@@ -84,6 +90,12 @@ describe('POST /api/admin/agents/approval-drill', () => {
       approval_type: 'send_email',
       status: 'pending',
     }))
+    expect(mocks.runAgentSlackNotificationSweep).toHaveBeenCalledWith({
+      mode: 'immediate',
+      kinds: ['pending_approvals'],
+      actorLabel: 'Agent approval drill',
+      triggerSource: 'approval_drill_created',
+    })
   })
 
   it('rejects unknown approval types', async () => {

--- a/app/api/admin/agents/approval-drill/route.ts
+++ b/app/api/admin/agents/approval-drill/route.ts
@@ -10,6 +10,23 @@ function isKnownApprovalType(value: string) {
   return APPROVAL_GATES.some((gate) => gate.approvalType === value)
 }
 
+async function notifyImmediatePendingApprovals() {
+  try {
+    const { runAgentSlackNotificationSweep } = await import('@/lib/agent-slack-notification-sweep')
+    await runAgentSlackNotificationSweep({
+      mode: 'immediate',
+      kinds: ['pending_approvals'],
+      actorLabel: 'Agent approval drill',
+      triggerSource: 'approval_drill_created',
+    })
+  } catch (error) {
+    console.warn(
+      '[approval-drill] immediate Slack approval notification skipped:',
+      error instanceof Error ? error.message : error,
+    )
+  }
+}
+
 /**
  * POST /api/admin/agents/approval-drill
  *
@@ -81,6 +98,8 @@ export async function POST(request: NextRequest) {
       metadata: { approval_id: data.id, approval_type: approvalType },
       idempotencyKey: `${run.id}:approval-drill-created`,
     }).catch(() => {})
+
+    await notifyImmediatePendingApprovals()
 
     return NextResponse.json({
       ok: true,

--- a/app/api/admin/agents/chief-of-staff/actions/route.test.ts
+++ b/app/api/admin/agents/chief-of-staff/actions/route.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   startAgentRun: vi.fn(),
   recordAgentEvent: vi.fn(),
   attachAgentArtifact: vi.fn(),
+  runAgentSlackNotificationSweep: vi.fn(),
   from: vi.fn(),
   insert: vi.fn(),
 }))
@@ -19,6 +20,10 @@ vi.mock('@/lib/agent-run', () => ({
   startAgentRun: mocks.startAgentRun,
   recordAgentEvent: mocks.recordAgentEvent,
   attachAgentArtifact: mocks.attachAgentArtifact,
+}))
+
+vi.mock('@/lib/agent-slack-notification-sweep', () => ({
+  runAgentSlackNotificationSweep: mocks.runAgentSlackNotificationSweep,
 }))
 
 vi.mock('@/lib/supabase', () => ({
@@ -61,6 +66,7 @@ describe('POST /api/admin/agents/chief-of-staff/actions', () => {
     mocks.startAgentRun.mockResolvedValue({ id: 'approval-run-1' })
     mocks.recordAgentEvent.mockResolvedValue({ id: 'event-1' })
     mocks.attachAgentArtifact.mockResolvedValue({ id: 'artifact-1' })
+    mocks.runAgentSlackNotificationSweep.mockResolvedValue({ ok: true, sentCount: 1 })
     approvalInsertChain()
   })
 
@@ -135,6 +141,12 @@ describe('POST /api/admin/agents/chief-of-staff/actions', () => {
         selected_candidate: 'send_email',
       }),
     }))
+    expect(mocks.runAgentSlackNotificationSweep).toHaveBeenCalledWith({
+      mode: 'immediate',
+      kinds: ['pending_approvals'],
+      actorLabel: 'Chief of Staff action approval',
+      triggerSource: 'chief_of_staff_approval_created',
+    })
     expect(mocks.attachAgentArtifact).toHaveBeenCalledWith(expect.objectContaining({
       runId: 'approval-run-1',
       artifactType: 'approval_action_payload',

--- a/app/api/admin/agents/chief-of-staff/actions/route.ts
+++ b/app/api/admin/agents/chief-of-staff/actions/route.ts
@@ -116,6 +116,23 @@ function formatActionPayloadSummary(payload: ReturnType<typeof buildActionPayloa
   ].join('\n')
 }
 
+async function notifyImmediatePendingApprovals() {
+  try {
+    const { runAgentSlackNotificationSweep } = await import('@/lib/agent-slack-notification-sweep')
+    await runAgentSlackNotificationSweep({
+      mode: 'immediate',
+      kinds: ['pending_approvals'],
+      actorLabel: 'Chief of Staff action approval',
+      triggerSource: 'chief_of_staff_approval_created',
+    })
+  } catch (error) {
+    console.warn(
+      '[chief-of-staff-actions] immediate Slack approval notification skipped:',
+      error instanceof Error ? error.message : error,
+    )
+  }
+}
+
 /**
  * POST /api/admin/agents/chief-of-staff/actions
  *
@@ -237,6 +254,8 @@ export async function POST(request: NextRequest) {
       },
       idempotencyKey: `${run.id}:chief-of-staff-approval-created`,
     }).catch(() => {})
+
+    await notifyImmediatePendingApprovals()
 
     await attachAgentArtifact({
       runId: run.id,

--- a/lib/agent-automation-goal-seeding.test.ts
+++ b/lib/agent-automation-goal-seeding.test.ts
@@ -3,11 +3,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   createAgentWorkItem: vi.fn(),
   listAgentWorkItems: vi.fn(),
+  runAgentSlackNotificationSweep: vi.fn(),
 }))
 
 vi.mock('@/lib/agent-work-items', () => ({
   createAgentWorkItem: mocks.createAgentWorkItem,
   listAgentWorkItems: mocks.listAgentWorkItems,
+}))
+
+vi.mock('@/lib/agent-slack-notification-sweep', () => ({
+  runAgentSlackNotificationSweep: mocks.runAgentSlackNotificationSweep,
 }))
 
 import { listAutomationGoalSeedStates, seedAutomationGoals } from './agent-automation-goal-seeding'
@@ -34,6 +39,7 @@ describe('agent automation goal seeding', () => {
       idempotency_key: input.idempotencyKey,
     }))
     mocks.listAgentWorkItems.mockResolvedValue([])
+    mocks.runAgentSlackNotificationSweep.mockResolvedValue({ ok: true, sentCount: 1 })
   })
 
   it('creates a parent goal and child tasks with automation metadata', async () => {
@@ -66,6 +72,13 @@ describe('agent automation goal seeding', () => {
         goal_parent_work_item_id: 'automation-goal:meeting-intake-follow-up-drafts:parent',
       }),
     }))
+    expect(mocks.runAgentSlackNotificationSweep).toHaveBeenCalledWith({
+      mode: 'immediate',
+      kinds: ['goal_decisions'],
+      goalId: 'automation:meeting-intake-follow-up-drafts',
+      actorLabel: 'Automation goal seeding',
+      triggerSource: 'automation_goal_seeded',
+    })
   })
 
   it('defaults to Tier 1 seeds and rejects unknown selected seeds', async () => {

--- a/lib/agent-automation-goal-seeding.ts
+++ b/lib/agent-automation-goal-seeding.ts
@@ -72,6 +72,28 @@ function baseMetadata(seed: AutomationGoalSeed, triggeredByUserId?: string | nul
   }
 }
 
+async function notifyImmediateGoalDecisions(input: {
+  goalId: string
+  actorLabel: string
+  triggerSource: string
+}) {
+  try {
+    const { runAgentSlackNotificationSweep } = await import('@/lib/agent-slack-notification-sweep')
+    await runAgentSlackNotificationSweep({
+      mode: 'immediate',
+      kinds: ['goal_decisions'],
+      goalId: input.goalId,
+      actorLabel: input.actorLabel,
+      triggerSource: input.triggerSource,
+    })
+  } catch (error) {
+    console.warn(
+      '[automation-goals] immediate Slack goal notification skipped:',
+      error instanceof Error ? error.message : error,
+    )
+  }
+}
+
 export async function listAutomationGoalSeedStates(limit = 250): Promise<AutomationGoalSeedState[]> {
   const items = await listAgentWorkItems({ limit })
   const seededItems = items.filter((item) => item.metadata?.automation_seed === true)
@@ -143,6 +165,14 @@ export async function seedAutomationGoals(input: SeedAutomationGoalsInput = {}):
     }
 
     seeded.push({ seed, parent, children })
+
+    if (children.some((child) => child.metadata?.requires_approval === true)) {
+      await notifyImmediateGoalDecisions({
+        goalId: goalIdForSeed(seed),
+        actorLabel: 'Automation goal seeding',
+        triggerSource: 'automation_goal_seeded',
+      })
+    }
   }
 
   return seeded

--- a/lib/agent-slack-notification-sweep.test.ts
+++ b/lib/agent-slack-notification-sweep.test.ts
@@ -99,6 +99,35 @@ describe('Agent Ops proactive Slack notification sweep', () => {
     expect(result.results.every((item) => item.triggerModes.includes('immediate'))).toBe(true)
   })
 
+  it('scopes immediate goal-decision packets to a goal id', async () => {
+    mocks.buildAgentSlackNotificationPayload.mockResolvedValue({
+      text: 'Goal decision needed',
+      blocks: [{ type: 'section', text: { type: 'mrkdwn', text: 'Goal decision' } }],
+      itemCount: 1,
+    })
+
+    const result = await runAgentSlackNotificationSweep({
+      mode: 'immediate',
+      kinds: ['goal_decisions'],
+      goalId: 'goal-1',
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      mode: 'immediate',
+      totalRules: 1,
+      sentCount: 1,
+    })
+    expect(mocks.buildAgentSlackNotificationPayload).toHaveBeenCalledWith({
+      kind: 'goal_decisions',
+      goalId: 'goal-1',
+    })
+    expect(mocks.sendAgentSlackNotification).toHaveBeenCalledWith(expect.objectContaining({
+      kind: 'goal_decisions',
+      goalId: 'goal-1',
+    }))
+  })
+
   it('sends non-empty packets with content-aware dedupe metadata', async () => {
     mocks.buildAgentSlackNotificationPayload.mockResolvedValue({
       text: '2 stale runs',

--- a/lib/agent-slack-notification-sweep.ts
+++ b/lib/agent-slack-notification-sweep.ts
@@ -26,6 +26,7 @@ export type ProactiveSlackNotificationRule = {
 export type AgentSlackNotificationSweepInput = {
   kinds?: ProactiveSlackNotificationKind[]
   mode?: ProactiveSlackNotificationMode
+  goalId?: string | null
   dryRun?: boolean
   force?: boolean
   actorLabel?: string | null
@@ -143,7 +144,10 @@ export async function runAgentSlackNotificationSweep(input: AgentSlackNotificati
 
   for (const rule of selectedRules(input.kinds, mode)) {
     try {
-      const payload = await buildAgentSlackNotificationPayload({ kind: rule.kind })
+      const payload = await buildAgentSlackNotificationPayload({
+        kind: rule.kind,
+        goalId: input.goalId ?? null,
+      })
 
       if (payload.itemCount < rule.minimumItemCount) {
         results.push({
@@ -184,6 +188,7 @@ export async function runAgentSlackNotificationSweep(input: AgentSlackNotificati
 
       const notification = await sendAgentSlackNotification({
         kind: rule.kind,
+        goalId: input.goalId ?? null,
         force: input.force,
         actorLabel: input.actorLabel ?? 'Agent Ops notification sweep',
         triggerSource: input.triggerSource ?? 'cron_agent_ops_slack_notifications',

--- a/lib/agent-slack-notifications.test.ts
+++ b/lib/agent-slack-notifications.test.ts
@@ -131,6 +131,63 @@ describe('Agent Ops Slack notifications', () => {
     }))
   })
 
+  it('includes goal tasks that require approval even when they are assigned', async () => {
+    mocks.listAgentWorkItems.mockResolvedValue([
+      {
+        id: 'goal-task-1',
+        title: 'Draft n8n workflow proposal',
+        objective: 'Create the workflow proposal packet',
+        status: 'assigned',
+        priority: 'high',
+        owner_agent_key: 'automation-systems',
+        active_run_id: 'trace-goal-1',
+        source_run_id: null,
+        blocker_summary: null,
+        validation_summary: 'Needs operator approval before activation',
+        metadata: {
+          goal_id: 'automation:meeting-intake-follow-up-drafts',
+          goal_title: 'Automate meeting intake to follow-up drafts',
+          requires_approval: true,
+        },
+        updated_at: '2026-05-23T10:00:00.000Z',
+      },
+      {
+        id: 'goal-task-2',
+        title: 'Unrelated goal task',
+        objective: 'No decision needed',
+        status: 'assigned',
+        priority: 'medium',
+        owner_agent_key: 'chief-of-staff',
+        active_run_id: null,
+        source_run_id: null,
+        blocker_summary: null,
+        validation_summary: null,
+        metadata: {
+          goal_id: 'automation:other-goal',
+          requires_approval: true,
+        },
+        updated_at: '2026-05-23T10:00:00.000Z',
+      },
+    ])
+
+    const payload = await sendAgentSlackNotification({
+      kind: 'goal_decisions',
+      goalId: 'automation:meeting-intake-follow-up-drafts',
+    })
+
+    expect(payload).toMatchObject({
+      itemCount: 1,
+      text: 'Goal tasks needing a decision: 1 item(s).',
+    })
+    expect(mocks.startAgentRun).toHaveBeenCalledWith(expect.objectContaining({
+      metadata: expect.objectContaining({
+        notification_kind: 'goal_decisions',
+        goal_id: 'automation:meeting-intake-follow-up-drafts',
+        item_count: 1,
+      }),
+    }))
+  })
+
   it('prefers bot-token delivery so Slack threads can be traced back to Portfolio', async () => {
     process.env.SLACK_BOT_TOKEN = 'xoxb-test'
     process.env.SLACK_AGENT_OPS_CHANNEL_ID = 'CAGENTOPS'

--- a/lib/agent-slack-notifications.ts
+++ b/lib/agent-slack-notifications.ts
@@ -410,7 +410,10 @@ async function buildWorkItemPayload(input: AgentSlackNotificationInput) {
     items = allItems.filter((item) => {
       const metadata = item.metadata ?? {}
       const goalId = typeof metadata.goal_id === 'string' ? metadata.goal_id : null
-      const needsDecision = Boolean(item.blocker_summary) || item.status === 'blocked' || item.status === 'proposed'
+      const needsDecision = Boolean(item.blocker_summary) ||
+        item.status === 'blocked' ||
+        item.status === 'proposed' ||
+        metadata.requires_approval === true
       return Boolean(goalId) && (!input.goalId || goalId === input.goalId) && needsDecision
     })
     title = 'Goal tasks needing a decision'

--- a/lib/agent-work-items.test.ts
+++ b/lib/agent-work-items.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   listQueue: [] as Array<{ data: unknown; error: unknown }>,
   startAgentRun: vi.fn(),
   recordAgentEvent: vi.fn(),
+  runAgentSlackNotificationSweep: vi.fn(),
 }))
 
 vi.mock('@/lib/supabase', () => ({
@@ -21,6 +22,10 @@ vi.mock('@/lib/agent-run', () => ({
   AGENT_RUNTIMES: ['codex', 'n8n', 'hermes', 'opencode', 'manual'],
   startAgentRun: mocks.startAgentRun,
   recordAgentEvent: mocks.recordAgentEvent,
+}))
+
+vi.mock('@/lib/agent-slack-notification-sweep', () => ({
+  runAgentSlackNotificationSweep: mocks.runAgentSlackNotificationSweep,
 }))
 
 import {
@@ -98,6 +103,7 @@ describe('agent work item helpers', () => {
     mocks.fromMock.mockImplementation(() => chain())
     mocks.startAgentRun.mockResolvedValue({ id: 'run-1' })
     mocks.recordAgentEvent.mockResolvedValue({ id: 'event-1' })
+    mocks.runAgentSlackNotificationSweep.mockResolvedValue({ ok: true, sentCount: 1 })
   })
 
   it('creates a trace-linked work item', async () => {
@@ -187,6 +193,12 @@ describe('agent work item helpers', () => {
     expect(mocks.updateMock).toHaveBeenCalledWith(expect.objectContaining({
       status: 'waiting_for_approval',
     }))
+    expect(mocks.runAgentSlackNotificationSweep).toHaveBeenCalledWith({
+      mode: 'immediate',
+      kinds: ['pending_approvals'],
+      actorLabel: 'Agent Ops approval checkpoint',
+      triggerSource: 'agent_work_item_approval_created',
+    })
   })
 
   it('records MCP build requests without activating external workflows', async () => {
@@ -418,6 +430,12 @@ describe('agent work item helpers', () => {
       status: 'waiting_for_approval',
       current_step: 'Approval required: n8n workflow activation',
     }))
+    expect(mocks.runAgentSlackNotificationSweep).toHaveBeenCalledWith({
+      mode: 'immediate',
+      kinds: ['pending_approvals'],
+      actorLabel: 'admin@example.com',
+      triggerSource: 'agent_work_item_n8n_activation_approval_created',
+    })
     expect(mocks.updateMock).toHaveBeenCalledWith(expect.objectContaining({
       status: 'ready_for_review',
       blocker_summary: null,

--- a/lib/agent-work-items.ts
+++ b/lib/agent-work-items.ts
@@ -141,6 +141,26 @@ function db() {
   return supabaseAdmin
 }
 
+async function notifyImmediatePendingApprovals(input: {
+  actorLabel: string
+  triggerSource: string
+}) {
+  try {
+    const { runAgentSlackNotificationSweep } = await import('@/lib/agent-slack-notification-sweep')
+    await runAgentSlackNotificationSweep({
+      mode: 'immediate',
+      kinds: ['pending_approvals'],
+      actorLabel: input.actorLabel,
+      triggerSource: input.triggerSource,
+    })
+  } catch (error) {
+    console.warn(
+      '[agent-work-items] immediate Slack approval notification skipped:',
+      error instanceof Error ? error.message : error,
+    )
+  }
+}
+
 function assertRuntime(value: string): asserts value is AgentRuntime {
   if (!AGENT_RUNTIMES.includes(value as AgentRuntime)) {
     throw new Error(`Invalid owner_runtime: ${value}`)
@@ -275,6 +295,11 @@ async function createApprovalCheckpoint(item: AgentWorkItem, status: AgentWorkIt
     .eq('id', item.active_run_id)
     .in('status', ['queued', 'running'])
 
+  await notifyImmediatePendingApprovals({
+    actorLabel: 'Agent Ops approval checkpoint',
+    triggerSource: 'agent_work_item_approval_created',
+  })
+
   return data.id as string
 }
 
@@ -335,6 +360,11 @@ async function createN8nActivationApprovalCheckpoint(input: {
     })
     .eq('id', input.item.active_run_id)
     .in('status', ['queued', 'running'])
+
+  await notifyImmediatePendingApprovals({
+    actorLabel: input.actorLabel,
+    triggerSource: 'agent_work_item_n8n_activation_approval_created',
+  })
 
   return data.id as string
 }


### PR DESCRIPTION
## Summary
- triggers immediate Agent Ops Slack notification sweeps when approval checkpoints are created
- scopes goal-decision Slack notifications to a specific automation goal and includes approval-required goal tasks
- covers approval drill, Chief of Staff action approval, work-item approval, n8n activation approval, and automation-goal seeding producers

## Validation
- `npm test -- lib/agent-slack-notification-sweep.test.ts lib/agent-slack-notifications.test.ts lib/agent-work-items.test.ts lib/agent-automation-goal-seeding.test.ts app/api/admin/agents/approval-drill/route.test.ts app/api/admin/agents/chief-of-staff/actions/route.test.ts app/api/cron/agent-ops-slack-notifications/route.test.ts app/api/admin/agents/slack-notifications/route.test.ts`
- `npm run build:knowledge`
- `npx tsc --noEmit --pretty false`
- `npm run lint`

## Integration Notes
- Conflict preflight found active Standup Room work in PR #436; this PR intentionally avoids `lib/agent-war-room.ts` and Standup UI files.
- Delivery still uses the existing notification sweep and dedupe windows; no new Slack app config, production send, credential change, customer-data mutation, n8n activation, or outbound workflow execution was performed.
- Vercel contexts to verify after merge: `Vercel – portfolio` and `Vercel – portfolio-staging`.
