### PR TITLE
docs: add pixel mirror command

### DIFF
--- a/commands/pixelmirror.md
+++ b/commands/pixelmirror.md
@@ -1,0 +1,129 @@
+# Pixel Mirror Command
+
+Use this command when Vambah asks to mirror, open, cast, inspect, or validate something on his Google Pixel from this Mac.
+
+## Command
+
+`/pixelmirror`
+
+## Aliases
+
+- `pixelmirror`
+- `pixel mirror`
+- `mirror pixel`
+- `open pixel`
+- `validate on mobile`
+- `run mobile Slack validation`
+
+## Objective
+
+Bring the Pixel into a known-good mobile validation state with the least possible friction:
+
+- reconnect a previously paired Pixel through ADB,
+- open a visible `scrcpy` mirror for Vambah when useful,
+- use ADB for screenshots and targeted actions,
+- avoid relying on Computer Use to control the `scrcpy` window,
+- ask Vambah for only the current Wireless debugging `IP address & Port` when the Pixel is not visible.
+
+## Start Gate
+
+Run a status check first:
+
+```bash
+bash /Users/vambahsillah/Projects/Portfolio/scripts/pixel-control.sh status
+```
+
+Classify the result:
+
+- If a device is connected, proceed with the requested validation.
+- If a cached endpoint exists but no device is connected, try:
+
+  ```bash
+  bash /Users/vambahsillah/Projects/Portfolio/scripts/pixel-control.sh connect "$(cat ~/.codex/pixel-adb-endpoint)"
+  ```
+
+- If no Pixel is visible, give Vambah the exact phone steps in the blocker section below.
+
+## Mirror Flow
+
+For a user-visible mirror, hand the long-running `scrcpy` process to Terminal:
+
+```bash
+osascript -e 'tell application "Terminal" to do script "bash /Users/vambahsillah/Projects/Portfolio/scripts/pixel-control.sh mirror"'
+```
+
+Do not keep the agent turn blocked on `scrcpy`.
+
+## Agent Control Flow
+
+Prefer ADB commands for functional validation:
+
+```bash
+bash /Users/vambahsillah/Projects/Portfolio/scripts/pixel-control.sh screenshot /tmp/pixel-screen.png
+bash /Users/vambahsillah/Projects/Portfolio/scripts/pixel-control.sh open-slack
+bash /Users/vambahsillah/Projects/Portfolio/scripts/pixel-control.sh tap 540 1480
+bash /Users/vambahsillah/Projects/Portfolio/scripts/pixel-control.sh text "/agent help"
+```
+
+Use screenshots as the source of truth for what the phone is displaying. If a screenshot contains private content outside the requested validation area, summarize only the relevant state.
+
+## Slack Validation Pattern
+
+When validating Agent Ops in Slack mobile:
+
+1. Open Slack on the Pixel:
+
+   ```bash
+   bash /Users/vambahsillah/Projects/Portfolio/scripts/pixel-control.sh open-slack
+   ```
+
+2. Capture a screenshot:
+
+   ```bash
+   bash /Users/vambahsillah/Projects/Portfolio/scripts/pixel-control.sh screenshot /tmp/pixel-slack.png
+   ```
+
+3. Confirm the workspace and destination before assuming command failure.
+4. Use the relevant command:
+
+   - staging: `/agent-staging help`
+   - production: `/agent help`
+
+5. Verify whether the response is ephemeral, threaded, in-channel, or absent.
+6. If no visible message appears, inspect server logs before asking Vambah to retry.
+
+## Blocker Instructions For Vambah
+
+If ADB cannot see the Pixel, give these steps:
+
+1. On the Pixel, open **Settings -> System -> Developer options -> Wireless debugging**.
+2. Make sure **Wireless debugging** is on.
+3. Copy the value labeled **IP address & Port**. Do not use the temporary pairing port.
+4. Send back only that `PHONE_IP:CONNECT_PORT` value.
+
+Then run:
+
+```bash
+bash /Users/vambahsillah/Projects/Portfolio/scripts/pixel-control.sh connect PHONE_IP:CONNECT_PORT
+```
+
+If the IP starts with `100.`, ask Vambah to turn off Tailscale/VPN on the phone and Mac, then use the normal Wi-Fi IP.
+
+## Safety Rules
+
+- Do not browse unrelated personal phone content.
+- Do not read private notifications unless they are part of the requested validation.
+- Do not send Slack messages, approve work, or trigger external actions from the phone unless Vambah explicitly approves that exact action.
+- For Slack Agent Ops validation, stay in the requested workspace and channel or DM.
+- If an action could mutate production state, stop and ask for explicit approval.
+
+## Report Format
+
+Return:
+
+- Pixel connection status,
+- mirror status,
+- validation action performed,
+- screenshot path if captured,
+- observed mobile result,
+- any blocker and the exact next step.

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -20,6 +20,8 @@ The goal is simple: workers can keep moving, but only one integration captain me
 
 Use `captain sweep` when Vambah wants the integration captain to inspect repo state, process ready PRs, verify GitHub/Vercel gates, and clean up conservatively. The command spec lives at `commands/captain-sweep.md`.
 
+Use `/pixelmirror` when Vambah wants the Google Pixel mirrored or used for mobile validation. The command spec lives at `commands/pixelmirror.md` and the helper script is `scripts/pixel-control.sh`.
+
 For non-docs PRs, `captain sweep` now uses a repeatable multi-agent review gate before merge consideration. The Integration Captain keeps merge authority, but parallel read-only reviewers split scope/risk review, validation planning, and Agent Coordination audit so PRs are not merged from a single-thread judgment call.
 
 ## Roles

--- a/docs/pixel-wireless-screen-mirroring.md
+++ b/docs/pixel-wireless-screen-mirroring.md
@@ -116,47 +116,87 @@ adb connect 192.168.4.26:43343
 scrcpy -s 192.168.4.26:43343
 ```
 
+Or use the Portfolio command helper, which caches the current endpoint in `~/.codex/pixel-adb-endpoint`:
+
+```bash
+bash /Users/vambahsillah/Projects/Portfolio/scripts/pixel-control.sh connect 192.168.4.26:43343
+bash /Users/vambahsillah/Projects/Portfolio/scripts/pixel-control.sh mirror
+```
+
+## Official Agent Command
+
+The official command spec lives at:
+
+```bash
+/Users/vambahsillah/Projects/Portfolio/commands/pixelmirror.md
+```
+
+Use `/pixelmirror` when Vambah asks to mirror the Pixel, inspect mobile Slack, or validate a mobile-only flow. The command starts with a status check:
+
+```bash
+bash /Users/vambahsillah/Projects/Portfolio/scripts/pixel-control.sh status
+```
+
+If the Pixel is connected, use ADB for validation actions and screenshots:
+
+```bash
+bash /Users/vambahsillah/Projects/Portfolio/scripts/pixel-control.sh open-slack
+bash /Users/vambahsillah/Projects/Portfolio/scripts/pixel-control.sh screenshot /tmp/pixel-screen.png
+```
+
+Use `scrcpy` primarily as a visible mirror for Vambah, not as the control surface for the agent.
+
 ## Agent Activation Rule
 
 Use this rule in project or global agent instructions:
 
 ```text
-When Vambah asks to mirror, open, cast, or control his Google Pixel from this Mac, run:
+When Vambah asks to mirror, open, cast, inspect, or validate his Google Pixel from this Mac, treat it as `/pixelmirror` and run:
 
-  osascript -e 'tell application "Terminal" to do script "bash /Users/vambahsillah/Projects/Portfolio/scripts/mirror-pixel.sh"'
+  bash /Users/vambahsillah/Projects/Portfolio/scripts/pixel-control.sh status
 
-This hands the long-running scrcpy process to Terminal so the agent session can finish cleanly. Do not walk through the full setup unless the script fails. If ADB cannot see the Pixel, ask Vambah to turn on Pixel Wireless debugging and provide the current IP address & Port from Settings -> System -> Developer options -> Wireless debugging. If pairing fails or the IP starts with 100.x.x.x, have Vambah disable Tailscale/VPN and use the normal Wi-Fi IP.
+If a visible mirror is needed, hand the long-running scrcpy process to Terminal:
+
+  osascript -e 'tell application "Terminal" to do script "bash /Users/vambahsillah/Projects/Portfolio/scripts/pixel-control.sh mirror"'
+
+For functional validation, use ADB commands and screenshots through `scripts/pixel-control.sh` instead of trying to control the scrcpy window with Computer Use. Do not walk through the full setup unless the script fails. If ADB cannot see the Pixel, ask Vambah to turn on Pixel Wireless debugging and provide the current IP address & Port from Settings -> System -> Developer options -> Wireless debugging. If pairing fails or the IP starts with 100.x.x.x, have Vambah disable Tailscale/VPN and use the normal Wi-Fi IP.
 ```
 
 ## Scripted Agent Flow
 
-The helper script lives at:
+The mirror helper lives at:
 
 ```bash
 /Users/vambahsillah/Projects/Portfolio/scripts/mirror-pixel.sh
 ```
 
+The control helper lives at:
+
+```bash
+/Users/vambahsillah/Projects/Portfolio/scripts/pixel-control.sh
+```
+
 Default command:
 
 ```bash
-bash /Users/vambahsillah/Projects/Portfolio/scripts/mirror-pixel.sh
+bash /Users/vambahsillah/Projects/Portfolio/scripts/pixel-control.sh mirror
 ```
 
 Agent-safe Terminal handoff:
 
 ```bash
-osascript -e 'tell application "Terminal" to do script "bash /Users/vambahsillah/Projects/Portfolio/scripts/mirror-pixel.sh"'
+osascript -e 'tell application "Terminal" to do script "bash /Users/vambahsillah/Projects/Portfolio/scripts/pixel-control.sh mirror"'
 ```
 
 If the wireless debugging port changes, reconnect first:
 
 ```bash
-adb connect PHONE_IP:CONNECT_PORT
-osascript -e 'tell application "Terminal" to do script "bash /Users/vambahsillah/Projects/Portfolio/scripts/mirror-pixel.sh"'
+bash /Users/vambahsillah/Projects/Portfolio/scripts/pixel-control.sh connect PHONE_IP:CONNECT_PORT
+osascript -e 'tell application "Terminal" to do script "bash /Users/vambahsillah/Projects/Portfolio/scripts/pixel-control.sh mirror"'
 ```
 
 To pin a known endpoint for a single run:
 
 ```bash
-osascript -e 'tell application "Terminal" to do script "PIXEL_ADB_ENDPOINT=192.168.4.26:43343 bash /Users/vambahsillah/Projects/Portfolio/scripts/mirror-pixel.sh"'
+osascript -e 'tell application "Terminal" to do script "PIXEL_ADB_ENDPOINT=192.168.4.26:43343 bash /Users/vambahsillah/Projects/Portfolio/scripts/pixel-control.sh mirror"'
 ```

--- a/scripts/mirror-pixel.sh
+++ b/scripts/mirror-pixel.sh
@@ -10,10 +10,12 @@ Usage:
 
 Optional environment:
   PIXEL_ADB_ENDPOINT=192.168.4.26:43343
+  PIXEL_ADB_ENDPOINT_FILE=/Users/vambahsillah/.codex/pixel-adb-endpoint
   PIXEL_ADB_SERIAL=adb-..._adb-tls-connect._tcp
 
 If no endpoint or serial is provided, the script selects a connected ADB device,
-preferring a normal IP:port serial when duplicate mDNS entries exist.
+preferring a normal IP:port serial when duplicate mDNS entries exist. If a
+cached endpoint exists, the script reconnects it before selecting a device.
 USAGE
 }
 
@@ -31,8 +33,13 @@ for command in adb scrcpy; do
 done
 
 scrcpy_bin="$(command -v scrcpy)"
+endpoint_file="${PIXEL_ADB_ENDPOINT_FILE:-$HOME/.codex/pixel-adb-endpoint}"
 
 adb start-server >/dev/null
+
+if [[ -z "${PIXEL_ADB_ENDPOINT:-}" && -f "$endpoint_file" ]]; then
+  PIXEL_ADB_ENDPOINT="$(tr -d '[:space:]' < "$endpoint_file")"
+fi
 
 if [[ -n "${PIXEL_ADB_ENDPOINT:-}" ]]; then
   adb connect "$PIXEL_ADB_ENDPOINT" >/dev/null || true
@@ -82,6 +89,11 @@ Then run:
 Avoid Tailscale/VPN 100.x.x.x addresses for pairing. Use the normal Wi-Fi IP.
 ERROR
   exit 1
+fi
+
+if [[ "$target" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+:[0-9]+$ ]]; then
+  mkdir -p "$(dirname "$endpoint_file")"
+  printf '%s\n' "$target" > "$endpoint_file"
 fi
 
 echo "Starting Pixel mirror with ADB target: $target"

--- a/scripts/pixel-control.sh
+++ b/scripts/pixel-control.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+endpoint_file="${PIXEL_ADB_ENDPOINT_FILE:-$HOME/.codex/pixel-adb-endpoint}"
+
+usage() {
+  cat <<'USAGE'
+Control the paired Google Pixel through ADB for mobile validation.
+
+Usage:
+  scripts/pixel-control.sh status
+  scripts/pixel-control.sh connect PHONE_IP:CONNECT_PORT
+  scripts/pixel-control.sh mirror [scrcpy args...]
+  scripts/pixel-control.sh screenshot [output.png]
+  scripts/pixel-control.sh open-slack
+  scripts/pixel-control.sh tap X Y
+  scripts/pixel-control.sh text "message"
+
+Notes:
+  - mirror launches scrcpy through scripts/mirror-pixel.sh.
+  - screenshot/open-slack/tap/text use ADB directly and do not require Computer Use.
+  - connect stores the latest endpoint in ~/.codex/pixel-adb-endpoint.
+USAGE
+}
+
+require_adb() {
+  if ! command -v adb >/dev/null 2>&1; then
+    echo "Missing required command: adb" >&2
+    echo "Install with: brew install android-platform-tools" >&2
+    exit 1
+  fi
+}
+
+require_scrcpy() {
+  if ! command -v scrcpy >/dev/null 2>&1; then
+    echo "Missing required command: scrcpy" >&2
+    echo "Install with: brew install scrcpy" >&2
+    exit 1
+  fi
+}
+
+read_cached_endpoint() {
+  if [[ -f "$endpoint_file" ]]; then
+    tr -d '[:space:]' < "$endpoint_file"
+  fi
+  return 0
+}
+
+cache_endpoint() {
+  local endpoint="$1"
+  mkdir -p "$(dirname "$endpoint_file")"
+  printf '%s\n' "$endpoint" > "$endpoint_file"
+}
+
+connect_endpoint() {
+  local endpoint="$1"
+  if [[ -z "$endpoint" ]]; then
+    return 0
+  fi
+  adb connect "$endpoint" >/dev/null || true
+}
+
+connected_devices() {
+  adb devices | awk 'NR > 1 && $2 == "device" { print $1 }'
+}
+
+select_device() {
+  local serial="${PIXEL_ADB_SERIAL:-}"
+  if [[ -n "$serial" ]]; then
+    printf '%s\n' "$serial"
+    return 0
+  fi
+
+  local devices=()
+  while IFS= read -r device; do
+    [[ -n "$device" ]] && devices+=("$device")
+  done < <(connected_devices)
+
+  if [[ "${#devices[@]}" -eq 0 ]]; then
+    return 1
+  fi
+
+  for device in "${devices[@]}"; do
+    if [[ "$device" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+:[0-9]+$ ]]; then
+      printf '%s\n' "$device"
+      return 0
+    fi
+  done
+
+  printf '%s\n' "${devices[0]}"
+}
+
+ensure_device() {
+  require_adb
+  adb start-server >/dev/null
+
+  if [[ -n "${PIXEL_ADB_ENDPOINT:-}" ]]; then
+    connect_endpoint "$PIXEL_ADB_ENDPOINT"
+  else
+    connect_endpoint "$(read_cached_endpoint)"
+  fi
+
+  local serial
+  if ! serial="$(select_device)"; then
+    cat >&2 <<'ERROR'
+No paired Pixel is currently visible to ADB.
+
+On the Pixel:
+  1. Open Settings -> System -> Developer options -> Wireless debugging.
+  2. Make sure Wireless debugging is on.
+  3. Copy the current IP address & Port.
+
+Then run:
+  scripts/pixel-control.sh connect PHONE_IP:CONNECT_PORT
+  scripts/pixel-control.sh mirror
+
+Use the normal Wi-Fi IP. Avoid Tailscale/VPN 100.x.x.x addresses.
+ERROR
+    exit 1
+  fi
+
+  if [[ "$serial" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+:[0-9]+$ ]]; then
+    cache_endpoint "$serial"
+  fi
+
+  printf '%s\n' "$serial"
+}
+
+status() {
+  require_adb
+  adb start-server >/dev/null
+
+  local cached
+  cached="$(read_cached_endpoint || true)"
+  if [[ -n "$cached" ]]; then
+    connect_endpoint "$cached"
+  fi
+
+  echo "ADB: $(command -v adb)"
+  if command -v scrcpy >/dev/null 2>&1; then
+    echo "scrcpy: $(command -v scrcpy)"
+  else
+    echo "scrcpy: missing"
+  fi
+
+  if [[ -n "$cached" ]]; then
+    echo "cached endpoint: $cached"
+  else
+    echo "cached endpoint: none"
+  fi
+
+  echo
+  echo "Connected devices:"
+  adb devices -l
+
+  echo
+  echo "Discovered wireless ADB services:"
+  adb mdns services || true
+}
+
+case "${1:-status}" in
+  -h|--help|help)
+    usage
+    ;;
+  status)
+    status
+    ;;
+  connect)
+    require_adb
+    endpoint="${2:-}"
+    if [[ -z "$endpoint" ]]; then
+      echo "Missing endpoint. Usage: scripts/pixel-control.sh connect PHONE_IP:CONNECT_PORT" >&2
+      exit 1
+    fi
+    adb start-server >/dev/null
+    adb connect "$endpoint"
+    cache_endpoint "$endpoint"
+    echo "Cached Pixel endpoint: $endpoint"
+    ;;
+  mirror)
+    require_scrcpy
+    shift
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    exec "$script_dir/mirror-pixel.sh" "$@"
+    ;;
+  screenshot)
+    serial="$(ensure_device)"
+    output="${2:-/tmp/pixel-screen.png}"
+    adb -s "$serial" exec-out screencap -p > "$output"
+    echo "Saved Pixel screenshot: $output"
+    ;;
+  open-slack)
+    serial="$(ensure_device)"
+    adb -s "$serial" shell monkey -p com.Slack 1 >/dev/null
+    echo "Opened Slack on Pixel target: $serial"
+    ;;
+  tap)
+    serial="$(ensure_device)"
+    x="${2:-}"
+    y="${3:-}"
+    if [[ -z "$x" || -z "$y" ]]; then
+      echo "Missing coordinates. Usage: scripts/pixel-control.sh tap X Y" >&2
+      exit 1
+    fi
+    adb -s "$serial" shell input tap "$x" "$y"
+    ;;
+  text)
+    serial="$(ensure_device)"
+    shift
+    text="${*:-}"
+    if [[ -z "$text" ]]; then
+      echo "Missing text. Usage: scripts/pixel-control.sh text \"message\"" >&2
+      exit 1
+    fi
+    escaped="${text// /%s}"
+    adb -s "$serial" shell input text "$escaped"
+    ;;
+  *)
+    echo "Unknown command: $1" >&2
+    usage >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- adds an official `/pixelmirror` command spec for Pixel mirroring and mobile validation
- adds `scripts/pixel-control.sh` for ADB-based status, reconnect, screenshots, Slack launch, tap, and text helpers
- updates the Pixel mirroring runbook and agent command index to use the new helper and cached endpoint

## Validation
- `bash -n scripts/pixel-control.sh scripts/mirror-pixel.sh`
- `bash scripts/pixel-control.sh status`
- `bash scripts/pixel-control.sh help`
- `bash scripts/mirror-pixel.sh --help`
- `git diff --check`
- No live Pixel action was run because no ADB device is currently connected. The no-device path was exercised and returned the expected setup steps.

## Integration Notes
- Conflict preflight: root checkout has unrelated dirty digest/subscription work; implementation used isolated worktree `/Users/vambahsillah/Projects/Portfolio.worktrees/pixelmirror-command`.
- Environment bootstrap: `npm run worktree:env -- --source /Users/vambahsillah/Projects/Portfolio` was attempted, but this docs/script worktree lacks installed dependencies and failed on missing `tsx`; no dev server or app env was needed for this change.
- Vercel contexts: not checked; docs/script-only change with no app build or deployment behavior expected.
