### PR TITLE
feat: route automation digests to agent backlog

### DIFF
--- a/docs/automation-digest-agent-ops-backlog-fixtures/2026-05-28-expected-actions.json
+++ b/docs/automation-digest-agent-ops-backlog-fixtures/2026-05-28-expected-actions.json
@@ -1,0 +1,44 @@
+{
+  "digest_date": "2026-05-28",
+  "channel": {
+    "name": "#agent-ops",
+    "id": "C0B1MM4LQKB"
+  },
+  "expected_actions": [
+    {
+      "title": "Prepare n8n drift access repair preflight",
+      "category": "blocked_until_access",
+      "owner_agent_key": "automation-systems",
+      "priority": "high",
+      "creates_work_item": true
+    },
+    {
+      "title": "Prepare authenticated Portfolio admin QA checklist",
+      "category": "blocked_until_access",
+      "owner_agent_key": "chief-of-staff",
+      "priority": "high",
+      "creates_work_item": true
+    },
+    {
+      "title": "Draft Codex thread-root repair decision packet",
+      "category": "needs_vambah_approval",
+      "owner_agent_key": "chief-of-staff",
+      "priority": "medium",
+      "creates_work_item": true
+    },
+    {
+      "title": "Prepare quiet-provider billing verification packet",
+      "category": "agent_can_prepare",
+      "owner_agent_key": "automation-systems",
+      "priority": "medium",
+      "creates_work_item": true
+    },
+    {
+      "title": "Personality corpus reports unchanged",
+      "category": "watch_only",
+      "owner_agent_key": null,
+      "priority": "low",
+      "creates_work_item": false
+    }
+  ]
+}

--- a/docs/automation-digest-agent-ops-backlog-fixtures/2026-05-28-synthetic-actions-summary.json
+++ b/docs/automation-digest-agent-ops-backlog-fixtures/2026-05-28-synthetic-actions-summary.json
@@ -1,0 +1,30 @@
+{
+  "automation_id": "portfolio-operations-manager",
+  "automation_name": "Portfolio Operations Manager",
+  "ran_at_utc": "2026-05-28T13:05:00Z",
+  "status": "yellow",
+  "headline": "Portfolio health green except operations follow-up",
+  "summary": "Checks passed, but n8n drift visibility still returns 403 and several safe follow-up packets need preparation.",
+  "material_findings": [
+    "n8n drift check still returns 403 for all tracked workflow pairs.",
+    "Authenticated admin context is needed for /api/admin/rag-health, Playwright smoke, and the unevaluated production chat review.",
+    "Thread-root state repair remains approval-gated and must start with a backup-first decision packet.",
+    "Quiet providers and auth-blocked vendors still need dashboard billing verification before any cancellation decision."
+  ],
+  "changed_files_or_links": [
+    "docs/subscription-cancellation-audit.md",
+    "docs/subscription-status.json"
+  ],
+  "blockers_or_approvals": [
+    "Approval needed to refresh or re-scope n8n API credentials for drift visibility.",
+    "Authenticated admin context is required before protected admin checks.",
+    "No subscription cancellation approval phrase was present."
+  ],
+  "next_run_focus": [
+    "Prepare the n8n drift access preflight.",
+    "Prepare the authenticated admin QA checklist.",
+    "Draft the Codex thread-root repair decision packet.",
+    "Prepare quiet-provider dashboard billing verification."
+  ],
+  "codex_thread_hint": "Use Integration Captain if the follow-up becomes a PR, merge, or deployment task."
+}

--- a/docs/automation-digest-agent-ops-backlog-fixtures/2026-05-28-synthetic-watch-summary.json
+++ b/docs/automation-digest-agent-ops-backlog-fixtures/2026-05-28-synthetic-watch-summary.json
@@ -1,0 +1,15 @@
+{
+  "automation_id": "personality-corpus-report-monitor",
+  "automation_name": "Personality Corpus Report Monitor",
+  "ran_at_utc": "2026-05-28T13:10:00Z",
+  "status": "no_change",
+  "headline": "Personality corpus reports unchanged",
+  "summary": "The corpus snapshot still has no diffs, errors, or active alerts.",
+  "material_findings": [],
+  "changed_files_or_links": [],
+  "blockers_or_approvals": [],
+  "next_run_focus": [
+    "Watch for a new refresh snapshot."
+  ],
+  "codex_thread_hint": "No Agent Ops work item should be created unless the next digest shows material movement."
+}

--- a/docs/automation-digest-agent-ops-backlog.md
+++ b/docs/automation-digest-agent-ops-backlog.md
@@ -1,0 +1,89 @@
+# Automation Digest To Agent Ops Backlog
+
+## Contract
+
+The Codex automation digest has three outputs:
+
+1. Private executive digest to `vsillah@gmail.com` and the private Slack DM.
+2. Sanitized action summary to `#agent-ops` (`C0B1MM4LQKB`).
+3. Proposed Agent Ops work items for actionable decisions and follow-up work.
+
+The private digest remains the full context surface. `#agent-ops` and work-item
+objectives get only sanitized titles, owner/routing, urgency, safe follow-up
+prompts, and safe Portfolio links.
+
+## Action Categories
+
+- `needs_vambah_approval`: a decision packet or explicit approval is needed before mutation.
+- `agent_can_prepare`: an agent can prepare a packet, checklist, audit, or preflight without changing external systems.
+- `blocked_until_access`: an agent can prepare, but execution waits on credentials, admin context, or provider access.
+- `watch_only`: no work item should be created; the signal exists only for digest continuity.
+
+## Work Item Rules
+
+- Work items use `source_type: codex_automation_digest`.
+- Work items are created as `status: proposed`.
+- The idempotency key format is:
+  `codex_automation_digest:<digest-date>:<automation-id>:<category>:<hash>`.
+- Metadata must include the digest date, automation id/name, category, safe
+  prompt, source summary path, `privacy_boundary: sanitized_action_only`, and
+  `requires_explicit_approval_for_mutation: true`.
+- Work items do not approve credential rotation, billing cancellation, provider
+  mutation, production config changes, external sends, repo merge, or deployment.
+
+## Routing Defaults
+
+- Shaka / `chief-of-staff`: approval routing, ambiguous decisions, admin context requests.
+- `automation-systems`: n8n, credentials, provider checks, billing packets, automation fixes.
+- `integration-captain`: PR, merge, deployment, and captain queue coordination.
+- Unassigned: items that need human triage before routing.
+
+## 2026-05-28 Review Fixture
+
+The expected-actions fixture lives at
+`docs/automation-digest-agent-ops-backlog-fixtures/2026-05-28-expected-actions.json`
+and captures the expected dry-run actions from the May 28 digest summaries:
+
+- Prepare n8n drift access repair preflight.
+- Prepare authenticated Portfolio admin QA checklist.
+- Draft Codex thread-root repair decision packet.
+- Prepare quiet-provider billing verification packet.
+- Keep personality corpus no-change as watch-only.
+
+The CLI validation fixtures are sanitized synthetic digest summaries:
+
+- `docs/automation-digest-agent-ops-backlog-fixtures/2026-05-28-synthetic-actions-summary.json`
+- `docs/automation-digest-agent-ops-backlog-fixtures/2026-05-28-synthetic-watch-summary.json`
+
+Dry-run validation:
+
+```bash
+npm run automation:digest-actions -- \
+  --summary-file docs/automation-digest-agent-ops-backlog-fixtures/2026-05-28-synthetic-actions-summary.json \
+  --summary-file docs/automation-digest-agent-ops-backlog-fixtures/2026-05-28-synthetic-watch-summary.json \
+  --json
+```
+
+## Phase 4 Live Simulation - 2026-05-28
+
+Live simulation used the already-sent 2026-05-28 digest summaries and ran the
+action router in `--apply` mode. The router created or reused four proposed
+Agent Ops work items:
+
+- `766a91eb-e9f1-41f6-913a-d1585bdbabdc` - Draft Codex thread-root repair decision packet.
+- `6cc7ba9d-0024-4ae2-ba55-57c7f2553cd9` - Prepare quiet-provider billing verification packet.
+- `d54729c6-992c-4bc0-b660-703355d481e2` - Prepare n8n drift access repair preflight.
+- `d17fef5a-4c8a-4c60-8bc5-e7c70a8b25b5` - Prepare authenticated Portfolio admin QA checklist.
+
+The sanitized simulation post was sent to `#agent-ops`:
+
+`https://amadutownadvi-3ze6268.slack.com/archives/C0B1MM4LQKB/p1780011824744919`
+
+Slack channel history verified the post is visible in `#agent-ops`. Re-running
+the apply command returned the same work item IDs, confirming idempotent
+create/reuse behavior.
+
+Pixel mobile verification was retried after the paired device reappeared in
+`adb devices -l`. The Pixel 10 Pro Slack window showed `#agent-ops` with the
+sanitized simulation summary and work-item IDs visible on mobile. Evidence:
+`/tmp/pixel-agentops-visible.png`.

--- a/lib/automation-digest-actions.test.ts
+++ b/lib/automation-digest-actions.test.ts
@@ -1,0 +1,169 @@
+import { mkdtemp, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  buildDigestActionsFromFiles,
+  runDigestActionRouting,
+  assertSafeDigestText,
+} from './automation-digest-actions'
+
+async function writeSummary(name: string, summary: Record<string, unknown>) {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'digest-actions-'))
+  const filePath = path.join(dir, name)
+  await writeFile(filePath, JSON.stringify(summary, null, 2))
+  return filePath
+}
+
+const baseSummary = {
+  automation_id: 'portfolio-operations-manager',
+  automation_name: 'Portfolio Operations Manager',
+  ran_at_utc: '2026-05-28T13:05:00Z',
+  status: 'yellow',
+  headline: 'Portfolio health green except n8n visibility',
+  summary: 'Checks passed; n8n drift API still returns 403.',
+  material_findings: [
+    'n8n drift check still returns 403 for all tracked workflow pairs.',
+  ],
+  changed_files_or_links: [],
+  blockers_or_approvals: [
+    'Approval needed to refresh/re-scope n8n API credentials for drift visibility.',
+    'Authenticated admin context needed for /api/admin/rag-health and Playwright smoke.',
+  ],
+  next_run_focus: [
+    'Evaluate the 1 unevaluated production chat session if admin access is available.',
+  ],
+}
+
+describe('automation digest action extraction', () => {
+  it('maps n8n and authenticated-admin blockers to proposed work item actions', async () => {
+    const filePath = await writeSummary('portfolio-ops.json', baseSummary)
+
+    const result = await buildDigestActionsFromFiles({ summaryPaths: [filePath] })
+
+    expect(result.actions).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        category: 'blocked_until_access',
+        title: 'Prepare n8n drift access repair preflight',
+        priority: 'high',
+        ownerAgentKey: 'automation-systems',
+        createWorkItem: true,
+      }),
+      expect.objectContaining({
+        category: 'blocked_until_access',
+        title: 'Prepare authenticated Portfolio admin QA checklist',
+        priority: 'high',
+        ownerAgentKey: 'chief-of-staff',
+        createWorkItem: true,
+      }),
+    ]))
+  })
+
+  it('maps billing dashboard checks and thread-root repair to durable action categories', async () => {
+    const orgPath = await writeSummary('codex-org.json', {
+      ...baseSummary,
+      automation_id: 'codex-project-organization-monitor',
+      automation_name: 'Codex Project Organization Monitor',
+      headline: 'Workspace roots aligned; thread-root drift remains',
+      summary: 'Read-only audit found 25 active non-Portfolio thread roots.',
+      blockers_or_approvals: ['State repair remains approval-gated; monitor stayed read-only.'],
+      next_run_focus: ['If approved, back up Codex state before migrating thread roots.'],
+    })
+    const subscriptionPath = await writeSummary('subscriptions.json', {
+      ...baseSummary,
+      automation_id: 'portfolio-subscription-cancellation-monitor',
+      automation_name: 'Portfolio Subscription Cancellation Monitor',
+      headline: 'Subscription watch refreshed; no cancellation approval needed',
+      summary: 'Active core services moved; quiet providers remain investigation-only.',
+      blockers_or_approvals: [
+        'No cancellation approval phrase was present.',
+        'Dashboard checks still needed for Vapi, Printful, Resend, Pinecone, ElevenLabs, Calendly, and Gemini.',
+      ],
+      next_run_focus: ['Verify dashboard billing for quiet or auth-blocked vendors.'],
+    })
+
+    const result = await buildDigestActionsFromFiles({ summaryPaths: [orgPath, subscriptionPath] })
+
+    expect(result.actions).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        category: 'needs_vambah_approval',
+        title: 'Draft Codex thread-root repair decision packet',
+      }),
+      expect.objectContaining({
+        category: 'agent_can_prepare',
+        title: 'Prepare quiet-provider billing verification packet',
+      }),
+    ]))
+  })
+
+  it('keeps no-change corpus summaries watch-only and out of work item creation', async () => {
+    const filePath = await writeSummary('corpus.json', {
+      ...baseSummary,
+      automation_id: 'personality-corpus-report-monitor',
+      automation_name: 'Personality Corpus Report Monitor',
+      status: 'no_change',
+      headline: 'Personality corpus reports unchanged',
+      summary: 'May 3 corpus snapshot still has no diffs, errors, or active alerts.',
+      material_findings: [],
+      blockers_or_approvals: [],
+      next_run_focus: ['Watch for a new refresh snapshot.'],
+    })
+
+    const result = await runDigestActionRouting({ summaryPaths: [filePath], apply: false })
+
+    expect(result.workItemCount).toBe(0)
+    expect(result.watchOnlyCount).toBe(1)
+    expect(result.results[0]).toEqual(expect.objectContaining({
+      status: 'watch_only',
+      workItemId: null,
+    }))
+  })
+
+  it('uses deterministic idempotency keys when applying work items', async () => {
+    const filePath = await writeSummary('portfolio-ops.json', baseSummary)
+    const createWorkItem = vi.fn(async (input) => ({ id: `wi-${String(input.idempotencyKey).slice(-4)}` }))
+
+    const first = await runDigestActionRouting({ summaryPaths: [filePath], apply: true, createWorkItem })
+    const second = await runDigestActionRouting({ summaryPaths: [filePath], apply: true, createWorkItem })
+
+    expect(first.results.map((result) => result.action.key)).toEqual(second.results.map((result) => result.action.key))
+    expect(createWorkItem).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'proposed',
+      source: expect.objectContaining({ type: 'codex_automation_digest' }),
+      idempotencyKey: expect.stringMatching(/^codex_automation_digest:2026-05-28:/),
+      metadata: expect.objectContaining({
+        automation_digest_action: true,
+        privacy_boundary: 'sanitized_action_only',
+      }),
+    }))
+  })
+
+  it('keeps the checked-in synthetic digest fixtures aligned with expected actions', async () => {
+    const fixtureDir = path.resolve(process.cwd(), 'docs/automation-digest-agent-ops-backlog-fixtures')
+    const result = await runDigestActionRouting({
+      summaryPaths: [
+        path.join(fixtureDir, '2026-05-28-synthetic-actions-summary.json'),
+        path.join(fixtureDir, '2026-05-28-synthetic-watch-summary.json'),
+      ],
+      apply: false,
+    })
+
+    expect(result.digestDate).toBe('2026-05-28')
+    expect(result.summaryCount).toBe(2)
+    expect(result.workItemCount).toBe(4)
+    expect(result.watchOnlyCount).toBe(1)
+    expect(result.results.map((item) => item.action.title)).toEqual(expect.arrayContaining([
+      'Prepare n8n drift access repair preflight',
+      'Prepare authenticated Portfolio admin QA checklist',
+      'Draft Codex thread-root repair decision packet',
+      'Prepare quiet-provider billing verification packet',
+      'Personality corpus reports unchanged',
+    ]))
+  })
+
+  it('rejects secret-looking values before Slack or work-item routing', () => {
+    expect(() => assertSafeDigestText('token = sk-1234567890abcdef1234567890abcdef', 'test')).toThrow(
+      /Unsafe automation digest content/,
+    )
+  })
+})

--- a/lib/automation-digest-actions.ts
+++ b/lib/automation-digest-actions.ts
@@ -1,0 +1,444 @@
+import { createHash } from 'node:crypto'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import type { CreateAgentWorkItemInput, AgentWorkItem } from '@/lib/agent-work-items'
+
+export const DIGEST_ACTION_SOURCE_TYPE = 'codex_automation_digest'
+export const AGENT_OPS_CHANNEL_ID = 'C0B1MM4LQKB'
+export const AGENT_OPS_CHANNEL_NAME = '#agent-ops'
+
+export const DIGEST_ACTION_CATEGORIES = [
+  'needs_vambah_approval',
+  'agent_can_prepare',
+  'blocked_until_access',
+  'watch_only',
+] as const
+
+export type DigestActionCategory = (typeof DIGEST_ACTION_CATEGORIES)[number]
+
+export type AutomationDigestSummary = {
+  automation_id: string
+  automation_name: string
+  ran_at_utc: string
+  status: 'green' | 'yellow' | 'red' | 'failed' | 'interrupted' | 'no_change'
+  headline: string
+  summary: string
+  material_findings: string[]
+  changed_files_or_links: string[]
+  blockers_or_approvals: string[]
+  next_run_focus: string[]
+  codex_thread_hint?: string
+}
+
+export type DigestAction = {
+  key: string
+  category: DigestActionCategory
+  title: string
+  objective: string
+  priority: 'low' | 'medium' | 'high' | 'urgent'
+  ownerAgentKey: string | null
+  ownerRuntime: 'codex' | 'n8n' | 'hermes' | 'opencode' | 'manual'
+  automationId: string
+  automationName: string
+  digestDate: string
+  sourcePath: string
+  safePrompt: string
+  createWorkItem: boolean
+}
+
+export type DigestActionResult = {
+  action: DigestAction
+  status: 'watch_only' | 'would_create_or_reuse' | 'created_or_reused'
+  workItemId: string | null
+}
+
+export type DigestActionRunResult = {
+  digestDate: string
+  applied: boolean
+  summaryCount: number
+  actionCount: number
+  workItemCount: number
+  watchOnlyCount: number
+  results: DigestActionResult[]
+  slackMessage: string
+}
+
+type CreateWorkItem = (input: CreateAgentWorkItemInput) => Promise<Pick<AgentWorkItem, 'id'>>
+
+const REQUIRED_KEYS = [
+  'automation_id',
+  'automation_name',
+  'ran_at_utc',
+  'status',
+  'headline',
+  'summary',
+  'material_findings',
+  'changed_files_or_links',
+  'blockers_or_approvals',
+  'next_run_focus',
+] as const
+
+const SECRET_VALUE_PATTERNS = [
+  /\b(?:api[_-]?key|token|secret|password|credential|authorization)\b\s*[:=]\s*["']?[A-Za-z0-9_./+=-]{12,}/i,
+  /\bBearer\s+[A-Za-z0-9_./+=-]{12,}/i,
+  /\bsk-[A-Za-z0-9]{16,}/i,
+  /\bxox[baprs]-[A-Za-z0-9-]{16,}/i,
+  /-----BEGIN\s+(?:RSA\s+)?PRIVATE\s+KEY-----/i,
+]
+
+function assertArray(value: unknown, key: string): asserts value is string[] {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    throw new Error(`Invalid automation digest summary: ${key} must be an array of strings.`)
+  }
+}
+
+export function assertSafeDigestText(value: string, context: string) {
+  for (const pattern of SECRET_VALUE_PATTERNS) {
+    if (pattern.test(value)) {
+      throw new Error(`Unsafe automation digest content in ${context}. Refusing to route to Agent Ops.`)
+    }
+  }
+}
+
+function sanitizeText(value: string, context: string) {
+  const normalized = value.replace(/\s+/g, ' ').trim()
+  assertSafeDigestText(normalized, context)
+  return normalized
+}
+
+function validateSummary(value: unknown, sourcePath: string): AutomationDigestSummary {
+  if (!value || typeof value !== 'object') {
+    throw new Error(`Invalid automation digest summary in ${sourcePath}: expected object.`)
+  }
+  const record = value as Record<string, unknown>
+  for (const key of REQUIRED_KEYS) {
+    if (!(key in record)) {
+      throw new Error(`Invalid automation digest summary in ${sourcePath}: missing ${key}.`)
+    }
+  }
+  for (const key of ['automation_id', 'automation_name', 'ran_at_utc', 'status', 'headline', 'summary'] as const) {
+    if (typeof record[key] !== 'string') {
+      throw new Error(`Invalid automation digest summary in ${sourcePath}: ${key} must be a string.`)
+    }
+  }
+  assertArray(record.material_findings, 'material_findings')
+  assertArray(record.changed_files_or_links, 'changed_files_or_links')
+  assertArray(record.blockers_or_approvals, 'blockers_or_approvals')
+  assertArray(record.next_run_focus, 'next_run_focus')
+  if (record.codex_thread_hint != null && typeof record.codex_thread_hint !== 'string') {
+    throw new Error(`Invalid automation digest summary in ${sourcePath}: codex_thread_hint must be a string.`)
+  }
+
+  const summary = record as AutomationDigestSummary
+  const allText = [
+    summary.automation_id,
+    summary.automation_name,
+    summary.ran_at_utc,
+    summary.status,
+    summary.headline,
+    summary.summary,
+    ...summary.material_findings,
+    ...summary.changed_files_or_links,
+    ...summary.blockers_or_approvals,
+    ...summary.next_run_focus,
+    summary.codex_thread_hint ?? '',
+  ].join('\n')
+  assertSafeDigestText(allText, sourcePath)
+  return summary
+}
+
+export async function readDigestSummaryFile(sourcePath: string) {
+  const raw = await readFile(sourcePath, 'utf8')
+  return validateSummary(JSON.parse(raw), sourcePath)
+}
+
+function digestDateFromSummary(summary: AutomationDigestSummary) {
+  return summary.ran_at_utc.slice(0, 10)
+}
+
+function hashAction(input: string) {
+  return createHash('sha256').update(input).digest('hex').slice(0, 12)
+}
+
+function normalizeActionKey(value: string) {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim()
+}
+
+function buildAction(input: Omit<DigestAction, 'key'>): DigestAction {
+  const keyInput = [
+    input.digestDate,
+    input.automationId,
+    input.category,
+    normalizeActionKey(input.title),
+    normalizeActionKey(input.objective),
+  ].join(':')
+  return {
+    ...input,
+    key: `${DIGEST_ACTION_SOURCE_TYPE}:${input.digestDate}:${input.automationId}:${input.category}:${hashAction(keyInput)}`,
+  }
+}
+
+function actionFromSummary(summary: AutomationDigestSummary, sourcePath: string, digestDate: string): DigestAction[] {
+  const automationId = sanitizeText(summary.automation_id, `${sourcePath}:automation_id`)
+  const automationName = sanitizeText(summary.automation_name, `${sourcePath}:automation_name`)
+  const text = [
+    summary.headline,
+    summary.summary,
+    ...summary.material_findings,
+    ...summary.blockers_or_approvals,
+    ...summary.next_run_focus,
+  ].map((item, index) => sanitizeText(item, `${sourcePath}:text:${index}`))
+  const combined = text.join('\n').toLowerCase()
+  const actions: DigestAction[] = []
+
+  if (summary.status === 'no_change') {
+    actions.push(buildAction({
+      category: 'watch_only',
+      title: sanitizeText(summary.headline, `${sourcePath}:headline`),
+      objective: sanitizeText(summary.summary, `${sourcePath}:summary`),
+      priority: 'low',
+      ownerAgentKey: null,
+      ownerRuntime: 'manual',
+      automationId,
+      automationName,
+      digestDate,
+      sourcePath,
+      safePrompt: `Codex: review ${automationName} only if the next digest shows material movement.`,
+      createWorkItem: false,
+    }))
+    return actions
+  }
+
+  if (combined.includes('n8n') && (combined.includes('403') || combined.includes('credential') || combined.includes('drift'))) {
+    actions.push(buildAction({
+      category: 'blocked_until_access',
+      title: 'Prepare n8n drift access repair preflight',
+      objective: [
+        'Prepare a non-mutating preflight for restoring scoped n8n drift visibility.',
+        'Do not rotate credentials, change provider settings, or mutate workflows without explicit approval.',
+      ].join(' '),
+      priority: 'high',
+      ownerAgentKey: 'automation-systems',
+      ownerRuntime: 'manual',
+      automationId,
+      automationName,
+      digestDate,
+      sourcePath,
+      safePrompt: 'Codex: run the n8n drift access repair preflight for Portfolio.',
+      createWorkItem: true,
+    }))
+  }
+
+  if (combined.includes('authenticated admin') || combined.includes('/api/admin/rag-health') || combined.includes('playwright smoke') || combined.includes('unevaluated production chat')) {
+    actions.push(buildAction({
+      category: 'blocked_until_access',
+      title: 'Prepare authenticated Portfolio admin QA checklist',
+      objective: [
+        'Prepare the admin QA checklist for RAG health, Playwright smoke, stale Agent Ops review, and unevaluated chat sessions.',
+        'Wait for authenticated admin context before running protected checks.',
+      ].join(' '),
+      priority: 'high',
+      ownerAgentKey: 'chief-of-staff',
+      ownerRuntime: 'manual',
+      automationId,
+      automationName,
+      digestDate,
+      sourcePath,
+      safePrompt: 'Codex: prepare the authenticated admin QA checklist for Portfolio.',
+      createWorkItem: true,
+    }))
+  }
+
+  if (combined.includes('thread-root') || combined.includes('thread roots') || combined.includes('state repair')) {
+    actions.push(buildAction({
+      category: 'needs_vambah_approval',
+      title: 'Draft Codex thread-root repair decision packet',
+      objective: [
+        'Draft a backup-first decision packet for Codex thread-root repair.',
+        'Preserve intentionally separate rotla and Personal chats unless Vambah explicitly approves migration.',
+      ].join(' '),
+      priority: 'medium',
+      ownerAgentKey: 'chief-of-staff',
+      ownerRuntime: 'manual',
+      automationId,
+      automationName,
+      digestDate,
+      sourcePath,
+      safePrompt: 'Codex: audit the Codex thread-root repair decision and propose a backup-first plan.',
+      createWorkItem: true,
+    }))
+  }
+
+  if (combined.includes('dashboard billing') || combined.includes('quiet-provider') || combined.includes('quiet providers') || combined.includes('auth-blocked vendors')) {
+    actions.push(buildAction({
+      category: 'agent_can_prepare',
+      title: 'Prepare quiet-provider billing verification packet',
+      objective: [
+        'Prepare a sanitized billing-dashboard verification packet for quiet or auth-blocked providers.',
+        'Do not cancel subscriptions or change provider settings without the exact approved cancellation phrase.',
+      ].join(' '),
+      priority: 'medium',
+      ownerAgentKey: 'automation-systems',
+      ownerRuntime: 'manual',
+      automationId,
+      automationName,
+      digestDate,
+      sourcePath,
+      safePrompt: 'Codex: prepare the quiet-provider billing verification packet.',
+      createWorkItem: true,
+    }))
+  }
+
+  return dedupeActions(actions)
+}
+
+function dedupeActions(actions: DigestAction[]) {
+  const byKey = new Map<string, DigestAction>()
+  for (const action of actions) {
+    const semanticKey = [
+      action.category,
+      normalizeActionKey(action.title),
+      normalizeActionKey(action.objective),
+    ].join(':')
+    byKey.set(semanticKey, byKey.get(semanticKey) ?? action)
+  }
+  return [...byKey.values()]
+}
+
+export async function buildDigestActionsFromFiles(input: {
+  summaryPaths: string[]
+  digestDate?: string | null
+}) {
+  const summaries = await Promise.all(input.summaryPaths.map(async (sourcePath) => ({
+    sourcePath,
+    summary: await readDigestSummaryFile(sourcePath),
+  })))
+  const digestDate = input.digestDate
+    ?? summaries.map(({ summary }) => digestDateFromSummary(summary)).sort().at(-1)
+    ?? new Date().toISOString().slice(0, 10)
+  const actions = summaries.flatMap(({ sourcePath, summary }) => actionFromSummary(summary, sourcePath, digestDate))
+  return {
+    digestDate,
+    summaryCount: summaries.length,
+    actions: dedupeActions(actions),
+  }
+}
+
+function workItemInputForAction(action: DigestAction): CreateAgentWorkItemInput {
+  return {
+    title: action.title,
+    objective: [
+      action.objective,
+      '',
+      `Safe Codex prompt: ${action.safePrompt}`,
+      'Approval boundary: this proposed work item does not approve credential rotation, billing cancellation, production config changes, external sends, repo merge, deployment, or provider mutation.',
+    ].join('\n'),
+    priority: action.priority,
+    status: 'proposed',
+    ownerAgentKey: action.ownerAgentKey,
+    ownerRuntime: action.ownerRuntime,
+    source: {
+      type: DIGEST_ACTION_SOURCE_TYPE,
+      id: `${action.digestDate}:${action.automationId}`,
+      label: `${action.automationName} digest action`,
+    },
+    overlapGroup: `automation-digest:${action.automationId}`,
+    metadata: {
+      automation_digest_action: true,
+      digest_date: action.digestDate,
+      automation_id: action.automationId,
+      automation_name: action.automationName,
+      category: action.category,
+      safe_prompt: action.safePrompt,
+      source_summary_path: path.resolve(action.sourcePath),
+      agent_ops_channel_id: AGENT_OPS_CHANNEL_ID,
+      privacy_boundary: 'sanitized_action_only',
+      requires_explicit_approval_for_mutation: true,
+    },
+    idempotencyKey: action.key,
+  }
+}
+
+export async function runDigestActionRouting(input: {
+  summaryPaths: string[]
+  digestDate?: string | null
+  apply?: boolean
+  createWorkItem?: CreateWorkItem
+}): Promise<DigestActionRunResult> {
+  const built = await buildDigestActionsFromFiles({
+    summaryPaths: input.summaryPaths,
+    digestDate: input.digestDate,
+  })
+  const apply = Boolean(input.apply)
+  const createWorkItem = input.createWorkItem
+    ?? (apply ? (await import('@/lib/agent-work-items')).createAgentWorkItem : null)
+  const results: DigestActionResult[] = []
+
+  for (const action of built.actions) {
+    if (!action.createWorkItem) {
+      results.push({ action, status: 'watch_only', workItemId: null })
+      continue
+    }
+    if (!apply) {
+      results.push({ action, status: 'would_create_or_reuse', workItemId: null })
+      continue
+    }
+    if (!createWorkItem) throw new Error('createAgentWorkItem unavailable for apply mode.')
+    const workItem = await createWorkItem(workItemInputForAction(action))
+    results.push({ action, status: 'created_or_reused', workItemId: workItem.id })
+  }
+
+  const workItemCount = results.filter((result) => result.action.createWorkItem).length
+  const watchOnlyCount = results.filter((result) => !result.action.createWorkItem).length
+  return {
+    digestDate: built.digestDate,
+    applied: apply,
+    summaryCount: built.summaryCount,
+    actionCount: results.length,
+    workItemCount,
+    watchOnlyCount,
+    results,
+    slackMessage: buildAgentOpsDigestSlackMessage({
+      digestDate: built.digestDate,
+      applied: apply,
+      results,
+    }),
+  }
+}
+
+function categoryLabel(category: DigestActionCategory) {
+  if (category === 'needs_vambah_approval') return 'needs Vambah approval'
+  if (category === 'agent_can_prepare') return 'agent can prepare'
+  if (category === 'blocked_until_access') return 'blocked until access'
+  return 'watch only'
+}
+
+export function buildAgentOpsDigestSlackMessage(input: {
+  digestDate: string
+  applied: boolean
+  results: DigestActionResult[]
+}) {
+  const workItems = input.results.filter((result) => result.action.createWorkItem)
+  const watchOnly = input.results.filter((result) => !result.action.createWorkItem)
+  const verb = input.applied ? 'created/reused' : 'would create/reuse'
+  const lines = [
+    `*Codex automation digest actions - ${input.digestDate}*`,
+    `Private digest stays in email/DM. This channel gets the sanitized Agent Ops backlog only.`,
+    `Work items ${verb}: ${workItems.length}. Watch-only signals: ${watchOnly.length}.`,
+  ]
+  if (workItems.length) {
+    lines.push('', '*Action backlog*')
+    for (const result of workItems.slice(0, 5)) {
+      const id = result.workItemId ? ` - work item \`${result.workItemId}\`` : ''
+      lines.push(`- *${result.action.title}* (${categoryLabel(result.action.category)}, ${result.action.priority})${id}`)
+    }
+  }
+  if (watchOnly.length) {
+    lines.push('', '*Watch-only*')
+    for (const result of watchOnly.slice(0, 3)) {
+      lines.push(`- ${result.action.automationName}: ${result.action.title}`)
+    }
+  }
+  lines.push('', 'Use `/agent work` to review active Agent Ops work items. Sensitive details and approval packets stay in Portfolio/private digest surfaces.')
+  return lines.join('\n')
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
+    "automation:digest-actions": "tsx scripts/automation-digest-actions.ts",
     "n8n:drift-check": "tsx scripts/n8n-workflow-drift-check.ts",
     "n8n:drift-check:warn": "tsx scripts/n8n-workflow-drift-check.ts -- --warn",
     "credentials:list-due": "tsx scripts/credential-broker.ts list-due",

--- a/scripts/automation-digest-actions.ts
+++ b/scripts/automation-digest-actions.ts
@@ -1,0 +1,90 @@
+#!/usr/bin/env tsx
+import { config } from 'dotenv'
+import { existsSync, readdirSync } from 'node:fs'
+import path from 'node:path'
+import { runDigestActionRouting } from '@/lib/automation-digest-actions'
+
+const envPath = process.env.PORTFOLIO_ENV_FILE
+  ?? (existsSync(path.resolve(process.cwd(), '.env.local'))
+    ? path.resolve(process.cwd(), '.env.local')
+    : '/Users/vambahsillah/Projects/Portfolio/.env.local')
+config({ path: envPath, quiet: true })
+
+type Options = {
+  apply: boolean
+  json: boolean
+  digestDate: string | null
+  summaryDir: string
+  summaryPaths: string[]
+}
+
+function valueAfter(argv: string[], flag: string) {
+  const index = argv.indexOf(flag)
+  if (index === -1) return null
+  return argv[index + 1] ?? null
+}
+
+function valuesAfter(argv: string[], flag: string) {
+  const values: string[] = []
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === flag && argv[index + 1]) values.push(argv[index + 1])
+  }
+  return values
+}
+
+function parseArgs(argv: string[]): Options {
+  return {
+    apply: argv.includes('--apply'),
+    json: argv.includes('--json'),
+    digestDate: valueAfter(argv, '--date'),
+    summaryDir: valueAfter(argv, '--summary-dir')
+      ?? '/Users/vambahsillah/.codex/automation-notifications/pending',
+    summaryPaths: valuesAfter(argv, '--summary-file'),
+  }
+}
+
+function summaryPaths(options: Options) {
+  if (options.summaryPaths.length) return options.summaryPaths.map((item) => path.resolve(item)).sort()
+  const dir = path.resolve(options.summaryDir)
+  if (!existsSync(dir)) return []
+  return readdirSync(dir)
+    .filter((entry) => entry.endsWith('.json'))
+    .map((entry) => path.join(dir, entry))
+    .sort()
+}
+
+function printText(result: Awaited<ReturnType<typeof runDigestActionRouting>>) {
+  console.log(result.slackMessage)
+  console.log('')
+  console.log(`Mode: ${result.applied ? 'apply' : 'dry-run'}`)
+  console.log(`Summaries: ${result.summaryCount}`)
+  console.log(`Actions: ${result.actionCount}`)
+  for (const item of result.results) {
+    const suffix = item.workItemId ? ` (${item.workItemId})` : ''
+    console.log(`- ${item.status}: ${item.action.title}${suffix}`)
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  const paths = summaryPaths(options)
+  if (!paths.length) {
+    throw new Error(`No automation digest summary JSON files found in ${options.summaryDir}.`)
+  }
+  const result = await runDigestActionRouting({
+    summaryPaths: paths,
+    digestDate: options.digestDate,
+    apply: options.apply,
+  })
+
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2))
+    return
+  }
+  printText(result)
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- adds a sanitized automation digest action router that turns private digest summaries into proposed Agent Ops work items
- adds an `automation:digest-actions` CLI for dry-run/apply routing from digest summary JSON
- documents the digest-to-#agent-ops contract and expected May 28 action fixture
- adds checked-in synthetic digest summaries so the CLI validation path is reproducible

## Validation
- `npm ci`
- `npm run worktree:env -- --source /Users/vambahsillah/Projects/Portfolio`
- `npm test -- lib/automation-digest-actions.test.ts`
- `npm run automation:digest-actions -- --summary-file docs/automation-digest-agent-ops-backlog-fixtures/2026-05-28-synthetic-actions-summary.json --summary-file docs/automation-digest-agent-ops-backlog-fixtures/2026-05-28-synthetic-watch-summary.json --json`
- `python3 -m json.tool docs/automation-digest-agent-ops-backlog-fixtures/2026-05-28-expected-actions.json`
- `python3 -m json.tool docs/automation-digest-agent-ops-backlog-fixtures/2026-05-28-synthetic-actions-summary.json`
- `python3 -m json.tool docs/automation-digest-agent-ops-backlog-fixtures/2026-05-28-synthetic-watch-summary.json`
- `npm run lint -- --file lib/automation-digest-actions.ts --file lib/automation-digest-actions.test.ts --file scripts/automation-digest-actions.ts`
- `npm run build` passed with the existing local env warning that outbound n8n webhooks are enabled; no live workflow or customer-data smoke was run
- `git diff --check origin/main...HEAD`
- push hook: `npm run db:health-check` passed against configured PROD env

Broader typecheck note: `npx tsc --noEmit --pretty false --skipLibCheck` is blocked by existing repo issues outside this lane: missing `chatbot-knowledge-content.generated` imports and a `RoadmapClientView.serviceProfile` test type mismatch.

## Integration Notes
- Implemented from clean worktree `/Users/vambahsillah/Projects/Portfolio.worktrees/digest-agent-ops-backlog` based on current `origin/main`.
- Root checkout remains dirty on `codex/digest-agent-ops-backlog`; subscription monitor docs were preserved and not included in this PR.
- No production mutation is performed by the router unless explicitly run with `--apply`; generated work items stay `proposed` and metadata keeps mutation approval-gated.
- Vercel contexts not yet verified after merge: `Vercel – portfolio`, `Vercel – portfolio-staging`.
