### PR TITLE
feat: add automated engagement insight scoring

### DIFF
--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -254,6 +254,29 @@ type MissionSnapshot = {
     href: string
     updated_at: string
   }>
+  high_signal_ai_insights?: Array<{
+    contentId: string
+    title: string
+    theme: string
+    score: number
+    recommendation: 'promote' | 'expand' | 'format_bakeoff' | 'hold' | 'retire'
+    recommendationLabel: string
+    ownerAgentKey: string
+    bestContentHref: string
+    bestContentUrl: string | null
+    sourcePrdHref: string | null
+    capturedAt: string
+    metrics: {
+      impressions: number | null
+      views: number | null
+      reactions: number
+      likes: number
+      comments: number
+      shares: number
+      reposts: number
+      engagementRate: number | null
+    }
+  }>
 }
 
 type WarRoomResult = {
@@ -981,6 +1004,8 @@ export default function AgentOperationsPage() {
                   pendingApprovals={decisionQueueCount}
                   costToday={snapshot?.status_strip.cost_today ?? 0}
                 />
+
+                <HighSignalInsightsPanel insights={snapshot?.high_signal_ai_insights ?? []} loading={loading} />
 
                 <SwarmCommandPanel
                   roster={snapshot?.roster ?? []}
@@ -1948,6 +1973,71 @@ function DailyBriefPanel({
             <BriefRouteCard key={card.label} {...card} />
           ))}
         </div>
+      </div>
+    </section>
+  )
+}
+
+function HighSignalInsightsPanel({
+  insights,
+  loading,
+}: {
+  insights: NonNullable<MissionSnapshot['high_signal_ai_insights']>
+  loading: boolean
+}) {
+  if (!loading && insights.length === 0) {
+    return null
+  }
+
+  return (
+    <section className="agent-ops-card mt-5 rounded-lg border p-4" aria-label="High-signal AI insights">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <div className="flex items-center gap-2 text-radiant-gold">
+            <Target size={18} />
+            <h2 className="font-semibold">High-signal AI insights</h2>
+          </div>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground">
+            Automated engagement refresh ranks published AI insight themes. Recommendations create research or bakeoff work only after review.
+          </p>
+        </div>
+        <Link href="/admin/social-content?status=published&platform=linkedin" className="inline-flex w-fit items-center gap-2 rounded-lg border border-silicon-slate/70 bg-background/55 px-3 py-2 text-sm hover:border-radiant-gold/55">
+          Social Content
+          <ArrowRight size={14} />
+        </Link>
+      </div>
+
+      <div className="mt-4 grid gap-3 lg:grid-cols-3">
+        {loading ? (
+          Array.from({ length: 3 }).map((_, index) => (
+            <div key={index} className="h-36 animate-pulse rounded-lg border border-silicon-slate/50 bg-silicon-slate/20" />
+          ))
+        ) : insights.map((insight) => (
+          <Link
+            key={insight.contentId}
+            href={insight.bestContentHref}
+            className="group rounded-lg border border-silicon-slate/60 bg-background/35 p-3 transition hover:border-radiant-gold/60"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <p className="text-xs font-semibold uppercase tracking-wider text-radiant-gold">{insight.theme}</p>
+                <p className="mt-2 line-clamp-2 text-sm font-semibold text-foreground">{insight.title}</p>
+              </div>
+              <span className="rounded-full border border-radiant-gold/45 bg-radiant-gold/10 px-2 py-1 text-xs font-semibold text-radiant-gold">
+                {insight.score}
+              </span>
+            </div>
+            <div className="mt-3 grid grid-cols-3 gap-2 text-xs text-muted-foreground">
+              <span>{insight.metrics.comments} comments</span>
+              <span>{insight.metrics.shares + insight.metrics.reposts} shares</span>
+              <span>{insight.metrics.reactions || insight.metrics.likes} reactions</span>
+            </div>
+            <div className="mt-3 flex items-center justify-between gap-2">
+              <span className="text-xs font-semibold text-radiant-gold">{insight.recommendationLabel}</span>
+              <ArrowRight size={14} className="text-muted-foreground transition group-hover:translate-x-0.5 group-hover:text-radiant-gold" />
+            </div>
+          </Link>
+        ))}
       </div>
     </section>
   )

--- a/app/admin/agents/standup/page.tsx
+++ b/app/admin/agents/standup/page.tsx
@@ -592,6 +592,7 @@ function StandupRoomContent() {
             </main>
             <aside className="space-y-5">
               <MetricsPanel organization={organization} />
+              <StandupInsightPanel insights={organization.highSignalInsights ?? []} />
               <TraceHistory runs={organization.warRoom.recentRuns} commandTraces={commandTraces} />
               <MiniKanban lanes={organization.lanes} focusedGoalId={focusedGoalId} />
             </aside>
@@ -1435,6 +1436,33 @@ function GoalSessionPanel({
             This goal has no visible Kanban cards yet. Refresh after approval or open the full Kanban board.
           </p>
         )}
+      </div>
+    </section>
+  )
+}
+
+function StandupInsightPanel({ insights }: { insights: AgentOrgBoardSnapshot['highSignalInsights'] }) {
+  if (!insights.length) return null
+  return (
+    <section className="agent-ops-card rounded-lg border p-4" aria-label="High-signal AI insights">
+      <div className="flex items-center gap-2 text-radiant-gold">
+        <Target size={16} />
+        <h2 className="text-sm font-semibold uppercase tracking-[0.16em]">High-signal insights</h2>
+      </div>
+      <p className="mt-2 text-sm leading-6 text-muted-foreground">
+        Use these engagement-ranked themes when Shaka drafts the next goal or asks the swarm what to expand.
+      </p>
+      <div className="mt-3 space-y-2">
+        {insights.slice(0, 3).map((insight) => (
+          <Link key={insight.contentId} href={insight.bestContentHref} className="block rounded-lg border border-silicon-slate/60 bg-background/45 p-3 transition hover:border-radiant-gold/60">
+            <div className="flex items-start justify-between gap-2">
+              <p className="line-clamp-2 text-sm font-semibold">{insight.theme}</p>
+              <span className="rounded-full border border-radiant-gold/45 px-2 py-1 text-xs text-radiant-gold">{insight.score}</span>
+            </div>
+            <p className="mt-2 line-clamp-2 text-xs leading-5 text-muted-foreground">{insight.title}</p>
+            <p className="mt-2 text-xs font-semibold text-radiant-gold">{insight.recommendationLabel}</p>
+          </Link>
+        ))}
       </div>
     </section>
   )

--- a/app/admin/agents/swarm-board/page.tsx
+++ b/app/admin/agents/swarm-board/page.tsx
@@ -16,6 +16,7 @@ import {
   RefreshCw,
   ShieldCheck,
   Sparkles,
+  Target,
   Timer,
   Users,
   Workflow,
@@ -385,6 +386,7 @@ function KanbanBoard({
         selectedGoalId={selectedGoalId}
         onGoalChange={onGoalChange}
       />
+      <HighSignalInsightsRail insights={organization.highSignalInsights ?? []} />
       <KanbanFilterPanel
         goals={organization.summary.goals}
         ownerOptions={ownerOptions}
@@ -714,6 +716,40 @@ function GoalRadiators({
             ))}
           </div>
         </div>
+      </div>
+    </section>
+  )
+}
+
+function HighSignalInsightsRail({ insights }: { insights: AgentOrgBoardSnapshot['highSignalInsights'] }) {
+  if (!insights.length) return null
+  return (
+    <section className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/15 p-4" aria-label="High-signal AI insights">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <div className="flex items-center gap-2 text-radiant-gold">
+            <Target size={16} />
+            <h2 className="text-sm font-semibold uppercase tracking-wide">High-signal AI insights</h2>
+          </div>
+          <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+            Engagement-ranked themes from published AI insight content. Use these as inputs for goal selection and content-format bakeoffs.
+          </p>
+        </div>
+        <Link href="/admin/social-content?status=published&platform=linkedin" className="text-sm text-radiant-gold hover:underline">
+          Open Social Content
+        </Link>
+      </div>
+      <div className="mt-3 grid gap-2 lg:grid-cols-3">
+        {insights.slice(0, 3).map((insight) => (
+          <Link key={insight.contentId} href={insight.bestContentHref} className="rounded-lg border border-silicon-slate/60 bg-background/45 p-3 transition hover:border-radiant-gold/60">
+            <div className="flex items-start justify-between gap-3">
+              <p className="line-clamp-2 text-sm font-semibold">{insight.theme}</p>
+              <span className="rounded-full border border-radiant-gold/45 bg-radiant-gold/10 px-2 py-1 text-xs font-semibold text-radiant-gold">{insight.score}</span>
+            </div>
+            <p className="mt-2 line-clamp-2 text-xs leading-5 text-muted-foreground">{insight.title}</p>
+            <p className="mt-3 text-xs font-semibold text-radiant-gold">{insight.recommendationLabel}</p>
+          </Link>
+        ))}
       </div>
     </section>
   )

--- a/app/admin/social-content/[id]/page.tsx
+++ b/app/admin/social-content/[id]/page.tsx
@@ -30,6 +30,7 @@ import {
   ArrowRightLeft,
   Maximize2,
   X,
+  BarChart3,
 } from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
@@ -112,6 +113,7 @@ function SocialContentDetailPage() {
   const [convertingFormat, setConvertingFormat] = useState(false)
   const [selectedSlide, setSelectedSlide] = useState(0)
   const [publishing, setPublishing] = useState(false)
+  const [refreshingEngagement, setRefreshingEngagement] = useState(false)
   const [savingCalibration, setSavingCalibration] = useState(false)
   const [revisingCalibration, setRevisingCalibration] = useState(false)
   const [showSource, setShowSource] = useState(false)
@@ -429,6 +431,34 @@ function SocialContentDetailPage() {
     }
   }
 
+  const handleRefreshEngagement = async () => {
+    setRefreshingEngagement(true)
+    try {
+      const session = await getCurrentSession()
+      if (!session) return
+
+      const res = await fetch('/api/admin/social-content/engagement/refresh', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${session.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ platform: 'linkedin', content_id: id, force: true }),
+      })
+      const data = await res.json()
+      if (!res.ok || data.errors?.length) {
+        showMsg('error', data.error || data.errors?.[0]?.message || 'Engagement refresh failed')
+        return
+      }
+      await fetchItem()
+      showMsg('success', data.refreshed ? 'Engagement metrics refreshed' : 'No published LinkedIn post found to refresh')
+    } catch {
+      showMsg('error', 'Engagement refresh failed')
+    } finally {
+      setRefreshingEngagement(false)
+    }
+  }
+
   const handleRegenerateImage = async () => {
     setRegeneratingImage(true)
     try {
@@ -605,6 +635,19 @@ function SocialContentDetailPage() {
   const agentPilotComparisonPrompt = asString(agentPilotCalibration?.comparison_prompt)
   const agentPilotOperatorFeedback = asRecord(agentPilotCalibration?.operator_feedback)
   const agentPilotFeedbackUpdatedAt = asString(agentPilotOperatorFeedback?.updated_at)
+  const engagement = asRecord(ragContext?.engagement)
+  const engagementLatest = asRecord(engagement?.latest)
+  const engagementScore = typeof engagement?.latest_score === 'number' ? engagement.latest_score : null
+  const engagementRecommendationLabel = asString(engagement?.recommendation_label)
+  const engagementTheme = asString(engagement?.mapped_theme)
+  const engagementCapturedAt = asString(engagementLatest?.capturedAt)
+  const engagementComments = typeof engagementLatest?.comments === 'number' ? engagementLatest.comments : 0
+  const engagementShares = (typeof engagementLatest?.shares === 'number' ? engagementLatest.shares : 0) + (typeof engagementLatest?.reposts === 'number' ? engagementLatest.reposts : 0)
+  const engagementReactions = typeof engagementLatest?.reactions === 'number'
+    ? engagementLatest.reactions
+    : typeof engagementLatest?.likes === 'number'
+      ? engagementLatest.likes
+      : 0
   const isDraftOnlyPilot = isAgentSocialPilot && agentPilotPublishGate === 'draft_only'
 
   return (
@@ -1516,6 +1559,73 @@ function SocialContentDetailPage() {
             </div>
           )}
         </div>
+
+        {/* ================================================================ */}
+        {/* SECTION 2B: Engagement Metrics                                   */}
+        {/* ================================================================ */}
+        {(item.status === 'published' || engagementLatest) && (
+          <motion.div
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="rounded-xl border border-gray-800 bg-gray-900 p-5"
+          >
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <h2 className="flex items-center gap-2 text-lg font-semibold text-gray-200">
+                  <BarChart3 className="h-5 w-5 text-amber-300" />
+                  Automated engagement signal
+                </h2>
+                <p className="mt-1 text-sm leading-6 text-gray-400">
+                  Metrics are refreshed from the configured read-only LinkedIn/Apify path and saved into this draft packet. This does not publish, schedule, DM, or trigger outbound work.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={handleRefreshEngagement}
+                disabled={refreshingEngagement}
+                className="inline-flex w-fit items-center gap-2 rounded-lg border border-amber-500/40 px-3 py-2 text-sm text-amber-200 transition-colors hover:bg-amber-500/10 disabled:opacity-50"
+              >
+                {refreshingEngagement ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+                Refresh metrics
+              </button>
+            </div>
+
+            {engagementLatest ? (
+              <div className="mt-4 grid gap-3 lg:grid-cols-[repeat(4,minmax(0,1fr))]">
+                <div className="rounded-lg border border-gray-800 bg-gray-950/45 p-3">
+                  <p className="text-xs font-semibold uppercase tracking-[0.14em] text-gray-500">Score</p>
+                  <p className="mt-1 text-2xl font-semibold text-amber-200">{engagementScore ?? 0}</p>
+                  <p className="mt-1 text-xs text-gray-500">{engagementRecommendationLabel || 'Keep watching'}</p>
+                </div>
+                <div className="rounded-lg border border-gray-800 bg-gray-950/45 p-3">
+                  <p className="text-xs font-semibold uppercase tracking-[0.14em] text-gray-500">Comments</p>
+                  <p className="mt-1 text-2xl font-semibold text-gray-100">{engagementComments}</p>
+                  <p className="mt-1 text-xs text-gray-500">High weight signal</p>
+                </div>
+                <div className="rounded-lg border border-gray-800 bg-gray-950/45 p-3">
+                  <p className="text-xs font-semibold uppercase tracking-[0.14em] text-gray-500">Shares</p>
+                  <p className="mt-1 text-2xl font-semibold text-gray-100">{engagementShares}</p>
+                  <p className="mt-1 text-xs text-gray-500">Reposts included</p>
+                </div>
+                <div className="rounded-lg border border-gray-800 bg-gray-950/45 p-3">
+                  <p className="text-xs font-semibold uppercase tracking-[0.14em] text-gray-500">Reactions</p>
+                  <p className="mt-1 text-2xl font-semibold text-gray-100">{engagementReactions}</p>
+                  <p className="mt-1 text-xs text-gray-500">{engagementCapturedAt ? `Captured ${new Date(engagementCapturedAt).toLocaleString()}` : 'Latest snapshot'}</p>
+                </div>
+                <div className="rounded-lg border border-amber-500/25 bg-amber-500/10 p-3 lg:col-span-4">
+                  <p className="text-xs font-semibold uppercase tracking-[0.14em] text-amber-200">Mapped backlog theme</p>
+                  <p className="mt-1 text-sm leading-6 text-amber-50/90">
+                    {engagementTheme || 'No backlog theme mapped yet.'}
+                  </p>
+                </div>
+              </div>
+            ) : (
+              <div className="mt-4 rounded-lg border border-gray-800 bg-gray-950/45 p-4 text-sm leading-6 text-gray-400">
+                No engagement snapshot has been captured yet. Refresh metrics after the LinkedIn post is published and visible to the configured Apify source.
+              </div>
+            )}
+          </motion.div>
+        )}
 
         {/* ================================================================ */}
         {/* SECTION 3: Publish Status                                         */}

--- a/app/api/admin/social-content/engagement/refresh/route.test.ts
+++ b/app/api/admin/social-content/engagement/refresh/route.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  refreshPublishedSocialEngagement: vi.fn(),
+  supabaseAdmin: { from: vi.fn() },
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/social-engagement-refresh', () => ({
+  refreshPublishedSocialEngagement: mocks.refreshPublishedSocialEngagement,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: mocks.supabaseAdmin,
+}))
+
+import { POST } from './route'
+
+function request(body: Record<string, unknown> = {}) {
+  return new Request('http://localhost/api/admin/social-content/engagement/refresh', {
+    method: 'POST',
+    headers: {
+      authorization: 'Bearer token',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/admin/social-content/engagement/refresh', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.refreshPublishedSocialEngagement.mockResolvedValue({
+      refreshed: 1,
+      skipped: 0,
+      errors: [],
+      insights: [{ contentId: 'content-1', theme: 'Agentic operating system', score: 88 }],
+    })
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(request() as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.refreshPublishedSocialEngagement).not.toHaveBeenCalled()
+  })
+
+  it('refreshes LinkedIn engagement through the guarded service', async () => {
+    const response = await POST(request({
+      platform: 'linkedin',
+      content_id: 'content-1',
+      limit: 5,
+      force: true,
+    }) as never)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({
+      ok: true,
+      platform: 'linkedin',
+      content_id: 'content-1',
+      refreshed: 1,
+      insights: [{ contentId: 'content-1', theme: 'Agentic operating system', score: 88 }],
+    })
+    expect(mocks.refreshPublishedSocialEngagement).toHaveBeenCalledWith({
+      db: mocks.supabaseAdmin,
+      platform: 'linkedin',
+      contentId: 'content-1',
+      limit: 5,
+      force: true,
+    })
+  })
+
+  it('defaults unsupported platform input to LinkedIn for V1', async () => {
+    const response = await POST(request({ platform: 'youtube' }) as never)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.platform).toBe('linkedin')
+    expect(mocks.refreshPublishedSocialEngagement).toHaveBeenCalledWith(expect.objectContaining({
+      platform: 'linkedin',
+      contentId: null,
+      limit: 20,
+      force: false,
+    }))
+  })
+
+  it('returns service unavailable when Apify credentials are missing', async () => {
+    mocks.refreshPublishedSocialEngagement.mockRejectedValue(new Error('APIFY_API_TOKEN is not configured'))
+
+    const response = await POST(request() as never)
+
+    expect(response.status).toBe(503)
+    expect(await response.json()).toEqual({ error: 'APIFY_API_TOKEN is not configured' })
+  })
+})

--- a/app/api/admin/social-content/engagement/refresh/route.ts
+++ b/app/api/admin/social-content/engagement/refresh/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { refreshPublishedSocialEngagement } from '@/lib/social-engagement-refresh'
+import { supabaseAdmin } from '@/lib/supabase'
+import type { SocialPlatform } from '@/lib/social-content'
+
+export const dynamic = 'force-dynamic'
+
+const SUPPORTED_PLATFORMS = new Set<SocialPlatform>(['linkedin'])
+
+function socialPlatform(value: unknown): SocialPlatform {
+  return typeof value === 'string' && SUPPORTED_PLATFORMS.has(value as SocialPlatform)
+    ? value as SocialPlatform
+    : 'linkedin'
+}
+
+/**
+ * POST /api/admin/social-content/engagement/refresh
+ *
+ * Refreshes read-only engagement metrics for published Social Content rows.
+ * This route does not publish, schedule, DM, or mutate any external platform.
+ */
+export async function POST(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  try {
+    const body = await request.json().catch(() => ({}))
+    const platform = socialPlatform(body.platform)
+    const contentId = typeof body.content_id === 'string' && body.content_id.trim() ? body.content_id.trim() : null
+    const limit = Number.isFinite(Number(body.limit)) ? Number(body.limit) : 20
+    const force = body.force === true
+
+    const result = await refreshPublishedSocialEngagement({
+      db: supabaseAdmin,
+      platform,
+      contentId,
+      limit,
+      force,
+    })
+
+    return NextResponse.json({
+      ok: true,
+      platform,
+      content_id: contentId,
+      ...result,
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Engagement refresh failed'
+    const status = message.includes('APIFY_API_TOKEN') ? 503 : 500
+    console.error('[social-engagement-refresh] failed:', error)
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/lib/agent-mission-control.test.ts
+++ b/lib/agent-mission-control.test.ts
@@ -8,6 +8,7 @@ import {
   buildAgentDeadLetterQueue,
   buildAgentCostSummary,
   buildAgentEngagementQueue,
+  buildHighSignalAIInsights,
   buildAgentInbox,
   buildAgentOperatingSignals,
   buildDailyOperatingBrief,
@@ -395,5 +396,74 @@ describe('Agent Mission Control helpers', () => {
         'Read-only; remediation approval-gated',
       ],
     })
+  })
+
+  it('projects automated engagement snapshots into high-signal AI insights', () => {
+    const insights = buildHighSignalAIInsights([
+      {
+        id: 'content-low',
+        post_text: 'Low engagement AI workflow note',
+        topic_extracted: { topic: 'Automation' },
+        rag_context: {
+          engagement: {
+            latest: {
+              platform: 'linkedin',
+              contentUrl: 'https://linkedin.com/posts/low',
+              platformPostId: 'low',
+              capturedAt: now,
+              impressions: 50,
+              views: null,
+              likes: 1,
+              reactions: 1,
+              comments: 0,
+              shares: 0,
+              reposts: 0,
+              engagementRate: null,
+              notableCommenters: [],
+              source: { provider: 'apify', actorId: 'actor', runId: 'run-low', datasetId: null, confidence: 'exact' },
+            },
+            backlog_theme: 'Automation',
+            source_prd_href: '/docs/low.md',
+          },
+        },
+      },
+      {
+        id: 'content-high',
+        post_text: 'Agentic operating system post',
+        topic_extracted: { topic: 'Agentic Operating System' },
+        rag_context: {
+          engagement: {
+            latest: {
+              platform: 'linkedin',
+              contentUrl: 'https://linkedin.com/posts/high',
+              platformPostId: 'high',
+              capturedAt: now,
+              impressions: 1200,
+              views: null,
+              likes: 0,
+              reactions: 18,
+              comments: 8,
+              shares: 1,
+              reposts: 1,
+              engagementRate: null,
+              notableCommenters: ['Operator One'],
+              source: { provider: 'apify', actorId: 'actor', runId: 'run-high', datasetId: null, confidence: 'exact' },
+            },
+            backlog_theme: 'Agentic operating system',
+            source_prd_href: '/docs/agentic.md',
+          },
+        },
+      },
+    ])
+
+    expect(insights).toHaveLength(2)
+    expect(insights[0]).toMatchObject({
+      contentId: 'content-high',
+      theme: 'Agentic Operating System',
+      recommendation: 'promote',
+      bestContentHref: '/admin/social-content/content-high',
+      ownerAgentKey: 'research-source-register',
+    })
+    expect(insights[0].score).toBeGreaterThan(insights[1].score)
   })
 })

--- a/lib/agent-mission-control.ts
+++ b/lib/agent-mission-control.ts
@@ -3,6 +3,11 @@ import { buildAgentGovernanceSnapshot, type GovernanceExportSummary } from '@/li
 import { getAgentQualitySummary, getEmptyAgentQualitySummary } from '@/lib/agent-evaluations'
 import { KNOWLEDGE_GOVERNANCE_STATUS } from '@/lib/knowledge-source-manifest'
 import { supabaseAdmin } from '@/lib/supabase'
+import {
+  buildHighSignalInsightsFromRows,
+  type EngagementSignalRow,
+  type HighSignalInsight,
+} from '@/lib/social-engagement'
 
 type AgentRunRow = {
   id: string
@@ -58,6 +63,8 @@ type MissionWorkItemRow = {
   active_run_id: string | null
   updated_at: string
 }
+
+type SocialContentSignalRow = EngagementSignalRow
 
 export type AgentMissionControlSnapshot = Awaited<ReturnType<typeof buildAgentMissionControlSnapshot>>
 
@@ -215,6 +222,10 @@ function summarizeRun(run: AgentRunRow, costByRun: Map<string, number>) {
 
 function findAgent(agentKey: string | null | undefined) {
   return AGENT_ORGANIZATION.find((agent) => agent.key === agentKey) ?? AGENT_ORGANIZATION.find((agent) => agent.key === 'chief-of-staff')
+}
+
+export function buildHighSignalAIInsights(rows: SocialContentSignalRow[]): HighSignalInsight[] {
+  return buildHighSignalInsightsFromRows(rows, 3)
 }
 
 function requestedAgentKey(run: AgentRunRow) {
@@ -822,7 +833,7 @@ export async function buildAgentMissionControlSnapshot() {
   const db = assertDatabase()
   const since = sinceHours(24)
 
-  const [runsRes, costsRes, approvalsRes, eventsRes, workItemsRes, governanceExportsRes] = await Promise.all([
+  const [runsRes, costsRes, approvalsRes, eventsRes, workItemsRes, governanceExportsRes, socialSignalsRes] = await Promise.all([
     db
       .from('agent_runs')
       .select('id, agent_key, runtime, kind, title, status, subject_label, current_step, error_message, started_at, completed_at, outcome, metadata')
@@ -854,6 +865,12 @@ export async function buildAgentMissionControlSnapshot() {
       .select('id, export_type, format, classification, run_id, client_project_id, from_at, to_at, matching_run_count, requested_by_user_id, generated_at, created_at')
       .order('created_at', { ascending: false })
       .limit(8),
+    db
+      .from('social_content_queue')
+      .select('id, post_text, topic_extracted, rag_context')
+      .eq('status', 'published')
+      .order('published_at', { ascending: false })
+      .limit(20),
   ])
 
   for (const result of [runsRes, costsRes, approvalsRes, eventsRes]) {
@@ -868,6 +885,9 @@ export async function buildAgentMissionControlSnapshot() {
   if (governanceExportsRes.error) {
     console.warn('[agent-mission-control] governance export ledger unavailable:', governanceExportsRes.error.message)
   }
+  if (socialSignalsRes.error) {
+    console.warn('[agent-mission-control] social engagement projection unavailable:', socialSignalsRes.error.message)
+  }
 
   const runs = (runsRes.data ?? []) as AgentRunRow[]
   const costs = (costsRes.data ?? []) as CostEventRow[]
@@ -875,6 +895,7 @@ export async function buildAgentMissionControlSnapshot() {
   const events = (eventsRes.data ?? []) as EventRow[]
   const workItems = workItemsRes.error ? [] : (workItemsRes.data ?? []) as MissionWorkItemRow[]
   const governanceExports = governanceExportsRes.error ? [] : (governanceExportsRes.data ?? []) as GovernanceExportSummary[]
+  const socialSignals = socialSignalsRes.error ? [] : (socialSignalsRes.data ?? []) as SocialContentSignalRow[]
   const costByRun = new Map<string, number>()
   const runsById = new Map(runs.map((run) => [run.id, run]))
 
@@ -969,6 +990,7 @@ export async function buildAgentMissionControlSnapshot() {
     cost_summary: costSummary,
     quality_summary: qualitySummary,
     governance,
+    high_signal_ai_insights: buildHighSignalAIInsights(socialSignals),
     operating_signals: operatingSignals,
     dependency_blockers: dependencyBlockers,
     knowledge_governance: KNOWLEDGE_GOVERNANCE_STATUS,

--- a/lib/agent-swarm-board.ts
+++ b/lib/agent-swarm-board.ts
@@ -6,6 +6,11 @@ import {
   type ClientConnectorReadiness,
 } from '@/lib/client-connector-readiness'
 import { supabaseAdmin } from '@/lib/supabase'
+import {
+  buildHighSignalInsightsFromRows,
+  type EngagementSignalRow,
+  type HighSignalInsight,
+} from '@/lib/social-engagement'
 
 type JsonRecord = Record<string, unknown>
 
@@ -349,6 +354,7 @@ export type AgentOrgBoardSnapshot = {
   agents: AgentOrgBoardAgent[]
   lanes: AgentOrgBoardLane[]
   activity: AgentOrgBoardActivity[]
+  highSignalInsights: HighSignalInsight[]
   warRoom: {
     roster: AgentOrgBoardWarRoomAgent[]
     recentRuns: AgentOrgBoardWarRoomRun[]
@@ -1353,6 +1359,7 @@ export function buildAgentOrgBoardSnapshotFromRows(input: AgentOrgBoardBuildInpu
     agents,
     lanes,
     activity,
+    highSignalInsights: [],
     warRoom: {
       roster,
       recentRuns: recentWarRoomRuns,
@@ -1469,7 +1476,7 @@ export async function buildAgentOrgBoardSnapshot(): Promise<AgentOrgBoardSnapsho
   if (!supabaseAdmin) throw new Error('Database not available')
   const db = supabaseAdmin
 
-  const [runsRes, eventsRes, workItemsRes, approvalsRes] = await Promise.all([
+  const [runsRes, eventsRes, workItemsRes, approvalsRes, socialSignalsRes] = await Promise.all([
     db
       .from('agent_runs')
       .select('id, agent_key, runtime, kind, title, status, subject_type, subject_id, subject_label, current_step, error_message, started_at, completed_at, metadata')
@@ -1491,10 +1498,19 @@ export async function buildAgentOrgBoardSnapshot(): Promise<AgentOrgBoardSnapsho
       .eq('status', 'pending')
       .order('requested_at', { ascending: false })
       .limit(75),
+    db
+      .from('social_content_queue')
+      .select('id, post_text, topic_extracted, rag_context')
+      .eq('status', 'published')
+      .order('published_at', { ascending: false })
+      .limit(20),
   ])
 
   for (const result of [runsRes, eventsRes, workItemsRes, approvalsRes]) {
     if (result.error) throw new Error(result.error.message)
+  }
+  if (socialSignalsRes.error) {
+    console.warn('[agent-swarm-board] high-signal insight projection unavailable:', socialSignalsRes.error.message)
   }
 
   const workItemIds = ((workItemsRes.data ?? []) as AgentWorkItemRow[]).map((item) => item.id)
@@ -1511,11 +1527,17 @@ export async function buildAgentOrgBoardSnapshot(): Promise<AgentOrgBoardSnapsho
     console.warn('[agent-swarm-board] handoff projection unavailable:', handoffsRes.error.message)
   }
 
-  return buildAgentOrgBoardSnapshotFromRows({
+  const snapshot = buildAgentOrgBoardSnapshotFromRows({
     runs: (runsRes.data ?? []) as AgentRunRow[],
     events: (eventsRes.data ?? []) as AgentRunEventRow[],
     workItems: (workItemsRes.data ?? []) as AgentWorkItemRow[],
     handoffs: handoffsRes.error ? [] : (handoffsRes.data ?? []) as AgentHandoffRow[],
     approvals: (approvalsRes.data ?? []) as ApprovalRow[],
   })
+  return {
+    ...snapshot,
+    highSignalInsights: socialSignalsRes.error
+      ? []
+      : buildHighSignalInsightsFromRows((socialSignalsRes.data ?? []) as EngagementSignalRow[], 3),
+  }
 }

--- a/lib/apify-engagement.test.ts
+++ b/lib/apify-engagement.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fetchEngagementMetrics, findBestEngagementMatch } from './apify-engagement'
+
+const originalEnv = { ...process.env }
+
+describe('Apify engagement adapter', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    process.env = { ...originalEnv, APIFY_API_TOKEN: 'test-token' }
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    process.env = { ...originalEnv }
+  })
+
+  it('matches LinkedIn rows by normalized URL before falling back', () => {
+    const match = findBestEngagementMatch({
+      contentUrl: 'https://www.linkedin.com/posts/demo?utm_source=test',
+      platformPostId: null,
+      items: [
+        { url: 'https://www.linkedin.com/posts/other', reactions: 2 },
+        { postUrl: 'https://www.linkedin.com/posts/demo', reactions: 10 },
+      ],
+    })
+
+    expect(match).toMatchObject({
+      confidence: 'exact',
+      item: { reactions: 10 },
+    })
+  })
+
+  it('runs the configured profile actor and normalizes a matching LinkedIn post', async () => {
+    process.env.APIFY_LINKEDIN_PROFILE_URL = 'https://www.linkedin.com/in/vambah'
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers({
+        'x-apify-run-id': 'run-profile',
+        'x-apify-default-dataset-id': 'dataset-profile',
+      }),
+      json: async () => [
+        {
+          postUrl: 'https://www.linkedin.com/posts/demo',
+          text: 'Portfolio AI insight',
+          reactions: 12,
+          commentsCount: 4,
+          reposts: 2,
+        },
+      ],
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchEngagementMetrics({
+      platform: 'linkedin',
+      contentUrl: 'https://www.linkedin.com/posts/demo',
+      platformPostId: null,
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/v2/acts/harvestapi~linkedin-profile-posts/run-sync-get-dataset-items'),
+      expect.objectContaining({ method: 'POST' }),
+    )
+    expect(result).toMatchObject({
+      actorId: 'harvestapi~linkedin-profile-posts',
+      runId: 'run-profile',
+      datasetId: 'dataset-profile',
+      metrics: {
+        platform: 'linkedin',
+        contentUrl: 'https://www.linkedin.com/posts/demo',
+        reactions: 12,
+        comments: 4,
+        reposts: 2,
+      },
+    })
+  })
+
+  it('falls back to direct post metrics when no profile URL is configured', async () => {
+    delete process.env.APIFY_LINKEDIN_PROFILE_URL
+    delete process.env.LINKEDIN_PROFILE_URL
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers({ 'x-apify-run-id': 'run-direct' }),
+      json: async () => [
+        {
+          url: 'https://www.linkedin.com/posts/direct',
+          likes: 8,
+          comments: 1,
+          shares: 1,
+        },
+      ],
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchEngagementMetrics({
+      platform: 'linkedin',
+      contentUrl: 'https://www.linkedin.com/posts/direct',
+      platformPostId: null,
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/v2/acts/iron-crawler~linkedin-post-metrics-scraper/run-sync-get-dataset-items'),
+      expect.any(Object),
+    )
+    expect(result.metrics).toMatchObject({
+      likes: 8,
+      comments: 1,
+      shares: 1,
+    })
+  })
+
+  it('fails closed when Apify credentials are missing', async () => {
+    delete process.env.APIFY_API_TOKEN
+    delete process.env.APIFY_TOKEN
+
+    await expect(fetchEngagementMetrics({
+      platform: 'linkedin',
+      contentUrl: 'https://www.linkedin.com/posts/demo',
+      platformPostId: null,
+    })).rejects.toThrow('APIFY_API_TOKEN')
+  })
+
+  it('rejects unsupported platforms for V1', async () => {
+    await expect(fetchEngagementMetrics({
+      platform: 'youtube',
+      contentUrl: 'https://youtube.com/watch?v=demo',
+      platformPostId: null,
+    })).rejects.toThrow('LinkedIn only')
+  })
+})

--- a/lib/apify-engagement.ts
+++ b/lib/apify-engagement.ts
@@ -1,0 +1,212 @@
+import {
+  LINKEDIN_PROFILE_POSTS_ACTOR,
+  LINKEDIN_PROFILE_POSTS_ACTOR_ID,
+  normalizeEngagementRow,
+  type NormalizedEngagementMetrics,
+} from './social-engagement'
+import type { SocialPlatform } from './social-content'
+
+export type ApifyDatasetItem = Record<string, unknown>
+
+export type EngagementFetchInput = {
+  platform: SocialPlatform
+  contentUrl: string | null
+  platformPostId: string | null
+  profileUrl?: string | null
+  maxPosts?: number
+}
+
+export type EngagementFetchResult = {
+  metrics: NormalizedEngagementMetrics
+  actorId: string
+  runId: string | null
+  datasetId: string | null
+  matchedItem: ApifyDatasetItem
+}
+
+function apifyToken() {
+  return process.env.APIFY_API_TOKEN || process.env.APIFY_TOKEN || null
+}
+
+function actorIdForLinkedInDirectPost() {
+  return process.env.APIFY_LINKEDIN_POST_METRICS_ACTOR || 'iron-crawler/linkedin-post-metrics-scraper'
+}
+
+function profileUrlForLinkedIn() {
+  return process.env.APIFY_LINKEDIN_PROFILE_URL || process.env.LINKEDIN_PROFILE_URL || null
+}
+
+function normalizeUrl(value: string | null | undefined) {
+  if (!value) return null
+  try {
+    const url = new URL(value)
+    url.hash = ''
+    url.search = ''
+    return url.toString().replace(/\/$/, '')
+  } catch {
+    return value.trim().replace(/\/$/, '')
+  }
+}
+
+function stringValue(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function itemUrl(item: ApifyDatasetItem) {
+  return normalizeUrl(
+    stringValue(item.url) ??
+    stringValue(item.postUrl) ??
+    stringValue(item.post_url) ??
+    stringValue(item.shareUrl) ??
+    stringValue(item.link),
+  )
+}
+
+function itemId(item: ApifyDatasetItem) {
+  return stringValue(item.id) ??
+    stringValue(item.postId) ??
+    stringValue(item.urn) ??
+    stringValue(item.activityUrn) ??
+    stringValue(item.shareUrn)
+}
+
+export function findBestEngagementMatch(input: {
+  items: ApifyDatasetItem[]
+  contentUrl: string | null
+  platformPostId: string | null
+}) {
+  const expectedUrl = normalizeUrl(input.contentUrl)
+  const expectedId = input.platformPostId
+
+  if (expectedUrl) {
+    const exact = input.items.find((item) => itemUrl(item) === expectedUrl)
+    if (exact) return { item: exact, confidence: 'exact' as const }
+  }
+
+  if (expectedId) {
+    const exactId = input.items.find((item) => itemId(item) === expectedId)
+    if (exactId) return { item: exactId, confidence: 'exact' as const }
+  }
+
+  if (expectedUrl) {
+    const matched = input.items.find((item) => {
+      const url = itemUrl(item)
+      return Boolean(url && (url.includes(expectedUrl) || expectedUrl.includes(url)))
+    })
+    if (matched) return { item: matched, confidence: 'matched' as const }
+  }
+
+  return input.items[0] ? { item: input.items[0], confidence: 'low' as const } : null
+}
+
+async function runActorAndGetDatasetItems(actorId: string, body: Record<string, unknown>) {
+  const token = apifyToken()
+  if (!token) {
+    throw new Error('APIFY_API_TOKEN is not configured')
+  }
+
+  const encodedActorId = actorId.replace('/', '~')
+  const url = `https://api.apify.com/v2/acts/${encodedActorId}/run-sync-get-dataset-items?token=${encodeURIComponent(token)}`
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+    cache: 'no-store',
+  })
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '')
+    throw new Error(`Apify actor ${actorId} failed with ${response.status}${text ? `: ${text.slice(0, 200)}` : ''}`)
+  }
+
+  const runId = response.headers.get('x-apify-run-id')
+  const datasetId = response.headers.get('x-apify-default-dataset-id')
+  const data = await response.json()
+  const items = Array.isArray(data) ? data : []
+  return { items: items as ApifyDatasetItem[], runId, datasetId }
+}
+
+async function fetchLinkedInProfileMetrics(input: EngagementFetchInput): Promise<EngagementFetchResult | null> {
+  const profileUrl = input.profileUrl || profileUrlForLinkedIn()
+  if (!profileUrl) return null
+
+  const actorId = LINKEDIN_PROFILE_POSTS_ACTOR
+  const { items, runId, datasetId } = await runActorAndGetDatasetItems(actorId, {
+    profileUrls: [profileUrl],
+    maxPosts: input.maxPosts ?? 20,
+    includeComments: true,
+  })
+  const match = findBestEngagementMatch({
+    items,
+    contentUrl: input.contentUrl,
+    platformPostId: input.platformPostId,
+  })
+  if (!match) return null
+
+  return {
+    metrics: normalizeEngagementRow({
+      platform: 'linkedin',
+      row: match.item,
+      contentUrl: input.contentUrl,
+      platformPostId: input.platformPostId,
+      actorId: LINKEDIN_PROFILE_POSTS_ACTOR_ID,
+      runId,
+      datasetId,
+      confidence: match.confidence,
+    }),
+    actorId: LINKEDIN_PROFILE_POSTS_ACTOR_ID,
+    runId,
+    datasetId,
+    matchedItem: match.item,
+  }
+}
+
+async function fetchLinkedInDirectPostMetrics(input: EngagementFetchInput): Promise<EngagementFetchResult> {
+  const actorId = actorIdForLinkedInDirectPost()
+  if (!input.contentUrl && !input.platformPostId) {
+    throw new Error('LinkedIn engagement refresh requires a platform post URL or post id')
+  }
+
+  const { items, runId, datasetId } = await runActorAndGetDatasetItems(actorId, {
+    postUrls: input.contentUrl ? [input.contentUrl] : undefined,
+    postUrl: input.contentUrl ?? undefined,
+    urls: input.contentUrl ? [input.contentUrl] : undefined,
+    postIds: input.platformPostId ? [input.platformPostId] : undefined,
+    includeComments: true,
+  })
+  const match = findBestEngagementMatch({
+    items,
+    contentUrl: input.contentUrl,
+    platformPostId: input.platformPostId,
+  })
+  if (!match) {
+    throw new Error('Apify returned no LinkedIn engagement rows')
+  }
+
+  return {
+    metrics: normalizeEngagementRow({
+      platform: 'linkedin',
+      row: match.item,
+      contentUrl: input.contentUrl,
+      platformPostId: input.platformPostId,
+      actorId: actorId.replace('/', '~'),
+      runId,
+      datasetId,
+      confidence: match.confidence,
+    }),
+    actorId: actorId.replace('/', '~'),
+    runId,
+    datasetId,
+    matchedItem: match.item,
+  }
+}
+
+export async function fetchEngagementMetrics(input: EngagementFetchInput): Promise<EngagementFetchResult> {
+  if (input.platform !== 'linkedin') {
+    throw new Error(`Automated engagement refresh currently supports LinkedIn only. Received ${input.platform}.`)
+  }
+
+  const profileResult = await fetchLinkedInProfileMetrics(input)
+  if (profileResult) return profileResult
+  return fetchLinkedInDirectPostMetrics(input)
+}

--- a/lib/client-ai-ops-readiness-contract.test.ts
+++ b/lib/client-ai-ops-readiness-contract.test.ts
@@ -183,6 +183,7 @@ function readinessView(overrides: Partial<RoadmapClientView> = {}): RoadmapClien
     title: 'Client AI Ops roadmap',
     status: 'active',
     clientSummary: 'Client is preparing AI Ops setup.',
+    serviceProfile: null,
     runtimePlacementOptions: [],
     connectorReadiness: connectorReadiness(),
     phases: [],

--- a/lib/social-engagement-refresh.test.ts
+++ b/lib/social-engagement-refresh.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  fetchEngagementMetrics: vi.fn(),
+}))
+
+vi.mock('./apify-engagement', () => ({
+  fetchEngagementMetrics: mocks.fetchEngagementMetrics,
+}))
+
+import { refreshPublishedSocialEngagement } from './social-engagement-refresh'
+
+type QueryResult = { data: unknown; error: { message: string } | null }
+
+function thenableQuery(result: QueryResult, methods: string[] = []) {
+  const query: Record<string, unknown> = {
+    then: (resolve: (value: QueryResult) => void) => resolve(result),
+  }
+  for (const method of methods) {
+    query[method] = vi.fn(() => query)
+  }
+  return query
+}
+
+function createDb(overrides?: {
+  publishes?: QueryResult
+  content?: QueryResult
+  update?: QueryResult
+}) {
+  const publishes = overrides?.publishes ?? {
+    data: [
+      {
+        id: 'publish-1',
+        content_id: 'content-1',
+        platform: 'linkedin',
+        status: 'published',
+        platform_post_id: 'post-1',
+        platform_post_url: 'https://www.linkedin.com/posts/demo',
+        published_at: '2026-05-31T12:00:00.000Z',
+      },
+    ],
+    error: null,
+  }
+  const content = overrides?.content ?? {
+    data: [
+      {
+        id: 'content-1',
+        platform: 'linkedin',
+        status: 'published',
+        post_text: 'AI operating system for community builders',
+        topic_extracted: { topic: 'Agentic operating system' },
+        rag_context: {},
+        platform_post_id: 'post-1',
+        published_at: '2026-05-31T12:00:00.000Z',
+      },
+    ],
+    error: null,
+  }
+  const update = overrides?.update ?? { data: { id: 'content-1' }, error: null }
+
+  const updateQuery = {
+    update: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: vi.fn().mockResolvedValue(update),
+        })),
+      })),
+    })),
+  }
+
+  return {
+    updateQuery,
+    db: {
+      from: vi.fn((table: string) => {
+        if (table === 'social_content_publishes') {
+          return thenableQuery(publishes, ['select', 'eq', 'order', 'limit'])
+        }
+        if (table === 'social_content_queue') {
+          return {
+            select: vi.fn(() => ({
+              in: vi.fn().mockResolvedValue(content),
+            })),
+            update: updateQuery.update,
+          }
+        }
+        throw new Error(`Unexpected table ${table}`)
+      }),
+    },
+  }
+}
+
+describe('refreshPublishedSocialEngagement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.setSystemTime(new Date('2026-06-01T10:00:00.000Z'))
+    mocks.fetchEngagementMetrics.mockResolvedValue({
+      actorId: 'harvestapi~linkedin-profile-posts',
+      runId: 'run-1',
+      datasetId: 'dataset-1',
+      matchedItem: {},
+      metrics: {
+        platform: 'linkedin',
+        contentUrl: 'https://www.linkedin.com/posts/demo',
+        platformPostId: 'post-1',
+        capturedAt: '2026-06-01T10:00:00.000Z',
+        impressions: 1200,
+        views: null,
+        likes: 0,
+        reactions: 24,
+        comments: 6,
+        shares: 2,
+        reposts: 1,
+        engagementRate: null,
+        notableCommenters: ['Operator One'],
+        source: {
+          provider: 'apify',
+          actorId: 'harvestapi~linkedin-profile-posts',
+          runId: 'run-1',
+          datasetId: 'dataset-1',
+          confidence: 'exact',
+        },
+        raw: {},
+      },
+    })
+  })
+
+  it('refreshes published LinkedIn rows and stores normalized engagement metadata', async () => {
+    const { db, updateQuery } = createDb()
+
+    const result = await refreshPublishedSocialEngagement({ db, captureDate: new Date('2026-06-01T10:00:00.000Z') })
+
+    expect(result).toMatchObject({
+      refreshed: 1,
+      skipped: 0,
+      errors: [],
+    })
+    expect(result.insights[0]).toMatchObject({
+      contentId: 'content-1',
+      theme: 'Agentic Operating System',
+      recommendation: 'promote',
+    })
+    expect(mocks.fetchEngagementMetrics).toHaveBeenCalledWith({
+      platform: 'linkedin',
+      contentUrl: 'https://www.linkedin.com/posts/demo',
+      platformPostId: 'post-1',
+    })
+    expect(updateQuery.update).toHaveBeenCalledWith({
+      rag_context: expect.objectContaining({
+        engagement: expect.objectContaining({
+          manual_entry_required: false,
+          latest: expect.objectContaining({
+            comments: 6,
+            shares: 2,
+          }),
+          latest_score: expect.any(Number),
+          recommendation: 'promote',
+          mapped_theme: 'Agentic Operating System',
+        }),
+      }),
+    })
+  })
+
+  it('skips rows already refreshed on the same capture date unless forced', async () => {
+    const { db, updateQuery } = createDb({
+      content: {
+        data: [
+          {
+            id: 'content-1',
+            platform: 'linkedin',
+            status: 'published',
+            post_text: 'AI operating system',
+            topic_extracted: {},
+            rag_context: {
+              engagement: {
+                latest: { capturedAt: '2026-06-01T08:00:00.000Z' },
+              },
+            },
+            platform_post_id: 'post-1',
+            published_at: '2026-05-31T12:00:00.000Z',
+          },
+        ],
+        error: null,
+      },
+    })
+
+    const result = await refreshPublishedSocialEngagement({ db, captureDate: new Date('2026-06-01T10:00:00.000Z') })
+
+    expect(result).toMatchObject({ refreshed: 0, skipped: 1, errors: [] })
+    expect(mocks.fetchEngagementMetrics).not.toHaveBeenCalled()
+    expect(updateQuery.update).not.toHaveBeenCalled()
+  })
+
+  it('records per-content errors without aborting the whole batch', async () => {
+    const { db } = createDb()
+    mocks.fetchEngagementMetrics.mockRejectedValue(new Error('Apify actor failed'))
+
+    const result = await refreshPublishedSocialEngagement({ db })
+
+    expect(result).toMatchObject({
+      refreshed: 0,
+      skipped: 0,
+      errors: [{ contentId: 'content-1', message: 'Apify actor failed' }],
+    })
+  })
+})

--- a/lib/social-engagement-refresh.ts
+++ b/lib/social-engagement-refresh.ts
@@ -1,0 +1,161 @@
+import { fetchEngagementMetrics } from './apify-engagement'
+import {
+  buildHighSignalInsight,
+  mapBacklogTheme,
+  mergeEngagementIntoRagContext,
+  scoreEngagement,
+  type HighSignalInsight,
+} from './social-engagement'
+import type { SocialPlatform } from './social-content'
+
+type SupabaseClientLike = {
+  from: (table: string) => any
+}
+
+type PublishRow = {
+  id: string
+  content_id: string
+  platform: SocialPlatform
+  status: string
+  platform_post_id: string | null
+  platform_post_url: string | null
+  published_at: string | null
+}
+
+type ContentRow = {
+  id: string
+  platform: SocialPlatform
+  status: string
+  post_text: string | null
+  topic_extracted: Record<string, unknown> | null
+  rag_context: Record<string, unknown> | null
+  platform_post_id: string | null
+  published_at: string | null
+}
+
+export type EngagementRefreshResult = {
+  refreshed: number
+  skipped: number
+  errors: Array<{ contentId: string; message: string }>
+  insights: HighSignalInsight[]
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null
+}
+
+function stringValue(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function todayKey(date = new Date()) {
+  return date.toISOString().slice(0, 10)
+}
+
+function refreshedToday(ragContext: Record<string, unknown> | null, dateKey = todayKey()) {
+  const latest = asRecord(asRecord(ragContext?.engagement)?.latest)
+  const capturedAt = stringValue(latest?.capturedAt)
+  return Boolean(capturedAt?.startsWith(dateKey))
+}
+
+export async function refreshPublishedSocialEngagement(input: {
+  db: SupabaseClientLike
+  platform?: SocialPlatform
+  contentId?: string | null
+  limit?: number
+  force?: boolean
+  captureDate?: Date
+}): Promise<EngagementRefreshResult> {
+  const platform = input.platform ?? 'linkedin'
+  const limit = Math.min(Math.max(input.limit ?? 20, 1), 50)
+  const captureDateKey = todayKey(input.captureDate)
+
+  let publishQuery = input.db
+    .from('social_content_publishes')
+    .select('id, content_id, platform, status, platform_post_id, platform_post_url, published_at')
+    .eq('status', 'published')
+    .eq('platform', platform)
+    .order('published_at', { ascending: false })
+    .limit(limit)
+
+  if (input.contentId) {
+    publishQuery = publishQuery.eq('content_id', input.contentId)
+  }
+
+  const publishesRes = await publishQuery
+  if (publishesRes.error) throw new Error(publishesRes.error.message)
+  const publishes = (publishesRes.data ?? []) as PublishRow[]
+  if (!publishes.length) return { refreshed: 0, skipped: 0, errors: [], insights: [] }
+
+  const contentIds = [...new Set(publishes.map((publish) => publish.content_id))]
+  const contentRes = await input.db
+    .from('social_content_queue')
+    .select('id, platform, status, post_text, topic_extracted, rag_context, platform_post_id, published_at')
+    .in('id', contentIds)
+
+  if (contentRes.error) throw new Error(contentRes.error.message)
+  const contentRows = (contentRes.data ?? []) as ContentRow[]
+  const contentById = new Map<string, ContentRow>(contentRows.map((row) => [row.id, row]))
+
+  const result: EngagementRefreshResult = { refreshed: 0, skipped: 0, errors: [], insights: [] }
+
+  for (const publish of publishes) {
+    const content = contentById.get(publish.content_id)
+    if (!content) {
+      result.errors.push({ contentId: publish.content_id, message: 'Social Content row not found' })
+      continue
+    }
+    if (!input.force && refreshedToday(content.rag_context, captureDateKey)) {
+      result.skipped += 1
+      continue
+    }
+
+    try {
+      const source = await fetchEngagementMetrics({
+        platform: publish.platform,
+        contentUrl: publish.platform_post_url,
+        platformPostId: publish.platform_post_id ?? content.platform_post_id,
+      })
+      const score = scoreEngagement(source.metrics)
+      const topic = stringValue(content.topic_extracted?.topic)
+      const mapped = mapBacklogTheme({
+        postText: content.post_text,
+        topic,
+        ragContext: content.rag_context,
+      })
+      const ragContext = mergeEngagementIntoRagContext({
+        ragContext: content.rag_context,
+        metrics: source.metrics,
+        score,
+        theme: mapped.theme,
+        sourcePrdHref: mapped.href,
+      })
+
+      const updateRes = await input.db
+        .from('social_content_queue')
+        .update({ rag_context: ragContext })
+        .eq('id', content.id)
+        .select('id')
+        .single()
+
+      if (updateRes.error) throw new Error(updateRes.error.message)
+
+      result.refreshed += 1
+      result.insights.push(buildHighSignalInsight({
+        contentId: content.id,
+        postText: content.post_text,
+        topic,
+        ragContext,
+        metrics: source.metrics,
+      }))
+    } catch (error) {
+      result.errors.push({
+        contentId: content.id,
+        message: error instanceof Error ? error.message : 'Engagement refresh failed',
+      })
+    }
+  }
+
+  result.insights.sort((a, b) => b.score - a.score)
+  return result
+}

--- a/lib/social-engagement.test.ts
+++ b/lib/social-engagement.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  buildHighSignalInsight,
+  mapBacklogTheme,
+  mergeEngagementIntoRagContext,
+  normalizeEngagementRow,
+  scoreEngagement,
+} from './social-engagement'
+
+describe('social engagement metrics', () => {
+  it('normalizes Apify LinkedIn rows into one internal metrics shape', () => {
+    const metrics = normalizeEngagementRow({
+      platform: 'linkedin',
+      row: {
+        postUrl: 'https://www.linkedin.com/posts/vambah_agent-ops?tracking=1',
+        urn: 'urn:li:activity:123',
+        reactionCount: '1,200',
+        commentCount: 14,
+        shareCount: 4,
+        impressions: '8.5k',
+        comments: [{ authorName: 'Operator One' }, { authorName: 'Operator One' }],
+      },
+      actorId: 'harvestapi~linkedin-profile-posts',
+      runId: 'run-1',
+      datasetId: 'dataset-1',
+      confidence: 'exact',
+    })
+
+    expect(metrics).toMatchObject({
+      platform: 'linkedin',
+      contentUrl: 'https://www.linkedin.com/posts/vambah_agent-ops',
+      platformPostId: 'urn:li:activity:123',
+      reactions: 1200,
+      comments: 14,
+      shares: 4,
+      impressions: 8500,
+      notableCommenters: ['Operator One'],
+      source: {
+        provider: 'apify',
+        actorId: 'harvestapi~linkedin-profile-posts',
+        runId: 'run-1',
+        datasetId: 'dataset-1',
+        confidence: 'exact',
+      },
+    })
+    expect(metrics.engagementRate).toBeGreaterThan(0)
+  })
+
+  it('weights comments and shares more heavily than passive views', () => {
+    vi.setSystemTime(new Date('2026-06-01T12:00:00.000Z'))
+    const highComment = normalizeEngagementRow({
+      platform: 'linkedin',
+      row: { views: 200, reactions: 4, comments: 8, shares: 3 },
+      capturedAt: '2026-06-01T11:00:00.000Z',
+    })
+    const highViewLowAction = normalizeEngagementRow({
+      platform: 'linkedin',
+      row: { views: 10000, reactions: 10, comments: 0, shares: 0 },
+      capturedAt: '2026-06-01T11:00:00.000Z',
+    })
+
+    expect(scoreEngagement(highComment).recommendation).toBe('promote')
+    expect(scoreEngagement(highComment).score).toBeGreaterThan(scoreEngagement(highViewLowAction).score)
+    expect(scoreEngagement(highViewLowAction).recommendation).toBe('format_bakeoff')
+    vi.useRealTimers()
+  })
+
+  it('maps content back to the agentic content PRD backlog', () => {
+    expect(mapBacklogTheme({
+      postText: 'Mission Control and Slack traceability are how agents become operational.',
+      topic: null,
+      ragContext: null,
+    })).toMatchObject({
+      theme: 'Mission Control and Slack Traceability',
+      href: expect.stringContaining('09-mission-control-and-slack-traceability'),
+    })
+  })
+
+  it('merges latest metrics into rag_context without requiring manual entry', () => {
+    const metrics = normalizeEngagementRow({
+      platform: 'linkedin',
+      row: { views: 100, reactions: 8, comments: 2, shares: 1 },
+      capturedAt: '2026-06-01T11:00:00.000Z',
+    })
+    const score = scoreEngagement(metrics)
+
+    const rag = mergeEngagementIntoRagContext({
+      ragContext: { source: 'agent_ops_social_outreach_goal' },
+      metrics,
+      score,
+      theme: 'Agentic Operating System',
+      sourcePrdHref: '/docs/agentic-content-research-prds/01-agentic-operating-system-overview.md',
+    })
+
+    expect(rag.engagement).toMatchObject({
+      latest_score: score.score,
+      mapped_theme: 'Agentic Operating System',
+      manual_entry_required: false,
+    })
+    expect((rag.engagement as { snapshots: unknown[] }).snapshots).toHaveLength(1)
+  })
+
+  it('builds Mission Control-ready high-signal insight cards', () => {
+    const metrics = normalizeEngagementRow({
+      platform: 'linkedin',
+      row: { url: 'https://www.linkedin.com/posts/vambah_agent-ops', reactions: 60, comments: 6, shares: 2 },
+      capturedAt: '2026-06-01T11:00:00.000Z',
+    })
+
+    const insight = buildHighSignalInsight({
+      contentId: 'content-1',
+      postText: 'Agent Ops needs a control plane, not a demo.',
+      topic: 'Agent Ops control plane',
+      ragContext: null,
+      metrics,
+    })
+
+    expect(insight).toMatchObject({
+      contentId: 'content-1',
+      bestContentHref: '/admin/social-content/content-1',
+      recommendationLabel: expect.any(String),
+    })
+    expect(insight.score).toBeGreaterThan(0)
+  })
+})

--- a/lib/social-engagement.ts
+++ b/lib/social-engagement.ts
@@ -1,0 +1,335 @@
+import type { SocialPlatform } from './social-content'
+
+export type EngagementSource = 'apify' | 'linkedin_organization' | 'manual_fixture'
+
+export type NormalizedEngagementMetrics = {
+  platform: SocialPlatform
+  contentUrl: string | null
+  platformPostId: string | null
+  capturedAt: string
+  impressions: number | null
+  views: number | null
+  reactions: number
+  likes: number
+  comments: number
+  shares: number
+  reposts: number
+  engagementRate: number | null
+  notableCommenters: string[]
+  source: {
+    provider: EngagementSource
+    actorId: string | null
+    runId: string | null
+    datasetId: string | null
+    confidence: 'exact' | 'matched' | 'low'
+  }
+  raw: Record<string, unknown>
+}
+
+export type EngagementRecommendation = 'promote' | 'expand' | 'format_bakeoff' | 'hold' | 'retire'
+
+export type EngagementScore = {
+  score: number
+  recommendation: EngagementRecommendation
+  rationale: string
+}
+
+export type HighSignalInsight = {
+  contentId: string
+  title: string
+  theme: string
+  score: number
+  recommendation: EngagementRecommendation
+  recommendationLabel: string
+  ownerAgentKey: string
+  bestContentHref: string
+  bestContentUrl: string | null
+  sourcePrdHref: string | null
+  capturedAt: string
+  metrics: Pick<NormalizedEngagementMetrics, 'impressions' | 'views' | 'reactions' | 'likes' | 'comments' | 'shares' | 'reposts' | 'engagementRate'>
+}
+
+export type EngagementSignalRow = {
+  id: string
+  post_text: string | null
+  topic_extracted: Record<string, unknown> | null
+  rag_context: Record<string, unknown> | null
+}
+
+export const LINKEDIN_PROFILE_POSTS_ACTOR = 'harvestapi/linkedin-profile-posts'
+export const LINKEDIN_PROFILE_POSTS_ACTOR_ID = 'harvestapi~linkedin-profile-posts'
+
+const AGENTIC_CONTENT_PRD_BASE = '/docs/agentic-content-research-prds/'
+
+const PRD_THEME_RULES: Array<{ pattern: RegExp; theme: string; href: string }> = [
+  { pattern: /slack|mobile|traceability|notification/i, theme: 'Mission Control and Slack Traceability', href: `${AGENTIC_CONTENT_PRD_BASE}09-mission-control-and-slack-traceability.md` },
+  { pattern: /operating system|agent ops|mission control|control plane/i, theme: 'Agentic Operating System', href: `${AGENTIC_CONTENT_PRD_BASE}01-agentic-operating-system-overview.md` },
+  { pattern: /trace|harness|audit|observability|evidence/i, theme: 'Harness and Trace Foundation', href: `${AGENTIC_CONTENT_PRD_BASE}02-harness-and-trace-foundation.md` },
+  { pattern: /shaka|controller|chief of staff|orchestrat/i, theme: 'Shaka Controller Brain', href: `${AGENTIC_CONTENT_PRD_BASE}03-shaka-controller-brain.md` },
+  { pattern: /open brain|memory|rag|knowledge/i, theme: 'Open Brain Memory Architecture', href: `${AGENTIC_CONTENT_PRD_BASE}04-open-brain-memory-architecture.md` },
+  { pattern: /evaluation|quality|rubric|feedback loop|self[- ]?eval/i, theme: 'Self-Evaluation and Quality Loops', href: `${AGENTIC_CONTENT_PRD_BASE}05-self-evaluation-and-quality-loops.md` },
+  { pattern: /swarm|delegation|agent roster|kanban|handoff/i, theme: 'Agent Swarms and Delegation', href: `${AGENTIC_CONTENT_PRD_BASE}06-agent-swarms-and-delegation.md` },
+  { pattern: /permission|risk boundary|approval gate|governance/i, theme: 'Permission Scopes and Risk Boundaries', href: `${AGENTIC_CONTENT_PRD_BASE}07-permission-scopes-and-risk-boundaries.md` },
+  { pattern: /human[- ]?in[- ]?the[- ]?loop|approval|reject|approve/i, theme: 'Human-In-The-Loop Approvals', href: `${AGENTIC_CONTENT_PRD_BASE}08-human-in-the-loop-approvals.md` },
+  { pattern: /cost|spend|payment|budget/i, theme: 'Cost, Spend, and Payment Authority', href: `${AGENTIC_CONTENT_PRD_BASE}10-cost-spend-and-payment-authority.md` },
+  { pattern: /client-safe|export|audit export/i, theme: 'Client-Safe Audit Export', href: `${AGENTIC_CONTENT_PRD_BASE}11-client-safe-audit-export.md` },
+  { pattern: /message|synthesis|voice|content/i, theme: 'Messaging Synthesis', href: `${AGENTIC_CONTENT_PRD_BASE}12-messaging-synthesis.md` },
+]
+
+function numberFrom(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string') {
+    const compact = value.trim().toLowerCase().replace(/,/g, '')
+    const multiplier = compact.endsWith('k') ? 1000 : compact.endsWith('m') ? 1000000 : 1
+    const numeric = Number(compact.replace(/[km]$/, ''))
+    return Number.isFinite(numeric) ? numeric * multiplier : null
+  }
+  return null
+}
+
+function firstNumber(row: Record<string, unknown>, keys: string[], fallback = 0): number {
+  for (const key of keys) {
+    const value = numberFrom(row[key])
+    if (value !== null) return value
+  }
+  return fallback
+}
+
+function firstString(row: Record<string, unknown>, keys: string[]): string | null {
+  for (const key of keys) {
+    const value = row[key]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  return null
+}
+
+function normalizeUrl(value: string | null | undefined) {
+  if (!value) return null
+  try {
+    const url = new URL(value)
+    url.hash = ''
+    url.search = ''
+    return url.toString().replace(/\/$/, '')
+  } catch {
+    return value.trim().replace(/\/$/, '')
+  }
+}
+
+export function normalizeEngagementRow(input: {
+  platform: SocialPlatform
+  row: Record<string, unknown>
+  contentUrl?: string | null
+  platformPostId?: string | null
+  actorId?: string | null
+  runId?: string | null
+  datasetId?: string | null
+  capturedAt?: string
+  confidence?: NormalizedEngagementMetrics['source']['confidence']
+}): NormalizedEngagementMetrics {
+  const row = input.row
+  const reactions = firstNumber(row, ['reactions', 'reactionCount', 'numReactions', 'likesCount', 'likeCount', 'likes'])
+  const likes = firstNumber(row, ['likes', 'likesCount', 'likeCount'], reactions)
+  const comments = firstNumber(row, ['comments', 'commentCount', 'numComments', 'commentsCount'])
+  const shares = firstNumber(row, ['shares', 'shareCount', 'numShares', 'sharesCount'])
+  const reposts = firstNumber(row, ['reposts', 'repostCount', 'numReposts'], shares)
+  const impressions = numberFrom(row.impressions ?? row.impressionCount ?? row.totalImpressions)
+  const views = numberFrom(row.views ?? row.viewCount ?? row.videoViews ?? row.numViews)
+  const denominator = impressions ?? views
+  const engagementRate = denominator && denominator > 0
+    ? Number(((reactions + comments + shares + reposts) / denominator).toFixed(4))
+    : numberFrom(row.engagementRate ?? row.engagement_rate)
+
+  const commenters = Array.isArray(row.comments)
+    ? row.comments
+        .map((comment) => comment && typeof comment === 'object' ? firstString(comment as Record<string, unknown>, ['author', 'authorName', 'name', 'profileName']) : null)
+        .filter((value): value is string => Boolean(value))
+    : []
+
+  return {
+    platform: input.platform,
+    contentUrl: normalizeUrl(input.contentUrl ?? firstString(row, ['url', 'postUrl', 'post_url', 'shareUrl', 'link'])),
+    platformPostId: input.platformPostId ?? firstString(row, ['id', 'postId', 'urn', 'activityUrn', 'shareUrn']),
+    capturedAt: input.capturedAt ?? new Date().toISOString(),
+    impressions,
+    views,
+    reactions,
+    likes,
+    comments,
+    shares,
+    reposts,
+    engagementRate,
+    notableCommenters: [...new Set(commenters)].slice(0, 5),
+    source: {
+      provider: 'apify',
+      actorId: input.actorId ?? null,
+      runId: input.runId ?? null,
+      datasetId: input.datasetId ?? null,
+      confidence: input.confidence ?? 'matched',
+    },
+    raw: row,
+  }
+}
+
+export function scoreEngagement(metrics: NormalizedEngagementMetrics, capturedAt = metrics.capturedAt): EngagementScore {
+  const impressionsOrViews = metrics.impressions ?? metrics.views ?? 0
+  const interactionScore =
+    metrics.comments * 12 +
+    (metrics.shares + metrics.reposts) * 10 +
+    metrics.reactions * 3 +
+    metrics.likes * 2 +
+    Math.log10(Math.max(impressionsOrViews, 0) + 1) * 4
+
+  const qualifiedMultiplier = metrics.notableCommenters.length > 0 || metrics.comments >= 3 ? 1.25 : 1
+  const daysOld = Math.max(0, (Date.now() - new Date(capturedAt).getTime()) / 86400000)
+  const decay = daysOld > 30 ? 0.8 : daysOld > 14 ? 0.9 : 1
+  const score = Number((interactionScore * qualifiedMultiplier * decay).toFixed(1))
+
+  if (score >= 80 || metrics.comments >= 8 || metrics.shares + metrics.reposts >= 5) {
+    return { score, recommendation: 'promote', rationale: 'High-quality interaction signal. Prioritize the related backlog theme.' }
+  }
+  if ((metrics.views ?? metrics.impressions ?? 0) >= 1000 && metrics.comments + metrics.shares + metrics.reposts < 2) {
+    return { score, recommendation: 'format_bakeoff', rationale: 'Reach is present but interaction is weak. Test format changes before expanding the theme.' }
+  }
+  if (score >= 45 || metrics.comments >= 3) {
+    return { score, recommendation: 'expand', rationale: 'Meaningful comments or shares suggest an adjacent research prompt is worth drafting.' }
+  }
+  if (score <= 4 && daysOld > 14) {
+    return { score, recommendation: 'retire', rationale: 'Repeated low signal after aging. Deprioritize unless the theme is strategically required.' }
+  }
+  return { score, recommendation: 'hold', rationale: 'Signal is not decisive yet. Keep watching before creating more work.' }
+}
+
+export function mapBacklogTheme(input: {
+  postText?: string | null
+  topic?: string | null
+  ragContext?: Record<string, unknown> | null
+}): { theme: string; href: string | null } {
+  const explicitRefs = Array.isArray(input.ragContext?.backlog_refs)
+    ? input.ragContext?.backlog_refs.filter((item): item is string => typeof item === 'string')
+    : []
+  if (explicitRefs.length) {
+    return { theme: explicitRefs[0].replace(/[-_]/g, ' '), href: null }
+  }
+
+  const haystack = [input.topic, input.postText, input.ragContext?.goal_title, input.ragContext?.content_packet_id]
+    .filter((value): value is string => typeof value === 'string')
+    .join('\n')
+
+  for (const rule of PRD_THEME_RULES) {
+    if (rule.pattern.test(haystack)) return { theme: rule.theme, href: rule.href }
+  }
+  return { theme: 'Messaging Synthesis', href: `${AGENTIC_CONTENT_PRD_BASE}12-messaging-synthesis.md` }
+}
+
+export function recommendationLabel(recommendation: EngagementRecommendation) {
+  switch (recommendation) {
+    case 'promote':
+      return 'Promote backlog priority'
+    case 'expand':
+      return 'Draft adjacent AutoResearch'
+    case 'format_bakeoff':
+      return 'Run format bakeoff'
+    case 'retire':
+      return 'Deprioritize theme'
+    case 'hold':
+    default:
+      return 'Keep watching'
+  }
+}
+
+export function latestEngagementFromRagContext(ragContext: Record<string, unknown> | null | undefined): NormalizedEngagementMetrics | null {
+  const engagement = ragContext?.engagement
+  if (!engagement || typeof engagement !== 'object' || Array.isArray(engagement)) return null
+  const latest = (engagement as Record<string, unknown>).latest
+  if (!latest || typeof latest !== 'object' || Array.isArray(latest)) return null
+  return latest as NormalizedEngagementMetrics
+}
+
+export function buildHighSignalInsight(input: {
+  contentId: string
+  postText: string | null
+  topic: string | null
+  ragContext: Record<string, unknown> | null
+  metrics: NormalizedEngagementMetrics
+}): HighSignalInsight {
+  const score = scoreEngagement(input.metrics)
+  const mapped = mapBacklogTheme({
+    postText: input.postText,
+    topic: input.topic,
+    ragContext: input.ragContext,
+  })
+
+  return {
+    contentId: input.contentId,
+    title: input.topic || input.postText?.slice(0, 90) || 'Published AI insight',
+    theme: mapped.theme,
+    score: score.score,
+    recommendation: score.recommendation,
+    recommendationLabel: recommendationLabel(score.recommendation),
+    ownerAgentKey: score.recommendation === 'format_bakeoff' ? 'voice-content-architect' : 'research-source-register',
+    bestContentHref: `/admin/social-content/${input.contentId}`,
+    bestContentUrl: input.metrics.contentUrl,
+    sourcePrdHref: mapped.href,
+    capturedAt: input.metrics.capturedAt,
+    metrics: {
+      impressions: input.metrics.impressions,
+      views: input.metrics.views,
+      reactions: input.metrics.reactions,
+      likes: input.metrics.likes,
+      comments: input.metrics.comments,
+      shares: input.metrics.shares,
+      reposts: input.metrics.reposts,
+      engagementRate: input.metrics.engagementRate,
+    },
+  }
+}
+
+export function buildHighSignalInsightsFromRows(rows: EngagementSignalRow[], limit = 3): HighSignalInsight[] {
+  return rows
+    .map((row) => {
+      const metrics = latestEngagementFromRagContext(row.rag_context)
+      if (!metrics) return null
+      const topic = typeof row.topic_extracted?.topic === 'string' ? row.topic_extracted.topic : null
+      return buildHighSignalInsight({
+        contentId: row.id,
+        postText: row.post_text,
+        topic,
+        ragContext: row.rag_context,
+        metrics,
+      })
+    })
+    .filter((item): item is HighSignalInsight => Boolean(item))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+}
+
+export function mergeEngagementIntoRagContext(input: {
+  ragContext: Record<string, unknown> | null
+  metrics: NormalizedEngagementMetrics
+  score: EngagementScore
+  theme: string
+  sourcePrdHref: string | null
+}) {
+  const existing = input.ragContext ?? {}
+  const existingEngagement = existing.engagement && typeof existing.engagement === 'object' && !Array.isArray(existing.engagement)
+    ? existing.engagement as Record<string, unknown>
+    : {}
+  const snapshots = Array.isArray(existingEngagement.snapshots) ? existingEngagement.snapshots : []
+
+  return {
+    ...existing,
+    engagement: {
+      ...existingEngagement,
+      latest: input.metrics,
+      latest_score: input.score.score,
+      recommendation: input.score.recommendation,
+      recommendation_label: recommendationLabel(input.score.recommendation),
+      recommendation_rationale: input.score.rationale,
+      mapped_theme: input.theme,
+      source_prd_href: input.sourcePrdHref,
+      updated_at: input.metrics.capturedAt,
+      snapshots: [input.metrics, ...snapshots].slice(0, 10),
+      manual_entry_required: false,
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- adds a LinkedIn-first Apify engagement adapter and guarded admin refresh endpoint for published Social Content rows
- normalizes engagement snapshots into `rag_context`, scores comments/shares/reposts above passive reach, and maps posts back to Agentic Content PRD themes
- projects high-signal AI insights into Mission Control, Standup Room, Agent Kanban, and Social Content detail without publishing or outbound mutations
- fixes the AI Ops readiness test fixture nullability blocker so full typecheck is green

## Validation
- `npm test -- lib/client-ai-ops-readiness-contract.test.ts lib/social-engagement.test.ts lib/apify-engagement.test.ts lib/social-engagement-refresh.test.ts app/api/admin/social-content/engagement/refresh/route.test.ts lib/agent-mission-control.test.ts app/api/admin/agents/mission-control/route.test.ts app/admin/agents/page.test.tsx app/admin/agents/swarm-board/page.test.tsx app/admin/agents/standup/page.test.tsx lib/agent-swarm-board.test.ts`
- `npx tsc --noEmit --pretty false`
- `npm run lint`
- push hook ran `npm run db:health-check` successfully before branch push

## Integration Notes
- Conflict preflight was clean: branch started from `main`; only open PR found was unrelated Slack test coverage work (#455)
- Requires `APIFY_API_TOKEN` or `APIFY_TOKEN` for live refresh; optional `APIFY_LINKEDIN_PROFILE_URL`/`LINKEDIN_PROFILE_URL` makes the profile actor the first source
- V1 is LinkedIn-only and read-only against external platforms; no publish, scheduling, DM, provider swap, n8n activation, or outbound behavior is triggered
- Vercel contexts pending final PR check: `Vercel – portfolio`, `Vercel – portfolio-staging`
