### PR TITLE
feat: add decision trust enforcement recommendations

### DIFF
--- a/app/api/admin/agents/chief-of-staff/actions/route.test.ts
+++ b/app/api/admin/agents/chief-of-staff/actions/route.test.ts
@@ -114,6 +114,12 @@ describe('POST /api/admin/agents/chief-of-staff/actions', () => {
           recommended_gate: 'human_review',
           selected_candidate: 'send_email',
         }),
+        decision_trust_enforcement: expect.objectContaining({
+          mode: 'soft_gate',
+          gate: 'human_review',
+          requiresApproval: true,
+          shouldBlock: false,
+        }),
       }),
     }))
     expect(mocks.insert).toHaveBeenCalledWith(expect.objectContaining({
@@ -129,6 +135,11 @@ describe('POST /api/admin/agents/chief-of-staff/actions', () => {
         decision_trust_frame: expect.objectContaining({
           recommended_gate: 'human_review',
           approval_type: 'send_email',
+        }),
+        decision_trust_enforcement: expect.objectContaining({
+          mode: 'soft_gate',
+          approvalType: 'send_email',
+          requiresApproval: true,
         }),
       }),
     }))
@@ -161,6 +172,11 @@ describe('POST /api/admin/agents/chief-of-staff/actions', () => {
         decision_trust_frame: expect.objectContaining({
           selected_candidate: 'send_email',
           recommended_gate: 'human_review',
+        }),
+        decision_trust_enforcement: expect.objectContaining({
+          mode: 'soft_gate',
+          gate: 'human_review',
+          requiresApproval: true,
         }),
       }),
     }))
@@ -195,6 +211,12 @@ describe('POST /api/admin/agents/chief-of-staff/actions', () => {
           decision_type: 'spend',
           recommended_gate: 'human_review',
           selected_candidate: 'create_refund',
+        }),
+        decision_trust_enforcement: expect.objectContaining({
+          mode: 'soft_gate',
+          approvalType: 'payment_create_refund',
+          requiresApproval: true,
+          shouldBlock: false,
         }),
       }),
     }))

--- a/app/api/admin/agents/chief-of-staff/actions/route.ts
+++ b/app/api/admin/agents/chief-of-staff/actions/route.ts
@@ -11,6 +11,7 @@ import {
   AGENT_DECISION_TRUST_EVENT,
   buildPaymentAuthorityDecisionTrustFrame,
 } from '@/lib/agent-decision-trust'
+import { recommendDecisionTrustEnforcement } from '@/lib/agent-decision-trust-enforcement'
 import { supabaseAdmin } from '@/lib/supabase'
 import type { ChiefOfStaffActionProposal } from '@/lib/chief-of-staff-chat'
 
@@ -180,6 +181,12 @@ export async function POST(request: NextRequest) {
       sourceRunId,
       approvalType,
     })
+    const decisionTrustEnforcement = recommendDecisionTrustEnforcement({
+      frame: decisionTrustFrame,
+      mode: 'soft_gate',
+      action: proposal.action,
+      runtime: 'codex',
+    })
 
     const run = await startAgentRun({
       agentKey: 'chief-of-staff',
@@ -200,6 +207,7 @@ export async function POST(request: NextRequest) {
         proposal,
         action_payload: actionPayload,
         decision_trust_frame: decisionTrustFrame,
+        decision_trust_enforcement: decisionTrustEnforcement,
         executes_action: false,
       },
       idempotencyKey: `chief-of-staff-action:${sourceRunId}:${proposal.action}:${auth.user.id}:${Date.now()}`,
@@ -217,6 +225,7 @@ export async function POST(request: NextRequest) {
           proposal,
           action_payload: actionPayload,
           decision_trust_frame: decisionTrustFrame,
+          decision_trust_enforcement: decisionTrustEnforcement,
           executes_action: false,
         },
       })
@@ -251,6 +260,7 @@ export async function POST(request: NextRequest) {
         proposal,
         action_payload: actionPayload,
         decision_trust_frame: decisionTrustFrame,
+        decision_trust_enforcement: decisionTrustEnforcement,
       },
       idempotencyKey: `${run.id}:chief-of-staff-approval-created`,
     }).catch(() => {})
@@ -270,6 +280,7 @@ export async function POST(request: NextRequest) {
         source_run_id: sourceRunId,
         action_payload: actionPayload,
         decision_trust_frame: decisionTrustFrame,
+        decision_trust_enforcement: decisionTrustEnforcement,
       },
       idempotencyKey: `${run.id}:approval-action-payload`,
     }).catch(() => {})

--- a/lib/agent-decision-trust-enforcement.test.ts
+++ b/lib/agent-decision-trust-enforcement.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest'
+import { buildAgentDecisionFrame } from './agent-decision-trust'
+import { recommendDecisionTrustEnforcement } from './agent-decision-trust-enforcement'
+
+describe('agent decision trust enforcement recommendation', () => {
+  it('keeps shadow mode non-blocking even for blocked frames', () => {
+    const frame = buildAgentDecisionFrame({
+      agentKey: 'chief-of-staff',
+      decisionType: 'vendor',
+      objective: 'Choose a payment destination.',
+      selectedCandidate: 'stripe-support-payments.example',
+      trustSignals: ['Search result appeared high on the page'],
+      riskSignals: ['Domain mismatch', 'Possible impersonation', 'Payment requested'],
+      missingEvidence: ['Official source confirmation'],
+      reversibility: 'irreversible',
+    })
+
+    const recommendation = recommendDecisionTrustEnforcement({ frame })
+
+    expect(frame.recommended_gate).toBe('block')
+    expect(recommendation).toMatchObject({
+      mode: 'shadow',
+      gate: 'block',
+      mayProceed: true,
+      requiresApproval: false,
+      shouldBlock: false,
+    })
+  })
+
+  it('warns in advisory mode without changing execution posture', () => {
+    const frame = buildAgentDecisionFrame({
+      agentKey: 'technology-bakeoff',
+      decisionType: 'tool',
+      objective: 'Compare tooling candidates.',
+      selectedCandidate: 'new-tool',
+      trustSignals: ['Candidate suggested'],
+      riskSignals: ['Unknown source'],
+      missingEvidence: ['Official docs', 'Current pricing', 'Source freshness', 'Rollback evidence'],
+    })
+
+    const recommendation = recommendDecisionTrustEnforcement({ frame, mode: 'advisory' })
+
+    expect(frame.recommended_gate).toBe('sandbox')
+    expect(recommendation.mayProceed).toBe(true)
+    expect(recommendation.requiresApproval).toBe(false)
+    expect(recommendation.shouldBlock).toBe(false)
+    expect(recommendation.reason).toMatch(/sandboxed or read-only/i)
+  })
+
+  it('turns human review frames into soft approval requirements', () => {
+    const frame = buildAgentDecisionFrame({
+      agentKey: 'chief-of-staff',
+      decisionType: 'spend',
+      objective: 'Create a vendor payment checkpoint.',
+      selectedCandidate: 'known-vendor',
+      trustSignals: ['Prior approval recorded', 'Official source verified'],
+      riskSignals: ['Vendor payment requested'],
+      missingEvidence: [],
+      reversibility: 'hard',
+      approvalType: 'payment_make_vendor_payment',
+    })
+
+    const recommendation = recommendDecisionTrustEnforcement({
+      frame,
+      mode: 'soft_gate',
+      action: 'make_vendor_payment',
+      runtime: 'codex',
+    })
+
+    expect(recommendation).toMatchObject({
+      mode: 'soft_gate',
+      gate: 'human_review',
+      mayProceed: false,
+      requiresApproval: true,
+      shouldBlock: false,
+      approvalType: 'payment_make_vendor_payment',
+    })
+  })
+
+  it('derives approval type from runtime policy when the frame does not carry one', () => {
+    const frame = buildAgentDecisionFrame({
+      agentKey: 'chief-of-staff',
+      decisionType: 'action',
+      objective: 'Send a client-facing email.',
+      selectedCandidate: 'send_email',
+      trustSignals: ['Agent Ops source run linked'],
+      riskSignals: ['Outbound email requested'],
+      missingEvidence: ['Human approval decision'],
+      reversibility: 'moderate',
+    })
+
+    const recommendation = recommendDecisionTrustEnforcement({
+      frame,
+      mode: 'soft_gate',
+      action: 'send_email',
+      runtime: 'codex',
+    })
+
+    expect(frame.recommended_gate).toBe('human_review')
+    expect(recommendation.requiresApproval).toBe(true)
+    expect(recommendation.approvalType).toBe('send_email')
+  })
+
+  it('hard-blocks blocked frames without creating an approval bypass', () => {
+    const frame = buildAgentDecisionFrame({
+      agentKey: 'chief-of-staff',
+      decisionType: 'oauth',
+      objective: 'Authorize an app.',
+      selectedCandidate: 'unknown-oauth-app',
+      trustSignals: ['Search result found'],
+      riskSignals: ['Typosquat app domain', 'OAuth app install requested', 'Broad access permissions requested'],
+      missingEvidence: ['Official source confirmation'],
+      reversibility: 'irreversible',
+    })
+
+    const recommendation = recommendDecisionTrustEnforcement({
+      frame,
+      mode: 'hard_block',
+      action: 'external_api_call',
+      runtime: 'codex',
+    })
+
+    expect(frame.recommended_gate).toBe('block')
+    expect(recommendation).toMatchObject({
+      mode: 'hard_block',
+      gate: 'block',
+      mayProceed: false,
+      requiresApproval: false,
+      shouldBlock: true,
+    })
+  })
+
+  it('allows strong low-risk frames in soft-gate mode', () => {
+    const frame = buildAgentDecisionFrame({
+      agentKey: 'research-source-register',
+      decisionType: 'information',
+      objective: 'Use official vendor docs for a read-only comparison.',
+      selectedCandidate: 'official-docs',
+      candidatesConsidered: ['official-docs', 'blog-summary'],
+      trustSignals: ['Official source verified', 'Domain match confirmed', 'Source evidence linked'],
+      riskSignals: ['Read-only source review'],
+      missingEvidence: [],
+      reversibility: 'easy',
+    })
+
+    const recommendation = recommendDecisionTrustEnforcement({ frame, mode: 'soft_gate' })
+
+    expect(frame.recommended_gate).toBe('allow')
+    expect(recommendation).toMatchObject({
+      mayProceed: true,
+      requiresApproval: false,
+      shouldBlock: false,
+    })
+    expect(recommendation.evidence).toMatchObject({
+      decisionId: frame.decision_id,
+      selectedCandidate: 'official-docs',
+      linkedRunId: null,
+    })
+  })
+})

--- a/lib/agent-decision-trust-enforcement.ts
+++ b/lib/agent-decision-trust-enforcement.ts
@@ -1,0 +1,152 @@
+import type { AgentRuntime } from '@/lib/agent-run'
+import {
+  actionRequiresApproval,
+  getApprovalGate,
+  isPaymentAuthorityAction,
+  type AgentAction,
+} from '@/lib/agent-policy'
+import type {
+  AgentDecisionFrame,
+  DecisionTrustGate,
+  DecisionTrustScore,
+} from '@/lib/agent-decision-trust'
+
+export type DecisionTrustEnforcementMode =
+  | 'shadow'
+  | 'advisory'
+  | 'soft_gate'
+  | 'hard_block'
+
+export type DecisionTrustEnforcementRecommendation = {
+  mode: DecisionTrustEnforcementMode
+  gate: DecisionTrustGate
+  mayProceed: boolean
+  requiresApproval: boolean
+  shouldBlock: boolean
+  approvalType: string | null
+  reason: string
+  evidence: {
+    decisionId: string
+    linkedRunId: string | null
+    selectedCandidate: string
+    scores: DecisionTrustScore
+    missingEvidence: string[]
+  }
+}
+
+export type RecommendDecisionTrustEnforcementInput = {
+  frame: AgentDecisionFrame
+  mode?: DecisionTrustEnforcementMode
+  runtime?: AgentRuntime
+  action?: AgentAction
+}
+
+export function recommendDecisionTrustEnforcement(
+  input: RecommendDecisionTrustEnforcementInput,
+): DecisionTrustEnforcementRecommendation {
+  const mode = input.mode ?? 'shadow'
+  const gate = input.frame.recommended_gate
+  const approvalType = approvalTypeFor(input)
+  const evidence = {
+    decisionId: input.frame.decision_id,
+    linkedRunId: input.frame.linked_run_id,
+    selectedCandidate: input.frame.selected_candidate,
+    scores: input.frame.scores,
+    missingEvidence: input.frame.missing_evidence,
+  }
+
+  if (mode === 'shadow') {
+    return {
+      mode,
+      gate,
+      mayProceed: true,
+      requiresApproval: false,
+      shouldBlock: false,
+      approvalType,
+      reason: 'Shadow mode records the Decision Trust posture without changing execution.',
+      evidence,
+    }
+  }
+
+  if (mode === 'advisory') {
+    return {
+      mode,
+      gate,
+      mayProceed: true,
+      requiresApproval: false,
+      shouldBlock: false,
+      approvalType,
+      reason: advisoryReason(gate),
+      evidence,
+    }
+  }
+
+  if (mode === 'hard_block' && gate === 'block') {
+    return {
+      mode,
+      gate,
+      mayProceed: false,
+      requiresApproval: false,
+      shouldBlock: true,
+      approvalType,
+      reason: 'Hard-block mode prevents blocked Decision Trust frames from executing until the evidence is corrected or explicitly overridden.',
+      evidence,
+    }
+  }
+
+  if (gate === 'human_review' || gate === 'block') {
+    return {
+      mode,
+      gate,
+      mayProceed: false,
+      requiresApproval: true,
+      shouldBlock: false,
+      approvalType,
+      reason: gate === 'block'
+        ? 'Soft-gate mode requires human review for a blocked Decision Trust frame before execution can continue.'
+        : 'Soft-gate mode requires human approval before this Decision Trust frame can produce a side effect.',
+      evidence,
+    }
+  }
+
+  if (gate === 'sandbox') {
+    return {
+      mode,
+      gate,
+      mayProceed: true,
+      requiresApproval: false,
+      shouldBlock: false,
+      approvalType,
+      reason: 'Sandbox decisions may proceed only in an isolated or read-only path with no sensitive side effect.',
+      evidence,
+    }
+  }
+
+  return {
+    mode,
+    gate,
+    mayProceed: true,
+    requiresApproval: false,
+    shouldBlock: false,
+    approvalType,
+    reason: 'Allow decisions may proceed when the calling workflow keeps the action low-risk, reversible, and inside existing policy.',
+    evidence,
+  }
+}
+
+function approvalTypeFor(input: RecommendDecisionTrustEnforcementInput) {
+  if (input.frame.approval_type) return input.frame.approval_type
+  if (!input.action) return null
+  const explicitGate = getApprovalGate(input.action)
+  if (explicitGate) return explicitGate.approvalType
+  if (input.runtime && actionRequiresApproval(input.runtime, input.action)) return input.action
+  if (isPaymentAuthorityAction(input.action)) return `payment_${input.action}`
+  return null
+}
+
+function advisoryReason(gate: DecisionTrustGate) {
+  if (gate === 'block') return 'Advisory mode warns that this Decision Trust frame would be blocked in hard-block mode.'
+  if (gate === 'human_review') return 'Advisory mode warns that this Decision Trust frame needs human review before side effects.'
+  if (gate === 'sandbox') return 'Advisory mode warns that this Decision Trust frame should stay sandboxed or read-only.'
+  return 'Advisory mode reports an allow posture without changing execution.'
+}


### PR DESCRIPTION
## Summary
- Add a pure Decision Trust enforcement recommendation helper with `shadow`, `advisory`, `soft_gate`, and `hard_block` modes.
- Cover non-blocking shadow/advisory behavior, soft approval requirements, hard-block recommendations, policy-derived approval types, and low-risk allow decisions.
- Attach the `soft_gate` recommendation to Chief-of-Staff action approval metadata without changing execution behavior or the `agent_decision_trust_recorded` frame shape.

## Validation
- `npm test -- --run lib/agent-decision-trust.test.ts lib/agent-decision-trust-enforcement.test.ts app/api/admin/agents/chief-of-staff/actions/route.test.ts`
- `npm run build:knowledge`
- `git diff --cached --check`
- `npx tsc --noEmit --pretty false` fails on existing `lib/client-ai-ops-readiness-contract.test.ts(182,3)` `RoadmapClientView.serviceProfile` type mismatch outside this branch.

## Integration Notes
- No migrations or new approval system.
- No runtime hard blocking is enabled by default.
- The Chief-of-Staff route still creates existing `agent_approvals`; this PR only adds deterministic enforcement posture metadata.
- Vercel – portfolio: not checked.
- Vercel – portfolio-staging: not checked.