### PR TITLE
docs: add p0 agentic challenger review packets

### DIFF
--- a/docs/agentic-content-review-packets/p0-challenger-review-packets.md
+++ b/docs/agentic-content-review-packets/p0-challenger-review-packets.md
@@ -1,0 +1,189 @@
+# P0 Agentic Content Challenger Review Packets
+
+Status: Human-review ready after simulated Amina challenger pass
+Date: 2026-06-01
+Source standard: [`docs/agentic-content-challenger-loop.md`](../agentic-content-challenger-loop.md)
+
+## Purpose
+
+This packet applies the Ralph Loop / Amina Agentic Challenger standard to the first P0 assets in the agentic communications backlog.
+
+No publishing, rendering, HeyGen, ElevenLabs, n8n, or provider queue action is approved by this packet. This only clears the content drafts for human editorial review.
+
+## Shared Source Packet
+
+| Source ID | Path | Use |
+| --- | --- | --- |
+| `value-map` | `docs/agentic-enterprise-value-map.md` | Master narrative, lifecycle diagram, LinkedIn seed, YouTube script spine. |
+| `communications-plan` | `docs/agentic-value-communications-plan.md` | Channel strategy, P0 backlog, challenger gate, review fields. |
+| `research-dossier` | `docs/agentic-content-research-briefs/phase-2-research-dossier.md` | Public-safe market and Portfolio claims. |
+| `linkedin-wave-1` | `docs/agentic-content-linkedin-drafts/wave-1-drafts.md` | Existing LinkedIn receipt and handoff language. |
+| `youtube-wave-1` | `docs/agentic-content-video-scripts/wave-1-youtube-scripts.md` | Existing video rhythm, storyboard conventions, provider guardrails. |
+| `trace-prd` | `docs/agentic-content-research-prds/02-harness-trace-foundation.md` | Receipt, trace envelope, safe B-roll boundaries. |
+| `mission-control-prd` | `docs/agentic-content-research-prds/09-mission-control-slack-traceability.md` | Mission Control, Slack unblock, operator surface claims. |
+
+## Packet 1: Flagship LinkedIn Post
+
+```yaml
+asset_id: p0-linkedin-flagship-agentic-operating-system
+channel: linkedin_text
+source_ids:
+  - value-map
+  - communications-plan
+  - research-dossier
+  - linkedin-wave-1
+draft_version: value-map-linkedin-post-seed-v1
+loop_round: 1
+creator_agent: Codex
+challenger_agent: Amina
+challenger_prompt_version: agentic-content-challenger-loop-v1
+challenger_status: passed
+pass_to_human: true
+approval_status: human_review_ready
+```
+
+Draft to review: the `LinkedIn Post Seed` section in `docs/agentic-enterprise-value-map.md`.
+
+Amina challenge findings:
+
+- Unsupported claims: none found. The post stays inside the public-safe claim that Portfolio is a governed proof surface, not a finished autonomous platform.
+- Implementation drift: none found. Trace, handoff, scope, approvals, Mission Control, Slack, and evaluations are supported by the source packet.
+- Privacy flags: none found. No private logs, client data, secrets, raw chats, or screenshots are included.
+- Duplicate-work check: acceptable adaptation. The post reuses the existing receipt language but changes the frame from "the receipt" to the broader operating system.
+- Channel fit: passed. The post has a strong opening, concrete operational questions, and a clear discussion close.
+
+Fixes applied:
+
+- No blocking fixes required.
+
+Residual risks for human review:
+
+- Decide whether to keep the Open CLAW reference in the public post or generalize it to "agent runtimes" if the target audience is less technical.
+- Decide whether the phrase "Execution is becoming cheap" should remain as the series tagline or move to the close only.
+
+Human packet:
+
+- Review the LinkedIn seed for voice and timing.
+- If approved, this can become the first public post in the series.
+- Publishing remains separately approval-gated.
+
+## Packet 2: LinkedIn Carousel Outline
+
+```yaml
+asset_id: p0-carousel-seven-things-after-agent-demo
+channel: linkedin_carousel
+source_ids:
+  - value-map
+  - communications-plan
+  - research-dossier
+  - trace-prd
+  - mission-control-prd
+draft_version: communications-plan-carousel-outline-v1
+loop_round: 1
+creator_agent: Codex
+challenger_agent: Amina
+challenger_prompt_version: agentic-content-challenger-loop-v1
+challenger_status: passed
+pass_to_human: true
+approval_status: human_review_ready
+```
+
+Draft to review: the `LinkedIn Carousel` format section in `docs/agentic-value-communications-plan.md`.
+
+Recommended slide outline:
+
+1. Cover: `The 7 things your enterprise agent needs after the demo`
+2. Receipt: every run needs trace, artifacts, cost, approvals, and handoffs.
+3. Scope: tool, data, write, outbound, and spend boundaries.
+4. Handoff: owner, summary, acceptance criteria, and linked evidence.
+5. Approval: human checkpoint for side effects.
+6. Compliance: risk monitor and client-safe governance export.
+7. QA: rubrics, challenger review, and coaching signals.
+8. Operator surface: Mission Control for full review, Slack for mobile unblock.
+9. Close: `Execution is becoming cheap. Governed execution is where the value is.`
+
+Amina challenge findings:
+
+- Unsupported claims: none found in outline form. Each slide maps to a source-backed component.
+- Implementation drift: none found, provided the final designed carousel keeps claims at the component level and avoids saying every path is fully automated.
+- Privacy flags: none found. Final visuals must use diagrams or sanitized UI only.
+- Duplicate-work check: acceptable. This converts existing component language into a channel-native carousel.
+- Channel fit: passed. The outline is scannable and keeps each slide to one operating concept.
+
+Fixes applied:
+
+- Added challenger review and QA explicitly to slide 7 so the carousel reflects the new Ralph Loop standard.
+
+Residual risks for human review:
+
+- Decide whether to use "enterprise agent" or "business agent" on the cover depending on target audience.
+- Final design still needs a visual QA pass before posting.
+
+Human packet:
+
+- Review slide sequence and wording.
+- If approved, build the carousel as a visual artifact.
+- Publishing remains separately approval-gated.
+
+## Packet 3: YouTube Script
+
+```yaml
+asset_id: p0-youtube-part-of-agentic-ai-most-teams-skip
+channel: youtube_long_form
+source_ids:
+  - value-map
+  - communications-plan
+  - research-dossier
+  - youtube-wave-1
+  - trace-prd
+  - mission-control-prd
+draft_version: value-map-script-v2
+loop_round: 1
+creator_agent: Codex
+challenger_agent: Amina
+challenger_prompt_version: agentic-content-challenger-loop-v1
+challenger_status: passed
+pass_to_human: true
+approval_status: human_review_ready
+```
+
+Draft to review: the `Script: "The Part Of Agentic AI Most Teams Skip"` section in `docs/agentic-enterprise-value-map.md`.
+
+Amina challenge findings:
+
+- Unsupported claims: none found after keeping the script inside the public-safe boundary that Portfolio is a working blueprint and proof surface.
+- Implementation drift: none found. Claims about traces, handoffs, scope, approval gates, risk review, evaluations, Mission Control, and Slack are source-backed.
+- Privacy flags: none found in the script text. Any future screen capture must blur private queue state, run payloads, client data, secrets, and raw logs.
+- Duplicate-work check: acceptable. The script synthesizes existing Wave 1 scripts into a lifecycle explainer.
+- Channel fit: passed after one repair. The repeated "governed execution" line was removed from the script.
+- Provider gate: still blocked. Challenger clearance makes the script ready for human review, not ready for HeyGen, ElevenLabs, rendering, or publishing.
+
+Fixes applied:
+
+- Removed the duplicate line in the YouTube script section of `docs/agentic-enterprise-value-map.md`.
+
+Residual risks for human review:
+
+- Decide whether the final runtime should target 6-8 minutes or be tightened to a 3-5 minute pilot.
+- Decide whether to use direct-to-camera only or combine avatar narration with screen-recorded Portfolio B-roll.
+
+Human packet:
+
+- Review the script for voice, pacing, and proof comfort.
+- If approved, create a separate render-readiness packet before touching HeyGen, ElevenLabs, Remotion, HyperFrames, or publishing.
+
+## Gate Summary
+
+| Asset | Challenger status | `pass_to_human` | Human review status | Provider/publish status |
+| --- | --- | --- | --- | --- |
+| Flagship LinkedIn post | `passed` | `true` | `human_review_ready` | Blocked pending publishing approval. |
+| LinkedIn carousel outline | `passed` | `true` | `human_review_ready` | Blocked pending visual build and publishing approval. |
+| YouTube script | `passed` | `true` | `human_review_ready` | Blocked pending render-readiness and provider approval. |
+
+## Next Operating Step
+
+Route these three packets to human editorial review. After approval:
+
+- adapt the LinkedIn post into the publishing queue,
+- build the carousel visual outline,
+- create the render-readiness packet for the YouTube script before any provider call.

--- a/docs/agentic-enterprise-value-map.md
+++ b/docs/agentic-enterprise-value-map.md
@@ -316,8 +316,6 @@ But I keep coming back to the same tension.
 
 The same capability that makes agents powerful also makes them risky. They answer questions, then they move work. They can touch systems. They can create records. They can spend money. They can publish. They can make a mistake while looking confident.
 
-So the enterprise problem is governed execution.
-
 The enterprise problem is governed execution.
 
 ### Section 2: The Agent Needs A Receipt

--- a/docs/agentic-value-communications-plan.md
+++ b/docs/agentic-value-communications-plan.md
@@ -464,9 +464,9 @@ The public channels will tell us which language lands. The client packet should 
 
 | Priority | Deliverable | Channel | Source component | Output | Approval status | Human review |
 | --- | --- | --- | --- | --- | --- | --- |
-| P0 | Flagship post: "Anyone can launch an agent now" | LinkedIn | Core message | Text post | `not_ready` until Ralph Loop pass | Blocked until `pass_to_human=true` |
-| P0 | Carousel: "7 things your enterprise agent needs after the demo" | LinkedIn | Component library | Slide outline | `not_ready` until Ralph Loop pass | Blocked until `pass_to_human=true` |
-| P0 | YouTube script: "The Part of Agentic AI Most Teams Skip" | YouTube | Full lifecycle | 6-10 minute script | `not_ready` until Ralph Loop pass | Blocked until `pass_to_human=true` |
+| P0 | Flagship post: "Anyone can launch an agent now" | LinkedIn | Core message | Text post | `human_review_ready` in `docs/agentic-content-review-packets/p0-challenger-review-packets.md` | Ready for editorial approval; publishing still gated |
+| P0 | Carousel: "7 things your enterprise agent needs after the demo" | LinkedIn | Component library | Slide outline | `human_review_ready` in `docs/agentic-content-review-packets/p0-challenger-review-packets.md` | Ready for editorial approval; visual build/publishing still gated |
+| P0 | YouTube script: "The Part of Agentic AI Most Teams Skip" | YouTube | Full lifecycle | 6-10 minute script | `human_review_ready` in `docs/agentic-content-review-packets/p0-challenger-review-packets.md` | Ready for editorial approval; render/provider still gated |
 | P1 | Short: "The agent needs a receipt" | TikTok/Reels/Shorts | Observability | 45-second script | `not_ready` until Ralph Loop pass | Blocked until `pass_to_human=true` |
 | P1 | Short: "A handoff is a work packet" | TikTok/Reels/Shorts | Handoff | 45-second script | `not_ready` until Ralph Loop pass | Blocked until `pass_to_human=true` |
 | P1 | Post: "Scope is the safety model" | LinkedIn | Scope | Text post | `not_ready` until Ralph Loop pass | Blocked until `pass_to_human=true` |


### PR DESCRIPTION
## Summary
- Add P0 challenger review packets for the first agentic content assets: flagship LinkedIn post, LinkedIn carousel outline, and YouTube lifecycle script.
- Mark the three P0 assets as `human_review_ready` after a simulated Amina challenger pass while keeping publishing/render/provider actions gated.
- Repair one duplicated line in the YouTube script spine and point the communications backlog to the new review packet.

## Validation
- `git diff --check`
- ASCII scan on changed docs
- Anti-AI phrase scan on changed docs
- Docs-only change; no app build, runtime smoke, provider job, render, or publishing action run

## Integration Notes
- No migrations or env changes.
- No database seeding, UI mutation, HeyGen, ElevenLabs, n8n, or publishing action was started.
- P0 content is ready for human editorial review only; downstream publishing, carousel build, and render-readiness remain separately gated.
- Vercel – portfolio: not checked before PR creation.
- Vercel – portfolio-staging: not checked before PR creation.