### PR TITLE
fix: optimize content package rls policies

### DIFF
--- a/migrations/2026_06_01_content_package_rls_policy_optimization.sql
+++ b/migrations/2026_06_01_content_package_rls_policy_optimization.sql
@@ -1,0 +1,59 @@
+-- Optimize PR #384 content-package admin RLS policies.
+-- Supabase advisors recommend wrapping auth helper calls in SELECT so Postgres
+-- can evaluate them once per statement instead of once per row.
+
+DROP POLICY IF EXISTS "Admins can manage content_frameworks" ON public.content_frameworks;
+CREATE POLICY "Admins can manage content_frameworks"
+  ON public.content_frameworks FOR ALL TO authenticated
+  USING (EXISTS (
+    SELECT 1
+    FROM public.user_profiles
+    WHERE id = (SELECT auth.uid()) AND role = 'admin'
+  ))
+  WITH CHECK (EXISTS (
+    SELECT 1
+    FROM public.user_profiles
+    WHERE id = (SELECT auth.uid()) AND role = 'admin'
+  ));
+
+DROP POLICY IF EXISTS "Admins can manage social_idea_intakes" ON public.social_idea_intakes;
+CREATE POLICY "Admins can manage social_idea_intakes"
+  ON public.social_idea_intakes FOR ALL TO authenticated
+  USING (EXISTS (
+    SELECT 1
+    FROM public.user_profiles
+    WHERE id = (SELECT auth.uid()) AND role = 'admin'
+  ))
+  WITH CHECK (EXISTS (
+    SELECT 1
+    FROM public.user_profiles
+    WHERE id = (SELECT auth.uid()) AND role = 'admin'
+  ));
+
+DROP POLICY IF EXISTS "Admins can manage content_packages" ON public.content_packages;
+CREATE POLICY "Admins can manage content_packages"
+  ON public.content_packages FOR ALL TO authenticated
+  USING (EXISTS (
+    SELECT 1
+    FROM public.user_profiles
+    WHERE id = (SELECT auth.uid()) AND role = 'admin'
+  ))
+  WITH CHECK (EXISTS (
+    SELECT 1
+    FROM public.user_profiles
+    WHERE id = (SELECT auth.uid()) AND role = 'admin'
+  ));
+
+DROP POLICY IF EXISTS "Admins can manage content_package_outputs" ON public.content_package_outputs;
+CREATE POLICY "Admins can manage content_package_outputs"
+  ON public.content_package_outputs FOR ALL TO authenticated
+  USING (EXISTS (
+    SELECT 1
+    FROM public.user_profiles
+    WHERE id = (SELECT auth.uid()) AND role = 'admin'
+  ))
+  WITH CHECK (EXISTS (
+    SELECT 1
+    FROM public.user_profiles
+    WHERE id = (SELECT auth.uid()) AND role = 'admin'
+  ));


### PR DESCRIPTION
## Summary
- Adds a follow-up migration for the PR #384 voice-note content package tables.
- Recreates the four admin-only RLS policies with `(SELECT auth.uid())` so Supabase can evaluate the helper once per statement instead of per row.
- Leaves table shape, roles, policy names, and admin access semantics unchanged.

## Validation
- Applied `migrations/2026_06_01_content_package_rls_policy_optimization.sql` to linked dev Supabase only.
- Queried `pg_policies` in dev and confirmed all four policies now store `( SELECT auth.uid() AS uid)` in `USING` and `WITH CHECK` expressions.
- Ran `supabase db advisors --linked --fail-on none` against dev and filtered for `content_frameworks`, `social_idea_intakes`, `content_packages`, and `content_package_outputs`: `relevantCount: 0`.
- `git diff --check` passed.
- Pre-push `npm run db:health-check` passed against production.

## Integration Notes
- Production migration has not been applied from this branch.
- Applying this migration to production is a database policy mutation and should remain approval-gated.
- The change is idempotent: it drops/recreates only the four named content-package admin policies.
- Vercel – portfolio: not checked yet.
- Vercel – portfolio-staging: not checked yet.
