### PR TITLE
docs: add p1 agentic challenger review packets

### DIFF
--- a/docs/agentic-content-review-packets/p1-challenger-review-packets.md
+++ b/docs/agentic-content-review-packets/p1-challenger-review-packets.md
@@ -1,0 +1,285 @@
+# P1 Agentic Content Challenger Review Packets
+
+Status: Human-review ready after simulated Amina challenger pass
+Date: 2026-06-01
+Source standard: [`docs/agentic-content-challenger-loop.md`](../agentic-content-challenger-loop.md)
+
+## Purpose
+
+This packet applies the Ralph Loop / Amina Agentic Challenger standard to the first P1 content assets:
+
+- short video: `The agent needs a receipt`,
+- short video: `A handoff is a work packet`,
+- LinkedIn post: `Scope is the safety model`,
+- LinkedIn post: `Agent QA needs scorecards`.
+
+No publishing, rendering, HeyGen, ElevenLabs, n8n, or provider queue action is approved by this packet. This only clears the drafts for human editorial review.
+
+## Shared Source Packet
+
+| Source ID | Path | Use |
+| --- | --- | --- |
+| `communications-plan` | `docs/agentic-value-communications-plan.md` | P1 backlog, channel constraints, challenger gate. |
+| `p0-review-packets` | `docs/agentic-content-review-packets/p0-challenger-review-packets.md` | Prior pass/fail pattern and source map. |
+| `linkedin-wave-1` | `docs/agentic-content-linkedin-drafts/wave-1-drafts.md` | Existing receipt, handoff, and QA post language. |
+| `youtube-wave-1` | `docs/agentic-content-video-scripts/wave-1-youtube-scripts.md` | Existing short-form source scripts and provider guardrails. |
+| `trace-prd` | `docs/agentic-content-research-prds/02-harness-trace-foundation.md` | Receipt and trace-envelope claims. |
+| `swarm-prd` | `docs/agentic-content-research-prds/06-agent-swarms-delegation.md` | Handoff, swarm ownership, and board claims. |
+| `scope-prd` | `docs/agentic-content-research-prds/07-permission-scopes-risk-boundaries.md` | Runtime policy, capability, and approval-boundary claims. |
+| `qa-prd` | `docs/agentic-content-research-prds/05-self-evaluation-quality-loops.md` | Eval, rubric, coaching, and promotion-gate claims. |
+
+## Packet 1: Short Video - The Agent Needs A Receipt
+
+```yaml
+asset_id: p1-short-agent-needs-receipt
+channel: short_form_video
+source_ids:
+  - communications-plan
+  - p0-review-packets
+  - linkedin-wave-1
+  - youtube-wave-1
+  - trace-prd
+draft_version: p1-short-receipt-v1
+loop_round: 1
+creator_agent: Codex
+challenger_agent: Amina
+challenger_prompt_version: agentic-content-challenger-loop-v1
+challenger_status: passed
+pass_to_human: true
+approval_status: human_review_ready
+```
+
+Draft script:
+
+```text
+Your agent needs a receipt.
+
+If it touches a tool, show the tool.
+If it uses evidence, show the source.
+If it hands work to another agent, show the handoff.
+If it needs approval, stop and ask.
+If it costs money, tie the cost back to the run.
+
+That is the layer most agent demos skip.
+
+The impressive part is watching the agent act.
+
+The useful part is being able to explain what happened after it acted.
+
+That is why I keep building the receipt first.
+```
+
+Amina challenge findings:
+
+- Unsupported claims: none found. The script stays at the principle and trace-envelope level.
+- Implementation drift: none found. Tool, source, handoff, approval, and cost evidence are supported by the source packet.
+- Privacy flags: none found. No private run details or screenshots are included.
+- Channel fit: passed. The script is short, spoken, and single-concept.
+- Provider gate: blocked until a separate render-readiness and provider approval packet exists.
+
+Residual risks for human review:
+
+- Decide whether to keep "costs money" in the short or reserve spend language for a separate payment-authority clip.
+
+## Packet 2: Short Video - A Handoff Is A Work Packet
+
+```yaml
+asset_id: p1-short-handoff-work-packet
+channel: short_form_video
+source_ids:
+  - communications-plan
+  - linkedin-wave-1
+  - youtube-wave-1
+  - swarm-prd
+draft_version: p1-short-handoff-v1
+loop_round: 1
+creator_agent: Codex
+challenger_agent: Amina
+challenger_prompt_version: agentic-content-challenger-loop-v1
+challenger_status: passed
+pass_to_human: true
+approval_status: human_review_ready
+```
+
+Draft script:
+
+```text
+A handoff is not a Slack message.
+
+A handoff is a work packet.
+
+Who owns the next step?
+What did the first agent produce?
+What evidence supports it?
+What does done mean?
+What risk changed?
+Where does the next agent continue the trace?
+
+Without that structure, a swarm becomes a pile of confident outputs.
+
+With it, agents can specialize without dropping accountability.
+
+That is the difference between agents talking and agents operating.
+```
+
+Amina challenge findings:
+
+- Unsupported claims: none found. The script maps to work items, handoffs, ownership, and acceptance criteria.
+- Implementation drift: none found, provided the visual layer stays structural and avoids private work item content.
+- Privacy flags: none found.
+- Channel fit: passed. Strong single concept and clear contrast.
+- Provider gate: blocked until render-readiness and provider approval.
+
+Residual risks for human review:
+
+- Decide whether to keep the Slack contrast. It is accurate as a framing device, but it should not imply Slack is weak; Slack remains the mobile unblock lane.
+
+## Packet 3: LinkedIn Post - Scope Is The Safety Model
+
+```yaml
+asset_id: p1-linkedin-scope-safety-model
+channel: linkedin_text
+source_ids:
+  - communications-plan
+  - scope-prd
+draft_version: p1-linkedin-scope-v1
+loop_round: 1
+creator_agent: Codex
+challenger_agent: Amina
+challenger_prompt_version: agentic-content-challenger-loop-v1
+challenger_status: passed
+pass_to_human: true
+approval_status: human_review_ready
+```
+
+Draft post:
+
+```text
+Agent access should feel less like a blank check and more like a permission slip.
+
+What can this agent read?
+
+What can it write?
+
+Can it touch client data?
+
+Can it send a message, publish a post, change production, start a paid job, or spend money?
+
+Those questions sound boring until an agent does something fast, confident, and wrong.
+
+That is why scope matters.
+
+In Portfolio, I am treating scope as part of the product, not a security appendix. Runtime policy, capability profiles, data classes, write classes, outbound authority, spend authority, and approval gates all need to be visible before the agent gets more room to move.
+
+The goal is not to make every agent powerful.
+
+The goal is to make every agent appropriately bounded.
+
+That is where enterprise trust starts. Before the demo. Before the workflow. Before the impressive answer.
+
+If an agent can act on behalf of the business, someone should be able to explain its boundary in plain language.
+
+Can your team explain what your agents are allowed to read, write, send, spend, and change?
+
+#AIProduct #ProductManagement #EnterpriseAI #AmadutownAdvisory
+```
+
+Amina challenge findings:
+
+- Unsupported claims: none found. Scope categories are source-backed by the permission PRD and communications plan.
+- Implementation drift: none found. The post says "I am treating scope as part of the product" and avoids claiming every capability profile is complete everywhere.
+- Privacy flags: none found.
+- Channel fit: passed. The post opens with a concrete metaphor and closes with a practical question.
+
+Residual risks for human review:
+
+- Decide whether the phrase "blank check" should remain or be softened for a less security-sensitive audience.
+
+## Packet 4: LinkedIn Post - Agent QA Needs Scorecards
+
+```yaml
+asset_id: p1-linkedin-agent-qa-scorecards
+channel: linkedin_text
+source_ids:
+  - communications-plan
+  - linkedin-wave-1
+  - qa-prd
+draft_version: p1-linkedin-qa-v1
+loop_round: 1
+creator_agent: Codex
+challenger_agent: Amina
+challenger_prompt_version: agentic-content-challenger-loop-v1
+challenger_status: passed
+pass_to_human: true
+approval_status: human_review_ready
+```
+
+Draft post:
+
+```text
+If an agent cannot evaluate its work, it should not get more power.
+
+That is the management rule I keep coming back to.
+
+A good answer is not enough.
+
+I want to know how the work happened.
+
+Did it choose the right tool?
+Did it stay inside scope?
+Did it route the work to the right owner?
+Did it ask for approval when the task became sensitive?
+Did it preserve the evidence?
+Did the cost make sense for the value of the work?
+
+That is why agent QA needs scorecards.
+
+Rubrics. Run evaluations. Pass and fail signals. Coaching notes. Trend lines. Evidence that the system is getting better for the right reason.
+
+Sometimes the lesson is that the agent needs a better prompt.
+
+Sometimes it needs a narrower tool.
+
+Sometimes it needs less authority.
+
+That last one matters because the market keeps rewarding bigger autonomy claims.
+
+Inside real operations, maturity often looks like restraint.
+
+The system learns where it is strong. It learns where it is weak. Then the operator changes the boundary.
+
+That is how trust gets built.
+
+What would you measure before giving an agent more authority?
+
+#AIProduct #ProductManagement #LLM #AmadutownAdvisory
+```
+
+Amina challenge findings:
+
+- Unsupported claims: none found. The post describes structural QA patterns and does not publish private evaluation content.
+- Implementation drift: none found. It distinguishes scorecards and run evaluations from autonomous self-improvement.
+- Privacy flags: none found.
+- Duplicate-work check: acceptable adaptation from Wave 1 Draft 4 into a tighter P1 post.
+- Channel fit: passed. The draft is practical, voice-aligned, and discussion-oriented.
+
+Residual risks for human review:
+
+- Decide whether to keep `#LLM` or rotate to `#EnterpriseAI` for audience fit.
+
+## Gate Summary
+
+| Asset | Challenger status | `pass_to_human` | Human review status | Provider/publish status |
+| --- | --- | --- | --- | --- |
+| Short: The agent needs a receipt | `passed` | `true` | `human_review_ready` | Blocked pending render-readiness and provider approval. |
+| Short: A handoff is a work packet | `passed` | `true` | `human_review_ready` | Blocked pending render-readiness and provider approval. |
+| Post: Scope is the safety model | `passed` | `true` | `human_review_ready` | Blocked pending publishing approval. |
+| Post: Agent QA needs scorecards | `passed` | `true` | `human_review_ready` | Blocked pending publishing approval. |
+
+## Next Operating Step
+
+Route these four P1 assets to human editorial review. After approval:
+
+- create render-readiness packets for the short videos before any provider call,
+- move approved LinkedIn posts into the publishing queue,
+- decide whether the scope and QA posts should run before or after the carousel.

--- a/docs/agentic-value-communications-plan.md
+++ b/docs/agentic-value-communications-plan.md
@@ -467,10 +467,10 @@ The public channels will tell us which language lands. The client packet should 
 | P0 | Flagship post: "Anyone can launch an agent now" | LinkedIn | Core message | Text post | `human_review_ready` in `docs/agentic-content-review-packets/p0-challenger-review-packets.md` | Ready for editorial approval; publishing still gated |
 | P0 | Carousel: "7 things your enterprise agent needs after the demo" | LinkedIn | Component library | Slide outline | `human_review_ready` in `docs/agentic-content-review-packets/p0-challenger-review-packets.md` | Ready for editorial approval; visual build/publishing still gated |
 | P0 | YouTube script: "The Part of Agentic AI Most Teams Skip" | YouTube | Full lifecycle | 6-10 minute script | `human_review_ready` in `docs/agentic-content-review-packets/p0-challenger-review-packets.md` | Ready for editorial approval; render/provider still gated |
-| P1 | Short: "The agent needs a receipt" | TikTok/Reels/Shorts | Observability | 45-second script | `not_ready` until Ralph Loop pass | Blocked until `pass_to_human=true` |
-| P1 | Short: "A handoff is a work packet" | TikTok/Reels/Shorts | Handoff | 45-second script | `not_ready` until Ralph Loop pass | Blocked until `pass_to_human=true` |
-| P1 | Post: "Scope is the safety model" | LinkedIn | Scope | Text post | `not_ready` until Ralph Loop pass | Blocked until `pass_to_human=true` |
-| P1 | Post: "Agent QA needs scorecards" | LinkedIn | QA loop | Text post | `not_ready` until Ralph Loop pass | Blocked until `pass_to_human=true` |
+| P1 | Short: "The agent needs a receipt" | TikTok/Reels/Shorts | Observability | 45-second script | `human_review_ready` in `docs/agentic-content-review-packets/p1-challenger-review-packets.md` | Ready for editorial approval; render/provider still gated |
+| P1 | Short: "A handoff is a work packet" | TikTok/Reels/Shorts | Handoff | 45-second script | `human_review_ready` in `docs/agentic-content-review-packets/p1-challenger-review-packets.md` | Ready for editorial approval; render/provider still gated |
+| P1 | Post: "Scope is the safety model" | LinkedIn | Scope | Text post | `human_review_ready` in `docs/agentic-content-review-packets/p1-challenger-review-packets.md` | Ready for editorial approval; publishing still gated |
+| P1 | Post: "Agent QA needs scorecards" | LinkedIn | QA loop | Text post | `human_review_ready` in `docs/agentic-content-review-packets/p1-challenger-review-packets.md` | Ready for editorial approval; publishing still gated |
 | P2 | Client one-pager | PDF/web | Value stack | Advisory asset | `not_ready` until Ralph Loop pass | Blocked until `pass_to_human=true` |
 | P2 | Technical appendix | PDF/Markdown | Source map | Due diligence asset | `not_ready` until Ralph Loop pass | Blocked until `pass_to_human=true` |
 | P2 | Website proof page | Portfolio | Full system | Webpage | `not_ready` until Ralph Loop pass | Blocked until `pass_to_human=true` |


### PR DESCRIPTION
## Summary
- Add P1 challenger review packets for two short-form scripts and two LinkedIn posts: receipt, handoff, scope, and QA.
- Embed human-review-ready draft copy while keeping publishing, rendering, HeyGen, ElevenLabs, n8n, and provider actions gated.
- Update the communications backlog so the four P1 rows point to the new challenger review packet.

## Validation
- `git diff --check`
- ASCII scan on changed docs
- Anti-AI phrase scan on changed docs
- Docs-only change; no app build, runtime smoke, provider job, render, UI seeding, or publishing action run

## Integration Notes
- No migrations or env changes.
- No database seeding, UI mutation, HeyGen, ElevenLabs, n8n, or publishing action was started.
- P1 content is ready for human editorial review only; downstream publishing and render-readiness remain separately gated.
- Vercel – portfolio: not checked before PR creation.
- Vercel – portfolio-staging: not checked before PR creation.