### PR TITLE
docs: add p2 agentic challenger review packets

### DIFF
--- a/docs/agentic-content-review-packets/p2-challenger-review-packets.md
+++ b/docs/agentic-content-review-packets/p2-challenger-review-packets.md
@@ -1,0 +1,264 @@
+# P2 Agentic Content Challenger Review Packets
+
+Status: Human-review ready after simulated Amina challenger pass
+Date: 2026-06-01
+Source standard: [`docs/agentic-content-challenger-loop.md`](../agentic-content-challenger-loop.md)
+
+## Purpose
+
+This packet applies the Ralph Loop / Amina Agentic Challenger standard to the first P2 proof and conversion assets:
+
+- client one-pager,
+- technical appendix,
+- website proof page brief.
+
+No publishing, PDF export, website implementation, provider job, n8n action, or database seeding is approved by this packet. This only clears the asset drafts for human editorial review.
+
+## Shared Source Packet
+
+| Source ID | Path | Use |
+| --- | --- | --- |
+| `client-explainer` | `docs/agentic-os-client-advisory-explainer.md` | Client-safe positioning, export boundary, advisory talk track. |
+| `value-map` | `docs/agentic-enterprise-value-map.md` | Lifecycle, component narratives, proof surfaces, script raw material. |
+| `communications-plan` | `docs/agentic-value-communications-plan.md` | P2 backlog, channel specs, editorial guardrails. |
+| `p0-review-packets` | `docs/agentic-content-review-packets/p0-challenger-review-packets.md` | Prior proof, lifecycle, and P0 clearance pattern. |
+| `p1-review-packets` | `docs/agentic-content-review-packets/p1-challenger-review-packets.md` | Prior receipt, handoff, scope, and QA clearance pattern. |
+| `research-dossier` | `docs/agentic-content-research-briefs/phase-2-research-dossier.md` | Public-safe market and Portfolio claims. |
+
+## Packet 1: Client One-Pager
+
+```yaml
+asset_id: p2-client-one-pager-governed-agentic-operations
+channel: client_one_pager
+source_ids:
+  - client-explainer
+  - value-map
+  - communications-plan
+  - p0-review-packets
+  - p1-review-packets
+draft_version: p2-client-one-pager-v1
+loop_round: 1
+creator_agent: Codex
+challenger_agent: Amina
+challenger_prompt_version: agentic-content-challenger-loop-v1
+challenger_status: passed
+pass_to_human: true
+approval_status: human_review_ready
+```
+
+Draft one-pager:
+
+```text
+Governed Agentic Operations
+
+AI agents are becoming easier to launch. The harder work starts when the agent can act on behalf of the business.
+
+What is it allowed to touch?
+Who assigned the work?
+Where does the handoff live?
+Which side effects need approval?
+How do you prove what happened without exposing private logs?
+
+Portfolio demonstrates the operating layer around that work.
+
+The model:
+
+- Agent registry: every agent has a role.
+- Scope profile: every role has clear read, write, send, spend, and production boundaries.
+- Delegation: Shaka routes work to the right specialist and records the reason.
+- Trace: runs, steps, artifacts, costs, handoffs, approvals, and evaluations leave a reviewable receipt.
+- Approval: publishing, outbound sends, production writes, private-to-public movement, payment authority, and paid external jobs remain gated.
+- QA: outputs are reviewed through rubrics, challenger loops, and coaching signals before authority expands.
+- Client-safe proof: governance exports summarize the evidence without raw prompts, secrets, private run logs, or sensitive records.
+
+What clients can validate:
+
+- which agents exist,
+- what each agent is responsible for,
+- what data, tools, and write authority each agent can use,
+- which actions require approval,
+- where audit evidence lives,
+- and what can be shared safely with a board, sponsor, or compliance reviewer.
+
+The value:
+
+Agents should reduce burden, not create a new layer of unmanaged risk.
+
+This approach gives teams a way to adopt AI with practical confidence: more speed where the system has earned it, human judgment where authority matters, and proof when someone needs to understand what happened.
+
+Advisory entry point:
+
+Run an Agent Readiness Audit to map your agent roles, scope, handoffs, approval gates, QA loops, and client-safe proof path before expanding autonomy.
+```
+
+Amina challenge findings:
+
+- Unsupported claims: none found. The one-pager presents Portfolio as a demonstration and advisory model, not a finished autonomous platform.
+- Implementation drift: none found. The proof points map to the client explainer, value map, and prior review packets.
+- Privacy flags: none found. The draft explicitly excludes raw prompts, secrets, private logs, and sensitive records.
+- Channel fit: passed. The language is plain, buyer-oriented, and one-page friendly.
+
+Residual risks for human review:
+
+- Decide whether "Agent Readiness Audit" should be the call to action or whether the CTA should be softer, such as "Start with an operating model review."
+- Decide whether this should be AmaduTown-branded before PDF or webpage production.
+
+## Packet 2: Technical Appendix
+
+```yaml
+asset_id: p2-technical-appendix-agentic-proof-map
+channel: technical_appendix
+source_ids:
+  - client-explainer
+  - value-map
+  - communications-plan
+  - research-dossier
+draft_version: p2-technical-appendix-v1
+loop_round: 1
+creator_agent: Codex
+challenger_agent: Amina
+challenger_prompt_version: agentic-content-challenger-loop-v1
+challenger_status: passed
+pass_to_human: true
+approval_status: human_review_ready
+```
+
+Draft appendix outline:
+
+```text
+Technical Appendix: Agentic Operating Proof Map
+
+Purpose:
+Give technical reviewers a source-mapped view of Portfolio's governed agent operating model without exposing private runtime payloads, secrets, client data, or raw logs.
+
+1. Agent Registry And Roles
+Proof question: Who is allowed to work?
+Evidence type: agent roster, pods, responsibilities, runtime posture.
+Public-safe boundary: display role and status summaries, not private work item contents.
+
+2. Scope And Runtime Policy
+Proof question: What can each agent touch?
+Evidence type: runtime policy, capability profiles, data classes, write classes, outbound authority, spend authority, approval-required actions.
+Public-safe boundary: discuss categories and gates, not env values, secrets, credentials, or sensitive data samples.
+
+3. Delegation And Handoff
+Proof question: Why did work move from one agent or runtime to another?
+Evidence type: Shaka routing, work item ownership, handoff summary, acceptance criteria, trace links.
+Public-safe boundary: use structural examples and sanitized records only.
+
+4. Observability Receipt
+Proof question: Can an operator reconstruct what happened?
+Evidence type: agent runs, steps, events, artifacts, costs, approvals, handoffs, evaluations.
+Public-safe boundary: show field types and UI surfaces, not raw artifact bodies or private run detail.
+
+5. Approval Gates
+Proof question: Where does autonomy stop?
+Evidence type: approval checkpoints for publishing, outbound email, production writes, config changes, private-to-public movement, payment actions, paid jobs, and provider work.
+Public-safe boundary: summarize gate types and decision flow, not private approval payloads.
+
+6. QA And Challenger Loops
+Proof question: How does the system know whether work is ready for a human?
+Evidence type: rubrics, run evaluations, quality summaries, Amina challenger packets, pass-to-human status.
+Public-safe boundary: report structural scoring and review states, not private evaluation text.
+
+7. Client-Safe Export Boundary
+Proof question: What can be shared outside the operator console?
+Evidence type: governance export scope, source references, capability inventory, filtered trace references.
+Public-safe boundary: exports exclude raw prompts, secrets, credentials, private reasoning, private source material, and sensitive records.
+
+8. Open Risks And Next Evidence
+Proof question: What still needs validation before broader rollout?
+Evidence type: unresolved proof gaps, planned screenshots, pending approval packets, deployment gates.
+Public-safe boundary: name the evidence needed without inventing proof.
+```
+
+Amina challenge findings:
+
+- Unsupported claims: none found. The appendix is framed as an outline and proof map.
+- Implementation drift: none found. It asks proof questions instead of asserting undocumented implementation detail.
+- Privacy flags: none found. Each section carries a public-safe boundary.
+- Channel fit: passed. The structure supports due diligence without becoming a marketing page.
+
+Residual risks for human review:
+
+- Decide whether to include exact implementation paths in the first appendix draft or keep paths in an internal source register.
+- Decide whether this should remain Markdown first or become a PDF after approval.
+
+## Packet 3: Website Proof Page Brief
+
+```yaml
+asset_id: p2-website-proof-page-governed-agents
+channel: portfolio_website_page
+source_ids:
+  - client-explainer
+  - value-map
+  - communications-plan
+  - p0-review-packets
+  - p1-review-packets
+draft_version: p2-website-proof-page-brief-v1
+loop_round: 1
+creator_agent: Codex
+challenger_agent: Amina
+challenger_prompt_version: agentic-content-challenger-loop-v1
+challenger_status: passed
+pass_to_human: true
+approval_status: human_review_ready
+```
+
+Draft page brief:
+
+```text
+Page title:
+Governed Agents, Not Unchecked Automation
+
+First viewport:
+Lead with the problem: agents are easy to launch, hard to govern.
+
+Use a lifecycle visual, not a marketing hero. The first screen should show the operating loop: intent, routing, scope, execution, evaluation, challenger review, handoff, approval, audit.
+
+Section 1: What Portfolio Proves
+Show the value stack in plain language: named agents, scoped roles, traceable runs, structured handoffs, approval gates, QA loops, and client-safe proof.
+
+Section 2: The Operating Components
+Use component cards for receipt, scope, handoff, approval, compliance, QA, Mission Control, Slack, and governance export.
+
+Section 3: The Client-Safe Proof Boundary
+Explain what can be shown publicly and what stays private. Use the client-safe export language: no raw prompts, private run logs, secrets, private reasoning, private source material, or sensitive records.
+
+Section 4: Why This Matters
+Connect the system back to real operators: nonprofits, small businesses, product teams, and organizations that need AI to reduce burden instead of creating unmanaged work.
+
+Call to action:
+Run an Agent Readiness Audit or request a governed agent operating model review.
+
+Visual direction:
+Use real diagrams, sanitized UI captures, and AmaduTown branding. Avoid decorative AI imagery. Do not expose private admin state.
+```
+
+Amina challenge findings:
+
+- Unsupported claims: none found. The brief defines a page concept, not a live page implementation.
+- Implementation drift: none found. It uses the merged lifecycle and component language from the value map.
+- Privacy flags: none found. The brief explicitly requires sanitized UI and excludes private admin state.
+- Channel fit: passed. It is visual-first and proof-oriented.
+
+Residual risks for human review:
+
+- Decide whether this becomes a public page, private sales page, or authenticated proof page.
+- Decide whether the first visual should be the lifecycle diagram or a sanitized Mission Control screenshot.
+
+## Gate Summary
+
+| Asset | Challenger status | `pass_to_human` | Human review status | Production/export status |
+| --- | --- | --- | --- | --- |
+| Client one-pager | `passed` | `true` | `human_review_ready` | Blocked pending PDF/web production approval. |
+| Technical appendix | `passed` | `true` | `human_review_ready` | Blocked pending appendix production approval. |
+| Website proof page brief | `passed` | `true` | `human_review_ready` | Blocked pending website implementation approval. |
+
+## Next Operating Step
+
+Route these three P2 assets to human editorial review. After approval:
+
+- decide whether the one-pager becomes a PDF, webpage, or both,
+- expand the technical appendix with exact source paths and screenshots,
+- open a separate website implementation PR for the proof page.

--- a/docs/agentic-value-communications-plan.md
+++ b/docs/agentic-value-communications-plan.md
@@ -471,9 +471,9 @@ The public channels will tell us which language lands. The client packet should 
 | P1 | Short: "A handoff is a work packet" | TikTok/Reels/Shorts | Handoff | 45-second script | `human_review_ready` in `docs/agentic-content-review-packets/p1-challenger-review-packets.md` | Ready for editorial approval; render/provider still gated |
 | P1 | Post: "Scope is the safety model" | LinkedIn | Scope | Text post | `human_review_ready` in `docs/agentic-content-review-packets/p1-challenger-review-packets.md` | Ready for editorial approval; publishing still gated |
 | P1 | Post: "Agent QA needs scorecards" | LinkedIn | QA loop | Text post | `human_review_ready` in `docs/agentic-content-review-packets/p1-challenger-review-packets.md` | Ready for editorial approval; publishing still gated |
-| P2 | Client one-pager | PDF/web | Value stack | Advisory asset | `not_ready` until Ralph Loop pass | Blocked until `pass_to_human=true` |
-| P2 | Technical appendix | PDF/Markdown | Source map | Due diligence asset | `not_ready` until Ralph Loop pass | Blocked until `pass_to_human=true` |
-| P2 | Website proof page | Portfolio | Full system | Webpage | `not_ready` until Ralph Loop pass | Blocked until `pass_to_human=true` |
+| P2 | Client one-pager | PDF/web | Value stack | Advisory asset | `human_review_ready` in `docs/agentic-content-review-packets/p2-challenger-review-packets.md` | Ready for editorial approval; PDF/web production still gated |
+| P2 | Technical appendix | PDF/Markdown | Source map | Due diligence asset | `human_review_ready` in `docs/agentic-content-review-packets/p2-challenger-review-packets.md` | Ready for editorial approval; appendix production still gated |
+| P2 | Website proof page | Portfolio | Full system | Webpage | `human_review_ready` in `docs/agentic-content-review-packets/p2-challenger-review-packets.md` | Ready for editorial approval; website implementation still gated |
 
 ## Challenger Test Scenarios
 


### PR DESCRIPTION
## Summary
- Add P2 challenger review packets for the client one-pager, technical appendix, and website proof-page brief.
- Embed human-review-ready drafts while keeping PDF export, website implementation, provider jobs, n8n actions, and publishing gated.
- Update the communications backlog so P2 rows point to the new challenger review packet.

## Validation
- `git diff --check`
- ASCII scan on changed docs
- Anti-AI phrase scan on changed docs
- Docs-only change; no app build, runtime smoke, provider job, render, PDF export, website implementation, UI seeding, or publishing action run

## Integration Notes
- No migrations or env changes.
- No database seeding, UI mutation, HeyGen, ElevenLabs, n8n, PDF export, website implementation, or publishing action was started.
- P2 content is ready for human editorial review only; downstream production remains separately gated.
- Vercel – portfolio: not checked before PR creation.
- Vercel – portfolio-staging: not checked before PR creation.