### PR TITLE
feat: surface challenger-cleared content packets

### DIFF
--- a/app/admin/content/video-generation/page.tsx
+++ b/app/admin/content/video-generation/page.tsx
@@ -19,6 +19,7 @@ import { readSSEStream } from '@/lib/sse-reader'
 import { getCurrentSession } from '@/lib/auth'
 import { VIDEO_CHANNEL_CONFIGS, type VideoChannel } from '@/lib/constants/video-channel'
 import { buildVideoRenderApproval, VIDEO_RENDER_APPROVAL_PACKET_PATH } from '@/lib/video-render-approval'
+import { getAgenticContentReviewPacketsForSurface } from '@/lib/agentic-content-review-packets'
 
 /* ───────────── Types ───────────── */
 
@@ -165,6 +166,7 @@ function lastRunLabel(date: Date | null): string | null {
 }
 
 const HEYGEN_SCRIPT_MAX = 5000
+const AGENTIC_VIDEO_REVIEW_PACKETS = getAgenticContentReviewPacketsForSurface('video')
 
 /* ───────────── Component ───────────── */
 
@@ -1767,6 +1769,40 @@ export default function VideoGenerationPage() {
                   {label}
                   {count && <span className="text-[10px] text-gray-500 font-normal">{count}</span>}
                 </button>
+              ))}
+            </div>
+          </div>
+
+          <div className={cardCls + ' mb-6'}>
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <div className="text-[10px] font-medium uppercase tracking-[0.16em] text-radiant-gold">Agentic challenger loop</div>
+                <h2 className="mt-1 text-base font-semibold text-foreground">Human script review packets</h2>
+                <p className="mt-1 max-w-3xl text-xs leading-5 text-gray-400">
+                  These scripts cleared Amina challenger review and can be edited here before render-readiness, HeyGen, ElevenLabs, Remotion, HyperFrames, or publishing gates.
+                </p>
+              </div>
+              <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-300">
+                {AGENTIC_VIDEO_REVIEW_PACKETS.length} ready
+              </span>
+            </div>
+
+            <div className="mt-4 grid gap-3 lg:grid-cols-3">
+              {AGENTIC_VIDEO_REVIEW_PACKETS.map((packet) => (
+                <div key={packet.assetId} className="rounded-lg border border-silicon-slate bg-background/35 p-3">
+                  <div className="flex flex-wrap items-center gap-2 text-[10px] font-medium uppercase tracking-[0.14em] text-gray-500">
+                    <span className="rounded-full border border-radiant-gold/30 px-2 py-0.5 text-radiant-gold">{packet.priority}</span>
+                    <span>{packet.channel}</span>
+                  </div>
+                  <h3 className="mt-3 text-sm font-semibold text-gray-100">{packet.title}</h3>
+                  <p className="mt-2 text-[11px] leading-5 text-gray-400">{packet.humanReview}</p>
+                  <div className="mt-3 rounded-md border border-silicon-slate/70 bg-imperial-navy/45 p-2 text-[10px] leading-5 text-gray-400">
+                    <div><span className="text-gray-500">Challenger:</span> <span className="text-emerald-300">{packet.challengerAgent} - {packet.challengerStatus}</span></div>
+                    <div><span className="text-gray-500">Approval:</span> <span className="text-emerald-300">{packet.approvalStatus}</span></div>
+                    <div><span className="text-gray-500">Source:</span> <code className="text-radiant-gold">{packet.packetPath}</code></div>
+                    <div><span className="text-gray-500">Next gate:</span> {packet.nextGate}</div>
+                  </div>
+                </div>
               ))}
             </div>
           </div>

--- a/app/admin/social-content/page.tsx
+++ b/app/admin/social-content/page.tsx
@@ -37,6 +37,7 @@ import Breadcrumbs from '@/components/admin/Breadcrumbs'
 import { ExtractionStatusChip } from '@/components/admin/ExtractionStatusChip'
 import { useExtractionStatus } from '@/lib/hooks/useExtractionStatus'
 import { getCurrentSession } from '@/lib/auth'
+import { getAgenticContentReviewPacketsForSurface } from '@/lib/agentic-content-review-packets'
 import {
   STATUS_CONFIG,
   CONTENT_STATUSES,
@@ -104,6 +105,7 @@ const VOICE_NOTE_OUTPUTS = [
 ]
 
 const MEETINGS_PER_PAGE = 5
+const AGENTIC_SOCIAL_REVIEW_PACKETS = getAgenticContentReviewPacketsForSurface('social')
 
 function SocialContentQueuePage() {
   const [items, setItems] = useState<SocialContentItem[]>([])
@@ -509,6 +511,49 @@ function SocialContentQueuePage() {
           <div className="admin-console-eyebrow mb-2">Content Operations</div>
           <h1 className="text-2xl font-bold text-foreground">Social Content Queue</h1>
           <p className="text-muted-foreground text-sm">AI-generated posts from meeting transcripts, ready for review, edit, and publish.</p>
+        </div>
+      </div>
+
+      <div className="admin-console-card mb-6 rounded-lg border p-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <div className="admin-console-eyebrow mb-2">Agentic challenger loop</div>
+            <h2 className="text-lg font-semibold text-foreground">Human editorial review packets</h2>
+            <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+              These assets have passed Amina challenger review and can be reviewed by Vambah here before any scheduling, publishing, visual build, or provider step.
+            </p>
+          </div>
+          <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-300">
+            {AGENTIC_SOCIAL_REVIEW_PACKETS.length} ready
+          </span>
+        </div>
+
+        <div className="mt-4 grid gap-3 lg:grid-cols-2">
+          {AGENTIC_SOCIAL_REVIEW_PACKETS.map((packet) => (
+            <div key={packet.assetId} className="rounded-lg border border-silicon-slate bg-imperial-navy/45 p-4">
+              <div className="flex flex-wrap items-center gap-2 text-[10px] font-medium uppercase tracking-[0.14em] text-gray-500">
+                <span className="rounded-full border border-radiant-gold/30 px-2 py-0.5 text-radiant-gold">{packet.priority}</span>
+                <span>{packet.channel}</span>
+                <span>{packet.output}</span>
+              </div>
+              <h3 className="mt-3 text-sm font-semibold text-gray-100">{packet.title}</h3>
+              <p className="mt-2 text-xs leading-5 text-gray-400">{packet.humanReview}</p>
+              <div className="mt-3 grid gap-2 text-[11px] text-gray-500 sm:grid-cols-2">
+                <div>
+                  <span className="text-gray-400">Challenger</span>
+                  <div className="mt-0.5 text-emerald-300">{packet.challengerAgent} - {packet.challengerStatus}</div>
+                </div>
+                <div>
+                  <span className="text-gray-400">Approval</span>
+                  <div className="mt-0.5 text-emerald-300">{packet.approvalStatus}</div>
+                </div>
+              </div>
+              <div className="mt-3 rounded-md border border-silicon-slate/70 bg-background/40 p-2 text-[11px] leading-5 text-gray-400">
+                <div><span className="text-gray-500">Source packet:</span> <code className="text-radiant-gold">{packet.packetPath}</code></div>
+                <div><span className="text-gray-500">Next gate:</span> {packet.nextGate}</div>
+              </div>
+            </div>
+          ))}
         </div>
       </div>
 

--- a/lib/agentic-content-review-packets.test.ts
+++ b/lib/agentic-content-review-packets.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AGENTIC_CONTENT_REVIEW_PACKETS,
+  getAgenticContentReviewPacketsForSurface,
+} from './agentic-content-review-packets'
+
+describe('agentic content review packet registry', () => {
+  it('only exposes challenger-cleared packets to human review surfaces', () => {
+    expect(AGENTIC_CONTENT_REVIEW_PACKETS.length).toBeGreaterThan(0)
+
+    for (const packet of AGENTIC_CONTENT_REVIEW_PACKETS) {
+      expect(packet.challengerAgent).toBe('Amina')
+      expect(packet.challengerStatus).toBe('passed')
+      expect(packet.passToHuman).toBe(true)
+      expect(packet.approvalStatus).toBe('human_review_ready')
+      expect(packet.nextGate).toMatch(/approval|Render-readiness/)
+    }
+  })
+
+  it('routes social and video packets to their existing Portfolio review surfaces', () => {
+    const socialPackets = getAgenticContentReviewPacketsForSurface('social')
+    const videoPackets = getAgenticContentReviewPacketsForSurface('video')
+
+    expect(socialPackets.map((packet) => packet.assetId)).toEqual([
+      'p0-linkedin-flagship-agentic-operating-system',
+      'p0-carousel-seven-things-after-agent-demo',
+      'p1-linkedin-scope-safety-model',
+      'p1-linkedin-agent-qa-scorecards',
+    ])
+
+    expect(videoPackets.map((packet) => packet.assetId)).toEqual([
+      'p0-youtube-agentic-ai-teams-skip',
+      'p1-short-agent-needs-receipt',
+      'p1-short-handoff-work-packet',
+    ])
+  })
+})

--- a/lib/agentic-content-review-packets.ts
+++ b/lib/agentic-content-review-packets.ts
@@ -1,0 +1,145 @@
+export type AgenticContentReviewSurface = 'social' | 'video'
+
+export type AgenticContentReviewPacket = {
+  assetId: string
+  priority: 'P0' | 'P1'
+  title: string
+  channel: string
+  output: string
+  sourceComponent: string
+  packetPath: string
+  draftSource: string
+  challengerAgent: 'Amina'
+  challengerStatus: 'passed'
+  passToHuman: true
+  approvalStatus: 'human_review_ready'
+  humanReview: string
+  nextGate: string
+  targetSurface: AgenticContentReviewSurface
+}
+
+export const AGENTIC_CONTENT_REVIEW_PACKETS: AgenticContentReviewPacket[] = [
+  {
+    assetId: 'p0-linkedin-flagship-agentic-operating-system',
+    priority: 'P0',
+    title: 'Flagship post: Anyone can launch an agent now',
+    channel: 'LinkedIn',
+    output: 'Text post',
+    sourceComponent: 'Core message',
+    packetPath: 'docs/agentic-content-review-packets/p0-challenger-review-packets.md',
+    draftSource: 'docs/agentic-enterprise-value-map.md',
+    challengerAgent: 'Amina',
+    challengerStatus: 'passed',
+    passToHuman: true,
+    approvalStatus: 'human_review_ready',
+    humanReview: 'Ready for editorial approval; publishing still gated.',
+    nextGate: 'Social Content approval before scheduling or publishing.',
+    targetSurface: 'social',
+  },
+  {
+    assetId: 'p0-carousel-seven-things-after-agent-demo',
+    priority: 'P0',
+    title: 'Carousel: 7 things your enterprise agent needs after the demo',
+    channel: 'LinkedIn',
+    output: 'Slide outline',
+    sourceComponent: 'Component library',
+    packetPath: 'docs/agentic-content-review-packets/p0-challenger-review-packets.md',
+    draftSource: 'docs/agentic-value-communications-plan.md',
+    challengerAgent: 'Amina',
+    challengerStatus: 'passed',
+    passToHuman: true,
+    approvalStatus: 'human_review_ready',
+    humanReview: 'Ready for editorial approval; visual build and publishing still gated.',
+    nextGate: 'Visual build review, then Social Content approval before publishing.',
+    targetSurface: 'social',
+  },
+  {
+    assetId: 'p1-linkedin-scope-safety-model',
+    priority: 'P1',
+    title: 'Post: Scope is the safety model',
+    channel: 'LinkedIn',
+    output: 'Text post',
+    sourceComponent: 'Scope',
+    packetPath: 'docs/agentic-content-review-packets/p1-challenger-review-packets.md',
+    draftSource: 'docs/agentic-content-review-packets/p1-challenger-review-packets.md',
+    challengerAgent: 'Amina',
+    challengerStatus: 'passed',
+    passToHuman: true,
+    approvalStatus: 'human_review_ready',
+    humanReview: 'Ready for editorial approval; publishing still gated.',
+    nextGate: 'Social Content approval before scheduling or publishing.',
+    targetSurface: 'social',
+  },
+  {
+    assetId: 'p1-linkedin-agent-qa-scorecards',
+    priority: 'P1',
+    title: 'Post: Agent QA needs scorecards',
+    channel: 'LinkedIn',
+    output: 'Text post',
+    sourceComponent: 'QA loop',
+    packetPath: 'docs/agentic-content-review-packets/p1-challenger-review-packets.md',
+    draftSource: 'docs/agentic-content-review-packets/p1-challenger-review-packets.md',
+    challengerAgent: 'Amina',
+    challengerStatus: 'passed',
+    passToHuman: true,
+    approvalStatus: 'human_review_ready',
+    humanReview: 'Ready for editorial approval; publishing still gated.',
+    nextGate: 'Social Content approval before scheduling or publishing.',
+    targetSurface: 'social',
+  },
+  {
+    assetId: 'p0-youtube-agentic-ai-teams-skip',
+    priority: 'P0',
+    title: 'YouTube script: The Part of Agentic AI Most Teams Skip',
+    channel: 'YouTube',
+    output: '6-10 minute script',
+    sourceComponent: 'Full lifecycle',
+    packetPath: 'docs/agentic-content-review-packets/p0-challenger-review-packets.md',
+    draftSource: 'docs/agentic-content-video-scripts/wave-1-youtube-scripts.md',
+    challengerAgent: 'Amina',
+    challengerStatus: 'passed',
+    passToHuman: true,
+    approvalStatus: 'human_review_ready',
+    humanReview: 'Ready for editorial approval; render and provider work still gated.',
+    nextGate: 'Render-readiness packet before HeyGen, ElevenLabs, Remotion, HyperFrames, or publishing.',
+    targetSurface: 'video',
+  },
+  {
+    assetId: 'p1-short-agent-needs-receipt',
+    priority: 'P1',
+    title: 'Short: The agent needs a receipt',
+    channel: 'TikTok/Reels/Shorts',
+    output: '45-second script',
+    sourceComponent: 'Observability',
+    packetPath: 'docs/agentic-content-review-packets/p1-challenger-review-packets.md',
+    draftSource: 'docs/agentic-content-review-packets/p1-challenger-review-packets.md',
+    challengerAgent: 'Amina',
+    challengerStatus: 'passed',
+    passToHuman: true,
+    approvalStatus: 'human_review_ready',
+    humanReview: 'Ready for editorial approval; render and provider work still gated.',
+    nextGate: 'Render-readiness packet before HeyGen, ElevenLabs, Remotion, HyperFrames, or publishing.',
+    targetSurface: 'video',
+  },
+  {
+    assetId: 'p1-short-handoff-work-packet',
+    priority: 'P1',
+    title: 'Short: A handoff is a work packet',
+    channel: 'TikTok/Reels/Shorts',
+    output: '45-second script',
+    sourceComponent: 'Handoff',
+    packetPath: 'docs/agentic-content-review-packets/p1-challenger-review-packets.md',
+    draftSource: 'docs/agentic-content-review-packets/p1-challenger-review-packets.md',
+    challengerAgent: 'Amina',
+    challengerStatus: 'passed',
+    passToHuman: true,
+    approvalStatus: 'human_review_ready',
+    humanReview: 'Ready for editorial approval; render and provider work still gated.',
+    nextGate: 'Render-readiness packet before HeyGen, ElevenLabs, Remotion, HyperFrames, or publishing.',
+    targetSurface: 'video',
+  },
+]
+
+export function getAgenticContentReviewPacketsForSurface(surface: AgenticContentReviewSurface) {
+  return AGENTIC_CONTENT_REVIEW_PACKETS.filter((packet) => packet.targetSurface === surface)
+}


### PR DESCRIPTION
## Summary
- Adds a shared agentic content review packet registry for challenger-cleared P0/P1 assets.
- Surfaces LinkedIn/carousel packets in the Social Content Queue as human editorial review-ready cards.
- Surfaces YouTube/short-form scripts in Video Generation as human script review-ready cards before render/provider gates.

## Validation
- `npm test -- --run lib/agentic-content-review-packets.test.ts`
- `npm run lint`
- `npx tsc --noEmit`
- `git diff --check`
- `MOCK_N8N=true N8N_DISABLE_OUTBOUND=true PORT=3005 npm run dev`
- In-app Browser smoke: `/admin/social-content` and `/admin/content/video-generation` compile and route through the admin auth boundary with no framework overlay or console errors. No authenticated post-login panel smoke was run.
- Pre-push `npm run db:health-check` passed.

## Integration Notes
- No migrations or env changes.
- No database seeding, provider execution, publishing, render, HeyGen, ElevenLabs, Remotion, HyperFrames, n8n, or external-send side effects.
- P2 packets remain in open PR #461; this registry can be extended after that PR lands.
- Vercel contexts not checked by this non-captain slice after PR creation:
  - Vercel – portfolio
  - Vercel – portfolio-staging
