### PR TITLE
Add OpenClaw evaluation gate to Open Brain runtime plan

### DIFF
--- a/docs/open-brain-local-service.md
+++ b/docs/open-brain-local-service.md
@@ -125,6 +125,20 @@ npm run open-brain:runtime-registration -- --write tmp/open-brain-runtime-regist
 
 The planner is intentionally non-mutating. It does not create or edit `~/.codex/config.toml`, `~/.hermes/config.yaml`, Cursor/Claude/OpenCode config files, or durable Open Brain memory records. Actual runtime registration remains a local-state approval step and should be performed one runtime at a time, followed by that runtime's own doctor/list/manual MCP verification.
 
+### OpenClaw Evaluation Gate
+
+OpenClaw is not required for Phase 2 parity unless it proves value beyond the already connected runtimes. Treat it as an evaluation candidate, not an install-by-default dependency.
+
+Before installing or registering OpenClaw, confirm:
+
+- it supports the local Open Brain MCP stdio server without copying secrets or weakening approval gates,
+- it can consume generated personality-pack exports without drifting from the canonical corpus,
+- durable memory writes remain proposal-gated, auditable, reversible, and local-first,
+- it provides coding, planning, long-running execution, or interoperability value Hermes does not already cover,
+- and setup, auth, config backups, doctor/list verification, and rollback are maintainable across future parity checks.
+
+If those criteria are not met, keep OpenClaw on the migration watch list and defer installation.
+
 ## Karpathy Wiki Overlay
 
 Karpathy Wiki pages are compiled views from approved, non-private Open Brain records. Initial pages:

--- a/lib/open-brain-runtime-registration.test.ts
+++ b/lib/open-brain-runtime-registration.test.ts
@@ -42,6 +42,9 @@ describe('Open Brain runtime registration planner', () => {
       },
     })
     expect(plan.safetyBoundary.join(' ')).toContain('no agent config files are edited')
+    expect(plan.safetyBoundary.join(' ')).toContain('OpenClaw is an evaluation candidate')
+    expect(plan.evaluationGates.join(' ')).toContain('Differentiated value')
+    expect(plan.evaluationGates.join(' ')).toContain('Hermes does not already cover')
     expect(plan.targets.map((target) => target.runtime)).toEqual([
       'codex',
       'hermes',
@@ -67,6 +70,8 @@ describe('Open Brain runtime registration planner', () => {
 
     expect(markdown).toContain('# Open Brain Runtime Registration Packet')
     expect(markdown).toContain('## Safety Boundary')
+    expect(markdown).toContain('## Evaluation Gates')
+    expect(markdown).toContain('Open Brain MCP support')
     expect(markdown).toContain('### Codex')
     expect(markdown).toContain('OPEN_BRAIN_HOME')
     expect(markdown).not.toMatch(/sk-[A-Za-z0-9]/)

--- a/lib/open-brain-runtime-registration.ts
+++ b/lib/open-brain-runtime-registration.ts
@@ -27,6 +27,7 @@ export interface OpenBrainRuntimeRegistrationPlan {
   }
   safetyBoundary: string[]
   setupCommands: string[]
+  evaluationGates: string[]
   targets: OpenBrainRuntimeRegistrationTarget[]
   nextAction: string
 }
@@ -127,12 +128,20 @@ export function buildOpenBrainRuntimeRegistrationPlan(
       'Dry-run packet only; no agent config files are edited by this planner.',
       'Create OPEN_BRAIN_HOME before registration, but do not promote durable memories without approval.',
       'Register each runtime in its own native config surface; Codex config is not inherited by Hermes, Claude, Cursor, OpenCode, or OpenClaw.',
+      'OpenClaw is an evaluation candidate until installed and approved; do not add it only for parity if Hermes already covers the required workflow.',
       'After registration, verify each runtime with its own list, doctor, or manual MCP tool call before marking it connected.',
     ],
     setupCommands: [
       `mkdir -p ${shellQuote(openBrainHome)}`,
       `OPEN_BRAIN_HOME=${shellQuote(openBrainHome)} OPEN_BRAIN_PORTFOLIO_ROOT=${shellQuote(portfolioRoot)} npm --prefix ${shellQuote(portfolioRoot)} test -- --run scripts/open-brain-mcp-server.test.ts lib/open-brain.test.ts`,
       `OPEN_BRAIN_HOME=${shellQuote(openBrainHome)} OPEN_BRAIN_PORTFOLIO_ROOT=${shellQuote(portfolioRoot)} npm --prefix ${shellQuote(portfolioRoot)} run open-brain:runtime-registration`,
+    ],
+    evaluationGates: [
+      'Open Brain MCP support: the runtime can register the local Open Brain stdio server without copying secrets or weakening approval gates.',
+      'Personality pack ingestion: the runtime can consume generated public-safe/personality-pack exports without drifting from the canonical corpus.',
+      'Governance fit: durable memory writes remain proposal-gated, auditable, reversible, and local-first.',
+      'Differentiated value: the runtime provides coding, planning, long-running execution, or interoperability capabilities that Hermes does not already cover.',
+      'Operational cost: setup, auth, config backups, doctor/list verification, and rollback are simple enough to maintain across future parity checks.',
     ],
     targets,
     nextAction: 'Review the target snippets, approve one runtime registration at a time, then run the matching verify command.',
@@ -158,6 +167,10 @@ export function renderOpenBrainRuntimeRegistrationMarkdown(plan: OpenBrainRuntim
     '## Setup Checks',
     '',
     ...plan.setupCommands.map((command) => `- \`${command}\``),
+    '',
+    '## Evaluation Gates',
+    '',
+    ...plan.evaluationGates.map((item) => `- ${item}`),
     '',
     '## Targets',
     '',


### PR DESCRIPTION
## Summary\n- Adds explicit OpenClaw evaluation gates to the Open Brain runtime registration planner.\n- Documents that OpenClaw should remain an evaluation candidate unless it proves value beyond Hermes and the already connected runtimes.\n- Extends planner tests so generated packets include the evaluation criteria.\n\n## Validation\n- npm --prefix /Users/vambahsillah/Projects/Portfolio test -- --run lib/open-brain-runtime-registration.test.ts\n- OPEN_BRAIN_HOME=/Users/vambahsillah/.open-brain OPEN_BRAIN_PORTFOLIO_ROOT=/Users/vambahsillah/Projects/Portfolio npm --prefix /Users/vambahsillah/Projects/Portfolio test -- --run scripts/open-brain-mcp-server.test.ts lib/open-brain.test.ts\n- git diff --check\n- push hook database health check passed\n\n## Roadmap Status\n- Completed: OpenClaw moved from immediate parity configuration to an explicit evaluation gate.\n- Next: keep OpenClaw on migration watch until it proves Open Brain MCP support, personality-pack ingestion, governance fit, differentiated value over Hermes, and maintainable rollback/verification.\n- Blockers: none.