### PR TITLE
fix: relax redesigned admin layout constraints

### DIFF
--- a/app/admin/outreach/page.tsx
+++ b/app/admin/outreach/page.tsx
@@ -1069,7 +1069,8 @@ function OutreachContent() {
                         }`}
                       >
                         {/* Lead Card Header */}
-                        <div className="p-4 flex items-start gap-3">
+                        <div className="grid gap-4 p-4 xl:grid-cols-[minmax(0,1fr)_minmax(18rem,auto)] xl:items-start">
+                          <div className="flex min-w-0 items-start gap-3">
                           <label className="flex-shrink-0 pt-0.5 cursor-pointer">
                             <input
                               type="checkbox"
@@ -1135,7 +1136,7 @@ function OutreachContent() {
                                 <span className="px-2 py-0.5 bg-red-900/50 text-red-300 rounded text-xs">Removed</span>
                               )}
                             </div>
-                            <div className="flex items-center gap-3 mt-1 text-sm text-muted-foreground">
+                            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1 text-sm text-muted-foreground">
                               {lead.job_title && (
                                 <span className="flex items-center gap-1">
                                   <User size={12} />
@@ -1272,9 +1273,10 @@ function OutreachContent() {
                               })()}
                             </div>
                           </div>
+                          </div>
 
                           {/* Actions — primary CTA + progressive fallback + More + expand */}
-                          <div className="flex items-center gap-2 shrink-0">
+                          <div className="flex w-full min-w-0 items-start justify-end gap-2 xl:w-[min(36rem,42vw)]">
                             {/* Primary CTA: pipeline-style pill (idle / running / succeeded / failed / cancelled / link). */}
                             <OutreachEmailGenerateRow
                               lead={lead}

--- a/app/admin/sales/conversation/[sessionId]/page.tsx
+++ b/app/admin/sales/conversation/[sessionId]/page.tsx
@@ -1006,7 +1006,7 @@ export default function ConversationPage() {
         </div>
 
         {/* Main row: Timeline | Script + objections | Unified offer panel */}
-        <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_minmax(0,1.15fr)_minmax(320px,480px)] gap-4 mb-6">
+        <div className="grid grid-cols-1 gap-4 mb-6 xl:grid-cols-[minmax(260px,0.8fr)_minmax(360px,1fr)_minmax(420px,1fr)]">
           {/* ---- Col 1: Conversation Timeline ---- */}
           <div className="admin-console-card flex h-[678px] min-h-[320px] flex-col overflow-hidden rounded-lg border">
             <div className="flex-1 min-h-0 overflow-y-auto p-4">
@@ -1086,7 +1086,7 @@ export default function ConversationPage() {
           </div>
 
           {/* ---- Col 3: Offer panel (Suggested/All + bundles, catalog, stack) ---- */}
-          <div className="min-h-[280px] flex flex-col xl:min-h-0">
+          <div className="min-h-[280px] min-w-0 flex flex-col xl:min-h-0">
             <StreamlinedProductSelection
               products={selectedAsProducts}
               totalPrice={grandSlamOffer.offerPrice}

--- a/components/admin/OutreachEmailGenerateRow.tsx
+++ b/components/admin/OutreachEmailGenerateRow.tsx
@@ -483,7 +483,7 @@ export function OutreachEmailGenerateRow({
   if (showN8nBarSuccess) {
     outreachBar = (
       <div
-        className="inline-flex h-9 min-h-11 w-full min-w-0 max-w-sm items-stretch justify-between gap-0 overflow-hidden rounded-lg bg-emerald-600/90 text-sm font-medium text-white"
+        className="inline-flex h-9 min-h-11 w-full min-w-0 items-stretch justify-between gap-0 overflow-hidden rounded-lg bg-emerald-600/90 text-sm font-medium text-white"
         role="status"
       >
         <button
@@ -530,7 +530,7 @@ export function OutreachEmailGenerateRow({
     )
   } else if (state === 'cancelled') {
     outreachBar = (
-      <div className="inline-flex h-9 min-h-11 w-full min-w-0 max-w-sm items-center gap-2 rounded-lg border border-silicon-slate bg-silicon-slate/40 px-3 text-sm text-muted-foreground">
+      <div className="inline-flex h-9 min-h-11 w-full min-w-0 items-center gap-2 rounded-lg border border-silicon-slate bg-silicon-slate/40 px-3 text-sm text-muted-foreground">
         <X size={14} className="shrink-0" />
         <span>Stopped</span>
         {queueCountLabel && <span className="truncate text-xs">· {queueCountLabel}</span>}
@@ -541,7 +541,7 @@ export function OutreachEmailGenerateRow({
     (serverN8nFailed && !n8nActive && !inAppRunning)
   ) {
     outreachBar = (
-      <div className="flex w-full min-w-0 max-w-sm flex-col gap-1 sm:flex-row sm:items-center sm:gap-2">
+      <div className="flex w-full min-w-0 flex-col gap-1 sm:flex-row sm:items-center sm:gap-2">
         <button
           type="button"
           onClick={() => {
@@ -571,7 +571,7 @@ export function OutreachEmailGenerateRow({
       : `${runningHeadline} — ${phase} · open for details`
     outreachBar = (
       <div
-        className="flex w-full min-w-0 max-w-sm overflow-hidden rounded-lg border border-amber-500/50 min-h-11"
+        className="flex w-full min-w-0 overflow-hidden rounded-lg border border-amber-500/50 min-h-11"
         role="group"
         aria-label={`${runningHeadline} for ${lead.name}`}
       >
@@ -629,7 +629,7 @@ export function OutreachEmailGenerateRow({
         onMouseEnter={() => {
           void fetchSuggested()
         }}
-        className="inline-flex h-9 min-h-11 w-full min-w-0 max-w-sm items-center justify-center gap-1.5 rounded-lg bg-gradient-to-r from-emerald-500 to-teal-500 px-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:from-emerald-600 hover:to-teal-600 focus:outline-none focus:ring-2 focus:ring-emerald-400/50"
+        className="inline-flex h-9 min-h-11 w-full min-w-0 items-center justify-center gap-1.5 rounded-lg bg-gradient-to-r from-emerald-500 to-teal-500 px-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:from-emerald-600 hover:to-teal-600 focus:outline-none focus:ring-2 focus:ring-emerald-400/50"
         title={
           queueCountLabel
             ? `Outreach, templates, and queue for ${lead.name} (${queueCountLabel})`
@@ -663,7 +663,7 @@ export function OutreachEmailGenerateRow({
   }
 
   return (
-    <div className="relative w-full min-w-0 max-w-md" ref={panelRef}>
+    <div className="relative w-full min-w-0" ref={panelRef}>
       <div className="flex min-w-0 flex-wrap items-center gap-1.5">{outreachBar}</div>
 
       {showProgressCard && (
@@ -697,7 +697,7 @@ export function OutreachEmailGenerateRow({
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -6 }}
             transition={{ duration: 0.12 }}
-            className="absolute right-0 top-full z-40 mt-1.5 w-[min(100vw-1.5rem,22rem)] overflow-hidden rounded-lg border border-silicon-slate bg-imperial-navy text-foreground shadow-2xl"
+            className="absolute right-0 top-full z-40 mt-1.5 w-[min(100vw-1.5rem,28rem)] overflow-hidden rounded-lg border border-silicon-slate bg-imperial-navy text-foreground shadow-2xl"
             role="dialog"
             aria-label="Outreach options"
           >

--- a/components/admin/sales/DynamicScriptFlow.tsx
+++ b/components/admin/sales/DynamicScriptFlow.tsx
@@ -65,24 +65,24 @@ export function DynamicScriptFlow({
   // Not started state
   if (!isCallActive) {
     return (
-      <div className="text-center py-12">
-        <div className="w-20 h-20 mx-auto mb-4 bg-emerald-500/20 rounded-full flex items-center justify-center">
+      <div className="rounded-lg border border-silicon-slate/60 bg-background/35 p-6 text-left">
+        <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-emerald-500/20">
           <Play className="w-10 h-10 text-emerald-400" />
         </div>
         <h3 className="text-xl font-semibold text-white mb-2">Ready to Start Call</h3>
-        <p className="text-gray-400 mb-6 max-w-md mx-auto">
+        <p className="text-gray-400 mb-6 max-w-2xl">
           Click below to generate your personalized opening based on the client&apos;s diagnostic data.
           The script will adapt to their responses throughout the conversation.
         </p>
         {generationError && (
-          <div className="max-w-md mx-auto mb-4 rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+          <div className="mb-4 rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-200">
             {generationError}
           </div>
         )}
         <button
           onClick={onStartCall}
           disabled={isLoadingNextStep}
-          className="px-6 py-3 bg-emerald-600 text-white rounded-lg font-medium hover:bg-emerald-700 transition-colors flex items-center gap-2 mx-auto disabled:opacity-50 disabled:cursor-not-allowed"
+          className="px-6 py-3 bg-emerald-600 text-white rounded-lg font-medium hover:bg-emerald-700 transition-colors inline-flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {isLoadingNextStep ? <RefreshCw className="w-5 h-5 animate-spin" /> : <Play className="w-5 h-5" />}
           {generationError ? 'Retry Dynamic Script' : 'Start Dynamic Script'}

--- a/components/admin/sales/StreamlinedProductSelection.tsx
+++ b/components/admin/sales/StreamlinedProductSelection.tsx
@@ -117,7 +117,7 @@ export function StreamlinedProductSelection({
   const useCustomAllCatalog = typeof allCatalogContent === 'function';
 
   return (
-    <div className="bg-gray-900 rounded-lg border border-gray-800 flex flex-col min-h-0 h-full max-h-[min(75vh,720px)] xl:max-h-[calc(100vh-10rem)] min-w-0 w-full sm:min-w-[300px] sm:max-w-[480px] flex-1">
+    <div className="bg-gray-900 rounded-lg border border-gray-800 flex flex-col min-h-0 h-full max-h-[min(75vh,720px)] xl:max-h-[calc(100vh-10rem)] min-w-0 w-full flex-1">
       <div className="p-3 sm:p-4 border-b border-gray-800 shrink-0 space-y-3">
         <div className="flex rounded-lg bg-gray-800 border border-gray-700 p-0.5">
           <button
@@ -125,7 +125,7 @@ export function StreamlinedProductSelection({
             onClick={() => setViewMode('suggested')}
             className={`flex-1 flex items-center justify-center gap-1.5 py-2 text-xs font-medium rounded-md transition-colors ${
               viewMode === 'suggested'
-                ? 'bg-purple-600 text-white'
+                ? 'bg-radiant-gold text-silicon-slate'
                 : 'text-gray-400 hover:text-gray-300'
             }`}
           >
@@ -137,7 +137,7 @@ export function StreamlinedProductSelection({
             onClick={() => setViewMode('all')}
             className={`flex-1 flex items-center justify-center gap-1.5 py-2 text-xs font-medium rounded-md transition-colors ${
               viewMode === 'all'
-                ? 'bg-purple-600 text-white'
+                ? 'bg-radiant-gold text-silicon-slate'
                 : 'text-gray-400 hover:text-gray-300'
             }`}
           >
@@ -152,7 +152,7 @@ export function StreamlinedProductSelection({
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               placeholder="Search products and content…"
-              className="w-full pl-8 pr-3 py-2 text-sm bg-gray-800 border border-gray-700 rounded-lg text-gray-200 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+              className="w-full pl-8 pr-3 py-2 text-sm bg-gray-800 border border-gray-700 rounded-lg text-gray-200 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-radiant-gold/60 focus:border-transparent"
               aria-label="Search products and content"
             />
           </div>


### PR DESCRIPTION
## Summary
- Relaxes fixed-width constraints on redesigned Lead Pipeline outreach rows so lead identity, metadata, and action controls use the available row width instead of compressing into narrow blocks.
- Lets the Outreach action bar and dialog size with the lead row while preserving the compact action/menu pattern.
- Rebalances the Sales Conversation three-column workbench so Timeline, Script Guide, and product/offer selection fit inside the admin content width with no clipped right rail.
- Aligns the sales product selector active state/focus ring with the Mission Control gold command aesthetic instead of the older purple treatment.

## Validation
- `npm run build:knowledge`
- `npx tsc --noEmit --pretty false`
- `npm run lint`
- `git diff --check`
- Authenticated Playwright smoke on local `http://localhost:3007`:
  - `/admin/outreach?tab=leads` at 1565x1238 and 1240x944
  - `/admin/sales` → first `/admin/sales/conversation/[sessionId]` at 1565x1238 and 1240x944
  - Confirmed `scrollWidth === viewport width` and `overflowX === 0` on both affected surfaces.
- `npm run build`
- Pre-push `npm run db:health-check` hook passed.

## Integration Notes
- No database migration.
- No API changes.
- No outbound workflow actions were triggered during QA; local build/dev logs still show the existing `.env.local` warning that outbound n8n is enabled.
- Vercel contexts not checked yet; this PR is draft pending integration-captain review and preview deployment checks.
