### PR TITLE
fix: make challenger packets actionable

### DIFF
--- a/app/admin/social-content/page.tsx
+++ b/app/admin/social-content/page.tsx
@@ -31,6 +31,8 @@ import {
   MicOff,
   Sparkles,
   Plus,
+  ExternalLink,
+  RotateCcw,
 } from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
@@ -106,6 +108,11 @@ const VOICE_NOTE_OUTPUTS = [
 
 const MEETINGS_PER_PAGE = 5
 const AGENTIC_SOCIAL_REVIEW_PACKETS = getAgenticContentReviewPacketsForSurface('social')
+const GITHUB_DOC_BASE_URL = 'https://github.com/vsillah/Portfolio/blob/main/'
+
+function sourcePacketUrl(path: string) {
+  return `${GITHUB_DOC_BASE_URL}${path}`
+}
 
 function SocialContentQueuePage() {
   const [items, setItems] = useState<SocialContentItem[]>([])
@@ -538,6 +545,18 @@ function SocialContentQueuePage() {
               </div>
               <h3 className="mt-3 text-sm font-semibold text-gray-100">{packet.title}</h3>
               <p className="mt-2 text-xs leading-5 text-gray-400">{packet.humanReview}</p>
+              <div className="mt-3 rounded-md border border-radiant-gold/25 bg-radiant-gold/10 p-3">
+                <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-radiant-gold">Human decision</div>
+                <p className="mt-1 text-xs leading-5 text-gray-200">{packet.decisionPrompt}</p>
+                <div className="mt-3 grid gap-2 text-[11px] leading-5 sm:grid-cols-2">
+                  <div className="rounded-md border border-emerald-500/20 bg-emerald-500/10 p-2 text-emerald-100">
+                    <span className="font-semibold text-emerald-300">Approve path:</span> {packet.approveMeaning}
+                  </div>
+                  <div className="rounded-md border border-amber-500/20 bg-amber-500/10 p-2 text-amber-100">
+                    <span className="font-semibold text-amber-300">Send back:</span> {packet.sendBackMeaning}
+                  </div>
+                </div>
+              </div>
               <div className="mt-3 grid gap-2 text-[11px] text-gray-500 sm:grid-cols-2">
                 <div>
                   <span className="text-gray-400">Challenger</span>
@@ -551,6 +570,31 @@ function SocialContentQueuePage() {
               <div className="mt-3 rounded-md border border-silicon-slate/70 bg-background/40 p-2 text-[11px] leading-5 text-gray-400">
                 <div><span className="text-gray-500">Source packet:</span> <code className="text-radiant-gold">{packet.packetPath}</code></div>
                 <div><span className="text-gray-500">Next gate:</span> {packet.nextGate}</div>
+              </div>
+              <div className="mt-3 flex flex-wrap gap-2">
+                <a
+                  href={sourcePacketUrl(packet.packetPath)}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-1.5 rounded-md border border-silicon-slate bg-background/50 px-3 py-2 text-xs font-medium text-gray-200 transition-colors hover:border-radiant-gold/50 hover:text-radiant-gold"
+                >
+                  <ExternalLink className="h-3.5 w-3.5" />
+                  Review packet
+                </a>
+                <a
+                  href="#social-content-approval-queue"
+                  className="inline-flex items-center gap-1.5 rounded-md border border-radiant-gold/60 bg-radiant-gold px-3 py-2 text-xs font-semibold text-slate-950 transition-colors hover:bg-radiant-gold/90"
+                >
+                  <CheckCircle2 className="h-3.5 w-3.5" />
+                  Open approval gate
+                </a>
+                <Link
+                  href={`/admin/agents/standup?context=agentic-content-review&asset=${encodeURIComponent(packet.assetId)}`}
+                  className="inline-flex items-center gap-1.5 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs font-medium text-amber-200 transition-colors hover:border-amber-400 hover:text-amber-100"
+                >
+                  <RotateCcw className="h-3.5 w-3.5" />
+                  Send back for repair
+                </Link>
               </div>
             </div>
           ))}
@@ -1114,6 +1158,7 @@ function SocialContentQueuePage() {
       </div>
 
       {/* Content List */}
+      <div id="social-content-approval-queue" className="scroll-mt-24" />
       {loading ? (
         <div className="flex items-center justify-center py-20">
           <Loader2 className="w-6 h-6 text-gray-400 animate-spin" />

--- a/lib/agentic-content-review-packets.test.ts
+++ b/lib/agentic-content-review-packets.test.ts
@@ -14,6 +14,9 @@ describe('agentic content review packet registry', () => {
       expect(packet.passToHuman).toBe(true)
       expect(packet.approvalStatus).toBe('human_review_ready')
       expect(packet.nextGate).toMatch(/approval|Render-readiness/)
+      expect(packet.decisionPrompt).toMatch(/Decide/)
+      expect(packet.approveMeaning).toMatch(/Open/)
+      expect(packet.sendBackMeaning).toMatch(/Route a repair task/)
     }
   })
 

--- a/lib/agentic-content-review-packets.ts
+++ b/lib/agentic-content-review-packets.ts
@@ -15,6 +15,9 @@ export type AgenticContentReviewPacket = {
   approvalStatus: 'human_review_ready'
   humanReview: string
   nextGate: string
+  decisionPrompt: string
+  approveMeaning: string
+  sendBackMeaning: string
   targetSurface: AgenticContentReviewSurface
 }
 
@@ -34,6 +37,9 @@ export const AGENTIC_CONTENT_REVIEW_PACKETS: AgenticContentReviewPacket[] = [
     approvalStatus: 'human_review_ready',
     humanReview: 'Ready for editorial approval; publishing still gated.',
     nextGate: 'Social Content approval before scheduling or publishing.',
+    decisionPrompt: 'Decide whether this LinkedIn post is ready to become a Social Content draft approval.',
+    approveMeaning: 'Open the Social Content approval gate, inspect the draft, then approve or publish only from that governed draft screen.',
+    sendBackMeaning: 'Route a repair task if the claim, voice, source support, or channel fit is not ready for public review.',
     targetSurface: 'social',
   },
   {
@@ -51,6 +57,9 @@ export const AGENTIC_CONTENT_REVIEW_PACKETS: AgenticContentReviewPacket[] = [
     approvalStatus: 'human_review_ready',
     humanReview: 'Ready for editorial approval; visual build and publishing still gated.',
     nextGate: 'Visual build review, then Social Content approval before publishing.',
+    decisionPrompt: 'Decide whether this carousel outline is ready for visual build review.',
+    approveMeaning: 'Open the Social Content approval path after reviewing the outline; visual build and publishing remain separate gates.',
+    sendBackMeaning: 'Route a repair task if the slide story, evidence, or sequence needs another challenger pass.',
     targetSurface: 'social',
   },
   {
@@ -68,6 +77,9 @@ export const AGENTIC_CONTENT_REVIEW_PACKETS: AgenticContentReviewPacket[] = [
     approvalStatus: 'human_review_ready',
     humanReview: 'Ready for editorial approval; publishing still gated.',
     nextGate: 'Social Content approval before scheduling or publishing.',
+    decisionPrompt: 'Decide whether this LinkedIn post is ready to become a Social Content draft approval.',
+    approveMeaning: 'Open the Social Content approval gate, inspect the draft, then approve or publish only from that governed draft screen.',
+    sendBackMeaning: 'Route a repair task if the scope claim, safety framing, source support, or voice needs revision.',
     targetSurface: 'social',
   },
   {
@@ -85,6 +97,9 @@ export const AGENTIC_CONTENT_REVIEW_PACKETS: AgenticContentReviewPacket[] = [
     approvalStatus: 'human_review_ready',
     humanReview: 'Ready for editorial approval; publishing still gated.',
     nextGate: 'Social Content approval before scheduling or publishing.',
+    decisionPrompt: 'Decide whether this LinkedIn post is ready to become a Social Content draft approval.',
+    approveMeaning: 'Open the Social Content approval gate, inspect the draft, then approve or publish only from that governed draft screen.',
+    sendBackMeaning: 'Route a repair task if the QA claim, scorecard framing, source support, or voice needs revision.',
     targetSurface: 'social',
   },
   {
@@ -102,6 +117,9 @@ export const AGENTIC_CONTENT_REVIEW_PACKETS: AgenticContentReviewPacket[] = [
     approvalStatus: 'human_review_ready',
     humanReview: 'Ready for editorial approval; render and provider work still gated.',
     nextGate: 'Render-readiness packet before HeyGen, ElevenLabs, Remotion, HyperFrames, or publishing.',
+    decisionPrompt: 'Decide whether this script is ready for render-readiness review.',
+    approveMeaning: 'Open the video review surface and approve only the next render-readiness step; provider work remains gated.',
+    sendBackMeaning: 'Route a repair task if the script, claims, evidence, or delivery shape needs revision.',
     targetSurface: 'video',
   },
   {
@@ -119,6 +137,9 @@ export const AGENTIC_CONTENT_REVIEW_PACKETS: AgenticContentReviewPacket[] = [
     approvalStatus: 'human_review_ready',
     humanReview: 'Ready for editorial approval; render and provider work still gated.',
     nextGate: 'Render-readiness packet before HeyGen, ElevenLabs, Remotion, HyperFrames, or publishing.',
+    decisionPrompt: 'Decide whether this short script is ready for render-readiness review.',
+    approveMeaning: 'Open the video review surface and approve only the next render-readiness step; provider work remains gated.',
+    sendBackMeaning: 'Route a repair task if the hook, claim, evidence, or short-form pacing needs revision.',
     targetSurface: 'video',
   },
   {
@@ -136,6 +157,9 @@ export const AGENTIC_CONTENT_REVIEW_PACKETS: AgenticContentReviewPacket[] = [
     approvalStatus: 'human_review_ready',
     humanReview: 'Ready for editorial approval; render and provider work still gated.',
     nextGate: 'Render-readiness packet before HeyGen, ElevenLabs, Remotion, HyperFrames, or publishing.',
+    decisionPrompt: 'Decide whether this short script is ready for render-readiness review.',
+    approveMeaning: 'Open the video review surface and approve only the next render-readiness step; provider work remains gated.',
+    sendBackMeaning: 'Route a repair task if the handoff framing, claim, evidence, or short-form pacing needs revision.',
     targetSurface: 'video',
   },
 ]


### PR DESCRIPTION
## Summary
- Makes Agentic Challenger Loop packets actionable instead of passive readiness cards.
- Adds explicit human decision copy for each packet: what approving means and what sending back means.
- Adds clear paths from each packet to the source review document, the existing Social Content approval gate, and Standup Room repair routing.

## Validation
- `npm test -- lib/agentic-content-review-packets.test.ts`
- `npx tsc --noEmit --pretty false`
- `npm run lint`
- `npm run build`
- Pre-push `npm run db:health-check` passed.

## Browser / Computer Use QA
- `/admin/social-content`: confirmed challenger cards now show `Human decision`, `Approve path`, `Send back`, `Review packet`, `Open approval gate`, and `Send back for repair`.
- `/admin/social-content#social-content-approval-queue`: confirmed `Open approval gate` jumps to the existing draft list where governed approve/reject controls live.
- `/admin/agents/standup`: confirmed attendance multi-select, avatars, standup control, chat, goal planner, radiators, trace history, and Kanban preview render after safe local dev restart.
- `/admin/agents/swarm-board`: confirmed Kanban route renders fixed lane model, action queue, dependency tracing, owner avatars/badges, trace/PR links, and collapsed empty Complete lane.
- No approve/reject/publish/start-standup/Slack-send mutation controls were clicked.

## Integration Notes
- Scoped to Social Content challenger packet UI and packet metadata.
- No schema, API, publishing, provider, credential, or outbound behavior changes.
- Existing governance remains intact: this PR adds navigation and decision clarity, not a new approval mutation path.
- Open PR #464 touches admin layout constraints; no planned file overlap with this PR.
- Vercel contexts not checked from this worker lane; captain should verify `Vercel – portfolio` and `Vercel – portfolio-staging` after merge sequencing.
