### PR TITLE
fix: keep agent avatars available in protected previews

### DIFF
--- a/components/admin/AgentAvatar.tsx
+++ b/components/admin/AgentAvatar.tsx
@@ -1,5 +1,8 @@
+'use client'
+
 import Image from 'next/image'
-import { getAgentAvatar, getAvatarToneStyles } from '@/lib/agent-avatars'
+import { useEffect, useState } from 'react'
+import { getAgentAvatar, getAvatarToneStyles, resolveAgentAvatarImageSrc } from '@/lib/agent-avatars'
 
 export default function AgentAvatar({
   agentKey,
@@ -13,6 +16,12 @@ export default function AgentAvatar({
   const avatar = getAgentAvatar(agentKey)
   const tone = getAvatarToneStyles(avatar.tone)
   const sizeClass = size === 'sm' ? 'h-8 w-8 text-[10px]' : size === 'lg' ? 'h-14 w-14 text-sm' : 'h-11 w-11 text-xs'
+  const imageSrc = resolveAgentAvatarImageSrc(avatar.imagePath)
+  const [imageFailed, setImageFailed] = useState(false)
+
+  useEffect(() => {
+    setImageFailed(false)
+  }, [imageSrc])
 
   return (
     <div
@@ -26,15 +35,22 @@ export default function AgentAvatar({
         color: tone.mark,
       }}
     >
-      <Image
-        src={avatar.imagePath}
-        alt=""
-        aria-hidden="true"
-        fill
-        sizes="56px"
-        unoptimized
-        className="absolute inset-[2px] h-[calc(100%-4px)] w-[calc(100%-4px)] object-contain"
-      />
+      {!imageFailed ? (
+        <Image
+          src={imageSrc}
+          alt=""
+          aria-hidden="true"
+          fill
+          sizes="56px"
+          unoptimized
+          className="absolute inset-[2px] h-[calc(100%-4px)] w-[calc(100%-4px)] object-contain"
+          onError={() => setImageFailed(true)}
+        />
+      ) : (
+        <span aria-hidden="true" className="relative z-10">
+          {avatar.initials}
+        </span>
+      )}
     </div>
   )
 }

--- a/lib/agent-avatars.test.ts
+++ b/lib/agent-avatars.test.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { AGENT_ORGANIZATION } from '@/lib/agent-organization'
-import { AGENT_AVATARS, getMissingAgentAvatarKeys } from '@/lib/agent-avatars'
+import { AGENT_AVATARS, getMissingAgentAvatarKeys, resolveAgentAvatarImageSrc } from '@/lib/agent-avatars'
 
 describe('agent avatar manifest', () => {
   it('covers every stable agent organization key', () => {
@@ -24,5 +24,20 @@ describe('agent avatar manifest', () => {
       expect(existsSync(path.join(process.cwd(), 'public', assetPath))).toBe(true)
     }
     expect(existsSync(path.join(process.cwd(), 'public', 'agent-avatars', 'unknown.svg'))).toBe(true)
+  })
+
+  it('can resolve avatar assets through a public base URL for protected deployments', () => {
+    const originalBaseUrl = process.env.NEXT_PUBLIC_AGENT_AVATAR_ASSET_BASE_URL
+    process.env.NEXT_PUBLIC_AGENT_AVATAR_ASSET_BASE_URL = 'https://assets.example.com/'
+
+    expect(resolveAgentAvatarImageSrc('/agent-avatars/baroque/chief-of-staff.png')).toBe(
+      'https://assets.example.com/agent-avatars/baroque/chief-of-staff.png',
+    )
+
+    if (originalBaseUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_AGENT_AVATAR_ASSET_BASE_URL
+    } else {
+      process.env.NEXT_PUBLIC_AGENT_AVATAR_ASSET_BASE_URL = originalBaseUrl
+    }
   })
 })

--- a/lib/agent-avatars.ts
+++ b/lib/agent-avatars.ts
@@ -194,6 +194,22 @@ export const AGENT_AVATARS: Record<string, AgentAvatarDefinition> = Object.fromE
   ]),
 ) as Record<string, AgentAvatarDefinition>
 
+const DEFAULT_PUBLIC_AVATAR_BASE_URL = 'https://amadutown.com'
+
+function normalizeBaseUrl(baseUrl: string) {
+  return baseUrl.replace(/\/+$/, '')
+}
+
+export function resolveAgentAvatarImageSrc(imagePath: string) {
+  const configuredBaseUrl = process.env.NEXT_PUBLIC_AGENT_AVATAR_ASSET_BASE_URL?.trim()
+  const baseUrl =
+    configuredBaseUrl ||
+    (process.env.NODE_ENV === 'production' ? DEFAULT_PUBLIC_AVATAR_BASE_URL : '')
+
+  if (!baseUrl) return imagePath
+  return `${normalizeBaseUrl(baseUrl)}${imagePath}`
+}
+
 export function getAgentAvatar(agentKey: string | null | undefined): AgentAvatarDefinition {
   if (agentKey && AGENT_AVATARS[agentKey]) return AGENT_AVATARS[agentKey]
   return {

--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,8 @@ const nextConfig = {
       { protocol: 'https', hostname: '*.supabase.co' },
       { protocol: 'https', hostname: '*.supabase.in' },
       { protocol: 'https', hostname: 'images.unsplash.com' },
+      // Agent portrait assets stay public so protected previews do not break avatar UI.
+      { protocol: 'https', hostname: 'amadutown.com' },
       // Printful sync thumbnails + catalog assets (merchandise store)
       { protocol: 'https', hostname: 'files.cdn.printful.com' },
       // Mockup generator output (temporary URLs on S3 accelerate)
@@ -24,4 +26,3 @@ const nextConfig = {
 }
 
 module.exports = nextConfig
-


### PR DESCRIPTION
## Summary
- Routes deployed agent avatar images through a public asset base so protected preview/staging deployments do not request protected static image URLs.
- Keeps local development same-origin while production-built environments default to `https://amadutown.com` for agent portraits.
- Adds an initials fallback when an avatar image still fails, preventing broken-image UI.
- Allows `amadutown.com` in the Next image remote patterns.

## Validation
- `npm test -- lib/agent-avatars.test.ts`
- `npx tsc --noEmit --pretty false`
- `npm run lint`
- `npm run build`
- `NODE_ENV=production npx tsx -e "import { resolveAgentAvatarImageSrc } from './lib/agent-avatars'; console.log(resolveAgentAvatarImageSrc('/agent-avatars/baroque/chief-of-staff.png'))"`
- Pre-push `npm run db:health-check` passed.

## Integration Notes
- This is a narrow avatar resilience fix; no schema/API/auth changes.
- Production asset URLs were manually checked before implementation: `amadutown.com/agent-avatars/baroque/*.png` returned 200 while protected staging returned 401 for the same paths.
- Fast follow: move the fixed avatar set to public Blob/object storage and update `NEXT_PUBLIC_AGENT_AVATAR_ASSET_BASE_URL` or the manifest to point at that stable asset origin.
- Blob/object-storage migration should be a one-time seed plus rerun only when portraits are added or replaced; it should not be coupled to every Portfolio deployment.
- Vercel contexts should be verified by integration captain before merge: `Vercel – portfolio` and `Vercel – portfolio-staging`.
