### PR TITLE
chore: add agent avatar blob seed path

### DIFF
--- a/docs/runbooks/agent-avatar-public-assets.md
+++ b/docs/runbooks/agent-avatar-public-assets.md
@@ -1,0 +1,81 @@
+# Agent Avatar Public Assets
+
+Agent avatar images must be publicly reachable in deployed admin surfaces. Staging deployments can be behind Vercel Deployment Protection, so static image requests to the staging host may return `401` even when the app itself is working.
+
+The current app resolves deployed avatar URLs through `NEXT_PUBLIC_AGENT_AVATAR_ASSET_BASE_URL`. Production defaults to `https://amadutown.com`, while local development keeps same-origin paths unless the environment variable is set.
+
+## Current Fast Path
+
+The default public asset host is:
+
+```text
+https://amadutown.com
+```
+
+Use this path when the static assets are already deployed with the public production site.
+
+## Blob Seed Path
+
+Use Vercel Blob when avatar assets need a dedicated public object-storage host.
+
+Dry run:
+
+```bash
+npm run agent-avatars:seed-blob
+```
+
+Write to the configured Blob store:
+
+```bash
+BLOB_READ_WRITE_TOKEN=... npm run agent-avatars:seed-blob -- --write
+```
+
+The script uploads files from:
+
+```text
+public/agent-avatars
+```
+
+It preserves stable pathnames such as:
+
+```text
+agent-avatars/baroque/chief-of-staff.png
+```
+
+The script uses public Blob objects, disables random suffixes, and allows overwrite so the application can keep resolving images by base URL plus pathname.
+
+## Deployment Configuration
+
+After a successful Blob seed, set:
+
+```text
+NEXT_PUBLIC_AGENT_AVATAR_ASSET_BASE_URL=<public Blob base URL>
+```
+
+Set it in the Vercel environments that should read from Blob. Do not change this variable for production unless the Blob URL has been verified.
+
+## Validation
+
+Check one representative image:
+
+```bash
+curl -I "$NEXT_PUBLIC_AGENT_AVATAR_ASSET_BASE_URL/agent-avatars/baroque/chief-of-staff.png"
+```
+
+Expected result:
+
+```text
+HTTP 200
+content-type: image/png
+```
+
+Then verify avatar rendering in:
+
+- `/admin/agents`
+- `/admin/agents/standup`
+- `/admin/agents/swarm-board`
+- `/admin/social-content`
+
+## Rollback
+
+Unset `NEXT_PUBLIC_AGENT_AVATAR_ASSET_BASE_URL` to return production builds to the default `https://amadutown.com` host. Local development remains same-origin.

--- a/lib/agent-avatars.test.ts
+++ b/lib/agent-avatars.test.ts
@@ -7,6 +7,10 @@ import { AGENT_AVATARS, getMissingAgentAvatarKeys, resolveAgentAvatarImageSrc } 
 const ORIGINAL_ASSET_BASE_URL = process.env.NEXT_PUBLIC_AGENT_AVATAR_ASSET_BASE_URL
 const ORIGINAL_NODE_ENV = process.env.NODE_ENV
 
+function setNodeEnv(value: typeof process.env.NODE_ENV) {
+  process.env = { ...process.env, NODE_ENV: value }
+}
+
 describe('agent avatar manifest', () => {
   afterEach(() => {
     if (ORIGINAL_ASSET_BASE_URL === undefined) {
@@ -14,7 +18,7 @@ describe('agent avatar manifest', () => {
     } else {
       process.env.NEXT_PUBLIC_AGENT_AVATAR_ASSET_BASE_URL = ORIGINAL_ASSET_BASE_URL
     }
-    process.env.NODE_ENV = ORIGINAL_NODE_ENV
+    setNodeEnv(ORIGINAL_NODE_ENV)
   })
 
   it('covers every stable agent organization key', () => {
@@ -48,7 +52,7 @@ describe('agent avatar manifest', () => {
 
   it('uses the public site origin for production previews when no asset base URL is configured', () => {
     delete process.env.NEXT_PUBLIC_AGENT_AVATAR_ASSET_BASE_URL
-    process.env.NODE_ENV = 'production'
+    setNodeEnv('production')
 
     expect(resolveAgentAvatarImageSrc('/agent-avatars/baroque/chief-of-staff.png')).toBe(
       'https://amadutown.com/agent-avatars/baroque/chief-of-staff.png',
@@ -57,7 +61,7 @@ describe('agent avatar manifest', () => {
 
   it('keeps relative asset paths outside production when no asset base URL is configured', () => {
     delete process.env.NEXT_PUBLIC_AGENT_AVATAR_ASSET_BASE_URL
-    process.env.NODE_ENV = 'test'
+    setNodeEnv('test')
 
     expect(resolveAgentAvatarImageSrc('/agent-avatars/baroque/chief-of-staff.png')).toBe(
       '/agent-avatars/baroque/chief-of-staff.png',

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "@types/pg": "^8.18.0",
         "@types/react": "^18.2.45",
         "@types/react-dom": "^18.2.18",
+        "@vercel/blob": "^2.4.0",
         "@vitejs/plugin-react": "^5.1.4",
         "autoprefixer": "^10.4.16",
         "dotenv": "^17.2.4",
@@ -4184,6 +4185,33 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@vercel/blob": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.4.0.tgz",
+      "integrity": "sha512-ncQ8CRb6XoEAYJwjOTRGpACRT6h/AeY+/33gLyeVxG5BIes27OPm1jmqreF+JHjcTmGhClTP+kBpmyLfbV0xew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@vercel/blob/node_modules/undici": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/@vercel/functions": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-3.5.0.tgz",
@@ -4747,6 +4775,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
       }
     },
     "node_modules/autoprefixer": {
@@ -8785,6 +8823,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/is-bun-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
@@ -8985,6 +9047,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -12523,6 +12592,16 @@
       "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
       "license": "MIT"
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -13753,6 +13832,19 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tiny-inflate": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "storyboard:assets:save-auth": "tsx scripts/save-storyboard-auth.ts",
     "storyboard:assets": "npm run storyboard:assets:schematics && npm run storyboard:assets:capture",
     "storyboard:assets:all": "npm run storyboard:assets:schematics && npm run storyboard:assets:capture -- --videos",
+    "agent-avatars:seed-blob": "tsx scripts/seed-agent-avatar-blob.ts",
     "prepare": "husky install"
   },
   "dependencies": {
@@ -105,6 +106,7 @@
     "@types/pg": "^8.18.0",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
+    "@vercel/blob": "^2.4.0",
     "@vitejs/plugin-react": "^5.1.4",
     "autoprefixer": "^10.4.16",
     "dotenv": "^17.2.4",

--- a/scripts/seed-agent-avatar-blob.ts
+++ b/scripts/seed-agent-avatar-blob.ts
@@ -1,0 +1,129 @@
+import { put } from '@vercel/blob'
+import { promises as fs } from 'fs'
+import path from 'path'
+
+type UploadPlanItem = {
+  localPath: string
+  pathname: string
+  contentType: string
+  sizeBytes: number
+}
+
+const REPO_ROOT = process.cwd()
+const AVATAR_ROOT = path.join(REPO_ROOT, 'public', 'agent-avatars')
+const DEFAULT_EXTENSIONS = new Set(['.png', '.svg'])
+
+function hasFlag(flag: string) {
+  return process.argv.includes(flag)
+}
+
+function getContentType(filePath: string) {
+  const extension = path.extname(filePath).toLowerCase()
+
+  if (extension === '.png') return 'image/png'
+  if (extension === '.svg') return 'image/svg+xml'
+
+  return 'application/octet-stream'
+}
+
+async function collectAvatarAssets(directory: string): Promise<UploadPlanItem[]> {
+  const entries = await fs.readdir(directory, { withFileTypes: true })
+  const items = await Promise.all(
+    entries.map(async (entry) => {
+      const localPath = path.join(directory, entry.name)
+
+      if (entry.isDirectory()) {
+        return collectAvatarAssets(localPath)
+      }
+
+      if (!entry.isFile() || !DEFAULT_EXTENSIONS.has(path.extname(entry.name).toLowerCase())) {
+        return []
+      }
+
+      const stats = await fs.stat(localPath)
+      const pathname = path
+        .relative(path.join(REPO_ROOT, 'public'), localPath)
+        .split(path.sep)
+        .join('/')
+
+      return [
+        {
+          localPath,
+          pathname,
+          contentType: getContentType(localPath),
+          sizeBytes: stats.size,
+        },
+      ]
+    }),
+  )
+
+  return items.flat().sort((a, b) => a.pathname.localeCompare(b.pathname))
+}
+
+function formatBytes(size: number) {
+  if (size < 1024) return `${size} B`
+  if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`
+
+  return `${(size / 1024 / 1024).toFixed(1)} MB`
+}
+
+async function main() {
+  const write = hasFlag('--write')
+  const token = process.env.BLOB_READ_WRITE_TOKEN
+  const plan = await collectAvatarAssets(AVATAR_ROOT)
+
+  if (write && !token) {
+    throw new Error('BLOB_READ_WRITE_TOKEN is required when running with --write.')
+  }
+
+  console.log(`Agent avatar Blob seed ${write ? 'write' : 'dry run'}`)
+  console.log(`Assets: ${plan.length}`)
+
+  const uploadedUrls: string[] = []
+
+  for (const item of plan) {
+    const summary = `${item.pathname} (${item.contentType}, ${formatBytes(item.sizeBytes)})`
+
+    if (!write) {
+      console.log(`DRY RUN  ${summary}`)
+      continue
+    }
+
+    const file = await fs.readFile(item.localPath)
+    const result = await put(item.pathname, file, {
+      access: 'public',
+      addRandomSuffix: false,
+      allowOverwrite: true,
+      contentType: item.contentType,
+      token,
+    })
+
+    uploadedUrls.push(result.url)
+    console.log(`UPLOADED ${summary} -> ${result.url}`)
+  }
+
+  if (!write) {
+    console.log('')
+    console.log('No storage writes were performed. Re-run with --write after confirming the target Blob store.')
+    console.log('Example: BLOB_READ_WRITE_TOKEN=... npm run agent-avatars:seed-blob -- --write')
+    return
+  }
+
+  const firstUrl = uploadedUrls[0]
+  if (firstUrl) {
+    const firstPath = plan[0]?.pathname
+    const baseUrl = firstPath && firstUrl.endsWith(firstPath) ? firstUrl.slice(0, -firstPath.length).replace(/\/$/, '') : null
+
+    console.log('')
+    if (baseUrl) {
+      console.log(`Set NEXT_PUBLIC_AGENT_AVATAR_ASSET_BASE_URL=${baseUrl}`)
+    } else {
+      console.log('Uploaded URLs did not share the expected pathname suffix. Do not set the base URL without manual review.')
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exit(1)
+})


### PR DESCRIPTION
Summary
- Adds a dry-run-first agent avatar Blob seed script.
- Adds a runbook for public avatar asset hosting, Blob seeding, validation, and rollback.
- Adds @vercel/blob as a dev dependency for the operational seed script.

Validation
- npm run agent-avatars:seed-blob
- npx tsc --noEmit --pretty false
- npm run lint
- git diff --check
- pre-push database health check passed

Integration Notes
- No Blob write was performed. Upload requires BLOB_READ_WRITE_TOKEN plus --write.
- No Vercel env vars were changed. If Blob is adopted, set NEXT_PUBLIC_AGENT_AVATAR_ASSET_BASE_URL after verifying the seeded public URL.
- Current production fallback to https://amadutown.com remains unchanged.
- Vercel contexts checked before this phase: Vercel – portfolio and Vercel – portfolio-staging were green.