### PR TITLE
test: add client ai ops real pilot qa plan

### DIFF
--- a/docs/client-ai-ops-roadmap-sop.md
+++ b/docs/client-ai-ops-roadmap-sop.md
@@ -123,6 +123,16 @@ Use `buildClientAiOpsReadinessContract` from `lib/client-ai-ops-readiness-contra
 
 The Client Dashboard should only show a client-safe setup readiness summary derived from the roadmap and connector read model. It may show readiness status, next action, connector counts, approval counts, isolation checks, and that live setup remains locked until approved. It should not expose internal swarm columns, agent traces, private approval packets, credential details, or provider implementation internals.
 
+## Real-Pilot QA Plan
+
+Use `buildClientAiOpsRealPilotQaPlan` from `lib/client-ai-ops-real-pilot-qa.ts` before any real-pilot rollout. The QA plan is generated from synthetic/test-owned data and separates three things:
+
+- automated proof that audit, connector readiness, admin readiness, client setup readiness, monitor summaries, and Meeting Task projection still line up,
+- manual authenticated smoke targets for the admin project page, client dashboard, and monitor follow-up path,
+- forbidden actions that must remain approval-gated, including OAuth, credential sync, provider writes, workflow activation, outbound sends, publishing, production deploy mutation, and client-data mutation.
+
+Authenticated UI smoke should use a synthetic or explicitly test-owned client project and dashboard token. If the tester cannot prove the record is synthetic or test-owned, stop before running the smoke.
+
 ## Roadmap Rule Checklist
 
 Use this checklist whenever a roadmap feature, monitor, report, or client implementation phase changes:
@@ -139,6 +149,7 @@ Use this checklist whenever a roadmap feature, monitor, report, or client implem
 - The synthetic pilot fixture still proves audit-to-roadmap-to-client/admin projection and read-only autonomous handoff boundaries.
 - The admin AI Ops readiness contract stays present and keeps `sideEffectsEnabled` false.
 - The client dashboard shows setup readiness without exposing internal swarm traces or credential/provider details.
+- The real-pilot QA plan separates automated synthetic proof from authenticated manual smoke and forbidden live actions.
 - Client-facing output excludes private logs, agent traces, credentials, and internal-only notes.
 
 ## Real Client Pilot Checklist

--- a/lib/client-ai-ops-real-pilot-qa.test.ts
+++ b/lib/client-ai-ops-real-pilot-qa.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/supabase', () => ({ supabaseAdmin: null }))
+
+import { buildClientAiOpsRealPilotQaPlan } from './client-ai-ops-real-pilot-qa'
+
+describe('buildClientAiOpsRealPilotQaPlan', () => {
+  it('builds a real-pilot QA plan from synthetic/test-owned data only', () => {
+    const plan = buildClientAiOpsRealPilotQaPlan()
+
+    expect(plan).toMatchObject({
+      fixture: 'synthetic_client_ai_ops_pilot',
+      projectId: 'synthetic-client-ai-ops-project',
+      summary: {
+        total: 7,
+        blocked: 0,
+      },
+    })
+    expect(plan.summary.passed).toBeGreaterThanOrEqual(5)
+    expect(plan.summary.waitingApproval).toBe(1)
+    expect(plan.summary.manualSmoke).toBe(1)
+    expect(plan.checks.map((check) => check.key)).toEqual([
+      'audit_to_connector_readiness',
+      'admin_readiness_contract',
+      'client_dashboard_setup_readiness',
+      'monitor_readiness_summary',
+      'meeting_task_projection',
+      'approval_boundaries',
+      'authenticated_ui_smoke',
+    ])
+  })
+
+  it('keeps risky setup work behind approval boundaries', () => {
+    const plan = buildClientAiOpsRealPilotQaPlan()
+    const approvalCheck = plan.checks.find((check) => check.key === 'approval_boundaries')
+
+    expect(approvalCheck).toMatchObject({
+      status: 'waiting_approval',
+      sideEffectFree: true,
+      clientSafe: true,
+    })
+    expect(approvalCheck?.evidence).toContain('credentialSync=waiting_approval')
+    expect(plan.forbiddenActions).toEqual(expect.arrayContaining([
+      'OAuth connection',
+      'credential sync',
+      'provider write',
+      'workflow activation',
+      'outbound send',
+      'client-data mutation',
+    ]))
+  })
+
+  it('separates manual authenticated smoke from automated synthetic proof', () => {
+    const plan = buildClientAiOpsRealPilotQaPlan()
+
+    expect(plan.manualSmokeTargets).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        surface: 'Admin project detail',
+        expectedEvidence: expect.arrayContaining([
+          'Readiness Contract panel shows side effects disabled.',
+        ]),
+      }),
+      expect.objectContaining({
+        surface: 'Client dashboard',
+        expectedEvidence: expect.arrayContaining([
+          'No internal swarm columns, agent traces, credentials, or provider internals are visible.',
+        ]),
+      }),
+      expect.objectContaining({
+        surface: 'Monitor report and meeting task projection',
+        expectedEvidence: expect.arrayContaining([
+          'Readiness blockers create an internal follow-up only.',
+        ]),
+      }),
+    ]))
+    expect(plan.checks.find((check) => check.key === 'authenticated_ui_smoke')).toMatchObject({
+      status: 'needs_manual_smoke',
+      sideEffectFree: true,
+    })
+  })
+})

--- a/lib/client-ai-ops-real-pilot-qa.ts
+++ b/lib/client-ai-ops-real-pilot-qa.ts
@@ -1,0 +1,198 @@
+import type { ClientAiOpsReadinessContract } from './client-ai-ops-readiness-contract'
+import { buildSyntheticClientAiOpsPilot, type SyntheticClientAiOpsPilot } from './client-ai-ops-synthetic-pilot'
+
+export type ClientAiOpsPilotQaStatus = 'passed' | 'needs_manual_smoke' | 'waiting_approval' | 'blocked'
+
+export type ClientAiOpsPilotQaCheck = {
+  key: string
+  label: string
+  status: ClientAiOpsPilotQaStatus
+  evidence: string
+  nextAction: string
+  clientSafe: boolean
+  sideEffectFree: boolean
+}
+
+export type ClientAiOpsPilotQaPlan = {
+  generatedAt: string
+  fixture: 'synthetic_client_ai_ops_pilot'
+  projectId: string
+  summary: {
+    total: number
+    passed: number
+    manualSmoke: number
+    waitingApproval: number
+    blocked: number
+  }
+  checks: ClientAiOpsPilotQaCheck[]
+  manualSmokeTargets: Array<{
+    surface: string
+    path: string
+    expectedEvidence: string[]
+  }>
+  forbiddenActions: string[]
+}
+
+const GENERATED_AT = '2026-06-02T12:00:00.000Z'
+const SYNTHETIC_PROJECT_ID = 'synthetic-client-ai-ops-project'
+
+export function buildClientAiOpsRealPilotQaPlan(pilot: SyntheticClientAiOpsPilot = buildSyntheticClientAiOpsPilot()): ClientAiOpsPilotQaPlan {
+  const readiness = pilot.readinessContract
+  const checks: ClientAiOpsPilotQaCheck[] = [
+    auditToReadinessCheck(pilot),
+    adminReadinessContractCheck(readiness),
+    clientDashboardReadinessCheck(pilot),
+    monitorReadinessCheck(readiness),
+    meetingTaskProjectionCheck(pilot),
+    approvalBoundaryCheck(readiness),
+    authenticatedUiSmokeCheck(),
+  ]
+  const summary = {
+    total: checks.length,
+    passed: checks.filter((check) => check.status === 'passed').length,
+    manualSmoke: checks.filter((check) => check.status === 'needs_manual_smoke').length,
+    waitingApproval: checks.filter((check) => check.status === 'waiting_approval').length,
+    blocked: checks.filter((check) => check.status === 'blocked').length,
+  }
+
+  return {
+    generatedAt: GENERATED_AT,
+    fixture: 'synthetic_client_ai_ops_pilot',
+    projectId: SYNTHETIC_PROJECT_ID,
+    summary,
+    checks,
+    manualSmokeTargets: [
+      {
+        surface: 'Admin project detail',
+        path: '/admin/client-projects/[synthetic-or-test-project-id]',
+        expectedEvidence: [
+          'AI Ops Roadmap section is visible.',
+          'Readiness Contract panel shows side effects disabled.',
+          'Connector readiness and projection status agree with the roadmap source.',
+        ],
+      },
+      {
+        surface: 'Client dashboard',
+        path: '/client/dashboard/[synthetic-or-test-token]',
+        expectedEvidence: [
+          'Setup Readiness panel is visible.',
+          'Live setup locked until approved is visible.',
+          'No internal swarm columns, agent traces, credentials, or provider internals are visible.',
+        ],
+      },
+      {
+        surface: 'Monitor report and meeting task projection',
+        path: '/api/cron/client-ai-ops-monitor plus admin Meeting Tasks',
+        expectedEvidence: [
+          'Monitor summary records readiness_status and side-effect lock state.',
+          'Readiness blockers create an internal follow-up only.',
+          'Follow-up appears as an AmaduTown-owned Meeting Task.',
+        ],
+      },
+    ],
+    forbiddenActions: [
+      'OAuth connection',
+      'credential sync',
+      'provider write',
+      'workflow activation',
+      'outbound send',
+      'publishing',
+      'production deploy mutation',
+      'client-data mutation',
+    ],
+  }
+}
+
+function auditToReadinessCheck(pilot: SyntheticClientAiOpsPilot): ClientAiOpsPilotQaCheck {
+  const connectorKeys = pilot.clientView.connectorReadiness.items.map((item) => item.key)
+  const requiredKeys = ['webflow', 'hubspot', 'google_workspace', 'slack', 'pinecone']
+  const missing = requiredKeys.filter((key) => !connectorKeys.includes(key))
+  return {
+    key: 'audit_to_connector_readiness',
+    label: 'Audit and stack signals map into connector readiness',
+    status: missing.length === 0 ? 'passed' : 'blocked',
+    evidence: missing.length === 0
+      ? `Detected connector keys include ${requiredKeys.join(', ')}.`
+      : `Missing connector keys: ${missing.join(', ')}.`,
+    nextAction: missing.length === 0 ? 'Use synthetic connector readiness as the test-owned baseline.' : 'Repair connector catalog/source mapping before pilot QA.',
+    clientSafe: true,
+    sideEffectFree: true,
+  }
+}
+
+function adminReadinessContractCheck(readiness: ClientAiOpsReadinessContract): ClientAiOpsPilotQaCheck {
+  return {
+    key: 'admin_readiness_contract',
+    label: 'Admin readiness contract is stable and non-mutating',
+    status: readiness.sideEffectsEnabled === false ? 'passed' : 'blocked',
+    evidence: `status=${readiness.status}; sideEffectsEnabled=${String(readiness.sideEffectsEnabled)}; nextAction=${readiness.nextAction}`,
+    nextAction: 'Render the readiness contract in admin project detail with authenticated test-owned data.',
+    clientSafe: false,
+    sideEffectFree: readiness.sideEffectsEnabled === false,
+  }
+}
+
+function clientDashboardReadinessCheck(pilot: SyntheticClientAiOpsPilot): ClientAiOpsPilotQaCheck {
+  const projection = pilot.clientView.projectionStatus
+  const connectors = pilot.clientView.connectorReadiness
+  return {
+    key: 'client_dashboard_setup_readiness',
+    label: 'Client dashboard setup readiness can be derived from client-safe data',
+    status: connectors.requiredConnectorCount > 0 && projection.isolationRequiredCount >= 0 ? 'passed' : 'blocked',
+    evidence: `${connectors.readyConnectorCount}/${connectors.requiredConnectorCount} connectors ready; ${projection.approvalNeededCount} roadmap approvals; ${projection.isolationRequiredCount} isolation checks.`,
+    nextAction: 'Run authenticated client dashboard smoke with a synthetic or explicitly test-owned dashboard token.',
+    clientSafe: true,
+    sideEffectFree: true,
+  }
+}
+
+function monitorReadinessCheck(readiness: ClientAiOpsReadinessContract): ClientAiOpsPilotQaCheck {
+  return {
+    key: 'monitor_readiness_summary',
+    label: 'Monitor can record readiness without live setup',
+    status: readiness.sideEffectsEnabled === false ? 'passed' : 'blocked',
+    evidence: `Monitor-ready values: readiness_status=${readiness.status}; connector_required=${readiness.connector.required}; connector_ready=${readiness.connector.ready}.`,
+    nextAction: 'Run monitor against synthetic/test-owned data and confirm the internal follow-up path only.',
+    clientSafe: false,
+    sideEffectFree: true,
+  }
+}
+
+function meetingTaskProjectionCheck(pilot: SyntheticClientAiOpsPilot): ClientAiOpsPilotQaCheck {
+  const visibleMeetingTasks = pilot.draft.tasks.filter((task) => task.meetingTaskVisible)
+  return {
+    key: 'meeting_task_projection',
+    label: 'Roadmap work can project into Meeting Tasks',
+    status: visibleMeetingTasks.length > 0 ? 'passed' : 'blocked',
+    evidence: `${visibleMeetingTasks.length} roadmap tasks are marked meetingTaskVisible.`,
+    nextAction: 'Confirm monitor follow-up appears as AmaduTown-owned Meeting Task in authenticated admin smoke.',
+    clientSafe: false,
+    sideEffectFree: true,
+  }
+}
+
+function approvalBoundaryCheck(readiness: ClientAiOpsReadinessContract): ClientAiOpsPilotQaCheck {
+  const boundaries = Object.values(readiness.approvalBoundaries)
+  const allWaiting = boundaries.every((value) => value === 'waiting_approval')
+  return {
+    key: 'approval_boundaries',
+    label: 'Risky setup actions stay behind approvals',
+    status: allWaiting ? 'waiting_approval' : 'blocked',
+    evidence: `Approval boundaries: ${Object.entries(readiness.approvalBoundaries).map(([key, value]) => `${key}=${value}`).join(', ')}.`,
+    nextAction: allWaiting ? 'Keep live setup disabled until the operator approves a specific setup packet.' : 'Repair readiness approval boundaries before pilot QA.',
+    clientSafe: true,
+    sideEffectFree: true,
+  }
+}
+
+function authenticatedUiSmokeCheck(): ClientAiOpsPilotQaCheck {
+  return {
+    key: 'authenticated_ui_smoke',
+    label: 'Authenticated admin and client surfaces are manually smoke-tested',
+    status: 'needs_manual_smoke',
+    evidence: 'Requires an authenticated admin session and a synthetic or explicitly test-owned dashboard token.',
+    nextAction: 'Open the admin project page and client dashboard for a synthetic/test-owned project, then capture screenshots or notes for the captain handoff.',
+    clientSafe: true,
+    sideEffectFree: true,
+  }
+}


### PR DESCRIPTION
## Summary
- adds a Client AI Ops real-pilot QA plan module generated from the synthetic pilot fixture
- separates automated synthetic proof, authenticated manual smoke targets, approval-waiting checks, and forbidden live actions
- covers admin project detail, client dashboard, monitor report creation, Meeting Task projection, and approval boundary visibility without creating live setup behavior
- documents the QA plan as the gate before any real-pilot rollout

## Enhancement Impact Preflight
- Enhancement: Real-pilot readiness QA plan for Client AI Ops.
- User-facing surface: internal QA/captain handoff for Client AI Ops pilot readiness.
- Predicted files: lib/client-ai-ops-real-pilot-qa.ts, lib/client-ai-ops-real-pilot-qa.test.ts, docs/client-ai-ops-roadmap-sop.md.
- Shared routes/APIs/tables/helpers: consumes existing synthetic pilot and readiness contract; no route, schema, provider, credential, or live workflow changes.
- Active PRs or branches checked: no open PRs at preflight; root checkout was on codex/ops-admin-outreach-smoke-auth-wait, so implementation used a fresh sibling worktree.
- Dirty worktree files checked: fresh worktree was clean after bootstrap.
- Overlap rating: green.
- Coordination decision: proceed independently.
- Merge-order note: can merge after normal captain checks.

## Validation
- npm ci
- npm run worktree:env -- --source /Users/vambahsillah/Projects/Portfolio
- npm test -- lib/client-ai-ops-real-pilot-qa.test.ts lib/client-ai-ops-synthetic-pilot.test.ts lib/client-ai-ops-readiness-contract.test.ts lib/client-ai-ops-roadmap.test.ts
- npm run build:knowledge
- npx tsc --noEmit --pretty false
- git diff --cached --check
- push hook database health check passed

## Integration Notes
- This is a QA/readiness artifact only. It does not create client records, credentials, OAuth connections, provider resources, live workflows, outbound messages, production configuration, or client-data mutations.
- Authenticated UI smoke remains manual and must use a synthetic or explicitly test-owned project/dashboard token.
- Vercel contexts still need normal Integration Captain verification before merge: Vercel – portfolio and Vercel – portfolio-staging.