### PR TITLE
Route personality corpus into Open Brain producer traces

### DIFF
--- a/docs/open-brain-local-service.md
+++ b/docs/open-brain-local-service.md
@@ -167,7 +167,7 @@ Memory-producing systems should write Open Brain records in this order:
 
 Current producer routes:
 
-- Personality corpus: public-safe derived pack appears as a `personality_corpus` source; raw private exports remain outside public projections.
+- Personality corpus: public-safe derived pack appears as a `personality_corpus` source; raw private exports remain outside public projections. Run `npm run open-brain:personality-corpus` to persist the public-safe source/event trace into `OPEN_BRAIN_HOME` without copying raw private corpus content.
 - Chatbot knowledge: `/api/knowledge` remains a public-safe projection, not canonical memory.
 - RAG/Pinecone: `/api/admin/rag-ingest` records shadow-plan source/event records and blocks writes pending cutover approval.
 - AutoResearch: when `OPEN_BRAIN_AUTORESEARCH_TRACE=true`, proposal creation records `autoresearch_proposal` source/event records; experiments, merges, deploys, hosted config changes, and durable memories remain separately gated. Keep this producer flag off by default until trace volume and privacy behavior are reviewed.

--- a/lib/open-brain.test.ts
+++ b/lib/open-brain.test.ts
@@ -11,6 +11,7 @@ import {
   linkOpenBrainRecords,
   recordOpenBrainEvent,
   recordOpenBrainSource,
+  recordPersonalityCorpusProducerTrace,
   reviewOpenBrainProposal,
   sanitizeOpenBrainText,
   validateMemoryProposal,
@@ -436,6 +437,34 @@ describe('Open Brain projection', () => {
     expect(snapshot.events).toEqual(expect.arrayContaining([expect.objectContaining({ kind: 'autoresearch_proposal_created' })]))
     expect(snapshot.links).toEqual([expect.objectContaining({ id: link.id, relationship: 'derived_from' })])
     expect(snapshot.wikiPages.map((page) => page.slug)).toContain('autoresearch-experiment-ledger')
+  })
+
+  it('records the personality corpus producer trace without raw private content', async () => {
+    const root = await makeTempRoot()
+    const first = await recordPersonalityCorpusProducerTrace(root, '2026-06-02T12:00:00.000Z')
+    const second = await recordPersonalityCorpusProducerTrace(root, '2026-06-02T12:00:00.000Z')
+    const snapshot = await getOpenBrainSnapshot(root)
+
+    expect(first.status).toBe('recorded')
+    expect(second.status).toBe('recorded')
+    expect(first.source).toEqual(expect.objectContaining({
+      id: 'personality-corpus:public-safe',
+      kind: 'personality_corpus',
+      privacyTier: 'public_safe',
+    }))
+    expect(first.event).toEqual(expect.objectContaining({
+      id: 'event:source-observed:personality-corpus:public-safe',
+      kind: 'source_observed',
+      sourceIds: ['personality-corpus:public-safe'],
+      metadata: expect.objectContaining({
+        producerId: 'producer:personality-corpus',
+        rawPrivateExportsIncluded: false,
+      }),
+    }))
+    expect(first.event?.summary).not.toContain('Anthropic_chat_data')
+    expect(first.event?.summary).not.toContain('ChatGPT')
+    expect(snapshot.sources.filter((source) => source.id === 'personality-corpus:public-safe')).toHaveLength(1)
+    expect(snapshot.events.filter((event) => event.id === 'event:source-observed:personality-corpus:public-safe')).toHaveLength(1)
   })
 
   it('projects only approved public-safe memories into RAG documents', () => {

--- a/lib/open-brain.ts
+++ b/lib/open-brain.ts
@@ -319,6 +319,13 @@ export interface OpenBrainProposalInput {
   metadata?: OpenBrainProposalMetadata
 }
 
+export interface OpenBrainPersonalityCorpusProducerTrace {
+  status: 'recorded' | 'missing'
+  source: OpenBrainSourceRecord | null
+  event: OpenBrainEventRecord | null
+  reason: string | null
+}
+
 export interface OpenBrainSnapshotOptions {
   decisionTrustFrames?: DecisionTrustOpenBrainFrame[]
 }
@@ -683,6 +690,50 @@ export async function recordOpenBrainEvent(
   const events = await readJsonArray<OpenBrainEventRecord>(filePath)
   await writeJsonArray(filePath, dedupeEvents([...events, record]))
   return record
+}
+
+export async function recordPersonalityCorpusProducerTrace(
+  openBrainHome = getOpenBrainHome(),
+  generatedAt = new Date().toISOString(),
+): Promise<OpenBrainPersonalityCorpusProducerTrace> {
+  const personalitySource = (await buildKnowledgeProjectionSources(generatedAt))
+    .find((source) => source.kind === 'personality_corpus')
+
+  if (!personalitySource) {
+    return {
+      status: 'missing',
+      source: null,
+      event: null,
+      reason: 'Public-safe personality corpus pack was not found in the Portfolio knowledge projection.',
+    }
+  }
+
+  const source = await recordOpenBrainSource(personalitySource, openBrainHome)
+  const event = await recordOpenBrainEvent({
+    id: `event:source-observed:${source.id}`,
+    kind: 'source_observed',
+    title: `Observed source: ${source.title}`,
+    summary: 'Public-safe derived personality corpus pack observed as an Open Brain source. Raw private exports remain excluded.',
+    privacyTier: source.privacyTier,
+    confidence: source.confidence,
+    sourceIds: [source.id],
+    createdAt: generatedAt,
+    fingerprint: fingerprintOpenBrainRecord(['source_observed', source.id, source.fingerprint]),
+    metadata: {
+      producerId: 'producer:personality-corpus',
+      sourceKind: source.kind,
+      path: source.path,
+      sourceFingerprint: source.fingerprint,
+      rawPrivateExportsIncluded: false,
+    },
+  }, openBrainHome)
+
+  return {
+    status: 'recorded',
+    source,
+    event,
+    reason: null,
+  }
 }
 
 export async function linkOpenBrainRecords(

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "model-ops:research:plan": "tsx scripts/model-ops-research-plan.ts",
     "open-brain:mcp": "tsx scripts/open-brain-mcp-server.ts",
     "open-brain:runtime-registration": "tsx scripts/open-brain-runtime-registration.ts",
+    "open-brain:personality-corpus": "tsx scripts/open-brain-personality-corpus-producer.ts",
     "wrm:smoke-gate": "tsx scripts/wrm-production-smoke-gate.ts",
     "source-protocol:smoke": "tsx scripts/source-protocol-smoke.ts",
     "staging:publications-parity": "tsx scripts/ensure-publications-experience-parity.ts --env-file .env.staging",

--- a/scripts/open-brain-personality-corpus-producer.ts
+++ b/scripts/open-brain-personality-corpus-producer.ts
@@ -1,0 +1,37 @@
+#!/usr/bin/env tsx
+import { recordPersonalityCorpusProducerTrace } from '../lib/open-brain'
+
+async function main() {
+  const result = await recordPersonalityCorpusProducerTrace()
+  const output = {
+    status: result.status,
+    reason: result.reason,
+    source: result.source ? {
+      id: result.source.id,
+      kind: result.source.kind,
+      title: result.source.title,
+      privacyTier: result.source.privacyTier,
+      path: result.source.path,
+      fingerprint: result.source.fingerprint,
+    } : null,
+    event: result.event ? {
+      id: result.event.id,
+      kind: result.event.kind,
+      title: result.event.title,
+      privacyTier: result.event.privacyTier,
+      sourceIds: result.event.sourceIds,
+      fingerprint: result.event.fingerprint,
+      metadata: result.event.metadata,
+    } : null,
+  }
+
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+  if (result.status === 'missing') process.exitCode = 1
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('[open-brain-personality-corpus-producer] failed:', error instanceof Error ? error.message : error)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Summary\n- Adds a Phase 3 producer function for the public-safe personality corpus projection.\n- Adds `npm run open-brain:personality-corpus` to persist the public-safe source/event trace into `OPEN_BRAIN_HOME`.\n- Keeps raw private corpus exports out of producer records; emitted records contain source metadata, path, fingerprints, and `rawPrivateExportsIncluded: false`.\n- Documents the new producer command in the Open Brain local service contract.\n\n## Validation\n- `npm --prefix /Users/vambahsillah/Projects/Portfolio test -- --run lib/open-brain.test.ts scripts/open-brain-mcp-server.test.ts`\n- `npm --prefix /Users/vambahsillah/Projects/Portfolio test -- --run lib/open-brain-runtime-registration.test.ts`\n- `OPEN_BRAIN_HOME=/Users/vambahsillah/.open-brain OPEN_BRAIN_PORTFOLIO_ROOT=/Users/vambahsillah/Projects/Portfolio npm --prefix /Users/vambahsillah/Projects/Portfolio run open-brain:personality-corpus`\n- `git diff --check`\n- push hook database health check passed\n\n## Local Open Brain Trace\n- Source recorded: `personality-corpus:public-safe`\n- Event recorded: `event:source-observed:personality-corpus:public-safe`\n- Raw private exports included: `false`\n\n## Roadmap Status\n- Completed: Phase 3 first producer route for personality corpus source/event traces.\n- Next: route automation reports and agent handoffs through source/event/proposal records.\n- Blockers: none.