### PR TITLE
Route automation inventory into Open Brain traces

### DIFF
--- a/docs/open-brain-local-service.md
+++ b/docs/open-brain-local-service.md
@@ -168,6 +168,7 @@ Memory-producing systems should write Open Brain records in this order:
 Current producer routes:
 
 - Personality corpus: public-safe derived pack appears as a `personality_corpus` source; raw private exports remain outside public projections. Run `npm run open-brain:personality-corpus` to persist the public-safe source/event trace into `OPEN_BRAIN_HOME` without copying raw private corpus content.
+- Codex automation inventory: Portfolio-related automation and repair-packet summaries appear as `codex_automation` and `repair_packet` sources. Run `npm run open-brain:automation-producer` to persist internal-ops source/event traces without copying raw automation prompts.
 - Chatbot knowledge: `/api/knowledge` remains a public-safe projection, not canonical memory.
 - RAG/Pinecone: `/api/admin/rag-ingest` records shadow-plan source/event records and blocks writes pending cutover approval.
 - AutoResearch: when `OPEN_BRAIN_AUTORESEARCH_TRACE=true`, proposal creation records `autoresearch_proposal` source/event records; experiments, merges, deploys, hosted config changes, and durable memories remain separately gated. Keep this producer flag off by default until trace volume and privacy behavior are reviewed.

--- a/lib/open-brain.test.ts
+++ b/lib/open-brain.test.ts
@@ -11,6 +11,7 @@ import {
   linkOpenBrainRecords,
   recordOpenBrainEvent,
   recordOpenBrainSource,
+  recordCodexAutomationProducerTraces,
   recordPersonalityCorpusProducerTrace,
   reviewOpenBrainProposal,
   sanitizeOpenBrainText,
@@ -465,6 +466,37 @@ describe('Open Brain projection', () => {
     expect(first.event?.summary).not.toContain('ChatGPT')
     expect(snapshot.sources.filter((source) => source.id === 'personality-corpus:public-safe')).toHaveLength(1)
     expect(snapshot.events.filter((event) => event.id === 'event:source-observed:personality-corpus:public-safe')).toHaveLength(1)
+  })
+
+  it('records Codex automation producer traces without raw prompt content', async () => {
+    const root = await makeTempRoot()
+    const first = await recordCodexAutomationProducerTraces(root, '2026-06-02T12:00:00.000Z')
+    const second = await recordCodexAutomationProducerTraces(root, '2026-06-02T12:00:00.000Z')
+    const snapshot = await getOpenBrainSnapshot(root)
+
+    expect(first.status).toBe('recorded')
+    expect(second.status).toBe('recorded')
+    expect(first.overview).toEqual({
+      sourcesRecorded: 2,
+      eventsRecorded: 2,
+      rawPromptsIncluded: false,
+    })
+    expect(first.sources.map((source) => source.id)).toEqual(expect.arrayContaining([
+      'automation:portfolio-operations-manager',
+      'repair:portfolio-operations-manager',
+    ]))
+    expect(first.events).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'event:source-observed:automation:portfolio-operations-manager',
+        metadata: expect.objectContaining({
+          producerId: 'producer:codex-automation-inventory',
+          rawPromptsIncluded: false,
+        }),
+      }),
+    ]))
+    expect(first.events.map((event) => event.summary).join(' ')).not.toContain('Add an authority boundary.')
+    expect(snapshot.sources.filter((source) => source.id === 'automation:portfolio-operations-manager')).toHaveLength(1)
+    expect(snapshot.events.filter((event) => event.id === 'event:source-observed:automation:portfolio-operations-manager')).toHaveLength(1)
   })
 
   it('projects only approved public-safe memories into RAG documents', () => {

--- a/lib/open-brain.ts
+++ b/lib/open-brain.ts
@@ -3,7 +3,7 @@ import { existsSync } from 'fs'
 import { mkdir, readFile, writeFile } from 'fs/promises'
 import { homedir } from 'os'
 import path from 'path'
-import { listCodexAutomationInventory } from './codex-automation-inventory'
+import { listCodexAutomationInventory, type CodexAutomationInventory } from './codex-automation-inventory'
 import { getCodexWorkspaceRootReport } from './codex-workspace-roots'
 import {
   buildDecisionTrustOpenBrainProjection,
@@ -326,6 +326,18 @@ export interface OpenBrainPersonalityCorpusProducerTrace {
   reason: string | null
 }
 
+export interface OpenBrainAutomationProducerTrace {
+  status: 'recorded' | 'missing'
+  sources: OpenBrainSourceRecord[]
+  events: OpenBrainEventRecord[]
+  reason: string | null
+  overview: {
+    sourcesRecorded: number
+    eventsRecorded: number
+    rawPromptsIncluded: false
+  }
+}
+
 export interface OpenBrainSnapshotOptions {
   decisionTrustFrames?: DecisionTrustOpenBrainFrame[]
 }
@@ -375,28 +387,7 @@ export async function getOpenBrainSnapshot(
   })
 
   const sources = dedupeSources([
-    ...inventory.automations.map((automation): OpenBrainSourceRecord => ({
-      id: `automation:${automation.id}`,
-      kind: 'codex_automation',
-      title: automation.name,
-      summary: sanitizeOpenBrainText(`${automation.category} automation. Risk ${automation.riskLevel}. Context ${automation.contextHealth}.`),
-      path: automation.sourceFile,
-      privacyTier: 'internal_ops',
-      confidence: 0.9,
-      lastObservedAt: inventory.generatedAt,
-      fingerprint: fingerprintOpenBrainRecord(['codex_automation', automation.id, automation.sourceFile, automation.updatedAt || '']),
-    })),
-    ...inventory.repairPackets.map((packet): OpenBrainSourceRecord => ({
-      id: `repair:${packet.automationId}`,
-      kind: 'repair_packet',
-      title: `${packet.automationName} repair packet`,
-      summary: sanitizeOpenBrainText(packet.summary),
-      path: packet.sourceFile,
-      privacyTier: 'internal_ops',
-      confidence: 0.86,
-      lastObservedAt: inventory.generatedAt,
-      fingerprint: fingerprintOpenBrainRecord(['repair_packet', packet.automationId, packet.summary]),
-    })),
+    ...buildCodexAutomationInventorySources(inventory),
     {
       id: 'workspace-root-report:codex',
       kind: 'workspace_root_report',
@@ -733,6 +724,66 @@ export async function recordPersonalityCorpusProducerTrace(
     source,
     event,
     reason: null,
+  }
+}
+
+export async function recordCodexAutomationProducerTraces(
+  openBrainHome = getOpenBrainHome(),
+  generatedAt = new Date().toISOString(),
+): Promise<OpenBrainAutomationProducerTrace> {
+  const inventory = await listCodexAutomationInventory()
+  if (!inventory.available) {
+    return {
+      status: 'missing',
+      sources: [],
+      events: [],
+      reason: inventory.reason || 'Codex automation inventory is not available.',
+      overview: {
+        sourcesRecorded: 0,
+        eventsRecorded: 0,
+        rawPromptsIncluded: false,
+      },
+    }
+  }
+
+  const sources = buildCodexAutomationInventorySources(inventory)
+  const recordedSources: OpenBrainSourceRecord[] = []
+  const recordedEvents: OpenBrainEventRecord[] = []
+
+  for (const sourceInput of sources) {
+    const source = await recordOpenBrainSource(sourceInput, openBrainHome)
+    const event = await recordOpenBrainEvent({
+      id: `event:source-observed:${source.id}`,
+      kind: 'source_observed',
+      title: `Observed source: ${source.title}`,
+      summary: `${source.kind} observed from Codex automation inventory. Raw automation prompts are excluded.`,
+      privacyTier: source.privacyTier,
+      confidence: source.confidence,
+      sourceIds: [source.id],
+      createdAt: generatedAt,
+      fingerprint: fingerprintOpenBrainRecord(['source_observed', source.id, source.fingerprint]),
+      metadata: {
+        producerId: 'producer:codex-automation-inventory',
+        sourceKind: source.kind,
+        path: source.path,
+        sourceFingerprint: source.fingerprint,
+        rawPromptsIncluded: false,
+      },
+    }, openBrainHome)
+    recordedSources.push(source)
+    recordedEvents.push(event)
+  }
+
+  return {
+    status: 'recorded',
+    sources: recordedSources,
+    events: recordedEvents,
+    reason: null,
+    overview: {
+      sourcesRecorded: recordedSources.length,
+      eventsRecorded: recordedEvents.length,
+      rawPromptsIncluded: false,
+    },
   }
 }
 
@@ -1155,6 +1206,34 @@ function getServiceStatus(openBrainHome: string, runtimeMcpConfigured = false): 
     reason: available ? null : 'Local Open Brain storage is not configured yet. Set OPEN_BRAIN_DATABASE_URL or initialize OPEN_BRAIN_HOME.',
     operationalBoundary: 'Portfolio is a projection and approval surface. The local Open Brain service remains the source of truth; direct writes to Codex operational state require a separate approved repair step.',
   }
+}
+
+function buildCodexAutomationInventorySources(inventory: CodexAutomationInventory): OpenBrainSourceRecord[] {
+  if (!inventory.available) return []
+  return [
+    ...inventory.automations.map((automation): OpenBrainSourceRecord => ({
+      id: `automation:${automation.id}`,
+      kind: 'codex_automation',
+      title: automation.name,
+      summary: sanitizeOpenBrainText(`${automation.category} automation. Risk ${automation.riskLevel}. Context ${automation.contextHealth}.`),
+      path: automation.sourceFile,
+      privacyTier: 'internal_ops',
+      confidence: 0.9,
+      lastObservedAt: inventory.generatedAt,
+      fingerprint: fingerprintOpenBrainRecord(['codex_automation', automation.id, automation.sourceFile, automation.updatedAt || '']),
+    })),
+    ...inventory.repairPackets.map((packet): OpenBrainSourceRecord => ({
+      id: `repair:${packet.automationId}`,
+      kind: 'repair_packet',
+      title: `${packet.automationName} repair packet`,
+      summary: sanitizeOpenBrainText(packet.summary),
+      path: packet.sourceFile,
+      privacyTier: 'internal_ops',
+      confidence: 0.86,
+      lastObservedAt: inventory.generatedAt,
+      fingerprint: fingerprintOpenBrainRecord(['repair_packet', packet.automationId, packet.summary]),
+    })),
+  ]
 }
 
 function buildRunbookSources(generatedAt: string): OpenBrainSourceRecord[] {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "open-brain:mcp": "tsx scripts/open-brain-mcp-server.ts",
     "open-brain:runtime-registration": "tsx scripts/open-brain-runtime-registration.ts",
     "open-brain:personality-corpus": "tsx scripts/open-brain-personality-corpus-producer.ts",
+    "open-brain:automation-producer": "tsx scripts/open-brain-automation-producer.ts",
     "wrm:smoke-gate": "tsx scripts/wrm-production-smoke-gate.ts",
     "source-protocol:smoke": "tsx scripts/source-protocol-smoke.ts",
     "staging:publications-parity": "tsx scripts/ensure-publications-experience-parity.ts --env-file .env.staging",

--- a/scripts/open-brain-automation-producer.ts
+++ b/scripts/open-brain-automation-producer.ts
@@ -1,0 +1,38 @@
+#!/usr/bin/env tsx
+import { recordCodexAutomationProducerTraces } from '../lib/open-brain'
+
+async function main() {
+  const result = await recordCodexAutomationProducerTraces()
+  const output = {
+    status: result.status,
+    reason: result.reason,
+    overview: result.overview,
+    sources: result.sources.map((source) => ({
+      id: source.id,
+      kind: source.kind,
+      title: source.title,
+      privacyTier: source.privacyTier,
+      path: source.path,
+      fingerprint: source.fingerprint,
+    })),
+    events: result.events.map((event) => ({
+      id: event.id,
+      kind: event.kind,
+      title: event.title,
+      privacyTier: event.privacyTier,
+      sourceIds: event.sourceIds,
+      fingerprint: event.fingerprint,
+      metadata: event.metadata,
+    })),
+  }
+
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+  if (result.status === 'missing') process.exitCode = 1
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('[open-brain-automation-producer] failed:', error instanceof Error ? error.message : error)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Summary\n- Adds a Phase 3 producer for Portfolio-related Codex automation inventory and repair-packet traces.\n- Adds `npm run open-brain:automation-producer` to persist internal-ops source/event records into `OPEN_BRAIN_HOME`.\n- Reuses the existing automation source projection builder for snapshots and persistent producer writes.\n- Excludes raw automation prompts; emitted events carry `rawPromptsIncluded: false` and metadata only.\n\n## Validation\n- `npm --prefix /Users/vambahsillah/Projects/Portfolio test -- --run lib/open-brain.test.ts scripts/open-brain-mcp-server.test.ts`\n- `npm --prefix /Users/vambahsillah/Projects/Portfolio test -- --run lib/open-brain-runtime-registration.test.ts`\n- `OPEN_BRAIN_HOME=/Users/vambahsillah/.open-brain OPEN_BRAIN_PORTFOLIO_ROOT=/Users/vambahsillah/Projects/Portfolio npm --prefix /Users/vambahsillah/Projects/Portfolio run open-brain:automation-producer`\n- Scoped `git diff --check` for touched Open Brain files\n- push hook database health check passed\n\n## Local Open Brain Trace\n- Sources recorded: 18\n- Events recorded: 18\n- Raw automation prompts included: `false`\n\n## Notes\n- Local dirty files outside this slice were preserved and not staged: `app/admin/content/page.tsx`, `lib/agentic-content-review-packets.ts`, and `lib/agentic-content-review-packets.test.ts`.\n\n## Roadmap Status\n- Completed: Phase 3 automation-report producer route.\n- Next: route agent handoffs/work items through source/event/proposal records.\n- Blockers: none.