### PR TITLE
feat: add p2 proof packets to content review

### DIFF
--- a/app/admin/content/page.tsx
+++ b/app/admin/content/page.tsx
@@ -1,12 +1,14 @@
 'use client'
 
 import { motion } from 'framer-motion'
-import { FolderOpen, Video, BookOpen, Music, Sparkles, Package, Tag, Briefcase, Layers, ShoppingBag, Target } from 'lucide-react'
+import { FolderOpen, Video, BookOpen, Music, Sparkles, Package, Tag, Briefcase, Layers, ShoppingBag, Target, CheckCircle2 } from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
 import Link from 'next/link'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
+import { getAgenticContentReviewPacketsForSurface } from '@/lib/agentic-content-review-packets'
 
 export default function ContentManagementPage() {
+  const proofReviewPackets = getAgenticContentReviewPacketsForSurface('content')
   const contentTypes = [
     {
       name: 'Outcome Groups',
@@ -91,6 +93,47 @@ export default function ContentManagementPage() {
             <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
               Route publishing assets, product materials, prototypes, and offer content from one operating surface.
             </p>
+          </div>
+
+          <div className="admin-console-card mb-6 rounded-lg border p-5">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <div className="admin-console-eyebrow mb-2">Agentic challenger loop</div>
+                <h2 className="text-lg font-semibold text-foreground">P2 proof assets ready for human review</h2>
+                <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+                  These proof and conversion assets have passed Amina challenger review. Editorial approval can happen here before PDF export, website implementation, client sharing, or public release.
+                </p>
+              </div>
+              <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-300">
+                {proofReviewPackets.length} ready
+              </span>
+            </div>
+
+            <div className="mt-4 grid grid-cols-1 gap-3 lg:grid-cols-3">
+              {proofReviewPackets.map((packet) => (
+                <div key={packet.assetId} className="rounded-lg border border-silicon-slate bg-imperial-navy/45 p-4">
+                  <div className="flex flex-wrap items-center gap-2 text-[10px] font-medium uppercase tracking-[0.14em] text-gray-500">
+                    <span className="rounded-full border border-radiant-gold/30 px-2 py-0.5 text-radiant-gold">{packet.priority}</span>
+                    <span>{packet.channel}</span>
+                  </div>
+                  <h3 className="mt-3 text-sm font-semibold text-gray-100">{packet.title}</h3>
+                  <p className="mt-2 text-xs leading-5 text-gray-400">{packet.humanReview}</p>
+                  <div className="mt-3 grid gap-2 text-[11px] text-gray-500">
+                    <div className="flex items-center gap-2 text-emerald-300">
+                      <CheckCircle2 className="h-3.5 w-3.5" />
+                      <span>{packet.challengerAgent} - {packet.challengerStatus}; {packet.approvalStatus}</span>
+                    </div>
+                    <div className="rounded-md border border-silicon-slate/70 bg-background/40 p-2 leading-5 text-gray-400">
+                      <div><span className="text-gray-500">Source packet:</span> <code className="text-radiant-gold">{packet.packetPath}</code></div>
+                      <div><span className="text-gray-500">Next gate:</span> {packet.nextGate}</div>
+                    </div>
+                    <Link href={`/admin/agents/standup?context=agentic-content-review&asset=${encodeURIComponent(packet.assetId)}`} className="inline-flex items-center gap-1 text-xs text-radiant-gold hover:underline">
+                      Create repair or production planning task
+                    </Link>
+                  </div>
+                </div>
+              ))}
+            </div>
           </div>
 
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">

--- a/lib/agentic-content-review-packets.test.ts
+++ b/lib/agentic-content-review-packets.test.ts
@@ -23,6 +23,7 @@ describe('agentic content review packet registry', () => {
   it('routes social and video packets to their existing Portfolio review surfaces', () => {
     const socialPackets = getAgenticContentReviewPacketsForSurface('social')
     const videoPackets = getAgenticContentReviewPacketsForSurface('video')
+    const contentPackets = getAgenticContentReviewPacketsForSurface('content')
 
     expect(socialPackets.map((packet) => packet.assetId)).toEqual([
       'p0-linkedin-flagship-agentic-operating-system',
@@ -35,6 +36,12 @@ describe('agentic content review packet registry', () => {
       'p0-youtube-agentic-ai-teams-skip',
       'p1-short-agent-needs-receipt',
       'p1-short-handoff-work-packet',
+    ])
+
+    expect(contentPackets.map((packet) => packet.assetId)).toEqual([
+      'p2-client-one-pager-governed-agentic-operations',
+      'p2-technical-appendix-agentic-proof-map',
+      'p2-website-proof-page-governed-agents',
     ])
   })
 })

--- a/lib/agentic-content-review-packets.ts
+++ b/lib/agentic-content-review-packets.ts
@@ -1,8 +1,8 @@
-export type AgenticContentReviewSurface = 'social' | 'video'
+export type AgenticContentReviewSurface = 'social' | 'video' | 'content'
 
 export type AgenticContentReviewPacket = {
   assetId: string
-  priority: 'P0' | 'P1'
+  priority: 'P0' | 'P1' | 'P2'
   title: string
   channel: string
   output: string
@@ -161,6 +161,66 @@ export const AGENTIC_CONTENT_REVIEW_PACKETS: AgenticContentReviewPacket[] = [
     approveMeaning: 'Open the video review surface and approve only the next render-readiness step; provider work remains gated.',
     sendBackMeaning: 'Route a repair task if the handoff framing, claim, evidence, or short-form pacing needs revision.',
     targetSurface: 'video',
+  },
+  {
+    assetId: 'p2-client-one-pager-governed-agentic-operations',
+    priority: 'P2',
+    title: 'Client one-pager: Governed Agentic Operations',
+    channel: 'Client one-pager',
+    output: 'PDF/web proof asset',
+    sourceComponent: 'Value stack',
+    packetPath: 'docs/agentic-content-review-packets/p2-challenger-review-packets.md',
+    draftSource: 'docs/agentic-content-review-packets/p2-challenger-review-packets.md',
+    challengerAgent: 'Amina',
+    challengerStatus: 'passed',
+    passToHuman: true,
+    approvalStatus: 'human_review_ready',
+    humanReview: 'Ready for editorial approval; PDF or webpage production still gated.',
+    nextGate: 'PDF/web production approval before export, implementation, or client sharing.',
+    decisionPrompt: 'Decide whether this one-pager is ready for PDF or webpage production review.',
+    approveMeaning: 'Open the Content Hub production path only after approving the editorial packet; PDF export and client sharing remain separate gates.',
+    sendBackMeaning: 'Route a repair task if the buyer language, CTA, source support, or AmaduTown branding decision needs revision.',
+    targetSurface: 'content',
+  },
+  {
+    assetId: 'p2-technical-appendix-agentic-proof-map',
+    priority: 'P2',
+    title: 'Technical appendix: Agentic Operating Proof Map',
+    channel: 'Technical appendix',
+    output: 'PDF/Markdown due diligence asset',
+    sourceComponent: 'Source map',
+    packetPath: 'docs/agentic-content-review-packets/p2-challenger-review-packets.md',
+    draftSource: 'docs/agentic-content-review-packets/p2-challenger-review-packets.md',
+    challengerAgent: 'Amina',
+    challengerStatus: 'passed',
+    passToHuman: true,
+    approvalStatus: 'human_review_ready',
+    humanReview: 'Ready for editorial approval; appendix production still gated.',
+    nextGate: 'Appendix production approval before PDF export, public release, or client sharing.',
+    decisionPrompt: 'Decide whether this appendix is ready for Markdown or PDF production review.',
+    approveMeaning: 'Open the Content Hub production path only after approving the proof map; public release and client sharing remain separate gates.',
+    sendBackMeaning: 'Route a repair task if the implementation paths, proof questions, or public-safe boundaries need revision.',
+    targetSurface: 'content',
+  },
+  {
+    assetId: 'p2-website-proof-page-governed-agents',
+    priority: 'P2',
+    title: 'Website proof page: Governed Agents, Not Unchecked Automation',
+    channel: 'Portfolio website',
+    output: 'Proof page brief',
+    sourceComponent: 'Full system',
+    packetPath: 'docs/agentic-content-review-packets/p2-challenger-review-packets.md',
+    draftSource: 'docs/agentic-content-review-packets/p2-challenger-review-packets.md',
+    challengerAgent: 'Amina',
+    challengerStatus: 'passed',
+    passToHuman: true,
+    approvalStatus: 'human_review_ready',
+    humanReview: 'Ready for editorial approval; website implementation still gated.',
+    nextGate: 'Website implementation approval before building or publishing a proof page.',
+    decisionPrompt: 'Decide whether this proof-page brief is ready for implementation planning.',
+    approveMeaning: 'Open the Content Hub or implementation planning path only after approving the editorial packet; deployment remains a separate gate.',
+    sendBackMeaning: 'Route a repair task if the page purpose, privacy boundary, visual direction, or CTA needs revision.',
+    targetSurface: 'content',
   },
 ]
 


### PR DESCRIPTION
## Summary
- Extends the challenger-cleared content packet registry with P2 proof/conversion assets from the merged P2 packet docs.
- Adds a Content Hub review panel for the client one-pager, technical appendix, and website proof-page brief.
- Keeps PDF export, website implementation, client sharing, publishing, and production work behind separate gates.

## Validation
- `npm test -- --run lib/agentic-content-review-packets.test.ts` using temporary symlinked `node_modules` in the sibling worktree: passed.
- `npm run lint` using temporary symlinked `node_modules` in the sibling worktree: passed.
- `git diff --check`: passed.
- In-app Browser smoke against `/admin/content` on local dev server: route reaches the auth boundary with no framework overlay or console errors.
- `npx tsc --noEmit` was started in the sibling worktree but did not complete in a reasonable interval; no lingering TypeScript process remains.

## Integration Notes
- No migrations or env changes.
- No database seeding, provider execution, PDF export, website implementation, publishing, n8n, or external-send side effects.
- Implemented in sibling worktree `/Users/vambahsillah/Projects/Portfolio.worktrees/p2-challenger-packet-review-surface` to avoid mixing with the shared checkout's active branch.
- Vercel contexts not checked by this non-captain slice after PR creation:
  - Vercel – portfolio
  - Vercel – portfolio-staging
