### PR TITLE
fix: gate google places n8n bakeoff test data

### DIFF
--- a/app/api/admin/value-evidence/ingest-market/route.ts
+++ b/app/api/admin/value-evidence/ingest-market/route.ts
@@ -25,6 +25,10 @@ interface MarketIntelligenceItem {
   relevance_score?: number
 }
 
+function isExplicitTestRun(value: unknown): boolean {
+  return value === true || value === 'true'
+}
+
 export async function POST(request: NextRequest) {
   const authHeader = request.headers.get('authorization')
   const token = authHeader?.replace('Bearer ', '')
@@ -38,6 +42,7 @@ export async function POST(request: NextRequest) {
     const body = await request.json()
     const items: MarketIntelligenceItem[] = body.items || []
     const contactSubmissionId: number | undefined = body.contact_submission_id
+    const isTestData = isExplicitTestRun(body.is_test_data)
 
     if (!Array.isArray(items) || items.length === 0) {
       return NextResponse.json(
@@ -52,6 +57,7 @@ export async function POST(request: NextRequest) {
       duplicates: 0,
       errors: [] as string[],
     }
+    const insertedIds: string[] = []
 
     const VALID_PLATFORMS = ['linkedin', 'reddit', 'g2', 'capterra', 'trustradius', 'facebook', 'twitter', 'google_maps']
     const VALID_CONTENT_TYPES = ['post', 'comment', 'review', 'question', 'article', 'other']
@@ -92,6 +98,7 @@ export async function POST(request: NextRequest) {
           sentiment_score: item.sentiment_score ?? null,
           relevance_score: relevanceScore,
           is_processed: false,
+          is_test_data: isTestData,
         }
         if (contactSubmissionId) {
           row.contact_submission_id = contactSubmissionId
@@ -100,9 +107,10 @@ export async function POST(request: NextRequest) {
         if (item.source_url) {
           // DB has a partial unique index on source_url (WHERE source_url IS NOT NULL AND != '').
           // upsert with ignoreDuplicates skips rows that conflict — no race condition.
-          const { error: upsertError, count } = await supabaseAdmin
+          const { data: inserted, error: upsertError, count } = await supabaseAdmin
             .from('market_intelligence')
             .upsert(row, { onConflict: 'source_url', ignoreDuplicates: true, count: 'exact' })
+            .select('id')
 
           if (upsertError) {
             results.errors.push(`Upsert failed: ${upsertError.message}`)
@@ -112,18 +120,26 @@ export async function POST(request: NextRequest) {
             results.duplicates++
           } else {
             results.inserted++
+            if (Array.isArray(inserted)) {
+              insertedIds.push(...inserted.map(entry => String(entry.id)).filter(Boolean))
+            }
           }
         } else {
           // No source_url — no dedup possible, just insert
-          const { error: insertError } = await supabaseAdmin
+          const { data: inserted, error: insertError } = await supabaseAdmin
             .from('market_intelligence')
             .insert(row)
+            .select('id')
+            .single()
 
           if (insertError) {
             results.errors.push(`Insert failed: ${insertError.message}`)
             continue
           }
           results.inserted++
+          if (inserted?.id) {
+            insertedIds.push(String(inserted.id))
+          }
         }
       } catch (itemError: any) {
         results.errors.push(`Unexpected error: ${itemError.message}`)
@@ -132,9 +148,9 @@ export async function POST(request: NextRequest) {
 
     // Auto-classify newly inserted records into pain point evidence
     let classification: { evidenceCreated: number; irrelevant: number } | null = null
-    if (results.inserted > 0) {
+    if (insertedIds.length > 0) {
       try {
-        const classifyResult = await classifyMarketIntel(results.inserted)
+        const classifyResult = await classifyMarketIntel(insertedIds.length, insertedIds)
         classification = {
           evidenceCreated: classifyResult.evidenceCreated,
           irrelevant: classifyResult.irrelevant,

--- a/app/api/admin/value-evidence/trigger/route.ts
+++ b/app/api/admin/value-evidence/trigger/route.ts
@@ -176,6 +176,7 @@ export async function POST(request: NextRequest) {
     scope_type,
     scope_id,
     phases,
+    is_test_data,
   } = body
 
   const validWorkflows = ['internal_extraction', 'social_listening', 'social_listening_lead']
@@ -226,6 +227,7 @@ export async function POST(request: NextRequest) {
     const scope: Record<string, unknown> = {}
     if (validMaxResults) scope.maxResults = validMaxResults
     if (validSources) scope.sources = validSources
+    if (is_test_data === true) scope.is_test_data = true
     if (isSingleLead) {
       scope.mode = 'single_lead'
       if (contact_submission_id) scope.contact_submission_id = contact_submission_id
@@ -330,6 +332,7 @@ export async function POST(request: NextRequest) {
         agentRunId,
         maxResults: validMaxResults,
         sources: validSources,
+        isTestData: is_test_data === true,
         contactSubmissionId: scopeContext.contactSubmissionId,
         leadContext,
       })
@@ -339,6 +342,7 @@ export async function POST(request: NextRequest) {
         agentRunId,
         maxResults: validMaxResults,
         sources: validSources,
+        isTestData: is_test_data === true,
         contactSubmissionId: isSingleLead ? contact_submission_id : scopeContext?.contactSubmissionId,
         leadContext,
       })

--- a/docs/google-places-production-runner-decision.md
+++ b/docs/google-places-production-runner-decision.md
@@ -68,3 +68,46 @@ Before replacing Apify's Google Maps actor:
 5. Run the live bakeoff from the production-like runner.
 6. Compare accepted-result rate, cost, source quality, and operator review burden against the Apify baseline.
 7. Keep Apify as rollback until the replacement meets or beats the baseline.
+
+## 2026-06-02 Production-Like n8n Bakeoff Preflight
+
+Live workflow inspected: `WF-VEP-002: Social Listening Pipeline`
+(`gUyOBZOknpAt41aF`, active version `ddfbae42-7e29-4ccd-8802-4682f026c531`).
+
+Preflight result:
+
+- Google Maps can be isolated through the existing source gate by sending
+  `sources: ["google_maps"]`.
+- The live graph still posts downstream results into Portfolio ingest endpoints
+  after scraping, so this is not a read-only n8n execution.
+- The checked-in Portfolio `ingest-market` route did not preserve
+  `is_test_data` before this change, even though the database migration already
+  provides the column.
+- The live n8n run was therefore not triggered from this preflight. Running it
+  before this test flag is deployed could create unmarked production
+  `market_intelligence` rows.
+
+Safe run payload after deployment and n8n export sync:
+
+```json
+{
+  "workflow": "WF-VEP-002",
+  "action": "google_places_replacement_bakeoff",
+  "sources": ["google_maps"],
+  "searchTerms": ["nonprofit organizations near Omaha NE"],
+  "googleMapsQuery": "nonprofit organizations near Omaha NE",
+  "maxResults": 5,
+  "is_test_data": true
+}
+```
+
+Promotion gate:
+
+1. Deploy the Portfolio ingest test-data propagation change.
+2. Sync the `WF-VEP-002` n8n graph so `Set Search Parameters`, `POST Raw to
+   Market Intel`, and `POST Pain Points` forward `is_test_data`.
+3. Trigger the isolated Google Maps run above.
+4. Confirm inserted `market_intelligence` and `pain_point_evidence` rows, if
+   any, are marked `is_test_data = true`.
+5. Compare result quality and cost against the Apify Google Maps baseline before
+   replacing the actor.

--- a/lib/__tests__/n8n-value-evidence.test.ts
+++ b/lib/__tests__/n8n-value-evidence.test.ts
@@ -27,7 +27,12 @@ describe('n8n value-evidence triggers', () => {
 
     const { triggerSocialListening } = await import('../n8n')
 
-    const result = await triggerSocialListening({ runId: 'run-123', agentRunId: 'agent-run-1', maxResults: 10 })
+    const result = await triggerSocialListening({
+      runId: 'run-123',
+      agentRunId: 'agent-run-1',
+      maxResults: 10,
+      isTestData: true,
+    })
     expect(result.triggered).toBe(true)
 
     expect(mockFetch).toHaveBeenCalledTimes(1)
@@ -44,6 +49,7 @@ describe('n8n value-evidence triggers', () => {
       agent_run_id: 'agent-run-1',
       agent_event_callback_url: 'https://portfolio.example.com/api/admin/agents/runs/agent-run-1/events',
       maxResults: 10,
+      is_test_data: true,
     })
     expect(body.agent_trace).toMatchObject({
       version: 1,
@@ -83,6 +89,7 @@ describe('n8n value-evidence triggers', () => {
     const body = JSON.parse(String(init.body))
     expect(body.run_id).toBe('run-456')
     expect(Object.prototype.hasOwnProperty.call(body, 'maxResults')).toBe(false)
+    expect(Object.prototype.hasOwnProperty.call(body, 'is_test_data')).toBe(false)
   })
 
   it('prefers explicit N8N_VEP002_WEBHOOK_URL over base URL fallback', async () => {

--- a/lib/__tests__/n8n-vep002-workflow-export.test.ts
+++ b/lib/__tests__/n8n-vep002-workflow-export.test.ts
@@ -17,6 +17,7 @@ type N8nNode = {
     headerParameters?: {
       parameters?: Array<{ name?: string; value?: string }>
     }
+    jsonBody?: string
   }
 }
 
@@ -59,9 +60,15 @@ describe('WF-VEP-002 export regression guards', () => {
       "={{ $json.body?.callbackBaseUrl || 'https://amadutown.com' }}",
     )
     expect(getAssignment(setParamsNode, 'ingestSecret').value).toBe("={{ $vars.N8N_INGEST_SECRET }}")
+    expect(getAssignment(setParamsNode, 'is_test_data').value).toBe(
+      "={{ $json.body?.is_test_data === true || $json.body?.is_test_data === 'true' }}",
+    )
 
     // activeVersion can lag behind editor exports, but the node should still exist there.
-    getNodeByName(workflow.activeVersion?.nodes ?? [], 'Set Search Parameters')
+    const activeSetParamsNode = getNodeByName(workflow.activeVersion?.nodes ?? [], 'Set Search Parameters')
+    expect(getAssignment(activeSetParamsNode, 'is_test_data').value).toBe(
+      "={{ $json.body?.is_test_data === true || $json.body?.is_test_data === 'true' }}",
+    )
   })
 
   it('uses AMADUTOWN_PUBLIC_BASE_URL + Bearer N8N_INGEST_SECRET for ingest endpoints', () => {
@@ -79,6 +86,8 @@ describe('WF-VEP-002 export regression guards', () => {
         )
 
         expect(authHeader?.value).toBe('=Bearer {{ $vars.N8N_INGEST_SECRET }}')
+        expect(ingestNode.parameters?.jsonBody).toContain('is_test_data')
+        expect(ingestNode.parameters?.jsonBody).toContain("$('Set Search Parameters').first().json.is_test_data === true")
       }
     }
   })

--- a/lib/market-intel-classifier.ts
+++ b/lib/market-intel-classifier.ts
@@ -212,7 +212,7 @@ export async function classifyMarketIntel(
   // Fetch unprocessed market intel
   let query = sb
     .from('market_intelligence')
-    .select('id, content_text, source_platform, source_url, industry_detected, company_size_detected, monetary_mentions')
+    .select('id, content_text, source_platform, source_url, industry_detected, company_size_detected, monetary_mentions, is_test_data')
     .eq('is_processed', false)
     .order('created_at', { ascending: true })
     .limit(limit)
@@ -269,6 +269,7 @@ export async function classifyMarketIntel(
           monetary_context: firstMonetary?.context ?? null,
           confidence_score: match.confidence,
           extracted_by: 'ai_classifier',
+          is_test_data: row.is_test_data === true,
         })
 
       if (insertError) {

--- a/lib/n8n.ts
+++ b/lib/n8n.ts
@@ -1424,6 +1424,8 @@ export interface SocialListeningOptions {
   contactSubmissionId?: number
   /** Lead context for single-lead mode: company name, industry, domain, pain points. */
   leadContext?: Record<string, unknown>
+  /** Marks downstream rows as cleanup-safe test data for production-like drills. */
+  isTestData?: boolean
 }
 
 export async function triggerSocialListening(options?: SocialListeningOptions): Promise<{ triggered: boolean; message: string }> {
@@ -1458,6 +1460,9 @@ export async function triggerSocialListening(options?: SocialListeningOptions): 
     }
     if (options?.sources && options.sources.length > 0) {
       body.sources = options.sources
+    }
+    if (options?.isTestData === true) {
+      body.is_test_data = true
     }
     if (options?.contactSubmissionId) {
       body.contact_submission_id = options.contactSubmissionId

--- a/n8n-exports/WF-VEP-002-Social-Listening-Pipeline.json
+++ b/n8n-exports/WF-VEP-002-Social-Listening-Pipeline.json
@@ -156,6 +156,12 @@
               "value": "={{ $json.body?.contact_submission_id || '' }}"
             },
             {
+              "id": "is_test_data",
+              "name": "is_test_data",
+              "type": "boolean",
+              "value": "={{ $json.body?.is_test_data === true || $json.body?.is_test_data === 'true' }}"
+            },
+            {
               "id": "baseUrl",
               "name": "baseUrl",
               "type": "string",
@@ -290,7 +296,7 @@
         "specifyBody": "json",
         "sendBody": true,
         "sendHeaders": true,
-        "jsonBody": "={{ JSON.stringify({ items: [{ source_platform: $json.platform, content_text: ($json.title || '') + (($json.title && $json.body) ? '\\n\\n' : '') + ($json.body || ''), content_type: $json.content_type === 'social_post' ? 'post' : ($json.content_type === 'review' ? 'review' : 'other'), source_url: $json.url || '', source_author: $json.author || '' }] }) }}",
+        "jsonBody": "={{ JSON.stringify({ is_test_data: $('Set Search Parameters').first().json.is_test_data === true, items: [{ source_platform: $json.platform, content_text: ($json.title || '') + (($json.title && $json.body) ? '\\n\\n' : '') + ($json.body || ''), content_type: $json.content_type === 'social_post' ? 'post' : ($json.content_type === 'review' ? 'review' : 'other'), source_url: $json.url || '', source_author: $json.author || '' }] }) }}",
         "options": {},
         "headerParameters": {
           "parameters": [
@@ -420,7 +426,7 @@
         "specifyBody": "json",
         "sendBody": true,
         "sendHeaders": true,
-        "jsonBody": "={{ JSON.stringify({ evidence: [{ pain_point_category_name: $json.pain_point_category_name, source_type: $json.source_type, source_id: $json.source_id, source_excerpt: $json.source_excerpt, confidence_score: $json.confidence_score, monetary_indicator: $json.monetary_indicator, monetary_context: $json.monetary_context, industry: $json.industry }] }) }}",
+        "jsonBody": "={{ JSON.stringify({ is_test_data: $('Set Search Parameters').first().json.is_test_data === true, evidence: [{ pain_point_category_name: $json.pain_point_category_name, source_type: $json.source_type, source_id: $json.source_id, source_excerpt: $json.source_excerpt, confidence_score: $json.confidence_score, monetary_indicator: $json.monetary_indicator, monetary_context: $json.monetary_context, industry: $json.industry }] }) }}",
         "options": {},
         "headerParameters": {
           "parameters": [
@@ -952,6 +958,12 @@
                 "name": "capterraProductUrls",
                 "type": "string",
                 "value": "={{ JSON.stringify($json.body && $json.body.capterraProductUrls ? $json.body.capterraProductUrls : ['https://www.capterra.com/p/140827/HubSpot/', 'https://www.capterra.com/p/233073/monday-com/', 'https://www.capterra.com/p/140127/Mailchimp/', 'https://www.capterra.com/p/205656/Bloomerang/', 'https://www.capterra.com/p/16666/QuickBooks/']) }}"
+              },
+              {
+                "id": "is_test_data",
+                "name": "is_test_data",
+                "type": "boolean",
+                "value": "={{ $json.body?.is_test_data === true || $json.body?.is_test_data === 'true' }}"
               }
             ]
           },
@@ -1076,7 +1088,7 @@
           "specifyBody": "json",
           "sendBody": true,
           "sendHeaders": true,
-          "jsonBody": "={{ JSON.stringify({ items: [{ source_platform: $json.platform, content_text: ($json.title || '') + (($json.title && $json.body) ? '\\n\\n' : '') + ($json.body || ''), content_type: $json.content_type === 'social_post' ? 'post' : ($json.content_type === 'review' ? 'review' : 'other'), source_url: $json.url || '', source_author: $json.author || '' }] }) }}",
+          "jsonBody": "={{ JSON.stringify({ is_test_data: $('Set Search Parameters').first().json.is_test_data === true, items: [{ source_platform: $json.platform, content_text: ($json.title || '') + (($json.title && $json.body) ? '\\n\\n' : '') + ($json.body || ''), content_type: $json.content_type === 'social_post' ? 'post' : ($json.content_type === 'review' ? 'review' : 'other'), source_url: $json.url || '', source_author: $json.author || '' }] }) }}",
           "options": {},
           "headerParameters": {
             "parameters": [
@@ -1206,7 +1218,7 @@
           "specifyBody": "json",
           "sendBody": true,
           "sendHeaders": true,
-          "jsonBody": "={{ JSON.stringify({ evidence: [{ pain_point_category_name: $json.pain_point_category_name, source_type: $json.source_type, source_id: $json.source_id, source_excerpt: $json.source_excerpt, confidence_score: $json.confidence_score, monetary_indicator: $json.monetary_indicator, monetary_context: $json.monetary_context, industry: $json.industry }] }) }}",
+          "jsonBody": "={{ JSON.stringify({ is_test_data: $('Set Search Parameters').first().json.is_test_data === true, evidence: [{ pain_point_category_name: $json.pain_point_category_name, source_type: $json.source_type, source_id: $json.source_id, source_excerpt: $json.source_excerpt, confidence_score: $json.confidence_score, monetary_indicator: $json.monetary_indicator, monetary_context: $json.monetary_context, industry: $json.industry }] }) }}",
           "options": {},
           "headerParameters": {
             "parameters": [


### PR DESCRIPTION
Summary
- Preserve `is_test_data` through the Google Places n8n bakeoff path for `market_intelligence` and classified pain-point evidence.
- Limit `ingest-market` auto-classification to the rows inserted by the current request instead of an arbitrary unprocessed-row limit.
- Update the WF-VEP-002 export and regression tests so n8n forwards the test-data marker, and document the 2026-06-02 production-like preflight result.

Validation
- `npm test -- --run lib/__tests__/n8n-value-evidence.test.ts lib/__tests__/n8n-vep002-workflow-export.test.ts`
- `npm run lint`
- `npm run build`
- `npm run n8n:drift-check:warn` exited 0 in warn mode, but every configured workflow returned n8n API 403 with the current API key. Live WF-VEP-002 was inspected separately through the n8n Cloud MCP before this change.
- Push hook ran `npm run db:health-check` against PROD and passed.
- No live WF-VEP-002 bakeoff was triggered because the current deployed ingest path can create unmarked production `market_intelligence` rows until this change is deployed and the n8n graph is synced.

Integration Notes
- After deploy, sync the live WF-VEP-002 graph so `Set Search Parameters`, `POST Raw to Market Intel`, and `POST Pain Points` forward `is_test_data`.
- Then run the isolated payload with `sources: ["google_maps"]`, `maxResults: 5`, and `is_test_data: true`.
- Confirm any created `market_intelligence` and `pain_point_evidence` rows are cleanup-safe before comparing Google Places quality and cost against the Apify baseline.
- Vercel contexts not checked from this non-captain lane: `Vercel – portfolio`, `Vercel – portfolio-staging`.
