### PR TITLE
test: stabilize admin outreach smoke auth wait

### DIFF
--- a/e2e/admin-outreach.spec.ts
+++ b/e2e/admin-outreach.spec.ts
@@ -1,4 +1,22 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
+
+async function waitForAdminContentOrLogin(page: Page, contentPattern: RegExp) {
+  await expect
+    .poll(
+      async () => {
+        const url = page.url()
+        const mainText = await page.locator('main').innerText().catch(() => '')
+        const bodyText = await page.locator('body').innerText().catch(() => '')
+        return (
+          url.includes('/auth/login') ||
+          /sign in|log in/i.test(bodyText) ||
+          contentPattern.test(mainText)
+        )
+      },
+      { timeout: 7000 },
+    )
+    .toBe(true)
+}
 
 /**
  * Smoke tests for Admin Lead Pipeline (All Leads + Escalations).
@@ -31,26 +49,17 @@ test.describe('Admin Outreach API', () => {
 test.describe('Admin Outreach UI', () => {
   test('Outreach page loads (Leads tab or sign-in)', async ({ page }) => {
     await page.goto('/admin/outreach')
-    // Either we see lead pipeline content or we are on sign-in
-    const hasOutreach = await page.getByText(/leads|manage all leads|lead pipeline/i).first().isVisible().catch(() => false)
-    const hasSignIn = await page.getByText(/sign in|log in/i).first().isVisible().catch(() => false)
-    expect(hasOutreach || hasSignIn).toBe(true)
+    await waitForAdminContentOrLogin(page, /all leads|manage all leads|escalations/i)
   })
 
   test('Leads tab is available and shows All leads filter or empty state', async ({ page }) => {
     await page.goto('/admin/outreach?tab=leads')
-    // Either leads tab content (All leads, Warm, Cold, or empty state) or sign-in
-    const hasLeadsContent = await page
-      .getByText(/all leads|warm|cold|no leads|search leads/i)
-      .first()
-      .isVisible()
-      .catch(() => false)
-    const hasSignIn = await page.getByText(/sign in|log in/i).first().isVisible().catch(() => false)
-    expect(hasLeadsContent || hasSignIn).toBe(true)
+    await waitForAdminContentOrLogin(page, /all leads|warm|cold|no leads|search leads/i)
   })
 
   test('Message Queue tab is not shown (single email history: Email center)', async ({ page }) => {
     await page.goto('/admin/outreach?tab=leads')
+    await waitForAdminContentOrLogin(page, /all leads|warm|cold|no leads|search leads/i)
     const hasQueueTab = await page.getByRole('button', { name: /message queue/i }).count()
     const hasSignIn = await page.getByText(/sign in|log in/i).first().isVisible().catch(() => false)
     expect(hasQueueTab === 0 || hasSignIn).toBe(true)


### PR DESCRIPTION
Summary
- Salvages the local-only admin outreach smoke auth wait fix from a stale branch.
- Replaces one-shot text checks with a polling helper that accepts either authenticated outreach content or the login boundary.
- Keeps the change scoped to one Playwright E2E smoke file.

Validation
- npx playwright test e2e/admin-outreach.spec.ts --project=chromium
- npx tsc --noEmit --pretty false
- git diff --check origin/main...HEAD
- pre-push production database health check passed

Integration Notes
- Test-only change.
- No schema migration, workflow mutation, provider call, customer-data write, or live n8n smoke.
- Vercel – portfolio and Vercel – portfolio-staging should be verified after merge.