### PR TITLE
feat: add client ai ops qa plan runner

### DIFF
--- a/docs/client-ai-ops-roadmap-sop.md
+++ b/docs/client-ai-ops-roadmap-sop.md
@@ -133,6 +133,16 @@ Use `buildClientAiOpsRealPilotQaPlan` from `lib/client-ai-ops-real-pilot-qa.ts` 
 
 Authenticated UI smoke should use a synthetic or explicitly test-owned client project and dashboard token. If the tester cannot prove the record is synthetic or test-owned, stop before running the smoke.
 
+For captain handoff or local readiness checks, print the same plan without touching live client systems:
+
+```bash
+npx tsx scripts/client-ai-ops-real-pilot-qa.ts
+npx tsx scripts/client-ai-ops-real-pilot-qa.ts --summary
+npx tsx scripts/client-ai-ops-real-pilot-qa.ts --json
+```
+
+The runner exits non-zero only when the synthetic QA plan has blocked checks. Waiting approvals and manual smoke targets remain visible but do not trigger live setup.
+
 ## Roadmap Rule Checklist
 
 Use this checklist whenever a roadmap feature, monitor, report, or client implementation phase changes:

--- a/lib/client-ai-ops-real-pilot-qa.test.ts
+++ b/lib/client-ai-ops-real-pilot-qa.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/lib/supabase', () => ({ supabaseAdmin: null }))
 
-import { buildClientAiOpsRealPilotQaPlan } from './client-ai-ops-real-pilot-qa'
+import { buildClientAiOpsRealPilotQaPlan, formatClientAiOpsRealPilotQaPlan } from './client-ai-ops-real-pilot-qa'
 
 describe('buildClientAiOpsRealPilotQaPlan', () => {
   it('builds a real-pilot QA plan from synthetic/test-owned data only', () => {
@@ -77,5 +77,29 @@ describe('buildClientAiOpsRealPilotQaPlan', () => {
       status: 'needs_manual_smoke',
       sideEffectFree: true,
     })
+  })
+
+  it('formats a captain-ready QA packet without hiding approval gates', () => {
+    const plan = buildClientAiOpsRealPilotQaPlan()
+    const output = formatClientAiOpsRealPilotQaPlan(plan)
+
+    expect(output).toContain('Client AI Ops Real-Pilot QA Plan')
+    expect(output).toContain('Summary: 5 passed; 1 waiting approval; 1 manual smoke; 0 blocked.')
+    expect(output).toContain('[waiting_approval] Risky setup actions stay behind approvals')
+    expect(output).toContain('Manual Smoke Targets:')
+    expect(output).toContain('Forbidden Live Actions:')
+    expect(output).toContain('OAuth connection')
+    expect(output).toContain('client-data mutation')
+  })
+
+  it('formats a compact summary for quick captain checks', () => {
+    const output = formatClientAiOpsRealPilotQaPlan(buildClientAiOpsRealPilotQaPlan(), {
+      includeDetails: false,
+    })
+
+    expect(output).toContain('Client AI Ops Real-Pilot QA Plan')
+    expect(output).toContain('Summary:')
+    expect(output).not.toContain('Checks:')
+    expect(output).not.toContain('Forbidden Live Actions:')
   })
 })

--- a/lib/client-ai-ops-real-pilot-qa.ts
+++ b/lib/client-ai-ops-real-pilot-qa.ts
@@ -33,6 +33,10 @@ export type ClientAiOpsPilotQaPlan = {
   forbiddenActions: string[]
 }
 
+export type ClientAiOpsPilotQaPlanFormatOptions = {
+  includeDetails?: boolean
+}
+
 const GENERATED_AT = '2026-06-02T12:00:00.000Z'
 const SYNTHETIC_PROJECT_ID = 'synthetic-client-ai-ops-project'
 
@@ -195,4 +199,43 @@ function authenticatedUiSmokeCheck(): ClientAiOpsPilotQaCheck {
     clientSafe: true,
     sideEffectFree: true,
   }
+}
+
+export function formatClientAiOpsRealPilotQaPlan(
+  plan: ClientAiOpsPilotQaPlan = buildClientAiOpsRealPilotQaPlan(),
+  options: ClientAiOpsPilotQaPlanFormatOptions = {},
+): string {
+  const includeDetails = options.includeDetails ?? true
+  const lines = [
+    'Client AI Ops Real-Pilot QA Plan',
+    `Generated: ${plan.generatedAt}`,
+    `Fixture: ${plan.fixture}`,
+    `Project: ${plan.projectId}`,
+    `Summary: ${plan.summary.passed} passed; ${plan.summary.waitingApproval} waiting approval; ${plan.summary.manualSmoke} manual smoke; ${plan.summary.blocked} blocked.`,
+  ]
+
+  if (includeDetails) {
+    lines.push('', 'Checks:')
+    for (const check of plan.checks) {
+      lines.push(`- [${check.status}] ${check.label}`)
+      lines.push(`  Evidence: ${check.evidence}`)
+      lines.push(`  Next: ${check.nextAction}`)
+      lines.push(`  Client safe: ${String(check.clientSafe)}; side-effect free: ${String(check.sideEffectFree)}`)
+    }
+
+    lines.push('', 'Manual Smoke Targets:')
+    for (const target of plan.manualSmokeTargets) {
+      lines.push(`- ${target.surface}: ${target.path}`)
+      for (const evidence of target.expectedEvidence) {
+        lines.push(`  - ${evidence}`)
+      }
+    }
+
+    lines.push('', 'Forbidden Live Actions:')
+    for (const action of plan.forbiddenActions) {
+      lines.push(`- ${action}`)
+    }
+  }
+
+  return lines.join('\n')
 }

--- a/scripts/client-ai-ops-real-pilot-qa.ts
+++ b/scripts/client-ai-ops-real-pilot-qa.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env tsx
+process.env.NEXT_PUBLIC_SUPABASE_URL ??= 'http://localhost:54321'
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??= 'synthetic-client-ai-ops-qa-runner'
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= 'synthetic-client-ai-ops-qa-runner'
+
+async function main() {
+  const {
+    buildClientAiOpsRealPilotQaPlan,
+    formatClientAiOpsRealPilotQaPlan,
+  } = await import('../lib/client-ai-ops-real-pilot-qa')
+
+  const args = new Set(process.argv.slice(2))
+  const plan = buildClientAiOpsRealPilotQaPlan()
+
+  if (args.has('--json')) {
+    console.log(JSON.stringify(plan, null, 2))
+  } else {
+    console.log(formatClientAiOpsRealPilotQaPlan(plan, {
+      includeDetails: !args.has('--summary'),
+    }))
+  }
+
+  if (plan.summary.blocked > 0) {
+    process.exitCode = 1
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## Summary
- Adds a `formatClientAiOpsRealPilotQaPlan` helper for captain-ready text packets from the existing synthetic real-pilot QA plan.
- Adds `scripts/client-ai-ops-real-pilot-qa.ts` with default, `--summary`, and `--json` modes for local readiness handoff without live client setup.
- Documents the runner in the Client AI Ops roadmap SOP so real-pilot QA stays separated into automated synthetic proof, manual authenticated smoke, and forbidden live actions.

Compatibility notes: this is read-only and synthetic/test-owned. It does not add OAuth, credential sync, provider writes, workflow activation, outbound sends, publishing, deploy mutation, or client-data mutation.

### Enhancement Impact Preflight

- Enhancement: Add a local Client AI Ops real-pilot QA plan runner for captain/admin handoff.
- User-facing surface: Internal command-line QA packet and Client AI Ops SOP guidance.
- Predicted files: `lib/client-ai-ops-real-pilot-qa.ts`, `lib/client-ai-ops-real-pilot-qa.test.ts`, `scripts/client-ai-ops-real-pilot-qa.ts`, `docs/client-ai-ops-roadmap-sop.md`.
- Shared routes/APIs/tables/helpers: Existing synthetic QA plan helper only; no API route, table, queue, migration, credential, or provider write path.
- Active PRs or branches checked: `gh pr list --state open` returned no open PRs; root checkout branch `codex/open-brain-handoff-producer` left untouched.
- Dirty worktree files checked: Root checkout had unrelated `lib/open-brain.ts`; this work used fresh worktree `/Users/vambahsillah/Projects/Portfolio.worktrees/client-ai-ops-qa-plan-runner`.
- Overlap rating: green.
- Coordination decision: Proceed in dedicated Client AI Ops worktree and commit only the scoped QA plan runner files.
- Merge-order note: Can merge after current checks because no open PR overlap was detected; integration captain should still re-check root Open Brain branch before cleanup.

## Validation
- `npx tsx scripts/client-ai-ops-real-pilot-qa.ts --summary`
- `npx tsx scripts/client-ai-ops-real-pilot-qa.ts --json | node -e "let s='';process.stdin.on('data',d=>s+=d);process.stdin.on('end',()=>{const j=JSON.parse(s); console.log(j.summary.blocked===0 && j.summary.waitingApproval===1 ? 'qa-json-ok' : 'qa-json-bad')})"`
- `npm test -- lib/client-ai-ops-real-pilot-qa.test.ts lib/client-ai-ops-synthetic-pilot.test.ts lib/client-ai-ops-readiness-contract.test.ts`
- `npm run build:knowledge`
- `npx tsc --noEmit --pretty false`
- `git diff --cached --check`

No live workflow, OAuth, credential, provider, outbound-send, deployment, or client-data smoke was run.

## Integration Notes
- No migrations or env changes required.
- The runner supplies harmless local placeholder Supabase env values only when absent so the synthetic plan can load in a clean worktree without secrets.
- Vercel contexts not checked for this PR:
  - Vercel - portfolio: not checked
  - Vercel - portfolio-staging: not checked
