### PR TITLE
Route Agent Ops work items into Open Brain traces

### DIFF
--- a/docs/open-brain-local-service.md
+++ b/docs/open-brain-local-service.md
@@ -169,6 +169,7 @@ Current producer routes:
 
 - Personality corpus: public-safe derived pack appears as a `personality_corpus` source; raw private exports remain outside public projections. Run `npm run open-brain:personality-corpus` to persist the public-safe source/event trace into `OPEN_BRAIN_HOME` without copying raw private corpus content.
 - Codex automation inventory: Portfolio-related automation and repair-packet summaries appear as `codex_automation` and `repair_packet` sources. Run `npm run open-brain:automation-producer` to persist internal-ops source/event traces without copying raw automation prompts.
+- Agent Ops work items and handoffs: active work items appear as `work_item` sources and latest handoffs appear as `handoff` sources. Run `npm run open-brain:agent-ops-producer` to persist internal-ops source/event traces and deterministic review proposals for blocked or review-ready work without copying full work-item or handoff bodies.
 - Chatbot knowledge: `/api/knowledge` remains a public-safe projection, not canonical memory.
 - RAG/Pinecone: `/api/admin/rag-ingest` records shadow-plan source/event records and blocks writes pending cutover approval.
 - AutoResearch: when `OPEN_BRAIN_AUTORESEARCH_TRACE=true`, proposal creation records `autoresearch_proposal` source/event records; experiments, merges, deploys, hosted config changes, and durable memories remain separately gated. Keep this producer flag off by default until trace volume and privacy behavior are reviewed.

--- a/lib/open-brain.test.ts
+++ b/lib/open-brain.test.ts
@@ -11,6 +11,7 @@ import {
   linkOpenBrainRecords,
   recordOpenBrainEvent,
   recordOpenBrainSource,
+  recordAgentOpsWorkItemProducerTraces,
   recordCodexAutomationProducerTraces,
   recordPersonalityCorpusProducerTrace,
   reviewOpenBrainProposal,
@@ -62,6 +63,93 @@ vi.mock('./codex-workspace-roots', () => ({
   })),
 }))
 
+vi.mock('./agent-work-items', () => ({
+  listAgentWorkItems: vi.fn(async () => [
+    {
+      id: 'work-1',
+      title: 'Review Open Brain handoff path',
+      objective: 'Sensitive objective should stay out of producer output.',
+      status: 'blocked',
+      priority: 'high',
+      owner_agent_key: 'integration-captain',
+      owner_runtime: 'codex',
+      source_type: 'agent_run',
+      source_id: 'run-1',
+      source_label: 'Agent run',
+      source_run_id: 'run-1',
+      active_run_id: null,
+      parent_work_item_id: null,
+      branch_name: null,
+      worktree_path: null,
+      pr_number: null,
+      pr_url: null,
+      expected_files: [],
+      touched_files: [],
+      overlap_group: null,
+      dependency_ids: [],
+      blocker_summary: 'Sensitive blocker should stay out of producer output.',
+      validation_summary: null,
+      approval_id: null,
+      metadata: {},
+      idempotency_key: 'work-1',
+      created_at: '2026-06-01T12:00:00.000Z',
+      updated_at: '2026-06-02T12:00:00.000Z',
+      completed_at: null,
+    },
+    {
+      id: 'work-2',
+      title: 'Queued low-risk worker',
+      objective: 'Queued objective.',
+      status: 'queued',
+      priority: 'medium',
+      owner_agent_key: null,
+      owner_runtime: 'manual',
+      source_type: null,
+      source_id: null,
+      source_label: null,
+      source_run_id: null,
+      active_run_id: null,
+      parent_work_item_id: null,
+      branch_name: null,
+      worktree_path: null,
+      pr_number: null,
+      pr_url: null,
+      expected_files: [],
+      touched_files: [],
+      overlap_group: null,
+      dependency_ids: [],
+      blocker_summary: null,
+      validation_summary: null,
+      approval_id: null,
+      metadata: {},
+      idempotency_key: 'work-2',
+      created_at: '2026-06-01T12:00:00.000Z',
+      updated_at: '2026-06-02T12:00:00.000Z',
+      completed_at: null,
+    },
+  ]),
+  getAgentWorkItem: vi.fn(async (id: string) => id === 'work-1'
+    ? {
+      id: 'work-1',
+      latest_handoff: {
+        id: 'handoff-1',
+        run_id: 'run-1',
+        work_item_id: 'work-1',
+        from_agent_key: 'chief-of-staff',
+        to_agent_key: 'integration-captain',
+        handoff_type: 'agent_work_item_handoff',
+        summary: 'Sensitive handoff summary should stay out of producer output.',
+        acceptance_criteria: 'Sensitive acceptance criteria should stay out.',
+        status: 'pending',
+        created_at: '2026-06-02T12:30:00.000Z',
+        accepted_at: null,
+        completed_at: null,
+        metadata: {},
+      },
+    }
+    : { id, latest_handoff: null }),
+}))
+
 let tempRoot: string | null = null
 
 async function makeTempRoot() {
@@ -105,6 +193,7 @@ describe('Open Brain projection', () => {
       'producer:model-ops',
       'producer:rag-pinecone',
       'producer:decision-trust',
+      'producer:agent-ops-work-items',
     ]))
     expect(snapshot.overview.producerGates).toBe(snapshot.producerGates.length)
     expect(snapshot.relationshipMap.nodes.map((node) => node.type)).toEqual(expect.arrayContaining([
@@ -497,6 +586,56 @@ describe('Open Brain projection', () => {
     expect(first.events.map((event) => event.summary).join(' ')).not.toContain('Add an authority boundary.')
     expect(snapshot.sources.filter((source) => source.id === 'automation:portfolio-operations-manager')).toHaveLength(1)
     expect(snapshot.events.filter((event) => event.id === 'event:source-observed:automation:portfolio-operations-manager')).toHaveLength(1)
+  })
+
+  it('records Agent Ops work item and handoff traces with review proposals', async () => {
+    const root = await makeTempRoot()
+    const first = await recordAgentOpsWorkItemProducerTraces(root, '2026-06-02T13:00:00.000Z')
+    const second = await recordAgentOpsWorkItemProducerTraces(root, '2026-06-02T13:00:00.000Z')
+    const snapshot = await getOpenBrainSnapshot(root)
+
+    expect(first.status).toBe('recorded')
+    expect(second.status).toBe('recorded')
+    expect(first.overview).toEqual({
+      workItemsObserved: 2,
+      handoffsObserved: 1,
+      proposalsRecorded: 1,
+      rawWorkItemBodyIncluded: false,
+      rawHandoffBodyIncluded: false,
+    })
+    expect(first.sources.map((source) => source.id)).toEqual(expect.arrayContaining([
+      'work-item:work-1',
+      'work-item:work-2',
+      'handoff:handoff-1',
+    ]))
+    expect(first.events).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'event:source-observed:work-item:work-1',
+        metadata: expect.objectContaining({
+          producerId: 'producer:agent-ops-work-items',
+          rawWorkItemBodyIncluded: false,
+          rawHandoffBodyIncluded: false,
+        }),
+      }),
+    ]))
+    expect(first.proposals).toEqual([
+      expect.objectContaining({
+        id: 'proposal:agent-ops-work-item-review:work-1',
+        status: 'pending',
+        proposedMemory: expect.objectContaining({
+          kind: 'risk',
+          sourceIds: ['work-item:work-1'],
+        }),
+      }),
+    ])
+    const serialized = JSON.stringify(first)
+    expect(serialized).not.toContain('Sensitive objective')
+    expect(serialized).not.toContain('Sensitive blocker')
+    expect(serialized).not.toContain('Sensitive handoff summary')
+    expect(serialized).not.toContain('Sensitive acceptance criteria')
+    expect(snapshot.sources.filter((source) => source.id === 'work-item:work-1')).toHaveLength(1)
+    expect(snapshot.events.filter((event) => event.id === 'event:source-observed:work-item:work-1')).toHaveLength(1)
+    expect(snapshot.proposals.filter((proposal) => proposal.id === 'proposal:agent-ops-work-item-review:work-1')).toHaveLength(1)
   })
 
   it('projects only approved public-safe memories into RAG documents', () => {

--- a/lib/open-brain.ts
+++ b/lib/open-brain.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'fs'
 import { mkdir, readFile, writeFile } from 'fs/promises'
 import { homedir } from 'os'
 import path from 'path'
+import { getAgentWorkItem, listAgentWorkItems, type AgentWorkItem, type AgentWorkItemHandoff } from './agent-work-items'
 import { listCodexAutomationInventory, type CodexAutomationInventory } from './codex-automation-inventory'
 import { getCodexWorkspaceRootReport } from './codex-workspace-roots'
 import {
@@ -336,6 +337,25 @@ export interface OpenBrainAutomationProducerTrace {
     eventsRecorded: number
     rawPromptsIncluded: false
   }
+}
+
+export interface OpenBrainAgentOpsProducerTrace {
+  status: 'recorded' | 'missing'
+  sources: OpenBrainSourceRecord[]
+  events: OpenBrainEventRecord[]
+  proposals: OpenBrainProposalRecord[]
+  reason: string | null
+  overview: {
+    workItemsObserved: number
+    handoffsObserved: number
+    proposalsRecorded: number
+    rawWorkItemBodyIncluded: false
+    rawHandoffBodyIncluded: false
+  }
+}
+
+export interface OpenBrainAgentOpsProducerOptions {
+  limit?: number
 }
 
 export interface OpenBrainSnapshotOptions {
@@ -783,6 +803,88 @@ export async function recordCodexAutomationProducerTraces(
       sourcesRecorded: recordedSources.length,
       eventsRecorded: recordedEvents.length,
       rawPromptsIncluded: false,
+    },
+  }
+}
+
+export async function recordAgentOpsWorkItemProducerTraces(
+  openBrainHome = getOpenBrainHome(),
+  generatedAt = new Date().toISOString(),
+  options: OpenBrainAgentOpsProducerOptions = {},
+): Promise<OpenBrainAgentOpsProducerTrace> {
+  let workItems: AgentWorkItem[] = []
+  try {
+    workItems = await listAgentWorkItems({ limit: options.limit ?? 25 })
+  } catch (error) {
+    return {
+      status: 'missing',
+      sources: [],
+      events: [],
+      proposals: [],
+      reason: error instanceof Error ? error.message : 'Agent Ops work item inventory is not available.',
+      overview: {
+        workItemsObserved: 0,
+        handoffsObserved: 0,
+        proposalsRecorded: 0,
+        rawWorkItemBodyIncluded: false,
+        rawHandoffBodyIncluded: false,
+      },
+    }
+  }
+
+  const sources: OpenBrainSourceRecord[] = []
+  const handoffs: AgentWorkItemHandoff[] = []
+  for (const item of workItems) {
+    sources.push(agentWorkItemToOpenBrainSource(item, generatedAt))
+    const detail = await getAgentWorkItem(item.id).catch(() => null)
+    if (detail?.latest_handoff) {
+      handoffs.push(detail.latest_handoff)
+      sources.push(agentHandoffToOpenBrainSource(detail.latest_handoff, item, generatedAt))
+    }
+  }
+
+  const recordedSources: OpenBrainSourceRecord[] = []
+  const recordedEvents: OpenBrainEventRecord[] = []
+  for (const sourceInput of sources) {
+    const source = await recordOpenBrainSource(sourceInput, openBrainHome)
+    const event = await recordOpenBrainEvent({
+      id: `event:source-observed:${source.id}`,
+      kind: 'source_observed',
+      title: `Observed source: ${source.title}`,
+      summary: `${source.kind} observed from Agent Ops work queue. Raw work item and handoff bodies are excluded.`,
+      privacyTier: source.privacyTier,
+      confidence: source.confidence,
+      sourceIds: [source.id],
+      createdAt: generatedAt,
+      fingerprint: fingerprintOpenBrainRecord(['source_observed', source.id, source.fingerprint]),
+      metadata: {
+        producerId: 'producer:agent-ops-work-items',
+        sourceKind: source.kind,
+        path: source.path,
+        sourceFingerprint: source.fingerprint,
+        rawWorkItemBodyIncluded: false,
+        rawHandoffBodyIncluded: false,
+      },
+    }, openBrainHome)
+    recordedSources.push(source)
+    recordedEvents.push(event)
+  }
+
+  const reviewProposals = buildAgentOpsReviewProposals(workItems, generatedAt)
+  const proposals = await persistGeneratedOpenBrainProposals(reviewProposals, openBrainHome)
+
+  return {
+    status: 'recorded',
+    sources: recordedSources,
+    events: recordedEvents,
+    proposals,
+    reason: null,
+    overview: {
+      workItemsObserved: workItems.length,
+      handoffsObserved: handoffs.length,
+      proposalsRecorded: proposals.length,
+      rawWorkItemBodyIncluded: false,
+      rawHandoffBodyIncluded: false,
     },
   }
 }
@@ -1236,6 +1338,70 @@ function buildCodexAutomationInventorySources(inventory: CodexAutomationInventor
   ]
 }
 
+function agentWorkItemToOpenBrainSource(item: AgentWorkItem, generatedAt: string): OpenBrainSourceRecord {
+  return {
+    id: `work-item:${item.id}`,
+    kind: 'work_item',
+    title: item.title,
+    summary: sanitizeOpenBrainText([
+      `Agent Ops work item status ${item.status}; priority ${item.priority}.`,
+      item.owner_agent_key ? `Owner ${item.owner_agent_key}; runtime ${item.owner_runtime}.` : `Runtime ${item.owner_runtime}.`,
+      item.source_label ? `Source ${item.source_label}.` : null,
+      item.pr_url ? 'PR link is attached.' : null,
+      item.blocker_summary ? 'Blocker summary is present and should be reviewed in Agent Ops.' : null,
+      item.validation_summary ? 'Validation summary is present.' : null,
+    ].filter(Boolean).join(' ')),
+    path: `/admin/agents/work-items/${item.id}`,
+    privacyTier: 'internal_ops',
+    confidence: 0.86,
+    lastObservedAt: item.updated_at || generatedAt,
+    fingerprint: fingerprintOpenBrainRecord([
+      'work_item',
+      item.id,
+      item.status,
+      item.priority,
+      item.owner_agent_key || '',
+      item.owner_runtime,
+      item.source_run_id || '',
+      item.pr_url || '',
+      item.updated_at || generatedAt,
+    ]),
+  }
+}
+
+function agentHandoffToOpenBrainSource(
+  handoff: AgentWorkItemHandoff,
+  item: AgentWorkItem,
+  generatedAt: string,
+): OpenBrainSourceRecord {
+  return {
+    id: `handoff:${handoff.id}`,
+    kind: 'handoff',
+    title: `Agent handoff: ${handoff.from_agent_key || 'unknown'} to ${handoff.to_agent_key || 'unknown'}`,
+    summary: sanitizeOpenBrainText([
+      `Handoff status ${handoff.status}; type ${handoff.handoff_type || 'unknown'}.`,
+      `Linked work item ${item.title}.`,
+      handoff.run_id ? 'Linked source run is present.' : null,
+      handoff.accepted_at ? 'Handoff has been accepted.' : null,
+      handoff.completed_at ? 'Handoff has been completed.' : null,
+    ].filter(Boolean).join(' ')),
+    path: `/admin/agents/work-items/${item.id}`,
+    privacyTier: 'internal_ops',
+    confidence: 0.84,
+    lastObservedAt: handoff.completed_at || handoff.accepted_at || handoff.created_at || generatedAt,
+    fingerprint: fingerprintOpenBrainRecord([
+      'handoff',
+      handoff.id,
+      handoff.work_item_id || '',
+      handoff.run_id || '',
+      handoff.from_agent_key || '',
+      handoff.to_agent_key || '',
+      handoff.status,
+      handoff.created_at || generatedAt,
+    ]),
+  }
+}
+
 function buildRunbookSources(generatedAt: string): OpenBrainSourceRecord[] {
   const runbooks = [
     'docs/open-brain-local-service.md',
@@ -1517,6 +1683,17 @@ function buildProducerGates(modelOps: ModelOpsProjection): OpenBrainProducerGate
       envVar: null,
       configuredValue: null,
       note: 'Agent decision trust frames may be projected into the relationship map as read-only evidence. Enforcement remains off.',
+    },
+    {
+      id: 'producer:agent-ops-work-items',
+      label: 'Agent Ops work items and handoffs',
+      status: 'enabled',
+      sourceKind: 'work_item',
+      eventKind: 'source_observed',
+      privacyTier: 'internal_ops',
+      envVar: null,
+      configuredValue: null,
+      note: 'Agent Ops work items and latest handoffs can emit source/event traces; review-needed items create approval-gated memory proposals.',
     },
   ]
 }
@@ -1862,6 +2039,51 @@ function mergeProposals(persisted: OpenBrainProposalRecord[], generated: OpenBra
   for (const proposal of generated) byId.set(proposal.id, proposal)
   for (const proposal of persisted) byId.set(proposal.id, proposal)
   return [...byId.values()].sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+}
+
+function buildAgentOpsReviewProposals(items: AgentWorkItem[], generatedAt: string): OpenBrainProposalRecord[] {
+  return items
+    .filter((item) => ['blocked', 'ready_for_review', 'ready_for_merge'].includes(item.status))
+    .map((item): OpenBrainProposalRecord => {
+      const sourceId = `work-item:${item.id}`
+      const riskLike = item.status === 'blocked' || item.status === 'ready_for_merge'
+      return {
+        id: `proposal:agent-ops-work-item-review:${item.id}`,
+        status: 'pending',
+        proposedMemory: {
+          kind: riskLike ? 'risk' : 'workflow',
+          title: `Review Agent Ops work item: ${item.title}`,
+          body: sanitizeOpenBrainText([
+            `Agent Ops work item ${item.id} is ${item.status} with ${item.priority} priority.`,
+            item.owner_agent_key ? `Owner is ${item.owner_agent_key} on ${item.owner_runtime}.` : `Runtime is ${item.owner_runtime}.`,
+            item.status === 'ready_for_merge'
+              ? 'Merge/deploy-adjacent work must remain approval-gated before durable operating assumptions are accepted.'
+              : 'Review the Agent Ops source record before promoting any durable memory or operational rule.',
+          ].join(' ')),
+          privacyTier: 'internal_ops',
+          confidence: item.status === 'blocked' ? 0.82 : 0.76,
+          sourceIds: [sourceId],
+        },
+        sourceIds: [sourceId],
+        reason: 'Generated from Agent Ops work item status. Requires human review before becoming durable Open Brain memory.',
+        createdBy: 'open-brain-agent-ops-producer',
+        createdAt: generatedAt,
+        reviewedAt: null,
+        reviewedBy: null,
+        reviewReason: null,
+      }
+    })
+}
+
+async function persistGeneratedOpenBrainProposals(
+  generated: OpenBrainProposalRecord[],
+  openBrainHome: string,
+): Promise<OpenBrainProposalRecord[]> {
+  if (generated.length === 0) return []
+  const proposalsPath = path.join(openBrainHome, PROPOSALS_FILE)
+  const persisted = await readJsonArray<OpenBrainProposalRecord>(proposalsPath)
+  await writeJsonArray(proposalsPath, mergeProposals(persisted, generated))
+  return generated
 }
 
 function proposalToMemory(proposal: OpenBrainProposalRecord): OpenBrainMemoryRecord {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "open-brain:runtime-registration": "tsx scripts/open-brain-runtime-registration.ts",
     "open-brain:personality-corpus": "tsx scripts/open-brain-personality-corpus-producer.ts",
     "open-brain:automation-producer": "tsx scripts/open-brain-automation-producer.ts",
+    "open-brain:agent-ops-producer": "tsx scripts/open-brain-agent-ops-producer.ts",
     "wrm:smoke-gate": "tsx scripts/wrm-production-smoke-gate.ts",
     "source-protocol:smoke": "tsx scripts/source-protocol-smoke.ts",
     "staging:publications-parity": "tsx scripts/ensure-publications-experience-parity.ts --env-file .env.staging",

--- a/scripts/open-brain-agent-ops-producer.ts
+++ b/scripts/open-brain-agent-ops-producer.ts
@@ -1,0 +1,61 @@
+#!/usr/bin/env tsx
+import dotenv from 'dotenv'
+import path from 'path'
+
+dotenv.config({ path: path.join(process.cwd(), '.env.local') })
+
+function parseLimit(argv: string[]) {
+  const index = argv.indexOf('--limit')
+  if (index === -1) return undefined
+  const raw = argv[index + 1]
+  const parsed = Number.parseInt(raw || '', 10)
+  if (!Number.isFinite(parsed) || parsed < 1) throw new Error('--limit must be a positive integer')
+  return parsed
+}
+
+async function main() {
+  const { recordAgentOpsWorkItemProducerTraces } = await import('../lib/open-brain')
+  const result = await recordAgentOpsWorkItemProducerTraces(undefined, undefined, {
+    limit: parseLimit(process.argv.slice(2)),
+  })
+  const output = {
+    status: result.status,
+    reason: result.reason,
+    overview: result.overview,
+    sources: result.sources.map((source) => ({
+      id: source.id,
+      kind: source.kind,
+      title: source.title,
+      privacyTier: source.privacyTier,
+      path: source.path,
+      fingerprint: source.fingerprint,
+    })),
+    events: result.events.map((event) => ({
+      id: event.id,
+      kind: event.kind,
+      title: event.title,
+      privacyTier: event.privacyTier,
+      sourceIds: event.sourceIds,
+      fingerprint: event.fingerprint,
+      metadata: event.metadata,
+    })),
+    proposals: result.proposals.map((proposal) => ({
+      id: proposal.id,
+      status: proposal.status,
+      proposedKind: proposal.proposedMemory.kind,
+      title: proposal.proposedMemory.title,
+      privacyTier: proposal.proposedMemory.privacyTier,
+      sourceIds: proposal.sourceIds,
+    })),
+  }
+
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+  if (result.status === 'missing') process.exitCode = 1
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('[open-brain-agent-ops-producer] failed:', error instanceof Error ? error.message : error)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Summary\n- Adds an Agent Ops Open Brain producer for current work items and latest handoffs.\n- Adds `npm run open-brain:agent-ops-producer` with optional `-- --limit <n>`.\n- Persists internal-ops `work_item` / `handoff` source records and `source_observed` events.\n- Creates deterministic pending review proposals for blocked, ready-for-review, and ready-for-merge work items.\n- Excludes full work-item objectives, blocker bodies, handoff summaries, and handoff acceptance criteria from producer output.\n\n## Validation\n- `npm --prefix /Users/vambahsillah/Projects/Portfolio test -- --run lib/open-brain.test.ts scripts/open-brain-mcp-server.test.ts`\n- `npm --prefix /Users/vambahsillah/Projects/Portfolio test -- --run lib/open-brain-runtime-registration.test.ts`\n- `OPEN_BRAIN_HOME=/Users/vambahsillah/.open-brain OPEN_BRAIN_PORTFOLIO_ROOT=/Users/vambahsillah/Projects/Portfolio npm --prefix /Users/vambahsillah/Projects/Portfolio run open-brain:agent-ops-producer -- --limit 25`\n- Scoped `git diff --check` for touched Open Brain files\n- push hook database health check passed\n\n## Local Open Brain Trace\n- Work items observed: 25\n- Latest handoffs observed: 0\n- Review proposals recorded: 1\n- Raw work-item bodies included: `false`\n- Raw handoff bodies included: `false`\n\n## Roadmap Status\n- Completed: Phase 3 Agent Ops work-item/handoff producer route.\n- Next: AutoResearch outcomes/experiment traces, then Phase 4 wiki overlay hardening.\n- Blockers: none.