### PR TITLE
Route AutoResearch proposals into Open Brain traces

### DIFF
--- a/docs/open-brain-local-service.md
+++ b/docs/open-brain-local-service.md
@@ -172,7 +172,7 @@ Current producer routes:
 - Agent Ops work items and handoffs: active work items appear as `work_item` sources and latest handoffs appear as `handoff` sources. Run `npm run open-brain:agent-ops-producer` to persist internal-ops source/event traces and deterministic review proposals for blocked or review-ready work without copying full work-item or handoff bodies.
 - Chatbot knowledge: `/api/knowledge` remains a public-safe projection, not canonical memory.
 - RAG/Pinecone: `/api/admin/rag-ingest` records shadow-plan source/event records and blocks writes pending cutover approval.
-- AutoResearch: when `OPEN_BRAIN_AUTORESEARCH_TRACE=true`, proposal creation records `autoresearch_proposal` source/event records; experiments, merges, deploys, hosted config changes, and durable memories remain separately gated. Keep this producer flag off by default until trace volume and privacy behavior are reviewed.
+- AutoResearch: when `OPEN_BRAIN_AUTORESEARCH_TRACE=true`, proposal creation records `autoresearch_proposal` source/event records; experiments, merges, deploys, hosted config changes, and durable memories remain separately gated. Keep this producer flag off by default until trace volume and privacy behavior are reviewed. Run `npm run open-brain:autoresearch-producer` to persist Vercel AutoResearch proposal source/event traces and pending review proposals without executing experiments or changing hosted settings.
 - Model Ops: router decisions and swap requests appear as projection sources; model defaults remain approval-gated.
 
 ## RAG And Pinecone Projection

--- a/lib/open-brain.test.ts
+++ b/lib/open-brain.test.ts
@@ -14,12 +14,14 @@ import {
   recordAgentOpsWorkItemProducerTraces,
   recordCodexAutomationProducerTraces,
   recordPersonalityCorpusProducerTrace,
+  recordVercelAutoResearchProducerTraces,
   reviewOpenBrainProposal,
   sanitizeOpenBrainText,
   validateMemoryProposal,
   buildOpenBrainRagProjection,
   type OpenBrainMemoryRecord,
 } from './open-brain'
+import type { VercelResearchPlan } from './vercel-deployment-research'
 
 vi.mock('./codex-automation-inventory', () => ({
   listCodexAutomationInventory: vi.fn(async () => ({
@@ -636,6 +638,88 @@ describe('Open Brain projection', () => {
     expect(snapshot.sources.filter((source) => source.id === 'work-item:work-1')).toHaveLength(1)
     expect(snapshot.events.filter((event) => event.id === 'event:source-observed:work-item:work-1')).toHaveLength(1)
     expect(snapshot.proposals.filter((proposal) => proposal.id === 'proposal:agent-ops-work-item-review:work-1')).toHaveLength(1)
+  })
+
+  it('records Vercel AutoResearch proposals without executing experiments', async () => {
+    const root = await makeTempRoot()
+    const plan: VercelResearchPlan = {
+      generatedAt: '2026-06-02T14:00:00.000Z',
+      approvalType: 'vercel_deployment_research_proposal',
+      thresholds: {
+        queueWatchSeconds: 60,
+        queueBlockedSeconds: 300,
+        buildWatchSeconds: 600,
+        buildBlockedSeconds: 900,
+      },
+      summaries: [],
+      findings: [],
+      operatingRules: ['Do not mutate hosted settings without approval.'],
+      proposals: [
+        {
+          id: 'settings-review',
+          title: 'Review preview deployment settings',
+          hypothesis: 'Queue pressure may be reduced by a reviewed settings packet.',
+          expectedImpact: 'Reduce integration waiting time without changing settings automatically.',
+          scorecardBaseline: {
+            project: 'portfolio',
+            target: 'preview',
+            queueSeconds: 90,
+            buildSeconds: 300,
+            totalSeconds: 390,
+          },
+          touchedFiles: ['docs/vercel-deployment-runbook.md'],
+          touchedSettings: ['Vercel preview deployment setting'],
+          riskLevel: 'high',
+          approvalState: 'approval_required',
+          approvalQuestion: 'Approve preparing the settings packet only?',
+          rollbackPath: 'Close the packet and keep current Vercel settings.',
+          evidence: ['queue 90s'],
+        },
+      ],
+    }
+
+    const first = await recordVercelAutoResearchProducerTraces(plan, root, plan.generatedAt)
+    const second = await recordVercelAutoResearchProducerTraces(plan, root, plan.generatedAt)
+    const snapshot = await getOpenBrainSnapshot(root)
+
+    expect(first.status).toBe('recorded')
+    expect(second.status).toBe('recorded')
+    expect(first.overview).toEqual({
+      proposalsObserved: 1,
+      approvalRequired: 1,
+      memoryProposalsRecorded: 1,
+      experimentsExecuted: false,
+      hostedConfigMutated: false,
+    })
+    expect(first.sources).toEqual([
+      expect.objectContaining({
+        id: 'autoresearch:vercel:settings-review',
+        kind: 'autoresearch_proposal',
+      }),
+    ])
+    expect(first.events).toEqual([
+      expect.objectContaining({
+        id: 'event:autoresearch-proposal-created:settings-review',
+        kind: 'autoresearch_proposal_created',
+        metadata: expect.objectContaining({
+          producerId: 'producer:autoresearch',
+          experimentsExecuted: false,
+          hostedConfigMutated: false,
+        }),
+      }),
+    ])
+    expect(first.proposals).toEqual([
+      expect.objectContaining({
+        id: 'proposal:autoresearch:settings-review',
+        proposedMemory: expect.objectContaining({
+          kind: 'risk',
+          sourceIds: ['autoresearch:vercel:settings-review'],
+        }),
+      }),
+    ])
+    expect(snapshot.sources.filter((source) => source.id === 'autoresearch:vercel:settings-review')).toHaveLength(1)
+    expect(snapshot.events.filter((event) => event.id === 'event:autoresearch-proposal-created:settings-review')).toHaveLength(1)
+    expect(snapshot.proposals.filter((proposal) => proposal.id === 'proposal:autoresearch:settings-review')).toHaveLength(1)
   })
 
   it('projects only approved public-safe memories into RAG documents', () => {

--- a/lib/open-brain.ts
+++ b/lib/open-brain.ts
@@ -13,6 +13,7 @@ import {
   type DecisionTrustOpenBrainFrame,
 } from './decision-trust-open-brain'
 import { getModelOpsProjection, type ModelOpsProjection } from './model-ops-open-brain'
+import type { VercelResearchPlan, VercelResearchProposal } from './vercel-deployment-research'
 
 export type OpenBrainPrivacyTier = 'public_safe' | 'client_safe' | 'internal_ops' | 'private'
 export type OpenBrainSourceKind =
@@ -356,6 +357,21 @@ export interface OpenBrainAgentOpsProducerTrace {
 
 export interface OpenBrainAgentOpsProducerOptions {
   limit?: number
+}
+
+export interface OpenBrainAutoResearchProducerTrace {
+  status: 'recorded' | 'missing'
+  sources: OpenBrainSourceRecord[]
+  events: OpenBrainEventRecord[]
+  proposals: OpenBrainProposalRecord[]
+  reason: string | null
+  overview: {
+    proposalsObserved: number
+    approvalRequired: number
+    memoryProposalsRecorded: number
+    experimentsExecuted: false
+    hostedConfigMutated: false
+  }
 }
 
 export interface OpenBrainSnapshotOptions {
@@ -889,6 +905,80 @@ export async function recordAgentOpsWorkItemProducerTraces(
   }
 }
 
+export async function recordVercelAutoResearchProducerTraces(
+  plan: VercelResearchPlan | null,
+  openBrainHome = getOpenBrainHome(),
+  generatedAt = plan?.generatedAt || new Date().toISOString(),
+): Promise<OpenBrainAutoResearchProducerTrace> {
+  if (!plan) {
+    return {
+      status: 'missing',
+      sources: [],
+      events: [],
+      proposals: [],
+      reason: 'Vercel AutoResearch plan is not available.',
+      overview: {
+        proposalsObserved: 0,
+        approvalRequired: 0,
+        memoryProposalsRecorded: 0,
+        experimentsExecuted: false,
+        hostedConfigMutated: false,
+      },
+    }
+  }
+
+  const recordedSources: OpenBrainSourceRecord[] = []
+  const recordedEvents: OpenBrainEventRecord[] = []
+  for (const proposal of plan.proposals) {
+    const source = await recordOpenBrainSource(vercelResearchProposalToSource(proposal, generatedAt), openBrainHome)
+    const event = await recordOpenBrainEvent({
+      id: `event:autoresearch-proposal-created:${proposal.id}`,
+      kind: 'autoresearch_proposal_created',
+      title: `AutoResearch proposal observed: ${proposal.title}`,
+      summary: sanitizeOpenBrainText(`Risk ${proposal.riskLevel}; approval ${proposal.approvalState}. ${proposal.expectedImpact}`),
+      privacyTier: 'internal_ops',
+      confidence: proposal.approvalState === 'approval_required' ? 0.86 : 0.78,
+      sourceIds: [source.id],
+      createdAt: generatedAt,
+      fingerprint: fingerprintOpenBrainRecord(['autoresearch_proposal_created', source.id, source.fingerprint]),
+      metadata: {
+        producerId: 'producer:autoresearch',
+        planner: 'vercel-deployment-research',
+        sourceKind: source.kind,
+        proposalId: proposal.id,
+        riskLevel: proposal.riskLevel,
+        approvalState: proposal.approvalState,
+        touchedFiles: proposal.touchedFiles,
+        touchedSettings: proposal.touchedSettings,
+        experimentsExecuted: false,
+        hostedConfigMutated: false,
+      },
+    }, openBrainHome)
+    recordedSources.push(source)
+    recordedEvents.push(event)
+  }
+
+  const memoryProposals = await persistGeneratedOpenBrainProposals(
+    buildAutoResearchMemoryProposals(plan.proposals, generatedAt),
+    openBrainHome,
+  )
+
+  return {
+    status: 'recorded',
+    sources: recordedSources,
+    events: recordedEvents,
+    proposals: memoryProposals,
+    reason: null,
+    overview: {
+      proposalsObserved: plan.proposals.length,
+      approvalRequired: plan.proposals.filter((proposal) => proposal.approvalState === 'approval_required').length,
+      memoryProposalsRecorded: memoryProposals.length,
+      experimentsExecuted: false,
+      hostedConfigMutated: false,
+    },
+  }
+}
+
 export async function linkOpenBrainRecords(
   input: Omit<OpenBrainLinkRecord, 'id' | 'createdAt'> & { id?: string; createdAt?: string },
   openBrainHome = getOpenBrainHome(),
@@ -1398,6 +1488,38 @@ function agentHandoffToOpenBrainSource(
       handoff.to_agent_key || '',
       handoff.status,
       handoff.created_at || generatedAt,
+    ]),
+  }
+}
+
+function vercelResearchProposalToSource(
+  proposal: VercelResearchProposal,
+  generatedAt: string,
+): OpenBrainSourceRecord {
+  return {
+    id: `autoresearch:vercel:${proposal.id}`,
+    kind: 'autoresearch_proposal',
+    title: proposal.title,
+    summary: sanitizeOpenBrainText([
+      `Hypothesis: ${proposal.hypothesis}`,
+      `Expected impact: ${proposal.expectedImpact}`,
+      `Risk ${proposal.riskLevel}; approval ${proposal.approvalState}.`,
+      `Rollback: ${proposal.rollbackPath}`,
+    ].join(' ')),
+    path: 'docs/vercel-deployment-autoresearch.md',
+    privacyTier: 'internal_ops',
+    confidence: proposal.approvalState === 'approval_required' ? 0.86 : 0.8,
+    lastObservedAt: generatedAt,
+    fingerprint: fingerprintOpenBrainRecord([
+      'autoresearch_proposal',
+      proposal.id,
+      proposal.hypothesis,
+      proposal.expectedImpact,
+      proposal.riskLevel,
+      proposal.approvalState,
+      proposal.touchedFiles.join(','),
+      proposal.touchedSettings.join(','),
+      proposal.rollbackPath,
     ]),
   }
 }
@@ -2073,6 +2195,41 @@ function buildAgentOpsReviewProposals(items: AgentWorkItem[], generatedAt: strin
         reviewReason: null,
       }
     })
+}
+
+function buildAutoResearchMemoryProposals(
+  proposals: VercelResearchProposal[],
+  generatedAt: string,
+): OpenBrainProposalRecord[] {
+  return proposals.map((proposal): OpenBrainProposalRecord => {
+    const sourceId = `autoresearch:vercel:${proposal.id}`
+    const riskLike = proposal.riskLevel === 'high' || proposal.approvalState === 'approval_required'
+    return {
+      id: `proposal:autoresearch:${proposal.id}`,
+      status: 'pending',
+      proposedMemory: {
+        kind: riskLike ? 'risk' : 'workflow',
+        title: `Review AutoResearch proposal: ${proposal.title}`,
+        body: sanitizeOpenBrainText([
+          `Hypothesis: ${proposal.hypothesis}`,
+          `Expected impact: ${proposal.expectedImpact}`,
+          `Approval question: ${proposal.approvalQuestion}`,
+          `Rollback path: ${proposal.rollbackPath}`,
+          'This trace does not authorize experiment execution, hosted config mutation, merge, deploy, or durable memory promotion.',
+        ].join(' ')),
+        privacyTier: 'internal_ops',
+        confidence: riskLike ? 0.84 : 0.78,
+        sourceIds: [sourceId],
+      },
+      sourceIds: [sourceId],
+      reason: 'Generated from Vercel AutoResearch proposal packet. Requires approval before experiment execution or durable memory promotion.',
+      createdBy: 'open-brain-autoresearch-producer',
+      createdAt: generatedAt,
+      reviewedAt: null,
+      reviewedBy: null,
+      reviewReason: null,
+    }
+  })
 }
 
 async function persistGeneratedOpenBrainProposals(

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "open-brain:personality-corpus": "tsx scripts/open-brain-personality-corpus-producer.ts",
     "open-brain:automation-producer": "tsx scripts/open-brain-automation-producer.ts",
     "open-brain:agent-ops-producer": "tsx scripts/open-brain-agent-ops-producer.ts",
+    "open-brain:autoresearch-producer": "tsx scripts/open-brain-autoresearch-producer.ts",
     "wrm:smoke-gate": "tsx scripts/wrm-production-smoke-gate.ts",
     "source-protocol:smoke": "tsx scripts/source-protocol-smoke.ts",
     "staging:publications-parity": "tsx scripts/ensure-publications-experience-parity.ts --env-file .env.staging",

--- a/scripts/open-brain-autoresearch-producer.ts
+++ b/scripts/open-brain-autoresearch-producer.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env tsx
+import { spawnSync } from 'node:child_process'
+import dotenv from 'dotenv'
+import path from 'path'
+import type { VercelResearchPlan } from '../lib/vercel-deployment-research'
+
+dotenv.config({ path: path.join(process.cwd(), '.env.local') })
+
+function parseLimit(argv: string[]) {
+  const index = argv.indexOf('--limit')
+  if (index === -1) return 20
+  const raw = argv[index + 1]
+  const parsed = Number.parseInt(raw || '', 10)
+  if (!Number.isFinite(parsed) || parsed < 1) throw new Error('--limit must be a positive integer')
+  return parsed
+}
+
+function readVercelResearchPlan(limit: number): VercelResearchPlan {
+  const result = spawnSync('tsx', ['scripts/vercel-deployment-research-plan.ts', '--json', '--limit', String(limit)], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  if (result.status !== 0) {
+    const message = result.stderr.trim() || result.stdout.trim() || 'deploy:research:plan failed'
+    throw new Error(message)
+  }
+
+  return JSON.parse(result.stdout) as VercelResearchPlan
+}
+
+async function main() {
+  const { recordVercelAutoResearchProducerTraces } = await import('../lib/open-brain')
+  const plan = readVercelResearchPlan(parseLimit(process.argv.slice(2)))
+  const result = await recordVercelAutoResearchProducerTraces(plan)
+  const output = {
+    status: result.status,
+    reason: result.reason,
+    overview: result.overview,
+    sources: result.sources.map((source) => ({
+      id: source.id,
+      kind: source.kind,
+      title: source.title,
+      privacyTier: source.privacyTier,
+      path: source.path,
+      fingerprint: source.fingerprint,
+    })),
+    events: result.events.map((event) => ({
+      id: event.id,
+      kind: event.kind,
+      title: event.title,
+      privacyTier: event.privacyTier,
+      sourceIds: event.sourceIds,
+      fingerprint: event.fingerprint,
+      metadata: event.metadata,
+    })),
+    proposals: result.proposals.map((proposal) => ({
+      id: proposal.id,
+      status: proposal.status,
+      proposedKind: proposal.proposedMemory.kind,
+      title: proposal.proposedMemory.title,
+      privacyTier: proposal.proposedMemory.privacyTier,
+      sourceIds: proposal.sourceIds,
+    })),
+  }
+
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+  if (result.status === 'missing') process.exitCode = 1
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('[open-brain-autoresearch-producer] failed:', error instanceof Error ? error.message : error)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Summary\n- Adds a Vercel AutoResearch Open Brain producer.\n- Adds `npm run open-brain:autoresearch-producer -- --limit <n>`.\n- Persists `autoresearch_proposal` source records and `autoresearch_proposal_created` events from the existing Vercel research planner.\n- Creates deterministic pending Open Brain review proposals for each AutoResearch proposal.\n- Explicitly records that no experiments were executed and no hosted Vercel config was mutated.\n\n## Validation\n- `npm --prefix /Users/vambahsillah/Projects/Portfolio test -- --run lib/open-brain.test.ts scripts/open-brain-mcp-server.test.ts`\n- `npm --prefix /Users/vambahsillah/Projects/Portfolio test -- --run lib/open-brain-runtime-registration.test.ts`\n- `OPEN_BRAIN_HOME=/Users/vambahsillah/.open-brain OPEN_BRAIN_PORTFOLIO_ROOT=/Users/vambahsillah/Projects/Portfolio npm --prefix /Users/vambahsillah/Projects/Portfolio run open-brain:autoresearch-producer -- --limit 5`\n- Scoped `git diff --check` for touched Open Brain files\n- push hook database health check passed\n\n## Local Open Brain Trace\n- AutoResearch proposals observed: 2\n- Approval-required proposals: 1\n- Pending review proposals recorded: 2\n- Experiments executed: `false`\n- Hosted config mutated: `false`\n\n## Roadmap Status\n- Completed: Phase 3 AutoResearch proposal trace route.\n- Next: Phase 4 Karpathy Wiki overlay hardening from approved non-private Open Brain records.\n- Blockers: none.