### PR TITLE
Harden Open Brain wiki overlay provenance

### DIFF
--- a/app/admin/agents/open-brain/page.test.tsx
+++ b/app/admin/agents/open-brain/page.test.tsx
@@ -363,6 +363,37 @@ describe('OpenBrainPage', () => {
     }))
   })
 
+  it('renders wiki overlay approval provenance for source-event previews', async () => {
+    const snapshot = JSON.parse(JSON.stringify(openBrainSnapshot))
+    snapshot.overview.wikiPages = 1
+    snapshot.wikiPages = [{
+      slug: 'autoresearch-experiment-ledger',
+      title: 'AutoResearch Experiment Ledger',
+      path: 'docs/open-brain/wiki/autoresearch-experiment-ledger.md',
+      markdown: [
+        '# AutoResearch Experiment Ledger',
+        '',
+        'This page is preview-only until a human-approved outcome becomes durable Open Brain memory.',
+      ].join('\n'),
+      sourceMemoryIds: [],
+      sourceIds: ['source:autoresearch-public'],
+      sourceEventIds: ['event:autoresearch-public'],
+      approvalState: 'source_event_preview',
+      privacyTier: 'internal_ops',
+    }]
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => snapshot })))
+
+    render(<OpenBrainPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Wiki Overlay' }))
+
+    expect(screen.getByText('AutoResearch Experiment Ledger')).toBeInTheDocument()
+    expect(screen.getByText('source_event_preview')).toBeInTheDocument()
+    expect(screen.getByText('source:autoresearch-public')).toBeInTheDocument()
+    expect(screen.getByText('event:autoresearch-public')).toBeInTheDocument()
+    expect(screen.getByText(/preview-only until a human-approved outcome becomes durable Open Brain memory/i)).toBeInTheDocument()
+  })
+
   it('creates an approval-gated relationship proposal from a map insight', async () => {
     render(<OpenBrainPage />)
 

--- a/app/admin/agents/open-brain/page.tsx
+++ b/app/admin/agents/open-brain/page.tsx
@@ -1615,6 +1615,11 @@ function WikiView({ pages }: { pages: OpenBrainSnapshot['wikiPages'] }) {
             </div>
             <PrivacyBadge tier={page.privacyTier} />
           </div>
+          <div className="mb-3 grid grid-cols-1 gap-2 text-xs md:grid-cols-3">
+            <Detail label="Approval" value={page.approvalState} />
+            <Detail label="Sources" value={page.sourceIds.length ? page.sourceIds.join(', ') : 'none'} />
+            <Detail label="Events" value={page.sourceEventIds.length ? page.sourceEventIds.join(', ') : 'none'} />
+          </div>
           <pre className="max-h-72 overflow-auto rounded-lg border border-silicon-slate/60 bg-black/20 p-3 text-xs text-muted-foreground whitespace-pre-wrap">
             {page.markdown}
           </pre>

--- a/lib/open-brain.test.ts
+++ b/lib/open-brain.test.ts
@@ -351,8 +351,13 @@ describe('Open Brain projection', () => {
     expect(snapshot.wikiPages[0]).toEqual(expect.objectContaining({
       slug: 'decision-memory',
       path: 'docs/open-brain/wiki/decision-memory.md',
+      sourceMemoryIds: [expect.stringMatching(/^memory:/)],
+      sourceIds: ['runbook:docs/open-brain-local-service.md'],
+      sourceEventIds: [],
+      approvalState: 'approved_memory_only',
     }))
     expect(snapshot.wikiPages[0].markdown).toContain('Portfolio owns projection only')
+    expect(snapshot.wikiPages[0].markdown).toContain('Approval state: `approved_memory_only`')
   })
 
   it('creates a durable link only after approving a relationship proposal', async () => {
@@ -489,6 +494,44 @@ describe('Open Brain projection', () => {
     expect(compileKarpathyWikiOverlay([memory])).toEqual([])
   })
 
+  it('does not compile private AutoResearch events into wiki overlays', () => {
+    const publicEvent = {
+      id: 'event:autoresearch-public',
+      kind: 'autoresearch_proposal_created' as const,
+      title: 'Public-safe AutoResearch proposal',
+      summary: 'Sanitized proposal trace only.',
+      privacyTier: 'internal_ops' as const,
+      confidence: 0.82,
+      sourceIds: ['source:autoresearch-public'],
+      createdAt: '2026-05-10T12:00:00.000Z',
+      fingerprint: fingerprintOpenBrainRecord(['event:autoresearch-public']),
+    }
+    const privateEvent = {
+      id: 'event:autoresearch-private',
+      kind: 'autoresearch_proposal_created' as const,
+      title: 'Private AutoResearch proposal',
+      summary: 'Raw private experiment details.',
+      privacyTier: 'private' as const,
+      confidence: 0.82,
+      sourceIds: ['source:autoresearch-private'],
+      createdAt: '2026-05-10T12:00:00.000Z',
+      fingerprint: fingerprintOpenBrainRecord(['event:autoresearch-private']),
+    }
+
+    const pages = compileKarpathyWikiOverlay([], [publicEvent, privateEvent])
+
+    expect(pages).toHaveLength(1)
+    expect(pages[0]).toEqual(expect.objectContaining({
+      slug: 'autoresearch-experiment-ledger',
+      sourceIds: ['source:autoresearch-public'],
+      sourceEventIds: ['event:autoresearch-public'],
+      approvalState: 'source_event_preview',
+    }))
+    expect(pages[0].markdown).toContain('Sanitized proposal trace only.')
+    expect(pages[0].markdown).not.toContain('Raw private experiment details.')
+    expect(pages[0].markdown).not.toContain('event:autoresearch-private')
+  })
+
   it('persists source, event, and link records in the local Open Brain home', async () => {
     const root = await makeTempRoot()
     const source = await recordOpenBrainSource({
@@ -529,6 +572,14 @@ describe('Open Brain projection', () => {
     expect(snapshot.events).toEqual(expect.arrayContaining([expect.objectContaining({ kind: 'autoresearch_proposal_created' })]))
     expect(snapshot.links).toEqual([expect.objectContaining({ id: link.id, relationship: 'derived_from' })])
     expect(snapshot.wikiPages.map((page) => page.slug)).toContain('autoresearch-experiment-ledger')
+    expect(snapshot.wikiPages).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        slug: 'autoresearch-experiment-ledger',
+        sourceIds: [source.id],
+        sourceEventIds: ['event:autoresearch-proposal-created:test'],
+        approvalState: 'source_event_preview',
+      }),
+    ]))
   })
 
   it('records the personality corpus producer trace without raw private content', async () => {
@@ -848,6 +899,9 @@ describe('Open Brain projection', () => {
         path: 'docs/open-brain/wiki/operating-rules.md',
         markdown: '# Operating Rules',
         sourceMemoryIds: ['memory:governance'],
+        sourceIds: ['source:automation'],
+        sourceEventIds: [],
+        approvalState: 'approved_memory_only' as const,
         privacyTier: 'internal_ops' as const,
       },
     ]
@@ -891,6 +945,11 @@ describe('Open Brain projection', () => {
         fromId: 'memory:governance',
         toId: 'wiki:operating-rules',
         relationship: 'compiled_overlay',
+      }),
+      expect.objectContaining({
+        fromId: 'source:automation',
+        toId: 'wiki:operating-rules',
+        relationship: 'compiled_from_source',
       }),
     ]))
     expect(relationshipMap.overview.staleSources).toBe(1)

--- a/lib/open-brain.ts
+++ b/lib/open-brain.ts
@@ -141,6 +141,9 @@ export interface OpenBrainWikiPage {
   path: string
   markdown: string
   sourceMemoryIds: string[]
+  sourceIds: string[]
+  sourceEventIds: string[]
+  approvalState: 'approved_memory_only' | 'source_event_preview'
   privacyTier: OpenBrainPrivacyTier
 }
 
@@ -1036,10 +1039,14 @@ export function compileKarpathyWikiOverlay(
   for (const [kind, records] of grouped.entries()) {
     const title = `${titleCase(kind.replace('_', ' '))} Memory`
     const slug = `${kind.replace(/_/g, '-')}-memory`
+    const sourceIds = uniqueOpenBrainIds(records.flatMap((record) => record.sourceIds))
     const markdown = [
       `# ${title}`,
       '',
       'Generated Karpathy Wiki overlay from approved Open Brain records. The local Open Brain remains the source of truth.',
+      '',
+      `- Approval state: \`approved_memory_only\``,
+      `- Source ids: ${sourceIds.map((sourceId) => `\`${sourceId}\``).join(', ') || 'none'}`,
       '',
       ...records.map((record) => [
         `## ${record.title}`,
@@ -1058,6 +1065,9 @@ export function compileKarpathyWikiOverlay(
       path: `docs/open-brain/wiki/${slug}.md`,
       markdown,
       sourceMemoryIds: records.map((record) => record.id),
+      sourceIds,
+      sourceEventIds: [],
+      approvalState: 'approved_memory_only',
       privacyTier: records.some((record) => record.privacyTier === 'internal_ops') ? 'internal_ops' : 'public_safe',
     })
   }
@@ -1066,6 +1076,8 @@ export function compileKarpathyWikiOverlay(
     event.privacyTier !== 'private' && event.kind.startsWith('autoresearch_')
   )
   if (autoresearchEvents.length > 0) {
+    const sourceIds = uniqueOpenBrainIds(autoresearchEvents.flatMap((event) => event.sourceIds))
+    const sourceEventIds = uniqueOpenBrainIds(autoresearchEvents.map((event) => event.id))
     pages.push({
       slug: 'autoresearch-experiment-ledger',
       title: 'AutoResearch Experiment Ledger',
@@ -1074,6 +1086,11 @@ export function compileKarpathyWikiOverlay(
         '# AutoResearch Experiment Ledger',
         '',
         'Generated Karpathy Wiki overlay from Open Brain source/event records. The local Open Brain remains the source of truth.',
+        'This page is preview-only until a human-approved outcome becomes durable Open Brain memory.',
+        '',
+        `- Approval state: \`source_event_preview\``,
+        `- Source ids: ${sourceIds.map((sourceId) => `\`${sourceId}\``).join(', ') || 'none'}`,
+        `- Event ids: ${sourceEventIds.map((eventId) => `\`${eventId}\``).join(', ') || 'none'}`,
         '',
         ...autoresearchEvents.map((event) => [
           `## ${event.title}`,
@@ -1087,10 +1104,17 @@ export function compileKarpathyWikiOverlay(
         ].join('\n')),
       ].join('\n'),
       sourceMemoryIds: [],
+      sourceIds,
+      sourceEventIds,
+      approvalState: 'source_event_preview',
       privacyTier: autoresearchEvents.some((event) => event.privacyTier === 'internal_ops') ? 'internal_ops' : 'public_safe',
     })
   }
   return pages.sort((a, b) => a.slug.localeCompare(b.slug))
+}
+
+function uniqueOpenBrainIds(ids: string[]) {
+  return [...new Set(ids.filter(Boolean))].sort()
 }
 
 export function buildOpenBrainRelationshipMap({
@@ -1180,6 +1204,19 @@ export function buildOpenBrainRelationshipMap({
         strength: 'strong',
         confidence: 0.86,
         evidence: 'Wiki overlay is compiled from this approved memory.',
+        status: 'inferred',
+      })
+    }
+    for (const sourceId of page.sourceIds) {
+      if (!nodeIds.has(sourceId)) continue
+      addRelationshipEdge(edgeMap, {
+        id: `edge:wiki-source:${fingerprintOpenBrainRecord([page.slug, sourceId]).slice(0, 16)}`,
+        fromId: sourceId,
+        toId: wikiNodeId,
+        relationship: 'compiled_from_source',
+        strength: page.approvalState === 'approved_memory_only' ? 'medium' : 'weak',
+        confidence: page.approvalState === 'approved_memory_only' ? 0.78 : 0.68,
+        evidence: 'Wiki overlay cites this source id for projection provenance.',
         status: 'inferred',
       })
     }
@@ -1930,7 +1967,7 @@ function wikiToRelationshipNode(page: OpenBrainWikiPage, index: number): OpenBra
     type: 'wiki',
     kind: 'wiki_page',
     privacyTier: page.privacyTier,
-    summary: `Compiled wiki overlay at ${page.path}.`,
+    summary: `Compiled wiki overlay at ${page.path}. Approval state: ${page.approvalState}. Sources: ${page.sourceIds.length}.`,
     path: page.path,
     health: page.privacyTier === 'private' ? 'red' : page.sourceMemoryIds.length > 0 ? 'green' : 'yellow',
     x: point.x,


### PR DESCRIPTION
## Summary
- Add source IDs, source event IDs, and approval state to Open Brain wiki overlay pages.
- Mark AutoResearch ledger pages as source/event preview material until approved outcomes become durable memory.
- Expose wiki provenance in the Portfolio Open Brain admin preview and relationship graph.
- Add admin UI coverage for source-event preview provenance on the Wiki Overlay tab.

## Validation
- npm test -- --run lib/open-brain.test.ts app/admin/agents/open-brain/page.test.tsx scripts/open-brain-mcp-server.test.ts
- npx tsc --noEmit --pretty false
- git diff --check
- push hook database health check passed
- In-app browser smoke attempted against http://127.0.0.1:3011/admin/agents/open-brain, but Browser navigation was blocked with ERR_BLOCKED_BY_CLIENT; no live browser smoke was completed in this turn.

## Integration Notes
- No migrations or env changes required.
- Preview gate currently waiting on Vercel – portfolio for commit 39fc59987d7178c0351dbfdf79a48129413c44c8.
- Vercel – portfolio-staging is not expected on this PR preview unless the integration captain sees it in the check rollup; verify both Vercel – portfolio and Vercel – portfolio-staging after merge to main.