### PR TITLE
feat: add client ai ops smoke evidence packet

### DIFF
--- a/docs/client-ai-ops-roadmap-sop.md
+++ b/docs/client-ai-ops-roadmap-sop.md
@@ -139,9 +139,12 @@ For captain handoff or local readiness checks, print the same plan without touch
 npx tsx scripts/client-ai-ops-real-pilot-qa.ts
 npx tsx scripts/client-ai-ops-real-pilot-qa.ts --summary
 npx tsx scripts/client-ai-ops-real-pilot-qa.ts --json
+npx tsx scripts/client-ai-ops-real-pilot-qa.ts --evidence-template
 ```
 
 The runner exits non-zero only when the synthetic QA plan has blocked checks. Waiting approvals and manual smoke targets remain visible but do not trigger live setup.
+
+Use the evidence template while performing authenticated manual smoke. A capture is captain-reviewable only when it uses synthetic or explicitly test-owned data, includes the expected evidence, contains no secrets or raw client records, and does not attempt any forbidden live setup action. Captures that include credentials, tokens, personal account data, or private client records must be redacted before review. Captures that use real client data without approval or attempt a forbidden action should stop the pilot path and open an approval/safety review.
 
 ## Roadmap Rule Checklist
 
@@ -160,6 +163,7 @@ Use this checklist whenever a roadmap feature, monitor, report, or client implem
 - The admin AI Ops readiness contract stays present and keeps `sideEffectsEnabled` false.
 - The client dashboard shows setup readiness without exposing internal swarm traces or credential/provider details.
 - The real-pilot QA plan separates automated synthetic proof from authenticated manual smoke and forbidden live actions.
+- The smoke evidence template captures screenshots and notes without secrets, raw client records, or live setup attempts.
 - Client-facing output excludes private logs, agent traces, credentials, and internal-only notes.
 
 ## Real Client Pilot Checklist

--- a/lib/client-ai-ops-real-pilot-qa.test.ts
+++ b/lib/client-ai-ops-real-pilot-qa.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/lib/supabase', () => ({ supabaseAdmin: null }))
 
-import { buildClientAiOpsRealPilotQaPlan, formatClientAiOpsRealPilotQaPlan } from './client-ai-ops-real-pilot-qa'
+import {
+  buildClientAiOpsRealPilotQaPlan,
+  buildClientAiOpsSmokeEvidencePacket,
+  formatClientAiOpsRealPilotQaPlan,
+  formatClientAiOpsSmokeEvidencePacket,
+} from './client-ai-ops-real-pilot-qa'
 
 describe('buildClientAiOpsRealPilotQaPlan', () => {
   it('builds a real-pilot QA plan from synthetic/test-owned data only', () => {
@@ -101,5 +106,98 @@ describe('buildClientAiOpsRealPilotQaPlan', () => {
     expect(output).toContain('Summary:')
     expect(output).not.toContain('Checks:')
     expect(output).not.toContain('Forbidden Live Actions:')
+  })
+
+  it('builds a pending smoke evidence template from manual smoke targets', () => {
+    const packet = buildClientAiOpsSmokeEvidencePacket()
+
+    expect(packet.summary).toEqual({
+      totalTargets: 3,
+      pendingCapture: 3,
+      readyForReview: 0,
+      needsRedaction: 0,
+      blocked: 0,
+    })
+    expect(packet.items.map((item) => item.surface)).toEqual([
+      'Admin project detail',
+      'Client dashboard',
+      'Monitor report and meeting task projection',
+    ])
+    expect(packet.items.every((item) => item.status === 'pending_capture')).toBe(true)
+    expect(packet.forbiddenActions).toContain('credential sync')
+  })
+
+  it('marks complete synthetic captures ready for review', () => {
+    const plan = buildClientAiOpsRealPilotQaPlan()
+    const target = plan.manualSmokeTargets[0]
+    const packet = buildClientAiOpsSmokeEvidencePacket(plan, [
+      {
+        targetSurface: target.surface,
+        capturedBy: 'Test Operator',
+        capturedAt: '2026-06-03T09:00:00.000Z',
+        screenshotPath: '/tmp/client-ai-ops-admin-smoke.png',
+        observedEvidence: target.expectedEvidence,
+        usedSyntheticData: true,
+        containsSecrets: false,
+      },
+    ])
+
+    expect(packet.summary.readyForReview).toBe(1)
+    expect(packet.summary.pendingCapture).toBe(2)
+    expect(packet.items[0]).toMatchObject({
+      status: 'ready_for_review',
+      clientSafe: true,
+      sideEffectFree: true,
+      missingEvidence: [],
+    })
+  })
+
+  it('requires redaction when a capture contains secrets', () => {
+    const plan = buildClientAiOpsRealPilotQaPlan()
+    const target = plan.manualSmokeTargets[1]
+    const packet = buildClientAiOpsSmokeEvidencePacket(plan, [
+      {
+        targetSurface: target.surface,
+        observedEvidence: target.expectedEvidence,
+        usedSyntheticData: true,
+        containsSecrets: true,
+      },
+    ])
+
+    expect(packet.items[1]).toMatchObject({
+      status: 'needs_redaction',
+      clientSafe: false,
+      sideEffectFree: true,
+    })
+  })
+
+  it('blocks evidence that uses real client data or attempts forbidden actions', () => {
+    const plan = buildClientAiOpsRealPilotQaPlan()
+    const target = plan.manualSmokeTargets[2]
+    const packet = buildClientAiOpsSmokeEvidencePacket(plan, [
+      {
+        targetSurface: target.surface,
+        observedEvidence: target.expectedEvidence,
+        usedSyntheticData: false,
+        containsSecrets: false,
+        attemptedForbiddenActions: ['provider write'],
+      },
+    ])
+
+    expect(packet.items[2]).toMatchObject({
+      status: 'blocked',
+      clientSafe: false,
+      sideEffectFree: false,
+    })
+  })
+
+  it('formats a smoke evidence packet for manual captain handoff', () => {
+    const output = formatClientAiOpsSmokeEvidencePacket(buildClientAiOpsSmokeEvidencePacket())
+
+    expect(output).toContain('Client AI Ops Smoke Evidence Packet')
+    expect(output).toContain('[pending_capture] Admin project detail')
+    expect(output).toContain('[capture screenshot path]')
+    expect(output).toContain('Reviewer Checklist:')
+    expect(output).toContain('Forbidden Live Actions:')
   })
 })

--- a/lib/client-ai-ops-real-pilot-qa.ts
+++ b/lib/client-ai-ops-real-pilot-qa.ts
@@ -37,6 +37,53 @@ export type ClientAiOpsPilotQaPlanFormatOptions = {
   includeDetails?: boolean
 }
 
+export type ClientAiOpsSmokeEvidenceStatus = 'pending_capture' | 'ready_for_review' | 'needs_redaction' | 'blocked'
+
+export type ClientAiOpsSmokeEvidenceCaptureInput = {
+  targetSurface: string
+  capturedBy?: string
+  capturedAt?: string
+  screenshotPath?: string
+  observedEvidence?: string[]
+  notes?: string
+  usedSyntheticData?: boolean
+  containsSecrets?: boolean
+  attemptedForbiddenActions?: string[]
+}
+
+export type ClientAiOpsSmokeEvidenceItem = {
+  surface: string
+  path: string
+  status: ClientAiOpsSmokeEvidenceStatus
+  expectedEvidence: string[]
+  observedEvidence: string[]
+  missingEvidence: string[]
+  screenshotPath: string | null
+  capturedBy: string | null
+  capturedAt: string | null
+  notes: string | null
+  clientSafe: boolean
+  sideEffectFree: boolean
+  nextAction: string
+}
+
+export type ClientAiOpsSmokeEvidencePacket = {
+  generatedAt: string
+  fixture: 'synthetic_client_ai_ops_pilot'
+  projectId: string
+  sourcePlanGeneratedAt: string
+  summary: {
+    totalTargets: number
+    pendingCapture: number
+    readyForReview: number
+    needsRedaction: number
+    blocked: number
+  }
+  items: ClientAiOpsSmokeEvidenceItem[]
+  reviewerChecklist: string[]
+  forbiddenActions: string[]
+}
+
 const GENERATED_AT = '2026-06-02T12:00:00.000Z'
 const SYNTHETIC_PROJECT_ID = 'synthetic-client-ai-ops-project'
 
@@ -238,4 +285,129 @@ export function formatClientAiOpsRealPilotQaPlan(
   }
 
   return lines.join('\n')
+}
+
+export function buildClientAiOpsSmokeEvidencePacket(
+  plan: ClientAiOpsPilotQaPlan = buildClientAiOpsRealPilotQaPlan(),
+  captures: ClientAiOpsSmokeEvidenceCaptureInput[] = [],
+): ClientAiOpsSmokeEvidencePacket {
+  const items = plan.manualSmokeTargets.map((target) => {
+    const capture = captures.find((item) => item.targetSurface === target.surface)
+    return buildSmokeEvidenceItem(target, plan.forbiddenActions, capture)
+  })
+  const summary = {
+    totalTargets: items.length,
+    pendingCapture: items.filter((item) => item.status === 'pending_capture').length,
+    readyForReview: items.filter((item) => item.status === 'ready_for_review').length,
+    needsRedaction: items.filter((item) => item.status === 'needs_redaction').length,
+    blocked: items.filter((item) => item.status === 'blocked').length,
+  }
+
+  return {
+    generatedAt: GENERATED_AT,
+    fixture: plan.fixture,
+    projectId: plan.projectId,
+    sourcePlanGeneratedAt: plan.generatedAt,
+    summary,
+    items,
+    reviewerChecklist: [
+      'Confirm every capture uses synthetic or explicitly test-owned client data.',
+      'Confirm screenshots and notes contain no secrets, tokens, credentials, personal account data, or raw client records.',
+      'Confirm no OAuth, credential sync, provider write, workflow activation, outbound send, publishing, deploy mutation, or client-data mutation was attempted.',
+      'Confirm observed evidence matches the expected evidence for each smoke target before marking the pilot ready for captain review.',
+    ],
+    forbiddenActions: plan.forbiddenActions,
+  }
+}
+
+export function formatClientAiOpsSmokeEvidencePacket(packet: ClientAiOpsSmokeEvidencePacket): string {
+  const lines = [
+    'Client AI Ops Smoke Evidence Packet',
+    `Generated: ${packet.generatedAt}`,
+    `Fixture: ${packet.fixture}`,
+    `Project: ${packet.projectId}`,
+    `Summary: ${packet.summary.readyForReview} ready; ${packet.summary.pendingCapture} pending; ${packet.summary.needsRedaction} needs redaction; ${packet.summary.blocked} blocked.`,
+    '',
+    'Smoke Targets:',
+  ]
+
+  for (const item of packet.items) {
+    lines.push(`- [${item.status}] ${item.surface}: ${item.path}`)
+    lines.push(`  Screenshot: ${item.screenshotPath ?? '[capture screenshot path]'}`)
+    lines.push(`  Captured by: ${item.capturedBy ?? '[operator name]'}`)
+    lines.push(`  Captured at: ${item.capturedAt ?? '[ISO timestamp]'}`)
+    lines.push(`  Next: ${item.nextAction}`)
+    if (item.missingEvidence.length > 0) {
+      lines.push(`  Missing evidence: ${item.missingEvidence.join('; ')}`)
+    }
+  }
+
+  lines.push('', 'Reviewer Checklist:')
+  for (const item of packet.reviewerChecklist) {
+    lines.push(`- ${item}`)
+  }
+
+  lines.push('', 'Forbidden Live Actions:')
+  for (const action of packet.forbiddenActions) {
+    lines.push(`- ${action}`)
+  }
+
+  return lines.join('\n')
+}
+
+function buildSmokeEvidenceItem(
+  target: ClientAiOpsPilotQaPlan['manualSmokeTargets'][number],
+  forbiddenActions: string[],
+  capture?: ClientAiOpsSmokeEvidenceCaptureInput,
+): ClientAiOpsSmokeEvidenceItem {
+  const observedEvidence = capture?.observedEvidence ?? []
+  const missingEvidence = target.expectedEvidence.filter((expected) => !observedEvidence.includes(expected))
+  const attemptedForbiddenActions = capture?.attemptedForbiddenActions ?? []
+  const matchedForbiddenActions = attemptedForbiddenActions.filter((action) => forbiddenActions.includes(action))
+  const usedSyntheticData = capture?.usedSyntheticData === true
+  const containsSecrets = capture?.containsSecrets === true
+  const status = smokeEvidenceStatus({
+    hasCapture: Boolean(capture),
+    usedSyntheticData,
+    containsSecrets,
+    matchedForbiddenActions,
+    missingEvidence,
+  })
+
+  return {
+    surface: target.surface,
+    path: target.path,
+    status,
+    expectedEvidence: target.expectedEvidence,
+    observedEvidence,
+    missingEvidence,
+    screenshotPath: capture?.screenshotPath ?? null,
+    capturedBy: capture?.capturedBy ?? null,
+    capturedAt: capture?.capturedAt ?? null,
+    notes: capture?.notes ?? null,
+    clientSafe: usedSyntheticData && !containsSecrets,
+    sideEffectFree: matchedForbiddenActions.length === 0,
+    nextAction: smokeEvidenceNextAction(status),
+  }
+}
+
+function smokeEvidenceStatus(input: {
+  hasCapture: boolean
+  usedSyntheticData: boolean
+  containsSecrets: boolean
+  matchedForbiddenActions: string[]
+  missingEvidence: string[]
+}): ClientAiOpsSmokeEvidenceStatus {
+  if (!input.hasCapture) return 'pending_capture'
+  if (!input.usedSyntheticData || input.matchedForbiddenActions.length > 0) return 'blocked'
+  if (input.containsSecrets) return 'needs_redaction'
+  if (input.missingEvidence.length > 0) return 'pending_capture'
+  return 'ready_for_review'
+}
+
+function smokeEvidenceNextAction(status: ClientAiOpsSmokeEvidenceStatus): string {
+  if (status === 'ready_for_review') return 'Attach the capture to the captain handoff for review.'
+  if (status === 'needs_redaction') return 'Redact secrets or private data before captain review.'
+  if (status === 'blocked') return 'Stop the pilot path and open an approval or safety review.'
+  return 'Capture this target with synthetic or explicitly test-owned data only.'
 }

--- a/scripts/client-ai-ops-real-pilot-qa.ts
+++ b/scripts/client-ai-ops-real-pilot-qa.ts
@@ -5,14 +5,19 @@ process.env.SUPABASE_SERVICE_ROLE_KEY ??= 'synthetic-client-ai-ops-qa-runner'
 
 async function main() {
   const {
+    buildClientAiOpsSmokeEvidencePacket,
     buildClientAiOpsRealPilotQaPlan,
+    formatClientAiOpsSmokeEvidencePacket,
     formatClientAiOpsRealPilotQaPlan,
   } = await import('../lib/client-ai-ops-real-pilot-qa')
 
   const args = new Set(process.argv.slice(2))
   const plan = buildClientAiOpsRealPilotQaPlan()
 
-  if (args.has('--json')) {
+  if (args.has('--evidence-template')) {
+    const packet = buildClientAiOpsSmokeEvidencePacket(plan)
+    console.log(formatClientAiOpsSmokeEvidencePacket(packet))
+  } else if (args.has('--json')) {
     console.log(JSON.stringify(plan, null, 2))
   } else {
     console.log(formatClientAiOpsRealPilotQaPlan(plan, {


### PR DESCRIPTION
## Summary
- Adds a Client AI Ops smoke evidence packet derived from the existing real-pilot QA plan.
- Adds capture states for pending, ready for review, needs redaction, and blocked evidence so authenticated manual smoke can be documented without live setup.
- Extends the QA runner with `--evidence-template` and documents how to use it for captain handoff.

Compatibility notes: this remains read-only and synthetic/test-owned. It does not add browser automation, OAuth, credential sync, provider writes, workflow activation, outbound sends, publishing, deployment mutation, or client-data mutation.

### Enhancement Impact Preflight

- Enhancement: Add a Client AI Ops smoke evidence packet/template for authenticated synthetic manual smoke handoff.
- User-facing surface: Internal command-line evidence template and Client AI Ops SOP guidance.
- Predicted files: `lib/client-ai-ops-real-pilot-qa.ts`, `lib/client-ai-ops-real-pilot-qa.test.ts`, `scripts/client-ai-ops-real-pilot-qa.ts`, `docs/client-ai-ops-roadmap-sop.md`.
- Shared routes/APIs/tables/helpers: Existing synthetic QA plan helper only; no API route, table, queue, migration, credential, OAuth, or provider write path.
- Active PRs or branches checked: PR #479 was confirmed merged; open PR #482 only touches `app/admin/social-content/[id]/page.tsx`.
- Dirty worktree files checked: Root checkout was on unrelated `codex/open-brain-wiki-overlay-hardening`; work used fresh worktree `/Users/vambahsillah/Projects/Portfolio.worktrees/client-ai-ops-smoke-evidence`.
- Overlap rating: green.
- Coordination decision: Proceed in dedicated Client AI Ops worktree and commit only the scoped smoke evidence files.
- Merge-order note: Can merge independently of PR #482; integration captain should still verify current open PR state before merge.

## Validation
- `npm test -- lib/client-ai-ops-real-pilot-qa.test.ts lib/client-ai-ops-synthetic-pilot.test.ts lib/client-ai-ops-readiness-contract.test.ts`
- `npx tsx scripts/client-ai-ops-real-pilot-qa.ts --evidence-template`
- `npx tsx scripts/client-ai-ops-real-pilot-qa.ts --summary`
- `npx tsx scripts/client-ai-ops-real-pilot-qa.ts --json | node -e "let s='';process.stdin.on('data',d=>s+=d);process.stdin.on('end',()=>{const j=JSON.parse(s); console.log(j.summary.blocked===0 && j.summary.manualSmoke===1 ? 'qa-json-ok' : 'qa-json-bad')})"`
- `npm run build:knowledge`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- `git diff --cached --check`

No live workflow, OAuth, credential, provider, outbound-send, deployment, browser automation, or client-data smoke was run.

## Integration Notes
- No migrations or env changes required.
- Pre-push DB health check skipped locally because `PROD_SUPABASE_URL` and `PROD_SUPABASE_SERVICE_ROLE_KEY` are not set in this worktree; CI should still enforce configured checks.
- Vercel contexts not checked for this PR at creation time:
  - Vercel - portfolio: not checked
  - Vercel - portfolio-staging: not checked
