### PR TITLE
fix: fallback market intel source url ingest

### DIFF
--- a/app/api/admin/value-evidence/ingest-market/route.test.ts
+++ b/app/api/admin/value-evidence/ingest-market/route.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const jsonMock = vi.fn((body: unknown, init?: { status?: number }) => ({
+  body,
+  status: init?.status ?? 200,
+}))
+
+const fromMock = vi.fn()
+const classifyMarketIntelMock = vi.fn()
+
+vi.mock('next/server', () => ({
+  NextResponse: {
+    json: jsonMock,
+  },
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: fromMock,
+  },
+}))
+
+vi.mock('@/lib/market-intel-classifier', () => ({
+  classifyMarketIntel: classifyMarketIntelMock,
+}))
+
+function makeRequest(body: unknown, token = 'secret-token') {
+  return {
+    headers: {
+      get: vi.fn().mockReturnValue(token ? `Bearer ${token}` : null),
+    },
+    json: vi.fn().mockResolvedValue(body),
+  } as never
+}
+
+describe('POST /api/admin/value-evidence/ingest-market', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    process.env = { ...originalEnv, N8N_INGEST_SECRET: 'secret-token' }
+    classifyMarketIntelMock.mockResolvedValue({ evidenceCreated: 0, irrelevant: 1, errors: [] })
+  })
+
+  it('falls back to lookup plus insert when source_url upsert has no unique constraint', async () => {
+    const insertedRows: Record<string, unknown>[] = []
+    const upsertSelect = vi.fn().mockResolvedValue({
+      data: null,
+      count: null,
+      error: {
+        message: 'there is no unique or exclusion constraint matching the ON CONFLICT specification',
+      },
+    })
+    const upsert = vi.fn(() => ({ select: upsertSelect }))
+
+    const maybeSingle = vi.fn().mockResolvedValue({ data: null, error: null })
+    const lookupEq = vi.fn(() => ({ maybeSingle }))
+    const tableSelect = vi.fn(() => ({ eq: lookupEq }))
+
+    const insertSingle = vi.fn().mockResolvedValue({ data: { id: 'market-1' }, error: null })
+    const insertSelect = vi.fn(() => ({ single: insertSingle }))
+    const insert = vi.fn((row: Record<string, unknown>) => {
+      insertedRows.push(row)
+      return { select: insertSelect }
+    })
+
+    fromMock.mockReturnValue({
+      upsert,
+      select: tableSelect,
+      insert,
+    })
+
+    const { POST } = await import('./route')
+    const response = await POST(makeRequest({
+      is_test_data: true,
+      items: [
+        {
+          source_platform: 'google_maps',
+          source_url: 'https://maps.example/review-1',
+          source_author: 'Reviewer',
+          content_text: 'Manual paperwork took weeks to process.',
+          content_type: 'review',
+        },
+      ],
+    }))
+
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source_platform: 'google_maps',
+        source_url: 'https://maps.example/review-1',
+        is_test_data: true,
+      }),
+      { onConflict: 'source_url', ignoreDuplicates: true, count: 'exact' },
+    )
+    expect(lookupEq).toHaveBeenCalledWith('source_url', 'https://maps.example/review-1')
+    expect(insertedRows).toHaveLength(1)
+    expect(insertedRows[0]).toMatchObject({
+      source_platform: 'google_maps',
+      source_url: 'https://maps.example/review-1',
+      is_test_data: true,
+    })
+    expect(classifyMarketIntelMock).toHaveBeenCalledWith(1, ['market-1'])
+    expect(jsonMock).toHaveBeenCalledWith({
+      total: 1,
+      inserted: 1,
+      duplicates: 0,
+      errors: [],
+      classification: { evidenceCreated: 0, irrelevant: 1 },
+    })
+    expect(response.status).toBe(200)
+  })
+
+  it('counts fallback lookup hits as duplicates without inserting', async () => {
+    const upsert = vi.fn(() => ({
+      select: vi.fn().mockResolvedValue({
+        data: null,
+        count: null,
+        error: {
+          message: 'there is no unique or exclusion constraint matching the ON CONFLICT specification',
+        },
+      }),
+    }))
+    const insert = vi.fn()
+
+    fromMock.mockReturnValue({
+      upsert,
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          maybeSingle: vi.fn().mockResolvedValue({ data: { id: 'existing-market' }, error: null }),
+        })),
+      })),
+      insert,
+    })
+
+    const { POST } = await import('./route')
+    await POST(makeRequest({
+      items: [
+        {
+          source_platform: 'google_maps',
+          source_url: 'https://maps.example/review-1',
+          content_text: 'Manual paperwork took weeks to process.',
+          content_type: 'review',
+        },
+      ],
+    }))
+
+    expect(insert).not.toHaveBeenCalled()
+    expect(classifyMarketIntelMock).not.toHaveBeenCalled()
+    expect(jsonMock).toHaveBeenCalledWith({
+      total: 1,
+      inserted: 0,
+      duplicates: 1,
+      errors: [],
+      classification: null,
+    })
+  })
+})

--- a/app/api/admin/value-evidence/ingest-market/route.ts
+++ b/app/api/admin/value-evidence/ingest-market/route.ts
@@ -29,6 +29,10 @@ function isExplicitTestRun(value: unknown): boolean {
   return value === true || value === 'true'
 }
 
+function isMissingSourceUrlConflictConstraint(errorMessage: string): boolean {
+  return errorMessage.includes('no unique or exclusion constraint matching the ON CONFLICT specification')
+}
+
 export async function POST(request: NextRequest) {
   const authHeader = request.headers.get('authorization')
   const token = authHeader?.replace('Bearer ', '')
@@ -113,7 +117,40 @@ export async function POST(request: NextRequest) {
             .select('id')
 
           if (upsertError) {
-            results.errors.push(`Upsert failed: ${upsertError.message}`)
+            if (!isMissingSourceUrlConflictConstraint(upsertError.message)) {
+              results.errors.push(`Upsert failed: ${upsertError.message}`)
+              continue
+            }
+
+            const { data: existing, error: lookupError } = await supabaseAdmin
+              .from('market_intelligence')
+              .select('id')
+              .eq('source_url', item.source_url)
+              .maybeSingle()
+
+            if (lookupError) {
+              results.errors.push(`Duplicate lookup failed: ${lookupError.message}`)
+              continue
+            }
+            if (existing?.id) {
+              results.duplicates++
+              continue
+            }
+
+            const { data: fallbackInserted, error: fallbackInsertError } = await supabaseAdmin
+              .from('market_intelligence')
+              .insert(row)
+              .select('id')
+              .single()
+
+            if (fallbackInsertError) {
+              results.errors.push(`Fallback insert failed: ${fallbackInsertError.message}`)
+              continue
+            }
+            results.inserted++
+            if (fallbackInserted?.id) {
+              insertedIds.push(String(fallbackInserted.id))
+            }
             continue
           }
           if (count === 0) {

--- a/docs/google-places-production-runner-decision.md
+++ b/docs/google-places-production-runner-decision.md
@@ -111,3 +111,43 @@ Promotion gate:
    any, are marked `is_test_data = true`.
 5. Compare result quality and cost against the Apify Google Maps baseline before
    replacing the actor.
+
+## 2026-06-03 Production Callback Run
+
+After PR #475 merged and both Vercel contexts were green, WF-VEP-002 was
+triggered against `https://amadutown.com` with the same isolated payload:
+
+```json
+{
+  "sources": ["google_maps"],
+  "searchTerms": ["nonprofit organizations near Omaha NE"],
+  "googleMapsQuery": "nonprofit organizations near Omaha NE",
+  "maxResults": 5,
+  "is_test_data": true
+}
+```
+
+Execution evidence:
+
+- n8n execution `16026` completed successfully.
+- `IF GMaps Enabled` evaluated true while Reddit, LinkedIn, G2, and Capterra
+  stayed disabled.
+- `Scrape Google Maps` returned 2 places.
+- `Extract GMaps Results` produced 20 Google Maps review/listing items.
+- Portfolio completion callbacks succeeded.
+
+Ingestion blocker found:
+
+- `POST Raw to Market Intel` inserted 0 rows.
+- The route returned repeated errors:
+  `there is no unique or exclusion constraint matching the ON CONFLICT specification`.
+- Root cause: the deployed database does not expose the `source_url` uniqueness
+  expected by the route's `upsert(... onConflict: "source_url")` path.
+
+Recommendation:
+
+Use an application-level fallback before considering a production schema
+mutation. If the `source_url` upsert fails because the constraint is missing,
+the route should query for an existing `source_url`; if none exists, perform a
+plain insert and preserve `is_test_data`. This keeps the bakeoff moving without
+changing shared production schema under pressure.


### PR DESCRIPTION
Summary
- Add an application-level fallback for `market_intelligence` rows when `upsert(... onConflict: "source_url")` fails because production lacks the expected source_url conflict constraint.
- Preserve duplicate protection by checking for an existing `source_url` before fallback insert.
- Keep `is_test_data` propagation intact and classify only inserted fallback rows.
- Record the June 3 production-like n8n run evidence in the Google Places runner decision doc.

Validation
- `npm test -- --run app/api/admin/value-evidence/ingest-market/route.test.ts`
- `npm run lint`
- `npm run build`
- `git diff --check`
- Push hook ran `npm run db:health-check` against PROD and passed.

Production-like n8n evidence
- WF-VEP-002 execution `16026` completed successfully against `https://amadutown.com`.
- Source gating worked: Google Maps enabled; Reddit, LinkedIn, G2, and Capterra disabled.
- `Scrape Google Maps` returned 2 places; `Extract GMaps Results` produced 20 items.
- `POST Raw to Market Intel` inserted 0 rows because production returned: `there is no unique or exclusion constraint matching the ON CONFLICT specification`.

Integration Notes
- This intentionally avoids a production schema mutation while keeping the bakeoff moving.
- After deploy, rerun the same isolated payload with `sources: ["google_maps"]`, `maxResults: 5`, and `is_test_data: true`, then confirm inserted rows are marked test data.
- Vercel contexts not yet checked for this PR: `Vercel – portfolio`, `Vercel – portfolio-staging`.
