### PR TITLE
Add Open Brain projection metadata to knowledge bundle

### DIFF
--- a/app/api/knowledge/chatbot/route.ts
+++ b/app/api/knowledge/chatbot/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server'
-import { getChatbotKnowledgeBody } from '@/lib/chatbot-knowledge'
+import { NextRequest, NextResponse } from 'next/server'
+import { getChatbotKnowledgeBody, getChatbotKnowledgeBundle } from '@/lib/chatbot-knowledge'
 
 export const dynamic = 'force-dynamic'
 
@@ -8,8 +8,18 @@ export const dynamic = 'force-dynamic'
  * Same as GET /api/knowledge (concatenated repo docs for chatbot).
  * Kept for backwards compatibility; n8n and docs can use either URL.
  */
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
+    const format = request.nextUrl.searchParams.get('format')
+    const includeOpenBrain = request.nextUrl.searchParams.get('include_open_brain') === 'true'
+    if (format === 'json') {
+      const bundle = await getChatbotKnowledgeBundle({ includeOpenBrainRagProjection: includeOpenBrain })
+      if ('error' in bundle) {
+        return NextResponse.json({ error: bundle.error }, { status: bundle.status })
+      }
+      return NextResponse.json(bundle)
+    }
+
     const result = await getChatbotKnowledgeBody()
     if ('error' in result) {
       return NextResponse.json({ error: result.error }, { status: result.status })

--- a/app/api/knowledge/route.ts
+++ b/app/api/knowledge/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server'
-import { getChatbotKnowledgeBody } from '@/lib/chatbot-knowledge'
+import { NextRequest, NextResponse } from 'next/server'
+import { getChatbotKnowledgeBody, getChatbotKnowledgeBundle } from '@/lib/chatbot-knowledge'
 
 export const dynamic = 'force-dynamic'
 
@@ -9,8 +9,18 @@ export const dynamic = 'force-dynamic'
  * Used by the n8n RAG Chatbot workflow so the AI Agent has latest website/process info.
  * Source of truth: repo files (docs/user-help-guide.md, admin-sales-lead-pipeline-sop, README).
  */
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
+    const format = request.nextUrl.searchParams.get('format')
+    const includeOpenBrain = request.nextUrl.searchParams.get('include_open_brain') === 'true'
+    if (format === 'json') {
+      const bundle = await getChatbotKnowledgeBundle({ includeOpenBrainRagProjection: includeOpenBrain })
+      if ('error' in bundle) {
+        return NextResponse.json({ error: bundle.error }, { status: bundle.status })
+      }
+      return NextResponse.json(bundle)
+    }
+
     const result = await getChatbotKnowledgeBody()
     if ('error' in result) {
       return NextResponse.json({ error: result.error }, { status: result.status })

--- a/docs/open-brain-local-service.md
+++ b/docs/open-brain-local-service.md
@@ -189,6 +189,8 @@ Open Brain-approved `public_safe` memories can be compiled into RAG projection d
 
 Pinecone remains a downstream projection. It must be rebuildable from approved Open Brain records and must not contain private records, unapproved inferences, or raw private exports.
 
+`GET /api/knowledge` and `GET /api/knowledge/chatbot` remain backwards-compatible plain-text public-safe chatbot bundles by default. Operators can request `?format=json&include_open_brain=true` to preview the same curated bundle with optional Open Brain public-safe RAG projection documents and provenance metadata. This JSON mode does not write Pinecone, does not promote memories, and does not include non-`public_safe` Open Brain records.
+
 ## V1 Scope
 
 V1 is intentionally narrow:

--- a/lib/__tests__/chatbot-knowledge.test.ts
+++ b/lib/__tests__/chatbot-knowledge.test.ts
@@ -1,6 +1,33 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import { CHATBOT_KNOWLEDGE_SOURCES, getChatbotKnowledgeBody } from '../chatbot-knowledge'
+import { CHATBOT_KNOWLEDGE_SOURCES, getChatbotKnowledgeBody, getChatbotKnowledgeBundle } from '../chatbot-knowledge'
+
+vi.mock('../open-brain', () => ({
+  getOpenBrainSnapshot: vi.fn(async () => ({
+    ragProjection: {
+      version: 'open-brain-rag-projection-v1',
+      documents: [
+        {
+          id: 'open-brain-rag:memory:public',
+          title: 'Public-safe Open Brain profile',
+          text: 'Approved public-safe Open Brain summary.',
+          metadata: {
+            openBrainMemoryId: 'memory:public',
+            openBrainSourceIds: ['source:public'],
+            privacyTier: 'public_safe',
+            sourceHash: 'hash-public',
+            projectionVersion: 'open-brain-rag-projection-v1',
+            deletionKey: 'open-brain:memory:public',
+            rollbackKey: 'open-brain:hash-public',
+          },
+        },
+      ],
+      eligibleMemoryCount: 1,
+      excludedPrivateCount: 2,
+      pineconeWriteStatus: 'blocked_pending_approval',
+    },
+  })),
+}))
 
 describe('chatbot knowledge corpus', () => {
   it('includes the public-safe personality corpus source', () => {
@@ -19,5 +46,31 @@ describe('chatbot knowledge corpus', () => {
     expect(result.body).toContain('## Source: Vambah Personality Corpus (public-safe)')
     expect(result.body).toContain('Source pack: `2026.05.03-d2eabc3d4b55`')
     expect(result.body).toContain('raw_private_content_included: false')
+  })
+
+  it('can append public-safe Open Brain RAG projections without exposing private records', async () => {
+    const result = await getChatbotKnowledgeBundle({ includeOpenBrainRagProjection: true })
+
+    expect(result).toHaveProperty('body')
+    if ('error' in result) return
+
+    expect(result.openBrain).toEqual({
+      included: true,
+      documentCount: 1,
+      excludedPrivateCount: 2,
+      pineconeWriteStatus: 'blocked_pending_approval',
+    })
+    expect(result.body).toContain('## Source: Open Brain Public-Safe Memory - Public-safe Open Brain profile')
+    expect(result.body).toContain('Approved public-safe Open Brain summary.')
+    expect(result.body).toContain('Pinecone write status: `blocked_pending_approval`')
+    expect(result.body).not.toContain('source:private')
+    expect(result.sources).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'open-brain-rag:memory:public',
+        kind: 'open_brain_rag_projection',
+        privacyTier: 'public_safe',
+        sourceHash: 'hash-public',
+      }),
+    ]))
   })
 })

--- a/lib/chatbot-knowledge.ts
+++ b/lib/chatbot-knowledge.ts
@@ -18,6 +18,25 @@ export interface ChatbotKnowledgeEntry {
   sectionTitle?: string
 }
 
+export interface ChatbotKnowledgeBundle {
+  body: string
+  sources: Array<{
+    id: string
+    title: string
+    kind: 'curated_repo_doc' | 'open_brain_rag_projection'
+    path: string | null
+    privacyTier: 'public_safe'
+    sourceHash: string | null
+    projectionVersion: string | null
+  }>
+  openBrain: {
+    included: boolean
+    documentCount: number
+    excludedPrivateCount: number
+    pineconeWriteStatus: 'blocked_pending_approval'
+  }
+}
+
 /** Ordered list of docs included in chatbot knowledge (used for runtime fallback and by build script). */
 export const CHATBOT_KNOWLEDGE_SOURCES: ChatbotKnowledgeEntry[] = [
   { path: 'docs/chatbot-products-and-services-overview.md', sectionTitle: 'What AmaduTown Offers (products and services)' },
@@ -35,12 +54,26 @@ export const CHATBOT_KNOWLEDGE_SOURCES: ChatbotKnowledgeEntry[] = [
  * Build concatenated markdown for the chatbot.
  * Uses embedded content from build script when available (production/Vercel); otherwise reads from filesystem (local dev).
  */
-export async function getChatbotKnowledgeBody(): Promise<{ body: string } | { error: string; status: 404 | 500 }> {
+export async function getChatbotKnowledgeBody(
+  options: { includeOpenBrainRagProjection?: boolean } = {},
+): Promise<{ body: string } | { error: string; status: 404 | 500 }> {
+  const bundle = await getChatbotKnowledgeBundle(options)
+  if ('error' in bundle) return bundle
+  return { body: bundle.body }
+}
+
+export async function getChatbotKnowledgeBundle(
+  options: { includeOpenBrainRagProjection?: boolean } = {},
+): Promise<ChatbotKnowledgeBundle | { error: string; status: 404 | 500 }> {
   try {
     const mod = await import('./chatbot-knowledge-content.generated')
     const body = mod.CHATBOT_KNOWLEDGE_BODY
     if (body && typeof body === 'string') {
-      return { body }
+      return appendOpenBrainProjection({
+        body,
+        sources: repoDocKnowledgeSources(),
+        openBrain: emptyOpenBrainBundleMetadata(false),
+      }, options)
     }
   } catch {
     // Generated file missing (e.g. dev without running build:knowledge) — fall back to fs
@@ -66,5 +99,87 @@ export async function getChatbotKnowledgeBody(): Promise<{ body: string } | { er
     return { error: 'No knowledge sources could be read', status: 404 }
   }
 
-  return { body: parts.join('\n\n---\n\n') }
+  return appendOpenBrainProjection({
+    body: parts.join('\n\n---\n\n'),
+    sources: repoDocKnowledgeSources(),
+    openBrain: emptyOpenBrainBundleMetadata(false),
+  }, options)
+}
+
+function repoDocKnowledgeSources(): ChatbotKnowledgeBundle['sources'] {
+  return CHATBOT_KNOWLEDGE_SOURCES.map((entry) => ({
+    id: entry.path,
+    title: entry.sectionTitle || entry.path,
+    kind: 'curated_repo_doc',
+    path: entry.path,
+    privacyTier: 'public_safe',
+    sourceHash: null,
+    projectionVersion: null,
+  }))
+}
+
+function emptyOpenBrainBundleMetadata(included: boolean): ChatbotKnowledgeBundle['openBrain'] {
+  return {
+    included,
+    documentCount: 0,
+    excludedPrivateCount: 0,
+    pineconeWriteStatus: 'blocked_pending_approval',
+  }
+}
+
+async function appendOpenBrainProjection(
+  bundle: ChatbotKnowledgeBundle,
+  options: { includeOpenBrainRagProjection?: boolean },
+): Promise<ChatbotKnowledgeBundle> {
+  if (!options.includeOpenBrainRagProjection) return bundle
+
+  const { getOpenBrainSnapshot } = await import('./open-brain')
+  const snapshot = await getOpenBrainSnapshot()
+  const projection = snapshot.ragProjection
+  if (projection.documents.length === 0) {
+    return {
+      ...bundle,
+      openBrain: {
+        included: true,
+        documentCount: 0,
+        excludedPrivateCount: projection.excludedPrivateCount,
+        pineconeWriteStatus: projection.pineconeWriteStatus,
+      },
+    }
+  }
+
+  const openBrainSections = projection.documents.map((document) => [
+    `## Source: Open Brain Public-Safe Memory - ${document.title}`,
+    '',
+    document.text.trim(),
+    '',
+    `- Open Brain memory id: \`${document.metadata.openBrainMemoryId}\``,
+    `- Open Brain source ids: ${document.metadata.openBrainSourceIds.map((sourceId) => `\`${sourceId}\``).join(', ') || 'none'}`,
+    `- Privacy tier: \`${document.metadata.privacyTier}\``,
+    `- Source hash: \`${document.metadata.sourceHash}\``,
+    `- Projection version: \`${document.metadata.projectionVersion}\``,
+    `- Pinecone write status: \`${projection.pineconeWriteStatus}\``,
+  ].join('\n'))
+
+  return {
+    body: [bundle.body, ...openBrainSections].join('\n\n---\n\n'),
+    sources: [
+      ...bundle.sources,
+      ...projection.documents.map((document) => ({
+        id: document.id,
+        title: document.title,
+        kind: 'open_brain_rag_projection' as const,
+        path: null,
+        privacyTier: document.metadata.privacyTier,
+        sourceHash: document.metadata.sourceHash,
+        projectionVersion: document.metadata.projectionVersion,
+      })),
+    ],
+    openBrain: {
+      included: true,
+      documentCount: projection.documents.length,
+      excludedPrivateCount: projection.excludedPrivateCount,
+      pineconeWriteStatus: projection.pineconeWriteStatus,
+    },
+  }
 }


### PR DESCRIPTION
## Summary
- add an opt-in JSON knowledge bundle mode for /api/knowledge and /api/knowledge/chatbot
- allow public-safe Open Brain RAG projection docs to be appended with provenance metadata
- keep default plain-text chatbot knowledge backwards-compatible and Pinecone writes blocked

## Validation
- npm test -- --run lib/__tests__/chatbot-knowledge.test.ts lib/open-brain.test.ts
- git diff --check
- push hook database health check passed

## Privacy boundary
- only Open Brain-approved public_safe projection documents are eligible
- private/non-public Open Brain records remain excluded and counted only
- no Pinecone writes, memory promotion, or hosted config mutation