### PR TITLE
feat: surface decision trust advisory posture

### DIFF
--- a/lib/chief-of-staff-chat.ts
+++ b/lib/chief-of-staff-chat.ts
@@ -19,7 +19,12 @@ import {
 import {
   AGENT_DECISION_TRUST_EVENT,
   buildDelegationDecisionTrustFrame,
+  type AgentDecisionFrame,
 } from '@/lib/agent-decision-trust'
+import {
+  recommendDecisionTrustEnforcement,
+  type DecisionTrustEnforcementRecommendation,
+} from '@/lib/agent-decision-trust-enforcement'
 import {
   evaluateAgentBudget,
   type AgentBudgetDecision,
@@ -867,11 +872,17 @@ export async function runChiefOfStaffChat(input: ChiefOfStaffChatRequest): Promi
         })
       : null
     const agentEngagements = applyDelegationDecisionToEngagements(parsed.agentEngagements, delegationDecision)
+    let delegationDecisionTrustFrame: AgentDecisionFrame | null = null
+    let delegationDecisionTrustEnforcement: DecisionTrustEnforcementRecommendation | null = null
 
     if (delegationDecision) {
-      const decisionTrustFrame = buildDelegationDecisionTrustFrame({
+      delegationDecisionTrustFrame = buildDelegationDecisionTrustFrame({
         decision: delegationDecision,
         runId: run.id,
+      })
+      delegationDecisionTrustEnforcement = recommendDecisionTrustEnforcement({
+        frame: delegationDecisionTrustFrame,
+        mode: 'advisory',
       })
       await recordAgentEvent({
         runId: run.id,
@@ -890,18 +901,19 @@ export async function runChiefOfStaffChat(input: ChiefOfStaffChatRequest): Promi
           fallback_agent_key: delegationDecision.fallback_agent_key,
           approval_gate: delegationDecision.approval_gate,
           confidence: delegationDecision.confidence,
+          decision_trust_enforcement: delegationDecisionTrustEnforcement,
         },
       }).catch(() => {})
       await recordAgentEvent({
         runId: run.id,
         eventType: AGENT_DECISION_TRUST_EVENT,
-        severity: decisionTrustFrame.recommended_gate === 'block'
+        severity: delegationDecisionTrustFrame.recommended_gate === 'block'
           ? 'error'
-          : decisionTrustFrame.recommended_gate === 'human_review'
+          : delegationDecisionTrustFrame.recommended_gate === 'human_review'
             ? 'warning'
             : 'info',
-        message: `${decisionTrustFrame.selected_candidate}: ${decisionTrustFrame.recommended_gate}`,
-        metadata: decisionTrustFrame,
+        message: `${delegationDecisionTrustFrame.selected_candidate}: ${delegationDecisionTrustFrame.recommended_gate}`,
+        metadata: delegationDecisionTrustFrame,
       }).catch(() => {})
     }
 
@@ -924,6 +936,7 @@ export async function runChiefOfStaffChat(input: ChiefOfStaffChatRequest): Promi
         action_proposals: parsed.actionProposals,
         agent_engagements: agentEngagements,
         delegation_decision: delegationDecision,
+        decision_trust_enforcement: delegationDecisionTrustEnforcement,
         context_ref: contextRef,
       },
     })
@@ -943,6 +956,7 @@ export async function runChiefOfStaffChat(input: ChiefOfStaffChatRequest): Promi
         action_proposals: parsed.actionProposals,
         agent_engagements: agentEngagements,
         delegation_decision: delegationDecision,
+        decision_trust_enforcement: delegationDecisionTrustEnforcement,
         context_ref: contextRef,
       },
     })

--- a/lib/technology-bakeoff.test.ts
+++ b/lib/technology-bakeoff.test.ts
@@ -23,6 +23,9 @@ describe('buildTechnologyBakeoffPlan', () => {
       expect(plan.rollbackPlan.length).toBeGreaterThan(0)
       expect(plan.decisionTrustFrame.objective).toBe(`Evaluate ${TECHNOLOGY_BAKEOFF_PROFILES[surface].label}`)
       expect(plan.decisionTrustFrame.candidates_considered.length).toBeGreaterThan(0)
+      expect(plan.decisionTrustEnforcement.mode).toBe('advisory')
+      expect(plan.decisionTrustEnforcement.gate).toBe(plan.decisionTrustFrame.recommended_gate)
+      expect(plan.decisionTrustEnforcement.mayProceed).toBe(true)
       expect(plan.nextImplementationStep).toContain(plan.surfaceLabel)
     }
   })
@@ -105,5 +108,6 @@ describe('buildTechnologyBakeoffPlan', () => {
     expect(plan.decisionTrustFrame.decision_type).toBe('vendor')
     expect(plan.decisionTrustFrame.missing_evidence).toContain('Direct Apify run history')
     expect(plan.decisionTrustFrame.recommended_gate).toMatch(/sandbox|human_review/)
+    expect(plan.decisionTrustEnforcement.reason).toMatch(/advisory mode/i)
   })
 })

--- a/lib/technology-bakeoff.ts
+++ b/lib/technology-bakeoff.ts
@@ -10,6 +10,10 @@ import {
   buildTechnologyBakeoffDecisionTrustFrame,
   type AgentDecisionFrame,
 } from './agent-decision-trust'
+import {
+  recommendDecisionTrustEnforcement,
+  type DecisionTrustEnforcementRecommendation,
+} from './agent-decision-trust-enforcement'
 
 export const TECHNOLOGY_BAKEOFF_SURFACES = [
   'media_generation',
@@ -90,6 +94,7 @@ export interface TechnologyBakeoffPlan {
   integrationNotes: string[]
   missingEvidence: string[]
   decisionTrustFrame: AgentDecisionFrame
+  decisionTrustEnforcement: DecisionTrustEnforcementRecommendation
   nextImplementationStep: string
   specialistSource?: 'media_generation' | 'presentation' | 'agent_runtime'
 }
@@ -610,6 +615,10 @@ export function buildTechnologyBakeoffPlan(input: TechnologyBakeoffInput): Techn
     candidates,
     missingEvidence,
   })
+  const decisionTrustEnforcement = recommendDecisionTrustEnforcement({
+    frame: decisionTrustFrame,
+    mode: 'advisory',
+  })
 
   return {
     generatedAt: new Date().toISOString(),
@@ -635,6 +644,7 @@ export function buildTechnologyBakeoffPlan(input: TechnologyBakeoffInput): Techn
     integrationNotes: specialist.integrationNotes ?? profile.integrationNotes,
     missingEvidence,
     decisionTrustFrame,
+    decisionTrustEnforcement,
     nextImplementationStep: `Create a small evidence packet for ${profile.label} in ${profile.adminArea}, then compare candidates with the scoring plan.`,
     specialistSource: specialist.specialistSource,
   }


### PR DESCRIPTION
## Summary
- Attach advisory Decision Trust enforcement posture to Shaka delegation trace metadata, generated-reply step metadata, and run outcome metadata.
- Add advisory Decision Trust enforcement posture to technology bakeoff plans beside the existing decision trust frame.
- Keep all behavior read-only/advisory: no hard blocks, no new approval system, and no changes to the `agent_decision_trust_recorded` frame shape.

## Validation
- `npm ci --ignore-scripts`
- `npm test -- --run lib/technology-bakeoff.test.ts lib/agent-decision-trust-enforcement.test.ts`
- `npm run build:knowledge`
- `npx tsc --noEmit --pretty false`
- `npm test -- --run lib/chief-of-staff-chat.test.ts lib/technology-bakeoff.test.ts lib/agent-decision-trust-enforcement.test.ts`
- `git diff --check`
- `git diff --cached --check`

## Integration Notes
- No migrations or environment changes.
- No production enforcement behavior is enabled by this PR.
- Vercel – portfolio: not checked yet for this PR.
- Vercel – portfolio-staging: not checked yet for this PR.