### PR TITLE
feat: add agentic content review actions

### DIFF
--- a/app/admin/agents/standup/page.tsx
+++ b/app/admin/agents/standup/page.tsx
@@ -21,6 +21,10 @@ import ProtectedRoute from '@/components/ProtectedRoute'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
 import AgentAvatar from '@/components/admin/AgentAvatar'
 import { getCurrentSession } from '@/lib/auth'
+import {
+  getAgenticContentReviewPacketByAssetId,
+  type AgenticContentReviewDecision,
+} from '@/lib/agentic-content-review-packets'
 import type {
   AgentOrgBoardAgent,
   AgentOrgBoardGoalMetric,
@@ -81,6 +85,58 @@ type N8nProposalState = {
   workItemId: string
   title: string
   createdAt: string
+}
+
+const AGENTIC_CONTENT_REVIEW_DECISIONS: AgenticContentReviewDecision[] = [
+  'approve_next_gate',
+  'send_back_for_repair',
+  'hold_for_human',
+]
+
+function isAgenticContentReviewDecision(value: string | null): value is AgenticContentReviewDecision {
+  return AGENTIC_CONTENT_REVIEW_DECISIONS.includes(value as AgenticContentReviewDecision)
+}
+
+function buildAgenticContentReviewPrefill(
+  assetId: string,
+  decision: AgenticContentReviewDecision,
+) {
+  const packet = getAgenticContentReviewPacketByAssetId(assetId)
+  if (!packet) return null
+
+  const decisionInstruction = {
+    approve_next_gate: `Prepare the next-gate work packet for ${packet.targetSurface} production. Treat challenger clearance as a precondition already satisfied, but do not publish, render, export, share, or deploy anything. Preserve the approval boundary: ${packet.nextGate}`,
+    send_back_for_repair: `Create a repair task for ${packet.challengerAgent}. Focus only on the issue areas implied by the packet and require another challenger pass before this returns to human review. ${packet.sendBackMeaning}`,
+    hold_for_human: `Hold this asset and frame the unresolved risk for Vambah. Do not route it to production planning until the human-only question is answered.`,
+  }[decision]
+
+  const decisionLabel = {
+    approve_next_gate: 'approve next gate',
+    send_back_for_repair: 'send back for repair',
+    hold_for_human: 'hold for human decision',
+  }[decision]
+
+  return {
+    packet,
+    decisionLabel,
+    goal: [
+      `Agentic content review: ${decisionLabel} - ${packet.title}`,
+      '',
+      decisionInstruction,
+      '',
+      `Asset ID: ${packet.assetId}`,
+      `Channel: ${packet.channel}`,
+      `Output: ${packet.output}`,
+      `Source packet: ${packet.packetPath}`,
+      `Draft source: ${packet.draftSource}`,
+      `Challenger: ${packet.challengerAgent} - ${packet.challengerStatus}`,
+      `Approval status: ${packet.approvalStatus}`,
+    ].join('\n'),
+    message: [
+      `Review the agentic content packet for "${packet.title}" and convert this ${decisionLabel} decision into traceable Agent Ops work.`,
+      `Keep this inside the existing Portfolio approval path. No side effects beyond creating the work item or next review plan.`,
+    ].join(' '),
+  }
 }
 
 function agentShortName(name: string) {
@@ -165,6 +221,30 @@ function StandupRoomContent() {
     const params = new URLSearchParams(window.location.search)
     const goalId = params.get('goal')
     if (goalId) setFocusedGoalId(goalId)
+    if (params.get('context') !== 'agentic-content-review') return
+
+    const assetId = params.get('asset')
+    const decision = params.get('decision')
+    if (!assetId || !isAgenticContentReviewDecision(decision)) return
+
+    const prefill = buildAgenticContentReviewPrefill(assetId, decision)
+    if (!prefill) return
+
+    setGoal(prefill.goal)
+    setMessage(prefill.message)
+    setGoalType('general')
+    setTranscript((current) => {
+      if (current.some((entry) => entry.id === `agentic-content-review-${assetId}-${decision}`)) return current
+      return [
+        ...current,
+        {
+          id: `agentic-content-review-${assetId}-${decision}`,
+          role: 'system',
+          content: `Loaded ${prefill.packet.title} for ${prefill.decisionLabel}. Review the prefilled goal, then draft or delegate it from this room.`,
+          created_at: new Date().toISOString(),
+        },
+      ]
+    })
   }, [])
 
   const participants = useMemo(() => {

--- a/app/admin/content/page.tsx
+++ b/app/admin/content/page.tsx
@@ -1,10 +1,11 @@
 'use client'
 
 import { motion } from 'framer-motion'
-import { FolderOpen, Video, BookOpen, Music, Sparkles, Package, Tag, Briefcase, Layers, ShoppingBag, Target, CheckCircle2 } from 'lucide-react'
+import { FolderOpen, Video, BookOpen, Music, Sparkles, Package, Tag, Briefcase, Layers, ShoppingBag, Target } from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
 import Link from 'next/link'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
+import AgenticContentReviewPacketCard from '@/components/admin/AgenticContentReviewPacketCard'
 import { getAgenticContentReviewPacketsForSurface } from '@/lib/agentic-content-review-packets'
 
 export default function ContentManagementPage() {
@@ -111,27 +112,7 @@ export default function ContentManagementPage() {
 
             <div className="mt-4 grid grid-cols-1 gap-3 lg:grid-cols-3">
               {proofReviewPackets.map((packet) => (
-                <div key={packet.assetId} className="rounded-lg border border-silicon-slate bg-imperial-navy/45 p-4">
-                  <div className="flex flex-wrap items-center gap-2 text-[10px] font-medium uppercase tracking-[0.14em] text-gray-500">
-                    <span className="rounded-full border border-radiant-gold/30 px-2 py-0.5 text-radiant-gold">{packet.priority}</span>
-                    <span>{packet.channel}</span>
-                  </div>
-                  <h3 className="mt-3 text-sm font-semibold text-gray-100">{packet.title}</h3>
-                  <p className="mt-2 text-xs leading-5 text-gray-400">{packet.humanReview}</p>
-                  <div className="mt-3 grid gap-2 text-[11px] text-gray-500">
-                    <div className="flex items-center gap-2 text-emerald-300">
-                      <CheckCircle2 className="h-3.5 w-3.5" />
-                      <span>{packet.challengerAgent} - {packet.challengerStatus}; {packet.approvalStatus}</span>
-                    </div>
-                    <div className="rounded-md border border-silicon-slate/70 bg-background/40 p-2 leading-5 text-gray-400">
-                      <div><span className="text-gray-500">Source packet:</span> <code className="text-radiant-gold">{packet.packetPath}</code></div>
-                      <div><span className="text-gray-500">Next gate:</span> {packet.nextGate}</div>
-                    </div>
-                    <Link href={`/admin/agents/standup?context=agentic-content-review&asset=${encodeURIComponent(packet.assetId)}`} className="inline-flex items-center gap-1 text-xs text-radiant-gold hover:underline">
-                      Create repair or production planning task
-                    </Link>
-                  </div>
-                </div>
+                <AgenticContentReviewPacketCard key={packet.assetId} packet={packet} />
               ))}
             </div>
           </div>

--- a/app/admin/content/video-generation/page.tsx
+++ b/app/admin/content/video-generation/page.tsx
@@ -12,6 +12,7 @@ import { AnimatePresence, motion } from 'framer-motion'
 import ProtectedRoute from '@/components/ProtectedRoute'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
 import AssetPicker from '@/components/admin/AssetPicker'
+import AgenticContentReviewPacketCard from '@/components/admin/AgenticContentReviewPacketCard'
 import { ExtractionStatusChip } from '@/components/admin/ExtractionStatusChip'
 import { useWorkflowStatus } from '@/lib/hooks/useWorkflowStatus'
 import ProgressPanel, { type ProgressStep } from '@/components/admin/ProgressPanel'
@@ -1789,20 +1790,12 @@ export default function VideoGenerationPage() {
 
             <div className="mt-4 grid gap-3 lg:grid-cols-3">
               {AGENTIC_VIDEO_REVIEW_PACKETS.map((packet) => (
-                <div key={packet.assetId} className="rounded-lg border border-silicon-slate bg-background/35 p-3">
-                  <div className="flex flex-wrap items-center gap-2 text-[10px] font-medium uppercase tracking-[0.14em] text-gray-500">
-                    <span className="rounded-full border border-radiant-gold/30 px-2 py-0.5 text-radiant-gold">{packet.priority}</span>
-                    <span>{packet.channel}</span>
-                  </div>
-                  <h3 className="mt-3 text-sm font-semibold text-gray-100">{packet.title}</h3>
-                  <p className="mt-2 text-[11px] leading-5 text-gray-400">{packet.humanReview}</p>
-                  <div className="mt-3 rounded-md border border-silicon-slate/70 bg-imperial-navy/45 p-2 text-[10px] leading-5 text-gray-400">
-                    <div><span className="text-gray-500">Challenger:</span> <span className="text-emerald-300">{packet.challengerAgent} - {packet.challengerStatus}</span></div>
-                    <div><span className="text-gray-500">Approval:</span> <span className="text-emerald-300">{packet.approvalStatus}</span></div>
-                    <div><span className="text-gray-500">Source:</span> <code className="text-radiant-gold">{packet.packetPath}</code></div>
-                    <div><span className="text-gray-500">Next gate:</span> {packet.nextGate}</div>
-                  </div>
-                </div>
+                <AgenticContentReviewPacketCard
+                  key={packet.assetId}
+                  packet={packet}
+                  nextGateHref="#decide"
+                  nextGateLabel="Open script queue"
+                />
               ))}
             </div>
           </div>
@@ -2196,7 +2189,7 @@ export default function VideoGenerationPage() {
           </div>
 
           {/* ═══════════ PHASE 2: DECIDE ═══════════ */}
-          <div ref={decideRef} className="mb-10 scroll-mt-16">
+          <div id="decide" ref={decideRef} className="mb-10 scroll-mt-16">
             <h2 className="text-lg font-semibold text-foreground mb-4 flex items-center gap-2">
               <span className="flex items-center justify-center w-6 h-6 rounded-full bg-radiant-gold/20 text-radiant-gold text-xs font-bold">2</span>
               Decide

--- a/app/admin/social-content/page.tsx
+++ b/app/admin/social-content/page.tsx
@@ -31,11 +31,10 @@ import {
   MicOff,
   Sparkles,
   Plus,
-  ExternalLink,
-  RotateCcw,
 } from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
+import AgenticContentReviewPacketCard from '@/components/admin/AgenticContentReviewPacketCard'
 import { ExtractionStatusChip } from '@/components/admin/ExtractionStatusChip'
 import { useExtractionStatus } from '@/lib/hooks/useExtractionStatus'
 import { getCurrentSession } from '@/lib/auth'
@@ -108,11 +107,6 @@ const VOICE_NOTE_OUTPUTS = [
 
 const MEETINGS_PER_PAGE = 5
 const AGENTIC_SOCIAL_REVIEW_PACKETS = getAgenticContentReviewPacketsForSurface('social')
-const GITHUB_DOC_BASE_URL = 'https://github.com/vsillah/Portfolio/blob/main/'
-
-function sourcePacketUrl(path: string) {
-  return `${GITHUB_DOC_BASE_URL}${path}`
-}
 
 function SocialContentQueuePage() {
   const [items, setItems] = useState<SocialContentItem[]>([])
@@ -537,66 +531,12 @@ function SocialContentQueuePage() {
 
         <div className="mt-4 grid gap-3 lg:grid-cols-2">
           {AGENTIC_SOCIAL_REVIEW_PACKETS.map((packet) => (
-            <div key={packet.assetId} className="rounded-lg border border-silicon-slate bg-imperial-navy/45 p-4">
-              <div className="flex flex-wrap items-center gap-2 text-[10px] font-medium uppercase tracking-[0.14em] text-gray-500">
-                <span className="rounded-full border border-radiant-gold/30 px-2 py-0.5 text-radiant-gold">{packet.priority}</span>
-                <span>{packet.channel}</span>
-                <span>{packet.output}</span>
-              </div>
-              <h3 className="mt-3 text-sm font-semibold text-gray-100">{packet.title}</h3>
-              <p className="mt-2 text-xs leading-5 text-gray-400">{packet.humanReview}</p>
-              <div className="mt-3 rounded-md border border-radiant-gold/25 bg-radiant-gold/10 p-3">
-                <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-radiant-gold">Human decision</div>
-                <p className="mt-1 text-xs leading-5 text-gray-200">{packet.decisionPrompt}</p>
-                <div className="mt-3 grid gap-2 text-[11px] leading-5 sm:grid-cols-2">
-                  <div className="rounded-md border border-emerald-500/20 bg-emerald-500/10 p-2 text-emerald-100">
-                    <span className="font-semibold text-emerald-300">Approve path:</span> {packet.approveMeaning}
-                  </div>
-                  <div className="rounded-md border border-amber-500/20 bg-amber-500/10 p-2 text-amber-100">
-                    <span className="font-semibold text-amber-300">Send back:</span> {packet.sendBackMeaning}
-                  </div>
-                </div>
-              </div>
-              <div className="mt-3 grid gap-2 text-[11px] text-gray-500 sm:grid-cols-2">
-                <div>
-                  <span className="text-gray-400">Challenger</span>
-                  <div className="mt-0.5 text-emerald-300">{packet.challengerAgent} - {packet.challengerStatus}</div>
-                </div>
-                <div>
-                  <span className="text-gray-400">Approval</span>
-                  <div className="mt-0.5 text-emerald-300">{packet.approvalStatus}</div>
-                </div>
-              </div>
-              <div className="mt-3 rounded-md border border-silicon-slate/70 bg-background/40 p-2 text-[11px] leading-5 text-gray-400">
-                <div><span className="text-gray-500">Source packet:</span> <code className="text-radiant-gold">{packet.packetPath}</code></div>
-                <div><span className="text-gray-500">Next gate:</span> {packet.nextGate}</div>
-              </div>
-              <div className="mt-3 flex flex-wrap gap-2">
-                <a
-                  href={sourcePacketUrl(packet.packetPath)}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="inline-flex items-center gap-1.5 rounded-md border border-silicon-slate bg-background/50 px-3 py-2 text-xs font-medium text-gray-200 transition-colors hover:border-radiant-gold/50 hover:text-radiant-gold"
-                >
-                  <ExternalLink className="h-3.5 w-3.5" />
-                  Review packet
-                </a>
-                <a
-                  href="#social-content-approval-queue"
-                  className="inline-flex items-center gap-1.5 rounded-md border border-radiant-gold/60 bg-radiant-gold px-3 py-2 text-xs font-semibold text-slate-950 transition-colors hover:bg-radiant-gold/90"
-                >
-                  <CheckCircle2 className="h-3.5 w-3.5" />
-                  Open approval gate
-                </a>
-                <Link
-                  href={`/admin/agents/standup?context=agentic-content-review&asset=${encodeURIComponent(packet.assetId)}`}
-                  className="inline-flex items-center gap-1.5 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs font-medium text-amber-200 transition-colors hover:border-amber-400 hover:text-amber-100"
-                >
-                  <RotateCcw className="h-3.5 w-3.5" />
-                  Send back for repair
-                </Link>
-              </div>
-            </div>
+            <AgenticContentReviewPacketCard
+              key={packet.assetId}
+              packet={packet}
+              nextGateHref="#social-content-approval-queue"
+              nextGateLabel="Open approval queue"
+            />
           ))}
         </div>
       </div>

--- a/components/admin/AgenticContentReviewPacketCard.tsx
+++ b/components/admin/AgenticContentReviewPacketCard.tsx
@@ -1,0 +1,142 @@
+import Link from 'next/link'
+import { AlertTriangle, CheckCircle2, ExternalLink, PauseCircle, RotateCcw } from 'lucide-react'
+import {
+  buildAgenticContentReviewActionHref,
+  type AgenticContentReviewPacket,
+} from '@/lib/agentic-content-review-packets'
+
+const GITHUB_DOC_BASE_URL = 'https://github.com/vsillah/Portfolio/blob/main/'
+
+function sourcePacketUrl(path: string) {
+  return `${GITHUB_DOC_BASE_URL}${path}`
+}
+
+function surfaceCopy(packet: AgenticContentReviewPacket) {
+  switch (packet.targetSurface) {
+    case 'social':
+      return {
+        approveLabel: 'Approve next gate',
+        approveHelp: 'Creates a traceable planning step before any scheduling or publishing.',
+      }
+    case 'video':
+      return {
+        approveLabel: 'Approve render-readiness',
+        approveHelp: 'Creates a traceable render-readiness step before provider execution.',
+      }
+    case 'content':
+      return {
+        approveLabel: 'Approve production planning',
+        approveHelp: 'Creates a traceable production step before export, client sharing, or implementation.',
+      }
+  }
+}
+
+type AgenticContentReviewPacketCardProps = {
+  packet: AgenticContentReviewPacket
+  nextGateHref?: string
+  nextGateLabel?: string
+}
+
+export default function AgenticContentReviewPacketCard({
+  packet,
+  nextGateHref,
+  nextGateLabel = 'Open current queue',
+}: AgenticContentReviewPacketCardProps) {
+  const copy = surfaceCopy(packet)
+
+  return (
+    <div className="rounded-lg border border-silicon-slate bg-imperial-navy/45 p-4">
+      <div className="flex flex-wrap items-center gap-2 text-[10px] font-medium uppercase tracking-[0.14em] text-gray-500">
+        <span className="rounded-full border border-radiant-gold/30 px-2 py-0.5 text-radiant-gold">{packet.priority}</span>
+        <span>{packet.channel}</span>
+        <span>{packet.output}</span>
+      </div>
+
+      <h3 className="mt-3 text-sm font-semibold text-gray-100">{packet.title}</h3>
+      <p className="mt-2 text-xs leading-5 text-gray-400">{packet.humanReview}</p>
+
+      <div className="mt-3 rounded-md border border-radiant-gold/25 bg-radiant-gold/10 p-3">
+        <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-radiant-gold">Human decision</div>
+        <p className="mt-1 text-xs leading-5 text-gray-200">{packet.decisionPrompt}</p>
+        <div className="mt-3 grid gap-2 text-[11px] leading-5 sm:grid-cols-2">
+          <div className="rounded-md border border-emerald-500/20 bg-emerald-500/10 p-2 text-emerald-100">
+            <span className="font-semibold text-emerald-300">Approve path:</span> {packet.approveMeaning}
+          </div>
+          <div className="rounded-md border border-amber-500/20 bg-amber-500/10 p-2 text-amber-100">
+            <span className="font-semibold text-amber-300">Send back:</span> {packet.sendBackMeaning}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-3 grid gap-2 text-[11px] text-gray-500 sm:grid-cols-2">
+        <div>
+          <span className="text-gray-400">Challenger</span>
+          <div className="mt-0.5 text-emerald-300">{packet.challengerAgent} - {packet.challengerStatus}</div>
+        </div>
+        <div>
+          <span className="text-gray-400">Approval</span>
+          <div className="mt-0.5 text-emerald-300">{packet.approvalStatus}</div>
+        </div>
+      </div>
+
+      <div className="mt-3 rounded-md border border-silicon-slate/70 bg-background/40 p-2 text-[11px] leading-5 text-gray-400">
+        <div><span className="text-gray-500">Source packet:</span> <code className="text-radiant-gold">{packet.packetPath}</code></div>
+        <div><span className="text-gray-500">Next gate:</span> {packet.nextGate}</div>
+      </div>
+
+      <div className="mt-3 grid gap-2 text-[11px] leading-5 sm:grid-cols-3">
+        <Link
+          href={buildAgenticContentReviewActionHref(packet, 'approve_next_gate')}
+          className="rounded-md border border-emerald-500/35 bg-emerald-500/10 p-2 text-emerald-100 transition-colors hover:border-emerald-400"
+        >
+          <span className="flex items-center gap-1.5 font-semibold text-emerald-300">
+            <CheckCircle2 className="h-3.5 w-3.5" />
+            {copy.approveLabel}
+          </span>
+          <span className="mt-1 block text-emerald-100/80">{copy.approveHelp}</span>
+        </Link>
+        <Link
+          href={buildAgenticContentReviewActionHref(packet, 'send_back_for_repair')}
+          className="rounded-md border border-amber-500/35 bg-amber-500/10 p-2 text-amber-100 transition-colors hover:border-amber-400"
+        >
+          <span className="flex items-center gap-1.5 font-semibold text-amber-300">
+            <RotateCcw className="h-3.5 w-3.5" />
+            Send back
+          </span>
+          <span className="mt-1 block text-amber-100/80">Opens a repair prompt for Amina before another human pass.</span>
+        </Link>
+        <Link
+          href={buildAgenticContentReviewActionHref(packet, 'hold_for_human')}
+          className="rounded-md border border-rose-500/30 bg-rose-500/10 p-2 text-rose-100 transition-colors hover:border-rose-400"
+        >
+          <span className="flex items-center gap-1.5 font-semibold text-rose-300">
+            <PauseCircle className="h-3.5 w-3.5" />
+            Hold
+          </span>
+          <span className="mt-1 block text-rose-100/80">Frames the unresolved risk for a human-only decision.</span>
+        </Link>
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-2">
+        <a
+          href={sourcePacketUrl(packet.packetPath)}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex items-center gap-1.5 rounded-md border border-silicon-slate bg-background/50 px-3 py-2 text-xs font-medium text-gray-200 transition-colors hover:border-radiant-gold/50 hover:text-radiant-gold"
+        >
+          <ExternalLink className="h-3.5 w-3.5" />
+          Review source packet
+        </a>
+        {nextGateHref ? (
+          <a
+            href={nextGateHref}
+            className="inline-flex items-center gap-1.5 rounded-md border border-silicon-slate bg-background/50 px-3 py-2 text-xs font-medium text-gray-200 transition-colors hover:border-radiant-gold/50 hover:text-radiant-gold"
+          >
+            <AlertTriangle className="h-3.5 w-3.5" />
+            {nextGateLabel}
+          </a>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/lib/agentic-content-review-packets.test.ts
+++ b/lib/agentic-content-review-packets.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   AGENTIC_CONTENT_REVIEW_PACKETS,
+  buildAgenticContentReviewActionHref,
+  getAgenticContentReviewPacketByAssetId,
   getAgenticContentReviewPacketsForSurface,
 } from './agentic-content-review-packets'
 
@@ -43,5 +45,16 @@ describe('agentic content review packet registry', () => {
       'p2-technical-appendix-agentic-proof-map',
       'p2-website-proof-page-governed-agents',
     ])
+  })
+
+  it('builds traceable Standup actions without changing content state directly', () => {
+    const packet = getAgenticContentReviewPacketByAssetId('p0-youtube-agentic-ai-teams-skip')
+
+    expect(packet).not.toBeNull()
+    expect(buildAgenticContentReviewActionHref(packet!, 'approve_next_gate')).toBe(
+      '/admin/agents/standup?context=agentic-content-review&asset=p0-youtube-agentic-ai-teams-skip&decision=approve_next_gate',
+    )
+    expect(buildAgenticContentReviewActionHref(packet!, 'send_back_for_repair')).toContain('decision=send_back_for_repair')
+    expect(buildAgenticContentReviewActionHref(packet!, 'hold_for_human')).toContain('decision=hold_for_human')
   })
 })

--- a/lib/agentic-content-review-packets.ts
+++ b/lib/agentic-content-review-packets.ts
@@ -1,4 +1,5 @@
 export type AgenticContentReviewSurface = 'social' | 'video' | 'content'
+export type AgenticContentReviewDecision = 'approve_next_gate' | 'send_back_for_repair' | 'hold_for_human'
 
 export type AgenticContentReviewPacket = {
   assetId: string
@@ -226,4 +227,21 @@ export const AGENTIC_CONTENT_REVIEW_PACKETS: AgenticContentReviewPacket[] = [
 
 export function getAgenticContentReviewPacketsForSurface(surface: AgenticContentReviewSurface) {
   return AGENTIC_CONTENT_REVIEW_PACKETS.filter((packet) => packet.targetSurface === surface)
+}
+
+export function getAgenticContentReviewPacketByAssetId(assetId: string) {
+  return AGENTIC_CONTENT_REVIEW_PACKETS.find((packet) => packet.assetId === assetId) ?? null
+}
+
+export function buildAgenticContentReviewActionHref(
+  packet: AgenticContentReviewPacket,
+  decision: AgenticContentReviewDecision,
+) {
+  const params = new URLSearchParams({
+    context: 'agentic-content-review',
+    asset: packet.assetId,
+    decision,
+  })
+
+  return `/admin/agents/standup?${params.toString()}`
 }


### PR DESCRIPTION
## Summary
- Adds a reusable challenger-cleared packet card with explicit approve next gate, send back for repair, and hold actions.
- Routes those actions into the existing Standup Room with packet-aware prefilled prompts so decisions become traceable Agent Ops work instead of direct publish/render/export side effects.
- Reuses the existing Social Content, Video Generation, and Content Hub surfaces while preserving challenger clearance as a precondition for human review.

## Validation
- npm test -- --run lib/agentic-content-review-packets.test.ts
- npm run lint
- npx tsc --noEmit
- git diff --check
- Local browser smoke with MOCK_N8N=true N8N_DISABLE_OUTBOUND=true PORT=3005 npm run dev for /admin/social-content, /admin/content/video-generation, /admin/content, and /admin/agents/standup?context=agentic-content-review&asset=p0-youtube-agentic-ai-teams-skip&decision=approve_next_gate
- Browser smoke reached protected routes/auth boundary with no Next overlay and no console errors; no authenticated visual packet-card review was run.
- Pre-push database health check passed.

## Integration Notes
- No migrations or env changes.
- The packet action buttons do not call publish, render, export, provider, or production APIs; they open traceable Standup work prompts.
- Open clean PRs #482 and #485 remained unmerged during polling; #487 remained draft. This branch has no file overlap with those PRs.
- Vercel – portfolio: pending for this draft PR.
- Vercel – portfolio-staging: not checked for this draft PR.