### PR TITLE
feat: add client ai ops smoke evidence api

### DIFF
--- a/app/api/admin/client-projects/[id]/ai-ops/smoke-evidence/route.test.ts
+++ b/app/api/admin/client-projects/[id]/ai-ops/smoke-evidence/route.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  buildClientAiOpsRealPilotQaPlan: vi.fn(),
+  buildClientAiOpsSmokeEvidencePacket: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/client-ai-ops-real-pilot-qa', () => ({
+  buildClientAiOpsRealPilotQaPlan: mocks.buildClientAiOpsRealPilotQaPlan,
+  buildClientAiOpsSmokeEvidencePacket: mocks.buildClientAiOpsSmokeEvidencePacket,
+}))
+
+import { GET } from './route'
+
+function request() {
+  return new Request('http://localhost/api/admin/client-projects/project-1/ai-ops/smoke-evidence', {
+    method: 'GET',
+    headers: { authorization: 'Bearer token' },
+  })
+}
+
+describe('GET /api/admin/client-projects/[id]/ai-ops/smoke-evidence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.buildClientAiOpsRealPilotQaPlan.mockReturnValue({
+      generatedAt: '2026-06-02T12:00:00.000Z',
+      fixture: 'synthetic_client_ai_ops_pilot',
+      projectId: 'synthetic-client-ai-ops-project',
+    })
+    mocks.buildClientAiOpsSmokeEvidencePacket.mockReturnValue({
+      generatedAt: '2026-06-02T12:00:00.000Z',
+      fixture: 'synthetic_client_ai_ops_pilot',
+      projectId: 'synthetic-client-ai-ops-project',
+      summary: {
+        totalTargets: 3,
+        pendingCapture: 3,
+        readyForReview: 0,
+        needsRedaction: 0,
+        blocked: 0,
+      },
+      items: [
+        {
+          surface: 'Admin project detail',
+          status: 'pending_capture',
+          clientSafe: false,
+          sideEffectFree: true,
+        },
+      ],
+      forbiddenActions: ['credential sync', 'provider write', 'outbound send'],
+    })
+  })
+
+  it('returns a read-only smoke evidence template for admin review', async () => {
+    const response = await GET(request() as never, { params: Promise.resolve({ id: 'project-1' }) })
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(mocks.buildClientAiOpsRealPilotQaPlan).toHaveBeenCalled()
+    expect(mocks.buildClientAiOpsSmokeEvidencePacket).toHaveBeenCalledWith({
+      generatedAt: '2026-06-02T12:00:00.000Z',
+      fixture: 'synthetic_client_ai_ops_pilot',
+      projectId: 'synthetic-client-ai-ops-project',
+    })
+    expect(body).toMatchObject({
+      clientProjectId: 'project-1',
+      source: 'synthetic_smoke_evidence_template',
+      sideEffectsEnabled: false,
+      capturesAccepted: false,
+      approvalBoundary: {
+        liveSetupActions: 'agent_approvals_required',
+        evidencePersistence: 'not_enabled_in_v1',
+        clientDataMutation: 'agent_approvals_required',
+      },
+      smokeEvidence: {
+        summary: {
+          pendingCapture: 3,
+          blocked: 0,
+        },
+        forbiddenActions: ['credential sync', 'provider write', 'outbound send'],
+      },
+    })
+  })
+
+  it('requires admin auth before building the evidence packet', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await GET(request() as never, { params: Promise.resolve({ id: 'project-1' }) })
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.buildClientAiOpsRealPilotQaPlan).not.toHaveBeenCalled()
+    expect(mocks.buildClientAiOpsSmokeEvidencePacket).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/admin/client-projects/[id]/ai-ops/smoke-evidence/route.ts
+++ b/app/api/admin/client-projects/[id]/ai-ops/smoke-evidence/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import {
+  buildClientAiOpsRealPilotQaPlan,
+  buildClientAiOpsSmokeEvidencePacket,
+} from '@/lib/client-ai-ops-real-pilot-qa'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const { id } = await params
+  const qaPlan = buildClientAiOpsRealPilotQaPlan()
+  const smokeEvidence = buildClientAiOpsSmokeEvidencePacket(qaPlan)
+
+  return NextResponse.json({
+    clientProjectId: id,
+    source: 'synthetic_smoke_evidence_template',
+    sideEffectsEnabled: false,
+    capturesAccepted: false,
+    smokeEvidence,
+    approvalBoundary: {
+      liveSetupActions: 'agent_approvals_required',
+      evidencePersistence: 'not_enabled_in_v1',
+      clientDataMutation: 'agent_approvals_required',
+    },
+    nextAction: 'Capture authenticated smoke evidence with synthetic or explicitly test-owned data, then review before any live setup.',
+  })
+}

--- a/docs/client-ai-ops-roadmap-sop.md
+++ b/docs/client-ai-ops-roadmap-sop.md
@@ -146,6 +146,8 @@ The runner exits non-zero only when the synthetic QA plan has blocked checks. Wa
 
 Use the evidence template while performing authenticated manual smoke. A capture is captain-reviewable only when it uses synthetic or explicitly test-owned data, includes the expected evidence, contains no secrets or raw client records, and does not attempt any forbidden live setup action. Captures that include credentials, tokens, personal account data, or private client records must be redacted before review. Captures that use real client data without approval or attempt a forbidden action should stop the pilot path and open an approval/safety review.
 
+Admins can fetch the same read-only template from `GET /api/admin/client-projects/[id]/ai-ops/smoke-evidence`. V1 does not persist captures from this endpoint; it is a review surface for the manual smoke packet only.
+
 ## Roadmap Rule Checklist
 
 Use this checklist whenever a roadmap feature, monitor, report, or client implementation phase changes:


### PR DESCRIPTION
## Summary
- Adds a read-only admin `GET /api/admin/client-projects/[id]/ai-ops/smoke-evidence` route for the Client AI Ops smoke evidence template.
- Returns the synthetic/manual-smoke evidence packet with explicit `sideEffectsEnabled: false` and `capturesAccepted: false` boundaries.
- Documents the endpoint in the Client AI Ops roadmap SOP.

Compatibility notes: V1 is a review surface only. It does not persist captures, connect OAuth, sync credentials, call providers, activate workflows, send outbound messages, publish reports, mutate deployments, or mutate client data.

### Enhancement Impact Preflight

- Enhancement: Add a read-only admin API/read model for Client AI Ops smoke evidence review.
- User-facing surface: `GET /api/admin/client-projects/[id]/ai-ops/smoke-evidence` and SOP docs.
- Predicted files: `app/api/admin/client-projects/[id]/ai-ops/smoke-evidence/route.ts`, `app/api/admin/client-projects/[id]/ai-ops/smoke-evidence/route.test.ts`, `docs/client-ai-ops-roadmap-sop.md`.
- Shared routes/APIs/tables/helpers: New nested admin API route; reuses merged smoke evidence helper without editing it. No DB table, queue, migration, credential, OAuth, or provider write path.
- Active PRs or branches checked: PR #484 was confirmed merged. Open PRs checked: #482, #487, #488, #489. PR #489 touches `lib/client-ai-ops-real-pilot-qa.test.ts`, so this branch avoided that shared test file.
- Dirty worktree files checked: Root checkout was on `codex/agentic-review-packet-actions` with dirty subscription docs; work used fresh worktree `/Users/vambahsillah/Projects/Portfolio.worktrees/client-ai-ops-smoke-evidence-api`.
- Overlap rating: yellow.
- Coordination decision: Proceed with strict ownership boundary: new nested smoke-evidence route/test plus SOP note only; no edits to #489's shared QA test file.
- Merge-order note: Can merge independently if #489 remains test-only, but integration captain should re-check #489 before merge because both relate to the real-pilot QA test area.

## Validation
- `npm test -- 'app/api/admin/client-projects/[id]/ai-ops/smoke-evidence/route.test.ts' 'app/api/admin/client-projects/[id]/ai-ops/route.test.ts' lib/client-ai-ops-real-pilot-qa.test.ts`
- `npx tsx scripts/client-ai-ops-real-pilot-qa.ts --evidence-template`
- `npm run build:knowledge`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- `git diff --cached --check`

No live workflow, OAuth, credential, provider, outbound-send, deployment, browser automation, capture persistence, or client-data smoke was run.

## Integration Notes
- No migrations or env changes required.
- Pre-push DB health check skipped locally because `PROD_SUPABASE_URL` and `PROD_SUPABASE_SERVICE_ROLE_KEY` are not set in this worktree; CI should still enforce configured checks.
- Vercel contexts not checked for this PR at creation time:
  - Vercel - portfolio: not checked
  - Vercel - portfolio-staging: not checked
