### PR TITLE
docs: record subscription monitor refresh

### DIFF
--- a/docs/subscription-cancellation-audit.md
+++ b/docs/subscription-cancellation-audit.md
@@ -10,6 +10,99 @@ no meaningful usage signal, or after clear redundancy plus a lower-risk
 replacement path. Production changes require explicit approval in the form
 `Cancel <tool/vendor> for Portfolio`.
 
+## 2026-06-03 Daily Monitor Run
+
+Status: YELLOW
+
+Summary:
+
+- No cancellation approvals requested and no cancellation action taken.
+- Initial checkout status was `codex/agentic-review-packet-actions...origin/codex/agentic-review-packet-actions` with no dirty files reported. This run only updates the subscription tracker artifacts plus automation notification/memory files.
+- Action tracker feedback still reports 51 open actions for this automation and no in-progress, blocked, done, or progress-note signals.
+- Supabase remains active. Production `analytics_events` moved to 5199 with latest row at 2026-06-02T22:04:18Z, production `agent_runs` moved to 80 with latest row at 2026-06-02T13:00:02Z, configured `analytics_events` moved to 2164 with latest row at 2026-06-02T18:00:54Z, and configured `agent_runs` moved to 124 with latest row at 2026-06-02T15:52:12Z.
+- n8n Cloud remains operational: direct API returned 85 workflows, 72 active workflows, and sampled successful executions `16036` through `16040` around 2026-06-03T12:00Z. Checked-in exports contain 46 JSON files, 45 top-level workflow objects, and 30 active top-level exports.
+- Vercel remains active through CLI evidence: `vercel whoami` returned `vsillah`, and JSON deployment listings returned READY deployments for both `portfolio` and `portfolio-staging`, including same-day main-branch deployments.
+- Stripe remains a live revenue dependency: latest sampled successful payment intent still dates to 2026-04-06, while checkout/payment routes and Stripe packages remain in the repo; no Stripe subscriptions were returned in the sample.
+- Read AI remains connector-readable but is a watch item for recency: the authenticated connector returned six meetings in the 2026-05-01 through 2026-06-03 window, latest returned meeting on 2026-05-29, and no June 1-3 meetings. No transcript, private participant detail, meeting URL, or raw meeting content is included here.
+- Apify moved from stale sample evidence to fresh account-level activity: direct API returned same-day successful actor runs on 2026-06-03 and 2026-06-02. Keep the account active while the actor-level replacement bakeoff continues.
+- OpenAI, Anthropic, Slack, Pinecone, Hunter, Printful, HeyGen voices, ElevenLabs, OpenRouter, Vapi, and Apify APIs were readable. Gamma changed from readable on the prior run to HTTP 401 invalid/expired token. Calendly still returned 401, Gemini/Google AI still returned 403, Resend local key remains absent, OpenRouter usage remains 0, Vapi sampled calls remain 0, and ElevenLabs current cycle remains 0/246,034 characters before the 2026-06-19 reset.
+- BuiltWith remains a protected watch item during the outreach/client-volume ramp. Fireflies remains resolved as canceled per Vambah's 2026-05-01 confirmation unless new paid-plan evidence appears.
+
+Raw Findings
+
+- Read-only provider checks ran on 2026-06-03. Secret values, raw account payloads, private meeting content, private exports, and raw logs are not included in this report.
+- Repo/config footprint remains broad: `.env.example`, `.env.local`, `.env.staging.example`, `package.json`, app/api routes, lib integrations, n8n exports, migrations, admin Subscription Watch, credential docs, bakeoff docs, and operations docs continue to reference the monitored provider set.
+- `.env.local` contains safe-to-check presence signals for Supabase, Stripe, n8n, OpenAI, Anthropic, OpenRouter, Vapi, ElevenLabs, Printful, Pinecone, Hunter, Gamma, HeyGen, Apify, Calendly, Gemini, Slack, and BuiltWith. `RESEND_API_KEY` and `READAI_API_KEY` were not present locally; Read AI was checked through the connector.
+- `package.json` still includes active integration dependencies for Supabase, Stripe, Resend, Vercel Blob/Functions/Speed Insights, Google APIs, Playwright, Vapi, and related client SDKs.
+- n8n checked-in exports: 46 JSON files, 45 workflow objects, 30 active top-level exports. Export references include Slack, Gmail, Supabase, Calendly, Google, OpenAI, Anthropic, Apify, HeyGen, Vapi, Stripe, and Read-style meeting workflows.
+- Supabase production aggregates: `analytics_events` 5199/latest 2026-06-02T22:04:18Z, `agent_runs` 80/latest 2026-06-02T13:00:02Z, `cost_events` 21/latest 2026-05-14T01:13:20Z, `orders` 26/latest 2026-03-19T14:54:19Z, `printful_sync_log` 0, `email_messages` 9/latest 2026-04-30T19:53:15Z, `meeting_records` 110/latest 2026-05-06T16:32:58Z, `gamma_reports` 6/latest 2026-05-02T01:20:15Z, `videos` 4/latest 2026-04-15T02:52:07Z, and `social_content_queue` 29/latest 2026-05-07T13:00:49Z.
+- Supabase local configured aggregates: `analytics_events` 2164/latest 2026-06-02T18:00:54Z, `agent_runs` 124/latest 2026-06-02T15:52:12Z, `cost_events` 12/latest 2026-05-27T20:37:59Z, `orders` 1/latest 2026-04-06T19:35:41Z, `printful_sync_log` 0, `email_messages` 6/latest 2026-04-28T00:38:19Z, `meeting_records` 4/latest 2026-04-14T01:15:12Z, `gamma_reports` 4/latest 2026-04-16T14:56:34Z, `videos` 4/latest 2026-03-25T13:48:33Z, and `social_content_queue` 3/latest 2026-05-23T09:24:08Z.
+- n8n Cloud API: `N8N_CLOUD_API_KEY` was valid and returned 85 workflows, 72 active workflows, and five sampled successful executions around 2026-06-03T12:00Z.
+- Vercel CLI authentication was available as `vsillah`; deployment listings returned READY same-day deployments for both `portfolio` and `portfolio-staging`.
+- Stripe API: payment intents and subscriptions were readable. Latest sampled successful payment intent remained 2026-04-06; sampled subscriptions returned 0.
+- OpenAI and Anthropic model listings were readable, with OpenAI returning 120 models and Anthropic returning 10 models.
+- Read AI connector returned six meetings from the May 1-June 3 window, latest returned meeting 2026-05-29; no private content, title, participant detail, report URL, or transcript was copied into this tracker.
+- Slack bot auth was readable and valid. Pinecone listed one ready `publications` index. Hunter remained on Free with 50 used calls and 75 available.
+- Apify API returned ten latest sampled actor runs, all succeeded, including runs on 2026-06-03 and 2026-06-02.
+- OpenRouter API: current key reports usage 0. Vapi API: default calls sample returned HTTP 200 with zero calls. ElevenLabs API: Creator subscription remained readable with 0 of 246,034 characters used before the 2026-06-19 reset.
+- Printful API: orders endpoint was readable and returned one sampled draft order with 2026-04-06 timestamp; both sampled Supabase `printful_sync_log` tables remain empty.
+- HeyGen voices returned 2348 voices. Gamma v1.0 themes now returned HTTP 401 invalid/expired token. Resend local key was absent. Calendly returned 401 unauthenticated. Gemini/Google AI returned 403.
+
+Discovered Subscription Inventory
+
+| Status | Tool/vendor | Portfolio purpose | Latest evidence | Session inactivity status | Recommendation |
+| --- | --- | --- | --- | --- | --- |
+| Green | Supabase | Core database, admin state, auth-adjacent data, RAG/storage paths | Production analytics and agent runs moved on 2026-06-02 | Active | Keep |
+| Green | n8n Cloud | Automation runtime and workflow orchestration | 85 workflows, 72 active, successful executions around 2026-06-03T12:00Z | Active | Keep; optimize weak workflows separately |
+| Green | Vercel | Production/staging hosting | CLI authenticated and listed READY `portfolio` plus `portfolio-staging` deployments | Active | Keep |
+| Green | Stripe | Checkout and revenue dependency | API readable; latest sampled successful payment intent 2026-04-06; no sampled subscriptions | Revenue path quiet but dependency remains | Keep |
+| Green | OpenAI | Model/API provider for app/admin workflows | Model list readable with 120 models | Active/configured | Keep/watch usage costs |
+| Yellow | Anthropic | Model/API provider and transition watch item | Model list readable with 10 models | Billing transition unresolved | Watch until next receipt/bakeoff refresh |
+| Green | Slack | Agent/admin notification routes | Bot auth valid | Active/configured | Keep |
+| Yellow | Read AI | Meeting intelligence and transcript workflows | Six meetings in May 1-June 3 window; latest returned 2026-05-29 | Connector active, recent activity quiet | Keep/watch recency |
+| Yellow | Gamma | Report/deck generation provider | API now returns 401 invalid/expired token | DB report rows quiet since 2026-05-02 | Investigate key/billing before renewal |
+| Yellow | HeyGen | Video/avatar generation provider | Voices readable with 2348 voices | Campaign-dependent | Keep/watch; verify quota and retry avatars |
+| Green | Apify | Lead/social/evidence scraping actors | Same-day successful runs on 2026-06-03 | Active | Keep account; continue actor bakeoff |
+| Yellow | OpenRouter | Alternate model routing/bakeoff | Key readable with usage 0 | Consecutive quiet evidence | Watch; deprecate only after spend and bakeoff check |
+| Yellow | Vapi | Optional voice UX | Calls endpoint returned zero calls | Consecutive quiet evidence | Investigate billing/voice intent |
+| Yellow | ElevenLabs | Voice/audio generation | Creator cycle 0/246,034 chars before 2026-06-19 reset | Consecutive quiet evidence | Review campaign need before reset |
+| Yellow | Printful | Store/merch fulfillment | One API-visible draft order from 2026-04-06; sync log 0 | Sync inactive | Investigate dashboard/store strategy |
+| Yellow | Resend | Optional outbound email provider | Local key absent; package/env references remain | Usage unresolved | Verify production env and billing |
+| Yellow | Calendly | Scheduling and n8n booking triggers | API returned 401; links/workflows remain configured | Auth unresolved | Refresh token; keep for now |
+| Yellow | Gemini / Google AI | Google AI/image/social workflow provider | Model-list check returned 403 | Auth/project unresolved | Resolve key/project status |
+| Yellow | Pinecone | Publications/vector search | One ready serverless `publications` index | Traffic/billing unresolved | Compare dashboard traffic with Supabase/local RAG |
+| Green | Hunter.io | Lead enrichment | API reports Free plan | Not a paid cancellation target | Keep/free-watch |
+| Yellow | BuiltWith | Outreach/client stack enrichment | Local key present; standing decision protects it during outreach ramp | Watch item | Keep active during ramp |
+| Green | Fireflies.ai | Historical meeting recaps only | No new paid-plan evidence | Resolved canceled | Keep out of active queue unless restarted |
+| Yellow | Figma / Paper / Excalidraw / Canva | Design and diagram production | Repo/workflow-adjacent references only | Billing unknown | Investigate only if receipts/dashboard evidence appear |
+
+Inactive-For-Two-Sessions Evidence
+
+- OpenRouter: zero current-key usage again across consecutive provider sweeps. Still not an automatic cancellation action because active spend, dependency scope, and replacement intent are not confirmed.
+- Vapi: zero sampled calls again, with prior visible call evidence still 2026-04-30. Investigate dashboard billing and production voice intent before deprecation.
+- Printful: `printful_sync_log` remains empty in sampled Supabase projects, but the Printful API still shows one older draft order. Treat as merchandise strategy investigation, not subscription cancellation.
+- Resend: local key remains absent while code/env references remain. Verify Vercel production env and billing before removing code paths.
+- Calendly and Gemini/Google AI: auth or project readiness issues continue, but repo and workflow dependencies remain. Refresh/resolve credentials before any provider decision.
+- ElevenLabs: current reset-cycle character usage is zero again. Review campaign plan and dashboard billing before proposing cancellation.
+- Gamma: API access regressed to 401 after prior readable checks, while older DB report rows remain quiet. Treat as key/billing investigation, not cancellation-ready evidence.
+
+Candidate Cancellations
+
+- **No automatic cancellation.**
+- **No current vendor has approval-ready cancellation evidence in this daily run.**
+
+Approval Needed
+
+- No cancellation approval is needed or requested today.
+- Future cancellation still requires the exact phrase `Cancel <tool/vendor> for Portfolio`, followed by verification, a branch, deprecation/replacement work, focused validation, and rollback notes.
+
+Next Audit Focus
+
+- Verify Gamma, Vapi, Printful, Resend, Pinecone, ElevenLabs, Calendly, Gemini, HeyGen, Read AI, and Anthropic in dashboards where API evidence is quiet, auth-blocked, billing-incomplete, quota-incomplete, or subscription-transition dependent.
+- Keep Apify active while same-day runs continue; focus on pausing or replacing weak actor surfaces rather than account-level cancellation.
+- Keep BuiltWith active during the outreach ramp and collect lead-prep/proposal outcome evidence before judging it.
+- Keep Fireflies out of the active queue unless new paid-plan evidence appears; if a future receipt/dashboard signal appears, verify whether the canceled plan restarted.
+
 ## 2026-06-02 Daily Monitor Run
 
 Status: YELLOW

--- a/docs/subscription-status.json
+++ b/docs/subscription-status.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-02T12:36:48Z",
+  "generatedAt": "2026-06-03T12:38:48Z",
   "sourceDocument": "/docs/subscription-cancellation-audit.md",
   "weeklyReportAutomationId": "portfolio-subscription-weekly-report",
   "dailyMonitorAutomationId": "portfolio-subscription-cancellation-monitor",
@@ -41,7 +41,8 @@
       "2026-05-29 daily refresh kept the budget status yellow: production Supabase analytics and agent_runs moved, local agent_runs moved, n8n returned 85 workflows with 72 active and successful executions around 2026-05-29T12:00Z, Vercel portfolio and portfolio-staging had ready deployments within the prior day, Read AI had May 27 meeting/Slack recap evidence, HeyGen avatar listing was readable, and OpenAI/Anthropic/Slack/Apify/Pinecone/Hunter/Printful APIs were readable; OpenRouter stayed zero-usage, Vapi returned no sampled calls, Resend local key was absent, Calendly returned 401, Gemini/Google AI returned 403, ElevenLabs current cycle still showed 0 of 246,034 characters used, and no vendor crossed the approval-ready cancellation threshold.",
       "2026-05-30 daily refresh kept the budget status yellow: production and local Supabase analytics/agent_runs moved, n8n returned 85 workflows with 72 active and successful executions around 2026-05-30T12:00Z, Vercel portfolio and portfolio-staging had ready deployments on 2026-05-29/30, Read AI had May 29 meeting evidence, Gamma themes were readable, HeyGen avatar and voice listings were readable, and OpenAI/Slack/Pinecone/Hunter/Printful APIs were readable; OpenRouter stayed zero-usage, Vapi returned no sampled calls, Resend local key was absent, Calendly returned 401, Gemini/Google AI returned 403, Anthropic model listing returned 401 after prior readable checks, ElevenLabs current cycle still showed 0 of 246,034 characters used, and no vendor crossed the approval-ready cancellation threshold.",
       "2026-05-31 daily refresh kept the budget status yellow: production Supabase analytics and local agent_runs moved, n8n returned 85 workflows with 72 active and successful executions around 2026-05-31T12:00Z, Vercel portfolio had ready preview deployments about 2 hours old, Read AI had six May meetings through 2026-05-29, Gamma v1.0 themes and HeyGen avatars/voices were readable, Anthropic model listing recovered, and OpenAI/Slack/Pinecone/Hunter/Printful/Apify APIs were readable; OpenRouter stayed zero-usage, Vapi returned no sampled calls, Resend local key was absent, Calendly returned 401, Gemini/Google AI returned 403, ElevenLabs current cycle still showed 0 of 246,034 characters used, and no vendor crossed the approval-ready cancellation threshold.",
-      "2026-06-02 daily refresh kept the budget status yellow: production Supabase analytics moved to 5184/latest 2026-06-02T12:34:01Z and production agent_runs moved to 79/latest 2026-06-01T13:00:03Z; n8n returned 85 workflows with 72 active and successful executions 15931-15935 around 2026-06-02T12:00Z; Vercel CLI remained authenticated and listed portfolio plus portfolio-staging deployments; Read AI connector returned six meetings in the May 1-June 2 window with latest on 2026-06-01; OpenAI/Anthropic/Slack/Pinecone/Hunter/Printful/Gamma/HeyGen voices APIs were readable; HeyGen avatars timed out once; OpenRouter stayed zero-usage, Vapi returned zero sampled calls, Resend local key was absent, Calendly returned 401, Gemini returned 403, ElevenLabs current cycle still showed 0 of 246,034 characters used, and no vendor crossed the approval-ready cancellation threshold."
+      "2026-06-02 daily refresh kept the budget status yellow: production Supabase analytics moved to 5184/latest 2026-06-02T12:34:01Z and production agent_runs moved to 79/latest 2026-06-01T13:00:03Z; n8n returned 85 workflows with 72 active and successful executions 15931-15935 around 2026-06-02T12:00Z; Vercel CLI remained authenticated and listed portfolio plus portfolio-staging deployments; Read AI connector returned six meetings in the May 1-June 2 window with latest on 2026-06-01; OpenAI/Anthropic/Slack/Pinecone/Hunter/Printful/Gamma/HeyGen voices APIs were readable; HeyGen avatars timed out once; OpenRouter stayed zero-usage, Vapi returned zero sampled calls, Resend local key was absent, Calendly returned 401, Gemini returned 403, ElevenLabs current cycle still showed 0 of 246,034 characters used, and no vendor crossed the approval-ready cancellation threshold.",
+      "2026-06-03 daily refresh kept the budget status yellow: production Supabase analytics moved to 5199/latest 2026-06-02T22:04:18Z and production agent_runs moved to 80/latest 2026-06-02T13:00:02Z; n8n returned 85 workflows with 72 active and successful executions 16036-16040 around 2026-06-03T12:00Z; Vercel CLI remained authenticated and listed READY portfolio plus portfolio-staging deployments; Read AI connector returned six meetings in the May 1-June 3 window with latest returned meeting 2026-05-29; Apify returned same-day successful actor runs on 2026-06-03; OpenAI/Anthropic/Slack/Pinecone/Hunter/Printful/HeyGen voices APIs were readable; Gamma returned 401 invalid/expired token; OpenRouter stayed zero-usage, Vapi returned zero sampled calls, Resend local key was absent, Calendly returned 401, Gemini returned 403, ElevenLabs current cycle still showed 0 of 246,034 characters used, and no vendor crossed the approval-ready cancellation threshold."
     ],
     "transitionAdjustments": [
       {
@@ -53,7 +54,7 @@
     ],
     "apifyCallAnalysis": {
       "configuredActorSurfaces": 12,
-      "lastMonitorExecution": "Direct provider refresh on 2026-06-02 was readable; sampled account-level Apify runs still most recently included 2026-05-27 activity with succeeded and failed statuses. Actor-level bakeoff evidence remains the active replacement-analysis base.",
+      "lastMonitorExecution": "Direct provider refresh on 2026-06-03 was readable; sampled account-level Apify runs included same-day successful runs on 2026-06-03 and 2026-06-02. Actor-level bakeoff evidence remains the active replacement-analysis base.",
       "sampledRuns": 59,
       "succeededRuns": 40,
       "failedRuns": 19,
@@ -370,8 +371,9 @@
   },
   "summary": {
     "status": "yellow",
-    "headline": "Daily refresh: Supabase, n8n, Vercel, Read AI, OpenAI, Anthropic, Slack, Pinecone, Hunter, Printful, Gamma, and HeyGen voices remain readable or active; OpenRouter and Vapi stayed quiet; no vendor reached the approval-ready cancellation threshold.",
+    "headline": "Daily refresh: Supabase, n8n, Vercel, Apify, OpenAI, Anthropic, Slack, Pinecone, Hunter, Printful, HeyGen voices, and Read AI remain readable or active; Gamma auth regressed; OpenRouter and Vapi stayed quiet; no vendor reached the approval-ready cancellation threshold.",
     "nextReviewFocus": [
+      "Restore or rotate Gamma API access and verify dashboard credits before renewal.",
       "Review ElevenLabs current-cycle zero usage against the next planned campaign before the 2026-06-19 reset.",
       "Confirm OpenRouter role in the next media/model bakeoff before preparing any deprecation packet.",
       "Verify Vapi dashboard billing and whether production voice UX should stay enabled.",
@@ -380,8 +382,8 @@
       "Check Pinecone billing/API traffic against Supabase/local RAG usage.",
       "Restore or replace Calendly API access and rerun event-type usage checks.",
       "Resolve Gemini/Google AI project/key status before relying on image/social workflows.",
-      "Check HeyGen dashboard quota/billing because voice catalog access and one avatar timeout do not prove active paid usage.",
-      "Check Gamma dashboard credits/usage because API theme access and older report rows do not prove current paid usage.",
+      "Check HeyGen dashboard quota/billing because voice catalog access does not prove active paid usage.",
+      "Verify Read AI recency because the connector was readable but returned no June 1-3 meetings.",
       "Verify Anthropic billing and Claude/API transition state now that API model listing remains readable.",
       "Continue the Apify actor-level replacement bakeoff by pausing weak surfaces before account-level changes.",
       "Keep BuiltWith active during the outreach ramp and judge it only against lead-prep and conversion evidence.",
@@ -450,8 +452,8 @@
       "name": "Vapi",
       "status": "watch",
       "statusColor": "yellow",
-      "billingSignal": "Dashboard billing still needs verification; VAPI_PRIVATE_KEY was present and the 2026-06-02 default call sample returned HTTP 200 with zero calls again; prior visible call remains 2026-04-30.",
-      "usageSignal": "No meaningful current Vapi usage appeared again on 2026-06-02; local references remain, including optional website voice paths.",
+      "billingSignal": "Dashboard billing still needs verification; VAPI_PRIVATE_KEY was present and the 2026-06-03 default call sample returned HTTP 200 with zero calls again.",
+      "usageSignal": "No meaningful current Vapi usage appeared again; local references remain, including optional website voice paths.",
       "portfolioDependency": "Voice/audit experience risk if production voice UX is enabled.",
       "recommendation": "Investigate billing and intended voice UX; prepare a deprecation packet only if dashboard spend exists and voice UX is not needed.",
       "nextAction": "Check Vapi dashboard billing and decide whether the voice path should stay enabled.",
@@ -484,7 +486,7 @@
       "name": "Fireflies.ai",
       "status": "resolved_canceled",
       "statusColor": "green",
-      "billingSignal": "No new paid-plan evidence found on 2026-06-02; standing decision remains canceled per Vambah confirmation on 2026-05-01.",
+      "billingSignal": "No new paid-plan evidence found on 2026-06-03; standing decision remains canceled per Vambah confirmation on 2026-05-01.",
       "usageSignal": "Any old transcript/Slack residue is historical only unless new billing or dashboard evidence appears.",
       "portfolioDependency": "No active Portfolio dependency identified.",
       "recommendation": "Keep out of active cancellation queue unless new billing or dashboard evidence shows the paid plan restarted.",
@@ -501,8 +503,8 @@
       "name": "Vercel",
       "status": "keep",
       "statusColor": "green",
-      "billingSignal": "Vercel CLI remained authenticated as vsillah on 2026-06-02; subscription cost remains receipt-backed from prior budget snapshot.",
-      "usageSignal": "CLI listed deployments for both portfolio and portfolio-staging on 2026-06-02.",
+      "billingSignal": "Vercel CLI remained authenticated as vsillah on 2026-06-03; subscription cost remains receipt-backed from prior budget snapshot.",
+      "usageSignal": "CLI JSON listings returned READY same-day deployments for both portfolio and portfolio-staging on 2026-06-03.",
       "portfolioDependency": "Core hosting, previews, production, and staging verification.",
       "recommendation": "Keep; hosting is active and high-risk to change.",
       "nextAction": "Keep hosting; continue deployment health checks through the normal Portfolio release workflow.",
@@ -518,7 +520,7 @@
       "name": "Printful",
       "status": "unresolved",
       "statusColor": "yellow",
-      "billingSignal": "Printful API remained readable on 2026-06-02 and returned one sampled draft order from 2026-04-06; dashboard billing/store status still needs verification.",
+      "billingSignal": "Printful API remained readable on 2026-06-03 and returned one sampled draft order from 2026-04-06; dashboard billing/store status still needs verification.",
       "usageSignal": "Both sampled Supabase printful_sync_log tables remain empty; native store code references remain.",
       "portfolioDependency": "Merchandise/order fulfillment if the store strategy is active.",
       "recommendation": "Investigate dashboard order history and merchandise strategy before any deprecation decision.",
@@ -535,11 +537,11 @@
       "name": "Resend",
       "status": "unresolved",
       "statusColor": "yellow",
-      "billingSignal": "No local RESEND_API_KEY was present on 2026-06-02; production env and billing remain unverified.",
-      "usageSignal": "Resend package/env references remain, but Gmail/n8n email flows are the visible active path.",
+      "billingSignal": "RESEND_API_KEY remained absent locally on 2026-06-03; package/env/webhook references remain.",
+      "usageSignal": "Production usage remains unresolved because local absence does not prove Vercel/runtime absence.",
       "portfolioDependency": "Transactional email deliverability if Resend is enabled in production.",
-      "recommendation": "Verify production env and billing before keeping as a paid dependency or removing code paths.",
-      "nextAction": "Verify Vercel production env and Resend billing before keeping or removing code paths.",
+      "recommendation": "Verify production env and billing before removing Resend paths.",
+      "nextAction": "Check Vercel production env and Resend dashboard billing/usage.",
       "decisionRequired": true,
       "links": [
         {
@@ -552,11 +554,11 @@
       "name": "Pinecone",
       "status": "unresolved",
       "statusColor": "yellow",
-      "billingSignal": "Pinecone API remained readable on 2026-06-02 with one ready serverless publications index in aws/us-east-1; billing/API traffic still needs dashboard verification.",
-      "usageSignal": "RAG/Google Drive ingestion exports still reference Pinecone while Supabase/local knowledge paths also exist.",
+      "billingSignal": "Pinecone API was readable on 2026-06-03 and listed one ready serverless publications index in aws/us-east-1.",
+      "usageSignal": "Index existence is confirmed; query traffic and billing remain unresolved.",
       "portfolioDependency": "Publication/RAG search path if Pinecone remains the live vector store.",
-      "recommendation": "Investigate billing/API traffic and compare with Supabase/local RAG replacement path.",
-      "nextAction": "Compare Pinecone dashboard traffic and billing against Supabase/local RAG before any deprecation packet.",
+      "recommendation": "Investigate billing/API traffic before any replacement with Supabase or local RAG.",
+      "nextAction": "Compare Pinecone dashboard traffic with Supabase/local RAG usage.",
       "decisionRequired": true,
       "links": [
         {
@@ -569,11 +571,11 @@
       "name": "Apify",
       "status": "keep",
       "statusColor": "green",
-      "billingSignal": "Apify API remained readable on 2026-06-02; latest sampled account-level runs still most recently included 2026-05-27 activity with mixed success/failure.",
-      "usageSignal": "n8n exports and the dedicated bakeoff still show Apify as active for lead/social/evidence collection, with actor-level quality mixed.",
-      "portfolioDependency": "Lead enrichment, social listening, review capture, and actor-health workflows where alternatives are not yet proven.",
-      "recommendation": "Keep account-level subscription; continue actor-level replacement bakeoff and disable weak surfaces first.",
-      "nextAction": "Keep the account for now; pause or replace weak actor surfaces through the bakeoff before account-level changes.",
+      "billingSignal": "Apify API was readable on 2026-06-03 and latest sampled actor runs included same-day successful runs with small sampled usage costs.",
+      "usageSignal": "Account-level activity is fresh; actor-level replacement work should target weak/no-output surfaces instead of account cancellation.",
+      "portfolioDependency": "Lead, social listening, and evidence scraping workflows remain wired through n8n and repo scripts.",
+      "recommendation": "Keep the account active; continue the actor-level bakeoff and pause or replace weak actor surfaces.",
+      "nextAction": "Use the bakeoff to decide actor-by-actor replacements before any account-level change.",
       "decisionRequired": false,
       "links": [
         {
@@ -603,11 +605,11 @@
       "name": "OpenRouter",
       "status": "watch",
       "statusColor": "yellow",
-      "billingSignal": "OpenRouter key status was readable on 2026-06-02 and current-key usage remained 0.",
-      "usageSignal": "No current usage signal appeared again; model/media bakeoff references remain.",
+      "billingSignal": "OpenRouter key was readable on 2026-06-03 and still reports usage 0.",
+      "usageSignal": "No meaningful current OpenRouter usage appeared again; model-routing references remain optional/bakeoff-oriented.",
       "portfolioDependency": "Potential model-router or bakeoff fallback; no current usage signal from the sampled key.",
-      "recommendation": "Watch; prepare deprecation packet only after bakeoff and spend check.",
-      "nextAction": "Confirm intended role and spend before preparing any deprecation packet.",
+      "recommendation": "Watch; prepare deprecation only after spend, dependency, and bakeoff role are confirmed.",
+      "nextAction": "Confirm whether OpenRouter has a remaining role in media/model bakeoffs.",
       "decisionRequired": true,
       "links": [
         {
@@ -620,11 +622,11 @@
       "name": "ElevenLabs",
       "status": "watch",
       "statusColor": "yellow",
-      "billingSignal": "ElevenLabs Creator subscription remained readable on 2026-06-02 with 0 of 246,034 characters used before the 2026-06-19 reset.",
-      "usageSignal": "Audio/voice campaign need remains unresolved; current reset cycle is still quiet.",
+      "billingSignal": "Creator subscription remained readable on 2026-06-03 with 0 of 246,034 characters used before the 2026-06-19 reset.",
+      "usageSignal": "Current reset cycle remains quiet while audio/social workflow references remain.",
       "portfolioDependency": "Voiceover/audio generation for social content and media campaigns.",
-      "recommendation": "Watch through campaign decision before next reset.",
-      "nextAction": "Review upcoming audio/social campaign needs before the 2026-06-19 reset.",
+      "recommendation": "Watch through the next campaign decision; cancellation needs dashboard spend and replacement-path confirmation.",
+      "nextAction": "Compare upcoming audio needs against renewal timing before the 2026-06-19 reset.",
       "decisionRequired": true,
       "links": [
         {
@@ -641,14 +643,14 @@
           "href": "https://github.com/vsillah/Portfolio/blob/main/docs/subscription-cancellation-audit.md"
         }
       ],
-      "status": "keep",
-      "statusColor": "green",
-      "billingSignal": "Read AI connector was readable on 2026-06-02 and returned six meetings in the May 1-June 2 window, latest on 2026-06-01.",
-      "usageSignal": "Meeting intelligence remains connected to meeting/transcript workflows; private transcript content and participant details were not copied into the tracker.",
-      "portfolioDependency": "Meeting transcript, recap, and client-context workflows.",
-      "recommendation": "Keep while meeting transcript workflow remains useful; use connector evidence rather than stale direct-token state.",
-      "nextAction": "Keep while meeting transcript workflows remain useful; review plan only if meeting volume drops.",
-      "decisionRequired": false
+      "status": "watch",
+      "statusColor": "yellow",
+      "billingSignal": "Read AI remains receipt-backed and connector-readable; the connector returned six meetings in the 2026-05-01 through 2026-06-03 window.",
+      "usageSignal": "Latest returned meeting was 2026-05-29 and no June 1-3 meetings were returned in this run; keep but verify recency before renewal.",
+      "portfolioDependency": "Meeting intelligence and transcript workflows remain useful for client/project work when meetings are active.",
+      "recommendation": "Keep/watch; verify dashboard recency and whether upcoming meeting workflows still need Read AI.",
+      "nextAction": "Check Read AI dashboard recency and keep only if meeting-capture workflow remains active.",
+      "decisionRequired": true
     },
     {
       "name": "Calendly",
@@ -660,11 +662,11 @@
       ],
       "status": "keep",
       "statusColor": "yellow",
-      "billingSignal": "Calendly API lookup returned 401 on 2026-06-02; receipt-backed cost is low and scheduling links remain configured.",
-      "usageSignal": "Scheduling links and n8n Calendly workflows remain in use/config, but API usage detail is auth-blocked.",
+      "billingSignal": "Calendly API still returned 401 on 2026-06-03; receipt-backed Standard plan remains in the budget snapshot.",
+      "usageSignal": "Scheduling links, tests, and n8n booking workflows remain configured, but API usage could not be verified.",
       "portfolioDependency": "Discovery, onboarding, kickoff, progress, renewal, and delivery scheduling links.",
-      "recommendation": "Keep, auth-refresh needed.",
-      "nextAction": "Refresh Calendly API access and rerun event-type usage checks.",
+      "recommendation": "Refresh token or verify dashboard usage; keep until scheduling replacement is decided.",
+      "nextAction": "Restore Calendly API access and rerun event-type usage checks.",
       "decisionRequired": true
     },
     {
@@ -677,11 +679,11 @@
       ],
       "status": "unresolved",
       "statusColor": "yellow",
-      "billingSignal": "Gemini model-list check returned 403 on 2026-06-02; Google Cloud spend remains low-cost/usage-based in the budget snapshot.",
-      "usageSignal": "Gemini remains referenced in n8n image/social and RAG workflows but current key/project status is blocked.",
+      "billingSignal": "Gemini/Google AI model-list check still returned 403 on 2026-06-03; Google Cloud spend remains low and separate in the budget snapshot.",
+      "usageSignal": "Image/social workflow references remain, but project/key readiness is unresolved.",
       "portfolioDependency": "Gemini/image generation and RAG chatbot experiments if still active.",
-      "recommendation": "Investigate key/project status before relying on Gemini workflows.",
-      "nextAction": "Resolve Google AI key/project status before relying on Gemini workflows.",
+      "recommendation": "Resolve key/project status before relying on or deprecating Gemini workflows.",
+      "nextAction": "Check Google AI Studio/Cloud project permissions and billing association.",
       "decisionRequired": true
     },
     {
@@ -694,11 +696,11 @@
       ],
       "status": "watch",
       "statusColor": "yellow",
-      "billingSignal": "Anthropic model listing was readable again on 2026-06-02 with 10 models; Claude/API billing transition still needs verification against the next cycle.",
-      "usageSignal": "Anthropic references remain in n8n and model workflows; API model-list access is currently readable.",
+      "billingSignal": "Anthropic API model listing remained readable on 2026-06-03 with 10 models; Claude Max billing transition still needs receipt/dashboard confirmation.",
+      "usageSignal": "Anthropic remains wired into model dispatch and n8n/model workflows.",
       "portfolioDependency": "LLM fallback/evaluation paths and any Claude Max workflow still in use.",
-      "recommendation": "Watch through next receipt/bakeoff refresh and verify API/Claude spend before changing the transition assumption.",
-      "nextAction": "Verify Anthropic billing and subscription transition state before the next cycle.",
+      "recommendation": "Watch billing transition; keep API path until replacement and spend are confirmed.",
+      "nextAction": "Verify whether Claude Max subscription spend actually drops next cycle and whether API spend is separate.",
       "decisionRequired": true
     },
     {
@@ -726,13 +728,13 @@
           "href": "https://github.com/vsillah/Portfolio/blob/main/docs/subscription-cancellation-audit.md"
         }
       ],
-      "status": "keep",
+      "status": "unresolved",
       "statusColor": "yellow",
-      "billingSignal": "Gamma API was readable on 2026-06-02 through the repo-aligned v1.0 themes endpoint with 50 themes and more pages.",
-      "usageSignal": "Gamma report routes and config remain wired, while gamma_reports latest production row remains 2026-05-02.",
-      "portfolioDependency": "Deck/report generation from admin report and video workflows.",
-      "recommendation": "Keep/watch; verify dashboard credits before renewal or campaign-heavy use.",
-      "nextAction": "Check Gamma dashboard credits/usage before renewal or campaign-heavy use.",
+      "billingSignal": "Gamma Pro remains receipt-backed, but the 2026-06-03 API check returned HTTP 401 invalid/expired token after prior readable checks.",
+      "usageSignal": "DB report rows remain quiet since 2026-05-02; report/deck code paths remain wired.",
+      "portfolioDependency": "Deck/report generation workflows may still depend on Gamma while Codex/PPTX alternatives are compared.",
+      "recommendation": "Investigate key, dashboard billing, and credit usage before renewal; do not cancel from API auth failure alone.",
+      "nextAction": "Restore/rotate Gamma API access and verify dashboard credits plus recent report usage.",
       "decisionRequired": true
     },
     {
@@ -745,11 +747,11 @@
       ],
       "status": "keep",
       "statusColor": "yellow",
-      "billingSignal": "HeyGen voice API was readable on 2026-06-02 with 2348 voices; avatar listing timed out once; dashboard quota/billing still needs verification.",
-      "usageSignal": "Video-generation routes remain wired to HeyGen; campaign-dependent usage is not proven by catalog access alone.",
+      "billingSignal": "HeyGen receipt remains active from prior budget snapshot; voice catalog was readable on 2026-06-03 with 2348 voices.",
+      "usageSignal": "Voice catalog access proves API readability, while campaign usage and avatar quota still need dashboard verification.",
       "portfolioDependency": "Avatar video generation and media campaign workflows.",
-      "recommendation": "Keep; verify dashboard quota/billing before renewal decisions.",
-      "nextAction": "Check HeyGen dashboard quota/billing before renewal decisions or the next video campaign.",
+      "recommendation": "Keep/watch; verify quota and active video campaign need before renewal.",
+      "nextAction": "Check HeyGen dashboard quota/billing and retry avatar/template evidence.",
       "decisionRequired": true
     }
   ]


### PR DESCRIPTION
## Summary
- Record the 2026-06-03 subscription cancellation monitor run.
- Refresh the Subscription Watch status JSON with the latest provider evidence and review focus.
- Preserve the no-cancellation boundary while marking Gamma, Read AI, and other quiet/auth-blocked providers for follow-up.

## Validation
- npm test -- --run lib/subscription-status.test.ts
- node -e "JSON.parse(require('fs').readFileSync('docs/subscription-status.json','utf8')); console.log('subscription-status.json valid')"
- git diff --check -- docs/subscription-cancellation-audit.md docs/subscription-status.json
- Push-hook database health check passed
- No live workflow/customer-data smoke was run

## Integration Notes
- No migration required.
- No production config, provider cancellation, or credential mutation is included.
- Follow-up hygiene recommendation: move future daily monitor detail into dated artifacts while keeping docs/subscription-status.json as the compact current-state index.
- Post-merge verification needed for both Vercel contexts:
  - Vercel – portfolio
  - Vercel – portfolio-staging