### PR TITLE
docs: define subscription monitor artifact contract

### DIFF
--- a/docs/automations/README.md
+++ b/docs/automations/README.md
@@ -14,6 +14,7 @@ These runbooks do not replace the local Codex automation TOML files under `~/.co
 | `codex-project-organization-monitor` | [`codex-project-organization-monitor.md`](./codex-project-organization-monitor.md) | Organization |
 | `daily-screen-recording-workflow-review` | [`daily-screen-recording-workflow-review.md`](./daily-screen-recording-workflow-review.md) | Operations |
 | `personality-corpus-report-monitor` | [`personality-corpus-report-monitor.md`](./personality-corpus-report-monitor.md) | Content/Voice |
+| `portfolio-subscription-cancellation-monitor` | [`portfolio-subscription-cancellation-monitor.md`](./portfolio-subscription-cancellation-monitor.md) | Operations |
 
 ## Shared Rules
 

--- a/docs/automations/portfolio-subscription-cancellation-monitor.md
+++ b/docs/automations/portfolio-subscription-cancellation-monitor.md
@@ -1,0 +1,63 @@
+# Portfolio Subscription Cancellation Monitor
+
+Automation id: `portfolio-subscription-cancellation-monitor`
+
+## Purpose
+
+Keep Portfolio's paid-app, vendor, hosted-service, model-provider, automation-runtime, and integration usage visible without taking cancellation action automatically.
+
+## Operating Rhythm
+
+Daily subscription and integration usage monitor.
+
+## Decisions Supported
+
+- Whether a vendor remains active, quiet, blocked, redundant, or ready for deeper review.
+- Whether a cancellation packet should be proposed after repeated inactivity evidence.
+- Whether a credential, dashboard, receipt, or provider-access issue is blocking reliable subscription judgment.
+
+## Inputs
+
+- [`../subscription-cancellation-audit.md`](../subscription-cancellation-audit.md)
+- [`../subscription-status.json`](../subscription-status.json)
+- Dated run artifacts under [`../subscription-monitor-runs/`](../subscription-monitor-runs/)
+- Local automation memory at `/Users/vambahsillah/.codex/automations/portfolio-subscription-cancellation-monitor/memory.md`
+- Local action-tracker feedback at `/Users/vambahsillah/.codex/automation-notifications/automation-action-feedback.json`
+- Read-only provider and connector checks when credentials or authenticated connectors are available.
+
+## Authority Boundary
+
+Read-only monitoring and report generation only. Do not cancel subscriptions, remove provider credentials, deactivate production integrations, mutate provider settings, delete production data, or remove code paths without Vambah's exact approval phrase: `Cancel <tool/vendor> for Portfolio`.
+
+## Output Contract
+
+Write the full daily monitor report to a dated artifact first:
+
+- Path: `docs/subscription-monitor-runs/YYYY-MM-DD.md`
+- Heading: `# YYYY-MM-DD Subscription Monitor Run`
+- Include full sanitized sections for summary, raw findings, discovered inventory, inactivity evidence, candidate cancellations, approval needed, and next audit focus.
+- Do not include secrets, raw account payloads, private meeting content, private exports, or full logs.
+
+Then update the compact tracker files:
+
+- `docs/subscription-cancellation-audit.md` should receive only the daily heading, status, link to the dated artifact, and a compact summary of the material findings.
+- `docs/subscription-status.json` should update `latestMonitorArtifact` to the new dated artifact path and keep `monitorRunArtifactPattern` as `/docs/subscription-monitor-runs/YYYY-MM-DD.md`.
+- Preserve prior dated artifacts. Do not paste another full monitor report into `docs/subscription-cancellation-audit.md`.
+
+Finally write the normal sanitized pending notification JSON under `/Users/vambahsillah/.codex/automation-notifications/pending/` and update local automation memory when the automation runner permits it.
+
+## Validation
+
+Before finalizing a run that changes repo artifacts:
+
+```bash
+node -e "JSON.parse(require('fs').readFileSync('docs/subscription-status.json','utf8')); console.log('subscription-status.json valid')"
+npm test -- --run lib/subscription-status.test.ts
+git diff --check
+```
+
+Run broader TypeScript or build validation when code, schemas, or admin UI fields change.
+
+## Escalation Trigger
+
+Escalate when a provider crosses the cancellation threshold, provider access regresses, billing evidence conflicts with usage evidence, repeated quiet usage persists across two or more runs, or the automation cannot write the dated artifact and compact tracker consistently.

--- a/docs/subscription-monitor-runs/README.md
+++ b/docs/subscription-monitor-runs/README.md
@@ -1,0 +1,11 @@
+# Subscription Monitor Runs
+
+This folder stores full sanitized daily artifacts from the Portfolio subscription cancellation monitor.
+
+Future monitor runs should write the detailed report here first, using:
+
+```text
+docs/subscription-monitor-runs/YYYY-MM-DD.md
+```
+
+The main audit document, `docs/subscription-cancellation-audit.md`, should stay compact: one daily heading, status, artifact link, and short material summary. This prevents the durable tracker from becoming the raw monitor log while preserving full run history for audit and follow-up.

--- a/lib/subscription-monitor-artifacts.test.ts
+++ b/lib/subscription-monitor-artifacts.test.ts
@@ -1,0 +1,47 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const repoRoot = process.cwd()
+
+function readRepoFile(path: string) {
+  return readFileSync(join(repoRoot, path), 'utf8')
+}
+
+function latestAuditSection(audit: string) {
+  const match = audit.match(/## 2026-06-03 Daily Monitor Run[\s\S]*?(?=\n## \d{4}-\d{2}-\d{2} |\n*$)/)
+  return match?.[0] ?? ''
+}
+
+describe('subscription monitor artifact contract', () => {
+  it('keeps the latest main audit entry compact and linked to its dated artifact', () => {
+    const audit = readRepoFile('docs/subscription-cancellation-audit.md')
+    const section = latestAuditSection(audit)
+
+    expect(section).toContain('Detailed run artifact:')
+    expect(section).toContain('subscription-monitor-runs/2026-06-03.md')
+    expect(section).toContain('Summary:')
+    expect(section).not.toContain('Raw Findings')
+    expect(section).not.toContain('Discovered Subscription Inventory')
+    expect(section).not.toContain('Inactive-For-Two-Sessions Evidence')
+  })
+
+  it('preserves the detailed latest run in the dated artifact directory', () => {
+    const artifactPath = 'docs/subscription-monitor-runs/2026-06-03.md'
+    const artifact = readRepoFile(artifactPath)
+
+    expect(existsSync(join(repoRoot, artifactPath))).toBe(true)
+    expect(artifact).toContain('# 2026-06-03 Subscription Monitor Run')
+    expect(artifact).toContain('Raw Findings')
+    expect(artifact).toContain('Discovered Subscription Inventory')
+    expect(artifact).toContain('Candidate Cancellations')
+  })
+
+  it('documents the future-run output contract in the automation runbook', () => {
+    const runbook = readRepoFile('docs/automations/portfolio-subscription-cancellation-monitor.md')
+
+    expect(runbook).toContain('docs/subscription-monitor-runs/YYYY-MM-DD.md')
+    expect(runbook).toContain('Do not paste another full monitor report into `docs/subscription-cancellation-audit.md`')
+    expect(runbook).toContain('latestMonitorArtifact')
+  })
+})


### PR DESCRIPTION
## Summary
- Add a repo-owned runbook for the subscription cancellation monitor output contract.
- Document the dated artifact directory so future runs write full reports under docs/subscription-monitor-runs/YYYY-MM-DD.md.
- Add a guard test that keeps the main audit compact and verifies the detailed latest artifact remains preserved.

## Validation
- npm test -- --run lib/subscription-status.test.ts lib/subscription-monitor-artifacts.test.ts
- npx tsc --noEmit --pretty false
- git diff --check
- Push-hook production DB health check passed.
- Local automation TOML smoke check passed after updating the operational prompt outside the PR.
- No live workflow or customer-data smoke was run.

## Integration Notes
- No database migration required.
- No production workflow mutation in the PR.
- Local operational state updated outside Git: /Users/vambahsillah/.codex/automations/portfolio-subscription-cancellation-monitor/automation.toml now points future runs to the dated artifact contract.
- Post-merge verify both Vercel contexts:
  - Vercel – portfolio
  - Vercel – portfolio-staging