### PR TITLE
feat: surface video render readiness packets

### DIFF
--- a/app/admin/agents/standup/page.tsx
+++ b/app/admin/agents/standup/page.tsx
@@ -25,6 +25,10 @@ import {
   getAgenticContentReviewPacketByAssetId,
   type AgenticContentReviewDecision,
 } from '@/lib/agentic-content-review-packets'
+import {
+  getAgenticVideoRenderReadinessPacketByAssetId,
+  type AgenticVideoRenderReadinessDecision,
+} from '@/lib/agentic-video-render-readiness-packets'
 import type {
   AgentOrgBoardAgent,
   AgentOrgBoardGoalMetric,
@@ -92,9 +96,18 @@ const AGENTIC_CONTENT_REVIEW_DECISIONS: AgenticContentReviewDecision[] = [
   'send_back_for_repair',
   'hold_for_human',
 ]
+const AGENTIC_VIDEO_RENDER_READINESS_DECISIONS: AgenticVideoRenderReadinessDecision[] = [
+  'prepare_preflight',
+  'send_back_to_script_repair',
+  'hold_provider_work',
+]
 
 function isAgenticContentReviewDecision(value: string | null): value is AgenticContentReviewDecision {
   return AGENTIC_CONTENT_REVIEW_DECISIONS.includes(value as AgenticContentReviewDecision)
+}
+
+function isAgenticVideoRenderReadinessDecision(value: string | null): value is AgenticVideoRenderReadinessDecision {
+  return AGENTIC_VIDEO_RENDER_READINESS_DECISIONS.includes(value as AgenticVideoRenderReadinessDecision)
 }
 
 function buildAgenticContentReviewPrefill(
@@ -135,6 +148,55 @@ function buildAgenticContentReviewPrefill(
     message: [
       `Review the agentic content packet for "${packet.title}" and convert this ${decisionLabel} decision into traceable Agent Ops work.`,
       `Keep this inside the existing Portfolio approval path. No side effects beyond creating the work item or next review plan.`,
+    ].join(' '),
+  }
+}
+
+function buildAgenticVideoRenderReadinessPrefill(
+  assetId: string,
+  decision: AgenticVideoRenderReadinessDecision,
+) {
+  const packet = getAgenticVideoRenderReadinessPacketByAssetId(assetId)
+  if (!packet) return null
+
+  const decisionInstruction = {
+    prepare_preflight: `Prepare the provider preflight work packet for this video asset. Run only readiness planning and checklist work. Do not start HeyGen, ElevenLabs, Remotion, HyperFrames, publishing, or outbound provider jobs. Preserve the boundary: ${packet.approvalBoundary}`,
+    send_back_to_script_repair: `Send this video back to script repair before provider planning. Focus on script length, channel fit, visual direction, source support, and anything that would prevent a clean render-readiness preflight.`,
+    hold_provider_work: 'Hold all provider work and frame the unresolved render or provider risk for Vambah. Do not request render approval until the human-only question is answered.',
+  }[decision]
+
+  const decisionLabel = {
+    prepare_preflight: 'prepare render preflight',
+    send_back_to_script_repair: 'send back to script repair',
+    hold_provider_work: 'hold provider work',
+  }[decision]
+
+  return {
+    packet,
+    decisionLabel,
+    goal: [
+      `Agentic video render-readiness: ${decisionLabel} - ${packet.title}`,
+      '',
+      decisionInstruction,
+      '',
+      `Asset ID: ${packet.assetId}`,
+      `Source script asset: ${packet.sourceAssetId}`,
+      `Channel: ${packet.channel}`,
+      `Format: ${packet.format}`,
+      `Provider targets: ${packet.providerTargets.join(', ')}`,
+      `Approval packet: ${packet.packetPath}`,
+      `Scope: ${packet.scope}`,
+      `Next gate: ${packet.nextGate}`,
+      '',
+      'Required checks:',
+      ...packet.requiredChecks.map((check) => `- ${check}`),
+      '',
+      'Hard blocks:',
+      ...packet.hardBlocks.map((block) => `- ${block}`),
+    ].join('\n'),
+    message: [
+      `Review the render-readiness packet for "${packet.title}" and convert this ${decisionLabel} decision into traceable Agent Ops work.`,
+      'Keep provider execution blocked unless the next explicit Shaka render approval gate is satisfied.',
     ].join(' '),
   }
 }
@@ -221,30 +283,55 @@ function StandupRoomContent() {
     const params = new URLSearchParams(window.location.search)
     const goalId = params.get('goal')
     if (goalId) setFocusedGoalId(goalId)
-    if (params.get('context') !== 'agentic-content-review') return
+
+    const context = params.get('context')
 
     const assetId = params.get('asset')
     const decision = params.get('decision')
-    if (!assetId || !isAgenticContentReviewDecision(decision)) return
+    if (!assetId || !decision) return
 
-    const prefill = buildAgenticContentReviewPrefill(assetId, decision)
-    if (!prefill) return
+    if (context === 'agentic-content-review' && isAgenticContentReviewDecision(decision)) {
+      const prefill = buildAgenticContentReviewPrefill(assetId, decision)
+      if (!prefill) return
 
-    setGoal(prefill.goal)
-    setMessage(prefill.message)
-    setGoalType('general')
-    setTranscript((current) => {
-      if (current.some((entry) => entry.id === `agentic-content-review-${assetId}-${decision}`)) return current
-      return [
-        ...current,
-        {
-          id: `agentic-content-review-${assetId}-${decision}`,
-          role: 'system',
-          content: `Loaded ${prefill.packet.title} for ${prefill.decisionLabel}. Review the prefilled goal, then draft or delegate it from this room.`,
-          created_at: new Date().toISOString(),
-        },
-      ]
-    })
+      setGoal(prefill.goal)
+      setMessage(prefill.message)
+      setGoalType('general')
+      setTranscript((current) => {
+        if (current.some((entry) => entry.id === `agentic-content-review-${assetId}-${decision}`)) return current
+        return [
+          ...current,
+          {
+            id: `agentic-content-review-${assetId}-${decision}`,
+            role: 'system',
+            content: `Loaded ${prefill.packet.title} for ${prefill.decisionLabel}. Review the prefilled goal, then draft or delegate it from this room.`,
+            created_at: new Date().toISOString(),
+          },
+        ]
+      })
+      return
+    }
+
+    if (context === 'agentic-render-readiness' && isAgenticVideoRenderReadinessDecision(decision)) {
+      const prefill = buildAgenticVideoRenderReadinessPrefill(assetId, decision)
+      if (!prefill) return
+
+      setGoal(prefill.goal)
+      setMessage(prefill.message)
+      setGoalType('general')
+      setTranscript((current) => {
+        if (current.some((entry) => entry.id === `agentic-render-readiness-${assetId}-${decision}`)) return current
+        return [
+          ...current,
+          {
+            id: `agentic-render-readiness-${assetId}-${decision}`,
+            role: 'system',
+            content: `Loaded ${prefill.packet.title} for ${prefill.decisionLabel}. Review the prefilled render-readiness goal, then draft or delegate it from this room.`,
+            created_at: new Date().toISOString(),
+          },
+        ]
+      })
+    }
   }, [])
 
   const participants = useMemo(() => {

--- a/app/admin/content/video-generation/page.tsx
+++ b/app/admin/content/video-generation/page.tsx
@@ -13,6 +13,7 @@ import ProtectedRoute from '@/components/ProtectedRoute'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
 import AssetPicker from '@/components/admin/AssetPicker'
 import AgenticContentReviewPacketCard from '@/components/admin/AgenticContentReviewPacketCard'
+import AgenticVideoRenderReadinessPanel from '@/components/admin/AgenticVideoRenderReadinessPanel'
 import { ExtractionStatusChip } from '@/components/admin/ExtractionStatusChip'
 import { useWorkflowStatus } from '@/lib/hooks/useWorkflowStatus'
 import ProgressPanel, { type ProgressStep } from '@/components/admin/ProgressPanel'
@@ -21,6 +22,7 @@ import { getCurrentSession } from '@/lib/auth'
 import { VIDEO_CHANNEL_CONFIGS, type VideoChannel } from '@/lib/constants/video-channel'
 import { buildVideoRenderApproval, VIDEO_RENDER_APPROVAL_PACKET_PATH } from '@/lib/video-render-approval'
 import { getAgenticContentReviewPacketsForSurface } from '@/lib/agentic-content-review-packets'
+import { getAgenticVideoRenderReadinessPackets } from '@/lib/agentic-video-render-readiness-packets'
 
 /* ───────────── Types ───────────── */
 
@@ -168,6 +170,7 @@ function lastRunLabel(date: Date | null): string | null {
 
 const HEYGEN_SCRIPT_MAX = 5000
 const AGENTIC_VIDEO_REVIEW_PACKETS = getAgenticContentReviewPacketsForSurface('video')
+const AGENTIC_VIDEO_RENDER_READINESS_PACKETS = getAgenticVideoRenderReadinessPackets()
 
 /* ───────────── Component ───────────── */
 
@@ -1798,6 +1801,10 @@ export default function VideoGenerationPage() {
                 />
               ))}
             </div>
+          </div>
+
+          <div className="mb-6">
+            <AgenticVideoRenderReadinessPanel packets={AGENTIC_VIDEO_RENDER_READINESS_PACKETS} />
           </div>
 
           {/* ═══════════ PHASE 1: PLAN ═══════════ */}

--- a/components/admin/AgenticVideoRenderReadinessPanel.tsx
+++ b/components/admin/AgenticVideoRenderReadinessPanel.tsx
@@ -1,0 +1,113 @@
+import Link from 'next/link'
+import { CheckCircle2, FileCheck2, PauseCircle, RotateCcw, ShieldCheck } from 'lucide-react'
+import {
+  buildAgenticVideoRenderReadinessActionHref,
+  type AgenticVideoRenderReadinessPacket,
+} from '@/lib/agentic-video-render-readiness-packets'
+
+type AgenticVideoRenderReadinessPanelProps = {
+  packets: AgenticVideoRenderReadinessPacket[]
+}
+
+export default function AgenticVideoRenderReadinessPanel({ packets }: AgenticVideoRenderReadinessPanelProps) {
+  return (
+    <div className="rounded-lg border border-silicon-slate bg-background/35 p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="text-[10px] font-medium uppercase tracking-[0.16em] text-radiant-gold">Provider preflight</div>
+          <h2 className="mt-1 text-base font-semibold text-foreground">Render-readiness packets</h2>
+          <p className="mt-1 max-w-3xl text-xs leading-5 text-gray-400">
+            These packets prepare HeyGen, ElevenLabs, Remotion, and HyperFrames readiness after challenger-cleared script review. They do not start provider jobs.
+          </p>
+        </div>
+        <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-300">
+          {packets.length} preflight
+        </span>
+      </div>
+
+      <div className="mt-4 grid gap-3 lg:grid-cols-3">
+        {packets.map((packet) => (
+          <div key={packet.assetId} className="rounded-lg border border-silicon-slate bg-imperial-navy/45 p-4">
+            <div className="flex flex-wrap items-center gap-2 text-[10px] font-medium uppercase tracking-[0.14em] text-gray-500">
+              <span className="rounded-full border border-radiant-gold/30 px-2 py-0.5 text-radiant-gold">{packet.priority}</span>
+              <span>{packet.channel}</span>
+              <span>{packet.format}</span>
+            </div>
+
+            <h3 className="mt-3 text-sm font-semibold text-gray-100">{packet.title}</h3>
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {packet.providerTargets.map((provider) => (
+                <span key={provider} className="rounded-full border border-silicon-slate bg-background/40 px-2 py-0.5 text-[10px] text-gray-300">
+                  {provider}
+                </span>
+              ))}
+            </div>
+
+            <div className="mt-3 rounded-md border border-emerald-500/20 bg-emerald-500/10 p-2 text-[11px] leading-5 text-emerald-100">
+              <div className="flex items-center gap-1.5 font-semibold text-emerald-300">
+                <ShieldCheck className="h-3.5 w-3.5" />
+                {packet.readinessStatus}; {packet.approvalStatus}
+              </div>
+              <p className="mt-1 text-emerald-100/80">{packet.approvalBoundary}</p>
+            </div>
+
+            <div className="mt-3 rounded-md border border-silicon-slate/70 bg-background/40 p-2 text-[11px] leading-5 text-gray-400">
+              <div><span className="text-gray-500">Source script:</span> <code className="text-radiant-gold">{packet.sourcePacket.assetId}</code></div>
+              <div><span className="text-gray-500">Approval packet:</span> <code className="text-radiant-gold">{packet.packetPath}</code></div>
+              <div><span className="text-gray-500">Scope:</span> {packet.scope}</div>
+            </div>
+
+            <div className="mt-3">
+              <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-gray-500">Required checks</div>
+              <ul className="mt-2 space-y-1.5 text-[11px] leading-5 text-gray-300">
+                {packet.requiredChecks.map((check) => (
+                  <li key={check} className="flex gap-2">
+                    <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-300" />
+                    <span>{check}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div className="mt-3 rounded-md border border-rose-500/25 bg-rose-500/10 p-2 text-[11px] leading-5 text-rose-100">
+              {packet.hardBlocks[0]}
+            </div>
+
+            <div className="mt-3 grid gap-2 text-[11px] leading-5">
+              <Link
+                href={buildAgenticVideoRenderReadinessActionHref(packet, 'prepare_preflight')}
+                className="rounded-md border border-emerald-500/35 bg-emerald-500/10 p-2 text-emerald-100 transition-colors hover:border-emerald-400"
+              >
+                <span className="flex items-center gap-1.5 font-semibold text-emerald-300">
+                  <FileCheck2 className="h-3.5 w-3.5" />
+                  Prepare preflight
+                </span>
+                <span className="mt-1 block text-emerald-100/80">Create a traceable readiness task before render approval.</span>
+              </Link>
+              <div className="grid gap-2 sm:grid-cols-2">
+                <Link
+                  href={buildAgenticVideoRenderReadinessActionHref(packet, 'send_back_to_script_repair')}
+                  className="rounded-md border border-amber-500/35 bg-amber-500/10 p-2 text-amber-100 transition-colors hover:border-amber-400"
+                >
+                  <span className="flex items-center gap-1.5 font-semibold text-amber-300">
+                    <RotateCcw className="h-3.5 w-3.5" />
+                    Script repair
+                  </span>
+                </Link>
+                <Link
+                  href={buildAgenticVideoRenderReadinessActionHref(packet, 'hold_provider_work')}
+                  className="rounded-md border border-rose-500/30 bg-rose-500/10 p-2 text-rose-100 transition-colors hover:border-rose-400"
+                >
+                  <span className="flex items-center gap-1.5 font-semibold text-rose-300">
+                    <PauseCircle className="h-3.5 w-3.5" />
+                    Hold
+                  </span>
+                </Link>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/lib/agentic-video-render-readiness-packets.test.ts
+++ b/lib/agentic-video-render-readiness-packets.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AGENTIC_VIDEO_RENDER_READINESS_PACKETS,
+  buildAgenticVideoRenderReadinessActionHref,
+  getAgenticVideoRenderReadinessPacketByAssetId,
+  getAgenticVideoRenderReadinessPackets,
+} from './agentic-video-render-readiness-packets'
+import { VIDEO_RENDER_APPROVAL_PACKET_PATH, VIDEO_RENDER_APPROVAL_SCOPE } from './video-render-approval'
+
+describe('agentic video render-readiness packets', () => {
+  it('derives provider preflight packets from challenger-cleared video scripts', () => {
+    expect(getAgenticVideoRenderReadinessPackets()).toHaveLength(3)
+
+    for (const packet of AGENTIC_VIDEO_RENDER_READINESS_PACKETS) {
+      expect(packet.sourcePacket.targetSurface).toBe('video')
+      expect(packet.sourcePacket.challengerStatus).toBe('passed')
+      expect(packet.sourcePacket.passToHuman).toBe(true)
+      expect(packet.readinessStatus).toBe('ready_for_preflight')
+      expect(packet.approvalStatus).toBe('render_readiness_review_ready')
+      expect(packet.packetPath).toBe(VIDEO_RENDER_APPROVAL_PACKET_PATH)
+      expect(packet.scope).toBe(VIDEO_RENDER_APPROVAL_SCOPE)
+      expect(packet.approvalBoundary).toContain('does not start a render')
+      expect(packet.hardBlocks.join(' ')).toContain('No HeyGen')
+      expect(packet.hardBlocks.join(' ')).toContain('Publishing approval remains separate')
+    }
+  })
+
+  it('keeps provider work behind explicit Standup decisions', () => {
+    const packet = getAgenticVideoRenderReadinessPacketByAssetId('render-p0-youtube-agentic-ai-teams-skip')
+
+    expect(packet).not.toBeNull()
+    expect(buildAgenticVideoRenderReadinessActionHref(packet!, 'prepare_preflight')).toBe(
+      '/admin/agents/standup?context=agentic-render-readiness&asset=render-p0-youtube-agentic-ai-teams-skip&decision=prepare_preflight',
+    )
+    expect(buildAgenticVideoRenderReadinessActionHref(packet!, 'send_back_to_script_repair')).toContain('decision=send_back_to_script_repair')
+    expect(buildAgenticVideoRenderReadinessActionHref(packet!, 'hold_provider_work')).toContain('decision=hold_provider_work')
+  })
+})

--- a/lib/agentic-video-render-readiness-packets.ts
+++ b/lib/agentic-video-render-readiness-packets.ts
@@ -1,0 +1,123 @@
+import {
+  getAgenticContentReviewPacketByAssetId,
+  type AgenticContentReviewPacket,
+} from './agentic-content-review-packets'
+import { VIDEO_RENDER_APPROVAL_PACKET_PATH, VIDEO_RENDER_APPROVAL_SCOPE } from './video-render-approval'
+
+export type AgenticVideoRenderProvider = 'HeyGen' | 'ElevenLabs' | 'Remotion' | 'HyperFrames'
+export type AgenticVideoRenderReadinessDecision = 'prepare_preflight' | 'send_back_to_script_repair' | 'hold_provider_work'
+
+export type AgenticVideoRenderReadinessPacket = {
+  assetId: string
+  sourceAssetId: string
+  title: string
+  channel: string
+  format: string
+  priority: 'P0' | 'P1'
+  sourcePacket: AgenticContentReviewPacket
+  providerTargets: AgenticVideoRenderProvider[]
+  readinessStatus: 'ready_for_preflight'
+  approvalStatus: 'render_readiness_review_ready'
+  requiredChecks: string[]
+  hardBlocks: string[]
+  approvalBoundary: string
+  nextGate: string
+  packetPath: string
+  scope: string
+}
+
+const RENDER_READINESS_PACKET_SPECS = [
+  {
+    assetId: 'render-p0-youtube-agentic-ai-teams-skip',
+    sourceAssetId: 'p0-youtube-agentic-ai-teams-skip',
+    providerTargets: ['HeyGen', 'ElevenLabs', 'Remotion', 'HyperFrames'] satisfies AgenticVideoRenderProvider[],
+    requiredChecks: [
+      'Confirm final spoken script length is within provider limits.',
+      'Confirm HeyGen template or avatar and voice defaults are configured.',
+      'Confirm ElevenLabs voice path is planned only if separate voiceover is requested.',
+      'Confirm B-roll, captions, and aspect ratio are selected before any render job.',
+    ],
+  },
+  {
+    assetId: 'render-p1-short-agent-needs-receipt',
+    sourceAssetId: 'p1-short-agent-needs-receipt',
+    providerTargets: ['HeyGen', 'ElevenLabs', 'Remotion', 'HyperFrames'] satisfies AgenticVideoRenderProvider[],
+    requiredChecks: [
+      'Confirm short-form script fits a 45-second spoken delivery.',
+      'Confirm 9:16 aspect ratio and caption-safe framing before render.',
+      'Confirm HeyGen template or avatar and voice defaults are configured.',
+      'Confirm no provider job starts until internal review render approval is recorded.',
+    ],
+  },
+  {
+    assetId: 'render-p1-short-handoff-work-packet',
+    sourceAssetId: 'p1-short-handoff-work-packet',
+    providerTargets: ['HeyGen', 'ElevenLabs', 'Remotion', 'HyperFrames'] satisfies AgenticVideoRenderProvider[],
+    requiredChecks: [
+      'Confirm short-form script fits a 45-second spoken delivery.',
+      'Confirm 9:16 aspect ratio and caption-safe framing before render.',
+      'Confirm handoff visuals are storyboarded before any avatar or voice job.',
+      'Confirm no provider job starts until internal review render approval is recorded.',
+    ],
+  },
+] as const
+
+function buildRenderReadinessPacket(
+  spec: (typeof RENDER_READINESS_PACKET_SPECS)[number],
+): AgenticVideoRenderReadinessPacket {
+  const sourcePacket = getAgenticContentReviewPacketByAssetId(spec.sourceAssetId)
+  if (!sourcePacket) {
+    throw new Error(`Missing source content review packet for ${spec.sourceAssetId}`)
+  }
+  if (sourcePacket.targetSurface !== 'video') {
+    throw new Error(`Render-readiness source must be a video packet: ${spec.sourceAssetId}`)
+  }
+
+  return {
+    assetId: spec.assetId,
+    sourceAssetId: spec.sourceAssetId,
+    title: sourcePacket.title,
+    channel: sourcePacket.channel,
+    format: sourcePacket.output,
+    priority: sourcePacket.priority === 'P0' ? 'P0' : 'P1',
+    sourcePacket,
+    providerTargets: [...spec.providerTargets],
+    readinessStatus: 'ready_for_preflight',
+    approvalStatus: 'render_readiness_review_ready',
+    requiredChecks: [...spec.requiredChecks],
+    hardBlocks: [
+      'No HeyGen, ElevenLabs, Remotion, HyperFrames, publishing, or outbound provider job is approved by this packet.',
+      'Challenger clearance is required before this packet can be prepared.',
+      'Shaka render approval is required before an internal review render can start.',
+      'Publishing approval remains separate from render approval.',
+    ],
+    approvalBoundary: 'This packet prepares provider preflight only. It does not start a render or approve publishing.',
+    nextGate: 'Run the read-only render-readiness preflight, then request Shaka internal review render approval if ready.',
+    packetPath: VIDEO_RENDER_APPROVAL_PACKET_PATH,
+    scope: VIDEO_RENDER_APPROVAL_SCOPE,
+  }
+}
+
+export const AGENTIC_VIDEO_RENDER_READINESS_PACKETS: AgenticVideoRenderReadinessPacket[] =
+  RENDER_READINESS_PACKET_SPECS.map(buildRenderReadinessPacket)
+
+export function getAgenticVideoRenderReadinessPackets() {
+  return AGENTIC_VIDEO_RENDER_READINESS_PACKETS
+}
+
+export function getAgenticVideoRenderReadinessPacketByAssetId(assetId: string) {
+  return AGENTIC_VIDEO_RENDER_READINESS_PACKETS.find((packet) => packet.assetId === assetId) ?? null
+}
+
+export function buildAgenticVideoRenderReadinessActionHref(
+  packet: AgenticVideoRenderReadinessPacket,
+  decision: AgenticVideoRenderReadinessDecision,
+) {
+  const params = new URLSearchParams({
+    context: 'agentic-render-readiness',
+    asset: packet.assetId,
+    decision,
+  })
+
+  return `/admin/agents/standup?${params.toString()}`
+}


### PR DESCRIPTION
## Summary
- Adds provider render-readiness packets for the challenger-cleared agentic video assets.
- Surfaces the packets in Video Generation as a provider preflight panel for HeyGen, ElevenLabs, Remotion, and HyperFrames.
- Extends Standup Room prefill handling for render-readiness decisions so provider work becomes traceable Agent Ops planning instead of direct execution.

## Validation
- npm test -- --run lib/agentic-content-review-packets.test.ts lib/agentic-video-render-readiness-packets.test.ts lib/video-render-readiness.test.ts
- npm run lint
- npx tsc --noEmit
- git diff --check
- Local browser smoke with MOCK_N8N=true N8N_DISABLE_OUTBOUND=true PORT=3005 npm run dev for /admin/content/video-generation and /admin/agents/standup?context=agentic-render-readiness&asset=render-p0-youtube-agentic-ai-teams-skip&decision=prepare_preflight
- Browser smoke reached protected routes/auth boundary with no Next overlay and no console errors; no authenticated visual packet-card review was run.
- Pre-push database health check passed.

## Integration Notes
- No migrations or env changes.
- No HeyGen, ElevenLabs, Remotion, HyperFrames, publishing, or outbound provider APIs are called by this change.
- Vercel – portfolio: pending for this draft PR.
- Vercel – portfolio-staging: not checked for this draft PR.