### PR TITLE
Add Open Brain roadmap status report

### DIFF
--- a/docs/open-brain-local-service.md
+++ b/docs/open-brain-local-service.md
@@ -2,6 +2,8 @@
 
 This document defines the Portfolio-facing contract for the local Open Brain. The Open Brain is user-owned local infrastructure; Portfolio Admin is only a dashboard, proposal, and wiki-overlay surface.
 
+Current implementation status is tracked in `docs/open-brain-roadmap-status.md`. Regenerate it with `npm run open-brain:roadmap-status -- --write docs/open-brain-roadmap-status.md` after completing an Open Brain implementation slice.
+
 ## Source Of Truth
 
 - Primary memory owner: local Open Brain service outside the Portfolio repo.

--- a/docs/open-brain-roadmap-status.md
+++ b/docs/open-brain-roadmap-status.md
@@ -143,4 +143,3 @@ Evidence:
 - docs/model-ops-autoresearch.md
 
 Next action: Use approval cards to decide the next scoped experiment, then record outcomes as source/event records.
-

--- a/docs/open-brain-roadmap-status.md
+++ b/docs/open-brain-roadmap-status.md
@@ -1,0 +1,146 @@
+# Open Brain Roadmap Status
+
+Generated: 2026-06-04T09:13:50.199Z
+
+Open Brain is established as the default local-first memory structure. Runtime registration and Pinecone cutover remain the main approval-gated gaps.
+
+Current focus: Retrieval QA for Phase 5 and runtime-specific approval packets for Phase 2.
+
+## phase-1: Lock Open Brain As Canonical Memory
+
+Status: `complete`
+
+Completed:
+- Open Brain is documented as the local-first source of truth for durable memory.
+- Portfolio is documented as a dashboard, approval, and projection surface only.
+- Privacy tiers and forbidden projection paths are documented.
+
+Remaining:
+- None.
+
+Gates:
+- Durable memories still require proposal approval before promotion.
+
+Evidence:
+- docs/open-brain-local-service.md
+- docs/memory-context-organization-workflow.md
+
+Next action: Keep new producers aligned with the source -> event -> proposal -> memory contract.
+
+## phase-2: Register Local Open Brain Runtime
+
+Status: `approval_gated`
+
+Completed:
+- Runtime registration dry-run packet exists.
+- Codex, Hermes, OpenCode/OpenClaw-style agents, Claude Desktop, and Cursor config snippets are generated without mutating configs.
+
+Remaining:
+- Register each runtime one at a time after local-state approval.
+- Run each runtime doctor/list/manual MCP verification after registration.
+
+Gates:
+- Do not edit agent runtime configs without explicit local-state approval.
+- Do not copy secrets across agent configs.
+
+Evidence:
+- lib/open-brain-runtime-registration.ts
+- scripts/open-brain-runtime-registration.ts
+- docs/open-brain-local-service.md
+
+Next action: Prepare a runtime-specific approval packet for the next chosen runtime.
+
+## phase-3: Route Producers Into Open Brain
+
+Status: `complete`
+
+Completed:
+- Personality corpus, Codex automation inventory, Agent Ops work items/handoffs, RAG shadow plans, AutoResearch proposals, and Model Ops projections have producer routes.
+- Producer routes record sanitized source/event traces before durable memory proposals.
+
+Remaining:
+- Keep adding producers only through sanitized source/event/proposal flows.
+
+Gates:
+- No raw private exports, work item bodies, handoff bodies, secrets, or hosted mutations in producer traces.
+
+Evidence:
+- scripts/open-brain-personality-corpus-producer.ts
+- scripts/open-brain-automation-producer.ts
+- scripts/open-brain-agent-ops-producer.ts
+- scripts/open-brain-autoresearch-producer.ts
+- app/api/admin/rag-ingest/route.ts
+- lib/model-ops-open-brain.ts
+
+Next action: Use producer traces as audit records and keep durable memories approval-gated.
+
+## phase-4: Karpathy Wiki Overlay
+
+Status: `complete`
+
+Completed:
+- Wiki overlay compilation is preview-only.
+- Wiki pages expose source memory IDs, source IDs, source event IDs, privacy tier, and approval state.
+- Private records are excluded from wiki overlays.
+
+Remaining:
+- Commit generated wiki pages only through a separate approved repo change.
+
+Gates:
+- Do not treat wiki output as canonical memory.
+
+Evidence:
+- lib/open-brain.ts
+- app/admin/agents/open-brain/page.tsx
+- app/api/admin/agents/open-brain/wiki/compile/route.ts
+
+Next action: Use wiki preview for review and traceability, not as a write path.
+
+## phase-5: RAG And Pinecone Projection
+
+Status: `in_progress`
+
+Completed:
+- Public-safe Open Brain RAG projection documents carry memory/source IDs, privacy tier, source hash, projection version, deletion key, and rollback key.
+- Chatbot knowledge has opt-in JSON mode for public-safe Open Brain projection metadata.
+- RAG ingest endpoint records shadow-plan traces and blocks Pinecone writes pending approval.
+
+Remaining:
+- Run retrieval-quality tests before production promotion.
+- Stage Pinecone ingestion only after explicit cutover approval.
+- Verify deletion and rollback keys in any external vector store staging packet.
+
+Gates:
+- No raw private exports or unapproved inference can enter chatbot knowledge or Pinecone.
+- Pinecone remains downstream and rebuildable from approved Open Brain records.
+
+Evidence:
+- lib/chatbot-knowledge.ts
+- app/api/knowledge/route.ts
+- app/api/admin/rag-ingest/route.ts
+- docs/open-brain-local-service.md
+
+Next action: Build a retrieval QA packet for the Open Brain public-safe projection before any Pinecone cutover.
+
+## phase-6: AutoResearch Loop Integration
+
+Status: `complete`
+
+Completed:
+- AutoResearch proposals include experiment config, metric gate, not-run result summary, rollback path, promotion recommendation, and forbidden actions.
+- Open Brain event metadata and pending proposals carry the experiment trace.
+- Experiments, merges, deploys, hosted config mutation, and durable memory writes remain blocked without separate approval.
+
+Remaining:
+- After approved experiments run, record metrics and rollback notes as source/event records before proposing durable memories.
+
+Gates:
+- AutoResearch cannot execute experiments automatically.
+
+Evidence:
+- lib/vercel-deployment-research.ts
+- lib/open-brain.ts
+- docs/model-ops-autoresearch.md
+
+Next action: Use approval cards to decide the next scoped experiment, then record outcomes as source/event records.
+

--- a/lib/open-brain-roadmap-status.test.ts
+++ b/lib/open-brain-roadmap-status.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildOpenBrainRoadmapStatus,
+  formatOpenBrainRoadmapStatusMarkdown,
+} from './open-brain-roadmap-status'
+
+describe('Open Brain roadmap status', () => {
+  it('summarizes the current Open Brain phase statuses and gates', () => {
+    const status = buildOpenBrainRoadmapStatus('2026-06-04T12:00:00.000Z')
+
+    expect(status.phases.map((phase) => phase.id)).toEqual([
+      'phase-1',
+      'phase-2',
+      'phase-3',
+      'phase-4',
+      'phase-5',
+      'phase-6',
+    ])
+    expect(status.phases.find((phase) => phase.id === 'phase-2')).toEqual(expect.objectContaining({
+      status: 'approval_gated',
+      gates: expect.arrayContaining([
+        'Do not edit agent runtime configs without explicit local-state approval.',
+      ]),
+    }))
+    expect(status.phases.find((phase) => phase.id === 'phase-5')).toEqual(expect.objectContaining({
+      status: 'in_progress',
+      nextAction: expect.stringContaining('retrieval QA packet'),
+    }))
+    expect(status.phases.find((phase) => phase.id === 'phase-6')).toEqual(expect.objectContaining({
+      status: 'complete',
+      completed: expect.arrayContaining([
+        expect.stringContaining('not-run result summary'),
+      ]),
+    }))
+  })
+
+  it('formats a reviewable markdown roadmap report', () => {
+    const markdown = formatOpenBrainRoadmapStatusMarkdown(
+      buildOpenBrainRoadmapStatus('2026-06-04T12:00:00.000Z'),
+    )
+
+    expect(markdown).toContain('# Open Brain Roadmap Status')
+    expect(markdown).toContain('Status: `approval_gated`')
+    expect(markdown).toContain('Status: `in_progress`')
+    expect(markdown).toContain('Next action: Build a retrieval QA packet')
+    expect(markdown).toContain('scripts/open-brain-autoresearch-producer.ts')
+  })
+})

--- a/lib/open-brain-roadmap-status.ts
+++ b/lib/open-brain-roadmap-status.ts
@@ -1,0 +1,204 @@
+export type OpenBrainRoadmapPhaseStatus = 'complete' | 'in_progress' | 'approval_gated' | 'deferred'
+
+export interface OpenBrainRoadmapPhase {
+  id: string
+  title: string
+  status: OpenBrainRoadmapPhaseStatus
+  completed: string[]
+  remaining: string[]
+  gates: string[]
+  evidence: string[]
+  nextAction: string
+}
+
+export interface OpenBrainRoadmapStatus {
+  generatedAt: string
+  summary: string
+  currentFocus: string
+  phases: OpenBrainRoadmapPhase[]
+}
+
+export function buildOpenBrainRoadmapStatus(generatedAt = new Date().toISOString()): OpenBrainRoadmapStatus {
+  const phases: OpenBrainRoadmapPhase[] = [
+    {
+      id: 'phase-1',
+      title: 'Lock Open Brain As Canonical Memory',
+      status: 'complete',
+      completed: [
+        'Open Brain is documented as the local-first source of truth for durable memory.',
+        'Portfolio is documented as a dashboard, approval, and projection surface only.',
+        'Privacy tiers and forbidden projection paths are documented.',
+      ],
+      remaining: [],
+      gates: [
+        'Durable memories still require proposal approval before promotion.',
+      ],
+      evidence: [
+        'docs/open-brain-local-service.md',
+        'docs/memory-context-organization-workflow.md',
+      ],
+      nextAction: 'Keep new producers aligned with the source -> event -> proposal -> memory contract.',
+    },
+    {
+      id: 'phase-2',
+      title: 'Register Local Open Brain Runtime',
+      status: 'approval_gated',
+      completed: [
+        'Runtime registration dry-run packet exists.',
+        'Codex, Hermes, OpenCode/OpenClaw-style agents, Claude Desktop, and Cursor config snippets are generated without mutating configs.',
+      ],
+      remaining: [
+        'Register each runtime one at a time after local-state approval.',
+        'Run each runtime doctor/list/manual MCP verification after registration.',
+      ],
+      gates: [
+        'Do not edit agent runtime configs without explicit local-state approval.',
+        'Do not copy secrets across agent configs.',
+      ],
+      evidence: [
+        'lib/open-brain-runtime-registration.ts',
+        'scripts/open-brain-runtime-registration.ts',
+        'docs/open-brain-local-service.md',
+      ],
+      nextAction: 'Prepare a runtime-specific approval packet for the next chosen runtime.',
+    },
+    {
+      id: 'phase-3',
+      title: 'Route Producers Into Open Brain',
+      status: 'complete',
+      completed: [
+        'Personality corpus, Codex automation inventory, Agent Ops work items/handoffs, RAG shadow plans, AutoResearch proposals, and Model Ops projections have producer routes.',
+        'Producer routes record sanitized source/event traces before durable memory proposals.',
+      ],
+      remaining: [
+        'Keep adding producers only through sanitized source/event/proposal flows.',
+      ],
+      gates: [
+        'No raw private exports, work item bodies, handoff bodies, secrets, or hosted mutations in producer traces.',
+      ],
+      evidence: [
+        'scripts/open-brain-personality-corpus-producer.ts',
+        'scripts/open-brain-automation-producer.ts',
+        'scripts/open-brain-agent-ops-producer.ts',
+        'scripts/open-brain-autoresearch-producer.ts',
+        'app/api/admin/rag-ingest/route.ts',
+        'lib/model-ops-open-brain.ts',
+      ],
+      nextAction: 'Use producer traces as audit records and keep durable memories approval-gated.',
+    },
+    {
+      id: 'phase-4',
+      title: 'Karpathy Wiki Overlay',
+      status: 'complete',
+      completed: [
+        'Wiki overlay compilation is preview-only.',
+        'Wiki pages expose source memory IDs, source IDs, source event IDs, privacy tier, and approval state.',
+        'Private records are excluded from wiki overlays.',
+      ],
+      remaining: [
+        'Commit generated wiki pages only through a separate approved repo change.',
+      ],
+      gates: [
+        'Do not treat wiki output as canonical memory.',
+      ],
+      evidence: [
+        'lib/open-brain.ts',
+        'app/admin/agents/open-brain/page.tsx',
+        'app/api/admin/agents/open-brain/wiki/compile/route.ts',
+      ],
+      nextAction: 'Use wiki preview for review and traceability, not as a write path.',
+    },
+    {
+      id: 'phase-5',
+      title: 'RAG And Pinecone Projection',
+      status: 'in_progress',
+      completed: [
+        'Public-safe Open Brain RAG projection documents carry memory/source IDs, privacy tier, source hash, projection version, deletion key, and rollback key.',
+        'Chatbot knowledge has opt-in JSON mode for public-safe Open Brain projection metadata.',
+        'RAG ingest endpoint records shadow-plan traces and blocks Pinecone writes pending approval.',
+      ],
+      remaining: [
+        'Run retrieval-quality tests before production promotion.',
+        'Stage Pinecone ingestion only after explicit cutover approval.',
+        'Verify deletion and rollback keys in any external vector store staging packet.',
+      ],
+      gates: [
+        'No raw private exports or unapproved inference can enter chatbot knowledge or Pinecone.',
+        'Pinecone remains downstream and rebuildable from approved Open Brain records.',
+      ],
+      evidence: [
+        'lib/chatbot-knowledge.ts',
+        'app/api/knowledge/route.ts',
+        'app/api/admin/rag-ingest/route.ts',
+        'docs/open-brain-local-service.md',
+      ],
+      nextAction: 'Build a retrieval QA packet for the Open Brain public-safe projection before any Pinecone cutover.',
+    },
+    {
+      id: 'phase-6',
+      title: 'AutoResearch Loop Integration',
+      status: 'complete',
+      completed: [
+        'AutoResearch proposals include experiment config, metric gate, not-run result summary, rollback path, promotion recommendation, and forbidden actions.',
+        'Open Brain event metadata and pending proposals carry the experiment trace.',
+        'Experiments, merges, deploys, hosted config mutation, and durable memory writes remain blocked without separate approval.',
+      ],
+      remaining: [
+        'After approved experiments run, record metrics and rollback notes as source/event records before proposing durable memories.',
+      ],
+      gates: [
+        'AutoResearch cannot execute experiments automatically.',
+      ],
+      evidence: [
+        'lib/vercel-deployment-research.ts',
+        'lib/open-brain.ts',
+        'docs/model-ops-autoresearch.md',
+      ],
+      nextAction: 'Use approval cards to decide the next scoped experiment, then record outcomes as source/event records.',
+    },
+  ]
+
+  return {
+    generatedAt,
+    summary: 'Open Brain is established as the default local-first memory structure. Runtime registration and Pinecone cutover remain the main approval-gated gaps.',
+    currentFocus: 'Retrieval QA for Phase 5 and runtime-specific approval packets for Phase 2.',
+    phases,
+  }
+}
+
+export function formatOpenBrainRoadmapStatusMarkdown(status: OpenBrainRoadmapStatus) {
+  return [
+    '# Open Brain Roadmap Status',
+    '',
+    `Generated: ${status.generatedAt}`,
+    '',
+    status.summary,
+    '',
+    `Current focus: ${status.currentFocus}`,
+    '',
+    ...status.phases.flatMap((phase) => [
+      `## ${phase.id}: ${phase.title}`,
+      '',
+      `Status: \`${phase.status}\``,
+      '',
+      'Completed:',
+      ...formatList(phase.completed),
+      '',
+      'Remaining:',
+      ...formatList(phase.remaining),
+      '',
+      'Gates:',
+      ...formatList(phase.gates),
+      '',
+      'Evidence:',
+      ...formatList(phase.evidence),
+      '',
+      `Next action: ${phase.nextAction}`,
+      '',
+    ]),
+  ].join('\n')
+}
+
+function formatList(items: string[]) {
+  return items.length ? items.map((item) => `- ${item}`) : ['- None.']
+}

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "open-brain:automation-producer": "tsx scripts/open-brain-automation-producer.ts",
     "open-brain:agent-ops-producer": "tsx scripts/open-brain-agent-ops-producer.ts",
     "open-brain:autoresearch-producer": "tsx scripts/open-brain-autoresearch-producer.ts",
+    "open-brain:roadmap-status": "tsx scripts/open-brain-roadmap-status.ts",
     "wrm:smoke-gate": "tsx scripts/wrm-production-smoke-gate.ts",
     "source-protocol:smoke": "tsx scripts/source-protocol-smoke.ts",
     "staging:publications-parity": "tsx scripts/ensure-publications-experience-parity.ts --env-file .env.staging",

--- a/scripts/open-brain-roadmap-status.ts
+++ b/scripts/open-brain-roadmap-status.ts
@@ -1,0 +1,65 @@
+#!/usr/bin/env tsx
+import { mkdir, writeFile } from 'fs/promises'
+import path from 'path'
+import {
+  buildOpenBrainRoadmapStatus,
+  formatOpenBrainRoadmapStatusMarkdown,
+} from '../lib/open-brain-roadmap-status'
+
+function parseArgs(argv: string[]) {
+  const options = {
+    json: false,
+    write: null as string | null,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    const next = argv[index + 1]
+    if (arg === '--json') {
+      options.json = true
+    } else if (arg === '--write' && next) {
+      options.write = next
+      index += 1
+    } else if (arg === '--help' || arg === '-h') {
+      console.log(`Usage:
+  npm run open-brain:roadmap-status -- [options]
+
+Options:
+  --json          Print machine-readable roadmap status.
+  --write <path>  Write markdown report to a repo-relative or absolute path.
+`)
+      process.exit(0)
+    }
+  }
+
+  return options
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  const status = buildOpenBrainRoadmapStatus()
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(status, null, 2)}\n`)
+    return
+  }
+
+  const markdown = formatOpenBrainRoadmapStatusMarkdown(status)
+  if (options.write) {
+    const outputPath = path.isAbsolute(options.write)
+      ? options.write
+      : path.join(process.cwd(), options.write)
+    await mkdir(path.dirname(outputPath), { recursive: true })
+    await writeFile(outputPath, `${markdown}\n`, 'utf8')
+    process.stdout.write(`Wrote ${outputPath}\n`)
+    return
+  }
+
+  process.stdout.write(`${markdown}\n`)
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('[open-brain-roadmap-status] failed:', error instanceof Error ? error.message : error)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Summary
- add a generated Open Brain roadmap status report covering phases 1-6
- add a CLI command for markdown or JSON roadmap status output
- link the status report from the Open Brain service contract
- preserve approval-gated status for runtime registration and Pinecone cutover

## Validation
- vitest run lib/open-brain-roadmap-status.test.ts
- tsx scripts/open-brain-roadmap-status.ts --json smoke
- git diff --check

## Safety boundary
- no agent runtime config changes
- no Open Brain memory writes
- no Pinecone writes
- no hosted config mutation