### PR TITLE
feat: add open brain map diagnostics

### DIFF
--- a/app/admin/agents/open-brain/page.test.tsx
+++ b/app/admin/agents/open-brain/page.test.tsx
@@ -418,6 +418,13 @@ describe('OpenBrainPage', () => {
     expect(within(map).getByRole('button', { name: 'All relationships' })).toBeInTheDocument()
     expect(within(map).getByRole('button', { name: 'Persisted edges' })).toBeInTheDocument()
     expect(within(map).getByRole('button', { name: 'Proposal routes' })).toBeInTheDocument()
+    expect(within(map).getByText('Map diagnostics')).toBeInTheDocument()
+    expect(within(map).getByText('Rendered edges')).toBeInTheDocument()
+    expect(within(map).getByText('Unconnected nodes')).toBeInTheDocument()
+    expect(within(map).getByText('The graph is drawing relationship evidence for the current lens.')).toBeInTheDocument()
+    expect(within(map).getByText('Node colors')).toBeInTheDocument()
+    expect(within(map).getAllByText('codex automation').length).toBeGreaterThan(0)
+    expect(within(map).getAllByText('operating rule').length).toBeGreaterThan(0)
     expect(within(map).getByText('Selected record')).toBeInTheDocument()
     expect(within(map).getByText('Connected relationships')).toBeInTheDocument()
     expect(within(map).getAllByText('Proposed route').length).toBeGreaterThan(0)
@@ -445,6 +452,8 @@ describe('OpenBrainPage', () => {
 
     expect(within(map).getByText('2 active filter(s)')).toBeInTheDocument()
     expect(within(map).getByText('Filtered view: 3 node(s), 0 rendered edge(s), 1 rendered proposal route(s)')).toBeInTheDocument()
+    expect(within(map).getByText('Only proposal routes are visible in this lens. No durable edge is being shown.')).toBeInTheDocument()
+    expect(within(map).getByText('Hidden by lens: 1 edge(s), 0 proposal route(s).')).toBeInTheDocument()
 
     fireEvent.click(within(map).getByRole('button', { name: 'Reset filters' }))
 

--- a/app/admin/agents/open-brain/page.tsx
+++ b/app/admin/agents/open-brain/page.tsx
@@ -676,6 +676,16 @@ function RelationshipMapView({
     .filter((route): route is { insight: OpenBrainRelationshipInsight; source: DisplayRelationshipGraphNode; target: DisplayRelationshipGraphNode } => Boolean(route.source && route.target))
   const renderedEdges = relationshipLens === 'routes' ? [] : visibleEdges
   const renderedProposalRoutes = relationshipLens === 'edges' ? [] : visibleProposalRoutes
+  const renderedRelationshipNodeIds = new Set<string>()
+  for (const edge of renderedEdges) {
+    renderedRelationshipNodeIds.add(edge.fromId)
+    renderedRelationshipNodeIds.add(edge.toId)
+  }
+  for (const route of renderedProposalRoutes) {
+    renderedRelationshipNodeIds.add(route.source.id)
+    renderedRelationshipNodeIds.add(route.target.id)
+  }
+  const renderedOrphanedNodes = visibleNodes.filter((node) => !renderedRelationshipNodeIds.has(node.id)).length
   const graphMinHeight = Math.max(680, Math.ceil(visibleNodes.length / 3) * 150 + 210)
   const activeFilterCount = [typeFilter, privacyFilter, healthFilter, strengthFilter, statusFilter, decisionTrustFilter, relationshipLens].filter((value) => value !== 'all').length
   const selectedRouteLabel = visibleInsightSource && visibleInsightTarget
@@ -806,6 +816,15 @@ function RelationshipMapView({
             <RelationshipLegend color="bg-red-300" label="Weak or risky" />
             <RelationshipLegend color="border border-radiant-gold bg-transparent" label="Proposal-only action" />
           </div>
+          <RelationshipMapDiagnostics
+            renderedEdges={renderedEdges.length}
+            renderedProposalRoutes={renderedProposalRoutes.length}
+            visibleEdges={visibleEdges.length}
+            visibleProposalRoutes={visibleProposalRoutes.length}
+            renderedOrphanedNodes={renderedOrphanedNodes}
+            relationshipLens={relationshipLens}
+          />
+          <RelationshipNodeColorLegend nodes={visibleNodes} />
         </aside>
 
         <div
@@ -1324,6 +1343,77 @@ function RelationshipLegend({ color, label }: { color: string; label: string }) 
   )
 }
 
+function RelationshipMapDiagnostics({
+  renderedEdges,
+  renderedProposalRoutes,
+  visibleEdges,
+  visibleProposalRoutes,
+  renderedOrphanedNodes,
+  relationshipLens,
+}: {
+  renderedEdges: number
+  renderedProposalRoutes: number
+  visibleEdges: number
+  visibleProposalRoutes: number
+  renderedOrphanedNodes: number
+  relationshipLens: RelationshipLens
+}) {
+  const hiddenEdges = Math.max(0, visibleEdges - renderedEdges)
+  const hiddenRoutes = Math.max(0, visibleProposalRoutes - renderedProposalRoutes)
+  const diagnostic = renderedEdges === 0 && renderedProposalRoutes > 0
+    ? 'Only proposal routes are visible in this lens. No durable edge is being shown.'
+    : renderedEdges === 0 && renderedProposalRoutes === 0
+      ? 'No relationship is visible under the current filters and lens.'
+      : 'The graph is drawing relationship evidence for the current lens.'
+
+  return (
+    <div className="mt-5 rounded-lg border border-silicon-slate/60 bg-background/20 p-3 text-xs text-muted-foreground">
+      <p className="font-semibold uppercase tracking-[0.14em] text-radiant-gold">Map diagnostics</p>
+      <div className="mt-3 grid grid-cols-2 gap-2">
+        <Detail label="Lens" value={relationshipLens} />
+        <Detail label="Rendered edges" value={renderedEdges} />
+        <Detail label="Proposal routes" value={renderedProposalRoutes} />
+        <Detail label="Unconnected nodes" value={renderedOrphanedNodes} />
+      </div>
+      <p className="mt-3 leading-relaxed">{diagnostic}</p>
+      {(hiddenEdges > 0 || hiddenRoutes > 0) ? (
+        <p className="mt-2 leading-relaxed">
+          Hidden by lens: {hiddenEdges} edge(s), {hiddenRoutes} proposal route(s).
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+function RelationshipNodeColorLegend({ nodes }: { nodes: RelationshipGraphNode[] }) {
+  const counts = new Map<string, { count: number; node: RelationshipGraphNode }>()
+  for (const node of nodes) {
+    const key = node.type === 'source' ? node.kind : node.type
+    const current = counts.get(key)
+    counts.set(key, { count: (current?.count || 0) + 1, node: current?.node || node })
+  }
+  const entries = [...counts.entries()].sort((a, b) => b[1].count - a[1].count || a[0].localeCompare(b[0]))
+
+  return (
+    <div className="mt-5 rounded-lg border border-silicon-slate/60 bg-background/20 p-3 text-xs text-muted-foreground">
+      <p className="font-semibold uppercase tracking-[0.14em] text-radiant-gold">Node colors</p>
+      <div className="mt-3 space-y-2">
+        {entries.length > 0 ? entries.map(([key, entry]) => (
+          <div key={key} className="flex items-center justify-between gap-3">
+            <span className="inline-flex min-w-0 items-center gap-2">
+              <span className={`h-2.5 w-2.5 shrink-0 rounded-full ${relationshipNodeLegendColor(entry.node.type, entry.node.health, entry.node.kind)}`} />
+              <span className="truncate">{key.replace(/_/g, ' ')}</span>
+            </span>
+            <span className="tabular-nums">{entry.count}</span>
+          </div>
+        )) : (
+          <p>No visible node colors for the current filters.</p>
+        )}
+      </div>
+    </div>
+  )
+}
+
 function relationshipLensButtonClass(active: boolean) {
   return `rounded-md border px-2.5 py-1 text-[11px] font-medium transition ${
     active
@@ -1356,6 +1446,23 @@ function relationshipNodeTone(type: OpenBrainRelationshipNodeType, health: 'gree
   return health === 'yellow'
     ? 'border-yellow-300/55 bg-yellow-500/15 text-yellow-100'
     : 'border-silicon-slate/70 bg-silicon-slate text-platinum-white'
+}
+
+function relationshipNodeLegendColor(type: OpenBrainRelationshipNodeType, health: 'green' | 'yellow' | 'red', kind: string) {
+  if (health === 'red') return 'bg-red-300'
+  if (type === 'source') {
+    if (kind === 'workspace_root_report') return 'bg-sky-300'
+    if (kind === 'codex_automation') return 'bg-radiant-gold'
+    if (kind === 'runbook') return 'bg-emerald-300'
+    if (kind.includes('credential')) return 'bg-red-300'
+    if (kind.includes('model')) return 'bg-violet-300'
+    if (kind.includes('content') || kind.includes('voice')) return 'bg-pink-300'
+    return 'bg-cyan-300'
+  }
+  if (type === 'memory') return 'bg-platinum-white'
+  if (type === 'wiki') return 'bg-bronze'
+  if (type === 'proposal') return 'bg-yellow-300'
+  return health === 'yellow' ? 'bg-yellow-300' : 'bg-silicon-slate'
 }
 
 function relationshipNodePosition(index: number, total: number) {
@@ -1752,7 +1859,7 @@ function PrivacyBadge({ tier }: { tier: string }) {
   return <span className={`rounded-full border px-2 py-1 text-xs ${tone}`}>{tier}</span>
 }
 
-function Detail({ label, value }: { label: string; value: string }) {
+function Detail({ label, value }: { label: string; value: string | number }) {
   return (
     <div className="rounded-lg border border-silicon-slate/60 bg-black/10 p-3">
       <p className="text-xs text-muted-foreground">{label}</p>


### PR DESCRIPTION
## Summary
- Adds an operator-facing Map diagnostics panel to the Open Brain relationship map so the current lens explains rendered edges, proposal routes, hidden relationships, and unconnected nodes.
- Adds a source-kind node color legend so source-heavy maps are easier to interpret instead of reading as one undifferentiated color field.
- Expands the Open Brain page test coverage for the diagnostics panel and proposal-route lens behavior.

## Enhancement Impact Preflight
- Enhancement: Open Brain Map diagnostics and node color/source-kind legend.
- User-facing surface: `/admin/agents/open-brain` Map tab.
- Predicted files: `app/admin/agents/open-brain/page.tsx`, `app/admin/agents/open-brain/page.test.tsx`.
- Actual files: `app/admin/agents/open-brain/page.tsx`, `app/admin/agents/open-brain/page.test.tsx`.
- Shared routes/APIs/tables/helpers: none; UI-only admin page change.
- Active overlap checked: PR #496 video render readiness packet branch was unrelated; sibling `open-brain-roadmap-status` worktree only had untracked roadmap status script/helper files and did not touch the Open Brain admin page.
- Overlap rating: green with boundary.

## Validation
- `npm test -- --run app/admin/agents/open-brain/page.test.tsx lib/open-brain.test.ts app/api/admin/agents/open-brain/route.test.ts` passed: 29 tests.
- `npm run lint` passed.
- `npm run build` passed. Existing warnings observed: stale Browserslist data and dev env n8n outbound warning.
- `git diff --check` passed.
- Local smoke: `curl` returned `200` for `http://localhost:3023/admin/agents/open-brain`.
- Browser check: in-app Browser reached the route and confirmed the sign-in boundary with no console warnings/errors. Authenticated visual QA was not run because that would require transmitting admin credentials through the browser.
- Pre-push hook: read-only production database health check passed.

## Integration Notes
- No migrations, env changes, or data writes.
- Non-git local state touched: created sibling worktree `Portfolio.worktrees/open-brain-map-diagnostics`, ran `npm ci`, linked ignored env files with `npm run worktree:env`, briefly ran a local dev server on port `3023`, and opened the local route in the in-app Browser.
- Vercel contexts not checked from this non-captain branch: Vercel - portfolio, Vercel - portfolio-staging.
