### PR TITLE
docs: add agentic sales outreach launch drafts

### DIFF
--- a/components/admin/AgenticContentReviewPacketCard.tsx
+++ b/components/admin/AgenticContentReviewPacketCard.tsx
@@ -118,6 +118,17 @@ export default function AgenticContentReviewPacketCard({
       </div>
 
       <div className="mt-3 flex flex-wrap gap-2">
+        {packet.launchDraftPath ? (
+          <a
+            href={sourcePacketUrl(packet.launchDraftPath)}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1.5 rounded-md border border-emerald-500/35 bg-emerald-500/10 px-3 py-2 text-xs font-medium text-emerald-100 transition-colors hover:border-emerald-400 hover:text-emerald-50"
+          >
+            <ExternalLink className="h-3.5 w-3.5" />
+            Review launch draft
+          </a>
+        ) : null}
         <a
           href={sourcePacketUrl(packet.packetPath)}
           target="_blank"

--- a/docs/agentic-content-linkedin-drafts/2026-06-04-sales-outreach-launch-drafts.md
+++ b/docs/agentic-content-linkedin-drafts/2026-06-04-sales-outreach-launch-drafts.md
@@ -1,0 +1,397 @@
+# Agentic AI sales outreach launch drafts
+
+Date: 2026-06-04
+Status: Draft packet for human editorial review
+Launch window: Week of 2026-06-08
+Source standard: `docs/agentic-content-challenger-loop.md`
+
+## Purpose
+
+This packet turns the already-cleared agentic content backlog into sales-outreach ready social drafts. It is additive to the existing backlog and challenger packets; it does not create a new content queue.
+
+Approval boundary:
+
+- These drafts are ready for Vambah editorial review.
+- Publishing, scheduling, direct outreach, carousel design, PDF export, and provider work remain separately gated.
+- No private run logs, client records, raw chats, secrets, screenshots, or unpublished operational details should be included in public posts.
+
+## Recommended launch order
+
+| Day | Asset | Channel | Goal |
+| --- | --- | --- | --- |
+| Monday, 2026-06-08 | Anyone can launch an agent now | LinkedIn text post | Establish the main operating-system frame. |
+| Tuesday, 2026-06-09 | 7 things your enterprise agent needs after the demo | LinkedIn carousel companion | Make the component model scannable. |
+| Wednesday, 2026-06-10 | Scope is the safety model | LinkedIn text post | Start a practical trust conversation with operators. |
+| Thursday, 2026-06-11 | Agent QA needs scorecards | LinkedIn text post | Explain quality loops and why approval should not receive first-pass work. |
+| Friday, 2026-06-12 | Governed Agentic Operations | LinkedIn/client proof post | Convert the week into a sales conversation. |
+
+## Shared source map
+
+| Source ID | Path | Use |
+| --- | --- | --- |
+| `value-map` | `docs/agentic-enterprise-value-map.md` | Core system frame, lifecycle, proof map. |
+| `communications-plan` | `docs/agentic-value-communications-plan.md` | Channel strategy, launch order, challenger gate. |
+| `p0-challenger` | `docs/agentic-content-review-packets/p0-challenger-review-packets.md` | P0 clearance for flagship post and carousel. |
+| `p1-challenger` | `docs/agentic-content-review-packets/p1-challenger-review-packets.md` | P1 clearance for scope and QA posts. |
+| `p2-challenger` | `docs/agentic-content-review-packets/p2-challenger-review-packets.md` | Client proof packet boundary. |
+| `linkedin-wave-1` | `docs/agentic-content-linkedin-drafts/wave-1-drafts.md` | Existing voice and component drafts. |
+| `linkedin-voice` | `docs/linkedin-voice.md` | LinkedIn voice, structure, and anti-AI constraints. |
+
+## Draft 1: Anyone can launch an agent now
+
+Asset ID: `p0-linkedin-flagship-agentic-operating-system`
+Channel: LinkedIn text post
+Audience: product leaders, operators, founders, AI builders, enterprise leaders
+Primary claim: the demo is no longer the hard part; governed execution is where the value starts.
+Status: `human_review_ready`
+
+### Post
+
+Anyone can launch an agent now.
+
+That is the exciting part.
+
+It is also the part that should make enterprise teams slow down.
+
+The barrier used to be code. You needed enough technical skill to wire up the model, connect the tools, handle the workflow, and get something useful to happen.
+
+That barrier is falling fast.
+
+Open runtimes. Coding agents. Workflow agents. Browser agents. Local tools. Cloud tools. A small team can now get a working agent into motion in a weekend.
+
+But a working agent is not the same thing as a trustworthy operating model.
+
+The real questions start after the demo:
+
+Who assigned the work?
+Why did this agent get the task?
+What data could it use?
+What tools could it touch?
+What did it cost?
+What did it hand off?
+Where did the human approve the side effect?
+What proof would you show later if something went wrong?
+
+That is the layer I have been building into Portfolio.
+
+Not just agents. The operating system around them.
+
+Trace records. Scope boundaries. Handoffs. Approval gates. Quality checks. Challenger review. Mission Control. Slack surfaces for mobile unblock. A client-safe way to explain what happened without exposing private raw material.
+
+That may sound less exciting than watching an agent complete a task in real time.
+
+Good.
+
+Because enterprises do not need more impressive demos that become someone else's operational risk.
+
+Small businesses do not need AI that adds another invisible mess.
+
+Nonprofits do not need tools that create more work for teams already carrying too much.
+
+The value is not the agent acting once.
+
+The value is knowing when it should act, what it was allowed to touch, how the work was evaluated, and where a person had the authority to say yes, pause, repair, or stop.
+
+Execution is becoming cheap.
+
+Governed execution is where the value is.
+
+If your team is starting to adopt agents, what proof would you need before giving one more authority?
+
+#AIProduct #ProductManagement #EnterpriseAI #AmadutownAdvisory
+
+### Amina challenger notes
+
+- Unsupported claims: none. The post frames Portfolio as a governed proof surface, not a finished autonomous enterprise platform.
+- Privacy flags: none. No private logs, screenshots, client details, or raw chats.
+- Implementation drift: acceptable. Mentions implemented control surfaces at component level.
+- Residual human decision: decide whether "enterprise" is the right word for the first launch post, or whether "business" broadens the audience.
+
+## Draft 2: 7 things your enterprise agent needs after the demo
+
+Asset ID: `p0-carousel-seven-things-after-agent-demo`
+Channel: LinkedIn carousel companion post
+Audience: enterprise AI evaluators, product leaders, founders, consultants
+Primary claim: the demo is only one stage; teams need a component model for operational trust.
+Status: `human_review_ready`
+
+### Companion post
+
+The agent demo is usually the easy part now.
+
+The harder question is what has to exist around the agent before a business should trust it with real work.
+
+I keep coming back to seven things:
+
+1. A receipt for every run.
+2. A scope boundary the operator can explain.
+3. A handoff packet when work changes owners.
+4. A human approval gate before side effects.
+5. A compliance path for risk and transactions.
+6. A QA loop that evaluates the work before authority expands.
+7. A Mission Control surface where a person can trace what happened.
+
+That is the difference between an agent that performs and an agent system that can be governed.
+
+I built this carousel because a lot of teams are about to bring agent runtimes into enterprise settings and discover that execution capacity is only the beginning.
+
+Swipe through the operating layer most demos skip.
+
+Which of these seven would you want in place first?
+
+#AIProduct #EnterpriseAI #ProductManagement #AmadutownAdvisory
+
+### Carousel slide outline
+
+1. Cover: `The 7 things your enterprise agent needs after the demo`
+2. Receipt: every run needs trace, artifacts, cost, approvals, and handoffs.
+3. Scope: tools, data, writes, outbound authority, and spend boundaries.
+4. Handoff: owner, summary, acceptance criteria, linked evidence.
+5. Approval: human checkpoint for side effects.
+6. Compliance: risk monitor, transaction authority, governance export.
+7. QA: rubrics, challenger review, coaching signals.
+8. Operator surface: Mission Control for full review; Slack for mobile unblock.
+9. Close: `Execution is becoming cheap. Governed execution is where the value is.`
+
+### Amina challenger notes
+
+- Unsupported claims: none in outline form.
+- Privacy flags: final design must use diagrams or sanitized UI only.
+- Implementation drift: do not imply every path is fully autonomous or production-mutating.
+- Residual human decision: decide whether cover says "enterprise agent" or "business agent."
+
+## Draft 3: Scope is the safety model
+
+Asset ID: `p1-linkedin-scope-safety-model`
+Channel: LinkedIn text post
+Audience: product leaders, risk/compliance partners, founders, AI operators
+Primary claim: scope is not a prompt detail; it is the operating boundary that makes agent authority explainable.
+Status: `human_review_ready`
+
+### Post
+
+Agent access should feel less like a blank check and more like a permission slip.
+
+What can this agent read?
+
+What can it write?
+
+Can it touch client data?
+
+Can it send a message, publish a post, change production, start a paid job, or spend money?
+
+Those questions sound boring until an agent does something fast, confident, and wrong.
+
+That is why scope matters.
+
+In Portfolio, I have been treating scope as part of the product.
+
+Not a security appendix.
+
+Not a line buried in a prompt.
+
+A product feature.
+
+If an agent is going to act on behalf of a business, the operator should be able to explain its boundary in plain language:
+
+- what tools it can call
+- what data it can use
+- what write actions are allowed
+- what outbound actions are blocked
+- what spending requires approval
+- what happens when the risk changes
+
+That last part matters.
+
+Good scope is not only a list of permissions. It is a path for escalation.
+
+The agent can prepare the work.
+
+The system can record the evidence.
+
+The human still approves the side effect when the action carries real risk.
+
+That is how you avoid giving the agent more authority than the organization can explain.
+
+The goal is not to make every agent powerful.
+
+The goal is to make every agent appropriately bounded.
+
+Can your team explain what your agents are allowed to read, write, send, spend, and change?
+
+#AIProduct #EnterpriseAI #ProductManagement #AmadutownAdvisory
+
+### Amina challenger notes
+
+- Unsupported claims: none. The scope categories are source-backed by the communications plan and permission boundary work.
+- Privacy flags: none.
+- Implementation drift: acceptable. The post describes operating discipline and does not claim unrestricted production authority.
+- Residual human decision: decide whether "blank check" should remain for a security-forward audience.
+
+## Draft 4: Agent QA needs scorecards
+
+Asset ID: `p1-linkedin-agent-qa-scorecards`
+Channel: LinkedIn text post
+Audience: product leaders, AI program owners, operations leaders
+Primary claim: agents should earn authority through evaluation, traces, and challenger loops.
+Status: `human_review_ready`
+
+### Post
+
+If an agent cannot evaluate its work, it should not get more power.
+
+That is the management rule I keep coming back to.
+
+A good answer is not enough.
+
+I want to know how the work happened.
+
+Did it choose the right tool?
+Did it stay inside scope?
+Did it route the work to the right owner?
+Did it ask for approval when the task became sensitive?
+Did it preserve the evidence?
+Did the cost make sense for the value of the work?
+
+That is why agent QA needs scorecards.
+
+Rubrics.
+
+Run evaluations.
+
+Pass and fail signals.
+
+Coaching notes.
+
+Trend lines that show whether the system is getting better for the right reason.
+
+Sometimes the lesson is that the agent needs a better prompt.
+
+Sometimes it needs a smaller scope.
+
+Sometimes it needs a different tool.
+
+Sometimes it should stop and ask a human instead of trying to sound certain.
+
+That is the part I think many teams will underestimate.
+
+Agent quality is not only about the final output. It is about whether the system can explain the path it took to get there.
+
+In Portfolio, I have been pairing quality checks with challenger review before the work reaches human approval.
+
+That matters because humans should not be doing the agent's first round of QA.
+
+The human decision should be higher value:
+
+Is this aligned?
+
+Is this safe?
+
+Is this ready to publish, send, spend, change, or escalate?
+
+A human reviewer should receive a decision packet, not a mystery.
+
+Where would your team draw the line between an agent that can draft and an agent that can act?
+
+#AIProduct #ProductManagement #EnterpriseAI #AmadutownAdvisory
+
+### Amina challenger notes
+
+- Unsupported claims: none. The post describes scorecards and challenger review at the operating-pattern level.
+- Privacy flags: none.
+- Implementation drift: acceptable. It does not claim all reflection loops are fully autonomous.
+- Residual human decision: decide whether to expand this into a carousel on "how an agent earns authority."
+
+## Draft 5: Governed Agentic Operations
+
+Asset ID: `p2-client-one-pager-governed-agentic-operations`
+Channel: LinkedIn text post and sales follow-up seed
+Audience: founders, nonprofit executives, small business owners, enterprise AI sponsors
+Primary claim: the portfolio is useful because it shows the operating layer around agentic AI, not only the agent.
+Status: `human_review_ready`
+
+### Post
+
+I have been building my Portfolio site like a proof surface for one question:
+
+What does it take to make AI agents useful in the real world?
+
+The answer keeps getting more practical.
+
+It is not enough to launch the agent.
+
+You need the harness around it.
+
+The trace that shows what happened.
+
+The scope boundary that limits what it can touch.
+
+The memory model that separates raw input from approved knowledge.
+
+The handoff packet that tells the next agent what to do.
+
+The approval gate that keeps side effects under human authority.
+
+The QA loop that tests work before a person is asked to approve it.
+
+The Mission Control surface that lets an operator see the work instead of guessing.
+
+That is what I mean by Governed Agentic Operations.
+
+For a small business, that might mean an agent can prepare outreach but cannot send it without approval.
+
+For a nonprofit, it might mean AI can summarize program work without exposing private participant context.
+
+For an enterprise team, it might mean every agent run leaves a receipt, every handoff has an owner, and every production-changing action has a decision trail.
+
+This is where AI consulting has to get more honest.
+
+The demo can show what is possible.
+
+The operating model shows whether it is responsible.
+
+I am starting to package this work for leaders who want agents in their organization but do not want a loose pile of automation risk.
+
+If that is the conversation you are having internally, I would be glad to compare notes.
+
+#AIProduct #EnterpriseAI #Consulting #AmadutownAdvisory
+
+### Sales follow-up seed
+
+If someone engages with this post, follow up with:
+
+> Appreciate you engaging with the agentic operations post. The part I am trying to make more concrete for leaders is the operating layer after the demo: scope, trace, handoff, approval, QA, and client-safe proof. If your team is exploring agents, I would be glad to compare notes on what has to be in place before the system gets more authority.
+
+### Amina challenger notes
+
+- Unsupported claims: none. The post frames Portfolio as a proof surface and advisory packaging path.
+- Privacy flags: none. No private run logs, client data, or raw screenshots.
+- Implementation drift: acceptable. Uses "might mean" examples rather than claiming all client workflows are deployed.
+- Residual human decision: decide whether to keep the direct "glad to compare notes" close or turn it into a softer question.
+
+## Packet gate summary
+
+| Asset | Challenger status | Human review status | Publish/send status |
+| --- | --- | --- | --- |
+| `p0-linkedin-flagship-agentic-operating-system` | `passed` | `human_review_ready` | Blocked pending publishing approval. |
+| `p0-carousel-seven-things-after-agent-demo` | `passed` | `human_review_ready` | Blocked pending visual build and publishing approval. |
+| `p1-linkedin-scope-safety-model` | `passed` | `human_review_ready` | Blocked pending publishing approval. |
+| `p1-linkedin-agent-qa-scorecards` | `passed` | `human_review_ready` | Blocked pending publishing approval. |
+| `p2-client-one-pager-governed-agentic-operations` | `passed` | `human_review_ready` | Blocked pending publishing/outreach approval. |
+
+## Humanizer pass
+
+Removed or avoided:
+
+- generic AI hype
+- "not just / not only" style antithesis
+- fake authority phrases
+- unsupported enterprise autonomy claims
+- private or client-specific details
+- provider/render/publish language that would imply approval
+
+Remaining editorial decisions:
+
+- Choose whether Monday's first post should say "enterprise agent" or "business agent."
+- Decide whether the sales follow-up seed should be direct or softened.
+- Decide whether the carousel should be designed as a polished visual this week or posted as a text/list first.

--- a/docs/agentic-content-linkedin-drafts/2026-06-04-sales-outreach-launch-drafts.md
+++ b/docs/agentic-content-linkedin-drafts/2026-06-04-sales-outreach-launch-drafts.md
@@ -74,7 +74,7 @@ What proof would you show later if something went wrong?
 
 That is the layer I have been building into Portfolio.
 
-Not just agents. The operating system around them.
+Agents need the operating system around them.
 
 Trace records. Scope boundaries. Handoffs. Approval gates. Quality checks. Challenger review. Mission Control. Slack surfaces for mobile unblock. A client-safe way to explain what happened without exposing private raw material.
 
@@ -88,9 +88,7 @@ Small businesses do not need AI that adds another invisible mess.
 
 Nonprofits do not need tools that create more work for teams already carrying too much.
 
-The value is not the agent acting once.
-
-The value is knowing when it should act, what it was allowed to touch, how the work was evaluated, and where a person had the authority to say yes, pause, repair, or stop.
+The value starts when the team knows when it should act, what it was allowed to touch, how the work was evaluated, and where a person had the authority to say yes, pause, repair, or stop.
 
 Execution is becoming cheap.
 
@@ -203,7 +201,7 @@ If an agent is going to act on behalf of a business, the operator should be able
 
 That last part matters.
 
-Good scope is not only a list of permissions. It is a path for escalation.
+Good scope goes past a permissions list. It gives the team a path for escalation.
 
 The agent can prepare the work.
 
@@ -275,7 +273,7 @@ Sometimes it should stop and ask a human instead of trying to sound certain.
 
 That is the part I think many teams will underestimate.
 
-Agent quality is not only about the final output. It is about whether the system can explain the path it took to get there.
+Agent quality includes the final output, but the path matters just as much.
 
 In Portfolio, I have been pairing quality checks with challenger review before the work reaches human approval.
 
@@ -307,7 +305,7 @@ Where would your team draw the line between an agent that can draft and an agent
 Asset ID: `p2-client-one-pager-governed-agentic-operations`
 Channel: LinkedIn text post and sales follow-up seed
 Audience: founders, nonprofit executives, small business owners, enterprise AI sponsors
-Primary claim: the portfolio is useful because it shows the operating layer around agentic AI, not only the agent.
+Primary claim: the portfolio is useful because it shows the operating layer around agentic AI alongside the agent.
 Status: `human_review_ready`
 
 ### Post
@@ -318,7 +316,7 @@ What does it take to make AI agents useful in the real world?
 
 The answer keeps getting more practical.
 
-It is not enough to launch the agent.
+Launching the agent is only the opening move.
 
 You need the harness around it.
 

--- a/lib/agentic-content-review-packets.test.ts
+++ b/lib/agentic-content-review-packets.test.ts
@@ -19,6 +19,9 @@ describe('agentic content review packet registry', () => {
       expect(packet.decisionPrompt).toMatch(/Decide/)
       expect(packet.approveMeaning).toMatch(/Open/)
       expect(packet.sendBackMeaning).toMatch(/Route a repair task/)
+      if (packet.launchDraftPath) {
+        expect(packet.launchDraftPath).toBe('docs/agentic-content-linkedin-drafts/2026-06-04-sales-outreach-launch-drafts.md')
+      }
     }
   })
 
@@ -56,5 +59,17 @@ describe('agentic content review packet registry', () => {
     )
     expect(buildAgenticContentReviewActionHref(packet!, 'send_back_for_repair')).toContain('decision=send_back_for_repair')
     expect(buildAgenticContentReviewActionHref(packet!, 'hold_for_human')).toContain('decision=hold_for_human')
+  })
+
+  it('links the sales outreach launch packet to the first Monday review batch', () => {
+    const launchPackets = AGENTIC_CONTENT_REVIEW_PACKETS.filter((packet) => packet.launchDraftPath)
+
+    expect(launchPackets.map((packet) => packet.assetId)).toEqual([
+      'p0-linkedin-flagship-agentic-operating-system',
+      'p0-carousel-seven-things-after-agent-demo',
+      'p1-linkedin-scope-safety-model',
+      'p1-linkedin-agent-qa-scorecards',
+      'p2-client-one-pager-governed-agentic-operations',
+    ])
   })
 })

--- a/lib/agentic-content-review-packets.ts
+++ b/lib/agentic-content-review-packets.ts
@@ -20,7 +20,10 @@ export type AgenticContentReviewPacket = {
   approveMeaning: string
   sendBackMeaning: string
   targetSurface: AgenticContentReviewSurface
+  launchDraftPath?: string
 }
+
+const SALES_OUTREACH_LAUNCH_DRAFT_PATH = 'docs/agentic-content-linkedin-drafts/2026-06-04-sales-outreach-launch-drafts.md'
 
 export const AGENTIC_CONTENT_REVIEW_PACKETS: AgenticContentReviewPacket[] = [
   {
@@ -42,6 +45,7 @@ export const AGENTIC_CONTENT_REVIEW_PACKETS: AgenticContentReviewPacket[] = [
     approveMeaning: 'Open the Social Content approval gate, inspect the draft, then approve or publish only from that governed draft screen.',
     sendBackMeaning: 'Route a repair task if the claim, voice, source support, or channel fit is not ready for public review.',
     targetSurface: 'social',
+    launchDraftPath: SALES_OUTREACH_LAUNCH_DRAFT_PATH,
   },
   {
     assetId: 'p0-carousel-seven-things-after-agent-demo',
@@ -62,6 +66,7 @@ export const AGENTIC_CONTENT_REVIEW_PACKETS: AgenticContentReviewPacket[] = [
     approveMeaning: 'Open the Social Content approval path after reviewing the outline; visual build and publishing remain separate gates.',
     sendBackMeaning: 'Route a repair task if the slide story, evidence, or sequence needs another challenger pass.',
     targetSurface: 'social',
+    launchDraftPath: SALES_OUTREACH_LAUNCH_DRAFT_PATH,
   },
   {
     assetId: 'p1-linkedin-scope-safety-model',
@@ -82,6 +87,7 @@ export const AGENTIC_CONTENT_REVIEW_PACKETS: AgenticContentReviewPacket[] = [
     approveMeaning: 'Open the Social Content approval gate, inspect the draft, then approve or publish only from that governed draft screen.',
     sendBackMeaning: 'Route a repair task if the scope claim, safety framing, source support, or voice needs revision.',
     targetSurface: 'social',
+    launchDraftPath: SALES_OUTREACH_LAUNCH_DRAFT_PATH,
   },
   {
     assetId: 'p1-linkedin-agent-qa-scorecards',
@@ -102,6 +108,7 @@ export const AGENTIC_CONTENT_REVIEW_PACKETS: AgenticContentReviewPacket[] = [
     approveMeaning: 'Open the Social Content approval gate, inspect the draft, then approve or publish only from that governed draft screen.',
     sendBackMeaning: 'Route a repair task if the QA claim, scorecard framing, source support, or voice needs revision.',
     targetSurface: 'social',
+    launchDraftPath: SALES_OUTREACH_LAUNCH_DRAFT_PATH,
   },
   {
     assetId: 'p0-youtube-agentic-ai-teams-skip',
@@ -182,6 +189,7 @@ export const AGENTIC_CONTENT_REVIEW_PACKETS: AgenticContentReviewPacket[] = [
     approveMeaning: 'Open the Content Hub production path only after approving the editorial packet; PDF export and client sharing remain separate gates.',
     sendBackMeaning: 'Route a repair task if the buyer language, CTA, source support, or AmaduTown branding decision needs revision.',
     targetSurface: 'content',
+    launchDraftPath: SALES_OUTREACH_LAUNCH_DRAFT_PATH,
   },
   {
     assetId: 'p2-technical-appendix-agentic-proof-map',


### PR DESCRIPTION
## Summary
- Adds a Monday-ready sales outreach launch packet for the first five agentic content assets.
- Includes four LinkedIn/social drafts, one client proof/sales follow-up seed, source maps, Amina challenger notes, residual human decisions, and a suggested week-of-2026-06-08 launch order.
- Links the affected review cards to the launch draft packet without creating database rows or bypassing approval gates.

## Validation
- npm test -- --run lib/agentic-content-review-packets.test.ts
- npm run lint
- npx tsc --noEmit
- git diff --check
- Local browser smoke with MOCK_N8N=true N8N_DISABLE_OUTBOUND=true PORT=3005 npm run dev for /admin/social-content, /admin/content, and /admin/agents/standup?context=agentic-content-review&asset=p0-linkedin-flagship-agentic-operating-system&decision=approve_next_gate
- Browser smoke reached protected routes/auth boundary with no Next overlay and no console errors; no authenticated visual packet-card review was run.
- Pre-push database health check passed.

## Integration Notes
- No migrations or env changes.
- No Social Content database seeding was performed. This is a reviewable launch packet plus UI link only.
- Publishing, scheduling, direct outreach, carousel design, PDF export, and provider work remain separately gated.
- Vercel – portfolio: pending for this draft PR.
- Vercel – portfolio-staging: not checked for this draft PR.