### PR TITLE
Fix Slack agent button feedback

### DIFF
--- a/app/api/slack/agent/actions/route.test.ts
+++ b/app/api/slack/agent/actions/route.test.ts
@@ -31,9 +31,12 @@ function signedRequest(payload: unknown, secret = 'test-slack-secret', extraHead
 }
 
 describe('POST /api/slack/agent/actions', () => {
+  const originalFetch = global.fetch
+
   beforeEach(() => {
     vi.clearAllMocks()
     process.env = { ...ORIGINAL_ENV, SLACK_SIGNING_SECRET: 'test-slack-secret' }
+    global.fetch = vi.fn().mockResolvedValue(new Response(null, { status: 200 }))
     mocks.handleSlackAgentAction.mockResolvedValue({
       responseType: 'ephemeral',
       text: 'Approved from Slack.',
@@ -42,6 +45,7 @@ describe('POST /api/slack/agent/actions', () => {
 
   afterEach(() => {
     process.env = ORIGINAL_ENV
+    global.fetch = originalFetch
   })
 
   it('rejects invalid Slack signatures', async () => {
@@ -103,5 +107,29 @@ describe('POST /api/slack/agent/actions', () => {
       replace_original: false,
     })
     expect(mocks.handleSlackAgentAction).toHaveBeenCalledWith(payload)
+  })
+
+  it('posts visible button feedback through the Slack response URL', async () => {
+    const payload = {
+      type: 'block_actions',
+      user: { id: 'U123', username: 'vambah' },
+      response_url: 'https://hooks.slack.com/actions/test-response',
+      actions: [{ action_id: 'agent_approval_approve', value: '{"action":"approval.approve","approvalId":"approval-1"}' }],
+    }
+
+    const response = await POST(signedRequest(payload) as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe('')
+    expect(mocks.handleSlackAgentAction).toHaveBeenCalledWith(payload)
+    expect(global.fetch).toHaveBeenCalledWith('https://hooks.slack.com/actions/test-response', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        response_type: 'ephemeral',
+        replace_original: false,
+        text: 'Approved from Slack.',
+      }),
+    })
   })
 })

--- a/app/api/slack/agent/actions/route.ts
+++ b/app/api/slack/agent/actions/route.ts
@@ -45,16 +45,49 @@ export async function POST(request: NextRequest) {
     }
 
     const result = await handleSlackAgentAction(payload)
-    return NextResponse.json({
-      response_type: result.responseType,
-      text: result.text,
-      replace_original: result.replaceOriginal ?? false,
-    })
+    if (payload.response_url) {
+      await postSlackActionResponse(payload.response_url, result)
+      return new NextResponse(null, { status: 200 })
+    }
+
+    return slackActionJsonResponse(result)
   } catch (error) {
     console.error('Error in Slack agent action handler:', error)
-    return NextResponse.json({
+    return slackActionJsonResponse({
       response_type: 'ephemeral',
       text: 'Agent Ops could not complete that Slack action. Check Portfolio logs and try again.',
     })
+  }
+}
+
+function slackActionJsonResponse(result: {
+  responseType?: 'ephemeral' | 'in_channel'
+  response_type?: 'ephemeral' | 'in_channel'
+  text: string
+  replaceOriginal?: boolean
+}) {
+  return NextResponse.json({
+    response_type: result.responseType ?? result.response_type ?? 'ephemeral',
+    text: result.text,
+    replace_original: result.replaceOriginal ?? false,
+  })
+}
+
+async function postSlackActionResponse(
+  responseUrl: string,
+  result: Awaited<ReturnType<typeof handleSlackAgentAction>>,
+) {
+  try {
+    await fetch(responseUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        response_type: result.responseType,
+        replace_original: result.replaceOriginal ?? false,
+        text: result.text,
+      }),
+    })
+  } catch (error) {
+    console.error('Error posting Slack agent action response:', error)
   }
 }


### PR DESCRIPTION
## Summary
- send Slack Agent Ops button action results through the interaction payload response_url
- preserve the direct JSON response fallback when Slack does not provide a response URL
- add route coverage for visible button feedback delivery

## Validation
- npm test -- --run app/api/slack/agent/actions/route.test.ts lib/agent-slack-actions.test.ts app/api/slack/agent/route.test.ts lib/agent-slack-command.test.ts
- npx tsc --noEmit --pretty false
- git diff --check
- pre-push database health check passed