### PR TITLE
feat: add engagement insight mobile actions

### DIFF
--- a/app/admin/agents/page.tsx
+++ b/app/admin/agents/page.tsx
@@ -377,7 +377,7 @@ type AutomationGoalSummary = {
 }
 
 type OperatorActionKind = 'morning-review' | 'hermes' | 'approval-drill' | 'runtime-evaluation'
-type SlackNotificationKind = 'pending_approvals' | 'blockers' | 'stale_runs' | 'review_ready' | 'goal_decisions'
+type SlackNotificationKind = 'pending_approvals' | 'blockers' | 'stale_runs' | 'review_ready' | 'goal_decisions' | 'high_signal_insights'
 
 const OPERATOR_ACTIONS: Array<{
   kind: OperatorActionKind
@@ -1437,6 +1437,7 @@ function SlackMobileBridgePanel({
     { kind: 'blockers', label: 'Send blockers', description: 'Blocked work with owner and next step context.' },
     { kind: 'stale_runs', label: 'Send stale runs', description: 'Failed or stale traces with recovery triage.' },
     { kind: 'goal_decisions', label: 'Send goal decisions', description: 'Goal-tagged tasks waiting on a human call.' },
+    { kind: 'high_signal_insights', label: 'Send insights', description: 'Engagement-ranked AI themes with safe research actions.' },
   ]
 
   return (

--- a/app/api/admin/agents/slack-notifications/route.test.ts
+++ b/app/api/admin/agents/slack-notifications/route.test.ts
@@ -97,4 +97,15 @@ describe('POST /api/admin/agents/slack-notifications', () => {
       triggerSource: 'admin_agent_slack_notification',
     }))
   })
+
+  it('accepts high-signal insight mobile packets', async () => {
+    const response = await POST(request({ kind: 'high_signal_insights' }) as never)
+
+    expect(response.status).toBe(200)
+    expect(mocks.sendAgentSlackNotification).toHaveBeenCalledWith(expect.objectContaining({
+      kind: 'high_signal_insights',
+      actorLabel: 'admin@example.com',
+      triggerSource: 'admin_agent_slack_notification',
+    }))
+  })
 })

--- a/app/api/admin/agents/slack-notifications/route.ts
+++ b/app/api/admin/agents/slack-notifications/route.ts
@@ -13,6 +13,7 @@ const VALID_KINDS = new Set<AgentSlackNotificationKind>([
   'stale_runs',
   'review_ready',
   'goal_decisions',
+  'high_signal_insights',
   'standup_blockers',
   'selected_agent_question',
 ])

--- a/lib/agent-slack-actions.test.ts
+++ b/lib/agent-slack-actions.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   claimAgentWorkItem: vi.fn(),
   getAgentWorkItem: vi.fn(),
   handoffAgentWorkItem: vi.fn(),
+  createAgentWorkItem: vi.fn(),
   markAgentWorkItemReadyForKanban: vi.fn(),
   recordAgentWorkItemBlocker: vi.fn(),
   routeAgentInboxItem: vi.fn(),
@@ -26,6 +27,7 @@ vi.mock('@/lib/agent-run', () => ({
 
 vi.mock('@/lib/agent-work-items', () => ({
   claimAgentWorkItem: mocks.claimAgentWorkItem,
+  createAgentWorkItem: mocks.createAgentWorkItem,
   getAgentWorkItem: mocks.getAgentWorkItem,
   handoffAgentWorkItem: mocks.handoffAgentWorkItem,
   markAgentWorkItemReadyForKanban: mocks.markAgentWorkItemReadyForKanban,
@@ -107,6 +109,27 @@ describe('Agent Ops Slack actions', () => {
     expect(recordedActionQuery.maybeSingle).toHaveBeenCalled()
     expect(mocks.claimAgentWorkItem).not.toHaveBeenCalled()
     expect(mocks.recordAgentEvent).not.toHaveBeenCalled()
+  })
+
+  it('uses content id in Slack action idempotency keys for insight buttons', async () => {
+    const recordedActionQuery = queryResult({
+      data: { id: 'event-1' },
+      error: null,
+    })
+    mocks.from.mockReturnValueOnce(recordedActionQuery)
+
+    const result = await handleSlackAgentAction(payload({
+      action: 'insight.draft_autoresearch',
+      contentId: 'content-1',
+      note: 'Theme: Agentic Operating System',
+    }))
+
+    expect(result.text).toContain('Already handled this Slack action')
+    expect(recordedActionQuery.eq).toHaveBeenCalledWith(
+      'idempotency_key',
+      'slack-agent-action:U123:1716400000.000:insight.draft_autoresearch:content-1',
+    )
+    expect(mocks.createAgentWorkItem).not.toHaveBeenCalled()
   })
 
   it('requires Portfolio review for high-risk approvals', async () => {
@@ -251,5 +274,62 @@ describe('Agent Ops Slack actions', () => {
     }))
     expect(result.text).toContain('heartbeat stopped')
     expect(result.text).toContain('/admin/agents/runs/shaka-run')
+  })
+
+  it('asks Shaka for a high-signal insight next-step recommendation without mutating work', async () => {
+    mocks.from.mockReturnValueOnce(queryResult({ data: null, error: null }))
+    mocks.runChiefOfStaffChat.mockResolvedValue({
+      reply: 'Draft a research proposal first; do not publish from Slack.',
+      runId: 'shaka-insight-run',
+    })
+
+    const result = await handleSlackAgentAction(payload({
+      action: 'insight.ask_shaka',
+      contentId: 'content-1',
+      note: 'Theme: Agentic Operating System\nScore: 87\nRecommendation: Expand with adjacent AutoResearch',
+    }))
+
+    expect(mocks.runChiefOfStaffChat).toHaveBeenCalledWith(expect.objectContaining({
+      triggerSource: 'slack_agent_insight_action',
+      message: expect.stringContaining('Do not publish, schedule, send messages, activate workflows, or mutate customer data.'),
+    }))
+    expect(mocks.createAgentWorkItem).not.toHaveBeenCalled()
+    expect(result.text).toContain('Draft a research proposal first')
+    expect(result.text).toContain('/admin/agents/runs/shaka-insight-run')
+  })
+
+  it('drafts a proposed AutoResearch work item from a high-signal insight Slack action', async () => {
+    mocks.from.mockReturnValueOnce(queryResult({ data: null, error: null }))
+    mocks.createAgentWorkItem.mockResolvedValue({
+      id: 'work-insight-1',
+      title: 'AutoResearch follow-up for high-signal insight',
+    })
+
+    const result = await handleSlackAgentAction(payload({
+      action: 'insight.draft_autoresearch',
+      contentId: 'content-1',
+      agentKey: 'research-source-register',
+      note: 'Theme: Agentic Operating System\nScore: 87\nRecommendation: Expand with adjacent AutoResearch',
+    }))
+
+    expect(mocks.createAgentWorkItem).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'AutoResearch follow-up for high-signal insight',
+      status: 'proposed',
+      priority: 'high',
+      ownerAgentKey: 'research-source-register',
+      source: expect.objectContaining({
+        type: 'social_content_engagement_signal',
+        id: 'content-1',
+      }),
+      metadata: expect.objectContaining({
+        created_from_slack_action: true,
+        social_content_id: 'content-1',
+        approval_boundary: expect.stringContaining('No publishing, scheduling, outbound sends'),
+      }),
+      idempotencyKey: 'slack-insight-autoresearch:content-1',
+    }))
+    expect(mocks.runChiefOfStaffChat).not.toHaveBeenCalled()
+    expect(result.text).toContain('Drafted proposed AutoResearch work item')
+    expect(result.text).toContain('/admin/agents/swarm-board?work_item=work-insight-1')
   })
 })

--- a/lib/agent-slack-actions.ts
+++ b/lib/agent-slack-actions.ts
@@ -2,6 +2,7 @@ import { runChiefOfStaffChat } from '@/lib/chief-of-staff-chat'
 import { recordAgentEvent } from '@/lib/agent-run'
 import {
   claimAgentWorkItem,
+  createAgentWorkItem,
   getAgentWorkItem,
   handoffAgentWorkItem,
   markAgentWorkItemReadyForKanban,
@@ -66,6 +67,10 @@ function agentRunsUrl(runId?: string | null) {
   return `${baseUrl()}/admin/agents/runs${runId ? `/${runId}` : ''}`
 }
 
+function agentKanbanUrl() {
+  return `${baseUrl()}/admin/agents/swarm-board`
+}
+
 function allowedSlackUserIds() {
   const raw =
     process.env.SLACK_AGENT_OPS_ALLOWED_USER_IDS ||
@@ -112,7 +117,7 @@ function idempotencyKey(payload: SlackInteractivePayload, value: SlackAgentActio
     payload.user?.id ?? 'unknown-user',
     payload.container?.message_ts ?? payload.message?.ts ?? payload.action_ts ?? 'unknown-ts',
     value.action,
-    value.approvalId ?? value.workItemId ?? value.runId ?? 'unknown-target',
+    value.approvalId ?? value.workItemId ?? value.runId ?? value.contentId ?? 'unknown-target',
   ].join(':')
 }
 
@@ -445,6 +450,57 @@ export async function handleSlackAgentAction(payload: SlackInteractivePayload): 
       contextRef,
     })
     return { responseType: 'ephemeral', text: `${result.reply}\n\nTrace: ${agentRunsUrl(result.runId)}` }
+  }
+
+  if (value.action === 'insight.ask_shaka') {
+    const note = value.note?.trim()
+    if (!value.contentId || !note) return { responseType: 'ephemeral', text: 'Missing insight packet.' }
+    const result = await runChiefOfStaffChat({
+      message: [
+        'Use this high-signal social engagement packet to recommend the safest mobile next step.',
+        'Do not publish, schedule, send messages, activate workflows, or mutate customer data.',
+        '',
+        note,
+      ].join('\n'),
+      userId: `slack:${authorization.userId}`,
+      triggerSource: 'slack_agent_insight_action',
+    })
+    return { responseType: 'ephemeral', text: `${result.reply}\n\nTrace: ${agentRunsUrl(result.runId)}` }
+  }
+
+  if (value.action === 'insight.draft_autoresearch') {
+    const note = value.note?.trim()
+    if (!value.contentId || !note) return { responseType: 'ephemeral', text: 'Missing insight packet.' }
+    const item = await createAgentWorkItem({
+      title: `AutoResearch follow-up for high-signal insight`,
+      objective: [
+        'Draft a proposal packet for adjacent research prompted by an engagement-ranked Social Content insight.',
+        'The output should identify the evidence gap, adjacent AI insight angle, recommended source path, acceptance criteria, and publishing boundary.',
+        '',
+        note,
+      ].join('\n'),
+      status: 'proposed',
+      priority: 'high',
+      ownerAgentKey: value.agentKey || 'research-source-register',
+      source: {
+        type: 'social_content_engagement_signal',
+        id: value.contentId,
+        label: 'High-signal AI insight',
+      },
+      metadata: {
+        created_from_slack_action: true,
+        slack_user_id: authorization.userId,
+        actor_label: authorization.actorLabel,
+        social_content_id: value.contentId,
+        insight_packet: note,
+        approval_boundary: 'Proposal only. No publishing, scheduling, outbound sends, workflow activation, credential changes, customer-data mutation, or production action.',
+      },
+      idempotencyKey: `slack-insight-autoresearch:${value.contentId}`,
+    })
+    return {
+      responseType: 'ephemeral',
+      text: `Drafted proposed AutoResearch work item: ${item.title}. Kanban: ${agentKanbanUrl()}?work_item=${encodeURIComponent(item.id)}`,
+    }
   }
 
   if (value.workItemId) {

--- a/lib/agent-slack-blocks.ts
+++ b/lib/agent-slack-blocks.ts
@@ -50,6 +50,7 @@ export type SlackAgentActionValue = {
   runId?: string
   workItemId?: string
   agentKey?: string
+  contentId?: string
   note?: string
 }
 

--- a/lib/agent-slack-command.test.ts
+++ b/lib/agent-slack-command.test.ts
@@ -145,6 +145,8 @@ describe('agent Slack command parsing', () => {
     expect(agentSlackCommandInternals.commandFromText('captain')).toBe('captain')
     expect(agentSlackCommandInternals.commandFromText('inbox')).toBe('inbox')
     expect(agentSlackCommandInternals.commandFromText('brief')).toBe('brief')
+    expect(agentSlackCommandInternals.commandFromText('insights')).toBe('insights')
+    expect(agentSlackCommandInternals.commandFromText('signals')).toBe('insights')
     expect(agentSlackCommandInternals.commandFromText('route 1')).toBe('route')
     expect(agentSlackCommandInternals.commandFromText('run chief-of-staff')).toBe('run')
     expect(agentSlackCommandInternals.commandFromText('standup')).toBe('standup')
@@ -163,6 +165,7 @@ describe('agent Slack command parsing', () => {
     expect(agentSlackCommandInternals.formatHelp()).toContain('/agent inbox')
     expect(agentSlackCommandInternals.formatHelp()).toContain('/agent route <number-or-id>')
     expect(agentSlackCommandInternals.formatHelp()).toContain('/agent standup')
+    expect(agentSlackCommandInternals.formatHelp()).toContain('/agent insights')
   })
 
   it('formats the mapped agent list for Slack', () => {
@@ -321,6 +324,48 @@ describe('agent Slack command parsing', () => {
     expect(text).toContain('Daily Operating Brief')
     expect(text).toContain('Chief of Staff recommends')
     expect(text).toContain('/admin/agents/runs/standup-run')
+  })
+
+  it('returns actionable high-signal insight cards for Slack', async () => {
+    inboxMocks.buildAgentMissionControlSnapshot.mockResolvedValue({
+      high_signal_ai_insights: [
+        {
+          contentId: 'content-1',
+          title: 'Anyone can launch an agent now',
+          theme: 'Agentic Operating System',
+          score: 87,
+          recommendation: 'expand',
+          recommendationLabel: 'Expand with adjacent AutoResearch',
+          ownerAgentKey: 'research-source-register',
+          bestContentHref: '/admin/social-content/content-1',
+          bestContentUrl: 'https://linkedin.com/posts/example',
+          sourcePrdHref: '/docs/agentic-content-research-prds/01-agentic-operating-system-overview.md',
+          capturedAt: '2026-06-04T10:00:00.000Z',
+          metrics: {
+            impressions: 1200,
+            views: null,
+            reactions: 42,
+            likes: 40,
+            comments: 9,
+            shares: 3,
+            reposts: 2,
+            engagementRate: 0.0467,
+          },
+        },
+      ],
+    })
+
+    const result = await handleAgentSlackCommand({ text: 'insights' })
+    const blocks = JSON.stringify(result.blocks)
+
+    expect(result.text).toContain('High-signal AI insights')
+    expect(result.text).toContain('Agentic Operating System')
+    expect(blocks).toContain('Draft AutoResearch')
+    expect(blocks).toContain('insight.draft_autoresearch')
+    expect(blocks).toContain('Ask Shaka')
+    expect(blocks).toContain('Open detail')
+    expect(blocks).toContain('/admin/social-content/content-1')
+    expect(blocks).toContain('No publishing, scheduling, outbound sends')
   })
 
   it('formats Moremi risk monitor status for Slack', async () => {

--- a/lib/agent-slack-command.ts
+++ b/lib/agent-slack-command.ts
@@ -4,6 +4,10 @@ import { routeAgentInboxItem } from '@/lib/agent-inbox-routing'
 import { buildAgentMissionControlSnapshot } from '@/lib/agent-mission-control'
 import { runAgentWarRoom } from '@/lib/agent-war-room'
 import { AGENT_ORGANIZATION, getAgentByKey } from '@/lib/agent-organization'
+import {
+  highSignalInsightsSlackBlocks,
+  highSignalInsightsSlackText,
+} from '@/lib/agent-slack-insights'
 import { supabaseAdmin } from '@/lib/supabase'
 import {
   claimAgentWorkItem,
@@ -34,6 +38,7 @@ type SlackCommandName =
   | 'risk'
   | 'agents'
   | 'engagements'
+  | 'insights'
   | 'work-items'
   | 'claim'
   | 'handoff'
@@ -119,6 +124,7 @@ function commandFromText(text: string): SlackCommandName {
   if (command === 'risk' || command === 'moremi') return 'risk'
   if (command === 'agents' || command === 'list') return 'agents'
   if (command === 'engagements' || command === 'queue') return 'engagements'
+  if (command === 'insights' || command === 'signals') return 'insights'
   if (command === 'work') return 'work-items'
   if (command === 'claim') return 'claim'
   if (command === 'handoff') return 'handoff'
@@ -149,6 +155,7 @@ function formatHelp() {
     '`/agent risk review create_moremi_warning_work_items` - create or reuse proposed work items from latest Moremi warnings.',
     '`/agent agents` - list currently mapped agents and engagement keys.',
     '`/agent engagements` - show the latest routed engagement work queue.',
+    '`/agent insights` - show high-signal AI insight themes and mobile-safe research actions.',
     '`/agent work [id]` - show coordination work items or one work packet.',
     '`/agent claim <id> [agent-key]` - claim a coordination work item.',
     '`/agent handoff <id> <agent-key>` - request an agent-to-agent handoff.',
@@ -678,6 +685,23 @@ export async function buildAgentEngagementQueueSlackText(limit = 5) {
   }
 }
 
+export async function buildHighSignalInsightsSlackResult(): Promise<AgentSlackCommandResult> {
+  try {
+    const snapshot = await buildAgentMissionControlSnapshot()
+    const insights = snapshot.high_signal_ai_insights ?? []
+    return {
+      responseType: 'ephemeral',
+      text: highSignalInsightsSlackText(insights),
+      blocks: highSignalInsightsSlackBlocks({ insights, baseUrl: baseUrl() }),
+    }
+  } catch (error) {
+    return {
+      responseType: 'ephemeral',
+      text: `High-signal insight lookup failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    }
+  }
+}
+
 export async function buildAgentInboxSlackText(limit = 5) {
   try {
     const snapshot = await buildAgentMissionControlSnapshot()
@@ -1146,6 +1170,7 @@ export async function handleAgentSlackCommand(input: AgentSlackCommandInput): Pr
   if (command === 'work-items') return buildAgentWorkItemsSlackResult(input)
   if (command === 'blockers') return buildAgentBlockersSlackResult()
   if (command === 'inbox') return buildAgentInboxSlackResult()
+  if (command === 'insights') return buildHighSignalInsightsSlackResult()
 
   const text =
     command === 'status'

--- a/lib/agent-slack-insights.ts
+++ b/lib/agent-slack-insights.ts
@@ -1,0 +1,116 @@
+import { mrkdwn, slackButton, truncateSlack, type SlackBlock } from '@/lib/agent-slack-blocks'
+import type { HighSignalInsight } from '@/lib/social-engagement'
+
+function insightDetailUrl(baseUrl: string, insight: HighSignalInsight) {
+  const path = insight.bestContentHref || `/admin/social-content/${insight.contentId}`
+  if (path.startsWith('http://') || path.startsWith('https://')) return path
+  return `${baseUrl}${path}`
+}
+
+function insightActionNote(insight: HighSignalInsight) {
+  return [
+    `Theme: ${insight.theme}`,
+    `Title: ${insight.title}`,
+    `Score: ${insight.score}`,
+    `Recommendation: ${insight.recommendationLabel}`,
+    `Metrics: ${insight.metrics.comments} comments, ${insight.metrics.shares + insight.metrics.reposts} shares, ${insight.metrics.reactions || insight.metrics.likes} reactions.`,
+    `Owner agent: ${insight.ownerAgentKey}`,
+    insight.sourcePrdHref ? `Source PRD: ${insight.sourcePrdHref}` : null,
+  ].filter(Boolean).join('\n')
+}
+
+export function highSignalInsightsSlackText(insights: HighSignalInsight[]) {
+  if (!insights.length) {
+    return 'No high-signal AI insight engagement packets are ready yet. Refresh LinkedIn engagement metrics from Social Content first.'
+  }
+
+  return [
+    '*High-signal AI insights*',
+    ...insights.slice(0, 3).map((insight, index) => {
+      const metrics = `${insight.metrics.comments} comments, ${insight.metrics.shares + insight.metrics.reposts} shares, ${insight.metrics.reactions || insight.metrics.likes} reactions`
+      return `${index + 1}. *${insight.theme}* - ${insight.score}\n   ${truncateSlack(insight.title, 120)}\n   ${insight.recommendationLabel}; ${metrics}`
+    }),
+  ].join('\n')
+}
+
+export function highSignalInsightsSlackBlocks(input: {
+  insights: HighSignalInsight[]
+  baseUrl: string
+}): SlackBlock[] {
+  const { insights, baseUrl } = input
+  const blocks: SlackBlock[] = [
+    {
+      type: 'section',
+      text: mrkdwn('*High-signal AI insights*\nEngagement-ranked AI insight themes from published Social Content. Slack can draft proposed research work; publishing and outbound actions stay gated in Portfolio.'),
+    },
+  ]
+
+  if (!insights.length) {
+    blocks.push({
+      type: 'section',
+      text: mrkdwn('No high-signal insight packets are ready yet. Refresh engagement metrics from a published LinkedIn Social Content item first.'),
+    })
+    blocks.push({
+      type: 'actions',
+      elements: [
+        slackButton({ label: 'Open Social Content', actionId: 'open_social_content', url: `${baseUrl}/admin/social-content?status=published&platform=linkedin` }),
+      ],
+    })
+    return blocks
+  }
+
+  insights.slice(0, 3).forEach((insight) => {
+    const note = insightActionNote(insight)
+    blocks.push({
+      type: 'section',
+      text: mrkdwn([
+        `*${truncateSlack(insight.theme, 90)}* - Score ${insight.score}`,
+        truncateSlack(insight.title, 150),
+        `Recommendation: *${insight.recommendationLabel}*`,
+        `Signal: ${insight.metrics.comments} comments - ${insight.metrics.shares + insight.metrics.reposts} shares - ${insight.metrics.reactions || insight.metrics.likes} reactions`,
+        '_Boundary: No publishing, scheduling, outbound sends, workflow activation, credential changes, or customer-data mutation from Slack._',
+      ].join('\n')),
+    })
+    blocks.push({
+      type: 'actions',
+      elements: [
+        slackButton({
+          label: 'Draft AutoResearch',
+          actionId: 'agent_insight_draft_autoresearch',
+          style: 'primary',
+          value: {
+            action: 'insight.draft_autoresearch',
+            contentId: insight.contentId,
+            agentKey: insight.ownerAgentKey,
+            note,
+          },
+          confirmText: `Create a proposed Agent Ops research task for ${insight.theme}?`,
+        }),
+        slackButton({
+          label: 'Ask Shaka',
+          actionId: 'agent_insight_ask_shaka',
+          value: {
+            action: 'insight.ask_shaka',
+            contentId: insight.contentId,
+            note,
+          },
+        }),
+        slackButton({
+          label: 'Open detail',
+          actionId: 'open_social_content_detail',
+          url: insightDetailUrl(baseUrl, insight),
+        }),
+      ],
+    })
+  })
+
+  blocks.push({
+    type: 'actions',
+    elements: [
+      slackButton({ label: 'Open Mission Control', actionId: 'open_mission_control', url: `${baseUrl}/admin/agents` }),
+      slackButton({ label: 'Open Social Content', actionId: 'open_social_content', url: `${baseUrl}/admin/social-content?status=published&platform=linkedin` }),
+    ],
+  })
+
+  return blocks
+}

--- a/lib/agent-slack-notifications.test.ts
+++ b/lib/agent-slack-notifications.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   from: vi.fn(),
   listAgentWorkItems: vi.fn(),
+  buildAgentMissionControlSnapshot: vi.fn(),
   startAgentRun: vi.fn(),
   recordAgentEvent: vi.fn(),
   endAgentRun: vi.fn(),
@@ -14,6 +15,10 @@ vi.mock('@/lib/supabase', () => ({
 
 vi.mock('@/lib/agent-work-items', () => ({
   listAgentWorkItems: mocks.listAgentWorkItems,
+}))
+
+vi.mock('@/lib/agent-mission-control', () => ({
+  buildAgentMissionControlSnapshot: mocks.buildAgentMissionControlSnapshot,
 }))
 
 vi.mock('@/lib/agent-run', () => ({
@@ -46,6 +51,9 @@ describe('Agent Ops Slack notifications', () => {
     mocks.startAgentRun.mockResolvedValue({ id: 'run-1' })
     mocks.recordAgentEvent.mockResolvedValue({ id: 'event-1' })
     mocks.endAgentRun.mockResolvedValue(undefined)
+    mocks.buildAgentMissionControlSnapshot.mockResolvedValue({
+      high_signal_ai_insights: [],
+    })
     mocks.listAgentWorkItems.mockResolvedValue([
       {
         id: 'work-1',
@@ -432,5 +440,52 @@ describe('Agent Ops Slack notifications', () => {
     expect(JSON.stringify(payload.blocks)).toContain('Askia Muhammad (Songhai) - Research Source Register')
     expect(JSON.stringify(payload.blocks)).toContain('No active Kanban cards are currently assigned')
     expect(JSON.stringify(payload.blocks)).toContain('/admin/agents/standup')
+  })
+
+  it('sends high-signal insight packets with mobile-safe research actions', async () => {
+    process.env.SLACK_AGENT_OPS_WEBHOOK_URL = 'https://hooks.slack.test/agent'
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+    vi.stubGlobal('fetch', fetchMock)
+    mocks.buildAgentMissionControlSnapshot.mockResolvedValueOnce({
+      high_signal_ai_insights: [
+        {
+          contentId: 'content-1',
+          title: 'Anyone can launch an agent now',
+          theme: 'Agentic Operating System',
+          score: 87,
+          recommendation: 'expand',
+          recommendationLabel: 'Expand with adjacent AutoResearch',
+          ownerAgentKey: 'research-source-register',
+          bestContentHref: '/admin/social-content/content-1',
+          bestContentUrl: 'https://linkedin.com/posts/example',
+          sourcePrdHref: '/docs/agentic-content-research-prds/01-agentic-operating-system-overview.md',
+          capturedAt: '2026-06-04T10:00:00.000Z',
+          metrics: {
+            impressions: 1200,
+            views: null,
+            reactions: 42,
+            likes: 40,
+            comments: 9,
+            shares: 3,
+            reposts: 2,
+            engagementRate: 0.0467,
+          },
+        },
+      ],
+    })
+
+    const result = await sendAgentSlackNotification({ kind: 'high_signal_insights' })
+
+    expect(result).toMatchObject({
+      sent: true,
+      itemCount: 1,
+      text: expect.stringContaining('High-signal AI insights'),
+    })
+    const payload = JSON.parse(fetchMock.mock.calls[0][1].body)
+    const blocks = JSON.stringify(payload.blocks)
+    expect(blocks).toContain('Draft AutoResearch')
+    expect(blocks).toContain('insight.draft_autoresearch')
+    expect(blocks).toContain('Ask Shaka')
+    expect(blocks).toContain('/admin/social-content/content-1')
   })
 })

--- a/lib/agent-slack-notifications.ts
+++ b/lib/agent-slack-notifications.ts
@@ -2,6 +2,11 @@ import { endAgentRun, recordAgentEvent, startAgentRun } from '@/lib/agent-run'
 import { listAgentWorkItems, type AgentWorkItem } from '@/lib/agent-work-items'
 import { AGENT_ORGANIZATION } from '@/lib/agent-organization'
 import { mrkdwn, slackButton, truncateSlack, type SlackBlock } from '@/lib/agent-slack-blocks'
+import { buildAgentMissionControlSnapshot } from '@/lib/agent-mission-control'
+import {
+  highSignalInsightsSlackBlocks,
+  highSignalInsightsSlackText,
+} from '@/lib/agent-slack-insights'
 import { supabaseAdmin } from '@/lib/supabase'
 
 export type AgentSlackNotificationKind =
@@ -10,6 +15,7 @@ export type AgentSlackNotificationKind =
   | 'stale_runs'
   | 'review_ready'
   | 'goal_decisions'
+  | 'high_signal_insights'
   | 'standup_blockers'
   | 'selected_agent_question'
 
@@ -391,6 +397,16 @@ async function buildStaleRunsPayload() {
   }
 }
 
+async function buildHighSignalInsightsPayload() {
+  const snapshot = await buildAgentMissionControlSnapshot()
+  const insights = snapshot.high_signal_ai_insights ?? []
+  return {
+    text: highSignalInsightsSlackText(insights),
+    blocks: highSignalInsightsSlackBlocks({ insights, baseUrl: baseUrl() }),
+    itemCount: insights.length,
+  }
+}
+
 async function buildWorkItemPayload(input: AgentSlackNotificationInput) {
   const targetAgentKeys = normalizeTargetAgentKeys(input.targetAgentKeys)
   const allItems = await listAgentWorkItems({ limit: 75 })
@@ -444,6 +460,7 @@ async function buildWorkItemPayload(input: AgentSlackNotificationInput) {
 export async function buildAgentSlackNotificationPayload(input: AgentSlackNotificationInput) {
   if (input.kind === 'pending_approvals') return buildPendingApprovalPayload()
   if (input.kind === 'stale_runs') return buildStaleRunsPayload()
+  if (input.kind === 'high_signal_insights') return buildHighSignalInsightsPayload()
   return buildWorkItemPayload(input)
 }
 


### PR DESCRIPTION
## Summary
- Add `/agent insights` Slack command rendering high-signal AI insight cards from Mission Control engagement data.
- Add a Mission Control Slack Mobile Bridge action for sending high-signal insights to Slack.
- Add mobile-safe Slack actions to ask Shaka about an insight or create a proposed AutoResearch follow-up work item.
- Make the Slack cards explicit that publishing, scheduling, outbound sends, workflow activation, credential changes, and customer-data mutation remain gated outside Slack.

## Validation
- `npm test -- lib/agent-slack-command.test.ts lib/agent-slack-notifications.test.ts lib/agent-slack-actions.test.ts app/api/admin/agents/slack-notifications/route.test.ts app/admin/agents/page.test.tsx`
- `npm run build:knowledge` to restore the generated local knowledge module required by typecheck in this clean worktree
- `npx tsc --noEmit --pretty false`
- `npm run lint`
- No live Slack click smoke or customer-data workflow smoke was run.

## Integration Notes
- No schema migration.
- No new env vars.
- This is proposal-only for AutoResearch; Slack does not publish, schedule, send outbound messages, activate n8n, change credentials, mutate customer data, or perform production actions.
- Existing open PR #503 touches the Slack actions API route; this PR touches shared action handlers and command/notification rendering. Integration Captain should merge #503 first if preserving response-url feedback sequencing.
- Vercel contexts checked pre-PR: not run in this non-captain slice.
  - Vercel – portfolio: not checked
  - Vercel – portfolio-staging: not checked