### PR TITLE
feat: add social launch draft seeding

### DIFF
--- a/app/admin/social-content/page.tsx
+++ b/app/admin/social-content/page.tsx
@@ -95,6 +95,19 @@ interface VoiceNoteIntake {
   created_at: string
 }
 
+interface LaunchDraftSeedLink {
+  id: string
+  assetId: string | null
+  href: string
+}
+
+interface LaunchDraftSeedResult {
+  success: boolean
+  message: string
+  inserted: LaunchDraftSeedLink[]
+  existing: LaunchDraftSeedLink[]
+}
+
 const VOICE_NOTE_OUTPUTS = [
   { value: 'linkedin_post', label: 'LinkedIn' },
   { value: 'linkedin_carousel', label: 'Carousel' },
@@ -117,6 +130,8 @@ function SocialContentQueuePage() {
   const [platformFilter, setPlatformFilter] = useState<SocialPlatform | 'all'>('all')
   const [search, setSearch] = useState('')
   const [actionLoading, setActionLoading] = useState<string | null>(null)
+  const [launchDraftSeeding, setLaunchDraftSeeding] = useState(false)
+  const [launchDraftResult, setLaunchDraftResult] = useState<LaunchDraftSeedResult | null>(null)
 
   // Extraction trigger state
   const [meetings, setMeetings] = useState<MeetingRecord[]>([])
@@ -448,6 +463,43 @@ function SocialContentQueuePage() {
     }
   }
 
+  const seedLaunchDrafts = async () => {
+    setLaunchDraftSeeding(true)
+    setLaunchDraftResult(null)
+    try {
+      const session = await getCurrentSession()
+      if (!session) return
+      const res = await fetch('/api/admin/social-content/launch-drafts', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${session.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({}),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to seed launch drafts')
+      setLaunchDraftResult({
+        success: true,
+        message: `${data.summary?.inserted ?? 0} launch draft${data.summary?.inserted === 1 ? '' : 's'} created. ${data.summary?.existing ?? 0} already existed.`,
+        inserted: data.inserted ?? [],
+        existing: data.existing ?? [],
+      })
+      setStatusFilter('draft')
+      setPlatformFilter('linkedin')
+      await fetchItems(1)
+    } catch (err) {
+      setLaunchDraftResult({
+        success: false,
+        message: err instanceof Error ? err.message : 'Failed to seed launch drafts.',
+        inserted: [],
+        existing: [],
+      })
+    } finally {
+      setLaunchDraftSeeding(false)
+    }
+  }
+
   const handleQuickApprove = async (e: React.MouseEvent, itemId: string) => {
     e.preventDefault()
     e.stopPropagation()
@@ -528,6 +580,50 @@ function SocialContentQueuePage() {
             {AGENTIC_SOCIAL_REVIEW_PACKETS.length} ready
           </span>
         </div>
+
+        <div className="mt-4 flex flex-col gap-3 rounded-lg border border-silicon-slate/80 bg-background/35 p-4 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <h3 className="text-sm font-semibold text-gray-200">Seed launch-week drafts</h3>
+            <p className="mt-1 max-w-2xl text-xs leading-5 text-muted-foreground">
+              Create draft-only Social Content rows from the challenger-cleared launch packet. This does not schedule, publish, send outreach, generate visuals, or call providers.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={seedLaunchDrafts}
+            disabled={launchDraftSeeding}
+            className="admin-console-button-primary shrink-0 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {launchDraftSeeding ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+            {launchDraftSeeding ? 'Seeding...' : 'Seed Drafts'}
+          </button>
+        </div>
+
+        {launchDraftResult && (
+          <div className={`mt-3 rounded-lg border px-4 py-3 text-sm ${
+            launchDraftResult.success
+              ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300'
+              : 'border-red-500/30 bg-red-500/10 text-red-300'
+          }`}>
+            <div className="flex items-center gap-2">
+              {launchDraftResult.success ? <CheckCircle2 className="h-4 w-4" /> : <AlertCircle className="h-4 w-4" />}
+              <span>{launchDraftResult.message}</span>
+            </div>
+            {launchDraftResult.success && (launchDraftResult.inserted.length > 0 || launchDraftResult.existing.length > 0) && (
+              <div className="mt-2 flex flex-wrap gap-2">
+                {[...launchDraftResult.inserted, ...launchDraftResult.existing].map((draft) => (
+                  <Link
+                    key={`${draft.assetId ?? draft.id}:${draft.id}`}
+                    href={draft.href}
+                    className="inline-flex items-center gap-1 rounded-full border border-radiant-gold/30 px-2.5 py-1 text-xs text-radiant-gold hover:bg-radiant-gold/10"
+                  >
+                    Open draft <Eye className="h-3 w-3" />
+                  </Link>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
 
         <div className="mt-4 grid gap-3 lg:grid-cols-2">
           {AGENTIC_SOCIAL_REVIEW_PACKETS.map((packet) => (

--- a/app/api/admin/social-content/launch-drafts/route.test.ts
+++ b/app/api/admin/social-content/launch-drafts/route.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  from: vi.fn(),
+  selectForLookup: vi.fn(),
+  contains: vi.fn(),
+  insert: vi.fn(),
+  selectAfterInsert: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import { POST } from './route'
+
+function makeRequest(body: Record<string, unknown> = {}) {
+  return new NextRequest('http://localhost/api/admin/social-content/launch-drafts', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('POST /api/admin/social-content/launch-drafts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user-1' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.contains.mockResolvedValue({ data: [], error: null })
+    mocks.selectAfterInsert.mockResolvedValue({
+      data: [
+        {
+          id: 'social-1',
+          rag_context: { launch_draft_asset_id: 'p0-linkedin-flagship-agentic-operating-system' },
+        },
+      ],
+      error: null,
+    })
+    mocks.selectForLookup.mockReturnValue({ contains: mocks.contains })
+    mocks.insert.mockReturnValue({ select: mocks.selectAfterInsert })
+    mocks.from.mockReturnValue({
+      select: mocks.selectForLookup,
+      insert: mocks.insert,
+    })
+  })
+
+  it('requires admin auth before checking existing social drafts', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Authentication required', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(makeRequest())
+
+    expect(response.status).toBe(401)
+    expect(mocks.from).not.toHaveBeenCalled()
+  })
+
+  it('seeds missing launch drafts as draft-only social content rows', async () => {
+    const response = await POST(makeRequest({
+      asset_ids: ['p0-linkedin-flagship-agentic-operating-system'],
+    }))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      summary: { requested: 1, inserted: 1, existing: 0 },
+      inserted: [{
+        id: 'social-1',
+        assetId: 'p0-linkedin-flagship-agentic-operating-system',
+        href: '/admin/social-content/social-1',
+      }],
+    })
+    expect(mocks.insert).toHaveBeenCalledWith([
+      expect.objectContaining({
+        platform: 'linkedin',
+        status: 'draft',
+        post_text: expect.stringContaining('Anyone can launch an agent now.'),
+        rag_context: expect.objectContaining({
+          source: 'agentic_sales_outreach_launch_draft',
+          launch_draft_asset_id: 'p0-linkedin-flagship-agentic-operating-system',
+          approval_required_for: expect.arrayContaining(['publish', 'outbound_send']),
+        }),
+      }),
+    ])
+  })
+
+  it('returns existing seeded rows instead of duplicating them', async () => {
+    mocks.contains.mockResolvedValue({
+      data: [{
+        id: 'existing-social-1',
+        rag_context: { launch_draft_asset_id: 'p0-linkedin-flagship-agentic-operating-system' },
+      }],
+      error: null,
+    })
+
+    const response = await POST(makeRequest({
+      asset_ids: ['p0-linkedin-flagship-agentic-operating-system'],
+    }))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      summary: { requested: 1, inserted: 0, existing: 1 },
+      existing: [{
+        id: 'existing-social-1',
+        assetId: 'p0-linkedin-flagship-agentic-operating-system',
+        href: '/admin/social-content/existing-social-1',
+      }],
+    })
+    expect(mocks.insert).not.toHaveBeenCalled()
+  })
+
+  it('rejects unknown asset ids before writing rows', async () => {
+    const response = await POST(makeRequest({ asset_ids: ['unknown-asset'] }))
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({
+      error: 'Unknown launch draft asset id',
+      invalidAssetIds: ['unknown-asset'],
+    })
+    expect(mocks.insert).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/admin/social-content/launch-drafts/route.ts
+++ b/app/api/admin/social-content/launch-drafts/route.ts
@@ -1,0 +1,113 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { supabaseAdmin } from '@/lib/supabase'
+import {
+  AGENTIC_SOCIAL_LAUNCH_DRAFTS,
+  buildAgenticSocialLaunchDraftRow,
+  getAgenticSocialLaunchDraftByAssetId,
+} from '@/lib/agentic-social-launch-drafts'
+
+export const dynamic = 'force-dynamic'
+
+type SeedRequestBody = {
+  asset_ids?: string[]
+}
+
+type ExistingSeedRow = {
+  id: string
+  rag_context: Record<string, unknown> | null
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await verifyAdmin(request)
+    if (isAuthError(auth)) {
+      return NextResponse.json({ error: auth.error }, { status: auth.status })
+    }
+
+    const body = await request.json().catch(() => ({})) as SeedRequestBody
+    const requestedAssetIds = Array.isArray(body.asset_ids) && body.asset_ids.length > 0
+      ? body.asset_ids
+      : AGENTIC_SOCIAL_LAUNCH_DRAFTS.map((draft) => draft.assetId)
+
+    const invalidAssetIds = requestedAssetIds.filter((assetId) => !getAgenticSocialLaunchDraftByAssetId(assetId))
+    if (invalidAssetIds.length > 0) {
+      return NextResponse.json({
+        error: 'Unknown launch draft asset id',
+        invalidAssetIds,
+      }, { status: 400 })
+    }
+
+    const drafts = requestedAssetIds
+      .map((assetId) => getAgenticSocialLaunchDraftByAssetId(assetId))
+      .filter(Boolean) as typeof AGENTIC_SOCIAL_LAUNCH_DRAFTS
+
+    const { data: existingRows, error: existingError } = await supabaseAdmin
+      .from('social_content_queue')
+      .select('id, rag_context')
+      .contains('rag_context', { source: 'agentic_sales_outreach_launch_draft' })
+
+    if (existingError) {
+      console.error('[launch-drafts] existing seed lookup failed:', existingError)
+      return NextResponse.json({ error: 'Failed to check existing launch drafts' }, { status: 500 })
+    }
+
+    const existingByAssetId = new Map<string, string>()
+    for (const row of (existingRows ?? []) as ExistingSeedRow[]) {
+      const assetId = typeof row.rag_context?.launch_draft_asset_id === 'string'
+        ? row.rag_context.launch_draft_asset_id
+        : null
+      if (assetId) existingByAssetId.set(assetId, row.id)
+    }
+
+    const draftsToInsert = drafts.filter((draft) => !existingByAssetId.has(draft.assetId))
+    const rowsToInsert = draftsToInsert.map((draft) => buildAgenticSocialLaunchDraftRow(draft, auth.user.id))
+
+    let insertedRows: Array<{ id: string; rag_context: Record<string, unknown> | null }> = []
+    if (rowsToInsert.length > 0) {
+      const { data, error } = await supabaseAdmin
+        .from('social_content_queue')
+        .insert(rowsToInsert)
+        .select('id, rag_context')
+
+      if (error) {
+        console.error('[launch-drafts] social draft insert failed:', error)
+        return NextResponse.json({ error: 'Failed to seed launch drafts' }, { status: 500 })
+      }
+      insertedRows = (data ?? []) as typeof insertedRows
+    }
+
+    const inserted = insertedRows.map((row) => ({
+      id: row.id,
+      assetId: typeof row.rag_context?.launch_draft_asset_id === 'string'
+        ? row.rag_context.launch_draft_asset_id
+        : null,
+      href: `/admin/social-content/${row.id}`,
+    }))
+
+    const existing = drafts
+      .filter((draft) => existingByAssetId.has(draft.assetId))
+      .map((draft) => {
+        const id = existingByAssetId.get(draft.assetId)!
+        return {
+          id,
+          assetId: draft.assetId,
+          href: `/admin/social-content/${id}`,
+        }
+      })
+
+    return NextResponse.json({
+      success: true,
+      inserted,
+      existing,
+      summary: {
+        requested: drafts.length,
+        inserted: inserted.length,
+        existing: existing.length,
+      },
+    })
+  } catch (error) {
+    console.error('[launch-drafts] seed error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/lib/agentic-social-launch-drafts.test.ts
+++ b/lib/agentic-social-launch-drafts.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AGENTIC_SOCIAL_LAUNCH_DRAFTS,
+  AGENTIC_SOCIAL_LAUNCH_PACKET_PATH,
+  buildAgenticSocialLaunchDraftRow,
+  getAgenticSocialLaunchDraftByAssetId,
+} from './agentic-social-launch-drafts'
+
+describe('agentic social launch drafts', () => {
+  it('keeps the challenger-cleared Monday launch set in order', () => {
+    expect(AGENTIC_SOCIAL_LAUNCH_DRAFTS.map((draft) => draft.assetId)).toEqual([
+      'p0-linkedin-flagship-agentic-operating-system',
+      'p0-carousel-seven-things-after-agent-demo',
+      'p1-linkedin-scope-safety-model',
+      'p1-linkedin-agent-qa-scorecards',
+      'p2-client-one-pager-governed-agentic-operations',
+    ])
+    expect(AGENTIC_SOCIAL_LAUNCH_DRAFTS.map((draft) => draft.launchDate)).toEqual([
+      '2026-06-08',
+      '2026-06-09',
+      '2026-06-10',
+      '2026-06-11',
+      '2026-06-12',
+    ])
+  })
+
+  it('builds draft-only social content rows with source and challenger trace', () => {
+    const draft = getAgenticSocialLaunchDraftByAssetId('p0-linkedin-flagship-agentic-operating-system')
+
+    expect(draft).not.toBeNull()
+    const row = buildAgenticSocialLaunchDraftRow(draft!, 'admin-user-1')
+
+    expect(row.platform).toBe('linkedin')
+    expect(row.status).toBe('draft')
+    expect(row.post_text).toContain('Anyone can launch an agent now.')
+    expect(row.rag_context).toMatchObject({
+      source: 'agentic_sales_outreach_launch_draft',
+      launch_draft_asset_id: 'p0-linkedin-flagship-agentic-operating-system',
+      launch_packet_path: AGENTIC_SOCIAL_LAUNCH_PACKET_PATH,
+      challenger_agent: 'Amina',
+      challenger_status: 'passed',
+      approval_status: 'human_review_ready',
+      pass_to_human: true,
+      seeded_by_user_id: 'admin-user-1',
+      approval_required_for: ['schedule', 'publish', 'outbound_send', 'visual_build', 'provider_execution'],
+    })
+    expect(row.admin_notes).toContain('Draft only.')
+    expect(row.admin_notes).toContain('Residual human decision:')
+  })
+
+  it('keeps carousel seed data renderable without provider execution', () => {
+    const draft = getAgenticSocialLaunchDraftByAssetId('p0-carousel-seven-things-after-agent-demo')
+
+    expect(draft).not.toBeNull()
+    const row = buildAgenticSocialLaunchDraftRow(draft!, 'admin-user-1')
+
+    expect(row.content_format).toBe('carousel')
+    expect(row.carousel_slides).toHaveLength(9)
+    expect(row.video_generation_method).toBe('none')
+    expect(row.rag_context).toMatchObject({
+      launch_draft_asset_id: 'p0-carousel-seven-things-after-agent-demo',
+      approval_required_for: expect.arrayContaining(['visual_build', 'publish']),
+    })
+  })
+})

--- a/lib/agentic-social-launch-drafts.ts
+++ b/lib/agentic-social-launch-drafts.ts
@@ -1,0 +1,448 @@
+import type { CarouselSlide, ContentFormat, ContentPillar, FrameworkVisualType, SocialPlatform } from './social-content'
+
+export const AGENTIC_SOCIAL_LAUNCH_PACKET_PATH = 'docs/agentic-content-linkedin-drafts/2026-06-04-sales-outreach-launch-drafts.md'
+
+export type AgenticSocialLaunchDraft = {
+  assetId: string
+  title: string
+  launchDate: string
+  channel: 'linkedin'
+  format: ContentFormat
+  postText: string
+  companionPostText?: string
+  ctaText: string
+  hashtags: string[]
+  contentPillar: ContentPillar
+  frameworkVisualType: FrameworkVisualType
+  sourceIds: string[]
+  sourcePaths: string[]
+  primaryClaim: string
+  audience: string
+  challengerNotes: string[]
+  residualHumanDecision: string
+  carouselSlides?: CarouselSlide[]
+  salesFollowupSeed?: string
+}
+
+const sharedSourcePaths = [
+  'docs/agentic-enterprise-value-map.md',
+  'docs/agentic-value-communications-plan.md',
+  'docs/agentic-content-review-packets/p0-challenger-review-packets.md',
+  'docs/agentic-content-review-packets/p1-challenger-review-packets.md',
+  'docs/agentic-content-review-packets/p2-challenger-review-packets.md',
+  'docs/agentic-content-linkedin-drafts/wave-1-drafts.md',
+  'docs/linkedin-voice.md',
+]
+
+export const AGENTIC_SOCIAL_LAUNCH_DRAFTS: AgenticSocialLaunchDraft[] = [
+  {
+    assetId: 'p0-linkedin-flagship-agentic-operating-system',
+    title: 'Anyone can launch an agent now',
+    launchDate: '2026-06-08',
+    channel: 'linkedin',
+    format: 'single_image',
+    postText: `Anyone can launch an agent now.
+
+That is the exciting part.
+
+It is also the part that should make enterprise teams slow down.
+
+The barrier used to be code. You needed enough technical skill to wire up the model, connect the tools, handle the workflow, and get something useful to happen.
+
+That barrier is falling fast.
+
+Open runtimes. Coding agents. Workflow agents. Browser agents. Local tools. Cloud tools. A small team can now get a working agent into motion in a weekend.
+
+But a working agent is not the same thing as a trustworthy operating model.
+
+The real questions start after the demo:
+
+Who assigned the work?
+Why did this agent get the task?
+What data could it use?
+What tools could it touch?
+What did it cost?
+What did it hand off?
+Where did the human approve the side effect?
+What proof would you show later if something went wrong?
+
+That is the layer I have been building into Portfolio.
+
+Agents need the operating system around them.
+
+Trace records. Scope boundaries. Handoffs. Approval gates. Quality checks. Challenger review. Mission Control. Slack surfaces for mobile unblock. A client-safe way to explain what happened without exposing private raw material.
+
+That may sound less exciting than watching an agent complete a task in real time.
+
+Good.
+
+Because enterprises do not need more impressive demos that become someone else's operational risk.
+
+Small businesses do not need AI that adds another invisible mess.
+
+Nonprofits do not need tools that create more work for teams already carrying too much.
+
+The value starts when the team knows when it should act, what it was allowed to touch, how the work was evaluated, and where a person had the authority to say yes, pause, repair, or stop.
+
+Execution is becoming cheap.
+
+Governed execution is where the value is.
+
+If your team is starting to adopt agents, what proof would you need before giving one more authority?
+
+#AIProduct #ProductManagement #EnterpriseAI #AmadutownAdvisory`,
+    ctaText: 'If your team is starting to adopt agents, what proof would you need before giving one more authority?',
+    hashtags: ['#AIProduct', '#ProductManagement', '#EnterpriseAI', '#AmadutownAdvisory'],
+    contentPillar: 'ai_product_management',
+    frameworkVisualType: 'architecture',
+    sourceIds: ['value-map', 'communications-plan', 'p0-challenger', 'linkedin-wave-1', 'linkedin-voice'],
+    sourcePaths: sharedSourcePaths,
+    primaryClaim: 'The demo is no longer the hard part; governed execution is where the value starts.',
+    audience: 'product leaders, operators, founders, AI builders, enterprise leaders',
+    challengerNotes: [
+      'Unsupported claims resolved.',
+      'No private logs, screenshots, client details, or raw chats.',
+      'Frames Portfolio as a governed proof surface, not a finished autonomous enterprise platform.',
+    ],
+    residualHumanDecision: 'Decide whether "enterprise" is the right word for the first launch post, or whether "business" broadens the audience.',
+  },
+  {
+    assetId: 'p0-carousel-seven-things-after-agent-demo',
+    title: '7 things your enterprise agent needs after the demo',
+    launchDate: '2026-06-09',
+    channel: 'linkedin',
+    format: 'carousel',
+    postText: `The agent demo is usually the easy part now.
+
+The harder question is what has to exist around the agent before a business should trust it with real work.
+
+I keep coming back to seven things:
+
+1. A receipt for every run.
+2. A scope boundary the operator can explain.
+3. A handoff packet when work changes owners.
+4. A human approval gate before side effects.
+5. A compliance path for risk and transactions.
+6. A QA loop that evaluates the work before authority expands.
+7. A Mission Control surface where a person can trace what happened.
+
+That is the difference between an agent that performs and an agent system that can be governed.
+
+I built this carousel because a lot of teams are about to bring agent runtimes into enterprise settings and discover that execution capacity is only the beginning.
+
+Swipe through the operating layer most demos skip.
+
+Which of these seven would you want in place first?
+
+#AIProduct #EnterpriseAI #ProductManagement #AmadutownAdvisory`,
+    companionPostText: `The agent demo is usually the easy part now.
+
+The harder question is what has to exist around the agent before a business should trust it with real work.
+
+Swipe through the operating layer most demos skip.
+
+Which of these seven would you want in place first?
+
+#AIProduct #EnterpriseAI #ProductManagement #AmadutownAdvisory`,
+    ctaText: 'Which of these seven would you want in place first?',
+    hashtags: ['#AIProduct', '#EnterpriseAI', '#ProductManagement', '#AmadutownAdvisory'],
+    contentPillar: 'ai_product_management',
+    frameworkVisualType: 'architecture',
+    sourceIds: ['communications-plan', 'p0-challenger', 'linkedin-wave-1', 'linkedin-voice'],
+    sourcePaths: sharedSourcePaths,
+    primaryClaim: 'The demo is only one stage; teams need a component model for operational trust.',
+    audience: 'enterprise AI evaluators, product leaders, founders, consultants',
+    challengerNotes: [
+      'Unsupported claims resolved in outline form.',
+      'Final design must use diagrams or sanitized UI only.',
+      'Does not imply every path is fully autonomous or production-mutating.',
+    ],
+    residualHumanDecision: 'Decide whether cover says "enterprise agent" or "business agent."',
+    carouselSlides: [
+      { type: 'cover', eyebrow: 'Agentic Operations', headline: 'The 7 things your enterprise agent needs after the demo', subhead: 'Execution capacity is only the beginning.', byline: 'Vambah Sillah' },
+      { type: 'principle', number: 1, pill: 'Receipt', headline: 'Every run needs proof', body: 'Trace the run, artifacts, cost, approvals, and handoffs. The system needs a receipt a human can inspect later.', accent_word: 'proof' },
+      { type: 'principle', number: 2, pill: 'Scope', headline: 'Bound the authority', body: 'Name the tools, data, writes, outbound actions, and spend limits. Scope should be explainable outside the prompt.', accent_word: 'authority' },
+      { type: 'principle', number: 3, pill: 'Handoff', headline: 'Package the work', body: 'When work changes owners, the next agent or human needs a summary, acceptance criteria, and linked evidence.', accent_word: 'work' },
+      { type: 'principle', number: 4, pill: 'Approval', headline: 'Gate the side effect', body: 'Let the agent prepare the work. Keep publishing, sending, spending, and production changes behind human approval.', accent_word: 'gate' },
+      { type: 'principle', number: 5, pill: 'Compliance', headline: 'Give risk a path', body: 'Transactions and sensitive actions need traceability, escalation, and a governance export when the stakes rise.', accent_word: 'risk' },
+      { type: 'principle', number: 6, pill: 'QA', headline: 'Evaluate before authority', body: 'Use rubrics, challenger review, and coaching signals before expanding what the agent can do.', accent_word: 'authority' },
+      { type: 'principle', number: 7, pill: 'Mission Control', headline: 'Make work visible', body: 'Operators need a surface to see what happened, what is blocked, and what decision is needed next.', accent_word: 'visible' },
+      { type: 'cta', headline: 'Governed execution is where the value is.', body: 'Which of these seven would you want in place first?', cta_label: 'Compare notes', hashtags: ['#AIProduct', '#EnterpriseAI', '#AmadutownAdvisory'] },
+    ],
+  },
+  {
+    assetId: 'p1-linkedin-scope-safety-model',
+    title: 'Scope is the safety model',
+    launchDate: '2026-06-10',
+    channel: 'linkedin',
+    format: 'single_image',
+    postText: `Agent access should feel less like a blank check and more like a permission slip.
+
+What can this agent read?
+
+What can it write?
+
+Can it touch client data?
+
+Can it send a message, publish a post, change production, start a paid job, or spend money?
+
+Those questions sound boring until an agent does something fast, confident, and wrong.
+
+That is why scope matters.
+
+In Portfolio, I have been treating scope as part of the product.
+
+Not a security appendix.
+
+Not a line buried in a prompt.
+
+A product feature.
+
+If an agent is going to act on behalf of a business, the operator should be able to explain its boundary in plain language:
+
+- what tools it can call
+- what data it can use
+- what write actions are allowed
+- what outbound actions are blocked
+- what spending requires approval
+- what happens when the risk changes
+
+That last part matters.
+
+Good scope goes past a permissions list. It gives the team a path for escalation.
+
+The agent can prepare the work.
+
+The system can record the evidence.
+
+The human still approves the side effect when the action carries real risk.
+
+That is how you avoid giving the agent more authority than the organization can explain.
+
+The goal is not to make every agent powerful.
+
+The goal is to make every agent appropriately bounded.
+
+Can your team explain what your agents are allowed to read, write, send, spend, and change?
+
+#AIProduct #EnterpriseAI #ProductManagement #AmadutownAdvisory`,
+    ctaText: 'Can your team explain what your agents are allowed to read, write, send, spend, and change?',
+    hashtags: ['#AIProduct', '#EnterpriseAI', '#ProductManagement', '#AmadutownAdvisory'],
+    contentPillar: 'ai_product_management',
+    frameworkVisualType: 'matrix',
+    sourceIds: ['communications-plan', 'p1-challenger', 'linkedin-wave-1', 'linkedin-voice'],
+    sourcePaths: sharedSourcePaths,
+    primaryClaim: 'Scope is not a prompt detail; it is the operating boundary that makes agent authority explainable.',
+    audience: 'product leaders, risk/compliance partners, founders, AI operators',
+    challengerNotes: [
+      'Unsupported claims resolved.',
+      'The post describes operating discipline and does not claim unrestricted production authority.',
+      'No privacy flags.',
+    ],
+    residualHumanDecision: 'Decide whether "blank check" should remain for a security-forward audience.',
+  },
+  {
+    assetId: 'p1-linkedin-agent-qa-scorecards',
+    title: 'Agent QA needs scorecards',
+    launchDate: '2026-06-11',
+    channel: 'linkedin',
+    format: 'single_image',
+    postText: `If an agent cannot evaluate its work, it should not get more power.
+
+That is the management rule I keep coming back to.
+
+A good answer is not enough.
+
+I want to know how the work happened.
+
+Did it choose the right tool?
+Did it stay inside scope?
+Did it route the work to the right owner?
+Did it ask for approval when the task became sensitive?
+Did it preserve the evidence?
+Did the cost make sense for the value of the work?
+
+That is why agent QA needs scorecards.
+
+Rubrics.
+
+Run evaluations.
+
+Pass and fail signals.
+
+Coaching notes.
+
+Trend lines that show whether the system is getting better for the right reason.
+
+Sometimes the lesson is that the agent needs a better prompt.
+
+Sometimes it needs a smaller scope.
+
+Sometimes it needs a different tool.
+
+Sometimes it should stop and ask a human instead of trying to sound certain.
+
+That is the part I think many teams will underestimate.
+
+Agent quality includes the final output, but the path matters just as much.
+
+In Portfolio, I have been pairing quality checks with challenger review before the work reaches human approval.
+
+That matters because humans should not be doing the agent's first round of QA.
+
+The human decision should be higher value:
+
+Is this aligned?
+
+Is this safe?
+
+Is this ready to publish, send, spend, change, or escalate?
+
+A human reviewer should receive a decision packet, not a mystery.
+
+Where would your team draw the line between an agent that can draft and an agent that can act?
+
+#AIProduct #ProductManagement #EnterpriseAI #AmadutownAdvisory`,
+    ctaText: 'Where would your team draw the line between an agent that can draft and an agent that can act?',
+    hashtags: ['#AIProduct', '#ProductManagement', '#EnterpriseAI', '#AmadutownAdvisory'],
+    contentPillar: 'ai_product_management',
+    frameworkVisualType: 'cycle',
+    sourceIds: ['communications-plan', 'p1-challenger', 'linkedin-wave-1', 'linkedin-voice'],
+    sourcePaths: sharedSourcePaths,
+    primaryClaim: 'Agents should earn authority through evaluation, traces, and challenger loops.',
+    audience: 'product leaders, AI program owners, operations leaders',
+    challengerNotes: [
+      'Unsupported claims resolved.',
+      'The post describes scorecards and challenger review at the operating-pattern level.',
+      'It does not claim all reflection loops are fully autonomous.',
+    ],
+    residualHumanDecision: 'Decide whether to expand this into a carousel on "how an agent earns authority."',
+  },
+  {
+    assetId: 'p2-client-one-pager-governed-agentic-operations',
+    title: 'Governed Agentic Operations',
+    launchDate: '2026-06-12',
+    channel: 'linkedin',
+    format: 'single_image',
+    postText: `I have been building my Portfolio site like a proof surface for one question:
+
+What does it take to make AI agents useful in the real world?
+
+The answer keeps getting more practical.
+
+Launching the agent is only the opening move.
+
+You need the harness around it.
+
+The trace that shows what happened.
+
+The scope boundary that limits what it can touch.
+
+The memory model that separates raw input from approved knowledge.
+
+The handoff packet that tells the next agent what to do.
+
+The approval gate that keeps side effects under human authority.
+
+The QA loop that tests work before a person is asked to approve it.
+
+The Mission Control surface that lets an operator see the work instead of guessing.
+
+That is what I mean by Governed Agentic Operations.
+
+For a small business, that might mean an agent can prepare outreach but cannot send it without approval.
+
+For a nonprofit, it might mean AI can summarize program work without exposing private participant context.
+
+For an enterprise team, it might mean every agent run leaves a receipt, every handoff has an owner, and every production-changing action has a decision trail.
+
+This is where AI consulting has to get more honest.
+
+The demo can show what is possible.
+
+The operating model shows whether it is responsible.
+
+I am starting to package this work for leaders who want agents in their organization but do not want a loose pile of automation risk.
+
+If that is the conversation you are having internally, I would be glad to compare notes.
+
+#AIProduct #EnterpriseAI #Consulting #AmadutownAdvisory`,
+    ctaText: 'If that is the conversation you are having internally, I would be glad to compare notes.',
+    hashtags: ['#AIProduct', '#EnterpriseAI', '#Consulting', '#AmadutownAdvisory'],
+    contentPillar: 'entrepreneurship',
+    frameworkVisualType: 'architecture',
+    sourceIds: ['value-map', 'communications-plan', 'p2-challenger', 'linkedin-wave-1', 'linkedin-voice'],
+    sourcePaths: sharedSourcePaths,
+    primaryClaim: 'The portfolio is useful because it shows the operating layer around agentic AI alongside the agent.',
+    audience: 'founders, nonprofit executives, small business owners, enterprise AI sponsors',
+    challengerNotes: [
+      'Unsupported claims resolved.',
+      'No private run logs, client data, or raw screenshots.',
+      'Uses "might mean" examples rather than claiming all client workflows are deployed.',
+    ],
+    residualHumanDecision: 'Decide whether to keep the direct "glad to compare notes" close or turn it into a softer question.',
+    salesFollowupSeed: 'Appreciate you engaging with the agentic operations post. The part I am trying to make more concrete for leaders is the operating layer after the demo: scope, trace, handoff, approval, QA, and client-safe proof. If your team is exploring agents, I would be glad to compare notes on what has to be in place before the system gets more authority.',
+  },
+]
+
+export function getAgenticSocialLaunchDraftByAssetId(assetId: string) {
+  return AGENTIC_SOCIAL_LAUNCH_DRAFTS.find((draft) => draft.assetId === assetId) ?? null
+}
+
+export function buildAgenticSocialLaunchDraftRow(draft: AgenticSocialLaunchDraft, seededByUserId: string) {
+  return {
+    platform: draft.channel as SocialPlatform,
+    status: 'draft',
+    post_text: draft.postText,
+    companion_post_text: draft.companionPostText ?? null,
+    cta_text: draft.ctaText,
+    cta_url: null,
+    hashtags: draft.hashtags,
+    image_prompt: `Create an AmaduTown-branded ${draft.frameworkVisualType} visual for ${draft.title}. Use sanitized diagrams only; do not use private logs, screenshots, or client data.`,
+    framework_visual_type: draft.frameworkVisualType,
+    voiceover_text: draft.postText,
+    topic_extracted: {
+      topic: draft.title,
+      angle: draft.primaryClaim,
+      key_insight: draft.primaryClaim,
+      personal_tie_in: 'Portfolio shows the operating layer around agentic AI: trace, scope, handoff, approval, QA, and human review.',
+      framework_visual: draft.frameworkVisualType,
+    },
+    hormozi_framework: {
+      framework_type: 'value_equation',
+      hook_type: 'operational_tension',
+      proof_pattern: 'source_packet_to_governed_draft',
+      cta_pattern: 'operator_question',
+    },
+    rag_context: {
+      source: 'agentic_sales_outreach_launch_draft',
+      launch_draft_asset_id: draft.assetId,
+      launch_packet_path: AGENTIC_SOCIAL_LAUNCH_PACKET_PATH,
+      source_ids: draft.sourceIds,
+      source_paths: draft.sourcePaths,
+      challenger_agent: 'Amina',
+      challenger_status: 'passed',
+      approval_status: 'human_review_ready',
+      pass_to_human: true,
+      launch_date: draft.launchDate,
+      audience: draft.audience,
+      primary_claim: draft.primaryClaim,
+      residual_human_decision: draft.residualHumanDecision,
+      sales_followup_seed: draft.salesFollowupSeed ?? null,
+      seeded_by_user_id: seededByUserId,
+      approval_required_for: ['schedule', 'publish', 'outbound_send', 'visual_build', 'provider_execution'],
+    },
+    admin_notes: [
+      `Seeded from ${AGENTIC_SOCIAL_LAUNCH_PACKET_PATH}.`,
+      `Asset ID: ${draft.assetId}.`,
+      'Draft only. Scheduling, publishing, outbound follow-up, visual build, and provider work require separate approval.',
+      `Amina challenger notes: ${draft.challengerNotes.join(' ')}`,
+      `Residual human decision: ${draft.residualHumanDecision}`,
+    ].join('\n'),
+    target_platforms: ['linkedin'],
+    video_generation_method: 'none',
+    content_format: draft.format,
+    content_pillar: draft.contentPillar,
+    carousel_slides: draft.carouselSlides ?? null,
+  }
+}


### PR DESCRIPTION
## Summary
- Add a typed launch-draft registry for the five challenger-cleared Agentic AI sales outreach posts.
- Add an authenticated Social Content seed route that creates draft-only rows and dedupes by launch asset id.
- Add a Social Content admin action that seeds the launch-week drafts and links back to the normal review screens.

## Validation
- npm test -- --run app/api/admin/social-content/launch-drafts/route.test.ts lib/agentic-social-launch-drafts.test.ts lib/agentic-content-review-packets.test.ts
- npm run lint
- npx tsc --noEmit
- git diff --check
- Local browser smoke: /admin/social-content compiled on localhost:3006 and reached the expected admin login boundary with no overlay.
- Pre-push database health check passed.

## Integration Notes
- No migration required.
- No provider execution, scheduling, publishing, outbound send, or direct DB seeding from Codex. The new write is behind the authenticated admin UI/API path and creates draft-only Social Content rows.
- Seed route dedupes existing rows via rag_context.source and rag_context.launch_draft_asset_id.
- Vercel contexts to verify after CI/deployment:
  - Vercel – portfolio
  - Vercel – portfolio-staging