### PR TITLE
feat: add model usage control plane

### DIFF
--- a/app/admin/agents/model-usage/page.test.tsx
+++ b/app/admin/agents/model-usage/page.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import ModelUsagePage from './page'
+
+vi.mock('@/components/ProtectedRoute', () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('@/components/admin/Breadcrumbs', () => ({
+  default: () => null,
+}))
+
+vi.mock('@/lib/auth', () => ({
+  getCurrentSession: vi.fn(async () => ({ access_token: 'admin-token' })),
+}))
+
+const snapshot = {
+  ok: true,
+  generatedAt: '2026-06-06T12:00:00.000Z',
+  window: { from: '2026-06-01T00:00:00.000Z', to: '2026-06-30T23:59:59.999Z' },
+  totals: {
+    eventCount: 2,
+    totalTokens: 8000,
+    inputTokens: 7000,
+    outputTokens: 1000,
+    costUsd: 12.5,
+    meteredCostUsd: 2.5,
+    allocatedCostUsd: 10,
+    inferredCostUsd: 0,
+    acceptedOutputCount: 2,
+    tokensPerAcceptedOutput: 4000,
+    costPerAcceptedOutput: 6.25,
+  },
+  byProvider: [{ key: 'codex', label: 'Codex', totalTokens: 6000, costUsd: 10, eventCount: 1, acceptedOutputCount: 1, efficiencyScore: 85 }],
+  byModel: [{ key: 'gpt-4o-mini', label: 'gpt-4o-mini', totalTokens: 2000, costUsd: 2.5, eventCount: 1, acceptedOutputCount: 1, efficiencyScore: 90 }],
+  byRuntime: [{ key: 'codex', label: 'Codex', totalTokens: 8000, costUsd: 12.5, eventCount: 2, acceptedOutputCount: 2, efficiencyScore: 88 }],
+  byTaskCategory: [{ key: 'research', label: 'Research', totalTokens: 8000, costUsd: 12.5, eventCount: 2, acceptedOutputCount: 2, efficiencyScore: 88 }],
+  byClientProject: [{ key: 'portfolio', label: 'Portfolio', totalTokens: 8000, costUsd: 12.5, eventCount: 2, acceptedOutputCount: 2, efficiencyScore: 88 }],
+  heatmap: [{ date: '2026-06-01', totalTokens: 8000, costUsd: 12.5, eventCount: 2, level: 4 }],
+  trend: [{ date: '2026-06-01', totalTokens: 8000, costUsd: 12.5, eventCount: 2 }],
+  topDays: [{ date: '2026-06-01', totalTokens: 8000, costUsd: 12.5, eventCount: 2, primaryActivity: 'Research' }],
+  topTransactions: [],
+  recommendations: [{
+    id: 'context-slimming',
+    severity: 'warning',
+    title: 'Slim repeated context before the next run',
+    action: 'Move reusable context into RAG.',
+    rationale: 'One transaction used heavy context.',
+    affectedEventIds: ['event-1'],
+    approvalRequired: false,
+  }],
+  events: [{
+    id: 'event-1',
+    occurredAt: '2026-06-01T12:00:00.000Z',
+    provider: 'codex',
+    runtime: 'codex',
+    model: 'gpt-5-codex',
+    taskCategory: 'research',
+    agentKey: 'research-source-register',
+    clientProjectId: null,
+    clientLabel: 'Portfolio',
+    actionLabel: 'Research transaction',
+    inputTokens: 7000,
+    outputTokens: 1000,
+    cachedTokens: 0,
+    reasoningTokens: 0,
+    totalTokens: 8000,
+    acceptedOutputCount: 1,
+    resolvedWorkItemCount: 0,
+    retryCount: 0,
+    costUsd: 12.5,
+    costBasis: 'subscription_prorated',
+    confidence: 'medium',
+    sourceTrace: { type: 'codex_session', id: 'session-1', href: null },
+    scrubbed: false,
+  }],
+  clientSafeEvents: [],
+}
+
+describe('ModelUsagePage', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => snapshot,
+    })))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('renders model usage totals, heatmap, recommendations, and transactions', async () => {
+    render(<ModelUsagePage />)
+
+    await waitFor(() => expect(screen.getByText('Model Usage And Token Efficiency')).toBeInTheDocument())
+    expect(screen.getAllByText('8,000').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('$12.50').length).toBeGreaterThan(0)
+    expect(screen.getByText('Token burn calendar')).toBeInTheDocument()
+    expect(screen.getByText('Slim repeated context before the next run')).toBeInTheDocument()
+    expect(screen.getByText('Research transaction')).toBeInTheDocument()
+  })
+})

--- a/app/admin/agents/model-usage/page.tsx
+++ b/app/admin/agents/model-usage/page.tsx
@@ -1,0 +1,396 @@
+'use client'
+
+import Link from 'next/link'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  Activity,
+  ArrowRight,
+  BarChart3,
+  BrainCircuit,
+  CalendarDays,
+  CircleDollarSign,
+  Gauge,
+  RefreshCw,
+  ShieldCheck,
+  SlidersHorizontal,
+  Zap,
+} from 'lucide-react'
+import ProtectedRoute from '@/components/ProtectedRoute'
+import Breadcrumbs from '@/components/admin/Breadcrumbs'
+import { getCurrentSession } from '@/lib/auth'
+import type { ModelUsageLedgerEvent, ModelUsageSnapshot } from '@/lib/model-usage'
+
+type Snapshot = ModelUsageSnapshot & { ok?: boolean }
+
+type DatePreset = '30d' | 'mtd' | 'qtd'
+
+function dateRange(preset: DatePreset) {
+  const now = new Date()
+  const to = now.toISOString().slice(0, 10)
+  if (preset === 'mtd') return { from: new Date(now.getFullYear(), now.getMonth(), 1).toISOString().slice(0, 10), to }
+  if (preset === 'qtd') {
+    const quarter = Math.floor(now.getMonth() / 3)
+    return { from: new Date(now.getFullYear(), quarter * 3, 1).toISOString().slice(0, 10), to }
+  }
+  return { from: new Date(now.getTime() - 29 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10), to }
+}
+
+function numberFormat(value: number) {
+  return new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(value)
+}
+
+function currency(value: number) {
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 2 }).format(value)
+}
+
+function shortDate(value: string) {
+  return new Date(value).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
+export default function ModelUsagePage() {
+  return (
+    <ProtectedRoute requireAdmin>
+      <ModelUsageContent />
+    </ProtectedRoute>
+  )
+}
+
+function ModelUsageContent() {
+  const [preset, setPreset] = useState<DatePreset>('30d')
+  const [snapshot, setSnapshot] = useState<Snapshot | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [clientFilter, setClientFilter] = useState('all')
+  const [taskFilter, setTaskFilter] = useState('all')
+  const [modelFilter, setModelFilter] = useState('all')
+  const [runtimeFilter, setRuntimeFilter] = useState('all')
+  const [confidenceFilter, setConfidenceFilter] = useState('all')
+
+  const fetchSnapshot = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    const { from, to } = dateRange(preset)
+    try {
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Missing admin session')
+      const res = await fetch(`/api/admin/model-usage/summary?from=${from}&to=${to}`, {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      })
+      const body = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(body.error || `HTTP ${res.status}`)
+      setSnapshot(body)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load model usage')
+      setSnapshot(null)
+    } finally {
+      setLoading(false)
+    }
+  }, [preset])
+
+  useEffect(() => {
+    fetchSnapshot()
+  }, [fetchSnapshot])
+
+  const filteredEvents = useMemo(() => {
+    const events = snapshot?.events ?? []
+    return events.filter((event) => (
+      (clientFilter === 'all' || (event.clientProjectId ?? 'portfolio') === clientFilter) &&
+      (taskFilter === 'all' || event.taskCategory === taskFilter) &&
+      (modelFilter === 'all' || event.model === modelFilter) &&
+      (runtimeFilter === 'all' || event.runtime === runtimeFilter) &&
+      (confidenceFilter === 'all' || event.confidence === confidenceFilter)
+    ))
+  }, [clientFilter, confidenceFilter, modelFilter, runtimeFilter, snapshot?.events, taskFilter])
+
+  const options = useMemo(() => {
+    const events = snapshot?.events ?? []
+    return {
+      clients: uniqueOptions(events.map((event) => ({ key: event.clientProjectId ?? 'portfolio', label: event.clientLabel }))),
+      tasks: uniqueOptions(events.map((event) => ({ key: event.taskCategory, label: event.taskCategory.replace(/_/g, ' ') }))),
+      models: uniqueOptions(events.map((event) => ({ key: event.model, label: event.model }))),
+      runtimes: uniqueOptions(events.map((event) => ({ key: event.runtime, label: event.runtime }))),
+      confidences: uniqueOptions(events.map((event) => ({ key: event.confidence, label: event.confidence }))),
+    }
+  }, [snapshot?.events])
+
+  return (
+    <div className="agent-ops-page min-h-screen p-5 text-foreground lg:p-7">
+      <div className="mx-auto max-w-[1680px]">
+        <Breadcrumbs items={[
+          { label: 'Admin Dashboard', href: '/admin' },
+          { label: 'Agent Operations', href: '/admin/agents' },
+          { label: 'Model Usage' },
+        ]} />
+
+        <header className="agent-ops-surface-header mb-5 mt-5 rounded-xl border p-5">
+          <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+            <div>
+              <div className="agent-ops-eyebrow mb-2">
+                <BrainCircuit size={16} />
+                Agent Ops model accounting
+              </div>
+              <h1 className="text-3xl font-bold">Model Usage And Token Efficiency</h1>
+              <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+                Token burn, inferred subscription allocation, model comparison, and client/project attribution from the same governed Agent Ops ledger.
+              </p>
+            </div>
+            <div className="agent-ops-header-actions">
+              <Link href="/admin/cost-revenue" className="agent-ops-button-muted">
+                <CircleDollarSign size={16} />
+                Cost & Revenue
+              </Link>
+              <button onClick={fetchSnapshot} disabled={loading} className="agent-ops-button-secondary disabled:opacity-60">
+                <RefreshCw size={16} className={loading ? 'animate-spin' : ''} />
+                Refresh
+              </button>
+            </div>
+          </div>
+        </header>
+
+        {loading ? (
+          <div className="py-16 text-center text-muted-foreground">Loading model usage...</div>
+        ) : error ? (
+          <div className="rounded-lg border border-red-500/50 bg-red-500/10 p-6 text-red-300">
+            <p className="font-semibold">Failed to load model usage</p>
+            <p className="mt-1 text-sm">{error}</p>
+          </div>
+        ) : snapshot ? (
+          <div className="space-y-5">
+            <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+              <MetricCard icon={Zap} label="Total tokens" value={numberFormat(snapshot.totals.totalTokens)} sub={`${snapshot.totals.eventCount} transactions`} />
+              <MetricCard icon={CircleDollarSign} label="Attributed cost" value={currency(snapshot.totals.costUsd)} sub={`${currency(snapshot.totals.allocatedCostUsd)} allocated`} />
+              <MetricCard icon={Gauge} label="Tokens per output" value={snapshot.totals.tokensPerAcceptedOutput ? numberFormat(snapshot.totals.tokensPerAcceptedOutput) : 'No outputs'} sub="Accepted-output denominator" />
+              <MetricCard icon={Activity} label="Cost per output" value={snapshot.totals.costPerAcceptedOutput ? currency(snapshot.totals.costPerAcceptedOutput) : 'No outputs'} sub="Metered + prorated where available" />
+            </section>
+
+            <section className="agent-ops-card rounded-lg border p-4">
+              <div className="mb-4 flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+                <div>
+                  <div className="flex items-center gap-2 text-sm font-semibold">
+                    <CalendarDays size={16} className="text-radiant-gold" />
+                    Token burn calendar
+                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">GitHub-style daily usage view. Darker cells represent heavier token burn in the selected window.</p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {(['30d', 'mtd', 'qtd'] as const).map((item) => (
+                    <button
+                      key={item}
+                      onClick={() => setPreset(item)}
+                      className={`rounded-lg border px-3 py-2 text-xs font-medium ${
+                        preset === item
+                          ? 'border-radiant-gold/60 bg-radiant-gold/15 text-radiant-gold'
+                          : 'border-silicon-slate/60 bg-background/45 text-muted-foreground hover:text-foreground'
+                      }`}
+                    >
+                      {item.toUpperCase()}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <div className="grid grid-cols-10 gap-2 md:grid-cols-15 xl:grid-cols-30" aria-label="Token burn heatmap">
+                {snapshot.heatmap.length > 0 ? snapshot.heatmap.map((day) => (
+                  <div
+                    key={day.date}
+                    title={`${day.date}: ${numberFormat(day.totalTokens)} tokens, ${currency(day.costUsd)}`}
+                    className={`aspect-square rounded-[4px] border ${heatmapClass(day.level)}`}
+                  />
+                )) : (
+                  <div className="col-span-full rounded-lg border border-dashed p-5 text-sm text-muted-foreground">No token usage captured in this period.</div>
+                )}
+              </div>
+            </section>
+
+            <section className="grid gap-5 xl:grid-cols-[minmax(0,1.25fr)_minmax(360px,0.75fr)]">
+              <div className="agent-ops-card rounded-lg border p-4">
+                <div className="mb-4 flex items-center gap-2 text-sm font-semibold">
+                  <BarChart3 size={16} className="text-radiant-gold" />
+                  Model and task comparison
+                </div>
+                <div className="grid gap-4 md:grid-cols-2">
+                  <GroupList title="Providers" rows={snapshot.byProvider} />
+                  <GroupList title="Models" rows={snapshot.byModel.slice(0, 8)} />
+                  <GroupList title="Task categories" rows={snapshot.byTaskCategory} />
+                  <GroupList title="Clients / projects" rows={snapshot.byClientProject} />
+                </div>
+              </div>
+              <div className="agent-ops-card rounded-lg border p-4">
+                <div className="mb-4 flex items-center gap-2 text-sm font-semibold">
+                  <ShieldCheck size={16} className="text-radiant-gold" />
+                  Efficiency recommendations
+                </div>
+                <div className="space-y-3">
+                  {snapshot.recommendations.length > 0 ? snapshot.recommendations.map((item) => (
+                    <div key={item.id} className="rounded-lg border border-silicon-slate/60 bg-background/35 p-3">
+                      <div className="flex items-center justify-between gap-2">
+                        <p className="text-sm font-semibold">{item.title}</p>
+                        {item.approvalRequired ? <span className="rounded-full border border-amber-400/50 px-2 py-0.5 text-[11px] text-amber-300">Approval</span> : null}
+                      </div>
+                      <p className="mt-1 text-xs text-muted-foreground">{item.rationale}</p>
+                      <p className="mt-2 text-xs text-foreground/85">{item.action}</p>
+                    </div>
+                  )) : (
+                    <p className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">No efficiency recommendations for this window.</p>
+                  )}
+                </div>
+              </div>
+            </section>
+
+            <section className="agent-ops-card rounded-lg border p-4">
+              <div className="mb-4 flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+                <div>
+                  <div className="flex items-center gap-2 text-sm font-semibold">
+                    <SlidersHorizontal size={16} className="text-radiant-gold" />
+                    Transaction audit trail
+                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">Trace token and cost allocation back to specific runs, calls, clients, and actions.</p>
+                </div>
+                <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-5">
+                  <FilterSelect label="Client" value={clientFilter} onChange={setClientFilter} options={options.clients} />
+                  <FilterSelect label="Task" value={taskFilter} onChange={setTaskFilter} options={options.tasks} />
+                  <FilterSelect label="Model" value={modelFilter} onChange={setModelFilter} options={options.models} />
+                  <FilterSelect label="Runtime" value={runtimeFilter} onChange={setRuntimeFilter} options={options.runtimes} />
+                  <FilterSelect label="Confidence" value={confidenceFilter} onChange={setConfidenceFilter} options={options.confidences} />
+                </div>
+              </div>
+              <div className="overflow-x-auto">
+                <table className="min-w-full text-left text-sm">
+                  <thead className="text-xs uppercase tracking-wide text-muted-foreground">
+                    <tr className="border-b border-silicon-slate/60">
+                      <th className="py-2 pr-4">When</th>
+                      <th className="py-2 pr-4">Action</th>
+                      <th className="py-2 pr-4">Model</th>
+                      <th className="py-2 pr-4">Client</th>
+                      <th className="py-2 pr-4 text-right">Tokens</th>
+                      <th className="py-2 pr-4 text-right">Cost</th>
+                      <th className="py-2 pr-4">Basis</th>
+                      <th className="py-2 pr-4">Trace</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {filteredEvents.slice(0, 50).map((event) => (
+                      <TransactionRow key={event.id} event={event} />
+                    ))}
+                    {filteredEvents.length === 0 ? (
+                      <tr>
+                        <td colSpan={8} className="py-8 text-center text-muted-foreground">No transactions match the selected filters.</td>
+                      </tr>
+                    ) : null}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function MetricCard({ icon: Icon, label, value, sub }: { icon: typeof Zap; label: string; value: string; sub: string }) {
+  return (
+    <div className="agent-ops-card rounded-lg border p-4">
+      <div className="mb-3 flex h-9 w-9 items-center justify-center rounded-lg border border-radiant-gold/30 bg-radiant-gold/10 text-radiant-gold">
+        <Icon size={18} />
+      </div>
+      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="mt-1 text-2xl font-bold tabular-nums">{value}</p>
+      <p className="mt-1 text-xs text-muted-foreground">{sub}</p>
+    </div>
+  )
+}
+
+function GroupList({ title, rows }: { title: string; rows: Snapshot['byProvider'] }) {
+  const max = Math.max(...rows.map((row) => row.totalTokens), 1)
+  return (
+    <div>
+      <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">{title}</p>
+      <div className="space-y-2">
+        {rows.length > 0 ? rows.map((row) => (
+          <div key={row.key}>
+            <div className="mb-1 flex items-center justify-between gap-3 text-xs">
+              <span className="truncate capitalize text-foreground/90">{row.label}</span>
+              <span className="tabular-nums text-muted-foreground">{numberFormat(row.totalTokens)} tok</span>
+            </div>
+            <div className="h-2 rounded-full bg-silicon-slate/50">
+              <div className="h-2 rounded-full bg-radiant-gold" style={{ width: `${Math.max(4, (row.totalTokens / max) * 100)}%` }} />
+            </div>
+          </div>
+        )) : (
+          <p className="rounded-lg border border-dashed p-3 text-xs text-muted-foreground">No rows captured.</p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function TransactionRow({ event }: { event: ModelUsageLedgerEvent }) {
+  return (
+    <tr className="border-b border-silicon-slate/40 align-top">
+      <td className="py-3 pr-4 text-muted-foreground">{shortDate(event.occurredAt)}</td>
+      <td className="py-3 pr-4">
+        <p className="max-w-[280px] truncate font-medium">{event.actionLabel}</p>
+        <p className="text-xs capitalize text-muted-foreground">{event.taskCategory.replace(/_/g, ' ')} · {event.runtime}</p>
+      </td>
+      <td className="py-3 pr-4">
+        <p className="font-mono text-xs">{event.model}</p>
+        <p className="text-xs capitalize text-muted-foreground">{event.provider.replace(/_/g, ' ')}</p>
+      </td>
+      <td className="py-3 pr-4">{event.clientLabel}</td>
+      <td className="py-3 pr-4 text-right tabular-nums">{numberFormat(event.totalTokens)}</td>
+      <td className="py-3 pr-4 text-right tabular-nums text-radiant-gold">{currency(event.costUsd)}</td>
+      <td className="py-3 pr-4">
+        <span className="rounded-full border border-silicon-slate/60 px-2 py-0.5 text-[11px] capitalize text-muted-foreground">
+          {event.costBasis.replace(/_/g, ' ')} · {event.confidence}
+        </span>
+      </td>
+      <td className="py-3 pr-4">
+        {event.sourceTrace.href ? (
+          <Link href={event.sourceTrace.href} className="inline-flex items-center gap-1 text-xs text-radiant-gold hover:underline">
+            Trace
+            <ArrowRight size={12} />
+          </Link>
+        ) : (
+          <span className="text-xs text-muted-foreground">Imported</span>
+        )}
+      </td>
+    </tr>
+  )
+}
+
+function FilterSelect({ label, value, onChange, options }: {
+  label: string
+  value: string
+  onChange: (value: string) => void
+  options: Array<{ key: string; label: string }>
+}) {
+  return (
+    <label className="text-xs text-muted-foreground">
+      <span className="sr-only">{label}</span>
+      <select
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="w-full rounded-lg border border-silicon-slate/60 bg-background/80 px-3 py-2 text-xs capitalize text-foreground"
+      >
+        <option value="all">All {label.toLowerCase()}</option>
+        {options.map((option) => (
+          <option key={option.key} value={option.key}>{option.label}</option>
+        ))}
+      </select>
+    </label>
+  )
+}
+
+function uniqueOptions(rows: Array<{ key: string; label: string }>) {
+  const map = new Map<string, string>()
+  for (const row of rows) map.set(row.key, row.label)
+  return [...map.entries()].map(([key, label]) => ({ key, label })).sort((a, b) => a.label.localeCompare(b.label))
+}
+
+function heatmapClass(level: number) {
+  if (level >= 4) return 'border-radiant-gold/80 bg-radiant-gold'
+  if (level === 3) return 'border-radiant-gold/60 bg-radiant-gold/70'
+  if (level === 2) return 'border-radiant-gold/40 bg-radiant-gold/40'
+  if (level === 1) return 'border-radiant-gold/25 bg-radiant-gold/20'
+  return 'border-silicon-slate/60 bg-silicon-slate/25'
+}

--- a/app/admin/cost-revenue/page.tsx
+++ b/app/admin/cost-revenue/page.tsx
@@ -1,8 +1,9 @@
 'use client'
 
+import Link from 'next/link'
 import { useEffect, useState, useCallback } from 'react'
 import { motion } from 'framer-motion'
-import { DollarSign, TrendingUp, TrendingDown, Percent } from 'lucide-react'
+import { BrainCircuit, DollarSign, TrendingUp, TrendingDown, Percent } from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
 import AdminPieChart from '@/components/admin/AdminPieChart'
@@ -134,7 +135,14 @@ function CostRevenuePageContent() {
             </p>
           </div>
 
-          <div className="flex gap-2">
+          <div className="flex flex-wrap gap-2">
+            <Link
+              href="/admin/agents/model-usage"
+              className="inline-flex items-center gap-2 rounded-lg border border-silicon-slate/60 bg-background/45 px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:border-radiant-gold/45 hover:text-foreground"
+            >
+              <BrainCircuit size={16} />
+              Model usage
+            </Link>
             {(['mtd', 'qtd', 'ytd'] as const).map((p) => (
               <button
                 key={p}

--- a/app/api/admin/client-projects/[id]/ai-ops/model-usage/route.test.ts
+++ b/app/api/admin/client-projects/[id]/ai-ops/model-usage/route.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  buildModelUsageSnapshot: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/model-usage', () => ({
+  buildModelUsageSnapshot: mocks.buildModelUsageSnapshot,
+}))
+
+import { GET } from './route'
+
+function request(url = 'http://localhost/api/admin/client-projects/client-1/ai-ops/model-usage?from=2026-06-01&to=2026-06-30') {
+  return new Request(url, { headers: { authorization: 'Bearer token' } })
+}
+
+describe('GET /api/admin/client-projects/[id]/ai-ops/model-usage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.buildModelUsageSnapshot.mockResolvedValue({
+      generatedAt: '2026-06-06T12:00:00.000Z',
+      window: { from: '2026-06-01T00:00:00.000Z', to: '2026-06-30T23:59:59.999Z' },
+      totals: { eventCount: 1, totalTokens: 1000, inputTokens: 800, outputTokens: 200, costUsd: 0.1 },
+      byProvider: [],
+      byModel: [],
+      byRuntime: [],
+      byTaskCategory: [],
+      byClientProject: [],
+      heatmap: [],
+      trend: [],
+      topDays: [],
+      topTransactions: [],
+      recommendations: [],
+      events: [{ id: 'private-event', actionLabel: 'Private action' }],
+      clientSafeEvents: [{ id: 'safe-event', actionLabel: 'Research transaction', scrubbed: true }],
+    })
+  })
+
+  it('returns a scrubbed client-scoped projection', async () => {
+    const response = await GET(request() as never, { params: Promise.resolve({ id: 'client-1' }) })
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.ok).toBe(true)
+    expect(body.clientProjectId).toBe('client-1')
+    expect(body.events).toEqual([{ id: 'safe-event', actionLabel: 'Research transaction', scrubbed: true }])
+    expect(mocks.buildModelUsageSnapshot).toHaveBeenCalledWith({
+      from: '2026-06-01',
+      to: '2026-06-30',
+      clientProjectId: 'client-1',
+    })
+  })
+})

--- a/app/api/admin/client-projects/[id]/ai-ops/model-usage/route.ts
+++ b/app/api/admin/client-projects/[id]/ai-ops/model-usage/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { buildModelUsageSnapshot } from '@/lib/model-usage'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const { id } = await params
+  const searchParams = new URL(request.url).searchParams
+  const from = searchParams.get('from') ?? undefined
+  const to = searchParams.get('to') ?? undefined
+
+  try {
+    const snapshot = await buildModelUsageSnapshot({ from, to, clientProjectId: id })
+    return NextResponse.json({
+      ok: true,
+      clientProjectId: id,
+      ...snapshot,
+      events: snapshot.clientSafeEvents,
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to build client model usage snapshot'
+    console.error('[client-ai-ops-model-usage] snapshot failed:', error)
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/app/api/admin/model-usage/summary/route.test.ts
+++ b/app/api/admin/model-usage/summary/route.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  buildModelUsageSnapshot: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/model-usage', () => ({
+  buildModelUsageSnapshot: mocks.buildModelUsageSnapshot,
+}))
+
+import { GET } from './route'
+
+function request(url = 'http://localhost/api/admin/model-usage/summary?from=2026-06-01&to=2026-06-30&clientProjectId=client-1') {
+  return new Request(url, { headers: { authorization: 'Bearer token' } })
+}
+
+describe('GET /api/admin/model-usage/summary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.buildModelUsageSnapshot.mockResolvedValue({
+      generatedAt: '2026-06-06T12:00:00.000Z',
+      window: { from: '2026-06-01T00:00:00.000Z', to: '2026-06-30T23:59:59.999Z' },
+      totals: { eventCount: 1, totalTokens: 1000, inputTokens: 800, outputTokens: 200, costUsd: 0.1 },
+      byProvider: [],
+      byModel: [],
+      byRuntime: [],
+      byTaskCategory: [],
+      byClientProject: [],
+      heatmap: [],
+      trend: [],
+      topDays: [],
+      topTransactions: [],
+      recommendations: [],
+      events: [],
+      clientSafeEvents: [],
+    })
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await GET(request() as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.buildModelUsageSnapshot).not.toHaveBeenCalled()
+  })
+
+  it('passes filters to the model usage snapshot builder', async () => {
+    const response = await GET(request() as never)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.ok).toBe(true)
+    expect(body.totals.totalTokens).toBe(1000)
+    expect(mocks.buildModelUsageSnapshot).toHaveBeenCalledWith({
+      from: '2026-06-01',
+      to: '2026-06-30',
+      clientProjectId: 'client-1',
+    })
+  })
+
+  it('returns a server error when the read model fails', async () => {
+    mocks.buildModelUsageSnapshot.mockRejectedValue(new Error('Database not available'))
+
+    const response = await GET(request() as never)
+
+    expect(response.status).toBe(500)
+    expect(await response.json()).toEqual({ error: 'Database not available' })
+  })
+})

--- a/app/api/admin/model-usage/summary/route.ts
+++ b/app/api/admin/model-usage/summary/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { buildModelUsageSnapshot } from '@/lib/model-usage'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const searchParams = new URL(request.url).searchParams
+  const from = searchParams.get('from') ?? undefined
+  const to = searchParams.get('to') ?? undefined
+  const clientProjectId = searchParams.get('clientProjectId') ?? undefined
+
+  try {
+    const snapshot = await buildModelUsageSnapshot({ from, to, clientProjectId })
+    return NextResponse.json({ ok: true, ...snapshot })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to build model usage snapshot'
+    console.error('[model-usage] summary failed:', error)
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/lib/cost-calculator.test.ts
+++ b/lib/cost-calculator.test.ts
@@ -144,8 +144,11 @@ describe('recordOpenAICost / recordAnthropicCost', () => {
       { operation: 'generate_insights' }
     )
 
-    expect(mocks.insertMock).toHaveBeenCalledTimes(1)
-    expect(mocks.insertMock).toHaveBeenCalledWith(
+    expect(mocks.insertMock).toHaveBeenCalledTimes(2)
+    expect(mocks.fromMock).toHaveBeenCalledWith('cost_events')
+    expect(mocks.fromMock).toHaveBeenCalledWith('model_usage_events')
+    expect(mocks.insertMock).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
         source: 'llm_openai',
         amount: 0.15,
@@ -153,8 +156,29 @@ describe('recordOpenAICost / recordAnthropicCost', () => {
         reference_type: 'diagnostic_audit',
         reference_id: 'audit-123',
         agent_run_id: null,
-        metadata: { model: 'gpt-4o-mini', operation: 'generate_insights' },
+        metadata: {
+          model: 'gpt-4o-mini',
+          prompt_tokens: 1_000_000,
+          completion_tokens: 0,
+          input_tokens: 1_000_000,
+          output_tokens: 0,
+          total_tokens: 1_000_000,
+          operation: 'generate_insights',
+        },
       })
+    )
+    expect(mocks.insertMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        input_tokens: 1_000_000,
+        output_tokens: 0,
+        total_tokens: 1_000_000,
+        cost_usd: 0.15,
+        cost_basis: 'metered',
+        confidence: 'high',
+      }),
     )
   })
 

--- a/lib/cost-calculator.ts
+++ b/lib/cost-calculator.ts
@@ -49,6 +49,19 @@ export interface CostEventInput {
   metadata?: Record<string, unknown>
 }
 
+function usageMetadata(usage: Usage): Record<string, number> {
+  return {
+    prompt_tokens: usage.prompt_tokens ?? usage.input_tokens ?? 0,
+    completion_tokens: usage.completion_tokens ?? usage.output_tokens ?? 0,
+    input_tokens: usage.input_tokens ?? usage.prompt_tokens ?? 0,
+    output_tokens: usage.output_tokens ?? usage.completion_tokens ?? 0,
+    total_tokens:
+      usage.total_tokens ??
+      (usage.prompt_tokens ?? usage.input_tokens ?? 0) +
+        (usage.completion_tokens ?? usage.output_tokens ?? 0),
+  }
+}
+
 /**
  * Compute OpenAI cost from token usage.
  */
@@ -126,6 +139,62 @@ export async function recordCostEvent(event: CostEventInput): Promise<{ ok: bool
   }
 }
 
+async function recordModelUsageLedgerEvent(input: {
+  usage: Usage
+  model: string
+  provider: 'openai' | 'anthropic'
+  amount: number
+  reference?: { type: string; id: string }
+  metadata?: Record<string, unknown>
+  agentRunId?: string
+}): Promise<void> {
+  try {
+    const { supabaseAdmin } = await import('@/lib/supabase')
+    if (!supabaseAdmin) return
+    const usage = usageMetadata(input.usage)
+    const metadata = input.metadata ?? {}
+    const taskCategory = typeof metadata.task_category === 'string' ? metadata.task_category : 'other'
+    const runtime = typeof metadata.runtime === 'string' ? metadata.runtime : 'api'
+    const clientProjectId = typeof metadata.client_project_id === 'string' ? metadata.client_project_id : null
+    const agentKey = typeof metadata.agent_key === 'string' ? metadata.agent_key : null
+    const actionLabel = typeof metadata.operation === 'string'
+      ? metadata.operation.replace(/_/g, ' ')
+      : input.reference?.type?.replace(/_/g, ' ') ?? 'Model usage transaction'
+
+    await supabaseAdmin.from('model_usage_events').insert({
+      occurred_at: new Date().toISOString(),
+      provider: input.provider,
+      runtime,
+      model: input.model,
+      task_category: taskCategory,
+      agent_key: agentKey,
+      client_project_id: clientProjectId,
+      client_label: typeof metadata.client_label === 'string' ? metadata.client_label : 'Portfolio',
+      action_label: actionLabel,
+      input_tokens: usage.input_tokens,
+      output_tokens: usage.output_tokens,
+      cached_tokens: typeof metadata.cached_tokens === 'number' ? metadata.cached_tokens : 0,
+      reasoning_tokens: typeof metadata.reasoning_tokens === 'number' ? metadata.reasoning_tokens : 0,
+      total_tokens: usage.total_tokens,
+      accepted_output_count: typeof metadata.accepted_output_count === 'number' ? metadata.accepted_output_count : 1,
+      resolved_work_item_count: typeof metadata.resolved_work_item_count === 'number' ? metadata.resolved_work_item_count : 0,
+      retry_count: typeof metadata.retry_count === 'number' ? metadata.retry_count : 0,
+      cost_usd: Math.round(input.amount * 10000) / 10000,
+      cost_basis: 'metered',
+      confidence: 'high',
+      source_type: input.reference?.type ?? 'llm_call',
+      source_id: input.reference?.id ?? input.agentRunId ?? null,
+      source_href: input.agentRunId ? `/admin/agents/runs/${input.agentRunId}` : null,
+      pricing_snapshot: { provider: input.provider, model: input.model, cost_event_source: `llm_${input.provider}` },
+      raw_metadata: metadata,
+      scrubbed: false,
+    })
+  } catch {
+    // Ledger writes are best-effort so older environments without the migration
+    // do not block the existing P&L cost event path.
+  }
+}
+
 /**
  * Record LLM cost after an OpenAI call.
  */
@@ -138,6 +207,7 @@ export async function recordOpenAICost(
 ): Promise<void> {
   const amount = computeOpenAICost(usage, model)
   if (amount <= 0) return
+  const usageFields = usageMetadata(usage)
   await recordCostEvent({
     occurred_at: new Date().toISOString(),
     source: 'llm_openai',
@@ -145,8 +215,9 @@ export async function recordOpenAICost(
     reference_type: reference?.type,
     reference_id: reference?.id,
     agent_run_id: agentRunId,
-    metadata: { model, ...metadata },
+    metadata: { model, ...usageFields, ...metadata },
   })
+  await recordModelUsageLedgerEvent({ usage, model, provider: 'openai', amount, reference, metadata, agentRunId })
 }
 
 /**
@@ -161,6 +232,7 @@ export async function recordAnthropicCost(
 ): Promise<void> {
   const amount = computeAnthropicCost(usage, model)
   if (amount <= 0) return
+  const usageFields = usageMetadata(usage)
   await recordCostEvent({
     occurred_at: new Date().toISOString(),
     source: 'llm_anthropic',
@@ -168,6 +240,7 @@ export async function recordAnthropicCost(
     reference_type: reference?.type,
     reference_id: reference?.id,
     agent_run_id: agentRunId,
-    metadata: { model, ...metadata },
+    metadata: { model, ...usageFields, ...metadata },
   })
+  await recordModelUsageLedgerEvent({ usage, model, provider: 'anthropic', amount, reference, metadata, agentRunId })
 }

--- a/lib/model-usage.test.ts
+++ b/lib/model-usage.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildModelUsageSnapshotFromEvents,
+  computeModelUsageCost,
+  inferModelUsageProvider,
+  inferTaskCategory,
+  modelUsageEventFromCostEvent,
+  type ModelUsageLedgerEvent,
+} from './model-usage'
+
+function event(overrides: Partial<ModelUsageLedgerEvent>): ModelUsageLedgerEvent {
+  return {
+    id: 'event-1',
+    occurredAt: '2026-06-01T12:00:00.000Z',
+    provider: 'openai',
+    runtime: 'codex',
+    model: 'gpt-4o-mini',
+    taskCategory: 'research',
+    agentKey: 'research-source-register',
+    clientProjectId: 'client-1',
+    clientLabel: 'Acme',
+    actionLabel: 'Audit research',
+    inputTokens: 1000,
+    outputTokens: 500,
+    cachedTokens: 0,
+    reasoningTokens: 0,
+    totalTokens: 1500,
+    acceptedOutputCount: 1,
+    resolvedWorkItemCount: 0,
+    retryCount: 0,
+    costUsd: 0.001,
+    costBasis: 'metered',
+    confidence: 'high',
+    sourceTrace: { type: 'agent_run', id: 'run-1', href: '/admin/agents/runs/run-1' },
+    scrubbed: false,
+    ...overrides,
+  }
+}
+
+describe('model usage cost and categorization', () => {
+  it('keeps Claude Code separate from direct Anthropic API usage', () => {
+    expect(inferModelUsageProvider('claude_code session import')).toBe('claude_code')
+    expect(inferModelUsageProvider('claude-sonnet-4-20250514')).toBe('anthropic')
+  })
+
+  it('computes catalog cost for Gemini usage', () => {
+    const result = computeModelUsageCost(
+      { input_tokens: 1_000_000, output_tokens: 100_000 },
+      'google',
+      'gemini-2.5-flash',
+    )
+
+    expect(result.costUsd).toBeCloseTo(0.55, 6)
+    expect(result.costBasis).toBe('catalog_priced')
+    expect(result.pricingSnapshot?.sourceUrl).toContain('google')
+  })
+
+  it('infers action categories from audit and workflow metadata', () => {
+    expect(inferTaskCategory({ operation: 'meeting_audit_enrichment' })).toBe('research')
+    expect(inferTaskCategory({ workflow_key: 'video_generation_prompt_format' })).toBe('video')
+    expect(inferTaskCategory({ artifact_type: 'linkedin_post' })).toBe('social')
+    expect(inferTaskCategory({ operation: 'gmail_outreach_draft' })).toBe('outreach')
+  })
+})
+
+describe('buildModelUsageSnapshotFromEvents', () => {
+  it('rolls up usage by model, client, task, runtime, and provider', () => {
+    const snapshot = buildModelUsageSnapshotFromEvents({
+      from: '2026-06-01T00:00:00.000Z',
+      to: '2026-06-30T23:59:59.999Z',
+      generatedAt: '2026-06-06T12:00:00.000Z',
+      events: [
+        event({ id: 'openai-research', totalTokens: 2000, costUsd: 0.01 }),
+        event({
+          id: 'claude-code',
+          provider: 'claude_code',
+          runtime: 'codex',
+          model: 'claude-sonnet-4-20250514',
+          taskCategory: 'coding',
+          clientProjectId: null,
+          clientLabel: 'Portfolio',
+          totalTokens: 6000,
+          costUsd: 0,
+          costBasis: 'inferred',
+          confidence: 'low',
+        }),
+      ],
+    })
+
+    expect(snapshot.totals).toMatchObject({
+      eventCount: 2,
+      totalTokens: 8000,
+      acceptedOutputCount: 2,
+      tokensPerAcceptedOutput: 4000,
+    })
+    expect(snapshot.byProvider.map((row) => row.key)).toEqual(['claude_code', 'openai'])
+    expect(snapshot.byClientProject.find((row) => row.key === 'portfolio')?.totalTokens).toBe(6000)
+    expect(snapshot.recommendations.find((item) => item.id === 'usage-source-confidence')).toBeTruthy()
+  })
+
+  it('prorates subscription allocations by token share with confidence labels', () => {
+    const snapshot = buildModelUsageSnapshotFromEvents({
+      from: '2026-06-01T00:00:00.000Z',
+      to: '2026-06-30T23:59:59.999Z',
+      events: [
+        event({ id: 'codex-a', provider: 'codex', totalTokens: 1000, costUsd: 0, costBasis: 'inferred', confidence: 'medium' }),
+        event({ id: 'codex-b', provider: 'codex', totalTokens: 3000, costUsd: 0, costBasis: 'inferred', confidence: 'medium' }),
+      ],
+      allocations: [{
+        id: 'alloc-1',
+        provider: 'codex',
+        runtime: 'any',
+        accountLabel: 'Codex Pro',
+        monthlyCostUsd: 40,
+        periodStart: '2026-06-01T00:00:00.000Z',
+        periodEnd: '2026-06-30T23:59:59.999Z',
+        allocationBasis: 'token_share',
+        confidence: 'medium',
+      }],
+    })
+
+    expect(snapshot.totals.costUsd).toBe(40)
+    expect(snapshot.events.find((item) => item.id === 'codex-a')?.costUsd).toBe(10)
+    expect(snapshot.events.find((item) => item.id === 'codex-b')?.costUsd).toBe(30)
+  })
+
+  it('recommends context slimming for high input-output imbalance', () => {
+    const snapshot = buildModelUsageSnapshotFromEvents({
+      from: '2026-06-01T00:00:00.000Z',
+      to: '2026-06-30T23:59:59.999Z',
+      events: [event({ id: 'heavy-context', inputTokens: 150_000, outputTokens: 1000, totalTokens: 151_000 })],
+    })
+
+    expect(snapshot.recommendations.find((item) => item.id === 'context-slimming')).toMatchObject({
+      approvalRequired: false,
+    })
+  })
+})
+
+describe('modelUsageEventFromCostEvent', () => {
+  it('converts legacy cost events into auditable usage rows', () => {
+    const converted = modelUsageEventFromCostEvent({
+      id: 'cost-1',
+      occurred_at: '2026-06-01T12:00:00.000Z',
+      source: 'llm_openai',
+      amount: 0.42,
+      reference_type: 'video_prompt',
+      reference_id: 'video-1',
+      agent_run_id: 'run-1',
+      metadata: {
+        model: 'gpt-4o-mini',
+        prompt_tokens: 100,
+        completion_tokens: 50,
+        operation: 'video_generation_prompt_format',
+      },
+    })
+
+    expect(converted).toMatchObject({
+      provider: 'openai',
+      taskCategory: 'video',
+      totalTokens: 150,
+      costUsd: 0.42,
+      confidence: 'high',
+      sourceTrace: { href: '/admin/agents/runs/run-1' },
+    })
+  })
+})

--- a/lib/model-usage.ts
+++ b/lib/model-usage.ts
@@ -1,0 +1,638 @@
+import { computeAnthropicCost, computeOpenAICost, type Usage } from '@/lib/cost-calculator'
+
+export type ModelUsageProvider =
+  | 'openai'
+  | 'anthropic'
+  | 'google'
+  | 'codex'
+  | 'claude_code'
+  | 'open_source'
+  | 'local'
+  | 'other'
+
+export type ModelUsageRuntime = 'codex' | 'n8n' | 'hermes' | 'opencode' | 'manual' | 'api' | 'local' | 'other'
+export type ModelUsageTaskCategory =
+  | 'research'
+  | 'coding'
+  | 'qa'
+  | 'planning'
+  | 'social'
+  | 'video'
+  | 'outreach'
+  | 'automation'
+  | 'rag'
+  | 'client_ops'
+  | 'other'
+
+export type ModelUsageCostBasis = 'metered' | 'catalog_priced' | 'subscription_prorated' | 'local_estimated' | 'inferred'
+export type ModelUsageConfidence = 'high' | 'medium' | 'low'
+
+export type ModelUsageLedgerEvent = {
+  id: string
+  occurredAt: string
+  provider: ModelUsageProvider
+  runtime: ModelUsageRuntime
+  model: string
+  taskCategory: ModelUsageTaskCategory
+  agentKey: string | null
+  clientProjectId: string | null
+  clientLabel: string
+  actionLabel: string
+  inputTokens: number
+  outputTokens: number
+  cachedTokens: number
+  reasoningTokens: number
+  totalTokens: number
+  acceptedOutputCount: number
+  resolvedWorkItemCount: number
+  retryCount: number
+  costUsd: number
+  costBasis: ModelUsageCostBasis
+  confidence: ModelUsageConfidence
+  sourceTrace: {
+    type: string
+    id: string | null
+    href?: string | null
+  }
+  pricingSnapshot?: Record<string, unknown>
+  scrubbed: boolean
+}
+
+export type ModelUsageSubscriptionAllocation = {
+  id: string
+  provider: ModelUsageProvider
+  runtime: ModelUsageRuntime | 'any'
+  accountLabel: string
+  monthlyCostUsd: number
+  periodStart: string
+  periodEnd: string
+  allocationBasis: 'token_share' | 'event_share' | 'manual_weight'
+  confidence: ModelUsageConfidence
+  notes?: string | null
+}
+
+export type ModelUsageSummaryGroup = {
+  key: string
+  label: string
+  totalTokens: number
+  costUsd: number
+  eventCount: number
+  acceptedOutputCount: number
+  efficiencyScore: number
+}
+
+export type ModelUsageRecommendation = {
+  id: string
+  severity: 'info' | 'warning' | 'critical'
+  title: string
+  action: string
+  rationale: string
+  affectedEventIds: string[]
+  approvalRequired: boolean
+}
+
+export type ModelUsageSnapshot = {
+  generatedAt: string
+  window: { from: string; to: string }
+  totals: {
+    eventCount: number
+    totalTokens: number
+    inputTokens: number
+    outputTokens: number
+    costUsd: number
+    meteredCostUsd: number
+    allocatedCostUsd: number
+    inferredCostUsd: number
+    acceptedOutputCount: number
+    tokensPerAcceptedOutput: number | null
+    costPerAcceptedOutput: number | null
+  }
+  byProvider: ModelUsageSummaryGroup[]
+  byModel: ModelUsageSummaryGroup[]
+  byRuntime: ModelUsageSummaryGroup[]
+  byTaskCategory: ModelUsageSummaryGroup[]
+  byClientProject: ModelUsageSummaryGroup[]
+  heatmap: Array<{ date: string; totalTokens: number; costUsd: number; eventCount: number; level: number }>
+  trend: Array<{ date: string; totalTokens: number; costUsd: number; eventCount: number }>
+  topDays: Array<{ date: string; totalTokens: number; costUsd: number; eventCount: number; primaryActivity: string }>
+  topTransactions: ModelUsageLedgerEvent[]
+  recommendations: ModelUsageRecommendation[]
+  events: ModelUsageLedgerEvent[]
+  clientSafeEvents: ModelUsageLedgerEvent[]
+}
+
+export type ModelPricingSnapshot = {
+  provider: ModelUsageProvider
+  model: string
+  inputUsdPer1MTokens: number
+  outputUsdPer1MTokens: number
+  sourceUrl: string
+  effectiveFrom: string
+  pricingState: 'current' | 'needs_review' | 'fallback'
+}
+
+export const MODEL_PRICING_CATALOG: ModelPricingSnapshot[] = [
+  { provider: 'openai', model: 'gpt-4o', inputUsdPer1MTokens: 2.5, outputUsdPer1MTokens: 10, sourceUrl: 'https://openai.com/api/pricing/', effectiveFrom: '2024-01-01', pricingState: 'needs_review' },
+  { provider: 'openai', model: 'gpt-4o-mini', inputUsdPer1MTokens: 0.15, outputUsdPer1MTokens: 0.6, sourceUrl: 'https://openai.com/api/pricing/', effectiveFrom: '2024-01-01', pricingState: 'needs_review' },
+  { provider: 'anthropic', model: 'claude-sonnet-4-20250514', inputUsdPer1MTokens: 3, outputUsdPer1MTokens: 15, sourceUrl: 'https://www.anthropic.com/pricing', effectiveFrom: '2025-05-14', pricingState: 'needs_review' },
+  { provider: 'anthropic', model: 'claude-3-5-sonnet-20241022', inputUsdPer1MTokens: 3, outputUsdPer1MTokens: 15, sourceUrl: 'https://www.anthropic.com/pricing', effectiveFrom: '2024-10-22', pricingState: 'needs_review' },
+  { provider: 'anthropic', model: 'claude-3-5-haiku-20241022', inputUsdPer1MTokens: 0.8, outputUsdPer1MTokens: 4, sourceUrl: 'https://www.anthropic.com/pricing', effectiveFrom: '2024-10-22', pricingState: 'needs_review' },
+  { provider: 'google', model: 'gemini-2.5-pro', inputUsdPer1MTokens: 1.25, outputUsdPer1MTokens: 10, sourceUrl: 'https://ai.google.dev/gemini-api/docs/pricing', effectiveFrom: '2025-01-01', pricingState: 'needs_review' },
+  { provider: 'google', model: 'gemini-2.5-flash', inputUsdPer1MTokens: 0.3, outputUsdPer1MTokens: 2.5, sourceUrl: 'https://ai.google.dev/gemini-api/docs/pricing', effectiveFrom: '2025-01-01', pricingState: 'needs_review' },
+]
+
+function roundUsd(value: number) {
+  return Math.round(value * 10_000) / 10_000
+}
+
+function safeNumber(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : 0
+  }
+  return 0
+}
+
+export function inferModelUsageProvider(sourceOrModel: string | null | undefined): ModelUsageProvider {
+  const value = (sourceOrModel ?? '').toLowerCase()
+  if (value.includes('claude_code') || value.includes('claude-code')) return 'claude_code'
+  if (value.includes('anthropic') || value.includes('claude')) return 'anthropic'
+  if (value.includes('openai') || value.includes('gpt')) return 'openai'
+  if (value.includes('google') || value.includes('gemini')) return 'google'
+  if (value.includes('codex')) return 'codex'
+  if (value.includes('ollama') || value.includes('local')) return 'local'
+  if (value.includes('open_source') || value.includes('open-weight')) return 'open_source'
+  return 'other'
+}
+
+export function inferTaskCategory(metadata: Record<string, unknown> | null | undefined): ModelUsageTaskCategory {
+  const joined = [
+    metadata?.task_category,
+    metadata?.operation,
+    metadata?.workflow_key,
+    metadata?.artifact_type,
+    metadata?.reference_type,
+  ].filter(Boolean).join(' ').toLowerCase()
+
+  if (/research|audit|source|meeting/.test(joined)) return 'research'
+  if (/video|prompt_format|ideas/.test(joined)) return 'video'
+  if (/social|linkedin|content|post/.test(joined)) return 'social'
+  if (/outreach|lead|email|gmail/.test(joined)) return 'outreach'
+  if (/qa|test|smoke|validation|diagnose/.test(joined)) return 'qa'
+  if (/roadmap|plan|decision|strategy/.test(joined)) return 'planning'
+  if (/rag|vector|retrieval|pinecone/.test(joined)) return 'rag'
+  if (/client|provision|ops/.test(joined)) return 'client_ops'
+  if (/automation|n8n|workflow/.test(joined)) return 'automation'
+  if (/code|coding|implementation/.test(joined)) return 'coding'
+  return 'other'
+}
+
+export function computeModelUsageCost(
+  usage: Usage,
+  provider: ModelUsageProvider,
+  model: string,
+): { costUsd: number; pricingSnapshot: ModelPricingSnapshot | null; costBasis: ModelUsageCostBasis } {
+  if (provider === 'openai') {
+    return { costUsd: roundUsd(computeOpenAICost(usage, model)), pricingSnapshot: pricingFor(provider, model), costBasis: 'catalog_priced' }
+  }
+  if (provider === 'anthropic') {
+    return { costUsd: roundUsd(computeAnthropicCost(usage, model)), pricingSnapshot: pricingFor(provider, model), costBasis: 'catalog_priced' }
+  }
+  const pricing = pricingFor(provider, model)
+  if (!pricing) return { costUsd: 0, pricingSnapshot: null, costBasis: provider === 'local' || provider === 'open_source' ? 'local_estimated' : 'inferred' }
+  const input = usage.prompt_tokens ?? usage.input_tokens ?? 0
+  const output = usage.completion_tokens ?? usage.output_tokens ?? 0
+  return {
+    costUsd: roundUsd((input / 1_000_000) * pricing.inputUsdPer1MTokens + (output / 1_000_000) * pricing.outputUsdPer1MTokens),
+    pricingSnapshot: pricing,
+    costBasis: 'catalog_priced',
+  }
+}
+
+export function pricingFor(provider: ModelUsageProvider, model: string): ModelPricingSnapshot | null {
+  return MODEL_PRICING_CATALOG.find((item) => item.provider === provider && item.model === model) ?? null
+}
+
+export function applySubscriptionAllocations(
+  events: ModelUsageLedgerEvent[],
+  allocations: ModelUsageSubscriptionAllocation[],
+): ModelUsageLedgerEvent[] {
+  if (events.length === 0 || allocations.length === 0) return events
+  return events.map((event) => ({ ...event }))
+    .map((event) => {
+      const matching = allocations.filter((allocation) => (
+        allocation.provider === event.provider &&
+        (allocation.runtime === 'any' || allocation.runtime === event.runtime) &&
+        event.occurredAt >= allocation.periodStart &&
+        event.occurredAt <= allocation.periodEnd
+      ))
+      if (matching.length === 0) return event
+      const totalTokenBasis = events
+        .filter((candidate) => candidate.provider === event.provider && candidate.occurredAt >= matching[0].periodStart && candidate.occurredAt <= matching[0].periodEnd)
+        .reduce((sum, candidate) => sum + Math.max(candidate.totalTokens, 1), 0)
+      const allocated = matching.reduce((sum, allocation) => {
+        const share = Math.max(event.totalTokens, 1) / Math.max(totalTokenBasis, 1)
+        return sum + allocation.monthlyCostUsd * share
+      }, 0)
+      if (allocated <= 0) return event
+      return {
+        ...event,
+        costUsd: roundUsd(event.costUsd + allocated),
+        costBasis: event.costUsd > 0 ? event.costBasis : 'subscription_prorated',
+        confidence: event.confidence === 'low' || matching.some((allocation) => allocation.confidence === 'low') ? 'low' : 'medium',
+        pricingSnapshot: {
+          ...event.pricingSnapshot,
+          subscriptionAllocation: matching.map((allocation) => ({
+            id: allocation.id,
+            accountLabel: allocation.accountLabel,
+            monthlyCostUsd: allocation.monthlyCostUsd,
+            allocationBasis: allocation.allocationBasis,
+            confidence: allocation.confidence,
+          })),
+        },
+      }
+    })
+}
+
+export function buildModelUsageSnapshotFromEvents(input: {
+  events: ModelUsageLedgerEvent[]
+  allocations?: ModelUsageSubscriptionAllocation[]
+  from: string
+  to: string
+  generatedAt?: string
+}): ModelUsageSnapshot {
+  const events = applySubscriptionAllocations(input.events, input.allocations ?? [])
+    .filter((event) => event.occurredAt >= input.from && event.occurredAt <= input.to)
+    .sort((a, b) => b.totalTokens - a.totalTokens)
+  const generatedAt = input.generatedAt ?? new Date().toISOString()
+  const acceptedOutputCount = events.reduce((sum, event) => sum + event.acceptedOutputCount, 0)
+  const totalTokens = events.reduce((sum, event) => sum + event.totalTokens, 0)
+  const costUsd = roundUsd(events.reduce((sum, event) => sum + event.costUsd, 0))
+  const totals = {
+    eventCount: events.length,
+    totalTokens,
+    inputTokens: events.reduce((sum, event) => sum + event.inputTokens, 0),
+    outputTokens: events.reduce((sum, event) => sum + event.outputTokens, 0),
+    costUsd,
+    meteredCostUsd: roundUsd(events.filter((event) => event.costBasis === 'metered' || event.costBasis === 'catalog_priced').reduce((sum, event) => sum + event.costUsd, 0)),
+    allocatedCostUsd: roundUsd(events.filter((event) => event.costBasis === 'subscription_prorated').reduce((sum, event) => sum + event.costUsd, 0)),
+    inferredCostUsd: roundUsd(events.filter((event) => event.costBasis === 'inferred' || event.costBasis === 'local_estimated').reduce((sum, event) => sum + event.costUsd, 0)),
+    acceptedOutputCount,
+    tokensPerAcceptedOutput: acceptedOutputCount > 0 ? Math.round(totalTokens / acceptedOutputCount) : null,
+    costPerAcceptedOutput: acceptedOutputCount > 0 ? roundUsd(costUsd / acceptedOutputCount) : null,
+  }
+
+  const trend = buildDailyTrend(events)
+  return {
+    generatedAt,
+    window: { from: input.from, to: input.to },
+    totals,
+    byProvider: groupEvents(events, (event) => event.provider, (event) => labelForKey(event.provider)),
+    byModel: groupEvents(events, (event) => event.model, (event) => event.model),
+    byRuntime: groupEvents(events, (event) => event.runtime, (event) => labelForKey(event.runtime)),
+    byTaskCategory: groupEvents(events, (event) => event.taskCategory, (event) => labelForKey(event.taskCategory)),
+    byClientProject: groupEvents(events, (event) => event.clientProjectId ?? 'portfolio', (event) => event.clientLabel),
+    heatmap: trend.map((day) => ({ ...day, level: heatmapLevel(day.totalTokens, trend) })),
+    trend,
+    topDays: trend
+      .slice()
+      .sort((a, b) => b.totalTokens - a.totalTokens)
+      .slice(0, 10)
+      .map((day) => ({
+        ...day,
+        primaryActivity: primaryActivityForDay(events, day.date),
+      })),
+    topTransactions: events.slice(0, 25),
+    recommendations: buildModelUsageRecommendations(events),
+    events,
+    clientSafeEvents: events.map(scrubClientSafeEvent),
+  }
+}
+
+function groupEvents(
+  events: ModelUsageLedgerEvent[],
+  keyFor: (event: ModelUsageLedgerEvent) => string,
+  labelFor: (event: ModelUsageLedgerEvent) => string,
+): ModelUsageSummaryGroup[] {
+  const groups = new Map<string, ModelUsageSummaryGroup>()
+  for (const event of events) {
+    const key = keyFor(event)
+    const existing = groups.get(key) ?? {
+      key,
+      label: labelFor(event),
+      totalTokens: 0,
+      costUsd: 0,
+      eventCount: 0,
+      acceptedOutputCount: 0,
+      efficiencyScore: 0,
+    }
+    existing.totalTokens += event.totalTokens
+    existing.costUsd = roundUsd(existing.costUsd + event.costUsd)
+    existing.eventCount += 1
+    existing.acceptedOutputCount += event.acceptedOutputCount
+    existing.efficiencyScore = efficiencyScore(existing.totalTokens, existing.costUsd, existing.acceptedOutputCount)
+    groups.set(key, existing)
+  }
+  return [...groups.values()].sort((a, b) => b.totalTokens - a.totalTokens)
+}
+
+function buildDailyTrend(events: ModelUsageLedgerEvent[]) {
+  const byDate = new Map<string, { date: string; totalTokens: number; costUsd: number; eventCount: number }>()
+  for (const event of events) {
+    const date = event.occurredAt.slice(0, 10)
+    const row = byDate.get(date) ?? { date, totalTokens: 0, costUsd: 0, eventCount: 0 }
+    row.totalTokens += event.totalTokens
+    row.costUsd = roundUsd(row.costUsd + event.costUsd)
+    row.eventCount += 1
+    byDate.set(date, row)
+  }
+  return [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date))
+}
+
+function heatmapLevel(tokens: number, trend: Array<{ totalTokens: number }>) {
+  const max = Math.max(...trend.map((day) => day.totalTokens), 0)
+  if (tokens <= 0 || max <= 0) return 0
+  return Math.max(1, Math.min(4, Math.ceil((tokens / max) * 4)))
+}
+
+function primaryActivityForDay(events: ModelUsageLedgerEvent[], date: string) {
+  const groups = groupEvents(events.filter((event) => event.occurredAt.startsWith(date)), (event) => event.taskCategory, (event) => labelForKey(event.taskCategory))
+  return groups[0]?.label ?? 'No categorized activity'
+}
+
+function efficiencyScore(tokens: number, costUsd: number, acceptedOutputs: number) {
+  if (tokens <= 0 || acceptedOutputs <= 0) return 0
+  const tokensPerOutput = tokens / acceptedOutputs
+  const costPenalty = costUsd > 0 ? Math.log10(costUsd + 1) : 0
+  return Math.round(Math.max(0, 100 - tokensPerOutput / 10_000 - costPenalty * 10))
+}
+
+function labelForKey(value: string) {
+  return value.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase())
+}
+
+function buildModelUsageRecommendations(events: ModelUsageLedgerEvent[]): ModelUsageRecommendation[] {
+  const recommendations: ModelUsageRecommendation[] = []
+  const highInputEvents = events.filter((event) => event.inputTokens > 100_000 && event.inputTokens > event.outputTokens * 8)
+  if (highInputEvents.length > 0) {
+    recommendations.push({
+      id: 'context-slimming',
+      severity: 'warning',
+      title: 'Slim repeated context before the next run',
+      action: 'Move reusable context into RAG, summaries, or project memory and pass only the task-specific delta.',
+      rationale: `${highInputEvents.length} transaction(s) used heavy input context relative to output.`,
+      affectedEventIds: highInputEvents.slice(0, 10).map((event) => event.id),
+      approvalRequired: false,
+    })
+  }
+  const lowConfidence = events.filter((event) => event.confidence === 'low')
+  if (lowConfidence.length > 0) {
+    recommendations.push({
+      id: 'usage-source-confidence',
+      severity: 'info',
+      title: 'Improve usage source confidence',
+      action: 'Attach exact provider usage exports or audited session logs for low-confidence model spend.',
+      rationale: `${lowConfidence.length} transaction(s) are currently inferred or subscription-prorated with low confidence.`,
+      affectedEventIds: lowConfidence.slice(0, 10).map((event) => event.id),
+      approvalRequired: false,
+    })
+  }
+  const expensiveResearch = events.filter((event) => event.taskCategory === 'research' && event.costUsd > 2)
+  if (expensiveResearch.length > 0) {
+    recommendations.push({
+      id: 'research-model-bakeoff',
+      severity: 'warning',
+      title: 'Run a research model bakeoff',
+      action: 'Compare the same research packet across a lower-cost model, cached RAG, and the incumbent model before changing routing.',
+      rationale: `${expensiveResearch.length} research transaction(s) crossed the V1 cost threshold.`,
+      affectedEventIds: expensiveResearch.slice(0, 10).map((event) => event.id),
+      approvalRequired: true,
+    })
+  }
+  return recommendations
+}
+
+function scrubClientSafeEvent(event: ModelUsageLedgerEvent): ModelUsageLedgerEvent {
+  return {
+    ...event,
+    actionLabel: event.taskCategory === 'other' ? 'Model usage transaction' : `${labelForKey(event.taskCategory)} transaction`,
+    sourceTrace: { type: event.sourceTrace.type, id: event.sourceTrace.id ? 'redacted' : null, href: null },
+    pricingSnapshot: event.pricingSnapshot ? { confidence: event.confidence, costBasis: event.costBasis } : undefined,
+    scrubbed: true,
+  }
+}
+
+type ModelUsageEventRow = {
+  id: string
+  occurred_at: string
+  provider: string | null
+  runtime: string | null
+  model: string | null
+  task_category: string | null
+  agent_key: string | null
+  client_project_id: string | null
+  client_label: string | null
+  action_label: string | null
+  input_tokens: number | null
+  output_tokens: number | null
+  cached_tokens: number | null
+  reasoning_tokens: number | null
+  total_tokens: number | null
+  accepted_output_count: number | null
+  resolved_work_item_count: number | null
+  retry_count: number | null
+  cost_usd: number | null
+  cost_basis: string | null
+  confidence: string | null
+  source_type: string | null
+  source_id: string | null
+  source_href: string | null
+  pricing_snapshot: Record<string, unknown> | null
+  scrubbed: boolean | null
+}
+
+type CostEventRow = {
+  id: string
+  occurred_at: string
+  source: string | null
+  amount: number | string | null
+  reference_type: string | null
+  reference_id: string | null
+  agent_run_id: string | null
+  metadata: Record<string, unknown> | null
+}
+
+type SubscriptionAllocationRow = {
+  id: string
+  provider: string | null
+  runtime: string | null
+  account_label: string | null
+  monthly_cost_usd: number | null
+  period_start: string
+  period_end: string
+  allocation_basis: string | null
+  confidence: string | null
+  notes: string | null
+}
+
+export async function buildModelUsageSnapshot(input?: {
+  from?: string
+  to?: string
+  clientProjectId?: string
+}): Promise<ModelUsageSnapshot> {
+  const { supabaseAdmin } = await import('@/lib/supabase')
+  if (!supabaseAdmin) throw new Error('Database not available')
+  const now = new Date()
+  const to = input?.to ? endOfDayIso(input.to) : now.toISOString()
+  const from = input?.from ? startOfDayIso(input.from) : new Date(now.getTime() - 29 * 24 * 60 * 60 * 1000).toISOString()
+
+  let usageQuery = supabaseAdmin
+    .from('model_usage_events')
+    .select('*')
+    .gte('occurred_at', from)
+    .lte('occurred_at', to)
+    .order('occurred_at', { ascending: false })
+    .limit(1000)
+  if (input?.clientProjectId) usageQuery = usageQuery.eq('client_project_id', input.clientProjectId)
+
+  const [usageResult, costResult, allocationResult] = await Promise.all([
+    usageQuery,
+    supabaseAdmin.from('cost_events').select('id, occurred_at, source, amount, reference_type, reference_id, agent_run_id, metadata').gte('occurred_at', from).lte('occurred_at', to).order('occurred_at', { ascending: false }).limit(1000),
+    supabaseAdmin.from('model_usage_subscription_allocations').select('*').lte('period_start', to).gte('period_end', from).eq('active', true),
+  ])
+
+  const ledgerEvents = (usageResult.error ? [] : ((usageResult.data ?? []) as ModelUsageEventRow[]).map(modelUsageEventFromRow))
+  const fallbackEvents = (costResult.error ? [] : ((costResult.data ?? []) as CostEventRow[]).map(modelUsageEventFromCostEvent))
+    .filter((event) => !ledgerEvents.some((existing) => existing.sourceTrace.type === event.sourceTrace.type && existing.sourceTrace.id === event.sourceTrace.id))
+  const allocations = allocationResult.error ? [] : ((allocationResult.data ?? []) as SubscriptionAllocationRow[]).map(subscriptionAllocationFromRow)
+
+  return buildModelUsageSnapshotFromEvents({
+    events: [...ledgerEvents, ...fallbackEvents],
+    allocations,
+    from,
+    to,
+  })
+}
+
+export function modelUsageEventFromCostEvent(row: CostEventRow): ModelUsageLedgerEvent {
+  const metadata = row.metadata ?? {}
+  const model = typeof metadata.model === 'string' ? metadata.model : 'unknown-model'
+  const provider = inferModelUsageProvider(`${row.source ?? ''} ${model}`)
+  const inputTokens = safeNumber(metadata.prompt_tokens) || safeNumber(metadata.input_tokens)
+  const outputTokens = safeNumber(metadata.completion_tokens) || safeNumber(metadata.output_tokens)
+  const totalTokens = safeNumber(metadata.total_tokens) || inputTokens + outputTokens
+  return {
+    id: `cost-${row.id}`,
+    occurredAt: row.occurred_at,
+    provider,
+    runtime: runtimeFromMetadata(metadata),
+    model,
+    taskCategory: inferTaskCategory({ ...metadata, reference_type: row.reference_type }),
+    agentKey: typeof metadata.agent_key === 'string' ? metadata.agent_key : null,
+    clientProjectId: typeof metadata.client_project_id === 'string' ? metadata.client_project_id : null,
+    clientLabel: typeof metadata.client_label === 'string' ? metadata.client_label : 'Portfolio',
+    actionLabel: typeof metadata.operation === 'string' ? metadata.operation.replace(/_/g, ' ') : row.reference_type ?? 'Model usage transaction',
+    inputTokens,
+    outputTokens,
+    cachedTokens: safeNumber(metadata.cached_tokens),
+    reasoningTokens: safeNumber(metadata.reasoning_tokens),
+    totalTokens,
+    acceptedOutputCount: safeNumber(metadata.accepted_output_count) || 1,
+    resolvedWorkItemCount: safeNumber(metadata.resolved_work_item_count),
+    retryCount: safeNumber(metadata.retry_count),
+    costUsd: roundUsd(safeNumber(row.amount)),
+    costBasis: 'metered',
+    confidence: totalTokens > 0 ? 'high' : 'medium',
+    sourceTrace: {
+      type: row.reference_type ?? 'cost_event',
+      id: row.reference_id ?? row.id,
+      href: row.agent_run_id ? `/admin/agents/runs/${row.agent_run_id}` : null,
+    },
+    pricingSnapshot: typeof metadata.pricing_snapshot === 'object' && metadata.pricing_snapshot ? metadata.pricing_snapshot as Record<string, unknown> : pricingFor(provider, model) ?? undefined,
+    scrubbed: false,
+  }
+}
+
+function modelUsageEventFromRow(row: ModelUsageEventRow): ModelUsageLedgerEvent {
+  const inputTokens = safeNumber(row.input_tokens)
+  const outputTokens = safeNumber(row.output_tokens)
+  return {
+    id: row.id,
+    occurredAt: row.occurred_at,
+    provider: normalizeProvider(row.provider),
+    runtime: normalizeRuntime(row.runtime),
+    model: row.model ?? 'unknown-model',
+    taskCategory: normalizeTaskCategory(row.task_category),
+    agentKey: row.agent_key,
+    clientProjectId: row.client_project_id,
+    clientLabel: row.client_label ?? 'Portfolio',
+    actionLabel: row.action_label ?? 'Model usage transaction',
+    inputTokens,
+    outputTokens,
+    cachedTokens: safeNumber(row.cached_tokens),
+    reasoningTokens: safeNumber(row.reasoning_tokens),
+    totalTokens: safeNumber(row.total_tokens) || inputTokens + outputTokens,
+    acceptedOutputCount: safeNumber(row.accepted_output_count),
+    resolvedWorkItemCount: safeNumber(row.resolved_work_item_count),
+    retryCount: safeNumber(row.retry_count),
+    costUsd: roundUsd(safeNumber(row.cost_usd)),
+    costBasis: normalizeCostBasis(row.cost_basis),
+    confidence: normalizeConfidence(row.confidence),
+    sourceTrace: { type: row.source_type ?? 'model_usage_event', id: row.source_id, href: row.source_href },
+    pricingSnapshot: row.pricing_snapshot ?? undefined,
+    scrubbed: Boolean(row.scrubbed),
+  }
+}
+
+function subscriptionAllocationFromRow(row: SubscriptionAllocationRow): ModelUsageSubscriptionAllocation {
+  return {
+    id: row.id,
+    provider: normalizeProvider(row.provider),
+    runtime: row.runtime === 'any' ? 'any' : normalizeRuntime(row.runtime),
+    accountLabel: row.account_label ?? 'Unlabeled account',
+    monthlyCostUsd: safeNumber(row.monthly_cost_usd),
+    periodStart: row.period_start,
+    periodEnd: row.period_end,
+    allocationBasis: row.allocation_basis === 'event_share' || row.allocation_basis === 'manual_weight' ? row.allocation_basis : 'token_share',
+    confidence: normalizeConfidence(row.confidence),
+    notes: row.notes,
+  }
+}
+
+function runtimeFromMetadata(metadata: Record<string, unknown>): ModelUsageRuntime {
+  return normalizeRuntime(typeof metadata.runtime === 'string' ? metadata.runtime : null)
+}
+
+function normalizeProvider(value: string | null | undefined): ModelUsageProvider {
+  const provider = inferModelUsageProvider(value)
+  return provider
+}
+
+function normalizeRuntime(value: string | null | undefined): ModelUsageRuntime {
+  if (value === 'codex' || value === 'n8n' || value === 'hermes' || value === 'opencode' || value === 'manual' || value === 'api' || value === 'local') return value
+  return 'other'
+}
+
+function normalizeTaskCategory(value: string | null | undefined): ModelUsageTaskCategory {
+  if (value === 'research' || value === 'coding' || value === 'qa' || value === 'planning' || value === 'social' || value === 'video' || value === 'outreach' || value === 'automation' || value === 'rag' || value === 'client_ops') return value
+  return 'other'
+}
+
+function normalizeCostBasis(value: string | null | undefined): ModelUsageCostBasis {
+  if (value === 'metered' || value === 'catalog_priced' || value === 'subscription_prorated' || value === 'local_estimated' || value === 'inferred') return value
+  return 'inferred'
+}
+
+function normalizeConfidence(value: string | null | undefined): ModelUsageConfidence {
+  if (value === 'high' || value === 'medium' || value === 'low') return value
+  return 'medium'
+}
+
+function startOfDayIso(value: string) {
+  return `${value.slice(0, 10)}T00:00:00.000Z`
+}
+
+function endOfDayIso(value: string) {
+  return `${value.slice(0, 10)}T23:59:59.999Z`
+}

--- a/supabase/migrations/20260606113000_model_usage_control_plane.sql
+++ b/supabase/migrations/20260606113000_model_usage_control_plane.sql
@@ -1,0 +1,99 @@
+-- Model Usage And Token Efficiency Control Plane
+-- Adds an auditable, read-first ledger for model usage attribution while
+-- keeping existing cost_events as the Portfolio P&L rollup source.
+
+CREATE TABLE IF NOT EXISTS public.model_usage_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  occurred_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  provider TEXT NOT NULL
+    CHECK (provider IN ('openai', 'anthropic', 'google', 'codex', 'claude_code', 'open_source', 'local', 'other')),
+  runtime TEXT NOT NULL DEFAULT 'api'
+    CHECK (runtime IN ('codex', 'n8n', 'hermes', 'opencode', 'manual', 'api', 'local', 'other')),
+  model TEXT NOT NULL,
+  task_category TEXT NOT NULL DEFAULT 'other'
+    CHECK (task_category IN ('research', 'coding', 'qa', 'planning', 'social', 'video', 'outreach', 'automation', 'rag', 'client_ops', 'other')),
+  agent_key TEXT,
+  client_project_id UUID REFERENCES public.client_projects(id) ON DELETE SET NULL,
+  client_label TEXT NOT NULL DEFAULT 'Portfolio',
+  action_label TEXT NOT NULL DEFAULT 'Model usage transaction',
+  input_tokens INTEGER NOT NULL DEFAULT 0 CHECK (input_tokens >= 0),
+  output_tokens INTEGER NOT NULL DEFAULT 0 CHECK (output_tokens >= 0),
+  cached_tokens INTEGER NOT NULL DEFAULT 0 CHECK (cached_tokens >= 0),
+  reasoning_tokens INTEGER NOT NULL DEFAULT 0 CHECK (reasoning_tokens >= 0),
+  total_tokens INTEGER NOT NULL DEFAULT 0 CHECK (total_tokens >= 0),
+  accepted_output_count INTEGER NOT NULL DEFAULT 0 CHECK (accepted_output_count >= 0),
+  resolved_work_item_count INTEGER NOT NULL DEFAULT 0 CHECK (resolved_work_item_count >= 0),
+  retry_count INTEGER NOT NULL DEFAULT 0 CHECK (retry_count >= 0),
+  cost_usd NUMERIC(12, 6) NOT NULL DEFAULT 0 CHECK (cost_usd >= 0),
+  cost_basis TEXT NOT NULL DEFAULT 'inferred'
+    CHECK (cost_basis IN ('metered', 'catalog_priced', 'subscription_prorated', 'local_estimated', 'inferred')),
+  confidence TEXT NOT NULL DEFAULT 'medium'
+    CHECK (confidence IN ('high', 'medium', 'low')),
+  source_type TEXT NOT NULL DEFAULT 'model_usage_event',
+  source_id TEXT,
+  source_href TEXT,
+  pricing_snapshot JSONB NOT NULL DEFAULT '{}'::jsonb,
+  raw_metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  scrubbed BOOLEAN NOT NULL DEFAULT false,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS model_usage_events_occurred_at_idx
+  ON public.model_usage_events(occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS model_usage_events_client_project_idx
+  ON public.model_usage_events(client_project_id, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS model_usage_events_provider_model_idx
+  ON public.model_usage_events(provider, model, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS model_usage_events_runtime_agent_idx
+  ON public.model_usage_events(runtime, agent_key, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS model_usage_events_task_category_idx
+  ON public.model_usage_events(task_category, occurred_at DESC);
+
+CREATE UNIQUE INDEX IF NOT EXISTS model_usage_events_source_unique_idx
+  ON public.model_usage_events(source_type, source_id)
+  WHERE source_id IS NOT NULL;
+
+ALTER TABLE public.model_usage_events ENABLE ROW LEVEL SECURITY;
+
+CREATE TABLE IF NOT EXISTS public.model_usage_subscription_allocations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  provider TEXT NOT NULL
+    CHECK (provider IN ('openai', 'anthropic', 'google', 'codex', 'claude_code', 'open_source', 'local', 'other')),
+  runtime TEXT NOT NULL DEFAULT 'any'
+    CHECK (runtime IN ('any', 'codex', 'n8n', 'hermes', 'opencode', 'manual', 'api', 'local', 'other')),
+  account_label TEXT NOT NULL,
+  monthly_cost_usd NUMERIC(12, 2) NOT NULL CHECK (monthly_cost_usd >= 0),
+  period_start TIMESTAMPTZ NOT NULL,
+  period_end TIMESTAMPTZ NOT NULL,
+  allocation_basis TEXT NOT NULL DEFAULT 'token_share'
+    CHECK (allocation_basis IN ('token_share', 'event_share', 'manual_weight')),
+  confidence TEXT NOT NULL DEFAULT 'medium'
+    CHECK (confidence IN ('high', 'medium', 'low')),
+  notes TEXT,
+  active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CHECK (period_end > period_start)
+);
+
+CREATE INDEX IF NOT EXISTS model_usage_subscription_period_idx
+  ON public.model_usage_subscription_allocations(provider, runtime, period_start, period_end)
+  WHERE active = true;
+
+ALTER TABLE public.model_usage_subscription_allocations ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE public.model_usage_events IS
+  'Auditable model usage ledger for token, cost, confidence, task, agent, and client/project attribution. Provider writes and credential actions remain approval-gated outside this table.';
+
+COMMENT ON COLUMN public.model_usage_events.cost_basis IS
+  'How the event cost was derived: exact meter, pricing catalog, subscription allocation, local estimate, or inference.';
+
+COMMENT ON COLUMN public.model_usage_events.pricing_snapshot IS
+  'Historical pricing or allocation evidence used for auditability at the time the event was recorded.';
+
+COMMENT ON TABLE public.model_usage_subscription_allocations IS
+  'Read-only/admin-configured monthly subscription allocation rules for flat-rate or hard-to-meter model tools.';


### PR DESCRIPTION
## Summary
- Adds an admin-first Model Usage and Token Efficiency dashboard under Agent Ops with token burn heatmap, rollups, filters, recommendations, and transaction drilldown.
- Adds a model usage ledger/read model with provider/runtime/model/task/client attribution, exact or inferred cost basis, confidence labels, pricing snapshots, and scrubbed client-safe projections.
- Extends existing OpenAI/Anthropic cost recorders to preserve token fields in `cost_events` and best-effort write `model_usage_events` without blocking current P&L writes.
- Adds client-project scoped model usage API for Client AI Ops portability while keeping raw private data out of the projection.

## Enhancement Impact Preflight
- Enhancement: Model usage and token efficiency control plane for Client AI Ops and Agent Ops.
- User-facing surface: `/admin/agents/model-usage`, `/api/admin/model-usage/summary`, `/api/admin/client-projects/[id]/ai-ops/model-usage`, and a Cost & Revenue link.
- Predicted files: `lib/model-usage*`, `lib/cost-calculator*`, `app/admin/agents/model-usage/*`, `app/api/admin/model-usage/**`, `app/api/admin/client-projects/**/ai-ops/model-usage/**`, `app/admin/cost-revenue/page.tsx`, Supabase migration.
- Shared routes/APIs/tables/helpers: existing `cost_events`, `recordOpenAICost`, `recordAnthropicCost`, Agent Ops admin UI, Client AI Ops API path.
- Active PRs or branches checked: #502, #504, #505, #506, #507, #508.
- Dirty worktree files checked: root Portfolio detached checkout has unrelated subscription-monitor files; this work used isolated worktree `/Users/vambahsillah/Projects/Portfolio.worktrees/client-ai-ops-roadmap`.
- Overlap rating: yellow.
- Coordination decision: proceed in isolated branch; avoid replacing Agent Ops Mission Control and keep new UI on a dedicated route. PR #504 also edits `app/admin/agents/page.tsx`, so this branch does not modify that shared page.
- Merge-order note: can merge after or before adjacent test/social/client-journey PRs; if #504 changes Agent Ops navigation, integration captain may add the model-usage link there during merge.

## Validation
- `npm test -- lib/model-usage.test.ts lib/cost-calculator.test.ts app/api/admin/model-usage/summary/route.test.ts 'app/api/admin/client-projects/[id]/ai-ops/model-usage/route.test.ts' app/admin/agents/model-usage/page.test.tsx` ✅
- `npx tsc --noEmit` ✅ after `npm run build:knowledge` generated ignored chatbot knowledge content.
- `npm run build` ⚠️ compiled successfully and reached page-data collection, then failed because this isolated worktree has no Supabase env vars (`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`). No live workflow/customer-data smoke was run.

## Integration Notes
- Migration required: `supabase/migrations/20260606113000_model_usage_control_plane.sql` creates `model_usage_events` and `model_usage_subscription_allocations` with RLS enabled.
- V1 remains read-only/import-only at the dashboard/API layer. Provider billing access, credential sync, OAuth setup, account writes, outbound sends, client-data mutation, and automatic model routing remain outside this PR and approval-gated.
- Existing `cost_events` remains the P&L rollup source; the new ledger adds token/cost auditability and client-safe projections.
- Vercel – portfolio: not checked from this non-captain branch.
- Vercel – portfolio-staging: not checked from this non-captain branch.
