### PR TITLE
feat: add model usage import packets

### DIFF
--- a/app/admin/agents/model-usage/page.test.tsx
+++ b/app/admin/agents/model-usage/page.test.tsx
@@ -99,5 +99,7 @@ describe('ModelUsagePage', () => {
     expect(screen.getByText('Token burn calendar')).toBeInTheDocument()
     expect(screen.getByText('Slim repeated context before the next run')).toBeInTheDocument()
     expect(screen.getByText('Research transaction')).toBeInTheDocument()
+    expect(screen.getByText('Reviewed usage import packet')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Dry run/i })).toBeInTheDocument()
   })
 })

--- a/app/admin/agents/model-usage/page.tsx
+++ b/app/admin/agents/model-usage/page.tsx
@@ -24,6 +24,39 @@ type Snapshot = ModelUsageSnapshot & { ok?: boolean }
 
 type DatePreset = '30d' | 'mtd' | 'qtd'
 
+const DEFAULT_IMPORT_PACKET = JSON.stringify({
+  events: [
+    {
+      occurredAt: '2026-06-06T12:00:00.000Z',
+      provider: 'codex',
+      runtime: 'codex',
+      model: 'gpt-5-codex',
+      taskCategory: 'coding',
+      clientLabel: 'Portfolio',
+      actionLabel: 'Reviewed Codex session import',
+      inputTokens: 12000,
+      outputTokens: 1800,
+      costBasis: 'subscription_prorated',
+      confidence: 'medium',
+      sourceTrace: { type: 'codex_session_import', id: 'replace-with-session-id' },
+      sourceMetadata: { source: 'manual-reviewed-import', category: 'implementation' },
+    },
+  ],
+  subscriptionAllocations: [
+    {
+      provider: 'codex',
+      runtime: 'any',
+      accountLabel: 'Codex subscription',
+      monthlyCostUsd: 20,
+      periodStart: '2026-06-01T00:00:00.000Z',
+      periodEnd: '2026-06-30T23:59:59.999Z',
+      allocationBasis: 'token_share',
+      confidence: 'medium',
+      notes: 'Reviewed flat-rate allocation; no provider account connection.',
+    },
+  ],
+}, null, 2)
+
 function dateRange(preset: DatePreset) {
   const now = new Date()
   const to = now.toISOString().slice(0, 10)
@@ -65,6 +98,9 @@ function ModelUsageContent() {
   const [modelFilter, setModelFilter] = useState('all')
   const [runtimeFilter, setRuntimeFilter] = useState('all')
   const [confidenceFilter, setConfidenceFilter] = useState('all')
+  const [importText, setImportText] = useState(DEFAULT_IMPORT_PACKET)
+  const [importing, setImporting] = useState(false)
+  const [importResult, setImportResult] = useState<string | null>(null)
 
   const fetchSnapshot = useCallback(async () => {
     setLoading(true)
@@ -112,6 +148,36 @@ function ModelUsageContent() {
       confidences: uniqueOptions(events.map((event) => ({ key: event.confidence, label: event.confidence }))),
     }
   }, [snapshot?.events])
+
+  const submitImportPacket = useCallback(async (dryRun: boolean) => {
+    setImporting(true)
+    setImportResult(null)
+    try {
+      const parsed = JSON.parse(importText)
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Missing admin session')
+      const res = await fetch('/api/admin/model-usage/import', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${session.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ ...parsed, dryRun }),
+      })
+      const body = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(body.error || `HTTP ${res.status}`)
+      if (dryRun) {
+        setImportResult(`Dry run passed: ${body.eventCount ?? 0} event(s), ${body.subscriptionAllocationCount ?? 0} allocation row(s). ${(body.warnings ?? []).join(' ')}`)
+      } else {
+        setImportResult(`Imported ${body.insertedEvents ?? 0} event(s) and ${body.insertedSubscriptionAllocations ?? 0} allocation row(s). ${(body.warnings ?? []).join(' ')}`)
+        fetchSnapshot()
+      }
+    } catch (err) {
+      setImportResult(err instanceof Error ? err.message : 'Import failed')
+    } finally {
+      setImporting(false)
+    }
+  }, [fetchSnapshot, importText])
 
   return (
     <div className="agent-ops-page min-h-screen p-5 text-foreground lg:p-7">
@@ -234,6 +300,52 @@ function ModelUsageContent() {
                   )}
                 </div>
               </div>
+            </section>
+
+            <section className="agent-ops-card rounded-lg border p-4">
+              <div className="mb-4 flex flex-col gap-2 xl:flex-row xl:items-start xl:justify-between">
+                <div>
+                  <div className="flex items-center gap-2 text-sm font-semibold">
+                    <BrainCircuit size={16} className="text-radiant-gold" />
+                    Reviewed usage import packet
+                  </div>
+                  <p className="mt-1 max-w-3xl text-xs text-muted-foreground">
+                    Import audited usage rows or subscription allocation rules from Codex, Claude Code, Gemini, or local model records. Raw prompts, transcripts, secrets, credentials, and provider account actions are blocked from this path.
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={() => submitImportPacket(true)}
+                    disabled={importing}
+                    className="agent-ops-button-muted disabled:opacity-60"
+                  >
+                    <ShieldCheck size={16} />
+                    Dry run
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => submitImportPacket(false)}
+                    disabled={importing}
+                    className="agent-ops-button-secondary disabled:opacity-60"
+                  >
+                    <Activity size={16} />
+                    Import reviewed packet
+                  </button>
+                </div>
+              </div>
+              <textarea
+                value={importText}
+                onChange={(event) => setImportText(event.target.value)}
+                spellCheck={false}
+                className="min-h-[220px] w-full rounded-lg border border-silicon-slate/60 bg-background/80 p-3 font-mono text-xs text-foreground outline-none focus:border-radiant-gold/60"
+                aria-label="Model usage import packet JSON"
+              />
+              {importResult ? (
+                <p className="mt-3 rounded-lg border border-silicon-slate/60 bg-background/45 p-3 text-sm text-muted-foreground">
+                  {importResult}
+                </p>
+              ) : null}
             </section>
 
             <section className="agent-ops-card rounded-lg border p-4">

--- a/app/api/admin/model-usage/import/route.test.ts
+++ b/app/api/admin/model-usage/import/route.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  fromMock: vi.fn(),
+  insertMock: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.fromMock,
+  },
+}))
+
+import { POST } from './route'
+
+function request(body: unknown) {
+  return new Request('http://localhost/api/admin/model-usage/import', {
+    method: 'POST',
+    headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+const packet = {
+  events: [{
+    occurredAt: '2026-06-06T12:00:00.000Z',
+    provider: 'codex',
+    runtime: 'codex',
+    model: 'gpt-5-codex',
+    taskCategory: 'coding',
+    inputTokens: 1000,
+    outputTokens: 200,
+    sourceTrace: { type: 'codex_session_import', id: 'session-1' },
+  }],
+  subscriptionAllocations: [{
+    provider: 'codex',
+    runtime: 'any',
+    accountLabel: 'Codex subscription',
+    monthlyCostUsd: 20,
+    periodStart: '2026-06-01T00:00:00.000Z',
+    periodEnd: '2026-06-30T23:59:59.999Z',
+  }],
+}
+
+describe('POST /api/admin/model-usage/import', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.fromMock.mockReturnValue({ insert: mocks.insertMock })
+    mocks.insertMock.mockResolvedValue({ error: null })
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(request(packet) as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.fromMock).not.toHaveBeenCalled()
+  })
+
+  it('dry-runs import packets without database writes', async () => {
+    const response = await POST(request({ ...packet, dryRun: true }) as never)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({
+      ok: true,
+      dryRun: true,
+      eventCount: 1,
+      subscriptionAllocationCount: 1,
+    })
+    expect(mocks.fromMock).not.toHaveBeenCalled()
+  })
+
+  it('inserts reviewed event and allocation rows', async () => {
+    const response = await POST(request(packet) as never)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({
+      ok: true,
+      dryRun: false,
+      insertedEvents: 1,
+      insertedSubscriptionAllocations: 1,
+    })
+    expect(mocks.fromMock).toHaveBeenCalledWith('model_usage_events')
+    expect(mocks.fromMock).toHaveBeenCalledWith('model_usage_subscription_allocations')
+    expect(mocks.insertMock).toHaveBeenNthCalledWith(1, [
+      expect.objectContaining({
+        provider: 'codex',
+        model: 'gpt-5-codex',
+        total_tokens: 1200,
+        scrubbed: true,
+      }),
+    ])
+  })
+
+  it('rejects packets that include raw prompt-like metadata', async () => {
+    const response = await POST(request({
+      events: [{
+        provider: 'codex',
+        model: 'gpt-5-codex',
+        sourceMetadata: { transcript: 'private meeting text' },
+      }],
+    }) as never)
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toMatchObject({
+      error: expect.stringContaining('not allowed'),
+    })
+    expect(mocks.fromMock).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/admin/model-usage/import/route.ts
+++ b/app/api/admin/model-usage/import/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { buildModelUsageImportPlan, importModelUsagePacket, type ModelUsageImportPacket } from '@/lib/model-usage'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const body = (await request.json().catch(() => ({}))) as ModelUsageImportPacket
+
+  try {
+    if (body.dryRun === true) {
+      const plan = buildModelUsageImportPlan(body)
+      return NextResponse.json({
+        ok: true,
+        dryRun: true,
+        eventCount: plan.eventRows.length,
+        subscriptionAllocationCount: plan.subscriptionAllocationRows.length,
+        warnings: plan.warnings,
+      })
+    }
+
+    const result = await importModelUsagePacket(body)
+    return NextResponse.json(result)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to import model usage packet'
+    console.error('[model-usage-import] import failed:', error)
+    return NextResponse.json({ error: message }, { status: 400 })
+  }
+}

--- a/lib/model-usage.test.ts
+++ b/lib/model-usage.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildModelUsageSnapshotFromEvents,
+  buildModelUsageImportPlan,
   computeModelUsageCost,
   inferModelUsageProvider,
   inferTaskCategory,
@@ -60,6 +61,72 @@ describe('model usage cost and categorization', () => {
     expect(inferTaskCategory({ workflow_key: 'video_generation_prompt_format' })).toBe('video')
     expect(inferTaskCategory({ artifact_type: 'linkedin_post' })).toBe('social')
     expect(inferTaskCategory({ operation: 'gmail_outreach_draft' })).toBe('outreach')
+  })
+})
+
+describe('buildModelUsageImportPlan', () => {
+  it('normalizes reviewed usage events and subscription allocations', () => {
+    const plan = buildModelUsageImportPlan({
+      dryRun: true,
+      events: [{
+        occurredAt: '2026-06-06T12:00:00.000Z',
+        provider: 'google',
+        runtime: 'api',
+        model: 'gemini-2.5-flash',
+        taskCategory: 'research',
+        clientLabel: 'Acme',
+        actionLabel: 'Gemini research import',
+        inputTokens: 1000,
+        outputTokens: 200,
+        sourceTrace: { type: 'gemini_usage_export', id: 'gemini-row-1' },
+        sourceMetadata: { exportBatch: 'batch-1' },
+      }],
+      subscriptionAllocations: [{
+        provider: 'codex',
+        runtime: 'any',
+        accountLabel: 'Codex subscription',
+        monthlyCostUsd: 20,
+        periodStart: '2026-06-01T00:00:00.000Z',
+        periodEnd: '2026-06-30T23:59:59.999Z',
+      }],
+    }, '2026-06-06T13:00:00.000Z')
+
+    expect(plan.dryRun).toBe(true)
+    expect(plan.eventRows[0]).toMatchObject({
+      provider: 'google',
+      runtime: 'api',
+      task_category: 'research',
+      client_label: 'Acme',
+      total_tokens: 1200,
+      source_type: 'gemini_usage_export',
+      source_id: 'gemini-row-1',
+      scrubbed: true,
+    })
+    expect(plan.subscriptionAllocationRows[0]).toMatchObject({
+      provider: 'codex',
+      runtime: 'any',
+      account_label: 'Codex subscription',
+      monthly_cost_usd: 20,
+      allocation_basis: 'token_share',
+    })
+  })
+
+  it('rejects raw prompts, messages, transcripts, and secret-like metadata keys', () => {
+    expect(() => buildModelUsageImportPlan({
+      events: [{
+        provider: 'codex',
+        model: 'gpt-5-codex',
+        sourceMetadata: { rawPrompt: 'do not store this' },
+      }],
+    })).toThrow(/not allowed/)
+
+    expect(() => buildModelUsageImportPlan({
+      events: [{
+        provider: 'codex',
+        model: 'gpt-5-codex',
+        pricingSnapshot: { apiKey: 'secret' },
+      }],
+    })).toThrow(/not allowed/)
   })
 })
 

--- a/lib/model-usage.ts
+++ b/lib/model-usage.ts
@@ -121,6 +121,103 @@ export type ModelUsageSnapshot = {
   clientSafeEvents: ModelUsageLedgerEvent[]
 }
 
+export type ModelUsageImportEventInput = {
+  occurredAt?: string
+  provider: ModelUsageProvider
+  runtime?: ModelUsageRuntime
+  model: string
+  taskCategory?: ModelUsageTaskCategory
+  agentKey?: string | null
+  clientProjectId?: string | null
+  clientLabel?: string | null
+  actionLabel?: string | null
+  inputTokens?: number
+  outputTokens?: number
+  cachedTokens?: number
+  reasoningTokens?: number
+  totalTokens?: number
+  acceptedOutputCount?: number
+  resolvedWorkItemCount?: number
+  retryCount?: number
+  costUsd?: number
+  costBasis?: ModelUsageCostBasis
+  confidence?: ModelUsageConfidence
+  sourceTrace?: {
+    type?: string
+    id?: string | null
+    href?: string | null
+  }
+  pricingSnapshot?: Record<string, unknown>
+  sourceMetadata?: Record<string, unknown>
+}
+
+export type ModelUsageSubscriptionAllocationInput = {
+  provider: ModelUsageProvider
+  runtime?: ModelUsageRuntime | 'any'
+  accountLabel: string
+  monthlyCostUsd: number
+  periodStart: string
+  periodEnd: string
+  allocationBasis?: 'token_share' | 'event_share' | 'manual_weight'
+  confidence?: ModelUsageConfidence
+  notes?: string | null
+}
+
+export type ModelUsageImportPacket = {
+  dryRun?: boolean
+  events?: ModelUsageImportEventInput[]
+  subscriptionAllocations?: ModelUsageSubscriptionAllocationInput[]
+}
+
+export type ModelUsageImportPlan = {
+  dryRun: boolean
+  eventRows: ModelUsageEventInsertRow[]
+  subscriptionAllocationRows: ModelUsageSubscriptionAllocationInsertRow[]
+  warnings: string[]
+}
+
+export type ModelUsageEventInsertRow = {
+  occurred_at: string
+  provider: ModelUsageProvider
+  runtime: ModelUsageRuntime
+  model: string
+  task_category: ModelUsageTaskCategory
+  agent_key: string | null
+  client_project_id: string | null
+  client_label: string
+  action_label: string
+  input_tokens: number
+  output_tokens: number
+  cached_tokens: number
+  reasoning_tokens: number
+  total_tokens: number
+  accepted_output_count: number
+  resolved_work_item_count: number
+  retry_count: number
+  cost_usd: number
+  cost_basis: ModelUsageCostBasis
+  confidence: ModelUsageConfidence
+  source_type: string
+  source_id: string | null
+  source_href: string | null
+  pricing_snapshot: Record<string, unknown>
+  raw_metadata: Record<string, unknown>
+  scrubbed: boolean
+}
+
+export type ModelUsageSubscriptionAllocationInsertRow = {
+  provider: ModelUsageProvider
+  runtime: ModelUsageRuntime | 'any'
+  account_label: string
+  monthly_cost_usd: number
+  period_start: string
+  period_end: string
+  allocation_basis: 'token_share' | 'event_share' | 'manual_weight'
+  confidence: ModelUsageConfidence
+  notes: string | null
+  active: boolean
+}
+
 export type ModelPricingSnapshot = {
   provider: ModelUsageProvider
   model: string
@@ -140,6 +237,8 @@ export const MODEL_PRICING_CATALOG: ModelPricingSnapshot[] = [
   { provider: 'google', model: 'gemini-2.5-pro', inputUsdPer1MTokens: 1.25, outputUsdPer1MTokens: 10, sourceUrl: 'https://ai.google.dev/gemini-api/docs/pricing', effectiveFrom: '2025-01-01', pricingState: 'needs_review' },
   { provider: 'google', model: 'gemini-2.5-flash', inputUsdPer1MTokens: 0.3, outputUsdPer1MTokens: 2.5, sourceUrl: 'https://ai.google.dev/gemini-api/docs/pricing', effectiveFrom: '2025-01-01', pricingState: 'needs_review' },
 ]
+
+const FORBIDDEN_IMPORT_KEY_PATTERN = /(api[_-]?key|secret|token|password|credential|raw[_-]?prompt|prompt|messages|transcript|content)/i
 
 function roundUsd(value: number) {
   return Math.round(value * 10_000) / 10_000
@@ -186,6 +285,62 @@ export function inferTaskCategory(metadata: Record<string, unknown> | null | und
   if (/automation|n8n|workflow/.test(joined)) return 'automation'
   if (/code|coding|implementation/.test(joined)) return 'coding'
   return 'other'
+}
+
+export function buildModelUsageImportPlan(packet: ModelUsageImportPacket, now = new Date().toISOString()): ModelUsageImportPlan {
+  const eventInputs = packet.events ?? []
+  const allocationInputs = packet.subscriptionAllocations ?? []
+  if (eventInputs.length === 0 && allocationInputs.length === 0) {
+    throw new Error('Import packet must include at least one event or subscription allocation.')
+  }
+  if (eventInputs.length > 100) throw new Error('Import packet cannot include more than 100 usage events.')
+  if (allocationInputs.length > 25) throw new Error('Import packet cannot include more than 25 subscription allocations.')
+
+  const warnings: string[] = []
+  return {
+    dryRun: packet.dryRun === true,
+    eventRows: eventInputs.map((event, index) => normalizeImportEvent(event, index, now, warnings)),
+    subscriptionAllocationRows: allocationInputs.map((allocation, index) => normalizeSubscriptionAllocation(allocation, index)),
+    warnings,
+  }
+}
+
+export async function importModelUsagePacket(packet: ModelUsageImportPacket): Promise<{
+  ok: true
+  dryRun: boolean
+  insertedEvents: number
+  insertedSubscriptionAllocations: number
+  warnings: string[]
+}> {
+  const plan = buildModelUsageImportPlan(packet)
+  if (plan.dryRun) {
+    return {
+      ok: true,
+      dryRun: true,
+      insertedEvents: 0,
+      insertedSubscriptionAllocations: 0,
+      warnings: plan.warnings,
+    }
+  }
+
+  const { supabaseAdmin } = await import('@/lib/supabase')
+  if (!supabaseAdmin) throw new Error('Database not available')
+  if (plan.eventRows.length > 0) {
+    const { error } = await supabaseAdmin.from('model_usage_events').insert(plan.eventRows)
+    if (error) throw new Error(error.message)
+  }
+  if (plan.subscriptionAllocationRows.length > 0) {
+    const { error } = await supabaseAdmin.from('model_usage_subscription_allocations').insert(plan.subscriptionAllocationRows)
+    if (error) throw new Error(error.message)
+  }
+
+  return {
+    ok: true,
+    dryRun: false,
+    insertedEvents: plan.eventRows.length,
+    insertedSubscriptionAllocations: plan.subscriptionAllocationRows.length,
+    warnings: plan.warnings,
+  }
 }
 
 export function computeModelUsageCost(
@@ -370,6 +525,129 @@ function efficiencyScore(tokens: number, costUsd: number, acceptedOutputs: numbe
 
 function labelForKey(value: string) {
   return value.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase())
+}
+
+function normalizeImportEvent(
+  event: ModelUsageImportEventInput,
+  index: number,
+  now: string,
+  warnings: string[],
+): ModelUsageEventInsertRow {
+  assertSafeImportObject(event.sourceMetadata, `events[${index}].sourceMetadata`)
+  assertSafeImportObject(event.pricingSnapshot, `events[${index}].pricingSnapshot`)
+  const provider = normalizeProvider(event.provider)
+  const runtime = normalizeRuntime(event.runtime)
+  const taskCategory = normalizeTaskCategory(event.taskCategory)
+  const inputTokens = nonNegativeInteger(event.inputTokens, `events[${index}].inputTokens`)
+  const outputTokens = nonNegativeInteger(event.outputTokens, `events[${index}].outputTokens`)
+  const cachedTokens = nonNegativeInteger(event.cachedTokens, `events[${index}].cachedTokens`)
+  const reasoningTokens = nonNegativeInteger(event.reasoningTokens, `events[${index}].reasoningTokens`)
+  const totalTokens = nonNegativeInteger(event.totalTokens, `events[${index}].totalTokens`) || inputTokens + outputTokens + cachedTokens + reasoningTokens
+  const sourceType = cleanLabel(event.sourceTrace?.type, 'manual_model_usage_import')
+  const sourceId = cleanNullableString(event.sourceTrace?.id)
+  if (!sourceId) warnings.push(`events[${index}] has no sourceTrace.id; duplicate detection will be weaker.`)
+  const model = cleanRequiredString(event.model, `events[${index}].model`)
+  const computedCost = computeModelUsageCost({ input_tokens: inputTokens, output_tokens: outputTokens, total_tokens: totalTokens }, provider, model)
+  const explicitCost = typeof event.costUsd === 'number' && Number.isFinite(event.costUsd)
+    ? roundUsd(Math.max(0, event.costUsd))
+    : null
+  const costUsd = explicitCost ?? computedCost.costUsd
+  const costBasis = normalizeCostBasis(event.costBasis ?? (costUsd > 0 ? computedCost.costBasis : provider === 'local' || provider === 'open_source' ? 'local_estimated' : 'inferred'))
+  const confidence = normalizeConfidence(event.confidence ?? (explicitCost != null || computedCost.pricingSnapshot ? 'medium' : 'low'))
+
+  return {
+    occurred_at: event.occurredAt ? normalizeIso(event.occurredAt, `events[${index}].occurredAt`) : now,
+    provider,
+    runtime,
+    model,
+    task_category: taskCategory,
+    agent_key: cleanNullableString(event.agentKey),
+    client_project_id: cleanNullableString(event.clientProjectId),
+    client_label: cleanLabel(event.clientLabel, 'Portfolio'),
+    action_label: cleanLabel(event.actionLabel, `${labelForKey(taskCategory)} import`),
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    cached_tokens: cachedTokens,
+    reasoning_tokens: reasoningTokens,
+    total_tokens: totalTokens,
+    accepted_output_count: nonNegativeInteger(event.acceptedOutputCount, `events[${index}].acceptedOutputCount`),
+    resolved_work_item_count: nonNegativeInteger(event.resolvedWorkItemCount, `events[${index}].resolvedWorkItemCount`),
+    retry_count: nonNegativeInteger(event.retryCount, `events[${index}].retryCount`),
+    cost_usd: costUsd,
+    cost_basis: costBasis,
+    confidence,
+    source_type: sourceType,
+    source_id: sourceId,
+    source_href: cleanNullableString(event.sourceTrace?.href),
+    pricing_snapshot: {
+      ...(computedCost.pricingSnapshot ?? {}),
+      ...(event.pricingSnapshot ?? {}),
+      importPacket: true,
+    },
+    raw_metadata: event.sourceMetadata ?? {},
+    scrubbed: true,
+  }
+}
+
+function normalizeSubscriptionAllocation(
+  allocation: ModelUsageSubscriptionAllocationInput,
+  index: number,
+): ModelUsageSubscriptionAllocationInsertRow {
+  const monthlyCostUsd = typeof allocation.monthlyCostUsd === 'number' && Number.isFinite(allocation.monthlyCostUsd)
+    ? Math.max(0, allocation.monthlyCostUsd)
+    : NaN
+  if (!Number.isFinite(monthlyCostUsd)) throw new Error(`subscriptionAllocations[${index}].monthlyCostUsd must be a non-negative number.`)
+  const periodStart = normalizeIso(allocation.periodStart, `subscriptionAllocations[${index}].periodStart`)
+  const periodEnd = normalizeIso(allocation.periodEnd, `subscriptionAllocations[${index}].periodEnd`)
+  if (periodEnd <= periodStart) throw new Error(`subscriptionAllocations[${index}].periodEnd must be after periodStart.`)
+  return {
+    provider: normalizeProvider(allocation.provider),
+    runtime: allocation.runtime === 'any' ? 'any' : normalizeRuntime(allocation.runtime),
+    account_label: cleanRequiredString(allocation.accountLabel, `subscriptionAllocations[${index}].accountLabel`),
+    monthly_cost_usd: roundUsd(monthlyCostUsd),
+    period_start: periodStart,
+    period_end: periodEnd,
+    allocation_basis: allocation.allocationBasis === 'event_share' || allocation.allocationBasis === 'manual_weight' ? allocation.allocationBasis : 'token_share',
+    confidence: normalizeConfidence(allocation.confidence),
+    notes: cleanNullableString(allocation.notes),
+    active: true,
+  }
+}
+
+function assertSafeImportObject(value: Record<string, unknown> | null | undefined, path: string) {
+  if (!value) return
+  for (const key of Object.keys(value)) {
+    if (FORBIDDEN_IMPORT_KEY_PATTERN.test(key)) {
+      throw new Error(`${path}.${key} is not allowed in model usage import packets.`)
+    }
+  }
+}
+
+function cleanRequiredString(value: unknown, path: string) {
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`${path} is required.`)
+  return value.trim()
+}
+
+function cleanNullableString(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function cleanLabel(value: unknown, fallback: string) {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback
+}
+
+function nonNegativeInteger(value: unknown, path: string) {
+  if (value == null) return 0
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    throw new Error(`${path} must be a non-negative number.`)
+  }
+  return Math.round(value)
+}
+
+function normalizeIso(value: string, path: string) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) throw new Error(`${path} must be a valid ISO date.`)
+  return date.toISOString()
 }
 
 function buildModelUsageRecommendations(events: ModelUsageLedgerEvent[]): ModelUsageRecommendation[] {


### PR DESCRIPTION
## Summary
- Adds an admin-only model usage import endpoint for reviewed usage packets and subscription allocation rows.
- Adds dry-run validation so Codex, Claude Code, Gemini, local/open-weight, and manual usage packets can be checked before ledger writes.
- Extends the Model Usage dashboard with a reviewed JSON import panel while blocking raw prompts, transcripts, secrets, credentials, and provider account actions.

## Enhancement Impact Preflight
- Enhancement: Model usage import packets and subscription allocation row entry for the Client AI Ops token/cost control plane.
- User-facing surface: `/admin/agents/model-usage` and `/api/admin/model-usage/import`.
- Predicted files: `lib/model-usage*`, `app/admin/agents/model-usage/*`, `app/api/admin/model-usage/import/**`.
- Shared routes/APIs/tables/helpers: `model_usage_events`, `model_usage_subscription_allocations`, existing Model Usage dashboard and read model from PR #509.
- Active PRs or branches checked: #502, #504, #505, #506, #507, #508. PR #509 was merged before this branch was created.
- Dirty worktree files checked: root Portfolio checkout still has unrelated subscription-monitor files; this work used isolated worktree `/Users/vambahsillah/Projects/Portfolio.worktrees/client-ai-ops-roadmap`.
- Overlap rating: yellow.
- Coordination decision: proceed after #509 merge; keep scoped to model usage import path and avoid Agent Ops shell/nav changes.
- Merge-order note: merge after #509 only; now satisfied. No open PR currently touches the model-usage files.

## Validation
- `npm test -- lib/model-usage.test.ts lib/cost-calculator.test.ts app/api/admin/model-usage/import/route.test.ts app/api/admin/model-usage/summary/route.test.ts 'app/api/admin/client-projects/[id]/ai-ops/model-usage/route.test.ts' app/admin/agents/model-usage/page.test.tsx` ✅
- `npx tsc --noEmit` ✅
- `git diff --check` ✅
- Pre-push `npm run db:health-check` against production env ✅
- No live provider OAuth, billing API, credential sync, outbound send, publishing, or client-data mutation smoke was run.

## Integration Notes
- Depends on #509 migration/table availability: `model_usage_events` and `model_usage_subscription_allocations`.
- Import endpoint writes only reviewed ledger/allocation rows. It does not call providers, connect accounts, sync credentials, mutate provider settings, or route models automatically.
- Sensitive packet keys matching raw prompt/message/transcript/content/secret/token/password/credential are rejected.
- Vercel – portfolio: pending PR preview.
- Vercel – portfolio-staging: not checked from this non-captain branch.
