### PR TITLE
feat: advance goal orchestration gates

### DIFF
--- a/lib/agent-war-room.test.ts
+++ b/lib/agent-war-room.test.ts
@@ -618,6 +618,7 @@ describe('runAgentWarRoom', () => {
       source: expect.objectContaining({ id: expect.stringContaining('-social-content-draft') }),
       metadata: expect.objectContaining({
         publish_gate: 'draft_only',
+        orchestration_gate: 'draft_build',
         current_gate: 'research_context_evidence',
         gate_status: 'research_pending',
         pass_to_human: false,

--- a/lib/agent-war-room.ts
+++ b/lib/agent-war-room.ts
@@ -12,6 +12,7 @@ import { createAgentWorkItem, type AgentWorkItem, type AgentWorkItemPriority } f
 import {
   buildGoalOrchestrationPacket,
   initialContentOrchestrationReview,
+  inferWorkItemOrchestrationGate,
   type GoalOrchestrationPacket,
 } from '@/lib/goal-orchestration'
 import { supabaseAdmin } from '@/lib/supabase'
@@ -1099,6 +1100,11 @@ async function approveGoalDraft(runId: string, draft: AgentGoalDraft) {
         goal_dependencies: task.dependencies,
         task_acceptance_criteria: task.acceptance_criteria,
         risk_notes: task.risk_notes,
+        orchestration_gate: inferWorkItemOrchestrationGate({
+          title: task.title,
+          status: 'assigned',
+          metadata: { goal_task_id: task.id },
+        }),
         orchestration_packet: orchestrationPacket,
         orchestration_version: orchestrationPacket.orchestration_version,
         current_gate: orchestrationPacket.current_gate,

--- a/lib/agent-work-items.test.ts
+++ b/lib/agent-work-items.test.ts
@@ -175,6 +175,60 @@ describe('agent work item helpers', () => {
     await expect(cancelAgentWorkItem({ id: 'work-1', reason: 'duplicate' })).resolves.toMatchObject({ status: 'cancelled' })
   })
 
+  it('refreshes shared goal orchestration metadata when a child work item changes', async () => {
+    const parent = {
+      ...baseItem,
+      id: 'goal-parent',
+      metadata: {
+        goal_id: 'goal-v2',
+        goal_type: 'general',
+        goal_role: 'parent',
+        approval_boundary: 'Human approval remains final.',
+      },
+    }
+    const child = {
+      ...baseItem,
+      id: 'goal-child',
+      parent_work_item_id: 'goal-parent',
+      metadata: {
+        goal_id: 'goal-v2',
+        goal_type: 'general',
+        goal_role: 'task',
+        goal_parent_work_item_id: 'goal-parent',
+        orchestration_gate: 'draft_build',
+      },
+    }
+    const blockedChild = {
+      ...child,
+      status: 'blocked',
+      blocker_summary: 'Implementation evidence is missing.',
+    }
+
+    mocks.maybeSingleQueue.push(
+      { data: child, error: null },
+      { data: parent, error: null },
+    )
+    mocks.listQueue.push(
+      { data: [], error: null },
+      { data: [blockedChild], error: null },
+    )
+    mocks.singleQueue.push({ data: blockedChild, error: null })
+
+    await expect(recordAgentWorkItemBlocker({
+      id: 'goal-child',
+      blockerSummary: 'Implementation evidence is missing.',
+    })).resolves.toMatchObject({ status: 'blocked' })
+
+    expect(mocks.updateMock).toHaveBeenCalledWith(expect.objectContaining({
+      metadata: expect.objectContaining({
+        current_gate: 'draft_build',
+        gate_status: 'blocked',
+        pass_to_human: false,
+        residual_risks_for_human: ['Implementation evidence is missing.'],
+      }),
+    }))
+  })
+
   it('creates an approval checkpoint when validation marks work ready for merge', async () => {
     queueExistingItem()
     mocks.singleQueue.push(

--- a/lib/agent-work-items.ts
+++ b/lib/agent-work-items.ts
@@ -5,6 +5,7 @@ import {
   startAgentRun,
   type AgentRuntime,
 } from '@/lib/agent-run'
+import { evaluateGoalOrchestration, type GoalOrchestrationWorkItem } from '@/lib/goal-orchestration'
 import { supabaseAdmin } from '@/lib/supabase'
 
 export const AGENT_WORK_ITEM_STATUSES = [
@@ -413,7 +414,10 @@ async function updateWorkItem(
     }).catch(() => {})
   }
 
-  return data as AgentWorkItem
+  const updatedItem = data as AgentWorkItem
+  await refreshGoalOrchestrationForWorkItem(updatedItem)
+
+  return updatedItem
 }
 
 export async function createAgentWorkItem(input: CreateAgentWorkItemInput): Promise<AgentWorkItem> {
@@ -852,6 +856,88 @@ function recordValue(value: unknown): Record<string, unknown> | null {
 
 function metadataString(value: unknown): string | null {
   return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function mergeOrchestrationMetadata(metadata: Record<string, unknown>, packet: ReturnType<typeof evaluateGoalOrchestration>) {
+  return {
+    ...metadata,
+    orchestration_packet: packet,
+    orchestration_version: packet.orchestration_version,
+    current_gate: packet.current_gate,
+    gate_status: packet.gate_status,
+    pass_to_human: packet.pass_to_human,
+    challenger_status: packet.challenger_status,
+    residual_risks_for_human: packet.residual_risks_for_human,
+    approval_boundary: packet.approval_boundary,
+  }
+}
+
+function workItemForOrchestration(item: AgentWorkItem): GoalOrchestrationWorkItem {
+  return {
+    title: item.title,
+    status: item.status,
+    blocker_summary: item.blocker_summary,
+    validation_summary: item.validation_summary,
+    metadata: item.metadata ?? {},
+  }
+}
+
+async function refreshGoalOrchestrationForWorkItem(item: AgentWorkItem) {
+  const metadata = item.metadata ?? {}
+  const goalId = metadataString(metadata.goal_id)
+  if (!goalId) return
+
+  const parentId = item.parent_work_item_id
+    ?? metadataString(metadata.goal_parent_work_item_id)
+    ?? (metadata.goal_role === 'parent' ? item.id : null)
+  if (!parentId) return
+
+  try {
+    const { data: parentData } = item.id === parentId
+      ? { data: item }
+      : await db()
+        .from('agent_work_items')
+        .select('*')
+        .eq('id', parentId)
+        .maybeSingle()
+
+    const parent = (parentData as AgentWorkItem | null) ?? null
+    const { data: childData } = await db()
+      .from('agent_work_items')
+      .select('*')
+      .eq('parent_work_item_id', parentId)
+      .order('created_at', { ascending: true })
+      .limit(100)
+
+    const children = ((childData ?? []) as AgentWorkItem[])
+      .filter((child) => metadataString(child.metadata?.goal_id) === goalId)
+    const sourceMetadata = parent?.metadata ?? metadata
+    const authorityBoundary = recordValue(sourceMetadata.authority_boundary)
+    const packet = evaluateGoalOrchestration({
+      goalType: metadataString(sourceMetadata.goal_type) ?? metadataString(metadata.goal_type) ?? 'general',
+      items: children.map(workItemForOrchestration),
+      approvalBoundary: metadataString(sourceMetadata.approval_boundary)
+        ?? metadataString(authorityBoundary?.notes)
+        ?? 'Human review remains the final approval boundary.',
+    })
+    const rows = [
+      ...(parent ? [parent] : []),
+      ...children,
+    ]
+    for (const row of rows) {
+      await db()
+        .from('agent_work_items')
+        .update({
+          metadata: mergeOrchestrationMetadata(row.metadata ?? {}, packet),
+        })
+        .eq('id', row.id)
+    }
+  } catch (error) {
+    console.warn(
+      '[agent-work-items] goal orchestration refresh skipped:',
+      error instanceof Error ? error.message : error,
+    )
+  }
 }
 
 export async function requestAgentWorkItemN8nActivationReview(input: {

--- a/lib/goal-orchestration.test.ts
+++ b/lib/goal-orchestration.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  evaluateGoalOrchestration,
   evaluateContentGoalOrchestration,
+  inferWorkItemOrchestrationGate,
   initialContentOrchestrationReview,
 } from './goal-orchestration'
 
@@ -75,6 +77,79 @@ describe('goal orchestration', () => {
         metadata: { challenger_status: 'passed' },
       },
     ])
+
+    expect(packet).toMatchObject({
+      current_gate: 'human_review',
+      gate_status: 'human_review_ready',
+      challenger_status: 'passed',
+      pass_to_human: true,
+    })
+  })
+
+  it('infers generic task gates from work item metadata and title', () => {
+    expect(inferWorkItemOrchestrationGate({
+      title: 'Review risk, governance, and rollout path',
+      status: 'assigned',
+    })).toBe('challenger_qa')
+    expect(inferWorkItemOrchestrationGate({
+      title: 'Custom task',
+      status: 'assigned',
+      metadata: { orchestration_gate: 'draft_build' },
+    })).toBe('draft_build')
+  })
+
+  it('evaluates non-content goals with the shared gate model', () => {
+    const packet = evaluateGoalOrchestration({
+      goalType: 'general',
+      approvalBoundary: 'Human approval remains the final authority boundary.',
+      items: [
+        { title: 'Frame the goal and acceptance gate', ...done, metadata: { orchestration_gate: 'readiness_packet' } },
+        { title: 'Implement the primary change set', status: 'in_progress', metadata: { orchestration_gate: 'draft_build' } },
+        { title: 'Review risk, governance, and rollout path', status: 'assigned', metadata: { orchestration_gate: 'challenger_qa' } },
+      ],
+    })
+
+    expect(packet).toMatchObject({
+      goal_type: 'general',
+      current_gate: 'draft_build',
+      gate_status: 'drafting',
+      pass_to_human: false,
+    })
+  })
+
+  it('routes generic blockers to the active gate', () => {
+    const packet = evaluateGoalOrchestration({
+      goalType: 'general',
+      approvalBoundary: 'Human approval remains the final authority boundary.',
+      items: [
+        {
+          title: 'Review risk, governance, and rollout path',
+          status: 'blocked',
+          blocker_summary: 'Rollback path is missing.',
+          metadata: { orchestration_gate: 'challenger_qa' },
+        },
+      ],
+    })
+
+    expect(packet).toMatchObject({
+      current_gate: 'challenger_qa',
+      gate_status: 'blocked',
+      challenger_status: 'blocked',
+      pass_to_human: false,
+      residual_risks_for_human: ['Rollback path is missing.'],
+    })
+  })
+
+  it('passes completed generic goals to human review', () => {
+    const packet = evaluateGoalOrchestration({
+      goalType: 'general',
+      approvalBoundary: 'Human approval remains the final authority boundary.',
+      items: [
+        { title: 'Frame the goal and acceptance gate', ...done, metadata: { orchestration_gate: 'readiness_packet' } },
+        { title: 'Implement the primary change set', ...done, metadata: { orchestration_gate: 'draft_build' } },
+        { title: 'Review risk, governance, and rollout path', ...done, metadata: { orchestration_gate: 'challenger_qa', challenger_status: 'passed' } },
+      ],
+    })
 
     expect(packet).toMatchObject({
       current_gate: 'human_review',

--- a/lib/goal-orchestration.ts
+++ b/lib/goal-orchestration.ts
@@ -47,8 +47,27 @@ export type GoalOrchestrationWorkItem = {
   metadata?: Record<string, unknown> | null
 }
 
+const GATE_ORDER = new Map<GoalOrchestrationGate, number>(
+  GOAL_ORCHESTRATION_PATTERN.map((gate, index) => [gate, index]),
+)
+
 function isDone(status: string) {
   return ['ready_for_review', 'ready_for_merge', 'merged', 'deployed'].includes(status)
+}
+
+function isTerminal(status: string) {
+  return ['merged', 'deployed', 'cancelled'].includes(status)
+}
+
+function isGate(value: unknown): value is GoalOrchestrationGate {
+  return typeof value === 'string' && GOAL_ORCHESTRATION_PATTERN.includes(value as GoalOrchestrationGate)
+}
+
+function firstString(...values: unknown[]) {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  return null
 }
 
 function hasTask(items: GoalOrchestrationWorkItem[], pattern: RegExp) {
@@ -90,6 +109,31 @@ export function buildGoalOrchestrationPacket(input: {
   }
 }
 
+export function inferWorkItemOrchestrationGate(item: GoalOrchestrationWorkItem): GoalOrchestrationGate {
+  const metadataGate = item.metadata?.orchestration_gate ?? item.metadata?.current_gate
+  if (isGate(metadataGate)) return metadataGate
+
+  const title = item.title
+  if (/intake|readiness|scope|frame|acceptance/i.test(title)) return 'readiness_packet'
+  if (/research|source|context|evidence|signal|open brain|chronicle|trace|workflow/i.test(title)) return 'research_context_evidence'
+  if (/implement|build|draft|design|create|compose|code|handoff/i.test(title)) return 'draft_build'
+  if (/qa|quality|risk|governance|review|challenger|compliance|validation/i.test(title)) return 'challenger_qa'
+  if (/approval|human|operator/i.test(title)) return 'human_review'
+  return 'delegated_work_graph'
+}
+
+function gateStatusForWorkItem(item: GoalOrchestrationWorkItem, gate: GoalOrchestrationGate): GoalOrchestrationGateStatus {
+  if (item.status === 'blocked') return 'blocked'
+  if (item.status === 'ready_for_review' && gate === 'challenger_qa') return 'challenger_pending'
+  if (gate === 'research_context_evidence') return 'research_pending'
+  if (gate === 'draft_build') return 'drafting'
+  if (gate === 'challenger_qa') return 'challenger_pending'
+  if (gate === 'human_review') return 'human_review_ready'
+  if (gate === 'approved_execution') return 'approved'
+  if (gate === 'delegated_work_graph') return 'delegated'
+  return 'ready'
+}
+
 export function initialContentOrchestrationReview(input: {
   goalType: string
   sourceIds?: string[]
@@ -118,6 +162,106 @@ export function initialContentOrchestrationReview(input: {
     fixes_applied: [],
     human_review_blocker: 'Human review is blocked until research/context evidence and challenger QA pass.',
   }
+}
+
+export function evaluateGoalOrchestration(input: {
+  goalType: string
+  items: GoalOrchestrationWorkItem[]
+  approvalBoundary: string
+}) {
+  if (input.goalType === 'social_outreach_linkedin_post') {
+    return evaluateContentGoalOrchestration(input.items)
+  }
+
+  const items = input.items.filter((item) => item.status !== 'cancelled')
+  const blocked = items.find((item) => item.status === 'blocked' || Boolean(item.blocker_summary))
+  if (blocked) {
+    const gate = inferWorkItemOrchestrationGate(blocked)
+    return buildGoalOrchestrationPacket({
+      goalType: input.goalType,
+      currentGate: gate === 'human_review' ? 'repair_loop' : gate,
+      gateStatus: 'blocked',
+      challengerStatus: gate === 'challenger_qa' ? 'blocked' : 'pending',
+      approvalBoundary: 'Human review is blocked until the active blocker is resolved.',
+      residualRisksForHuman: [
+        firstString(blocked.blocker_summary, blocked.validation_summary, `${blocked.title} is blocked.`) ?? `${blocked.title} is blocked.`,
+      ],
+    })
+  }
+
+  if (!items.length) {
+    return buildGoalOrchestrationPacket({
+      goalType: input.goalType,
+      currentGate: 'delegated_work_graph',
+      gateStatus: 'delegated',
+      approvalBoundary: input.approvalBoundary,
+      residualRisksForHuman: ['No delegated work items are linked to this goal yet.'],
+    })
+  }
+
+  const challengerItems = items.filter((item) => inferWorkItemOrchestrationGate(item) === 'challenger_qa')
+  const challengerFindings = challengerItems.flatMap((item) => [
+    ...stringArray(item.metadata?.challenge_findings),
+    ...stringArray(item.metadata?.unsupported_claims).map((claim) => `Unsupported claim: ${claim}`),
+    ...stringArray(item.metadata?.privacy_flags).map((flag) => `Privacy flag: ${flag}`),
+  ])
+  const challengerBlocked = challengerItems.some((item) => item.metadata?.challenger_status === 'blocked')
+  const challengerNeedsRevision = challengerItems.some((item) => item.metadata?.challenger_status === 'needs_revision') || challengerFindings.length > 0
+
+  if (challengerBlocked || challengerNeedsRevision) {
+    return buildGoalOrchestrationPacket({
+      goalType: input.goalType,
+      currentGate: 'repair_loop',
+      gateStatus: challengerBlocked ? 'blocked' : 'needs_revision',
+      challengerStatus: challengerBlocked ? 'blocked' : 'needs_revision',
+      approvalBoundary: 'Human review is blocked until challenger findings are repaired and re-checked.',
+      residualRisksForHuman: challengerFindings.length ? challengerFindings : ['Challenger QA requires revision.'],
+    })
+  }
+
+  const incomplete = [...items]
+    .filter((item) => !isDone(item.status) && !isTerminal(item.status))
+    .sort((a, b) => {
+      const aGate = inferWorkItemOrchestrationGate(a)
+      const bGate = inferWorkItemOrchestrationGate(b)
+      return (GATE_ORDER.get(aGate) ?? 0) - (GATE_ORDER.get(bGate) ?? 0)
+    })[0]
+
+  if (incomplete) {
+    const gate = inferWorkItemOrchestrationGate(incomplete)
+    return buildGoalOrchestrationPacket({
+      goalType: input.goalType,
+      currentGate: gate,
+      gateStatus: gateStatusForWorkItem(incomplete, gate),
+      challengerStatus: gate === 'challenger_qa' ? 'pending' : 'pending',
+      approvalBoundary: input.approvalBoundary,
+      residualRisksForHuman: [`${incomplete.title} has not cleared ${gate.replace(/_/g, ' ')}.`],
+    })
+  }
+
+  const challengerPassed = challengerItems.length === 0 || challengerItems.every((item) => (
+    item.metadata?.challenger_status === 'passed' || isDone(item.status)
+  ))
+
+  if (challengerPassed) {
+    return buildGoalOrchestrationPacket({
+      goalType: input.goalType,
+      currentGate: 'human_review',
+      gateStatus: 'human_review_ready',
+      passToHuman: true,
+      challengerStatus: 'passed',
+      approvalBoundary: input.approvalBoundary,
+    })
+  }
+
+  return buildGoalOrchestrationPacket({
+    goalType: input.goalType,
+    currentGate: 'challenger_qa',
+    gateStatus: 'challenger_pending',
+    challengerStatus: 'pending',
+    approvalBoundary: input.approvalBoundary,
+    residualRisksForHuman: ['Challenger QA has not passed.'],
+  })
 }
 
 export function evaluateContentGoalOrchestration(items: GoalOrchestrationWorkItem[]) {


### PR DESCRIPTION
## Summary
- Adds a generic Goal Orchestration evaluator for non-content goals, including gate inference, blocked/repair states, challenger status, pass-to-human state, residual risks, and approval boundaries.
- Tags generated Standup Room child work items with an `orchestration_gate` so generic goals follow the same lifecycle pattern as V1 content goals.
- Refreshes shared goal orchestration metadata whenever existing work-item lifecycle updates run, keeping parent/child goal state visible in Mission Control, Swarm Board, and Radar without a new table or runner.
- Keeps this as V2 gate-state generalization only: no autonomous runner, no publishing, no deploy, no merge, no n8n activation, and no external side effects.

## Validation
- ./node_modules/.bin/vitest run lib/goal-orchestration.test.ts lib/agent-work-items.test.ts lib/agent-war-room.test.ts lib/agent-swarm-board.test.ts lib/agent-activity-radar.test.ts components/admin/AgentActivityRadar.test.tsx
- ./node_modules/.bin/tsc --noEmit
- npm run lint
- npm run build
- Pre-push hook: npm run db:health-check passed against configured production health baseline.

## Integration Notes
- No database migration. V2 continues to use existing `agent_work_items.metadata`.
- No new environment variables.
- Existing build warning remains: local env has MOCK_N8N=false and N8N_DISABLE_OUTBOUND=false, so outbound n8n webhooks can fire if workflows are manually triggered.
- Vercel contexts not checked by this non-captain lane:
  - Vercel – portfolio: not checked
  - Vercel – portfolio-staging: not checked
