### PR TITLE
feat: add social content revision receipts

### DIFF
--- a/app/admin/social-content/[id]/page.tsx
+++ b/app/admin/social-content/[id]/page.tsx
@@ -475,7 +475,9 @@ function SocialContentDetailPage() {
         const data = await res.json()
         setItem(prev => prev ? { ...prev, ...data.item, publishes: data.publishes } : prev)
 
-        if (scheduledFor) {
+        if (data.reference_work_item) {
+          showMsg('success', 'Draft approved and reference handoff queued.')
+        } else if (scheduledFor) {
           showMsg('success', 'Approved and scheduled!')
         } else {
           showMsg('success', data.publish_triggered
@@ -756,6 +758,17 @@ function SocialContentDetailPage() {
   const agentPilotRequiredFixes = asStringArray(ragContext?.required_fixes)
   const agentPilotCalibration = asRecord(ragContext?.content_calibration)
   const agentPilotCalibrationStatus = asString(agentPilotCalibration?.status)
+  const agentPilotLatestRevision = asRecord(agentPilotCalibration?.latest_revision)
+  const agentPilotLatestRevisionCreatedAt = asString(agentPilotLatestRevision?.created_at)
+  const agentPilotRevisionUnderstanding = asRecord(agentPilotLatestRevision?.shaka_understanding)
+  const agentPilotRevisionNotes = asStringArray(agentPilotLatestRevision?.revision_notes)
+  const agentPilotRevisionRequest = asString(agentPilotLatestRevision?.operator_request)
+  const agentPilotWhatHeard = asString(agentPilotRevisionUnderstanding?.what_i_heard)
+  const agentPilotPlannedChanges = asStringArray(agentPilotRevisionUnderstanding?.planned_changes)
+  const agentPilotNotChanging = asStringArray(agentPilotRevisionUnderstanding?.not_changing)
+  const agentPilotSeparateActions = asStringArray(agentPilotRevisionUnderstanding?.separate_actions)
+  const agentPilotQuestionsOrAmbiguity = asStringArray(agentPilotRevisionUnderstanding?.questions_or_ambiguity)
+  const hasAgentPilotRevisionReceipt = Boolean(agentPilotLatestRevision)
   const agentPilotPriorPatterns = asRecordArray(agentPilotCalibration?.prior_success_patterns)
   const agentPilotVoicePrinciples = asStringArray(agentPilotCalibration?.voice_principles)
   const agentPilotMissingContextPrompts = asStringArray(agentPilotCalibration?.missing_context_prompts)
@@ -794,6 +807,11 @@ function SocialContentDetailPage() {
       : 0
   const isDraftOnlyPilot = isAgentSocialPilot && agentPilotPublishGate === 'draft_only'
   const canApproveAgentPilot = !isAgentSocialPilot || agentPilotPassToHuman
+  const approveActionLabel = isDraftOnlyPilot
+    ? 'Approve Draft'
+    : scheduledFor
+      ? 'Approve & Schedule'
+      : 'Approve & Publish'
 
   return (
     <div className="min-h-screen bg-background text-foreground">
@@ -1010,6 +1028,78 @@ function SocialContentDetailPage() {
                 ) : (
                   <div className="mt-3 rounded-md border border-silicon-slate/80 bg-imperial-navy/45 p-3 text-sm leading-6 text-gray-300">
                     No calibration notes are attached yet. Start by adding a prior successful post, what made it work, and what should change in this draft.
+                  </div>
+                )}
+
+                {hasAgentPilotRevisionReceipt && (
+                  <div className="mt-4 rounded-lg border border-emerald-500/25 bg-emerald-500/5 p-4">
+                    <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-[0.14em] text-emerald-200">Shaka Revision Receipt</p>
+                        <p className="mt-1 text-sm leading-6 text-gray-300">
+                          Shaka records what he understood before the revised draft replaces the text.
+                        </p>
+                      </div>
+                      {agentPilotLatestRevisionCreatedAt && (
+                        <span className="w-fit rounded-full border border-emerald-500/30 px-3 py-1 text-xs text-emerald-100">
+                          {new Date(agentPilotLatestRevisionCreatedAt).toLocaleString()}
+                        </span>
+                      )}
+                    </div>
+                    {agentPilotRevisionRequest && (
+                      <div className="mt-3 rounded-lg border border-emerald-500/20 bg-background/35 p-3">
+                        <p className="text-xs font-semibold uppercase tracking-[0.14em] text-emerald-200">Your request</p>
+                        <p className="mt-2 text-sm leading-6 text-gray-200">{agentPilotRevisionRequest}</p>
+                      </div>
+                    )}
+                    {agentPilotWhatHeard && (
+                      <div className="mt-3 rounded-lg border border-emerald-500/20 bg-background/35 p-3">
+                        <p className="text-xs font-semibold uppercase tracking-[0.14em] text-emerald-200">What I heard</p>
+                        <p className="mt-2 text-sm leading-6 text-gray-200">{agentPilotWhatHeard}</p>
+                      </div>
+                    )}
+                    <div className="mt-3 grid gap-3 lg:grid-cols-2">
+                      {agentPilotPlannedChanges.length > 0 && (
+                        <div className="rounded-lg border border-emerald-500/20 bg-background/35 p-3">
+                          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-emerald-200">Planned changes</p>
+                          <ul className="mt-2 space-y-1 text-sm leading-6 text-gray-200">
+                            {agentPilotPlannedChanges.map((change) => <li key={change}>• {change}</li>)}
+                          </ul>
+                        </div>
+                      )}
+                      {agentPilotRevisionNotes.length > 0 && (
+                        <div className="rounded-lg border border-emerald-500/20 bg-background/35 p-3">
+                          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-emerald-200">What changed</p>
+                          <ul className="mt-2 space-y-1 text-sm leading-6 text-gray-200">
+                            {agentPilotRevisionNotes.map((note) => <li key={note}>• {note}</li>)}
+                          </ul>
+                        </div>
+                      )}
+                      {agentPilotSeparateActions.length > 0 && (
+                        <div className="rounded-lg border border-amber-500/20 bg-amber-500/5 p-3">
+                          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-amber-200">Separate actions</p>
+                          <ul className="mt-2 space-y-1 text-sm leading-6 text-amber-50/90">
+                            {agentPilotSeparateActions.map((action) => <li key={action}>• {action}</li>)}
+                          </ul>
+                        </div>
+                      )}
+                      {agentPilotNotChanging.length > 0 && (
+                        <div className="rounded-lg border border-silicon-slate/80 bg-background/35 p-3">
+                          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-gray-500">Not changing</p>
+                          <ul className="mt-2 space-y-1 text-sm leading-6 text-gray-300">
+                            {agentPilotNotChanging.map((item) => <li key={item}>• {item}</li>)}
+                          </ul>
+                        </div>
+                      )}
+                    </div>
+                    {agentPilotQuestionsOrAmbiguity.length > 0 && (
+                      <div className="mt-3 rounded-lg border border-amber-500/20 bg-amber-500/5 p-3">
+                        <p className="text-xs font-semibold uppercase tracking-[0.14em] text-amber-200">Questions or ambiguity</p>
+                        <ul className="mt-2 space-y-1 text-sm leading-6 text-amber-50/90">
+                          {agentPilotQuestionsOrAmbiguity.map((question) => <li key={question}>• {question}</li>)}
+                        </ul>
+                      </div>
+                    )}
                   </div>
                 )}
 
@@ -1794,7 +1884,7 @@ function SocialContentDetailPage() {
               </button>
               <button
                 onClick={() => {
-                  if (targetPlatforms.length === 0) {
+                  if (!isDraftOnlyPilot && targetPlatforms.length === 0) {
                     showMsg('error', 'Select at least one platform')
                     return
                   }
@@ -1805,7 +1895,7 @@ function SocialContentDetailPage() {
                 className="flex items-center gap-1.5 px-5 py-2 bg-green-600 hover:bg-green-500 text-white rounded-lg text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {approving ? <Loader2 className="w-4 h-4 animate-spin" /> : <Send className="w-4 h-4" />}
-                Approve & Publish
+                {approveActionLabel}
               </button>
             </div>
           )}
@@ -1995,32 +2085,40 @@ function SocialContentDetailPage() {
               onClick={(e) => e.stopPropagation()}
               className="bg-gray-900 border border-gray-700 rounded-xl p-6 max-w-md w-full shadow-2xl"
             >
-              <h3 className="text-lg font-semibold text-gray-200 mb-4">Confirm Publishing</h3>
+              <h3 className="text-lg font-semibold text-gray-200 mb-4">
+                {isDraftOnlyPilot ? 'Confirm Draft Approval' : 'Confirm Publishing'}
+              </h3>
 
               <div className="space-y-3 mb-6">
                 {isDraftOnlyPilot && (
                   <div className={`rounded-lg border p-3 text-sm ${agentPilotPassToHuman ? 'border-amber-500/30 bg-amber-500/10 text-amber-100' : 'border-red-500/30 bg-red-500/10 text-red-100'}`}>
                     {agentPilotPassToHuman
-                      ? 'This draft came from a draft-only Agent Ops pilot. Goal approval did not publish it; this confirmation is the separate Social Content approval gate.'
+                      ? 'This draft came from a draft-only Agent Ops pilot. Approving it queues the reference/source handoff and keeps publishing behind a separate action.'
                       : 'This Agent Ops draft has not cleared challenger QA. Close this modal and finish the upstream gate before approving.'}
                   </div>
                 )}
-                <div className="flex items-center justify-between text-sm">
-                  <span className="text-gray-400">Platforms</span>
-                  <span className="text-gray-200">{enabledPlatformLabels}</span>
-                </div>
-                <div className="flex items-center justify-between text-sm">
-                  <span className="text-gray-400">Schedule</span>
-                  <span className="text-gray-200">
-                    {scheduledFor
-                      ? new Date(scheduledFor).toLocaleString()
-                      : 'Immediately (now)'}
-                  </span>
-                </div>
+                {!isDraftOnlyPilot && (
+                  <>
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="text-gray-400">Platforms</span>
+                      <span className="text-gray-200">{enabledPlatformLabels}</span>
+                    </div>
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="text-gray-400">Schedule</span>
+                      <span className="text-gray-200">
+                        {scheduledFor
+                          ? new Date(scheduledFor).toLocaleString()
+                          : 'Immediately (now)'}
+                      </span>
+                    </div>
+                  </>
+                )}
               </div>
 
               <p className="text-xs text-gray-500 mb-6">
-                Any unsaved changes will be saved before publishing.
+                {isDraftOnlyPilot
+                  ? 'Any unsaved changes will be saved before approval. Publishing, scheduling, provider generation, and external sends remain blocked.'
+                  : 'Any unsaved changes will be saved before publishing.'}
               </p>
 
               <div className="flex items-center justify-end gap-3">
@@ -2036,7 +2134,7 @@ function SocialContentDetailPage() {
                   className="flex items-center gap-2 px-5 py-2 bg-green-600 hover:bg-green-500 text-white rounded-lg text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {approving ? <Loader2 className="w-4 h-4 animate-spin" /> : <Send className="w-4 h-4" />}
-                  {scheduledFor ? 'Approve & Schedule' : 'Approve & Publish'}
+                  {approveActionLabel}
                 </button>
               </div>
             </motion.div>

--- a/app/api/admin/social-content/[id]/approve/route.test.ts
+++ b/app/api/admin/social-content/[id]/approve/route.test.ts
@@ -1,121 +1,173 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
 
-const authMocks = vi.hoisted(() => ({
+const mocks = vi.hoisted(() => ({
   verifyAdmin: vi.fn(),
-}))
-
-const dbMocks = vi.hoisted(() => ({
+  isAuthError: vi.fn(),
+  createAgentWorkItem: vi.fn(),
+  queueSingle: vi.fn(),
+  queueUpdateSingle: vi.fn(),
+  queueSelect: vi.fn(),
+  queueEq: vi.fn(),
+  queueUpdate: vi.fn(),
+  queueUpdateEq: vi.fn(),
+  queueUpdateSelect: vi.fn(),
+  publishesSelect: vi.fn(),
+  publishesEq: vi.fn(),
+  publishesUpsert: vi.fn(),
   from: vi.fn(),
-  item: {
-    id: 'social-1',
-    status: 'draft',
-    target_platforms: ['linkedin'],
-    scheduled_for: '2026-06-12T14:00:00.000Z',
-    rag_context: null as Record<string, unknown> | null,
-  },
-  updated: null as Record<string, unknown> | null,
-  upsert: vi.fn(async () => ({ error: null })),
 }))
 
 vi.mock('@/lib/auth-server', () => ({
-  verifyAdmin: authMocks.verifyAdmin,
-  isAuthError: (value: unknown) => Boolean(value && typeof value === 'object' && 'error' in value),
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-work-items', () => ({
+  createAgentWorkItem: mocks.createAgentWorkItem,
 }))
 
 vi.mock('@/lib/supabase', () => ({
-  supabaseAdmin: { from: dbMocks.from },
+  supabaseAdmin: {
+    from: mocks.from,
+  },
 }))
 
 import { POST } from './route'
 
 function request() {
-  return new Request('http://localhost/api/admin/social-content/social-1/approve', {
+  return new NextRequest('http://localhost/api/admin/social-content/social-1/approve', {
     method: 'POST',
-    headers: { Authorization: 'Bearer token' },
+    headers: { authorization: 'Bearer admin-token' },
   })
+}
+
+const agentOpsRagContext = {
+  source: 'agent_ops_social_outreach_goal',
+  goal_id: 'goal-1',
+  goal_type: 'social_outreach_linkedin_post',
+  content_packet_id: 'packet-1',
+  publish_gate: 'draft_only',
+  pass_to_human: true,
+  challenger_status: 'passed',
 }
 
 describe('POST /api/admin/social-content/[id]/approve', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    dbMocks.item = {
-      id: 'social-1',
-      status: 'draft',
-      target_platforms: ['linkedin'],
-      scheduled_for: '2026-06-12T14:00:00.000Z',
-      rag_context: null,
-    }
-    dbMocks.updated = null
-    authMocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' }, isAdmin: true })
-    dbMocks.from.mockImplementation((table: string) => {
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-1' }, isAdmin: true })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.createAgentWorkItem.mockResolvedValue({
+      id: 'work-reference-1',
+      title: 'Attach approved Social Content references',
+      status: 'assigned',
+      owner_agent_key: 'research-source-register',
+    })
+    mocks.queueSingle.mockResolvedValue({
+      data: {
+        id: 'social-1',
+        status: 'draft',
+        scheduled_for: null,
+        target_platforms: ['linkedin'],
+        rag_context: agentOpsRagContext,
+      },
+      error: null,
+    })
+    mocks.queueUpdateSingle.mockResolvedValue({
+      data: {
+        id: 'social-1',
+        status: 'approved',
+        scheduled_for: null,
+        target_platforms: ['linkedin'],
+        rag_context: agentOpsRagContext,
+      },
+      error: null,
+    })
+    mocks.queueEq.mockReturnValue({ single: mocks.queueSingle })
+    mocks.queueSelect.mockReturnValue({ eq: mocks.queueEq })
+    mocks.queueUpdateSelect.mockReturnValue({ single: mocks.queueUpdateSingle })
+    mocks.queueUpdateEq.mockReturnValue({ select: mocks.queueUpdateSelect })
+    mocks.queueUpdate.mockReturnValue({ eq: mocks.queueUpdateEq })
+    mocks.publishesEq.mockResolvedValue({ data: [], error: null })
+    mocks.publishesSelect.mockReturnValue({ eq: mocks.publishesEq })
+    mocks.publishesUpsert.mockResolvedValue({ error: null })
+    mocks.from.mockImplementation((table: string) => {
       if (table === 'social_content_queue') {
         return {
-          select: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              single: vi.fn(async () => ({ data: dbMocks.item, error: null })),
-            })),
-          })),
-          update: vi.fn((payload) => {
-            dbMocks.updated = { ...dbMocks.item, ...payload }
-            return {
-              eq: vi.fn(() => ({
-                select: vi.fn(() => ({
-                  single: vi.fn(async () => ({ data: dbMocks.updated, error: null })),
-                })),
-              })),
-            }
-          }),
+          select: mocks.queueSelect,
+          update: mocks.queueUpdate,
         }
       }
       if (table === 'social_content_publishes') {
         return {
-          upsert: dbMocks.upsert,
-          select: vi.fn(() => ({
-            eq: vi.fn(async () => ({ data: [], error: null })),
-          })),
+          select: mocks.publishesSelect,
+          upsert: mocks.publishesUpsert,
         }
       }
       throw new Error(`Unexpected table ${table}`)
     })
   })
 
-  it('blocks Agent Ops draft-only content before challenger clearance', async () => {
-    dbMocks.item.rag_context = {
-      source: 'agent_ops_social_outreach_goal',
-      publish_gate: 'draft_only',
-      current_gate: 'research_context_evidence',
-      challenger_status: 'pending',
-      pass_to_human: false,
-    }
+  it('blocks draft-only Agent Ops content until challenger clearance passes', async () => {
+    mocks.queueSingle.mockResolvedValueOnce({
+      data: {
+        id: 'social-1',
+        status: 'draft',
+        rag_context: {
+          ...agentOpsRagContext,
+          pass_to_human: false,
+          current_gate: 'challenger_qa',
+          challenger_status: 'pending',
+        },
+      },
+      error: null,
+    })
 
-    const response = await POST(request() as never, { params: { id: 'social-1' } })
-    const body = await response.json()
+    const response = await POST(request(), { params: { id: 'social-1' } })
 
     expect(response.status).toBe(409)
-    expect(body).toMatchObject({
+    expect(await response.json()).toEqual({
       error: 'Agent Ops content has not cleared challenger QA for human approval',
-      current_gate: 'research_context_evidence',
+      current_gate: 'challenger_qa',
       challenger_status: 'pending',
     })
-    expect(dbMocks.upsert).not.toHaveBeenCalled()
+    expect(mocks.queueUpdate).not.toHaveBeenCalled()
+    expect(mocks.createAgentWorkItem).not.toHaveBeenCalled()
+    expect(mocks.publishesUpsert).not.toHaveBeenCalled()
   })
 
-  it('allows challenger-cleared Agent Ops content to use the existing approval flow', async () => {
-    dbMocks.item.rag_context = {
-      source: 'agent_ops_social_outreach_goal',
-      publish_gate: 'draft_only',
-      current_gate: 'human_review',
-      challenger_status: 'passed',
-      pass_to_human: true,
-    }
+  it('approves cleared draft-only Agent Ops content by queuing a reference handoff without publishing', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
 
-    const response = await POST(request() as never, { params: { id: 'social-1' } })
-    const body = await response.json()
+    const response = await POST(request(), { params: { id: 'social-1' } })
 
     expect(response.status).toBe(200)
-    expect(body.item).toMatchObject({ status: 'approved', reviewed_by: 'admin-user' })
-    expect(dbMocks.upsert).toHaveBeenCalledWith([
-      { content_id: 'social-1', platform: 'linkedin', status: 'pending' },
-    ], { onConflict: 'content_id,platform' })
+    const json = await response.json()
+    expect(json.publish_triggered).toBe(false)
+    expect(json.publishes).toEqual([])
+    expect(json.reference_work_item).toEqual({
+      id: 'work-reference-1',
+      title: 'Attach approved Social Content references',
+      status: 'assigned',
+      owner_agent_key: 'research-source-register',
+    })
+    expect(mocks.queueUpdate).toHaveBeenCalledWith({
+      status: 'approved',
+      reviewed_by: 'admin-1',
+    })
+    expect(mocks.createAgentWorkItem).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'Attach approved Social Content references',
+      ownerAgentKey: 'research-source-register',
+      status: 'assigned',
+      idempotencyKey: 'social-content-reference-handoff:social-1',
+      metadata: expect.objectContaining({
+        social_content_id: 'social-1',
+        publish_gate: 'draft_only',
+        approval_boundary: 'reference_handoff_only',
+      }),
+    }))
+    expect(mocks.publishesUpsert).not.toHaveBeenCalled()
+    expect(fetchSpy).not.toHaveBeenCalled()
+    fetchSpy.mockRestore()
   })
 })

--- a/app/api/admin/social-content/[id]/approve/route.ts
+++ b/app/api/admin/social-content/[id]/approve/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
 import type { SocialPlatform } from '@/lib/social-content'
+import { createAgentWorkItem } from '@/lib/agent-work-items'
 
 export const dynamic = 'force-dynamic'
 
@@ -46,9 +47,10 @@ export async function POST(
     }
 
     const ragContext = recordValue(item.rag_context)
+    const isAgentOpsDraftOnly = ragContext?.source === 'agent_ops_social_outreach_goal' &&
+      ragContext.publish_gate === 'draft_only'
     if (
-      ragContext?.source === 'agent_ops_social_outreach_goal' &&
-      ragContext.publish_gate === 'draft_only' &&
+      isAgentOpsDraftOnly &&
       ragContext.pass_to_human !== true
     ) {
       return NextResponse.json({
@@ -72,6 +74,55 @@ export async function POST(
     if (updateError) {
       console.error('Error approving content:', updateError)
       return NextResponse.json({ error: 'Failed to approve content' }, { status: 500 })
+    }
+
+    if (isAgentOpsDraftOnly) {
+      const referenceWorkItem = await createAgentWorkItem({
+        title: 'Attach approved Social Content references',
+        objective: [
+          'Add the approved draft references and source links to the Social Content packet after human editorial approval.',
+          'Confirm public references are safe to cite, source URLs are traceable, and framework illustration/carousel needs are recorded as separate draft asset actions.',
+          'Do not publish, schedule, send, call providers, or mutate production systems.',
+        ].join(' '),
+        priority: 'high',
+        status: 'assigned',
+        ownerAgentKey: 'research-source-register',
+        source: {
+          type: 'social_content_approval',
+          id,
+          label: 'Social Content draft approval',
+        },
+        expectedFiles: [],
+        metadata: {
+          source: 'social_content_reference_handoff',
+          social_content_id: id,
+          social_content_href: `/admin/social-content/${id}`,
+          goal_id: typeof ragContext?.goal_id === 'string' ? ragContext.goal_id : null,
+          goal_type: typeof ragContext?.goal_type === 'string' ? ragContext.goal_type : null,
+          content_packet_id: typeof ragContext?.content_packet_id === 'string' ? ragContext.content_packet_id : null,
+          publish_gate: 'draft_only',
+          approval_boundary: 'reference_handoff_only',
+          approval_result: 'human_editorial_approved',
+          required_actions: [
+            'Attach public source/reference links to the approved draft packet.',
+            'Record whether framework illustration or carousel work is needed as separate draft asset actions.',
+            'Keep publishing and provider generation behind separate approval.',
+          ],
+        },
+        idempotencyKey: `social-content-reference-handoff:${id}`,
+      })
+
+      return NextResponse.json({
+        item: updated,
+        publish_triggered: false,
+        publishes: [],
+        reference_work_item: {
+          id: referenceWorkItem.id,
+          title: referenceWorkItem.title,
+          status: referenceWorkItem.status,
+          owner_agent_key: referenceWorkItem.owner_agent_key,
+        },
+      })
     }
 
     // Create social_content_publishes rows — one per target platform

--- a/app/api/admin/social-content/[id]/calibration-revision/route.test.ts
+++ b/app/api/admin/social-content/[id]/calibration-revision/route.test.ts
@@ -158,6 +158,18 @@ describe('POST /api/admin/social-content/[id]/calibration-revision', () => {
       rag_context: expect.objectContaining({
         content_calibration: expect.objectContaining({
           status: 'revision_generated',
+          latest_revision: expect.objectContaining({
+            operator_request: 'Make the hook more concrete.',
+            shaka_understanding: expect.objectContaining({
+              what_i_heard: 'Make the hook more concrete.',
+              planned_changes: expect.arrayContaining([
+                'Address revision request: Make the hook more concrete.',
+              ]),
+              not_changing: expect.arrayContaining([
+                'Draft-only status remains in place.',
+              ]),
+            }),
+          }),
           revision_history: expect.any(Array),
         }),
       }),

--- a/app/api/admin/social-content/[id]/calibration-revision/route.ts
+++ b/app/api/admin/social-content/[id]/calibration-revision/route.ts
@@ -74,6 +74,71 @@ function hasOperatorFeedback(feedback: Record<string, unknown> | null): boolean 
   ].some((key) => Boolean(asString(feedback[key]).trim()))
 }
 
+function includesAny(value: string, words: string[]) {
+  const lower = value.toLowerCase()
+  return words.some((word) => lower.includes(word))
+}
+
+function buildRevisionUnderstanding(feedback: Record<string, unknown> | null) {
+  const revisionRequest = asString(feedback?.revision_request).trim()
+  const claimBoundaries = asString(feedback?.claim_boundaries).trim()
+  const audienceContext = asString(feedback?.audience_context).trim()
+  const engagementSignal = asString(feedback?.engagement_signal).trim()
+  const priorPostExcerpt = asString(feedback?.prior_post_excerpt).trim()
+  const successExamples = normalizeSuccessExamples(feedback?.success_examples)
+  const combined = [
+    revisionRequest,
+    claimBoundaries,
+    audienceContext,
+    engagementSignal,
+    priorPostExcerpt,
+    successExamples.map((example) => [
+      example.source_label,
+      example.post_excerpt,
+      example.engagement_signal,
+      example.why_it_worked,
+    ].filter(Boolean).join(' ')).join(' '),
+  ].join(' ')
+
+  const plannedChanges: string[] = []
+  if (revisionRequest) plannedChanges.push(`Address revision request: ${revisionRequest}`)
+  if (audienceContext) plannedChanges.push(`Tune audience and desired reaction: ${audienceContext}`)
+  if (engagementSignal || successExamples.length > 0 || priorPostExcerpt) {
+    plannedChanges.push('Compare the draft against the saved successful-post references and engagement signals.')
+  }
+  if (includesAny(combined, ['anecdote', 'story', 'scene', 'example'])) {
+    plannedChanges.push('Add or strengthen a concrete anecdote before the broader point.')
+  }
+  if (includesAny(combined, ['ai-ism', 'ai ism', 'not just', 'not only', "it's not", 'generic'])) {
+    plannedChanges.push('Remove formulaic AI phrasing and negative antithesis constructions.')
+  }
+
+  const separateActions: string[] = []
+  if (includesAny(combined, ['illustration', 'image', 'visual', 'framework'])) {
+    separateActions.push('Framework illustration or visual generation is a separate asset action after copy revision.')
+  }
+  if (includesAny(combined, ['carousel', 'slides', 'slide'])) {
+    separateActions.push('Carousel creation is a separate asset action after copy revision.')
+  }
+  if (includesAny(combined, ['reference', 'source', 'citation'])) {
+    separateActions.push('Reference/source attachment should become an Agent Ops follow-up after draft approval.')
+  }
+
+  return {
+    what_i_heard: revisionRequest || 'Use the saved calibration feedback to improve this draft.',
+    planned_changes: plannedChanges.length ? plannedChanges : ['Revise the draft against the saved calibration feedback and voice guidance.'],
+    not_changing: [
+      'Draft-only status remains in place.',
+      'Publishing, scheduling, provider generation, DMs, sends, deploys, and production mutations remain outside this revision.',
+      ...(claimBoundaries ? [`Respect claim boundary: ${claimBoundaries}`] : []),
+    ],
+    separate_actions: separateActions,
+    questions_or_ambiguity: separateActions.length
+      ? ['Some feedback asks for non-copy assets. Those are tracked separately so Shaka does not hide them inside a text revision.']
+      : [],
+  }
+}
+
 function buildRevisionPrompt(row: SocialContentRow) {
   const ragContext = asRecord(row.rag_context) ?? {}
   const calibration = asRecord(ragContext.content_calibration) ?? {}
@@ -231,6 +296,7 @@ export async function POST(
     if (!hasOperatorFeedback(operatorFeedback)) {
       return NextResponse.json({ error: 'Save operator feedback before generating a calibrated revision' }, { status: 400 })
     }
+    const revisionUnderstanding = buildRevisionUnderstanding(operatorFeedback)
 
     const promptRagContext: Record<string, unknown> = {
       ...ragContext,
@@ -276,6 +342,8 @@ Additional role: You are Shaka, the Agent Ops Chief of Staff. Use the operator f
       model: aiResponse.model,
       provider: aiResponse.provider,
       revision_notes: revision.revision_notes,
+      operator_request: asString(operatorFeedback?.revision_request) || null,
+      shaka_understanding: revisionUnderstanding,
       operator_feedback_updated_at: asString(operatorFeedback?.updated_at) || null,
     }
     const revisionHistory = Array.isArray(calibration.revision_history)
@@ -320,6 +388,7 @@ Additional role: You are Shaka, the Agent Ops Chief of Staff. Use the operator f
     return NextResponse.json({
       item: updated,
       revision: revisionEntry,
+      shaka_understanding: revisionUnderstanding,
     })
   } catch (error) {
     console.error('[calibration-revision] error:', error)


### PR DESCRIPTION
## Summary
- Stores Shaka's revision understanding with each Social Content calibration revision: original request, planned changes, unchanged boundaries, separate asset actions, and open ambiguity.
- Renders a Shaka Revision Receipt in the Agent Ops Social Content detail page so operators can see whether feedback was understood before trusting the revised draft.
- Changes draft-only Agent Ops approval from publish-oriented behavior to an approval-only handoff that creates an idempotent Research Source Register work item for approved draft references and separate asset follow-up.

## Validation
- `./node_modules/.bin/vitest run 'app/api/admin/social-content/[id]/calibration-revision/route.test.ts' 'app/api/admin/social-content/[id]/approve/route.test.ts'`
- `./node_modules/.bin/tsc --noEmit`
- `npm run lint`
- `npm run build:knowledge && node --env-file=/Users/vambahsillah/Projects/Portfolio/.env.local ./node_modules/next/dist/bin/next build`
- Local branch smoke on `http://localhost:3016/admin/social-content/25d7efa3-62bc-4f5e-a191-1a131918593a`: draft-only panel rendered, primary action showed `Approve Draft`, and `Approve & Publish` was absent for the Agent Ops draft-only item.

## Integration Notes
- No database migration. Revision receipts are stored in existing `rag_context.content_calibration.latest_revision` and `revision_history`.
- Draft-only Agent Ops approval still updates the Social Content item to `approved`, but skips publish rows and publish triggers, returning `publish_triggered=false` and a `reference_work_item` payload.
- The reference handoff uses existing Agent Ops work-item creation with idempotency key `social-content-reference-handoff:<content_id>`.
- No publish, schedule, provider generation, send, deploy, n8n activation, or production external side effect is authorized by this change.
- Build used the main checkout env file for Supabase config and surfaced the existing env-check warning that `MOCK_N8N=false` and `N8N_DISABLE_OUTBOUND=false` in that env.
- Vercel contexts not checked by this non-captain lane:
  - Vercel – portfolio: not checked
  - Vercel – portfolio-staging: not checked
