### PR TITLE
feat: orchestrate social content production swarm

### DIFF
--- a/app/api/admin/social-content/[id]/approve/route.test.ts
+++ b/app/api/admin/social-content/[id]/approve/route.test.ts
@@ -57,12 +57,12 @@ describe('POST /api/admin/social-content/[id]/approve', () => {
     vi.clearAllMocks()
     mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-1' }, isAdmin: true })
     mocks.isAuthError.mockReturnValue(false)
-    mocks.createAgentWorkItem.mockResolvedValue({
-      id: 'work-reference-1',
-      title: 'Attach approved Social Content references',
-      status: 'assigned',
-      owner_agent_key: 'research-source-register',
-    })
+    mocks.createAgentWorkItem.mockImplementation(async (input) => ({
+      id: `work-${input.metadata.production_lane}-1`,
+      title: input.title,
+      status: input.status,
+      owner_agent_key: input.ownerAgentKey,
+    }))
     mocks.queueSingle.mockResolvedValue({
       data: {
         id: 'social-1',
@@ -136,7 +136,7 @@ describe('POST /api/admin/social-content/[id]/approve', () => {
     expect(mocks.publishesUpsert).not.toHaveBeenCalled()
   })
 
-  it('approves cleared draft-only Agent Ops content by queuing a reference handoff without publishing', async () => {
+  it('approves cleared draft-only Agent Ops content by queuing production handoffs without publishing', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch')
 
     const response = await POST(request(), { params: { id: 'social-1' } })
@@ -146,15 +146,39 @@ describe('POST /api/admin/social-content/[id]/approve', () => {
     expect(json.publish_triggered).toBe(false)
     expect(json.publishes).toEqual([])
     expect(json.reference_work_item).toEqual({
-      id: 'work-reference-1',
+      id: 'work-references-1',
       title: 'Attach approved Social Content references',
       status: 'assigned',
       owner_agent_key: 'research-source-register',
+      production_lane: 'references',
     })
+    expect(json.production_work_items).toEqual([
+      expect.objectContaining({
+        title: 'Attach approved Social Content references',
+        owner_agent_key: 'research-source-register',
+        production_lane: 'references',
+      }),
+      expect.objectContaining({
+        title: 'Prepare approved Social Content illustration brief',
+        owner_agent_key: 'amadutown-brand',
+        production_lane: 'illustration',
+      }),
+      expect.objectContaining({
+        title: 'Prepare Social Content carousel production packet',
+        owner_agent_key: 'content-repurposing',
+        production_lane: 'carousel',
+      }),
+      expect.objectContaining({
+        title: 'Run post-approval visual QA',
+        owner_agent_key: 'risk-compliance-intelligence',
+        production_lane: 'visual_qa',
+      }),
+    ])
     expect(mocks.queueUpdate).toHaveBeenCalledWith({
       status: 'approved',
       reviewed_by: 'admin-1',
     })
+    expect(mocks.createAgentWorkItem).toHaveBeenCalledTimes(4)
     expect(mocks.createAgentWorkItem).toHaveBeenCalledWith(expect.objectContaining({
       title: 'Attach approved Social Content references',
       ownerAgentKey: 'research-source-register',
@@ -163,7 +187,19 @@ describe('POST /api/admin/social-content/[id]/approve', () => {
       metadata: expect.objectContaining({
         social_content_id: 'social-1',
         publish_gate: 'draft_only',
-        approval_boundary: 'reference_handoff_only',
+        approval_boundary: 'post_approval_production_handoff_only',
+        production_lane: 'references',
+      }),
+    }))
+    expect(mocks.createAgentWorkItem).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'Prepare approved Social Content illustration brief',
+      ownerAgentKey: 'amadutown-brand',
+      status: 'assigned',
+      idempotencyKey: 'social-content-production-handoff:social-1:illustration',
+      metadata: expect.objectContaining({
+        social_content_id: 'social-1',
+        publish_gate: 'draft_only',
+        production_lane: 'illustration',
       }),
     }))
     expect(mocks.publishesUpsert).not.toHaveBeenCalled()

--- a/app/api/admin/social-content/[id]/approve/route.ts
+++ b/app/api/admin/social-content/[id]/approve/route.ts
@@ -10,6 +10,101 @@ function recordValue(value: unknown): Record<string, unknown> | null {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null
 }
 
+function stringValue(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function productionHandoffDefinitions(id: string, ragContext: Record<string, unknown> | null) {
+  const commonMetadata = {
+    social_content_id: id,
+    social_content_href: `/admin/social-content/${id}`,
+    goal_id: stringValue(ragContext?.goal_id),
+    goal_type: stringValue(ragContext?.goal_type),
+    content_packet_id: stringValue(ragContext?.content_packet_id),
+    publish_gate: 'draft_only',
+    approval_result: 'human_editorial_approved',
+    approval_boundary: 'post_approval_production_handoff_only',
+    blocked_actions: [
+      'Do not publish or schedule.',
+      'Do not send DMs or external outreach.',
+      'Do not call image, audio, carousel render, or provider-generation APIs.',
+      'Do not mutate production systems outside Agent Ops work-item routing.',
+    ],
+  }
+
+  return [
+    {
+      title: 'Attach approved Social Content references',
+      ownerAgentKey: 'research-source-register',
+      priority: 'high' as const,
+      productionLane: 'references',
+      objective: [
+        'Add the approved draft references and source links to the Social Content packet after human editorial approval.',
+        'Confirm public references are safe to cite, source URLs are traceable, and claim boundaries are visible.',
+        'Do not publish, schedule, send, call providers, or mutate production systems.',
+      ].join(' '),
+      requiredActions: [
+        'Attach public source/reference links to the approved draft packet.',
+        'Mark unsupported or private-derived claims for revision before publish approval.',
+        'Record reference placement guidance for the final post or carousel.',
+      ],
+    },
+    {
+      title: 'Prepare approved Social Content illustration brief',
+      ownerAgentKey: 'amadutown-brand',
+      priority: 'medium' as const,
+      productionLane: 'illustration',
+      objective: [
+        'Turn the approved draft into a brand-safe illustration brief and image prompt for the AmaduTown visual system.',
+        'Document style, accessibility, claim, and evidence boundaries before any provider generation is requested.',
+      ].join(' '),
+      requiredActions: [
+        'Confirm the illustration is labeled as an illustration, not evidence.',
+        'Attach the approved image prompt and brand constraints.',
+        'Identify any required operator approval before generation.',
+      ],
+    },
+    {
+      title: 'Prepare Social Content carousel production packet',
+      ownerAgentKey: 'content-repurposing',
+      priority: 'medium' as const,
+      productionLane: 'carousel',
+      objective: [
+        'Prepare the optional carousel or single-image production packet from the approved draft, references, and illustration brief.',
+        'Keep rendering, uploads, provider calls, and scheduling behind separate governed approvals.',
+      ].join(' '),
+      requiredActions: [
+        'Draft the slide-by-slide carousel outline or record why single-image is better.',
+        'Map any slide claims to approved references.',
+        'Record render/provider prerequisites without triggering them.',
+      ],
+    },
+    {
+      title: 'Run post-approval visual QA',
+      ownerAgentKey: 'risk-compliance-intelligence',
+      priority: 'medium' as const,
+      productionLane: 'visual_qa',
+      objective: [
+        'Review the reference, illustration, and carousel production packet for accessibility, privacy, unsupported claims, and misrepresentation risk.',
+        'Return a clear pass/revise recommendation before any publish or provider-generation approval.',
+      ].join(' '),
+      requiredActions: [
+        'Check accessibility and mobile readability risks.',
+        'Confirm visual claims do not imply unsupported proof.',
+        'List any residual risks for human publish approval.',
+      ],
+    },
+  ].map((definition) => ({
+    ...definition,
+    metadata: {
+      ...commonMetadata,
+      source: 'social_content_production_handoff',
+      production_lane: definition.productionLane,
+      required_actions: definition.requiredActions,
+    },
+  }))
+}
+
 /**
  * POST /api/admin/social-content/[id]/approve
  * Approve content, create per-platform publish records, and trigger immediate publishing
@@ -77,51 +172,40 @@ export async function POST(
     }
 
     if (isAgentOpsDraftOnly) {
-      const referenceWorkItem = await createAgentWorkItem({
-        title: 'Attach approved Social Content references',
-        objective: [
-          'Add the approved draft references and source links to the Social Content packet after human editorial approval.',
-          'Confirm public references are safe to cite, source URLs are traceable, and framework illustration/carousel needs are recorded as separate draft asset actions.',
-          'Do not publish, schedule, send, call providers, or mutate production systems.',
-        ].join(' '),
-        priority: 'high',
-        status: 'assigned',
-        ownerAgentKey: 'research-source-register',
-        source: {
-          type: 'social_content_approval',
-          id,
-          label: 'Social Content draft approval',
-        },
-        expectedFiles: [],
-        metadata: {
-          source: 'social_content_reference_handoff',
-          social_content_id: id,
-          social_content_href: `/admin/social-content/${id}`,
-          goal_id: typeof ragContext?.goal_id === 'string' ? ragContext.goal_id : null,
-          goal_type: typeof ragContext?.goal_type === 'string' ? ragContext.goal_type : null,
-          content_packet_id: typeof ragContext?.content_packet_id === 'string' ? ragContext.content_packet_id : null,
-          publish_gate: 'draft_only',
-          approval_boundary: 'reference_handoff_only',
-          approval_result: 'human_editorial_approved',
-          required_actions: [
-            'Attach public source/reference links to the approved draft packet.',
-            'Record whether framework illustration or carousel work is needed as separate draft asset actions.',
-            'Keep publishing and provider generation behind separate approval.',
-          ],
-        },
-        idempotencyKey: `social-content-reference-handoff:${id}`,
-      })
+      const productionWorkItems = []
+      for (const definition of productionHandoffDefinitions(id, ragContext)) {
+        const workItem = await createAgentWorkItem({
+          title: definition.title,
+          objective: definition.objective,
+          priority: definition.priority,
+          status: 'assigned',
+          ownerAgentKey: definition.ownerAgentKey,
+          source: {
+            type: 'social_content_approval',
+            id,
+            label: 'Social Content draft approval',
+          },
+          expectedFiles: [],
+          metadata: definition.metadata,
+          idempotencyKey: definition.productionLane === 'references'
+            ? `social-content-reference-handoff:${id}`
+            : `social-content-production-handoff:${id}:${definition.productionLane}`,
+        })
+        productionWorkItems.push({
+          id: workItem.id,
+          title: workItem.title,
+          status: workItem.status,
+          owner_agent_key: workItem.owner_agent_key,
+          production_lane: definition.productionLane,
+        })
+      }
 
       return NextResponse.json({
         item: updated,
         publish_triggered: false,
         publishes: [],
-        reference_work_item: {
-          id: referenceWorkItem.id,
-          title: referenceWorkItem.title,
-          status: referenceWorkItem.status,
-          owner_agent_key: referenceWorkItem.owner_agent_key,
-        },
+        reference_work_item: productionWorkItems.find((workItem) => workItem.production_lane === 'references') ?? null,
+        production_work_items: productionWorkItems,
       })
     }
 

--- a/lib/agent-war-room.test.ts
+++ b/lib/agent-war-room.test.ts
@@ -565,6 +565,22 @@ describe('runAgentWarRoom', () => {
           ]),
           comparison_prompt: expect.stringContaining('Compare this draft against Vambah LinkedIn voice guidance'),
         }),
+        production_orchestration: expect.objectContaining({
+          version: 'social_content_production_v1',
+          asset_actions_require_approval: true,
+          illustration_required: true,
+          carousel_candidate: true,
+          lanes: expect.arrayContaining([
+            expect.objectContaining({
+              key: 'illustration',
+              owner_agent_key: 'amadutown-brand',
+            }),
+            expect.objectContaining({
+              key: 'carousel',
+              owner_agent_key: 'content-repurposing',
+            }),
+          ]),
+        }),
       }),
     })
     expect(draftResult.goalDraft?.tasks.map((task) => task.title)).toEqual([
@@ -573,8 +589,12 @@ describe('runAgentWarRoom', () => {
       'Attach manual Chronicle evidence packet',
       'Select AmaduTown proof points',
       'Draft the LinkedIn post',
-      'Create the visual brief',
+      'Plan reference and citation annotations',
+      'Design the framework illustration system',
+      'Prepare the carousel and illustration production packet',
       'Run content QA and governance review',
+      'Run visual QA and accessibility review',
+      'Package the human editorial review bundle',
       'Create the Social Content draft handoff',
     ])
     expect(workItemMocks.createAgentWorkItem).not.toHaveBeenCalled()
@@ -611,6 +631,12 @@ describe('runAgentWarRoom', () => {
           content_calibration: expect.objectContaining({
             status: 'needs_operator_context',
           }),
+          production_orchestration: expect.objectContaining({
+            version: 'social_content_production_v1',
+          }),
+        }),
+        production_orchestration: expect.objectContaining({
+          version: 'social_content_production_v1',
         }),
       }),
     }))
@@ -624,6 +650,14 @@ describe('runAgentWarRoom', () => {
         pass_to_human: false,
         challenger_status: 'pending',
         social_content_draft_id: 'social-draft-1',
+        production_lane: 'human_review_packet',
+      }),
+    }))
+    expect(workItemMocks.createAgentWorkItem).toHaveBeenCalledWith(expect.objectContaining({
+      source: expect.objectContaining({ id: expect.stringContaining('-illustration-system') }),
+      ownerAgentKey: 'amadutown-brand',
+      metadata: expect.objectContaining({
+        production_lane: 'illustration',
       }),
     }))
     expect(agentRunMocks.attachAgentArtifact).toHaveBeenCalledWith(expect.objectContaining({

--- a/lib/agent-war-room.ts
+++ b/lib/agent-war-room.ts
@@ -74,6 +74,33 @@ export interface LinkedInContentCalibration {
   }
 }
 
+export type SocialContentProductionLaneKey =
+  | 'copy'
+  | 'references'
+  | 'illustration'
+  | 'carousel'
+  | 'visual_qa'
+  | 'human_review_packet'
+  | 'post_approval_handoff'
+
+export interface SocialContentProductionLane {
+  key: SocialContentProductionLaneKey
+  label: string
+  owner_agent_key: string
+  objective: string
+  approval_boundary: string
+  outputs: string[]
+}
+
+export interface SocialContentProductionOrchestration {
+  version: 'social_content_production_v1'
+  enabled: boolean
+  asset_actions_require_approval: boolean
+  illustration_required: boolean
+  carousel_candidate: boolean
+  lanes: SocialContentProductionLane[]
+}
+
 export interface LinkedInContentPacket {
   id: string
   goal_statement: string
@@ -88,6 +115,7 @@ export interface LinkedInContentPacket {
   source_provenance_checklist: string[]
   approval_checklist: string[]
   content_calibration: LinkedInContentCalibration
+  production_orchestration: SocialContentProductionOrchestration
   social_content_draft_id?: string | null
   social_content_draft_href?: string | null
 }
@@ -202,13 +230,26 @@ function selectAgents(command: AgentWarRoomCommand, message: string | null, targ
   const callable = callableAgents()
   if (command === 'standup') return callable.slice(0, 8)
   if (command === 'draft_goal' || isApprovalCommand(command)) {
-    return [
-      getAgentByKey('chief-of-staff'),
-      getAgentByKey('engineering-copilot'),
-      getAgentByKey('automation-systems'),
-      getAgentByKey('research-source-register'),
-      getAgentByKey('risk-compliance-intelligence'),
-    ].filter(Boolean) as AgentOrganizationNode[]
+    const isSocialContent = /social|linkedin|content|post|carousel|illustration|visual/i.test(message ?? '')
+    const keys = isSocialContent
+      ? [
+        'chief-of-staff',
+        'research-source-register',
+        'private-knowledge-librarian',
+        'voice-content-architect',
+        'content-repurposing',
+        'amadutown-brand',
+        'website-product-copy',
+        'risk-compliance-intelligence',
+      ]
+      : [
+        'chief-of-staff',
+        'engineering-copilot',
+        'automation-systems',
+        'research-source-register',
+        'risk-compliance-intelligence',
+      ]
+    return keys.map((key) => getAgentByKey(key)).filter(Boolean) as AgentOrganizationNode[]
   }
 
   const text = (message ?? '').toLowerCase()
@@ -394,6 +435,74 @@ function buildLinkedInContentCalibration(): LinkedInContentCalibration {
   }
 }
 
+function buildSocialContentProductionOrchestration(): SocialContentProductionOrchestration {
+  return {
+    version: 'social_content_production_v1',
+    enabled: true,
+    asset_actions_require_approval: true,
+    illustration_required: true,
+    carousel_candidate: true,
+    lanes: [
+      {
+        key: 'copy',
+        label: 'Copy draft and revision loop',
+        owner_agent_key: 'voice-content-architect',
+        objective: 'Turn the approved signal, evidence, and operator feedback into a Vambah-aligned LinkedIn draft.',
+        approval_boundary: 'Human editorial review is required before publishing or scheduling.',
+        outputs: ['LinkedIn post draft', 'revision receipt', 'operator feedback summary'],
+      },
+      {
+        key: 'references',
+        label: 'Reference and citation packet',
+        owner_agent_key: 'research-source-register',
+        objective: 'Attach public-safe source links, internal proof labels, and claim boundaries to the draft packet.',
+        approval_boundary: 'References may be prepared after draft approval; public claims still require publish approval.',
+        outputs: ['source link list', 'claim support notes', 'reference placement guidance'],
+      },
+      {
+        key: 'illustration',
+        label: 'Framework illustration spec',
+        owner_agent_key: 'amadutown-brand',
+        objective: 'Translate the content argument into an AmaduTown visual system, image prompt, and reviewable illustration brief.',
+        approval_boundary: 'Provider image generation is not authorized by goal approval.',
+        outputs: ['illustration brief', 'image prompt', 'brand fit notes'],
+      },
+      {
+        key: 'carousel',
+        label: 'Carousel and asset production packet',
+        owner_agent_key: 'content-repurposing',
+        objective: 'Prepare the slide-by-slide carousel structure and production notes needed for optional visual asset generation.',
+        approval_boundary: 'Rendering, upload, scheduling, and provider calls require a separate approval.',
+        outputs: ['carousel outline', 'asset checklist', 'render readiness notes'],
+      },
+      {
+        key: 'visual_qa',
+        label: 'Visual QA and accessibility',
+        owner_agent_key: 'risk-compliance-intelligence',
+        objective: 'Check illustration/carousel work for accessibility, claim accuracy, privacy, and misrepresentation risk.',
+        approval_boundary: 'QA may recommend human review; it cannot publish or generate provider assets.',
+        outputs: ['visual QA notes', 'accessibility flags', 'risk findings'],
+      },
+      {
+        key: 'human_review_packet',
+        label: 'Human editorial review packet',
+        owner_agent_key: 'content-repurposing',
+        objective: 'Package copy, references, illustration brief, carousel notes, QA, and revision receipt into one reviewable Social Content item.',
+        approval_boundary: 'Approval advances the draft to post-approval production handoffs only, not public publishing.',
+        outputs: ['review packet', 'Social Content draft link', 'remaining decisions'],
+      },
+      {
+        key: 'post_approval_handoff',
+        label: 'Post-approval production handoffs',
+        owner_agent_key: 'chief-of-staff',
+        objective: 'After human draft approval, route reference, illustration, carousel, and visual QA tasks without triggering external production.',
+        approval_boundary: 'Publishing and provider generation remain behind separate governed actions.',
+        outputs: ['assigned handoff tasks', 'approval boundary notes', 'next production gate'],
+      },
+    ],
+  }
+}
+
 function buildLinkedInPacket(goalId: string, title: string): LinkedInContentPacket {
   const packetId = `packet-${goalId}`
   return {
@@ -435,10 +544,12 @@ function buildLinkedInPacket(goalId: string, title: string): LinkedInContentPack
     approval_checklist: [
       'Post matches Vambah LinkedIn voice guidance.',
       'Visual concept supports the argument instead of decorating it.',
+      'Reference, illustration, carousel, and visual QA lanes are represented in the swarm before final human review.',
       'CTA invites discussion without overpromising.',
       'Social Content item remains draft-only until separately approved.',
     ],
     content_calibration: buildLinkedInContentCalibration(),
+    production_orchestration: buildSocialContentProductionOrchestration(),
     social_content_draft_id: null,
     social_content_draft_href: null,
   }
@@ -582,16 +693,40 @@ function socialOutreachTasks(goalId: string, title: string): AgentGoalDraftTask[
       goal_progress_weight: 3,
     },
     {
-      id: `${goalId}-visual-brief`,
-      title: 'Create the visual brief',
-      objective: 'Write a visual concept and image prompt that illustrates the operating model behind the post.',
+      id: `${goalId}-reference-plan`,
+      title: 'Plan reference and citation annotations',
+      objective: 'Map the draft claims to public-safe source links, internal proof labels, and reference placement notes.',
+      owner_agent_key: 'research-source-register',
+      priority: 'high',
+      dependencies: [`${goalId}-post-draft`, `${goalId}-industry-research`, `${goalId}-open-brain-context`],
+      expected_files: ['/admin/social-content', '/admin/value-evidence', '/admin/agents/open-brain'],
+      acceptance_criteria: ['Each public claim has source support or a softening note', 'Internal proof is labeled without exposing private material', 'Reference placement is ready for post-approval attachment'],
+      risk_notes: 'Do not add unsupported URLs or imply private evidence can be cited publicly.',
+      goal_progress_weight: 2,
+    },
+    {
+      id: `${goalId}-illustration-system`,
+      title: 'Design the framework illustration system',
+      objective: 'Create the AmaduTown visual concept, image prompt, and design constraints for the post illustration.',
+      owner_agent_key: 'amadutown-brand',
+      priority: 'medium',
+      dependencies: [`${goalId}-post-draft`, `${goalId}-amadutown-proof`],
+      expected_files: ['/admin/social-content', 'public/amadutown-logo-upscaled.png', 'docs/carousel-design-system.md'],
+      acceptance_criteria: ['Visual prompt matches the Mission Control aesthetic', 'Illustration supports the argument instead of acting as proof', 'Brand and accessibility constraints are documented'],
+      risk_notes: 'Provider image generation is a separate approval-gated action; this task only prepares the spec.',
+      goal_progress_weight: 2,
+    },
+    {
+      id: `${goalId}-asset-production-packet`,
+      title: 'Prepare the carousel and illustration production packet',
+      objective: 'Translate the post, reference plan, and illustration system into a reviewable asset packet for optional carousel or single-image production.',
       owner_agent_key: 'content-repurposing',
       priority: 'medium',
-      dependencies: [`${goalId}-post-draft`],
-      expected_files: ['/admin/social-content'],
-      acceptance_criteria: ['Visual prompt matches the Mission Control aesthetic', 'Visual supports the argument', 'Generated asset remains reviewable before use'],
-      risk_notes: 'Do not imply a generated image is evidence; label it as an illustration.',
-      goal_progress_weight: 1,
+      dependencies: [`${goalId}-reference-plan`, `${goalId}-illustration-system`],
+      expected_files: ['/admin/social-content', 'docs/carousel-design-system.md'],
+      acceptance_criteria: ['Carousel outline or single-image decision is documented', 'Slide/image copy stays source-backed', 'Provider/render/upload steps remain explicitly approval-gated'],
+      risk_notes: 'Do not render, upload, call image providers, or schedule assets from goal approval.',
+      goal_progress_weight: 2,
     },
     {
       id: `${goalId}-qa-governance`,
@@ -599,11 +734,35 @@ function socialOutreachTasks(goalId: string, title: string): AgentGoalDraftTask[
       objective: 'Check voice fit, source support, privacy, claims, and draft-only publishing boundary.',
       owner_agent_key: 'risk-compliance-intelligence',
       priority: 'high',
-      dependencies: [`${goalId}-post-draft`, `${goalId}-visual-brief`],
+      dependencies: [`${goalId}-post-draft`, `${goalId}-reference-plan`, `${goalId}-asset-production-packet`],
       expected_files: ['/admin/social-content', '/admin/agents/coordination'],
-      acceptance_criteria: ['No private leakage', 'Claims are source-backed or softened', 'Publish remains separately approval-gated'],
+      acceptance_criteria: ['No private leakage', 'Claims are source-backed or softened', 'Asset production and publish remain separately approval-gated'],
       risk_notes: 'Approval to create a draft is not approval to publish.',
       goal_progress_weight: 2,
+    },
+    {
+      id: `${goalId}-visual-qa`,
+      title: 'Run visual QA and accessibility review',
+      objective: 'Check the illustration/carousel packet for brand fit, accessibility, claim accuracy, and misrepresentation risk.',
+      owner_agent_key: 'risk-compliance-intelligence',
+      priority: 'medium',
+      dependencies: [`${goalId}-asset-production-packet`],
+      expected_files: ['/admin/social-content', 'docs/carousel-design-system.md'],
+      acceptance_criteria: ['Visual is clearly labeled as an illustration when applicable', 'Accessibility and mobile readability risks are noted', 'No visual claim implies unsupported evidence'],
+      risk_notes: 'Visual QA can recommend review or revision; it cannot authorize publishing or provider generation.',
+      goal_progress_weight: 1,
+    },
+    {
+      id: `${goalId}-review-bundle`,
+      title: 'Package the human editorial review bundle',
+      objective: 'Assemble copy, references, illustration brief, carousel notes, QA findings, and revision receipt into one Social Content review packet.',
+      owner_agent_key: 'content-repurposing',
+      priority: 'high',
+      dependencies: [`${goalId}-qa-governance`, `${goalId}-visual-qa`],
+      expected_files: ['/admin/social-content', '/admin/agents/swarm-board'],
+      acceptance_criteria: ['Reviewer can see what Shaka understood and what changed', 'Reference and visual next actions are explicit', 'Remaining approval gates are visible'],
+      risk_notes: 'The review bundle is for human approval; it must not imply public publishing is authorized.',
+      goal_progress_weight: 1,
     },
     {
       id: `${goalId}-social-content-draft`,
@@ -611,13 +770,24 @@ function socialOutreachTasks(goalId: string, title: string): AgentGoalDraftTask[
       objective: 'Create or link the draft-only Social Content item with the packet, visual brief, provenance, and approval notes.',
       owner_agent_key: 'content-repurposing',
       priority: 'high',
-      dependencies: [`${goalId}-qa-governance`],
+      dependencies: [`${goalId}-review-bundle`],
       expected_files: ['/admin/social-content'],
       acceptance_criteria: ['Social Content item is draft status', 'Packet id and goal id are traceable', 'No publish, schedule, DM, or external outreach is triggered'],
       risk_notes: 'Publishing remains manual and separately approved outside this goal approval.',
       goal_progress_weight: 1,
     },
   ]
+}
+
+function socialProductionLaneForTask(taskId: string): SocialContentProductionLaneKey | null {
+  if (taskId.endsWith('-industry-research') || taskId.endsWith('-open-brain-context') || taskId.endsWith('-chronicle-packet')) return 'references'
+  if (taskId.endsWith('-amadutown-proof') || taskId.endsWith('-post-draft')) return 'copy'
+  if (taskId.endsWith('-reference-plan')) return 'references'
+  if (taskId.endsWith('-illustration-system')) return 'illustration'
+  if (taskId.endsWith('-asset-production-packet')) return 'carousel'
+  if (taskId.endsWith('-visual-qa')) return 'visual_qa'
+  if (taskId.endsWith('-qa-governance') || taskId.endsWith('-review-bundle') || taskId.endsWith('-social-content-draft')) return 'human_review_packet'
+  return null
 }
 
 function draftSocialOutreachGoal(goal: string, title: string, goalId: string): AgentGoalDraft {
@@ -932,6 +1102,8 @@ async function createSocialContentDraftForGoal(draft: AgentGoalDraft) {
     ...packet.content_calibration.missing_context_prompts.slice(0, 3).map((item) => `- ${item}`),
     'Approval checklist:',
     ...packet.approval_checklist.map((item) => `- ${item}`),
+    'Production orchestration:',
+    ...packet.production_orchestration.lanes.map((lane) => `- ${lane.label}: ${lane.owner_agent_key}; ${lane.approval_boundary}`),
   ].join('\n')
 
   const { data, error } = await supabaseAdmin
@@ -979,6 +1151,7 @@ async function createSocialContentDraftForGoal(draft: AgentGoalDraft) {
         approval_checklist: packet.approval_checklist,
         visual_brief: packet.visual_concept,
         content_calibration: packet.content_calibration,
+        production_orchestration: packet.production_orchestration,
       },
       admin_notes: adminNotes,
       target_platforms: ['linkedin'],
@@ -1056,6 +1229,7 @@ async function approveGoalDraft(runId: string, draft: AgentGoalDraft) {
       chronicle_packet_status: draft.chronicle_packet_status ?? null,
       content_packet_id: draft.content_packet_id ?? contentPacket?.id ?? null,
       content_packet: contentPacket,
+      production_orchestration: contentPacket?.production_orchestration ?? null,
       social_content_draft_id: socialContentDraft?.id ?? null,
       social_content_draft_href: socialContentDraft?.href ?? null,
     },
@@ -1100,6 +1274,12 @@ async function approveGoalDraft(runId: string, draft: AgentGoalDraft) {
         goal_dependencies: task.dependencies,
         task_acceptance_criteria: task.acceptance_criteria,
         risk_notes: task.risk_notes,
+        production_lane: draft.goal_type === 'social_outreach_linkedin_post'
+          ? socialProductionLaneForTask(task.id)
+          : null,
+        production_orchestration: draft.goal_type === 'social_outreach_linkedin_post'
+          ? contentPacket?.production_orchestration ?? null
+          : null,
         orchestration_gate: inferWorkItemOrchestrationGate({
           title: task.title,
           status: 'assigned',

--- a/lib/goal-orchestration.ts
+++ b/lib/goal-orchestration.ts
@@ -266,8 +266,21 @@ export function evaluateGoalOrchestration(input: {
 
 export function evaluateContentGoalOrchestration(items: GoalOrchestrationWorkItem[]) {
   const researchPatterns = [/industry signal/i, /Open Brain context/i, /Chronicle evidence/i]
-  const draftPatterns = [/proof points/i, /LinkedIn post/i, /visual brief/i]
-  const challenger = items.find((item) => /QA|governance|challenger/i.test(item.title)) ?? null
+  const draftPatterns = [
+    /proof points/i,
+    /LinkedIn post/i,
+    /visual brief|framework illustration/i,
+  ]
+  const productionPatterns = [
+    /reference and citation/i,
+    /carousel and illustration production/i,
+    /human editorial review bundle/i,
+    /Social Content draft handoff/i,
+  ]
+  const visualQaPatterns = [/visual QA/i]
+  const hasProductionPacketTasks = hasTask(items, /reference and citation|carousel and illustration production|human editorial review bundle/i)
+  const hasVisualQaTasks = hasTask(items, /visual QA/i)
+  const challenger = items.find((item) => /content QA|governance|challenger/i.test(item.title)) ?? null
 
   if (!taskGroupDone(items, researchPatterns)) {
     return buildGoalOrchestrationPacket({
@@ -286,6 +299,26 @@ export function evaluateContentGoalOrchestration(items: GoalOrchestrationWorkIte
       gateStatus: 'drafting',
       approvalBoundary: 'Human review is blocked until draft/build work is complete.',
       residualRisksForHuman: ['Draft/build work is incomplete.'],
+    })
+  }
+
+  if (hasProductionPacketTasks && !taskGroupDone(items, productionPatterns)) {
+    return buildGoalOrchestrationPacket({
+      goalType: 'social_outreach_linkedin_post',
+      currentGate: 'draft_build',
+      gateStatus: 'drafting',
+      approvalBoundary: 'Human review is blocked until references, illustration, carousel, and review packaging are complete.',
+      residualRisksForHuman: ['Production packet work is incomplete.'],
+    })
+  }
+
+  if (hasVisualQaTasks && !taskGroupDone(items, visualQaPatterns)) {
+    return buildGoalOrchestrationPacket({
+      goalType: 'social_outreach_linkedin_post',
+      currentGate: 'challenger_qa',
+      gateStatus: 'challenger_pending',
+      approvalBoundary: 'Human review is blocked until visual QA and accessibility review are complete.',
+      residualRisksForHuman: ['Visual QA and accessibility review are incomplete.'],
     })
   }
 


### PR DESCRIPTION
## Summary
- Expands the social outreach goal packet with a full Social Content production orchestration model: copy, references, illustration, carousel, visual QA, human review packet, and post-approval handoffs.
- Adds swarm work items for reference annotation, framework illustration design, carousel/asset production prep, visual QA, review packaging, and Social Content draft handoff.
- Extends draft approval to queue governed post-approval production handoffs for references, illustration, carousel prep, and visual QA without publishing or provider generation.
- Keeps existing social goal orchestration compatible with older in-flight work items that only have the prior visual-brief graph.

## Validation
- npm test -- --run lib/agent-war-room.test.ts app/api/admin/social-content/[id]/approve/route.test.ts lib/goal-orchestration.test.ts
- npm run lint
- npm run build:knowledge && npx tsc --noEmit
- node --env-file=/Users/vambahsillah/Projects/Portfolio/.env.local ./node_modules/next/dist/bin/next build

## Integration Notes
- No database migration or env change.
- Approval still stops at Agent Ops work-item routing; publishing, scheduling, provider generation, render/upload actions, sends, and production mutation remain separately approval-gated.
- Vercel contexts not checked in this non-captain lane; Integration Captain should verify before/after merge:
  - Vercel – portfolio
  - Vercel – portfolio-staging
- Build emitted existing warnings about dev n8n outbound env settings and stale Browserslist data.