### PR TITLE
feat: add social visual production review

### DIFF
--- a/app/admin/social-content/[id]/page.test.tsx
+++ b/app/admin/social-content/[id]/page.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import SocialContentDetailRoute from './page'
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ id: 'social-1' }),
+  useRouter: () => ({ push: mocks.push }),
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+vi.mock('@/components/ProtectedRoute', () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('@/components/admin/Breadcrumbs', () => ({
+  default: () => null,
+}))
+
+vi.mock('@/lib/auth', () => ({
+  getCurrentSession: vi.fn(async () => ({ access_token: 'admin-token' })),
+}))
+
+describe('SocialContentDetailRoute visual production review', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        item: {
+          id: 'social-1',
+          meeting_record_id: null,
+          platform: 'linkedin',
+          status: 'approved',
+          post_text: 'The draft copy is approved and should stay locked.',
+          cta_text: 'Build with receipts.',
+          cta_url: null,
+          hashtags: ['AgentOps', 'AI'],
+          image_url: null,
+          image_prompt: 'Create a framework visual about review gates.',
+          framework_visual_type: 'architecture',
+          voiceover_url: null,
+          voiceover_text: null,
+          video_url: null,
+          topic_extracted: null,
+          hormozi_framework: null,
+          rag_context: {
+            source: 'agent_ops_social_outreach_goal',
+            publish_gate: 'draft_only',
+            goal_id: 'goal-123',
+            pass_to_human: true,
+            visual_brief: 'Show the review gates.',
+          },
+          scheduled_for: null,
+          published_at: null,
+          platform_post_id: null,
+          admin_notes: null,
+          reviewed_by: 'admin-user',
+          target_platforms: ['linkedin'],
+          video_generation_method: 'none',
+          youtube_title: null,
+          youtube_description: null,
+          content_format: 'single_image',
+          content_pillar: null,
+          companion_post_text: null,
+          carousel_slides: null,
+          carousel_pdf_url: null,
+          carousel_slide_urls: null,
+          created_at: '2026-06-12T10:00:00.000Z',
+          updated_at: '2026-06-12T10:05:00.000Z',
+          publishes: [],
+        },
+      }),
+    })))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('keeps approved copy locked while exposing visual production actions', async () => {
+    render(<SocialContentDetailRoute />)
+
+    expect(await screen.findByText('Visual Production')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Generate Framework Illustration/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Build Carousel from App Screenshots/i })).toBeInTheDocument()
+    expect(screen.getByText('Publishing locked')).toBeInTheDocument()
+    expect(screen.queryByText('Publish immediately after approval')).not.toBeInTheDocument()
+
+    expect(screen.getByDisplayValue('The draft copy is approved and should stay locked.')).toBeDisabled()
+    expect(screen.getByDisplayValue(/Architecture/i)).not.toBeDisabled()
+    expect(screen.getByDisplayValue('Create a framework visual about review gates.')).not.toBeDisabled()
+  })
+})

--- a/app/admin/social-content/[id]/page.tsx
+++ b/app/admin/social-content/[id]/page.tsx
@@ -27,7 +27,6 @@ import {
   AlertCircle,
   LayoutGrid,
   Download,
-  ArrowRightLeft,
   Maximize2,
   X,
   BarChart3,
@@ -181,6 +180,7 @@ function SocialContentDetailPage() {
   const [regeneratingImage, setRegeneratingImage] = useState(false)
   const [regeneratingAudio, setRegeneratingAudio] = useState(false)
   const [convertingFormat, setConvertingFormat] = useState(false)
+  const [capturingAppCarousel, setCapturingAppCarousel] = useState(false)
   const [selectedSlide, setSelectedSlide] = useState(0)
   const [publishing, setPublishing] = useState(false)
   const [refreshingEngagement, setRefreshingEngagement] = useState(false)
@@ -637,16 +637,20 @@ function SocialContentDetailPage() {
     }
   }
 
-  const handleConvertToCarousel = async () => {
-    if (!confirm('Convert this post to a carousel? This will generate slides from the post content and replace the current image.')) return
-    setConvertingFormat(true)
+  const handleBuildAppScreenshotCarousel = async () => {
+    if (!confirm('Build a carousel from Portfolio app screenshots? This captures admin review surfaces, uploads the screenshots, and replaces the current visual asset with a carousel. It will not publish this post.')) return
+    setCapturingAppCarousel(true)
     try {
       const session = await getCurrentSession()
       if (!session) return
 
-      const res = await fetch(`/api/admin/social-content/${id}/convert-to-carousel`, {
+      const res = await fetch(`/api/admin/social-content/${id}/capture-app-carousel`, {
         method: 'POST',
-        headers: { Authorization: `Bearer ${session.access_token}` },
+        headers: {
+          Authorization: `Bearer ${session.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({}),
       })
 
       const data = await res.json()
@@ -657,16 +661,17 @@ function SocialContentDetailPage() {
           carousel_slides: data.carousel_slides,
           carousel_slide_urls: data.carousel_slide_urls,
           carousel_pdf_url: data.carousel_pdf_url,
+          rag_context: data.rag_context || prev.rag_context,
         } : prev)
         setSelectedSlide(0)
-        showMsg('success', `Carousel generated with ${data.slide_count} slides`)
+        showMsg('success', `App screenshot carousel built with ${data.slide_count} slides`)
       } else {
-        showMsg('error', data.error || 'Failed to convert to carousel')
+        showMsg('error', data.error || 'Failed to build app screenshot carousel')
       }
     } catch {
-      showMsg('error', 'Failed to convert to carousel')
+      showMsg('error', 'Failed to build app screenshot carousel')
     } finally {
-      setConvertingFormat(false)
+      setCapturingAppCarousel(false)
     }
   }
 
@@ -807,6 +812,11 @@ function SocialContentDetailPage() {
       : 0
   const isDraftOnlyPilot = isAgentSocialPilot && agentPilotPublishGate === 'draft_only'
   const canApproveAgentPilot = !isAgentSocialPilot || agentPilotPassToHuman
+  const canEditVisualProduction = isEditable || (isDraftOnlyPilot && item.status === 'approved')
+  const visualProductionUnlocked = canEditVisualProduction && isDraftOnlyPilot
+  const frameworkIllustrationLabel = item.image_url
+    ? 'Regenerate Framework Illustration'
+    : 'Generate Framework Illustration'
   const approveActionLabel = isDraftOnlyPilot
     ? 'Approve Draft'
     : scheduledFor
@@ -1365,6 +1375,40 @@ function SocialContentDetailPage() {
 
             {/* Visual Media section (single image or carousel) */}
             <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
+              {canEditVisualProduction && (
+                <div className="mb-4 rounded-lg border border-amber-500/30 bg-amber-500/10 p-4">
+                  <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.14em] text-amber-200">Visual Production</p>
+                      <p className="mt-1 text-sm leading-6 text-amber-50/90">
+                        {visualProductionUnlocked
+                          ? 'Copy is approved and locked. Choose the next visual asset manually; neither action publishes, schedules, or sends provider work until you click it.'
+                          : 'Choose the visual asset path for this draft. These actions stay separate from copy approval and publishing.'}
+                      </p>
+                    </div>
+                    <div className="flex flex-col gap-2 sm:flex-row xl:justify-end">
+                      <button
+                        type="button"
+                        onClick={item.content_format === 'carousel' ? handleConvertToSingleImage : handleRegenerateImage}
+                        disabled={regeneratingImage || !imagePrompt}
+                        className="inline-flex items-center justify-center gap-2 rounded-lg bg-amber-400 px-3 py-2 text-sm font-semibold text-slate-950 transition-colors hover:bg-amber-300 disabled:opacity-50"
+                      >
+                        {regeneratingImage ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <ImageIcon className="h-3.5 w-3.5" />}
+                        {frameworkIllustrationLabel}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={handleBuildAppScreenshotCarousel}
+                        disabled={capturingAppCarousel}
+                        className="inline-flex items-center justify-center gap-2 rounded-lg border border-amber-500/45 px-3 py-2 text-sm font-semibold text-amber-100 transition-colors hover:bg-amber-500/10 disabled:opacity-50"
+                      >
+                        {capturingAppCarousel ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <LayoutGrid className="h-3.5 w-3.5" />}
+                        Build Carousel from App Screenshots
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              )}
               {item.content_format === 'carousel' ? (
                 <>
                   <div className="flex items-center justify-between mb-3">
@@ -1382,7 +1426,7 @@ function SocialContentDetailPage() {
                           <Download className="w-3 h-3" /> PDF
                         </a>
                       )}
-                      {isEditable && (
+                      {canEditVisualProduction && (
                         <>
                           <button
                             onClick={handleRegenerateCarousel}
@@ -1391,13 +1435,6 @@ function SocialContentDetailPage() {
                           >
                             {convertingFormat ? <Loader2 className="w-3 h-3 animate-spin" /> : <RefreshCw className="w-3 h-3" />}
                             Re-render
-                          </button>
-                          <button
-                            onClick={handleConvertToSingleImage}
-                            disabled={convertingFormat || regeneratingImage}
-                            className="flex items-center gap-1 px-2 py-1 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded-lg text-xs transition-colors disabled:opacity-50"
-                          >
-                            <ArrowRightLeft className="w-3 h-3" /> Single Image
                           </button>
                         </>
                       )}
@@ -1433,7 +1470,7 @@ function SocialContentDetailPage() {
                       <div className="text-center text-gray-500">
                         <LayoutGrid className="w-8 h-8 mx-auto mb-2 opacity-50" />
                         <p className="text-xs">Slides not yet rendered</p>
-                        {isEditable && (
+                        {canEditVisualProduction && (
                           <button
                             onClick={handleRegenerateCarousel}
                             disabled={convertingFormat}
@@ -1452,28 +1489,6 @@ function SocialContentDetailPage() {
                     <h3 className="text-sm font-medium text-gray-400 flex items-center gap-2">
                       <ImageIcon className="w-4 h-4" /> Framework Illustration
                     </h3>
-                    <div className="flex items-center gap-2">
-                      {isEditable && (
-                        <>
-                          <button
-                            onClick={handleRegenerateImage}
-                            disabled={regeneratingImage || !imagePrompt}
-                            className="flex items-center gap-1 px-2 py-1 bg-purple-900/50 hover:bg-purple-900/70 text-purple-300 rounded-lg text-xs transition-colors disabled:opacity-50"
-                          >
-                            {regeneratingImage ? <Loader2 className="w-3 h-3 animate-spin" /> : <RefreshCw className="w-3 h-3" />}
-                            Regenerate
-                          </button>
-                          <button
-                            onClick={handleConvertToCarousel}
-                            disabled={convertingFormat}
-                            className="flex items-center gap-1 px-2 py-1 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded-lg text-xs transition-colors disabled:opacity-50"
-                          >
-                            {convertingFormat ? <Loader2 className="w-3 h-3 animate-spin" /> : <ArrowRightLeft className="w-3 h-3" />}
-                            Carousel
-                          </button>
-                        </>
-                      )}
-                    </div>
                   </div>
                   {item.image_url ? (
                     <div className="rounded-lg overflow-hidden mb-3 bg-gray-800 relative w-full h-[400px]">
@@ -1495,7 +1510,7 @@ function SocialContentDetailPage() {
                   <select
                     value={frameworkVisualType}
                     onChange={(e) => setFrameworkVisualType(e.target.value as FrameworkVisualType | '')}
-                    disabled={!isEditable}
+                    disabled={!canEditVisualProduction}
                     className="w-full bg-gray-800 text-gray-300 border border-gray-700 rounded-lg px-3 py-1.5 text-sm disabled:opacity-60"
                   >
                     <option value="">Auto-detect</option>
@@ -1509,7 +1524,7 @@ function SocialContentDetailPage() {
                   <textarea
                     value={imagePrompt}
                     onChange={(e) => setImagePrompt(e.target.value)}
-                    disabled={!isEditable}
+                    disabled={!canEditVisualProduction}
                     rows={3}
                     className="w-full bg-gray-800 text-gray-200 border border-gray-700 rounded-lg px-3 py-2 text-xs resize-y disabled:opacity-60"
                   />
@@ -1774,90 +1789,103 @@ function SocialContentDetailPage() {
         <div className="bg-gray-900 border-2 border-gray-700 rounded-xl p-6 space-y-6">
           <h2 className="text-lg font-semibold text-gray-200 flex items-center gap-2">
             <Send className="w-5 h-5 text-green-400" />
-            Where & When
+            {isDraftOnlyPilot ? 'Draft Approval Gate' : 'Where & When'}
           </h2>
 
-          {/* Platform pills */}
-          <div>
-            <label className="block text-sm font-medium text-gray-400 mb-3">Publish to</label>
-            <div className="flex flex-wrap gap-2">
-              {PLATFORMS.map((p) => {
-                const isActive = targetPlatforms.includes(p.value)
-                const colors = PLATFORM_COLORS[p.value] || PLATFORM_COLORS.linkedin
-                return (
-                  <button
-                    key={p.value}
-                    type="button"
-                    onClick={() => p.enabled && isEditable && togglePlatform(p.value)}
-                    disabled={!isEditable || !p.enabled}
-                    className={`flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium border transition-all disabled:cursor-not-allowed ${
-                      !p.enabled
-                        ? 'opacity-40 bg-gray-800 border-gray-700 text-gray-500'
-                        : isActive
-                          ? colors.active
-                          : colors.inactive
-                    }`}
-                  >
-                    {PLATFORM_ICONS[p.value]}
-                    {p.label}
-                    {!p.enabled && <span className="text-xs">(coming soon)</span>}
-                  </button>
-                )
-              })}
+          {isDraftOnlyPilot && (
+            <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-4 text-sm leading-6 text-amber-50/90">
+              <p className="font-semibold text-amber-100">Publishing locked</p>
+              <p className="mt-1">
+                This Agent Ops post is draft-only. Approval locks the copy and queues the reference handoff, but publishing, scheduling, screenshot capture, carousel rendering, image generation, and provider sends each require a separate explicit action.
+              </p>
             </div>
-          </div>
+          )}
+
+          {/* Platform pills */}
+          {!isDraftOnlyPilot && (
+            <div>
+              <label className="block text-sm font-medium text-gray-400 mb-3">Publish to</label>
+              <div className="flex flex-wrap gap-2">
+                {PLATFORMS.map((p) => {
+                  const isActive = targetPlatforms.includes(p.value)
+                  const colors = PLATFORM_COLORS[p.value] || PLATFORM_COLORS.linkedin
+                  return (
+                    <button
+                      key={p.value}
+                      type="button"
+                      onClick={() => p.enabled && isEditable && togglePlatform(p.value)}
+                      disabled={!isEditable || !p.enabled}
+                      className={`flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium border transition-all disabled:cursor-not-allowed ${
+                        !p.enabled
+                          ? 'opacity-40 bg-gray-800 border-gray-700 text-gray-500'
+                          : isActive
+                            ? colors.active
+                            : colors.inactive
+                      }`}
+                    >
+                      {PLATFORM_ICONS[p.value]}
+                      {p.label}
+                      {!p.enabled && <span className="text-xs">(coming soon)</span>}
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+          )}
 
           {/* Schedule radio */}
-          <div>
-            <label className="block text-sm font-medium text-gray-400 mb-3">When</label>
-            <div className="space-y-3">
-              <label className="flex items-center gap-3 cursor-pointer">
-                <input
-                  type="radio"
-                  name="schedule"
-                  checked={!scheduledFor}
-                  onChange={() => setScheduledFor('')}
-                  disabled={!isEditable}
-                  className="text-green-500 focus:ring-green-500 bg-gray-800 border-gray-600"
-                />
-                <span className="text-sm text-gray-300">Publish immediately after approval</span>
-              </label>
-              <label className="flex items-center gap-3 cursor-pointer">
-                <input
-                  type="radio"
-                  name="schedule"
-                  checked={!!scheduledFor}
-                  onChange={() => {
-                    const tomorrow = new Date()
-                    tomorrow.setDate(tomorrow.getDate() + 1)
-                    tomorrow.setHours(9, 0, 0, 0)
-                    setScheduledFor(tomorrow.toISOString().slice(0, 16))
-                  }}
-                  disabled={!isEditable}
-                  className="text-amber-500 focus:ring-amber-500 bg-gray-800 border-gray-600"
-                />
-                <span className="text-sm text-gray-300">Schedule for later</span>
-              </label>
-              <AnimatePresence>
-                {scheduledFor && (
-                  <motion.div
-                    initial={{ opacity: 0, height: 0 }}
-                    animate={{ opacity: 1, height: 'auto' }}
-                    exit={{ opacity: 0, height: 0 }}
-                    className="overflow-hidden"
-                  >
-                    <input
-                      type="datetime-local"
-                      value={scheduledFor}
-                      onChange={(e) => setScheduledFor(e.target.value)}
-                      disabled={!isEditable}
-                      className="ml-7 bg-gray-800 text-gray-300 border border-gray-700 rounded-lg px-3 py-2 text-sm disabled:opacity-60"
-                    />
-                  </motion.div>
-                )}
-              </AnimatePresence>
+          {!isDraftOnlyPilot && (
+            <div>
+              <label className="block text-sm font-medium text-gray-400 mb-3">When</label>
+              <div className="space-y-3">
+                <label className="flex items-center gap-3 cursor-pointer">
+                  <input
+                    type="radio"
+                    name="schedule"
+                    checked={!scheduledFor}
+                    onChange={() => setScheduledFor('')}
+                    disabled={!isEditable}
+                    className="text-green-500 focus:ring-green-500 bg-gray-800 border-gray-600"
+                  />
+                  <span className="text-sm text-gray-300">Publish immediately after approval</span>
+                </label>
+                <label className="flex items-center gap-3 cursor-pointer">
+                  <input
+                    type="radio"
+                    name="schedule"
+                    checked={!!scheduledFor}
+                    onChange={() => {
+                      const tomorrow = new Date()
+                      tomorrow.setDate(tomorrow.getDate() + 1)
+                      tomorrow.setHours(9, 0, 0, 0)
+                      setScheduledFor(tomorrow.toISOString().slice(0, 16))
+                    }}
+                    disabled={!isEditable}
+                    className="text-amber-500 focus:ring-amber-500 bg-gray-800 border-gray-600"
+                  />
+                  <span className="text-sm text-gray-300">Schedule for later</span>
+                </label>
+                <AnimatePresence>
+                  {scheduledFor && (
+                    <motion.div
+                      initial={{ opacity: 0, height: 0 }}
+                      animate={{ opacity: 1, height: 'auto' }}
+                      exit={{ opacity: 0, height: 0 }}
+                      className="overflow-hidden"
+                    >
+                      <input
+                        type="datetime-local"
+                        value={scheduledFor}
+                        onChange={(e) => setScheduledFor(e.target.value)}
+                        disabled={!isEditable}
+                        className="ml-7 bg-gray-800 text-gray-300 border border-gray-700 rounded-lg px-3 py-2 text-sm disabled:opacity-60"
+                      />
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </div>
             </div>
-          </div>
+          )}
 
           {/* Admin Notes */}
           <div>

--- a/app/api/admin/social-content/[id]/capture-app-carousel/route.test.ts
+++ b/app/api/admin/social-content/[id]/capture-app-carousel/route.test.ts
@@ -1,0 +1,193 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  captureBroll: vi.fn(),
+  renderCarousel: vi.fn(),
+  from: vi.fn(),
+  select: vi.fn(),
+  selectEq: vi.fn(),
+  single: vi.fn(),
+  update: vi.fn(),
+  updateEq: vi.fn(),
+  storageFrom: vi.fn(),
+  upload: vi.fn(),
+  getPublicUrl: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/playtest-broll', () => ({
+  captureBroll: mocks.captureBroll,
+}))
+
+vi.mock('@/lib/carousel', () => ({
+  renderCarousel: mocks.renderCarousel,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+    storage: {
+      from: mocks.storageFrom,
+    },
+  },
+}))
+
+import { POST } from './route'
+
+function request(body?: unknown) {
+  return new NextRequest('http://localhost:3016/api/admin/social-content/social-1/capture-app-carousel', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  })
+}
+
+describe('POST /api/admin/social-content/[id]/capture-app-carousel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user-1' }, isAdmin: true })
+    mocks.isAuthError.mockReturnValue(false)
+
+    mocks.single.mockResolvedValue({
+      data: {
+        post_text: 'A review surface should show what the agent understood.',
+        cta_text: 'Build with receipts.',
+        hashtags: ['AgentOps', 'AI'],
+        rag_context: {
+          source: 'agent_ops_social_outreach_goal',
+          goal_id: 'goal-123',
+          publish_gate: 'draft_only',
+        },
+      },
+      error: null,
+    })
+    mocks.selectEq.mockReturnValue({ single: mocks.single })
+    mocks.select.mockReturnValue({ eq: mocks.selectEq })
+    mocks.updateEq.mockResolvedValue({ error: null })
+    mocks.update.mockReturnValue({ eq: mocks.updateEq })
+    mocks.from.mockImplementation((table: string) => {
+      if (table !== 'social_content_queue') throw new Error(`Unexpected table: ${table}`)
+      return {
+        select: mocks.select,
+        update: mocks.update,
+      }
+    })
+
+    mocks.captureBroll.mockImplementation(async (config: { outputDir: string; routes: Array<{ filename: string }> }) => {
+      await fs.mkdir(config.outputDir, { recursive: true })
+      const screenshots = await Promise.all(config.routes.map(async (route) => {
+        const file = path.join(config.outputDir, `${route.filename}.png`)
+        await fs.writeFile(file, Buffer.from(`screenshot:${route.filename}`))
+        return file
+      }))
+      return { screenshots, clips: [], outputDir: config.outputDir }
+    })
+
+    mocks.renderCarousel.mockImplementation(async (slides: unknown[]) => ({
+      pngBuffers: slides.map((_, index) => Buffer.from(`slide-${index + 1}`)),
+      pdfBuffer: Buffer.from('pdf'),
+    }))
+    mocks.upload.mockResolvedValue({ error: null })
+    mocks.getPublicUrl.mockImplementation((fileName: string) => ({
+      data: { publicUrl: `https://cdn.example.com/${fileName}` },
+    }))
+    mocks.storageFrom.mockReturnValue({
+      upload: mocks.upload,
+      getPublicUrl: mocks.getPublicUrl,
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('rejects unauthenticated requests before fetching content', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Authentication required', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(request(), { params: { id: 'social-1' } })
+
+    expect(response.status).toBe(401)
+    expect(mocks.from).not.toHaveBeenCalled()
+    expect(mocks.captureBroll).not.toHaveBeenCalled()
+  })
+
+  it('rejects non-whitelisted routes before capture', async () => {
+    const response = await POST(request({
+      routes: [{ route: '/api/admin/social-content/social-1', label: 'API route' }],
+    }), { params: { id: 'social-1' } })
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Routes must be whitelisted internal Portfolio admin paths.',
+    })
+    expect(mocks.from).not.toHaveBeenCalled()
+    expect(mocks.captureBroll).not.toHaveBeenCalled()
+  })
+
+  it('uses default routes from the content item and goal id', async () => {
+    const response = await POST(request(), { params: { id: 'social-1' } })
+
+    expect(response.status).toBe(200)
+    const captureConfig = mocks.captureBroll.mock.calls[0][0]
+    expect(captureConfig).toEqual(expect.objectContaining({
+      baseUrl: 'http://localhost:3016',
+      noStartServer: true,
+    }))
+    expect(captureConfig.routes.map((route: { route: string; description: string }) => ({
+      route: route.route,
+      description: route.description,
+    }))).toEqual([
+      { route: '/admin/social-content/social-1', description: 'Social Content review' },
+      { route: '/admin/agents/swarm-board', description: 'Agent Swarm Board' },
+      { route: '/admin/agents/standup?goal=goal-123', description: 'Standup Room goal' },
+      { route: '/admin/agents/open-brain', description: 'Open Brain references' },
+    ])
+  })
+
+  it('uploads screenshots, renders carousel assets, and records screenshot assets', async () => {
+    const response = await POST(request(), { params: { id: 'social-1' } })
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.success).toBe(true)
+    expect(body.content_format).toBe('carousel')
+    expect(body.app_screenshot_assets).toHaveLength(4)
+    expect(body.carousel_slide_urls).toHaveLength(8)
+    expect(body.carousel_pdf_url).toBe('https://cdn.example.com/carousels/social-1/carousel.pdf')
+    expect(mocks.renderCarousel).toHaveBeenCalledWith(expect.arrayContaining([
+      expect.objectContaining({ type: 'screenshot', screenshot_url: 'https://cdn.example.com/app-screenshots/social-1/01-social-content-review.png' }),
+    ]))
+    expect(mocks.upload).toHaveBeenCalledWith(
+      'app-screenshots/social-1/01-social-content-review.png',
+      expect.any(Buffer),
+      expect.objectContaining({ contentType: 'image/png', upsert: true }),
+    )
+    expect(mocks.update).toHaveBeenCalledWith(expect.objectContaining({
+      content_format: 'carousel',
+      carousel_slides: expect.any(Array),
+      carousel_slide_urls: expect.any(Array),
+      carousel_pdf_url: 'https://cdn.example.com/carousels/social-1/carousel.pdf',
+      rag_context: expect.objectContaining({
+        app_screenshot_assets: expect.any(Array),
+        app_screenshot_carousel: expect.objectContaining({
+          status: 'ready',
+          route_count: 4,
+          slide_count: 8,
+        }),
+      }),
+    }))
+    expect(mocks.updateEq).toHaveBeenCalledWith('id', 'social-1')
+  })
+})

--- a/app/api/admin/social-content/[id]/capture-app-carousel/route.ts
+++ b/app/api/admin/social-content/[id]/capture-app-carousel/route.ts
@@ -1,0 +1,330 @@
+import { promises as fs } from 'fs'
+import os from 'os'
+import path from 'path'
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { renderCarousel } from '@/lib/carousel'
+import { captureBroll, type RouteConfig } from '@/lib/playtest-broll'
+import { supabaseAdmin } from '@/lib/supabase'
+import type { CarouselSlide } from '@/lib/social-content'
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+export const maxDuration = 300
+
+type AppCarouselRoute = {
+  route: string
+  label: string
+}
+
+type ScreenshotAsset = AppCarouselRoute & {
+  storage_path: string
+  url: string
+  captured_at: string
+}
+
+const ALLOWED_ROUTE_PREFIXES = [
+  '/admin/social-content',
+  '/admin/agents',
+]
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {}
+}
+
+function asString(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+function slug(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48) || 'route'
+}
+
+function normalizeInternalRoute(route: string): string | null {
+  const trimmed = route.trim()
+  if (!trimmed || !trimmed.startsWith('/') || trimmed.startsWith('//') || trimmed.includes('\\')) {
+    return null
+  }
+  if (/^https?:\/\//i.test(trimmed)) {
+    return null
+  }
+
+  try {
+    const parsed = new URL(trimmed, 'http://portfolio.local')
+    if (parsed.origin !== 'http://portfolio.local') {
+      return null
+    }
+    const isAllowed = ALLOWED_ROUTE_PREFIXES.some((prefix) => (
+      parsed.pathname === prefix || parsed.pathname.startsWith(`${prefix}/`)
+    ))
+    if (!isAllowed) return null
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`
+  } catch {
+    return null
+  }
+}
+
+function parseRequestedRoutes(value: unknown): AppCarouselRoute[] | null {
+  if (value == null) return null
+  if (!Array.isArray(value)) return []
+
+  return value
+    .map((entry) => {
+      const record = asRecord(entry)
+      const route = normalizeInternalRoute(asString(record.route))
+      if (!route) return null
+      const label = asString(record.label).trim() || route
+      return { route, label }
+    })
+    .filter((entry): entry is AppCarouselRoute => Boolean(entry))
+}
+
+function defaultRoutes(contentId: string, ragContext: Record<string, unknown>): AppCarouselRoute[] {
+  const goalId = asString(ragContext.goal_id)
+  return [
+    { route: `/admin/social-content/${contentId}`, label: 'Social Content review' },
+    { route: '/admin/agents/swarm-board', label: 'Agent Swarm Board' },
+    {
+      route: goalId
+        ? `/admin/agents/standup?goal=${encodeURIComponent(goalId)}`
+        : '/admin/agents/standup',
+      label: 'Standup Room goal',
+    },
+    { route: '/admin/agents/open-brain', label: 'Open Brain references' },
+  ]
+}
+
+function toBrollRoutes(routes: AppCarouselRoute[]): RouteConfig[] {
+  return routes.map((route, index) => ({
+    route: route.route,
+    filename: `app-screenshot-${String(index + 1).padStart(2, '0')}-${slug(route.label)}`,
+    description: route.label,
+    fullPage: false,
+  }))
+}
+
+function buildScreenshotSlides(params: {
+  postText: string
+  ctaText: string
+  hashtags: string[]
+  assets: ScreenshotAsset[]
+}): CarouselSlide[] {
+  const hookLine = params.postText.split(/\n+/).find((line) => line.trim())?.trim()
+  const firstAssetLabel = params.assets[0]?.label || 'Portfolio workflow'
+  const ctaHeadline = params.ctaText.trim() || 'Make the workflow visible before you scale it.'
+
+  return [
+    {
+      type: 'cover',
+      eyebrow: 'Agent Ops Proof',
+      headline: 'The operating layer behind the post',
+      subhead: hookLine || 'Screenshots from the Portfolio workflow that produced and reviewed this draft.',
+      byline: 'AmaduTown Advisory Solutions',
+      ghost_text: 'PROOF',
+    },
+    {
+      type: 'hook',
+      headline: 'Portfolio review surfaces',
+      big_stat: String(params.assets.length),
+      stat_label: 'Portfolio review surfaces',
+      body: 'The post is one artifact. The trust comes from the review steps, references, gates, and ownership trail around it.',
+    },
+    ...params.assets.map((asset): CarouselSlide => ({
+      type: 'screenshot',
+      eyebrow: 'Portfolio Screenshot',
+      headline: asset.label,
+      route_label: asset.label,
+      route: asset.route,
+      screenshot_url: asset.url,
+      caption: asset.label === firstAssetLabel
+        ? 'The approved draft stays in Social Content while visual production remains a separate manual action.'
+        : 'Each supporting surface keeps the source trail visible before anything moves toward publishing.',
+    })),
+    {
+      type: 'quote',
+      headline: 'Receipts before scale',
+      blockquote: 'Every answer needs receipts. Every task needs an owner. Every risky action needs a gate.',
+      attribution: 'Agent Ops operating principle',
+    },
+    {
+      type: 'cta',
+      cta_label: 'Build with receipts',
+      headline: ctaHeadline,
+      body: 'If AI is going to run closer to the work, the review surface has to show what it understood, what it changed, and what still needs human approval.',
+      hashtags: params.hashtags,
+    },
+  ]
+}
+
+async function uploadBuffer(params: {
+  bucket: string
+  fileName: string
+  buffer: Buffer
+  contentType: string
+}): Promise<string> {
+  const storage = supabaseAdmin.storage.from(params.bucket)
+  const { error } = await storage.upload(params.fileName, params.buffer, {
+    contentType: params.contentType,
+    upsert: true,
+  })
+  if (error) {
+    throw new Error(`Failed to upload ${params.fileName}: ${error.message || String(error)}`)
+  }
+  const { data } = storage.getPublicUrl(params.fileName)
+  return data.publicUrl
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const authResult = await verifyAdmin(request)
+  if (isAuthError(authResult)) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status })
+  }
+
+  const { id } = params
+  let body: unknown = {}
+  try {
+    body = await request.json()
+  } catch {
+    body = {}
+  }
+
+  const bodyRecord = asRecord(body)
+  const requestedRoutesInput = bodyRecord.routes
+  if (requestedRoutesInput != null && !Array.isArray(requestedRoutesInput)) {
+    return NextResponse.json({ error: 'Routes must be an array of whitelisted internal Portfolio admin paths.' }, { status: 400 })
+  }
+  const requestedRoutes = parseRequestedRoutes(requestedRoutesInput)
+  if (requestedRoutesInput != null && (!requestedRoutes || requestedRoutes.length !== (Array.isArray(requestedRoutesInput) ? requestedRoutesInput.length : 0))) {
+    return NextResponse.json({ error: 'Routes must be whitelisted internal Portfolio admin paths.' }, { status: 400 })
+  }
+
+  const { data: row, error: fetchErr } = await supabaseAdmin
+    .from('social_content_queue')
+    .select('post_text, cta_text, hashtags, rag_context')
+    .eq('id', id)
+    .single()
+
+  if (fetchErr || !row) {
+    return NextResponse.json({ error: 'Content not found' }, { status: 404 })
+  }
+
+  const ragContext = asRecord(row.rag_context)
+  const routes = requestedRoutes?.length ? requestedRoutes : defaultRoutes(id, ragContext)
+  const outputDir = path.join(os.tmpdir(), 'portfolio-social-content-app-screenshots', id, String(Date.now()))
+  const baseUrl = new URL(request.url).origin
+  const capturedAt = new Date().toISOString()
+
+  try {
+    const captureResult = await captureBroll({
+      routes: toBrollRoutes(routes),
+      outputDir,
+      baseUrl,
+      noStartServer: true,
+      authStateOutPath: path.join(outputDir, '.auth-state.json'),
+    })
+
+    if (captureResult.screenshots.length !== routes.length) {
+      return NextResponse.json({ error: 'Screenshot capture did not complete for every requested route.' }, { status: 502 })
+    }
+
+    const assets: ScreenshotAsset[] = []
+    for (let i = 0; i < routes.length; i += 1) {
+      const fileBuffer = await fs.readFile(captureResult.screenshots[i])
+      const fileName = `app-screenshots/${id}/${String(i + 1).padStart(2, '0')}-${slug(routes[i].label)}.png`
+      const url = await uploadBuffer({
+        bucket: 'social-content',
+        fileName,
+        buffer: fileBuffer,
+        contentType: 'image/png',
+      })
+      assets.push({
+        ...routes[i],
+        storage_path: fileName,
+        url,
+        captured_at: capturedAt,
+      })
+    }
+
+    const slides = buildScreenshotSlides({
+      postText: asString(row.post_text),
+      ctaText: asString(row.cta_text),
+      hashtags: Array.isArray(row.hashtags) ? (row.hashtags as unknown[]).filter((tag): tag is string => typeof tag === 'string') : [],
+      assets,
+    })
+
+    const { pngBuffers, pdfBuffer } = await renderCarousel(slides)
+    const slideUrls: string[] = []
+    const storageBase = `carousels/${id}`
+
+    for (let i = 0; i < pngBuffers.length; i += 1) {
+      const fileName = `${storageBase}/slide_${String(i + 1).padStart(2, '0')}.png`
+      const url = await uploadBuffer({
+        bucket: 'social-content',
+        fileName,
+        buffer: pngBuffers[i],
+        contentType: 'image/png',
+      })
+      slideUrls.push(url)
+    }
+
+    const pdfUrl = await uploadBuffer({
+      bucket: 'social-content',
+      fileName: `${storageBase}/carousel.pdf`,
+      buffer: pdfBuffer,
+      contentType: 'application/pdf',
+    })
+
+    const nextRagContext = {
+      ...ragContext,
+      app_screenshot_assets: assets,
+      app_screenshot_carousel: {
+        status: 'ready',
+        route_count: routes.length,
+        slide_count: slides.length,
+        updated_at: capturedAt,
+      },
+    }
+
+    const { error: updateErr } = await supabaseAdmin
+      .from('social_content_queue')
+      .update({
+        content_format: 'carousel',
+        carousel_slides: slides,
+        carousel_slide_urls: slideUrls,
+        carousel_pdf_url: pdfUrl,
+        rag_context: nextRagContext,
+      })
+      .eq('id', id)
+
+    if (updateErr) {
+      throw new Error(`Failed to update social content: ${updateErr.message || String(updateErr)}`)
+    }
+
+    return NextResponse.json({
+      success: true,
+      content_format: 'carousel',
+      carousel_slides: slides,
+      carousel_slide_urls: slideUrls,
+      carousel_pdf_url: pdfUrl,
+      app_screenshot_assets: assets,
+      rag_context: nextRagContext,
+      slide_count: slides.length,
+    })
+  } catch (error) {
+    console.error('Error in capture-app-carousel:', error)
+    return NextResponse.json({
+      error: error instanceof Error ? error.message : 'Failed to build app screenshot carousel',
+    }, { status: 500 })
+  } finally {
+    await fs.rm(outputDir, { recursive: true, force: true }).catch(() => {})
+  }
+}

--- a/lib/carousel/templates.ts
+++ b/lib/carousel/templates.ts
@@ -126,6 +126,27 @@ function renderCta(slide: CarouselSlide, index: number, total: number, logoB64: 
   `
 }
 
+function renderScreenshot(slide: CarouselSlide, index: number, total: number, logoB64: string): string {
+  return `
+    <div style="position:relative;width:1080px;height:1080px;background:${COLORS.black};overflow:hidden;font-family:'Inter',sans-serif;">
+      ${commonElements(logoB64)}
+      ${slideCounter(index, total)}
+      <div style="position:absolute;top:62px;left:60px;right:60px;">
+        <div style="font-size:13px;font-weight:800;letter-spacing:3px;color:${COLORS.purple};text-transform:uppercase;margin-bottom:12px;">${slide.eyebrow || 'Portfolio Screenshot'}</div>
+        <div style="font-family:'Bebas Neue',sans-serif;font-size:54px;color:${COLORS.white};line-height:1.0;max-width:760px;">${slide.headline || slide.route_label || 'App screenshot'}</div>
+        ${slide.route_label ? `<div style="margin-top:10px;font-size:14px;font-weight:700;letter-spacing:1.5px;color:${COLORS.gray};text-transform:uppercase;">${slide.route_label}</div>` : ''}
+      </div>
+      <div style="position:absolute;top:230px;left:58px;right:58px;height:610px;border:1px solid #262626;border-radius:18px;background:#111;overflow:hidden;box-shadow:0 30px 80px rgba(0,0,0,0.45);">
+        ${slide.screenshot_url ? `<img src="${slide.screenshot_url}" style="width:100%;height:100%;object-fit:cover;object-position:top center;" />` : `<div style="width:100%;height:100%;display:flex;align-items:center;justify-content:center;color:${COLORS.gray};font-size:24px;">Screenshot pending</div>`}
+      </div>
+      <div style="position:absolute;left:60px;right:140px;bottom:78px;">
+        ${slide.caption ? `<div style="font-size:19px;color:${COLORS.darkText};line-height:1.55;max-width:760px;">${slide.caption}</div>` : ''}
+        ${slide.route ? `<div style="margin-top:14px;font-size:12px;font-weight:700;letter-spacing:1.5px;color:#555;text-transform:uppercase;">${slide.route}</div>` : ''}
+      </div>
+    </div>
+  `
+}
+
 export function generateCarouselHTML(slides: CarouselSlide[]): string {
   const logoB64 = getLogoBase64()
   const photoB64 = getProfilePhotoBase64()
@@ -137,6 +158,7 @@ export function generateCarouselHTML(slides: CarouselSlide[]): string {
     principle: (s, i) => renderPrinciple(s, i, total, logoB64),
     quote: (s, i) => renderQuote(s, i, total, logoB64),
     cta: (s, i) => renderCta(s, i, total, logoB64, photoB64),
+    screenshot: (s, i) => renderScreenshot(s, i, total, logoB64),
   }
 
   const slidesHtml = slides.map((slide, i) => {

--- a/lib/social-content.ts
+++ b/lib/social-content.ts
@@ -331,7 +331,7 @@ Return a valid JSON array of slide objects. Each object must have a "type" field
 // Carousel Types
 // ============================================================================
 
-export type CarouselSlideType = 'cover' | 'hook' | 'principle' | 'quote' | 'cta'
+export type CarouselSlideType = 'cover' | 'hook' | 'principle' | 'quote' | 'cta' | 'screenshot'
 
 export type ContentFormat = 'single_image' | 'carousel'
 
@@ -352,6 +352,10 @@ export interface CarouselSlide {
   attribution?: string
   cta_label?: string
   hashtags?: string[]
+  screenshot_url?: string
+  caption?: string
+  route_label?: string
+  route?: string
 }
 
 export type ContentPillar =


### PR DESCRIPTION
## Summary
- Adds a Visual Production panel to the Social Content detail page so approved draft-only Agent Ops posts show the next visual step in the review surface.
- Keeps approved copy fields locked while allowing visual type and image prompt updates, and replaces draft-only publish controls with a Publishing locked notice.
- Adds a protected app-screenshot carousel endpoint that captures whitelisted Portfolio admin routes, uploads screenshots to the social-content bucket, renders carousel assets, and records screenshot assets in rag_context.
- Extends carousel slides/rendering with first-class screenshot slide support.

## Validation
- npm test -- --run app/api/admin/social-content/[id]/capture-app-carousel/route.test.ts app/admin/social-content/[id]/page.test.tsx
- npm run build:knowledge && npx tsc --noEmit
- npm run build
- Local live smoke on http://localhost:3017/admin/social-content/25d7efa3-62bc-4f5e-a191-1a131918593a confirmed Visual Production, both visual action buttons, Publishing locked, post/CTA/hashtags locked, and visual type/image prompt enabled. No generation, screenshot capture, publish, or provider action was clicked.

## Integration Notes
- No migrations.
- The new capture route is manual admin-only and uses noStartServer=true; screenshot capture still requires an already-running Portfolio app.
- Vercel contexts not checked by this non-captain lane; Integration Captain should verify both after merge gate:
  - Vercel – portfolio
  - Vercel – portfolio-staging
