### PR TITLE
Refresh Model Ops dashboard snapshot

### DIFF
--- a/data/model-ops/reports/latest-dashboard-data.json
+++ b/data/model-ops/reports/latest-dashboard-data.json
@@ -1,6 +1,6 @@
 {
   "projectName": "Local LLM Model Ops & Hermes Automation",
-  "generatedAt": "2026-05-26T03:30:17.419Z",
+  "generatedAt": "2026-06-15T13:03:37.977Z",
   "recommendations": {
     "replyIntentDefault": "Keep qwen3-4b-instruct-2507 for reply-intent classification. It has the best current accuracy/latency balance.",
     "ragDefault": "Use routed local RAG as the leading local/shadow candidate, with Pinecone/OpenAI fallback until larger answer-level evals pass.",

--- a/data/model-ops/reports/latest-dashboard-data.json
+++ b/data/model-ops/reports/latest-dashboard-data.json
@@ -1,6 +1,6 @@
 {
   "projectName": "Local LLM Model Ops & Hermes Automation",
-  "generatedAt": "2026-06-15T13:03:37.977Z",
+  "generatedAt": "2026-06-15T13:13:43.787Z",
   "recommendations": {
     "replyIntentDefault": "Keep qwen3-4b-instruct-2507 for reply-intent classification. It has the best current accuracy/latency balance.",
     "ragDefault": "Use routed local RAG as the leading local/shadow candidate, with Pinecone/OpenAI fallback until larger answer-level evals pass.",


### PR DESCRIPTION
## Summary
- refresh the sanitized Model Ops admin snapshot from the June 15 local dashboard rebuild
- snapshot diff is timestamp-only; benchmark metrics and recommendations are unchanged

## Validation
- `npm --prefix /Users/vambahsillah/Projects/Portfolio run model-ops:snapshot`
- `npm --prefix /Users/vambahsillah/Projects/Portfolio run model-ops:research:plan -- --repo-snapshot`
- `npm --prefix /Users/vambahsillah/Projects/Portfolio run model-ops:snapshot:check`
- `PATH=/Users/vambahsillah/Projects/Portfolio/node_modules/.bin:$PATH npm run model-ops:snapshot:check` in isolated worktree

## Notes
- labels `codex` and `codex-automation` are not available in this repository
- no production routing, hosted flags, n8n logic, Supabase/Pinecone resources, secrets, merge, or deploy changed