### PR TITLE
fix: support local carousel rendering

### DIFF
--- a/lib/carousel/render.ts
+++ b/lib/carousel/render.ts
@@ -4,7 +4,8 @@
  * 2. Render each slide to PNG via Playwright (headless Chromium)
  * 3. Combine PNGs into a single PDF via pdf-lib
  *
- * Uses @sparticuz/chromium for Vercel/Lambda compatibility.
+ * Uses @sparticuz/chromium for Vercel/Lambda compatibility and Playwright's
+ * installed browser for local development.
  */
 
 import { PDFDocument, PDFImage } from 'pdf-lib'
@@ -12,6 +13,31 @@ import type { CarouselSlide } from '@/lib/social-content'
 import { generateCarouselHTML } from './templates'
 
 const SLIDE_SIZE = 1080
+
+function shouldUseServerlessChromium(): boolean {
+  return Boolean(
+    process.env.VERCEL
+    || process.env.AWS_LAMBDA_FUNCTION_NAME
+    || process.env.AWS_EXECUTION_ENV
+  )
+}
+
+async function launchCarouselBrowser() {
+  if (shouldUseServerlessChromium()) {
+    const chromium = await import('@sparticuz/chromium')
+    const { chromium: playwrightChromium } = await import('playwright-core')
+    const executablePath = await chromium.default.executablePath()
+
+    return playwrightChromium.launch({
+      args: chromium.default.args,
+      executablePath,
+      headless: true,
+    })
+  }
+
+  const { chromium: playwrightChromium } = await import('playwright')
+  return playwrightChromium.launch({ headless: true })
+}
 
 /**
  * Render carousel slides to PNG buffers using Playwright.
@@ -23,17 +49,7 @@ export async function renderCarouselSlides(
   const html = generateCarouselHTML(slides)
   const total = slides.length
 
-  // Dynamic import to avoid bundling Chromium at module load time
-  const chromium = await import('@sparticuz/chromium')
-  const { chromium: playwrightChromium } = await import('playwright-core')
-
-  const executablePath = await chromium.default.executablePath()
-
-  const browser = await playwrightChromium.launch({
-    args: chromium.default.args,
-    executablePath,
-    headless: true,
-  })
+  const browser = await launchCarouselBrowser()
 
   try {
     const page = await browser.newPage({
@@ -55,15 +71,13 @@ export async function renderCarouselSlides(
       const wrapper = await page.$('.carousel-wrapper')
       if (!wrapper) throw new Error('Carousel wrapper element not found')
 
-      const clip = {
-        x: i * SLIDE_SIZE,
-        y: 0,
-        width: SLIDE_SIZE,
-        height: SLIDE_SIZE,
-      }
-
       const screenshot = await page.screenshot({
-        clip,
+        clip: {
+          x: 0,
+          y: 0,
+          width: SLIDE_SIZE,
+          height: SLIDE_SIZE,
+        },
         type: 'png',
       })
 


### PR DESCRIPTION
## Summary
- Use Playwright's installed Chromium for local carousel rendering while keeping @sparticuz/chromium for Vercel/Lambda runtimes.
- Capture each carousel slide from the visible viewport after advancing slides, fixing the follow-on local screenshot clipping error.
- This lets the Social Content "Build Carousel from App Screenshots" action render locally after screenshots are captured.

## Validation
- npm run build:knowledge && npx tsc --noEmit
- npx tsx -e "import { renderCarousel } from './lib/carousel'; (async () => { const slides = [{ type: 'cover', headline: 'Local render check', subhead: 'Renderer should launch locally.' }, { type: 'cta', headline: 'Done', body: 'No ENOEXEC.' }]; const result = await renderCarousel(slides as any); console.log(JSON.stringify({ png: result.pngBuffers.length, pdf: result.pdfBuffer.length > 0 })); })();"
- npm test -- --run 'app/api/admin/social-content/[id]/capture-app-carousel/route.test.ts' 'app/api/admin/social-content/[id]/convert-to-carousel/route.test.ts' 'app/api/admin/social-content/render-carousel/route.test.ts'
- npm run build
- No live screenshot carousel write was retried after the fix because it updates the Social Content asset fields; the local dev server is running on port 3017 for explicit user retry.

## Integration Notes
- No migrations or env changes.
- No publishing actions are triggered by this change.
- Vercel contexts to check after captain merge:
  - Vercel – portfolio
  - Vercel – portfolio-staging