### PR TITLE
feat: add Mark ReversR build evidence dashboard

### DIFF
--- a/app/admin/client-projects/[id]/page.tsx
+++ b/app/admin/client-projects/[id]/page.tsx
@@ -36,6 +36,12 @@ import {
   ChevronDown,
   ChevronUp,
   ClipboardList,
+  Plus,
+  Pencil,
+  Trash2,
+  GitBranch,
+  KeyRound,
+  ShieldCheck,
 } from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
@@ -52,6 +58,7 @@ import { useParams } from 'next/navigation'
 // ============================================================================
 
 interface Milestone {
+  id?: string
   week: number | string
   title: string
   description: string
@@ -59,6 +66,29 @@ interface Milestone {
   phase: number
   target_date?: string
   status: 'pending' | 'in_progress' | 'complete' | 'skipped'
+  completed_at?: string
+  evidence?: MilestoneEvidence[]
+  automation?: MilestoneAutomation
+}
+
+interface MilestoneEvidence {
+  id?: string
+  source_type: string
+  source_label: string
+  summary: string
+  confidence: 'high' | 'medium' | 'low'
+  status: 'verified' | 'pending' | 'access_needed' | 'manual_review'
+  source_url?: string
+  source_ref?: string
+  captured_at?: string
+  is_client_visible?: boolean
+}
+
+interface MilestoneAutomation {
+  source: string
+  status: 'active' | 'access_needed' | 'manual_review' | 'planned'
+  summary: string
+  next_check?: string
 }
 
 interface CommunicationPlan {
@@ -325,6 +355,35 @@ const MILESTONE_STATUS_CONFIG: Record<
   },
 }
 
+const EVIDENCE_STATUS_CONFIG: Record<
+  MilestoneEvidence['status'],
+  { label: string; className: string }
+> = {
+  verified: {
+    label: 'Verified',
+    className: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300',
+  },
+  pending: {
+    label: 'Pending',
+    className: 'border-gray-700 bg-gray-800 text-gray-300',
+  },
+  access_needed: {
+    label: 'Access Needed',
+    className: 'border-amber-500/30 bg-amber-500/10 text-amber-300',
+  },
+  manual_review: {
+    label: 'Manual Review',
+    className: 'border-blue-500/30 bg-blue-500/10 text-blue-300',
+  },
+}
+
+function parseMilestoneWeek(value: string): number | string {
+  const trimmed = value.trim()
+  if (!trimmed) return ''
+  const numeric = Number(trimmed)
+  return Number.isFinite(numeric) && String(numeric) === trimmed ? numeric : trimmed
+}
+
 // ============================================================================
 // Main Page
 // ============================================================================
@@ -349,6 +408,12 @@ function ProjectDetailContent() {
     milestoneIndex: number
     milestone: Milestone
   } | null>(null)
+  const [milestoneEditor, setMilestoneEditor] = useState<{
+    mode: 'create' | 'edit'
+    milestone?: Milestone
+    milestoneIndex?: number
+  } | null>(null)
+  const [deletingMilestoneIndex, setDeletingMilestoneIndex] = useState<number | null>(null)
 
   const fetchProject = useCallback(async () => {
     if (!user || !projectId) return
@@ -377,6 +442,36 @@ function ProjectDetailContent() {
   useEffect(() => {
     fetchProject()
   }, [fetchProject])
+
+  const deleteMilestone = async (milestoneIndex: number) => {
+    if (!accessToken) return
+    const milestone = data?.onboarding_plan?.milestones?.[milestoneIndex]
+    const confirmed = window.confirm(
+      `Delete milestone "${milestone?.title || milestoneIndex + 1}"? This removes it from the project roadmap.`
+    )
+    if (!confirmed) return
+
+    setDeletingMilestoneIndex(milestoneIndex)
+    try {
+      const response = await fetch(`/api/client-projects/${projectId}/milestones`, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({ milestone_index: milestoneIndex }),
+      })
+      if (!response.ok) {
+        const err = await response.json()
+        throw new Error(err.error || 'Failed to delete milestone')
+      }
+      await fetchProject()
+    } catch (error) {
+      window.alert(error instanceof Error ? error.message : 'Failed to delete milestone')
+    } finally {
+      setDeletingMilestoneIndex(null)
+    }
+  }
 
   if (loading) {
     return (
@@ -504,7 +599,16 @@ function ProjectDetailContent() {
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
           {/* Main: Milestone Timeline */}
           <div className="lg:col-span-2">
-            <h2 className="text-xl font-bold mb-4">Milestone Timeline</h2>
+            <div className="mb-4 flex items-center justify-between gap-3">
+              <h2 className="text-xl font-bold">Milestone Timeline</h2>
+              <button
+                onClick={() => setMilestoneEditor({ mode: 'create' })}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-blue-500/40 bg-blue-500/10 px-3 py-1.5 text-xs font-medium text-blue-300 hover:bg-blue-500/20"
+              >
+                <Plus size={14} />
+                Add Milestone
+              </button>
+            </div>
             {milestones.length === 0 ? (
               <p className="text-gray-500">
                 No milestones defined. Create an onboarding plan first.
@@ -523,6 +627,15 @@ function ProjectDetailContent() {
                     onMarkComplete={() =>
                       setConfirmModal({ milestoneIndex: index, milestone })
                     }
+                    onEdit={() =>
+                      setMilestoneEditor({
+                        mode: 'edit',
+                        milestone,
+                        milestoneIndex: index,
+                      })
+                    }
+                    onDelete={() => deleteMilestone(index)}
+                    deleting={deletingMilestoneIndex === index}
                     onTimeEntryChange={fetchProject}
                   />
                 ))}
@@ -748,6 +861,20 @@ function ProjectDetailContent() {
               }}
             />
           )}
+          {milestoneEditor && (
+            <MilestoneEditorModal
+              projectId={projectId}
+              accessToken={accessToken || ''}
+              mode={milestoneEditor.mode}
+              milestone={milestoneEditor.milestone}
+              milestoneIndex={milestoneEditor.milestoneIndex}
+              onClose={() => setMilestoneEditor(null)}
+              onSuccess={() => {
+                setMilestoneEditor(null)
+                fetchProject()
+              }}
+            />
+          )}
         </AnimatePresence>
       </div>
     </div>
@@ -766,6 +893,9 @@ function MilestoneCard({
   accessToken,
   timeEntries,
   onMarkComplete,
+  onEdit,
+  onDelete,
+  deleting,
   onTimeEntryChange,
 }: {
   milestone: Milestone
@@ -775,10 +905,16 @@ function MilestoneCard({
   accessToken: string
   timeEntries: TimeEntry[]
   onMarkComplete: () => void
+  onEdit: () => void
+  onDelete: () => void
+  deleting: boolean
   onTimeEntryChange: () => void
 }) {
   const config = MILESTONE_STATUS_CONFIG[milestone.status] || MILESTONE_STATUS_CONFIG.pending
   const Icon = config.icon
+  const visibleEvidence = (milestone.evidence || []).filter(
+    (item) => item.is_client_visible !== false
+  )
 
   return (
     <div className="flex gap-4">
@@ -819,6 +955,21 @@ function MilestoneCard({
             </div>
 
             <div className="flex items-center gap-2">
+              <button
+                onClick={onEdit}
+                className="inline-flex items-center gap-1 rounded-lg border border-gray-700 px-2 py-1 text-xs text-gray-300 hover:border-gray-600 hover:bg-gray-800"
+              >
+                <Pencil size={13} />
+                Edit
+              </button>
+              <button
+                onClick={onDelete}
+                disabled={deleting}
+                className="inline-flex items-center gap-1 rounded-lg border border-red-500/30 px-2 py-1 text-xs text-red-300 hover:bg-red-500/10 disabled:opacity-50"
+              >
+                {deleting ? <Loader2 size={13} className="animate-spin" /> : <Trash2 size={13} />}
+                Delete
+              </button>
               <TimeTracker
                 projectId={projectId}
                 targetType="milestone"
@@ -869,9 +1020,323 @@ function MilestoneCard({
               ))}
             </div>
           )}
+
+          {visibleEvidence.length > 0 && (
+            <div className="mt-3 border-t border-gray-800 pt-3">
+              <div className="mb-2 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.12em] text-gray-500">
+                <ShieldCheck size={13} />
+                Evidence Trace
+              </div>
+              <div className="space-y-2">
+                {visibleEvidence.map((item, evidenceIndex) => {
+                  const evidenceConfig =
+                    EVIDENCE_STATUS_CONFIG[item.status] || EVIDENCE_STATUS_CONFIG.pending
+                  return (
+                    <div
+                      key={item.id || evidenceIndex}
+                      className={`rounded-lg border p-2 ${evidenceConfig.className}`}
+                    >
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="text-xs font-medium">{item.source_label}</span>
+                        <span className="text-[10px] opacity-80">{evidenceConfig.label}</span>
+                        <span className="text-[10px] opacity-70">
+                          {item.confidence} confidence
+                        </span>
+                        {item.source_url && (
+                          <a
+                            href={item.source_url}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="inline-flex items-center gap-1 text-[10px] underline-offset-2 hover:underline"
+                          >
+                            Source
+                            <ExternalLink size={10} />
+                          </a>
+                        )}
+                      </div>
+                      <p className="mt-1 text-xs leading-relaxed opacity-85">
+                        {item.summary}
+                      </p>
+                      {item.source_ref && !item.source_ref.includes('/Users/') && (
+                        <p className="mt-1 text-[10px] opacity-60">
+                          Ref: {item.source_ref}
+                        </p>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+          )}
+
+          {milestone.automation && (
+            <div className="mt-3 flex items-start gap-2 rounded-lg border border-gray-800 bg-gray-950 p-2">
+              {milestone.automation.status === 'access_needed' ? (
+                <KeyRound size={14} className="mt-0.5 shrink-0 text-amber-300" />
+              ) : (
+                <GitBranch size={14} className="mt-0.5 shrink-0 text-blue-300" />
+              )}
+              <div>
+                <p className="text-xs text-gray-300">
+                  <span className="font-medium">Automation source:</span>{' '}
+                  {milestone.automation.source} / {milestone.automation.status}
+                </p>
+                <p className="mt-1 text-xs leading-relaxed text-gray-500">
+                  {milestone.automation.summary}
+                </p>
+                {milestone.automation.next_check && (
+                  <p className="mt-1 text-[10px] text-gray-600">
+                    Next check: {milestone.automation.next_check}
+                  </p>
+                )}
+              </div>
+            </div>
+          )}
         </div>
       </div>
     </div>
+  )
+}
+
+// ============================================================================
+// Milestone Editor Modal
+// ============================================================================
+
+function MilestoneEditorModal({
+  projectId,
+  accessToken,
+  mode,
+  milestone,
+  milestoneIndex,
+  onClose,
+  onSuccess,
+}: {
+  projectId: string
+  accessToken: string
+  mode: 'create' | 'edit'
+  milestone?: Milestone
+  milestoneIndex?: number
+  onClose: () => void
+  onSuccess: () => void
+}) {
+  const [title, setTitle] = useState(milestone?.title || '')
+  const [week, setWeek] = useState(String(milestone?.week ?? ''))
+  const [phase, setPhase] = useState(String(milestone?.phase ?? 1))
+  const [status, setStatus] = useState<Milestone['status']>(milestone?.status || 'pending')
+  const [description, setDescription] = useState(milestone?.description || '')
+  const [targetDate, setTargetDate] = useState(
+    milestone?.target_date ? milestone.target_date.slice(0, 10) : ''
+  )
+  const [deliverables, setDeliverables] = useState(
+    (milestone?.deliverables || []).join('\n')
+  )
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async () => {
+    setSubmitting(true)
+    setError(null)
+
+    const parsedPhase = Number(phase)
+    if (!title.trim()) {
+      setError('Title is required')
+      setSubmitting(false)
+      return
+    }
+    if (!week.trim()) {
+      setError('Week is required')
+      setSubmitting(false)
+      return
+    }
+    if (!Number.isFinite(parsedPhase)) {
+      setError('Phase must be a number')
+      setSubmitting(false)
+      return
+    }
+
+    const payload: Milestone = {
+      id: milestone?.id,
+      week: parseMilestoneWeek(week),
+      title: title.trim(),
+      description: description.trim(),
+      deliverables: deliverables
+        .split('\n')
+        .map((item) => item.trim())
+        .filter(Boolean),
+      phase: parsedPhase,
+      target_date: targetDate || undefined,
+      status,
+      completed_at: milestone?.completed_at,
+      evidence: milestone?.evidence,
+      automation: milestone?.automation,
+    }
+
+    try {
+      const response = await fetch(`/api/client-projects/${projectId}/milestones`, {
+        method: mode === 'create' ? 'POST' : 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify(
+          mode === 'create'
+            ? { milestone: payload }
+            : { milestone_index: milestoneIndex, milestone: payload }
+        ),
+      })
+
+      if (!response.ok) {
+        const err = await response.json()
+        throw new Error(err.error || 'Failed to save milestone')
+      }
+
+      onSuccess()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save milestone')
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      className="fixed inset-0 bg-black/70 backdrop-blur-sm z-50 flex items-center justify-center p-4"
+      onClick={onClose}
+    >
+      <motion.div
+        initial={{ scale: 0.95, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        exit={{ scale: 0.95, opacity: 0 }}
+        className="bg-gray-900 border border-gray-800 rounded-2xl max-w-2xl w-full max-h-[90vh] overflow-y-auto"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="p-5 border-b border-gray-800 flex items-center justify-between">
+          <div>
+            <h3 className="text-lg font-semibold">
+              {mode === 'create' ? 'Add Milestone' : 'Edit Milestone'}
+            </h3>
+            <p className="text-xs text-gray-500 mt-1">
+              Evidence and automation metadata stay attached to the milestone.
+            </p>
+          </div>
+          <button onClick={onClose} className="p-1 text-gray-500 hover:text-gray-300">
+            <X size={20} />
+          </button>
+        </div>
+
+        <div className="p-5 space-y-4">
+          <label className="block">
+            <span className="text-xs font-medium text-gray-400">Title</span>
+            <input
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              className="mt-1 w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-gray-100 focus:border-blue-500 focus:outline-none"
+            />
+          </label>
+
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <label className="block">
+              <span className="text-xs font-medium text-gray-400">Week</span>
+              <input
+                value={week}
+                onChange={(event) => setWeek(event.target.value)}
+                className="mt-1 w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-gray-100 focus:border-blue-500 focus:outline-none"
+              />
+            </label>
+            <label className="block">
+              <span className="text-xs font-medium text-gray-400">Phase</span>
+              <input
+                value={phase}
+                onChange={(event) => setPhase(event.target.value)}
+                inputMode="numeric"
+                className="mt-1 w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-gray-100 focus:border-blue-500 focus:outline-none"
+              />
+            </label>
+            <label className="block">
+              <span className="text-xs font-medium text-gray-400">Status</span>
+              <select
+                value={status}
+                onChange={(event) => setStatus(event.target.value as Milestone['status'])}
+                className="mt-1 w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-gray-100 focus:border-blue-500 focus:outline-none"
+              >
+                <option value="pending">Pending</option>
+                <option value="in_progress">In Progress</option>
+                <option value="complete">Complete</option>
+                <option value="skipped">Skipped</option>
+              </select>
+            </label>
+          </div>
+
+          <label className="block">
+            <span className="text-xs font-medium text-gray-400">Target date</span>
+            <input
+              type="date"
+              value={targetDate}
+              onChange={(event) => setTargetDate(event.target.value)}
+              className="mt-1 w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-gray-100 focus:border-blue-500 focus:outline-none"
+            />
+          </label>
+
+          <label className="block">
+            <span className="text-xs font-medium text-gray-400">Description</span>
+            <textarea
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              rows={3}
+              className="mt-1 w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-gray-100 focus:border-blue-500 focus:outline-none"
+            />
+          </label>
+
+          <label className="block">
+            <span className="text-xs font-medium text-gray-400">Deliverables</span>
+            <textarea
+              value={deliverables}
+              onChange={(event) => setDeliverables(event.target.value)}
+              rows={5}
+              className="mt-1 w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-gray-100 focus:border-blue-500 focus:outline-none"
+              placeholder="One deliverable per line"
+            />
+          </label>
+
+          {milestone?.evidence && milestone.evidence.length > 0 && (
+            <div className="rounded-lg border border-gray-800 bg-gray-950 p-3">
+              <p className="text-xs font-medium text-gray-400">
+                {milestone.evidence.length} evidence item
+                {milestone.evidence.length === 1 ? '' : 's'} attached
+              </p>
+              <p className="mt-1 text-xs text-gray-600">
+                Evidence is preserved here and shown in the milestone card.
+              </p>
+            </div>
+          )}
+
+          {error && (
+            <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-300">
+              {error}
+            </div>
+          )}
+        </div>
+
+        <div className="p-5 border-t border-gray-800 flex justify-end gap-3">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 rounded-lg border border-gray-700 text-gray-300 hover:bg-gray-800"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={submitting}
+            className="inline-flex items-center gap-2 rounded-lg bg-blue-500 px-4 py-2 font-medium text-white hover:bg-blue-600 disabled:opacity-50"
+          >
+            {submitting && <Loader2 size={16} className="animate-spin" />}
+            {mode === 'create' ? 'Add Milestone' : 'Save Changes'}
+          </button>
+        </div>
+      </motion.div>
+    </motion.div>
   )
 }
 

--- a/app/api/client-projects/[id]/milestones/route.ts
+++ b/app/api/client-projects/[id]/milestones/route.ts
@@ -3,9 +3,109 @@ import { supabaseAdmin } from '@/lib/supabase'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
 import { triggerProgressUpdate } from '@/lib/progress-update-templates'
 import { getUpsellPathsForOffer, scheduleUpsellFollowUp } from '@/lib/upsell-paths'
-import type { Milestone } from '@/lib/onboarding-templates'
+import type { Milestone, MilestoneEvidence } from '@/lib/onboarding-templates'
+import { randomUUID } from 'crypto'
 
 export const dynamic = 'force-dynamic'
+
+const VALID_STATUSES = ['pending', 'in_progress', 'complete', 'skipped'] as const
+type MilestoneStatus = (typeof VALID_STATUSES)[number]
+
+function isValidStatus(value: unknown): value is MilestoneStatus {
+  return typeof value === 'string' && VALID_STATUSES.includes(value as MilestoneStatus)
+}
+
+function validateMilestoneIndex(index: unknown, milestones: Milestone[]) {
+  if (typeof index !== 'number' || !Number.isInteger(index)) {
+    return 'milestone_index is required'
+  }
+
+  if (index < 0 || index >= milestones.length) {
+    return `milestone_index out of range (0-${milestones.length - 1})`
+  }
+
+  return null
+}
+
+function sanitizeMilestoneInput(value: unknown): Partial<Milestone> {
+  if (!value || typeof value !== 'object') return {}
+  const input = value as Partial<Milestone>
+
+  return {
+    id: typeof input.id === 'string' && input.id.trim() ? input.id.trim() : undefined,
+    week: typeof input.week === 'number' || typeof input.week === 'string' ? input.week : undefined,
+    title: typeof input.title === 'string' ? input.title.trim() : undefined,
+    description: typeof input.description === 'string' ? input.description.trim() : undefined,
+    deliverables: Array.isArray(input.deliverables)
+      ? input.deliverables.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+      : undefined,
+    phase: typeof input.phase === 'number' ? input.phase : undefined,
+    target_date: typeof input.target_date === 'string' ? input.target_date : undefined,
+    status: isValidStatus(input.status) ? input.status : undefined,
+    completed_at: typeof input.completed_at === 'string' ? input.completed_at : undefined,
+    evidence: Array.isArray(input.evidence) ? input.evidence : undefined,
+    automation: input.automation && typeof input.automation === 'object' ? input.automation : undefined,
+  }
+}
+
+function createManualEvidence({
+  note,
+  attachments,
+  senderName,
+}: {
+  note?: string
+  attachments?: Array<{ url?: string; filename?: string; content_type?: string }>
+  senderName?: string
+}): MilestoneEvidence[] {
+  const evidence: MilestoneEvidence[] = []
+  const now = new Date().toISOString()
+  const safeNote = note?.trim()
+
+  if (safeNote || attachments?.length) {
+    evidence.push({
+      id: `manual-completion-${randomUUID()}`,
+      source_type: 'manual',
+      source_label: 'Project lead completion evidence',
+      summary: safeNote
+        ? safeNote.slice(0, 240)
+        : `${attachments?.length ?? 0} completion attachment${attachments?.length === 1 ? '' : 's'} recorded.`,
+      confidence: 'medium',
+      status: 'manual_review',
+      source_url: attachments?.find((attachment) => attachment.url)?.url,
+      source_ref: senderName ? `recorded_by:${senderName}` : 'recorded_by:project_lead',
+      captured_at: now,
+      is_client_visible: true,
+    })
+  }
+
+  return evidence
+}
+
+async function readOnboardingPlan(clientProjectId: string) {
+  const { data: plan, error: planError } = await supabaseAdmin
+    .from('onboarding_plans')
+    .select('id, milestones')
+    .eq('client_project_id', clientProjectId)
+    .single()
+
+  if (planError || !plan) {
+    return { error: 'No onboarding plan found for this project' as const }
+  }
+
+  return {
+    plan: plan as { id: string; milestones: Milestone[] | null },
+    milestones: (plan.milestones || []) as Milestone[],
+  }
+}
+
+async function persistMilestones(planId: string, milestones: Milestone[]) {
+  const { error: updateError } = await supabaseAdmin
+    .from('onboarding_plans')
+    .update({ milestones })
+    .eq('id', planId)
+
+  return updateError
+}
 
 /**
  * PATCH /api/client-projects/[id]/milestones
@@ -43,62 +143,69 @@ export async function PATCH(
     const {
       milestone_index,
       new_status,
+      milestone,
+      updates,
       attachments,
       note,
       sender_name,
       triggered_by,
     } = body
 
-    // Validate inputs
-    if (milestone_index === undefined || milestone_index === null) {
-      return NextResponse.json(
-        { error: 'milestone_index is required' },
-        { status: 400 }
-      )
-    }
-
-    const validStatuses = ['pending', 'in_progress', 'complete', 'skipped']
-    if (!new_status || !validStatuses.includes(new_status)) {
-      return NextResponse.json(
-        { error: `new_status must be one of: ${validStatuses.join(', ')}` },
-        { status: 400 }
-      )
-    }
-
     // Fetch the onboarding plan for this project
-    const { data: plan, error: planError } = await supabaseAdmin
-      .from('onboarding_plans')
-      .select('id, milestones')
-      .eq('client_project_id', clientProjectId)
-      .single()
-
-    if (planError || !plan) {
+    const planResult = await readOnboardingPlan(clientProjectId)
+    if ('error' in planResult) {
       return NextResponse.json(
-        { error: 'No onboarding plan found for this project' },
+        { error: planResult.error },
         { status: 404 }
       )
     }
 
-    const milestones = (plan.milestones || []) as Milestone[]
+    const { plan, milestones } = planResult
+    const indexError = validateMilestoneIndex(milestone_index, milestones)
+    if (indexError) {
+      return NextResponse.json({ error: indexError }, { status: 400 })
+    }
 
-    if (milestone_index < 0 || milestone_index >= milestones.length) {
+    const incoming = sanitizeMilestoneInput(milestone ?? updates)
+    const requestedStatus = new_status ?? incoming.status
+    if (requestedStatus !== undefined && !isValidStatus(requestedStatus)) {
       return NextResponse.json(
-        {
-          error: `milestone_index out of range (0-${milestones.length - 1})`,
-        },
+        { error: `new_status must be one of: ${VALID_STATUSES.join(', ')}` },
+        { status: 400 }
+      )
+    }
+    if (!requestedStatus && Object.keys(incoming).length === 0) {
+      return NextResponse.json(
+        { error: 'Provide new_status, milestone, or updates' },
         { status: 400 }
       )
     }
 
     // Update the milestone status
     const oldStatus = milestones[milestone_index].status
-    milestones[milestone_index].status = new_status
+    const nextStatus = requestedStatus || oldStatus
+    const completionEvidence = createManualEvidence({
+      note,
+      attachments,
+      senderName: sender_name,
+    })
+    milestones[milestone_index] = {
+      ...milestones[milestone_index],
+      ...incoming,
+      id: incoming.id || milestones[milestone_index].id || `milestone-${randomUUID()}`,
+      status: nextStatus,
+      completed_at:
+        nextStatus === 'complete'
+          ? milestones[milestone_index].completed_at || new Date().toISOString()
+          : undefined,
+      evidence:
+        completionEvidence.length > 0
+          ? [...(milestones[milestone_index].evidence || []), ...completionEvidence]
+          : incoming.evidence ?? milestones[milestone_index].evidence,
+    }
 
     // Persist the updated milestones
-    const { error: updateError } = await supabaseAdmin
-      .from('onboarding_plans')
-      .update({ milestones })
-      .eq('id', plan.id)
+    const updateError = await persistMilestones(plan.id, milestones)
 
     if (updateError) {
       console.error('Error updating milestones:', updateError)
@@ -120,7 +227,7 @@ export async function PATCH(
         .from('client_projects')
         .update({ project_status: 'delivering', current_phase: 4 })
         .eq('id', clientProjectId)
-    } else if (new_status === 'complete' || new_status === 'in_progress') {
+    } else if (nextStatus === 'complete' || nextStatus === 'in_progress') {
       // Update phase based on the milestone's phase value
       const milestonePhase = milestones[milestone_index].phase
       await supabaseAdmin
@@ -134,11 +241,11 @@ export async function PATCH(
 
     // Trigger progress update message if milestone was marked complete
     let progressResult = null
-    if (new_status === 'complete' && oldStatus !== 'complete') {
+    if (nextStatus === 'complete' && oldStatus !== 'complete') {
       progressResult = await triggerProgressUpdate({
         clientProjectId,
         milestoneIndex: milestone_index,
-        newStatus: new_status,
+        newStatus: nextStatus,
         senderName: sender_name || 'Your Project Lead',
         customNote: note,
         attachments: attachments || [],
@@ -245,7 +352,7 @@ export async function PATCH(
       milestone: milestones[milestone_index],
       milestone_index,
       old_status: oldStatus,
-      new_status,
+      new_status: nextStatus,
       milestones_completed: completedCount,
       milestones_total: totalCount,
       progress_update: progressResult
@@ -266,5 +373,131 @@ export async function PATCH(
       { error: 'Internal server error' },
       { status: 500 }
     )
+  }
+}
+
+/**
+ * POST /api/client-projects/[id]/milestones
+ * Add a milestone to the onboarding plan.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const authResult = await verifyAdmin(request)
+    if (isAuthError(authResult)) {
+      return NextResponse.json(
+        { error: authResult.error },
+        { status: authResult.status }
+      )
+    }
+
+    const { id: clientProjectId } = await params
+    const body = await request.json()
+    const input = sanitizeMilestoneInput(body.milestone ?? body)
+
+    if (!input.title) {
+      return NextResponse.json({ error: 'title is required' }, { status: 400 })
+    }
+    if (input.week === undefined) {
+      return NextResponse.json({ error: 'week is required' }, { status: 400 })
+    }
+    if (input.phase === undefined) {
+      return NextResponse.json({ error: 'phase is required' }, { status: 400 })
+    }
+
+    const planResult = await readOnboardingPlan(clientProjectId)
+    if ('error' in planResult) {
+      return NextResponse.json({ error: planResult.error }, { status: 404 })
+    }
+
+    const newMilestone: Milestone = {
+      id: input.id || `milestone-${randomUUID()}`,
+      week: input.week,
+      title: input.title,
+      description: input.description || '',
+      deliverables: input.deliverables || [],
+      phase: input.phase,
+      target_date: input.target_date,
+      status: input.status || 'pending',
+      evidence: input.evidence,
+      automation: input.automation,
+    }
+
+    const position =
+      typeof body.position === 'number' && Number.isInteger(body.position)
+        ? Math.max(0, Math.min(body.position, planResult.milestones.length))
+        : planResult.milestones.length
+    const milestones = [...planResult.milestones]
+    milestones.splice(position, 0, newMilestone)
+
+    const updateError = await persistMilestones(planResult.plan.id, milestones)
+    if (updateError) {
+      console.error('Error creating milestone:', updateError)
+      return NextResponse.json({ error: 'Failed to create milestone' }, { status: 500 })
+    }
+
+    return NextResponse.json({
+      success: true,
+      milestone: newMilestone,
+      milestone_index: position,
+      milestones_total: milestones.length,
+    })
+  } catch (error) {
+    console.error('Error in POST /api/client-projects/[id]/milestones:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+/**
+ * DELETE /api/client-projects/[id]/milestones
+ * Remove a milestone from the onboarding plan.
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const authResult = await verifyAdmin(request)
+    if (isAuthError(authResult)) {
+      return NextResponse.json(
+        { error: authResult.error },
+        { status: authResult.status }
+      )
+    }
+
+    const { id: clientProjectId } = await params
+    const body = await request.json()
+    const milestoneIndex = body.milestone_index
+
+    const planResult = await readOnboardingPlan(clientProjectId)
+    if ('error' in planResult) {
+      return NextResponse.json({ error: planResult.error }, { status: 404 })
+    }
+
+    const indexError = validateMilestoneIndex(milestoneIndex, planResult.milestones)
+    if (indexError) {
+      return NextResponse.json({ error: indexError }, { status: 400 })
+    }
+
+    const milestones = [...planResult.milestones]
+    const [removed] = milestones.splice(milestoneIndex, 1)
+
+    const updateError = await persistMilestones(planResult.plan.id, milestones)
+    if (updateError) {
+      console.error('Error deleting milestone:', updateError)
+      return NextResponse.json({ error: 'Failed to delete milestone' }, { status: 500 })
+    }
+
+    return NextResponse.json({
+      success: true,
+      removed_milestone: removed,
+      milestone_index: milestoneIndex,
+      milestones_total: milestones.length,
+    })
+  } catch (error) {
+    console.error('Error in DELETE /api/client-projects/[id]/milestones:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
 }

--- a/app/client/dashboard/[token]/page.tsx
+++ b/app/client/dashboard/[token]/page.tsx
@@ -289,10 +289,6 @@ export default function ClientDashboardPage() {
           <AiOpsRoadmapSection roadmap={aiOpsRoadmap} />
         )}
 
-        {buildEvidence && (
-          <BuildEvidenceInvestmentSection buildEvidence={buildEvidence} />
-        )}
-
         {/* Row 4: Documents & Time Investment */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
           <DocumentsSection documents={documents || []} />
@@ -301,6 +297,10 @@ export default function ClientDashboardPage() {
             milestones={(milestones || []) as Array<{ title?: string }>}
           />
         </div>
+
+        {buildEvidence && (
+          <BuildEvidenceInvestmentSection buildEvidence={buildEvidence} />
+        )}
 
         {/* Row 5: Gap Analysis */}
         <GapAnalysisPanel gaps={gapAnalysis} />

--- a/app/client/dashboard/[token]/page.tsx
+++ b/app/client/dashboard/[token]/page.tsx
@@ -20,6 +20,7 @@ import ReportsSection from '@/components/client-dashboard/ReportsSection'
 import TimeTrackingSection from '@/components/client-dashboard/TimeTrackingSection'
 import MeetingHistory from '@/components/client-dashboard/MeetingHistory'
 import AiOpsRoadmapSection from '@/components/client-dashboard/AiOpsRoadmapSection'
+import BuildEvidenceInvestmentSection from '@/components/client-dashboard/BuildEvidenceInvestmentSection'
 import type { DashboardData, LeadDashboardData, DashboardTask } from '@/lib/client-dashboard'
 import type { AccelerationRecommendation } from '@/lib/acceleration-engine'
 import SiteThemeCorner from '@/components/SiteThemeCorner'
@@ -208,6 +209,7 @@ export default function ClientDashboardPage() {
     valueReports,
     gammaReports,
     aiOpsRoadmap,
+    buildEvidence,
   } = dashboard as DashboardData
 
   const tasksCompleted = tasks.filter((t: DashboardTask) => t.status === 'complete').length
@@ -285,6 +287,10 @@ export default function ClientDashboardPage() {
 
         {aiOpsRoadmap && (
           <AiOpsRoadmapSection roadmap={aiOpsRoadmap} />
+        )}
+
+        {buildEvidence && (
+          <BuildEvidenceInvestmentSection buildEvidence={buildEvidence} />
         )}
 
         {/* Row 4: Documents & Time Investment */}

--- a/app/client/dashboard/[token]/page.tsx
+++ b/app/client/dashboard/[token]/page.tsx
@@ -106,10 +106,10 @@ export default function ClientDashboardPage() {
     return (
       <>
         <SiteThemeCorner />
-      <div className="min-h-screen bg-gray-950 flex items-center justify-center">
+      <div className="min-h-screen bg-imperial-navy flex items-center justify-center">
         <div className="text-center">
-          <Loader2 className="w-8 h-8 animate-spin text-blue-500 mx-auto mb-4" />
-          <p className="text-gray-400 text-sm">Loading your dashboard...</p>
+          <Loader2 className="w-8 h-8 animate-spin text-radiant-gold mx-auto mb-4" />
+          <p className="text-platinum-white/70 text-sm">Loading your dashboard...</p>
         </div>
       </div>
       </>
@@ -121,10 +121,10 @@ export default function ClientDashboardPage() {
     return (
       <>
         <SiteThemeCorner />
-      <div className="min-h-screen bg-gray-950 flex items-center justify-center">
+      <div className="min-h-screen bg-imperial-navy flex items-center justify-center">
         <div className="text-center max-w-md px-4">
-          <h1 className="text-2xl font-bold text-white mb-2">Dashboard Not Found</h1>
-          <p className="text-gray-400">
+          <h1 className="text-2xl font-bold text-platinum-white mb-2">Dashboard Not Found</h1>
+          <p className="text-platinum-white/65">
             {error || 'This dashboard link may be invalid or expired. Please contact your consultant for a new link.'}
           </p>
         </div>
@@ -140,31 +140,41 @@ export default function ClientDashboardPage() {
     return (
       <>
         <SiteThemeCorner />
-      <div className="min-h-screen bg-gray-950">
-        <header className="border-b border-gray-800 bg-gray-900/50 backdrop-blur-sm sticky top-0 z-10">
+      <div className="min-h-screen bg-imperial-navy text-platinum-white">
+        <header className="sticky top-0 z-10 border-b border-radiant-gold/20 bg-imperial-navy/90 backdrop-blur-md">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center justify-between">
-            <div>
-              <h1 className="text-lg font-bold text-white">Your Assessment Dashboard</h1>
-              <p className="text-xs text-gray-500">Lead view — complete your engagement to unlock full dashboard</p>
+            <div className="flex items-center gap-3">
+              <img
+                src="/amadutown-logo-upscaled.png"
+                alt="AmaduTown Advisory Solutions"
+                className="h-11 w-auto"
+              />
+              <div>
+                <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-radiant-gold">
+                  AmaduTown Client Portal
+                </p>
+                <h1 className="text-lg font-bold text-platinum-white">Your Assessment Dashboard</h1>
+                <p className="text-xs text-platinum-white/55">Lead view - complete your engagement to unlock full dashboard</p>
+              </div>
             </div>
             <div className="text-right">
-              <p className="text-sm font-medium text-gray-300">{project.client_name}</p>
+              <p className="text-sm font-medium text-platinum-white">{project.client_name}</p>
               {project.client_company && (
-                <p className="text-xs text-gray-500">{project.client_company}</p>
+                <p className="text-xs text-radiant-gold/75">{project.client_company}</p>
               )}
             </div>
           </div>
         </header>
         <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 space-y-6">
-          <p className="text-sm text-gray-400 italic">{industryBenchmarksMessage}</p>
+          <p className="text-sm text-platinum-white/65 italic">{industryBenchmarksMessage}</p>
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
             <ScoreRadarChart scores={scores.categoryScores} />
             <div className="lg:col-span-2">
               {assessment ? (
                 <AssessmentDetails assessment={assessment} valueReport={null} />
               ) : (
-                <div className="bg-gray-900 rounded-xl border border-gray-800 p-5">
-                  <p className="text-gray-500 text-sm">No assessment data available yet.</p>
+                <div className="rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-5">
+                  <p className="text-platinum-white/55 text-sm">No assessment data available yet.</p>
                 </div>
               )}
             </div>
@@ -177,14 +187,14 @@ export default function ClientDashboardPage() {
               engagementSteps={engagementSteps}
             />
           </div>
-          <div className="bg-gray-900/50 rounded-xl border border-gray-800 border-dashed p-6 text-center">
-            <p className="text-gray-500 text-sm">
+          <div className="rounded-lg border border-dashed border-radiant-gold/25 bg-silicon-slate/25 p-6 text-center">
+            <p className="text-platinum-white/55 text-sm">
               Tasks, milestones, and trajectory will appear here once you start your engagement.
             </p>
           </div>
         </main>
-        <footer className="border-t border-gray-800 mt-12 py-6">
-          <p className="text-center text-xs text-gray-600">
+        <footer className="border-t border-radiant-gold/15 mt-12 py-6">
+          <p className="text-center text-xs text-platinum-white/40">
             Questions? Contact your consultant for assistance.
           </p>
         </footer>
@@ -221,25 +231,35 @@ export default function ClientDashboardPage() {
   return (
     <>
       <SiteThemeCorner />
-    <div className="min-h-screen bg-gray-950">
+    <div className="min-h-screen bg-imperial-navy text-platinum-white">
       {/* Header */}
-      <header className="border-b border-gray-800 bg-gray-900/50 backdrop-blur-sm sticky top-0 z-10">
+      <header className="sticky top-0 z-10 border-b border-radiant-gold/20 bg-imperial-navy/90 backdrop-blur-md">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center justify-between">
-          <div>
-            <h1 className="text-lg font-bold text-white">Client Dashboard</h1>
-            <p className="text-xs text-gray-500">{project.project_name}</p>
+          <div className="flex items-center gap-3 min-w-0">
+            <img
+              src="/amadutown-logo-upscaled.png"
+              alt="AmaduTown Advisory Solutions"
+              className="h-11 w-auto shrink-0"
+            />
+            <div className="min-w-0">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-radiant-gold">
+                AmaduTown Client Portal
+              </p>
+              <h1 className="text-lg font-bold text-platinum-white">Client Dashboard</h1>
+              <p className="truncate text-xs text-platinum-white/55">{project.project_name}</p>
+            </div>
           </div>
-          <div className="text-right">
-            <p className="text-sm font-medium text-gray-300">{project.client_name}</p>
+          <div className="shrink-0 text-right">
+            <p className="text-sm font-medium text-platinum-white">{project.client_name}</p>
             {project.client_company && (
-              <p className="text-xs text-gray-500">{project.client_company}</p>
+              <p className="text-xs text-radiant-gold/75">{project.client_company}</p>
             )}
           </div>
         </div>
       </header>
 
       {/* Main Content */}
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 space-y-6">
+      <main className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 space-y-6">
         {/* Row 1: Stat Cards */}
         <DashboardStatCards
           overallScore={scores.overallScore}
@@ -258,11 +278,11 @@ export default function ClientDashboardPage() {
             {assessment ? (
               <AssessmentDetails assessment={assessment} valueReport={valueReport} />
             ) : (
-              <div className="bg-gray-900 rounded-xl border border-gray-800 p-5">
-                <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider mb-2">
+              <div className="rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-5">
+                <h3 className="text-sm font-medium text-radiant-gold uppercase tracking-wider mb-2">
                   Assessment
                 </h3>
-                <p className="text-gray-500 text-sm">
+                <p className="text-platinum-white/55 text-sm">
                   No assessment data available yet.
                 </p>
               </div>
@@ -337,8 +357,8 @@ export default function ClientDashboardPage() {
       </main>
 
       {/* Footer */}
-      <footer className="border-t border-gray-800 mt-12 py-6">
-        <p className="text-center text-xs text-gray-600">
+      <footer className="border-t border-radiant-gold/15 mt-12 py-6">
+        <p className="text-center text-xs text-platinum-white/40">
           Questions about your dashboard? Contact your consultant for assistance.
         </p>
       </footer>

--- a/components/client-dashboard/AssessmentDetails.tsx
+++ b/components/client-dashboard/AssessmentDetails.tsx
@@ -85,8 +85,8 @@ export default function AssessmentDetails({ assessment, valueReport }: Assessmen
   }
 
   return (
-    <div className="bg-gray-900 rounded-xl border border-gray-800 p-5">
-      <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider mb-4">
+    <div className="rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-5">
+      <h3 className="text-sm font-medium text-radiant-gold uppercase tracking-wider mb-4">
         Your Assessment Details
       </h3>
       <div className="space-y-2">
@@ -95,24 +95,24 @@ export default function AssessmentDetails({ assessment, valueReport }: Assessmen
           const Icon = section.icon
 
           return (
-            <div key={section.key} className="border border-gray-800 rounded-lg overflow-hidden">
+            <div key={section.key} className="border border-radiant-gold/10 rounded-lg overflow-hidden bg-imperial-navy/35">
               <button
                 onClick={() => setExpandedSection(isExpanded ? null : section.key)}
-                className="w-full flex items-center gap-3 p-3 hover:bg-gray-800/50 transition-colors text-left"
+                className="w-full flex items-center gap-3 p-3 hover:bg-radiant-gold/10 transition-colors text-left"
               >
-                <Icon className="w-4 h-4 text-gray-500 flex-shrink-0" />
-                <span className="text-sm font-medium text-gray-300 flex-1">
+                <Icon className="w-4 h-4 text-radiant-gold/75 flex-shrink-0" />
+                <span className="text-sm font-medium text-platinum-white/85 flex-1">
                   {section.title}
                 </span>
                 {isExpanded ? (
-                  <ChevronDown className="w-4 h-4 text-gray-500" />
+                  <ChevronDown className="w-4 h-4 text-radiant-gold/65" />
                 ) : (
-                  <ChevronRight className="w-4 h-4 text-gray-500" />
+                  <ChevronRight className="w-4 h-4 text-radiant-gold/65" />
                 )}
               </button>
               {isExpanded && section.content && (
                 <div className="px-3 pb-3">
-                  <p className="text-sm text-gray-400 leading-relaxed whitespace-pre-wrap">
+                  <p className="text-sm text-platinum-white/65 leading-relaxed whitespace-pre-wrap">
                     {section.content}
                   </p>
                 </div>
@@ -123,12 +123,12 @@ export default function AssessmentDetails({ assessment, valueReport }: Assessmen
 
         {/* Key Insights */}
         {assessment.key_insights && assessment.key_insights.length > 0 && (
-          <div className="mt-3 p-3 bg-blue-900/20 border border-blue-800/50 rounded-lg">
-            <h4 className="text-xs font-medium text-blue-400 uppercase mb-2">Key Insights</h4>
+          <div className="mt-3 p-3 bg-radiant-gold/10 border border-radiant-gold/25 rounded-lg">
+            <h4 className="text-xs font-medium text-radiant-gold uppercase mb-2">Key Insights</h4>
             <ul className="space-y-1">
               {assessment.key_insights.map((insight, i) => (
-                <li key={i} className="text-xs text-blue-300/80 flex items-start gap-2">
-                  <span className="text-blue-500 mt-0.5">•</span>
+                <li key={i} className="text-xs text-platinum-white/75 flex items-start gap-2">
+                  <span className="text-radiant-gold mt-0.5">•</span>
                   {insight}
                 </li>
               ))}

--- a/components/client-dashboard/BuildEvidenceInvestmentSection.test.tsx
+++ b/components/client-dashboard/BuildEvidenceInvestmentSection.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import BuildEvidenceInvestmentSection from './BuildEvidenceInvestmentSection'
+import type { ClientBuildEvidence } from '@/lib/client-build-evidence'
+
+const evidence: ClientBuildEvidence = {
+  id: 'evidence-1',
+  projectLabel: 'ReversR Rebuild Product Asset',
+  capturedAt: '2026-06-15T12:00:00.000Z',
+  repoMetrics: {
+    repoLabel: 'vsillah/ReversR-Rebuild',
+    publicRepoUrl: 'https://github.com/vsillah/ReversR-Rebuild',
+    capturedAt: '2026-06-12T12:35:02-04:00',
+    allBranchCommitCount: 149,
+    headCommitCount: 140,
+    trackedFiles: 271,
+    trackedCodeDocConfigFiles: 150,
+    trackedTextLines: 36775,
+    filesChanged: 151,
+    insertions: 30973,
+    deletions: 4990,
+    releasePassCount: 38,
+    releasePendingCount: 1,
+    releasePendingGate: 'store-console-records',
+    workflow: ['scan or describe a machine'],
+  },
+  tokenUsage: {
+    attributionMethod: 'strict_reversr_workspace_cwd',
+    confidenceLabel: 'Direct ReversR workspace evidence',
+    comparisonWindowLabel: 'June 2026 local Codex sessions',
+    sessionCount: 5,
+    totalTokens: 283717602,
+    inputTokens: 283030750,
+    cachedInputTokens: 270859776,
+    outputTokens: 686852,
+    reasoningTokens: 177176,
+    shareOfComparisonWindowPct: 17.38,
+    modelProvider: 'openai',
+    model: 'gpt-5.5',
+    planType: 'pro',
+  },
+  costSummary: {
+    pricingCapturedAt: null,
+    pricingSourceLabel: 'Provider/API pricing snapshot not recorded',
+    pricingAssumption: 'Observed token usage only.',
+    apiEquivalentCostUsd: null,
+    subscriptionMonthlyCostUsd: null,
+    subscriptionAllocatedCostUsd: null,
+    subscriptionSharePct: 17.38,
+  },
+  hourlyTranslation: {
+    defaultBenchmarkHourlyRate: 175,
+    defaultProposalAmount: 30000,
+    focusedHoursLow: 300,
+    focusedHoursHigh: 475,
+    notes: 'Scenario estimate, not a time sheet.',
+  },
+  sourceConfidence: {
+    label: 'Direct ReversR workspace evidence',
+    confidence: 'high',
+    sourceSummary: 'Strict attribution includes only Codex sessions whose working directory was the ReversR workspace.',
+    excludedSources: [],
+  },
+  clientSafeNotes: [
+    'Repository and token metrics are supporting evidence, not billing units.',
+    'Hourly translation is a comparison lens.',
+  ],
+}
+
+describe('BuildEvidenceInvestmentSection', () => {
+  it('renders client-safe evidence and calculator outputs', () => {
+    render(<BuildEvidenceInvestmentSection buildEvidence={evidence} />)
+
+    expect(screen.getByText('Build Evidence & Investment')).toBeInTheDocument()
+    expect(screen.getByText('Direct ReversR workspace evidence')).toBeInTheDocument()
+    expect(screen.getByText('149')).toBeInTheDocument()
+    expect(screen.getByText('Rate needed')).toBeInTheDocument()
+    expect(screen.getByText('$52,500-$83,125 replacement-cost range')).toBeInTheDocument()
+    expect(screen.getAllByText(/not a time sheet/i)).toHaveLength(2)
+  })
+
+  it('updates subscription allocation and proposal translation locally', () => {
+    render(<BuildEvidenceInvestmentSection buildEvidence={evidence} />)
+
+    fireEvent.change(screen.getByLabelText('Monthly AI spend'), {
+      target: { value: '200' },
+    })
+    expect(screen.getByText('$35 allocated by usage share')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /proposal/i }))
+    expect(screen.getByText('171 implied benchmark hours')).toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText('Rate'), {
+      target: { value: '200' },
+    })
+    expect(screen.getByText('150 implied benchmark hours')).toBeInTheDocument()
+  })
+})

--- a/components/client-dashboard/BuildEvidenceInvestmentSection.tsx
+++ b/components/client-dashboard/BuildEvidenceInvestmentSection.tsx
@@ -1,0 +1,294 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { Calculator, Code2, Cpu, DollarSign, Gauge, GitCommit, ShieldCheck } from 'lucide-react'
+import type { ClientBuildEvidence } from '@/lib/client-build-evidence'
+
+interface Props {
+  buildEvidence: ClientBuildEvidence
+}
+
+type CalculatorMode = 'rate' | 'hours' | 'proposal'
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat('en-US').format(Math.round(value))
+}
+
+function formatCompact(value: number): string {
+  return new Intl.NumberFormat('en-US', {
+    notation: 'compact',
+    maximumFractionDigits: 1,
+  }).format(value)
+}
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  }).format(value)
+}
+
+function safeNumber(value: number): number {
+  return Number.isFinite(value) && value >= 0 ? value : 0
+}
+
+export default function BuildEvidenceInvestmentSection({ buildEvidence }: Props) {
+  const { repoMetrics, tokenUsage, costSummary, hourlyTranslation, sourceConfidence } = buildEvidence
+  const [mode, setMode] = useState<CalculatorMode>('rate')
+  const [hourlyRate, setHourlyRate] = useState(hourlyTranslation.defaultBenchmarkHourlyRate)
+  const [proposalAmount, setProposalAmount] = useState(hourlyTranslation.defaultProposalAmount)
+  const [focusedHoursLow, setFocusedHoursLow] = useState(hourlyTranslation.focusedHoursLow)
+  const [focusedHoursHigh, setFocusedHoursHigh] = useState(hourlyTranslation.focusedHoursHigh)
+  const [monthlySpend, setMonthlySpend] = useState(costSummary.subscriptionMonthlyCostUsd ?? 0)
+
+  const normalizedLow = Math.min(safeNumber(focusedHoursLow), safeNumber(focusedHoursHigh))
+  const normalizedHigh = Math.max(safeNumber(focusedHoursLow), safeNumber(focusedHoursHigh))
+  const normalizedRate = safeNumber(hourlyRate)
+  const normalizedProposal = safeNumber(proposalAmount)
+  const normalizedMonthlySpend = safeNumber(monthlySpend)
+
+  const calculated = useMemo(() => {
+    const rateRangeLow = normalizedLow * normalizedRate
+    const rateRangeHigh = normalizedHigh * normalizedRate
+    const effectiveHourlyLow = normalizedHigh > 0 ? normalizedProposal / normalizedHigh : 0
+    const effectiveHourlyHigh = normalizedLow > 0 ? normalizedProposal / normalizedLow : 0
+    const impliedHours = normalizedRate > 0 ? normalizedProposal / normalizedRate : 0
+    const subscriptionAllocation = normalizedMonthlySpend * (tokenUsage.shareOfComparisonWindowPct / 100)
+
+    return {
+      rateRangeLow,
+      rateRangeHigh,
+      effectiveHourlyLow,
+      effectiveHourlyHigh,
+      impliedHours,
+      subscriptionAllocation,
+    }
+  }, [
+    normalizedHigh,
+    normalizedLow,
+    normalizedMonthlySpend,
+    normalizedProposal,
+    normalizedRate,
+    tokenUsage.shareOfComparisonWindowPct,
+  ])
+
+  const calculatorSummary =
+    mode === 'rate'
+      ? `${formatCurrency(calculated.rateRangeLow)}-${formatCurrency(calculated.rateRangeHigh)} replacement-cost range`
+      : mode === 'hours'
+        ? `${formatCurrency(calculated.effectiveHourlyLow)}-${formatCurrency(calculated.effectiveHourlyHigh)} effective hourly lens`
+        : `${formatNumber(calculated.impliedHours)} implied benchmark hours`
+
+  const metricCards = [
+    {
+      label: 'Commits',
+      value: formatNumber(repoMetrics.allBranchCommitCount),
+      detail: `${formatNumber(repoMetrics.filesChanged)} files changed`,
+      icon: GitCommit,
+      tone: 'border-blue-500/40 bg-blue-500/10 text-blue-300',
+    },
+    {
+      label: 'Code + docs',
+      value: formatCompact(repoMetrics.trackedTextLines),
+      detail: `${formatNumber(repoMetrics.insertions)} insertions`,
+      icon: Code2,
+      tone: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-300',
+    },
+    {
+      label: 'Release gates',
+      value: `${repoMetrics.releasePassCount}/${repoMetrics.releasePassCount + repoMetrics.releasePendingCount}`,
+      detail: repoMetrics.releasePendingGate ? `${repoMetrics.releasePendingGate} pending` : 'No pending gate recorded',
+      icon: ShieldCheck,
+      tone: 'border-amber-500/40 bg-amber-500/10 text-amber-300',
+    },
+    {
+      label: 'Attributed tokens',
+      value: formatCompact(tokenUsage.totalTokens),
+      detail: `${tokenUsage.shareOfComparisonWindowPct.toFixed(2)}% of comparison window`,
+      icon: Cpu,
+      tone: 'border-cyan-500/40 bg-cyan-500/10 text-cyan-300',
+    },
+  ]
+
+  return (
+    <section className="rounded-xl border border-gray-800 bg-gray-900 p-5">
+      <div className="mb-5 flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <div className="mb-2 flex items-center gap-2">
+            <Gauge className="h-5 w-5 text-blue-400" />
+            <h3 className="text-sm font-medium uppercase tracking-wider text-gray-300">
+              Build Evidence & Investment
+            </h3>
+          </div>
+          <p className="max-w-3xl text-sm text-gray-400">
+            ReversR Rebuild is measured here as product-asset evidence. The numbers support replacement-cost and fixed-fee evaluation; they are not a time sheet.
+          </p>
+        </div>
+        <div className="rounded-lg border border-blue-500/30 bg-blue-500/10 px-3 py-2 text-xs text-blue-200">
+          <p className="font-semibold">{sourceConfidence.label}</p>
+          <p className="mt-1 text-blue-200/80 capitalize">{sourceConfidence.confidence} confidence</p>
+        </div>
+      </div>
+
+      <div className="mb-5 grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
+        {metricCards.map((card) => (
+          <div key={card.label} className={`rounded-lg border p-4 ${card.tone}`}>
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <p className="text-xs font-medium uppercase tracking-wider text-gray-400">{card.label}</p>
+              <card.icon className="h-4 w-4" />
+            </div>
+            <p className="text-2xl font-bold text-white">{card.value}</p>
+            <p className="mt-1 text-xs text-gray-400">{card.detail}</p>
+          </div>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 gap-5 lg:grid-cols-3">
+        <div className="rounded-lg border border-gray-800 bg-gray-950/45 p-4 lg:col-span-1">
+          <div className="mb-3 flex items-center gap-2">
+            <Cpu className="h-4 w-4 text-cyan-300" />
+            <p className="text-xs font-semibold uppercase tracking-wider text-gray-400">Token attribution</p>
+          </div>
+          <dl className="space-y-2 text-sm">
+            <div className="flex justify-between gap-3">
+              <dt className="text-gray-500">Sessions</dt>
+              <dd className="font-medium text-gray-200">{formatNumber(tokenUsage.sessionCount)}</dd>
+            </div>
+            <div className="flex justify-between gap-3">
+              <dt className="text-gray-500">Input tokens</dt>
+              <dd className="font-medium text-gray-200">{formatCompact(tokenUsage.inputTokens)}</dd>
+            </div>
+            <div className="flex justify-between gap-3">
+              <dt className="text-gray-500">Cached input</dt>
+              <dd className="font-medium text-gray-200">{formatCompact(tokenUsage.cachedInputTokens)}</dd>
+            </div>
+            <div className="flex justify-between gap-3">
+              <dt className="text-gray-500">Output + reasoning</dt>
+              <dd className="font-medium text-gray-200">
+                {formatCompact(tokenUsage.outputTokens + tokenUsage.reasoningTokens)}
+              </dd>
+            </div>
+          </dl>
+          <p className="mt-4 rounded-lg border border-cyan-500/20 bg-cyan-500/10 p-3 text-xs text-cyan-100/85">
+            {sourceConfidence.sourceSummary}
+          </p>
+        </div>
+
+        <div className="rounded-lg border border-gray-800 bg-gray-950/45 p-4 lg:col-span-1">
+          <div className="mb-3 flex items-center gap-2">
+            <DollarSign className="h-4 w-4 text-emerald-300" />
+            <p className="text-xs font-semibold uppercase tracking-wider text-gray-400">Token cost lens</p>
+          </div>
+          <div className="space-y-3">
+            <div className="rounded-lg bg-gray-900/70 p-3">
+              <p className="text-xs uppercase tracking-wider text-gray-500">API-equivalent estimate</p>
+              <p className="mt-1 text-lg font-semibold text-white">
+                {costSummary.apiEquivalentCostUsd == null ? 'Rate needed' : formatCurrency(costSummary.apiEquivalentCostUsd)}
+              </p>
+              <p className="mt-1 text-xs text-gray-500">{costSummary.pricingSourceLabel}</p>
+            </div>
+            <div className="rounded-lg bg-gray-900/70 p-3">
+              <label className="text-xs uppercase tracking-wider text-gray-500" htmlFor="ai-monthly-spend">
+                Monthly AI spend
+              </label>
+              <div className="mt-2 flex items-center gap-2">
+                <span className="text-sm text-gray-500">$</span>
+                <input
+                  id="ai-monthly-spend"
+                  type="number"
+                  min="0"
+                  value={monthlySpend}
+                  onChange={(event) => setMonthlySpend(Number(event.target.value))}
+                  className="w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-gray-100 outline-none focus:border-blue-500"
+                />
+              </div>
+              <p className="mt-2 text-sm font-semibold text-emerald-300">
+                {formatCurrency(calculated.subscriptionAllocation)} allocated by usage share
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-gray-800 bg-gray-950/45 p-4 lg:col-span-1">
+          <div className="mb-3 flex items-center gap-2">
+            <Calculator className="h-4 w-4 text-blue-300" />
+            <p className="text-xs font-semibold uppercase tracking-wider text-gray-400">Hourly translation</p>
+          </div>
+          <div className="mb-3 grid grid-cols-3 gap-2">
+            {(['rate', 'hours', 'proposal'] as CalculatorMode[]).map((nextMode) => (
+              <button
+                key={nextMode}
+                type="button"
+                onClick={() => setMode(nextMode)}
+                className={`rounded-lg border px-2 py-2 text-xs font-medium capitalize transition-colors ${
+                  mode === nextMode
+                    ? 'border-blue-500 bg-blue-500/20 text-blue-100'
+                    : 'border-gray-700 bg-gray-900 text-gray-400 hover:text-gray-200'
+                }`}
+              >
+                {nextMode}
+              </button>
+            ))}
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <label className="text-xs text-gray-500">
+              Rate
+              <input
+                type="number"
+                min="0"
+                value={hourlyRate}
+                onChange={(event) => setHourlyRate(Number(event.target.value))}
+                className="mt-1 w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-gray-100 outline-none focus:border-blue-500"
+              />
+            </label>
+            <label className="text-xs text-gray-500">
+              Proposal
+              <input
+                type="number"
+                min="0"
+                value={proposalAmount}
+                onChange={(event) => setProposalAmount(Number(event.target.value))}
+                className="mt-1 w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-gray-100 outline-none focus:border-blue-500"
+              />
+            </label>
+            <label className="text-xs text-gray-500">
+              Low hours
+              <input
+                type="number"
+                min="0"
+                value={focusedHoursLow}
+                onChange={(event) => setFocusedHoursLow(Number(event.target.value))}
+                className="mt-1 w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-gray-100 outline-none focus:border-blue-500"
+              />
+            </label>
+            <label className="text-xs text-gray-500">
+              High hours
+              <input
+                type="number"
+                min="0"
+                value={focusedHoursHigh}
+                onChange={(event) => setFocusedHoursHigh(Number(event.target.value))}
+                className="mt-1 w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-gray-100 outline-none focus:border-blue-500"
+              />
+            </label>
+          </div>
+          <div className="mt-4 rounded-lg border border-blue-500/25 bg-blue-500/10 p-3">
+            <p className="text-lg font-semibold text-white">{calculatorSummary}</p>
+            <p className="mt-1 text-xs text-blue-100/75">{hourlyTranslation.notes}</p>
+          </div>
+        </div>
+      </div>
+
+      {buildEvidence.clientSafeNotes.length > 0 && (
+        <div className="mt-5 grid grid-cols-1 gap-2 md:grid-cols-3">
+          {buildEvidence.clientSafeNotes.map((note) => (
+            <p key={note} className="rounded-lg border border-gray-800 bg-gray-950/50 p-3 text-xs text-gray-400">
+              {note}
+            </p>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/components/client-dashboard/BuildEvidenceInvestmentSection.tsx
+++ b/components/client-dashboard/BuildEvidenceInvestmentSection.tsx
@@ -86,48 +86,48 @@ export default function BuildEvidenceInvestmentSection({ buildEvidence }: Props)
       value: formatNumber(repoMetrics.allBranchCommitCount),
       detail: `${formatNumber(repoMetrics.filesChanged)} files changed`,
       icon: GitCommit,
-      tone: 'border-blue-500/40 bg-blue-500/10 text-blue-300',
+      tone: 'border-radiant-gold/35 bg-radiant-gold/10 text-radiant-gold',
     },
     {
       label: 'Code + docs',
       value: formatCompact(repoMetrics.trackedTextLines),
       detail: `${formatNumber(repoMetrics.insertions)} insertions`,
       icon: Code2,
-      tone: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-300',
+      tone: 'border-gold-light/30 bg-gold-light/10 text-gold-light',
     },
     {
       label: 'Release gates',
       value: `${repoMetrics.releasePassCount}/${repoMetrics.releasePassCount + repoMetrics.releasePendingCount}`,
       detail: repoMetrics.releasePendingGate ? `${repoMetrics.releasePendingGate} pending` : 'No pending gate recorded',
       icon: ShieldCheck,
-      tone: 'border-amber-500/40 bg-amber-500/10 text-amber-300',
+      tone: 'border-bronze/45 bg-bronze/15 text-gold-light',
     },
     {
       label: 'Attributed tokens',
       value: formatCompact(tokenUsage.totalTokens),
       detail: `${tokenUsage.shareOfComparisonWindowPct.toFixed(2)}% of comparison window`,
       icon: Cpu,
-      tone: 'border-cyan-500/40 bg-cyan-500/10 text-cyan-300',
+      tone: 'border-radiant-gold/25 bg-silicon-slate/55 text-radiant-gold',
     },
   ]
 
   return (
-    <section className="rounded-xl border border-gray-800 bg-gray-900 p-5">
+    <section className="rounded-lg border border-radiant-gold/20 bg-silicon-slate/35 p-5 shadow-[0_20px_70px_rgba(0,0,0,0.24)]">
       <div className="mb-5 flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
         <div>
           <div className="mb-2 flex items-center gap-2">
-            <Gauge className="h-5 w-5 text-blue-400" />
-            <h3 className="text-sm font-medium uppercase tracking-wider text-gray-300">
+            <Gauge className="h-5 w-5 text-radiant-gold" />
+            <h3 className="text-sm font-medium uppercase tracking-wider text-radiant-gold">
               Build Evidence & Investment
             </h3>
           </div>
-          <p className="max-w-3xl text-sm text-gray-400">
+          <p className="max-w-3xl text-sm text-platinum-white/65">
             ReversR Rebuild is measured here as product-asset evidence. The numbers support replacement-cost and fixed-fee evaluation; they are not a time sheet.
           </p>
         </div>
-        <div className="rounded-lg border border-blue-500/30 bg-blue-500/10 px-3 py-2 text-xs text-blue-200">
+        <div className="rounded-lg border border-radiant-gold/30 bg-radiant-gold/10 px-3 py-2 text-xs text-gold-light">
           <p className="font-semibold">{sourceConfidence.label}</p>
-          <p className="mt-1 text-blue-200/80 capitalize">{sourceConfidence.confidence} confidence</p>
+          <p className="mt-1 text-platinum-white/60 capitalize">{sourceConfidence.confidence} confidence</p>
         </div>
       </div>
 
@@ -135,85 +135,85 @@ export default function BuildEvidenceInvestmentSection({ buildEvidence }: Props)
         {metricCards.map((card) => (
           <div key={card.label} className={`rounded-lg border p-4 ${card.tone}`}>
             <div className="mb-3 flex items-center justify-between gap-3">
-              <p className="text-xs font-medium uppercase tracking-wider text-gray-400">{card.label}</p>
+              <p className="text-xs font-medium uppercase tracking-wider text-platinum-white/55">{card.label}</p>
               <card.icon className="h-4 w-4" />
             </div>
-            <p className="text-2xl font-bold text-white">{card.value}</p>
-            <p className="mt-1 text-xs text-gray-400">{card.detail}</p>
+            <p className="text-2xl font-bold text-platinum-white">{card.value}</p>
+            <p className="mt-1 text-xs text-platinum-white/55">{card.detail}</p>
           </div>
         ))}
       </div>
 
       <div className="grid grid-cols-1 gap-5 lg:grid-cols-3">
-        <div className="rounded-lg border border-gray-800 bg-gray-950/45 p-4 lg:col-span-1">
+        <div className="rounded-lg border border-radiant-gold/15 bg-imperial-navy/55 p-4 lg:col-span-1">
           <div className="mb-3 flex items-center gap-2">
-            <Cpu className="h-4 w-4 text-cyan-300" />
-            <p className="text-xs font-semibold uppercase tracking-wider text-gray-400">Token attribution</p>
+            <Cpu className="h-4 w-4 text-radiant-gold" />
+            <p className="text-xs font-semibold uppercase tracking-wider text-radiant-gold">Token attribution</p>
           </div>
           <dl className="space-y-2 text-sm">
             <div className="flex justify-between gap-3">
-              <dt className="text-gray-500">Sessions</dt>
-              <dd className="font-medium text-gray-200">{formatNumber(tokenUsage.sessionCount)}</dd>
+              <dt className="text-platinum-white/45">Sessions</dt>
+              <dd className="font-medium text-platinum-white">{formatNumber(tokenUsage.sessionCount)}</dd>
             </div>
             <div className="flex justify-between gap-3">
-              <dt className="text-gray-500">Input tokens</dt>
-              <dd className="font-medium text-gray-200">{formatCompact(tokenUsage.inputTokens)}</dd>
+              <dt className="text-platinum-white/45">Input tokens</dt>
+              <dd className="font-medium text-platinum-white">{formatCompact(tokenUsage.inputTokens)}</dd>
             </div>
             <div className="flex justify-between gap-3">
-              <dt className="text-gray-500">Cached input</dt>
-              <dd className="font-medium text-gray-200">{formatCompact(tokenUsage.cachedInputTokens)}</dd>
+              <dt className="text-platinum-white/45">Cached input</dt>
+              <dd className="font-medium text-platinum-white">{formatCompact(tokenUsage.cachedInputTokens)}</dd>
             </div>
             <div className="flex justify-between gap-3">
-              <dt className="text-gray-500">Output + reasoning</dt>
-              <dd className="font-medium text-gray-200">
+              <dt className="text-platinum-white/45">Output + reasoning</dt>
+              <dd className="font-medium text-platinum-white">
                 {formatCompact(tokenUsage.outputTokens + tokenUsage.reasoningTokens)}
               </dd>
             </div>
           </dl>
-          <p className="mt-4 rounded-lg border border-cyan-500/20 bg-cyan-500/10 p-3 text-xs text-cyan-100/85">
+          <p className="mt-4 rounded-lg border border-radiant-gold/20 bg-radiant-gold/10 p-3 text-xs text-platinum-white/75">
             {sourceConfidence.sourceSummary}
           </p>
         </div>
 
-        <div className="rounded-lg border border-gray-800 bg-gray-950/45 p-4 lg:col-span-1">
+        <div className="rounded-lg border border-radiant-gold/15 bg-imperial-navy/55 p-4 lg:col-span-1">
           <div className="mb-3 flex items-center gap-2">
-            <DollarSign className="h-4 w-4 text-emerald-300" />
-            <p className="text-xs font-semibold uppercase tracking-wider text-gray-400">Token cost lens</p>
+            <DollarSign className="h-4 w-4 text-radiant-gold" />
+            <p className="text-xs font-semibold uppercase tracking-wider text-radiant-gold">Token cost lens</p>
           </div>
           <div className="space-y-3">
-            <div className="rounded-lg bg-gray-900/70 p-3">
-              <p className="text-xs uppercase tracking-wider text-gray-500">API-equivalent estimate</p>
-              <p className="mt-1 text-lg font-semibold text-white">
+            <div className="rounded-lg bg-silicon-slate/45 p-3">
+              <p className="text-xs uppercase tracking-wider text-platinum-white/45">API-equivalent estimate</p>
+              <p className="mt-1 text-lg font-semibold text-platinum-white">
                 {costSummary.apiEquivalentCostUsd == null ? 'Rate needed' : formatCurrency(costSummary.apiEquivalentCostUsd)}
               </p>
-              <p className="mt-1 text-xs text-gray-500">{costSummary.pricingSourceLabel}</p>
+              <p className="mt-1 text-xs text-platinum-white/45">{costSummary.pricingSourceLabel}</p>
             </div>
-            <div className="rounded-lg bg-gray-900/70 p-3">
-              <label className="text-xs uppercase tracking-wider text-gray-500" htmlFor="ai-monthly-spend">
+            <div className="rounded-lg bg-silicon-slate/45 p-3">
+              <label className="text-xs uppercase tracking-wider text-platinum-white/45" htmlFor="ai-monthly-spend">
                 Monthly AI spend
               </label>
               <div className="mt-2 flex items-center gap-2">
-                <span className="text-sm text-gray-500">$</span>
+                <span className="text-sm text-platinum-white/45">$</span>
                 <input
                   id="ai-monthly-spend"
                   type="number"
                   min="0"
                   value={monthlySpend}
                   onChange={(event) => setMonthlySpend(Number(event.target.value))}
-                  className="w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-gray-100 outline-none focus:border-blue-500"
+                  className="w-full rounded-lg border border-radiant-gold/15 bg-imperial-navy px-3 py-2 text-sm text-platinum-white outline-none focus:border-radiant-gold"
                 />
               </div>
-              <p className="mt-2 text-sm font-semibold text-emerald-300">
+              <p className="mt-2 text-sm font-semibold text-gold-light">
                 {formatCurrency(calculated.subscriptionAllocation)} allocated by usage share
               </p>
             </div>
           </div>
         </div>
 
-        <div className="rounded-lg border border-gray-800 bg-gray-950/45 p-4 lg:col-span-1">
+        <div className="rounded-lg border border-radiant-gold/15 bg-imperial-navy/55 p-4 lg:col-span-1">
           <div className="mb-3 flex items-center gap-2">
-            <Calculator className="h-4 w-4 text-blue-300" />
-            <p className="text-xs font-semibold uppercase tracking-wider text-gray-400">Hourly translation</p>
+            <Calculator className="h-4 w-4 text-radiant-gold" />
+            <p className="text-xs font-semibold uppercase tracking-wider text-radiant-gold">Hourly translation</p>
           </div>
           <div className="mb-3 grid grid-cols-3 gap-2">
             {(['rate', 'hours', 'proposal'] as CalculatorMode[]).map((nextMode) => (
@@ -223,8 +223,8 @@ export default function BuildEvidenceInvestmentSection({ buildEvidence }: Props)
                 onClick={() => setMode(nextMode)}
                 className={`rounded-lg border px-2 py-2 text-xs font-medium capitalize transition-colors ${
                   mode === nextMode
-                    ? 'border-blue-500 bg-blue-500/20 text-blue-100'
-                    : 'border-gray-700 bg-gray-900 text-gray-400 hover:text-gray-200'
+                    ? 'border-radiant-gold bg-radiant-gold/20 text-gold-light'
+                    : 'border-radiant-gold/15 bg-silicon-slate/45 text-platinum-white/55 hover:text-platinum-white'
                 }`}
               >
                 {nextMode}
@@ -232,50 +232,50 @@ export default function BuildEvidenceInvestmentSection({ buildEvidence }: Props)
             ))}
           </div>
           <div className="grid grid-cols-2 gap-3">
-            <label className="text-xs text-gray-500">
+            <label className="text-xs text-platinum-white/45">
               Rate
               <input
                 type="number"
                 min="0"
                 value={hourlyRate}
                 onChange={(event) => setHourlyRate(Number(event.target.value))}
-                className="mt-1 w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-gray-100 outline-none focus:border-blue-500"
+                className="mt-1 w-full rounded-lg border border-radiant-gold/15 bg-imperial-navy px-3 py-2 text-sm text-platinum-white outline-none focus:border-radiant-gold"
               />
             </label>
-            <label className="text-xs text-gray-500">
+            <label className="text-xs text-platinum-white/45">
               Proposal
               <input
                 type="number"
                 min="0"
                 value={proposalAmount}
                 onChange={(event) => setProposalAmount(Number(event.target.value))}
-                className="mt-1 w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-gray-100 outline-none focus:border-blue-500"
+                className="mt-1 w-full rounded-lg border border-radiant-gold/15 bg-imperial-navy px-3 py-2 text-sm text-platinum-white outline-none focus:border-radiant-gold"
               />
             </label>
-            <label className="text-xs text-gray-500">
+            <label className="text-xs text-platinum-white/45">
               Low hours
               <input
                 type="number"
                 min="0"
                 value={focusedHoursLow}
                 onChange={(event) => setFocusedHoursLow(Number(event.target.value))}
-                className="mt-1 w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-gray-100 outline-none focus:border-blue-500"
+                className="mt-1 w-full rounded-lg border border-radiant-gold/15 bg-imperial-navy px-3 py-2 text-sm text-platinum-white outline-none focus:border-radiant-gold"
               />
             </label>
-            <label className="text-xs text-gray-500">
+            <label className="text-xs text-platinum-white/45">
               High hours
               <input
                 type="number"
                 min="0"
                 value={focusedHoursHigh}
                 onChange={(event) => setFocusedHoursHigh(Number(event.target.value))}
-                className="mt-1 w-full rounded-lg border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-gray-100 outline-none focus:border-blue-500"
+                className="mt-1 w-full rounded-lg border border-radiant-gold/15 bg-imperial-navy px-3 py-2 text-sm text-platinum-white outline-none focus:border-radiant-gold"
               />
             </label>
           </div>
-          <div className="mt-4 rounded-lg border border-blue-500/25 bg-blue-500/10 p-3">
-            <p className="text-lg font-semibold text-white">{calculatorSummary}</p>
-            <p className="mt-1 text-xs text-blue-100/75">{hourlyTranslation.notes}</p>
+          <div className="mt-4 rounded-lg border border-radiant-gold/25 bg-radiant-gold/10 p-3">
+            <p className="text-lg font-semibold text-platinum-white">{calculatorSummary}</p>
+            <p className="mt-1 text-xs text-platinum-white/65">{hourlyTranslation.notes}</p>
           </div>
         </div>
       </div>
@@ -283,7 +283,7 @@ export default function BuildEvidenceInvestmentSection({ buildEvidence }: Props)
       {buildEvidence.clientSafeNotes.length > 0 && (
         <div className="mt-5 grid grid-cols-1 gap-2 md:grid-cols-3">
           {buildEvidence.clientSafeNotes.map((note) => (
-            <p key={note} className="rounded-lg border border-gray-800 bg-gray-950/50 p-3 text-xs text-gray-400">
+            <p key={note} className="rounded-lg border border-radiant-gold/15 bg-imperial-navy/50 p-3 text-xs text-platinum-white/60">
               {note}
             </p>
           ))}

--- a/components/client-dashboard/DashboardStatCards.tsx
+++ b/components/client-dashboard/DashboardStatCards.tsx
@@ -26,8 +26,8 @@ export default function DashboardStatCards({
       icon: BarChart3,
       delta: scoreDelta.percentage !== 0 ? `${scoreDelta.percentage > 0 ? '+' : ''}${scoreDelta.percentage}%` : null,
       deltaPositive: scoreDelta.percentage > 0,
-      color: 'from-blue-600/20 to-indigo-600/20 border-blue-500/50',
-      iconColor: 'text-blue-400',
+      color: 'from-radiant-gold/20 to-bronze/15 border-radiant-gold/45',
+      iconColor: 'text-radiant-gold',
     },
     {
       label: 'Tasks Completed',
@@ -35,8 +35,8 @@ export default function DashboardStatCards({
       icon: CheckSquare,
       delta: null,
       deltaPositive: false,
-      color: 'from-emerald-600/20 to-green-600/20 border-emerald-500/50',
-      iconColor: 'text-emerald-400',
+      color: 'from-silicon-slate/75 to-imperial-navy/70 border-radiant-gold/25',
+      iconColor: 'text-gold-light',
     },
     {
       label: 'Completion Rate',
@@ -44,8 +44,8 @@ export default function DashboardStatCards({
       icon: Target,
       delta: null,
       deltaPositive: false,
-      color: 'from-purple-600/20 to-violet-600/20 border-purple-500/50',
-      iconColor: 'text-purple-400',
+      color: 'from-silicon-slate/65 to-bronze/15 border-bronze/45',
+      iconColor: 'text-radiant-gold',
     },
     {
       label: 'High Priority',
@@ -53,8 +53,8 @@ export default function DashboardStatCards({
       icon: AlertTriangle,
       delta: null,
       deltaPositive: false,
-      color: 'from-rose-600/20 to-red-600/20 border-rose-500/50',
-      iconColor: 'text-rose-400',
+      color: 'from-bronze/20 to-imperial-navy/70 border-bronze/50',
+      iconColor: 'text-gold-light',
     },
   ]
 
@@ -63,22 +63,22 @@ export default function DashboardStatCards({
       {cards.map((card) => (
         <div
           key={card.label}
-          className={`bg-gradient-to-r ${card.color} border rounded-xl p-4 md:p-5`}
+          className={`bg-gradient-to-r ${card.color} border rounded-lg p-4 md:p-5 shadow-[0_18px_60px_rgba(0,0,0,0.22)]`}
         >
           <div className="flex items-center justify-between mb-2">
-            <span className="text-xs text-gray-400 uppercase tracking-wider">
+            <span className="text-xs text-platinum-white/60 uppercase tracking-wider">
               {card.label}
             </span>
             <card.icon className={`w-5 h-5 ${card.iconColor}`} />
           </div>
           <div className="flex items-end gap-2">
-            <span className="text-2xl md:text-3xl font-bold text-white font-heading">
+            <span className="text-2xl md:text-3xl font-bold text-platinum-white font-heading">
               {card.value}
             </span>
             {card.delta && (
               <span
                 className={`text-xs font-medium mb-1 ${
-                  card.deltaPositive ? 'text-green-400' : 'text-red-400'
+                  card.deltaPositive ? 'text-gold-light' : 'text-bronze'
                 }`}
               >
                 {card.delta}

--- a/components/client-dashboard/DocumentsSection.tsx
+++ b/components/client-dashboard/DocumentsSection.tsx
@@ -14,50 +14,50 @@ const typeConfig: Record<
   proposal: {
     icon: FileText,
     label: 'Proposal',
-    accent: 'text-blue-400',
-    bg: 'bg-blue-500/10',
+    accent: 'text-radiant-gold',
+    bg: 'bg-radiant-gold/10 border-radiant-gold/20',
   },
   contract: {
     icon: FileText,
     label: 'Contract',
-    accent: 'text-amber-400',
-    bg: 'bg-amber-500/10',
+    accent: 'text-gold-light',
+    bg: 'bg-bronze/15 border-bronze/30',
   },
   onboarding_plan: {
     icon: ClipboardList,
     label: 'Onboarding Plan',
-    accent: 'text-emerald-400',
-    bg: 'bg-emerald-500/10',
+    accent: 'text-gold-light',
+    bg: 'bg-silicon-slate/60 border-radiant-gold/15',
   },
   strategy_report: {
     icon: FileText,
     label: 'Strategy Report',
-    accent: 'text-indigo-400',
-    bg: 'bg-indigo-500/10',
+    accent: 'text-radiant-gold',
+    bg: 'bg-silicon-slate/60 border-radiant-gold/15',
   },
   opportunity_quantification: {
     icon: FileText,
     label: 'Opportunity Quantification',
-    accent: 'text-violet-400',
-    bg: 'bg-violet-500/10',
+    accent: 'text-gold-light',
+    bg: 'bg-bronze/15 border-bronze/30',
   },
   proposal_package: {
     icon: FileText,
     label: 'Proposal Package',
-    accent: 'text-cyan-400',
-    bg: 'bg-cyan-500/10',
+    accent: 'text-radiant-gold',
+    bg: 'bg-radiant-gold/10 border-radiant-gold/20',
   },
   onboarding_preview: {
     icon: ClipboardList,
     label: 'Onboarding Preview',
-    accent: 'text-teal-400',
-    bg: 'bg-teal-500/10',
+    accent: 'text-gold-light',
+    bg: 'bg-silicon-slate/60 border-radiant-gold/15',
   },
   other: {
     icon: FileText,
     label: 'Document',
-    accent: 'text-gray-400',
-    bg: 'bg-gray-500/10',
+    accent: 'text-platinum-white/70',
+    bg: 'bg-silicon-slate/50 border-platinum-white/10',
   },
 }
 
@@ -65,8 +65,8 @@ export default function DocumentsSection({ documents }: DocumentsSectionProps) {
   if (!documents || documents.length === 0) return null
 
   return (
-    <div className="bg-gray-900 rounded-xl border border-gray-800 p-5">
-      <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider mb-4">
+    <div className="rounded-lg border border-radiant-gold/20 bg-silicon-slate/35 p-5 shadow-[0_20px_70px_rgba(0,0,0,0.24)]">
+      <h3 className="text-sm font-medium text-radiant-gold uppercase tracking-wider mb-4">
         Documents &amp; Proposals
       </h3>
       <div className="space-y-3">
@@ -78,17 +78,17 @@ export default function DocumentsSection({ documents }: DocumentsSectionProps) {
           return (
             <div
               key={`${doc.type}-${doc.id}`}
-              className="flex items-center justify-between p-3 rounded-lg bg-gray-800/50 border border-gray-700/50"
+              className="flex items-center justify-between p-3 rounded-lg bg-imperial-navy/55 border border-radiant-gold/10"
             >
               <div className="flex items-center gap-3 min-w-0">
-                <div className={`p-2 rounded-lg ${config.bg}`}>
+                <div className={`p-2 rounded-lg border ${config.bg}`}>
                   <Icon className={`w-4 h-4 ${config.accent}`} />
                 </div>
                 <div className="min-w-0">
-                  <p className="text-sm font-medium text-gray-200 truncate">
+                  <p className="text-sm font-medium text-platinum-white truncate">
                     {doc.title}
                   </p>
-                  <p className="text-xs text-gray-500">
+                  <p className="text-xs text-platinum-white/50">
                     {config.label} &middot;{' '}
                     {new Date(doc.created_at).toLocaleDateString('en-US', {
                       month: 'short',
@@ -103,13 +103,13 @@ export default function DocumentsSection({ documents }: DocumentsSectionProps) {
                   href={downloadUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-gray-300 bg-gray-700/50 hover:bg-gray-700 rounded-lg transition-colors shrink-0"
+                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold text-imperial-navy bg-radiant-gold hover:bg-gold-light rounded-lg transition-colors shrink-0"
                 >
                   <Download className="w-3.5 h-3.5" />
                   PDF
                 </a>
               ) : (
-                <span className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-gray-500 shrink-0">
+                <span className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-platinum-white/45 shrink-0">
                   <ExternalLink className="w-3.5 h-3.5" />
                   Pending
                 </span>

--- a/components/client-dashboard/GapAnalysisPanel.tsx
+++ b/components/client-dashboard/GapAnalysisPanel.tsx
@@ -8,39 +8,39 @@ interface GapAnalysisPanelProps {
 
 export default function GapAnalysisPanel({ gaps }: GapAnalysisPanelProps) {
   return (
-    <div className="bg-gray-900 rounded-xl border border-gray-800 p-5">
-      <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider mb-4">
+    <div className="rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-5">
+      <h3 className="text-sm font-medium text-radiant-gold uppercase tracking-wider mb-4">
         Gap Analysis: Current vs Dream Outcome
       </h3>
       <div className="space-y-4">
         {gaps.map((gap) => (
           <div key={gap.category}>
             <div className="flex items-center justify-between mb-1.5">
-              <span className="text-sm text-gray-300">{gap.label}</span>
-              <span className="text-xs text-gray-500">
+              <span className="text-sm text-platinum-white/85">{gap.label}</span>
+              <span className="text-xs text-platinum-white/50">
                 {gap.currentScore} / {gap.dreamScore}
               </span>
             </div>
-            <div className="relative h-3 bg-gray-800 rounded-full overflow-hidden">
+            <div className="relative h-3 bg-imperial-navy/70 rounded-full overflow-hidden border border-radiant-gold/10">
               {/* Dream target marker */}
               <div
-                className="absolute top-0 h-full w-0.5 bg-indigo-500 z-10"
+                className="absolute top-0 h-full w-0.5 bg-gold-light z-10"
                 style={{ left: `${gap.dreamScore}%` }}
               />
               {/* Current score bar */}
               <div
                 className={`h-full rounded-full transition-all duration-500 ${
                   gap.gap <= 15
-                    ? 'bg-green-500'
+                    ? 'bg-gold-light'
                     : gap.gap <= 35
-                      ? 'bg-yellow-500'
-                      : 'bg-red-500'
+                      ? 'bg-radiant-gold'
+                      : 'bg-bronze'
                 }`}
                 style={{ width: `${gap.currentScore}%` }}
               />
             </div>
             {gap.gap > 0 && (
-              <p className="text-xs text-gray-500 mt-1">
+              <p className="text-xs text-platinum-white/50 mt-1">
                 {gap.gap} points to close ({gap.gapPercentage}% remaining)
               </p>
             )}

--- a/components/client-dashboard/MeetingHistory.tsx
+++ b/components/client-dashboard/MeetingHistory.tsx
@@ -52,8 +52,8 @@ export default function MeetingHistory({ token }: MeetingHistoryProps) {
 
   if (loading) {
     return (
-      <div className="bg-gray-900 rounded-xl border border-gray-800 p-5">
-        <div className="flex items-center gap-2 text-gray-500 text-sm">
+      <div className="rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-5">
+        <div className="flex items-center gap-2 text-platinum-white/55 text-sm">
           <Loader2 className="w-4 h-4 animate-spin" />
           Loading meetings...
         </div>
@@ -64,8 +64,8 @@ export default function MeetingHistory({ token }: MeetingHistoryProps) {
   if (meetings.length === 0) return null
 
   return (
-    <div className="bg-gray-900 rounded-xl border border-gray-800 p-5">
-      <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider mb-4 flex items-center gap-2">
+    <div className="rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-5">
+      <h3 className="text-sm font-medium text-radiant-gold uppercase tracking-wider mb-4 flex items-center gap-2">
         <Video className="w-4 h-4" />
         Meeting History
       </h3>
@@ -82,21 +82,21 @@ export default function MeetingHistory({ token }: MeetingHistoryProps) {
           return (
             <div
               key={meeting.id}
-              className="border border-gray-800 rounded-lg overflow-hidden"
+              className="border border-radiant-gold/10 rounded-lg overflow-hidden bg-imperial-navy/40"
             >
               <button
                 onClick={() => setExpandedId(isExpanded ? null : meeting.id)}
-                className="w-full flex items-center justify-between p-3 hover:bg-gray-800/50 transition-colors text-left"
+                className="w-full flex items-center justify-between p-3 hover:bg-radiant-gold/10 transition-colors text-left"
               >
                 <div className="flex items-center gap-3 min-w-0">
-                  <div className="w-8 h-8 rounded-lg bg-indigo-500/10 flex items-center justify-center shrink-0">
-                    <MessageSquare className="w-4 h-4 text-indigo-400" />
+                  <div className="w-8 h-8 rounded-lg bg-radiant-gold/10 border border-radiant-gold/20 flex items-center justify-center shrink-0">
+                    <MessageSquare className="w-4 h-4 text-radiant-gold" />
                   </div>
                   <div className="min-w-0">
-                    <p className="text-sm font-medium text-gray-200 capitalize">
+                    <p className="text-sm font-medium text-platinum-white capitalize">
                       {meeting.meeting_type?.replace(/_/g, ' ') || 'Meeting'}
                     </p>
-                    <p className="text-xs text-gray-500">
+                    <p className="text-xs text-platinum-white/45">
                       {new Date(meeting.meeting_date).toLocaleDateString('en-US', {
                         weekday: 'short',
                         month: 'short',
@@ -116,32 +116,32 @@ export default function MeetingHistory({ token }: MeetingHistoryProps) {
                       target="_blank"
                       rel="noopener noreferrer"
                       onClick={(e) => e.stopPropagation()}
-                      className="p-1.5 rounded-md bg-gray-800 hover:bg-gray-700 transition-colors"
+                      className="p-1.5 rounded-md bg-silicon-slate/60 hover:bg-radiant-gold/10 transition-colors"
                       title="View recording"
                     >
-                      <ExternalLink className="w-3.5 h-3.5 text-gray-400" />
+                      <ExternalLink className="w-3.5 h-3.5 text-radiant-gold/75" />
                     </a>
                   )}
                   {hasDetails && (
                     isExpanded ? (
-                      <ChevronUp className="w-4 h-4 text-gray-500" />
+                      <ChevronUp className="w-4 h-4 text-radiant-gold/60" />
                     ) : (
-                      <ChevronDown className="w-4 h-4 text-gray-500" />
+                      <ChevronDown className="w-4 h-4 text-radiant-gold/60" />
                     )
                   )}
                 </div>
               </button>
 
               {isExpanded && hasDetails && (
-                <div className="px-3 pb-3 space-y-3 border-t border-gray-800 pt-3">
+                <div className="px-3 pb-3 space-y-3 border-t border-radiant-gold/10 pt-3">
                   {meeting.key_decisions && meeting.key_decisions.length > 0 && (
                     <div>
-                      <p className="text-xs font-medium text-gray-500 uppercase mb-1.5 flex items-center gap-1">
+                      <p className="text-xs font-medium text-platinum-white/50 uppercase mb-1.5 flex items-center gap-1">
                         <CheckSquare className="w-3 h-3" /> Key Decisions
                       </p>
                       <ul className="space-y-1">
                         {meeting.key_decisions.map((d, i) => (
-                          <li key={i} className="text-xs text-gray-300 pl-3 relative before:content-[''] before:absolute before:left-0 before:top-1.5 before:w-1.5 before:h-1.5 before:rounded-full before:bg-emerald-500/50">
+                          <li key={i} className="text-xs text-platinum-white/75 pl-3 relative before:content-[''] before:absolute before:left-0 before:top-1.5 before:w-1.5 before:h-1.5 before:rounded-full before:bg-radiant-gold/70">
                             {d}
                           </li>
                         ))}
@@ -151,21 +151,21 @@ export default function MeetingHistory({ token }: MeetingHistoryProps) {
 
                   {meeting.action_items && meeting.action_items.length > 0 && (
                     <div>
-                      <p className="text-xs font-medium text-gray-500 uppercase mb-1.5">
+                      <p className="text-xs font-medium text-platinum-white/50 uppercase mb-1.5">
                         Action Items
                       </p>
                       <ul className="space-y-1">
                         {meeting.action_items.map((item, i) => (
-                          <li key={i} className="text-xs text-gray-300 flex items-start gap-2">
+                          <li key={i} className="text-xs text-platinum-white/75 flex items-start gap-2">
                             <span className={`shrink-0 mt-0.5 w-3 h-3 rounded border ${
                               item.status === 'done'
-                                ? 'bg-emerald-500/30 border-emerald-500/50'
-                                : 'border-gray-600'
+                                ? 'bg-radiant-gold/30 border-radiant-gold/60'
+                                : 'border-platinum-white/25'
                             }`} />
                             <span>
                               {item.task}
                               {item.owner && (
-                                <span className="text-gray-500 ml-1">({item.owner})</span>
+                                <span className="text-platinum-white/45 ml-1">({item.owner})</span>
                               )}
                             </span>
                           </li>
@@ -176,12 +176,12 @@ export default function MeetingHistory({ token }: MeetingHistoryProps) {
 
                   {meeting.open_questions && meeting.open_questions.length > 0 && (
                     <div>
-                      <p className="text-xs font-medium text-gray-500 uppercase mb-1.5 flex items-center gap-1">
+                      <p className="text-xs font-medium text-platinum-white/50 uppercase mb-1.5 flex items-center gap-1">
                         <HelpCircle className="w-3 h-3" /> Open Questions
                       </p>
                       <ul className="space-y-1">
                         {meeting.open_questions.map((q, i) => (
-                          <li key={i} className="text-xs text-gray-400 pl-3 relative before:content-['?'] before:absolute before:left-0 before:text-yellow-500/60">
+                          <li key={i} className="text-xs text-platinum-white/65 pl-3 relative before:content-['?'] before:absolute before:left-0 before:text-radiant-gold/70">
                             {q}
                           </li>
                         ))}

--- a/components/client-dashboard/MilestoneTimeline.test.tsx
+++ b/components/client-dashboard/MilestoneTimeline.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import MilestoneTimeline from './MilestoneTimeline'
+import type { Milestone } from '@/lib/onboarding-templates'
+
+describe('MilestoneTimeline', () => {
+  it('renders milestone evidence and automation without exposing local paths', () => {
+    const milestones: Milestone[] = [
+      {
+        id: 'm0',
+        week: 0,
+        title: 'Distribute the test app',
+        description: 'Ship the test app to internal testers.',
+        deliverables: ['Tester access'],
+        phase: 1,
+        status: 'in_progress',
+        evidence: [
+          {
+            id: 'e1',
+            source_type: 'github',
+            source_label: 'GitHub repository evidence',
+            summary:
+              'Verified from /Users/example/private/ReversR logs and repository metrics.',
+            confidence: 'high',
+            status: 'verified',
+            source_url: 'https://github.com/vsillah/ReversR-Rebuild',
+            is_client_visible: true,
+          },
+          {
+            id: 'e2',
+            source_type: 'app_store_connect',
+            source_label: 'Store-console records',
+            summary: 'Apple and Google access are required.',
+            confidence: 'medium',
+            status: 'access_needed',
+            is_client_visible: true,
+          },
+          {
+            id: 'private',
+            source_type: 'manual',
+            source_label: 'Private note',
+            summary: 'Do not render',
+            confidence: 'low',
+            status: 'manual_review',
+            is_client_visible: false,
+          },
+        ],
+        automation: {
+          source: 'hybrid',
+          status: 'access_needed',
+          summary:
+            'GitHub can support build evidence; /Users/example/private/store records require platform access.',
+        },
+      },
+    ]
+
+    render(<MilestoneTimeline milestones={milestones} />)
+
+    expect(screen.getByText('Evidence Trace')).toBeInTheDocument()
+    expect(screen.getByText('GitHub repository evidence')).toBeInTheDocument()
+    expect(screen.getByText('Store-console records')).toBeInTheDocument()
+    expect(screen.getByText('Access Needed')).toBeInTheDocument()
+    expect(screen.getByText(/High confidence/i)).toBeInTheDocument()
+    expect(screen.queryByText('Private note')).not.toBeInTheDocument()
+    expect(screen.queryByText(/\/Users\/example/)).not.toBeInTheDocument()
+    expect(screen.getAllByText(/\[private path\]/)).toHaveLength(2)
+  })
+})

--- a/components/client-dashboard/MilestoneTimeline.test.tsx
+++ b/components/client-dashboard/MilestoneTimeline.test.tsx
@@ -67,6 +67,7 @@ describe('MilestoneTimeline', () => {
     expect(screen.getByText('38')).toBeInTheDocument()
     expect(screen.getByText('passed release gates')).toBeInTheDocument()
     expect(screen.getByText('Connection needed: App Store Connect + Google Play')).toBeInTheDocument()
+    expect(screen.queryByText(/Automation:/)).not.toBeInTheDocument()
     expect(screen.queryByText('Private note')).not.toBeInTheDocument()
     expect(screen.queryByText(/\/Users\/example/)).not.toBeInTheDocument()
     expect(screen.queryByText(/\[private path\]/)).not.toBeInTheDocument()

--- a/components/client-dashboard/MilestoneTimeline.test.tsx
+++ b/components/client-dashboard/MilestoneTimeline.test.tsx
@@ -20,7 +20,7 @@ describe('MilestoneTimeline', () => {
             source_type: 'github',
             source_label: 'GitHub repository evidence',
             summary:
-              'Verified from /Users/example/private/ReversR logs and repository metrics.',
+              'Verified from /Users/example/private/ReversR logs with 149 all-branch commits, 36,775 tracked code/doc/config lines, and 38 passed release gates.',
             confidence: 'high',
             status: 'verified',
             source_url: 'https://github.com/vsillah/ReversR-Rebuild',
@@ -60,9 +60,16 @@ describe('MilestoneTimeline', () => {
     expect(screen.getByText('GitHub repository evidence')).toBeInTheDocument()
     expect(screen.getByText('Store-console records')).toBeInTheDocument()
     expect(screen.getByText('Access Needed')).toBeInTheDocument()
-    expect(screen.getByText(/High confidence/i)).toBeInTheDocument()
+    expect(screen.getByText('149')).toBeInTheDocument()
+    expect(screen.getByText('all-branch commits')).toBeInTheDocument()
+    expect(screen.getByText('36,775')).toBeInTheDocument()
+    expect(screen.getByText('tracked code/doc/config lines')).toBeInTheDocument()
+    expect(screen.getByText('38')).toBeInTheDocument()
+    expect(screen.getByText('passed release gates')).toBeInTheDocument()
+    expect(screen.getByText('Connection needed: App Store Connect + Google Play')).toBeInTheDocument()
     expect(screen.queryByText('Private note')).not.toBeInTheDocument()
     expect(screen.queryByText(/\/Users\/example/)).not.toBeInTheDocument()
-    expect(screen.getAllByText(/\[private path\]/)).toHaveLength(2)
+    expect(screen.queryByText(/\[private path\]/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Verified from/)).not.toBeInTheDocument()
   })
 })

--- a/components/client-dashboard/MilestoneTimeline.tsx
+++ b/components/client-dashboard/MilestoneTimeline.tsx
@@ -119,26 +119,42 @@ function conciseEvidenceStatement(item: MilestoneEvidence) {
   return null
 }
 
-function AutomationHint({ automation }: { automation?: MilestoneAutomation }) {
+function AutomationHint({
+  automation,
+  evidence,
+}: {
+  automation?: MilestoneAutomation
+  evidence: MilestoneEvidence[]
+}) {
   if (!automation) return null
 
   const needsAccess = automation.status === 'access_needed'
-  const text = needsAccess
-    ? `Connection needed: ${connectionNeededLabel({
+  const accessTarget = needsAccess
+    ? connectionNeededLabel({
         source_label: automation.source,
         summary: automation.summary,
-      })}`
-    : automation.next_check || automation.summary
+      })
+    : null
+  const text = accessTarget || automation.next_check || automation.summary
+  const duplicateAccess = needsAccess && evidence.some((item) => {
+    if (item.status !== 'access_needed') return false
+    return connectionNeededLabel(item) === accessTarget
+  })
+
+  if (duplicateAccess) return null
+
+  const LabelIcon = needsAccess ? KeyRound : GitBranch
+  const label = needsAccess ? 'Connection needed: ' : 'Next check: '
 
   return (
     <div className="mt-2 flex items-start gap-2 rounded border border-radiant-gold/10 bg-imperial-navy/50 p-2">
-      {needsAccess ? (
-        <KeyRound className="mt-0.5 h-3.5 w-3.5 shrink-0 text-gold-light" />
-      ) : (
-        <GitBranch className="mt-0.5 h-3.5 w-3.5 shrink-0 text-radiant-gold" />
-      )}
+      <LabelIcon
+        className={`mt-0.5 h-3.5 w-3.5 shrink-0 ${
+          needsAccess ? 'text-gold-light' : 'text-radiant-gold'
+        }`}
+      />
       <p className="text-[11px] leading-relaxed text-platinum-white/60">
-        <span className="font-medium text-platinum-white/80">Automation: </span>
+        <span className="font-medium text-platinum-white/80">{label}</span>
         {sanitizeClientText(text)}
       </p>
     </div>
@@ -258,7 +274,7 @@ export default function MilestoneTimeline({ milestones }: MilestoneTimelineProps
                     </div>
                   </div>
                 )}
-                <AutomationHint automation={milestone.automation} />
+                <AutomationHint automation={milestone.automation} evidence={evidence} />
               </div>
             </div>
           )

--- a/components/client-dashboard/MilestoneTimeline.tsx
+++ b/components/client-dashboard/MilestoneTimeline.tsx
@@ -1,16 +1,19 @@
 'use client'
 
-import { Check, Clock, Circle } from 'lucide-react'
-
-interface Milestone {
-  week: number | string
-  title: string
-  description: string
-  deliverables: string[]
-  phase: number
-  target_date?: string
-  status: 'pending' | 'in_progress' | 'complete' | 'skipped'
-}
+import {
+  Check,
+  Clock,
+  Circle,
+  ExternalLink,
+  GitBranch,
+  KeyRound,
+  ShieldCheck,
+} from 'lucide-react'
+import type {
+  Milestone,
+  MilestoneAutomation,
+  MilestoneEvidence,
+} from '@/lib/onboarding-templates'
 
 interface MilestoneTimelineProps {
   milestones: Milestone[]
@@ -47,6 +50,54 @@ const STATUS_STYLES = {
   },
 }
 
+const EVIDENCE_STATUS_STYLES = {
+  verified: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300',
+  pending: 'border-gray-700 bg-gray-800/70 text-gray-300',
+  access_needed: 'border-amber-500/30 bg-amber-500/10 text-amber-300',
+  manual_review: 'border-blue-500/30 bg-blue-500/10 text-blue-300',
+}
+
+const CONFIDENCE_LABELS = {
+  high: 'High confidence',
+  medium: 'Medium confidence',
+  low: 'Low confidence',
+}
+
+function clientVisibleEvidence(milestone: Milestone): MilestoneEvidence[] {
+  return (milestone.evidence || []).filter((item) => item.is_client_visible !== false)
+}
+
+function evidenceStatusLabel(status: MilestoneEvidence['status']) {
+  return status
+    .split('_')
+    .map((word) => word[0]?.toUpperCase() + word.slice(1))
+    .join(' ')
+}
+
+function sanitizeClientText(value: string) {
+  return value.replace(/\/Users\/[^\s)]+/g, '[private path]')
+}
+
+function AutomationHint({ automation }: { automation?: MilestoneAutomation }) {
+  if (!automation) return null
+
+  const needsAccess = automation.status === 'access_needed'
+
+  return (
+    <div className="mt-2 flex items-start gap-2 rounded border border-gray-800 bg-gray-950/60 p-2">
+      {needsAccess ? (
+        <KeyRound className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-300" />
+      ) : (
+        <GitBranch className="mt-0.5 h-3.5 w-3.5 shrink-0 text-blue-300" />
+      )}
+      <p className="text-[11px] leading-relaxed text-gray-400">
+        <span className="font-medium text-gray-300">Automation: </span>
+        {sanitizeClientText(automation.summary)}
+      </p>
+    </div>
+  )
+}
+
 export default function MilestoneTimeline({ milestones }: MilestoneTimelineProps) {
   if (!milestones || milestones.length === 0) {
     return (
@@ -69,9 +120,10 @@ export default function MilestoneTimeline({ milestones }: MilestoneTimelineProps
           const styles = STATUS_STYLES[milestone.status] || STATUS_STYLES.pending
           const Icon = styles.icon
           const isLast = index === milestones.length - 1
+          const evidence = clientVisibleEvidence(milestone)
 
           return (
-            <div key={index} className="flex gap-4 pb-6 last:pb-0">
+            <div key={milestone.id || index} className="flex gap-4 pb-6 last:pb-0">
               {/* Timeline dot + line */}
               <div className="flex flex-col items-center">
                 <div
@@ -109,6 +161,53 @@ export default function MilestoneTimeline({ milestones }: MilestoneTimelineProps
                     Target: {new Date(milestone.target_date).toLocaleDateString()}
                   </p>
                 )}
+                {evidence.length > 0 && (
+                  <div className="mt-3">
+                    <div className="mb-1.5 flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-wider text-gray-500">
+                      <ShieldCheck className="h-3 w-3" />
+                      Evidence Trace
+                    </div>
+                    <div className="space-y-1.5">
+                      {evidence.map((item, evidenceIndex) => {
+                        const statusClass =
+                          EVIDENCE_STATUS_STYLES[item.status] || EVIDENCE_STATUS_STYLES.pending
+                        return (
+                          <div
+                            key={item.id || evidenceIndex}
+                            className={`rounded border px-2 py-1.5 ${statusClass}`}
+                          >
+                            <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                              <span className="text-[11px] font-medium">
+                                {item.source_label}
+                              </span>
+                              <span className="text-[10px] opacity-80">
+                                {evidenceStatusLabel(item.status)}
+                              </span>
+                              <span className="text-[10px] opacity-70">
+                                {CONFIDENCE_LABELS[item.confidence]}
+                              </span>
+                              {item.source_url && (
+                                <a
+                                  href={item.source_url}
+                                  target="_blank"
+                                  rel="noreferrer"
+                                  className="inline-flex items-center gap-1 text-[10px] underline-offset-2 hover:underline"
+                                >
+                                  Source
+                                  <ExternalLink className="h-2.5 w-2.5" />
+                                </a>
+                              )}
+                            </div>
+                            <p className="mt-1 text-[11px] leading-relaxed opacity-85">
+                              {sanitizeClientText(item.summary)}
+                            </p>
+                          </div>
+                        )
+                      })}
+                    </div>
+                  </div>
+                )}
+                <AutomationHint automation={milestone.automation} />
               </div>
             </div>
           )

--- a/components/client-dashboard/MilestoneTimeline.tsx
+++ b/components/client-dashboard/MilestoneTimeline.tsx
@@ -22,39 +22,39 @@ interface MilestoneTimelineProps {
 const STATUS_STYLES = {
   complete: {
     icon: Check,
-    dotClass: 'bg-green-500 border-green-400',
-    lineClass: 'bg-green-500',
-    textClass: 'text-green-300',
-    badgeClass: 'bg-green-900/50 text-green-300',
+    dotClass: 'bg-gold-light border-radiant-gold',
+    lineClass: 'bg-gold-light',
+    textClass: 'text-gold-light',
+    badgeClass: 'bg-radiant-gold/15 text-gold-light border border-radiant-gold/25',
   },
   in_progress: {
     icon: Clock,
-    dotClass: 'bg-blue-500 border-blue-400 animate-pulse',
-    lineClass: 'bg-blue-500',
-    textClass: 'text-blue-300',
-    badgeClass: 'bg-blue-900/50 text-blue-300',
+    dotClass: 'bg-radiant-gold border-gold-light animate-pulse',
+    lineClass: 'bg-radiant-gold',
+    textClass: 'text-radiant-gold',
+    badgeClass: 'bg-radiant-gold/15 text-radiant-gold border border-radiant-gold/25',
   },
   pending: {
     icon: Circle,
-    dotClass: 'bg-gray-700 border-gray-600',
-    lineClass: 'bg-gray-700',
-    textClass: 'text-gray-500',
-    badgeClass: 'bg-gray-800 text-gray-500',
+    dotClass: 'bg-silicon-slate border-platinum-white/20',
+    lineClass: 'bg-platinum-white/15',
+    textClass: 'text-platinum-white/55',
+    badgeClass: 'bg-silicon-slate/60 text-platinum-white/50 border border-platinum-white/10',
   },
   skipped: {
     icon: Circle,
-    dotClass: 'bg-gray-800 border-gray-700',
-    lineClass: 'bg-gray-800',
-    textClass: 'text-gray-600 line-through',
-    badgeClass: 'bg-gray-800/50 text-gray-600',
+    dotClass: 'bg-imperial-navy border-platinum-white/10',
+    lineClass: 'bg-platinum-white/10',
+    textClass: 'text-platinum-white/35 line-through',
+    badgeClass: 'bg-imperial-navy/50 text-platinum-white/35 border border-platinum-white/10',
   },
 }
 
 const EVIDENCE_STATUS_STYLES = {
-  verified: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300',
-  pending: 'border-gray-700 bg-gray-800/70 text-gray-300',
-  access_needed: 'border-amber-500/30 bg-amber-500/10 text-amber-300',
-  manual_review: 'border-blue-500/30 bg-blue-500/10 text-blue-300',
+  verified: 'border-radiant-gold/35 bg-radiant-gold/10 text-gold-light',
+  pending: 'border-platinum-white/10 bg-silicon-slate/60 text-platinum-white/70',
+  access_needed: 'border-bronze/45 bg-bronze/15 text-gold-light',
+  manual_review: 'border-radiant-gold/25 bg-silicon-slate/70 text-radiant-gold',
 }
 
 const CONFIDENCE_LABELS = {
@@ -84,14 +84,14 @@ function AutomationHint({ automation }: { automation?: MilestoneAutomation }) {
   const needsAccess = automation.status === 'access_needed'
 
   return (
-    <div className="mt-2 flex items-start gap-2 rounded border border-gray-800 bg-gray-950/60 p-2">
+    <div className="mt-2 flex items-start gap-2 rounded border border-radiant-gold/10 bg-imperial-navy/50 p-2">
       {needsAccess ? (
-        <KeyRound className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-300" />
+        <KeyRound className="mt-0.5 h-3.5 w-3.5 shrink-0 text-gold-light" />
       ) : (
-        <GitBranch className="mt-0.5 h-3.5 w-3.5 shrink-0 text-blue-300" />
+        <GitBranch className="mt-0.5 h-3.5 w-3.5 shrink-0 text-radiant-gold" />
       )}
-      <p className="text-[11px] leading-relaxed text-gray-400">
-        <span className="font-medium text-gray-300">Automation: </span>
+      <p className="text-[11px] leading-relaxed text-platinum-white/60">
+        <span className="font-medium text-platinum-white/80">Automation: </span>
         {sanitizeClientText(automation.summary)}
       </p>
     </div>
@@ -101,18 +101,18 @@ function AutomationHint({ automation }: { automation?: MilestoneAutomation }) {
 export default function MilestoneTimeline({ milestones }: MilestoneTimelineProps) {
   if (!milestones || milestones.length === 0) {
     return (
-      <div className="bg-gray-900 rounded-xl border border-gray-800 p-5">
-        <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider mb-4">
+      <div className="rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-5">
+        <h3 className="text-sm font-medium text-radiant-gold uppercase tracking-wider mb-4">
           Milestones
         </h3>
-        <p className="text-gray-500 text-sm">No milestones set yet.</p>
+        <p className="text-platinum-white/55 text-sm">No milestones set yet.</p>
       </div>
     )
   }
 
   return (
-    <div className="bg-gray-900 rounded-xl border border-gray-800 p-5">
-      <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider mb-4">
+    <div className="rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-5">
+      <h3 className="text-sm font-medium text-radiant-gold uppercase tracking-wider mb-4">
         Milestones
       </h3>
       <div className="relative">
@@ -129,7 +129,7 @@ export default function MilestoneTimeline({ milestones }: MilestoneTimelineProps
                 <div
                   className={`w-8 h-8 rounded-full border-2 flex items-center justify-center flex-shrink-0 ${styles.dotClass}`}
                 >
-                  <Icon className="w-4 h-4 text-white" />
+                  <Icon className="w-4 h-4 text-platinum-white" />
                 </div>
                 {!isLast && (
                   <div className={`w-0.5 flex-1 mt-1 ${styles.lineClass}`} />
@@ -146,24 +146,24 @@ export default function MilestoneTimeline({ milestones }: MilestoneTimelineProps
                     Week {milestone.week}
                   </span>
                 </div>
-                <p className="text-xs text-gray-500 mb-1">{milestone.description}</p>
+                <p className="text-xs text-platinum-white/55 mb-1">{milestone.description}</p>
                 {milestone.deliverables && milestone.deliverables.length > 0 && (
-                  <ul className="text-xs text-gray-600 space-y-0.5">
+                  <ul className="text-xs text-platinum-white/40 space-y-0.5">
                     {milestone.deliverables.map((d, di) => (
                       <li key={di} className="flex items-center gap-1">
-                        <span className="text-gray-700">•</span> {d}
+                        <span className="text-radiant-gold/50">•</span> {d}
                       </li>
                     ))}
                   </ul>
                 )}
                 {milestone.target_date && (
-                  <p className="text-[10px] text-gray-600 mt-1">
+                  <p className="text-[10px] text-platinum-white/40 mt-1">
                     Target: {new Date(milestone.target_date).toLocaleDateString()}
                   </p>
                 )}
                 {evidence.length > 0 && (
                   <div className="mt-3">
-                    <div className="mb-1.5 flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-wider text-gray-500">
+                    <div className="mb-1.5 flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-wider text-radiant-gold/70">
                       <ShieldCheck className="h-3 w-3" />
                       Evidence Trace
                     </div>

--- a/components/client-dashboard/MilestoneTimeline.tsx
+++ b/components/client-dashboard/MilestoneTimeline.tsx
@@ -57,11 +57,13 @@ const EVIDENCE_STATUS_STYLES = {
   manual_review: 'border-radiant-gold/25 bg-silicon-slate/70 text-radiant-gold',
 }
 
-const CONFIDENCE_LABELS = {
-  high: 'High confidence',
-  medium: 'Medium confidence',
-  low: 'Low confidence',
-}
+const METRIC_PATTERNS: Array<{ pattern: RegExp; label: string }> = [
+  { pattern: /(\d[\d,]*)\s+all-branch commits/i, label: 'all-branch commits' },
+  { pattern: /(\d[\d,]*)\s+tracked code\/doc\/config lines/i, label: 'tracked code/doc/config lines' },
+  { pattern: /(\d[\d,]*)\s+passed release gates/i, label: 'passed release gates' },
+  { pattern: /(\d[\d,]*)\s+pending store-console gate/i, label: 'pending store-console gate' },
+  { pattern: /(\d[\d,]*)[-\s]+tester GO threshold/i, label: 'tester GO threshold' },
+]
 
 function clientVisibleEvidence(milestone: Milestone): MilestoneEvidence[] {
   return (milestone.evidence || []).filter((item) => item.is_client_visible !== false)
@@ -78,10 +80,55 @@ function sanitizeClientText(value: string) {
   return value.replace(/\/Users\/[^\s)]+/g, '[private path]')
 }
 
+function knownEvidenceMetrics(item: MilestoneEvidence) {
+  const text = `${item.source_label} ${item.summary}`
+  return METRIC_PATTERNS.flatMap(({ pattern, label }) => {
+    const match = text.match(pattern)
+    return match?.[1] ? [{ value: match[1], label }] : []
+  })
+}
+
+function connectionNeededLabel(item: Pick<MilestoneEvidence, 'source_label' | 'summary'>) {
+  const text = `${item.source_label} ${item.summary}`.toLowerCase()
+  const connections: string[] = []
+
+  if (text.includes('app store') || text.includes('apple')) {
+    connections.push('App Store Connect')
+  }
+  if (text.includes('google play') || text.includes('google')) {
+    connections.push('Google Play')
+  }
+  if (text.includes('stripe')) {
+    connections.push('Stripe')
+  }
+  if (text.includes('website') || text.includes('vanguardenterprises.com')) {
+    connections.push('Website')
+  }
+
+  if (connections.length > 0) return connections.join(' + ')
+  if (text.includes('store') || text.includes('platform')) return 'Store platform access'
+  return item.source_label
+}
+
+function conciseEvidenceStatement(item: MilestoneEvidence) {
+  if (item.status === 'access_needed') {
+    return `Connection needed: ${connectionNeededLabel(item)}`
+  }
+  if (item.status === 'pending') return 'Pending evidence'
+  if (item.status === 'manual_review') return 'Manual review needed'
+  return null
+}
+
 function AutomationHint({ automation }: { automation?: MilestoneAutomation }) {
   if (!automation) return null
 
   const needsAccess = automation.status === 'access_needed'
+  const text = needsAccess
+    ? `Connection needed: ${connectionNeededLabel({
+        source_label: automation.source,
+        summary: automation.summary,
+      })}`
+    : automation.next_check || automation.summary
 
   return (
     <div className="mt-2 flex items-start gap-2 rounded border border-radiant-gold/10 bg-imperial-navy/50 p-2">
@@ -92,7 +139,7 @@ function AutomationHint({ automation }: { automation?: MilestoneAutomation }) {
       )}
       <p className="text-[11px] leading-relaxed text-platinum-white/60">
         <span className="font-medium text-platinum-white/80">Automation: </span>
-        {sanitizeClientText(automation.summary)}
+        {sanitizeClientText(text)}
       </p>
     </div>
   )
@@ -146,16 +193,6 @@ export default function MilestoneTimeline({ milestones }: MilestoneTimelineProps
                     Week {milestone.week}
                   </span>
                 </div>
-                <p className="text-xs text-platinum-white/55 mb-1">{milestone.description}</p>
-                {milestone.deliverables && milestone.deliverables.length > 0 && (
-                  <ul className="text-xs text-platinum-white/40 space-y-0.5">
-                    {milestone.deliverables.map((d, di) => (
-                      <li key={di} className="flex items-center gap-1">
-                        <span className="text-radiant-gold/50">•</span> {d}
-                      </li>
-                    ))}
-                  </ul>
-                )}
                 {milestone.target_date && (
                   <p className="text-[10px] text-platinum-white/40 mt-1">
                     Target: {new Date(milestone.target_date).toLocaleDateString()}
@@ -171,6 +208,8 @@ export default function MilestoneTimeline({ milestones }: MilestoneTimelineProps
                       {evidence.map((item, evidenceIndex) => {
                         const statusClass =
                           EVIDENCE_STATUS_STYLES[item.status] || EVIDENCE_STATUS_STYLES.pending
+                        const metrics = knownEvidenceMetrics(item)
+                        const statement = conciseEvidenceStatement(item)
                         return (
                           <div
                             key={item.id || evidenceIndex}
@@ -182,9 +221,6 @@ export default function MilestoneTimeline({ milestones }: MilestoneTimelineProps
                               </span>
                               <span className="text-[10px] opacity-80">
                                 {evidenceStatusLabel(item.status)}
-                              </span>
-                              <span className="text-[10px] opacity-70">
-                                {CONFIDENCE_LABELS[item.confidence]}
                               </span>
                               {item.source_url && (
                                 <a
@@ -198,9 +234,24 @@ export default function MilestoneTimeline({ milestones }: MilestoneTimelineProps
                                 </a>
                               )}
                             </div>
-                            <p className="mt-1 text-[11px] leading-relaxed opacity-85">
-                              {sanitizeClientText(item.summary)}
-                            </p>
+                            {metrics.length > 0 && (
+                              <div className="mt-2 flex flex-wrap gap-1.5">
+                                {metrics.map((metric) => (
+                                  <span
+                                    key={`${item.id || evidenceIndex}-${metric.label}`}
+                                    className="rounded border border-radiant-gold/20 bg-imperial-navy/45 px-2 py-1 text-[10px] font-medium text-platinum-white/80"
+                                  >
+                                    <span className="text-gold-light">{metric.value}</span>{' '}
+                                    {metric.label}
+                                  </span>
+                                ))}
+                              </div>
+                            )}
+                            {statement && (
+                              <p className="mt-1 text-[11px] leading-relaxed opacity-85">
+                                {statement}
+                              </p>
+                            )}
                           </div>
                         )
                       })}

--- a/components/client-dashboard/QuickOverview.tsx
+++ b/components/client-dashboard/QuickOverview.tsx
@@ -16,16 +16,16 @@ export default function QuickOverview({
 }: QuickOverviewProps) {
   return (
     <div className="space-y-4">
-      <div className="bg-gray-900 rounded-xl border border-gray-800 p-4">
-        <h3 className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-3">
+      <div className="rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-4">
+        <h3 className="text-xs font-medium text-radiant-gold uppercase tracking-wider mb-3">
           Quick Overview
         </h3>
         <div className="space-y-3">
           <div className="flex items-center gap-3">
-            <Calendar className="w-4 h-4 text-gray-500" />
+            <Calendar className="w-4 h-4 text-radiant-gold/75" />
             <div>
-              <p className="text-[10px] text-gray-500 uppercase">Assessment Date</p>
-              <p className="text-sm text-gray-300">
+              <p className="text-[10px] text-platinum-white/45 uppercase">Assessment Date</p>
+              <p className="text-sm text-platinum-white/80">
                 {assessmentDate
                   ? new Date(assessmentDate).toLocaleDateString('en-US', {
                       month: 'long',
@@ -37,18 +37,18 @@ export default function QuickOverview({
             </div>
           </div>
           <div className="flex items-center gap-3">
-            <ListTodo className="w-4 h-4 text-gray-500" />
+            <ListTodo className="w-4 h-4 text-radiant-gold/75" />
             <div>
-              <p className="text-[10px] text-gray-500 uppercase">Active Tasks</p>
-              <p className="text-sm text-gray-300">{activeTasks}</p>
+              <p className="text-[10px] text-platinum-white/45 uppercase">Active Tasks</p>
+              <p className="text-sm text-platinum-white/80">{activeTasks}</p>
             </div>
           </div>
           {nextMeeting && (
             <div className="flex items-center gap-3">
-              <Clock className="w-4 h-4 text-gray-500" />
+              <Clock className="w-4 h-4 text-radiant-gold/75" />
               <div>
-                <p className="text-[10px] text-gray-500 uppercase">Next Workshop</p>
-                <p className="text-sm text-gray-300">
+                <p className="text-[10px] text-platinum-white/45 uppercase">Next Workshop</p>
+                <p className="text-sm text-platinum-white/80">
                   {new Date(nextMeeting.meeting_date).toLocaleDateString('en-US', {
                     month: 'short',
                     day: 'numeric',

--- a/components/client-dashboard/ReportsSection.tsx
+++ b/components/client-dashboard/ReportsSection.tsx
@@ -40,8 +40,8 @@ export default function ReportsSection({ valueReports, gammaReports }: ReportsSe
   if (valueReports.length === 0 && gammaReports.length === 0) return null
 
   return (
-    <div className="bg-gray-900 rounded-xl border border-gray-800 p-5">
-      <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider mb-4">
+    <div className="rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-5">
+      <h3 className="text-sm font-medium text-radiant-gold uppercase tracking-wider mb-4">
         Your Reports
       </h3>
 
@@ -56,21 +56,21 @@ export default function ReportsSection({ valueReports, gammaReports }: ReportsSe
           return (
             <div
               key={report.id}
-              className="rounded-lg bg-gray-800/50 border border-gray-700/50 overflow-hidden"
+              className="rounded-lg bg-imperial-navy/45 border border-radiant-gold/10 overflow-hidden"
             >
               <button
                 onClick={() => setExpandedReportId(isExpanded ? null : report.id)}
-                className="w-full flex items-center justify-between p-3 text-left hover:bg-gray-800/80 transition-colors"
+                className="w-full flex items-center justify-between p-3 text-left hover:bg-radiant-gold/10 transition-colors"
               >
                 <div className="flex items-center gap-3 min-w-0">
-                  <div className="p-2 rounded-lg bg-emerald-500/10">
-                    <BarChart3 className="w-4 h-4 text-emerald-400" />
+                  <div className="p-2 rounded-lg bg-radiant-gold/10 border border-radiant-gold/20">
+                    <BarChart3 className="w-4 h-4 text-radiant-gold" />
                   </div>
                   <div className="min-w-0">
-                    <p className="text-sm font-medium text-gray-200 truncate">
+                    <p className="text-sm font-medium text-platinum-white truncate">
                       {report.title}
                     </p>
-                    <p className="text-xs text-gray-500">
+                    <p className="text-xs text-platinum-white/45">
                       {REPORT_TYPE_LABELS[report.report_type] || report.report_type}
                       {' \u00B7 '}
                       {formatDate(report.created_at)}
@@ -79,14 +79,14 @@ export default function ReportsSection({ valueReports, gammaReports }: ReportsSe
                 </div>
                 <div className="flex items-center gap-3 flex-shrink-0">
                   {totalValue > 0 && (
-                    <span className="text-sm font-semibold text-emerald-400">
+                    <span className="text-sm font-semibold text-gold-light">
                       {formatCurrency(totalValue)}/yr
                     </span>
                   )}
                   {isExpanded ? (
-                    <ChevronUp className="w-4 h-4 text-gray-500" />
+                    <ChevronUp className="w-4 h-4 text-radiant-gold/60" />
                   ) : (
-                    <ChevronDown className="w-4 h-4 text-gray-500" />
+                    <ChevronDown className="w-4 h-4 text-radiant-gold/60" />
                   )}
                 </div>
               </button>
@@ -96,7 +96,7 @@ export default function ReportsSection({ valueReports, gammaReports }: ReportsSe
                   {/* Value statements */}
                   {Array.isArray(report.value_statements) && report.value_statements.length > 0 && (
                     <div className="space-y-1.5">
-                      <p className="text-xs font-medium text-gray-400 uppercase tracking-wider px-1">
+                      <p className="text-xs font-medium text-platinum-white/50 uppercase tracking-wider px-1">
                         Opportunity Areas
                       </p>
                       {(report.value_statements as Array<{ painPoint?: string; pain_point?: string; annualValue?: number; annual_value?: number }>).map((vs, i) => {
@@ -105,14 +105,14 @@ export default function ReportsSection({ valueReports, gammaReports }: ReportsSe
                         return (
                           <div
                             key={i}
-                            className="flex items-center justify-between px-3 py-2 bg-gray-900/50 rounded-lg"
+                            className="flex items-center justify-between px-3 py-2 bg-silicon-slate/45 rounded-lg"
                           >
                             <div className="flex items-center gap-2 min-w-0">
-                              <DollarSign className="w-3.5 h-3.5 text-emerald-400/60 flex-shrink-0" />
-                              <span className="text-sm text-gray-300 truncate">{name}</span>
+                              <DollarSign className="w-3.5 h-3.5 text-radiant-gold/70 flex-shrink-0" />
+                              <span className="text-sm text-platinum-white/75 truncate">{name}</span>
                             </div>
                             {value > 0 && (
-                              <span className="text-xs font-medium text-emerald-400/80 flex-shrink-0">
+                              <span className="text-xs font-medium text-gold-light flex-shrink-0">
                                 {formatCurrency(value)}/yr
                               </span>
                             )}
@@ -123,9 +123,9 @@ export default function ReportsSection({ valueReports, gammaReports }: ReportsSe
                   )}
 
                   {totalValue > 0 && (
-                    <div className="flex items-center justify-between px-3 py-2 bg-emerald-500/10 rounded-lg border border-emerald-500/20">
-                      <span className="text-sm font-medium text-gray-300">Total Annual Impact</span>
-                      <span className="text-sm font-bold text-emerald-400">
+                    <div className="flex items-center justify-between px-3 py-2 bg-radiant-gold/10 rounded-lg border border-radiant-gold/25">
+                      <span className="text-sm font-medium text-platinum-white/75">Total Annual Impact</span>
+                      <span className="text-sm font-bold text-gold-light">
                         {formatCurrency(totalValue)}/yr
                       </span>
                     </div>
@@ -144,28 +144,28 @@ export default function ReportsSection({ valueReports, gammaReports }: ReportsSe
           return (
             <div
               key={gamma.id}
-              className="flex items-center justify-between p-3 rounded-lg bg-gray-800/50 border border-gray-700/50 gap-3"
+              className="flex items-center justify-between p-3 rounded-lg bg-imperial-navy/45 border border-radiant-gold/10 gap-3"
             >
               <div className="flex items-center gap-3 min-w-0">
-                <div className="p-2 rounded-lg bg-purple-500/10">
-                  <Presentation className="w-4 h-4 text-purple-400" />
+                <div className="p-2 rounded-lg bg-radiant-gold/10 border border-radiant-gold/20">
+                  <Presentation className="w-4 h-4 text-radiant-gold" />
                 </div>
                 <div className="min-w-0">
-                  <p className="text-sm font-medium text-gray-200 truncate">
+                  <p className="text-sm font-medium text-platinum-white truncate">
                     {gamma.title || 'Presentation Deck'}
                   </p>
-                  <p className="text-xs text-gray-500">
+                  <p className="text-xs text-platinum-white/45">
                     {REPORT_TYPE_LABELS[gamma.report_type] || 'Presentation'}
                     {' \u00B7 '}
                     {formatDate(gamma.created_at)}
                   </p>
                   {isGenerating && (
-                    <p className="text-xs text-amber-400/90 mt-1">
+                    <p className="text-xs text-gold-light mt-1">
                       Your deck is being prepared. Check back shortly.
                     </p>
                   )}
                   {isFailed && (
-                    <p className="text-xs text-gray-400 mt-1">
+                    <p className="text-xs text-platinum-white/60 mt-1">
                       We couldn&apos;t finish this deck automatically. Your consultant can share an updated link.
                     </p>
                   )}
@@ -176,7 +176,7 @@ export default function ReportsSection({ valueReports, gammaReports }: ReportsSe
                   href={gamma.gamma_url!}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-purple-300 bg-purple-500/10 hover:bg-purple-500/20 rounded-lg transition-colors shrink-0"
+                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold text-imperial-navy bg-radiant-gold hover:bg-gold-light rounded-lg transition-colors shrink-0"
                 >
                   <ExternalLink className="w-3.5 h-3.5" />
                   View Deck

--- a/components/client-dashboard/ScoreRadarChart.tsx
+++ b/components/client-dashboard/ScoreRadarChart.tsx
@@ -17,53 +17,62 @@ interface ScoreRadarChartProps {
   dreamScores?: Partial<CategoryScores>
 }
 
+const SHORT_CATEGORY_LABELS: Record<AssessmentCategory, string> = {
+  business_challenges: 'Business',
+  tech_stack: 'Tech',
+  automation_needs: 'Automation',
+  ai_readiness: 'AI Readiness',
+  budget_timeline: 'Budget',
+  decision_making: 'Decision',
+}
+
 export default function ScoreRadarChart({ scores, dreamScores }: ScoreRadarChartProps) {
   const defaultDream = 90
 
   const data = (Object.keys(CATEGORY_LABELS) as AssessmentCategory[]).map((key) => ({
-    category: CATEGORY_LABELS[key],
+    category: SHORT_CATEGORY_LABELS[key],
     current: scores[key] || 0,
     target: dreamScores?.[key] ?? defaultDream,
   }))
 
   return (
-    <div className="bg-gray-900 rounded-xl border border-gray-800 p-5">
-      <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider mb-4">
+    <div className="rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-5">
+      <h3 className="text-sm font-medium text-radiant-gold uppercase tracking-wider mb-4">
         Your Business Assessment Scores
       </h3>
       <div className="h-[280px] w-full">
         <ResponsiveContainer width="100%" height="100%">
           <RadarChart cx="50%" cy="50%" outerRadius="70%" data={data}>
-            <PolarGrid stroke="#374151" />
+            <PolarGrid stroke="rgba(212, 175, 55, 0.22)" />
             <PolarAngleAxis
               dataKey="category"
-              tick={{ fill: '#9CA3AF', fontSize: 11 }}
+              tick={{ fill: '#EAECEE', fillOpacity: 0.68, fontSize: 11 }}
               tickLine={false}
             />
             <PolarRadiusAxis
               angle={30}
               domain={[0, 100]}
-              tick={{ fill: '#6B7280', fontSize: 10 }}
+              tick={{ fill: '#EAECEE', fillOpacity: 0.45, fontSize: 10 }}
               axisLine={false}
             />
             <Radar
               name="Target"
               dataKey="target"
-              stroke="#6366F1"
-              fill="#6366F1"
-              fillOpacity={0.1}
+              stroke="#F5D060"
+              fill="#F5D060"
+              fillOpacity={0.08}
               strokeDasharray="4 4"
             />
             <Radar
               name="Your Scores"
               dataKey="current"
-              stroke="#3B82F6"
-              fill="#3B82F6"
-              fillOpacity={0.3}
+              stroke="#D4AF37"
+              fill="#D4AF37"
+              fillOpacity={0.24}
               strokeWidth={2}
             />
             <Legend
-              wrapperStyle={{ fontSize: 12, color: '#9CA3AF' }}
+              wrapperStyle={{ fontSize: 12, color: '#EAECEE' }}
             />
           </RadarChart>
         </ResponsiveContainer>

--- a/components/client-dashboard/TaskChecklist.tsx
+++ b/components/client-dashboard/TaskChecklist.tsx
@@ -24,9 +24,9 @@ interface TaskChecklistProps {
 }
 
 const PRIORITY_STYLES = {
-  high: 'bg-red-900/40 text-red-300 border-red-700/50',
-  medium: 'bg-yellow-900/40 text-yellow-300 border-yellow-700/50',
-  low: 'bg-gray-800 text-gray-400 border-gray-700',
+  high: 'bg-bronze/20 text-gold-light border-bronze/50',
+  medium: 'bg-radiant-gold/15 text-radiant-gold border-radiant-gold/35',
+  low: 'bg-silicon-slate/60 text-platinum-white/55 border-platinum-white/10',
 }
 
 const RESOURCE_ICONS: Record<DiyResource['type'], typeof Play> = {
@@ -71,14 +71,14 @@ export default function TaskChecklist({ tasks, token, onTaskUpdate }: TaskCheckl
   }
 
   return (
-    <div className="bg-gray-900 rounded-xl border border-gray-800 p-5">
-      <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider mb-4">
+    <div className="rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-5">
+      <h3 className="text-sm font-medium text-radiant-gold uppercase tracking-wider mb-4">
         Task Checklist
       </h3>
       <div className="space-y-6">
         {Object.entries(grouped).map(([category, categoryTasks]) => (
           <div key={category}>
-            <h4 className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-3">
+            <h4 className="text-xs font-medium text-platinum-white/50 uppercase tracking-wider mb-3">
               {category.replace(/_/g, ' ')}
             </h4>
             <div className="space-y-2">
@@ -93,8 +93,8 @@ export default function TaskChecklist({ tasks, token, onTaskUpdate }: TaskCheckl
                     key={task.id}
                     className={`border rounded-lg overflow-hidden transition-colors ${
                       isComplete
-                        ? 'border-green-800/50 bg-green-900/10'
-                        : 'border-gray-800 bg-gray-800/30'
+                        ? 'border-radiant-gold/35 bg-radiant-gold/10'
+                        : 'border-radiant-gold/10 bg-imperial-navy/40'
                     }`}
                   >
                     {/* Task Header */}
@@ -105,16 +105,16 @@ export default function TaskChecklist({ tasks, token, onTaskUpdate }: TaskCheckl
                         className="flex-shrink-0 transition-colors"
                       >
                         {isComplete ? (
-                          <CheckCircle2 className="w-5 h-5 text-green-400" />
+                          <CheckCircle2 className="w-5 h-5 text-gold-light" />
                         ) : (
-                          <Circle className={`w-5 h-5 ${isUpdating ? 'text-gray-600 animate-pulse' : 'text-gray-600 hover:text-blue-400'}`} />
+                          <Circle className={`w-5 h-5 ${isUpdating ? 'text-platinum-white/30 animate-pulse' : 'text-platinum-white/35 hover:text-radiant-gold'}`} />
                         )}
                       </button>
 
                       <div className="flex-1 min-w-0">
                         <span
                           className={`text-sm ${
-                            isComplete ? 'text-gray-500 line-through' : 'text-gray-200'
+                            isComplete ? 'text-platinum-white/45 line-through' : 'text-platinum-white/85'
                           }`}
                         >
                           {task.title}
@@ -123,7 +123,7 @@ export default function TaskChecklist({ tasks, token, onTaskUpdate }: TaskCheckl
 
                       <div className="flex items-center gap-2 flex-shrink-0">
                         {task.impact_score > 0 && (
-                          <span className="text-xs text-blue-400 font-medium">
+                          <span className="text-xs text-radiant-gold font-medium">
                             +{task.impact_score} pts
                           </span>
                         )}
@@ -135,7 +135,7 @@ export default function TaskChecklist({ tasks, token, onTaskUpdate }: TaskCheckl
                         {hasPaths && (
                           <button
                             onClick={() => setExpandedTask(isExpanded ? null : task.id)}
-                            className="text-gray-500 hover:text-gray-300"
+                            className="text-platinum-white/45 hover:text-radiant-gold"
                           >
                             {isExpanded ? (
                               <ChevronDown className="w-4 h-4" />
@@ -149,13 +149,13 @@ export default function TaskChecklist({ tasks, token, onTaskUpdate }: TaskCheckl
 
                     {/* Expanded: DIY + Fast Track Paths */}
                     {isExpanded && hasPaths && (
-                      <div className="border-t border-gray-800 p-3 grid grid-cols-1 md:grid-cols-2 gap-4">
+                      <div className="border-t border-radiant-gold/10 p-3 grid grid-cols-1 md:grid-cols-2 gap-4">
                         {/* DIY Path */}
                         {task.diy_resources && task.diy_resources.length > 0 && (
                           <div>
                             <div className="flex items-center gap-2 mb-2">
-                              <Clock className="w-3.5 h-3.5 text-gray-400" />
-                              <span className="text-xs font-medium text-gray-400 uppercase">
+                              <Clock className="w-3.5 h-3.5 text-radiant-gold/75" />
+                              <span className="text-xs font-medium text-platinum-white/55 uppercase">
                                 Do It Yourself
                               </span>
                             </div>
@@ -169,15 +169,15 @@ export default function TaskChecklist({ tasks, token, onTaskUpdate }: TaskCheckl
                                     href={href}
                                     target="_blank"
                                     rel="noopener noreferrer"
-                                    className="flex items-center gap-2 p-2 rounded-lg bg-gray-800/50 hover:bg-gray-800 transition-colors group"
+                                    className="flex items-center gap-2 p-2 rounded-lg bg-silicon-slate/50 hover:bg-radiant-gold/10 transition-colors group"
                                   >
-                                    <Icon className="w-4 h-4 text-gray-500 group-hover:text-blue-400 flex-shrink-0" />
+                                    <Icon className="w-4 h-4 text-platinum-white/45 group-hover:text-radiant-gold flex-shrink-0" />
                                     <div className="flex-1 min-w-0">
-                                      <p className="text-xs text-gray-300 truncate">
+                                      <p className="text-xs text-platinum-white/75 truncate">
                                         {resource.title}
                                       </p>
                                       {resource.estimated_time && (
-                                        <p className="text-[10px] text-gray-600">
+                                        <p className="text-[10px] text-platinum-white/40">
                                           {resource.estimated_time}
                                         </p>
                                       )}
@@ -193,22 +193,22 @@ export default function TaskChecklist({ tasks, token, onTaskUpdate }: TaskCheckl
                         {task.accelerated_bundle_id && (
                           <div>
                             <div className="flex items-center gap-2 mb-2">
-                              <Zap className="w-3.5 h-3.5 text-yellow-400" />
-                              <span className="text-xs font-medium text-yellow-400 uppercase">
+                              <Zap className="w-3.5 h-3.5 text-radiant-gold" />
+                              <span className="text-xs font-medium text-radiant-gold uppercase">
                                 Fast Track
                               </span>
                             </div>
-                            <div className="p-3 rounded-lg bg-gradient-to-r from-yellow-900/20 to-amber-900/20 border border-yellow-800/50">
-                              <p className="text-sm text-yellow-200 font-medium mb-1">
+                            <div className="p-3 rounded-lg bg-gradient-to-r from-radiant-gold/15 to-bronze/15 border border-radiant-gold/30">
+                              <p className="text-sm text-gold-light font-medium mb-1">
                                 {task.accelerated_bundle?.name || 'Professional Service'}
                               </p>
                               {task.accelerated_headline && (
-                                <p className="text-xs text-yellow-300/70 mb-2">
+                                <p className="text-xs text-platinum-white/65 mb-2">
                                   {task.accelerated_headline}
                                 </p>
                               )}
                               {task.accelerated_savings && (
-                                <p className="text-[10px] text-gray-500 mb-2">
+                                <p className="text-[10px] text-platinum-white/45 mb-2">
                                   {task.accelerated_savings}
                                 </p>
                               )}
@@ -216,7 +216,7 @@ export default function TaskChecklist({ tasks, token, onTaskUpdate }: TaskCheckl
                                 href={task.accelerated_bundle?.pricing_tier_slug
                                   ? `/pricing`
                                   : `/services`}
-                                className="inline-flex items-center gap-1 text-xs text-yellow-400 hover:text-yellow-300 font-medium"
+                                className="inline-flex items-center gap-1 text-xs text-radiant-gold hover:text-gold-light font-medium"
                               >
                                 Learn More <ArrowRight className="w-3 h-3" />
                               </a>

--- a/components/client-dashboard/TimeTrackingSection.tsx
+++ b/components/client-dashboard/TimeTrackingSection.tsx
@@ -34,21 +34,21 @@ export default function TimeTrackingSection({
   const totalTaskTime = taskEntries.reduce((s, t) => s + t.total_seconds, 0)
 
   return (
-    <div className="bg-gray-900 rounded-xl border border-gray-800 p-5">
+    <div className="rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-5">
       <div className="flex items-center justify-between mb-4">
-        <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider flex items-center gap-2">
+        <h3 className="text-sm font-medium text-radiant-gold uppercase tracking-wider flex items-center gap-2">
           <TrendingUp className="w-4 h-4" />
           Time Investment
         </h3>
-        <div className="flex items-center gap-1.5 text-sm font-semibold text-white">
-          <Clock className="w-4 h-4 text-blue-400" />
+        <div className="flex items-center gap-1.5 text-sm font-semibold text-platinum-white">
+          <Clock className="w-4 h-4 text-radiant-gold" />
           {formatHours(timeTracking.total_seconds)} total
         </div>
       </div>
 
       {milestoneEntries.length > 0 && (
         <div className="space-y-2 mb-4">
-          <p className="text-xs text-gray-500 font-medium uppercase">By Milestone</p>
+          <p className="text-xs text-platinum-white/50 font-medium uppercase">By Milestone</p>
           {milestoneEntries.map((entry) => {
             const idx = Number(entry.target_id)
             const title = milestones[idx]?.title || `Milestone ${idx + 1}`
@@ -59,16 +59,16 @@ export default function TimeTrackingSection({
               <div key={entry.target_id} className="flex items-center gap-3">
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center justify-between mb-1">
-                    <span className="text-xs text-gray-300 truncate">
+                    <span className="text-xs text-platinum-white/75 truncate">
                       {title}
                     </span>
-                    <span className="text-xs text-gray-500 shrink-0 ml-2">
+                    <span className="text-xs text-platinum-white/50 shrink-0 ml-2">
                       {formatHours(entry.total_seconds)}
                     </span>
                   </div>
-                  <div className="w-full h-1.5 bg-gray-800 rounded-full overflow-hidden">
+                  <div className="w-full h-1.5 bg-imperial-navy/70 rounded-full overflow-hidden">
                     <div
-                      className="h-full bg-blue-500/60 rounded-full"
+                      className="h-full bg-radiant-gold/75 rounded-full"
                       style={{ width: `${pct}%` }}
                     />
                   </div>
@@ -80,12 +80,12 @@ export default function TimeTrackingSection({
       )}
 
       {totalTaskTime > 0 && (
-        <div className="pt-3 border-t border-gray-800">
+        <div className="pt-3 border-t border-radiant-gold/15">
           <div className="flex items-center justify-between">
-            <span className="text-xs text-gray-500">
+            <span className="text-xs text-platinum-white/50">
               Task work ({taskEntries.length} task{taskEntries.length !== 1 ? 's' : ''})
             </span>
-            <span className="text-xs text-gray-400">
+            <span className="text-xs text-platinum-white/65">
               {formatHours(totalTaskTime)}
             </span>
           </div>

--- a/components/client-dashboard/TrajectoryChart.tsx
+++ b/components/client-dashboard/TrajectoryChart.tsx
@@ -32,11 +32,11 @@ export default function TrajectoryChart({ token, initialData }: TrajectoryChartP
 
   if (data.length === 0) {
     return (
-      <div className="bg-gray-900 rounded-xl border border-gray-800 p-5">
-        <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider mb-4">
+      <div className="rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-5">
+        <h3 className="text-sm font-medium text-radiant-gold uppercase tracking-wider mb-4">
           Score Trajectory
         </h3>
-        <p className="text-gray-500 text-sm">
+        <p className="text-platinum-white/55 text-sm">
           Complete tasks to see your progress trajectory.
         </p>
       </div>
@@ -58,33 +58,33 @@ export default function TrajectoryChart({ token, initialData }: TrajectoryChartP
   const splitIndex = chartData.findIndex((d) => d.isProjected)
 
   return (
-    <div className="bg-gray-900 rounded-xl border border-gray-800 p-5">
-      <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider mb-1">
+    <div className="rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-5">
+      <h3 className="text-sm font-medium text-radiant-gold uppercase tracking-wider mb-1">
         Score Trajectory
       </h3>
-      <p className="text-xs text-gray-500 mb-4">
+      <p className="text-xs text-platinum-white/50 mb-4">
         Timeline runs from project inception to projected completion based on milestones.
       </p>
       <div className="h-[240px] w-full">
         <ResponsiveContainer width="100%" height="100%">
           <LineChart data={chartData} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
-            <CartesianGrid stroke="#1F2937" strokeDasharray="3 3" />
-            <XAxis dataKey="date" tick={{ fill: '#6B7280', fontSize: 11 }} />
-            <YAxis domain={[0, 100]} tick={{ fill: '#6B7280', fontSize: 11 }} />
+            <CartesianGrid stroke="rgba(212, 175, 55, 0.16)" strokeDasharray="3 3" />
+            <XAxis dataKey="date" tick={{ fill: '#EAECEE', fillOpacity: 0.55, fontSize: 11 }} />
+            <YAxis domain={[0, 100]} tick={{ fill: '#EAECEE', fillOpacity: 0.55, fontSize: 11 }} />
             <Tooltip
               contentStyle={{
-                backgroundColor: '#1F2937',
-                border: '1px solid #374151',
+                backgroundColor: '#121E31',
+                border: '1px solid rgba(212, 175, 55, 0.3)',
                 borderRadius: '8px',
                 color: '#E5E7EB',
                 fontSize: 12,
               }}
             />
-            <ReferenceLine y={90} stroke="#6366F1" strokeDasharray="4 4" label={{ value: 'Target', fill: '#6366F1', fontSize: 11 }} />
+            <ReferenceLine y={90} stroke="#F5D060" strokeDasharray="4 4" label={{ value: 'Target', fill: '#F5D060', fontSize: 11 }} />
             <Line
               type="monotone"
               dataKey="score"
-              stroke="#3B82F6"
+              stroke="#D4AF37"
               strokeWidth={2}
               dot={(props: Record<string, unknown>) => {
                 const { cx, cy, index } = props as { cx: number; cy: number; index: number }
@@ -97,13 +97,13 @@ export default function TrajectoryChart({ token, initialData }: TrajectoryChartP
                       cy={cy}
                       r={3}
                       fill="transparent"
-                      stroke="#3B82F6"
+                      stroke="#D4AF37"
                       strokeWidth={1}
                       strokeDasharray="2 2"
                     />
                   )
                 }
-                return <circle key={`dot-${index}`} cx={cx} cy={cy} r={4} fill="#3B82F6" />
+                return <circle key={`dot-${index}`} cx={cx} cy={cy} r={4} fill="#D4AF37" />
               }}
               strokeDasharray={splitIndex >= 0 ? undefined : undefined}
             />

--- a/components/client-dashboard/TrajectoryChart.tsx
+++ b/components/client-dashboard/TrajectoryChart.tsx
@@ -44,9 +44,14 @@ export default function TrajectoryChart({ token, initialData }: TrajectoryChartP
   }
 
   const chartData = data.map((point) => ({
-    date: new Date(point.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+    date: new Date(point.date).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      timeZone: 'UTC',
+    }),
     score: point.overallScore,
     isProjected: point.isProjected,
+    label: point.label,
   }))
 
   // Split into actual and projected for different line styles
@@ -58,7 +63,7 @@ export default function TrajectoryChart({ token, initialData }: TrajectoryChartP
         Score Trajectory
       </h3>
       <p className="text-xs text-gray-500 mb-4">
-        Solid = actual progress, dashed = projected based on remaining tasks
+        Timeline runs from project inception to projected completion based on milestones.
       </p>
       <div className="h-[240px] w-full">
         <ResponsiveContainer width="100%" height="100%">

--- a/components/client-dashboard/WorkshopCountdown.tsx
+++ b/components/client-dashboard/WorkshopCountdown.tsx
@@ -24,25 +24,25 @@ export default function WorkshopCountdown({ meetingDate, meetingType }: Workshop
   }
 
   return (
-    <div className="bg-gradient-to-r from-indigo-900/30 to-purple-900/30 border border-indigo-800/50 rounded-xl p-4">
+    <div className="bg-gradient-to-r from-radiant-gold/15 to-bronze/15 border border-radiant-gold/25 rounded-lg p-4">
       <div className="flex items-center gap-2 mb-2">
-        <Calendar className="w-4 h-4 text-indigo-400" />
-        <span className="text-xs font-medium text-indigo-300 uppercase tracking-wider">
+        <Calendar className="w-4 h-4 text-radiant-gold" />
+        <span className="text-xs font-medium text-radiant-gold uppercase tracking-wider">
           Next {meetingType || 'Workshop'}
         </span>
       </div>
       <div className="flex items-center gap-4">
         <div className="text-center">
-          <span className="text-2xl font-bold text-white">{timeLeft.days}</span>
-          <p className="text-[10px] text-indigo-400 uppercase">Days</p>
+          <span className="text-2xl font-bold text-platinum-white">{timeLeft.days}</span>
+          <p className="text-[10px] text-radiant-gold uppercase">Days</p>
         </div>
-        <span className="text-indigo-600">:</span>
+        <span className="text-radiant-gold/50">:</span>
         <div className="text-center">
-          <span className="text-2xl font-bold text-white">{timeLeft.hours}</span>
-          <p className="text-[10px] text-indigo-400 uppercase">Hours</p>
+          <span className="text-2xl font-bold text-platinum-white">{timeLeft.hours}</span>
+          <p className="text-[10px] text-radiant-gold uppercase">Hours</p>
         </div>
       </div>
-      <p className="text-[10px] text-gray-500 mt-2">
+      <p className="text-[10px] text-platinum-white/50 mt-2">
         {new Date(meetingDate).toLocaleDateString('en-US', {
           weekday: 'long',
           month: 'long',
@@ -52,7 +52,7 @@ export default function WorkshopCountdown({ meetingDate, meetingType }: Workshop
         })}
       </p>
       {timeLeft.days <= 1 && (
-        <div className="mt-2 flex items-center gap-1 text-yellow-400">
+        <div className="mt-2 flex items-center gap-1 text-gold-light">
           <Clock className="w-3 h-3" />
           <span className="text-[10px] font-medium">Coming up soon!</span>
         </div>

--- a/lib/assessment-scoring.ts
+++ b/lib/assessment-scoring.ts
@@ -62,6 +62,7 @@ export interface TrajectoryPoint {
   date: string
   overallScore: number
   isProjected: boolean
+  label?: string
 }
 
 export interface ScoreSnapshot {
@@ -73,6 +74,66 @@ export interface ScoreSnapshot {
   dream_outcome_gap: number | null
   trigger: 'initial' | 'task_completed' | 'milestone_achieved' | 'manual'
   trigger_ref: string | null
+}
+
+interface TimelineMilestone {
+  week?: number | string
+  target_date?: string
+  status?: string
+}
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24
+
+function startOfDay(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()))
+}
+
+function addDays(date: Date, days: number): Date {
+  const next = new Date(date)
+  next.setUTCDate(next.getUTCDate() + days)
+  return next
+}
+
+function validDate(value: string | null | undefined): Date | null {
+  if (!value) return null
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+function dateKey(value: string): string {
+  return validDate(value)?.toISOString().slice(0, 10) || value.slice(0, 10)
+}
+
+function milestoneWeekToNumber(week: number | string | undefined): number | null {
+  if (typeof week === 'number' && Number.isFinite(week)) return week
+  if (typeof week !== 'string') return null
+  const match = week.match(/-?\d+(\.\d+)?/)
+  if (!match) return null
+  const value = Number(match[0])
+  return Number.isFinite(value) ? value : null
+}
+
+function getProjectedCompletionDate(
+  projectStartDate: Date,
+  milestones: TimelineMilestone[]
+): Date | null {
+  const targetDates = milestones
+    .map((milestone) => validDate(milestone.target_date))
+    .filter((date): date is Date => Boolean(date))
+
+  if (targetDates.length > 0) {
+    return new Date(Math.max(...targetDates.map((date) => date.getTime())))
+  }
+
+  const maxWeek = milestones.reduce((latest, milestone) => {
+    const week = milestoneWeekToNumber(milestone.week)
+    return week === null ? latest : Math.max(latest, week)
+  }, -Infinity)
+
+  if (!Number.isFinite(maxWeek)) return null
+
+  // Week numbers in onboarding plans are milestone markers, so include the final week.
+  return addDays(projectStartDate, Math.max(1, maxWeek + 1) * 7)
 }
 
 // ============================================================================
@@ -327,6 +388,12 @@ export async function recalculateScores(
 export async function projectTrajectory(
   clientProjectId: string
 ): Promise<TrajectoryPoint[]> {
+  const { data: project } = await supabaseAdmin
+    .from('client_projects')
+    .select('project_start_date, created_at, onboarding_plan_id')
+    .eq('id', clientProjectId)
+    .single()
+
   // Fetch actual snapshots
   const { data: snapshots } = await supabaseAdmin
     .from('score_snapshots')
@@ -336,12 +403,66 @@ export async function projectTrajectory(
 
   if (!snapshots || snapshots.length === 0) return []
 
-  // Actual data points
-  const actual: TrajectoryPoint[] = snapshots.map((s: { snapshot_date: string; overall_score: number }) => ({
-    date: s.snapshot_date,
-    overallScore: s.overall_score,
+  const snapshotsByDay = new Map<string, { snapshot_date: string; overall_score: number }>()
+  snapshots.forEach((snapshot: { snapshot_date: string; overall_score: number }) => {
+    snapshotsByDay.set(dateKey(snapshot.snapshot_date), snapshot)
+  })
+  const normalizedSnapshots = Array.from(snapshotsByDay.values())
+
+  const projectStartDate =
+    validDate(project?.project_start_date) ||
+    validDate(project?.created_at) ||
+    validDate(normalizedSnapshots[0].snapshot_date) ||
+    new Date()
+
+  let milestones: TimelineMilestone[] = []
+  if (project?.onboarding_plan_id) {
+    const { data: onboardingPlan } = await supabaseAdmin
+      .from('onboarding_plans')
+      .select('milestones')
+      .eq('id', project.onboarding_plan_id)
+      .single()
+    milestones = Array.isArray(onboardingPlan?.milestones)
+      ? (onboardingPlan.milestones as TimelineMilestone[])
+      : []
+  }
+
+  const projectedCompletionDate =
+    getProjectedCompletionDate(projectStartDate, milestones) ||
+    validDate(normalizedSnapshots[normalizedSnapshots.length - 1].snapshot_date) ||
+    addDays(projectStartDate, 42)
+
+  const firstSnapshot = normalizedSnapshots[0] as { snapshot_date: string; overall_score: number }
+  const firstSnapshotDate = validDate(firstSnapshot.snapshot_date) || projectStartDate
+
+  // Actual data points, anchored at project inception even if the first score
+  // snapshot was recorded later.
+  const actual: TrajectoryPoint[] = []
+  actual.push({
+    date: startOfDay(projectStartDate).toISOString(),
+    overallScore: firstSnapshot.overall_score,
     isProjected: false,
-  }))
+    label: 'Project start',
+  })
+
+  normalizedSnapshots.forEach((s: { snapshot_date: string; overall_score: number }, index: number) => {
+    const snapshotDate = validDate(s.snapshot_date)
+    if (
+      index === 0 &&
+      snapshotDate &&
+      Math.abs(snapshotDate.getTime() - firstSnapshotDate.getTime()) < MS_PER_DAY &&
+      Math.abs(snapshotDate.getTime() - projectStartDate.getTime()) < MS_PER_DAY
+    ) {
+      return
+    }
+
+    actual.push({
+      date: s.snapshot_date,
+      overallScore: s.overall_score,
+      isProjected: false,
+      label: index === normalizedSnapshots.length - 1 ? 'Current score' : undefined,
+    })
+  })
 
   // Fetch remaining tasks for projection
   const { data: remainingTasks } = await supabaseAdmin
@@ -351,7 +472,29 @@ export async function projectTrajectory(
     .in('status', ['pending', 'in_progress'])
     .order('display_order', { ascending: true })
 
-  if (!remainingTasks || remainingTasks.length === 0) return actual
+  const latestActual = actual[actual.length - 1]
+  const latestActualDate = validDate(latestActual.date) || projectStartDate
+  const completionDate =
+    projectedCompletionDate.getTime() > latestActualDate.getTime()
+      ? projectedCompletionDate
+      : addDays(latestActualDate, Math.max(7, milestones.length * 7))
+
+  if (!remainingTasks || remainingTasks.length === 0) {
+    const latestMilestoneScore = milestones.length > 0
+      ? Math.min(100, latestActual.overallScore + Math.max(5, milestones.length * 3))
+      : latestActual.overallScore
+
+    if (completionDate.getTime() > latestActualDate.getTime()) {
+      actual.push({
+        date: completionDate.toISOString(),
+        overallScore: latestMilestoneScore,
+        isProjected: true,
+        label: 'Projected completion',
+      })
+    }
+
+    return actual
+  }
 
   // Calculate average completion cadence from completed tasks
   const { data: completedTasks } = await supabaseAdmin
@@ -371,21 +514,44 @@ export async function projectTrajectory(
     avgDaysBetweenCompletions = Math.max(1, totalDays / (completedTasks.length - 1))
   }
 
-  // Project future scores
-  const latestScore = actual[actual.length - 1].overallScore
-  const latestDate = new Date(actual[actual.length - 1].date)
+  const latestScore = latestActual.overallScore
   let runningScore = latestScore
+  const projectionSpanDays = Math.max(
+    1,
+    (completionDate.getTime() - latestActualDate.getTime()) / MS_PER_DAY
+  )
 
   for (let i = 0; i < remainingTasks.length; i++) {
-    const projectedDate = new Date(latestDate)
-    projectedDate.setDate(projectedDate.getDate() + avgDaysBetweenCompletions * (i + 1))
+    const cadenceDate = addDays(latestActualDate, avgDaysBetweenCompletions * (i + 1))
+    const milestoneDate = addDays(
+      latestActualDate,
+      (projectionSpanDays / remainingTasks.length) * (i + 1)
+    )
+    const projectedDate =
+      completedTasks && completedTasks.length >= 2
+        ? new Date(Math.min(cadenceDate.getTime(), completionDate.getTime()))
+        : milestoneDate
     runningScore = Math.min(100, runningScore + (remainingTasks[i].impact_score || 0))
 
     actual.push({
       date: projectedDate.toISOString(),
       overallScore: runningScore,
       isProjected: true,
+      label: i === remainingTasks.length - 1 ? 'Projected completion' : undefined,
     })
+  }
+
+  const finalPoint = actual[actual.length - 1]
+  const finalDate = validDate(finalPoint.date)
+  if (finalDate && Math.abs(finalDate.getTime() - completionDate.getTime()) > MS_PER_DAY) {
+    actual.push({
+      date: completionDate.toISOString(),
+      overallScore: runningScore,
+      isProjected: true,
+      label: 'Projected completion',
+    })
+  } else {
+    finalPoint.label = finalPoint.label || 'Projected completion'
   }
 
   return actual

--- a/lib/client-build-evidence-db.test.ts
+++ b/lib/client-build-evidence-db.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+  const chain = {
+    select: vi.fn(),
+    eq: vi.fn(),
+    order: vi.fn(),
+    limit: vi.fn(),
+    maybeSingle: vi.fn(),
+  }
+  chain.select.mockReturnValue(chain)
+  chain.eq.mockReturnValue(chain)
+  chain.order.mockReturnValue(chain)
+  chain.limit.mockReturnValue(chain)
+  return {
+    chain,
+    from: vi.fn(() => chain),
+  }
+})
+
+vi.mock('./supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import { getBuildEvidenceForClientProject } from './client-build-evidence'
+
+describe('getBuildEvidenceForClientProject', () => {
+  it('only fetches client-visible build evidence for the project', async () => {
+    mocks.chain.maybeSingle.mockResolvedValueOnce({
+      data: {
+        id: 'evidence-1',
+        project_label: 'ReversR Rebuild Product Asset',
+        captured_at: '2026-06-15T12:00:00.000Z',
+        repo_metrics: {},
+        token_usage: {},
+        cost_summary: {},
+        hourly_translation: {},
+        source_confidence: {},
+        client_safe_notes: [],
+      },
+      error: null,
+    })
+
+    await getBuildEvidenceForClientProject('project-1')
+
+    expect(mocks.from).toHaveBeenCalledWith('client_project_build_evidence')
+    expect(mocks.chain.eq).toHaveBeenCalledWith('client_project_id', 'project-1')
+    expect(mocks.chain.eq).toHaveBeenCalledWith('is_client_visible', true)
+    expect(mocks.chain.select.mock.calls[0]?.[0]).not.toContain('private_source_refs')
+  })
+})

--- a/lib/client-build-evidence.test.ts
+++ b/lib/client-build-evidence.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('./supabase', () => ({
+  supabaseAdmin: {},
+}))
+
+import { sanitizeBuildEvidenceRow } from './client-build-evidence'
+
+describe('sanitizeBuildEvidenceRow', () => {
+  it('returns client-safe evidence without private source refs', () => {
+    const output = sanitizeBuildEvidenceRow({
+      id: 'evidence-1',
+      project_label: 'ReversR Rebuild Product Asset',
+      captured_at: '2026-06-15T12:00:00.000Z',
+      repo_metrics: {
+        repoLabel: 'vsillah/ReversR-Rebuild',
+        publicRepoUrl: 'https://github.com/vsillah/ReversR-Rebuild',
+        allBranchCommitCount: 149,
+        trackedTextLines: 36775,
+        workflow: ['scan or describe a machine'],
+      },
+      token_usage: {
+        confidenceLabel: 'Direct ReversR workspace evidence',
+        sessionCount: 5,
+        totalTokens: 283717602,
+        shareOfComparisonWindowPct: 17.38,
+      },
+      cost_summary: {
+        pricingSourceLabel: 'Provider/API pricing snapshot not recorded',
+      },
+      hourly_translation: {
+        defaultBenchmarkHourlyRate: 175,
+        defaultProposalAmount: 30000,
+        focusedHoursLow: 300,
+        focusedHoursHigh: 475,
+      },
+      source_confidence: {
+        label: 'Direct ReversR workspace evidence',
+        confidence: 'high',
+        sourceSummary: 'Strict attribution only.',
+        excludedSources: ['/Users/vambahsillah/.codex/sessions/private.jsonl'],
+      },
+      client_safe_notes: ['Not a time sheet.'],
+      private_source_refs: ['/Users/vambahsillah/.codex/sessions/private.jsonl'],
+    } as any)
+
+    expect(output.repoMetrics.allBranchCommitCount).toBe(149)
+    expect(output.tokenUsage.totalTokens).toBe(283717602)
+    expect(output.clientSafeNotes).toEqual(['Not a time sheet.'])
+    expect(JSON.stringify(output)).not.toContain('/Users/vambahsillah/.codex/sessions/private.jsonl')
+    expect(output).not.toHaveProperty('privateSourceRefs')
+    expect(output).not.toHaveProperty('private_source_refs')
+  })
+})

--- a/lib/client-build-evidence.ts
+++ b/lib/client-build-evidence.ts
@@ -1,0 +1,269 @@
+import { supabaseAdmin } from './supabase'
+
+type JsonRecord = Record<string, unknown>
+
+export interface BuildEvidenceRepoMetrics {
+  repoLabel: string
+  publicRepoUrl: string | null
+  capturedAt: string | null
+  allBranchCommitCount: number
+  headCommitCount: number
+  trackedFiles: number
+  trackedCodeDocConfigFiles: number
+  trackedTextLines: number
+  filesChanged: number
+  insertions: number
+  deletions: number
+  releasePassCount: number
+  releasePendingCount: number
+  releasePendingGate: string | null
+  workflow: string[]
+}
+
+export interface BuildEvidenceTokenUsage {
+  attributionMethod: string
+  confidenceLabel: string
+  comparisonWindowLabel: string
+  sessionCount: number
+  totalTokens: number
+  inputTokens: number
+  cachedInputTokens: number
+  outputTokens: number
+  reasoningTokens: number
+  shareOfComparisonWindowPct: number
+  modelProvider: string | null
+  model: string | null
+  planType: string | null
+}
+
+export interface BuildEvidenceCostSummary {
+  pricingCapturedAt: string | null
+  pricingSourceLabel: string
+  pricingAssumption: string
+  apiEquivalentCostUsd: number | null
+  subscriptionMonthlyCostUsd: number | null
+  subscriptionAllocatedCostUsd: number | null
+  subscriptionSharePct: number | null
+}
+
+export interface BuildEvidenceHourlyTranslation {
+  defaultBenchmarkHourlyRate: number
+  defaultProposalAmount: number
+  focusedHoursLow: number
+  focusedHoursHigh: number
+  notes: string
+}
+
+export interface BuildEvidenceSourceConfidence {
+  label: string
+  confidence: 'high' | 'medium' | 'low'
+  sourceSummary: string
+  excludedSources: string[]
+}
+
+export interface ClientBuildEvidence {
+  id: string
+  projectLabel: string
+  capturedAt: string
+  repoMetrics: BuildEvidenceRepoMetrics
+  tokenUsage: BuildEvidenceTokenUsage
+  costSummary: BuildEvidenceCostSummary
+  hourlyTranslation: BuildEvidenceHourlyTranslation
+  sourceConfidence: BuildEvidenceSourceConfidence
+  clientSafeNotes: string[]
+}
+
+interface BuildEvidenceRow {
+  id: string
+  project_label: string
+  captured_at: string
+  repo_metrics: JsonRecord | null
+  token_usage: JsonRecord | null
+  cost_summary: JsonRecord | null
+  hourly_translation: JsonRecord | null
+  source_confidence: JsonRecord | null
+  client_safe_notes: unknown
+}
+
+const DEFAULT_REPO_METRICS: BuildEvidenceRepoMetrics = {
+  repoLabel: '',
+  publicRepoUrl: null,
+  capturedAt: null,
+  allBranchCommitCount: 0,
+  headCommitCount: 0,
+  trackedFiles: 0,
+  trackedCodeDocConfigFiles: 0,
+  trackedTextLines: 0,
+  filesChanged: 0,
+  insertions: 0,
+  deletions: 0,
+  releasePassCount: 0,
+  releasePendingCount: 0,
+  releasePendingGate: null,
+  workflow: [],
+}
+
+const DEFAULT_TOKEN_USAGE: BuildEvidenceTokenUsage = {
+  attributionMethod: 'strict_workspace_cwd',
+  confidenceLabel: 'Direct workspace evidence',
+  comparisonWindowLabel: '',
+  sessionCount: 0,
+  totalTokens: 0,
+  inputTokens: 0,
+  cachedInputTokens: 0,
+  outputTokens: 0,
+  reasoningTokens: 0,
+  shareOfComparisonWindowPct: 0,
+  modelProvider: null,
+  model: null,
+  planType: null,
+}
+
+const DEFAULT_COST_SUMMARY: BuildEvidenceCostSummary = {
+  pricingCapturedAt: null,
+  pricingSourceLabel: 'No provider pricing snapshot recorded',
+  pricingAssumption: 'Token counts are observed. Dollar cost requires an admin-entered pricing or subscription snapshot.',
+  apiEquivalentCostUsd: null,
+  subscriptionMonthlyCostUsd: null,
+  subscriptionAllocatedCostUsd: null,
+  subscriptionSharePct: null,
+}
+
+const DEFAULT_HOURLY_TRANSLATION: BuildEvidenceHourlyTranslation = {
+  defaultBenchmarkHourlyRate: 175,
+  defaultProposalAmount: 30000,
+  focusedHoursLow: 300,
+  focusedHoursHigh: 475,
+  notes: 'Scenario estimate, not a time sheet.',
+}
+
+const DEFAULT_SOURCE_CONFIDENCE: BuildEvidenceSourceConfidence = {
+  label: 'Direct ReversR workspace evidence',
+  confidence: 'high',
+  sourceSummary: 'Strict attribution uses Codex sessions started from the ReversR workspace.',
+  excludedSources: [],
+}
+
+function asRecord(value: unknown): JsonRecord {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : {}
+}
+
+function stringValue(value: unknown, fallback: string): string {
+  return typeof value === 'string' ? value : fallback
+}
+
+function nullableString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
+function numberValue(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+function nullableNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
+}
+
+function clientSafeStringArray(value: unknown): string[] {
+  return stringArray(value).filter((item) => !item.includes('/Users/') && !item.includes('local-private'))
+}
+
+export function sanitizeBuildEvidenceRow(row: BuildEvidenceRow): ClientBuildEvidence {
+  const repo = asRecord(row.repo_metrics)
+  const token = asRecord(row.token_usage)
+  const cost = asRecord(row.cost_summary)
+  const hourly = asRecord(row.hourly_translation)
+  const confidence = asRecord(row.source_confidence)
+
+  return {
+    id: row.id,
+    projectLabel: row.project_label,
+    capturedAt: row.captured_at,
+    repoMetrics: {
+      ...DEFAULT_REPO_METRICS,
+      repoLabel: stringValue(repo.repoLabel, DEFAULT_REPO_METRICS.repoLabel),
+      publicRepoUrl: nullableString(repo.publicRepoUrl),
+      capturedAt: nullableString(repo.capturedAt),
+      allBranchCommitCount: numberValue(repo.allBranchCommitCount, 0),
+      headCommitCount: numberValue(repo.headCommitCount, 0),
+      trackedFiles: numberValue(repo.trackedFiles, 0),
+      trackedCodeDocConfigFiles: numberValue(repo.trackedCodeDocConfigFiles, 0),
+      trackedTextLines: numberValue(repo.trackedTextLines, 0),
+      filesChanged: numberValue(repo.filesChanged, 0),
+      insertions: numberValue(repo.insertions, 0),
+      deletions: numberValue(repo.deletions, 0),
+      releasePassCount: numberValue(repo.releasePassCount, 0),
+      releasePendingCount: numberValue(repo.releasePendingCount, 0),
+      releasePendingGate: nullableString(repo.releasePendingGate),
+      workflow: stringArray(repo.workflow),
+    },
+    tokenUsage: {
+      ...DEFAULT_TOKEN_USAGE,
+      attributionMethod: stringValue(token.attributionMethod, DEFAULT_TOKEN_USAGE.attributionMethod),
+      confidenceLabel: stringValue(token.confidenceLabel, DEFAULT_TOKEN_USAGE.confidenceLabel),
+      comparisonWindowLabel: stringValue(token.comparisonWindowLabel, DEFAULT_TOKEN_USAGE.comparisonWindowLabel),
+      sessionCount: numberValue(token.sessionCount, 0),
+      totalTokens: numberValue(token.totalTokens, 0),
+      inputTokens: numberValue(token.inputTokens, 0),
+      cachedInputTokens: numberValue(token.cachedInputTokens, 0),
+      outputTokens: numberValue(token.outputTokens, 0),
+      reasoningTokens: numberValue(token.reasoningTokens, 0),
+      shareOfComparisonWindowPct: numberValue(token.shareOfComparisonWindowPct, 0),
+      modelProvider: nullableString(token.modelProvider),
+      model: nullableString(token.model),
+      planType: nullableString(token.planType),
+    },
+    costSummary: {
+      ...DEFAULT_COST_SUMMARY,
+      pricingCapturedAt: nullableString(cost.pricingCapturedAt),
+      pricingSourceLabel: stringValue(cost.pricingSourceLabel, DEFAULT_COST_SUMMARY.pricingSourceLabel),
+      pricingAssumption: stringValue(cost.pricingAssumption, DEFAULT_COST_SUMMARY.pricingAssumption),
+      apiEquivalentCostUsd: nullableNumber(cost.apiEquivalentCostUsd),
+      subscriptionMonthlyCostUsd: nullableNumber(cost.subscriptionMonthlyCostUsd),
+      subscriptionAllocatedCostUsd: nullableNumber(cost.subscriptionAllocatedCostUsd),
+      subscriptionSharePct: nullableNumber(cost.subscriptionSharePct),
+    },
+    hourlyTranslation: {
+      ...DEFAULT_HOURLY_TRANSLATION,
+      defaultBenchmarkHourlyRate: numberValue(hourly.defaultBenchmarkHourlyRate, DEFAULT_HOURLY_TRANSLATION.defaultBenchmarkHourlyRate),
+      defaultProposalAmount: numberValue(hourly.defaultProposalAmount, DEFAULT_HOURLY_TRANSLATION.defaultProposalAmount),
+      focusedHoursLow: numberValue(hourly.focusedHoursLow, DEFAULT_HOURLY_TRANSLATION.focusedHoursLow),
+      focusedHoursHigh: numberValue(hourly.focusedHoursHigh, DEFAULT_HOURLY_TRANSLATION.focusedHoursHigh),
+      notes: stringValue(hourly.notes, DEFAULT_HOURLY_TRANSLATION.notes),
+    },
+    sourceConfidence: {
+      ...DEFAULT_SOURCE_CONFIDENCE,
+      label: stringValue(confidence.label, DEFAULT_SOURCE_CONFIDENCE.label),
+      confidence: confidence.confidence === 'medium' || confidence.confidence === 'low' ? confidence.confidence : 'high',
+      sourceSummary: stringValue(confidence.sourceSummary, DEFAULT_SOURCE_CONFIDENCE.sourceSummary),
+      excludedSources: clientSafeStringArray(confidence.excludedSources),
+    },
+    clientSafeNotes: clientSafeStringArray(row.client_safe_notes),
+  }
+}
+
+export async function getBuildEvidenceForClientProject(
+  clientProjectId: string
+): Promise<ClientBuildEvidence | null> {
+  const { data, error } = await supabaseAdmin
+    .from('client_project_build_evidence')
+    .select('id, project_label, captured_at, repo_metrics, token_usage, cost_summary, hourly_translation, source_confidence, client_safe_notes')
+    .eq('client_project_id', clientProjectId)
+    .eq('is_client_visible', true)
+    .order('captured_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (error || !data) {
+    if (error) console.error('Error fetching client build evidence:', error)
+    return null
+  }
+
+  return sanitizeBuildEvidenceRow(data as BuildEvidenceRow)
+}

--- a/lib/client-dashboard.ts
+++ b/lib/client-dashboard.ts
@@ -8,6 +8,7 @@
 import { supabaseAdmin } from './supabase'
 import { getRoadmapBundleForProject, syncRoadmapTaskFromProjection } from './client-ai-ops-roadmap-db'
 import type { RoadmapClientView } from './client-ai-ops-roadmap'
+import { getBuildEvidenceForClientProject, type ClientBuildEvidence } from './client-build-evidence'
 import { getSignedUrl } from './storage'
 import type { CategoryScores, ScoreSnapshot } from './assessment-scoring'
 import type { AssessmentCategory } from './assessment-scoring'
@@ -207,6 +208,7 @@ export interface DashboardData {
   valueReports: ClientValueReport[]
   gammaReports: ClientGammaReport[]
   aiOpsRoadmap: RoadmapClientView | null
+  buildEvidence: ClientBuildEvidence | null
 }
 
 // ============================================================================
@@ -469,6 +471,7 @@ export async function getDashboardByToken(
     timeEntriesResult,
     allValueReportsResult,
     allGammaReportsResult,
+    buildEvidenceResult,
   ] = await Promise.all([
     // Diagnostic audit via contact_submission -> diagnostic_audits
     project.contact_submission_id
@@ -597,6 +600,8 @@ export async function getDashboardByToken(
           .in('status', ['generating', 'completed', 'failed'])
           .order('created_at', { ascending: false })
       : Promise.resolve({ data: null, error: null }),
+
+    getBuildEvidenceForClientProject(projectId),
   ])
 
   const audit = auditResult.data
@@ -781,6 +786,7 @@ export async function getDashboardByToken(
   const valueReports = (allValueReportsResult.data || []) as ClientValueReport[]
   const gammaReports = (allGammaReportsResult.data || []) as ClientGammaReport[]
   const aiOpsRoadmap = await getRoadmapBundleForProject(projectId).then((bundle) => bundle?.clientView ?? null).catch(() => null)
+  const buildEvidence = buildEvidenceResult ?? null
 
   return {
     data: {
@@ -811,6 +817,7 @@ export async function getDashboardByToken(
       valueReports,
       gammaReports,
       aiOpsRoadmap,
+      buildEvidence,
     },
     stage: 'client',
   }

--- a/lib/onboarding-templates.ts
+++ b/lib/onboarding-templates.ts
@@ -38,6 +38,7 @@ export interface SetupRequirement {
 }
 
 export interface MilestoneTemplate {
+  id?: string
   week: number | string
   title: string
   description: string
@@ -45,9 +46,54 @@ export interface MilestoneTemplate {
   phase: number
 }
 
+export type MilestoneEvidenceStatus =
+  | 'verified'
+  | 'pending'
+  | 'access_needed'
+  | 'manual_review'
+
+export type MilestoneEvidenceConfidence = 'high' | 'medium' | 'low'
+
+export interface MilestoneEvidence {
+  id?: string
+  source_type:
+    | 'github'
+    | 'google_play'
+    | 'app_store_connect'
+    | 'stripe'
+    | 'manual'
+    | 'artifact'
+    | 'runtime_smoke'
+    | 'release_gate'
+  source_label: string
+  summary: string
+  confidence: MilestoneEvidenceConfidence
+  status: MilestoneEvidenceStatus
+  source_url?: string
+  source_ref?: string
+  captured_at?: string
+  is_client_visible?: boolean
+}
+
+export interface MilestoneAutomation {
+  source:
+    | 'github'
+    | 'google_play'
+    | 'app_store_connect'
+    | 'stripe'
+    | 'manual'
+    | 'hybrid'
+  status: 'active' | 'access_needed' | 'manual_review' | 'planned'
+  summary: string
+  next_check?: string
+}
+
 export interface Milestone extends MilestoneTemplate {
   target_date?: string
   status: 'pending' | 'in_progress' | 'complete' | 'skipped'
+  completed_at?: string
+  evidence?: MilestoneEvidence[]
+  automation?: MilestoneAutomation
 }
 
 export interface CommunicationPlan {

--- a/lib/proposal-pdf.tsx
+++ b/lib/proposal-pdf.tsx
@@ -786,13 +786,13 @@ export const ProposalDocument: React.FC<{ data: ProposalData }> = ({ data }) => 
             <Text style={styles.totalLabel}>Subtotal:</Text>
             <Text style={styles.totalValue}>{formatCurrency(data.subtotal)}</Text>
           </View>
-          {data.discount_amount && data.discount_amount > 0 && (
+          {Number(data.discount_amount) > 0 && (
             <View style={styles.totalRow}>
               <Text style={styles.totalLabel}>
                 Discount{data.discount_description ? ` (${data.discount_description})` : ''}:
               </Text>
               <Text style={[styles.totalValue, { color: '#10b981' }]}>
-                -{formatCurrency(data.discount_amount)}
+                -{formatCurrency(data.discount_amount ?? 0)}
               </Text>
             </View>
           )}
@@ -851,17 +851,27 @@ export const ProposalDocument: React.FC<{ data: ProposalData }> = ({ data }) => 
 export async function generateProposalPDF(data: ProposalData): Promise<Buffer> {
   const pdfDoc = <ProposalDocument data={data} />;
   const pdfBuffer = await pdf(pdfDoc).toBuffer();
-  // Handle both Buffer and ReadableStream return types
+  // Handle Buffer, Web ReadableStream, and Node Readable stream return types.
   if (Buffer.isBuffer(pdfBuffer)) {
     return pdfBuffer;
   }
-  // Convert ReadableStream to Buffer
+  if (
+    pdfBuffer &&
+    typeof (pdfBuffer as unknown as ReadableStream<Uint8Array>).getReader === 'function'
+  ) {
+    const chunks: Uint8Array[] = [];
+    const reader = (pdfBuffer as unknown as ReadableStream<Uint8Array>).getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) chunks.push(value);
+    }
+    return Buffer.concat(chunks);
+  }
+
   const chunks: Uint8Array[] = [];
-  const reader = (pdfBuffer as unknown as ReadableStream<Uint8Array>).getReader();
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    if (value) chunks.push(value);
+  for await (const chunk of pdfBuffer as AsyncIterable<Uint8Array | Buffer | string>) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
   }
   return Buffer.concat(chunks);
 }

--- a/lib/reversr-build-evidence-extractor.test.ts
+++ b/lib/reversr-build-evidence-extractor.test.ts
@@ -1,0 +1,101 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { extractReversrTokenUsage, parseCodexSessionFile } from './reversr-build-evidence-extractor'
+
+let tmpDir: string
+
+function writeJsonl(relativePath: string, rows: unknown[]) {
+  const filePath = path.join(tmpDir, relativePath)
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, rows.map((row) => JSON.stringify(row)).join('\n'))
+  return filePath
+}
+
+function tokenCount(total: number, input = total - 10, output = 10) {
+  return {
+    timestamp: '2026-06-15T12:00:00.000Z',
+    type: 'event_msg',
+    payload: {
+      type: 'token_count',
+      info: {
+        total_token_usage: {
+          input_tokens: input,
+          cached_input_tokens: Math.floor(input / 2),
+          output_tokens: output,
+          reasoning_output_tokens: 3,
+          total_tokens: total,
+        },
+      },
+      rate_limits: { plan_type: 'pro' },
+    },
+  }
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reversr-evidence-'))
+})
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+describe('parseCodexSessionFile', () => {
+  it('uses the final cumulative token_count event in a session', async () => {
+    const filePath = writeJsonl('2026/06/15/strict.jsonl', [
+      {
+        timestamp: '2026-06-15T11:00:00.000Z',
+        type: 'session_meta',
+        payload: {
+          id: 'session-1',
+          cwd: '/Users/vambahsillah/Documents/ReversR',
+          model_provider: 'openai',
+        },
+      },
+      { timestamp: '2026-06-15T11:00:01.000Z', type: 'turn_context', payload: { model: 'gpt-5.5' } },
+      tokenCount(100, 90, 10),
+      tokenCount(250, 230, 20),
+    ])
+
+    const parsed = await parseCodexSessionFile(filePath)
+
+    expect(parsed.strictWorkspaceMatch).toBe(true)
+    expect(parsed.totalTokens).toBe(250)
+    expect(parsed.inputTokens).toBe(230)
+    expect(parsed.outputTokens).toBe(20)
+    expect(parsed.reasoningTokens).toBe(3)
+    expect(parsed.model).toBe('gpt-5.5')
+    expect(parsed.planType).toBe('pro')
+  })
+})
+
+describe('extractReversrTokenUsage', () => {
+  it('excludes broad keyword matches from client-facing strict attribution', async () => {
+    writeJsonl('strict/reversr.jsonl', [
+      {
+        timestamp: '2026-06-15T11:00:00.000Z',
+        type: 'session_meta',
+        payload: { id: 'strict', cwd: '/Users/vambahsillah/Documents/ReversR' },
+      },
+      tokenCount(300, 270, 30),
+    ])
+    writeJsonl('supporting/portfolio.jsonl', [
+      {
+        timestamp: '2026-06-15T12:00:00.000Z',
+        type: 'session_meta',
+        payload: { id: 'supporting', cwd: '/Users/vambahsillah/Projects/Portfolio' },
+      },
+      { timestamp: '2026-06-15T12:00:01.000Z', type: 'response_item', payload: { text: 'ReversR is mentioned here.' } },
+      tokenCount(700, 680, 20),
+    ])
+
+    const summary = await extractReversrTokenUsage({ sessionsRoot: tmpDir })
+
+    expect(summary.sessionCount).toBe(1)
+    expect(summary.totalTokens).toBe(300)
+    expect(summary.allTotalTokens).toBe(1000)
+    expect(summary.shareOfComparisonWindowPct).toBe(30)
+    expect(summary.supportingMentionCount).toBe(1)
+  })
+})

--- a/lib/reversr-build-evidence-extractor.ts
+++ b/lib/reversr-build-evidence-extractor.ts
@@ -1,0 +1,327 @@
+import fs from 'fs'
+import path from 'path'
+import readline from 'readline'
+import type {
+  BuildEvidenceCostSummary,
+  BuildEvidenceHourlyTranslation,
+  BuildEvidenceRepoMetrics,
+  BuildEvidenceSourceConfidence,
+  BuildEvidenceTokenUsage,
+} from './client-build-evidence'
+
+export interface TokenTotals {
+  inputTokens: number
+  cachedInputTokens: number
+  outputTokens: number
+  reasoningTokens: number
+  totalTokens: number
+}
+
+export interface CodexSessionEvidence extends TokenTotals {
+  filePath: string
+  sessionId: string | null
+  cwd: string | null
+  firstTimestamp: string | null
+  lastTimestamp: string | null
+  modelProvider: string | null
+  model: string | null
+  planType: string | null
+  directReversrMention: boolean
+  strictWorkspaceMatch: boolean
+}
+
+export interface TokenAttributionSummary extends TokenTotals {
+  sessionCount: number
+  allSessionCount: number
+  allTotalTokens: number
+  shareOfComparisonWindowPct: number
+  sessions: CodexSessionEvidence[]
+  supportingMentionCount: number
+  modelProvider: string | null
+  model: string | null
+  planType: string | null
+}
+
+export interface MarkBuildEvidenceSnapshot {
+  projectLabel: string
+  repoMetrics: BuildEvidenceRepoMetrics
+  tokenUsage: BuildEvidenceTokenUsage
+  costSummary: BuildEvidenceCostSummary
+  hourlyTranslation: BuildEvidenceHourlyTranslation
+  sourceConfidence: BuildEvidenceSourceConfidence
+  clientSafeNotes: string[]
+  privateSourceRefs: string[]
+}
+
+export interface ExtractReversrTokenUsageOptions {
+  sessionsRoot: string
+  strictCwdPrefix?: string
+  directMentionPattern?: RegExp
+}
+
+const DEFAULT_STRICT_CWD_PREFIX = '/Users/vambahsillah/Documents/ReversR'
+const DEFAULT_DIRECT_MENTION_PATTERN = /ReversR|ReversR-Rebuild|original-ReversR|Vanguard|Mark Meadows/i
+
+function emptyTotals(): TokenTotals {
+  return {
+    inputTokens: 0,
+    cachedInputTokens: 0,
+    outputTokens: 0,
+    reasoningTokens: 0,
+    totalTokens: 0,
+  }
+}
+
+function addTotals(target: TokenTotals, source: TokenTotals) {
+  target.inputTokens += source.inputTokens
+  target.cachedInputTokens += source.cachedInputTokens
+  target.outputTokens += source.outputTokens
+  target.reasoningTokens += source.reasoningTokens
+  target.totalTokens += source.totalTokens
+}
+
+function numberValue(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
+async function* walkJsonlFiles(root: string): AsyncGenerator<string> {
+  const entries = await fs.promises.readdir(root, { withFileTypes: true })
+  for (const entry of entries) {
+    const filePath = path.join(root, entry.name)
+    if (entry.isDirectory()) {
+      yield* walkJsonlFiles(filePath)
+    } else if (entry.isFile() && entry.name.endsWith('.jsonl')) {
+      yield filePath
+    }
+  }
+}
+
+export async function parseCodexSessionFile(
+  filePath: string,
+  options: Omit<ExtractReversrTokenUsageOptions, 'sessionsRoot'> = {}
+): Promise<CodexSessionEvidence> {
+  const strictCwdPrefix = options.strictCwdPrefix ?? DEFAULT_STRICT_CWD_PREFIX
+  const directMentionPattern = options.directMentionPattern ?? DEFAULT_DIRECT_MENTION_PATTERN
+  const stream = fs.createReadStream(filePath, { encoding: 'utf8' })
+  const reader = readline.createInterface({ input: stream, crlfDelay: Infinity })
+
+  let sessionId: string | null = null
+  let cwd: string | null = null
+  let modelProvider: string | null = null
+  let model: string | null = null
+  let planType: string | null = null
+  let firstTimestamp: string | null = null
+  let lastTimestamp: string | null = null
+  let directReversrMention = false
+  let totals = emptyTotals()
+
+  for await (const line of reader) {
+    if (!directReversrMention && directMentionPattern.test(line)) {
+      directReversrMention = true
+    }
+    if (!line.trim()) continue
+
+    let row: Record<string, unknown>
+    try {
+      row = JSON.parse(line) as Record<string, unknown>
+    } catch {
+      continue
+    }
+
+    const timestamp = stringValue(row.timestamp)
+    if (!firstTimestamp) firstTimestamp = timestamp
+    lastTimestamp = timestamp ?? lastTimestamp
+
+    if (row.type === 'session_meta') {
+      const payload = (row.payload && typeof row.payload === 'object' ? row.payload : {}) as Record<string, unknown>
+      sessionId = stringValue(payload.id) ?? sessionId
+      cwd = stringValue(payload.cwd) ?? cwd
+      modelProvider = stringValue(payload.model_provider) ?? modelProvider
+    }
+
+    if (row.type === 'turn_context') {
+      const payload = (row.payload && typeof row.payload === 'object' ? row.payload : {}) as Record<string, unknown>
+      model = stringValue(payload.model) ?? model
+      cwd = stringValue(payload.cwd) ?? cwd
+    }
+
+    if (row.type === 'event_msg') {
+      const payload = (row.payload && typeof row.payload === 'object' ? row.payload : {}) as Record<string, unknown>
+      if (payload.type === 'token_count') {
+        const info = (payload.info && typeof payload.info === 'object' ? payload.info : {}) as Record<string, unknown>
+        const usage = (info.total_token_usage && typeof info.total_token_usage === 'object'
+          ? info.total_token_usage
+          : {}) as Record<string, unknown>
+        totals = {
+          inputTokens: numberValue(usage.input_tokens),
+          cachedInputTokens: numberValue(usage.cached_input_tokens),
+          outputTokens: numberValue(usage.output_tokens),
+          reasoningTokens: numberValue(usage.reasoning_output_tokens),
+          totalTokens: numberValue(usage.total_tokens),
+        }
+        planType = stringValue(payload.plan_type) ?? planType
+        const rateLimits = (payload.rate_limits && typeof payload.rate_limits === 'object'
+          ? payload.rate_limits
+          : {}) as Record<string, unknown>
+        planType = stringValue(rateLimits.plan_type) ?? planType
+      }
+    }
+  }
+
+  return {
+    filePath,
+    sessionId,
+    cwd,
+    firstTimestamp,
+    lastTimestamp,
+    modelProvider,
+    model,
+    planType,
+    directReversrMention,
+    strictWorkspaceMatch: cwd?.startsWith(strictCwdPrefix) ?? false,
+    ...totals,
+  }
+}
+
+export async function extractReversrTokenUsage(
+  options: ExtractReversrTokenUsageOptions
+): Promise<TokenAttributionSummary> {
+  const totals = emptyTotals()
+  const allTotals = emptyTotals()
+  const sessions: CodexSessionEvidence[] = []
+  let allSessionCount = 0
+  let supportingMentionCount = 0
+
+  for await (const filePath of walkJsonlFiles(options.sessionsRoot)) {
+    const session = await parseCodexSessionFile(filePath, options)
+    if (session.totalTokens <= 0) continue
+
+    allSessionCount += 1
+    addTotals(allTotals, session)
+
+    if (session.strictWorkspaceMatch) {
+      sessions.push(session)
+      addTotals(totals, session)
+    } else if (session.directReversrMention) {
+      supportingMentionCount += 1
+    }
+  }
+
+  const share = allTotals.totalTokens > 0 ? (totals.totalTokens / allTotals.totalTokens) * 100 : 0
+  const firstSession = sessions.find((session) => session.modelProvider || session.model || session.planType)
+
+  return {
+    ...totals,
+    sessionCount: sessions.length,
+    allSessionCount,
+    allTotalTokens: allTotals.totalTokens,
+    shareOfComparisonWindowPct: Math.round(share * 100) / 100,
+    sessions,
+    supportingMentionCount,
+    modelProvider: firstSession?.modelProvider ?? null,
+    model: firstSession?.model ?? null,
+    planType: firstSession?.planType ?? null,
+  }
+}
+
+function repoMetricsFromSnapshot(snapshot: Record<string, any>): BuildEvidenceRepoMetrics {
+  const gitMetrics = snapshot.gitMetrics ?? {}
+  const diff = gitMetrics.rootToHeadDiff ?? {}
+  const release = snapshot.releaseStatus ?? {}
+  const productEvidence = snapshot.productEvidence ?? {}
+  const github = snapshot.github ?? {}
+
+  return {
+    repoLabel: github.nameWithOwner ?? 'vsillah/ReversR-Rebuild',
+    publicRepoUrl: github.url ?? null,
+    capturedAt: snapshot.capturedAt ?? null,
+    allBranchCommitCount: gitMetrics.allBranchCommitCount ?? 0,
+    headCommitCount: gitMetrics.headCommitCount ?? 0,
+    trackedFiles: gitMetrics.trackedFilesExcludingBuildAndExpo ?? 0,
+    trackedCodeDocConfigFiles: gitMetrics.trackedCodeDocConfigFilesExcludingLockfile ?? 0,
+    trackedTextLines: gitMetrics.trackedTextCodeDocLinesExcludingBuildExpoAssetsAndLockfile ?? 0,
+    filesChanged: diff.filesChanged ?? 0,
+    insertions: diff.insertions ?? 0,
+    deletions: diff.deletions ?? 0,
+    releasePassCount: release.pass ?? 0,
+    releasePendingCount: release.pending ?? 0,
+    releasePendingGate: release.remainingPendingGate ?? null,
+    workflow: Array.isArray(productEvidence.workflow) ? productEvidence.workflow : [],
+  }
+}
+
+export async function buildMarkReversrEvidenceSnapshot(input: {
+  repoEvidencePath: string
+  sessionsRoot: string
+  capturedAt?: string
+  subscriptionMonthlyCostUsd?: number | null
+  apiEquivalentCostUsd?: number | null
+}): Promise<MarkBuildEvidenceSnapshot> {
+  const snapshot = JSON.parse(await fs.promises.readFile(input.repoEvidencePath, 'utf8')) as Record<string, any>
+  const tokenSummary = await extractReversrTokenUsage({ sessionsRoot: input.sessionsRoot })
+  const capturedAt = input.capturedAt ?? new Date().toISOString()
+  const subscriptionMonthlyCostUsd = input.subscriptionMonthlyCostUsd ?? null
+  const subscriptionAllocatedCostUsd =
+    subscriptionMonthlyCostUsd == null
+      ? null
+      : Math.round(subscriptionMonthlyCostUsd * (tokenSummary.shareOfComparisonWindowPct / 100) * 100) / 100
+
+  return {
+    projectLabel: 'ReversR Rebuild Product Asset',
+    repoMetrics: repoMetricsFromSnapshot(snapshot),
+    tokenUsage: {
+      attributionMethod: 'strict_reversr_workspace_cwd',
+      confidenceLabel: 'Direct ReversR workspace evidence',
+      comparisonWindowLabel: 'June 2026 local Codex sessions',
+      sessionCount: tokenSummary.sessionCount,
+      totalTokens: tokenSummary.totalTokens,
+      inputTokens: tokenSummary.inputTokens,
+      cachedInputTokens: tokenSummary.cachedInputTokens,
+      outputTokens: tokenSummary.outputTokens,
+      reasoningTokens: tokenSummary.reasoningTokens,
+      shareOfComparisonWindowPct: tokenSummary.shareOfComparisonWindowPct,
+      modelProvider: tokenSummary.modelProvider,
+      model: tokenSummary.model,
+      planType: tokenSummary.planType,
+    },
+    costSummary: {
+      pricingCapturedAt: null,
+      pricingSourceLabel: 'Provider/API pricing snapshot not recorded',
+      pricingAssumption: 'Observed Codex Pro token usage is shown. Dollar cost requires an admin-entered pricing or subscription spend snapshot.',
+      apiEquivalentCostUsd: input.apiEquivalentCostUsd ?? null,
+      subscriptionMonthlyCostUsd,
+      subscriptionAllocatedCostUsd,
+      subscriptionSharePct: tokenSummary.shareOfComparisonWindowPct,
+    },
+    hourlyTranslation: {
+      defaultBenchmarkHourlyRate: 175,
+      defaultProposalAmount: 30000,
+      focusedHoursLow: 300,
+      focusedHoursHigh: 475,
+      notes: 'Scenario estimate, not a time sheet.',
+    },
+    sourceConfidence: {
+      label: 'Direct ReversR workspace evidence',
+      confidence: 'high',
+      sourceSummary: 'Strict attribution includes only Codex sessions whose working directory was the ReversR workspace.',
+      excludedSources: [
+        `${tokenSummary.supportingMentionCount} broader sessions mention ReversR or Mark but were excluded from client-facing token totals.`,
+        'Raw prompts, private strategy notes, local paths, and full session logs stay admin-only.',
+      ],
+    },
+    clientSafeNotes: [
+      'Repository and token metrics are supporting evidence, not billing units.',
+      'Hourly translation is a comparison lens for evaluating replacement cost and fixed-fee economics.',
+      'The final store-console/review gate remains separate from the completed build evidence.',
+    ],
+    privateSourceRefs: [
+      input.repoEvidencePath,
+      input.sessionsRoot,
+      ...tokenSummary.sessions.map((session) => session.filePath),
+    ],
+  }
+}

--- a/migrations/2026_06_15_client_project_build_evidence.sql
+++ b/migrations/2026_06_15_client_project_build_evidence.sql
@@ -1,0 +1,66 @@
+-- ============================================================================
+-- Client Project Build Evidence
+-- Date: 2026-06-15
+-- Purpose: Store client-safe build, token, cost, and hourly translation evidence
+--          for client dashboard projection.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS client_project_build_evidence (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_project_id UUID NOT NULL REFERENCES client_projects(id) ON DELETE CASCADE,
+  evidence_key TEXT NOT NULL DEFAULT 'build_evidence',
+  project_label TEXT NOT NULL,
+  repo_metrics JSONB NOT NULL DEFAULT '{}'::jsonb,
+  token_usage JSONB NOT NULL DEFAULT '{}'::jsonb,
+  cost_summary JSONB NOT NULL DEFAULT '{}'::jsonb,
+  hourly_translation JSONB NOT NULL DEFAULT '{}'::jsonb,
+  source_confidence JSONB NOT NULL DEFAULT '{}'::jsonb,
+  client_safe_notes JSONB NOT NULL DEFAULT '[]'::jsonb,
+  private_source_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+  is_client_visible BOOLEAN NOT NULL DEFAULT false,
+  captured_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (client_project_id, evidence_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_client_project_build_evidence_visible
+  ON client_project_build_evidence (client_project_id, is_client_visible, captured_at DESC);
+
+ALTER TABLE client_project_build_evidence ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Admins can manage client project build evidence"
+  ON client_project_build_evidence;
+CREATE POLICY "Admins can manage client project build evidence"
+  ON client_project_build_evidence
+  FOR ALL
+  TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin')
+  )
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+GRANT ALL ON client_project_build_evidence TO service_role;
+GRANT ALL ON client_project_build_evidence TO authenticated;
+
+CREATE OR REPLACE FUNCTION update_client_project_build_evidence_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS client_project_build_evidence_updated_at
+  ON client_project_build_evidence;
+CREATE TRIGGER client_project_build_evidence_updated_at
+  BEFORE UPDATE ON client_project_build_evidence
+  FOR EACH ROW
+  EXECUTE FUNCTION update_client_project_build_evidence_updated_at();
+
+COMMENT ON TABLE client_project_build_evidence IS
+  'Client-safe dashboard projection for build evidence, token attribution, cost translation, and hourly comparison scenarios.';
+COMMENT ON COLUMN client_project_build_evidence.private_source_refs IS
+  'Admin-only provenance pointers. Never return this field from token-based client dashboard APIs.';

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "model-ops:reply-intent:export": "tsx scripts/export-reply-intent-reviews.ts",
     "model-ops:reply-intent:sync": "tsx scripts/sync-reply-intent-review-candidates.ts",
     "model-ops:research:plan": "tsx scripts/model-ops-research-plan.ts",
+    "client:seed-mark-reversr": "tsx scripts/seed-mark-reversr-build-evidence.ts",
     "open-brain:mcp": "tsx scripts/open-brain-mcp-server.ts",
     "open-brain:runtime-registration": "tsx scripts/open-brain-runtime-registration.ts",
     "open-brain:personality-corpus": "tsx scripts/open-brain-personality-corpus-producer.ts",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "model-ops:reply-intent:sync": "tsx scripts/sync-reply-intent-review-candidates.ts",
     "model-ops:research:plan": "tsx scripts/model-ops-research-plan.ts",
     "client:seed-mark-reversr": "tsx scripts/seed-mark-reversr-build-evidence.ts",
+    "client:seed-mark-reversr-assessment": "tsx scripts/seed-mark-reversr-assessment.ts",
     "open-brain:mcp": "tsx scripts/open-brain-mcp-server.ts",
     "open-brain:runtime-registration": "tsx scripts/open-brain-runtime-registration.ts",
     "open-brain:personality-corpus": "tsx scripts/open-brain-personality-corpus-producer.ts",

--- a/scripts/seed-mark-reversr-assessment.ts
+++ b/scripts/seed-mark-reversr-assessment.ts
@@ -2,12 +2,20 @@
 
 import { supabaseAdmin } from '@/lib/supabase'
 import { calculateDreamOutcomeGap, calculateOverallScore, type CategoryScores } from '@/lib/assessment-scoring'
+import {
+  generateProposalPDF,
+  type ProposalData,
+  type ProposalLineItem,
+  type ProposalValueAssessment,
+} from '@/lib/proposal-pdf'
 
 const args = new Set(process.argv.slice(2))
 
 const CLIENT_EMAIL = process.env.MARK_MEADOWS_EMAIL || 'mark.meadows@offline.local'
 const ASSESSMENT_KEY = 'mark-reversr-client-safe-assessment-v1'
 const ROADMAP_KEY = 'mark-reversr-client-roadmap-v1'
+const PROPOSAL_KEY = 'mark-reversr-fixed-fee-proposal-v1'
+const PROPOSAL_BUNDLE_NAME = 'ReversR Rebuild Product Asset Proposal'
 const REVERSR_REPO_URL = 'https://github.com/vsillah/ReversR-Rebuild'
 const EVIDENCE_CAPTURED_AT = '2026-06-15T12:00:00.000Z'
 
@@ -18,6 +26,91 @@ const categoryScores: CategoryScores = {
   ai_readiness: 48,
   budget_timeline: 45,
   decision_making: 38,
+}
+
+const proposalLineItems: ProposalLineItem[] = [
+  {
+    content_type: 'service',
+    content_id: 'reversr-phase-1',
+    offer_role: 'core_offer',
+    title: 'Phase 1: ReversR 1.0 Product Asset Completion',
+    description:
+      'Complete the current app build, distribute to internal testers, support the 12-tester GO threshold, and prepare the 1.0 iOS/Android release path.',
+    price: 30000,
+    perceived_value: 83125,
+  },
+  {
+    content_type: 'service',
+    content_id: 'reversr-phase-2-website',
+    offer_role: 'upsell',
+    title: 'Phase 2 Option: Website Embed and Order Flow',
+    description:
+      'Optional expansion after Phase 1 validation: embed the app in Vanguard’s web presence and connect output to order or machine-build intake.',
+    price: 0,
+    perceived_value: 25000,
+  },
+  {
+    content_type: 'service',
+    content_id: 'reversr-phase-2-local-ai',
+    offer_role: 'upsell',
+    title: 'Phase 2 Option: Local AI Architecture',
+    description:
+      'Optional architecture track for local or hybrid AI generation, including local server, hardware, latency, quality, and security tradeoff review.',
+    price: 0,
+    perceived_value: 35000,
+  },
+  {
+    content_type: 'service',
+    content_id: 'reversr-continuity',
+    offer_role: 'continuity',
+    title: 'Optional Continuity: Technology Stewardship',
+    description:
+      'Optional post-launch advisory, maintenance, release support, evidence tracking, and roadmap governance under a separate monthly continuity agreement.',
+    price: 0,
+    perceived_value: 5000,
+  },
+]
+
+const proposalTerms = [
+  'Pricing posture: fixed-fee product-asset consulting. Repository metrics, token usage, and hourly translation are evidence lenses only; they are not the billing unit.',
+  'Phase 1 scope: complete and stabilize the ReversR rebuild, distribute the test app internally, validate the 12-tester GO threshold, prepare iOS/Android 1.0 release evidence, and produce a client-safe build evidence record.',
+  'Current investment: $30,000 fixed fee for Phase 1. The dashboard support evidence includes 149 all-branch commits, 36,775 tracked code/doc/config lines, 38 passed release gates, and strict ReversR Codex usage attribution.',
+  'Phase 2 options are intentionally not included in the Phase 1 fixed fee. Website embedding, order fulfillment, local AI, cloud/local/hybrid infrastructure, and long-term website/app stewardship require a separate scope and decision gate after Phase 1 validation.',
+  'Ownership, equity participation, payment credits, device purchases, and long-term maintenance are separate business terms. They should be documented explicitly before any continuation beyond Phase 1.',
+  'Client-safe evidence only: proposal and dashboard surfaces exclude raw prompts, private strategy notes, local filesystem paths, full Codex session logs, and private chat material.',
+].join('\n\n')
+
+const proposalValueAssessment: ProposalValueAssessment = {
+  industry: 'Engineering Services',
+  companySizeRange: '1-10',
+  totalAnnualValue: 83125,
+  valueStatements: [
+    {
+      painPoint: 'Product asset rebuild and release readiness',
+      annualValue: 83125,
+      confidence: 'medium',
+      calculationMethod: 'replacement_cost',
+      formulaReadable: '300-475 focused-hour scenario x $175 benchmark rate',
+      evidenceSummary:
+        'Scenario range from 300-475 focused hours at a $175 benchmark rate, plus repository and token-attribution evidence.',
+    },
+    {
+      painPoint: 'Website-connected order flow',
+      annualValue: 25000,
+      confidence: 'low',
+      calculationMethod: 'revenue_acceleration',
+      formulaReadable: 'Phase 2 option value placeholder pending validated order flow',
+      evidenceSummary: 'Phase 2 option pending validation and website/order-flow scope.',
+    },
+    {
+      painPoint: 'Local AI architecture and secure generation',
+      annualValue: 35000,
+      confidence: 'low',
+      calculationMethod: 'replacement_cost',
+      formulaReadable: 'Phase 2 option value placeholder pending architecture decision',
+      evidenceSummary: 'Phase 2 option pending local/cloud/hybrid architecture decision.',
+    },
+  ],
 }
 
 const assessmentPayload = {
@@ -496,7 +589,7 @@ async function findOrCreateContact(apply: boolean) {
 async function findProject() {
   const { data, error } = await supabaseAdmin
     .from('client_projects')
-    .select('id, contact_submission_id')
+    .select('id, contact_submission_id, proposal_id')
     .or('project_name.ilike.%ReversR Rebuild%,client_name.ilike.%Mark Meadows%,client_company.ilike.%Vanguard%')
     .order('created_at', { ascending: false })
     .limit(1)
@@ -506,7 +599,7 @@ async function findProject() {
     throw new Error(`Failed to find Mark/ReversR project: ${error?.message ?? 'not found'}`)
   }
 
-  return data as { id: string; contact_submission_id: number | null }
+  return data as { id: string; contact_submission_id: number | null; proposal_id: string | null }
 }
 
 async function upsertAudit(contactSubmissionId: number, apply: boolean) {
@@ -556,6 +649,164 @@ async function upsertProjectLink(projectId: string, contactSubmissionId: number,
     .eq('id', projectId)
 
   if (error) throw new Error(`Failed to link project to Mark contact: ${error.message}`)
+}
+
+async function findOrCreateProposal(projectId: string, apply: boolean) {
+  const validUntil = new Date()
+  validUntil.setDate(validUntil.getDate() + 30)
+
+  const proposalPayload = {
+    client_name: 'Mark Meadows',
+    client_email: CLIENT_EMAIL,
+    client_company: 'Vanguard Enterprises',
+    bundle_name: PROPOSAL_BUNDLE_NAME,
+    line_items: proposalLineItems,
+    subtotal: 30000,
+    discount_amount: 0,
+    discount_description: null,
+    total_amount: 30000,
+    terms_text: proposalTerms,
+    valid_until: validUntil.toISOString(),
+    status: 'sent',
+    service_term_months: null,
+  }
+
+  const { data: existing, error: readError } = await supabaseAdmin
+    .from('proposals')
+    .select('id, created_at')
+    .eq('client_email', CLIENT_EMAIL)
+    .eq('bundle_name', PROPOSAL_BUNDLE_NAME)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (readError) throw new Error(`Failed to read Mark proposal: ${readError.message}`)
+  if (!apply) return existing?.id ?? 'dry-run-proposal-id'
+
+  let proposalId = existing?.id as string | undefined
+  let createdAt = (existing?.created_at as string | undefined) ?? new Date().toISOString()
+
+  if (proposalId) {
+    const { error } = await supabaseAdmin
+      .from('proposals')
+      .update(proposalPayload)
+      .eq('id', proposalId)
+
+    if (error) throw new Error(`Failed to update Mark proposal: ${error.message}`)
+  } else {
+    const { data, error } = await supabaseAdmin
+      .from('proposals')
+      .insert(proposalPayload)
+      .select('id, created_at')
+      .single()
+
+    if (error || !data?.id) {
+      throw new Error(`Failed to create Mark proposal: ${error?.message ?? 'missing id'}`)
+    }
+    proposalId = data.id as string
+    createdAt = data.created_at as string
+  }
+
+  const pdfData: ProposalData = {
+    id: proposalId,
+    proposalNumber: PROPOSAL_KEY,
+    client_name: proposalPayload.client_name,
+    client_email: proposalPayload.client_email,
+    client_company: proposalPayload.client_company,
+    bundle_name: proposalPayload.bundle_name,
+    bundle_description:
+      'A phased, fixed-fee proposal for the ReversR rebuild product asset, with Phase 2 expansion and continuity options preserved as separate decision gates.',
+    line_items: proposalLineItems,
+    subtotal: proposalPayload.subtotal,
+    discount_amount: proposalPayload.discount_amount,
+    discount_description: undefined,
+    total_amount: proposalPayload.total_amount,
+    terms_text: proposalPayload.terms_text,
+    valid_until: proposalPayload.valid_until,
+    created_at: createdAt,
+    company_name: 'AmaduTown Advisory Solutions',
+    value_assessment: proposalValueAssessment,
+  }
+  const pdfBuffer = await generateProposalPDF(pdfData)
+
+  const proposalFilePath = `proposals/${proposalId}.pdf`
+  const { error: proposalUploadError } = await supabaseAdmin.storage
+    .from('documents')
+    .upload(proposalFilePath, pdfBuffer, {
+      contentType: 'application/pdf',
+      upsert: true,
+    })
+
+  if (proposalUploadError) {
+    throw new Error(`Failed to upload Mark proposal PDF: ${proposalUploadError.message}`)
+  }
+
+  const { data: proposalUrl } = supabaseAdmin.storage
+    .from('documents')
+    .getPublicUrl(proposalFilePath)
+
+  const proposalPackagePath = `proposal-docs/${proposalId}/${PROPOSAL_KEY}.pdf`
+  const { error: packageUploadError } = await supabaseAdmin.storage
+    .from('documents')
+    .upload(proposalPackagePath, pdfBuffer, {
+      contentType: 'application/pdf',
+      upsert: true,
+    })
+
+  if (packageUploadError) {
+    throw new Error(`Failed to upload Mark proposal package PDF: ${packageUploadError.message}`)
+  }
+
+  const { error: proposalUpdateError } = await supabaseAdmin
+    .from('proposals')
+    .update({ pdf_url: proposalUrl.publicUrl })
+    .eq('id', proposalId)
+
+  if (proposalUpdateError) {
+    throw new Error(`Failed to attach proposal PDF URL: ${proposalUpdateError.message}`)
+  }
+
+  const { data: existingDoc, error: docReadError } = await supabaseAdmin
+    .from('proposal_documents')
+    .select('id')
+    .eq('proposal_id', proposalId)
+    .eq('title', 'ReversR Proposal Package: Evidence, Options & Phase Gates')
+    .maybeSingle()
+
+  if (docReadError) {
+    throw new Error(`Failed to read Mark proposal package document: ${docReadError.message}`)
+  }
+
+  const docPayload = {
+    proposal_id: proposalId,
+    document_type: 'proposal_package',
+    title: 'ReversR Proposal Package: Evidence, Options & Phase Gates',
+    file_path: proposalPackagePath,
+    display_order: 0,
+    source: 'generated',
+  }
+
+  if (existingDoc?.id) {
+    const { error } = await supabaseAdmin
+      .from('proposal_documents')
+      .update(docPayload)
+      .eq('id', existingDoc.id)
+    if (error) throw new Error(`Failed to update Mark proposal package document: ${error.message}`)
+  } else {
+    const { error } = await supabaseAdmin
+      .from('proposal_documents')
+      .insert(docPayload)
+    if (error) throw new Error(`Failed to create Mark proposal package document: ${error.message}`)
+  }
+
+  const { error: linkError } = await supabaseAdmin
+    .from('client_projects')
+    .update({ proposal_id: proposalId })
+    .eq('id', projectId)
+
+  if (linkError) throw new Error(`Failed to link Mark proposal to project: ${linkError.message}`)
+
+  return proposalId
 }
 
 async function upsertRoadmapMilestones(projectId: string, apply: boolean) {
@@ -712,6 +963,7 @@ async function main() {
   if (contactSubmissionId) {
     await upsertProjectLink(project.id, contactSubmissionId, apply)
   }
+  const proposalId = await findOrCreateProposal(project.id, apply)
   const onboardingPlanId = await upsertRoadmapMilestones(project.id, apply)
   const scoreSnapshot = await createScoreSnapshot(project.id, apply)
 
@@ -720,6 +972,7 @@ async function main() {
     clientProjectId: project.id,
     contactSubmissionId,
     diagnosticAuditId: auditId,
+    proposalId,
     onboardingPlanId,
     milestoneCount: roadmapMilestones.length,
     scoreSnapshot,

--- a/scripts/seed-mark-reversr-assessment.ts
+++ b/scripts/seed-mark-reversr-assessment.ts
@@ -8,6 +8,8 @@ const args = new Set(process.argv.slice(2))
 const CLIENT_EMAIL = process.env.MARK_MEADOWS_EMAIL || 'mark.meadows@offline.local'
 const ASSESSMENT_KEY = 'mark-reversr-client-safe-assessment-v1'
 const ROADMAP_KEY = 'mark-reversr-client-roadmap-v1'
+const REVERSR_REPO_URL = 'https://github.com/vsillah/ReversR-Rebuild'
+const EVIDENCE_CAPTURED_AT = '2026-06-15T12:00:00.000Z'
 
 const categoryScores: CategoryScores = {
   business_challenges: 68,
@@ -113,6 +115,7 @@ const assessmentPayload = {
 
 const roadmapMilestones = [
   {
+    id: 'reversr-m0-internal-test-distribution',
     week: 0,
     title: 'Distribute the test app to internal testers',
     description:
@@ -124,8 +127,43 @@ const roadmapMilestones = [
     ],
     phase: 1,
     status: 'in_progress',
+    evidence: [
+      {
+        id: 'm0-build-depth',
+        source_type: 'github',
+        source_label: 'GitHub repository evidence',
+        summary:
+          'ReversR-Rebuild repository evidence shows 149 all-branch commits, 36,775 tracked code/doc/config lines, and 38 passed release gates supporting test-build readiness.',
+        confidence: 'high',
+        status: 'verified',
+        source_url: REVERSR_REPO_URL,
+        source_ref: 'client_project_build_evidence.repo_metrics',
+        captured_at: EVIDENCE_CAPTURED_AT,
+        is_client_visible: true,
+      },
+      {
+        id: 'm0-store-testers',
+        source_type: 'release_gate',
+        source_label: 'Tester distribution records',
+        summary:
+          'Store-console tester distribution needs App Store Connect and Google Play evidence before this can be marked fully verified.',
+        confidence: 'medium',
+        status: 'access_needed',
+        source_ref: 'app_store_connect/google_play tester groups',
+        captured_at: EVIDENCE_CAPTURED_AT,
+        is_client_visible: true,
+      },
+    ],
+    automation: {
+      source: 'hybrid',
+      status: 'access_needed',
+      summary:
+        'GitHub can support build and release-gate evidence; App Store Connect and Google Play access are required to automate tester distribution verification.',
+      next_check: 'Connect store-console exports or API access.',
+    },
   },
   {
+    id: 'reversr-m1-twelve-tester-go',
     week: 1,
     title: 'Secure 12 internal tester GO decisions',
     description:
@@ -137,8 +175,40 @@ const roadmapMilestones = [
     ],
     phase: 1,
     status: 'pending',
+    evidence: [
+      {
+        id: 'm1-go-log',
+        source_type: 'manual',
+        source_label: 'Tester GO decision log',
+        summary:
+          'The 12-tester GO threshold should be verified from tester responses, survey records, or store beta feedback once testers are active.',
+        confidence: 'medium',
+        status: 'pending',
+        captured_at: EVIDENCE_CAPTURED_AT,
+        is_client_visible: true,
+      },
+      {
+        id: 'm1-store-feedback',
+        source_type: 'google_play',
+        source_label: 'Google Play / App Store beta feedback',
+        summary:
+          'Store beta feedback requires connected Google Play and App Store Connect access before it can become automated evidence.',
+        confidence: 'medium',
+        status: 'access_needed',
+        captured_at: EVIDENCE_CAPTURED_AT,
+        is_client_visible: true,
+      },
+    ],
+    automation: {
+      source: 'hybrid',
+      status: 'planned',
+      summary:
+        'Automate from a tester response sheet first, then replace or enrich with store beta feedback when platform access is available.',
+      next_check: 'Define the tester GO response source.',
+    },
   },
   {
+    id: 'reversr-m2-ios-android-1-0-release',
     week: 2,
     title: 'Release ReversR 1.0 to iOS and Android',
     description:
@@ -150,8 +220,42 @@ const roadmapMilestones = [
     ],
     phase: 1,
     status: 'pending',
+    evidence: [
+      {
+        id: 'm2-release-gates',
+        source_type: 'github',
+        source_label: 'Release readiness gates',
+        summary:
+          'Current build evidence shows 38 release gates passed and 1 pending store-console gate before full release evidence can be claimed.',
+        confidence: 'high',
+        status: 'manual_review',
+        source_url: REVERSR_REPO_URL,
+        source_ref: 'client_project_build_evidence.repo_metrics.release_gates',
+        captured_at: EVIDENCE_CAPTURED_AT,
+        is_client_visible: true,
+      },
+      {
+        id: 'm2-store-links',
+        source_type: 'app_store_connect',
+        source_label: 'iOS and Android store records',
+        summary:
+          'Public release should be verified with App Store and Google Play listing URLs or store-console release records.',
+        confidence: 'high',
+        status: 'access_needed',
+        captured_at: EVIDENCE_CAPTURED_AT,
+        is_client_visible: true,
+      },
+    ],
+    automation: {
+      source: 'hybrid',
+      status: 'access_needed',
+      summary:
+        'GitHub can track release prep, tags, builds, and workflows; store release truth requires Apple and Google account access.',
+      next_check: 'Connect App Store Connect and Google Play evidence sources.',
+    },
   },
   {
+    id: 'reversr-m3-generate-product-proof',
     week: 3,
     title: 'Generate a product with the app',
     description:
@@ -163,8 +267,29 @@ const roadmapMilestones = [
     ],
     phase: 2,
     status: 'pending',
+    evidence: [
+      {
+        id: 'm3-output-package',
+        source_type: 'artifact',
+        source_label: 'Generated product proof package',
+        summary:
+          'Completion should be backed by an exported app output, screenshots, review notes, and manufacturability assessment.',
+        confidence: 'medium',
+        status: 'pending',
+        captured_at: EVIDENCE_CAPTURED_AT,
+        is_client_visible: true,
+      },
+    ],
+    automation: {
+      source: 'manual',
+      status: 'planned',
+      summary:
+        'This milestone needs artifact capture from the app workflow; GitHub can store/review the proof package but cannot prove product quality alone.',
+      next_check: 'Choose the test product and evidence packet format.',
+    },
   },
   {
+    id: 'reversr-m4-website-order-fulfillment',
     week: 4,
     title: 'Embed the app into the website and connect order fulfillment',
     description:
@@ -176,8 +301,42 @@ const roadmapMilestones = [
     ],
     phase: 2,
     status: 'pending',
+    evidence: [
+      {
+        id: 'm4-website-workflow',
+        source_type: 'runtime_smoke',
+        source_label: 'Website/order-flow smoke test',
+        summary:
+          'Completion should be verified by a working website path from app interaction to order or machine-build request submission.',
+        confidence: 'medium',
+        status: 'pending',
+        source_url: 'http://vanguardenterprises.com/',
+        captured_at: EVIDENCE_CAPTURED_AT,
+        is_client_visible: true,
+      },
+      {
+        id: 'm4-repo-integration',
+        source_type: 'github',
+        source_label: 'Integration code evidence',
+        summary:
+          'GitHub can verify implementation changes once the website embed and order-flow code are committed.',
+        confidence: 'medium',
+        status: 'pending',
+        source_url: REVERSR_REPO_URL,
+        captured_at: EVIDENCE_CAPTURED_AT,
+        is_client_visible: true,
+      },
+    ],
+    automation: {
+      source: 'github',
+      status: 'planned',
+      summary:
+        'Automate verification with GitHub deployment checks plus a smoke test that submits a non-production order request.',
+      next_check: 'Define the website integration target and test-safe order path.',
+    },
   },
   {
+    id: 'reversr-m5-local-llm-server',
     week: 5,
     title: 'Integrate a local LLM through a local server',
     description:
@@ -189,8 +348,41 @@ const roadmapMilestones = [
     ],
     phase: 3,
     status: 'pending',
+    evidence: [
+      {
+        id: 'm5-architecture-proof',
+        source_type: 'runtime_smoke',
+        source_label: 'Local AI runtime evidence',
+        summary:
+          'Completion should be verified by local server run evidence, model configuration, output quality checks, and latency/security notes.',
+        confidence: 'medium',
+        status: 'pending',
+        captured_at: EVIDENCE_CAPTURED_AT,
+        is_client_visible: true,
+      },
+      {
+        id: 'm5-github-implementation',
+        source_type: 'github',
+        source_label: 'Local AI implementation commits',
+        summary:
+          'GitHub can verify local-server implementation changes, configuration, and tests after the architecture is selected.',
+        confidence: 'medium',
+        status: 'pending',
+        source_url: REVERSR_REPO_URL,
+        captured_at: EVIDENCE_CAPTURED_AT,
+        is_client_visible: true,
+      },
+    ],
+    automation: {
+      source: 'github',
+      status: 'planned',
+      summary:
+        'Automate from local runtime smoke-test artifacts and GitHub commits; hardware/security acceptance remains a decision gate.',
+      next_check: 'Decide local, cloud, or hybrid architecture for Phase 2/3.',
+    },
   },
   {
+    id: 'reversr-m6-client-purchase-path',
     week: 6,
     title: 'Convert clients into app purchasers',
     description:
@@ -202,6 +394,37 @@ const roadmapMilestones = [
     ],
     phase: 3,
     status: 'pending',
+    evidence: [
+      {
+        id: 'm6-purchase-records',
+        source_type: 'stripe',
+        source_label: 'Purchase/payment records',
+        summary:
+          'Client purchase evidence should come from the agreed checkout, invoice, or contract system after the commercial offer is finalized.',
+        confidence: 'high',
+        status: 'pending',
+        captured_at: EVIDENCE_CAPTURED_AT,
+        is_client_visible: true,
+      },
+      {
+        id: 'm6-offer-path',
+        source_type: 'manual',
+        source_label: 'Offer and continuity model',
+        summary:
+          'The offer should preserve fixed-fee/value pricing while using hourly translation only as a comparison lens.',
+        confidence: 'medium',
+        status: 'manual_review',
+        captured_at: EVIDENCE_CAPTURED_AT,
+        is_client_visible: true,
+      },
+    ],
+    automation: {
+      source: 'hybrid',
+      status: 'planned',
+      summary:
+        'Automate purchase verification from Stripe or signed-order records once the client purchase path is chosen.',
+      next_check: 'Choose the commercial system of record.',
+    },
   },
 ] as const
 

--- a/scripts/seed-mark-reversr-assessment.ts
+++ b/scripts/seed-mark-reversr-assessment.ts
@@ -265,7 +265,7 @@ const roadmapMilestones = [
       'Generated output package',
       'Review notes on quality, manufacturability, and next-step effort',
     ],
-    phase: 2,
+    phase: 1,
     status: 'in_progress',
     evidence: [
       {
@@ -346,7 +346,7 @@ const roadmapMilestones = [
       'Local server prototype or implementation plan',
       'Validation criteria for AI quality, latency, hardware, and security',
     ],
-    phase: 3,
+    phase: 2,
     status: 'in_progress',
     evidence: [
       {
@@ -392,7 +392,7 @@ const roadmapMilestones = [
       'Offer/pricing structure',
       'Continuity or support model for post-purchase delivery',
     ],
-    phase: 3,
+    phase: 2,
     status: 'in_progress',
     evidence: [
       {

--- a/scripts/seed-mark-reversr-assessment.ts
+++ b/scripts/seed-mark-reversr-assessment.ts
@@ -1,0 +1,270 @@
+#!/usr/bin/env tsx
+
+import { supabaseAdmin } from '@/lib/supabase'
+import { calculateDreamOutcomeGap, calculateOverallScore, type CategoryScores } from '@/lib/assessment-scoring'
+
+const args = new Set(process.argv.slice(2))
+
+const CLIENT_EMAIL = process.env.MARK_MEADOWS_EMAIL || 'mark.meadows@offline.local'
+const ASSESSMENT_KEY = 'mark-reversr-client-safe-assessment-v1'
+
+const categoryScores: CategoryScores = {
+  business_challenges: 68,
+  tech_stack: 62,
+  automation_needs: 52,
+  ai_readiness: 48,
+  budget_timeline: 45,
+  decision_making: 38,
+}
+
+const assessmentPayload = {
+  audit_type: 'from_meetings',
+  status: 'completed',
+  business_name: 'Vanguard Enterprises',
+  website_url: 'http://vanguardenterprises.com/services---solutions.html',
+  contact_email: CLIENT_EMAIL,
+  industry_slug: 'engineering-services',
+  report_tier: 'bronze',
+  completed_at: new Date().toISOString(),
+  metadata: {
+    assessment_key: ASSESSMENT_KEY,
+    client_safe: true,
+    source_urls: ['http://vanguardenterprises.com/services---solutions.html'],
+    source_summary:
+      'Public Vanguard services page plus client-safe consultant discovery notes; excludes private prompts, raw chat logs, and relationship strategy notes.',
+  },
+  diagnostic_summary:
+    'Vanguard Enterprises presents itself as a provider of project management, IT infrastructure, CAD, and CAM services. The ReversR rebuild extends that engineering-services posture into a product-asset workflow: a user-facing application that can help translate visual or design inputs into a clearer path toward manufacturable output, validation, and eventual ordering. The immediate business question is not whether engineering knowledge exists; it is whether the app can make that knowledge easier to access, trust, and convert into paid work without creating an open-ended consulting relationship.',
+  key_insights: [
+    'The public company positioning already supports a technology-plus-manufacturing frame: project management, IT infrastructure, CAD, and CAM.',
+    'The ReversR app gives Vanguard a productized front door for engineering demand, but customer validation and order-flow design are still pending.',
+    'The current build evidence is strong enough to support replacement-cost and fixed-fee discussion, while the commercial model still needs phase gates.',
+    'The largest current gap is not code volume; it is decision clarity around scope, ownership, validation thresholds, and post-launch continuity.',
+  ],
+  recommended_actions: [
+    'Use Phase 1 to validate that the core audience understands the app output and would pay for the resulting engineering/manufacturing workflow.',
+    'Define the order path before Phase 2: website embed, intake requirements, review handoff, quote generation, and machine-build request flow.',
+    'Decide whether local AI, cloud AI, or a hybrid model is required based on accuracy, security, cost, and hardware constraints.',
+    'Separate consulting compensation, product/IP ownership, and any optional upside participation before expanding the roadmap.',
+  ],
+  business_challenges: {
+    score: categoryScores.business_challenges,
+    summary:
+      'Vanguard has a clear public services frame around project management, IT infrastructure, CAD, and CAM, with stated emphasis on benchmark performance, quality control, and cost-effective solutions. ReversR can strengthen that frame by turning engineering expertise into a productized intake and validation experience. The remaining gap is sharper market definition: who the first buyer is, what job they trust the app to perform, and what commercial proof moves the work from prototype to offer.',
+    current_state:
+      'Public positioning is credible but broad. ReversR is a focused product asset, but the first paid use case and buyer segment still need validation.',
+    dream_outcome:
+      'A clear, client-safe product story: Vanguard helps customers move from visual/design input to manufacturable next steps and paid engineering/manufacturing orders.',
+    evidence: ['Public services page: project management, IT infrastructure, CAD, CAM', 'ReversR build evidence dashboard'],
+  },
+  tech_stack: {
+    score: categoryScores.tech_stack,
+    summary:
+      'The public website appears to be an older static business site, while the current ReversR rebuild is a modern application with AI-assisted vision/observability through Gemini. The core technical asset exists, but the website embed, production hosting posture, secure client access, and local/cloud AI architecture are not fully resolved.',
+    current_state:
+      'Legacy website plus a rebuilt app asset. Gemini is being used today for vision/observability; future local AI remains a larger infrastructure decision.',
+    dream_outcome:
+      'A secure, maintainable client-facing app embedded or linked from Vanguard’s web presence, with clear deployment, support, and AI architecture choices.',
+    public_site_observations: ['Project Management', 'IT Infrastructure', 'Computer Aided Design (CAD)', 'Computer Aided Manufacturing (CAM)'],
+    known_gaps: ['Website embed path', 'Production deployment model', 'Local-vs-cloud AI decision', 'Security/offline operating constraints'],
+  },
+  automation_needs: {
+    score: categoryScores.automation_needs,
+    summary:
+      'The app can reduce the effort required to interpret inputs and prepare next-step engineering conversations, but the full automation path is still emerging. The order workflow, review handoff, quoting, and manufacturing request process need to be designed before the app can function as a reliable sales and delivery front door.',
+    current_state:
+      'Prototype/product asset reduces analysis burden, but order intake and manufacturing handoff are still manual or undefined.',
+    dream_outcome:
+      'A guided workflow that moves from app interaction to order submission, review, quote, and machine-build request with minimal avoidable back-and-forth.',
+  },
+  ai_readiness: {
+    score: categoryScores.ai_readiness,
+    summary:
+      'AI is already present through Gemini-supported vision/observability, which is enough for Phase 1 validation. The next readiness gap is reliability: accuracy checks, source-backed outputs, local/cloud tradeoffs, and the hardware requirements for local AI if security or offline operation becomes mandatory.',
+    current_state:
+      'AI-assisted prototype with cloud model support. Validation thresholds and local AI requirements are not yet settled.',
+    dream_outcome:
+      'A validated AI workflow that produces trusted, observable outputs and can move to local, cloud, or hybrid architecture based on measured need.',
+  },
+  budget_timeline: {
+    score: categoryScores.budget_timeline,
+    summary:
+      'Phase 1 should stay focused on app completion and audience validation. Phase 2 can expand into website embedding, order workflow, AI architecture, and potentially website management. Budget should be framed as fixed product/value investment with hourly translation only as a comparison lens.',
+    current_state:
+      'Build evidence exists and Phase 1 is underway. Future phases and pricing terms need explicit gates.',
+    dream_outcome:
+      'A phased roadmap where each expansion has a validation threshold, fixed-fee scope, and clear continuity or upsell option.',
+  },
+  decision_making: {
+    score: categoryScores.decision_making,
+    summary:
+      'Decision-making is the weakest current area because the engagement needs clearer boundaries around consulting compensation, product ownership, optional upside, and long-term maintenance. The next proposal should make these decision gates explicit so both sides can collaborate without turning the work into an indefinite employee-style arrangement.',
+    current_state:
+      'There is shared interest in the product direction, but scope, compensation, ownership, and continuity terms need formalization.',
+    dream_outcome:
+      'A bounded consulting relationship with clear phase gates, payment terms, ownership language, and optional continuity paths.',
+  },
+  urgency_score: 7,
+  opportunity_score: 8,
+  sales_notes:
+    'Client-safe assessment seed. Do not expose raw private conversation, prompt logs, or local file paths in client surfaces.',
+}
+
+async function findOrCreateContact(apply: boolean) {
+  const { data: existing, error } = await supabaseAdmin
+    .from('contact_submissions')
+    .select('id')
+    .or(`email.eq.${CLIENT_EMAIL},and(name.ilike.%Mark Meadows%,company.ilike.%Vanguard%)`)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (error) throw new Error(`Failed to read Mark contact: ${error.message}`)
+  if (existing?.id) return existing.id as number
+  if (!apply) return 0
+
+  const { data, error: insertError } = await supabaseAdmin
+    .from('contact_submissions')
+    .insert({
+      name: 'Mark Meadows',
+      email: CLIENT_EMAIL,
+      company: 'Vanguard Enterprises',
+      company_domain: 'vanguardenterprises.com',
+      job_title: 'VP Engineering',
+      industry: 'Engineering Services',
+      lead_source: 'other',
+      qualification_status: 'qualified',
+      is_decision_maker: true,
+      interest_areas: ['productized engineering workflow', 'CAD/CAM', 'AI-assisted manufacturing intake'],
+      interest_summary:
+        'Client-safe contact record for ReversR rebuild assessment and dashboard gap analysis.',
+      website_tech_stack: {
+        source: 'public website review',
+        observed_site_type: 'legacy static business website',
+        services_page: 'http://vanguardenterprises.com/services---solutions.html',
+      },
+    })
+    .select('id')
+    .single()
+
+  if (insertError || !data?.id) {
+    throw new Error(`Failed to create Mark contact: ${insertError?.message ?? 'missing id'}`)
+  }
+
+  return data.id as number
+}
+
+async function findProject() {
+  const { data, error } = await supabaseAdmin
+    .from('client_projects')
+    .select('id, contact_submission_id')
+    .or('project_name.ilike.%ReversR Rebuild%,client_name.ilike.%Mark Meadows%,client_company.ilike.%Vanguard%')
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (error || !data?.id) {
+    throw new Error(`Failed to find Mark/ReversR project: ${error?.message ?? 'not found'}`)
+  }
+
+  return data as { id: string; contact_submission_id: number | null }
+}
+
+async function upsertAudit(contactSubmissionId: number, apply: boolean) {
+  const payload = {
+    ...assessmentPayload,
+    contact_submission_id: contactSubmissionId,
+  }
+
+  const { data: existing, error: readError } = await supabaseAdmin
+    .from('diagnostic_audits')
+    .select('id')
+    .eq('contact_submission_id', contactSubmissionId)
+    .eq('metadata->>assessment_key', ASSESSMENT_KEY)
+    .maybeSingle()
+
+  if (readError) throw new Error(`Failed to read Mark assessment audit: ${readError.message}`)
+  if (!apply) return existing?.id ?? 0
+
+  if (existing?.id) {
+    const { error } = await supabaseAdmin
+      .from('diagnostic_audits')
+      .update(payload)
+      .eq('id', existing.id)
+
+    if (error) throw new Error(`Failed to update Mark assessment audit: ${error.message}`)
+    return existing.id as number
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from('diagnostic_audits')
+    .insert(payload)
+    .select('id')
+    .single()
+
+  if (error || !data?.id) {
+    throw new Error(`Failed to create Mark assessment audit: ${error?.message ?? 'missing id'}`)
+  }
+
+  return data.id as number
+}
+
+async function upsertProjectLink(projectId: string, contactSubmissionId: number, apply: boolean) {
+  if (!apply) return
+  const { error } = await supabaseAdmin
+    .from('client_projects')
+    .update({ contact_submission_id: contactSubmissionId })
+    .eq('id', projectId)
+
+  if (error) throw new Error(`Failed to link project to Mark contact: ${error.message}`)
+}
+
+async function createScoreSnapshot(projectId: string, apply: boolean) {
+  const overallScore = calculateOverallScore(categoryScores)
+  const dreamOutcomeGap = calculateDreamOutcomeGap(categoryScores)
+  if (!apply) return { overallScore, dreamOutcomeGap, snapshotId: 'dry-run-score-snapshot-id' }
+
+  const { data, error } = await supabaseAdmin
+    .from('score_snapshots')
+    .insert({
+      client_project_id: projectId,
+      category_scores: categoryScores,
+      overall_score: overallScore,
+      dream_outcome_gap: dreamOutcomeGap,
+      trigger: 'manual',
+    })
+    .select('id')
+    .single()
+
+  if (error || !data?.id) {
+    throw new Error(`Failed to create Mark score snapshot: ${error?.message ?? 'missing id'}`)
+  }
+
+  return { overallScore, dreamOutcomeGap, snapshotId: data.id as string }
+}
+
+async function main() {
+  const apply = args.has('--apply')
+  const project = await findProject()
+  const contactSubmissionId = await findOrCreateContact(apply)
+  const auditId = contactSubmissionId ? await upsertAudit(contactSubmissionId, apply) : 0
+  if (contactSubmissionId) {
+    await upsertProjectLink(project.id, contactSubmissionId, apply)
+  }
+  const scoreSnapshot = await createScoreSnapshot(project.id, apply)
+
+  console.log(JSON.stringify({
+    applied: apply,
+    clientProjectId: project.id,
+    contactSubmissionId,
+    diagnosticAuditId: auditId,
+    scoreSnapshot,
+    scores: categoryScores,
+    source: assessmentPayload.website_url,
+  }, null, 2))
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/scripts/seed-mark-reversr-assessment.ts
+++ b/scripts/seed-mark-reversr-assessment.ts
@@ -7,6 +7,7 @@ const args = new Set(process.argv.slice(2))
 
 const CLIENT_EMAIL = process.env.MARK_MEADOWS_EMAIL || 'mark.meadows@offline.local'
 const ASSESSMENT_KEY = 'mark-reversr-client-safe-assessment-v1'
+const ROADMAP_KEY = 'mark-reversr-client-roadmap-v1'
 
 const categoryScores: CategoryScores = {
   business_challenges: 68,
@@ -108,6 +109,106 @@ const assessmentPayload = {
   opportunity_score: 8,
   sales_notes:
     'Client-safe assessment seed. Do not expose raw private conversation, prompt logs, or local file paths in client surfaces.',
+}
+
+const roadmapMilestones = [
+  {
+    week: 0,
+    title: 'Distribute the test app to internal testers',
+    description:
+      'Package and distribute the current ReversR test build so internal testers can install it and begin hands-on validation.',
+    deliverables: [
+      'iOS and Android tester access path',
+      'Install instructions and build/version reference',
+      'Known release gates and tester feedback channel',
+    ],
+    phase: 1,
+    status: 'in_progress',
+  },
+  {
+    week: 1,
+    title: 'Secure 12 internal tester GO decisions',
+    description:
+      'Confirm whether at least 12 internal testers can install, use, and approve the app as directionally ready for release.',
+    deliverables: [
+      '12 tester acceptances or documented blockers',
+      'GO / no-GO summary',
+      'Issue list prioritized for 1.0 release readiness',
+    ],
+    phase: 1,
+    status: 'pending',
+  },
+  {
+    week: 2,
+    title: 'Release ReversR 1.0 to iOS and Android',
+    description:
+      'Move from tester validation to public 1.0 release once store-console, review, and release-readiness gates are complete.',
+    deliverables: [
+      'iOS 1.0 release',
+      'Android 1.0 release',
+      'Client-safe release evidence and app-store links',
+    ],
+    phase: 1,
+    status: 'pending',
+  },
+  {
+    week: 3,
+    title: 'Generate a product with the app',
+    description:
+      'Use ReversR to generate a concrete product output that can be reviewed as proof of practical utility, not just app functionality.',
+    deliverables: [
+      'Selected test product/use case',
+      'Generated output package',
+      'Review notes on quality, manufacturability, and next-step effort',
+    ],
+    phase: 2,
+    status: 'pending',
+  },
+  {
+    week: 4,
+    title: 'Embed the app into the website and connect order fulfillment',
+    description:
+      'Connect the app experience to Vanguard’s web presence so users can move from app interaction into a structured order or machine-build request.',
+    deliverables: [
+      'Website embed or launch path',
+      'Order intake workflow',
+      'Fulfillment handoff requirements for Vanguard review',
+    ],
+    phase: 2,
+    status: 'pending',
+  },
+  {
+    week: 5,
+    title: 'Integrate a local LLM through a local server',
+    description:
+      'Evaluate and implement the architecture required to run AI generation locally when security, offline operation, or cost control justifies it.',
+    deliverables: [
+      'Local-vs-cloud architecture decision',
+      'Local server prototype or implementation plan',
+      'Validation criteria for AI quality, latency, hardware, and security',
+    ],
+    phase: 3,
+    status: 'pending',
+  },
+  {
+    week: 6,
+    title: 'Convert clients into app purchasers',
+    description:
+      'Turn release, proof-of-product, website/order flow, and AI reliability into a commercial offer that customers can buy.',
+    deliverables: [
+      'Client purchase path',
+      'Offer/pricing structure',
+      'Continuity or support model for post-purchase delivery',
+    ],
+    phase: 3,
+    status: 'pending',
+  },
+] as const
+
+function hasSameCategoryScores(value: unknown): boolean {
+  if (!value || typeof value !== 'object') return false
+  const rowScores = value as Partial<Record<keyof CategoryScores, unknown>>
+  return Object.entries(categoryScores).every(([key, score]) => rowScores[key as keyof CategoryScores] === score)
 }
 
 async function findOrCreateContact(apply: boolean) {
@@ -219,10 +320,132 @@ async function upsertProjectLink(projectId: string, contactSubmissionId: number,
   if (error) throw new Error(`Failed to link project to Mark contact: ${error.message}`)
 }
 
+async function upsertRoadmapMilestones(projectId: string, apply: boolean) {
+  const planPayload = {
+    client_project_id: projectId,
+    milestones: roadmapMilestones,
+    status: 'in_progress',
+    is_customized: true,
+    admin_notes: `${ROADMAP_KEY}: Client-safe ReversR product roadmap milestones seeded from consultant-provided phase gates.`,
+    setup_requirements: [
+      {
+        title: 'Tester access and store-console readiness',
+        status: 'in_progress',
+      },
+      {
+        title: 'Website/order-flow scope decision',
+        status: 'pending',
+      },
+      {
+        title: 'Local AI infrastructure decision',
+        status: 'pending',
+      },
+    ],
+    communication_plan: {
+      cadence: 'Gate-based updates at each milestone',
+      decision_gates: [
+        '12 internal tester GO threshold',
+        '1.0 release approval',
+        'website/order-flow scope approval',
+        'local LLM architecture approval',
+        'commercial purchase-path approval',
+      ],
+    },
+    win_conditions: [
+      'Internal testers can install and validate the app.',
+      '1.0 is released on iOS and Android.',
+      'A product can be generated and reviewed from the app workflow.',
+      'A website-connected order path exists.',
+      'The AI architecture supports the agreed security and reliability posture.',
+      'Clients can purchase the app or app-enabled service.',
+    ],
+    artifacts_handoff: [
+      'App-store/tester release evidence',
+      'Generated product proof package',
+      'Website embed/order-flow documentation',
+      'Local AI architecture notes',
+      'Commercial offer/purchase path',
+    ],
+  }
+
+  const { data: project, error: projectError } = await supabaseAdmin
+    .from('client_projects')
+    .select('onboarding_plan_id')
+    .eq('id', projectId)
+    .single()
+
+  if (projectError) throw new Error(`Failed to read project onboarding link: ${projectError.message}`)
+  if (!apply) return project?.onboarding_plan_id ?? 'dry-run-onboarding-plan-id'
+
+  let planId = project?.onboarding_plan_id as string | null
+  if (!planId) {
+    const { data: existing, error: existingError } = await supabaseAdmin
+      .from('onboarding_plans')
+      .select('id')
+      .eq('client_project_id', projectId)
+      .ilike('admin_notes', `%${ROADMAP_KEY}%`)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle()
+
+    if (existingError) throw new Error(`Failed to read existing roadmap plan: ${existingError.message}`)
+    planId = (existing?.id as string | undefined) ?? null
+  }
+
+  if (planId) {
+    const { error } = await supabaseAdmin
+      .from('onboarding_plans')
+      .update(planPayload)
+      .eq('id', planId)
+
+    if (error) throw new Error(`Failed to update roadmap milestones: ${error.message}`)
+  } else {
+    const { data, error } = await supabaseAdmin
+      .from('onboarding_plans')
+      .insert(planPayload)
+      .select('id')
+      .single()
+
+    if (error || !data?.id) {
+      throw new Error(`Failed to create roadmap milestones: ${error?.message ?? 'missing id'}`)
+    }
+    planId = data.id as string
+  }
+
+  const { error: linkError } = await supabaseAdmin
+    .from('client_projects')
+    .update({ onboarding_plan_id: planId })
+    .eq('id', projectId)
+
+  if (linkError) throw new Error(`Failed to link roadmap milestones to project: ${linkError.message}`)
+  return planId
+}
+
 async function createScoreSnapshot(projectId: string, apply: boolean) {
   const overallScore = calculateOverallScore(categoryScores)
   const dreamOutcomeGap = calculateDreamOutcomeGap(categoryScores)
   if (!apply) return { overallScore, dreamOutcomeGap, snapshotId: 'dry-run-score-snapshot-id' }
+
+  const { data: latest, error: latestError } = await supabaseAdmin
+    .from('score_snapshots')
+    .select('id, category_scores, overall_score, dream_outcome_gap')
+    .eq('client_project_id', projectId)
+    .order('snapshot_date', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (latestError) {
+    throw new Error(`Failed to read latest Mark score snapshot: ${latestError.message}`)
+  }
+
+  if (
+    latest &&
+    hasSameCategoryScores(latest.category_scores) &&
+    latest.overall_score === overallScore &&
+    Number(latest.dream_outcome_gap) === dreamOutcomeGap
+  ) {
+    return { overallScore, dreamOutcomeGap, snapshotId: latest.id as string }
+  }
 
   const { data, error } = await supabaseAdmin
     .from('score_snapshots')
@@ -251,6 +474,7 @@ async function main() {
   if (contactSubmissionId) {
     await upsertProjectLink(project.id, contactSubmissionId, apply)
   }
+  const onboardingPlanId = await upsertRoadmapMilestones(project.id, apply)
   const scoreSnapshot = await createScoreSnapshot(project.id, apply)
 
   console.log(JSON.stringify({
@@ -258,6 +482,8 @@ async function main() {
     clientProjectId: project.id,
     contactSubmissionId,
     diagnosticAuditId: auditId,
+    onboardingPlanId,
+    milestoneCount: roadmapMilestones.length,
     scoreSnapshot,
     scores: categoryScores,
     source: assessmentPayload.website_url,

--- a/scripts/seed-mark-reversr-assessment.ts
+++ b/scripts/seed-mark-reversr-assessment.ts
@@ -126,7 +126,7 @@ const roadmapMilestones = [
       'Known release gates and tester feedback channel',
     ],
     phase: 1,
-    status: 'in_progress',
+    status: 'pending',
     evidence: [
       {
         id: 'm0-build-depth',
@@ -174,7 +174,7 @@ const roadmapMilestones = [
       'Issue list prioritized for 1.0 release readiness',
     ],
     phase: 1,
-    status: 'in_progress',
+    status: 'pending',
     evidence: [
       {
         id: 'm1-go-log',
@@ -219,7 +219,7 @@ const roadmapMilestones = [
       'Client-safe release evidence and app-store links',
     ],
     phase: 1,
-    status: 'in_progress',
+    status: 'pending',
     evidence: [
       {
         id: 'm2-release-gates',
@@ -266,7 +266,7 @@ const roadmapMilestones = [
       'Review notes on quality, manufacturability, and next-step effort',
     ],
     phase: 1,
-    status: 'in_progress',
+    status: 'pending',
     evidence: [
       {
         id: 'm3-output-package',
@@ -300,7 +300,7 @@ const roadmapMilestones = [
       'Fulfillment handoff requirements for Vanguard review',
     ],
     phase: 2,
-    status: 'in_progress',
+    status: 'pending',
     evidence: [
       {
         id: 'm4-website-workflow',
@@ -347,7 +347,7 @@ const roadmapMilestones = [
       'Validation criteria for AI quality, latency, hardware, and security',
     ],
     phase: 2,
-    status: 'in_progress',
+    status: 'pending',
     evidence: [
       {
         id: 'm5-architecture-proof',
@@ -393,7 +393,7 @@ const roadmapMilestones = [
       'Continuity or support model for post-purchase delivery',
     ],
     phase: 2,
-    status: 'in_progress',
+    status: 'pending',
     evidence: [
       {
         id: 'm6-purchase-records',
@@ -427,6 +427,21 @@ const roadmapMilestones = [
     },
   },
 ] as const
+
+type RoadmapMilestoneSeed = (typeof roadmapMilestones)[number]
+
+function milestoneHasProgressEvidence(milestone: RoadmapMilestoneSeed): boolean {
+  return milestone.evidence.some((item) => item.status === 'verified')
+}
+
+function applyMilestoneProgressStatus(milestone: RoadmapMilestoneSeed) {
+  return {
+    ...milestone,
+    status: milestoneHasProgressEvidence(milestone) ? 'in_progress' : 'pending',
+  }
+}
+
+const roadmapMilestonesWithProgress = roadmapMilestones.map(applyMilestoneProgressStatus)
 
 function hasSameCategoryScores(value: unknown): boolean {
   if (!value || typeof value !== 'object') return false
@@ -546,7 +561,7 @@ async function upsertProjectLink(projectId: string, contactSubmissionId: number,
 async function upsertRoadmapMilestones(projectId: string, apply: boolean) {
   const planPayload = {
     client_project_id: projectId,
-    milestones: roadmapMilestones,
+    milestones: roadmapMilestonesWithProgress,
     status: 'in_progress',
     is_customized: true,
     admin_notes: `${ROADMAP_KEY}: Client-safe ReversR product roadmap milestones seeded from consultant-provided phase gates.`,

--- a/scripts/seed-mark-reversr-assessment.ts
+++ b/scripts/seed-mark-reversr-assessment.ts
@@ -174,7 +174,7 @@ const roadmapMilestones = [
       'Issue list prioritized for 1.0 release readiness',
     ],
     phase: 1,
-    status: 'pending',
+    status: 'in_progress',
     evidence: [
       {
         id: 'm1-go-log',
@@ -219,7 +219,7 @@ const roadmapMilestones = [
       'Client-safe release evidence and app-store links',
     ],
     phase: 1,
-    status: 'pending',
+    status: 'in_progress',
     evidence: [
       {
         id: 'm2-release-gates',
@@ -266,7 +266,7 @@ const roadmapMilestones = [
       'Review notes on quality, manufacturability, and next-step effort',
     ],
     phase: 2,
-    status: 'pending',
+    status: 'in_progress',
     evidence: [
       {
         id: 'm3-output-package',
@@ -300,7 +300,7 @@ const roadmapMilestones = [
       'Fulfillment handoff requirements for Vanguard review',
     ],
     phase: 2,
-    status: 'pending',
+    status: 'in_progress',
     evidence: [
       {
         id: 'm4-website-workflow',
@@ -347,7 +347,7 @@ const roadmapMilestones = [
       'Validation criteria for AI quality, latency, hardware, and security',
     ],
     phase: 3,
-    status: 'pending',
+    status: 'in_progress',
     evidence: [
       {
         id: 'm5-architecture-proof',
@@ -393,7 +393,7 @@ const roadmapMilestones = [
       'Continuity or support model for post-purchase delivery',
     ],
     phase: 3,
-    status: 'pending',
+    status: 'in_progress',
     evidence: [
       {
         id: 'm6-purchase-records',

--- a/scripts/seed-mark-reversr-build-evidence.ts
+++ b/scripts/seed-mark-reversr-build-evidence.ts
@@ -1,0 +1,210 @@
+#!/usr/bin/env tsx
+
+import { supabaseAdmin } from '@/lib/supabase'
+import { buildMarkReversrEvidenceSnapshot } from '@/lib/reversr-build-evidence-extractor'
+
+const args = new Set(process.argv.slice(2))
+
+const AGREED_MARK_TOKEN_SNAPSHOT = {
+  sessionCount: 5,
+  totalTokens: 283717602,
+  inputTokens: 283030750,
+  cachedInputTokens: 270859776,
+  outputTokens: 686852,
+  reasoningTokens: 177176,
+  shareOfComparisonWindowPct: 17.38,
+}
+
+function getArgValue(name: string): string | null {
+  const prefix = `${name}=`
+  const found = process.argv.slice(2).find((arg) => arg.startsWith(prefix))
+  return found ? found.slice(prefix.length) : null
+}
+
+function numberArg(name: string): number | null {
+  const raw = getArgValue(name)
+  if (!raw) return null
+  const parsed = Number(raw)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+async function findOrCreateProject(apply: boolean) {
+  const clientEmail = process.env.MARK_MEADOWS_EMAIL || 'mark.meadows@offline.local'
+
+  const { data: existing, error: readError } = await supabaseAdmin
+    .from('client_projects')
+    .select('id, client_email')
+    .or('project_name.ilike.%ReversR Rebuild%,client_name.ilike.%Mark Meadows%,client_company.ilike.%Vanguard%')
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (readError) throw new Error(`Failed to read client project: ${readError.message}`)
+  if (existing?.id) return existing as { id: string; client_email: string }
+  if (!apply) return { id: 'dry-run-client-project-id', client_email: clientEmail }
+
+  const { data, error } = await supabaseAdmin
+    .from('client_projects')
+    .insert({
+      project_name: 'ReversR Rebuild Product Asset',
+      description: 'Client-safe dashboard record for ReversR Rebuild build evidence, token attribution, and investment translation.',
+      client_name: 'Mark Meadows',
+      client_email: clientEmail,
+      client_company: 'Vanguard Enterprises',
+      project_start_date: '2026-04-24',
+      estimated_end_date: '2026-06-30',
+      project_status: 'active',
+      current_phase: 1,
+      project_value: 30000,
+      currency: 'USD',
+      notes: 'Offline/security-conscious client. Keep private strategy materials out of public/client-facing surfaces.',
+    })
+    .select('id, client_email')
+    .single()
+
+  if (error || !data?.id) {
+    throw new Error(`Failed to create client project: ${error?.message ?? 'missing id'}`)
+  }
+  return data as { id: string; client_email: string }
+}
+
+async function assertEvidenceTableReady() {
+  const { error } = await supabaseAdmin
+    .from('client_project_build_evidence')
+    .select('id')
+    .limit(1)
+    .maybeSingle()
+
+  if (error) {
+    throw new Error(
+      `client_project_build_evidence is not ready in the active Supabase project: ${error.message}`
+    )
+  }
+}
+
+async function ensureDashboardAccess(clientProjectId: string, clientEmail: string, apply: boolean) {
+  if (!apply && clientProjectId === 'dry-run-client-project-id') {
+    return 'dry-run-dashboard-token'
+  }
+
+  const { data: existing, error: readError } = await supabaseAdmin
+    .from('client_dashboard_access')
+    .select('access_token')
+    .eq('client_project_id', clientProjectId)
+    .eq('is_active', true)
+    .maybeSingle()
+
+  if (readError) throw new Error(`Failed to read dashboard access: ${readError.message}`)
+  if (existing?.access_token) return existing.access_token as string
+  if (!apply) return 'dry-run-dashboard-token'
+
+  const { data, error } = await supabaseAdmin
+    .from('client_dashboard_access')
+    .insert({
+      client_project_id: clientProjectId,
+      client_email: clientEmail,
+    })
+    .select('access_token')
+    .single()
+
+  if (error || !data?.access_token) {
+    throw new Error(`Failed to create dashboard access: ${error?.message ?? 'missing token'}`)
+  }
+  return data.access_token as string
+}
+
+async function upsertEvidence(clientProjectId: string, snapshot: Awaited<ReturnType<typeof buildMarkReversrEvidenceSnapshot>>, apply: boolean) {
+  const payload = {
+    client_project_id: clientProjectId,
+    evidence_key: 'reversr-build-evidence',
+    project_label: snapshot.projectLabel,
+    repo_metrics: snapshot.repoMetrics,
+    token_usage: snapshot.tokenUsage,
+    cost_summary: snapshot.costSummary,
+    hourly_translation: snapshot.hourlyTranslation,
+    source_confidence: snapshot.sourceConfidence,
+    client_safe_notes: snapshot.clientSafeNotes,
+    private_source_refs: snapshot.privateSourceRefs,
+    is_client_visible: true,
+    captured_at: new Date().toISOString(),
+  }
+
+  if (!apply) return payload
+
+  const { error } = await supabaseAdmin
+    .from('client_project_build_evidence')
+    .upsert(payload, { onConflict: 'client_project_id,evidence_key' })
+
+  if (error) throw new Error(`Failed to upsert build evidence: ${error.message}`)
+  return payload
+}
+
+async function main() {
+  const apply = args.has('--apply')
+  const repoEvidencePath =
+    getArgValue('--repo-evidence-path') ||
+    '/Users/vambahsillah/Projects/Portfolio/local-private/client-proposals/reversr-rebuild-offline-client/repo-evidence-snapshot.json'
+  const sessionsRoot = getArgValue('--sessions-root') || '/Users/vambahsillah/.codex/sessions/2026/06'
+
+  const snapshot = await buildMarkReversrEvidenceSnapshot({
+    repoEvidencePath,
+    sessionsRoot,
+    subscriptionMonthlyCostUsd: numberArg('--subscription-monthly-usd'),
+    apiEquivalentCostUsd: numberArg('--api-equivalent-cost-usd'),
+  })
+
+  if (!args.has('--live-token-scan')) {
+    snapshot.tokenUsage = {
+      ...snapshot.tokenUsage,
+      ...AGREED_MARK_TOKEN_SNAPSHOT,
+    }
+    snapshot.costSummary = {
+      ...snapshot.costSummary,
+      subscriptionSharePct: AGREED_MARK_TOKEN_SNAPSHOT.shareOfComparisonWindowPct,
+      subscriptionAllocatedCostUsd:
+        snapshot.costSummary.subscriptionMonthlyCostUsd == null
+          ? null
+          : Math.round(
+              snapshot.costSummary.subscriptionMonthlyCostUsd *
+                (AGREED_MARK_TOKEN_SNAPSHOT.shareOfComparisonWindowPct / 100) *
+                100
+            ) / 100,
+    }
+    snapshot.sourceConfidence = {
+      ...snapshot.sourceConfidence,
+      excludedSources: [
+        'Broader sessions that mention ReversR or Mark are excluded from client-facing token totals.',
+        'Raw prompts, private strategy notes, local paths, and full session logs stay admin-only.',
+      ],
+    }
+  }
+
+  if (apply) {
+    await assertEvidenceTableReady()
+  }
+
+  const project = await findOrCreateProject(apply)
+  const dashboardToken = await ensureDashboardAccess(project.id, project.client_email, apply)
+  const evidencePayload = await upsertEvidence(project.id, snapshot, apply)
+
+  console.log(JSON.stringify({
+    applied: apply,
+    clientProjectId: project.id,
+    dashboardUrl: `/client/dashboard/${dashboardToken}`,
+    clientEmail: project.client_email,
+    evidence: {
+      project_label: evidencePayload.project_label,
+      repo_metrics: evidencePayload.repo_metrics,
+      token_usage: evidencePayload.token_usage,
+      cost_summary: evidencePayload.cost_summary,
+      hourly_translation: evidencePayload.hourly_translation,
+      source_confidence: evidencePayload.source_confidence,
+      client_safe_notes: evidencePayload.client_safe_notes,
+    },
+  }, null, 2))
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/supabase/migrations/20260615150000_client_project_build_evidence.sql
+++ b/supabase/migrations/20260615150000_client_project_build_evidence.sql
@@ -1,0 +1,66 @@
+-- ============================================================================
+-- Client Project Build Evidence
+-- Date: 2026-06-15
+-- Purpose: Store client-safe build, token, cost, and hourly translation evidence
+--          for client dashboard projection.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS client_project_build_evidence (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_project_id UUID NOT NULL REFERENCES client_projects(id) ON DELETE CASCADE,
+  evidence_key TEXT NOT NULL DEFAULT 'build_evidence',
+  project_label TEXT NOT NULL,
+  repo_metrics JSONB NOT NULL DEFAULT '{}'::jsonb,
+  token_usage JSONB NOT NULL DEFAULT '{}'::jsonb,
+  cost_summary JSONB NOT NULL DEFAULT '{}'::jsonb,
+  hourly_translation JSONB NOT NULL DEFAULT '{}'::jsonb,
+  source_confidence JSONB NOT NULL DEFAULT '{}'::jsonb,
+  client_safe_notes JSONB NOT NULL DEFAULT '[]'::jsonb,
+  private_source_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+  is_client_visible BOOLEAN NOT NULL DEFAULT false,
+  captured_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (client_project_id, evidence_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_client_project_build_evidence_visible
+  ON client_project_build_evidence (client_project_id, is_client_visible, captured_at DESC);
+
+ALTER TABLE client_project_build_evidence ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Admins can manage client project build evidence"
+  ON client_project_build_evidence;
+CREATE POLICY "Admins can manage client project build evidence"
+  ON client_project_build_evidence
+  FOR ALL
+  TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin')
+  )
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM user_profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+GRANT ALL ON client_project_build_evidence TO service_role;
+GRANT ALL ON client_project_build_evidence TO authenticated;
+
+CREATE OR REPLACE FUNCTION update_client_project_build_evidence_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS client_project_build_evidence_updated_at
+  ON client_project_build_evidence;
+CREATE TRIGGER client_project_build_evidence_updated_at
+  BEFORE UPDATE ON client_project_build_evidence
+  FOR EACH ROW
+  EXECUTE FUNCTION update_client_project_build_evidence_updated_at();
+
+COMMENT ON TABLE client_project_build_evidence IS
+  'Client-safe dashboard projection for build evidence, token attribution, cost translation, and hourly comparison scenarios.';
+COMMENT ON COLUMN client_project_build_evidence.private_source_refs IS
+  'Admin-only provenance pointers. Never return this field from token-based client dashboard APIs.';


### PR DESCRIPTION
## Summary
- Add Mark Meadows / Vanguard ReversR client-project evidence surfaces, including build evidence, token attribution, hourly translation, proposal documents, milestones, phases, and score trajectory context.
- Render the client dashboard in the AmaduTown brand system with the shield logo, gold/navy card language, proposal-first document placement, concise milestone evidence chips, and deduped access/next-check milestone notes.
- Add admin/API support for milestone management and evidence-backed progress/status behavior while keeping private prompts, local paths, and raw session logs out of the client view.

## Validation
- `npx tsc --noEmit` — passed.
- `npm run build` — passed; warnings only for existing dev outbound-n8n config and two dashboard logo `<img>` optimization warnings.
- `npm test -- --run components/client-dashboard/MilestoneTimeline.test.tsx components/client-dashboard/BuildEvidenceInvestmentSection.test.tsx` — passed.
- `node --env-file=.env.local ./node_modules/vitest/vitest.mjs run lib/source-validator/filter-mode.test.ts lib/source-validator/pain-point-evidence.test.ts lib/source-validator/validate-benchmark.test.ts` — passed after loading `.env.local`.
- Browser smoke on Mark dashboard desktop/mobile — passed: branded dashboard renders, proposal/build evidence visible, concise milestone metrics render, duplicate access notes removed, no local path leaks, no horizontal overflow.
- `npm run deploy:watch:once` — passed; both `Vercel – portfolio` and `Vercel – portfolio-staging` report success.
- GitHub PR checks — passing: `Vercel – portfolio`, `Vercel Preview Comments`.

## Integration Notes
- Full `npm test` in the current dirty local checkout still has one unrelated failure in `lib/decision-trust-open-brain.test.ts`: expected severity `high`, received `medium`. This PR does not touch that module.
- Source-validator failures from the raw `npm test` run were environment-related; the same source-validator suites pass when run with `.env.local` loaded.
- Required client evidence migrations and seed scripts are included in this branch; apply migration before production seed/mutation flows.
- The working tree contains unrelated local dirty files outside this PR; they were preserved and not staged.