### PR TITLE
fix: enforce AmaduTown email sender identity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -130,7 +130,7 @@ SLACK_OUTREACH_DRAFT_WEBHOOK_URL=
 # ── Email identity and delivery ─────────────────────────────────────────────
 # Business identity is what clients see. Transport credentials remain provider-specific.
 BUSINESS_FROM_EMAIL=vambah@amadutown.com
-BUSINESS_REPLY_TO_EMAIL=clients@amadutown.com
+BUSINESS_REPLY_TO_EMAIL=vambah@amadutown.com
 ADMIN_NOTIFICATION_EMAIL=
 AUTOMATION_INBOUND_EMAIL=automation@amadutown.com
 BUSINESS_FROM_NAME=AmaduTown

--- a/app/api/admin/outreach/[id]/gmail-user-draft/route.ts
+++ b/app/api/admin/outreach/[id]/gmail-user-draft/route.ts
@@ -8,6 +8,7 @@ import {
 } from '@/lib/gmail-user-api'
 import { isGmailUserOauthSecretConfigured } from '@/lib/gmail-user-oauth-secret'
 import { logCommunication } from '@/lib/communications'
+import { resolveBusinessEmailConfig } from '@/lib/business-email-config'
 
 export const dynamic = 'force-dynamic'
 
@@ -74,6 +75,17 @@ export async function POST(
         {
           error:
             'Connect your Gmail account first (admin: Google sign-in for Gmail drafts).',
+        },
+        { status: 400 }
+      )
+    }
+
+    const requiredSender = resolveBusinessEmailConfig().fromEmail.toLowerCase()
+    const connectedEmail = String(creds.google_email ?? '').trim().toLowerCase()
+    if (connectedEmail !== requiredSender) {
+      return NextResponse.json(
+        {
+          error: `Customer-facing Gmail drafts must be created from ${requiredSender}. Reconnect Gmail with that account before saving this draft.`,
         },
         { status: 400 }
       )

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -10,7 +10,7 @@ import { Chat } from './chat'
 
 const socialLinks = [
   { icon: Linkedin, href: 'https://www.linkedin.com/in/vambah-sillah-08989b8/', label: 'LinkedIn' },
-  { icon: Mail, href: 'mailto:vsillah@gmail.com', label: 'Email' },
+  { icon: Mail, href: 'mailto:vambah@amadutown.com', label: 'Email' },
   { icon: Music, href: 'https://open.spotify.com/artist/1B5vy5knIGXOxClIzkkVHR?si=frSOxcxXSPCi6S04691zkg', label: 'Spotify' },
   { icon: Github, href: 'https://github.com/vsillah', label: 'GitHub' },
   { icon: BookOpen, href: 'https://medium.com/@vsillah', label: 'Medium' },
@@ -112,7 +112,7 @@ export default function Contact() {
       setStatusMessage(
         error instanceof Error 
           ? error.message 
-          : 'Failed to send message. Please try again or email me directly at vsillah@gmail.com'
+          : 'Failed to send message. Please try again or email me directly at vambah@amadutown.com'
       )
       
       setTimeout(() => {
@@ -173,8 +173,8 @@ export default function Contact() {
             <div>
               <h3 className="text-[10px] font-heading tracking-[0.2em] text-radiant-gold uppercase mb-6">Contact Info</h3>
               <div className="space-y-4">
-                <a href="mailto:vsillah@gmail.com" className="block font-premium text-2xl text-foreground hover:text-radiant-gold transition-colors">
-                  vsillah@gmail.com
+                <a href="mailto:vambah@amadutown.com" className="block font-premium text-2xl text-foreground hover:text-radiant-gold transition-colors">
+                  vambah@amadutown.com
                 </a>
                 <p className="font-body text-muted-foreground/90 text-lg">
                   617-967-7448 <br />

--- a/components/ui/animated-scroll.tsx
+++ b/components/ui/animated-scroll.tsx
@@ -27,7 +27,7 @@ const pages = [
                 </div>
                 <div className="flex items-center gap-2">
                     <Mail className="w-4 h-4" />
-                    <span>vsillah@gmail.com</span>
+                    <span>vambah@amadutown.com</span>
                 </div>
                 <div className="flex items-center gap-2">
                     <Phone className="w-4 h-4" />

--- a/docs/amadutown-email-domain-runbook.md
+++ b/docs/amadutown-email-domain-runbook.md
@@ -15,7 +15,7 @@ AmaduTown uses a phased hybrid email migration:
 | --- | --- |
 | `vambah@amadutown.com` | Primary sender and named business mailbox |
 | `hello@amadutown.com` | Public intake and general inquiries |
-| `clients@amadutown.com` | Active client communication and reply-to |
+| `clients@amadutown.com` | Optional active-client alias; not the default customer-facing sender |
 | `billing@amadutown.com` | Billing, receipts, and payment issues |
 | `automation@amadutown.com` | Machine-triggered routing, filters, and workflow tests |
 
@@ -69,7 +69,7 @@ Set these variables in local and deployed environments:
 
 ```bash
 BUSINESS_FROM_EMAIL=vambah@amadutown.com
-BUSINESS_REPLY_TO_EMAIL=clients@amadutown.com
+BUSINESS_REPLY_TO_EMAIL=vambah@amadutown.com
 ADMIN_NOTIFICATION_EMAIL=<current preferred admin inbox>
 AUTOMATION_INBOUND_EMAIL=automation@amadutown.com
 BUSINESS_FROM_NAME=AmaduTown
@@ -78,13 +78,20 @@ BUSINESS_FROM_NAME=AmaduTown
 Keep delivery credentials provider-specific:
 
 ```bash
-GMAIL_USER=<transport mailbox>
+GMAIL_USER=vambah@amadutown.com
 GMAIL_APP_PASSWORD=<app password>
 RESEND_API_KEY=<optional>
 RESEND_FROM_EMAIL=<optional verified sender>
 ```
 
-`BUSINESS_FROM_EMAIL` is the address clients should see. `GMAIL_USER` is only a transport credential during the hybrid migration.
+`BUSINESS_FROM_EMAIL` and `BUSINESS_REPLY_TO_EMAIL` are the addresses customers should see. For customer-facing communication, both should be `vambah@amadutown.com`. If Gmail SMTP is used for customer-facing sends, `GMAIL_USER` must also be `vambah@amadutown.com`; otherwise Portfolio should refuse to send through that transport.
+
+Repo-side status on 2026-06-06:
+
+- Public contact components point to `vambah@amadutown.com`.
+- `business_owner_email` has a forward migration to `vambah@amadutown.com`.
+- Customer-facing app sends should use `vambah@amadutown.com` for both From and Reply-To.
+- Gmail OAuth credentials, n8n Gmail credentials, Read AI, Google Drive, Calendly, and SaaS account ownership remain provider-side migration gates. Change them only after confirming Workspace access, MFA, app passwords/OAuth consent, and rollback.
 
 ## Phase 3: n8n Migration
 

--- a/docs/amadutown-email-migration-inventory.md
+++ b/docs/amadutown-email-migration-inventory.md
@@ -35,13 +35,23 @@ Set these before or immediately after merging PR #81:
 | Variable | Target Value | Notes |
 | --- | --- | --- |
 | `BUSINESS_FROM_EMAIL` | `vambah@amadutown.com` | Client-facing sender identity |
-| `BUSINESS_REPLY_TO_EMAIL` | `clients@amadutown.com` | Client replies and active-project routing |
+| `BUSINESS_REPLY_TO_EMAIL` | `vambah@amadutown.com` | Customer-facing reply path |
 | `ADMIN_NOTIFICATION_EMAIL` | current preferred admin inbox | Keep personal Gmail if it remains the recovery inbox |
 | `AUTOMATION_INBOUND_EMAIL` | `automation@amadutown.com` | Machine-triggered routing and filters |
 | `BUSINESS_FROM_NAME` | `AmaduTown` | Optional; `EMAIL_FROM_NAME` remains supported |
-| `GMAIL_USER` | transport mailbox | Credential only, not the public identity |
+| `GMAIL_USER` | `vambah@amadutown.com` | Required for customer-facing Gmail SMTP sends |
 | `GMAIL_APP_PASSWORD` | transport app password | Rotate after Workspace cutover |
 | `RESEND_FROM_EMAIL` | verified sender if using Resend | Should align with the branded domain once DNS is ready |
+
+Current repo-side status on 2026-06-06:
+
+- Public contact surfaces should display `vambah@amadutown.com`.
+- `lib/business-email-config.ts` already defaults customer-facing From and Reply-To to `vambah@amadutown.com`, and automation inbound to `automation@amadutown.com`.
+- Transactional Gmail SMTP sends refuse to use a Gmail transport account that does not match `vambah@amadutown.com`.
+- `business_owner_email` is now forward-migrated to `vambah@amadutown.com` for n8n/business-owner lookups.
+- The per-admin Gmail draft route now requires the connected Gmail account to be `vambah@amadutown.com` before creating customer-facing drafts.
+- Local and hosted runtime credentials still need provider-side review before changing `GMAIL_USER`, Gmail OAuth, n8n Gmail credentials, or SaaS login owners.
+- A small number of repo docs still reference local Google Drive paths mounted under the personal Google account. Treat those as Drive ownership/workspace migration gates, not text-only replacements.
 
 ## n8n Gmail Workflow Migration List
 
@@ -68,6 +78,20 @@ Migrate in this order so client-facing communication moves first and reply autom
 | 4 | `HeyGen Cold Email - Sub Agent - Jono Catliff` | follow-up messaging nodes | Confirm whether this is still active before migrating |
 
 Keep Google Drive and Google Contacts credentials unchanged unless a workflow explicitly needs Workspace-owned Drive/Contacts data.
+
+Repo export scan on 2026-06-06 still found archived/exported n8n credentials and owner references labeled with the personal Gmail account. Treat those JSON exports as evidence of workflows that must be reconnected in n8n Cloud, not as code-only fixes. Do not bulk edit exported credential labels until the live n8n credential is reconnected and a fresh export is saved.
+
+## Google Drive And Workspace Ownership
+
+Portfolio-related Drive materials should move toward Workspace-owned storage, but this requires a controlled file-owner migration rather than changing local path strings.
+
+Recommended sequence:
+
+1. Create or confirm the AmaduTown Workspace Drive/Shared Drive destination.
+2. Move or copy Portfolio-owned business folders from the personal Google Drive into Workspace-owned storage.
+3. Preserve source paths in source registers until every dependent artifact is updated.
+4. Update repo docs and source maps only after the Workspace path exists and access is verified.
+5. Keep personal Google Drive as recovery/source-of-record until checks confirm no active automation depends on the old path.
 
 ## SaaS Login Classification
 

--- a/docs/automation-digest-agent-ops-backlog.md
+++ b/docs/automation-digest-agent-ops-backlog.md
@@ -4,7 +4,7 @@
 
 The Codex automation digest has three outputs:
 
-1. Private executive digest to `vsillah@gmail.com` and the private Slack DM.
+1. Private executive digest to `vambah@amadutown.com` and the private Slack DM.
 2. Sanitized action summary to `#agent-ops` (`C0B1MM4LQKB`).
 3. Proposed Agent Ops work items for actionable decisions and follow-up work.
 

--- a/lib/business-email-config.test.ts
+++ b/lib/business-email-config.test.ts
@@ -40,17 +40,35 @@ describe('business email config', () => {
 
     expect(resolveBusinessEmailConfig()).toEqual({
       fromEmail: 'vambah@amadutown.com',
-      replyToEmail: 'clients@amadutown.com',
+      replyToEmail: 'vambah@amadutown.com',
       adminNotificationEmail: 'vambah@amadutown.com',
       automationInboundEmail: 'automation@amadutown.com',
       fromName: 'AmaduTown',
     })
   })
 
+  it('does not use Resend transport identity as the customer-facing sender', () => {
+    setEnv({
+      BUSINESS_FROM_EMAIL: undefined,
+      RESEND_FROM_EMAIL: 'notifications@example.com',
+      BUSINESS_REPLY_TO_EMAIL: undefined,
+      ADMIN_NOTIFICATION_EMAIL: undefined,
+      AUTOMATION_INBOUND_EMAIL: undefined,
+      EMAIL_FROM_NAME: undefined,
+      BUSINESS_FROM_NAME: undefined,
+      GMAIL_USER: undefined,
+    })
+
+    expect(resolveBusinessEmailConfig()).toMatchObject({
+      fromEmail: 'vambah@amadutown.com',
+      replyToEmail: 'vambah@amadutown.com',
+    })
+  })
+
   it('separates client-facing sender, reply-to, admin, and automation inboxes', () => {
     setEnv({
       BUSINESS_FROM_EMAIL: 'vambah@amadutown.com',
-      BUSINESS_REPLY_TO_EMAIL: 'clients@amadutown.com',
+      BUSINESS_REPLY_TO_EMAIL: 'vambah@amadutown.com',
       ADMIN_NOTIFICATION_EMAIL: 'admin@example.com',
       AUTOMATION_INBOUND_EMAIL: 'automation@amadutown.com',
       EMAIL_FROM_NAME: 'AmaduTown Advisory',
@@ -59,7 +77,7 @@ describe('business email config', () => {
 
     expect(resolveBusinessEmailConfig()).toEqual({
       fromEmail: 'vambah@amadutown.com',
-      replyToEmail: 'clients@amadutown.com',
+      replyToEmail: 'vambah@amadutown.com',
       adminNotificationEmail: 'admin@example.com',
       automationInboundEmail: 'automation@amadutown.com',
       fromName: 'AmaduTown Advisory',

--- a/lib/business-email-config.ts
+++ b/lib/business-email-config.ts
@@ -1,5 +1,5 @@
 const DEFAULT_BUSINESS_FROM_EMAIL = 'vambah@amadutown.com'
-const DEFAULT_BUSINESS_REPLY_TO_EMAIL = 'clients@amadutown.com'
+const DEFAULT_BUSINESS_REPLY_TO_EMAIL = 'vambah@amadutown.com'
 const DEFAULT_AUTOMATION_INBOUND_EMAIL = 'automation@amadutown.com'
 const DEFAULT_EMAIL_FROM_NAME = 'AmaduTown'
 
@@ -33,7 +33,6 @@ export function getEmailFromName(): string {
 export function resolveBusinessEmailConfig(): BusinessEmailConfig {
   const fromEmail =
     extractEmailAddress(process.env.BUSINESS_FROM_EMAIL) ||
-    extractEmailAddress(process.env.RESEND_FROM_EMAIL) ||
     DEFAULT_BUSINESS_FROM_EMAIL
 
   const replyToEmail =

--- a/lib/email/deliver-transactional.test.ts
+++ b/lib/email/deliver-transactional.test.ts
@@ -92,8 +92,8 @@ describe('deliverTransactionalMail', () => {
     expect(mocks.resendCtor).toHaveBeenCalledWith('re_test_key')
     expect(mocks.resendSend).toHaveBeenCalledWith(
       expect.objectContaining({
-        from: '"AmaduTown" <notifications@example.com>',
-        replyTo: 'clients@amadutown.com',
+        from: '"AmaduTown" <vambah@amadutown.com>',
+        replyTo: 'vambah@amadutown.com',
         to: 'client@example.com',
       }),
     )
@@ -109,8 +109,8 @@ describe('deliverTransactionalMail', () => {
       RESEND_API_KEY: 're_test_key',
       RESEND_FROM_EMAIL: 'notifications@example.com',
       BUSINESS_FROM_EMAIL: 'vambah@amadutown.com',
-      BUSINESS_REPLY_TO_EMAIL: 'clients@amadutown.com',
-      GMAIL_USER: 'sender@gmail.com',
+      BUSINESS_REPLY_TO_EMAIL: 'vambah@amadutown.com',
+      GMAIL_USER: 'vambah@amadutown.com',
       GMAIL_APP_PASSWORD: 'gmail-app-password',
     })
     mocks.createTransport.mockReturnValueOnce({
@@ -129,8 +129,8 @@ describe('deliverTransactionalMail', () => {
     expect(mocks.sendMail).toHaveBeenCalledWith(
       expect.objectContaining({
         from: '"AmaduTown" <vambah@amadutown.com>',
-        replyTo: 'clients@amadutown.com',
-        sender: 'sender@gmail.com',
+        replyTo: 'vambah@amadutown.com',
+        sender: 'vambah@amadutown.com',
         to: 'client@example.com',
       }),
     )
@@ -155,7 +155,23 @@ describe('deliverTransactionalMail', () => {
     expect(result).toEqual({ ok: false, transport: 'resend' })
   })
 
-  it('reports transactional mail configured when gmail smtp is available', async () => {
+  it('reports transactional mail configured when gmail smtp matches the customer-facing sender', async () => {
+    setEnv({
+      RESEND_API_KEY: undefined,
+      RESEND_FROM_EMAIL: undefined,
+      GMAIL_USER: 'vambah@amadutown.com',
+      GMAIL_APP_PASSWORD: 'gmail-app-password',
+    })
+    mocks.createTransport.mockReturnValueOnce({
+      sendMail: mocks.sendMail,
+    })
+
+    const { isTransactionalMailConfigured } = await import('./deliver-transactional')
+
+    expect(isTransactionalMailConfigured()).toBe(true)
+  })
+
+  it('does not report transactional mail configured for a mismatched gmail smtp account', async () => {
     setEnv({
       RESEND_API_KEY: undefined,
       RESEND_FROM_EMAIL: undefined,
@@ -166,8 +182,13 @@ describe('deliverTransactionalMail', () => {
       sendMail: mocks.sendMail,
     })
 
-    const { isTransactionalMailConfigured } = await import('./deliver-transactional')
+    const { isTransactionalMailConfigured, deliverTransactionalMail } = await import('./deliver-transactional')
 
-    expect(isTransactionalMailConfigured()).toBe(true)
+    expect(isTransactionalMailConfigured()).toBe(false)
+    await expect(deliverTransactionalMail(payload)).resolves.toEqual({
+      ok: false,
+      transport: 'gmail_smtp',
+    })
+    expect(mocks.sendMail).not.toHaveBeenCalled()
   })
 })

--- a/lib/email/deliver-transactional.ts
+++ b/lib/email/deliver-transactional.ts
@@ -36,6 +36,13 @@ const transporter =
       })
     : null
 
+function gmailMatchesCustomerSender(): boolean {
+  return Boolean(
+    gmailUser &&
+      gmailUser.trim().toLowerCase() === businessEmail.fromEmail.trim().toLowerCase()
+  )
+}
+
 function resolveResendFrom(): string | null {
   const fromEmail = businessEmail.fromEmail || resendFromRaw
   if (!fromEmail) return null
@@ -43,7 +50,7 @@ function resolveResendFrom(): string | null {
 }
 
 export function isTransactionalMailConfigured(): boolean {
-  return Boolean((resendKey && resolveResendFrom()) || (gmailUser && gmailPass))
+  return Boolean((resendKey && resolveResendFrom()) || (gmailUser && gmailPass && gmailMatchesCustomerSender()))
 }
 
 async function sendViaResend(
@@ -79,6 +86,10 @@ async function sendViaResend(
 
 async function sendViaGmail(payload: TransactionalEmailPayload): Promise<boolean> {
   if (!transporter || !gmailUser) return false
+  if (!gmailMatchesCustomerSender()) {
+    console.warn('[Transactional email] Gmail transport does not match customer-facing sender; refusing send')
+    return false
+  }
   try {
     await transporter.sendMail({
       from: formatMailboxAddress(businessEmail.fromName, businessEmail.fromEmail),

--- a/migrations/2026_06_06_business_owner_email_amadutown.sql
+++ b/migrations/2026_06_06_business_owner_email_amadutown.sql
@@ -1,0 +1,14 @@
+-- Move Portfolio business-owner routing to the AmaduTown Workspace mailbox.
+-- Existing environments should keep recovery/admin access separate from client-facing identity.
+
+INSERT INTO site_settings (key, value, description)
+VALUES (
+  'business_owner_email',
+  '"vambah@amadutown.com"',
+  'Primary email for the business owner. Used as reply-to on outbound emails and as the forwarding target for unrecognized inbound replies.'
+)
+ON CONFLICT (key) DO UPDATE
+SET
+  value = EXCLUDED.value,
+  description = EXCLUDED.description,
+  updated_at = now();


### PR DESCRIPTION
## Summary
- Align customer-facing Portfolio email identity around `vambah@amadutown.com` for default From and Reply-To values.
- Prevent Resend transport identity from overriding the business sender, and refuse Gmail SMTP sends when the transport mailbox does not match the customer-facing sender.
- Add a forward migration for `business_owner_email` and update the Gmail draft route to require the connected customer-facing Gmail account.

## Validation
- `npm test -- lib/business-email-config.test.ts lib/email/deliver-transactional.test.ts`
- `SLACK_AGENT_OPS_WEBHOOK_URL= BUSINESS_FROM_EMAIL= BUSINESS_REPLY_TO_EMAIL= EMAIL_FROM_NAME= GMAIL_USER= GMAIL_APP_PASSWORD= RESEND_API_KEY= RESEND_FROM_EMAIL= MOCK_N8N=true N8N_DISABLE_OUTBOUND=true npm run build`
- No live email smoke was run.
- No `typecheck` script exists in this repo; focused Vitest coverage was used.

## Integration Notes
- Requires applying `migrations/2026_06_06_business_owner_email_amadutown.sql` in the normal migration lane.
- Hosted env reviewed by Vambah on 2026-06-15: Production and Preview values are confirmed for `BUSINESS_FROM_EMAIL`, `BUSINESS_REPLY_TO_EMAIL`, `GMAIL_USER`, and `GMAIL_APP_PASSWORD`.
- Vercel – portfolio: preview deployment passed for rebased commit `d32b967`.
- Vercel – portfolio-staging: not applicable to this draft PR until merge.



