### PR TITLE
docs: refresh subscription monitor evidence

### DIFF
--- a/docs/subscription-cancellation-audit.md
+++ b/docs/subscription-cancellation-audit.md
@@ -10,6 +10,228 @@ no meaningful usage signal, or after clear redundancy plus a lower-risk
 replacement path. Production changes require explicit approval in the form
 `Cancel <tool/vendor> for Portfolio`.
 
+## 2026-06-15 Daily Monitor Run
+
+Status: YELLOW
+
+Detailed run artifact: [`docs/subscription-monitor-runs/2026-06-15.md`](subscription-monitor-runs/2026-06-15.md)
+
+Summary:
+
+- No cancellation approvals requested and no cancellation action taken.
+- Supabase production moved through 2026-06-15 across analytics and agent runs; n8n Cloud returned 85 workflows, 72 active workflows, and successful executions `17309`-`17313` around 2026-06-15T13:00Z.
+- Vercel listed ready deployment entries for both `portfolio` and `portfolio-staging`; Stripe, OpenAI, Anthropic, Slack, Pinecone, Hunter, Gamma, HeyGen, Printful, ElevenLabs, Apify, OpenRouter, Vapi, and Gemini/Google AI were readable or dependency-backed.
+- Gamma recovered from the June 14 HTTP 401 to HTTP 200 with 50 themes; Read AI connector startup failed today, so prior June 11 meeting evidence was carried forward as visibility context rather than refreshed usage.
+- OpenRouter, Vapi, Printful sync, Resend, Calendly, Pinecone traffic/billing, Gamma dashboard credits/usage, Read AI connector/plan fit, and design-tool billing remain investigate/watch items.
+- BuiltWith remains active/watch during the outreach ramp; Fireflies remains resolved canceled unless new paid-plan evidence appears.
+
+## 2026-06-15 Weekly Subscription Report
+
+Status: YELLOW
+
+Source set:
+
+- Primary tracker/status files: `docs/subscription-cancellation-audit.md` and `docs/subscription-status.json`.
+- Current daily evidence artifact: [`docs/subscription-monitor-runs/2026-06-14.md`](subscription-monitor-runs/2026-06-14.md).
+- Prior weekly comparison point: `2026-06-08 Weekly Subscription Report`.
+- Action tracker feedback: 12 open actions for `portfolio-subscription-weekly-report`, with 0 in progress, 0 blocked, 0 done, and no progress notes.
+
+Summary:
+
+- No cancellation approvals requested and no cancellation action taken.
+- Core keep items remain active/readable or strongly dependency-backed: Supabase, n8n Cloud, Vercel, Stripe, OpenAI, Anthropic API, Slack, Read AI, HeyGen, Apify, Google Cloud, Gemini/Google AI, Hunter.io, and Pinecone.
+- Watch/investigate items remain BuiltWith, ElevenLabs, OpenRouter, Vapi, Gamma, Printful, Resend, Calendly, Pinecone traffic/billing, Anthropic billing transition, HeyGen quota/billing, Gemini billing/project status, Read AI plan fit, and design-tool billing.
+- Resolved/canceled item remains Fireflies.ai. Keep it out of the active queue unless a new receipt or dashboard signal shows the paid plan restarted.
+- BuiltWith remains a protected outreach-ramp watch item, not a current cancellation candidate.
+- No vendor crossed the approval-ready cancellation threshold. Future cancellation still requires the exact approval phrase `Cancel <tool/vendor> for Portfolio`.
+
+Derived movement since the prior weekly report:
+
+- Supabase, n8n Cloud, and Vercel stayed active: production Supabase analytics moved through 2026-06-13, n8n Cloud returned 85 workflows, 72 active workflows, and successful executions `17197`-`17201` around 2026-06-14T12:00Z, and Vercel listed current `portfolio` plus `portfolio-staging` deployment URLs.
+- Read AI improved from the prior weekly six-meeting window to seven May 1-June 14 meeting metadata records, with latest meeting metadata on 2026-06-11. Keep it, but verify plan fit if meeting volume drops or receipt pressure rises.
+- ElevenLabs moved from the earlier zero-use posture to low use: 802 of 246,034 characters before the 2026-06-19 reset. Review planned voice/audio campaign need before the reset.
+- Gamma remains unstable: it recovered to HTTP 200 on 2026-06-13, then regressed to HTTP 401 on 2026-06-14. Treat this as API/dashboard access drift and credit visibility work, not cancellation approval.
+- HeyGen catalog visibility improved: voices and avatars were both readable on 2026-06-14, but quota/billing still requires dashboard verification.
+- Gemini/Google AI stayed readable with 50 models, while billing/project status remains unresolved.
+- OpenRouter and Vapi remained quiet with zero current-key usage or zero sampled calls; they remain watch/deprecation-packet candidates only after spend, dependency, and replacement checks.
+
+Candidate cancellations:
+
+- No automatic cancellation.
+- Strongest future deprecation-packet candidates remain OpenRouter, Vapi, Printful sync, Resend, Calendly, Gamma access/credits, and possibly Pinecone, but only after dashboard billing, usage, and replacement-risk checks.
+- BuiltWith is excluded from cancellation candidacy during the outreach/client-volume ramp.
+- Fireflies.ai is already resolved/canceled and should only be revisited if new paid-plan evidence appears.
+
+Next weekly focus:
+
+- Verify Vapi billing/product intent, ElevenLabs campaign need before the 2026-06-19 reset, Printful dashboard/store strategy, Resend production env/billing, Pinecone traffic/billing, Calendly access/usage, Gamma API/dashboard credits, Gemini billing/project status, HeyGen quota/billing, Anthropic transition billing, and Read AI plan fit.
+- Continue the Apify actor-level replacement bakeoff before any account-level change.
+- Keep BuiltWith active while collecting outreach-ramp outcome evidence.
+
+## 2026-06-14 Daily Monitor Run
+
+Status: YELLOW
+
+Detailed run artifact: [`docs/subscription-monitor-runs/2026-06-14.md`](subscription-monitor-runs/2026-06-14.md)
+
+Summary:
+
+- No cancellation approvals requested and no cancellation action taken.
+- Supabase production analytics moved through 2026-06-13, n8n Cloud returned 85 workflows, 72 active workflows, and successful executions `17197`-`17201` around 2026-06-14T12:00Z.
+- Vercel listed current deployment URLs for both `portfolio` and `portfolio-staging`; Stripe, OpenAI, Anthropic, Slack, Pinecone, Hunter, HeyGen, Printful, ElevenLabs, Apify, OpenRouter, Vapi, Gemini/Google AI, and Read AI were readable or dependency-backed.
+- Gamma regressed from the June 13 HTTP 200 recovery back to HTTP 401; treat this as access/billing visibility drift, not cancellation approval.
+- OpenRouter, Vapi, Printful sync, Resend, Calendly, Pinecone traffic/billing, Gamma dashboard credits/usage, and design-tool billing remain investigate/watch items.
+- BuiltWith remains active/watch during the outreach ramp; Fireflies remains resolved canceled unless new paid-plan evidence appears.
+
+## 2026-06-13 Daily Monitor Run
+
+Status: YELLOW
+
+Detailed run artifact: [`docs/subscription-monitor-runs/2026-06-13.md`](subscription-monitor-runs/2026-06-13.md)
+
+Summary:
+
+- No cancellation approvals requested and no cancellation action taken.
+- Supabase production moved through 2026-06-12, configured-local data remained current through 2026-06-12, and n8n Cloud returned 85 workflows, 72 active workflows, and successful executions `17092`-`17096` around 2026-06-13T12:00Z.
+- Vercel listed ready deployments for both `portfolio` and `portfolio-staging`; Stripe, OpenAI, Anthropic, Slack, Pinecone, Hunter, Gamma, HeyGen, Printful, ElevenLabs, Apify, OpenRouter, Vapi, Gemini/Google AI, and Read AI were readable or dependency-backed.
+- Gamma recovered from the June 12 HTTP 401 to HTTP 200 with 50 themes; HeyGen catalogs stayed readable; Read AI stayed connector-readable with latest meeting metadata on 2026-06-11.
+- OpenRouter, Vapi, Printful sync, Resend, Calendly, Pinecone traffic/billing, Gamma dashboard credits/usage, and design-tool billing remain investigate/watch items.
+- BuiltWith remains active/watch during the outreach ramp; Fireflies remains resolved canceled unless new paid-plan evidence appears.
+
+## 2026-06-12 Daily Monitor Run
+
+Status: YELLOW
+
+Detailed run artifact: [`docs/subscription-monitor-runs/2026-06-12.md`](subscription-monitor-runs/2026-06-12.md)
+
+Summary:
+
+- No cancellation approvals requested and no cancellation action taken.
+- Supabase production moved through 2026-06-11, configured-local `agent_runs` moved through 2026-06-12, and n8n Cloud returned 85 workflows, 72 active workflows, and successful executions `16985`-`16989` around 2026-06-12T12:00Z.
+- Vercel listed ready deployments for both `portfolio` and `portfolio-staging`; Stripe, OpenAI, Anthropic, Slack, Pinecone, Hunter, HeyGen, Printful, ElevenLabs, Apify, OpenRouter, Vapi, Gemini/Google AI, and Read AI were readable or dependency-backed.
+- Read AI had seven May 1-June 12 meeting metadata records with latest June 11 activity; HeyGen avatar retry recovered; ElevenLabs stayed low-use at 802/246,034 characters before the 2026-06-19 reset.
+- Gamma regressed to HTTP 401 after the June 11 recovery; OpenRouter, Vapi, Printful sync, Resend, Calendly, Pinecone traffic/billing, Gamma access/credits, and design-tool billing remain investigate/watch items.
+- BuiltWith remains active/watch during the outreach ramp; Fireflies remains resolved canceled unless new paid-plan evidence appears.
+
+## 2026-06-11 Daily Monitor Run
+
+Status: YELLOW
+
+Detailed run artifact: [`docs/subscription-monitor-runs/2026-06-11.md`](subscription-monitor-runs/2026-06-11.md)
+
+Summary:
+
+- No cancellation approvals requested and no cancellation action taken.
+- Supabase production moved through 2026-06-10 across analytics, agent runs, cost events, and social content; n8n Cloud returned 85 workflows, 72 active workflows, and successful executions `16878`-`16882` around 2026-06-11T12:00Z.
+- Vercel listed ready `portfolio` and `portfolio-staging` deployments; Stripe, OpenAI, Anthropic, Slack, Pinecone, Hunter, Gamma, HeyGen, Printful, ElevenLabs, Apify, OpenRouter, Vapi, Gemini/Google AI, and Read AI were readable or dependency-backed.
+- Gamma recovered to HTTP 200 with 50 themes; Gemini stayed readable with 50 models; ElevenLabs moved from zero-use to 802/246,034 characters this cycle.
+- OpenRouter, Vapi, Printful sync, Resend, Calendly, Pinecone traffic/billing, and design-tool billing remain investigate/watch items, but no vendor crossed the approval-ready cancellation threshold.
+- BuiltWith remains active/watch during the outreach ramp; Fireflies remains resolved canceled unless new paid-plan evidence appears.
+
+## 2026-06-08 Weekly Subscription Report
+
+Status: YELLOW
+
+Source set:
+
+- Primary tracker/status files: `docs/subscription-cancellation-audit.md` and `docs/subscription-status.json`.
+- Current daily evidence artifact: [`docs/subscription-monitor-runs/2026-06-08.md`](subscription-monitor-runs/2026-06-08.md).
+- Prior weekly comparison point: `2026-05-25 Weekly Report`.
+- Action tracker feedback: 12 open actions for `portfolio-subscription-weekly-report`, with 0 in progress, 0 blocked, 0 done, and no progress notes.
+
+Summary:
+
+- No cancellation approvals requested and no cancellation action taken.
+- Core keep items remain active/readable: Supabase, n8n Cloud, Vercel, Stripe, OpenAI, Anthropic API, Slack, Read AI, HeyGen, Apify, Hunter.io, Google Cloud, and Gemini/Google AI.
+- Watch/investigate items remain: BuiltWith, ElevenLabs, OpenRouter, Vapi, Gamma, Pinecone, Printful, Resend, Calendly, Anthropic billing transition, HeyGen quota/billing, Read AI recency, and design-tool billing.
+- Resolved/canceled item remains Fireflies.ai. Keep it out of the active queue unless a new receipt or dashboard signal shows the paid plan restarted.
+- BuiltWith remains a protected outreach-ramp watch item, not a current cancellation candidate.
+- No vendor crossed the approval-ready cancellation threshold. Future cancellation still requires the exact approval phrase `Cancel <tool/vendor> for Portfolio`.
+
+Derived movement since the prior weekly report:
+
+- Supabase and n8n stayed active: production Supabase analytics reached 5,239/latest 2026-06-07T14:55:04Z, configured-local `agent_runs` reached 131/latest 2026-06-08T00:27:15Z, and n8n Cloud returned 85 workflows, 72 active workflows, and successful executions around 2026-06-08T12:00Z.
+- Vercel stayed active with ready `portfolio` and `portfolio-staging` deployments.
+- Gemini/Google AI improved from repeated HTTP 403 evidence to HTTP 200 with 50 readable models, but billing/project status remains unresolved.
+- Gamma moved in the wrong direction after a recent readable check: `/v1.0/themes` returned HTTP 401 on 2026-06-08. Treat this as access/billing visibility drift, not cancellation evidence.
+- Read AI remains connector-readable with six meetings in the May 1-June 8 window, latest 2026-05-29; dashboard recency should be checked only if June meeting capture is expected.
+- OpenRouter, Vapi, ElevenLabs, Printful sync, Resend, Calendly, Gamma, and Pinecone traffic/billing remain quiet, auth-blocked, or unresolved, but still require dashboard/login evidence before any cancellation packet.
+
+Candidate cancellations:
+
+- No automatic cancellation.
+- Strongest future deprecation-packet candidates remain OpenRouter, Vapi, ElevenLabs, Printful, Resend, Pinecone, Calendly, and Gamma, but only after dashboard billing, usage, and replacement-risk checks.
+- BuiltWith is excluded from cancellation candidacy during the outreach/client-volume ramp.
+- Fireflies.ai is already resolved/canceled and should only be revisited if new paid-plan evidence appears.
+
+Next weekly focus:
+
+- Verify Vapi billing/product intent, ElevenLabs campaign need before the 2026-06-19 reset, Printful dashboard/store strategy, Resend production env/billing, Pinecone traffic/billing, Calendly access/usage, Gamma API/dashboard credits, Gemini billing/project status, HeyGen quota/billing, and Anthropic transition billing.
+- Continue the Apify actor-level replacement bakeoff before any account-level change.
+- Keep BuiltWith active while collecting outreach-ramp outcome evidence.
+
+## 2026-06-08 Daily Monitor Run
+
+Status: YELLOW
+
+Detailed run artifact: [`docs/subscription-monitor-runs/2026-06-08.md`](subscription-monitor-runs/2026-06-08.md)
+
+Summary:
+
+- No cancellation approvals requested and no cancellation action taken.
+- Supabase production analytics moved to 5,239/latest 2026-06-07T14:55:04Z; configured-local `agent_runs` moved to 131/latest 2026-06-08T00:27:15Z.
+- n8n Cloud returned 85 workflows, 72 active workflows, and successful executions `16550`-`16554` around 2026-06-08T12:00Z; Vercel listed ready `portfolio` and `portfolio-staging` deployments.
+- Stripe, OpenAI, Anthropic, Slack, Pinecone, Hunter, HeyGen, Printful, ElevenLabs, Apify, OpenRouter, Vapi, Gemini/Google AI, and Read AI were readable or dependency-backed.
+- Gemini/Google AI recovered to HTTP 200 with 50 models; Gamma regressed to HTTP 401 and should be treated as access/billing visibility drift.
+- OpenRouter, Vapi, ElevenLabs, Printful sync, Resend, Calendly, Gamma, and Pinecone traffic/billing remain investigate/watch items, but no vendor crossed the approval-ready cancellation threshold.
+- BuiltWith remains active/watch during the outreach ramp; Fireflies remains resolved canceled unless new paid-plan evidence appears.
+
+## 2026-06-07 Daily Monitor Run
+
+Status: YELLOW
+
+Detailed run artifact: [`docs/subscription-monitor-runs/2026-06-07.md`](subscription-monitor-runs/2026-06-07.md)
+
+Summary:
+
+- No cancellation approvals requested and no cancellation action taken.
+- Supabase production analytics moved to 5,236/latest 2026-06-07T03:57:33Z; n8n Cloud returned 85 workflows, 72 active workflows, and successful executions around 2026-06-07T12:00Z.
+- Vercel listed deployments for `portfolio` and `portfolio-staging`; Stripe remained readable with latest sampled successful charge/payment evidence on 2026-04-06.
+- OpenAI, Anthropic, Slack, Pinecone, Hunter, Gamma, HeyGen, Printful, ElevenLabs, Apify, OpenRouter, Vapi, and Read AI were readable or dependency-backed.
+- OpenRouter, Vapi, ElevenLabs, Printful sync, Resend, Calendly, Gemini/Google AI, and Pinecone traffic/billing remain investigate/watch items, but no vendor crossed the approval-ready cancellation threshold.
+- BuiltWith remains active/watch during the outreach ramp; Fireflies remains resolved canceled unless new paid-plan evidence appears.
+
+## 2026-06-06 Daily Monitor Run
+
+Status: YELLOW
+
+Detailed run artifact: [`docs/subscription-monitor-runs/2026-06-06.md`](subscription-monitor-runs/2026-06-06.md)
+
+Summary:
+
+- No cancellation approvals requested and no cancellation action taken.
+- Supabase production `agent_runs` moved to 84/latest 2026-06-05T13:00:03Z; n8n Cloud returned 85 workflows, 72 active workflows, and successful executions around 2026-06-06T12:00Z.
+- Vercel listed ready `portfolio` and `portfolio-staging` deployments, Stripe remained readable with latest sampled successful payment evidence on 2026-04-06, and OpenAI/Anthropic/Slack/Pinecone/Hunter/Printful/ElevenLabs/HeyGen/Apify/Read AI remained readable or dependency-backed.
+- Gamma is readable again through the current `/v1.0/themes` endpoint; future probes should avoid the sunset `/v0.2/themes` endpoint and the invalid `pageSize` parameter.
+- OpenRouter, Vapi, ElevenLabs, Printful sync, Resend, Calendly, Gemini/Google AI, and Pinecone traffic/billing remain investigate/watch items, but no vendor crossed the approval-ready cancellation threshold.
+- BuiltWith remains active/watch during the outreach ramp; Fireflies remains resolved canceled unless new paid-plan evidence appears.
+
+## 2026-06-05 Daily Monitor Run
+
+Status: YELLOW
+
+Detailed run artifact: [`docs/subscription-monitor-runs/2026-06-05.md`](subscription-monitor-runs/2026-06-05.md)
+
+Summary:
+
+- No cancellation approvals requested and no cancellation action taken.
+- Supabase, n8n, Vercel, OpenAI, Anthropic, Slack, Read AI, HeyGen, Apify, Pinecone, Hunter, Printful, and ElevenLabs remain active, readable, or configured with meaningful Portfolio dependencies.
+- n8n had 85 workflows, 72 active workflows, and sampled successful executions around 2026-06-05T12:00Z.
+- Supabase production movement continued on 2026-06-04 across analytics, agent runs, cost events, email messages, and meeting records.
+- Gamma remained HTTP 401, Calendly remained HTTP 401, and Gemini/Google AI remained HTTP 403; these are investigate/access blockers, not cancellation approvals.
+- OpenRouter, Vapi, ElevenLabs, Printful, and Resend still show repeated quiet or unresolved usage signals, but dashboard billing and replacement-risk evidence are still required before any cancellation packet.
+- BuiltWith remains active/watch during the outreach ramp; Fireflies remains resolved canceled unless new paid-plan evidence appears.
+
 ## 2026-06-03 Daily Monitor Run
 
 Status: YELLOW

--- a/docs/subscription-monitor-runs/2026-06-05.md
+++ b/docs/subscription-monitor-runs/2026-06-05.md
@@ -1,0 +1,106 @@
+# 2026-06-05 Subscription Monitor Run
+
+Status: YELLOW
+
+## Summary
+
+- No cancellation approvals requested and no cancellation action taken.
+- Core Portfolio infrastructure remains active: Supabase, n8n Cloud, Vercel, OpenAI, Anthropic, Slack, Pinecone, HeyGen, Printful, Hunter, Apify, and Read AI were readable or showed operational/config evidence.
+- Supabase moved since the prior run: production `analytics_events` 5208/latest 2026-06-04T14:42:31Z, production `agent_runs` 83/latest 2026-06-04T18:33:51Z, production `cost_events` 22/latest 2026-06-04T18:34:01Z, production `meeting_records` 111/latest 2026-06-04T16:45:12Z, and production `email_messages` 10/latest 2026-06-04T16:46:08Z.
+- n8n Cloud remains operational with 85 workflows, 72 active workflows, and sampled successful executions `16239` through `16243` around 2026-06-05T12:00Z.
+- Vercel CLI remained authenticated as `vsillah` and listed current `portfolio` and `portfolio-staging` deployments.
+- Read AI connector returned six meetings in the 2026-05-01 through 2026-06-05 window, latest on 2026-05-29. Raw meeting content, participant details, URLs, and transcripts were not copied into this artifact.
+- Gamma remained blocked with HTTP 401 invalid/expired token. Calendly remained HTTP 401 unauthenticated. Gemini/Google AI remained HTTP 403 permission denied.
+- OpenRouter still reports current-key usage 0, Vapi still returned zero sampled calls, Resend local key remains absent, Printful still shows one older draft order with empty app sync logs, and ElevenLabs still shows 0 of 246,034 characters used in the current cycle before the 2026-06-19 reset.
+- BuiltWith remains a protected watch item during the outreach/client-volume ramp. Fireflies remains resolved as canceled per Vambah's 2026-05-01 confirmation unless new paid-plan evidence appears.
+- No vendor crossed the approval-ready cancellation threshold.
+
+## Raw Findings
+
+- Read-only checks ran on 2026-06-05. Secret values, raw account payloads, private meeting content, private exports, and full logs are not included.
+- Initial checkout state was detached HEAD with one unrelated untracked folder: `docs/client-followups/`. This run preserved that work and only touched subscription-monitor artifacts, status JSON, automation memory, and the sanitized pending notification.
+- Action tracker feedback existed for `portfolio-subscription-cancellation-monitor`: 51 open actions, 0 in progress, 0 blocked, 0 done, and no progress notes. No completed or dismissed action signal changed this run's recommendations.
+- Repo/config footprint remains broad. `.env.example`, `.env.staging.example`, `.env.local`, `package.json`, app/api routes, lib integrations, scripts, docs, n8n exports, and migrations continue to reference Supabase, Stripe, n8n, Vercel, OpenAI, Anthropic, Apify, BuiltWith, Calendly, ElevenLabs, Gamma, Gemini/Google, HeyGen, Printful, Resend, Slack, Vapi, OpenRouter, Pinecone, Hunter, Read AI, Google/Gmail/Drive, and related webhooks.
+- `package.json` keeps active dependencies for Supabase, Stripe, Resend, Vercel Functions/Speed Insights/Blob, Google APIs, Playwright, and Vapi.
+- Checked-in n8n exports contain 46 JSON files, 45 top-level workflow objects, and 38 active top-level exports. Integration node references include Supabase, Slack, webhooks, OpenAI, Gmail, Apify, Google Drive/Docs/Sheets, Pinecone, Calendly, Stripe, and Anthropic.
+- Supabase production aggregates: `analytics_events` 5208/latest 2026-06-04T14:42:31Z, `agent_runs` 83/latest 2026-06-04T18:33:51Z, `cost_events` 22/latest 2026-06-04T18:34:01Z, `orders` 26/latest 2026-03-19T14:54:19Z, `printful_sync_log` 0, `email_messages` 10/latest 2026-06-04T16:46:08Z, `meeting_records` 111/latest 2026-06-04T16:45:12Z, `gamma_reports` 6/latest 2026-05-02T01:20:15Z, `videos` 4/latest 2026-04-15T02:52:07Z, and `social_content_queue` 29/latest 2026-05-07T13:00:49Z.
+- Supabase configured-local aggregates: `analytics_events` 2164/latest 2026-06-02T18:00:54Z, `agent_runs` 130/latest 2026-06-04T14:46:50Z, `cost_events` 12/latest 2026-05-27T20:37:59Z, `orders` 1/latest 2026-04-06T19:35:41Z, `printful_sync_log` 0, `email_messages` 7/latest 2026-06-04T16:46:11Z, `meeting_records` 5/latest 2026-06-04T16:45:15Z, `gamma_reports` 4/latest 2026-04-16T14:56:34Z, `videos` 4/latest 2026-03-25T13:48:33Z, and `social_content_queue` 3/latest 2026-05-23T09:24:08Z.
+- n8n Cloud API returned HTTP 200 for workflows and executions: 85 workflows, 72 active, and five sampled successful/finished executions around 2026-06-05T12:00Z.
+- Vercel CLI returned an authenticated user and deployment listings for both `portfolio` and `portfolio-staging`.
+- OpenAI model listing returned HTTP 200 with 120 models. Anthropic model listing returned HTTP 200 with 10 models.
+- Slack bot auth returned HTTP 200 and `ok: true`.
+- Pinecone listed one ready serverless `publications` index in `aws/us-east-1`.
+- Hunter account remained readable and on Free, with 50 used calls and 75 available.
+- HeyGen returned HTTP 200 for both voices and avatars: 2348 voices and 1289 avatars. Billing/quota still requires dashboard verification.
+- Printful orders endpoint returned HTTP 200 with one sampled draft order created 2026-04-06; sampled app sync logs remain empty.
+- ElevenLabs subscription endpoint returned HTTP 200 for Creator with 0 of 246,034 characters used before 2026-06-19T18:38:26Z.
+- Apify actor-runs endpoint returned HTTP 200 with five recent sampled runs, latest on 2026-06-03, mixed succeeded/failed, low sampled usage.
+- Read AI connector returned six meetings for the May 1-June 5 window, latest start 2026-05-29.
+- OpenRouter auth/key endpoint returned HTTP 200 with usage 0. Vapi calls endpoint returned HTTP 200 with zero sampled calls.
+- Resend local key was absent. Calendly user lookup returned HTTP 401 unauthenticated. Gamma themes returned HTTP 401 invalid/expired token. Gemini model listing returned HTTP 403 permission denied.
+
+## Discovered Inventory
+
+| Status | Tool/vendor | Purpose in Portfolio | Evidence source | Likely cost/billing status | Last code/config/reference usage | Last operational usage | Dependencies or replacement risk | Session inactivity status | Recommendation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Green | Supabase | Core database, admin state, analytics, agent runs, app data, RAG-adjacent records | Supabase read-only aggregates; repo env/docs/routes | Paid/core hosted service | `.env.example`, app/api routes, lib database helpers, migrations, admin surfaces | Production movement on 2026-06-04 | High replacement risk; foundational | Active | Keep |
+| Green | n8n Cloud | Automation runtime and workflow orchestration | n8n API and checked-in exports | Paid hosted automation runtime | `.env.example`, `.env.staging.example`, n8n exports, webhook routes/docs | Executions `16239`-`16243` around 2026-06-05T12:00Z | High risk; many workflows and external sends depend on it | Active | Keep; optimize weak workflows separately |
+| Green | Vercel | Production/staging hosting and deployment surface | Vercel CLI | Paid/hosted deployment platform | Vercel scripts/docs, deployment runbooks, app runtime | Current deployment listings for `portfolio` and `portfolio-staging` | High risk; app hosting | Active | Keep |
+| Green | Stripe | Checkout, payments, subscriptions, revenue path | Repo routes/deps and prior API evidence | Revenue dependency; billing status requires dashboard/receipt refresh | Stripe packages, checkout/payment/webhook routes, admin test checkout | Latest sampled successful payment evidence remains 2026-04-06 | High revenue-path risk | Quiet recent transaction sample but dependency remains | Keep |
+| Green | OpenAI | Model provider for app/admin workflows and n8n | API model listing; n8n exports; env/docs | Usage-based API | `.env.example`, n8n OpenAI nodes, lib/provider fetch, admin LLM routes | Model API readable on 2026-06-05 | Medium/high; many AI paths | Active/configured | Keep/watch usage costs |
+| Green | Anthropic | Model provider and transition watch item | API model listing; n8n exports; env/docs | Billing transition unresolved | `.env.example`, n8n Anthropic node, lib/provider fetch | Model API readable on 2026-06-05 | Medium; replacement possible but quality/bakeoff dependent | Active API, billing unresolved | Keep/watch billing transition |
+| Green | Slack | Agent/admin notifications and mobile ops | Slack auth; n8n exports; env/docs | Workspace/app billing not proven here | Slack env keys, Slack API routes, n8n Slack nodes | Bot auth readable on 2026-06-05 | Medium/high; operational notification surface | Active/configured | Keep |
+| Green | Read AI | Meeting intelligence and transcript workflows | Read AI connector | Paid/subscription status not available here | `.env.local` token presence, meeting dedupe routes, meeting docs | Six meetings since 2026-05-01; latest 2026-05-29 | Medium; could replace with manual notes, but meeting memory value remains | Active enough; no June 1-5 meeting returned | Keep/watch recency |
+| Green | HeyGen | Avatar/video generation and campaign media | HeyGen API catalog checks; repo env/docs/routes | Paid/quota status needs dashboard | HeyGen env keys, webhook route, video docs/workflows | Avatars and voices readable on 2026-06-05 | Medium; video campaigns may depend on it | API readable, usage/quota unknown | Keep/watch; verify dashboard quota |
+| Green | Apify | Lead/social/evidence scraping actors and replacement bakeoff | Apify API and bakeoff docs/status JSON | Usage-based; sampled runs low cost | Apify docs/scripts/n8n exports/env | Latest sampled actor runs 2026-06-03 | Medium; actor-level replacement still in progress | Account active, actor-level mixed | Keep account; continue actor bakeoff |
+| Green | Pinecone | Publications/vector search | Pinecone API | Billing/traffic unresolved | Pinecone env key, RAG docs/n8n vector nodes | One ready `publications` index readable on 2026-06-05 | Medium; may be replaceable with Supabase/local RAG after traffic check | Config active, traffic unknown | Investigate dashboard/API traffic before replacement |
+| Green | Hunter.io | Lead enrichment | Hunter API | Free plan | `.env.local` key and lead enrichment docs | Free account readable on 2026-06-05 | Low; not a paid cancellation target | Not paid in sampled evidence | Keep/free-watch |
+| Yellow | BuiltWith | Outreach/client stack enrichment | Standing decision plus env/docs | Receipt-backed $307/month historical line item | BuiltWith env key, deprecation packet, outreach docs | No fresh usage probe in this run | Medium; protected until outreach ramp has outcome evidence | Watch item, not cancellation candidate | Keep active during outreach ramp |
+| Yellow | Gamma | Report/deck generation provider | Gamma API, DB report rows, repo routes | Paid/credit status needs dashboard | Gamma env key, admin gamma reports, auto audit summary lib | API blocked 401; DB rows quiet since 2026-05-02 | Medium; reports/decks may depend on it | Auth-blocked, usage quiet | Investigate key and credits; do not cancel from auth failure alone |
+| Yellow | ElevenLabs | Voice/audio generation | ElevenLabs API | Creator subscription readable | Env key and voice docs | 0/246,034 characters used this cycle; reset 2026-06-19 | Low/medium; can replace with HeyGen/native audio if no campaign need | Consecutive zero-usage evidence | Review campaign need before reset |
+| Yellow | OpenRouter | Alternate model routing/bakeoff | OpenRouter API | Usage 0 on current key; billing/spend unresolved | `.env.local` key; model bakeoff context | Usage 0 again on 2026-06-05 | Low/medium; replaceable if no bakeoff role | Consecutive quiet evidence | Investigate/deprecate only after spend and dependency check |
+| Yellow | Vapi | Optional voice UX | Vapi API and app/webhook refs | Billing unresolved | Vapi env keys, `@vapi-ai/web`, Vapi webhook/lib | Zero sampled calls again on 2026-06-05 | Medium if production voice UX is intended | Consecutive quiet evidence | Verify dashboard billing and product intent |
+| Yellow | Printful | Store/merch fulfillment | Printful API, Supabase sync logs, store routes/docs | Billing/order costs uncertain | Printful env keys, webhook route, store page, fulfillment lib | One draft order from 2026-04-06; sync logs empty | Medium; store/merch path depends on it | Sync inactive; older draft order exists | Investigate dashboard/store strategy |
+| Yellow | Resend | Optional outbound email and webhook provider | Env presence check and repo routes/deps | Local key absent; production billing unknown | Resend package, webhook route, email docs/env | No local key; production env not verified | Medium; Gmail/n8n may replace if Resend unused | Usage unresolved | Verify production env/billing before removing |
+| Yellow | Calendly | Scheduling links and booking triggers | Calendly API, n8n exports, env/docs | Paid/free status unknown | Calendly env keys, scheduling docs, n8n triggers/router | API returned 401; workflow refs remain | Medium; scheduling workflows depend on it | Auth unresolved | Refresh token or verify dashboard usage |
+| Yellow | Gemini / Google AI | Google AI/image/social workflow provider | Gemini API, n8n export refs | Billing/project status unknown | Gemini env key, Google AI n8n workflow, Google docs | API returned 403 | Medium; workflow may need key/project repair | Auth/project blocked | Resolve key/project before relying on or deprecating |
+| Yellow | Figma / Paper / Excalidraw / Canva | Design and diagram production | Repo/docs references only | Billing unknown | Design docs/assets; no direct billing probe | No operational provider check in this run | Low/medium; depends on design pipeline | Unknown | Investigate only if receipts/dashboard evidence appear |
+| Green | Fireflies.ai | Historical meeting recaps only | Standing cancellation decision | Already canceled per 2026-05-01 confirmation | Historical docs only | No new paid-plan evidence | Low unless restarted | Resolved canceled | Keep out of active queue unless paid plan restarts |
+
+## Inactivity Evidence
+
+- OpenRouter: current-key usage remained 0 across consecutive audit sessions. This is still investigate/watch, not approval-ready cancellation, because spend and remaining bakeoff purpose are not confirmed.
+- Vapi: sampled calls remained 0 across consecutive sessions. Treat as investigate until dashboard billing and production voice UX intent are verified.
+- ElevenLabs: current cycle remains 0/246,034 characters used across consecutive sessions before the 2026-06-19 reset. Review planned voice/audio campaign needs before proposing cancellation.
+- Printful: app sync logs remain empty across sampled Supabase projects, while the API still shows one older draft order from 2026-04-06. Treat as merchandise strategy investigation, not a subscription cancellation.
+- Resend: local key remains absent while package/env/webhook references remain. Verify Vercel production env and billing before removing code paths.
+- Calendly and Gemini/Google AI: auth/project failures continue across sessions, but workflow and scheduling dependencies remain. Repair visibility before making a provider decision.
+- Gamma: API access remained HTTP 401 invalid/expired token after the 2026-06-03 regression. This is an access/credential blocker, not cancellation evidence by itself.
+
+## Candidate Cancellations
+
+- No automatic cancellation.
+- No current vendor has approval-ready cancellation evidence in this daily run.
+- If Vambah wants to convert a watch item into a cancellation workflow, the exact approval phrase is still required: `Cancel <tool/vendor> for Portfolio`.
+
+## Approval Needed
+
+- No cancellation approval is requested today.
+- Manual/dashboard checks needed before any future cancellation packet:
+  - Verify Gamma key, dashboard billing, and remaining credits.
+  - Verify Vapi billing and whether production voice UX should stay enabled.
+  - Verify ElevenLabs campaign need before the 2026-06-19 reset.
+  - Verify Printful dashboard/store strategy and whether the older draft order matters.
+  - Verify whether production uses Resend or Gmail/n8n as the real outbound email channel.
+  - Verify Pinecone billing/API traffic against Supabase/local RAG.
+  - Restore or replace Calendly API access and check scheduling event usage.
+  - Resolve Gemini/Google AI project/key status before relying on those workflows.
+  - Keep BuiltWith active while collecting outreach-ramp outcome evidence.
+
+## Next Audit Focus
+
+- Re-run the quiet-provider group with dashboard evidence where APIs cannot prove billing: Vapi, ElevenLabs, Printful, Resend, Pinecone, Gamma, Calendly, Gemini, HeyGen, and Anthropic billing transition.
+- Continue tracking OpenRouter as a zero-usage model-routing watch item and only draft deprecation if no bakeoff role or spend remains.
+- Continue the Apify actor-level replacement bakeoff before any account-level decision.
+- Keep Fireflies out of the active queue unless new receipt/dashboard evidence shows the paid plan restarted.
+- Carry forward action-tracker context: 51 open actions, no in-progress/blocked/done/progress-note changes.

--- a/docs/subscription-monitor-runs/2026-06-06.md
+++ b/docs/subscription-monitor-runs/2026-06-06.md
@@ -1,0 +1,112 @@
+# 2026-06-06 Subscription Monitor Run
+
+Status: YELLOW
+
+## Summary
+
+- No cancellation approvals requested and no cancellation action taken.
+- Core Portfolio systems remain active or readable: Supabase, n8n Cloud, Vercel, Stripe, OpenAI, Anthropic, Slack, Gamma, HeyGen, Pinecone, Hunter, Apify, Printful, ElevenLabs, and Read AI all returned current read-only or dependency evidence.
+- Supabase production moved since the prior run: `agent_runs` increased to 84 with latest row at 2026-06-05T13:00:03Z, while analytics, cost, email, meeting, and social/report tables still show recent or configured Portfolio usage.
+- n8n Cloud remains operational with 85 workflows, 72 active workflows, and sampled successful executions `16342` through `16346` around 2026-06-06T12:00Z.
+- Vercel CLI remained authenticated as `vsillah`; `portfolio` and `portfolio-staging` both listed ready deployments, including same-day Portfolio preview/production activity and recent staging production activity.
+- Stripe remains a revenue dependency. Read-only Stripe checks were successful; latest sampled successful payment intent and charge remain 2026-04-06, while checkout sessions remain older but app checkout/payment code is still wired.
+- Read AI connector returned six meetings in the 2026-05-01 through 2026-06-06 window, latest on 2026-05-29. Raw meeting content, participant details, URLs, and transcripts were not copied into this artifact.
+- Gamma recovered as readable when checked through the current `/v1.0/themes` endpoint: 50 themes returned with more available. The older `/v0.2/themes` endpoint remains sunset, and the bad `pageSize` parameter returns validation errors; this is a probe-shape issue, not cancellation evidence.
+- Repeated quiet or unresolved items remain: OpenRouter usage 0, Vapi zero sampled calls, ElevenLabs 0 of 246,034 characters used before the 2026-06-19 reset, Printful sync logs empty despite one older draft order, Resend local key absent, Calendly HTTP 401, Gemini/Google AI HTTP 403, and Pinecone traffic/billing unresolved.
+- BuiltWith remains a protected watch item during the outreach/client-volume ramp. Fireflies remains resolved as canceled per Vambah's 2026-05-01 confirmation unless new paid-plan evidence appears.
+- No vendor crossed the approval-ready cancellation threshold.
+
+## Raw Findings
+
+- Read-only checks ran on 2026-06-06. Secret values, raw account payloads, private meeting content, private exports, and full logs are not included.
+- Initial checkout state was detached HEAD with pre-existing dirty work in `docs/subscription-cancellation-audit.md`, `docs/subscription-status.json`, `lib/subscription-status.test.ts`, untracked `docs/subscription-monitor-runs/2026-06-05.md`, untracked `docs/client-followups/`, and two stray untracked path fragments. This run preserved that work and only layered the June 6 monitor outputs on top.
+- No prior automation memory file existed at `$CODEX_HOME/automations/portfolio-subscription-cancellation-monitor/memory.md`; this run used checked-in audit/status artifacts and action-tracker feedback as continuity state.
+- Action tracker feedback existed for `portfolio-subscription-cancellation-monitor`: 51 open actions, 0 in progress, 0 blocked, 0 done, and no progress notes. No completed, dismissed, blocked, or in-progress action signal changed today's recommendations.
+- Repo/config footprint remains broad. `.env.example`, `.env.staging.example`, `.env.local`, `package.json`, app/api routes, lib integrations, scripts, docs, n8n exports, and migrations continue to reference Supabase, Stripe, n8n, Vercel, OpenAI, Anthropic, Apify, BuiltWith, Calendly, ElevenLabs, Gamma, Gemini/Google, HeyGen, Printful, Resend, Slack, Vapi, OpenRouter, Pinecone, Hunter, Read AI, Google/Gmail/Drive, and related webhooks.
+- `package.json` keeps active dependencies for Supabase, Stripe, Resend, Vercel Functions/Speed Insights/Blob, Google APIs, Playwright, and Vapi.
+- Checked-in n8n exports contain 46 JSON files, 45 top-level workflow objects, and 38 active top-level exports. Integration node references include Supabase, Slack, webhooks, OpenAI, Gmail, Apify, Google Drive/Docs/Sheets, Pinecone, Calendly, Stripe, and Anthropic.
+- Supabase production aggregates: `analytics_events` 5208/latest 2026-06-04T14:42:31Z, `agent_runs` 84/latest 2026-06-05T13:00:03Z, `cost_events` 22/latest 2026-06-04T18:34:01Z, `orders` 26/latest 2026-03-19T14:54:19Z, `printful_sync_log` 0, `email_messages` 10/latest 2026-06-04T16:46:08Z, `meeting_records` 111/latest 2026-06-04T16:45:12Z, `gamma_reports` 6/latest 2026-05-02T01:20:15Z, `videos` 4/latest 2026-04-15T02:52:07Z, and `social_content_queue` 29/latest 2026-05-07T13:00:49Z.
+- Supabase configured-local aggregates: `analytics_events` 2164/latest 2026-06-02T18:00:54Z, `agent_runs` 130/latest 2026-06-04T14:46:50Z, `cost_events` 12/latest 2026-05-27T20:37:59Z, `orders` 1/latest 2026-04-06T19:35:41Z, `printful_sync_log` 0, `email_messages` 7/latest 2026-06-04T16:46:11Z, `meeting_records` 5/latest 2026-06-04T16:45:15Z, `gamma_reports` 4/latest 2026-04-16T14:56:34Z, `videos` 4/latest 2026-03-25T13:48:33Z, and `social_content_queue` 3/latest 2026-05-23T09:24:08Z.
+- n8n Cloud API returned HTTP 200 for workflows and executions: 85 workflows, 72 active, and five sampled successful/finished executions around 2026-06-06T12:00Z.
+- Vercel CLI returned authenticated user `vsillah`; `portfolio` listed ready deployments including same-day preview and production entries, and `portfolio-staging` listed ready production deployments with latest about two hours old at probe time.
+- Stripe payment intents, charges, and checkout sessions were readable. Latest sampled successful payment intent and charge were 2026-04-06; latest sampled paid checkout sessions were 2026-02-23.
+- OpenAI model listing returned HTTP 200 with 120 models. Anthropic model listing returned HTTP 200 with 10 models.
+- Slack bot auth returned HTTP 200 and `ok: true`.
+- Pinecone listed one ready serverless `publications` index in `aws/us-east-1`.
+- Hunter account remained readable and on Free, with 50 used calls and 75 available.
+- Gamma `/v1.0/themes` returned HTTP 200 with 50 themes and `hasMore: true`; `/v1.0/themes?pageSize=50` returned HTTP 400 because `pageSize` is not accepted; `/v0.2/themes` returned HTTP 410 because that endpoint is sunset.
+- HeyGen returned HTTP 200 for both voices and avatars: 2347 voices and 1289 avatars. Billing/quota still requires dashboard verification.
+- Printful orders endpoint returned HTTP 200 with one sampled draft order created 2026-04-06; sampled app sync logs remain empty.
+- ElevenLabs subscription endpoint returned HTTP 200 for Creator with 0 of 246,034 characters used before 2026-06-19T18:38:26Z.
+- Apify actor-runs endpoint returned HTTP 200 with five recent sampled runs, latest on 2026-06-03, mixed succeeded/failed, low sampled usage.
+- Read AI connector returned six meetings for the May 1-June 6 window, latest start 2026-05-29.
+- OpenRouter auth/key endpoint returned HTTP 200 with usage 0. Vapi calls endpoint returned HTTP 200 with zero sampled calls.
+- Resend local key was absent. Calendly user lookup returned HTTP 401 unauthenticated. Gemini model listing returned HTTP 403 permission denied.
+
+## Discovered Inventory
+
+| Status | Tool/vendor | Purpose in Portfolio | Evidence source | Likely cost/billing status | Last code/config/reference usage | Last operational usage | Dependencies or replacement risk | Session inactivity status | Recommendation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Green | Supabase | Core database, admin state, analytics, agent runs, app data, RAG-adjacent records | Supabase read-only aggregates; repo env/docs/routes | Paid/core hosted service | `.env.example`, app/api routes, lib database helpers, migrations, admin surfaces | Production `agent_runs` latest 2026-06-05 | High replacement risk; foundational | Active | Keep |
+| Green | n8n Cloud | Automation runtime and workflow orchestration | n8n API and checked-in exports | Paid hosted automation runtime | `.env.example`, `.env.staging.example`, n8n exports, webhook routes/docs | Executions `16342`-`16346` around 2026-06-06T12:00Z | High risk; many workflows and external sends depend on it | Active | Keep; optimize weak workflows separately |
+| Green | Vercel | Production/staging hosting and deployment surface | Vercel CLI | Paid/hosted deployment platform | Vercel scripts/docs, deployment runbooks, app runtime | Ready `portfolio` and `portfolio-staging` deployments on 2026-06-06 | High risk; app hosting | Active | Keep |
+| Green | Stripe | Checkout, payments, subscriptions, revenue path | Stripe API; repo routes/deps | Revenue dependency; billing status requires dashboard/receipt refresh | Stripe packages, checkout/payment/webhook routes, admin test checkout | Latest sampled successful payment intent/charge 2026-04-06 | High revenue-path risk | Quiet recent transaction sample but dependency remains | Keep |
+| Green | OpenAI | Model provider for app/admin workflows and n8n | API model listing; n8n exports; env/docs | Usage-based API | `.env.example`, n8n OpenAI nodes, lib/provider fetch, admin LLM routes | Model API readable on 2026-06-06 | Medium/high; many AI paths | Active/configured | Keep/watch usage costs |
+| Green | Anthropic | Model provider and transition watch item | API model listing; n8n exports; env/docs | Billing transition unresolved | `.env.example`, n8n Anthropic node, lib/provider fetch | Model API readable on 2026-06-06 | Medium; replacement possible but quality/bakeoff dependent | Active API, billing unresolved | Keep/watch billing transition |
+| Green | Slack | Agent/admin notifications and mobile ops | Slack auth; n8n exports; env/docs | Workspace/app billing not proven here | Slack env keys, Slack API routes, n8n Slack nodes | Bot auth readable on 2026-06-06 | Medium/high; operational notification surface | Active/configured | Keep |
+| Green | Read AI | Meeting intelligence and transcript workflows | Read AI connector | Paid/subscription status not available here | `.env.local` token presence, meeting dedupe routes, meeting docs | Six meetings since 2026-05-01; latest 2026-05-29 | Medium; can replace with manual notes, but meeting memory value remains | Active enough; no June meeting returned | Keep/watch recency |
+| Green | Gamma | Report/deck generation provider | Gamma API, DB report rows, repo routes | Paid/credit status needs dashboard | Gamma env key, admin gamma reports, auto audit summary lib | `/v1.0/themes` readable on 2026-06-06 | Medium; reports/decks may depend on it while Codex/PPTX alternatives are compared | Catalog readable, usage quiet | Keep/watch; verify credits and use correct endpoint |
+| Green | HeyGen | Avatar/video generation and campaign media | HeyGen API catalog checks; repo env/docs/routes | Paid/quota status needs dashboard | HeyGen env keys, webhook route, video docs/workflows | Avatars and voices readable on 2026-06-06 | Medium; video campaigns may depend on it | API readable, usage/quota unknown | Keep/watch; verify dashboard quota |
+| Green | Apify | Lead/social/evidence scraping actors and replacement bakeoff | Apify API and bakeoff docs/status JSON | Usage-based; sampled runs low cost | Apify docs/scripts/n8n exports/env | Latest sampled actor runs 2026-06-03 | Medium; actor-level replacement still in progress | Account active, actor-level mixed | Keep account; continue actor bakeoff |
+| Green | Pinecone | Publications/vector search | Pinecone API | Billing/traffic unresolved | Pinecone env key, RAG docs/n8n vector nodes | One ready `publications` index readable on 2026-06-06 | Medium; may be replaceable with Supabase/local RAG after traffic check | Config active, traffic unknown | Investigate dashboard/API traffic before replacement |
+| Green | Hunter.io | Lead enrichment | Hunter API | Free plan | `.env.local` key and lead enrichment docs | Free account readable on 2026-06-06 | Low; not a paid cancellation target | Not paid in sampled evidence | Keep/free-watch |
+| Yellow | BuiltWith | Outreach/client stack enrichment | Standing decision plus env/docs | Receipt-backed $307/month historical line item | BuiltWith env key, deprecation packet, outreach docs | No fresh usage probe in this run | Medium; protected until outreach ramp has outcome evidence | Watch item, not cancellation candidate | Keep active during outreach ramp |
+| Yellow | ElevenLabs | Voice/audio generation | ElevenLabs API | Creator subscription readable | Env key and voice docs | 0/246,034 characters used this cycle; reset 2026-06-19 | Low/medium; can replace with HeyGen/native audio if no campaign need | Consecutive zero-usage evidence | Review campaign need before reset |
+| Yellow | OpenRouter | Alternate model routing/bakeoff | OpenRouter API | Usage 0 on current key; billing/spend unresolved | `.env.local` key; model bakeoff context | Usage 0 again on 2026-06-06 | Low/medium; replaceable if no bakeoff role | Consecutive quiet evidence | Investigate/deprecate only after spend and dependency check |
+| Yellow | Vapi | Optional voice UX | Vapi API and app/webhook refs | Billing unresolved | Vapi env keys, `@vapi-ai/web`, Vapi webhook/lib | Zero sampled calls again on 2026-06-06 | Medium if production voice UX is intended | Consecutive quiet evidence | Verify dashboard billing and product intent |
+| Yellow | Printful | Store/merch fulfillment | Printful API, Supabase sync logs, store routes/docs | Billing/order costs uncertain | Printful env keys, webhook route, store page, fulfillment lib | One draft order from 2026-04-06; sync logs empty | Medium; store/merch path depends on it | Sync inactive; older draft order exists | Investigate dashboard/store strategy |
+| Yellow | Resend | Optional outbound email and webhook provider | Env presence check and repo routes/deps | Local key absent; production billing unknown | Resend package, webhook route, email docs/env | No local key; production env not verified | Medium; Gmail/n8n may replace if Resend unused | Usage unresolved | Verify production env/billing before removing |
+| Yellow | Calendly | Scheduling links and booking triggers | Calendly API, n8n exports, env/docs | Paid/free status unknown | Calendly env keys, scheduling docs, n8n triggers/router | API returned 401; workflow refs remain | Medium; scheduling workflows depend on it | Auth unresolved | Refresh token or verify dashboard usage |
+| Yellow | Gemini / Google AI | Google AI/image/social workflow provider | Gemini API, n8n export refs | Billing/project status unknown | Gemini env key, Google AI n8n workflow, Google docs | API returned 403 | Medium; workflow may need key/project repair | Auth/project blocked | Resolve key/project before relying on or deprecating |
+| Yellow | Figma / Paper / Excalidraw / Canva | Design and diagram production | Repo/docs references only | Billing unknown | Design docs/assets; no direct billing probe | No operational provider check in this run | Low/medium; depends on design pipeline | Unknown | Investigate only if receipts/dashboard evidence appear |
+| Green | Fireflies.ai | Historical meeting recaps only | Standing cancellation decision | Already canceled per 2026-05-01 confirmation | Historical docs only | No new paid-plan evidence | Low unless restarted | Resolved canceled | Keep out of active queue unless paid plan restarts |
+
+## Inactivity Evidence
+
+- OpenRouter: current-key usage remained 0 across consecutive audit sessions. This is still investigate/watch, not approval-ready cancellation, because spend and remaining bakeoff purpose are not confirmed.
+- Vapi: sampled calls remained 0 across consecutive sessions. Treat as investigate until dashboard billing and production voice UX intent are verified.
+- ElevenLabs: current cycle remains 0/246,034 characters used across consecutive sessions before the 2026-06-19 reset. Review planned voice/audio campaign needs before proposing cancellation.
+- Printful: app sync logs remain empty across sampled Supabase projects, while the API still shows one older draft order from 2026-04-06. Treat as merchandise strategy investigation, not a subscription cancellation.
+- Resend: local key remains absent while package/env/webhook references remain. Verify Vercel production env and billing before removing code paths.
+- Calendly and Gemini/Google AI: auth/project failures continue across sessions, but workflow and scheduling dependencies remain. Repair visibility before making a provider decision.
+- Pinecone: one index exists and is ready, but traffic and billing remain unresolved. This is an investigate item, not cancellation evidence by itself.
+- Gamma: report rows remain quiet since 2026-05-02, but the current catalog endpoint is readable. Verify dashboard credits and recent deck/report need before any renewal decision.
+
+## Candidate Cancellations
+
+- No automatic cancellation.
+- No current vendor has approval-ready cancellation evidence in this daily run.
+- If Vambah wants to convert a watch item into a cancellation workflow, the exact approval phrase is still required: `Cancel <tool/vendor> for Portfolio`.
+
+## Approval Needed
+
+- No cancellation approval is requested today.
+- Manual/dashboard checks needed before any future cancellation packet:
+  - Verify Vapi billing and whether production voice UX should stay enabled.
+  - Verify ElevenLabs campaign need before the 2026-06-19 reset.
+  - Verify Printful dashboard/store strategy and whether the older draft order matters.
+  - Verify whether production uses Resend or Gmail/n8n as the real outbound email channel.
+  - Verify Pinecone billing/API traffic against Supabase/local RAG.
+  - Restore or replace Calendly API access and check scheduling event usage.
+  - Resolve Gemini/Google AI project/key status before relying on those workflows.
+  - Verify Gamma dashboard credits using the current `/v1.0/themes` API shape for future probes.
+  - Verify HeyGen quota and active video campaign need before renewal.
+  - Keep BuiltWith active while collecting outreach-ramp outcome evidence.
+
+## Next Audit Focus
+
+- Re-run the quiet-provider group with dashboard evidence where APIs cannot prove billing: Vapi, ElevenLabs, Printful, Resend, Pinecone, Gamma, Calendly, Gemini, HeyGen, and Anthropic billing transition.
+- Continue tracking OpenRouter as a zero-usage model-routing watch item and only draft deprecation if no bakeoff role or spend remains.
+- Continue the Apify actor-level replacement bakeoff before any account-level decision.
+- Keep Fireflies out of the active queue unless new receipt/dashboard evidence shows the paid plan restarted.
+- Carry forward action-tracker context: 51 open actions, no in-progress/blocked/done/progress-note changes.

--- a/docs/subscription-monitor-runs/2026-06-07.md
+++ b/docs/subscription-monitor-runs/2026-06-07.md
@@ -1,0 +1,111 @@
+# 2026-06-07 Subscription Monitor Run
+
+Status: YELLOW
+
+## Summary
+
+- No cancellation approvals requested and no cancellation action taken.
+- Core systems remain active/readable: Supabase, n8n Cloud, Vercel, Stripe, OpenAI, Anthropic, Slack, Gamma, HeyGen, Pinecone, Hunter, Apify, Printful, ElevenLabs, and Read AI returned current read-only, connector, or dependency evidence.
+- Supabase production analytics moved to 5,236 with latest row at 2026-06-07T03:57:33Z. Production `agent_runs` stayed at 84/latest 2026-06-05T13:00:03Z; email and meeting rows remain latest on 2026-06-04.
+- n8n Cloud remains operational with 85 workflows, 72 active workflows, and five sampled successful executions `16445` through `16449` around 2026-06-07T12:00Z.
+- Vercel CLI remained authenticated as `vsillah` and listed deployments for both `portfolio` and `portfolio-staging`.
+- Stripe remains a revenue dependency. Read-only Stripe checks were successful; latest sampled successful payment intent and charge remain 2026-04-06, while checkout sessions remain older.
+- Read AI connector returned six meetings in the 2026-05-01 through 2026-06-07 window, latest on 2026-05-29. No raw meeting content, transcripts, participant details, or URLs are included in this artifact.
+- Repeated quiet or unresolved items remain: OpenRouter usage 0, Vapi zero sampled calls, ElevenLabs 0 of 246,034 characters used before the 2026-06-19 reset, Printful sync logs empty despite one older draft order, Resend local key absent, Calendly HTTP 401, Gemini/Google AI HTTP 403, and Pinecone traffic/billing unresolved.
+- BuiltWith remains a protected watch item during the outreach/client-volume ramp. Fireflies remains resolved as canceled per Vambah's 2026-05-01 confirmation unless new paid-plan evidence appears.
+- No vendor crossed the approval-ready cancellation threshold.
+
+## Raw Findings
+
+- Read-only checks ran on 2026-06-07. Secret values, raw account payloads, private meeting content, private exports, and full logs are not included.
+- Initial checkout state was detached HEAD with pre-existing dirty work across `.env.example`, outreach/email files, docs, subscription tracker files, tests, migrations, and untracked prior monitor/client/revenue artifacts. This run preserved that work and only added the June 7 monitor outputs plus required tracker/status synchronization.
+- `CODEX_HOME` was unset in the shell, so the literal `$CODEX_HOME/...` check missed the memory path at first. The canonical memory file existed under `/Users/vambahsillah/.codex/automations/portfolio-subscription-cancellation-monitor/memory.md` and was read before finalizing; this run used automation memory, checked-in audit/status artifacts, and action-tracker feedback as continuity state.
+- Action tracker feedback existed for `portfolio-subscription-cancellation-monitor`: 51 open actions, 0 in progress, 0 blocked, 0 done, and no progress notes. No completed, dismissed, blocked, or in-progress action signal changed today's recommendations.
+- Repo/config footprint remains broad. `.env.example`, `.env.staging.example`, `.env.local`, `package.json`, app/api routes, lib integrations, scripts, docs, n8n exports, and migrations continue to reference Supabase, Stripe, n8n, Vercel, OpenAI, Anthropic, Apify, BuiltWith, Calendly, ElevenLabs, Gamma, Gemini/Google, HeyGen, Printful, Resend, Slack, Vapi, OpenRouter, Pinecone, Hunter, Read AI, Google/Gmail/Drive, and related webhooks.
+- `package.json` keeps active dependencies for Supabase, Stripe, Resend, Vercel Functions/Speed Insights/Blob, Google APIs, Playwright, and Vapi.
+- Checked-in n8n exports contain 46 JSON files, 45 top-level workflow objects, and 38 active top-level exports. Integration references include Supabase, Slack, Gmail/Google, Calendly, OpenAI, Apify, Pinecone, Stripe, Anthropic, HeyGen, and Vapi.
+- Supabase production aggregates: `analytics_events` 5236/latest 2026-06-07T03:57:33Z, `agent_runs` 84/latest 2026-06-05T13:00:03Z, `cost_events` 22/latest 2026-06-04T18:34:01Z, `orders` 26/latest 2026-03-19T14:54:19Z, `printful_sync_log` 0, `email_messages` 10/latest 2026-06-04T16:46:08Z, `meeting_records` 111/latest 2026-06-04T16:45:12Z, `gamma_reports` 6/latest 2026-05-02T01:20:15Z, `videos` 4/latest 2026-04-15T02:52:07Z, and `social_content_queue` 29/latest 2026-05-07T13:00:49Z.
+- Supabase configured-local aggregates: `analytics_events` 2164/latest 2026-06-02T18:00:54Z, `agent_runs` 130/latest 2026-06-04T14:46:50Z, `cost_events` 12/latest 2026-05-27T20:37:59Z, `orders` 1/latest 2026-04-06T19:35:41Z, `printful_sync_log` 0, `email_messages` 7/latest 2026-06-04T16:46:11Z, `meeting_records` 5/latest 2026-06-04T16:45:15Z, `gamma_reports` 4/latest 2026-04-16T14:56:34Z, `videos` 4/latest 2026-03-25T13:48:33Z, and `social_content_queue` 3/latest 2026-05-23T09:24:08Z.
+- n8n Cloud API returned HTTP 200 for workflows and executions: 85 workflows, 72 active, and five sampled successful/finished executions around 2026-06-07T12:00Z.
+- Vercel CLI returned authenticated user `vsillah`; deployment listings returned current deployment URLs for both `portfolio` and `portfolio-staging`.
+- Stripe payment intents, charges, and checkout sessions were readable. Latest sampled successful payment intent was 2026-04-06T19:35:48Z; latest sampled successful charge was 2026-04-06T19:37:14Z; latest sampled paid checkout sessions remain 2026-02-23.
+- OpenAI model listing returned HTTP 200 with 120 models. Anthropic model listing returned HTTP 200 with 10 models.
+- Slack bot auth returned HTTP 200 and `ok: true`.
+- Pinecone listed one ready serverless `publications` index in `aws/us-east-1`.
+- Hunter account remained readable and on Free, with 50 used calls and 75 available.
+- Gamma `/v1.0/themes` returned HTTP 200 with 50 themes and `hasMore: true`.
+- HeyGen returned HTTP 200 for both voices and avatars: 2347 voices and 1289 avatars. Billing/quota still requires dashboard verification.
+- Printful orders endpoint returned HTTP 200 with one sampled draft order created 2026-04-06; sampled app sync logs remain empty.
+- ElevenLabs subscription endpoint returned HTTP 200 for Creator with 0 of 246,034 characters used before the 2026-06-19 reset.
+- Apify actor-runs endpoint returned HTTP 200 with five recent sampled runs, latest on 2026-06-03, mixed succeeded/failed, low sampled usage.
+- Read AI connector returned six meetings for the May 1-June 7 window, latest start 2026-05-29.
+- OpenRouter auth/key endpoint returned HTTP 200 with usage 0. Vapi calls endpoint returned HTTP 200 with zero sampled calls.
+- Resend local key was absent. Calendly user lookup returned HTTP 401 unauthenticated. Gemini model listing returned HTTP 403 permission denied.
+
+## Discovered Inventory
+
+| Status | Tool/vendor | Purpose in Portfolio | Evidence source | Likely cost/billing status | Last code/config/reference usage | Last operational usage | Dependencies or replacement risk | Session inactivity status | Recommendation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Green | Supabase | Core database, admin state, analytics, agent runs, app data, RAG-adjacent records | Supabase read-only aggregates; repo env/docs/routes | Paid/core hosted service | `.env.example`, app/api routes, lib database helpers, migrations, admin surfaces | Production analytics latest 2026-06-07; agent runs latest 2026-06-05 | High replacement risk; foundational | Active | Keep |
+| Green | n8n Cloud | Automation runtime and workflow orchestration | n8n API and checked-in exports | Paid hosted automation runtime | `.env.example`, `.env.staging.example`, n8n exports, webhook routes/docs | Executions `16445`-`16449` around 2026-06-07T12:00Z | High risk; many workflows and external sends depend on it | Active | Keep; optimize weak workflows separately |
+| Green | Vercel | Production/staging hosting and deployment surface | Vercel CLI | Paid/hosted deployment platform | Vercel scripts/docs, deployment runbooks, app runtime | Deployment listings readable on 2026-06-07 | High risk; app hosting | Active | Keep |
+| Green | Stripe | Checkout, payments, subscriptions, revenue path | Stripe API; repo routes/deps | Revenue dependency; billing status requires dashboard/receipt refresh | Stripe packages, checkout/payment/webhook routes, admin test checkout | Latest sampled successful charge/payment intent 2026-04-06 | High revenue-path risk | Quiet recent transaction sample but dependency remains | Keep |
+| Green | OpenAI | Model provider for app/admin workflows and n8n | API model listing; n8n exports; env/docs | Usage-based API | `.env.example`, n8n OpenAI nodes, lib/provider fetch, admin LLM routes | Model API readable on 2026-06-07 | Medium/high; many AI paths | Active/configured | Keep/watch usage costs |
+| Green | Anthropic | Model provider and transition watch item | API model listing; n8n exports; env/docs | Billing transition unresolved | `.env.example`, n8n Anthropic node, lib/provider fetch | Model API readable on 2026-06-07 | Medium; replacement possible but quality/bakeoff dependent | Active API, billing unresolved | Keep/watch billing transition |
+| Green | Slack | Agent/admin notifications and mobile ops | Slack auth; n8n exports; env/docs | Workspace/app billing not proven here | Slack env keys, Slack API routes, n8n Slack nodes | Bot auth readable on 2026-06-07 | Medium/high; operational notification surface | Active/configured | Keep |
+| Green | Read AI | Meeting intelligence and transcript workflows | Read AI connector | Paid/subscription status not available here | `.env.local` token presence, meeting dedupe routes, meeting docs | Six meetings since 2026-05-01; latest 2026-05-29 | Medium; can replace with manual notes, but meeting memory value remains | Active enough; no June meeting returned | Keep/watch recency |
+| Green | Gamma | Report/deck generation provider | Gamma API, DB report rows, repo routes | Paid/credit status needs dashboard | Gamma env key, admin gamma reports, auto audit summary lib | `/v1.0/themes` readable on 2026-06-07 | Medium; reports/decks may depend on it while Codex/PPTX alternatives are compared | Catalog readable, usage quiet | Keep/watch; verify credits |
+| Green | HeyGen | Avatar/video generation and campaign media | HeyGen API catalog checks; repo env/docs/routes | Paid/quota status needs dashboard | HeyGen env keys, webhook route, video docs/workflows | Avatars and voices readable on 2026-06-07 | Medium; video campaigns may depend on it | API readable, usage/quota unknown | Keep/watch; verify dashboard quota |
+| Green | Apify | Lead/social/evidence scraping actors and replacement bakeoff | Apify API and bakeoff docs/status JSON | Usage-based; sampled runs low cost | Apify docs/scripts/n8n exports/env | Latest sampled actor runs 2026-06-03 | Medium; actor-level replacement still in progress | Account active, actor-level mixed | Keep account; continue actor bakeoff |
+| Green | Pinecone | Publications/vector search | Pinecone API | Billing/traffic unresolved | Pinecone env key, RAG docs/n8n vector nodes | One ready `publications` index readable on 2026-06-07 | Medium; may be replaceable with Supabase/local RAG after traffic check | Config active, traffic unknown | Investigate dashboard/API traffic before replacement |
+| Green | Hunter.io | Lead enrichment | Hunter API | Free plan | `.env.local` key and lead enrichment docs | Free account readable on 2026-06-07 | Low; not a paid cancellation target | Not paid in sampled evidence | Keep/free-watch |
+| Yellow | BuiltWith | Outreach/client stack enrichment | Standing decision plus env/docs | Receipt-backed $307/month historical line item | BuiltWith env key, deprecation packet, outreach docs | No fresh usage probe in this run | Medium; protected until outreach ramp has outcome evidence | Watch item, not cancellation candidate | Keep active during outreach ramp |
+| Yellow | ElevenLabs | Voice/audio generation | ElevenLabs API | Creator subscription readable | Env key and voice docs | 0/246,034 characters used this cycle; reset 2026-06-19 | Low/medium; can replace with HeyGen/native audio if no campaign need | Consecutive zero-usage evidence | Review campaign need before reset |
+| Yellow | OpenRouter | Alternate model routing/bakeoff | OpenRouter API | Usage 0 on current key; billing/spend unresolved | `.env.local` key; model bakeoff context | Usage 0 again on 2026-06-07 | Low/medium; replaceable if no bakeoff role | Consecutive quiet evidence | Investigate/deprecate only after spend and dependency check |
+| Yellow | Vapi | Optional voice UX | Vapi API and app/webhook refs | Billing unresolved | Vapi env keys, `@vapi-ai/web`, Vapi webhook/lib | Zero sampled calls again on 2026-06-07 | Medium if production voice UX is intended | Consecutive quiet evidence | Verify dashboard billing and product intent |
+| Yellow | Printful | Store/merch fulfillment | Printful API, Supabase sync logs, store routes/docs | Billing/order costs uncertain | Printful env keys, webhook route, store page, fulfillment lib | One draft order from 2026-04-06; sync logs empty | Medium; store/merch path depends on it | Sync inactive; older draft order exists | Investigate dashboard/store strategy |
+| Yellow | Resend | Optional outbound email and webhook provider | Env presence check and repo routes/deps | Local key absent; production billing unknown | Resend package, webhook route, email docs/env | No local key; production env not verified | Medium; Gmail/n8n may replace if Resend unused | Usage unresolved | Verify production env/billing before removing |
+| Yellow | Calendly | Scheduling links and booking triggers | Calendly API, n8n exports, env/docs | Paid/free status unknown | Calendly env keys, scheduling docs, n8n triggers/router | API returned 401; workflow refs remain | Medium; scheduling workflows depend on it | Auth unresolved | Refresh token or verify dashboard usage |
+| Yellow | Gemini / Google AI | Google AI/image/social workflow provider | Gemini API, n8n export refs | Billing/project status unknown | Gemini env key, Google AI n8n workflow, Google docs | API returned 403 | Medium; workflow may need key/project repair | Auth/project blocked | Resolve key/project before relying on or deprecating |
+| Yellow | Figma / Paper / Excalidraw / Canva | Design and diagram production | Repo/docs references only | Billing unknown | Design docs/assets; no direct billing probe | No operational provider check in this run | Low/medium; depends on design pipeline | Unknown | Investigate only if receipts/dashboard evidence appear |
+| Green | Fireflies.ai | Historical meeting recaps only | Standing cancellation decision | Already canceled per 2026-05-01 confirmation | Historical docs only | No new paid-plan evidence | Low unless restarted | Resolved canceled | Keep out of active queue unless paid plan restarts |
+
+## Inactivity Evidence
+
+- OpenRouter: current-key usage remained 0 across consecutive audit sessions. This is still investigate/watch, not approval-ready cancellation, because spend and remaining bakeoff purpose are not confirmed.
+- Vapi: sampled calls remained 0 across consecutive sessions. Treat as investigate until dashboard billing and production voice UX intent are verified.
+- ElevenLabs: current cycle remains 0/246,034 characters used across consecutive sessions before the 2026-06-19 reset. Review planned voice/audio campaign needs before proposing cancellation.
+- Printful: app sync logs remain empty across sampled Supabase projects, while the API still shows one older draft order from 2026-04-06. Treat as merchandise strategy investigation, not a subscription cancellation.
+- Resend: local key remains absent while package/env/webhook references remain. Verify Vercel production env and billing before removing code paths.
+- Calendly and Gemini/Google AI: auth/project failures continue across sessions, but workflow and scheduling dependencies remain. Repair visibility before making a provider decision.
+- Pinecone: one index exists and is ready, but traffic and billing remain unresolved. This is an investigate item, not cancellation evidence by itself.
+- Gamma: report rows remain quiet since 2026-05-02, but the current catalog endpoint is readable. Verify dashboard credits and recent deck/report need before any renewal decision.
+
+## Candidate Cancellations
+
+- No automatic cancellation.
+- No current vendor has approval-ready cancellation evidence in this daily run.
+- If Vambah wants to convert a watch item into a cancellation workflow, the exact approval phrase is still required: `Cancel <tool/vendor> for Portfolio`.
+
+## Approval Needed
+
+- No cancellation approval is requested today.
+- Manual/dashboard checks needed before any future cancellation packet:
+  - Verify Vapi billing and whether production voice UX should stay enabled.
+  - Verify ElevenLabs campaign need before the 2026-06-19 reset.
+  - Verify Printful dashboard/store strategy and whether the older draft order matters.
+  - Verify whether production uses Resend or Gmail/n8n as the real outbound email channel.
+  - Verify Pinecone billing/API traffic against Supabase/local RAG.
+  - Restore or replace Calendly API access and check scheduling event usage.
+  - Resolve Gemini/Google AI project/key status before relying on those workflows.
+  - Verify Gamma dashboard credits and recent report/deck need.
+  - Verify HeyGen quota and active video campaign need before renewal.
+  - Keep BuiltWith active while collecting outreach-ramp outcome evidence.
+
+## Next Audit Focus
+
+- Re-run the quiet-provider group with dashboard evidence where APIs cannot prove billing: Vapi, ElevenLabs, Printful, Resend, Pinecone, Gamma, Calendly, Gemini, HeyGen, and Anthropic billing transition.
+- Continue tracking OpenRouter as a zero-usage model-routing watch item and only draft deprecation if no bakeoff role or spend remains.
+- Continue the Apify actor-level replacement bakeoff before any account-level decision.
+- Keep Fireflies out of the active queue unless new receipt/dashboard evidence shows the paid plan restarted.
+- Carry forward action-tracker context: 51 open actions, no in-progress/blocked/done/progress-note changes.

--- a/docs/subscription-monitor-runs/2026-06-08.md
+++ b/docs/subscription-monitor-runs/2026-06-08.md
@@ -1,0 +1,113 @@
+# 2026-06-08 Subscription Monitor Run
+
+Status: YELLOW
+
+## Summary
+
+- No cancellation approvals requested and no cancellation action taken.
+- Core Portfolio systems remain active/readable: Supabase, n8n Cloud, Vercel, Stripe, OpenAI, Anthropic, Slack, Pinecone, Hunter, HeyGen, Apify, Printful, ElevenLabs, Vapi, OpenRouter, Gemini/Google AI, and Read AI returned current read-only, connector, or dependency evidence.
+- Supabase production analytics moved to 5,239 with latest row at 2026-06-07T14:55:04Z. Configured-local `agent_runs` moved to 131 with latest row at 2026-06-08T00:27:15Z.
+- n8n Cloud remains operational with 85 workflows, 72 active workflows, and five sampled successful executions `16550` through `16554` around 2026-06-08T12:00Z.
+- Vercel CLI remained authenticated as `vsillah` and listed ready deployments for both `portfolio` and `portfolio-staging`; the scoped personal-account command failed, but the unscoped project listing succeeded.
+- Stripe remains a revenue dependency. Read-only Stripe checks were successful; latest sampled successful payment intent and charge remain 2026-04-06, while checkout sessions remain older.
+- Gemini/Google AI recovered from prior 403 evidence and returned 50 models. Gamma regressed to HTTP 401 after the prior June 6 readable check.
+- Read AI connector returned six meetings in the 2026-05-01 through 2026-06-08 window, latest on 2026-05-29. No raw meeting content, transcripts, participant details, or URLs are included in this artifact.
+- Repeated quiet or unresolved items remain: OpenRouter usage 0, Vapi zero sampled calls, ElevenLabs 0 of 246,034 characters used before the 2026-06-19 reset, Printful sync logs empty despite one older draft order, Resend local key absent, Calendly HTTP 401, Gamma HTTP 401, and Pinecone traffic/billing unresolved.
+- BuiltWith remains a protected watch item during the outreach/client-volume ramp. Fireflies remains resolved as canceled per Vambah's 2026-05-01 confirmation unless new paid-plan evidence appears.
+- No vendor crossed the approval-ready cancellation threshold.
+
+## Raw Findings
+
+- Read-only checks ran on 2026-06-08. Secret values, raw account payloads, private meeting content, private exports, and full logs are not included.
+- Initial checkout state was detached HEAD with pre-existing dirty work across `.env.example`, outreach/email files, docs, subscription tracker files, tests, migrations, and untracked prior monitor/client/revenue artifacts. This run preserved unrelated work and only added the June 8 monitor outputs plus required tracker/status synchronization.
+- No automation memory file existed at `$CODEX_HOME/automations/portfolio-subscription-cancellation-monitor/memory.md` at the start of this run, so the file was created during closeout. The checked-in audit/status artifacts and prior dated run artifacts supplied continuity state.
+- Action tracker feedback existed for `portfolio-subscription-cancellation-monitor`: 51 open actions, 0 in progress, 0 blocked, 0 done, and no progress notes. No completed, dismissed, blocked, or in-progress action signal changed today's recommendations.
+- Repo/config footprint remains broad. `.env.example`, `.env.staging.example`, `.env.local`, `package.json`, app/api routes, lib integrations, scripts, docs, n8n exports, and migrations continue to reference Supabase, Stripe, n8n, Vercel, OpenAI, Anthropic, Apify, BuiltWith, Calendly, ElevenLabs, Gamma, Gemini/Google, HeyGen, Printful, Resend, Slack, Vapi, OpenRouter, Pinecone, Hunter, Read AI, Google/Gmail/Drive, and related webhooks.
+- `package.json` keeps active dependencies for Supabase, Stripe, Resend, Vercel Functions/Speed Insights/Blob, Google APIs, Playwright, and Vapi.
+- Checked-in n8n exports contain 45 JSON files, 44 top-level workflow objects, and 29 active top-level exports. Integration references include Supabase, Slack, Gmail/Google, Calendly, OpenAI, Anthropic, Apify, HeyGen, Vapi, Stripe, Pinecone, Read AI, Gemini, and Printful.
+- Supabase production aggregates: `analytics_events` 5239/latest 2026-06-07T14:55:04Z, `agent_runs` 84/latest 2026-06-05T13:00:03Z, `cost_events` 22/latest 2026-06-04T18:34:01Z, `orders` 26/latest 2026-03-19T14:54:19Z, `printful_sync_log` 0, `email_messages` 10/latest 2026-06-04T16:46:08Z, `meeting_records` 111/latest 2026-06-04T16:45:12Z, `gamma_reports` 6/latest 2026-05-02T01:20:15Z, `videos` 4/latest 2026-04-15T02:52:07Z, and `social_content_queue` 29/latest 2026-05-07T13:00:49Z.
+- Supabase configured-local aggregates: `analytics_events` 2164/latest 2026-06-02T18:00:54Z, `agent_runs` 131/latest 2026-06-08T00:27:15Z, `cost_events` 12/latest 2026-05-27T20:37:59Z, `orders` 1/latest 2026-04-06T19:35:41Z, `printful_sync_log` 0, `email_messages` 7/latest 2026-06-04T16:46:11Z, `meeting_records` 5/latest 2026-06-04T16:45:15Z, `gamma_reports` 4/latest 2026-04-16T14:56:34Z, `videos` 4/latest 2026-03-25T13:48:33Z, and `social_content_queue` 3/latest 2026-05-23T09:24:08Z.
+- n8n Cloud API returned HTTP 200 for workflows and executions when using the cloud API key: 85 workflows, 72 active, and five sampled successful executions around 2026-06-08T12:00Z. The local `N8N_API_KEY` returned 403 and should not be used for this monitor's cloud check.
+- Vercel CLI returned authenticated user `vsillah`; unscoped project listings returned ready deployments for both `portfolio` and `portfolio-staging`.
+- Stripe payment intents, charges, and checkout sessions were readable. Latest sampled successful payment intent was 2026-04-06T19:35:48Z; latest sampled successful charge was 2026-04-06T19:37:14Z; latest sampled paid checkout sessions remain 2026-02-23.
+- OpenAI model listing returned HTTP 200 with 120 models. Anthropic model listing returned HTTP 200 with 10 models.
+- Slack bot auth returned HTTP 200 and `ok: true`.
+- Pinecone listed one ready serverless `publications` index.
+- Hunter account remained readable and on Free, with 50 used calls and 75 available.
+- Gamma `/v1.0/themes` returned HTTP 401. Treat this as access/billing visibility drift after the June 6 readable check, not cancellation evidence.
+- HeyGen returned HTTP 200 for both voices and avatars: 2347 voices and 1289 avatars. Billing/quota still requires dashboard verification.
+- Printful orders endpoint returned HTTP 200 with one sampled draft order created 2026-04-06; sampled app sync logs remain empty.
+- ElevenLabs subscription endpoint returned HTTP 200 for Creator with 0 of 246,034 characters used before the 2026-06-19 reset.
+- Apify actor-runs endpoint returned HTTP 200 with five recent sampled runs, latest on 2026-06-03, mixed succeeded/failed, low sampled usage.
+- Read AI connector returned six meetings for the May 1-June 8 window, latest start 2026-05-29.
+- OpenRouter auth/key endpoint returned HTTP 200 with usage 0. Vapi calls endpoint returned HTTP 200 with zero sampled calls.
+- Resend local key was absent. Calendly user lookup returned HTTP 401 unauthenticated. Gemini model listing returned HTTP 200 with 50 models.
+
+## Discovered Inventory
+
+| Status | Tool/vendor | Purpose in Portfolio | Evidence source | Likely cost/billing status | Last code/config/reference usage | Last operational usage | Dependencies or replacement risk | Session inactivity status | Recommendation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Green | Supabase | Core database, admin state, analytics, agent runs, app data, RAG-adjacent records | Supabase read-only aggregates; repo env/docs/routes | Paid/core hosted service | `.env.example`, app/api routes, lib database helpers, migrations, admin surfaces | Production analytics latest 2026-06-07; local agent runs latest 2026-06-08 | High replacement risk; foundational | Active | Keep |
+| Green | n8n Cloud | Automation runtime and workflow orchestration | n8n API and checked-in exports | Paid hosted automation runtime | `.env.example`, `.env.staging.example`, n8n exports, webhook routes/docs | Executions `16550`-`16554` around 2026-06-08T12:00Z | High risk; many workflows and external sends depend on it | Active | Keep; optimize weak workflows separately |
+| Green | Vercel | Production/staging hosting and deployment surface | Vercel CLI | Paid/hosted deployment platform | Vercel scripts/docs, deployment runbooks, app runtime | Ready deployments listed on 2026-06-08 | High risk; app hosting | Active | Keep |
+| Green | Stripe | Checkout, payments, subscriptions, revenue path | Stripe API; repo routes/deps | Revenue dependency; billing status requires dashboard/receipt refresh | Stripe packages, checkout/payment/webhook routes, admin test checkout | Latest sampled successful charge/payment intent 2026-04-06 | High revenue-path risk | Quiet recent transaction sample but dependency remains | Keep |
+| Green | OpenAI | Model provider for app/admin workflows and n8n | API model listing; n8n exports; env/docs | Usage-based API | `.env.example`, n8n OpenAI nodes, lib/provider fetch, admin LLM routes | Model API readable on 2026-06-08 | Medium/high; many AI paths | Active/configured | Keep/watch usage costs |
+| Green | Anthropic | Model provider and transition watch item | API model listing; n8n exports; env/docs | Billing transition unresolved | `.env.example`, n8n Anthropic node, lib/provider fetch | Model API readable on 2026-06-08 | Medium; replacement possible but quality/bakeoff dependent | Active API, billing unresolved | Keep/watch billing transition |
+| Green | Slack | Agent/admin notifications and mobile ops | Slack auth; n8n exports; env/docs | Workspace/app billing not proven here | Slack env keys, Slack API routes, n8n Slack nodes | Bot auth readable on 2026-06-08 | Medium/high; operational notification surface | Active/configured | Keep |
+| Green | Read AI | Meeting intelligence and transcript workflows | Read AI connector | Paid/subscription status not available here | `.env.local` token presence, meeting dedupe routes, meeting docs | Six meetings since 2026-05-01; latest 2026-05-29 | Medium; can replace with manual notes, but meeting memory value remains | Active enough; no June meeting returned | Keep/watch recency |
+| Yellow | Gamma | Report/deck generation provider | Gamma API, DB report rows, repo routes | Paid/credit status needs dashboard | Gamma env key, admin gamma reports, auto audit summary lib | API returned 401; DB report rows latest 2026-05-02 | Medium; reports/decks may depend on it while Codex/PPTX alternatives are compared | Access drift and quiet usage | Investigate dashboard credits/API access |
+| Green | HeyGen | Avatar/video generation and campaign media | HeyGen API catalog checks; repo env/docs/routes | Paid/quota status needs dashboard | HeyGen env keys, webhook route, video docs/workflows | Avatars and voices readable on 2026-06-08 | Medium; video campaigns may depend on it | API readable, usage/quota unknown | Keep/watch; verify dashboard quota |
+| Green | Apify | Lead/social/evidence scraping actors and replacement bakeoff | Apify API and bakeoff docs/status JSON | Usage-based; sampled runs low cost | Apify docs/scripts/n8n exports/env | Latest sampled actor runs 2026-06-03 | Medium; actor-level replacement still in progress | Account active, actor-level mixed | Keep account; continue actor bakeoff |
+| Green | Pinecone | Publications/vector search | Pinecone API | Billing/traffic unresolved | Pinecone env key, RAG docs/n8n vector nodes | One ready `publications` index readable on 2026-06-08 | Medium; may be replaceable with Supabase/local RAG after traffic check | Config active, traffic unknown | Investigate dashboard/API traffic before replacement |
+| Green | Hunter.io | Lead enrichment | Hunter API | Free plan | `.env.local` key and lead enrichment docs | Free account readable on 2026-06-08 | Low; not a paid cancellation target | Not paid in sampled evidence | Keep/free-watch |
+| Yellow | BuiltWith | Outreach/client stack enrichment | Standing decision plus env/docs | Receipt-backed $307/month historical line item | BuiltWith env key, deprecation packet, outreach docs | No fresh usage probe in this run | Medium; protected until outreach ramp has outcome evidence | Watch item, not cancellation candidate | Keep active during outreach ramp |
+| Yellow | ElevenLabs | Voice/audio generation | ElevenLabs API | Creator subscription readable | Env key and voice docs | 0/246,034 characters used this cycle; reset 2026-06-19 | Low/medium; can replace with HeyGen/native audio if no campaign need | Consecutive zero-usage evidence | Review campaign need before reset |
+| Yellow | OpenRouter | Alternate model routing/bakeoff | OpenRouter API | Usage 0 on current key; billing/spend unresolved | `.env.local` key; model bakeoff context | Usage 0 again on 2026-06-08 | Low/medium; replaceable if no bakeoff role | Consecutive quiet evidence | Investigate/deprecate only after spend and dependency check |
+| Yellow | Vapi | Optional voice UX | Vapi API and app/webhook refs | Billing unresolved | Vapi env keys, `@vapi-ai/web`, Vapi webhook/lib | Zero sampled calls again on 2026-06-08 | Medium if production voice UX is intended | Consecutive quiet evidence | Verify dashboard billing and product intent |
+| Yellow | Printful | Store/merch fulfillment | Printful API, Supabase sync logs, store routes/docs | Billing/order costs uncertain | Printful env keys, webhook route, store page, fulfillment lib | One draft order from 2026-04-06; sync logs empty | Medium; store/merch path depends on it | Sync inactive; older draft order exists | Investigate dashboard/store strategy |
+| Yellow | Resend | Optional outbound email and webhook provider | Env presence check and repo routes/deps | Local key absent; production billing unknown | Resend package, webhook route, email docs/env | No local key; production env not verified | Medium; Gmail/n8n may replace if Resend unused | Usage unresolved | Verify production env/billing before removing |
+| Yellow | Calendly | Scheduling links and booking triggers | Calendly API, n8n exports, env/docs | Paid/free status unknown | Calendly env keys, scheduling docs, n8n triggers/router | API returned 401; workflow refs remain | Medium; scheduling workflows depend on it | Auth unresolved | Refresh token or verify dashboard usage |
+| Yellow | Gemini / Google AI | Google AI/image/social workflow provider | Gemini API, n8n export refs | Billing/project status unknown | Gemini env key, Google AI n8n workflow, Google docs | Model listing readable on 2026-06-08 | Medium; workflow may need usage/billing visibility | Access recovered, billing unknown | Verify billing/project and workflow usage |
+| Yellow | Figma / Paper / Excalidraw / Canva | Design and diagram production | Repo/docs references only | Billing unknown | Design docs/assets; no direct billing probe | No operational provider check in this run | Low/medium; depends on design pipeline | Unknown | Investigate only if receipts/dashboard evidence appear |
+| Green | Fireflies.ai | Historical meeting recaps only | Standing cancellation decision | Already canceled per 2026-05-01 confirmation | Historical docs only | No new paid-plan evidence | Low unless restarted | Resolved canceled | Keep out of active queue unless paid plan restarts |
+
+## Inactivity Evidence
+
+- OpenRouter: current-key usage remained 0 across consecutive audit sessions. This is still investigate/watch, not approval-ready cancellation, because spend and remaining bakeoff purpose are not confirmed.
+- Vapi: sampled calls remained 0 across consecutive sessions. Treat as investigate until dashboard billing and production voice UX intent are verified.
+- ElevenLabs: current cycle remains 0/246,034 characters used across consecutive sessions before the 2026-06-19 reset. Review planned voice/audio campaign needs before proposing cancellation.
+- Printful: app sync logs remain empty across sampled Supabase projects, while the API still shows one older draft order from 2026-04-06. Treat as merchandise strategy investigation, not a subscription cancellation.
+- Resend: local key remains absent while package/env/webhook references remain. Verify Vercel production env and billing before removing code paths.
+- Calendly: API access remains 401 across sessions, but scheduling links and n8n booking workflows remain configured. Repair visibility before making a provider decision.
+- Gamma: access regressed to 401 after a recent readable catalog check, and DB report rows remain quiet since 2026-05-02. Verify API key/dashboard credits and recent report need before any renewal decision.
+- Pinecone: one index exists and is ready, but traffic and billing remain unresolved. This is an investigate item, not cancellation evidence by itself.
+
+## Candidate Cancellations
+
+- No automatic cancellation.
+- No current vendor has approval-ready cancellation evidence in this daily run.
+- If Vambah wants to convert a watch item into a cancellation workflow, the exact approval phrase is still required: `Cancel <tool/vendor> for Portfolio`.
+
+## Approval Needed
+
+- No cancellation approval is requested today.
+- Manual/dashboard checks needed before any future cancellation packet:
+  - Verify Vapi billing and whether production voice UX should stay enabled.
+  - Verify ElevenLabs campaign need before the 2026-06-19 reset.
+  - Verify Printful dashboard/store strategy and whether the older draft order matters.
+  - Verify whether production uses Resend or Gmail/n8n as the real outbound email channel.
+  - Verify Pinecone billing/API traffic against Supabase/local RAG.
+  - Restore or replace Calendly API access and check scheduling event usage.
+  - Restore or rotate Gamma API access and verify dashboard credits/recent report need.
+  - Verify Gemini/Google AI billing/project status now that model access is readable again.
+  - Verify HeyGen quota and active video campaign need before renewal.
+  - Keep BuiltWith active while collecting outreach-ramp outcome evidence.
+
+## Next Audit Focus
+
+- Re-run the quiet-provider group with dashboard evidence where APIs cannot prove billing: Vapi, ElevenLabs, Printful, Resend, Pinecone, Gamma, Calendly, Gemini, HeyGen, and Anthropic billing transition.
+- Continue tracking OpenRouter as a zero-usage model-routing watch item and only draft deprecation if no bakeoff role or spend remains.
+- Use `N8N_CLOUD_API_KEY` for the n8n cloud API probe; the local `N8N_API_KEY` returned 403.
+- Continue the Apify actor-level replacement bakeoff before any account-level decision.
+- Keep Fireflies out of the active queue unless new receipt/dashboard evidence shows the paid plan restarted.
+- Carry forward action-tracker context: 51 open actions, no in-progress/blocked/done/progress-note changes.

--- a/docs/subscription-monitor-runs/2026-06-11.md
+++ b/docs/subscription-monitor-runs/2026-06-11.md
@@ -1,0 +1,119 @@
+# 2026-06-11 Subscription Monitor Run
+
+Status: YELLOW
+
+## Summary
+
+- No cancellation approvals requested and no cancellation action taken.
+- Core Portfolio systems remain active/readable: Supabase, n8n Cloud, Vercel, Stripe, OpenAI, Anthropic, Slack, Read AI, HeyGen, Gamma, Gemini/Google AI, Apify, Pinecone, Hunter, Printful, ElevenLabs, OpenRouter, and Vapi returned current read-only, connector, or dependency evidence.
+- Supabase production moved materially since the prior monitor: `analytics_events` reached 5,258/latest 2026-06-10T21:37:39Z, `agent_runs` reached 95/latest 2026-06-10T16:11:17Z, `cost_events` reached 25/latest 2026-06-10T15:58:02Z, and `social_content_queue` reached 30/latest 2026-06-08T13:00:48Z.
+- n8n Cloud remains operational with 85 workflows, 72 active workflows, and five sampled successful executions `16878` through `16882` around 2026-06-11T12:00Z.
+- Vercel CLI remained authenticated as `vsillah`; both `portfolio` and `portfolio-staging` listed ready deployments from roughly 11 hours before the run, and `portfolio` also had ready preview deployments roughly 2 hours before the run.
+- Stripe remains a revenue dependency. Read-only checks were successful; latest sampled successful payment intent/charge remains 2026-04-06 and latest sampled paid checkout session remains 2026-02-23.
+- Gamma recovered to HTTP 200 on `/v1.0/themes` with 50 themes and more pages. Gemini/Google AI stayed readable with 50 models.
+- ElevenLabs no longer shows a zero-use cycle: current readable Creator-cycle usage is 802 of 246,034 characters before the 2026-06-19 reset. That reduces immediate cancellation pressure but still warrants campaign/billing review.
+- Apify had fresh account-level activity on 2026-06-10 with mixed succeeded/failed sampled actor runs and low sampled cost. Keep the account while continuing actor-level replacement work.
+- Read AI connector returned six meetings in the 2026-05-01 through 2026-06-11 window, latest on 2026-05-29. No raw meeting content, transcripts, participant details, or meeting URLs are included in this artifact.
+- Repeated quiet or unresolved items remain: OpenRouter usage 0, Vapi zero sampled calls, Printful sync logs empty despite one older draft order, Resend local key absent, Calendly HTTP 401, Pinecone traffic/billing unresolved, and design-tool billing unknown.
+- BuiltWith remains a protected watch item during the outreach/client-volume ramp. Fireflies remains resolved as canceled per Vambah's 2026-05-01 confirmation unless new paid-plan evidence appears.
+- No vendor crossed the approval-ready cancellation threshold.
+
+## Raw Findings
+
+- Read-only checks ran on 2026-06-11. Secret values, raw account payloads, private meeting content, private exports, and full logs are not included.
+- Initial checkout state was `codex/subscription-weekly-report-2026-06-08` with pre-existing dirty work across `.env.example`, `.gitignore`, email/outreach files, docs, subscription tracker files, tests, migrations, and untracked prior monitor/client/revenue artifacts. This run preserved unrelated work and only adds/synchronizes the June 11 monitor outputs plus required local notification/memory files.
+- No automation memory file existed at `$CODEX_HOME/automations/portfolio-subscription-cancellation-monitor/memory.md` at the start of this run. The checked-in audit/status artifacts and prior dated run artifacts supplied continuity state, and this run creates the automation memory during closeout.
+- Action tracker feedback existed for `portfolio-subscription-cancellation-monitor`: 51 open actions, 0 in progress, 0 blocked, 0 done, and no progress notes. No completed, dismissed, blocked, or in-progress action signal changed today's recommendations.
+- Repo/config footprint remains broad. `.env.example`, `.env.staging.example`, `.env.local`, `package.json`, app/api routes, lib integrations, scripts, docs, n8n exports, and migrations continue to reference Supabase, Stripe, n8n, Vercel, OpenAI, Anthropic, Apify, BuiltWith, Calendly, ElevenLabs, Gamma, Gemini/Google, HeyGen, Printful, Resend, Slack, Vapi, OpenRouter, Pinecone, Hunter, Read AI, Google/Gmail/Drive, and related webhooks.
+- `package.json` keeps active dependencies for Supabase, Stripe, Resend, Vercel Functions/Speed Insights/Blob, Google APIs, Playwright, and Vapi.
+- Checked-in n8n exports contain 46 JSON files, 45 top-level workflow objects, and 38 active top-level exports. Integration node references include Supabase, Slack, webhooks, Gmail/Google, Calendly, OpenAI, Anthropic, Apify, HeyGen, Vapi, Stripe, Pinecone, Gemini, and Printful.
+- Supabase production aggregates: `analytics_events` 5,258/latest 2026-06-10T21:37:39Z, `agent_runs` 95/latest 2026-06-10T16:11:17Z, `cost_events` 25/latest 2026-06-10T15:58:02Z, `orders` 26/latest 2026-03-19T14:54:19Z, `printful_sync_log` 0, `email_messages` 10/latest 2026-06-04T16:46:08Z, `meeting_records` 111/latest 2026-06-04T16:45:12Z, `gamma_reports` 6/latest 2026-05-02T01:20:15Z, `videos` 4/latest 2026-04-15T02:52:07Z, and `social_content_queue` 30/latest 2026-06-08T13:00:48Z.
+- Supabase configured-local aggregates: `analytics_events` 2,164/latest 2026-06-02T18:00:54Z, `agent_runs` 131/latest 2026-06-08T00:27:15Z, `cost_events` 12/latest 2026-05-27T20:37:59Z, `orders` 1/latest 2026-04-06T19:35:41Z, `printful_sync_log` 0, `email_messages` 7/latest 2026-06-04T16:46:11Z, `meeting_records` 5/latest 2026-06-04T16:45:15Z, `gamma_reports` 4/latest 2026-04-16T14:56:34Z, `videos` 4/latest 2026-03-25T13:48:33Z, and `social_content_queue` 3/latest 2026-05-23T09:24:08Z.
+- n8n Cloud API returned HTTP 200 for workflows and executions when using the cloud API key: 85 workflows, 72 active workflows, and five sampled successful executions around 2026-06-11T12:00Z.
+- Vercel CLI returned authenticated user `vsillah`; deployment listings returned ready deployments for `portfolio` and `portfolio-staging`.
+- Stripe payment intents, charges, and checkout sessions were readable. Latest sampled successful payment intent was 2026-04-06T19:35:48Z; latest sampled successful charge was 2026-04-06T19:37:14Z; latest sampled paid checkout session was 2026-02-23T21:05:32Z.
+- OpenAI model listing returned HTTP 200 with 120 models. Anthropic model listing returned HTTP 200 with 11 models.
+- Slack bot auth returned HTTP 200 and `ok: true`.
+- Pinecone listed one ready serverless `publications` index.
+- Hunter account remained readable and on Free, with 0 sampled used calls and 75 available in the current API response.
+- Gamma `/v1.0/themes` returned HTTP 200 with 50 themes and `hasMore: true`, recovering from the June 8 HTTP 401 check.
+- HeyGen retried successfully after one transient timeout: voices returned HTTP 200 with 2,347 voices and avatars returned HTTP 200 with 1,289 avatars. Billing/quota still requires dashboard verification.
+- Printful orders endpoint returned HTTP 200 with one sampled draft order created 2026-04-06; sampled app sync logs remain empty.
+- ElevenLabs subscription endpoint returned HTTP 200 for Creator with 802 of 246,034 characters used before 2026-06-19T18:38:26Z.
+- Apify actor-runs endpoint returned HTTP 200 with five recent sampled runs, including 2026-06-10 succeeded/failed runs and low sampled usage.
+- Read AI connector returned six meetings for the May 1-June 11 window, latest start 2026-05-29.
+- OpenRouter auth/key endpoint returned HTTP 200 with usage 0. Vapi calls endpoint returned HTTP 200 with zero sampled calls.
+- Resend local key was absent. Calendly user lookup returned HTTP 401 unauthenticated. Gemini model listing returned HTTP 200 with 50 models.
+- Local visual/design evidence remains repo-adjacent only for Figma/Paper/Excalidraw/Canva-style tools; no direct billing probe was available in this run.
+
+## Discovered Inventory
+
+| Status | Tool/vendor | Purpose in Portfolio | Evidence source | Likely cost/billing status | Last code/config/reference usage | Last operational usage | Dependencies or replacement risk | Session inactivity status | Recommendation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Green | Supabase | Core database, admin state, analytics, agent runs, app data, RAG-adjacent records | Supabase read-only aggregates; repo env/docs/routes | Paid/core hosted service | `.env.example`, app/api routes, lib database helpers, migrations, admin surfaces | Production analytics/agent/cost rows latest 2026-06-10 | High replacement risk; foundational | Active | Keep |
+| Green | n8n Cloud | Automation runtime and workflow orchestration | n8n API and checked-in exports | Paid hosted automation runtime | `.env.example`, `.env.staging.example`, n8n exports, webhook routes/docs | Executions `16878`-`16882` around 2026-06-11T12:00Z | High risk; many workflows and external sends depend on it | Active | Keep; optimize weak workflows separately |
+| Green | Vercel | Production/staging hosting and deployment surface | Vercel CLI | Paid/hosted deployment platform | Vercel scripts/docs, deployment runbooks, app runtime | Ready production/staging deployments listed on 2026-06-11 | High risk; app hosting | Active | Keep |
+| Green | Stripe | Checkout, payments, subscriptions, revenue path | Stripe API; repo routes/deps | Revenue dependency; billing status requires dashboard/receipt refresh | Stripe packages, checkout/payment/webhook routes, admin test checkout | Latest sampled successful charge/payment intent 2026-04-06 | High revenue-path risk | Quiet recent transaction sample but dependency remains | Keep |
+| Green | OpenAI | Model provider for app/admin workflows and n8n | API model listing; n8n exports; env/docs | Usage-based API | `.env.example`, n8n OpenAI nodes, lib/provider fetch, admin LLM routes | Model API readable on 2026-06-11 | Medium/high; many AI paths | Active/configured | Keep/watch usage costs |
+| Green | Anthropic | Model provider and transition watch item | API model listing; n8n exports; env/docs | Billing transition unresolved | `.env.example`, n8n Anthropic node, lib/provider fetch | Model API readable on 2026-06-11 | Medium; replacement possible but quality/bakeoff dependent | Active API, billing unresolved | Keep/watch billing transition |
+| Green | Slack | Agent/admin notifications and mobile ops | Slack auth; n8n exports; env/docs | Workspace/app billing not proven here | Slack env keys, Slack API routes, n8n Slack nodes | Bot auth readable on 2026-06-11 | Medium/high; operational notification surface | Active/configured | Keep |
+| Green | Read AI | Meeting intelligence and transcript workflows | Read AI connector | Paid/subscription status not available here | Meeting dedupe routes, meeting docs, connector availability | Six meetings since 2026-05-01; latest 2026-05-29 | Medium; can replace with manual notes, but meeting memory value remains | Active enough; no June meeting returned | Keep/watch recency |
+| Green | Gamma | Report/deck generation provider | Gamma API, DB report rows, repo routes | Paid/credit status needs dashboard | Gamma env key, admin gamma reports, auto audit summary lib | `/v1.0/themes` readable on 2026-06-11; report rows latest 2026-05-02 | Medium; reports/decks may depend on it while Codex/PPTX alternatives are compared | Access recovered, usage quiet | Keep/watch; verify dashboard credits and recent report need |
+| Green | HeyGen | Avatar/video generation and campaign media | HeyGen API catalog checks; repo env/docs/routes | Paid/quota status needs dashboard | HeyGen env keys, webhook route, video docs/workflows | Avatars and voices readable on retry 2026-06-11 | Medium; video campaigns may depend on it | API readable, usage/quota unknown | Keep/watch; verify dashboard quota |
+| Green | Apify | Lead/social/evidence scraping actors and replacement bakeoff | Apify API and bakeoff docs/status JSON | Usage-based; sampled runs low cost | Apify docs/scripts/n8n exports/env | Latest sampled actor runs 2026-06-10 | Medium; actor-level replacement still in progress | Account active, actor-level mixed | Keep account; continue actor bakeoff |
+| Green | Pinecone | Publications/vector search | Pinecone API | Billing/traffic unresolved | Pinecone env key, RAG docs/n8n vector nodes | One ready `publications` index readable on 2026-06-11 | Medium; may be replaceable with Supabase/local RAG after traffic check | Config active, traffic unknown | Investigate dashboard/API traffic before replacement |
+| Green | Hunter.io | Lead enrichment | Hunter API | Free plan in sampled evidence | `.env.local` key and lead enrichment docs | Free account readable on 2026-06-11 | Low; not a paid cancellation target | Not paid in sampled evidence | Keep/free-watch |
+| Yellow | BuiltWith | Outreach/client stack enrichment | Standing decision plus env/docs | Receipt-backed $307/month historical line item | BuiltWith env key, deprecation packet, outreach docs | No fresh usage probe in this run | Medium; protected until outreach ramp has outcome evidence | Watch item, not cancellation candidate | Keep active during outreach ramp |
+| Yellow | ElevenLabs | Voice/audio generation | ElevenLabs API | Creator subscription readable | Env key and voice/social content docs | 802/246,034 characters used this cycle; reset 2026-06-19 | Low/medium; can replace with HeyGen/native audio if no campaign need | Low usage, no longer zero | Review campaign need before reset |
+| Yellow | OpenRouter | Alternate model routing/bakeoff | OpenRouter API | Usage 0 on current key; billing/spend unresolved | `.env.local` key; n8n OpenRouter nodes; model bakeoff context | Usage 0 again on 2026-06-11 | Low/medium; replaceable if no bakeoff role | Consecutive quiet evidence | Investigate/deprecate only after spend and dependency check |
+| Yellow | Vapi | Optional voice UX | Vapi API and app/webhook refs | Billing unresolved | Vapi env keys, `@vapi-ai/web`, Vapi webhook/lib | Zero sampled calls again on 2026-06-11 | Medium if production voice UX is intended | Consecutive quiet evidence | Verify dashboard billing and product intent |
+| Yellow | Printful | Store/merch fulfillment | Printful API, Supabase sync logs, store routes/docs | Billing/order costs uncertain | Printful env keys, webhook route, store page, fulfillment lib | One draft order from 2026-04-06; sync logs empty | Medium; store/merch path depends on it | Sync inactive; older draft order exists | Investigate dashboard/store strategy |
+| Yellow | Resend | Optional outbound email and webhook provider | Env presence check and repo routes/deps | Local key absent; production billing unknown | Resend package, webhook route, email docs/env | No local key; production env not verified | Medium; Gmail/n8n may replace if Resend unused | Usage unresolved | Verify production env/billing before removing |
+| Yellow | Calendly | Scheduling links and booking triggers | Calendly API, n8n exports, env/docs | Paid/free status unknown | Calendly env keys, scheduling docs, n8n triggers/router | API returned 401; workflow refs remain | Medium; scheduling workflows depend on it | Auth unresolved | Refresh token or verify dashboard usage |
+| Yellow | Gemini / Google AI | Google AI/image/social workflow provider | Gemini API, n8n export refs | Billing/project status unknown | Gemini env key, Google AI n8n workflow, Google docs | Model listing readable on 2026-06-11 | Medium; workflow may need usage/billing visibility | Access readable, billing unknown | Verify billing/project and workflow usage |
+| Yellow | Figma / Paper / Excalidraw / Canva | Design and diagram production | Repo/docs references only | Billing unknown | Design docs/assets; no direct billing probe | No operational provider check in this run | Low/medium; depends on design pipeline | Unknown | Investigate only if receipts/dashboard evidence appear |
+| Green | Fireflies.ai | Historical meeting recaps only | Standing cancellation decision | Already canceled per 2026-05-01 confirmation | Historical docs only | No new paid-plan evidence | Low unless restarted | Resolved canceled | Keep out of active queue unless paid plan restarts |
+
+## Inactivity Evidence
+
+- OpenRouter: current-key usage remained 0 across consecutive audit sessions. This remains investigate/watch, not approval-ready cancellation, because spend, remaining bakeoff purpose, and n8n OpenRouter-node dependency scope are not confirmed.
+- Vapi: sampled calls remained 0 across consecutive sessions. Treat as investigate until dashboard billing and production voice UX intent are verified.
+- Printful: app sync logs remain empty across sampled Supabase projects, while the API still shows one older draft order from 2026-04-06. Treat as merchandise strategy investigation, not a subscription cancellation.
+- Resend: local key remains absent while package/env/webhook references remain. Verify Vercel production env and billing before removing code paths.
+- Calendly: API access remains 401 across sessions, but scheduling links and n8n booking workflows remain configured. Repair visibility before making a provider decision.
+- Pinecone: one index exists and is ready, but traffic and billing remain unresolved. This is an investigate item, not cancellation evidence by itself.
+- Gamma: access recovered, but report rows remain quiet since 2026-05-02. Verify dashboard credits and recent deck/report need before any renewal decision.
+- ElevenLabs: the current cycle is no longer zero-use, but 802/246,034 characters is still low. Review the next social/video/audio campaign before the 2026-06-19 reset.
+
+## Candidate Cancellations
+
+- No automatic cancellation.
+- No current vendor has approval-ready cancellation evidence in this daily run.
+- Strongest future deprecation-packet candidates remain OpenRouter, Vapi, Printful sync, Resend, Calendly, and possibly Pinecone, but only after dashboard billing, usage, and replacement-risk checks.
+- BuiltWith is excluded from cancellation candidacy during the outreach/client-volume ramp.
+- Fireflies.ai is already resolved/canceled and should only be revisited if new paid-plan evidence appears.
+- If Vambah wants to convert a watch item into a cancellation workflow, the exact approval phrase is still required: `Cancel <tool/vendor> for Portfolio`.
+
+## Approval Needed
+
+- No cancellation approval is requested today.
+- Manual/dashboard checks needed before any future cancellation packet:
+  - Verify Vapi billing and whether production voice UX should stay enabled.
+  - Verify Printful dashboard/store strategy and whether the older draft order matters.
+  - Verify whether production uses Resend or Gmail/n8n as the real outbound email channel.
+  - Verify Pinecone billing/API traffic against Supabase/local RAG.
+  - Restore or replace Calendly API access and check scheduling event usage.
+  - Verify Gamma dashboard credits/recent report need now that API access recovered.
+  - Verify Gemini/Google AI billing/project status now that model access remains readable.
+  - Verify HeyGen quota and active video campaign need before renewal.
+  - Verify Anthropic billing transition state even though API model access is healthy.
+  - Check whether ElevenLabs' 802-character usage is intentional campaign work or incidental testing before the 2026-06-19 reset.
+  - Keep BuiltWith active while collecting outreach-ramp outcome evidence.
+
+## Next Audit Focus
+
+- Re-run the quiet-provider group with dashboard evidence where APIs cannot prove billing: Vapi, Printful, Resend, Pinecone, Calendly, Gamma, Gemini, HeyGen, Anthropic billing transition, and ElevenLabs campaign need.
+- Continue tracking OpenRouter as a zero-usage model-routing watch item and only draft deprecation if no bakeoff role, workflow dependency, or spend remains.
+- Continue the Apify actor-level replacement bakeoff before any account-level decision, especially after the fresh June 10 mixed succeeded/failed runs.
+- Keep Fireflies out of the active queue unless new receipt/dashboard evidence shows the paid plan restarted.
+- Carry forward action-tracker context: 51 open actions, no in-progress/blocked/done/progress-note changes.

--- a/docs/subscription-monitor-runs/2026-06-12.md
+++ b/docs/subscription-monitor-runs/2026-06-12.md
@@ -1,0 +1,119 @@
+# 2026-06-12 Subscription Monitor Run
+
+Status: YELLOW
+
+## Summary
+
+- No cancellation approvals requested and no cancellation action taken.
+- Core Portfolio systems remain active/readable: Supabase, n8n Cloud, Vercel, Stripe, OpenAI, Anthropic, Slack, Read AI, HeyGen, Apify, Pinecone, Hunter, Printful, ElevenLabs, OpenRouter, Vapi, Gemini/Google AI, and the app-side integration footprint all returned current read-only, connector, or dependency evidence.
+- Supabase production moved since the prior monitor: `analytics_events` reached 5,300/latest 2026-06-11T23:35:14Z and `agent_runs` reached 96/latest 2026-06-11T13:00:03Z. Configured-local Supabase also moved: `agent_runs` reached 146/latest 2026-06-12T10:16:48Z and `cost_events` reached 13/latest 2026-06-11T23:04:11Z.
+- n8n Cloud remains operational with 85 workflows, 72 active workflows, and five sampled successful executions `16985` through `16989` around 2026-06-12T12:00Z.
+- Vercel CLI remained authenticated as `vsillah`; both `portfolio` and `portfolio-staging` listed ready deployments, including production deployments around 9 hours before the run and preview activity for `portfolio` around 2 hours before the run.
+- Stripe remains a revenue dependency. Read-only checks were successful; latest sampled successful payment intent/charge remains 2026-04-06 and latest sampled paid checkout session remains 2026-02-23.
+- Read AI connector returned seven meetings in the 2026-05-01 through 2026-06-12 window, with latest meeting metadata from 2026-06-11. No raw meeting content, transcripts, participant details, or meeting URLs are included in this artifact.
+- Gamma regressed to HTTP 401 after the 2026-06-11 recovery. Treat this as access/billing visibility drift, not cancellation approval.
+- HeyGen voices were readable with 2,347 voices, and the avatar retry succeeded with 1,289 avatars. Billing/quota still requires dashboard verification.
+- ElevenLabs remains low-use but not zero-use: current readable Creator-cycle usage is 802 of 246,034 characters before the 2026-06-19 reset.
+- Repeated quiet or unresolved items remain: OpenRouter usage 0, Vapi zero sampled calls, Printful sync logs empty despite one older draft order, Resend local key absent, Calendly HTTP 401, Pinecone traffic/billing unresolved, Gamma access drift, and design-tool billing unknown.
+- BuiltWith remains a protected watch item during the outreach/client-volume ramp. Fireflies remains resolved as canceled per Vambah's 2026-05-01 confirmation unless new paid-plan evidence appears.
+- No vendor crossed the approval-ready cancellation threshold.
+
+## Raw Findings
+
+- Read-only checks ran on 2026-06-12T12:35:56Z. Secret values, raw account payloads, private meeting content, private exports, and full logs are not included.
+- Initial checkout state was `codex/subscription-weekly-report-2026-06-08` with pre-existing dirty work across `.env.example`, `.gitignore`, email/outreach files, docs, subscription tracker files, tests, migrations, and untracked prior monitor/client/revenue artifacts. This run preserved unrelated work and only adds/synchronizes the June 12 monitor outputs plus required local notification/memory files.
+- Automation memory existed and carried forward the 2026-06-11 run. The standing decisions still apply: BuiltWith is protected during the outreach ramp, and Fireflies is already canceled unless new paid-plan evidence appears.
+- Action tracker feedback existed for `portfolio-subscription-cancellation-monitor`: 51 open actions, 0 in progress, 0 blocked, 0 done, and no progress notes. No completed, dismissed, blocked, or in-progress action signal changed today's recommendations.
+- Repo/config footprint remains broad. `.env.example`, `.env.staging.example`, `.env.local`, `package.json`, app/api routes, lib integrations, scripts, docs, n8n exports, and migrations continue to reference Supabase, Stripe, n8n, Vercel, OpenAI, Anthropic, Apify, BuiltWith, Calendly, ElevenLabs, Gamma, Gemini/Google, HeyGen, Printful, Resend, Slack, Vapi, OpenRouter, Pinecone, Hunter, Read AI, Google/Gmail/Drive, and related webhooks.
+- `package.json` keeps active dependencies for Supabase, Stripe, Resend, Vercel Functions/Speed Insights/Blob, Google APIs, Playwright, React Calendly, and Vapi.
+- Checked-in n8n exports contain 46 JSON files, 45 top-level workflow objects, and 38 active top-level exports. Integration references include Supabase, Slack, Gmail/Google, Calendly, OpenAI, Anthropic, Apify, HeyGen, Vapi, Stripe, Pinecone, Gemini, Hunter, and OpenRouter.
+- Supabase production aggregates: `analytics_events` 5,300/latest 2026-06-11T23:35:14Z, `agent_runs` 96/latest 2026-06-11T13:00:03Z, `cost_events` 25/latest 2026-06-10T15:58:02Z, `orders` 26/latest 2026-03-19T14:54:19Z, `printful_sync_log` 0, `email_messages` 10/latest 2026-06-04T16:46:08Z, `meeting_records` 111/latest 2026-06-04T16:45:12Z, `gamma_reports` 6/latest 2026-05-02T01:20:15Z, `videos` 4/latest 2026-04-15T02:52:07Z, and `social_content_queue` 30/latest 2026-06-08T13:00:48Z.
+- Supabase configured-local aggregates: `analytics_events` 2,170/latest 2026-06-11T14:22:56Z, `agent_runs` 146/latest 2026-06-12T10:16:48Z, `cost_events` 13/latest 2026-06-11T23:04:11Z, `orders` 1/latest 2026-04-06T19:35:41Z, `printful_sync_log` 0, `email_messages` 7/latest 2026-06-04T16:46:11Z, `meeting_records` 5/latest 2026-06-04T16:45:15Z, `gamma_reports` 4/latest 2026-04-16T14:56:34Z, `videos` 4/latest 2026-03-25T13:48:33Z, and `social_content_queue` 4/latest 2026-06-11T19:23:34Z.
+- n8n Cloud API returned HTTP 200 for workflows and executions when using the cloud API key: 85 workflows, 72 active workflows, and five sampled successful executions around 2026-06-12T12:00Z.
+- Vercel CLI returned authenticated user `vsillah`; deployment listings returned ready deployments for both `portfolio` and `portfolio-staging`.
+- Stripe payment intents, charges, and checkout sessions were readable. Latest sampled successful payment intent was 2026-04-06T19:35:48Z; latest sampled successful charge was 2026-04-06T19:37:14Z; latest sampled paid checkout session was 2026-02-23T21:05:32Z.
+- OpenAI model listing returned HTTP 200 with 120 models. Anthropic model listing returned HTTP 200 with 11 models.
+- Slack bot auth returned HTTP 200 and `ok: true`.
+- Pinecone listed one ready serverless `publications` index.
+- Hunter account remained readable and on Free, with 0 sampled used calls and 75 available in the current API response.
+- Gamma `/v1.0/themes` returned HTTP 401 in this run, after recovering to HTTP 200 on 2026-06-11.
+- HeyGen voices returned HTTP 200 with 2,347 voices; HeyGen avatars initially timed out/error-returned during the combined sweep, then retried successfully with HTTP 200 and 1,289 avatars.
+- Printful orders endpoint returned HTTP 200 with one sampled draft order created 2026-04-06; sampled app sync logs remain empty.
+- ElevenLabs subscription endpoint returned HTTP 200 for Creator with 802 of 246,034 characters used before 2026-06-19T18:38:26Z.
+- Apify actor-runs endpoint returned HTTP 200 with five recent sampled runs, including 2026-06-10 succeeded/failed runs and low sampled usage.
+- Read AI connector returned seven meetings for the May 1-June 12 window, latest start metadata 2026-06-11.
+- OpenRouter auth/key endpoint returned HTTP 200 with usage 0. Vapi calls endpoint returned HTTP 200 with zero sampled calls.
+- Resend local key was absent. Calendly user lookup returned HTTP 401 unauthenticated. Gemini model listing returned HTTP 200 with 50 models.
+- Local visual/design evidence remains repo-adjacent only for Figma/Paper/Excalidraw/Canva-style tools; no direct billing probe was available in this run.
+
+## Discovered Inventory
+
+| Status | Tool/vendor | Purpose in Portfolio | Evidence source | Likely cost/billing status | Last code/config/reference usage | Last operational usage | Dependencies or replacement risk | Session inactivity status | Recommendation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Green | Supabase | Core database, admin state, analytics, agent runs, app data, RAG-adjacent records | Supabase read-only aggregates; repo env/docs/routes | Paid/core hosted service | `.env.example`, app/api routes, lib database helpers, migrations, admin surfaces | Production analytics and agent rows latest 2026-06-11; configured-local agent rows latest 2026-06-12 | High replacement risk; foundational | Active | Keep |
+| Green | n8n Cloud | Automation runtime and workflow orchestration | n8n API and checked-in exports | Paid hosted automation runtime | `.env.example`, `.env.staging.example`, n8n exports, webhook routes/docs | Executions `16985`-`16989` around 2026-06-12T12:00Z | High risk; many workflows and external sends depend on it | Active | Keep; optimize weak workflows separately |
+| Green | Vercel | Production/staging hosting and deployment surface | Vercel CLI | Paid/hosted deployment platform | Vercel scripts/docs, deployment runbooks, app runtime | Ready production/staging deployments listed on 2026-06-12 | High risk; app hosting | Active | Keep |
+| Green | Stripe | Checkout, payments, subscriptions, revenue path | Stripe API; repo routes/deps | Revenue dependency; billing status requires dashboard/receipt refresh | Stripe packages, checkout/payment/webhook routes, admin test checkout | Latest sampled successful charge/payment intent 2026-04-06 | High revenue-path risk | Quiet recent transaction sample but dependency remains | Keep |
+| Green | OpenAI | Model provider for app/admin workflows and n8n | API model listing; n8n exports; env/docs | Usage-based API | `.env.example`, n8n OpenAI nodes, lib/provider fetch, admin LLM routes | Model API readable on 2026-06-12 | Medium/high; many AI paths | Active/configured | Keep/watch usage costs |
+| Green | Anthropic | Model provider and transition watch item | API model listing; n8n exports; env/docs | Billing transition unresolved | `.env.example`, n8n Anthropic node, lib/provider fetch | Model API readable on 2026-06-12 | Medium; replacement possible but quality/bakeoff dependent | Active API, billing unresolved | Keep/watch billing transition |
+| Green | Slack | Agent/admin notifications and mobile ops | Slack auth; n8n exports; env/docs | Workspace/app billing not proven here | Slack env keys, Slack API routes, n8n Slack nodes | Bot auth readable on 2026-06-12 | Medium/high; operational notification surface | Active/configured | Keep |
+| Green | Read AI | Meeting intelligence and transcript workflows | Read AI connector | Paid/subscription status not available here | Meeting dedupe routes, meeting docs, connector availability | Seven meetings since 2026-05-01; latest metadata 2026-06-11 | Medium; can replace with manual notes, but meeting memory value remains | Active enough | Keep/watch plan fit |
+| Yellow | Gamma | Report/deck generation provider | Gamma API, DB report rows, repo routes | Paid/credit status needs dashboard | Gamma env key, admin gamma reports, auto audit summary lib | API returned 401 on 2026-06-12; report rows latest 2026-05-02 | Medium; reports/decks may depend on it while Codex/PPTX alternatives are compared | Access drift, usage quiet | Investigate dashboard credits/key before renewal decision |
+| Green | HeyGen | Avatar/video generation and campaign media | HeyGen API catalog checks; repo env/docs/routes | Paid/quota status needs dashboard | HeyGen env keys, webhook route, video docs/workflows | Voices and avatars readable on 2026-06-12 retry | Medium; video campaigns may depend on it | API readable, usage/quota unknown | Keep/watch; verify dashboard quota |
+| Green | Apify | Lead/social/evidence scraping actors and replacement bakeoff | Apify API and bakeoff docs/status JSON | Usage-based; sampled runs low cost | Apify docs/scripts/n8n exports/env | Latest sampled actor runs 2026-06-10 | Medium; actor-level replacement still in progress | Account active, actor-level mixed | Keep account; continue actor bakeoff |
+| Green | Pinecone | Publications/vector search | Pinecone API | Billing/traffic unresolved | Pinecone env key, RAG docs/n8n vector nodes | One ready `publications` index readable on 2026-06-12 | Medium; may be replaceable with Supabase/local RAG after traffic check | Config active, traffic unknown | Investigate dashboard/API traffic before replacement |
+| Green | Hunter.io | Lead enrichment | Hunter API | Free plan in sampled evidence | `.env.local` key and lead enrichment docs | Free account readable on 2026-06-12 | Low; not a paid cancellation target | Not paid in sampled evidence | Keep/free-watch |
+| Yellow | BuiltWith | Outreach/client stack enrichment | Standing decision plus env/docs | Receipt-backed historical paid line item | BuiltWith env key, deprecation packet, outreach docs | No fresh usage probe in this run | Medium; protected until outreach ramp has outcome evidence | Watch item, not cancellation candidate | Keep active during outreach ramp |
+| Yellow | ElevenLabs | Voice/audio generation | ElevenLabs API | Creator subscription readable | Env key and voice/social content docs | 802/246,034 characters used this cycle; reset 2026-06-19 | Low/medium; can replace with HeyGen/native audio if no campaign need | Low usage, no longer zero | Review campaign need before reset |
+| Yellow | OpenRouter | Alternate model routing/bakeoff | OpenRouter API | Usage 0 on current key; billing/spend unresolved | `.env.local` key; n8n OpenRouter nodes; model bakeoff context | Usage 0 again on 2026-06-12 | Low/medium; replaceable if no bakeoff role | Consecutive quiet evidence | Investigate/deprecate only after spend and dependency check |
+| Yellow | Vapi | Optional voice UX | Vapi API and app/webhook refs | Billing unresolved | Vapi env keys, `@vapi-ai/web`, Vapi webhook/lib | Zero sampled calls again on 2026-06-12 | Medium if production voice UX is intended | Consecutive quiet evidence | Verify dashboard billing and product intent |
+| Yellow | Printful | Store/merch fulfillment | Printful API, Supabase sync logs, store routes/docs | Billing/order costs uncertain | Printful env keys, webhook route, store page, fulfillment lib | One draft order from 2026-04-06; sync logs empty | Medium; store/merch path depends on it | Sync inactive; older draft order exists | Investigate dashboard/store strategy |
+| Yellow | Resend | Optional outbound email and webhook provider | Env presence check and repo routes/deps | Local key absent; production billing unknown | Resend package, webhook route, email docs/env | No local key; production env not verified | Medium; Gmail/n8n may replace if Resend unused | Usage unresolved | Verify production env/billing before removing |
+| Yellow | Calendly | Scheduling links and booking triggers | Calendly API, n8n exports, env/docs | Paid/free status unknown | Calendly env keys, scheduling docs, n8n triggers/router | API returned 401; workflow refs remain | Medium; scheduling workflows depend on it | Auth unresolved | Refresh token or verify dashboard usage |
+| Yellow | Gemini / Google AI | Google AI/image/social workflow provider | Gemini API, n8n export refs | Billing/project status unknown | Gemini env key, Google AI n8n workflow, Google docs | Model listing readable on 2026-06-12 | Medium; workflow may need usage/billing visibility | Access readable, billing unknown | Verify billing/project and workflow usage |
+| Yellow | Figma / Paper / Excalidraw / Canva | Design and diagram production | Repo/docs references only | Billing unknown | Design docs/assets; no direct billing probe | No operational provider check in this run | Low/medium; depends on design pipeline | Unknown | Investigate only if receipts/dashboard evidence appear |
+| Green | Fireflies.ai | Historical meeting recaps only | Standing cancellation decision | Already canceled per 2026-05-01 confirmation | Historical docs only | No new paid-plan evidence | Low unless restarted | Resolved canceled | Keep out of active queue unless paid plan restarts |
+
+## Inactivity Evidence
+
+- OpenRouter: current-key usage remained 0 across consecutive audit sessions. This remains investigate/watch, not approval-ready cancellation, because spend, remaining bakeoff purpose, and n8n OpenRouter-node dependency scope are not confirmed.
+- Vapi: sampled calls remained 0 across consecutive sessions. Treat as investigate until dashboard billing and production voice UX intent are verified.
+- Printful: app sync logs remain empty across sampled Supabase projects, while the API still shows one older draft order from 2026-04-06. Treat as merchandise strategy investigation, not a subscription cancellation.
+- Resend: local key remains absent while package/env/webhook references remain. Verify Vercel production env and billing before removing code paths.
+- Calendly: API access remains 401 across sessions, but scheduling links and n8n booking workflows remain configured. Repair visibility before making a provider decision.
+- Pinecone: one index exists and is ready, but traffic and billing remain unresolved. This is an investigate item, not cancellation evidence by itself.
+- Gamma: API access regressed from 2026-06-11 readability to 401, and report rows remain quiet since 2026-05-02. Verify dashboard credits/key status and recent deck/report need before any renewal decision.
+- ElevenLabs: the current cycle is no longer zero-use, but 802/246,034 characters is still low. Review the next social/video/audio campaign before the 2026-06-19 reset.
+
+## Candidate Cancellations
+
+- No automatic cancellation.
+- No current vendor has approval-ready cancellation evidence in this daily run.
+- Strongest future deprecation-packet candidates remain OpenRouter, Vapi, Printful sync, Resend, Calendly, Gamma access/credits, and possibly Pinecone, but only after dashboard billing, usage, and replacement-risk checks.
+- BuiltWith is excluded from cancellation candidacy during the outreach/client-volume ramp.
+- Fireflies.ai is already resolved/canceled and should only be revisited if new paid-plan evidence appears.
+- If Vambah wants to convert a watch item into a cancellation workflow, the exact approval phrase is still required: `Cancel <tool/vendor> for Portfolio`.
+
+## Approval Needed
+
+- No cancellation approval is requested today.
+- Manual/dashboard checks needed before any future cancellation packet:
+  - Verify Vapi billing and whether production voice UX should stay enabled.
+  - Verify Printful dashboard/store strategy and whether the older draft order matters.
+  - Verify whether production uses Resend or Gmail/n8n as the real outbound email channel.
+  - Verify Pinecone billing/API traffic against Supabase/local RAG.
+  - Restore or replace Calendly API access and check scheduling event usage.
+  - Restore or rotate Gamma API access and verify dashboard credits/recent report need.
+  - Verify Gemini/Google AI billing/project status while model access remains readable.
+  - Verify HeyGen quota and active video campaign need before renewal.
+  - Verify Anthropic billing transition state even though API model access is healthy.
+  - Check whether ElevenLabs' 802-character usage is intentional campaign work or incidental testing before the 2026-06-19 reset.
+  - Keep BuiltWith active while collecting outreach-ramp outcome evidence.
+
+## Next Audit Focus
+
+- Re-run the quiet-provider group with dashboard evidence where APIs cannot prove billing: Vapi, Printful, Resend, Pinecone, Calendly, Gamma, Gemini, HeyGen, Anthropic billing transition, and ElevenLabs campaign need.
+- Continue tracking OpenRouter as a zero-usage model-routing watch item and only draft deprecation if no bakeoff role, workflow dependency, or spend remains.
+- Continue the Apify actor-level replacement bakeoff before any account-level decision, especially after the fresh June 10 mixed succeeded/failed runs.
+- Keep Fireflies out of the active queue unless new receipt/dashboard evidence shows the paid plan restarted.
+- Carry forward action-tracker context: 51 open actions, no in-progress/blocked/done/progress-note changes.

--- a/docs/subscription-monitor-runs/2026-06-13.md
+++ b/docs/subscription-monitor-runs/2026-06-13.md
@@ -1,0 +1,119 @@
+# 2026-06-13 Subscription Monitor Run
+
+Status: YELLOW
+
+## Summary
+
+- No cancellation approvals requested and no cancellation action taken.
+- Core Portfolio systems remain active/readable: Supabase, n8n Cloud, Vercel, Stripe, OpenAI, Anthropic, Slack, Read AI, Gamma, HeyGen, Apify, Pinecone, Hunter, Printful, ElevenLabs, OpenRouter, Vapi, Gemini/Google AI, and the app-side integration footprint all returned current read-only, connector, or dependency evidence.
+- Supabase production moved since the prior monitor: `analytics_events` reached 5,302/latest 2026-06-12T19:27:17Z and `agent_runs` reached 97/latest 2026-06-12T13:00:03Z. Configured-local Supabase remained current with `agent_runs` at 146/latest 2026-06-12T10:16:48Z and `cost_events` at 13/latest 2026-06-11T23:04:11Z.
+- n8n Cloud remains operational with 85 workflows, 72 active workflows, and five sampled successful executions `17092` through `17096` around 2026-06-13T12:00Z.
+- Vercel CLI remained authenticated as `vsillah`; `portfolio` listed a ready preview deployment about 2 hours before the run plus ready production deployments in the prior day, and `portfolio-staging` listed ready production deployments in the prior day.
+- Stripe remains a revenue dependency. Read-only checks were successful; latest sampled successful payment intent/charge remains 2026-04-06 and latest sampled paid checkout session remains 2026-02-23.
+- Read AI connector returned seven meetings in the 2026-05-01 through 2026-06-13 window. Latest meeting metadata remained 2026-06-11. No raw meeting content, transcripts, participant details, or meeting URLs are included in this artifact.
+- Gamma recovered to HTTP 200 with 50 themes after the June 12 HTTP 401. Treat this as restored API visibility, but dashboard credits/billing and recent report need still require verification.
+- HeyGen voices and avatars were readable with 2,347 voices and 1,289 avatars. Billing/quota still requires dashboard verification.
+- ElevenLabs remains low-use but not zero-use: current readable Creator-cycle usage is 802 of 246,034 characters before the 2026-06-19 reset.
+- Repeated quiet or unresolved items remain: OpenRouter usage 0, Vapi zero sampled calls, Printful sync logs empty despite one older draft order, Resend local key absent, Calendly HTTP 401, Pinecone traffic/billing unresolved, Gamma dashboard credits/usage, and design-tool billing unknown.
+- BuiltWith remains a protected watch item during the outreach/client-volume ramp. Fireflies remains resolved as canceled per Vambah's 2026-05-01 confirmation unless new paid-plan evidence appears.
+- No vendor crossed the approval-ready cancellation threshold.
+
+## Raw Findings
+
+- Read-only checks ran on 2026-06-13T12:33:46Z. Secret values, raw account payloads, private meeting content, private exports, and full logs are not included.
+- Initial checkout state was `codex/subscription-weekly-report-2026-06-08` with pre-existing dirty work across env templates, email/outreach files, docs, subscription tracker files, tests, migrations, and untracked prior monitor/client/revenue artifacts. This run preserved unrelated work and only adds/synchronizes the June 13 monitor outputs plus required local notification/memory files.
+- Automation memory existed and carried forward the 2026-06-12 run. Standing decisions still apply: BuiltWith is protected during the outreach ramp, and Fireflies is already canceled unless new paid-plan evidence appears.
+- Action tracker feedback existed for `portfolio-subscription-cancellation-monitor`: 51 open actions, 0 in progress, 0 blocked, 0 done, and no progress notes. No completed, dismissed, blocked, or in-progress action signal changed today's recommendations.
+- Repo/config footprint remains broad. `.env.example`, `.env.staging.example`, `.env.local`, `package.json`, app/api routes, lib integrations, scripts, docs, n8n exports, and migrations continue to reference Supabase, Stripe, n8n, Vercel, OpenAI, Anthropic, Apify, BuiltWith, Calendly, ElevenLabs, Gamma, Gemini/Google, HeyGen, Printful, Resend, Slack, Vapi, OpenRouter, Pinecone, Hunter, Read AI, Google/Gmail/Drive, and related webhooks.
+- `package.json` keeps active dependencies for Supabase, Stripe, Resend, Vercel Functions/Speed Insights/Blob, Google APIs, Playwright, React Calendly, and Vapi.
+- Checked-in n8n exports contain 45 JSON files, 44 top-level workflow objects, and 37 active top-level exports in the current working tree. Integration references include Supabase, Slack, Gmail/Google, Calendly, OpenAI, Anthropic, Apify, HeyGen, Vapi, Stripe, Pinecone, Gemini, Hunter, OpenRouter, and ElevenLabs.
+- Supabase production aggregates: `analytics_events` 5,302/latest 2026-06-12T19:27:17Z, `agent_runs` 97/latest 2026-06-12T13:00:03Z, `cost_events` 25/latest 2026-06-10T15:58:02Z, `orders` 26/latest 2026-03-19T14:54:19Z, `printful_sync_log` 0, `email_messages` 10/latest 2026-06-04T16:46:08Z, `meeting_records` 111/latest 2026-06-04T16:45:12Z, `gamma_reports` 6/latest 2026-05-02T01:20:15Z, `videos` 4/latest 2026-04-15T02:52:07Z, and `social_content_queue` 30/latest 2026-06-08T13:00:48Z.
+- Supabase configured-local aggregates: `analytics_events` 2,170/latest 2026-06-11T14:22:56Z, `agent_runs` 146/latest 2026-06-12T10:16:48Z, `cost_events` 13/latest 2026-06-11T23:04:11Z, `orders` 1/latest 2026-04-06T19:35:41Z, `printful_sync_log` 0, `email_messages` 7/latest 2026-06-04T16:46:11Z, `meeting_records` 5/latest 2026-06-04T16:45:15Z, `gamma_reports` 4/latest 2026-04-16T14:56:34Z, `videos` 4/latest 2026-03-25T13:48:33Z, and `social_content_queue` 4/latest 2026-06-11T19:23:34Z.
+- n8n Cloud API returned HTTP 200 for workflows and executions when using the cloud API key: 85 workflows, 72 active workflows, and five sampled successful executions around 2026-06-13T12:00Z.
+- Vercel CLI returned authenticated user `vsillah`; deployment listings returned ready deployments for both `portfolio` and `portfolio-staging`. The installed CLI does not accept the prior `--limit` option, so the run used the current `vercel list <project>` syntax.
+- Stripe payment intents, charges, and checkout sessions were readable. Latest sampled successful payment intent was 2026-04-06T19:35:48Z; latest sampled successful charge was 2026-04-06T19:37:14Z; latest sampled paid checkout session was 2026-02-23T21:05:32Z.
+- OpenAI model listing returned HTTP 200 with 120 models. Anthropic model listing returned HTTP 200 with 11 models.
+- Slack bot auth returned HTTP 200 and `ok: true`.
+- Pinecone listed one ready serverless `publications` index.
+- Hunter account remained readable and on Free, with 0 sampled used calls and 75 available in the current API response.
+- Gamma `/v1.0/themes` returned HTTP 200 with 50 themes, recovering from the 2026-06-12 HTTP 401.
+- HeyGen voices returned HTTP 200 with 2,347 voices; HeyGen avatars returned HTTP 200 with 1,289 avatars.
+- Printful orders endpoint returned HTTP 200 with one sampled draft order created 2026-04-06; sampled app sync logs remain empty.
+- ElevenLabs subscription endpoint returned HTTP 200 for Creator with 802 of 246,034 characters used before 2026-06-19T18:38:26Z.
+- Apify actor-runs endpoint returned HTTP 200 with recent sampled runs through 2026-06-10, including one succeeded run and one failed run on that date with low sampled usage.
+- Read AI connector returned seven meetings for the May 1-June 13 window, latest start metadata 2026-06-11.
+- OpenRouter auth/key endpoint returned HTTP 200 with usage 0. Vapi calls endpoint returned HTTP 200 with zero sampled calls.
+- Resend local key was absent. Calendly user lookup returned HTTP 401 unauthenticated. Gemini model listing returned HTTP 200 with 50 models.
+- Local visual/design evidence remains repo-adjacent only for Figma/Paper/Excalidraw/Canva-style tools; no direct billing probe was available in this run.
+
+## Discovered Inventory
+
+| Status | Tool/vendor | Purpose in Portfolio | Evidence source | Likely cost/billing status | Last code/config/reference usage | Last operational usage | Dependencies or replacement risk | Session inactivity status | Recommendation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Green | Supabase | Core database, admin state, analytics, agent runs, app data, RAG-adjacent records | Supabase read-only aggregates; repo env/docs/routes | Paid/core hosted service | `.env.example`, app/api routes, lib database helpers, migrations, admin surfaces | Production analytics and agent rows latest 2026-06-12 | High replacement risk; foundational | Active | Keep |
+| Green | n8n Cloud | Automation runtime and workflow orchestration | n8n API and checked-in exports | Paid hosted automation runtime | `.env.example`, `.env.staging.example`, n8n exports, webhook routes/docs | Executions `17092`-`17096` around 2026-06-13T12:00Z | High risk; many workflows and external sends depend on it | Active | Keep; optimize weak workflows separately |
+| Green | Vercel | Production/staging hosting and deployment surface | Vercel CLI | Paid/hosted deployment platform | Vercel scripts/docs, deployment runbooks, app runtime | Ready production/staging deployments listed on 2026-06-13 | High risk; app hosting | Active | Keep |
+| Green | Stripe | Checkout, payments, subscriptions, revenue path | Stripe API; repo routes/deps | Revenue dependency; billing status requires dashboard/receipt refresh | Stripe packages, checkout/payment/webhook routes, admin test checkout | Latest sampled successful charge/payment intent 2026-04-06 | High revenue-path risk | Quiet recent transaction sample but dependency remains | Keep |
+| Green | OpenAI | Model provider for app/admin workflows and n8n | API model listing; n8n exports; env/docs | Usage-based API | `.env.example`, n8n OpenAI nodes, lib/provider fetch, admin LLM routes | Model API readable on 2026-06-13 | Medium/high; many AI paths | Active/configured | Keep/watch usage costs |
+| Green | Anthropic | Model provider and transition watch item | API model listing; n8n exports; env/docs | Billing transition unresolved | `.env.example`, n8n Anthropic nodes, lib/provider fetch | Model API readable on 2026-06-13 | Medium; replacement possible but quality/bakeoff dependent | Active API, billing unresolved | Keep/watch billing transition |
+| Green | Slack | Agent/admin notifications and mobile ops | Slack auth; n8n exports; env/docs | Workspace/app billing not proven here | Slack env keys, Slack API routes, n8n Slack nodes | Bot auth readable on 2026-06-13 | Medium/high; operational notification surface | Active/configured | Keep |
+| Green | Read AI | Meeting intelligence and transcript workflows | Read AI connector | Paid/subscription status not available here | Meeting dedupe routes, meeting docs, connector availability | Seven meetings since 2026-05-01; latest metadata 2026-06-11 | Medium; can replace with manual notes, but meeting memory value remains | Active enough | Keep/watch plan fit |
+| Yellow | Gamma | Report/deck generation provider | Gamma API, DB report rows, repo routes | Paid/credit status needs dashboard | Gamma env key, admin gamma reports, auto audit summary lib | API recovered to 200 on 2026-06-13; report rows latest 2026-05-02 | Medium; reports/decks may depend on it while Codex/PPTX alternatives are compared | API readable again, usage quiet | Investigate dashboard credits/recent report need before renewal decision |
+| Green | HeyGen | Avatar/video generation and campaign media | HeyGen API catalog checks; repo env/docs/routes | Paid/quota status needs dashboard | HeyGen env keys, webhook route, video docs/workflows | Voices and avatars readable on 2026-06-13 | Medium; video campaigns may depend on it | API readable, usage/quota unknown | Keep/watch; verify dashboard quota |
+| Green | Apify | Lead/social/evidence scraping actors and replacement bakeoff | Apify API and bakeoff docs/status JSON | Usage-based; sampled runs low cost | Apify docs/scripts/n8n exports/env | Latest sampled actor runs 2026-06-10 | Medium; actor-level replacement still in progress | Account active, actor-level mixed | Keep account; continue actor bakeoff |
+| Green | Pinecone | Publications/vector search | Pinecone API | Billing/traffic unresolved | Pinecone env key, RAG docs/n8n vector nodes | One ready `publications` index readable on 2026-06-13 | Medium; may be replaceable with Supabase/local RAG after traffic check | Config active, traffic unknown | Investigate dashboard/API traffic before replacement |
+| Green | Hunter.io | Lead enrichment | Hunter API | Free plan in sampled evidence | `.env.local` key and lead enrichment docs | Free account readable on 2026-06-13 | Low; not a paid cancellation target | Not paid in sampled evidence | Keep/free-watch |
+| Yellow | BuiltWith | Outreach/client stack enrichment | Standing decision plus env/docs | Receipt-backed historical paid line item | BuiltWith env key, deprecation packet, outreach docs | No fresh usage probe in this run | Medium; protected until outreach ramp has outcome evidence | Watch item, not cancellation candidate | Keep active during outreach ramp |
+| Yellow | ElevenLabs | Voice/audio generation | ElevenLabs API | Creator subscription readable | Env key and voice/social content docs | 802/246,034 characters used this cycle; reset 2026-06-19 | Low/medium; can replace with HeyGen/native audio if no campaign need | Low usage, no longer zero | Review campaign need before reset |
+| Yellow | OpenRouter | Alternate model routing/bakeoff | OpenRouter API | Usage 0 on current key; billing/spend unresolved | `.env.local` key; n8n OpenRouter nodes; model bakeoff context | Usage 0 again on 2026-06-13 | Low/medium; replaceable if no bakeoff role | Consecutive quiet evidence | Investigate/deprecate only after spend and dependency check |
+| Yellow | Vapi | Optional voice UX | Vapi API and app/webhook refs | Billing unresolved | Vapi env keys, `@vapi-ai/web`, Vapi webhook/lib | Zero sampled calls again on 2026-06-13 | Medium if production voice UX is intended | Consecutive quiet evidence | Verify dashboard billing and product intent |
+| Yellow | Printful | Store/merch fulfillment | Printful API, Supabase sync logs, store routes/docs | Billing/order costs uncertain | Printful env keys, webhook route, store page, fulfillment lib | One draft order from 2026-04-06; sync logs empty | Medium; store/merch path depends on it | Sync inactive; older draft order exists | Investigate dashboard/store strategy |
+| Yellow | Resend | Optional outbound email and webhook provider | Env presence check and repo routes/deps | Local key absent; production billing unknown | Resend package, webhook route, email docs/env | No local key; production env not verified | Medium; Gmail/n8n may replace if Resend unused | Usage unresolved | Verify production env/billing before removing |
+| Yellow | Calendly | Scheduling links and booking triggers | Calendly API, n8n exports, env/docs | Paid/free status unknown | Calendly env keys, scheduling docs, n8n triggers/router | API returned 401; workflow refs remain | Medium; scheduling workflows depend on it | Auth unresolved | Refresh token or verify dashboard usage |
+| Yellow | Gemini / Google AI | Google AI/image/social workflow provider | Gemini API, n8n export refs | Billing/project status unknown | Gemini env key, Google AI n8n workflow, Google docs | Model listing readable on 2026-06-13 | Medium; workflow may need usage/billing visibility | Access readable, billing unknown | Verify billing/project and workflow usage |
+| Yellow | Figma / Paper / Excalidraw / Canva | Design and diagram production | Repo/docs references only | Billing unknown | Design docs/assets; no direct billing probe | No operational provider check in this run | Low/medium; depends on design pipeline | Unknown | Investigate only if receipts/dashboard evidence appear |
+| Green | Fireflies.ai | Historical meeting recaps only | Standing cancellation decision | Already canceled per 2026-05-01 confirmation | Historical docs only | No new paid-plan evidence | Low unless restarted | Resolved canceled | Keep out of active queue unless paid plan restarts |
+
+## Inactivity Evidence
+
+- OpenRouter: current-key usage remained 0 across consecutive audit sessions. This remains investigate/watch, not approval-ready cancellation, because spend, remaining bakeoff purpose, and n8n OpenRouter-node dependency scope are not confirmed.
+- Vapi: sampled calls remained 0 across consecutive sessions. Treat as investigate until dashboard billing and production voice UX intent are verified.
+- Printful: app sync logs remain empty across sampled Supabase projects, while the API still shows one older draft order from 2026-04-06. Treat as merchandise strategy investigation, not a subscription cancellation.
+- Resend: local key remains absent while package/env/webhook references remain. Verify Vercel production env and billing before removing code paths.
+- Calendly: API access remains 401 across sessions, but scheduling links and n8n booking workflows remain configured. Repair visibility before making a provider decision.
+- Pinecone: one index exists and is ready, but traffic and billing remain unresolved. This is an investigate item, not cancellation evidence by itself.
+- Gamma: API access recovered, but report rows remain quiet since 2026-05-02. Verify dashboard credits, recent report/deck need, and whether Codex/PPTX alternatives now cover the use case.
+- ElevenLabs: the current cycle is no longer zero-use, but 802/246,034 characters is still low. Review the next social/video/audio campaign before the 2026-06-19 reset.
+
+## Candidate Cancellations
+
+- No automatic cancellation.
+- No current vendor has approval-ready cancellation evidence in this daily run.
+- Strongest future deprecation-packet candidates remain OpenRouter, Vapi, Printful sync, Resend, Calendly, Gamma credits/usage, and possibly Pinecone, but only after dashboard billing, usage, and replacement-risk checks.
+- BuiltWith is excluded from cancellation candidacy during the outreach/client-volume ramp.
+- Fireflies.ai is already resolved/canceled and should only be revisited if new paid-plan evidence appears.
+- If Vambah wants to convert a watch item into a cancellation workflow, the exact approval phrase is still required: `Cancel <tool/vendor> for Portfolio`.
+
+## Approval Needed
+
+- No cancellation approval is requested today.
+- Manual/dashboard checks needed before any future cancellation packet:
+  - Verify Vapi billing and whether production voice UX should stay enabled.
+  - Verify Printful dashboard/store strategy and whether the older draft order matters.
+  - Verify whether production uses Resend or Gmail/n8n as the real outbound email channel.
+  - Verify Pinecone billing/API traffic against Supabase/local RAG.
+  - Restore or replace Calendly API access and check scheduling event usage.
+  - Verify Gamma dashboard credits/recent report need now that API access is readable again.
+  - Verify Gemini/Google AI billing/project status while model access remains readable.
+  - Verify HeyGen quota and active video campaign need before renewal.
+  - Verify Anthropic billing transition state even though API model access is healthy.
+  - Check whether ElevenLabs' 802-character usage is intentional campaign work or incidental testing before the 2026-06-19 reset.
+  - Keep BuiltWith active while collecting outreach-ramp outcome evidence.
+
+## Next Audit Focus
+
+- Re-run the quiet-provider group with dashboard evidence where APIs cannot prove billing: Vapi, Printful, Resend, Pinecone, Calendly, Gamma, Gemini, HeyGen, Anthropic billing transition, and ElevenLabs campaign need.
+- Continue tracking OpenRouter as a zero-usage model-routing watch item and only draft deprecation if no bakeoff role, workflow dependency, or spend remains.
+- Continue the Apify actor-level replacement bakeoff before any account-level decision, especially after the fresh June 10 mixed succeeded/failed runs.
+- Keep Fireflies out of the active queue unless new receipt/dashboard evidence shows the paid plan restarted.
+- Carry forward action-tracker context: 51 open actions, no in-progress/blocked/done/progress-note changes.

--- a/docs/subscription-monitor-runs/2026-06-14.md
+++ b/docs/subscription-monitor-runs/2026-06-14.md
@@ -1,0 +1,119 @@
+# 2026-06-14 Subscription Monitor Run
+
+Status: YELLOW
+
+## Summary
+
+- No cancellation approvals requested and no cancellation action taken.
+- Core Portfolio systems remain active/readable: Supabase, n8n Cloud, Vercel, Stripe, OpenAI, Anthropic, Slack, Read AI, HeyGen, Apify, Pinecone, Hunter, Printful, ElevenLabs, OpenRouter, Vapi, Gemini/Google AI, and the app-side integration footprint all returned current read-only, connector, or dependency evidence.
+- Supabase production moved since the prior monitor: `analytics_events` reached 5,305/latest 2026-06-13T15:07:48Z and `agent_runs` remained 97/latest 2026-06-12T13:00:03Z. Configured-local Supabase remained current with `agent_runs` at 146/latest 2026-06-12T10:16:48Z and `cost_events` at 13/latest 2026-06-11T23:04:11Z.
+- n8n Cloud remains operational with 85 workflows, 72 active workflows, and five sampled successful executions `17197` through `17201` around 2026-06-14T12:00Z.
+- Vercel CLI remained authenticated as `vsillah` and listed current `portfolio` plus `portfolio-staging` deployment URLs.
+- Stripe remains a revenue dependency. Read-only checks were successful; latest sampled successful payment intent/charge remains 2026-04-06 and latest sampled paid checkout session remains 2026-02-23.
+- Read AI connector returned seven meetings in the 2026-05-01 through 2026-06-14 window. Latest meeting metadata remained 2026-06-11. No raw meeting content, transcripts, participant details, or meeting URLs are included in this artifact.
+- Gamma regressed to HTTP 401 after the June 13 recovery. Treat this as access/billing visibility drift, not cancellation approval.
+- HeyGen voices and avatars were readable with 2,347 voices and 1,289 avatars. Billing/quota still requires dashboard verification.
+- ElevenLabs remains low-use but not zero-use: current readable Creator-cycle usage is 802 of 246,034 characters before the 2026-06-19 reset.
+- Repeated quiet or unresolved items remain: OpenRouter usage 0, Vapi zero sampled calls, Printful sync logs empty despite one older draft order, Resend local key absent, Calendly HTTP 401, Pinecone traffic/billing unresolved, Gamma dashboard credits/usage, and design-tool billing unknown.
+- BuiltWith remains a protected watch item during the outreach/client-volume ramp. Fireflies remains resolved as canceled per Vambah's 2026-05-01 confirmation unless new paid-plan evidence appears.
+- No vendor crossed the approval-ready cancellation threshold.
+
+## Raw Findings
+
+- Read-only checks ran on 2026-06-14T12:33:15Z. Secret values, raw account payloads, private meeting content, private exports, and full logs are not included.
+- Initial checkout state was `codex/subscription-weekly-report-2026-06-08` with pre-existing dirty work across env templates, email/outreach files, docs, subscription tracker files, tests, migrations, and untracked prior monitor/client/revenue artifacts. This run preserved unrelated work and only adds/synchronizes the June 14 monitor outputs plus required local notification/memory files.
+- No prior local automation memory file was present at `$CODEX_HOME/automations/portfolio-subscription-cancellation-monitor/memory.md`; continuity came from the checked-in monitor contract, status file, and prior dated artifacts. Standing decisions still apply: BuiltWith is protected during the outreach ramp, and Fireflies is already canceled unless new paid-plan evidence appears.
+- Action tracker feedback existed for `portfolio-subscription-cancellation-monitor`: 51 open actions, 0 in progress, 0 blocked, 0 done, and no progress notes. No completed, dismissed, blocked, or in-progress action signal changed today's recommendations.
+- Repo/config footprint remains broad. `.env.example`, `.env.staging.example`, `.env.local`, `package.json`, app/api routes, lib integrations, scripts, docs, n8n exports, and migrations continue to reference Supabase, Stripe, n8n, Vercel, OpenAI, Anthropic, Apify, BuiltWith, Calendly, ElevenLabs, Gamma, Gemini/Google, HeyGen, Printful, Resend, Slack, Vapi, OpenRouter, Pinecone, Hunter, Read AI, Google/Gmail/Drive, and related webhooks.
+- `package.json` keeps active dependencies for Supabase, Stripe, Resend, Vercel Functions/Speed Insights/Blob, Google APIs, Playwright, React Calendly, and Vapi.
+- Checked-in n8n exports contain 46 JSON files, 45 top-level workflow objects, and 30 active top-level exports in the current working tree. Integration references include Supabase, Slack, Gmail/Google, Calendly, OpenAI, Anthropic, Apify, HeyGen, Vapi, Stripe, Pinecone, Gemini, Hunter, OpenRouter, and ElevenLabs.
+- Supabase production aggregates: `analytics_events` 5,305/latest 2026-06-13T15:07:48Z, `agent_runs` 97/latest 2026-06-12T13:00:03Z, `cost_events` 25/latest 2026-06-10T15:58:02Z, `orders` 26/latest 2026-03-19T14:54:19Z, `printful_sync_log` 0, `email_messages` 10/latest 2026-06-04T16:46:08Z, `meeting_records` 111/latest 2026-06-04T16:45:12Z, `gamma_reports` 6/latest 2026-05-02T01:20:15Z, `videos` 4/latest 2026-04-15T02:52:07Z, and `social_content_queue` 30/latest 2026-06-08T13:00:48Z.
+- Supabase configured-local aggregates: `analytics_events` 2,170/latest 2026-06-11T14:22:56Z, `agent_runs` 146/latest 2026-06-12T10:16:48Z, `cost_events` 13/latest 2026-06-11T23:04:11Z, `orders` 1/latest 2026-04-06T19:35:41Z, `printful_sync_log` 0, `email_messages` 7/latest 2026-06-04T16:46:11Z, `meeting_records` 5/latest 2026-06-04T16:45:15Z, `gamma_reports` 4/latest 2026-04-16T14:56:34Z, `videos` 4/latest 2026-03-25T13:48:33Z, and `social_content_queue` 4/latest 2026-06-11T19:23:34Z.
+- n8n Cloud API returned HTTP 200 for workflows and executions when using the cloud API key: 85 workflows, 72 active workflows, and five sampled successful executions around 2026-06-14T12:00Z.
+- Vercel CLI returned authenticated user `vsillah`; deployment listings returned current URLs for both `portfolio` and `portfolio-staging`.
+- Stripe payment intents, charges, and checkout sessions were readable. Latest sampled successful payment intent was 2026-04-06T19:35:48Z; latest sampled successful charge was 2026-04-06T19:37:14Z; latest sampled paid checkout session was 2026-02-23T21:05:32Z.
+- OpenAI model listing returned HTTP 200 with 120 models. Anthropic model listing returned HTTP 200 with 11 models.
+- Slack bot auth returned HTTP 200.
+- Pinecone listed one ready serverless `publications` index.
+- Hunter account remained readable and on Free, with 0 sampled used calls and 75 available in the current API response.
+- Gamma `/v1.0/themes` returned HTTP 401 in this run, after recovering to HTTP 200 on 2026-06-13.
+- HeyGen voices returned HTTP 200 with 2,347 voices; HeyGen avatars returned HTTP 200 with 1,289 avatars.
+- Printful orders endpoint returned HTTP 200 with one sampled draft order created 2026-04-06; sampled app sync logs remain empty.
+- ElevenLabs subscription endpoint returned HTTP 200 for Creator with 802 of 246,034 characters used before 2026-06-19T18:38:26Z.
+- Apify actor-runs endpoint returned HTTP 200 with recent sampled runs through 2026-06-10, including low-cost succeeded and failed runs.
+- Read AI connector returned seven meetings for the May 1-June 14 window, latest start metadata 2026-06-11.
+- OpenRouter auth/key endpoint returned HTTP 200 with usage 0. Vapi calls endpoint returned HTTP 200 with zero sampled calls.
+- Resend local key was absent. Calendly user lookup returned HTTP 401 unauthenticated. Gemini model listing returned HTTP 200 with 50 models.
+- Local visual/design evidence remains repo-adjacent only for Figma/Paper/Excalidraw/Canva-style tools; no direct billing probe was available in this run.
+
+## Discovered Inventory
+
+| Status | Tool/vendor | Purpose in Portfolio | Evidence source | Likely cost/billing status | Last code/config/reference usage | Last operational usage | Dependencies or replacement risk | Session inactivity status | Recommendation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Green | Supabase | Core database, admin state, analytics, agent runs, app data, RAG-adjacent records | Supabase read-only aggregates; repo env/docs/routes | Paid/core hosted service | `.env.example`, app/api routes, lib database helpers, migrations, admin surfaces | Production analytics latest 2026-06-13; production agent rows latest 2026-06-12 | High replacement risk; foundational | Active | Keep |
+| Green | n8n Cloud | Automation runtime and workflow orchestration | n8n API and checked-in exports | Paid hosted automation runtime | `.env.example`, `.env.staging.example`, n8n exports, webhook routes/docs | Executions `17197`-`17201` around 2026-06-14T12:00Z | High risk; many workflows and external sends depend on it | Active | Keep; optimize weak workflows separately |
+| Green | Vercel | Production/staging hosting and deployment surface | Vercel CLI | Paid/hosted deployment platform | Vercel scripts/docs, deployment runbooks, app runtime | Current `portfolio` and `portfolio-staging` deployment URLs listed on 2026-06-14 | High risk; app hosting | Active | Keep |
+| Green | Stripe | Checkout, payments, subscriptions, revenue path | Stripe API; repo routes/deps | Revenue dependency; billing status requires dashboard/receipt refresh | Stripe packages, checkout/payment/webhook routes, admin test checkout | Latest sampled successful charge/payment intent 2026-04-06 | High revenue-path risk | Quiet recent transaction sample but dependency remains | Keep |
+| Green | OpenAI | Model provider for app/admin workflows and n8n | API model listing; n8n exports; env/docs | Usage-based API | `.env.example`, n8n OpenAI nodes, lib/provider fetch, admin LLM routes | Model API readable on 2026-06-14 | Medium/high; many AI paths | Active/configured | Keep/watch usage costs |
+| Green | Anthropic | Model provider and transition watch item | API model listing; n8n exports; env/docs | Billing transition unresolved | `.env.example`, n8n Anthropic nodes, lib/provider fetch | Model API readable on 2026-06-14 | Medium; replacement possible but quality/bakeoff dependent | Active API, billing unresolved | Keep/watch billing transition |
+| Green | Slack | Agent/admin notifications and mobile ops | Slack auth; n8n exports; env/docs | Workspace/app billing not proven here | Slack env keys, Slack API routes, n8n Slack nodes | Bot auth readable on 2026-06-14 | Medium/high; operational notification surface | Active/configured | Keep |
+| Green | Read AI | Meeting intelligence and transcript workflows | Read AI connector | Paid/subscription status not available here | Meeting dedupe routes, meeting docs, connector availability | Seven meetings since 2026-05-01; latest metadata 2026-06-11 | Medium; can replace with manual notes, but meeting memory value remains | Active enough | Keep/watch plan fit |
+| Yellow | Gamma | Report/deck generation provider | Gamma API, DB report rows, repo routes | Paid/credit status needs dashboard | Gamma env key, admin gamma reports, auto audit summary lib | API returned 401 on 2026-06-14; report rows latest 2026-05-02 | Medium; reports/decks may depend on it while Codex/PPTX alternatives are compared | Access drift, usage quiet | Investigate dashboard credits/key before renewal decision |
+| Green | HeyGen | Avatar/video generation and campaign media | HeyGen API catalog checks; repo env/docs/routes | Paid/quota status needs dashboard | HeyGen env keys, webhook route, video docs/workflows | Voices and avatars readable on 2026-06-14 | Medium; video campaigns may depend on it | API readable, usage/quota unknown | Keep/watch; verify dashboard quota |
+| Green | Apify | Lead/social/evidence scraping actors and replacement bakeoff | Apify API and bakeoff docs/status JSON | Usage-based; sampled runs low cost | Apify docs/scripts/n8n exports/env | Latest sampled actor runs 2026-06-10 | Medium; actor-level replacement still in progress | Account active, actor-level mixed | Keep account; continue actor bakeoff |
+| Green | Pinecone | Publications/vector search | Pinecone API | Billing/traffic unresolved | Pinecone env key, RAG docs/n8n vector nodes | One ready `publications` index readable on 2026-06-14 | Medium; may be replaceable with Supabase/local RAG after traffic check | Config active, traffic unknown | Investigate dashboard/API traffic before replacement |
+| Green | Hunter.io | Lead enrichment | Hunter API | Free plan in sampled evidence | `.env.local` key and lead enrichment docs | Free account readable on 2026-06-14 | Low; not a paid cancellation target | Not paid in sampled evidence | Keep/free-watch |
+| Yellow | BuiltWith | Outreach/client stack enrichment | Standing decision plus env/docs | Receipt-backed historical paid line item | BuiltWith env key, deprecation packet, outreach docs | No fresh usage probe in this run | Medium; protected until outreach ramp has outcome evidence | Watch item, not cancellation candidate | Keep active during outreach ramp |
+| Yellow | ElevenLabs | Voice/audio generation | ElevenLabs API | Creator subscription readable | Env key and voice/social content docs | 802/246,034 characters used this cycle; reset 2026-06-19 | Low/medium; can replace with HeyGen/native audio if no campaign need | Low usage, no longer zero | Review campaign need before reset |
+| Yellow | OpenRouter | Alternate model routing/bakeoff | OpenRouter API | Usage 0 on current key; billing/spend unresolved | `.env.local` key; n8n OpenRouter nodes; model bakeoff context | Usage 0 again on 2026-06-14 | Low/medium; replaceable if no bakeoff role | Consecutive quiet evidence | Investigate/deprecate only after spend and dependency check |
+| Yellow | Vapi | Optional voice UX | Vapi API and app/webhook refs | Billing unresolved | Vapi env keys, `@vapi-ai/web`, Vapi webhook/lib | Zero sampled calls again on 2026-06-14 | Medium if production voice UX is intended | Consecutive quiet evidence | Verify dashboard billing and product intent |
+| Yellow | Printful | Store/merch fulfillment | Printful API, Supabase sync logs, store routes/docs | Billing/order costs uncertain | Printful env keys, webhook route, store page, fulfillment lib | One draft order from 2026-04-06; sync logs empty | Medium; store/merch path depends on it | Sync inactive; older draft order exists | Investigate dashboard/store strategy |
+| Yellow | Resend | Optional outbound email and webhook provider | Env presence check and repo routes/deps | Local key absent; production billing unknown | Resend package, webhook route, email docs/env | No local key; production env not verified | Medium; Gmail/n8n may replace if Resend unused | Usage unresolved | Verify production env/billing before removing |
+| Yellow | Calendly | Scheduling links and booking triggers | Calendly API, n8n exports, env/docs | Paid/free status unknown | Calendly env keys, scheduling docs, n8n triggers/router | API returned 401; workflow refs remain | Medium; scheduling workflows depend on it | Auth unresolved | Refresh token or verify dashboard usage |
+| Yellow | Gemini / Google AI | Google AI/image/social workflow provider | Gemini API, n8n export refs | Billing/project status unknown | Gemini env key, Google AI n8n workflow, Google docs | Model listing readable on 2026-06-14 | Medium; workflow may need usage/billing visibility | Access readable, billing unknown | Verify billing/project and workflow usage |
+| Yellow | Figma / Paper / Excalidraw / Canva | Design and diagram production | Repo/docs references only | Billing unknown | Design docs/assets; no direct billing probe | No operational provider check in this run | Low/medium; depends on design pipeline | Unknown | Investigate only if receipts/dashboard evidence appear |
+| Green | Fireflies.ai | Historical meeting recaps only | Standing cancellation decision | Already canceled per 2026-05-01 confirmation | Historical docs only | No new paid-plan evidence | Low unless restarted | Keep out of active queue unless paid plan restarts |
+
+## Inactivity Evidence
+
+- OpenRouter: current-key usage remained 0 across consecutive audit sessions. This remains investigate/watch, not approval-ready cancellation, because spend, remaining bakeoff purpose, and n8n OpenRouter-node dependency scope are not confirmed.
+- Vapi: sampled calls remained 0 across consecutive sessions. Treat as investigate until dashboard billing and production voice UX intent are verified.
+- Printful: app sync logs remain empty across sampled Supabase projects, while the API still shows one older draft order from 2026-04-06. Treat as merchandise strategy investigation, not a subscription cancellation.
+- Resend: local key remains absent while package/env/webhook references remain. Verify Vercel production env and billing before removing code paths.
+- Calendly: API access remains 401 across sessions, but scheduling links and n8n booking workflows remain configured. Repair visibility before making a provider decision.
+- Pinecone: one index exists and is ready, but traffic and billing remain unresolved. This is an investigate item, not cancellation evidence by itself.
+- Gamma: API access regressed from 2026-06-13 readability to 401, and report rows remain quiet since 2026-05-02. Verify dashboard credits/key status and recent deck/report need before any renewal decision.
+- ElevenLabs: the current cycle is no longer zero-use, but 802/246,034 characters is still low. Review the next social/video/audio campaign before the 2026-06-19 reset.
+
+## Candidate Cancellations
+
+- No automatic cancellation.
+- No current vendor has approval-ready cancellation evidence in this daily run.
+- Strongest future deprecation-packet candidates remain OpenRouter, Vapi, Printful sync, Resend, Calendly, Gamma access/credits, and possibly Pinecone, but only after dashboard billing, usage, and replacement-risk checks.
+- BuiltWith is excluded from cancellation candidacy during the outreach/client-volume ramp.
+- Fireflies.ai is already resolved/canceled and should only be revisited if new paid-plan evidence appears.
+- If Vambah wants to convert a watch item into a cancellation workflow, the exact approval phrase is still required: `Cancel <tool/vendor> for Portfolio`.
+
+## Approval Needed
+
+- No cancellation approval is requested today.
+- Manual/dashboard checks needed before any future cancellation packet:
+  - Verify Vapi billing and whether production voice UX should stay enabled.
+  - Verify Printful dashboard/store strategy and whether the older draft order matters.
+  - Verify whether production uses Resend or Gmail/n8n as the real outbound email channel.
+  - Verify Pinecone billing/API traffic against Supabase/local RAG.
+  - Restore or replace Calendly API access and check scheduling event usage.
+  - Restore or rotate Gamma API access and verify dashboard credits/recent report need.
+  - Verify Gemini/Google AI billing/project status while model access remains readable.
+  - Verify HeyGen quota and active video campaign need before renewal.
+  - Verify Anthropic billing transition state even though API model access is healthy.
+  - Check whether ElevenLabs' 802-character usage is intentional campaign work or incidental testing before the 2026-06-19 reset.
+  - Keep BuiltWith active while collecting outreach-ramp outcome evidence.
+
+## Next Audit Focus
+
+- Re-run the quiet-provider group with dashboard evidence where APIs cannot prove billing: Vapi, Printful, Resend, Pinecone, Calendly, Gamma, Gemini, HeyGen, Anthropic billing transition, and ElevenLabs campaign need.
+- Continue tracking OpenRouter as a zero-usage model-routing watch item and only draft deprecation if no bakeoff role, workflow dependency, or spend remains.
+- Continue the Apify actor-level replacement bakeoff before any account-level decision, especially after the fresh June 10 mixed succeeded/failed runs.
+- Keep Fireflies out of the active queue unless new receipt/dashboard evidence shows the paid plan restarted.
+- Carry forward action-tracker context: 51 open actions, no in-progress/blocked/done/progress-note changes.

--- a/docs/subscription-monitor-runs/2026-06-15.md
+++ b/docs/subscription-monitor-runs/2026-06-15.md
@@ -1,0 +1,121 @@
+# 2026-06-15 Subscription Monitor Run
+
+Status: YELLOW
+
+## Summary
+
+- No cancellation approvals requested and no cancellation action taken.
+- Core Portfolio systems remain active/readable: Supabase, n8n Cloud, Vercel, Stripe, OpenAI, Anthropic, Slack, HeyGen, Apify, Pinecone, Hunter, Printful, ElevenLabs, OpenRouter, Vapi, Gemini/Google AI, Gamma, and the app-side integration footprint all returned current read-only or dependency evidence.
+- Supabase production moved again today: `analytics_events` reached 5,306/latest 2026-06-15T08:03:40Z and `agent_runs` reached 98/latest 2026-06-15T13:00:04Z. Configured-local Supabase remained current with `agent_runs` at 146/latest 2026-06-12T10:16:48Z and `social_content_queue` at 4/latest 2026-06-11T19:23:34Z.
+- n8n Cloud remains operational with 85 workflows, 72 active workflows, and five sampled successful executions `17309` through `17313`, latest started at 2026-06-15T13:00:52Z.
+- Vercel CLI remained authenticated as `vsillah` and listed ready deployments for both `portfolio` and `portfolio-staging`; `portfolio` had preview deployments around 3 hours old and a production deployment around 1 day old, while `portfolio-staging` had a production deployment around 1 day old.
+- Stripe remains a revenue dependency. Read-only checks were successful; latest sampled successful payment intent/charge remains 2026-04-06 and latest sampled paid checkout session remains 2026-02-23.
+- Gamma recovered from yesterday's HTTP 401 and returned HTTP 200 with 50 themes. Dashboard credits/usage still require verification because DB report rows remain quiet since 2026-05-02.
+- Read AI connector startup failed in this run, so no fresh meeting metadata was retrieved. Carry forward the prior confirmed connector evidence: seven May 1-June 14 meetings, latest metadata 2026-06-11, while treating today's connector failure as a visibility issue.
+- HeyGen voices and avatars were readable with 2,347 voices and 1,289 avatars. Billing/quota still requires dashboard verification.
+- ElevenLabs remains low-use: Creator-cycle usage is 802 of 246,034 characters before the 2026-06-19T18:38:26Z reset.
+- Repeated quiet or unresolved items remain: OpenRouter usage 0, Vapi zero sampled calls, Printful sync logs empty despite one older draft order, Resend local key absent, Calendly HTTP 401, Pinecone traffic/billing unresolved, Gamma dashboard credits/usage, Read AI connector availability, and design-tool billing unknown.
+- BuiltWith remains a protected watch item during the outreach/client-volume ramp. Fireflies remains resolved as canceled per Vambah's 2026-05-01 confirmation unless new paid-plan evidence appears.
+- No vendor crossed the approval-ready cancellation threshold.
+
+## Raw Findings
+
+- Read-only checks ran on 2026-06-15T13:04:15Z. Secret values, raw account payloads, private meeting content, private exports, and full logs are not included.
+- Initial checkout state was `codex/subscription-weekly-report-2026-06-08` with pre-existing dirty work across env templates, outreach/email files, docs, subscription tracker files, tests, migrations, and untracked prior monitor/client/revenue artifacts. This run preserved unrelated work and only adds/synchronizes the June 15 monitor outputs plus required local notification/memory files.
+- Automation memory existed and carried forward the 2026-06-14 daily run. Standing decisions still apply: BuiltWith is protected during the outreach ramp, and Fireflies is already canceled unless new paid-plan evidence appears.
+- Action tracker feedback existed for `portfolio-subscription-cancellation-monitor`: 51 open actions, 0 in progress, 0 blocked, 0 done, and no progress notes. No completed, dismissed, blocked, or in-progress action signal changed today's recommendations.
+- Repo/config footprint remains broad. `.env.example`, `.env.staging.example`, `.env.local`, `package.json`, app/api routes, lib integrations, scripts, docs, n8n exports, and migrations continue to reference Supabase, Stripe, n8n, Vercel, OpenAI, Anthropic, Apify, BuiltWith, Calendly, ElevenLabs, Gamma, Gemini/Google, HeyGen, Printful, Resend, Slack, Vapi, OpenRouter, Pinecone, Hunter, Read AI, Google/Gmail/Drive, and related webhooks.
+- `package.json` keeps active dependencies for Supabase, Stripe, Resend, Vercel Functions/Speed Insights/Blob, Google APIs, Playwright, React Calendly, and Vapi.
+- Checked-in n8n exports contain 45 JSON files, 44 top-level workflow objects, and 37 active top-level exports in the current working tree. Integration references include Supabase, Slack, Gmail/Google, Calendly, OpenAI, Anthropic, Apify, HeyGen, Vapi, Stripe, Pinecone, Gemini, Hunter, OpenRouter, and ElevenLabs.
+- Supabase production aggregates: `analytics_events` 5,306/latest 2026-06-15T08:03:40Z, `agent_runs` 98/latest 2026-06-15T13:00:04Z, `cost_events` 25/latest 2026-06-10T15:58:02Z, `orders` 26/latest 2026-03-19T14:54:19Z, `printful_sync_log` 0, `email_messages` 10/latest 2026-06-04T16:46:08Z, `meeting_records` 111/latest 2026-06-04T16:45:12Z, `gamma_reports` 6/latest 2026-05-02T01:20:15Z, `videos` 4/latest 2026-04-15T02:52:07Z, and `social_content_queue` 30/latest 2026-06-08T13:00:48Z.
+- Supabase configured-local aggregates: `analytics_events` 2,170/latest 2026-06-11T14:22:56Z, `agent_runs` 146/latest 2026-06-12T10:16:48Z, `cost_events` 13/latest 2026-06-11T23:04:11Z, `orders` 1/latest 2026-04-06T19:35:41Z, `printful_sync_log` 0, `email_messages` 7/latest 2026-06-04T16:46:11Z, `meeting_records` 5/latest 2026-06-04T16:45:15Z, `gamma_reports` 4/latest 2026-04-16T14:56:34Z, `videos` 4/latest 2026-03-25T13:48:33Z, and `social_content_queue` 4/latest 2026-06-11T19:23:34Z.
+- n8n Cloud API returned HTTP 200 for workflows and executions when using the cloud API key: 85 workflows, 72 active workflows, and five sampled successful executions around 2026-06-15T13:00Z.
+- Vercel CLI returned authenticated user `vsillah`; deployment listings returned ready entries for both `portfolio` and `portfolio-staging`.
+- Stripe payment intents, charges, and checkout sessions were readable. Latest sampled successful payment intent was 2026-04-06T19:35:48Z; latest sampled successful charge was 2026-04-06T19:37:14Z; latest sampled paid checkout session was 2026-02-23T21:05:32Z.
+- OpenAI model listing returned HTTP 200 with 120 models. Anthropic model listing returned HTTP 200 with 11 models.
+- Slack bot auth returned HTTP 200.
+- Pinecone listed one ready serverless `publications` index.
+- Hunter account remained readable and on Free, with 5 sampled used calls and 50 available in the current API response.
+- Gamma `/v1.0/themes` returned HTTP 200 with 50 themes in this run, after returning HTTP 401 on 2026-06-14.
+- HeyGen voices returned HTTP 200 with 2,347 voices; HeyGen avatars returned HTTP 200 with 1,289 avatars.
+- Printful orders endpoint returned HTTP 200 with one sampled draft order created 2026-04-06T20:21:48Z; sampled app sync logs remain empty.
+- ElevenLabs subscription endpoint returned HTTP 200 for Creator with 802 of 246,034 characters used before 2026-06-19T18:38:26Z.
+- Apify actor-runs endpoint returned HTTP 200 with recent sampled runs through 2026-06-10, including low-cost succeeded and failed runs.
+- Read AI connector failed to start during this run, so no fresh metadata was retrieved. Prior run evidence remains seven meetings for the May 1-June 14 window with latest start metadata 2026-06-11.
+- OpenRouter auth/key endpoint returned HTTP 200 with usage 0. Vapi calls endpoint returned HTTP 200 with zero sampled calls.
+- Resend local key was absent. Calendly user lookup returned HTTP 401 unauthenticated. Gemini model listing returned HTTP 200 with 50 models.
+- Local and Drive visual/design evidence remains project-adjacent for Paper, Canva-style exports, and HeyGen media clips, but no direct billing probe was available for Figma/Paper/Canva-like design tools in this run.
+
+## Discovered Inventory
+
+| Status | Tool/vendor | Purpose in Portfolio | Evidence source | Likely cost/billing status | Last code/config/reference usage | Last operational usage | Dependencies or replacement risk | Session inactivity status | Recommendation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Green | Supabase | Core database, admin state, analytics, agent runs, app data, RAG-adjacent records | Supabase read-only aggregates; repo env/docs/routes | Paid/core hosted service | `.env.example`, app/api routes, lib database helpers, migrations, admin surfaces | Production analytics and agent runs latest 2026-06-15 | High replacement risk; foundational | Active | Keep |
+| Green | n8n Cloud | Automation runtime and workflow orchestration | n8n API and checked-in exports | Paid hosted automation runtime | `.env.example`, `.env.staging.example`, n8n exports, webhook routes/docs | Executions `17309`-`17313` around 2026-06-15T13:00Z | High risk; many workflows and external sends depend on it | Active | Keep; optimize weak workflows separately |
+| Green | Vercel | Production/staging hosting and deployment surface | Vercel CLI | Paid/hosted deployment platform | Vercel scripts/docs, deployment runbooks, app runtime | Ready `portfolio` and `portfolio-staging` deployments listed on 2026-06-15 | High risk; app hosting | Active | Keep |
+| Green | Stripe | Checkout, payments, subscriptions, revenue path | Stripe API; repo routes/deps | Revenue dependency; billing status requires dashboard/receipt refresh | Stripe packages, checkout/payment/webhook routes, admin test checkout | Latest sampled successful charge/payment intent 2026-04-06 | High revenue-path risk | Quiet recent transaction sample but dependency remains | Keep |
+| Green | OpenAI | Model provider for app/admin workflows and n8n | API model listing; n8n exports; env/docs | Usage-based API | `.env.example`, n8n OpenAI nodes, lib/provider fetch, admin LLM routes | Model API readable on 2026-06-15 | Medium/high; many AI paths | Active/configured | Keep/watch usage costs |
+| Green | Anthropic | Model provider and transition watch item | API model listing; n8n exports; env/docs | Billing transition unresolved | `.env.example`, n8n Anthropic nodes, lib/provider fetch | Model API readable on 2026-06-15 | Medium; replacement possible but quality/bakeoff dependent | Active API, billing unresolved | Keep/watch billing transition |
+| Green | Slack | Agent/admin notifications and mobile ops | Slack auth; n8n exports; env/docs | Workspace/app billing not proven here | Slack env keys, Slack API routes, n8n Slack nodes | Bot auth readable on 2026-06-15 | Medium/high; operational notification surface | Active/configured | Keep |
+| Yellow | Read AI | Meeting intelligence and transcript workflows | Connector attempt; prior connector evidence | Paid/subscription status not available here | Meeting dedupe routes, meeting docs, connector availability | Connector failed today; prior latest metadata 2026-06-11 | Medium; can replace with manual notes, but meeting memory value remains | Visibility regressed, prior use active enough | Keep/watch plan fit and connector availability |
+| Yellow | Gamma | Report/deck generation provider | Gamma API, DB report rows, repo routes | Paid/credit status needs dashboard | Gamma env key, admin gamma reports, auto audit summary lib | API recovered to HTTP 200 on 2026-06-15; report rows latest 2026-05-02 | Medium; reports/decks may depend on it while Codex/PPTX alternatives are compared | API readable, usage quiet | Investigate dashboard credits/recent report need |
+| Green | HeyGen | Avatar/video generation and campaign media | HeyGen API catalog checks; repo env/docs/routes | Paid/quota status needs dashboard | HeyGen env keys, webhook route, video docs/workflows | Voices and avatars readable on 2026-06-15 | Medium; video campaigns may depend on it | API readable, usage/quota unknown | Keep/watch; verify dashboard quota |
+| Green | Apify | Lead/social/evidence scraping actors and replacement bakeoff | Apify API and bakeoff docs/status JSON | Usage-based; sampled runs low cost | Apify docs/scripts/n8n exports/env | Latest sampled actor runs 2026-06-10 | Medium; actor-level replacement still in progress | Account active, actor-level mixed | Keep account; continue actor bakeoff |
+| Green | Pinecone | Publications/vector search | Pinecone API | Billing/traffic unresolved | Pinecone env key, RAG docs/n8n vector nodes | One ready `publications` index readable on 2026-06-15 | Medium; may be replaceable with Supabase/local RAG after traffic check | Config active, traffic unknown | Investigate dashboard/API traffic before replacement |
+| Green | Hunter.io | Lead enrichment | Hunter API | Free plan in sampled evidence | `.env.local` key and lead enrichment docs | Free account readable on 2026-06-15, 5 used/50 available | Low; not a paid cancellation target | Free/readable | Keep/free-watch |
+| Yellow | BuiltWith | Outreach/client stack enrichment | Standing decision plus env/docs | Receipt-backed historical paid line item | BuiltWith env key, deprecation packet, outreach docs | No fresh usage probe in this run | Medium; protected until outreach ramp has outcome evidence | Watch item, not cancellation candidate | Keep active during outreach ramp |
+| Yellow | ElevenLabs | Voice/audio generation | ElevenLabs API | Creator subscription readable | Env key and voice/social content docs | 802/246,034 characters used this cycle; reset 2026-06-19 | Low/medium; can replace with HeyGen/native audio if no campaign need | Low usage, no longer zero | Review campaign need before reset |
+| Yellow | OpenRouter | Alternate model routing/bakeoff | OpenRouter API | Usage 0 on current key; billing/spend unresolved | `.env.local` key; n8n OpenRouter nodes; model bakeoff context | Usage 0 again on 2026-06-15 | Low/medium; replaceable if no bakeoff role | Consecutive quiet evidence | Investigate/deprecate only after spend and dependency check |
+| Yellow | Vapi | Optional voice UX | Vapi API and app/webhook refs | Billing unresolved | Vapi env keys, `@vapi-ai/web`, Vapi webhook/lib | Zero sampled calls again on 2026-06-15 | Medium if production voice UX is intended | Consecutive quiet evidence | Verify dashboard billing and product intent |
+| Yellow | Printful | Store/merch fulfillment | Printful API, Supabase sync logs, store routes/docs | Billing/order costs uncertain | Printful env keys, webhook route, store page, fulfillment lib | One draft order from 2026-04-06; sync logs empty | Medium; store/merch path depends on it | Sync inactive; older draft order exists | Investigate dashboard/store strategy |
+| Yellow | Resend | Optional outbound email and webhook provider | Env presence check and repo routes/deps | Local key absent; production billing unknown | Resend package, webhook route, email docs/env | No local key; production env not verified | Medium; Gmail/n8n may replace if Resend unused | Usage unresolved | Verify production env/billing before removing |
+| Yellow | Calendly | Scheduling links and booking triggers | Calendly API, n8n exports, env/docs | Paid/free status unknown | Calendly env keys, scheduling docs, n8n triggers/router | API returned 401; workflow refs remain | Medium; scheduling workflows depend on it | Auth unresolved | Refresh token or verify dashboard usage |
+| Yellow | Gemini / Google AI | Google AI/image/social workflow provider | Gemini API, n8n export refs | Billing/project status unknown | Gemini env key, Google AI n8n workflow, Google docs | Model listing readable on 2026-06-15 | Medium; workflow may need usage/billing visibility | Access readable, billing unknown | Verify billing/project and workflow usage |
+| Yellow | Figma / Paper / Excalidraw / Canva | Design and diagram production | Repo/docs/Drive references only | Billing unknown | Design docs/assets and Drive artifacts; no direct billing probe | Paper/KMB assets, Canva-style PDF, and project visual assets found locally/Drive | Low/medium; depends on design pipeline | Unknown | Investigate only if receipts/dashboard evidence appear |
+| Green | Fireflies.ai | Historical meeting recaps only | Standing cancellation decision | Already canceled per 2026-05-01 confirmation | Historical docs only | No new paid-plan evidence | Low unless restarted | Resolved canceled | Keep out of active queue unless paid plan restarts |
+
+## Inactivity Evidence
+
+- OpenRouter: current-key usage remained 0 across consecutive audit sessions. This remains investigate/watch, not approval-ready cancellation, because spend, remaining bakeoff purpose, and n8n OpenRouter-node dependency scope are not confirmed.
+- Vapi: sampled calls remained 0 across consecutive sessions. Treat as investigate until dashboard billing and production voice UX intent are verified.
+- Printful: app sync logs remain empty across sampled Supabase projects, while the API still shows one older draft order from 2026-04-06. Treat as merchandise strategy investigation, not a subscription cancellation.
+- Resend: local key remains absent while package/env/webhook references remain. Verify Vercel production env and billing before removing code paths.
+- Calendly: API access remains 401 across sessions, but scheduling links and n8n booking workflows remain configured. Repair visibility before making a provider decision.
+- Pinecone: one index exists and is ready, but traffic and billing remain unresolved. This is an investigate item, not cancellation evidence by itself.
+- Gamma: API recovered today, but report rows remain quiet since 2026-05-02. Verify dashboard credits, recent report/deck need, and whether Codex/PPTX alternatives now cover the use case.
+- ElevenLabs: the current cycle is no longer zero-use, but 802/246,034 characters is still low. Review the next social/video/audio campaign before the 2026-06-19 reset.
+- Read AI: connector evidence could not be refreshed today because the connector failed to start. Treat this as a visibility issue, not inactivity evidence, because the prior run showed June 11 meeting metadata.
+
+## Candidate Cancellations
+
+- No automatic cancellation.
+- No current vendor has approval-ready cancellation evidence in this daily run.
+- Strongest future deprecation-packet candidates remain OpenRouter, Vapi, Printful sync, Resend, Calendly, Gamma credits/usage, and possibly Pinecone, but only after dashboard billing, usage, and replacement-risk checks.
+- BuiltWith is excluded from cancellation candidacy during the outreach/client-volume ramp.
+- Fireflies.ai is already resolved/canceled and should only be revisited if new paid-plan evidence appears.
+- If Vambah wants to convert a watch item into a cancellation workflow, the exact approval phrase is still required: `Cancel <tool/vendor> for Portfolio`.
+
+## Approval Needed
+
+- No cancellation approval is requested today.
+- Manual/dashboard checks needed before any future cancellation packet:
+  - Verify Vapi billing and whether production voice UX should stay enabled.
+  - Verify Printful dashboard/store strategy and whether the older draft order matters.
+  - Verify whether production uses Resend or Gmail/n8n as the real outbound email channel.
+  - Verify Pinecone billing/API traffic against Supabase/local RAG.
+  - Restore or replace Calendly API access and check scheduling event usage.
+  - Verify Gamma dashboard credits/recent report need now that API access recovered.
+  - Verify Gemini/Google AI billing/project status while model access remains readable.
+  - Verify HeyGen quota and active video campaign need before renewal.
+  - Verify Anthropic billing transition state even though API model access is healthy.
+  - Check whether ElevenLabs' 802-character usage is intentional campaign work or incidental testing before the 2026-06-19 reset.
+  - Recheck Read AI connector availability and plan fit.
+  - Keep BuiltWith active while collecting outreach-ramp outcome evidence.
+
+## Next Audit Focus
+
+- Re-run the quiet-provider group with dashboard evidence where APIs cannot prove billing: Vapi, Printful, Resend, Pinecone, Calendly, Gamma, Gemini, HeyGen, Anthropic billing transition, Read AI plan/connector state, and ElevenLabs campaign need.
+- Continue tracking OpenRouter as a zero-usage model-routing watch item and only draft deprecation if no bakeoff role, workflow dependency, or spend remains.
+- Continue the Apify actor-level replacement bakeoff before any account-level decision, especially after the June 10 mixed succeeded/failed runs.
+- Keep Fireflies out of the active queue unless new receipt/dashboard evidence shows the paid plan restarted.
+- Carry forward action-tracker context: 51 open actions, no in-progress/blocked/done/progress-note changes.

--- a/docs/subscription-status.json
+++ b/docs/subscription-status.json
@@ -1,7 +1,7 @@
 {
-  "generatedAt": "2026-06-03T12:38:48Z",
+  "generatedAt": "2026-06-15T13:04:15Z",
   "sourceDocument": "/docs/subscription-cancellation-audit.md",
-  "latestMonitorArtifact": "/docs/subscription-monitor-runs/2026-06-03.md",
+  "latestMonitorArtifact": "/docs/subscription-monitor-runs/2026-06-15.md",
   "monitorRunArtifactPattern": "/docs/subscription-monitor-runs/YYYY-MM-DD.md",
   "weeklyReportAutomationId": "portfolio-subscription-weekly-report",
   "dailyMonitorAutomationId": "portfolio-subscription-cancellation-monitor",
@@ -44,7 +44,18 @@
       "2026-05-30 daily refresh kept the budget status yellow: production and local Supabase analytics/agent_runs moved, n8n returned 85 workflows with 72 active and successful executions around 2026-05-30T12:00Z, Vercel portfolio and portfolio-staging had ready deployments on 2026-05-29/30, Read AI had May 29 meeting evidence, Gamma themes were readable, HeyGen avatar and voice listings were readable, and OpenAI/Slack/Pinecone/Hunter/Printful APIs were readable; OpenRouter stayed zero-usage, Vapi returned no sampled calls, Resend local key was absent, Calendly returned 401, Gemini/Google AI returned 403, Anthropic model listing returned 401 after prior readable checks, ElevenLabs current cycle still showed 0 of 246,034 characters used, and no vendor crossed the approval-ready cancellation threshold.",
       "2026-05-31 daily refresh kept the budget status yellow: production Supabase analytics and local agent_runs moved, n8n returned 85 workflows with 72 active and successful executions around 2026-05-31T12:00Z, Vercel portfolio had ready preview deployments about 2 hours old, Read AI had six May meetings through 2026-05-29, Gamma v1.0 themes and HeyGen avatars/voices were readable, Anthropic model listing recovered, and OpenAI/Slack/Pinecone/Hunter/Printful/Apify APIs were readable; OpenRouter stayed zero-usage, Vapi returned no sampled calls, Resend local key was absent, Calendly returned 401, Gemini/Google AI returned 403, ElevenLabs current cycle still showed 0 of 246,034 characters used, and no vendor crossed the approval-ready cancellation threshold.",
       "2026-06-02 daily refresh kept the budget status yellow: production Supabase analytics moved to 5184/latest 2026-06-02T12:34:01Z and production agent_runs moved to 79/latest 2026-06-01T13:00:03Z; n8n returned 85 workflows with 72 active and successful executions 15931-15935 around 2026-06-02T12:00Z; Vercel CLI remained authenticated and listed portfolio plus portfolio-staging deployments; Read AI connector returned six meetings in the May 1-June 2 window with latest on 2026-06-01; OpenAI/Anthropic/Slack/Pinecone/Hunter/Printful/Gamma/HeyGen voices APIs were readable; HeyGen avatars timed out once; OpenRouter stayed zero-usage, Vapi returned zero sampled calls, Resend local key was absent, Calendly returned 401, Gemini returned 403, ElevenLabs current cycle still showed 0 of 246,034 characters used, and no vendor crossed the approval-ready cancellation threshold.",
-      "2026-06-03 daily refresh kept the budget status yellow: production Supabase analytics moved to 5199/latest 2026-06-02T22:04:18Z and production agent_runs moved to 80/latest 2026-06-02T13:00:02Z; n8n returned 85 workflows with 72 active and successful executions 16036-16040 around 2026-06-03T12:00Z; Vercel CLI remained authenticated and listed READY portfolio plus portfolio-staging deployments; Read AI connector returned six meetings in the May 1-June 3 window with latest returned meeting 2026-05-29; Apify returned same-day successful actor runs on 2026-06-03; OpenAI/Anthropic/Slack/Pinecone/Hunter/Printful/HeyGen voices APIs were readable; Gamma returned 401 invalid/expired token; OpenRouter stayed zero-usage, Vapi returned zero sampled calls, Resend local key was absent, Calendly returned 401, Gemini returned 403, ElevenLabs current cycle still showed 0 of 246,034 characters used, and no vendor crossed the approval-ready cancellation threshold."
+      "2026-06-03 daily refresh kept the budget status yellow: production Supabase analytics moved to 5199/latest 2026-06-02T22:04:18Z and production agent_runs moved to 80/latest 2026-06-02T13:00:02Z; n8n returned 85 workflows with 72 active and successful executions 16036-16040 around 2026-06-03T12:00Z; Vercel CLI remained authenticated and listed READY portfolio plus portfolio-staging deployments; Read AI connector returned six meetings in the May 1-June 3 window with latest returned meeting 2026-05-29; Apify returned same-day successful actor runs on 2026-06-03; OpenAI/Anthropic/Slack/Pinecone/Hunter/Printful/HeyGen voices APIs were readable; Gamma returned 401 invalid/expired token; OpenRouter stayed zero-usage, Vapi returned zero sampled calls, Resend local key was absent, Calendly returned 401, Gemini returned 403, ElevenLabs current cycle still showed 0 of 246,034 characters used, and no vendor crossed the approval-ready cancellation threshold.",
+      "2026-06-05 daily refresh kept the budget status yellow: Supabase production and local samples moved on 2026-06-04, n8n returned 85 workflows with 72 active and successful executions around 2026-06-05T12:00Z, Vercel CLI listed portfolio plus portfolio-staging, Read AI returned six meetings since 2026-05-01 with latest 2026-05-29, OpenAI/Anthropic/Slack/Pinecone/Hunter/Printful/HeyGen/ElevenLabs/Apify were readable; Gamma returned 401, Calendly returned 401, Gemini returned 403, Resend local key was absent, OpenRouter stayed zero-usage, Vapi returned zero sampled calls, and no vendor crossed the approval-ready cancellation threshold.",
+      "2026-06-06 daily refresh kept the budget status yellow: production Supabase agent_runs moved to 84/latest 2026-06-05T13:00:03Z; n8n returned 85 workflows with 72 active and successful executions 16342-16346 around 2026-06-06T12:00Z; Vercel CLI listed ready portfolio and portfolio-staging deployments; Stripe/OpenAI/Anthropic/Slack/Pinecone/Hunter/Printful/ElevenLabs/Gamma/HeyGen/Apify/Read AI were readable or dependency-backed; Gamma recovered through the current /v1.0/themes endpoint; OpenRouter stayed zero-usage, Vapi returned zero sampled calls, Resend local key was absent, Calendly returned 401, Gemini returned 403, ElevenLabs current cycle still showed 0 of 246034 characters used, and no vendor crossed the approval-ready cancellation threshold.",
+      "2026-06-07 daily refresh kept the budget status yellow: production Supabase analytics moved to 5236/latest 2026-06-07T03:57:33Z; n8n returned 85 workflows with 72 active and successful executions 16445-16449 around 2026-06-07T12:00Z; Vercel CLI listed portfolio and portfolio-staging deployments; Stripe/OpenAI/Anthropic/Slack/Pinecone/Hunter/Printful/ElevenLabs/Gamma/HeyGen/Apify/OpenRouter/Vapi/Read AI were readable or dependency-backed; OpenRouter stayed zero-usage, Vapi returned zero sampled calls, Resend local key was absent, Calendly returned 401, Gemini returned 403, ElevenLabs current cycle still showed 0 of 246034 characters used, and no vendor crossed the approval-ready cancellation threshold.",
+      "2026-06-08 daily refresh kept the budget status yellow: production Supabase analytics moved to 5239/latest 2026-06-07T14:55:04Z and configured-local agent_runs moved to 131/latest 2026-06-08T00:27:15Z; n8n returned 85 workflows with 72 active and successful executions 16550-16554 around 2026-06-08T12:00Z; Vercel CLI listed ready portfolio and portfolio-staging deployments; Stripe/OpenAI/Anthropic/Slack/Pinecone/Hunter/Printful/ElevenLabs/HeyGen/Apify/OpenRouter/Vapi/Gemini/Read AI were readable or dependency-backed; Gemini recovered to 50 readable models, Gamma returned 401, OpenRouter stayed zero-usage, Vapi returned zero sampled calls, Resend local key was absent, Calendly returned 401, ElevenLabs current cycle still showed 0 of 246034 characters used, and no vendor crossed the approval-ready cancellation threshold.",
+      "2026-06-08 weekly refresh kept the budget status yellow: BuiltWith stayed protected during the outreach ramp, Fireflies stayed resolved/canceled, Gemini moved from access-blocked to readable model evidence, Gamma regressed to 401 access drift, and quiet or unresolved providers still require dashboard/login evidence before any cancellation packet.",
+      "2026-06-11 daily refresh kept the budget status yellow: production Supabase analytics, agent_runs, cost_events, and social_content_queue moved through 2026-06-10/08; n8n returned 85 workflows with 72 active and successful executions 16878-16882 around 2026-06-11T12:00Z; Vercel CLI listed ready portfolio and portfolio-staging deployments; Stripe/OpenAI/Anthropic/Slack/Pinecone/Hunter/Gamma/HeyGen/Printful/ElevenLabs/Apify/OpenRouter/Vapi/Gemini/Read AI were readable or dependency-backed; Gamma recovered to 50 readable themes, Gemini stayed at 50 readable models, ElevenLabs current cycle showed 802 of 246034 characters used, OpenRouter stayed zero-usage, Vapi returned zero sampled calls, Resend local key was absent, Calendly returned 401, and no vendor crossed the approval-ready cancellation threshold.",
+      "2026-06-12 daily refresh kept the budget status yellow: production Supabase analytics and agent_runs moved through 2026-06-11, configured-local agent_runs moved through 2026-06-12, n8n returned 85 workflows with 72 active and successful executions 16985-16989 around 2026-06-12T12:00Z; Vercel CLI listed ready portfolio and portfolio-staging deployments; Stripe/OpenAI/Anthropic/Slack/Pinecone/Hunter/Printful/ElevenLabs/HeyGen/Apify/OpenRouter/Vapi/Gemini/Read AI were readable or dependency-backed; Read AI had seven May 1-June 12 meeting metadata records with latest June 11 activity; Gamma regressed to 401 after the June 11 recovery; OpenRouter stayed zero-usage, Vapi returned zero sampled calls, Resend local key was absent, Calendly returned 401, and no vendor crossed the approval-ready cancellation threshold.",
+      "2026-06-13 daily refresh kept the budget status yellow: production Supabase analytics and agent_runs moved through 2026-06-12, n8n returned 85 workflows with 72 active and successful executions 17092-17096 around 2026-06-13T12:00Z; Vercel CLI listed ready portfolio and portfolio-staging deployments; Stripe/OpenAI/Anthropic/Slack/Pinecone/Hunter/Gamma/HeyGen/Printful/ElevenLabs/Apify/OpenRouter/Vapi/Gemini/Read AI were readable or dependency-backed; Gamma recovered to 50 readable themes, Gemini stayed at 50 readable models, ElevenLabs current cycle stayed at 802 of 246034 characters used, OpenRouter stayed zero-usage, Vapi returned zero sampled calls, Resend local key was absent, Calendly returned 401, and no vendor crossed the approval-ready cancellation threshold.",
+      "2026-06-14 daily refresh kept the budget status yellow: production Supabase analytics moved through 2026-06-13, n8n returned 85 workflows with 72 active and successful executions 17197-17201 around 2026-06-14T12:00Z; Vercel CLI listed portfolio and portfolio-staging deployment URLs; Stripe/OpenAI/Anthropic/Slack/Pinecone/Hunter/HeyGen/Printful/ElevenLabs/Apify/OpenRouter/Vapi/Gemini/Read AI were readable or dependency-backed; Gamma regressed to 401 after the June 13 recovery; OpenRouter stayed zero-usage, Vapi returned zero sampled calls, Resend local key was absent, Calendly returned 401, and no vendor crossed the approval-ready cancellation threshold.",
+      "2026-06-15 weekly refresh kept the budget status yellow: Supabase, n8n, Vercel, Read AI, HeyGen, Gemini, Anthropic API, and core providers stayed active/readable; ElevenLabs moved from zero-use to low-use at 802 characters before the 2026-06-19 reset; Gamma recovered then regressed to 401 access drift; OpenRouter and Vapi stayed quiet; BuiltWith stayed protected during the outreach ramp; Fireflies stayed resolved/canceled; no vendor crossed the approval-ready cancellation threshold.",
+      "2026-06-15 daily refresh kept the budget status yellow: production Supabase analytics and agent_runs moved through 2026-06-15, n8n returned 85 workflows with 72 active and successful executions 17309-17313 around 2026-06-15T13:00Z; Vercel CLI listed ready portfolio and portfolio-staging deployments; Stripe/OpenAI/Anthropic/Slack/Pinecone/Hunter/Gamma/HeyGen/Printful/ElevenLabs/Apify/OpenRouter/Vapi/Gemini were readable or dependency-backed; Gamma recovered to 50 themes after the June 14 401; Read AI connector failed to start so prior June 11 meeting evidence was carried forward; OpenRouter stayed zero-usage, Vapi returned zero sampled calls, Resend local key was absent, Calendly returned 401, and no vendor crossed the approval-ready cancellation threshold."
     ],
     "transitionAdjustments": [
       {
@@ -56,7 +67,7 @@
     ],
     "apifyCallAnalysis": {
       "configuredActorSurfaces": 12,
-      "lastMonitorExecution": "Direct provider refresh on 2026-06-03 was readable; sampled account-level Apify runs included same-day successful runs on 2026-06-03 and 2026-06-02. Actor-level bakeoff evidence remains the active replacement-analysis base.",
+      "lastMonitorExecution": "Direct provider refresh on 2026-06-14 was readable; sampled account-level Apify runs still included 2026-06-10 succeeded/failed runs with low sampled usage. Actor-level bakeoff evidence remains the active replacement-analysis base.",
       "sampledRuns": 59,
       "succeededRuns": 40,
       "failedRuns": 19,
@@ -373,23 +384,22 @@
   },
   "summary": {
     "status": "yellow",
-    "headline": "Daily refresh: Supabase, n8n, Vercel, Apify, OpenAI, Anthropic, Slack, Pinecone, Hunter, Printful, HeyGen voices, and Read AI remain readable or active; Gamma auth regressed; OpenRouter and Vapi stayed quiet; no vendor reached the approval-ready cancellation threshold.",
+    "headline": "Weekly refresh: core Portfolio subscriptions remain active/readable; Read AI and ElevenLabs have fresher usage signals; Gamma regressed to access drift; no vendor reached the approval-ready cancellation threshold.",
     "nextReviewFocus": [
-      "Restore or rotate Gamma API access and verify dashboard credits before renewal.",
-      "Review ElevenLabs current-cycle zero usage against the next planned campaign before the 2026-06-19 reset.",
-      "Confirm OpenRouter role in the next media/model bakeoff before preparing any deprecation packet.",
-      "Verify Vapi dashboard billing and whether production voice UX should stay enabled.",
-      "Check Printful dashboard order history and decide whether the 2026-04-06 API-visible draft order plus quiet sync log justifies keeping native store paths.",
+      "Restore or rotate Gamma API access and verify dashboard credits/recent report need.",
+      "Verify Vapi dashboard billing and decide whether production voice UX should stay enabled.",
+      "Check Printful dashboard order history and merchandise strategy before changing store paths.",
       "Verify whether production uses Resend or Gmail/n8n as the real outbound channel.",
       "Check Pinecone billing/API traffic against Supabase/local RAG usage.",
       "Restore or replace Calendly API access and rerun event-type usage checks.",
-      "Resolve Gemini/Google AI project/key status before relying on image/social workflows.",
-      "Check HeyGen dashboard quota/billing because voice catalog access does not prove active paid usage.",
-      "Verify Read AI recency because the connector was readable but returned no June 1-3 meetings.",
-      "Verify Anthropic billing and Claude/API transition state now that API model listing remains readable.",
-      "Continue the Apify actor-level replacement bakeoff by pausing weak surfaces before account-level changes.",
+      "Verify Gemini/Google AI billing/project status while model access remains readable.",
+      "Check HeyGen dashboard quota/billing because catalog access does not prove active paid usage.",
+      "Verify Anthropic billing and Claude/API transition state now that API listing remains readable.",
+      "Review ElevenLabs 802-character usage before the 2026-06-19 reset.",
+      "Continue tracking OpenRouter zero-usage evidence and confirm whether it still has a bakeoff or n8n role.",
+      "Continue the Apify actor-level replacement bakeoff before any account-level decision.",
       "Keep BuiltWith active during the outreach ramp and judge it only against lead-prep and conversion evidence.",
-      "For Fireflies, verify billing only if dashboard or receipt evidence suggests the canceled plan was restarted."
+      "Keep Fireflies out of the active queue unless new paid-plan evidence appears."
     ]
   },
   "buckets": {
@@ -399,16 +409,15 @@
       "Vercel",
       "Stripe",
       "OpenAI",
-      "Gamma",
       "HeyGen",
       "Read.ai",
       "Slack",
       "Gmail/n8n email",
       "Apify",
-      "Calendly",
       "Anthropic",
       "Google Cloud",
-      "Hunter.io"
+      "Hunter.io",
+      "Gemini / Google AI"
     ],
     "watch": [
       "BuiltWith",
@@ -417,19 +426,27 @@
       "Anthropic",
       "Vapi",
       "Apify",
+      "HeyGen",
       "Gamma",
-      "HeyGen"
+      "Pinecone",
+      "Read.ai",
+      "Printful",
+      "Resend",
+      "Calendly",
+      "HeyGen quota/billing",
+      "Anthropic billing transition"
     ],
     "unresolved": [
       "Printful",
       "Resend",
       "Pinecone",
       "Calendly auth",
-      "Gemini auth",
       "Figma/Paper/Excalidraw/Canva billing",
       "HeyGen dashboard quota/billing",
+      "Anthropic subscription transition",
       "Gamma dashboard credits/usage",
-      "Anthropic subscription transition"
+      "Gemini / Google AI billing",
+      "Gamma API access"
     ],
     "resolvedCanceled": [
       "Fireflies.ai"
@@ -454,7 +471,7 @@
       "name": "Vapi",
       "status": "watch",
       "statusColor": "yellow",
-      "billingSignal": "Dashboard billing still needs verification; VAPI_PRIVATE_KEY was present and the 2026-06-03 default call sample returned HTTP 200 with zero calls again.",
+      "billingSignal": "Dashboard billing still needs verification; VAPI_PRIVATE_KEY was present and the 2026-06-14 default calls sample returned HTTP 200 with zero calls.",
       "usageSignal": "No meaningful current Vapi usage appeared again; local references remain, including optional website voice paths.",
       "portfolioDependency": "Voice/audit experience risk if production voice UX is enabled.",
       "recommendation": "Investigate billing and intended voice UX; prepare a deprecation packet only if dashboard spend exists and voice UX is not needed.",
@@ -471,11 +488,11 @@
       "name": "BuiltWith",
       "status": "watch",
       "statusColor": "yellow",
-      "billingSignal": "Receipt-backed spend remains the largest watch item, but Vambah confirmed BuiltWith should stay active during the outreach/client-volume ramp.",
-      "usageSignal": "Portfolio still stores website tech-stack enrichment fields in outreach/admin flows; usefulness depends on lead-prep, implementation-strategy, proposal, and conversion evidence.",
+      "billingSignal": "Standing decision keeps BuiltWith active/watch during the outreach/client-volume ramp; historical receipts made it the largest known monthly line item.",
+      "usageSignal": "No fresh usage probe in this run; judge against lead-prep, implementation strategy, proposal quality, and conversion evidence when the ramp has enough volume.",
       "portfolioDependency": "Outreach and client-preparation enrichment may depend on stack data during ramp.",
       "recommendation": "Keep active during outreach ramp; reassess only after enough sales evidence exists.",
-      "nextAction": "Keep collecting sales-prep and proposal-quality evidence before judging BuiltWith.",
+      "nextAction": "Keep active during outreach ramp and collect outcome evidence.",
       "decisionRequired": false,
       "links": [
         {
@@ -488,11 +505,11 @@
       "name": "Fireflies.ai",
       "status": "resolved_canceled",
       "statusColor": "green",
-      "billingSignal": "No new paid-plan evidence found on 2026-06-03; standing decision remains canceled per Vambah confirmation on 2026-05-01.",
-      "usageSignal": "Any old transcript/Slack residue is historical only unless new billing or dashboard evidence appears.",
+      "billingSignal": "Fireflies remains resolved canceled per Vambah confirmation on 2026-05-01; no new paid-plan evidence found in this run.",
+      "usageSignal": "Historical only; keep out of active cancellation queue unless restarted.",
       "portfolioDependency": "No active Portfolio dependency identified.",
       "recommendation": "Keep out of active cancellation queue unless new billing or dashboard evidence shows the paid plan restarted.",
-      "nextAction": "Do not reopen Fireflies unless new paid-plan evidence appears.",
+      "nextAction": "Verify only if new receipt or dashboard evidence appears.",
       "decisionRequired": false,
       "links": [
         {
@@ -505,11 +522,11 @@
       "name": "Vercel",
       "status": "keep",
       "statusColor": "green",
-      "billingSignal": "Vercel CLI remained authenticated as vsillah on 2026-06-03; subscription cost remains receipt-backed from prior budget snapshot.",
-      "usageSignal": "CLI JSON listings returned READY same-day deployments for both portfolio and portfolio-staging on 2026-06-03.",
+      "billingSignal": "Vercel CLI remained authenticated as vsillah and listed portfolio plus portfolio-staging deployment URLs on 2026-06-14.",
+      "usageSignal": "Active hosting/deployment surface with current Portfolio and staging deployment URLs.",
       "portfolioDependency": "Core hosting, previews, production, and staging verification.",
       "recommendation": "Keep; hosting is active and high-risk to change.",
-      "nextAction": "Keep hosting; continue deployment health checks through the normal Portfolio release workflow.",
+      "nextAction": "Keep; verify both deployment contexts during integration captain work.",
       "decisionRequired": false,
       "links": [
         {
@@ -522,11 +539,11 @@
       "name": "Printful",
       "status": "unresolved",
       "statusColor": "yellow",
-      "billingSignal": "Printful API remained readable on 2026-06-03 and returned one sampled draft order from 2026-04-06; dashboard billing/store status still needs verification.",
-      "usageSignal": "Both sampled Supabase printful_sync_log tables remain empty; native store code references remain.",
+      "billingSignal": "Printful API remained readable on 2026-06-14 and returned one sampled draft order from 2026-04-06; dashboard billing/order status still needs review.",
+      "usageSignal": "Supabase printful_sync_log remains empty in sampled projects.",
       "portfolioDependency": "Merchandise/order fulfillment if the store strategy is active.",
       "recommendation": "Investigate dashboard order history and merchandise strategy before any deprecation decision.",
-      "nextAction": "Check Printful dashboard order/store status and decide whether merchandise paths should remain first-class.",
+      "nextAction": "Check Printful dashboard order history and store strategy before any deprecation packet.",
       "decisionRequired": true,
       "links": [
         {
@@ -539,11 +556,11 @@
       "name": "Resend",
       "status": "unresolved",
       "statusColor": "yellow",
-      "billingSignal": "RESEND_API_KEY remained absent locally on 2026-06-03; package/env/webhook references remain.",
-      "usageSignal": "Production usage remains unresolved because local absence does not prove Vercel/runtime absence.",
+      "billingSignal": "RESEND_API_KEY remains absent locally on 2026-06-14; production env and billing are not verified.",
+      "usageSignal": "Resend package, env template, and webhook route remain in repo.",
       "portfolioDependency": "Transactional email deliverability if Resend is enabled in production.",
       "recommendation": "Verify production env and billing before removing Resend paths.",
-      "nextAction": "Check Vercel production env and Resend dashboard billing/usage.",
+      "nextAction": "Verify production env/billing and whether Gmail/n8n is the real outbound channel.",
       "decisionRequired": true,
       "links": [
         {
@@ -556,11 +573,11 @@
       "name": "Pinecone",
       "status": "unresolved",
       "statusColor": "yellow",
-      "billingSignal": "Pinecone API was readable on 2026-06-03 and listed one ready serverless publications index in aws/us-east-1.",
-      "usageSignal": "Index existence is confirmed; query traffic and billing remain unresolved.",
+      "billingSignal": "Pinecone listed one ready serverless publications index on 2026-06-14; billing/traffic remains unresolved.",
+      "usageSignal": "Vector/RAG references remain configured in repo and n8n exports.",
       "portfolioDependency": "Publication/RAG search path if Pinecone remains the live vector store.",
       "recommendation": "Investigate billing/API traffic before any replacement with Supabase or local RAG.",
-      "nextAction": "Compare Pinecone dashboard traffic with Supabase/local RAG usage.",
+      "nextAction": "Check dashboard/API traffic before replacing with Supabase/local RAG.",
       "decisionRequired": true,
       "links": [
         {
@@ -573,11 +590,11 @@
       "name": "Apify",
       "status": "keep",
       "statusColor": "green",
-      "billingSignal": "Apify API was readable on 2026-06-03 and latest sampled actor runs included same-day successful runs with small sampled usage costs.",
-      "usageSignal": "Account-level activity is fresh; actor-level replacement work should target weak/no-output surfaces instead of account cancellation.",
+      "billingSignal": "Apify API returned sampled actor runs through 2026-06-10, with low sampled usage and mixed succeeded/failed outcomes.",
+      "usageSignal": "Account active; actor-level bakeoff remains the right optimization path.",
       "portfolioDependency": "Lead, social listening, and evidence scraping workflows remain wired through n8n and repo scripts.",
       "recommendation": "Keep the account active; continue the actor-level bakeoff and pause or replace weak actor surfaces.",
-      "nextAction": "Use the bakeoff to decide actor-by-actor replacements before any account-level change.",
+      "nextAction": "Continue actor-level replacement bakeoff before account-level changes.",
       "decisionRequired": false,
       "links": [
         {
@@ -590,11 +607,11 @@
       "name": "Hunter.io",
       "status": "keep",
       "statusColor": "green",
-      "billingSignal": "Hunter API remained readable on 2026-06-02 and reported Free plan with 50 used calls and 75 available.",
-      "usageSignal": "Lead enrichment references remain; no paid-plan cancellation target was found.",
+      "billingSignal": "Hunter account remained readable on 2026-06-13 on Free with 0 sampled used calls and 75 available.",
+      "usageSignal": "Not a paid cancellation target in sampled evidence.",
       "portfolioDependency": "Optional lead/contact enrichment only.",
       "recommendation": "Keep/watch; not a paid cancellation target unless paid-plan evidence appears.",
-      "nextAction": "Keep as free/watch; revisit only if paid receipts or active replacement work appear.",
+      "nextAction": "Keep/free-watch.",
       "decisionRequired": false,
       "links": [
         {
@@ -607,11 +624,11 @@
       "name": "OpenRouter",
       "status": "watch",
       "statusColor": "yellow",
-      "billingSignal": "OpenRouter key was readable on 2026-06-03 and still reports usage 0.",
-      "usageSignal": "No meaningful current OpenRouter usage appeared again; model-routing references remain optional/bakeoff-oriented.",
+      "billingSignal": "OpenRouter key endpoint remained readable with current-key usage 0 on 2026-06-14.",
+      "usageSignal": "Consecutive zero-usage evidence; active spend and remaining bakeoff role are not confirmed.",
       "portfolioDependency": "Potential model-router or bakeoff fallback; no current usage signal from the sampled key.",
       "recommendation": "Watch; prepare deprecation only after spend, dependency, and bakeoff role are confirmed.",
-      "nextAction": "Confirm whether OpenRouter has a remaining role in media/model bakeoffs.",
+      "nextAction": "Confirm spend and bakeoff role before deprecation.",
       "decisionRequired": true,
       "links": [
         {
@@ -624,11 +641,11 @@
       "name": "ElevenLabs",
       "status": "watch",
       "statusColor": "yellow",
-      "billingSignal": "Creator subscription remained readable on 2026-06-03 with 0 of 246,034 characters used before the 2026-06-19 reset.",
-      "usageSignal": "Current reset cycle remains quiet while audio/social workflow references remain.",
+      "billingSignal": "ElevenLabs Creator subscription remained readable on 2026-06-14 with 802 of 246,034 characters used before the 2026-06-19 reset.",
+      "usageSignal": "Low current-cycle usage; no longer zero-use.",
       "portfolioDependency": "Voiceover/audio generation for social content and media campaigns.",
       "recommendation": "Watch through the next campaign decision; cancellation needs dashboard spend and replacement-path confirmation.",
-      "nextAction": "Compare upcoming audio needs against renewal timing before the 2026-06-19 reset.",
+      "nextAction": "Review planned voice/audio campaign need before reset.",
       "decisionRequired": true,
       "links": [
         {
@@ -646,12 +663,12 @@
         }
       ],
       "status": "watch",
-      "statusColor": "yellow",
-      "billingSignal": "Read AI remains receipt-backed and connector-readable; the connector returned six meetings in the 2026-05-01 through 2026-06-03 window.",
-      "usageSignal": "Latest returned meeting was 2026-05-29 and no June 1-3 meetings were returned in this run; keep but verify recency before renewal.",
+      "statusColor": "green",
+      "billingSignal": "Read AI connector remained readable on 2026-06-14 with seven meeting metadata records in the May 1-June 14 window; paid plan status still needs dashboard/receipt verification.",
+      "usageSignal": "Latest meeting metadata remained 2026-06-11; no raw meeting content is stored in the tracker.",
       "portfolioDependency": "Meeting intelligence and transcript workflows remain useful for client/project work when meetings are active.",
-      "recommendation": "Keep/watch; verify dashboard recency and whether upcoming meeting workflows still need Read AI.",
-      "nextAction": "Check Read AI dashboard recency and keep only if meeting-capture workflow remains active.",
+      "recommendation": "Keep/watch; meeting memory value remains active enough, but plan fit should be checked against actual meeting volume.",
+      "nextAction": "Check plan fit only if meeting volume drops or receipt pressure increases.",
       "decisionRequired": true
     },
     {
@@ -664,11 +681,11 @@
       ],
       "status": "keep",
       "statusColor": "yellow",
-      "billingSignal": "Calendly API still returned 401 on 2026-06-03; receipt-backed Standard plan remains in the budget snapshot.",
-      "usageSignal": "Scheduling links, tests, and n8n booking workflows remain configured, but API usage could not be verified.",
+      "billingSignal": "Calendly API still returned HTTP 401 unauthenticated on 2026-06-14; billing status unknown.",
+      "usageSignal": "Scheduling links and n8n Calendly workflows remain configured.",
       "portfolioDependency": "Discovery, onboarding, kickoff, progress, renewal, and delivery scheduling links.",
       "recommendation": "Refresh token or verify dashboard usage; keep until scheduling replacement is decided.",
-      "nextAction": "Restore Calendly API access and rerun event-type usage checks.",
+      "nextAction": "Restore token or verify dashboard usage before any provider decision.",
       "decisionRequired": true
     },
     {
@@ -679,13 +696,13 @@
           "href": "https://github.com/vsillah/Portfolio/blob/main/docs/subscription-cancellation-audit.md"
         }
       ],
-      "status": "unresolved",
-      "statusColor": "yellow",
-      "billingSignal": "Gemini/Google AI model-list check still returned 403 on 2026-06-03; Google Cloud spend remains low and separate in the budget snapshot.",
-      "usageSignal": "Image/social workflow references remain, but project/key readiness is unresolved.",
+      "status": "watch",
+      "statusColor": "green",
+      "billingSignal": "Gemini model listing remained readable on 2026-06-14 with HTTP 200 and 50 models; billing/project status still needs verification.",
+      "usageSignal": "Google AI/Gemini workflow references remain in repo and n8n exports.",
       "portfolioDependency": "Gemini/image generation and RAG chatbot experiments if still active.",
-      "recommendation": "Resolve key/project status before relying on or deprecating Gemini workflows.",
-      "nextAction": "Check Google AI Studio/Cloud project permissions and billing association.",
+      "recommendation": "Verify billing/project status and workflow usage before relying on or deprecating Gemini workflows.",
+      "nextAction": "Verify billing/project status while model access remains readable.",
       "decisionRequired": true
     },
     {
@@ -697,19 +714,19 @@
         }
       ],
       "status": "watch",
-      "statusColor": "yellow",
-      "billingSignal": "Anthropic API model listing remained readable on 2026-06-03 with 10 models; Claude Max billing transition still needs receipt/dashboard confirmation.",
-      "usageSignal": "Anthropic remains wired into model dispatch and n8n/model workflows.",
+      "statusColor": "green",
+      "billingSignal": "Anthropic model listing remained readable with 11 models on 2026-06-14; billing transition still needs receipt/dashboard verification.",
+      "usageSignal": "Model provider path remains configured in app/n8n context.",
       "portfolioDependency": "LLM fallback/evaluation paths and any Claude Max workflow still in use.",
       "recommendation": "Watch billing transition; keep API path until replacement and spend are confirmed.",
-      "nextAction": "Verify whether Claude Max subscription spend actually drops next cycle and whether API spend is separate.",
+      "nextAction": "Verify billing and Claude/API transition state.",
       "decisionRequired": true
     },
     {
       "name": "Figma / Paper / Excalidraw / Canva",
       "status": "unresolved",
       "statusColor": "yellow",
-      "billingSignal": "No fresh billing evidence was found on 2026-05-31; repo/workflow-adjacent references remain only.",
+      "billingSignal": "No fresh billing evidence was found on 2026-06-14; repo/workflow-adjacent references remain only.",
       "usageSignal": "Design and diagram assets exist locally, but no current paid dashboard signal was gathered in this run.",
       "portfolioDependency": "Design artifacts, diagrams, and visual content workflows if active outside repo code.",
       "recommendation": "Investigate only if receipts, dashboard evidence, or active design-production needs appear.",
@@ -730,13 +747,13 @@
           "href": "https://github.com/vsillah/Portfolio/blob/main/docs/subscription-cancellation-audit.md"
         }
       ],
-      "status": "unresolved",
+      "status": "watch",
       "statusColor": "yellow",
-      "billingSignal": "Gamma Pro remains receipt-backed, but the 2026-06-03 API check returned HTTP 401 invalid/expired token after prior readable checks.",
-      "usageSignal": "DB report rows remain quiet since 2026-05-02; report/deck code paths remain wired.",
+      "billingSignal": "Gamma /v1.0/themes regressed to HTTP 401 on 2026-06-14 after the June 13 recovery; dashboard credits/billing still need verification.",
+      "usageSignal": "Gamma report rows remain quiet since 2026-05-02, and routes/docs still reference Gamma.",
       "portfolioDependency": "Deck/report generation workflows may still depend on Gamma while Codex/PPTX alternatives are compared.",
-      "recommendation": "Investigate key, dashboard billing, and credit usage before renewal; do not cancel from API auth failure alone.",
-      "nextAction": "Restore/rotate Gamma API access and verify dashboard credits plus recent report usage.",
+      "recommendation": "Investigate dashboard credits/key status plus recent report need before renewal.",
+      "nextAction": "Restore or rotate API access and verify dashboard credits/recent report need.",
       "decisionRequired": true
     },
     {
@@ -748,12 +765,12 @@
         }
       ],
       "status": "keep",
-      "statusColor": "yellow",
-      "billingSignal": "HeyGen receipt remains active from prior budget snapshot; voice catalog was readable on 2026-06-03 with 2348 voices.",
-      "usageSignal": "Voice catalog access proves API readability, while campaign usage and avatar quota still need dashboard verification.",
+      "statusColor": "green",
+      "billingSignal": "HeyGen voices and avatars were both readable on 2026-06-14: 2347 voices and 1289 avatars; quota/billing still needs dashboard verification.",
+      "usageSignal": "Video/avatar campaign surfaces remain configured.",
       "portfolioDependency": "Avatar video generation and media campaign workflows.",
       "recommendation": "Keep/watch; verify quota and active video campaign need before renewal.",
-      "nextAction": "Check HeyGen dashboard quota/billing and retry avatar/template evidence.",
+      "nextAction": "Verify quota and active video campaign need before renewal.",
       "decisionRequired": true
     }
   ]

--- a/lib/subscription-status.test.ts
+++ b/lib/subscription-status.test.ts
@@ -11,7 +11,7 @@ describe('subscription status budget queries', () => {
     expect(registry.budget?.lineItems.map((item) => item.vendor)).toEqual(
       expect.arrayContaining(['Gamma', 'Apify', 'OpenAI / ChatGPT Pro'])
     )
-    expect(registry.latestMonitorArtifact).toBe('/docs/subscription-monitor-runs/2026-06-03.md')
+    expect(registry.latestMonitorArtifact).toBe('/docs/subscription-monitor-runs/2026-06-15.md')
     expect(registry.monitorRunArtifactPattern).toBe('/docs/subscription-monitor-runs/YYYY-MM-DD.md')
   })
 


### PR DESCRIPTION
## Summary
- Add subscription monitor evidence artifacts for June 5 through June 15, 2026.
- Refresh the subscription cancellation audit and machine-readable subscription status snapshot.
- Update the subscription status test expectation to the latest monitor artifact.

## Validation
- `npm test -- lib/subscription-status.test.ts`
- No live subscription/vendor dashboard smoke was run in this split lane.

## Integration Notes
- Docs/evidence-only lane; no migration or env changes required.
- Vercel – portfolio: not checked for this draft PR.
- Vercel – portfolio-staging: not checked for this draft PR.
