### PR TITLE
feat: refine Mark client dashboard presentation

### DIFF
--- a/app/client/dashboard/[token]/page.tsx
+++ b/app/client/dashboard/[token]/page.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback, useRef } from 'react'
 import { useParams } from 'next/navigation'
-import { Loader2 } from 'lucide-react'
+import { Check, Copy, Loader2 } from 'lucide-react'
 import DashboardStatCards from '@/components/client-dashboard/DashboardStatCards'
 import ScoreRadarChart from '@/components/client-dashboard/ScoreRadarChart'
 import ConfidenceRadar from '@/components/client-dashboard/ConfidenceRadar'
@@ -12,7 +12,6 @@ import GapAnalysisPanel from '@/components/client-dashboard/GapAnalysisPanel'
 import TaskChecklist from '@/components/client-dashboard/TaskChecklist'
 import MilestoneTimeline from '@/components/client-dashboard/MilestoneTimeline'
 import AssessmentDetails from '@/components/client-dashboard/AssessmentDetails'
-import QuickOverview from '@/components/client-dashboard/QuickOverview'
 import AccelerationCards from '@/components/client-dashboard/AccelerationCards'
 import CampaignProgressSection from '@/components/client-dashboard/CampaignProgressSection'
 import DocumentsSection from '@/components/client-dashboard/DocumentsSection'
@@ -36,6 +35,8 @@ export default function ClientDashboardPage() {
   const [recommendations, setRecommendations] = useState<AccelerationRecommendation[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [copiedDashboardUrl, setCopiedDashboardUrl] = useState(false)
+  const copyResetTimeoutRef = useRef<number | null>(null)
 
   // Fetch dashboard data
   useEffect(() => {
@@ -99,6 +100,34 @@ export default function ClientDashboardPage() {
   // Recommendation dismiss handler
   const handleDismissRec = useCallback((recId: string) => {
     setRecommendations((prev) => prev.filter((r) => r.id !== recId))
+  }, [])
+
+  const handleCopyDashboardUrl = useCallback(async () => {
+    if (typeof window === 'undefined') return
+
+    try {
+      await navigator.clipboard.writeText(window.location.href)
+      setCopiedDashboardUrl(true)
+
+      if (copyResetTimeoutRef.current) {
+        window.clearTimeout(copyResetTimeoutRef.current)
+      }
+
+      copyResetTimeoutRef.current = window.setTimeout(() => {
+        setCopiedDashboardUrl(false)
+        copyResetTimeoutRef.current = null
+      }, 2000)
+    } catch (copyError) {
+      console.error('Failed to copy dashboard URL', copyError)
+    }
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      if (copyResetTimeoutRef.current) {
+        window.clearTimeout(copyResetTimeoutRef.current)
+      }
+    }
   }, [])
 
   // Loading state
@@ -171,7 +200,10 @@ export default function ClientDashboardPage() {
             <ScoreRadarChart scores={scores.categoryScores} />
             <div className="lg:col-span-2">
               {assessment ? (
-                <AssessmentDetails assessment={assessment} valueReport={null} />
+              <AssessmentDetails
+                assessment={assessment}
+                valueReport={null}
+              />
               ) : (
                 <div className="rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-5">
                   <p className="text-platinum-white/55 text-sm">No assessment data available yet.</p>
@@ -249,11 +281,24 @@ export default function ClientDashboardPage() {
               <p className="truncate text-xs text-platinum-white/55">{project.project_name}</p>
             </div>
           </div>
-          <div className="shrink-0 text-right">
-            <p className="text-sm font-medium text-platinum-white">{project.client_name}</p>
-            {project.client_company && (
-              <p className="text-xs text-radiant-gold/75">{project.client_company}</p>
-            )}
+          <div className="shrink-0">
+            <div className="mb-2 flex justify-end">
+              <button
+                type="button"
+                onClick={handleCopyDashboardUrl}
+                className="inline-flex items-center gap-2 rounded-md border border-radiant-gold/25 bg-silicon-slate/45 px-3 py-1.5 text-xs font-medium text-radiant-gold transition hover:border-radiant-gold/50 hover:bg-silicon-slate/60"
+                aria-label="Copy dashboard URL"
+              >
+                {copiedDashboardUrl ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+                <span>{copiedDashboardUrl ? 'Copied' : 'Copy URL'}</span>
+              </button>
+            </div>
+            <div className="text-right">
+              <p className="text-sm font-medium text-platinum-white">{project.client_name}</p>
+              {project.client_company && (
+                <p className="text-xs text-radiant-gold/75">{project.client_company}</p>
+              )}
+            </div>
           </div>
         </div>
       </header>
@@ -269,14 +314,32 @@ export default function ClientDashboardPage() {
           highPriorityRemaining={highPriorityRemaining}
         />
 
-        {/* Row 2: Radar + Assessment + Quick Overview */}
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          <div className="lg:col-span-1">
-            <ScoreRadarChart scores={scores.categoryScores} />
-          </div>
-          <div className="lg:col-span-1">
+        {/* Row 2: Radar + Trajectory */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <ScoreRadarChart scores={scores.categoryScores} />
+          {snapshots.length > 0 ? (
+            <TrajectoryChart token={token} />
+          ) : (
+            <div className="rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-5">
+              <h3 className="mb-2 text-sm font-medium uppercase tracking-wider text-radiant-gold">
+                Score Trajectory
+              </h3>
+              <p className="text-sm text-platinum-white/55">
+                Score trajectory will appear once milestone-based projections are available.
+              </p>
+            </div>
+          )}
+        </div>
+
+        {/* Row 3: Assessment */}
+        <div className="grid grid-cols-1 gap-6">
+          <div>
             {assessment ? (
-              <AssessmentDetails assessment={assessment} valueReport={valueReport} />
+              <AssessmentDetails
+                assessment={assessment}
+                valueReport={valueReport}
+                assessmentDate={project.project_start_date}
+              />
             ) : (
               <div className="rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-5">
                 <h3 className="text-sm font-medium text-radiant-gold uppercase tracking-wider mb-2">
@@ -288,16 +351,9 @@ export default function ClientDashboardPage() {
               </div>
             )}
           </div>
-          <div className="lg:col-span-1">
-            <QuickOverview
-              assessmentDate={project.project_start_date}
-              activeTasks={activeTasks}
-              nextMeeting={nextMeeting}
-            />
-          </div>
         </div>
 
-        {/* Row 3: Reports & Presentations (only when reports exist) */}
+        {/* Row 4: Reports & Presentations (only when reports exist) */}
         {((valueReports && valueReports.length > 0) || (gammaReports && gammaReports.length > 0)) && (
           <ReportsSection
             valueReports={valueReports || []}
@@ -309,7 +365,7 @@ export default function ClientDashboardPage() {
           <AiOpsRoadmapSection roadmap={aiOpsRoadmap} />
         )}
 
-        {/* Row 4: Documents & Time Investment */}
+        {/* Row 5: Documents & Time Investment */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
           <DocumentsSection documents={documents || []} />
           <TimeTrackingSection
@@ -322,10 +378,10 @@ export default function ClientDashboardPage() {
           <BuildEvidenceInvestmentSection buildEvidence={buildEvidence} />
         )}
 
-        {/* Row 5: Gap Analysis */}
+        {/* Row 6: Gap Analysis */}
         <GapAnalysisPanel gaps={gapAnalysis} />
 
-        {/* Row 4: Acceleration Opportunities */}
+        {/* Row 7: Acceleration Opportunities */}
         <AccelerationCards
           recommendations={recommendations}
           token={token}
@@ -335,7 +391,7 @@ export default function ClientDashboardPage() {
         {/* Campaign Progress */}
         <CampaignProgressSection clientEmail={project.client_email} />
 
-        {/* Row 5: Task Checklist */}
+        {/* Row 8: Task Checklist */}
         {tasks.length > 0 && (
           <TaskChecklist
             tasks={tasks}
@@ -344,16 +400,11 @@ export default function ClientDashboardPage() {
           />
         )}
 
-        {/* Row 6: Milestones */}
+        {/* Row 9: Milestones */}
         <MilestoneTimeline milestones={milestones as []} />
 
-        {/* Row 7: Meeting History */}
+        {/* Row 10: Meeting History */}
         <MeetingHistory token={token} />
-
-        {/* Row 8: Trajectory */}
-        {snapshots.length > 0 && (
-          <TrajectoryChart token={token} />
-        )}
       </main>
 
       {/* Footer */}

--- a/components/client-dashboard/AssessmentDetails.tsx
+++ b/components/client-dashboard/AssessmentDetails.tsx
@@ -19,6 +19,7 @@ interface AssessmentDetailsProps {
     total_annual_value: number | null
     value_statements: unknown[]
   } | null
+  assessmentDate?: string | null
 }
 
 interface Section {
@@ -28,8 +29,22 @@ interface Section {
   content: string | null
 }
 
-export default function AssessmentDetails({ assessment, valueReport }: AssessmentDetailsProps) {
+function formatAssessmentDate(value: string | null | undefined): string | null {
+  if (!value) return null
+
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return null
+
+  return parsed.toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+export default function AssessmentDetails({ assessment, valueReport, assessmentDate }: AssessmentDetailsProps) {
   const [expandedSection, setExpandedSection] = useState<string | null>('summary')
+  const formattedAssessmentDate = formatAssessmentDate(assessmentDate)
 
   // Build sections from assessment data
   const sections: Section[] = []
@@ -86,9 +101,19 @@ export default function AssessmentDetails({ assessment, valueReport }: Assessmen
 
   return (
     <div className="rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-5">
-      <h3 className="text-sm font-medium text-radiant-gold uppercase tracking-wider mb-4">
-        Your Assessment Details
-      </h3>
+      <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <h3 className="text-sm font-medium text-radiant-gold uppercase tracking-wider">
+          Your Assessment Details
+        </h3>
+        {formattedAssessmentDate && (
+          <div className="text-left sm:text-right">
+            <p className="text-[10px] uppercase tracking-[0.16em] text-platinum-white/40">
+              Assessment Date
+            </p>
+            <p className="text-xs text-platinum-white/72">{formattedAssessmentDate}</p>
+          </div>
+        )}
+      </div>
       <div className="space-y-2">
         {sections.map((section) => {
           const isExpanded = expandedSection === section.key

--- a/components/client-dashboard/BuildEvidenceInvestmentSection.test.tsx
+++ b/components/client-dashboard/BuildEvidenceInvestmentSection.test.tsx
@@ -74,18 +74,24 @@ describe('BuildEvidenceInvestmentSection', () => {
     expect(screen.getByText('Build Evidence & Investment')).toBeInTheDocument()
     expect(screen.getByText('Direct ReversR workspace evidence')).toBeInTheDocument()
     expect(screen.getByText('149')).toBeInTheDocument()
-    expect(screen.getByText('Rate needed')).toBeInTheDocument()
+    expect(screen.getByText('283.7M total attributed tokens')).toBeInTheDocument()
     expect(screen.getByText('$52,500-$83,125 replacement-cost range')).toBeInTheDocument()
     expect(screen.getAllByText(/not a time sheet/i)).toHaveLength(2)
+    expect(screen.getByRole('button', { name: /evidence scope:/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /hourly lens:/i })).toBeInTheDocument()
   })
 
   it('updates subscription allocation and proposal translation locally', () => {
     render(<BuildEvidenceInvestmentSection buildEvidence={evidence} />)
 
+    fireEvent.click(screen.getByRole('button', { name: /subscription/i }))
     fireEvent.change(screen.getByLabelText('Monthly AI spend'), {
       target: { value: '200' },
     })
-    expect(screen.getByText('$35 allocated by usage share')).toBeInTheDocument()
+    expect(screen.getAllByText('$35 allocated by usage share')).toHaveLength(2)
+
+    fireEvent.click(screen.getByRole('button', { name: /^api$/i }))
+    expect(screen.getAllByText('Rate needed')).toHaveLength(2)
 
     fireEvent.click(screen.getByRole('button', { name: /proposal/i }))
     expect(screen.getByText('171 implied benchmark hours')).toBeInTheDocument()

--- a/components/client-dashboard/BuildEvidenceInvestmentSection.tsx
+++ b/components/client-dashboard/BuildEvidenceInvestmentSection.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useMemo, useState } from 'react'
-import { Calculator, Code2, Cpu, DollarSign, Gauge, GitCommit, ShieldCheck } from 'lucide-react'
+import { Calculator, Code2, Cpu, DollarSign, Gauge, GitCommit, Info, ShieldCheck } from 'lucide-react'
 import type { ClientBuildEvidence } from '@/lib/client-build-evidence'
 
 interface Props {
@@ -9,6 +9,7 @@ interface Props {
 }
 
 type CalculatorMode = 'rate' | 'hours' | 'proposal'
+type TokenMode = 'usage' | 'api' | 'subscription'
 
 function formatNumber(value: number): string {
   return new Intl.NumberFormat('en-US').format(Math.round(value))
@@ -33,9 +34,31 @@ function safeNumber(value: number): number {
   return Number.isFinite(value) && value >= 0 ? value : 0
 }
 
+function getClientNoteLabel(note: string, index: number): string {
+  if (/supporting evidence/i.test(note)) return 'Evidence scope'
+  if (/comparison lens/i.test(note)) return 'Hourly lens'
+  if (/store-console\/review gate/i.test(note)) return 'Release gate note'
+  return `Note ${index + 1}`
+}
+
+function NoteTooltip({ label, body }: { label: string; body: string }) {
+  return (
+    <button
+      type="button"
+      title={body}
+      className="group relative inline-flex items-center gap-2 rounded-md border border-radiant-gold/15 bg-imperial-navy/50 px-3 py-2 text-xs text-platinum-white/65 transition hover:border-radiant-gold/35 hover:text-platinum-white focus:outline-none focus:ring-2 focus:ring-radiant-gold/45"
+      aria-label={`${label}: ${body}`}
+    >
+      <Info className="h-3.5 w-3.5 text-radiant-gold" />
+      <span>{label}</span>
+    </button>
+  )
+}
+
 export default function BuildEvidenceInvestmentSection({ buildEvidence }: Props) {
   const { repoMetrics, tokenUsage, costSummary, hourlyTranslation, sourceConfidence } = buildEvidence
   const [mode, setMode] = useState<CalculatorMode>('rate')
+  const [tokenMode, setTokenMode] = useState<TokenMode>('usage')
   const [hourlyRate, setHourlyRate] = useState(hourlyTranslation.defaultBenchmarkHourlyRate)
   const [proposalAmount, setProposalAmount] = useState(hourlyTranslation.defaultProposalAmount)
   const [focusedHoursLow, setFocusedHoursLow] = useState(hourlyTranslation.focusedHoursLow)
@@ -79,6 +102,13 @@ export default function BuildEvidenceInvestmentSection({ buildEvidence }: Props)
       : mode === 'hours'
         ? `${formatCurrency(calculated.effectiveHourlyLow)}-${formatCurrency(calculated.effectiveHourlyHigh)} effective hourly lens`
         : `${formatNumber(calculated.impliedHours)} implied benchmark hours`
+
+  const tokenSummary =
+    tokenMode === 'usage'
+      ? `${formatCompact(tokenUsage.totalTokens)} total attributed tokens`
+      : tokenMode === 'api'
+        ? (costSummary.apiEquivalentCostUsd == null ? 'Rate needed' : formatCurrency(costSummary.apiEquivalentCostUsd))
+        : `${formatCurrency(calculated.subscriptionAllocation)} allocated by usage share`
 
   const metricCards = [
     {
@@ -145,50 +175,70 @@ export default function BuildEvidenceInvestmentSection({ buildEvidence }: Props)
       </div>
 
       <div className="grid grid-cols-1 gap-5 lg:grid-cols-3">
-        <div className="rounded-lg border border-radiant-gold/15 bg-imperial-navy/55 p-4 lg:col-span-1">
-          <div className="mb-3 flex items-center gap-2">
-            <Cpu className="h-4 w-4 text-radiant-gold" />
-            <p className="text-xs font-semibold uppercase tracking-wider text-radiant-gold">Token attribution</p>
-          </div>
-          <dl className="space-y-2 text-sm">
-            <div className="flex justify-between gap-3">
-              <dt className="text-platinum-white/45">Sessions</dt>
-              <dd className="font-medium text-platinum-white">{formatNumber(tokenUsage.sessionCount)}</dd>
-            </div>
-            <div className="flex justify-between gap-3">
-              <dt className="text-platinum-white/45">Input tokens</dt>
-              <dd className="font-medium text-platinum-white">{formatCompact(tokenUsage.inputTokens)}</dd>
-            </div>
-            <div className="flex justify-between gap-3">
-              <dt className="text-platinum-white/45">Cached input</dt>
-              <dd className="font-medium text-platinum-white">{formatCompact(tokenUsage.cachedInputTokens)}</dd>
-            </div>
-            <div className="flex justify-between gap-3">
-              <dt className="text-platinum-white/45">Output + reasoning</dt>
-              <dd className="font-medium text-platinum-white">
-                {formatCompact(tokenUsage.outputTokens + tokenUsage.reasoningTokens)}
-              </dd>
-            </div>
-          </dl>
-          <p className="mt-4 rounded-lg border border-radiant-gold/20 bg-radiant-gold/10 p-3 text-xs text-platinum-white/75">
-            {sourceConfidence.sourceSummary}
-          </p>
-        </div>
-
-        <div className="rounded-lg border border-radiant-gold/15 bg-imperial-navy/55 p-4 lg:col-span-1">
+        <div className="rounded-lg border border-radiant-gold/15 bg-imperial-navy/55 p-4 lg:col-span-2">
           <div className="mb-3 flex items-center gap-2">
             <DollarSign className="h-4 w-4 text-radiant-gold" />
-            <p className="text-xs font-semibold uppercase tracking-wider text-radiant-gold">Token cost lens</p>
+            <p className="text-xs font-semibold uppercase tracking-wider text-radiant-gold">Token lens</p>
           </div>
-          <div className="space-y-3">
-            <div className="rounded-lg bg-silicon-slate/45 p-3">
+          <div className="mb-3 grid grid-cols-3 gap-2">
+            {(['usage', 'api', 'subscription'] as TokenMode[]).map((nextMode) => (
+              <button
+                key={nextMode}
+                type="button"
+                onClick={() => setTokenMode(nextMode)}
+                className={`rounded-lg border px-2 py-2 text-xs font-medium capitalize transition-colors ${
+                  tokenMode === nextMode
+                    ? 'border-radiant-gold bg-radiant-gold/20 text-gold-light'
+                    : 'border-radiant-gold/15 bg-silicon-slate/45 text-platinum-white/55 hover:text-platinum-white'
+                }`}
+              >
+                {nextMode}
+              </button>
+            ))}
+          </div>
+          <div className="rounded-lg border border-radiant-gold/18 bg-silicon-slate/45 p-3">
+            <p className="text-lg font-semibold text-platinum-white">{tokenSummary}</p>
+            <p className="mt-1 text-xs text-platinum-white/50">
+              {tokenMode === 'usage'
+                ? sourceConfidence.sourceSummary
+                : tokenMode === 'api'
+                  ? costSummary.pricingSourceLabel
+                  : `${tokenUsage.shareOfComparisonWindowPct.toFixed(2)}% of ${tokenUsage.comparisonWindowLabel}`}
+            </p>
+          </div>
+          {tokenMode === 'usage' && (
+            <dl className="mt-4 grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
+              <div className="rounded-lg bg-imperial-navy/50 p-3">
+                <dt className="text-platinum-white/45">Sessions</dt>
+                <dd className="mt-1 font-medium text-platinum-white">{formatNumber(tokenUsage.sessionCount)}</dd>
+              </div>
+              <div className="rounded-lg bg-imperial-navy/50 p-3">
+                <dt className="text-platinum-white/45">Input tokens</dt>
+                <dd className="mt-1 font-medium text-platinum-white">{formatCompact(tokenUsage.inputTokens)}</dd>
+              </div>
+              <div className="rounded-lg bg-imperial-navy/50 p-3">
+                <dt className="text-platinum-white/45">Cached input</dt>
+                <dd className="mt-1 font-medium text-platinum-white">{formatCompact(tokenUsage.cachedInputTokens)}</dd>
+              </div>
+              <div className="rounded-lg bg-imperial-navy/50 p-3">
+                <dt className="text-platinum-white/45">Output + reasoning</dt>
+                <dd className="mt-1 font-medium text-platinum-white">
+                  {formatCompact(tokenUsage.outputTokens + tokenUsage.reasoningTokens)}
+                </dd>
+              </div>
+            </dl>
+          )}
+          {tokenMode === 'api' && (
+            <div className="mt-4 rounded-lg bg-imperial-navy/50 p-3">
               <p className="text-xs uppercase tracking-wider text-platinum-white/45">API-equivalent estimate</p>
               <p className="mt-1 text-lg font-semibold text-platinum-white">
                 {costSummary.apiEquivalentCostUsd == null ? 'Rate needed' : formatCurrency(costSummary.apiEquivalentCostUsd)}
               </p>
-              <p className="mt-1 text-xs text-platinum-white/45">{costSummary.pricingSourceLabel}</p>
+              <p className="mt-2 text-xs text-platinum-white/45">{costSummary.pricingAssumption}</p>
             </div>
-            <div className="rounded-lg bg-silicon-slate/45 p-3">
+          )}
+          {tokenMode === 'subscription' && (
+            <div className="mt-4 rounded-lg bg-imperial-navy/50 p-3">
               <label className="text-xs uppercase tracking-wider text-platinum-white/45" htmlFor="ai-monthly-spend">
                 Monthly AI spend
               </label>
@@ -207,7 +257,7 @@ export default function BuildEvidenceInvestmentSection({ buildEvidence }: Props)
                 {formatCurrency(calculated.subscriptionAllocation)} allocated by usage share
               </p>
             </div>
-          </div>
+          )}
         </div>
 
         <div className="rounded-lg border border-radiant-gold/15 bg-imperial-navy/55 p-4 lg:col-span-1">
@@ -281,11 +331,9 @@ export default function BuildEvidenceInvestmentSection({ buildEvidence }: Props)
       </div>
 
       {buildEvidence.clientSafeNotes.length > 0 && (
-        <div className="mt-5 grid grid-cols-1 gap-2 md:grid-cols-3">
-          {buildEvidence.clientSafeNotes.map((note) => (
-            <p key={note} className="rounded-lg border border-radiant-gold/15 bg-imperial-navy/50 p-3 text-xs text-platinum-white/60">
-              {note}
-            </p>
+        <div className="mt-5 flex flex-wrap gap-2">
+          {buildEvidence.clientSafeNotes.map((note, index) => (
+            <NoteTooltip key={note} label={getClientNoteLabel(note, index)} body={note} />
           ))}
         </div>
       )}

--- a/components/client-dashboard/MilestoneTimeline.test.tsx
+++ b/components/client-dashboard/MilestoneTimeline.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import MilestoneTimeline from './MilestoneTimeline'
 import type { Milestone } from '@/lib/onboarding-templates'
@@ -55,6 +55,12 @@ describe('MilestoneTimeline', () => {
     ]
 
     render(<MilestoneTimeline milestones={milestones} />)
+
+    expect(screen.getByText('Phase 1')).toBeInTheDocument()
+    expect(screen.getByText('Expand all')).toBeInTheDocument()
+    expect(screen.queryByText('Evidence Trace')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /Distribute the test app/i }))
 
     expect(screen.getByText('Evidence Trace')).toBeInTheDocument()
     expect(screen.getByText('GitHub repository evidence')).toBeInTheDocument()

--- a/components/client-dashboard/MilestoneTimeline.tsx
+++ b/components/client-dashboard/MilestoneTimeline.tsx
@@ -1,7 +1,10 @@
 'use client'
 
+import { useMemo, useState } from 'react'
 import {
   Check,
+  ChevronDown,
+  ChevronRight,
   Clock,
   Circle,
   ExternalLink,
@@ -16,6 +19,12 @@ import type {
 } from '@/lib/onboarding-templates'
 
 interface MilestoneTimelineProps {
+  milestones: Milestone[]
+}
+
+interface PhaseGroup {
+  phase: number
+  title: string
   milestones: Milestone[]
 }
 
@@ -76,6 +85,13 @@ function evidenceStatusLabel(status: MilestoneEvidence['status']) {
     .join(' ')
 }
 
+function milestoneStatusLabel(status: Milestone['status']) {
+  return status
+    .split('_')
+    .map((word) => word[0]?.toUpperCase() + word.slice(1))
+    .join(' ')
+}
+
 function sanitizeClientText(value: string) {
   return value.replace(/\/Users\/[^\s)]+/g, '[private path]')
 }
@@ -117,6 +133,25 @@ function conciseEvidenceStatement(item: MilestoneEvidence) {
   if (item.status === 'pending') return 'Pending evidence'
   if (item.status === 'manual_review') return 'Manual review needed'
   return null
+}
+
+function groupMilestonesByPhase(milestones: Milestone[]): PhaseGroup[] {
+  const groups = new Map<number, Milestone[]>()
+
+  milestones.forEach((milestone) => {
+    const phase = milestone.phase || 1
+    const existing = groups.get(phase) || []
+    existing.push(milestone)
+    groups.set(phase, existing)
+  })
+
+  return Array.from(groups.entries())
+    .sort(([a], [b]) => a - b)
+    .map(([phase, phaseMilestones]) => ({
+      phase,
+      title: `Phase ${phase}`,
+      milestones: phaseMilestones,
+    }))
 }
 
 function AutomationHint({
@@ -162,6 +197,9 @@ function AutomationHint({
 }
 
 export default function MilestoneTimeline({ milestones }: MilestoneTimelineProps) {
+  const [expandedMilestones, setExpandedMilestones] = useState<Set<string>>(new Set())
+  const phaseGroups = useMemo(() => groupMilestonesByPhase(milestones || []), [milestones])
+
   if (!milestones || milestones.length === 0) {
     return (
       <div className="rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-5">
@@ -173,112 +211,181 @@ export default function MilestoneTimeline({ milestones }: MilestoneTimelineProps
     )
   }
 
+  const milestoneIds = milestones.map((milestone, index) => milestone.id || `milestone-${index}`)
+  const allExpanded = milestoneIds.length > 0 && milestoneIds.every((id) => expandedMilestones.has(id))
+
+  function toggleMilestone(id: string) {
+    setExpandedMilestones((current) => {
+      const next = new Set(current)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      return next
+    })
+  }
+
+  function toggleAllMilestones() {
+    setExpandedMilestones(allExpanded ? new Set() : new Set(milestoneIds))
+  }
+
   return (
     <div className="rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-5">
-      <h3 className="text-sm font-medium text-radiant-gold uppercase tracking-wider mb-4">
-        Milestones
-      </h3>
-      <div className="relative">
-        {milestones.map((milestone, index) => {
-          const styles = STATUS_STYLES[milestone.status] || STATUS_STYLES.pending
-          const Icon = styles.icon
-          const isLast = index === milestones.length - 1
-          const evidence = clientVisibleEvidence(milestone)
-
-          return (
-            <div key={milestone.id || index} className="flex gap-4 pb-6 last:pb-0">
-              {/* Timeline dot + line */}
-              <div className="flex flex-col items-center">
-                <div
-                  className={`w-8 h-8 rounded-full border-2 flex items-center justify-center flex-shrink-0 ${styles.dotClass}`}
-                >
-                  <Icon className="w-4 h-4 text-platinum-white" />
-                </div>
-                {!isLast && (
-                  <div className={`w-0.5 flex-1 mt-1 ${styles.lineClass}`} />
-                )}
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <h3 className="text-sm font-medium text-radiant-gold uppercase tracking-wider">
+          Milestones
+        </h3>
+        <button
+          type="button"
+          onClick={toggleAllMilestones}
+          className="rounded border border-radiant-gold/25 bg-imperial-navy/45 px-2.5 py-1.5 text-[11px] font-medium text-radiant-gold transition-colors hover:bg-radiant-gold/10"
+        >
+          {allExpanded ? 'Collapse all' : 'Expand all'}
+        </button>
+      </div>
+      <div className="space-y-7">
+        {phaseGroups.map((group) => (
+          <section key={group.phase}>
+            <div className="mb-4 flex items-center gap-3">
+              <div className="rounded border border-radiant-gold/30 bg-radiant-gold/10 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wider text-radiant-gold">
+                {group.title}
               </div>
+              <div className="h-px flex-1 bg-radiant-gold/15" />
+              <p className="text-[11px] text-platinum-white/45">
+                {group.milestones.length} milestone{group.milestones.length === 1 ? '' : 's'}
+              </p>
+            </div>
+            <div className="relative">
+              {group.milestones.map((milestone, index) => {
+                const globalIndex = milestones.indexOf(milestone)
+                const milestoneId = milestone.id || `milestone-${globalIndex}`
+                const isExpanded = expandedMilestones.has(milestoneId)
+                const styles = STATUS_STYLES[milestone.status] || STATUS_STYLES.pending
+                const Icon = styles.icon
+                const isLast = index === group.milestones.length - 1
+                const evidence = clientVisibleEvidence(milestone)
+                const visibleEvidenceCount = evidence.length
+                const accessCount = evidence.filter((item) => item.status === 'access_needed').length
 
-              {/* Content */}
-              <div className="flex-1 min-w-0 pb-2">
-                <div className="flex items-center gap-2 mb-1">
-                  <span className={`text-sm font-medium ${styles.textClass}`}>
-                    {milestone.title}
-                  </span>
-                  <span className={`text-[10px] px-1.5 py-0.5 rounded ${styles.badgeClass}`}>
-                    Week {milestone.week}
-                  </span>
-                </div>
-                {milestone.target_date && (
-                  <p className="text-[10px] text-platinum-white/40 mt-1">
-                    Target: {new Date(milestone.target_date).toLocaleDateString()}
-                  </p>
-                )}
-                {evidence.length > 0 && (
-                  <div className="mt-3">
-                    <div className="mb-1.5 flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-wider text-radiant-gold/70">
-                      <ShieldCheck className="h-3 w-3" />
-                      Evidence Trace
+                return (
+                  <div key={milestoneId} className="flex gap-4 pb-5 last:pb-0">
+                    <div className="flex flex-col items-center">
+                      <div
+                        className={`w-8 h-8 rounded-full border-2 flex items-center justify-center flex-shrink-0 ${styles.dotClass}`}
+                      >
+                        <Icon className="w-4 h-4 text-platinum-white" />
+                      </div>
+                      {!isLast && (
+                        <div className={`w-0.5 flex-1 mt-1 ${styles.lineClass}`} />
+                      )}
                     </div>
-                    <div className="space-y-1.5">
-                      {evidence.map((item, evidenceIndex) => {
-                        const statusClass =
-                          EVIDENCE_STATUS_STYLES[item.status] || EVIDENCE_STATUS_STYLES.pending
-                        const metrics = knownEvidenceMetrics(item)
-                        const statement = conciseEvidenceStatement(item)
-                        return (
-                          <div
-                            key={item.id || evidenceIndex}
-                            className={`rounded border px-2 py-1.5 ${statusClass}`}
-                          >
-                            <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                              <span className="text-[11px] font-medium">
-                                {item.source_label}
-                              </span>
-                              <span className="text-[10px] opacity-80">
-                                {evidenceStatusLabel(item.status)}
-                              </span>
-                              {item.source_url && (
-                                <a
-                                  href={item.source_url}
-                                  target="_blank"
-                                  rel="noreferrer"
-                                  className="inline-flex items-center gap-1 text-[10px] underline-offset-2 hover:underline"
-                                >
-                                  Source
-                                  <ExternalLink className="h-2.5 w-2.5" />
-                                </a>
-                              )}
-                            </div>
-                            {metrics.length > 0 && (
-                              <div className="mt-2 flex flex-wrap gap-1.5">
-                                {metrics.map((metric) => (
-                                  <span
-                                    key={`${item.id || evidenceIndex}-${metric.label}`}
-                                    className="rounded border border-radiant-gold/20 bg-imperial-navy/45 px-2 py-1 text-[10px] font-medium text-platinum-white/80"
-                                  >
-                                    <span className="text-gold-light">{metric.value}</span>{' '}
-                                    {metric.label}
-                                  </span>
-                                ))}
-                              </div>
+
+                    <div className="flex-1 min-w-0 pb-2">
+                      <button
+                        type="button"
+                        onClick={() => toggleMilestone(milestoneId)}
+                        aria-expanded={isExpanded}
+                        className="flex w-full items-start justify-between gap-3 rounded-lg border border-radiant-gold/10 bg-imperial-navy/35 px-3 py-2 text-left transition-colors hover:bg-radiant-gold/10"
+                      >
+                        <div className="min-w-0">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <span className={`text-sm font-medium ${styles.textClass}`}>
+                              {milestone.title}
+                            </span>
+                            <span className={`text-[10px] px-1.5 py-0.5 rounded ${styles.badgeClass}`}>
+                              Week {milestone.week}
+                            </span>
+                          </div>
+                          <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[10px] text-platinum-white/45">
+                            <span>{milestoneStatusLabel(milestone.status)}</span>
+                            {visibleEvidenceCount > 0 && (
+                              <span>{visibleEvidenceCount} evidence source{visibleEvidenceCount === 1 ? '' : 's'}</span>
                             )}
-                            {statement && (
-                              <p className="mt-1 text-[11px] leading-relaxed opacity-85">
-                                {statement}
-                              </p>
+                            {accessCount > 0 && (
+                              <span className="text-gold-light">{accessCount} connection needed</span>
+                            )}
+                            {milestone.target_date && (
+                              <span>Target: {new Date(milestone.target_date).toLocaleDateString()}</span>
                             )}
                           </div>
-                        )
-                      })}
+                        </div>
+                        {isExpanded ? (
+                          <ChevronDown className="mt-0.5 h-4 w-4 shrink-0 text-radiant-gold" />
+                        ) : (
+                          <ChevronRight className="mt-0.5 h-4 w-4 shrink-0 text-radiant-gold" />
+                        )}
+                      </button>
+                      {isExpanded && evidence.length > 0 && (
+                        <div className="mt-3">
+                          <div className="mb-1.5 flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-wider text-radiant-gold/70">
+                            <ShieldCheck className="h-3 w-3" />
+                            Evidence Trace
+                          </div>
+                          <div className="space-y-1.5">
+                            {evidence.map((item, evidenceIndex) => {
+                              const statusClass =
+                                EVIDENCE_STATUS_STYLES[item.status] || EVIDENCE_STATUS_STYLES.pending
+                              const metrics = knownEvidenceMetrics(item)
+                              const statement = conciseEvidenceStatement(item)
+                              return (
+                                <div
+                                  key={item.id || evidenceIndex}
+                                  className={`rounded border px-2 py-1.5 ${statusClass}`}
+                                >
+                                  <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                                    <span className="text-[11px] font-medium">
+                                      {item.source_label}
+                                    </span>
+                                    <span className="text-[10px] opacity-80">
+                                      {evidenceStatusLabel(item.status)}
+                                    </span>
+                                    {item.source_url && (
+                                      <a
+                                        href={item.source_url}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        className="inline-flex items-center gap-1 text-[10px] underline-offset-2 hover:underline"
+                                      >
+                                        Source
+                                        <ExternalLink className="h-2.5 w-2.5" />
+                                      </a>
+                                    )}
+                                  </div>
+                                  {metrics.length > 0 && (
+                                    <div className="mt-2 flex flex-wrap gap-1.5">
+                                      {metrics.map((metric) => (
+                                        <span
+                                          key={`${item.id || evidenceIndex}-${metric.label}`}
+                                          className="rounded border border-radiant-gold/20 bg-imperial-navy/45 px-2 py-1 text-[10px] font-medium text-platinum-white/80"
+                                        >
+                                          <span className="text-gold-light">{metric.value}</span>{' '}
+                                          {metric.label}
+                                        </span>
+                                      ))}
+                                    </div>
+                                  )}
+                                  {statement && (
+                                    <p className="mt-1 text-[11px] leading-relaxed opacity-85">
+                                      {statement}
+                                    </p>
+                                  )}
+                                </div>
+                              )
+                            })}
+                          </div>
+                        </div>
+                      )}
+                      {isExpanded && (
+                        <AutomationHint automation={milestone.automation} evidence={evidence} />
+                      )}
                     </div>
                   </div>
-                )}
-                <AutomationHint automation={milestone.automation} evidence={evidence} />
-              </div>
+                )
+              })}
             </div>
-          )
-        })}
+          </section>
+        ))}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- collapse milestone presentation and refine phase language in the Mark client dashboard
- move trajectory beside the spider chart, remove the quick overview block, and fold assessment date into the assessment section
- add a copy URL action in the client header and consolidate token attribution and cost into a single token lens

## Validation
- npm test -- --run components/client-dashboard/BuildEvidenceInvestmentSection.test.tsx components/client-dashboard/MilestoneTimeline.test.tsx
- npx tsc --noEmit --pretty false
- npm run build:knowledge
- git diff --check origin/main...HEAD
- npm run build
- localhost browser smoke on the Mark dashboard (validated on source branch before captain integration)
- pre-push database health check passed (validated on source branch before captain integration)

## Integration Notes
- captain branch lifts commit 9a23b7c onto current origin/main without rewriting the source branch
- no migration or env change required
- Vercel – portfolio and Vercel – portfolio-staging remain a post-merge gate and have not been rechecked for this unmerged branch