### PR TITLE
fix: generalize client dashboard build evidence copy

### DIFF
--- a/components/client-dashboard/BuildEvidenceInvestmentSection.test.tsx
+++ b/components/client-dashboard/BuildEvidenceInvestmentSection.test.tsx
@@ -72,6 +72,7 @@ describe('BuildEvidenceInvestmentSection', () => {
     render(<BuildEvidenceInvestmentSection buildEvidence={evidence} />)
 
     expect(screen.getByText('Build Evidence & Investment')).toBeInTheDocument()
+    expect(screen.getByText(/this section treats the work as build evidence/i)).toBeInTheDocument()
     expect(screen.getByText('Direct ReversR workspace evidence')).toBeInTheDocument()
     expect(screen.getByText('149')).toBeInTheDocument()
     expect(screen.getByText('283.7M total attributed tokens')).toBeInTheDocument()

--- a/components/client-dashboard/BuildEvidenceInvestmentSection.tsx
+++ b/components/client-dashboard/BuildEvidenceInvestmentSection.tsx
@@ -141,6 +141,9 @@ export default function BuildEvidenceInvestmentSection({ buildEvidence }: Props)
     },
   ]
 
+  const sectionSummary =
+    'This section treats the work as build evidence. The numbers support replacement-cost and fixed-fee evaluation; they are not a time sheet.'
+
   return (
     <section className="rounded-lg border border-radiant-gold/20 bg-silicon-slate/35 p-5 shadow-[0_20px_70px_rgba(0,0,0,0.24)]">
       <div className="mb-5 flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
@@ -151,9 +154,7 @@ export default function BuildEvidenceInvestmentSection({ buildEvidence }: Props)
               Build Evidence & Investment
             </h3>
           </div>
-          <p className="max-w-3xl text-sm text-platinum-white/65">
-            ReversR Rebuild is measured here as product-asset evidence. The numbers support replacement-cost and fixed-fee evaluation; they are not a time sheet.
-          </p>
+          <p className="max-w-3xl text-sm text-platinum-white/65">{sectionSummary}</p>
         </div>
         <div className="rounded-lg border border-radiant-gold/30 bg-radiant-gold/10 px-3 py-2 text-xs text-gold-light">
           <p className="font-semibold">{sourceConfidence.label}</p>

--- a/lib/client-build-evidence.test.ts
+++ b/lib/client-build-evidence.test.ts
@@ -51,4 +51,23 @@ describe('sanitizeBuildEvidenceRow', () => {
     expect(output).not.toHaveProperty('privateSourceRefs')
     expect(output).not.toHaveProperty('private_source_refs')
   })
+
+  it('falls back to template-safe source confidence copy', () => {
+    const output = sanitizeBuildEvidenceRow({
+      id: 'evidence-2',
+      project_label: 'Client Dashboard Build',
+      captured_at: '2026-06-16T12:00:00.000Z',
+      repo_metrics: null,
+      token_usage: null,
+      cost_summary: null,
+      hourly_translation: null,
+      source_confidence: null,
+      client_safe_notes: [],
+    } as any)
+
+    expect(output.sourceConfidence.label).toBe('Direct workspace evidence')
+    expect(output.sourceConfidence.sourceSummary).toBe(
+      'Strict attribution uses Codex sessions started from the tracked workspace.'
+    )
+  })
 })

--- a/lib/client-build-evidence.ts
+++ b/lib/client-build-evidence.ts
@@ -138,9 +138,9 @@ const DEFAULT_HOURLY_TRANSLATION: BuildEvidenceHourlyTranslation = {
 }
 
 const DEFAULT_SOURCE_CONFIDENCE: BuildEvidenceSourceConfidence = {
-  label: 'Direct ReversR workspace evidence',
+  label: 'Direct workspace evidence',
   confidence: 'high',
-  sourceSummary: 'Strict attribution uses Codex sessions started from the ReversR workspace.',
+  sourceSummary: 'Strict attribution uses Codex sessions started from the tracked workspace.',
   excludedSources: [],
 }
 


### PR DESCRIPTION
## Summary
- remove client-specific wording from the shared build evidence dashboard section
- make sanitizer fallback source-confidence copy template-safe when project-specific evidence text is absent
- extend focused tests for the shared dashboard copy and sanitizer defaults

## Validation
- npm test -- --run components/client-dashboard/BuildEvidenceInvestmentSection.test.tsx lib/client-build-evidence.test.ts
- npm run build:knowledge
- npx tsc --noEmit --pretty false
- npm run build

## Integration Notes
- no migration or env change required
- captain lane validated against current origin/main
- Vercel – portfolio and Vercel – portfolio-staging remain post-merge gates