### PR TITLE
test: cover homepage scroll narrative behavior

### DIFF
--- a/components/Hero.test.tsx
+++ b/components/Hero.test.tsx
@@ -1,0 +1,108 @@
+import { act, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import Hero from './Hero'
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: ReactNode }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}))
+
+type RafCallback = FrameRequestCallback
+
+function setElementLayout(element: HTMLElement, offsetHeight: number, top: number) {
+  Object.defineProperty(element, 'offsetHeight', {
+    configurable: true,
+    value: offsetHeight,
+  })
+  element.getBoundingClientRect = vi.fn(() => ({
+    bottom: top + offsetHeight,
+    height: offsetHeight,
+    left: 0,
+    right: 0,
+    top,
+    width: 1200,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  }))
+}
+
+describe('Hero', () => {
+  let rafCallbacks: RafCallback[]
+
+  beforeEach(() => {
+    rafCallbacks = []
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      value: 1000,
+    })
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      rafCallbacks.push(callback)
+      return rafCallbacks.length
+    })
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined)
+    vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function flushAnimationFrame() {
+    const callback = rafCallbacks.shift()
+    if (!callback) throw new Error('Expected a queued animation frame')
+
+    act(() => {
+      callback(0)
+    })
+  }
+
+  it('scrubs the hero video from scroll progress and never seeks to the exact video end', () => {
+    const { container } = render(<Hero />)
+    const section = container.querySelector('[data-section="hero"]') as HTMLElement
+    const video = container.querySelector('video') as HTMLVideoElement
+    const source = container.querySelector('source') as HTMLSourceElement
+    const pause = vi.fn()
+
+    setElementLayout(section, 2000, -1000)
+    Object.defineProperty(video, 'duration', {
+      configurable: true,
+      value: 12,
+    })
+    Object.defineProperty(video, 'paused', {
+      configurable: true,
+      value: false,
+    })
+    video.pause = pause
+
+    flushAnimationFrame()
+
+    expect(screen.getByRole('heading', {
+      name: /turn disconnected work into one operating system/i,
+    })).toBeInTheDocument()
+    expect(source).toHaveAttribute(
+      'src',
+      '/prototypes/portfolio-pipeline-hero/higgsfield-gold-pipeline-loop-desktop-only-360-starburst-web-20260617.mp4',
+    )
+    expect(video.currentTime).toBeCloseTo(11.95, 2)
+    expect(pause).toHaveBeenCalled()
+  })
+
+  it('keeps the video at the beginning when the hero has no scroll distance', () => {
+    const { container } = render(<Hero />)
+    const section = container.querySelector('[data-section="hero"]') as HTMLElement
+    const video = container.querySelector('video') as HTMLVideoElement
+
+    setElementLayout(section, 900, -500)
+    Object.defineProperty(video, 'duration', {
+      configurable: true,
+      value: 10,
+    })
+
+    flushAnimationFrame()
+
+    expect(video.currentTime).toBe(0)
+  })
+})

--- a/components/SystemStory.test.tsx
+++ b/components/SystemStory.test.tsx
@@ -1,0 +1,111 @@
+import { act, render, screen } from '@testing-library/react'
+import type { ImgHTMLAttributes, ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import SystemStory from './SystemStory'
+
+type MockImageProps = ImgHTMLAttributes<HTMLImageElement> & {
+  fill?: boolean
+  priority?: boolean
+  src: string
+}
+
+vi.mock('next/image', () => ({
+  default: ({ alt = '', fill: _fill, priority: _priority, src, ...props }: MockImageProps) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={alt} src={src} {...props} />
+  ),
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: ReactNode }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}))
+
+type RafCallback = FrameRequestCallback
+
+function setElementLayout(element: HTMLElement, offsetHeight: number, top: number) {
+  Object.defineProperty(element, 'offsetHeight', {
+    configurable: true,
+    value: offsetHeight,
+  })
+  element.getBoundingClientRect = vi.fn(() => ({
+    bottom: top + offsetHeight,
+    height: offsetHeight,
+    left: 0,
+    right: 0,
+    top,
+    width: 1200,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  }))
+}
+
+describe('SystemStory', () => {
+  let rafCallbacks: RafCallback[]
+
+  beforeEach(() => {
+    rafCallbacks = []
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      value: 1000,
+    })
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      rafCallbacks.push(callback)
+      return rafCallbacks.length
+    })
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function flushAnimationFrame() {
+    const callback = rafCallbacks.shift()
+    if (!callback) throw new Error('Expected a queued animation frame')
+
+    act(() => {
+      callback(0)
+    })
+  }
+
+  it('advances the active story frame from clamped scroll progress', () => {
+    const { container } = render(<SystemStory />)
+    const section = container.querySelector('[data-section="system-story"]') as HTMLElement
+
+    setElementLayout(section, 4000, -1600)
+    flushAnimationFrame()
+
+    expect(screen.getByText('02 / 03')).toBeInTheDocument()
+    expect(screen.getByRole('heading', {
+      name: /we map the operating system/i,
+    })).toBeInTheDocument()
+    expect(screen.getByText('Handoffs Under Review')).toBeInTheDocument()
+
+    setElementLayout(section, 4000, -6000)
+    window.dispatchEvent(new Event('scroll'))
+    flushAnimationFrame()
+
+    expect(screen.getByText('03 / 03')).toBeInTheDocument()
+    expect(screen.getByRole('heading', {
+      name: /then we connect the work/i,
+    })).toBeInTheDocument()
+    expect(screen.getByText('Operating Layer Engaged')).toBeInTheDocument()
+  })
+
+  it('stays on the first story frame when there is no scrollable distance', () => {
+    const { container } = render(<SystemStory />)
+    const section = container.querySelector('[data-section="system-story"]') as HTMLElement
+
+    setElementLayout(section, 900, -600)
+    flushAnimationFrame()
+
+    expect(screen.getByText('01 / 03')).toBeInTheDocument()
+    expect(screen.getByRole('heading', {
+      name: /the work is already there/i,
+    })).toBeInTheDocument()
+    expect(screen.getByText('Intake Drift Detected')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- recover the closed #541 homepage scroll-behavior tests onto current main
- add focused component coverage for Hero scroll video scrubbing and SystemStory frame progression
- keep the change test-only with no production behavior changes

## Validation
- npx vitest run components/Hero.test.tsx components/SystemStory.test.tsx
- npm run build:knowledge
- npx tsc --noEmit --pretty false
- git diff --check origin/main...HEAD
- npm run build

## Integration Notes
- no migration or env change required
- both Vercel contexts will be checked after merge:
  - Vercel – portfolio
  - Vercel – portfolio-staging