### PR TITLE
feat: add Shaka social topic discovery

### DIFF
--- a/app/admin/social-content/[id]/page.test.tsx
+++ b/app/admin/social-content/[id]/page.test.tsx
@@ -88,6 +88,8 @@ describe('SocialContentDetailRoute visual production review', () => {
     render(<SocialContentDetailRoute />)
 
     expect(await screen.findByText('Visual Production')).toBeInTheDocument()
+    expect(screen.getByText('Shaka topic scout')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Ask Shaka for Topics/i })).toBeInTheDocument()
     expect(screen.queryByText('Review gates')).not.toBeInTheDocument()
     expect(screen.queryByText('Every gate uses the same state language; the detail line preserves each system status.')).not.toBeInTheDocument()
     expect(screen.queryByText(/Copy is approved and locked/i)).not.toBeInTheDocument()
@@ -140,6 +142,79 @@ describe('SocialContentDetailRoute visual production review', () => {
     expect(within(copyGate as HTMLElement).getByText('Hashtags (comma-separated)')).toBeInTheDocument()
     expect(screen.getByDisplayValue(/Architecture/i)).not.toBeDisabled()
     expect(screen.getByDisplayValue('Create a framework visual about review gates.')).not.toBeDisabled()
+  })
+
+  it('lets Shaka discover topic triggers and apply one to copy review', async () => {
+    const packet = {
+      version: 'social_topic_trigger_discovery_v1',
+      status: 'review_ready',
+      generated_at: '2026-06-21T20:00:00.000Z',
+      source_counts: { meeting: 1, client_safe_project: 1, shipped_feature: 1, open_brain: 1 },
+      candidates: [
+        {
+          id: 'approval-gates-review',
+          title: 'Approval gates create trust',
+          triggering_event: 'A recent Agent Ops review exposed where AI-generated work needed clearer ownership before publishing.',
+          source_type: 'meeting',
+          source_label: 'Agent Ops review',
+          source_ids: ['meeting:meeting-1'],
+          why_vambah_can_speak: 'You are building the Portfolio Agent Ops workflow and reviewed the approval path directly.',
+          brand_goal: 'Show AmaduTown builds governed AI systems.',
+          content_angle: 'AI needs accountable operating gates.',
+          suggested_hook: 'AI should reduce burden. That only happens when every risky action has a gate.',
+          audience: 'Product leaders adopting AI',
+          sensitivity: 'needs_review',
+          evidence_summary: 'Sanitized meeting summary.',
+          claim_boundaries: ['Do not name private meeting participants.'],
+        },
+      ],
+    }
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input).includes('/discover-topic-triggers') && init?.method === 'POST') {
+        return {
+          ok: true,
+          json: async () => ({
+            success: true,
+            item: {
+              ...baseItem,
+              rag_context: {
+                ...baseItem.rag_context,
+                content_calibration: {
+                  status: 'topic_triggers_ready',
+                  topic_trigger_packet: packet,
+                },
+              },
+            },
+            topic_trigger_packet: packet,
+          }),
+        } as Response
+      }
+      return {
+        ok: true,
+        json: async () => ({ item: baseItem }),
+      } as Response
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<SocialContentDetailRoute />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /Ask Shaka for Topics/i }))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/api/admin/social-content/social-1/discover-topic-triggers'),
+        expect.objectContaining({ method: 'POST' }),
+      )
+    })
+    expect(await screen.findByText('Approval gates create trust')).toBeInTheDocument()
+    expect(screen.getByText(/Why you can speak on it:/)).toBeInTheDocument()
+    expect(screen.getByText(/Hook: AI should reduce burden/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /Use trigger/i }))
+
+    expect(screen.getAllByDisplayValue(/recent Agent Ops review exposed/).length).toBeGreaterThan(0)
+    expect(screen.getAllByDisplayValue(/Anchor this draft in Shaka's selected topic trigger/).length).toBeGreaterThan(0)
+    expect(screen.getByRole('button', { name: /Reject and Generate Revision/i })).not.toBeDisabled()
   })
 
   it('shows production assets and blocks publish readiness while redaction is unresolved', async () => {

--- a/app/admin/social-content/[id]/page.tsx
+++ b/app/admin/social-content/[id]/page.tsx
@@ -33,6 +33,7 @@ import {
   Plus,
   Trash2,
   MessageSquare,
+  Lightbulb,
 } from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
@@ -161,6 +162,8 @@ type CalibrationSuccessExample = {
   why_it_worked: string
 }
 
+type TopicTriggerCandidateRecord = Record<string, unknown>
+
 const EMPTY_SUCCESS_EXAMPLE: CalibrationSuccessExample = {
   source_label: '',
   post_excerpt: '',
@@ -252,6 +255,7 @@ function SocialContentDetailPage() {
   const [savingCalibration, setSavingCalibration] = useState(false)
   const [revisingCalibration, setRevisingCalibration] = useState(false)
   const [requestingCopyRevision, setRequestingCopyRevision] = useState(false)
+  const [discoveringTopicTriggers, setDiscoveringTopicTriggers] = useState(false)
   const [savingSectionGate, setSavingSectionGate] = useState<SectionGateKey | null>(null)
   const [showSource, setShowSource] = useState(false)
   const [expandedSection, setExpandedSection] = useState<'rag' | 'transcript' | null>(null)
@@ -521,6 +525,60 @@ function SocialContentDetailPage() {
     } finally {
       setSavingCalibration(false)
     }
+  }
+
+  const handleDiscoverTopicTriggers = async () => {
+    if (!item) return
+    setDiscoveringTopicTriggers(true)
+    try {
+      const session = await getCurrentSession()
+      if (!session) return
+
+      const res = await fetch(`/api/admin/social-content/${id}/discover-topic-triggers`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${session.access_token}`,
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const data = await res.json()
+      if (!res.ok) {
+        showMsg('error', data.error || 'Failed to discover topic triggers')
+        return
+      }
+
+      const updated = data.item as SocialContentItem
+      setItem(updated)
+      showMsg('success', 'Shaka found topic triggers for review')
+    } catch {
+      showMsg('error', 'Failed to discover topic triggers')
+    } finally {
+      setDiscoveringTopicTriggers(false)
+    }
+  }
+
+  const handleUseTopicTrigger = (candidate: TopicTriggerCandidateRecord) => {
+    const title = asString(candidate.title).trim()
+    const triggeringEvent = asString(candidate.triggering_event).trim()
+    const audience = asString(candidate.audience).trim()
+    const brandGoal = asString(candidate.brand_goal).trim()
+    const claimBoundaries = asStringArray(candidate.claim_boundaries).join('\n')
+    const revisionRequest = title
+      ? `Anchor this draft in Shaka's selected topic trigger: ${title}. Make why I am qualified to speak on this explicit.`
+      : "Anchor this draft in Shaka's selected topic trigger and make why I am qualified to speak on this explicit."
+
+    setCalibrationFeedback((current) => ({
+      ...current,
+      triggering_event: triggeringEvent || current.triggering_event,
+      audience_context: [current.audience_context, audience, brandGoal].filter(Boolean).join('\n'),
+      revision_request: current.revision_request || revisionRequest,
+      claim_boundaries: [current.claim_boundaries, claimBoundaries].filter(Boolean).join('\n'),
+    }))
+    if (!copyRevisionRequest.trim()) {
+      setCopyRevisionRequest(revisionRequest)
+    }
+    showMsg('success', 'Topic trigger added to the copy review')
   }
 
   const handleRequestCopyRevision = async (generateRevision: boolean) => {
@@ -1171,6 +1229,11 @@ function SocialContentDetailPage() {
   const agentPilotComparisonPrompt = asString(agentPilotCalibration?.comparison_prompt)
   const agentPilotOperatorFeedback = asRecord(agentPilotCalibration?.operator_feedback)
   const agentPilotFeedbackUpdatedAt = asString(agentPilotOperatorFeedback?.updated_at)
+  const agentPilotTopicTriggerPacket = asRecord(agentPilotCalibration?.topic_trigger_packet)
+  const agentPilotTopicTriggerStatus = asString(agentPilotTopicTriggerPacket?.status)
+  const agentPilotTopicTriggerGeneratedAt = asString(agentPilotTopicTriggerPacket?.generated_at)
+  const agentPilotTopicTriggerCandidates = asRecordArray(agentPilotTopicTriggerPacket?.candidates)
+  const agentPilotTopicTriggerCounts = asRecord(agentPilotTopicTriggerPacket?.source_counts)
   const productionAssets = getProductionAssets(ragContext)
   const redactionGate = getVideoRedactionGate(productionAssets)
   const sectionGateReviews = asRecord(ragContext?.section_gate_reviews) ?? {}
@@ -1996,6 +2059,96 @@ function SocialContentDetailPage() {
                   Copy: {GATE_STATE_CONFIG[copyGateState].label}
                 </span>
               </div>
+              {isAgentSocialPilot && (
+                <div className="mb-4 rounded-lg border border-blue-500/25 bg-blue-500/10 p-3">
+                  <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                    <div className="min-w-0">
+                      <p className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.14em] text-blue-200">
+                        <Lightbulb className="h-3.5 w-3.5" />
+                        Shaka topic scout
+                      </p>
+                      <p className="mt-1 text-sm leading-6 text-blue-50/85">
+                        Cull recent meetings, shipped work, client-safe projects, and approved memory into trigger options.
+                      </p>
+                    </div>
+                    <div className="flex shrink-0 flex-wrap items-center gap-2 lg:justify-end">
+                      {agentPilotTopicTriggerStatus && (
+                        <span className="rounded-full border border-blue-400/35 px-2 py-0.5 text-[10px] font-semibold text-blue-100">
+                          {agentPilotTopicTriggerStatus.replace(/_/g, ' ')}
+                        </span>
+                      )}
+                      <button
+                        type="button"
+                        onClick={handleDiscoverTopicTriggers}
+                        disabled={discoveringTopicTriggers}
+                        className="inline-flex items-center gap-2 rounded-lg border border-blue-400/45 px-3 py-2 text-sm font-semibold text-blue-100 transition-colors hover:bg-blue-500/10 disabled:opacity-50"
+                      >
+                        {discoveringTopicTriggers ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Sparkles className="h-3.5 w-3.5" />}
+                        Ask Shaka for Topics
+                      </button>
+                    </div>
+                  </div>
+                  {agentPilotTopicTriggerGeneratedAt && (
+                    <p className="mt-2 text-xs text-blue-50/65">
+                      Generated {new Date(agentPilotTopicTriggerGeneratedAt).toLocaleString()}
+                    </p>
+                  )}
+                  {agentPilotTopicTriggerCounts && (
+                    <div className="mt-2 flex flex-wrap gap-1.5">
+                      {Object.entries(agentPilotTopicTriggerCounts)
+                        .filter(([, value]) => Number(value) > 0)
+                        .map(([key, value]) => (
+                          <span key={key} className="rounded-full border border-blue-400/25 px-2 py-0.5 text-[10px] text-blue-50/75">
+                            {key.replace(/_/g, ' ')}: {String(value)}
+                          </span>
+                        ))}
+                    </div>
+                  )}
+                  {agentPilotTopicTriggerCandidates.length > 0 && (
+                    <div className="mt-3 grid gap-2">
+                      {agentPilotTopicTriggerCandidates.map((candidate, index) => {
+                        const title = asString(candidate.title) || `Topic ${index + 1}`
+                        const sensitivity = asString(candidate.sensitivity) || 'needs_review'
+                        return (
+                          <div key={asString(candidate.id) || `${title}-${index}`} className="rounded-lg border border-blue-400/20 bg-background/35 p-3">
+                            <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                              <div className="min-w-0">
+                                <div className="flex flex-wrap items-center gap-2">
+                                  <p className="text-sm font-semibold text-blue-50">{title}</p>
+                                  <span className="rounded-full border border-blue-400/25 px-2 py-0.5 text-[10px] text-blue-100">
+                                    {sensitivity.replace(/_/g, ' ')}
+                                  </span>
+                                </div>
+                                <p className="mt-1 text-sm leading-6 text-blue-50/85">
+                                  {asString(candidate.triggering_event)}
+                                </p>
+                                {asString(candidate.why_vambah_can_speak) && (
+                                  <p className="mt-1 text-xs leading-5 text-blue-50/70">
+                                    Why you can speak on it: {asString(candidate.why_vambah_can_speak)}
+                                  </p>
+                                )}
+                                {asString(candidate.suggested_hook) && (
+                                  <p className="mt-1 text-xs leading-5 text-blue-50/70">
+                                    Hook: {asString(candidate.suggested_hook)}
+                                  </p>
+                                )}
+                              </div>
+                              <button
+                                type="button"
+                                onClick={() => handleUseTopicTrigger(candidate)}
+                                className="inline-flex shrink-0 items-center justify-center gap-2 rounded-lg bg-blue-400 px-3 py-2 text-sm font-semibold text-slate-950 transition-colors hover:bg-blue-300"
+                              >
+                                <CheckCircle2 className="h-3.5 w-3.5" />
+                                Use trigger
+                              </button>
+                            </div>
+                          </div>
+                        )
+                      })}
+                    </div>
+                  )}
+                </div>
+              )}
               <textarea
                 value={postText}
                 onChange={(e) => setPostText(e.target.value)}

--- a/app/api/admin/social-content/[id]/discover-topic-triggers/route.test.ts
+++ b/app/api/admin/social-content/[id]/discover-topic-triggers/route.test.ts
@@ -1,0 +1,295 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  generateJsonCompletion: vi.fn(),
+  from: vi.fn(),
+  currentSingle: vi.fn(),
+  updateSingle: vi.fn(),
+  recentSocialLimit: vi.fn(),
+  meetingsLimit: vi.fn(),
+  projectsLimit: vi.fn(),
+  runsLimit: vi.fn(),
+  update: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/llm-dispatch', () => ({
+  generateJsonCompletion: mocks.generateJsonCompletion,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import { POST } from './route'
+
+function request(body: unknown = {}) {
+  return new NextRequest('http://localhost/api/admin/social-content/social-1/discover-topic-triggers', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+const agentOpsRagContext = {
+  source: 'agent_ops_social_outreach_goal',
+  goal_id: 'goal-1',
+  content_packet_id: 'packet-1',
+  open_brain_references: ['memory-1'],
+  chronicle_packet_status: 'manual_packet_summarized',
+  content_calibration: {
+    status: 'ready_for_draft_review',
+  },
+}
+
+function socialContentTable() {
+  return {
+    select: vi.fn((columns: string) => {
+      if (columns.includes('cta_text')) {
+        return {
+          eq: vi.fn(() => ({
+            single: mocks.currentSingle,
+          })),
+        }
+      }
+      return {
+        in: vi.fn(() => ({
+          order: vi.fn(() => ({
+            limit: mocks.recentSocialLimit,
+          })),
+        })),
+      }
+    }),
+    update: mocks.update,
+  }
+}
+
+function limitTable(limitMock: ReturnType<typeof vi.fn>) {
+  return {
+    select: vi.fn(() => ({
+      order: vi.fn(() => ({
+        limit: limitMock,
+      })),
+    })),
+  }
+}
+
+describe('POST /api/admin/social-content/[id]/discover-topic-triggers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-1' }, isAdmin: true })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.currentSingle.mockResolvedValue({
+      data: {
+        id: 'social-1',
+        status: 'approved',
+        post_text: 'Current draft about Agent Ops.',
+        cta_text: 'Where is AI adding work?',
+        hashtags: ['#AIProduct'],
+        image_prompt: null,
+        topic_extracted: { topic: 'Agent Ops approval gates' },
+        hormozi_framework: { framework_type: 'proof_stacking' },
+        rag_context: agentOpsRagContext,
+      },
+      error: null,
+    })
+    mocks.meetingsLimit.mockResolvedValue({
+      data: [
+        {
+          id: 'meeting-1',
+          meeting_type: 'Product review',
+          meeting_date: '2026-06-18',
+          created_at: '2026-06-18T10:00:00.000Z',
+          raw_notes: null,
+          structured_notes: {
+            title: 'Agent Ops review',
+            summary: 'The review exposed that approval gates need clearer ownership. Contact vambah@example.com for details.',
+          },
+        },
+      ],
+      error: null,
+    })
+    mocks.projectsLimit.mockResolvedValue({
+      data: [
+        {
+          id: 'project-1',
+          project_name: 'Client-safe automation readiness build',
+          product_purchased: 'AI Ops sprint',
+          project_status: 'active',
+          current_phase: 'Evidence review',
+          created_at: '2026-06-15T10:00:00.000Z',
+          updated_at: '2026-06-19T10:00:00.000Z',
+        },
+      ],
+      error: null,
+    })
+    mocks.runsLimit.mockResolvedValue({
+      data: [
+        {
+          id: 'run-1',
+          agent_key: 'chief-of-staff',
+          kind: 'social_content_generation',
+          title: 'Generate social content draft',
+          status: 'completed',
+          current_step: 'Draft returned for review',
+          subject_label: 'Agent Ops LinkedIn pilot',
+          metadata: { operation: 'social_content_calibration_revision' },
+          created_at: '2026-06-20T10:00:00.000Z',
+        },
+      ],
+      error: null,
+    })
+    mocks.recentSocialLimit.mockResolvedValue({
+      data: [
+        {
+          id: 'social-2',
+          status: 'published',
+          topic_extracted: {
+            topic: 'AI should reduce burden',
+            angle: 'Governance makes automation accountable',
+            personal_tie_in: 'Built in Portfolio Agent Ops.',
+          },
+          post_text: 'AI should reduce burden.',
+          rag_context: { open_brain_references: ['memory-2'] },
+          created_at: '2026-06-17T10:00:00.000Z',
+        },
+      ],
+      error: null,
+    })
+    mocks.generateJsonCompletion.mockResolvedValue({
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      content: JSON.stringify({
+        candidates: [
+          {
+            id: 'approval-gates-review',
+            title: 'Approval gates create trust',
+            triggering_event: 'A recent Agent Ops review exposed where AI-generated work needed clearer ownership before publishing.',
+            source_type: 'meeting',
+            source_label: 'Agent Ops review',
+            source_ids: ['meeting:meeting-1'],
+            why_vambah_can_speak: 'Vambah is building the Portfolio Agent Ops workflow and personally reviewed the approval path.',
+            brand_goal: 'Show AmaduTown builds governed AI systems, not loose demos.',
+            content_angle: 'AI needs accountable operating gates.',
+            suggested_hook: 'AI should reduce burden. That only happens when every risky action has a gate.',
+            audience: 'Product leaders and operators adopting AI',
+            sensitivity: 'needs_review',
+            evidence_summary: 'Sanitized meeting summary about approval gate ownership.',
+            claim_boundaries: ['Do not name private meeting participants.'],
+          },
+        ],
+        notes: ['Review-only candidates.'],
+      }),
+    })
+    mocks.updateSingle.mockResolvedValue({
+      data: {
+        id: 'social-1',
+        rag_context: {
+          ...agentOpsRagContext,
+          content_calibration: {
+            status: 'topic_triggers_ready',
+          },
+        },
+      },
+      error: null,
+    })
+    mocks.update.mockReturnValue({
+      eq: vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: mocks.updateSingle,
+        })),
+      })),
+    })
+    mocks.from.mockImplementation((table: string) => {
+      if (table === 'social_content_queue') return socialContentTable()
+      if (table === 'meeting_records') return limitTable(mocks.meetingsLimit)
+      if (table === 'client_projects') return limitTable(mocks.projectsLimit)
+      if (table === 'agent_runs') return limitTable(mocks.runsLimit)
+      throw new Error(`Unexpected table ${table}`)
+    })
+  })
+
+  it('requires admin auth before reading source signals', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Authentication required', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(request(), { params: { id: 'social-1' } })
+
+    expect(response.status).toBe(401)
+    expect(mocks.from).not.toHaveBeenCalled()
+    expect(mocks.generateJsonCompletion).not.toHaveBeenCalled()
+  })
+
+  it('discovers sanitized topic triggers and saves a review-only packet', async () => {
+    const response = await POST(request(), { params: { id: 'social-1' } })
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.topic_trigger_packet).toMatchObject({
+      version: 'social_topic_trigger_discovery_v1',
+      status: 'review_ready',
+      source_policy: 'sanitized_summaries_only',
+      privacy_boundary: expect.stringContaining('Review-only topic scouting'),
+      candidates: [
+        expect.objectContaining({
+          id: 'approval-gates-review',
+          title: 'Approval gates create trust',
+          source_ids: ['meeting:meeting-1'],
+          sensitivity: 'needs_review',
+        }),
+      ],
+    })
+    expect(mocks.generateJsonCompletion).toHaveBeenCalledWith(expect.objectContaining({
+      costContext: expect.objectContaining({
+        metadata: expect.objectContaining({
+          operation: 'social_content_topic_trigger_discovery',
+        }),
+      }),
+      userPrompt: expect.not.stringContaining('vambah@example.com'),
+    }))
+    expect(mocks.update).toHaveBeenCalledWith({
+      rag_context: expect.objectContaining({
+        content_calibration: expect.objectContaining({
+          status: 'topic_triggers_ready',
+          topic_trigger_packet: expect.objectContaining({
+            candidates: expect.any(Array),
+          }),
+        }),
+      }),
+    })
+  })
+
+  it('rejects non-Agent-Ops social drafts', async () => {
+    mocks.currentSingle.mockResolvedValueOnce({
+      data: {
+        id: 'social-1',
+        status: 'draft',
+        post_text: 'Draft',
+        cta_text: null,
+        hashtags: [],
+        image_prompt: null,
+        topic_extracted: {},
+        hormozi_framework: {},
+        rag_context: { source: 'manual_social_post' },
+      },
+      error: null,
+    })
+
+    const response = await POST(request(), { params: { id: 'social-1' } })
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: 'Topic discovery is only available for Agent Ops social pilot drafts',
+    })
+    expect(mocks.generateJsonCompletion).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/admin/social-content/[id]/discover-topic-triggers/route.ts
+++ b/app/api/admin/social-content/[id]/discover-topic-triggers/route.ts
@@ -1,0 +1,504 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { generateJsonCompletion } from '@/lib/llm-dispatch'
+import { supabaseAdmin } from '@/lib/supabase'
+import {
+  extractMeetingSummary,
+  extractMeetingTitle,
+} from '@/lib/social-content'
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 60
+
+type SourceType =
+  | 'meeting'
+  | 'shipped_feature'
+  | 'client_safe_project'
+  | 'chronicle_observation'
+  | 'chatgpt_session'
+  | 'open_brain'
+  | 'portfolio_work'
+
+type TopicSensitivity = 'public_safe' | 'client_safe_summary' | 'needs_review'
+
+type SocialContentRow = {
+  id: string
+  status: string
+  post_text: string | null
+  cta_text: string | null
+  hashtags: string[] | null
+  image_prompt: string | null
+  topic_extracted: unknown
+  hormozi_framework: unknown
+  rag_context: Record<string, unknown> | null
+}
+
+type SourceSignal = {
+  id: string
+  type: SourceType
+  label: string
+  summary: string
+  date?: string | null
+  sensitivity: TopicSensitivity
+}
+
+type TopicTriggerCandidate = {
+  id: string
+  title: string
+  triggering_event: string
+  source_type: SourceType
+  source_label: string
+  source_ids: string[]
+  why_vambah_can_speak: string
+  brand_goal: string
+  content_angle: string
+  suggested_hook: string
+  audience: string
+  sensitivity: TopicSensitivity
+  evidence_summary: string
+  claim_boundaries: string[]
+}
+
+type DiscoveryResponse = {
+  candidates?: unknown
+  notes?: unknown
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null
+}
+
+function asString(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
+}
+
+function truncate(value: string, maxLength: number): string {
+  const trimmed = value.replace(/\s+/g, ' ').trim()
+  if (trimmed.length <= maxLength) return trimmed
+  return `${trimmed.slice(0, maxLength - 3).trim()}...`
+}
+
+function redactSensitiveText(value: string): string {
+  return value
+    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, '[email redacted]')
+    .replace(/\b(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b/g, '[phone redacted]')
+    .replace(/https?:\/\/[^\s]+/gi, (match) => {
+      try {
+        const url = new URL(match)
+        return `${url.origin}/[private-path-redacted]`
+      } catch {
+        return '[url redacted]'
+      }
+    })
+}
+
+function sanitizeSummary(value: unknown, maxLength = 700): string {
+  return truncate(redactSensitiveText(asString(value)), maxLength)
+}
+
+function normalizeTopicSensitivity(value: unknown, fallback: TopicSensitivity): TopicSensitivity {
+  if (value === 'public_safe' || value === 'client_safe_summary' || value === 'needs_review') {
+    return value
+  }
+  return fallback
+}
+
+function normalizeSourceType(value: unknown): SourceType {
+  if (
+    value === 'meeting'
+    || value === 'shipped_feature'
+    || value === 'client_safe_project'
+    || value === 'chronicle_observation'
+    || value === 'chatgpt_session'
+    || value === 'open_brain'
+    || value === 'portfolio_work'
+  ) {
+    return value
+  }
+  return 'portfolio_work'
+}
+
+function sourceCounts(signals: SourceSignal[]) {
+  return signals.reduce<Record<SourceType, number>>((counts, signal) => {
+    counts[signal.type] = (counts[signal.type] ?? 0) + 1
+    return counts
+  }, {
+    meeting: 0,
+    shipped_feature: 0,
+    client_safe_project: 0,
+    chronicle_observation: 0,
+    chatgpt_session: 0,
+    open_brain: 0,
+    portfolio_work: 0,
+  })
+}
+
+function normalizeCandidates(parsed: DiscoveryResponse, signals: SourceSignal[]): TopicTriggerCandidate[] {
+  const sourceIdSet = new Set(signals.map((signal) => signal.id))
+  return (Array.isArray(parsed.candidates) ? parsed.candidates : [])
+    .map((item, index) => {
+      const record = asRecord(item)
+      if (!record) return null
+      const sourceType = normalizeSourceType(record.source_type)
+      const candidate: TopicTriggerCandidate = {
+        id: asString(record.id).trim() || `topic-trigger-${index + 1}`,
+        title: truncate(asString(record.title), 90),
+        triggering_event: sanitizeSummary(record.triggering_event, 500),
+        source_type: sourceType,
+        source_label: truncate(asString(record.source_label), 120),
+        source_ids: asStringArray(record.source_ids).filter((id) => sourceIdSet.has(id)).slice(0, 4),
+        why_vambah_can_speak: sanitizeSummary(record.why_vambah_can_speak, 500),
+        brand_goal: truncate(asString(record.brand_goal), 180),
+        content_angle: sanitizeSummary(record.content_angle, 450),
+        suggested_hook: sanitizeSummary(record.suggested_hook, 280),
+        audience: truncate(asString(record.audience), 140),
+        sensitivity: normalizeTopicSensitivity(record.sensitivity, sourceType === 'client_safe_project' ? 'client_safe_summary' : 'needs_review'),
+        evidence_summary: sanitizeSummary(record.evidence_summary, 500),
+        claim_boundaries: asStringArray(record.claim_boundaries).map((boundary) => truncate(boundary, 160)).slice(0, 5),
+      }
+      if (!candidate.title || !candidate.triggering_event || !candidate.why_vambah_can_speak) return null
+      return candidate
+    })
+    .filter((item): item is TopicTriggerCandidate => Boolean(item))
+    .slice(0, 8)
+}
+
+function buildDiscoveryPrompt(row: SocialContentRow, signals: SourceSignal[]) {
+  const ragContext = asRecord(row.rag_context) ?? {}
+  return `Shaka is Vambah Sillah's Agent Ops Chief of Staff.
+
+Cull potential LinkedIn topic triggers from sanctioned internal summaries.
+The goal is to answer: why is Vambah qualified to speak about this topic now?
+
+Return JSON only:
+{
+  "candidates": [
+    {
+      "id": "short-stable-id",
+      "title": "topic title",
+      "triggering_event": "recent event or proof that makes the topic timely",
+      "source_type": "meeting | shipped_feature | client_safe_project | chronicle_observation | chatgpt_session | open_brain | portfolio_work",
+      "source_label": "human-readable source label",
+      "source_ids": ["internal source ids from the provided signals"],
+      "why_vambah_can_speak": "why this comes from Vambah's lived work, shipped work, or approved evidence",
+      "brand_goal": "how this advances AmaduTown or Vambah's thought leadership",
+      "content_angle": "plain-language angle for the draft",
+      "suggested_hook": "first-sentence candidate",
+      "audience": "primary reader",
+      "sensitivity": "public_safe | client_safe_summary | needs_review",
+      "evidence_summary": "sanitized evidence summary only",
+      "claim_boundaries": ["what to avoid or verify before publishing"]
+    }
+  ],
+  "notes": ["review-only notes"]
+}
+
+Rules:
+- Do not quote raw private chats, raw Chronicle notes, raw meeting transcripts, emails, phone numbers, account IDs, or private URLs.
+- Use only the sanitized summaries and approved packet fields below.
+- Prefer concrete triggers: a meeting theme, shipped feature, client-safe project pattern, approved Open Brain reference, or recent Portfolio work.
+- Mark anything involving client work, raw Chronicle, or private ChatGPT-derived material as needs_review unless it is already summarized as public-safe.
+- These candidates are review-only. Do not publish, schedule, send, call providers, or create drafts outside this packet.
+
+Current Social Content draft:
+${JSON.stringify({
+    id: row.id,
+    status: row.status,
+    post_text: truncate(row.post_text ?? '', 1200),
+    cta_text: row.cta_text,
+    hashtags: row.hashtags,
+    topic_extracted: row.topic_extracted,
+    hormozi_framework: row.hormozi_framework,
+    rag_context: {
+      source: ragContext.source,
+      goal_id: ragContext.goal_id,
+      content_packet_id: ragContext.content_packet_id,
+      open_brain_references: ragContext.open_brain_references,
+      chronicle_packet_status: ragContext.chronicle_packet_status,
+      chronicle_evidence_notes: ragContext.chronicle_evidence_notes,
+      source_provenance_checklist: ragContext.source_provenance_checklist,
+    },
+  }, null, 2)}
+
+Sanitized source signals:
+${JSON.stringify(signals, null, 2)}
+
+Vambah voice and brand filters:
+- Start from a concrete scene, meeting tension, shipped feature, or practical proof.
+- Connect the trigger to a larger system problem.
+- Keep the topic grounded in product strategy, AI governance, operational reality, access, dignity, and AmaduTown's build-the-system posture.
+- Avoid generic AI hype and detached consulting language.`
+}
+
+async function fetchCurrentItem(id: string) {
+  const { data, error } = await supabaseAdmin
+    .from('social_content_queue')
+    .select('id, status, post_text, cta_text, hashtags, image_prompt, topic_extracted, hormozi_framework, rag_context')
+    .eq('id', id)
+    .single()
+  if (error || !data) return null
+  return data as SocialContentRow
+}
+
+async function fetchRecentMeetingSignals(): Promise<SourceSignal[]> {
+  const { data } = await supabaseAdmin
+    .from('meeting_records')
+    .select('id, meeting_type, meeting_date, created_at, raw_notes, structured_notes')
+    .order('meeting_date', { ascending: false })
+    .limit(8)
+
+  return (data ?? []).map((meeting: {
+    id: string
+    meeting_type: string | null
+    meeting_date: string | null
+    created_at: string | null
+    raw_notes: string | null
+    structured_notes: Record<string, unknown> | null
+  }) => {
+    const title = extractMeetingTitle(meeting.raw_notes, meeting.structured_notes) || meeting.meeting_type || 'Recent meeting'
+    const summary = extractMeetingSummary(meeting.raw_notes, meeting.structured_notes)
+      || sanitizeSummary(meeting.structured_notes?.summary)
+      || 'Meeting summary unavailable; use only as an internal lead.'
+    return {
+      id: `meeting:${meeting.id}`,
+      type: 'meeting' as const,
+      label: `${title} (${meeting.meeting_date ?? meeting.created_at ?? 'recent'})`,
+      date: meeting.meeting_date ?? meeting.created_at,
+      summary: sanitizeSummary(summary),
+      sensitivity: 'needs_review' as const,
+    }
+  }).filter((signal: SourceSignal) => signal.summary)
+}
+
+async function fetchClientProjectSignals(): Promise<SourceSignal[]> {
+  const { data } = await supabaseAdmin
+    .from('client_projects')
+    .select('id, project_name, product_purchased, project_status, current_phase, created_at, updated_at')
+    .order('updated_at', { ascending: false })
+    .limit(8)
+
+  return (data ?? []).map((project: {
+    id: string
+    project_name: string | null
+    product_purchased: string | null
+    project_status: string | null
+    current_phase: string | null
+    created_at: string | null
+    updated_at: string | null
+  }) => ({
+    id: `client_project:${project.id}`,
+    type: 'client_safe_project' as const,
+    label: project.project_name || project.product_purchased || 'Client-safe project',
+    date: project.updated_at ?? project.created_at,
+    summary: sanitizeSummary([
+      project.project_name && `Project: ${project.project_name}`,
+      project.product_purchased && `Offer: ${project.product_purchased}`,
+      project.project_status && `Status: ${project.project_status}`,
+      project.current_phase && `Phase: ${project.current_phase}`,
+    ].filter(Boolean).join('. ')),
+    sensitivity: 'client_safe_summary' as const,
+  })).filter((signal: SourceSignal) => signal.summary)
+}
+
+async function fetchAgentRunSignals(): Promise<SourceSignal[]> {
+  const { data } = await supabaseAdmin
+    .from('agent_runs')
+    .select('id, agent_key, kind, title, status, current_step, subject_label, metadata, created_at')
+    .order('created_at', { ascending: false })
+    .limit(10)
+
+  return (data ?? []).map((run: {
+    id: string
+    agent_key: string | null
+    kind: string | null
+    title: string | null
+    status: string | null
+    current_step: string | null
+    subject_label: string | null
+    metadata: Record<string, unknown> | null
+    created_at: string | null
+  }) => {
+    const metadataSummary = sanitizeSummary([
+      asString(run.metadata?.goal_id) && `Goal ${asString(run.metadata?.goal_id)}`,
+      asString(run.metadata?.workflow) && `Workflow ${asString(run.metadata?.workflow)}`,
+      asString(run.metadata?.operation) && `Operation ${asString(run.metadata?.operation)}`,
+    ].filter(Boolean).join('. '), 300)
+    return {
+      id: `agent_run:${run.id}`,
+      type: run.kind?.includes('social_content') ? 'shipped_feature' as const : 'portfolio_work' as const,
+      label: run.title || run.subject_label || run.kind || 'Agent run',
+      date: run.created_at,
+      summary: sanitizeSummary([
+        run.agent_key && `Agent: ${run.agent_key}`,
+        run.kind && `Kind: ${run.kind}`,
+        run.status && `Status: ${run.status}`,
+        run.current_step && `Step: ${run.current_step}`,
+        metadataSummary,
+      ].filter(Boolean).join('. ')),
+      sensitivity: 'public_safe' as const,
+    }
+  }).filter((signal: SourceSignal) => signal.summary)
+}
+
+async function fetchRecentSocialContentSignals(currentId: string): Promise<SourceSignal[]> {
+  const { data } = await supabaseAdmin
+    .from('social_content_queue')
+    .select('id, status, topic_extracted, post_text, rag_context, created_at')
+    .in('status', ['draft', 'approved', 'published', 'rejected'])
+    .order('created_at', { ascending: false })
+    .limit(8)
+
+  return (data ?? [])
+    .filter((row: { id: string }) => row.id !== currentId)
+    .map((row: {
+      id: string
+      status: string | null
+      topic_extracted: Record<string, unknown> | null
+      post_text: string | null
+      rag_context: Record<string, unknown> | null
+      created_at: string | null
+    }) => {
+      const topic = asString(row.topic_extracted?.topic) || 'Prior Social Content packet'
+      const openBrainRefs = asStringArray(row.rag_context?.open_brain_references)
+      const chronicleStatus = asString(row.rag_context?.chronicle_packet_status)
+      const chronicleNotes = asStringArray(row.rag_context?.chronicle_evidence_notes)
+      const type: SourceType = openBrainRefs.length ? 'open_brain' : 'portfolio_work'
+      return {
+        id: `social_content:${row.id}`,
+        type,
+        label: topic,
+        date: row.created_at,
+        summary: sanitizeSummary([
+          `Status: ${row.status ?? 'unknown'}`,
+          asString(row.topic_extracted?.angle) && `Angle: ${asString(row.topic_extracted?.angle)}`,
+          asString(row.topic_extracted?.personal_tie_in) && `Personal tie-in: ${asString(row.topic_extracted?.personal_tie_in)}`,
+          openBrainRefs.length && `Approved Open Brain refs: ${openBrainRefs.join(', ')}`,
+          chronicleStatus && `Chronicle status: ${chronicleStatus}`,
+          chronicleNotes.length && `Chronicle summaries: ${chronicleNotes.slice(0, 3).join(' | ')}`,
+          row.post_text && `Draft excerpt: ${truncate(row.post_text, 300)}`,
+        ].filter(Boolean).join('. '), 700),
+        sensitivity: chronicleNotes.length ? 'needs_review' as const : 'public_safe' as const,
+      }
+    })
+    .filter((signal: SourceSignal) => signal.summary)
+}
+
+async function collectSignals(currentId: string): Promise<SourceSignal[]> {
+  const [meetings, projects, runs, socialContent] = await Promise.all([
+    fetchRecentMeetingSignals().catch(() => []),
+    fetchClientProjectSignals().catch(() => []),
+    fetchAgentRunSignals().catch(() => []),
+    fetchRecentSocialContentSignals(currentId).catch(() => []),
+  ])
+
+  return [...meetings, ...projects, ...runs, ...socialContent].slice(0, 30)
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const authResult = await verifyAdmin(request)
+    if (isAuthError(authResult)) {
+      return NextResponse.json({ error: authResult.error }, { status: authResult.status })
+    }
+
+    const row = await fetchCurrentItem(params.id)
+    if (!row) {
+      return NextResponse.json({ error: 'Content not found' }, { status: 404 })
+    }
+
+    const ragContext = asRecord(row.rag_context) ?? {}
+    if (ragContext.source !== 'agent_ops_social_outreach_goal') {
+      return NextResponse.json({ error: 'Topic discovery is only available for Agent Ops social pilot drafts' }, { status: 400 })
+    }
+
+    const signals = await collectSignals(params.id)
+    if (signals.length === 0) {
+      return NextResponse.json({ error: 'No sanctioned source summaries were available for topic discovery' }, { status: 409 })
+    }
+
+    const model = process.env.SOCIAL_TOPIC_DISCOVERY_MODEL || 'gpt-4o-mini'
+    const aiResponse = await generateJsonCompletion({
+      model,
+      systemPrompt: "You are Shaka (Zulu), Vambah Sillah's Chief of Staff. You create review-only Social Content topic trigger packets from sanitized internal evidence.",
+      userPrompt: buildDiscoveryPrompt(row, signals),
+      temperature: 0.45,
+      maxTokens: 1800,
+      costContext: {
+        reference: { type: 'social_content_queue', id: params.id },
+        metadata: {
+          operation: 'social_content_topic_trigger_discovery',
+          signal_count: signals.length,
+          source_counts: sourceCounts(signals),
+        },
+      },
+    })
+
+    let parsed: DiscoveryResponse
+    try {
+      parsed = JSON.parse(aiResponse.content) as DiscoveryResponse
+    } catch {
+      return NextResponse.json({ error: 'Topic discovery returned invalid JSON' }, { status: 502 })
+    }
+
+    const candidates = normalizeCandidates(parsed, signals)
+    if (candidates.length === 0) {
+      return NextResponse.json({ error: 'Topic discovery did not return usable candidates' }, { status: 502 })
+    }
+
+    const generatedAt = new Date().toISOString()
+    const existingCalibration = asRecord(ragContext.content_calibration) ?? {}
+    const packet = {
+      version: 'social_topic_trigger_discovery_v1',
+      status: 'review_ready',
+      generated_at: generatedAt,
+      generated_by: authResult.user.id,
+      model: aiResponse.model,
+      provider: aiResponse.provider,
+      source_policy: 'sanitized_summaries_only',
+      source_counts: sourceCounts(signals),
+      candidates,
+      notes: asStringArray(parsed.notes).map((note) => truncate(note, 240)).slice(0, 5),
+      privacy_boundary: 'Review-only topic scouting. Raw meetings, Chronicle media, private ChatGPT exports, provider sends, publishing, and scheduling stay out of this action.',
+    }
+
+    const nextRagContext = {
+      ...ragContext,
+      content_calibration: {
+        ...existingCalibration,
+        status: 'topic_triggers_ready',
+        topic_trigger_packet: packet,
+      },
+    }
+
+    const { data: updated, error: updateError } = await supabaseAdmin
+      .from('social_content_queue')
+      .update({ rag_context: nextRagContext })
+      .eq('id', params.id)
+      .select('*')
+      .single()
+
+    if (updateError || !updated) {
+      console.error('[discover-topic-triggers] update failed:', updateError)
+      return NextResponse.json({ error: 'Failed to save topic trigger packet' }, { status: 500 })
+    }
+
+    return NextResponse.json({
+      success: true,
+      item: updated,
+      topic_trigger_packet: packet,
+    })
+  } catch (error) {
+    console.error('[discover-topic-triggers] error:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Internal server error' },
+      { status: 500 },
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- Add an authenticated Social Content topic-trigger discovery endpoint for Agent Ops pilot drafts.
- Store Shaka's review-only topic trigger packet in rag_context.content_calibration so it survives refreshes and later review.
- Add a Shaka topic scout panel in the Copy section so candidates can fill the triggering event/revision context without approving, publishing, scheduling, or calling visual providers.

## Validation
- npm test -- --run 'app/api/admin/social-content/[id]/discover-topic-triggers/route.test.ts' 'app/api/admin/social-content/[id]/calibration-revision/route.test.ts' 'app/api/admin/social-content/[id]/route.test.ts' 'app/admin/social-content/[id]/page.test.tsx'
- npx tsc --noEmit
- git diff --check
- Browser smoke on http://localhost:3022/admin/social-content/25d7efa3-62bc-4f5e-a191-1a131918593a confirmed the Shaka topic scout, Ask Shaka button, copy review controls, Visual Production, and no immediate publish control. I did not click Ask Shaka during smoke because it would make a real LLM/provider call and update DB state.

## Integration Notes
- No migrations or env changes.
- Topic discovery only reads sanitized Portfolio summaries/current rag_context and writes a review-only packet; raw Chronicle media, raw ChatGPT exports, publishing, scheduling, provider sends, and LinkedIn draft creation remain outside this action.
- Vercel contexts not checked for this draft implementation PR:
  - Vercel – portfolio
  - Vercel – portfolio-staging