### PR TITLE
feat: add Shaka social topic backlog

### DIFF
--- a/app/admin/social-content/[id]/page.test.tsx
+++ b/app/admin/social-content/[id]/page.test.tsx
@@ -70,14 +70,42 @@ describe('SocialContentDetailRoute visual production review', () => {
     publishes: [],
   }
 
+  const topicBacklogItem = {
+    id: 'topic-backlog-1',
+    candidate_key: 'approval-gates-review-meeting-1',
+    title: 'Approval gates create trust',
+    triggering_event: 'A recent Agent Ops review exposed where AI-generated work needed clearer ownership before publishing.',
+    source_type: 'meeting',
+    source_label: 'Agent Ops review',
+    source_ids: ['meeting:meeting-1'],
+    why_vambah_can_speak: 'You are building the Portfolio Agent Ops workflow and reviewed the approval path directly.',
+    brand_goal: 'Show AmaduTown builds governed AI systems.',
+    content_angle: 'AI needs accountable operating gates.',
+    suggested_hook: 'AI should reduce burden. That only happens when every risky action has a gate.',
+    audience: 'Product leaders adopting AI',
+    sensitivity: 'needs_review',
+    evidence_summary: 'Sanitized meeting summary.',
+    claim_boundaries: ['Do not name private meeting participants.'],
+    status: 'available',
+    last_seen_at: '2026-06-22T16:00:00.000Z',
+  }
+
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      json: async () => ({
-        item: baseItem,
-      }),
-    })))
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes('/topic-backlog')) {
+        return {
+          ok: true,
+          json: async () => ({ items: [topicBacklogItem] }),
+        } as Response
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          item: baseItem,
+        }),
+      } as Response
+    }))
   })
 
   afterEach(() => {
@@ -88,8 +116,10 @@ describe('SocialContentDetailRoute visual production review', () => {
     render(<SocialContentDetailRoute />)
 
     expect(await screen.findByText('Visual Production')).toBeInTheDocument()
-    expect(screen.getByText('Shaka topic scout')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /Ask Shaka for Topics/i })).toBeInTheDocument()
+    expect(await screen.findByText('Shaka topic backlog')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Ask Shaka for Topics/i })).not.toBeInTheDocument()
+    expect(screen.getByText('Approval gates create trust')).toBeInTheDocument()
+    expect(screen.getByText('Weekday scan')).toBeInTheDocument()
     expect(screen.queryByText('Review gates')).not.toBeInTheDocument()
     expect(screen.queryByText('Every gate uses the same state language; the detail line preserves each system status.')).not.toBeInTheDocument()
     expect(screen.queryByText(/Copy is approved and locked/i)).not.toBeInTheDocument()
@@ -144,49 +174,21 @@ describe('SocialContentDetailRoute visual production review', () => {
     expect(screen.getByDisplayValue('Create a framework visual about review gates.')).not.toBeDisabled()
   })
 
-  it('lets Shaka discover topic triggers and apply one to copy review', async () => {
-    const packet = {
-      version: 'social_topic_trigger_discovery_v1',
-      status: 'review_ready',
-      generated_at: '2026-06-21T20:00:00.000Z',
-      source_counts: { meeting: 1, client_safe_project: 1, shipped_feature: 1, open_brain: 1 },
-      candidates: [
-        {
-          id: 'approval-gates-review',
-          title: 'Approval gates create trust',
-          triggering_event: 'A recent Agent Ops review exposed where AI-generated work needed clearer ownership before publishing.',
-          source_type: 'meeting',
-          source_label: 'Agent Ops review',
-          source_ids: ['meeting:meeting-1'],
-          why_vambah_can_speak: 'You are building the Portfolio Agent Ops workflow and reviewed the approval path directly.',
-          brand_goal: 'Show AmaduTown builds governed AI systems.',
-          content_angle: 'AI needs accountable operating gates.',
-          suggested_hook: 'AI should reduce burden. That only happens when every risky action has a gate.',
-          audience: 'Product leaders adopting AI',
-          sensitivity: 'needs_review',
-          evidence_summary: 'Sanitized meeting summary.',
-          claim_boundaries: ['Do not name private meeting participants.'],
-        },
-      ],
-    }
+  it('lets the operator pull a topic from Shaka backlog into copy review', async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      if (String(input).includes('/discover-topic-triggers') && init?.method === 'POST') {
+      if (String(input).includes('/topic-backlog') && init?.method === 'PATCH') {
         return {
           ok: true,
           json: async () => ({
             success: true,
-            item: {
-              ...baseItem,
-              rag_context: {
-                ...baseItem.rag_context,
-                content_calibration: {
-                  status: 'topic_triggers_ready',
-                  topic_trigger_packet: packet,
-                },
-              },
-            },
-            topic_trigger_packet: packet,
+            item: { ...topicBacklogItem, status: 'selected' },
           }),
+        } as Response
+      }
+      if (String(input).includes('/topic-backlog')) {
+        return {
+          ok: true,
+          json: async () => ({ items: [topicBacklogItem] }),
         } as Response
       }
       return {
@@ -198,23 +200,24 @@ describe('SocialContentDetailRoute visual production review', () => {
 
     render(<SocialContentDetailRoute />)
 
-    fireEvent.click(await screen.findByRole('button', { name: /Ask Shaka for Topics/i }))
-
-    await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith(
-        expect.stringContaining('/api/admin/social-content/social-1/discover-topic-triggers'),
-        expect.objectContaining({ method: 'POST' }),
-      )
-    })
     expect(await screen.findByText('Approval gates create trust')).toBeInTheDocument()
     expect(screen.getByText(/Why you can speak on it:/)).toBeInTheDocument()
     expect(screen.getByText(/Hook: AI should reduce burden/)).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: /Use trigger/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Use topic/i }))
 
     expect(screen.getAllByDisplayValue(/recent Agent Ops review exposed/).length).toBeGreaterThan(0)
     expect(screen.getAllByDisplayValue(/Anchor this draft in Shaka's selected topic trigger/).length).toBeGreaterThan(0)
     expect(screen.getByRole('button', { name: /Reject and Generate Revision/i })).not.toBeDisabled()
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/api/admin/social-content/topic-backlog'),
+        expect.objectContaining({
+          method: 'PATCH',
+          body: expect.stringContaining('topic-backlog-1'),
+        }),
+      )
+    })
   })
 
   it('shows production assets and blocks publish readiness while redaction is unresolved', async () => {

--- a/app/admin/social-content/[id]/page.tsx
+++ b/app/admin/social-content/[id]/page.tsx
@@ -163,6 +163,12 @@ type CalibrationSuccessExample = {
 }
 
 type TopicTriggerCandidateRecord = Record<string, unknown>
+type TopicBacklogRecord = TopicTriggerCandidateRecord & {
+  id?: string
+  candidate_key?: string
+  last_seen_at?: string
+  generated_at?: string
+}
 
 const EMPTY_SUCCESS_EXAMPLE: CalibrationSuccessExample = {
   source_label: '',
@@ -255,7 +261,10 @@ function SocialContentDetailPage() {
   const [savingCalibration, setSavingCalibration] = useState(false)
   const [revisingCalibration, setRevisingCalibration] = useState(false)
   const [requestingCopyRevision, setRequestingCopyRevision] = useState(false)
-  const [discoveringTopicTriggers, setDiscoveringTopicTriggers] = useState(false)
+  const [loadingTopicBacklog, setLoadingTopicBacklog] = useState(false)
+  const [topicBacklogItems, setTopicBacklogItems] = useState<TopicBacklogRecord[]>([])
+  const [topicBacklogUnavailable, setTopicBacklogUnavailable] = useState(false)
+  const [selectedTopicBacklogId, setSelectedTopicBacklogId] = useState<string | null>(null)
   const [savingSectionGate, setSavingSectionGate] = useState<SectionGateKey | null>(null)
   const [showSource, setShowSource] = useState(false)
   const [expandedSection, setExpandedSection] = useState<'rag' | 'transcript' | null>(null)
@@ -287,6 +296,26 @@ function SocialContentDetailPage() {
     linkedin_draft: false,
   })
   const rejectedGateKeysRef = useRef<SectionGateKey[]>([])
+
+  const fetchTopicBacklog = useCallback(async () => {
+    setLoadingTopicBacklog(true)
+    try {
+      const session = await getCurrentSession()
+      if (!session) return
+
+      const res = await fetch('/api/admin/social-content/topic-backlog?status=available&limit=6', {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      })
+      const data = await res.json()
+      if (!res.ok) return
+      setTopicBacklogItems(Array.isArray(data.items) ? data.items : [])
+      setTopicBacklogUnavailable(Boolean(data.unavailable))
+    } catch (err) {
+      console.error('Failed to fetch topic backlog:', err)
+    } finally {
+      setLoadingTopicBacklog(false)
+    }
+  }, [])
 
   const fetchItem = useCallback(async (options: { silent?: boolean } = {}) => {
     if (!options.silent) setLoading(true)
@@ -338,6 +367,10 @@ function SocialContentDetailPage() {
   useEffect(() => {
     fetchItem()
   }, [fetchItem])
+
+  useEffect(() => {
+    fetchTopicBacklog()
+  }, [fetchTopicBacklog])
 
   const showMsg = (type: 'success' | 'error', text: string) => {
     setMessage({ type, text })
@@ -527,38 +560,7 @@ function SocialContentDetailPage() {
     }
   }
 
-  const handleDiscoverTopicTriggers = async () => {
-    if (!item) return
-    setDiscoveringTopicTriggers(true)
-    try {
-      const session = await getCurrentSession()
-      if (!session) return
-
-      const res = await fetch(`/api/admin/social-content/${id}/discover-topic-triggers`, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${session.access_token}`,
-          'Content-Type': 'application/json',
-        },
-      })
-
-      const data = await res.json()
-      if (!res.ok) {
-        showMsg('error', data.error || 'Failed to discover topic triggers')
-        return
-      }
-
-      const updated = data.item as SocialContentItem
-      setItem(updated)
-      showMsg('success', 'Shaka found topic triggers for review')
-    } catch {
-      showMsg('error', 'Failed to discover topic triggers')
-    } finally {
-      setDiscoveringTopicTriggers(false)
-    }
-  }
-
-  const handleUseTopicTrigger = (candidate: TopicTriggerCandidateRecord) => {
+  const handleUseTopicTrigger = async (candidate: TopicTriggerCandidateRecord) => {
     const title = asString(candidate.title).trim()
     const triggeringEvent = asString(candidate.triggering_event).trim()
     const audience = asString(candidate.audience).trim()
@@ -578,7 +580,30 @@ function SocialContentDetailPage() {
     if (!copyRevisionRequest.trim()) {
       setCopyRevisionRequest(revisionRequest)
     }
-    showMsg('success', 'Topic trigger added to the copy review')
+    const backlogId = asString(candidate.id)
+    if (backlogId && asString(candidate.candidate_key)) {
+      setSelectedTopicBacklogId(backlogId)
+      try {
+        const session = await getCurrentSession()
+        if (session) {
+          await fetch('/api/admin/social-content/topic-backlog', {
+            method: 'PATCH',
+            headers: {
+              Authorization: `Bearer ${session.access_token}`,
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              id: backlogId,
+              content_id: item?.id,
+              status: 'selected',
+            }),
+          })
+        }
+      } catch (err) {
+        console.error('Failed to mark topic backlog item selected:', err)
+      }
+    }
+    showMsg('success', 'Topic from Shaka backlog added to the copy review')
   }
 
   const handleRequestCopyRevision = async (generateRevision: boolean) => {
@@ -1234,6 +1259,10 @@ function SocialContentDetailPage() {
   const agentPilotTopicTriggerGeneratedAt = asString(agentPilotTopicTriggerPacket?.generated_at)
   const agentPilotTopicTriggerCandidates = asRecordArray(agentPilotTopicTriggerPacket?.candidates)
   const agentPilotTopicTriggerCounts = asRecord(agentPilotTopicTriggerPacket?.source_counts)
+  const displayedTopicBacklogItems = topicBacklogItems.length > 0
+    ? topicBacklogItems
+    : agentPilotTopicTriggerCandidates
+  const usingDraftTopicFallback = topicBacklogItems.length === 0 && agentPilotTopicTriggerCandidates.length > 0
   const productionAssets = getProductionAssets(ragContext)
   const redactionGate = getVideoRedactionGate(productionAssets)
   const sectionGateReviews = asRecord(ragContext?.section_gate_reviews) ?? {}
@@ -2065,35 +2094,42 @@ function SocialContentDetailPage() {
                     <div className="min-w-0">
                       <p className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.14em] text-blue-200">
                         <Lightbulb className="h-3.5 w-3.5" />
-                        Shaka topic scout
+                        Shaka topic backlog
                       </p>
                       <p className="mt-1 text-sm leading-6 text-blue-50/85">
-                        Cull recent meetings, shipped work, client-safe projects, and approved memory into trigger options.
+                        Pulled from Shaka&apos;s recurring scan of sanitized meetings, shipped work, client-safe projects, and approved memory.
                       </p>
                     </div>
                     <div className="flex shrink-0 flex-wrap items-center gap-2 lg:justify-end">
-                      {agentPilotTopicTriggerStatus && (
-                        <span className="rounded-full border border-blue-400/35 px-2 py-0.5 text-[10px] font-semibold text-blue-100">
-                          {agentPilotTopicTriggerStatus.replace(/_/g, ' ')}
-                        </span>
-                      )}
-                      <button
-                        type="button"
-                        onClick={handleDiscoverTopicTriggers}
-                        disabled={discoveringTopicTriggers}
-                        className="inline-flex items-center gap-2 rounded-lg border border-blue-400/45 px-3 py-2 text-sm font-semibold text-blue-100 transition-colors hover:bg-blue-500/10 disabled:opacity-50"
-                      >
-                        {discoveringTopicTriggers ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Sparkles className="h-3.5 w-3.5" />}
-                        Ask Shaka for Topics
-                      </button>
+                      <span className="rounded-full border border-blue-400/35 px-2 py-0.5 text-[10px] font-semibold text-blue-100">
+                        {loadingTopicBacklog ? 'Loading backlog' : `${displayedTopicBacklogItems.length} available`}
+                      </span>
+                      <span className="rounded-full border border-blue-400/25 px-2 py-0.5 text-[10px] text-blue-50/75">
+                        Weekday scan
+                      </span>
                     </div>
                   </div>
-                  {agentPilotTopicTriggerGeneratedAt && (
-                    <p className="mt-2 text-xs text-blue-50/65">
-                      Generated {new Date(agentPilotTopicTriggerGeneratedAt).toLocaleString()}
+                  {topicBacklogUnavailable && (
+                    <p className="mt-2 text-xs text-amber-200">
+                      Backlog migration pending. The scheduled scan will populate this after deployment.
                     </p>
                   )}
-                  {agentPilotTopicTriggerCounts && (
+                  {!topicBacklogUnavailable && displayedTopicBacklogItems.length === 0 && !loadingTopicBacklog && (
+                    <p className="mt-2 text-xs text-blue-50/65">
+                      No topics are available yet. Shaka&apos;s scheduled scan will populate this backlog.
+                    </p>
+                  )}
+                  {usingDraftTopicFallback && agentPilotTopicTriggerGeneratedAt && (
+                    <p className="mt-2 text-xs text-blue-50/65">
+                      Showing the last draft-local topic packet from {new Date(agentPilotTopicTriggerGeneratedAt).toLocaleString()} until the standing backlog is populated.
+                    </p>
+                  )}
+                  {usingDraftTopicFallback && agentPilotTopicTriggerStatus && (
+                    <p className="mt-1 text-xs text-blue-50/60">
+                      Packet status: {agentPilotTopicTriggerStatus.replace(/_/g, ' ')}
+                    </p>
+                  )}
+                  {usingDraftTopicFallback && agentPilotTopicTriggerCounts && (
                     <div className="mt-2 flex flex-wrap gap-1.5">
                       {Object.entries(agentPilotTopicTriggerCounts)
                         .filter(([, value]) => Number(value) > 0)
@@ -2104,11 +2140,18 @@ function SocialContentDetailPage() {
                         ))}
                     </div>
                   )}
-                  {agentPilotTopicTriggerCandidates.length > 0 && (
+                  {loadingTopicBacklog && displayedTopicBacklogItems.length === 0 && (
+                    <div className="mt-3 flex items-center gap-2 text-sm text-blue-50/70">
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      Loading Shaka&apos;s topic backlog
+                    </div>
+                  )}
+                  {displayedTopicBacklogItems.length > 0 && (
                     <div className="mt-3 grid gap-2">
-                      {agentPilotTopicTriggerCandidates.map((candidate, index) => {
+                      {displayedTopicBacklogItems.map((candidate, index) => {
                         const title = asString(candidate.title) || `Topic ${index + 1}`
                         const sensitivity = asString(candidate.sensitivity) || 'needs_review'
+                        const isSelectedTopic = selectedTopicBacklogId === asString(candidate.id)
                         return (
                           <div key={asString(candidate.id) || `${title}-${index}`} className="rounded-lg border border-blue-400/20 bg-background/35 p-3">
                             <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
@@ -2118,6 +2161,11 @@ function SocialContentDetailPage() {
                                   <span className="rounded-full border border-blue-400/25 px-2 py-0.5 text-[10px] text-blue-100">
                                     {sensitivity.replace(/_/g, ' ')}
                                   </span>
+                                  {isSelectedTopic && (
+                                    <span className="rounded-full border border-emerald-400/35 px-2 py-0.5 text-[10px] text-emerald-100">
+                                      Selected
+                                    </span>
+                                  )}
                                 </div>
                                 <p className="mt-1 text-sm leading-6 text-blue-50/85">
                                   {asString(candidate.triggering_event)}
@@ -2136,10 +2184,11 @@ function SocialContentDetailPage() {
                               <button
                                 type="button"
                                 onClick={() => handleUseTopicTrigger(candidate)}
-                                className="inline-flex shrink-0 items-center justify-center gap-2 rounded-lg bg-blue-400 px-3 py-2 text-sm font-semibold text-slate-950 transition-colors hover:bg-blue-300"
+                                disabled={isSelectedTopic}
+                                className="inline-flex shrink-0 items-center justify-center gap-2 rounded-lg bg-blue-400 px-3 py-2 text-sm font-semibold text-slate-950 transition-colors hover:bg-blue-300 disabled:opacity-60"
                               >
                                 <CheckCircle2 className="h-3.5 w-3.5" />
-                                Use trigger
+                                {isSelectedTopic ? 'Selected' : 'Use topic'}
                               </button>
                             </div>
                           </div>

--- a/app/api/admin/social-content/[id]/discover-topic-triggers/route.test.ts
+++ b/app/api/admin/social-content/[id]/discover-topic-triggers/route.test.ts
@@ -299,6 +299,34 @@ describe('POST /api/admin/social-content/[id]/discover-topic-triggers', () => {
     expect(body.backlog_items).toHaveLength(1)
   })
 
+  it('still saves the draft-local topic packet when the backlog table is unavailable', async () => {
+    mocks.backlogSelect.mockResolvedValueOnce({
+      data: null,
+      error: {
+        message: "Could not find the table 'public.social_topic_backlog' in the schema cache",
+      },
+    })
+
+    const response = await POST(request(), { params: { id: 'social-1' } })
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.topic_trigger_packet).toMatchObject({
+      version: 'social_topic_trigger_discovery_v1',
+      status: 'review_ready',
+    })
+    expect(body.backlog_items).toEqual([])
+    expect(body.backlog_warning).toContain('social_topic_backlog')
+    expect(mocks.update).toHaveBeenCalledWith({
+      rag_context: expect.objectContaining({
+        content_calibration: expect.objectContaining({
+          status: 'topic_triggers_ready',
+          topic_trigger_packet: expect.any(Object),
+        }),
+      }),
+    })
+  })
+
   it('rejects non-Agent-Ops social drafts', async () => {
     mocks.currentSingle.mockResolvedValueOnce({
       data: {

--- a/app/api/admin/social-content/[id]/discover-topic-triggers/route.test.ts
+++ b/app/api/admin/social-content/[id]/discover-topic-triggers/route.test.ts
@@ -13,6 +13,8 @@ const mocks = vi.hoisted(() => ({
   projectsLimit: vi.fn(),
   runsLimit: vi.fn(),
   update: vi.fn(),
+  backlogUpsert: vi.fn(),
+  backlogSelect: vi.fn(),
 }))
 
 vi.mock('@/lib/auth-server', () => ({
@@ -80,6 +82,12 @@ function limitTable(limitMock: ReturnType<typeof vi.fn>) {
         limit: limitMock,
       })),
     })),
+  }
+}
+
+function socialTopicBacklogTable() {
+  return {
+    upsert: mocks.backlogUpsert,
   }
 }
 
@@ -209,8 +217,22 @@ describe('POST /api/admin/social-content/[id]/discover-topic-triggers', () => {
         })),
       })),
     })
+    mocks.backlogSelect.mockResolvedValue({
+      data: [
+        {
+          id: 'topic-1',
+          candidate_key: 'approval-gates-review-meeting-meeting-1',
+          title: 'Approval gates create trust',
+        },
+      ],
+      error: null,
+    })
+    mocks.backlogUpsert.mockReturnValue({
+      select: mocks.backlogSelect,
+    })
     mocks.from.mockImplementation((table: string) => {
       if (table === 'social_content_queue') return socialContentTable()
+      if (table === 'social_topic_backlog') return socialTopicBacklogTable()
       if (table === 'meeting_records') return limitTable(mocks.meetingsLimit)
       if (table === 'client_projects') return limitTable(mocks.projectsLimit)
       if (table === 'agent_runs') return limitTable(mocks.runsLimit)
@@ -266,6 +288,15 @@ describe('POST /api/admin/social-content/[id]/discover-topic-triggers', () => {
         }),
       }),
     })
+    expect(mocks.backlogUpsert).toHaveBeenCalledWith([
+      expect.objectContaining({
+        candidate_key: expect.stringContaining('approval-gates-review'),
+        title: 'Approval gates create trust',
+        status: 'available',
+        source_policy: 'sanitized_summaries_only',
+      }),
+    ], { onConflict: 'candidate_key' })
+    expect(body.backlog_items).toHaveLength(1)
   })
 
   it('rejects non-Agent-Ops social drafts', async () => {

--- a/app/api/admin/social-content/[id]/discover-topic-triggers/route.ts
+++ b/app/api/admin/social-content/[id]/discover-topic-triggers/route.ts
@@ -39,16 +39,24 @@ export async function POST(
       actorId: authResult.user.id,
       operation: 'social_content_topic_trigger_discovery',
     })
-    const [updated, backlogItems] = await Promise.all([
-      saveTopicTriggerPacketToSocialContent(row, packet),
-      upsertSocialTopicBacklog(packet, 'manual_social_content_detail'),
-    ])
+    const updated = await saveTopicTriggerPacketToSocialContent(row, packet)
+    let backlogItems: unknown[] = []
+    let backlogWarning: string | null = null
+    try {
+      backlogItems = await upsertSocialTopicBacklog(packet, 'manual_social_content_detail')
+    } catch (backlogError) {
+      backlogWarning = backlogError instanceof Error
+        ? backlogError.message
+        : 'Topic backlog write failed'
+      console.warn('[discover-topic-triggers] topic backlog write skipped:', backlogWarning)
+    }
 
     return NextResponse.json({
       success: true,
       item: updated,
       topic_trigger_packet: packet,
       backlog_items: backlogItems,
+      backlog_warning: backlogWarning,
     })
   } catch (error) {
     console.error('[discover-topic-triggers] error:', error)

--- a/app/api/admin/social-content/[id]/discover-topic-triggers/route.ts
+++ b/app/api/admin/social-content/[id]/discover-topic-triggers/route.ts
@@ -1,401 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
-import { generateJsonCompletion } from '@/lib/llm-dispatch'
-import { supabaseAdmin } from '@/lib/supabase'
 import {
-  extractMeetingSummary,
-  extractMeetingTitle,
-} from '@/lib/social-content'
+  discoverSocialTopicCandidates,
+  fetchSocialContentTopicContext,
+  saveTopicTriggerPacketToSocialContent,
+  upsertSocialTopicBacklog,
+} from '@/lib/social-topic-backlog'
 
 export const dynamic = 'force-dynamic'
 export const maxDuration = 60
 
-type SourceType =
-  | 'meeting'
-  | 'shipped_feature'
-  | 'client_safe_project'
-  | 'chronicle_observation'
-  | 'chatgpt_session'
-  | 'open_brain'
-  | 'portfolio_work'
-
-type TopicSensitivity = 'public_safe' | 'client_safe_summary' | 'needs_review'
-
-type SocialContentRow = {
-  id: string
-  status: string
-  post_text: string | null
-  cta_text: string | null
-  hashtags: string[] | null
-  image_prompt: string | null
-  topic_extracted: unknown
-  hormozi_framework: unknown
-  rag_context: Record<string, unknown> | null
-}
-
-type SourceSignal = {
-  id: string
-  type: SourceType
-  label: string
-  summary: string
-  date?: string | null
-  sensitivity: TopicSensitivity
-}
-
-type TopicTriggerCandidate = {
-  id: string
-  title: string
-  triggering_event: string
-  source_type: SourceType
-  source_label: string
-  source_ids: string[]
-  why_vambah_can_speak: string
-  brand_goal: string
-  content_angle: string
-  suggested_hook: string
-  audience: string
-  sensitivity: TopicSensitivity
-  evidence_summary: string
-  claim_boundaries: string[]
-}
-
-type DiscoveryResponse = {
-  candidates?: unknown
-  notes?: unknown
-}
-
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null
-}
-
-function asString(value: unknown): string {
-  return typeof value === 'string' ? value : ''
-}
-
-function asStringArray(value: unknown): string[] {
-  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
-}
-
-function truncate(value: string, maxLength: number): string {
-  const trimmed = value.replace(/\s+/g, ' ').trim()
-  if (trimmed.length <= maxLength) return trimmed
-  return `${trimmed.slice(0, maxLength - 3).trim()}...`
-}
-
-function redactSensitiveText(value: string): string {
-  return value
-    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, '[email redacted]')
-    .replace(/\b(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b/g, '[phone redacted]')
-    .replace(/https?:\/\/[^\s]+/gi, (match) => {
-      try {
-        const url = new URL(match)
-        return `${url.origin}/[private-path-redacted]`
-      } catch {
-        return '[url redacted]'
-      }
-    })
-}
-
-function sanitizeSummary(value: unknown, maxLength = 700): string {
-  return truncate(redactSensitiveText(asString(value)), maxLength)
-}
-
-function normalizeTopicSensitivity(value: unknown, fallback: TopicSensitivity): TopicSensitivity {
-  if (value === 'public_safe' || value === 'client_safe_summary' || value === 'needs_review') {
-    return value
-  }
-  return fallback
-}
-
-function normalizeSourceType(value: unknown): SourceType {
-  if (
-    value === 'meeting'
-    || value === 'shipped_feature'
-    || value === 'client_safe_project'
-    || value === 'chronicle_observation'
-    || value === 'chatgpt_session'
-    || value === 'open_brain'
-    || value === 'portfolio_work'
-  ) {
-    return value
-  }
-  return 'portfolio_work'
-}
-
-function sourceCounts(signals: SourceSignal[]) {
-  return signals.reduce<Record<SourceType, number>>((counts, signal) => {
-    counts[signal.type] = (counts[signal.type] ?? 0) + 1
-    return counts
-  }, {
-    meeting: 0,
-    shipped_feature: 0,
-    client_safe_project: 0,
-    chronicle_observation: 0,
-    chatgpt_session: 0,
-    open_brain: 0,
-    portfolio_work: 0,
-  })
-}
-
-function normalizeCandidates(parsed: DiscoveryResponse, signals: SourceSignal[]): TopicTriggerCandidate[] {
-  const sourceIdSet = new Set(signals.map((signal) => signal.id))
-  return (Array.isArray(parsed.candidates) ? parsed.candidates : [])
-    .map((item, index) => {
-      const record = asRecord(item)
-      if (!record) return null
-      const sourceType = normalizeSourceType(record.source_type)
-      const candidate: TopicTriggerCandidate = {
-        id: asString(record.id).trim() || `topic-trigger-${index + 1}`,
-        title: truncate(asString(record.title), 90),
-        triggering_event: sanitizeSummary(record.triggering_event, 500),
-        source_type: sourceType,
-        source_label: truncate(asString(record.source_label), 120),
-        source_ids: asStringArray(record.source_ids).filter((id) => sourceIdSet.has(id)).slice(0, 4),
-        why_vambah_can_speak: sanitizeSummary(record.why_vambah_can_speak, 500),
-        brand_goal: truncate(asString(record.brand_goal), 180),
-        content_angle: sanitizeSummary(record.content_angle, 450),
-        suggested_hook: sanitizeSummary(record.suggested_hook, 280),
-        audience: truncate(asString(record.audience), 140),
-        sensitivity: normalizeTopicSensitivity(record.sensitivity, sourceType === 'client_safe_project' ? 'client_safe_summary' : 'needs_review'),
-        evidence_summary: sanitizeSummary(record.evidence_summary, 500),
-        claim_boundaries: asStringArray(record.claim_boundaries).map((boundary) => truncate(boundary, 160)).slice(0, 5),
-      }
-      if (!candidate.title || !candidate.triggering_event || !candidate.why_vambah_can_speak) return null
-      return candidate
-    })
-    .filter((item): item is TopicTriggerCandidate => Boolean(item))
-    .slice(0, 8)
-}
-
-function buildDiscoveryPrompt(row: SocialContentRow, signals: SourceSignal[]) {
-  const ragContext = asRecord(row.rag_context) ?? {}
-  return `Shaka is Vambah Sillah's Agent Ops Chief of Staff.
-
-Cull potential LinkedIn topic triggers from sanctioned internal summaries.
-The goal is to answer: why is Vambah qualified to speak about this topic now?
-
-Return JSON only:
-{
-  "candidates": [
-    {
-      "id": "short-stable-id",
-      "title": "topic title",
-      "triggering_event": "recent event or proof that makes the topic timely",
-      "source_type": "meeting | shipped_feature | client_safe_project | chronicle_observation | chatgpt_session | open_brain | portfolio_work",
-      "source_label": "human-readable source label",
-      "source_ids": ["internal source ids from the provided signals"],
-      "why_vambah_can_speak": "why this comes from Vambah's lived work, shipped work, or approved evidence",
-      "brand_goal": "how this advances AmaduTown or Vambah's thought leadership",
-      "content_angle": "plain-language angle for the draft",
-      "suggested_hook": "first-sentence candidate",
-      "audience": "primary reader",
-      "sensitivity": "public_safe | client_safe_summary | needs_review",
-      "evidence_summary": "sanitized evidence summary only",
-      "claim_boundaries": ["what to avoid or verify before publishing"]
-    }
-  ],
-  "notes": ["review-only notes"]
-}
-
-Rules:
-- Do not quote raw private chats, raw Chronicle notes, raw meeting transcripts, emails, phone numbers, account IDs, or private URLs.
-- Use only the sanitized summaries and approved packet fields below.
-- Prefer concrete triggers: a meeting theme, shipped feature, client-safe project pattern, approved Open Brain reference, or recent Portfolio work.
-- Mark anything involving client work, raw Chronicle, or private ChatGPT-derived material as needs_review unless it is already summarized as public-safe.
-- These candidates are review-only. Do not publish, schedule, send, call providers, or create drafts outside this packet.
-
-Current Social Content draft:
-${JSON.stringify({
-    id: row.id,
-    status: row.status,
-    post_text: truncate(row.post_text ?? '', 1200),
-    cta_text: row.cta_text,
-    hashtags: row.hashtags,
-    topic_extracted: row.topic_extracted,
-    hormozi_framework: row.hormozi_framework,
-    rag_context: {
-      source: ragContext.source,
-      goal_id: ragContext.goal_id,
-      content_packet_id: ragContext.content_packet_id,
-      open_brain_references: ragContext.open_brain_references,
-      chronicle_packet_status: ragContext.chronicle_packet_status,
-      chronicle_evidence_notes: ragContext.chronicle_evidence_notes,
-      source_provenance_checklist: ragContext.source_provenance_checklist,
-    },
-  }, null, 2)}
-
-Sanitized source signals:
-${JSON.stringify(signals, null, 2)}
-
-Vambah voice and brand filters:
-- Start from a concrete scene, meeting tension, shipped feature, or practical proof.
-- Connect the trigger to a larger system problem.
-- Keep the topic grounded in product strategy, AI governance, operational reality, access, dignity, and AmaduTown's build-the-system posture.
-- Avoid generic AI hype and detached consulting language.`
-}
-
-async function fetchCurrentItem(id: string) {
-  const { data, error } = await supabaseAdmin
-    .from('social_content_queue')
-    .select('id, status, post_text, cta_text, hashtags, image_prompt, topic_extracted, hormozi_framework, rag_context')
-    .eq('id', id)
-    .single()
-  if (error || !data) return null
-  return data as SocialContentRow
-}
-
-async function fetchRecentMeetingSignals(): Promise<SourceSignal[]> {
-  const { data } = await supabaseAdmin
-    .from('meeting_records')
-    .select('id, meeting_type, meeting_date, created_at, raw_notes, structured_notes')
-    .order('meeting_date', { ascending: false })
-    .limit(8)
-
-  return (data ?? []).map((meeting: {
-    id: string
-    meeting_type: string | null
-    meeting_date: string | null
-    created_at: string | null
-    raw_notes: string | null
-    structured_notes: Record<string, unknown> | null
-  }) => {
-    const title = extractMeetingTitle(meeting.raw_notes, meeting.structured_notes) || meeting.meeting_type || 'Recent meeting'
-    const summary = extractMeetingSummary(meeting.raw_notes, meeting.structured_notes)
-      || sanitizeSummary(meeting.structured_notes?.summary)
-      || 'Meeting summary unavailable; use only as an internal lead.'
-    return {
-      id: `meeting:${meeting.id}`,
-      type: 'meeting' as const,
-      label: `${title} (${meeting.meeting_date ?? meeting.created_at ?? 'recent'})`,
-      date: meeting.meeting_date ?? meeting.created_at,
-      summary: sanitizeSummary(summary),
-      sensitivity: 'needs_review' as const,
-    }
-  }).filter((signal: SourceSignal) => signal.summary)
-}
-
-async function fetchClientProjectSignals(): Promise<SourceSignal[]> {
-  const { data } = await supabaseAdmin
-    .from('client_projects')
-    .select('id, project_name, product_purchased, project_status, current_phase, created_at, updated_at')
-    .order('updated_at', { ascending: false })
-    .limit(8)
-
-  return (data ?? []).map((project: {
-    id: string
-    project_name: string | null
-    product_purchased: string | null
-    project_status: string | null
-    current_phase: string | null
-    created_at: string | null
-    updated_at: string | null
-  }) => ({
-    id: `client_project:${project.id}`,
-    type: 'client_safe_project' as const,
-    label: project.project_name || project.product_purchased || 'Client-safe project',
-    date: project.updated_at ?? project.created_at,
-    summary: sanitizeSummary([
-      project.project_name && `Project: ${project.project_name}`,
-      project.product_purchased && `Offer: ${project.product_purchased}`,
-      project.project_status && `Status: ${project.project_status}`,
-      project.current_phase && `Phase: ${project.current_phase}`,
-    ].filter(Boolean).join('. ')),
-    sensitivity: 'client_safe_summary' as const,
-  })).filter((signal: SourceSignal) => signal.summary)
-}
-
-async function fetchAgentRunSignals(): Promise<SourceSignal[]> {
-  const { data } = await supabaseAdmin
-    .from('agent_runs')
-    .select('id, agent_key, kind, title, status, current_step, subject_label, metadata, created_at')
-    .order('created_at', { ascending: false })
-    .limit(10)
-
-  return (data ?? []).map((run: {
-    id: string
-    agent_key: string | null
-    kind: string | null
-    title: string | null
-    status: string | null
-    current_step: string | null
-    subject_label: string | null
-    metadata: Record<string, unknown> | null
-    created_at: string | null
-  }) => {
-    const metadataSummary = sanitizeSummary([
-      asString(run.metadata?.goal_id) && `Goal ${asString(run.metadata?.goal_id)}`,
-      asString(run.metadata?.workflow) && `Workflow ${asString(run.metadata?.workflow)}`,
-      asString(run.metadata?.operation) && `Operation ${asString(run.metadata?.operation)}`,
-    ].filter(Boolean).join('. '), 300)
-    return {
-      id: `agent_run:${run.id}`,
-      type: run.kind?.includes('social_content') ? 'shipped_feature' as const : 'portfolio_work' as const,
-      label: run.title || run.subject_label || run.kind || 'Agent run',
-      date: run.created_at,
-      summary: sanitizeSummary([
-        run.agent_key && `Agent: ${run.agent_key}`,
-        run.kind && `Kind: ${run.kind}`,
-        run.status && `Status: ${run.status}`,
-        run.current_step && `Step: ${run.current_step}`,
-        metadataSummary,
-      ].filter(Boolean).join('. ')),
-      sensitivity: 'public_safe' as const,
-    }
-  }).filter((signal: SourceSignal) => signal.summary)
-}
-
-async function fetchRecentSocialContentSignals(currentId: string): Promise<SourceSignal[]> {
-  const { data } = await supabaseAdmin
-    .from('social_content_queue')
-    .select('id, status, topic_extracted, post_text, rag_context, created_at')
-    .in('status', ['draft', 'approved', 'published', 'rejected'])
-    .order('created_at', { ascending: false })
-    .limit(8)
-
-  return (data ?? [])
-    .filter((row: { id: string }) => row.id !== currentId)
-    .map((row: {
-      id: string
-      status: string | null
-      topic_extracted: Record<string, unknown> | null
-      post_text: string | null
-      rag_context: Record<string, unknown> | null
-      created_at: string | null
-    }) => {
-      const topic = asString(row.topic_extracted?.topic) || 'Prior Social Content packet'
-      const openBrainRefs = asStringArray(row.rag_context?.open_brain_references)
-      const chronicleStatus = asString(row.rag_context?.chronicle_packet_status)
-      const chronicleNotes = asStringArray(row.rag_context?.chronicle_evidence_notes)
-      const type: SourceType = openBrainRefs.length ? 'open_brain' : 'portfolio_work'
-      return {
-        id: `social_content:${row.id}`,
-        type,
-        label: topic,
-        date: row.created_at,
-        summary: sanitizeSummary([
-          `Status: ${row.status ?? 'unknown'}`,
-          asString(row.topic_extracted?.angle) && `Angle: ${asString(row.topic_extracted?.angle)}`,
-          asString(row.topic_extracted?.personal_tie_in) && `Personal tie-in: ${asString(row.topic_extracted?.personal_tie_in)}`,
-          openBrainRefs.length && `Approved Open Brain refs: ${openBrainRefs.join(', ')}`,
-          chronicleStatus && `Chronicle status: ${chronicleStatus}`,
-          chronicleNotes.length && `Chronicle summaries: ${chronicleNotes.slice(0, 3).join(' | ')}`,
-          row.post_text && `Draft excerpt: ${truncate(row.post_text, 300)}`,
-        ].filter(Boolean).join('. '), 700),
-        sensitivity: chronicleNotes.length ? 'needs_review' as const : 'public_safe' as const,
-      }
-    })
-    .filter((signal: SourceSignal) => signal.summary)
-}
-
-async function collectSignals(currentId: string): Promise<SourceSignal[]> {
-  const [meetings, projects, runs, socialContent] = await Promise.all([
-    fetchRecentMeetingSignals().catch(() => []),
-    fetchClientProjectSignals().catch(() => []),
-    fetchAgentRunSignals().catch(() => []),
-    fetchRecentSocialContentSignals(currentId).catch(() => []),
-  ])
-
-  return [...meetings, ...projects, ...runs, ...socialContent].slice(0, 30)
 }
 
 export async function POST(
@@ -408,7 +24,7 @@ export async function POST(
       return NextResponse.json({ error: authResult.error }, { status: authResult.status })
     }
 
-    const row = await fetchCurrentItem(params.id)
+    const row = await fetchSocialContentTopicContext(params.id)
     if (!row) {
       return NextResponse.json({ error: 'Content not found' }, { status: 404 })
     }
@@ -418,87 +34,26 @@ export async function POST(
       return NextResponse.json({ error: 'Topic discovery is only available for Agent Ops social pilot drafts' }, { status: 400 })
     }
 
-    const signals = await collectSignals(params.id)
-    if (signals.length === 0) {
-      return NextResponse.json({ error: 'No sanctioned source summaries were available for topic discovery' }, { status: 409 })
-    }
-
-    const model = process.env.SOCIAL_TOPIC_DISCOVERY_MODEL || 'gpt-4o-mini'
-    const aiResponse = await generateJsonCompletion({
-      model,
-      systemPrompt: "You are Shaka (Zulu), Vambah Sillah's Chief of Staff. You create review-only Social Content topic trigger packets from sanitized internal evidence.",
-      userPrompt: buildDiscoveryPrompt(row, signals),
-      temperature: 0.45,
-      maxTokens: 1800,
-      costContext: {
-        reference: { type: 'social_content_queue', id: params.id },
-        metadata: {
-          operation: 'social_content_topic_trigger_discovery',
-          signal_count: signals.length,
-          source_counts: sourceCounts(signals),
-        },
-      },
+    const { packet } = await discoverSocialTopicCandidates({
+      row,
+      actorId: authResult.user.id,
+      operation: 'social_content_topic_trigger_discovery',
     })
-
-    let parsed: DiscoveryResponse
-    try {
-      parsed = JSON.parse(aiResponse.content) as DiscoveryResponse
-    } catch {
-      return NextResponse.json({ error: 'Topic discovery returned invalid JSON' }, { status: 502 })
-    }
-
-    const candidates = normalizeCandidates(parsed, signals)
-    if (candidates.length === 0) {
-      return NextResponse.json({ error: 'Topic discovery did not return usable candidates' }, { status: 502 })
-    }
-
-    const generatedAt = new Date().toISOString()
-    const existingCalibration = asRecord(ragContext.content_calibration) ?? {}
-    const packet = {
-      version: 'social_topic_trigger_discovery_v1',
-      status: 'review_ready',
-      generated_at: generatedAt,
-      generated_by: authResult.user.id,
-      model: aiResponse.model,
-      provider: aiResponse.provider,
-      source_policy: 'sanitized_summaries_only',
-      source_counts: sourceCounts(signals),
-      candidates,
-      notes: asStringArray(parsed.notes).map((note) => truncate(note, 240)).slice(0, 5),
-      privacy_boundary: 'Review-only topic scouting. Raw meetings, Chronicle media, private ChatGPT exports, provider sends, publishing, and scheduling stay out of this action.',
-    }
-
-    const nextRagContext = {
-      ...ragContext,
-      content_calibration: {
-        ...existingCalibration,
-        status: 'topic_triggers_ready',
-        topic_trigger_packet: packet,
-      },
-    }
-
-    const { data: updated, error: updateError } = await supabaseAdmin
-      .from('social_content_queue')
-      .update({ rag_context: nextRagContext })
-      .eq('id', params.id)
-      .select('*')
-      .single()
-
-    if (updateError || !updated) {
-      console.error('[discover-topic-triggers] update failed:', updateError)
-      return NextResponse.json({ error: 'Failed to save topic trigger packet' }, { status: 500 })
-    }
+    const [updated, backlogItems] = await Promise.all([
+      saveTopicTriggerPacketToSocialContent(row, packet),
+      upsertSocialTopicBacklog(packet, 'manual_social_content_detail'),
+    ])
 
     return NextResponse.json({
       success: true,
       item: updated,
       topic_trigger_packet: packet,
+      backlog_items: backlogItems,
     })
   } catch (error) {
     console.error('[discover-topic-triggers] error:', error)
-    return NextResponse.json(
-      { error: error instanceof Error ? error.message : 'Internal server error' },
-      { status: 500 },
-    )
+    const message = error instanceof Error ? error.message : 'Internal server error'
+    const status = message.includes('No sanctioned source summaries') ? 409 : message.includes('invalid JSON') || message.includes('usable candidates') ? 502 : 500
+    return NextResponse.json({ error: message }, { status })
   }
 }

--- a/app/api/admin/social-content/topic-backlog/route.test.ts
+++ b/app/api/admin/social-content/topic-backlog/route.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  from: vi.fn(),
+  selectLimit: vi.fn(),
+  updateSingle: vi.fn(),
+  runSocialTopicBacklogDiscovery: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+vi.mock('@/lib/social-topic-backlog', () => ({
+  runSocialTopicBacklogDiscovery: mocks.runSocialTopicBacklogDiscovery,
+}))
+
+import { GET, PATCH, POST } from './route'
+
+describe('/api/admin/social-content/topic-backlog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-1' }, isAdmin: true })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.selectLimit.mockResolvedValue({
+      data: [
+        {
+          id: 'topic-1',
+          title: 'Approval gates create trust',
+          status: 'available',
+        },
+      ],
+      error: null,
+    })
+    mocks.updateSingle.mockResolvedValue({
+      data: {
+        id: 'topic-1',
+        status: 'selected',
+        selected_for_content_id: 'social-1',
+      },
+      error: null,
+    })
+    mocks.runSocialTopicBacklogDiscovery.mockResolvedValue({
+      backlogItems: [{ id: 'topic-1' }],
+      sourceCounts: { meeting: 1 },
+      packet: { candidates: [{ id: 'topic-1' }] },
+    })
+    mocks.from.mockReturnValue({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          order: vi.fn(() => ({
+            limit: mocks.selectLimit,
+          })),
+        })),
+      })),
+      update: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: mocks.updateSingle,
+          })),
+        })),
+      })),
+    })
+  })
+
+  it('lists available Shaka topic backlog entries', async () => {
+    const response = await GET(new NextRequest('http://localhost/api/admin/social-content/topic-backlog'))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      items: [
+        {
+          id: 'topic-1',
+          title: 'Approval gates create trust',
+          status: 'available',
+        },
+      ],
+    })
+  })
+
+  it('requires admin auth before listing entries', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Authentication required', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await GET(new NextRequest('http://localhost/api/admin/social-content/topic-backlog'))
+
+    expect(response.status).toBe(401)
+    expect(mocks.from).not.toHaveBeenCalled()
+  })
+
+  it('runs a manual backlog refresh without publish side effects', async () => {
+    const response = await POST(new NextRequest('http://localhost/api/admin/social-content/topic-backlog', {
+      method: 'POST',
+    }))
+
+    expect(response.status).toBe(200)
+    expect(mocks.runSocialTopicBacklogDiscovery).toHaveBeenCalledWith({
+      actorId: 'admin-1',
+      triggerSource: 'manual_admin_social_topic_backlog',
+    })
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      candidate_count: 1,
+      side_effects: {
+        provider_generation: false,
+        publish: false,
+        schedule: false,
+        external_post: false,
+      },
+    })
+  })
+
+  it('marks a backlog topic selected for a Social Content draft', async () => {
+    const response = await PATCH(new NextRequest('http://localhost/api/admin/social-content/topic-backlog', {
+      method: 'PATCH',
+      body: JSON.stringify({
+        id: 'topic-1',
+        content_id: 'social-1',
+        status: 'selected',
+      }),
+    }))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      item: {
+        id: 'topic-1',
+        status: 'selected',
+        selected_for_content_id: 'social-1',
+      },
+    })
+  })
+})

--- a/app/api/admin/social-content/topic-backlog/route.ts
+++ b/app/api/admin/social-content/topic-backlog/route.ts
@@ -1,0 +1,144 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { runSocialTopicBacklogDiscovery } from '@/lib/social-topic-backlog'
+import { supabaseAdmin } from '@/lib/supabase'
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 60
+
+function isMissingBacklogTable(error: unknown) {
+  const record = error && typeof error === 'object' ? error as Record<string, unknown> : null
+  const message = error instanceof Error
+    ? error.message
+    : typeof record?.message === 'string'
+      ? record.message
+      : String(error ?? '')
+  return message.includes('social_topic_backlog') && (
+    message.includes('does not exist')
+    || message.includes('Could not find the table')
+    || message.includes('schema cache')
+  )
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const authResult = await verifyAdmin(request)
+    if (isAuthError(authResult)) {
+      return NextResponse.json({ error: authResult.error }, { status: authResult.status })
+    }
+
+    const { searchParams } = new URL(request.url)
+    const status = searchParams.get('status') || 'available'
+    const limit = Math.min(Math.max(parseInt(searchParams.get('limit') || '8', 10), 1), 24)
+
+    const { data, error } = await supabaseAdmin
+      .from('social_topic_backlog')
+      .select('*')
+      .eq('status', status)
+      .order('last_seen_at', { ascending: false })
+      .limit(limit)
+
+    if (error) {
+      if (isMissingBacklogTable(error)) {
+        return NextResponse.json({
+          items: [],
+          unavailable: true,
+          error: 'Social topic backlog migration has not been applied yet',
+        })
+      }
+      throw new Error(error.message)
+    }
+
+    return NextResponse.json({ items: data ?? [] })
+  } catch (error) {
+    console.error('[social-topic-backlog] list failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to fetch social topic backlog' },
+      { status: 500 },
+    )
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const authResult = await verifyAdmin(request)
+    if (isAuthError(authResult)) {
+      return NextResponse.json({ error: authResult.error }, { status: authResult.status })
+    }
+
+    const result = await runSocialTopicBacklogDiscovery({
+      actorId: authResult.user.id,
+      triggerSource: 'manual_admin_social_topic_backlog',
+    })
+
+    return NextResponse.json({
+      success: true,
+      items: result.backlogItems,
+      source_counts: result.sourceCounts,
+      candidate_count: result.packet.candidates.length,
+      side_effects: {
+        provider_generation: false,
+        publish: false,
+        schedule: false,
+        external_post: false,
+      },
+    })
+  } catch (error) {
+    console.error('[social-topic-backlog] refresh failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to refresh social topic backlog' },
+      { status: 500 },
+    )
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const authResult = await verifyAdmin(request)
+    if (isAuthError(authResult)) {
+      return NextResponse.json({ error: authResult.error }, { status: authResult.status })
+    }
+
+    const body = await request.json().catch(() => ({})) as {
+      id?: string
+      content_id?: string
+      status?: string
+    }
+    if (!body.id) {
+      return NextResponse.json({ error: 'Topic backlog id is required' }, { status: 400 })
+    }
+
+    const nextStatus = body.status || 'selected'
+    if (!['available', 'selected', 'used', 'dismissed', 'archived'].includes(nextStatus)) {
+      return NextResponse.json({ error: 'Invalid topic backlog status' }, { status: 400 })
+    }
+
+    const update: Record<string, unknown> = {
+      status: nextStatus,
+      updated_at: new Date().toISOString(),
+    }
+    if (body.content_id) {
+      update.selected_for_content_id = body.content_id
+      update.selected_at = new Date().toISOString()
+    }
+
+    const { data, error } = await supabaseAdmin
+      .from('social_topic_backlog')
+      .update(update)
+      .eq('id', body.id)
+      .select('*')
+      .single()
+
+    if (error) {
+      throw new Error(error.message)
+    }
+
+    return NextResponse.json({ success: true, item: data })
+  } catch (error) {
+    console.error('[social-topic-backlog] update failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to update social topic backlog item' },
+      { status: 500 },
+    )
+  }
+}

--- a/app/api/cron/social-topic-backlog/route.test.ts
+++ b/app/api/cron/social-topic-backlog/route.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({
+  runSocialTopicBacklogDiscovery: vi.fn(),
+}))
+
+vi.mock('@/lib/social-topic-backlog', () => ({
+  runSocialTopicBacklogDiscovery: mocks.runSocialTopicBacklogDiscovery,
+}))
+
+import { GET, POST } from './route'
+
+describe('/api/cron/social-topic-backlog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.CRON_SECRET = 'cron-secret'
+    process.env.N8N_INGEST_SECRET = 'n8n-secret'
+    mocks.runSocialTopicBacklogDiscovery.mockResolvedValue({
+      backlogItems: [{ id: 'topic-1' }],
+      sourceCounts: { meeting: 1 },
+      packet: { candidates: [{ id: 'topic-1' }] },
+    })
+  })
+
+  it('rejects unauthenticated cron refreshes', async () => {
+    const response = await GET(new NextRequest('http://localhost/api/cron/social-topic-backlog'))
+
+    expect(response.status).toBe(401)
+    expect(mocks.runSocialTopicBacklogDiscovery).not.toHaveBeenCalled()
+  })
+
+  it('runs the scheduled Shaka backlog refresh', async () => {
+    const response = await GET(new NextRequest('http://localhost/api/cron/social-topic-backlog', {
+      headers: { authorization: 'Bearer cron-secret' },
+    }))
+
+    expect(response.status).toBe(200)
+    expect(mocks.runSocialTopicBacklogDiscovery).toHaveBeenCalledWith({
+      actorId: null,
+      triggerSource: 'vercel_cron_social_topic_backlog',
+    })
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      candidate_count: 1,
+      backlog_item_count: 1,
+      side_effects: {
+        provider_generation: false,
+        publish: false,
+        schedule: false,
+        external_post: false,
+      },
+    })
+  })
+
+  it('allows n8n/manual cron triggering with the ingest secret', async () => {
+    const response = await POST(new NextRequest('http://localhost/api/cron/social-topic-backlog', {
+      method: 'POST',
+      headers: { authorization: 'Bearer n8n-secret' },
+    }))
+
+    expect(response.status).toBe(200)
+    expect(mocks.runSocialTopicBacklogDiscovery).toHaveBeenCalledWith({
+      actorId: null,
+      triggerSource: 'manual_cron_social_topic_backlog',
+    })
+  })
+})

--- a/app/api/cron/social-topic-backlog/route.ts
+++ b/app/api/cron/social-topic-backlog/route.ts
@@ -1,0 +1,60 @@
+/**
+ * GET/POST /api/cron/social-topic-backlog
+ *
+ * Lets Shaka maintain a review-only Social Content topic backlog from
+ * sanitized internal summaries. Auth: Bearer CRON_SECRET or N8N_INGEST_SECRET.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { runSocialTopicBacklogDiscovery } from '@/lib/social-topic-backlog'
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 60
+
+function isAuthorizedCronRequest(request: NextRequest): boolean {
+  const token = request.headers.get('authorization')?.replace(/^Bearer\s+/i, '')
+  const allowedTokens = [process.env.CRON_SECRET, process.env.N8N_INGEST_SECRET].filter(Boolean)
+  return Boolean(token && allowedTokens.includes(token))
+}
+
+async function runBacklogRefresh(request: NextRequest) {
+  if (!isAuthorizedCronRequest(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const result = await runSocialTopicBacklogDiscovery({
+      actorId: null,
+      triggerSource: request.method === 'GET'
+        ? 'vercel_cron_social_topic_backlog'
+        : 'manual_cron_social_topic_backlog',
+    })
+
+    return NextResponse.json({
+      ok: true,
+      candidate_count: result.packet.candidates.length,
+      backlog_item_count: result.backlogItems.length,
+      source_counts: result.sourceCounts,
+      side_effects: {
+        provider_generation: false,
+        publish: false,
+        schedule: false,
+        external_post: false,
+      },
+    })
+  } catch (error) {
+    console.error('[social-topic-backlog-cron] failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Social topic backlog refresh failed' },
+      { status: 500 },
+    )
+  }
+}
+
+export async function GET(request: NextRequest) {
+  return runBacklogRefresh(request)
+}
+
+export async function POST(request: NextRequest) {
+  return runBacklogRefresh(request)
+}

--- a/lib/social-topic-backlog.ts
+++ b/lib/social-topic-backlog.ts
@@ -1,0 +1,574 @@
+import { generateJsonCompletion } from '@/lib/llm-dispatch'
+import { supabaseAdmin } from '@/lib/supabase'
+import {
+  extractMeetingSummary,
+  extractMeetingTitle,
+} from '@/lib/social-content'
+
+export type SourceType =
+  | 'meeting'
+  | 'shipped_feature'
+  | 'client_safe_project'
+  | 'chronicle_observation'
+  | 'chatgpt_session'
+  | 'open_brain'
+  | 'portfolio_work'
+
+export type TopicSensitivity = 'public_safe' | 'client_safe_summary' | 'needs_review'
+
+export type SocialContentTopicContext = {
+  id: string
+  status: string
+  post_text: string | null
+  cta_text: string | null
+  hashtags: string[] | null
+  image_prompt: string | null
+  topic_extracted: unknown
+  hormozi_framework: unknown
+  rag_context: Record<string, unknown> | null
+}
+
+export type SourceSignal = {
+  id: string
+  type: SourceType
+  label: string
+  summary: string
+  date?: string | null
+  sensitivity: TopicSensitivity
+}
+
+export type TopicTriggerCandidate = {
+  id: string
+  title: string
+  triggering_event: string
+  source_type: SourceType
+  source_label: string
+  source_ids: string[]
+  why_vambah_can_speak: string
+  brand_goal: string
+  content_angle: string
+  suggested_hook: string
+  audience: string
+  sensitivity: TopicSensitivity
+  evidence_summary: string
+  claim_boundaries: string[]
+}
+
+type DiscoveryResponse = {
+  candidates?: unknown
+  notes?: unknown
+}
+
+export type TopicTriggerPacket = {
+  version: 'social_topic_trigger_discovery_v1'
+  status: 'review_ready'
+  generated_at: string
+  generated_by: string | null
+  model: string
+  provider: string
+  source_policy: 'sanitized_summaries_only'
+  source_counts: Record<SourceType, number>
+  candidates: TopicTriggerCandidate[]
+  notes: string[]
+  privacy_boundary: string
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null
+}
+
+function asString(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
+}
+
+function truncate(value: string, maxLength: number): string {
+  const trimmed = value.replace(/\s+/g, ' ').trim()
+  if (trimmed.length <= maxLength) return trimmed
+  return `${trimmed.slice(0, maxLength - 3).trim()}...`
+}
+
+function redactSensitiveText(value: string): string {
+  return value
+    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, '[email redacted]')
+    .replace(/\b(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b/g, '[phone redacted]')
+    .replace(/https?:\/\/[^\s]+/gi, (match) => {
+      try {
+        const url = new URL(match)
+        return `${url.origin}/[private-path-redacted]`
+      } catch {
+        return '[url redacted]'
+      }
+    })
+}
+
+function sanitizeSummary(value: unknown, maxLength = 700): string {
+  return truncate(redactSensitiveText(asString(value)), maxLength)
+}
+
+function normalizeTopicSensitivity(value: unknown, fallback: TopicSensitivity): TopicSensitivity {
+  if (value === 'public_safe' || value === 'client_safe_summary' || value === 'needs_review') {
+    return value
+  }
+  return fallback
+}
+
+function normalizeSourceType(value: unknown): SourceType {
+  if (
+    value === 'meeting'
+    || value === 'shipped_feature'
+    || value === 'client_safe_project'
+    || value === 'chronicle_observation'
+    || value === 'chatgpt_session'
+    || value === 'open_brain'
+    || value === 'portfolio_work'
+  ) {
+    return value
+  }
+  return 'portfolio_work'
+}
+
+export function socialTopicSourceCounts(signals: SourceSignal[]) {
+  return signals.reduce<Record<SourceType, number>>((counts, signal) => {
+    counts[signal.type] = (counts[signal.type] ?? 0) + 1
+    return counts
+  }, {
+    meeting: 0,
+    shipped_feature: 0,
+    client_safe_project: 0,
+    chronicle_observation: 0,
+    chatgpt_session: 0,
+    open_brain: 0,
+    portfolio_work: 0,
+  })
+}
+
+function normalizeCandidates(parsed: DiscoveryResponse, signals: SourceSignal[]): TopicTriggerCandidate[] {
+  const sourceIdSet = new Set(signals.map((signal) => signal.id))
+  return (Array.isArray(parsed.candidates) ? parsed.candidates : [])
+    .map((item, index) => {
+      const record = asRecord(item)
+      if (!record) return null
+      const sourceType = normalizeSourceType(record.source_type)
+      const candidate: TopicTriggerCandidate = {
+        id: asString(record.id).trim() || `topic-trigger-${index + 1}`,
+        title: truncate(asString(record.title), 90),
+        triggering_event: sanitizeSummary(record.triggering_event, 500),
+        source_type: sourceType,
+        source_label: truncate(asString(record.source_label), 120),
+        source_ids: asStringArray(record.source_ids).filter((id) => sourceIdSet.has(id)).slice(0, 4),
+        why_vambah_can_speak: sanitizeSummary(record.why_vambah_can_speak, 500),
+        brand_goal: truncate(asString(record.brand_goal), 180),
+        content_angle: sanitizeSummary(record.content_angle, 450),
+        suggested_hook: sanitizeSummary(record.suggested_hook, 280),
+        audience: truncate(asString(record.audience), 140),
+        sensitivity: normalizeTopicSensitivity(record.sensitivity, sourceType === 'client_safe_project' ? 'client_safe_summary' : 'needs_review'),
+        evidence_summary: sanitizeSummary(record.evidence_summary, 500),
+        claim_boundaries: asStringArray(record.claim_boundaries).map((boundary) => truncate(boundary, 160)).slice(0, 5),
+      }
+      if (!candidate.title || !candidate.triggering_event || !candidate.why_vambah_can_speak) return null
+      return candidate
+    })
+    .filter((item): item is TopicTriggerCandidate => Boolean(item))
+    .slice(0, 8)
+}
+
+function buildDiscoveryPrompt(row: SocialContentTopicContext | null, signals: SourceSignal[]) {
+  const ragContext = asRecord(row?.rag_context) ?? {}
+  const currentDraft = row ? {
+    id: row.id,
+    status: row.status,
+    post_text: truncate(row.post_text ?? '', 1200),
+    cta_text: row.cta_text,
+    hashtags: row.hashtags,
+    topic_extracted: row.topic_extracted,
+    hormozi_framework: row.hormozi_framework,
+    rag_context: {
+      source: ragContext.source,
+      goal_id: ragContext.goal_id,
+      content_packet_id: ragContext.content_packet_id,
+      open_brain_references: ragContext.open_brain_references,
+      chronicle_packet_status: ragContext.chronicle_packet_status,
+      chronicle_evidence_notes: ragContext.chronicle_evidence_notes,
+      source_provenance_checklist: ragContext.source_provenance_checklist,
+    },
+  } : {
+    mode: 'standing_social_topic_backlog',
+    instruction: 'Cull evergreen and timely candidate topics for future Social Content drafts.',
+  }
+
+  return `Shaka is Vambah Sillah's Agent Ops Chief of Staff.
+
+Cull potential LinkedIn topic triggers from sanctioned internal summaries.
+The goal is to answer: why is Vambah qualified to speak about this topic now?
+
+Return JSON only:
+{
+  "candidates": [
+    {
+      "id": "short-stable-id",
+      "title": "topic title",
+      "triggering_event": "recent event or proof that makes the topic timely",
+      "source_type": "meeting | shipped_feature | client_safe_project | chronicle_observation | chatgpt_session | open_brain | portfolio_work",
+      "source_label": "human-readable source label",
+      "source_ids": ["internal source ids from the provided signals"],
+      "why_vambah_can_speak": "why this comes from Vambah's lived work, shipped work, or approved evidence",
+      "brand_goal": "how this advances AmaduTown or Vambah's thought leadership",
+      "content_angle": "plain-language angle for the draft",
+      "suggested_hook": "first-sentence candidate",
+      "audience": "primary reader",
+      "sensitivity": "public_safe | client_safe_summary | needs_review",
+      "evidence_summary": "sanitized evidence summary only",
+      "claim_boundaries": ["what to avoid or verify before publishing"]
+    }
+  ],
+  "notes": ["review-only notes"]
+}
+
+Rules:
+- Do not quote raw private chats, raw Chronicle notes, raw meeting transcripts, emails, phone numbers, account IDs, or private URLs.
+- Use only the sanitized summaries and approved packet fields below.
+- Prefer concrete triggers: a meeting theme, shipped feature, client-safe project pattern, approved Open Brain reference, or recent Portfolio work.
+- Mark anything involving client work, raw Chronicle, or private ChatGPT-derived material as needs_review unless it is already summarized as public-safe.
+- These candidates are review-only. Do not publish, schedule, send, call providers, or create drafts outside this packet.
+
+Current Social Content context:
+${JSON.stringify(currentDraft, null, 2)}
+
+Sanitized source signals:
+${JSON.stringify(signals, null, 2)}
+
+Vambah voice and brand filters:
+- Start from a concrete scene, meeting tension, shipped feature, or practical proof.
+- Connect the trigger to a larger system problem.
+- Keep the topic grounded in product strategy, AI governance, operational reality, access, dignity, and AmaduTown's build-the-system posture.
+- Avoid generic AI hype and detached consulting language.`
+}
+
+export async function fetchSocialContentTopicContext(id: string) {
+  const { data, error } = await supabaseAdmin
+    .from('social_content_queue')
+    .select('id, status, post_text, cta_text, hashtags, image_prompt, topic_extracted, hormozi_framework, rag_context')
+    .eq('id', id)
+    .single()
+  if (error || !data) return null
+  return data as SocialContentTopicContext
+}
+
+async function fetchRecentMeetingSignals(): Promise<SourceSignal[]> {
+  const { data } = await supabaseAdmin
+    .from('meeting_records')
+    .select('id, meeting_type, meeting_date, created_at, raw_notes, structured_notes')
+    .order('meeting_date', { ascending: false })
+    .limit(8)
+
+  return (data ?? []).map((meeting: {
+    id: string
+    meeting_type: string | null
+    meeting_date: string | null
+    created_at: string | null
+    raw_notes: string | null
+    structured_notes: Record<string, unknown> | null
+  }) => {
+    const title = extractMeetingTitle(meeting.raw_notes, meeting.structured_notes) || meeting.meeting_type || 'Recent meeting'
+    const summary = extractMeetingSummary(meeting.raw_notes, meeting.structured_notes)
+      || sanitizeSummary(meeting.structured_notes?.summary)
+      || 'Meeting summary unavailable; use only as an internal lead.'
+    return {
+      id: `meeting:${meeting.id}`,
+      type: 'meeting' as const,
+      label: `${title} (${meeting.meeting_date ?? meeting.created_at ?? 'recent'})`,
+      date: meeting.meeting_date ?? meeting.created_at,
+      summary: sanitizeSummary(summary),
+      sensitivity: 'needs_review' as const,
+    }
+  }).filter((signal: SourceSignal) => signal.summary)
+}
+
+async function fetchClientProjectSignals(): Promise<SourceSignal[]> {
+  const { data } = await supabaseAdmin
+    .from('client_projects')
+    .select('id, project_name, product_purchased, project_status, current_phase, created_at, updated_at')
+    .order('updated_at', { ascending: false })
+    .limit(8)
+
+  return (data ?? []).map((project: {
+    id: string
+    project_name: string | null
+    product_purchased: string | null
+    project_status: string | null
+    current_phase: string | null
+    created_at: string | null
+    updated_at: string | null
+  }) => ({
+    id: `client_project:${project.id}`,
+    type: 'client_safe_project' as const,
+    label: project.project_name || project.product_purchased || 'Client-safe project',
+    date: project.updated_at ?? project.created_at,
+    summary: sanitizeSummary([
+      project.project_name && `Project: ${project.project_name}`,
+      project.product_purchased && `Offer: ${project.product_purchased}`,
+      project.project_status && `Status: ${project.project_status}`,
+      project.current_phase && `Phase: ${project.current_phase}`,
+    ].filter(Boolean).join('. ')),
+    sensitivity: 'client_safe_summary' as const,
+  })).filter((signal: SourceSignal) => signal.summary)
+}
+
+async function fetchAgentRunSignals(): Promise<SourceSignal[]> {
+  const { data } = await supabaseAdmin
+    .from('agent_runs')
+    .select('id, agent_key, kind, title, status, current_step, subject_label, metadata, created_at')
+    .order('created_at', { ascending: false })
+    .limit(10)
+
+  return (data ?? []).map((run: {
+    id: string
+    agent_key: string | null
+    kind: string | null
+    title: string | null
+    status: string | null
+    current_step: string | null
+    subject_label: string | null
+    metadata: Record<string, unknown> | null
+    created_at: string | null
+  }) => {
+    const metadataSummary = sanitizeSummary([
+      asString(run.metadata?.goal_id) && `Goal ${asString(run.metadata?.goal_id)}`,
+      asString(run.metadata?.workflow) && `Workflow ${asString(run.metadata?.workflow)}`,
+      asString(run.metadata?.operation) && `Operation ${asString(run.metadata?.operation)}`,
+    ].filter(Boolean).join('. '), 300)
+    return {
+      id: `agent_run:${run.id}`,
+      type: run.kind?.includes('social_content') ? 'shipped_feature' as const : 'portfolio_work' as const,
+      label: run.title || run.subject_label || run.kind || 'Agent run',
+      date: run.created_at,
+      summary: sanitizeSummary([
+        run.agent_key && `Agent: ${run.agent_key}`,
+        run.kind && `Kind: ${run.kind}`,
+        run.status && `Status: ${run.status}`,
+        run.current_step && `Step: ${run.current_step}`,
+        metadataSummary,
+      ].filter(Boolean).join('. ')),
+      sensitivity: 'public_safe' as const,
+    }
+  }).filter((signal: SourceSignal) => signal.summary)
+}
+
+async function fetchRecentSocialContentSignals(currentId?: string): Promise<SourceSignal[]> {
+  const { data } = await supabaseAdmin
+    .from('social_content_queue')
+    .select('id, status, topic_extracted, post_text, rag_context, created_at')
+    .in('status', ['draft', 'approved', 'published', 'rejected'])
+    .order('created_at', { ascending: false })
+    .limit(8)
+
+  return (data ?? [])
+    .filter((row: { id: string }) => row.id !== currentId)
+    .map((row: {
+      id: string
+      status: string | null
+      topic_extracted: Record<string, unknown> | null
+      post_text: string | null
+      rag_context: Record<string, unknown> | null
+      created_at: string | null
+    }) => {
+      const topic = asString(row.topic_extracted?.topic) || 'Prior Social Content packet'
+      const openBrainRefs = asStringArray(row.rag_context?.open_brain_references)
+      const chronicleStatus = asString(row.rag_context?.chronicle_packet_status)
+      const chronicleNotes = asStringArray(row.rag_context?.chronicle_evidence_notes)
+      const type: SourceType = openBrainRefs.length ? 'open_brain' : 'portfolio_work'
+      return {
+        id: `social_content:${row.id}`,
+        type,
+        label: topic,
+        date: row.created_at,
+        summary: sanitizeSummary([
+          `Status: ${row.status ?? 'unknown'}`,
+          asString(row.topic_extracted?.angle) && `Angle: ${asString(row.topic_extracted?.angle)}`,
+          asString(row.topic_extracted?.personal_tie_in) && `Personal tie-in: ${asString(row.topic_extracted?.personal_tie_in)}`,
+          openBrainRefs.length && `Approved Open Brain refs: ${openBrainRefs.join(', ')}`,
+          chronicleStatus && `Chronicle status: ${chronicleStatus}`,
+          chronicleNotes.length && `Chronicle summaries: ${chronicleNotes.slice(0, 3).join(' | ')}`,
+          row.post_text && `Draft excerpt: ${truncate(row.post_text, 300)}`,
+        ].filter(Boolean).join('. '), 700),
+        sensitivity: chronicleNotes.length ? 'needs_review' as const : 'public_safe' as const,
+      }
+    })
+    .filter((signal: SourceSignal) => signal.summary)
+}
+
+export async function collectSocialTopicSignals(currentId?: string): Promise<SourceSignal[]> {
+  const [meetings, projects, runs, socialContent] = await Promise.all([
+    fetchRecentMeetingSignals().catch(() => []),
+    fetchClientProjectSignals().catch(() => []),
+    fetchAgentRunSignals().catch(() => []),
+    fetchRecentSocialContentSignals(currentId).catch(() => []),
+  ])
+
+  return [...meetings, ...projects, ...runs, ...socialContent].slice(0, 30)
+}
+
+export async function discoverSocialTopicCandidates(options: {
+  row?: SocialContentTopicContext | null
+  actorId?: string | null
+  operation?: string
+}) {
+  const signals = await collectSocialTopicSignals(options.row?.id)
+  if (signals.length === 0) {
+    throw new Error('No sanctioned source summaries were available for topic discovery')
+  }
+
+  const model = process.env.SOCIAL_TOPIC_DISCOVERY_MODEL || 'gpt-4o-mini'
+  const aiResponse = await generateJsonCompletion({
+    model,
+    systemPrompt: "You are Shaka (Zulu), Vambah Sillah's Chief of Staff. You create review-only Social Content topic trigger packets from sanitized internal evidence.",
+    userPrompt: buildDiscoveryPrompt(options.row ?? null, signals),
+    temperature: 0.45,
+    maxTokens: 1800,
+    costContext: {
+      reference: options.row
+        ? { type: 'social_content_queue', id: options.row.id }
+        : { type: 'social_topic_backlog', id: 'standing-topic-scan' },
+      metadata: {
+        operation: options.operation || 'social_content_topic_trigger_discovery',
+        signal_count: signals.length,
+        source_counts: socialTopicSourceCounts(signals),
+      },
+    },
+  })
+
+  let parsed: DiscoveryResponse
+  try {
+    parsed = JSON.parse(aiResponse.content) as DiscoveryResponse
+  } catch {
+    throw new Error('Topic discovery returned invalid JSON')
+  }
+
+  const candidates = normalizeCandidates(parsed, signals)
+  if (candidates.length === 0) {
+    throw new Error('Topic discovery did not return usable candidates')
+  }
+
+  const packet: TopicTriggerPacket = {
+    version: 'social_topic_trigger_discovery_v1',
+    status: 'review_ready',
+    generated_at: new Date().toISOString(),
+    generated_by: options.actorId ?? null,
+    model: aiResponse.model,
+    provider: aiResponse.provider,
+    source_policy: 'sanitized_summaries_only',
+    source_counts: socialTopicSourceCounts(signals),
+    candidates,
+    notes: asStringArray(parsed.notes).map((note) => truncate(note, 240)).slice(0, 5),
+    privacy_boundary: 'Review-only topic scouting. Raw meetings, Chronicle media, private ChatGPT exports, provider sends, publishing, and scheduling stay out of this action.',
+  }
+
+  return { packet, signals }
+}
+
+export async function saveTopicTriggerPacketToSocialContent(
+  row: SocialContentTopicContext,
+  packet: TopicTriggerPacket,
+) {
+  const ragContext = asRecord(row.rag_context) ?? {}
+  const existingCalibration = asRecord(ragContext.content_calibration) ?? {}
+  const nextRagContext = {
+    ...ragContext,
+    content_calibration: {
+      ...existingCalibration,
+      status: 'topic_triggers_ready',
+      topic_trigger_packet: packet,
+    },
+  }
+
+  const { data: updated, error } = await supabaseAdmin
+    .from('social_content_queue')
+    .update({ rag_context: nextRagContext })
+    .eq('id', row.id)
+    .select('*')
+    .single()
+
+  if (error || !updated) {
+    throw new Error('Failed to save topic trigger packet')
+  }
+
+  return updated
+}
+
+function candidateKey(candidate: TopicTriggerCandidate) {
+  return [
+    candidate.id,
+    candidate.source_type,
+    candidate.source_ids.join('-') || candidate.title,
+  ]
+    .join('-')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 180)
+}
+
+export async function upsertSocialTopicBacklog(packet: TopicTriggerPacket, triggerSource: string) {
+  const now = new Date().toISOString()
+  const rows = packet.candidates.map((candidate) => ({
+    candidate_key: candidateKey(candidate),
+    title: candidate.title,
+    triggering_event: candidate.triggering_event,
+    source_type: candidate.source_type,
+    source_label: candidate.source_label || null,
+    source_ids: candidate.source_ids,
+    why_vambah_can_speak: candidate.why_vambah_can_speak,
+    brand_goal: candidate.brand_goal || null,
+    content_angle: candidate.content_angle || null,
+    suggested_hook: candidate.suggested_hook || null,
+    audience: candidate.audience || null,
+    sensitivity: candidate.sensitivity,
+    evidence_summary: candidate.evidence_summary || null,
+    claim_boundaries: candidate.claim_boundaries,
+    status: 'available',
+    source_policy: packet.source_policy,
+    source_counts: packet.source_counts,
+    generated_by: packet.generated_by,
+    generated_at: packet.generated_at,
+    last_seen_at: now,
+    metadata: {
+      trigger_source: triggerSource,
+      model: packet.model,
+      provider: packet.provider,
+      notes: packet.notes,
+      privacy_boundary: packet.privacy_boundary,
+    },
+  }))
+
+  const { data, error } = await supabaseAdmin
+    .from('social_topic_backlog')
+    .upsert(rows, { onConflict: 'candidate_key' })
+    .select('*')
+
+  if (error) {
+    throw new Error(error.message || 'Failed to upsert social topic backlog')
+  }
+
+  return data ?? []
+}
+
+export async function runSocialTopicBacklogDiscovery(options: {
+  actorId?: string | null
+  triggerSource: string
+}) {
+  const { packet, signals } = await discoverSocialTopicCandidates({
+    actorId: options.actorId ?? null,
+    operation: 'social_topic_backlog_discovery',
+  })
+  const backlogItems = await upsertSocialTopicBacklog(packet, options.triggerSource)
+  return {
+    packet,
+    signals,
+    backlogItems,
+    sourceCounts: packet.source_counts,
+  }
+}

--- a/migrations/2026_06_22_social_topic_backlog.sql
+++ b/migrations/2026_06_22_social_topic_backlog.sql
@@ -62,16 +62,22 @@ ALTER TABLE public.social_topic_backlog ENABLE ROW LEVEL SECURITY;
 
 DROP POLICY IF EXISTS "Enable read for authenticated users" ON public.social_topic_backlog;
 CREATE POLICY "Enable read for authenticated users" ON public.social_topic_backlog
-    FOR SELECT USING (auth.role() = 'authenticated');
+    FOR SELECT
+    TO authenticated
+    USING (true);
 
 DROP POLICY IF EXISTS "Enable insert for service role" ON public.social_topic_backlog;
 CREATE POLICY "Enable insert for service role" ON public.social_topic_backlog
-    FOR INSERT WITH CHECK (auth.role() = 'service_role');
+    FOR INSERT
+    TO service_role
+    WITH CHECK (true);
 
 DROP POLICY IF EXISTS "Enable update for service role" ON public.social_topic_backlog;
 CREATE POLICY "Enable update for service role" ON public.social_topic_backlog
-    FOR UPDATE USING (auth.role() = 'service_role')
-    WITH CHECK (auth.role() = 'service_role');
+    FOR UPDATE
+    TO service_role
+    USING (true)
+    WITH CHECK (true);
 
 GRANT SELECT ON public.social_topic_backlog TO authenticated;
 GRANT ALL ON public.social_topic_backlog TO service_role;

--- a/migrations/2026_06_22_social_topic_backlog.sql
+++ b/migrations/2026_06_22_social_topic_backlog.sql
@@ -1,0 +1,87 @@
+-- ========================================
+-- Social Topic Backlog
+-- ========================================
+-- Purpose: Store Shaka-curated LinkedIn topic triggers as a reusable backlog
+-- for Social Content drafts. Entries are generated from sanitized internal
+-- summaries and remain review-only until a human selects them for a draft.
+
+CREATE TABLE IF NOT EXISTS public.social_topic_backlog (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    candidate_key TEXT NOT NULL UNIQUE,
+
+    title TEXT NOT NULL,
+    triggering_event TEXT NOT NULL,
+    source_type TEXT NOT NULL
+        CHECK (source_type IN (
+            'meeting',
+            'shipped_feature',
+            'client_safe_project',
+            'chronicle_observation',
+            'chatgpt_session',
+            'open_brain',
+            'portfolio_work'
+        )),
+    source_label TEXT,
+    source_ids TEXT[] DEFAULT '{}',
+
+    why_vambah_can_speak TEXT NOT NULL,
+    brand_goal TEXT,
+    content_angle TEXT,
+    suggested_hook TEXT,
+    audience TEXT,
+    sensitivity TEXT NOT NULL DEFAULT 'needs_review'
+        CHECK (sensitivity IN ('public_safe', 'client_safe_summary', 'needs_review')),
+    evidence_summary TEXT,
+    claim_boundaries TEXT[] DEFAULT '{}',
+
+    status TEXT NOT NULL DEFAULT 'available'
+        CHECK (status IN ('available', 'selected', 'used', 'dismissed', 'archived')),
+    source_policy TEXT NOT NULL DEFAULT 'sanitized_summaries_only',
+    source_counts JSONB DEFAULT '{}'::jsonb,
+    metadata JSONB DEFAULT '{}'::jsonb,
+
+    generated_by UUID,
+    selected_for_content_id UUID REFERENCES public.social_content_queue(id) ON DELETE SET NULL,
+    selected_at TIMESTAMPTZ,
+    generated_at TIMESTAMPTZ DEFAULT NOW(),
+    last_seen_at TIMESTAMPTZ DEFAULT NOW(),
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_social_topic_backlog_status
+    ON public.social_topic_backlog(status);
+
+CREATE INDEX IF NOT EXISTS idx_social_topic_backlog_last_seen
+    ON public.social_topic_backlog(last_seen_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_social_topic_backlog_source_type
+    ON public.social_topic_backlog(source_type);
+
+ALTER TABLE public.social_topic_backlog ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Enable read for authenticated users" ON public.social_topic_backlog;
+CREATE POLICY "Enable read for authenticated users" ON public.social_topic_backlog
+    FOR SELECT USING (auth.role() = 'authenticated');
+
+DROP POLICY IF EXISTS "Enable insert for service role" ON public.social_topic_backlog;
+CREATE POLICY "Enable insert for service role" ON public.social_topic_backlog
+    FOR INSERT WITH CHECK (auth.role() = 'service_role');
+
+DROP POLICY IF EXISTS "Enable update for service role" ON public.social_topic_backlog;
+CREATE POLICY "Enable update for service role" ON public.social_topic_backlog
+    FOR UPDATE USING (auth.role() = 'service_role')
+    WITH CHECK (auth.role() = 'service_role');
+
+GRANT SELECT ON public.social_topic_backlog TO authenticated;
+GRANT ALL ON public.social_topic_backlog TO service_role;
+
+DROP TRIGGER IF EXISTS update_social_topic_backlog_updated_at ON public.social_topic_backlog;
+CREATE TRIGGER update_social_topic_backlog_updated_at
+    BEFORE UPDATE ON public.social_topic_backlog
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+COMMENT ON TABLE public.social_topic_backlog IS 'Shaka-curated review-only Social Content topic triggers generated from sanitized internal summaries';
+COMMENT ON COLUMN public.social_topic_backlog.source_policy IS 'Privacy policy used by the generator; raw private sources are not stored in this table';
+COMMENT ON COLUMN public.social_topic_backlog.selected_for_content_id IS 'Social Content draft that pulled this topic into review, if selected';

--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,10 @@
     {
       "path": "/api/cron/agent-ops-slack-notifications",
       "schedule": "0 15 * * *"
+    },
+    {
+      "path": "/api/cron/social-topic-backlog",
+      "schedule": "0 16 * * 1-5"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add a persistent Shaka-curated social topic backlog for reusable LinkedIn trigger ideas.
- Add an admin backlog API, selection tracking, and a weekday cron refresh endpoint.
- Update the Social Content review page to pull from the standing topic backlog instead of asking the operator to manually trigger discovery per draft.
- Add a migration for social_topic_backlog and keep all topic candidates review-only/sanitized-summary only.

## Validation
- npm test -- --run 'app/api/admin/social-content/[id]/discover-topic-triggers/route.test.ts' 'app/api/admin/social-content/topic-backlog/route.test.ts' 'app/api/cron/social-topic-backlog/route.test.ts' 'app/admin/social-content/[id]/page.test.tsx'
- npx tsc --noEmit
- git diff --check
- Browser smoke on http://localhost:3022/admin/social-content/25d7efa3-62bc-4f5e-a191-1a131918593a confirmed the Shaka topic backlog panel renders, the old Ask Shaka button is gone, weekday scan state is visible, and Visual Production remains present.
- No provider-generation, publish, schedule, external-post, or live Shaka backlog refresh action was executed in browser smoke.

## Integration Notes
- Requires applying migrations/2026_06_22_social_topic_backlog.sql before the scheduled backlog can store entries.
- Adds Vercel cron path /api/cron/social-topic-backlog scheduled weekdays at 16:00 UTC.
- Local smoke showed the pre-migration fallback message cleanly when the table is not yet present.
- Vercel contexts not checked by this non-captain lane:
  - Vercel – portfolio
  - Vercel – portfolio-staging