### PR TITLE
feat: add read ai follow-up import

### DIFF
--- a/app/api/admin/read-ai/meetings/[id]/follow-up-import/route.ts
+++ b/app/api/admin/read-ai/meetings/[id]/follow-up-import/route.ts
@@ -51,24 +51,30 @@ export async function POST(
   }
 
   try {
-    const result = await importReadAiFollowUp({
-      readAiMeetingId: params.id,
-      contactName,
-      contactEmail,
-      company: stringField(body.company) || null,
-      projectName: stringField(body.project_name ?? body.projectName) || null,
-      userId: authorized.userId,
-      draft: draftSubject && draftBody
-        ? {
-            subject: draftSubject,
-            body: draftBody,
-            gmailDraftId: stringField(body.gmail_draft_id ?? body.gmailDraftId) || null,
-            gmailThreadId: stringField(body.gmail_thread_id ?? body.gmailThreadId) || null,
-            gmailMessageId: stringField(body.gmail_message_id ?? body.gmailMessageId) || null,
-            sourceEmailThreadId: stringField(body.source_email_thread_id ?? body.sourceEmailThreadId) || null,
-          }
-        : null,
-    })
+    const meeting = body.meeting && typeof body.meeting === 'object'
+      ? body.meeting as Record<string, unknown>
+      : undefined
+    const result = await importReadAiFollowUp(
+      {
+        readAiMeetingId: params.id,
+        contactName,
+        contactEmail,
+        company: stringField(body.company) || null,
+        projectName: stringField(body.project_name ?? body.projectName) || null,
+        userId: authorized.userId,
+        draft: draftSubject && draftBody
+          ? {
+              subject: draftSubject,
+              body: draftBody,
+              gmailDraftId: stringField(body.gmail_draft_id ?? body.gmailDraftId) || null,
+              gmailThreadId: stringField(body.gmail_thread_id ?? body.gmailThreadId) || null,
+              gmailMessageId: stringField(body.gmail_message_id ?? body.gmailMessageId) || null,
+              sourceEmailThreadId: stringField(body.source_email_thread_id ?? body.sourceEmailThreadId) || null,
+            }
+          : null,
+      },
+      meeting ? { meeting } : undefined,
+    )
 
     return NextResponse.json({ success: true, result }, { status: 201 })
   } catch (error) {

--- a/app/api/admin/read-ai/meetings/[id]/follow-up-import/route.ts
+++ b/app/api/admin/read-ai/meetings/[id]/follow-up-import/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { importReadAiFollowUp } from '@/lib/read-ai-follow-up-import'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * POST /api/admin/read-ai/meetings/:id/follow-up-import
+ *
+ * Imports a Read.ai meeting into the Portfolio follow-up system:
+ * - creates/updates the contact submission
+ * - creates/updates the meeting record by read_ai_meeting_id
+ * - promotes action items into meeting_action_tasks
+ * - optionally stores the drafted follow-up in client_update_drafts
+ * - optionally logs Gmail draft metadata in contact_communications/email_messages
+ *
+ * Auth: admin session or Bearer N8N_INGEST_SECRET.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const authorized = await authorizeRequest(request)
+  if (!authorized.ok) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let body: Record<string, unknown>
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const contactName = stringField(body.contact_name ?? body.contactName)
+  const contactEmail = stringField(body.contact_email ?? body.contactEmail)
+  if (!contactName || !contactEmail) {
+    return NextResponse.json(
+      { error: 'contact_name and contact_email are required' },
+      { status: 400 },
+    )
+  }
+
+  const draftSubject = stringField(body.draft_subject ?? body.draftSubject)
+  const draftBody = stringField(body.draft_body ?? body.draftBody)
+  if ((draftSubject && !draftBody) || (!draftSubject && draftBody)) {
+    return NextResponse.json(
+      { error: 'draft_subject and draft_body must be provided together' },
+      { status: 400 },
+    )
+  }
+
+  try {
+    const result = await importReadAiFollowUp({
+      readAiMeetingId: params.id,
+      contactName,
+      contactEmail,
+      company: stringField(body.company) || null,
+      projectName: stringField(body.project_name ?? body.projectName) || null,
+      userId: authorized.userId,
+      draft: draftSubject && draftBody
+        ? {
+            subject: draftSubject,
+            body: draftBody,
+            gmailDraftId: stringField(body.gmail_draft_id ?? body.gmailDraftId) || null,
+            gmailThreadId: stringField(body.gmail_thread_id ?? body.gmailThreadId) || null,
+            gmailMessageId: stringField(body.gmail_message_id ?? body.gmailMessageId) || null,
+            sourceEmailThreadId: stringField(body.source_email_thread_id ?? body.sourceEmailThreadId) || null,
+          }
+        : null,
+    })
+
+    return NextResponse.json({ success: true, result }, { status: 201 })
+  } catch (error) {
+    console.error(`[read-ai/meetings/${params.id}/follow-up-import] Import failed:`, error)
+    const message = error instanceof Error ? error.message : 'Failed to import follow-up'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}
+
+async function authorizeRequest(request: NextRequest): Promise<{ ok: boolean; userId?: string }> {
+  const authResult = await verifyAdmin(request)
+  if (!isAuthError(authResult)) {
+    return { ok: true, userId: authResult.user.id }
+  }
+
+  const expectedSecret = process.env.N8N_INGEST_SECRET
+  const authHeader = request.headers.get('authorization')
+  const token = authHeader?.replace(/^Bearer\s+/i, '')
+  if (expectedSecret && token === expectedSecret) {
+    return { ok: true }
+  }
+
+  return { ok: false }
+}
+
+function stringField(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}

--- a/docs/meeting-follow-up-communications-guide.md
+++ b/docs/meeting-follow-up-communications-guide.md
@@ -80,7 +80,49 @@ If WF-SLK never calls the webhook, WF-MCH never runs, so you get no Slack summar
 
 ---
 
-## 4. Follow-Up Meeting Scheduling (WF-FUP)
+## 4. Manual Read.ai Follow-Up Import
+
+When Read.ai has the transcript but the Slack-triggered intake path misses it, use the app import endpoint instead of pasting notes into disconnected docs.
+
+**Endpoint:** `POST /api/admin/read-ai/meetings/:read_ai_meeting_id/follow-up-import`
+
+**Auth:** Admin session or `Authorization: Bearer <N8N_INGEST_SECRET>`.
+
+**What it creates or updates:**
+
+- `contact_submissions`: creates or updates the contact by email, with `lead_source = warm_meeting` for new contacts.
+- `meeting_records`: creates or updates by `read_ai_meeting_id`, preserving transcript, summary, attendees, action items, report URL, and Gmail draft metadata.
+- `meeting_action_tasks`: promotes Read.ai action items into tracked tasks.
+- `client_update_drafts`: stores the follow-up email draft when `draft_subject` and `draft_body` are provided.
+- `contact_communications` and `email_messages`: logs a draft outbound email timeline row and stores Gmail draft/thread/message IDs in metadata.
+
+**Payload example:**
+
+```json
+{
+  "contact_name": "Neil Rhein",
+  "contact_email": "neil@keepmassbeautiful.org",
+  "company": "Keep Massachusetts Beautiful",
+  "project_name": "KMB FireSpring web migration",
+  "draft_subject": "KMB Balance Proof Site - Round 1 Revision Requests",
+  "draft_body": "Hi Andrew,\n\nNeil and I reviewed the proof site...",
+  "gmail_draft_id": "r-3368138120782057946",
+  "gmail_thread_id": "19eefc89d9bc4c6b",
+  "source_email_thread_id": "19ea8770420bcb64"
+}
+```
+
+**Recommended KMB use:**
+
+1. Use `GET /api/admin/read-ai/meetings?email=neil@keepmassbeautiful.org` to find the latest Neil/KMB meeting.
+2. Create or revise the Gmail draft for FireSpring.
+3. Call the follow-up import endpoint with the Read.ai meeting ID and Gmail draft metadata.
+4. Review the imported action tasks in **Admin > Meeting Tasks**.
+5. Review the draft in **Client Update Drafts** and the contact email timeline before sending.
+
+---
+
+## 5. Follow-Up Meeting Scheduling (WF-FUP)
 
 After each meeting is processed by WF-MCH, a follow-up meeting can be automatically scheduled via **WF-FUP: Follow-Up Meeting Scheduler** (n8n workflow ID: `HyVGDTStTaWYL4Do`).
 
@@ -121,7 +163,7 @@ After each meeting is processed by WF-MCH, a follow-up meeting can be automatica
 
 ---
 
-## 5. Client Email Draft Responses (WF-GDR)
+## 6. Client Email Draft Responses (WF-GDR)
 
 When a client sends an email, a draft reply is automatically generated and stored **in the app** (visible in Admin > Meeting Tasks > Client Update Drafts).
 
@@ -162,7 +204,7 @@ The LLM prompt used to generate draft replies is editable at **Admin > System Pr
 
 ---
 
-## 6. Meeting Action Tasks and Client Update Drafts
+## 7. Meeting Action Tasks and Client Update Drafts
 
 Action items from meetings are tracked as tasks and can trigger client update emails. See the **Admin > Meeting Tasks** page for:
 
@@ -171,7 +213,7 @@ Action items from meetings are tracked as tasks and can trigger client update em
 
 ---
 
-## 7. WF-MCH RAG dependency (separate issue)
+## 8. WF-MCH RAG dependency (separate issue)
 
 Some WF-MCH runs fail because the **Fetch RAG (MCH)** node calls `POST https://n8n.amadutown.com/webhook/amadutown-rag-query`, which returns 404 (webhook not registered). So even when WF-MCH is triggered, it can error before reaching "Post Summary to Slack". Fix by either:
 
@@ -180,7 +222,7 @@ Some WF-MCH runs fail because the **Fetch RAG (MCH)** node calls `POST https://n
 
 ---
 
-## 8. Summary
+## 9. Summary
 
 | Your expectation | Actual design |
 |------------------|----------------|
@@ -188,5 +230,6 @@ Some WF-MCH runs fail because the **Fetch RAG (MCH)** node calls `POST https://n
 | Notification when meeting is complete | **Slack message** from WF-MCH with summary, decisions, action items, open questions. |
 | Draft follow-up email | **Gmail draft** created by WF-MCH "Build Follow-Up Email" + "Create Follow-Up Draft" nodes. |
 | Follow-up meeting scheduling | **WF-FUP** creates a Calendly scheduling link and notifies client via Slack or email. |
+| Manual missed Read.ai import | **Read.ai follow-up import endpoint** imports the transcript into Portfolio and links draft metadata when Slack intake misses it. |
 | Draft reply to client emails | **WF-GDR** (id: `7dsXnjup9zi5rf8N`) generates LLM-based draft replies stored in the app (Client Update Drafts) and as Gmail drafts. |
 | Action item tracking | **Meeting Action Tasks** promoted from meeting records, synced to Slack Kanban channels. |

--- a/docs/meeting-follow-up-communications-guide.md
+++ b/docs/meeting-follow-up-communications-guide.md
@@ -88,6 +88,8 @@ When Read.ai has the transcript but the Slack-triggered intake path misses it, u
 
 **Auth:** Admin session or `Authorization: Bearer <N8N_INGEST_SECRET>`.
 
+By default the app fetches the meeting from Read.ai using its stored integration token. If that app token is stale but another trusted workflow or connector already fetched the meeting, include a `meeting` object in the request body and the endpoint will import that supplied payload instead.
+
 **What it creates or updates:**
 
 - `contact_submissions`: creates or updates the contact by email, with `lead_source = warm_meeting` for new contacts.
@@ -108,7 +110,13 @@ When Read.ai has the transcript but the Slack-triggered intake path misses it, u
   "draft_body": "Hi Andrew,\n\nNeil and I reviewed the proof site...",
   "gmail_draft_id": "r-3368138120782057946",
   "gmail_thread_id": "19eefc89d9bc4c6b",
-  "source_email_thread_id": "19ea8770420bcb64"
+  "source_email_thread_id": "19ea8770420bcb64",
+  "meeting": {
+    "id": "01KVDTBWZYQ48J06DD303PAVGD",
+    "title": "Neil Rhein and Vambah Sillah",
+    "summary": "Optional pre-fetched Read.ai meeting payload when the app token should not be used.",
+    "action_items": ["Send FireSpring Round 1 feedback."]
+  }
 }
 ```
 

--- a/lib/read-ai-follow-up-import.test.ts
+++ b/lib/read-ai-follow-up-import.test.ts
@@ -48,6 +48,19 @@ describe('read-ai follow-up import helpers', () => {
     expect(text).toBe('Neil: The homepage images feel too boxed in.\nVambah: We can soften that.')
   })
 
+  it('normalizes transcript turns from the Read.ai connector shape', () => {
+    const text = normalizeReadAiTranscript({
+      transcript: {
+        turns: [
+          { speaker: { name: 'Neil Rhein' }, text: 'Can the theme support breadcrumbs?' },
+          { speaker: { name: 'Vambah Sillah' }, text: 'We should confirm that with FireSpring.' },
+        ],
+      },
+    })
+
+    expect(text).toBe('Neil Rhein: Can the theme support breadcrumbs?\nVambah Sillah: We should confirm that with FireSpring.')
+  })
+
   it('normalizes mixed Read.ai action item shapes', () => {
     expect(normalizeReadAiActionItems([
       'Send FireSpring the first revision packet.',
@@ -97,7 +110,7 @@ describe('read-ai follow-up import helpers', () => {
 
     expect(payload).toMatchObject({
       read_ai_meeting_id: '01KVDTBWZYQ48J06DD303PAVGD',
-      meeting_type: 'client_follow_up',
+      meeting_type: 'progress_checkin',
       meeting_date: '2026-06-18T14:00:00.000Z',
       duration_minutes: 45,
       transcript: 'Transcript text',

--- a/lib/read-ai-follow-up-import.test.ts
+++ b/lib/read-ai-follow-up-import.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: null,
+}))
+
+vi.mock('@/lib/client-update-drafts', () => ({
+  createDraftDirect: vi.fn(),
+}))
+
+vi.mock('@/lib/email-messages', () => ({
+  insertEmailMessageFromCommunication: vi.fn(),
+}))
+
+vi.mock('@/lib/meeting-action-tasks', () => ({
+  promoteActionItems: vi.fn(),
+}))
+
+vi.mock('@/lib/read-ai', () => ({
+  getMeetingDetail: vi.fn(),
+}))
+
+import {
+  buildReadAiMeetingRecordPayload,
+  normalizeReadAiActionItems,
+  normalizeReadAiTranscript,
+} from './read-ai-follow-up-import'
+
+describe('read-ai follow-up import helpers', () => {
+  it('normalizes transcript text from the direct Read.ai shape', () => {
+    const text = normalizeReadAiTranscript({
+      transcript: { text: 'Neil: Can we adjust the template?\nVambah: Yes.' },
+    })
+
+    expect(text).toBe('Neil: Can we adjust the template?\nVambah: Yes.')
+  })
+
+  it('normalizes transcript speaker blocks when Read.ai returns segmented transcript data', () => {
+    const text = normalizeReadAiTranscript({
+      transcript: {
+        speaker_blocks: [
+          { speaker_name: 'Neil', text: 'The homepage images feel too boxed in.' },
+          { speaker_name: 'Vambah', words: [{ text: 'We' }, { text: 'can' }, { text: 'soften' }, { text: 'that.' }] },
+        ],
+      },
+    })
+
+    expect(text).toBe('Neil: The homepage images feel too boxed in.\nVambah: We can soften that.')
+  })
+
+  it('normalizes mixed Read.ai action item shapes', () => {
+    expect(normalizeReadAiActionItems([
+      'Send FireSpring the first revision packet.',
+      { action: 'Replace placeholder yoga image.', owner: 'Neil' },
+      { title: 'Confirm donation link targets.', assignee: 'Vambah' },
+      { text: 'Review logo options with the board.' },
+      { ignored: true },
+    ])).toEqual([
+      { text: 'Send FireSpring the first revision packet.' },
+      { text: 'Replace placeholder yoga image.', assignee: 'Neil' },
+      { text: 'Confirm donation link targets.', assignee: 'Vambah' },
+      { text: 'Review logo options with the board.' },
+    ])
+  })
+
+  it('builds a meeting_records payload with Portfolio follow-up provenance', () => {
+    const payload = buildReadAiMeetingRecordPayload(
+      {
+        id: 'read-ai-1',
+        title: 'Neil Rhein and Vambah Sillah',
+        start_time_ms: Date.parse('2026-06-18T14:00:00.000Z'),
+        end_time_ms: Date.parse('2026-06-18T14:45:00.000Z'),
+        participants: [
+          { name: 'Neil Rhein', email: 'neil@keepmassbeautiful.org', attended: true },
+        ],
+        owner: { name: 'Vambah Sillah', email: 'vambah@example.com' },
+        report_url: 'https://app.read.ai/analytics/meetings/01KVDTBWZYQ48J06DD303PAVGD',
+        platform: 'google_meet',
+        summary: 'Discussed FireSpring proof-site revision requests.',
+        action_items: [{ text: 'Send consolidated feedback to FireSpring.', assignee: 'Vambah' }],
+        transcript: { text: 'Transcript text' },
+      },
+      {
+        readAiMeetingId: '01KVDTBWZYQ48J06DD303PAVGD',
+        contactName: 'Neil Rhein',
+        contactEmail: 'neil@keepmassbeautiful.org',
+        company: 'Keep Massachusetts Beautiful',
+        projectName: 'KMB FireSpring web migration',
+        draft: {
+          subject: 'KMB Balance Proof Site - Round 1 Revision Requests',
+          body: 'Draft body',
+          gmailDraftId: 'gmail-draft-1',
+          gmailThreadId: 'gmail-thread-1',
+        },
+      },
+    )
+
+    expect(payload).toMatchObject({
+      read_ai_meeting_id: '01KVDTBWZYQ48J06DD303PAVGD',
+      meeting_type: 'client_follow_up',
+      meeting_date: '2026-06-18T14:00:00.000Z',
+      duration_minutes: 45,
+      transcript: 'Transcript text',
+      action_items: [{ text: 'Send consolidated feedback to FireSpring.', assignee: 'Vambah' }],
+      structured_notes: {
+        title: 'Neil Rhein and Vambah Sillah',
+        summary: 'Discussed FireSpring proof-site revision requests.',
+        project_name: 'KMB FireSpring web migration',
+        source: 'read_ai_follow_up_import',
+      },
+      meeting_data: {
+        read_ai_meeting_id: '01KVDTBWZYQ48J06DD303PAVGD',
+        gmail_draft_id: 'gmail-draft-1',
+        gmail_thread_id: 'gmail-thread-1',
+        source: 'read_ai_follow_up_import',
+      },
+    })
+  })
+})

--- a/lib/read-ai-follow-up-import.ts
+++ b/lib/read-ai-follow-up-import.ts
@@ -1,0 +1,431 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { createDraftDirect } from '@/lib/client-update-drafts'
+import { insertEmailMessageFromCommunication } from '@/lib/email-messages'
+import { promoteActionItems } from '@/lib/meeting-action-tasks'
+import { getMeetingDetail, type ReadAiMeeting } from '@/lib/read-ai'
+import { supabaseAdmin } from '@/lib/supabase'
+
+type DbClient = SupabaseClient | typeof supabaseAdmin
+
+export interface ReadAiFollowUpDraftInput {
+  subject: string
+  body: string
+  gmailDraftId?: string | null
+  gmailThreadId?: string | null
+  gmailMessageId?: string | null
+  sourceEmailThreadId?: string | null
+}
+
+export interface ImportReadAiFollowUpInput {
+  readAiMeetingId: string
+  contactName: string
+  contactEmail: string
+  company?: string | null
+  projectName?: string | null
+  draft?: ReadAiFollowUpDraftInput | null
+  userId?: string
+}
+
+export interface ImportReadAiFollowUpResult {
+  contactSubmissionId: number
+  meetingRecordId: string
+  actionTasks: { created: number; skipped: number }
+  clientUpdateDraftId: string | null
+  contactCommunicationId: string | null
+  emailMessageId: string | null
+  meetingWasExisting: boolean
+}
+
+interface ImportReadAiFollowUpOptions {
+  db?: DbClient
+  meeting?: ReadAiMeeting
+}
+
+export function normalizeReadAiTranscript(meeting: ReadAiMeeting | Record<string, unknown>): string {
+  const transcript = (meeting as Record<string, unknown>).transcript
+  if (!transcript) return ''
+  if (typeof transcript === 'string') return transcript.trim()
+  if (typeof transcript === 'object' && !Array.isArray(transcript)) {
+    const obj = transcript as Record<string, unknown>
+    if (typeof obj.text === 'string') return obj.text.trim()
+    if (Array.isArray(obj.speaker_blocks)) return transcriptBlocksToText(obj.speaker_blocks)
+    if (Array.isArray(obj.blocks)) return transcriptBlocksToText(obj.blocks)
+  }
+  if (Array.isArray(transcript)) return transcriptBlocksToText(transcript)
+  return ''
+}
+
+export function normalizeReadAiActionItems(input: unknown): Array<{ text: string; assignee?: string }> {
+  if (!Array.isArray(input)) return []
+
+  return input.flatMap((item) => {
+    if (typeof item === 'string') {
+      const text = item.trim()
+      return text ? [{ text }] : []
+    }
+    if (!item || typeof item !== 'object') return []
+
+    const raw = item as Record<string, unknown>
+    const text = stringValue(raw.text ?? raw.action ?? raw.title)
+    if (!text) return []
+
+    const assignee = stringValue(raw.assignee ?? raw.owner)
+    return assignee ? [{ text, assignee }] : [{ text }]
+  })
+}
+
+export function buildReadAiMeetingRecordPayload(
+  meeting: ReadAiMeeting | Record<string, unknown>,
+  input: ImportReadAiFollowUpInput,
+): Record<string, unknown> {
+  const summary = normalizeSummary((meeting as Record<string, unknown>).summary)
+  const actionItems = normalizeReadAiActionItems((meeting as Record<string, unknown>).action_items)
+  const startMs = numberValue((meeting as Record<string, unknown>).start_time_ms)
+  const endMs = numberValue((meeting as Record<string, unknown>).end_time_ms)
+  const meetingDate = startMs ? new Date(startMs).toISOString() : new Date().toISOString()
+  const durationMinutes = startMs && endMs && endMs > startMs
+    ? Math.round((endMs - startMs) / 60000)
+    : null
+
+  return {
+    contact_submission_id: null,
+    client_project_id: null,
+    read_ai_meeting_id: input.readAiMeetingId,
+    meeting_type: 'client_follow_up',
+    meeting_date: meetingDate,
+    duration_minutes: durationMinutes,
+    transcript: normalizeReadAiTranscript(meeting),
+    raw_notes: buildRawNotes(stringValue((meeting as Record<string, unknown>).title), summary),
+    attendees: normalizeParticipants((meeting as Record<string, unknown>).participants),
+    action_items: actionItems,
+    key_decisions: [],
+    open_questions: normalizeOpenQuestions((meeting as Record<string, unknown>).key_questions),
+    structured_notes: {
+      title: stringValue((meeting as Record<string, unknown>).title) || 'Read.ai meeting',
+      summary,
+      topics: (meeting as Record<string, unknown>).topics ?? [],
+      project_name: input.projectName ?? null,
+      source: 'read_ai_follow_up_import',
+    },
+    meeting_data: {
+      read_ai_meeting_id: input.readAiMeetingId,
+      report_url: stringValue((meeting as Record<string, unknown>).report_url) || null,
+      platform: stringValue((meeting as Record<string, unknown>).platform) || null,
+      owner: (meeting as Record<string, unknown>).owner ?? null,
+      source: 'read_ai_follow_up_import',
+      gmail_draft_id: input.draft?.gmailDraftId ?? null,
+      gmail_thread_id: input.draft?.gmailThreadId ?? null,
+      gmail_message_id: input.draft?.gmailMessageId ?? null,
+      source_email_thread_id: input.draft?.sourceEmailThreadId ?? null,
+    },
+  }
+}
+
+export async function importReadAiFollowUp(
+  input: ImportReadAiFollowUpInput,
+  options?: ImportReadAiFollowUpOptions,
+): Promise<ImportReadAiFollowUpResult> {
+  const db = options?.db ?? supabaseAdmin
+  if (!db) {
+    throw new Error('Database is not available')
+  }
+
+  const normalizedEmail = input.contactEmail.trim().toLowerCase()
+  const contactName = input.contactName.trim()
+  if (!input.readAiMeetingId.trim()) throw new Error('readAiMeetingId is required')
+  if (!contactName) throw new Error('contactName is required')
+  if (!normalizedEmail) throw new Error('contactEmail is required')
+
+  const meeting = options?.meeting ?? await getMeetingDetail(input.readAiMeetingId.trim())
+  const contactSubmissionId = await ensureContactSubmission(db, {
+    name: contactName,
+    email: normalizedEmail,
+    company: input.company ?? null,
+    readAiMeetingId: input.readAiMeetingId.trim(),
+  })
+
+  const payload = {
+    ...buildReadAiMeetingRecordPayload(meeting, input),
+    contact_submission_id: contactSubmissionId,
+  }
+  const { meetingRecordId, existing } = await upsertMeetingRecord(db, input.readAiMeetingId.trim(), payload)
+  const actionTasks = await promoteActionItems(meetingRecordId)
+
+  let clientUpdateDraftId: string | null = null
+  let contactCommunicationId: string | null = null
+  let emailMessageId: string | null = null
+
+  if (input.draft?.subject && input.draft.body) {
+    const draft = await createDraftDirect({
+      clientProjectId: null,
+      contactSubmissionId,
+      subject: input.draft.subject,
+      body: input.draft.body,
+      clientEmail: normalizedEmail,
+      clientName: contactName,
+      meetingRecordId,
+      userId: input.userId,
+    })
+    clientUpdateDraftId = draft?.id ?? null
+
+    const communication = await insertContactCommunication(db, {
+      contactSubmissionId,
+      subject: input.draft.subject,
+      body: input.draft.body,
+      sourceId: clientUpdateDraftId ?? input.draft.gmailDraftId ?? meetingRecordId,
+      userId: input.userId,
+      metadata: {
+        read_ai_meeting_id: input.readAiMeetingId.trim(),
+        meeting_record_id: meetingRecordId,
+        client_update_draft_id: clientUpdateDraftId,
+        gmail_draft_id: input.draft.gmailDraftId ?? null,
+        gmail_thread_id: input.draft.gmailThreadId ?? null,
+        gmail_message_id: input.draft.gmailMessageId ?? null,
+        source_email_thread_id: input.draft.sourceEmailThreadId ?? null,
+      },
+    })
+    contactCommunicationId = communication?.id ?? null
+
+    if (communication?.id) {
+      const emailMessage = await insertEmailMessageFromCommunication({
+        contactCommunicationId: communication.id,
+        contactSubmissionId,
+        emailKind: 'follow_up',
+        channel: 'email',
+        recipientEmail: normalizedEmail,
+        subject: input.draft.subject,
+        body: input.draft.body,
+        direction: 'outbound',
+        status: 'draft',
+        transport: 'logged_only',
+        sourceSystem: 'manual',
+        sourceId: input.draft.gmailDraftId ?? clientUpdateDraftId ?? meetingRecordId,
+        metadata: {
+          read_ai_meeting_id: input.readAiMeetingId.trim(),
+          meeting_record_id: meetingRecordId,
+          client_update_draft_id: clientUpdateDraftId,
+          gmail_draft_id: input.draft.gmailDraftId ?? null,
+          gmail_thread_id: input.draft.gmailThreadId ?? null,
+          gmail_message_id: input.draft.gmailMessageId ?? null,
+          source_email_thread_id: input.draft.sourceEmailThreadId ?? null,
+        },
+      })
+      emailMessageId = emailMessage?.id ?? null
+    }
+  }
+
+  return {
+    contactSubmissionId,
+    meetingRecordId,
+    actionTasks,
+    clientUpdateDraftId,
+    contactCommunicationId,
+    emailMessageId,
+    meetingWasExisting: existing,
+  }
+}
+
+async function ensureContactSubmission(
+  db: DbClient,
+  input: { name: string; email: string; company: string | null; readAiMeetingId: string },
+): Promise<number> {
+  const { data: existing, error: selectError } = await db
+    .from('contact_submissions')
+    .select('id')
+    .ilike('email', input.email)
+    .limit(1)
+    .maybeSingle()
+
+  if (selectError) {
+    throw new Error(`Failed to look up contact submission: ${selectError.message}`)
+  }
+
+  const message = `Imported from Read.ai follow-up meeting ${input.readAiMeetingId}.`
+
+  if (existing?.id) {
+    const updatePayload: Record<string, unknown> = {
+      name: input.name,
+      message,
+    }
+    if (input.company) updatePayload.company = input.company
+
+    const { error: updateError } = await db
+      .from('contact_submissions')
+      .update(updatePayload)
+      .eq('id', existing.id)
+
+    if (updateError) {
+      throw new Error(`Failed to update contact submission: ${updateError.message}`)
+    }
+    return Number(existing.id)
+  }
+
+  const { data: inserted, error: insertError } = await db
+    .from('contact_submissions')
+    .insert({
+      name: input.name,
+      email: input.email,
+      company: input.company,
+      message,
+      lead_source: 'warm_meeting',
+      submission_source: 'read_ai_follow_up_import',
+    })
+    .select('id')
+    .single()
+
+  if (insertError || !inserted?.id) {
+    throw new Error(`Failed to create contact submission: ${insertError?.message ?? 'no id returned'}`)
+  }
+
+  return Number(inserted.id)
+}
+
+async function upsertMeetingRecord(
+  db: DbClient,
+  readAiMeetingId: string,
+  payload: Record<string, unknown>,
+): Promise<{ meetingRecordId: string; existing: boolean }> {
+  const { data: existing, error: selectError } = await db
+    .from('meeting_records')
+    .select('id')
+    .eq('read_ai_meeting_id', readAiMeetingId)
+    .limit(1)
+    .maybeSingle()
+
+  if (selectError) {
+    throw new Error(`Failed to look up meeting record: ${selectError.message}`)
+  }
+
+  if (existing?.id) {
+    const { data: updated, error: updateError } = await db
+      .from('meeting_records')
+      .update(payload)
+      .eq('id', existing.id)
+      .select('id')
+      .single()
+
+    if (updateError || !updated?.id) {
+      throw new Error(`Failed to update meeting record: ${updateError?.message ?? 'no id returned'}`)
+    }
+    return { meetingRecordId: String(updated.id), existing: true }
+  }
+
+  const { data: inserted, error: insertError } = await db
+    .from('meeting_records')
+    .insert(payload)
+    .select('id')
+    .single()
+
+  if (insertError || !inserted?.id) {
+    throw new Error(`Failed to create meeting record: ${insertError?.message ?? 'no id returned'}`)
+  }
+
+  return { meetingRecordId: String(inserted.id), existing: false }
+}
+
+async function insertContactCommunication(
+  db: DbClient,
+  input: {
+    contactSubmissionId: number
+    subject: string
+    body: string
+    sourceId: string
+    userId?: string
+    metadata: Record<string, unknown>
+  },
+): Promise<{ id: string } | null> {
+  const { data, error } = await db
+    .from('contact_communications')
+    .insert({
+      contact_submission_id: input.contactSubmissionId,
+      channel: 'email',
+      direction: 'outbound',
+      message_type: 'follow_up',
+      subject: input.subject,
+      body: input.body,
+      source_system: 'manual',
+      source_id: input.sourceId,
+      status: 'draft',
+      sent_by: input.userId ?? null,
+      metadata: input.metadata,
+    })
+    .select('id')
+    .single()
+
+  if (error) {
+    console.error('[read-ai-follow-up-import] contact_communications insert failed:', error.message)
+    return null
+  }
+
+  return data ? { id: data.id } : null
+}
+
+function transcriptBlocksToText(blocks: unknown[]): string {
+  return blocks.flatMap((block) => {
+    if (typeof block === 'string') return block.trim() ? [block.trim()] : []
+    if (!block || typeof block !== 'object') return []
+
+    const obj = block as Record<string, unknown>
+    const speaker = stringValue(obj.speaker_name ?? obj.speaker ?? obj.name)
+    const text = stringValue(obj.text ?? obj.transcript)
+      || (Array.isArray(obj.words)
+        ? obj.words.map((word) => stringValue((word as Record<string, unknown>)?.text ?? word)).filter(Boolean).join(' ')
+        : '')
+    if (!text) return []
+    return speaker ? [`${speaker}: ${text}`] : [text]
+  }).join('\n')
+}
+
+function normalizeParticipants(input: unknown): Array<{ name?: string; email?: string | null; attended?: boolean }> {
+  if (!Array.isArray(input)) return []
+  return input.flatMap((participant) => {
+    if (!participant || typeof participant !== 'object') return []
+    const obj = participant as Record<string, unknown>
+    const name = stringValue(obj.name)
+    const email = stringValue(obj.email) || null
+    if (!name && !email) return []
+    return [{
+      ...(name ? { name } : {}),
+      email,
+      attended: Boolean(obj.attended),
+    }]
+  })
+}
+
+function normalizeOpenQuestions(input: unknown): string[] {
+  if (!Array.isArray(input)) return []
+  return input.flatMap((item) => {
+    const question = typeof item === 'string'
+      ? item.trim()
+      : item && typeof item === 'object'
+        ? stringValue((item as Record<string, unknown>).text ?? (item as Record<string, unknown>).question)
+        : ''
+    return question ? [question] : []
+  })
+}
+
+function normalizeSummary(input: unknown): string {
+  if (typeof input === 'string') return input.trim()
+  if (Array.isArray(input)) {
+    return input.map((item) => stringValue(item)).filter(Boolean).join('\n')
+  }
+  if (input && typeof input === 'object') {
+    const obj = input as Record<string, unknown>
+    return stringValue(obj.text ?? obj.summary ?? obj.markdown)
+      || JSON.stringify(input)
+  }
+  return ''
+}
+
+function buildRawNotes(title: string, summary: string): string {
+  const chunks = [title, summary].map((chunk) => chunk.trim()).filter(Boolean)
+  return chunks.join('\n\n').slice(0, 2000)
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function numberValue(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}

--- a/lib/read-ai-follow-up-import.ts
+++ b/lib/read-ai-follow-up-import.ts
@@ -38,7 +38,7 @@ export interface ImportReadAiFollowUpResult {
 
 interface ImportReadAiFollowUpOptions {
   db?: DbClient
-  meeting?: ReadAiMeeting
+  meeting?: ReadAiMeeting | Record<string, unknown>
 }
 
 export function normalizeReadAiTranscript(meeting: ReadAiMeeting | Record<string, unknown>): string {
@@ -50,6 +50,7 @@ export function normalizeReadAiTranscript(meeting: ReadAiMeeting | Record<string
     if (typeof obj.text === 'string') return obj.text.trim()
     if (Array.isArray(obj.speaker_blocks)) return transcriptBlocksToText(obj.speaker_blocks)
     if (Array.isArray(obj.blocks)) return transcriptBlocksToText(obj.blocks)
+    if (Array.isArray(obj.turns)) return transcriptBlocksToText(obj.turns)
   }
   if (Array.isArray(transcript)) return transcriptBlocksToText(transcript)
   return ''
@@ -91,7 +92,7 @@ export function buildReadAiMeetingRecordPayload(
     contact_submission_id: null,
     client_project_id: null,
     read_ai_meeting_id: input.readAiMeetingId,
-    meeting_type: 'client_follow_up',
+    meeting_type: 'progress_checkin',
     meeting_date: meetingDate,
     duration_minutes: durationMinutes,
     transcript: normalizeReadAiTranscript(meeting),
@@ -366,7 +367,10 @@ function transcriptBlocksToText(blocks: unknown[]): string {
     if (!block || typeof block !== 'object') return []
 
     const obj = block as Record<string, unknown>
-    const speaker = stringValue(obj.speaker_name ?? obj.speaker ?? obj.name)
+    const speakerObj = obj.speaker && typeof obj.speaker === 'object'
+      ? obj.speaker as Record<string, unknown>
+      : null
+    const speaker = stringValue(obj.speaker_name ?? speakerObj?.name ?? obj.speaker ?? obj.name)
     const text = stringValue(obj.text ?? obj.transcript)
       || (Array.isArray(obj.words)
         ? obj.words.map((word) => stringValue((word as Record<string, unknown>)?.text ?? word)).filter(Boolean).join(' ')


### PR DESCRIPTION
## Summary
- Add an admin/N8N-authenticated Read.ai follow-up import endpoint for missed Slack intake cases
- Create/update contact and meeting records, promote Read.ai action items, store in-app follow-up drafts, and log Gmail draft metadata to the contact/email timeline
- Support a supplied `meeting` payload so connector/n8n-fetched Read.ai data can be imported even when the app's stored Read.ai OAuth token is stale
- Document the manual import payload and KMB workflow in the meeting follow-up guide

## Validation
- `npm test -- lib/read-ai-follow-up-import.test.ts` passed
- `npm run build:knowledge && npx tsc --noEmit` passed
- Live KMB import completed using connector-supplied Read.ai meeting data and Gmail draft metadata:
  - contact_submission_id: `21`
  - meeting_record_id: `ac8514f9-356b-487d-a1cc-6853f469873a`
  - promoted meeting_action_tasks: `9`
  - client_update_draft_id: `1806f655-f79d-48bf-9b16-fbdbb57a7760`
  - contact_communication_id: `229fe2b1-c945-474f-af7d-d4c7c2ceec67`
  - email_message_id: `4b197309-b83b-4ffb-8cde-e59f7c88fa8f`
- Verified the imported meeting, task count, draft status, communication metadata, and email metadata directly in Supabase

## Integration Notes
- No migrations or env changes required
- Uses existing `N8N_INGEST_SECRET`, `meeting_records`, `meeting_action_tasks`, `client_update_drafts`, `contact_communications`, and `email_messages`
- The app's stored Read.ai OAuth token failed refresh with `invalid_grant`; the supplied-meeting fallback worked around this for KMB, but the Read.ai integration token should be reauthorized separately
- Vercel – portfolio: not checked
- Vercel – portfolio-staging: not checked