### PR TITLE
feat: add social content intelligence backlog

### DIFF
--- a/app/admin/agents/content-intelligence/page.test.tsx
+++ b/app/admin/agents/content-intelligence/page.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import ContentIntelligencePage from './page'
+
+vi.mock('@/components/ProtectedRoute', () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('@/components/admin/Breadcrumbs', () => ({
+  default: () => null,
+}))
+
+vi.mock('@/lib/auth', () => ({
+  getCurrentSession: vi.fn(async () => ({ access_token: 'admin-token' })),
+}))
+
+describe('ContentIntelligencePage', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.startsWith('/api/admin/social-content/intelligence/research-packets')) {
+        return {
+          ok: true,
+          json: async () => ({
+            packets: [
+              {
+                id: 'packet-1',
+                source_url: 'https://youtube.com/watch?v=abc',
+                platform: 'youtube',
+                creator_name: 'Creator',
+                creator_handle: '@creator',
+                title: 'Outlier research process',
+                caption: null,
+                thumbnail_url: 'https://example.com/thumb.jpg',
+                hook_transcript: 'The first 30 seconds make the promise clear.',
+                outlier_score: 87,
+                pattern_status: 'needs_brand_translation',
+                retrieved_at: '2026-06-22T12:00:00.000Z',
+                actor_metadata: { actor_id: 'pintostudio/youtube-transcript-scraper' },
+                metrics: { views: 120000, likes: 8000, comments: 900 },
+              },
+            ],
+          }),
+        }
+      }
+      if (url.startsWith('/api/admin/agents/work-items')) {
+        return {
+          ok: true,
+          json: async () => ({
+            work_items: [
+              {
+                id: 'work-social-1',
+                title: 'Approval gates create trust',
+                status: 'proposed',
+                priority: 'high',
+                source_type: 'social_topic_trigger',
+                metadata: {
+                  insight: {
+                    title: 'Approval gates create trust',
+                    triggering_event: 'A shipped review gate changed the work.',
+                    why_vambah_can_speak: 'Vambah built the system.',
+                  },
+                },
+                updated_at: '2026-06-22T12:00:00.000Z',
+              },
+            ],
+          }),
+        }
+      }
+      return { ok: false, status: 404, json: async () => ({ error: 'not found' }) }
+    }))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('shows research packets and central Shaka insights', async () => {
+    render(<ContentIntelligencePage />)
+
+    expect(await screen.findByRole('heading', { name: 'Research and Shaka insight queue' })).toBeInTheDocument()
+    expect(screen.getByText('pintostudio/youtube-transcript-scraper')).toBeInTheDocument()
+    expect(screen.getByText('Outlier research process')).toBeInTheDocument()
+    expect(screen.getByText('Approval gates create trust')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Approval gates create trust/ })).toHaveAttribute('href', '/admin/agents/social-insights/work-social-1')
+  })
+})

--- a/app/admin/agents/content-intelligence/page.tsx
+++ b/app/admin/agents/content-intelligence/page.tsx
@@ -1,0 +1,320 @@
+'use client'
+
+import Link from 'next/link'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  BarChart3,
+  Database,
+  ExternalLink,
+  FileSearch,
+  Film,
+  Instagram,
+  RefreshCw,
+  ShieldCheck,
+  Youtube,
+} from 'lucide-react'
+import ProtectedRoute from '@/components/ProtectedRoute'
+import Breadcrumbs from '@/components/admin/Breadcrumbs'
+import { getCurrentSession } from '@/lib/auth'
+import type { AgentWorkItem } from '@/lib/agent-work-items'
+
+type ResearchPacket = {
+  id: string
+  source_url: string
+  platform: string
+  creator_name: string | null
+  creator_handle: string | null
+  title: string | null
+  caption: string | null
+  thumbnail_url: string | null
+  hook_transcript: string | null
+  outlier_score: number
+  pattern_status: string
+  retrieved_at: string
+  actor_metadata: Record<string, unknown>
+  metrics: Record<string, unknown>
+}
+
+function stringValue(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function numberValue(value: unknown) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function insightFor(item: AgentWorkItem) {
+  const metadata = item.metadata ?? {}
+  const insight = metadata.insight && typeof metadata.insight === 'object' && !Array.isArray(metadata.insight)
+    ? metadata.insight as Record<string, unknown>
+    : {}
+  return {
+    title: stringValue(insight.title) ?? item.title,
+    triggeringEvent: stringValue(insight.triggering_event),
+    whyVambahCanSpeak: stringValue(insight.why_vambah_can_speak),
+    sensitivity: stringValue(insight.sensitivity) ?? 'needs_review',
+  }
+}
+
+function platformIcon(platform: string) {
+  if (platform.includes('youtube')) return <Youtube className="h-4 w-4 text-red-200" />
+  if (platform.includes('instagram')) return <Instagram className="h-4 w-4 text-pink-200" />
+  return <Film className="h-4 w-4 text-blue-200" />
+}
+
+export default function ContentIntelligencePage() {
+  return (
+    <ProtectedRoute requireAdmin>
+      <ContentIntelligenceContent />
+    </ProtectedRoute>
+  )
+}
+
+function ContentIntelligenceContent() {
+  const [packets, setPackets] = useState<ResearchPacket[]>([])
+  const [insights, setInsights] = useState<AgentWorkItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const authedFetch = useCallback(async (path: string) => {
+    const session = await getCurrentSession()
+    if (!session?.access_token) throw new Error('Missing admin session')
+    return fetch(path, {
+      headers: { Authorization: `Bearer ${session.access_token}` },
+    })
+  }, [])
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const [packetResponse, insightResponse] = await Promise.all([
+        authedFetch('/api/admin/social-content/intelligence/research-packets?limit=12'),
+        authedFetch('/api/admin/agents/work-items?source_type=social_topic_trigger&limit=12'),
+      ])
+      const packetBody = await packetResponse.json().catch(() => ({}))
+      const insightBody = await insightResponse.json().catch(() => ({}))
+      if (!packetResponse.ok) throw new Error(packetBody.error || `Research packets HTTP ${packetResponse.status}`)
+      if (!insightResponse.ok) throw new Error(insightBody.error || `Insights HTTP ${insightResponse.status}`)
+      setPackets(Array.isArray(packetBody.packets) ? packetBody.packets : [])
+      setInsights(Array.isArray(insightBody.work_items) ? insightBody.work_items : [])
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load Content Intelligence')
+      setPackets([])
+      setInsights([])
+    } finally {
+      setLoading(false)
+    }
+  }, [authedFetch])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const strongestPacket = useMemo(() => packets[0] ?? null, [packets])
+
+  return (
+    <div className="agent-ops-page min-h-screen p-5 text-foreground lg:p-7">
+      <div className="mx-auto max-w-7xl">
+        <Breadcrumbs items={[
+          { label: 'Admin Dashboard', href: '/admin' },
+          { label: 'Agent Operations', href: '/admin/agents' },
+          { label: 'Content Intelligence' },
+        ]} />
+
+        <header className="agent-ops-surface-header mb-6 mt-5 flex flex-col gap-4 rounded-xl border p-5 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <div className="agent-ops-eyebrow mb-2">
+              <FileSearch size={16} />
+              Content Intelligence
+            </div>
+            <h1 className="text-3xl font-bold">Research and Shaka insight queue</h1>
+            <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+              Public creator research stays read-only. Shaka insights stay centralized in the Agentic Dashboard backlog, then feed LinkedIn, YouTube Shorts, Instagram Reels, and thumbnail lanes.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={load}
+            disabled={loading}
+            className="agent-ops-button-secondary disabled:opacity-60"
+          >
+            <RefreshCw size={16} className={loading ? 'animate-spin' : ''} />
+            Refresh
+          </button>
+        </header>
+
+        {error ? (
+          <div className="mb-6 rounded-lg border border-red-500/35 bg-red-500/10 p-4 text-sm text-red-100">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="mb-6 grid gap-3 md:grid-cols-4">
+          <MetricCard label="Research packets" value={packets.length} />
+          <MetricCard label="Shaka insights" value={insights.length} />
+          <MetricCard label="Top outlier score" value={strongestPacket ? Math.round(Number(strongestPacket.outlier_score)) : 0} />
+          <MetricCard label="Live schedules" value={0} tone="amber" />
+        </div>
+
+        <section className="agent-ops-card mb-6 rounded-lg border p-4">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <h2 className="text-lg font-semibold">Scoped collection layer</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                These actors are configured as approved research sources, but no recurring run is active from this page.
+              </p>
+            </div>
+            <span className="inline-flex w-fit items-center gap-2 rounded-full border border-amber-500/35 bg-amber-500/10 px-3 py-1 text-xs font-semibold text-amber-100">
+              <ShieldCheck className="h-3.5 w-3.5" />
+              Activation approval required
+            </span>
+          </div>
+          <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+            <ActorCard title="YouTube transcripts" actor="pintostudio/youtube-transcript-scraper" />
+            <ActorCard title="YouTube video/channel data" actor="streamers/youtube-scraper" />
+            <ActorCard title="Instagram posts/reels" actor="apify/instagram-scraper" />
+            <ActorCard title="TikTok research later" actor="clockworks/tiktok-scraper" />
+          </div>
+        </section>
+
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(22rem,0.45fr)]">
+          <section className="agent-ops-card rounded-lg border p-4">
+            <div className="mb-4 flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+              <div>
+                <h2 className="text-lg font-semibold">Public creator research</h2>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Evidence packets preserve source transparency and reusable patterns without copying creator scripts, titles, thumbnails, or visual identity.
+                </p>
+              </div>
+            </div>
+            {loading ? (
+              <div className="py-12 text-center text-sm text-muted-foreground">Loading research packets...</div>
+            ) : packets.length ? (
+              <div className="space-y-3">
+                {packets.map((packet) => (
+                  <article key={packet.id} className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
+                    <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                      <div className="min-w-0">
+                        <div className="mb-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                          <span className="inline-flex items-center gap-1 rounded-full border border-blue-500/30 bg-blue-500/10 px-2 py-0.5 text-blue-100">
+                            {platformIcon(packet.platform)}
+                            {packet.platform.replace(/_/g, ' ')}
+                          </span>
+                          <span>{packet.creator_name ?? packet.creator_handle ?? 'Creator unknown'}</span>
+                          <span>{new Date(packet.retrieved_at).toLocaleString()}</span>
+                        </div>
+                        <h3 className="font-semibold">{packet.title ?? packet.caption ?? packet.source_url}</h3>
+                        {packet.hook_transcript ? (
+                          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                            Hook: {packet.hook_transcript}
+                          </p>
+                        ) : null}
+                        <div className="mt-3 flex flex-wrap gap-2 text-xs text-muted-foreground">
+                          <SourceMetric label="views" value={numberValue(packet.metrics.views)} />
+                          <SourceMetric label="likes" value={numberValue(packet.metrics.likes)} />
+                          <SourceMetric label="comments" value={numberValue(packet.metrics.comments)} />
+                        </div>
+                      </div>
+                      <div className="flex shrink-0 flex-col gap-2 text-right">
+                        <span className="inline-flex justify-center rounded-full border border-radiant-gold/40 bg-radiant-gold/10 px-3 py-1 text-xs font-semibold text-radiant-gold">
+                          Outlier {Math.round(Number(packet.outlier_score))}
+                        </span>
+                        <span className="rounded-full border border-silicon-slate/70 px-3 py-1 text-xs text-muted-foreground">
+                          {packet.pattern_status.replace(/_/g, ' ')}
+                        </span>
+                        <a
+                          href={packet.source_url}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="inline-flex items-center justify-center gap-1 text-xs text-blue-200 hover:text-blue-100"
+                        >
+                          Source <ExternalLink className="h-3 w-3" />
+                        </a>
+                      </div>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            ) : (
+              <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 px-4 py-12 text-center text-sm text-muted-foreground">
+                No research packets have been stored yet. Run a scoped research collection only after approval.
+              </div>
+            )}
+          </section>
+
+          <section className="agent-ops-card rounded-lg border p-4">
+            <h2 className="text-lg font-semibold">Shaka insight backlog</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              These are central Agentic Dashboard work items. Social Content pages filter this same backlog.
+            </p>
+            <div className="mt-4 space-y-3">
+              {insights.length ? insights.map((item) => {
+                const insight = insightFor(item)
+                return (
+                  <Link
+                    key={item.id}
+                    href={`/admin/agents/social-insights/${item.id}`}
+                    className="block rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-3 transition hover:border-radiant-gold/45"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="font-semibold">{insight.title}</p>
+                        {insight.triggeringEvent ? (
+                          <p className="mt-1 line-clamp-2 text-sm leading-5 text-muted-foreground">{insight.triggeringEvent}</p>
+                        ) : null}
+                      </div>
+                      <span className="shrink-0 rounded-full border border-blue-500/30 bg-blue-500/10 px-2 py-0.5 text-xs text-blue-100">
+                        {item.status.replace(/_/g, ' ')}
+                      </span>
+                    </div>
+                    {insight.whyVambahCanSpeak ? (
+                      <p className="mt-2 text-xs leading-5 text-muted-foreground">
+                        Why now: {insight.whyVambahCanSpeak}
+                      </p>
+                    ) : null}
+                  </Link>
+                )
+              }) : (
+                <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 px-4 py-10 text-center text-sm text-muted-foreground">
+                  No Shaka insight work items found.
+                </div>
+              )}
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function MetricCard({ label, value, tone = 'slate' }: { label: string; value: number; tone?: 'slate' | 'amber' }) {
+  return (
+    <div className={`rounded-lg border p-4 ${tone === 'amber' ? 'border-amber-500/30 bg-amber-500/10' : 'border-silicon-slate/70 bg-silicon-slate/20'}`}>
+      <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="mt-2 text-2xl font-semibold">{value}</p>
+    </div>
+  )
+}
+
+function ActorCard({ title, actor }: { title: string; actor: string }) {
+  return (
+    <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-3">
+      <div className="mb-2 flex items-center gap-2 text-sm font-semibold">
+        <Database className="h-4 w-4 text-radiant-gold" />
+        {title}
+      </div>
+      <p className="break-words text-xs leading-5 text-muted-foreground">{actor}</p>
+    </div>
+  )
+}
+
+function SourceMetric({ label, value }: { label: string; value: number | null }) {
+  if (value == null) return null
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full border border-silicon-slate/70 px-2 py-0.5">
+      <BarChart3 className="h-3 w-3" />
+      {label}: {value.toLocaleString()}
+    </span>
+  )
+}

--- a/app/admin/agents/coordination/page.test.tsx
+++ b/app/admin/agents/coordination/page.test.tsx
@@ -199,6 +199,51 @@ const workItems = [
     completed_at: null,
   },
   {
+    id: 'work-social-topic-1',
+    title: 'Approval gates create trust',
+    objective: 'Use a shipped Agent Ops approval gate to explain why AI needs accountable work paths.',
+    status: 'proposed',
+    priority: 'high',
+    owner_agent_key: 'chief-of-staff',
+    owner_runtime: 'codex',
+    source_type: 'social_topic_trigger',
+    source_id: 'approval-gates-create-trust',
+    source_label: 'Shaka topic trigger',
+    source_run_id: null,
+    active_run_id: null,
+    parent_work_item_id: null,
+    branch_name: null,
+    worktree_path: null,
+    pr_number: null,
+    pr_url: null,
+    expected_files: [],
+    touched_files: [],
+    overlap_group: 'social-content-intelligence',
+    dependency_ids: [],
+    blocker_summary: null,
+    validation_summary: null,
+    approval_id: null,
+    metadata: {
+      social_topic_trigger: true,
+      insight: {
+        title: 'Approval gates create trust',
+        triggering_event: 'The Social Content review flow now shows visible approval gates.',
+        why_vambah_can_speak: 'Vambah is building the operating layer and reviewing the content gates directly.',
+        sensitivity: 'public_safe',
+      },
+      channel_lanes: {
+        linkedin: { status: 'selected', label: 'LinkedIn', required_inputs: ['post text'] },
+        youtube_shorts: { status: 'not_started', label: 'YouTube Shorts', required_inputs: ['hook'] },
+        instagram_reels: { status: 'not_started', label: 'Instagram Reels', required_inputs: ['hook'] },
+        thumbnail: { status: 'not_started', label: 'Thumbnail', required_inputs: ['2-3 variants'] },
+      },
+    },
+    idempotency_key: 'social-topic-trigger:approval-gates-create-trust',
+    created_at: now,
+    updated_at: now,
+    completed_at: null,
+  },
+  {
     id: 'work-queue-3',
     title: 'Route standup room follow-up',
     objective: 'Convert the standup room follow-up into a bounded agent task.',
@@ -433,7 +478,10 @@ describe('AgentCoordinationPage decision queue controller', () => {
     expect(screen.getByRole('button', { name: /Validation handoff/ })).toBeInTheDocument()
     expect(screen.getByText('Objective: Package validation evidence so the captain can make a merge or handoff decision.')).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: 'Full work-item archive' })).toBeInTheDocument()
-    expect(screen.getByText('Showing 1-3 of 5')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Central backlog for social topics' })).toBeInTheDocument()
+    expect(screen.getAllByText('Approval gates create trust').length).toBeGreaterThan(0)
+    expect(screen.getByRole('link', { name: /Open channel tabs/ })).toHaveAttribute('href', '/admin/agents/social-insights/work-social-topic-1')
+    expect(screen.getByText('Showing 1-3 of 6')).toBeInTheDocument()
   })
 
   it('runs top controller decision actions with scoped Shaka context', async () => {
@@ -689,13 +737,13 @@ describe('AgentCoordinationPage decision queue controller', () => {
     expect(await screen.findByRole('heading', { name: 'Full work-item archive' })).toBeInTheDocument()
     const archive = screen.getByRole('heading', { name: 'Full work-item archive' }).closest('section')
     expect(archive).not.toBeNull()
-    expect(within(archive as HTMLElement).getByText('Showing 1-3 of 5')).toBeInTheDocument()
+    expect(within(archive as HTMLElement).getByText('Showing 1-3 of 6')).toBeInTheDocument()
     expect(within(archive as HTMLElement).getByLabelText('Status filters')).toBeInTheDocument()
     expect(within(archive as HTMLElement).queryByText('Route standup room follow-up')).not.toBeInTheDocument()
 
     fireEvent.click(within(archive as HTMLElement).getByRole('button', { name: 'Next' }))
 
-    expect(within(archive as HTMLElement).getByText('Showing 4-5 of 5')).toBeInTheDocument()
+    expect(within(archive as HTMLElement).getByText('Showing 4-6 of 6')).toBeInTheDocument()
     expect(within(archive as HTMLElement).getByText('Route standup room follow-up')).toBeInTheDocument()
   })
 

--- a/app/admin/agents/coordination/page.tsx
+++ b/app/admin/agents/coordination/page.tsx
@@ -9,6 +9,7 @@ import {
   BellRing,
   Bot,
   CheckCircle2,
+  FileSearch,
   GitPullRequest,
   MessageSquare,
   Network,
@@ -26,6 +27,10 @@ import type { AgentRuntime } from '@/lib/agent-run'
 import type { AgentWorkItem, AgentWorkItemStatus } from '@/lib/agent-work-items'
 import type { VercelResearchProposal } from '@/lib/vercel-deployment-research'
 import { VERCEL_AUTORESEARCH_DEFINITION_OF_READY, VERCEL_AUTORESEARCH_IDEA_SOURCE_TYPE } from '@/lib/vercel-autoresearch-ideas'
+import {
+  isSocialTopicTriggerWorkItem,
+  socialChannelLaneSummary,
+} from '@/lib/social-content-intelligence'
 
 const STATUSES: Array<'all' | AgentWorkItemStatus> = [
   'all',
@@ -271,6 +276,10 @@ function isN8nWorkflowProposal(item: AgentWorkItem) {
   return item.source_type === 'n8n_workflow_proposal' || item.metadata?.n8n_workflow_proposal === true
 }
 
+function isSocialTopicInsight(item: AgentWorkItem) {
+  return isSocialTopicTriggerWorkItem(item)
+}
+
 function textArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0) : []
 }
@@ -494,11 +503,12 @@ function AgentCoordinationContent() {
 
   const summary = useMemo(() => ({
     active: items.filter((item) => !['merged', 'deployed', 'cancelled'].includes(item.status)).length,
-    controllerOpen: items.filter((item) => !isTerminalWorkItem(item) && !isN8nWorkflowProposal(item)).length,
+    controllerOpen: items.filter((item) => !isTerminalWorkItem(item) && !isN8nWorkflowProposal(item) && !isSocialTopicInsight(item)).length,
     blocked: items.filter((item) => item.status === 'blocked').length,
     review: items.filter((item) => item.status === 'ready_for_review' || item.status === 'ready_for_merge').length,
     approvals: items.filter((item) => Boolean(item.approval_id)).length,
     n8nProposals: items.filter((item) => isN8nWorkflowProposal(item) && !isTerminalWorkItem(item)).length,
+    shakaInsights: items.filter((item) => isSocialTopicInsight(item) && !isTerminalWorkItem(item)).length,
   }), [items])
 
   const autoResearchIdeas = useMemo(() => {
@@ -509,7 +519,7 @@ function AgentCoordinationContent() {
 
   const controllerQueueItems = useMemo(() => {
     return items
-      .filter((item) => !isTerminalWorkItem(item) && !isN8nWorkflowProposal(item))
+      .filter((item) => !isTerminalWorkItem(item) && !isN8nWorkflowProposal(item) && !isSocialTopicInsight(item))
       .sort((a, b) => {
         const statusDelta = STATUS_RANK[a.status] - STATUS_RANK[b.status]
         if (statusDelta !== 0) return statusDelta
@@ -528,6 +538,17 @@ function AgentCoordinationContent() {
         if (priorityDelta !== 0) return priorityDelta
         return new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
       })
+  }, [items])
+
+  const shakaSocialInsights = useMemo(() => {
+    return items
+      .filter((item) => isSocialTopicInsight(item) && !isTerminalWorkItem(item))
+      .sort((a, b) => {
+        const priorityDelta = PRIORITY_RANK[a.priority] - PRIORITY_RANK[b.priority]
+        if (priorityDelta !== 0) return priorityDelta
+        return new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
+      })
+      .slice(0, 6)
   }, [items])
 
   const archiveTotalPages = Math.max(1, Math.ceil(items.length / ARCHIVE_PAGE_SIZE))
@@ -802,11 +823,12 @@ function AgentCoordinationContent() {
           </div>
         </header>
 
-        <div className="mb-6 grid grid-cols-2 gap-3 md:grid-cols-4">
+        <div className="mb-6 grid grid-cols-2 gap-3 md:grid-cols-5">
           <Metric label="Action required" value={summary.active} />
           <Metric label="Blocked" value={summary.blocked} tone={summary.blocked ? 'red' : 'slate'} />
           <Metric label="Review queue" value={summary.review} tone={summary.review ? 'yellow' : 'slate'} />
           <Metric label="n8n proposals" value={summary.n8nProposals} tone={summary.n8nProposals ? 'yellow' : 'slate'} />
+          <Metric label="Shaka insights" value={summary.shakaInsights} tone={summary.shakaInsights ? 'yellow' : 'slate'} />
         </div>
 
         <ControllerDecisionQueuePanel
@@ -831,6 +853,8 @@ function AgentCoordinationContent() {
             { type: 'work_item', id: workItem.id },
           )}
         />
+
+        <ShakaSocialInsightsPanel insights={shakaSocialInsights} />
 
         <VercelResearchApprovalPanel
           approvals={vercelResearchApprovals}
@@ -1252,6 +1276,91 @@ function ControllerDecisionQueuePanel({
                       {model.primaryIcon}
                       {model.primaryLabel}
                     </button>
+                  </div>
+                </div>
+              </article>
+            )
+          })}
+        </div>
+      )}
+    </section>
+  )
+}
+
+function ShakaSocialInsightsPanel({ insights }: { insights: AgentWorkItem[] }) {
+  return (
+    <section className="agent-ops-card mb-6 rounded-lg border border-blue-500/25 bg-blue-500/5 p-4">
+      <div className="mb-4 flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <p className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-blue-100">
+            <FileSearch size={16} />
+            Shaka social insights
+          </p>
+          <h2 className="mt-1 text-xl font-semibold">Central backlog for social topics</h2>
+          <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+            These are channel-agnostic Agentic Dashboard work items. LinkedIn, YouTube Shorts, Instagram Reels, and thumbnail production pull from the same insight.
+          </p>
+        </div>
+        <Link
+          href="/admin/agents/content-intelligence"
+          className="inline-flex items-center justify-center gap-2 rounded-lg border border-blue-400/40 bg-blue-500/10 px-3 py-2 text-sm text-blue-100 hover:bg-blue-500/15"
+        >
+          Open Content Intelligence
+          <ArrowRight size={16} />
+        </Link>
+      </div>
+
+      {insights.length === 0 ? (
+        <div className="rounded-lg border border-silicon-slate/70 bg-background/40 p-4 text-sm text-muted-foreground">
+          No Shaka social insights are waiting in the central backlog.
+        </div>
+      ) : (
+        <div className="grid gap-3 lg:grid-cols-2">
+          {insights.map((item) => {
+            const metadata = recordValue(item.metadata)
+            const insight = recordValue(metadata?.insight)
+            const title = stringValue(insight?.title) ?? item.title
+            const trigger = stringValue(insight?.triggering_event)
+            const whyNow = stringValue(insight?.why_vambah_can_speak)
+            const lanes = socialChannelLaneSummary(item)
+            return (
+              <article key={item.id} className="rounded-lg border border-silicon-slate/70 bg-background/40 p-4">
+                <div className="flex flex-col gap-3">
+                  <div>
+                    <div className="mb-2 flex flex-wrap items-center gap-2">
+                      <StatusBadge status={item.status} />
+                      <span className="rounded-full border border-blue-400/30 bg-blue-500/10 px-2 py-0.5 text-xs text-blue-100">
+                        {item.priority} priority
+                      </span>
+                    </div>
+                    <h3 className="font-semibold">{title}</h3>
+                    {trigger ? (
+                      <p className="mt-1 text-sm leading-6 text-muted-foreground">{trigger}</p>
+                    ) : null}
+                    {whyNow ? (
+                      <p className="mt-2 text-xs leading-5 text-muted-foreground">
+                        Why now: {whyNow}
+                      </p>
+                    ) : null}
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {lanes.map((lane) => (
+                      <span
+                        key={lane.channel}
+                        className="rounded-full border border-silicon-slate/70 bg-silicon-slate/20 px-2 py-0.5 text-xs text-muted-foreground"
+                      >
+                        {lane.label}: {lane.status.replace(/_/g, ' ')}
+                      </span>
+                    ))}
+                  </div>
+                  <div>
+                    <Link
+                      href={`/admin/agents/social-insights/${item.id}`}
+                      className="inline-flex items-center gap-2 rounded-lg border border-blue-400/40 bg-blue-500/10 px-3 py-2 text-sm text-blue-100 hover:bg-blue-500/15"
+                    >
+                      Open channel tabs
+                      <ArrowRight size={16} />
+                    </Link>
                   </div>
                 </div>
               </article>

--- a/app/admin/agents/social-insights/[id]/page.test.tsx
+++ b/app/admin/agents/social-insights/[id]/page.test.tsx
@@ -1,0 +1,79 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import SocialInsightDetailPage from './page'
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ id: 'work-social-1' }),
+}))
+
+vi.mock('@/components/ProtectedRoute', () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('@/components/admin/Breadcrumbs', () => ({
+  default: () => null,
+}))
+
+vi.mock('@/lib/auth', () => ({
+  getCurrentSession: vi.fn(async () => ({ access_token: 'admin-token' })),
+}))
+
+describe('SocialInsightDetailPage', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        work_item: {
+          id: 'work-social-1',
+          title: 'Approval gates create trust',
+          status: 'proposed',
+          priority: 'high',
+          source_type: 'social_topic_trigger',
+          metadata: {
+            insight: {
+              title: 'Approval gates create trust',
+              triggering_event: 'The Social Content review flow made the gate visible.',
+              why_vambah_can_speak: 'Vambah is building and reviewing the system directly.',
+              evidence_summary: 'Review path and visual gate work shipped locally.',
+              brand_goal: 'Show AmaduTown as the operating layer for governed AI.',
+              audience: 'Operators adopting AI workflows.',
+              content_angle: 'AI should reduce burden, but only when authority and evidence are separated.',
+              suggested_hook: 'AI should reduce burden.',
+              claim_boundaries: ['Do not imply publishing is automated.'],
+            },
+            channel_lanes: {
+              linkedin: { status: 'selected', label: 'LinkedIn', required_inputs: ['post text', 'CTA'] },
+              youtube_shorts: { status: 'not_started', label: 'YouTube Shorts', required_inputs: ['hook', 'script'] },
+              instagram_reels: { status: 'not_started', label: 'Instagram Reels', required_inputs: ['hook', 'caption'] },
+              thumbnail: { status: 'not_started', label: 'Thumbnail', required_inputs: ['short thumbnail text', '2-3 variants'] },
+            },
+          },
+          updated_at: '2026-06-22T12:00:00.000Z',
+        },
+      }),
+    })))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('shows shared evidence and channel-specific production tabs', async () => {
+    render(<SocialInsightDetailPage />)
+
+    expect(await screen.findByRole('heading', { name: 'Approval gates create trust' })).toBeInTheDocument()
+    expect(screen.getByText('The Social Content review flow made the gate visible.')).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /LinkedIn/ })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /YouTube Shorts/ })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /Instagram Reels/ })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /Thumbnail/ })).toBeInTheDocument()
+    expect(screen.getByText('post text')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('tab', { name: /Thumbnail/ }))
+
+    expect(screen.getByText('Thumbnail production inputs')).toBeInTheDocument()
+    expect(screen.getByText('short thumbnail text')).toBeInTheDocument()
+    expect(screen.getByText('2-3 variants')).toBeInTheDocument()
+  })
+})

--- a/app/admin/agents/social-insights/[id]/page.tsx
+++ b/app/admin/agents/social-insights/[id]/page.tsx
@@ -1,0 +1,311 @@
+'use client'
+
+import Link from 'next/link'
+import { useParams } from 'next/navigation'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { ReactNode } from 'react'
+import {
+  CheckCircle2,
+  FileText,
+  Image as ImageIcon,
+  Instagram,
+  MessageSquare,
+  RefreshCw,
+  ShieldAlert,
+  Youtube,
+} from 'lucide-react'
+import ProtectedRoute from '@/components/ProtectedRoute'
+import Breadcrumbs from '@/components/admin/Breadcrumbs'
+import { getCurrentSession } from '@/lib/auth'
+import type { AgentWorkItem } from '@/lib/agent-work-items'
+import {
+  SOCIAL_CONTENT_INTELLIGENCE_CHANNELS,
+  type SocialContentIntelligenceChannel,
+} from '@/lib/social-content-intelligence'
+
+type ChannelLane = {
+  status: string
+  label: string
+  decision_note?: string | null
+  required_inputs?: string[]
+}
+
+const CHANNEL_LABELS: Record<SocialContentIntelligenceChannel, string> = {
+  linkedin: 'LinkedIn',
+  youtube_shorts: 'YouTube Shorts',
+  instagram_reels: 'Instagram Reels',
+  thumbnail: 'Thumbnail',
+}
+
+const CHANNEL_ICONS: Record<SocialContentIntelligenceChannel, ReactNode> = {
+  linkedin: <FileText className="h-4 w-4" />,
+  youtube_shorts: <Youtube className="h-4 w-4" />,
+  instagram_reels: <Instagram className="h-4 w-4" />,
+  thumbnail: <ImageIcon className="h-4 w-4" />,
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
+}
+
+function asString(value: unknown) {
+  return typeof value === 'string' ? value : ''
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
+}
+
+function lanesFor(item: AgentWorkItem | null): Record<SocialContentIntelligenceChannel, ChannelLane> {
+  const metadata = item?.metadata ?? {}
+  const lanes = asRecord(metadata.channel_lanes)
+  return SOCIAL_CONTENT_INTELLIGENCE_CHANNELS.reduce((result, channel) => {
+    const lane = asRecord(lanes[channel])
+    result[channel] = {
+      status: asString(lane.status) || 'not_started',
+      label: asString(lane.label) || CHANNEL_LABELS[channel],
+      decision_note: asString(lane.decision_note) || null,
+      required_inputs: asStringArray(lane.required_inputs),
+    }
+    return result
+  }, {} as Record<SocialContentIntelligenceChannel, ChannelLane>)
+}
+
+export default function SocialInsightDetailPage() {
+  return (
+    <ProtectedRoute requireAdmin>
+      <SocialInsightDetailContent />
+    </ProtectedRoute>
+  )
+}
+
+function SocialInsightDetailContent() {
+  const { id } = useParams<{ id: string }>()
+  const [item, setItem] = useState<AgentWorkItem | null>(null)
+  const [activeTab, setActiveTab] = useState<SocialContentIntelligenceChannel>('linkedin')
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const authedFetch = useCallback(async (path: string) => {
+    const session = await getCurrentSession()
+    if (!session?.access_token) throw new Error('Missing admin session')
+    return fetch(path, {
+      headers: { Authorization: `Bearer ${session.access_token}` },
+    })
+  }, [])
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await authedFetch(`/api/admin/agents/work-items/${id}`)
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`)
+      setItem(body.work_item ?? null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load insight')
+      setItem(null)
+    } finally {
+      setLoading(false)
+    }
+  }, [authedFetch, id])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const metadata = item?.metadata ?? {}
+  const insight = asRecord(metadata.insight)
+  const lanes = useMemo(() => lanesFor(item), [item])
+  const activeLane = lanes[activeTab]
+
+  return (
+    <div className="agent-ops-page min-h-screen p-5 text-foreground lg:p-7">
+      <div className="mx-auto max-w-7xl">
+        <Breadcrumbs items={[
+          { label: 'Admin Dashboard', href: '/admin' },
+          { label: 'Agent Operations', href: '/admin/agents' },
+          { label: 'Content Intelligence', href: '/admin/agents/content-intelligence' },
+          { label: 'Social Insight' },
+        ]} />
+
+        <header className="agent-ops-surface-header mb-6 mt-5 rounded-xl border p-5">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+            <div>
+              <div className="agent-ops-eyebrow mb-2">
+                <MessageSquare size={16} />
+                Shared insight
+              </div>
+              <h1 className="text-3xl font-bold">{asString(insight.title) || item?.title || 'Social insight'}</h1>
+              <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+                One central Shaka backlog item feeds each social channel lane. Drafting, media, uploads, scheduling, and publishing remain separate approval gates.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Link href="/admin/agents/coordination" className="agent-ops-button-muted">
+                Backlog
+              </Link>
+              <button
+                type="button"
+                onClick={load}
+                disabled={loading}
+                className="agent-ops-button-secondary disabled:opacity-60"
+              >
+                <RefreshCw size={16} className={loading ? 'animate-spin' : ''} />
+                Refresh
+              </button>
+            </div>
+          </div>
+        </header>
+
+        {error ? (
+          <div className="mb-6 rounded-lg border border-red-500/35 bg-red-500/10 p-4 text-sm text-red-100">
+            {error}
+          </div>
+        ) : null}
+
+        {loading ? (
+          <div className="py-16 text-center text-sm text-muted-foreground">Loading insight...</div>
+        ) : item ? (
+          <div className="grid gap-6 xl:grid-cols-[minmax(0,0.45fr)_minmax(0,1fr)]">
+            <section className="agent-ops-card rounded-lg border p-4">
+              <h2 className="text-lg font-semibold">Shared evidence</h2>
+              <div className="mt-4 space-y-3">
+                <InsightField label="Triggering event" value={asString(insight.triggering_event)} />
+                <InsightField label="Why Vambah can speak" value={asString(insight.why_vambah_can_speak)} />
+                <InsightField label="Evidence summary" value={asString(insight.evidence_summary)} />
+                <InsightField label="Brand goal" value={asString(insight.brand_goal)} />
+                <InsightField label="Audience" value={asString(insight.audience)} />
+              </div>
+              <div className="mt-4 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3">
+                <div className="mb-2 flex items-center gap-2 text-sm font-semibold text-amber-100">
+                  <ShieldAlert className="h-4 w-4" />
+                  Claim boundaries
+                </div>
+                {asStringArray(insight.claim_boundaries).length ? (
+                  <ul className="space-y-1 text-sm leading-6 text-muted-foreground">
+                    {asStringArray(insight.claim_boundaries).map((boundary) => (
+                      <li key={boundary}>{boundary}</li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="text-sm text-muted-foreground">No claim boundaries recorded yet.</p>
+                )}
+              </div>
+            </section>
+
+            <section className="agent-ops-card rounded-lg border p-4">
+              <div className="mb-4 flex flex-wrap gap-2" role="tablist" aria-label="Social channel lanes">
+                {SOCIAL_CONTENT_INTELLIGENCE_CHANNELS.map((channel) => (
+                  <button
+                    key={channel}
+                    type="button"
+                    role="tab"
+                    aria-selected={activeTab === channel}
+                    onClick={() => setActiveTab(channel)}
+                    className={`inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm ${
+                      activeTab === channel
+                        ? 'border-radiant-gold/60 bg-radiant-gold/15 text-radiant-gold'
+                        : 'border-silicon-slate/70 bg-silicon-slate/20 text-muted-foreground hover:text-foreground'
+                    }`}
+                  >
+                    {CHANNEL_ICONS[channel]}
+                    {CHANNEL_LABELS[channel]}
+                    <span className="rounded-full border border-current/30 px-2 py-0.5 text-[10px]">
+                      {lanes[channel].status.replace(/_/g, ' ')}
+                    </span>
+                  </button>
+                ))}
+              </div>
+
+              <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
+                <div className="mb-4 flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+                  <div>
+                    <h2 className="text-lg font-semibold">{CHANNEL_LABELS[activeTab]} production inputs</h2>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      This lane defines what must be reviewed before production. It does not create drafts, render media, upload, schedule, or publish.
+                    </p>
+                  </div>
+                  <span className="inline-flex w-fit items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/10 px-3 py-1 text-xs font-semibold text-blue-100">
+                    <CheckCircle2 className="h-3.5 w-3.5" />
+                    {activeLane.status.replace(/_/g, ' ')}
+                  </span>
+                </div>
+
+                <ChannelInputs channel={activeTab} lane={activeLane} insight={insight} />
+
+                {activeLane.decision_note ? (
+                  <div className="mt-4 rounded-lg border border-silicon-slate/70 bg-background/45 p-3">
+                    <p className="text-xs uppercase tracking-wide text-muted-foreground">Decision note</p>
+                    <p className="mt-1 text-sm leading-6">{activeLane.decision_note}</p>
+                  </div>
+                ) : null}
+              </div>
+            </section>
+          </div>
+        ) : (
+          <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 px-4 py-12 text-center text-sm text-muted-foreground">
+            Insight not found.
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function InsightField({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-3">
+      <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="mt-1 text-sm leading-6">{value || 'Not recorded yet'}</p>
+    </div>
+  )
+}
+
+function ChannelInputs({
+  channel,
+  lane,
+  insight,
+}: {
+  channel: SocialContentIntelligenceChannel
+  lane: ChannelLane
+  insight: Record<string, unknown>
+}) {
+  const requiredInputs = lane.required_inputs?.length ? lane.required_inputs : defaultInputs(channel)
+  return (
+    <div>
+      <div className="grid gap-3 md:grid-cols-2">
+        {requiredInputs.map((input) => (
+          <div key={input} className="rounded-lg border border-silicon-slate/70 bg-background/40 p-3">
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">{input}</p>
+            <p className="mt-1 text-sm leading-6 text-muted-foreground">
+              {suggestedValue(input, insight) || 'Pending lane draft'}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function defaultInputs(channel: SocialContentIntelligenceChannel) {
+  if (channel === 'linkedin') {
+    return ['post text', 'CTA', 'CTA URL', 'hashtags', 'carousel or illustration mode', 'screenshot routes', 'references']
+  }
+  if (channel === 'youtube_shorts') {
+    return ['hook', 'first 30 seconds', 'script', 'target duration', 'storyboard scenes', 'b-roll hints/assets', 'on-screen text', 'caption', 'render readiness']
+  }
+  if (channel === 'instagram_reels') {
+    return ['hook', 'script', 'target duration', 'storyboard scenes', 'cover text', 'caption', 'hashtags', 'b-roll assets', 'safe-area notes', 'export readiness']
+  }
+  return ['source thumbnail reference', 'pattern explanation', 'AmaduTown adaptation direction', 'short thumbnail text', 'face/photo/avatar choice', 'brand colors/style', '2-3 variants', 'approval state']
+}
+
+function suggestedValue(input: string, insight: Record<string, unknown>) {
+  const lower = input.toLowerCase()
+  if (lower.includes('hook')) return asString(insight.suggested_hook)
+  if (lower.includes('caption') || lower.includes('post text') || lower.includes('script')) return asString(insight.content_angle)
+  if (lower.includes('references')) return asString(insight.evidence_summary)
+  if (lower.includes('thumbnail') || lower.includes('pattern')) return 'Use approved public research patterns only; adapt into AmaduTown style.'
+  return ''
+}

--- a/app/admin/social-content/[id]/page.tsx
+++ b/app/admin/social-content/[id]/page.tsx
@@ -303,7 +303,7 @@ function SocialContentDetailPage() {
       const session = await getCurrentSession()
       if (!session) return
 
-      const res = await fetch('/api/admin/social-content/topic-backlog?status=available&limit=6', {
+      const res = await fetch('/api/admin/social-content/topic-backlog?status=available&social_channel=linkedin&limit=6', {
         headers: { Authorization: `Bearer ${session.access_token}` },
       })
       const data = await res.json()
@@ -2094,15 +2094,15 @@ function SocialContentDetailPage() {
                     <div className="min-w-0">
                       <p className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.14em] text-blue-200">
                         <Lightbulb className="h-3.5 w-3.5" />
-                        Shaka topic backlog
+                        LinkedIn topics from Agentic Backlog
                       </p>
                       <p className="mt-1 text-sm leading-6 text-blue-50/85">
-                        Pulled from Shaka&apos;s recurring scan of sanitized meetings, shipped work, client-safe projects, and approved memory.
+                        Filtered from the central Shaka insight backlog. The same insight can also feed YouTube Shorts, Instagram Reels, and thumbnail production.
                       </p>
                     </div>
                     <div className="flex shrink-0 flex-wrap items-center gap-2 lg:justify-end">
                       <span className="rounded-full border border-blue-400/35 px-2 py-0.5 text-[10px] font-semibold text-blue-100">
-                        {loadingTopicBacklog ? 'Loading backlog' : `${displayedTopicBacklogItems.length} available`}
+                        {loadingTopicBacklog ? 'Loading backlog' : `${displayedTopicBacklogItems.length} LinkedIn-ready`}
                       </span>
                       <span className="rounded-full border border-blue-400/25 px-2 py-0.5 text-[10px] text-blue-50/75">
                         Weekday scan
@@ -2111,12 +2111,12 @@ function SocialContentDetailPage() {
                   </div>
                   {topicBacklogUnavailable && (
                     <p className="mt-2 text-xs text-amber-200">
-                      Backlog migration pending. The scheduled scan will populate this after deployment.
+                      Backlog migration pending. The central Agentic Backlog will populate this after deployment.
                     </p>
                   )}
                   {!topicBacklogUnavailable && displayedTopicBacklogItems.length === 0 && !loadingTopicBacklog && (
                     <p className="mt-2 text-xs text-blue-50/65">
-                      No topics are available yet. Shaka&apos;s scheduled scan will populate this backlog.
+                      No LinkedIn-filtered topics are available yet. Shaka&apos;s scheduled scan will populate the central Agentic Backlog.
                     </p>
                   )}
                   {usingDraftTopicFallback && agentPilotTopicTriggerGeneratedAt && (
@@ -2143,7 +2143,7 @@ function SocialContentDetailPage() {
                   {loadingTopicBacklog && displayedTopicBacklogItems.length === 0 && (
                     <div className="mt-3 flex items-center gap-2 text-sm text-blue-50/70">
                       <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                      Loading Shaka&apos;s topic backlog
+                      Loading central Shaka insight backlog
                     </div>
                   )}
                   {displayedTopicBacklogItems.length > 0 && (

--- a/app/api/admin/agents/work-items/[id]/social-channels/[channel]/route.ts
+++ b/app/api/admin/agents/work-items/[id]/social-channels/[channel]/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { getAgentWorkItem, updateAgentWorkItemMetadata } from '@/lib/agent-work-items'
+import {
+  isSocialContentIntelligenceChannel,
+  normalizeSocialChannelLanes,
+  type SocialChannelLaneStatus,
+} from '@/lib/social-content-intelligence'
+
+export const dynamic = 'force-dynamic'
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
+}
+
+function asString(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string; channel: string } },
+) {
+  const authResult = await verifyAdmin(request)
+  if (isAuthError(authResult)) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status })
+  }
+
+  if (!isSocialContentIntelligenceChannel(params.channel)) {
+    return NextResponse.json({ error: 'Invalid social content channel' }, { status: 400 })
+  }
+
+  const body = asRecord(await request.json().catch(() => ({})))
+  const status = asString(body.status)
+  if (status && ![
+    'not_started',
+    'selected',
+    'draft_ready',
+    'in_review',
+    'approved',
+    'blocked',
+  ].includes(status)) {
+    return NextResponse.json({ error: 'Invalid channel status' }, { status: 400 })
+  }
+  const nextStatus = status as SocialChannelLaneStatus | ''
+
+  try {
+    const workItem = await getAgentWorkItem(params.id)
+    if (!workItem) {
+      return NextResponse.json({ error: 'Work item not found' }, { status: 404 })
+    }
+
+    const lanes = normalizeSocialChannelLanes(workItem.metadata?.channel_lanes)
+    lanes[params.channel] = {
+      ...lanes[params.channel],
+      ...asRecord(body.patch),
+      status: nextStatus || lanes[params.channel].status,
+      decision_note: asString(body.decision_note) || lanes[params.channel].decision_note || null,
+      updated_at: new Date().toISOString(),
+    }
+
+    const updated = await updateAgentWorkItemMetadata({
+      id: workItem.id,
+      metadata: {
+        ...(workItem.metadata ?? {}),
+        channel_lanes: lanes,
+      },
+      note: `${lanes[params.channel].label} lane updated by ${authResult.user.email ?? authResult.user.id}.`,
+    })
+
+    return NextResponse.json({
+      success: true,
+      work_item: updated,
+      lane: lanes[params.channel],
+      side_effects: {
+        provider_generation: false,
+        upload: false,
+        publish: false,
+        schedule: false,
+        external_post: false,
+      },
+    })
+  } catch (error) {
+    console.error('[social-channel-lane] update failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to update social channel lane' },
+      { status: 500 },
+    )
+  }
+}

--- a/app/api/admin/agents/work-items/route.test.ts
+++ b/app/api/admin/agents/work-items/route.test.ts
@@ -75,6 +75,50 @@ describe('/api/admin/agents/work-items', () => {
     expect(bad.status).toBe(400)
   })
 
+  it('passes source filters and supports social channel backlog filtering', async () => {
+    mocks.listAgentWorkItems.mockResolvedValue([
+      {
+        id: 'work-social-1',
+        source_type: 'social_topic_trigger',
+        metadata: {
+          social_topic_trigger: true,
+          channel_lanes: {
+            linkedin: { status: 'not_started' },
+          },
+        },
+      },
+      {
+        id: 'work-other-1',
+        source_type: 'agent_run',
+        metadata: {},
+      },
+    ])
+
+    const response = await GET(request('http://localhost/api/admin/agents/work-items?source_type=social_topic_trigger&social_channel=linkedin') as never)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      work_items: [
+        {
+          id: 'work-social-1',
+          source_type: 'social_topic_trigger',
+          metadata: {
+            social_topic_trigger: true,
+            channel_lanes: {
+              linkedin: { status: 'not_started' },
+            },
+          },
+        },
+      ],
+    })
+    expect(mocks.listAgentWorkItems).toHaveBeenCalledWith(expect.objectContaining({
+      sourceType: 'social_topic_trigger',
+    }))
+
+    const bad = await GET(request('http://localhost/api/admin/agents/work-items?social_channel=threads') as never)
+    expect(bad.status).toBe(400)
+  })
+
   it('creates a work item with scoped fields', async () => {
     const response = await POST(request('http://localhost/api/admin/agents/work-items', {
       title: 'Coordinate feature',

--- a/app/api/admin/agents/work-items/route.ts
+++ b/app/api/admin/agents/work-items/route.ts
@@ -9,6 +9,10 @@ import {
   type AgentWorkItemStatus,
 } from '@/lib/agent-work-items'
 import { AGENT_RUNTIMES, type AgentRuntime } from '@/lib/agent-run'
+import {
+  isSocialContentIntelligenceChannel,
+  isSocialTopicTriggerWorkItem,
+} from '@/lib/social-content-intelligence'
 
 export const dynamic = 'force-dynamic'
 
@@ -40,13 +44,21 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid status' }, { status: 400 })
   }
   const statusFilter: AgentWorkItemStatus | null = status ? status as AgentWorkItemStatus : null
+  const socialChannel = searchParams.get('social_channel')
+  if (socialChannel && !isSocialContentIntelligenceChannel(socialChannel)) {
+    return NextResponse.json({ error: 'Invalid social_channel' }, { status: 400 })
+  }
 
   try {
-    const work_items = await listAgentWorkItems({
+    const workItems = await listAgentWorkItems({
       status: statusFilter,
       ownerAgentKey: searchParams.get('owner_agent_key'),
+      sourceType: searchParams.get('source_type'),
       limit: Number(searchParams.get('limit') || 50),
     })
+    const work_items = socialChannel
+      ? workItems.filter((item) => isSocialTopicTriggerWorkItem(item) && Boolean(item.metadata?.channel_lanes))
+      : workItems
     return NextResponse.json({ work_items })
   } catch (error) {
     console.error('[agent-work-items] list failed:', error)

--- a/app/api/admin/social-content/intelligence/research-packets/route.test.ts
+++ b/app/api/admin/social-content/intelligence/research-packets/route.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  from: vi.fn(),
+  selectLimit: vi.fn(),
+  insertSingle: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import { GET, POST } from './route'
+
+describe('/api/admin/social-content/intelligence/research-packets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-1' }, isAdmin: true })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.selectLimit.mockResolvedValue({
+      data: [
+        {
+          id: 'packet-1',
+          source_url: 'https://youtube.com/watch?v=abc',
+          platform: 'youtube',
+          outlier_score: 82,
+        },
+      ],
+      error: null,
+    })
+    mocks.insertSingle.mockResolvedValue({
+      data: {
+        id: 'packet-2',
+        source_url: 'https://youtube.com/watch?v=abc',
+        platform: 'youtube',
+        outlier_score: 81,
+        actor_metadata: { actor_id: 'pintostudio/youtube-transcript-scraper' },
+      },
+      error: null,
+    })
+    const selectChain = {
+      eq: vi.fn(() => selectChain),
+      order: vi.fn(() => selectChain),
+      limit: mocks.selectLimit,
+    }
+    mocks.from.mockReturnValue({
+      select: vi.fn(() => ({
+        eq: selectChain.eq,
+        order: selectChain.order,
+        limit: mocks.selectLimit,
+      })),
+      insert: vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: mocks.insertSingle,
+        })),
+      })),
+    })
+  })
+
+  it('lists stored research packets for admin review', async () => {
+    const response = await GET(new NextRequest('http://localhost/api/admin/social-content/intelligence/research-packets?platform=youtube'))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      packets: [
+        {
+          id: 'packet-1',
+          source_url: 'https://youtube.com/watch?v=abc',
+          platform: 'youtube',
+          outlier_score: 82,
+        },
+      ],
+    })
+  })
+
+  it('stores research packets with actor metadata and no publishing side effects', async () => {
+    const response = await POST(new NextRequest('http://localhost/api/admin/social-content/intelligence/research-packets', {
+      method: 'POST',
+      body: JSON.stringify({
+        source_url: 'https://youtube.com/watch?v=abc',
+        platform: 'youtube',
+        title: 'How I find outlier videos',
+        hook_transcript: 'I spent weeks studying what actually worked.',
+        metrics: {
+          views: 100000,
+          likes: 7000,
+          comments: 400,
+          follower_count: 50000,
+          published_at: '2026-06-20T12:00:00.000Z',
+        },
+        actor_metadata: {
+          actor_id: 'pintostudio/youtube-transcript-scraper',
+          run_id: 'run-1',
+        },
+      }),
+    }))
+
+    expect(response.status).toBe(200)
+    expect(mocks.from).toHaveBeenCalledWith('social_content_research_packets')
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      packet: {
+        id: 'packet-2',
+        actor_metadata: { actor_id: 'pintostudio/youtube-transcript-scraper' },
+      },
+      side_effects: {
+        provider_generation: false,
+        upload: false,
+        publish: false,
+        schedule: false,
+        external_post: false,
+      },
+    })
+  })
+
+  it('rejects invalid platform values', async () => {
+    const response = await POST(new NextRequest('http://localhost/api/admin/social-content/intelligence/research-packets', {
+      method: 'POST',
+      body: JSON.stringify({
+        source_url: 'https://example.com/video',
+        platform: 'snapchat',
+      }),
+    }))
+
+    expect(response.status).toBe(400)
+  })
+})

--- a/app/api/admin/social-content/intelligence/research-packets/route.ts
+++ b/app/api/admin/social-content/intelligence/research-packets/route.ts
@@ -1,0 +1,160 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import {
+  normalizePatternStatus,
+  scoreCreatorAsset,
+  socialMetricsFromUnknown,
+} from '@/lib/social-content-intelligence'
+import { supabaseAdmin } from '@/lib/supabase'
+
+export const dynamic = 'force-dynamic'
+
+const PLATFORMS = new Set([
+  'youtube',
+  'youtube_shorts',
+  'instagram',
+  'instagram_reels',
+  'tiktok',
+  'x',
+  'linkedin',
+  'other',
+])
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
+}
+
+function asString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function isMissingResearchTable(error: unknown) {
+  const message = error instanceof Error
+    ? error.message
+    : typeof error === 'object' && error && 'message' in error
+      ? String((error as { message?: unknown }).message ?? '')
+      : String(error ?? '')
+  return message.includes('social_content_research_packets') && (
+    message.includes('does not exist')
+    || message.includes('schema cache')
+    || message.includes('Could not find the table')
+  )
+}
+
+export async function GET(request: NextRequest) {
+  const authResult = await verifyAdmin(request)
+  if (isAuthError(authResult)) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status })
+  }
+
+  const { searchParams } = new URL(request.url)
+  const status = searchParams.get('status')
+  const platform = searchParams.get('platform')
+  const limit = Math.min(Math.max(parseInt(searchParams.get('limit') || '20', 10), 1), 50)
+
+  if (platform && !PLATFORMS.has(platform)) {
+    return NextResponse.json({ error: 'Invalid platform' }, { status: 400 })
+  }
+
+  try {
+    let query = supabaseAdmin
+      .from('social_content_research_packets')
+      .select('*')
+
+    if (status) query = query.eq('status', status)
+    if (platform) query = query.eq('platform', platform)
+
+    const { data, error } = await query
+      .order('outlier_score', { ascending: false })
+      .order('retrieved_at', { ascending: false })
+      .limit(limit)
+
+    if (error) {
+      if (isMissingResearchTable(error)) {
+        return NextResponse.json({
+          packets: [],
+          unavailable: true,
+          error: 'Social Content Intelligence migration has not been applied yet',
+        })
+      }
+      throw new Error(error.message)
+    }
+
+    return NextResponse.json({ packets: data ?? [] })
+  } catch (error) {
+    console.error('[social-content-intelligence] list packets failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to list research packets' },
+      { status: 500 },
+    )
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const authResult = await verifyAdmin(request)
+  if (isAuthError(authResult)) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status })
+  }
+
+  const body = asRecord(await request.json().catch(() => ({})))
+  const sourceUrl = asString(body.source_url)
+  const platform = asString(body.platform) || 'other'
+  if (!sourceUrl) {
+    return NextResponse.json({ error: 'source_url is required' }, { status: 400 })
+  }
+  if (!PLATFORMS.has(platform)) {
+    return NextResponse.json({ error: 'Invalid platform' }, { status: 400 })
+  }
+
+  const metrics = asRecord(body.metrics)
+  const score = scoreCreatorAsset({
+    ...socialMetricsFromUnknown(metrics),
+    retrieved_at: asString(body.retrieved_at) || new Date().toISOString(),
+  })
+
+  try {
+    const { data, error } = await supabaseAdmin
+      .from('social_content_research_packets')
+      .insert({
+        source_url: sourceUrl,
+        platform,
+        creator_name: asString(body.creator_name) || null,
+        creator_handle: asString(body.creator_handle) || null,
+        title: asString(body.title) || null,
+        caption: asString(body.caption) || null,
+        thumbnail_url: asString(body.thumbnail_url) || null,
+        hook_transcript: asString(body.hook_transcript) || null,
+        metrics,
+        actor_metadata: asRecord(body.actor_metadata),
+        outlier_score: score.outlier_score,
+        score_breakdown: score,
+        pattern_packet: asRecord(body.pattern_packet),
+        pattern_status: normalizePatternStatus(body.pattern_status),
+        privacy_notes: asString(body.privacy_notes) || 'Public research packet. Do not copy source script, title, thumbnail, or visual identity.',
+        retrieved_at: asString(body.retrieved_at) || new Date().toISOString(),
+        created_by: authResult.user.id,
+      })
+      .select('*')
+      .single()
+
+    if (error) throw new Error(error.message)
+
+    return NextResponse.json({
+      success: true,
+      packet: data,
+      side_effects: {
+        provider_generation: false,
+        upload: false,
+        publish: false,
+        schedule: false,
+        external_post: false,
+      },
+    })
+  } catch (error) {
+    console.error('[social-content-intelligence] create packet failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to create research packet' },
+      { status: 500 },
+    )
+  }
+}

--- a/app/api/admin/social-content/topic-backlog/route.test.ts
+++ b/app/api/admin/social-content/topic-backlog/route.test.ts
@@ -7,6 +7,9 @@ const mocks = vi.hoisted(() => ({
   from: vi.fn(),
   selectLimit: vi.fn(),
   updateSingle: vi.fn(),
+  getAgentWorkItem: vi.fn(),
+  listAgentWorkItems: vi.fn(),
+  updateAgentWorkItemMetadata: vi.fn(),
   runSocialTopicBacklogDiscovery: vi.fn(),
 }))
 
@@ -25,7 +28,59 @@ vi.mock('@/lib/social-topic-backlog', () => ({
   runSocialTopicBacklogDiscovery: mocks.runSocialTopicBacklogDiscovery,
 }))
 
+vi.mock('@/lib/agent-work-items', () => ({
+  getAgentWorkItem: mocks.getAgentWorkItem,
+  listAgentWorkItems: mocks.listAgentWorkItems,
+  updateAgentWorkItemMetadata: mocks.updateAgentWorkItemMetadata,
+}))
+
 import { GET, PATCH, POST } from './route'
+
+const centralWorkItem = {
+  id: 'work-topic-1',
+  title: 'Approval gates create trust',
+  objective: 'Make the case for governed AI work.',
+  status: 'proposed',
+  priority: 'high',
+  owner_agent_key: 'chief-of-staff',
+  owner_runtime: 'codex',
+  source_type: 'social_topic_trigger',
+  source_id: 'approval-gates-create-trust',
+  source_label: 'Shaka topic trigger',
+  source_run_id: null,
+  active_run_id: null,
+  parent_work_item_id: null,
+  branch_name: null,
+  worktree_path: null,
+  pr_number: null,
+  pr_url: null,
+  expected_files: [],
+  touched_files: [],
+  overlap_group: null,
+  dependency_ids: [],
+  blocker_summary: null,
+  validation_summary: null,
+  approval_id: null,
+  metadata: {
+    social_topic_trigger: true,
+    channel_lanes: {
+      linkedin: {
+        status: 'not_started',
+        label: 'LinkedIn',
+        required_inputs: ['post text'],
+      },
+    },
+    insight: {
+      title: 'Approval gates create trust',
+      triggering_event: 'A recent shipped feature made approval visible.',
+      why_vambah_can_speak: 'Vambah shipped the feature.',
+    },
+  },
+  idempotency_key: 'social-topic-trigger:approval-gates-create-trust',
+  created_at: '2026-06-22T12:00:00.000Z',
+  updated_at: '2026-06-22T12:00:00.000Z',
+  completed_at: null,
+}
 
 describe('/api/admin/social-content/topic-backlog', () => {
   beforeEach(() => {
@@ -55,6 +110,22 @@ describe('/api/admin/social-content/topic-backlog', () => {
       sourceCounts: { meeting: 1 },
       packet: { candidates: [{ id: 'topic-1' }] },
     })
+    mocks.listAgentWorkItems.mockResolvedValue([centralWorkItem])
+    mocks.getAgentWorkItem.mockResolvedValue(centralWorkItem)
+    mocks.updateAgentWorkItemMetadata.mockResolvedValue({
+      ...centralWorkItem,
+      metadata: {
+        ...centralWorkItem.metadata,
+        channel_lanes: {
+          linkedin: {
+            status: 'selected',
+            label: 'LinkedIn',
+            selected_for_content_id: 'social-1',
+            required_inputs: ['post text'],
+          },
+        },
+      },
+    })
     mocks.from.mockReturnValue({
       select: vi.fn(() => ({
         eq: vi.fn(() => ({
@@ -77,15 +148,19 @@ describe('/api/admin/social-content/topic-backlog', () => {
     const response = await GET(new NextRequest('http://localhost/api/admin/social-content/topic-backlog'))
 
     expect(response.status).toBe(200)
-    await expect(response.json()).resolves.toEqual({
+    await expect(response.json()).resolves.toMatchObject({
+      source: 'agent_work_items',
       items: [
         {
-          id: 'topic-1',
+          id: 'work-topic-1',
           title: 'Approval gates create trust',
           status: 'available',
         },
       ],
     })
+    expect(mocks.listAgentWorkItems).toHaveBeenCalledWith(expect.objectContaining({
+      sourceType: 'social_topic_trigger',
+    }))
   })
 
   it('requires admin auth before listing entries', async () => {
@@ -95,7 +170,7 @@ describe('/api/admin/social-content/topic-backlog', () => {
     const response = await GET(new NextRequest('http://localhost/api/admin/social-content/topic-backlog'))
 
     expect(response.status).toBe(401)
-    expect(mocks.from).not.toHaveBeenCalled()
+    expect(mocks.listAgentWorkItems).not.toHaveBeenCalled()
   })
 
   it('runs a manual backlog refresh without publish side effects', async () => {
@@ -124,7 +199,7 @@ describe('/api/admin/social-content/topic-backlog', () => {
     const response = await PATCH(new NextRequest('http://localhost/api/admin/social-content/topic-backlog', {
       method: 'PATCH',
       body: JSON.stringify({
-        id: 'topic-1',
+        id: 'work-topic-1',
         content_id: 'social-1',
         status: 'selected',
       }),
@@ -133,11 +208,17 @@ describe('/api/admin/social-content/topic-backlog', () => {
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toMatchObject({
       success: true,
+      source: 'agent_work_items',
       item: {
-        id: 'topic-1',
+        id: 'work-topic-1',
         status: 'selected',
-        selected_for_content_id: 'social-1',
       },
     })
+    expect(mocks.updateAgentWorkItemMetadata).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'work-topic-1',
+      metadata: expect.objectContaining({
+        selected_for_social_content_id: 'social-1',
+      }),
+    }))
   })
 })

--- a/app/api/admin/social-content/topic-backlog/route.ts
+++ b/app/api/admin/social-content/topic-backlog/route.ts
@@ -1,5 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import {
+  getAgentWorkItem,
+  listAgentWorkItems,
+  updateAgentWorkItemMetadata,
+} from '@/lib/agent-work-items'
+import {
+  normalizeSocialChannelLanes,
+  socialTopicBacklogItemFromWorkItem,
+  SOCIAL_TOPIC_TRIGGER_SOURCE_TYPE,
+} from '@/lib/social-content-intelligence'
 import { runSocialTopicBacklogDiscovery } from '@/lib/social-topic-backlog'
 import { supabaseAdmin } from '@/lib/supabase'
 
@@ -30,6 +40,21 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url)
     const status = searchParams.get('status') || 'available'
     const limit = Math.min(Math.max(parseInt(searchParams.get('limit') || '8', 10), 1), 24)
+
+    const workItems = await listAgentWorkItems({
+      sourceType: SOCIAL_TOPIC_TRIGGER_SOURCE_TYPE,
+      limit,
+    })
+    const mappedItems = workItems
+      .map(socialTopicBacklogItemFromWorkItem)
+      .filter((item) => status === 'all' || item.status === status)
+
+    if (mappedItems.length > 0) {
+      return NextResponse.json({
+        items: mappedItems,
+        source: 'agent_work_items',
+      })
+    }
 
     const { data, error } = await supabaseAdmin
       .from('social_topic_backlog')
@@ -120,6 +145,32 @@ export async function PATCH(request: NextRequest) {
     if (body.content_id) {
       update.selected_for_content_id = body.content_id
       update.selected_at = new Date().toISOString()
+    }
+
+    const workItem = await getAgentWorkItem(body.id)
+    if (workItem?.source_type === SOCIAL_TOPIC_TRIGGER_SOURCE_TYPE || workItem?.metadata?.social_topic_trigger === true) {
+      const lanes = normalizeSocialChannelLanes(workItem.metadata?.channel_lanes)
+      lanes.linkedin = {
+        ...lanes.linkedin,
+        status: nextStatus === 'selected' || nextStatus === 'used' ? 'selected' : 'not_started',
+        selected_for_content_id: body.content_id ?? lanes.linkedin.selected_for_content_id ?? null,
+        updated_at: new Date().toISOString(),
+      }
+      const updated = await updateAgentWorkItemMetadata({
+        id: workItem.id,
+        metadata: {
+          ...(workItem.metadata ?? {}),
+          channel_lanes: lanes,
+          selected_for_social_content_id: body.content_id ?? null,
+          social_topic_backlog_status: nextStatus,
+        },
+        note: `LinkedIn lane marked ${nextStatus} from Social Content topic picker.`,
+      })
+      return NextResponse.json({
+        success: true,
+        item: socialTopicBacklogItemFromWorkItem(updated),
+        source: 'agent_work_items',
+      })
     }
 
     const { data, error } = await supabaseAdmin

--- a/lib/admin-nav.ts
+++ b/lib/admin-nav.ts
@@ -88,6 +88,7 @@ export const ADMIN_NAV: { dashboard: AdminNavItem; categories: AdminNavCategory[
         { label: 'Mission Control', href: '/admin/agents' },
         { label: 'Standup Room', href: '/admin/agents/standup' },
         { label: 'Decision Queue', href: '/admin/agents/coordination' },
+        { label: 'Content Intelligence', href: '/admin/agents/content-intelligence' },
         { label: 'Agent Kanban', href: '/admin/agents/swarm-board' },
         { label: 'Run Console', href: '/admin/agents/runs' },
         { label: 'Automation Context', href: '/admin/agents/automations' },

--- a/lib/agent-work-items.ts
+++ b/lib/agent-work-items.ts
@@ -212,6 +212,8 @@ async function findWorkItemByIdempotencyKey(idempotencyKey?: string | null): Pro
 export async function listAgentWorkItems(input: {
   status?: AgentWorkItemStatus | null
   ownerAgentKey?: string | null
+  sourceType?: string | null
+  metadataContains?: Record<string, unknown> | null
   limit?: number
 } = {}): Promise<AgentWorkItem[]> {
   let query = db()
@@ -224,6 +226,12 @@ export async function listAgentWorkItems(input: {
   }
   if (input.ownerAgentKey) {
     query = query.eq('owner_agent_key', input.ownerAgentKey)
+  }
+  if (input.sourceType) {
+    query = query.eq('source_type', input.sourceType)
+  }
+  if (input.metadataContains && Object.keys(input.metadataContains).length > 0) {
+    query = query.contains('metadata', input.metadataContains)
   }
 
   const { data, error } = await query
@@ -543,6 +551,22 @@ export async function updateAgentWorkItemStatus(input: {
     {
       type: 'agent_work_item_status_updated',
       message: input.note ?? `${item.title}: ${input.status}`,
+    },
+  )
+}
+
+export async function updateAgentWorkItemMetadata(input: {
+  id: string
+  metadata: Record<string, unknown>
+  note?: string | null
+}) {
+  const item = await requireAgentWorkItem(input.id)
+  return updateWorkItem(
+    item,
+    { metadata: input.metadata },
+    {
+      type: 'agent_work_item_metadata_updated',
+      message: input.note ?? `${item.title}: metadata updated`,
     },
   )
 }

--- a/lib/social-content-intelligence.test.ts
+++ b/lib/social-content-intelligence.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+import {
+  defaultSocialChannelLanes,
+  normalizeSocialChannelLanes,
+  scoreCreatorAsset,
+  socialTopicBacklogItemFromWorkItem,
+} from './social-content-intelligence'
+import type { AgentWorkItem } from './agent-work-items'
+
+describe('social-content-intelligence', () => {
+  it('scores creator assets deterministically with a small-creator outlier boost', () => {
+    const score = scoreCreatorAsset({
+      views: 120_000,
+      likes: 8_000,
+      comments: 900,
+      shares: 400,
+      follower_count: 20_000,
+      published_at: '2026-06-20T12:00:00.000Z',
+      retrieved_at: '2026-06-22T12:00:00.000Z',
+      channel_relative_performance: 2.4,
+      strategic_fit: 0.9,
+    })
+
+    expect(score).toEqual({
+      outlier_score: 80,
+      view_to_follower_ratio: 6,
+      engagement_rate: 0.0775,
+      comment_density: 0.0075,
+      recency_score: 0.9333,
+      channel_relative_performance: 2.4,
+      small_creator_outlier_boost: 1,
+      strategic_fit: 0.9,
+    })
+  })
+
+  it('normalizes all channel lanes required for social production', () => {
+    const lanes = normalizeSocialChannelLanes({
+      linkedin: { status: 'selected', decision_note: 'Use as first channel.' },
+    })
+
+    expect(Object.keys(lanes)).toEqual(['linkedin', 'youtube_shorts', 'instagram_reels', 'thumbnail'])
+    expect(lanes.linkedin.status).toBe('selected')
+    expect(lanes.youtube_shorts.status).toBe('not_started')
+    expect(lanes.thumbnail.required_inputs).toContain('2-3 variants')
+  })
+
+  it('maps central work items into the legacy Social Content topic shape', () => {
+    const item = {
+      id: 'work-social-1',
+      title: 'Approval gates create trust',
+      objective: 'Make the case for governed AI work.',
+      status: 'proposed',
+      priority: 'high',
+      owner_agent_key: 'chief-of-staff',
+      owner_runtime: 'codex',
+      source_type: 'social_topic_trigger',
+      source_id: 'approval-gates-create-trust',
+      source_label: 'Shaka topic trigger',
+      source_run_id: null,
+      active_run_id: null,
+      parent_work_item_id: null,
+      branch_name: null,
+      worktree_path: null,
+      pr_number: null,
+      pr_url: null,
+      expected_files: [],
+      touched_files: [],
+      overlap_group: null,
+      dependency_ids: [],
+      blocker_summary: null,
+      validation_summary: null,
+      approval_id: null,
+      metadata: {
+        social_topic_trigger: true,
+        channel_lanes: defaultSocialChannelLanes(),
+        insight: {
+          title: 'Approval gates create trust',
+          triggering_event: 'A recent shipped feature made the approval path visible.',
+          why_vambah_can_speak: 'Vambah built the system and reviewed the gates.',
+          claim_boundaries: ['Do not imply every workflow is automated.'],
+        },
+      },
+      idempotency_key: 'social-topic-trigger:approval-gates-create-trust',
+      created_at: '2026-06-22T12:00:00.000Z',
+      updated_at: '2026-06-22T12:00:00.000Z',
+      completed_at: null,
+    } satisfies AgentWorkItem
+
+    const mapped = socialTopicBacklogItemFromWorkItem(item)
+
+    expect(mapped.id).toBe('work-social-1')
+    expect(mapped.agent_work_item_id).toBe('work-social-1')
+    expect(mapped.title).toBe('Approval gates create trust')
+    expect(mapped.claim_boundaries).toEqual(['Do not imply every workflow is automated.'])
+  })
+})

--- a/lib/social-content-intelligence.ts
+++ b/lib/social-content-intelligence.ts
@@ -1,0 +1,351 @@
+import type { AgentWorkItem } from '@/lib/agent-work-items'
+import type { TopicTriggerCandidate, TopicTriggerPacket } from '@/lib/social-topic-backlog'
+
+export const SOCIAL_TOPIC_TRIGGER_SOURCE_TYPE = 'social_topic_trigger'
+
+export const SOCIAL_CONTENT_INTELLIGENCE_CHANNELS = [
+  'linkedin',
+  'youtube_shorts',
+  'instagram_reels',
+  'thumbnail',
+] as const
+
+export type SocialContentIntelligenceChannel = (typeof SOCIAL_CONTENT_INTELLIGENCE_CHANNELS)[number]
+
+export type SocialChannelLaneStatus =
+  | 'not_started'
+  | 'selected'
+  | 'draft_ready'
+  | 'in_review'
+  | 'approved'
+  | 'blocked'
+
+export type SocialChannelLane = {
+  status: SocialChannelLaneStatus
+  label: string
+  decision_note?: string | null
+  selected_for_content_id?: string | null
+  updated_at?: string | null
+  required_inputs: string[]
+}
+
+export type SocialChannelLanes = Record<SocialContentIntelligenceChannel, SocialChannelLane>
+
+export type SocialResearchPatternStatus =
+  | 'usable_framework'
+  | 'needs_brand_translation'
+  | 'too_close_to_source'
+  | 'not_relevant'
+
+export type CreatorAssetScoreInput = {
+  views?: number | null
+  likes?: number | null
+  comments?: number | null
+  shares?: number | null
+  follower_count?: number | null
+  published_at?: string | null
+  retrieved_at?: string | null
+  strategic_fit?: number | null
+  channel_relative_performance?: number | null
+}
+
+export type CreatorAssetScore = {
+  outlier_score: number
+  view_to_follower_ratio: number | null
+  engagement_rate: number | null
+  comment_density: number | null
+  recency_score: number
+  channel_relative_performance: number
+  small_creator_outlier_boost: number
+  strategic_fit: number
+}
+
+const CHANNEL_LABELS: Record<SocialContentIntelligenceChannel, string> = {
+  linkedin: 'LinkedIn',
+  youtube_shorts: 'YouTube Shorts',
+  instagram_reels: 'Instagram Reels',
+  thumbnail: 'Thumbnail',
+}
+
+const CHANNEL_INPUTS: Record<SocialContentIntelligenceChannel, string[]> = {
+  linkedin: [
+    'post text',
+    'CTA',
+    'CTA URL',
+    'hashtags',
+    'carousel or illustration mode',
+    'screenshot routes',
+    'references',
+  ],
+  youtube_shorts: [
+    'hook',
+    'first 30 seconds',
+    'script',
+    'target duration',
+    'storyboard scenes',
+    'b-roll hints/assets',
+    'on-screen text',
+    'caption',
+    'render readiness',
+  ],
+  instagram_reels: [
+    'hook',
+    'script',
+    'target duration',
+    'storyboard scenes',
+    'cover text',
+    'caption',
+    'hashtags',
+    'b-roll assets',
+    'safe-area notes',
+    'export readiness',
+  ],
+  thumbnail: [
+    'source thumbnail reference',
+    'pattern explanation',
+    'AmaduTown adaptation direction',
+    'short thumbnail text',
+    'face/photo/avatar choice',
+    'brand colors/style',
+    '2-3 variants',
+    'approval state',
+  ],
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null
+}
+
+function asString(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
+}
+
+function numberOrNull(value: unknown) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value))
+}
+
+export function isSocialContentIntelligenceChannel(value: string | null | undefined): value is SocialContentIntelligenceChannel {
+  return SOCIAL_CONTENT_INTELLIGENCE_CHANNELS.includes(value as SocialContentIntelligenceChannel)
+}
+
+export function socialChannelLabel(channel: SocialContentIntelligenceChannel) {
+  return CHANNEL_LABELS[channel]
+}
+
+export function defaultSocialChannelLanes(status: SocialChannelLaneStatus = 'not_started'): SocialChannelLanes {
+  return SOCIAL_CONTENT_INTELLIGENCE_CHANNELS.reduce((lanes, channel) => {
+    lanes[channel] = {
+      status,
+      label: CHANNEL_LABELS[channel],
+      required_inputs: CHANNEL_INPUTS[channel],
+    }
+    return lanes
+  }, {} as SocialChannelLanes)
+}
+
+export function normalizeSocialChannelLanes(value: unknown): SocialChannelLanes {
+  const record = asRecord(value)
+  const defaults = defaultSocialChannelLanes()
+  if (!record) return defaults
+
+  for (const channel of SOCIAL_CONTENT_INTELLIGENCE_CHANNELS) {
+    const lane = asRecord(record[channel])
+    if (!lane) continue
+    const status = asString(lane.status)
+    defaults[channel] = {
+      ...defaults[channel],
+      ...lane,
+      status: isSocialChannelLaneStatus(status) ? status : defaults[channel].status,
+      label: asString(lane.label) || defaults[channel].label,
+      required_inputs: asStringArray(lane.required_inputs).length
+        ? asStringArray(lane.required_inputs)
+        : defaults[channel].required_inputs,
+      decision_note: asString(lane.decision_note) || null,
+      selected_for_content_id: asString(lane.selected_for_content_id) || null,
+      updated_at: asString(lane.updated_at) || null,
+    }
+  }
+
+  return defaults
+}
+
+function isSocialChannelLaneStatus(value: string): value is SocialChannelLaneStatus {
+  return [
+    'not_started',
+    'selected',
+    'draft_ready',
+    'in_review',
+    'approved',
+    'blocked',
+  ].includes(value)
+}
+
+export function normalizePatternStatus(value: unknown): SocialResearchPatternStatus {
+  if (
+    value === 'usable_framework'
+    || value === 'needs_brand_translation'
+    || value === 'too_close_to_source'
+    || value === 'not_relevant'
+  ) {
+    return value
+  }
+  return 'needs_brand_translation'
+}
+
+export function scoreCreatorAsset(input: CreatorAssetScoreInput): CreatorAssetScore {
+  const views = input.views && input.views > 0 ? input.views : null
+  const followers = input.follower_count && input.follower_count > 0 ? input.follower_count : null
+  const likes = input.likes && input.likes > 0 ? input.likes : 0
+  const comments = input.comments && input.comments > 0 ? input.comments : 0
+  const shares = input.shares && input.shares > 0 ? input.shares : 0
+
+  const viewToFollowerRatio = views && followers ? views / followers : null
+  const engagementRate = views ? (likes + comments + shares) / views : null
+  const commentDensity = views ? comments / views : null
+  const channelRelativePerformance = clamp(input.channel_relative_performance ?? 1, 0, 5)
+  const strategicFit = clamp(input.strategic_fit ?? 0.5, 0, 1)
+
+  const retrievedAt = input.retrieved_at ? Date.parse(input.retrieved_at) : Date.now()
+  const publishedAt = input.published_at ? Date.parse(input.published_at) : retrievedAt
+  const ageDays = Number.isFinite(publishedAt)
+    ? Math.max(0, (retrievedAt - publishedAt) / 86_400_000)
+    : 30
+  const recencyScore = clamp(1 - ageDays / 30, 0, 1)
+
+  const smallCreatorOutlierBoost = followers && followers <= 100_000 && viewToFollowerRatio
+    ? clamp((viewToFollowerRatio - 1) / 4, 0, 1)
+    : 0
+
+  const outlierScore = Math.round(100 * clamp(
+    (clamp((viewToFollowerRatio ?? 0) / 3, 0, 1) * 0.22)
+    + (clamp((engagementRate ?? 0) / 0.12, 0, 1) * 0.18)
+    + (clamp((commentDensity ?? 0) / 0.03, 0, 1) * 0.12)
+    + (recencyScore * 0.12)
+    + (clamp(channelRelativePerformance / 3, 0, 1) * 0.16)
+    + (smallCreatorOutlierBoost * 0.10)
+    + (strategicFit * 0.10),
+    0,
+    1,
+  ))
+
+  return {
+    outlier_score: outlierScore,
+    view_to_follower_ratio: viewToFollowerRatio == null ? null : Number(viewToFollowerRatio.toFixed(4)),
+    engagement_rate: engagementRate == null ? null : Number(engagementRate.toFixed(4)),
+    comment_density: commentDensity == null ? null : Number(commentDensity.toFixed(4)),
+    recency_score: Number(recencyScore.toFixed(4)),
+    channel_relative_performance: Number(channelRelativePerformance.toFixed(4)),
+    small_creator_outlier_boost: Number(smallCreatorOutlierBoost.toFixed(4)),
+    strategic_fit: Number(strategicFit.toFixed(4)),
+  }
+}
+
+export function socialInsightMetadataFromCandidate(input: {
+  candidate: TopicTriggerCandidate
+  packet: TopicTriggerPacket
+  triggerSource: string
+  researchPacketIds?: string[]
+}) {
+  const { candidate, packet, triggerSource } = input
+  return {
+    social_topic_trigger: true,
+    insight_version: 'social_content_intelligence_v1',
+    trigger_source: triggerSource,
+    source_policy: packet.source_policy,
+    source_counts: packet.source_counts,
+    generated_at: packet.generated_at,
+    generated_by: packet.generated_by,
+    model: packet.model,
+    provider: packet.provider,
+    notes: packet.notes,
+    privacy_boundary: packet.privacy_boundary,
+    research_packet_ids: input.researchPacketIds ?? [],
+    channel_lanes: defaultSocialChannelLanes(),
+    insight: {
+      candidate_id: candidate.id,
+      title: candidate.title,
+      triggering_event: candidate.triggering_event,
+      source_type: candidate.source_type,
+      source_label: candidate.source_label,
+      source_ids: candidate.source_ids,
+      why_vambah_can_speak: candidate.why_vambah_can_speak,
+      brand_goal: candidate.brand_goal,
+      content_angle: candidate.content_angle,
+      suggested_hook: candidate.suggested_hook,
+      audience: candidate.audience,
+      sensitivity: candidate.sensitivity,
+      evidence_summary: candidate.evidence_summary,
+      claim_boundaries: candidate.claim_boundaries,
+      approved_research_patterns: [],
+    },
+  }
+}
+
+export function isSocialTopicTriggerWorkItem(item: AgentWorkItem) {
+  return item.source_type === SOCIAL_TOPIC_TRIGGER_SOURCE_TYPE || item.metadata?.social_topic_trigger === true
+}
+
+export function socialTopicBacklogItemFromWorkItem(item: AgentWorkItem) {
+  const metadata = item.metadata ?? {}
+  const insight = asRecord(metadata.insight) ?? {}
+  const lanes = normalizeSocialChannelLanes(metadata.channel_lanes)
+  const linkedinLane = lanes.linkedin
+  return {
+    id: item.id,
+    agent_work_item_id: item.id,
+    candidate_key: item.idempotency_key?.replace(/^social-topic-trigger:/, '') ?? item.id,
+    title: asString(insight.title) || item.title,
+    triggering_event: asString(insight.triggering_event),
+    source_type: asString(insight.source_type) || item.source_type,
+    source_label: asString(insight.source_label) || item.source_label,
+    source_ids: asStringArray(insight.source_ids),
+    why_vambah_can_speak: asString(insight.why_vambah_can_speak),
+    brand_goal: asString(insight.brand_goal),
+    content_angle: asString(insight.content_angle) || item.objective,
+    suggested_hook: asString(insight.suggested_hook),
+    audience: asString(insight.audience),
+    sensitivity: asString(insight.sensitivity) || 'needs_review',
+    evidence_summary: asString(insight.evidence_summary),
+    claim_boundaries: asStringArray(insight.claim_boundaries),
+    status: linkedinLane.status === 'selected' ? 'selected' : 'available',
+    source_policy: asString(metadata.source_policy) || 'sanitized_summaries_only',
+    source_counts: asRecord(metadata.source_counts) ?? {},
+    generated_by: asString(metadata.generated_by) || null,
+    generated_at: asString(metadata.generated_at) || item.created_at,
+    last_seen_at: item.updated_at,
+    channel_lanes: lanes,
+    metadata,
+  }
+}
+
+export function socialChannelLaneSummary(item: AgentWorkItem) {
+  const lanes = normalizeSocialChannelLanes(item.metadata?.channel_lanes)
+  return SOCIAL_CONTENT_INTELLIGENCE_CHANNELS.map((channel) => ({
+    channel,
+    label: CHANNEL_LABELS[channel],
+    status: lanes[channel].status,
+  }))
+}
+
+export function socialMetricsFromUnknown(value: unknown): CreatorAssetScoreInput {
+  const record = asRecord(value) ?? {}
+  return {
+    views: numberOrNull(record.views),
+    likes: numberOrNull(record.likes),
+    comments: numberOrNull(record.comments),
+    shares: numberOrNull(record.shares),
+    follower_count: numberOrNull(record.follower_count ?? record.followers ?? record.subscriber_count),
+    published_at: asString(record.published_at) || null,
+    retrieved_at: asString(record.retrieved_at) || null,
+    strategic_fit: numberOrNull(record.strategic_fit),
+    channel_relative_performance: numberOrNull(record.channel_relative_performance),
+  }
+}

--- a/lib/social-topic-backlog.ts
+++ b/lib/social-topic-backlog.ts
@@ -1,4 +1,11 @@
 import { generateJsonCompletion } from '@/lib/llm-dispatch'
+import { createAgentWorkItem } from '@/lib/agent-work-items'
+import {
+  defaultSocialChannelLanes,
+  socialInsightMetadataFromCandidate,
+  socialTopicBacklogItemFromWorkItem,
+  SOCIAL_TOPIC_TRIGGER_SOURCE_TYPE,
+} from '@/lib/social-content-intelligence'
 import { supabaseAdmin } from '@/lib/supabase'
 import {
   extractMeetingSummary,
@@ -499,7 +506,7 @@ export async function saveTopicTriggerPacketToSocialContent(
   return updated
 }
 
-function candidateKey(candidate: TopicTriggerCandidate) {
+export function candidateKey(candidate: TopicTriggerCandidate) {
   return [
     candidate.id,
     candidate.source_type,
@@ -514,46 +521,79 @@ function candidateKey(candidate: TopicTriggerCandidate) {
 
 export async function upsertSocialTopicBacklog(packet: TopicTriggerPacket, triggerSource: string) {
   const now = new Date().toISOString()
-  const rows = packet.candidates.map((candidate) => ({
-    candidate_key: candidateKey(candidate),
-    title: candidate.title,
-    triggering_event: candidate.triggering_event,
-    source_type: candidate.source_type,
-    source_label: candidate.source_label || null,
-    source_ids: candidate.source_ids,
-    why_vambah_can_speak: candidate.why_vambah_can_speak,
-    brand_goal: candidate.brand_goal || null,
-    content_angle: candidate.content_angle || null,
-    suggested_hook: candidate.suggested_hook || null,
-    audience: candidate.audience || null,
-    sensitivity: candidate.sensitivity,
-    evidence_summary: candidate.evidence_summary || null,
-    claim_boundaries: candidate.claim_boundaries,
-    status: 'available',
-    source_policy: packet.source_policy,
-    source_counts: packet.source_counts,
-    generated_by: packet.generated_by,
-    generated_at: packet.generated_at,
-    last_seen_at: now,
-    metadata: {
-      trigger_source: triggerSource,
-      model: packet.model,
-      provider: packet.provider,
-      notes: packet.notes,
-      privacy_boundary: packet.privacy_boundary,
-    },
-  }))
+  const workItems = []
+  const projectionRows = []
+
+  for (const candidate of packet.candidates) {
+    const key = candidateKey(candidate)
+    const metadata = socialInsightMetadataFromCandidate({
+      candidate,
+      packet,
+      triggerSource,
+    })
+    const workItem = await createAgentWorkItem({
+      title: candidate.title,
+      objective: candidate.content_angle || candidate.suggested_hook || candidate.triggering_event,
+      priority: candidate.sensitivity === 'public_safe' ? 'medium' : 'high',
+      status: 'proposed',
+      ownerAgentKey: 'chief-of-staff',
+      ownerRuntime: 'codex',
+      source: {
+        type: SOCIAL_TOPIC_TRIGGER_SOURCE_TYPE,
+        id: key,
+        label: candidate.source_label || 'Shaka topic trigger',
+      },
+      overlapGroup: 'social-content-intelligence',
+      metadata,
+      idempotencyKey: `social-topic-trigger:${key}`,
+    })
+
+    workItems.push(workItem)
+    projectionRows.push({
+      agent_work_item_id: workItem.id,
+      candidate_key: key,
+      title: candidate.title,
+      triggering_event: candidate.triggering_event,
+      source_type: candidate.source_type,
+      source_label: candidate.source_label || null,
+      source_ids: candidate.source_ids,
+      why_vambah_can_speak: candidate.why_vambah_can_speak,
+      brand_goal: candidate.brand_goal || null,
+      content_angle: candidate.content_angle || null,
+      suggested_hook: candidate.suggested_hook || null,
+      audience: candidate.audience || null,
+      sensitivity: candidate.sensitivity,
+      evidence_summary: candidate.evidence_summary || null,
+      claim_boundaries: candidate.claim_boundaries,
+      status: 'available',
+      source_policy: packet.source_policy,
+      source_counts: packet.source_counts,
+      generated_by: packet.generated_by,
+      generated_at: packet.generated_at,
+      last_seen_at: now,
+      channel_lanes: defaultSocialChannelLanes(),
+      metadata: {
+        trigger_source: triggerSource,
+        model: packet.model,
+        provider: packet.provider,
+        notes: packet.notes,
+        privacy_boundary: packet.privacy_boundary,
+        canonical_agent_work_item_id: workItem.id,
+      },
+    })
+  }
 
   const { data, error } = await supabaseAdmin
     .from('social_topic_backlog')
-    .upsert(rows, { onConflict: 'candidate_key' })
+    .upsert(projectionRows, { onConflict: 'candidate_key' })
     .select('*')
 
   if (error) {
-    throw new Error(error.message || 'Failed to upsert social topic backlog')
+    console.warn('[social-topic-backlog] projection upsert skipped:', error.message)
+    return workItems.map(socialTopicBacklogItemFromWorkItem)
   }
 
-  return data ?? []
+  return data ?? workItems.map(socialTopicBacklogItemFromWorkItem)
 }
 
 export async function runSocialTopicBacklogDiscovery(options: {

--- a/migrations/2026_06_22_social_content_intelligence.sql
+++ b/migrations/2026_06_22_social_content_intelligence.sql
@@ -1,0 +1,161 @@
+-- Social Content Intelligence keeps public creator research separate from
+-- private Shaka evidence and uses agent_work_items as the canonical backlog.
+
+ALTER TABLE IF EXISTS public.social_topic_backlog
+  ADD COLUMN IF NOT EXISTS agent_work_item_id UUID REFERENCES public.agent_work_items(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS channel_lanes JSONB NOT NULL DEFAULT '{}'::jsonb,
+  ADD COLUMN IF NOT EXISTS research_packet_ids UUID[] NOT NULL DEFAULT '{}';
+
+CREATE INDEX IF NOT EXISTS idx_social_topic_backlog_agent_work_item_id
+  ON public.social_topic_backlog(agent_work_item_id);
+
+CREATE TABLE IF NOT EXISTS public.social_content_research_packets (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  source_url TEXT NOT NULL,
+  platform TEXT NOT NULL CHECK (platform IN (
+    'youtube',
+    'youtube_shorts',
+    'instagram',
+    'instagram_reels',
+    'tiktok',
+    'x',
+    'linkedin',
+    'other'
+  )),
+  creator_name TEXT,
+  creator_handle TEXT,
+  title TEXT,
+  caption TEXT,
+  thumbnail_url TEXT,
+  hook_transcript TEXT,
+  metrics JSONB NOT NULL DEFAULT '{}'::jsonb,
+  actor_metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  outlier_score NUMERIC(6, 2) NOT NULL DEFAULT 0,
+  score_breakdown JSONB NOT NULL DEFAULT '{}'::jsonb,
+  pattern_packet JSONB NOT NULL DEFAULT '{}'::jsonb,
+  pattern_status TEXT NOT NULL DEFAULT 'needs_brand_translation' CHECK (pattern_status IN (
+    'usable_framework',
+    'needs_brand_translation',
+    'too_close_to_source',
+    'not_relevant'
+  )),
+  status TEXT NOT NULL DEFAULT 'review_ready' CHECK (status IN (
+    'review_ready',
+    'approved',
+    'rejected',
+    'archived'
+  )),
+  privacy_notes TEXT,
+  retrieved_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_by UUID REFERENCES public.user_profiles(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_social_content_research_packets_platform
+  ON public.social_content_research_packets(platform);
+
+CREATE INDEX IF NOT EXISTS idx_social_content_research_packets_status
+  ON public.social_content_research_packets(status);
+
+CREATE INDEX IF NOT EXISTS idx_social_content_research_packets_outlier_score
+  ON public.social_content_research_packets(outlier_score DESC);
+
+CREATE INDEX IF NOT EXISTS idx_social_content_research_packets_retrieved_at
+  ON public.social_content_research_packets(retrieved_at DESC);
+
+ALTER TABLE public.social_content_research_packets ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Admins can read social content research packets" ON public.social_content_research_packets;
+CREATE POLICY "Admins can read social content research packets"
+  ON public.social_content_research_packets
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.user_profiles
+      WHERE user_profiles.id = auth.uid()
+        AND user_profiles.role = 'admin'
+    )
+  );
+
+DROP POLICY IF EXISTS "Admins can insert social content research packets" ON public.social_content_research_packets;
+CREATE POLICY "Admins can insert social content research packets"
+  ON public.social_content_research_packets
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.user_profiles
+      WHERE user_profiles.id = auth.uid()
+        AND user_profiles.role = 'admin'
+    )
+  );
+
+DROP POLICY IF EXISTS "Admins can update social content research packets" ON public.social_content_research_packets;
+CREATE POLICY "Admins can update social content research packets"
+  ON public.social_content_research_packets
+  FOR UPDATE
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.user_profiles
+      WHERE user_profiles.id = auth.uid()
+        AND user_profiles.role = 'admin'
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.user_profiles
+      WHERE user_profiles.id = auth.uid()
+        AND user_profiles.role = 'admin'
+    )
+  );
+
+GRANT SELECT, INSERT, UPDATE ON public.social_content_research_packets TO authenticated;
+GRANT ALL ON public.social_content_research_packets TO service_role;
+
+DROP TRIGGER IF EXISTS update_social_content_research_packets_updated_at
+  ON public.social_content_research_packets;
+CREATE TRIGGER update_social_content_research_packets_updated_at
+  BEFORE UPDATE ON public.social_content_research_packets
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+COMMENT ON TABLE public.social_content_research_packets IS
+  'Read-only public creator research packets used by Social Content Intelligence review. Packets do not create drafts, upload media, schedule, or publish.';
+
+COMMENT ON COLUMN public.social_content_research_packets.actor_metadata IS
+  'Apify actor/run metadata and retrieval configuration for source transparency.';
+
+COMMENT ON COLUMN public.social_content_research_packets.pattern_packet IS
+  'Reusable pattern analysis. Final content must be rewritten in Vambah voice and AmaduTown brand style.';
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.table_constraints
+    WHERE constraint_schema = 'public'
+      AND table_name = 'video_generation_jobs'
+      AND constraint_name = 'video_generation_jobs_channel_check'
+  ) THEN
+    ALTER TABLE public.video_generation_jobs
+      DROP CONSTRAINT video_generation_jobs_channel_check;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name = 'video_generation_jobs'
+  ) THEN
+    ALTER TABLE public.video_generation_jobs
+      ADD CONSTRAINT video_generation_jobs_channel_check
+      CHECK (channel IN ('youtube', 'youtube_shorts', 'linkedin', 'linkedin_video', 'instagram_reels'));
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- Adds a Content Intelligence dashboard under Agent Ops for read-only creator research packets and Shaka social insights.
- Stores Shaka social topic triggers canonically in agent_work_items with source_type=social_topic_trigger, while keeping the existing Social Content topic-backlog API as a LinkedIn-filtered compatibility projection.
- Adds shared social insight detail tabs for LinkedIn, YouTube Shorts, Instagram Reels, and Thumbnail, plus review-only channel lane metadata APIs.
- Adds a social_content_research_packets migration with RLS and transparent outlier scoring metadata.

## Validation
- npm test -- --run lib/social-content-intelligence.test.ts app/api/admin/agents/work-items/route.test.ts app/api/admin/social-content/topic-backlog/route.test.ts app/api/admin/social-content/intelligence/research-packets/route.test.ts app/admin/agents/coordination/page.test.tsx app/admin/agents/content-intelligence/page.test.tsx 'app/admin/agents/social-insights/[id]/page.test.tsx'
- npx tsc --noEmit --pretty false
- Browser smoke on local dev server at http://127.0.0.1:3024: /admin/agents/content-intelligence and /admin/agents/social-insights/smoke-id returned HTTP 200 with no Next.js error overlay.

## Integration Notes
- Requires applying migration migrations/2026_06_22_social_content_intelligence.sql.
- Scheduled Apify collection is not activated by this PR; research packet creation is review-only and does not call providers, upload, schedule, or publish.
- Instagram Reels starts as planning/export readiness only.
- Local smoke surfaced existing dev env warning: MOCK_N8N=false and N8N_DISABLE_OUTBOUND=false. No n8n/provider/publish actions were triggered.
- Vercel contexts not checked by this implementation lane: Vercel – portfolio and Vercel – portfolio-staging remain integration-captain gates.