### PR TITLE
chore: ignore local artifact archives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /coverage
 test-results/
 /tmp/
+/outputs/
 
 # next.js
 /.next/
@@ -31,6 +32,19 @@ yarn-error.log*
 # local env files
 .env*.local
 .credential-rotation-audits/
+
+# local-private client/source artifacts; preserve locally, never commit
+/local-private/
+/docs/client-followups/
+/docs/runbooks/kmb-firespring-neil-meeting-*.md
+/docs/runbooks/kmb-firespring-proof-review-*.pptx
+
+# raw/generated prototype media variants; keep only web-selected assets tracked
+/public/prototypes/portfolio-pipeline-hero/higgsfield-gold-pipeline-loop-20260617.mp4
+/public/prototypes/portfolio-pipeline-hero/higgsfield-gold-pipeline-loop-360-starburst-20260617.mp4
+/public/prototypes/portfolio-pipeline-hero/higgsfield-gold-pipeline-loop-360-starburst-20260617-contact-sheet.jpg
+/public/prototypes/portfolio-pipeline-hero/higgsfield-gold-pipeline-loop-desktop-only-360-starburst-20260617.mp4
+/public/prototypes/portfolio-pipeline-hero/higgsfield-gold-pipeline-loop-desktop-only-360-starburst-20260617-contact-sheet.jpg
 
 # n8n workflow backups (real exports with credentials; never commit)
 n8n-backups/


### PR DESCRIPTION
## Summary
- Adds tracked ignore rules for local-private artifact archives, generated `outputs/`, client follow-up drafts, KMB proof-review deck artifacts, and unused raw hero media variants.
- Keeps the deployed web-selected hero MP4 tracked and untouched.
- Preserves the inspected KMB/client/media artifacts locally under `local-private/artifact-archive/2026-06-22` instead of committing client-sensitive or redundant generated files.

## Validation
- `git diff --check` — PASS
- `git check-ignore -v` verified archived local-private artifacts are ignored.
- `git ls-files --error-unmatch public/prototypes/portfolio-pipeline-hero/higgsfield-gold-pipeline-loop-desktop-only-360-starburst-web-20260617.mp4` — PASS; deployed web video remains tracked.

## Integration Notes
- No runtime code changes.
- No migration or env changes.
- Vercel contexts not checked because this is an ignore-policy-only draft PR:
  - Vercel – portfolio
  - Vercel – portfolio-staging
