### PR TITLE
feat: add free-first social research intake

### DIFF
--- a/app/admin/agents/content-intelligence/page.test.tsx
+++ b/app/admin/agents/content-intelligence/page.test.tsx
@@ -80,7 +80,9 @@ describe('ContentIntelligencePage', () => {
     render(<ContentIntelligencePage />)
 
     expect(await screen.findByRole('heading', { name: 'Research and Shaka insight queue' })).toBeInTheDocument()
-    expect(screen.getByText('pintostudio/youtube-transcript-scraper')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Free-first evidence layer' })).toBeInTheDocument()
+    expect(screen.getByText('Recorded public evidence from Codex/browser review. Cost: $0.')).toBeInTheDocument()
+    expect(screen.getByText('pintostudio/youtube-transcript-scraper only after cost approval')).toBeInTheDocument()
     expect(screen.getByText('Outlier research process')).toBeInTheDocument()
     expect(screen.getByText('Approval gates create trust')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /Approval gates create trust/ })).toHaveAttribute('href', '/admin/agents/social-insights/work-social-1')

--- a/app/admin/agents/content-intelligence/page.tsx
+++ b/app/admin/agents/content-intelligence/page.tsx
@@ -154,27 +154,27 @@ function ContentIntelligenceContent() {
           <MetricCard label="Research packets" value={packets.length} />
           <MetricCard label="Shaka insights" value={insights.length} />
           <MetricCard label="Top outlier score" value={strongestPacket ? Math.round(Number(strongestPacket.outlier_score)) : 0} />
-          <MetricCard label="Live schedules" value={0} tone="amber" />
+          <MetricCard label="Paid scraper runs" value={0} tone="amber" />
         </div>
 
         <section className="agent-ops-card mb-6 rounded-lg border p-4">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
             <div>
-              <h2 className="text-lg font-semibold">Scoped collection layer</h2>
+              <h2 className="text-lg font-semibold">Free-first evidence layer</h2>
               <p className="mt-1 text-sm text-muted-foreground">
-                These actors are configured as approved research sources, but no recurring run is active from this page.
+                Codex/browser review and public manual evidence are the default research path. Paid scrapers are fallback tools only when a scoped source cannot be captured cheaply.
               </p>
             </div>
             <span className="inline-flex w-fit items-center gap-2 rounded-full border border-amber-500/35 bg-amber-500/10 px-3 py-1 text-xs font-semibold text-amber-100">
               <ShieldCheck className="h-3.5 w-3.5" />
-              Activation approval required
+              Paid scraper approval required
             </span>
           </div>
           <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-            <ActorCard title="YouTube transcripts" actor="pintostudio/youtube-transcript-scraper" />
-            <ActorCard title="YouTube video/channel data" actor="streamers/youtube-scraper" />
-            <ActorCard title="Instagram posts/reels" actor="apify/instagram-scraper" />
-            <ActorCard title="TikTok research later" actor="clockworks/tiktok-scraper" />
+            <ActorCard title="Default" actor="Recorded public evidence from Codex/browser review. Cost: $0." />
+            <ActorCard title="YouTube fallback" actor="pintostudio/youtube-transcript-scraper only after cost approval" />
+            <ActorCard title="YouTube data fallback" actor="streamers/youtube-scraper only after cost approval" />
+            <ActorCard title="Instagram/TikTok fallback" actor="apify/instagram-scraper or clockworks/tiktok-scraper only after cost approval" />
           </div>
         </section>
 
@@ -238,7 +238,7 @@ function ContentIntelligenceContent() {
               </div>
             ) : (
               <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 px-4 py-12 text-center text-sm text-muted-foreground">
-                No research packets have been stored yet. Run a scoped research collection only after approval.
+                No research packets have been stored yet. Store free recorded public evidence first; use paid scrapers only after explicit approval.
               </div>
             )}
           </section>

--- a/app/api/admin/social-content/intelligence/research-runs/route.test.ts
+++ b/app/api/admin/social-content/intelligence/research-runs/route.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  runSocialContentResearchCollection: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/social-content-research-run', () => ({
+  runSocialContentResearchCollection: mocks.runSocialContentResearchCollection,
+}))
+
+import { POST } from './route'
+
+describe('/api/admin/social-content/intelligence/research-runs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-1', email: 'admin@example.com' }, isAdmin: true })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.runSocialContentResearchCollection.mockResolvedValue({
+      ok: true,
+      mode: 'recorded_evidence',
+      packets: [{ id: 'packet-1' }],
+      side_effects: {
+        apify_collection: false,
+        estimated_scraper_cost_usd: 0,
+        publish: false,
+      },
+    })
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(new NextRequest('http://localhost/api/admin/social-content/intelligence/research-runs', {
+      method: 'POST',
+    }))
+
+    expect(response.status).toBe(401)
+    expect(mocks.runSocialContentResearchCollection).not.toHaveBeenCalled()
+  })
+
+  it('stores free recorded public evidence as the default executable path', async () => {
+    const response = await POST(new NextRequest('http://localhost/api/admin/social-content/intelligence/research-runs', {
+      method: 'POST',
+      body: JSON.stringify({
+        mode: 'recorded_evidence',
+        evidence_items: [
+          {
+            source_url: 'https://youtube.com/watch?v=abc',
+            platform: 'youtube',
+            title: 'Outlier research process',
+            hook_transcript: 'The first 30 seconds make the promise clear.',
+            retrieval_method: 'codex_browser',
+          },
+        ],
+      }),
+    }))
+
+    expect(response.status).toBe(200)
+    expect(mocks.runSocialContentResearchCollection).toHaveBeenCalledWith(expect.objectContaining({
+      mode: 'recorded_evidence',
+      actorId: 'admin-1',
+      actorLabel: 'admin@example.com',
+      triggerSource: 'admin_social_content_intelligence_recorded_evidence',
+      evidenceItems: [
+        expect.objectContaining({
+          source_url: 'https://youtube.com/watch?v=abc',
+          retrieval_method: 'codex_browser',
+        }),
+      ],
+    }))
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      packets: [{ id: 'packet-1' }],
+      side_effects: {
+        apify_collection: false,
+        estimated_scraper_cost_usd: 0,
+      },
+    })
+  })
+
+  it('rejects recorded evidence requests without evidence items', async () => {
+    const response = await POST(new NextRequest('http://localhost/api/admin/social-content/intelligence/research-runs', {
+      method: 'POST',
+      body: JSON.stringify({ mode: 'recorded_evidence' }),
+    }))
+
+    expect(response.status).toBe(400)
+    expect(mocks.runSocialContentResearchCollection).not.toHaveBeenCalled()
+  })
+
+  it('passes the Apify cost confirmation flag only when explicit', async () => {
+    mocks.runSocialContentResearchCollection.mockResolvedValueOnce({
+      ok: true,
+      mode: 'apify',
+      packets: [],
+      side_effects: { apify_collection: true, estimated_scraper_cost_usd: 'variable' },
+    })
+
+    const response = await POST(new NextRequest('http://localhost/api/admin/social-content/intelligence/research-runs', {
+      method: 'POST',
+      body: JSON.stringify({
+        mode: 'apify',
+        confirm_apify_cost: true,
+        sources: [{ url: 'https://youtube.com/watch?v=abc' }],
+      }),
+    }))
+
+    expect(response.status).toBe(200)
+    expect(mocks.runSocialContentResearchCollection).toHaveBeenCalledWith(expect.objectContaining({
+      mode: 'apify',
+      confirmApifyCost: true,
+      triggerSource: 'admin_social_content_intelligence_apify_confirmed',
+    }))
+  })
+})

--- a/app/api/admin/social-content/intelligence/research-runs/route.ts
+++ b/app/api/admin/social-content/intelligence/research-runs/route.ts
@@ -1,0 +1,119 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import {
+  runSocialContentResearchCollection,
+  type SocialResearchRunMode,
+} from '@/lib/social-content-research-run'
+import type {
+  SocialResearchEvidenceItem,
+  SocialResearchSource,
+} from '@/lib/social-content-intelligence'
+import {
+  normalizePatternStatus,
+  normalizeResearchActorKey,
+  normalizeResearchPlatform,
+} from '@/lib/social-content-intelligence'
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 60
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
+}
+
+function asString(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function isMode(value: unknown): value is SocialResearchRunMode {
+  return value === 'dry_run' || value === 'recorded_evidence' || value === 'apify'
+}
+
+function sourceArray(value: unknown): SocialResearchSource[] {
+  return Array.isArray(value)
+    ? value.map((item) => asRecord(item))
+        .map((item) => ({
+          url: asString(item.url),
+          platform: item.platform ? normalizeResearchPlatform(item.platform) : null,
+          actor_key: item.actor_key ? normalizeResearchActorKey(item.actor_key, asString(item.url)) : null,
+          label: asString(item.label) || null,
+        }))
+        .filter((item) => item.url)
+    : []
+}
+
+function evidenceArray(value: unknown): SocialResearchEvidenceItem[] {
+  return Array.isArray(value)
+    ? value.map((item) => asRecord(item))
+        .map((item) => ({
+          source_url: asString(item.source_url),
+          platform: item.platform ? normalizeResearchPlatform(item.platform) : null,
+          creator_name: asString(item.creator_name) || null,
+          creator_handle: asString(item.creator_handle) || null,
+          title: asString(item.title) || null,
+          caption: asString(item.caption) || null,
+          thumbnail_url: asString(item.thumbnail_url) || null,
+          hook_transcript: asString(item.hook_transcript) || null,
+          metrics: asRecord(item.metrics),
+          pattern_packet: asRecord(item.pattern_packet),
+          pattern_status: normalizePatternStatus(item.pattern_status),
+          retrieval_method: normalizeRetrievalMethod(item.retrieval_method),
+          retrieval_notes: asString(item.retrieval_notes) || null,
+        }))
+        .filter((item) => item.source_url)
+    : []
+}
+
+function normalizeRetrievalMethod(value: unknown): SocialResearchEvidenceItem['retrieval_method'] {
+  if (
+    value === 'codex_browser'
+    || value === 'manual_public_review'
+    || value === 'public_page_fetch'
+    || value === 'apify'
+    || value === 'other'
+  ) {
+    return value
+  }
+  return 'codex_browser'
+}
+
+export async function POST(request: NextRequest) {
+  const authResult = await verifyAdmin(request)
+  if (isAuthError(authResult)) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status })
+  }
+
+  const body = asRecord(await request.json().catch(() => ({})))
+  const mode = isMode(body.mode) ? body.mode : 'dry_run'
+  const sources = sourceArray(body.sources)
+  const evidenceItems = evidenceArray(body.evidence_items)
+
+  if (mode === 'recorded_evidence' && evidenceItems.length === 0) {
+    return NextResponse.json({ error: 'evidence_items are required for recorded_evidence mode' }, { status: 400 })
+  }
+  if ((mode === 'dry_run' || mode === 'apify') && sources.length === 0) {
+    return NextResponse.json({ error: 'sources are required for dry_run or apify mode' }, { status: 400 })
+  }
+
+  try {
+    const result = await runSocialContentResearchCollection({
+      mode,
+      sources,
+      evidenceItems,
+      confirmApifyCost: body.confirm_apify_cost === true,
+      actorId: authResult.user.id,
+      actorLabel: authResult.user.email ?? authResult.user.id,
+      triggerSource: mode === 'apify'
+        ? 'admin_social_content_intelligence_apify_confirmed'
+        : mode === 'recorded_evidence'
+          ? 'admin_social_content_intelligence_recorded_evidence'
+          : 'admin_social_content_intelligence_dry_run',
+    })
+
+    return NextResponse.json(result)
+  } catch (error) {
+    console.error('[social-content-intelligence] research run failed:', error)
+    const message = error instanceof Error ? error.message : 'Research run failed'
+    return NextResponse.json({ error: message }, { status: message.includes('confirm_apify_cost') ? 400 : 500 })
+  }
+}

--- a/lib/social-content-intelligence.ts
+++ b/lib/social-content-intelligence.ts
@@ -60,6 +60,71 @@ export type CreatorAssetScore = {
   strategic_fit: number
 }
 
+export type SocialResearchPlatform =
+  | 'youtube'
+  | 'youtube_shorts'
+  | 'instagram'
+  | 'instagram_reels'
+  | 'tiktok'
+  | 'x'
+  | 'linkedin'
+  | 'other'
+
+export type SocialResearchActorKey =
+  | 'youtube_transcript'
+  | 'youtube_video'
+  | 'instagram_post'
+  | 'instagram_reel'
+  | 'tiktok_video'
+
+export type SocialResearchSource = {
+  url: string
+  platform?: SocialResearchPlatform | null
+  actor_key?: SocialResearchActorKey | null
+  label?: string | null
+}
+
+export type SocialResearchActorConfig = {
+  key: SocialResearchActorKey
+  label: string
+  actor_id: string
+  platform: SocialResearchPlatform
+  default_input: Record<string, unknown>
+}
+
+export type SocialResearchPacketDraft = {
+  source_url: string
+  platform: SocialResearchPlatform
+  creator_name?: string | null
+  creator_handle?: string | null
+  title?: string | null
+  caption?: string | null
+  thumbnail_url?: string | null
+  hook_transcript?: string | null
+  metrics: Record<string, unknown>
+  actor_metadata: Record<string, unknown>
+  pattern_packet: Record<string, unknown>
+  pattern_status: SocialResearchPatternStatus
+  privacy_notes?: string | null
+  retrieved_at: string
+}
+
+export type SocialResearchEvidenceItem = {
+  source_url: string
+  platform?: SocialResearchPlatform | null
+  creator_name?: string | null
+  creator_handle?: string | null
+  title?: string | null
+  caption?: string | null
+  thumbnail_url?: string | null
+  hook_transcript?: string | null
+  metrics?: Record<string, unknown> | null
+  pattern_packet?: Record<string, unknown> | null
+  pattern_status?: SocialResearchPatternStatus | null
+  retrieval_method?: 'codex_browser' | 'manual_public_review' | 'public_page_fetch' | 'apify' | 'other'
+  retrieval_notes?: string | null
+}
+
 const CHANNEL_LABELS: Record<SocialContentIntelligenceChannel, string> = {
   linkedin: 'LinkedIn',
   youtube_shorts: 'YouTube Shorts',
@@ -112,6 +177,44 @@ const CHANNEL_INPUTS: Record<SocialContentIntelligenceChannel, string[]> = {
   ],
 }
 
+export const SOCIAL_RESEARCH_ACTORS: Record<SocialResearchActorKey, SocialResearchActorConfig> = {
+  youtube_transcript: {
+    key: 'youtube_transcript',
+    label: 'YouTube transcript',
+    actor_id: 'pintostudio/youtube-transcript-scraper',
+    platform: 'youtube',
+    default_input: {},
+  },
+  youtube_video: {
+    key: 'youtube_video',
+    label: 'YouTube video/channel data',
+    actor_id: 'streamers/youtube-scraper',
+    platform: 'youtube',
+    default_input: { maxResults: 10 },
+  },
+  instagram_post: {
+    key: 'instagram_post',
+    label: 'Instagram post/reel data',
+    actor_id: 'apify/instagram-post-scraper',
+    platform: 'instagram',
+    default_input: {},
+  },
+  instagram_reel: {
+    key: 'instagram_reel',
+    label: 'Instagram reels data',
+    actor_id: 'apify/instagram-scraper',
+    platform: 'instagram_reels',
+    default_input: { resultsLimit: 10 },
+  },
+  tiktok_video: {
+    key: 'tiktok_video',
+    label: 'TikTok research later',
+    actor_id: 'clockworks/tiktok-scraper',
+    platform: 'tiktok',
+    default_input: { resultsPerPage: 10 },
+  },
+}
+
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null
 }
@@ -122,6 +225,20 @@ function asString(value: unknown): string {
 
 function asStringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
+}
+
+function firstString(...values: unknown[]) {
+  for (const value of values) {
+    const text = asString(value).trim()
+    if (text) return text
+  }
+  return ''
+}
+
+function truncate(value: string, maxLength: number) {
+  const trimmed = value.replace(/\s+/g, ' ').trim()
+  if (trimmed.length <= maxLength) return trimmed
+  return `${trimmed.slice(0, maxLength - 3).trim()}...`
 }
 
 function numberOrNull(value: unknown) {
@@ -200,6 +317,69 @@ export function normalizePatternStatus(value: unknown): SocialResearchPatternSta
   return 'needs_brand_translation'
 }
 
+export function normalizeResearchPlatform(value: unknown): SocialResearchPlatform {
+  if (
+    value === 'youtube'
+    || value === 'youtube_shorts'
+    || value === 'instagram'
+    || value === 'instagram_reels'
+    || value === 'tiktok'
+    || value === 'x'
+    || value === 'linkedin'
+    || value === 'other'
+  ) {
+    return value
+  }
+  return 'other'
+}
+
+export function normalizeResearchActorKey(value: unknown, sourceUrl = ''): SocialResearchActorKey {
+  if (
+    value === 'youtube_transcript'
+    || value === 'youtube_video'
+    || value === 'instagram_post'
+    || value === 'instagram_reel'
+    || value === 'tiktok_video'
+  ) {
+    return value
+  }
+  const url = sourceUrl.toLowerCase()
+  if (url.includes('youtu')) return 'youtube_transcript'
+  if (url.includes('instagram.com/reel')) return 'instagram_reel'
+  if (url.includes('instagram.com')) return 'instagram_post'
+  if (url.includes('tiktok.com')) return 'tiktok_video'
+  return 'youtube_transcript'
+}
+
+export function apifyInputForResearchSource(source: SocialResearchSource, config: SocialResearchActorConfig) {
+  const url = source.url
+  if (config.key === 'youtube_transcript') {
+    return {
+      ...config.default_input,
+      videoUrls: [url],
+      urls: [url],
+      url,
+    }
+  }
+  if (config.key === 'youtube_video') {
+    return {
+      ...config.default_input,
+      startUrls: [{ url }],
+    }
+  }
+  if (config.key === 'instagram_post' || config.key === 'instagram_reel') {
+    return {
+      ...config.default_input,
+      directUrls: [url],
+      startUrls: [{ url }],
+    }
+  }
+  return {
+    ...config.default_input,
+    startUrls: [url],
+  }
+}
+
 export function scoreCreatorAsset(input: CreatorAssetScoreInput): CreatorAssetScore {
   const views = input.views && input.views > 0 ? input.views : null
   const followers = input.follower_count && input.follower_count > 0 ? input.follower_count : null
@@ -245,6 +425,149 @@ export function scoreCreatorAsset(input: CreatorAssetScoreInput): CreatorAssetSc
     channel_relative_performance: Number(channelRelativePerformance.toFixed(4)),
     small_creator_outlier_boost: Number(smallCreatorOutlierBoost.toFixed(4)),
     strategic_fit: Number(strategicFit.toFixed(4)),
+  }
+}
+
+export function extractHookTranscript(item: Record<string, unknown>) {
+  const transcript = firstString(
+    item.hook_transcript,
+    item.transcript,
+    item.text,
+    item.description,
+    item.caption,
+  )
+  return transcript ? truncate(transcript, 500) : null
+}
+
+export function extractReusablePattern(input: {
+  title?: string | null
+  caption?: string | null
+  hookTranscript?: string | null
+  thumbnailUrl?: string | null
+}) {
+  const title = input.title ?? ''
+  const hook = input.hookTranscript ?? ''
+  const caption = input.caption ?? ''
+  const titleWords = title.split(/\s+/).filter(Boolean)
+  const hookSentence = hook.split(/[.!?]/).map((part) => part.trim()).find(Boolean) ?? hook
+  return {
+    hook_structure: hookSentence
+      ? truncate(hookSentence, 180)
+      : 'No first-30-second hook transcript available yet.',
+    tension_or_missed_opportunity: caption || title
+      ? truncate(caption || title, 220)
+      : 'Needs analyst review.',
+    promise_value: titleWords.length >= 4
+      ? truncate(titleWords.slice(0, 10).join(' '), 140)
+      : 'Needs title/caption review.',
+    proof_style: 'Review source for proof pattern only; do not copy claims or creator identity.',
+    title_pattern: title
+      ? truncate(title.replace(/[A-Za-z0-9]+/g, '[word]'), 180)
+      : 'No title pattern available.',
+    thumbnail_pattern: input.thumbnailUrl
+      ? 'Thumbnail reference captured; translate layout concept into AmaduTown brand style.'
+      : 'No thumbnail reference captured.',
+    pacing_visual_framing: 'Needs human pattern review from source evidence.',
+    cta_style: 'Needs human pattern review from source evidence.',
+    source_use_boundary: 'Reusable framework only. Final content must be rewritten in Vambah voice and AmaduTown brand style.',
+  }
+}
+
+export function researchPacketDraftFromApifyItem(input: {
+  source: SocialResearchSource
+  config: SocialResearchActorConfig
+  item: Record<string, unknown>
+  actorRun: Record<string, unknown>
+  retrievedAt: string
+}): SocialResearchPacketDraft {
+  const item = input.item
+  const sourceUrl = firstString(item.url, item.videoUrl, item.inputUrl, item.shortUrl, input.source.url)
+  const title = firstString(item.title, item.name)
+  const caption = firstString(item.caption, item.description, item.text)
+  const hookTranscript = extractHookTranscript(item)
+  const thumbnailUrl = firstString(item.thumbnailUrl, item.thumbnail, item.displayUrl, item.imageUrl)
+  const metrics = {
+    views: numberOrNull(item.views) ?? numberOrNull(item.viewCount) ?? numberOrNull(item.playCount),
+    likes: numberOrNull(item.likes) ?? numberOrNull(item.likeCount),
+    comments: numberOrNull(item.comments) ?? numberOrNull(item.commentCount),
+    shares: numberOrNull(item.shares) ?? numberOrNull(item.shareCount),
+    follower_count: numberOrNull(item.followerCount) ?? numberOrNull(item.subscriberCount) ?? numberOrNull(item.followers),
+    published_at: firstString(item.publishedAt, item.date, item.timestamp) || null,
+    retrieved_at: input.retrievedAt,
+  }
+  const score = scoreCreatorAsset(socialMetricsFromUnknown(metrics))
+  return {
+    source_url: sourceUrl,
+    platform: input.source.platform ?? input.config.platform,
+    creator_name: firstString(item.creatorName, item.channelName, item.ownerFullName, item.authorName) || null,
+    creator_handle: firstString(item.creatorHandle, item.channelHandle, item.username, item.authorMeta) || null,
+    title: title || null,
+    caption: caption || null,
+    thumbnail_url: thumbnailUrl || null,
+    hook_transcript: hookTranscript,
+    metrics,
+    actor_metadata: {
+      actor_id: input.config.actor_id,
+      actor_key: input.config.key,
+      actor_label: input.config.label,
+      run_id: firstString(input.actorRun.id, input.actorRun.runId) || null,
+      dataset_id: firstString(input.actorRun.defaultDatasetId, input.actorRun.datasetId) || null,
+      source_label: input.source.label ?? null,
+      input_url: input.source.url,
+      score_breakdown: score,
+    },
+    pattern_packet: extractReusablePattern({
+      title,
+      caption,
+      hookTranscript,
+      thumbnailUrl,
+    }),
+    pattern_status: 'needs_brand_translation',
+    privacy_notes: 'Public creator research packet. Use patterns only; do not copy source script, title, thumbnail, or visual identity.',
+    retrieved_at: input.retrievedAt,
+  }
+}
+
+export function researchPacketDraftFromRecordedEvidence(input: {
+  evidence: SocialResearchEvidenceItem
+  retrievedAt: string
+  actorLabel?: string | null
+}): SocialResearchPacketDraft {
+  const evidence = input.evidence
+  const metrics = {
+    ...(asRecord(evidence.metrics) ?? {}),
+    retrieved_at: input.retrievedAt,
+  }
+  const hookTranscript = evidence.hook_transcript ? truncate(evidence.hook_transcript, 500) : null
+  const patternPacket = asRecord(evidence.pattern_packet)
+    ?? extractReusablePattern({
+      title: evidence.title,
+      caption: evidence.caption,
+      hookTranscript,
+      thumbnailUrl: evidence.thumbnail_url,
+    })
+  return {
+    source_url: evidence.source_url,
+    platform: normalizeResearchPlatform(evidence.platform),
+    creator_name: evidence.creator_name ?? null,
+    creator_handle: evidence.creator_handle ?? null,
+    title: evidence.title ?? null,
+    caption: evidence.caption ?? null,
+    thumbnail_url: evidence.thumbnail_url ?? null,
+    hook_transcript: hookTranscript,
+    metrics,
+    actor_metadata: {
+      provider: 'free_recorded_evidence',
+      retrieval_method: evidence.retrieval_method ?? 'codex_browser',
+      retrieval_notes: evidence.retrieval_notes ?? null,
+      actor_label: input.actorLabel ?? null,
+      source_url: evidence.source_url,
+      cost_usd: 0,
+    },
+    pattern_packet: patternPacket,
+    pattern_status: normalizePatternStatus(evidence.pattern_status),
+    privacy_notes: 'Free public research packet. Use patterns only; do not copy source script, title, thumbnail, or visual identity.',
+    retrieved_at: input.retrievedAt,
   }
 }
 

--- a/lib/social-content-research-run.test.ts
+++ b/lib/social-content-research-run.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  from: vi.fn(),
+  insertSingle: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import {
+  buildSocialResearchRunPlan,
+  runSocialContentResearchCollection,
+} from './social-content-research-run'
+
+describe('social-content-research-run', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.insertSingle.mockResolvedValue({
+      data: {
+        id: 'packet-1',
+        source_url: 'https://youtube.com/watch?v=abc',
+        platform: 'youtube',
+        title: 'Free research packet',
+        outlier_score: 42,
+      },
+      error: null,
+    })
+    mocks.from.mockReturnValue({
+      insert: vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: mocks.insertSingle,
+        })),
+      })),
+    })
+  })
+
+  it('builds a free-first plan before paid scraper fallback', () => {
+    const plan = buildSocialResearchRunPlan([
+      { url: 'https://youtube.com/watch?v=abc', label: 'Reference video' },
+    ])
+
+    expect(plan).toHaveLength(1)
+    expect(plan[0]).toMatchObject({
+      recommended_method: 'free_first_recorded_evidence',
+      actor_id: 'pintostudio/youtube-transcript-scraper',
+    })
+    expect(plan[0].free_first_steps.join(' ')).toContain('Codex/browser/public page review')
+  })
+
+  it('stores recorded public evidence without paid scraper side effects', async () => {
+    const result = await runSocialContentResearchCollection({
+      mode: 'recorded_evidence',
+      evidenceItems: [
+        {
+          source_url: 'https://youtube.com/watch?v=abc',
+          platform: 'youtube',
+          title: 'Free research packet',
+          hook_transcript: 'The opening hook explains the promise.',
+          metrics: { views: 1000, likes: 50 },
+          retrieval_method: 'codex_browser',
+        },
+      ],
+      actorId: 'admin-1',
+      actorLabel: 'admin@example.com',
+      triggerSource: 'test',
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      mode: 'recorded_evidence',
+      packets: [{ id: 'packet-1' }],
+      side_effects: {
+        apify_collection: false,
+        estimated_scraper_cost_usd: 0,
+        publish: false,
+      },
+    })
+    expect(mocks.from).toHaveBeenCalledWith('social_content_research_packets')
+    expect(mocks.insertSingle).toHaveBeenCalled()
+  })
+
+  it('blocks Apify mode without explicit cost confirmation', async () => {
+    await expect(runSocialContentResearchCollection({
+      mode: 'apify',
+      sources: [{ url: 'https://youtube.com/watch?v=abc' }],
+      triggerSource: 'test',
+    })).rejects.toThrow('confirm_apify_cost=true')
+  })
+})

--- a/lib/social-content-research-run.ts
+++ b/lib/social-content-research-run.ts
@@ -1,0 +1,250 @@
+import {
+  apifyInputForResearchSource,
+  normalizePatternStatus,
+  normalizeResearchActorKey,
+  normalizeResearchPlatform,
+  researchPacketDraftFromApifyItem,
+  researchPacketDraftFromRecordedEvidence,
+  scoreCreatorAsset,
+  SOCIAL_RESEARCH_ACTORS,
+  socialMetricsFromUnknown,
+  type SocialResearchEvidenceItem,
+  type SocialResearchPacketDraft,
+  type SocialResearchSource,
+} from '@/lib/social-content-intelligence'
+import { supabaseAdmin } from '@/lib/supabase'
+
+export type SocialResearchRunMode = 'dry_run' | 'recorded_evidence' | 'apify'
+
+export type SocialResearchRunInput = {
+  mode: SocialResearchRunMode
+  sources?: SocialResearchSource[]
+  evidenceItems?: SocialResearchEvidenceItem[]
+  confirmApifyCost?: boolean
+  actorId?: string | null
+  actorLabel?: string | null
+  triggerSource: string
+}
+
+export type StoredResearchPacket = {
+  id: string
+  source_url: string
+  platform: string
+  title: string | null
+  outlier_score: number
+}
+
+type ApifyRunResult = {
+  items: Record<string, unknown>[]
+  run: Record<string, unknown>
+}
+
+function apifyToken() {
+  return process.env.APIFY_API_TOKEN || process.env.APIFY_TOKEN || null
+}
+
+function encodeActorId(actorId: string) {
+  return actorId.replace('/', '~')
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
+}
+
+function asString(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function normalizeSource(value: SocialResearchSource): SocialResearchSource | null {
+  const url = asString(value.url)
+  if (!url || !/^https?:\/\//i.test(url)) return null
+  const actorKey = normalizeResearchActorKey(value.actor_key, url)
+  return {
+    url,
+    actor_key: actorKey,
+    platform: value.platform ? normalizeResearchPlatform(value.platform) : SOCIAL_RESEARCH_ACTORS[actorKey].platform,
+    label: asString(value.label) || null,
+  }
+}
+
+async function runApifyActor(input: {
+  actorId: string
+  payload: Record<string, unknown>
+}): Promise<ApifyRunResult> {
+  const token = apifyToken()
+  if (!token) throw new Error('APIFY_API_TOKEN is not configured')
+
+  const response = await fetch(
+    `https://api.apify.com/v2/acts/${encodeActorId(input.actorId)}/run-sync-get-dataset-items?token=${encodeURIComponent(token)}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input.payload),
+    },
+  )
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '')
+    throw new Error(`Apify actor failed (${response.status}): ${text || response.statusText}`)
+  }
+
+  const runId = response.headers.get('x-apify-run-id')
+  const datasetId = response.headers.get('x-apify-default-dataset-id')
+  const parsed = await response.json().catch(() => [])
+  const items = Array.isArray(parsed)
+    ? parsed.filter((item): item is Record<string, unknown> => Boolean(asRecord(item)))
+    : []
+
+  return {
+    items,
+    run: {
+      id: runId,
+      defaultDatasetId: datasetId,
+    },
+  }
+}
+
+export function buildSocialResearchRunPlan(sources: SocialResearchSource[]) {
+  return sources
+    .map(normalizeSource)
+    .filter((source): source is SocialResearchSource => Boolean(source))
+    .slice(0, 12)
+    .map((source) => {
+      const actorKey = normalizeResearchActorKey(source.actor_key, source.url)
+      const config = SOCIAL_RESEARCH_ACTORS[actorKey]
+      return {
+        source,
+        recommended_method: 'free_first_recorded_evidence',
+        free_first_steps: [
+          'Use Codex/browser/public page review to capture title, creator, thumbnail reference, metrics, and first-30-second hook where visible.',
+          'Store the result as recorded evidence before considering a paid scraper.',
+          'Use Apify only when public manual extraction is blocked or too slow for the approved scope.',
+        ],
+        actor_key: actorKey,
+        actor_id: config.actor_id,
+        actor_label: config.label,
+        platform: source.platform ?? config.platform,
+        input: apifyInputForResearchSource(source, config),
+      }
+    })
+}
+
+export async function storeSocialResearchPacket(input: {
+  draft: SocialResearchPacketDraft
+  createdBy?: string | null
+}) {
+  const score = scoreCreatorAsset({
+    ...socialMetricsFromUnknown(input.draft.metrics),
+    retrieved_at: input.draft.retrieved_at,
+  })
+  const { data, error } = await supabaseAdmin
+    .from('social_content_research_packets')
+    .insert({
+      source_url: input.draft.source_url,
+      platform: input.draft.platform,
+      creator_name: input.draft.creator_name ?? null,
+      creator_handle: input.draft.creator_handle ?? null,
+      title: input.draft.title ?? null,
+      caption: input.draft.caption ?? null,
+      thumbnail_url: input.draft.thumbnail_url ?? null,
+      hook_transcript: input.draft.hook_transcript ?? null,
+      metrics: input.draft.metrics,
+      actor_metadata: input.draft.actor_metadata,
+      outlier_score: score.outlier_score,
+      score_breakdown: score,
+      pattern_packet: input.draft.pattern_packet,
+      pattern_status: normalizePatternStatus(input.draft.pattern_status),
+      privacy_notes: input.draft.privacy_notes ?? 'Public research packet. Use patterns only.',
+      retrieved_at: input.draft.retrieved_at,
+      created_by: input.createdBy ?? null,
+    })
+    .select('id, source_url, platform, title, outlier_score')
+    .single()
+
+  if (error || !data) throw new Error(error?.message ?? 'Failed to store research packet')
+  return data as StoredResearchPacket
+}
+
+export async function runSocialContentResearchCollection(input: SocialResearchRunInput) {
+  const plan = buildSocialResearchRunPlan(input.sources ?? [])
+  const sideEffects = {
+    provider_generation: false,
+    upload: false,
+    publish: false,
+    schedule: false,
+    external_post: false,
+    apify_collection: input.mode === 'apify',
+    estimated_scraper_cost_usd: input.mode === 'apify' ? 'variable' : 0,
+  }
+
+  if (input.mode === 'dry_run') {
+    return {
+      ok: true,
+      mode: input.mode,
+      plan,
+      packets: [] as StoredResearchPacket[],
+      side_effects: sideEffects,
+    }
+  }
+
+  const retrievedAt = new Date().toISOString()
+  const packets: StoredResearchPacket[] = []
+
+  if (input.mode === 'recorded_evidence') {
+    for (const evidence of (input.evidenceItems ?? []).slice(0, 25)) {
+      const draft = researchPacketDraftFromRecordedEvidence({
+        evidence,
+        retrievedAt,
+        actorLabel: input.actorLabel ?? null,
+      })
+      packets.push(await storeSocialResearchPacket({
+        draft,
+        createdBy: input.actorId ?? null,
+      }))
+    }
+    return {
+      ok: true,
+      mode: input.mode,
+      plan,
+      packets,
+      side_effects: sideEffects,
+    }
+  }
+
+  if (!input.confirmApifyCost) {
+    throw new Error('Apify collection requires confirm_apify_cost=true; use recorded_evidence for the free-first path')
+  }
+
+  for (const step of plan) {
+    const config = SOCIAL_RESEARCH_ACTORS[step.actor_key]
+    const result = await runApifyActor({
+      actorId: step.actor_id,
+      payload: step.input,
+    })
+    for (const item of result.items.slice(0, 10)) {
+      const draft = researchPacketDraftFromApifyItem({
+        source: step.source,
+        config,
+        item,
+        actorRun: {
+          ...result.run,
+          trigger_source: input.triggerSource,
+          actor_label: input.actorLabel ?? null,
+        },
+        retrievedAt,
+      })
+      packets.push(await storeSocialResearchPacket({
+        draft,
+        createdBy: input.actorId ?? null,
+      }))
+    }
+  }
+
+  return {
+    ok: true,
+    mode: input.mode,
+    plan,
+    packets,
+    side_effects: sideEffects,
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a free-first Social Content Intelligence research-run API for recorded public evidence from Codex/browser/manual review.
- Keeps Apify as an explicit fallback only: Apify mode requires confirm_apify_cost=true and is never scheduled or defaulted.
- Updates the Content Intelligence dashboard language to show Codex/browser evidence as the default path and paid scrapers as approval-gated fallback.
- Adds helper logic to normalize free recorded evidence, preserve zero-cost provenance, score outlier metrics, and extract reusable patterns without copying source content.

## Validation
- npm test -- --run lib/social-content-intelligence.test.ts lib/social-content-research-run.test.ts app/api/admin/social-content/intelligence/research-packets/route.test.ts app/api/admin/social-content/intelligence/research-runs/route.test.ts app/admin/agents/content-intelligence/page.test.tsx
- npx tsc --noEmit --pretty false
- Browser smoke on local dev server at http://127.0.0.1:3025: /admin/agents/content-intelligence returned HTTP 200 with no Next.js error overlay; unauthenticated smoke stopped at the login gate, so admin copy visibility remains covered by component tests.

## Integration Notes
- No Vercel cron entry was added.
- No live Apify run was executed.
- No provider generation, uploads, scheduling, or publishing paths are activated.
- The default executable mode is recorded_evidence with estimated_scraper_cost_usd=0.
- Apify mode is blocked unless confirm_apify_cost=true is included in the API request.
- Vercel contexts not checked by this implementation lane: Vercel – portfolio and Vercel – portfolio-staging remain integration-captain gates.