### PR TITLE
feat: add social insight lane review controls

### DIFF
--- a/app/admin/agents/social-insights/[id]/page.test.tsx
+++ b/app/admin/agents/social-insights/[id]/page.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import SocialInsightDetailPage from './page'
@@ -19,40 +19,79 @@ vi.mock('@/lib/auth', () => ({
   getCurrentSession: vi.fn(async () => ({ access_token: 'admin-token' })),
 }))
 
+function socialWorkItem(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'work-social-1',
+    title: 'Approval gates create trust',
+    status: 'proposed',
+    priority: 'high',
+    source_type: 'social_topic_trigger',
+    metadata: {
+      insight: {
+        title: 'Approval gates create trust',
+        triggering_event: 'The Social Content review flow made the gate visible.',
+        why_vambah_can_speak: 'Vambah is building and reviewing the system directly.',
+        evidence_summary: 'Review path and visual gate work shipped locally.',
+        brand_goal: 'Show AmaduTown as the operating layer for governed AI.',
+        audience: 'Operators adopting AI workflows.',
+        content_angle: 'AI should reduce burden, but only when authority and evidence are separated.',
+        suggested_hook: 'AI should reduce burden.',
+        claim_boundaries: ['Do not imply publishing is automated.'],
+      },
+      channel_lanes: {
+        linkedin: { status: 'selected', label: 'LinkedIn', required_inputs: ['post text', 'CTA'] },
+        youtube_shorts: { status: 'not_started', label: 'YouTube Shorts', required_inputs: ['hook', 'script'] },
+        instagram_reels: { status: 'not_started', label: 'Instagram Reels', required_inputs: ['hook', 'caption'] },
+        thumbnail: { status: 'not_started', label: 'Thumbnail', required_inputs: ['short thumbnail text', '2-3 variants'] },
+      },
+    },
+    updated_at: '2026-06-22T12:00:00.000Z',
+    ...overrides,
+  }
+}
+
 describe('SocialInsightDetailPage', () => {
   beforeEach(() => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: true,
-      json: async () => ({
-        work_item: {
-          id: 'work-social-1',
-          title: 'Approval gates create trust',
-          status: 'proposed',
-          priority: 'high',
-          source_type: 'social_topic_trigger',
-          metadata: {
-            insight: {
-              title: 'Approval gates create trust',
-              triggering_event: 'The Social Content review flow made the gate visible.',
-              why_vambah_can_speak: 'Vambah is building and reviewing the system directly.',
-              evidence_summary: 'Review path and visual gate work shipped locally.',
-              brand_goal: 'Show AmaduTown as the operating layer for governed AI.',
-              audience: 'Operators adopting AI workflows.',
-              content_angle: 'AI should reduce burden, but only when authority and evidence are separated.',
-              suggested_hook: 'AI should reduce burden.',
-              claim_boundaries: ['Do not imply publishing is automated.'],
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url === '/api/admin/agents/work-items/work-social-1') {
+        return {
+          ok: true,
+          json: async () => ({ work_item: socialWorkItem() }),
+        }
+      }
+      if (url === '/api/admin/agents/work-items/work-social-1/social-channels/linkedin') {
+        const body = JSON.parse(String(init?.body ?? '{}'))
+        return {
+          ok: true,
+          json: async () => ({
+            success: true,
+            work_item: socialWorkItem({
+              metadata: {
+                ...socialWorkItem().metadata,
+                channel_lanes: {
+                  ...socialWorkItem().metadata.channel_lanes,
+                  linkedin: {
+                    ...socialWorkItem().metadata.channel_lanes.linkedin,
+                    status: body.status,
+                    decision_note: body.decision_note,
+                    updated_at: '2026-06-23T10:00:00.000Z',
+                  },
+                },
+              },
+            }),
+            side_effects: {
+              provider_generation: false,
+              upload: false,
+              publish: false,
+              schedule: false,
+              external_post: false,
             },
-            channel_lanes: {
-              linkedin: { status: 'selected', label: 'LinkedIn', required_inputs: ['post text', 'CTA'] },
-              youtube_shorts: { status: 'not_started', label: 'YouTube Shorts', required_inputs: ['hook', 'script'] },
-              instagram_reels: { status: 'not_started', label: 'Instagram Reels', required_inputs: ['hook', 'caption'] },
-              thumbnail: { status: 'not_started', label: 'Thumbnail', required_inputs: ['short thumbnail text', '2-3 variants'] },
-            },
-          },
-          updated_at: '2026-06-22T12:00:00.000Z',
-        },
-      }),
-    })))
+          }),
+        }
+      }
+      return { ok: false, status: 404, json: async () => ({ error: 'not found' }) }
+    }))
   })
 
   afterEach(() => {
@@ -75,5 +114,46 @@ describe('SocialInsightDetailPage', () => {
     expect(screen.getByText('Thumbnail production inputs')).toBeInTheDocument()
     expect(screen.getByText('short thumbnail text')).toBeInTheDocument()
     expect(screen.getByText('2-3 variants')).toBeInTheDocument()
+  })
+
+  it('requires a decision note before blocking a channel lane', async () => {
+    render(<SocialInsightDetailPage />)
+
+    await screen.findByRole('heading', { name: 'Approval gates create trust' })
+    fireEvent.click(screen.getByRole('button', { name: 'Reject Lane' }))
+
+    expect(await screen.findByText('Add a decision note before rejecting a channel lane.')).toBeInTheDocument()
+    expect(vi.mocked(fetch).mock.calls.some(([input]) => String(input).includes('/social-channels/linkedin'))).toBe(false)
+  })
+
+  it('updates a channel lane decision through the review controls', async () => {
+    render(<SocialInsightDetailPage />)
+
+    await screen.findByRole('heading', { name: 'Approval gates create trust' })
+
+    fireEvent.change(screen.getByLabelText('Decision note'), {
+      target: { value: 'Approved for LinkedIn planning; no publishing authorized.' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Approve Lane' }))
+
+    await screen.findByText('LinkedIn lane marked approved.')
+
+    const patchCall = vi.mocked(fetch).mock.calls.find(([input]) => String(input) === '/api/admin/agents/work-items/work-social-1/social-channels/linkedin')
+    expect(patchCall).toBeTruthy()
+    expect(patchCall?.[1]).toMatchObject({
+      method: 'PATCH',
+    })
+    expect(Object.fromEntries(new Headers(patchCall?.[1]?.headers))).toMatchObject({
+      authorization: 'Bearer admin-token',
+      'content-type': 'application/json',
+    })
+    expect(JSON.parse(String(patchCall?.[1]?.body))).toEqual({
+      status: 'approved',
+      decision_note: 'Approved for LinkedIn planning; no publishing authorized.',
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Approved' })).toBeInTheDocument()
+    })
   })
 })

--- a/app/admin/agents/social-insights/[id]/page.tsx
+++ b/app/admin/agents/social-insights/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'next/navigation'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { ReactNode } from 'react'
 import {
+  AlertCircle,
   CheckCircle2,
   FileText,
   Image as ImageIcon,
@@ -12,6 +13,7 @@ import {
   MessageSquare,
   RefreshCw,
   ShieldAlert,
+  XCircle,
   Youtube,
 } from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
@@ -21,6 +23,7 @@ import type { AgentWorkItem } from '@/lib/agent-work-items'
 import {
   SOCIAL_CONTENT_INTELLIGENCE_CHANNELS,
   type SocialContentIntelligenceChannel,
+  type SocialChannelLaneStatus,
 } from '@/lib/social-content-intelligence'
 
 type ChannelLane = {
@@ -56,6 +59,14 @@ function asStringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
 }
 
+function statusLabel(status: string) {
+  return status.replace(/_/g, ' ')
+}
+
+function decisionLabel(status: SocialChannelLaneStatus) {
+  return status === 'blocked' ? 'rejected' : statusLabel(status)
+}
+
 function lanesFor(item: AgentWorkItem | null): Record<SocialContentIntelligenceChannel, ChannelLane> {
   const metadata = item?.metadata ?? {}
   const lanes = asRecord(metadata.channel_lanes)
@@ -85,12 +96,21 @@ function SocialInsightDetailContent() {
   const [activeTab, setActiveTab] = useState<SocialContentIntelligenceChannel>('linkedin')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [decisionNote, setDecisionNote] = useState('')
+  const [savingLane, setSavingLane] = useState<SocialChannelLaneStatus | null>(null)
+  const [laneNotice, setLaneNotice] = useState<string | null>(null)
 
-  const authedFetch = useCallback(async (path: string) => {
+  const authedFetch = useCallback(async (path: string, init: RequestInit = {}) => {
     const session = await getCurrentSession()
     if (!session?.access_token) throw new Error('Missing admin session')
+    const headers = new Headers(init.headers)
+    headers.set('Authorization', `Bearer ${session.access_token}`)
+    if (init.body && !headers.has('Content-Type')) {
+      headers.set('Content-Type', 'application/json')
+    }
     return fetch(path, {
-      headers: { Authorization: `Bearer ${session.access_token}` },
+      ...init,
+      headers,
     })
   }, [])
 
@@ -118,6 +138,44 @@ function SocialInsightDetailContent() {
   const insight = asRecord(metadata.insight)
   const lanes = useMemo(() => lanesFor(item), [item])
   const activeLane = lanes[activeTab]
+
+  useEffect(() => {
+    setDecisionNote(activeLane?.decision_note ?? '')
+  }, [activeLane?.decision_note, activeTab])
+
+  useEffect(() => {
+    setLaneNotice(null)
+  }, [activeTab])
+
+  const updateLane = useCallback(async (status: SocialChannelLaneStatus) => {
+    setError(null)
+    setLaneNotice(null)
+
+    const note = decisionNote.trim()
+    if (status === 'blocked' && !note) {
+      setError('Add a decision note before rejecting a channel lane.')
+      return
+    }
+
+    setSavingLane(status)
+    try {
+      const response = await authedFetch(`/api/admin/agents/work-items/${id}/social-channels/${activeTab}`, {
+        method: 'PATCH',
+        body: JSON.stringify({
+          status,
+          decision_note: note || null,
+        }),
+      })
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body.error || `Lane update HTTP ${response.status}`)
+      setItem(body.work_item ?? null)
+      setLaneNotice(`${CHANNEL_LABELS[activeTab]} lane marked ${decisionLabel(status)}.`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update channel lane')
+    } finally {
+      setSavingLane(null)
+    }
+  }, [activeTab, authedFetch, decisionNote, id])
 
   return (
     <div className="agent-ops-page min-h-screen p-5 text-foreground lg:p-7">
@@ -212,7 +270,7 @@ function SocialInsightDetailContent() {
                     {CHANNEL_ICONS[channel]}
                     {CHANNEL_LABELS[channel]}
                     <span className="rounded-full border border-current/30 px-2 py-0.5 text-[10px]">
-                      {lanes[channel].status.replace(/_/g, ' ')}
+                      {statusLabel(lanes[channel].status)}
                     </span>
                   </button>
                 ))}
@@ -228,18 +286,66 @@ function SocialInsightDetailContent() {
                   </div>
                   <span className="inline-flex w-fit items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/10 px-3 py-1 text-xs font-semibold text-blue-100">
                     <CheckCircle2 className="h-3.5 w-3.5" />
-                    {activeLane.status.replace(/_/g, ' ')}
+                    {statusLabel(activeLane.status)}
                   </span>
                 </div>
 
                 <ChannelInputs channel={activeTab} lane={activeLane} insight={insight} />
 
-                {activeLane.decision_note ? (
-                  <div className="mt-4 rounded-lg border border-silicon-slate/70 bg-background/45 p-3">
-                    <p className="text-xs uppercase tracking-wide text-muted-foreground">Decision note</p>
-                    <p className="mt-1 text-sm leading-6">{activeLane.decision_note}</p>
+                <div className="mt-4 rounded-lg border border-silicon-slate/70 bg-background/45 p-3">
+                  <div className="flex flex-col gap-2 lg:flex-row lg:items-start lg:justify-between">
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-muted-foreground">Lane decision</p>
+                      <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                        Updates this channel lane only. No draft, render, upload, schedule, or publish action runs here.
+                      </p>
+                    </div>
+                    {laneNotice ? (
+                      <span className="inline-flex w-fit rounded-full border border-emerald-500/35 bg-emerald-500/10 px-3 py-1 text-xs font-semibold text-emerald-100">
+                        {laneNotice}
+                      </span>
+                    ) : null}
                   </div>
-                ) : null}
+                  <label className="mt-3 block text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    Decision note
+                    <textarea
+                      value={decisionNote}
+                      onChange={(event) => setDecisionNote(event.target.value)}
+                      rows={3}
+                      placeholder="What should Shaka or the production agent change before this lane moves forward?"
+                      className="mt-2 w-full rounded-md border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm normal-case tracking-normal text-foreground"
+                    />
+                  </label>
+                  <div className="mt-3 flex flex-col gap-2 md:flex-row md:justify-end">
+                    <button
+                      type="button"
+                      onClick={() => updateLane('in_review')}
+                      disabled={savingLane !== null}
+                      className="agent-ops-button-secondary disabled:opacity-60"
+                    >
+                      <AlertCircle size={16} />
+                      {savingLane === 'in_review' ? 'Updating...' : 'Return to Review'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => updateLane('blocked')}
+                      disabled={savingLane !== null}
+                      className="inline-flex items-center justify-center gap-2 rounded-lg border border-red-500/45 bg-red-500/10 px-4 py-2 text-sm font-semibold text-red-100 transition hover:bg-red-500/15 disabled:opacity-60"
+                    >
+                      <XCircle size={16} />
+                      {savingLane === 'blocked' ? 'Rejecting...' : activeLane.status === 'blocked' ? 'Rejected' : 'Reject Lane'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => updateLane('approved')}
+                      disabled={savingLane !== null}
+                      className="inline-flex items-center justify-center gap-2 rounded-lg border border-emerald-500/45 bg-emerald-500/10 px-4 py-2 text-sm font-semibold text-emerald-100 transition hover:bg-emerald-500/15 disabled:opacity-60"
+                    >
+                      <CheckCircle2 size={16} />
+                      {savingLane === 'approved' ? 'Approving...' : activeLane.status === 'approved' ? 'Approved' : 'Approve Lane'}
+                    </button>
+                  </div>
+                </div>
               </div>
             </section>
           </div>

--- a/app/api/admin/agents/work-items/[id]/social-channels/[channel]/route.test.ts
+++ b/app/api/admin/agents/work-items/[id]/social-channels/[channel]/route.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  getAgentWorkItem: vi.fn(),
+  updateAgentWorkItemMetadata: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-work-items', () => ({
+  getAgentWorkItem: mocks.getAgentWorkItem,
+  updateAgentWorkItemMetadata: mocks.updateAgentWorkItemMetadata,
+}))
+
+import { PATCH } from './route'
+
+function request(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/admin/agents/work-items/work-1/social-channels/linkedin', {
+    method: 'PATCH',
+    headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+const baseWorkItem = {
+  id: 'work-1',
+  metadata: {
+    channel_lanes: {
+      linkedin: {
+        status: 'selected',
+        label: 'LinkedIn',
+        required_inputs: ['post text', 'CTA'],
+      },
+    },
+  },
+}
+
+describe('/api/admin/agents/work-items/[id]/social-channels/[channel]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user', email: 'admin@example.com' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.getAgentWorkItem.mockResolvedValue(baseWorkItem)
+    mocks.updateAgentWorkItemMetadata.mockResolvedValue({
+      ...baseWorkItem,
+      metadata: {
+        ...baseWorkItem.metadata,
+        channel_lanes: {
+          ...baseWorkItem.metadata.channel_lanes,
+          linkedin: {
+            ...baseWorkItem.metadata.channel_lanes.linkedin,
+            status: 'approved',
+            decision_note: 'Approved for planning.',
+            updated_at: '2026-06-23T10:00:00.000Z',
+          },
+        },
+      },
+    })
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await PATCH(request({ status: 'approved' }) as never, {
+      params: { id: 'work-1', channel: 'linkedin' },
+    })
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.getAgentWorkItem).not.toHaveBeenCalled()
+  })
+
+  it('validates channel and status', async () => {
+    const badChannel = await PATCH(request({ status: 'approved' }) as never, {
+      params: { id: 'work-1', channel: 'threads' },
+    })
+    expect(badChannel.status).toBe(400)
+
+    const badStatus = await PATCH(request({ status: 'published' }) as never, {
+      params: { id: 'work-1', channel: 'linkedin' },
+    })
+    expect(badStatus.status).toBe(400)
+  })
+
+  it('updates only the selected social channel lane and reports no side effects', async () => {
+    const response = await PATCH(request({
+      status: 'approved',
+      decision_note: 'Approved for planning.',
+    }) as never, {
+      params: { id: 'work-1', channel: 'linkedin' },
+    })
+
+    expect(response.status).toBe(200)
+    expect(mocks.updateAgentWorkItemMetadata).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'work-1',
+      note: 'LinkedIn lane updated by admin@example.com.',
+      metadata: expect.objectContaining({
+        channel_lanes: expect.objectContaining({
+          linkedin: expect.objectContaining({
+            status: 'approved',
+            decision_note: 'Approved for planning.',
+            required_inputs: ['post text', 'CTA'],
+          }),
+          youtube_shorts: expect.objectContaining({
+            status: 'not_started',
+            label: 'YouTube Shorts',
+          }),
+        }),
+      }),
+    }))
+    expect(await response.json()).toMatchObject({
+      success: true,
+      side_effects: {
+        provider_generation: false,
+        upload: false,
+        publish: false,
+        schedule: false,
+        external_post: false,
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Adds explicit lane decision controls to the shared Social Insight detail page for LinkedIn, YouTube Shorts, Instagram Reels, and Thumbnail tabs.
- Lets an admin return a lane to review, reject a lane with a required decision note, or approve a lane through the existing social-channel PATCH API.
- Keeps the action scoped to lane metadata only; no draft creation, rendering, provider generation, upload, scheduling, or publishing is triggered.
- Adds direct API coverage for the social-channel lane PATCH route.

## Validation
- `npm test -- --run 'app/admin/agents/social-insights/[id]/page.test.tsx' 'app/api/admin/agents/work-items/[id]/social-channels/[channel]/route.test.ts' app/admin/agents/content-intelligence/page.test.tsx app/api/admin/agents/work-items/route.test.ts`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- Browser smoke on `http://127.0.0.1:3027/admin/agents/social-insights/00000000-0000-0000-0000-000000000000` with local admin session:
  - protected route shell rendered
  - valid missing-item state rendered without framework overlay
  - no browser console errors observed
- Component tests cover the actual lane decision controls because no existing social-topic trigger item was present in configured data and I avoided creating a DB item solely for QA.

## Integration Notes
- No migrations or env changes required.
- Existing dev warning observed: `.env.local` has outbound n8n webhooks enabled; this flow did not submit provider, upload, scheduling, or publish actions.
- Observed out-of-scope behavior: non-UUID social insight IDs produce a noisy work-item fetch error; UUID-shaped missing IDs render the clean not-found state.
- Vercel contexts were not checked from this implementation lane and should be verified by the Integration Captain:
  - Vercel – portfolio
  - Vercel – portfolio-staging
