### PR TITLE
feat: link research patterns to social insights

### DIFF
--- a/app/admin/agents/content-intelligence/page.test.tsx
+++ b/app/admin/agents/content-intelligence/page.test.tsx
@@ -25,6 +25,22 @@ describe('ContentIntelligencePage', () => {
           json: async () => ({ packets: [{ id: 'packet-new' }], run: { mode: 'recorded_evidence' } }),
         }
       }
+      if (url === '/api/admin/agents/work-items/work-social-1/research-packets') {
+        return {
+          ok: true,
+          json: async () => ({
+            success: true,
+            linked_packet_ids: ['packet-1'],
+            side_effects: {
+              provider_generation: false,
+              upload: false,
+              publish: false,
+              schedule: false,
+              external_post: false,
+            },
+          }),
+        }
+      }
       if (url.startsWith('/api/admin/social-content/intelligence/research-packets')) {
         return {
           ok: true,
@@ -90,8 +106,8 @@ describe('ContentIntelligencePage', () => {
     expect(screen.getByText('Recorded public evidence from Codex/browser review. Cost: $0.')).toBeInTheDocument()
     expect(screen.getByText('pintostudio/youtube-transcript-scraper only after cost approval')).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: 'Add recorded public evidence' })).toBeInTheDocument()
-    expect(screen.getByText('Outlier research process')).toBeInTheDocument()
-    expect(screen.getByText('Approval gates create trust')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Link pattern to Shaka insight' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Outlier research process' })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /Approval gates create trust/ })).toHaveAttribute('href', '/admin/agents/social-insights/work-social-1')
   })
 
@@ -135,6 +151,27 @@ describe('ContentIntelligencePage', () => {
 
     await waitFor(() => {
       expect(vi.mocked(fetch).mock.calls.filter(([input]) => String(input).startsWith('/api/admin/social-content/intelligence/research-packets'))).toHaveLength(2)
+    })
+  })
+
+  it('links a research pattern to a central Shaka insight without production side effects', async () => {
+    render(<ContentIntelligencePage />)
+
+    await screen.findByRole('heading', { name: 'Link pattern to Shaka insight' })
+
+    fireEvent.change(screen.getByLabelText('Decision note'), {
+      target: { value: 'Use the structure, not the source wording.' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Link Pattern' }))
+
+    await screen.findByText('Research pattern linked to Shaka insight.')
+
+    const linkCall = vi.mocked(fetch).mock.calls.find(([input]) => String(input) === '/api/admin/agents/work-items/work-social-1/research-packets')
+    expect(linkCall).toBeTruthy()
+    expect(linkCall?.[1]).toMatchObject({ method: 'POST' })
+    expect(JSON.parse(String(linkCall?.[1]?.body))).toEqual({
+      packet_ids: ['packet-1'],
+      decision_note: 'Use the structure, not the source wording.',
     })
   })
 })

--- a/app/admin/agents/content-intelligence/page.tsx
+++ b/app/admin/agents/content-intelligence/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { type FormEvent, useCallback, useEffect, useMemo, useState } from 'react'
 import {
   BarChart3,
+  CheckCircle2,
   Database,
   ExternalLink,
   FileSearch,
@@ -114,6 +115,11 @@ function ContentIntelligenceContent() {
   const [evidenceForm, setEvidenceForm] = useState<EvidenceForm>(EMPTY_EVIDENCE_FORM)
   const [submittingEvidence, setSubmittingEvidence] = useState(false)
   const [evidenceNotice, setEvidenceNotice] = useState<string | null>(null)
+  const [selectedPacketId, setSelectedPacketId] = useState('')
+  const [selectedInsightId, setSelectedInsightId] = useState('')
+  const [linkDecisionNote, setLinkDecisionNote] = useState('')
+  const [linkingPattern, setLinkingPattern] = useState(false)
+  const [linkNotice, setLinkNotice] = useState<string | null>(null)
 
   const authedFetch = useCallback(async (path: string, init: RequestInit = {}) => {
     const session = await getCurrentSession()
@@ -157,6 +163,14 @@ function ContentIntelligenceContent() {
   }, [load])
 
   const strongestPacket = useMemo(() => packets[0] ?? null, [packets])
+
+  useEffect(() => {
+    setSelectedPacketId((current) => current || packets[0]?.id || '')
+  }, [packets])
+
+  useEffect(() => {
+    setSelectedInsightId((current) => current || insights[0]?.id || '')
+  }, [insights])
 
   const submitRecordedEvidence = useCallback(async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -209,6 +223,37 @@ function ContentIntelligenceContent() {
       setSubmittingEvidence(false)
     }
   }, [authedFetch, evidenceForm, load])
+
+  const linkResearchPattern = useCallback(async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError(null)
+    setLinkNotice(null)
+
+    if (!selectedPacketId || !selectedInsightId) {
+      setError('Choose a research packet and Shaka insight before linking a pattern.')
+      return
+    }
+
+    setLinkingPattern(true)
+    try {
+      const response = await authedFetch(`/api/admin/agents/work-items/${selectedInsightId}/research-packets`, {
+        method: 'POST',
+        body: JSON.stringify({
+          packet_ids: [selectedPacketId],
+          decision_note: linkDecisionNote.trim() || null,
+        }),
+      })
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body.error || `Pattern link HTTP ${response.status}`)
+      setLinkDecisionNote('')
+      setLinkNotice('Research pattern linked to Shaka insight.')
+      await load()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to link research pattern')
+    } finally {
+      setLinkingPattern(false)
+    }
+  }, [authedFetch, linkDecisionNote, load, selectedInsightId, selectedPacketId])
 
   return (
     <div className="agent-ops-page min-h-screen p-5 text-foreground lg:p-7">
@@ -357,6 +402,73 @@ function ContentIntelligenceContent() {
               <div className="py-12 text-center text-sm text-muted-foreground">Loading research packets...</div>
             ) : packets.length ? (
               <div className="space-y-3">
+                {insights.length ? (
+                  <form onSubmit={linkResearchPattern} className="rounded-lg border border-radiant-gold/35 bg-radiant-gold/10 p-3">
+                    <div className="mb-3 flex flex-col gap-2 lg:flex-row lg:items-start lg:justify-between">
+                      <div>
+                        <h3 className="text-sm font-semibold text-radiant-gold">Link pattern to Shaka insight</h3>
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          Adds the reusable pattern to the central backlog item. No draft, media, upload, schedule, or publish action runs.
+                        </p>
+                      </div>
+                      {linkNotice ? (
+                        <span className="inline-flex w-fit rounded-full border border-emerald-500/35 bg-emerald-500/10 px-3 py-1 text-xs font-semibold text-emerald-100">
+                          {linkNotice}
+                        </span>
+                      ) : null}
+                    </div>
+                    <div className="grid gap-3 lg:grid-cols-2">
+                      <label className="block text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        Research packet
+                        <select
+                          value={selectedPacketId}
+                          onChange={(event) => setSelectedPacketId(event.target.value)}
+                          className="mt-1 w-full rounded-md border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm normal-case tracking-normal text-foreground"
+                        >
+                          {packets.map((packet) => (
+                            <option key={packet.id} value={packet.id}>
+                              {(packet.title ?? packet.creator_name ?? packet.source_url).slice(0, 90)}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                      <label className="block text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        Shaka insight
+                        <select
+                          value={selectedInsightId}
+                          onChange={(event) => setSelectedInsightId(event.target.value)}
+                          className="mt-1 w-full rounded-md border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm normal-case tracking-normal text-foreground"
+                        >
+                          {insights.map((item) => (
+                            <option key={item.id} value={item.id}>
+                              {insightFor(item).title.slice(0, 90)}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                    </div>
+                    <label className="mt-3 block text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Decision note
+                      <textarea
+                        value={linkDecisionNote}
+                        onChange={(event) => setLinkDecisionNote(event.target.value)}
+                        rows={2}
+                        placeholder="Why this source pattern is safe and useful for this insight."
+                        className="mt-1 w-full rounded-md border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm normal-case tracking-normal text-foreground"
+                      />
+                    </label>
+                    <div className="mt-3 flex justify-end">
+                      <button
+                        type="submit"
+                        disabled={linkingPattern}
+                        className="agent-ops-button-primary disabled:opacity-60"
+                      >
+                        <CheckCircle2 size={16} />
+                        {linkingPattern ? 'Linking...' : 'Link Pattern'}
+                      </button>
+                    </div>
+                  </form>
+                ) : null}
                 {packets.map((packet) => (
                   <article key={packet.id} className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-4">
                     <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">

--- a/app/admin/agents/social-insights/[id]/page.test.tsx
+++ b/app/admin/agents/social-insights/[id]/page.test.tsx
@@ -37,6 +37,21 @@ function socialWorkItem(overrides: Record<string, unknown> = {}) {
         content_angle: 'AI should reduce burden, but only when authority and evidence are separated.',
         suggested_hook: 'AI should reduce burden.',
         claim_boundaries: ['Do not imply publishing is automated.'],
+        approved_research_patterns: [
+          {
+            packet_id: 'packet-1',
+            source_url: 'https://youtube.com/watch?v=abc',
+            platform: 'youtube',
+            creator_name: 'Creator',
+            title: 'Useful outlier',
+            outlier_score: 87,
+            pattern_packet: {
+              hook_structure: 'Start with the missed approval gate.',
+              promise_value: 'Show how review gates build trust.',
+              thumbnail_pattern: 'Translate the layout into AmaduTown style.',
+            },
+          },
+        ],
       },
       channel_lanes: {
         linkedin: { status: 'selected', label: 'LinkedIn', required_inputs: ['post text', 'CTA'] },
@@ -108,6 +123,9 @@ describe('SocialInsightDetailPage', () => {
     expect(screen.getByRole('tab', { name: /Instagram Reels/ })).toBeInTheDocument()
     expect(screen.getByRole('tab', { name: /Thumbnail/ })).toBeInTheDocument()
     expect(screen.getByText('post text')).toBeInTheDocument()
+    expect(screen.getByText('Approved research patterns')).toBeInTheDocument()
+    expect(screen.getByText('Useful outlier')).toBeInTheDocument()
+    expect(screen.getByText('Hook: Start with the missed approval gate.')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('tab', { name: /Thumbnail/ }))
 

--- a/app/admin/agents/social-insights/[id]/page.tsx
+++ b/app/admin/agents/social-insights/[id]/page.tsx
@@ -59,6 +59,10 @@ function asStringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
 }
 
+function asRecordArray(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value) ? value.map((item) => asRecord(item)).filter((item) => Object.keys(item).length > 0) : []
+}
+
 function statusLabel(status: string) {
   return status.replace(/_/g, ' ')
 }
@@ -136,6 +140,7 @@ function SocialInsightDetailContent() {
 
   const metadata = item?.metadata ?? {}
   const insight = asRecord(metadata.insight)
+  const approvedResearchPatterns = asRecordArray(insight.approved_research_patterns)
   const lanes = useMemo(() => lanesFor(item), [item])
   const activeLane = lanes[activeTab]
 
@@ -250,6 +255,18 @@ function SocialInsightDetailContent() {
                   <p className="text-sm text-muted-foreground">No claim boundaries recorded yet.</p>
                 )}
               </div>
+              <div className="mt-4 rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-3">
+                <p className="text-xs uppercase tracking-wide text-muted-foreground">Approved research patterns</p>
+                {approvedResearchPatterns.length ? (
+                  <div className="mt-3 space-y-3">
+                    {approvedResearchPatterns.map((pattern) => (
+                      <ResearchPatternCard key={asString(pattern.packet_id) || asString(pattern.source_url)} pattern={pattern} />
+                    ))}
+                  </div>
+                ) : (
+                  <p className="mt-2 text-sm text-muted-foreground">No public research patterns linked yet.</p>
+                )}
+              </div>
             </section>
 
             <section className="agent-ops-card rounded-lg border p-4">
@@ -356,6 +373,44 @@ function SocialInsightDetailContent() {
         )}
       </div>
     </div>
+  )
+}
+
+function ResearchPatternCard({ pattern }: { pattern: Record<string, unknown> }) {
+  const patternPacket = asRecord(pattern.pattern_packet)
+  const title = asString(pattern.title) || asString(pattern.source_url) || 'Research pattern'
+  const hook = asString(patternPacket.hook_structure)
+  const promise = asString(patternPacket.promise_value)
+  const thumbnail = asString(patternPacket.thumbnail_pattern)
+  return (
+    <article className="rounded-lg border border-silicon-slate/70 bg-background/45 p-3">
+      <div className="flex flex-col gap-2 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <p className="text-sm font-semibold">{title}</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {asString(pattern.platform).replace(/_/g, ' ')} · {asString(pattern.creator_name) || asString(pattern.creator_handle) || 'Creator unknown'}
+          </p>
+        </div>
+        <span className="inline-flex w-fit rounded-full border border-radiant-gold/35 bg-radiant-gold/10 px-2 py-0.5 text-xs text-radiant-gold">
+          Outlier {Math.round(Number(pattern.outlier_score ?? 0))}
+        </span>
+      </div>
+      <div className="mt-3 space-y-2 text-sm leading-6 text-muted-foreground">
+        {hook ? <p>Hook: {hook}</p> : null}
+        {promise ? <p>Promise: {promise}</p> : null}
+        {thumbnail ? <p>Thumbnail: {thumbnail}</p> : null}
+      </div>
+      {asString(pattern.source_url) ? (
+        <a
+          href={asString(pattern.source_url)}
+          target="_blank"
+          rel="noreferrer"
+          className="mt-3 inline-flex text-xs text-blue-200 hover:text-blue-100"
+        >
+          Open source
+        </a>
+      ) : null}
+    </article>
   )
 }
 

--- a/app/api/admin/agents/work-items/[id]/research-packets/route.test.ts
+++ b/app/api/admin/agents/work-items/[id]/research-packets/route.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  getAgentWorkItem: vi.fn(),
+  updateAgentWorkItemMetadata: vi.fn(),
+  from: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-work-items', () => ({
+  getAgentWorkItem: mocks.getAgentWorkItem,
+  updateAgentWorkItemMetadata: mocks.updateAgentWorkItemMetadata,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import { POST } from './route'
+
+function request(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/admin/agents/work-items/work-1/research-packets', {
+    method: 'POST',
+    headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+const workItem = {
+  id: 'work-1',
+  source_type: 'social_topic_trigger',
+  metadata: {
+    social_topic_trigger: true,
+    research_packet_ids: ['packet-existing'],
+    insight: {
+      title: 'Approval gates create trust',
+      approved_research_patterns: [
+        {
+          packet_id: 'packet-existing',
+          source_url: 'https://example.com/existing',
+          pattern_packet: { hook_structure: 'Existing hook' },
+        },
+      ],
+    },
+  },
+}
+
+const packet = {
+  id: 'packet-1',
+  source_url: 'https://youtube.com/watch?v=abc',
+  platform: 'youtube',
+  creator_name: 'Creator',
+  creator_handle: '@creator',
+  title: 'Useful outlier',
+  outlier_score: 87,
+  pattern_status: 'needs_brand_translation',
+  pattern_packet: {
+    hook_structure: 'Start with the missed approval gate.',
+    promise_value: 'Show how review gates build trust.',
+  },
+  privacy_notes: 'Public pattern only.',
+  retrieved_at: '2026-06-23T10:00:00.000Z',
+  status: 'review_ready',
+}
+
+function mockResearchPacketQuery(packetRows = [packet]) {
+  mocks.from.mockImplementation((table: string) => {
+    if (table !== 'social_content_research_packets') throw new Error(`Unexpected table ${table}`)
+    return {
+      select: vi.fn(() => ({
+        in: vi.fn(async () => ({ data: packetRows, error: null })),
+      })),
+      update: vi.fn(() => ({
+        in: vi.fn(async () => ({ error: null })),
+      })),
+    }
+  })
+}
+
+describe('/api/admin/agents/work-items/[id]/research-packets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user', email: 'admin@example.com' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.getAgentWorkItem.mockResolvedValue(workItem)
+    mocks.updateAgentWorkItemMetadata.mockResolvedValue(workItem)
+    mockResearchPacketQuery()
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(request({ packet_ids: ['packet-1'] }) as never, {
+      params: { id: 'work-1' },
+    })
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.getAgentWorkItem).not.toHaveBeenCalled()
+  })
+
+  it('rejects research patterns that are too close to the source', async () => {
+    mockResearchPacketQuery([{ ...packet, pattern_status: 'too_close_to_source' }])
+
+    const response = await POST(request({ packet_ids: ['packet-1'] }) as never, {
+      params: { id: 'work-1' },
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: 'Only usable or brand-translation research patterns can be linked to an insight',
+    })
+    expect(mocks.updateAgentWorkItemMetadata).not.toHaveBeenCalled()
+  })
+
+  it('links public research patterns to a social insight without production side effects', async () => {
+    const response = await POST(request({
+      packet_ids: ['packet-1'],
+      decision_note: 'Use the hook framework, not the wording.',
+    }) as never, {
+      params: { id: 'work-1' },
+    })
+
+    expect(response.status).toBe(200)
+    expect(mocks.updateAgentWorkItemMetadata).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'work-1',
+      note: 'Linked 1 public research pattern(s) to social insight.',
+      metadata: expect.objectContaining({
+        research_packet_ids: ['packet-existing', 'packet-1'],
+        research_patterns_decision_note: 'Use the hook framework, not the wording.',
+        insight: expect.objectContaining({
+          approved_research_patterns: expect.arrayContaining([
+            expect.objectContaining({
+              packet_id: 'packet-1',
+              source_url: 'https://youtube.com/watch?v=abc',
+              pattern_packet: expect.objectContaining({
+                hook_structure: 'Start with the missed approval gate.',
+              }),
+            }),
+          ]),
+        }),
+      }),
+    }))
+    expect(await response.json()).toMatchObject({
+      success: true,
+      linked_packet_ids: ['packet-existing', 'packet-1'],
+      side_effects: {
+        provider_generation: false,
+        upload: false,
+        publish: false,
+        schedule: false,
+        external_post: false,
+      },
+    })
+  })
+})

--- a/app/api/admin/agents/work-items/[id]/research-packets/route.ts
+++ b/app/api/admin/agents/work-items/[id]/research-packets/route.ts
@@ -1,0 +1,147 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { getAgentWorkItem, updateAgentWorkItemMetadata } from '@/lib/agent-work-items'
+import { isSocialTopicTriggerWorkItem } from '@/lib/social-content-intelligence'
+import { supabaseAdmin } from '@/lib/supabase'
+
+export const dynamic = 'force-dynamic'
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
+}
+
+function asString(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function asStringArray(value: unknown) {
+  return Array.isArray(value)
+    ? value
+        .filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+        .map((item) => item.trim())
+    : []
+}
+
+function compactPattern(packet: Record<string, unknown>) {
+  return {
+    packet_id: asString(packet.id),
+    source_url: asString(packet.source_url),
+    platform: asString(packet.platform) || 'other',
+    creator_name: asString(packet.creator_name) || null,
+    creator_handle: asString(packet.creator_handle) || null,
+    title: asString(packet.title) || null,
+    outlier_score: typeof packet.outlier_score === 'number' ? packet.outlier_score : Number(packet.outlier_score ?? 0),
+    pattern_status: asString(packet.pattern_status) || 'needs_brand_translation',
+    pattern_packet: asRecord(packet.pattern_packet),
+    privacy_notes: asString(packet.privacy_notes) || null,
+    retrieved_at: asString(packet.retrieved_at) || null,
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const authResult = await verifyAdmin(request)
+  if (isAuthError(authResult)) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status })
+  }
+
+  const body = asRecord(await request.json().catch(() => ({})))
+  const packetIds = Array.from(new Set(asStringArray(body.packet_ids)))
+  if (packetIds.length === 0) {
+    return NextResponse.json({ error: 'packet_ids are required' }, { status: 400 })
+  }
+
+  try {
+    const workItem = await getAgentWorkItem(params.id)
+    if (!workItem) {
+      return NextResponse.json({ error: 'Work item not found' }, { status: 404 })
+    }
+    if (!isSocialTopicTriggerWorkItem(workItem)) {
+      return NextResponse.json({ error: 'Work item is not a social topic trigger' }, { status: 400 })
+    }
+
+    const { data: packets, error } = await supabaseAdmin
+      .from('social_content_research_packets')
+      .select('id, source_url, platform, creator_name, creator_handle, title, outlier_score, pattern_status, pattern_packet, privacy_notes, retrieved_at, status')
+      .in('id', packetIds)
+
+    if (error) throw new Error(error.message)
+    const packetRows: Record<string, unknown>[] = ((packets ?? []) as unknown[]).map((packet) => asRecord(packet))
+    if (packetRows.length !== packetIds.length) {
+      return NextResponse.json({ error: 'One or more research packets were not found' }, { status: 404 })
+    }
+
+    const blockedPacket = packetRows.find((packet) => {
+      const status = asString(packet.status)
+      const patternStatus = asString(packet.pattern_status)
+      return status === 'rejected'
+        || status === 'archived'
+        || patternStatus === 'too_close_to_source'
+        || patternStatus === 'not_relevant'
+    })
+    if (blockedPacket) {
+      return NextResponse.json(
+        { error: 'Only usable or brand-translation research patterns can be linked to an insight' },
+        { status: 400 },
+      )
+    }
+
+    const metadata = workItem.metadata ?? {}
+    const insight = asRecord(metadata.insight)
+    const existingPatterns = Array.isArray(insight.approved_research_patterns)
+      ? insight.approved_research_patterns.map((item) => asRecord(item))
+      : []
+    const nextPatterns = [
+      ...existingPatterns.filter((item) => !packetIds.includes(asString(item.packet_id))),
+      ...packetRows.map((packet) => compactPattern(packet)),
+    ]
+    const nextPacketIds = Array.from(new Set([
+      ...asStringArray(metadata.research_packet_ids),
+      ...packetIds,
+    ]))
+
+    const { error: packetUpdateError } = await supabaseAdmin
+      .from('social_content_research_packets')
+      .update({ status: 'approved' })
+      .in('id', packetIds)
+    if (packetUpdateError) throw new Error(packetUpdateError.message)
+
+    const updated = await updateAgentWorkItemMetadata({
+      id: workItem.id,
+      metadata: {
+        ...metadata,
+        research_packet_ids: nextPacketIds,
+        research_patterns_linked_at: new Date().toISOString(),
+        research_patterns_linked_by: authResult.user.email ?? authResult.user.id,
+        research_patterns_decision_note: asString(body.decision_note) || null,
+        insight: {
+          ...insight,
+          approved_research_patterns: nextPatterns,
+        },
+      },
+      note: `Linked ${packetIds.length} public research pattern(s) to social insight.`,
+    })
+
+    return NextResponse.json({
+      success: true,
+      work_item: updated,
+      linked_packet_ids: nextPacketIds,
+      approved_research_patterns: nextPatterns,
+      side_effects: {
+        provider_generation: false,
+        upload: false,
+        publish: false,
+        schedule: false,
+        external_post: false,
+      },
+    })
+  } catch (error) {
+    console.error('[social-insight-research-packets] link failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to link research packets' },
+      { status: 500 },
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- Add an admin-only endpoint to link approved public research packets to central Shaka social-topic work items.
- Add Content Intelligence controls for selecting a research packet and Shaka insight without provider, upload, schedule, or publish side effects.
- Show approved research patterns on the Social Insight detail page so channel tabs can inherit transparent source patterns.

## Validation
- npm test -- --run app/admin/agents/content-intelligence/page.test.tsx 'app/admin/agents/social-insights/[id]/page.test.tsx' 'app/api/admin/agents/work-items/[id]/research-packets/route.test.ts' 'app/api/admin/agents/work-items/[id]/social-channels/[channel]/route.test.ts' app/api/admin/social-content/intelligence/research-packets/route.test.ts
- npx tsc --noEmit --pretty false
- git diff --check
- Browser smoke: http://127.0.0.1:3028/admin/agents/content-intelligence rendered behind admin auth; evidence Source URL field accepted input; no framework overlay; only pre-existing shared admin image-position warnings observed.
- Pre-push database health check passed.

## Integration Notes
- No migrations or env changes.
- No Apify runs, provider sends, uploads, scheduling, publishing, or external posts fired.
- Vercel contexts for Integration Captain to verify after merge: Vercel – portfolio and Vercel – portfolio-staging.