### PR TITLE
feat: add social intelligence daily digest

### DIFF
--- a/app/admin/agents/content-intelligence/page.test.tsx
+++ b/app/admin/agents/content-intelligence/page.test.tsx
@@ -41,6 +41,86 @@ describe('ContentIntelligencePage', () => {
           }),
         }
       }
+      if (url.startsWith('/api/admin/social-content/intelligence/daily-digest')) {
+        return {
+          ok: true,
+          json: async () => ({
+            digest: {
+              generated_at: '2026-06-23T12:00:00.000Z',
+              lookback_days: 5,
+              summary: {
+                new_research_packets: 1,
+                usable_patterns: 1,
+                shaka_insights: 1,
+                blocked_or_sensitive_items: 1,
+              },
+              strongest_patterns: [
+                {
+                  packet_id: 'packet-1',
+                  title: 'Outlier research process',
+                  source_url: 'https://youtube.com/watch?v=abc',
+                  platform: 'youtube',
+                  creator: 'Creator',
+                  outlier_score: 87,
+                  pattern_status: 'needs_brand_translation',
+                  hook_structure: 'The first 30 seconds make the promise clear.',
+                  promise_value: 'Clear public research process',
+                  thumbnail_pattern: 'High contrast proof frame.',
+                },
+              ],
+              recommended_insights: [
+                {
+                  work_item_id: 'work-social-1',
+                  title: 'Approval gates create trust',
+                  status: 'proposed',
+                  priority: 'high',
+                  triggering_event: 'A shipped review gate changed the work.',
+                  why_vambah_can_speak: 'Vambah built the system.',
+                  sensitivity: 'needs_review',
+                },
+              ],
+              suggested_channel_lanes: [
+                {
+                  work_item_id: 'work-social-1',
+                  insight_title: 'Approval gates create trust',
+                  channel: 'youtube_shorts',
+                  label: 'YouTube Shorts',
+                  status: 'not_started',
+                  required_inputs: ['hook', 'script'],
+                },
+              ],
+              thumbnail_opportunities: [
+                {
+                  packet_id: 'packet-1',
+                  title: 'Outlier research process',
+                  thumbnail_pattern: 'High contrast proof frame.',
+                },
+              ],
+              blocked_or_sensitive_items: [
+                {
+                  type: 'shaka_insight',
+                  id: 'work-social-1',
+                  title: 'Approval gates create trust',
+                  reason: 'needs_review',
+                },
+              ],
+              governance: {
+                schedule_activation: 'approval_required',
+                apify_collection: 'approval_required',
+                publishing: 'approval_required',
+              },
+              side_effects: {
+                provider_generation: false,
+                upload: false,
+                publish: false,
+                schedule: false,
+                external_post: false,
+                apify_run: false,
+              },
+            },
+          }),
+        }
+      }
       if (url.startsWith('/api/admin/social-content/intelligence/research-packets')) {
         return {
           ok: true,
@@ -105,10 +185,15 @@ describe('ContentIntelligencePage', () => {
     expect(screen.getByRole('heading', { name: 'Free-first evidence layer' })).toBeInTheDocument()
     expect(screen.getByText('Recorded public evidence from Codex/browser review. Cost: $0.')).toBeInTheDocument()
     expect(screen.getByText('pintostudio/youtube-transcript-scraper only after cost approval')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'What Shaka should review next' })).toBeInTheDocument()
+    expect(screen.getByText('Schedule: approval required')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Strongest patterns' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Channel lanes' })).toBeInTheDocument()
+    expect(screen.getByText('YouTube Shorts: Approval gates create trust')).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: 'Add recorded public evidence' })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: 'Link pattern to Shaka insight' })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: 'Outlier research process' })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /Approval gates create trust/ })).toHaveAttribute('href', '/admin/agents/social-insights/work-social-1')
+    expect(screen.getAllByRole('link', { name: /Approval gates create trust/ }).map((link) => link.getAttribute('href'))).toContain('/admin/agents/social-insights/work-social-1')
   })
 
   it('stores recorded evidence without paid scraper fields', async () => {

--- a/app/admin/agents/content-intelligence/page.tsx
+++ b/app/admin/agents/content-intelligence/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { type FormEvent, useCallback, useEffect, useMemo, useState } from 'react'
 import {
   BarChart3,
+  CalendarDays,
   CheckCircle2,
   Database,
   ExternalLink,
@@ -49,6 +50,59 @@ type EvidenceForm = {
   comments: string
   follower_count: string
   retrieval_notes: string
+}
+
+type DailyDigest = {
+  generated_at: string
+  lookback_days: number
+  summary: {
+    new_research_packets: number
+    usable_patterns: number
+    shaka_insights: number
+    blocked_or_sensitive_items: number
+  }
+  strongest_patterns: Array<{
+    packet_id: string
+    title: string
+    source_url: string
+    platform: string
+    creator: string | null
+    outlier_score: number
+    pattern_status: string
+    hook_structure: string | null
+    promise_value: string | null
+    thumbnail_pattern: string | null
+  }>
+  recommended_insights: Array<{
+    work_item_id: string
+    title: string
+    status: string
+    priority: string
+    triggering_event: string | null
+    why_vambah_can_speak: string | null
+    sensitivity: string
+  }>
+  suggested_channel_lanes: Array<{
+    work_item_id: string
+    insight_title: string
+    channel: string
+    label: string
+    status: string
+    required_inputs: string[]
+  }>
+  thumbnail_opportunities: Array<{
+    packet_id: string
+    title: string
+    thumbnail_pattern: string | null
+  }>
+  blocked_or_sensitive_items: Array<{
+    type: string
+    id: string
+    title: string
+    reason: string
+  }>
+  governance: Record<string, string>
+  side_effects: Record<string, boolean>
 }
 
 const EMPTY_EVIDENCE_FORM: EvidenceForm = {
@@ -120,6 +174,7 @@ function ContentIntelligenceContent() {
   const [linkDecisionNote, setLinkDecisionNote] = useState('')
   const [linkingPattern, setLinkingPattern] = useState(false)
   const [linkNotice, setLinkNotice] = useState<string | null>(null)
+  const [digest, setDigest] = useState<DailyDigest | null>(null)
 
   const authedFetch = useCallback(async (path: string, init: RequestInit = {}) => {
     const session = await getCurrentSession()
@@ -139,20 +194,25 @@ function ContentIntelligenceContent() {
     setLoading(true)
     setError(null)
     try {
-      const [packetResponse, insightResponse] = await Promise.all([
+      const [packetResponse, insightResponse, digestResponse] = await Promise.all([
         authedFetch('/api/admin/social-content/intelligence/research-packets?limit=12'),
         authedFetch('/api/admin/agents/work-items?source_type=social_topic_trigger&limit=12'),
+        authedFetch('/api/admin/social-content/intelligence/daily-digest?lookback_days=5&limit=12'),
       ])
       const packetBody = await packetResponse.json().catch(() => ({}))
       const insightBody = await insightResponse.json().catch(() => ({}))
+      const digestBody = await digestResponse.json().catch(() => ({}))
       if (!packetResponse.ok) throw new Error(packetBody.error || `Research packets HTTP ${packetResponse.status}`)
       if (!insightResponse.ok) throw new Error(insightBody.error || `Insights HTTP ${insightResponse.status}`)
+      if (!digestResponse.ok) throw new Error(digestBody.error || `Digest HTTP ${digestResponse.status}`)
       setPackets(Array.isArray(packetBody.packets) ? packetBody.packets : [])
       setInsights(Array.isArray(insightBody.work_items) ? insightBody.work_items : [])
+      setDigest(digestBody.digest ?? null)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load Content Intelligence')
       setPackets([])
       setInsights([])
+      setDigest(null)
     } finally {
       setLoading(false)
     }
@@ -298,6 +358,90 @@ function ContentIntelligenceContent() {
           <MetricCard label="Top outlier score" value={strongestPacket ? Math.round(Number(strongestPacket.outlier_score)) : 0} />
           <MetricCard label="Paid scraper runs" value={0} tone="amber" />
         </div>
+
+        <section className="agent-ops-card mb-6 rounded-lg border p-4">
+          <div className="mb-4 flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+            <div>
+              <div className="agent-ops-eyebrow mb-2">
+                <CalendarDays size={16} />
+                Daily review digest
+              </div>
+              <h2 className="text-lg font-semibold">What Shaka should review next</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Read-only digest from public research and central backlog items. Activation, drafting, media generation, upload, schedule, and publish gates stay locked.
+              </p>
+            </div>
+            <span className="inline-flex w-fit items-center gap-2 rounded-full border border-emerald-500/35 bg-emerald-500/10 px-3 py-1 text-xs font-semibold text-emerald-100">
+              <ShieldCheck className="h-3.5 w-3.5" />
+              No side effects
+            </span>
+          </div>
+          {digest ? (
+            <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(20rem,0.45fr)]">
+              <div className="grid gap-3 md:grid-cols-4">
+                <DigestMetric label="New research" value={digest.summary.new_research_packets} />
+                <DigestMetric label="Usable patterns" value={digest.summary.usable_patterns} />
+                <DigestMetric label="Insights" value={digest.summary.shaka_insights} />
+                <DigestMetric label="Blocked/privacy" value={digest.summary.blocked_or_sensitive_items} tone="amber" />
+              </div>
+              <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-3">
+                <p className="text-xs uppercase tracking-wide text-muted-foreground">Governance</p>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  <DigestPill label="Schedule" value={digest.governance.schedule_activation} />
+                  <DigestPill label="Apify" value={digest.governance.apify_collection} />
+                  <DigestPill label="Publish" value={digest.governance.publishing} />
+                </div>
+              </div>
+              <DigestList
+                title="Strongest patterns"
+                empty="No usable patterns in the current lookback."
+                items={digest.strongest_patterns.map((pattern) => ({
+                  id: pattern.packet_id,
+                  title: pattern.title,
+                  detail: pattern.hook_structure ?? pattern.promise_value ?? pattern.pattern_status,
+                  href: pattern.source_url,
+                  meta: `Outlier ${Math.round(Number(pattern.outlier_score))}`,
+                }))}
+              />
+              <DigestList
+                title="Recommended insights"
+                empty="No Shaka insight backlog items found."
+                items={digest.recommended_insights.map((insight) => ({
+                  id: insight.work_item_id,
+                  title: insight.title,
+                  detail: insight.why_vambah_can_speak ?? insight.triggering_event ?? insight.sensitivity,
+                  href: `/admin/agents/social-insights/${insight.work_item_id}`,
+                  meta: insight.status.replace(/_/g, ' '),
+                }))}
+              />
+              <DigestList
+                title="Channel lanes"
+                empty="No channel lane suggestions yet."
+                items={digest.suggested_channel_lanes.slice(0, 4).map((lane) => ({
+                  id: `${lane.work_item_id}-${lane.channel}`,
+                  title: `${lane.label}: ${lane.insight_title}`,
+                  detail: lane.required_inputs.join(', '),
+                  href: `/admin/agents/social-insights/${lane.work_item_id}`,
+                  meta: lane.status.replace(/_/g, ' '),
+                }))}
+              />
+              <DigestList
+                title="Thumbnail opportunities"
+                empty="No thumbnail opportunities in the current lookback."
+                items={digest.thumbnail_opportunities.map((item) => ({
+                  id: item.packet_id,
+                  title: item.title,
+                  detail: item.thumbnail_pattern ?? 'Review source thumbnail pattern.',
+                  meta: 'thumbnail',
+                }))}
+              />
+            </div>
+          ) : (
+            <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 px-4 py-8 text-center text-sm text-muted-foreground">
+              {loading ? 'Loading daily digest...' : 'Daily digest is not available yet.'}
+            </div>
+          )}
+        </section>
 
         <section className="agent-ops-card mb-6 rounded-lg border p-4">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
@@ -570,6 +714,67 @@ function MetricCard({ label, value, tone = 'slate' }: { label: string; value: nu
     <div className={`rounded-lg border p-4 ${tone === 'amber' ? 'border-amber-500/30 bg-amber-500/10' : 'border-silicon-slate/70 bg-silicon-slate/20'}`}>
       <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
       <p className="mt-2 text-2xl font-semibold">{value}</p>
+    </div>
+  )
+}
+
+function DigestMetric({ label, value, tone = 'slate' }: { label: string; value: number; tone?: 'slate' | 'amber' }) {
+  return (
+    <div className={`rounded-lg border p-3 ${tone === 'amber' ? 'border-amber-500/30 bg-amber-500/10' : 'border-silicon-slate/70 bg-background/40'}`}>
+      <p className="text-[0.68rem] uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="mt-1 text-xl font-semibold">{value}</p>
+    </div>
+  )
+}
+
+function DigestPill({ label, value }: { label: string; value: string }) {
+  return (
+    <span className="inline-flex rounded-full border border-amber-500/35 bg-amber-500/10 px-2.5 py-1 text-xs text-amber-100">
+      {label}: {value.replace(/_/g, ' ')}
+    </span>
+  )
+}
+
+function DigestList({
+  title,
+  empty,
+  items,
+}: {
+  title: string
+  empty: string
+  items: Array<{ id: string; title: string; detail: string | null; meta?: string; href?: string }>
+}) {
+  return (
+    <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-3">
+      <h3 className="text-sm font-semibold">{title}</h3>
+      <div className="mt-3 space-y-2">
+        {items.length ? items.map((item) => {
+          const body = (
+            <>
+              <div className="flex items-start justify-between gap-3">
+                <p className="text-sm font-medium">{item.title}</p>
+                {item.meta ? (
+                  <span className="shrink-0 rounded-full border border-silicon-slate/70 px-2 py-0.5 text-[0.68rem] text-muted-foreground">
+                    {item.meta}
+                  </span>
+                ) : null}
+              </div>
+              {item.detail ? <p className="mt-1 line-clamp-2 text-xs leading-5 text-muted-foreground">{item.detail}</p> : null}
+            </>
+          )
+          return item.href ? (
+            <Link key={item.id} href={item.href} className="block rounded-md border border-silicon-slate/60 bg-background/35 p-2 transition hover:border-radiant-gold/45">
+              {body}
+            </Link>
+          ) : (
+            <div key={item.id} className="rounded-md border border-silicon-slate/60 bg-background/35 p-2">
+              {body}
+            </div>
+          )
+        }) : (
+          <p className="rounded-md border border-silicon-slate/60 bg-background/35 p-3 text-xs text-muted-foreground">{empty}</p>
+        )}
+      </div>
     </div>
   )
 }

--- a/app/api/admin/social-content/intelligence/daily-digest/route.test.ts
+++ b/app/api/admin/social-content/intelligence/daily-digest/route.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  listAgentWorkItems: vi.fn(),
+  from: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-work-items', () => ({
+  listAgentWorkItems: mocks.listAgentWorkItems,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import { GET } from './route'
+
+function request(url = 'http://localhost/api/admin/social-content/intelligence/daily-digest') {
+  return new Request(url, {
+    headers: { authorization: 'Bearer admin-token' },
+  })
+}
+
+const packets = [
+  {
+    id: 'packet-1',
+    source_url: 'https://youtube.com/watch?v=abc',
+    platform: 'youtube',
+    creator_name: 'Creator',
+    creator_handle: '@creator',
+    title: 'Approval gate outlier',
+    hook_transcript: 'Start with the moment the workflow broke.',
+    thumbnail_url: 'https://example.com/thumb.jpg',
+    outlier_score: 91,
+    pattern_status: 'usable_framework',
+    pattern_packet: {
+      hook_structure: 'Open with the broken approval path.',
+      promise_value: 'Show how trust gets built.',
+      thumbnail_pattern: 'High contrast before and after frame.',
+    },
+    privacy_notes: 'Public pattern only.',
+    retrieved_at: '2026-06-23T10:00:00.000Z',
+    status: 'review_ready',
+  },
+  {
+    id: 'packet-2',
+    source_url: 'https://youtube.com/watch?v=copy',
+    platform: 'youtube',
+    creator_name: 'Too Close',
+    title: 'Do not use directly',
+    outlier_score: 88,
+    pattern_status: 'too_close_to_source',
+    pattern_packet: {},
+    retrieved_at: '2026-06-23T09:00:00.000Z',
+    status: 'review_ready',
+  },
+]
+
+const workItems = [
+  {
+    id: 'work-1',
+    title: 'Approval gates create trust',
+    status: 'proposed',
+    priority: 'high',
+    source_type: 'social_topic_trigger',
+    metadata: {
+      channel_lanes: {
+        linkedin: { status: 'not_started', label: 'LinkedIn', required_inputs: ['post text', 'CTA'] },
+        youtube_shorts: { status: 'blocked', label: 'YouTube Shorts', required_inputs: ['hook', 'script'] },
+        instagram_reels: { status: 'not_started', label: 'Instagram Reels', required_inputs: ['hook', 'caption'] },
+        thumbnail: { status: 'not_started', label: 'Thumbnail', required_inputs: ['short thumbnail text', '2-3 variants'] },
+      },
+      insight: {
+        title: 'Approval gates create trust',
+        triggering_event: 'A shipped review gate changed the work.',
+        why_vambah_can_speak: 'Vambah built the system.',
+        audience: 'operators',
+        sensitivity: 'needs_review',
+      },
+    },
+  },
+]
+
+function mockPacketQuery(packetRows = packets) {
+  const limit = vi.fn(async () => ({ data: packetRows, error: null }))
+  const orderSecond = vi.fn(() => ({ limit }))
+  const orderFirst = vi.fn(() => ({ order: orderSecond }))
+  const gte = vi.fn(() => ({ order: orderFirst }))
+  const select = vi.fn(() => ({ gte }))
+  mocks.from.mockReturnValue({ select })
+  return { select, gte, orderFirst, orderSecond, limit }
+}
+
+describe('/api/admin/social-content/intelligence/daily-digest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user', email: 'admin@example.com' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.listAgentWorkItems.mockResolvedValue(workItems)
+    mockPacketQuery()
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await GET(request() as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.from).not.toHaveBeenCalled()
+  })
+
+  it('builds a read-only daily digest from public research and Shaka insights', async () => {
+    const query = mockPacketQuery()
+
+    const response = await GET(request('http://localhost/api/admin/social-content/intelligence/daily-digest?lookback_days=5&limit=12') as never)
+
+    expect(response.status).toBe(200)
+    expect(mocks.from).toHaveBeenCalledWith('social_content_research_packets')
+    expect(query.gte).toHaveBeenCalledWith('retrieved_at', expect.any(String))
+    expect(mocks.listAgentWorkItems).toHaveBeenCalledWith({
+      sourceType: 'social_topic_trigger',
+      limit: 12,
+    })
+
+    const body = await response.json()
+    expect(body.digest.summary).toEqual({
+      new_research_packets: 2,
+      usable_patterns: 1,
+      shaka_insights: 1,
+      blocked_or_sensitive_items: 2,
+    })
+    expect(body.digest.strongest_patterns).toEqual([
+      expect.objectContaining({
+        packet_id: 'packet-1',
+        title: 'Approval gate outlier',
+        outlier_score: 91,
+        hook_structure: 'Open with the broken approval path.',
+      }),
+    ])
+    expect(body.digest.recommended_insights).toEqual([
+      expect.objectContaining({
+        work_item_id: 'work-1',
+        title: 'Approval gates create trust',
+        why_vambah_can_speak: 'Vambah built the system.',
+      }),
+    ])
+    expect(body.digest.suggested_channel_lanes).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        work_item_id: 'work-1',
+        channel: 'youtube_shorts',
+        status: 'blocked',
+      }),
+      expect.objectContaining({
+        channel: 'thumbnail',
+        label: 'Thumbnail',
+      }),
+    ]))
+    expect(body.digest.thumbnail_opportunities).toHaveLength(1)
+    expect(body.digest.blocked_or_sensitive_items).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: 'research_packet',
+        id: 'packet-2',
+        reason: 'too_close_to_source',
+      }),
+      expect.objectContaining({
+        type: 'shaka_insight',
+        id: 'work-1',
+        reason: 'needs_review',
+      }),
+    ]))
+    expect(body.digest.side_effects).toEqual({
+      provider_generation: false,
+      upload: false,
+      publish: false,
+      schedule: false,
+      external_post: false,
+      apify_run: false,
+    })
+    expect(body.digest.governance.schedule_activation).toBe('approval_required')
+  })
+})

--- a/app/api/admin/social-content/intelligence/daily-digest/route.ts
+++ b/app/api/admin/social-content/intelligence/daily-digest/route.ts
@@ -1,0 +1,188 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { listAgentWorkItems, type AgentWorkItem } from '@/lib/agent-work-items'
+import {
+  normalizeSocialChannelLanes,
+  SOCIAL_CONTENT_INTELLIGENCE_CHANNELS,
+  SOCIAL_TOPIC_TRIGGER_SOURCE_TYPE,
+  socialChannelLabel,
+  type SocialContentIntelligenceChannel,
+} from '@/lib/social-content-intelligence'
+import { supabaseAdmin } from '@/lib/supabase'
+
+export const dynamic = 'force-dynamic'
+
+type ResearchPacketRow = Record<string, unknown>
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
+}
+
+function asString(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function asNumber(value: unknown) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0
+}
+
+function isBlockedPattern(packet: ResearchPacketRow) {
+  const status = asString(packet.status)
+  const patternStatus = asString(packet.pattern_status)
+  return status === 'rejected'
+    || status === 'archived'
+    || patternStatus === 'too_close_to_source'
+    || patternStatus === 'not_relevant'
+}
+
+function packetTitle(packet: ResearchPacketRow) {
+  return asString(packet.title)
+    || asString(packet.caption)
+    || asString(packet.creator_name)
+    || asString(packet.source_url)
+    || 'Untitled research packet'
+}
+
+function compactPattern(packet: ResearchPacketRow) {
+  const pattern = asRecord(packet.pattern_packet)
+  return {
+    packet_id: asString(packet.id),
+    title: packetTitle(packet),
+    source_url: asString(packet.source_url),
+    platform: asString(packet.platform) || 'other',
+    creator: asString(packet.creator_name) || asString(packet.creator_handle) || null,
+    outlier_score: asNumber(packet.outlier_score),
+    pattern_status: asString(packet.pattern_status) || 'needs_brand_translation',
+    hook_structure: asString(pattern.hook_structure) || asString(packet.hook_transcript) || null,
+    promise_value: asString(pattern.promise_value) || null,
+    thumbnail_pattern: asString(pattern.thumbnail_pattern) || null,
+  }
+}
+
+function insightFor(item: AgentWorkItem) {
+  const insight = asRecord(item.metadata?.insight)
+  return {
+    work_item_id: item.id,
+    title: asString(insight.title) || item.title,
+    status: item.status,
+    priority: item.priority,
+    triggering_event: asString(insight.triggering_event) || null,
+    why_vambah_can_speak: asString(insight.why_vambah_can_speak) || null,
+    audience: asString(insight.audience) || null,
+    sensitivity: asString(insight.sensitivity) || 'needs_review',
+  }
+}
+
+function laneSuggestions(items: AgentWorkItem[]) {
+  return SOCIAL_CONTENT_INTELLIGENCE_CHANNELS.flatMap((channel: SocialContentIntelligenceChannel) => {
+    return items
+      .map((item) => {
+        const lanes = normalizeSocialChannelLanes(item.metadata?.channel_lanes)
+        const lane = lanes[channel]
+        if (lane.status === 'approved') return null
+        return {
+          work_item_id: item.id,
+          insight_title: insightFor(item).title,
+          channel,
+          label: socialChannelLabel(channel),
+          status: lane.status,
+          required_inputs: lane.required_inputs.slice(0, 4),
+        }
+      })
+      .filter((value): value is NonNullable<typeof value> => Boolean(value))
+      .slice(0, 4)
+  })
+}
+
+export async function GET(request: NextRequest) {
+  const authResult = await verifyAdmin(request)
+  if (isAuthError(authResult)) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status })
+  }
+
+  const { searchParams } = new URL(request.url)
+  const lookbackDays = Math.min(Math.max(parseInt(searchParams.get('lookback_days') || '5', 10), 1), 30)
+  const limit = Math.min(Math.max(parseInt(searchParams.get('limit') || '12', 10), 1), 25)
+  const since = new Date(Date.now() - lookbackDays * 86_400_000).toISOString()
+
+  try {
+    const [{ data: packetData, error: packetError }, workItems] = await Promise.all([
+      supabaseAdmin
+        .from('social_content_research_packets')
+        .select('id, source_url, platform, creator_name, creator_handle, title, caption, hook_transcript, thumbnail_url, outlier_score, pattern_status, pattern_packet, privacy_notes, retrieved_at, status')
+        .gte('retrieved_at', since)
+        .order('outlier_score', { ascending: false })
+        .order('retrieved_at', { ascending: false })
+        .limit(limit),
+      listAgentWorkItems({
+        sourceType: SOCIAL_TOPIC_TRIGGER_SOURCE_TYPE,
+        limit,
+      }),
+    ])
+
+    if (packetError) throw new Error(packetError.message)
+
+    const packets = ((packetData ?? []) as unknown[]).map((packet) => asRecord(packet))
+    const usablePackets = packets.filter((packet) => !isBlockedPattern(packet))
+    const blockedPackets = packets.filter(isBlockedPattern)
+    const insights = workItems.map(insightFor)
+    const sensitiveInsights = insights.filter((insight) => insight.sensitivity !== 'public_safe' && insight.sensitivity !== 'low')
+
+    return NextResponse.json({
+      digest: {
+        generated_at: new Date().toISOString(),
+        lookback_days: lookbackDays,
+        retrieval_window_start: since,
+        summary: {
+          new_research_packets: packets.length,
+          usable_patterns: usablePackets.length,
+          shaka_insights: workItems.length,
+          blocked_or_sensitive_items: blockedPackets.length + sensitiveInsights.length,
+        },
+        strongest_patterns: usablePackets.slice(0, 5).map(compactPattern),
+        recommended_insights: insights.slice(0, 5),
+        suggested_channel_lanes: laneSuggestions(workItems).slice(0, 8),
+        thumbnail_opportunities: usablePackets
+          .filter((packet) => asString(packet.thumbnail_url) || asString(asRecord(packet.pattern_packet).thumbnail_pattern))
+          .slice(0, 4)
+          .map(compactPattern),
+        blocked_or_sensitive_items: [
+          ...blockedPackets.slice(0, 4).map((packet) => ({
+            type: 'research_packet',
+            id: asString(packet.id),
+            title: packetTitle(packet),
+            reason: asString(packet.pattern_status) || asString(packet.status) || 'blocked',
+          })),
+          ...sensitiveInsights.slice(0, 4).map((insight) => ({
+            type: 'shaka_insight',
+            id: insight.work_item_id,
+            title: insight.title,
+            reason: insight.sensitivity,
+          })),
+        ],
+        governance: {
+          schedule_activation: 'approval_required',
+          apify_collection: 'approval_required',
+          drafting: 'approval_required',
+          media_generation: 'approval_required',
+          uploads: 'approval_required',
+          publishing: 'approval_required',
+        },
+        side_effects: {
+          provider_generation: false,
+          upload: false,
+          publish: false,
+          schedule: false,
+          external_post: false,
+          apify_run: false,
+        },
+      },
+    })
+  } catch (error) {
+    console.error('[social-content-intelligence] daily digest failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to build Content Intelligence digest' },
+      { status: 500 },
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- Add a read-only Content Intelligence daily digest API that summarizes recent public research packets, central Shaka insights, channel lane suggestions, thumbnail opportunities, and privacy blockers.
- Surface the digest on the Content Intelligence dashboard with governance pills for schedule, Apify, and publishing approval gates.
- Preserve the free-first/review-only model: no paid scraper run, provider generation, upload, schedule, publish, or external post is triggered.

## Validation
- npm test -- --run app/admin/agents/content-intelligence/page.test.tsx app/api/admin/social-content/intelligence/daily-digest/route.test.ts app/api/admin/social-content/intelligence/research-packets/route.test.ts 'app/api/admin/agents/work-items/[id]/research-packets/route.test.ts'
- npx tsc --noEmit --pretty false
- git diff --check
- Browser smoke: http://127.0.0.1:3029/admin/agents/content-intelligence rendered the daily digest panel behind admin auth; governance pills and no-side-effects badge were visible; no framework overlay. Existing shared admin image-position warnings were still present.
- Pre-push database health check passed.

## Integration Notes
- No migrations or env changes.
- No Apify runs, provider sends, uploads, scheduling, publishing, or external posts fired.
- Vercel contexts for Integration Captain to verify after merge: Vercel – portfolio and Vercel – portfolio-staging.