### PR TITLE
feat: request social intelligence digest activation

### DIFF
--- a/app/admin/agents/content-intelligence/page.test.tsx
+++ b/app/admin/agents/content-intelligence/page.test.tsx
@@ -41,6 +41,29 @@ describe('ContentIntelligencePage', () => {
           }),
         }
       }
+      if (url === '/api/admin/social-content/intelligence/daily-digest/activation-request') {
+        return {
+          ok: true,
+          json: async () => ({
+            ok: true,
+            work_item: {
+              id: 'work-digest-activation',
+              title: 'Approve daily Social Content Intelligence digest activation',
+            },
+            activation_requested: true,
+            activation_executed: false,
+            side_effects: {
+              cron_activated: false,
+              apify_run: false,
+              provider_generation: false,
+              upload: false,
+              schedule: false,
+              publish: false,
+              external_post: false,
+            },
+          }),
+        }
+      }
       if (url.startsWith('/api/admin/social-content/intelligence/daily-digest')) {
         return {
           ok: true,
@@ -187,6 +210,7 @@ describe('ContentIntelligencePage', () => {
     expect(screen.getByText('pintostudio/youtube-transcript-scraper only after cost approval')).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: 'What Shaka should review next' })).toBeInTheDocument()
     expect(screen.getByText('Schedule: approval required')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Request Daily Activation Review' })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: 'Strongest patterns' })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: 'Channel lanes' })).toBeInTheDocument()
     expect(screen.getByText('YouTube Shorts: Approval gates create trust')).toBeInTheDocument()
@@ -257,6 +281,28 @@ describe('ContentIntelligencePage', () => {
     expect(JSON.parse(String(linkCall?.[1]?.body))).toEqual({
       packet_ids: ['packet-1'],
       decision_note: 'Use the structure, not the source wording.',
+    })
+  })
+
+  it('requests daily digest activation review without enabling the schedule', async () => {
+    render(<ContentIntelligencePage />)
+
+    await screen.findByRole('heading', { name: 'What Shaka should review next' })
+
+    fireEvent.change(screen.getByLabelText('Activation review note'), {
+      target: { value: 'Start with free public research and Shaka internal triggers.' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Request Daily Activation Review' }))
+
+    await screen.findByText('Daily activation review added to Agentic Dashboard backlog.')
+
+    const activationCall = vi.mocked(fetch).mock.calls.find(([input]) => String(input) === '/api/admin/social-content/intelligence/daily-digest/activation-request')
+    expect(activationCall).toBeTruthy()
+    expect(activationCall?.[1]).toMatchObject({ method: 'POST' })
+    expect(JSON.parse(String(activationCall?.[1]?.body))).toEqual({
+      cadence: 'daily',
+      lookback_days: 5,
+      scope_note: 'Start with free public research and Shaka internal triggers.',
     })
   })
 })

--- a/app/admin/agents/content-intelligence/page.tsx
+++ b/app/admin/agents/content-intelligence/page.tsx
@@ -175,6 +175,9 @@ function ContentIntelligenceContent() {
   const [linkingPattern, setLinkingPattern] = useState(false)
   const [linkNotice, setLinkNotice] = useState<string | null>(null)
   const [digest, setDigest] = useState<DailyDigest | null>(null)
+  const [activationScopeNote, setActivationScopeNote] = useState('')
+  const [requestingActivation, setRequestingActivation] = useState(false)
+  const [activationNotice, setActivationNotice] = useState<string | null>(null)
 
   const authedFetch = useCallback(async (path: string, init: RequestInit = {}) => {
     const session = await getCurrentSession()
@@ -315,6 +318,31 @@ function ContentIntelligenceContent() {
     }
   }, [authedFetch, linkDecisionNote, load, selectedInsightId, selectedPacketId])
 
+  const requestDailyActivationReview = useCallback(async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError(null)
+    setActivationNotice(null)
+    setRequestingActivation(true)
+    try {
+      const response = await authedFetch('/api/admin/social-content/intelligence/daily-digest/activation-request', {
+        method: 'POST',
+        body: JSON.stringify({
+          cadence: 'daily',
+          lookback_days: digest?.lookback_days ?? 5,
+          scope_note: activationScopeNote.trim() || null,
+        }),
+      })
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body.error || `Activation request HTTP ${response.status}`)
+      setActivationScopeNote('')
+      setActivationNotice('Daily activation review added to Agentic Dashboard backlog.')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to request daily activation review')
+    } finally {
+      setRequestingActivation(false)
+    }
+  }, [activationScopeNote, authedFetch, digest?.lookback_days])
+
   return (
     <div className="agent-ops-page min-h-screen p-5 text-foreground lg:p-7">
       <div className="mx-auto max-w-7xl">
@@ -376,6 +404,36 @@ function ContentIntelligenceContent() {
               No side effects
             </span>
           </div>
+          <form onSubmit={requestDailyActivationReview} className="mb-4 rounded-lg border border-radiant-gold/35 bg-radiant-gold/10 p-3">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-end">
+              <label className="min-w-0 flex-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Activation review note
+                <input
+                  type="text"
+                  value={activationScopeNote}
+                  onChange={(event) => setActivationScopeNote(event.target.value)}
+                  placeholder="Optional scope guidance before Shaka reviews the daily run."
+                  className="mt-1 w-full rounded-md border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm normal-case tracking-normal text-foreground"
+                />
+              </label>
+              <button
+                type="submit"
+                disabled={requestingActivation}
+                className="agent-ops-button-primary shrink-0 disabled:opacity-60"
+              >
+                <CheckCircle2 size={16} />
+                {requestingActivation ? 'Requesting...' : 'Request Daily Activation Review'}
+              </button>
+            </div>
+            <p className="mt-2 text-xs leading-5 text-muted-foreground">
+              Creates a backlog review item only. Cron activation, Apify collection, drafting, media, uploads, scheduling, and publishing remain locked.
+            </p>
+            {activationNotice ? (
+              <p className="mt-2 rounded-md border border-emerald-500/35 bg-emerald-500/10 px-3 py-2 text-xs font-semibold text-emerald-100">
+                {activationNotice}
+              </p>
+            ) : null}
+          </form>
           {digest ? (
             <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(20rem,0.45fr)]">
               <div className="grid gap-3 md:grid-cols-4">

--- a/app/api/admin/social-content/intelligence/daily-digest/activation-request/route.test.ts
+++ b/app/api/admin/social-content/intelligence/daily-digest/activation-request/route.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  createAgentWorkItem: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-work-items', () => ({
+  createAgentWorkItem: mocks.createAgentWorkItem,
+}))
+
+import { POST } from './route'
+
+function request(body: Record<string, unknown> = {}) {
+  return new Request('http://localhost/api/admin/social-content/intelligence/daily-digest/activation-request', {
+    method: 'POST',
+    headers: { authorization: 'Bearer admin-token', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('/api/admin/social-content/intelligence/daily-digest/activation-request', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user', email: 'admin@example.com' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.createAgentWorkItem.mockResolvedValue({
+      id: 'work-digest-activation',
+      title: 'Approve daily Social Content Intelligence digest activation',
+      status: 'queued',
+    })
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(request() as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.createAgentWorkItem).not.toHaveBeenCalled()
+  })
+
+  it('rejects unsupported cadence before creating a work item', async () => {
+    const response = await POST(request({ cadence: 'hourly' }) as never)
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: 'Only daily cadence is supported for this activation request',
+    })
+    expect(mocks.createAgentWorkItem).not.toHaveBeenCalled()
+  })
+
+  it('creates an approval-gated Agentic Dashboard work item without activating the schedule', async () => {
+    const response = await POST(request({
+      cadence: 'daily',
+      lookback_days: 7,
+      scope_note: 'Start with public YouTube and internal Shaka triggers.',
+    }) as never)
+
+    expect(response.status).toBe(200)
+    expect(mocks.createAgentWorkItem).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'Approve daily Social Content Intelligence digest activation',
+      priority: 'high',
+      status: 'queued',
+      ownerAgentKey: 'chief-of-staff',
+      ownerRuntime: 'codex',
+      source: {
+        type: 'social_intelligence_daily_digest_activation',
+        id: 'daily-social-content-intelligence',
+        label: 'Content Intelligence daily digest activation review',
+      },
+      metadata: expect.objectContaining({
+        requested_by_user_id: 'admin-user',
+        requested_by_email: 'admin@example.com',
+        cadence: 'daily',
+        lookback_days: 7,
+        scope_note: 'Start with public YouTube and internal Shaka triggers.',
+        activation_boundary: expect.objectContaining({
+          schedule_activation: 'approval_required',
+          apify_collection: 'approval_required',
+          publishing: 'approval_required',
+        }),
+        side_effects: {
+          cron_activated: false,
+          apify_run: false,
+          provider_generation: false,
+          upload: false,
+          schedule: false,
+          publish: false,
+          external_post: false,
+        },
+      }),
+      idempotencyKey: 'social-intelligence-daily-digest-activation:daily:7',
+    }))
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      work_item: { id: 'work-digest-activation' },
+      activation_requested: true,
+      activation_executed: false,
+      side_effects: {
+        cron_activated: false,
+        apify_run: false,
+        provider_generation: false,
+        upload: false,
+        schedule: false,
+        publish: false,
+        external_post: false,
+      },
+    })
+  })
+})

--- a/app/api/admin/social-content/intelligence/daily-digest/activation-request/route.ts
+++ b/app/api/admin/social-content/intelligence/daily-digest/activation-request/route.ts
@@ -1,0 +1,103 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { createAgentWorkItem } from '@/lib/agent-work-items'
+
+export const dynamic = 'force-dynamic'
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
+}
+
+function asString(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function asPositiveInteger(value: unknown, fallback: number, max: number) {
+  const parsed = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN
+  if (!Number.isInteger(parsed) || parsed < 1) return fallback
+  return Math.min(parsed, max)
+}
+
+export async function POST(request: NextRequest) {
+  const authResult = await verifyAdmin(request)
+  if (isAuthError(authResult)) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status })
+  }
+
+  const body = asRecord(await request.json().catch(() => ({})))
+  const cadence = asString(body.cadence) || 'daily'
+  if (cadence !== 'daily') {
+    return NextResponse.json({ error: 'Only daily cadence is supported for this activation request' }, { status: 400 })
+  }
+  const lookbackDays = asPositiveInteger(body.lookback_days, 5, 30)
+  const scopeNote = asString(body.scope_note)
+
+  try {
+    const workItem = await createAgentWorkItem({
+      title: 'Approve daily Social Content Intelligence digest activation',
+      objective: [
+        `Review whether Shaka should run a ${cadence} Social Content Intelligence digest.`,
+        `Default lookback window: ${lookbackDays} day(s).`,
+        'Scope: summarize public creator research, Shaka internal insight triggers, suggested channel lanes, thumbnail opportunities, and privacy blockers into the Agentic Dashboard.',
+        'Approval boundary: this work item does not activate cron, run Apify, generate drafts, generate media, upload assets, schedule posts, or publish externally.',
+        scopeNote ? `Operator note: ${scopeNote}` : null,
+      ].filter(Boolean).join('\n'),
+      priority: 'high',
+      status: 'queued',
+      ownerAgentKey: 'chief-of-staff',
+      ownerRuntime: 'codex',
+      source: {
+        type: 'social_intelligence_daily_digest_activation',
+        id: 'daily-social-content-intelligence',
+        label: 'Content Intelligence daily digest activation review',
+      },
+      metadata: {
+        requested_by_user_id: authResult.user.id,
+        requested_by_email: authResult.user.email ?? null,
+        cadence,
+        lookback_days: lookbackDays,
+        scope_note: scopeNote || null,
+        activation_boundary: {
+          schedule_activation: 'approval_required',
+          apify_collection: 'approval_required',
+          drafting: 'approval_required',
+          media_generation: 'approval_required',
+          uploads: 'approval_required',
+          publishing: 'approval_required',
+        },
+        side_effects: {
+          cron_activated: false,
+          apify_run: false,
+          provider_generation: false,
+          upload: false,
+          schedule: false,
+          publish: false,
+          external_post: false,
+        },
+      },
+      idempotencyKey: `social-intelligence-daily-digest-activation:${cadence}:${lookbackDays}`,
+    })
+
+    return NextResponse.json({
+      ok: true,
+      work_item: workItem,
+      activation_requested: true,
+      activation_executed: false,
+      side_effects: {
+        cron_activated: false,
+        apify_run: false,
+        provider_generation: false,
+        upload: false,
+        schedule: false,
+        publish: false,
+        external_post: false,
+      },
+    })
+  } catch (error) {
+    console.error('[social-content-intelligence] activation request failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to request daily digest activation review' },
+      { status: 500 },
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- Add an admin-only Social Content Intelligence daily digest activation request endpoint.
- Create an Agentic Dashboard backlog work item for Shaka review instead of activating schedules or external providers directly.
- Add dashboard controls for requesting activation review with an optional scope note.

## Validation
- npm test -- --run app/admin/agents/content-intelligence/page.test.tsx app/api/admin/social-content/intelligence/daily-digest/activation-request/route.test.ts app/api/admin/social-content/intelligence/daily-digest/route.test.ts
- npx tsc --noEmit --pretty false
- git diff --check
- Browser smoke on /admin/agents/content-intelligence verified the Daily Review Digest panel and activation-review controls render without submitting a real request.
- Pre-push database health check passed.

## Integration Notes
- No migrations or env changes.
- This PR does not activate cron, run Apify, call providers, upload assets, schedule posts, publish, or create external posts.
- Integration Captain should verify both Vercel contexts after merge: Vercel – portfolio and Vercel – portfolio-staging.