### PR TITLE
feat: gate social intelligence digest runs

### DIFF
--- a/app/api/admin/social-content/intelligence/daily-digest/route.ts
+++ b/app/api/admin/social-content/intelligence/daily-digest/route.ts
@@ -1,98 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
-import { listAgentWorkItems, type AgentWorkItem } from '@/lib/agent-work-items'
-import {
-  normalizeSocialChannelLanes,
-  SOCIAL_CONTENT_INTELLIGENCE_CHANNELS,
-  SOCIAL_TOPIC_TRIGGER_SOURCE_TYPE,
-  socialChannelLabel,
-  type SocialContentIntelligenceChannel,
-} from '@/lib/social-content-intelligence'
-import { supabaseAdmin } from '@/lib/supabase'
+import { buildSocialContentDailyDigest } from '@/lib/social-content-daily-digest'
 
 export const dynamic = 'force-dynamic'
-
-type ResearchPacketRow = Record<string, unknown>
-
-function asRecord(value: unknown): Record<string, unknown> {
-  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
-}
-
-function asString(value: unknown) {
-  return typeof value === 'string' ? value.trim() : ''
-}
-
-function asNumber(value: unknown) {
-  return typeof value === 'number' && Number.isFinite(value) ? value : 0
-}
-
-function isBlockedPattern(packet: ResearchPacketRow) {
-  const status = asString(packet.status)
-  const patternStatus = asString(packet.pattern_status)
-  return status === 'rejected'
-    || status === 'archived'
-    || patternStatus === 'too_close_to_source'
-    || patternStatus === 'not_relevant'
-}
-
-function packetTitle(packet: ResearchPacketRow) {
-  return asString(packet.title)
-    || asString(packet.caption)
-    || asString(packet.creator_name)
-    || asString(packet.source_url)
-    || 'Untitled research packet'
-}
-
-function compactPattern(packet: ResearchPacketRow) {
-  const pattern = asRecord(packet.pattern_packet)
-  return {
-    packet_id: asString(packet.id),
-    title: packetTitle(packet),
-    source_url: asString(packet.source_url),
-    platform: asString(packet.platform) || 'other',
-    creator: asString(packet.creator_name) || asString(packet.creator_handle) || null,
-    outlier_score: asNumber(packet.outlier_score),
-    pattern_status: asString(packet.pattern_status) || 'needs_brand_translation',
-    hook_structure: asString(pattern.hook_structure) || asString(packet.hook_transcript) || null,
-    promise_value: asString(pattern.promise_value) || null,
-    thumbnail_pattern: asString(pattern.thumbnail_pattern) || null,
-  }
-}
-
-function insightFor(item: AgentWorkItem) {
-  const insight = asRecord(item.metadata?.insight)
-  return {
-    work_item_id: item.id,
-    title: asString(insight.title) || item.title,
-    status: item.status,
-    priority: item.priority,
-    triggering_event: asString(insight.triggering_event) || null,
-    why_vambah_can_speak: asString(insight.why_vambah_can_speak) || null,
-    audience: asString(insight.audience) || null,
-    sensitivity: asString(insight.sensitivity) || 'needs_review',
-  }
-}
-
-function laneSuggestions(items: AgentWorkItem[]) {
-  return SOCIAL_CONTENT_INTELLIGENCE_CHANNELS.flatMap((channel: SocialContentIntelligenceChannel) => {
-    return items
-      .map((item) => {
-        const lanes = normalizeSocialChannelLanes(item.metadata?.channel_lanes)
-        const lane = lanes[channel]
-        if (lane.status === 'approved') return null
-        return {
-          work_item_id: item.id,
-          insight_title: insightFor(item).title,
-          channel,
-          label: socialChannelLabel(channel),
-          status: lane.status,
-          required_inputs: lane.required_inputs.slice(0, 4),
-        }
-      })
-      .filter((value): value is NonNullable<typeof value> => Boolean(value))
-      .slice(0, 4)
-  })
-}
 
 export async function GET(request: NextRequest) {
   const authResult = await verifyAdmin(request)
@@ -103,80 +13,10 @@ export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url)
   const lookbackDays = Math.min(Math.max(parseInt(searchParams.get('lookback_days') || '5', 10), 1), 30)
   const limit = Math.min(Math.max(parseInt(searchParams.get('limit') || '12', 10), 1), 25)
-  const since = new Date(Date.now() - lookbackDays * 86_400_000).toISOString()
 
   try {
-    const [{ data: packetData, error: packetError }, workItems] = await Promise.all([
-      supabaseAdmin
-        .from('social_content_research_packets')
-        .select('id, source_url, platform, creator_name, creator_handle, title, caption, hook_transcript, thumbnail_url, outlier_score, pattern_status, pattern_packet, privacy_notes, retrieved_at, status')
-        .gte('retrieved_at', since)
-        .order('outlier_score', { ascending: false })
-        .order('retrieved_at', { ascending: false })
-        .limit(limit),
-      listAgentWorkItems({
-        sourceType: SOCIAL_TOPIC_TRIGGER_SOURCE_TYPE,
-        limit,
-      }),
-    ])
-
-    if (packetError) throw new Error(packetError.message)
-
-    const packets = ((packetData ?? []) as unknown[]).map((packet) => asRecord(packet))
-    const usablePackets = packets.filter((packet) => !isBlockedPattern(packet))
-    const blockedPackets = packets.filter(isBlockedPattern)
-    const insights = workItems.map(insightFor)
-    const sensitiveInsights = insights.filter((insight) => insight.sensitivity !== 'public_safe' && insight.sensitivity !== 'low')
-
     return NextResponse.json({
-      digest: {
-        generated_at: new Date().toISOString(),
-        lookback_days: lookbackDays,
-        retrieval_window_start: since,
-        summary: {
-          new_research_packets: packets.length,
-          usable_patterns: usablePackets.length,
-          shaka_insights: workItems.length,
-          blocked_or_sensitive_items: blockedPackets.length + sensitiveInsights.length,
-        },
-        strongest_patterns: usablePackets.slice(0, 5).map(compactPattern),
-        recommended_insights: insights.slice(0, 5),
-        suggested_channel_lanes: laneSuggestions(workItems).slice(0, 8),
-        thumbnail_opportunities: usablePackets
-          .filter((packet) => asString(packet.thumbnail_url) || asString(asRecord(packet.pattern_packet).thumbnail_pattern))
-          .slice(0, 4)
-          .map(compactPattern),
-        blocked_or_sensitive_items: [
-          ...blockedPackets.slice(0, 4).map((packet) => ({
-            type: 'research_packet',
-            id: asString(packet.id),
-            title: packetTitle(packet),
-            reason: asString(packet.pattern_status) || asString(packet.status) || 'blocked',
-          })),
-          ...sensitiveInsights.slice(0, 4).map((insight) => ({
-            type: 'shaka_insight',
-            id: insight.work_item_id,
-            title: insight.title,
-            reason: insight.sensitivity,
-          })),
-        ],
-        governance: {
-          schedule_activation: 'approval_required',
-          apify_collection: 'approval_required',
-          drafting: 'approval_required',
-          media_generation: 'approval_required',
-          uploads: 'approval_required',
-          publishing: 'approval_required',
-        },
-        side_effects: {
-          provider_generation: false,
-          upload: false,
-          publish: false,
-          schedule: false,
-          external_post: false,
-          apify_run: false,
-        },
-      },
+      digest: await buildSocialContentDailyDigest({ lookbackDays, limit }),
     })
   } catch (error) {
     console.error('[social-content-intelligence] daily digest failed:', error)

--- a/app/api/cron/social-content-intelligence-digest/route.test.ts
+++ b/app/api/cron/social-content-intelligence-digest/route.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  buildSocialContentDailyDigest: vi.fn(),
+  createAgentWorkItem: vi.fn(),
+}))
+
+vi.mock('@/lib/social-content-daily-digest', () => ({
+  buildSocialContentDailyDigest: mocks.buildSocialContentDailyDigest,
+}))
+
+vi.mock('@/lib/agent-work-items', () => ({
+  createAgentWorkItem: mocks.createAgentWorkItem,
+}))
+
+import { GET, POST } from './route'
+
+const digest = {
+  generated_at: '2026-06-23T12:00:00.000Z',
+  lookback_days: 5,
+  retrieval_window_start: '2026-06-18T12:00:00.000Z',
+  summary: {
+    new_research_packets: 2,
+    usable_patterns: 1,
+    shaka_insights: 3,
+    blocked_or_sensitive_items: 1,
+  },
+  strongest_patterns: [
+    {
+      packet_id: 'packet-1',
+      title: 'Outlier approval gate video',
+      source_url: 'https://youtube.com/watch?v=abc',
+      platform: 'youtube',
+      creator: 'Creator',
+      outlier_score: 91,
+      pattern_status: 'usable_framework',
+      hook_structure: 'Open with the missed approval gate.',
+      promise_value: 'Show where trust gets built.',
+      thumbnail_pattern: 'High contrast proof frame.',
+    },
+  ],
+  recommended_insights: [
+    {
+      work_item_id: 'work-1',
+      title: 'Approval gates create trust',
+      status: 'proposed',
+      priority: 'high',
+      triggering_event: 'A shipped review gate changed the work.',
+      why_vambah_can_speak: 'Vambah built the system.',
+      audience: 'operators',
+      sensitivity: 'needs_review',
+    },
+  ],
+  suggested_channel_lanes: [
+    {
+      work_item_id: 'work-1',
+      insight_title: 'Approval gates create trust',
+      channel: 'linkedin',
+      label: 'LinkedIn',
+      status: 'not_started',
+      required_inputs: ['post text'],
+    },
+  ],
+  thumbnail_opportunities: [],
+  blocked_or_sensitive_items: [
+    {
+      type: 'shaka_insight',
+      id: 'work-1',
+      title: 'Approval gates create trust',
+      reason: 'needs_review',
+    },
+  ],
+  governance: {
+    schedule_activation: 'approval_required',
+    apify_collection: 'approval_required',
+    drafting: 'approval_required',
+    media_generation: 'approval_required',
+    uploads: 'approval_required',
+    publishing: 'approval_required',
+  },
+  side_effects: {
+    provider_generation: false,
+    upload: false,
+    publish: false,
+    schedule: false,
+    external_post: false,
+    apify_run: false,
+  },
+}
+
+function getRequest(url = 'http://localhost/api/cron/social-content-intelligence-digest') {
+  return new Request(url, {
+    headers: { authorization: 'Bearer cron-secret' },
+  })
+}
+
+function postRequest(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/cron/social-content-intelligence-digest', {
+    method: 'POST',
+    headers: { authorization: 'Bearer cron-secret', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('/api/cron/social-content-intelligence-digest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-23T12:30:00.000Z'))
+    process.env.CRON_SECRET = 'cron-secret'
+    delete process.env.N8N_INGEST_SECRET
+    delete process.env.SOCIAL_CONTENT_INTELLIGENCE_DAILY_DIGEST_ENABLED
+    mocks.buildSocialContentDailyDigest.mockResolvedValue(digest)
+    mocks.createAgentWorkItem.mockResolvedValue({
+      id: 'work-digest-review',
+      title: 'Review Social Content Intelligence daily digest (2026-06-23)',
+      status: 'queued',
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('requires cron auth before building the digest', async () => {
+    const response = await GET(new Request('http://localhost/api/cron/social-content-intelligence-digest') as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.buildSocialContentDailyDigest).not.toHaveBeenCalled()
+    expect(mocks.createAgentWorkItem).not.toHaveBeenCalled()
+  })
+
+  it('builds a disabled-by-default digest without creating a work item', async () => {
+    const response = await GET(getRequest('http://localhost/api/cron/social-content-intelligence-digest?lookback_days=7&limit=10') as never)
+
+    expect(response.status).toBe(200)
+    expect(mocks.buildSocialContentDailyDigest).toHaveBeenCalledWith({
+      lookbackDays: 7,
+      limit: 10,
+    })
+    expect(mocks.createAgentWorkItem).not.toHaveBeenCalled()
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      activation: {
+        enabled: false,
+        manual_confirmed: false,
+        executed: false,
+        manual_confirmation: 'run_social_intelligence_daily_digest',
+      },
+      work_item: null,
+      side_effects: {
+        internal_work_item_created: false,
+        apify_run: false,
+        provider_generation: false,
+        upload: false,
+        schedule: false,
+        publish: false,
+        external_post: false,
+      },
+    })
+  })
+
+  it('creates an internal Shaka review work item only with manual confirmation', async () => {
+    const response = await POST(postRequest({
+      confirmation: 'run_social_intelligence_daily_digest',
+      lookback_days: 5,
+    }) as never)
+
+    expect(response.status).toBe(200)
+    expect(mocks.createAgentWorkItem).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'Review Social Content Intelligence daily digest (2026-06-23)',
+      priority: 'high',
+      status: 'queued',
+      ownerAgentKey: 'chief-of-staff',
+      ownerRuntime: 'codex',
+      source: {
+        type: 'social_intelligence_daily_digest',
+        id: '2026-06-23',
+        label: 'Social Content Intelligence daily digest',
+      },
+      metadata: expect.objectContaining({
+        digest,
+        trigger_source: 'manual_social_content_intelligence_digest',
+        side_effects: {
+          internal_work_item_created: true,
+          apify_run: false,
+          provider_generation: false,
+          upload: false,
+          schedule: false,
+          publish: false,
+          external_post: false,
+        },
+      }),
+      idempotencyKey: 'social-intelligence-daily-digest:2026-06-23:5',
+    }))
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      activation: {
+        enabled: false,
+        manual_confirmed: true,
+        executed: true,
+      },
+      work_item: { id: 'work-digest-review' },
+      side_effects: {
+        internal_work_item_created: true,
+        apify_run: false,
+        provider_generation: false,
+        upload: false,
+        schedule: false,
+        publish: false,
+        external_post: false,
+      },
+    })
+  })
+})

--- a/app/api/cron/social-content-intelligence-digest/route.ts
+++ b/app/api/cron/social-content-intelligence-digest/route.ts
@@ -1,0 +1,206 @@
+/**
+ * GET/POST /api/cron/social-content-intelligence-digest
+ *
+ * Builds the Social Content Intelligence daily digest and, once explicitly
+ * activated, creates a Shaka review work item in the Agentic Dashboard.
+ * Auth: Bearer CRON_SECRET or N8N_INGEST_SECRET.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { createAgentWorkItem } from '@/lib/agent-work-items'
+import {
+  buildSocialContentDailyDigest,
+  type SocialContentDailyDigest,
+} from '@/lib/social-content-daily-digest'
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 60
+
+const MANUAL_CONFIRMATION = 'run_social_intelligence_daily_digest'
+
+function isAuthorizedCronRequest(request: NextRequest): boolean {
+  const token = request.headers.get('authorization')?.replace(/^Bearer\s+/i, '')
+  const allowedTokens = [process.env.CRON_SECRET, process.env.N8N_INGEST_SECRET].filter(Boolean)
+  return Boolean(token && allowedTokens.includes(token))
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
+}
+
+function asString(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function asPositiveInteger(value: unknown, fallback: number, max: number) {
+  const parsed = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN
+  if (!Number.isInteger(parsed) || parsed < 1) return fallback
+  return Math.min(parsed, max)
+}
+
+async function parseBody(request: NextRequest) {
+  if (request.method !== 'POST') return {}
+  try {
+    return asRecord(await request.json())
+  } catch {
+    return {}
+  }
+}
+
+function activationEnabled() {
+  return process.env.SOCIAL_CONTENT_INTELLIGENCE_DAILY_DIGEST_ENABLED === 'true'
+}
+
+function runDateKey(now = new Date()) {
+  return now.toISOString().slice(0, 10)
+}
+
+function bulletList(values: string[]) {
+  return values.length ? values.map((value) => `- ${value}`).join('\n') : '- None'
+}
+
+function digestObjective(digest: SocialContentDailyDigest) {
+  const patterns = digest.strongest_patterns
+    .slice(0, 3)
+    .map((pattern) => `${pattern.title} (${pattern.platform}, score ${pattern.outlier_score})`)
+  const insights = digest.recommended_insights
+    .slice(0, 3)
+    .map((insight) => `${insight.title} (${insight.sensitivity})`)
+  const lanes = digest.suggested_channel_lanes
+    .slice(0, 4)
+    .map((lane) => `${lane.label}: ${lane.status} for ${lane.insight_title}`)
+  const blockers = digest.blocked_or_sensitive_items
+    .slice(0, 4)
+    .map((item) => `${item.title}: ${item.reason}`)
+
+  return [
+    'Review the daily Social Content Intelligence digest for Shaka.',
+    '',
+    `Lookback window: ${digest.lookback_days} day(s).`,
+    `New research packets: ${digest.summary.new_research_packets}.`,
+    `Usable public patterns: ${digest.summary.usable_patterns}.`,
+    `Shaka insight triggers: ${digest.summary.shaka_insights}.`,
+    `Blocked/privacy-sensitive items: ${digest.summary.blocked_or_sensitive_items}.`,
+    '',
+    'Strongest reusable patterns:',
+    bulletList(patterns),
+    '',
+    'Recommended Shaka insights:',
+    bulletList(insights),
+    '',
+    'Suggested channel lanes:',
+    bulletList(lanes),
+    '',
+    'Privacy/source blockers:',
+    bulletList(blockers),
+    '',
+    'Approval boundary: this digest only creates an internal Agentic Dashboard review item. It does not run Apify, generate drafts, generate media, upload assets, schedule posts, publish, or create external posts.',
+  ].join('\n')
+}
+
+async function createDigestReviewWorkItem(input: {
+  digest: SocialContentDailyDigest
+  triggerSource: string
+  actorLabel: string
+}) {
+  const dateKey = runDateKey()
+  const blockers = input.digest.summary.blocked_or_sensitive_items
+  return createAgentWorkItem({
+    title: `Review Social Content Intelligence daily digest (${dateKey})`,
+    objective: digestObjective(input.digest),
+    priority: blockers > 0 ? 'high' : 'medium',
+    status: 'queued',
+    ownerAgentKey: 'chief-of-staff',
+    ownerRuntime: 'codex',
+    source: {
+      type: 'social_intelligence_daily_digest',
+      id: dateKey,
+      label: 'Social Content Intelligence daily digest',
+    },
+    metadata: {
+      digest: input.digest,
+      trigger_source: input.triggerSource,
+      actor_label: input.actorLabel,
+      run_date: dateKey,
+      activation: {
+        enabled: activationEnabled(),
+        manual_confirmation_required_when_disabled: MANUAL_CONFIRMATION,
+      },
+      side_effects: {
+        internal_work_item_created: true,
+        apify_run: false,
+        provider_generation: false,
+        upload: false,
+        schedule: false,
+        publish: false,
+        external_post: false,
+      },
+    },
+    idempotencyKey: `social-intelligence-daily-digest:${dateKey}:${input.digest.lookback_days}`,
+  })
+}
+
+async function runDigest(request: NextRequest, body: Record<string, unknown>) {
+  if (!isAuthorizedCronRequest(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const searchParams = new URL(request.url).searchParams
+  const lookbackDays = asPositiveInteger(body.lookback_days ?? searchParams.get('lookback_days'), 5, 30)
+  const limit = asPositiveInteger(body.limit ?? searchParams.get('limit'), 12, 25)
+  const dryRun = body.dry_run === true || searchParams.get('dry_run') === '1'
+  const manualConfirmed = request.method === 'POST' && asString(body.confirmation) === MANUAL_CONFIRMATION
+  const enabled = activationEnabled()
+  const shouldCreateWorkItem = !dryRun && (enabled || manualConfirmed)
+
+  try {
+    const digest = await buildSocialContentDailyDigest({ lookbackDays, limit })
+    const workItem = shouldCreateWorkItem
+      ? await createDigestReviewWorkItem({
+        digest,
+        triggerSource: request.method === 'GET'
+          ? 'vercel_cron_social_content_intelligence_digest'
+          : 'manual_social_content_intelligence_digest',
+        actorLabel: request.method === 'GET' ? 'Vercel cron' : 'Manual cron trigger',
+      })
+      : null
+
+    return NextResponse.json({
+      ok: true,
+      digest,
+      activation: {
+        enabled,
+        manual_confirmed: manualConfirmed,
+        executed: Boolean(workItem),
+        disabled_reason: !shouldCreateWorkItem
+          ? 'SOCIAL_CONTENT_INTELLIGENCE_DAILY_DIGEST_ENABLED is not true and no manual confirmation was provided.'
+          : null,
+        manual_confirmation: MANUAL_CONFIRMATION,
+      },
+      work_item: workItem,
+      side_effects: {
+        internal_work_item_created: Boolean(workItem),
+        apify_run: false,
+        provider_generation: false,
+        upload: false,
+        schedule: false,
+        publish: false,
+        external_post: false,
+      },
+    })
+  } catch (error) {
+    console.error('[social-content-intelligence-digest-cron] failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Social Content Intelligence digest failed' },
+      { status: 500 },
+    )
+  }
+}
+
+export async function GET(request: NextRequest) {
+  return runDigest(request, {})
+}
+
+export async function POST(request: NextRequest) {
+  return runDigest(request, await parseBody(request))
+}

--- a/lib/social-content-daily-digest.ts
+++ b/lib/social-content-daily-digest.ts
@@ -1,0 +1,240 @@
+import { listAgentWorkItems, type AgentWorkItem } from '@/lib/agent-work-items'
+import {
+  normalizeSocialChannelLanes,
+  SOCIAL_CONTENT_INTELLIGENCE_CHANNELS,
+  SOCIAL_TOPIC_TRIGGER_SOURCE_TYPE,
+  socialChannelLabel,
+  type SocialContentIntelligenceChannel,
+} from '@/lib/social-content-intelligence'
+import { supabaseAdmin } from '@/lib/supabase'
+
+type ResearchPacketRow = Record<string, unknown>
+
+export type SocialContentDailyDigest = {
+  generated_at: string
+  lookback_days: number
+  retrieval_window_start: string
+  summary: {
+    new_research_packets: number
+    usable_patterns: number
+    shaka_insights: number
+    blocked_or_sensitive_items: number
+  }
+  strongest_patterns: Array<{
+    packet_id: string
+    title: string
+    source_url: string
+    platform: string
+    creator: string | null
+    outlier_score: number
+    pattern_status: string
+    hook_structure: string | null
+    promise_value: string | null
+    thumbnail_pattern: string | null
+  }>
+  recommended_insights: Array<{
+    work_item_id: string
+    title: string
+    status: string
+    priority: string
+    triggering_event: string | null
+    why_vambah_can_speak: string | null
+    audience: string | null
+    sensitivity: string
+  }>
+  suggested_channel_lanes: Array<{
+    work_item_id: string
+    insight_title: string
+    channel: SocialContentIntelligenceChannel
+    label: string
+    status: string
+    required_inputs: string[]
+  }>
+  thumbnail_opportunities: Array<{
+    packet_id: string
+    title: string
+    source_url: string
+    platform: string
+    creator: string | null
+    outlier_score: number
+    pattern_status: string
+    hook_structure: string | null
+    promise_value: string | null
+    thumbnail_pattern: string | null
+  }>
+  blocked_or_sensitive_items: Array<{
+    type: string
+    id: string
+    title: string
+    reason: string
+  }>
+  governance: Record<string, string>
+  side_effects: {
+    provider_generation: false
+    upload: false
+    publish: false
+    schedule: false
+    external_post: false
+    apify_run: false
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
+}
+
+function asString(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function asNumber(value: unknown) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0
+}
+
+function isBlockedPattern(packet: ResearchPacketRow) {
+  const status = asString(packet.status)
+  const patternStatus = asString(packet.pattern_status)
+  return status === 'rejected'
+    || status === 'archived'
+    || patternStatus === 'too_close_to_source'
+    || patternStatus === 'not_relevant'
+}
+
+function packetTitle(packet: ResearchPacketRow) {
+  return asString(packet.title)
+    || asString(packet.caption)
+    || asString(packet.creator_name)
+    || asString(packet.source_url)
+    || 'Untitled research packet'
+}
+
+function compactPattern(packet: ResearchPacketRow) {
+  const pattern = asRecord(packet.pattern_packet)
+  return {
+    packet_id: asString(packet.id),
+    title: packetTitle(packet),
+    source_url: asString(packet.source_url),
+    platform: asString(packet.platform) || 'other',
+    creator: asString(packet.creator_name) || asString(packet.creator_handle) || null,
+    outlier_score: asNumber(packet.outlier_score),
+    pattern_status: asString(packet.pattern_status) || 'needs_brand_translation',
+    hook_structure: asString(pattern.hook_structure) || asString(packet.hook_transcript) || null,
+    promise_value: asString(pattern.promise_value) || null,
+    thumbnail_pattern: asString(pattern.thumbnail_pattern) || null,
+  }
+}
+
+function insightFor(item: AgentWorkItem) {
+  const insight = asRecord(item.metadata?.insight)
+  return {
+    work_item_id: item.id,
+    title: asString(insight.title) || item.title,
+    status: item.status,
+    priority: item.priority,
+    triggering_event: asString(insight.triggering_event) || null,
+    why_vambah_can_speak: asString(insight.why_vambah_can_speak) || null,
+    audience: asString(insight.audience) || null,
+    sensitivity: asString(insight.sensitivity) || 'needs_review',
+  }
+}
+
+function laneSuggestions(items: AgentWorkItem[]) {
+  return SOCIAL_CONTENT_INTELLIGENCE_CHANNELS.flatMap((channel: SocialContentIntelligenceChannel) => {
+    return items
+      .map((item) => {
+        const lanes = normalizeSocialChannelLanes(item.metadata?.channel_lanes)
+        const lane = lanes[channel]
+        if (lane.status === 'approved') return null
+        return {
+          work_item_id: item.id,
+          insight_title: insightFor(item).title,
+          channel,
+          label: socialChannelLabel(channel),
+          status: lane.status,
+          required_inputs: lane.required_inputs.slice(0, 4),
+        }
+      })
+      .filter((value): value is NonNullable<typeof value> => Boolean(value))
+      .slice(0, 4)
+  })
+}
+
+export async function buildSocialContentDailyDigest(input: {
+  lookbackDays?: number
+  limit?: number
+} = {}): Promise<SocialContentDailyDigest> {
+  const lookbackDays = Math.min(Math.max(input.lookbackDays ?? 5, 1), 30)
+  const limit = Math.min(Math.max(input.limit ?? 12, 1), 25)
+  const since = new Date(Date.now() - lookbackDays * 86_400_000).toISOString()
+
+  const [{ data: packetData, error: packetError }, workItems] = await Promise.all([
+    supabaseAdmin
+      .from('social_content_research_packets')
+      .select('id, source_url, platform, creator_name, creator_handle, title, caption, hook_transcript, thumbnail_url, outlier_score, pattern_status, pattern_packet, privacy_notes, retrieved_at, status')
+      .gte('retrieved_at', since)
+      .order('outlier_score', { ascending: false })
+      .order('retrieved_at', { ascending: false })
+      .limit(limit),
+    listAgentWorkItems({
+      sourceType: SOCIAL_TOPIC_TRIGGER_SOURCE_TYPE,
+      limit,
+    }),
+  ])
+
+  if (packetError) throw new Error(packetError.message)
+
+  const packets = ((packetData ?? []) as unknown[]).map((packet) => asRecord(packet))
+  const usablePackets = packets.filter((packet) => !isBlockedPattern(packet))
+  const blockedPackets = packets.filter(isBlockedPattern)
+  const insights = workItems.map(insightFor)
+  const sensitiveInsights = insights.filter((insight) => insight.sensitivity !== 'public_safe' && insight.sensitivity !== 'low')
+
+  return {
+    generated_at: new Date().toISOString(),
+    lookback_days: lookbackDays,
+    retrieval_window_start: since,
+    summary: {
+      new_research_packets: packets.length,
+      usable_patterns: usablePackets.length,
+      shaka_insights: workItems.length,
+      blocked_or_sensitive_items: blockedPackets.length + sensitiveInsights.length,
+    },
+    strongest_patterns: usablePackets.slice(0, 5).map(compactPattern),
+    recommended_insights: insights.slice(0, 5),
+    suggested_channel_lanes: laneSuggestions(workItems).slice(0, 8),
+    thumbnail_opportunities: usablePackets
+      .filter((packet) => asString(packet.thumbnail_url) || asString(asRecord(packet.pattern_packet).thumbnail_pattern))
+      .slice(0, 4)
+      .map(compactPattern),
+    blocked_or_sensitive_items: [
+      ...blockedPackets.slice(0, 4).map((packet) => ({
+        type: 'research_packet',
+        id: asString(packet.id),
+        title: packetTitle(packet),
+        reason: asString(packet.pattern_status) || asString(packet.status) || 'blocked',
+      })),
+      ...sensitiveInsights.slice(0, 4).map((insight) => ({
+        type: 'shaka_insight',
+        id: insight.work_item_id,
+        title: insight.title,
+        reason: insight.sensitivity,
+      })),
+    ],
+    governance: {
+      schedule_activation: 'approval_required',
+      apify_collection: 'approval_required',
+      drafting: 'approval_required',
+      media_generation: 'approval_required',
+      uploads: 'approval_required',
+      publishing: 'approval_required',
+    },
+    side_effects: {
+      provider_generation: false,
+      upload: false,
+      publish: false,
+      schedule: false,
+      external_post: false,
+      apify_run: false,
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- Move Social Content Intelligence daily digest assembly into a shared library.
- Add a cron/manual digest route that is disabled by default unless the activation env flag is true or a manual POST includes the explicit confirmation string.
- When activated, the route creates an internal Shaka Agentic Dashboard review work item from the digest; it does not run Apify, generate drafts/media, upload, schedule, publish, or create external posts.

## Validation
- npm test -- --run app/api/admin/social-content/intelligence/daily-digest/route.test.ts app/api/admin/social-content/intelligence/daily-digest/activation-request/route.test.ts app/api/cron/social-content-intelligence-digest/route.test.ts
- npx tsc --noEmit --pretty false
- git diff --check
- Local smoke: GET /api/cron/social-content-intelligence-digest?dry_run=1&lookback_days=5&limit=3 returned 200 with internal_work_item_created=false and all provider/upload/schedule/publish side effects false.
- Pre-push database health check passed.

## Integration Notes
- No migrations.
- No env changes required for this PR.
- Does not add this route to vercel.json, so no live schedule is activated by merging.
- Future activation requires approval plus SOCIAL_CONTENT_INTELLIGENCE_DAILY_DIGEST_ENABLED=true and/or an explicitly scheduled cron entry.
- Integration Captain should verify both Vercel contexts after merge: Vercel – portfolio and Vercel – portfolio-staging.