### PR TITLE
feat: add campaign content calendar

### DIFF
--- a/app/admin/agents/content-intelligence/page.test.tsx
+++ b/app/admin/agents/content-intelligence/page.test.tsx
@@ -64,6 +64,65 @@ describe('ContentIntelligencePage', () => {
           }),
         }
       }
+      if (url === '/api/admin/social-content/calendar') {
+        return {
+          ok: true,
+          json: async () => ({
+            ok: true,
+            item: { id: 'calendar-new', title: 'Manual calendar item' },
+            side_effects: {
+              provider_generation: false,
+              upload: false,
+              external_schedule: false,
+              publish: false,
+              external_post: false,
+            },
+          }),
+        }
+      }
+      if (url.startsWith('/api/admin/social-content/calendar')) {
+        return {
+          ok: true,
+          json: async () => ({
+            items: [
+              {
+                id: 'calendar-1',
+                campaign_id: 'campaign-1',
+                agent_work_item_id: 'work-social-1',
+                social_content_id: null,
+                channel: 'linkedin',
+                campaign_phase: 'tease',
+                title: 'Tease: Approval gates',
+                planned_angle: 'Open with the moment an approval path created extra work.',
+                scheduled_for: '2026-06-24T14:00:00.000Z',
+                due_status: 'planned',
+                authorization_status: 'pending',
+                authorization_due_at: '2026-06-23T14:00:00.000Z',
+                autonomy_eligible: false,
+                attraction_campaigns: { id: 'campaign-1', name: 'Agent Ops Campaign', slug: 'agent-ops' },
+                agent_work_items: { id: 'work-social-1', title: 'Approval gates create trust', status: 'proposed' },
+                social_content_queue: null,
+              },
+            ],
+          }),
+        }
+      }
+      if (url.startsWith('/api/admin/campaigns')) {
+        return {
+          ok: true,
+          json: async () => ({
+            data: [
+              {
+                id: 'campaign-1',
+                name: 'Agent Ops Campaign',
+                status: 'draft',
+                starts_at: '2026-06-24T00:00:00.000Z',
+                ends_at: '2026-07-01T00:00:00.000Z',
+              },
+            ],
+          }),
+        }
+      }
       if (url.startsWith('/api/admin/social-content/intelligence/daily-digest')) {
         return {
           ok: true,
@@ -209,6 +268,10 @@ describe('ContentIntelligencePage', () => {
     expect(screen.getByText('Recorded public evidence from Codex/browser review. Cost: $0.')).toBeInTheDocument()
     expect(screen.getByText('pintostudio/youtube-transcript-scraper only after cost approval')).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: 'What Shaka should review next' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Campaign arc and due gates' })).toBeInTheDocument()
+    expect(screen.getByText('Tease: Approval gates')).toBeInTheDocument()
+    expect(screen.getAllByText('Agent Ops Campaign').length).toBeGreaterThan(0)
+    expect(screen.getByRole('heading', { name: 'Plan calendar item' })).toBeInTheDocument()
     expect(screen.getByText('Schedule: approval required')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Request Daily Activation Review' })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: 'Strongest patterns' })).toBeInTheDocument()
@@ -226,7 +289,7 @@ describe('ContentIntelligencePage', () => {
     await screen.findByRole('heading', { name: 'Research and Shaka insight queue' })
 
     fireEvent.change(screen.getByLabelText('Source URL'), { target: { value: 'https://youtube.com/watch?v=recorded' } })
-    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'Recorded hook pattern' } })
+    fireEvent.change(screen.getAllByLabelText('Title')[1], { target: { value: 'Recorded hook pattern' } })
     fireEvent.change(screen.getByLabelText('Creator'), { target: { value: 'Public Creator' } })
     fireEvent.change(screen.getByLabelText('Hook or first 30 seconds'), { target: { value: 'The hook makes a specific promise first.' } })
     fireEvent.change(screen.getByLabelText('Views'), { target: { value: '24000' } })
@@ -303,6 +366,40 @@ describe('ContentIntelligencePage', () => {
       cadence: 'daily',
       lookback_days: 5,
       scope_note: 'Start with free public research and Shaka internal triggers.',
+    })
+  })
+
+  it('creates a pending calendar item without publishing side effects', async () => {
+    render(<ContentIntelligencePage />)
+
+    await screen.findByRole('heading', { name: 'Plan calendar item' })
+
+    fireEvent.change(screen.getAllByLabelText('Title')[0], {
+      target: { value: 'Teach: Campaign operating lesson' },
+    })
+    fireEvent.change(screen.getByLabelText('Scheduled for'), {
+      target: { value: '2026-06-25T10:00' },
+    })
+    fireEvent.change(screen.getAllByLabelText('Campaign')[1], {
+      target: { value: 'campaign-1' },
+    })
+    fireEvent.change(screen.getByLabelText('Planned angle'), {
+      target: { value: 'Teach the operating framework behind the campaign.' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Plan Item' }))
+
+    await screen.findByText('Calendar item planned. Human authorization remains pending.')
+
+    const calendarCall = vi.mocked(fetch).mock.calls.find(([input, init]) => (
+      String(input) === '/api/admin/social-content/calendar' && init?.method === 'POST'
+    ))
+    expect(calendarCall).toBeTruthy()
+    expect(JSON.parse(String(calendarCall?.[1]?.body))).toMatchObject({
+      title: 'Teach: Campaign operating lesson',
+      campaign_id: 'campaign-1',
+      channel: 'linkedin',
+      campaign_phase: 'tease',
+      planned_angle: 'Teach the operating framework behind the campaign.',
     })
   })
 })

--- a/app/admin/agents/content-intelligence/page.tsx
+++ b/app/admin/agents/content-intelligence/page.tsx
@@ -11,6 +11,7 @@ import {
   FileSearch,
   Film,
   Instagram,
+  Plus,
   RefreshCw,
   ShieldCheck,
   Youtube,
@@ -105,6 +106,42 @@ type DailyDigest = {
   side_effects: Record<string, boolean>
 }
 
+type CalendarItem = {
+  id: string
+  campaign_id: string | null
+  agent_work_item_id: string | null
+  social_content_id: string | null
+  channel: 'linkedin' | 'youtube_shorts' | 'instagram_reels' | 'thumbnail'
+  campaign_phase: 'tease' | 'teach' | 'proof' | 'offer'
+  title: string
+  planned_angle: string | null
+  scheduled_for: string
+  due_status: string
+  authorization_status: string
+  authorization_due_at: string | null
+  autonomy_eligible: boolean
+  attraction_campaigns?: { id: string; name: string; slug: string } | null
+  agent_work_items?: { id: string; title: string; status: string } | null
+  social_content_queue?: { id: string; status: string } | null
+}
+
+type CampaignOption = {
+  id: string
+  name: string
+  status: string
+  starts_at: string | null
+  ends_at: string | null
+}
+
+type CalendarForm = {
+  title: string
+  campaign_id: string
+  channel: CalendarItem['channel']
+  campaign_phase: CalendarItem['campaign_phase']
+  scheduled_for: string
+  planned_angle: string
+}
+
 const EMPTY_EVIDENCE_FORM: EvidenceForm = {
   source_url: '',
   platform: 'youtube',
@@ -118,6 +155,29 @@ const EMPTY_EVIDENCE_FORM: EvidenceForm = {
   comments: '',
   follower_count: '',
   retrieval_notes: '',
+}
+
+const EMPTY_CALENDAR_FORM: CalendarForm = {
+  title: '',
+  campaign_id: '',
+  channel: 'linkedin',
+  campaign_phase: 'tease',
+  scheduled_for: '',
+  planned_angle: '',
+}
+
+const CALENDAR_PHASES: Array<{ key: CalendarItem['campaign_phase']; label: string }> = [
+  { key: 'tease', label: 'Tease' },
+  { key: 'teach', label: 'Teach' },
+  { key: 'proof', label: 'Proof' },
+  { key: 'offer', label: 'Offer' },
+]
+
+const CALENDAR_CHANNEL_LABELS: Record<CalendarItem['channel'], string> = {
+  linkedin: 'LinkedIn',
+  youtube_shorts: 'YouTube Shorts',
+  instagram_reels: 'Instagram Reels',
+  thumbnail: 'Thumbnail',
 }
 
 function stringValue(value: unknown) {
@@ -153,6 +213,13 @@ function platformIcon(platform: string) {
   return <Film className="h-4 w-4 text-blue-200" />
 }
 
+function formatCalendarDate(value: string) {
+  const date = new Date(value)
+  return Number.isFinite(date.getTime())
+    ? date.toLocaleString([], { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })
+    : 'Unscheduled'
+}
+
 export default function ContentIntelligencePage() {
   return (
     <ProtectedRoute requireAdmin>
@@ -164,6 +231,8 @@ export default function ContentIntelligencePage() {
 function ContentIntelligenceContent() {
   const [packets, setPackets] = useState<ResearchPacket[]>([])
   const [insights, setInsights] = useState<AgentWorkItem[]>([])
+  const [calendarItems, setCalendarItems] = useState<CalendarItem[]>([])
+  const [campaigns, setCampaigns] = useState<CampaignOption[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [evidenceForm, setEvidenceForm] = useState<EvidenceForm>(EMPTY_EVIDENCE_FORM)
@@ -178,6 +247,13 @@ function ContentIntelligenceContent() {
   const [activationScopeNote, setActivationScopeNote] = useState('')
   const [requestingActivation, setRequestingActivation] = useState(false)
   const [activationNotice, setActivationNotice] = useState<string | null>(null)
+  const [calendarForm, setCalendarForm] = useState<CalendarForm>(EMPTY_CALENDAR_FORM)
+  const [calendarNotice, setCalendarNotice] = useState<string | null>(null)
+  const [creatingCalendarItem, setCreatingCalendarItem] = useState(false)
+  const [calendarCampaignFilter, setCalendarCampaignFilter] = useState('')
+  const [calendarChannelFilter, setCalendarChannelFilter] = useState('')
+  const [calendarPhaseFilter, setCalendarPhaseFilter] = useState('')
+  const [calendarAuthorizationFilter, setCalendarAuthorizationFilter] = useState('')
 
   const authedFetch = useCallback(async (path: string, init: RequestInit = {}) => {
     const session = await getCurrentSession()
@@ -197,25 +273,35 @@ function ContentIntelligenceContent() {
     setLoading(true)
     setError(null)
     try {
-      const [packetResponse, insightResponse, digestResponse] = await Promise.all([
+      const [packetResponse, insightResponse, digestResponse, calendarResponse, campaignResponse] = await Promise.all([
         authedFetch('/api/admin/social-content/intelligence/research-packets?limit=12'),
         authedFetch('/api/admin/agents/work-items?source_type=social_topic_trigger&limit=12'),
         authedFetch('/api/admin/social-content/intelligence/daily-digest?lookback_days=5&limit=12'),
+        authedFetch('/api/admin/social-content/calendar?limit=50'),
+        authedFetch('/api/admin/campaigns?limit=50'),
       ])
       const packetBody = await packetResponse.json().catch(() => ({}))
       const insightBody = await insightResponse.json().catch(() => ({}))
       const digestBody = await digestResponse.json().catch(() => ({}))
+      const calendarBody = await calendarResponse.json().catch(() => ({}))
+      const campaignBody = await campaignResponse.json().catch(() => ({}))
       if (!packetResponse.ok) throw new Error(packetBody.error || `Research packets HTTP ${packetResponse.status}`)
       if (!insightResponse.ok) throw new Error(insightBody.error || `Insights HTTP ${insightResponse.status}`)
       if (!digestResponse.ok) throw new Error(digestBody.error || `Digest HTTP ${digestResponse.status}`)
+      if (!calendarResponse.ok) throw new Error(calendarBody.error || `Calendar HTTP ${calendarResponse.status}`)
+      if (!campaignResponse.ok) throw new Error(campaignBody.error || `Campaigns HTTP ${campaignResponse.status}`)
       setPackets(Array.isArray(packetBody.packets) ? packetBody.packets : [])
       setInsights(Array.isArray(insightBody.work_items) ? insightBody.work_items : [])
       setDigest(digestBody.digest ?? null)
+      setCalendarItems(Array.isArray(calendarBody.items) ? calendarBody.items : [])
+      setCampaigns(Array.isArray(campaignBody.data) ? campaignBody.data : [])
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load Content Intelligence')
       setPackets([])
       setInsights([])
       setDigest(null)
+      setCalendarItems([])
+      setCampaigns([])
     } finally {
       setLoading(false)
     }
@@ -226,6 +312,29 @@ function ContentIntelligenceContent() {
   }, [load])
 
   const strongestPacket = useMemo(() => packets[0] ?? null, [packets])
+
+  const filteredCalendarItems = useMemo(() => {
+    return calendarItems.filter((item) => {
+      if (calendarCampaignFilter && item.campaign_id !== calendarCampaignFilter) return false
+      if (calendarChannelFilter && item.channel !== calendarChannelFilter) return false
+      if (calendarPhaseFilter && item.campaign_phase !== calendarPhaseFilter) return false
+      if (calendarAuthorizationFilter && item.authorization_status !== calendarAuthorizationFilter) return false
+      return true
+    })
+  }, [
+    calendarAuthorizationFilter,
+    calendarCampaignFilter,
+    calendarChannelFilter,
+    calendarItems,
+    calendarPhaseFilter,
+  ])
+
+  const calendarItemsByPhase = useMemo(() => {
+    return CALENDAR_PHASES.reduce((lanes, phase) => {
+      lanes[phase.key] = filteredCalendarItems.filter((item) => item.campaign_phase === phase.key)
+      return lanes
+    }, {} as Record<CalendarItem['campaign_phase'], CalendarItem[]>)
+  }, [filteredCalendarItems])
 
   useEffect(() => {
     setSelectedPacketId((current) => current || packets[0]?.id || '')
@@ -343,6 +452,39 @@ function ContentIntelligenceContent() {
     }
   }, [activationScopeNote, authedFetch, digest?.lookback_days])
 
+  const createCalendarItem = useCallback(async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError(null)
+    setCalendarNotice(null)
+
+    if (!calendarForm.title.trim() || !calendarForm.scheduled_for) {
+      setError('Calendar item title and due time are required.')
+      return
+    }
+
+    setCreatingCalendarItem(true)
+    try {
+      const response = await authedFetch('/api/admin/social-content/calendar', {
+        method: 'POST',
+        body: JSON.stringify({
+          ...calendarForm,
+          campaign_id: calendarForm.campaign_id || null,
+          planned_angle: calendarForm.planned_angle.trim() || null,
+          scheduled_for: new Date(calendarForm.scheduled_for).toISOString(),
+        }),
+      })
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body.error || `Calendar create HTTP ${response.status}`)
+      setCalendarForm(EMPTY_CALENDAR_FORM)
+      setCalendarNotice('Calendar item planned. Human authorization remains pending.')
+      await load()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create calendar item')
+    } finally {
+      setCreatingCalendarItem(false)
+    }
+  }, [authedFetch, calendarForm, load])
+
   return (
     <div className="agent-ops-page min-h-screen p-5 text-foreground lg:p-7">
       <div className="mx-auto max-w-7xl">
@@ -386,6 +528,198 @@ function ContentIntelligenceContent() {
           <MetricCard label="Top outlier score" value={strongestPacket ? Math.round(Number(strongestPacket.outlier_score)) : 0} />
           <MetricCard label="Paid scraper runs" value={0} tone="amber" />
         </div>
+
+        <section className="agent-ops-card mb-6 rounded-lg border p-4">
+          <div className="mb-4 flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+            <div>
+              <div className="agent-ops-eyebrow mb-2">
+                <CalendarDays size={16} />
+                Content Calendar
+              </div>
+              <h2 className="text-lg font-semibold">Campaign arc and due gates</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Channel-agnostic plan tied to campaigns and Shaka insights. Authorization prepares internal draft handoffs only.
+              </p>
+            </div>
+            <span className="inline-flex w-fit items-center gap-2 rounded-full border border-amber-500/35 bg-amber-500/10 px-3 py-1 text-xs font-semibold text-amber-100">
+              <ShieldCheck className="h-3.5 w-3.5" />
+              External publishing locked
+            </span>
+          </div>
+
+          <div className="mb-4 grid gap-3 md:grid-cols-4">
+            <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Campaign
+              <select
+                value={calendarCampaignFilter}
+                onChange={(event) => setCalendarCampaignFilter(event.target.value)}
+                className="mt-1 w-full rounded-md border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm normal-case tracking-normal text-foreground"
+              >
+                <option value="">All campaigns</option>
+                {campaigns.map((campaign) => (
+                  <option key={campaign.id} value={campaign.id}>{campaign.name}</option>
+                ))}
+              </select>
+            </label>
+            <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Channel
+              <select
+                value={calendarChannelFilter}
+                onChange={(event) => setCalendarChannelFilter(event.target.value)}
+                className="mt-1 w-full rounded-md border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm normal-case tracking-normal text-foreground"
+              >
+                <option value="">All channels</option>
+                {Object.entries(CALENDAR_CHANNEL_LABELS).map(([value, label]) => (
+                  <option key={value} value={value}>{label}</option>
+                ))}
+              </select>
+            </label>
+            <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Phase
+              <select
+                value={calendarPhaseFilter}
+                onChange={(event) => setCalendarPhaseFilter(event.target.value)}
+                className="mt-1 w-full rounded-md border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm normal-case tracking-normal text-foreground"
+              >
+                <option value="">All phases</option>
+                {CALENDAR_PHASES.map((phase) => (
+                  <option key={phase.key} value={phase.key}>{phase.label}</option>
+                ))}
+              </select>
+            </label>
+            <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Authorization
+              <select
+                value={calendarAuthorizationFilter}
+                onChange={(event) => setCalendarAuthorizationFilter(event.target.value)}
+                className="mt-1 w-full rounded-md border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm normal-case tracking-normal text-foreground"
+              >
+                <option value="">All states</option>
+                <option value="pending">Pending</option>
+                <option value="authorized">Authorized</option>
+                <option value="rejected">Rejected</option>
+                <option value="expired">Expired</option>
+                <option value="not_required">Not required</option>
+              </select>
+            </label>
+          </div>
+
+          <div className="grid gap-3 xl:grid-cols-4">
+            {CALENDAR_PHASES.map((phase) => (
+              <div key={phase.key} className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-3">
+                <div className="mb-3 flex items-center justify-between gap-2">
+                  <h3 className="text-sm font-semibold">{phase.label}</h3>
+                  <span className="rounded-full border border-silicon-slate/70 px-2 py-0.5 text-xs text-muted-foreground">
+                    {calendarItemsByPhase[phase.key].length}
+                  </span>
+                </div>
+                <div className="space-y-2">
+                  {calendarItemsByPhase[phase.key].length ? calendarItemsByPhase[phase.key].map((item) => (
+                    <CalendarItemCard key={item.id} item={item} />
+                  )) : (
+                    <p className="rounded-md border border-silicon-slate/60 bg-background/35 p-3 text-xs text-muted-foreground">
+                      No planned items.
+                    </p>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <form onSubmit={createCalendarItem} className="mt-4 rounded-lg border border-radiant-gold/35 bg-radiant-gold/10 p-3">
+            <div className="mb-3 flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+              <div>
+                <h3 className="text-sm font-semibold text-radiant-gold">Plan calendar item</h3>
+                <p className="mt-1 text-xs text-muted-foreground">Creates a pending calendar gate only. Use campaign detail to generate the default whisper-to-shout arc.</p>
+              </div>
+              {calendarNotice ? (
+                <span className="inline-flex w-fit rounded-full border border-emerald-500/35 bg-emerald-500/10 px-3 py-1 text-xs font-semibold text-emerald-100">
+                  {calendarNotice}
+                </span>
+              ) : null}
+            </div>
+            <div className="grid gap-3 lg:grid-cols-[minmax(0,1.2fr)_14rem_12rem]">
+              <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Title
+                <input
+                  required
+                  type="text"
+                  value={calendarForm.title}
+                  onChange={(event) => setCalendarForm((current) => ({ ...current, title: event.target.value }))}
+                  className="mt-1 w-full rounded-md border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm normal-case tracking-normal text-foreground"
+                />
+              </label>
+              <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Scheduled for
+                <input
+                  required
+                  type="datetime-local"
+                  value={calendarForm.scheduled_for}
+                  onChange={(event) => setCalendarForm((current) => ({ ...current, scheduled_for: event.target.value }))}
+                  className="mt-1 w-full rounded-md border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm normal-case tracking-normal text-foreground"
+                />
+              </label>
+              <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Channel
+                <select
+                  value={calendarForm.channel}
+                  onChange={(event) => setCalendarForm((current) => ({ ...current, channel: event.target.value as CalendarItem['channel'] }))}
+                  className="mt-1 w-full rounded-md border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm normal-case tracking-normal text-foreground"
+                >
+                  {Object.entries(CALENDAR_CHANNEL_LABELS).map(([value, label]) => (
+                    <option key={value} value={value}>{label}</option>
+                  ))}
+                </select>
+              </label>
+            </div>
+            <div className="mt-3 grid gap-3 lg:grid-cols-[14rem_1fr]">
+              <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Phase
+                <select
+                  value={calendarForm.campaign_phase}
+                  onChange={(event) => setCalendarForm((current) => ({ ...current, campaign_phase: event.target.value as CalendarItem['campaign_phase'] }))}
+                  className="mt-1 w-full rounded-md border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm normal-case tracking-normal text-foreground"
+                >
+                  {CALENDAR_PHASES.map((phase) => (
+                    <option key={phase.key} value={phase.key}>{phase.label}</option>
+                  ))}
+                </select>
+              </label>
+              <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Campaign
+                <select
+                  value={calendarForm.campaign_id}
+                  onChange={(event) => setCalendarForm((current) => ({ ...current, campaign_id: event.target.value }))}
+                  className="mt-1 w-full rounded-md border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm normal-case tracking-normal text-foreground"
+                >
+                  <option value="">No campaign</option>
+                  {campaigns.map((campaign) => (
+                    <option key={campaign.id} value={campaign.id}>{campaign.name}</option>
+                  ))}
+                </select>
+              </label>
+            </div>
+            <label className="mt-3 block text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Planned angle
+              <textarea
+                value={calendarForm.planned_angle}
+                onChange={(event) => setCalendarForm((current) => ({ ...current, planned_angle: event.target.value }))}
+                rows={2}
+                className="mt-1 w-full rounded-md border border-silicon-slate/70 bg-background/70 px-3 py-2 text-sm normal-case tracking-normal text-foreground"
+              />
+            </label>
+            <div className="mt-3 flex justify-end">
+              <button
+                type="submit"
+                disabled={creatingCalendarItem}
+                className="agent-ops-button-primary disabled:opacity-60"
+              >
+                <Plus size={16} />
+                {creatingCalendarItem ? 'Planning...' : 'Plan Item'}
+              </button>
+            </div>
+          </form>
+        </section>
 
         <section className="agent-ops-card mb-6 rounded-lg border p-4">
           <div className="mb-4 flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
@@ -832,6 +1166,53 @@ function DigestList({
         }) : (
           <p className="rounded-md border border-silicon-slate/60 bg-background/35 p-3 text-xs text-muted-foreground">{empty}</p>
         )}
+      </div>
+    </div>
+  )
+}
+
+function CalendarItemCard({ item }: { item: CalendarItem }) {
+  const campaignName = item.attraction_campaigns?.name ?? 'No campaign'
+  return (
+    <div className="rounded-md border border-silicon-slate/60 bg-background/35 p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-sm font-semibold leading-5">{item.title}</p>
+          <p className="mt-1 text-xs text-muted-foreground">{formatCalendarDate(item.scheduled_for)}</p>
+        </div>
+        <span className="shrink-0 rounded-full border border-amber-500/35 bg-amber-500/10 px-2 py-0.5 text-[0.68rem] font-semibold text-amber-100">
+          {item.authorization_status.replace(/_/g, ' ')}
+        </span>
+      </div>
+      {item.planned_angle ? (
+        <p className="mt-2 line-clamp-2 text-xs leading-5 text-muted-foreground">{item.planned_angle}</p>
+      ) : null}
+      <div className="mt-3 flex flex-wrap gap-2 text-[0.68rem] text-muted-foreground">
+        <span className="rounded-full border border-silicon-slate/70 px-2 py-0.5">
+          {CALENDAR_CHANNEL_LABELS[item.channel]}
+        </span>
+        <span className="rounded-full border border-silicon-slate/70 px-2 py-0.5">
+          {item.due_status.replace(/_/g, ' ')}
+        </span>
+      </div>
+      <div className="mt-3 flex flex-wrap gap-2 text-xs">
+        {item.campaign_id ? (
+          <Link href={`/admin/campaigns/${item.campaign_id}`} className="text-blue-200 hover:text-blue-100">
+            {campaignName}
+          </Link>
+        ) : (
+          <span className="text-muted-foreground">{campaignName}</span>
+        )}
+        {item.agent_work_item_id ? (
+          <Link href={`/admin/agents/social-insights/${item.agent_work_item_id}`} className="text-blue-200 hover:text-blue-100">
+            Insight
+          </Link>
+        ) : null}
+        {item.social_content_id ? (
+          <Link href={`/admin/social-content/${item.social_content_id}`} className="text-blue-200 hover:text-blue-100">
+            Draft
+          </Link>
+        ) : null}
       </div>
     </div>
   )

--- a/app/admin/campaigns/[id]/page.tsx
+++ b/app/admin/campaigns/[id]/page.tsx
@@ -19,6 +19,20 @@ import type {
   AttractionCampaign, CampaignCriteriaTemplate, CriteriaType, TrackingSource,
 } from '@/lib/campaigns';
 
+type CampaignCalendarItem = {
+  id: string;
+  title: string;
+  channel: 'linkedin' | 'youtube_shorts' | 'instagram_reels' | 'thumbnail';
+  campaign_phase: 'tease' | 'teach' | 'proof' | 'offer';
+  planned_angle: string | null;
+  scheduled_for: string;
+  due_status: string;
+  authorization_status: string;
+  authorization_due_at: string | null;
+  agent_work_item_id: string | null;
+  social_content_id: string | null;
+};
+
 interface CampaignDetail extends AttractionCampaign {
   campaign_eligible_bundles: Array<{
     id: string;
@@ -26,6 +40,9 @@ interface CampaignDetail extends AttractionCampaign {
     offer_bundles: { id: string; name: string; pricing_tier_slug: string; bundle_price: number } | null;
   }>;
   campaign_criteria_templates: CampaignCriteriaTemplate[];
+  social_content_calendar_items?: CampaignCalendarItem[];
+  calendar_item_count?: number;
+  next_calendar_item?: CampaignCalendarItem | null;
 }
 
 interface EnrollmentRow {
@@ -51,7 +68,9 @@ export default function CampaignDetailPage() {
   const [campaign, setCampaign] = useState<CampaignDetail | null>(null);
   const [enrollments, setEnrollments] = useState<EnrollmentRow[]>([]);
   const [loading, setLoading] = useState(true);
-  const [activeTab, setActiveTab] = useState<'criteria' | 'bundles' | 'enrollments'>('criteria');
+  const [activeTab, setActiveTab] = useState<'criteria' | 'bundles' | 'enrollments' | 'content-calendar'>('criteria');
+  const [generatingContentPlan, setGeneratingContentPlan] = useState(false);
+  const [contentPlanNotice, setContentPlanNotice] = useState('');
 
   // Criteria form
   const [showCriteriaForm, setShowCriteriaForm] = useState(false);
@@ -188,6 +207,29 @@ export default function CampaignDetailPage() {
     }
   };
 
+  const handleGenerateContentPlan = async () => {
+    setGeneratingContentPlan(true);
+    setContentPlanNotice('');
+    try {
+      const res = await fetch(`/api/admin/campaigns/${campaignId}/content-plan`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      const data = await res.json().catch(() => ({}));
+      if (res.ok) {
+        setContentPlanNotice(`Created ${data.created_count || 0} items; skipped ${data.skipped_existing_count || 0} existing phases.`);
+        await fetchCampaign();
+      } else {
+        setContentPlanNotice(data.error || 'Failed to generate content plan.');
+      }
+    } catch (err) {
+      console.error('Failed to generate content plan:', err);
+      setContentPlanNotice('Failed to generate content plan.');
+    } finally {
+      setGeneratingContentPlan(false);
+    }
+  };
+
   if (loading) {
     return (
       <div className="admin-console-page min-h-screen flex items-center justify-center text-foreground">
@@ -213,6 +255,15 @@ export default function CampaignDetailPage() {
     { key: 'criteria' as const, label: 'Criteria Templates', icon: Target, count: campaign.campaign_criteria_templates.length },
     { key: 'bundles' as const, label: 'Eligible Bundles', icon: Package, count: campaign.campaign_eligible_bundles.length },
     { key: 'enrollments' as const, label: 'Enrollments', icon: Users, count: enrollments.length },
+    { key: 'content-calendar' as const, label: 'Content Calendar', icon: Calendar, count: campaign.calendar_item_count || 0 },
+  ];
+
+  const campaignCalendarItems = campaign.social_content_calendar_items || [];
+  const calendarPhases: Array<{ key: CampaignCalendarItem['campaign_phase']; label: string }> = [
+    { key: 'tease', label: 'Tease' },
+    { key: 'teach', label: 'Teach' },
+    { key: 'proof', label: 'Proof' },
+    { key: 'offer', label: 'Offer' },
   ];
 
   return (
@@ -483,6 +534,93 @@ export default function CampaignDetailPage() {
                 );
               })
             )}
+          </div>
+        </div>
+      )}
+
+      {activeTab === 'content-calendar' && (
+        <div>
+          <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 className="text-xl font-semibold">Content Calendar</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Campaign-specific projection of the central Social Content calendar.
+              </p>
+            </div>
+            <button
+              onClick={handleGenerateContentPlan}
+              disabled={generatingContentPlan}
+              className="admin-console-button-primary disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {generatingContentPlan ? <Loader2 size={14} className="animate-spin" /> : <Plus size={14} />}
+              {generatingContentPlan ? 'Generating...' : 'Generate Whisper-to-Shout Plan'}
+            </button>
+          </div>
+
+          {contentPlanNotice && (
+            <div className="admin-console-card mb-4 rounded-lg border border-radiant-gold/35 bg-radiant-gold/10 p-3 text-sm text-radiant-gold">
+              {contentPlanNotice}
+            </div>
+          )}
+
+          <div className="admin-console-card mb-4 rounded-lg border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-amber-100">
+            Authorization creates or updates the internal draft handoff only. External publishing, uploads, scheduling, media generation, and autonomous execution remain locked.
+          </div>
+
+          <div className="grid gap-4 lg:grid-cols-4">
+            {calendarPhases.map((phase) => {
+              const items = campaignCalendarItems.filter((item) => item.campaign_phase === phase.key);
+              return (
+                <div key={phase.key} className="admin-console-card rounded-lg border p-4">
+                  <div className="mb-3 flex items-center justify-between gap-2">
+                    <h3 className="font-semibold">{phase.label}</h3>
+                    <span className="rounded-full border border-white/10 px-2 py-0.5 text-xs text-muted-foreground">
+                      {items.length}
+                    </span>
+                  </div>
+                  <div className="space-y-3">
+                    {items.length ? items.map((item) => (
+                      <div key={item.id} className="rounded-lg border border-white/10 bg-silicon-slate/40 p-3">
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <p className="break-words text-sm font-semibold">{item.title}</p>
+                            <p className="mt-1 text-xs text-muted-foreground">
+                              {new Date(item.scheduled_for).toLocaleString([], { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })}
+                            </p>
+                          </div>
+                          <span className="shrink-0 rounded-full border border-amber-500/35 bg-amber-500/10 px-2 py-0.5 text-[0.68rem] font-semibold text-amber-100">
+                            {item.authorization_status.replace(/_/g, ' ')}
+                          </span>
+                        </div>
+                        {item.planned_angle && (
+                          <p className="mt-2 line-clamp-3 text-xs leading-5 text-muted-foreground">{item.planned_angle}</p>
+                        )}
+                        <div className="mt-3 flex flex-wrap gap-2 text-[0.68rem] text-muted-foreground">
+                          <span className="rounded-full border border-white/10 px-2 py-0.5">{item.channel.replace(/_/g, ' ')}</span>
+                          <span className="rounded-full border border-white/10 px-2 py-0.5">{item.due_status.replace(/_/g, ' ')}</span>
+                        </div>
+                        <div className="mt-3 flex flex-wrap gap-2 text-xs">
+                          {item.agent_work_item_id && (
+                            <Link href={`/admin/agents/social-insights/${item.agent_work_item_id}`} className="text-blue-200 hover:text-blue-100">
+                              Insight
+                            </Link>
+                          )}
+                          {item.social_content_id && (
+                            <Link href={`/admin/social-content/${item.social_content_id}`} className="text-blue-200 hover:text-blue-100">
+                              Draft
+                            </Link>
+                          )}
+                        </div>
+                      </div>
+                    )) : (
+                      <p className="rounded-lg border border-white/10 bg-silicon-slate/40 p-4 text-center text-sm text-muted-foreground">
+                        No planned items.
+                      </p>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
           </div>
         </div>
       )}

--- a/app/admin/campaigns/page.tsx
+++ b/app/admin/campaigns/page.tsx
@@ -25,6 +25,15 @@ interface CampaignWithCounts extends AttractionCampaign {
   criteria_count: number;
   enrollment_count: number;
   active_enrollment_count: number;
+  calendar_item_count: number;
+  next_calendar_item: {
+    id: string;
+    title: string;
+    channel: string;
+    campaign_phase: string;
+    scheduled_for: string;
+    authorization_status: string;
+  } | null;
 }
 
 export default function CampaignsAdminPage() {
@@ -333,6 +342,16 @@ export default function CampaignsAdminPage() {
                         <Users size={14} />
                         {c.active_enrollment_count} active / {c.enrollment_count} total
                       </span>
+                    </div>
+                    <div className="mt-3 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                      <span className="rounded-full border border-blue-500/30 bg-blue-500/10 px-2 py-0.5 text-blue-100">
+                        {c.calendar_item_count || 0} calendar item{c.calendar_item_count === 1 ? '' : 's'}
+                      </span>
+                      {c.next_calendar_item && (
+                        <span className="min-w-0 rounded-full border border-white/10 px-2 py-0.5">
+                          Next: {c.next_calendar_item.campaign_phase.replace(/_/g, ' ')} · {new Date(c.next_calendar_item.scheduled_for).toLocaleDateString()}
+                        </span>
+                      )}
                     </div>
                   </div>
                   <div className="flex items-center gap-2">

--- a/app/api/admin/campaigns/[id]/content-plan/route.test.ts
+++ b/app/api/admin/campaigns/[id]/content-plan/route.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  from: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: { from: mocks.from },
+}))
+
+import { POST } from './route'
+
+function request() {
+  return new Request('http://localhost/api/admin/campaigns/campaign-1/content-plan', {
+    method: 'POST',
+    headers: { authorization: 'Bearer admin-token' },
+  })
+}
+
+describe('/api/admin/campaigns/[id]/content-plan', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(request() as never, { params: { id: 'campaign-1' } })
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.from).not.toHaveBeenCalled()
+  })
+
+  it('creates missing whisper-to-shout calendar items without creating drafts or publishes', async () => {
+    const campaignSingle = vi.fn(async () => ({
+      data: {
+        id: 'campaign-1',
+        name: 'Agent Ops Campaign',
+        starts_at: '2026-06-24T00:00:00.000Z',
+        ends_at: '2026-07-04T00:00:00.000Z',
+      },
+      error: null,
+    }))
+    const campaignSelect = vi.fn(() => ({ eq: vi.fn(() => ({ single: campaignSingle })) }))
+
+    const existingOrder = vi.fn(async () => ({
+      data: [{ id: 'existing-tease', campaign_phase: 'tease', channel: 'linkedin' }],
+      error: null,
+    }))
+    const existingSelect = vi.fn(() => ({ eq: vi.fn(() => ({ order: existingOrder })) }))
+    const existingEq = vi.fn(async () => ({
+      data: [{ id: 'existing-tease', campaign_phase: 'tease', channel: 'linkedin' }],
+      error: null,
+    }))
+
+    const insertedRows = [
+      { id: 'teach-item', campaign_phase: 'teach' },
+      { id: 'proof-item', campaign_phase: 'proof' },
+      { id: 'offer-item', campaign_phase: 'offer' },
+    ]
+    const insertSelect = vi.fn(async () => ({ data: insertedRows, error: null }))
+    const insert = vi.fn(() => ({ select: insertSelect }))
+
+    mocks.from.mockImplementation((table: string) => {
+      if (table === 'attraction_campaigns') return { select: campaignSelect }
+      if (table === 'social_content_calendar_items') {
+        if (mocks.from.mock.calls.filter(([name]) => name === 'social_content_calendar_items').length === 1) {
+          return { select: vi.fn(() => ({ eq: existingEq })) }
+        }
+        return { insert }
+      }
+      return {}
+    })
+
+    const response = await POST(request() as never, { params: { id: 'campaign-1' } })
+
+    expect(response.status).toBe(200)
+    expect(insert).toHaveBeenCalledWith(expect.arrayContaining([
+      expect.objectContaining({ campaign_phase: 'teach', campaign_id: 'campaign-1', created_by: 'admin-user' }),
+      expect.objectContaining({ campaign_phase: 'proof' }),
+      expect.objectContaining({ campaign_phase: 'offer' }),
+    ]))
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      created_count: 3,
+      skipped_existing_count: 1,
+      planned_phases: ['tease', 'teach', 'proof', 'offer'],
+      side_effects: {
+        publish: false,
+        external_post: false,
+        social_draft_created: false,
+      },
+    })
+  })
+})

--- a/app/api/admin/campaigns/[id]/content-plan/route.ts
+++ b/app/api/admin/campaigns/[id]/content-plan/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { supabaseAdmin } from '@/lib/supabase'
+import {
+  CALENDAR_SIDE_EFFECTS,
+  campaignContentPlanSlots,
+  type SocialContentCampaignPhase,
+} from '@/lib/social-content-calendar'
+import type { AttractionCampaign } from '@/lib/campaigns'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const auth = await verifyAdmin(request)
+    if (isAuthError(auth)) {
+      return NextResponse.json({ error: auth.error }, { status: auth.status })
+    }
+
+    const { data: campaign, error: campaignError } = await supabaseAdmin
+      .from('attraction_campaigns')
+      .select('*')
+      .eq('id', params.id)
+      .single()
+
+    if (campaignError) {
+      if (campaignError.code === 'PGRST116') {
+        return NextResponse.json({ error: 'Campaign not found' }, { status: 404 })
+      }
+      throw campaignError
+    }
+
+    const { data: existing, error: existingError } = await supabaseAdmin
+      .from('social_content_calendar_items')
+      .select('id, campaign_phase, channel')
+      .eq('campaign_id', params.id)
+
+    if (
+      existingError
+      && existingError.code !== '42P01'
+      && existingError.code !== 'PGRST205'
+    ) throw existingError
+
+    const existingKeys = new Set(
+      (existing ?? []).map((item: { campaign_phase: string; channel: string }) => (
+        `${item.campaign_phase}:${item.channel}`
+      )),
+    )
+
+    const slots = campaignContentPlanSlots(campaign as AttractionCampaign)
+    const inserts = slots
+      .filter((slot) => !existingKeys.has(`${slot.campaign_phase}:${slot.channel}`))
+      .map((slot) => ({
+        ...slot,
+        campaign_id: params.id,
+        created_by: auth.user.id,
+        metadata: {
+          ...slot.metadata,
+          created_by_content_plan_route: true,
+        },
+      }))
+
+    let insertedItems: unknown[] = []
+    if (inserts.length > 0) {
+      const { data, error } = await supabaseAdmin
+        .from('social_content_calendar_items')
+        .insert(inserts)
+        .select(`
+          *,
+          attraction_campaigns (id, name, slug, status, starts_at, ends_at),
+          agent_work_items (id, title, status, priority),
+          social_content_queue (id, status, post_text, scheduled_for)
+        `)
+
+      if (error) throw error
+      insertedItems = data ?? []
+    }
+
+    return NextResponse.json({
+      ok: true,
+      campaign_id: params.id,
+      created_count: insertedItems.length,
+      skipped_existing_count: slots.length - inserts.length,
+      planned_phases: slots.map((slot) => slot.campaign_phase as SocialContentCampaignPhase),
+      items: insertedItems,
+      side_effects: {
+        ...CALENDAR_SIDE_EFFECTS,
+        social_draft_created: false,
+      },
+    })
+  } catch (error) {
+    console.error('[campaign-content-plan] create failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to create campaign content plan' },
+      { status: 500 },
+    )
+  }
+}

--- a/app/api/admin/campaigns/[id]/route.ts
+++ b/app/api/admin/campaigns/[id]/route.ts
@@ -40,7 +40,30 @@ export async function GET(
       throw error;
     }
 
-    return NextResponse.json({ data });
+    const { data: calendarItems, error: calendarError } = await supabaseAdmin
+      .from('social_content_calendar_items')
+      .select('id, title, channel, campaign_phase, planned_angle, scheduled_for, due_status, authorization_status, authorization_due_at, autonomy_eligible, agent_work_item_id, social_content_id, metadata')
+      .eq('campaign_id', params.id)
+      .order('scheduled_for', { ascending: true });
+
+    if (
+      calendarError
+      && calendarError.code !== '42P01'
+      && calendarError.code !== 'PGRST205'
+    ) throw calendarError;
+
+    const calendar = calendarItems || [];
+
+    return NextResponse.json({
+      data: {
+        ...data,
+        social_content_calendar_items: calendar,
+        calendar_item_count: calendar.length,
+        next_calendar_item: calendar.find((item: { due_status: string }) => (
+          item.due_status !== 'completed' && item.due_status !== 'cancelled'
+        )) || null,
+      },
+    });
   } catch (error: unknown) {
     console.error('Error fetching campaign:', error);
     return NextResponse.json(

--- a/app/api/admin/campaigns/route.ts
+++ b/app/api/admin/campaigns/route.ts
@@ -40,6 +40,38 @@ export async function GET(request: NextRequest) {
       throw error;
     }
 
+    const campaignIds = (data || [])
+      .map((campaign: Record<string, unknown>) => String(campaign.id || ''))
+      .filter(Boolean);
+
+    let calendarByCampaign = new Map<string, {
+      count: number;
+      next: Record<string, unknown> | null;
+    }>();
+
+    if (campaignIds.length > 0) {
+      const { data: calendarItems, error: calendarError } = await supabaseAdmin
+        .from('social_content_calendar_items')
+        .select('id, campaign_id, title, channel, campaign_phase, scheduled_for, due_status, authorization_status')
+        .in('campaign_id', campaignIds)
+        .order('scheduled_for', { ascending: true });
+
+      if (
+        calendarError
+        && calendarError.code !== '42P01'
+        && calendarError.code !== 'PGRST205'
+      ) throw calendarError;
+
+      for (const item of calendarItems || []) {
+        const campaignId = String(item.campaign_id || '');
+        if (!campaignId) continue;
+        const current = calendarByCampaign.get(campaignId) || { count: 0, next: null };
+        current.count += 1;
+        if (!current.next) current.next = item as Record<string, unknown>;
+        calendarByCampaign.set(campaignId, current);
+      }
+    }
+
     const campaigns = (data || []).map((c: Record<string, unknown>) => ({
       ...c,
       eligible_bundle_count: Array.isArray(c.campaign_eligible_bundles) ? c.campaign_eligible_bundles.length : 0,
@@ -48,6 +80,8 @@ export async function GET(request: NextRequest) {
       active_enrollment_count: Array.isArray(c.campaign_enrollments)
         ? (c.campaign_enrollments as Array<{ status: string }>).filter((e) => e.status === 'active').length
         : 0,
+      calendar_item_count: calendarByCampaign.get(String(c.id))?.count || 0,
+      next_calendar_item: calendarByCampaign.get(String(c.id))?.next || null,
     }));
 
     return NextResponse.json({ data: campaigns, total: count || 0 });

--- a/app/api/admin/social-content/calendar/[id]/route.test.ts
+++ b/app/api/admin/social-content/calendar/[id]/route.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  from: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: { from: mocks.from },
+}))
+
+import { PATCH } from './route'
+
+function request(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/admin/social-content/calendar/calendar-1', {
+    method: 'PATCH',
+    headers: { authorization: 'Bearer admin-token', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('/api/admin/social-content/calendar/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+  })
+
+  it('requires a decision note when rejecting a calendar item', async () => {
+    const response = await PATCH(
+      request({ authorization_status: 'rejected' }) as never,
+      { params: { id: 'calendar-1' } },
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: 'Decision note is required when rejecting a calendar item',
+    })
+    expect(mocks.from).not.toHaveBeenCalled()
+  })
+
+  it('records authorized state as internal draft-handoff only', async () => {
+    const readMaybeSingle = vi.fn(async () => ({ data: { metadata: { existing: true } }, error: null }))
+    const readSelect = vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle: readMaybeSingle })) }))
+    const updateSingle = vi.fn(async () => ({
+      data: { id: 'calendar-1', authorization_status: 'authorized' },
+      error: null,
+    }))
+    const updateSelect = vi.fn(() => ({ single: updateSingle }))
+    const updateEq = vi.fn(() => ({ select: updateSelect }))
+    const update = vi.fn(() => ({ eq: updateEq }))
+    mocks.from
+      .mockReturnValueOnce({ select: readSelect })
+      .mockReturnValueOnce({ update })
+
+    const response = await PATCH(
+      request({ authorization_status: 'authorized' }) as never,
+      { params: { id: 'calendar-1' } },
+    )
+
+    expect(response.status).toBe(200)
+    expect(update).toHaveBeenCalledWith(expect.objectContaining({
+      authorization_status: 'authorized',
+      metadata: expect.objectContaining({
+        existing: true,
+        authorized_by: 'admin-user',
+        draft_handoff_only: true,
+        external_execution_enabled: false,
+      }),
+    }))
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      side_effects: { publish: false, external_post: false },
+    })
+  })
+})

--- a/app/api/admin/social-content/calendar/[id]/route.ts
+++ b/app/api/admin/social-content/calendar/[id]/route.ts
@@ -1,0 +1,164 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { supabaseAdmin } from '@/lib/supabase'
+import {
+  CALENDAR_SIDE_EFFECTS,
+  defaultAuthorizationDueAt,
+  deriveDueStatus,
+  isAuthorizationStatus,
+  isCalendarChannel,
+  isCampaignPhase,
+  isDueStatus,
+  parseMetadata,
+} from '@/lib/social-content-calendar'
+
+export const dynamic = 'force-dynamic'
+
+function cleanText(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function isoOrNull(value: unknown) {
+  if (typeof value !== 'string' || !value.trim()) return null
+  const date = new Date(value)
+  return Number.isFinite(date.getTime()) ? date.toISOString() : null
+}
+
+function nullableUuid(value: unknown) {
+  const text = cleanText(value)
+  return text || null
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const auth = await verifyAdmin(request)
+    if (isAuthError(auth)) {
+      return NextResponse.json({ error: auth.error }, { status: auth.status })
+    }
+
+    const body = await request.json().catch(() => ({})) as Record<string, unknown>
+    const updates: Record<string, unknown> = {}
+
+    for (const field of ['campaign_id', 'agent_work_item_id', 'social_content_id'] as const) {
+      if (field in body) updates[field] = nullableUuid(body[field])
+    }
+    if ('channel' in body) {
+      if (!isCalendarChannel(body.channel)) {
+        return NextResponse.json({ error: 'Invalid channel' }, { status: 400 })
+      }
+      updates.channel = body.channel
+    }
+    if ('campaign_phase' in body) {
+      if (!isCampaignPhase(body.campaign_phase)) {
+        return NextResponse.json({ error: 'Invalid campaign phase' }, { status: 400 })
+      }
+      updates.campaign_phase = body.campaign_phase
+    }
+    if ('due_status' in body) {
+      if (!isDueStatus(body.due_status)) {
+        return NextResponse.json({ error: 'Invalid due status' }, { status: 400 })
+      }
+      updates.due_status = body.due_status
+    }
+    if ('authorization_status' in body) {
+      if (!isAuthorizationStatus(body.authorization_status)) {
+        return NextResponse.json({ error: 'Invalid authorization status' }, { status: 400 })
+      }
+      updates.authorization_status = body.authorization_status
+    }
+    if ('title' in body) {
+      const title = cleanText(body.title)
+      if (!title) return NextResponse.json({ error: 'Title cannot be blank' }, { status: 400 })
+      updates.title = title.slice(0, 240)
+    }
+    if ('planned_angle' in body) updates.planned_angle = cleanText(body.planned_angle) || null
+    if ('scheduled_for' in body) {
+      const scheduledFor = isoOrNull(body.scheduled_for)
+      if (!scheduledFor) return NextResponse.json({ error: 'Valid scheduled_for is required' }, { status: 400 })
+      updates.scheduled_for = scheduledFor
+      if (!('due_status' in body)) updates.due_status = deriveDueStatus(scheduledFor)
+      if (!('authorization_due_at' in body)) {
+        updates.authorization_due_at = defaultAuthorizationDueAt(scheduledFor)
+      }
+    }
+    if ('authorization_due_at' in body) updates.authorization_due_at = isoOrNull(body.authorization_due_at)
+    if ('last_pinged_at' in body) updates.last_pinged_at = isoOrNull(body.last_pinged_at)
+    if ('autonomy_eligible' in body) updates.autonomy_eligible = body.autonomy_eligible === true
+
+    const metadataPatch = parseMetadata(body.metadata)
+    const decisionNote = cleanText(body.decision_note)
+    if (updates.authorization_status === 'rejected' && !decisionNote) {
+      return NextResponse.json({ error: 'Decision note is required when rejecting a calendar item' }, { status: 400 })
+    }
+
+    if (Object.keys(metadataPatch).length > 0 || decisionNote || updates.authorization_status) {
+      const { data: existing, error: readError } = await supabaseAdmin
+        .from('social_content_calendar_items')
+        .select('metadata')
+        .eq('id', params.id)
+        .maybeSingle()
+      if (readError) throw readError
+      const currentMetadata = parseMetadata(existing?.metadata)
+      updates.metadata = {
+        ...currentMetadata,
+        ...metadataPatch,
+        external_execution_enabled: false,
+      }
+      if (decisionNote) {
+        updates.metadata = {
+          ...(updates.metadata as Record<string, unknown>),
+          authorization_decision_note: decisionNote,
+        }
+      }
+      if (updates.authorization_status === 'authorized') {
+        updates.metadata = {
+          ...(updates.metadata as Record<string, unknown>),
+          authorized_at: new Date().toISOString(),
+          authorized_by: auth.user.id,
+          draft_handoff_only: true,
+        }
+      }
+      if (updates.authorization_status === 'rejected') {
+        updates.metadata = {
+          ...(updates.metadata as Record<string, unknown>),
+          rejected_at: new Date().toISOString(),
+          rejected_by: auth.user.id,
+          returned_to_shaka: true,
+        }
+      }
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return NextResponse.json({ error: 'No fields to update' }, { status: 400 })
+    }
+
+    const { data, error } = await supabaseAdmin
+      .from('social_content_calendar_items')
+      .update(updates)
+      .eq('id', params.id)
+      .select(`
+        *,
+        attraction_campaigns (id, name, slug, status, starts_at, ends_at),
+        agent_work_items (id, title, status, priority),
+        social_content_queue (id, status, post_text, scheduled_for)
+      `)
+      .single()
+
+    if (error) throw error
+
+    return NextResponse.json({
+      ok: true,
+      item: data,
+      side_effects: CALENDAR_SIDE_EFFECTS,
+    })
+  } catch (error) {
+    console.error('[social-content-calendar] update failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to update calendar item' },
+      { status: 500 },
+    )
+  }
+}

--- a/app/api/admin/social-content/calendar/route.test.ts
+++ b/app/api/admin/social-content/calendar/route.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  from: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: { from: mocks.from },
+}))
+
+import { GET, POST } from './route'
+
+function request(url: string, body?: Record<string, unknown>) {
+  return new Request(url, {
+    method: body ? 'POST' : 'GET',
+    headers: { authorization: 'Bearer admin-token', 'content-type': 'application/json' },
+    body: body ? JSON.stringify(body) : undefined,
+  })
+}
+
+function listQuery(data: unknown[] = []) {
+  const query: Record<string, unknown> = {
+    data,
+    error: null,
+    order: vi.fn(() => query),
+    limit: vi.fn(() => query),
+    eq: vi.fn(() => query),
+    gte: vi.fn(() => query),
+    lte: vi.fn(() => query),
+    lt: vi.fn(() => query),
+  }
+  mocks.from.mockReturnValue({ select: vi.fn(() => query) })
+  return query
+}
+
+describe('/api/admin/social-content/calendar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+  })
+
+  it('requires admin auth when listing calendar items', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await GET(request('http://localhost/api/admin/social-content/calendar') as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.from).not.toHaveBeenCalled()
+  })
+
+  it('filters by campaign, channel, phase, due window, and authorization state', async () => {
+    const query = listQuery([{ id: 'calendar-1', title: 'Tease item' }])
+
+    const response = await GET(request(
+      'http://localhost/api/admin/social-content/calendar?campaign_id=campaign-1&channel=youtube_shorts&campaign_phase=teach&authorization_status=pending&due_window=24h',
+    ) as never)
+
+    expect(response.status).toBe(200)
+    expect(mocks.from).toHaveBeenCalledWith('social_content_calendar_items')
+    expect(query.eq).toHaveBeenCalledWith('campaign_id', 'campaign-1')
+    expect(query.eq).toHaveBeenCalledWith('channel', 'youtube_shorts')
+    expect(query.eq).toHaveBeenCalledWith('campaign_phase', 'teach')
+    expect(query.eq).toHaveBeenCalledWith('authorization_status', 'pending')
+    expect(query.gte).toHaveBeenCalledWith('scheduled_for', expect.any(String))
+    expect(query.lte).toHaveBeenCalledWith('scheduled_for', expect.any(String))
+    expect(await response.json()).toMatchObject({
+      items: [{ id: 'calendar-1' }],
+      side_effects: { publish: false, external_post: false },
+    })
+  })
+
+  it('creates a pending calendar item without external side effects', async () => {
+    const single = vi.fn(async () => ({
+      data: { id: 'calendar-new', title: 'Teach item', authorization_status: 'pending' },
+      error: null,
+    }))
+    const select = vi.fn(() => ({ single }))
+    const insert = vi.fn(() => ({ select }))
+    mocks.from.mockReturnValue({ insert })
+
+    const response = await POST(request('http://localhost/api/admin/social-content/calendar', {
+      campaign_id: 'campaign-1',
+      title: 'Teach item',
+      channel: 'linkedin',
+      campaign_phase: 'teach',
+      scheduled_for: '2026-06-25T14:00:00.000Z',
+      planned_angle: 'Teach the campaign framework.',
+    }) as never)
+
+    expect(response.status).toBe(201)
+    expect(insert).toHaveBeenCalledWith(expect.objectContaining({
+      campaign_id: 'campaign-1',
+      title: 'Teach item',
+      channel: 'linkedin',
+      campaign_phase: 'teach',
+      authorization_status: 'pending',
+      autonomy_eligible: false,
+      created_by: 'admin-user',
+      metadata: expect.objectContaining({
+        external_execution_enabled: false,
+      }),
+    }))
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      item: { id: 'calendar-new' },
+      side_effects: {
+        provider_generation: false,
+        upload: false,
+        publish: false,
+        external_post: false,
+      },
+    })
+  })
+})

--- a/app/api/admin/social-content/calendar/route.ts
+++ b/app/api/admin/social-content/calendar/route.ts
@@ -1,0 +1,168 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { supabaseAdmin } from '@/lib/supabase'
+import {
+  CALENDAR_SIDE_EFFECTS,
+  defaultAuthorizationDueAt,
+  deriveDueStatus,
+  normalizeAuthorizationStatus,
+  normalizeCalendarChannel,
+  normalizeCampaignPhase,
+  normalizeDueStatus,
+  parseMetadata,
+} from '@/lib/social-content-calendar'
+
+export const dynamic = 'force-dynamic'
+
+function cleanText(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function isoOrNull(value: unknown) {
+  if (typeof value !== 'string' || !value.trim()) return null
+  const date = new Date(value)
+  return Number.isFinite(date.getTime()) ? date.toISOString() : null
+}
+
+function limitFrom(value: string | null) {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) return 50
+  return Math.min(Math.max(Math.floor(parsed), 1), 100)
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const auth = await verifyAdmin(request)
+    if (isAuthError(auth)) {
+      return NextResponse.json({ error: auth.error }, { status: auth.status })
+    }
+
+    const { searchParams } = new URL(request.url)
+    const limit = limitFrom(searchParams.get('limit'))
+    const campaignId = searchParams.get('campaign_id')
+    const channel = searchParams.get('channel')
+    const phase = searchParams.get('campaign_phase')
+    const dueStatus = searchParams.get('due_status')
+    const authorizationStatus = searchParams.get('authorization_status')
+    const dueWindow = searchParams.get('due_window')
+    const from = isoOrNull(searchParams.get('from'))
+    const to = isoOrNull(searchParams.get('to'))
+
+    let query = supabaseAdmin
+      .from('social_content_calendar_items')
+      .select(`
+        *,
+        attraction_campaigns (id, name, slug, status, starts_at, ends_at),
+        agent_work_items (id, title, status, priority),
+        social_content_queue (id, status, post_text, scheduled_for)
+      `)
+      .order('scheduled_for', { ascending: true })
+      .limit(limit)
+
+    if (campaignId) query = query.eq('campaign_id', campaignId)
+    if (channel) query = query.eq('channel', normalizeCalendarChannel(channel))
+    if (phase) query = query.eq('campaign_phase', normalizeCampaignPhase(phase))
+    if (dueStatus) query = query.eq('due_status', normalizeDueStatus(dueStatus))
+    if (authorizationStatus) {
+      query = query.eq('authorization_status', normalizeAuthorizationStatus(authorizationStatus))
+    }
+    if (from) query = query.gte('scheduled_for', from)
+    if (to) query = query.lte('scheduled_for', to)
+
+    if (dueWindow === '24h' || dueWindow === '2h') {
+      const now = new Date()
+      const hours = dueWindow === '2h' ? 2 : 24
+      query = query.gte('scheduled_for', now.toISOString())
+        .lte('scheduled_for', new Date(now.getTime() + hours * 60 * 60 * 1000).toISOString())
+    } else if (dueWindow === 'past_due') {
+      query = query.lt('scheduled_for', new Date().toISOString())
+    }
+
+    const { data, error } = await query
+    if (error) {
+      if (error.code === '42P01' || error.code === 'PGRST205') {
+        return NextResponse.json({ items: [], side_effects: CALENDAR_SIDE_EFFECTS })
+      }
+      throw error
+    }
+
+    return NextResponse.json({
+      items: data ?? [],
+      side_effects: CALENDAR_SIDE_EFFECTS,
+    })
+  } catch (error) {
+    console.error('[social-content-calendar] list failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to load content calendar' },
+      { status: 500 },
+    )
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await verifyAdmin(request)
+    if (isAuthError(auth)) {
+      return NextResponse.json({ error: auth.error }, { status: auth.status })
+    }
+
+    const body = await request.json().catch(() => ({})) as Record<string, unknown>
+    const title = cleanText(body.title)
+    const scheduledFor = isoOrNull(body.scheduled_for)
+
+    if (!title) {
+      return NextResponse.json({ error: 'Title is required' }, { status: 400 })
+    }
+    if (!scheduledFor) {
+      return NextResponse.json({ error: 'Valid scheduled_for is required' }, { status: 400 })
+    }
+
+    const authorizationDueAt = isoOrNull(body.authorization_due_at)
+      ?? defaultAuthorizationDueAt(scheduledFor)
+
+    const insert = {
+      campaign_id: cleanText(body.campaign_id) || null,
+      agent_work_item_id: cleanText(body.agent_work_item_id) || null,
+      social_content_id: cleanText(body.social_content_id) || null,
+      channel: normalizeCalendarChannel(body.channel),
+      campaign_phase: normalizeCampaignPhase(body.campaign_phase),
+      title: title.slice(0, 240),
+      planned_angle: cleanText(body.planned_angle) || null,
+      scheduled_for: scheduledFor,
+      due_status: normalizeDueStatus(body.due_status ?? deriveDueStatus(scheduledFor)),
+      authorization_status: normalizeAuthorizationStatus(body.authorization_status),
+      authorization_due_at: authorizationDueAt,
+      autonomy_eligible: body.autonomy_eligible === true,
+      metadata: {
+        ...parseMetadata(body.metadata),
+        external_execution_enabled: false,
+      },
+      created_by: auth.user.id,
+    }
+
+    const { data, error } = await supabaseAdmin
+      .from('social_content_calendar_items')
+      .insert(insert)
+      .select(`
+        *,
+        attraction_campaigns (id, name, slug, status, starts_at, ends_at),
+        agent_work_items (id, title, status, priority),
+        social_content_queue (id, status, post_text, scheduled_for)
+      `)
+      .single()
+
+    if (error) throw error
+
+    return NextResponse.json({
+      ok: true,
+      item: data,
+      side_effects: CALENDAR_SIDE_EFFECTS,
+    }, { status: 201 })
+  } catch (error) {
+    console.error('[social-content-calendar] create failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to create calendar item' },
+      { status: 500 },
+    )
+  }
+}

--- a/app/api/cron/social-content-calendar-due-gates/route.test.ts
+++ b/app/api/cron/social-content-calendar-due-gates/route.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  from: vi.fn(),
+  createAgentWorkItem: vi.fn(),
+  runAgentSlackNotificationSweep: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: { from: mocks.from },
+}))
+
+vi.mock('@/lib/agent-work-items', () => ({
+  createAgentWorkItem: mocks.createAgentWorkItem,
+}))
+
+vi.mock('@/lib/agent-slack-notification-sweep', () => ({
+  runAgentSlackNotificationSweep: mocks.runAgentSlackNotificationSweep,
+}))
+
+import { GET, POST } from './route'
+
+function request(url: string, method = 'GET') {
+  return new Request(url, {
+    method,
+    headers: { authorization: 'Bearer cron-secret' },
+  })
+}
+
+function mockDueGateQuery(items: unknown[]) {
+  const query: Record<string, unknown> = {
+    data: items,
+    error: null,
+    eq: vi.fn(() => query),
+    lte: vi.fn(() => query),
+    order: vi.fn(() => query),
+    limit: vi.fn(() => query),
+  }
+  mocks.from.mockReturnValue({ select: vi.fn(() => query) })
+  return query
+}
+
+describe('/api/cron/social-content-calendar-due-gates', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.CRON_SECRET = 'cron-secret'
+    process.env.N8N_INGEST_SECRET = ''
+  })
+
+  it('rejects unauthenticated cron requests', async () => {
+    const response = await GET(new Request('http://localhost/api/cron/social-content-calendar-due-gates') as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.from).not.toHaveBeenCalled()
+  })
+
+  it('supports dry-run due-gate scans without creating work items', async () => {
+    const scheduledFor = new Date(Date.now() + 60 * 60 * 1000).toISOString()
+    const query = mockDueGateQuery([
+      {
+        id: 'calendar-1',
+        title: 'Authorize tomorrow post',
+        campaign_id: 'campaign-1',
+        agent_work_item_id: 'work-social-1',
+        social_content_id: null,
+        channel: 'linkedin',
+        campaign_phase: 'teach',
+        scheduled_for: scheduledFor,
+        authorization_status: 'pending',
+        metadata: {},
+      },
+    ])
+
+    const response = await GET(request('http://localhost/api/cron/social-content-calendar-due-gates?dry_run=1') as never)
+
+    expect(response.status).toBe(200)
+    expect(query.eq).toHaveBeenCalledWith('authorization_status', 'pending')
+    expect(query.lte).toHaveBeenCalledWith('scheduled_for', expect.any(String))
+    expect(mocks.createAgentWorkItem).not.toHaveBeenCalled()
+    expect(mocks.runAgentSlackNotificationSweep).not.toHaveBeenCalled()
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      dry_run: true,
+      candidate_count: 1,
+      pinged_count: 0,
+      candidates: [expect.objectContaining({ id: 'calendar-1', due_gate_window: '2h' })],
+      side_effects: { publish: false, external_post: false },
+    })
+  })
+
+  it('creates a deduped Agent Ops work item for due authorization without publishing', async () => {
+    const scheduledFor = new Date(Date.now() + 60 * 60 * 1000).toISOString()
+    const selectQuery: Record<string, unknown> = {
+      data: [
+        {
+          id: 'calendar-1',
+          title: 'Authorize tomorrow post',
+          campaign_id: 'campaign-1',
+          agent_work_item_id: 'work-social-1',
+          social_content_id: null,
+          channel: 'linkedin',
+          campaign_phase: 'teach',
+          scheduled_for: scheduledFor,
+          authorization_status: 'pending',
+          metadata: {},
+        },
+      ],
+      error: null,
+      eq: vi.fn(() => selectQuery),
+      lte: vi.fn(() => selectQuery),
+      order: vi.fn(() => selectQuery),
+      limit: vi.fn(() => selectQuery),
+    }
+    const updateEq = vi.fn(async () => ({ data: null, error: null }))
+    const update = vi.fn(() => ({ eq: updateEq }))
+    mocks.from
+      .mockReturnValueOnce({ select: vi.fn(() => selectQuery) })
+      .mockReturnValue({ update })
+    mocks.createAgentWorkItem.mockResolvedValue({ id: 'work-due-gate' })
+    mocks.runAgentSlackNotificationSweep.mockResolvedValue({ sentCount: 1 })
+
+    const response = await POST(request('http://localhost/api/cron/social-content-calendar-due-gates', 'POST') as never)
+
+    expect(response.status).toBe(200)
+    expect(mocks.createAgentWorkItem).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'Authorize content calendar item: Authorize tomorrow post',
+      priority: 'urgent',
+      ownerAgentKey: 'chief-of-staff',
+      source: {
+        type: 'social_content_calendar_due_gate',
+        id: 'calendar-1',
+        label: 'Authorize tomorrow post',
+      },
+      metadata: expect.objectContaining({
+        approval_action: 'authorize_internal_platform_draft_handoff',
+        side_effects: expect.objectContaining({ publish: false, external_post: false }),
+      }),
+      idempotencyKey: 'social-content-calendar-due:calendar-1:2h',
+    }))
+    expect(update).toHaveBeenCalledWith(expect.objectContaining({
+      metadata: expect.objectContaining({
+        external_execution_enabled: false,
+        due_gate_pings: expect.objectContaining({
+          '2h': expect.objectContaining({ work_item_id: 'work-due-gate' }),
+        }),
+      }),
+    }))
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      dry_run: false,
+      pinged_count: 1,
+      side_effects: {
+        publish: false,
+        external_post: false,
+        internal_work_items_created: 1,
+        slack_notification_requested: true,
+      },
+    })
+  })
+})

--- a/app/api/cron/social-content-calendar-due-gates/route.ts
+++ b/app/api/cron/social-content-calendar-due-gates/route.ts
@@ -1,0 +1,220 @@
+/**
+ * GET/POST /api/cron/social-content-calendar-due-gates
+ *
+ * Finds pending calendar authorization gates due within 24h/2h and creates
+ * internal Agent Ops work items. Auth: Bearer CRON_SECRET or N8N_INGEST_SECRET.
+ * This route does not publish, upload, schedule externally, or call providers.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { createAgentWorkItem } from '@/lib/agent-work-items'
+import { runAgentSlackNotificationSweep } from '@/lib/agent-slack-notification-sweep'
+import { supabaseAdmin } from '@/lib/supabase'
+import {
+  CALENDAR_SIDE_EFFECTS,
+  dueGateWindow,
+  deriveDueStatus,
+  parseMetadata,
+  type SocialContentCalendarItem,
+} from '@/lib/social-content-calendar'
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 60
+
+function isAuthorizedCronRequest(request: NextRequest): boolean {
+  const token = request.headers.get('authorization')?.replace(/^Bearer\s+/i, '')
+  const allowedTokens = [process.env.CRON_SECRET, process.env.N8N_INGEST_SECRET].filter(Boolean)
+  return Boolean(token && allowedTokens.includes(token))
+}
+
+async function bodyOrEmpty(request: NextRequest) {
+  if (request.method === 'GET') return {}
+  return request.json().catch(() => ({})) as Promise<Record<string, unknown>>
+}
+
+function isDryRun(request: NextRequest, body: Record<string, unknown>) {
+  const { searchParams } = new URL(request.url)
+  return searchParams.get('dry_run') === '1'
+    || searchParams.get('dry_run') === 'true'
+    || body.dry_run === true
+}
+
+function pingAlreadySent(item: SocialContentCalendarItem, window: '24h' | '2h') {
+  const metadata = parseMetadata(item.metadata)
+  const pings = parseMetadata(metadata.due_gate_pings)
+  return Boolean(pings[window])
+}
+
+async function runDueGateSweep(request: NextRequest) {
+  if (!isAuthorizedCronRequest(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const body = await bodyOrEmpty(request)
+    const dryRun = isDryRun(request, body)
+    const now = new Date()
+    const windowEnd = new Date(now.getTime() + 24 * 60 * 60 * 1000)
+
+    const { data, error } = await supabaseAdmin
+      .from('social_content_calendar_items')
+      .select(`
+        *,
+        attraction_campaigns (id, name, slug, status, starts_at, ends_at),
+        agent_work_items (id, title, status, priority),
+        social_content_queue (id, status, post_text, scheduled_for)
+      `)
+      .eq('authorization_status', 'pending')
+      .lte('scheduled_for', windowEnd.toISOString())
+      .order('scheduled_for', { ascending: true })
+      .limit(50)
+
+    if (error) {
+      if (error.code === '42P01' || error.code === 'PGRST205') {
+        return NextResponse.json({
+          ok: true,
+          dry_run: dryRun,
+          candidate_count: 0,
+          pinged_count: 0,
+          candidates: [],
+          side_effects: CALENDAR_SIDE_EFFECTS,
+        })
+      }
+      throw error
+    }
+
+    const candidates = ((data ?? []) as SocialContentCalendarItem[])
+      .map((item) => ({ item, window: dueGateWindow(item.scheduled_for, now) }))
+      .filter((entry): entry is { item: SocialContentCalendarItem; window: '24h' | '2h' } => (
+        Boolean(entry.window) && !pingAlreadySent(entry.item, entry.window as '24h' | '2h')
+      ))
+
+    if (dryRun) {
+      return NextResponse.json({
+        ok: true,
+        dry_run: true,
+        candidate_count: candidates.length,
+        pinged_count: 0,
+        candidates: candidates.map(({ item, window }) => ({
+          id: item.id,
+          title: item.title,
+          scheduled_for: item.scheduled_for,
+          due_gate_window: window,
+          campaign_id: item.campaign_id,
+          channel: item.channel,
+          campaign_phase: item.campaign_phase,
+        })),
+        side_effects: CALENDAR_SIDE_EFFECTS,
+      })
+    }
+
+    const pinged: Array<{ calendar_item_id: string; work_item_id: string; window: '24h' | '2h' }> = []
+
+    for (const { item, window } of candidates) {
+      const idempotencyKey = `social-content-calendar-due:${item.id}:${window}`
+      const workItem = await createAgentWorkItem({
+        title: `Authorize content calendar item: ${item.title}`,
+        objective: [
+          `Review the ${window} due gate for ${item.channel.replace(/_/g, ' ')} content.`,
+          'Authorize only the internal platform draft handoff if the item is ready.',
+          'Reject with a decision note if Shaka or research should revise it.',
+          'Do not publish, upload, schedule externally, or call media providers from this gate.',
+        ].join(' '),
+        priority: window === '2h' ? 'urgent' : 'high',
+        status: 'queued',
+        ownerAgentKey: 'chief-of-staff',
+        ownerRuntime: 'codex',
+        source: {
+          type: 'social_content_calendar_due_gate',
+          id: item.id,
+          label: item.title,
+        },
+        overlapGroup: 'social-content-calendar',
+        metadata: {
+          goal_id: 'social-content-calendar',
+          requires_approval: true,
+          calendar_item_id: item.id,
+          campaign_id: item.campaign_id,
+          agent_work_item_id: item.agent_work_item_id,
+          social_content_id: item.social_content_id,
+          channel: item.channel,
+          campaign_phase: item.campaign_phase,
+          scheduled_for: item.scheduled_for,
+          due_gate_window: window,
+          approval_action: 'authorize_internal_platform_draft_handoff',
+          rejection_action: 'return_to_shaka_or_research_revision',
+          side_effects: {
+            ...CALENDAR_SIDE_EFFECTS,
+            social_draft_handoff_only: true,
+          },
+        },
+        idempotencyKey,
+      })
+
+      const metadata = parseMetadata(item.metadata)
+      const dueGatePings = parseMetadata(metadata.due_gate_pings)
+      await supabaseAdmin
+        .from('social_content_calendar_items')
+        .update({
+          due_status: deriveDueStatus(item.scheduled_for, now),
+          last_pinged_at: now.toISOString(),
+          metadata: {
+            ...metadata,
+            due_gate_pings: {
+              ...dueGatePings,
+              [window]: {
+                pinged_at: now.toISOString(),
+                work_item_id: workItem.id,
+              },
+            },
+            external_execution_enabled: false,
+          },
+        })
+        .eq('id', item.id)
+
+      pinged.push({ calendar_item_id: item.id, work_item_id: workItem.id, window })
+    }
+
+    const slackResult = pinged.length > 0
+      ? await runAgentSlackNotificationSweep({
+          mode: 'immediate',
+          kinds: ['goal_decisions'],
+          goalId: 'social-content-calendar',
+          actorLabel: request.method === 'GET' ? 'Calendar due-gate cron' : 'Manual calendar due-gate sweep',
+          triggerSource: request.method === 'GET'
+            ? 'vercel_cron_social_content_calendar_due_gates'
+            : 'manual_social_content_calendar_due_gates',
+        }).catch((notificationError) => ({
+          error: notificationError instanceof Error ? notificationError.message : 'Slack sweep failed',
+        }))
+      : null
+
+    return NextResponse.json({
+      ok: true,
+      dry_run: false,
+      candidate_count: candidates.length,
+      pinged_count: pinged.length,
+      pinged,
+      slack_notification_result: slackResult,
+      side_effects: {
+        ...CALENDAR_SIDE_EFFECTS,
+        internal_work_items_created: pinged.length,
+        slack_notification_requested: pinged.length > 0,
+      },
+    })
+  } catch (error) {
+    console.error('[social-content-calendar-due-gates] failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Calendar due-gate sweep failed' },
+      { status: 500 },
+    )
+  }
+}
+
+export async function GET(request: NextRequest) {
+  return runDueGateSweep(request)
+}
+
+export async function POST(request: NextRequest) {
+  return runDueGateSweep(request)
+}

--- a/lib/social-content-calendar.ts
+++ b/lib/social-content-calendar.ts
@@ -1,0 +1,233 @@
+import type { AttractionCampaign } from '@/lib/campaigns'
+
+export const SOCIAL_CONTENT_CALENDAR_CHANNELS = [
+  'linkedin',
+  'youtube_shorts',
+  'instagram_reels',
+  'thumbnail',
+] as const
+
+export const SOCIAL_CONTENT_CAMPAIGN_PHASES = ['tease', 'teach', 'proof', 'offer'] as const
+
+export const SOCIAL_CONTENT_CALENDAR_DUE_STATUSES = [
+  'planned',
+  'due_soon',
+  'due_now',
+  'past_due',
+  'completed',
+  'cancelled',
+] as const
+
+export const SOCIAL_CONTENT_CALENDAR_AUTHORIZATION_STATUSES = [
+  'not_required',
+  'pending',
+  'authorized',
+  'rejected',
+  'expired',
+] as const
+
+export type SocialContentCalendarChannel = (typeof SOCIAL_CONTENT_CALENDAR_CHANNELS)[number]
+export type SocialContentCampaignPhase = (typeof SOCIAL_CONTENT_CAMPAIGN_PHASES)[number]
+export type SocialContentCalendarDueStatus = (typeof SOCIAL_CONTENT_CALENDAR_DUE_STATUSES)[number]
+export type SocialContentCalendarAuthorizationStatus =
+  (typeof SOCIAL_CONTENT_CALENDAR_AUTHORIZATION_STATUSES)[number]
+
+export type SocialContentCalendarItem = {
+  id: string
+  campaign_id: string | null
+  agent_work_item_id: string | null
+  social_content_id: string | null
+  channel: SocialContentCalendarChannel
+  campaign_phase: SocialContentCampaignPhase
+  title: string
+  planned_angle: string | null
+  scheduled_for: string
+  due_status: SocialContentCalendarDueStatus
+  authorization_status: SocialContentCalendarAuthorizationStatus
+  authorization_due_at: string | null
+  last_pinged_at: string | null
+  autonomy_eligible: boolean
+  metadata: Record<string, unknown>
+  created_by: string | null
+  created_at: string
+  updated_at: string
+  attraction_campaigns?: {
+    id: string
+    name: string
+    slug: string
+    status: string
+    starts_at: string | null
+    ends_at: string | null
+  } | null
+  agent_work_items?: {
+    id: string
+    title: string
+    status: string
+    priority?: string | null
+  } | null
+  social_content_queue?: {
+    id: string
+    status: string
+    post_text?: string | null
+    scheduled_for?: string | null
+  } | null
+}
+
+export const CALENDAR_SIDE_EFFECTS = {
+  provider_generation: false,
+  upload: false,
+  external_schedule: false,
+  publish: false,
+  external_post: false,
+} as const
+
+export const CALENDAR_CHANNEL_LABELS: Record<SocialContentCalendarChannel, string> = {
+  linkedin: 'LinkedIn',
+  youtube_shorts: 'YouTube Shorts',
+  instagram_reels: 'Instagram Reels',
+  thumbnail: 'Thumbnail',
+}
+
+export const CAMPAIGN_PHASE_LABELS: Record<SocialContentCampaignPhase, string> = {
+  tease: 'Tease',
+  teach: 'Teach',
+  proof: 'Proof',
+  offer: 'Offer',
+}
+
+export function isCalendarChannel(value: unknown): value is SocialContentCalendarChannel {
+  return typeof value === 'string'
+    && SOCIAL_CONTENT_CALENDAR_CHANNELS.includes(value as SocialContentCalendarChannel)
+}
+
+export function isCampaignPhase(value: unknown): value is SocialContentCampaignPhase {
+  return typeof value === 'string'
+    && SOCIAL_CONTENT_CAMPAIGN_PHASES.includes(value as SocialContentCampaignPhase)
+}
+
+export function isDueStatus(value: unknown): value is SocialContentCalendarDueStatus {
+  return typeof value === 'string'
+    && SOCIAL_CONTENT_CALENDAR_DUE_STATUSES.includes(value as SocialContentCalendarDueStatus)
+}
+
+export function isAuthorizationStatus(value: unknown): value is SocialContentCalendarAuthorizationStatus {
+  return typeof value === 'string'
+    && SOCIAL_CONTENT_CALENDAR_AUTHORIZATION_STATUSES.includes(
+      value as SocialContentCalendarAuthorizationStatus,
+    )
+}
+
+export function normalizeCalendarChannel(value: unknown): SocialContentCalendarChannel {
+  return isCalendarChannel(value) ? value : 'linkedin'
+}
+
+export function normalizeCampaignPhase(value: unknown): SocialContentCampaignPhase {
+  return isCampaignPhase(value) ? value : 'tease'
+}
+
+export function normalizeDueStatus(value: unknown): SocialContentCalendarDueStatus {
+  return isDueStatus(value) ? value : 'planned'
+}
+
+export function normalizeAuthorizationStatus(value: unknown): SocialContentCalendarAuthorizationStatus {
+  return isAuthorizationStatus(value) ? value : 'pending'
+}
+
+export function defaultAuthorizationDueAt(scheduledFor: string | Date) {
+  const scheduled = typeof scheduledFor === 'string' ? new Date(scheduledFor) : scheduledFor
+  if (!Number.isFinite(scheduled.getTime())) return null
+  const due = new Date(scheduled.getTime() - 24 * 60 * 60 * 1000)
+  return due.toISOString()
+}
+
+export function deriveDueStatus(
+  scheduledFor: string | Date,
+  now: Date = new Date(),
+): SocialContentCalendarDueStatus {
+  const scheduled = typeof scheduledFor === 'string' ? new Date(scheduledFor) : scheduledFor
+  if (!Number.isFinite(scheduled.getTime())) return 'planned'
+
+  const diffMs = scheduled.getTime() - now.getTime()
+  if (diffMs < -2 * 60 * 60 * 1000) return 'past_due'
+  if (diffMs <= 2 * 60 * 60 * 1000) return 'due_now'
+  if (diffMs <= 24 * 60 * 60 * 1000) return 'due_soon'
+  return 'planned'
+}
+
+export function dueGateWindow(scheduledFor: string | Date, now: Date = new Date()): '24h' | '2h' | null {
+  const scheduled = typeof scheduledFor === 'string' ? new Date(scheduledFor) : scheduledFor
+  if (!Number.isFinite(scheduled.getTime())) return null
+  const diffMs = scheduled.getTime() - now.getTime()
+  if (diffMs < -2 * 60 * 60 * 1000 || diffMs > 24 * 60 * 60 * 1000) return null
+  if (diffMs <= 2 * 60 * 60 * 1000) return '2h'
+  return '24h'
+}
+
+export function parseMetadata(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {}
+}
+
+function dateOrNull(value: string | null | undefined) {
+  if (!value) return null
+  const date = new Date(value)
+  return Number.isFinite(date.getTime()) ? date : null
+}
+
+function addDays(date: Date, days: number) {
+  const next = new Date(date)
+  next.setDate(next.getDate() + days)
+  return next
+}
+
+function atLocalWorkHour(date: Date, hour = 10) {
+  const next = new Date(date)
+  next.setHours(hour, 0, 0, 0)
+  return next
+}
+
+function campaignDateAt(start: Date, end: Date, ratio: number) {
+  const time = start.getTime() + (end.getTime() - start.getTime()) * ratio
+  return atLocalWorkHour(new Date(time))
+}
+
+export function campaignContentPlanSlots(campaign: Pick<AttractionCampaign, 'name' | 'starts_at' | 'ends_at'>) {
+  const start = dateOrNull(campaign.starts_at) ?? addDays(new Date(), 1)
+  const end = dateOrNull(campaign.ends_at) ?? addDays(start, 21)
+  const hasUsableWindow = end.getTime() > start.getTime()
+  const baseStart = atLocalWorkHour(start)
+
+  const scheduledDates = hasUsableWindow
+    ? [
+        campaignDateAt(start, end, 0.1),
+        campaignDateAt(start, end, 0.35),
+        campaignDateAt(start, end, 0.65),
+        campaignDateAt(start, end, 0.9),
+      ]
+    : [baseStart, addDays(baseStart, 3), addDays(baseStart, 6), addDays(baseStart, 9)]
+
+  const angles: Record<SocialContentCampaignPhase, string> = {
+    tease: 'Open with a small tension, observation, or question that makes the campaign problem visible.',
+    teach: 'Give the audience a useful framework or operating lesson connected to the campaign promise.',
+    proof: 'Show evidence, a shipped example, client-safe result, or lived project insight that earns trust.',
+    offer: 'Make the clearest campaign offer, bonus, release, or invitation as the campaign reaches the shout moment.',
+  }
+
+  return SOCIAL_CONTENT_CAMPAIGN_PHASES.map((phase, index) => ({
+    campaign_phase: phase,
+    channel: 'linkedin' as SocialContentCalendarChannel,
+    title: `${CAMPAIGN_PHASE_LABELS[phase]}: ${campaign.name}`,
+    planned_angle: angles[phase],
+    scheduled_for: scheduledDates[index].toISOString(),
+    authorization_due_at: defaultAuthorizationDueAt(scheduledDates[index]),
+    authorization_status: 'pending' as SocialContentCalendarAuthorizationStatus,
+    due_status: deriveDueStatus(scheduledDates[index]),
+    autonomy_eligible: false,
+    metadata: {
+      generated_from: 'campaign_content_plan',
+      campaign_arc: 'whisper_to_shout',
+      external_execution_enabled: false,
+    },
+  }))
+}

--- a/supabase/migrations/20260623182842_social_content_calendar_items.sql
+++ b/supabase/migrations/20260623182842_social_content_calendar_items.sql
@@ -1,0 +1,142 @@
+-- Campaign-aware Social Content calendar.
+-- This is the channel-agnostic planning layer for campaign arcs and due gates.
+-- Calendar authorization creates internal handoff work only; it does not publish,
+-- upload, schedule externally, or call media providers.
+
+CREATE TABLE IF NOT EXISTS public.social_content_calendar_items (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  campaign_id UUID REFERENCES public.attraction_campaigns(id) ON DELETE SET NULL,
+  agent_work_item_id UUID REFERENCES public.agent_work_items(id) ON DELETE SET NULL,
+  social_content_id UUID REFERENCES public.social_content_queue(id) ON DELETE SET NULL,
+  channel TEXT NOT NULL DEFAULT 'linkedin'
+    CHECK (channel IN ('linkedin', 'youtube_shorts', 'instagram_reels', 'thumbnail')),
+  campaign_phase TEXT NOT NULL DEFAULT 'tease'
+    CHECK (campaign_phase IN ('tease', 'teach', 'proof', 'offer')),
+  title TEXT NOT NULL,
+  planned_angle TEXT,
+  scheduled_for TIMESTAMPTZ NOT NULL,
+  due_status TEXT NOT NULL DEFAULT 'planned'
+    CHECK (due_status IN ('planned', 'due_soon', 'due_now', 'past_due', 'completed', 'cancelled')),
+  authorization_status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (authorization_status IN ('not_required', 'pending', 'authorized', 'rejected', 'expired')),
+  authorization_due_at TIMESTAMPTZ,
+  last_pinged_at TIMESTAMPTZ,
+  autonomy_eligible BOOLEAN NOT NULL DEFAULT false,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_by UUID REFERENCES public.user_profiles(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_social_content_calendar_campaign_id
+  ON public.social_content_calendar_items(campaign_id);
+
+CREATE INDEX IF NOT EXISTS idx_social_content_calendar_agent_work_item_id
+  ON public.social_content_calendar_items(agent_work_item_id);
+
+CREATE INDEX IF NOT EXISTS idx_social_content_calendar_social_content_id
+  ON public.social_content_calendar_items(social_content_id);
+
+CREATE INDEX IF NOT EXISTS idx_social_content_calendar_channel_phase
+  ON public.social_content_calendar_items(channel, campaign_phase);
+
+CREATE INDEX IF NOT EXISTS idx_social_content_calendar_schedule
+  ON public.social_content_calendar_items(scheduled_for);
+
+CREATE INDEX IF NOT EXISTS idx_social_content_calendar_authorization
+  ON public.social_content_calendar_items(authorization_status, scheduled_for);
+
+CREATE INDEX IF NOT EXISTS idx_social_content_calendar_due_status
+  ON public.social_content_calendar_items(due_status, scheduled_for);
+
+ALTER TABLE public.social_content_calendar_items ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Admins can read social content calendar items"
+  ON public.social_content_calendar_items;
+CREATE POLICY "Admins can read social content calendar items"
+  ON public.social_content_calendar_items
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.user_profiles
+      WHERE user_profiles.id = auth.uid()
+        AND user_profiles.role = 'admin'
+    )
+  );
+
+DROP POLICY IF EXISTS "Admins can insert social content calendar items"
+  ON public.social_content_calendar_items;
+CREATE POLICY "Admins can insert social content calendar items"
+  ON public.social_content_calendar_items
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.user_profiles
+      WHERE user_profiles.id = auth.uid()
+        AND user_profiles.role = 'admin'
+    )
+  );
+
+DROP POLICY IF EXISTS "Admins can update social content calendar items"
+  ON public.social_content_calendar_items;
+CREATE POLICY "Admins can update social content calendar items"
+  ON public.social_content_calendar_items
+  FOR UPDATE
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.user_profiles
+      WHERE user_profiles.id = auth.uid()
+        AND user_profiles.role = 'admin'
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.user_profiles
+      WHERE user_profiles.id = auth.uid()
+        AND user_profiles.role = 'admin'
+    )
+  );
+
+DROP POLICY IF EXISTS "Admins can delete social content calendar items"
+  ON public.social_content_calendar_items;
+CREATE POLICY "Admins can delete social content calendar items"
+  ON public.social_content_calendar_items
+  FOR DELETE
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.user_profiles
+      WHERE user_profiles.id = auth.uid()
+        AND user_profiles.role = 'admin'
+    )
+  );
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.social_content_calendar_items TO authenticated;
+GRANT ALL ON public.social_content_calendar_items TO service_role;
+
+DROP TRIGGER IF EXISTS update_social_content_calendar_items_updated_at
+  ON public.social_content_calendar_items;
+CREATE TRIGGER update_social_content_calendar_items_updated_at
+  BEFORE UPDATE ON public.social_content_calendar_items
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+COMMENT ON TABLE public.social_content_calendar_items IS
+  'Channel-agnostic Social Content calendar tied to campaigns, Shaka insights, governed drafts, and due-gate authorization. External publishing remains a separate gate.';
+
+COMMENT ON COLUMN public.social_content_calendar_items.campaign_phase IS
+  'Whisper-to-shout campaign phase: tease, teach, proof, or offer.';
+
+COMMENT ON COLUMN public.social_content_calendar_items.authorization_status IS
+  'Human due-gate state. Authorized means internal draft handoff may be prepared, not externally published.';
+
+COMMENT ON COLUMN public.social_content_calendar_items.autonomy_eligible IS
+  'Future autonomy metadata only. Defaults false and does not activate execution.';


### PR DESCRIPTION
## Summary
- Add a campaign-aware Social Content calendar table and shared helper logic for channel, campaign phase, due state, authorization state, and whisper-to-shout plan slots.
- Add admin planning APIs for listing/creating/updating calendar items, generating campaign content plans, and dry-running/triggering due-gate work items.
- Add Content Intelligence calendar lanes plus campaign list/detail projections so campaigns and calendar items stay tied to the same source of truth.

## Validation
- npm test -- --run app/api/admin/social-content/calendar/route.test.ts app/api/admin/social-content/calendar/[id]/route.test.ts app/api/admin/campaigns/[id]/content-plan/route.test.ts app/api/cron/social-content-calendar-due-gates/route.test.ts app/admin/agents/content-intelligence/page.test.tsx
- npx tsc --noEmit --pretty false
- git diff --check
- Browser smoke: opened http://127.0.0.1:3030/admin/agents/content-intelligence, verified Content Calendar and Campaign arc sections render, no framework overlay, no console errors, and calendar form title input accepts text without submitting. Browser screenshot capture timed out in the plugin, so DOM/console/interaction proof was used.
- Pre-push hook ran npm run db:health-check and passed.
- GitHub check: Vercel – portfolio passed on PR #560.

## Integration Notes
- Includes Supabase migration: supabase/migrations/20260623182842_social_content_calendar_items.sql. The route degrades to an empty calendar state when the local/dev DB has not applied the migration yet.
- The due-gate route is available at /api/cron/social-content-calendar-due-gates but is not registered in vercel.json, so no production schedule is activated by this PR.
- Calendar authorization creates internal Agent Ops work only; provider generation, uploads, external scheduling, and publishing remain locked.
- Vercel – portfolio: passed for the PR preview.
- Vercel – portfolio-staging: not checked by this implementation lane; integration captain should verify after merge.
