### PR TITLE
feat: add calendar draft handoff gates

### DIFF
--- a/app/admin/agents/content-intelligence/page.test.tsx
+++ b/app/admin/agents/content-intelligence/page.test.tsx
@@ -64,6 +64,47 @@ describe('ContentIntelligencePage', () => {
           }),
         }
       }
+      if (url === '/api/admin/social-content/calendar/calendar-1/authorize') {
+        return {
+          ok: true,
+          json: async () => ({
+            ok: true,
+            item: { id: 'calendar-1', authorization_status: 'authorized', social_content_id: 'social-1' },
+            handoff: {
+              kind: 'linkedin_social_content_draft',
+              work_item_id: 'work-handoff-1',
+              social_content_id: 'social-1',
+            },
+            side_effects: {
+              provider_generation: false,
+              upload: false,
+              external_schedule: false,
+              publish: false,
+              external_post: false,
+              internal_draft_handoff_created: true,
+              social_content_draft_created: true,
+            },
+          }),
+        }
+      }
+      if (url === '/api/admin/social-content/calendar/calendar-1/reject') {
+        return {
+          ok: true,
+          json: async () => ({
+            ok: true,
+            item: { id: 'calendar-1', authorization_status: 'rejected' },
+            revision_work_item_id: 'work-revision-1',
+            side_effects: {
+              provider_generation: false,
+              upload: false,
+              external_schedule: false,
+              publish: false,
+              external_post: false,
+              revision_work_item_created: true,
+            },
+          }),
+        }
+      }
       if (url === '/api/admin/social-content/calendar') {
         return {
           ok: true,
@@ -400,6 +441,46 @@ describe('ContentIntelligencePage', () => {
       channel: 'linkedin',
       campaign_phase: 'tease',
       planned_angle: 'Teach the operating framework behind the campaign.',
+    })
+  })
+
+  it('authorizes a calendar item as an internal draft handoff', async () => {
+    render(<ContentIntelligencePage />)
+
+    await screen.findByText('Tease: Approval gates')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Authorize Draft Handoff' }))
+
+    await screen.findByText('Draft handoff authorized and Social Content draft created.')
+
+    const authorizeCall = vi.mocked(fetch).mock.calls.find(([input]) => (
+      String(input) === '/api/admin/social-content/calendar/calendar-1/authorize'
+    ))
+    expect(authorizeCall).toBeTruthy()
+    expect(authorizeCall?.[1]).toMatchObject({ method: 'POST' })
+    expect(JSON.parse(String(authorizeCall?.[1]?.body))).toEqual({})
+  })
+
+  it('requires a decision note before rejecting a calendar item', async () => {
+    render(<ContentIntelligencePage />)
+
+    await screen.findByText('Tease: Approval gates')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reject' }))
+    fireEvent.change(screen.getAllByLabelText('Decision note')[0], {
+      target: { value: 'Needs stronger proof before this is due.' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Submit Rejection' }))
+
+    await screen.findByText('Calendar item rejected and returned to Shaka for revision.')
+
+    const rejectCall = vi.mocked(fetch).mock.calls.find(([input]) => (
+      String(input) === '/api/admin/social-content/calendar/calendar-1/reject'
+    ))
+    expect(rejectCall).toBeTruthy()
+    expect(rejectCall?.[1]).toMatchObject({ method: 'POST' })
+    expect(JSON.parse(String(rejectCall?.[1]?.body))).toEqual({
+      decision_note: 'Needs stronger proof before this is due.',
     })
   })
 })

--- a/app/admin/agents/content-intelligence/page.tsx
+++ b/app/admin/agents/content-intelligence/page.tsx
@@ -14,6 +14,7 @@ import {
   Plus,
   RefreshCw,
   ShieldCheck,
+  XCircle,
   Youtube,
 } from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
@@ -120,6 +121,7 @@ type CalendarItem = {
   authorization_status: string
   authorization_due_at: string | null
   autonomy_eligible: boolean
+  metadata?: Record<string, unknown> | null
   attraction_campaigns?: { id: string; name: string; slug: string } | null
   agent_work_items?: { id: string; title: string; status: string } | null
   social_content_queue?: { id: string; status: string } | null
@@ -220,6 +222,12 @@ function formatCalendarDate(value: string) {
     : 'Unscheduled'
 }
 
+function recordValue(value: unknown) {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {}
+}
+
 export default function ContentIntelligencePage() {
   return (
     <ProtectedRoute requireAdmin>
@@ -254,6 +262,9 @@ function ContentIntelligenceContent() {
   const [calendarChannelFilter, setCalendarChannelFilter] = useState('')
   const [calendarPhaseFilter, setCalendarPhaseFilter] = useState('')
   const [calendarAuthorizationFilter, setCalendarAuthorizationFilter] = useState('')
+  const [calendarActionItemId, setCalendarActionItemId] = useState<string | null>(null)
+  const [rejectingCalendarItemId, setRejectingCalendarItemId] = useState<string | null>(null)
+  const [calendarDecisionNotes, setCalendarDecisionNotes] = useState<Record<string, string>>({})
 
   const authedFetch = useCallback(async (path: string, init: RequestInit = {}) => {
     const session = await getCurrentSession()
@@ -485,6 +496,57 @@ function ContentIntelligenceContent() {
     }
   }, [authedFetch, calendarForm, load])
 
+  const authorizeCalendarItem = useCallback(async (item: CalendarItem) => {
+    setError(null)
+    setCalendarNotice(null)
+    setCalendarActionItemId(item.id)
+    try {
+      const response = await authedFetch(`/api/admin/social-content/calendar/${item.id}/authorize`, {
+        method: 'POST',
+        body: JSON.stringify({}),
+      })
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body.error || `Calendar authorize HTTP ${response.status}`)
+      setCalendarNotice(body.handoff?.social_content_id
+        ? 'Draft handoff authorized and Social Content draft created.'
+        : 'Draft handoff authorized for channel planning.')
+      await load()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to authorize calendar item')
+    } finally {
+      setCalendarActionItemId(null)
+    }
+  }, [authedFetch, load])
+
+  const rejectCalendarItem = useCallback(async (item: CalendarItem) => {
+    const decisionNote = calendarDecisionNotes[item.id]?.trim() ?? ''
+    if (!decisionNote) {
+      setRejectingCalendarItemId(item.id)
+      setError('Decision note is required when rejecting a calendar item.')
+      return
+    }
+
+    setError(null)
+    setCalendarNotice(null)
+    setCalendarActionItemId(item.id)
+    try {
+      const response = await authedFetch(`/api/admin/social-content/calendar/${item.id}/reject`, {
+        method: 'POST',
+        body: JSON.stringify({ decision_note: decisionNote }),
+      })
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body.error || `Calendar reject HTTP ${response.status}`)
+      setCalendarDecisionNotes((current) => ({ ...current, [item.id]: '' }))
+      setRejectingCalendarItemId(null)
+      setCalendarNotice('Calendar item rejected and returned to Shaka for revision.')
+      await load()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to reject calendar item')
+    } finally {
+      setCalendarActionItemId(null)
+    }
+  }, [authedFetch, calendarDecisionNotes, load])
+
   return (
     <div className="agent-ops-page min-h-screen p-5 text-foreground lg:p-7">
       <div className="mx-auto max-w-7xl">
@@ -615,7 +677,20 @@ function ContentIntelligenceContent() {
                 </div>
                 <div className="space-y-2">
                   {calendarItemsByPhase[phase.key].length ? calendarItemsByPhase[phase.key].map((item) => (
-                    <CalendarItemCard key={item.id} item={item} />
+                    <CalendarItemCard
+                      key={item.id}
+                      item={item}
+                      actionItemId={calendarActionItemId}
+                      rejectingItemId={rejectingCalendarItemId}
+                      decisionNote={calendarDecisionNotes[item.id] ?? ''}
+                      onAuthorize={authorizeCalendarItem}
+                      onBeginReject={(id) => setRejectingCalendarItemId(id)}
+                      onDecisionNoteChange={(id, value) => setCalendarDecisionNotes((current) => ({
+                        ...current,
+                        [id]: value,
+                      }))}
+                      onReject={rejectCalendarItem}
+                    />
                   )) : (
                     <p className="rounded-md border border-silicon-slate/60 bg-background/35 p-3 text-xs text-muted-foreground">
                       No planned items.
@@ -1171,8 +1246,47 @@ function DigestList({
   )
 }
 
-function CalendarItemCard({ item }: { item: CalendarItem }) {
+function calendarAuthorizationTone(status: string) {
+  if (status === 'authorized') {
+    return 'border-emerald-500/35 bg-emerald-500/10 text-emerald-100'
+  }
+  if (status === 'rejected' || status === 'expired') {
+    return 'border-red-500/35 bg-red-500/10 text-red-100'
+  }
+  return 'border-amber-500/35 bg-amber-500/10 text-amber-100'
+}
+
+function CalendarItemCard({
+  item,
+  actionItemId,
+  rejectingItemId,
+  decisionNote,
+  onAuthorize,
+  onBeginReject,
+  onDecisionNoteChange,
+  onReject,
+}: {
+  item: CalendarItem
+  actionItemId: string | null
+  rejectingItemId: string | null
+  decisionNote: string
+  onAuthorize: (item: CalendarItem) => void
+  onBeginReject: (id: string) => void
+  onDecisionNoteChange: (id: string, value: string) => void
+  onReject: (item: CalendarItem) => void
+}) {
   const campaignName = item.attraction_campaigns?.name ?? 'No campaign'
+  const metadata = recordValue(item.metadata)
+  const platformDraftHandoff = recordValue(metadata.platform_draft_handoff)
+  const handoffWorkItemId = typeof platformDraftHandoff.work_item_id === 'string'
+    ? platformDraftHandoff.work_item_id
+    : null
+  const socialContentId = item.social_content_id
+    ?? (typeof platformDraftHandoff.social_content_id === 'string' ? platformDraftHandoff.social_content_id : null)
+  const isPending = item.authorization_status === 'pending'
+  const isRejected = item.authorization_status === 'rejected'
+  const showRejectNote = rejectingItemId === item.id || isRejected
+  const isBusy = actionItemId === item.id
   return (
     <div className="rounded-md border border-silicon-slate/60 bg-background/35 p-3">
       <div className="flex items-start justify-between gap-3">
@@ -1180,7 +1294,7 @@ function CalendarItemCard({ item }: { item: CalendarItem }) {
           <p className="text-sm font-semibold leading-5">{item.title}</p>
           <p className="mt-1 text-xs text-muted-foreground">{formatCalendarDate(item.scheduled_for)}</p>
         </div>
-        <span className="shrink-0 rounded-full border border-amber-500/35 bg-amber-500/10 px-2 py-0.5 text-[0.68rem] font-semibold text-amber-100">
+        <span className={`shrink-0 rounded-full border px-2 py-0.5 text-[0.68rem] font-semibold ${calendarAuthorizationTone(item.authorization_status)}`}>
           {item.authorization_status.replace(/_/g, ' ')}
         </span>
       </div>
@@ -1213,7 +1327,52 @@ function CalendarItemCard({ item }: { item: CalendarItem }) {
             Draft
           </Link>
         ) : null}
+        {handoffWorkItemId ? (
+          <Link href={`/admin/agents/social-insights/${handoffWorkItemId}`} className="text-blue-200 hover:text-blue-100">
+            Handoff
+          </Link>
+        ) : null}
+        {!item.social_content_id && socialContentId ? (
+          <Link href={`/admin/social-content/${socialContentId}`} className="text-blue-200 hover:text-blue-100">
+            Draft
+          </Link>
+        ) : null}
       </div>
+      {showRejectNote ? (
+        <label className="mt-3 block text-[0.68rem] font-semibold uppercase tracking-wide text-muted-foreground">
+          Decision note
+          <textarea
+            value={decisionNote}
+            onChange={(event) => onDecisionNoteChange(item.id, event.target.value)}
+            rows={2}
+            disabled={isBusy || (!isPending && !isRejected)}
+            placeholder="What should Shaka revise before this can be authorized?"
+            className="mt-1 w-full rounded-md border border-silicon-slate/70 bg-background/70 px-3 py-2 text-xs normal-case tracking-normal text-foreground disabled:opacity-60"
+          />
+        </label>
+      ) : null}
+      {isPending || isRejected ? (
+        <div className="mt-3 flex flex-col gap-2 sm:flex-row">
+          <button
+            type="button"
+            onClick={() => onAuthorize(item)}
+            disabled={isBusy}
+            className="inline-flex min-h-9 flex-1 items-center justify-center gap-2 rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-xs font-semibold text-emerald-100 transition hover:bg-emerald-500/20 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <CheckCircle2 className="h-3.5 w-3.5" />
+            {isBusy ? 'Authorizing...' : 'Authorize Draft Handoff'}
+          </button>
+          <button
+            type="button"
+            onClick={() => showRejectNote ? onReject(item) : onBeginReject(item.id)}
+            disabled={isBusy}
+            className="inline-flex min-h-9 flex-1 items-center justify-center gap-2 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-xs font-semibold text-red-100 transition hover:bg-red-500/20 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <XCircle className="h-3.5 w-3.5" />
+            {isRejected ? 'Rejected' : showRejectNote ? 'Submit Rejection' : 'Reject'}
+          </button>
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/app/api/admin/social-content/calendar/[id]/authorize/route.test.ts
+++ b/app/api/admin/social-content/calendar/[id]/authorize/route.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  authorizeCalendarDraftHandoff: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/social-content-calendar-handoff', () => ({
+  authorizeCalendarDraftHandoff: mocks.authorizeCalendarDraftHandoff,
+}))
+
+import { POST } from './route'
+
+function request() {
+  return new Request('http://localhost/api/admin/social-content/calendar/calendar-1/authorize', {
+    method: 'POST',
+    headers: { authorization: 'Bearer admin-token' },
+  })
+}
+
+describe('/api/admin/social-content/calendar/[id]/authorize', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.authorizeCalendarDraftHandoff.mockResolvedValue({
+      calendarItem: { id: 'calendar-1', authorization_status: 'authorized' },
+      socialContentId: 'social-1',
+      handoffWorkItemId: 'work-handoff-1',
+      handoffKind: 'linkedin_social_content_draft',
+    })
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(request() as never, { params: { id: 'calendar-1' } })
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.authorizeCalendarDraftHandoff).not.toHaveBeenCalled()
+  })
+
+  it('authorizes an internal draft handoff without external side effects', async () => {
+    const response = await POST(request() as never, { params: { id: 'calendar-1' } })
+
+    expect(response.status).toBe(200)
+    expect(mocks.authorizeCalendarDraftHandoff).toHaveBeenCalledWith('calendar-1', {
+      user: { id: 'admin-user' },
+    })
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      handoff: {
+        kind: 'linkedin_social_content_draft',
+        work_item_id: 'work-handoff-1',
+        social_content_id: 'social-1',
+      },
+      side_effects: {
+        internal_draft_handoff_created: true,
+        social_content_draft_created: true,
+        publish: false,
+        external_post: false,
+      },
+    })
+  })
+})

--- a/app/api/admin/social-content/calendar/[id]/authorize/route.ts
+++ b/app/api/admin/social-content/calendar/[id]/authorize/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { authorizeCalendarDraftHandoff } from '@/lib/social-content-calendar-handoff'
+import { CALENDAR_SIDE_EFFECTS } from '@/lib/social-content-calendar'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const auth = await verifyAdmin(request)
+    if (isAuthError(auth)) {
+      return NextResponse.json({ error: auth.error }, { status: auth.status })
+    }
+
+    const result = await authorizeCalendarDraftHandoff(params.id, auth)
+
+    return NextResponse.json({
+      ok: true,
+      item: result.calendarItem,
+      handoff: {
+        kind: result.handoffKind,
+        work_item_id: result.handoffWorkItemId,
+        social_content_id: result.socialContentId,
+      },
+      side_effects: {
+        ...CALENDAR_SIDE_EFFECTS,
+        internal_draft_handoff_created: true,
+        social_content_draft_created: Boolean(result.socialContentId),
+      },
+    })
+  } catch (error) {
+    console.error('[social-content-calendar] authorize handoff failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to authorize calendar draft handoff' },
+      { status: 500 },
+    )
+  }
+}

--- a/app/api/admin/social-content/calendar/[id]/reject/route.test.ts
+++ b/app/api/admin/social-content/calendar/[id]/reject/route.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  rejectCalendarDraftHandoff: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/social-content-calendar-handoff', () => ({
+  rejectCalendarDraftHandoff: mocks.rejectCalendarDraftHandoff,
+}))
+
+import { POST } from './route'
+
+function request(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/admin/social-content/calendar/calendar-1/reject', {
+    method: 'POST',
+    headers: { authorization: 'Bearer admin-token', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('/api/admin/social-content/calendar/[id]/reject', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.rejectCalendarDraftHandoff.mockResolvedValue({
+      calendarItem: { id: 'calendar-1', authorization_status: 'rejected' },
+      revisionWorkItemId: 'work-revision-1',
+    })
+  })
+
+  it('requires a decision note', async () => {
+    const response = await POST(request({ decision_note: '   ' }) as never, {
+      params: { id: 'calendar-1' },
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: 'Decision note is required when rejecting a calendar item',
+    })
+    expect(mocks.rejectCalendarDraftHandoff).not.toHaveBeenCalled()
+  })
+
+  it('returns the item to Shaka for revision without external side effects', async () => {
+    const response = await POST(request({ decision_note: 'Needs stronger campaign proof.' }) as never, {
+      params: { id: 'calendar-1' },
+    })
+
+    expect(response.status).toBe(200)
+    expect(mocks.rejectCalendarDraftHandoff).toHaveBeenCalledWith({
+      id: 'calendar-1',
+      decisionNote: 'Needs stronger campaign proof.',
+      auth: { user: { id: 'admin-user' } },
+    })
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      revision_work_item_id: 'work-revision-1',
+      side_effects: {
+        revision_work_item_created: true,
+        publish: false,
+        external_post: false,
+      },
+    })
+  })
+})

--- a/app/api/admin/social-content/calendar/[id]/reject/route.ts
+++ b/app/api/admin/social-content/calendar/[id]/reject/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { rejectCalendarDraftHandoff } from '@/lib/social-content-calendar-handoff'
+import { CALENDAR_SIDE_EFFECTS } from '@/lib/social-content-calendar'
+
+export const dynamic = 'force-dynamic'
+
+function cleanText(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const auth = await verifyAdmin(request)
+    if (isAuthError(auth)) {
+      return NextResponse.json({ error: auth.error }, { status: auth.status })
+    }
+
+    const body = await request.json().catch(() => ({})) as Record<string, unknown>
+    const decisionNote = cleanText(body.decision_note)
+    if (!decisionNote) {
+      return NextResponse.json(
+        { error: 'Decision note is required when rejecting a calendar item' },
+        { status: 400 },
+      )
+    }
+
+    const result = await rejectCalendarDraftHandoff({
+      id: params.id,
+      decisionNote,
+      auth,
+    })
+
+    return NextResponse.json({
+      ok: true,
+      item: result.calendarItem,
+      revision_work_item_id: result.revisionWorkItemId,
+      side_effects: {
+        ...CALENDAR_SIDE_EFFECTS,
+        revision_work_item_created: true,
+      },
+    })
+  } catch (error) {
+    console.error('[social-content-calendar] reject handoff failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to reject calendar draft handoff' },
+      { status: 500 },
+    )
+  }
+}

--- a/lib/social-content-calendar-handoff.ts
+++ b/lib/social-content-calendar-handoff.ts
@@ -1,0 +1,331 @@
+import { createAgentWorkItem } from '@/lib/agent-work-items'
+import { supabaseAdmin } from '@/lib/supabase'
+import {
+  CALENDAR_CHANNEL_LABELS,
+  CALENDAR_SIDE_EFFECTS,
+  parseMetadata,
+  type SocialContentCalendarItem,
+} from '@/lib/social-content-calendar'
+
+type CalendarActionAuth = {
+  user: {
+    id: string
+  }
+}
+
+type HandoffResult = {
+  calendarItem: SocialContentCalendarItem
+  socialContentId: string | null
+  handoffWorkItemId: string
+  handoffKind: 'linkedin_social_content_draft' | 'channel_planning_handoff'
+}
+
+function calendarSelect() {
+  return `
+    *,
+    attraction_campaigns (id, name, slug, status, starts_at, ends_at),
+    agent_work_items (id, title, status, priority),
+    social_content_queue (id, status, post_text, scheduled_for)
+  `
+}
+
+function cleanText(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function campaignName(item: SocialContentCalendarItem) {
+  return item.attraction_campaigns?.name ?? 'Unassigned campaign'
+}
+
+function buildDraftSeed(item: SocialContentCalendarItem) {
+  const plannedAngle = cleanText(item.planned_angle)
+  return [
+    `Calendar draft seed: ${item.title}`,
+    plannedAngle ? `Planned angle: ${plannedAngle}` : null,
+    `Campaign phase: ${item.campaign_phase}`,
+    'This is an internal draft seed. Shaka/content agents should turn it into reviewed channel copy before any publish approval.',
+  ].filter(Boolean).join('\n\n')
+}
+
+function buildDraftRagContext(item: SocialContentCalendarItem, auth: CalendarActionAuth) {
+  const metadata = parseMetadata(item.metadata)
+  return {
+    source: 'social_content_calendar_authorization',
+    source_type: 'social_content_calendar_item',
+    calendar_item_id: item.id,
+    campaign_id: item.campaign_id,
+    campaign_name: campaignName(item),
+    campaign_phase: item.campaign_phase,
+    channel: item.channel,
+    planned_angle: item.planned_angle,
+    scheduled_for: item.scheduled_for,
+    authorization_status: 'authorized',
+    authorized_at: new Date().toISOString(),
+    authorized_by: auth.user.id,
+    publish_gate: 'draft_only',
+    external_execution_enabled: false,
+    approval_boundary: 'Internal draft handoff only. This does not publish, schedule externally, upload, call media providers, or create public content.',
+    linked_agent_work_item_id: item.agent_work_item_id,
+    calendar_metadata: metadata,
+  }
+}
+
+async function readCalendarItem(id: string): Promise<SocialContentCalendarItem> {
+  const { data, error } = await supabaseAdmin
+    .from('social_content_calendar_items')
+    .select(calendarSelect())
+    .eq('id', id)
+    .single()
+
+  if (error || !data) {
+    throw new Error(error?.message ?? 'Calendar item not found')
+  }
+
+  return data as SocialContentCalendarItem
+}
+
+async function findExistingLinkedInDraft(calendarItemId: string) {
+  const { data, error } = await supabaseAdmin
+    .from('social_content_queue')
+    .select('id')
+    .contains('rag_context', {
+      source: 'social_content_calendar_authorization',
+      calendar_item_id: calendarItemId,
+    })
+    .maybeSingle()
+
+  if (error) throw new Error(`Failed to check existing Social Content draft: ${error.message}`)
+  return typeof data?.id === 'string' ? data.id : null
+}
+
+async function createLinkedInSocialContentDraft(item: SocialContentCalendarItem, auth: CalendarActionAuth) {
+  const existingId = item.social_content_id ?? (await findExistingLinkedInDraft(item.id))
+  if (existingId) return existingId
+
+  const ragContext = buildDraftRagContext(item, auth)
+  const { data, error } = await supabaseAdmin
+    .from('social_content_queue')
+    .insert({
+      platform: 'linkedin',
+      status: 'draft',
+      post_text: buildDraftSeed(item),
+      cta_text: null,
+      cta_url: null,
+      hashtags: ['#AIProduct', '#ProductManagement', '#AmaduTownAdvisory'],
+      image_prompt: null,
+      framework_visual_type: null,
+      topic_extracted: {
+        topic: item.title,
+        angle: item.planned_angle ?? item.title,
+        key_insight: 'Calendar-authorized Shaka insight requires governed copy production.',
+        personal_tie_in: 'Queued from a campaign-aware Content Intelligence calendar gate.',
+        framework_visual: 'architecture',
+      },
+      hormozi_framework: {
+        framework_type: 'campaign_calendar_handoff',
+        hook_type: 'triggering_event',
+        proof_pattern: 'Shaka insight plus approved research evidence',
+        cta_pattern: 'human-reviewed channel CTA',
+      },
+      rag_context: ragContext,
+      admin_notes: [
+        'Created by Content Intelligence calendar authorization.',
+        'Draft handoff only. Publishing, external scheduling, media generation, uploads, and provider sends remain separately approval-gated.',
+        `Calendar item: ${item.id}`,
+        `Campaign: ${campaignName(item)}`,
+        `Scheduled intent: ${item.scheduled_for}`,
+      ].join('\n'),
+      target_platforms: ['linkedin'],
+      video_generation_method: 'none',
+      content_format: 'single_image',
+      content_pillar: 'technology_as_equalizer',
+      companion_post_text: null,
+      scheduled_for: null,
+    })
+    .select('id')
+    .single()
+
+  if (error || !data?.id) {
+    throw new Error(error?.message ?? 'Failed to create Social Content draft')
+  }
+
+  return String(data.id)
+}
+
+async function createDraftHandoffWorkItem(input: {
+  item: SocialContentCalendarItem
+  socialContentId: string | null
+  auth: CalendarActionAuth
+}) {
+  const { item, socialContentId, auth } = input
+  const channelLabel = CALENDAR_CHANNEL_LABELS[item.channel]
+  const isLinkedInDraft = item.channel === 'linkedin' && Boolean(socialContentId)
+
+  return createAgentWorkItem({
+    title: `Prepare ${channelLabel} draft handoff: ${item.title}`,
+    objective: [
+      `Use the authorized calendar item to prepare the ${channelLabel} draft handoff.`,
+      item.planned_angle ? `Planned angle: ${item.planned_angle}` : null,
+      isLinkedInDraft && socialContentId
+        ? `Continue in the Social Content draft at /admin/social-content/${socialContentId}.`
+        : 'Prepare planning/export-readiness inputs only; this channel does not have an approved publishing integration in V1.',
+      'Do not publish, schedule externally, upload, call media providers, or create public content from this gate.',
+    ].filter(Boolean).join(' '),
+    priority: 'high',
+    status: 'queued',
+    ownerAgentKey: 'content-repurposing',
+    ownerRuntime: 'codex',
+    source: {
+      type: 'social_content_calendar_authorization',
+      id: item.id,
+      label: item.title,
+    },
+    overlapGroup: 'social-content-calendar',
+    metadata: {
+      source: 'social_content_calendar_authorization',
+      calendar_item_id: item.id,
+      campaign_id: item.campaign_id,
+      campaign_name: campaignName(item),
+      agent_work_item_id: item.agent_work_item_id,
+      social_content_id: socialContentId,
+      channel: item.channel,
+      campaign_phase: item.campaign_phase,
+      scheduled_for: item.scheduled_for,
+      authorized_by: auth.user.id,
+      authorized_at: new Date().toISOString(),
+      draft_handoff_only: true,
+      external_execution_enabled: false,
+      approval_boundary: 'internal_platform_draft_handoff_only',
+      side_effects: {
+        ...CALENDAR_SIDE_EFFECTS,
+        social_content_draft_created: Boolean(socialContentId),
+      },
+    },
+    idempotencyKey: `social-content-calendar-draft-handoff:${item.id}`,
+  })
+}
+
+export async function authorizeCalendarDraftHandoff(
+  id: string,
+  auth: CalendarActionAuth,
+): Promise<HandoffResult> {
+  const item = await readCalendarItem(id)
+  const metadata = parseMetadata(item.metadata)
+  const socialContentId = item.channel === 'linkedin'
+    ? await createLinkedInSocialContentDraft(item, auth)
+    : item.social_content_id
+
+  const handoffWorkItem = await createDraftHandoffWorkItem({
+    item,
+    socialContentId,
+    auth,
+  })
+
+  const nextMetadata = {
+    ...metadata,
+    authorized_at: new Date().toISOString(),
+    authorized_by: auth.user.id,
+    draft_handoff_only: true,
+    external_execution_enabled: false,
+    platform_draft_handoff: {
+      kind: item.channel === 'linkedin' ? 'linkedin_social_content_draft' : 'channel_planning_handoff',
+      status: 'queued',
+      work_item_id: handoffWorkItem.id,
+      social_content_id: socialContentId,
+      created_at: new Date().toISOString(),
+    },
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from('social_content_calendar_items')
+    .update({
+      authorization_status: 'authorized',
+      social_content_id: socialContentId,
+      metadata: nextMetadata,
+    })
+    .eq('id', id)
+    .select(calendarSelect())
+    .single()
+
+  if (error || !data) {
+    throw new Error(error?.message ?? 'Failed to authorize calendar draft handoff')
+  }
+
+  return {
+    calendarItem: data as SocialContentCalendarItem,
+    socialContentId,
+    handoffWorkItemId: handoffWorkItem.id,
+    handoffKind: item.channel === 'linkedin' ? 'linkedin_social_content_draft' : 'channel_planning_handoff',
+  }
+}
+
+export async function rejectCalendarDraftHandoff(input: {
+  id: string
+  decisionNote: string
+  auth: CalendarActionAuth
+}) {
+  const item = await readCalendarItem(input.id)
+  const metadata = parseMetadata(item.metadata)
+  const rejectedAt = new Date().toISOString()
+  const revisionWorkItem = await createAgentWorkItem({
+    title: `Revise content calendar item: ${item.title}`,
+    objective: [
+      `Revise the ${CALENDAR_CHANNEL_LABELS[item.channel]} calendar item before it can be authorized.`,
+      `Decision note: ${input.decisionNote}`,
+      'Return the revised item to pending review. Do not publish, schedule externally, upload, call media providers, or create public content.',
+    ].join(' '),
+    priority: 'high',
+    status: 'queued',
+    ownerAgentKey: 'chief-of-staff',
+    ownerRuntime: 'codex',
+    source: {
+      type: 'social_content_calendar_revision',
+      id: item.id,
+      label: item.title,
+    },
+    overlapGroup: 'social-content-calendar',
+    metadata: {
+      source: 'social_content_calendar_revision',
+      calendar_item_id: item.id,
+      campaign_id: item.campaign_id,
+      agent_work_item_id: item.agent_work_item_id,
+      social_content_id: item.social_content_id,
+      channel: item.channel,
+      campaign_phase: item.campaign_phase,
+      decision_note: input.decisionNote,
+      rejected_by: input.auth.user.id,
+      rejected_at: rejectedAt,
+      returned_to_shaka: true,
+      external_execution_enabled: false,
+      side_effects: CALENDAR_SIDE_EFFECTS,
+    },
+    idempotencyKey: `social-content-calendar-revision:${item.id}:${Date.parse(rejectedAt)}`,
+  })
+
+  const { data, error } = await supabaseAdmin
+    .from('social_content_calendar_items')
+    .update({
+      authorization_status: 'rejected',
+      metadata: {
+        ...metadata,
+        authorization_decision_note: input.decisionNote,
+        rejected_at: rejectedAt,
+        rejected_by: input.auth.user.id,
+        returned_to_shaka: true,
+        revision_work_item_id: revisionWorkItem.id,
+        external_execution_enabled: false,
+      },
+    })
+    .eq('id', input.id)
+    .select(calendarSelect())
+    .single()
+
+  if (error || !data) {
+    throw new Error(error?.message ?? 'Failed to reject calendar draft handoff')
+  }
+
+  return {
+    calendarItem: data as SocialContentCalendarItem,
+    revisionWorkItemId: revisionWorkItem.id,
+  }
+}


### PR DESCRIPTION
## Summary
- Add explicit calendar authorization and rejection endpoints for Content Intelligence due gates.
- Authorizing a LinkedIn calendar item creates or reuses an internal Social Content draft plus a draft-handoff work item; other channels create planning/export-readiness handoffs only.
- Update Content Intelligence calendar cards with visible authorize/reject controls, rejection notes, handoff links, and traceable status feedback.

## Validation
- npm test -- --run 'app/api/admin/social-content/calendar/[id]/authorize/route.test.ts' 'app/api/admin/social-content/calendar/[id]/reject/route.test.ts' 'app/api/admin/social-content/calendar/[id]/route.test.ts' app/admin/agents/content-intelligence/page.test.tsx
- npx tsc --noEmit --pretty false
- git diff --check
- Browser smoke: http://127.0.0.1:3031/admin/agents/content-intelligence loaded after local admin auth; Content Calendar rendered; Authorization filter changed to Pending; no console errors. Live DB had no planned calendar items, so no mutating authorize/reject button was submitted.

## Integration Notes
- No migration required.
- No provider generation, upload, external scheduling, LinkedIn publishing, or external post creation is triggered by these gates.
- Vercel contexts were not checked from this implementation lane; integration captain should verify:
  - Vercel – portfolio
  - Vercel – portfolio-staging