### PR TITLE
test: add content calendar demo fixture

### DIFF
--- a/app/admin/testing/page.tsx
+++ b/app/admin/testing/page.tsx
@@ -157,6 +157,7 @@ const SCENARIOS: ScenarioMeta[] = [
   { id: 'seed_onboarding_project', name: 'Seed: Onboarding Project', tags: ['seed', 'populate-demo'], journeyStage: 'client' },
   { id: 'seed_kickoff_project', name: 'Seed: Kickoff Project', tags: ['seed', 'populate-demo'], journeyStage: 'client' },
   { id: 'seed_discovery_sql_compat', name: 'Seed: Discovery (test-discovery@)', tags: ['seed', 'populate-demo'], journeyStage: 'lead' },
+  { id: 'seed_social_content_calendar_fixture', name: 'Seed: Content Calendar Fixture', tags: ['seed', 'populate-demo', 'content-intelligence', 'calendar'], journeyStage: 'lead' },
   // Chatbot question bank scenarios
   { id: 'chatbot_question_bank_stratified', name: 'Chatbot Questions (Stratified)', tags: ['chat', 'chatbot-questions'], journeyStage: 'prospect' },
   { id: 'chatbot_question_bank_boundary', name: 'Chatbot Questions (Boundary)', tags: ['chat', 'chatbot-questions'], journeyStage: 'prospect' },
@@ -211,6 +212,7 @@ function scenarioIdsForPreset(presetId: string): string[] {
         'seed_onboarding_project',
         'seed_kickoff_project',
         'seed_discovery_sql_compat',
+        'seed_social_content_calendar_fixture',
       ]
     case 'all':
       return SCENARIOS.map(s => s.id)

--- a/app/api/admin/testing/cleanup-seeds/route.ts
+++ b/app/api/admin/testing/cleanup-seeds/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
 import { supabaseAdmin } from '@/lib/supabase'
+import {
+  SOCIAL_CONTENT_CALENDAR_FIXTURE_KEY,
+  SOCIAL_CONTENT_CALENDAR_FIXTURE_SLUG,
+} from '@/lib/admin-demo-seed'
 
 export const dynamic = 'force-dynamic'
 
@@ -59,6 +63,38 @@ async function countFlaggedTestRows(): Promise<{
   return { counts, total, tablesScanned: TABLES_WITH_TEST_FLAG.length }
 }
 
+async function countContentCalendarFixtureRows(): Promise<{
+  calendarItems: number
+  campaigns: number
+  total: number
+}> {
+  const { count: calendarItems, error: calendarError } = await supabaseAdmin
+    .from('social_content_calendar_items')
+    .select('*', { count: 'exact', head: true })
+    .contains('metadata', { demo_seed_key: SOCIAL_CONTENT_CALENDAR_FIXTURE_KEY })
+
+  if (calendarError && calendarError.code !== '42P01' && calendarError.code !== 'PGRST205') {
+    console.error('Cleanup preview social_content_calendar_items fixture:', calendarError)
+  }
+
+  const { count: campaigns, error: campaignError } = await supabaseAdmin
+    .from('attraction_campaigns')
+    .select('*', { count: 'exact', head: true })
+    .eq('slug', SOCIAL_CONTENT_CALENDAR_FIXTURE_SLUG)
+
+  if (campaignError && campaignError.code !== '42P01' && campaignError.code !== 'PGRST205') {
+    console.error('Cleanup preview attraction_campaigns fixture:', campaignError)
+  }
+
+  const calendarCount = calendarError ? 0 : calendarItems ?? 0
+  const campaignCount = campaignError ? 0 : campaigns ?? 0
+  return {
+    calendarItems: calendarCount,
+    campaigns: campaignCount,
+    total: calendarCount + campaignCount,
+  }
+}
+
 /**
  * GET /api/admin/testing/cleanup-seeds?mode=flag_only | all
  * Preview row counts for the matching POST mode (no deletes).
@@ -76,6 +112,9 @@ export async function GET(request: NextRequest) {
     }
 
     const flagPhase = await countFlaggedTestRows()
+    const calendarFixture = await countContentCalendarFixtureRows()
+    flagPhase.counts.social_content_calendar_fixture = calendarFixture.total
+    flagPhase.total += calendarFixture.total
 
     if (mode === 'flag_only') {
       return NextResponse.json({
@@ -233,6 +272,36 @@ export async function POST(request: NextRequest) {
           results[`${table}_flagged`] = data?.length ?? 0
         }
       }
+
+      const { data: calendarRows, error: calendarDeleteError } = await supabaseAdmin
+        .from('social_content_calendar_items')
+        .delete()
+        .contains('metadata', { demo_seed_key: SOCIAL_CONTENT_CALENDAR_FIXTURE_KEY })
+        .select('id')
+
+      if (
+        calendarDeleteError
+        && calendarDeleteError.code !== '42P01'
+        && calendarDeleteError.code !== 'PGRST205'
+      ) {
+        console.error('Cleanup social_content_calendar_items fixture error:', calendarDeleteError)
+      }
+      results.social_content_calendar_fixture = calendarRows?.length ?? 0
+
+      const { data: campaigns, error: campaignDeleteError } = await supabaseAdmin
+        .from('attraction_campaigns')
+        .delete()
+        .eq('slug', SOCIAL_CONTENT_CALENDAR_FIXTURE_SLUG)
+        .select('id')
+
+      if (
+        campaignDeleteError
+        && campaignDeleteError.code !== '42P01'
+        && campaignDeleteError.code !== 'PGRST205'
+      ) {
+        console.error('Cleanup attraction_campaigns fixture error:', campaignDeleteError)
+      }
+      results.attraction_campaigns_fixture = campaigns?.length ?? 0
     }
 
     // Phase 2: Delete by known test emails (legacy approach)

--- a/app/api/admin/testing/demo-seed/route.ts
+++ b/app/api/admin/testing/demo-seed/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
 import { supabaseAdmin } from '@/lib/supabase'
-import { isDemoSeedKey, runDemoSeed } from '@/lib/admin-demo-seed'
+import { DEMO_SEED_KEYS, isDemoSeedKey, runDemoSeed } from '@/lib/admin-demo-seed'
 
 export const dynamic = 'force-dynamic'
 
@@ -27,14 +27,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         {
           error: 'Invalid or missing key',
-          validKeys: [
-            'sarah_mitchell_lead',
-            'paid_proposal_jordan',
-            'lead_qualification_99999',
-            'onboarding_test_project',
-            'kickoff_test_project',
-            'discovery_call_test_contact',
-          ],
+          validKeys: DEMO_SEED_KEYS,
         },
         { status: 400 }
       )

--- a/lib/admin-demo-seed.test.ts
+++ b/lib/admin-demo-seed.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  isDemoSeedKey,
+  runDemoSeed,
+  SOCIAL_CONTENT_CALENDAR_FIXTURE_KEY,
+  SOCIAL_CONTENT_CALENDAR_FIXTURE_SLUG,
+} from './admin-demo-seed'
+
+describe('admin demo seed', () => {
+  it('creates a safe Social Content calendar fixture', async () => {
+    const inserts: Record<string, unknown[]> = {}
+
+    const supabase = {
+      from: vi.fn((table: string) => {
+        if (table === 'attraction_campaigns') {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+              })),
+            })),
+            delete: vi.fn(() => ({
+              eq: vi.fn(async () => ({ data: [], error: null })),
+            })),
+            insert: vi.fn((row: Record<string, unknown>) => {
+              inserts[table] = [row]
+              return {
+                select: vi.fn(() => ({
+                  single: vi.fn(async () => ({
+                    data: {
+                      id: 'campaign-fixture-1',
+                      name: row.name,
+                      slug: row.slug,
+                      starts_at: row.starts_at,
+                      ends_at: row.ends_at,
+                    },
+                    error: null,
+                  })),
+                })),
+              }
+            }),
+          }
+        }
+
+        if (table === 'social_content_calendar_items') {
+          return {
+            delete: vi.fn(() => ({
+              contains: vi.fn(async () => ({ data: [], error: null })),
+            })),
+            insert: vi.fn(async (rows: unknown[]) => {
+              inserts[table] = rows
+              return { error: null }
+            }),
+          }
+        }
+
+        throw new Error(`Unexpected table ${table}`)
+      }),
+    }
+
+    const result = await runDemoSeed('social_content_calendar_fixture', supabase as never)
+
+    expect(result).toMatchObject({
+      ok: true,
+      key: 'social_content_calendar_fixture',
+    })
+    expect(isDemoSeedKey('social_content_calendar_fixture')).toBe(true)
+    expect(inserts.attraction_campaigns[0]).toMatchObject({
+      slug: SOCIAL_CONTENT_CALENDAR_FIXTURE_SLUG,
+      status: 'draft',
+      campaign_type: 'free_challenge',
+    })
+
+    const rows = inserts.social_content_calendar_items as Array<Record<string, unknown>>
+    expect(rows).toHaveLength(4)
+    expect(rows.map((row) => row.campaign_phase)).toEqual(['tease', 'teach', 'proof', 'offer'])
+    expect(rows.map((row) => row.channel)).toEqual([
+      'linkedin',
+      'youtube_shorts',
+      'instagram_reels',
+      'thumbnail',
+    ])
+    expect(rows.some((row) => row.authorization_status === 'rejected')).toBe(true)
+    rows.forEach((row) => {
+      expect(row).toMatchObject({
+        campaign_id: 'campaign-fixture-1',
+        autonomy_eligible: false,
+      })
+      expect(row.metadata).toMatchObject({
+        demo_seed_key: SOCIAL_CONTENT_CALENDAR_FIXTURE_KEY,
+        external_execution_enabled: false,
+        provider_generation_enabled: false,
+        publish_enabled: false,
+      })
+    })
+  })
+})

--- a/lib/admin-demo-seed.ts
+++ b/lib/admin-demo-seed.ts
@@ -4,6 +4,7 @@
  */
 
 import type { SupabaseClient } from '@supabase/supabase-js'
+import { campaignContentPlanSlots } from './social-content-calendar'
 
 export const DEMO_SEED_KEYS = [
   'sarah_mitchell_lead',
@@ -12,6 +13,7 @@ export const DEMO_SEED_KEYS = [
   'onboarding_test_project',
   'kickoff_test_project',
   'discovery_call_test_contact',
+  'social_content_calendar_fixture',
 ] as const
 
 export type DemoSeedKey = (typeof DEMO_SEED_KEYS)[number]
@@ -22,6 +24,8 @@ export function isDemoSeedKey(k: string): k is DemoSeedKey {
 
 const SARAH_SESSION = 'test-lead-session-001'
 const SARAH_EMAIL = 'sarah.mitchell@techflow.io'
+export const SOCIAL_CONTENT_CALENDAR_FIXTURE_SLUG = 'demo-content-calendar-smoke'
+export const SOCIAL_CONTENT_CALENDAR_FIXTURE_KEY = 'social_content_calendar_fixture'
 
 const BUSINESS_CHALLENGES = {
   primary_challenges: [
@@ -106,6 +110,13 @@ function addDaysISO(days: number): string {
   return d.toISOString().slice(0, 10)
 }
 
+function addDaysAtHourISO(days: number, hour: number): string {
+  const d = new Date()
+  d.setDate(d.getDate() + days)
+  d.setHours(hour, 0, 0, 0)
+  return d.toISOString()
+}
+
 async function removeSarahMitchellChain(supabase: SupabaseClient): Promise<void> {
   const { data: contact } = await supabase
     .from('contact_submissions')
@@ -119,6 +130,31 @@ async function removeSarahMitchellChain(supabase: SupabaseClient): Promise<void>
   await supabase.from('diagnostic_audits').delete().eq('session_id', SARAH_SESSION)
   await supabase.from('contact_submissions').delete().eq('email', SARAH_EMAIL)
   await supabase.from('chat_sessions').delete().eq('session_id', SARAH_SESSION)
+}
+
+async function removeSocialContentCalendarFixture(supabase: SupabaseClient): Promise<void> {
+  const { data: campaign } = await supabase
+    .from('attraction_campaigns')
+    .select('id')
+    .eq('slug', SOCIAL_CONTENT_CALENDAR_FIXTURE_SLUG)
+    .maybeSingle()
+
+  await supabase
+    .from('social_content_calendar_items')
+    .delete()
+    .contains('metadata', { demo_seed_key: SOCIAL_CONTENT_CALENDAR_FIXTURE_KEY })
+
+  if (campaign?.id != null) {
+    await supabase
+      .from('social_content_calendar_items')
+      .delete()
+      .eq('campaign_id', campaign.id)
+  }
+
+  await supabase
+    .from('attraction_campaigns')
+    .delete()
+    .eq('slug', SOCIAL_CONTENT_CALENDAR_FIXTURE_SLUG)
 }
 
 export async function runDemoSeed(
@@ -296,6 +332,84 @@ export async function runDemoSeed(
         })
         if (error) return { ok: false, error: `contact_submissions: ${error.message}` }
         return { ok: true, key, detail: 'test-discovery@example.com' }
+      }
+
+      case 'social_content_calendar_fixture': {
+        await removeSocialContentCalendarFixture(supabase)
+
+        const startsAt = addDaysAtHourISO(1, 9)
+        const endsAt = addDaysAtHourISO(21, 17)
+
+        const { data: campaign, error: campaignError } = await supabase
+          .from('attraction_campaigns')
+          .insert({
+            name: 'Demo Content Calendar Smoke Campaign',
+            slug: SOCIAL_CONTENT_CALENDAR_FIXTURE_SLUG,
+            description:
+              'Dev-safe campaign fixture for Content Intelligence calendar smoke tests.',
+            campaign_type: 'free_challenge',
+            status: 'draft',
+            starts_at: startsAt,
+            ends_at: endsAt,
+            completion_window_days: 30,
+            min_purchase_amount: 0,
+            payout_type: 'credit',
+            payout_amount_type: 'fixed',
+            payout_amount_value: 0,
+            rollover_bonus_multiplier: 1,
+            promo_copy:
+              'Seeded only for local/admin calendar review. No external execution is enabled.',
+          })
+          .select('id, name, slug, starts_at, ends_at')
+          .single()
+
+        if (campaignError || !campaign) {
+          return {
+            ok: false,
+            error: `attraction_campaigns: ${campaignError?.message ?? 'no row'}`,
+          }
+        }
+
+        const slots = campaignContentPlanSlots({
+          name: String(campaign.name),
+          starts_at: String(campaign.starts_at),
+          ends_at: String(campaign.ends_at),
+        })
+
+        const channels = ['linkedin', 'youtube_shorts', 'instagram_reels', 'thumbnail'] as const
+        const rows = slots.map((slot, index) => ({
+          ...slot,
+          campaign_id: campaign.id,
+          channel: channels[index],
+          title: `${slot.title} (${channels[index].replace(/_/g, ' ')})`,
+          authorization_status: index === 2 ? 'rejected' : slot.authorization_status,
+          metadata: {
+            ...slot.metadata,
+            demo_seed_key: SOCIAL_CONTENT_CALENDAR_FIXTURE_KEY,
+            fixture_version: 1,
+            fixture_purpose: 'content_intelligence_calendar_smoke',
+            external_execution_enabled: false,
+            provider_generation_enabled: false,
+            publish_enabled: false,
+            decision_note: index === 2
+              ? 'Demo rejected item for the calendar revision path.'
+              : null,
+          },
+        }))
+
+        const { error: calendarError } = await supabase
+          .from('social_content_calendar_items')
+          .insert(rows)
+
+        if (calendarError) {
+          return { ok: false, error: `social_content_calendar_items: ${calendarError.message}` }
+        }
+
+        return {
+          ok: true,
+          key,
+          detail: `Content calendar fixture campaign ${campaign.id} with ${rows.length} items`,
+        }
       }
 
       default: {

--- a/lib/testing/scenarios.test.ts
+++ b/lib/testing/scenarios.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { scenarioIncludesDiagnosticStep } from './scenarios'
+import { getScenario, POPULATE_DEMO_SCENARIOS, scenarioIncludesDiagnosticStep } from './scenarios'
 
 describe('scenarioIncludesDiagnosticStep', () => {
   it('returns true for scenarios that include a diagnostic step', () => {
@@ -14,5 +14,25 @@ describe('scenarioIncludesDiagnosticStep', () => {
 
   it('returns false for unknown scenario IDs', () => {
     expect(scenarioIncludesDiagnosticStep('nonexistent_scenario')).toBe(false)
+  })
+
+  it('registers the Content Intelligence calendar fixture seed scenario', () => {
+    const scenario = getScenario('seed_social_content_calendar_fixture')
+
+    expect(scenario).toMatchObject({
+      id: 'seed_social_content_calendar_fixture',
+      name: 'Seed: Content Calendar Fixture',
+      tags: expect.arrayContaining(['seed', 'populate-demo', 'content-intelligence', 'calendar']),
+    })
+    expect(scenario?.steps[0]).toMatchObject({
+      type: 'apiCall',
+      endpoint: '/api/admin/testing/demo-seed',
+      method: 'POST',
+      body: { key: 'social_content_calendar_fixture' },
+      expectedStatus: 200,
+    })
+    expect(POPULATE_DEMO_SCENARIOS.map((item) => item.id)).toContain(
+      'seed_social_content_calendar_fixture',
+    )
   })
 })

--- a/lib/testing/scenarios.ts
+++ b/lib/testing/scenarios.ts
@@ -1174,6 +1174,15 @@ export const seedDiscoverySqlCompatScenario = demoSeedApiScenario(
   ['seed', 'populate-demo', 'discovery']
 )
 
+export const seedSocialContentCalendarFixtureScenario = demoSeedApiScenario(
+  'seed_social_content_calendar_fixture',
+  'Seed: Content Calendar Fixture',
+  'Dev-safe campaign calendar data for Content Intelligence smoke tests',
+  'social_content_calendar_fixture',
+  'lead',
+  ['seed', 'populate-demo', 'content-intelligence', 'calendar']
+)
+
 /** Scenarios that populate demo data via E2E (no SQL). Run with cleanupAfter: false. */
 export const POPULATE_DEMO_SCENARIOS: TestScenario[] = [
   seedWarmLeadsScenario,
@@ -1186,6 +1195,7 @@ export const POPULATE_DEMO_SCENARIOS: TestScenario[] = [
   seedOnboardingProjectScenario,
   seedKickoffProjectScenario,
   seedDiscoverySqlCompatScenario,
+  seedSocialContentCalendarFixtureScenario,
 ]
 
 // ============================================================================
@@ -1324,6 +1334,7 @@ export const SCENARIOS_BY_ID: Record<string, TestScenario> = {
   seed_onboarding_project: seedOnboardingProjectScenario,
   seed_kickoff_project: seedKickoffProjectScenario,
   seed_discovery_sql_compat: seedDiscoverySqlCompatScenario,
+  seed_social_content_calendar_fixture: seedSocialContentCalendarFixtureScenario,
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add an admin-only demo seed key for a dev-safe Content Intelligence calendar fixture.
- Seed one draft campaign plus four Tease/Teach/Proof/Offer calendar items across LinkedIn, YouTube Shorts, Instagram Reels, and Thumbnail lanes.
- Register the fixture in the Admin Testing populate-demo preset and include cleanup support for the deterministic fixture rows.

## Validation
- npm test -- --run lib/admin-demo-seed.test.ts lib/testing/scenarios.test.ts app/api/admin/social-content/calendar/route.test.ts lib/social-content-calendar.test.ts
- npx tsc --noEmit
- npm run lint (passes with pre-existing unrelated img warnings)
- git diff --check
- Browser smoke with MOCK_N8N=true N8N_DISABLE_OUTBOUND=true PORT=3031 npm run dev: opened /admin/testing and confirmed Populate Demo Data shows 11 seed scenarios; did not start the run or seed live rows.
- Pre-push hook: npm run db:health-check passed.

## Integration Notes
- No schema migration or env change.
- Fixture is opt-in through the existing verifyAdmin demo seed endpoint and cleanup route.
- No provider generation, uploads, external scheduling, publishing, or social posting are triggered.
- Vercel – portfolio and Vercel – portfolio-staging were checked on the prior merged ref 68fc633 before this branch; they have not been checked for this unmerged PR.