### PR TITLE
fix: repair client email lead context lookup

### DIFF
--- a/app/api/client-email-context/route.ts
+++ b/app/api/client-email-context/route.ts
@@ -40,7 +40,7 @@ export async function GET(request: NextRequest) {
       .eq('client_email', email)
       .order('created_at', { ascending: false })
       .limit(1)
-      .single()
+      .maybeSingle()
 
     if (projErr || !project) {
       // Fallback: check contact_submissions (leads)
@@ -61,7 +61,7 @@ export async function GET(request: NextRequest) {
       .select('milestones, status')
       .eq('client_project_id', project.id)
       .limit(1)
-      .single()
+      .maybeSingle()
 
     if (plan?.milestones && Array.isArray(plan.milestones)) {
       const ms = plan.milestones as Array<{ title?: string; status?: string; target_date?: string }>
@@ -92,7 +92,7 @@ export async function GET(request: NextRequest) {
       .eq('client_project_id', project.id)
       .order('meeting_date', { ascending: false })
       .limit(1)
-      .single()
+      .maybeSingle()
 
     if (meeting) {
       // Extract a short summary from structured_notes if available
@@ -172,11 +172,11 @@ export async function GET(request: NextRequest) {
 async function getLeadContext(email: string): Promise<NextResponse> {
   const { data: lead, error: leadErr } = await supabaseAdmin
     .from('contact_submissions')
-    .select('id, name, email, company, service_interest, message, created_at')
+    .select('id, name, email, company, interest_areas, interest_summary, message, created_at')
     .eq('email', email)
     .order('created_at', { ascending: false })
     .limit(1)
-    .single()
+    .maybeSingle()
 
   if (leadErr || !lead) {
     return NextResponse.json({
@@ -262,13 +262,22 @@ async function getLeadContext(email: string): Promise<NextResponse> {
       project_start_date: null,
       estimated_end_date: null,
       lead_id: lead.id,
-      service_interest: lead.service_interest,
+      service_interest: lead.interest_summary || formatInterestAreas(lead.interest_areas),
       initial_message: lead.message,
     },
     milestones: null,
     last_meeting: lastMeeting,
     action_items: actionItems,
   })
+}
+
+function formatInterestAreas(value: unknown): string | null {
+  if (Array.isArray(value)) {
+    const labels = value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+    return labels.length > 0 ? labels.join(', ') : null
+  }
+
+  return null
 }
 
 /**

--- a/lib/client-update-drafts.ts
+++ b/lib/client-update-drafts.ts
@@ -415,7 +415,6 @@ export async function createDraftDirect(
     clientEmail,
     clientName,
     meetingRecordId,
-    source,
     userId,
   } = input
 
@@ -433,7 +432,6 @@ export async function createDraftDirect(
       task_ids: [],
       status: 'draft',
       created_by: userId || null,
-      ...(source ? { source } : {}),
     })
     .select('*')
     .single()


### PR DESCRIPTION
## Summary
- Update the client email context route to read current lead interest fields instead of stale contact_submissions.service_interest.
- Preserve the existing service_interest response key for n8n by deriving it from interest_summary or interest_areas.
- Use maybeSingle() for zero-or-one lookups so expected misses do not generate Supabase 406 noise.
- Stop direct client-update draft inserts from sending a stale source column that does not exist in production.

## Validation
- Supabase prod logs showed contact_submissions.service_interest does not exist during /api/client-email-context lookups.
- Supabase prod SQL confirmed the synthetic GDR smoke lead is present and readable with interest_summary/interest_areas.
- Production /api/client-email-context probe returned 200 for the synthetic smoke lead after deployment.
- WF-GDR execution 18309 reached Generate Draft Reply successfully and then exposed the client_update_drafts source-column mismatch.
- npm ci
- npm run build:knowledge && npx tsc --noEmit --pretty false
- node --env-file=/Users/vambahsillah/Projects/Portfolio/.env.local ./node_modules/.bin/next build

## Integration Notes
- No schema migration required.
- No customer-facing outreach was sent.
- Vercel contexts checked:
  - Vercel – portfolio: CLI project visible, linked, and production deployment promoted from branch preview
  - Vercel – portfolio-staging: CLI project visible in team list