### PR TITLE
feat: show creative open brain sources

### DIFF
--- a/app/admin/agents/open-brain/page.test.tsx
+++ b/app/admin/agents/open-brain/page.test.tsx
@@ -38,7 +38,7 @@ const openBrainSnapshot = {
     links: 0,
     ragProjectionDocuments: 1,
     staleSources: 1,
-    privateRecords: 0,
+    privateRecords: 1,
     producerGates: 2,
     enabledProducerGates: 1,
   },
@@ -57,6 +57,16 @@ const openBrainSnapshot = {
     privacyTier: 'internal',
     lastObservedAt: '2026-05-14T12:00:00.000Z',
     confidence: 0.9,
+    metadata: {},
+  }, {
+    id: 'creative-source:codex-chronicles:quantum-rebel-book-1',
+    kind: 'creative_manuscript',
+    title: 'Code Chronicles, Book 1: The Quantum Rebel',
+    summary: 'Private book draft/source document by Vambah Sillah. Raw manuscript text is not copied into Open Brain.',
+    path: '/Users/vambahsillah/Library/CloudStorage/GoogleDrive-vsillah@gmail.com/My Drive/2. AmaduTown Advisory Solutions/Artifacts /Promotional /Code Breaker Chronicles/Book 1: The Quantum Rebel.gdoc',
+    privacyTier: 'private',
+    lastObservedAt: '2026-06-25T22:31:44.851Z',
+    confidence: 0.94,
     metadata: {},
   }],
   events: [],
@@ -348,6 +358,9 @@ describe('OpenBrainPage', () => {
 
     expect(screen.getByText('Morning review source')).toBeInTheDocument()
     expect(screen.getByText('/tmp/source.json')).toBeInTheDocument()
+    expect(screen.getByText('Code Chronicles, Book 1: The Quantum Rebel')).toBeInTheDocument()
+    expect(screen.getByText('Creative Manuscript')).toBeInTheDocument()
+    expect(screen.getAllByText('private').length).toBeGreaterThan(0)
   })
 
   it('keeps wiki compilation as an explicit gated action', async () => {

--- a/app/admin/agents/open-brain/page.tsx
+++ b/app/admin/agents/open-brain/page.tsx
@@ -1430,8 +1430,10 @@ function relationshipEdgeColor(strength: 'strong' | 'medium' | 'weak', status: s
 }
 
 function relationshipNodeTone(type: OpenBrainRelationshipNodeType, health: 'green' | 'yellow' | 'red', kind: string) {
-  if (health === 'red') return 'border-red-300/70 bg-red-950/80 text-red-100'
   if (type === 'source') {
+    if (kind === 'creative_manuscript') return 'border-fuchsia-300/70 bg-fuchsia-500/20 text-fuchsia-50'
+    if (kind === 'creative_project') return 'border-amber-300/70 bg-amber-500/20 text-amber-50'
+    if (health === 'red') return 'border-red-300/70 bg-red-950/80 text-red-100'
     if (kind === 'workspace_root_report') return 'border-sky-300/70 bg-sky-500/25 text-sky-50'
     if (kind === 'codex_automation') return 'border-radiant-gold/70 bg-radiant-gold text-imperial-navy'
     if (kind === 'runbook') return 'border-emerald-300/70 bg-emerald-500/25 text-emerald-50'
@@ -1449,8 +1451,10 @@ function relationshipNodeTone(type: OpenBrainRelationshipNodeType, health: 'gree
 }
 
 function relationshipNodeLegendColor(type: OpenBrainRelationshipNodeType, health: 'green' | 'yellow' | 'red', kind: string) {
-  if (health === 'red') return 'bg-red-300'
   if (type === 'source') {
+    if (kind === 'creative_manuscript') return 'bg-fuchsia-300'
+    if (kind === 'creative_project') return 'bg-amber-300'
+    if (health === 'red') return 'bg-red-300'
     if (kind === 'workspace_root_report') return 'bg-sky-300'
     if (kind === 'codex_automation') return 'bg-radiant-gold'
     if (kind === 'runbook') return 'bg-emerald-300'
@@ -1536,7 +1540,7 @@ function SourcesView({ snapshot }: { snapshot: OpenBrainSnapshot }) {
                 <p className="mt-1 text-xs text-muted-foreground">{source.summary}</p>
                 <p className="mt-1 break-all text-xs text-muted-foreground">{source.path || source.id}</p>
               </td>
-              <td className="px-4 py-3">{source.kind}</td>
+              <td className="px-4 py-3"><SourceKindBadge kind={source.kind} /></td>
               <td className="px-4 py-3"><PrivacyBadge tier={source.privacyTier} /></td>
               <td className="px-4 py-3">{Math.round(source.confidence * 100)}%</td>
               <td className="px-4 py-3 text-muted-foreground">{formatDateTime(source.lastObservedAt)}</td>
@@ -1546,6 +1550,25 @@ function SourcesView({ snapshot }: { snapshot: OpenBrainSnapshot }) {
       </table>
     </div>
   )
+}
+
+function SourceKindBadge({ kind }: { kind: string }) {
+  const tone = kind === 'creative_manuscript'
+    ? 'border-fuchsia-300/40 bg-fuchsia-500/10 text-fuchsia-100'
+    : kind === 'creative_project'
+      ? 'border-amber-300/40 bg-amber-500/10 text-amber-100'
+      : kind.includes('creative')
+        ? 'border-fuchsia-300/30 bg-fuchsia-500/10 text-fuchsia-100'
+        : 'border-silicon-slate/70 bg-silicon-slate/30 text-muted-foreground'
+  return (
+    <span className={`inline-flex rounded-full border px-2 py-1 text-xs ${tone}`}>
+      {formatSourceKind(kind)}
+    </span>
+  )
+}
+
+function formatSourceKind(kind: string) {
+  return kind.split('_').map((part) => part.charAt(0).toUpperCase() + part.slice(1)).join(' ')
 }
 
 function ProposalsView({

--- a/lib/open-brain.ts
+++ b/lib/open-brain.ts
@@ -29,6 +29,8 @@ export type OpenBrainSourceKind =
   | 'model_ops_dashboard'
   | 'model_ops_swap_request'
   | 'personality_corpus'
+  | 'creative_manuscript'
+  | 'creative_project'
   | 'chatbot_knowledge'
   | 'rag_projection'
   | 'pinecone_projection'
@@ -2038,7 +2040,7 @@ function relationshipPoint(type: OpenBrainRelationshipNodeType, kind: string, in
 function sourceRelationshipPoint(kind: string, index: number) {
   const columns = [12, 31, 50, 69, 88]
   const row = Math.floor(index / columns.length)
-  const kindNudge = kind === 'runbook' ? 2 : kind === 'repair_packet' ? -2 : 0
+  const kindNudge = kind === 'runbook' ? 2 : kind === 'repair_packet' ? -2 : kind.includes('creative') ? 1 : 0
   const x = columns[index % columns.length] + (row % 2 === 1 ? 2 : 0) + kindNudge
   const y = 12 + row * 10
   return {


### PR DESCRIPTION
## Summary
- Adds first-class Open Brain source kinds for private creative manuscripts and creative project packages.
- Updates the Open Brain Admin Sources table to show readable source-kind badges such as `Creative Manuscript` instead of raw snake_case.
- Adds creative-source color support in the relationship map and test coverage for a private Codex Chronicles manuscript source.

## Enhancement Impact Preflight
- Enhancement: Make Codex Chronicles / private creative Open Brain sources visible and legible in Portfolio Admin.
- User-facing surface: `/admin/agents/open-brain` Sources tab and relationship map source nodes.
- Predicted files: `lib/open-brain.ts`, `app/admin/agents/open-brain/page.tsx`, `app/admin/agents/open-brain/page.test.tsx`.
- Actual files: `lib/open-brain.ts`, `app/admin/agents/open-brain/page.tsx`, `app/admin/agents/open-brain/page.test.tsx`.
- Shared routes/APIs/tables/helpers: Open Brain local JSON projection types only; no database schema, API contract, or hosted sync changes.
- Active PRs or branches checked: PR #570 calendar template tests, PR #568 subscription/revenue ops docs, PR #566 client email context fix; no shared files.
- Dirty worktree files checked: root checkout was clean but on `codex/subscription-revenue-ops-2026-06-24`; implementation used clean sibling worktree `Portfolio.worktrees/open-brain-creative-sources`.
- Overlap rating: green.
- Coordination decision: proceed independently; Integration Captain can merge after normal PR checks.
- Merge-order note: no required sequencing with the checked open PRs.

## Validation
- `npm test -- --run app/admin/agents/open-brain/page.test.tsx lib/open-brain.test.ts app/api/admin/agents/open-brain/route.test.ts` passed: 29 tests.
- Live local Open Brain snapshot check passed against `/Users/vambahsillah/.open-brain`; it returned 4 creative sources and 4 private Codex Chronicles memories.
- `npm run lint` passed with existing `<img>` warnings outside this change.
- `npm run build` passed with existing Browserslist and dev env n8n outbound warnings.
- `git diff --check` passed.
- Local route smoke: `curl` returned `200` for `http://localhost:3024/admin/agents/open-brain`.
- In-app Browser verification: authenticated Open Brain route loaded, Sources tab showed `Code Chronicles, Book 1: The Quantum Rebel`, `Code Breaker Chronicles: The Quantum Prophecy`, `Creative Manuscript`, and `private`; console warnings/errors count was 0.
- Pre-push hook: read-only production database health check passed.

## Integration Notes
- No migrations, env changes, Supabase writes, Pinecone writes, or hosted config changes.
- Non-git operational state touched earlier in this workflow: `/Users/vambahsillah/.open-brain/sources.json`, `/Users/vambahsillah/.open-brain/events.json`, and `/Users/vambahsillah/.open-brain/memories.json` were updated with private Codex Chronicles source/event/memory records and backed up before writing.
- Non-git operational state touched for this PR: created sibling worktree, ran `npm ci`, linked ignored env files with `npm run worktree:env`, briefly ran local dev server on port `3024`, and used the in-app Browser for local validation.
- Vercel contexts not manually checked from this non-captain branch: Vercel - portfolio, Vercel - portfolio-staging.
