### PR TITLE
feat: add open brain manuscript summaries

### DIFF
--- a/app/admin/agents/open-brain/page.test.tsx
+++ b/app/admin/agents/open-brain/page.test.tsx
@@ -71,7 +71,18 @@ const openBrainSnapshot = {
   }],
   events: [],
   links: [],
-  memories: [],
+  memories: [{
+    id: 'memory:creative-chapter:creative-source-codex-chronicles-quantum-rebel-book-1:chapter-001',
+    kind: 'fact',
+    title: 'Code Breaker Chronicles: The Quantum Rebel - The Hidden Cache',
+    body: 'Private chapter-level summary for Code Breaker Chronicles: The Quantum Rebel. Position: 1. Working title: The Hidden Cache. Summary: A young builder discovers evidence of a buried system shaping access to code and power.',
+    privacyTier: 'private',
+    confidence: 0.91,
+    sourceIds: ['creative-source:codex-chronicles:quantum-rebel-book-1'],
+    createdAt: '2026-06-25T22:31:44.851Z',
+    updatedAt: '2026-06-25T22:31:44.851Z',
+    fingerprint: 'chapter-memory-fingerprint',
+  }],
   proposals: [{
     id: 'proposal-1',
     status: 'pending',
@@ -361,6 +372,20 @@ describe('OpenBrainPage', () => {
     expect(screen.getByText('Code Chronicles, Book 1: The Quantum Rebel')).toBeInTheDocument()
     expect(screen.getByText('Creative Manuscript')).toBeInTheDocument()
     expect(screen.getAllByText('private').length).toBeGreaterThan(0)
+  })
+
+  it('surfaces durable private manuscript chapter memories in the memories view', async () => {
+    render(<OpenBrainPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Memories' }))
+
+    expect(screen.getByText('Creative Manuscript Chapter Summaries')).toBeInTheDocument()
+    expect(screen.getByText('Code Breaker Chronicles: The Quantum Rebel - The Hidden Cache')).toBeInTheDocument()
+    expect(screen.getByText(/Private chapter-level summaries are durable Open Brain memory/i)).toBeInTheDocument()
+    expect(screen.getByText('Code Chronicles, Book 1: The Quantum Rebel')).toBeInTheDocument()
+    expect(screen.getByText('91%')).toBeInTheDocument()
+    expect(screen.getAllByText('private').length).toBeGreaterThan(0)
+    expect(screen.getByText(/excluded from public wiki\/RAG projections/i)).toBeInTheDocument()
   })
 
   it('keeps wiki compilation as an explicit gated action', async () => {

--- a/app/admin/agents/open-brain/page.tsx
+++ b/app/admin/agents/open-brain/page.tsx
@@ -7,6 +7,7 @@ import {
   AlertTriangle,
   ArrowRight,
   Brain,
+  BookOpen,
   CheckCircle2,
   Database,
   FileText,
@@ -28,7 +29,7 @@ import type {
   OpenBrainSnapshot,
 } from '@/lib/open-brain'
 
-type ViewMode = 'router' | 'sources' | 'proposals' | 'wiki' | 'parity' | 'producers' | 'map'
+type ViewMode = 'router' | 'sources' | 'memories' | 'proposals' | 'wiki' | 'parity' | 'producers' | 'map'
 type RelationshipFilterValue = 'all'
 type RelationshipHealthFilter = RelationshipFilterValue | 'green' | 'yellow' | 'red'
 type RelationshipStrengthFilter = RelationshipFilterValue | 'strong' | 'medium' | 'weak'
@@ -237,6 +238,7 @@ function OpenBrainContent() {
                 <div className="inline-flex min-w-max">
                 <ModeButton icon={<Route size={16} />} active={viewMode === 'router'} onClick={() => setViewMode('router')}>Router</ModeButton>
                 <ModeButton icon={<Database size={16} />} active={viewMode === 'sources'} onClick={() => setViewMode('sources')}>Sources</ModeButton>
+                <ModeButton icon={<BookOpen size={16} />} active={viewMode === 'memories'} onClick={() => setViewMode('memories')}>Memories</ModeButton>
                 <ModeButton icon={<ShieldCheck size={16} />} active={viewMode === 'proposals'} onClick={() => setViewMode('proposals')}>Proposals</ModeButton>
                 <ModeButton icon={<FileText size={16} />} active={viewMode === 'wiki'} onClick={() => setViewMode('wiki')}>Wiki Overlay</ModeButton>
                 <ModeButton icon={<Network size={16} />} active={viewMode === 'parity'} onClick={() => setViewMode('parity')}>Runtime Parity</ModeButton>
@@ -261,6 +263,7 @@ function OpenBrainContent() {
 
             {viewMode === 'router' ? <RouterView snapshot={snapshot} /> : null}
             {viewMode === 'sources' ? <SourcesView snapshot={snapshot} /> : null}
+            {viewMode === 'memories' ? <MemoriesView snapshot={snapshot} /> : null}
             {viewMode === 'proposals' ? (
               <ProposalsView
                 proposals={pendingProposals.length ? pendingProposals : snapshot.proposals}
@@ -1552,6 +1555,176 @@ function SourcesView({ snapshot }: { snapshot: OpenBrainSnapshot }) {
   )
 }
 
+function MemoriesView({ snapshot }: { snapshot: OpenBrainSnapshot }) {
+  const sourceById = new Map(snapshot.sources.map((source) => [source.id, source]))
+  const creativeChapterMemories = snapshot.memories
+    .filter(isCreativeChapterMemory)
+    .sort(compareCreativeChapterMemories)
+  const otherMemories = snapshot.memories
+    .filter((memory) => !isCreativeChapterMemory(memory))
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+  const privateMemories = snapshot.memories.filter((memory) => memory.privacyTier === 'private').length
+  const ragEligibleMemories = snapshot.memories.filter((memory) => memory.privacyTier === 'public_safe').length
+  const wikiEligibleMemories = snapshot.memories.filter((memory) => memory.privacyTier !== 'private').length
+
+  if (snapshot.memories.length === 0) {
+    return <EmptyState message="No durable Open Brain memories are stored locally yet. Approved proposals and trusted producer lanes will appear here after they write memory records." />
+  }
+
+  return (
+    <section className="space-y-5">
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+        <MemoryMetric label="Durable memories" value={snapshot.memories.length} detail="Approved or trusted local records" />
+        <MemoryMetric label="Private memories" value={privateMemories} detail="Visible here, excluded from public projections" tone={privateMemories ? 'red' : 'default'} />
+        <MemoryMetric label="Chapter summaries" value={creativeChapterMemories.length} detail="Private manuscript-level context" tone={creativeChapterMemories.length ? 'gold' : 'default'} />
+        <MemoryMetric label="Wiki/RAG eligible" value={`${wikiEligibleMemories}/${ragEligibleMemories}`} detail="Non-private / public-safe" />
+      </div>
+
+      {creativeChapterMemories.length > 0 ? (
+        <section className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-5">
+          <div className="mb-4 flex flex-col gap-2 lg:flex-row lg:items-start lg:justify-between">
+            <div>
+              <p className="agent-ops-eyebrow"><BookOpen size={14} /> Creative memory</p>
+              <h2 className="mt-2 text-xl font-semibold">Creative Manuscript Chapter Summaries</h2>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Private chapter-level summaries are durable Open Brain memory for local agent context. They are not raw manuscript text, and they remain excluded from public wiki/RAG projections.
+              </p>
+            </div>
+            <PrivacyBadge tier="private" />
+          </div>
+          <div className="overflow-x-auto rounded-lg border border-silicon-slate/70">
+            <table className="min-w-[980px] w-full text-sm">
+              <thead className="bg-silicon-slate/40 text-muted-foreground">
+                <tr>
+                  <th className="px-4 py-3 text-left font-medium">Chapter memory</th>
+                  <th className="px-4 py-3 text-left font-medium">Source</th>
+                  <th className="px-4 py-3 text-left font-medium">Summary excerpt</th>
+                  <th className="px-4 py-3 text-left font-medium">Confidence</th>
+                  <th className="px-4 py-3 text-left font-medium">Updated</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-silicon-slate/60">
+                {creativeChapterMemories.map((memory) => (
+                  <tr key={memory.id}>
+                    <td className="px-4 py-3">
+                      <p className="font-medium">{memory.title}</p>
+                      <p className="mt-1 text-xs text-muted-foreground">{memory.id}</p>
+                    </td>
+                    <td className="px-4 py-3">
+                      <MemorySourceList memory={memory} sourceById={sourceById} />
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">{truncateText(memory.body, 180)}</td>
+                    <td className="px-4 py-3">{Math.round(memory.confidence * 100)}%</td>
+                    <td className="px-4 py-3 text-muted-foreground">{formatDateTime(memory.updatedAt)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      ) : null}
+
+      {otherMemories.length > 0 ? (
+        <section className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-5">
+          <div className="mb-4">
+            <p className="agent-ops-eyebrow"><Brain size={14} /> Durable memory</p>
+            <h2 className="mt-2 text-xl font-semibold">Other Open Brain Memories</h2>
+          </div>
+          <div className="grid gap-3 xl:grid-cols-2">
+            {otherMemories.map((memory) => (
+              <article key={memory.id} className="rounded-lg border border-silicon-slate/60 bg-background/20 p-4">
+                <div className="mb-3 flex flex-wrap items-start justify-between gap-2">
+                  <div>
+                    <h3 className="font-semibold">{memory.title}</h3>
+                    <p className="mt-1 text-xs text-muted-foreground">{memory.id}</p>
+                  </div>
+                  <PrivacyBadge tier={memory.privacyTier} />
+                </div>
+                <p className="text-sm leading-relaxed text-muted-foreground">{truncateText(memory.body, 240)}</p>
+                <div className="mt-3 grid grid-cols-2 gap-2 text-xs">
+                  <Detail label="Kind" value={formatMemoryKind(memory.kind)} />
+                  <Detail label="Confidence" value={`${Math.round(memory.confidence * 100)}%`} />
+                  <Detail label="Sources" value={memory.sourceIds.length || 'none'} />
+                  <Detail label="Updated" value={formatDateTime(memory.updatedAt)} />
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+      ) : null}
+    </section>
+  )
+}
+
+function MemoryMetric({
+  label,
+  value,
+  detail,
+  tone = 'default',
+}: {
+  label: string
+  value: string | number
+  detail: string
+  tone?: 'default' | 'gold' | 'red'
+}) {
+  const toneClass = tone === 'gold'
+    ? 'border-radiant-gold/45 bg-radiant-gold/10'
+    : tone === 'red'
+      ? 'border-red-400/35 bg-red-500/10'
+      : 'border-silicon-slate/70 bg-silicon-slate/20'
+  return (
+    <div className={`rounded-lg border p-4 ${toneClass}`}>
+      <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">{label}</p>
+      <p className="mt-3 text-3xl font-bold tabular-nums text-foreground">{value}</p>
+      <p className="mt-1 text-sm text-muted-foreground">{detail}</p>
+    </div>
+  )
+}
+
+function MemorySourceList({
+  memory,
+  sourceById,
+}: {
+  memory: OpenBrainSnapshot['memories'][number]
+  sourceById: Map<string, OpenBrainSnapshot['sources'][number]>
+}) {
+  if (memory.sourceIds.length === 0) {
+    return <span className="text-xs text-muted-foreground">No linked source</span>
+  }
+
+  return (
+    <div className="space-y-2">
+      {memory.sourceIds.map((sourceId) => {
+        const source = sourceById.get(sourceId)
+        return (
+          <div key={sourceId}>
+            <p className="font-medium">{source?.title || sourceId}</p>
+            <p className="mt-1 text-xs text-muted-foreground">{source?.kind ? formatSourceKind(source.kind) : 'source record'}</p>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function isCreativeChapterMemory(memory: OpenBrainSnapshot['memories'][number]) {
+  return memory.id.startsWith('memory:creative-chapter:') || memory.body.startsWith('Private chapter-level summary')
+}
+
+function compareCreativeChapterMemories(
+  a: OpenBrainSnapshot['memories'][number],
+  b: OpenBrainSnapshot['memories'][number],
+) {
+  const sourceCompare = (a.sourceIds[0] || '').localeCompare(b.sourceIds[0] || '')
+  if (sourceCompare !== 0) return sourceCompare
+  return creativeChapterOrdinal(a) - creativeChapterOrdinal(b) || a.title.localeCompare(b.title)
+}
+
+function creativeChapterOrdinal(memory: OpenBrainSnapshot['memories'][number]) {
+  const match = memory.id.match(/chapter-(\d+)/)
+  return match ? Number(match[1]) : Number.MAX_SAFE_INTEGER
+}
+
 function SourceKindBadge({ kind }: { kind: string }) {
   const tone = kind === 'creative_manuscript'
     ? 'border-fuchsia-300/40 bg-fuchsia-500/10 text-fuchsia-100'
@@ -1569,6 +1742,15 @@ function SourceKindBadge({ kind }: { kind: string }) {
 
 function formatSourceKind(kind: string) {
   return kind.split('_').map((part) => part.charAt(0).toUpperCase() + part.slice(1)).join(' ')
+}
+
+function formatMemoryKind(kind: string) {
+  return kind.split('_').map((part) => part.charAt(0).toUpperCase() + part.slice(1)).join(' ')
+}
+
+function truncateText(value: string, maxLength: number) {
+  if (value.length <= maxLength) return value
+  return `${value.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`
 }
 
 function ProposalsView({

--- a/docs/open-brain-local-service.md
+++ b/docs/open-brain-local-service.md
@@ -102,6 +102,32 @@ The first production MCP registration is an operational-state step. It should be
 
 The repo-owned MCP server prototype is `scripts/open-brain-mcp-server.ts`. It exposes the tool names above and stores local JSON records under `OPEN_BRAIN_HOME`, but registering it with Codex, Hermes, OpenCode, Claude, Cursor, or ChatGPT remains a separate local-state change.
 
+## Private Creative Manuscript Summaries
+
+Codex Chronicles and other private manuscripts can be indexed into Open Brain as chapter-level private memories without copying raw manuscript text into the Portfolio repo, public wiki overlays, chatbot knowledge, Pinecone, or public RAG.
+
+The producer is:
+
+```bash
+npm run open-brain:manuscript-summaries
+```
+
+By default it runs in dry-run mode. It reads private `creative_manuscript` source records from `OPEN_BRAIN_HOME/sources.json`, resolves matching plain-text exports from `OPEN_BRAIN_MANUSCRIPT_EXPORT_DIR` or `~/.open-brain/private-vault/manuscripts`, detects chapter headings, and reports the private memory records it would create.
+
+To write private chapter summaries into the local Open Brain:
+
+```bash
+npm run open-brain:manuscript-summaries -- --write
+```
+
+Source handling rules:
+
+- Google Docs should be exported as `.txt` files into the private manuscript vault before running the producer.
+- The producer writes `private` memory records only.
+- The producer records provenance events with `rawFullTextIncluded: false`.
+- The CLI output is sanitized and does not print chapter bodies or raw manuscript text.
+- Generated chapter summaries are retrieval and orientation aids; they do not replace a human literary summary.
+
 ## Runtime Registration Packet
 
 Phase 2 uses a dry-run registration packet before any agent config is edited:

--- a/lib/open-brain-manuscript-summaries.test.ts
+++ b/lib/open-brain-manuscript-summaries.test.ts
@@ -1,0 +1,191 @@
+import { mkdir, readFile, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import path from 'path'
+import { mkdtemp } from 'fs/promises'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  recordManuscriptChapterSummaries,
+  summarizeManuscriptChapters,
+} from './open-brain-manuscript-summaries'
+import type { OpenBrainEventRecord, OpenBrainMemoryRecord, OpenBrainSourceRecord } from './open-brain'
+
+vi.mock('./codex-automation-inventory', () => ({
+  listCodexAutomationInventory: vi.fn(async () => ({
+    available: true,
+    generatedAt: '2026-06-25T12:00:00.000Z',
+    automations: [],
+    repairPackets: [],
+  })),
+}))
+
+vi.mock('./codex-workspace-roots', () => ({
+  getCodexWorkspaceRootReport: vi.fn(async () => ({
+    available: true,
+    generatedAt: '2026-06-25T12:00:00.000Z',
+    stateDatabase: '/tmp/state.sqlite',
+    overview: {
+      portfolioThreads: 0,
+      nonPortfolioThreads: 0,
+    },
+    health: 'green',
+  })),
+}))
+
+vi.mock('./agent-work-items', () => ({
+  listAgentWorkItems: vi.fn(async () => []),
+  getAgentWorkItem: vi.fn(async () => ({ id: 'work-item', latest_handoff: null })),
+}))
+
+let tempRoot: string | null = null
+
+async function makeTempRoot() {
+  tempRoot = await mkdtemp(path.join(tmpdir(), 'open-brain-manuscripts-'))
+  return tempRoot
+}
+
+afterEach(async () => {
+  if (tempRoot) {
+    await rm(tempRoot, { recursive: true, force: true })
+    tempRoot = null
+  }
+})
+
+describe('Open Brain manuscript chapter summaries', () => {
+  it('extracts chapter summaries from chaptered manuscript text without copying full manuscript text', () => {
+    const summaries = summarizeManuscriptChapters({
+      id: 'creative-source:codex-chronicles:quantum-rebel-book-1',
+      title: 'Code Chronicles, Book 1: The Quantum Rebel',
+      path: '/private/book.txt',
+    }, '/private/book.txt', [
+      'Chapter 1: The Quantum Key',
+      'Kwame entered the Analog District with Dr. Wangari. Quantum power and access shaped the argument.',
+      '',
+      '**Chapter 2: The Plan**',
+      'Chapter 2 Summary with Additional Characters',
+      'This metadata section should stay inside the chapter body, not become a separate chapter.',
+      '',
+      '### Part 1: Chapter 3: The Betrayal',
+      'Mobutu watched the Quantum Elite turn code into surveillance. Community trust broke under pressure.',
+    ].join('\n'))
+
+    expect(summaries).toHaveLength(3)
+    expect(summaries[0]).toEqual(expect.objectContaining({
+      sequence: 1,
+      title: 'The Quantum Key',
+    }))
+    expect(summaries[0].motifs).toEqual(expect.arrayContaining(['quantum power', 'access']))
+    expect(summaries[1].title).toBe('The Plan')
+    expect(summaries[2].title).toBe('The Betrayal')
+    expect(summaries[2].summary).toContain('private machine-generated orientation summary')
+    expect(summaries[2].summary).not.toContain('Mobutu watched the Quantum Elite turn code into surveillance')
+  })
+
+  it('records private chapter memory records and a projection event from a Google Doc text export', async () => {
+    const root = await makeTempRoot()
+    const exportDir = path.join(root, 'exports')
+    const pointerPath = path.join(root, 'Book 1.gdoc')
+    await mkdir(exportDir, { recursive: true })
+    await writeFile(pointerPath, JSON.stringify({
+      doc_id: 'doc-123',
+      url: 'https://docs.google.com/document/d/doc-123/edit',
+    }), 'utf8')
+    await writeSources(root, [{
+      id: 'creative-source:codex-chronicles:quantum-rebel-book-1',
+      kind: 'creative_manuscript',
+      title: 'Code Chronicles, Book 1: The Quantum Rebel',
+      summary: 'Private book draft/source document. Raw manuscript text is not copied into Open Brain.',
+      path: pointerPath,
+      privacyTier: 'private',
+      confidence: 0.94,
+      lastObservedAt: '2026-06-25T22:31:44.851Z',
+      fingerprint: 'source-fingerprint',
+    }])
+    await writeFile(path.join(exportDir, 'doc-123.txt'), [
+      'Chapter 1: The Signal',
+      'Kwame studies the Quantum Key inside the Analog District. Access and community shape the conflict.',
+      '',
+      'Chapter 2: The Gate',
+      'Dr. Wangari explains the algorithm. The elite system tests trust and memory.',
+    ].join('\n'), 'utf8')
+
+    const result = await recordManuscriptChapterSummaries({
+      openBrainHome: root,
+      exportDir,
+      write: true,
+      generatedAt: '2026-06-25T23:00:00.000Z',
+    })
+
+    expect(result.status).toBe('recorded')
+    expect(result.overview).toEqual(expect.objectContaining({
+      sourcesObserved: 1,
+      manuscriptsWithExports: 1,
+      chaptersDetected: 2,
+      memoriesRecorded: 2,
+      eventsRecorded: 1,
+      rawFullTextIncluded: false,
+    }))
+    const memories = await readJson<OpenBrainMemoryRecord[]>(path.join(root, 'memories.json'))
+    expect(memories).toHaveLength(2)
+    expect(memories[0]).toEqual(expect.objectContaining({
+      privacyTier: 'private',
+      sourceIds: ['creative-source:codex-chronicles:quantum-rebel-book-1'],
+    }))
+    expect(memories[0].body).toContain('raw manuscript text was read from the private manuscript export vault')
+    expect(memories[0].body).not.toContain('Kwame studies the Quantum Key inside the Analog District')
+    const events = await readJson<OpenBrainEventRecord[]>(path.join(root, 'events.json'))
+    expect(events).toHaveLength(1)
+    expect(events[0].metadata).toEqual(expect.objectContaining({
+      producerId: 'producer:creative-manuscript-chapter-summarizer',
+      rawFullTextIncluded: false,
+      publicProjectionAllowed: false,
+    }))
+
+    await recordManuscriptChapterSummaries({
+      openBrainHome: root,
+      exportDir,
+      write: true,
+      generatedAt: '2026-06-25T23:05:00.000Z',
+    })
+    const afterSecondRun = await readJson<OpenBrainMemoryRecord[]>(path.join(root, 'memories.json'))
+    expect(afterSecondRun).toHaveLength(2)
+  })
+
+  it('reports missing private exports without writing memory records', async () => {
+    const root = await makeTempRoot()
+    const exportDir = path.join(root, 'exports')
+    await writeSources(root, [{
+      id: 'creative-source:codex-chronicles:quantum-prophecy-outline',
+      kind: 'creative_manuscript',
+      title: 'Code Breaker Chronicles: The Quantum Prophecy',
+      summary: 'Private source.',
+      path: path.join(root, 'missing.gdoc'),
+      privacyTier: 'private',
+      confidence: 0.94,
+      lastObservedAt: '2026-06-25T22:31:44.851Z',
+      fingerprint: 'source-fingerprint',
+    }])
+
+    const result = await recordManuscriptChapterSummaries({
+      openBrainHome: root,
+      exportDir,
+      write: true,
+      generatedAt: '2026-06-25T23:00:00.000Z',
+    })
+
+    expect(result.status).toBe('missing')
+    expect(result.missingExports).toHaveLength(1)
+    expect(result.missingExports[0].expectedCandidates).toEqual(expect.arrayContaining([
+      path.join(exportDir, 'creative-source-codex-chronicles-quantum-prophecy-outline.txt'),
+    ]))
+    await expect(readFile(path.join(root, 'memories.json'), 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+})
+
+async function writeSources(root: string, sources: OpenBrainSourceRecord[]) {
+  await mkdir(root, { recursive: true })
+  await writeFile(path.join(root, 'sources.json'), `${JSON.stringify(sources, null, 2)}\n`, 'utf8')
+}
+
+async function readJson<T>(filePath: string): Promise<T> {
+  return JSON.parse(await readFile(filePath, 'utf8')) as T
+}

--- a/lib/open-brain-manuscript-summaries.ts
+++ b/lib/open-brain-manuscript-summaries.ts
@@ -1,0 +1,530 @@
+import { createHash } from 'crypto'
+import { existsSync } from 'fs'
+import { mkdir, readFile, writeFile } from 'fs/promises'
+import { homedir } from 'os'
+import path from 'path'
+import type { OpenBrainEventRecord, OpenBrainMemoryRecord, OpenBrainSourceRecord } from './open-brain'
+
+const SOURCES_FILE = 'sources.json'
+const MEMORIES_FILE = 'memories.json'
+const EVENTS_FILE = 'events.json'
+const DEFAULT_OPEN_BRAIN_HOME = path.join(homedir(), '.open-brain')
+const DEFAULT_EXPORT_DIR = path.join(homedir(), '.open-brain', 'private-vault', 'manuscripts')
+const SECRETISH_PATTERN =
+  /(sk-[A-Za-z0-9_-]{12,}|github_pat_[A-Za-z0-9_]{12,}|[A-Za-z0-9_]*(?:TOKEN|SECRET|KEY|PASSWORD)[A-Za-z0-9_]*\s*[:=]\s*["']?[^"'\s,}]+)/gi
+
+export interface ManuscriptChapterSummary {
+  id: string
+  sourceId: string
+  sourceTitle: string
+  sourcePath: string | null
+  exportPath: string
+  sequence: number
+  heading: string
+  title: string
+  wordCount: number
+  narrativeSignals: string[]
+  motifs: string[]
+  summary: string
+  fingerprint: string
+}
+
+export interface ManuscriptSummaryTrace {
+  status: 'recorded' | 'dry_run' | 'missing'
+  reason: string | null
+  openBrainHome: string
+  exportDir: string
+  memories: OpenBrainMemoryRecord[]
+  events: OpenBrainEventRecord[]
+  missingExports: Array<{
+    sourceId: string
+    title: string
+    expectedCandidates: string[]
+  }>
+  overview: {
+    sourcesObserved: number
+    manuscriptsWithExports: number
+    chaptersDetected: number
+    memoriesRecorded: number
+    eventsRecorded: number
+    rawFullTextIncluded: false
+  }
+}
+
+export interface RecordManuscriptSummariesOptions {
+  openBrainHome?: string
+  exportDir?: string
+  write?: boolean
+  generatedAt?: string
+}
+
+type GoogleDocPointer = {
+  doc_id?: string
+  resource_id?: string
+  url?: string
+}
+
+export async function recordManuscriptChapterSummaries(
+  options: RecordManuscriptSummariesOptions = {},
+): Promise<ManuscriptSummaryTrace> {
+  const openBrainHome = options.openBrainHome || process.env.OPEN_BRAIN_HOME || DEFAULT_OPEN_BRAIN_HOME
+  const exportDir = options.exportDir || process.env.OPEN_BRAIN_MANUSCRIPT_EXPORT_DIR || DEFAULT_EXPORT_DIR
+  const generatedAt = options.generatedAt || new Date().toISOString()
+  const write = options.write === true
+  const sources = await readJsonArray<OpenBrainSourceRecord>(path.join(openBrainHome, SOURCES_FILE))
+  const manuscriptSources = sources.filter((source) => source.kind === 'creative_manuscript' && source.privacyTier === 'private')
+
+  if (manuscriptSources.length === 0) {
+    return emptyTrace({
+      status: 'missing',
+      reason: 'No private creative_manuscript Open Brain sources were found.',
+      openBrainHome,
+      exportDir,
+    })
+  }
+
+  const missingExports: ManuscriptSummaryTrace['missingExports'] = []
+  const chapterSummaries: ManuscriptChapterSummary[] = []
+
+  for (const source of manuscriptSources) {
+    const resolved = await resolveManuscriptTextPath(source, exportDir)
+    if (!resolved.path) {
+      missingExports.push({
+        sourceId: source.id,
+        title: source.title,
+        expectedCandidates: resolved.candidates,
+      })
+      continue
+    }
+
+    const manuscriptText = await readFile(resolved.path, 'utf8')
+    chapterSummaries.push(...summarizeManuscriptChapters(source, resolved.path, manuscriptText))
+  }
+
+  if (chapterSummaries.length === 0) {
+    return {
+      ...emptyTrace({
+        status: 'missing',
+        reason: missingExports.length > 0
+          ? 'Private manuscript exports are missing. Export Google Docs as plain text before running with --write.'
+          : 'No chapter headings were detected in available private manuscript exports.',
+        openBrainHome,
+        exportDir,
+      }),
+      missingExports,
+      overview: {
+        sourcesObserved: manuscriptSources.length,
+        manuscriptsWithExports: 0,
+        chaptersDetected: 0,
+        memoriesRecorded: 0,
+        eventsRecorded: 0,
+        rawFullTextIncluded: false,
+      },
+    }
+  }
+
+  const memories = chapterSummaries.map((chapter) => chapterSummaryToMemory(chapter, generatedAt))
+  const events = buildSummaryEvents(chapterSummaries, generatedAt)
+
+  if (write) {
+    await mkdir(openBrainHome, { recursive: true })
+    await upsertMemories(path.join(openBrainHome, MEMORIES_FILE), memories)
+    await upsertEvents(path.join(openBrainHome, EVENTS_FILE), events)
+    return {
+      status: 'recorded',
+      reason: null,
+      openBrainHome,
+      exportDir,
+      memories,
+      events,
+      missingExports,
+      overview: {
+        sourcesObserved: manuscriptSources.length,
+        manuscriptsWithExports: unique(chapterSummaries.map((chapter) => chapter.sourceId)).length,
+        chaptersDetected: chapterSummaries.length,
+        memoriesRecorded: memories.length,
+        eventsRecorded: events.length,
+        rawFullTextIncluded: false,
+      },
+    }
+  }
+
+  return {
+    status: 'dry_run',
+    reason: null,
+    openBrainHome,
+    exportDir,
+    memories,
+    events,
+    missingExports,
+    overview: {
+      sourcesObserved: manuscriptSources.length,
+      manuscriptsWithExports: unique(chapterSummaries.map((chapter) => chapter.sourceId)).length,
+      chaptersDetected: chapterSummaries.length,
+      memoriesRecorded: 0,
+      eventsRecorded: 0,
+      rawFullTextIncluded: false,
+    },
+  }
+}
+
+export function summarizeManuscriptChapters(
+  source: Pick<OpenBrainSourceRecord, 'id' | 'title' | 'path'>,
+  exportPath: string,
+  manuscriptText: string,
+): ManuscriptChapterSummary[] {
+  const chapters = splitIntoChapters(manuscriptText)
+  return chapters.map((chapter, index) => {
+    const title = deriveChapterTitle(chapter.heading, index + 1)
+    const body = normalizeWhitespace(chapter.body)
+    const narrativeSignals = extractNarrativeSignals(body)
+    const motifs = extractMotifs(body)
+    const wordCount = countWords(body)
+    const id = `memory:creative-chapter:${slugify(source.id)}:chapter-${String(index + 1).padStart(3, '0')}`
+    const summary = buildDeterministicChapterSummary({
+      sourceTitle: source.title,
+      chapterTitle: title,
+      wordCount,
+      narrativeSignals,
+      motifs,
+    })
+    return {
+      id,
+      sourceId: source.id,
+      sourceTitle: source.title,
+      sourcePath: source.path,
+      exportPath,
+      sequence: index + 1,
+      heading: sanitizeOpenBrainText(chapter.heading, 180),
+      title: sanitizeOpenBrainText(title, 180),
+      wordCount,
+      narrativeSignals,
+      motifs,
+      summary,
+      fingerprint: fingerprintOpenBrainRecord([
+        'creative_chapter_summary',
+        source.id,
+        index + 1,
+        chapter.heading,
+        createHash('sha256').update(body).digest('hex'),
+      ]),
+    }
+  })
+}
+
+async function resolveManuscriptTextPath(source: OpenBrainSourceRecord, exportDir: string) {
+  const candidates: string[] = []
+  const sourcePath = source.path || ''
+  if (sourcePath.match(/\.(txt|md|markdown)$/i)) candidates.push(sourcePath)
+
+  const pointer = sourcePath.endsWith('.gdoc') ? await readGoogleDocPointer(sourcePath) : null
+  const docId = pointer?.doc_id || googleDocIdFromUrl(pointer?.url || '') || null
+  if (docId) {
+    candidates.push(path.join(exportDir, `${docId}.txt`))
+    candidates.push(path.join(exportDir, `${docId}.md`))
+  }
+
+  const sourceSlug = slugify(source.id)
+  candidates.push(path.join(exportDir, `${sourceSlug}.txt`))
+  candidates.push(path.join(exportDir, `${sourceSlug}.md`))
+  if (sourcePath) {
+    const basename = path.basename(sourcePath, path.extname(sourcePath))
+    candidates.push(path.join(exportDir, `${basename}.txt`))
+    candidates.push(path.join(exportDir, `${basename}.md`))
+  }
+
+  const found = unique(candidates).find((candidate) => existsSync(candidate))
+  return {
+    path: found || null,
+    candidates: unique(candidates),
+  }
+}
+
+async function readGoogleDocPointer(filePath: string): Promise<GoogleDocPointer | null> {
+  try {
+    return JSON.parse(await readFile(filePath, 'utf8')) as GoogleDocPointer
+  } catch {
+    return null
+  }
+}
+
+function googleDocIdFromUrl(url: string) {
+  const match = url.match(/\/document\/d\/([^/]+)/)
+  return match?.[1] || null
+}
+
+function splitIntoChapters(text: string) {
+  const lines = text.replace(/\r\n?/g, '\n').split('\n')
+  const headings: Array<{ line: number; heading: string }> = []
+  lines.forEach((line, index) => {
+    if (isChapterHeading(line)) {
+      headings.push({ line: index, heading: stripMarkdownHeading(line).trim() })
+    }
+  })
+
+  if (headings.length === 0) {
+    return [{
+      heading: 'Full manuscript',
+      body: text,
+    }]
+  }
+
+  return headings.map((heading, index) => {
+    const next = headings[index + 1]
+    return {
+      heading: heading.heading,
+      body: lines.slice(heading.line + 1, next ? next.line : lines.length).join('\n'),
+    }
+  }).filter((chapter) => countWords(chapter.body) > 0)
+}
+
+function isChapterHeading(line: string) {
+  const normalized = stripMarkdownHeading(line).trim()
+  if (!normalized || normalized.length > 140) return false
+  if (/chapter\s+beats?/i.test(normalized)) return false
+  if (/chapter\s+\d+\s+(?:summary|detailed beats?)/i.test(normalized)) return false
+  return /^(?:(?:part|book)\s+[a-z0-9ivxlcdm]+[\s:.-]+)?(?:chapter|chap\.?)\s+([0-9ivxlcdm]+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty)(?:\s*[:.\-]\s*.+)?$/i.test(normalized)
+    || /^(prologue|epilogue)(?:\s*[:.\-]\s*.+)?$/i.test(normalized)
+}
+
+function stripMarkdownHeading(line: string) {
+  return line
+    .replace(/^\s{0,3}#{1,6}\s+/, '')
+    .trim()
+    .replace(/^\*{1,3}(.+?)\*{1,3}$/g, '$1')
+    .trim()
+}
+
+function deriveChapterTitle(heading: string, sequence: number) {
+  const stripped = stripMarkdownHeading(heading)
+  const titleMatch = stripped.match(/(?:chapter|chap\.?)\s+[0-9a-zivxlcdm]+(?:\s*[:.\-]\s*(.+))$/i)
+    || stripped.match(/^(?:prologue|epilogue)(?:\s*[:.\-]\s*(.+))$/i)
+  return titleMatch?.[1]?.trim() || stripped || `Chapter ${sequence}`
+}
+
+function chapterSummaryToMemory(chapter: ManuscriptChapterSummary, now: string): OpenBrainMemoryRecord {
+  const body = sanitizeOpenBrainText([
+    `Private chapter-level summary for ${chapter.sourceTitle}.`,
+    `Position: ${chapter.sequence}. Working title: ${chapter.title}.`,
+    `Approximate length: ${chapter.wordCount} words.`,
+    `Summary: ${chapter.summary}`,
+    `Narrative signals: ${chapter.narrativeSignals.join(', ') || 'none detected'}.`,
+    `Motifs: ${chapter.motifs.join(', ') || 'none detected'}.`,
+    'Source handling: raw manuscript text was read from the private manuscript export vault and was not copied into the repo, public wiki overlay, chatbot knowledge, or public RAG.',
+  ].join('\n'), 1400)
+
+  return {
+    id: chapter.id,
+    kind: 'fact',
+    title: sanitizeOpenBrainText(`${chapter.sourceTitle} - ${chapter.title}`, 180),
+    body,
+    privacyTier: 'private',
+    confidence: 0.82,
+    sourceIds: [chapter.sourceId],
+    createdAt: now,
+    updatedAt: now,
+    fingerprint: chapter.fingerprint,
+  }
+}
+
+function buildSummaryEvents(chapters: ManuscriptChapterSummary[], now: string) {
+  return unique(chapters.map((chapter) => chapter.sourceId)).map((sourceId) => {
+    const sourceChapters = chapters.filter((chapter) => chapter.sourceId === sourceId)
+    const source = sourceChapters[0]
+    return {
+      id: `event:creative-manuscript-summary:${slugify(sourceId)}`,
+      kind: 'projection_compiled' as const,
+      title: `Compiled private chapter summaries: ${source.sourceTitle}`,
+      summary: `${sourceChapters.length} chapter-level private summary record(s) generated. Raw manuscript text remains only in the private export vault.`,
+      privacyTier: 'private' as const,
+      confidence: 0.82,
+      sourceIds: [sourceId],
+      createdAt: now,
+      fingerprint: fingerprintOpenBrainRecord([
+        'creative_manuscript_summary',
+        sourceId,
+        sourceChapters.map((chapter) => chapter.fingerprint).join(','),
+      ]),
+      metadata: {
+        producerId: 'producer:creative-manuscript-chapter-summarizer',
+        sourceKind: 'creative_manuscript',
+        chaptersRecorded: sourceChapters.length,
+        exportPaths: unique(sourceChapters.map((chapter) => chapter.exportPath)),
+        rawFullTextIncluded: false,
+        publicProjectionAllowed: false,
+      },
+    }
+  })
+}
+
+function buildDeterministicChapterSummary(input: {
+  sourceTitle: string
+  chapterTitle: string
+  wordCount: number
+  narrativeSignals: string[]
+  motifs: string[]
+}) {
+  const signals = input.narrativeSignals.slice(0, 5)
+  const motifs = input.motifs.slice(0, 5)
+  const signalText = signals.length > 0 ? signals.join(', ') : 'the named story world and chapter cast'
+  const motifText = motifs.length > 0 ? motifs.join(', ') : 'the manuscript themes already present in the source'
+  return sanitizeOpenBrainText(
+    `This chapter appears to develop ${input.chapterTitle} within ${input.sourceTitle}, with attention on ${signalText}. The recurring motif layer points toward ${motifText}. This is a private machine-generated orientation summary from chapter structure and term signals; it should guide retrieval and review, not replace a human literary summary.`,
+    700,
+  )
+}
+
+function extractNarrativeSignals(text: string) {
+  const matches = Array.from(text.matchAll(/\b[A-Z][a-zA-Z'’-]+(?:\s+[A-Z][a-zA-Z'’-]+){0,3}\b/g))
+    .map((match) => normalizeWhitespace(match[0]))
+    .filter((phrase) => !COMMON_CAPITALIZED.has(phrase) && phrase.length > 2)
+  return topCounts(matches, 8)
+}
+
+function extractMotifs(text: string) {
+  const motifPatterns: Array<[string, RegExp]> = [
+    ['access', /\baccess\b/gi],
+    ['algorithmic control', /\b(?:algorithm|algorithms|algorithmic)\b/gi],
+    ['analog districts', /\banalog\s+districts?\b/gi],
+    ['betrayal', /\bbetray(?:al|ed|s)?\b/gi],
+    ['code', /\bcode\b/gi],
+    ['community', /\bcommun(?:ity|ities)\b/gi],
+    ['elite power', /\belites?\b/gi],
+    ['liberation', /\bliberat(?:e|ed|ion)\b/gi],
+    ['memory', /\bmemor(?:y|ies)\b/gi],
+    ['quantum power', /\bquantum\b/gi],
+    ['surveillance', /\bsurveil(?:lance|led|s)?\b/gi],
+    ['trust', /\btrust\b/gi],
+  ]
+  return motifPatterns
+    .map(([label, pattern]) => ({ label, count: Array.from(text.matchAll(pattern)).length }))
+    .filter((motif) => motif.count > 0)
+    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label))
+    .slice(0, 8)
+    .map((motif) => motif.label)
+}
+
+function topCounts(values: string[], limit: number) {
+  const counts = new Map<string, number>()
+  for (const value of values) counts.set(value, (counts.get(value) || 0) + 1)
+  return Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, limit)
+    .map(([value]) => value)
+}
+
+function countWords(text: string) {
+  return (text.match(/\b[\w'’-]+\b/g) || []).length
+}
+
+function normalizeWhitespace(value: string) {
+  return value.replace(/\s+/g, ' ').trim()
+}
+
+function slugify(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+async function upsertMemories(filePath: string, memories: OpenBrainMemoryRecord[]) {
+  const existing = await readJsonArray<OpenBrainMemoryRecord>(filePath)
+  const byId = new Map(existing.map((memory) => [memory.id, memory]))
+  for (const memory of memories) {
+    byId.set(memory.id, {
+      ...byId.get(memory.id),
+      ...memory,
+      createdAt: byId.get(memory.id)?.createdAt || memory.createdAt,
+      updatedAt: memory.updatedAt,
+    })
+  }
+  await writeJsonArray(filePath, Array.from(byId.values()))
+}
+
+async function upsertEvents(filePath: string, events: OpenBrainEventRecord[]) {
+  const existing = await readJsonArray<OpenBrainEventRecord>(filePath)
+  const byId = new Map(existing.map((event) => [event.id, event]))
+  for (const event of events) byId.set(event.id, event)
+  await writeJsonArray(filePath, Array.from(byId.values()))
+}
+
+async function readJsonArray<T>(filePath: string): Promise<T[]> {
+  try {
+    return JSON.parse(await readFile(filePath, 'utf8')) as T[]
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === 'ENOENT') return []
+    throw error
+  }
+}
+
+async function writeJsonArray<T>(filePath: string, records: T[]) {
+  await mkdir(path.dirname(filePath), { recursive: true })
+  await writeFile(filePath, `${JSON.stringify(records, null, 2)}\n`, 'utf8')
+}
+
+function unique<T>(values: T[]) {
+  return Array.from(new Set(values))
+}
+
+function fingerprintOpenBrainRecord(parts: unknown[]) {
+  return createHash('sha256').update(JSON.stringify(parts)).digest('hex')
+}
+
+function sanitizeOpenBrainText(value: string, maxLength = 700) {
+  const scrubbed = value
+    .replace(SECRETISH_PATTERN, '[redacted-secret]')
+    .replace(/\s+/g, ' ')
+    .trim()
+  if (scrubbed.length <= maxLength) return scrubbed
+  return `${scrubbed.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`
+}
+
+function emptyTrace(input: {
+  status: ManuscriptSummaryTrace['status']
+  reason: string
+  openBrainHome: string
+  exportDir: string
+}): ManuscriptSummaryTrace {
+  return {
+    status: input.status,
+    reason: input.reason,
+    openBrainHome: input.openBrainHome,
+    exportDir: input.exportDir,
+    memories: [],
+    events: [],
+    missingExports: [],
+    overview: {
+      sourcesObserved: 0,
+      manuscriptsWithExports: 0,
+      chaptersDetected: 0,
+      memoriesRecorded: 0,
+      eventsRecorded: 0,
+      rawFullTextIncluded: false,
+    },
+  }
+}
+
+const COMMON_CAPITALIZED = new Set([
+  'A',
+  'And',
+  'But',
+  'Chapter',
+  'He',
+  'Her',
+  'His',
+  'I',
+  'In',
+  'It',
+  'Part',
+  'She',
+  'That',
+  'The',
+  'They',
+  'This',
+  'We',
+  'When',
+  'Where',
+  'With',
+])

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "open-brain:automation-producer": "tsx scripts/open-brain-automation-producer.ts",
     "open-brain:agent-ops-producer": "tsx scripts/open-brain-agent-ops-producer.ts",
     "open-brain:autoresearch-producer": "tsx scripts/open-brain-autoresearch-producer.ts",
+    "open-brain:manuscript-summaries": "tsx scripts/open-brain-manuscript-summarizer.ts",
     "open-brain:roadmap-status": "tsx scripts/open-brain-roadmap-status.ts",
     "wrm:smoke-gate": "tsx scripts/wrm-production-smoke-gate.ts",
     "source-protocol:smoke": "tsx scripts/source-protocol-smoke.ts",

--- a/scripts/open-brain-manuscript-summarizer.ts
+++ b/scripts/open-brain-manuscript-summarizer.ts
@@ -1,0 +1,62 @@
+#!/usr/bin/env tsx
+import { recordManuscriptChapterSummaries } from '../lib/open-brain-manuscript-summaries'
+
+function parseArgs(argv: string[]) {
+  const args = argv.includes('--') ? argv.slice(argv.indexOf('--') + 1) : argv.slice(2)
+  const options: {
+    write: boolean
+    openBrainHome?: string
+    exportDir?: string
+  } = {
+    write: false,
+  }
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+    if (arg === '--write') options.write = true
+    if (arg === '--open-brain-home') options.openBrainHome = args[index + 1]
+    if (arg === '--export-dir') options.exportDir = args[index + 1]
+  }
+
+  return options
+}
+
+async function main() {
+  const options = parseArgs(process.argv)
+  const result = await recordManuscriptChapterSummaries(options)
+  const output = {
+    status: result.status,
+    reason: result.reason,
+    openBrainHome: result.openBrainHome,
+    exportDir: result.exportDir,
+    overview: result.overview,
+    missingExports: result.missingExports,
+    memories: result.memories.map((memory) => ({
+      id: memory.id,
+      kind: memory.kind,
+      title: memory.title,
+      privacyTier: memory.privacyTier,
+      sourceIds: memory.sourceIds,
+      fingerprint: memory.fingerprint,
+    })),
+    events: result.events.map((event) => ({
+      id: event.id,
+      kind: event.kind,
+      title: event.title,
+      privacyTier: event.privacyTier,
+      sourceIds: event.sourceIds,
+      fingerprint: event.fingerprint,
+      metadata: event.metadata,
+    })),
+  }
+
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+  if (result.status === 'missing') process.exitCode = 1
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('[open-brain-manuscript-summarizer] failed:', error instanceof Error ? error.message : error)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Summary
- Add a local-only Open Brain manuscript chapter summarizer producer and CLI.
- Generate private chapter-level memory records from private text exports without copying raw manuscript text into the repo, public wiki overlays, chatbot knowledge, Pinecone, or public RAG.
- Add an Open Brain Admin `Memories` tab that surfaces durable memory records, including private creative manuscript chapter summaries, with privacy and projection boundaries visible.
- Document the private manuscript summary workflow in the Open Brain local service contract.

## Enhancement Impact Preflight
- Enhancement: Add private Open Brain chapter-level manuscript summary producer for Codex Chronicles materials, then surface durable memories in Portfolio Admin.
- User-facing surface: `/admin/agents/open-brain` with the new `Memories` tab.
- Predicted files: `package.json`, `lib/open-brain-manuscript-summaries.ts`, `lib/open-brain-manuscript-summaries.test.ts`, `scripts/open-brain-manuscript-summarizer.ts`, `docs/open-brain-local-service.md`, `app/admin/agents/open-brain/page.tsx`, `app/admin/agents/open-brain/page.test.tsx`.
- Shared routes/APIs/tables/helpers: local Open Brain JSON files and existing `/api/admin/agents/open-brain` snapshot shape only; no database tables, hosted sync, or mutating admin controls added.
- Active PRs checked before editing: #570/#571 lineage, #568, #566, and current #572. Other open PRs touched subscription/revenue docs/tests and client email context files; no overlap with this lane.
- Dirty worktree files checked: work was performed in sibling worktree `/Users/vambahsillah/Projects/Portfolio.worktrees/open-brain-manuscript-summaries`; staged/committed files were scoped to this feature.
- Overlap rating: GREEN.
- Coordination decision: proceed independently on draft PR #572; no merge performed.

## Validation
- `npm ci`
- `npm test -- --run lib/open-brain-manuscript-summaries.test.ts lib/open-brain.test.ts scripts/open-brain-mcp-server.test.ts`
- `npm test -- --run app/admin/agents/open-brain/page.test.tsx lib/open-brain-manuscript-summaries.test.ts lib/open-brain.test.ts`
- `npm test -- --run app/admin/agents/open-brain/page.test.tsx`
- `npm run lint`
- `git diff --check`
- `npm run build`
- Local operational dry-run: `OPEN_BRAIN_HOME=/Users/vambahsillah/.open-brain OPEN_BRAIN_MANUSCRIPT_EXPORT_DIR=/Users/vambahsillah/.open-brain/private-vault/manuscripts npm run open-brain:manuscript-summaries`
- Local operational write: `OPEN_BRAIN_HOME=/Users/vambahsillah/.open-brain OPEN_BRAIN_MANUSCRIPT_EXPORT_DIR=/Users/vambahsillah/.open-brain/private-vault/manuscripts npm run open-brain:manuscript-summaries -- --write`
- Browser smoke: fresh in-app browser tab at `http://localhost:3024/admin/agents/open-brain`, clicked `Memories`, confirmed `Creative Manuscript Chapter Summaries`, `Durable memories`, `Chapter summaries`, and private manuscript chapter rows render.

Notes:
- `npm run lint` passes with existing `<img>` warnings in `app/client/dashboard/[token]/page.tsx` and `components/Navigation.test.tsx`.
- `npm run build` passes with the same image warnings plus existing dev env warnings that `MOCK_N8N=false` and `N8N_DISABLE_OUTBOUND=false`.
- Push hook database health check passed using `.env.local`.
- No live workflow/customer-data smoke was run.

## Integration Notes
- No migrations or database changes.
- No Vercel env changes required.
- Vercel contexts were not checked by this feature lane:
  - Vercel – portfolio: not checked
  - Vercel – portfolio-staging: not checked
- Non-git operational state touched locally:
  - Wrote private manuscript text exports under `/Users/vambahsillah/.open-brain/private-vault/manuscripts`.
  - Backed up current local Open Brain JSON files to `/Users/vambahsillah/.open-brain/backups/manuscript-chapter-summaries-2026-06-25T23-05-19`.
  - Wrote 65 private `memory:creative-chapter:*` records to `/Users/vambahsillah/.open-brain/memories.json`.
  - Wrote 3 private `event:creative-manuscript-summary:*` provenance events to `/Users/vambahsillah/.open-brain/events.json`.
  - Post-write audit found 65/65 chapter memories private and all manuscript summary events set `rawFullTextIncluded: false` and `publicProjectionAllowed: false`.
  - The follow-up admin UI fix did not intentionally write additional Open Brain operational state.
