### PR TITLE
feat: recommend campaign calendar templates

### DIFF
--- a/app/admin/campaigns/[id]/page.test.tsx
+++ b/app/admin/campaigns/[id]/page.test.tsx
@@ -53,14 +53,17 @@ const campaignDetail = {
 };
 
 describe('CampaignDetailPage content calendar gates', () => {
+  let campaignResponse = campaignDetail;
+
   beforeEach(() => {
+    campaignResponse = campaignDetail;
     vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
 
       if (url === '/api/admin/campaigns/campaign-1') {
         return {
           ok: true,
-          json: async () => ({ data: campaignDetail }),
+          json: async () => ({ data: campaignResponse }),
         };
       }
 
@@ -154,6 +157,9 @@ describe('CampaignDetailPage content calendar gates', () => {
     );
     expect(screen.getByText('14d lead')).toBeInTheDocument();
     expect(screen.getByText('1 gates')).toBeInTheDocument();
+    expect(screen.getByText('Recommended from campaign signals')).toBeInTheDocument();
+    expect(screen.getByText('Type, name, and description only')).toBeInTheDocument();
+    expect(screen.getByText('Recommended fit')).toBeInTheDocument();
     expect(screen.getByText('Tease: Approval gates')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Authorize Draft Handoff' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Reject' })).toBeInTheDocument();
@@ -196,5 +202,28 @@ describe('CampaignDetailPage content calendar gates', () => {
     expect(JSON.parse(String(rejectCall?.[1]?.body))).toEqual({
       decision_note: 'Needs a stronger proof point before this campaign item is due.',
     });
+  });
+
+  it('auto-selects the recommended template when campaign signals point to video production', async () => {
+    campaignResponse = {
+      ...campaignDetail,
+      name: 'YouTube Authority Video Launch',
+      description: 'Prepare a thumbnail-led creator video release for the Agent Ops framework.',
+      campaign_type: 'bonus_credit',
+    };
+
+    render(<CampaignDetailPage />);
+
+    expect(await screen.findByRole('heading', { name: 'YouTube Authority Video Launch' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Content Calendar1' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('A video-led calendar with topic validation, hook/script readiness, thumbnail/title work, launch, and post-publish learning.')).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByText('YouTube video release').length).toBeGreaterThan(1);
+    expect(screen.getByText('YouTube language calls for video-led milestones.')).toBeInTheDocument();
+    expect(screen.getByText('Score 12')).toBeInTheDocument();
+    expect(screen.getByText('21d lead')).toBeInTheDocument();
   });
 });

--- a/app/admin/campaigns/[id]/page.tsx
+++ b/app/admin/campaigns/[id]/page.tsx
@@ -25,6 +25,7 @@ import {
   SOCIAL_CONTENT_CALENDAR_SOURCE_LABELS,
   SOCIAL_CONTENT_CALENDAR_TEMPLATE_KEYS,
   SOCIAL_CONTENT_CALENDAR_TEMPLATES,
+  recommendCalendarTemplates,
   type SocialContentCalendarTemplateKey,
 } from '@/lib/social-content-calendar';
 
@@ -103,10 +104,12 @@ export default function CampaignDetailPage() {
   const [contentPlanNotice, setContentPlanNotice] = useState('');
   const [contentPlanTemplateKey, setContentPlanTemplateKey] =
     useState<SocialContentCalendarTemplateKey>('whisper_to_shout');
+  const [templateRecommendationAppliedCampaignId, setTemplateRecommendationAppliedCampaignId] = useState<string | null>(null);
   const [calendarActionItemId, setCalendarActionItemId] = useState<string | null>(null);
   const [rejectingCalendarItemId, setRejectingCalendarItemId] = useState<string | null>(null);
   const [calendarDecisionNotes, setCalendarDecisionNotes] = useState<Record<string, string>>({});
   const selectedContentPlanTemplate = SOCIAL_CONTENT_CALENDAR_TEMPLATES[contentPlanTemplateKey];
+  const templateRecommendations = campaign ? recommendCalendarTemplates(campaign).slice(0, 3) : [];
 
   // Criteria form
   const [showCriteriaForm, setShowCriteriaForm] = useState(false);
@@ -176,6 +179,15 @@ export default function CampaignDetailPage() {
   useEffect(() => {
     Promise.all([fetchCampaign(), fetchEnrollments(), fetchBundles()]).finally(() => setLoading(false));
   }, [fetchCampaign, fetchEnrollments, fetchBundles]);
+
+  useEffect(() => {
+    if (!campaign || templateRecommendationAppliedCampaignId === campaign.id) return;
+    const [recommendation] = recommendCalendarTemplates(campaign);
+    if (recommendation) {
+      setContentPlanTemplateKey(recommendation.key);
+    }
+    setTemplateRecommendationAppliedCampaignId(campaign.id);
+  }, [campaign, templateRecommendationAppliedCampaignId]);
 
   const handleAddCriterion = async () => {
     if (!criteriaForm.label_template.trim()) return;
@@ -684,7 +696,14 @@ export default function CampaignDetailPage() {
           <div className="admin-console-card mb-4 rounded-lg border border-blue-500/25 bg-blue-500/10 p-3 text-sm text-blue-100">
             <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
               <div>
-                <p className="font-semibold">{selectedContentPlanTemplate.label}</p>
+                <div className="flex flex-wrap items-center gap-2">
+                  <p className="font-semibold">{selectedContentPlanTemplate.label}</p>
+                  {templateRecommendations[0]?.key === contentPlanTemplateKey && (
+                    <span className="rounded-full border border-emerald-400/30 bg-emerald-500/10 px-2 py-0.5 text-[0.65rem] font-semibold text-emerald-100">
+                      Recommended fit
+                    </span>
+                  )}
+                </div>
                 <p className="mt-1 text-xs leading-5 text-blue-100/80">
                   {selectedContentPlanTemplate.description}
                 </p>
@@ -703,6 +722,42 @@ export default function CampaignDetailPage() {
                 ))}
               </div>
             </div>
+            {templateRecommendations.length > 0 && (
+              <div className="mt-3 rounded-lg border border-blue-300/20 bg-background/35 p-3">
+                <div className="mb-2 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-blue-100/80">
+                    Recommended from campaign signals
+                  </p>
+                  <span className="text-[0.68rem] text-blue-100/65">
+                    Type, name, and description only
+                  </span>
+                </div>
+                <div className="grid gap-2 lg:grid-cols-3">
+                  {templateRecommendations.map((recommendation) => (
+                    <button
+                      key={recommendation.key}
+                      type="button"
+                      onClick={() => setContentPlanTemplateKey(recommendation.key)}
+                      className={`rounded-lg border p-3 text-left transition-colors ${
+                        recommendation.key === contentPlanTemplateKey
+                          ? 'border-emerald-400/45 bg-emerald-500/10 text-emerald-50'
+                          : 'border-blue-300/20 bg-blue-950/20 text-blue-100 hover:bg-blue-500/15'
+                      }`}
+                    >
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="text-xs font-semibold">{recommendation.label}</span>
+                        <span className="rounded-full border border-current/20 px-2 py-0.5 text-[0.62rem]">
+                          Score {recommendation.score}
+                        </span>
+                      </div>
+                      <p className="mt-2 line-clamp-2 text-[0.68rem] leading-5 opacity-80">
+                        {recommendation.reasons[0] ?? 'Safe fit for this campaign.'}
+                      </p>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
             <div className="mt-3 grid gap-2 lg:grid-cols-4">
               {selectedContentPlanTemplate.milestones.map((milestone) => (
                 <div key={milestone.key} className="rounded-lg border border-blue-300/20 bg-background/35 p-3">

--- a/lib/social-content-calendar.test.ts
+++ b/lib/social-content-calendar.test.ts
@@ -10,6 +10,7 @@ import {
   normalizeCampaignPhase,
   normalizeCalendarTemplateKey,
   normalizeDueStatus,
+  recommendCalendarTemplates,
 } from './social-content-calendar'
 
 describe('social-content-calendar helpers', () => {
@@ -163,5 +164,34 @@ describe('social-content-calendar helpers', () => {
         approval_gates: ['script_review', 'visual_review'],
       }),
     }))
+  })
+
+  it('recommends calendar templates from campaign goal signals', () => {
+    const youtubeRecommendations = recommendCalendarTemplates({
+      name: 'YouTube Authority Video Launch',
+      description: 'Prepare a thumbnail-led creator video release for the Agent Ops framework.',
+      campaign_type: 'bonus_credit',
+    })
+
+    expect(youtubeRecommendations[0]).toEqual(expect.objectContaining({
+      key: 'youtube_video_release',
+      score: expect.any(Number),
+      matched_terms: expect.arrayContaining(['youtube', 'video', 'thumbnail', 'creator']),
+      reasons: expect.arrayContaining([
+        'YouTube language calls for video-led milestones.',
+      ]),
+    }))
+
+    const proofRecommendations = recommendCalendarTemplates({
+      name: 'Client-safe proof drop',
+      description: 'Turn shipped project evidence and results into a case study without exposing private client details.',
+      campaign_type: 'win_money_back',
+    })
+
+    expect(proofRecommendations[0]).toEqual(expect.objectContaining({
+      key: 'case_study_proof_drop',
+      matched_terms: expect.arrayContaining(['case study', 'proof', 'client', 'shipped', 'result', 'evidence']),
+    }))
+    expect(proofRecommendations.map((recommendation) => recommendation.key)).toContain('whisper_to_shout')
   })
 })

--- a/lib/social-content-calendar.ts
+++ b/lib/social-content-calendar.ts
@@ -127,6 +127,14 @@ export type SocialContentCalendarTemplate = {
   milestones: SocialContentCalendarTemplateMilestone[]
 }
 
+export type SocialContentCalendarTemplateRecommendation = {
+  key: SocialContentCalendarTemplateKey
+  label: string
+  score: number
+  reasons: string[]
+  matched_terms: string[]
+}
+
 const SOURCE_URLS = {
   youtubeCreators: 'https://www.youtube.com/creators/grow/optimize-your-content/',
   youtubePremieres: 'https://support.google.com/youtube/answer/9080341',
@@ -509,6 +517,106 @@ export function normalizeCalendarTemplateKey(value: unknown): SocialContentCalen
 
 export function getCalendarTemplate(value?: unknown): SocialContentCalendarTemplate {
   return SOCIAL_CONTENT_CALENDAR_TEMPLATES[normalizeCalendarTemplateKey(value)]
+}
+
+const TEMPLATE_RECOMMENDATION_ORDER: SocialContentCalendarTemplateKey[] = [
+  'whisper_to_shout',
+  'youtube_video_release',
+  'short_form_series',
+  'evergreen_authority',
+  'case_study_proof_drop',
+]
+
+const TEMPLATE_RECOMMENDATION_TERMS: Record<
+  SocialContentCalendarTemplateKey,
+  Array<{ term: string; reason: string; weight: number }>
+> = {
+  whisper_to_shout: [
+    { term: 'launch', reason: 'Campaign language points to a launch arc.', weight: 3 },
+    { term: 'offer', reason: 'Offer language needs tease-to-conversion pacing.', weight: 3 },
+    { term: 'bonus', reason: 'Bonus language fits a whisper-to-shout sequence.', weight: 2 },
+    { term: 'release', reason: 'Release language benefits from staged announcements.', weight: 2 },
+    { term: 'promotion', reason: 'Promotional language maps to campaign pacing.', weight: 2 },
+  ],
+  youtube_video_release: [
+    { term: 'youtube', reason: 'YouTube language calls for video-led milestones.', weight: 4 },
+    { term: 'video', reason: 'Video language needs hook, script, thumbnail, and launch gates.', weight: 3 },
+    { term: 'thumbnail', reason: 'Thumbnail language makes the video release template stronger.', weight: 3 },
+    { term: 'premiere', reason: 'Premiere language maps to YouTube launch planning.', weight: 3 },
+    { term: 'creator', reason: 'Creator language points to public video research patterns.', weight: 2 },
+  ],
+  short_form_series: [
+    { term: 'reel', reason: 'Reels language needs short-form batches and safe-area planning.', weight: 4 },
+    { term: 'short', reason: 'Short-form language benefits from repeatable hook testing.', weight: 3 },
+    { term: 'tiktok', reason: 'TikTok language maps to short-form series planning.', weight: 3 },
+    { term: 'instagram', reason: 'Instagram language fits the Reels planning lane.', weight: 3 },
+    { term: 'series', reason: 'Series language benefits from repeated variations.', weight: 2 },
+  ],
+  evergreen_authority: [
+    { term: 'evergreen', reason: 'Evergreen language calls for durable authority content.', weight: 4 },
+    { term: 'authority', reason: 'Authority language fits a reusable education sequence.', weight: 3 },
+    { term: 'education', reason: 'Education language needs framework and reference milestones.', weight: 3 },
+    { term: 'framework', reason: 'Framework language fits an evergreen teaching asset.', weight: 3 },
+    { term: 'guide', reason: 'Guide language points to durable thought-leadership content.', weight: 2 },
+  ],
+  case_study_proof_drop: [
+    { term: 'case study', reason: 'Case-study language needs proof and privacy review.', weight: 4 },
+    { term: 'proof', reason: 'Proof language calls for evidence packaging.', weight: 3 },
+    { term: 'client', reason: 'Client language needs privacy-safe evidence handling.', weight: 3 },
+    { term: 'shipped', reason: 'Shipped-work language maps to a proof drop.', weight: 3 },
+    { term: 'result', reason: 'Result language benefits from metrics and before/after framing.', weight: 2 },
+    { term: 'evidence', reason: 'Evidence language points to screenshot and source review.', weight: 2 },
+  ],
+}
+
+function recommendationText(campaign: Pick<AttractionCampaign, 'name' | 'description' | 'campaign_type'>) {
+  return `${campaign.name} ${campaign.description ?? ''} ${campaign.campaign_type}`.toLowerCase()
+}
+
+function uniqueValues(values: string[]) {
+  return Array.from(new Set(values))
+}
+
+export function recommendCalendarTemplates(
+  campaign: Pick<AttractionCampaign, 'name' | 'description' | 'campaign_type'>,
+): SocialContentCalendarTemplateRecommendation[] {
+  const text = recommendationText(campaign)
+
+  return TEMPLATE_RECOMMENDATION_ORDER
+    .map((key, orderIndex) => {
+      const template = SOCIAL_CONTENT_CALENDAR_TEMPLATES[key]
+      const termMatches = TEMPLATE_RECOMMENDATION_TERMS[key].filter(({ term }) => text.includes(term))
+      const matchedTerms = termMatches.map(({ term }) => term)
+      const reasons = termMatches.map(({ reason }) => reason)
+      let score = termMatches.reduce((total, match) => total + match.weight, 0)
+
+      if (campaign.campaign_type === 'free_challenge' && key === 'short_form_series') {
+        score += 3
+        reasons.push('Challenge campaigns benefit from repeatable short-form prompts.')
+        matchedTerms.push('free_challenge')
+      }
+      if ((campaign.campaign_type === 'bonus_credit' || campaign.campaign_type === 'win_money_back') && key === 'whisper_to_shout') {
+        score += 3
+        reasons.push('Offer-backed campaigns benefit from staged campaign pacing.')
+        matchedTerms.push(campaign.campaign_type)
+      }
+      if (key === 'whisper_to_shout') {
+        score += 1
+        reasons.push('Safe default for time-bound campaign announcements.')
+      }
+
+      return {
+        key,
+        label: template.label,
+        score,
+        reasons: uniqueValues(reasons).slice(0, 3),
+        matched_terms: uniqueValues(matchedTerms),
+        orderIndex,
+      }
+    })
+    .filter((recommendation) => recommendation.score > 0)
+    .sort((a, b) => b.score - a.score || a.orderIndex - b.orderIndex)
+    .map(({ orderIndex: _orderIndex, ...recommendation }) => recommendation)
 }
 
 export function defaultAuthorizationDueAt(scheduledFor: string | Date) {


### PR DESCRIPTION
## Summary
- Add deterministic campaign calendar template recommendations from campaign type, name, and description signals.
- Auto-select the top recommended template once per campaign load.
- Show the top recommendation cards with fit reasons and scores next to the Campaign detail Content Calendar template selector.

## Validation
- npm test -- --run 'app/admin/campaigns/[id]/page.test.tsx' lib/social-content-calendar.test.ts\n- npm run build:knowledge && npx tsc --noEmit\n- npm run lint (passes with existing unrelated <img> warnings in app/client/dashboard/[token]/page.tsx and components/Navigation.test.tsx)\n- git diff --check\n- Browser smoke fallback: Playwright opened http://localhost:3034/admin/campaigns and verified the Campaigns page rendered. Campaign detail smoke was skipped because local dev has 0 campaigns; the changed detail tab is covered by the focused React test.\n\n## Integration Notes\n- No migration required.\n- No provider generation, upload, schedule, publish, external post, or calendar item creation is triggered by recommendations.\n- Vercel contexts not checked for this PR yet:\n  - Vercel – portfolio\n  - Vercel – portfolio-staging\n