### PR TITLE
feat: explain calendar milestone rationale

### DIFF
--- a/app/admin/campaigns/[id]/page.test.tsx
+++ b/app/admin/campaigns/[id]/page.test.tsx
@@ -47,7 +47,18 @@ const campaignDetail = {
       authorization_due_at: '2026-06-24T14:00:00.000Z',
       agent_work_item_id: 'work-social-1',
       social_content_id: null,
-      metadata: {},
+      metadata: {
+        template_label: 'Whisper-to-shout launch',
+        source_labels: ['HubSpot social calendar template'],
+        milestone_rationale: {
+          summary: 'Tease milestone for LinkedIn: Open with a small tension before the campaign teaches the larger frame.',
+          campaign_fit: 'Whisper-to-shout launch fits "Agent Ops Campaign" because the campaign brief points to governed AI operating layer content.',
+          timing: '14 day lead time keeps tease work reviewable before the scheduled campaign moment.',
+          required_inputs: ['triggering_event'],
+          approval_gates: ['copy_review'],
+          source_labels: ['HubSpot social calendar template'],
+        },
+      },
     },
   ],
 };
@@ -161,6 +172,9 @@ describe('CampaignDetailPage content calendar gates', () => {
     expect(screen.getByText('Type, name, and description only')).toBeInTheDocument();
     expect(screen.getByText('Recommended fit')).toBeInTheDocument();
     expect(screen.getByText('Tease: Approval gates')).toBeInTheDocument();
+    expect(screen.getByText('Why this exists:')).toBeInTheDocument();
+    expect(screen.getByText(/Tease milestone for LinkedIn/)).toBeInTheDocument();
+    expect(screen.getAllByText('HubSpot social calendar template').length).toBeGreaterThan(1);
     expect(screen.getByRole('button', { name: 'Authorize Draft Handoff' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Reject' })).toBeInTheDocument();
 

--- a/app/admin/campaigns/[id]/page.tsx
+++ b/app/admin/campaigns/[id]/page.tsx
@@ -60,6 +60,12 @@ function metadataRecord(value: unknown) {
     : {};
 }
 
+function metadataStringArray(value: unknown) {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+    : [];
+}
+
 function sourceLabel(url: string) {
   return SOCIAL_CONTENT_CALENDAR_SOURCE_LABELS[url] || new URL(url).hostname.replace(/^www\./, '');
 }
@@ -783,6 +789,11 @@ export default function CampaignDetailPage() {
                     <span className="rounded-full border border-blue-300/20 px-2 py-0.5 text-[0.62rem] text-blue-100/75">
                       {milestone.approval_gates.length} gates
                     </span>
+                    {milestone.source_urls.slice(0, 1).map((url) => (
+                      <span key={url} className="rounded-full border border-blue-300/20 px-2 py-0.5 text-[0.62rem] text-blue-100/75">
+                        {sourceLabel(url)}
+                      </span>
+                    ))}
                   </div>
                 </div>
               ))}
@@ -827,6 +838,38 @@ export default function CampaignDetailPage() {
                         {item.planned_angle && (
                           <p className="mt-2 line-clamp-3 text-xs leading-5 text-muted-foreground">{item.planned_angle}</p>
                         )}
+                        {(() => {
+                          const metadata = metadataRecord(item.metadata);
+                          const rationale = metadataRecord(metadata.milestone_rationale);
+                          const summary = typeof rationale.summary === 'string'
+                            ? rationale.summary
+                            : typeof metadata.campaign_fit_summary === 'string'
+                              ? metadata.campaign_fit_summary
+                              : '';
+                          const sourceLabels = metadataStringArray(metadata.source_labels);
+
+                          if (!summary && sourceLabels.length === 0) return null;
+
+                          return (
+                            <div className="mt-3 rounded-md border border-white/10 bg-background/35 p-2">
+                              {summary && (
+                                <p className="text-[0.68rem] leading-5 text-muted-foreground">
+                                  <span className="font-semibold text-foreground/80">Why this exists: </span>
+                                  {summary}
+                                </p>
+                              )}
+                              {sourceLabels.length > 0 && (
+                                <div className="mt-2 flex flex-wrap gap-1.5">
+                                  {sourceLabels.slice(0, 2).map((label) => (
+                                    <span key={label} className="rounded-full border border-white/10 px-2 py-0.5 text-[0.62rem] text-muted-foreground">
+                                      {label}
+                                    </span>
+                                  ))}
+                                </div>
+                              )}
+                            </div>
+                          );
+                        })()}
                         <div className="mt-3 flex flex-wrap gap-2 text-[0.68rem] text-muted-foreground">
                           <span className="rounded-full border border-white/10 px-2 py-0.5">{item.channel.replace(/_/g, ' ')}</span>
                           <span className="rounded-full border border-white/10 px-2 py-0.5">{item.due_status.replace(/_/g, ' ')}</span>

--- a/app/api/admin/campaigns/[id]/content-plan/route.test.ts
+++ b/app/api/admin/campaigns/[id]/content-plan/route.test.ts
@@ -88,7 +88,17 @@ describe('/api/admin/campaigns/[id]/content-plan', () => {
 
     expect(response.status).toBe(200)
     expect(insert).toHaveBeenCalledWith(expect.arrayContaining([
-      expect.objectContaining({ campaign_phase: 'teach', campaign_id: 'campaign-1', created_by: 'admin-user' }),
+      expect.objectContaining({
+        campaign_phase: 'teach',
+        campaign_id: 'campaign-1',
+        created_by: 'admin-user',
+        metadata: expect.objectContaining({
+          milestone_rationale: expect.objectContaining({
+            summary: expect.stringContaining('Teach milestone for LinkedIn'),
+          }),
+          source_labels: expect.arrayContaining(['HubSpot social calendar template']),
+        }),
+      }),
       expect.objectContaining({ campaign_phase: 'proof' }),
       expect.objectContaining({ campaign_phase: 'offer' }),
     ]))
@@ -98,6 +108,15 @@ describe('/api/admin/campaigns/[id]/content-plan', () => {
       created_count: 3,
       skipped_existing_count: 1,
       planned_phases: ['tease', 'teach', 'proof', 'offer'],
+      planned_milestones: expect.arrayContaining([
+        expect.objectContaining({
+          title: 'Teach: Agent Ops Campaign',
+          rationale: expect.objectContaining({
+            summary: expect.stringContaining('Teach milestone for LinkedIn'),
+          }),
+          source_labels: expect.arrayContaining(['HubSpot social calendar template']),
+        }),
+      ]),
       side_effects: {
         publish: false,
         external_post: false,
@@ -111,6 +130,8 @@ describe('/api/admin/campaigns/[id]/content-plan', () => {
       data: {
         id: 'campaign-1',
         name: 'Agent Ops Video Launch',
+        description: 'Prepare a thumbnail-led creator video release for the Agent Ops framework.',
+        campaign_type: 'bonus_credit',
         starts_at: '2026-07-01T00:00:00.000Z',
         ends_at: '2026-07-21T00:00:00.000Z',
       },
@@ -151,6 +172,11 @@ describe('/api/admin/campaigns/[id]/content-plan', () => {
         metadata: expect.objectContaining({
           template_key: 'youtube_video_release',
           milestone_key: 'thumbnail_title_package',
+          milestone_rationale: expect.objectContaining({
+            summary: expect.stringContaining('Proof milestone for Thumbnail'),
+            source_labels: expect.arrayContaining(['YouTube creator optimization guidance']),
+          }),
+          campaign_fit_summary: expect.stringContaining('YouTube video release fits "Agent Ops Video Launch"'),
           required_assets: expect.arrayContaining(['thumbnail_reference']),
         }),
       }),
@@ -168,6 +194,15 @@ describe('/api/admin/campaigns/[id]/content-plan', () => {
       template_label: 'YouTube video release',
       created_count: 4,
       skipped_existing_count: 0,
+      planned_milestones: expect.arrayContaining([
+        expect.objectContaining({
+          campaign_phase: 'proof',
+          channel: 'thumbnail',
+          rationale: expect.objectContaining({
+            summary: expect.stringContaining('Proof milestone for Thumbnail'),
+          }),
+        }),
+      ]),
       side_effects: {
         publish: false,
         external_post: false,

--- a/app/api/admin/campaigns/[id]/content-plan/route.ts
+++ b/app/api/admin/campaigns/[id]/content-plan/route.ts
@@ -107,6 +107,14 @@ export async function POST(
       created_count: insertedItems.length,
       skipped_existing_count: slots.length - inserts.length,
       planned_phases: slots.map((slot) => slot.campaign_phase as SocialContentCampaignPhase),
+      planned_milestones: slots.map((slot) => ({
+        title: slot.title,
+        campaign_phase: slot.campaign_phase,
+        channel: slot.channel,
+        scheduled_for: slot.scheduled_for,
+        rationale: slot.metadata.milestone_rationale,
+        source_labels: slot.metadata.source_labels,
+      })),
       items: insertedItems,
       side_effects: {
         ...CALENDAR_SIDE_EFFECTS,

--- a/lib/social-content-calendar.test.ts
+++ b/lib/social-content-calendar.test.ts
@@ -63,6 +63,11 @@ describe('social-content-calendar helpers', () => {
           metadata: expect.objectContaining({
             generated_from: 'campaign_content_plan',
             template_key: 'whisper_to_shout',
+            campaign_fit_summary: 'Whisper-to-shout launch is the selected planning arc for "Summer AI Readiness".',
+            milestone_rationale: expect.objectContaining({
+              summary: expect.stringContaining('Tease milestone for LinkedIn'),
+              source_labels: expect.arrayContaining(['HubSpot social calendar template']),
+            }),
             external_execution_enabled: false,
           }),
         }),
@@ -114,6 +119,15 @@ describe('social-content-calendar helpers', () => {
       metadata: expect.objectContaining({
         template_key: 'youtube_video_release',
         milestone_key: 'thumbnail_title_package',
+        campaign_fit_summary: 'YouTube video release is the selected planning arc for "Agent Ops Video Launch".',
+        milestone_rationale: expect.objectContaining({
+          summary: expect.stringContaining('Proof milestone for Thumbnail'),
+          timing: expect.stringContaining('7 day lead time'),
+          required_inputs: expect.arrayContaining(['thumbnail_reference', 'title_variants']),
+          approval_gates: expect.arrayContaining(['thumbnail_review']),
+          source_labels: expect.arrayContaining(['YouTube creator optimization guidance']),
+        }),
+        source_labels: expect.arrayContaining(['YouTube creator optimization guidance']),
         required_assets: expect.arrayContaining(['thumbnail_reference', 'title_variants']),
         approval_gates: expect.arrayContaining(['thumbnail_review']),
         source_urls: expect.arrayContaining([

--- a/lib/social-content-calendar.ts
+++ b/lib/social-content-calendar.ts
@@ -135,6 +135,15 @@ export type SocialContentCalendarTemplateRecommendation = {
   matched_terms: string[]
 }
 
+export type SocialContentCalendarMilestoneRationale = {
+  summary: string
+  campaign_fit: string
+  timing: string
+  required_inputs: string[]
+  approval_gates: string[]
+  source_labels: string[]
+}
+
 const SOURCE_URLS = {
   youtubeCreators: 'https://www.youtube.com/creators/grow/optimize-your-content/',
   youtubePremieres: 'https://support.google.com/youtube/answer/9080341',
@@ -619,6 +628,48 @@ export function recommendCalendarTemplates(
     .map(({ orderIndex: _orderIndex, ...recommendation }) => recommendation)
 }
 
+export function calendarSourceLabels(sourceUrls: string[]) {
+  return sourceUrls.map((url) => SOCIAL_CONTENT_CALENDAR_SOURCE_LABELS[url] || url)
+}
+
+function campaignFitText(
+  campaign: Pick<AttractionCampaign, 'name'> & Partial<Pick<AttractionCampaign, 'description' | 'campaign_type'>>,
+  template: SocialContentCalendarTemplate,
+) {
+  const description = typeof campaign.description === 'string' && campaign.description.trim()
+    ? campaign.description.trim()
+    : null
+  const type = typeof campaign.campaign_type === 'string' && campaign.campaign_type.trim()
+    ? campaign.campaign_type.replace(/_/g, ' ')
+    : null
+
+  if (description) {
+    return `${template.label} fits "${campaign.name}" because the campaign brief points to: ${description}`
+  }
+  if (type) {
+    return `${template.label} fits "${campaign.name}" because the campaign type is ${type}.`
+  }
+  return `${template.label} is the selected planning arc for "${campaign.name}".`
+}
+
+export function calendarMilestoneRationale(
+  campaign: Pick<AttractionCampaign, 'name'> & Partial<Pick<AttractionCampaign, 'description' | 'campaign_type'>>,
+  template: SocialContentCalendarTemplate,
+  milestone: SocialContentCalendarTemplateMilestone,
+): SocialContentCalendarMilestoneRationale {
+  const phase = CAMPAIGN_PHASE_LABELS[milestone.campaign_phase]
+  const channel = CALENDAR_CHANNEL_LABELS[milestone.channel]
+
+  return {
+    summary: `${phase} milestone for ${channel}: ${milestone.planned_angle}`,
+    campaign_fit: campaignFitText(campaign, template),
+    timing: `${milestone.recommended_lead_time_days} day lead time keeps ${phase.toLowerCase()} work reviewable before the scheduled campaign moment.`,
+    required_inputs: milestone.required_assets,
+    approval_gates: milestone.approval_gates,
+    source_labels: calendarSourceLabels(milestone.source_urls),
+  }
+}
+
 export function defaultAuthorizationDueAt(scheduledFor: string | Date) {
   const scheduled = typeof scheduledFor === 'string' ? new Date(scheduledFor) : scheduledFor
   if (!Number.isFinite(scheduled.getTime())) return null
@@ -679,7 +730,7 @@ function campaignDateAt(start: Date, end: Date, ratio: number) {
 }
 
 export function campaignContentPlanSlots(
-  campaign: Pick<AttractionCampaign, 'name' | 'starts_at' | 'ends_at'>,
+  campaign: Pick<AttractionCampaign, 'name' | 'starts_at' | 'ends_at'> & Partial<Pick<AttractionCampaign, 'description' | 'campaign_type'>>,
   options: { templateKey?: SocialContentCalendarTemplateKey } = {},
 ) {
   const start = dateOrNull(campaign.starts_at) ?? addDays(new Date(), 1)
@@ -692,6 +743,7 @@ export function campaignContentPlanSlots(
     const scheduledDate = hasUsableWindow
       ? campaignDateAt(start, end, milestone.relative_position)
       : addDays(baseStart, milestone.fallback_day_offset)
+    const rationale = calendarMilestoneRationale(campaign, template, milestone)
 
     return {
       campaign_phase: milestone.campaign_phase,
@@ -712,6 +764,9 @@ export function campaignContentPlanSlots(
         template_source_urls: template.source_urls,
         milestone_key: milestone.key,
         recommended_lead_time_days: milestone.recommended_lead_time_days,
+        milestone_rationale: rationale,
+        campaign_fit_summary: rationale.campaign_fit,
+        source_labels: rationale.source_labels,
         required_assets: milestone.required_assets,
         approval_gates: milestone.approval_gates,
         source_urls: milestone.source_urls,


### PR DESCRIPTION
## Summary
- Add source-backed rationale metadata to generated campaign calendar milestones.
- Return planned milestone rationale from the campaign content-plan API.
- Show compact "Why this exists" and source-label context on campaign Content Calendar cards.

## Validation
- `npm test -- --run 'app/admin/campaigns/[id]/page.test.tsx' 'app/api/admin/campaigns/[id]/content-plan/route.test.ts' lib/social-content-calendar.test.ts`
- `npm run build:knowledge && npx tsc --noEmit`
- `npm run lint` (passes with existing unrelated `<img>` warnings in `app/client/dashboard/[token]/page.tsx` and `components/Navigation.test.tsx`)
- `git diff --check`
- Browser smoke: opened `http://localhost:3035/admin/campaigns` in the in-app Browser and confirmed the campaign list route renders; local dev database had 0 campaigns, so live detail smoke was skipped and covered by focused React tests.

## Integration Notes
- No migration required.
- No provider generation, upload, scheduling, publishing, or external post behavior changed.
- No demo seed rows were created during smoke because that would mutate the configured database.
- Vercel contexts not checked by this feature lane:
  - Vercel – portfolio
  - Vercel – portfolio-staging
