### PR TITLE
feat: prepare social channel review drafts

### DIFF
--- a/app/admin/agents/content-intelligence/page.test.tsx
+++ b/app/admin/agents/content-intelligence/page.test.tsx
@@ -304,6 +304,50 @@ describe('ContentIntelligencePage', () => {
           }),
         }
       }
+      if (url === '/api/admin/agents/work-items/work-social-1/social-channels/prepare-review-drafts') {
+        return {
+          ok: true,
+          json: async () => ({
+            success: true,
+            work_item: {
+              id: 'work-social-1',
+              title: 'Approval gates create trust',
+              status: 'proposed',
+              priority: 'high',
+              source_type: 'social_topic_trigger',
+              metadata: {
+                insight: {
+                  title: 'Approval gates create trust',
+                  triggering_event: 'A shipped review gate changed the work.',
+                  why_vambah_can_speak: 'Vambah built the system.',
+                },
+                channel_lanes: {
+                  linkedin: {
+                    status: 'in_review',
+                    label: 'LinkedIn',
+                    draft_packet: { channel: 'linkedin', fields: { post_text: 'LinkedIn draft' } },
+                    required_inputs: ['post text', 'CTA'],
+                  },
+                  youtube_shorts: {
+                    status: 'in_review',
+                    label: 'YouTube Shorts',
+                    draft_packet: { channel: 'youtube_shorts', fields: { script: ['YouTube draft'] } },
+                    required_inputs: ['hook', 'script'],
+                  },
+                },
+              },
+              updated_at: '2026-06-23T12:00:00.000Z',
+            },
+            side_effects: {
+              provider_generation: false,
+              upload: false,
+              publish: false,
+              schedule: false,
+              external_post: false,
+            },
+          }),
+        }
+      }
       if (url.startsWith('/api/admin/agents/work-items')) {
         return {
           ok: true,
@@ -320,6 +364,10 @@ describe('ContentIntelligencePage', () => {
                     title: 'Approval gates create trust',
                     triggering_event: 'A shipped review gate changed the work.',
                     why_vambah_can_speak: 'Vambah built the system.',
+                  },
+                  channel_lanes: {
+                    linkedin: { status: 'selected', label: 'LinkedIn', required_inputs: ['post text', 'CTA'] },
+                    youtube_shorts: { status: 'not_started', label: 'YouTube Shorts', required_inputs: ['hook', 'script'] },
                   },
                 },
                 updated_at: '2026-06-22T12:00:00.000Z',
@@ -378,6 +426,9 @@ describe('ContentIntelligencePage', () => {
     fireEvent.click(screen.getByRole('button', { name: /Backlog/ }))
     expect(screen.getByRole('heading', { name: 'Shaka insight backlog' })).toBeInTheDocument()
     expect(screen.getAllByRole('link', { name: /Approval gates create trust/ }).map((link) => link.getAttribute('href'))).toContain('/admin/agents/social-insights/work-social-1')
+    expect(screen.getByText('LinkedIn: selected')).toBeInTheDocument()
+    expect(screen.getByText('YouTube: not started')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Prepare Review Drafts' })).toBeInTheDocument()
   })
 
   it('stores recorded evidence without paid scraper fields', async () => {
@@ -445,6 +496,23 @@ describe('ContentIntelligencePage', () => {
       packet_ids: ['packet-1'],
       decision_note: 'Use the structure, not the source wording.',
     })
+  })
+
+  it('prepares LinkedIn and YouTube channel drafts from the backlog without publishing side effects', async () => {
+    render(<ContentIntelligencePage />)
+
+    await screen.findByRole('heading', { name: 'Research and Shaka insight queue' })
+    fireEvent.click(screen.getByRole('button', { name: /Backlog/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Prepare Review Drafts' }))
+
+    expect(await screen.findByText('LinkedIn and YouTube Shorts review drafts are ready for human approval.')).toBeInTheDocument()
+    expect(screen.getByText('LinkedIn: in review')).toBeInTheDocument()
+    expect(screen.getByText('YouTube: in review')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Open human review' })).toHaveAttribute('href', '/admin/agents/social-insights/work-social-1')
+
+    const prepareCall = vi.mocked(fetch).mock.calls.find(([input]) => String(input) === '/api/admin/agents/work-items/work-social-1/social-channels/prepare-review-drafts')
+    expect(prepareCall).toBeTruthy()
+    expect(prepareCall?.[1]).toMatchObject({ method: 'POST' })
   })
 
   it('requests daily digest activation review without enabling the schedule', async () => {

--- a/app/admin/agents/content-intelligence/page.test.tsx
+++ b/app/admin/agents/content-intelligence/page.test.tsx
@@ -304,6 +304,50 @@ describe('ContentIntelligencePage', () => {
           }),
         }
       }
+      if (url === '/api/admin/agents/work-items/work-social-1/research-packets') {
+        return {
+          ok: true,
+          json: async () => ({
+            success: true,
+            work_item: {
+              id: 'work-social-1',
+              title: 'Approval gates create trust',
+              status: 'proposed',
+              priority: 'high',
+              source_type: 'social_topic_trigger',
+              metadata: {
+                suggested_research_packet_ids: ['packet-1'],
+                insight: {
+                  title: 'Approval gates create trust',
+                  triggering_event: 'A shipped review gate changed the work.',
+                  why_vambah_can_speak: 'Vambah built the system.',
+                  approved_research_patterns: [
+                    {
+                      packet_id: 'packet-1',
+                      source_url: 'https://youtube.com/watch?v=abc',
+                      pattern_packet: {
+                        hook_structure: 'The first 30 seconds make the promise clear.',
+                      },
+                    },
+                  ],
+                },
+                channel_lanes: {
+                  linkedin: { status: 'selected', label: 'LinkedIn', required_inputs: ['post text', 'CTA'] },
+                  youtube_shorts: { status: 'not_started', label: 'YouTube Shorts', required_inputs: ['hook', 'script'] },
+                },
+              },
+              updated_at: '2026-06-23T12:00:00.000Z',
+            },
+            side_effects: {
+              provider_generation: false,
+              upload: false,
+              publish: false,
+              schedule: false,
+              external_post: false,
+            },
+          }),
+        }
+      }
       if (url === '/api/admin/agents/work-items/work-social-1/social-channels/prepare-review-drafts') {
         return {
           ok: true,
@@ -316,10 +360,17 @@ describe('ContentIntelligencePage', () => {
               priority: 'high',
               source_type: 'social_topic_trigger',
               metadata: {
+                suggested_research_packet_ids: ['packet-1'],
                 insight: {
                   title: 'Approval gates create trust',
                   triggering_event: 'A shipped review gate changed the work.',
                   why_vambah_can_speak: 'Vambah built the system.',
+                  approved_research_patterns: [
+                    {
+                      packet_id: 'packet-1',
+                      source_url: 'https://youtube.com/watch?v=abc',
+                    },
+                  ],
                 },
                 channel_lanes: {
                   linkedin: {
@@ -360,10 +411,12 @@ describe('ContentIntelligencePage', () => {
                 priority: 'high',
                 source_type: 'social_topic_trigger',
                 metadata: {
+                  suggested_research_packet_ids: ['packet-1'],
                   insight: {
                     title: 'Approval gates create trust',
                     triggering_event: 'A shipped review gate changed the work.',
                     why_vambah_can_speak: 'Vambah built the system.',
+                    approved_research_patterns: [],
                   },
                   channel_lanes: {
                     linkedin: { status: 'selected', label: 'LinkedIn', required_inputs: ['post text', 'CTA'] },
@@ -428,7 +481,9 @@ describe('ContentIntelligencePage', () => {
     expect(screen.getAllByRole('link', { name: /Approval gates create trust/ }).map((link) => link.getAttribute('href'))).toContain('/admin/agents/social-insights/work-social-1')
     expect(screen.getByText('LinkedIn: selected')).toBeInTheDocument()
     expect(screen.getByText('YouTube: not started')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Link Suggested Research' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Prepare Review Drafts' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Prepare Review Drafts' })).toBeDisabled()
   })
 
   it('stores recorded evidence without paid scraper fields', async () => {
@@ -503,6 +558,12 @@ describe('ContentIntelligencePage', () => {
 
     await screen.findByRole('heading', { name: 'Research and Shaka insight queue' })
     fireEvent.click(screen.getByRole('button', { name: /Backlog/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Link Suggested Research' }))
+
+    await screen.findByText('Suggested research linked to Shaka insight.')
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Prepare Review Drafts' })).not.toBeDisabled()
+    })
     fireEvent.click(screen.getByRole('button', { name: 'Prepare Review Drafts' }))
 
     expect(await screen.findByText('LinkedIn and YouTube Shorts review drafts are ready for human approval.')).toBeInTheDocument()
@@ -513,6 +574,15 @@ describe('ContentIntelligencePage', () => {
     const prepareCall = vi.mocked(fetch).mock.calls.find(([input]) => String(input) === '/api/admin/agents/work-items/work-social-1/social-channels/prepare-review-drafts')
     expect(prepareCall).toBeTruthy()
     expect(prepareCall?.[1]).toMatchObject({ method: 'POST' })
+    const suggestedLinkCall = vi.mocked(fetch).mock.calls.find(([input, init]) => (
+      String(input) === '/api/admin/agents/work-items/work-social-1/research-packets'
+      && String(init?.body).includes('Linked suggested public research pattern')
+    ))
+    expect(suggestedLinkCall).toBeTruthy()
+    expect(JSON.parse(String(suggestedLinkCall?.[1]?.body))).toEqual({
+      packet_ids: ['packet-1'],
+      decision_note: 'Linked suggested public research pattern from Content Intelligence backlog.',
+    })
   })
 
   it('requests daily digest activation review without enabling the schedule', async () => {

--- a/app/admin/agents/content-intelligence/page.tsx
+++ b/app/admin/agents/content-intelligence/page.tsx
@@ -11,6 +11,7 @@ import {
   Database,
   ExternalLink,
   FileSearch,
+  FileText,
   Film,
   Info,
   Instagram,
@@ -268,6 +269,31 @@ function insightFor(item: AgentWorkItem) {
   }
 }
 
+function channelLaneFor(item: AgentWorkItem, channel: 'linkedin' | 'youtube_shorts') {
+  const metadata = recordValue(item.metadata)
+  const lanes = recordValue(metadata.channel_lanes)
+  return recordValue(lanes[channel])
+}
+
+function channelLaneStatus(item: AgentWorkItem, channel: 'linkedin' | 'youtube_shorts') {
+  return stringValue(channelLaneFor(item, channel).status) ?? 'not_started'
+}
+
+function hasChannelReviewDraft(item: AgentWorkItem, channel: 'linkedin' | 'youtube_shorts') {
+  return Object.keys(recordValue(channelLaneFor(item, channel).draft_packet)).length > 0
+}
+
+function hasLinkedInYoutubeReviewDrafts(item: AgentWorkItem) {
+  return hasChannelReviewDraft(item, 'linkedin') && hasChannelReviewDraft(item, 'youtube_shorts')
+}
+
+function channelReviewPillClass(status: string) {
+  if (status === 'approved') return 'border-emerald-500/35 bg-emerald-500/10 text-emerald-100'
+  if (status === 'in_review' || status === 'draft_ready') return 'border-blue-500/35 bg-blue-500/10 text-blue-100'
+  if (status === 'blocked') return 'border-red-500/35 bg-red-500/10 text-red-100'
+  return 'border-amber-500/35 bg-amber-500/10 text-amber-100'
+}
+
 function platformIcon(platform: string) {
   if (platform.includes('youtube')) return <Youtube className="h-4 w-4 text-red-200" />
   if (platform.includes('instagram')) return <Instagram className="h-4 w-4 text-pink-200" />
@@ -379,6 +405,8 @@ function ContentIntelligenceContent() {
   const [linkDecisionNote, setLinkDecisionNote] = useState('')
   const [linkingPattern, setLinkingPattern] = useState(false)
   const [linkNotice, setLinkNotice] = useState<string | null>(null)
+  const [preparingReviewInsightId, setPreparingReviewInsightId] = useState<string | null>(null)
+  const [reviewDraftNotice, setReviewDraftNotice] = useState<string | null>(null)
   const [digest, setDigest] = useState<DailyDigest | null>(null)
   const [activationScopeNote, setActivationScopeNote] = useState('')
   const [requestingActivation, setRequestingActivation] = useState(false)
@@ -714,6 +742,29 @@ function ContentIntelligenceContent() {
       setLinkingPattern(false)
     }
   }, [authedFetch, linkDecisionNote, load, selectedInsightId, selectedPacketId])
+
+  const prepareChannelReviewDrafts = useCallback(async (insightId: string) => {
+    setError(null)
+    setReviewDraftNotice(null)
+    setPreparingReviewInsightId(insightId)
+    try {
+      const response = await authedFetch(`/api/admin/agents/work-items/${insightId}/social-channels/prepare-review-drafts`, {
+        method: 'POST',
+      })
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body.error || `Review draft HTTP ${response.status}`)
+      if (body.work_item) {
+        setInsights((current) => current.map((item) => (item.id === insightId ? body.work_item : item)))
+      } else {
+        await load()
+      }
+      setReviewDraftNotice('LinkedIn and YouTube Shorts review drafts are ready for human approval.')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to prepare channel review drafts')
+    } finally {
+      setPreparingReviewInsightId(null)
+    }
+  }, [authedFetch, load])
 
   const requestDailyActivationReview = useCallback(async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -1783,6 +1834,11 @@ function ContentIntelligenceContent() {
                   </select>
                 </label>
               </div>
+              {reviewDraftNotice ? (
+                <div className="rounded-lg border border-emerald-500/35 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-100">
+                  {reviewDraftNotice}
+                </div>
+              ) : null}
               {insights.length ? (
                 <>
                   <div className="overflow-x-auto rounded-lg border border-silicon-slate/70">
@@ -1798,6 +1854,7 @@ function ContentIntelligenceContent() {
                             </SortButton>
                           </th>
                           <th scope="col" className="px-3 py-2 text-left">Status</th>
+                          <th scope="col" className="px-3 py-2 text-left">Channel review</th>
                           <th scope="col" className="px-3 py-2 text-right">
                             <SortButton active={insightSort === 'priority'} direction={insightSortDirection} onClick={() => {
                               setInsightSort('priority')
@@ -1814,11 +1871,16 @@ function ContentIntelligenceContent() {
                               Updated
                             </SortButton>
                           </th>
+                          <th scope="col" className="px-3 py-2 text-right">Next step</th>
                         </tr>
                       </thead>
                       <tbody className="divide-y divide-silicon-slate/60 bg-background/20">
                         {pagedInsights.map((item) => {
                           const insight = insightFor(item)
+                          const linkedinStatus = channelLaneStatus(item, 'linkedin')
+                          const youtubeStatus = channelLaneStatus(item, 'youtube_shorts')
+                          const hasReviewDrafts = hasLinkedInYoutubeReviewDrafts(item)
+                          const isPreparingReview = preparingReviewInsightId === item.id
                           return (
                             <tr key={item.id} className="align-top">
                               <td className="max-w-xl px-3 py-3">
@@ -1841,11 +1903,41 @@ function ContentIntelligenceContent() {
                                   {item.status.replace(/_/g, ' ')}
                                 </span>
                               </td>
+                              <td className="px-3 py-3">
+                                <div className="flex flex-col gap-1.5">
+                                  <span className={`inline-flex w-fit rounded-full border px-2 py-0.5 text-xs ${channelReviewPillClass(linkedinStatus)}`}>
+                                    LinkedIn: {linkedinStatus.replace(/_/g, ' ')}
+                                  </span>
+                                  <span className={`inline-flex w-fit rounded-full border px-2 py-0.5 text-xs ${channelReviewPillClass(youtubeStatus)}`}>
+                                    YouTube: {youtubeStatus.replace(/_/g, ' ')}
+                                  </span>
+                                </div>
+                              </td>
                               <td className="px-3 py-3 text-right text-xs font-semibold text-radiant-gold">
                                 {item.priority.replace(/_/g, ' ')}
                               </td>
                               <td className="px-3 py-3 text-right text-xs text-muted-foreground">
                                 {item.updated_at ? new Date(item.updated_at).toLocaleDateString() : 'Unknown'}
+                              </td>
+                              <td className="px-3 py-3 text-right">
+                                <div className="flex flex-col items-end gap-2">
+                                  <button
+                                    type="button"
+                                    onClick={() => prepareChannelReviewDrafts(item.id)}
+                                    disabled={isPreparingReview}
+                                    className="inline-flex items-center justify-center gap-2 rounded-lg border border-blue-500/45 bg-blue-500/10 px-3 py-1.5 text-xs font-semibold text-blue-100 transition hover:bg-blue-500/15 disabled:opacity-60"
+                                  >
+                                    <FileText size={14} />
+                                    {isPreparingReview ? 'Preparing...' : hasReviewDrafts ? 'Refresh Review Drafts' : 'Prepare Review Drafts'}
+                                  </button>
+                                  {hasReviewDrafts ? (
+                                    <Link href={`/admin/agents/social-insights/${item.id}`} className="text-xs text-blue-200 hover:text-blue-100">
+                                      Open human review
+                                    </Link>
+                                  ) : (
+                                    <span className="text-[0.68rem] text-muted-foreground">No publish action</span>
+                                  )}
+                                </div>
                               </td>
                             </tr>
                           )

--- a/app/admin/agents/content-intelligence/page.tsx
+++ b/app/admin/agents/content-intelligence/page.tsx
@@ -287,6 +287,16 @@ function hasLinkedInYoutubeReviewDrafts(item: AgentWorkItem) {
   return hasChannelReviewDraft(item, 'linkedin') && hasChannelReviewDraft(item, 'youtube_shorts')
 }
 
+function suggestedResearchPacketIds(item: AgentWorkItem) {
+  return metadataStringArray(recordValue(item.metadata).suggested_research_packet_ids)
+}
+
+function hasApprovedResearchPatterns(item: AgentWorkItem) {
+  const insight = recordValue(recordValue(item.metadata).insight)
+  const patterns = Array.isArray(insight.approved_research_patterns) ? insight.approved_research_patterns : []
+  return patterns.some((pattern) => Object.keys(recordValue(pattern)).length > 0)
+}
+
 function channelReviewPillClass(status: string) {
   if (status === 'approved') return 'border-emerald-500/35 bg-emerald-500/10 text-emerald-100'
   if (status === 'in_review' || status === 'draft_ready') return 'border-blue-500/35 bg-blue-500/10 text-blue-100'
@@ -404,6 +414,7 @@ function ContentIntelligenceContent() {
   const [selectedInsightId, setSelectedInsightId] = useState('')
   const [linkDecisionNote, setLinkDecisionNote] = useState('')
   const [linkingPattern, setLinkingPattern] = useState(false)
+  const [linkingSuggestedInsightId, setLinkingSuggestedInsightId] = useState<string | null>(null)
   const [linkNotice, setLinkNotice] = useState<string | null>(null)
   const [preparingReviewInsightId, setPreparingReviewInsightId] = useState<string | null>(null)
   const [reviewDraftNotice, setReviewDraftNotice] = useState<string | null>(null)
@@ -742,6 +753,68 @@ function ContentIntelligenceContent() {
       setLinkingPattern(false)
     }
   }, [authedFetch, linkDecisionNote, load, selectedInsightId, selectedPacketId])
+
+  const linkSuggestedResearchPattern = useCallback(async (item: AgentWorkItem) => {
+    const packetIds = suggestedResearchPacketIds(item)
+    if (!packetIds.length) {
+      setError('No suggested research packets are available for this Shaka insight.')
+      return
+    }
+
+    setError(null)
+    setLinkNotice(null)
+    setLinkingSuggestedInsightId(item.id)
+    try {
+      const response = await authedFetch(`/api/admin/agents/work-items/${item.id}/research-packets`, {
+        method: 'POST',
+        body: JSON.stringify({
+          packet_ids: packetIds,
+          decision_note: 'Linked suggested public research pattern from Content Intelligence backlog.',
+        }),
+      })
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body.error || `Suggested pattern link HTTP ${response.status}`)
+      const linkedPatterns = packets
+        .filter((packet) => packetIds.includes(packet.id))
+        .map((packet) => ({
+          packet_id: packet.id,
+          source_url: packet.source_url,
+          platform: packet.platform,
+          creator_name: packet.creator_name,
+          creator_handle: packet.creator_handle,
+          title: packet.title,
+          outlier_score: packet.outlier_score,
+          pattern_status: packet.pattern_status,
+        }))
+      setInsights((current) => current.map((currentItem) => {
+        if (currentItem.id !== item.id) return currentItem
+        const nextItem = (body.work_item ?? currentItem) as AgentWorkItem
+        const metadata = recordValue(nextItem.metadata)
+        const insight = recordValue(metadata.insight)
+        const existingPatterns = Array.isArray(insight.approved_research_patterns)
+          ? insight.approved_research_patterns
+          : []
+        return {
+          ...nextItem,
+          metadata: {
+            ...metadata,
+            insight: {
+              ...insight,
+              approved_research_patterns: [
+                ...existingPatterns.filter((pattern) => !packetIds.includes(String(recordValue(pattern).packet_id ?? ''))),
+                ...linkedPatterns,
+              ],
+            },
+          },
+        }
+      }))
+      setLinkNotice('Suggested research linked to Shaka insight.')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to link suggested research')
+    } finally {
+      setLinkingSuggestedInsightId(null)
+    }
+  }, [authedFetch, packets])
 
   const prepareChannelReviewDrafts = useCallback(async (insightId: string) => {
     setError(null)
@@ -1839,6 +1912,11 @@ function ContentIntelligenceContent() {
                   {reviewDraftNotice}
                 </div>
               ) : null}
+              {linkNotice ? (
+                <div className="rounded-lg border border-emerald-500/35 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-100">
+                  {linkNotice}
+                </div>
+              ) : null}
               {insights.length ? (
                 <>
                   <div className="overflow-x-auto rounded-lg border border-silicon-slate/70">
@@ -1880,7 +1958,10 @@ function ContentIntelligenceContent() {
                           const linkedinStatus = channelLaneStatus(item, 'linkedin')
                           const youtubeStatus = channelLaneStatus(item, 'youtube_shorts')
                           const hasReviewDrafts = hasLinkedInYoutubeReviewDrafts(item)
+                          const hasApprovedResearch = hasApprovedResearchPatterns(item)
+                          const suggestedPacketIds = suggestedResearchPacketIds(item)
                           const isPreparingReview = preparingReviewInsightId === item.id
+                          const isLinkingSuggested = linkingSuggestedInsightId === item.id
                           return (
                             <tr key={item.id} className="align-top">
                               <td className="max-w-xl px-3 py-3">
@@ -1921,10 +2002,22 @@ function ContentIntelligenceContent() {
                               </td>
                               <td className="px-3 py-3 text-right">
                                 <div className="flex flex-col items-end gap-2">
+                                  {!hasApprovedResearch && suggestedPacketIds.length ? (
+                                    <button
+                                      type="button"
+                                      onClick={() => linkSuggestedResearchPattern(item)}
+                                      disabled={isLinkingSuggested}
+                                      className="inline-flex items-center justify-center gap-2 rounded-lg border border-radiant-gold/45 bg-radiant-gold/10 px-3 py-1.5 text-xs font-semibold text-radiant-gold transition hover:bg-radiant-gold/15 disabled:opacity-60"
+                                    >
+                                      <CheckCircle2 size={14} />
+                                      {isLinkingSuggested ? 'Linking...' : 'Link Suggested Research'}
+                                    </button>
+                                  ) : null}
                                   <button
                                     type="button"
                                     onClick={() => prepareChannelReviewDrafts(item.id)}
-                                    disabled={isPreparingReview}
+                                    disabled={isPreparingReview || !hasApprovedResearch}
+                                    title={hasApprovedResearch ? undefined : 'Link an approved research pattern before preparing review drafts.'}
                                     className="inline-flex items-center justify-center gap-2 rounded-lg border border-blue-500/45 bg-blue-500/10 px-3 py-1.5 text-xs font-semibold text-blue-100 transition hover:bg-blue-500/15 disabled:opacity-60"
                                   >
                                     <FileText size={14} />
@@ -1934,6 +2027,8 @@ function ContentIntelligenceContent() {
                                     <Link href={`/admin/agents/social-insights/${item.id}`} className="text-xs text-blue-200 hover:text-blue-100">
                                       Open human review
                                     </Link>
+                                  ) : !hasApprovedResearch ? (
+                                    <span className="text-[0.68rem] text-muted-foreground">Research link required</span>
                                   ) : (
                                     <span className="text-[0.68rem] text-muted-foreground">No publish action</span>
                                   )}

--- a/app/admin/agents/social-insights/[id]/page.test.tsx
+++ b/app/admin/agents/social-insights/[id]/page.test.tsx
@@ -160,6 +160,36 @@ describe('SocialInsightDetailPage', () => {
           }),
         }
       }
+      if (url === '/api/admin/agents/work-items/work-social-1/social-channels/youtube_shorts') {
+        const body = JSON.parse(String(init?.body ?? '{}'))
+        return {
+          ok: true,
+          json: async () => ({
+            success: true,
+            work_item: socialWorkItem({
+              metadata: {
+                ...socialWorkItem().metadata,
+                channel_lanes: {
+                  ...socialWorkItem().metadata.channel_lanes,
+                  youtube_shorts: {
+                    ...socialWorkItem().metadata.channel_lanes.youtube_shorts,
+                    status: body.status,
+                    decision_note: body.decision_note,
+                    updated_at: '2026-06-23T10:05:00.000Z',
+                  },
+                },
+              },
+            }),
+            side_effects: {
+              provider_generation: false,
+              upload: false,
+              publish: false,
+              schedule: false,
+              external_post: false,
+            },
+          }),
+        }
+      }
       return { ok: false, status: 404, json: async () => ({ error: 'not found' }) }
     }))
   })
@@ -251,5 +281,29 @@ describe('SocialInsightDetailPage', () => {
     const prepareCall = vi.mocked(fetch).mock.calls.find(([input]) => String(input) === '/api/admin/agents/work-items/work-social-1/social-channels/prepare-review-drafts')
     expect(prepareCall).toBeTruthy()
     expect(prepareCall?.[1]).toMatchObject({ method: 'POST' })
+  })
+
+  it('approves the prepared YouTube lane through the human review controls', async () => {
+    render(<SocialInsightDetailPage />)
+
+    await screen.findByRole('heading', { name: 'Approval gates create trust' })
+    fireEvent.click(screen.getByRole('button', { name: 'Prepare LinkedIn + YouTube Review Drafts' }))
+    await screen.findByText('LinkedIn and YouTube Shorts are ready for human review.')
+
+    fireEvent.click(screen.getByRole('tab', { name: /YouTube Shorts/ }))
+    fireEvent.change(screen.getByLabelText('Decision note'), {
+      target: { value: 'Approved for YouTube Shorts review; rendering remains gated.' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Approve Lane' }))
+
+    await screen.findByText('YouTube Shorts lane marked approved.')
+
+    const patchCall = vi.mocked(fetch).mock.calls.find(([input]) => String(input) === '/api/admin/agents/work-items/work-social-1/social-channels/youtube_shorts')
+    expect(patchCall).toBeTruthy()
+    expect(patchCall?.[1]).toMatchObject({ method: 'PATCH' })
+    expect(JSON.parse(String(patchCall?.[1]?.body))).toEqual({
+      status: 'approved',
+      decision_note: 'Approved for YouTube Shorts review; rendering remains gated.',
+    })
   })
 })

--- a/app/admin/agents/social-insights/[id]/page.test.tsx
+++ b/app/admin/agents/social-insights/[id]/page.test.tsx
@@ -233,6 +233,11 @@ describe('SocialInsightDetailPage', () => {
     render(<SocialInsightDetailPage />)
 
     await screen.findByRole('heading', { name: 'Approval gates create trust' })
+    expect(screen.getByRole('button', { name: 'Approve Lane' })).toBeDisabled()
+    expect(screen.getByText('Prepare the LinkedIn + YouTube review drafts before approving this lane.')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Prepare LinkedIn + YouTube Review Drafts' }))
+    await screen.findByText('LinkedIn and YouTube Shorts are ready for human review.')
 
     fireEvent.change(screen.getByLabelText('Decision note'), {
       target: { value: 'Approved for LinkedIn planning; no publishing authorized.' },

--- a/app/admin/agents/social-insights/[id]/page.test.tsx
+++ b/app/admin/agents/social-insights/[id]/page.test.tsx
@@ -75,6 +75,61 @@ describe('SocialInsightDetailPage', () => {
           json: async () => ({ work_item: socialWorkItem() }),
         }
       }
+      if (url === '/api/admin/agents/work-items/work-social-1/social-channels/prepare-review-drafts') {
+        const base = socialWorkItem()
+        return {
+          ok: true,
+          json: async () => ({
+            success: true,
+            work_item: {
+              ...base,
+              metadata: {
+                ...base.metadata,
+                channel_lanes: {
+                  ...base.metadata.channel_lanes,
+                  linkedin: {
+                    ...base.metadata.channel_lanes.linkedin,
+                    status: 'in_review',
+                    review_requested_at: '2026-06-24T15:00:00.000Z',
+                    draft_packet: {
+                      channel: 'linkedin',
+                      generated_at: '2026-06-24T15:00:00.000Z',
+                      source_use_boundary: 'Drafts are generated for human review only.',
+                      fields: {
+                        post_text: 'The Social Content review flow made the gate visible.\n\nAI should reduce burden.',
+                        cta: 'Where have you seen AI create more work because the approval path was never designed?',
+                        hashtags: ['#AIProduct', '#AmaduTownAdvisory'],
+                      },
+                    },
+                  },
+                  youtube_shorts: {
+                    ...base.metadata.channel_lanes.youtube_shorts,
+                    status: 'in_review',
+                    review_requested_at: '2026-06-24T15:00:00.000Z',
+                    draft_packet: {
+                      channel: 'youtube_shorts',
+                      generated_at: '2026-06-24T15:00:00.000Z',
+                      source_use_boundary: 'Drafts are generated for human review only.',
+                      fields: {
+                        hook: 'AI should reduce burden.',
+                        first_30_seconds: 'I noticed this through the social content review flow.',
+                        script: ['Opening: AI should reduce burden.', 'Trigger: Social Content review flow.'],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            side_effects: {
+              provider_generation: false,
+              upload: false,
+              publish: false,
+              schedule: false,
+              external_post: false,
+            },
+          }),
+        }
+      }
       if (url === '/api/admin/agents/work-items/work-social-1/social-channels/linkedin') {
         const body = JSON.parse(String(init?.body ?? '{}'))
         return {
@@ -173,5 +228,28 @@ describe('SocialInsightDetailPage', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Approved' })).toBeInTheDocument()
     })
+  })
+
+  it('prepares LinkedIn and YouTube review drafts from the shared insight', async () => {
+    render(<SocialInsightDetailPage />)
+
+    await screen.findByRole('heading', { name: 'Approval gates create trust' })
+    fireEvent.click(screen.getByRole('button', { name: 'Prepare LinkedIn + YouTube Review Drafts' }))
+
+    expect(await screen.findByText('LinkedIn and YouTube Shorts are ready for human review.')).toBeInTheDocument()
+    expect(screen.getByText('Review draft packet')).toBeInTheDocument()
+    expect(screen.getAllByText((content) => content.includes('The Social Content review flow made the gate visible.'))).toHaveLength(2)
+    expect(screen.getByText('#AmaduTownAdvisory')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('tab', { name: /YouTube Shorts/ }))
+
+    expect(screen.getByText('YouTube Shorts production inputs')).toBeInTheDocument()
+    expect(screen.getByText('first 30 seconds')).toBeInTheDocument()
+    expect(screen.getByText('I noticed this through the social content review flow.')).toBeInTheDocument()
+    expect(screen.getByText('Opening: AI should reduce burden.')).toBeInTheDocument()
+
+    const prepareCall = vi.mocked(fetch).mock.calls.find(([input]) => String(input) === '/api/admin/agents/work-items/work-social-1/social-channels/prepare-review-drafts')
+    expect(prepareCall).toBeTruthy()
+    expect(prepareCall?.[1]).toMatchObject({ method: 'POST' })
   })
 })

--- a/app/admin/agents/social-insights/[id]/page.test.tsx
+++ b/app/admin/agents/social-insights/[id]/page.test.tsx
@@ -95,10 +95,23 @@ describe('SocialInsightDetailPage', () => {
                       channel: 'linkedin',
                       generated_at: '2026-06-24T15:00:00.000Z',
                       source_use_boundary: 'Drafts are generated for human review only.',
+                      shared_source: {
+                        insight_title: 'Approval gates create trust',
+                        triggering_event: 'The Social Content review flow made the gate visible.',
+                        content_angle: 'AI should reduce burden, but only when authority and evidence are separated.',
+                        evidence_summary: 'Review path and visual gate work shipped locally.',
+                      },
                       fields: {
                         post_text: 'The Social Content review flow made the gate visible.\n\nAI should reduce burden.',
                         cta: 'Where have you seen AI create more work because the approval path was never designed?',
                         hashtags: ['#AIProduct', '#AmaduTownAdvisory'],
+                      },
+                      side_effects: {
+                        provider_generation: false,
+                        upload: false,
+                        publish: false,
+                        schedule: false,
+                        external_post: false,
                       },
                     },
                   },
@@ -110,10 +123,23 @@ describe('SocialInsightDetailPage', () => {
                       channel: 'youtube_shorts',
                       generated_at: '2026-06-24T15:00:00.000Z',
                       source_use_boundary: 'Drafts are generated for human review only.',
+                      shared_source: {
+                        insight_title: 'Approval gates create trust',
+                        triggering_event: 'The Social Content review flow made the gate visible.',
+                        content_angle: 'AI should reduce burden, but only when authority and evidence are separated.',
+                        evidence_summary: 'Review path and visual gate work shipped locally.',
+                      },
                       fields: {
                         hook: 'AI should reduce burden.',
                         first_30_seconds: 'I noticed this through the social content review flow.',
                         script: ['Opening: AI should reduce burden.', 'Trigger: Social Content review flow.'],
+                      },
+                      side_effects: {
+                        provider_generation: false,
+                        upload: false,
+                        publish: false,
+                        schedule: false,
+                        external_post: false,
                       },
                     },
                   },
@@ -273,12 +299,16 @@ describe('SocialInsightDetailPage', () => {
 
     expect(await screen.findByText('LinkedIn and YouTube Shorts are ready for human review.')).toBeInTheDocument()
     expect(screen.getByText('Review draft packet')).toBeInTheDocument()
+    expect(screen.getByText('Shared source: Approval gates create trust')).toBeInTheDocument()
+    expect(screen.getByText('No side effects authorized: provider generation, upload, publish, schedule, external post.')).toBeInTheDocument()
     expect(screen.getAllByText((content) => content.includes('The Social Content review flow made the gate visible.'))).toHaveLength(2)
     expect(screen.getByText('#AmaduTownAdvisory')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('tab', { name: /YouTube Shorts/ }))
 
     expect(screen.getByText('YouTube Shorts production inputs')).toBeInTheDocument()
+    expect(screen.getByText('Shared source: Approval gates create trust')).toBeInTheDocument()
+    expect(screen.getByText('No side effects authorized: provider generation, upload, publish, schedule, external post.')).toBeInTheDocument()
     expect(screen.getByText('first 30 seconds')).toBeInTheDocument()
     expect(screen.getByText('I noticed this through the social content review flow.')).toBeInTheDocument()
     expect(screen.getByText('Opening: AI should reduce burden.')).toBeInTheDocument()

--- a/app/admin/agents/social-insights/[id]/page.tsx
+++ b/app/admin/agents/social-insights/[id]/page.tsx
@@ -490,6 +490,7 @@ function ChannelInputs({
   const draftPacket = asRecord(lane.draft_packet)
   const fields = asRecord(draftPacket.fields)
   const hasDraftFields = Object.keys(fields).length > 0
+  const draftApprovalStatus = asString(draftPacket.approval_status)
   return (
     <div>
       {hasDraftFields ? (
@@ -501,11 +502,18 @@ function ChannelInputs({
                 Generated from the shared insight and approved research patterns for human approval.
               </p>
             </div>
-            {asString(draftPacket.generated_at) ? (
-              <span className="inline-flex w-fit rounded-full border border-blue-400/35 px-2 py-0.5 text-xs text-blue-100">
-                {new Date(asString(draftPacket.generated_at)).toLocaleString()}
-              </span>
-            ) : null}
+            <div className="flex flex-wrap gap-2">
+              {draftApprovalStatus ? (
+                <span className="inline-flex w-fit rounded-full border border-blue-400/35 px-2 py-0.5 text-xs text-blue-100">
+                  Packet: {statusLabel(draftApprovalStatus)}
+                </span>
+              ) : null}
+              {asString(draftPacket.generated_at) ? (
+                <span className="inline-flex w-fit rounded-full border border-blue-400/35 px-2 py-0.5 text-xs text-blue-100">
+                  {new Date(asString(draftPacket.generated_at)).toLocaleString()}
+                </span>
+              ) : null}
+            </div>
           </div>
           {asString(draftPacket.source_use_boundary) ? (
             <p className="mt-3 rounded-md border border-blue-400/20 bg-background/35 px-3 py-2 text-xs leading-5 text-blue-100">

--- a/app/admin/agents/social-insights/[id]/page.tsx
+++ b/app/admin/agents/social-insights/[id]/page.tsx
@@ -65,6 +65,12 @@ function asRecordArray(value: unknown): Record<string, unknown>[] {
   return Array.isArray(value) ? value.map((item) => asRecord(item)).filter((item) => Object.keys(item).length > 0) : []
 }
 
+function hasReviewDraft(lane: ChannelLane) {
+  const draftPacket = asRecord(lane.draft_packet)
+  const fields = asRecord(draftPacket.fields)
+  return Object.keys(fields).length > 0
+}
+
 function statusLabel(status: string) {
   return status.replace(/_/g, ' ')
 }
@@ -148,6 +154,9 @@ function SocialInsightDetailContent() {
   const approvedResearchPatterns = asRecordArray(insight.approved_research_patterns)
   const lanes = useMemo(() => lanesFor(item), [item])
   const activeLane = lanes[activeTab]
+  const activeLaneHasReviewDraft = hasReviewDraft(activeLane)
+  const activeLaneNeedsReviewDraft = (activeTab === 'linkedin' || activeTab === 'youtube_shorts') && !activeLaneHasReviewDraft
+  const canPrepareReviewDrafts = approvedResearchPatterns.length > 0
 
   useEffect(() => {
     setDecisionNote(activeLane?.decision_note ?? '')
@@ -245,7 +254,8 @@ function SocialInsightDetailContent() {
               <button
                 type="button"
                 onClick={prepareReviewDrafts}
-                disabled={loading || preparingReviewDrafts}
+                disabled={loading || preparingReviewDrafts || !canPrepareReviewDrafts}
+                title={canPrepareReviewDrafts ? undefined : 'Link approved research patterns before preparing channel review drafts.'}
                 className="agent-ops-button-primary disabled:opacity-60"
               >
                 <FileText size={16} />
@@ -267,6 +277,11 @@ function SocialInsightDetailContent() {
           <div className="grid gap-6 xl:grid-cols-[minmax(0,0.45fr)_minmax(0,1fr)]">
             <section className="agent-ops-card rounded-lg border p-4">
               <h2 className="text-lg font-semibold">Shared evidence</h2>
+              {!canPrepareReviewDrafts ? (
+                <div className="mt-4 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-100">
+                  Link at least one approved research pattern before preparing LinkedIn and YouTube review drafts.
+                </div>
+              ) : null}
               <div className="mt-4 space-y-3">
                 <InsightField label="Triggering event" value={asString(insight.triggering_event)} />
                 <InsightField label="Why Vambah can speak" value={asString(insight.why_vambah_can_speak)} />
@@ -350,6 +365,11 @@ function SocialInsightDetailContent() {
                       <p className="mt-1 text-sm leading-6 text-muted-foreground">
                         Updates this channel lane only. No draft, render, upload, schedule, or publish action runs here.
                       </p>
+                      {activeLaneNeedsReviewDraft ? (
+                        <p className="mt-1 text-sm text-amber-100">
+                          Prepare the LinkedIn + YouTube review drafts before approving this lane.
+                        </p>
+                      ) : null}
                     </div>
                     {laneNotice ? (
                       <span className="inline-flex w-fit rounded-full border border-emerald-500/35 bg-emerald-500/10 px-3 py-1 text-xs font-semibold text-emerald-100">
@@ -389,7 +409,7 @@ function SocialInsightDetailContent() {
                     <button
                       type="button"
                       onClick={() => updateLane('approved')}
-                      disabled={savingLane !== null}
+                      disabled={savingLane !== null || activeLaneNeedsReviewDraft}
                       className="inline-flex items-center justify-center gap-2 rounded-lg border border-emerald-500/45 bg-emerald-500/10 px-4 py-2 text-sm font-semibold text-emerald-100 transition hover:bg-emerald-500/15 disabled:opacity-60"
                     >
                       <CheckCircle2 size={16} />

--- a/app/admin/agents/social-insights/[id]/page.tsx
+++ b/app/admin/agents/social-insights/[id]/page.tsx
@@ -493,6 +493,16 @@ function ChannelInputs({
   const draftApprovalStatus = asString(draftPacket.approval_status)
   const sharedSource = asRecord(draftPacket.shared_source)
   const sharedSourceTitle = asString(sharedSource.insight_title)
+  const sideEffects = asRecord(draftPacket.side_effects)
+  const disabledSideEffects = [
+    ['provider_generation', 'provider generation'],
+    ['upload', 'upload'],
+    ['publish', 'publish'],
+    ['schedule', 'schedule'],
+    ['external_post', 'external post'],
+  ]
+    .filter(([key]) => sideEffects[key] === false)
+    .map(([, label]) => label)
   return (
     <div>
       {hasDraftFields ? (
@@ -525,6 +535,11 @@ function ChannelInputs({
           {sharedSourceTitle ? (
             <p className="mt-2 rounded-md border border-blue-400/20 bg-background/35 px-3 py-2 text-xs leading-5 text-blue-100">
               Shared source: {sharedSourceTitle}
+            </p>
+          ) : null}
+          {disabledSideEffects.length ? (
+            <p className="mt-2 rounded-md border border-emerald-400/20 bg-background/35 px-3 py-2 text-xs leading-5 text-emerald-100">
+              No side effects authorized: {disabledSideEffects.join(', ')}.
             </p>
           ) : null}
         </div>

--- a/app/admin/agents/social-insights/[id]/page.tsx
+++ b/app/admin/agents/social-insights/[id]/page.tsx
@@ -30,6 +30,8 @@ type ChannelLane = {
   status: string
   label: string
   decision_note?: string | null
+  draft_packet?: Record<string, unknown> | null
+  review_requested_at?: string | null
   required_inputs?: string[]
 }
 
@@ -80,6 +82,8 @@ function lanesFor(item: AgentWorkItem | null): Record<SocialContentIntelligenceC
       status: asString(lane.status) || 'not_started',
       label: asString(lane.label) || CHANNEL_LABELS[channel],
       decision_note: asString(lane.decision_note) || null,
+      draft_packet: asRecord(lane.draft_packet),
+      review_requested_at: asString(lane.review_requested_at) || null,
       required_inputs: asStringArray(lane.required_inputs),
     }
     return result
@@ -102,6 +106,7 @@ function SocialInsightDetailContent() {
   const [error, setError] = useState<string | null>(null)
   const [decisionNote, setDecisionNote] = useState('')
   const [savingLane, setSavingLane] = useState<SocialChannelLaneStatus | null>(null)
+  const [preparingReviewDrafts, setPreparingReviewDrafts] = useState(false)
   const [laneNotice, setLaneNotice] = useState<string | null>(null)
 
   const authedFetch = useCallback(async (path: string, init: RequestInit = {}) => {
@@ -182,6 +187,26 @@ function SocialInsightDetailContent() {
     }
   }, [activeTab, authedFetch, decisionNote, id])
 
+  const prepareReviewDrafts = useCallback(async () => {
+    setError(null)
+    setLaneNotice(null)
+    setPreparingReviewDrafts(true)
+    try {
+      const response = await authedFetch(`/api/admin/agents/work-items/${id}/social-channels/prepare-review-drafts`, {
+        method: 'POST',
+      })
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body.error || `Review draft HTTP ${response.status}`)
+      setItem(body.work_item ?? null)
+      setActiveTab('linkedin')
+      setLaneNotice('LinkedIn and YouTube Shorts are ready for human review.')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to prepare channel review drafts')
+    } finally {
+      setPreparingReviewDrafts(false)
+    }
+  }, [authedFetch, id])
+
   return (
     <div className="agent-ops-page min-h-screen p-5 text-foreground lg:p-7">
       <div className="mx-auto max-w-7xl">
@@ -216,6 +241,15 @@ function SocialInsightDetailContent() {
               >
                 <RefreshCw size={16} className={loading ? 'animate-spin' : ''} />
                 Refresh
+              </button>
+              <button
+                type="button"
+                onClick={prepareReviewDrafts}
+                disabled={loading || preparingReviewDrafts}
+                className="agent-ops-button-primary disabled:opacity-60"
+              >
+                <FileText size={16} />
+                {preparingReviewDrafts ? 'Preparing...' : 'Prepare LinkedIn + YouTube Review Drafts'}
               </button>
             </div>
           </div>
@@ -298,7 +332,7 @@ function SocialInsightDetailContent() {
                   <div>
                     <h2 className="text-lg font-semibold">{CHANNEL_LABELS[activeTab]} production inputs</h2>
                     <p className="mt-1 text-sm text-muted-foreground">
-                      This lane defines what must be reviewed before production. It does not create drafts, render media, upload, schedule, or publish.
+                      Review the channel adaptation before approval. This step does not render media, upload, schedule, or publish.
                     </p>
                   </div>
                   <span className="inline-flex w-fit items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/10 px-3 py-1 text-xs font-semibold text-blue-100">
@@ -433,20 +467,68 @@ function ChannelInputs({
   insight: Record<string, unknown>
 }) {
   const requiredInputs = lane.required_inputs?.length ? lane.required_inputs : defaultInputs(channel)
+  const draftPacket = asRecord(lane.draft_packet)
+  const fields = asRecord(draftPacket.fields)
+  const hasDraftFields = Object.keys(fields).length > 0
   return (
     <div>
-      <div className="grid gap-3 md:grid-cols-2">
-        {requiredInputs.map((input) => (
-          <div key={input} className="rounded-lg border border-silicon-slate/70 bg-background/40 p-3">
-            <p className="text-xs uppercase tracking-wide text-muted-foreground">{input}</p>
-            <p className="mt-1 text-sm leading-6 text-muted-foreground">
-              {suggestedValue(input, insight) || 'Pending lane draft'}
-            </p>
+      {hasDraftFields ? (
+        <div className="mb-4 rounded-lg border border-blue-500/30 bg-blue-500/10 p-3">
+          <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+            <div>
+              <p className="text-xs uppercase tracking-wide text-blue-100">Review draft packet</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Generated from the shared insight and approved research patterns for human approval.
+              </p>
+            </div>
+            {asString(draftPacket.generated_at) ? (
+              <span className="inline-flex w-fit rounded-full border border-blue-400/35 px-2 py-0.5 text-xs text-blue-100">
+                {new Date(asString(draftPacket.generated_at)).toLocaleString()}
+              </span>
+            ) : null}
           </div>
-        ))}
+          {asString(draftPacket.source_use_boundary) ? (
+            <p className="mt-3 rounded-md border border-blue-400/20 bg-background/35 px-3 py-2 text-xs leading-5 text-blue-100">
+              {asString(draftPacket.source_use_boundary)}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div className="grid gap-3 md:grid-cols-2">
+        {(hasDraftFields ? Object.entries(fields) : requiredInputs.map((input) => [input, suggestedValue(input, insight)] as const))
+          .map(([input, value]) => (
+            <div key={input} className="rounded-lg border border-silicon-slate/70 bg-background/40 p-3">
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">{formatInputLabel(input)}</p>
+              <div className="mt-1 text-sm leading-6 text-muted-foreground">
+                <FormattedValue value={hasDraftFields ? value : value || 'Pending lane draft'} />
+              </div>
+            </div>
+          ))}
       </div>
     </div>
   )
+}
+
+function formatInputLabel(input: string) {
+  return input.replace(/_/g, ' ')
+}
+
+function FormattedValue({ value }: { value: unknown }) {
+  if (Array.isArray(value)) {
+    if (!value.length) return <span>Pending</span>
+    return (
+      <ul className="space-y-1">
+        {value.map((item, index) => (
+          <li key={`${String(item)}-${index}`}>{String(item)}</li>
+        ))}
+      </ul>
+    )
+  }
+  if (value && typeof value === 'object') {
+    return <pre className="whitespace-pre-wrap text-xs">{JSON.stringify(value, null, 2)}</pre>
+  }
+  return <span className="whitespace-pre-line">{String(value ?? 'Pending')}</span>
 }
 
 function defaultInputs(channel: SocialContentIntelligenceChannel) {

--- a/app/admin/agents/social-insights/[id]/page.tsx
+++ b/app/admin/agents/social-insights/[id]/page.tsx
@@ -491,6 +491,8 @@ function ChannelInputs({
   const fields = asRecord(draftPacket.fields)
   const hasDraftFields = Object.keys(fields).length > 0
   const draftApprovalStatus = asString(draftPacket.approval_status)
+  const sharedSource = asRecord(draftPacket.shared_source)
+  const sharedSourceTitle = asString(sharedSource.insight_title)
   return (
     <div>
       {hasDraftFields ? (
@@ -518,6 +520,11 @@ function ChannelInputs({
           {asString(draftPacket.source_use_boundary) ? (
             <p className="mt-3 rounded-md border border-blue-400/20 bg-background/35 px-3 py-2 text-xs leading-5 text-blue-100">
               {asString(draftPacket.source_use_boundary)}
+            </p>
+          ) : null}
+          {sharedSourceTitle ? (
+            <p className="mt-2 rounded-md border border-blue-400/20 bg-background/35 px-3 py-2 text-xs leading-5 text-blue-100">
+              Shared source: {sharedSourceTitle}
             </p>
           ) : null}
         </div>

--- a/app/admin/testing/page.tsx
+++ b/app/admin/testing/page.tsx
@@ -158,6 +158,7 @@ const SCENARIOS: ScenarioMeta[] = [
   { id: 'seed_kickoff_project', name: 'Seed: Kickoff Project', tags: ['seed', 'populate-demo'], journeyStage: 'client' },
   { id: 'seed_discovery_sql_compat', name: 'Seed: Discovery (test-discovery@)', tags: ['seed', 'populate-demo'], journeyStage: 'lead' },
   { id: 'seed_social_content_calendar_fixture', name: 'Seed: Content Calendar Fixture', tags: ['seed', 'populate-demo', 'content-intelligence', 'calendar'], journeyStage: 'lead' },
+  { id: 'seed_social_channel_review_fixture', name: 'Seed: Social Channel Review Fixture', tags: ['seed', 'populate-demo', 'content-intelligence', 'social-review'], journeyStage: 'lead' },
   // Chatbot question bank scenarios
   { id: 'chatbot_question_bank_stratified', name: 'Chatbot Questions (Stratified)', tags: ['chat', 'chatbot-questions'], journeyStage: 'prospect' },
   { id: 'chatbot_question_bank_boundary', name: 'Chatbot Questions (Boundary)', tags: ['chat', 'chatbot-questions'], journeyStage: 'prospect' },
@@ -213,6 +214,7 @@ function scenarioIdsForPreset(presetId: string): string[] {
         'seed_kickoff_project',
         'seed_discovery_sql_compat',
         'seed_social_content_calendar_fixture',
+        'seed_social_channel_review_fixture',
       ]
     case 'all':
       return SCENARIOS.map(s => s.id)

--- a/app/api/admin/agents/work-items/[id]/social-channels/[channel]/route.test.ts
+++ b/app/api/admin/agents/work-items/[id]/social-channels/[channel]/route.test.ts
@@ -35,6 +35,12 @@ const baseWorkItem = {
         status: 'selected',
         label: 'LinkedIn',
         required_inputs: ['post text', 'CTA'],
+        draft_packet: {
+          channel: 'linkedin',
+          fields: {
+            post_text: 'LinkedIn draft',
+          },
+        },
       },
     },
   },
@@ -124,5 +130,33 @@ describe('/api/admin/agents/work-items/[id]/social-channels/[channel]', () => {
         external_post: false,
       },
     })
+  })
+
+  it('requires a prepared review draft before approving LinkedIn or YouTube lanes', async () => {
+    mocks.getAgentWorkItem.mockResolvedValue({
+      ...baseWorkItem,
+      metadata: {
+        channel_lanes: {
+          linkedin: {
+            status: 'selected',
+            label: 'LinkedIn',
+            required_inputs: ['post text', 'CTA'],
+          },
+        },
+      },
+    })
+
+    const response = await PATCH(request({
+      status: 'approved',
+      decision_note: 'Approved for planning.',
+    }) as never, {
+      params: { id: 'work-1', channel: 'linkedin' },
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: 'Prepare the LinkedIn and YouTube review drafts before approving this channel lane',
+    })
+    expect(mocks.updateAgentWorkItemMetadata).not.toHaveBeenCalled()
   })
 })

--- a/app/api/admin/agents/work-items/[id]/social-channels/[channel]/route.test.ts
+++ b/app/api/admin/agents/work-items/[id]/social-channels/[channel]/route.test.ts
@@ -112,6 +112,11 @@ describe('/api/admin/agents/work-items/[id]/social-channels/[channel]', () => {
             status: 'approved',
             decision_note: 'Approved for planning.',
             required_inputs: ['post text', 'CTA'],
+            draft_packet: expect.objectContaining({
+              approval_status: 'approved',
+              decision_note: 'Approved for planning.',
+              decided_at: expect.any(String),
+            }),
           }),
           youtube_shorts: expect.objectContaining({
             status: 'not_started',
@@ -129,6 +134,12 @@ describe('/api/admin/agents/work-items/[id]/social-channels/[channel]', () => {
         schedule: false,
         external_post: false,
       },
+      lane: expect.objectContaining({
+        draft_packet: expect.objectContaining({
+          approval_status: 'approved',
+          decision_note: 'Approved for planning.',
+        }),
+      }),
     })
   })
 

--- a/app/api/admin/agents/work-items/[id]/social-channels/[channel]/route.ts
+++ b/app/api/admin/agents/work-items/[id]/social-channels/[channel]/route.ts
@@ -4,6 +4,7 @@ import { getAgentWorkItem, updateAgentWorkItemMetadata } from '@/lib/agent-work-
 import {
   isSocialContentIntelligenceChannel,
   normalizeSocialChannelLanes,
+  type SocialChannelReviewDraftPacket,
   type SocialChannelLaneStatus,
 } from '@/lib/social-content-intelligence'
 
@@ -21,6 +22,28 @@ function hasReviewDraft(lane: Record<string, unknown>) {
   const draftPacket = asRecord(lane.draft_packet)
   const fields = asRecord(draftPacket.fields)
   return Object.keys(fields).length > 0
+}
+
+function draftApprovalStatus(status: SocialChannelLaneStatus) {
+  if (status === 'approved' || status === 'blocked') return status
+  return 'in_review'
+}
+
+function stampDraftPacketDecision(input: {
+  draftPacket: unknown
+  status: SocialChannelLaneStatus
+  decisionNote: string | null
+  decidedAt: string
+}) {
+  const draftPacket = asRecord(input.draftPacket)
+  if (!Object.keys(draftPacket).length) return input.draftPacket as SocialChannelReviewDraftPacket | null | undefined
+
+  return {
+    ...draftPacket,
+    approval_status: draftApprovalStatus(input.status),
+    decision_note: input.decisionNote,
+    decided_at: input.decidedAt,
+  } as SocialChannelReviewDraftPacket
 }
 
 export async function PATCH(
@@ -67,12 +90,22 @@ export async function PATCH(
       )
     }
 
+    const decidedAt = new Date().toISOString()
+    const nextLaneStatus = nextStatus || lanes[params.channel].status
+    const decisionNote = asString(body.decision_note) || lanes[params.channel].decision_note || null
+
     lanes[params.channel] = {
       ...lanes[params.channel],
       ...asRecord(body.patch),
-      status: nextStatus || lanes[params.channel].status,
-      decision_note: asString(body.decision_note) || lanes[params.channel].decision_note || null,
-      updated_at: new Date().toISOString(),
+      status: nextLaneStatus,
+      decision_note: decisionNote,
+      draft_packet: stampDraftPacketDecision({
+        draftPacket: lanes[params.channel].draft_packet,
+        status: nextLaneStatus,
+        decisionNote,
+        decidedAt,
+      }),
+      updated_at: decidedAt,
     }
 
     const updated = await updateAgentWorkItemMetadata({

--- a/app/api/admin/agents/work-items/[id]/social-channels/[channel]/route.ts
+++ b/app/api/admin/agents/work-items/[id]/social-channels/[channel]/route.ts
@@ -17,6 +17,12 @@ function asString(value: unknown) {
   return typeof value === 'string' ? value.trim() : ''
 }
 
+function hasReviewDraft(lane: Record<string, unknown>) {
+  const draftPacket = asRecord(lane.draft_packet)
+  const fields = asRecord(draftPacket.fields)
+  return Object.keys(fields).length > 0
+}
+
 export async function PATCH(
   request: NextRequest,
   { params }: { params: { id: string; channel: string } },
@@ -51,6 +57,16 @@ export async function PATCH(
     }
 
     const lanes = normalizeSocialChannelLanes(workItem.metadata?.channel_lanes)
+    if (nextStatus === 'approved'
+      && (params.channel === 'linkedin' || params.channel === 'youtube_shorts')
+      && !hasReviewDraft(lanes[params.channel])
+    ) {
+      return NextResponse.json(
+        { error: 'Prepare the LinkedIn and YouTube review drafts before approving this channel lane' },
+        { status: 400 },
+      )
+    }
+
     lanes[params.channel] = {
       ...lanes[params.channel],
       ...asRecord(body.patch),

--- a/app/api/admin/agents/work-items/[id]/social-channels/prepare-review-drafts/route.test.ts
+++ b/app/api/admin/agents/work-items/[id]/social-channels/prepare-review-drafts/route.test.ts
@@ -102,6 +102,29 @@ describe('/api/admin/agents/work-items/[id]/social-channels/prepare-review-draft
     expect(mocks.updateAgentWorkItemMetadata).not.toHaveBeenCalled()
   })
 
+  it('requires approved research patterns before preparing channel drafts', async () => {
+    mocks.getAgentWorkItem.mockResolvedValue({
+      ...baseWorkItem,
+      metadata: {
+        ...baseWorkItem.metadata,
+        insight: {
+          ...baseWorkItem.metadata.insight,
+          approved_research_patterns: [],
+        },
+      },
+    })
+
+    const response = await POST(request() as never, {
+      params: { id: 'work-1' },
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: 'Link at least one approved research pattern before preparing LinkedIn and YouTube review drafts',
+    })
+    expect(mocks.updateAgentWorkItemMetadata).not.toHaveBeenCalled()
+  })
+
   it('prepares LinkedIn and YouTube review drafts without external side effects', async () => {
     const response = await POST(request() as never, {
       params: { id: 'work-1' },

--- a/app/api/admin/agents/work-items/[id]/social-channels/prepare-review-drafts/route.test.ts
+++ b/app/api/admin/agents/work-items/[id]/social-channels/prepare-review-drafts/route.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  getAgentWorkItem: vi.fn(),
+  updateAgentWorkItemMetadata: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-work-items', () => ({
+  getAgentWorkItem: mocks.getAgentWorkItem,
+  updateAgentWorkItemMetadata: mocks.updateAgentWorkItemMetadata,
+}))
+
+import { POST } from './route'
+
+function request() {
+  return new Request('http://localhost/api/admin/agents/work-items/work-1/social-channels/prepare-review-drafts', {
+    method: 'POST',
+    headers: { authorization: 'Bearer token' },
+  })
+}
+
+const baseWorkItem = {
+  id: 'work-1',
+  title: 'Approval gates create trust',
+  metadata: {
+    insight: {
+      title: 'Approval gates create trust',
+      triggering_event: 'The Social Content review flow made the gate visible.',
+      why_vambah_can_speak: 'Vambah is building and reviewing the system directly.',
+      evidence_summary: 'Review path and visual gate work shipped locally.',
+      content_angle: 'AI should reduce burden, but only when authority and evidence are separated.',
+      suggested_hook: 'AI should reduce burden.',
+      claim_boundaries: ['Do not imply publishing is automated.'],
+      approved_research_patterns: [
+        {
+          source_url: 'https://youtube.com/watch?v=abc',
+          platform: 'youtube',
+          creator_name: 'Creator',
+          pattern_status: 'usable_framework',
+          pattern_packet: {
+            hook_structure: 'Start with the missed approval gate.',
+            promise_value: 'Show how review gates build trust.',
+            thumbnail_pattern: 'Translate the layout into AmaduTown style.',
+          },
+        },
+      ],
+    },
+    channel_lanes: {
+      linkedin: { status: 'selected', label: 'LinkedIn', required_inputs: ['post text', 'CTA'] },
+      youtube_shorts: { status: 'not_started', label: 'YouTube Shorts', required_inputs: ['hook', 'script'] },
+    },
+  },
+}
+
+describe('/api/admin/agents/work-items/[id]/social-channels/prepare-review-drafts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-24T15:00:00.000Z'))
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user', email: 'admin@example.com' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.getAgentWorkItem.mockResolvedValue(baseWorkItem)
+    mocks.updateAgentWorkItemMetadata.mockImplementation(async (input) => ({
+      ...baseWorkItem,
+      metadata: input.metadata,
+    }))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(request() as never, {
+      params: { id: 'work-1' },
+    })
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.getAgentWorkItem).not.toHaveBeenCalled()
+  })
+
+  it('requires social insight metadata', async () => {
+    mocks.getAgentWorkItem.mockResolvedValue({ ...baseWorkItem, metadata: {} })
+
+    const response = await POST(request() as never, {
+      params: { id: 'work-1' },
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'Social insight metadata is required' })
+    expect(mocks.updateAgentWorkItemMetadata).not.toHaveBeenCalled()
+  })
+
+  it('prepares LinkedIn and YouTube review drafts without external side effects', async () => {
+    const response = await POST(request() as never, {
+      params: { id: 'work-1' },
+    })
+
+    expect(response.status).toBe(200)
+    expect(mocks.updateAgentWorkItemMetadata).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'work-1',
+      note: 'LinkedIn and YouTube Shorts review drafts prepared by admin@example.com.',
+      metadata: expect.objectContaining({
+        channel_review_workflow: expect.objectContaining({
+          status: 'human_review_ready',
+          prepared_channels: ['linkedin', 'youtube_shorts'],
+          prepared_at: '2026-06-24T15:00:00.000Z',
+        }),
+        channel_lanes: expect.objectContaining({
+          linkedin: expect.objectContaining({
+            status: 'in_review',
+            review_requested_at: '2026-06-24T15:00:00.000Z',
+            draft_packet: expect.objectContaining({
+              channel: 'linkedin',
+              fields: expect.objectContaining({
+                post_text: expect.stringContaining('The Social Content review flow made the gate visible.'),
+                cta: expect.stringContaining('Where have you seen AI'),
+              }),
+            }),
+          }),
+          youtube_shorts: expect.objectContaining({
+            status: 'in_review',
+            review_requested_at: '2026-06-24T15:00:00.000Z',
+            draft_packet: expect.objectContaining({
+              channel: 'youtube_shorts',
+              fields: expect.objectContaining({
+                hook: 'AI should reduce burden.',
+                first_30_seconds: expect.stringContaining('I noticed this through the social content review flow'),
+              }),
+            }),
+          }),
+        }),
+      }),
+    }))
+
+    expect(await response.json()).toMatchObject({
+      success: true,
+      side_effects: {
+        provider_generation: false,
+        upload: false,
+        publish: false,
+        schedule: false,
+        external_post: false,
+      },
+    })
+  })
+})

--- a/app/api/admin/agents/work-items/[id]/social-channels/prepare-review-drafts/route.ts
+++ b/app/api/admin/agents/work-items/[id]/social-channels/prepare-review-drafts/route.ts
@@ -12,6 +12,11 @@ function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
 }
 
+function hasApprovedResearchPatterns(insight: Record<string, unknown>) {
+  return Array.isArray(insight.approved_research_patterns)
+    && insight.approved_research_patterns.some((pattern) => Object.keys(asRecord(pattern)).length > 0)
+}
+
 export async function POST(
   request: NextRequest,
   { params }: { params: { id: string } },
@@ -31,6 +36,12 @@ export async function POST(
     const insight = asRecord(metadata.insight)
     if (!Object.keys(insight).length) {
       return NextResponse.json({ error: 'Social insight metadata is required' }, { status: 400 })
+    }
+    if (!hasApprovedResearchPatterns(insight)) {
+      return NextResponse.json(
+        { error: 'Link at least one approved research pattern before preparing LinkedIn and YouTube review drafts' },
+        { status: 400 },
+      )
     }
 
     const now = new Date().toISOString()

--- a/app/api/admin/agents/work-items/[id]/social-channels/prepare-review-drafts/route.ts
+++ b/app/api/admin/agents/work-items/[id]/social-channels/prepare-review-drafts/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { getAgentWorkItem, updateAgentWorkItemMetadata } from '@/lib/agent-work-items'
+import {
+  buildLinkedInYoutubeReviewDrafts,
+  normalizeSocialChannelLanes,
+} from '@/lib/social-content-intelligence'
+
+export const dynamic = 'force-dynamic'
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const authResult = await verifyAdmin(request)
+  if (isAuthError(authResult)) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status })
+  }
+
+  try {
+    const workItem = await getAgentWorkItem(params.id)
+    if (!workItem) {
+      return NextResponse.json({ error: 'Work item not found' }, { status: 404 })
+    }
+
+    const metadata = workItem.metadata ?? {}
+    const insight = asRecord(metadata.insight)
+    if (!Object.keys(insight).length) {
+      return NextResponse.json({ error: 'Social insight metadata is required' }, { status: 400 })
+    }
+
+    const now = new Date().toISOString()
+    const drafts = buildLinkedInYoutubeReviewDrafts({ insight, generatedAt: now })
+    const lanes = normalizeSocialChannelLanes(metadata.channel_lanes)
+
+    lanes.linkedin = {
+      ...lanes.linkedin,
+      status: 'in_review',
+      draft_packet: drafts.linkedin,
+      decision_note: null,
+      review_requested_at: now,
+      updated_at: now,
+    }
+    lanes.youtube_shorts = {
+      ...lanes.youtube_shorts,
+      status: 'in_review',
+      draft_packet: drafts.youtube_shorts,
+      decision_note: null,
+      review_requested_at: now,
+      updated_at: now,
+    }
+
+    const updated = await updateAgentWorkItemMetadata({
+      id: workItem.id,
+      metadata: {
+        ...metadata,
+        channel_lanes: lanes,
+        channel_review_workflow: {
+          status: 'human_review_ready',
+          prepared_channels: ['linkedin', 'youtube_shorts'],
+          prepared_at: now,
+          source_use_boundary: drafts.linkedin.source_use_boundary,
+          side_effects: {
+            provider_generation: false,
+            upload: false,
+            publish: false,
+            schedule: false,
+            external_post: false,
+          },
+        },
+      },
+      note: `LinkedIn and YouTube Shorts review drafts prepared by ${authResult.user.email ?? authResult.user.id}.`,
+    })
+
+    return NextResponse.json({
+      success: true,
+      work_item: updated,
+      drafts,
+      side_effects: {
+        provider_generation: false,
+        upload: false,
+        publish: false,
+        schedule: false,
+        external_post: false,
+      },
+    })
+  } catch (error) {
+    console.error('[social-channel-review-drafts] prepare failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to prepare channel review drafts' },
+      { status: 500 },
+    )
+  }
+}

--- a/app/api/admin/agents/work-items/[id]/social-channels/workflow.test.ts
+++ b/app/api/admin/agents/work-items/[id]/social-channels/workflow.test.ts
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  getAgentWorkItem: vi.fn(),
+  updateAgentWorkItemMetadata: vi.fn(),
+  from: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/agent-work-items', () => ({
+  getAgentWorkItem: mocks.getAgentWorkItem,
+  updateAgentWorkItemMetadata: mocks.updateAgentWorkItemMetadata,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import { POST as linkResearchPacket } from '../research-packets/route'
+import { PATCH as decideChannelLane } from './[channel]/route'
+import { POST as prepareReviewDrafts } from './prepare-review-drafts/route'
+
+function jsonRequest(url: string, body: Record<string, unknown> = {}, method = 'POST') {
+  return new Request(url, {
+    method,
+    headers: { authorization: 'Bearer token', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+const researchPacket = {
+  id: 'packet-1',
+  source_url: 'https://youtube.com/watch?v=abc',
+  platform: 'youtube',
+  creator_name: 'Creator',
+  creator_handle: '@creator',
+  title: 'Useful outlier',
+  outlier_score: 87,
+  pattern_status: 'needs_brand_translation',
+  pattern_packet: {
+    hook_structure: 'Start with the missed approval gate.',
+    promise_value: 'Show how review gates build trust.',
+    source_use_boundary: 'Use the framework only.',
+  },
+  privacy_notes: 'Public pattern only.',
+  retrieved_at: '2026-06-23T10:00:00.000Z',
+  status: 'review_ready',
+}
+
+function sideEffectsOff(body: Record<string, unknown>) {
+  return {
+    ...body,
+    side_effects: {
+      provider_generation: false,
+      upload: false,
+      publish: false,
+      schedule: false,
+      external_post: false,
+    },
+  }
+}
+
+describe('social content intelligence research-to-channel-approval workflow', () => {
+  let currentWorkItem: Record<string, unknown>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    currentWorkItem = {
+      id: 'work-social-1',
+      title: 'Approval gates create trust',
+      source_type: 'social_topic_trigger',
+      metadata: {
+        social_topic_trigger: true,
+        research_packet_ids: [],
+        insight: {
+          title: 'Approval gates create trust',
+          triggering_event: 'The Social Content review flow made the gate visible.',
+          why_vambah_can_speak: 'Vambah is building and reviewing the system directly.',
+          evidence_summary: 'Review path and visual gate work shipped locally.',
+          content_angle: 'AI should reduce burden, but only when authority and evidence are separated.',
+          suggested_hook: 'AI should reduce burden.',
+          claim_boundaries: ['Do not imply publishing is automated.'],
+          approved_research_patterns: [],
+        },
+        channel_lanes: {
+          linkedin: { status: 'selected', label: 'LinkedIn', required_inputs: ['post text', 'CTA'] },
+          youtube_shorts: { status: 'not_started', label: 'YouTube Shorts', required_inputs: ['hook', 'script'] },
+        },
+      },
+    }
+
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user', email: 'admin@example.com' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.getAgentWorkItem.mockImplementation(async () => currentWorkItem)
+    mocks.updateAgentWorkItemMetadata.mockImplementation(async (input) => {
+      currentWorkItem = {
+        ...currentWorkItem,
+        metadata: input.metadata,
+      }
+      return currentWorkItem
+    })
+    mocks.from.mockImplementation((table: string) => {
+      if (table !== 'social_content_research_packets') throw new Error(`Unexpected table ${table}`)
+      return {
+        select: vi.fn(() => ({
+          in: vi.fn(async () => ({ data: [researchPacket], error: null })),
+        })),
+        update: vi.fn(() => ({
+          in: vi.fn(async () => ({ error: null })),
+        })),
+      }
+    })
+  })
+
+  it('links research, prepares channel drafts, and approves LinkedIn and YouTube without production side effects', async () => {
+    const linkResponse = await linkResearchPacket(jsonRequest(
+      'http://localhost/api/admin/agents/work-items/work-social-1/research-packets',
+      {
+        packet_ids: ['packet-1'],
+        decision_note: 'Use the framework, not the source wording.',
+      },
+    ) as never, {
+      params: { id: 'work-social-1' },
+    })
+
+    expect(linkResponse.status).toBe(200)
+    expect(await linkResponse.json()).toMatchObject(sideEffectsOff({
+      success: true,
+      linked_packet_ids: ['packet-1'],
+      approved_research_patterns: [
+        expect.objectContaining({
+          packet_id: 'packet-1',
+          source_url: 'https://youtube.com/watch?v=abc',
+          pattern_packet: expect.objectContaining({
+            hook_structure: 'Start with the missed approval gate.',
+          }),
+        }),
+      ],
+    }))
+
+    const prepareResponse = await prepareReviewDrafts(jsonRequest(
+      'http://localhost/api/admin/agents/work-items/work-social-1/social-channels/prepare-review-drafts',
+    ) as never, {
+      params: { id: 'work-social-1' },
+    })
+
+    expect(prepareResponse.status).toBe(200)
+    expect(await prepareResponse.json()).toMatchObject(sideEffectsOff({
+      success: true,
+      drafts: {
+        linkedin: expect.objectContaining({
+          channel: 'linkedin',
+          approval_status: 'in_review',
+          source_research_patterns: [
+            expect.objectContaining({
+              source_url: 'https://youtube.com/watch?v=abc',
+              hook_structure: 'Start with the missed approval gate.',
+            }),
+          ],
+        }),
+        youtube_shorts: expect.objectContaining({
+          channel: 'youtube_shorts',
+          approval_status: 'in_review',
+          fields: expect.objectContaining({
+            hook: 'AI should reduce burden.',
+            render_readiness: 'pending_human_approval',
+          }),
+        }),
+      },
+    }))
+
+    const approveLinkedInResponse = await decideChannelLane(jsonRequest(
+      'http://localhost/api/admin/agents/work-items/work-social-1/social-channels/linkedin',
+      {
+        status: 'approved',
+        decision_note: 'Approved for LinkedIn review; external publishing remains gated.',
+      },
+      'PATCH',
+    ) as never, {
+      params: { id: 'work-social-1', channel: 'linkedin' },
+    })
+
+    expect(approveLinkedInResponse.status).toBe(200)
+    expect(await approveLinkedInResponse.json()).toMatchObject(sideEffectsOff({
+      success: true,
+      lane: expect.objectContaining({
+        status: 'approved',
+        decision_note: 'Approved for LinkedIn review; external publishing remains gated.',
+      }),
+    }))
+
+    const approveYouTubeResponse = await decideChannelLane(jsonRequest(
+      'http://localhost/api/admin/agents/work-items/work-social-1/social-channels/youtube_shorts',
+      {
+        status: 'approved',
+        decision_note: 'Approved for YouTube Shorts review; rendering remains gated.',
+      },
+      'PATCH',
+    ) as never, {
+      params: { id: 'work-social-1', channel: 'youtube_shorts' },
+    })
+
+    expect(approveYouTubeResponse.status).toBe(200)
+    expect(await approveYouTubeResponse.json()).toMatchObject(sideEffectsOff({
+      success: true,
+      lane: expect.objectContaining({
+        status: 'approved',
+        decision_note: 'Approved for YouTube Shorts review; rendering remains gated.',
+      }),
+    }))
+
+    const metadata = currentWorkItem.metadata as Record<string, unknown>
+    const lanes = metadata.channel_lanes as Record<string, Record<string, unknown>>
+    const insight = metadata.insight as Record<string, unknown>
+    expect(insight.approved_research_patterns).toEqual([
+      expect.objectContaining({ packet_id: 'packet-1' }),
+    ])
+    expect(lanes.linkedin.status).toBe('approved')
+    expect(lanes.youtube_shorts.status).toBe('approved')
+    expect(lanes.linkedin.draft_packet).toEqual(expect.objectContaining({ channel: 'linkedin' }))
+    expect(lanes.youtube_shorts.draft_packet).toEqual(expect.objectContaining({ channel: 'youtube_shorts' }))
+  })
+})

--- a/app/api/admin/agents/work-items/[id]/social-channels/workflow.test.ts
+++ b/app/api/admin/agents/work-items/[id]/social-channels/workflow.test.ts
@@ -225,7 +225,15 @@ describe('social content intelligence research-to-channel-approval workflow', ()
     ])
     expect(lanes.linkedin.status).toBe('approved')
     expect(lanes.youtube_shorts.status).toBe('approved')
-    expect(lanes.linkedin.draft_packet).toEqual(expect.objectContaining({ channel: 'linkedin' }))
-    expect(lanes.youtube_shorts.draft_packet).toEqual(expect.objectContaining({ channel: 'youtube_shorts' }))
+    expect(lanes.linkedin.draft_packet).toEqual(expect.objectContaining({
+      channel: 'linkedin',
+      approval_status: 'approved',
+      decision_note: 'Approved for LinkedIn review; external publishing remains gated.',
+    }))
+    expect(lanes.youtube_shorts.draft_packet).toEqual(expect.objectContaining({
+      channel: 'youtube_shorts',
+      approval_status: 'approved',
+      decision_note: 'Approved for YouTube Shorts review; rendering remains gated.',
+    }))
   })
 })

--- a/docs/admin-page-structure-guidelines.md
+++ b/docs/admin-page-structure-guidelines.md
@@ -1,0 +1,21 @@
+# Admin Page Structure Guidelines
+
+Use this rule when adding or expanding Portfolio admin pages.
+
+Admin pages should keep the first viewport focused on the current decision, next action, and status. Avoid long vertical scroll caused by static explanation text or unbounded result lists.
+
+## Required Structure
+
+- Put the primary gate or action near the top of the page.
+- Use tabs or segmented navigation for major work surfaces.
+- Use collapsible panels for supporting evidence, checklists, logs, and reference material.
+- Move explanatory copy into tooltips or short helper text.
+- Paginate result groups and template libraries when more than four cards appear in one section.
+- Give table-style results search, sort, filter, and pagination controls.
+- Keep approval state visible inside the section where the decision is made.
+- Link summary status pills to the matching decision section when a page has multiple gates.
+
+## Safety
+
+- Keep publishing, provider generation, uploads, external scheduling, and production mutation behind explicit approval controls.
+- Do not let a layout shortcut hide a required human gate, source note, privacy warning, or provenance trail.

--- a/lib/admin-demo-seed.test.ts
+++ b/lib/admin-demo-seed.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   isDemoSeedKey,
   runDemoSeed,
+  SOCIAL_CHANNEL_REVIEW_FIXTURE_IDEMPOTENCY_KEY,
+  SOCIAL_CHANNEL_REVIEW_FIXTURE_KEY,
   SOCIAL_CONTENT_CALENDAR_FIXTURE_KEY,
   SOCIAL_CONTENT_CALENDAR_FIXTURE_SLUG,
 } from './admin-demo-seed'
@@ -93,5 +95,107 @@ describe('admin demo seed', () => {
         publish_enabled: false,
       })
     })
+  })
+
+  it('creates a safe Social Channel review fixture', async () => {
+    const inserts: Record<string, unknown[]> = {}
+    const deletes: Array<{ table: string; matcher: string }> = []
+
+    const supabase = {
+      from: vi.fn((table: string) => {
+        if (table === 'agent_work_items') {
+          return {
+            delete: vi.fn(() => ({
+              eq: vi.fn(async (_column: string, matcher: string) => {
+                deletes.push({ table, matcher })
+                return { data: [], error: null }
+              }),
+            })),
+            insert: vi.fn((row: Record<string, unknown>) => {
+              inserts[table] = [row]
+              return {
+                select: vi.fn(() => ({
+                  single: vi.fn(async () => ({
+                    data: { id: 'work-social-review-1' },
+                    error: null,
+                  })),
+                })),
+              }
+            }),
+          }
+        }
+
+        if (table === 'social_content_research_packets') {
+          return {
+            delete: vi.fn(() => ({
+              contains: vi.fn(async (_column: string, matcher: Record<string, unknown>) => {
+                deletes.push({ table, matcher: String(matcher.demo_seed_key) })
+                return { data: [], error: null }
+              }),
+            })),
+            insert: vi.fn((row: Record<string, unknown>) => {
+              inserts[table] = [row]
+              return {
+                select: vi.fn(() => ({
+                  single: vi.fn(async () => ({
+                    data: { id: 'packet-social-review-1' },
+                    error: null,
+                  })),
+                })),
+              }
+            }),
+          }
+        }
+
+        throw new Error(`Unexpected table ${table}`)
+      }),
+    }
+
+    const result = await runDemoSeed('social_channel_review_fixture', supabase as never)
+
+    expect(result).toMatchObject({
+      ok: true,
+      key: 'social_channel_review_fixture',
+    })
+    expect(isDemoSeedKey('social_channel_review_fixture')).toBe(true)
+    expect(deletes).toEqual(expect.arrayContaining([
+      { table: 'agent_work_items', matcher: SOCIAL_CHANNEL_REVIEW_FIXTURE_IDEMPOTENCY_KEY },
+      { table: 'social_content_research_packets', matcher: SOCIAL_CHANNEL_REVIEW_FIXTURE_KEY },
+    ]))
+
+    expect(inserts.social_content_research_packets[0]).toMatchObject({
+      platform: 'youtube',
+      pattern_status: 'needs_brand_translation',
+      status: 'review_ready',
+      actor_metadata: {
+        demo_seed_key: SOCIAL_CHANNEL_REVIEW_FIXTURE_KEY,
+        external_execution_enabled: false,
+      },
+      privacy_notes: expect.stringContaining('No private meetings'),
+    })
+
+    const workItem = inserts.agent_work_items[0] as Record<string, unknown>
+    expect(workItem).toMatchObject({
+      source_type: 'social_topic_trigger',
+      idempotency_key: SOCIAL_CHANNEL_REVIEW_FIXTURE_IDEMPOTENCY_KEY,
+      owner_agent_key: 'chief-of-staff',
+      owner_runtime: 'manual',
+      metadata: expect.objectContaining({
+        demo_seed_key: SOCIAL_CHANNEL_REVIEW_FIXTURE_KEY,
+        suggested_research_packet_ids: ['packet-social-review-1'],
+        side_effects: {
+          provider_generation: false,
+          upload: false,
+          publish: false,
+          schedule: false,
+          external_post: false,
+        },
+      }),
+    })
+    const metadata = workItem.metadata as Record<string, unknown>
+    const channelLanes = metadata.channel_lanes as Record<string, Record<string, unknown>>
+    expect(channelLanes.linkedin.status).toBe('selected')
+    expect(channelLanes.youtube_shorts.status).toBe('not_started')
+    expect((metadata.insight as Record<string, unknown>).approved_research_patterns).toEqual([])
   })
 })

--- a/lib/admin-demo-seed.ts
+++ b/lib/admin-demo-seed.ts
@@ -14,6 +14,7 @@ export const DEMO_SEED_KEYS = [
   'kickoff_test_project',
   'discovery_call_test_contact',
   'social_content_calendar_fixture',
+  'social_channel_review_fixture',
 ] as const
 
 export type DemoSeedKey = (typeof DEMO_SEED_KEYS)[number]
@@ -26,6 +27,8 @@ const SARAH_SESSION = 'test-lead-session-001'
 const SARAH_EMAIL = 'sarah.mitchell@techflow.io'
 export const SOCIAL_CONTENT_CALENDAR_FIXTURE_SLUG = 'demo-content-calendar-smoke'
 export const SOCIAL_CONTENT_CALENDAR_FIXTURE_KEY = 'social_content_calendar_fixture'
+export const SOCIAL_CHANNEL_REVIEW_FIXTURE_KEY = 'social_channel_review_fixture'
+export const SOCIAL_CHANNEL_REVIEW_FIXTURE_IDEMPOTENCY_KEY = 'demo:social-channel-review-fixture'
 
 const BUSINESS_CHALLENGES = {
   primary_challenges: [
@@ -155,6 +158,18 @@ async function removeSocialContentCalendarFixture(supabase: SupabaseClient): Pro
     .from('attraction_campaigns')
     .delete()
     .eq('slug', SOCIAL_CONTENT_CALENDAR_FIXTURE_SLUG)
+}
+
+async function removeSocialChannelReviewFixture(supabase: SupabaseClient): Promise<void> {
+  await supabase
+    .from('agent_work_items')
+    .delete()
+    .eq('idempotency_key', SOCIAL_CHANNEL_REVIEW_FIXTURE_IDEMPOTENCY_KEY)
+
+  await supabase
+    .from('social_content_research_packets')
+    .delete()
+    .contains('actor_metadata', { demo_seed_key: SOCIAL_CHANNEL_REVIEW_FIXTURE_KEY })
 }
 
 export async function runDemoSeed(
@@ -409,6 +424,181 @@ export async function runDemoSeed(
           ok: true,
           key,
           detail: `Content calendar fixture campaign ${campaign.id} with ${rows.length} items`,
+        }
+      }
+
+      case 'social_channel_review_fixture': {
+        await removeSocialChannelReviewFixture(supabase)
+
+        const retrievedAt = new Date().toISOString()
+        const { data: packet, error: packetError } = await supabase
+          .from('social_content_research_packets')
+          .insert({
+            source_url: 'https://youtube.com/watch?v=demo-social-review',
+            platform: 'youtube',
+            creator_name: 'Public Creator Demo',
+            creator_handle: '@publiccreatordemo',
+            title: 'Demo research pattern for accountable AI content',
+            caption:
+              'Public demo packet for Content Intelligence smoke testing. Use the pattern only.',
+            thumbnail_url: 'https://example.com/demo-social-review-thumbnail.jpg',
+            hook_transcript:
+              'The first thirty seconds frame the tension: AI content only works when the proof and approval path are visible.',
+            metrics: {
+              views: 128000,
+              likes: 8600,
+              comments: 940,
+              shares: 520,
+              follower_count: 22000,
+              retrieved_at: retrievedAt,
+            },
+            actor_metadata: {
+              provider: 'free_recorded_evidence',
+              retrieval_method: 'demo_seed',
+              demo_seed_key: SOCIAL_CHANNEL_REVIEW_FIXTURE_KEY,
+              cost_usd: 0,
+              external_execution_enabled: false,
+            },
+            outlier_score: 87,
+            score_breakdown: {
+              view_to_follower_ratio: 5.82,
+              engagement_rate: 0.0785,
+              comment_density: 0.0073,
+              small_creator_outlier_boost: 15,
+              strategic_fit: 80,
+            },
+            pattern_packet: {
+              hook_structure: 'Open with the missed approval gate before explaining the system.',
+              tension_or_missed_opportunity:
+                'AI output creates risk when evidence and authority are hidden.',
+              promise_value:
+                'Show how visible review gates turn AI content into accountable work.',
+              proof_style: 'Use product-screen proof and decision history, not generic claims.',
+              title_pattern: 'Why [system] needs [visible proof] before [public action]',
+              thumbnail_pattern:
+                'High-contrast proof frame with a clear approval/status artifact; translate into AmaduTown style.',
+              pacing_visual_framing:
+                'Start face-to-camera, cut to the dashboard proof, close on the principle.',
+              cta_style: 'Ask where automation added work because the gate was missing.',
+              source_use_boundary:
+                'Use reusable frameworks only; do not copy creator scripts, titles, thumbnails, or visual identity.',
+            },
+            pattern_status: 'needs_brand_translation',
+            status: 'review_ready',
+            privacy_notes:
+              'Public demo research packet. No private meetings, Chronicle notes, client records, uploads, schedules, or publishes.',
+            retrieved_at: retrievedAt,
+          })
+          .select('id')
+          .single()
+
+        if (packetError || !packet) {
+          return {
+            ok: false,
+            error: `social_content_research_packets: ${packetError?.message ?? 'no row'}`,
+          }
+        }
+
+        const { data: workItem, error: workItemError } = await supabase
+          .from('agent_work_items')
+          .insert({
+            title: 'Demo: turn a Shaka insight into LinkedIn and YouTube review drafts',
+            objective:
+              'Link the demo public research pattern, prepare LinkedIn and YouTube Shorts drafts from the same Shaka insight, then approve or reject each channel lane.',
+            status: 'proposed',
+            priority: 'high',
+            owner_agent_key: 'chief-of-staff',
+            owner_runtime: 'manual',
+            source_type: 'social_topic_trigger',
+            source_id: SOCIAL_CHANNEL_REVIEW_FIXTURE_KEY,
+            source_label: 'Demo Content Intelligence channel review fixture',
+            expected_files: [],
+            touched_files: [],
+            overlap_group: 'social-content-intelligence',
+            dependency_ids: [],
+            idempotency_key: SOCIAL_CHANNEL_REVIEW_FIXTURE_IDEMPOTENCY_KEY,
+            metadata: {
+              social_topic_trigger: true,
+              demo_seed_key: SOCIAL_CHANNEL_REVIEW_FIXTURE_KEY,
+              fixture_version: 1,
+              fixture_purpose: 'content_intelligence_linkedin_youtube_review_smoke',
+              research_packet_ids: [],
+              suggested_research_packet_ids: [packet.id],
+              insight: {
+                title: 'Approval gates turn AI content into accountable work',
+                triggering_event:
+                  'A Portfolio review flow showed that AI-generated social content needs visible proof before public handoff.',
+                why_vambah_can_speak:
+                  'Vambah is building the operating layer directly and can show the difference between AI output and governed work.',
+                evidence_summary:
+                  'The Content Intelligence backlog, research packet, channel lanes, and human approval controls all stay inside Portfolio before any external action.',
+                brand_goal:
+                  'Show AmaduTown as the practical operating layer for governed AI content production.',
+                audience: 'Operators, founders, and product leaders adopting agentic AI workflows.',
+                content_angle:
+                  'AI should reduce burden, but only when the evidence, owner, and approval gate are visible before the output reaches the public.',
+                suggested_hook:
+                  'AI content does not earn trust because it sounds polished. It earns trust when the handoff is visible.',
+                claim_boundaries: [
+                  'Do not imply publishing is automated.',
+                  'Do not claim provider generation, upload, or scheduling has been approved.',
+                  'Use the public research packet as a framework only.',
+                ],
+                approved_research_patterns: [],
+              },
+              channel_lanes: {
+                linkedin: {
+                  status: 'selected',
+                  label: 'LinkedIn',
+                  decision_note: null,
+                  draft_packet: null,
+                  required_inputs: ['post text', 'CTA', 'CTA URL', 'hashtags', 'references'],
+                },
+                youtube_shorts: {
+                  status: 'not_started',
+                  label: 'YouTube Shorts',
+                  decision_note: null,
+                  draft_packet: null,
+                  required_inputs: ['hook', 'first 30 seconds', 'script', 'storyboard scenes', 'b-roll hints'],
+                },
+                instagram_reels: {
+                  status: 'not_started',
+                  label: 'Instagram Reels',
+                  decision_note: null,
+                  draft_packet: null,
+                  required_inputs: ['hook', 'script', 'caption', 'safe-area notes'],
+                },
+                thumbnail: {
+                  status: 'not_started',
+                  label: 'Thumbnail',
+                  decision_note: null,
+                  draft_packet: null,
+                  required_inputs: ['pattern explanation', 'short thumbnail text', '2-3 variants'],
+                },
+              },
+              side_effects: {
+                provider_generation: false,
+                upload: false,
+                publish: false,
+                schedule: false,
+                external_post: false,
+              },
+            },
+          })
+          .select('id')
+          .single()
+
+        if (workItemError || !workItem) {
+          return {
+            ok: false,
+            error: `agent_work_items: ${workItemError?.message ?? 'no row'}`,
+          }
+        }
+
+        return {
+          ok: true,
+          key,
+          detail: `Social channel review fixture work item ${workItem.id} with research packet ${packet.id}`,
         }
       }
 

--- a/lib/social-content-intelligence.test.ts
+++ b/lib/social-content-intelligence.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  buildLinkedInYoutubeReviewDrafts,
   defaultSocialChannelLanes,
   normalizeSocialChannelLanes,
   scoreCreatorAsset,
@@ -92,5 +93,61 @@ describe('social-content-intelligence', () => {
     expect(mapped.agent_work_item_id).toBe('work-social-1')
     expect(mapped.title).toBe('Approval gates create trust')
     expect(mapped.claim_boundaries).toEqual(['Do not imply every workflow is automated.'])
+  })
+
+  it('builds LinkedIn and YouTube review drafts from the same source while adapting fields by channel', () => {
+    const drafts = buildLinkedInYoutubeReviewDrafts({
+      generatedAt: '2026-06-24T15:00:00.000Z',
+      insight: {
+        title: 'Approval gates create trust',
+        triggering_event: 'The Social Content review flow made the gate visible.',
+        why_vambah_can_speak: 'Vambah built and reviewed the workflow.',
+        evidence_summary: 'The work item links public research, channel drafts, and human decisions.',
+        content_angle: 'AI should reduce burden when receipts and approval gates are visible.',
+        suggested_hook: 'AI should reduce burden.',
+        claim_boundaries: ['Do not claim external publishing is automated.'],
+        approved_research_patterns: [
+          {
+            source_url: 'https://youtube.com/watch?v=abc',
+            platform: 'youtube',
+            creator_name: 'Useful outlier',
+            pattern_status: 'usable_framework',
+            pattern_packet: {
+              hook_structure: 'Start with the missed approval gate.',
+              promise_value: 'Show the operating layer behind the content.',
+            },
+          },
+        ],
+      },
+    })
+
+    expect(drafts.linkedin.shared_source).toEqual(drafts.youtube_shorts.shared_source)
+    expect(drafts.linkedin.shared_source).toEqual({
+      insight_title: 'Approval gates create trust',
+      triggering_event: 'The Social Content review flow made the gate visible.',
+      content_angle: 'AI should reduce burden when receipts and approval gates are visible.',
+      evidence_summary: 'The work item links public research, channel drafts, and human decisions.',
+    })
+    expect(drafts.linkedin.fields).toMatchObject({
+      post_text: expect.stringContaining('The Social Content review flow made the gate visible.'),
+      cta: expect.stringContaining('Where have you seen AI'),
+      visual_mode: 'carousel_or_framework_illustration_review',
+    })
+    expect(drafts.youtube_shorts.fields).toMatchObject({
+      hook: 'AI should reduce burden.',
+      first_30_seconds: expect.stringContaining('I noticed this through the social content review flow'),
+      target_duration_seconds: 45,
+      render_readiness: 'pending_human_approval',
+    })
+    expect(drafts.linkedin.fields).not.toHaveProperty('first_30_seconds')
+    expect(drafts.youtube_shorts.fields).not.toHaveProperty('post_text')
+    expect(drafts.linkedin.side_effects).toEqual({
+      provider_generation: false,
+      upload: false,
+      publish: false,
+      schedule: false,
+      external_post: false,
+    })
+    expect(drafts.youtube_shorts.side_effects).toEqual(drafts.linkedin.side_effects)
   })
 })

--- a/lib/social-content-intelligence.ts
+++ b/lib/social-content-intelligence.ts
@@ -36,7 +36,9 @@ export type SocialChannelLanes = Record<SocialContentIntelligenceChannel, Social
 export type SocialChannelReviewDraftPacket = {
   channel: 'linkedin' | 'youtube_shorts'
   generated_at: string
-  approval_status: 'in_review'
+  approval_status: 'in_review' | 'approved' | 'blocked'
+  decision_note?: string | null
+  decided_at?: string | null
   source_insight_title: string
   source_use_boundary: string
   fields: Record<string, unknown>

--- a/lib/social-content-intelligence.ts
+++ b/lib/social-content-intelligence.ts
@@ -39,6 +39,12 @@ export type SocialChannelReviewDraftPacket = {
   approval_status: 'in_review' | 'approved' | 'blocked'
   decision_note?: string | null
   decided_at?: string | null
+  shared_source: {
+    insight_title: string
+    triggering_event: string
+    content_angle: string
+    evidence_summary: string
+  }
   source_insight_title: string
   source_use_boundary: string
   fields: Record<string, unknown>
@@ -653,6 +659,12 @@ export function buildLinkedInYoutubeReviewDrafts(input: {
   const patternHook = firstString(...patterns.map((pattern) => pattern.hook_structure))
   const patternPromise = firstString(...patterns.map((pattern) => pattern.promise_value))
   const sourceBoundary = 'Drafts are generated for human review only. Public research patterns are framework inputs, not source copy.'
+  const sharedSource = {
+    insight_title: title,
+    triggering_event: triggeringEvent,
+    content_angle: contentAngle,
+    evidence_summary: evidenceSummary,
+  }
 
   const linkedinPostText = [
     triggeringEvent,
@@ -681,6 +693,7 @@ export function buildLinkedInYoutubeReviewDrafts(input: {
       channel: 'linkedin',
       generated_at: generatedAt,
       approval_status: 'in_review',
+      shared_source: sharedSource,
       source_insight_title: title,
       source_use_boundary: sourceBoundary,
       fields: {
@@ -703,6 +716,7 @@ export function buildLinkedInYoutubeReviewDrafts(input: {
       channel: 'youtube_shorts',
       generated_at: generatedAt,
       approval_status: 'in_review',
+      shared_source: sharedSource,
       source_insight_title: title,
       source_use_boundary: sourceBoundary,
       fields: {

--- a/lib/social-content-intelligence.ts
+++ b/lib/social-content-intelligence.ts
@@ -24,12 +24,36 @@ export type SocialChannelLane = {
   status: SocialChannelLaneStatus
   label: string
   decision_note?: string | null
+  draft_packet?: SocialChannelReviewDraftPacket | null
+  review_requested_at?: string | null
   selected_for_content_id?: string | null
   updated_at?: string | null
   required_inputs: string[]
 }
 
 export type SocialChannelLanes = Record<SocialContentIntelligenceChannel, SocialChannelLane>
+
+export type SocialChannelReviewDraftPacket = {
+  channel: 'linkedin' | 'youtube_shorts'
+  generated_at: string
+  approval_status: 'in_review'
+  source_insight_title: string
+  source_use_boundary: string
+  fields: Record<string, unknown>
+  source_research_patterns: Array<Record<string, unknown>>
+  side_effects: {
+    provider_generation: false
+    upload: false
+    publish: false
+    schedule: false
+    external_post: false
+  }
+}
+
+export type LinkedInYoutubeReviewDrafts = {
+  linkedin: SocialChannelReviewDraftPacket
+  youtube_shorts: SocialChannelReviewDraftPacket
+}
 
 export type SocialResearchPatternStatus =
   | 'usable_framework'
@@ -227,6 +251,12 @@ function asStringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
 }
 
+function asRecordArray(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value)
+    ? value.map((item) => asRecord(item)).filter((item): item is Record<string, unknown> => Boolean(item))
+    : []
+}
+
 function firstString(...values: unknown[]) {
   for (const value of values) {
     const text = asString(value).trim()
@@ -287,6 +317,8 @@ export function normalizeSocialChannelLanes(value: unknown): SocialChannelLanes 
         : defaults[channel].required_inputs,
       decision_note: asString(lane.decision_note) || null,
       selected_for_content_id: asString(lane.selected_for_content_id) || null,
+      draft_packet: asRecord(lane.draft_packet) as SocialChannelReviewDraftPacket | null,
+      review_requested_at: asString(lane.review_requested_at) || null,
       updated_at: asString(lane.updated_at) || null,
     }
   }
@@ -568,6 +600,145 @@ export function researchPacketDraftFromRecordedEvidence(input: {
     pattern_status: normalizePatternStatus(evidence.pattern_status),
     privacy_notes: 'Free public research packet. Use patterns only; do not copy source script, title, thumbnail, or visual identity.',
     retrieved_at: input.retrievedAt,
+  }
+}
+
+function compactResearchPattern(pattern: Record<string, unknown>) {
+  const patternPacket = asRecord(pattern.pattern_packet) ?? {}
+  return {
+    source_url: firstString(pattern.source_url) || null,
+    platform: firstString(pattern.platform) || null,
+    creator: firstString(pattern.creator_name, pattern.creator_handle) || null,
+    pattern_status: firstString(pattern.pattern_status) || null,
+    hook_structure: firstString(patternPacket.hook_structure) || null,
+    promise_value: firstString(patternPacket.promise_value) || null,
+    thumbnail_pattern: firstString(patternPacket.thumbnail_pattern) || null,
+    source_use_boundary: firstString(patternPacket.source_use_boundary)
+      || 'Use reusable frameworks only; do not copy creator scripts, titles, thumbnails, or visual identity.',
+  }
+}
+
+function reviewDraftSideEffects(): SocialChannelReviewDraftPacket['side_effects'] {
+  return {
+    provider_generation: false,
+    upload: false,
+    publish: false,
+    schedule: false,
+    external_post: false,
+  }
+}
+
+export function buildLinkedInYoutubeReviewDrafts(input: {
+  insight: Record<string, unknown>
+  generatedAt?: string
+}): LinkedInYoutubeReviewDrafts {
+  const insight = input.insight
+  const generatedAt = input.generatedAt ?? new Date().toISOString()
+  const title = firstString(insight.title, 'Untitled Shaka insight')
+  const triggeringEvent = firstString(insight.triggering_event, title)
+  const whyVambahCanSpeak = firstString(
+    insight.why_vambah_can_speak,
+    'Vambah is close enough to the work to explain what changed, what remains bounded, and what still needs review.',
+  )
+  const evidenceSummary = firstString(insight.evidence_summary, 'Evidence summary pending.')
+  const contentAngle = firstString(
+    insight.content_angle,
+    'AI should reduce burden only when evidence, ownership, and approval gates are visible.',
+  )
+  const hook = firstString(insight.suggested_hook, contentAngle)
+  const claimBoundaries = asStringArray(insight.claim_boundaries)
+  const patterns = asRecordArray(insight.approved_research_patterns).map(compactResearchPattern)
+  const patternHook = firstString(...patterns.map((pattern) => pattern.hook_structure))
+  const patternPromise = firstString(...patterns.map((pattern) => pattern.promise_value))
+  const sourceBoundary = 'Drafts are generated for human review only. Public research patterns are framework inputs, not source copy.'
+
+  const linkedinPostText = [
+    triggeringEvent,
+    '',
+    contentAngle,
+    '',
+    `That matters because ${whyVambahCanSpeak}`,
+    '',
+    evidenceSummary,
+    '',
+    'The practical test is simple: can the system show what the draft is based on, who touched it, and what still needs review before it reaches the public?',
+    '',
+    patternPromise ? `The outside pattern I want to adapt: ${patternPromise}` : '',
+  ].filter((line) => line !== '').join('\n')
+
+  const youtubeHook = hook.length <= 120 ? hook : truncate(hook, 120)
+  const firstThirtySeconds = [
+    youtubeHook,
+    `I noticed this through ${triggeringEvent.toLowerCase()}.`,
+    'The lesson was not that AI can create more content.',
+    'The lesson was that trust gets built when every risky output has evidence, ownership, and a visible approval gate.',
+  ].join(' ')
+
+  return {
+    linkedin: {
+      channel: 'linkedin',
+      generated_at: generatedAt,
+      approval_status: 'in_review',
+      source_insight_title: title,
+      source_use_boundary: sourceBoundary,
+      fields: {
+        post_text: linkedinPostText,
+        cta: 'Where have you seen AI create more work because the approval path was never designed?',
+        cta_url: null,
+        hashtags: ['#AIProduct', '#ProductManagement', '#AmaduTownAdvisory', '#TechForGood'],
+        visual_mode: 'carousel_or_framework_illustration_review',
+        screenshot_routes: ['/admin/agents/content-intelligence', '/admin/agents/coordination'],
+        references: [
+          evidenceSummary,
+          ...patterns.map((pattern) => pattern.source_url).filter(Boolean),
+        ],
+        claim_boundaries: claimBoundaries,
+      },
+      source_research_patterns: patterns,
+      side_effects: reviewDraftSideEffects(),
+    },
+    youtube_shorts: {
+      channel: 'youtube_shorts',
+      generated_at: generatedAt,
+      approval_status: 'in_review',
+      source_insight_title: title,
+      source_use_boundary: sourceBoundary,
+      fields: {
+        hook: youtubeHook,
+        first_30_seconds: firstThirtySeconds,
+        script: [
+          `Opening: ${youtubeHook}`,
+          `Trigger: ${triggeringEvent}`,
+          `Authority: ${whyVambahCanSpeak}`,
+          `Point: ${contentAngle}`,
+          `Proof: ${evidenceSummary}`,
+          patternHook ? `Pattern to adapt: ${patternHook}` : 'Pattern to adapt: use the approved research packet without copying source language.',
+          'Close: AI earns trust when the handoff is visible before the output goes public.',
+        ],
+        target_duration_seconds: 45,
+        storyboard_scenes: [
+          'Face-to-camera hook with the triggering event.',
+          'Screen capture of the review gate or backlog surface.',
+          'B-roll showing evidence, owner, and approval status.',
+          'Closing frame with the principle and AmaduTown branding.',
+        ],
+        b_roll_hints: [
+          'Content Intelligence dashboard',
+          'Agentic Dashboard Backlog',
+          'Social Content approval gates',
+        ],
+        on_screen_text: [
+          'AI output needs receipts.',
+          'Every risky action needs a gate.',
+          'Trust is an operating layer.',
+        ],
+        caption: contentAngle,
+        render_readiness: 'pending_human_approval',
+        claim_boundaries: claimBoundaries,
+      },
+      source_research_patterns: patterns,
+      side_effects: reviewDraftSideEffects(),
+    },
   }
 }
 

--- a/lib/testing/scenarios.test.ts
+++ b/lib/testing/scenarios.test.ts
@@ -35,4 +35,24 @@ describe('scenarioIncludesDiagnosticStep', () => {
       'seed_social_content_calendar_fixture',
     )
   })
+
+  it('registers the Social Channel review fixture seed scenario', () => {
+    const scenario = getScenario('seed_social_channel_review_fixture')
+
+    expect(scenario).toMatchObject({
+      id: 'seed_social_channel_review_fixture',
+      name: 'Seed: Social Channel Review Fixture',
+      tags: expect.arrayContaining(['seed', 'populate-demo', 'content-intelligence', 'social-review']),
+    })
+    expect(scenario?.steps[0]).toMatchObject({
+      type: 'apiCall',
+      endpoint: '/api/admin/testing/demo-seed',
+      method: 'POST',
+      body: { key: 'social_channel_review_fixture' },
+      expectedStatus: 200,
+    })
+    expect(POPULATE_DEMO_SCENARIOS.map((item) => item.id)).toContain(
+      'seed_social_channel_review_fixture',
+    )
+  })
 })

--- a/lib/testing/scenarios.ts
+++ b/lib/testing/scenarios.ts
@@ -1183,6 +1183,15 @@ export const seedSocialContentCalendarFixtureScenario = demoSeedApiScenario(
   ['seed', 'populate-demo', 'content-intelligence', 'calendar']
 )
 
+export const seedSocialChannelReviewFixtureScenario = demoSeedApiScenario(
+  'seed_social_channel_review_fixture',
+  'Seed: Social Channel Review Fixture',
+  'Dev-safe Shaka insight plus public research packet for LinkedIn and YouTube review workflow',
+  'social_channel_review_fixture',
+  'lead',
+  ['seed', 'populate-demo', 'content-intelligence', 'social-review']
+)
+
 /** Scenarios that populate demo data via E2E (no SQL). Run with cleanupAfter: false. */
 export const POPULATE_DEMO_SCENARIOS: TestScenario[] = [
   seedWarmLeadsScenario,
@@ -1196,6 +1205,7 @@ export const POPULATE_DEMO_SCENARIOS: TestScenario[] = [
   seedKickoffProjectScenario,
   seedDiscoverySqlCompatScenario,
   seedSocialContentCalendarFixtureScenario,
+  seedSocialChannelReviewFixtureScenario,
 ]
 
 // ============================================================================
@@ -1335,6 +1345,7 @@ export const SCENARIOS_BY_ID: Record<string, TestScenario> = {
   seed_kickoff_project: seedKickoffProjectScenario,
   seed_discovery_sql_compat: seedDiscoverySqlCompatScenario,
   seed_social_content_calendar_fixture: seedSocialContentCalendarFixtureScenario,
+  seed_social_channel_review_fixture: seedSocialChannelReviewFixtureScenario,
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add a prepare-only Social Insight action that creates LinkedIn and YouTube Shorts review draft packets from the same Shaka insight.
- Require at least one linked approved research pattern before preparing LinkedIn/YouTube review drafts, so creation stays research-backed.
- Add `Link Suggested Research` in the Content Intelligence Backlog row, then enable `Prepare Review Drafts` only after an approved public research pattern is linked.
- Persist channel-specific draft packets on `agent_work_items.metadata.channel_lanes` and move both lanes to `in_review` for human approval.
- Add a `shared_source` block to both LinkedIn and YouTube draft packets so reviewers can trace that both channel adaptations came from the same Shaka insight, triggering event, content angle, and evidence summary.
- Prevent LinkedIn/YouTube lane approval until the prepared review draft packet exists; rejection still requires a decision note.
- Stamp the embedded channel draft packet with `approval_status`, `decision_note`, and `decided_at` when a reviewer approves, rejects, or returns a lane to review.
- Render prepared draft fields, shared source, packet approval status, and the no-side-effects boundary in the channel tabs while keeping render, upload, schedule, provider generation, and publishing side effects disabled.
- Paginate the Content Calendar template research library at 4 templates per page, with tests covering page 1 hiding the fifth template until Next.
- Add `docs/admin-page-structure-guidelines.md` so future admin pages default to compact first viewport, collapsible support content, tooltips, and paginated/searchable result sets.
- Add an admin-only demo seed scenario for the research-to-channel-review workflow: public research packet plus central Shaka social-topic work item, with decisions intentionally left for human review.

## Validation
- `npm test -- --run app/admin/agents/social-insights/[id]/page.test.tsx`
- `npm test -- --run lib/social-content-intelligence.test.ts app/admin/agents/content-intelligence/page.test.tsx app/api/admin/agents/work-items/[id]/social-channels/workflow.test.ts app/api/admin/agents/work-items/[id]/research-packets/route.test.ts app/api/admin/agents/work-items/[id]/social-channels/[channel]/route.test.ts app/api/admin/agents/work-items/[id]/social-channels/prepare-review-drafts/route.test.ts app/admin/agents/social-insights/[id]/page.test.tsx lib/admin-demo-seed.test.ts lib/testing/scenarios.test.ts`
- `npx tsc --noEmit`
- `npm run lint` (passes with existing unrelated `<img>` warnings in `app/client/dashboard/[token]/page.tsx` and `components/Navigation.test.tsx`)
- `git diff --check`
- Added unit proof that LinkedIn and YouTube drafts have identical `shared_source` while exposing channel-specific fields: LinkedIn has post text/CTA/visual mode, YouTube has hook/first 30 seconds/script/render readiness.
- Added UI proof that the Social Insight review packet shows `Shared source` and `No side effects authorized: provider generation, upload, publish, schedule, external post.` on the human review surface.

- Authenticated local UI smoke on `http://localhost:3042`: generated admin storage state, seeded `social_channel_review_fixture`, opened Content Intelligence Backlog, linked suggested research, prepared LinkedIn + YouTube review drafts, opened Social Insight human review, approved LinkedIn, approved YouTube Shorts, then verified via API that both lanes and both embedded draft packets are `approved`, `shared_source` matches, side effects remain false, and browser console errors were empty. Screenshot evidence saved outside repo at `/tmp/social-channel-review-smoke-final.png`.
- Smoke caveat: dev server warned `MOCK_N8N=false` and `N8N_DISABLE_OUTBOUND=false`; this smoke only exercised internal admin/test/work-item routes and did not call n8n, provider generation, upload, schedule, publish, or external-post routes.
- Authenticated headless smoke on `http://localhost:3038/admin/agents/content-intelligence`: generated temporary admin storage state from existing local helper, loaded Content Intelligence, opened Backlog, confirmed the Shaka insight backlog renders with no console errors. Local DB had no social insight rows before this fixture, so the row-level channel-review action is covered by UI/API tests and the new seed scenario.
- In-app browser smoke was attempted earlier on a fresh port and hit the real login gate; auth state could not be seeded into that browser surface. A later Browser automation attempt failed to attach to a usable tab, so no fresh in-app rendered smoke is claimed for the final packet-status/shared-source/side-effect-boundary patches.
- Added explicit API workflow coverage for: link public research pattern -> prepare LinkedIn + YouTube review drafts -> approve LinkedIn lane -> approve YouTube Shorts lane. Every step asserts provider generation, upload, schedule, publish, and external post remain false.
- Added explicit UI test coverage for: template pagination, linked suggested research enabling review-draft prep, LinkedIn approval blocked until review drafts are prepared, preparing the shared drafts, approving LinkedIn, and approving YouTube Shorts through human review controls.
- Added seed coverage for `seed_social_channel_review_fixture`, proving it creates only a review-ready public pattern and central work item with provider/upload/publish/schedule/external post disabled.

## Integration Notes
- No migration required.
- Metadata-only prepare flow; no provider generation, upload, external schedule, publish row, or external post is created.
- New admin testing scenario: `seed_social_channel_review_fixture` via `POST /api/admin/testing/demo-seed` or Admin Testing populate-demo surfaces.
- Latest Vercel status should be checked by Integration Captain before merge.
- `Vercel – portfolio-staging` has not appeared on this PR check set; Integration Captain should verify required deployment contexts during merge sequencing.

