### PR TITLE
docs: add accelerated course module package

### DIFF
--- a/docs/accelerated-course-modules/README.md
+++ b/docs/accelerated-course-modules/README.md
@@ -1,0 +1,41 @@
+# Accelerated Course Module Production Package
+
+This package turns *Accelerated: Building Smarter Products with AI* into a flagship mini-course with eight review-ready module packets.
+
+The course is built from the existing 60-minute workshop spine, but each module is shaped for self-paced video learning. Every module includes:
+
+- a lesson outcome,
+- a book-spine mapping,
+- an AmaduTown or Portfolio proof cue,
+- a primary lesson script draft,
+- a YouTube Shorts cutdown,
+- b-roll and storyboard direction,
+- thumbnail concepts,
+- a worksheet prompt,
+- and a privacy/review gate.
+
+## Production Stack
+
+- HeyGen: avatar/presenter segments for intro, transition, and close.
+- ElevenLabs: alternate narration for framework-heavy or slide-first lessons.
+- Remotion / HyperFrames: final lesson composition, captions, title cards, proof clips, and exports.
+- Portfolio b-roll capture: public AmaduTown pages and sanitized admin proof moments.
+
+Provider execution is locked until separately approved. These files prepare review packets only; they do not call HeyGen, ElevenLabs, Remotion, HyperFrames, n8n, upload, schedule, or publish.
+
+## Files
+
+- `module-production-packets.md` - the eight module packets.
+- `broll-capture-list.md` - reusable capture list and privacy rules.
+- `source-register.md` - source, voice, and safety provenance.
+- `review-status.json` - machine-checkable review status per module.
+
+## Validation
+
+Run:
+
+```bash
+npx tsx scripts/validate-accelerated-course-modules.ts
+```
+
+The validator checks that all eight modules are present, each has chapter mapping, proof cue, practical exercise, video packet fields, thumbnail direction, and the provider safety boundary.

--- a/docs/accelerated-course-modules/broll-capture-list.md
+++ b/docs/accelerated-course-modules/broll-capture-list.md
@@ -1,0 +1,39 @@
+# Accelerated Course B-Roll Capture List
+
+Use this list to capture proof clips and screenshots after human approval. Prefer demo or seed data for admin screens. Blur or crop any private records, emails, raw Chronicle notes, client names, account IDs, tokens, or internal-only rows.
+
+## Primary Routes
+
+| Proof Moment | Route / Source | Use In Modules | Capture Type | Privacy Notes |
+| --- | --- | --- | --- | --- |
+| Accelerated as a public product | `/`, publication card, store/ebook surface | 0, 1 | Screenshot and slow scroll | Public-safe if the page uses published product copy. |
+| Public site vs. operating layer | `/`, `/admin` | 1 | Split-screen or two short clips | Admin side must use sanitized rows or cropped dashboard cards. |
+| Diagnostic intake | `/tools/audit` | 2, 7 | Click-through or slow scroll | Public-safe; avoid submitting real personal data. |
+| Value Evidence Pipeline | `/admin/value-evidence` | 3, 5 | Dashboard clip | Use seed/demo rows; blur real companies or people. |
+| Module Sync | `/admin/module-sync` | 4, 6 | Table interaction clip | Repo names are generally safe, but crop tokens, branches, and private URLs if visible. |
+| Chat Eval | `/admin/chat-eval` | 4, 6 | Review-loop clip | Use public-safe prompts only. |
+| Analytics and funnel | `/admin/analytics/funnel` | 4 | Dashboard clip | Avoid exposing live customer/session identifiers. |
+| Cost and revenue | `/admin/cost-revenue` | 4, 6 | Dashboard clip | Use aggregate/cropped values only. |
+| n8n workflow proof | `n8n-exports/` or sanitized screenshot | 6 | Diagram or still image | Never show credentials, webhook secrets, or raw private payloads. |
+| Agent Ops / campaign proof | `/admin/agents/content-intelligence`, `/admin/agents/social-insights/[id]` | 6, 7 | Workflow clip | Use the Accelerated campaign fixture or other public-safe demo data. |
+
+## Capture Pattern
+
+Each proof clip should answer three questions:
+
+1. What principle is being taught?
+2. What does the system do?
+3. What should a product leader take from it?
+
+Keep each clip short. The lesson should not become a product tour.
+
+## Review Gate
+
+Before any clip is used in a course render:
+
+- confirm the route is public-safe or demo-data-safe,
+- inspect every visible row,
+- blur/crop sensitive fields,
+- save original and redacted review assets separately,
+- record reviewer decision in the module packet,
+- and keep final export locked until the module is approved.

--- a/docs/accelerated-course-modules/module-production-packets.md
+++ b/docs/accelerated-course-modules/module-production-packets.md
@@ -1,0 +1,525 @@
+# Accelerated Course Module Production Packets
+
+Course: *Accelerated: Build Faster Without Losing the Plot*
+Format: flagship mini-course
+Default video style: HeyGen avatar plus Portfolio/AmaduTown b-roll
+Execution status: review packets only. Provider calls, uploads, rendering, scheduling, and publishing remain locked until separately approved.
+
+## Module 0 - Why Accelerated Exists
+
+**Book spine:** Foreword, Chapter 1, A Critical Note on Data Safety
+**Lesson outcome:** Participants understand the course promise: AI speed becomes useful only when judgment, data safety, and learning keep up.
+**Proof cue:** Accelerated publication/product surface on AmaduTown.
+
+### Primary Lesson Script Draft
+
+Anyone can ask an AI tool for a roadmap now.
+
+You can ask for a PRD, a persona, a list of user stories, a launch plan, or a prototype. In a few minutes, something appears that looks like work.
+
+That is useful. I use these tools every day.
+
+But speed introduces a new problem. Product teams can now create more artifacts than they can govern, test, or learn from. The blank page is no longer the bottleneck. The bottleneck is judgment.
+
+That is why I wrote *Accelerated*. The book is not an argument that AI should replace product thinking. It is an argument that AI makes product thinking more important.
+
+When the first draft gets cheap, the next question becomes harder. What deserves to exist? What evidence do we have? What decision are we trying to make? What risk are we introducing? What did the last experiment teach us? Who is carrying the burden if this system gets it wrong?
+
+That is the center of this course.
+
+The promise is simple: use AI to reduce friction without losing the plot. Let the tool help with drafts, questions, summaries, options, and patterns. Keep the human responsible for context, judgment, consent, and consequence.
+
+You will see that through the book, but also through AmaduTown. I do not want this course to live only as theory. The operating layer behind AmaduTown is part of the proof. The site, the tools, the admin workflows, the social content system, the evidence dashboards, and the agent approvals all point to the same lesson.
+
+AI can move fast.
+
+A product system has to remember what happened after it moved.
+
+So this first module sets the frame. We are not chasing more output. We are building a learning loop. The work is to connect speed to evidence, evidence to decisions, decisions to action, and action back to learning.
+
+That is what turns AI from a content machine into a product advantage.
+
+By the end of the course, you should be able to take one messy product decision and build a practical learning loop around it. You will know what signal you need, what AI can help draft, what still needs human review, and how to keep the system from creating more work than it removes.
+
+Start with this question: where is your team already moving fast, but learning slowly?
+
+### Video Packet
+
+- **HeyGen avatar:** Opening frame, thesis, and closing question.
+- **ElevenLabs option:** Use for a short audio-only course preview if the avatar version feels too heavy.
+- **Remotion/HyperFrames composition:** Course title card, Accelerated cover/product surface, AmaduTown proof clip, captioned closing question.
+- **B-roll hints:** `accelerated publication`, `amadutown home`, `store ebook`, `public product surface`.
+- **YouTube Shorts cutdown:** "The blank page disappeared. Judgment became the bottleneck."
+- **On-screen text:** "AI speed + product discipline = learning advantage."
+- **Thumbnail concepts:** "AI SPEED NEEDS JUDGMENT"; "THE BLANK PAGE IS GONE"; "BUILD FASTER WITHOUT LOSING THE PLOT".
+
+### Worksheet Prompt
+
+Name one area where your team creates artifacts quickly. Then write the decision those artifacts are supposed to help you make.
+
+### Privacy Checklist
+
+Use public product surfaces only. Do not show private sales data, account records, provider dashboards, or unpublished book assets.
+
+## Module 1 - The Speed Trap
+
+**Book spine:** Chapters 1-3
+**Lesson outcome:** Participants can explain why fast artifacts can create noise unless product judgment filters them.
+**Proof cue:** Portfolio public surface compared with the admin operating layer behind it.
+
+### Primary Lesson Script Draft
+
+The first time you watch an AI tool create a polished product artifact, it feels like the work changed overnight.
+
+The roadmap appears. The persona sounds reasonable. The user stories are formatted. The launch plan has dates. The prototype looks close enough to make people excited.
+
+Then the team has to decide what any of it means.
+
+That is the speed trap.
+
+AI removes friction from making the first version. It does not automatically make the first version worth building. It does not know the politics of the room. It does not know which customer pain is loud but rare, which executive request is urgent but misaligned, or which technical shortcut will become expensive six months from now.
+
+In the old world, the blank page slowed us down. That was frustrating, but it also forced a certain amount of thinking. You had to sit with the problem before the artifact existed.
+
+Now the artifact can show up before the thinking is finished.
+
+That changes the product manager's job. The work becomes less about producing the document and more about interrogating it. What assumption is hiding inside this roadmap? Which user is this persona really representing? What evidence supports this priority? Which risk is being buried because the language sounds confident?
+
+This is why the first draft should become a thinking surface. Do not worship it. Do not ship it because it looks complete. Put it on the table and argue with it.
+
+Inside AmaduTown, this shows up as the difference between the public surface and the operating layer. The public website can make the work look clean. The admin layer is where the evidence, workflows, approvals, and checks live.
+
+That distinction matters. A polished front end is not a product system by itself. A good product system has a way to decide what gets built, what gets reviewed, what gets measured, and what gets changed.
+
+The trap is believing speed is the advantage.
+
+Speed is only an advantage when the team knows how to filter it.
+
+For this module, I want you to look at your own work and find the places where AI could produce more output immediately. Then ask a harder question: what filter would keep that output from becoming noise?
+
+That filter may be a decision rubric. It may be a customer evidence threshold. It may be a privacy rule. It may be a human approval gate.
+
+Whatever it is, name it before the tool starts producing.
+
+Because once the machine can make everything look ready, the team has to get much clearer about what ready actually means.
+
+### Video Packet
+
+- **HeyGen avatar:** Explain the speed trap and introduce the "thinking surface" frame.
+- **ElevenLabs option:** Narrate over a split-screen composition of public Portfolio surface and admin proof layer.
+- **Remotion/HyperFrames composition:** Fast artifact montage, then slow reveal of review gates and evidence screens.
+- **B-roll hints:** `portfolio home`, `admin dashboard`, `social content review`, `agent ops approvals`.
+- **YouTube Shorts cutdown:** "The artifact can now arrive before the thinking is done."
+- **On-screen text:** "Fast draft. Slow judgment. Better product."
+- **Thumbnail concepts:** "THE SPEED TRAP"; "WHEN AI MOVES TOO FAST"; "FIRST DRAFT IS NOT READY".
+
+### Worksheet Prompt
+
+Pick one artifact your team creates often. Write the filter that should decide whether it is useful, risky, or ready.
+
+### Privacy Checklist
+
+Use sanitized admin screens only. Crop out private rows, user IDs, emails, and raw agent notes.
+
+## Module 2 - Decision-First Discovery
+
+**Book spine:** Chapters 4-5
+**Lesson outcome:** Participants can start discovery from the decision they need to make, then use AI to shape questions, options, and evidence gaps.
+**Proof cue:** Audit/diagnostic flow as structured intake.
+
+### Primary Lesson Script Draft
+
+A lot of discovery starts too wide.
+
+Teams ask, "What do users want?" Then they collect interviews, comments, tickets, requests, and opinions. The pile grows. Everyone feels busy. Nobody is sure what decision the research is supposed to change.
+
+Decision-first discovery starts somewhere else.
+
+It asks: what decision are we trying to make?
+
+Should we build this feature? Should we serve this segment? Should we automate this workflow? Should we change the onboarding path? Should we invest in this product line? Should we stop doing something that no longer earns its place?
+
+Once the decision is named, the rest of discovery becomes sharper.
+
+You can ask what you already know. You can ask what you need to learn. You can separate evidence from opinion. You can use AI to generate interview questions, map assumptions, identify risks, and draft options. The tool becomes useful because the work has a target.
+
+Without that target, AI can make the mess look organized without making it more true.
+
+The diagnostic flow in AmaduTown is a useful proof point here. The point is not just to collect information. The point is to turn ambiguity into structured input. What is the current pain? What is the business impact? What systems are involved? What would make the work easier? What decision does this support?
+
+That structure is what keeps discovery from becoming a scrapbook.
+
+In *Accelerated*, this connects to answer-driven discovery. Start from the answer the team needs to stand behind, then work backward into the evidence that would make that answer responsible.
+
+If the answer is, "We should automate intake," then the evidence might include volume, handoff delays, error rates, staff time, user friction, and privacy risk. If the answer is, "We should not build yet," the evidence might show that the problem is real but the workflow is not stable enough.
+
+AI can help with the work around the decision. It can summarize interviews. It can propose segments. It can generate question sets. It can compare options.
+
+But the decision still belongs to the team.
+
+This module asks you to practice a simple move. Before generating anything, write the decision in plain language. Then list the evidence you have and the evidence you need.
+
+That is how you keep AI from becoming a very impressive distraction.
+
+Discovery is not valuable because it creates more notes.
+
+Discovery is valuable when it changes the quality of a decision.
+
+### Video Packet
+
+- **HeyGen avatar:** Teach the decision-first discovery frame.
+- **ElevenLabs option:** Use for a guided worksheet walkthrough.
+- **Remotion/HyperFrames composition:** Decision card, evidence gaps, diagnostic intake flow.
+- **B-roll hints:** `tools audit`, `diagnostic flow`, `intake form`, `readiness questions`.
+- **YouTube Shorts cutdown:** "Start with the decision. Then ask what evidence would make that decision responsible."
+- **On-screen text:** "Decision -> Unknowns -> Evidence -> Recommendation"
+- **Thumbnail concepts:** "START WITH THE DECISION"; "DISCOVERY NEEDS A TARGET"; "STOP COLLECTING RANDOM SIGNAL".
+
+### Worksheet Prompt
+
+Write one product decision in plain language. Then create two lists: evidence on hand and evidence still needed.
+
+### Privacy Checklist
+
+Use demo intake data only. Never enter real client, contact, or personal information during capture.
+
+## Module 3 - Feedback Becomes Signal
+
+**Book spine:** Chapters 6-9
+**Lesson outcome:** Participants can turn raw feedback into personas, roadmap inputs, PRD clarity, and evidence-backed decisions.
+**Proof cue:** Value Evidence Pipeline or diagnostic admin output.
+
+### Primary Lesson Script Draft
+
+Feedback is everywhere.
+
+It shows up in sales calls, support tickets, Slack messages, meetings, emails, surveys, analytics, renewal conversations, and side comments that someone remembers three weeks later.
+
+That volume can feel like insight. It usually is not.
+
+Feedback is raw material. Signal is designed.
+
+The difference is structure. Signal has a relationship to a decision. It has source context. It has confidence. It has a pattern. It has a reason to be trusted or questioned.
+
+This is where AI can help a lot, but only if the team knows what it is asking for.
+
+AI can cluster comments. It can summarize themes. It can compare feedback across segments. It can draft persona updates. It can identify contradictions. It can turn messy notes into candidate requirements.
+
+But AI can also make weak evidence sound cleaner than it is.
+
+So the product discipline is to preserve the source, name the confidence level, and connect the pattern to a decision.
+
+The Value Evidence Pipeline in Portfolio is the proof moment for this module. Raw evidence comes in. It gets classified. It becomes visible in a way that can support decisions. That does not mean the system is magically right. It means the system gives the team a better surface to review.
+
+That is the job.
+
+Dynamic personas work the same way. A persona should not be a poster that ages on the wall. It should learn as the product learns. If the evidence changes, the persona should change. If the evidence is thin, the persona should say so.
+
+Roadmaps and PRDs also need that discipline. A roadmap should show what the team plans to ship and what it expects to learn. A PRD should stay connected to the problem, the user, the evidence, the tradeoffs, and the metrics.
+
+When those connections break, the document drifts.
+
+AI gives us a chance to keep those connections alive, but the system has to be designed for it.
+
+In this module, you will take three pieces of raw feedback and turn them into signal. You will name the source, the pattern, the decision it might affect, and the confidence level.
+
+That small move changes the work.
+
+The team stops asking, "What did people say?"
+
+It starts asking, "What are we learning, how strong is the evidence, and what decision should change because of it?"
+
+### Video Packet
+
+- **HeyGen avatar:** Teach the feedback-to-signal distinction.
+- **ElevenLabs option:** Narrate over a signal-refinery visual.
+- **Remotion/HyperFrames composition:** Raw feedback streams into classified evidence and decision cards.
+- **B-roll hints:** `value evidence`, `diagnostic admin`, `evidence dashboard`, `classification`.
+- **YouTube Shorts cutdown:** "Feedback is raw material. Signal is designed."
+- **On-screen text:** "Source + pattern + confidence + decision"
+- **Thumbnail concepts:** "FEEDBACK IS NOT SIGNAL"; "TURN NOISE INTO EVIDENCE"; "WHAT DID WE LEARN?".
+
+### Worksheet Prompt
+
+Choose three pieces of feedback. For each one, record source, pattern, confidence, and the decision it could affect.
+
+### Privacy Checklist
+
+Use synthetic or sanitized evidence rows. Do not show real customer quotes, names, emails, account records, or internal notes.
+
+## Module 4 - Roadmaps That Learn
+
+**Book spine:** Chapters 10-13
+**Lesson outcome:** Participants can turn roadmaps into learning systems with assumptions, metrics, and checkpoints.
+**Proof cue:** Analytics/funnel, cost/revenue, Chat Eval, or Module Sync.
+
+### Primary Lesson Script Draft
+
+Most roadmaps pretend the future is cleaner than it is.
+
+They organize dates, features, dependencies, and themes. That structure helps. But too often the roadmap hides the thing the team most needs to say out loud.
+
+We are making bets.
+
+Every roadmap carries assumptions. We believe this customer problem matters. We believe this segment will respond. We believe this workflow is stable enough to automate. We believe this metric will move. We believe the cost is worth the outcome.
+
+A roadmap that learns names those assumptions.
+
+It does not only ask, "What are we shipping?" It asks, "What are we trying to learn by shipping this?"
+
+That changes the behavior of the team.
+
+Metrics become more than dashboard decoration. A metric matters when it can change a decision. If the number goes up, what do we do? If it goes down, what do we stop? If nothing changes, what did we misunderstand?
+
+AI can help generate roadmap options, surface dependencies, compare tradeoffs, and draft learning plans. It can also create roadmap theater at industrial speed if nobody names the assumptions.
+
+The Portfolio proof cues for this module are the analytics, cost/revenue, Chat Eval, and Module Sync surfaces. Each one makes a different kind of learning visible. Analytics shows behavior. Cost/revenue shows operating constraints. Chat Eval shows quality review. Module Sync shows how reusable assets stay aligned instead of drifting away from the main system.
+
+Together, they make the point: learning has to be captured somewhere.
+
+If the system cannot remember what happened, the team pays for the same lesson twice.
+
+In *Accelerated*, the Learning Plan Framework is the bridge. For each roadmap item, name the assumption, the signal, the metric, the review date, and the decision that will follow.
+
+This is practical. It does not require a giant process. It requires honesty.
+
+For one roadmap item, write: "We believe..." Then write: "We will know because..." Then write: "If we are wrong, we will..."
+
+That one exercise makes the roadmap more real.
+
+Shipping is still important.
+
+But shipping without learning is just motion with a release note attached.
+
+### Video Packet
+
+- **HeyGen avatar:** Explain learning roadmaps and assumption checkpoints.
+- **ElevenLabs option:** Strong fit for a slide-first framework lesson.
+- **Remotion/HyperFrames composition:** Roadmap lane overlaid with assumption, metric, and decision checkpoints.
+- **B-roll hints:** `analytics funnel`, `cost revenue`, `chat eval`, `module sync`.
+- **YouTube Shorts cutdown:** "A roadmap should show what you are shipping and what you are trying to learn."
+- **On-screen text:** "Ship -> Measure -> Decide -> Learn"
+- **Thumbnail concepts:** "ROADMAPS SHOULD LEARN"; "STOP ROADMAP THEATER"; "WHAT WILL THIS PROVE?".
+
+### Worksheet Prompt
+
+Pick one roadmap item. Write the assumption, the metric, the review checkpoint, and the decision that follows.
+
+### Privacy Checklist
+
+Show aggregate dashboards only. Crop internal financial details, account names, private repo URLs, and raw eval content.
+
+## Module 5 - The Decision Theater
+
+**Book spine:** Chapters 14-16
+**Lesson outcome:** Participants can map the visible and hidden dynamics around product decisions.
+**Proof cue:** Proposal, service, admin, or value evidence surfaces reframed for different decision owners.
+
+### Primary Lesson Script Draft
+
+The visible work of product management is easy to name.
+
+Tickets. Roadmaps. PRDs. Meetings. Metrics. Standups. Reviews.
+
+The hidden work is harder.
+
+Trust. Timing. Risk. Incentives. Power. Budget. Reputation. Fear. The quiet memory of what happened the last time someone tried something similar.
+
+That hidden work is the decision theater.
+
+A product idea does not move through an organization because the document is well written. It moves because the right people understand the evidence, trust the path, and believe the risk is worth carrying.
+
+AI can help map the theater. It can summarize stakeholder concerns, draft different explanations for different audiences, identify risks, and turn a messy thread into a decision memo.
+
+But AI cannot own the relationship.
+
+That remains human work.
+
+In AmaduTown, this shows up when the same evidence has to be translated for different people. An operator wants to know if the workflow will reduce burden. A founder wants to know if the investment will pay off. A technical partner wants to know what can break. A compliance-minded reviewer wants to know where data goes. A customer-facing team wants to know whether the promise is real.
+
+The evidence may be the same. The explanation has to respect the risk each person carries.
+
+That is influence before impact.
+
+Influence is not manipulation. It is the work of making evidence legible. It is saying, "Here is the problem, here is what we know, here is what we do not know, here is the risk, here is the next decision."
+
+This is where a lot of AI advice gets too shallow. It focuses on writing the message. The harder work is understanding why the message needs to land differently in each room.
+
+For this module, you will map one product decision across four stakeholders. For each one, write what they care about, what risk they carry, what evidence they need, and what question they are probably asking but may not say out loud.
+
+That map will make the decision more honest.
+
+Product work is not only about having the right answer.
+
+It is about creating the conditions where the organization can act on the answer responsibly.
+
+### Video Packet
+
+- **HeyGen avatar:** Teach decision theater and influence-before-impact.
+- **ElevenLabs option:** Narrate a stakeholder-map animation.
+- **Remotion/HyperFrames composition:** Visible work layer, hidden dynamics layer, stakeholder evidence map.
+- **B-roll hints:** `value evidence`, `services`, `proposal`, `admin dashboard`, `campaign review`.
+- **YouTube Shorts cutdown:** "Most product friction is decision friction."
+- **On-screen text:** "Evidence has to be legible to the people carrying risk."
+- **Thumbnail concepts:** "THE HIDDEN PRODUCT WORK"; "DECISION FRICTION"; "WHO CARRIES THE RISK?".
+
+### Worksheet Prompt
+
+Map one product decision across four stakeholders. For each one, name concern, risk, evidence needed, and likely unspoken question.
+
+### Privacy Checklist
+
+Use generic stakeholder roles. Do not expose client names, internal politics, private proposals, or real meeting notes.
+
+## Module 6 - The New Moat
+
+**Book spine:** Chapters 17-25
+**Lesson outcome:** Participants understand why advantage moves to workflow memory, governance, proprietary signal, evals, and agent boundaries.
+**Proof cue:** RAG, n8n workflows, Chat Eval, Module Sync, and agent workflow surfaces.
+
+### Primary Lesson Script Draft
+
+The tools are getting easier to copy.
+
+A chatbot can be cloned. A workflow can be rebuilt. A landing page can be generated. A prompt can be shared. A prototype can be created in an afternoon.
+
+That does not make the work worthless. It changes where the advantage lives.
+
+The advantage moves to the system around the tool.
+
+What does the system know? What data can it safely use? What workflow does it understand? What can it do without permission, and where must it stop? How does it get evaluated? How does it remember failures? How does a human review risky action before it creates harm?
+
+That is the new moat.
+
+In *Accelerated*, this is the shift from isolated AI use to operating systems that learn. Tools matter. Models matter. But the durable value comes from workflow fit, proprietary signal, governance, and product judgment.
+
+AmaduTown is the proof environment for this idea. The public site is only one layer. Behind it are RAG patterns, n8n workflows, evidence dashboards, social content approvals, module sync, evals, and agent operations. The point is not that every piece is finished. The point is that the system is being built around learning, review, and reuse.
+
+That is what makes the work compound.
+
+Agents make this even more important. When an agent can cross systems, use tools, open pages, summarize evidence, and prepare drafts, the boundary has to be explicit. What is it allowed to read? What is it allowed to change? What needs approval? What gets logged? What happens when it is wrong?
+
+Without those boundaries, automation becomes another burden.
+
+With those boundaries, AI can reduce burden while keeping accountability visible.
+
+This module asks you to define the moat around one workflow. Start with the workflow. Then name the proprietary signal, the data boundary, the human approval gate, the evaluation method, and the learning record.
+
+That is the difference between using a tool and building an operating layer.
+
+The tool may help you move faster.
+
+The operating layer helps you get better.
+
+### Video Packet
+
+- **HeyGen avatar:** Teach the new moat and governance frame.
+- **ElevenLabs option:** Use for a diagram-led lesson with an enterprise AI moat stack.
+- **Remotion/HyperFrames composition:** Stack visual: tools, models, agents, workflows, data, governance, evals, judgment.
+- **B-roll hints:** `rag chatbot`, `n8n workflows`, `chat eval`, `module sync`, `agent ops`, `content intelligence`.
+- **YouTube Shorts cutdown:** "The tool is easy to copy. The learning system is not."
+- **On-screen text:** "Workflow memory + governance + evals + judgment"
+- **Thumbnail concepts:** "THE NEW AI MOAT"; "TOOLS ARE EASY TO COPY"; "BUILD THE OPERATING LAYER".
+
+### Worksheet Prompt
+
+Choose one workflow. Define its signal, data boundary, approval gate, evaluation method, and learning record.
+
+### Privacy Checklist
+
+Use diagrams or sanitized workflow screenshots. Never show secrets, webhook URLs, private payloads, raw RAG context, or provider credentials.
+
+## Module 7 - Build Your Learning Loop
+
+**Book spine:** Chapter 26
+**Lesson outcome:** Participants leave with a one-week product learning loop they can apply immediately.
+**Proof cue:** One-page operating system: signal, decision, loop, metric, next action.
+
+### Primary Lesson Script Draft
+
+This course ends where the work begins.
+
+You do not need a giant AI transformation program to apply *Accelerated*. You need one decision, one signal, one loop, and one honest review.
+
+Start small.
+
+Pick a product decision your team is carrying right now. It could be a feature decision, a workflow decision, a content decision, an onboarding decision, or an automation decision.
+
+Write it plainly.
+
+Then name the signal. What evidence would help the team make that decision responsibly? Customer behavior? Support volume? Interview patterns? Staff time? Cost? Error rate? Conversion? Quality review?
+
+Next, define the loop. How will the signal enter the system? Who reviews it? What can AI help summarize or draft? Where does human judgment enter? What decision follows?
+
+Then instrument the learning. Choose one metric or review artifact that will tell you whether the decision improved anything.
+
+This is the operating system in its simplest form.
+
+Find the signal. Define the decision. Build the loop. Instrument the learning.
+
+That frame is intentionally small because small systems reveal the truth. If you cannot make one decision more evidence-driven, a bigger transformation will only hide the confusion behind more tooling.
+
+The AmaduTown proof is the work you have seen throughout the course. The diagnostic flow structures intake. The evidence pipeline turns raw input into reviewable signal. The content intelligence system turns insights into channel-specific drafts. The approval gates keep risky actions from firing without human review. The b-roll and video systems prepare assets without automatically publishing them.
+
+All of that points to the same principle.
+
+AI should reduce burden and increase learning. If it only creates more artifacts, the system is not done.
+
+Your capstone is to create a one-week loop.
+
+Day one: name the decision.
+
+Day two: gather the signal.
+
+Day three: let AI help organize the evidence.
+
+Day four: review the recommendation.
+
+Day five: make the decision and record what you expect to learn.
+
+After the week ends, look back. Did the loop make the decision clearer? Did it reduce burden? Did it surface risk earlier? Did it preserve judgment?
+
+That is how the work compounds.
+
+Not through more output.
+
+Through captured learning.
+
+### Video Packet
+
+- **HeyGen avatar:** Capstone walkthrough and closing invitation.
+- **ElevenLabs option:** Narrate the one-week worksheet as a downloadable guided exercise.
+- **Remotion/HyperFrames composition:** One-week loop calendar, proof montage, final operating-system card.
+- **B-roll hints:** `tools audit`, `value evidence`, `content intelligence`, `social insight review`, `agent approvals`.
+- **YouTube Shorts cutdown:** "One decision. One signal. One loop. One honest review."
+- **On-screen text:** "Find the signal. Define the decision. Build the loop. Instrument the learning."
+- **Thumbnail concepts:** "BUILD YOUR LEARNING LOOP"; "ONE WEEK TO BETTER PRODUCT WORK"; "STOP LOSING THE LESSON".
+
+### Worksheet Prompt
+
+Create a one-week learning loop for one decision. Include signal, AI support, human review, metric, and next decision.
+
+### Privacy Checklist
+
+Use only public-safe or synthetic examples in the capstone. Any internal workflow proof must pass visual redaction before render.
+
+## Course-Level Approval Gates
+
+- **Draft review:** Module content, exercises, proof cues, and scripts are reviewed for clarity and voice.
+- **Privacy review:** Every screenshot, clip, and b-roll asset is inspected and redacted before use.
+- **Render readiness:** HeyGen/ElevenLabs/Remotion/HyperFrames are checked without provider execution unless explicitly approved.
+- **Final approval:** Rendered videos are reviewed before upload, scheduling, publishing, or platform draft handoff.
+
+## Routing Into Existing Video Workflow
+
+Each module packet can be converted into a video idea queue item with:
+
+- `title`: module title,
+- `script`: primary lesson script draft,
+- `storyboard.scenes`: proof cue, framework visual, b-roll, worksheet, close,
+- `brollHint`: matching route keyword from the packet,
+- `channel`: `youtube`,
+- `scriptSource`: `campaign` or `manual`,
+- `targetType`: `campaign`.
+
+Use render-readiness first. Do not call provider generation until the module has explicit human approval.

--- a/docs/accelerated-course-modules/review-status.json
+++ b/docs/accelerated-course-modules/review-status.json
@@ -1,0 +1,88 @@
+{
+  "course": "Accelerated: Build Faster Without Losing the Plot",
+  "shape": "flagship_mini_course",
+  "default_video_style": "heygen_avatar_plus_broll",
+  "provider_execution_status": "locked_until_explicit_approval",
+  "modules": [
+    {
+      "id": "module-0",
+      "title": "Why Accelerated Exists",
+      "review_status": "draft",
+      "render_status": "not_started",
+      "primary_video_status": "script_ready_for_review",
+      "shorts_status": "draft",
+      "thumbnail_status": "draft",
+      "privacy_status": "needs_screen_review"
+    },
+    {
+      "id": "module-1",
+      "title": "The Speed Trap",
+      "review_status": "draft",
+      "render_status": "not_started",
+      "primary_video_status": "script_ready_for_review",
+      "shorts_status": "draft",
+      "thumbnail_status": "draft",
+      "privacy_status": "needs_screen_review"
+    },
+    {
+      "id": "module-2",
+      "title": "Decision-First Discovery",
+      "review_status": "draft",
+      "render_status": "not_started",
+      "primary_video_status": "script_ready_for_review",
+      "shorts_status": "draft",
+      "thumbnail_status": "draft",
+      "privacy_status": "needs_screen_review"
+    },
+    {
+      "id": "module-3",
+      "title": "Feedback Becomes Signal",
+      "review_status": "draft",
+      "render_status": "not_started",
+      "primary_video_status": "script_ready_for_review",
+      "shorts_status": "draft",
+      "thumbnail_status": "draft",
+      "privacy_status": "needs_screen_review"
+    },
+    {
+      "id": "module-4",
+      "title": "Roadmaps That Learn",
+      "review_status": "draft",
+      "render_status": "not_started",
+      "primary_video_status": "script_ready_for_review",
+      "shorts_status": "draft",
+      "thumbnail_status": "draft",
+      "privacy_status": "needs_screen_review"
+    },
+    {
+      "id": "module-5",
+      "title": "The Decision Theater",
+      "review_status": "draft",
+      "render_status": "not_started",
+      "primary_video_status": "script_ready_for_review",
+      "shorts_status": "draft",
+      "thumbnail_status": "draft",
+      "privacy_status": "needs_screen_review"
+    },
+    {
+      "id": "module-6",
+      "title": "The New Moat",
+      "review_status": "draft",
+      "render_status": "not_started",
+      "primary_video_status": "script_ready_for_review",
+      "shorts_status": "draft",
+      "thumbnail_status": "draft",
+      "privacy_status": "needs_screen_review"
+    },
+    {
+      "id": "module-7",
+      "title": "Build Your Learning Loop",
+      "review_status": "draft",
+      "render_status": "not_started",
+      "primary_video_status": "script_ready_for_review",
+      "shorts_status": "draft",
+      "thumbnail_status": "draft",
+      "privacy_status": "needs_screen_review"
+    }
+  ]
+}

--- a/docs/accelerated-course-modules/source-register.md
+++ b/docs/accelerated-course-modules/source-register.md
@@ -1,0 +1,57 @@
+# Accelerated Course Source Register
+
+This register separates public-facing course material from private-derived voice guidance and internal proof sources.
+
+## Primary Course Sources
+
+- Existing course kit: `/Users/vambahsillah/Documents/Codex/2026-04-30/i-need-you-to-help-me/accelerated-course-kit/`
+- Workshop slide spine: `deck/slide-outline.md`
+- Facilitator timing and talk track: `facilitator-guide/run-of-show.md`
+- Demo proof map: `demos/amadutown-demo-map.md`
+- Book source: `/Users/vambahsillah/Projects/Portfolio/accelerated_ebook_leadmagnet.epub`
+
+## Voice Sources
+
+Use these for voice, rhythm, and framing. Do not quote private exports.
+
+- `/Users/vambahsillah/Documents/Codex/2026-04-30/i-have-quite-a-bit-of/personality-corpus/agent-exports/core/personality_pack.md`
+- `/Users/vambahsillah/Documents/Codex/2026-04-30/i-have-quite-a-bit-of/personality-corpus/voice_and_style_guide.md`
+- `/Users/vambahsillah/Documents/Codex/2026-04-30/i-have-quite-a-bit-of/personality-corpus/personality_profile.md`
+- `/Users/vambahsillah/Documents/Codex/2026-04-30/i-have-quite-a-bit-of/personality-corpus/corpus_index.jsonl`
+- `/Users/vambahsillah/Projects/Portfolio/docs/linkedin-voice.md`
+
+## Video Production Sources
+
+- HeyGen config and job routes: `app/api/admin/video-generation/`
+- Video ideas queue and render-readiness routes: `app/api/admin/video-generation/ideas-queue/`
+- B-roll capture utilities: `scripts/capture-storyboard-assets.ts`, `lib/playtest-broll.ts`
+- AmaduTown logo: `public/amadutown-logo-upscaled.png`
+
+## Public Industry Evidence
+
+Use sparingly. The course should stay practical and product-led.
+
+- Stanford HAI AI Index reports.
+- McKinsey State of AI reports.
+- Linux Foundation open-source reports.
+- Gartner agentic AI project cancellation forecast.
+- Menlo Ventures enterprise generative AI reporting.
+
+## Privacy Boundary
+
+Allowed in public course scripts:
+
+- public AmaduTown positioning,
+- public-safe product and portfolio proof,
+- generalized lessons from Vambah's product and builder experience,
+- screenshots or clips that have passed review.
+
+Not allowed without explicit review:
+
+- private chat exports,
+- raw Chronicle notes,
+- meeting transcripts,
+- client names or project details,
+- family-sensitive material,
+- internal account IDs,
+- secrets, tokens, webhook URLs, or private provider data.

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "mobile-foundry:analyze": "tsx scripts/mobile-app-foundry-analyze.ts",
     "mobile-foundry:prototype-packet": "tsx scripts/mobile-app-foundry-prototype-packet.ts",
     "mobile-foundry:commercialization-packet": "tsx scripts/mobile-app-foundry-commercialization-packet.ts",
+    "course:accelerated:validate": "tsx scripts/validate-accelerated-course-modules.ts",
     "client:seed-mark-reversr": "tsx scripts/seed-mark-reversr-build-evidence.ts",
     "client:seed-mark-reversr-assessment": "tsx scripts/seed-mark-reversr-assessment.ts",
     "open-brain:mcp": "tsx scripts/open-brain-mcp-server.ts",

--- a/scripts/validate-accelerated-course-modules.ts
+++ b/scripts/validate-accelerated-course-modules.ts
@@ -1,0 +1,76 @@
+import fs from 'fs'
+import path from 'path'
+
+const root = process.cwd()
+const packetPath = path.join(root, 'docs', 'accelerated-course-modules', 'module-production-packets.md')
+const statusPath = path.join(root, 'docs', 'accelerated-course-modules', 'review-status.json')
+const brollPath = path.join(root, 'docs', 'accelerated-course-modules', 'broll-capture-list.md')
+const sourcePath = path.join(root, 'docs', 'accelerated-course-modules', 'source-register.md')
+
+function read(filePath: string) {
+  return fs.readFileSync(filePath, 'utf8')
+}
+
+function assert(condition: unknown, message: string) {
+  if (!condition) {
+    throw new Error(message)
+  }
+}
+
+const packet = read(packetPath)
+const broll = read(brollPath)
+const source = read(sourcePath)
+const status = JSON.parse(read(statusPath)) as {
+  provider_execution_status?: string
+  modules?: Array<Record<string, string>>
+}
+
+const moduleMatches = [...packet.matchAll(/^## Module ([0-7]) - (.+)$/gm)]
+assert(moduleMatches.length === 8, `Expected 8 module sections; found ${moduleMatches.length}`)
+
+for (let index = 0; index < moduleMatches.length; index += 1) {
+  const current = moduleMatches[index]
+  const next = moduleMatches[index + 1]
+  const moduleNumber = current[1]
+  const title = current[2]
+  const start = current.index ?? 0
+  const end = next?.index ?? packet.length
+  const section = packet.slice(start, end)
+
+  assert(moduleNumber === String(index), `Expected Module ${index}; found Module ${moduleNumber}`)
+  assert(section.includes('**Book spine:**'), `Module ${index} missing book spine`)
+  assert(section.includes('**Lesson outcome:**'), `Module ${index} missing lesson outcome`)
+  assert(section.includes('**Proof cue:**'), `Module ${index} missing proof cue`)
+  assert(section.includes('### Primary Lesson Script Draft'), `Module ${index} missing lesson script`)
+  assert(section.includes('### Video Packet'), `Module ${index} missing video packet`)
+  assert(section.includes('HeyGen'), `Module ${index} missing HeyGen direction`)
+  assert(section.includes('ElevenLabs'), `Module ${index} missing ElevenLabs option`)
+  assert(section.includes('Remotion/HyperFrames'), `Module ${index} missing composition direction`)
+  assert(section.includes('YouTube Shorts cutdown'), `Module ${index} missing Shorts cutdown`)
+  assert(section.includes('Thumbnail concepts'), `Module ${index} missing thumbnail concepts`)
+  assert(section.includes('### Worksheet Prompt'), `Module ${index} missing worksheet prompt`)
+  assert(section.includes('### Privacy Checklist'), `Module ${index} missing privacy checklist`)
+  assert(title.trim().length > 0, `Module ${index} title is empty`)
+}
+
+assert(status.provider_execution_status === 'locked_until_explicit_approval', 'Provider execution must stay locked')
+assert(Array.isArray(status.modules) && status.modules.length === 8, 'review-status.json must contain 8 modules')
+for (const moduleStatus of status.modules ?? []) {
+  assert(moduleStatus.review_status === 'draft', `${moduleStatus.id} review_status must be draft`)
+  assert(moduleStatus.render_status === 'not_started', `${moduleStatus.id} render_status must be not_started`)
+  assert(moduleStatus.privacy_status === 'needs_screen_review', `${moduleStatus.id} privacy_status must require screen review`)
+}
+
+for (const expected of ['HeyGen', 'ElevenLabs', 'Remotion', 'HyperFrames', 'B-roll capture']) {
+  assert(packet.includes(expected) || source.includes(expected), `Missing production stack reference: ${expected}`)
+}
+
+for (const route of ['/tools/audit', '/admin/value-evidence', '/admin/chat-eval', '/admin/module-sync']) {
+  assert(broll.includes(route), `B-roll list missing route ${route}`)
+}
+
+for (const forbidden of ['Provider calls, uploads, rendering, scheduling, and publishing remain locked', 'Do not call provider generation']) {
+  assert(packet.includes(forbidden), `Missing safety boundary text: ${forbidden}`)
+}
+
+console.log('Accelerated course module package validated: 8 modules, video packets, proof cues, exercises, and safety gates present.')


### PR DESCRIPTION
## Summary
- Adds a repo-backed Accelerated flagship mini-course production package with 8 module review packets.
- Includes lesson scripts, proof cues, worksheet prompts, b-roll guidance, YouTube Shorts cutdowns, thumbnail concepts, source boundaries, and review status metadata.
- Adds a validator and npm script to confirm modules, video packet fields, exercises, proof cues, and provider safety gates remain present.

## Validation
- PATH=/Users/vambahsillah/Projects/Portfolio/node_modules/.bin:$PATH npm run course:accelerated:validate
- /Users/vambahsillah/Projects/Portfolio/node_modules/.bin/tsc --noEmit --pretty false --target ES2022 --module NodeNext --moduleResolution NodeNext --types node --typeRoots /Users/vambahsillah/Projects/Portfolio/node_modules/@types scripts/validate-accelerated-course-modules.ts
- git diff --cached --check
- Full npx tsc --noEmit was not usable in this isolated worktree because it has no local node_modules; the standalone validator was typechecked against the root checkout's installed TypeScript/types.

## Integration Notes
- Documentation and validation script only; no migrations or env changes.
- No HeyGen, ElevenLabs, Remotion, HyperFrames, n8n, uploads, scheduling, publishing, or provider execution was run.
- Vercel contexts were not checked by this non-captain branch:
  - Vercel – portfolio: not checked
  - Vercel – portfolio-staging: not checked