### PR TITLE
docs: add accelerated module zero video assets

### DIFF
--- a/docs/accelerated-course-modules/README.md
+++ b/docs/accelerated-course-modules/README.md
@@ -29,6 +29,7 @@ Provider execution is locked until separately approved. These files prepare revi
 - `broll-capture-list.md` - reusable capture list and privacy rules.
 - `source-register.md` - source, voice, and safety provenance.
 - `review-status.json` - machine-checkable review status per module.
+- `module-0-video-assets/` - the first approved local video asset packet, ready for render preflight.
 
 ## Validation
 

--- a/docs/accelerated-course-modules/module-0-video-assets/README.md
+++ b/docs/accelerated-course-modules/module-0-video-assets/README.md
@@ -1,0 +1,49 @@
+# Module 0 Approved Video Asset Packet
+
+Module: `module-0`
+Title: `Why Accelerated Exists`
+Approval scope: course content and local video asset packet only
+Status: approved for render preflight
+External execution: locked
+
+This packet contains the first approved module video assets for the Accelerated mini-course. It is ready to route into the existing video-generation review workflow, but it does not authorize provider execution.
+
+## Included Assets
+
+- `primary-lesson-script.md` - final 6-10 minute lesson script.
+- `heygen-segments.md` - avatar-ready intro, bridge, and close segments.
+- `elevenlabs-narration.md` - narration-safe version for audio or slide-first render.
+- `storyboard-render-spec.md` - Remotion/HyperFrames scene plan and b-roll mapping.
+- `render-handoff-checklist.md` - explicit bridge into the existing video-generation workflow.
+- `shorts-package.md` - 30-60 second YouTube Shorts asset packet.
+- `thumbnail-briefs.md` - three thumbnail concepts adapted to AmaduTown style.
+- `worksheet.md` - learner worksheet prompt and facilitator review notes.
+- `privacy-qa.md` - privacy and redaction review checklist.
+- `asset-manifest.json` - machine-readable routing manifest.
+- `captions/module-0-primary.srt` - draft caption file for primary lesson.
+- `visual-assets/title-card.svg` - local title-card source asset.
+- `visual-assets/closing-card.svg` - local closing-card source asset.
+
+## Safety Boundary
+
+Allowed by this packet:
+
+- local review,
+- render-readiness preflight,
+- b-roll planning,
+- storyboard planning,
+- video-generation workflow handoff planning,
+- provider configuration check without job creation.
+
+Not allowed by this packet:
+
+- HeyGen generation,
+- ElevenLabs generation,
+- Remotion/HyperFrames final render,
+- n8n workflow execution,
+- uploads,
+- scheduling,
+- publishing,
+- external platform draft creation.
+
+Those actions require a separate human approval gate.

--- a/docs/accelerated-course-modules/module-0-video-assets/asset-manifest.json
+++ b/docs/accelerated-course-modules/module-0-video-assets/asset-manifest.json
@@ -1,0 +1,59 @@
+{
+  "module_id": "module-0",
+  "module_title": "Why Accelerated Exists",
+  "course": "Accelerated: Build Faster Without Losing the Plot",
+  "asset_packet_status": "approved_for_render_preflight",
+  "approval_scope": "course_content_and_local_video_asset_packet_only",
+  "provider_execution_status": "locked_until_explicit_approval",
+  "target_outputs": {
+    "primary_lesson": {
+      "format": "16:9",
+      "target_duration_minutes": [6, 10],
+      "script": "primary-lesson-script.md",
+      "captions": "captions/module-0-primary.srt",
+      "storyboard": "storyboard-render-spec.md"
+    },
+    "youtube_short": {
+      "format": "9:16",
+      "target_duration_seconds": [30, 60],
+      "packet": "shorts-package.md"
+    },
+    "thumbnail": {
+      "concept_count": 3,
+      "brief": "thumbnail-briefs.md"
+    },
+    "worksheet": {
+      "packet": "worksheet.md"
+    }
+  },
+  "provider_assets": {
+    "heygen_segments": "heygen-segments.md",
+    "elevenlabs_narration": "elevenlabs-narration.md",
+    "remotion_hyperframes_spec": "storyboard-render-spec.md",
+    "render_handoff_checklist": "render-handoff-checklist.md"
+  },
+  "local_visual_assets": [
+    "visual-assets/title-card.svg",
+    "visual-assets/closing-card.svg"
+  ],
+  "safety": {
+    "allowed_now": [
+      "local_review",
+      "render_readiness_preflight",
+      "broll_planning",
+      "storyboard_planning",
+      "video_generation_workflow_handoff_planning"
+    ],
+    "blocked_until_separate_approval": [
+      "heygen_generation",
+      "elevenlabs_generation",
+      "final_render",
+      "n8n_execution",
+      "upload",
+      "schedule",
+      "publish",
+      "external_platform_draft_creation"
+    ],
+    "privacy_review_required_before_render": true
+  }
+}

--- a/docs/accelerated-course-modules/module-0-video-assets/captions/module-0-primary.srt
+++ b/docs/accelerated-course-modules/module-0-video-assets/captions/module-0-primary.srt
@@ -1,0 +1,59 @@
+1
+00:00:00,000 --> 00:00:05,000
+Anyone can ask AI for a roadmap now.
+
+2
+00:00:05,000 --> 00:00:12,000
+A PRD. A persona. A launch plan. A prototype.
+
+3
+00:00:12,000 --> 00:00:18,000
+In a few minutes, something shows up that looks like product work.
+
+4
+00:00:18,000 --> 00:00:25,000
+The blank page is not the bottleneck anymore. The bottleneck is judgment.
+
+5
+00:00:25,000 --> 00:00:34,000
+That is why Accelerated exists. AI makes product judgment more important.
+
+6
+00:00:34,000 --> 00:00:44,000
+The tool can help draft options, questions, summaries, risks, and patterns.
+
+7
+00:00:44,000 --> 00:00:53,000
+The human still owns context, judgment, consent, and consequence.
+
+8
+00:00:53,000 --> 00:01:04,000
+Inside AmaduTown, the public site is only one layer.
+
+9
+00:01:04,000 --> 00:01:15,000
+Behind it are diagnostic flows, evidence dashboards, approval gates, and render-readiness checks.
+
+10
+00:01:15,000 --> 00:01:25,000
+The system has to remember what happened after it moved.
+
+11
+00:01:25,000 --> 00:01:34,000
+Find the signal. Define the decision. Build the loop. Instrument the learning.
+
+12
+00:01:34,000 --> 00:01:45,000
+That loop is the difference between moving fast and moving blindly.
+
+13
+00:01:45,000 --> 00:01:55,000
+Technology should reduce burden. It should not create more invisible work.
+
+14
+00:01:55,000 --> 00:02:05,000
+Move fast to discover. Slow down where the decision carries risk.
+
+15
+00:02:05,000 --> 00:02:16,000
+What is the system learning from all of that speed?

--- a/docs/accelerated-course-modules/module-0-video-assets/elevenlabs-narration.md
+++ b/docs/accelerated-course-modules/module-0-video-assets/elevenlabs-narration.md
@@ -1,0 +1,87 @@
+# Module 0 ElevenLabs Narration Packet
+
+Status: approved for render preflight
+Provider execution: locked until explicit approval
+
+Use this narration path if Module 0 is produced as a slide-first or audio-first lesson. It is adapted from the primary script with less direct-to-camera phrasing and clearer visual beats.
+
+## Narration Direction
+
+- Voice: grounded, reflective, practical.
+- Pace: measured, with room between the short operating-loop lines.
+- Avoid overly dramatic trailer delivery.
+- Keep the tone closer to a product leader explaining a hard lesson than a keynote promo.
+
+## Narration Script
+
+Anyone can ask AI for a roadmap now.
+
+The tool can draft a PRD, a persona, a stakeholder map, a launch plan, a prototype, or a set of user stories in minutes.
+
+That changes the work.
+
+The blank page used to slow teams down. Now the artifact can arrive before the thinking is finished.
+
+That speed is useful. It can also create a new burden.
+
+Teams can make more drafts than they can review, more concepts than they can test, more workflows than they can govern, and more output than the organization can learn from.
+
+That is the reason *Accelerated* exists.
+
+The book does not argue that AI replaces product judgment. It argues that AI makes judgment more important.
+
+When the first version gets cheap, the expensive work moves to the questions behind the artifact.
+
+What problem deserves attention?
+
+What evidence do we trust?
+
+What decision are we trying to make?
+
+What risk are we introducing?
+
+Who carries the consequence if the system gets it wrong?
+
+Inside AmaduTown, that question is not theoretical. The public site is only one layer. Behind it are diagnostic flows, evidence dashboards, content approval gates, agent workflows, review packets, b-roll capture plans, and render-readiness checks.
+
+The operating layer matters because product work does not end when something gets created.
+
+The system has to remember what happened after it moved.
+
+This course is built around a simple loop.
+
+Find the signal.
+
+Define the decision.
+
+Build the loop.
+
+Instrument the learning.
+
+Signal tells the team what evidence matters.
+
+Decision names the choice the evidence should improve.
+
+Loop keeps the signal from living only in someone's memory.
+
+Learning gives the team a record of what changed.
+
+That is the difference between moving fast and moving blindly.
+
+Technology should reduce burden. It should not create more invisible work for people who were already overloaded. It should not make teams pretend speed and progress are the same thing.
+
+The product leader's job is to keep the work honest.
+
+Move fast to discover.
+
+Slow down where the decision carries risk.
+
+Capture what the system learns.
+
+So start with one place where your team is already moving fast.
+
+Then ask the question most teams skip:
+
+What is the system learning from all of that speed?
+
+If the answer is unclear, the work is not done.

--- a/docs/accelerated-course-modules/module-0-video-assets/heygen-segments.md
+++ b/docs/accelerated-course-modules/module-0-video-assets/heygen-segments.md
@@ -1,0 +1,66 @@
+# Module 0 HeyGen Segment Scripts
+
+Status: approved for render preflight
+Provider execution: locked until explicit approval
+
+Use these as discrete avatar clips that can be composited with b-roll in Remotion or HyperFrames. Keep the avatar framed cleanly with AmaduTown visual treatment. Do not generate these clips until the provider approval gate is granted.
+
+## Segment A - Opening Hook
+
+Target duration: 35-45 seconds
+
+Anyone can ask AI for a roadmap now.
+
+A PRD. A persona. A launch plan. A prototype. In a few minutes, something appears that looks like product work.
+
+That is useful. I use these tools every day.
+
+But the blank page is not the bottleneck anymore.
+
+The bottleneck is judgment.
+
+That is why *Accelerated* exists. This course is about using AI speed without losing the product discipline that makes the work safe, useful, and worth building.
+
+## Segment B - Course Frame
+
+Target duration: 55-70 seconds
+
+AI can help generate options, questions, summaries, risks, and first drafts.
+
+The human still owns context, judgment, consent, and consequence.
+
+Inside AmaduTown, I am building against that exact tension. The public site is one layer. Behind it are diagnostic flows, evidence dashboards, content approval gates, agent workflows, review packets, b-roll plans, and render-readiness checks.
+
+The operating layer matters because the work does not end when the artifact gets created.
+
+The system has to remember what happened after it moved.
+
+## Segment C - Operating Loop
+
+Target duration: 45-60 seconds
+
+The course comes back to one operating loop.
+
+Find the signal.
+
+Define the decision.
+
+Build the loop.
+
+Instrument the learning.
+
+That loop is the difference between moving fast and moving blindly. It gives the team a way to turn AI output into accountable product learning.
+
+## Segment D - Closing Question
+
+Target duration: 25-35 seconds
+
+Start with one place where your team is already moving fast.
+
+Maybe AI is drafting content. Maybe prototypes are easier to build. Maybe meetings are being summarized. Maybe workflows are getting automated.
+
+Then ask the question most teams skip:
+
+What is the system learning from all of that speed?
+
+If the answer is unclear, the work is not done.

--- a/docs/accelerated-course-modules/module-0-video-assets/primary-lesson-script.md
+++ b/docs/accelerated-course-modules/module-0-video-assets/primary-lesson-script.md
@@ -1,0 +1,141 @@
+# Module 0 Primary Lesson Script
+
+Title: Why Accelerated Exists
+Target length: 6-10 minutes
+Video style: HeyGen avatar plus AmaduTown/Portfolio b-roll
+Status: approved for render preflight
+
+## Script
+
+Anyone can ask AI for a roadmap now.
+
+You can ask for a PRD, a persona, a stakeholder map, a launch plan, a prototype, or a list of user stories. In a few minutes, something shows up that looks like product work.
+
+That changes the room.
+
+The blank page used to slow us down. It was annoying, but it forced a certain kind of thinking. You had to sit with the problem long enough to make choices. You had to decide what mattered before the artifact existed.
+
+Now the artifact can arrive before the thinking is finished.
+
+That is useful. I use these tools every day. A lot of what I have built for AmaduTown started with AI helping me get a rough draft out of my head and onto the screen.
+
+But speed creates a new kind of burden.
+
+Product teams can now make more drafts than they can review. More concepts than they can test. More workflows than they can govern. More content than they can explain. More output than the organization can learn from.
+
+That is the reason *Accelerated* exists.
+
+The book is not a pitch for replacing product judgment with AI. It is a warning that AI makes judgment more important. When the first version gets cheap, the expensive work moves somewhere else.
+
+It moves to the questions behind the work.
+
+What problem deserves attention?
+
+What evidence do we trust?
+
+What decision are we trying to make?
+
+What risk are we introducing?
+
+Who has to carry the consequence if this system gets it wrong?
+
+What did we learn the last time we tried something similar?
+
+Those questions do not disappear because the tool got faster. They become easier to avoid.
+
+That is the trap.
+
+The screen fills up. The document looks polished. The prototype moves. The meeting has something to react to. Everyone feels like progress happened.
+
+Then a week later, the team is still arguing about the same decision because the artifact never answered the real question.
+
+So this course starts with a different frame.
+
+AI speed only helps when it is connected to product discipline.
+
+That means the tool can help generate options, questions, drafts, summaries, risks, and patterns. The human still owns context, judgment, consent, and consequence.
+
+I want to make that practical.
+
+Inside AmaduTown, I am not only talking about this. I am building against it. The public website is one layer. Behind it are diagnostic flows, evidence dashboards, content approval gates, agent workflows, review packets, b-roll capture plans, and render-readiness checks.
+
+Some of it is polished. Some of it is still rough. That is part of the point.
+
+The operating layer matters because the work does not end when an artifact gets created.
+
+The system has to remember what happened after it moved.
+
+If a diagnostic intake collects a pain point, where does that signal go?
+
+If a social post draft gets revised, where does that feedback live?
+
+If an agent prepares a video asset, what stops it from publishing before a human reviews the privacy risk?
+
+If a dashboard shows activity, what decision does that activity change?
+
+Those are product questions.
+
+And once AI enters the workflow, they become governance questions too.
+
+That is why this mini-course is structured around a simple operating loop.
+
+Find the signal.
+
+Define the decision.
+
+Build the loop.
+
+Instrument the learning.
+
+That loop is the difference between moving fast and moving blindly.
+
+Signal means the team knows what evidence matters. It may be customer behavior, staff time, conversion, cost, support volume, quality review, or the pattern inside a set of conversations.
+
+Decision means the team can say what choice the evidence is supposed to improve. Build this. Stop that. Test this segment. Delay this automation. Change this onboarding step.
+
+Loop means the signal does not live in someone's memory. It enters a workflow. It gets reviewed. It changes a recommendation. It creates a record.
+
+Learning means the team can look back and say what changed because of the decision.
+
+That is what I want participants to leave with.
+
+Not a pile of AI prompts.
+
+A way to make product work lighter, clearer, and more accountable.
+
+There is a moral piece to this too.
+
+Technology should reduce burden. It should not dump more invisible work on the same people who were already overloaded. It should not make teams pretend that speed and progress are the same thing. It should not create systems that act with confidence but cannot explain themselves.
+
+The product leader's job is to keep the work honest.
+
+That does not mean slowing everything down until nothing ships. It means creating the right friction in the right place.
+
+Move fast to discover.
+
+Slow down where the decision carries risk.
+
+Capture what the system learns.
+
+This first module sets the frame for the rest of the course. In the next modules, we will move through discovery, feedback, roadmaps, decision theater, the new moat, and the one-week learning loop you can build around a real product decision.
+
+But before any of that, start here.
+
+Look at one place where your team is already moving fast.
+
+Maybe AI is drafting content. Maybe prototypes are easier to build. Maybe meetings are being summarized. Maybe workflows are getting automated. Maybe people are generating strategy docs that used to take weeks.
+
+Then ask the question most teams skip:
+
+What is the system learning from all of that speed?
+
+If the answer is unclear, the work is not done.
+
+That is where *Accelerated* begins.
+
+## Voice Review
+
+- Grounded in Vambah's product-builder voice.
+- Keeps AI practical, not hype-driven.
+- Preserves the moral frame: speed must reduce burden and preserve accountability.
+- Avoids raw private details, client details, and private chat quotes.

--- a/docs/accelerated-course-modules/module-0-video-assets/privacy-qa.md
+++ b/docs/accelerated-course-modules/module-0-video-assets/privacy-qa.md
@@ -1,0 +1,34 @@
+# Module 0 Privacy And QA Checklist
+
+Status: approved asset packet; capture review still required before render
+
+## Approved Source Types
+
+- Public AmaduTown pages.
+- Public Accelerated product, ebook, or publication surfaces.
+- Locally authored course diagrams.
+- Sanitized admin screens with demo or cropped data.
+
+## Blocked Source Types
+
+- Raw Chronicle notes.
+- Private meeting transcripts.
+- Private ChatGPT or Claude exports.
+- Client names, project details, emails, phone numbers, account IDs, or private records.
+- Provider dashboards showing quota, billing, API keys, webhook URLs, or account identifiers.
+- Unredacted admin tables.
+
+## QA Gate
+
+Before render:
+
+- confirm every screen recording is public-safe or redacted,
+- confirm the script contains no private quote or private-derived claim,
+- confirm captions match the approved script,
+- confirm visual assets use AmaduTown spelling and logo rules,
+- confirm provider execution remains locked until explicitly approved,
+- confirm no upload, external draft, schedule, or publish row is created.
+
+## Current Decision
+
+The Module 0 content and local assets are approved for render preflight. Provider generation and final rendering are not approved by this packet.

--- a/docs/accelerated-course-modules/module-0-video-assets/render-handoff-checklist.md
+++ b/docs/accelerated-course-modules/module-0-video-assets/render-handoff-checklist.md
@@ -52,4 +52,3 @@ Module 0 can move from `ready_for_render_preflight` to queued render work only w
 - cost/quota risk is accepted,
 - the operator confirms the job is local review only,
 - external upload, scheduling, and publishing remain locked.
-

--- a/docs/accelerated-course-modules/module-0-video-assets/render-handoff-checklist.md
+++ b/docs/accelerated-course-modules/module-0-video-assets/render-handoff-checklist.md
@@ -1,0 +1,55 @@
+# Module 0 Render Handoff Checklist
+
+Status: approved asset packet; render preflight allowed
+Provider execution: locked until explicit approval
+
+This checklist is the bridge from the approved Module 0 asset packet into the existing Portfolio video-generation workflow. It does not authorize HeyGen, ElevenLabs, Remotion, HyperFrames, upload, scheduling, or publishing jobs.
+
+## Target Workflow
+
+- Primary review surface: `/admin/content/video-generation`
+- Course source packet: `docs/accelerated-course-modules/module-0-video-assets`
+- Primary lesson script: `primary-lesson-script.md`
+- Avatar script segments: `heygen-segments.md`
+- Narration option: `elevenlabs-narration.md`
+- Composition spec: `storyboard-render-spec.md`
+- Caption source: `captions/module-0-primary.srt`
+- Thumbnail source: `thumbnail-briefs.md`
+
+## Preflight Steps
+
+1. Open the Module 0 packet and confirm the script, worksheet, Shorts package, thumbnail briefs, and privacy checklist are still approved.
+2. Confirm the selected render mode:
+   - default: HeyGen avatar plus Portfolio/AmaduTown b-roll,
+   - fallback: ElevenLabs narration plus slide-first visuals.
+3. Review all b-roll surfaces before capture. Public pages are allowed; admin screens require crop, redaction, or demo data.
+4. Confirm the title and closing cards render at `1920x1080` and preserve the AmaduTown logo aspect ratio.
+5. Confirm captions are regenerated or manually checked after any script edit.
+6. Confirm no provider job, upload, social draft, schedule, or publish row exists before the explicit render approval.
+
+## Approval Gate Required Before Execution
+
+The next human approval must explicitly name which actions are approved:
+
+- `heygen_generation`
+- `elevenlabs_generation`
+- `broll_capture`
+- `render_preflight`
+- `final_render`
+- `upload`
+- `schedule`
+- `publish`
+
+Approval for one action does not imply approval for the others.
+
+## Ready-To-Queue Criteria
+
+Module 0 can move from `ready_for_render_preflight` to queued render work only when:
+
+- privacy review is passed,
+- b-roll sources are public-safe or redacted,
+- avatar/narration provider choice is confirmed,
+- cost/quota risk is accepted,
+- the operator confirms the job is local review only,
+- external upload, scheduling, and publishing remain locked.
+

--- a/docs/accelerated-course-modules/module-0-video-assets/shorts-package.md
+++ b/docs/accelerated-course-modules/module-0-video-assets/shorts-package.md
@@ -1,0 +1,60 @@
+# Module 0 YouTube Shorts Packet
+
+Status: approved for render preflight
+Provider execution: locked until explicit approval
+
+## Short Title
+
+The Blank Page Is Gone. Judgment Is The Bottleneck.
+
+## Hook
+
+Anyone can ask AI for a roadmap now.
+
+## 45-Second Script
+
+Anyone can ask AI for a roadmap now.
+
+A PRD. A persona. A launch plan. A prototype.
+
+In a few minutes, something appears that looks like product work.
+
+That is useful. I use these tools every day.
+
+But the blank page is not the bottleneck anymore.
+
+The bottleneck is judgment.
+
+AI can help make the first draft. The product leader still has to ask what deserves to exist, what evidence supports it, what risk it creates, and what the system learns after it moves.
+
+That is why I built *Accelerated* around a simple loop:
+
+Find the signal.
+
+Define the decision.
+
+Build the loop.
+
+Instrument the learning.
+
+The question is not whether your team can move faster.
+
+The question is whether the system is learning from all that speed.
+
+## Visual Plan
+
+- 0:00-0:04: Direct-to-camera avatar, text: "Anyone can ask AI for a roadmap now."
+- 0:04-0:12: Rapid artifact cards: PRD, persona, launch plan, prototype.
+- 0:12-0:20: Hard pause, text: "The bottleneck is judgment."
+- 0:20-0:34: Four-part loop cards.
+- 0:34-0:45: Closing question over AmaduTown/Accelerated visual.
+
+## Caption
+
+AI made the first draft cheaper. Product judgment became more important.
+
+Module 0 of Accelerated starts here: speed only matters when the system learns from it.
+
+## Hashtags
+
+#AIProduct #ProductManagement #AmaduTownAdvisory #EnterpriseAI

--- a/docs/accelerated-course-modules/module-0-video-assets/storyboard-render-spec.md
+++ b/docs/accelerated-course-modules/module-0-video-assets/storyboard-render-spec.md
@@ -1,0 +1,45 @@
+# Module 0 Storyboard And Render Spec
+
+Status: approved for render preflight
+Render execution: locked until explicit approval
+
+## Composition Defaults
+
+- Format: 16:9 primary course lesson.
+- Target duration: 6-10 minutes.
+- Visual identity: Imperial Navy, Radiant Gold, Silicon Slate, Platinum White, Gold Light.
+- Logo: `public/amadutown-logo-upscaled.png`, portrait aspect ratio preserved.
+- Captions: use `captions/module-0-primary.srt` as draft caption source.
+- Final render tool: Remotion or HyperFrames.
+
+## Scene Plan
+
+| Scene | Duration | Visual | Audio Source | B-roll / Asset |
+| --- | ---: | --- | --- | --- |
+| 1. Title | 0:00-0:12 | Title card: Why Accelerated Exists | Music bed only or cold open | `visual-assets/title-card.svg` |
+| 2. Hook | 0:12-0:55 | HeyGen avatar opening | HeyGen Segment A | Avatar clip pending provider approval |
+| 3. Artifact Speed | 0:55-1:45 | Animated list: roadmap, PRD, persona, launch plan, prototype | Primary script or narration | Local text animation |
+| 4. Judgment Bottleneck | 1:45-2:45 | Split visual: fast artifacts vs. review gates | Primary script | Course framework visual |
+| 5. AmaduTown Proof | 2:45-4:05 | Public AmaduTown/Accelerated product surface | Primary script | Capture public publication/product surface |
+| 6. Operating Layer | 4:05-5:35 | Diagnostic, evidence, approval, and render-readiness screens | HeyGen Segment B | Public-safe/sanitized b-roll only |
+| 7. The Loop | 5:35-7:10 | Four-part loop animation | HeyGen Segment C or narration | Signal -> Decision -> Loop -> Learning |
+| 8. Moral Frame | 7:10-8:20 | Quiet avatar or text-led cards | Primary script | No private b-roll |
+| 9. Closing Question | 8:20-9:00 | Closing card and avatar close | HeyGen Segment D | `visual-assets/closing-card.svg` |
+
+## B-Roll Capture Requests
+
+Use existing Portfolio capture tooling only after local screen review:
+
+- Public homepage or publication section showing Accelerated.
+- Store/ebook surface if public-safe and current.
+- Public AmaduTown home proof.
+- Sanitized admin proof only if no private rows, identifiers, secrets, or raw notes are visible.
+
+## Render-Readiness Checklist
+
+- Confirm title card and closing card render at 1920x1080.
+- Confirm all avatar clips are optional and can be replaced with narration if HeyGen is unavailable.
+- Confirm b-roll uses public or redacted surfaces only.
+- Confirm captions match the final selected script.
+- Confirm final render has no provider watermark unless intentionally accepted.
+- Confirm no platform upload, draft handoff, or publish job is created during render preflight.

--- a/docs/accelerated-course-modules/module-0-video-assets/thumbnail-briefs.md
+++ b/docs/accelerated-course-modules/module-0-video-assets/thumbnail-briefs.md
@@ -1,0 +1,54 @@
+# Module 0 Thumbnail Briefs
+
+Status: approved for render preflight
+Generation status: local brief only. No image provider call approved.
+
+## Brand Direction
+
+- Background: Imperial Navy with subtle Silicon Slate panels.
+- Accent: Radiant Gold linework and small glow.
+- Logo: AmaduTown shield, natural portrait ratio.
+- Style: mature course/product strategy, not hype thumbnail.
+- Avoid: generic robot imagery, neon overload, fake urgency, copied creator thumbnail styles.
+
+## Concept 1 - Judgment Is The Bottleneck
+
+Text:
+
+`JUDGMENT IS THE BOTTLENECK`
+
+Visual:
+
+Two columns. Left column shows fast artifact cards: Roadmap, PRD, Persona, Prototype. Right column shows a single gold review gate labeled Product Judgment.
+
+Why it fits:
+
+This is the strongest course thesis for Module 0.
+
+## Concept 2 - The Blank Page Is Gone
+
+Text:
+
+`THE BLANK PAGE IS GONE`
+
+Visual:
+
+A blank document turns into a stack of AI-generated artifacts. A gold warning line separates the stack from a quiet decision loop.
+
+Why it fits:
+
+This ties directly to the opening hook and Shorts package.
+
+## Concept 3 - Build Faster Without Losing The Plot
+
+Text:
+
+`BUILD FASTER WITHOUT LOSING THE PLOT`
+
+Visual:
+
+AmaduTown shield, Accelerated cover/product cue, and a four-step operating loop: Signal, Decision, Loop, Learning.
+
+Why it fits:
+
+This is the best course-library thumbnail if Module 0 becomes the first visible lesson in a full playlist.

--- a/docs/accelerated-course-modules/module-0-video-assets/visual-assets/closing-card.svg
+++ b/docs/accelerated-course-modules/module-0-video-assets/visual-assets/closing-card.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1920" height="1080" viewBox="0 0 1920 1080" role="img" aria-labelledby="title desc">
+  <title id="title">Accelerated Module 0 closing question</title>
+  <desc id="desc">Closing card asking what the system is learning from AI speed.</desc>
+  <rect width="1920" height="1080" fill="#121E31"/>
+  <rect x="120" y="120" width="1680" height="840" rx="32" fill="#172640" stroke="#D4AF37" stroke-width="4"/>
+  <text x="190" y="260" fill="#F5D060" font-family="Inter, Arial, sans-serif" font-size="34" letter-spacing="7">MODULE 0 REFLECTION</text>
+  <text x="190" y="455" fill="#EAECEE" font-family="Inter, Arial, sans-serif" font-size="82" font-weight="700">What is the system learning</text>
+  <text x="190" y="560" fill="#EAECEE" font-family="Inter, Arial, sans-serif" font-size="82" font-weight="700">from all of that speed?</text>
+  <line x1="190" y1="650" x2="1540" y2="650" stroke="#D4AF37" stroke-width="4"/>
+  <text x="190" y="740" fill="#EAECEE" font-family="Inter, Arial, sans-serif" font-size="40">If the answer is unclear, the work is not done.</text>
+  <text x="190" y="880" fill="#F5D060" font-family="Inter, Arial, sans-serif" font-size="32">Find the signal. Define the decision. Build the loop. Instrument the learning.</text>
+</svg>

--- a/docs/accelerated-course-modules/module-0-video-assets/visual-assets/title-card.svg
+++ b/docs/accelerated-course-modules/module-0-video-assets/visual-assets/title-card.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1920" height="1080" viewBox="0 0 1920 1080" role="img" aria-labelledby="title desc">
+  <title id="title">Accelerated Module 0 title card</title>
+  <desc id="desc">Imperial navy course title card with gold accents for Module 0, Why Accelerated Exists.</desc>
+  <rect width="1920" height="1080" fill="#121E31"/>
+  <rect x="96" y="96" width="1728" height="888" rx="28" fill="#172640" stroke="#D4AF37" stroke-width="4"/>
+  <circle cx="1620" cy="252" r="176" fill="#2C3E50" opacity="0.65"/>
+  <path d="M1450 252h340M1620 82v340" stroke="#D4AF37" stroke-width="3" opacity="0.45"/>
+  <text x="150" y="210" fill="#F5D060" font-family="Inter, Arial, sans-serif" font-size="32" letter-spacing="8">ACCELERATED MINI-COURSE</text>
+  <text x="150" y="405" fill="#EAECEE" font-family="Inter, Arial, sans-serif" font-size="104" font-weight="700">Why Accelerated Exists</text>
+  <text x="150" y="515" fill="#EAECEE" font-family="Inter, Arial, sans-serif" font-size="46">AI speed only matters when learning and judgment keep up.</text>
+  <g transform="translate(150 650)">
+    <rect width="340" height="86" rx="18" fill="#2C3E50" stroke="#D4AF37" stroke-width="3"/>
+    <text x="34" y="55" fill="#F5D060" font-family="Inter, Arial, sans-serif" font-size="30">Signal</text>
+    <rect x="390" width="340" height="86" rx="18" fill="#2C3E50" stroke="#D4AF37" stroke-width="3"/>
+    <text x="424" y="55" fill="#F5D060" font-family="Inter, Arial, sans-serif" font-size="30">Decision</text>
+    <rect x="780" width="340" height="86" rx="18" fill="#2C3E50" stroke="#D4AF37" stroke-width="3"/>
+    <text x="814" y="55" fill="#F5D060" font-family="Inter, Arial, sans-serif" font-size="30">Loop</text>
+    <rect x="1170" width="340" height="86" rx="18" fill="#2C3E50" stroke="#D4AF37" stroke-width="3"/>
+    <text x="1204" y="55" fill="#F5D060" font-family="Inter, Arial, sans-serif" font-size="30">Learning</text>
+  </g>
+  <text x="150" y="910" fill="#EAECEE" font-family="Inter, Arial, sans-serif" font-size="30">AmaduTown Advisory Solutions</text>
+</svg>

--- a/docs/accelerated-course-modules/module-0-video-assets/worksheet.md
+++ b/docs/accelerated-course-modules/module-0-video-assets/worksheet.md
@@ -1,0 +1,43 @@
+# Module 0 Worksheet
+
+Title: Where Are You Moving Fast But Learning Slowly?
+
+## Participant Prompt
+
+Pick one place where your team is already using AI or automation to move faster.
+
+Examples:
+
+- drafting product docs,
+- summarizing meetings,
+- generating social content,
+- prototyping features,
+- routing intake,
+- creating reports,
+- automating follow-up.
+
+Then answer:
+
+1. What artifact or workflow is getting faster?
+2. What decision is that speed supposed to improve?
+3. What evidence tells you whether the output is useful?
+4. Who reviews the work before it affects another person?
+5. Where does the system record what it learned?
+
+## Output
+
+Complete this sentence:
+
+`We are moving faster at __________, but we are still learning slowly about __________.`
+
+Then define the first loop:
+
+- Signal:
+- Decision:
+- Human review gate:
+- Metric or review artifact:
+- Next action:
+
+## Facilitator Review Notes
+
+Look for answers that name a decision, not just an activity. If the participant only names output, ask what choice the output is supposed to change.

--- a/docs/accelerated-course-modules/review-status.json
+++ b/docs/accelerated-course-modules/review-status.json
@@ -7,12 +7,13 @@
     {
       "id": "module-0",
       "title": "Why Accelerated Exists",
-      "review_status": "draft",
-      "render_status": "not_started",
-      "primary_video_status": "script_ready_for_review",
-      "shorts_status": "draft",
-      "thumbnail_status": "draft",
-      "privacy_status": "needs_screen_review"
+      "review_status": "approved",
+      "render_status": "ready_for_render_preflight",
+      "primary_video_status": "approved_asset_packet",
+      "shorts_status": "approved_asset_packet",
+      "thumbnail_status": "approved_asset_packet",
+      "privacy_status": "asset_packet_approved_capture_review_required",
+      "asset_packet_path": "docs/accelerated-course-modules/module-0-video-assets"
     },
     {
       "id": "module-1",

--- a/scripts/validate-accelerated-course-modules.ts
+++ b/scripts/validate-accelerated-course-modules.ts
@@ -6,6 +6,7 @@ const packetPath = path.join(root, 'docs', 'accelerated-course-modules', 'module
 const statusPath = path.join(root, 'docs', 'accelerated-course-modules', 'review-status.json')
 const brollPath = path.join(root, 'docs', 'accelerated-course-modules', 'broll-capture-list.md')
 const sourcePath = path.join(root, 'docs', 'accelerated-course-modules', 'source-register.md')
+const module0AssetDir = path.join(root, 'docs', 'accelerated-course-modules', 'module-0-video-assets')
 
 function read(filePath: string) {
   return fs.readFileSync(filePath, 'utf8')
@@ -23,6 +24,20 @@ const source = read(sourcePath)
 const status = JSON.parse(read(statusPath)) as {
   provider_execution_status?: string
   modules?: Array<Record<string, string>>
+}
+const module0Manifest = JSON.parse(read(path.join(module0AssetDir, 'asset-manifest.json'))) as {
+  module_id?: string
+  asset_packet_status?: string
+  provider_execution_status?: string
+  target_outputs?: Record<string, unknown>
+  provider_assets?: {
+    render_handoff_checklist?: string
+  }
+  safety?: {
+    allowed_now?: string[]
+    blocked_until_separate_approval?: string[]
+    privacy_review_required_before_render?: boolean
+  }
 }
 
 const moduleMatches = [...packet.matchAll(/^## Module ([0-7]) - (.+)$/gm)]
@@ -56,9 +71,50 @@ for (let index = 0; index < moduleMatches.length; index += 1) {
 assert(status.provider_execution_status === 'locked_until_explicit_approval', 'Provider execution must stay locked')
 assert(Array.isArray(status.modules) && status.modules.length === 8, 'review-status.json must contain 8 modules')
 for (const moduleStatus of status.modules ?? []) {
-  assert(moduleStatus.review_status === 'draft', `${moduleStatus.id} review_status must be draft`)
-  assert(moduleStatus.render_status === 'not_started', `${moduleStatus.id} render_status must be not_started`)
-  assert(moduleStatus.privacy_status === 'needs_screen_review', `${moduleStatus.id} privacy_status must require screen review`)
+  if (moduleStatus.id === 'module-0') {
+    assert(moduleStatus.review_status === 'approved', 'module-0 review_status must be approved')
+    assert(moduleStatus.render_status === 'ready_for_render_preflight', 'module-0 must be ready for render preflight')
+    assert(moduleStatus.primary_video_status === 'approved_asset_packet', 'module-0 primary video packet must be approved')
+    assert(moduleStatus.asset_packet_path === 'docs/accelerated-course-modules/module-0-video-assets', 'module-0 asset packet path is missing')
+  } else {
+    assert(moduleStatus.review_status === 'draft', `${moduleStatus.id} review_status must be draft`)
+    assert(moduleStatus.render_status === 'not_started', `${moduleStatus.id} render_status must be not_started`)
+    assert(moduleStatus.privacy_status === 'needs_screen_review', `${moduleStatus.id} privacy_status must require screen review`)
+  }
+}
+
+const module0Files = [
+  'README.md',
+  'primary-lesson-script.md',
+  'heygen-segments.md',
+  'elevenlabs-narration.md',
+  'storyboard-render-spec.md',
+  'render-handoff-checklist.md',
+  'shorts-package.md',
+  'thumbnail-briefs.md',
+  'worksheet.md',
+  'privacy-qa.md',
+  'asset-manifest.json',
+  path.join('captions', 'module-0-primary.srt'),
+  path.join('visual-assets', 'title-card.svg'),
+  path.join('visual-assets', 'closing-card.svg'),
+]
+
+for (const file of module0Files) {
+  assert(fs.existsSync(path.join(module0AssetDir, file)), `Module 0 asset missing: ${file}`)
+}
+
+assert(module0Manifest.module_id === 'module-0', 'Module 0 manifest must identify module-0')
+assert(module0Manifest.asset_packet_status === 'approved_for_render_preflight', 'Module 0 manifest must be approved for render preflight')
+assert(module0Manifest.provider_execution_status === 'locked_until_explicit_approval', 'Module 0 provider execution must stay locked')
+assert(module0Manifest.target_outputs?.primary_lesson, 'Module 0 manifest missing primary lesson output')
+assert(module0Manifest.target_outputs?.youtube_short, 'Module 0 manifest missing YouTube Shorts output')
+assert(module0Manifest.target_outputs?.thumbnail, 'Module 0 manifest missing thumbnail output')
+assert(module0Manifest.provider_assets?.render_handoff_checklist === 'render-handoff-checklist.md', 'Module 0 manifest missing render handoff checklist')
+assert(module0Manifest.safety?.allowed_now?.includes('video_generation_workflow_handoff_planning'), 'Module 0 must allow handoff planning without execution')
+assert(module0Manifest.safety?.privacy_review_required_before_render === true, 'Module 0 must require privacy review before render')
+for (const blocked of ['heygen_generation', 'elevenlabs_generation', 'final_render', 'upload', 'schedule', 'publish']) {
+  assert(module0Manifest.safety?.blocked_until_separate_approval?.includes(blocked), `Module 0 manifest must block ${blocked}`)
 }
 
 for (const expected of ['HeyGen', 'ElevenLabs', 'Remotion', 'HyperFrames', 'B-roll capture']) {
@@ -73,4 +129,4 @@ for (const forbidden of ['Provider calls, uploads, rendering, scheduling, and pu
   assert(packet.includes(forbidden), `Missing safety boundary text: ${forbidden}`)
 }
 
-console.log('Accelerated course module package validated: 8 modules, video packets, proof cues, exercises, and safety gates present.')
+console.log('Accelerated course module package validated: 8 modules plus approved Module 0 video asset packet and safety gates present.')


### PR DESCRIPTION
## Summary
- Adds the first approved local video asset packet for Accelerated Module 0: Why Accelerated Exists.
- Includes the primary lesson script, HeyGen segment scripts, ElevenLabs narration path, Remotion/HyperFrames storyboard, render handoff checklist, Shorts packet, thumbnail briefs, worksheet, privacy QA, captions, SVG title/closing cards, and a machine-readable asset manifest.
- Updates review status and validator coverage so Module 0 is approved for render preflight while provider execution, final render, upload, scheduling, publishing, and external platform draft creation stay locked behind separate approval.

## Validation
- `PATH=/Users/vambahsillah/Projects/Portfolio/node_modules/.bin:$PATH npm run course:accelerated:validate`
- `/Users/vambahsillah/Projects/Portfolio/node_modules/.bin/tsc --noEmit --pretty false --target ES2022 --module NodeNext --moduleResolution NodeNext --types node --typeRoots /Users/vambahsillah/Projects/Portfolio/node_modules/@types scripts/validate-accelerated-course-modules.ts`
- `git diff --check`
- `gh pr checks 584 --watch --interval 10`

## Integration Notes
- Documentation/local asset source files only; no migrations or env changes.
- No HeyGen, ElevenLabs, Remotion, HyperFrames, n8n, upload, schedule, publish, or external platform draft action was run.
- The new render handoff checklist maps Module 0 into `/admin/content/video-generation` for approval-gated preflight only.
- Vercel contexts checked on this PR branch:
  - Vercel – portfolio: passed
  - Vercel – portfolio-staging: not checked; Integration Captain verifies staging after merge per Portfolio workflow