### PR TITLE
feat: add no-send Gmail draft smoke

### DIFF
--- a/app/api/admin/outreach/[id]/gmail-user-draft/route.test.ts
+++ b/app/api/admin/outreach/[id]/gmail-user-draft/route.test.ts
@@ -73,7 +73,7 @@ function restoreEnv() {
   Object.assign(process.env, BASE_ENV)
 }
 
-function makeRequest(overrides: Record<string, string> = {}) {
+function makeRequest(overrides: Record<string, unknown> = {}) {
   return new NextRequest(
     'http://localhost/api/admin/outreach/queue-1/gmail-user-draft',
     {
@@ -272,6 +272,51 @@ describe('POST /api/admin/outreach/[id]/gmail-user-draft', () => {
       updated_at: expect.any(String),
     })
     expect(outreachUpdateEq).toHaveBeenCalledWith('id', 'queue-1')
+  })
+
+  it('runs a no-send smoke without creating a Gmail draft or writing tracking', async () => {
+    const { outreachUpdate } = mockSupabase({
+      credentials: credentialsRow('vambah@amadutown.com'),
+      outreachItem: outreachRow(),
+    })
+
+    const response = await POST(makeRequest({ noSendSmoke: true }), params())
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      message:
+        'No-send Gmail draft smoke passed. No Gmail draft was created and no email was sent.',
+      noSendSmoke: true,
+      wouldCreateDraft: true,
+      queueId: 'queue-1',
+      to: 'alice@example.com',
+      subject: 'Queue subject',
+      bodyChars: 'Queue body'.length,
+      requiredSender: 'vambah@amadutown.com',
+      connectedAs: 'vambah@amadutown.com',
+    })
+    expect(mocks.decryptRefreshToken).toHaveBeenCalledWith('cipher', 'iv', 'tag')
+    expect(mocks.createUserGmailDraft).not.toHaveBeenCalled()
+    expect(outreachUpdate).not.toHaveBeenCalled()
+    expect(mocks.logCommunication).not.toHaveBeenCalled()
+  })
+
+  it('keeps sender identity as a no-send smoke gate', async () => {
+    const { outreachSelect } = mockSupabase({
+      credentials: credentialsRow('personal@gmail.com'),
+      outreachItem: outreachRow(),
+    })
+
+    const response = await POST(makeRequest({ noSendSmoke: true }), params())
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error:
+        'Customer-facing Gmail drafts must be created from vambah@amadutown.com. Reconnect Gmail with that account before saving this draft.',
+    })
+    expect(outreachSelect).not.toHaveBeenCalled()
+    expect(mocks.decryptRefreshToken).not.toHaveBeenCalled()
+    expect(mocks.createUserGmailDraft).not.toHaveBeenCalled()
   })
 
   it('fails closed when Gmail does not return a thread id for reply tracking', async () => {

--- a/app/api/admin/outreach/[id]/gmail-user-draft/route.ts
+++ b/app/api/admin/outreach/[id]/gmail-user-draft/route.ts
@@ -51,12 +51,17 @@ export async function POST(
     const { id } = await params
 
     let bodyOverrides: { subject?: string; body?: string } = {}
+    let noSendSmoke = false
     try {
       const raw = await request.json()
       if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
         const o = raw as Record<string, unknown>
         if (typeof o.subject === 'string') bodyOverrides.subject = o.subject
         if (typeof o.body === 'string') bodyOverrides.body = o.body
+        noSendSmoke =
+          o.noSendSmoke === true ||
+          o.dryRun === true ||
+          o.smokeMode === true
       }
     } catch {
       // use DB only
@@ -170,6 +175,21 @@ export async function POST(
         },
         { status: 400 }
       )
+    }
+
+    if (noSendSmoke) {
+      return NextResponse.json({
+        message:
+          'No-send Gmail draft smoke passed. No Gmail draft was created and no email was sent.',
+        noSendSmoke: true,
+        wouldCreateDraft: true,
+        queueId: item.id,
+        to,
+        subject,
+        bodyChars: bodyText.length,
+        requiredSender,
+        connectedAs: creds.google_email,
+      })
     }
 
     let draft: { id: string; messageId?: string; threadId?: string }

--- a/components/admin/OutreachEmailGenerateRow.tsx
+++ b/components/admin/OutreachEmailGenerateRow.tsx
@@ -156,6 +156,7 @@ export function OutreachEmailGenerateRow({
   const [inAppLoading, setInAppLoading] = useState(false)
   const [whyRequest, setWhyRequest] = useState<WhyThisDraftRequest | null>(null)
   const [gmailDraftSavingId, setGmailDraftSavingId] = useState<string | null>(null)
+  const [gmailDraftSmokeId, setGmailDraftSmokeId] = useState<string | null>(null)
 
   /** `meeting_records.id` for prompt + dedup; empty = server uses latest meeting for this lead. */
   const [outreachMeetingId, setOutreachMeetingId] = useState('')
@@ -463,6 +464,42 @@ export function OutreachEmailGenerateRow({
       }
     },
     [gmailDraftSavingId, onSettled, onToast],
+  )
+
+  const runGmailDraftSmoke = useCallback(
+    async (draft: RecentEmailDraftItem) => {
+      if (gmailDraftSmokeId) return
+      setGmailDraftSmokeId(draft.id)
+      try {
+        const session = await getCurrentSession()
+        if (!session?.access_token) {
+          onToast?.('Please sign in to run the Gmail draft smoke.')
+          return
+        }
+        const res = await fetch(`/api/admin/outreach/${draft.id}/gmail-user-draft`, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${session.access_token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ noSendSmoke: true }),
+        })
+        const data = (await res.json().catch(() => ({}))) as {
+          error?: string
+          message?: string
+        }
+        if (!res.ok) {
+          onToast?.(data.error ?? 'Gmail draft smoke failed.')
+          return
+        }
+        onToast?.(data.message ?? 'No-send Gmail draft smoke passed.')
+      } catch {
+        onToast?.('Gmail draft smoke failed.')
+      } finally {
+        setGmailDraftSmokeId(null)
+      }
+    },
+    [gmailDraftSmokeId, onToast],
   )
 
   const pickTemplate = (
@@ -1069,23 +1106,42 @@ export function OutreachEmailGenerateRow({
                                 <HelpCircle size={12} />
                               </button>
                               {(r.status === 'draft' || r.status === 'approved') && (
-                                <button
-                                  type="button"
-                                  onClick={(e) => {
-                                    e.stopPropagation()
-                                    void saveToGmailDraft(r)
-                                  }}
-                                  disabled={gmailDraftSavingId != null}
-                                  title="Save this email as a draft in the connected Gmail account. This does not send."
-                                  aria-label={`Save ${r.subject ?? 'this draft'} to connected Gmail drafts`}
-                                  className="mt-1 shrink-0 rounded p-1 text-muted-foreground transition-colors hover:bg-silicon-slate/40 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
-                                >
-                                  {gmailDraftSavingId === r.id ? (
-                                    <Loader2 size={12} className="animate-spin" aria-hidden />
-                                  ) : (
-                                    <Mail size={12} aria-hidden />
-                                  )}
-                                </button>
+                                <>
+                                  <button
+                                    type="button"
+                                    onClick={(e) => {
+                                      e.stopPropagation()
+                                      void runGmailDraftSmoke(r)
+                                    }}
+                                    disabled={gmailDraftSmokeId != null || gmailDraftSavingId != null}
+                                    title="Run the Gmail draft gate as a no-send smoke. This does not create a Gmail draft or send email."
+                                    aria-label={`Run no-send Gmail draft smoke for ${r.subject ?? 'this draft'}`}
+                                    className="mt-1 shrink-0 rounded p-1 text-muted-foreground transition-colors hover:bg-silicon-slate/40 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                                  >
+                                    {gmailDraftSmokeId === r.id ? (
+                                      <Loader2 size={12} className="animate-spin" aria-hidden />
+                                    ) : (
+                                      <CheckCircle size={12} aria-hidden />
+                                    )}
+                                  </button>
+                                  <button
+                                    type="button"
+                                    onClick={(e) => {
+                                      e.stopPropagation()
+                                      void saveToGmailDraft(r)
+                                    }}
+                                    disabled={gmailDraftSavingId != null || gmailDraftSmokeId != null}
+                                    title="Save this email as a draft in the connected Gmail account. This does not send."
+                                    aria-label={`Save ${r.subject ?? 'this draft'} to connected Gmail drafts`}
+                                    className="mt-1 shrink-0 rounded p-1 text-muted-foreground transition-colors hover:bg-silicon-slate/40 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                                  >
+                                    {gmailDraftSavingId === r.id ? (
+                                      <Loader2 size={12} className="animate-spin" aria-hidden />
+                                    ) : (
+                                      <Mail size={12} aria-hidden />
+                                    )}
+                                  </button>
+                                </>
                               )}
                             </div>
                           </li>


### PR DESCRIPTION
## Summary
- Add a no-send smoke mode to the Gmail draft route using `noSendSmoke`, `dryRun`, or `smokeMode`.
- Surface a no-send smoke icon beside the existing Gmail draft save action in the Outreach row recent-email list.
- Cover the smoke path so it validates Gmail OAuth/sender/queue gates but does not create a Gmail draft, write thread tracking, or log communication.

## Validation
- `npm run test -- app/api/admin/outreach/[id]/gmail-user-draft/route.test.ts`
- `npm run lint -- --file components/admin/OutreachEmailGenerateRow.tsx --file app/api/admin/outreach/[id]/gmail-user-draft/route.ts --file app/api/admin/outreach/[id]/gmail-user-draft/route.test.ts`
- No live Gmail draft, no n8n workflow, and no customer-facing smoke was run.

## Integration Notes
- No migrations or env changes required.
- The no-send smoke still requires the configured AmaduTown sender identity before passing.
- Vercel contexts not checked in this non-captain lane before merge:
  - Vercel – portfolio: not checked
  - Vercel – portfolio-staging: not checked