### PR TITLE
feat: add inbound outreach handoff contract

### DIFF
--- a/app/api/client-email-context/route.test.ts
+++ b/app/api/client-email-context/route.test.ts
@@ -146,6 +146,18 @@ describe('GET /api/client-email-context', () => {
         pending: [{ title: 'Send recap', owner: 'Vambah', due_date: '2026-06-05' }],
         recently_completed: [{ title: 'Confirm budget', completed_at: '2026-06-04T00:00:00.000Z' }],
       },
+      handoff: {
+        version: 'inbound-outreach-handoff/v1',
+        intent: 'lead_reply_context',
+        next_action: 'review_lead_reply_for_outreach',
+        approval_boundary: 'context_handoff_only_no_send_no_auto_approval',
+        human_review_required: true,
+        source_refs: {
+          source_type: 'lead',
+          lead_id: 42,
+        },
+        target_surface: '/admin/outreach?tab=leads&id=42',
+      },
     })
   })
 
@@ -185,6 +197,13 @@ describe('GET /api/client-email-context', () => {
       },
       last_meeting: null,
       action_items: null,
+      handoff: {
+        intent: 'lead_reply_context',
+        source_refs: {
+          source_type: 'lead',
+          lead_id: 43,
+        },
+      },
     })
     expect(mocks.from).not.toHaveBeenCalledWith('meeting_action_tasks')
   })
@@ -233,7 +252,7 @@ describe('GET /api/client-email-context', () => {
     expect(response.status).toBe(200)
     expect(planQuery.maybeSingle).toHaveBeenCalled()
     expect(meetingQuery.maybeSingle).toHaveBeenCalled()
-    expect(await response.json()).toEqual({
+    expect(await response.json()).toMatchObject({
       found: true,
       source_type: 'client_project',
       project: {
@@ -252,6 +271,19 @@ describe('GET /api/client-email-context', () => {
       milestones: null,
       last_meeting: null,
       action_items: null,
+      handoff: {
+        version: 'inbound-outreach-handoff/v1',
+        intent: 'client_reply_context',
+        next_action: 'draft_client_reply',
+        approval_boundary: 'context_handoff_only_no_send_no_auto_approval',
+        human_review_required: true,
+        source_refs: {
+          source_type: 'client_project',
+          client_project_id: 'project-1',
+          lead_id: null,
+        },
+        target_surface: '/admin/email-center',
+      },
     })
   })
 })

--- a/app/api/client-email-context/route.ts
+++ b/app/api/client-email-context/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
 import { supabaseAdmin } from '@/lib/supabase'
+import { buildClientEmailContextHandoff } from '@/lib/inbound-outreach-handoff'
 
 export const dynamic = 'force-dynamic'
 
@@ -138,25 +139,33 @@ export async function GET(request: NextRequest) {
       }
     }
 
+    const projectPayload = {
+      id: project.id,
+      client_name: project.client_name,
+      client_email: project.client_email,
+      client_company: project.client_company,
+      project_name: project.project_name,
+      project_status: project.project_status,
+      current_phase: project.current_phase,
+      product_purchased: project.product_purchased,
+      slack_channel: project.slack_channel,
+      project_start_date: project.project_start_date,
+      estimated_end_date: project.estimated_end_date,
+    }
+
     return NextResponse.json({
       found: true,
       source_type: 'client_project',
-      project: {
-        id: project.id,
-        client_name: project.client_name,
-        client_email: project.client_email,
-        client_company: project.client_company,
-        project_name: project.project_name,
-        project_status: project.project_status,
-        current_phase: project.current_phase,
-        product_purchased: project.product_purchased,
-        slack_channel: project.slack_channel,
-        project_start_date: project.project_start_date,
-        estimated_end_date: project.estimated_end_date,
-      },
+      project: projectPayload,
       milestones,
       last_meeting: lastMeeting,
       action_items: actionItems,
+      handoff: buildClientEmailContextHandoff({
+        sourceType: 'client_project',
+        project: projectPayload,
+        lastMeeting,
+        actionItems,
+      }),
     })
   } catch (error) {
     console.error('[Client email context] Error:', error)
@@ -246,28 +255,36 @@ async function getLeadContext(email: string): Promise<NextResponse> {
     }
   }
 
+  const projectPayload = {
+    id: null,
+    client_name: lead.name,
+    client_email: lead.email,
+    client_company: lead.company || null,
+    project_name: null,
+    project_status: null,
+    current_phase: null,
+    product_purchased: null,
+    slack_channel: null,
+    project_start_date: null,
+    estimated_end_date: null,
+    lead_id: lead.id,
+    service_interest: lead.interest_summary || formatInterestAreas(lead.interest_areas),
+    initial_message: lead.message,
+  }
+
   return NextResponse.json({
     found: true,
     source_type: 'lead',
-    project: {
-      id: null,
-      client_name: lead.name,
-      client_email: lead.email,
-      client_company: lead.company || null,
-      project_name: null,
-      project_status: null,
-      current_phase: null,
-      product_purchased: null,
-      slack_channel: null,
-      project_start_date: null,
-      estimated_end_date: null,
-      lead_id: lead.id,
-      service_interest: lead.interest_summary || formatInterestAreas(lead.interest_areas),
-      initial_message: lead.message,
-    },
+    project: projectPayload,
     milestones: null,
     last_meeting: lastMeeting,
     action_items: actionItems,
+    handoff: buildClientEmailContextHandoff({
+      sourceType: 'lead',
+      project: projectPayload,
+      lastMeeting,
+      actionItems,
+    }),
   })
 }
 

--- a/app/api/meetings/[id]/follow-up-context/route.test.ts
+++ b/app/api/meetings/[id]/follow-up-context/route.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  from: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: { from: mocks.from },
+}))
+
+import { GET } from './route'
+
+function singleQuery<T>(result: { data: T; error: { message: string } | null }) {
+  const single = vi.fn(async () => result)
+  const eq = vi.fn(() => ({ single }))
+  const select = vi.fn(() => ({ eq }))
+  return { select, eq, single }
+}
+
+function taskQuery<T>(result: { data: T; error: { message: string } | null }) {
+  const eq = vi.fn(async () => result)
+  const select = vi.fn(() => ({ eq }))
+  return { select, eq }
+}
+
+describe('GET /api/meetings/[id]/follow-up-context', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user' } })
+    mocks.isAuthError.mockReturnValue(false)
+  })
+
+  it('returns meeting context with an explicit context-only handoff contract', async () => {
+    const meetingQuery = singleQuery({
+      data: {
+        id: 'meeting-1',
+        meeting_type: 'discovery',
+        meeting_date: '2026-06-03T14:00:00.000Z',
+        duration_minutes: 45,
+        attendees: ['client@example.com'],
+        next_meeting_type: 'implementation review',
+        next_meeting_agenda: 'Confirm next workflow lane.',
+        client_project_id: 'project-1',
+        calendly_event_uri: null,
+      },
+      error: null,
+    })
+    const projectQuery = singleQuery({
+      data: {
+        id: 'project-1',
+        client_name: 'Client Person',
+        client_email: 'client@example.com',
+        client_company: 'Client Co',
+        project_name: 'Client AI Ops',
+        slack_channel: '#client-ai-ops',
+        project_status: 'active',
+      },
+      error: null,
+    })
+    const tasksQuery = taskQuery({
+      data: [
+        { status: 'pending' },
+        { status: 'in_progress' },
+        { status: 'complete' },
+      ],
+      error: null,
+    })
+
+    mocks.from.mockImplementation((table: string) => {
+      if (table === 'meeting_records') return { select: meetingQuery.select }
+      if (table === 'client_projects') return { select: projectQuery.select }
+      if (table === 'meeting_action_tasks') return { select: tasksQuery.select }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+
+    const response = await GET(
+      new NextRequest('http://localhost/api/meetings/meeting-1/follow-up-context') as never,
+      { params: Promise.resolve({ id: 'meeting-1' }) },
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      meeting: {
+        id: 'meeting-1',
+        next_meeting_type: 'implementation review',
+      },
+      task_summary: {
+        pending: 1,
+        in_progress: 1,
+        complete: 1,
+        total: 3,
+      },
+      handoff: {
+        version: 'inbound-outreach-handoff/v1',
+        intent: 'meeting_follow_up_context',
+        next_action: 'schedule_follow_up',
+        approval_boundary: 'context_handoff_only_no_send_no_auto_approval',
+        human_review_required: true,
+        source_refs: {
+          source_type: 'meeting',
+          client_project_id: 'project-1',
+          meeting_record_id: 'meeting-1',
+        },
+      },
+    })
+  })
+})

--- a/app/api/meetings/[id]/follow-up-context/route.ts
+++ b/app/api/meetings/[id]/follow-up-context/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
 import { supabaseAdmin } from '@/lib/supabase'
+import { buildMeetingFollowUpHandoff } from '@/lib/inbound-outreach-handoff'
 
 export const dynamic = 'force-dynamic'
 
@@ -82,19 +83,26 @@ export async function GET(
       }
     }
 
+    const meetingPayload = {
+      id: meeting.id,
+      meeting_type: meeting.meeting_type,
+      meeting_date: meeting.meeting_date,
+      duration_minutes: meeting.duration_minutes,
+      attendees: meeting.attendees,
+      next_meeting_type: meeting.next_meeting_type,
+      next_meeting_agenda: meeting.next_meeting_agenda,
+      calendly_event_uri: meeting.calendly_event_uri,
+    }
+
     return NextResponse.json({
-      meeting: {
-        id: meeting.id,
-        meeting_type: meeting.meeting_type,
-        meeting_date: meeting.meeting_date,
-        duration_minutes: meeting.duration_minutes,
-        attendees: meeting.attendees,
-        next_meeting_type: meeting.next_meeting_type,
-        next_meeting_agenda: meeting.next_meeting_agenda,
-        calendly_event_uri: meeting.calendly_event_uri,
-      },
+      meeting: meetingPayload,
       project,
       task_summary: taskSummary,
+      handoff: buildMeetingFollowUpHandoff({
+        meeting: meetingPayload,
+        project,
+        taskSummary,
+      }),
     })
   } catch (error) {
     console.error('[Follow-up context] Error:', error)

--- a/docs/revenue-sprint/inbound-outreach-handoff-contract.md
+++ b/docs/revenue-sprint/inbound-outreach-handoff-contract.md
@@ -1,0 +1,60 @@
+# Inbound Outreach Handoff Contract
+
+Version: `inbound-outreach-handoff/v1`
+
+This contract lets inbound lead intake, client email context, meeting follow-up context, and reply classification hand context to downstream workflows without changing outbound send or draft approval behavior.
+
+## Boundary
+
+Every packet must include:
+
+- `approval_boundary: "context_handoff_only_no_send_no_auto_approval"`
+- `human_review_required: true`
+
+Consumers may use the packet to ground a reply, prepare a reviewed follow-up, or route a lead into the admin outreach surface. Consumers must not send email, approve a draft, mark a draft ready, create a calendar event, or bypass the existing outreach/email review gates from this context response alone.
+
+## Current Producers
+
+- `GET /api/client-email-context?email=...`
+  - `intent: "client_reply_context"` for active client project context.
+  - `intent: "lead_reply_context"` for lead-only inbox context.
+- `GET /api/meetings/[id]/follow-up-context`
+  - `intent: "meeting_follow_up_context"` for scheduling or follow-up preparation.
+
+## Packet Shape
+
+```json
+{
+  "version": "inbound-outreach-handoff/v1",
+  "intent": "lead_reply_context",
+  "next_action": "review_lead_reply_for_outreach",
+  "approval_boundary": "context_handoff_only_no_send_no_auto_approval",
+  "human_review_required": true,
+  "contact": {
+    "name": "Lead Person",
+    "email": "lead@example.com",
+    "company": "Lead Co"
+  },
+  "source_refs": {
+    "source_type": "lead",
+    "lead_id": 42
+  },
+  "context_signals": [
+    "Interest: AI ops",
+    "Last meeting: Lead wants faster reply drafting."
+  ],
+  "handoff_notes": [
+    "Use this packet to ground a reply or outreach review.",
+    "Do not send, approve, or mark a draft ready from this context response alone."
+  ],
+  "target_surface": "/admin/outreach?tab=leads&id=42"
+}
+```
+
+## Consumer Rules
+
+- Reply detection may classify inbound replies and attach this packet as review context.
+- Meeting-to-lead extraction may pass this packet into the Add Lead or outreach review flow.
+- Client email workflows may use the packet for drafting context only.
+- Follow-up schedulers may use the packet to prepare copy or a scheduling recommendation only.
+- Any side-effecting step must continue through the existing admin review, outreach queue, Gmail draft, or calendar approval gate.

--- a/lib/inbound-outreach-handoff.test.ts
+++ b/lib/inbound-outreach-handoff.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+import {
+  INBOUND_OUTREACH_APPROVAL_BOUNDARY,
+  INBOUND_OUTREACH_HANDOFF_VERSION,
+  buildClientEmailContextHandoff,
+  buildMeetingFollowUpHandoff,
+} from './inbound-outreach-handoff'
+
+describe('inbound outreach handoff contract', () => {
+  it('builds a lead reply handoff without granting send or approval authority', () => {
+    const handoff = buildClientEmailContextHandoff({
+      sourceType: 'lead',
+      project: {
+        id: null,
+        lead_id: 42,
+        client_name: 'Lead Person',
+        client_email: 'lead@example.com',
+        client_company: 'Lead Co',
+        service_interest: 'AI ops',
+        initial_message: 'Need help with follow-up.',
+      },
+      lastMeeting: {
+        meeting_type: 'discovery',
+        meeting_date: '2026-06-03T14:00:00.000Z',
+        summary: 'Lead wants faster reply drafting.',
+      },
+      actionItems: {
+        pending: [{ title: 'Send recap', owner: 'Vambah', due_date: '2026-06-05' }],
+        recently_completed: [],
+      },
+    })
+
+    expect(handoff).toMatchObject({
+      version: INBOUND_OUTREACH_HANDOFF_VERSION,
+      intent: 'lead_reply_context',
+      next_action: 'review_lead_reply_for_outreach',
+      approval_boundary: INBOUND_OUTREACH_APPROVAL_BOUNDARY,
+      human_review_required: true,
+      source_refs: {
+        source_type: 'lead',
+        lead_id: 42,
+      },
+      target_surface: '/admin/outreach?tab=leads&id=42',
+    })
+    expect(handoff.context_signals).toContain('Interest: AI ops')
+    expect(handoff.handoff_notes.join(' ')).toContain('Do not send')
+  })
+
+  it('keeps client email context separate from cold outreach', () => {
+    const handoff = buildClientEmailContextHandoff({
+      sourceType: 'client_project',
+      project: {
+        id: 'project-1',
+        client_name: 'Client Person',
+        client_email: 'client@example.com',
+        client_company: 'Client Co',
+        project_name: 'Client AI Ops',
+        project_status: 'active',
+        current_phase: 'implementation',
+      },
+      lastMeeting: null,
+      actionItems: null,
+    })
+
+    expect(handoff).toMatchObject({
+      intent: 'client_reply_context',
+      next_action: 'draft_client_reply',
+      target_surface: '/admin/email-center',
+      source_refs: {
+        source_type: 'client_project',
+        client_project_id: 'project-1',
+        lead_id: null,
+      },
+    })
+    expect(handoff.handoff_notes.join(' ')).toContain('not cold outreach')
+  })
+
+  it('builds meeting follow-up handoffs as context-only scheduling inputs', () => {
+    const handoff = buildMeetingFollowUpHandoff({
+      meeting: {
+        id: 'meeting-1',
+        meeting_type: 'discovery',
+        meeting_date: '2026-06-03T14:00:00.000Z',
+        next_meeting_type: 'implementation review',
+        next_meeting_agenda: 'Confirm next workflow lane.',
+        calendly_event_uri: null,
+      },
+      project: {
+        id: 'project-1',
+        client_name: 'Client Person',
+        client_email: 'client@example.com',
+        client_company: 'Client Co',
+        project_name: 'Client AI Ops',
+        project_status: 'active',
+      },
+      taskSummary: { pending: 2, in_progress: 1, complete: 3, total: 6 },
+    })
+
+    expect(handoff).toMatchObject({
+      version: INBOUND_OUTREACH_HANDOFF_VERSION,
+      intent: 'meeting_follow_up_context',
+      next_action: 'schedule_follow_up',
+      approval_boundary: INBOUND_OUTREACH_APPROVAL_BOUNDARY,
+      human_review_required: true,
+      target_surface: '/admin/meetings/meeting-1',
+      source_refs: {
+        source_type: 'meeting',
+        client_project_id: 'project-1',
+        meeting_record_id: 'meeting-1',
+      },
+    })
+    expect(handoff.context_signals).toContain('Action items: 3 open of 6')
+    expect(handoff.handoff_notes.join(' ')).toContain('Do not send a follow-up')
+  })
+})

--- a/lib/inbound-outreach-handoff.ts
+++ b/lib/inbound-outreach-handoff.ts
@@ -1,0 +1,184 @@
+export const INBOUND_OUTREACH_HANDOFF_VERSION = 'inbound-outreach-handoff/v1'
+export const INBOUND_OUTREACH_APPROVAL_BOUNDARY =
+  'context_handoff_only_no_send_no_auto_approval'
+
+export type InboundOutreachHandoffIntent =
+  | 'client_reply_context'
+  | 'lead_reply_context'
+  | 'meeting_follow_up_context'
+
+export type InboundOutreachNextAction =
+  | 'draft_client_reply'
+  | 'review_lead_reply_for_outreach'
+  | 'schedule_follow_up'
+
+export type InboundOutreachHandoff = {
+  version: typeof INBOUND_OUTREACH_HANDOFF_VERSION
+  intent: InboundOutreachHandoffIntent
+  next_action: InboundOutreachNextAction
+  approval_boundary: typeof INBOUND_OUTREACH_APPROVAL_BOUNDARY
+  human_review_required: true
+  contact: {
+    name: string | null
+    email: string | null
+    company: string | null
+  }
+  source_refs: {
+    source_type: 'client_project' | 'lead' | 'meeting'
+    client_project_id?: string | null
+    lead_id?: number | null
+    meeting_record_id?: string | null
+  }
+  context_signals: string[]
+  handoff_notes: string[]
+  target_surface: string
+}
+
+type ClientEmailProject = {
+  id: string | null
+  client_name: string | null
+  client_email: string | null
+  client_company: string | null
+  project_name?: string | null
+  project_status?: string | null
+  current_phase?: string | null
+  lead_id?: number | null
+  service_interest?: string | null
+  initial_message?: string | null
+}
+
+type LastMeeting = {
+  meeting_type?: string | null
+  meeting_date?: string | null
+  summary?: string | null
+} | null
+
+type ActionItems = {
+  pending?: Array<{ title: string; owner?: string | null; due_date?: string | null }>
+  recently_completed?: Array<{ title: string; completed_at?: string | null }>
+} | null
+
+type TaskSummary = {
+  pending: number
+  in_progress: number
+  complete: number
+  total: number
+} | null
+
+export function buildClientEmailContextHandoff(args: {
+  sourceType: 'client_project' | 'lead'
+  project: ClientEmailProject
+  lastMeeting: LastMeeting
+  actionItems: ActionItems
+}): InboundOutreachHandoff {
+  const isLead = args.sourceType === 'lead'
+  const leadId = typeof args.project.lead_id === 'number' ? args.project.lead_id : null
+  const signals = compact([
+    args.project.project_name ? `Project: ${args.project.project_name}` : null,
+    args.project.project_status ? `Status: ${args.project.project_status}` : null,
+    args.project.current_phase ? `Phase: ${args.project.current_phase}` : null,
+    args.project.service_interest ? `Interest: ${args.project.service_interest}` : null,
+    args.lastMeeting?.summary ? `Last meeting: ${args.lastMeeting.summary}` : null,
+    args.actionItems?.pending?.length
+      ? `Pending action items: ${args.actionItems.pending.length}`
+      : null,
+    args.actionItems?.recently_completed?.length
+      ? `Recently completed action items: ${args.actionItems.recently_completed.length}`
+      : null,
+  ])
+
+  return {
+    version: INBOUND_OUTREACH_HANDOFF_VERSION,
+    intent: isLead ? 'lead_reply_context' : 'client_reply_context',
+    next_action: isLead ? 'review_lead_reply_for_outreach' : 'draft_client_reply',
+    approval_boundary: INBOUND_OUTREACH_APPROVAL_BOUNDARY,
+    human_review_required: true,
+    contact: {
+      name: args.project.client_name,
+      email: args.project.client_email,
+      company: args.project.client_company,
+    },
+    source_refs: {
+      source_type: args.sourceType,
+      client_project_id: isLead ? null : args.project.id,
+      lead_id: isLead ? leadId : null,
+    },
+    context_signals: signals,
+    handoff_notes: [
+      'Use this packet to ground a reply or outreach review.',
+      'Do not send, approve, or mark a draft ready from this context response alone.',
+      isLead
+        ? 'If outreach is appropriate, route through the admin outreach review queue.'
+        : 'Treat this as client-service reply context, not cold outreach.',
+    ],
+    target_surface: isLead && leadId
+      ? `/admin/outreach?tab=leads&id=${leadId}`
+      : '/admin/email-center',
+  }
+}
+
+export function buildMeetingFollowUpHandoff(args: {
+  meeting: {
+    id: string
+    meeting_type: string | null
+    meeting_date: string | null
+    next_meeting_type: string | null
+    next_meeting_agenda: string | null
+    calendly_event_uri: string | null
+  }
+  project: {
+    id: string
+    client_name: string | null
+    client_email: string | null
+    client_company: string | null
+    project_name: string | null
+    project_status: string | null
+  } | null
+  taskSummary: TaskSummary
+}): InboundOutreachHandoff {
+  const signals = compact([
+    args.meeting.meeting_type ? `Meeting type: ${args.meeting.meeting_type}` : null,
+    args.meeting.meeting_date ? `Meeting date: ${args.meeting.meeting_date}` : null,
+    args.meeting.next_meeting_type
+      ? `Next meeting type: ${args.meeting.next_meeting_type}`
+      : null,
+    args.meeting.next_meeting_agenda
+      ? `Next agenda: ${args.meeting.next_meeting_agenda}`
+      : null,
+    args.meeting.calendly_event_uri ? 'Calendly event already linked' : null,
+    args.taskSummary ? `Action items: ${args.taskSummary.pending + args.taskSummary.in_progress} open of ${args.taskSummary.total}` : null,
+  ])
+
+  return {
+    version: INBOUND_OUTREACH_HANDOFF_VERSION,
+    intent: 'meeting_follow_up_context',
+    next_action: 'schedule_follow_up',
+    approval_boundary: INBOUND_OUTREACH_APPROVAL_BOUNDARY,
+    human_review_required: true,
+    contact: {
+      name: args.project?.client_name ?? null,
+      email: args.project?.client_email ?? null,
+      company: args.project?.client_company ?? null,
+    },
+    source_refs: {
+      source_type: 'meeting',
+      client_project_id: args.project?.id ?? null,
+      meeting_record_id: args.meeting.id,
+    },
+    context_signals: signals,
+    handoff_notes: [
+      'Use this packet to prepare follow-up context or scheduling copy.',
+      'Do not send a follow-up, create a calendar event, or approve a draft from this response alone.',
+      'Route any outbound message through the existing outreach or email review gate.',
+    ],
+    target_surface: args.project?.id
+      ? `/admin/meetings/${args.meeting.id}`
+      : '/admin/meetings',
+  }
+}
+
+function compact(values: Array<string | null | undefined>): string[] {
+  return values
+    .map((value) => value?.trim())
+    .filter((value): value is string => Boolean(value))
+}


### PR DESCRIPTION
## Summary
- Added a shared `inbound-outreach-handoff/v1` contract for client email, lead reply, and meeting follow-up context packets.
- Extended `GET /api/client-email-context` and `GET /api/meetings/[id]/follow-up-context` with additive `handoff` payloads while preserving existing response fields.
- Documented the boundary that these packets are context-only and cannot send email, approve drafts, create calendar events, or bypass admin review gates.

## Validation
- `npx vitest run lib/inbound-outreach-handoff.test.ts app/api/client-email-context/route.test.ts 'app/api/meetings/[id]/follow-up-context/route.test.ts'`
- `npm run build:knowledge`
- `npx tsc --noEmit`
- `npm run lint` (passes; existing `<img>` warnings remain in unrelated files)
- `git diff --check`
- No live workflow/customer-data smoke was run; this lane exercised the changed API/helper surfaces through focused route tests.

## Integration Notes
- No database migration or environment variable change required.
- Outbound send and Gmail draft approval behavior was not changed.
- Both Vercel contexts were not checked in this non-captain lane and should be verified by Integration Captain before merge:
  - Vercel – portfolio
  - Vercel – portfolio-staging
