### PR TITLE
docs: add content strategy lane packet

### DIFF
--- a/docs/content-strategy/README.md
+++ b/docs/content-strategy/README.md
@@ -1,0 +1,63 @@
+# Portfolio content strategy lane
+
+Status: Lane operating packet
+Date: 2026-06-28
+Branch: `codex/content-strategy`
+Worktree: `/Users/vambahsillah/Projects/Portfolio.worktrees/content-strategy`
+
+## Scope
+
+This lane owns content strategy artifacts for Portfolio social execution:
+
+- social content calendar plans
+- topic backlog and campaign sequencing
+- LinkedIn and social draft workflows
+- content intelligence review packets
+- approval-gated publishing prep
+
+It does not publish, schedule, upload, generate provider media, send external messages, or mutate production campaign queues without explicit approval.
+
+## Source map
+
+| Source | Use in this lane | Boundary |
+| --- | --- | --- |
+| `docs/linkedin-voice.md` | LinkedIn voice, post rhythm, hashtags, and anti-formula guidance. | Public-facing drafts must still pass human review. |
+| Personality corpus pack | Vambah voice, content pillars, source sensitivity, and privacy rules. | Private-derived summaries inform tone only. Raw private exports stay out of artifacts. |
+| `docs/automations/content-voice-runbook.md` | Corpus drift and content voice governance. | Agents may report and recommend; they do not move or quote private corpus files. |
+| `lib/social-content-calendar.ts` | Canonical `whisper_to_shout` template, phases, required assets, and gates. | Do not invent phase enums. Store campaign phases as `tease`, `teach`, `proof`, and `offer`. |
+| `supabase/migrations/20260623182842_social_content_calendar_items.sql` | Calendar item authorization contract. | `authorized` means internal draft handoff may proceed. It does not mean external publishing. |
+| `docs/agentic-content-linkedin-drafts/` | Existing LinkedIn draft packet pattern. | Drafts are review artifacts, not posting instructions. |
+| `docs/agentic-content-review-packets/` | Challenger review packet structure. | Challenger pass routes to human review only. |
+
+## Operating rules
+
+1. Start from campaign goal, audience, proof source, offer path, and approval gate before writing copy.
+2. Use `whisper_to_shout` for launch arcs unless a product owner approves a different template.
+3. Keep the remembered "Tease/Wispr/Shout" language as a planning overlay only. Canonical stored phases remain `tease`, `teach`, `proof`, and `offer`.
+4. Separate raw inputs, source notes, draft copy, review findings, and publishing prep.
+5. Mark every draft with `draft`, `human_review_ready`, `approved_for_internal_handoff`, or `blocked`.
+6. Use Shaka for final publishing authority and Nefertiti for voice/public-claim review when a packet is ready.
+7. Keep provider work separate: HeyGen, ElevenLabs, YouTube, LinkedIn, n8n, and scheduler actions all require explicit approval.
+
+## Lane artifacts
+
+- `accelerated-whisper-to-shout-campaign-plan.md`: 14-day campaign plan, calendar, topic backlog, source map, and review gates.
+- `social-draft-workflow.md`: draft creation workflow, approval checklist, review packet template, and publishing prep boundary.
+
+## Current roadmap status
+
+Completed in this packet:
+
+- Defined the Portfolio Content Strategy lane scope.
+- Bound the lane to the existing campaign calendar model and approval gates.
+- Added a first campaign plan and draft workflow packet.
+
+Next:
+
+- Human review of the campaign angles and backlog priority.
+- If approved, create internal Social Content calendar items through the admin UI or a separately approved data path.
+- After calendar creation, generate review-ready draft packets per phase.
+
+Decision gate:
+
+- No publishing, external scheduling, provider generation, or queue mutation is approved by these docs.

--- a/docs/content-strategy/accelerated-whisper-to-shout-campaign-plan.md
+++ b/docs/content-strategy/accelerated-whisper-to-shout-campaign-plan.md
@@ -1,0 +1,147 @@
+# Accelerated whisper_to_shout campaign plan
+
+Status: Draft strategy packet
+Date: 2026-06-28
+Campaign target: Accelerated Workshop
+Template: `whisper_to_shout`
+Window: 14 days
+
+## Campaign intent
+
+The campaign should make one practical argument:
+
+AI-assisted work only becomes useful when teams can turn output into governed product execution.
+
+The audience is product leaders, operators, consultants, and community-centered organizations that are curious about AI but wary of more dashboards, more tools, and more unmanaged work.
+
+The offer path is simple:
+
+1. Build trust through a concrete operating problem.
+2. Teach the governed-work frame.
+3. Show AmaduTown-owned proof surfaces.
+4. Invite the reader toward the Accelerated Workshop interest path, AI Quick Win, or discovery call.
+
+## Message spine
+
+| Phase | Plain-language job | Reader tension | Proof or asset needed | Approval gate |
+| --- | --- | --- | --- | --- |
+| `tease` | Make the problem visible. | AI output is easy; accountable work is harder. | A concrete scene from product, consulting, or agent ops. | Copy review. |
+| `teach` | Give a reusable frame. | Teams need a loop for scope, evidence, review, and decision. | SAM Loop, Agent Ops receipts, or Content Intelligence workflow. | Copy and source review. |
+| `proof` | Show that the frame is being built. | Trust comes from visible proof, not claims of autonomy. | Portfolio admin proof surface, sanitized artifact, or Accelerated packet. | Copy and privacy review. |
+| `offer` | Make the next step clear. | Readers need a low-friction way to test the operating model. | Workshop interest path, AI Quick Win, or discovery call CTA. | Copy and authorization gate. |
+
+## 14-day calendar
+
+These are planning slots only. Do not schedule externally from this table.
+
+| Day | Phase | Channel | Working title | Planned angle | Review gate |
+| --- | --- | --- | --- | --- | --- |
+| 1 | `tease` | LinkedIn | The expensive part comes after the prompt | Open with the moment a team realizes AI output created a review burden. | Voice review. |
+| 3 | `tease` | LinkedIn carousel | What every AI workflow needs before it touches real work | Visualize source, scope, output, evidence, approval, and handoff. | Visual and claim review. |
+| 4 | `teach` | LinkedIn | The SAM Loop is a work loop, not a slogan | Teach how sense, act, and measure can govern AI-assisted product work. | Source review. |
+| 6 | `teach` | YouTube Shorts | AI output needs a receipt | Short spoken frame tied to Agent Ops receipts and approval gates. | Script and provider gate. |
+| 8 | `proof` | LinkedIn | I am building the receipt first | Show Portfolio as a proof discipline: runs, artifacts, handoffs, approvals, and costs. | Privacy review. |
+| 10 | `proof` | Thumbnail | From prompt to proof | Thumbnail concept for a screen-backed proof episode or carousel. | Visual proof review. |
+| 12 | `offer` | LinkedIn | A workshop for teams that need AI to survive contact with real work | Invite operators to the Accelerated Workshop path without overpromising automation. | Shaka authorization. |
+| 14 | `offer` | LinkedIn follow-up | Bring one workflow. Leave with the operating loop. | Clear CTA for a practical workshop or AI Quick Win consult. | Publishing approval. |
+
+## Topic backlog
+
+| Priority | Topic | Best phase | Format | Why it belongs |
+| --- | --- | --- | --- | --- |
+| P0 | AI output needs a receipt | `tease` | LinkedIn post | Strong entry point into governance without sounding abstract. |
+| P0 | The SAM Loop as an operator loop | `teach` | LinkedIn post or carousel | Connects Accelerated to product execution and day-to-day work. |
+| P0 | Portfolio as a proof surface | `proof` | LinkedIn post | Uses AmaduTown-owned proof without exposing private data. |
+| P0 | Bring one workflow to the workshop | `offer` | LinkedIn CTA post | Gives the audience a concrete next action. |
+| P1 | What small teams should automate last | `teach` | LinkedIn list post | Pushes against AI hype and respects overloaded operators. |
+| P1 | The difference between speed and stewardship | `teach` | Essay or carousel | Fits Vambah's access, dignity, and governance themes. |
+| P1 | From demo to operating discipline | `proof` | YouTube script | Expands the core argument into a deeper proof episode. |
+| P1 | Approval gates are not bureaucracy | `proof` | LinkedIn post | Reframes human review as trust infrastructure. |
+| P2 | What nonprofits should ask before buying AI | `teach` | LinkedIn carousel | Useful for community-centered audience, requires careful sourcing. |
+| P2 | The workshop after the workshop | `offer` | Email or follow-up post | Sets up continuity after the campaign without forcing a sale. |
+
+## Draft seed: first LinkedIn post
+
+Status: Draft seed for Nefertiti voice review. Not approved for posting.
+
+The expensive part comes after the prompt.
+
+A team can get AI to produce a plan in minutes now. Strategy memo. Product brief. Outreach draft. Training outline. Code scaffold. All of it shows up fast.
+
+Then the real work starts.
+
+Who checks whether the output is true?
+
+Who knows which source it used?
+
+Who decides whether it can touch a client record, a public claim, or a workflow that sends something outside the building?
+
+Who owns the next step after the model sounds confident?
+
+That is where a lot of AI work starts to wobble.
+
+I have been building Portfolio and the Accelerated material around that problem. The goal is not to make AI feel magical. The goal is to make AI-assisted work reviewable enough that a real team can trust what happens next.
+
+Runs need receipts.
+
+Outputs need owners.
+
+Approvals need to happen before side effects.
+
+Proof needs to sit close to the work.
+
+That is the operating gap I keep seeing between "we used AI" and "this made the business stronger."
+
+The teams with the least spare capacity are usually the ones being handed the most abstract version of innovation. More dashboards. More prompts. More tools to manage the tools.
+
+I want the opposite.
+
+Bring one real workflow. Map the sources. Define the guardrails. Decide where the human approval belongs. Then use AI to reduce burden instead of creating a new pile of unreviewed output.
+
+That is the frame behind the Accelerated Workshop.
+
+What is one workflow where AI made you faster, but left you with a review problem afterward?
+
+#AIProduct #ProductManagement #EnterpriseAI #AmadutownAdvisory
+
+## Review notes
+
+- The draft stays public-safe and does not quote private chats, client records, Chronicle notes, or raw corpus material.
+- The proof claim is intentionally modest: Portfolio and Accelerated are being used as operating proof surfaces.
+- Before posting, confirm the CTA should point to the Accelerated Workshop, AI Quick Win, discovery call, or a softer comment prompt only.
+
+## Source handling
+
+Allowed:
+
+- public-safe Vambah voice guidance
+- existing Portfolio admin proof concepts
+- Accelerated/SAM Loop positioning
+- owned AmaduTown campaign framing
+
+Blocked without approval:
+
+- private AI chat excerpts
+- client records or meeting notes
+- raw Chronicle summaries
+- screenshots with private queue state
+- provider-generated media
+- external scheduler or posting actions
+
+## Roadmap status
+
+Completed in this plan:
+
+- Translated the content strategy lane into a 14-day `whisper_to_shout` campaign.
+- Added a calendar, backlog, and first LinkedIn draft seed.
+- Kept all execution behind review and publishing gates.
+
+Next:
+
+- Review the campaign promise and CTA path.
+- Select the first four P0 items for internal Social Content calendar creation.
+- Generate full draft packets only after the calendar and approval route are confirmed.
+
+Blocker:
+
+- Human decision needed on the final CTA path before any post becomes publish-ready.

--- a/docs/content-strategy/social-draft-workflow.md
+++ b/docs/content-strategy/social-draft-workflow.md
@@ -1,0 +1,169 @@
+# Social draft workflow
+
+Status: Lane workflow packet
+Date: 2026-06-28
+
+## Purpose
+
+This workflow turns a campaign idea into review-ready social content without crossing into publishing, scheduling, provider generation, or external sends.
+
+The goal is a clean handoff:
+
+`campaign goal -> topic backlog -> calendar item -> draft packet -> challenger review -> human approval -> internal handoff -> separate publishing approval`
+
+## Draft states
+
+| State | Meaning | Allowed action |
+| --- | --- | --- |
+| `draft` | Working copy exists, but it has not passed voice, source, or privacy review. | Edit internally. |
+| `human_review_ready` | The packet passed source, privacy, and challenger checks. | Route to Nefertiti/Shaka for review. |
+| `approved_for_internal_handoff` | Human approved the draft for Portfolio internal handoff. | Create or link internal Social Content draft/work item. |
+| `blocked` | A claim, source, privacy issue, CTA, or asset dependency needs a decision. | Stop and request the specific decision. |
+| `publish_ready` | Human explicitly approved publishing prep after internal handoff. | Prepare external publishing packet only. |
+
+`publish_ready` is still not permission to publish. It means the content packet can move to a separate publishing approval surface.
+
+## Workflow
+
+1. Confirm campaign source.
+   - Campaign name
+   - Audience
+   - Offer path
+   - Template key, usually `whisper_to_shout`
+   - Canonical phase: `tease`, `teach`, `proof`, or `offer`
+
+2. Build the source packet.
+   - Public sources
+   - Portfolio-owned proof surface
+   - Private-derived voice notes, summarized only
+   - Blocked or missing evidence
+   - Privacy boundary
+
+3. Draft the channel asset.
+   - LinkedIn text
+   - Carousel outline
+   - YouTube Shorts script
+   - Thumbnail concept
+   - Email or follow-up note, when approved
+
+4. Apply the voice pass.
+   - Start from a concrete scene, tension, or practical problem.
+   - Keep claims specific.
+   - Use plain sentences.
+   - Keep the bridge between story and execution.
+   - Avoid formulaic signposting, generic AI hype, and negative antithesis patterns.
+
+5. Apply the source and privacy pass.
+   - Mark every proof claim as owned, public, private-derived, or blocked.
+   - Remove private chats, client records, raw account data, and sensitive personal details.
+   - Keep screenshots sanitized or replace them with diagrams.
+
+6. Apply the challenger pass.
+   - Unsupported claim check
+   - Implementation drift check
+   - Privacy check
+   - Duplicate work check
+   - Channel fit check
+   - CTA fit check
+
+7. Route to human review.
+   - Nefertiti: voice, rhythm, public claim comfort.
+   - Shaka: campaign priority, approval state, publishing authority.
+   - Integration Captain: only if a code/data mutation or merge is needed.
+
+## Review packet template
+
+```yaml
+asset_id:
+campaign_id:
+campaign_template_key: whisper_to_shout
+campaign_phase:
+channel:
+draft_version:
+creator_lane: content-strategy
+status: human_review_ready
+source_ids:
+  -
+approval_required:
+  voice_review: true
+  source_review: true
+  privacy_review: true
+  publishing_approval: true
+external_actions:
+  provider_generation: false
+  upload: false
+  publish: false
+  schedule: false
+  send: false
+```
+
+Required packet sections:
+
+- Draft to review
+- Intended audience
+- Campaign role
+- Source map
+- Claim boundary
+- Privacy notes
+- Challenger findings
+- Human decision needed
+- Next internal handoff if approved
+
+## LinkedIn draft checklist
+
+- The first 210 characters carry the tension.
+- The post has one main idea.
+- Paragraphs are short enough for mobile reading.
+- A lived detail, operational scene, or concrete work moment opens the frame.
+- The post moves from diagnosis to a practical next step.
+- The CTA asks a specific question or routes to a specific approved offer path.
+- Hashtags stay between three and five.
+- Character count is checked before review.
+- The humanizer pass removed formulaic phrases, generic AI terms, empty uplift, and over-polished list cadence.
+
+## Publishing prep boundary
+
+Content Strategy may prepare:
+
+- final copy packet
+- alt text or visual notes
+- sanitized image/screen-capture request
+- recommended publish window
+- approval checklist
+- internal Social Content handoff note
+
+Content Strategy may not do the following without explicit approval:
+
+- publish to LinkedIn, YouTube, Instagram, or email
+- schedule through any external platform
+- trigger n8n, HeyGen, ElevenLabs, Remotion, HyperFrames, or upload workflows
+- use private or client-specific proof in public content
+- mark a rejected calendar item as authorized without a decision note
+
+## Escalation rules
+
+Escalate to Vambah when:
+
+- the CTA path is unclear
+- a proof claim depends on private work
+- a screenshot would expose private state
+- a campaign asks for external publishing
+- a draft needs a public claim that the current product cannot support
+- the same topic appears in another active worktree or PR
+
+## Roadmap status
+
+Completed in this workflow:
+
+- Defined draft states and approval gates.
+- Added the review packet template.
+- Clarified the publishing prep boundary.
+
+Next:
+
+- Use this template for the first Accelerated campaign review packet after the topic priority is approved.
+- Attach each future draft packet to the relevant Social Content calendar item or campaign work item.
+
+Decision gate:
+
+- A human must approve movement from review-ready content into any external publishing workflow.


### PR DESCRIPTION
## Summary
- Added a scoped Portfolio Content Strategy lane README with source map, lane boundaries, and approval rules.
- Added a 14-day Accelerated Workshop `whisper_to_shout` campaign plan with calendar slots, topic backlog, first LinkedIn draft seed, and review gates.
- Added a social draft workflow packet covering draft states, review packet structure, LinkedIn checklist, and publishing prep boundaries.

## Validation
- Loaded the personality corpus, LinkedIn voice guidance, and humanizer guidance before drafting.
- Ran anti-AI/style scan against `docs/content-strategy` for banned filler/signposting terms.
- Ran `git diff --check HEAD~1..HEAD` successfully.
- Ran `npm test -- lib/social-content-calendar.test.ts` successfully using a temporary local symlink to the already-installed main Portfolio `node_modules`; removed the symlink afterward.
- No live workflow, provider, publishing, scheduler, customer-data, or deployment smoke was run.

## Integration Notes
- Docs-only change. No migrations, env changes, provider calls, queue writes, publishing, or external scheduling.
- Publishing remains explicitly approval-gated through Shaka/human review.
- Worktree is clean and PR merge state was `CLEAN` before ready-for-review handoff.
- Vercel – portfolio: not checked; docs-only non-captain packet.
- Vercel – portfolio-staging: not checked; docs-only non-captain packet.
