### PR TITLE
docs: revise accelerated module zero script packet

### DIFF
--- a/docs/accelerated-course-modules/module-0-video-assets/README.md
+++ b/docs/accelerated-course-modules/module-0-video-assets/README.md
@@ -3,10 +3,10 @@
 Module: `module-0`
 Title: `Why Accelerated Exists`
 Approval scope: course content and local video asset packet only
-Status: approved for render preflight
+Status: ready for script-intelligence human review
 External execution: locked
 
-This packet contains the first approved module video assets for the Accelerated mini-course. It is ready to route into the existing video-generation review workflow, but it does not authorize provider execution.
+This packet contains the revised Module 0 video assets for the Accelerated mini-course. The script now uses the Script Intelligence anatomy before render approval: pain point, hook, loop, proof, CTA, and source-distance safety. It is ready for human content review, but it does not authorize provider execution.
 
 ## Included Assets
 
@@ -15,6 +15,7 @@ This packet contains the first approved module video assets for the Accelerated 
 - `elevenlabs-narration.md` - narration-safe version for audio or slide-first render.
 - `storyboard-render-spec.md` - Remotion/HyperFrames scene plan and b-roll mapping.
 - `render-handoff-checklist.md` - explicit bridge into the existing video-generation workflow.
+- `script-intelligence-review.md` - template, anatomy, scorecard, and review gate for the revised script.
 - `shorts-package.md` - 30-60 second YouTube Shorts asset packet.
 - `thumbnail-briefs.md` - three thumbnail concepts adapted to AmaduTown style.
 - `worksheet.md` - learner worksheet prompt and facilitator review notes.
@@ -29,7 +30,7 @@ This packet contains the first approved module video assets for the Accelerated 
 Allowed by this packet:
 
 - local review,
-- render-readiness preflight,
+- script-intelligence human review,
 - b-roll planning,
 - storyboard planning,
 - video-generation workflow handoff planning,
@@ -39,6 +40,7 @@ Not allowed by this packet:
 
 - HeyGen generation,
 - ElevenLabs generation,
+- render-readiness approval,
 - Remotion/HyperFrames final render,
 - n8n workflow execution,
 - uploads,

--- a/docs/accelerated-course-modules/module-0-video-assets/asset-manifest.json
+++ b/docs/accelerated-course-modules/module-0-video-assets/asset-manifest.json
@@ -2,7 +2,7 @@
   "module_id": "module-0",
   "module_title": "Why Accelerated Exists",
   "course": "Accelerated: Build Faster Without Losing the Plot",
-  "asset_packet_status": "approved_for_render_preflight",
+  "asset_packet_status": "ready_for_script_intelligence_review",
   "approval_scope": "course_content_and_local_video_asset_packet_only",
   "provider_execution_status": "locked_until_explicit_approval",
   "target_outputs": {
@@ -11,7 +11,8 @@
       "target_duration_minutes": [6, 10],
       "script": "primary-lesson-script.md",
       "captions": "captions/module-0-primary.srt",
-      "storyboard": "storyboard-render-spec.md"
+      "storyboard": "storyboard-render-spec.md",
+      "script_intelligence_review": "script-intelligence-review.md"
     },
     "youtube_short": {
       "format": "9:16",
@@ -22,7 +23,7 @@
       "concept_count": 3,
       "brief": "thumbnail-briefs.md"
     },
-    "worksheet": {
+      "worksheet": {
       "packet": "worksheet.md"
     }
   },
@@ -39,7 +40,7 @@
   "safety": {
     "allowed_now": [
       "local_review",
-      "render_readiness_preflight",
+      "script_intelligence_human_review",
       "broll_planning",
       "storyboard_planning",
       "video_generation_workflow_handoff_planning"
@@ -47,6 +48,7 @@
     "blocked_until_separate_approval": [
       "heygen_generation",
       "elevenlabs_generation",
+      "render_readiness_approval",
       "final_render",
       "n8n_execution",
       "upload",

--- a/docs/accelerated-course-modules/module-0-video-assets/captions/module-0-primary.srt
+++ b/docs/accelerated-course-modules/module-0-video-assets/captions/module-0-primary.srt
@@ -1,59 +1,59 @@
 1
 00:00:00,000 --> 00:00:05,000
-Anyone can ask AI for a roadmap now.
+The video looked ready. The script wasn't.
 
 2
 00:00:05,000 --> 00:00:12,000
-A PRD. A persona. A launch plan. A prototype.
+The avatar looked real. The cadence worked. The tool stopped being the problem.
 
 3
-00:00:12,000 --> 00:00:18,000
-In a few minutes, something shows up that looks like product work.
+00:00:12,000 --> 00:00:20,000
+Then the content exposed the gap. It did not make the pain unavoidable.
 
 4
-00:00:18,000 --> 00:00:25,000
-The blank page is not the bottleneck anymore. The bottleneck is judgment.
+00:00:20,000 --> 00:00:28,000
+That is the reason Accelerated exists.
 
 5
-00:00:25,000 --> 00:00:34,000
-That is why Accelerated exists. AI makes product judgment more important.
+00:00:28,000 --> 00:00:38,000
+AI can make the first version look finished before the thinking is finished.
 
 6
-00:00:34,000 --> 00:00:44,000
-The tool can help draft options, questions, summaries, risks, and patterns.
+00:00:38,000 --> 00:00:48,000
+The blank page used to slow us down. Now the bottleneck is judgment.
 
 7
-00:00:44,000 --> 00:00:53,000
-The human still owns context, judgment, consent, and consequence.
+00:00:48,000 --> 00:00:58,000
+The tool can create the artifact. The team still has to know what the artifact is supposed to change.
 
 8
-00:00:53,000 --> 00:01:04,000
-Inside AmaduTown, the public site is only one layer.
+00:00:58,000 --> 00:01:10,000
+Inside AmaduTown, the public site is one layer. Behind it is the operating layer.
 
 9
-00:01:04,000 --> 00:01:15,000
-Behind it are diagnostic flows, evidence dashboards, approval gates, and render-readiness checks.
+00:01:10,000 --> 00:01:22,000
+Diagnostics, evidence dashboards, review gates, script scorecards, privacy checks, and render-readiness approvals.
 
 10
-00:01:15,000 --> 00:01:25,000
-The system has to remember what happened after it moved.
-
-11
-00:01:25,000 --> 00:01:34,000
+00:01:22,000 --> 00:01:34,000
 Find the signal. Define the decision. Build the loop. Instrument the learning.
 
-12
-00:01:34,000 --> 00:01:45,000
+11
+00:01:34,000 --> 00:01:44,000
 That loop is the difference between moving fast and moving blindly.
 
+12
+00:01:44,000 --> 00:01:54,000
+Start with one workflow where AI is creating faster than your review process can keep up.
+
 13
-00:01:45,000 --> 00:01:55,000
-Technology should reduce burden. It should not create more invisible work.
+00:01:54,000 --> 00:02:05,000
+Write down the decision that workflow is supposed to improve.
 
 14
-00:01:55,000 --> 00:02:05,000
-Move fast to discover. Slow down where the decision carries risk.
+00:02:05,000 --> 00:02:16,000
+Then identify the signal that would prove the work is actually getting better.
 
 15
-00:02:05,000 --> 00:02:16,000
-What is the system learning from all of that speed?
+00:02:16,000 --> 00:02:27,000
+That is your first Accelerated loop.

--- a/docs/accelerated-course-modules/module-0-video-assets/elevenlabs-narration.md
+++ b/docs/accelerated-course-modules/module-0-video-assets/elevenlabs-narration.md
@@ -1,52 +1,54 @@
 # Module 0 ElevenLabs Narration Packet
 
-Status: approved for render preflight
+Status: ready for script-intelligence human review
 Provider execution: locked until explicit approval
 
-Use this narration path if Module 0 is produced as a slide-first or audio-first lesson. It is adapted from the primary script with less direct-to-camera phrasing and clearer visual beats.
+Use this narration path if Module 0 is produced as a slide-first or audio-first lesson. It is adapted from the revised primary script with less direct-to-camera phrasing and clearer visual beats.
 
 ## Narration Direction
 
 - Voice: grounded, reflective, practical.
-- Pace: measured, with room between the short operating-loop lines.
-- Avoid overly dramatic trailer delivery.
-- Keep the tone closer to a product leader explaining a hard lesson than a keynote promo.
+- Pace: measured, with real pauses after the opening production-review lines.
+- Avoid trailer delivery.
+- Keep the tone closer to a product leader explaining a hard lesson from a real build than a keynote promo.
 
 ## Narration Script
 
-Anyone can ask AI for a roadmap now.
+A generated lesson preview can look finished before the lesson is actually ready.
 
-The tool can draft a PRD, a persona, a stakeholder map, a launch plan, a prototype, or a set of user stories in minutes.
+The avatar can look real.
 
-That changes the work.
+The cadence can work.
 
-The blank page used to slow teams down. Now the artifact can arrive before the thinking is finished.
+The production quality can be strong enough that the tool stops being the problem.
 
-That speed is useful. It can also create a new burden.
+Then the script exposes the gap.
 
-Teams can make more drafts than they can review, more concepts than they can test, more workflows than they can govern, and more output than the organization can learn from.
+It explains the topic, but it does not make the pain unavoidable. It does not make the next action clear.
 
 That is the reason *Accelerated* exists.
 
-The book does not argue that AI replaces product judgment. It argues that AI makes judgment more important.
+AI can now create the first version before the thinking is finished.
 
-When the first version gets cheap, the expensive work moves to the questions behind the artifact.
+Anyone can ask for a roadmap, a PRD, a persona, a stakeholder map, a launch plan, a prototype, or a video script in minutes.
 
-What problem deserves attention?
+That speed is useful. It can also create a new burden.
 
-What evidence do we trust?
+Teams can make more drafts than they can review, more ideas than they can test, more content than they can defend, and more workflows than they can govern.
 
-What decision are we trying to make?
+The blank page used to slow teams down.
 
-What risk are we introducing?
+Now the bottleneck is judgment.
 
-Who carries the consequence if the system gets it wrong?
+The tool can create the artifact. The team still has to know what the artifact is supposed to change.
 
-Inside AmaduTown, that question is not theoretical. The public site is only one layer. Behind it are diagnostic flows, evidence dashboards, content approval gates, agent workflows, review packets, b-roll capture plans, and render-readiness checks.
+If that answer is unclear, speed becomes expensive.
+
+Inside AmaduTown, this is not theoretical. The public site is one layer. Behind it are diagnostic flows, evidence dashboards, review gates, script scorecards, b-roll plans, privacy checks, and render-readiness approvals.
 
 The operating layer matters because product work does not end when something gets created.
 
-The system has to remember what happened after it moved.
+The system has to learn after the first version moves.
 
 This course is built around a simple loop.
 
@@ -66,22 +68,14 @@ Loop keeps the signal from living only in someone's memory.
 
 Learning gives the team a record of what changed.
 
-That is the difference between moving fast and moving blindly.
+Technology should reduce burden. It should not make teams pretend speed and progress are the same thing.
 
-Technology should reduce burden. It should not create more invisible work for people who were already overloaded. It should not make teams pretend speed and progress are the same thing.
+So start with one workflow where AI is already helping your team create faster than the review process can keep up.
 
-The product leader's job is to keep the work honest.
+Write down the decision that workflow is supposed to improve.
 
-Move fast to discover.
+Then identify the signal that would prove the work is getting better.
 
-Slow down where the decision carries risk.
+That is your first Accelerated loop.
 
-Capture what the system learns.
-
-So start with one place where your team is already moving fast.
-
-Then ask the question most teams skip:
-
-What is the system learning from all of that speed?
-
-If the answer is unclear, the work is not done.
+If you want help building it, join the Accelerated Workshop interest path or book an AI Quick Win discovery call through AmaduTown.

--- a/docs/accelerated-course-modules/module-0-video-assets/heygen-segments.md
+++ b/docs/accelerated-course-modules/module-0-video-assets/heygen-segments.md
@@ -1,45 +1,57 @@
 # Module 0 HeyGen Segment Scripts
 
-Status: approved for render preflight
+Status: ready for script-intelligence human review
 Provider execution: locked until explicit approval
 
-Use these as discrete avatar clips that can be composited with b-roll in Remotion or HyperFrames. Keep the avatar framed cleanly with AmaduTown visual treatment. Do not generate these clips until the provider approval gate is granted.
+Use these as discrete avatar clips that can be composited with b-roll in Remotion or HyperFrames after the content review gate is approved. Keep the avatar framed cleanly with AmaduTown visual treatment. Do not generate these clips until the provider approval gate is granted.
 
-## Segment A - Opening Hook
+## Segment A - Opening Pain Point
 
-Target duration: 35-45 seconds
+Target duration: 45-55 seconds
 
-Anyone can ask AI for a roadmap now.
+I watched a generated lesson preview and had the reaction every product leader should pay attention to.
 
-A PRD. A persona. A launch plan. A prototype. In a few minutes, something appears that looks like product work.
+The avatar looked real.
 
-That is useful. I use these tools every day.
+The cadence worked.
 
-But the blank page is not the bottleneck anymore.
+The production quality was finally good enough that I could stop worrying about the tool.
 
-The bottleneck is judgment.
+Then I listened to the content and felt the gap.
 
-That is why *Accelerated* exists. This course is about using AI speed without losing the product discipline that makes the work safe, useful, and worth building.
+It explained the topic, but it did not make the pain unavoidable. It did not make the next action obvious.
+
+That is the exact reason *Accelerated* exists.
+
+AI can now make the first version look finished before the thinking is finished.
 
 ## Segment B - Course Frame
 
-Target duration: 55-70 seconds
+Target duration: 60-75 seconds
 
-AI can help generate options, questions, summaries, risks, and first drafts.
+Anyone can ask AI for a roadmap now. A PRD. A persona. A stakeholder map. A launch plan. A prototype. A video script.
 
-The human still owns context, judgment, consent, and consequence.
+That is useful. I use these tools every day.
 
-Inside AmaduTown, I am building against that exact tension. The public site is one layer. Behind it are diagnostic flows, evidence dashboards, content approval gates, agent workflows, review packets, b-roll plans, and render-readiness checks.
+But speed creates a new kind of burden.
 
-The operating layer matters because the work does not end when the artifact gets created.
+Teams can make more drafts than they can review. More ideas than they can test. More content than they can defend. More workflows than they can govern.
 
-The system has to remember what happened after it moved.
+The blank page used to slow us down.
 
-## Segment C - Operating Loop
+Now the real bottleneck is judgment.
 
-Target duration: 45-60 seconds
+The tool can create the artifact. The team still has to know what the artifact is supposed to change.
 
-The course comes back to one operating loop.
+## Segment C - Proof And Operating Loop
+
+Target duration: 60-75 seconds
+
+Inside AmaduTown, I am building the operating layer around this tension.
+
+The public site is one layer. Behind it are diagnostic flows, evidence dashboards, social content review gates, agent work queues, script scorecards, b-roll capture plans, privacy checks, and render-readiness approvals.
+
+The course comes back to one operating loop:
 
 Find the signal.
 
@@ -49,18 +61,18 @@ Build the loop.
 
 Instrument the learning.
 
-That loop is the difference between moving fast and moving blindly. It gives the team a way to turn AI output into accountable product learning.
+That loop is the difference between moving fast and moving blindly.
 
-## Segment D - Closing Question
+## Segment D - CTA Close
 
-Target duration: 25-35 seconds
+Target duration: 35-45 seconds
 
-Start with one place where your team is already moving fast.
+Start with one workflow where AI is already helping your team create faster than the review process can keep up.
 
-Maybe AI is drafting content. Maybe prototypes are easier to build. Maybe meetings are being summarized. Maybe workflows are getting automated.
+Write down the decision that workflow is supposed to improve.
 
-Then ask the question most teams skip:
+Then identify the signal that would prove the work is actually getting better.
 
-What is the system learning from all of that speed?
+That is your first Accelerated loop.
 
-If the answer is unclear, the work is not done.
+If you want help building that loop with me, join the Accelerated Workshop interest path or book an AI Quick Win discovery call through AmaduTown.

--- a/docs/accelerated-course-modules/module-0-video-assets/primary-lesson-script.md
+++ b/docs/accelerated-course-modules/module-0-video-assets/primary-lesson-script.md
@@ -3,31 +3,71 @@
 Title: Why Accelerated Exists
 Target length: 6-10 minutes
 Video style: HeyGen avatar plus AmaduTown/Portfolio b-roll
-Status: approved for render preflight
+Status: ready for script-intelligence human review
 
 ## Script
 
-Anyone can ask AI for a roadmap now.
+I watched a generated lesson preview and had the reaction every product leader should pay attention to.
 
-You can ask for a PRD, a persona, a stakeholder map, a launch plan, a prototype, or a list of user stories. In a few minutes, something shows up that looks like product work.
+The avatar looked real.
 
-That changes the room.
+The cadence worked.
 
-The blank page used to slow us down. It was annoying, but it forced a certain kind of thinking. You had to sit with the problem long enough to make choices. You had to decide what mattered before the artifact existed.
+The production quality was finally good enough that I could stop worrying about the tool.
 
-Now the artifact can arrive before the thinking is finished.
+Then I listened to the content and felt the gap.
 
-That is useful. I use these tools every day. A lot of what I have built for AmaduTown started with AI helping me get a rough draft out of my head and onto the screen.
+It explained the topic, but it did not make the pain unavoidable. It sounded like a smart overview, but it did not make a builder, founder, or product leader feel the problem in their own workflow. It did not make the next action obvious.
+
+That is the exact reason *Accelerated* exists.
+
+AI can now make the first version look finished before the thinking is finished.
+
+That changes the work.
+
+Anyone can ask AI for a roadmap now. A PRD. A persona. A stakeholder map. A launch plan. A prototype. A video script. A course outline. In a few minutes, something shows up that looks like product work.
+
+That is useful. I use these tools every day.
 
 But speed creates a new kind of burden.
 
-Product teams can now make more drafts than they can review. More concepts than they can test. More workflows than they can govern. More content than they can explain. More output than the organization can learn from.
+Teams can make more drafts than they can review. More ideas than they can test. More content than they can defend. More workflows than they can govern. More polished assets than the organization can learn from.
 
-That is the reason *Accelerated* exists.
+The blank page used to slow us down.
 
-The book is not a pitch for replacing product judgment with AI. It is a warning that AI makes judgment more important. When the first version gets cheap, the expensive work moves somewhere else.
+Now the real bottleneck is judgment.
 
-It moves to the questions behind the work.
+That is the pain point.
+
+The tool can create the artifact. The team still has to know what the artifact is supposed to change.
+
+If the answer is unclear, speed becomes expensive.
+
+You get more documents, more meetings, more revisions, more approvals, more content, more screenshots, more decks, more scripts, and still no cleaner decision.
+
+I do not say that as someone watching from the outside. I am building the operating layer behind AmaduTown with this tension in the middle of the room.
+
+The public site is one layer.
+
+Behind it are diagnostic flows, evidence dashboards, social content review gates, agent work queues, script scorecards, b-roll capture plans, privacy checks, and render-readiness approvals.
+
+Some pieces are polished. Some pieces are still being hardened.
+
+That is the proof point. I am not teaching AI-assisted product work as a theory. I am trying to build the system I would trust enough to use.
+
+And the lesson keeps coming back to the same question:
+
+What does the system learn after AI creates the first version?
+
+Because if the system does not learn, the team just gets faster at producing noise.
+
+That is the trap *Accelerated* is trying to help people avoid.
+
+The book is not a pitch for replacing product judgment with AI. It is a practical warning that AI makes judgment more important.
+
+When the first version gets cheap, the expensive work moves somewhere else.
+
+It moves to the questions behind the artifact.
 
 What problem deserves attention?
 
@@ -41,43 +81,31 @@ Who has to carry the consequence if this system gets it wrong?
 
 What did we learn the last time we tried something similar?
 
-Those questions do not disappear because the tool got faster. They become easier to avoid.
+Those questions do not disappear because the tool got faster.
 
-That is the trap.
+They become easier to avoid.
 
-The screen fills up. The document looks polished. The prototype moves. The meeting has something to react to. Everyone feels like progress happened.
+The screen fills up. The draft sounds confident. The prototype moves. The video looks clean. The meeting finally has something to react to.
 
-Then a week later, the team is still arguing about the same decision because the artifact never answered the real question.
+Everyone feels like progress happened.
+
+Then the next week arrives and the team is still arguing about the same decision because the artifact never answered the real question.
 
 So this course starts with a different frame.
 
 AI speed only helps when it is connected to product discipline.
 
-That means the tool can help generate options, questions, drafts, summaries, risks, and patterns. The human still owns context, judgment, consent, and consequence.
+That discipline is not bureaucracy. It is not a committee for every click. It is not slowing everything down until nobody ships.
 
-I want to make that practical.
+It is the right friction in the right place.
 
-Inside AmaduTown, I am not only talking about this. I am building against it. The public website is one layer. Behind it are diagnostic flows, evidence dashboards, content approval gates, agent workflows, review packets, b-roll capture plans, and render-readiness checks.
+Move fast to discover.
 
-Some of it is polished. Some of it is still rough. That is part of the point.
+Slow down where the decision carries risk.
 
-The operating layer matters because the work does not end when an artifact gets created.
+Capture what the system learns.
 
-The system has to remember what happened after it moved.
-
-If a diagnostic intake collects a pain point, where does that signal go?
-
-If a social post draft gets revised, where does that feedback live?
-
-If an agent prepares a video asset, what stops it from publishing before a human reviews the privacy risk?
-
-If a dashboard shows activity, what decision does that activity change?
-
-Those are product questions.
-
-And once AI enters the workflow, they become governance questions too.
-
-That is why this mini-course is structured around a simple operating loop.
+Inside this course, we will use a simple operating loop:
 
 Find the signal.
 
@@ -87,55 +115,57 @@ Build the loop.
 
 Instrument the learning.
 
-That loop is the difference between moving fast and moving blindly.
+Signal means you know what evidence matters. It might be customer behavior, staff time, conversion, cost, support volume, content performance, quality review, or a repeated pattern inside a set of conversations.
 
-Signal means the team knows what evidence matters. It may be customer behavior, staff time, conversion, cost, support volume, quality review, or the pattern inside a set of conversations.
+Decision means you can name the choice that evidence should improve. Build this. Stop that. Test this segment. Delay this automation. Change this onboarding step. Rewrite this script because the pain point is missing.
 
-Decision means the team can say what choice the evidence is supposed to improve. Build this. Stop that. Test this segment. Delay this automation. Change this onboarding step.
-
-Loop means the signal does not live in someone's memory. It enters a workflow. It gets reviewed. It changes a recommendation. It creates a record.
+Loop means the signal does not live in somebody's memory. It enters a workflow. It gets reviewed. It changes a recommendation. It creates a record.
 
 Learning means the team can look back and say what changed because of the decision.
 
-That is what I want participants to leave with.
+That is the difference between moving fast and moving blindly.
 
-Not a pile of AI prompts.
-
-A way to make product work lighter, clearer, and more accountable.
-
-There is a moral piece to this too.
+The moral piece matters too.
 
 Technology should reduce burden. It should not dump more invisible work on the same people who were already overloaded. It should not make teams pretend that speed and progress are the same thing. It should not create systems that act with confidence but cannot explain themselves.
 
 The product leader's job is to keep the work honest.
 
-That does not mean slowing everything down until nothing ships. It means creating the right friction in the right place.
+That is why Module 0 starts here, before we talk about prompts, roadmaps, decision theater, or the new moat.
 
-Move fast to discover.
+If the opening does not name the pain, people will not trust the course.
 
-Slow down where the decision carries risk.
+If the system cannot show the receipt, people will not trust the work.
 
-Capture what the system learns.
+If the CTA is vague, people will not know what to do next.
 
-This first module sets the frame for the rest of the course. In the next modules, we will move through discovery, feedback, roadmaps, decision theater, the new moat, and the one-week learning loop you can build around a real product decision.
+So here is the CTA for this lesson:
 
-But before any of that, start here.
+If your team is using AI to create faster, pick one workflow where the output is already moving faster than the review process. Write down the decision that workflow is supposed to improve. Then identify the signal that would prove the work is actually getting better.
 
-Look at one place where your team is already moving fast.
+That is your first Accelerated loop.
 
-Maybe AI is drafting content. Maybe prototypes are easier to build. Maybe meetings are being summarized. Maybe workflows are getting automated. Maybe people are generating strategy docs that used to take weeks.
+If you want help building that loop with me, join the Accelerated Workshop interest path or book an AI Quick Win discovery call through AmaduTown.
 
-Then ask the question most teams skip:
+The goal is not more AI output.
 
-What is the system learning from all of that speed?
-
-If the answer is unclear, the work is not done.
+The goal is a product system that learns from the speed.
 
 That is where *Accelerated* begins.
 
+## Script Intelligence Review Notes
+
+- **Template used:** `accelerated_lesson` with the `problem_proof_offer` CTA pattern.
+- **Pain point:** AI can make polished artifacts before the team has clarified judgment, evidence, risk, and next action.
+- **Triggering event:** Review of a generated lesson preview where production quality was strong but the content lacked urgency and CTA clarity.
+- **Proof cue:** AmaduTown/Portfolio operating layer: diagnostics, evidence dashboards, review gates, script scorecards, b-roll planning, privacy checks, and render readiness.
+- **CTA:** Build one Accelerated loop; join the Accelerated Workshop interest path or book an AI Quick Win discovery call.
+- **Provider boundary:** This script is ready for human content review only. HeyGen, ElevenLabs, rendering, upload, scheduling, and publishing remain locked.
+
 ## Voice Review
 
-- Grounded in Vambah's product-builder voice.
-- Keeps AI practical, not hype-driven.
-- Preserves the moral frame: speed must reduce burden and preserve accountability.
-- Avoids raw private details, client details, and private chat quotes.
+- Starts from a concrete builder moment instead of an abstract course premise.
+- Names the pain before introducing the framework.
+- Keeps the AmaduTown proof public-safe and operational.
+- Makes the CTA explicit without promising external execution.
+- Removes generic AI hype and keeps the script grounded in product judgment.

--- a/docs/accelerated-course-modules/module-0-video-assets/privacy-qa.md
+++ b/docs/accelerated-course-modules/module-0-video-assets/privacy-qa.md
@@ -1,6 +1,6 @@
 # Module 0 Privacy And QA Checklist
 
-Status: approved asset packet; capture review still required before render
+Status: script review required; capture review still required before render
 
 ## Approved Source Types
 
@@ -31,4 +31,4 @@ Before render:
 
 ## Current Decision
 
-The Module 0 content and local assets are approved for render preflight. Provider generation and final rendering are not approved by this packet.
+The Module 0 content has been revised and must pass Script Intelligence review before render-readiness approval. Provider generation and final rendering are not approved by this packet.

--- a/docs/accelerated-course-modules/module-0-video-assets/render-handoff-checklist.md
+++ b/docs/accelerated-course-modules/module-0-video-assets/render-handoff-checklist.md
@@ -1,9 +1,9 @@
 # Module 0 Render Handoff Checklist
 
-Status: approved asset packet; render preflight allowed
+Status: blocked until script-intelligence approval
 Provider execution: locked until explicit approval
 
-This checklist is the bridge from the approved Module 0 asset packet into the existing Portfolio video-generation workflow. It does not authorize HeyGen, ElevenLabs, Remotion, HyperFrames, upload, scheduling, or publishing jobs.
+This checklist is the bridge from the revised Module 0 asset packet into the existing Portfolio video-generation workflow. It does not authorize render-readiness approval, HeyGen, ElevenLabs, Remotion, HyperFrames, upload, scheduling, or publishing jobs.
 
 ## Target Workflow
 
@@ -18,7 +18,7 @@ This checklist is the bridge from the approved Module 0 asset packet into the ex
 
 ## Preflight Steps
 
-1. Open the Module 0 packet and confirm the script, worksheet, Shorts package, thumbnail briefs, and privacy checklist are still approved.
+1. Open the Module 0 packet and confirm the revised script, Shorts package, thumbnail briefs, and privacy checklist have passed Script Intelligence review.
 2. Confirm the selected render mode:
    - default: HeyGen avatar plus Portfolio/AmaduTown b-roll,
    - fallback: ElevenLabs narration plus slide-first visuals.
@@ -44,8 +44,9 @@ Approval for one action does not imply approval for the others.
 
 ## Ready-To-Queue Criteria
 
-Module 0 can move from `ready_for_render_preflight` to queued render work only when:
+Module 0 can move from `ready_for_script_intelligence_review` to render-readiness preflight only when:
 
+- Script Intelligence review is approved,
 - privacy review is passed,
 - b-roll sources are public-safe or redacted,
 - avatar/narration provider choice is confirmed,

--- a/docs/accelerated-course-modules/module-0-video-assets/script-intelligence-review.md
+++ b/docs/accelerated-course-modules/module-0-video-assets/script-intelligence-review.md
@@ -1,0 +1,39 @@
+# Module 0 Script Intelligence Review
+
+Status: ready for human review
+Provider execution: locked
+
+## Template
+
+- **Primary template:** `accelerated_lesson`
+- **CTA pattern:** `problem_proof_offer`
+- **Source references:** internal AmaduTown/Portfolio proof only; no creator script, title, or thumbnail copying.
+
+## Script Anatomy
+
+| Component | Current draft |
+| --- | --- |
+| Pain point | AI can make polished artifacts before the team has clarified judgment, evidence, risk, and next action. |
+| Hook | A generated lesson preview looked realistic and well-paced, but the content did not make the pain or CTA clear. |
+| Open loop | If production quality is no longer the blocker, what keeps the work trustworthy? |
+| Frame | The blank page is gone; judgment is the bottleneck. |
+| Proof | AmaduTown/Portfolio operating layer: diagnostics, evidence dashboards, social content review gates, agent work queues, script scorecards, b-roll planning, privacy checks, and render-readiness approvals. |
+| CTA | Build one Accelerated loop, then join the Accelerated Workshop interest path or book an AI Quick Win discovery call through AmaduTown. |
+| Closing question | What decision is this AI-generated artifact supposed to improve? |
+
+## Review Gate
+
+Approve only if the reviewer agrees that:
+
+- the opening pain is strong enough to justify the course;
+- the proof cue shows why Vambah is qualified to teach this now;
+- the CTA is specific enough to guide the learner's next action;
+- the script does not expose private meetings, raw Chronicle notes, client material, secrets, or unpublished sensitive data;
+- provider generation remains locked until the next explicit approval.
+
+Reject with a decision note if:
+
+- the pain point still feels abstract;
+- the CTA should point somewhere more specific than the workshop interest or AI Quick Win path;
+- the proof needs a cleaner AmaduTown/Portfolio screen;
+- any language sounds like generic AI/product hype.

--- a/docs/accelerated-course-modules/module-0-video-assets/shorts-package.md
+++ b/docs/accelerated-course-modules/module-0-video-assets/shorts-package.md
@@ -1,59 +1,64 @@
 # Module 0 YouTube Shorts Packet
 
-Status: approved for render preflight
+Status: ready for script-intelligence human review
 Provider execution: locked until explicit approval
 
 ## Short Title
 
-The Blank Page Is Gone. Judgment Is The Bottleneck.
+The Video Looked Ready. The Script Wasn't.
 
 ## Hook
 
-Anyone can ask AI for a roadmap now.
+The avatar looked real. The cadence worked. The content still missed the pain.
 
 ## 45-Second Script
 
-Anyone can ask AI for a roadmap now.
+The avatar looked real.
 
-A PRD. A persona. A launch plan. A prototype.
+The cadence worked.
 
-In a few minutes, something appears that looks like product work.
+The video finally looked good enough that the tool stopped being the problem.
 
-That is useful. I use these tools every day.
+Then I listened to the script and felt the gap.
 
-But the blank page is not the bottleneck anymore.
+It explained the topic, but it did not make the pain unavoidable. It did not make the next action clear.
+
+That is the AI product trap.
+
+The first version can look finished before the thinking is finished.
+
+So the bottleneck is not the blank page anymore.
 
 The bottleneck is judgment.
 
-AI can help make the first draft. The product leader still has to ask what deserves to exist, what evidence supports it, what risk it creates, and what the system learns after it moves.
+Before you ship the AI-generated artifact, ask one question:
 
-That is why I built *Accelerated* around a simple loop:
+What decision is this supposed to improve?
 
-Find the signal.
+If you cannot answer that, the work is moving faster than the system is learning.
 
-Define the decision.
+That is why I built *Accelerated* around one loop:
 
-Build the loop.
+Signal. Decision. Loop. Learning.
 
-Instrument the learning.
-
-The question is not whether your team can move faster.
-
-The question is whether the system is learning from all that speed.
+Join the Accelerated Workshop interest path if you want help building that loop.
 
 ## Visual Plan
 
-- 0:00-0:04: Direct-to-camera avatar, text: "Anyone can ask AI for a roadmap now."
-- 0:04-0:12: Rapid artifact cards: PRD, persona, launch plan, prototype.
-- 0:12-0:20: Hard pause, text: "The bottleneck is judgment."
-- 0:20-0:34: Four-part loop cards.
-- 0:34-0:45: Closing question over AmaduTown/Accelerated visual.
+- 0:00-0:05: Direct-to-camera avatar, text: "The video looked ready."
+- 0:05-0:12: Split cards: avatar, cadence, production quality.
+- 0:12-0:20: Hard pause, text: "The script missed the pain."
+- 0:20-0:31: Artifact cards: PRD, roadmap, video script, prototype.
+- 0:31-0:41: Four-part loop cards: Signal -> Decision -> Loop -> Learning.
+- 0:41-0:45: CTA card: "Build your first Accelerated loop."
 
 ## Caption
 
-AI made the first draft cheaper. Product judgment became more important.
+AI can make the first version look finished before the thinking is finished.
 
-Module 0 of Accelerated starts here: speed only matters when the system learns from it.
+That is why the bottleneck is judgment now.
+
+Module 0 of Accelerated starts with one question: what decision is this artifact supposed to improve?
 
 ## Hashtags
 

--- a/docs/accelerated-course-modules/module-0-video-assets/storyboard-render-spec.md
+++ b/docs/accelerated-course-modules/module-0-video-assets/storyboard-render-spec.md
@@ -1,6 +1,6 @@
 # Module 0 Storyboard And Render Spec
 
-Status: approved for render preflight
+Status: ready for script-intelligence human review
 Render execution: locked until explicit approval
 
 ## Composition Defaults
@@ -16,15 +16,15 @@ Render execution: locked until explicit approval
 
 | Scene | Duration | Visual | Audio Source | B-roll / Asset |
 | --- | ---: | --- | --- | --- |
-| 1. Title | 0:00-0:12 | Title card: Why Accelerated Exists | Music bed only or cold open | `visual-assets/title-card.svg` |
-| 2. Hook | 0:12-0:55 | HeyGen avatar opening | HeyGen Segment A | Avatar clip pending provider approval |
-| 3. Artifact Speed | 0:55-1:45 | Animated list: roadmap, PRD, persona, launch plan, prototype | Primary script or narration | Local text animation |
-| 4. Judgment Bottleneck | 1:45-2:45 | Split visual: fast artifacts vs. review gates | Primary script | Course framework visual |
-| 5. AmaduTown Proof | 2:45-4:05 | Public AmaduTown/Accelerated product surface | Primary script | Capture public publication/product surface |
-| 6. Operating Layer | 4:05-5:35 | Diagnostic, evidence, approval, and render-readiness screens | HeyGen Segment B | Public-safe/sanitized b-roll only |
-| 7. The Loop | 5:35-7:10 | Four-part loop animation | HeyGen Segment C or narration | Signal -> Decision -> Loop -> Learning |
-| 8. Moral Frame | 7:10-8:20 | Quiet avatar or text-led cards | Primary script | No private b-roll |
-| 9. Closing Question | 8:20-9:00 | Closing card and avatar close | HeyGen Segment D | `visual-assets/closing-card.svg` |
+| 1. Cold Open | 0:00-0:18 | Avatar or text-led cold open: "The video looked ready. The script wasn't." | HeyGen Segment A or narration | Avatar clip pending provider approval |
+| 2. Title | 0:18-0:30 | Title card: Why Accelerated Exists | Music bed | `visual-assets/title-card.svg` |
+| 3. Production Gap | 0:30-1:25 | Three cards: avatar looked real, cadence worked, pain was missing | Primary script or narration | Local text animation |
+| 4. Artifact Speed | 1:25-2:15 | Animated list: roadmap, PRD, persona, launch plan, prototype, video script | Primary script or narration | Local text animation |
+| 5. Judgment Bottleneck | 2:15-3:20 | Split visual: polished artifacts vs. review gates | HeyGen Segment B | Course framework visual |
+| 6. AmaduTown Proof | 3:20-4:50 | Public AmaduTown/Accelerated product surface plus safe Portfolio proof surfaces | Primary script | Capture public/sanitized proof only |
+| 7. Operating Layer | 4:50-6:15 | Diagnostic, evidence, approval, script scorecard, privacy, and render-readiness screens | HeyGen Segment C | Public-safe/sanitized b-roll only |
+| 8. The Loop | 6:15-7:35 | Four-part loop animation | HeyGen Segment C or narration | Signal -> Decision -> Loop -> Learning |
+| 9. CTA Close | 7:35-8:35 | CTA card and avatar close | HeyGen Segment D | `visual-assets/closing-card.svg` |
 
 ## B-Roll Capture Requests
 
@@ -38,6 +38,7 @@ Use existing Portfolio capture tooling only after local screen review:
 ## Render-Readiness Checklist
 
 - Confirm title card and closing card render at 1920x1080.
+- Confirm Script Intelligence review is approved before render-readiness approval.
 - Confirm all avatar clips are optional and can be replaced with narration if HeyGen is unavailable.
 - Confirm b-roll uses public or redacted surfaces only.
 - Confirm captions match the final selected script.

--- a/docs/accelerated-course-modules/module-0-video-assets/thumbnail-briefs.md
+++ b/docs/accelerated-course-modules/module-0-video-assets/thumbnail-briefs.md
@@ -1,6 +1,6 @@
 # Module 0 Thumbnail Briefs
 
-Status: approved for render preflight
+Status: review required after script update
 Generation status: local brief only. No image provider call approved.
 
 ## Brand Direction
@@ -25,19 +25,19 @@ Why it fits:
 
 This is the strongest course thesis for Module 0.
 
-## Concept 2 - The Blank Page Is Gone
+## Concept 2 - The Script Wasn't Ready
 
 Text:
 
-`THE BLANK PAGE IS GONE`
+`THE SCRIPT WASN'T READY`
 
 Visual:
 
-A blank document turns into a stack of AI-generated artifacts. A gold warning line separates the stack from a quiet decision loop.
+A clean avatar preview sits beside a script review card with the missing pain point highlighted. A gold line connects the review card to Signal, Decision, Loop, Learning.
 
 Why it fits:
 
-This ties directly to the opening hook and Shorts package.
+This ties directly to the revised opening hook and Shorts package.
 
 ## Concept 3 - Build Faster Without Losing The Plot
 

--- a/docs/accelerated-course-modules/module-production-packets.md
+++ b/docs/accelerated-course-modules/module-production-packets.md
@@ -13,45 +13,55 @@ Execution status: review packets only. Provider calls, uploads, rendering, sched
 
 ### Primary Lesson Script Draft
 
-Anyone can ask an AI tool for a roadmap now.
+I watched a generated lesson preview and had the reaction every product leader should pay attention to.
 
-You can ask for a PRD, a persona, a list of user stories, a launch plan, or a prototype. In a few minutes, something appears that looks like work.
+The avatar looked real. The cadence worked. The production quality was finally good enough that I could stop worrying about the tool.
+
+Then I listened to the content and felt the gap.
+
+It explained the topic, but it did not make the pain unavoidable. It sounded like a smart overview, but it did not make a builder, founder, or product leader feel the problem in their own workflow. It did not make the next action obvious.
+
+That is the exact reason *Accelerated* exists.
+
+AI can now make the first version look finished before the thinking is finished.
+
+Anyone can ask AI for a roadmap now. A PRD. A persona. A stakeholder map. A launch plan. A prototype. A video script. A course outline. In a few minutes, something shows up that looks like product work.
 
 That is useful. I use these tools every day.
 
-But speed introduces a new problem. Product teams can now create more artifacts than they can govern, test, or learn from. The blank page is no longer the bottleneck. The bottleneck is judgment.
+But speed creates a new kind of burden.
 
-That is why I wrote *Accelerated*. The book is not an argument that AI should replace product thinking. It is an argument that AI makes product thinking more important.
+Teams can make more drafts than they can review. More ideas than they can test. More content than they can defend. More workflows than they can govern. More polished assets than the organization can learn from.
 
-When the first draft gets cheap, the next question becomes harder. What deserves to exist? What evidence do we have? What decision are we trying to make? What risk are we introducing? What did the last experiment teach us? Who is carrying the burden if this system gets it wrong?
+The blank page used to slow us down. Now the real bottleneck is judgment.
 
-That is the center of this course.
+The tool can create the artifact. The team still has to know what the artifact is supposed to change.
 
-The promise is simple: use AI to reduce friction without losing the plot. Let the tool help with drafts, questions, summaries, options, and patterns. Keep the human responsible for context, judgment, consent, and consequence.
+If the answer is unclear, speed becomes expensive.
 
-You will see that through the book, but also through AmaduTown. I do not want this course to live only as theory. The operating layer behind AmaduTown is part of the proof. The site, the tools, the admin workflows, the social content system, the evidence dashboards, and the agent approvals all point to the same lesson.
+Inside AmaduTown, I am building the operating layer around this tension. The public site is one layer. Behind it are diagnostic flows, evidence dashboards, social content review gates, agent work queues, script scorecards, b-roll capture plans, privacy checks, and render-readiness approvals.
 
-AI can move fast.
+The course uses one operating loop: find the signal, define the decision, build the loop, and instrument the learning.
 
-A product system has to remember what happened after it moved.
+That loop is the difference between moving fast and moving blindly.
 
-So this first module sets the frame. We are not chasing more output. We are building a learning loop. The work is to connect speed to evidence, evidence to decisions, decisions to action, and action back to learning.
+Here is the CTA for this lesson:
 
-That is what turns AI from a content machine into a product advantage.
+If your team is using AI to create faster, pick one workflow where the output is already moving faster than the review process. Write down the decision that workflow is supposed to improve. Then identify the signal that would prove the work is actually getting better.
 
-By the end of the course, you should be able to take one messy product decision and build a practical learning loop around it. You will know what signal you need, what AI can help draft, what still needs human review, and how to keep the system from creating more work than it removes.
+That is your first Accelerated loop.
 
-Start with this question: where is your team already moving fast, but learning slowly?
+If you want help building that loop with me, join the Accelerated Workshop interest path or book an AI Quick Win discovery call through AmaduTown.
 
 ### Video Packet
 
 - **HeyGen avatar:** Opening frame, thesis, and closing question.
 - **ElevenLabs option:** Use for a short audio-only course preview if the avatar version feels too heavy.
 - **Remotion/HyperFrames composition:** Course title card, Accelerated cover/product surface, AmaduTown proof clip, captioned closing question.
-- **B-roll hints:** `accelerated publication`, `amadutown home`, `store ebook`, `public product surface`.
-- **YouTube Shorts cutdown:** "The blank page disappeared. Judgment became the bottleneck."
-- **On-screen text:** "AI speed + product discipline = learning advantage."
-- **Thumbnail concepts:** "AI SPEED NEEDS JUDGMENT"; "THE BLANK PAGE IS GONE"; "BUILD FASTER WITHOUT LOSING THE PLOT".
+- **B-roll hints:** `accelerated publication`, `amadutown home`, `store ebook`, `public product surface`, `script scorecard`, `review gates`.
+- **YouTube Shorts cutdown:** "The video looked ready. The script wasn't."
+- **On-screen text:** "The first version can look finished before the thinking is finished."
+- **Thumbnail concepts:** "THE SCRIPT WASN'T READY"; "JUDGMENT IS THE BOTTLENECK"; "AI SPEED NEEDS A LOOP".
 
 ### Worksheet Prompt
 

--- a/docs/accelerated-course-modules/review-status.json
+++ b/docs/accelerated-course-modules/review-status.json
@@ -7,12 +7,12 @@
     {
       "id": "module-0",
       "title": "Why Accelerated Exists",
-      "review_status": "approved",
-      "render_status": "ready_for_render_preflight",
-      "primary_video_status": "approved_asset_packet",
-      "shorts_status": "approved_asset_packet",
-      "thumbnail_status": "approved_asset_packet",
-      "privacy_status": "asset_packet_approved_capture_review_required",
+      "review_status": "script_intelligence_review_ready",
+      "render_status": "blocked_until_script_approval",
+      "primary_video_status": "revised_script_ready_for_review",
+      "shorts_status": "revised_script_ready_for_review",
+      "thumbnail_status": "review_required_after_script_update",
+      "privacy_status": "capture_review_required_before_render",
       "asset_packet_path": "docs/accelerated-course-modules/module-0-video-assets"
     },
     {

--- a/scripts/validate-accelerated-course-modules.ts
+++ b/scripts/validate-accelerated-course-modules.ts
@@ -72,9 +72,9 @@ assert(status.provider_execution_status === 'locked_until_explicit_approval', 'P
 assert(Array.isArray(status.modules) && status.modules.length === 8, 'review-status.json must contain 8 modules')
 for (const moduleStatus of status.modules ?? []) {
   if (moduleStatus.id === 'module-0') {
-    assert(moduleStatus.review_status === 'approved', 'module-0 review_status must be approved')
-    assert(moduleStatus.render_status === 'ready_for_render_preflight', 'module-0 must be ready for render preflight')
-    assert(moduleStatus.primary_video_status === 'approved_asset_packet', 'module-0 primary video packet must be approved')
+    assert(moduleStatus.review_status === 'script_intelligence_review_ready', 'module-0 review_status must be script-intelligence review ready')
+    assert(moduleStatus.render_status === 'blocked_until_script_approval', 'module-0 must block render until script approval')
+    assert(moduleStatus.primary_video_status === 'revised_script_ready_for_review', 'module-0 primary video packet must be ready for revised script review')
     assert(moduleStatus.asset_packet_path === 'docs/accelerated-course-modules/module-0-video-assets', 'module-0 asset packet path is missing')
   } else {
     assert(moduleStatus.review_status === 'draft', `${moduleStatus.id} review_status must be draft`)
@@ -90,6 +90,7 @@ const module0Files = [
   'elevenlabs-narration.md',
   'storyboard-render-spec.md',
   'render-handoff-checklist.md',
+  'script-intelligence-review.md',
   'shorts-package.md',
   'thumbnail-briefs.md',
   'worksheet.md',
@@ -105,12 +106,13 @@ for (const file of module0Files) {
 }
 
 assert(module0Manifest.module_id === 'module-0', 'Module 0 manifest must identify module-0')
-assert(module0Manifest.asset_packet_status === 'approved_for_render_preflight', 'Module 0 manifest must be approved for render preflight')
+assert(module0Manifest.asset_packet_status === 'ready_for_script_intelligence_review', 'Module 0 manifest must be ready for script-intelligence review')
 assert(module0Manifest.provider_execution_status === 'locked_until_explicit_approval', 'Module 0 provider execution must stay locked')
 assert(module0Manifest.target_outputs?.primary_lesson, 'Module 0 manifest missing primary lesson output')
 assert(module0Manifest.target_outputs?.youtube_short, 'Module 0 manifest missing YouTube Shorts output')
 assert(module0Manifest.target_outputs?.thumbnail, 'Module 0 manifest missing thumbnail output')
 assert(module0Manifest.provider_assets?.render_handoff_checklist === 'render-handoff-checklist.md', 'Module 0 manifest missing render handoff checklist')
+assert(module0Manifest.safety?.allowed_now?.includes('script_intelligence_human_review'), 'Module 0 must allow script-intelligence review without execution')
 assert(module0Manifest.safety?.allowed_now?.includes('video_generation_workflow_handoff_planning'), 'Module 0 must allow handoff planning without execution')
 assert(module0Manifest.safety?.privacy_review_required_before_render === true, 'Module 0 must require privacy review before render')
 for (const blocked of ['heygen_generation', 'elevenlabs_generation', 'final_render', 'upload', 'schedule', 'publish']) {
@@ -121,6 +123,11 @@ for (const expected of ['HeyGen', 'ElevenLabs', 'Remotion', 'HyperFrames', 'B-ro
   assert(packet.includes(expected) || source.includes(expected), `Missing production stack reference: ${expected}`)
 }
 
+const module0ScriptReview = read(path.join(module0AssetDir, 'script-intelligence-review.md'))
+for (const expected of ['Pain point', 'Hook', 'CTA', 'Provider execution: locked']) {
+  assert(module0ScriptReview.includes(expected), `Module 0 script-intelligence review missing ${expected}`)
+}
+
 for (const route of ['/tools/audit', '/admin/value-evidence', '/admin/chat-eval', '/admin/module-sync']) {
   assert(broll.includes(route), `B-roll list missing route ${route}`)
 }
@@ -129,4 +136,4 @@ for (const forbidden of ['Provider calls, uploads, rendering, scheduling, and pu
   assert(packet.includes(forbidden), `Missing safety boundary text: ${forbidden}`)
 }
 
-console.log('Accelerated course module package validated: 8 modules plus approved Module 0 video asset packet and safety gates present.')
+console.log('Accelerated course module package validated: 8 modules plus revised Module 0 Script Intelligence review packet and safety gates present.')


### PR DESCRIPTION
## Summary
- Revise the Accelerated Module 0 video packet around a pain-first Script Intelligence structure.
- Add an explicit `script-intelligence-review.md` gate with pain point, hook, loop, proof, CTA, source-distance safety, and approve/reject criteria.
- Move Module 0 back from render-preflight approval to script-intelligence review-ready so provider/render approval remains a separate human gate.
- Align HeyGen segments, ElevenLabs narration, Shorts packet, storyboard, captions, thumbnail brief, privacy QA, handoff checklist, manifest, and course packet status with the revised script.

## Validation
- `npx tsx scripts/validate-accelerated-course-modules.ts`
- `npm test -- lib/video-script-intelligence.test.ts`
- Script scorecard check using `evaluateVideoScript`: overall score 99, no blockers, no warnings.
- Pre-push database health check passed.
- Browser smoke not run: docs/course asset packet only, no app runtime surface changed.

## Integration Notes
- No migration or env change.
- No provider calls, HeyGen, ElevenLabs, rendering, upload, scheduling, publishing, or platform draft handoff triggered.
- Provider execution and render-readiness approval remain locked until a separate explicit human approval.
- Integration Captain required for merge sequencing and post-merge verification.
- Vercel contexts not checked by this implementation thread:
  - Vercel – portfolio
  - Vercel – portfolio-staging
