### PR TITLE
feat: gate revenue reply sends from Slack

### DIFF
--- a/docs/revenue-sprint/reply-response-automation-sop.md
+++ b/docs/revenue-sprint/reply-response-automation-sop.md
@@ -24,12 +24,11 @@ No external reply should be sent automatically. The send gate remains the exact 
 
 For revenue outreach replies:
 
-- Detect and alert within 30 minutes.
-- Draft a follow-up within 60 minutes.
+- Detect, draft, and alert on the approved WF-GDR cadence, currently every 4 hours.
 - Escalate scheduling intent, buying intent, or referral names as high priority.
 - If automation fails, produce a daily exception report so the failure is visible.
 
-The workflow can run more frequently than the general inbox sweep because this lane is tied to active sales experiments. General inbox triage can remain slower; revenue replies need faster handling.
+The 4-hour cadence is a deliberate cost/noise tradeoff for this phase. Tighten it only if reply lag becomes the experiment bottleneck.
 
 ## Existing Assets To Reuse
 
@@ -72,7 +71,10 @@ Do not rely on the current checked-in WF-GDR export as production-ready until th
 4. Confirm reply matching uses Gmail `thread_id` from the sent outreach row.
 5. Confirm Slack alert delivery goes to Vambah personally or the configured owner alert channel.
 6. Confirm Gmail draft creation does not send automatically.
-7. Confirm the exact phrase `safe to send` is required before any AI-assisted send action.
+7. Confirm the Slack alert includes both:
+   - `App draft ID`
+   - `Gmail draft ID`
+8. Confirm the exact phrase `safe to send` is required before any AI-assisted send action.
 
 ## Reply Classification
 
@@ -99,9 +101,11 @@ Each alert should include:
 - reply summary,
 - recommended next move,
 - draft follow-up,
+- app draft ID,
+- Gmail draft ID,
 - explicit approval prompt:
 
-`Reply safe to send, or send edits.`
+`Reply in Codex or Slack with: safe to send, modify: ..., or hold.`
 
 Do not include phone numbers, secrets, raw contact exports, or unnecessary private relationship notes in alerts.
 
@@ -148,7 +152,7 @@ Send is allowed only after Vambah gives explicit approval with:
 
 `safe to send`
 
-If Vambah sends edits instead, revise the draft and ask again.
+If Vambah replies `hold`, the draft remains unsent. If Vambah replies `modify: ...`, capture the requested change, keep the draft unsent, revise in Codex or Portfolio, and ask again.
 
 ## Weekly Experiment Protection
 

--- a/lib/agent-slack-events.test.ts
+++ b/lib/agent-slack-events.test.ts
@@ -3,6 +3,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   runChiefOfStaffChat: vi.fn(),
   handleSlackAgentAction: vi.fn(),
+  sendUserGmailDraft: vi.fn(),
+  decryptRefreshToken: vi.fn(),
+  resolveBusinessEmailConfig: vi.fn(),
   from: vi.fn(),
 }))
 
@@ -18,10 +21,23 @@ vi.mock('@/lib/supabase', () => ({
   supabaseAdmin: { from: mocks.from },
 }))
 
+vi.mock('@/lib/gmail-user-api', () => ({
+  sendUserGmailDraft: mocks.sendUserGmailDraft,
+}))
+
+vi.mock('@/lib/gmail-user-oauth-crypto', () => ({
+  decryptRefreshToken: mocks.decryptRefreshToken,
+}))
+
+vi.mock('@/lib/business-email-config', () => ({
+  resolveBusinessEmailConfig: mocks.resolveBusinessEmailConfig,
+}))
+
 import {
   formatChiefOfStaffSlackReply,
   handleSlackAgentEvent,
   normalizeSlackAgentMessage,
+  parseRevenueReplyApprovalCommand,
   shouldHandleSlackAgentEvent,
 } from './agent-slack-events'
 
@@ -32,8 +48,11 @@ function queryResult(result: unknown) {
     select: vi.fn(() => query),
     eq: vi.fn(() => query),
     filter: vi.fn(() => query),
+    ilike: vi.fn(() => query),
+    update: vi.fn(() => query),
     order: vi.fn(() => query),
     limit: vi.fn(() => query),
+    single: vi.fn(() => Promise.resolve(result)),
     maybeSingle: vi.fn(() => Promise.resolve(result)),
   }
   return query
@@ -78,6 +97,9 @@ describe('agent Slack events', () => {
       responseType: 'ephemeral',
       text: 'Blocker acknowledged. Ask Shaka for a next-step recommendation.',
     })
+    mocks.decryptRefreshToken.mockReturnValue('refresh-token')
+    mocks.resolveBusinessEmailConfig.mockReturnValue({ fromEmail: 'vambah@amadutown.com' })
+    mocks.sendUserGmailDraft.mockResolvedValue({ id: 'message-1', threadId: 'thread-1' })
     mocks.runChiefOfStaffChat.mockResolvedValue({
       runId: 'run-123',
       reply: 'Two items need attention.',
@@ -132,6 +154,16 @@ describe('agent Slack events', () => {
     })).toBe(false)
 
     expect(shouldHandleSlackAgentEvent({
+      type: 'message',
+      channel_type: 'channel',
+      user: 'U123',
+      channel: 'C123',
+      text: 'safe to send',
+      ts: '1700000000.000002',
+      thread_ts: '1700000000.000001',
+    })).toBe(true)
+
+    expect(shouldHandleSlackAgentEvent({
       type: 'app_mention',
       bot_id: 'B123',
       user: 'U123',
@@ -144,6 +176,17 @@ describe('agent Slack events', () => {
     expect(normalizeSlackAgentMessage({
       text: '<@UAGENT>   what is blocked right now?  <@UOTHER>',
     })).toBe('what is blocked right now?')
+  })
+
+  it('parses revenue reply approval phrases conservatively', () => {
+    expect(parseRevenueReplyApprovalCommand('safe to send')).toEqual({ action: 'safe_to_send' })
+    expect(parseRevenueReplyApprovalCommand('Safe to send.')).toEqual({ action: 'safe_to_send' })
+    expect(parseRevenueReplyApprovalCommand('hold')).toEqual({ action: 'hold', note: 'hold' })
+    expect(parseRevenueReplyApprovalCommand('modify: tighten the opening')).toEqual({
+      action: 'modify',
+      note: 'tighten the opening',
+    })
+    expect(parseRevenueReplyApprovalCommand('send it')).toBeNull()
   })
 
   it('routes a Slack mention into Chief of Staff chat and replies in thread', async () => {
@@ -294,6 +337,127 @@ describe('agent Slack events', () => {
       ],
     })
     expect(mocks.runChiefOfStaffChat).not.toHaveBeenCalled()
+  })
+
+  it('sends a revenue reply Gmail draft from a guarded Slack safe-to-send thread reply', async () => {
+    const appDraftId = '9abee71a-930d-49e9-a2b5-d929021ec9cb'
+    const gmailDraftId = 'r5747226337828186444'
+    mocks.from
+      .mockReturnValueOnce(queryResult({ data: null, error: null }))
+      .mockReturnValueOnce(queryResult({
+        data: {
+          id: appDraftId,
+          status: 'draft',
+          subject: 'Re: controlled smoke',
+          client_email: 'lead@example.com',
+        },
+        error: null,
+      }))
+      .mockReturnValueOnce(queryResult({
+        data: {
+          google_email: 'vambah@amadutown.com',
+          refresh_token_cipher: 'cipher',
+          refresh_token_iv: 'iv',
+          refresh_token_tag: 'tag',
+        },
+        error: null,
+      }))
+      .mockReturnValueOnce(queryResult({ data: { id: appDraftId }, error: null }))
+
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          messages: [
+            {
+              ts: '1700000000.000001',
+              text: [
+                ':incoming_envelope: *Revenue reply ready for approval*',
+                `*App draft ID:* ${appDraftId}`,
+                `*Gmail draft ID:* ${gmailDraftId}`,
+                'Reply in Codex or Slack with: `safe to send`, `modify: ...`, or `hold`.',
+              ].join('\n'),
+            },
+          ],
+        }),
+      } as never)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true, ts: '1700000000.000010' }),
+      } as never)
+
+    const result = await handleSlackAgentEvent({
+      type: 'event_callback',
+      event_id: 'EvRevenueSend',
+      event: {
+        type: 'message',
+        channel_type: 'channel',
+        user: 'U123',
+        channel: 'C123',
+        text: 'safe to send',
+        ts: '1700000000.000009',
+        thread_ts: '1700000000.000001',
+      },
+    })
+
+    expect(result).toEqual({ handled: true, reason: 'revenue_reply_approval_action' })
+    expect(mocks.decryptRefreshToken).toHaveBeenCalledWith('cipher', 'iv', 'tag')
+    expect(mocks.sendUserGmailDraft).toHaveBeenCalledWith('refresh-token', gmailDraftId)
+    expect(mocks.runChiefOfStaffChat).not.toHaveBeenCalled()
+    expect((fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[1]?.body).toContain('marked app draft')
+  })
+
+  it('holds revenue reply drafts without sending email', async () => {
+    const appDraftId = '9abee71a-930d-49e9-a2b5-d929021ec9cb'
+    const gmailDraftId = 'r5747226337828186444'
+    mocks.from
+      .mockReturnValueOnce(queryResult({ data: null, error: null }))
+      .mockReturnValueOnce(queryResult({
+        data: {
+          id: appDraftId,
+          status: 'draft',
+          subject: 'Re: controlled smoke',
+          client_email: 'lead@example.com',
+        },
+        error: null,
+      }))
+
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          messages: [
+            {
+              ts: '1700000000.000001',
+              text: `*Revenue reply ready for approval*\n*App draft ID:* ${appDraftId}\n*Gmail draft ID:* ${gmailDraftId}`,
+            },
+          ],
+        }),
+      } as never)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true, ts: '1700000000.000010' }),
+      } as never)
+
+    const result = await handleSlackAgentEvent({
+      type: 'event_callback',
+      event_id: 'EvRevenueHold',
+      event: {
+        type: 'message',
+        channel_type: 'channel',
+        user: 'U123',
+        channel: 'C123',
+        text: 'hold',
+        ts: '1700000000.000009',
+        thread_ts: '1700000000.000001',
+      },
+    })
+
+    expect(result).toEqual({ handled: true, reason: 'revenue_reply_approval_action' })
+    expect(mocks.sendUserGmailDraft).not.toHaveBeenCalled()
+    expect((fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[1]?.body).toContain('remains unsent')
   })
 
   it('turns rejection thread replies into governed approval rejection actions', async () => {

--- a/lib/agent-slack-events.ts
+++ b/lib/agent-slack-events.ts
@@ -2,6 +2,9 @@ import { runChiefOfStaffChat } from '@/lib/chief-of-staff-chat'
 import { handleSlackAgentAction } from '@/lib/agent-slack-actions'
 import { decodeSlackActionValue, type SlackAgentActionValue } from '@/lib/agent-slack-blocks'
 import { supabaseAdmin } from '@/lib/supabase'
+import { resolveBusinessEmailConfig } from '@/lib/business-email-config'
+import { sendUserGmailDraft } from '@/lib/gmail-user-api'
+import { decryptRefreshToken } from '@/lib/gmail-user-oauth-crypto'
 
 export type SlackAgentEvent = {
   type?: string
@@ -38,11 +41,24 @@ type SlackThreadContext = {
   actions: SlackAgentActionValue[]
 }
 
+type RevenueReplyApprovalCommand =
+  | { action: 'safe_to_send' }
+  | { action: 'hold'; note?: string }
+  | { action: 'modify'; note: string }
+
+type RevenueReplyApprovalContext = {
+  appDraftId: string
+  gmailDraftId: string
+}
+
 export function shouldHandleSlackAgentEvent(event: SlackAgentEvent | undefined): event is HandleableSlackAgentEvent {
   if (!event) return false
   if (event.bot_id || event.subtype) return false
   if (!event.user || !event.channel) return false
   if (event.type === 'app_mention') return true
+  if (event.type === 'message' && event.thread_ts && parseRevenueReplyApprovalCommand(normalizeSlackAgentMessage(event))) {
+    return true
+  }
   return event.type === 'message' && event.channel_type === 'im'
 }
 
@@ -147,6 +163,121 @@ function singleWorkItemId(actions: SlackAgentActionValue[]) {
   return workItemIds.size === 1 ? [...workItemIds][0] : null
 }
 
+export function parseRevenueReplyApprovalCommand(message: string): RevenueReplyApprovalCommand | null {
+  const trimmed = message.trim()
+  const normalized = trimmed.toLowerCase()
+  if (/^safe\s+to\s+send[.!]?$/.test(normalized)) return { action: 'safe_to_send' }
+  if (/^hold\b/.test(normalized)) return { action: 'hold', note: noteFromReply(trimmed, 'Held from Slack thread reply.') }
+  const modifyMatch = trimmed.match(/^modify\s*:\s*([\s\S]+)/i)
+  if (modifyMatch?.[1]?.trim()) return { action: 'modify', note: modifyMatch[1].trim() }
+  return null
+}
+
+function parseRevenueReplyApprovalContext(text: string): RevenueReplyApprovalContext | null {
+  if (!/Revenue reply ready for approval/i.test(text)) return null
+
+  const appDraftId = text.match(/\*?App draft ID:\*?\s*`?([0-9a-f-]{36})`?/i)?.[1]
+  const gmailDraftId = text.match(/\*?Gmail draft ID:\*?\s*`?([A-Za-z0-9_-]+)`?/i)?.[1]
+  if (!appDraftId || !gmailDraftId) return null
+  return { appDraftId, gmailDraftId }
+}
+
+async function findRevenueReplyApprovalContext(channel: string, threadTs: string): Promise<RevenueReplyApprovalContext | null> {
+  const token = process.env.SLACK_BOT_TOKEN
+  if (!token) return null
+
+  const url = new URL('https://slack.com/api/conversations.replies')
+  url.searchParams.set('channel', channel)
+  url.searchParams.set('ts', threadTs)
+  url.searchParams.set('limit', '20')
+  url.searchParams.set('inclusive', 'true')
+
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  const body = await response.json().catch(() => null)
+  if (!response.ok || body?.ok === false || !Array.isArray(body?.messages)) {
+    console.warn('[agent-slack-events] Slack thread fetch failed:', response.status, body)
+    return null
+  }
+
+  const parent = body.messages.find((message: { ts?: string }) => message.ts === threadTs) ?? body.messages[0]
+  const text = typeof parent?.text === 'string' ? parent.text : ''
+  return parseRevenueReplyApprovalContext(text)
+}
+
+async function handleRevenueReplyApprovalCommand(command: RevenueReplyApprovalCommand, context: RevenueReplyApprovalContext) {
+  if (!supabaseAdmin) {
+    return 'Revenue reply approval could not run because the database is not available. No email was sent.'
+  }
+
+  const { data: draft, error: draftError } = await supabaseAdmin
+    .from('client_update_drafts')
+    .select('id, status, subject, client_email')
+    .eq('id', context.appDraftId)
+    .single()
+
+  if (draftError || !draft?.id) {
+    console.warn('[agent-slack-events] Revenue reply draft lookup failed:', draftError)
+    return `I could not find app draft ${context.appDraftId}. No email was sent.`
+  }
+
+  if (command.action === 'hold') {
+    return `Held. App draft ${context.appDraftId} remains unsent.`
+  }
+
+  if (command.action === 'modify') {
+    return [
+      `Modification request captured for app draft ${context.appDraftId}.`,
+      `Requested change: ${command.note}`,
+      'No email was sent. Continue iterating in Codex or update the draft, then reply `safe to send` when approved.',
+    ].join('\n')
+  }
+
+  if (draft.status === 'sent') {
+    return `App draft ${context.appDraftId} is already marked sent. No duplicate email was sent.`
+  }
+
+  const requiredSender = resolveBusinessEmailConfig().fromEmail.toLowerCase()
+  const { data: credential, error: credentialError } = await supabaseAdmin
+    .from('admin_gmail_user_credentials')
+    .select('google_email, refresh_token_cipher, refresh_token_iv, refresh_token_tag')
+    .ilike('google_email', requiredSender)
+    .limit(1)
+    .maybeSingle()
+
+  if (credentialError || !credential?.refresh_token_cipher || !credential?.refresh_token_iv || !credential?.refresh_token_tag) {
+    console.warn('[agent-slack-events] Revenue reply Gmail credential lookup failed:', credentialError)
+    return `No connected Gmail credential was found for ${requiredSender}. No email was sent.`
+  }
+
+  const refreshToken = decryptRefreshToken(
+    credential.refresh_token_cipher as string,
+    credential.refresh_token_iv as string,
+    credential.refresh_token_tag as string,
+  )
+  await sendUserGmailDraft(refreshToken, context.gmailDraftId)
+
+  const { error: updateError } = await supabaseAdmin
+    .from('client_update_drafts')
+    .update({
+      status: 'sent',
+      sent_at: new Date().toISOString(),
+      sent_via: 'email',
+    })
+    .eq('id', context.appDraftId)
+    .eq('status', 'draft')
+    .select('id')
+    .single()
+
+  if (updateError) {
+    console.warn('[agent-slack-events] Revenue reply sent but draft status update failed:', updateError)
+    return `Sent Gmail draft ${context.gmailDraftId}, but Portfolio could not mark app draft ${context.appDraftId} as sent.`
+  }
+
+  return `Sent Gmail draft ${context.gmailDraftId} from ${requiredSender} and marked app draft ${context.appDraftId} as sent.`
+}
+
 function replyActionFromMessage(message: string, context: SlackThreadContext): SlackAgentActionValue | null {
   const normalized = message.trim().toLowerCase()
   const assignMatch = normalized.match(/^assign\s+([a-z0-9_-]+)/)
@@ -227,6 +358,20 @@ export async function handleSlackAgentEvent(payload: SlackAgentEventPayload) {
   const threadContext = event.thread_ts
     ? await findSlackThreadContext(channel, event.thread_ts)
     : null
+  const revenueReplyCommand = event.thread_ts ? parseRevenueReplyApprovalCommand(message) : null
+  if (revenueReplyCommand) {
+    const revenueReplyContext = await findRevenueReplyApprovalContext(channel, event.thread_ts as string)
+    if (revenueReplyContext) {
+      const text = await handleRevenueReplyApprovalCommand(revenueReplyCommand, revenueReplyContext)
+      await postSlackAgentMessage({
+        channel,
+        threadTs: event.thread_ts || event.ts,
+        text,
+      })
+      return { handled: true as const, reason: 'revenue_reply_approval_action' }
+    }
+  }
+
   const replyAction = threadContext ? replyActionFromMessage(message, threadContext) : null
   if (replyAction) {
     const actionResult = await handleSlackAgentAction({
@@ -244,6 +389,10 @@ export async function handleSlackAgentEvent(payload: SlackAgentEventPayload) {
     })
 
     return { handled: true as const, reason: 'thread_reply_action' }
+  }
+
+  if (event.type === 'message' && event.channel_type !== 'im') {
+    return { handled: false as const, reason: 'unsupported_channel_thread_reply' }
   }
 
   const contextRef = threadContext ? { type: 'run' as const, id: threadContext.runId } : null

--- a/lib/gmail-user-api.ts
+++ b/lib/gmail-user-api.ts
@@ -109,3 +109,21 @@ export async function createUserGmailDraft(
   }
   return { id, messageId, threadId }
 }
+
+export async function sendUserGmailDraft(
+  refreshToken: string,
+  draftId: string
+): Promise<{ id?: string; threadId?: string; labelIds?: string[] }> {
+  const oauth2Client = getGmailUserOAuth2Client()
+  oauth2Client.setCredentials({ refresh_token: refreshToken })
+  const gmail = google.gmail({ version: 'v1', auth: oauth2Client })
+  const res = await gmail.users.drafts.send({
+    userId: 'me',
+    requestBody: { id: draftId },
+  })
+  return {
+    id: res.data.id ?? undefined,
+    threadId: res.data.threadId ?? undefined,
+    labelIds: res.data.labelIds ?? undefined,
+  }
+}


### PR DESCRIPTION
## Summary
- Add a guarded Slack thread approval path for WF-GDR revenue reply alerts.
- Require the parent Slack alert to contain both App draft ID and Gmail draft ID before handling `safe to send`, `modify: ...`, or `hold`.
- Send the original Gmail draft via the connected `vambah@amadutown.com` Gmail credential only after the exact `safe to send` phrase, then mark the app draft sent.
- Document the current 4-hour WF-GDR cadence and alert metadata contract.

## Validation
- Rebased cleanly onto current `origin/main`.
- `npm test -- --run lib/agent-slack-events.test.ts lib/__tests__/gmail-user-api.test.ts`
- `npm run lint -- --file lib/agent-slack-events.ts --file lib/agent-slack-events.test.ts --file lib/gmail-user-api.ts --file lib/__tests__/gmail-user-api.test.ts`
- `npm run build:knowledge && npx tsc --noEmit --pretty false` currently fails on unrelated current-main `app/api/admin/visual-assets/route.test.ts` type errors, outside this PR diff.
- Live WF-GDR alert node was patched and re-read in active mode to confirm App draft ID and Gmail draft ID are present.
- Vercel preview for `Vercel – portfolio` is Ready on the rebased branch.
- No customer-facing outreach smoke was sent from this branch.
- Pre-push database health hook skipped locally because `PROD_SUPABASE_URL` and `PROD_SUPABASE_SERVICE_ROLE_KEY` are not set in this worktree env.

## Integration Notes
- Production n8n WF-GDR (`zXfZmgqM6g1teIMY`) was updated to include the two IDs required by this handler; Integration Captain should verify drift expectations and decide whether to mirror staging.
- This PR needs production deployment before Slack replies can trigger the app handler in production.
- Vercel contexts checked:
  - Vercel – portfolio: preview Ready
  - Vercel – portfolio-staging: not checked by this non-captain implementation pass
