### PR TITLE
feat: import accelerated module zero video draft

### DIFF
--- a/app/api/admin/video-generation/course-packets/module-0/import-draft/route.test.ts
+++ b/app/api/admin/video-generation/course-packets/module-0/import-draft/route.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  from: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import { POST } from './route'
+import { ACCELERATED_MODULE0_DRAFT_MARKER } from '@/lib/accelerated-module0-video-draft'
+
+function makeRequest(body: Record<string, unknown> = {}) {
+  return new NextRequest('http://localhost/api/admin/video-generation/course-packets/module-0/import-draft', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+function mockExistingDraft(data: Array<Record<string, unknown>>, error: unknown = null) {
+  const limit = vi.fn().mockResolvedValue({ data, error })
+  const order = vi.fn(() => ({ limit }))
+  const neq = vi.fn(() => ({ order }))
+  const eq = vi.fn(() => ({ neq }))
+  const select = vi.fn(() => ({ eq }))
+  return { select, eq, neq, order, limit }
+}
+
+function mockTemplate(data: Record<string, unknown> | null, error: unknown = null) {
+  const maybeSingle = vi.fn().mockResolvedValue({ data, error })
+  const eqStatus = vi.fn(() => ({ maybeSingle }))
+  const eqKey = vi.fn(() => ({ eq: eqStatus }))
+  const select = vi.fn(() => ({ eq: eqKey }))
+  return { select, eqKey, eqStatus, maybeSingle }
+}
+
+function mockInsert(data: Record<string, unknown> | null, error: unknown = null) {
+  const single = vi.fn().mockResolvedValue({ data, error })
+  const select = vi.fn(() => ({ single }))
+  const insert = vi.fn(() => ({ select }))
+  return { insert, select, single }
+}
+
+describe('POST /api/admin/video-generation/course-packets/module-0/import-draft', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-1' }, isAdmin: true })
+    mocks.isAuthError.mockReturnValue(false)
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Authentication required', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(makeRequest())
+
+    expect(response.status).toBe(401)
+    expect(mocks.from).not.toHaveBeenCalled()
+  })
+
+  it('reuses an existing active Module 0 draft without provider side effects', async () => {
+    const existingBuilder = mockExistingDraft([
+      {
+        id: 'draft-existing',
+        title: 'Accelerated Module 0: Why Accelerated Exists',
+        status: 'pending',
+        custom_prompt: ACCELERATED_MODULE0_DRAFT_MARKER,
+      },
+    ])
+    mocks.from.mockReturnValueOnce(existingBuilder)
+
+    const response = await POST(makeRequest())
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.reused).toBe(true)
+    expect(body.draft.id).toBe('draft-existing')
+    expect(body.side_effects).toMatchObject({
+      heygen: false,
+      elevenlabs: false,
+      render: false,
+      upload: false,
+      publish: false,
+      apify: false,
+    })
+  })
+
+  it('inserts a deterministic pending manual draft with script intelligence metadata', async () => {
+    const existingBuilder = mockExistingDraft([])
+    const templateBuilder = mockTemplate({
+      id: 'template-accelerated',
+      key: 'accelerated_lesson',
+      name: 'Accelerated lesson',
+      description: 'Lesson template.',
+      source_type: 'seeded',
+      source_urls: [],
+      outline: {
+        pain_point: 'Show why speed without judgment creates more noise.',
+        cta: 'Ask the learner to complete the worksheet.',
+      },
+      status: 'active',
+    })
+    const insertBuilder = mockInsert({
+      id: 'draft-new',
+      title: 'Accelerated Module 0: Why Accelerated Exists',
+      source: 'manual',
+      status: 'pending',
+      custom_prompt: ACCELERATED_MODULE0_DRAFT_MARKER,
+      script_template_id: 'template-accelerated',
+      script_scorecard: { blockers: [] },
+    })
+
+    mocks.from
+      .mockReturnValueOnce(existingBuilder)
+      .mockReturnValueOnce(templateBuilder)
+      .mockReturnValueOnce(insertBuilder)
+
+    const response = await POST(makeRequest())
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.reused).toBe(false)
+    expect(insertBuilder.insert).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'Accelerated Module 0: Why Accelerated Exists',
+      source: 'manual',
+      status: 'pending',
+      custom_prompt: ACCELERATED_MODULE0_DRAFT_MARKER,
+      script_template_id: 'template-accelerated',
+      script_outline: expect.objectContaining({
+        pain_point: expect.stringContaining('polished artifacts'),
+        cta: expect.stringContaining('Accelerated Workshop interest path'),
+      }),
+      script_scorecard: expect.objectContaining({
+        blockers: [],
+        overall_score: expect.any(Number),
+      }),
+      research_packet_ids: [],
+    }))
+    expect(body.side_effects.publish).toBe(false)
+  })
+})

--- a/app/api/admin/video-generation/course-packets/module-0/import-draft/route.ts
+++ b/app/api/admin/video-generation/course-packets/module-0/import-draft/route.ts
@@ -1,0 +1,118 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { supabaseAdmin } from '@/lib/supabase'
+import {
+  ACCELERATED_MODULE0_DRAFT_MARKER,
+  buildAcceleratedModule0VideoDraft,
+} from '@/lib/accelerated-module0-video-draft'
+import { normalizeVideoScriptTemplate, SCRIPT_INTELLIGENCE_SIDE_EFFECTS } from '@/lib/video-script-intelligence'
+
+export const dynamic = 'force-dynamic'
+
+function isMissingScriptIntelligenceColumn(error: { code?: string; message?: string } | null) {
+  if (!error) return false
+  return error.code === '42703' && /script_template_id|script_outline|script_scorecard|research_packet_ids/.test(error.message ?? '')
+}
+
+async function getAcceleratedLessonTemplateId() {
+  const { data, error } = await supabaseAdmin
+    .from('video_script_templates')
+    .select('id, key, name, description, source_type, source_urls, outline, status')
+    .eq('key', 'accelerated_lesson')
+    .eq('status', 'active')
+    .maybeSingle()
+
+  if (error) {
+    console.warn('[video-generation] Module 0 template lookup skipped:', error)
+    return null
+  }
+
+  return data ? normalizeVideoScriptTemplate(data).id : null
+}
+
+async function findExistingDraft() {
+  const { data, error } = await supabaseAdmin
+    .from('video_ideas_queue')
+    .select('id, title, status, created_at, custom_prompt')
+    .eq('custom_prompt', ACCELERATED_MODULE0_DRAFT_MARKER)
+    .neq('status', 'dismissed')
+    .order('created_at', { ascending: false })
+    .limit(1)
+
+  if (error) {
+    console.error('[video-generation] Module 0 draft lookup error:', error)
+    throw new Error('Failed to check for existing Module 0 draft')
+  }
+
+  return Array.isArray(data) && data.length > 0 ? data[0] : null
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await verifyAdmin(request)
+    if (isAuthError(auth)) {
+      return NextResponse.json({ error: auth.error }, { status: auth.status })
+    }
+
+    const body = await request.json().catch(() => ({})) as { force?: boolean }
+    const existingDraft = await findExistingDraft()
+
+    if (existingDraft && !body.force) {
+      return NextResponse.json({
+        draft: existingDraft,
+        reused: true,
+        marker: ACCELERATED_MODULE0_DRAFT_MARKER,
+        side_effects: SCRIPT_INTELLIGENCE_SIDE_EFFECTS,
+      })
+    }
+
+    const templateId = await getAcceleratedLessonTemplateId()
+    const draft = buildAcceleratedModule0VideoDraft()
+    const insertPayload = {
+      ...draft,
+      script_template_id: templateId,
+    }
+
+    let { data, error } = await supabaseAdmin
+      .from('video_ideas_queue')
+      .insert(insertPayload)
+      .select('id, title, script_text, storyboard_json, source, status, video_generation_job_id, custom_prompt, created_at, script_template_id, script_outline, script_scorecard, research_packet_ids')
+      .single()
+
+    if (isMissingScriptIntelligenceColumn(error)) {
+      const fallbackPayload = {
+        title: draft.title,
+        script_text: draft.script_text,
+        storyboard_json: draft.storyboard_json,
+        source: draft.source,
+        status: draft.status,
+        custom_prompt: draft.custom_prompt,
+      }
+
+      const fallback = await supabaseAdmin
+        .from('video_ideas_queue')
+        .insert(fallbackPayload)
+        .select('id, title, script_text, storyboard_json, source, status, video_generation_job_id, custom_prompt, created_at')
+        .single()
+
+      data = fallback.data
+      error = fallback.error
+    }
+
+    if (error) {
+      console.error('[video-generation] Module 0 draft insert error:', error)
+      return NextResponse.json({ error: 'Failed to import Module 0 draft' }, { status: 500 })
+    }
+
+    return NextResponse.json({
+      draft: data,
+      reused: false,
+      marker: ACCELERATED_MODULE0_DRAFT_MARKER,
+      side_effects: SCRIPT_INTELLIGENCE_SIDE_EFFECTS,
+    })
+  } catch (error) {
+    console.error('[video-generation] Module 0 draft import error:', error)
+    const message = error instanceof Error ? error.message : String(error)
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/lib/accelerated-module0-video-draft.test.ts
+++ b/lib/accelerated-module0-video-draft.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ACCELERATED_MODULE0_DRAFT_MARKER,
+  buildAcceleratedModule0VideoDraft,
+} from './accelerated-module0-video-draft'
+
+describe('buildAcceleratedModule0VideoDraft', () => {
+  it('builds a provider-locked Video Generation draft from the Module 0 packet', () => {
+    const draft = buildAcceleratedModule0VideoDraft()
+
+    expect(draft.title).toBe('Accelerated Module 0: Why Accelerated Exists')
+    expect(draft.source).toBe('manual')
+    expect(draft.status).toBe('pending')
+    expect(draft.custom_prompt).toBe(ACCELERATED_MODULE0_DRAFT_MARKER)
+    expect(draft.script_text).toContain('AI can now make the first version look finished')
+    expect(draft.script_outline).toMatchObject({
+      pain_point: expect.stringContaining('polished artifacts'),
+      cta: expect.stringContaining('Accelerated Workshop interest path'),
+    })
+    expect(draft.script_scorecard.blockers).toEqual([])
+    expect(draft.script_scorecard.cta_clarity).toBeGreaterThanOrEqual(80)
+    expect(draft.storyboard_json.safety.external_side_effects).toMatchObject({
+      heygen: false,
+      elevenlabs: false,
+      render: false,
+      upload: false,
+      publish: false,
+      apify: false,
+    })
+  })
+})

--- a/lib/accelerated-module0-video-draft.ts
+++ b/lib/accelerated-module0-video-draft.ts
@@ -1,0 +1,167 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import {
+  evaluateVideoScript,
+  SCRIPT_INTELLIGENCE_SIDE_EFFECTS,
+  SEEDED_VIDEO_SCRIPT_TEMPLATES,
+  type VideoScriptScorecard,
+  type VideoScriptTemplate,
+  type VideoScriptTemplateOutline,
+} from './video-script-intelligence'
+
+export const ACCELERATED_MODULE0_DRAFT_MARKER = 'course_packet:accelerated-module-0:script_intelligence_review_ready'
+
+export const ACCELERATED_MODULE0_PACKET_DIR = 'docs/accelerated-course-modules/module-0-video-assets'
+
+export type AcceleratedModule0VideoDraft = {
+  title: string
+  script_text: string
+  storyboard_json: {
+    source_packet: {
+      module: string
+      script_path: string
+      storyboard_path: string
+      review_path: string
+      marker: string
+    }
+    scenes: Array<{
+      sceneNumber: number
+      title: string
+      duration: string
+      description: string
+      brollHint: string
+    }>
+    safety: {
+      provider_execution: 'locked_until_explicit_approval'
+      external_side_effects: typeof SCRIPT_INTELLIGENCE_SIDE_EFFECTS
+      privacy_review_required: true
+    }
+  }
+  source: 'manual'
+  status: 'pending'
+  custom_prompt: string
+  script_outline: VideoScriptTemplateOutline
+  script_scorecard: VideoScriptScorecard
+  research_packet_ids: string[]
+}
+
+function readPacketFile(relativeFile: string) {
+  return fs.readFileSync(path.join(process.cwd(), ACCELERATED_MODULE0_PACKET_DIR, relativeFile), 'utf8')
+}
+
+function extractSection(markdown: string, heading: string, nextHeadingPrefix = '## ') {
+  const start = markdown.indexOf(heading)
+  if (start === -1) return markdown.trim()
+
+  const contentStart = start + heading.length
+  const nextStart = markdown.indexOf(nextHeadingPrefix, contentStart)
+  return markdown
+    .slice(contentStart, nextStart === -1 ? undefined : nextStart)
+    .trim()
+}
+
+export function getAcceleratedModule0Template(): VideoScriptTemplate {
+  return SEEDED_VIDEO_SCRIPT_TEMPLATES.find((template) => template.key === 'accelerated_lesson')
+    ?? SEEDED_VIDEO_SCRIPT_TEMPLATES[0]
+}
+
+export function buildAcceleratedModule0ScriptOutline(): VideoScriptTemplateOutline {
+  return {
+    pain_point: 'AI can make polished artifacts before the team has clarified judgment, evidence, risk, and next action.',
+    hook: 'A generated lesson preview looked realistic and well-paced, but the content did not make the pain or CTA clear.',
+    open_loop: 'If production quality is no longer the blocker, what keeps the work trustworthy?',
+    frame: 'The blank page is gone; judgment is the bottleneck.',
+    proof_demo: 'AmaduTown/Portfolio operating layer: diagnostics, evidence dashboards, social content review gates, agent work queues, script scorecards, b-roll planning, privacy checks, and render-readiness approvals.',
+    teaching_beats: [
+      'The speed trap: AI output can look finished before the thinking is finished.',
+      'The decision-first frame: name the decision before polishing the artifact.',
+      'The proof loop: connect signal, decision, workflow, and learning.',
+    ],
+    cta: 'Build one Accelerated loop, then join the Accelerated Workshop interest path or book an AI Quick Win discovery call through AmaduTown.',
+    closing_question: 'What decision is this AI-generated artifact supposed to improve?',
+    thumbnail_promise: 'The video looked ready. The script was not.',
+    source_distance_notes: 'Internal AmaduTown/Portfolio proof only; no creator script, title, thumbnail, or visual identity copied.',
+  }
+}
+
+export function buildAcceleratedModule0VideoDraft(): AcceleratedModule0VideoDraft {
+  const primaryScript = readPacketFile('primary-lesson-script.md')
+  const scriptText = extractSection(primaryScript, '## Script')
+  const outline = buildAcceleratedModule0ScriptOutline()
+  const template = getAcceleratedModule0Template()
+  const scorecard = evaluateVideoScript({
+    scriptText,
+    outline,
+    template,
+    researchPacketCount: 0,
+  })
+
+  return {
+    title: 'Accelerated Module 0: Why Accelerated Exists',
+    script_text: scriptText,
+    storyboard_json: {
+      source_packet: {
+        module: 'accelerated-module-0',
+        script_path: `${ACCELERATED_MODULE0_PACKET_DIR}/primary-lesson-script.md`,
+        storyboard_path: `${ACCELERATED_MODULE0_PACKET_DIR}/storyboard-render-spec.md`,
+        review_path: `${ACCELERATED_MODULE0_PACKET_DIR}/script-intelligence-review.md`,
+        marker: ACCELERATED_MODULE0_DRAFT_MARKER,
+      },
+      scenes: [
+        {
+          sceneNumber: 1,
+          title: 'Cold Open',
+          duration: '0:00-0:18',
+          description: 'Open on the production-quality lesson preview problem: the video looked ready, but the script was not.',
+          brollHint: 'Avatar clip placeholder or text-led cold open; provider execution locked.',
+        },
+        {
+          sceneNumber: 2,
+          title: 'Production Gap',
+          duration: '0:30-1:25',
+          description: 'Show the contrast between realistic cadence and missing pain/CTA clarity.',
+          brollHint: 'Local text animation only until HeyGen/ElevenLabs approval.',
+        },
+        {
+          sceneNumber: 3,
+          title: 'Judgment Bottleneck',
+          duration: '2:15-3:20',
+          description: 'Frame the core lesson: AI removes the blank page, but judgment becomes the bottleneck.',
+          brollHint: 'Framework card or sanitized course visual.',
+        },
+        {
+          sceneNumber: 4,
+          title: 'AmaduTown Proof',
+          duration: '3:20-4:50',
+          description: 'Use public-safe Portfolio and AmaduTown proof surfaces as the receipt.',
+          brollHint: 'Public or redacted b-roll only; privacy review required before render.',
+        },
+        {
+          sceneNumber: 5,
+          title: 'The Accelerated Loop',
+          duration: '6:15-7:35',
+          description: 'Animate Signal -> Decision -> Loop -> Learning as the first practical exercise.',
+          brollHint: 'Course-native framework animation.',
+        },
+        {
+          sceneNumber: 6,
+          title: 'CTA Close',
+          duration: '7:35-8:35',
+          description: 'Ask the learner to identify one workflow where AI output outruns review, then choose the workshop interest or AI Quick Win path.',
+          brollHint: 'Closing card; upload and publishing locked.',
+        },
+      ],
+      safety: {
+        provider_execution: 'locked_until_explicit_approval',
+        external_side_effects: SCRIPT_INTELLIGENCE_SIDE_EFFECTS,
+        privacy_review_required: true,
+      },
+    },
+    source: 'manual',
+    status: 'pending',
+    custom_prompt: ACCELERATED_MODULE0_DRAFT_MARKER,
+    script_outline: outline,
+    script_scorecard: scorecard,
+    research_packet_ids: [],
+  }
+}


### PR DESCRIPTION
## Summary
- Adds an admin-only import endpoint for the merged Accelerated Module 0 video packet: `POST /api/admin/video-generation/course-packets/module-0/import-draft`.
- Builds a deterministic pending `video_ideas_queue` draft from the checked-in Module 0 script/storyboard packet, including script anatomy, scorecard, storyboard scenes, and a course-packet marker.
- Reuses an existing active Module 0 draft by marker unless `force` is passed, so repeated review setup does not create duplicate drafts by default.

## Validation
- `npm test -- lib/accelerated-module0-video-draft.test.ts app/api/admin/video-generation/course-packets/module-0/import-draft/route.test.ts lib/video-script-intelligence.test.ts app/api/admin/video-generation/script-templates/route.test.ts 'app/api/admin/video-generation/ideas-queue/[id]/route.test.ts'`
- `npx tsc --noEmit`
- `npm run lint` passes with existing unrelated `<img>` warnings in `app/client/dashboard/[token]/page.tsx` and `components/Navigation.test.tsx`.
- Browser smoke was not run because this PR adds an authenticated API handoff only and intentionally does not mutate the local queue during validation.

## Side Effects
- No HeyGen calls.
- No ElevenLabs calls.
- No render/export.
- No uploads.
- No scheduling.
- No publishing or external posts.
- No Apify calls.
- The only runtime mutation is the explicit admin POST inserting/reusing an internal pending Video Generation queue draft.

## Integration Notes
- Depends on the Script Intelligence migration from the merged #592 path for full scorecard columns. The route falls back to the legacy queue columns if those columns are missing locally.
- No new migration or env var required.
- Integration Captain required for merge/deploy verification.
- Vercel contexts were not checked by this non-captain implementation thread:
  - Vercel – portfolio
  - Vercel – portfolio-staging
