### PR TITLE
fix: use serverless chromium for visual capture

### DIFF
--- a/lib/playtest-broll.ts
+++ b/lib/playtest-broll.ts
@@ -7,13 +7,15 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import { spawn } from 'child_process'
-import { chromium } from 'playwright'
+import chromiumServerless from '@sparticuz/chromium'
+import { chromium } from 'playwright-core'
 import { generateAuthState } from '@/scripts/save-storyboard-auth'
 
 const VIEWPORT = { width: 1920, height: 1080 }
 const CLIP_DURATION_MS = 4000
 const SERVER_READY_TIMEOUT_MS = 90_000
 const SERVER_POLL_MS = 1500
+const IS_SERVERLESS_CHROMIUM_RUNTIME = Boolean(process.env.VERCEL || process.env.AWS_LAMBDA_FUNCTION_NAME)
 
 export interface RouteConfig {
   route: string
@@ -189,6 +191,18 @@ export async function resolveAuthState(
   return undefined
 }
 
+async function launchCaptureBrowser() {
+  if (!IS_SERVERLESS_CHROMIUM_RUNTIME) {
+    return chromium.launch({ headless: true })
+  }
+
+  return chromium.launch({
+    args: chromiumServerless.args,
+    executablePath: await chromiumServerless.executablePath(),
+    headless: true,
+  })
+}
+
 /**
  * Capture B-roll (screenshots and optional video clips) for the given routes.
  */
@@ -209,7 +223,7 @@ export async function captureBroll(config: PlaytestConfig): Promise<CaptureResul
   const screenshots: string[] = []
   const clips: string[] = []
 
-  const browser = await chromium.launch({ headless: true })
+  const browser = await launchCaptureBrowser()
 
   const total = config.routes.length
   for (let i = 0; i < config.routes.length; i++) {


### PR DESCRIPTION
## Summary
- Updates the shared B-roll/visual asset capture helper to launch `@sparticuz/chromium` when running in Vercel/serverless.
- Keeps local capture behavior on the normal Playwright launch path.
- Fixes production visual asset capture failures caused by missing downloaded Playwright browser binaries.

## Validation
- `npx vitest run lib/visual-assets.test.ts app/api/admin/visual-assets/route.test.ts`
- `npm run build`
- Production smoke before this fix: audit created dark/light proposed candidates, but capture returned 500 because Vercel lacked the Playwright browser executable.

## Integration Notes
- No migration or env changes required.
- After merge/deploy, rerun `/admin/content/visual-assets` Capture against one candidate, then confirm `visual_asset_candidates.candidate_url` is populated.
- Vercel contexts to verify after merge:
  - Vercel - portfolio
  - Vercel - portfolio-staging
