### PR TITLE
fix: tolerate Slack approval connector suffix

### DIFF
--- a/docs/revenue-sprint/reply-response-automation-sop.md
+++ b/docs/revenue-sprint/reply-response-automation-sop.md
@@ -186,3 +186,25 @@ Before the next warm outreach batch is sent:
 8. Confirm sending requires `safe to send`.
 
 Only after that should the outreach experiment scale beyond the first controlled batch.
+
+## 2026-06-28 Approval Handler Status
+
+The Slack approval handler is now configured and proven for non-send commands.
+
+Current production requirements:
+
+- Slack app: `Portfolio Agent Ops` (`A0B5UUPV6LS`)
+- Event request URL: `https://amadutown.com/api/slack/agent/events`
+- Bot event subscriptions: `app_mention`, `message.im`, `message.channels`
+- Required bot scopes: `commands`, `app_mentions:read`, `im:history`, `channels:history`
+- The app must be installed in the approval alert channel, currently `#meeting-actions-todo`.
+
+Validated commands:
+
+- `hold` posts an acknowledgement and leaves the app draft unsent.
+- `modify: ...` captures the requested change and leaves the app draft unsent.
+
+Remaining validation:
+
+- `safe to send` reached the production route in the controlled internal smoke, but the draft remained unsent because the Slack connector appended `Sent using ChatGPT` and the strict parser rejected the suffixed phrase. Deploy the parser fix, then retest only against an internal-only Gmail draft or after Vambah explicitly approves the exact customer-facing send.
+- Until `modify:` is upgraded to rewrite drafts automatically, revision requests remain capture-only and should be completed in Codex or Portfolio before a final `safe to send`.

--- a/docs/runbooks/revenue-reply-loop-smoke-2026-06-26.md
+++ b/docs/runbooks/revenue-reply-loop-smoke-2026-06-26.md
@@ -107,3 +107,45 @@ Patch the durable tracking gap before expanding outreach:
 2. Repair or prove the natural `WF-GDR` 4-hour Gmail trigger with a fresh controlled inbound message.
 3. Tighten the reply prompt/parser so the body does not include a duplicated `Subject:` line.
 4. Run one more controlled live test that starts with the canonical send path and ends with a draft plus Slack approval alert, without temporary webhooks.
+
+## 2026-06-28 Slack Approval Handler Follow-Up
+
+After PR #593 landed, a controlled internal WF-GDR smoke proved the production Slack approval handler can receive plain thread replies when the Slack app and channel are configured correctly.
+
+Production Slack app configuration:
+
+- App: `Portfolio Agent Ops`
+- App ID: `A0B5UUPV6LS`
+- Workspace: `AmaduTown Advisory Solutions`
+- Event Subscriptions: on
+- Request URL: `https://amadutown.com/api/slack/agent/events`
+- Request URL verification: pass
+- Bot events:
+  - `app_mention`
+  - `message.im`
+  - `message.channels`
+- Reinstalled scopes:
+  - `commands`
+  - `app_mentions:read`
+  - `im:history`
+  - `channels:history`
+- Approval alert channel: `C0AFE8874LR` (`meeting-actions-todo`)
+- Channel membership: `Portfolio Agent Ops` added to `#meeting-actions-todo`
+
+Controlled internal smoke evidence:
+
+- WF-GDR execution: `18739`
+- App draft ID: `46f6aa29-92c0-4b31-be43-e6335d3d3f8b`
+- Gmail draft ID: `r7886723628103744141`
+- Slack alert timestamp: `1782673812.138509`
+- `hold` thread reply: pass. The app replied, `Held. App draft 46f6aa29-92c0-4b31-be43-e6335d3d3f8b remains unsent.`
+- `modify: ...` thread reply: pass. The app captured the modification request and confirmed no email was sent.
+- `safe to send` thread reply: production route returned HTTP 200, but the app draft remained unsent. Root cause was the Slack connector suffixing the message with `Sent using ChatGPT`; the strict parser rejected the suffixed approval phrase before the send branch ran.
+- Production route evidence: `/api/slack/agent/events` returned HTTP 200 for the post-configuration thread replies.
+
+Important behavior note:
+
+- `hold` keeps the draft unsent.
+- `modify: ...` currently captures and acknowledges the requested revision, but does not automatically rewrite the Gmail draft.
+- `safe to send` sends the Gmail draft and should only be used after confirming the draft recipient is internal or the user has explicitly approved the customer-facing send.
+- After the Slack connector suffix parser fix is deployed, rerun `safe to send` against an internal-only draft before enabling this as a normal approval path.

--- a/lib/agent-slack-events.test.ts
+++ b/lib/agent-slack-events.test.ts
@@ -158,7 +158,7 @@ describe('agent Slack events', () => {
       channel_type: 'channel',
       user: 'U123',
       channel: 'C123',
-      text: 'safe to send',
+      text: 'safe to send *Sent using* ChatGPT',
       ts: '1700000000.000002',
       thread_ts: '1700000000.000001',
     })).toBe(true)
@@ -181,8 +181,15 @@ describe('agent Slack events', () => {
   it('parses revenue reply approval phrases conservatively', () => {
     expect(parseRevenueReplyApprovalCommand('safe to send')).toEqual({ action: 'safe_to_send' })
     expect(parseRevenueReplyApprovalCommand('Safe to send.')).toEqual({ action: 'safe_to_send' })
+    expect(parseRevenueReplyApprovalCommand('safe to send *Sent using* ChatGPT')).toEqual({ action: 'safe_to_send' })
+    expect(parseRevenueReplyApprovalCommand('Safe to send. *Sent using* ChatGPT')).toEqual({ action: 'safe_to_send' })
     expect(parseRevenueReplyApprovalCommand('hold')).toEqual({ action: 'hold', note: 'hold' })
+    expect(parseRevenueReplyApprovalCommand('hold *Sent using* ChatGPT')).toEqual({ action: 'hold', note: 'hold' })
     expect(parseRevenueReplyApprovalCommand('modify: tighten the opening')).toEqual({
+      action: 'modify',
+      note: 'tighten the opening',
+    })
+    expect(parseRevenueReplyApprovalCommand('modify: tighten the opening *Sent using* ChatGPT')).toEqual({
       action: 'modify',
       note: 'tighten the opening',
     })
@@ -395,7 +402,7 @@ describe('agent Slack events', () => {
         channel_type: 'channel',
         user: 'U123',
         channel: 'C123',
-        text: 'safe to send',
+        text: 'safe to send *Sent using* ChatGPT',
         ts: '1700000000.000009',
         thread_ts: '1700000000.000001',
       },

--- a/lib/agent-slack-events.ts
+++ b/lib/agent-slack-events.ts
@@ -158,13 +158,17 @@ function singleTargetAction(actions: SlackAgentActionValue[], predicate: (value:
   return targetKeys.size === 1 ? candidates[0] : null
 }
 
+function stripSlackConnectorProvenance(message: string) {
+  return message.replace(/\s*\*?Sent using\*?\s+ChatGPT\s*$/i, '').trim()
+}
+
 function singleWorkItemId(actions: SlackAgentActionValue[]) {
   const workItemIds = new Set(actions.map((value) => value.workItemId).filter((value): value is string => Boolean(value)))
   return workItemIds.size === 1 ? [...workItemIds][0] : null
 }
 
 export function parseRevenueReplyApprovalCommand(message: string): RevenueReplyApprovalCommand | null {
-  const trimmed = message.trim()
+  const trimmed = stripSlackConnectorProvenance(message.trim())
   const normalized = trimmed.toLowerCase()
   if (/^safe\s+to\s+send[.!]?$/.test(normalized)) return { action: 'safe_to_send' }
   if (/^hold\b/.test(normalized)) return { action: 'hold', note: noteFromReply(trimmed, 'Held from Slack thread reply.') }


### PR DESCRIPTION
## Summary
- Strip the known Slack connector `Sent using ChatGPT` suffix before parsing revenue reply approval commands.
- Keep `safe to send` strict after suffix cleanup so ambiguous send phrases are still rejected.
- Document the 2026-06-28 Slack approval smoke evidence and the remaining safe-send validation gate.

## Validation
- `npx vitest run lib/agent-slack-events.test.ts`
- No live customer-facing email send was run. The failed production `safe to send` attempt remained unsent and this branch has not been deployed yet.

## Integration Notes
- After merge and production deploy, rerun the WF-GDR Slack approval smoke against an internal-only Gmail draft before treating Slack `safe to send` as launch-ready.
- No migrations required.
- Vercel – portfolio: not checked in this non-captain branch; captain should verify after deploy.
- Vercel – portfolio-staging: not checked in this non-captain branch; captain should verify after deploy.