### PR TITLE
fix: prefer synced HeyGen defaults for video renders

### DIFF
--- a/app/api/admin/video-generation/ideas-queue/[id]/generate/route.test.ts
+++ b/app/api/admin/video-generation/ideas-queue/[id]/generate/route.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   isAuthError: vi.fn(),
   from: vi.fn(),
   createVideo: vi.fn(),
+  getHeyGenDefaults: vi.fn(),
 }))
 
 vi.mock('@/lib/auth-server', () => ({
@@ -22,6 +23,10 @@ vi.mock('@/lib/supabase', () => ({
 
 vi.mock('@/lib/heygen', () => ({
   createVideo: mocks.createVideo,
+}))
+
+vi.mock('@/lib/heygen-config', () => ({
+  getHeyGenDefaults: mocks.getHeyGenDefaults,
 }))
 
 import { POST } from './route'
@@ -101,6 +106,7 @@ describe('POST /api/admin/video-generation/ideas-queue/[id]/generate', () => {
     mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user-1' }, isAdmin: true })
     mocks.isAuthError.mockReturnValue(false)
     mocks.createVideo.mockResolvedValue({ videoId: 'heygen-1' })
+    mocks.getHeyGenDefaults.mockResolvedValue({ avatarId: null, voiceId: null })
   })
 
   it('requires render approval before reading the queue or calling HeyGen', async () => {
@@ -143,6 +149,32 @@ describe('POST /api/admin/video-generation/ideas-queue/[id]/generate', () => {
       title: 'The Receipt Every Agent Needs',
       channel: 'youtube',
       templateId: 'template-1',
+    }))
+  })
+
+  it('uses synced HeyGen defaults before stale env avatar fallbacks', async () => {
+    vi.stubEnv('HEYGEN_AVATAR_ID', 'stale-env-avatar')
+    vi.stubEnv('HEYGEN_VOICE_ID', 'stale-env-voice')
+    mocks.getHeyGenDefaults.mockResolvedValue({ avatarId: 'db-avatar-1', voiceId: 'db-voice-1' })
+    mocks.from
+      .mockReturnValueOnce(queueFetchBuilder())
+      .mockReturnValueOnce(brollBuilder())
+      .mockReturnValueOnce(jobInsertBuilder())
+      .mockReturnValueOnce(queueUpdateBuilder())
+
+    const response = await POST(
+      makeRequest({
+        channel: 'youtube',
+        aspectRatio: '16:9',
+        renderApproval: buildVideoRenderApproval(true),
+      }),
+      { params: { id: 'draft-1' } }
+    )
+
+    expect(response.status).toBe(200)
+    expect(mocks.createVideo).toHaveBeenCalledWith(expect.objectContaining({
+      avatarId: 'db-avatar-1',
+      voiceId: 'db-voice-1',
     }))
   })
 })

--- a/app/api/admin/video-generation/ideas-queue/[id]/generate/route.ts
+++ b/app/api/admin/video-generation/ideas-queue/[id]/generate/route.ts
@@ -46,9 +46,9 @@ export async function POST(
     const brandVoiceId =
       (body.brandVoiceId as string)?.trim() || process.env.HEYGEN_BRAND_VOICE_ID
     let avatarId =
-      (body.avatarId as string)?.trim() || process.env.HEYGEN_AVATAR_ID
+      (body.avatarId as string)?.trim() || null
     let voiceId =
-      (body.voiceId as string)?.trim() || process.env.HEYGEN_VOICE_ID
+      (body.voiceId as string)?.trim() || null
 
     const { data: queueItem, error: fetchErr } = await supabaseAdmin
       .from('video_ideas_queue')

--- a/app/api/admin/video-generation/ideas-queue/[id]/render-readiness/route.test.ts
+++ b/app/api/admin/video-generation/ideas-queue/[id]/render-readiness/route.test.ts
@@ -122,4 +122,24 @@ describe('POST /api/admin/video-generation/ideas-queue/[id]/render-readiness', (
     expect(body.report.blockingIssues.join(' ')).toContain('HeyGen template or avatar and voice')
     expect(body.report.warnings).toContain('No storyboard scenes are attached for visual direction.')
   })
+
+  it('uses synced HeyGen defaults before stale env avatar fallbacks', async () => {
+    vi.stubEnv('HEYGEN_AVATAR_ID', 'stale-env-avatar')
+    vi.stubEnv('HEYGEN_VOICE_ID', 'stale-env-voice')
+    mocks.getHeyGenDefaults.mockResolvedValue({ avatarId: 'db-avatar-1', voiceId: 'db-voice-1' })
+    mocks.from
+      .mockReturnValueOnce(queueFetchBuilder({ storyboard_json: { scenes: [] } }))
+
+    const response = await POST(
+      makeRequest({ channel: 'youtube', aspectRatio: '16:9' }),
+      { params: { id: 'draft-1' } }
+    )
+
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.report.ready).toBe(true)
+    expect(body.report.details.avatarId).toBe('db-avatar-1')
+    expect(body.report.details.voiceId).toBe('db-voice-1')
+  })
 })

--- a/app/api/admin/video-generation/ideas-queue/[id]/render-readiness/route.ts
+++ b/app/api/admin/video-generation/ideas-queue/[id]/render-readiness/route.ts
@@ -39,9 +39,9 @@ export async function POST(
     const templateId =
       (body.templateId as string)?.trim() || process.env.HEYGEN_TEMPLATE_ID || null
     let avatarId =
-      (body.avatarId as string)?.trim() || process.env.HEYGEN_AVATAR_ID || null
+      (body.avatarId as string)?.trim() || null
     let voiceId =
-      (body.voiceId as string)?.trim() || process.env.HEYGEN_VOICE_ID || null
+      (body.voiceId as string)?.trim() || null
 
     const { data: queueItem, error: fetchErr } = await supabaseAdmin
       .from('video_ideas_queue')

--- a/lib/video-render-readiness.test.ts
+++ b/lib/video-render-readiness.test.ts
@@ -6,7 +6,15 @@ describe('video render readiness', () => {
     const report = buildVideoRenderReadinessReport({
       title: 'The Receipt Every Agent Needs',
       status: 'pending',
-      scriptText: 'A receipt is the difference between motion and trust.',
+      scriptText:
+        'A receipt is the difference between motion and trust. The problem is that AI can produce polished work before anyone knows what decision it should improve. In the Portfolio workflow, AmaduTown keeps the proof visible through script scorecards, review gates, and render readiness checks. Join the workshop interest path when you want to build that loop in your own work.',
+      scriptOutline: {
+        pain_point: 'AI can produce polished work before the team knows what decision it should improve.',
+        hook: 'The video can look ready while the script is still missing the point.',
+        open_loop: 'By the end, the viewer should know why proof has to come before polish.',
+        proof_demo: 'Portfolio and AmaduTown use script scorecards, review gates, and render readiness checks as the receipt.',
+        cta: 'Join the workshop interest path when you want to build that loop in your own work.',
+      },
       storyboardScenes: 5,
       videoGenerationJobId: null,
       templateId: 'template-1',
@@ -45,7 +53,15 @@ describe('video render readiness', () => {
     const report = buildVideoRenderReadinessReport({
       title: 'Ready draft',
       status: 'pending',
-      scriptText: 'Ready for review.',
+      scriptText:
+        'AI makes the first draft faster, but that speed creates a problem when nobody can explain the decision behind the artifact. The AmaduTown proof is the operating layer around the draft: script anatomy, source distance, storyboard review, and render readiness. Book an AI Quick Win discovery call if you want to turn one messy workflow into a reviewable loop.',
+      scriptOutline: {
+        pain_point: 'AI speed creates a problem when nobody can explain the decision behind the artifact.',
+        hook: 'The first draft is faster now. The judgment still has to be designed.',
+        open_loop: 'The viewer will see how readiness stays separate from approval.',
+        proof_demo: 'The AmaduTown proof is the operating layer around the draft: script anatomy, source distance, storyboard review, and render readiness.',
+        cta: 'Book an AI Quick Win discovery call if you want to turn one messy workflow into a reviewable loop.',
+      },
       storyboardScenes: 0,
       videoGenerationJobId: null,
       templateId: null,


### PR DESCRIPTION
## Summary
- Prefer synced HeyGen DB defaults over stale env avatar/voice fallbacks for render-readiness and draft generation.
- Add regression coverage for stale env IDs so readiness and generation use the same resolved provider config.
- Refresh render-readiness fixtures so they satisfy the merged script-intelligence pain/proof/CTA gate.

## Validation
- `npm test -- lib/video-script-intelligence.test.ts lib/video-render-readiness.test.ts app/api/admin/video-generation/course-packets/module-0/import-draft/route.test.ts app/api/admin/video-generation/script-templates/route.test.ts app/api/admin/video-generation/ideas-queue/[id]/generate/route.test.ts app/api/admin/video-generation/ideas-queue/[id]/render-readiness/route.test.ts`
- Local API smoke on `http://localhost:3074`: Module 0 draft import reused existing pending draft before generation.
- Local readiness smoke: resolved DB default avatar `4a1dba...`, no blockers, script score 99.
- Local provider smoke: one approved internal HeyGen review render completed; job `c74dcf5f-f92b-4529-a175-f8d3c39d39d9`, video record `5`.
- Local browser smoke on `/admin/content/video-generation`: completed job visible on the review surface.

## Integration Notes
- No migration required.
- External side effects: one explicitly approved HeyGen internal review render was started and completed during smoke. No ElevenLabs, upload, schedule, publish, social post, or external platform publish action was triggered.
- Existing local workflow-status warning observed: `video_generation_workflow_runs.agent_run_id` is missing in the current schema cache; this PR does not address that migration drift.
- Integration Captain required for merge/deploy verification.
- Vercel contexts not checked from this implementation thread:
  - Vercel – portfolio
  - Vercel – portfolio-staging