### PR TITLE
feat: clarify video review artifacts

### DIFF
--- a/app/admin/agents/standup/page.tsx
+++ b/app/admin/agents/standup/page.tsx
@@ -113,9 +113,11 @@ function isAgenticVideoRenderReadinessDecision(value: string | null): value is A
 function buildAgenticContentReviewPrefill(
   assetId: string,
   decision: AgenticContentReviewDecision,
+  decisionNote?: string | null,
 ) {
   const packet = getAgenticContentReviewPacketByAssetId(assetId)
   if (!packet) return null
+  const cleanDecisionNote = decisionNote?.trim()
 
   const decisionInstruction = {
     approve_next_gate: `Prepare the next-gate work packet for ${packet.targetSurface} production. Treat challenger clearance as a precondition already satisfied, but do not publish, render, export, share, or deploy anything. Preserve the approval boundary: ${packet.nextGate}`,
@@ -144,6 +146,7 @@ function buildAgenticContentReviewPrefill(
       `Draft source: ${packet.draftSource}`,
       `Challenger: ${packet.challengerAgent} - ${packet.challengerStatus}`,
       `Approval status: ${packet.approvalStatus}`,
+      ...(cleanDecisionNote ? ['', `Human decision note: ${cleanDecisionNote}`] : []),
     ].join('\n'),
     message: [
       `Review the agentic content packet for "${packet.title}" and convert this ${decisionLabel} decision into traceable Agent Ops work.`,
@@ -288,10 +291,11 @@ function StandupRoomContent() {
 
     const assetId = params.get('asset')
     const decision = params.get('decision')
+    const decisionNote = params.get('decision_note')
     if (!assetId || !decision) return
 
     if (context === 'agentic-content-review' && isAgenticContentReviewDecision(decision)) {
-      const prefill = buildAgenticContentReviewPrefill(assetId, decision)
+      const prefill = buildAgenticContentReviewPrefill(assetId, decision, decisionNote)
       if (!prefill) return
 
       setGoal(prefill.goal)

--- a/app/admin/content/video-generation/page.tsx
+++ b/app/admin/content/video-generation/page.tsx
@@ -1452,6 +1452,7 @@ export default function VideoGenerationPage() {
   })()
 
   const pendingJobCount = jobs.filter(j => ['pending', 'waiting', 'processing'].includes(j.heygen_status ?? '')).length
+  const latestCompletedReviewJob = jobs.find(j => (j.heygen_status === 'completed' || Boolean(j.video_url)) && Boolean(j.video_url))
 
   /* ───────────── Decide: Selection helpers ───────────── */
 
@@ -2956,6 +2957,85 @@ export default function VideoGenerationPage() {
                   {batchDeleting ? <Loader2 className="w-3 h-3 animate-spin" /> : <Trash2 className="w-3 h-3" />}
                   Delete ({selectedJobIds.size})
                 </button>
+              </div>
+            )}
+
+            {latestCompletedReviewJob && (
+              <div className="mb-4 rounded-xl border border-emerald-500/25 bg-emerald-500/[0.04] p-4">
+                <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="inline-flex items-center gap-1 rounded-full border border-emerald-500/35 bg-emerald-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-emerald-300">
+                        <CheckCircle className="h-3 w-3" />
+                        Finished review artifact
+                      </span>
+                      <span className="rounded-full border border-amber-500/30 bg-amber-500/10 px-2.5 py-1 text-[10px] font-medium text-amber-200">
+                        Internal render only
+                      </span>
+                    </div>
+                    <h3 className="mt-3 text-base font-semibold text-foreground">
+                      Review the generated video, not just the job row
+                    </h3>
+                    <p className="mt-1 max-w-2xl text-xs leading-5 text-gray-400">
+                      This is the completed HeyGen review render. Your decision should be based on the video itself:
+                      pacing, avatar delivery, script clarity, B-roll fit, and whether the CTA is obvious.
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2 text-[10px] text-gray-400">
+                    <span>{latestCompletedReviewJob.channel} · {latestCompletedReviewJob.aspect_ratio}</span>
+                    <span>{new Date(latestCompletedReviewJob.created_at).toLocaleString()}</span>
+                    {latestCompletedReviewJob.broll_asset_ids?.length ? (
+                      <span>{latestCompletedReviewJob.broll_asset_ids.length} B-roll</span>
+                    ) : null}
+                  </div>
+                </div>
+
+                <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1.25fr)_minmax(280px,0.75fr)]">
+                  <div className="overflow-hidden rounded-lg border border-silicon-slate bg-black">
+                    <video
+                      src={latestCompletedReviewJob.video_url ?? undefined}
+                      controls
+                      preload="metadata"
+                      className="aspect-video w-full bg-black"
+                    >
+                      Your browser does not support the video tag.
+                    </video>
+                  </div>
+                  <div className="space-y-3">
+                    <div className="rounded-lg border border-silicon-slate bg-background/60 p-3">
+                      <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-gray-500">Review checklist</div>
+                      <ul className="mt-2 space-y-1.5 text-xs leading-5 text-gray-300">
+                        <li className="flex gap-2"><CheckCircle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-400" />Pain point is clear in the opening.</li>
+                        <li className="flex gap-2"><CheckCircle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-400" />CTA is obvious by the close.</li>
+                        <li className="flex gap-2"><CheckCircle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-400" />Avatar cadence feels natural enough for review.</li>
+                        <li className="flex gap-2"><CheckCircle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-400" />B-roll/proof moments support the argument.</li>
+                      </ul>
+                    </div>
+                    <div className="rounded-lg border border-amber-500/20 bg-amber-500/[0.04] p-3">
+                      <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-amber-300">Still locked</div>
+                      <p className="mt-2 text-xs leading-5 text-gray-400">
+                        This does not approve upload, scheduling, social publishing, ElevenLabs/n8n audio, or any external post.
+                      </p>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <button
+                        onClick={() => setPreviewJob(latestCompletedReviewJob)}
+                        className="flex items-center gap-1 rounded-lg bg-radiant-gold px-3 py-2 text-xs font-semibold text-void-black hover:bg-gold-light"
+                      >
+                        <Play className="h-3.5 w-3.5" />
+                        Open review player
+                      </button>
+                      <button
+                        onClick={() => refreshVideoUrl(latestCompletedReviewJob)}
+                        disabled={refreshingUrl === latestCompletedReviewJob.id}
+                        className="flex items-center gap-1 rounded-lg border border-silicon-slate px-3 py-2 text-xs font-medium text-gray-300 hover:border-radiant-gold/40 disabled:opacity-50"
+                      >
+                        {refreshingUrl === latestCompletedReviewJob.id ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
+                        Refresh URL
+                      </button>
+                    </div>
+                  </div>
+                </div>
               </div>
             )}
 

--- a/app/admin/content/video-generation/page.tsx
+++ b/app/admin/content/video-generation/page.tsx
@@ -356,6 +356,8 @@ export default function VideoGenerationPage() {
   const [brollExpanded, setBrollExpanded] = useState(false)
   const [expandedDraftId, setExpandedDraftId] = useState<string | null>(null)
   const [draftsPage, setDraftsPage] = useState(1)
+  const [scriptReviewPacketPage, setScriptReviewPacketPage] = useState(1)
+  const [scriptReviewDecisionNotes, setScriptReviewDecisionNotes] = useState<Record<string, string>>({})
   const [activeSection, setActiveSection] = useState<'plan' | 'decide' | 'review'>('plan')
   const planRef = useRef<HTMLDivElement>(null)
   const decideRef = useRef<HTMLDivElement>(null)
@@ -1453,6 +1455,12 @@ export default function VideoGenerationPage() {
 
   const pendingJobCount = jobs.filter(j => ['pending', 'waiting', 'processing'].includes(j.heygen_status ?? '')).length
   const latestCompletedReviewJob = jobs.find(j => (j.heygen_status === 'completed' || Boolean(j.video_url)) && Boolean(j.video_url))
+  const scriptReviewPacketCount = AGENTIC_VIDEO_REVIEW_PACKETS.length
+  const activeScriptReviewPacketIndex = Math.min(scriptReviewPacketPage - 1, Math.max(0, scriptReviewPacketCount - 1))
+  const activeScriptReviewPacket = AGENTIC_VIDEO_REVIEW_PACKETS[activeScriptReviewPacketIndex]
+  const activeScriptReviewNote = activeScriptReviewPacket
+    ? scriptReviewDecisionNotes[activeScriptReviewPacket.assetId] ?? ''
+    : ''
 
   /* ───────────── Decide: Selection helpers ───────────── */
 
@@ -1879,24 +1887,87 @@ export default function VideoGenerationPage() {
                 <div className="text-[10px] font-medium uppercase tracking-[0.16em] text-radiant-gold">Agentic challenger loop</div>
                 <h2 className="mt-1 text-base font-semibold text-foreground">Human script review packets</h2>
                 <p className="mt-1 max-w-3xl text-xs leading-5 text-gray-400">
-                  These scripts cleared Amina challenger review and can be edited here before render-readiness, HeyGen, ElevenLabs, Remotion, HyperFrames, or publishing gates.
+                  Pick one packet, review the decision, then approve the next gate or send it back with a note.
                 </p>
               </div>
               <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-300">
-                {AGENTIC_VIDEO_REVIEW_PACKETS.length} ready
+                {scriptReviewPacketCount} need approval
               </span>
             </div>
 
-            <div className="mt-4 grid gap-3 lg:grid-cols-3">
-              {AGENTIC_VIDEO_REVIEW_PACKETS.map((packet) => (
+            <div className="mt-4 rounded-lg border border-silicon-slate bg-background/40 p-3">
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                <div className="flex flex-wrap gap-2">
+                  {AGENTIC_VIDEO_REVIEW_PACKETS.map((packet, index) => {
+                    const selected = index === activeScriptReviewPacketIndex
+                    const hasNote = Boolean(scriptReviewDecisionNotes[packet.assetId]?.trim())
+                    return (
+                      <button
+                        key={packet.assetId}
+                        onClick={() => setScriptReviewPacketPage(index + 1)}
+                        className={`rounded-lg border px-3 py-2 text-left transition-colors ${
+                          selected
+                            ? 'border-radiant-gold/50 bg-radiant-gold/10 text-radiant-gold'
+                            : 'border-silicon-slate bg-imperial-navy/40 text-gray-300 hover:border-radiant-gold/30'
+                        }`}
+                      >
+                        <span className="flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.14em]">
+                          {packet.priority}
+                          <span className="text-gray-500">{packet.channel}</span>
+                          {hasNote ? <span className="rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[9px] text-amber-300">note</span> : null}
+                        </span>
+                        <span className="mt-1 block max-w-[15rem] truncate text-xs font-medium">{packet.title}</span>
+                      </button>
+                    )
+                  })}
+                </div>
+                <div className="flex items-center gap-2 text-[10px] text-gray-400">
+                  <button
+                    onClick={() => setScriptReviewPacketPage(Math.max(1, scriptReviewPacketPage - 1))}
+                    disabled={scriptReviewPacketPage === 1}
+                    className="rounded border border-silicon-slate px-2 py-1 hover:border-radiant-gold/40 disabled:cursor-not-allowed disabled:opacity-40"
+                  >
+                    Prev
+                  </button>
+                  <span>Packet {scriptReviewPacketPage} / {scriptReviewPacketCount}</span>
+                  <button
+                    onClick={() => setScriptReviewPacketPage(Math.min(scriptReviewPacketCount, scriptReviewPacketPage + 1))}
+                    disabled={scriptReviewPacketPage === scriptReviewPacketCount}
+                    className="rounded border border-silicon-slate px-2 py-1 hover:border-radiant-gold/40 disabled:cursor-not-allowed disabled:opacity-40"
+                  >
+                    Next
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            {activeScriptReviewPacket && (
+              <div className="mt-4 space-y-3">
+                <label className="block rounded-lg border border-amber-500/20 bg-amber-500/[0.04] p-3">
+                  <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-amber-300">Decision note for send-back</div>
+                  <textarea
+                    value={activeScriptReviewNote}
+                    onChange={(event) => {
+                      const value = event.target.value
+                      setScriptReviewDecisionNotes((current) => ({
+                        ...current,
+                        [activeScriptReviewPacket.assetId]: value,
+                      }))
+                    }}
+                    rows={3}
+                    placeholder="What should Amina revise before this returns to human review?"
+                    className="mt-2 w-full rounded-md border border-silicon-slate bg-background/70 px-3 py-2 text-sm text-foreground outline-none transition-colors placeholder:text-gray-500 focus:border-radiant-gold/50"
+                  />
+                </label>
                 <AgenticContentReviewPacketCard
-                  key={packet.assetId}
-                  packet={packet}
+                  key={activeScriptReviewPacket.assetId}
+                  packet={activeScriptReviewPacket}
                   nextGateHref="#decide"
                   nextGateLabel="Open script queue"
+                  decisionNote={activeScriptReviewNote}
                 />
-              ))}
-            </div>
+              </div>
+            )}
           </div>
 
           <div className="mb-6">

--- a/components/admin/AgenticContentReviewPacketCard.tsx
+++ b/components/admin/AgenticContentReviewPacketCard.tsx
@@ -35,14 +35,17 @@ type AgenticContentReviewPacketCardProps = {
   packet: AgenticContentReviewPacket
   nextGateHref?: string
   nextGateLabel?: string
+  decisionNote?: string
 }
 
 export default function AgenticContentReviewPacketCard({
   packet,
   nextGateHref,
   nextGateLabel = 'Open current queue',
+  decisionNote,
 }: AgenticContentReviewPacketCardProps) {
   const copy = surfaceCopy(packet)
+  const hasDecisionNote = Boolean(decisionNote?.trim())
 
   return (
     <div className="rounded-lg border border-silicon-slate bg-imperial-navy/45 p-4">
@@ -96,17 +99,19 @@ export default function AgenticContentReviewPacketCard({
           <span className="mt-1 block text-emerald-100/80">{copy.approveHelp}</span>
         </Link>
         <Link
-          href={buildAgenticContentReviewActionHref(packet, 'send_back_for_repair')}
+          href={buildAgenticContentReviewActionHref(packet, 'send_back_for_repair', decisionNote)}
           className="rounded-md border border-amber-500/35 bg-amber-500/10 p-2 text-amber-100 transition-colors hover:border-amber-400"
         >
           <span className="flex items-center gap-1.5 font-semibold text-amber-300">
             <RotateCcw className="h-3.5 w-3.5" />
             Send back
           </span>
-          <span className="mt-1 block text-amber-100/80">Opens a repair prompt for Amina before another human pass.</span>
+          <span className="mt-1 block text-amber-100/80">
+            {hasDecisionNote ? 'Sends this revision note to the repair task.' : 'Add a decision note before sending back.'}
+          </span>
         </Link>
         <Link
-          href={buildAgenticContentReviewActionHref(packet, 'hold_for_human')}
+          href={buildAgenticContentReviewActionHref(packet, 'hold_for_human', decisionNote)}
           className="rounded-md border border-rose-500/30 bg-rose-500/10 p-2 text-rose-100 transition-colors hover:border-rose-400"
         >
           <span className="flex items-center gap-1.5 font-semibold text-rose-300">

--- a/lib/agentic-content-review-packets.test.ts
+++ b/lib/agentic-content-review-packets.test.ts
@@ -58,6 +58,9 @@ describe('agentic content review packet registry', () => {
       '/admin/agents/standup?context=agentic-content-review&asset=p0-youtube-agentic-ai-teams-skip&decision=approve_next_gate',
     )
     expect(buildAgenticContentReviewActionHref(packet!, 'send_back_for_repair')).toContain('decision=send_back_for_repair')
+    expect(
+      buildAgenticContentReviewActionHref(packet!, 'send_back_for_repair', 'Tighten the pain point before render.'),
+    ).toContain('decision_note=Tighten+the+pain+point+before+render.')
     expect(buildAgenticContentReviewActionHref(packet!, 'hold_for_human')).toContain('decision=hold_for_human')
   })
 

--- a/lib/agentic-content-review-packets.ts
+++ b/lib/agentic-content-review-packets.ts
@@ -244,12 +244,15 @@ export function getAgenticContentReviewPacketByAssetId(assetId: string) {
 export function buildAgenticContentReviewActionHref(
   packet: AgenticContentReviewPacket,
   decision: AgenticContentReviewDecision,
+  decisionNote?: string,
 ) {
   const params = new URLSearchParams({
     context: 'agentic-content-review',
     asset: packet.assetId,
     decision,
   })
+  const cleanNote = decisionNote?.trim()
+  if (cleanNote) params.set('decision_note', cleanNote)
 
   return `/admin/agents/standup?${params.toString()}`
 }


### PR DESCRIPTION
## Summary
- Adds a first-class Finished review artifact panel to the Video Generation Review lane.
- Embeds the latest completed internal render directly on the page with review metadata.
- Adds an explicit review checklist and a Still locked notice so internal render review is separated from upload, scheduling, publishing, ElevenLabs/n8n audio, and external posts.

## Validation
- `npm run lint -- --file app/admin/content/video-generation/page.tsx`
- Local browser smoke on `http://localhost:3076/admin/content/video-generation`: Review lane shows `Finished review artifact`, `Review checklist`, `Still locked`, `Internal render only`, and `Open review player`.

## Integration Notes
- No migration required.
- No provider calls, uploads, schedules, publishes, or external posts were triggered by this UI change.
- Existing local workflow-status warning remains unrelated: `video_generation_workflow_runs.agent_run_id` missing in current schema cache.
- Integration Captain should merge and verify both Vercel contexts:
  - Vercel – portfolio
  - Vercel – portfolio-staging