### PR TITLE
fix: streamline visual asset review

### DIFF
--- a/app/admin/content/visual-assets/page.test.tsx
+++ b/app/admin/content/visual-assets/page.test.tsx
@@ -150,4 +150,53 @@ describe("VisualAssetsReviewPage", () => {
         ),
     ).toBe(false);
   });
+
+  it("does not approve candidates blocked by Idia automated review", async () => {
+    vi.mocked(fetch).mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/approve")) {
+        return {
+          ok: true,
+          json: async () => ({ candidate: { id: url.split("/").at(-2) } }),
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          candidates: [
+            candidate(1, {
+              metadata: {
+                agent_review: {
+                  decision: "passed",
+                  summary: "Passed automated quality review for dark human approval.",
+                },
+              },
+            }),
+            candidate(2, {
+              id: "blocked-candidate",
+              metadata: {
+                agent_review: {
+                  decision: "blocked",
+                  summary: "Blocked before human review: dark mode mismatch.",
+                },
+              },
+            }),
+          ],
+        }),
+      } as Response;
+    });
+
+    render(<VisualAssetsReviewPage />);
+
+    expect(await screen.findByText("Idia blocked")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Approve Visible" }));
+
+    await waitFor(() => {
+      const approvalCalls = vi
+        .mocked(fetch)
+        .mock.calls.filter(([input]) => String(input).includes("/approve"));
+      expect(approvalCalls).toHaveLength(1);
+      expect(String(approvalCalls[0][0])).toContain("candidate-1");
+    });
+  });
 });

--- a/app/admin/content/visual-assets/page.test.tsx
+++ b/app/admin/content/visual-assets/page.test.tsx
@@ -1,0 +1,153 @@
+/* eslint-disable @next/next/no-img-element */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import VisualAssetsReviewPage from "./page";
+
+vi.mock("@/components/ProtectedRoute", () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getCurrentSession: vi.fn(async () => ({ access_token: "admin-token" })),
+}));
+
+vi.mock("next/image", () => ({
+  default: ({ alt, src }: { alt: string; src: string }) => (
+    <img alt={alt} src={src} />
+  ),
+}));
+
+function candidate(index: number, overrides: Record<string, unknown> = {}) {
+  return {
+    id: `candidate-${index}`,
+    entity_type: "service",
+    entity_id: `service-${index}`,
+    title: `Service ${index}`,
+    theme: index % 2 === 0 ? "dark" : "light",
+    current_url: null,
+    candidate_url: `https://example.com/candidate-${index}.png`,
+    candidate_storage_path: `products/visual-candidates/service-${index}/candidate-${index}.png`,
+    capture_route: `/services/service-${index}`,
+    score: 70,
+    reason_codes: ["missing_image"],
+    status: "proposed",
+    reviewed_by: null,
+    reviewed_at: null,
+    applied_at: null,
+    metadata: {},
+    created_at: `2026-06-28T12:${String(index).padStart(2, "0")}:00.000Z`,
+    updated_at: `2026-06-28T12:${String(index).padStart(2, "0")}:00.000Z`,
+    ...overrides,
+  };
+}
+
+const capturedCandidates = Array.from({ length: 13 }, (_, index) =>
+  candidate(index + 1),
+);
+const missingCandidates = [
+  candidate(101, {
+    id: "needs-capture-1",
+    title: "Missing Screenshot Service",
+    candidate_url: null,
+    candidate_storage_path: null,
+  }),
+];
+
+describe("VisualAssetsReviewPage", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes("/approve")) {
+          return {
+            ok: true,
+            json: async () => ({ candidate: { id: url.split("/").at(-2) } }),
+          };
+        }
+        if (url.includes("candidate_state=needs_capture")) {
+          return {
+            ok: true,
+            json: async () => ({ candidates: missingCandidates }),
+          };
+        }
+        return {
+          ok: true,
+          json: async () => ({ candidates: capturedCandidates }),
+        };
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("defaults to captured review candidates with pagination controls", async () => {
+    render(<VisualAssetsReviewPage />);
+
+    expect(
+      await screen.findByRole("heading", { name: "Homepage Visual Assets" }),
+    ).toBeInTheDocument();
+    expect(await screen.findAllByText("Page 1 of 2")).toHaveLength(2);
+    expect(
+      screen.getByRole("button", { name: "Approve Visible" }),
+    ).toBeEnabled();
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/admin/visual-assets/candidates?status=proposed&candidate_state=captured&limit=250",
+        expect.objectContaining({
+          headers: { Authorization: "Bearer admin-token" },
+        }),
+      );
+    });
+  });
+
+  it("separates the missing-capture queue from the captured review queue", async () => {
+    render(<VisualAssetsReviewPage />);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "needs capture" }),
+    );
+
+    expect(
+      await screen.findByText("Missing Screenshot Service"),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("needs capture").length).toBeGreaterThan(0);
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/admin/visual-assets/candidates?status=proposed&candidate_state=needs_capture&limit=250",
+        expect.objectContaining({
+          headers: { Authorization: "Bearer admin-token" },
+        }),
+      );
+    });
+  });
+
+  it("approves only visible captured candidates and leaves apply-approved untouched", async () => {
+    render(<VisualAssetsReviewPage />);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Approve Visible" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        vi
+          .mocked(fetch)
+          .mock.calls.filter(([input]) => String(input).includes("/approve"))
+          .length,
+      ).toBe(12);
+    });
+    expect(
+      vi
+        .mocked(fetch)
+        .mock.calls.some(([input]) =>
+          String(input).includes("/apply-approved"),
+        ),
+    ).toBe(false);
+  });
+});

--- a/app/admin/content/visual-assets/page.tsx
+++ b/app/admin/content/visual-assets/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import Image from 'next/image'
-import { Check, CheckCheck, ChevronLeft, ChevronRight, ImageIcon, Loader2, RefreshCw, Search, Sparkles, X } from 'lucide-react'
+import { Check, CheckCheck, ChevronLeft, ChevronRight, ImageIcon, Loader2, RefreshCw, Search, ShieldAlert, ShieldCheck, Sparkles, X } from 'lucide-react'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
 import ProtectedRoute from '@/components/ProtectedRoute'
 import { getCurrentSession } from '@/lib/auth'
@@ -60,8 +60,38 @@ function CandidateImage({ url, label }: { url: string | null; label: string }) {
   )
 }
 
+function agentReview(candidate: VisualAssetCandidate): { decision?: string; summary?: string } | null {
+  const review = candidate.metadata?.agent_review
+  if (!review || typeof review !== 'object' || Array.isArray(review)) return null
+  const data = review as Record<string, unknown>
+  return {
+    decision: typeof data.decision === 'string' ? data.decision : undefined,
+    summary: typeof data.summary === 'string' ? data.summary : undefined,
+  }
+}
+
+function AgentReviewBadge({ candidate }: { candidate: VisualAssetCandidate }) {
+  const review = agentReview(candidate)
+  if (!review?.decision) return null
+  const blocked = review.decision === 'blocked'
+  const Icon = blocked ? ShieldAlert : ShieldCheck
+  return (
+    <span
+      title={review.summary}
+      className={`inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs uppercase ${
+        blocked
+          ? 'border-rose-400/25 text-rose-200'
+          : 'border-emerald-400/25 text-emerald-200'
+      }`}
+    >
+      <Icon className="h-3.5 w-3.5" />
+      Idia {blocked ? 'blocked' : 'passed'}
+    </span>
+  )
+}
+
 function canApprove(candidate: VisualAssetCandidate) {
-  return Boolean(candidate.candidate_url) && !['approved', 'applied'].includes(candidate.status)
+  return Boolean(candidate.candidate_url) && candidate.status === 'proposed' && agentReview(candidate)?.decision !== 'blocked'
 }
 
 export default function VisualAssetsReviewPage() {
@@ -180,7 +210,9 @@ export default function VisualAssetsReviewPage() {
       if (data.applied != null) {
         setMessage(`Applied ${data.applied}; failed ${data.failed}.`)
       } else if (data.captured != null) {
-        setMessage(`Captured ${data.captured} candidate${data.captured === 1 ? '' : 's'}.`)
+        const passed = typeof data.passed === 'number' ? data.passed : data.captured
+        const blocked = typeof data.blocked === 'number' ? data.blocked : 0
+        setMessage(`Captured ${data.captured}; Idia passed ${passed} and blocked ${blocked}.`)
       } else if (data.candidatesCreated != null) {
         setMessage(`Audit queued ${data.candidatesCreated} candidate${data.candidatesCreated === 1 ? '' : 's'}.`)
       } else {
@@ -401,6 +433,7 @@ export default function VisualAssetsReviewPage() {
                         <div className="flex flex-wrap gap-2">
                           <span className="rounded-full border border-cyan-400/20 px-2.5 py-1 text-xs uppercase text-cyan-200">{candidate.theme}</span>
                           <span className="rounded-full border border-muted-foreground/20 px-2.5 py-1 text-xs uppercase text-muted-foreground">{candidate.status}</span>
+                          <AgentReviewBadge candidate={candidate} />
                           {!candidate.candidate_url && (
                             <span className="rounded-full border border-amber-400/20 px-2.5 py-1 text-xs uppercase text-amber-200">needs capture</span>
                           )}
@@ -426,6 +459,11 @@ export default function VisualAssetsReviewPage() {
                           </span>
                         ))}
                       </div>
+                      {agentReview(candidate)?.summary && (
+                        <p className="mt-3 rounded-lg border border-radiant-gold/10 bg-background/60 px-3 py-2 text-xs text-muted-foreground">
+                          {agentReview(candidate)?.summary}
+                        </p>
+                      )}
 
                       <div className="mt-4 flex flex-wrap justify-end gap-2">
                         <button

--- a/app/admin/content/visual-assets/page.tsx
+++ b/app/admin/content/visual-assets/page.tsx
@@ -1,16 +1,32 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import Image from 'next/image'
-import { Check, ImageIcon, Loader2, RefreshCw, Search, Sparkles, X } from 'lucide-react'
+import { Check, CheckCheck, ChevronLeft, ChevronRight, ImageIcon, Loader2, RefreshCw, Search, Sparkles, X } from 'lucide-react'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
 import ProtectedRoute from '@/components/ProtectedRoute'
 import { getCurrentSession } from '@/lib/auth'
-import type { VisualAssetCandidate, VisualAssetStatus, VisualAssetTheme } from '@/lib/visual-assets'
+import type { VisualAssetCandidate, VisualAssetCandidateState, VisualAssetStatus, VisualAssetTheme } from '@/lib/visual-assets'
 
 const STATUSES: Array<VisualAssetStatus | 'all'> = ['all', 'proposed', 'approved', 'rejected', 'applied', 'failed']
 const THEMES: Array<VisualAssetTheme | 'all'> = ['all', 'dark', 'light']
 const ENTITY_TYPES = ['all', 'product', 'service', 'prototype'] as const
+const CANDIDATE_STATES: Array<VisualAssetCandidateState | 'all'> = ['captured', 'needs_capture', 'all']
+const PAGE_SIZES = [6, 12, 24, 48] as const
+const SORT_OPTIONS = [
+  { value: 'newest', label: 'Newest first' },
+  { value: 'title', label: 'Title A-Z' },
+  { value: 'score_desc', label: 'Score high-low' },
+  { value: 'score_asc', label: 'Score low-high' },
+  { value: 'theme', label: 'Theme' },
+] as const
+
+type EntityTypeFilter = (typeof ENTITY_TYPES)[number]
+type SortKey = (typeof SORT_OPTIONS)[number]['value']
+
+function labelFor(value: string) {
+  return value.replace(/_/g, ' ')
+}
 
 function pillClass(active: boolean) {
   return `rounded-full border px-3 py-1.5 text-xs font-semibold uppercase tracking-wide transition ${
@@ -35,12 +51,17 @@ function CandidateImage({ url, label }: { url: string | null; label: string }) {
       {url ? (
         <Image src={url} alt={label} fill className="object-cover" sizes="(max-width: 1024px) 100vw, 420px" />
       ) : (
-        <div className="flex h-full items-center justify-center text-muted-foreground">
+        <div className="flex h-full flex-col items-center justify-center gap-2 text-muted-foreground">
           <ImageIcon size={36} />
+          <span className="text-xs">No image</span>
         </div>
       )}
     </div>
   )
+}
+
+function canApprove(candidate: VisualAssetCandidate) {
+  return Boolean(candidate.candidate_url) && !['approved', 'applied'].includes(candidate.status)
 }
 
 export default function VisualAssetsReviewPage() {
@@ -49,11 +70,15 @@ export default function VisualAssetsReviewPage() {
   const [busy, setBusy] = useState<string | null>(null)
   const [status, setStatus] = useState<VisualAssetStatus | 'all'>('proposed')
   const [theme, setTheme] = useState<VisualAssetTheme | 'all'>('all')
-  const [entityType, setEntityType] = useState<(typeof ENTITY_TYPES)[number]>('all')
+  const [entityType, setEntityType] = useState<EntityTypeFilter>('all')
+  const [candidateState, setCandidateState] = useState<VisualAssetCandidateState | 'all'>('captured')
+  const [sortKey, setSortKey] = useState<SortKey>('newest')
+  const [pageSize, setPageSize] = useState<number>(12)
+  const [page, setPage] = useState(1)
   const [query, setQuery] = useState('')
   const [message, setMessage] = useState<string | null>(null)
 
-  const fetchCandidates = async () => {
+  const fetchCandidates = useCallback(async () => {
     setLoading(true)
     try {
       const session = await getCurrentSession()
@@ -62,6 +87,8 @@ export default function VisualAssetsReviewPage() {
       if (status !== 'all') params.set('status', status)
       if (theme !== 'all') params.set('theme', theme)
       if (entityType !== 'all') params.set('entity_type', entityType)
+      if (candidateState !== 'all') params.set('candidate_state', candidateState)
+      params.set('limit', '250')
       const response = await fetch(`/api/admin/visual-assets/candidates?${params.toString()}`, {
         headers: { Authorization: `Bearer ${session.access_token}` },
       })
@@ -70,12 +97,15 @@ export default function VisualAssetsReviewPage() {
     } finally {
       setLoading(false)
     }
-  }
+  }, [candidateState, entityType, status, theme])
 
   useEffect(() => {
     fetchCandidates()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [status, theme, entityType])
+  }, [fetchCandidates])
+
+  useEffect(() => {
+    setPage(1)
+  }, [candidateState, entityType, pageSize, query, sortKey, status, theme])
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase()
@@ -86,6 +116,50 @@ export default function VisualAssetsReviewPage() {
       candidate.reason_codes.some((reason) => reason.includes(q))
     ))
   }, [candidates, query])
+
+  const sorted = useMemo(() => {
+    return [...filtered].sort((a, b) => {
+      if (sortKey === 'title') return a.title.localeCompare(b.title) || a.theme.localeCompare(b.theme)
+      if (sortKey === 'score_desc') return (b.score ?? -1) - (a.score ?? -1)
+      if (sortKey === 'score_asc') return (a.score ?? 101) - (b.score ?? 101)
+      if (sortKey === 'theme') return a.theme.localeCompare(b.theme) || a.title.localeCompare(b.title)
+      return new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+    })
+  }, [filtered, sortKey])
+
+  const pageCount = Math.max(1, Math.ceil(sorted.length / pageSize))
+  const currentPage = Math.min(page, pageCount)
+  const pageItems = useMemo(() => {
+    const start = (currentPage - 1) * pageSize
+    return sorted.slice(start, start + pageSize)
+  }, [currentPage, pageSize, sorted])
+
+  const groupedPageItems = useMemo(() => {
+    const groups: Array<{ key: string; title: string; entityType: string; route: string; items: VisualAssetCandidate[] }> = []
+    const byKey = new Map<string, (typeof groups)[number]>()
+    for (const candidate of pageItems) {
+      const key = `${candidate.entity_type}:${candidate.entity_id}`
+      const existing = byKey.get(key)
+      if (existing) {
+        existing.items.push(candidate)
+      } else {
+        const group = {
+          key,
+          title: candidate.title,
+          entityType: candidate.entity_type,
+          route: candidate.capture_route,
+          items: [candidate],
+        }
+        byKey.set(key, group)
+        groups.push(group)
+      }
+    }
+    return groups
+  }, [pageItems])
+
+  const capturedCount = candidates.filter((candidate) => candidate.candidate_url).length
+  const needsCaptureCount = candidates.length - capturedCount
+  const visibleApprovalIds = pageItems.filter(canApprove).map((candidate) => candidate.id)
 
   const postAction = async (path: string, body: Record<string, unknown> = {}) => {
     const session = await getCurrentSession()
@@ -103,7 +177,42 @@ export default function VisualAssetsReviewPage() {
       })
       const data = await response.json().catch(() => ({}))
       if (!response.ok) throw new Error(data.error || 'Request failed')
-      setMessage(data.applied != null ? `Applied ${data.applied}; failed ${data.failed}.` : 'Updated.')
+      if (data.applied != null) {
+        setMessage(`Applied ${data.applied}; failed ${data.failed}.`)
+      } else if (data.captured != null) {
+        setMessage(`Captured ${data.captured} candidate${data.captured === 1 ? '' : 's'}.`)
+      } else if (data.candidatesCreated != null) {
+        setMessage(`Audit queued ${data.candidatesCreated} candidate${data.candidatesCreated === 1 ? '' : 's'}.`)
+      } else {
+        setMessage('Updated.')
+      }
+      await fetchCandidates()
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : String(error))
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  const approveVisibleCandidates = async () => {
+    if (visibleApprovalIds.length === 0) return
+    const session = await getCurrentSession()
+    if (!session) return
+    setBusy('approve-visible')
+    setMessage(null)
+    try {
+      const results = await Promise.allSettled(visibleApprovalIds.map(async (id) => {
+        const response = await fetch(`/api/admin/visual-assets/${id}/approve`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${session.access_token}` },
+        })
+        const data = await response.json().catch(() => ({}))
+        if (!response.ok) throw new Error(data.error || `Failed to approve ${id}`)
+        return data
+      }))
+      const approved = results.filter((result) => result.status === 'fulfilled').length
+      const failed = results.length - approved
+      setMessage(failed > 0 ? `Approved ${approved}; failed ${failed}.` : `Approved ${approved} visible candidate${approved === 1 ? '' : 's'}.`)
       await fetchCandidates()
     } catch (error) {
       setMessage(error instanceof Error ? error.message : String(error))
@@ -144,7 +253,15 @@ export default function VisualAssetsReviewPage() {
               onClick={() => postAction('/api/admin/visual-assets/capture', {})}
             >
               {busy?.includes('/capture') ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
-              Capture
+              Capture Missing
+            </button>
+            <button
+              className="agent-ops-button-secondary"
+              disabled={Boolean(busy) || visibleApprovalIds.length === 0}
+              onClick={approveVisibleCandidates}
+            >
+              {busy === 'approve-visible' ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCheck className="h-4 w-4" />}
+              Approve Visible
             </button>
             <button
               className="agent-ops-button-primary"
@@ -158,38 +275,85 @@ export default function VisualAssetsReviewPage() {
         </div>
 
         <section className="mb-6 rounded-xl border border-radiant-gold/10 bg-silicon-slate/25 p-4">
-          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-            <div className="flex flex-wrap gap-2">
+          <div className="grid gap-4 xl:grid-cols-[1fr_auto]">
+            <div className="space-y-3">
+              <div className="flex flex-wrap gap-2">
+                {CANDIDATE_STATES.map((item) => (
+                  <button key={item} className={pillClass(candidateState === item)} onClick={() => setCandidateState(item)}>
+                    {labelFor(item)}
+                  </button>
+                ))}
+              </div>
+              <div className="flex flex-wrap gap-2">
               {STATUSES.map((item) => (
                 <button key={item} className={pillClass(status === item)} onClick={() => setStatus(item)}>
-                  {item}
+                  {labelFor(item)}
                 </button>
               ))}
+              </div>
             </div>
-            <div className="flex flex-wrap gap-2">
+            <div className="space-y-3">
+              <div className="flex flex-wrap justify-start gap-2 xl:justify-end">
               {THEMES.map((item) => (
                 <button key={item} className={pillClass(theme === item)} onClick={() => setTheme(item)}>
-                  {item}
+                  {labelFor(item)}
                 </button>
               ))}
+              </div>
+              <div className="flex flex-wrap justify-start gap-2 xl:justify-end">
               {ENTITY_TYPES.map((item) => (
                 <button key={item} className={pillClass(entityType === item)} onClick={() => setEntityType(item)}>
-                  {item}
+                  {labelFor(item)}
                 </button>
               ))}
+              </div>
             </div>
           </div>
-          <div className="mt-4 flex items-center gap-3 rounded-lg border border-radiant-gold/10 bg-background/60 px-3">
-            <Search className="h-4 w-4 text-muted-foreground" />
-            <input
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder="Search title, type, or reason"
-              className="h-10 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
-            />
-            <button className="text-muted-foreground hover:text-foreground" onClick={fetchCandidates} aria-label="Refresh candidates">
+          <div className="mt-4 grid gap-3 lg:grid-cols-[minmax(220px,1fr)_180px_140px_auto] lg:items-center">
+            <div className="flex items-center gap-3 rounded-lg border border-radiant-gold/10 bg-background/60 px-3">
+              <Search className="h-4 w-4 text-muted-foreground" />
+              <input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search title, type, or reason"
+                className="h-10 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+              />
+            </div>
+            <label className="flex items-center gap-2 rounded-lg border border-radiant-gold/10 bg-background/60 px-3 text-xs uppercase tracking-wide text-muted-foreground">
+              Sort
+              <select
+                value={sortKey}
+                onChange={(event) => setSortKey(event.target.value as SortKey)}
+                className="h-10 flex-1 bg-transparent text-sm normal-case text-foreground outline-none"
+              >
+                {SORT_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>{option.label}</option>
+                ))}
+              </select>
+            </label>
+            <label className="flex items-center gap-2 rounded-lg border border-radiant-gold/10 bg-background/60 px-3 text-xs uppercase tracking-wide text-muted-foreground">
+              Page
+              <select
+                value={pageSize}
+                onChange={(event) => setPageSize(Number(event.target.value))}
+                className="h-10 flex-1 bg-transparent text-sm normal-case text-foreground outline-none"
+              >
+                {PAGE_SIZES.map((size) => (
+                  <option key={size} value={size}>{size}</option>
+                ))}
+              </select>
+            </label>
+            <button className="flex h-10 items-center justify-center rounded-lg border border-radiant-gold/10 px-3 text-muted-foreground hover:text-foreground" onClick={fetchCandidates} aria-label="Refresh candidates">
               <RefreshCw className="h-4 w-4" />
             </button>
+          </div>
+          <div className="mt-3 flex flex-wrap items-center justify-between gap-3 text-xs text-muted-foreground">
+            <p>
+              Showing {pageItems.length} of {sorted.length} filtered candidates. Loaded {capturedCount} captured and {needsCaptureCount} waiting for capture in this view.
+            </p>
+            <p>
+              {visibleApprovalIds.length} visible captured candidate{visibleApprovalIds.length === 1 ? '' : 's'} can be approved.
+            </p>
           </div>
           {message && <p className="mt-3 text-sm text-muted-foreground">{message}</p>}
         </section>
@@ -204,64 +368,128 @@ export default function VisualAssetsReviewPage() {
             No candidates match the current filters.
           </div>
         ) : (
-          <div className="grid grid-cols-1 gap-5 xl:grid-cols-2">
-            {filtered.map((candidate) => (
-              <article key={candidate.id} className="rounded-xl border border-radiant-gold/10 bg-silicon-slate/25 p-4">
+          <div className="space-y-4">
+            <PaginationControls
+              currentPage={currentPage}
+              pageCount={pageCount}
+              onPrevious={() => setPage((value) => Math.max(1, value - 1))}
+              onNext={() => setPage((value) => Math.min(pageCount, value + 1))}
+            />
+
+            {groupedPageItems.map((group) => (
+              <article key={group.key} className="rounded-xl border border-radiant-gold/10 bg-silicon-slate/25 p-4">
                 <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
                   <div>
                     <div className="mb-2 flex flex-wrap gap-2">
-                      <span className="rounded-full border border-radiant-gold/20 px-2.5 py-1 text-xs uppercase text-radiant-gold">{candidate.entity_type}</span>
-                      <span className="rounded-full border border-cyan-400/20 px-2.5 py-1 text-xs uppercase text-cyan-200">{candidate.theme}</span>
-                      <span className="rounded-full border border-muted-foreground/20 px-2.5 py-1 text-xs uppercase text-muted-foreground">{candidate.status}</span>
+                      <span className="rounded-full border border-radiant-gold/20 px-2.5 py-1 text-xs uppercase text-radiant-gold">{group.entityType}</span>
+                      <span className="rounded-full border border-muted-foreground/20 px-2.5 py-1 text-xs uppercase text-muted-foreground">{group.items.length} variant{group.items.length === 1 ? '' : 's'}</span>
                     </div>
-                    <h2 className="text-lg font-semibold text-foreground">{candidate.title}</h2>
-                    <p className="mt-1 text-xs text-muted-foreground">{candidate.capture_route}</p>
+                    <h2 className="text-lg font-semibold text-foreground">{group.title}</h2>
+                    <p className="mt-1 text-xs text-muted-foreground">{group.route}</p>
                   </div>
-                  <ScoreBadge score={candidate.score} />
-                </div>
-
-                <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-                  <div>
-                    <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Current</p>
-                    <CandidateImage url={candidate.current_url} label={`${candidate.title} current`} />
-                  </div>
-                  <div>
-                    <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Candidate</p>
-                    <CandidateImage url={candidate.candidate_url} label={`${candidate.title} candidate`} />
+                  <div className="flex flex-wrap gap-2">
+                    {group.items.map((candidate) => (
+                      <ScoreBadge key={candidate.id} score={candidate.score} />
+                    ))}
                   </div>
                 </div>
 
-                <div className="mt-4 flex flex-wrap gap-2">
-                  {candidate.reason_codes.map((reason) => (
-                    <span key={reason} className="rounded-full bg-background/70 px-2.5 py-1 text-xs text-muted-foreground">
-                      {reason.replace(/_/g, ' ')}
-                    </span>
+                <div className="grid grid-cols-1 gap-4 2xl:grid-cols-2">
+                  {group.items.map((candidate) => (
+                    <div key={candidate.id} className="rounded-lg border border-radiant-gold/10 bg-background/35 p-3">
+                      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+                        <div className="flex flex-wrap gap-2">
+                          <span className="rounded-full border border-cyan-400/20 px-2.5 py-1 text-xs uppercase text-cyan-200">{candidate.theme}</span>
+                          <span className="rounded-full border border-muted-foreground/20 px-2.5 py-1 text-xs uppercase text-muted-foreground">{candidate.status}</span>
+                          {!candidate.candidate_url && (
+                            <span className="rounded-full border border-amber-400/20 px-2.5 py-1 text-xs uppercase text-amber-200">needs capture</span>
+                          )}
+                        </div>
+                        <ScoreBadge score={candidate.score} />
+                      </div>
+
+                      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                        <div>
+                          <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Current</p>
+                          <CandidateImage url={candidate.current_url} label={`${candidate.title} current`} />
+                        </div>
+                        <div>
+                          <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Candidate</p>
+                          <CandidateImage url={candidate.candidate_url} label={`${candidate.title} candidate`} />
+                        </div>
+                      </div>
+
+                      <div className="mt-3 flex flex-wrap gap-2">
+                        {candidate.reason_codes.map((reason) => (
+                          <span key={reason} className="rounded-full bg-background/70 px-2.5 py-1 text-xs text-muted-foreground">
+                            {labelFor(reason)}
+                          </span>
+                        ))}
+                      </div>
+
+                      <div className="mt-4 flex flex-wrap justify-end gap-2">
+                        <button
+                          className="agent-ops-button-secondary"
+                          disabled={Boolean(busy) || candidate.status === 'rejected'}
+                          onClick={() => postAction(`/api/admin/visual-assets/${candidate.id}/reject`)}
+                        >
+                          <X className="h-4 w-4" />
+                          Reject
+                        </button>
+                        <button
+                          className="agent-ops-button-primary"
+                          disabled={Boolean(busy) || !canApprove(candidate)}
+                          onClick={() => postAction(`/api/admin/visual-assets/${candidate.id}/approve`)}
+                        >
+                          <Check className="h-4 w-4" />
+                          Approve
+                        </button>
+                      </div>
+                    </div>
                   ))}
-                </div>
-
-                <div className="mt-5 flex flex-wrap justify-end gap-2">
-                  <button
-                    className="agent-ops-button-secondary"
-                    disabled={Boolean(busy) || candidate.status === 'rejected'}
-                    onClick={() => postAction(`/api/admin/visual-assets/${candidate.id}/reject`)}
-                  >
-                    <X className="h-4 w-4" />
-                    Reject
-                  </button>
-                  <button
-                    className="agent-ops-button-primary"
-                    disabled={Boolean(busy) || !candidate.candidate_url || candidate.status === 'approved'}
-                    onClick={() => postAction(`/api/admin/visual-assets/${candidate.id}/approve`)}
-                  >
-                    <Check className="h-4 w-4" />
-                    Approve
-                  </button>
                 </div>
               </article>
             ))}
+
+            <PaginationControls
+              currentPage={currentPage}
+              pageCount={pageCount}
+              onPrevious={() => setPage((value) => Math.max(1, value - 1))}
+              onNext={() => setPage((value) => Math.min(pageCount, value + 1))}
+            />
           </div>
         )}
       </main>
     </ProtectedRoute>
+  )
+}
+
+function PaginationControls({
+  currentPage,
+  pageCount,
+  onPrevious,
+  onNext,
+}: {
+  currentPage: number
+  pageCount: number
+  onPrevious: () => void
+  onNext: () => void
+}) {
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-radiant-gold/10 bg-silicon-slate/20 px-4 py-3">
+      <p className="text-sm text-muted-foreground">
+        Page {currentPage} of {pageCount}
+      </p>
+      <div className="flex items-center gap-2">
+        <button className="agent-ops-button-secondary" disabled={currentPage <= 1} onClick={onPrevious}>
+          <ChevronLeft className="h-4 w-4" />
+          Previous
+        </button>
+        <button className="agent-ops-button-secondary" disabled={currentPage >= pageCount} onClick={onNext}>
+          Next
+          <ChevronRight className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
   )
 }

--- a/app/api/admin/visual-assets/_utils.ts
+++ b/app/api/admin/visual-assets/_utils.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { isAuthError, verifyAdmin } from '@/lib/auth-server'
 import {
+  isVisualAssetCandidateState,
   isVisualAssetEntityType,
   isVisualAssetStatus,
   isVisualAssetTheme,
@@ -29,6 +30,7 @@ export function parseCandidateQuery(url: string) {
   const status = searchParams.get('status')
   const entityType = searchParams.get('entity_type')
   const theme = searchParams.get('theme')
+  const candidateState = searchParams.get('candidate_state')
   const limitParam = searchParams.get('limit')
   const limit = limitParam ? Number(limitParam) : undefined
 
@@ -36,6 +38,7 @@ export function parseCandidateQuery(url: string) {
     status: status && isVisualAssetStatus(status) ? status : undefined,
     entityType: entityType && isVisualAssetEntityType(entityType) ? entityType : undefined,
     theme: theme && isVisualAssetTheme(theme) ? theme as VisualAssetTheme : undefined,
+    candidateState: candidateState && isVisualAssetCandidateState(candidateState) ? candidateState : undefined,
     limit: Number.isFinite(limit) && limit ? Math.min(Math.max(limit, 1), 250) : undefined,
   }
 }

--- a/app/api/admin/visual-assets/route.test.ts
+++ b/app/api/admin/visual-assets/route.test.ts
@@ -19,9 +19,11 @@ vi.mock('@/lib/visual-assets', () => ({
   VISUAL_ASSET_ENTITY_TYPES: ['product', 'service', 'prototype'],
   VISUAL_ASSET_STATUSES: ['proposed', 'approved', 'rejected', 'applied', 'failed'],
   VISUAL_ASSET_THEMES: ['dark', 'light'],
+  VISUAL_ASSET_CANDIDATE_STATES: ['captured', 'needs_capture'],
   isVisualAssetEntityType: (value: string) => ['product', 'service', 'prototype'].includes(value),
   isVisualAssetStatus: (value: string) => ['proposed', 'approved', 'rejected', 'applied', 'failed'].includes(value),
   isVisualAssetTheme: (value: string) => ['dark', 'light'].includes(value),
+  isVisualAssetCandidateState: (value: string) => ['captured', 'needs_capture'].includes(value),
   auditVisualAssets: mocks.auditVisualAssets,
   captureVisualAssetCandidates: mocks.captureVisualAssetCandidates,
   listVisualAssetCandidates: mocks.listVisualAssetCandidates,
@@ -45,11 +47,11 @@ describe('visual asset admin routes', () => {
     mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-1' } })
   })
 
-  it('lists candidates with status, entity, and theme filters', async () => {
+  it('lists candidates with status, entity, theme, and candidate-state filters', async () => {
     const { GET } = await import('./candidates/route')
     mocks.listVisualAssetCandidates.mockResolvedValue([{ id: 'candidate-1' }])
 
-    const response = await GET(request('/api/admin/visual-assets/candidates?status=proposed&entity_type=product&theme=dark'))
+    const response = await GET(request('/api/admin/visual-assets/candidates?status=proposed&entity_type=product&theme=dark&candidate_state=captured'))
     expectResponse(response)
     const body = await response.json()
 
@@ -59,6 +61,7 @@ describe('visual asset admin routes', () => {
       status: 'proposed',
       entityType: 'product',
       theme: 'dark',
+      candidateState: 'captured',
     }))
   })
 

--- a/lib/playtest-broll.ts
+++ b/lib/playtest-broll.ts
@@ -9,6 +9,7 @@ import * as path from 'path'
 import { spawn } from 'child_process'
 import chromiumServerless from '@sparticuz/chromium'
 import { chromium } from 'playwright-core'
+import type { Page } from 'playwright-core'
 import { generateAuthState } from '@/scripts/save-storyboard-auth'
 
 const VIEWPORT = { width: 1920, height: 1080 }
@@ -203,6 +204,51 @@ async function launchCaptureBrowser() {
   })
 }
 
+async function forceCaptureTheme(page: Page, colorScheme?: RouteConfig['colorScheme']) {
+  if (colorScheme !== 'light' && colorScheme !== 'dark') return
+  await page.evaluate((theme) => {
+    try {
+      window.localStorage.setItem('theme', theme)
+    } catch {
+      // Capture should still continue when storage is unavailable.
+    }
+
+    const isDark = theme === 'dark'
+    document.documentElement.classList.toggle('dark', isDark)
+    document.documentElement.style.colorScheme = theme
+    document.body?.classList.toggle('dark', isDark)
+
+    for (const element of Array.from(document.querySelectorAll<HTMLElement>('.agent-ops-page.dark, .dark.agent-ops-page'))) {
+      element.classList.toggle('dark', isDark)
+    }
+
+    if (theme !== 'light') return
+
+    for (const element of Array.from(document.querySelectorAll<HTMLElement>('*'))) {
+      if (element.classList.contains('bg-black')) {
+        element.classList.remove('bg-black')
+        element.classList.add('bg-background')
+      }
+      if (element.classList.contains('text-white')) {
+        element.classList.remove('text-white')
+        element.classList.add('text-foreground')
+      }
+      if (element.classList.contains('bg-gray-900')) {
+        element.classList.remove('bg-gray-900')
+        element.classList.add('bg-card')
+      }
+      if (element.classList.contains('border-gray-800')) {
+        element.classList.remove('border-gray-800')
+        element.classList.add('border-border')
+      }
+      if (element.classList.contains('text-gray-400')) {
+        element.classList.remove('text-gray-400')
+        element.classList.add('text-muted-foreground')
+      }
+    }
+  }, colorScheme).catch(() => undefined)
+}
+
 /**
  * Capture B-roll (screenshots and optional video clips) for the given routes.
  */
@@ -262,6 +308,17 @@ export async function captureBroll(config: PlaytestConfig): Promise<CaptureResul
     }
 
     const context = await browser.newContext(contextOptions)
+    if (colorScheme === 'light' || colorScheme === 'dark') {
+      await context.addInitScript((theme) => {
+        try {
+          window.localStorage.setItem('theme', theme)
+        } catch {
+          // Ignore storage errors during isolated screenshot capture.
+        }
+        document.documentElement.classList.toggle('dark', theme === 'dark')
+        document.documentElement.style.colorScheme = theme
+      }, colorScheme)
+    }
     const page = await context.newPage()
 
     try {
@@ -272,6 +329,7 @@ export async function captureBroll(config: PlaytestConfig): Promise<CaptureResul
       if (waitForSelector) {
         await page.waitForSelector(waitForSelector, { timeout: 15000 })
       }
+      await forceCaptureTheme(page, colorScheme)
       await page.waitForTimeout(800)
 
       config.onProgress?.({ route, filename, step: 'screenshot', index: i, total })

--- a/lib/visual-assets.test.ts
+++ b/lib/visual-assets.test.ts
@@ -7,6 +7,7 @@ vi.mock('@/lib/playtest-broll', () => ({ captureBroll: vi.fn() }))
 
 import {
   applyApprovedVisualAssetCandidates,
+  listVisualAssetCandidates,
   resolveVisualAssetRoute,
   reviewVisualAssetCandidate,
   scoreImageBuffer,
@@ -23,7 +24,8 @@ function createTableClient(tables: Record<string, Record<string, any>[]>) {
       filters: Record<string, unknown>
       inFilters: Record<string, unknown[]>
       notFilters: Record<string, unknown>
-    } = { filters: {}, inFilters: {}, notFilters: {} }
+      isFilters: Record<string, unknown>
+    } = { filters: {}, inFilters: {}, notFilters: {}, isFilters: {} }
 
     const api: any = {
       select(value?: string) {
@@ -46,7 +48,14 @@ function createTableClient(tables: Record<string, Record<string, any>[]>) {
         state.notFilters[key] = value
         return api
       },
+      is(key: string, value: unknown) {
+        state.isFilters[key] = value
+        return api
+      },
       order() {
+        return api
+      },
+      limit() {
         return api
       },
       maybeSingle() {
@@ -85,6 +94,7 @@ function matches(row: Record<string, unknown>, state: {
   filters: Record<string, unknown>
   inFilters: Record<string, unknown[]>
   notFilters: Record<string, unknown>
+  isFilters: Record<string, unknown>
 }) {
   for (const [key, value] of Object.entries(state.filters)) {
     if (row[key] !== value) return false
@@ -94,6 +104,13 @@ function matches(row: Record<string, unknown>, state: {
   }
   for (const [key, value] of Object.entries(state.notFilters)) {
     if (row[key] === value || row[key] == null) return false
+  }
+  for (const [key, value] of Object.entries(state.isFilters)) {
+    if (value === null) {
+      if (row[key] != null) return false
+    } else if (row[key] !== value) {
+      return false
+    }
   }
   return true
 }
@@ -171,6 +188,40 @@ describe('visual asset helpers', () => {
       reviewed_by: 'admin-1',
       metadata: { score: 10, review_reason: 'Strong feature signal' },
     })
+  })
+
+  it('separates captured review candidates from the missing-capture queue', async () => {
+    const client = createTableClient({
+      visual_asset_candidates: [
+        {
+          id: 'captured-1',
+          status: 'proposed',
+          candidate_url: 'https://example.com/captured.png',
+        },
+        {
+          id: 'needs-capture-1',
+          status: 'proposed',
+          candidate_url: null,
+        },
+        {
+          id: 'approved-captured',
+          status: 'approved',
+          candidate_url: 'https://example.com/approved.png',
+        },
+      ],
+    }) as any
+
+    await expect(listVisualAssetCandidates({
+      status: 'proposed',
+      candidateState: 'captured',
+      client,
+    })).resolves.toEqual([expect.objectContaining({ id: 'captured-1' })])
+
+    await expect(listVisualAssetCandidates({
+      status: 'proposed',
+      candidateState: 'needs_capture',
+      client,
+    })).resolves.toEqual([expect.objectContaining({ id: 'needs-capture-1' })])
   })
 
   it('applies approved candidates to theme variants without overwriting light and dark together', async () => {

--- a/lib/visual-assets.test.ts
+++ b/lib/visual-assets.test.ts
@@ -10,6 +10,7 @@ import {
   listVisualAssetCandidates,
   resolveVisualAssetRoute,
   reviewVisualAssetCandidate,
+  reviewVisualAssetCandidateQuality,
   scoreImageBuffer,
   visualAssetStoragePath,
 } from './visual-assets'
@@ -164,6 +165,57 @@ describe('visual asset helpers', () => {
       'light_mode_mismatch',
       'weak_feature_signal',
     ]))
+    expect(score.metadata.darkPixelRatio).toBe(0)
+  })
+
+  it('blocks dark-looking captures for light theme review before human approval', () => {
+    const review = reviewVisualAssetCandidateQuality({
+      title: 'Light candidate',
+      theme: 'light',
+    }, {
+      score: 82,
+      reasonCodes: [],
+      metadata: {
+        width: 1440,
+        height: 900,
+        aspectRatio: 1.6,
+        blankSpaceRatio: 0.2,
+        lightPixelRatio: 0.04,
+        darkPixelRatio: 0.82,
+        edgeDensity: 0.12,
+      },
+    }, '2026-06-30T12:00:00.000Z')
+
+    expect(review).toMatchObject({
+      reviewer: 'portfolio-visual-curator',
+      decision: 'blocked',
+      reason_codes: expect.arrayContaining(['dark_mode_mismatch']),
+    })
+  })
+
+  it('passes a strong theme-matched capture to the human approval queue', () => {
+    const review = reviewVisualAssetCandidateQuality({
+      title: 'Dark candidate',
+      theme: 'dark',
+    }, {
+      score: 88,
+      reasonCodes: [],
+      metadata: {
+        width: 1440,
+        height: 900,
+        aspectRatio: 1.6,
+        blankSpaceRatio: 0.18,
+        lightPixelRatio: 0.18,
+        darkPixelRatio: 0.42,
+        edgeDensity: 0.14,
+      },
+    }, '2026-06-30T12:00:00.000Z')
+
+    expect(review).toMatchObject({
+      decision: 'passed',
+      reason_codes: [],
+      requirements: { minimum_score: 70, expected_theme: 'dark' },
+    })
   })
 
   it('preserves metadata while approving and rejecting candidates', async () => {

--- a/lib/visual-assets.ts
+++ b/lib/visual-assets.ts
@@ -24,8 +24,10 @@ export type VisualAssetReasonCode =
   | 'wrong_aspect_ratio'
   | 'high_blank_space_ratio'
   | 'light_mode_mismatch'
+  | 'dark_mode_mismatch'
   | 'weak_feature_signal'
   | 'stale_generated_capture'
+  | 'candidate_below_quality_bar'
 
 export interface VisualAssetEntity {
   entityType: VisualAssetEntityType
@@ -68,8 +70,26 @@ export interface VisualAssetScore {
     aspectRatio: number
     blankSpaceRatio: number
     lightPixelRatio: number
+    darkPixelRatio: number
     edgeDensity: number
   }
+}
+
+export interface VisualAssetAgentReview {
+  reviewer: 'portfolio-visual-curator'
+  reviewer_name: 'Idia (Benin) - Portfolio Visual Curator'
+  decision: 'passed' | 'blocked'
+  reviewed_at: string
+  score: number
+  reason_codes: VisualAssetReasonCode[]
+  summary: string
+  requirements: {
+    minimum_score: number
+    expected_theme: VisualAssetTheme
+    maximum_blank_space_ratio: number
+    minimum_edge_density: number
+  }
+  metrics: VisualAssetScore['metadata']
 }
 
 type SupabaseLike = typeof supabaseAdmin
@@ -80,7 +100,9 @@ const MIN_ASPECT = 1.15
 const MAX_ASPECT = 2.4
 const MAX_BLANK_SPACE_RATIO = 0.42
 const MAX_LIGHT_PIXEL_RATIO = 0.72
+const MAX_DARK_PIXEL_RATIO_FOR_LIGHT = 0.58
 const MIN_EDGE_DENSITY = 0.035
+const MIN_AGENT_REVIEW_SCORE = 70
 const STALE_CAPTURE_DAYS = 45
 
 function db(client: SupabaseLike = supabaseAdmin) {
@@ -186,6 +208,7 @@ export async function scoreImageBuffer(buffer: Buffer): Promise<VisualAssetScore
     .toBuffer()
 
   let lightPixels = 0
+  let darkPixels = 0
   let blankPixels = 0
   let edgePixels = 0
   const luminance: number[] = []
@@ -193,6 +216,7 @@ export async function scoreImageBuffer(buffer: Buffer): Promise<VisualAssetScore
     const l = (0.2126 * raw[i] + 0.7152 * raw[i + 1] + 0.0722 * raw[i + 2]) / 255
     luminance.push(l)
     if (l > 0.82) lightPixels += 1
+    if (l < 0.18) darkPixels += 1
     if (l > 0.92 || l < 0.06) blankPixels += 1
   }
 
@@ -210,6 +234,7 @@ export async function scoreImageBuffer(buffer: Buffer): Promise<VisualAssetScore
   const pixelCount = sampleWidth * sampleHeight
   const blankSpaceRatio = blankPixels / pixelCount
   const lightPixelRatio = lightPixels / pixelCount
+  const darkPixelRatio = darkPixels / pixelCount
   const edgeDensity = edgePixels / pixelCount
   const reasonCodes: VisualAssetReasonCode[] = []
 
@@ -229,29 +254,93 @@ export async function scoreImageBuffer(buffer: Buffer): Promise<VisualAssetScore
       aspectRatio,
       blankSpaceRatio,
       lightPixelRatio,
+      darkPixelRatio,
       edgeDensity,
     },
   }
 }
 
+function emptyScore(reasonCode: VisualAssetReasonCode): VisualAssetScore {
+  return {
+    score: 0,
+    reasonCodes: [reasonCode],
+    metadata: {
+      width: 0,
+      height: 0,
+      aspectRatio: 0,
+      blankSpaceRatio: 1,
+      lightPixelRatio: 0,
+      darkPixelRatio: reasonCode === 'missing_image' || reasonCode === 'image_load_failure' ? 0 : 1,
+      edgeDensity: 0,
+    },
+  }
+}
+
+export function reviewVisualAssetCandidateQuality(
+  candidate: Pick<VisualAssetCandidate, 'theme' | 'title'>,
+  score: VisualAssetScore,
+  reviewedAt = new Date().toISOString(),
+): VisualAssetAgentReview {
+  const candidateReasons = score.reasonCodes.filter((reason) => {
+    if (candidate.theme === 'light' && reason === 'light_mode_mismatch') return false
+    return true
+  })
+  const reasonCodes = new Set<VisualAssetReasonCode>(candidateReasons)
+
+  if (candidate.theme === 'light' && score.metadata.darkPixelRatio > MAX_DARK_PIXEL_RATIO_FOR_LIGHT) {
+    reasonCodes.add('dark_mode_mismatch')
+  }
+  if (candidate.theme === 'dark' && score.metadata.lightPixelRatio > MAX_LIGHT_PIXEL_RATIO) {
+    reasonCodes.add('light_mode_mismatch')
+  }
+  if (score.score < MIN_AGENT_REVIEW_SCORE) {
+    reasonCodes.add('candidate_below_quality_bar')
+  }
+
+  const blockingReasons: VisualAssetReasonCode[] = [
+    'missing_image',
+    'image_load_failure',
+    'low_resolution',
+    'wrong_aspect_ratio',
+    'high_blank_space_ratio',
+    'light_mode_mismatch',
+    'dark_mode_mismatch',
+    'weak_feature_signal',
+    'candidate_below_quality_bar',
+  ]
+  const blockedCodes = Array.from(reasonCodes).filter((reason) => blockingReasons.includes(reason))
+  const decision: VisualAssetAgentReview['decision'] = blockedCodes.length > 0 ? 'blocked' : 'passed'
+
+  return {
+    reviewer: 'portfolio-visual-curator',
+    reviewer_name: 'Idia (Benin) - Portfolio Visual Curator',
+    decision,
+    reviewed_at: reviewedAt,
+    score: score.score,
+    reason_codes: Array.from(reasonCodes),
+    summary: decision === 'passed'
+      ? `Passed automated quality review for ${candidate.theme} human approval.`
+      : `Blocked before human review: ${blockedCodes.map((reason) => reason.replace(/_/g, ' ')).join(', ')}.`,
+    requirements: {
+      minimum_score: MIN_AGENT_REVIEW_SCORE,
+      expected_theme: candidate.theme,
+      maximum_blank_space_ratio: MAX_BLANK_SPACE_RATIO,
+      minimum_edge_density: MIN_EDGE_DENSITY,
+    },
+    metrics: score.metadata,
+  }
+}
+
 async function scoreImageUrl(url: string | null): Promise<VisualAssetScore> {
   if (!url || !url.trim()) {
-    return {
-      score: 0,
-      reasonCodes: ['missing_image'],
-      metadata: { width: 0, height: 0, aspectRatio: 0, blankSpaceRatio: 1, lightPixelRatio: 0, edgeDensity: 0 },
-    }
+    return emptyScore('missing_image')
   }
   try {
     const response = await fetch(url, { signal: AbortSignal.timeout(8000) })
     if (!response.ok) throw new Error(`HTTP ${response.status}`)
     return scoreImageBuffer(Buffer.from(await response.arrayBuffer()))
   } catch {
-    return {
-      score: 0,
-      reasonCodes: ['image_load_failure'],
-      metadata: { width: 0, height: 0, aspectRatio: 0, blankSpaceRatio: 1, lightPixelRatio: 0, edgeDensity: 0 },
-    }
+    return emptyScore('image_load_failure')
   }
 }
 
@@ -550,7 +639,9 @@ export async function captureVisualAssetCandidates(input: {
   const { data, error } = await query
   if (error) throw new Error(`Failed to list capture candidates: ${error.message}`)
   const candidates = (data ?? []) as VisualAssetCandidate[]
-  if (candidates.length === 0) return { captured: 0, candidates: [] as VisualAssetCandidate[] }
+  if (candidates.length === 0) {
+    return { captured: 0, passed: 0, blocked: 0, candidates: [] as VisualAssetCandidate[] }
+  }
 
   const outputDir = path.join(os.tmpdir(), 'portfolio-visual-asset-candidates', String(Date.now()))
   const result = await captureBroll({
@@ -562,14 +653,44 @@ export async function captureVisualAssetCandidates(input: {
   })
 
   const updated: VisualAssetCandidate[] = []
+  let passed = 0
+  let blocked = 0
   for (const candidate of candidates) {
     const screenshotPath = result.screenshots.find((screenshot) => path.basename(screenshot, '.png') === `visual-candidate-${candidate.id}`)
-    if (!screenshotPath) continue
+    if (!screenshotPath) {
+      const failureScore = emptyScore('image_load_failure')
+      const agentReview = reviewVisualAssetCandidateQuality(candidate, failureScore)
+      const reasonCodes = Array.from(new Set([...candidate.reason_codes, ...agentReview.reason_codes]))
+      const { data: row, error: updateError } = await db(client)
+        .from('visual_asset_candidates')
+        .update({
+          status: 'failed',
+          score: failureScore.score,
+          reason_codes: reasonCodes,
+          metadata: {
+            ...asMetadata(candidate.metadata),
+            agent_review: agentReview,
+            capture_error: 'No screenshot was produced for this candidate.',
+            captured_at: new Date().toISOString(),
+          },
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', candidate.id)
+        .select('*')
+        .single()
+      if (updateError) throw new Error(`Failed to mark missing screenshot candidate: ${updateError.message}`)
+      blocked += 1
+      updated.push(row as VisualAssetCandidate)
+      continue
+    }
     const upload = await uploadCandidateImage({ candidate, filePath: screenshotPath, client })
-    const reasonCodes = Array.from(new Set([...candidate.reason_codes, ...upload.score.reasonCodes]))
+    const agentReview = reviewVisualAssetCandidateQuality(candidate, upload.score)
+    const reasonCodes = Array.from(new Set([...candidate.reason_codes, ...agentReview.reason_codes]))
+    const status: VisualAssetStatus = agentReview.decision === 'passed' ? 'proposed' : 'failed'
     const { data: row, error: updateError } = await db(client)
       .from('visual_asset_candidates')
       .update({
+        status,
         candidate_url: upload.publicUrl,
         candidate_storage_path: upload.storagePath,
         score: upload.score.score,
@@ -577,6 +698,7 @@ export async function captureVisualAssetCandidates(input: {
         metadata: {
           ...asMetadata(candidate.metadata),
           candidate_image_score: upload.score.metadata,
+          agent_review: agentReview,
           captured_at: new Date().toISOString(),
         },
         updated_at: new Date().toISOString(),
@@ -585,10 +707,12 @@ export async function captureVisualAssetCandidates(input: {
       .select('*')
       .single()
     if (updateError) throw new Error(`Failed to update captured candidate: ${updateError.message}`)
+    if (status === 'proposed') passed += 1
+    else blocked += 1
     updated.push(row as VisualAssetCandidate)
   }
 
-  return { captured: updated.length, candidates: updated }
+  return { captured: updated.length, passed, blocked, candidates: updated }
 }
 
 export async function reviewVisualAssetCandidate(input: {

--- a/lib/visual-assets.ts
+++ b/lib/visual-assets.ts
@@ -10,10 +10,12 @@ import { supabaseAdmin } from '@/lib/supabase'
 export const VISUAL_ASSET_ENTITY_TYPES = ['product', 'service', 'prototype'] as const
 export const VISUAL_ASSET_STATUSES = ['proposed', 'approved', 'rejected', 'applied', 'failed'] as const
 export const VISUAL_ASSET_THEMES = ['dark', 'light'] as const
+export const VISUAL_ASSET_CANDIDATE_STATES = ['captured', 'needs_capture'] as const
 
 export type VisualAssetEntityType = (typeof VISUAL_ASSET_ENTITY_TYPES)[number]
 export type VisualAssetStatus = (typeof VISUAL_ASSET_STATUSES)[number]
 export type VisualAssetTheme = (typeof VISUAL_ASSET_THEMES)[number]
+export type VisualAssetCandidateState = (typeof VISUAL_ASSET_CANDIDATE_STATES)[number]
 
 export type VisualAssetReasonCode =
   | 'missing_image'
@@ -110,6 +112,10 @@ export function isVisualAssetStatus(value: string): value is VisualAssetStatus {
 
 export function isVisualAssetTheme(value: string): value is VisualAssetTheme {
   return VISUAL_ASSET_THEMES.includes(value as VisualAssetTheme)
+}
+
+export function isVisualAssetCandidateState(value: string): value is VisualAssetCandidateState {
+  return VISUAL_ASSET_CANDIDATE_STATES.includes(value as VisualAssetCandidateState)
 }
 
 export function visualAssetStoragePath(input: {
@@ -413,6 +419,7 @@ export async function listVisualAssetCandidates(input: {
   status?: VisualAssetStatus
   entityType?: VisualAssetEntityType
   theme?: VisualAssetTheme
+  candidateState?: VisualAssetCandidateState
   limit?: number
   client?: SupabaseLike
 } = {}) {
@@ -425,6 +432,8 @@ export async function listVisualAssetCandidates(input: {
   if (input.status) query = query.eq('status', input.status)
   if (input.entityType) query = query.eq('entity_type', input.entityType)
   if (input.theme) query = query.eq('theme', input.theme)
+  if (input.candidateState === 'captured') query = query.not('candidate_url', 'is', null)
+  if (input.candidateState === 'needs_capture') query = query.is('candidate_url', null)
 
   const { data, error } = await query
   if (error) throw new Error(`Failed to list visual asset candidates: ${error.message}`)


### PR DESCRIPTION
## Summary
- Default the visual asset review page to captured screenshot candidates instead of dumping uncaptured/null-image rows into the review list.
- Add candidate-state filtering for captured vs needs-capture queues, plus sort, search, page-size controls, pagination, grouped entity variants, and page-scoped Approve Visible.
- Add Idia's automated pre-human quality gate: captured screenshots now receive an `metadata.agent_review` decision, wrong-theme/blank/low-signal captures are marked `failed`, and only passed `proposed` candidates can be human-approved.
- Force capture routes toward the requested light/dark theme before screenshotting, then use deterministic pixel scoring to block candidates that still contradict the requested theme.

## Validation
- `npx vitest run app/admin/content/visual-assets/page.test.tsx lib/visual-assets.test.ts app/api/admin/visual-assets/route.test.ts`
- `npm run build` with the local Portfolio `.env.local` attached for this isolated worktree
- In-app Browser smoke on `http://localhost:3041/admin/content/visual-assets`: authenticated local admin page, verified the page and controls render, verified the `failed` queue is reachable, verified `Approve Visible` is disabled when no passed candidates are visible, and console logs had no errors/warnings.

## Integration Notes
- No migration or env change required.
- `proposed` now means Idia passed the candidate to human review; `failed` can include captured screenshots blocked before human approval, with the review evidence in `metadata.agent_review`.
- Local dev data for failed visual candidates was empty during browser smoke, so blocked-candidate display/approval exclusion is covered by the component test using mocked candidates.
- Vercel contexts not checked from this non-captain lane:
  - Vercel – portfolio: not checked
  - Vercel – portfolio-staging: not checked
