### PR TITLE
feat: add governed social platform submission

### DIFF
--- a/app/admin/social-content/[id]/page.tsx
+++ b/app/admin/social-content/[id]/page.tsx
@@ -21,6 +21,7 @@ import {
   Youtube,
   Instagram,
   Facebook,
+  Hash,
   FileText,
   Sparkles,
   ExternalLink,
@@ -50,9 +51,11 @@ import {
   getVideoRedactionGate,
   type RedactionReviewDecision,
 } from '@/lib/social-production-assets'
+import { buildPlatformOrchestrationPlan, type PlatformOrchestrationStageState } from '@/lib/social-platform-orchestration'
 import type {
   SocialContentItem,
   SocialContentPublish,
+  SocialContentConfig,
   ContentStatus,
   FrameworkVisualType,
   SocialPlatform,
@@ -64,6 +67,7 @@ const PLATFORM_ICONS: Record<string, React.ReactNode> = {
   youtube: <Youtube className="w-4 h-4" />,
   instagram: <Instagram className="w-4 h-4" />,
   facebook: <Facebook className="w-4 h-4" />,
+  tiktok: <Hash className="w-4 h-4" />,
 }
 
 const PLATFORM_COLORS: Record<string, { active: string; inactive: string }> = {
@@ -71,6 +75,7 @@ const PLATFORM_COLORS: Record<string, { active: string; inactive: string }> = {
   youtube: { active: 'bg-red-600/20 border-red-500 text-red-300', inactive: 'bg-gray-800 border-gray-700 text-gray-500 hover:border-gray-600' },
   instagram: { active: 'bg-pink-600/20 border-pink-500 text-pink-300', inactive: 'bg-gray-800 border-gray-700 text-gray-500 hover:border-gray-600' },
   facebook: { active: 'bg-blue-600/20 border-blue-500 text-blue-300', inactive: 'bg-gray-800 border-gray-700 text-gray-500 hover:border-gray-600' },
+  tiktok: { active: 'bg-cyan-600/20 border-cyan-500 text-cyan-200', inactive: 'bg-gray-800 border-gray-700 text-gray-500 hover:border-gray-600' },
 }
 
 type GateState = 'approved' | 'in_review' | 'pending' | 'blocked' | 'rejected'
@@ -125,6 +130,20 @@ function gateStateFromRawStatus(value: string): GateState {
   if (['failed', 'blocked', 'rejected', 'error'].includes(status)) return 'blocked'
   if (status.includes('review') || status.includes('running') || status.includes('progress')) return 'in_review'
   return 'pending'
+}
+
+function platformStageClass(state: PlatformOrchestrationStageState) {
+  if (state === 'complete') return 'border-emerald-500/35 bg-emerald-500/10 text-emerald-100'
+  if (state === 'available') return 'border-blue-500/35 bg-blue-500/10 text-blue-100'
+  if (state === 'blocked') return 'border-red-500/35 bg-red-500/10 text-red-100'
+  return 'border-amber-500/35 bg-amber-500/10 text-amber-100'
+}
+
+function platformStageDotClass(state: PlatformOrchestrationStageState) {
+  if (state === 'complete') return 'bg-emerald-300'
+  if (state === 'available') return 'bg-blue-300'
+  if (state === 'blocked') return 'bg-red-300'
+  return 'bg-amber-300'
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -265,6 +284,7 @@ function SocialContentDetailPage() {
   const [topicBacklogItems, setTopicBacklogItems] = useState<TopicBacklogRecord[]>([])
   const [topicBacklogUnavailable, setTopicBacklogUnavailable] = useState(false)
   const [selectedTopicBacklogId, setSelectedTopicBacklogId] = useState<string | null>(null)
+  const [platformConfigs, setPlatformConfigs] = useState<SocialContentConfig[]>([])
   const [savingSectionGate, setSavingSectionGate] = useState<SectionGateKey | null>(null)
   const [showSource, setShowSource] = useState(false)
   const [expandedSection, setExpandedSection] = useState<'rag' | 'transcript' | null>(null)
@@ -314,6 +334,23 @@ function SocialContentDetailPage() {
       console.error('Failed to fetch topic backlog:', err)
     } finally {
       setLoadingTopicBacklog(false)
+    }
+  }, [])
+
+  const fetchPlatformConfigs = useCallback(async () => {
+    try {
+      const session = await getCurrentSession()
+      if (!session) return
+
+      const res = await fetch('/api/admin/social-content/config', {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      })
+      if (!res.ok) return
+
+      const data = await res.json()
+      setPlatformConfigs(Array.isArray(data.configs) ? data.configs : [])
+    } catch (err) {
+      console.error('Failed to fetch social platform config:', err)
     }
   }, [])
 
@@ -367,6 +404,10 @@ function SocialContentDetailPage() {
   useEffect(() => {
     fetchItem()
   }, [fetchItem])
+
+  useEffect(() => {
+    fetchPlatformConfigs()
+  }, [fetchPlatformConfigs])
 
   useEffect(() => {
     fetchTopicBacklog()
@@ -1388,6 +1429,28 @@ function SocialContentDetailPage() {
         : 'pending'
   const linkedinDraftGateState: GateState = getExplicitSectionGateState('linkedin_draft', linkedinDraftBaseGateState)
   const canCreateLinkedInDraft = isDraftOnlyPilot && linkedinDraftBlockers.length === 0 && linkedinDraftGateState === 'approved'
+  const platformSubmissionPlan = buildPlatformOrchestrationPlan({
+    item,
+    targetPlatforms: isDraftOnlyPilot ? ['linkedin'] : targetPlatforms,
+    publishRecords: item.publishes ?? [],
+    platformConfigs,
+    copyApproved: item.status === 'approved' || item.status === 'scheduled' || item.status === 'published',
+    productionReady: isDraftOnlyPilot
+      ? visualAssetsGateState === 'approved' && assetPacketGateState === 'approved' && privacyGateState === 'approved'
+      : !videoPrivacyBlocked,
+    redactionReady: !videoPrivacyBlocked,
+    draftHandoffReady: isDraftOnlyPilot ? Boolean(linkedinDraftHandoff) : Boolean(item.publishes?.length),
+  })
+  const platformNextStages = platformSubmissionPlan.platforms
+    .map((platformPlan) => platformPlan.stages.find((stage) => stage.state !== 'complete'))
+    .filter((stage): stage is NonNullable<typeof stage> => Boolean(stage))
+  const platformSubmissionGateState: GateState = platformSubmissionPlan.allAutomaticSubmissionComplete
+    ? 'approved'
+    : platformNextStages.some((stage) => stage.state === 'blocked')
+      ? 'blocked'
+      : platformNextStages.some((stage) => stage.state === 'available')
+        ? 'in_review'
+        : 'pending'
   const reviewGateSummary: Array<{ label: string; state: GateState; href: string }> = [
     {
       label: 'Copy',
@@ -1418,6 +1481,11 @@ function SocialContentDetailPage() {
       label: isDraftOnlyPilot ? 'LinkedIn draft' : 'Publish',
       state: isDraftOnlyPilot ? linkedinDraftGateState : gateStateFromRawStatus(agentPilotPublishGate),
       href: '#social-draft-approval-gate',
+    },
+    {
+      label: 'Platform submit',
+      state: platformSubmissionGateState,
+      href: '#social-platform-submission-gate',
     },
   ]
   const overallGateState: GateState = reviewGateSummary.some((gate) => gate.state === 'blocked' || gate.state === 'rejected')
@@ -3116,6 +3184,101 @@ function SocialContentDetailPage() {
               Scheduled for {new Date(item.scheduled_for).toLocaleString()}
             </div>
           )}
+        </div>
+
+        {/* ================================================================ */}
+        {/* SECTION 2A: Platform Submission Path                              */}
+        {/* ================================================================ */}
+        <div id="social-platform-submission-gate" className="scroll-mt-28 rounded-xl border-2 border-gray-700 bg-gray-900 p-6">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <h2 className="flex items-center gap-2 text-lg font-semibold text-gray-200">
+                <Send className="h-5 w-5 text-blue-300" />
+                Platform Submission Path
+              </h2>
+              <p className="mt-1 text-sm leading-6 text-gray-400">
+                Human approval moves the item through draft handoff, final submission gate, then automatic platform submission only where an integration is connected.
+              </p>
+            </div>
+            <span className={`inline-flex w-fit rounded-full border px-2.5 py-1 text-xs font-semibold ${GATE_STATE_CONFIG[platformSubmissionGateState].className}`}>
+              Platform submit: {GATE_STATE_CONFIG[platformSubmissionGateState].label}
+            </span>
+          </div>
+
+          <div className="mt-4 rounded-lg border border-emerald-500/25 bg-emerald-500/10 px-3 py-2 text-xs leading-5 text-emerald-50/90">
+            Until the final submission gate is approved, this path does not generate media, upload files, schedule externally, publish, or create public posts.
+          </div>
+
+          <div className="mt-4 grid gap-3 lg:grid-cols-2">
+            {platformSubmissionPlan.platforms.map((platformPlan) => {
+              const automaticStage = platformPlan.stages.find((stage) => stage.key === 'automatic_submission')
+              const canSubmitPlatform = automaticStage?.state === 'available'
+              return (
+                <div key={platformPlan.platform} className="rounded-lg border border-gray-800 bg-gray-950/45 p-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="flex items-center gap-2">
+                      <div className="flex h-9 w-9 items-center justify-center rounded-lg border border-gray-700 bg-gray-900 text-gray-300">
+                        {PLATFORM_ICONS[platformPlan.platform] ?? <Send className="h-4 w-4" />}
+                      </div>
+                      <div>
+                        <p className="text-sm font-semibold text-gray-100">{platformPlan.label}</p>
+                        <p className="text-xs text-gray-500">
+                          {platformPlan.automaticSubmissionSupported ? 'Automatic submit connected' : 'Automatic submit not connected'}
+                        </p>
+                      </div>
+                    </div>
+                    {platformPlan.publishStatus ? (
+                      <span className="rounded-full border border-silicon-slate/70 px-2 py-0.5 text-[0.68rem] font-semibold text-gray-300">
+                        {platformPlan.publishStatus}
+                      </span>
+                    ) : null}
+                  </div>
+
+                  <div className="mt-3 space-y-2">
+                    {platformPlan.stages.map((stage) => (
+                      <div key={stage.key} className={`rounded-md border px-3 py-2 ${platformStageClass(stage.state)}`}>
+                        <div className="flex items-center justify-between gap-3">
+                          <div className="flex min-w-0 items-center gap-2">
+                            <span className={`h-2 w-2 shrink-0 rounded-full ${platformStageDotClass(stage.state)}`} />
+                            <span className="truncate text-xs font-semibold">{stage.label}</span>
+                          </div>
+                          <span className="shrink-0 text-[0.62rem] uppercase tracking-[0.12em] opacity-75">
+                            {stage.state}
+                          </span>
+                        </div>
+                        <p className="mt-1 text-[0.68rem] leading-5 opacity-80">{stage.detail}</p>
+                      </div>
+                    ))}
+                  </div>
+
+                  <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <p className="text-xs leading-5 text-gray-400">{platformPlan.nextAction}</p>
+                    {canSubmitPlatform ? (
+                      <button
+                        type="button"
+                        onClick={() => handleRetryPublish([platformPlan.platform])}
+                        disabled={publishing}
+                        className="inline-flex min-h-9 shrink-0 items-center justify-center gap-2 rounded-lg border border-blue-500/40 bg-blue-500/10 px-3 py-2 text-xs font-semibold text-blue-100 transition-colors hover:bg-blue-500/20 disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        {publishing ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Send className="h-3.5 w-3.5" />}
+                        Submit to {platformPlan.label}
+                      </button>
+                    ) : platformPlan.platformPostUrl ? (
+                      <a
+                        href={platformPlan.platformPostUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex min-h-9 shrink-0 items-center justify-center gap-2 rounded-lg border border-emerald-500/35 bg-emerald-500/10 px-3 py-2 text-xs font-semibold text-emerald-100 transition-colors hover:bg-emerald-500/20"
+                      >
+                        View Post
+                        <ExternalLink className="h-3.5 w-3.5" />
+                      </a>
+                    ) : null}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
         </div>
 
         {/* ================================================================ */}

--- a/app/api/admin/social-content/[id]/publish/route.test.ts
+++ b/app/api/admin/social-content/[id]/publish/route.test.ts
@@ -9,6 +9,10 @@ const mocks = vi.hoisted(() => ({
   eq: vi.fn(),
   single: vi.fn(),
   publishToLinkedIn: vi.fn(),
+  publishToYouTube: vi.fn(),
+  publishToInstagram: vi.fn(),
+  publishToFacebook: vi.fn(),
+  publishToTikTok: vi.fn(),
 }))
 
 vi.mock('@/lib/auth-server', () => ({
@@ -24,6 +28,22 @@ vi.mock('@/lib/supabase', () => ({
 
 vi.mock('@/lib/publishing/linkedin', () => ({
   publishToLinkedIn: mocks.publishToLinkedIn,
+}))
+
+vi.mock('@/lib/publishing/youtube', () => ({
+  publishToYouTube: mocks.publishToYouTube,
+}))
+
+vi.mock('@/lib/publishing/instagram', () => ({
+  publishToInstagram: mocks.publishToInstagram,
+}))
+
+vi.mock('@/lib/publishing/facebook', () => ({
+  publishToFacebook: mocks.publishToFacebook,
+}))
+
+vi.mock('@/lib/publishing/tiktok', () => ({
+  publishToTikTok: mocks.publishToTikTok,
 }))
 
 import { POST } from './route'
@@ -88,5 +108,211 @@ describe('POST /api/admin/social-content/[id]/publish redaction gate', () => {
       unresolved_redaction_items: 1,
     })
     expect(mocks.publishToLinkedIn).not.toHaveBeenCalled()
+  })
+})
+
+function installPublishRouteSupabase({
+  item,
+  publishes,
+}: {
+  item: Record<string, unknown>
+  publishes: Array<Record<string, unknown>>
+}) {
+  const queueSingle = vi.fn().mockResolvedValue({ data: item, error: null })
+  const queueSelectEq = vi.fn(() => ({ single: queueSingle }))
+  const queueSelect = vi.fn(() => ({ eq: queueSelectEq }))
+  const queueUpdateEq = vi.fn().mockResolvedValue({ data: null, error: null })
+  const queueUpdate = vi.fn(() => ({ eq: queueUpdateEq }))
+
+  const publishSelectEq = vi.fn().mockResolvedValue({ data: publishes, error: null })
+  const publishSelect = vi.fn(() => ({ eq: publishSelectEq }))
+  const publishUpdateSecondEq = vi.fn().mockResolvedValue({ data: null, error: null })
+  const publishUpdateFirstEq = vi.fn(() => ({ eq: publishUpdateSecondEq }))
+  const publishUpdate = vi.fn(() => ({ eq: publishUpdateFirstEq }))
+
+  mocks.from.mockImplementation((table: string) => {
+    if (table === 'social_content_queue') return { select: queueSelect, update: queueUpdate }
+    if (table === 'social_content_publishes') return { select: publishSelect, update: publishUpdate }
+    return {}
+  })
+
+  return { queueUpdate }
+}
+
+describe('POST /api/admin/social-content/[id]/publish platform dispatch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-1' }, isAdmin: true })
+    mocks.isAuthError.mockReturnValue(false)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('dispatches Instagram and TikTok publish modules from approved content', async () => {
+    const { queueUpdate } = installPublishRouteSupabase({
+      item: {
+        id: 'social-1',
+        status: 'approved',
+        post_text: 'Post text',
+        cta_text: 'CTA',
+        cta_url: 'https://example.com',
+        hashtags: ['AI'],
+        image_url: 'https://cdn.example.com/image.png',
+        video_url: 'https://cdn.example.com/video.mp4',
+        carousel_slide_urls: null,
+        rag_context: null,
+      },
+      publishes: [
+        { platform: 'instagram', status: 'pending' },
+        { platform: 'tiktok', status: 'pending' },
+      ],
+    })
+    mocks.publishToInstagram.mockResolvedValue({
+      success: true,
+      status: 'published',
+      platformPostId: 'ig-post-1',
+    })
+    mocks.publishToTikTok.mockResolvedValue({
+      success: true,
+      status: 'publishing',
+      platformPostId: 'tt-publish-1',
+    })
+
+    const response = await POST(request({ platforms: ['instagram', 'tiktok'] }), { params: { id: 'social-1' } })
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.published).toBe(true)
+    expect(mocks.publishToInstagram).toHaveBeenCalledWith(expect.objectContaining({
+      contentId: 'social-1',
+      imageUrl: 'https://cdn.example.com/image.png',
+      videoUrl: 'https://cdn.example.com/video.mp4',
+    }))
+    expect(mocks.publishToTikTok).toHaveBeenCalledWith(expect.objectContaining({
+      contentId: 'social-1',
+      videoUrl: 'https://cdn.example.com/video.mp4',
+    }))
+    expect(queueUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'published',
+    }))
+  })
+
+  it('dispatches YouTube publishing with final video metadata', async () => {
+    const { queueUpdate } = installPublishRouteSupabase({
+      item: {
+        id: 'social-1',
+        status: 'approved',
+        post_text: 'Post text',
+        cta_text: 'CTA',
+        cta_url: 'https://example.com',
+        hashtags: ['AI'],
+        image_url: null,
+        video_url: 'https://cdn.example.com/video.mp4',
+        youtube_title: 'YouTube title',
+        youtube_description: 'YouTube description',
+        carousel_slide_urls: null,
+        rag_context: null,
+      },
+      publishes: [
+        { platform: 'youtube', status: 'pending' },
+      ],
+    })
+    mocks.publishToYouTube.mockResolvedValue({
+      success: true,
+      status: 'published',
+      platformPostId: 'youtube-video-1',
+      platformPostUrl: 'https://www.youtube.com/watch?v=youtube-video-1',
+    })
+
+    const response = await POST(request({ platforms: ['youtube'] }), { params: { id: 'social-1' } })
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.published).toBe(true)
+    expect(mocks.publishToYouTube).toHaveBeenCalledWith(expect.objectContaining({
+      contentId: 'social-1',
+      videoUrl: 'https://cdn.example.com/video.mp4',
+      youtubeTitle: 'YouTube title',
+      youtubeDescription: 'YouTube description',
+    }))
+    expect(queueUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'published',
+    }))
+  })
+
+  it('dispatches Facebook publishing from approved content', async () => {
+    const { queueUpdate } = installPublishRouteSupabase({
+      item: {
+        id: 'social-1',
+        status: 'approved',
+        post_text: 'Post text',
+        cta_text: 'CTA',
+        cta_url: 'https://example.com',
+        hashtags: ['AI'],
+        image_url: 'https://cdn.example.com/image.png',
+        video_url: null,
+        youtube_title: null,
+        youtube_description: null,
+        carousel_slide_urls: null,
+        rag_context: null,
+      },
+      publishes: [
+        { platform: 'facebook', status: 'pending' },
+      ],
+    })
+    mocks.publishToFacebook.mockResolvedValue({
+      success: true,
+      status: 'published',
+      platformPostId: 'facebook-post-1',
+      platformPostUrl: 'https://www.facebook.com/page/posts/facebook-post-1',
+    })
+
+    const response = await POST(request({ platforms: ['facebook'] }), { params: { id: 'social-1' } })
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.published).toBe(true)
+    expect(mocks.publishToFacebook).toHaveBeenCalledWith(expect.objectContaining({
+      contentId: 'social-1',
+      imageUrl: 'https://cdn.example.com/image.png',
+    }))
+    expect(queueUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'published',
+    }))
+  })
+
+  it('does not mark the queue published for TikTok async processing alone', async () => {
+    const { queueUpdate } = installPublishRouteSupabase({
+      item: {
+        id: 'social-1',
+        status: 'approved',
+        post_text: 'Post text',
+        cta_text: null,
+        cta_url: null,
+        hashtags: [],
+        image_url: null,
+        video_url: 'https://cdn.example.com/video.mp4',
+        carousel_slide_urls: null,
+        rag_context: null,
+      },
+      publishes: [
+        { platform: 'tiktok', status: 'pending' },
+      ],
+    })
+    mocks.publishToTikTok.mockResolvedValue({
+      success: true,
+      status: 'publishing',
+      platformPostId: 'tt-publish-1',
+    })
+
+    const response = await POST(request({ platforms: ['tiktok'] }), { params: { id: 'social-1' } })
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.published).toBe(false)
+    expect(queueUpdate).not.toHaveBeenCalled()
   })
 })

--- a/app/api/admin/social-content/[id]/publish/route.ts
+++ b/app/api/admin/social-content/[id]/publish/route.ts
@@ -2,6 +2,10 @@ import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
 import { publishToLinkedIn } from '@/lib/publishing/linkedin'
+import { publishToYouTube } from '@/lib/publishing/youtube'
+import { publishToInstagram } from '@/lib/publishing/instagram'
+import { publishToFacebook } from '@/lib/publishing/facebook'
+import { publishToTikTok } from '@/lib/publishing/tiktok'
 import type { SocialPlatform } from '@/lib/social-content'
 import { getProductionAssets, getVideoRedactionGate } from '@/lib/social-production-assets'
 
@@ -117,6 +121,10 @@ export async function POST(
           ctaUrl: item.cta_url,
           hashtags: item.hashtags,
           imageUrl: item.image_url,
+          videoUrl: item.video_url,
+          carouselSlideUrls: item.carousel_slide_urls,
+          youtubeTitle: item.youtube_title,
+          youtubeDescription: item.youtube_description,
         }
 
         switch (platform) {
@@ -124,8 +132,18 @@ export async function POST(
             return { platform, result: await publishToLinkedIn(payload) }
 
           case 'youtube':
+            return { platform, result: await publishToYouTube(payload) }
+
           case 'instagram':
+            return { platform, result: await publishToInstagram(payload) }
+
           case 'facebook':
+            return { platform, result: await publishToFacebook(payload) }
+
+          case 'tiktok':
+            return { platform, result: await publishToTikTok(payload) }
+
+          default:
             // Mark as skipped until these modules are implemented
             await admin
               .from('social_content_publishes')
@@ -136,9 +154,6 @@ export async function POST(
               platform,
               result: { success: false, error: `${platform} publishing not yet implemented` },
             }
-
-          default:
-            return { platform, result: { success: false, error: `Unknown platform: ${platform}` } }
         }
       })
     )
@@ -149,9 +164,11 @@ export async function POST(
       return { platform: 'unknown', result: { success: false, error: r.reason?.message || 'Unknown error' } }
     })
 
-    const anySuccess = platformResults.some((r) => r.result.success)
+    const anyPublished = platformResults.some((r) => (
+      r.result.success && r.result.status !== 'publishing'
+    ))
 
-    if (anySuccess) {
+    if (anyPublished) {
       await admin
         .from('social_content_queue')
         .update({
@@ -168,7 +185,7 @@ export async function POST(
       .eq('content_id', id)
 
     return NextResponse.json({
-      published: anySuccess,
+      published: anyPublished,
       results: platformResults,
       publishes: updatedPublishes,
     })

--- a/lib/publishing/facebook.test.ts
+++ b/lib/publishing/facebook.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  from: vi.fn(),
+  fetch: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import { publishToFacebook } from './facebook'
+
+function installSupabase(configData: Record<string, unknown>) {
+  const single = vi.fn().mockResolvedValue({ data: configData, error: null })
+  const selectEq = vi.fn(() => ({ single }))
+  const select = vi.fn(() => ({ eq: selectEq }))
+  const secondEq = vi.fn().mockResolvedValue({ data: null, error: null })
+  const firstEq = vi.fn(() => ({ eq: secondEq }))
+  const update = vi.fn(() => ({ eq: firstEq }))
+
+  mocks.from.mockImplementation((table: string) => (
+    table === 'social_content_config'
+      ? { select }
+      : { update }
+  ))
+
+  return { update }
+}
+
+describe('publishToFacebook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    global.fetch = mocks.fetch
+  })
+
+  it('publishes a Facebook Page feed post when no media exists', async () => {
+    installSupabase({
+      is_active: true,
+      credentials: {
+        page_access_token: 'page-token',
+        page_id: 'page-1',
+      },
+      settings: {
+        graph_api_version: 'v20.0',
+      },
+    })
+
+    mocks.fetch.mockResolvedValueOnce(new Response(JSON.stringify({
+      id: 'page-1_post-1',
+    }), { status: 200 }))
+
+    const result = await publishToFacebook({
+      contentId: 'content-1',
+      postText: 'Post text',
+      ctaUrl: 'https://example.com',
+      hashtags: ['AI'],
+    })
+
+    expect(result).toMatchObject({
+      success: true,
+      status: 'published',
+      platformPostId: 'page-1_post-1',
+      platformPostUrl: 'https://www.facebook.com/page-1/posts/page-1_post-1',
+    })
+    expect(mocks.fetch).toHaveBeenCalledWith(
+      'https://graph.facebook.com/v20.0/page-1/feed',
+      expect.objectContaining({
+        method: 'POST',
+      }),
+    )
+  })
+
+  it('fails closed when Page credentials are missing', async () => {
+    const { update } = installSupabase({
+      is_active: true,
+      credentials: {
+        page_access_token: 'page-token',
+      },
+      settings: {},
+    })
+
+    const result = await publishToFacebook({
+      contentId: 'content-1',
+      postText: 'Post text',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('Page access token or Page ID')
+    expect(mocks.fetch).not.toHaveBeenCalled()
+    expect(update).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'failed',
+      error_message: expect.stringContaining('Page access token or Page ID'),
+    }))
+  })
+})

--- a/lib/publishing/facebook.ts
+++ b/lib/publishing/facebook.ts
@@ -1,0 +1,201 @@
+/**
+ * Facebook Publishing Module
+ *
+ * Publishes to a configured Facebook Page after the human submission gate.
+ * Supports text-only Page feed posts, image posts, and video URL uploads.
+ */
+
+import { supabaseAdmin } from '@/lib/supabase'
+import type { PublishStatus, SocialPlatform } from '@/lib/social-content'
+
+export interface FacebookPublishPayload {
+  contentId: string
+  postText: string
+  ctaText?: string | null
+  ctaUrl?: string | null
+  hashtags?: string[] | null
+  imageUrl?: string | null
+  videoUrl?: string | null
+}
+
+export interface FacebookPublishResult {
+  success: boolean
+  platformPostId?: string
+  platformPostUrl?: string
+  status?: PublishStatus
+  error?: string
+}
+
+interface FacebookCredentials {
+  access_token?: string
+  page_access_token?: string
+  page_id?: string
+}
+
+interface FacebookSettings {
+  graph_api_version?: string
+  default_published?: boolean
+}
+
+async function getFacebookConfig(): Promise<{
+  credentials: FacebookCredentials
+  settings: FacebookSettings
+} | null> {
+  const admin = supabaseAdmin
+  if (!admin) return null
+
+  const { data } = await admin
+    .from('social_content_config')
+    .select('credentials, settings, is_active')
+    .eq('platform', 'facebook')
+    .single()
+
+  if (!data || !data.is_active) return null
+
+  return {
+    credentials: data.credentials as FacebookCredentials,
+    settings: data.settings as FacebookSettings,
+  }
+}
+
+async function updatePublishStatus(
+  contentId: string,
+  platform: SocialPlatform,
+  status: PublishStatus,
+  extra?: { platform_post_id?: string; platform_post_url?: string; error_message?: string }
+) {
+  const admin = supabaseAdmin
+  if (!admin) return
+
+  await admin
+    .from('social_content_publishes')
+    .update({
+      status,
+      ...(status === 'published' ? { published_at: new Date().toISOString() } : {}),
+      ...extra,
+    })
+    .eq('content_id', contentId)
+    .eq('platform', platform)
+}
+
+function buildMessage(payload: FacebookPublishPayload) {
+  const parts = [payload.postText]
+  if (payload.ctaText) parts.push(payload.ctaText)
+  if (payload.ctaUrl) parts.push(payload.ctaUrl)
+  if (payload.hashtags?.length) {
+    parts.push(payload.hashtags.map((tag) => tag.startsWith('#') ? tag : `#${tag}`).join(' '))
+  }
+  return parts.filter(Boolean).join('\n\n')
+}
+
+function graphUrl(apiVersion: string, path: string) {
+  return `https://graph.facebook.com/${apiVersion}/${path}`
+}
+
+function parseJson(text: string): Record<string, unknown> {
+  if (!text) return {}
+  try {
+    return JSON.parse(text) as Record<string, unknown>
+  } catch {
+    return {}
+  }
+}
+
+async function postGraph(apiVersion: string, path: string, params: Record<string, string | boolean>) {
+  const body = new URLSearchParams()
+  Object.entries(params).forEach(([key, value]) => body.set(key, String(value)))
+
+  const response = await fetch(graphUrl(apiVersion, path), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  })
+  const data = parseJson(await response.text())
+
+  if (!response.ok) {
+    const message = typeof data.error === 'object' && data.error && 'message' in data.error
+      ? String((data.error as { message?: unknown }).message)
+      : `Facebook API error (${response.status})`
+    throw new Error(message)
+  }
+
+  return data
+}
+
+function platformPostUrl(pageId: string, postId: string) {
+  return `https://www.facebook.com/${pageId}/posts/${postId}`
+}
+
+export async function publishToFacebook(payload: FacebookPublishPayload): Promise<FacebookPublishResult> {
+  const config = await getFacebookConfig()
+  if (!config) {
+    const error = 'Facebook is not connected or inactive'
+    await updatePublishStatus(payload.contentId, 'facebook', 'failed', { error_message: error })
+    return { success: false, error }
+  }
+
+  const accessToken = config.credentials.page_access_token || config.credentials.access_token
+  const pageId = config.credentials.page_id
+  const apiVersion = config.settings.graph_api_version || 'v20.0'
+
+  if (!accessToken || !pageId) {
+    const error = 'Facebook credentials incomplete — missing Page access token or Page ID'
+    await updatePublishStatus(payload.contentId, 'facebook', 'failed', { error_message: error })
+    return { success: false, error }
+  }
+
+  await updatePublishStatus(payload.contentId, 'facebook', 'publishing')
+
+  try {
+    const message = buildMessage(payload)
+    let data: Record<string, unknown>
+
+    if (payload.videoUrl) {
+      data = await postGraph(apiVersion, `${pageId}/videos`, {
+        file_url: payload.videoUrl,
+        description: message,
+        published: config.settings.default_published ?? true,
+        access_token: accessToken,
+      })
+    } else if (payload.imageUrl) {
+      data = await postGraph(apiVersion, `${pageId}/photos`, {
+        url: payload.imageUrl,
+        caption: message,
+        published: config.settings.default_published ?? true,
+        access_token: accessToken,
+      })
+    } else {
+      data = await postGraph(apiVersion, `${pageId}/feed`, {
+        message,
+        published: config.settings.default_published ?? true,
+        access_token: accessToken,
+      })
+    }
+
+    const platformPostId = typeof data.post_id === 'string'
+      ? data.post_id
+      : typeof data.id === 'string'
+        ? data.id
+        : null
+
+    if (!platformPostId) throw new Error('Facebook publish response missing post ID')
+
+    const url = platformPostUrl(pageId, platformPostId)
+    await updatePublishStatus(payload.contentId, 'facebook', 'published', {
+      platform_post_id: platformPostId,
+      platform_post_url: url,
+    })
+
+    return {
+      success: true,
+      status: 'published',
+      platformPostId,
+      platformPostUrl: url,
+    }
+  } catch (err) {
+    const error = err instanceof Error ? err.message : 'Unknown error during Facebook publish'
+    console.error('[Facebook] Publish error:', err)
+    await updatePublishStatus(payload.contentId, 'facebook', 'failed', { error_message: error })
+    return { success: false, error }
+  }
+}

--- a/lib/publishing/instagram.test.ts
+++ b/lib/publishing/instagram.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  from: vi.fn(),
+  fetch: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import { publishToInstagram } from './instagram'
+
+function installSupabase(configData: Record<string, unknown>) {
+  const single = vi.fn().mockResolvedValue({ data: configData, error: null })
+  const selectEq = vi.fn(() => ({ single }))
+  const select = vi.fn(() => ({ eq: selectEq }))
+  const secondEq = vi.fn().mockResolvedValue({ data: null, error: null })
+  const firstEq = vi.fn(() => ({ eq: secondEq }))
+  const update = vi.fn(() => ({ eq: firstEq }))
+
+  mocks.from.mockImplementation((table: string) => (
+    table === 'social_content_config'
+      ? { select }
+      : { update }
+  ))
+
+  return { update }
+}
+
+describe('publishToInstagram', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    global.fetch = mocks.fetch
+  })
+
+  it('publishes an image post through the configured Instagram Graph account', async () => {
+    installSupabase({
+      is_active: true,
+      credentials: {
+        access_token: 'token',
+        ig_user_id: 'ig-1',
+      },
+      settings: {
+        graph_api_version: 'v20.0',
+      },
+    })
+
+    mocks.fetch
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: 'creation-1' }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: 'media-1' }), { status: 200 }))
+
+    const result = await publishToInstagram({
+      contentId: 'content-1',
+      postText: 'Post text',
+      hashtags: ['AI'],
+      imageUrl: 'https://cdn.example.com/image.png',
+    })
+
+    expect(result).toMatchObject({
+      success: true,
+      status: 'published',
+      platformPostId: 'media-1',
+    })
+    expect(mocks.fetch).toHaveBeenCalledTimes(2)
+    expect(mocks.fetch.mock.calls[0][0]).toBe('https://graph.facebook.com/v20.0/ig-1/media')
+    expect(mocks.fetch.mock.calls[1][0]).toBe('https://graph.facebook.com/v20.0/ig-1/media_publish')
+  })
+
+  it('fails closed when no media is ready for Instagram', async () => {
+    const { update } = installSupabase({
+      is_active: true,
+      credentials: {
+        access_token: 'token',
+        ig_user_id: 'ig-1',
+      },
+      settings: {},
+    })
+
+    const result = await publishToInstagram({
+      contentId: 'content-1',
+      postText: 'Text-only post',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('requires an image')
+    expect(mocks.fetch).not.toHaveBeenCalled()
+    expect(update).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'failed',
+      error_message: expect.stringContaining('requires an image'),
+    }))
+  })
+})

--- a/lib/publishing/instagram.ts
+++ b/lib/publishing/instagram.ts
@@ -1,0 +1,311 @@
+/**
+ * Instagram Publishing Module
+ *
+ * Uses the Instagram Graph API Content Publishing flow. The module is gated by
+ * social_content_config and only submits when a public media URL is present.
+ */
+
+import { supabaseAdmin } from '@/lib/supabase'
+import type { PublishStatus, SocialPlatform } from '@/lib/social-content'
+
+export interface InstagramPublishPayload {
+  contentId: string
+  postText: string
+  ctaText?: string | null
+  ctaUrl?: string | null
+  hashtags?: string[] | null
+  imageUrl?: string | null
+  videoUrl?: string | null
+  carouselSlideUrls?: string[] | null
+}
+
+export interface InstagramPublishResult {
+  success: boolean
+  platformPostId?: string
+  platformPostUrl?: string
+  status?: PublishStatus
+  error?: string
+}
+
+interface InstagramCredentials {
+  access_token?: string
+  ig_user_id?: string
+  instagram_user_id?: string
+  business_account_id?: string
+}
+
+interface InstagramSettings {
+  graph_api_version?: string
+  share_reels_to_feed?: boolean
+  max_video_publish_poll_attempts?: number
+  video_publish_poll_delay_ms?: number
+}
+
+async function getInstagramConfig(): Promise<{
+  credentials: InstagramCredentials
+  settings: InstagramSettings
+} | null> {
+  const admin = supabaseAdmin
+  if (!admin) return null
+
+  const { data } = await admin
+    .from('social_content_config')
+    .select('credentials, settings, is_active')
+    .eq('platform', 'instagram')
+    .single()
+
+  if (!data || !data.is_active) return null
+
+  return {
+    credentials: data.credentials as InstagramCredentials,
+    settings: data.settings as InstagramSettings,
+  }
+}
+
+async function updatePublishStatus(
+  contentId: string,
+  platform: SocialPlatform,
+  status: PublishStatus,
+  extra?: { platform_post_id?: string; platform_post_url?: string; error_message?: string }
+) {
+  const admin = supabaseAdmin
+  if (!admin) return
+
+  await admin
+    .from('social_content_publishes')
+    .update({
+      status,
+      ...(status === 'published' ? { published_at: new Date().toISOString() } : {}),
+      ...extra,
+    })
+    .eq('content_id', contentId)
+    .eq('platform', platform)
+}
+
+function buildCaption(payload: InstagramPublishPayload) {
+  const parts = [payload.postText]
+  if (payload.ctaText) parts.push(payload.ctaText)
+  if (payload.ctaUrl) parts.push(payload.ctaUrl)
+  if (payload.hashtags?.length) {
+    parts.push(payload.hashtags.map((tag) => tag.startsWith('#') ? tag : `#${tag}`).join(' '))
+  }
+  return parts.filter(Boolean).join('\n\n')
+}
+
+function graphUrl(apiVersion: string, path: string) {
+  return `https://graph.facebook.com/${apiVersion}/${path}`
+}
+
+async function postGraph(apiVersion: string, path: string, params: Record<string, string | boolean>) {
+  const body = new URLSearchParams()
+  Object.entries(params).forEach(([key, value]) => body.set(key, String(value)))
+
+  const response = await fetch(graphUrl(apiVersion, path), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  })
+
+  const text = await response.text()
+  const data = parseJson(text)
+
+  if (!response.ok) {
+    const message = typeof data.error === 'object' && data.error && 'message' in data.error
+      ? String((data.error as { message?: unknown }).message)
+      : `Instagram API error (${response.status})`
+    throw new Error(message)
+  }
+
+  return data
+}
+
+async function getGraph(apiVersion: string, path: string, params: Record<string, string>) {
+  const searchParams = new URLSearchParams(params)
+  const response = await fetch(`${graphUrl(apiVersion, path)}?${searchParams.toString()}`)
+  const text = await response.text()
+  const data = parseJson(text)
+
+  if (!response.ok) {
+    const message = typeof data.error === 'object' && data.error && 'message' in data.error
+      ? String((data.error as { message?: unknown }).message)
+      : `Instagram API error (${response.status})`
+    throw new Error(message)
+  }
+
+  return data
+}
+
+function parseJson(text: string): Record<string, unknown> {
+  if (!text) return {}
+  try {
+    return JSON.parse(text) as Record<string, unknown>
+  } catch {
+    return {}
+  }
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function createImageContainer(
+  apiVersion: string,
+  igUserId: string,
+  accessToken: string,
+  imageUrl: string,
+  caption: string,
+  isCarouselItem = false,
+) {
+  const data = await postGraph(apiVersion, `${igUserId}/media`, {
+    image_url: imageUrl,
+    caption,
+    access_token: accessToken,
+    ...(isCarouselItem ? { is_carousel_item: true } : {}),
+  })
+  return typeof data.id === 'string' ? data.id : null
+}
+
+async function createReelContainer(
+  apiVersion: string,
+  igUserId: string,
+  accessToken: string,
+  videoUrl: string,
+  caption: string,
+  shareToFeed: boolean,
+) {
+  const data = await postGraph(apiVersion, `${igUserId}/media`, {
+    media_type: 'REELS',
+    video_url: videoUrl,
+    caption,
+    share_to_feed: shareToFeed,
+    access_token: accessToken,
+  })
+  return typeof data.id === 'string' ? data.id : null
+}
+
+async function createCarouselContainer(
+  apiVersion: string,
+  igUserId: string,
+  accessToken: string,
+  childContainerIds: string[],
+  caption: string,
+) {
+  const data = await postGraph(apiVersion, `${igUserId}/media`, {
+    media_type: 'CAROUSEL',
+    children: childContainerIds.join(','),
+    caption,
+    access_token: accessToken,
+  })
+  return typeof data.id === 'string' ? data.id : null
+}
+
+async function publishContainer(apiVersion: string, igUserId: string, accessToken: string, creationId: string) {
+  const data = await postGraph(apiVersion, `${igUserId}/media_publish`, {
+    creation_id: creationId,
+    access_token: accessToken,
+  })
+  return typeof data.id === 'string' ? data.id : null
+}
+
+async function waitForVideoContainer(
+  apiVersion: string,
+  accessToken: string,
+  creationId: string,
+  settings: InstagramSettings,
+) {
+  const attempts = settings.max_video_publish_poll_attempts ?? 5
+  const delayMs = settings.video_publish_poll_delay_ms ?? 2000
+
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const data = await getGraph(apiVersion, creationId, {
+      fields: 'status_code',
+      access_token: accessToken,
+    })
+    const statusCode = typeof data.status_code === 'string' ? data.status_code : null
+    if (statusCode === 'FINISHED' || statusCode === 'PUBLISHED') return
+    if (statusCode === 'ERROR' || statusCode === 'EXPIRED') {
+      throw new Error(`Instagram Reel container ${statusCode.toLowerCase()}`)
+    }
+    if (attempt < attempts - 1) await sleep(delayMs)
+  }
+
+  throw new Error('Instagram Reel container was not ready for publish')
+}
+
+export async function publishToInstagram(payload: InstagramPublishPayload): Promise<InstagramPublishResult> {
+  const config = await getInstagramConfig()
+  if (!config) {
+    const error = 'Instagram is not connected or inactive'
+    await updatePublishStatus(payload.contentId, 'instagram', 'failed', { error_message: error })
+    return { success: false, error }
+  }
+
+  const accessToken = config.credentials.access_token
+  const igUserId = config.credentials.ig_user_id
+    || config.credentials.instagram_user_id
+    || config.credentials.business_account_id
+  const apiVersion = config.settings.graph_api_version || 'v20.0'
+
+  if (!accessToken || !igUserId) {
+    const error = 'Instagram credentials incomplete — missing access token or Instagram business user ID'
+    await updatePublishStatus(payload.contentId, 'instagram', 'failed', { error_message: error })
+    return { success: false, error }
+  }
+
+  const carouselUrls = payload.carouselSlideUrls?.filter(Boolean) ?? []
+  const hasCarousel = carouselUrls.length > 1
+  const hasMedia = hasCarousel || Boolean(payload.imageUrl || payload.videoUrl)
+  if (!hasMedia) {
+    const error = 'Instagram publishing requires an image, carousel images, or a Reel video URL'
+    await updatePublishStatus(payload.contentId, 'instagram', 'failed', { error_message: error })
+    return { success: false, error }
+  }
+
+  await updatePublishStatus(payload.contentId, 'instagram', 'publishing')
+
+  try {
+    const caption = buildCaption(payload)
+    let creationId: string | null = null
+
+    if (payload.videoUrl) {
+      creationId = await createReelContainer(
+        apiVersion,
+        igUserId,
+        accessToken,
+        payload.videoUrl,
+        caption,
+        config.settings.share_reels_to_feed ?? true,
+      )
+      if (creationId) {
+        await waitForVideoContainer(apiVersion, accessToken, creationId, config.settings)
+      }
+    } else if (hasCarousel) {
+      const childContainerIds = await Promise.all(
+        carouselUrls.map((url) => createImageContainer(apiVersion, igUserId, accessToken, url, caption, true))
+      )
+      const validChildren = childContainerIds.filter((id): id is string => Boolean(id))
+      if (validChildren.length !== carouselUrls.length) {
+        throw new Error('Instagram carousel media container creation failed')
+      }
+      creationId = await createCarouselContainer(apiVersion, igUserId, accessToken, validChildren, caption)
+    } else if (payload.imageUrl) {
+      creationId = await createImageContainer(apiVersion, igUserId, accessToken, payload.imageUrl, caption)
+    }
+
+    if (!creationId) throw new Error('Instagram media container creation failed')
+
+    const platformPostId = await publishContainer(apiVersion, igUserId, accessToken, creationId)
+    if (!platformPostId) throw new Error('Instagram media publish failed')
+
+    await updatePublishStatus(payload.contentId, 'instagram', 'published', {
+      platform_post_id: platformPostId,
+    })
+
+    return { success: true, status: 'published', platformPostId }
+  } catch (err) {
+    const error = err instanceof Error ? err.message : 'Unknown error during Instagram publish'
+    console.error('[Instagram] Publish error:', err)
+    await updatePublishStatus(payload.contentId, 'instagram', 'failed', { error_message: error })
+    return { success: false, error }
+  }
+}

--- a/lib/publishing/tiktok.test.ts
+++ b/lib/publishing/tiktok.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  from: vi.fn(),
+  fetch: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import { publishToTikTok } from './tiktok'
+
+function installSupabase(configData: Record<string, unknown>) {
+  const single = vi.fn().mockResolvedValue({ data: configData, error: null })
+  const selectEq = vi.fn(() => ({ single }))
+  const select = vi.fn(() => ({ eq: selectEq }))
+  const secondEq = vi.fn().mockResolvedValue({ data: null, error: null })
+  const firstEq = vi.fn(() => ({ eq: secondEq }))
+  const update = vi.fn(() => ({ eq: firstEq }))
+
+  mocks.from.mockImplementation((table: string) => (
+    table === 'social_content_config'
+      ? { select }
+      : { update }
+  ))
+
+  return { update }
+}
+
+describe('publishToTikTok', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    global.fetch = mocks.fetch
+  })
+
+  it('submits a Direct Post request when creator and media URL gates are configured', async () => {
+    installSupabase({
+      is_active: true,
+      credentials: {
+        access_token: 'token',
+      },
+      settings: {
+        creator_info_confirmed: true,
+        source_url_approved: true,
+        privacy_level: 'SELF_ONLY',
+      },
+    })
+
+    mocks.fetch.mockResolvedValueOnce(new Response(JSON.stringify({
+      data: { publish_id: 'publish-1' },
+    }), { status: 200 }))
+
+    const result = await publishToTikTok({
+      contentId: 'content-1',
+      postText: 'Post text',
+      hashtags: ['AI'],
+      videoUrl: 'https://cdn.example.com/video.mp4',
+    })
+
+    expect(result).toMatchObject({
+      success: true,
+      status: 'publishing',
+      platformPostId: 'publish-1',
+    })
+    expect(mocks.fetch).toHaveBeenCalledWith(
+      'https://open.tiktokapis.com/v2/post/publish/video/init/',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ Authorization: 'Bearer token' }),
+      }),
+    )
+  })
+
+  it('fails closed until creator-info review is confirmed', async () => {
+    const { update } = installSupabase({
+      is_active: true,
+      credentials: {
+        access_token: 'token',
+      },
+      settings: {
+        source_url_approved: true,
+      },
+    })
+
+    const result = await publishToTikTok({
+      contentId: 'content-1',
+      postText: 'Post text',
+      videoUrl: 'https://cdn.example.com/video.mp4',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('creator info')
+    expect(mocks.fetch).not.toHaveBeenCalled()
+    expect(update).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'failed',
+      error_message: expect.stringContaining('creator info'),
+    }))
+  })
+})

--- a/lib/publishing/tiktok.ts
+++ b/lib/publishing/tiktok.ts
@@ -1,0 +1,213 @@
+/**
+ * TikTok Publishing Module
+ *
+ * Uses TikTok Content Posting API Direct Post with PULL_FROM_URL. The module
+ * requires explicit creator-info confirmation and approved media URL settings
+ * before it will submit anything to TikTok.
+ */
+
+import { supabaseAdmin } from '@/lib/supabase'
+import type { PublishStatus, SocialPlatform } from '@/lib/social-content'
+
+export interface TikTokPublishPayload {
+  contentId: string
+  postText: string
+  ctaText?: string | null
+  ctaUrl?: string | null
+  hashtags?: string[] | null
+  videoUrl?: string | null
+}
+
+export interface TikTokPublishResult {
+  success: boolean
+  platformPostId?: string
+  platformPostUrl?: string
+  status?: PublishStatus
+  error?: string
+}
+
+interface TikTokCredentials {
+  access_token?: string
+}
+
+interface TikTokSettings {
+  privacy_level?: string
+  creator_info_confirmed?: boolean
+  creator_info_confirmed_at?: string
+  source_url_approved?: boolean
+  approved_media_domains?: string[]
+  disable_duet?: boolean
+  disable_comment?: boolean
+  disable_stitch?: boolean
+  brand_content_toggle?: boolean
+  brand_organic_toggle?: boolean
+  is_aigc?: boolean
+}
+
+async function getTikTokConfig(): Promise<{
+  credentials: TikTokCredentials
+  settings: TikTokSettings
+} | null> {
+  const admin = supabaseAdmin
+  if (!admin) return null
+
+  const { data } = await admin
+    .from('social_content_config')
+    .select('credentials, settings, is_active')
+    .eq('platform', 'tiktok')
+    .single()
+
+  if (!data || !data.is_active) return null
+
+  return {
+    credentials: data.credentials as TikTokCredentials,
+    settings: data.settings as TikTokSettings,
+  }
+}
+
+async function updatePublishStatus(
+  contentId: string,
+  platform: SocialPlatform,
+  status: PublishStatus,
+  extra?: { platform_post_id?: string; platform_post_url?: string; error_message?: string }
+) {
+  const admin = supabaseAdmin
+  if (!admin) return
+
+  await admin
+    .from('social_content_publishes')
+    .update({
+      status,
+      ...(status === 'published' ? { published_at: new Date().toISOString() } : {}),
+      ...extra,
+    })
+    .eq('content_id', contentId)
+    .eq('platform', platform)
+}
+
+function buildTitle(payload: TikTokPublishPayload) {
+  const text = [payload.postText, payload.ctaText, payload.ctaUrl]
+    .filter(Boolean)
+    .join('\n\n')
+  const tags = payload.hashtags?.length
+    ? `\n\n${payload.hashtags.map((tag) => tag.startsWith('#') ? tag : `#${tag}`).join(' ')}`
+    : ''
+  return `${text}${tags}`.trim().slice(0, 2200)
+}
+
+function mediaUrlApproved(videoUrl: string, settings: TikTokSettings) {
+  if (settings.source_url_approved) return true
+  if (!settings.approved_media_domains?.length) return false
+
+  try {
+    const hostname = new URL(videoUrl).hostname.toLowerCase()
+    return settings.approved_media_domains.some((domain) => (
+      hostname === domain.toLowerCase() || hostname.endsWith(`.${domain.toLowerCase()}`)
+    ))
+  } catch {
+    return false
+  }
+}
+
+function parseTikTokResponse(text: string): {
+  data?: { publish_id?: string }
+  error?: { message?: string }
+} {
+  if (!text) return {}
+  try {
+    return JSON.parse(text) as {
+      data?: { publish_id?: string }
+      error?: { message?: string }
+    }
+  } catch {
+    return {}
+  }
+}
+
+export async function publishToTikTok(payload: TikTokPublishPayload): Promise<TikTokPublishResult> {
+  const config = await getTikTokConfig()
+  if (!config) {
+    const error = 'TikTok is not connected or inactive'
+    await updatePublishStatus(payload.contentId, 'tiktok', 'failed', { error_message: error })
+    return { success: false, error }
+  }
+
+  const accessToken = config.credentials.access_token
+  if (!accessToken) {
+    const error = 'TikTok credentials incomplete — missing access token'
+    await updatePublishStatus(payload.contentId, 'tiktok', 'failed', { error_message: error })
+    return { success: false, error }
+  }
+
+  if (!payload.videoUrl) {
+    const error = 'TikTok publishing requires a final video URL'
+    await updatePublishStatus(payload.contentId, 'tiktok', 'failed', { error_message: error })
+    return { success: false, error }
+  }
+
+  if (!config.settings.creator_info_confirmed && !config.settings.creator_info_confirmed_at) {
+    const error = 'TikTok creator info must be reviewed before Direct Post submission'
+    await updatePublishStatus(payload.contentId, 'tiktok', 'failed', { error_message: error })
+    return { success: false, error }
+  }
+
+  if (!mediaUrlApproved(payload.videoUrl, config.settings)) {
+    const error = 'TikTok media URL domain is not approved for Direct Post URL ingestion'
+    await updatePublishStatus(payload.contentId, 'tiktok', 'failed', { error_message: error })
+    return { success: false, error }
+  }
+
+  await updatePublishStatus(payload.contentId, 'tiktok', 'publishing')
+
+  try {
+    const response = await fetch('https://open.tiktokapis.com/v2/post/publish/video/init/', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json; charset=UTF-8',
+      },
+      body: JSON.stringify({
+        post_info: {
+          title: buildTitle(payload),
+          privacy_level: config.settings.privacy_level || 'SELF_ONLY',
+          disable_duet: config.settings.disable_duet ?? false,
+          disable_comment: config.settings.disable_comment ?? false,
+          disable_stitch: config.settings.disable_stitch ?? false,
+          brand_content_toggle: config.settings.brand_content_toggle ?? false,
+          brand_organic_toggle: config.settings.brand_organic_toggle ?? false,
+          is_aigc: config.settings.is_aigc ?? true,
+        },
+        source_info: {
+          source: 'PULL_FROM_URL',
+          video_url: payload.videoUrl,
+        },
+      }),
+    })
+
+    const body = parseTikTokResponse(await response.text())
+
+    if (!response.ok) {
+      const error = body.error?.message || `TikTok API error (${response.status})`
+      await updatePublishStatus(payload.contentId, 'tiktok', 'failed', { error_message: error })
+      return { success: false, error }
+    }
+
+    const platformPostId = body.data?.publish_id
+    if (!platformPostId) {
+      const error = 'TikTok publish response missing publish_id'
+      await updatePublishStatus(payload.contentId, 'tiktok', 'failed', { error_message: error })
+      return { success: false, error }
+    }
+
+    await updatePublishStatus(payload.contentId, 'tiktok', 'publishing', {
+      platform_post_id: platformPostId,
+    })
+
+    return { success: true, status: 'publishing', platformPostId }
+  } catch (err) {
+    const error = err instanceof Error ? err.message : 'Unknown error during TikTok publish'
+    console.error('[TikTok] Publish error:', err)
+    await updatePublishStatus(payload.contentId, 'tiktok', 'failed', { error_message: error })
+    return { success: false, error }
+  }
+}

--- a/lib/publishing/youtube.test.ts
+++ b/lib/publishing/youtube.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  from: vi.fn(),
+  fetch: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import { publishToYouTube } from './youtube'
+
+function installSupabase(configData: Record<string, unknown>) {
+  const single = vi.fn().mockResolvedValue({ data: configData, error: null })
+  const selectEq = vi.fn(() => ({ single }))
+  const select = vi.fn(() => ({ eq: selectEq }))
+  const secondEq = vi.fn().mockResolvedValue({ data: null, error: null })
+  const firstEq = vi.fn(() => ({ eq: secondEq }))
+  const update = vi.fn(() => ({ eq: firstEq }))
+
+  mocks.from.mockImplementation((table: string) => (
+    table === 'social_content_config'
+      ? { select, update }
+      : { update }
+  ))
+
+  return { update }
+}
+
+describe('publishToYouTube', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    global.fetch = mocks.fetch
+  })
+
+  it('uploads a final video asset to YouTube with private default privacy', async () => {
+    installSupabase({
+      is_active: true,
+      credentials: {
+        access_token: 'token',
+      },
+      settings: {
+        default_privacy: 'private',
+        max_download_bytes: 1024,
+      },
+    })
+
+    mocks.fetch
+      .mockResolvedValueOnce(new Response(new Uint8Array([1, 2, 3]), {
+        status: 200,
+        headers: { 'content-type': 'video/mp4', 'content-length': '3' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: 'youtube-video-1' }), { status: 200 }))
+
+    const result = await publishToYouTube({
+      contentId: 'content-1',
+      postText: 'Post text',
+      youtubeTitle: 'Video title',
+      youtubeDescription: 'Video description',
+      hashtags: ['AI'],
+      videoUrl: 'https://cdn.example.com/video.mp4',
+    })
+
+    expect(result).toMatchObject({
+      success: true,
+      status: 'published',
+      platformPostId: 'youtube-video-1',
+      platformPostUrl: 'https://www.youtube.com/watch?v=youtube-video-1',
+    })
+    expect(mocks.fetch).toHaveBeenCalledTimes(2)
+    expect(mocks.fetch.mock.calls[1][0]).toContain('https://www.googleapis.com/upload/youtube/v3/videos')
+    expect(mocks.fetch.mock.calls[1][1]).toEqual(expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({ Authorization: 'Bearer token' }),
+    }))
+  })
+
+  it('fails closed when no final video URL exists', async () => {
+    const { update } = installSupabase({
+      is_active: true,
+      credentials: {
+        access_token: 'token',
+      },
+      settings: {},
+    })
+
+    const result = await publishToYouTube({
+      contentId: 'content-1',
+      postText: 'Post text',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('final video URL')
+    expect(mocks.fetch).not.toHaveBeenCalled()
+    expect(update).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'failed',
+      error_message: expect.stringContaining('final video URL'),
+    }))
+  })
+})

--- a/lib/publishing/youtube.ts
+++ b/lib/publishing/youtube.ts
@@ -1,0 +1,300 @@
+/**
+ * YouTube Publishing Module
+ *
+ * Uploads a final video asset to YouTube Data API after the human submission
+ * gate. This module does not render, generate media, schedule, or publish
+ * without an active social_content_config row and a final video URL.
+ */
+
+import { supabaseAdmin } from '@/lib/supabase'
+import type { PublishStatus, SocialPlatform } from '@/lib/social-content'
+
+export interface YouTubePublishPayload {
+  contentId: string
+  postText: string
+  ctaText?: string | null
+  ctaUrl?: string | null
+  hashtags?: string[] | null
+  videoUrl?: string | null
+  youtubeTitle?: string | null
+  youtubeDescription?: string | null
+}
+
+export interface YouTubePublishResult {
+  success: boolean
+  platformPostId?: string
+  platformPostUrl?: string
+  status?: PublishStatus
+  error?: string
+}
+
+interface YouTubeCredentials {
+  access_token?: string
+  refresh_token?: string
+  expires_in?: number
+  token_obtained_at?: string
+}
+
+interface YouTubeSettings {
+  default_privacy?: 'private' | 'unlisted' | 'public'
+  category_id?: string
+  made_for_kids?: boolean
+  notify_subscribers?: boolean
+  max_download_bytes?: number
+}
+
+async function getYouTubeConfig(): Promise<{
+  credentials: YouTubeCredentials
+  settings: YouTubeSettings
+} | null> {
+  const admin = supabaseAdmin
+  if (!admin) return null
+
+  const { data } = await admin
+    .from('social_content_config')
+    .select('credentials, settings, is_active')
+    .eq('platform', 'youtube')
+    .single()
+
+  if (!data || !data.is_active) return null
+
+  return {
+    credentials: data.credentials as YouTubeCredentials,
+    settings: data.settings as YouTubeSettings,
+  }
+}
+
+async function updateYouTubeCredentials(credentials: YouTubeCredentials) {
+  const admin = supabaseAdmin
+  if (!admin) return
+
+  await admin
+    .from('social_content_config')
+    .update({ credentials })
+    .eq('platform', 'youtube')
+}
+
+async function updatePublishStatus(
+  contentId: string,
+  platform: SocialPlatform,
+  status: PublishStatus,
+  extra?: { platform_post_id?: string; platform_post_url?: string; error_message?: string }
+) {
+  const admin = supabaseAdmin
+  if (!admin) return
+
+  await admin
+    .from('social_content_publishes')
+    .update({
+      status,
+      ...(status === 'published' ? { published_at: new Date().toISOString() } : {}),
+      ...extra,
+    })
+    .eq('content_id', contentId)
+    .eq('platform', platform)
+}
+
+function isTokenExpired(credentials: YouTubeCredentials, bufferMs = 10 * 60 * 1000) {
+  if (!credentials.token_obtained_at || !credentials.expires_in) return false
+  const obtainedAt = new Date(credentials.token_obtained_at).getTime()
+  const expiresAt = obtainedAt + credentials.expires_in * 1000
+  return Date.now() + bufferMs >= expiresAt
+}
+
+async function refreshYouTubeToken(credentials: YouTubeCredentials): Promise<{
+  success: boolean
+  credentials?: YouTubeCredentials
+  error?: string
+}> {
+  if (!credentials.refresh_token) {
+    return { success: false, error: 'YouTube token expired — reconnect YouTube before publishing' }
+  }
+
+  const clientId = process.env.YOUTUBE_CLIENT_ID || process.env.GOOGLE_CLIENT_ID
+  const clientSecret = process.env.YOUTUBE_CLIENT_SECRET || process.env.GOOGLE_CLIENT_SECRET
+  if (!clientId || !clientSecret) {
+    return { success: false, error: 'YouTube OAuth client credentials are not configured' }
+  }
+
+  const response = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      refresh_token: credentials.refresh_token,
+      grant_type: 'refresh_token',
+    }),
+  })
+
+  const data = await response.json() as {
+    access_token?: string
+    expires_in?: number
+    error_description?: string
+  }
+
+  if (!response.ok || !data.access_token) {
+    return {
+      success: false,
+      error: data.error_description || 'YouTube token refresh failed — reconnect YouTube before publishing',
+    }
+  }
+
+  const updated = {
+    ...credentials,
+    access_token: data.access_token,
+    expires_in: data.expires_in,
+    token_obtained_at: new Date().toISOString(),
+  }
+  await updateYouTubeCredentials(updated)
+  return { success: true, credentials: updated }
+}
+
+function buildTitle(payload: YouTubePublishPayload) {
+  const source = payload.youtubeTitle || payload.ctaText || payload.postText
+  return source.replace(/\s+/g, ' ').trim().slice(0, 100) || 'AmaduTown video'
+}
+
+function buildDescription(payload: YouTubePublishPayload) {
+  const parts = [
+    payload.youtubeDescription || payload.postText,
+    payload.ctaText,
+    payload.ctaUrl,
+    payload.hashtags?.length
+      ? payload.hashtags.map((tag) => tag.startsWith('#') ? tag : `#${tag}`).join(' ')
+      : null,
+  ]
+  return parts.filter(Boolean).join('\n\n')
+}
+
+async function downloadVideo(videoUrl: string, maxBytes: number) {
+  const response = await fetch(videoUrl)
+  if (!response.ok) throw new Error(`Failed to download YouTube video asset (${response.status})`)
+
+  const contentLength = Number(response.headers.get('content-length') || 0)
+  if (contentLength && contentLength > maxBytes) {
+    throw new Error(`YouTube video asset exceeds configured upload limit (${maxBytes} bytes)`)
+  }
+
+  const arrayBuffer = await response.arrayBuffer()
+  if (arrayBuffer.byteLength > maxBytes) {
+    throw new Error(`YouTube video asset exceeds configured upload limit (${maxBytes} bytes)`)
+  }
+
+  return {
+    arrayBuffer,
+    contentType: response.headers.get('content-type') || 'video/mp4',
+  }
+}
+
+async function uploadVideo({
+  accessToken,
+  payload,
+  settings,
+}: {
+  accessToken: string
+  payload: YouTubePublishPayload
+  settings: YouTubeSettings
+}) {
+  if (!payload.videoUrl) throw new Error('YouTube publishing requires a final video URL')
+
+  const maxBytes = settings.max_download_bytes ?? 512 * 1024 * 1024
+  const video = await downloadVideo(payload.videoUrl, maxBytes)
+  const metadata = {
+    snippet: {
+      title: buildTitle(payload),
+      description: buildDescription(payload),
+      categoryId: settings.category_id || '22',
+      tags: payload.hashtags?.map((tag) => tag.replace(/^#/, '')).filter(Boolean) ?? [],
+    },
+    status: {
+      privacyStatus: settings.default_privacy || 'private',
+      selfDeclaredMadeForKids: settings.made_for_kids ?? false,
+    },
+  }
+
+  const formData = new FormData()
+  formData.set('metadata', new Blob([JSON.stringify(metadata)], { type: 'application/json' }))
+  formData.set('media', new Blob([video.arrayBuffer], { type: video.contentType }), 'video.mp4')
+
+  const notifySubscribers = settings.notify_subscribers ?? false
+  const response = await fetch(
+    `https://www.googleapis.com/upload/youtube/v3/videos?uploadType=multipart&part=snippet,status&notifySubscribers=${notifySubscribers}`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: formData,
+    },
+  )
+
+  const data = await response.json() as { id?: string; error?: { message?: string } }
+  if (!response.ok || !data.id) {
+    throw new Error(data.error?.message || `YouTube upload failed (${response.status})`)
+  }
+
+  return data.id
+}
+
+export async function publishToYouTube(payload: YouTubePublishPayload): Promise<YouTubePublishResult> {
+  const config = await getYouTubeConfig()
+  if (!config) {
+    const error = 'YouTube is not connected or inactive'
+    await updatePublishStatus(payload.contentId, 'youtube', 'failed', { error_message: error })
+    return { success: false, error }
+  }
+
+  let { credentials } = config
+  const { settings } = config
+
+  if (!credentials.access_token) {
+    const error = 'YouTube credentials incomplete — missing access token'
+    await updatePublishStatus(payload.contentId, 'youtube', 'failed', { error_message: error })
+    return { success: false, error }
+  }
+
+  if (isTokenExpired(credentials)) {
+    const refresh = await refreshYouTubeToken(credentials)
+    if (!refresh.success || !refresh.credentials) {
+      await updatePublishStatus(payload.contentId, 'youtube', 'failed', { error_message: refresh.error })
+      return { success: false, error: refresh.error }
+    }
+    credentials = refresh.credentials
+  }
+
+  const accessToken = credentials.access_token
+  if (!accessToken) {
+    const error = 'YouTube credentials incomplete — missing refreshed access token'
+    await updatePublishStatus(payload.contentId, 'youtube', 'failed', { error_message: error })
+    return { success: false, error }
+  }
+
+  await updatePublishStatus(payload.contentId, 'youtube', 'publishing')
+
+  try {
+    const platformPostId = await uploadVideo({
+      accessToken,
+      payload,
+      settings,
+    })
+    const platformPostUrl = `https://www.youtube.com/watch?v=${platformPostId}`
+
+    await updatePublishStatus(payload.contentId, 'youtube', 'published', {
+      platform_post_id: platformPostId,
+      platform_post_url: platformPostUrl,
+    })
+
+    return {
+      success: true,
+      status: 'published',
+      platformPostId,
+      platformPostUrl,
+    }
+  } catch (err) {
+    const error = err instanceof Error ? err.message : 'Unknown error during YouTube publish'
+    console.error('[YouTube] Publish error:', err)
+    await updatePublishStatus(payload.contentId, 'youtube', 'failed', { error_message: error })
+    return { success: false, error }
+  }
+}

--- a/lib/social-content-calendar-handoff.test.ts
+++ b/lib/social-content-calendar-handoff.test.ts
@@ -127,6 +127,15 @@ describe('social-content-calendar-handoff', () => {
         authorized_by: 'admin-user',
         publish_gate: 'draft_only',
         external_execution_enabled: false,
+        platform_submission_orchestration: expect.objectContaining({
+          anyAutomaticSubmissionAvailable: false,
+          platforms: expect.arrayContaining([
+            expect.objectContaining({
+              platform: 'linkedin',
+              automaticSubmissionSupported: true,
+            }),
+          ]),
+        }),
       }),
     }))
     expect(mocks.createAgentWorkItem).toHaveBeenCalledWith(expect.objectContaining({
@@ -142,6 +151,15 @@ describe('social-content-calendar-handoff', () => {
         social_content_id: 'social-draft-1',
         draft_handoff_only: true,
         external_execution_enabled: false,
+        platform_submission_orchestration: expect.objectContaining({
+          sideEffectsUntilFinalGate: {
+            providerGeneration: false,
+            upload: false,
+            externalSchedule: false,
+            publish: false,
+            externalPost: false,
+          },
+        }),
         side_effects: expect.objectContaining({
           provider_generation: false,
           upload: false,
@@ -166,6 +184,11 @@ describe('social-content-calendar-handoff', () => {
           kind: 'linkedin_social_content_draft',
           work_item_id: 'work-handoff-1',
           social_content_id: 'social-draft-1',
+        }),
+        platform_submission_orchestration: expect.objectContaining({
+          platforms: expect.arrayContaining([
+            expect.objectContaining({ platform: 'linkedin' }),
+          ]),
         }),
       }),
     }))
@@ -206,7 +229,7 @@ describe('social-content-calendar-handoff', () => {
     expect(result.socialContentId).toBe('social-existing-1')
   })
 
-  it('authorizes non-LinkedIn channels as planning-only handoffs without social queue inserts', async () => {
+  it('authorizes YouTube Shorts calendar items as planning-only handoffs without social queue inserts', async () => {
     const item = baseCalendarItem({
       channel: 'youtube_shorts',
       social_content_id: null,
@@ -240,6 +263,14 @@ describe('social-content-calendar-handoff', () => {
         platform_draft_handoff: expect.objectContaining({
           kind: 'channel_planning_handoff',
           social_content_id: null,
+        }),
+        platform_submission_orchestration: expect.objectContaining({
+          platforms: expect.arrayContaining([
+            expect.objectContaining({
+              platform: 'youtube',
+              automaticSubmissionSupported: true,
+            }),
+          ]),
         }),
       }),
     }))

--- a/lib/social-content-calendar-handoff.ts
+++ b/lib/social-content-calendar-handoff.ts
@@ -6,6 +6,11 @@ import {
   parseMetadata,
   type SocialContentCalendarItem,
 } from '@/lib/social-content-calendar'
+import {
+  buildPlatformOrchestrationPlan,
+  type PlatformOrchestrationPlan,
+} from '@/lib/social-platform-orchestration'
+import type { SocialPlatform } from '@/lib/social-content'
 
 type CalendarActionAuth = {
   user: {
@@ -37,6 +42,32 @@ function campaignName(item: SocialContentCalendarItem) {
   return item.attraction_campaigns?.name ?? 'Unassigned campaign'
 }
 
+function calendarPlatformTargets(item: SocialContentCalendarItem): SocialPlatform[] {
+  switch (item.channel) {
+    case 'linkedin':
+      return ['linkedin']
+    case 'youtube_shorts':
+      return ['youtube']
+    case 'instagram_reels':
+      return ['instagram']
+    case 'thumbnail':
+      return []
+    default:
+      return ['linkedin']
+  }
+}
+
+function platformOrchestrationForCalendarItem(item: SocialContentCalendarItem): PlatformOrchestrationPlan {
+  return buildPlatformOrchestrationPlan({
+    targetPlatforms: calendarPlatformTargets(item),
+    copyApproved: true,
+    productionReady: false,
+    redactionReady: true,
+    draftHandoffReady: item.channel === 'linkedin' && Boolean(item.social_content_id),
+    finalSubmissionGateReady: false,
+  })
+}
+
 function buildDraftSeed(item: SocialContentCalendarItem) {
   const plannedAngle = cleanText(item.planned_angle)
   return [
@@ -65,6 +96,7 @@ function buildDraftRagContext(item: SocialContentCalendarItem, auth: CalendarAct
     publish_gate: 'draft_only',
     external_execution_enabled: false,
     approval_boundary: 'Internal draft handoff only. This does not publish, schedule externally, upload, call media providers, or create public content.',
+    platform_submission_orchestration: platformOrchestrationForCalendarItem(item),
     linked_agent_work_item_id: item.agent_work_item_id,
     calendar_metadata: metadata,
   }
@@ -196,6 +228,7 @@ async function createDraftHandoffWorkItem(input: {
       draft_handoff_only: true,
       external_execution_enabled: false,
       approval_boundary: 'internal_platform_draft_handoff_only',
+      platform_submission_orchestration: platformOrchestrationForCalendarItem(item),
       side_effects: {
         ...CALENDAR_SIDE_EFFECTS,
         social_content_draft_created: Boolean(socialContentId),
@@ -234,6 +267,10 @@ export async function authorizeCalendarDraftHandoff(
       social_content_id: socialContentId,
       created_at: new Date().toISOString(),
     },
+    platform_submission_orchestration: platformOrchestrationForCalendarItem({
+      ...item,
+      social_content_id: socialContentId,
+    }),
   }
 
   const { data, error } = await supabaseAdmin

--- a/lib/social-content.ts
+++ b/lib/social-content.ts
@@ -7,7 +7,7 @@
 // Types
 // ============================================================================
 
-export type SocialPlatform = 'linkedin' | 'instagram' | 'facebook' | 'youtube'
+export type SocialPlatform = 'linkedin' | 'instagram' | 'facebook' | 'youtube' | 'tiktok'
 
 export type ContentStatus = 'draft' | 'approved' | 'scheduled' | 'published' | 'rejected'
 
@@ -128,9 +128,10 @@ export interface SocialContentConfig {
 
 export const PLATFORMS: { value: SocialPlatform; label: string; enabled: boolean }[] = [
   { value: 'linkedin', label: 'LinkedIn', enabled: true },
-  { value: 'youtube', label: 'YouTube', enabled: false },
-  { value: 'instagram', label: 'Instagram', enabled: false },
-  { value: 'facebook', label: 'Facebook', enabled: false },
+  { value: 'youtube', label: 'YouTube', enabled: true },
+  { value: 'instagram', label: 'Instagram', enabled: true },
+  { value: 'facebook', label: 'Facebook', enabled: true },
+  { value: 'tiktok', label: 'TikTok', enabled: true },
 ]
 
 export const PUBLISH_STATUS_CONFIG: Record<PublishStatus, {

--- a/lib/social-platform-orchestration.test.ts
+++ b/lib/social-platform-orchestration.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildPlatformOrchestrationPlan } from './social-platform-orchestration'
+
+describe('buildPlatformOrchestrationPlan', () => {
+  it('exposes connected platform automatic submission only after the final submission gate is ready', () => {
+    const plan = buildPlatformOrchestrationPlan({
+      targetPlatforms: ['linkedin', 'youtube', 'instagram', 'facebook', 'tiktok'],
+      copyApproved: true,
+      productionReady: true,
+      redactionReady: true,
+      draftHandoffReady: true,
+      publishRecords: [{
+        platform: 'linkedin',
+        status: 'pending',
+        platform_post_url: null,
+      }],
+    })
+
+    expect(plan.anyAutomaticSubmissionAvailable).toBe(true)
+    expect(plan.platforms.map((platform) => platform.platform)).toEqual(['linkedin', 'youtube', 'instagram', 'facebook', 'tiktok'])
+    expect(plan.platforms.every((platform) => platform.automaticSubmissionSupported === true)).toBe(true)
+    expect(plan.platforms[0]).toMatchObject({
+      platform: 'linkedin',
+      automaticSubmissionSupported: true,
+      publishStatus: 'pending',
+      nextAction: 'Submit to LinkedIn through the configured platform integration.',
+    })
+    expect(plan.platforms[0].stages.map((stage) => [stage.key, stage.state])).toEqual([
+      ['human_approval', 'complete'],
+      ['asset_readiness', 'complete'],
+      ['platform_draft_handoff', 'complete'],
+      ['platform_configuration', 'complete'],
+      ['final_submission_gate', 'complete'],
+      ['automatic_submission', 'available'],
+    ])
+    expect(plan.sideEffectsUntilFinalGate).toEqual({
+      providerGeneration: false,
+      upload: false,
+      externalSchedule: false,
+      publish: false,
+      externalPost: false,
+    })
+  })
+
+  it('connects Facebook to the same automatic submission gate path', () => {
+    const plan = buildPlatformOrchestrationPlan({
+      targetPlatforms: ['facebook'],
+      copyApproved: true,
+      productionReady: true,
+      redactionReady: true,
+      draftHandoffReady: true,
+      finalSubmissionGateReady: true,
+    })
+
+    expect(plan.anyAutomaticSubmissionAvailable).toBe(true)
+    expect(plan.platforms.map((platform) => platform.platform)).toEqual(['facebook'])
+    expect(plan.platforms.every((platform) => platform.automaticSubmissionSupported === true)).toBe(true)
+    expect(plan.platforms.map((platform) => (
+      platform.stages.find((stage) => stage.key === 'automatic_submission')?.state
+    ))).toEqual(['available'])
+  })
+
+  it('keeps platform submission blocked until privacy and asset readiness clear', () => {
+    const plan = buildPlatformOrchestrationPlan({
+      targetPlatforms: ['linkedin'],
+      copyApproved: true,
+      productionReady: false,
+      redactionReady: false,
+      draftHandoffReady: false,
+    })
+
+    expect(plan.anyAutomaticSubmissionAvailable).toBe(false)
+    expect(plan.platforms[0].stages.map((stage) => [stage.key, stage.state])).toEqual([
+      ['human_approval', 'complete'],
+      ['asset_readiness', 'blocked'],
+      ['platform_draft_handoff', 'blocked'],
+      ['platform_configuration', 'blocked'],
+      ['final_submission_gate', 'blocked'],
+      ['automatic_submission', 'blocked'],
+    ])
+  })
+
+  it('blocks final submission when requested platform configuration is missing', () => {
+    const plan = buildPlatformOrchestrationPlan({
+      targetPlatforms: ['tiktok'],
+      copyApproved: true,
+      productionReady: true,
+      redactionReady: true,
+      draftHandoffReady: true,
+      finalSubmissionGateReady: true,
+      platformConfigs: [{
+        platform: 'tiktok',
+        is_active: true,
+        credentials: { access_token: 'token' },
+        settings: { creator_info_confirmed: false, source_url_approved: false } as never,
+      }],
+    })
+
+    expect(plan.anyAutomaticSubmissionAvailable).toBe(false)
+    expect(plan.platforms[0].nextAction).toBe('TikTok needs creator-info confirmation, approved URL ingestion.')
+    expect(plan.platforms[0].stages.map((stage) => [stage.key, stage.state])).toEqual([
+      ['human_approval', 'complete'],
+      ['asset_readiness', 'complete'],
+      ['platform_draft_handoff', 'complete'],
+      ['platform_configuration', 'blocked'],
+      ['final_submission_gate', 'blocked'],
+      ['automatic_submission', 'blocked'],
+    ])
+  })
+})

--- a/lib/social-platform-orchestration.ts
+++ b/lib/social-platform-orchestration.ts
@@ -1,0 +1,333 @@
+import type {
+  ContentStatus,
+  PublishStatus,
+  SocialContentConfig,
+  SocialContentItem,
+  SocialContentPublish,
+  SocialPlatform,
+} from '@/lib/social-content'
+
+export type PlatformOrchestrationStageKey =
+  | 'human_approval'
+  | 'asset_readiness'
+  | 'platform_draft_handoff'
+  | 'platform_configuration'
+  | 'final_submission_gate'
+  | 'automatic_submission'
+
+export type PlatformOrchestrationStageState = 'complete' | 'available' | 'pending' | 'blocked'
+
+export type PlatformOrchestrationStage = {
+  key: PlatformOrchestrationStageKey
+  label: string
+  state: PlatformOrchestrationStageState
+  detail: string
+}
+
+export type PlatformOrchestrationPlatformPlan = {
+  platform: SocialPlatform
+  label: string
+  automaticSubmissionSupported: boolean
+  publishStatus: PublishStatus | null
+  platformPostUrl: string | null
+  nextAction: string
+  stages: PlatformOrchestrationStage[]
+}
+
+export type PlatformOrchestrationPlan = {
+  platforms: PlatformOrchestrationPlatformPlan[]
+  anyAutomaticSubmissionAvailable: boolean
+  allAutomaticSubmissionComplete: boolean
+  sideEffectsUntilFinalGate: {
+    providerGeneration: false
+    upload: false
+    externalSchedule: false
+    publish: false
+    externalPost: false
+  }
+}
+
+const PLATFORM_LABELS: Record<SocialPlatform, string> = {
+  linkedin: 'LinkedIn',
+  youtube: 'YouTube',
+  instagram: 'Instagram',
+  facebook: 'Facebook',
+  tiktok: 'TikTok',
+}
+
+const AUTOMATIC_SUBMISSION_SUPPORTED = new Set<SocialPlatform>(['linkedin', 'youtube', 'instagram', 'facebook', 'tiktok'])
+
+const SUBMITTED_STATUSES = new Set<PublishStatus>(['published'])
+const SUBMITTABLE_STATUSES = new Set<PublishStatus>(['pending', 'failed'])
+
+export type BuildPlatformOrchestrationInput = {
+  item?: Pick<SocialContentItem, 'status' | 'platform' | 'target_platforms' | 'publishes'> | null
+  targetPlatforms?: SocialPlatform[]
+  publishRecords?: Pick<SocialContentPublish, 'platform' | 'status' | 'platform_post_url'>[]
+  platformConfigs?: Pick<SocialContentConfig, 'platform' | 'credentials' | 'settings' | 'is_active'>[]
+  copyApproved?: boolean
+  productionReady?: boolean
+  redactionReady?: boolean
+  draftHandoffReady?: boolean
+  finalSubmissionGateReady?: boolean
+}
+
+function uniquePlatforms(platforms: SocialPlatform[]) {
+  return Array.from(new Set(platforms)).filter((platform): platform is SocialPlatform => Boolean(PLATFORM_LABELS[platform]))
+}
+
+function resolveTargetPlatforms(input: BuildPlatformOrchestrationInput) {
+  if (input.targetPlatforms?.length) return uniquePlatforms(input.targetPlatforms)
+  if (input.item?.target_platforms?.length) return uniquePlatforms(input.item.target_platforms)
+  if (input.item?.platform) return uniquePlatforms([input.item.platform])
+  return ['linkedin'] as SocialPlatform[]
+}
+
+function isCopyApproved(status?: ContentStatus) {
+  return status === 'approved' || status === 'scheduled' || status === 'published'
+}
+
+function stage(
+  key: PlatformOrchestrationStageKey,
+  label: string,
+  state: PlatformOrchestrationStageState,
+  detail: string,
+): PlatformOrchestrationStage {
+  return { key, label, state, detail }
+}
+
+function nextActionFor(stages: PlatformOrchestrationStage[], platform: SocialPlatform) {
+  const actionable = stages.find((candidate) => candidate.state !== 'complete')
+  if (!actionable) return `${PLATFORM_LABELS[platform]} submission is complete.`
+  return actionable.detail
+}
+
+function truthyString(value: unknown) {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function configField(config: Pick<SocialContentConfig, 'credentials' | 'settings'> | undefined, key: string) {
+  const credentials = config?.credentials as Record<string, unknown> | undefined
+  const settings = config?.settings as Record<string, unknown> | undefined
+  return credentials?.[key] ?? settings?.[key]
+}
+
+function configSettings(config: Pick<SocialContentConfig, 'settings'> | undefined) {
+  return config?.settings as Record<string, unknown> | undefined
+}
+
+function hasPlatformConfiguration(
+  platform: SocialPlatform,
+  config: Pick<SocialContentConfig, 'platform' | 'credentials' | 'settings' | 'is_active'> | undefined,
+) {
+  if (!config?.is_active) {
+    return {
+      ready: false,
+      detail: `Connect and activate ${PLATFORM_LABELS[platform]} in Social Content settings.`,
+    }
+  }
+
+  switch (platform) {
+    case 'linkedin': {
+      const hasToken = truthyString(configField(config, 'access_token'))
+      const hasAuthor = truthyString(configField(config, 'author_urn')) || truthyString(configField(config, 'person_urn'))
+      return {
+        ready: hasToken && hasAuthor,
+        detail: hasToken && hasAuthor
+          ? 'LinkedIn credentials are configured.'
+          : 'LinkedIn needs an access token and author/person URN.',
+      }
+    }
+    case 'youtube': {
+      const hasToken = truthyString(configField(config, 'access_token'))
+      return {
+        ready: hasToken,
+        detail: hasToken
+          ? 'YouTube upload credentials are configured.'
+          : 'YouTube needs an access token before upload.',
+      }
+    }
+    case 'instagram': {
+      const hasToken = truthyString(configField(config, 'access_token'))
+      const hasAccount = truthyString(configField(config, 'ig_user_id'))
+        || truthyString(configField(config, 'instagram_user_id'))
+        || truthyString(configField(config, 'business_account_id'))
+      return {
+        ready: hasToken && hasAccount,
+        detail: hasToken && hasAccount
+          ? 'Instagram business publishing credentials are configured.'
+          : 'Instagram needs an access token and business/IG user ID.',
+      }
+    }
+    case 'facebook': {
+      const hasToken = truthyString(configField(config, 'page_access_token')) || truthyString(configField(config, 'access_token'))
+      const hasPage = truthyString(configField(config, 'page_id'))
+      return {
+        ready: hasToken && hasPage,
+        detail: hasToken && hasPage
+          ? 'Facebook Page publishing credentials are configured.'
+          : 'Facebook needs a Page access token and Page ID.',
+      }
+    }
+    case 'tiktok': {
+      const hasToken = truthyString(configField(config, 'access_token'))
+      const settings = configSettings(config)
+      const creatorConfirmed = settings?.creator_info_confirmed === true
+        || truthyString(settings?.creator_info_confirmed_at)
+      const sourceUrlApproved = settings?.source_url_approved === true
+        || (Array.isArray(settings?.approved_media_domains) && settings.approved_media_domains.length > 0)
+      const missing = [
+        !hasToken ? 'access token' : null,
+        !creatorConfirmed ? 'creator-info confirmation' : null,
+        !sourceUrlApproved ? 'approved URL ingestion' : null,
+      ].filter(Boolean)
+      return {
+        ready: hasToken && creatorConfirmed && sourceUrlApproved,
+        detail: hasToken && creatorConfirmed && sourceUrlApproved
+          ? 'TikTok Direct Post credentials and URL ingestion approval are configured.'
+          : `TikTok needs ${missing.join(', ')}.`,
+      }
+    }
+    default:
+      return {
+        ready: false,
+        detail: `${PLATFORM_LABELS[platform]} configuration is missing.`,
+      }
+  }
+}
+
+export function buildPlatformOrchestrationPlan(input: BuildPlatformOrchestrationInput): PlatformOrchestrationPlan {
+  const targetPlatforms = resolveTargetPlatforms(input)
+  const publishRecords = input.publishRecords ?? input.item?.publishes ?? []
+  const copyReady = input.copyApproved ?? isCopyApproved(input.item?.status)
+  const redactionReady = input.redactionReady ?? true
+  const productionReady = input.productionReady ?? redactionReady
+  const draftHandoffReady = input.draftHandoffReady ?? false
+
+  const platforms = targetPlatforms.map((platform) => {
+    const publishRecord = publishRecords.find((record) => record.platform === platform)
+    const platformConfig = input.platformConfigs?.find((config) => config.platform === platform)
+    const configuration = input.platformConfigs ? hasPlatformConfiguration(platform, platformConfig) : {
+      ready: true,
+      detail: `${PLATFORM_LABELS[platform]} configuration check was not requested.`,
+    }
+    const publishStatus = publishRecord?.status ?? null
+    const automaticSubmissionSupported = AUTOMATIC_SUBMISSION_SUPPORTED.has(platform)
+    const submissionComplete = Boolean(publishStatus && SUBMITTED_STATUSES.has(publishStatus))
+    const finalSubmissionGateReady = input.finalSubmissionGateReady
+      ?? Boolean((publishStatus && SUBMITTABLE_STATUSES.has(publishStatus)) || submissionComplete)
+
+    const humanApprovalState: PlatformOrchestrationStageState = copyReady ? 'complete' : 'pending'
+    const assetState: PlatformOrchestrationStageState = !copyReady
+      ? 'blocked'
+      : productionReady
+        ? 'complete'
+        : redactionReady
+          ? 'pending'
+          : 'blocked'
+    const draftState: PlatformOrchestrationStageState = assetState !== 'complete'
+      ? 'blocked'
+      : (draftHandoffReady || Boolean(publishRecord))
+        ? 'complete'
+        : 'pending'
+    const configurationState: PlatformOrchestrationStageState = draftState !== 'complete'
+      ? 'blocked'
+      : configuration.ready
+        ? 'complete'
+        : 'blocked'
+    const finalGateState: PlatformOrchestrationStageState = configurationState !== 'complete'
+      ? 'blocked'
+      : finalSubmissionGateReady || submissionComplete
+        ? 'complete'
+        : 'pending'
+    const automaticState: PlatformOrchestrationStageState = submissionComplete
+      ? 'complete'
+      : finalGateState !== 'complete'
+        ? 'blocked'
+        : automaticSubmissionSupported
+          ? 'available'
+          : 'blocked'
+
+    const stages = [
+      stage(
+        'human_approval',
+        'Human approval',
+        humanApprovalState,
+        copyReady ? 'Copy is approved.' : 'Approve the content packet before any platform handoff.',
+      ),
+      stage(
+        'asset_readiness',
+        'Assets and privacy',
+        assetState,
+        assetState === 'complete'
+          ? 'Required assets and privacy checks are ready.'
+          : redactionReady
+            ? 'Finish visual assets, asset packet, and channel-specific readiness.'
+            : 'Resolve privacy/redaction blockers before submission.',
+      ),
+      stage(
+        'platform_draft_handoff',
+        'Platform draft handoff',
+        draftState,
+        draftState === 'complete'
+          ? 'Internal platform draft handoff exists.'
+          : `Create or authorize the ${PLATFORM_LABELS[platform]} draft handoff.`,
+      ),
+      stage(
+        'platform_configuration',
+        'Platform configuration',
+        configurationState,
+        configurationState === 'complete'
+          ? configuration.detail
+          : draftState !== 'complete'
+            ? `Create the ${PLATFORM_LABELS[platform]} draft handoff before checking platform credentials.`
+            : configuration.detail,
+      ),
+      stage(
+        'final_submission_gate',
+        'Final submission gate',
+        finalGateState,
+        finalGateState === 'complete'
+          ? 'Final submission approval is recorded.'
+          : `Approve ${PLATFORM_LABELS[platform]} platform submission as a separate gate.`,
+      ),
+      stage(
+        'automatic_submission',
+        'Automatic submission',
+        automaticState,
+        automaticState === 'complete'
+          ? `${PLATFORM_LABELS[platform]} has a published platform record.`
+          : !automaticSubmissionSupported
+            ? `${PLATFORM_LABELS[platform]} automatic submission is not connected yet.`
+            : `Submit to ${PLATFORM_LABELS[platform]} through the configured platform integration.`,
+      ),
+    ]
+
+    return {
+      platform,
+      label: PLATFORM_LABELS[platform],
+      automaticSubmissionSupported,
+      publishStatus,
+      platformPostUrl: publishRecord?.platform_post_url ?? null,
+      nextAction: nextActionFor(stages, platform),
+      stages,
+    }
+  })
+
+  return {
+    platforms,
+    anyAutomaticSubmissionAvailable: platforms.some((platform) => (
+      platform.stages.some((stageItem) => stageItem.key === 'automatic_submission' && stageItem.state === 'available')
+    )),
+    allAutomaticSubmissionComplete: platforms.length > 0 && platforms.every((platform) => (
+      platform.stages.some((stageItem) => stageItem.key === 'automatic_submission' && stageItem.state === 'complete')
+    )),
+    sideEffectsUntilFinalGate: {
+      providerGeneration: false,
+      upload: false,
+      externalSchedule: false,
+      publish: false,
+      externalPost: false,
+    },
+  }
+}

--- a/migrations/2026_06_29_social_platform_tiktok_publish.sql
+++ b/migrations/2026_06_29_social_platform_tiktok_publish.sql
@@ -1,0 +1,59 @@
+-- ========================================
+-- Social Platform Publishing Expansion
+-- ========================================
+-- Purpose: Enable TikTok as a governed social content target alongside LinkedIn and Instagram.
+-- Created: 2026-06-29
+
+ALTER TABLE public.social_content_config
+    DROP CONSTRAINT IF EXISTS social_content_config_platform_check;
+
+ALTER TABLE public.social_content_config
+    ADD CONSTRAINT social_content_config_platform_check
+    CHECK (platform IN ('linkedin', 'instagram', 'facebook', 'youtube', 'tiktok'));
+
+ALTER TABLE public.social_content_queue
+    DROP CONSTRAINT IF EXISTS social_content_queue_platform_check;
+
+ALTER TABLE public.social_content_queue
+    ADD CONSTRAINT social_content_queue_platform_check
+    CHECK (platform IN ('linkedin', 'instagram', 'facebook', 'youtube', 'tiktok'));
+
+ALTER TABLE public.social_content_publishes
+    DROP CONSTRAINT IF EXISTS social_content_publishes_platform_check;
+
+ALTER TABLE public.social_content_publishes
+    ADD CONSTRAINT social_content_publishes_platform_check
+    CHECK (platform IN ('linkedin', 'instagram', 'facebook', 'youtube', 'tiktok'));
+
+INSERT INTO public.social_content_config (platform, credentials, settings, is_active)
+VALUES (
+    'tiktok',
+    '{}',
+    '{
+      "privacy_level": "SELF_ONLY",
+      "creator_info_confirmed": false,
+      "source_url_approved": false,
+      "disable_comment": false,
+      "disable_duet": false,
+      "disable_stitch": false,
+      "brand_content_toggle": false,
+      "brand_organic_toggle": false,
+      "is_aigc": true
+    }',
+    false
+)
+ON CONFLICT (platform) DO NOTHING;
+
+UPDATE public.social_content_config
+SET settings = COALESCE(settings, '{}'::jsonb) || '{
+  "graph_api_version": "v20.0",
+  "share_reels_to_feed": true
+}'::jsonb
+WHERE platform = 'instagram';
+
+UPDATE public.social_content_config
+SET settings = COALESCE(settings, '{}'::jsonb) || '{
+  "graph_api_version": "v20.0",
+  "default_published": true
+}'::jsonb
+WHERE platform = 'facebook';


### PR DESCRIPTION
## Summary
- Adds a governed platform submission path to Social Content so approved packets move through human approval, asset/privacy readiness, internal draft handoff, platform configuration, final submission approval, and automatic submission.
- Extends social publishing support across LinkedIn, YouTube, Instagram, Facebook, and TikTok while keeping provider generation, uploads, schedules, publishing, and external posts gated until the final submission step.
- Adds TikTok publish schema/support and platform-specific publisher modules/tests, including Instagram business publishing and TikTok Direct Post guardrails.
- Surfaces the Platform Submission Path on the Social Content detail page, with platform configuration readiness pulled from existing Social Content settings.

## Validation
- `./node_modules/.bin/vitest run lib/social-platform-orchestration.test.ts lib/social-content-calendar-handoff.test.ts lib/publishing/youtube.test.ts lib/publishing/instagram.test.ts lib/publishing/facebook.test.ts lib/publishing/tiktok.test.ts 'app/api/admin/social-content/[id]/publish/route.test.ts'` - 21 tests passed.
- `./node_modules/.bin/next lint --file 'app/admin/social-content/[id]/page.tsx' --file 'app/api/admin/social-content/[id]/publish/route.ts' --file 'app/api/admin/social-content/[id]/publish/route.test.ts' --file lib/social-platform-orchestration.ts --file lib/social-platform-orchestration.test.ts --file lib/social-content-calendar-handoff.ts --file lib/social-content-calendar-handoff.test.ts --file lib/social-content.ts --file lib/publishing/youtube.ts --file lib/publishing/youtube.test.ts --file lib/publishing/instagram.ts --file lib/publishing/instagram.test.ts --file lib/publishing/facebook.ts --file lib/publishing/facebook.test.ts --file lib/publishing/tiktok.ts --file lib/publishing/tiktok.test.ts` - passed.
- `PATH=/Users/vambahsillah/Projects/Portfolio/node_modules/.bin:$PATH npm run build:knowledge && ./node_modules/.bin/tsc --noEmit` - passed.
- Browser smoke on `http://127.0.0.1:3080/admin/social-content/25d7efa3-62bc-4f5e-a191-1a131918593a` confirmed `#social-platform-submission-gate` renders and includes the `Platform configuration` stage. The current smoke item is a draft-only LinkedIn pilot, so TikTok/Instagram do not appear on that item-specific path.

## Integration Notes
- Migration included: `migrations/2026_06_29_social_platform_tiktok_publish.sql`.
- TikTok requires access token, creator-info confirmation, and approved URL ingestion before final submission can unlock.
- Instagram requires access token and IG/business account ID before final submission can unlock.
- No HeyGen, ElevenLabs, rendering, upload, scheduling, publish, or external post side effects are triggered by review/navigation/config checks.
- Integration Captain required for merge sequencing, deployment watcher/preflight, and Vercel verification.
- Vercel contexts not checked by this implementation lane after merge:
  - Vercel – portfolio
  - Vercel – portfolio-staging
