### PR TITLE
fix: keep Gmail draft send failures visible

### DIFF
--- a/docs/runbooks/revenue-reply-loop-smoke-2026-06-26.md
+++ b/docs/runbooks/revenue-reply-loop-smoke-2026-06-26.md
@@ -149,3 +149,25 @@ Important behavior note:
 - `modify: ...` currently captures and acknowledges the requested revision, but does not automatically rewrite the Gmail draft.
 - `safe to send` sends the Gmail draft and should only be used after confirming the draft recipient is internal or the user has explicitly approved the customer-facing send.
 - After the Slack connector suffix parser fix is deployed, rerun `safe to send` against an internal-only draft before enabling this as a normal approval path.
+
+## 2026-06-30 Safe-To-Send Follow-Up
+
+After PR #597 deployed, the same internal-only Slack thread was used to post a fresh `safe to send` reply.
+
+Observed result:
+
+- Production route `/api/slack/agent/events` received the Slack reply and returned HTTP 200.
+- The parser fix worked: production attempted to send Gmail draft `r7886723628103744141`.
+- Gmail rejected the send with `Recipient address required`.
+- App draft `46f6aa29-92c0-4b31-be43-e6335d3d3f8b` remained `draft` with `sent_at = null`.
+
+Root cause:
+
+- The WF-GDR `Create Gmail Draft` node created the Gmail draft with subject, body, and thread id, but without `sendTo`.
+- The existing Gmail draft is therefore not a valid send candidate and should not be retried as the launch proof.
+
+Required next fix:
+
+- Add `sendTo: {{$json.client_email}}` to the WF-GDR Gmail draft creation node.
+- Keep Slack safe-send failures visible by returning a Slack failure message when Gmail rejects `drafts.send`.
+- Import/publish the updated WF-GDR workflow, then generate a fresh internal-only draft and rerun the `safe to send` proof.

--- a/lib/agent-slack-events.test.ts
+++ b/lib/agent-slack-events.test.ts
@@ -415,6 +415,74 @@ describe('agent Slack events', () => {
     expect((fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[1]?.body).toContain('marked app draft')
   })
 
+  it('keeps the app draft unsent and posts a Slack failure when Gmail rejects send', async () => {
+    const appDraftId = '9abee71a-930d-49e9-a2b5-d929021ec9cb'
+    const gmailDraftId = 'r5747226337828186444'
+    mocks.sendUserGmailDraft.mockRejectedValueOnce(new Error('Recipient address required'))
+    mocks.from
+      .mockReturnValueOnce(queryResult({ data: null, error: null }))
+      .mockReturnValueOnce(queryResult({
+        data: {
+          id: appDraftId,
+          status: 'draft',
+          subject: 'Re: controlled smoke',
+          client_email: 'lead@example.com',
+        },
+        error: null,
+      }))
+      .mockReturnValueOnce(queryResult({
+        data: {
+          google_email: 'vambah@amadutown.com',
+          refresh_token_cipher: 'cipher',
+          refresh_token_iv: 'iv',
+          refresh_token_tag: 'tag',
+        },
+        error: null,
+      }))
+
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          messages: [
+            {
+              ts: '1700000000.000001',
+              text: [
+                ':incoming_envelope: *Revenue reply ready for approval*',
+                `*App draft ID:* ${appDraftId}`,
+                `*Gmail draft ID:* ${gmailDraftId}`,
+              ].join('\n'),
+            },
+          ],
+        }),
+      } as never)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true, ts: '1700000000.000010' }),
+      } as never)
+
+    const result = await handleSlackAgentEvent({
+      type: 'event_callback',
+      event_id: 'EvRevenueSendFailure',
+      event: {
+        type: 'message',
+        channel_type: 'channel',
+        user: 'U123',
+        channel: 'C123',
+        text: 'safe to send *Sent using* ChatGPT',
+        ts: '1700000000.000009',
+        thread_ts: '1700000000.000001',
+      },
+    })
+
+    expect(result).toEqual({ handled: true, reason: 'revenue_reply_approval_action' })
+    expect(mocks.sendUserGmailDraft).toHaveBeenCalledWith('refresh-token', gmailDraftId)
+    expect(mocks.from).toHaveBeenCalledTimes(3)
+    expect((fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[1]?.body).toContain('Recipient address required')
+    expect((fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[1]?.body).toContain('remains unsent')
+  })
+
   it('holds revenue reply drafts without sending email', async () => {
     const appDraftId = '9abee71a-930d-49e9-a2b5-d929021ec9cb'
     const gmailDraftId = 'r5747226337828186444'

--- a/lib/agent-slack-events.ts
+++ b/lib/agent-slack-events.ts
@@ -260,7 +260,13 @@ async function handleRevenueReplyApprovalCommand(command: RevenueReplyApprovalCo
     credential.refresh_token_iv as string,
     credential.refresh_token_tag as string,
   )
-  await sendUserGmailDraft(refreshToken, context.gmailDraftId)
+  try {
+    await sendUserGmailDraft(refreshToken, context.gmailDraftId)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown Gmail API error'
+    console.warn('[agent-slack-events] Revenue reply Gmail draft send failed:', error)
+    return `Gmail draft ${context.gmailDraftId} could not be sent: ${message}. App draft ${context.appDraftId} remains unsent.`
+  }
 
   const { error: updateError } = await supabaseAdmin
     .from('client_update_drafts')

--- a/n8n-exports/WF-GDR-Gmail-Draft-Reply.json
+++ b/n8n-exports/WF-GDR-Gmail-Draft-Reply.json
@@ -223,6 +223,7 @@
     {
       "parameters": {
         "resource": "draft",
+        "sendTo": "={{ $json.client_email }}",
         "subject": "={{ $json.subject }}",
         "message": "={{ $json.body }}",
         "options": {


### PR DESCRIPTION
## Summary
- Add `sendTo: {{$json.client_email}}` to the WF-GDR Gmail draft node so newly generated approval drafts have a recipient.
- Catch Gmail API `drafts.send` failures in the Slack approval handler and post a visible Slack failure instead of letting the waitUntil task fail silently.
- Document the 2026-06-30 internal safe-to-send smoke result and the required fresh-draft retest.

## Validation
- `npx vitest run lib/agent-slack-events.test.ts`
- `node -e "JSON.parse(require('fs').readFileSync('n8n-exports/WF-GDR-Gmail-Draft-Reply.json','utf8')); console.log('WF-GDR JSON ok')"`
- Live proof observed before this PR: production attempted Gmail draft send and Gmail returned `Recipient address required`; app draft remained unsent.

## Integration Notes
- This PR updates the repo export only. The live WF-GDR workflow still needs import/publish approval before rerunning the smoke.
- Do not retry old Gmail draft `r7886723628103744141`; it was created without a recipient. Generate a fresh internal-only draft after WF-GDR is updated.
- No database migration required.
- Vercel – portfolio: not checked in this non-captain branch; captain should verify after deploy.
- Vercel – portfolio-staging: not checked in this non-captain branch; captain should verify after deploy.