### PR TITLE
Prefer Portfolio-local personality corpus path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 # local env files
 .env*.local
 .credential-rotation-audits/
+.local/
 
 # local-private client/source artifacts; preserve locally, never commit
 /local-private/

--- a/docs/accelerated-course-modules/source-register.md
+++ b/docs/accelerated-course-modules/source-register.md
@@ -14,10 +14,11 @@ This register separates public-facing course material from private-derived voice
 
 Use these for voice, rhythm, and framing. Do not quote private exports.
 
-- `/Users/vambahsillah/Documents/Codex/2026-04-30/i-have-quite-a-bit-of/personality-corpus/agent-exports/core/personality_pack.md`
-- `/Users/vambahsillah/Documents/Codex/2026-04-30/i-have-quite-a-bit-of/personality-corpus/voice_and_style_guide.md`
-- `/Users/vambahsillah/Documents/Codex/2026-04-30/i-have-quite-a-bit-of/personality-corpus/personality_profile.md`
-- `/Users/vambahsillah/Documents/Codex/2026-04-30/i-have-quite-a-bit-of/personality-corpus/corpus_index.jsonl`
+- `/Users/vambahsillah/Projects/Portfolio/.local/personality-corpus/agent-exports/core/personality_pack.md`
+- `/Users/vambahsillah/Projects/Portfolio/.local/personality-corpus/voice_and_style_guide.md`
+- `/Users/vambahsillah/Projects/Portfolio/.local/personality-corpus/personality_profile.md`
+- `/Users/vambahsillah/Projects/Portfolio/.local/personality-corpus/corpus_index.jsonl`
+- Fallback only: `/Users/vambahsillah/Documents/Codex/2026-04-30/i-have-quite-a-bit-of/personality-corpus/`
 - `/Users/vambahsillah/Projects/Portfolio/docs/linkedin-voice.md`
 
 ## Video Production Sources

--- a/docs/agentic-content-research-prds/12-messaging-synthesis.md
+++ b/docs/agentic-content-research-prds/12-messaging-synthesis.md
@@ -17,8 +17,9 @@ This is the bridge from research to public narrative.
 
 - All PRDs in `docs/agentic-content-research-prds/`
 - `docs/linkedin-voice.md`
-- `/Users/vambahsillah/Documents/Codex/2026-04-30/i-have-quite-a-bit-of/personality-corpus/voice_and_style_guide.md`
-- `/Users/vambahsillah/Documents/Codex/2026-04-30/i-have-quite-a-bit-of/personality-corpus/personality_profile.md`
+- `/Users/vambahsillah/Projects/Portfolio/.local/personality-corpus/voice_and_style_guide.md`
+- `/Users/vambahsillah/Projects/Portfolio/.local/personality-corpus/personality_profile.md`
+- Fallback only: `/Users/vambahsillah/Documents/Codex/2026-04-30/i-have-quite-a-bit-of/personality-corpus/`
 - `/Users/vambahsillah/.hermes/hermes-agent/skills/creative/humanizer/SKILL.md`
 - `app/api/admin/video-generation/generate-ideas/route.ts`
 - `docs/heygen-template-brand-setup.md`

--- a/docs/automations/personality-corpus-report-monitor.md
+++ b/docs/automations/personality-corpus-report-monitor.md
@@ -20,6 +20,8 @@ Recurring report review. Confirm the exact schedule from local Codex automation 
 
 - [`content-voice-runbook.md`](./content-voice-runbook.md)
 - [`../memory-context-organization-workflow.md`](../memory-context-organization-workflow.md)
+- Local private corpus home: `/Users/vambahsillah/Projects/Portfolio/.local/personality-corpus`
+- Fallback only: `/Users/vambahsillah/Documents/Codex/2026-04-30/i-have-quite-a-bit-of/personality-corpus`
 - Derived personality corpus reports, read-only.
 - Private source exports only as local source material; do not quote them.
 

--- a/docs/open-brain-local-service.md
+++ b/docs/open-brain-local-service.md
@@ -195,7 +195,7 @@ Memory-producing systems should write Open Brain records in this order:
 
 Current producer routes:
 
-- Personality corpus: public-safe derived pack appears as a `personality_corpus` source; raw private exports remain outside public projections. Run `npm run open-brain:personality-corpus` to persist the public-safe source/event trace into `OPEN_BRAIN_HOME` without copying raw private corpus content.
+- Personality corpus: public-safe derived pack appears as a `personality_corpus` source; raw private exports remain outside public projections. The local private corpus home is `/Users/vambahsillah/Projects/Portfolio/.local/personality-corpus`; the old generated Codex path is compatibility fallback only. Run `npm run open-brain:personality-corpus` to persist the public-safe source/event trace into `OPEN_BRAIN_HOME` without copying raw private corpus content.
 - Codex automation inventory: Portfolio-related automation and repair-packet summaries appear as `codex_automation` and `repair_packet` sources. Run `npm run open-brain:automation-producer` to persist internal-ops source/event traces without copying raw automation prompts.
 - Agent Ops work items and handoffs: active work items appear as `work_item` sources and latest handoffs appear as `handoff` sources. Run `npm run open-brain:agent-ops-producer` to persist internal-ops source/event traces and deterministic review proposals for blocked or review-ready work without copying full work-item or handoff bodies.
 - Chatbot knowledge: `/api/knowledge` remains a public-safe projection, not canonical memory.

--- a/docs/vambah-personality-public-safe.md
+++ b/docs/vambah-personality-public-safe.md
@@ -4,7 +4,9 @@ Source pack: `2026.05.03-d2eabc3d4b55`
 
 Source hash: `d2eabc3d4b55ab55f58703b04517dff6b30e1c7f7142a93e7a254e9911ee2f60`
 
-Origin: `/Users/vambahsillah/Documents/Codex/2026-04-30/i-have-quite-a-bit-of/personality-corpus/rag-ready/vambah_personality_public_safe.md`
+Origin: `/Users/vambahsillah/Projects/Portfolio/.local/personality-corpus/rag-ready/vambah_personality_public_safe.md`
+
+Legacy compatibility path: `/Users/vambahsillah/Documents/Codex/2026-04-30/i-have-quite-a-bit-of/personality-corpus/rag-ready/vambah_personality_public_safe.md`
 
 Sensitivity: public-safe, private-derived summary. This document is intentionally staged for chatbot and RAG use. It is not raw source text.
 

--- a/lib/personality-corpus-paths.test.ts
+++ b/lib/personality-corpus-paths.test.ts
@@ -1,0 +1,56 @@
+import { mkdir, mkdtemp, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import path from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  LEGACY_PERSONALITY_CORPUS_HOME,
+  resolvePersonalityCorpusPaths,
+} from './personality-corpus-paths'
+
+const tempRoots: string[] = []
+
+async function makeTempRoot() {
+  const root = await mkdtemp(path.join(tmpdir(), 'personality-corpus-paths-'))
+  tempRoots.push(root)
+  return root
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('resolvePersonalityCorpusPaths', () => {
+  it('prefers the Portfolio-local personality corpus when present', async () => {
+    const root = await makeTempRoot()
+    const localCorpus = path.join(root, '.local/personality-corpus')
+    await mkdir(localCorpus, { recursive: true })
+
+    const paths = resolvePersonalityCorpusPaths({ portfolioRoot: root })
+
+    expect(paths.activeHome).toBe(localCorpus)
+    expect(paths.activeSource).toBe('portfolio_local')
+    expect(paths.publicSafeRagPack).toBe(path.join(localCorpus, 'rag-ready/vambah_personality_public_safe.md'))
+    expect(paths.rawPrivateExportsHome).toBe(path.join(localCorpus, 'raw-exports'))
+    expect(paths.exists).toBe(true)
+  })
+
+  it('uses an explicit env home when it exists', async () => {
+    const root = await makeTempRoot()
+    const envHome = path.join(root, 'custom-corpus')
+    await mkdir(envHome, { recursive: true })
+
+    const paths = resolvePersonalityCorpusPaths({ portfolioRoot: root, envHome })
+
+    expect(paths.activeHome).toBe(envHome)
+    expect(paths.activeSource).toBe('env')
+  })
+
+  it('falls back to the legacy Codex path when local homes are absent', async () => {
+    const root = await makeTempRoot()
+
+    const paths = resolvePersonalityCorpusPaths({ portfolioRoot: root, envHome: null })
+
+    expect(paths.activeHome).toBe(LEGACY_PERSONALITY_CORPUS_HOME)
+    expect(paths.activeSource).toBe('legacy_codex')
+  })
+})

--- a/lib/personality-corpus-paths.ts
+++ b/lib/personality-corpus-paths.ts
@@ -1,0 +1,49 @@
+import { existsSync } from 'fs'
+import path from 'path'
+
+export const LEGACY_PERSONALITY_CORPUS_HOME = '/Users/vambahsillah/Documents/Codex/2026-04-30/i-have-quite-a-bit-of/personality-corpus'
+
+export interface PersonalityCorpusPaths {
+  portfolioRoot: string
+  preferredHome: string
+  legacyHome: string
+  activeHome: string
+  activeSource: 'env' | 'portfolio_local' | 'legacy_codex'
+  publicSafeRagPack: string
+  voiceGuide: string
+  personalityProfile: string
+  rawPrivateExportsHome: string
+  exists: boolean
+}
+
+export function resolvePersonalityCorpusPaths(options: {
+  portfolioRoot?: string
+  envHome?: string | null
+} = {}): PersonalityCorpusPaths {
+  const portfolioRoot = path.resolve(options.portfolioRoot || process.env.OPEN_BRAIN_PORTFOLIO_ROOT || process.cwd())
+  const preferredHome = path.join(portfolioRoot, '.local/personality-corpus')
+  const envHome = options.envHome ?? process.env.PERSONALITY_CORPUS_HOME ?? null
+  const activeHome = envHome && existsSync(envHome)
+    ? envHome
+    : existsSync(preferredHome)
+      ? preferredHome
+      : LEGACY_PERSONALITY_CORPUS_HOME
+  const activeSource = envHome && existsSync(envHome)
+    ? 'env'
+    : activeHome === preferredHome
+      ? 'portfolio_local'
+      : 'legacy_codex'
+
+  return {
+    portfolioRoot,
+    preferredHome,
+    legacyHome: LEGACY_PERSONALITY_CORPUS_HOME,
+    activeHome,
+    activeSource,
+    publicSafeRagPack: path.join(activeHome, 'rag-ready/vambah_personality_public_safe.md'),
+    voiceGuide: path.join(activeHome, 'voice_and_style_guide.md'),
+    personalityProfile: path.join(activeHome, 'personality_profile.md'),
+    rawPrivateExportsHome: path.join(activeHome, 'raw-exports'),
+    exists: existsSync(activeHome),
+  }
+}

--- a/scripts/open-brain-personality-corpus-producer.ts
+++ b/scripts/open-brain-personality-corpus-producer.ts
@@ -1,11 +1,22 @@
 #!/usr/bin/env tsx
 import { recordPersonalityCorpusProducerTrace } from '../lib/open-brain'
+import { resolvePersonalityCorpusPaths } from '../lib/personality-corpus-paths'
 
 async function main() {
   const result = await recordPersonalityCorpusProducerTrace()
+  const corpusPaths = resolvePersonalityCorpusPaths()
   const output = {
     status: result.status,
     reason: result.reason,
+    corpusPaths: {
+      activeHome: corpusPaths.activeHome,
+      activeSource: corpusPaths.activeSource,
+      preferredHome: corpusPaths.preferredHome,
+      legacyHome: corpusPaths.legacyHome,
+      publicSafeRagPack: corpusPaths.publicSafeRagPack,
+      exists: corpusPaths.exists,
+      rawPrivateExportsTracked: false,
+    },
     source: result.source ? {
       id: result.source.id,
       kind: result.source.kind,


### PR DESCRIPTION
## Summary
- document the Portfolio-local private corpus home at /Users/vambahsillah/Projects/Portfolio/.local/personality-corpus
- keep the generated Codex folder as fallback compatibility path only
- add a personality corpus path resolver with env override support
- update the Open Brain personality corpus producer output to report active corpus path without tracking raw private exports
- ignore .local/ so raw private corpus state is not accidentally committed

## Validation
- vitest run lib/personality-corpus-paths.test.ts lib/open-brain.test.ts
- open-brain personality corpus producer smoke with temporary OPEN_BRAIN_HOME and PERSONALITY_CORPUS_HOME=/Users/vambahsillah/Projects/Portfolio/.local/personality-corpus
- git diff --check

## Privacy boundary
- raw private exports stay under .local/ and remain git-ignored
- tracked docs only point to paths and public-safe derived pack metadata
- no real Open Brain state was mutated during smoke validation