### PR TITLE
fix: generate visual asset review candidates

### DIFF
--- a/app/services/[id]/page.tsx
+++ b/app/services/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import Image from 'next/image'
-import { useParams, useRouter } from 'next/navigation'
+import { useParams, useRouter, useSearchParams } from 'next/navigation'
 import { motion } from 'framer-motion'
 import {
   ShoppingCart,
@@ -66,7 +66,9 @@ const DELIVERY_ICONS: Record<string, { icon: React.ReactNode; label: string }> =
 export default function ServiceDetailPage() {
   const params = useParams()
   const router = useRouter()
+  const searchParams = useSearchParams()
   const serviceId = params.id as string
+  const visualCapture = searchParams.get('visualCapture') === '1'
 
   const [service, setService] = useState<Service | null>(null)
   const [bundles, setBundles] = useState<BundleRef[]>([])
@@ -161,6 +163,143 @@ export default function ServiceDetailPage() {
     { label: 'Services', href: '/services' },
     { label: String(service.title) },
   ]
+
+  if (visualCapture) {
+    const typeLabel = TYPE_LABELS[service.service_type] || service.service_type || 'Service'
+    const priceLabel = service.is_quote_based
+      ? 'Custom scope'
+      : service.price !== null
+        ? formatCurrency(service.price)
+        : 'Free'
+    const deliveryLabel = delivery.label
+    const durationLabel = service.duration_description || (
+      service.duration_hours ? `${service.duration_hours} hours` : 'Scoped delivery'
+    )
+    const featuredTopics = topicsList.length > 0
+      ? topicsList.slice(0, 5)
+      : ['Discovery', 'Implementation', 'Operator handoff']
+    const featuredDeliverables = deliverablesList.length > 0
+      ? deliverablesList.slice(0, 4)
+      : ['Working session', 'Action plan', 'Implementation guidance', 'Follow-up notes']
+    const deliveryPath = [
+      'Diagnose the operating constraint',
+      'Build the practical delivery plan',
+      'Leave the team with a usable handoff',
+    ]
+
+    return (
+      <main className="min-h-screen bg-background text-foreground flex items-center justify-center overflow-hidden p-10">
+        <section
+          data-visual-capture-frame
+          className="relative h-[720px] w-[1280px] overflow-hidden rounded-xl border border-border bg-card text-card-foreground shadow-2xl"
+        >
+          <div className="absolute inset-0 bg-[linear-gradient(135deg,rgba(18,30,49,0.08),rgba(212,175,55,0.16)_44%,transparent_72%)] dark:bg-[linear-gradient(135deg,rgba(212,175,55,0.22),transparent_44%,rgba(234,236,238,0.08))]" />
+          <div className="absolute left-0 top-0 h-full w-2 bg-radiant-gold" />
+          <div className="relative grid h-full grid-cols-[0.9fr_1.1fr] gap-8 p-12">
+            <div className="flex min-w-0 flex-col gap-5">
+              <div className="relative h-72 overflow-hidden rounded-xl border border-border bg-background">
+                {service.image_url ? (
+                  <Image
+                    src={service.image_url}
+                    alt={service.title}
+                    fill
+                    className="object-cover"
+                    sizes="520px"
+                    priority
+                  />
+                ) : (
+                  <div className="flex h-full flex-col items-center justify-center gap-4 bg-[radial-gradient(circle_at_35%_25%,rgba(212,175,55,0.3),transparent_34%),linear-gradient(135deg,rgba(44,62,80,0.14),rgba(212,175,55,0.2))] dark:bg-[radial-gradient(circle_at_35%_25%,rgba(212,175,55,0.3),transparent_34%),linear-gradient(135deg,rgba(234,236,238,0.1),rgba(212,175,55,0.16))]">
+                    <Building className="h-20 w-20 text-radiant-gold" />
+                    <span className="text-lg font-semibold text-muted-foreground">Service delivery visual</span>
+                  </div>
+                )}
+              </div>
+
+              <div className="grid grid-cols-2 gap-4">
+                <div className="rounded-xl border border-border bg-background/80 p-5">
+                  <div className="mb-2 flex items-center gap-2 text-muted-foreground">
+                    {delivery.icon}
+                    <span className="text-sm font-bold uppercase tracking-wider">Delivery</span>
+                  </div>
+                  <p className="text-2xl font-bold">{deliveryLabel}</p>
+                </div>
+                <div className="rounded-xl border border-border bg-background/80 p-5">
+                  <div className="mb-2 flex items-center gap-2 text-muted-foreground">
+                    <Clock className="h-4 w-4" />
+                    <span className="text-sm font-bold uppercase tracking-wider">Timeline</span>
+                  </div>
+                  <p className="text-2xl font-bold">{durationLabel}</p>
+                </div>
+              </div>
+
+              <div className="rounded-xl border border-radiant-gold/40 bg-radiant-gold/10 p-5">
+                <span className="text-sm font-bold uppercase tracking-wider text-muted-foreground">Investment</span>
+                <p className="mt-2 text-4xl font-bold text-radiant-gold">{priceLabel}</p>
+              </div>
+            </div>
+
+            <div className="flex min-w-0 flex-col justify-between">
+              <div>
+                <div className="mb-7 flex flex-wrap items-center gap-3">
+                  <span className="rounded-full bg-radiant-gold px-4 py-2 text-sm font-bold uppercase tracking-wide text-imperial-navy">
+                    {typeLabel}
+                  </span>
+                  {service.is_featured && (
+                    <span className="rounded-full border border-radiant-gold/50 bg-radiant-gold/10 px-4 py-2 text-sm font-bold uppercase tracking-wide text-radiant-gold">
+                      Featured
+                    </span>
+                  )}
+                </div>
+                <h1 className="font-premium text-[60px] leading-[0.98] text-foreground">
+                  {service.title}
+                </h1>
+                {service.description && (
+                  <p className="mt-6 max-h-32 overflow-hidden text-2xl leading-snug text-muted-foreground">
+                    {service.description}
+                  </p>
+                )}
+              </div>
+
+              <div className="grid grid-cols-[1fr_1fr] gap-5">
+                <div className="rounded-xl border border-border bg-background/80 p-5">
+                  <span className="mb-4 block text-sm font-bold uppercase tracking-wider text-muted-foreground">Delivery path</span>
+                  <div className="space-y-3">
+                    {deliveryPath.map((item, index) => (
+                      <div key={item} className="flex items-start gap-3">
+                        <span className="flex h-8 w-8 flex-none items-center justify-center rounded-full bg-silicon-slate text-xs font-bold text-platinum-white dark:bg-radiant-gold dark:text-imperial-navy">
+                          {index + 1}
+                        </span>
+                        <span className="text-lg font-semibold leading-tight">{item}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+                <div className="rounded-xl border border-border bg-background/80 p-5">
+                  <span className="mb-4 block text-sm font-bold uppercase tracking-wider text-muted-foreground">Deliverables</span>
+                  <div className="space-y-3">
+                    {featuredDeliverables.map((item) => (
+                      <div key={item} className="flex items-start gap-3">
+                        <Check className="mt-1 h-5 w-5 flex-none text-radiant-gold" />
+                        <span className="text-lg font-semibold leading-tight">{item}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                {featuredTopics.map((topic) => (
+                  <span key={topic} className="rounded-full border border-border bg-background/80 px-4 py-2 text-sm font-bold text-muted-foreground">
+                    {topic}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+    )
+  }
 
   return (
     <div className="min-h-screen bg-black text-white">

--- a/app/store/[id]/page.tsx
+++ b/app/store/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import Image from 'next/image'
-import { useParams, useRouter } from 'next/navigation'
+import { useParams, useRouter, useSearchParams } from 'next/navigation'
 import { motion, AnimatePresence } from 'framer-motion'
 import {
   ShoppingCart,
@@ -57,7 +57,9 @@ const CATEGORY_LABELS: Record<string, string> = {
 export default function ProductDetailPage() {
   const params = useParams()
   const router = useRouter()
+  const searchParams = useSearchParams()
   const productId = params.id as string
+  const visualCapture = searchParams.get('visualCapture') === '1'
   const { getCampaignForBundle } = useCampaignEligibility()
 
   const [product, setProduct] = useState<Product | null>(null)
@@ -195,6 +197,109 @@ export default function ProductDetailPage() {
     { label: 'Store', href: '/store' },
     { label: String(product.title) },
   ]
+
+  if (visualCapture) {
+    const typeLabel = PRODUCT_TYPE_LABELS[product.type as keyof typeof PRODUCT_TYPE_LABELS] || product.type || 'Product'
+    const categoryLabel = product.category ? CATEGORY_LABELS[product.category] || product.category : 'Digital asset'
+    const priceLabel = product.price !== null ? formatCurrency(product.price) : 'Free'
+    const includedItems = deliverablesList.length > 0
+      ? deliverablesList.slice(0, 4)
+      : ['Ready-to-use asset', 'Implementation notes', 'Designed for operators']
+    const workflowItems = [
+      'Deploy the core asset',
+      'Adapt it to your workflow',
+      'Use the included guidance to move faster',
+    ]
+
+    return (
+      <main className="min-h-screen bg-background text-foreground flex items-center justify-center overflow-hidden p-10">
+        <section
+          data-visual-capture-frame
+          className="relative h-[720px] w-[1280px] overflow-hidden rounded-xl border border-border bg-card text-card-foreground shadow-2xl"
+        >
+          <div className="absolute inset-0 bg-[linear-gradient(135deg,rgba(212,175,55,0.18),transparent_38%,rgba(44,62,80,0.16))] dark:bg-[linear-gradient(135deg,rgba(212,175,55,0.24),transparent_42%,rgba(255,255,255,0.08))]" />
+          <div className="absolute inset-x-0 top-0 h-2 bg-radiant-gold" />
+          <div className="relative grid h-full grid-cols-[1.05fr_0.95fr] gap-8 p-12">
+            <div className="flex min-w-0 flex-col justify-between">
+              <div>
+                <div className="mb-8 flex flex-wrap items-center gap-3">
+                  <span className="rounded-full bg-radiant-gold px-4 py-2 text-sm font-bold uppercase tracking-wide text-imperial-navy">
+                    {typeLabel}
+                  </span>
+                  <span className="rounded-full border border-border bg-background/80 px-4 py-2 text-sm font-semibold text-muted-foreground">
+                    {categoryLabel}
+                  </span>
+                </div>
+                <h1 className="font-premium text-[64px] leading-[0.95] text-foreground">
+                  {product.title}
+                </h1>
+                {product.description && (
+                  <p className="mt-8 max-h-36 overflow-hidden text-2xl leading-snug text-muted-foreground">
+                    {product.description}
+                  </p>
+                )}
+              </div>
+
+              <div className="grid grid-cols-2 gap-4">
+                {includedItems.map((item) => (
+                  <div key={item} className="flex items-start gap-3 rounded-lg border border-border bg-background/80 p-4">
+                    <Check className="mt-1 h-5 w-5 flex-none text-radiant-gold" />
+                    <span className="text-lg font-medium leading-snug">{item}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="flex min-w-0 flex-col gap-5">
+              <div className="relative h-64 overflow-hidden rounded-xl border border-border bg-background">
+                {heroSrc ? (
+                  <Image
+                    src={heroSrc}
+                    alt={product.title}
+                    fill
+                    className="object-cover"
+                    sizes="520px"
+                    priority
+                  />
+                ) : (
+                  <div className="flex h-full flex-col items-center justify-center gap-4 bg-[radial-gradient(circle_at_30%_20%,rgba(212,175,55,0.28),transparent_32%),linear-gradient(135deg,rgba(18,30,49,0.12),rgba(212,175,55,0.18))] dark:bg-[radial-gradient(circle_at_30%_20%,rgba(212,175,55,0.28),transparent_32%),linear-gradient(135deg,rgba(234,236,238,0.1),rgba(212,175,55,0.16))]">
+                    <Package className="h-20 w-20 text-radiant-gold" />
+                    <span className="text-lg font-semibold text-muted-foreground">Product visual system</span>
+                  </div>
+                )}
+              </div>
+
+              <div className="rounded-xl border border-border bg-background/80 p-6">
+                <div className="mb-5 flex items-center justify-between">
+                  <span className="text-sm font-bold uppercase tracking-wider text-muted-foreground">Operator path</span>
+                  <span className="text-3xl font-bold text-radiant-gold">{priceLabel}</span>
+                </div>
+                <div className="space-y-4">
+                  {workflowItems.map((item, index) => (
+                    <div key={item} className="flex items-center gap-4">
+                      <span className="flex h-10 w-10 flex-none items-center justify-center rounded-full bg-silicon-slate text-sm font-bold text-platinum-white dark:bg-radiant-gold dark:text-imperial-navy">
+                        {index + 1}
+                      </span>
+                      <span className="text-xl font-semibold leading-tight">{item}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div className="mt-auto grid grid-cols-3 gap-3">
+                {['Reusable', 'Documented', 'Ready'].map((label) => (
+                  <div key={label} className="rounded-lg border border-radiant-gold/40 bg-radiant-gold/10 p-4 text-center">
+                    <Sparkles className="mx-auto mb-2 h-5 w-5 text-radiant-gold" />
+                    <span className="text-sm font-bold uppercase tracking-wide text-foreground">{label}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+    )
+  }
 
   return (
     <div className="dark agent-ops-page min-h-screen text-foreground">

--- a/lib/visual-assets.test.ts
+++ b/lib/visual-assets.test.ts
@@ -139,13 +139,13 @@ describe('visual asset helpers', () => {
       entityId: '1',
       title: 'Diagnostic Template',
       type: 'template',
-    })).toMatchObject({ route: '/tools/audit' })
+    })).toMatchObject({ route: '/store/1?visualCapture=1' })
 
     expect(resolveVisualAssetRoute({
       entityType: 'service',
       entityId: 'svc-1',
       title: 'AI Advisory',
-    })).toMatchObject({ route: '/services/svc-1' })
+    })).toMatchObject({ route: '/services/svc-1?visualCapture=1' })
   })
 
   it('scores blank light screenshots with deterministic reason codes', async () => {

--- a/lib/visual-assets.ts
+++ b/lib/visual-assets.ts
@@ -4,7 +4,6 @@ import path from 'path'
 import sharp from 'sharp'
 import { createAgentWorkItem } from '@/lib/agent-work-items'
 import { captureBroll, type RouteConfig } from '@/lib/playtest-broll'
-import { resolveStoreScreenshotRoute } from '@/lib/product-screenshot-routes'
 import { supabaseAdmin } from '@/lib/supabase'
 
 export const VISUAL_ASSET_ENTITY_TYPES = ['product', 'service', 'prototype'] as const
@@ -174,14 +173,15 @@ export function resolveVisualAssetRoute(entity: {
   serviceType?: string | null
 }) {
   if (entity.entityType === 'product') {
-    return resolveStoreScreenshotRoute({
-      title: entity.title,
-      type: entity.type ?? 'template',
-    })
+    return {
+      route: `/store/${encodeURIComponent(entity.entityId)}?visualCapture=1`,
+      requiresAdminAuth: false,
+      fullPage: false,
+    }
   }
   if (entity.entityType === 'service') {
     return {
-      route: `/services/${encodeURIComponent(entity.entityId)}`,
+      route: `/services/${encodeURIComponent(entity.entityId)}?visualCapture=1`,
       requiresAdminAuth: false,
       fullPage: false,
     }
@@ -209,7 +209,7 @@ export async function scoreImageBuffer(buffer: Buffer): Promise<VisualAssetScore
 
   let lightPixels = 0
   let darkPixels = 0
-  let blankPixels = 0
+  let extremePixels = 0
   let edgePixels = 0
   const luminance: number[] = []
   for (let i = 0; i < raw.length; i += 3) {
@@ -217,7 +217,7 @@ export async function scoreImageBuffer(buffer: Buffer): Promise<VisualAssetScore
     luminance.push(l)
     if (l > 0.82) lightPixels += 1
     if (l < 0.18) darkPixels += 1
-    if (l > 0.92 || l < 0.06) blankPixels += 1
+    if (l > 0.92 || l < 0.06) extremePixels += 1
   }
 
   for (let y = 1; y < sampleHeight; y += 1) {
@@ -232,10 +232,11 @@ export async function scoreImageBuffer(buffer: Buffer): Promise<VisualAssetScore
   }
 
   const pixelCount = sampleWidth * sampleHeight
-  const blankSpaceRatio = blankPixels / pixelCount
+  const rawExtremeSpaceRatio = extremePixels / pixelCount
   const lightPixelRatio = lightPixels / pixelCount
   const darkPixelRatio = darkPixels / pixelCount
   const edgeDensity = edgePixels / pixelCount
+  const blankSpaceRatio = Math.max(0, rawExtremeSpaceRatio - edgeDensity * 3)
   const reasonCodes: VisualAssetReasonCode[] = []
 
   if (width < MIN_WIDTH || height < MIN_HEIGHT) reasonCodes.push('low_resolution')
@@ -588,7 +589,8 @@ function toRouteConfig(candidate: VisualAssetCandidate): RouteConfig {
     fullPage: false,
     colorScheme: candidate.theme,
     viewport: { width: 1440, height: 900 },
-    waitForSelector: 'body',
+    waitForSelector: '[data-visual-capture-frame]',
+    screenshotSelector: '[data-visual-capture-frame]',
   }
 }
 
@@ -627,13 +629,12 @@ export async function captureVisualAssetCandidates(input: {
   let query = db(client)
     .from('visual_asset_candidates')
     .select('*')
-    .eq('status', 'proposed')
     .order('created_at', { ascending: true })
 
   if (input.candidateIds?.length) {
-    query = query.in('id', input.candidateIds)
+    query = query.in('id', input.candidateIds).in('status', ['proposed', 'failed'])
   } else {
-    query = query.is('candidate_url', null)
+    query = query.eq('status', 'proposed').is('candidate_url', null)
   }
 
   const { data, error } = await query
@@ -660,15 +661,15 @@ export async function captureVisualAssetCandidates(input: {
     if (!screenshotPath) {
       const failureScore = emptyScore('image_load_failure')
       const agentReview = reviewVisualAssetCandidateQuality(candidate, failureScore)
-      const reasonCodes = Array.from(new Set([...candidate.reason_codes, ...agentReview.reason_codes]))
       const { data: row, error: updateError } = await db(client)
         .from('visual_asset_candidates')
         .update({
           status: 'failed',
           score: failureScore.score,
-          reason_codes: reasonCodes,
+          reason_codes: agentReview.reason_codes,
           metadata: {
             ...asMetadata(candidate.metadata),
+            audit_reason_codes: candidate.reason_codes,
             agent_review: agentReview,
             capture_error: 'No screenshot was produced for this candidate.',
             captured_at: new Date().toISOString(),
@@ -685,7 +686,6 @@ export async function captureVisualAssetCandidates(input: {
     }
     const upload = await uploadCandidateImage({ candidate, filePath: screenshotPath, client })
     const agentReview = reviewVisualAssetCandidateQuality(candidate, upload.score)
-    const reasonCodes = Array.from(new Set([...candidate.reason_codes, ...agentReview.reason_codes]))
     const status: VisualAssetStatus = agentReview.decision === 'passed' ? 'proposed' : 'failed'
     const { data: row, error: updateError } = await db(client)
       .from('visual_asset_candidates')
@@ -694,9 +694,10 @@ export async function captureVisualAssetCandidates(input: {
         candidate_url: upload.publicUrl,
         candidate_storage_path: upload.storagePath,
         score: upload.score.score,
-        reason_codes: reasonCodes,
+        reason_codes: agentReview.reason_codes,
         metadata: {
           ...asMetadata(candidate.metadata),
+          audit_reason_codes: candidate.reason_codes,
           candidate_image_score: upload.score.metadata,
           agent_review: agentReview,
           captured_at: new Date().toISOString(),

--- a/scripts/capture-product-store-images.ts
+++ b/scripts/capture-product-store-images.ts
@@ -9,11 +9,11 @@
 
 import path from 'path'
 import * as dotenv from 'dotenv'
-import { auditVisualAssets, captureVisualAssetCandidates } from '@/lib/visual-assets'
 
 dotenv.config({ path: path.resolve(process.cwd(), '.env.local') })
 
 async function main() {
+  const { auditVisualAssets, captureVisualAssetCandidates } = await import('@/lib/visual-assets')
   console.warn(
     '[capture-product-store-images] Deprecated direct-update path replaced. ' +
       'Creating visual_asset_candidates and capturing screenshots only.',
@@ -29,6 +29,8 @@ async function main() {
     entitiesScanned: audit.entitiesScanned,
     candidatesCreated: audit.candidatesCreated,
     captured: capture.captured,
+    passed: capture.passed,
+    blocked: capture.blocked,
     workItemId: audit.workItemId,
   }, null, 2))
 }

--- a/scripts/visual-assets-apply-approved.ts
+++ b/scripts/visual-assets-apply-approved.ts
@@ -2,7 +2,6 @@
 
 import path from 'path'
 import * as dotenv from 'dotenv'
-import { applyApprovedVisualAssetCandidates } from '@/lib/visual-assets'
 
 dotenv.config({ path: path.resolve(process.cwd(), '.env.local') })
 
@@ -12,6 +11,7 @@ function candidateIds() {
 }
 
 async function main() {
+  const { applyApprovedVisualAssetCandidates } = await import('@/lib/visual-assets')
   const result = await applyApprovedVisualAssetCandidates({
     candidateIds: candidateIds(),
   })

--- a/scripts/visual-assets-audit.ts
+++ b/scripts/visual-assets-audit.ts
@@ -2,7 +2,6 @@
 
 import path from 'path'
 import * as dotenv from 'dotenv'
-import { auditVisualAssets } from '@/lib/visual-assets'
 
 dotenv.config({ path: path.resolve(process.cwd(), '.env.local') })
 
@@ -12,6 +11,7 @@ function argValue(name: string) {
 }
 
 async function main() {
+  const { auditVisualAssets } = await import('@/lib/visual-assets')
   const result = await auditVisualAssets({
     createWorkItem: !process.argv.includes('--no-work-item'),
     auditDate: argValue('date'),

--- a/scripts/visual-assets-capture.ts
+++ b/scripts/visual-assets-capture.ts
@@ -2,7 +2,6 @@
 
 import path from 'path'
 import * as dotenv from 'dotenv'
-import { captureVisualAssetCandidates } from '@/lib/visual-assets'
 
 dotenv.config({ path: path.resolve(process.cwd(), '.env.local') })
 
@@ -12,6 +11,7 @@ function candidateIds() {
 }
 
 async function main() {
+  const { captureVisualAssetCandidates } = await import('@/lib/visual-assets')
   const result = await captureVisualAssetCandidates({
     candidateIds: candidateIds(),
     noStartServer: process.argv.includes('--no-start-server'),
@@ -19,6 +19,8 @@ async function main() {
 
   console.log(JSON.stringify({
     captured: result.captured,
+    passed: result.passed,
+    blocked: result.blocked,
     candidateIds: result.candidates.map((candidate) => candidate.id),
   }, null, 2))
 }


### PR DESCRIPTION
## Summary
- Adds product/service-specific visual capture frames via `visualCapture=1` so candidates show the actual item instead of generic tool or service pages.
- Updates the visual asset capture pipeline to selector-crop the 16:9 frame, preserve original audit reasons in metadata, and expose only Idia candidate-review reasons on the candidate row.
- Fixes visual asset scripts so dotenv loads before Supabase-backed helper imports, and allows explicit candidate recapture for failed rows when the automated gate changes.

## Validation
- Rebased onto current `origin/main` on 2026-07-03; stale diff that would have removed newer Decision Trust/Open Brain work is gone.
- `npx vitest run lib/visual-assets.test.ts app/admin/content/visual-assets/page.test.tsx app/api/admin/visual-assets/route.test.ts` passed: 3 files, 20 tests.
- `npm run build` passed. Existing warnings: stale Browserslist data, existing `<img>` lint warnings, repeated n8n outbound env warnings.
- `git diff --check` passed.
- Push hook production database health check passed.
- Prior lane validation generated candidate data on local dev server `http://localhost:3042`: audit scanned 92 entities; capture produced 92 screenshots; Idia passed 85 candidates into proposed human review and blocked 7 light candidates before approval.
- Prior lane validation generated local contact sheets for visual sanity checks: `/tmp/portfolio-visual-assets-check/passed-dark-final-contact-sheet.png` and `/tmp/portfolio-visual-assets-check/passed-light-final-contact-sheet.png`.
- In-app Browser was previously opened to `/admin/content/visual-assets`, but authenticated page smoke remained blocked at login until a human signs into the local browser session.

## Integration Notes
- No schema migration in this PR.
- Candidate rows and Supabase Storage uploads were generated during validation; public product/service image fields were not applied.
- `Vercel – portfolio`: pending for rebased commit `812d472`.
- `Vercel – portfolio-staging`: not expected as a routine PR preview; verify both Vercel contexts after merge to `main`.