### PR TITLE
feat: surface decision trust enforcement posture

### DIFF
--- a/app/admin/agents/governance/page.test.tsx
+++ b/app/admin/agents/governance/page.test.tsx
@@ -153,6 +153,21 @@ const governance = {
       approval_type: 'payment_make_vendor_payment',
       reversibility: 'hard',
       occurred_at: '2026-05-13T12:00:00.000Z',
+      decision_trust_enforcement: {
+        mode: 'soft_gate',
+        gate: 'human_review',
+        may_proceed: false,
+        requires_approval: true,
+        should_block: false,
+        approval_type: 'payment_make_vendor_payment',
+        reason: 'Soft-gate mode requires human approval before this Decision Trust frame can produce a side effect.',
+        evidence: {
+          decision_id: 'decision-trust-1',
+          linked_run_id: 'trust-run',
+          selected_candidate: 'make_vendor_payment',
+          missing_evidence: ['Human approval decision'],
+        },
+      },
     },
   ],
   recent_governance_exports: [
@@ -205,7 +220,7 @@ describe('AgentGovernancePage', () => {
     expect(within(governancePanel).getByText('Create refund')).toBeInTheDocument()
     expect(within(governancePanel).getByText('No refund is issued until this payment authority checkpoint is approved and linked to a trace.')).toBeInTheDocument()
     expect(within(governancePanel).getByText(/Risk: high · Executes now: no/i)).toBeInTheDocument()
-    expect(within(governancePanel).getByText(/Enforcement: soft gate · human review · requires review/i)).toBeInTheDocument()
+    expect(within(governancePanel).getAllByText(/Enforcement: soft gate · human review · requires review/i).length).toBeGreaterThan(0)
     const decisionTrust = within(governancePanel).getByLabelText('Decision Trust')
     expect(within(decisionTrust).getByText('make_vendor_payment')).toBeInTheDocument()
     expect(within(decisionTrust).getByText(/spend · Create approval checkpoint for vendor payment/i)).toBeInTheDocument()
@@ -216,6 +231,7 @@ describe('AgentGovernancePage', () => {
     expect(within(decisionTrust).getByText('60%')).toBeInTheDocument()
     expect(within(decisionTrust).getByText(/Missing evidence: Human approval decision, Post-approval execution trace/i)).toBeInTheDocument()
     expect(within(decisionTrust).getByText(/Approval: payment_make_vendor_payment · Reversibility: hard/i)).toBeInTheDocument()
+    expect(within(decisionTrust).getByText(/Enforcement: soft gate · human review · requires review/i)).toBeInTheDocument()
     expect(within(decisionTrust).getByRole('link', { name: /Inspect in Open Brain/i })).toHaveAttribute('href', '/admin/agents/open-brain')
     expect(within(decisionTrust).getByRole('link', { name: /make_vendor_payment/i })).toHaveAttribute('href', '/admin/agents/runs/trust-run')
     expect(within(governancePanel).getByRole('link', { name: /Export client audit/i })).toHaveAttribute('href', '/api/admin/agents/governance/export?format=markdown')

--- a/app/admin/agents/governance/page.test.tsx
+++ b/app/admin/agents/governance/page.test.tsx
@@ -83,6 +83,21 @@ const governance = {
           side_effect_boundary: 'No refund is issued until this payment authority checkpoint is approved and linked to a trace.',
           executes_action: false,
         },
+        decision_trust_enforcement: {
+          mode: 'soft_gate',
+          gate: 'human_review',
+          may_proceed: false,
+          requires_approval: true,
+          should_block: false,
+          approval_type: 'payment_create_refund',
+          reason: 'Soft-gate mode requires human approval before this Decision Trust frame can produce a side effect.',
+          evidence: {
+            decision_id: 'decision-refund',
+            linked_run_id: 'payment-run',
+            selected_candidate: 'create_refund',
+            missing_evidence: ['Human approval decision'],
+          },
+        },
       },
     },
   ],
@@ -100,6 +115,21 @@ const governance = {
       approval_gate: 'payment_create_refund',
       fallback_agent_key: 'chief-of-staff',
       alternatives_considered: [],
+      decision_trust_enforcement: {
+        mode: 'advisory',
+        gate: 'human_review',
+        may_proceed: true,
+        requires_approval: false,
+        should_block: false,
+        approval_type: 'payment_create_refund',
+        reason: 'Advisory mode warns that this Decision Trust frame needs human review before side effects.',
+        evidence: {
+          decision_id: 'decision-delegation',
+          linked_run_id: 'delegation-run',
+          selected_candidate: 'automation-systems',
+          missing_evidence: [],
+        },
+      },
     },
   ],
   recent_decision_trust_frames: [
@@ -171,9 +201,11 @@ describe('AgentGovernancePage', () => {
     expect(within(governancePanel).getByText(/payment · 90% confidence/i)).toBeInTheDocument()
     expect(within(governancePanel).getByText(/Evidence: approval_record, payment_object, trace_id/i)).toBeInTheDocument()
     expect(within(governancePanel).getByText(/Approval: payment_create_refund · Fallback: chief-of-staff/i)).toBeInTheDocument()
+    expect(within(governancePanel).getByText(/Enforcement: advisory · human review · may proceed/i)).toBeInTheDocument()
     expect(within(governancePanel).getByText('Create refund')).toBeInTheDocument()
     expect(within(governancePanel).getByText('No refund is issued until this payment authority checkpoint is approved and linked to a trace.')).toBeInTheDocument()
     expect(within(governancePanel).getByText(/Risk: high · Executes now: no/i)).toBeInTheDocument()
+    expect(within(governancePanel).getByText(/Enforcement: soft gate · human review · requires review/i)).toBeInTheDocument()
     const decisionTrust = within(governancePanel).getByLabelText('Decision Trust')
     expect(within(decisionTrust).getByText('make_vendor_payment')).toBeInTheDocument()
     expect(within(decisionTrust).getByText(/spend · Create approval checkpoint for vendor payment/i)).toBeInTheDocument()

--- a/app/admin/agents/open-brain/page.test.tsx
+++ b/app/admin/agents/open-brain/page.test.tsx
@@ -540,6 +540,14 @@ describe('OpenBrainPage', () => {
       path: '/admin/agents/runs/run-trust',
       health: 'yellow',
       decisionTrustGate: 'human_review',
+      decisionTrustEnforcement: {
+        mode: 'soft_gate',
+        gate: 'human_review',
+        mayProceed: false,
+        requiresApproval: true,
+        shouldBlock: false,
+        reason: 'Soft-gate mode requires human approval before this Decision Trust frame can produce a side effect.',
+      },
       x: 28,
       y: 82,
     })
@@ -592,6 +600,8 @@ describe('OpenBrainPage', () => {
     const map = await screen.findByRole('region', { name: 'Open Brain relationship map' })
     expect(within(map).getAllByText('Review decision trust: make_vendor_payment').length).toBeGreaterThan(0)
     expect(within(map).getByText('human review')).toBeInTheDocument()
+    fireEvent.click(within(map).getByRole('button', { name: 'Select Decision trust: make_vendor_payment' }))
+    expect(within(map).getByText('Decision trust enforcement: soft gate · human review · requires approval')).toBeInTheDocument()
 
     fireEvent.click(within(map).getByRole('button', { name: 'Human/block gate 1' }))
     expect(within(map).getByText('1 active filter(s)')).toBeInTheDocument()

--- a/app/admin/agents/open-brain/page.tsx
+++ b/app/admin/agents/open-brain/page.tsx
@@ -1122,6 +1122,11 @@ function SelectedRelationshipRecordPanel({
           Decision trust gate: {node.decisionTrustGate.replace(/_/g, ' ')}
         </p>
       ) : null}
+      {node.decisionTrustEnforcement ? (
+        <p className="mt-3 rounded-lg border border-radiant-gold/25 bg-radiant-gold/10 p-3 text-xs text-radiant-gold">
+          Decision trust enforcement: {formatDecisionTrustEnforcement(node.decisionTrustEnforcement)}
+        </p>
+      ) : null}
 
       <div className="mt-4">
         <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Connected relationships</p>
@@ -1269,6 +1274,19 @@ function decisionTrustCount(nodes: OpenBrainSnapshot['relationshipMap']['nodes']
   if (value === 'decision_trust') return nodes.filter((node) => node.kind === 'agent_decision_trust_observed').length
   if (value === 'high_risk_gate') return nodes.filter((node) => node.decisionTrustGate === 'human_review' || node.decisionTrustGate === 'block').length
   return nodes.length
+}
+
+function formatDecisionTrustEnforcement(
+  enforcement: NonNullable<OpenBrainSnapshot['relationshipMap']['nodes'][number]['decisionTrustEnforcement']>,
+) {
+  const decision = enforcement.shouldBlock
+    ? 'blocks'
+    : enforcement.requiresApproval
+      ? 'requires approval'
+      : enforcement.mayProceed
+        ? 'may proceed'
+        : 'holds'
+  return `${enforcement.mode.replace(/_/g, ' ')} · ${enforcement.gate.replace(/_/g, ' ')} · ${decision}`
 }
 
 function strongestPrivacyTier(tiers: Array<OpenBrainPrivacyTier | undefined>): OpenBrainPrivacyTier {

--- a/components/admin/agents/AgentGovernancePanel.tsx
+++ b/components/admin/agents/AgentGovernancePanel.tsx
@@ -82,6 +82,7 @@ export type AgentGovernanceSnapshot = {
     approval_type: string | null
     reversibility: string
     occurred_at: string
+    decision_trust_enforcement: DecisionTrustEnforcementSummary | null
   }>
   recent_governance_exports: Array<{
     id: string
@@ -345,6 +346,11 @@ function DecisionTrustPanel({ frames }: { frames: AgentGovernanceSnapshot['recen
           {latest.approval_type ? (
             <p className="mt-1 text-xs leading-5 text-muted-foreground">
               Approval: {latest.approval_type} · Reversibility: {latest.reversibility}
+            </p>
+          ) : null}
+          {latest.decision_trust_enforcement ? (
+            <p className="mt-1 text-xs leading-5 text-muted-foreground">
+              Enforcement: {formatEnforcementPosture(latest.decision_trust_enforcement)}
             </p>
           ) : null}
         </Link>

--- a/components/admin/agents/AgentGovernancePanel.tsx
+++ b/components/admin/agents/AgentGovernancePanel.tsx
@@ -60,6 +60,7 @@ export type AgentGovernanceSnapshot = {
     approval_gate: string | null
     fallback_agent_key: string | null
     alternatives_considered: string[]
+    decision_trust_enforcement: DecisionTrustEnforcementSummary | null
   }>
   recent_decision_trust_frames: Array<{
     run_id: string
@@ -98,6 +99,22 @@ export type AgentGovernanceSnapshot = {
   }>
 }
 
+type DecisionTrustEnforcementSummary = {
+  mode: 'shadow' | 'advisory' | 'soft_gate' | 'hard_block'
+  gate: 'allow' | 'sandbox' | 'human_review' | 'block'
+  may_proceed: boolean
+  requires_approval: boolean
+  should_block: boolean
+  approval_type: string | null
+  reason: string
+  evidence: {
+    decision_id: string | null
+    linked_run_id: string | null
+    selected_candidate: string | null
+    missing_evidence: string[]
+  }
+}
+
 export function AgentGovernancePanel({ governance }: { governance: AgentGovernanceSnapshot | null }) {
   if (!governance) return null
 
@@ -106,6 +123,7 @@ export function AgentGovernancePanel({ governance }: { governance: AgentGovernan
   const latestPaymentAction = governance.payment_authority_actions[0]
   const pendingAuthority = governance.pending_authority_approvals[0]
   const pendingAuthorityPacket = authorityPacket(pendingAuthority?.metadata)
+  const pendingAuthorityEnforcement = decisionTrustEnforcement(pendingAuthority?.metadata)
   const statusTone = governance.summary.pending_authority_approvals > 0
     ? 'yellow'
     : governance.summary.least_privilege_attention > 0
@@ -226,6 +244,11 @@ export function AgentGovernancePanel({ governance }: { governance: AgentGovernan
                 {latestDelegation.fallback_agent_key ? `Fallback: ${latestDelegation.fallback_agent_key}` : 'Fallback: none'}
               </p>
             ) : null}
+            {latestDelegation?.decision_trust_enforcement ? (
+              <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                Enforcement: {formatEnforcementPosture(latestDelegation.decision_trust_enforcement)}
+              </p>
+            ) : null}
           </Link>
 
           <Link
@@ -247,6 +270,11 @@ export function AgentGovernancePanel({ governance }: { governance: AgentGovernan
                 {pendingAuthorityPacket?.risk_level ? `Risk: ${pendingAuthorityPacket.risk_level}` : `Approval: ${pendingAuthority.approval_type}`}
                 {' · '}
                 {pendingAuthorityPacket?.executes_action ? 'Executes now: yes' : 'Executes now: no'}
+              </p>
+            ) : null}
+            {pendingAuthorityEnforcement ? (
+              <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                Enforcement: {formatEnforcementPosture(pendingAuthorityEnforcement)}
               </p>
             ) : null}
           </Link>
@@ -339,6 +367,39 @@ function authorityPacket(metadata: Record<string, unknown> | null | undefined) {
     side_effect_boundary: typeof record.side_effect_boundary === 'string' ? record.side_effect_boundary : null,
     executes_action: record.executes_action === true,
   }
+}
+
+function decisionTrustEnforcement(metadata: Record<string, unknown> | null | undefined): DecisionTrustEnforcementSummary | null {
+  const value = metadata?.decision_trust_enforcement
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const record = value as Partial<DecisionTrustEnforcementSummary>
+  if (!record.mode || !record.gate || typeof record.reason !== 'string') return null
+  return {
+    mode: record.mode,
+    gate: record.gate,
+    may_proceed: record.may_proceed === true,
+    requires_approval: record.requires_approval === true,
+    should_block: record.should_block === true,
+    approval_type: typeof record.approval_type === 'string' ? record.approval_type : null,
+    reason: record.reason,
+    evidence: {
+      decision_id: record.evidence?.decision_id ?? null,
+      linked_run_id: record.evidence?.linked_run_id ?? null,
+      selected_candidate: record.evidence?.selected_candidate ?? null,
+      missing_evidence: Array.isArray(record.evidence?.missing_evidence) ? record.evidence.missing_evidence : [],
+    },
+  }
+}
+
+function formatEnforcementPosture(enforcement: DecisionTrustEnforcementSummary) {
+  const decision = enforcement.should_block
+    ? 'blocks'
+    : enforcement.requires_approval
+      ? 'requires review'
+      : enforcement.may_proceed
+        ? 'may proceed'
+        : 'holds'
+  return `${enforcement.mode.replace(/_/g, ' ')} · ${enforcement.gate.replace(/_/g, ' ')} · ${decision}`
 }
 
 function GovernanceExportLedger({ exports }: { exports: AgentGovernanceSnapshot['recent_governance_exports'] }) {

--- a/lib/agent-governance-export.test.ts
+++ b/lib/agent-governance-export.test.ts
@@ -74,6 +74,15 @@ const governance = {
           side_effect_boundary: 'No refund is issued until this payment authority checkpoint is approved and linked to a trace.',
           executes_action: false,
         },
+        decision_trust_enforcement: {
+          mode: 'soft_gate',
+          gate: 'human_review',
+          may_proceed: false,
+          requires_approval: true,
+          should_block: false,
+          approval_type: 'payment_create_refund',
+          reason: 'Soft-gate mode requires human approval before this Decision Trust frame can produce a side effect.',
+        },
       },
     },
   ],
@@ -91,6 +100,21 @@ const governance = {
       approval_gate: 'payment_create_refund',
       fallback_agent_key: 'chief-of-staff',
       alternatives_considered: ['chief-of-staff'],
+      decision_trust_enforcement: {
+        mode: 'advisory',
+        gate: 'human_review',
+        may_proceed: true,
+        requires_approval: false,
+        should_block: false,
+        approval_type: 'payment_create_refund',
+        reason: 'Advisory mode warns that this Decision Trust frame needs human review before side effects.',
+        evidence: {
+          decision_id: 'decision-delegation',
+          linked_run_id: 'run-delegation',
+          selected_candidate: 'automation-systems',
+          missing_evidence: [],
+        },
+      },
     },
   ],
   recent_decision_trust_frames: [],
@@ -122,6 +146,18 @@ describe('agent governance client export', () => {
       required_evidence: ['approval_record', 'payment_object', 'trace_id'],
       approval_gate: 'payment_create_refund',
       fallback_agent: 'chief-of-staff',
+      decision_trust_enforcement: {
+        mode: 'advisory',
+        gate: 'human_review',
+        may_proceed: true,
+      },
+    })
+    expect(clientExport.authority_controls.pending_authority_checkpoints[0]).toMatchObject({
+      decision_trust_enforcement: {
+        mode: 'soft_gate',
+        gate: 'human_review',
+        requires_approval: true,
+      },
     })
     expect(JSON.stringify(clientExport)).not.toContain('selected_agent_key')
     expect(clientExport.audit_boundaries.join(' ')).toContain('excludes raw prompts')
@@ -135,8 +171,8 @@ describe('agent governance client export', () => {
     expect(markdown).toContain('- Run ID: All visible governance runs')
     expect(markdown).toContain('## Capability Inventory')
     expect(markdown).toContain('| Yaa Asantewaa (Ashanti) - Automation Systems | active | n8n | yellow | approval_required | known_workflow |')
-    expect(markdown).toContain('| run-delegation | Yaa Asantewaa (Ashanti) - Automation Systems | payment | payment_spend | 90% | approval_record, payment_object, trace_id | payment_create_refund | chief-of-staff |')
-    expect(markdown).toContain('| approval-payment | run-payment | Create refund | payment_create_refund | high | No | run-source | No refund is issued until this payment authority checkpoint is approved and linked to a trace. |')
+    expect(markdown).toContain('| run-delegation | Yaa Asantewaa (Ashanti) - Automation Systems | payment | payment_spend | 90% | approval_record, payment_object, trace_id | payment_create_refund | chief-of-staff | advisory / human review / may proceed |')
+    expect(markdown).toContain('| approval-payment | run-payment | Create refund | payment_create_refund | high | No | run-source | No refund is issued until this payment authority checkpoint is approved and linked to a trace. | soft gate / human review / requires review |')
     expect(markdown).toContain('Payment and paid-job actions are represented as approval gates')
   })
 

--- a/lib/agent-governance-export.ts
+++ b/lib/agent-governance-export.ts
@@ -1,6 +1,16 @@
 import type { AgentGovernanceSnapshot } from '@/lib/agent-governance'
 import type { AgentGovernanceExportScope } from '@/lib/agent-governance-scope'
 
+type ClientSafeDecisionTrustEnforcement = {
+  mode: string
+  gate: string
+  may_proceed: boolean
+  requires_approval: boolean
+  should_block: boolean
+  approval_type: string | null
+  reason: string
+}
+
 export type AgentGovernanceClientExport = {
   export_type: 'agent_governance_client_audit'
   generated_at: string
@@ -46,6 +56,7 @@ export type AgentGovernanceClientExport = {
     approval_gate: string | null
     fallback_agent: string | null
     alternatives_considered: string[]
+    decision_trust_enforcement: ClientSafeDecisionTrustEnforcement | null
   }>
   authority_controls: {
     payment_gates: Array<{
@@ -66,6 +77,7 @@ export type AgentGovernanceClientExport = {
       source_run_id: string | null
       side_effect_boundary: string | null
       executes_action: boolean
+      decision_trust_enforcement: ClientSafeDecisionTrustEnforcement | null
     }>
   }
   audit_boundaries: string[]
@@ -90,6 +102,42 @@ function recordValue(record: Record<string, unknown> | null | undefined, key: st
 function authorityPacket(metadata: Record<string, unknown> | null | undefined) {
   const value = metadata?.authority_packet
   return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null
+}
+
+function enforcementPacket(metadata: Record<string, unknown> | null | undefined) {
+  const value = metadata?.decision_trust_enforcement
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null
+}
+
+function clientSafeEnforcement(value: AgentGovernanceSnapshot['recent_delegation_decisions'][number]['decision_trust_enforcement'] | null | undefined): ClientSafeDecisionTrustEnforcement | null {
+  if (!value) return null
+  return {
+    mode: value.mode,
+    gate: value.gate,
+    may_proceed: value.may_proceed,
+    requires_approval: value.requires_approval,
+    should_block: value.should_block,
+    approval_type: value.approval_type,
+    reason: value.reason,
+  }
+}
+
+function clientSafeMetadataEnforcement(metadata: Record<string, unknown> | null | undefined): ClientSafeDecisionTrustEnforcement | null {
+  const packet = enforcementPacket(metadata)
+  if (!packet) return null
+  const mode = recordValue(packet, 'mode')
+  const gate = recordValue(packet, 'gate')
+  const reason = recordValue(packet, 'reason')
+  if (!mode || !gate || !reason) return null
+  return {
+    mode,
+    gate,
+    may_proceed: packet.may_proceed === true,
+    requires_approval: packet.requires_approval === true,
+    should_block: packet.should_block === true,
+    approval_type: recordValue(packet, 'approval_type'),
+    reason,
+  }
 }
 
 export function buildAgentGovernanceClientExport(
@@ -141,6 +189,7 @@ export function buildAgentGovernanceClientExport(
       approval_gate: decision.approval_gate,
       fallback_agent: decision.fallback_agent_key,
       alternatives_considered: decision.alternatives_considered,
+      decision_trust_enforcement: clientSafeEnforcement(decision.decision_trust_enforcement),
     })),
     authority_controls: {
       payment_gates: governance.payment_authority_actions.map((gate) => ({
@@ -161,6 +210,7 @@ export function buildAgentGovernanceClientExport(
         source_run_id: recordValue(authorityPacket(approval.metadata), 'source_run_id'),
         side_effect_boundary: recordValue(authorityPacket(approval.metadata), 'side_effect_boundary'),
         executes_action: authorityPacket(approval.metadata)?.executes_action === true,
+        decision_trust_enforcement: clientSafeMetadataEnforcement(approval.metadata),
       })),
     },
     audit_boundaries: AUDIT_BOUNDARIES,
@@ -179,9 +229,9 @@ export function formatAgentGovernanceClientMarkdown(clientExport: AgentGovernanc
 
   const delegationRows = clientExport.delegation_trace.length
     ? clientExport.delegation_trace.map((decision) =>
-        `| ${decision.trace_reference} | ${decision.selected_agent} | ${decision.task_type} | ${decision.risk_class} | ${decision.confidence} | ${decision.required_evidence.length ? decision.required_evidence.join(', ') : 'None recorded'} | ${decision.approval_gate ?? 'None'} | ${decision.fallback_agent ?? 'None'} |`,
+        `| ${decision.trace_reference} | ${decision.selected_agent} | ${decision.task_type} | ${decision.risk_class} | ${decision.confidence} | ${decision.required_evidence.length ? decision.required_evidence.join(', ') : 'None recorded'} | ${decision.approval_gate ?? 'None'} | ${decision.fallback_agent ?? 'None'} | ${formatClientSafeEnforcement(decision.decision_trust_enforcement)} |`,
       )
-    : ['| No recent delegation decisions recorded. | - | - | - | - | - | - | - |']
+    : ['| No recent delegation decisions recorded. | - | - | - | - | - | - | - | - |']
 
   const paymentRows = clientExport.authority_controls.payment_gates.map((gate) =>
     `| ${gate.label} | ${gate.approval_type} | ${gate.description} |`,
@@ -189,9 +239,9 @@ export function formatAgentGovernanceClientMarkdown(clientExport: AgentGovernanc
 
   const pendingRows = clientExport.authority_controls.pending_authority_checkpoints.length
     ? clientExport.authority_controls.pending_authority_checkpoints.map((approval) =>
-        `| ${approval.approval_id ?? 'None'} | ${approval.trace_reference} | ${approval.label} | ${approval.approval_type} | ${approval.risk_level ?? 'Not recorded'} | ${approval.executes_action ? 'Yes' : 'No'} | ${approval.source_run_id ?? 'None'} | ${approval.side_effect_boundary ?? 'Not recorded'} |`,
+        `| ${approval.approval_id ?? 'None'} | ${approval.trace_reference} | ${approval.label} | ${approval.approval_type} | ${approval.risk_level ?? 'Not recorded'} | ${approval.executes_action ? 'Yes' : 'No'} | ${approval.source_run_id ?? 'None'} | ${approval.side_effect_boundary ?? 'Not recorded'} | ${formatClientSafeEnforcement(approval.decision_trust_enforcement)} |`,
       )
-    : ['| No pending authority checkpoints. | - | - | - | - | - | - | - |']
+    : ['| No pending authority checkpoints. | - | - | - | - | - | - | - | - |']
 
   return [
     `# ${clientExport.title}`,
@@ -230,8 +280,8 @@ export function formatAgentGovernanceClientMarkdown(clientExport: AgentGovernanc
     '',
     '## Delegation Trace',
     '',
-    '| Trace | Selected Agent | Task | Risk | Confidence | Required Evidence | Approval Gate | Fallback |',
-    '| --- | --- | --- | --- | --- | --- | --- | --- |',
+    '| Trace | Selected Agent | Task | Risk | Confidence | Required Evidence | Approval Gate | Fallback | Decision Trust Enforcement |',
+    '| --- | --- | --- | --- | --- | --- | --- | --- | --- |',
     ...delegationRows,
     '',
     '## Payment And Spend Authority',
@@ -242,8 +292,8 @@ export function formatAgentGovernanceClientMarkdown(clientExport: AgentGovernanc
     '',
     '## Pending Authority Checkpoints',
     '',
-    '| Approval | Trace | Label | Approval Type | Risk | Executes Now | Source Run | Boundary |',
-    '| --- | --- | --- | --- | --- | --- | --- | --- |',
+    '| Approval | Trace | Label | Approval Type | Risk | Executes Now | Source Run | Boundary | Decision Trust Enforcement |',
+    '| --- | --- | --- | --- | --- | --- | --- | --- | --- |',
     ...pendingRows,
     '',
     '## Audit Boundaries',
@@ -251,4 +301,16 @@ export function formatAgentGovernanceClientMarkdown(clientExport: AgentGovernanc
     list(clientExport.audit_boundaries),
     '',
   ].join('\n')
+}
+
+function formatClientSafeEnforcement(enforcement: ClientSafeDecisionTrustEnforcement | null) {
+  if (!enforcement) return 'Not recorded'
+  const decision = enforcement.should_block
+    ? 'blocks'
+    : enforcement.requires_approval
+      ? 'requires review'
+      : enforcement.may_proceed
+        ? 'may proceed'
+        : 'holds'
+  return `${enforcement.mode.replace(/_/g, ' ')} / ${enforcement.gate.replace(/_/g, ' ')} / ${decision}`
 }

--- a/lib/agent-governance.test.ts
+++ b/lib/agent-governance.test.ts
@@ -37,6 +37,21 @@ describe('agent governance', () => {
               side_effect_boundary: 'No refund is issued until this payment authority checkpoint is approved and linked to a trace.',
               executes_action: false,
             },
+            decision_trust_enforcement: {
+              mode: 'soft_gate',
+              gate: 'human_review',
+              mayProceed: false,
+              requiresApproval: true,
+              shouldBlock: false,
+              approvalType: 'payment_create_refund',
+              reason: 'Soft-gate mode requires human approval before this Decision Trust frame can produce a side effect.',
+              evidence: {
+                decisionId: 'decision-refund',
+                linkedRunId: 'run-source',
+                selectedCandidate: 'create_refund',
+                missingEvidence: ['Human approval decision', 'private chat export payment notes'],
+              },
+            },
           },
         },
       ],
@@ -57,6 +72,21 @@ describe('agent governance', () => {
             approval_gate: 'payment_create_refund',
             fallback_agent_key: 'chief-of-staff',
             alternatives_considered: ['chief-of-staff'],
+            decision_trust_enforcement: {
+              mode: 'advisory',
+              gate: 'human_review',
+              mayProceed: true,
+              requiresApproval: false,
+              shouldBlock: false,
+              approvalType: 'payment_create_refund',
+              reason: 'Advisory mode warns that this Decision Trust frame needs human review before side effects.',
+              evidence: {
+                decisionId: 'decision-delegation',
+                linkedRunId: 'run-shaka',
+                selectedCandidate: 'automation-systems',
+                missingEvidence: ['private message export routing detail'],
+              },
+            },
           },
         },
         {
@@ -126,6 +156,15 @@ describe('agent governance', () => {
       risk_level: 'high',
       executes_action: false,
     })
+    expect(snapshot.pending_authority_approvals[0]?.metadata?.decision_trust_enforcement).toMatchObject({
+      mode: 'soft_gate',
+      gate: 'human_review',
+      requires_approval: true,
+      approval_type: 'payment_create_refund',
+      evidence: {
+        missing_evidence: ['Human approval decision', 'private source summary'],
+      },
+    })
     expect(snapshot.recent_delegation_decisions[0]).toMatchObject({
       selected_agent_key: 'automation-systems',
       task_type: 'payment',
@@ -134,6 +173,17 @@ describe('agent governance', () => {
       approval_gate: 'payment_create_refund',
       fallback_agent_key: 'chief-of-staff',
       alternatives_considered: ['chief-of-staff'],
+      decision_trust_enforcement: {
+        mode: 'advisory',
+        gate: 'human_review',
+        may_proceed: true,
+        requires_approval: false,
+        should_block: false,
+        approval_type: 'payment_create_refund',
+        evidence: {
+          missing_evidence: ['private source summary'],
+        },
+      },
     })
     expect(snapshot.recent_decision_trust_frames).toHaveLength(1)
     expect(snapshot.recent_decision_trust_frames[0]).toMatchObject({

--- a/lib/agent-governance.test.ts
+++ b/lib/agent-governance.test.ts
@@ -113,6 +113,21 @@ describe('agent governance', () => {
             recommended_gate: 'human_review',
             approval_type: 'payment_make_vendor_payment',
             reversibility: 'hard',
+            decision_trust_enforcement: {
+              mode: 'soft_gate',
+              gate: 'human_review',
+              mayProceed: false,
+              requiresApproval: true,
+              shouldBlock: false,
+              approvalType: 'payment_make_vendor_payment',
+              reason: 'Soft-gate mode requires human approval before this Decision Trust frame can produce a side effect.',
+              evidence: {
+                decisionId: 'decision-payment',
+                linkedRunId: 'run-trust',
+                selectedCandidate: 'make_vendor_payment',
+                missingEvidence: ['Human approval decision', 'private message export detail'],
+              },
+            },
           },
         },
         {
@@ -194,6 +209,17 @@ describe('agent governance', () => {
       selected_candidate: 'make_vendor_payment',
       recommended_gate: 'human_review',
       approval_type: 'payment_make_vendor_payment',
+      decision_trust_enforcement: {
+        mode: 'soft_gate',
+        gate: 'human_review',
+        may_proceed: false,
+        requires_approval: true,
+        should_block: false,
+        approval_type: 'payment_make_vendor_payment',
+        evidence: {
+          missing_evidence: ['Human approval decision', 'private source summary'],
+        },
+      },
     })
     expect(snapshot.recent_decision_trust_frames[0]?.missing_evidence.join(' ')).toContain('private source summary')
     expect(snapshot.recent_decision_trust_frames[0]?.missing_evidence.join(' ')).not.toContain('private chat export')

--- a/lib/agent-governance.ts
+++ b/lib/agent-governance.ts
@@ -130,6 +130,7 @@ export type AgentGovernanceSnapshot = {
     approval_type: string | null
     reversibility: string
     occurred_at: string
+    decision_trust_enforcement: DecisionTrustEnforcementSummary | null
   }>
   recent_governance_exports: GovernanceExportSummary[]
 }
@@ -432,6 +433,7 @@ export function parseDecisionTrustFrames(
         approval_type: safeMetadataString(metadata, 'approval_type'),
         reversibility: safeMetadataString(metadata, 'reversibility') ?? 'unknown',
         occurred_at: event.occurred_at,
+        decision_trust_enforcement: decisionTrustEnforcementSummary(metadata?.decision_trust_enforcement),
       }]
     })
     .slice(0, limit)

--- a/lib/agent-governance.ts
+++ b/lib/agent-governance.ts
@@ -65,6 +65,22 @@ export type GovernanceExportSummary = {
   created_at: string
 }
 
+export type DecisionTrustEnforcementSummary = {
+  mode: 'shadow' | 'advisory' | 'soft_gate' | 'hard_block'
+  gate: DecisionTrustGate
+  may_proceed: boolean
+  requires_approval: boolean
+  should_block: boolean
+  approval_type: string | null
+  reason: string
+  evidence: {
+    decision_id: string | null
+    linked_run_id: string | null
+    selected_candidate: string | null
+    missing_evidence: string[]
+  }
+}
+
 export type AgentGovernanceSnapshot = {
   generated_at: string
   summary: {
@@ -96,6 +112,7 @@ export type AgentGovernanceSnapshot = {
     approval_gate: string | null
     fallback_agent_key: string | null
     alternatives_considered: string[]
+    decision_trust_enforcement: DecisionTrustEnforcementSummary | null
   }>
   recent_decision_trust_frames: Array<{
     run_id: string
@@ -290,6 +307,7 @@ function authorityApprovalSummary(approval: GovernanceApprovalSummary): Governan
         side_effect_boundary: metadataString(actionPayload, 'side_effect_boundary'),
         executes_action: actionPayload?.executes_action === true,
       },
+      decision_trust_enforcement: decisionTrustEnforcementSummary(metadata?.decision_trust_enforcement),
     },
   }
 }
@@ -316,6 +334,7 @@ function recentDelegationDecisions(events: GovernanceEventSummary[]): AgentGover
         approval_gate: metadataString(metadata, 'approval_gate'),
         fallback_agent_key: metadataString(metadata, 'fallback_agent_key'),
         alternatives_considered: metadataStringArray(metadata, 'alternatives_considered'),
+        decision_trust_enforcement: decisionTrustEnforcementSummary(metadata?.decision_trust_enforcement),
       }]
     })
     .slice(0, 5)
@@ -344,6 +363,39 @@ function isDecisionType(value: string | null): value is AgentDecisionType {
 
 function isDecisionTrustGate(value: string | null): value is DecisionTrustGate {
   return value === 'allow' || value === 'sandbox' || value === 'human_review' || value === 'block'
+}
+
+function isDecisionTrustEnforcementMode(value: string | null): value is DecisionTrustEnforcementSummary['mode'] {
+  return value === 'shadow' || value === 'advisory' || value === 'soft_gate' || value === 'hard_block'
+}
+
+function metadataBoolean(record: Record<string, unknown> | null, key: string) {
+  return record?.[key] === true
+}
+
+function decisionTrustEnforcementSummary(value: unknown): DecisionTrustEnforcementSummary | null {
+  const record = metadataRecord(value)
+  if (!record) return null
+  const evidence = metadataRecord(record.evidence)
+  const mode = safeMetadataString(record, 'mode')
+  const gate = safeMetadataString(record, 'gate')
+  if (!isDecisionTrustEnforcementMode(mode) || !isDecisionTrustGate(gate)) return null
+
+  return {
+    mode,
+    gate,
+    may_proceed: metadataBoolean(record, 'mayProceed'),
+    requires_approval: metadataBoolean(record, 'requiresApproval'),
+    should_block: metadataBoolean(record, 'shouldBlock'),
+    approval_type: safeMetadataString(record, 'approvalType'),
+    reason: safeMetadataString(record, 'reason') ?? 'Decision Trust enforcement posture recorded.',
+    evidence: {
+      decision_id: safeMetadataString(evidence, 'decisionId'),
+      linked_run_id: safeMetadataString(evidence, 'linkedRunId'),
+      selected_candidate: safeMetadataString(evidence, 'selectedCandidate'),
+      missing_evidence: metadataSafeStringArray(evidence, 'missingEvidence'),
+    },
+  }
 }
 
 export function parseDecisionTrustFrames(

--- a/lib/decision-trust-open-brain.test.ts
+++ b/lib/decision-trust-open-brain.test.ts
@@ -30,6 +30,7 @@ function frame(overrides: Partial<DecisionTrustOpenBrainFrame> = {}): DecisionTr
     approval_type: null,
     reversibility: 'easy',
     occurred_at: generatedAt,
+    decision_trust_enforcement: null,
     ...overrides,
   }
 }
@@ -85,6 +86,41 @@ describe('decision trust Open Brain projection', () => {
         status: 'inferred',
       }),
     ])
+  })
+
+  it('preserves sanitized enforcement posture on projected decision trust events', () => {
+    const projection = buildDecisionTrustOpenBrainProjection([
+      frame({
+        recommended_gate: 'human_review',
+        decision_trust_enforcement: {
+          mode: 'soft_gate',
+          gate: 'human_review',
+          may_proceed: false,
+          requires_approval: true,
+          should_block: false,
+          approval_type: 'payment_make_vendor_payment',
+          reason: 'Soft-gate mode requires human approval before this Decision Trust frame can produce a side effect.',
+          evidence: {
+            decision_id: 'decision-trust-1',
+            linked_run_id: 'run-trust-1',
+            selected_candidate: 'source:official-docs',
+            missing_evidence: ['Human approval decision'],
+          },
+        },
+      }),
+    ], { generatedAt })
+
+    expect(projection.events[0]?.metadata).toEqual(expect.objectContaining({
+      decisionTrustEnforcement: expect.objectContaining({
+        mode: 'soft_gate',
+        gate: 'human_review',
+        may_proceed: false,
+        requires_approval: true,
+        should_block: false,
+        approval_type: 'payment_make_vendor_payment',
+        reason: expect.stringContaining('Soft-gate mode'),
+      }),
+    }))
   })
 
   it('creates a review insight for a human-review frame', () => {

--- a/lib/decision-trust-open-brain.ts
+++ b/lib/decision-trust-open-brain.ts
@@ -263,6 +263,19 @@ function decisionTrustEvent(frame: DecisionTrustOpenBrainFrame): OpenBrainEventR
         missing_evidence: frame.missing_evidence.map((item) => sanitizeDecisionTrustText(item, 160)).slice(0, 6),
         evidence_summary: evidenceSummary(frame),
       },
+      ...(frame.decision_trust_enforcement ? {
+        decisionTrustEnforcement: {
+          mode: frame.decision_trust_enforcement.mode,
+          gate: frame.decision_trust_enforcement.gate,
+          may_proceed: frame.decision_trust_enforcement.may_proceed,
+          requires_approval: frame.decision_trust_enforcement.requires_approval,
+          should_block: frame.decision_trust_enforcement.should_block,
+          approval_type: frame.decision_trust_enforcement.approval_type
+            ? sanitizeDecisionTrustText(frame.decision_trust_enforcement.approval_type, 140)
+            : null,
+          reason: sanitizeDecisionTrustText(frame.decision_trust_enforcement.reason, 280),
+        },
+      } : {}),
     },
   }
 }

--- a/lib/open-brain.test.ts
+++ b/lib/open-brain.test.ts
@@ -229,6 +229,21 @@ describe('Open Brain projection', () => {
           approval_type: 'payment_make_vendor_payment',
           reversibility: 'hard',
           occurred_at: '2026-05-27T12:00:00.000Z',
+          decision_trust_enforcement: {
+            mode: 'soft_gate',
+            gate: 'human_review',
+            may_proceed: false,
+            requires_approval: true,
+            should_block: false,
+            approval_type: 'payment_make_vendor_payment',
+            reason: 'Soft-gate mode requires human approval before this Decision Trust frame can produce a side effect.',
+            evidence: {
+              decision_id: 'decision-payment',
+              linked_run_id: 'run-trust',
+              selected_candidate: 'make_vendor_payment',
+              missing_evidence: ['Human approval decision'],
+            },
+          },
         },
       ],
     })
@@ -245,6 +260,12 @@ describe('Open Brain projection', () => {
         type: 'event',
         kind: 'agent_decision_trust_observed',
         decisionTrustGate: 'human_review',
+        decisionTrustEnforcement: expect.objectContaining({
+          mode: 'soft_gate',
+          gate: 'human_review',
+          requiresApproval: true,
+          shouldBlock: false,
+        }),
       }),
     ]))
     expect(snapshot.relationshipMap.insights).toEqual(expect.arrayContaining([

--- a/lib/open-brain.ts
+++ b/lib/open-brain.ts
@@ -197,6 +197,14 @@ export interface OpenBrainRelationshipNode {
   path: string | null
   health: 'green' | 'yellow' | 'red'
   decisionTrustGate?: string | null
+  decisionTrustEnforcement?: {
+    mode: string
+    gate: string
+    mayProceed: boolean
+    requiresApproval: boolean
+    shouldBlock: boolean
+    reason: string
+  } | null
   x: number
   y: number
 }
@@ -1966,6 +1974,7 @@ function memoryToRelationshipNode(memory: OpenBrainMemoryRecord, index: number):
 function eventToRelationshipNode(event: OpenBrainEventRecord, index: number): OpenBrainRelationshipNode {
   const point = relationshipPoint('event', event.kind, index)
   const decisionTrust = decisionTrustMetadataFromEvent(event)
+  const decisionTrustEnforcement = decisionTrustEnforcementMetadataFromEvent(event)
   return {
     id: event.id,
     label: event.title,
@@ -1982,6 +1991,7 @@ function eventToRelationshipNode(event: OpenBrainEventRecord, index: number): Op
           ? 'yellow'
           : event.confidence >= 0.75 ? 'green' : 'yellow',
     decisionTrustGate: decisionTrust?.recommendedGate ?? null,
+    decisionTrustEnforcement,
     x: point.x,
     y: point.y,
   }
@@ -1994,6 +2004,23 @@ function decisionTrustMetadataFromEvent(event: OpenBrainEventRecord) {
   const recommendedGate = stringFromMetadata(record.recommended_gate)
   if (!recommendedGate) return null
   return { recommendedGate }
+}
+
+function decisionTrustEnforcementMetadataFromEvent(event: OpenBrainEventRecord): OpenBrainRelationshipNode['decisionTrustEnforcement'] {
+  const value = event.metadata?.decisionTrustEnforcement ?? event.metadata?.decision_trust_enforcement
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const record = value as Record<string, unknown>
+  const mode = stringFromMetadata(record.mode)
+  const gate = stringFromMetadata(record.gate)
+  if (!mode || !gate) return null
+  return {
+    mode,
+    gate,
+    mayProceed: record.may_proceed === true || record.mayProceed === true,
+    requiresApproval: record.requires_approval === true || record.requiresApproval === true,
+    shouldBlock: record.should_block === true || record.shouldBlock === true,
+    reason: stringFromMetadata(record.reason) ?? 'Decision Trust enforcement posture recorded.',
+  }
 }
 
 function wikiToRelationshipNode(page: OpenBrainWikiPage, index: number): OpenBrainRelationshipNode {


### PR DESCRIPTION
## Summary
- Parse sanitized Decision Trust enforcement posture into Agent Governance snapshots, pending authority approvals, delegation decisions, and recent Decision Trust frames.
- Surface enforcement posture in the Agent Governance panel and client-safe governance exports.
- Project enforcement posture into Open Brain decision-trust event nodes and render it in the relationship map detail panel.

## Validation
- npm ci --ignore-scripts
- npm test -- --run lib/agent-governance.test.ts lib/agent-governance-export.test.ts app/admin/agents/governance/page.test.tsx
- npm test -- --run lib/agent-governance.test.ts lib/open-brain.test.ts lib/decision-trust-open-brain.test.ts app/admin/agents/open-brain/page.test.tsx app/admin/agents/governance/page.test.tsx
- npm run build:knowledge
- npx tsc --noEmit --pretty false
- git diff --check
- git diff --cached --check
- No live workflow/customer-data smoke was run.

## Integration Notes
- No migration or env changes.
- Read-only visibility only; no new approval system and no enforcement mode default changes.
- Vercel – portfolio: pending after latest push.
- Vercel – portfolio-staging: not checked by this non-captain branch.