### PR TITLE
feat: enforce decision trust gate invariants

### DIFF
--- a/app/api/admin/agents/chief-of-staff/actions/route.test.ts
+++ b/app/api/admin/agents/chief-of-staff/actions/route.test.ts
@@ -222,6 +222,64 @@ describe('POST /api/admin/agents/chief-of-staff/actions', () => {
     }))
   })
 
+  it('hard-blocks scam-like authority proposals before creating approval checkpoints', async () => {
+    const response = await POST(makeRequest({
+      source_run_id: 'chief-run-1',
+      proposal: {
+        label: 'Approve refund to suspicious destination',
+        description: 'Domain mismatch and possible impersonation in the payment destination.',
+        action: 'create_refund',
+        riskLevel: 'high',
+      },
+    }) as never)
+
+    expect(response.status).toBe(409)
+    expect(await response.json()).toMatchObject({
+      ok: false,
+      run_id: 'approval-run-1',
+      approval_required: false,
+      blocked: true,
+      recommended_gate: 'block',
+      enforcement_mode: 'hard_block',
+    })
+    expect(mocks.startAgentRun).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'failed',
+      currentStep: 'Blocked by Decision Trust',
+      metadata: expect.objectContaining({
+        decision_trust_frame: expect.objectContaining({
+          recommended_gate: 'block',
+          risk_signals: expect.arrayContaining(['Domain mismatch or scam hard-block canary marker from proposal text']),
+        }),
+        decision_trust_enforcement: expect.objectContaining({
+          mode: 'hard_block',
+          shouldBlock: true,
+        }),
+        executes_action: false,
+      }),
+    }))
+    expect(mocks.recordAgentEvent).toHaveBeenCalledWith(expect.objectContaining({
+      runId: 'approval-run-1',
+      eventType: 'agent_decision_trust_recorded',
+      severity: 'error',
+      message: 'create_refund: block',
+    }))
+    expect(mocks.recordAgentEvent).toHaveBeenCalledWith(expect.objectContaining({
+      runId: 'approval-run-1',
+      eventType: 'chief_of_staff_approval_blocked',
+      severity: 'error',
+      metadata: expect.objectContaining({
+        decision_trust_enforcement: expect.objectContaining({
+          mode: 'hard_block',
+          shouldBlock: true,
+        }),
+        executes_action: false,
+      }),
+    }))
+    expect(mocks.insert).not.toHaveBeenCalled()
+    expect(mocks.runAgentSlackNotificationSweep).not.toHaveBeenCalled()
+    expect(mocks.attachAgentArtifact).not.toHaveBeenCalled()
+  })
+
   it('rejects non-gated proposals', async () => {
     const response = await POST(makeRequest({
       source_run_id: 'chief-run-1',

--- a/app/api/admin/agents/chief-of-staff/actions/route.ts
+++ b/app/api/admin/agents/chief-of-staff/actions/route.ts
@@ -101,6 +101,15 @@ function buildActionPayload(input: {
   }
 }
 
+function decisionTrustRiskSignalsForProposal(proposal: ChiefOfStaffActionProposal) {
+  const text = `${proposal.label} ${proposal.description}`.toLowerCase()
+  const signals: string[] = []
+  if (/\b(domain mismatch|typosquat|impersonat|known.?bad|scam|contradict|excessive unexplained permission)\b/i.test(text)) {
+    signals.push('Domain mismatch or scam hard-block canary marker from proposal text')
+  }
+  return signals
+}
+
 function formatActionPayloadSummary(payload: ReturnType<typeof buildActionPayload>) {
   return [
     `# Approval Action Payload: ${payload.label}`,
@@ -180,13 +189,76 @@ export async function POST(request: NextRequest) {
       label: proposal.label,
       sourceRunId,
       approvalType,
+      riskSignals: decisionTrustRiskSignalsForProposal(proposal),
     })
     const decisionTrustEnforcement = recommendDecisionTrustEnforcement({
       frame: decisionTrustFrame,
-      mode: 'soft_gate',
+      mode: decisionTrustFrame.recommended_gate === 'block' ? 'hard_block' : 'soft_gate',
       action: proposal.action,
       runtime: 'codex',
     })
+
+    if (decisionTrustEnforcement.shouldBlock) {
+      const run = await startAgentRun({
+        agentKey: 'chief-of-staff',
+        runtime: 'manual',
+        kind: 'chief_of_staff_action_approval',
+        title: proposal.label,
+        status: 'failed',
+        subject: {
+          type: 'agent_run',
+          id: sourceRunId,
+          label: 'Chief of Staff recommendation',
+        },
+        triggerSource: 'admin_chief_of_staff_action',
+        triggeredByUserId: auth.user.id,
+        currentStep: 'Blocked by Decision Trust',
+        metadata: {
+          source_run_id: sourceRunId,
+          proposal,
+          action_payload: actionPayload,
+          decision_trust_frame: decisionTrustFrame,
+          decision_trust_enforcement: decisionTrustEnforcement,
+          executes_action: false,
+        },
+        idempotencyKey: `chief-of-staff-action-blocked:${sourceRunId}:${proposal.action}:${auth.user.id}:${Date.now()}`,
+      })
+
+      await recordAgentEvent({
+        runId: run.id,
+        eventType: AGENT_DECISION_TRUST_EVENT,
+        severity: 'error',
+        message: `${proposal.action}: ${decisionTrustFrame.recommended_gate}`,
+        metadata: decisionTrustFrame,
+        idempotencyKey: `${run.id}:decision-trust-recorded`,
+      }).catch(() => {})
+
+      await recordAgentEvent({
+        runId: run.id,
+        eventType: 'chief_of_staff_approval_blocked',
+        severity: 'error',
+        message: decisionTrustEnforcement.reason,
+        metadata: {
+          source_run_id: sourceRunId,
+          proposal,
+          action_payload: actionPayload,
+          decision_trust_frame: decisionTrustFrame,
+          decision_trust_enforcement: decisionTrustEnforcement,
+          executes_action: false,
+        },
+        idempotencyKey: `${run.id}:chief-of-staff-approval-blocked`,
+      }).catch(() => {})
+
+      return NextResponse.json({
+        ok: false,
+        run_id: run.id,
+        approval_required: false,
+        blocked: true,
+        recommended_gate: decisionTrustFrame.recommended_gate,
+        enforcement_mode: decisionTrustEnforcement.mode,
+        reason: decisionTrustEnforcement.reason,
+      }, { status: 409 })
+    }
 
     const run = await startAgentRun({
       agentKey: 'chief-of-staff',

--- a/docs/agent-decision-trust-v3-enforcement.md
+++ b/docs/agent-decision-trust-v3-enforcement.md
@@ -63,6 +63,11 @@ Mode behavior:
 
 The rollout should allow different surfaces to adopt modes independently. For example, technology bakeoff recommendations can stay `advisory` while spend authority actions move to `soft_gate`.
 
+Mode values should pass through `resolveDecisionTrustEnforcementMode(value, fallback)`.
+Invalid, missing, or emergency-disable values resolve to `shadow` by default so
+rollback is fail-open on execution impact while still preserving recorded
+Decision Trust evidence.
+
 ## Gate Contract
 
 V3 should preserve the current Decision Trust gate meanings:
@@ -184,6 +189,11 @@ Before turning on any non-shadow mode, add focused tests that prove:
 ## Rollback
 
 Rollback should be an environment or config change back to `shadow` or `advisory`.
+Until a central admin policy surface exists, route-level constants and any env
+or config adoption must use `resolveDecisionTrustEnforcementMode`. To roll back
+execution impact, set the affected surface to `shadow`. Use `advisory` only when
+operators still need warnings returned to the caller while side effects continue
+through the pre-existing Agent Ops policy.
 
 Rollback must preserve:
 
@@ -211,4 +221,3 @@ V3 is done when:
 - `block` decisions can be prevented in `hard_block` without mutating Open Brain,
 - Agent Governance and Open Brain make the enforcement posture visible,
 - rollback to `shadow` is documented and tested.
-

--- a/lib/agent-decision-trust-enforcement.test.ts
+++ b/lib/agent-decision-trust-enforcement.test.ts
@@ -1,8 +1,20 @@
 import { describe, expect, it } from 'vitest'
 import { buildAgentDecisionFrame } from './agent-decision-trust'
-import { recommendDecisionTrustEnforcement } from './agent-decision-trust-enforcement'
+import {
+  recommendDecisionTrustEnforcement,
+  resolveDecisionTrustEnforcementMode,
+} from './agent-decision-trust-enforcement'
 
 describe('agent decision trust enforcement recommendation', () => {
+  it('resolves invalid or missing mode config to shadow for rollback safety', () => {
+    expect(resolveDecisionTrustEnforcementMode(undefined)).toBe('shadow')
+    expect(resolveDecisionTrustEnforcementMode(null)).toBe('shadow')
+    expect(resolveDecisionTrustEnforcementMode('')).toBe('shadow')
+    expect(resolveDecisionTrustEnforcementMode('SOFT_GATE')).toBe('soft_gate')
+    expect(resolveDecisionTrustEnforcementMode('panic_disable')).toBe('shadow')
+    expect(resolveDecisionTrustEnforcementMode('panic_disable', 'advisory')).toBe('advisory')
+  })
+
   it('keeps shadow mode non-blocking even for blocked frames', () => {
     const frame = buildAgentDecisionFrame({
       agentKey: 'chief-of-staff',
@@ -24,6 +36,45 @@ describe('agent decision trust enforcement recommendation', () => {
       mayProceed: true,
       requiresApproval: false,
       shouldBlock: false,
+    })
+  })
+
+  it('rolls a hard-block frame back to shadow without deleting decision evidence', () => {
+    const frame = buildAgentDecisionFrame({
+      agentKey: 'chief-of-staff',
+      decisionType: 'vendor',
+      objective: 'Choose a payment destination.',
+      selectedCandidate: 'stripe-support-payments.example',
+      trustSignals: ['Search result appeared high on the page'],
+      riskSignals: ['Domain mismatch', 'Known-bad source marker', 'Payment requested'],
+      missingEvidence: ['Official source confirmation'],
+      reversibility: 'irreversible',
+    })
+    const blocked = recommendDecisionTrustEnforcement({ frame, mode: 'hard_block' })
+    const rolledBack = recommendDecisionTrustEnforcement({
+      frame,
+      mode: resolveDecisionTrustEnforcementMode('shadow'),
+    })
+
+    expect(frame.recommended_gate).toBe('block')
+    expect(blocked).toMatchObject({
+      mode: 'hard_block',
+      mayProceed: false,
+      shouldBlock: true,
+    })
+    expect(rolledBack).toMatchObject({
+      mode: 'shadow',
+      gate: 'block',
+      mayProceed: true,
+      requiresApproval: false,
+      shouldBlock: false,
+      evidence: {
+        decisionId: frame.decision_id,
+        linkedRunId: null,
+        selectedCandidate: 'stripe-support-payments.example',
+        scores: frame.scores,
+        missingEvidence: frame.missing_evidence,
+      },
     })
   })
 

--- a/lib/agent-decision-trust-enforcement.test.ts
+++ b/lib/agent-decision-trust-enforcement.test.ts
@@ -130,6 +130,67 @@ describe('agent decision trust enforcement recommendation', () => {
     })
   })
 
+  it('does not let allow frames bypass approval-required runtime actions in soft-gate mode', () => {
+    const frame = buildAgentDecisionFrame({
+      agentKey: 'chief-of-staff',
+      decisionType: 'information',
+      objective: 'Use official source text in an outbound email draft.',
+      selectedCandidate: 'official-docs',
+      trustSignals: ['Official source verified', 'Domain match confirmed', 'Source evidence linked'],
+      riskSignals: ['Read-only source review'],
+      missingEvidence: [],
+      reversibility: 'easy',
+    })
+
+    const recommendation = recommendDecisionTrustEnforcement({
+      frame,
+      mode: 'soft_gate',
+      action: 'send_email',
+      runtime: 'codex',
+    })
+
+    expect(frame.recommended_gate).toBe('allow')
+    expect(recommendation).toMatchObject({
+      mode: 'soft_gate',
+      gate: 'allow',
+      mayProceed: false,
+      requiresApproval: true,
+      shouldBlock: false,
+      approvalType: 'send_email',
+    })
+    expect(recommendation.reason).toMatch(/runtime policy requires human approval/i)
+  })
+
+  it('keeps approval-required runtime actions gated in hard-block mode when no block signal exists', () => {
+    const frame = buildAgentDecisionFrame({
+      agentKey: 'chief-of-staff',
+      decisionType: 'information',
+      objective: 'Use an official source in a public post.',
+      selectedCandidate: 'official-docs',
+      trustSignals: ['Official source verified', 'Domain match confirmed', 'Source evidence linked'],
+      riskSignals: ['Read-only source review'],
+      missingEvidence: [],
+      reversibility: 'easy',
+    })
+
+    const recommendation = recommendDecisionTrustEnforcement({
+      frame,
+      mode: 'hard_block',
+      action: 'publish_public_content',
+      runtime: 'codex',
+    })
+
+    expect(frame.recommended_gate).toBe('allow')
+    expect(recommendation).toMatchObject({
+      mode: 'hard_block',
+      gate: 'allow',
+      mayProceed: false,
+      requiresApproval: true,
+      shouldBlock: false,
+      approvalType: 'publishing',
+    })
+  })
+
   it('allows strong low-risk frames in soft-gate mode', () => {
     const frame = buildAgentDecisionFrame({
       agentKey: 'research-source-register',

--- a/lib/agent-decision-trust-enforcement.ts
+++ b/lib/agent-decision-trust-enforcement.ts
@@ -41,10 +41,26 @@ export type RecommendDecisionTrustEnforcementInput = {
   action?: AgentAction
 }
 
+export function resolveDecisionTrustEnforcementMode(
+  value: string | null | undefined,
+  fallback: DecisionTrustEnforcementMode = 'shadow',
+): DecisionTrustEnforcementMode {
+  const normalized = value?.trim().toLowerCase()
+  if (
+    normalized === 'shadow' ||
+    normalized === 'advisory' ||
+    normalized === 'soft_gate' ||
+    normalized === 'hard_block'
+  ) {
+    return normalized
+  }
+  return fallback
+}
+
 export function recommendDecisionTrustEnforcement(
   input: RecommendDecisionTrustEnforcementInput,
 ): DecisionTrustEnforcementRecommendation {
-  const mode = input.mode ?? 'shadow'
+  const mode = resolveDecisionTrustEnforcementMode(input.mode)
   const gate = input.frame.recommended_gate
   const approvalType = approvalTypeFor(input)
   const evidence = {

--- a/lib/agent-decision-trust-enforcement.ts
+++ b/lib/agent-decision-trust-enforcement.ts
@@ -94,6 +94,19 @@ export function recommendDecisionTrustEnforcement(
     }
   }
 
+  if (approvalType && gate !== 'human_review' && gate !== 'block') {
+    return {
+      mode,
+      gate,
+      mayProceed: false,
+      requiresApproval: true,
+      shouldBlock: false,
+      approvalType,
+      reason: 'Runtime policy requires human approval before this action can continue, regardless of the Decision Trust score.',
+      evidence,
+    }
+  }
+
   if (gate === 'human_review' || gate === 'block') {
     return {
       mode,

--- a/lib/agent-decision-trust.ts
+++ b/lib/agent-decision-trust.ts
@@ -262,6 +262,7 @@ export function buildPaymentAuthorityDecisionTrustFrame(input: {
   label: string
   sourceRunId: string
   approvalType: string | null
+  riskSignals?: string[]
 }) {
   const paymentAuthority = isPaymentAuthorityAction(input.action)
   return buildAgentDecisionFrame({
@@ -277,6 +278,7 @@ export function buildPaymentAuthorityDecisionTrustFrame(input: {
     riskSignals: [
       paymentAuthority ? 'Payment or spend authority requested' : 'Approval-gated side effect requested',
       'Action does not execute during checkpoint creation',
+      ...(input.riskSignals ?? []),
     ],
     missingEvidence: [
       'Human approval decision',


### PR DESCRIPTION
## Summary
- Add the Decision Trust enforcement helper and soft-gate invariants for approval-required actions.
- Add a hard-block canary for scam/domain-mismatch payment authority proposals before approval creation.
- Add an explicit enforcement mode resolver so invalid or rollback config falls back to shadow, with rollback tests and documentation.

## Validation
- npm test -- --run lib/agent-decision-trust.test.ts lib/agent-decision-trust-enforcement.test.ts app/api/admin/agents/chief-of-staff/actions/route.test.ts
- npm run build:knowledge
- npx tsc --noEmit --pretty false
- git diff --check
- git diff --cached --check
- No live workflow/customer-data smoke was run.

## Integration Notes
- No migration or env changes.
- Production default remains shadow unless a caller explicitly selects advisory, soft_gate, or hard_block.
- High-risk approval boundaries still use existing agent_approvals.
- Vercel – portfolio: pending after latest push.
- Vercel – portfolio-staging: not checked by this non-captain branch.