### PR TITLE
feat: guard decision trust link promotion

### DIFF
--- a/lib/open-brain.test.ts
+++ b/lib/open-brain.test.ts
@@ -299,6 +299,70 @@ describe('Open Brain projection', () => {
     expect(snapshot.links).toHaveLength(0)
   })
 
+  it('does not promote blocked decision trust relationship metadata into a durable link', async () => {
+    const root = await makeTempRoot()
+    const proposal = await createOpenBrainProposal({
+      kind: 'workflow',
+      title: 'Blocked vendor trust link',
+      body: 'A blocked vendor decision can be reviewed without creating positive trust evidence.',
+      privacyTier: 'internal_ops',
+      confidence: 0.84,
+      sourceIds: ['event:decision-trust:blocked-vendor'],
+      reason: 'Decision trust block should suppress relationship promotion.',
+      metadata: {
+        relationship: {
+          fromId: 'event:decision-trust:blocked-vendor',
+          toId: 'vendor:unknown-payments',
+          relationship: 'trusted_for_decision',
+          insightId: 'insight:decision-trust:blocked-vendor',
+          insightKind: 'decision_trust_review',
+          sourceLabel: 'Blocked vendor decision',
+          targetLabel: 'Unknown Payments',
+        },
+        decisionTrust: {
+          decisionId: 'decision-blocked-vendor',
+          linkedRunId: 'run-blocked-vendor',
+          selectedCandidate: 'unknown-payments.example',
+          recommendedGate: 'block',
+          scores: {
+            relationshipTrust: 0.12,
+            decisionRisk: 0.94,
+            evidenceCompleteness: 0.38,
+          },
+          evidenceSummary: 'Domain mismatch with excessive unexplained payment permissions.',
+        },
+      },
+    }, root)
+
+    const approved = await reviewOpenBrainProposal(proposal.id, 'approved', 'Review captured; no trust promotion.', 'admin', root)
+    const snapshot = await getOpenBrainSnapshot(root)
+    const approvalEvent = snapshot.events.find((event) => (
+      event.kind === 'proposal_approved' &&
+      event.metadata?.proposalId === proposal.id
+    ))
+
+    expect(approved.metadata?.decisionTrust).toEqual(expect.objectContaining({
+      decisionId: 'decision-blocked-vendor',
+      recommendedGate: 'block',
+    }))
+    expect(snapshot.links).toHaveLength(0)
+    expect(approvalEvent?.metadata).toEqual(expect.objectContaining({
+      relationship: expect.objectContaining({
+        fromId: 'event:decision-trust:blocked-vendor',
+        toId: 'vendor:unknown-payments',
+        relationship: 'trusted_for_decision',
+      }),
+      decisionTrust: expect.objectContaining({
+        decisionId: 'decision-blocked-vendor',
+        linkedRunId: 'run-blocked-vendor',
+        recommendedGate: 'block',
+      }),
+      decisionTrustRelationshipLinkBlocked: true,
+      relationshipLinkBlockedReason: 'decision_trust_block',
+    }))
+    expect(approvalEvent?.metadata).not.toHaveProperty('relationshipLinkId')
+  })
+
   it('keeps AutoResearch producer traces disabled until explicitly configured', async () => {
     const root = await makeTempRoot()
     let snapshot = await getOpenBrainSnapshot(root)

--- a/lib/open-brain.ts
+++ b/lib/open-brain.ts
@@ -645,6 +645,9 @@ export async function reviewOpenBrainProposal(
   proposals[index] = reviewed
   await writeJsonArray(proposalsPath, proposals)
   let approvedRelationshipLink: OpenBrainLinkRecord | null = null
+  const relationshipLinkBlockedByDecisionTrust = status === 'approved' &&
+    decisionTrustBlocksRelationshipLink(reviewed) &&
+    Boolean(reviewed.metadata?.relationship)
   if (status === 'approved') {
     const memoriesPath = path.join(openBrainHome, MEMORIES_FILE)
     const memories = await readJsonArray<OpenBrainMemoryRecord>(memoriesPath)
@@ -666,6 +669,9 @@ export async function reviewOpenBrainProposal(
       reviewedBy: reviewed.reviewedBy,
       memoryKind: reviewed.proposedMemory.kind,
       relationship: reviewed.metadata?.relationship,
+      decisionTrust: reviewed.metadata?.decisionTrust,
+      decisionTrustRelationshipLinkBlocked: relationshipLinkBlockedByDecisionTrust,
+      ...(relationshipLinkBlockedByDecisionTrust ? { relationshipLinkBlockedReason: 'decision_trust_block' } : {}),
       relationshipLinkId: approvedRelationshipLink?.id,
     },
   }, openBrainHome)
@@ -1991,7 +1997,7 @@ function decisionTrustMetadataFromEvent(event: OpenBrainEventRecord) {
   const value = event.metadata?.decisionTrust
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null
   const record = value as Record<string, unknown>
-  const recommendedGate = stringFromMetadata(record.recommended_gate)
+  const recommendedGate = stringFromMetadata(record.recommended_gate) || stringFromMetadata(record.recommendedGate)
   if (!recommendedGate) return null
   return { recommendedGate }
 }
@@ -2410,12 +2416,17 @@ function relationshipLinkFromProposal(proposal: OpenBrainProposalRecord) {
   const relationship = proposal.metadata?.relationship
   if (!relationship?.fromId || !relationship.toId || !relationship.relationship) return null
   if (proposal.proposedMemory.privacyTier === 'private') return null
+  if (decisionTrustBlocksRelationshipLink(proposal)) return null
   return {
     id: `link:${fingerprintOpenBrainRecord([relationship.fromId, relationship.toId, relationship.relationship]).slice(0, 16)}`,
     fromId: relationship.fromId,
     toId: relationship.toId,
     relationship: relationship.relationship,
   }
+}
+
+function decisionTrustBlocksRelationshipLink(proposal: OpenBrainProposalRecord) {
+  return proposal.metadata?.decisionTrust?.recommendedGate.trim().toLowerCase() === 'block'
 }
 
 function dedupeSources(sources: OpenBrainSourceRecord[]) {


### PR DESCRIPTION
## Summary
- Prevent approved Open Brain proposals with a blocked Decision Trust gate from creating durable positive relationship links.
- Record Decision Trust metadata on proposal approval/rejection audit events, including whether a relationship link was suppressed by a Decision Trust block.
- Extend Open Brain tests to cover the blocked relationship promotion invariant.

## Validation
- npm ci --ignore-scripts
- npm test -- --run lib/open-brain.test.ts lib/decision-trust-open-brain.test.ts
- npm run build:knowledge
- npx tsc --noEmit --pretty false
- git diff --check
- git diff --cached --check
- No live workflow/customer-data smoke was run.

## Integration Notes
- No migration or env changes.
- V2/V3 behavior remains proposal-gated; this does not turn on enforcement.
- Vercel – portfolio: pending after PR creation.
- Vercel – portfolio-staging: not checked by this non-captain branch.