### PR TITLE
feat: add model usage source packets

### DIFF
--- a/app/admin/agents/model-usage/page.tsx
+++ b/app/admin/agents/model-usage/page.tsx
@@ -25,21 +25,30 @@ type Snapshot = ModelUsageSnapshot & { ok?: boolean }
 type DatePreset = '30d' | 'mtd' | 'qtd'
 
 const DEFAULT_IMPORT_PACKET = JSON.stringify({
-  events: [
+  sourcePackets: [
     {
+      kind: 'codex_session',
+      sourceId: 'replace-with-session-id',
       occurredAt: '2026-06-06T12:00:00.000Z',
-      provider: 'codex',
-      runtime: 'codex',
       model: 'gpt-5-codex',
       taskCategory: 'coding',
       clientLabel: 'Portfolio',
       actionLabel: 'Reviewed Codex session import',
       inputTokens: 12000,
       outputTokens: 1800,
-      costBasis: 'subscription_prorated',
       confidence: 'medium',
-      sourceTrace: { type: 'codex_session_import', id: 'replace-with-session-id' },
       sourceMetadata: { source: 'manual-reviewed-import', category: 'implementation' },
+    },
+    {
+      kind: 'local_model_run',
+      sourceId: 'replace-with-local-run-id',
+      model: 'llama-3.1-8b',
+      taskCategory: 'rag',
+      inputTokens: 2400,
+      outputTokens: 500,
+      executionHost: 'mac-mini',
+      deploymentTarget: 'local_device',
+      sourceMetadata: { runner: 'ollama', environment: 'private-local' },
     },
   ],
   subscriptionAllocations: [
@@ -310,7 +319,7 @@ function ModelUsageContent() {
                     Reviewed usage import packet
                   </div>
                   <p className="mt-1 max-w-3xl text-xs text-muted-foreground">
-                    Import audited usage rows or subscription allocation rules from Codex, Claude Code, Gemini, or local model records. Raw prompts, transcripts, secrets, credentials, and provider account actions are blocked from this path.
+                    Import audited source packets, ledger rows, or subscription allocation rules from Codex, Claude Code, Gemini, OpenAI, Anthropic, or local/open-weight model records. Raw prompts, transcripts, secrets, credentials, OAuth, provider writes, and routing changes are blocked from this path.
                   </p>
                 </div>
                 <div className="flex flex-wrap gap-2">

--- a/app/api/admin/model-usage/import/route.test.ts
+++ b/app/api/admin/model-usage/import/route.test.ts
@@ -106,6 +106,31 @@ describe('POST /api/admin/model-usage/import', () => {
     ])
   })
 
+  it('dry-runs source-specific packets without provider side effects', async () => {
+    const response = await POST(request({
+      dryRun: true,
+      sourcePackets: [{
+        kind: 'gemini_usage_export',
+        sourceId: 'gemini-row-1',
+        model: 'gemini-2.5-flash',
+        taskCategory: 'research',
+        inputTokens: 1000,
+        outputTokens: 200,
+        costUsd: 0.01,
+      }],
+    }) as never)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({
+      ok: true,
+      dryRun: true,
+      eventCount: 1,
+      subscriptionAllocationCount: 0,
+    })
+    expect(mocks.fromMock).not.toHaveBeenCalled()
+  })
+
   it('rejects packets that include raw prompt-like metadata', async () => {
     const response = await POST(request({
       events: [{

--- a/lib/model-usage.test.ts
+++ b/lib/model-usage.test.ts
@@ -5,6 +5,7 @@ import {
   computeModelUsageCost,
   inferModelUsageProvider,
   inferTaskCategory,
+  modelUsageEventInputFromSourcePacket,
   modelUsageEventFromCostEvent,
   type ModelUsageLedgerEvent,
 } from './model-usage'
@@ -245,6 +246,128 @@ describe('buildModelUsageImportPlan', () => {
         pricingSnapshot: { apiKey: 'secret' },
       }],
     })).toThrow(/not allowed/)
+
+    expect(() => buildModelUsageImportPlan({
+      events: [{
+        provider: 'codex',
+        model: 'gpt-5-codex',
+        sourceMetadata: { nested: { messages: ['private chat'] } },
+      }],
+    })).toThrow(/not allowed/)
+  })
+
+  it('normalizes source-specific packets for Codex, Claude Code, Gemini, and local models', () => {
+    const plan = buildModelUsageImportPlan({
+      dryRun: true,
+      sourcePackets: [
+        {
+          kind: 'codex_session',
+          sourceId: 'codex-session-1',
+          occurredAt: '2026-06-06T12:00:00.000Z',
+          taskCategory: 'coding',
+          inputTokens: 12_000,
+          outputTokens: 1800,
+          clientLabel: 'Portfolio',
+        },
+        {
+          kind: 'claude_code_session',
+          sourceId: 'claude-code-1',
+          model: 'claude-sonnet-4-20250514',
+          taskCategory: 'qa',
+          inputTokens: 5000,
+          outputTokens: 600,
+          costUsd: 0,
+        },
+        {
+          kind: 'gemini_usage_export',
+          sourceId: 'gemini-row-1',
+          model: 'gemini-2.5-flash',
+          taskCategory: 'research',
+          inputTokens: 1_000_000,
+          outputTokens: 100_000,
+          costUsd: 0.55,
+          exportBatchId: 'batch-1',
+        },
+        {
+          kind: 'local_model_run',
+          sourceId: 'local-run-1',
+          model: 'llama-3.1-8b',
+          taskCategory: 'rag',
+          inputTokens: 2000,
+          outputTokens: 400,
+          executionHost: 'mac-mini',
+          deploymentTarget: 'local_device',
+        },
+      ],
+    }, '2026-06-06T13:00:00.000Z')
+
+    expect(plan.eventRows).toHaveLength(4)
+    expect(plan.eventRows[0]).toMatchObject({
+      provider: 'codex',
+      runtime: 'codex',
+      source_type: 'codex_session_import',
+      source_id: 'codex-session-1',
+      cost_basis: 'subscription_prorated',
+      confidence: 'medium',
+      scrubbed: true,
+    })
+    expect(plan.eventRows[1]).toMatchObject({
+      provider: 'claude_code',
+      runtime: 'claude_code',
+      source_type: 'claude_code_session_import',
+      task_category: 'qa',
+    })
+    expect(plan.eventRows[2]).toMatchObject({
+      provider: 'google',
+      runtime: 'api',
+      source_type: 'gemini_usage_export',
+      source_id: 'gemini-row-1',
+      cost_usd: 0.55,
+      cost_basis: 'metered',
+      raw_metadata: expect.objectContaining({
+        importSource: 'gemini_usage_export',
+        exportBatchId: 'batch-1',
+      }),
+    })
+    expect(plan.eventRows[3]).toMatchObject({
+      provider: 'local',
+      runtime: 'local',
+      cost_basis: 'local_estimated',
+      confidence: 'low',
+      raw_metadata: expect.objectContaining({
+        executionHost: 'mac-mini',
+        deploymentTarget: 'local_device',
+      }),
+    })
+  })
+
+  it('builds a reviewed source packet without carrying raw private content', () => {
+    const event = modelUsageEventInputFromSourcePacket({
+      kind: 'open_weight_model_run',
+      sourceId: 'local-cloud-run-1',
+      model: 'mixtral-open-weight',
+      taskCategory: 'planning',
+      inputTokens: 3000,
+      outputTokens: 500,
+      deploymentTarget: 'private_cloud',
+      sourceMetadata: { runner: 'ollama', quantization: 'q4' },
+    })
+
+    expect(event).toMatchObject({
+      provider: 'open_source',
+      runtime: 'local',
+      model: 'mixtral-open-weight',
+      costBasis: 'local_estimated',
+      sourceTrace: {
+        type: 'open_weight_model_usage_import',
+        id: 'local-cloud-run-1',
+      },
+      sourceMetadata: expect.objectContaining({
+        importSource: 'open_weight_model_run',
+        deploymentTarget: 'private_cloud',
+        runner: 'ollama',
+      }),
+    })
   })
 })
 

--- a/lib/model-usage.ts
+++ b/lib/model-usage.ts
@@ -10,7 +10,7 @@ export type ModelUsageProvider =
   | 'local'
   | 'other'
 
-export type ModelUsageRuntime = 'codex' | 'n8n' | 'hermes' | 'opencode' | 'manual' | 'api' | 'local' | 'other'
+export type ModelUsageRuntime = 'codex' | 'claude_code' | 'n8n' | 'hermes' | 'opencode' | 'manual' | 'api' | 'local' | 'other'
 export type ModelUsageTaskCategory =
   | 'research'
   | 'coding'
@@ -151,6 +151,43 @@ export type ModelUsageImportEventInput = {
   sourceMetadata?: Record<string, unknown>
 }
 
+export type ModelUsageSourcePacketKind =
+  | 'codex_session'
+  | 'claude_code_session'
+  | 'gemini_usage_export'
+  | 'openai_usage_export'
+  | 'anthropic_usage_export'
+  | 'local_model_run'
+  | 'open_weight_model_run'
+
+export type ModelUsageSourcePacket = {
+  kind: ModelUsageSourcePacketKind
+  sourceId: string
+  occurredAt?: string
+  model?: string
+  taskCategory?: ModelUsageTaskCategory
+  agentKey?: string | null
+  clientProjectId?: string | null
+  clientLabel?: string | null
+  actionLabel?: string | null
+  inputTokens?: number
+  outputTokens?: number
+  cachedTokens?: number
+  reasoningTokens?: number
+  totalTokens?: number
+  acceptedOutputCount?: number
+  resolvedWorkItemCount?: number
+  retryCount?: number
+  costUsd?: number
+  confidence?: ModelUsageConfidence
+  href?: string | null
+  accountLabel?: string | null
+  exportBatchId?: string | null
+  executionHost?: string | null
+  deploymentTarget?: 'local_device' | 'private_cloud' | 'managed_cloud' | 'unknown'
+  sourceMetadata?: Record<string, unknown>
+}
+
 export type ModelUsageSubscriptionAllocationInput = {
   provider: ModelUsageProvider
   runtime?: ModelUsageRuntime | 'any'
@@ -166,6 +203,7 @@ export type ModelUsageSubscriptionAllocationInput = {
 export type ModelUsageImportPacket = {
   dryRun?: boolean
   events?: ModelUsageImportEventInput[]
+  sourcePackets?: ModelUsageSourcePacket[]
   subscriptionAllocations?: ModelUsageSubscriptionAllocationInput[]
 }
 
@@ -238,7 +276,7 @@ export const MODEL_PRICING_CATALOG: ModelPricingSnapshot[] = [
   { provider: 'google', model: 'gemini-2.5-flash', inputUsdPer1MTokens: 0.3, outputUsdPer1MTokens: 2.5, sourceUrl: 'https://ai.google.dev/gemini-api/docs/pricing', effectiveFrom: '2025-01-01', pricingState: 'needs_review' },
 ]
 
-const FORBIDDEN_IMPORT_KEY_PATTERN = /(api[_-]?key|secret|token|password|credential|raw[_-]?prompt|prompt|messages|transcript|content)/i
+const FORBIDDEN_IMPORT_KEY_PATTERN = /(api[_-]?key|secret|access[_-]?token|refresh[_-]?token|(?:^|[_-])token(?:$|[_-])|password|credential|raw[_-]?prompt|prompt|messages|transcript|content)/i
 
 function roundUsd(value: number) {
   return Math.round(value * 10_000) / 10_000
@@ -288,7 +326,8 @@ export function inferTaskCategory(metadata: Record<string, unknown> | null | und
 }
 
 export function buildModelUsageImportPlan(packet: ModelUsageImportPacket, now = new Date().toISOString()): ModelUsageImportPlan {
-  const eventInputs = packet.events ?? []
+  const sourceEventInputs = (packet.sourcePackets ?? []).map((sourcePacket, index) => modelUsageEventInputFromSourcePacket(sourcePacket, index))
+  const eventInputs = [...(packet.events ?? []), ...sourceEventInputs]
   const allocationInputs = packet.subscriptionAllocations ?? []
   if (eventInputs.length === 0 && allocationInputs.length === 0) {
     throw new Error('Import packet must include at least one event or subscription allocation.')
@@ -621,11 +660,115 @@ function normalizeSubscriptionAllocation(
 
 function assertSafeImportObject(value: Record<string, unknown> | null | undefined, path: string) {
   if (!value) return
-  for (const key of Object.keys(value)) {
+  for (const [key, child] of Object.entries(value)) {
     if (FORBIDDEN_IMPORT_KEY_PATTERN.test(key)) {
       throw new Error(`${path}.${key} is not allowed in model usage import packets.`)
     }
+    if (Array.isArray(child)) {
+      child.forEach((item, index) => {
+        if (item && typeof item === 'object') assertSafeImportObject(item as Record<string, unknown>, `${path}.${key}[${index}]`)
+      })
+    } else if (child && typeof child === 'object') {
+      assertSafeImportObject(child as Record<string, unknown>, `${path}.${key}`)
+    }
   }
+}
+
+export function modelUsageEventInputFromSourcePacket(
+  packet: ModelUsageSourcePacket,
+  index = 0,
+): ModelUsageImportEventInput {
+  assertSafeImportObject(packet.sourceMetadata, `sourcePackets[${index}].sourceMetadata`)
+  const sourceId = cleanRequiredString(packet.sourceId, `sourcePackets[${index}].sourceId`)
+  const defaults = sourceDefaults(packet.kind, index)
+  const provider = defaults.provider
+  const runtime = defaults.runtime
+  const model = cleanLabel(packet.model, defaults.model)
+  const sourceMetadata = {
+    importSource: packet.kind,
+    accountLabel: cleanNullableString(packet.accountLabel),
+    exportBatchId: cleanNullableString(packet.exportBatchId),
+    executionHost: cleanNullableString(packet.executionHost),
+    deploymentTarget: packet.deploymentTarget ?? undefined,
+    ...(packet.sourceMetadata ?? {}),
+  }
+  const computedCost = computeModelUsageCost(
+    {
+      input_tokens: nonNegativeInteger(packet.inputTokens, `sourcePackets[${index}].inputTokens`),
+      output_tokens: nonNegativeInteger(packet.outputTokens, `sourcePackets[${index}].outputTokens`),
+      total_tokens: nonNegativeInteger(packet.totalTokens, `sourcePackets[${index}].totalTokens`),
+    },
+    provider,
+    model,
+  )
+  const explicitCost = typeof packet.costUsd === 'number' && Number.isFinite(packet.costUsd) ? roundUsd(Math.max(0, packet.costUsd)) : null
+  const hasMeteredExport = packet.kind === 'openai_usage_export' || packet.kind === 'anthropic_usage_export' || packet.kind === 'gemini_usage_export'
+  const localEstimate = packet.kind === 'local_model_run' || packet.kind === 'open_weight_model_run'
+
+  return {
+    occurredAt: packet.occurredAt,
+    provider,
+    runtime,
+    model,
+    taskCategory: packet.taskCategory ?? inferTaskCategory(sourceMetadata),
+    agentKey: packet.agentKey,
+    clientProjectId: packet.clientProjectId,
+    clientLabel: packet.clientLabel,
+    actionLabel: packet.actionLabel ?? defaults.actionLabel,
+    inputTokens: packet.inputTokens,
+    outputTokens: packet.outputTokens,
+    cachedTokens: packet.cachedTokens,
+    reasoningTokens: packet.reasoningTokens,
+    totalTokens: packet.totalTokens,
+    acceptedOutputCount: packet.acceptedOutputCount,
+    resolvedWorkItemCount: packet.resolvedWorkItemCount,
+    retryCount: packet.retryCount,
+    costUsd: explicitCost ?? computedCost.costUsd,
+    costBasis: explicitCost != null || hasMeteredExport ? 'metered' : localEstimate ? 'local_estimated' : 'subscription_prorated',
+    confidence: packet.confidence ?? (explicitCost != null || computedCost.pricingSnapshot ? 'medium' : localEstimate ? 'low' : 'medium'),
+    sourceTrace: {
+      type: defaults.sourceType,
+      id: sourceId,
+      href: packet.href,
+    },
+    pricingSnapshot: {
+      ...(computedCost.pricingSnapshot ?? {}),
+      sourcePacketKind: packet.kind,
+      importPacket: true,
+    },
+    sourceMetadata,
+  }
+}
+
+function sourceDefaults(kind: ModelUsageSourcePacketKind, index: number): {
+  provider: ModelUsageProvider
+  runtime: ModelUsageRuntime
+  model: string
+  sourceType: string
+  actionLabel: string
+} {
+  if (kind === 'codex_session') {
+    return { provider: 'codex', runtime: 'codex', model: 'gpt-5-codex', sourceType: 'codex_session_import', actionLabel: 'Reviewed Codex session import' }
+  }
+  if (kind === 'claude_code_session') {
+    return { provider: 'claude_code', runtime: 'claude_code', model: 'claude-code', sourceType: 'claude_code_session_import', actionLabel: 'Reviewed Claude Code session import' }
+  }
+  if (kind === 'gemini_usage_export') {
+    return { provider: 'google', runtime: 'api', model: 'gemini-2.5-flash', sourceType: 'gemini_usage_export', actionLabel: 'Reviewed Gemini usage export' }
+  }
+  if (kind === 'openai_usage_export') {
+    return { provider: 'openai', runtime: 'api', model: 'gpt-4o-mini', sourceType: 'openai_usage_export', actionLabel: 'Reviewed OpenAI usage export' }
+  }
+  if (kind === 'anthropic_usage_export') {
+    return { provider: 'anthropic', runtime: 'api', model: 'claude-3-5-sonnet-20241022', sourceType: 'anthropic_usage_export', actionLabel: 'Reviewed Anthropic usage export' }
+  }
+  if (kind === 'local_model_run') {
+    return { provider: 'local', runtime: 'local', model: 'local-model', sourceType: 'local_model_usage_import', actionLabel: 'Reviewed local model run import' }
+  }
+  if (kind === 'open_weight_model_run') {
+    return { provider: 'open_source', runtime: 'local', model: 'open-weight-model', sourceType: 'open_weight_model_usage_import', actionLabel: 'Reviewed open-weight model run import' }
+  }
+  throw new Error(`sourcePackets[${index}].kind is not supported.`)
 }
 
 function cleanRequiredString(value: unknown, path: string) {
@@ -893,7 +1036,7 @@ function normalizeProvider(value: string | null | undefined): ModelUsageProvider
 }
 
 function normalizeRuntime(value: string | null | undefined): ModelUsageRuntime {
-  if (value === 'codex' || value === 'n8n' || value === 'hermes' || value === 'opencode' || value === 'manual' || value === 'api' || value === 'local') return value
+  if (value === 'codex' || value === 'claude_code' || value === 'n8n' || value === 'hermes' || value === 'opencode' || value === 'manual' || value === 'api' || value === 'local') return value
   return 'other'
 }
 


### PR DESCRIPTION
## Summary
- Adds reviewed source-packet normalization for Codex sessions, Claude Code sessions, Gemini/OpenAI/Anthropic usage exports, and local/open-weight model runs.
- Keeps the model usage import path read-only/import-only: packets normalize into existing ledger rows, while credentials, OAuth, provider writes, routing changes, and raw prompt/message/transcript storage remain blocked.
- Updates the admin Model Usage dashboard sample packet to show source-specific imports, including local-device LLM usage metadata.

## Validation
- npm run build:knowledge
- npm test -- lib/model-usage.test.ts app/api/admin/model-usage/import/route.test.ts app/api/admin/model-usage/summary/route.test.ts app/admin/agents/model-usage/page.test.tsx
- npx tsc --noEmit
- git diff --check
- Pre-push production db health check skipped locally because PROD_SUPABASE_URL and PROD_SUPABASE_SERVICE_ROLE_KEY are not set; CI still runs it.
- No live provider billing, OAuth, credential sync, routing change, outbound send, publishing, deploy, or customer-data smoke was run.

## Integration Notes
- No migrations or env changes required.
- Extends the existing model_usage_events import contract with additive sourcePackets support.
- Vercel – portfolio: not checked yet; expected after PR preview starts.
- Vercel – portfolio-staging: not checked yet; verify after merge/deploy gate.