### PR TITLE
fix: fail closed on stalled auth loading

### DIFF
--- a/components/AuthProvider.test.tsx
+++ b/components/AuthProvider.test.tsx
@@ -1,0 +1,75 @@
+import { act, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AuthProvider, useAuth } from './AuthProvider'
+
+const authMocks = vi.hoisted(() => ({
+  getCurrentSession: vi.fn(),
+  getCurrentUser: vi.fn(),
+  onAuthStateChange: vi.fn(),
+  unsubscribe: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  getCurrentSession: authMocks.getCurrentSession,
+  getCurrentUser: authMocks.getCurrentUser,
+  onAuthStateChange: authMocks.onAuthStateChange,
+}))
+
+function AuthProbe() {
+  const { loading, user, session, profile } = useAuth()
+
+  return (
+    <div>
+      <div data-testid="status">{loading ? 'loading' : 'ready'}</div>
+      <div data-testid="user">{user ? 'user' : 'no-user'}</div>
+      <div data-testid="session">{session ? 'session' : 'no-session'}</div>
+      <div data-testid="profile">{profile ? 'profile' : 'no-profile'}</div>
+    </div>
+  )
+}
+
+describe('AuthProvider', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    authMocks.getCurrentSession.mockReset()
+    authMocks.getCurrentUser.mockReset()
+    authMocks.onAuthStateChange.mockReset()
+    authMocks.unsubscribe.mockReset()
+    authMocks.onAuthStateChange.mockReturnValue({
+      data: {
+        subscription: {
+          unsubscribe: authMocks.unsubscribe,
+        },
+      },
+    })
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('fails closed when initial session restore stalls', async () => {
+    authMocks.getCurrentSession.mockReturnValue(new Promise(() => {}))
+    authMocks.getCurrentUser.mockResolvedValue(null)
+
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>,
+    )
+
+    expect(screen.getByTestId('status')).toHaveTextContent('loading')
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(8000)
+      await Promise.resolve()
+    })
+
+    expect(screen.getByTestId('status')).toHaveTextContent('ready')
+    expect(screen.getByTestId('user')).toHaveTextContent('no-user')
+    expect(screen.getByTestId('session')).toHaveTextContent('no-session')
+    expect(screen.getByTestId('profile')).toHaveTextContent('no-profile')
+  })
+})

--- a/components/AuthProvider.tsx
+++ b/components/AuthProvider.tsx
@@ -20,6 +20,32 @@ const AuthContext = createContext<AuthContextType>({
   isAdmin: false,
 })
 
+const AUTH_REQUEST_TIMEOUT_MS = 8000
+const PROFILE_REQUEST_TIMEOUT_MS = 10000
+
+async function resolveWithTimeout<T>(
+  operation: () => Promise<T>,
+  timeoutMs: number,
+  fallback: T,
+  label: string,
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<T>((resolve) => {
+    timeoutId = setTimeout(() => {
+      console.warn(`${label} timed out after ${timeoutMs}ms`)
+      resolve(fallback)
+    }, timeoutMs)
+  })
+
+  try {
+    return await Promise.race([operation(), timeout])
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId)
+    }
+  }
+}
+
 export function useAuth() {
   return useContext(AuthContext)
 }
@@ -39,12 +65,22 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     try {
       const url = `/api/user/profile${forceRefresh ? '?t=' + Date.now() : ''}`
-      const response = await fetch(url, {
-        headers: {
-          'Authorization': `Bearer ${session.access_token}`,
-        },
-        cache: forceRefresh ? 'no-store' : 'default',
-      })
+      const response = await resolveWithTimeout(
+        () =>
+          fetch(url, {
+            headers: {
+              'Authorization': `Bearer ${session.access_token}`,
+            },
+            cache: forceRefresh ? 'no-store' : 'default',
+          }),
+        PROFILE_REQUEST_TIMEOUT_MS,
+        null,
+        'Profile request',
+      )
+
+      if (!response) {
+        return null
+      }
 
       if (!response.ok) {
         if (response.status === 401) {
@@ -66,24 +102,42 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // while getUser() (server round-trip) is in flight
     const initAuth = async () => {
       try {
-        const session = await getCurrentSession()
-        if (session?.user) {
-          setUser(session.user)
-          setSession(session)
+        const restoredSession = await resolveWithTimeout(
+          getCurrentSession,
+          AUTH_REQUEST_TIMEOUT_MS,
+          null,
+          'Initial session restore',
+        )
+
+        if (restoredSession?.user) {
+          setUser(restoredSession.user)
+          setSession(restoredSession)
           try {
-            const userProfile = await fetchProfileFromAPI(session, true)
+            const userProfile = await fetchProfileFromAPI(restoredSession, true)
             setProfile(userProfile)
           } catch (profileError) {
             console.warn('Profile fetch error:', profileError)
           }
         }
-        const user = await getCurrentUser()
-        setUser(user)
-        if (user) {
-          const currentSession = await getCurrentSession()
+
+        const currentUser = await resolveWithTimeout(
+          getCurrentUser,
+          AUTH_REQUEST_TIMEOUT_MS,
+          null,
+          'Current user request',
+        )
+        setUser(currentUser)
+
+        if (currentUser) {
+          const currentSession = await resolveWithTimeout(
+            getCurrentSession,
+            AUTH_REQUEST_TIMEOUT_MS,
+            null,
+            'Current session refresh',
+          )
           if (currentSession) {
             setSession(currentSession)
-            if (!session?.user) {
+            if (!restoredSession?.user) {
               try {
                 const userProfile = await fetchProfileFromAPI(currentSession, true)
                 setProfile(userProfile)
@@ -94,6 +148,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           }
         } else {
           setSession(null)
+          setProfile(null)
         }
       } catch (error) {
         console.error('Auth init error:', error)


### PR DESCRIPTION
## Summary
- Add bounded client-side waits around initial Supabase auth/session/profile requests.
- Prevent protected admin routes from sitting indefinitely on the black Loading screen when auth restore stalls.
- Add a regression test for stalled initial session restore.

## Validation
- npx vitest run components/AuthProvider.test.tsx components/ProtectedRoute.test.tsx
- npx tsc --noEmit --pretty false
- In-app Browser smoke: /admin/content/visual-assets redirects to /auth/login?redirect=%2Fadmin%2Fcontent%2Fvisual-assets instead of remaining on Loading.
- Push hook database health check passed.
- Full npm run build not run for this scoped auth fix.

## Integration Notes
- No migrations or env changes.
- Non-captain branch; do not merge from this thread.
- Vercel – portfolio: not checked.
- Vercel – portfolio-staging: not checked.