### PR TITLE
feat: add social calibration reference library

### DIFF
--- a/app/admin/social-content/[id]/page.test.tsx
+++ b/app/admin/social-content/[id]/page.test.tsx
@@ -232,6 +232,75 @@ describe('SocialContentDetailRoute visual production review', () => {
     })
   })
 
+  it('lets the operator add a reusable calibration reference to the feedback packet', async () => {
+    const draftItem = {
+      ...baseItem,
+      status: 'draft',
+      reviewed_by: null,
+    }
+    const calibrationReference = {
+      id: 'linkedin-builder-insight-production-readiness',
+      platform: 'linkedin',
+      label: 'Builder insight: production readiness',
+      source_type: 'voice_guide_reference',
+      content_pillar: 'AI and product management',
+      post_excerpt: 'Anyone can build an app right now.\n\nThat speed does not give you production readiness.',
+      engagement_signal: 'Approved voice-guide reference. Measured LinkedIn engagement has not been imported yet.',
+      why_it_worked: 'It starts with a concrete builder reality, names the tools, then moves into operational risk.',
+      claim_boundaries: ['Do not overstate production readiness.'],
+      provenance: 'docs/linkedin-voice.md',
+    }
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/calibration-library')) {
+        return {
+          ok: true,
+          json: async () => ({
+            references: [calibrationReference],
+            source: 'approved_calibration_library',
+            side_effects: {
+              provider_generation: false,
+              publish: false,
+              schedule: false,
+              external_post: false,
+            },
+          }),
+        } as Response
+      }
+      if (url.includes('/topic-backlog')) {
+        return {
+          ok: true,
+          json: async () => ({ items: [topicBacklogItem] }),
+        } as Response
+      }
+      return {
+        ok: true,
+        json: async () => ({ item: draftItem }),
+      } as Response
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderAtStep('context')
+
+    fireEvent.click(await screen.findByText('Content calibration'))
+    expect(await screen.findByText('Reusable calibration library')).toBeInTheDocument()
+    const referenceCard = screen.getByText('Builder insight: production readiness').closest('.rounded-lg')
+    expect(referenceCard).toBeTruthy()
+    fireEvent.click(within(referenceCard as HTMLElement).getByRole('button', { name: 'Add' }))
+
+    expect(screen.getByDisplayValue('Builder insight: production readiness (docs/linkedin-voice.md)')).toBeInTheDocument()
+    expect(screen.getByDisplayValue(/Anyone can build an app right now/)).toBeInTheDocument()
+    expect(screen.getByDisplayValue(/Approved voice-guide reference/)).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Do not overstate production readiness.')).toBeInTheDocument()
+    expect(within(referenceCard as HTMLElement).getByRole('button', { name: 'Added' })).toBeDisabled()
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/api/admin/social-content/calibration-library?platform=linkedin'),
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer admin-token' },
+      }),
+    )
+  })
+
   it('shows production assets and blocks publish readiness while redaction is unresolved', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => ({
       ok: true,

--- a/app/admin/social-content/[id]/page.tsx
+++ b/app/admin/social-content/[id]/page.tsx
@@ -60,6 +60,7 @@ import type {
   FrameworkVisualType,
   SocialPlatform,
 } from '@/lib/social-content'
+import type { SocialContentCalibrationReference } from '@/lib/social-content-calibration-library'
 import Link from 'next/link'
 
 const PLATFORM_ICONS: Record<string, React.ReactNode> = {
@@ -322,6 +323,9 @@ function SocialContentDetailPage() {
     privacy: false,
     linkedin_draft: false,
   })
+  const [calibrationLibraryReferences, setCalibrationLibraryReferences] = useState<SocialContentCalibrationReference[]>([])
+  const [loadingCalibrationLibrary, setLoadingCalibrationLibrary] = useState(false)
+  const [calibrationLibraryUnavailable, setCalibrationLibraryUnavailable] = useState(false)
   const rejectedGateKeysRef = useRef<SectionGateKey[]>([])
 
   const fetchTopicBacklog = useCallback(async () => {
@@ -341,6 +345,30 @@ function SocialContentDetailPage() {
       console.error('Failed to fetch topic backlog:', err)
     } finally {
       setLoadingTopicBacklog(false)
+    }
+  }, [])
+
+  const fetchCalibrationLibrary = useCallback(async () => {
+    setLoadingCalibrationLibrary(true)
+    setCalibrationLibraryUnavailable(false)
+    try {
+      const session = await getCurrentSession()
+      if (!session) return
+
+      const res = await fetch('/api/admin/social-content/calibration-library?platform=linkedin', {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setCalibrationLibraryUnavailable(true)
+        return
+      }
+      setCalibrationLibraryReferences(Array.isArray(data.references) ? data.references : [])
+    } catch (err) {
+      console.error('Failed to fetch social calibration library:', err)
+      setCalibrationLibraryUnavailable(true)
+    } finally {
+      setLoadingCalibrationLibrary(false)
     }
   }, [])
 
@@ -420,9 +448,56 @@ function SocialContentDetailPage() {
     fetchTopicBacklog()
   }, [fetchTopicBacklog])
 
+  useEffect(() => {
+    const rag = asRecord(item?.rag_context)
+    if (rag?.source !== 'agent_ops_social_outreach_goal') return
+    void fetchCalibrationLibrary()
+  }, [fetchCalibrationLibrary, item?.rag_context])
+
   const showMsg = (type: 'success' | 'error', text: string) => {
     setMessage({ type, text })
     setTimeout(() => setMessage(null), 4000)
+  }
+
+  const addCalibrationLibraryReference = (reference: SocialContentCalibrationReference) => {
+    setCalibrationFeedback((current) => {
+      const sourceLabel = `${reference.label} (${reference.provenance})`
+      const alreadyAdded = current.success_examples.some((example) => (
+        example.source_label.trim() === sourceLabel
+        || example.source_label.trim() === reference.label
+      ))
+      if (alreadyAdded) return current
+
+      const nextExample: CalibrationSuccessExample = {
+        source_label: sourceLabel,
+        post_excerpt: reference.post_excerpt,
+        engagement_signal: reference.engagement_signal,
+        why_it_worked: reference.why_it_worked,
+      }
+      const hasOnlyBlankExample = current.success_examples.length === 1
+        && !current.success_examples[0].source_label.trim()
+        && !current.success_examples[0].post_excerpt.trim()
+        && !current.success_examples[0].engagement_signal.trim()
+        && !current.success_examples[0].why_it_worked.trim()
+      const existingBoundaries = current.claim_boundaries
+        .split('\n')
+        .map((item) => item.trim())
+        .filter(Boolean)
+      const newBoundaries = reference.claim_boundaries
+        .filter((boundary) => !existingBoundaries.includes(boundary))
+
+      return {
+        ...current,
+        success_examples: hasOnlyBlankExample
+          ? [nextExample]
+          : [...current.success_examples, nextExample],
+        claim_boundaries: [
+          current.claim_boundaries.trim(),
+          ...newBoundaries,
+        ].filter(Boolean).join('\n'),
+      }
+    })
+    showMsg('success', 'Calibration reference added to this draft')
   }
 
   const getRejectedSectionGateKeys = useCallback((contentItem: SocialContentItem | null) => {
@@ -2040,6 +2115,72 @@ function SocialContentDetailPage() {
                         Add reference
                       </button>
                     </div>
+                    {isAgentSocialPilot && (
+                      <div className="mt-3 rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-3">
+                        <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                          <div>
+                            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-emerald-200">Reusable calibration library</p>
+                            <p className="mt-1 text-sm leading-6 text-emerald-50/80">
+                              Add approved voice patterns as comparison material. These are draft-only references, not publishing instructions.
+                            </p>
+                          </div>
+                          {loadingCalibrationLibrary && (
+                            <span className="inline-flex w-fit items-center gap-2 rounded-full border border-emerald-400/25 px-2 py-0.5 text-xs text-emerald-100">
+                              <Loader2 className="h-3 w-3 animate-spin" />
+                              Loading
+                            </span>
+                          )}
+                        </div>
+                        {calibrationLibraryUnavailable && (
+                          <p className="mt-2 text-xs leading-5 text-amber-200">
+                            Calibration library unavailable. Manual references still work.
+                          </p>
+                        )}
+                        {!loadingCalibrationLibrary && calibrationLibraryReferences.length === 0 && !calibrationLibraryUnavailable && (
+                          <p className="mt-2 text-xs leading-5 text-emerald-50/65">
+                            No reusable references are available for this platform yet.
+                          </p>
+                        )}
+                        {calibrationLibraryReferences.length > 0 && (
+                          <div className="mt-3 grid gap-2 lg:grid-cols-2">
+                            {calibrationLibraryReferences.map((reference) => {
+                              const sourceLabel = `${reference.label} (${reference.provenance})`
+                              const alreadyAdded = calibrationFeedback.success_examples.some((example) => (
+                                example.source_label.trim() === sourceLabel
+                                || example.source_label.trim() === reference.label
+                              ))
+                              return (
+                                <div key={reference.id} className="rounded-lg border border-emerald-400/20 bg-background/35 p-3">
+                                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                                    <div className="min-w-0">
+                                      <p className="text-sm font-semibold text-emerald-50">{reference.label}</p>
+                                      <p className="mt-1 text-xs uppercase tracking-[0.12em] text-emerald-100/70">
+                                        {reference.content_pillar}
+                                      </p>
+                                    </div>
+                                    <button
+                                      type="button"
+                                      onClick={() => addCalibrationLibraryReference(reference)}
+                                      disabled={!isEditable || alreadyAdded}
+                                      className="inline-flex shrink-0 items-center justify-center gap-1 rounded-lg border border-emerald-400/35 px-2.5 py-1.5 text-xs font-semibold text-emerald-100 transition-colors hover:bg-emerald-500/10 disabled:opacity-50"
+                                    >
+                                      {alreadyAdded ? <CheckCircle2 className="h-3 w-3" /> : <Plus className="h-3 w-3" />}
+                                      {alreadyAdded ? 'Added' : 'Add'}
+                                    </button>
+                                  </div>
+                                  <p className="mt-2 line-clamp-3 text-xs leading-5 text-emerald-50/75">
+                                    {reference.why_it_worked}
+                                  </p>
+                                  <p className="mt-2 text-[11px] leading-5 text-emerald-50/55">
+                                    {reference.engagement_signal}
+                                  </p>
+                                </div>
+                              )
+                            })}
+                          </div>
+                        )}
+                      </div>
+                    )}
                     <div className="mt-3 grid gap-3">
                       {calibrationFeedback.success_examples.map((example, index) => (
                         <div key={index} className="rounded-lg border border-silicon-slate/80 bg-imperial-navy/45 p-3">

--- a/app/api/admin/social-content/calibration-library/route.test.ts
+++ b/app/api/admin/social-content/calibration-library/route.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+import { GET } from './route'
+
+describe('GET /api/admin/social-content/calibration-library', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-1' }, isAdmin: true })
+    mocks.isAuthError.mockReturnValue(false)
+  })
+
+  it('returns reusable LinkedIn calibration references without side effects', async () => {
+    const response = await GET(new NextRequest('http://localhost/api/admin/social-content/calibration-library?platform=linkedin'))
+
+    expect(response.status).toBe(200)
+    const json = await response.json()
+    expect(json).toMatchObject({
+      source: 'approved_calibration_library',
+      side_effects: {
+        provider_generation: false,
+        publish: false,
+        schedule: false,
+        external_post: false,
+      },
+    })
+    expect(json.references).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'linkedin-builder-insight-production-readiness',
+        platform: 'linkedin',
+        source_type: 'voice_guide_reference',
+        provenance: 'docs/linkedin-voice.md',
+      }),
+      expect.objectContaining({
+        id: 'linkedin-governed-agent-work',
+        platform: 'linkedin',
+        source_type: 'operator_approved_pattern',
+      }),
+    ]))
+  })
+
+  it('requires admin auth before exposing calibration references', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Authentication required', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await GET(new NextRequest('http://localhost/api/admin/social-content/calibration-library'))
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Authentication required' })
+  })
+
+  it('returns an empty set for unsupported platforms', async () => {
+    const response = await GET(new NextRequest('http://localhost/api/admin/social-content/calibration-library?platform=tiktok'))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      references: [],
+      source: 'approved_calibration_library',
+    })
+  })
+})

--- a/app/api/admin/social-content/calibration-library/route.ts
+++ b/app/api/admin/social-content/calibration-library/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { listSocialContentCalibrationReferences } from '@/lib/social-content-calibration-library'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  try {
+    const authResult = await verifyAdmin(request)
+    if (isAuthError(authResult)) {
+      return NextResponse.json({ error: authResult.error }, { status: authResult.status })
+    }
+
+    const { searchParams } = new URL(request.url)
+    const platform = searchParams.get('platform') || 'linkedin'
+    const references = listSocialContentCalibrationReferences({ platform })
+
+    return NextResponse.json({
+      references,
+      source: 'approved_calibration_library',
+      side_effects: {
+        provider_generation: false,
+        publish: false,
+        schedule: false,
+        external_post: false,
+      },
+    })
+  } catch (error) {
+    console.error('[social-content-calibration-library] list failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to fetch calibration references' },
+      { status: 500 },
+    )
+  }
+}

--- a/lib/social-content-calibration-library.ts
+++ b/lib/social-content-calibration-library.ts
@@ -1,0 +1,118 @@
+export type SocialContentCalibrationPlatform = 'linkedin'
+
+export type SocialContentCalibrationReference = {
+  id: string
+  platform: SocialContentCalibrationPlatform
+  label: string
+  source_type: 'voice_guide_reference' | 'operator_approved_pattern'
+  content_pillar: string
+  post_excerpt: string
+  engagement_signal: string
+  why_it_worked: string
+  claim_boundaries: string[]
+  provenance: string
+}
+
+const LINKEDIN_CALIBRATION_REFERENCES: SocialContentCalibrationReference[] = [
+  {
+    id: 'linkedin-builder-insight-production-readiness',
+    platform: 'linkedin',
+    label: 'Builder insight: production readiness',
+    source_type: 'voice_guide_reference',
+    content_pillar: 'AI and product management',
+    post_excerpt: [
+      'Anyone can build an app right now.',
+      '',
+      'Cursor. Replit. Bolt. Lovable. You can go from idea to working product in an afternoon.',
+      '',
+      'That speed does not give you the infrastructure that makes something safe to hand to another human being.',
+    ].join('\n'),
+    engagement_signal: 'Approved voice-guide reference. Measured LinkedIn engagement has not been imported yet.',
+    why_it_worked: 'It starts with a concrete builder reality, names the tools, then moves into the operational risk instead of generic AI enthusiasm.',
+    claim_boundaries: [
+      'Do not overstate production readiness.',
+      'Keep the lesson practical and accountable.',
+      'Avoid generic AI hype.',
+    ],
+    provenance: 'docs/linkedin-voice.md',
+  },
+  {
+    id: 'linkedin-access-exposure-metco',
+    platform: 'linkedin',
+    label: 'Access and exposure: METCO bus ride',
+    source_type: 'voice_guide_reference',
+    content_pillar: 'Technology as equalizer',
+    post_excerpt: [
+      'I took a 45-minute bus ride every morning from Roxbury to a school in the suburbs.',
+      '',
+      'Same state. Same city limits, almost. Different planet.',
+      '',
+      'That ride showed me what was possible. Exposure expands the ceiling you did not know was there.',
+    ].join('\n'),
+    engagement_signal: 'Approved voice-guide reference. Use when the draft needs a human entry point before the systems lesson.',
+    why_it_worked: 'It opens with a scene, stays plainspoken, and earns the access argument through lived experience.',
+    claim_boundaries: [
+      'Use personal context only when it clarifies the operational point.',
+      'Do not flatten lived experience into trauma branding.',
+      'Do not force the story if the draft is primarily tactical.',
+    ],
+    provenance: 'docs/linkedin-voice.md',
+  },
+  {
+    id: 'linkedin-ai-reduces-burden',
+    platform: 'linkedin',
+    label: 'Operator burden: AI should reduce work',
+    source_type: 'operator_approved_pattern',
+    content_pillar: 'Entrepreneurship',
+    post_excerpt: [
+      'A small business does not need another AI demo.',
+      '',
+      'It needs fewer tabs open, fewer follow-ups lost, fewer moments where the owner has to remember what the system should have remembered.',
+      '',
+      'The question is not whether AI can generate output. The question is whether the work gets lighter.',
+    ].join('\n'),
+    engagement_signal: 'Reusable approved pattern for AmaduTown operator-facing posts. Measured engagement pending Open Brain import.',
+    why_it_worked: 'It centers the operator burden, avoids tool-first messaging, and makes the value of automation concrete.',
+    claim_boundaries: [
+      'Do not imply autonomous outreach or publishing.',
+      'Keep claims tied to work already visible in Portfolio or approved evidence.',
+      'Avoid vague transformation language.',
+    ],
+    provenance: 'Agent Ops social outreach calibration packet',
+  },
+  {
+    id: 'linkedin-governed-agent-work',
+    platform: 'linkedin',
+    label: 'Governed agents: readiness before delegation',
+    source_type: 'operator_approved_pattern',
+    content_pillar: 'AI and product management',
+    post_excerpt: [
+      'Agentic work needs a meeting before it needs a task list.',
+      '',
+      'Define what ready means. Name the source material. Set the authority boundary. Decide what requires a human gate.',
+      '',
+      'Then let the agents move.',
+    ].join('\n'),
+    engagement_signal: 'Reusable approved pattern for Agent Ops posts. Best for posts about Mission Control, readiness gates, and delegation.',
+    why_it_worked: 'It turns the product architecture into a practical management principle with clear stages.',
+    claim_boundaries: [
+      'Do not suggest agents can merge, publish, send, or deploy without approval gates.',
+      'Keep Shaka framed as facilitator, not autonomous executive authority.',
+      'Preserve draft-only boundaries for external-facing workflows.',
+    ],
+    provenance: 'Agent Ops Goal Readiness Gate V1',
+  },
+]
+
+export function listSocialContentCalibrationReferences(options: {
+  platform?: string | null
+} = {}): SocialContentCalibrationReference[] {
+  const platform = options.platform?.toLowerCase()
+  if (!platform || platform === 'all') return [...LINKEDIN_CALIBRATION_REFERENCES]
+  if (platform !== 'linkedin') return []
+  return [...LINKEDIN_CALIBRATION_REFERENCES]
+}
+
+export function getSocialContentCalibrationReferenceById(id: string) {
+  return LINKEDIN_CALIBRATION_REFERENCES.find((reference) => reference.id === id) ?? null
+}


### PR DESCRIPTION
## Summary
- Add a reusable LinkedIn calibration reference library for Social Content drafts.
- Add a read-only admin API endpoint that returns approved calibration references with explicit no-publish side effects.
- Surface reusable references inside the Agent Ops Social Content calibration flow so operators can add approved voice patterns into structured feedback without retyping examples.

## Validation
- npm test -- app/api/admin/social-content/calibration-library/route.test.ts 'app/api/admin/social-content/[id]/route.test.ts' 'app/admin/social-content/[id]/page.test.tsx' 'app/api/admin/social-content/[id]/calibration-revision/route.test.ts'
- npm run build:knowledge
- npx tsc --noEmit --pretty false
- npm run lint
- git diff --check
- npm run build
- Local authenticated smoke on http://localhost:3017/admin/social-content/25d7efa3-62bc-4f5e-a191-1a131918593a?step=context confirmed the calibration library rendered on a real Agent Ops social draft page.

## Integration Notes
- No database migration.
- No publishing, scheduling, provider generation, DM, send, or external outreach behavior added.
- References are approved pattern/voice-guide entries, not raw private LinkedIn exports.
- Vercel – portfolio: not checked yet for this PR branch.
- Vercel – portfolio-staging: not checked yet for this PR branch.