### PR TITLE
feat: add social calibration history references

### DIFF
--- a/app/api/admin/social-content/calibration-library/route.test.ts
+++ b/app/api/admin/social-content/calibration-library/route.test.ts
@@ -4,11 +4,22 @@ import { NextRequest } from 'next/server'
 const mocks = vi.hoisted(() => ({
   verifyAdmin: vi.fn(),
   isAuthError: vi.fn(),
+  from: vi.fn(),
+  select: vi.fn(),
+  inFilter: vi.fn(),
+  order: vi.fn(),
+  limit: vi.fn(),
 }))
 
 vi.mock('@/lib/auth-server', () => ({
   verifyAdmin: mocks.verifyAdmin,
   isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
 }))
 
 import { GET } from './route'
@@ -18,6 +29,42 @@ describe('GET /api/admin/social-content/calibration-library', () => {
     vi.clearAllMocks()
     mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-1' }, isAdmin: true })
     mocks.isAuthError.mockReturnValue(false)
+    mocks.limit.mockResolvedValue({
+      data: [
+        {
+          id: 'social-history-1',
+          platform: 'linkedin',
+          status: 'published',
+          post_text: 'A small business does not need another AI demo. It needs the work to get lighter.',
+          cta_text: 'What work should AI remove first?',
+          hashtags: ['#AIProduct'],
+          topic_extracted: { topic: 'AI should reduce operator burden' },
+          rag_context: {
+            engagement: {
+              latest_score: 81,
+              recommendation_label: 'high signal',
+              mapped_theme: 'operator burden',
+              latest: {
+                comments: 4,
+                shares: 2,
+                reactions: 37,
+                capturedAt: '2026-07-01T12:00:00.000Z',
+              },
+            },
+          },
+          content_pillar: 'AI and product management',
+          target_platforms: ['linkedin'],
+          published_at: '2026-06-30T12:00:00.000Z',
+          updated_at: '2026-07-01T12:00:00.000Z',
+          created_at: '2026-06-29T12:00:00.000Z',
+        },
+      ],
+      error: null,
+    })
+    mocks.order.mockReturnValue({ limit: mocks.limit })
+    mocks.inFilter.mockReturnValue({ order: mocks.order })
+    mocks.select.mockReturnValue({ in: mocks.inFilter })
+    mocks.from.mockReturnValue({ select: mocks.select })
   })
 
   it('returns reusable LinkedIn calibration references without side effects', async () => {
@@ -27,6 +74,11 @@ describe('GET /api/admin/social-content/calibration-library', () => {
     const json = await response.json()
     expect(json).toMatchObject({
       source: 'approved_calibration_library',
+      counts: {
+        portfolio_history: 1,
+        static_references: 4,
+        total: 5,
+      },
       side_effects: {
         provider_generation: false,
         publish: false,
@@ -35,6 +87,13 @@ describe('GET /api/admin/social-content/calibration-library', () => {
       },
     })
     expect(json.references).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'portfolio-social-social-history-1',
+        platform: 'linkedin',
+        source_type: 'portfolio_content_history',
+        engagement_signal: expect.stringContaining('Engagement score 81'),
+        provenance: '/admin/social-content/social-history-1',
+      }),
       expect.objectContaining({
         id: 'linkedin-builder-insight-production-readiness',
         platform: 'linkedin',
@@ -47,6 +106,8 @@ describe('GET /api/admin/social-content/calibration-library', () => {
         source_type: 'operator_approved_pattern',
       }),
     ]))
+    expect(mocks.from).toHaveBeenCalledWith('social_content_queue')
+    expect(mocks.inFilter).toHaveBeenCalledWith('status', ['published', 'approved'])
   })
 
   it('requires admin auth before exposing calibration references', async () => {
@@ -57,6 +118,7 @@ describe('GET /api/admin/social-content/calibration-library', () => {
 
     expect(response.status).toBe(401)
     expect(await response.json()).toEqual({ error: 'Authentication required' })
+    expect(mocks.from).not.toHaveBeenCalled()
   })
 
   it('returns an empty set for unsupported platforms', async () => {
@@ -67,5 +129,22 @@ describe('GET /api/admin/social-content/calibration-library', () => {
       references: [],
       source: 'approved_calibration_library',
     })
+    expect(mocks.from).not.toHaveBeenCalled()
+  })
+
+  it('can return only static references when history is disabled', async () => {
+    const response = await GET(new NextRequest('http://localhost/api/admin/social-content/calibration-library?platform=linkedin&include_history=false'))
+
+    expect(response.status).toBe(200)
+    const json = await response.json()
+    expect(json.counts).toEqual({
+      portfolio_history: 0,
+      static_references: 4,
+      total: 4,
+    })
+    expect(json.references).toEqual(expect.not.arrayContaining([
+      expect.objectContaining({ source_type: 'portfolio_content_history' }),
+    ]))
+    expect(mocks.from).not.toHaveBeenCalled()
   })
 })

--- a/app/api/admin/social-content/calibration-library/route.ts
+++ b/app/api/admin/social-content/calibration-library/route.ts
@@ -1,6 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { verifyAdmin, isAuthError } from '@/lib/auth-server'
-import { listSocialContentCalibrationReferences } from '@/lib/social-content-calibration-library'
+import { supabaseAdmin } from '@/lib/supabase'
+import {
+  listSocialContentCalibrationReferences,
+  socialContentHistoryReferenceFromRow,
+  type SocialContentCalibrationHistoryRow,
+  type SocialContentCalibrationReference,
+} from '@/lib/social-content-calibration-library'
 
 export const dynamic = 'force-dynamic'
 
@@ -13,11 +19,36 @@ export async function GET(request: NextRequest) {
 
     const { searchParams } = new URL(request.url)
     const platform = searchParams.get('platform') || 'linkedin'
-    const references = listSocialContentCalibrationReferences({ platform })
+    const includeHistory = searchParams.get('include_history') !== 'false'
+    const historyLimit = Math.min(Math.max(parseInt(searchParams.get('history_limit') || '8', 10), 0), 20)
+    const staticReferences = listSocialContentCalibrationReferences({ platform })
+    let historyReferences: SocialContentCalibrationReference[] = []
+
+    if (includeHistory && platform.toLowerCase() === 'linkedin' && historyLimit > 0) {
+      const { data, error } = await supabaseAdmin
+        .from('social_content_queue')
+        .select('id, platform, status, post_text, cta_text, hashtags, topic_extracted, rag_context, content_pillar, target_platforms, published_at, updated_at, created_at')
+        .in('status', ['published', 'approved'])
+        .order('updated_at', { ascending: false })
+        .limit(historyLimit * 2)
+
+      if (error) throw new Error(error.message)
+
+      historyReferences = ((data ?? []) as SocialContentCalibrationHistoryRow[])
+        .map(socialContentHistoryReferenceFromRow)
+        .filter((reference): reference is NonNullable<typeof reference> => Boolean(reference))
+        .slice(0, historyLimit)
+    }
+    const references = [...historyReferences, ...staticReferences]
 
     return NextResponse.json({
       references,
       source: 'approved_calibration_library',
+      counts: {
+        portfolio_history: historyReferences.length,
+        static_references: staticReferences.length,
+        total: references.length,
+      },
       side_effects: {
         provider_generation: false,
         publish: false,

--- a/lib/social-content-calibration-library.ts
+++ b/lib/social-content-calibration-library.ts
@@ -4,13 +4,29 @@ export type SocialContentCalibrationReference = {
   id: string
   platform: SocialContentCalibrationPlatform
   label: string
-  source_type: 'voice_guide_reference' | 'operator_approved_pattern'
+  source_type: 'voice_guide_reference' | 'operator_approved_pattern' | 'portfolio_content_history'
   content_pillar: string
   post_excerpt: string
   engagement_signal: string
   why_it_worked: string
   claim_boundaries: string[]
   provenance: string
+}
+
+export type SocialContentCalibrationHistoryRow = {
+  id: string
+  platform?: string | null
+  status?: string | null
+  post_text?: string | null
+  cta_text?: string | null
+  hashtags?: string[] | null
+  topic_extracted?: unknown
+  rag_context?: Record<string, unknown> | null
+  content_pillar?: string | null
+  target_platforms?: string[] | null
+  published_at?: string | null
+  updated_at?: string | null
+  created_at?: string | null
 }
 
 const LINKEDIN_CALIBRATION_REFERENCES: SocialContentCalibrationReference[] = [
@@ -115,4 +131,115 @@ export function listSocialContentCalibrationReferences(options: {
 
 export function getSocialContentCalibrationReferenceById(id: string) {
   return LINKEDIN_CALIBRATION_REFERENCES.find((reference) => reference.id === id) ?? null
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+}
+
+function asString(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function truncateReferenceText(value: string, maxLength = 900) {
+  const normalized = value.replace(/\n{3,}/g, '\n\n').trim()
+  if (normalized.length <= maxLength) return normalized
+  return `${normalized.slice(0, maxLength).trim()}...`
+}
+
+function isLinkedInHistoryRow(row: SocialContentCalibrationHistoryRow) {
+  const targetPlatforms = Array.isArray(row.target_platforms) ? row.target_platforms : []
+  return row.platform === 'linkedin' || targetPlatforms.includes('linkedin')
+}
+
+function formatHistoryDate(value: string | null | undefined) {
+  if (!value) return null
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return null
+  return date.toISOString().slice(0, 10)
+}
+
+function buildHistoryEngagementSignal(row: SocialContentCalibrationHistoryRow) {
+  const ragContext = asRecord(row.rag_context) ?? {}
+  const engagement = asRecord(ragContext.engagement) ?? {}
+  const latest = asRecord(engagement.latest) ?? {}
+  const score = asNumber(engagement.latest_score)
+  const recommendation = asString(engagement.recommendation_label)
+  const comments = asNumber(latest.comments)
+  const shares = asNumber(latest.shares) ?? asNumber(latest.reposts)
+  const reactions = asNumber(latest.reactions) ?? asNumber(latest.likes)
+  const capturedAt = asString(latest.capturedAt)
+
+  if (score !== null || comments !== null || shares !== null || reactions !== null) {
+    return [
+      score !== null ? `Engagement score ${score}` : '',
+      recommendation,
+      comments !== null ? `${comments} comment(s)` : '',
+      shares !== null ? `${shares} share/repost signal(s)` : '',
+      reactions !== null ? `${reactions} reaction(s)` : '',
+      capturedAt ? `Captured ${formatHistoryDate(capturedAt) ?? capturedAt}` : '',
+    ].filter(Boolean).join(' · ')
+  }
+
+  const publishedAt = formatHistoryDate(row.published_at)
+  if (publishedAt) {
+    return `Published Portfolio LinkedIn post on ${publishedAt}. Measured engagement has not been captured yet.`
+  }
+
+  return 'Approved Portfolio Social Content draft. Measured LinkedIn engagement has not been captured yet.'
+}
+
+export function socialContentHistoryReferenceFromRow(
+  row: SocialContentCalibrationHistoryRow,
+): SocialContentCalibrationReference | null {
+  const status = row.status ?? ''
+  if (!['approved', 'published'].includes(status)) return null
+  if (!isLinkedInHistoryRow(row)) return null
+
+  const postText = asString(row.post_text).trim()
+  if (!postText) return null
+
+  const topic = asRecord(row.topic_extracted)
+  const topicLabel = asString(topic?.topic) || asString(topic?.angle)
+  const contentPillar = row.content_pillar || asString(topic?.topic) || 'Portfolio social content'
+  const referenceDate = formatHistoryDate(row.published_at) ?? formatHistoryDate(row.updated_at) ?? formatHistoryDate(row.created_at)
+  const labelParts = [
+    'Portfolio history',
+    topicLabel || row.content_pillar || status,
+    referenceDate,
+  ].filter(Boolean)
+
+  const ragContext = asRecord(row.rag_context) ?? {}
+  const engagement = asRecord(ragContext.engagement) ?? {}
+  const mappedTheme = asString(engagement.mapped_theme)
+  const sourceProvenance = Array.isArray(ragContext.source_provenance_checklist)
+    ? ragContext.source_provenance_checklist.filter((item): item is string => typeof item === 'string')
+    : []
+
+  return {
+    id: `portfolio-social-${row.id}`,
+    platform: 'linkedin',
+    label: labelParts.join(' · '),
+    source_type: 'portfolio_content_history',
+    content_pillar: contentPillar,
+    post_excerpt: truncateReferenceText(postText),
+    engagement_signal: buildHistoryEngagementSignal(row),
+    why_it_worked: [
+      'This was already approved in Portfolio Social Content',
+      status === 'published' ? 'and moved through the LinkedIn publish path' : '',
+      mappedTheme ? `with mapped theme: ${mappedTheme}` : '',
+    ].filter(Boolean).join(' '),
+    claim_boundaries: [
+      'Reuse as a voice and structure reference only.',
+      'Do not copy private source details unless they are already public-safe in this draft.',
+      ...sourceProvenance.slice(0, 2),
+    ],
+    provenance: `/admin/social-content/${row.id}`,
+  }
 }


### PR DESCRIPTION
## Summary
- Adds approved/published Portfolio Social Content history to the LinkedIn calibration library response.
- Keeps static approved voice references as fallback and reports counts for portfolio-history vs static references.
- Preserves the prepare-only contract: no provider generation, publish, schedule, or external post side effects.

## Validation
- `npm test -- app/api/admin/social-content/calibration-library/route.test.ts 'app/admin/social-content/[id]/page.test.tsx'` passed: 12 tests.
- `npx tsc --noEmit --pretty false` passed.
- `npm run lint` passed with existing unrelated `<img>` warnings in `app/client/dashboard/[token]/page.tsx` and `components/Navigation.test.tsx`.
- `git diff --check` passed.
- `npm run build` passed with existing local warning that outbound n8n webhooks are enabled in `.env.local`.
- Pre-push `npm run db:health-check` passed.

## Integration Notes
- No schema migration.
- Uses existing `social_content_queue` rows with `status in (published, approved)` and LinkedIn platform targeting.
- Vercel – portfolio: pending PR check.
- Vercel – portfolio-staging: pending PR check.
- No live LinkedIn publish/send/schedule smoke was run; this is read-only calibration context.
