### PR TITLE
feat: add TikTok social review readiness

### DIFF
--- a/app/admin/agents/content-intelligence/page.test.tsx
+++ b/app/admin/agents/content-intelligence/page.test.tsx
@@ -246,6 +246,14 @@ describe('ContentIntelligencePage', () => {
                   status: 'not_started',
                   required_inputs: ['hook', 'script'],
                 },
+                {
+                  work_item_id: 'work-social-1',
+                  insight_title: 'Approval gates create trust',
+                  channel: 'tiktok',
+                  label: 'TikTok',
+                  status: 'not_started',
+                  required_inputs: ['hook', 'caption', 'audio rights'],
+                },
               ],
               thumbnail_opportunities: [
                 {
@@ -334,6 +342,8 @@ describe('ContentIntelligencePage', () => {
                 channel_lanes: {
                   linkedin: { status: 'selected', label: 'LinkedIn', required_inputs: ['post text', 'CTA'] },
                   youtube_shorts: { status: 'not_started', label: 'YouTube Shorts', required_inputs: ['hook', 'script'] },
+                  instagram_reels: { status: 'not_started', label: 'Instagram Reels', required_inputs: ['hook', 'caption'] },
+                  tiktok: { status: 'not_started', label: 'TikTok', required_inputs: ['hook', 'caption', 'audio rights'] },
                 },
               },
               updated_at: '2026-06-23T12:00:00.000Z',
@@ -385,6 +395,18 @@ describe('ContentIntelligencePage', () => {
                     draft_packet: { channel: 'youtube_shorts', fields: { script: ['YouTube draft'] } },
                     required_inputs: ['hook', 'script'],
                   },
+                  instagram_reels: {
+                    status: 'in_review',
+                    label: 'Instagram Reels',
+                    draft_packet: { channel: 'instagram_reels', fields: { caption: 'Instagram draft' } },
+                    required_inputs: ['hook', 'caption'],
+                  },
+                  tiktok: {
+                    status: 'in_review',
+                    label: 'TikTok',
+                    draft_packet: { channel: 'tiktok', fields: { caption: 'TikTok draft', audio_rights: 'platform-safe audio' } },
+                    required_inputs: ['hook', 'caption', 'audio rights'],
+                  },
                 },
               },
               updated_at: '2026-06-23T12:00:00.000Z',
@@ -421,6 +443,8 @@ describe('ContentIntelligencePage', () => {
                   channel_lanes: {
                     linkedin: { status: 'selected', label: 'LinkedIn', required_inputs: ['post text', 'CTA'] },
                     youtube_shorts: { status: 'not_started', label: 'YouTube Shorts', required_inputs: ['hook', 'script'] },
+                    instagram_reels: { status: 'not_started', label: 'Instagram Reels', required_inputs: ['hook', 'caption'] },
+                    tiktok: { status: 'not_started', label: 'TikTok', required_inputs: ['hook', 'caption', 'audio rights'] },
                   },
                 },
                 updated_at: '2026-06-22T12:00:00.000Z',
@@ -553,7 +577,7 @@ describe('ContentIntelligencePage', () => {
     })
   })
 
-  it('prepares LinkedIn and YouTube channel drafts from the backlog without publishing side effects', async () => {
+  it('prepares channel drafts from the backlog without publishing side effects', async () => {
     render(<ContentIntelligencePage />)
 
     await screen.findByRole('heading', { name: 'Research and Shaka insight queue' })
@@ -566,9 +590,11 @@ describe('ContentIntelligencePage', () => {
     })
     fireEvent.click(screen.getByRole('button', { name: 'Prepare Review Drafts' }))
 
-    expect(await screen.findByText('LinkedIn and YouTube Shorts review drafts are ready for human approval.')).toBeInTheDocument()
+    expect(await screen.findByText('LinkedIn, YouTube Shorts, Instagram Reels, and TikTok review drafts are ready for human approval.')).toBeInTheDocument()
     expect(screen.getByText('LinkedIn: in review')).toBeInTheDocument()
     expect(screen.getByText('YouTube: in review')).toBeInTheDocument()
+    expect(screen.getByText('Instagram: in review')).toBeInTheDocument()
+    expect(screen.getByText('TikTok: in review')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Open human review' })).toHaveAttribute('href', '/admin/agents/social-insights/work-social-1')
 
     const prepareCall = vi.mocked(fetch).mock.calls.find(([input]) => String(input) === '/api/admin/agents/work-items/work-social-1/social-channels/prepare-review-drafts')

--- a/app/admin/agents/content-intelligence/page.tsx
+++ b/app/admin/agents/content-intelligence/page.tsx
@@ -128,7 +128,7 @@ type CalendarItem = {
   campaign_id: string | null
   agent_work_item_id: string | null
   social_content_id: string | null
-  channel: 'linkedin' | 'youtube_shorts' | 'instagram_reels' | 'thumbnail'
+  channel: 'linkedin' | 'youtube_shorts' | 'instagram_reels' | 'tiktok' | 'thumbnail'
   campaign_phase: 'tease' | 'teach' | 'proof' | 'offer'
   title: string
   planned_angle: string | null
@@ -204,6 +204,7 @@ const CALENDAR_CHANNEL_LABELS: Record<CalendarItem['channel'], string> = {
   linkedin: 'LinkedIn',
   youtube_shorts: 'YouTube Shorts',
   instagram_reels: 'Instagram Reels',
+  tiktok: 'TikTok',
   thumbnail: 'Thumbnail',
 }
 
@@ -269,22 +270,25 @@ function insightFor(item: AgentWorkItem) {
   }
 }
 
-function channelLaneFor(item: AgentWorkItem, channel: 'linkedin' | 'youtube_shorts') {
+function channelLaneFor(item: AgentWorkItem, channel: 'linkedin' | 'youtube_shorts' | 'instagram_reels' | 'tiktok') {
   const metadata = recordValue(item.metadata)
   const lanes = recordValue(metadata.channel_lanes)
   return recordValue(lanes[channel])
 }
 
-function channelLaneStatus(item: AgentWorkItem, channel: 'linkedin' | 'youtube_shorts') {
+function channelLaneStatus(item: AgentWorkItem, channel: 'linkedin' | 'youtube_shorts' | 'instagram_reels' | 'tiktok') {
   return stringValue(channelLaneFor(item, channel).status) ?? 'not_started'
 }
 
-function hasChannelReviewDraft(item: AgentWorkItem, channel: 'linkedin' | 'youtube_shorts') {
+function hasChannelReviewDraft(item: AgentWorkItem, channel: 'linkedin' | 'youtube_shorts' | 'instagram_reels' | 'tiktok') {
   return Object.keys(recordValue(channelLaneFor(item, channel).draft_packet)).length > 0
 }
 
-function hasLinkedInYoutubeReviewDrafts(item: AgentWorkItem) {
-  return hasChannelReviewDraft(item, 'linkedin') && hasChannelReviewDraft(item, 'youtube_shorts')
+function hasPrimaryChannelReviewDrafts(item: AgentWorkItem) {
+  return hasChannelReviewDraft(item, 'linkedin')
+    && hasChannelReviewDraft(item, 'youtube_shorts')
+    && hasChannelReviewDraft(item, 'instagram_reels')
+    && hasChannelReviewDraft(item, 'tiktok')
 }
 
 function suggestedResearchPacketIds(item: AgentWorkItem) {
@@ -831,7 +835,7 @@ function ContentIntelligenceContent() {
       } else {
         await load()
       }
-      setReviewDraftNotice('LinkedIn and YouTube Shorts review drafts are ready for human approval.')
+      setReviewDraftNotice('LinkedIn, YouTube Shorts, Instagram Reels, and TikTok review drafts are ready for human approval.')
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to prepare channel review drafts')
     } finally {
@@ -1957,7 +1961,9 @@ function ContentIntelligenceContent() {
                           const insight = insightFor(item)
                           const linkedinStatus = channelLaneStatus(item, 'linkedin')
                           const youtubeStatus = channelLaneStatus(item, 'youtube_shorts')
-                          const hasReviewDrafts = hasLinkedInYoutubeReviewDrafts(item)
+                          const instagramStatus = channelLaneStatus(item, 'instagram_reels')
+                          const tiktokStatus = channelLaneStatus(item, 'tiktok')
+                          const hasReviewDrafts = hasPrimaryChannelReviewDrafts(item)
                           const hasApprovedResearch = hasApprovedResearchPatterns(item)
                           const suggestedPacketIds = suggestedResearchPacketIds(item)
                           const isPreparingReview = preparingReviewInsightId === item.id
@@ -1991,6 +1997,12 @@ function ContentIntelligenceContent() {
                                   </span>
                                   <span className={`inline-flex w-fit rounded-full border px-2 py-0.5 text-xs ${channelReviewPillClass(youtubeStatus)}`}>
                                     YouTube: {youtubeStatus.replace(/_/g, ' ')}
+                                  </span>
+                                  <span className={`inline-flex w-fit rounded-full border px-2 py-0.5 text-xs ${channelReviewPillClass(instagramStatus)}`}>
+                                    Instagram: {instagramStatus.replace(/_/g, ' ')}
+                                  </span>
+                                  <span className={`inline-flex w-fit rounded-full border px-2 py-0.5 text-xs ${channelReviewPillClass(tiktokStatus)}`}>
+                                    TikTok: {tiktokStatus.replace(/_/g, ' ')}
                                   </span>
                                 </div>
                               </td>

--- a/app/admin/agents/social-insights/[id]/page.test.tsx
+++ b/app/admin/agents/social-insights/[id]/page.test.tsx
@@ -57,6 +57,7 @@ function socialWorkItem(overrides: Record<string, unknown> = {}) {
         linkedin: { status: 'selected', label: 'LinkedIn', required_inputs: ['post text', 'CTA'] },
         youtube_shorts: { status: 'not_started', label: 'YouTube Shorts', required_inputs: ['hook', 'script'] },
         instagram_reels: { status: 'not_started', label: 'Instagram Reels', required_inputs: ['hook', 'caption'] },
+        tiktok: { status: 'not_started', label: 'TikTok', required_inputs: ['hook', 'caption', 'audio rights'] },
         thumbnail: { status: 'not_started', label: 'Thumbnail', required_inputs: ['short thumbnail text', '2-3 variants'] },
       },
     },
@@ -133,6 +134,69 @@ describe('SocialInsightDetailPage', () => {
                         hook: 'AI should reduce burden.',
                         first_30_seconds: 'I noticed this through the social content review flow.',
                         script: ['Opening: AI should reduce burden.', 'Trigger: Social Content review flow.'],
+                      },
+                      side_effects: {
+                        provider_generation: false,
+                        upload: false,
+                        publish: false,
+                        schedule: false,
+                        external_post: false,
+                      },
+                    },
+                  },
+                  instagram_reels: {
+                    ...base.metadata.channel_lanes.instagram_reels,
+                    status: 'in_review',
+                    review_requested_at: '2026-06-24T15:00:00.000Z',
+                    draft_packet: {
+                      channel: 'instagram_reels',
+                      generated_at: '2026-06-24T15:00:00.000Z',
+                      source_use_boundary: 'Drafts are generated for human review only.',
+                      shared_source: {
+                        insight_title: 'Approval gates create trust',
+                        triggering_event: 'The Social Content review flow made the gate visible.',
+                        content_angle: 'AI should reduce burden, but only when authority and evidence are separated.',
+                        evidence_summary: 'Review path and visual gate work shipped locally.',
+                      },
+                      fields: {
+                        hook: 'AI should reduce burden.',
+                        script: ['Opening: AI should reduce burden.', 'Trigger: Social Content review flow.'],
+                        cover_text: 'Visible approval gates',
+                        caption: 'AI should reduce burden.',
+                        safe_area_notes: ['Keep captions inside 9:16 safe areas.'],
+                        export_readiness: 'pending_human_approval',
+                      },
+                      side_effects: {
+                        provider_generation: false,
+                        upload: false,
+                        publish: false,
+                        schedule: false,
+                        external_post: false,
+                      },
+                    },
+                  },
+                  tiktok: {
+                    ...base.metadata.channel_lanes.tiktok,
+                    status: 'in_review',
+                    review_requested_at: '2026-06-24T15:00:00.000Z',
+                    draft_packet: {
+                      channel: 'tiktok',
+                      generated_at: '2026-06-24T15:00:00.000Z',
+                      source_use_boundary: 'Drafts are generated for human review only.',
+                      shared_source: {
+                        insight_title: 'Approval gates create trust',
+                        triggering_event: 'The Social Content review flow made the gate visible.',
+                        content_angle: 'AI should reduce burden, but only when authority and evidence are separated.',
+                        evidence_summary: 'Review path and visual gate work shipped locally.',
+                      },
+                      fields: {
+                        hook: 'AI should reduce burden.',
+                        script: ['Opening: AI should reduce burden.', 'Trigger: Social Content review flow.'],
+                        cover_frame: 'Approval gate visible',
+                        caption: 'AI should reduce burden.',
+                        audio_rights: 'Use original narration or platform-safe audio only.',
+                        safe_area_notes: ['Keep text clear of TikTok controls.'],
+                        export_readiness: 'pending_human_approval',
                       },
                       side_effects: {
                         provider_generation: false,
@@ -232,6 +296,7 @@ describe('SocialInsightDetailPage', () => {
     expect(screen.getByRole('tab', { name: /LinkedIn/ })).toBeInTheDocument()
     expect(screen.getByRole('tab', { name: /YouTube Shorts/ })).toBeInTheDocument()
     expect(screen.getByRole('tab', { name: /Instagram Reels/ })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /TikTok/ })).toBeInTheDocument()
     expect(screen.getByRole('tab', { name: /Thumbnail/ })).toBeInTheDocument()
     expect(screen.getByText('post text')).toBeInTheDocument()
     expect(screen.getByText('Approved research patterns')).toBeInTheDocument()
@@ -260,10 +325,10 @@ describe('SocialInsightDetailPage', () => {
 
     await screen.findByRole('heading', { name: 'Approval gates create trust' })
     expect(screen.getByRole('button', { name: 'Approve Lane' })).toBeDisabled()
-    expect(screen.getByText('Prepare the LinkedIn + YouTube review drafts before approving this lane.')).toBeInTheDocument()
+    expect(screen.getByText('Prepare channel review drafts before approving this lane.')).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Prepare LinkedIn + YouTube Review Drafts' }))
-    await screen.findByText('LinkedIn and YouTube Shorts are ready for human review.')
+    fireEvent.click(screen.getByRole('button', { name: 'Prepare Channel Review Drafts' }))
+    await screen.findByText('LinkedIn, YouTube Shorts, Instagram Reels, and TikTok are ready for human review.')
 
     fireEvent.change(screen.getByLabelText('Decision note'), {
       target: { value: 'Approved for LinkedIn planning; no publishing authorized.' },
@@ -291,13 +356,13 @@ describe('SocialInsightDetailPage', () => {
     })
   })
 
-  it('prepares LinkedIn and YouTube review drafts from the shared insight', async () => {
+  it('prepares channel review drafts from the shared insight', async () => {
     render(<SocialInsightDetailPage />)
 
     await screen.findByRole('heading', { name: 'Approval gates create trust' })
-    fireEvent.click(screen.getByRole('button', { name: 'Prepare LinkedIn + YouTube Review Drafts' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Prepare Channel Review Drafts' }))
 
-    expect(await screen.findByText('LinkedIn and YouTube Shorts are ready for human review.')).toBeInTheDocument()
+    expect(await screen.findByText('LinkedIn, YouTube Shorts, Instagram Reels, and TikTok are ready for human review.')).toBeInTheDocument()
     expect(screen.getByText('Review draft packet')).toBeInTheDocument()
     expect(screen.getByText('Shared source: Approval gates create trust')).toBeInTheDocument()
     expect(screen.getByText('No side effects authorized: provider generation, upload, publish, schedule, external post.')).toBeInTheDocument()
@@ -313,6 +378,12 @@ describe('SocialInsightDetailPage', () => {
     expect(screen.getByText('I noticed this through the social content review flow.')).toBeInTheDocument()
     expect(screen.getByText('Opening: AI should reduce burden.')).toBeInTheDocument()
 
+    fireEvent.click(screen.getByRole('tab', { name: /TikTok/ }))
+
+    expect(screen.getByText('TikTok production inputs')).toBeInTheDocument()
+    expect(screen.getByText('audio rights')).toBeInTheDocument()
+    expect(screen.getByText('Use original narration or platform-safe audio only.')).toBeInTheDocument()
+
     const prepareCall = vi.mocked(fetch).mock.calls.find(([input]) => String(input) === '/api/admin/agents/work-items/work-social-1/social-channels/prepare-review-drafts')
     expect(prepareCall).toBeTruthy()
     expect(prepareCall?.[1]).toMatchObject({ method: 'POST' })
@@ -322,8 +393,8 @@ describe('SocialInsightDetailPage', () => {
     render(<SocialInsightDetailPage />)
 
     await screen.findByRole('heading', { name: 'Approval gates create trust' })
-    fireEvent.click(screen.getByRole('button', { name: 'Prepare LinkedIn + YouTube Review Drafts' }))
-    await screen.findByText('LinkedIn and YouTube Shorts are ready for human review.')
+    fireEvent.click(screen.getByRole('button', { name: 'Prepare Channel Review Drafts' }))
+    await screen.findByText('LinkedIn, YouTube Shorts, Instagram Reels, and TikTok are ready for human review.')
 
     fireEvent.click(screen.getByRole('tab', { name: /YouTube Shorts/ }))
     fireEvent.change(screen.getByLabelText('Decision note'), {

--- a/app/admin/agents/social-insights/[id]/page.tsx
+++ b/app/admin/agents/social-insights/[id]/page.tsx
@@ -8,6 +8,7 @@ import {
   AlertCircle,
   CheckCircle2,
   FileText,
+  Hash,
   Image as ImageIcon,
   Instagram,
   MessageSquare,
@@ -39,6 +40,7 @@ const CHANNEL_LABELS: Record<SocialContentIntelligenceChannel, string> = {
   linkedin: 'LinkedIn',
   youtube_shorts: 'YouTube Shorts',
   instagram_reels: 'Instagram Reels',
+  tiktok: 'TikTok',
   thumbnail: 'Thumbnail',
 }
 
@@ -46,6 +48,7 @@ const CHANNEL_ICONS: Record<SocialContentIntelligenceChannel, ReactNode> = {
   linkedin: <FileText className="h-4 w-4" />,
   youtube_shorts: <Youtube className="h-4 w-4" />,
   instagram_reels: <Instagram className="h-4 w-4" />,
+  tiktok: <Hash className="h-4 w-4" />,
   thumbnail: <ImageIcon className="h-4 w-4" />,
 }
 
@@ -155,7 +158,7 @@ function SocialInsightDetailContent() {
   const lanes = useMemo(() => lanesFor(item), [item])
   const activeLane = lanes[activeTab]
   const activeLaneHasReviewDraft = hasReviewDraft(activeLane)
-  const activeLaneNeedsReviewDraft = (activeTab === 'linkedin' || activeTab === 'youtube_shorts') && !activeLaneHasReviewDraft
+  const activeLaneNeedsReviewDraft = activeTab !== 'thumbnail' && !activeLaneHasReviewDraft
   const canPrepareReviewDrafts = approvedResearchPatterns.length > 0
 
   useEffect(() => {
@@ -208,7 +211,7 @@ function SocialInsightDetailContent() {
       if (!response.ok) throw new Error(body.error || `Review draft HTTP ${response.status}`)
       setItem(body.work_item ?? null)
       setActiveTab('linkedin')
-      setLaneNotice('LinkedIn and YouTube Shorts are ready for human review.')
+      setLaneNotice('LinkedIn, YouTube Shorts, Instagram Reels, and TikTok are ready for human review.')
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to prepare channel review drafts')
     } finally {
@@ -259,7 +262,7 @@ function SocialInsightDetailContent() {
                 className="agent-ops-button-primary disabled:opacity-60"
               >
                 <FileText size={16} />
-                {preparingReviewDrafts ? 'Preparing...' : 'Prepare LinkedIn + YouTube Review Drafts'}
+                {preparingReviewDrafts ? 'Preparing...' : 'Prepare Channel Review Drafts'}
               </button>
             </div>
           </div>
@@ -279,7 +282,7 @@ function SocialInsightDetailContent() {
               <h2 className="text-lg font-semibold">Shared evidence</h2>
               {!canPrepareReviewDrafts ? (
                 <div className="mt-4 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-100">
-                  Link at least one approved research pattern before preparing LinkedIn and YouTube review drafts.
+                  Link at least one approved research pattern before preparing channel review drafts.
                 </div>
               ) : null}
               <div className="mt-4 space-y-3">
@@ -367,7 +370,7 @@ function SocialInsightDetailContent() {
                       </p>
                       {activeLaneNeedsReviewDraft ? (
                         <p className="mt-1 text-sm text-amber-100">
-                          Prepare the LinkedIn + YouTube review drafts before approving this lane.
+                          Prepare channel review drafts before approving this lane.
                         </p>
                       ) : null}
                     </div>
@@ -590,6 +593,9 @@ function defaultInputs(channel: SocialContentIntelligenceChannel) {
   }
   if (channel === 'instagram_reels') {
     return ['hook', 'script', 'target duration', 'storyboard scenes', 'cover text', 'caption', 'hashtags', 'b-roll assets', 'safe-area notes', 'export readiness']
+  }
+  if (channel === 'tiktok') {
+    return ['hook', 'script', 'target duration', 'storyboard scenes', 'cover frame', 'caption', 'hashtags', 'b-roll assets', 'audio rights', 'safe-area notes', 'export readiness']
   }
   return ['source thumbnail reference', 'pattern explanation', 'AmaduTown adaptation direction', 'short thumbnail text', 'face/photo/avatar choice', 'brand colors/style', '2-3 variants', 'approval state']
 }

--- a/app/admin/campaigns/[id]/page.tsx
+++ b/app/admin/campaigns/[id]/page.tsx
@@ -32,7 +32,7 @@ import {
 type CampaignCalendarItem = {
   id: string;
   title: string;
-  channel: 'linkedin' | 'youtube_shorts' | 'instagram_reels' | 'thumbnail';
+  channel: 'linkedin' | 'youtube_shorts' | 'instagram_reels' | 'tiktok' | 'thumbnail';
   campaign_phase: 'tease' | 'teach' | 'proof' | 'offer';
   planned_angle: string | null;
   scheduled_for: string;

--- a/app/api/admin/agents/work-items/[id]/social-channels/[channel]/route.test.ts
+++ b/app/api/admin/agents/work-items/[id]/social-channels/[channel]/route.test.ts
@@ -143,7 +143,7 @@ describe('/api/admin/agents/work-items/[id]/social-channels/[channel]', () => {
     })
   })
 
-  it('requires a prepared review draft before approving LinkedIn or YouTube lanes', async () => {
+  it('requires a prepared review draft before approving a production channel lane', async () => {
     mocks.getAgentWorkItem.mockResolvedValue({
       ...baseWorkItem,
       metadata: {
@@ -166,7 +166,7 @@ describe('/api/admin/agents/work-items/[id]/social-channels/[channel]', () => {
 
     expect(response.status).toBe(400)
     expect(await response.json()).toEqual({
-      error: 'Prepare the LinkedIn and YouTube review drafts before approving this channel lane',
+      error: 'Prepare the channel review draft before approving this lane',
     })
     expect(mocks.updateAgentWorkItemMetadata).not.toHaveBeenCalled()
   })

--- a/app/api/admin/agents/work-items/[id]/social-channels/[channel]/route.ts
+++ b/app/api/admin/agents/work-items/[id]/social-channels/[channel]/route.ts
@@ -80,12 +80,9 @@ export async function PATCH(
     }
 
     const lanes = normalizeSocialChannelLanes(workItem.metadata?.channel_lanes)
-    if (nextStatus === 'approved'
-      && (params.channel === 'linkedin' || params.channel === 'youtube_shorts')
-      && !hasReviewDraft(lanes[params.channel])
-    ) {
+    if (nextStatus === 'approved' && !hasReviewDraft(lanes[params.channel])) {
       return NextResponse.json(
-        { error: 'Prepare the LinkedIn and YouTube review drafts before approving this channel lane' },
+        { error: 'Prepare the channel review draft before approving this lane' },
         { status: 400 },
       )
     }

--- a/app/api/admin/agents/work-items/[id]/social-channels/prepare-review-drafts/route.test.ts
+++ b/app/api/admin/agents/work-items/[id]/social-channels/prepare-review-drafts/route.test.ts
@@ -55,6 +55,8 @@ const baseWorkItem = {
     channel_lanes: {
       linkedin: { status: 'selected', label: 'LinkedIn', required_inputs: ['post text', 'CTA'] },
       youtube_shorts: { status: 'not_started', label: 'YouTube Shorts', required_inputs: ['hook', 'script'] },
+      instagram_reels: { status: 'not_started', label: 'Instagram Reels', required_inputs: ['hook', 'caption'] },
+      tiktok: { status: 'not_started', label: 'TikTok', required_inputs: ['hook', 'caption', 'audio rights'] },
     },
   },
 }
@@ -120,12 +122,12 @@ describe('/api/admin/agents/work-items/[id]/social-channels/prepare-review-draft
 
     expect(response.status).toBe(400)
     expect(await response.json()).toEqual({
-      error: 'Link at least one approved research pattern before preparing LinkedIn and YouTube review drafts',
+      error: 'Link at least one approved research pattern before preparing channel review drafts',
     })
     expect(mocks.updateAgentWorkItemMetadata).not.toHaveBeenCalled()
   })
 
-  it('prepares LinkedIn and YouTube review drafts without external side effects', async () => {
+  it('prepares channel review drafts without external side effects', async () => {
     const response = await POST(request() as never, {
       params: { id: 'work-1' },
     })
@@ -133,11 +135,11 @@ describe('/api/admin/agents/work-items/[id]/social-channels/prepare-review-draft
     expect(response.status).toBe(200)
     expect(mocks.updateAgentWorkItemMetadata).toHaveBeenCalledWith(expect.objectContaining({
       id: 'work-1',
-      note: 'LinkedIn and YouTube Shorts review drafts prepared by admin@example.com.',
+      note: 'Social channel review drafts prepared by admin@example.com.',
       metadata: expect.objectContaining({
         channel_review_workflow: expect.objectContaining({
           status: 'human_review_ready',
-          prepared_channels: ['linkedin', 'youtube_shorts'],
+          prepared_channels: ['linkedin', 'youtube_shorts', 'instagram_reels', 'tiktok'],
           prepared_at: '2026-06-24T15:00:00.000Z',
         }),
         channel_lanes: expect.objectContaining({
@@ -160,6 +162,28 @@ describe('/api/admin/agents/work-items/[id]/social-channels/prepare-review-draft
               fields: expect.objectContaining({
                 hook: 'AI should reduce burden.',
                 first_30_seconds: expect.stringContaining('I noticed this through the social content review flow'),
+              }),
+            }),
+          }),
+          instagram_reels: expect.objectContaining({
+            status: 'in_review',
+            review_requested_at: '2026-06-24T15:00:00.000Z',
+            draft_packet: expect.objectContaining({
+              channel: 'instagram_reels',
+              fields: expect.objectContaining({
+                cover_text: expect.any(String),
+                export_readiness: 'pending_human_approval',
+              }),
+            }),
+          }),
+          tiktok: expect.objectContaining({
+            status: 'in_review',
+            review_requested_at: '2026-06-24T15:00:00.000Z',
+            draft_packet: expect.objectContaining({
+              channel: 'tiktok',
+              fields: expect.objectContaining({
+                audio_rights: expect.stringContaining('platform-safe audio'),
+                export_readiness: 'pending_human_approval',
               }),
             }),
           }),

--- a/app/api/admin/agents/work-items/[id]/social-channels/prepare-review-drafts/route.ts
+++ b/app/api/admin/agents/work-items/[id]/social-channels/prepare-review-drafts/route.ts
@@ -39,7 +39,7 @@ export async function POST(
     }
     if (!hasApprovedResearchPatterns(insight)) {
       return NextResponse.json(
-        { error: 'Link at least one approved research pattern before preparing LinkedIn and YouTube review drafts' },
+        { error: 'Link at least one approved research pattern before preparing channel review drafts' },
         { status: 400 },
       )
     }
@@ -64,6 +64,22 @@ export async function POST(
       review_requested_at: now,
       updated_at: now,
     }
+    lanes.instagram_reels = {
+      ...lanes.instagram_reels,
+      status: 'in_review',
+      draft_packet: drafts.instagram_reels,
+      decision_note: null,
+      review_requested_at: now,
+      updated_at: now,
+    }
+    lanes.tiktok = {
+      ...lanes.tiktok,
+      status: 'in_review',
+      draft_packet: drafts.tiktok,
+      decision_note: null,
+      review_requested_at: now,
+      updated_at: now,
+    }
 
     const updated = await updateAgentWorkItemMetadata({
       id: workItem.id,
@@ -72,7 +88,7 @@ export async function POST(
         channel_lanes: lanes,
         channel_review_workflow: {
           status: 'human_review_ready',
-          prepared_channels: ['linkedin', 'youtube_shorts'],
+          prepared_channels: ['linkedin', 'youtube_shorts', 'instagram_reels', 'tiktok'],
           prepared_at: now,
           source_use_boundary: drafts.linkedin.source_use_boundary,
           side_effects: {
@@ -84,7 +100,7 @@ export async function POST(
           },
         },
       },
-      note: `LinkedIn and YouTube Shorts review drafts prepared by ${authResult.user.email ?? authResult.user.id}.`,
+      note: `Social channel review drafts prepared by ${authResult.user.email ?? authResult.user.id}.`,
     })
 
     return NextResponse.json({

--- a/app/api/admin/agents/work-items/[id]/social-channels/workflow.test.ts
+++ b/app/api/admin/agents/work-items/[id]/social-channels/workflow.test.ts
@@ -93,6 +93,8 @@ describe('social content intelligence research-to-channel-approval workflow', ()
         channel_lanes: {
           linkedin: { status: 'selected', label: 'LinkedIn', required_inputs: ['post text', 'CTA'] },
           youtube_shorts: { status: 'not_started', label: 'YouTube Shorts', required_inputs: ['hook', 'script'] },
+          instagram_reels: { status: 'not_started', label: 'Instagram Reels', required_inputs: ['hook', 'caption'] },
+          tiktok: { status: 'not_started', label: 'TikTok', required_inputs: ['hook', 'caption', 'audio rights'] },
         },
       },
     }
@@ -120,7 +122,7 @@ describe('social content intelligence research-to-channel-approval workflow', ()
     })
   })
 
-  it('links research, prepares channel drafts, and approves LinkedIn and YouTube without production side effects', async () => {
+  it('links research, prepares channel drafts, and approves selected lanes without production side effects', async () => {
     const linkResponse = await linkResearchPacket(jsonRequest(
       'http://localhost/api/admin/agents/work-items/work-social-1/research-packets',
       {
@@ -174,6 +176,20 @@ describe('social content intelligence research-to-channel-approval workflow', ()
             render_readiness: 'pending_human_approval',
           }),
         }),
+        instagram_reels: expect.objectContaining({
+          channel: 'instagram_reels',
+          approval_status: 'in_review',
+          fields: expect.objectContaining({
+            export_readiness: 'pending_human_approval',
+          }),
+        }),
+        tiktok: expect.objectContaining({
+          channel: 'tiktok',
+          approval_status: 'in_review',
+          fields: expect.objectContaining({
+            audio_rights: expect.stringContaining('platform-safe audio'),
+          }),
+        }),
       },
     }))
 
@@ -225,6 +241,8 @@ describe('social content intelligence research-to-channel-approval workflow', ()
     ])
     expect(lanes.linkedin.status).toBe('approved')
     expect(lanes.youtube_shorts.status).toBe('approved')
+    expect(lanes.instagram_reels.status).toBe('in_review')
+    expect(lanes.tiktok.status).toBe('in_review')
     expect(lanes.linkedin.draft_packet).toEqual(expect.objectContaining({
       channel: 'linkedin',
       approval_status: 'approved',

--- a/lib/admin-demo-seed.test.ts
+++ b/lib/admin-demo-seed.test.ts
@@ -83,7 +83,7 @@ describe('admin demo seed', () => {
       'linkedin',
       'youtube_shorts',
       'instagram_reels',
-      'thumbnail',
+      'tiktok',
     ])
     expect(rows.some((row) => row.authorization_status === 'rejected')).toBe(true)
     rows.forEach((row) => {
@@ -199,6 +199,8 @@ describe('admin demo seed', () => {
     const channelLanes = metadata.channel_lanes as Record<string, Record<string, unknown>>
     expect(channelLanes.linkedin.status).toBe('selected')
     expect(channelLanes.youtube_shorts.status).toBe('not_started')
+    expect(channelLanes.instagram_reels.status).toBe('not_started')
+    expect(channelLanes.tiktok.status).toBe('not_started')
     expect((metadata.insight as Record<string, unknown>).approved_research_patterns).toEqual([])
   })
 
@@ -390,7 +392,8 @@ describe('admin demo seed', () => {
       expect(lanes.linkedin.status).toBe('in_review')
       expect(lanes.youtube_shorts.status).toBe('in_review')
       expect(lanes.thumbnail.status).toBe('in_review')
-      expect(lanes.instagram_reels.status).toBe('not_started')
+      expect(lanes.instagram_reels.status).toBe('in_review')
+      expect(lanes.tiktok.status).toBe('in_review')
       expect((lanes.linkedin.draft_packet as Record<string, unknown>).side_effects).toMatchObject({
         provider_generation: false,
         upload: false,
@@ -400,6 +403,9 @@ describe('admin demo seed', () => {
       })
       expect((lanes.thumbnail.draft_packet as Record<string, unknown>).fields).toMatchObject({
         approval_state: 'in_review',
+      })
+      expect((lanes.tiktok.draft_packet as Record<string, unknown>).fields).toMatchObject({
+        audio_rights: expect.stringContaining('platform-safe audio'),
       })
     })
 
@@ -439,14 +445,14 @@ describe('admin demo seed', () => {
     primaryRows.forEach((row) => {
       expect(row.metadata).toMatchObject({
         calendar_item_role: 'primary_phase_item',
-        channel_draft_targets: ['linkedin', 'youtube_shorts', 'thumbnail'],
+        channel_draft_targets: ['linkedin', 'youtube_shorts', 'instagram_reels', 'tiktok', 'thumbnail'],
       })
     })
     youtubeRows.forEach((row) => {
       expect(row.metadata).toMatchObject({
         calendar_item_role: 'companion_channel_item',
         primary_channel: 'linkedin',
-        channel_draft_targets: ['youtube_shorts', 'thumbnail'],
+        channel_draft_targets: ['youtube_shorts', 'instagram_reels', 'tiktok', 'thumbnail'],
       })
     })
   })

--- a/lib/admin-demo-seed.ts
+++ b/lib/admin-demo-seed.ts
@@ -404,6 +404,34 @@ function acceleratedWorkshopInsightMetadata(input: {
       'Approval before handoff.',
     ],
   }
+  drafts.instagram_reels.fields = {
+    ...drafts.instagram_reels.fields,
+    caption: `${input.phase.contentAngle} Built for the Accelerated Workshop proof campaign.`,
+    b_roll_assets: [
+      'Accelerated ebook page',
+      'Content Intelligence dashboard',
+      'Campaign calendar arc',
+      'Social Insight approval tabs',
+      'AmaduTown proof surface',
+    ],
+    safe_area_notes: [
+      'Keep captions and CTA clear of top and bottom app chrome.',
+      'Frame Portfolio proof screens in the vertical center.',
+      'Redact private admin, client, Chronicle, or meeting-derived detail before export.',
+    ],
+  }
+  drafts.tiktok.fields = {
+    ...drafts.tiktok.fields,
+    caption: `${input.phase.suggestedHook} Built for the Accelerated Workshop proof campaign.`,
+    b_roll_assets: [
+      'Accelerated ebook page',
+      'Content Intelligence dashboard',
+      'Campaign calendar arc',
+      'Social Insight approval tabs',
+      'AmaduTown proof surface',
+    ],
+    audio_rights: 'Use original narration, approved provider voiceover, or platform-safe audio only.',
+  }
 
   return {
     social_topic_trigger: true,
@@ -438,11 +466,22 @@ function acceleratedWorkshopInsightMetadata(input: {
         required_inputs: ['hook', 'first 30 seconds', 'script', 'storyboard scenes', 'b-roll hints'],
       },
       instagram_reels: {
-        status: 'not_started',
+        status: 'in_review',
         label: 'Instagram Reels',
         decision_note: null,
-        draft_packet: null,
+        draft_packet: drafts.instagram_reels,
+        review_requested_at: input.generatedAt,
+        updated_at: input.generatedAt,
         required_inputs: ['hook', 'script', 'caption', 'safe-area notes'],
+      },
+      tiktok: {
+        status: 'in_review',
+        label: 'TikTok',
+        decision_note: null,
+        draft_packet: drafts.tiktok,
+        review_requested_at: input.generatedAt,
+        updated_at: input.generatedAt,
+        required_inputs: ['hook', 'script', 'caption', 'audio rights', 'safe-area notes'],
       },
       thumbnail: {
         status: 'in_review',
@@ -690,7 +729,7 @@ export async function runDemoSeed(
           ends_at: String(campaign.ends_at),
         })
 
-        const channels = ['linkedin', 'youtube_shorts', 'instagram_reels', 'thumbnail'] as const
+        const channels = ['linkedin', 'youtube_shorts', 'instagram_reels', 'tiktok'] as const
         const rows = slots.map((slot, index) => ({
           ...slot,
           campaign_id: campaign.id,
@@ -801,9 +840,9 @@ export async function runDemoSeed(
         const { data: workItem, error: workItemError } = await supabase
           .from('agent_work_items')
           .insert({
-            title: 'Demo: turn a Shaka insight into LinkedIn and YouTube review drafts',
+            title: 'Demo: turn a Shaka insight into multi-channel review drafts',
             objective:
-              'Link the demo public research pattern, prepare LinkedIn and YouTube Shorts drafts from the same Shaka insight, then approve or reject each channel lane.',
+              'Link the demo public research pattern, prepare LinkedIn, YouTube Shorts, Instagram Reels, and TikTok drafts from the same Shaka insight, then approve or reject each channel lane.',
             status: 'proposed',
             priority: 'high',
             owner_agent_key: 'chief-of-staff',
@@ -820,7 +859,7 @@ export async function runDemoSeed(
               social_topic_trigger: true,
               demo_seed_key: SOCIAL_CHANNEL_REVIEW_FIXTURE_KEY,
               fixture_version: 1,
-              fixture_purpose: 'content_intelligence_linkedin_youtube_review_smoke',
+              fixture_purpose: 'content_intelligence_social_channel_review_smoke',
               research_packet_ids: [],
               suggested_research_packet_ids: [packet.id],
               insight: {
@@ -866,6 +905,13 @@ export async function runDemoSeed(
                   decision_note: null,
                   draft_packet: null,
                   required_inputs: ['hook', 'script', 'caption', 'safe-area notes'],
+                },
+                tiktok: {
+                  status: 'not_started',
+                  label: 'TikTok',
+                  decision_note: null,
+                  draft_packet: null,
+                  required_inputs: ['hook', 'script', 'caption', 'audio rights', 'safe-area notes'],
                 },
                 thumbnail: {
                   status: 'not_started',
@@ -1122,14 +1168,14 @@ export async function runDemoSeed(
             agent_work_item_id: workItem.id,
             channel: 'linkedin',
             title: `${phase.titlePrefix}: ${phase.insightTitle}`,
-            planned_angle: `${phase.contentAngle} LinkedIn, YouTube Shorts, and Thumbnail drafts are ready for human approval.`,
+            planned_angle: `${phase.contentAngle} LinkedIn, YouTube Shorts, Instagram Reels, TikTok, and Thumbnail drafts are ready for human approval.`,
             scheduled_for: scheduledFor,
             authorization_due_at: addDaysAtHourISO(Math.max(0, phase.day - 1), 10),
             authorization_status: 'pending',
             metadata: {
               ...commonMetadata,
               calendar_item_role: 'primary_phase_item',
-              channel_draft_targets: ['linkedin', 'youtube_shorts', 'thumbnail'],
+              channel_draft_targets: ['linkedin', 'youtube_shorts', 'instagram_reels', 'tiktok', 'thumbnail'],
             },
           }
           const youtubeRow = {
@@ -1146,7 +1192,7 @@ export async function runDemoSeed(
               ...commonMetadata,
               calendar_item_role: 'companion_channel_item',
               primary_channel: 'linkedin',
-              channel_draft_targets: ['youtube_shorts', 'thumbnail'],
+              channel_draft_targets: ['youtube_shorts', 'instagram_reels', 'tiktok', 'thumbnail'],
             },
           }
           return [primaryRow, youtubeRow]

--- a/lib/social-content-calendar-handoff.ts
+++ b/lib/social-content-calendar-handoff.ts
@@ -50,6 +50,8 @@ function calendarPlatformTargets(item: SocialContentCalendarItem): SocialPlatfor
       return ['youtube']
     case 'instagram_reels':
       return ['instagram']
+    case 'tiktok':
+      return ['tiktok']
     case 'thumbnail':
       return []
     default:

--- a/lib/social-content-calendar.test.ts
+++ b/lib/social-content-calendar.test.ts
@@ -165,7 +165,7 @@ describe('social-content-calendar helpers', () => {
     expect(slots.map((slot) => slot.channel)).toEqual([
       'linkedin',
       'instagram_reels',
-      'youtube_shorts',
+      'tiktok',
       'instagram_reels',
     ])
     expect(slots[1]).toEqual(expect.objectContaining({

--- a/lib/social-content-calendar.ts
+++ b/lib/social-content-calendar.ts
@@ -4,6 +4,7 @@ export const SOCIAL_CONTENT_CALENDAR_CHANNELS = [
   'linkedin',
   'youtube_shorts',
   'instagram_reels',
+  'tiktok',
   'thumbnail',
 ] as const
 
@@ -94,6 +95,7 @@ export const CALENDAR_CHANNEL_LABELS: Record<SocialContentCalendarChannel, strin
   linkedin: 'LinkedIn',
   youtube_shorts: 'YouTube Shorts',
   instagram_reels: 'Instagram Reels',
+  tiktok: 'TikTok',
   thumbnail: 'Thumbnail',
 }
 
@@ -328,14 +330,14 @@ export const SOCIAL_CONTENT_CALENDAR_TEMPLATES: Record<
       {
         key: 'proof_cutdown',
         campaign_phase: 'proof',
-        channel: 'youtube_shorts',
+        channel: 'tiktok',
         title_prefix: 'Proof cutdown',
-        planned_angle: 'Create the proof-driven cutdown that points to the shipped feature, client-safe project, or Chronicle observation.',
+        planned_angle: 'Create the TikTok-ready proof cutdown that points to the shipped feature, client-safe project, or Chronicle observation.',
         relative_position: 0.65,
         fallback_day_offset: 5,
         recommended_lead_time_days: 4,
-        required_assets: ['proof_asset', 'b_roll', 'privacy_review'],
-        approval_gates: ['privacy_review', 'visual_qa'],
+        required_assets: ['proof_asset', 'vertical_video', 'caption', 'cover_frame', 'audio_rights', 'privacy_review'],
+        approval_gates: ['script_review', 'privacy_review', 'export_readiness'],
         source_urls: [SOURCE_URLS.youtubeCreators],
       },
       {

--- a/lib/social-content-intelligence.test.ts
+++ b/lib/social-content-intelligence.test.ts
@@ -39,9 +39,10 @@ describe('social-content-intelligence', () => {
       linkedin: { status: 'selected', decision_note: 'Use as first channel.' },
     })
 
-    expect(Object.keys(lanes)).toEqual(['linkedin', 'youtube_shorts', 'instagram_reels', 'thumbnail'])
+    expect(Object.keys(lanes)).toEqual(['linkedin', 'youtube_shorts', 'instagram_reels', 'tiktok', 'thumbnail'])
     expect(lanes.linkedin.status).toBe('selected')
     expect(lanes.youtube_shorts.status).toBe('not_started')
+    expect(lanes.tiktok.required_inputs).toContain('audio rights')
     expect(lanes.thumbnail.required_inputs).toContain('2-3 variants')
   })
 
@@ -95,7 +96,7 @@ describe('social-content-intelligence', () => {
     expect(mapped.claim_boundaries).toEqual(['Do not imply every workflow is automated.'])
   })
 
-  it('builds LinkedIn and YouTube review drafts from the same source while adapting fields by channel', () => {
+  it('builds channel review drafts from the same source while adapting fields by channel', () => {
     const drafts = buildLinkedInYoutubeReviewDrafts({
       generatedAt: '2026-06-24T15:00:00.000Z',
       insight: {
@@ -139,6 +140,23 @@ describe('social-content-intelligence', () => {
       target_duration_seconds: 45,
       render_readiness: 'pending_human_approval',
     })
+    expect(drafts.instagram_reels.fields).toMatchObject({
+      hook: 'AI should reduce burden.',
+      cover_text: expect.any(String),
+      safe_area_notes: expect.arrayContaining([
+        expect.stringContaining('9:16 vertical framing'),
+      ]),
+      export_readiness: 'pending_human_approval',
+    })
+    expect(drafts.tiktok.fields).toMatchObject({
+      hook: 'AI should reduce burden.',
+      cover_frame: expect.any(String),
+      audio_rights: expect.stringContaining('platform-safe audio'),
+      safe_area_notes: expect.arrayContaining([
+        expect.stringContaining('TikTok controls'),
+      ]),
+      export_readiness: 'pending_human_approval',
+    })
     expect(drafts.linkedin.fields).not.toHaveProperty('first_30_seconds')
     expect(drafts.youtube_shorts.fields).not.toHaveProperty('post_text')
     expect(drafts.linkedin.side_effects).toEqual({
@@ -149,5 +167,7 @@ describe('social-content-intelligence', () => {
       external_post: false,
     })
     expect(drafts.youtube_shorts.side_effects).toEqual(drafts.linkedin.side_effects)
+    expect(drafts.instagram_reels.side_effects).toEqual(drafts.linkedin.side_effects)
+    expect(drafts.tiktok.side_effects).toEqual(drafts.linkedin.side_effects)
   })
 })

--- a/lib/social-content-intelligence.ts
+++ b/lib/social-content-intelligence.ts
@@ -7,6 +7,7 @@ export const SOCIAL_CONTENT_INTELLIGENCE_CHANNELS = [
   'linkedin',
   'youtube_shorts',
   'instagram_reels',
+  'tiktok',
   'thumbnail',
 ] as const
 
@@ -34,7 +35,7 @@ export type SocialChannelLane = {
 export type SocialChannelLanes = Record<SocialContentIntelligenceChannel, SocialChannelLane>
 
 export type SocialChannelReviewDraftPacket = {
-  channel: 'linkedin' | 'youtube_shorts'
+  channel: SocialContentIntelligenceChannel
   generated_at: string
   approval_status: 'in_review' | 'approved' | 'blocked'
   decision_note?: string | null
@@ -61,6 +62,8 @@ export type SocialChannelReviewDraftPacket = {
 export type LinkedInYoutubeReviewDrafts = {
   linkedin: SocialChannelReviewDraftPacket
   youtube_shorts: SocialChannelReviewDraftPacket
+  instagram_reels: SocialChannelReviewDraftPacket
+  tiktok: SocialChannelReviewDraftPacket
 }
 
 export type SocialResearchPatternStatus =
@@ -161,6 +164,7 @@ const CHANNEL_LABELS: Record<SocialContentIntelligenceChannel, string> = {
   linkedin: 'LinkedIn',
   youtube_shorts: 'YouTube Shorts',
   instagram_reels: 'Instagram Reels',
+  tiktok: 'TikTok',
   thumbnail: 'Thumbnail',
 }
 
@@ -194,6 +198,19 @@ const CHANNEL_INPUTS: Record<SocialContentIntelligenceChannel, string[]> = {
     'caption',
     'hashtags',
     'b-roll assets',
+    'safe-area notes',
+    'export readiness',
+  ],
+  tiktok: [
+    'hook',
+    'script',
+    'target duration',
+    'storyboard scenes',
+    'cover frame',
+    'caption',
+    'hashtags',
+    'b-roll assets',
+    'audio rights',
     'safe-area notes',
     'export readiness',
   ],
@@ -695,6 +712,31 @@ export function buildLinkedInYoutubeReviewDrafts(input: {
     'The lesson was not that AI can create more content.',
     'The lesson was that trust gets built when every risky output has evidence, ownership, and a visible approval gate.',
   ].join(' ')
+  const shortScript = [
+    `Opening: ${youtubeHook}`,
+    `Trigger: ${triggeringEvent}`,
+    `Authority: ${whyVambahCanSpeak}`,
+    `Point: ${contentAngle}`,
+    `Proof: ${evidenceSummary}`,
+    patternHook ? `Pattern to adapt: ${patternHook}` : 'Pattern to adapt: use the approved research packet without copying source language.',
+    'Close: AI earns trust when the handoff is visible before the output goes public.',
+  ]
+  const storyboardScenes = [
+    'Face-to-camera hook with the triggering event.',
+    'Screen capture of the review gate or backlog surface.',
+    'B-roll showing evidence, owner, and approval status.',
+    'Closing frame with the principle and AmaduTown branding.',
+  ]
+  const bRollHints = [
+    'Content Intelligence dashboard',
+    'Agentic Dashboard Backlog',
+    'Social Content approval gates',
+  ]
+  const onScreenText = [
+    'AI output needs receipts.',
+    'Every risky action needs a gate.',
+    'Trust is an operating layer.',
+  ]
 
   return {
     linkedin: {
@@ -730,34 +772,68 @@ export function buildLinkedInYoutubeReviewDrafts(input: {
       fields: {
         hook: youtubeHook,
         first_30_seconds: firstThirtySeconds,
-        script: [
-          `Opening: ${youtubeHook}`,
-          `Trigger: ${triggeringEvent}`,
-          `Authority: ${whyVambahCanSpeak}`,
-          `Point: ${contentAngle}`,
-          `Proof: ${evidenceSummary}`,
-          patternHook ? `Pattern to adapt: ${patternHook}` : 'Pattern to adapt: use the approved research packet without copying source language.',
-          'Close: AI earns trust when the handoff is visible before the output goes public.',
-        ],
+        script: shortScript,
         target_duration_seconds: 45,
-        storyboard_scenes: [
-          'Face-to-camera hook with the triggering event.',
-          'Screen capture of the review gate or backlog surface.',
-          'B-roll showing evidence, owner, and approval status.',
-          'Closing frame with the principle and AmaduTown branding.',
-        ],
-        b_roll_hints: [
-          'Content Intelligence dashboard',
-          'Agentic Dashboard Backlog',
-          'Social Content approval gates',
-        ],
-        on_screen_text: [
-          'AI output needs receipts.',
-          'Every risky action needs a gate.',
-          'Trust is an operating layer.',
-        ],
+        storyboard_scenes: storyboardScenes,
+        b_roll_hints: bRollHints,
+        on_screen_text: onScreenText,
         caption: contentAngle,
         render_readiness: 'pending_human_approval',
+        claim_boundaries: claimBoundaries,
+      },
+      source_research_patterns: patterns,
+      side_effects: reviewDraftSideEffects(),
+    },
+    instagram_reels: {
+      channel: 'instagram_reels',
+      generated_at: generatedAt,
+      approval_status: 'in_review',
+      shared_source: sharedSource,
+      source_insight_title: title,
+      source_use_boundary: sourceBoundary,
+      fields: {
+        hook: youtubeHook,
+        script: shortScript,
+        target_duration_seconds: 45,
+        storyboard_scenes: storyboardScenes,
+        cover_text: patternPromise ? truncate(patternPromise, 52) : truncate(contentAngle, 52),
+        caption: contentAngle,
+        hashtags: ['#AIProduct', '#ProductManagement', '#AmaduTownAdvisory', '#TechForGood'],
+        b_roll_assets: bRollHints,
+        safe_area_notes: [
+          'Keep captions and CTA clear of top and bottom app chrome.',
+          'Use 9:16 vertical framing with the proof screen centered.',
+          'Avoid exposing admin names, client data, private notes, or raw Chronicle material.',
+        ],
+        export_readiness: 'pending_human_approval',
+        claim_boundaries: claimBoundaries,
+      },
+      source_research_patterns: patterns,
+      side_effects: reviewDraftSideEffects(),
+    },
+    tiktok: {
+      channel: 'tiktok',
+      generated_at: generatedAt,
+      approval_status: 'in_review',
+      shared_source: sharedSource,
+      source_insight_title: title,
+      source_use_boundary: sourceBoundary,
+      fields: {
+        hook: youtubeHook,
+        script: shortScript,
+        target_duration_seconds: 45,
+        storyboard_scenes: storyboardScenes,
+        cover_frame: patternPromise ? truncate(patternPromise, 48) : truncate(contentAngle, 48),
+        caption: contentAngle,
+        hashtags: ['#AIProduct', '#ProductOps', '#Automation', '#AmaduTown'],
+        b_roll_assets: bRollHints,
+        audio_rights: 'Use original narration, approved provider voiceover, or platform-safe audio only.',
+        safe_area_notes: [
+          'Keep text inside central 9:16 safe areas for TikTok controls.',
+          'Use a first-frame promise that can stand without sound.',
+          'Redact any private admin, client, Chronicle, or meeting-derived detail before export.',
+        ],
+        export_readiness: 'pending_human_approval',
         claim_boundaries: claimBoundaries,
       },
       source_research_patterns: patterns,

--- a/lib/testing/scenarios.ts
+++ b/lib/testing/scenarios.ts
@@ -1186,7 +1186,7 @@ export const seedSocialContentCalendarFixtureScenario = demoSeedApiScenario(
 export const seedSocialChannelReviewFixtureScenario = demoSeedApiScenario(
   'seed_social_channel_review_fixture',
   'Seed: Social Channel Review Fixture',
-  'Dev-safe Shaka insight plus public research packet for LinkedIn and YouTube review workflow',
+  'Dev-safe Shaka insight plus public research packet for multi-channel review workflow',
   'social_channel_review_fixture',
   'lead',
   ['seed', 'populate-demo', 'content-intelligence', 'social-review']
@@ -1195,7 +1195,7 @@ export const seedSocialChannelReviewFixtureScenario = demoSeedApiScenario(
 export const seedAcceleratedWorkshopCampaignFixtureScenario = demoSeedApiScenario(
   'seed_accelerated_workshop_campaign_fixture',
   'Seed: Accelerated Workshop Campaign Fixture',
-  'Dev-safe 14-day whisper_to_shout campaign with calendar items and review-ready LinkedIn, YouTube Shorts, and Thumbnail lanes',
+  'Dev-safe 14-day whisper_to_shout campaign with calendar items and review-ready LinkedIn, YouTube Shorts, Instagram Reels, TikTok, and Thumbnail lanes',
   'accelerated_workshop_campaign_fixture',
   'lead',
   ['seed', 'populate-demo', 'content-intelligence', 'calendar', 'social-review', 'accelerated']

--- a/supabase/migrations/20260706013723_add_tiktok_calendar_channel.sql
+++ b/supabase/migrations/20260706013723_add_tiktok_calendar_channel.sql
@@ -1,0 +1,10 @@
+-- Add TikTok as a first-class campaign calendar lane.
+-- This only enables planning/export-readiness rows. Publishing remains guarded by
+-- social_content_publishes, platform configuration, privacy, and final submission gates.
+
+ALTER TABLE public.social_content_calendar_items
+  DROP CONSTRAINT IF EXISTS social_content_calendar_items_channel_check;
+
+ALTER TABLE public.social_content_calendar_items
+  ADD CONSTRAINT social_content_calendar_items_channel_check
+  CHECK (channel IN ('linkedin', 'youtube_shorts', 'instagram_reels', 'tiktok', 'thumbnail'));


### PR DESCRIPTION
## Summary
- Adds TikTok as a first-class Content Intelligence and campaign calendar lane alongside LinkedIn, YouTube Shorts, Instagram Reels, and Thumbnail.
- Extends social insight review draft preparation to create Instagram Reels and TikTok review packets with captions, safe-area notes, export readiness, and TikTok audio-rights guidance.
- Updates calendar handoff targeting, demo seeds, admin UI labels, and tests so multi-channel review stays centralized before any provider or publishing gate.
- Adds a Supabase migration to allow `tiktok` in `social_content_calendar_items.channel`.

## Validation
- `npm ci`
- `npm test -- --run lib/social-content-intelligence.test.ts lib/social-content-calendar.test.ts lib/social-content-calendar-handoff.test.ts lib/admin-demo-seed.test.ts 'app/api/admin/agents/work-items/[id]/social-channels/prepare-review-drafts/route.test.ts' 'app/api/admin/agents/work-items/[id]/social-channels/[channel]/route.test.ts' 'app/api/admin/agents/work-items/[id]/social-channels/workflow.test.ts' 'app/admin/agents/social-insights/[id]/page.test.tsx' app/admin/agents/content-intelligence/page.test.tsx app/api/admin/social-content/calendar/route.test.ts 'app/api/admin/campaigns/[id]/content-plan/route.test.ts'`
- `npm run build:knowledge && npx tsc --noEmit`
- `npm run lint` passed with existing `<img>` warnings outside this change.
- Local smoke with `MOCK_N8N=true N8N_DISABLE_OUTBOUND=true npm run dev -- --port 3081`:
  - `HEAD /admin/agents/content-intelligence` -> 200
  - `HEAD /admin/agents/social-insights/work-social-1` -> 200
  - `HEAD /admin/campaigns/demo` -> 200
- Push hook: `npm run db:health-check` passed.

## Integration Notes
- Migration: `supabase/migrations/20260706013723_add_tiktok_calendar_channel.sql` updates the calendar channel check constraint to include `tiktok`.
- No HeyGen, ElevenLabs, rendering, upload, external schedule, external publish, or platform post is triggered by this change.
- Existing Instagram/TikTok platform submission adapters remain behind platform config, final submission, privacy, and publish gates.
- Integration Captain required for merge sequencing, migration/deploy verification, and both Vercel contexts:
  - Vercel – portfolio
  - Vercel – portfolio-staging
