### PR TITLE
fix: stabilize n8n value evidence accounting

### DIFF
--- a/app/api/admin/value-evidence/ingest-market/route.test.ts
+++ b/app/api/admin/value-evidence/ingest-market/route.test.ts
@@ -155,4 +155,59 @@ describe('POST /api/admin/value-evidence/ingest-market', () => {
       classification: null,
     })
   })
+
+  it('counts fallback duplicate insert races as duplicates without failing the request', async () => {
+    const upsert = vi.fn(() => ({
+      select: vi.fn().mockResolvedValue({
+        data: null,
+        count: null,
+        error: {
+          message: 'there is no unique or exclusion constraint matching the ON CONFLICT specification',
+        },
+      }),
+    }))
+    const insert = vi.fn(() => ({
+      select: vi.fn(() => ({
+        single: vi.fn().mockResolvedValue({
+          data: null,
+          error: {
+            code: '23505',
+            message: 'duplicate key value violates unique constraint "idx_market_intelligence_source_url_unique"',
+          },
+        }),
+      })),
+    }))
+
+    fromMock.mockReturnValue({
+      upsert,
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+        })),
+      })),
+      insert,
+    })
+
+    const { POST } = await import('./route')
+    const response = await POST(makeRequest({
+      items: [
+        {
+          source_platform: 'google_maps',
+          source_url: 'https://maps.example/review-race',
+          content_text: 'Manual paperwork took weeks to process.',
+          content_type: 'review',
+        },
+      ],
+    }))
+
+    expect(classifyMarketIntelMock).not.toHaveBeenCalled()
+    expect(jsonMock).toHaveBeenCalledWith({
+      total: 1,
+      inserted: 0,
+      duplicates: 1,
+      errors: [],
+      classification: null,
+    })
+    expect(response.status).toBe(200)
+  })
 })

--- a/app/api/admin/value-evidence/ingest-market/route.ts
+++ b/app/api/admin/value-evidence/ingest-market/route.ts
@@ -33,6 +33,10 @@ function isMissingSourceUrlConflictConstraint(errorMessage: string): boolean {
   return errorMessage.includes('no unique or exclusion constraint matching the ON CONFLICT specification')
 }
 
+function isDuplicateConstraintError(error: { code?: string; message?: string }): boolean {
+  return error.code === '23505' || Boolean(error.message?.includes('duplicate key value violates unique constraint'))
+}
+
 export async function POST(request: NextRequest) {
   const authHeader = request.headers.get('authorization')
   const token = authHeader?.replace('Bearer ', '')
@@ -144,6 +148,10 @@ export async function POST(request: NextRequest) {
               .single()
 
             if (fallbackInsertError) {
+              if (isDuplicateConstraintError(fallbackInsertError)) {
+                results.duplicates++
+                continue
+              }
               results.errors.push(`Fallback insert failed: ${fallbackInsertError.message}`)
               continue
             }

--- a/app/api/admin/value-evidence/workflow-complete/route.test.ts
+++ b/app/api/admin/value-evidence/workflow-complete/route.test.ts
@@ -178,4 +178,108 @@ describe('POST /api/admin/value-evidence/workflow-complete', () => {
       chained_social: false,
     })
   })
+
+  it('materializes a supplied UUID run_id so repeated callbacks reuse one row', async () => {
+    const suppliedRunId = '25c30da4-7b69-42d4-9237-8187d691e2ac'
+    requestJsonMock.mockResolvedValue({
+      run_id: suppliedRunId,
+      workflow_id: 'WF-VEP-002',
+      status: 'success',
+      items_inserted: 0,
+    })
+
+    const runTable = {
+      select: vi.fn(() => selectChain),
+      insert: vi.fn(() => insertChain),
+      update: vi.fn(() => updateChain),
+    }
+    fromMock.mockReturnValue(runTable)
+
+    selectChain.maybeSingle.mockResolvedValueOnce({ data: null })
+    insertChain.single.mockResolvedValueOnce({
+      data: {
+        id: suppliedRunId,
+        stages: null,
+        scope_type: null,
+        scope_id: null,
+        scope_label: null,
+      },
+      error: null,
+    })
+
+    const { POST } = await import('./route')
+    const request = {
+      headers: { get: vi.fn().mockReturnValue('Bearer secret-token') },
+      json: requestJsonMock,
+    } as unknown as Request
+
+    await POST(request as never)
+
+    expect(selectChain.eq).toHaveBeenCalledWith('id', suppliedRunId)
+    expect(runTable.insert).toHaveBeenCalledWith({
+      id: suppliedRunId,
+      workflow_id: 'vep002',
+      status: 'running',
+    })
+    expect(updateChain.eq).toHaveBeenCalledWith('id', suppliedRunId)
+    expect(jsonMock).toHaveBeenCalledWith({
+      ok: true,
+      run_id: suppliedRunId,
+      agent_run_id: null,
+      chained_social: false,
+    })
+  })
+
+  it('reselects supplied UUID run_id when concurrent callback already created it', async () => {
+    const suppliedRunId = '25c30da4-7b69-42d4-9237-8187d691e2ac'
+    requestJsonMock.mockResolvedValue({
+      run_id: suppliedRunId,
+      workflow_id: 'vep002',
+      status: 'success',
+    })
+
+    const runTable = {
+      select: vi.fn(() => selectChain),
+      insert: vi.fn(() => insertChain),
+      update: vi.fn(() => updateChain),
+    }
+    fromMock.mockReturnValue(runTable)
+
+    selectChain.maybeSingle
+      .mockResolvedValueOnce({ data: null })
+      .mockResolvedValueOnce({
+        data: {
+          id: suppliedRunId,
+          stages: null,
+          scope_type: null,
+          scope_id: null,
+          scope_label: null,
+        },
+      })
+    insertChain.single.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'duplicate key value violates unique constraint "value_evidence_workflow_runs_pkey"' },
+    })
+
+    const { POST } = await import('./route')
+    const request = {
+      headers: { get: vi.fn().mockReturnValue('Bearer secret-token') },
+      json: requestJsonMock,
+    } as unknown as Request
+
+    await POST(request as never)
+
+    expect(runTable.insert).toHaveBeenCalledWith({
+      id: suppliedRunId,
+      workflow_id: 'vep002',
+      status: 'running',
+    })
+    expect(updateChain.eq).toHaveBeenCalledWith('id', suppliedRunId)
+    expect(jsonMock).toHaveBeenCalledWith({
+      ok: true,
+      run_id: suppliedRunId,
+      agent_run_id: null,
+      chained_social: false,
+    })
+  })
 })

--- a/app/api/admin/value-evidence/workflow-complete/route.ts
+++ b/app/api/admin/value-evidence/workflow-complete/route.ts
@@ -5,6 +5,20 @@ import { attachAgentArtifact, endAgentRun, markAgentRunFailed, recordAgentStep }
 
 export const dynamic = 'force-dynamic'
 
+type ValueEvidenceRun = {
+  id: string
+  stages: Record<string, unknown> | null
+  scope_type: string | null
+  scope_id: string | null
+  scope_label: string | null
+}
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+function isUuid(value: string | undefined): value is string {
+  return Boolean(value && UUID_PATTERN.test(value))
+}
+
 /**
  * POST /api/admin/value-evidence/workflow-complete
  * Called by n8n at the end of a run.
@@ -64,14 +78,32 @@ export async function POST(request: NextRequest) {
     const status = completionStatus === 'failed' ? 'failed' : 'success'
 
     // Find run — fetch full record for auto-chain logic
-    let run: { id: string; stages: Record<string, unknown> | null; scope_type: string | null; scope_id: string | null; scope_label: string | null } | null = null
+    let run: ValueEvidenceRun | null = null
     if (run_id) {
       const { data } = await supabaseAdmin
         .from('value_evidence_workflow_runs')
         .select('id, stages, scope_type, scope_id, scope_label')
         .eq('id', run_id)
-        .single()
+        .maybeSingle()
       run = data
+    }
+    if (!run && isUuid(run_id)) {
+      const { data: created, error: createWithIdError } = await supabaseAdmin
+        .from('value_evidence_workflow_runs')
+        .insert({ id: run_id, workflow_id: wf, status: 'running' })
+        .select('id, stages, scope_type, scope_id, scope_label')
+        .single()
+
+      if (createWithIdError) {
+        const { data: existing } = await supabaseAdmin
+          .from('value_evidence_workflow_runs')
+          .select('id, stages, scope_type, scope_id, scope_label')
+          .eq('id', run_id)
+          .maybeSingle()
+        run = existing
+      } else {
+        run = created
+      }
     }
     if (!run) {
       const { data } = await supabaseAdmin


### PR DESCRIPTION
## Summary
- Treat fallback duplicate-key races in `ingest-market` as duplicates instead of request errors.
- Materialize UUID `run_id` values supplied by n8n completion callbacks so repeated branch callbacks converge on one `value_evidence_workflow_runs` row.
- Add focused route tests for duplicate fallback races and UUID run-id reuse/concurrent creation.

## Validation
- `npm test -- app/api/admin/value-evidence/ingest-market/route.test.ts app/api/admin/value-evidence/workflow-complete/route.test.ts`
- `npm run lint` (passes; existing `<img>` warnings remain in unrelated files)
- Pre-push `db:health-check` hook skipped because this isolated worktree does not have `.env.local` production credentials.
- No live n8n rerun was run after this code change because the branch is not deployed yet.

## Integration Notes
- No migration required. Uses existing UUID primary key on `value_evidence_workflow_runs.id`.
- Expected to make future WF-VEP-002 production-like bakeoff runs report as one run row when the callback payload includes a UUID `run_id`.
- Vercel contexts checked before this fix during rerun prep; not rechecked after branch push because this is a draft PR and not merged/deployed:
  - Vercel – portfolio: not rechecked after branch push
  - Vercel – portfolio-staging: not rechecked after branch push