### PR TITLE
feat: add LM Studio Open Brain update lane

### DIFF
--- a/docs/open-brain-local-service.md
+++ b/docs/open-brain-local-service.md
@@ -153,6 +153,86 @@ npm run open-brain:runtime-registration -- --write tmp/open-brain-runtime-regist
 
 The planner is intentionally non-mutating. It does not create or edit `~/.codex/config.toml`, `~/.hermes/config.yaml`, Cursor/Claude/OpenCode config files, or durable Open Brain memory records. Actual runtime registration remains a local-state approval step and should be performed one runtime at a time, followed by that runtime's own doctor/list/manual MCP verification.
 
+## LM Studio Bridge
+
+LM Studio should connect to Open Brain through its MCP integration, not through a separate static `rag-v1` document index. Open Brain remains the governed memory layer; LM Studio is the local model workbench that can call read-only search/context tools, proposal-gated memory tools, and a guarded Portfolio patch lane.
+
+Current local registration shape:
+
+```json
+{
+  "mcpServers": {
+    "open-brain": {
+      "command": "/Users/vambahsillah/.hermes/bin/open-brain-mcp"
+    }
+  }
+}
+```
+
+Operational-state boundary:
+
+- This config lives at `~/.lmstudio/mcp.json`, outside the Portfolio git worktree.
+- Editing it requires an explicit local-state action and should be backed up first.
+- The `mcp/open-brain` integration may lazy-start only when a tool call is requested.
+- A healthy active tool call has an LM Studio-owned `mcpbridgeworker.js` process with an Open Brain MCP server child.
+- Stale MCP server processes from manual smoke tests can be stopped, but do not stop the LM Studio-owned bridge while a tool call is active.
+
+Recommended LM Studio usage:
+
+- Start Open Brain prompts from a fresh chat when testing local models. Old chats can exceed the model context window and make tool behavior look broken.
+- Keep the `open-brain` integration chip attached to the chat.
+- Approve `search_memory` when the model asks for read-only retrieval.
+- Do not grant blanket approval to all Open Brain tools unless a separate trust policy is approved.
+- If a local model repeats the same search request, deny the repeated call with a reason and tell the model to answer from the already returned context.
+- For Portfolio or Open Brain repo updates, start with `get_update_workspace_context`, then `read_update_target`, then `apply_portfolio_patch` with `apply=false`.
+- Only apply a local patch after reviewing the dry-run result. Actual application requires `apply=true`, the approval phrase `APPLY PORTFOLIO PATCH`, and human approval of the LM Studio tool call.
+- The patch lane applies local files only. It does not commit, push, deploy, change hosted settings, or approve durable Open Brain memory.
+- Use explicit prompts for Qwen-style reasoning models:
+
+```text
+Use mcp/open-brain. Call search_memory once with query "<topic>". After the tool result, stop using tools and answer in one paragraph. Do not call search_memory again unless I ask.
+```
+
+For local update work, use this prompt pattern:
+
+```text
+Use mcp/open-brain as the update lane. First call get_update_workspace_context. Then read only the files needed. Prepare a unified diff and call apply_portfolio_patch with apply=false. Stop after the dry run and ask me before applying.
+```
+
+LM Studio update tools:
+
+- `get_update_workspace_context`: reports Portfolio root, branch/status, Open Brain health, allowed scopes, and update boundaries.
+- `read_update_target`: reads a scoped text file from the Portfolio worktree. It blocks secrets, private folders, generated media, binary files, and paths outside the repo.
+- `apply_portfolio_patch`: checks or applies a unified diff. Dry-run is the default. Applying requires `apply=true`, `approvalPhrase="APPLY PORTFOLIO PATCH"`, and LM Studio tool approval.
+
+Allowed patch scopes:
+
+- `open_brain`: `docs/open-brain*`, `scripts/open-brain*`, `lib/open-brain*`, `lib/model-ops-open-brain*`, `/admin/agents/open-brain`, and `/api/admin/agents/open-brain` files.
+- `portfolio`: `docs`, `app`, `components`, `lib`, `scripts`, `package.json`, and `package-lock.json`.
+
+Blocked paths include env files, `local-private`, `.git`, `.next`, `.vercel`, `node_modules`, and generated/binary media.
+
+Validation commands:
+
+```bash
+printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"lm-studio-smoke","version":"1.0"}}}\n' | /Users/vambahsillah/.hermes/bin/open-brain-mcp | head -1
+openbrain-ask --model qwen3.6-27b-optiq --limit 1 "In one sentence, name one Open Brain boundary."
+npm test -- --run scripts/open-brain-mcp-server.test.ts
+```
+
+Expected boundary answer:
+
+```text
+Durable Open Brain memory writes require approval before they become part of the verified record.
+```
+
+Troubleshooting:
+
+- If LM Studio shows `mcp/open-brain` disconnected, verify `~/.lmstudio/mcp.json`, toggle the integration off and back on, then retry from a fresh chat.
+- If the chat context indicator is above 100%, create a new chat before testing tools again.
+- If `openbrain-ask` works but LM Studio loops on tool calls, the issue is the model planner or chat context, not the Open Brain server.
+- If direct MCP initialization fails, inspect `.env.local`, `OPEN_BRAIN_HOME`, and the wrapper at `/Users/vambahsillah/.hermes/bin/open-brain-mcp`.
+
 ### OpenClaw Evaluation Gate
 
 OpenClaw is not required for Phase 2 parity unless it proves value beyond the already connected runtimes. Treat it as an evaluation candidate, not an install-by-default dependency.

--- a/scripts/open-brain-mcp-server.test.ts
+++ b/scripts/open-brain-mcp-server.test.ts
@@ -2,8 +2,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   asText,
   createProposalToolResult,
+  extractUnifiedDiffPaths,
   proposalSchema,
   registerOpenBrainTools,
+  resolveAllowedUpdatePath,
 } from './open-brain-mcp-server'
 
 type MockMemory = { id: string; title: string; body: string }
@@ -91,7 +93,7 @@ describe('open-brain MCP server tools', () => {
   it('registers the standards-compliant Open Brain tool surface', () => {
     const tools = captureRegisteredTools()
 
-    expect(tools).toHaveLength(7)
+    expect(tools).toHaveLength(10)
     expect(tools.map((tool) => tool.name)).toEqual(expect.arrayContaining([
       'capture_memory',
       'search_memory',
@@ -100,6 +102,9 @@ describe('open-brain MCP server tools', () => {
       'list_pending_memory_proposals',
       'link_memory_to_source',
       'compile_wiki_overlay',
+      'get_update_workspace_context',
+      'read_update_target',
+      'apply_portfolio_patch',
     ]))
 
     const schema = proposalSchema()
@@ -204,5 +209,42 @@ describe('open-brain MCP server tools', () => {
         },
       ],
     })
+  })
+
+  it('extracts changed file paths from unified diffs', () => {
+    expect(extractUnifiedDiffPaths([
+      'diff --git a/docs/open-brain-local-service.md b/docs/open-brain-local-service.md',
+      '--- a/docs/open-brain-local-service.md',
+      '+++ b/docs/open-brain-local-service.md',
+      '@@ -1,2 +1,2 @@',
+      'diff --git a/scripts/open-brain-mcp-server.ts b/scripts/open-brain-mcp-server.ts',
+      '--- a/scripts/open-brain-mcp-server.ts',
+      '+++ b/scripts/open-brain-mcp-server.ts',
+    ].join('\n'))).toEqual([
+      'docs/open-brain-local-service.md',
+      'scripts/open-brain-mcp-server.ts',
+    ])
+  })
+
+  it('enforces scoped update paths for the LM Studio patch lane', () => {
+    expect(resolveAllowedUpdatePath('docs/open-brain-local-service.md', 'open_brain', '/tmp/portfolio')).toEqual({
+      relativePath: 'docs/open-brain-local-service.md',
+      absolutePath: '/tmp/portfolio/docs/open-brain-local-service.md',
+    })
+    expect(() => resolveAllowedUpdatePath('components/Hero.tsx', 'open_brain', '/tmp/portfolio')).toThrow(
+      'outside the open_brain update scope',
+    )
+    expect(resolveAllowedUpdatePath('components/Hero.tsx', 'portfolio', '/tmp/portfolio').relativePath).toBe(
+      'components/Hero.tsx',
+    )
+    expect(() => resolveAllowedUpdatePath('../.env.local', 'portfolio', '/tmp/portfolio')).toThrow(
+      'Path escapes Portfolio root',
+    )
+    expect(() => resolveAllowedUpdatePath('local-private/notes.md', 'portfolio', '/tmp/portfolio')).toThrow(
+      'Blocked path segment',
+    )
+    expect(() => resolveAllowedUpdatePath('public/generated.png', 'portfolio', '/tmp/portfolio')).toThrow(
+      'Blocked generated or binary file',
+    )
   })
 })

--- a/scripts/open-brain-mcp-server.ts
+++ b/scripts/open-brain-mcp-server.ts
@@ -1,4 +1,9 @@
 #!/usr/bin/env tsx
+import { execFile, spawn } from 'child_process'
+import { readFile, mkdtemp, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import path from 'path'
+import { promisify } from 'util'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import * as z from 'zod/v4'
@@ -12,6 +17,39 @@ import {
 } from '../lib/open-brain'
 
 type OpenBrainMcpServer = Pick<McpServer, 'registerTool'>
+type UpdateScope = 'open_brain' | 'portfolio'
+
+const execFileAsync = promisify(execFile)
+const APPLY_APPROVAL_PHRASE = 'APPLY PORTFOLIO PATCH'
+const MAX_READ_BYTES = 40_000
+const MAX_PATCH_BYTES = 250_000
+const BLOCKED_PATH_PARTS = new Set([
+  '.git',
+  '.next',
+  'node_modules',
+  'local-private',
+  '.vercel',
+  '.turbo',
+])
+const BLOCKED_FILE_NAMES = new Set([
+  '.env',
+  '.env.local',
+  '.env.production',
+  '.env.staging',
+  '.npmrc',
+])
+const BLOCKED_EXTENSIONS = new Set([
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.mp4',
+  '.mov',
+  '.tiff',
+  '.pdf',
+  '.zip',
+])
 
 export function registerOpenBrainTools(target: OpenBrainMcpServer) {
   target.registerTool('capture_memory', {
@@ -79,6 +117,41 @@ export function registerOpenBrainTools(target: OpenBrainMcpServer) {
     const snapshot = await getOpenBrainSnapshot()
     return asText({ mode: 'preview', pages: compileKarpathyWikiOverlay(snapshot.memories, snapshot.events) })
   })
+
+  target.registerTool('get_update_workspace_context', {
+    description: 'Inspect the local Portfolio/Open Brain update workspace before proposing or applying changes.',
+    inputSchema: {},
+  }, async () => getUpdateWorkspaceContextToolResult())
+
+  target.registerTool('read_update_target', {
+    description: 'Read a scoped Portfolio/Open Brain file for local update work. Secrets, private folders, generated media, and oversized files are blocked.',
+    inputSchema: {
+      scope: z.enum(['open_brain', 'portfolio']),
+      relativePath: z.string(),
+      maxBytes: z.number().optional(),
+    },
+  }, async ({ scope, relativePath, maxBytes }) => readUpdateTargetToolResult({
+    scope,
+    relativePath,
+    maxBytes,
+  }))
+
+  target.registerTool('apply_portfolio_patch', {
+    description: 'Check or apply a unified diff against the local Portfolio worktree. Applying requires explicit approval phrase and LM Studio tool approval.',
+    inputSchema: {
+      scope: z.enum(['open_brain', 'portfolio']),
+      unifiedDiff: z.string(),
+      reason: z.string(),
+      apply: z.boolean().optional(),
+      approvalPhrase: z.string().optional(),
+    },
+  }, async ({ scope, unifiedDiff, reason, apply = false, approvalPhrase }) => applyPortfolioPatchToolResult({
+    scope,
+    unifiedDiff,
+    reason,
+    apply,
+    approvalPhrase,
+  }))
 }
 
 export async function createProposalToolResult(args: {
@@ -124,6 +197,224 @@ export function proposalSchema() {
     sourceIds: z.array(z.string()).optional(),
     reason: z.string(),
   }
+}
+
+export async function getUpdateWorkspaceContextToolResult() {
+  const portfolioRoot = getPortfolioRoot()
+  const [branch, status, snapshot] = await Promise.all([
+    runGit(['branch', '--show-current'], portfolioRoot).catch((error) => `unavailable: ${error.message}`),
+    runGit(['status', '--short', '--branch'], portfolioRoot).catch((error) => `unavailable: ${error.message}`),
+    getOpenBrainSnapshot().catch((error) => null),
+  ])
+
+  return asText({
+    portfolioRoot,
+    branch: branch.trim(),
+    gitStatus: status.trim().split('\n').slice(0, 120),
+    openBrain: snapshot
+      ? {
+          home: snapshot.service.home,
+          available: snapshot.service.available,
+          sources: snapshot.overview.sources,
+          memories: snapshot.overview.memories,
+          pendingProposals: snapshot.overview.pendingProposals,
+          health: snapshot.health,
+        }
+      : { available: false, reason: 'Open Brain snapshot could not be loaded.' },
+    updateLane: {
+      modelRole: 'LM Studio can inspect, propose, and apply explicitly approved local patches through this MCP server.',
+      defaultMode: 'dry-run patch check',
+      applyBoundary: `Applying a patch requires apply=true, approvalPhrase="${APPLY_APPROVAL_PHRASE}", and approving the LM Studio tool call.`,
+      allowedScopes: {
+        open_brain: [
+          'docs/open-brain*',
+          'scripts/open-brain*',
+          'lib/open-brain*',
+          'lib/model-ops-open-brain*',
+          'app/admin/agents/open-brain/**',
+          'app/api/admin/agents/open-brain/**',
+        ],
+        portfolio: [
+          'docs/**',
+          'app/**',
+          'components/**',
+          'lib/**',
+          'scripts/**',
+          'package.json',
+          'package-lock.json',
+        ],
+      },
+      blocked: [
+        'secrets and env files',
+        'node_modules, .git, .next, local-private, .vercel',
+        'generated media and binary files',
+        'paths outside the Portfolio root',
+      ],
+    },
+    nextStepForModel: 'Read only the files needed, run apply_portfolio_patch with apply=false first, then ask Vambah before applying.',
+  })
+}
+
+export async function readUpdateTargetToolResult(args: {
+  scope: UpdateScope
+  relativePath: string
+  maxBytes?: number
+}) {
+  const portfolioRoot = getPortfolioRoot()
+  const safePath = resolveAllowedUpdatePath(args.relativePath, args.scope, portfolioRoot)
+  const maxBytes = Math.min(Math.max(args.maxBytes ?? MAX_READ_BYTES, 1), MAX_READ_BYTES)
+  const contents = await readFile(safePath.absolutePath, 'utf8')
+  const truncated = Buffer.byteLength(contents, 'utf8') > maxBytes
+  return asText({
+    path: safePath.relativePath,
+    bytesReturned: Math.min(Buffer.byteLength(contents, 'utf8'), maxBytes),
+    truncated,
+    text: contents.slice(0, maxBytes),
+    boundary: 'Read-only. No file was changed.',
+  })
+}
+
+export async function applyPortfolioPatchToolResult(args: {
+  scope: UpdateScope
+  unifiedDiff: string
+  reason: string
+  apply?: boolean
+  approvalPhrase?: string
+}) {
+  const portfolioRoot = getPortfolioRoot()
+  if (!args.reason?.trim()) throw new Error('Patch reason is required.')
+  if (Buffer.byteLength(args.unifiedDiff || '', 'utf8') > MAX_PATCH_BYTES) {
+    throw new Error(`Patch is too large for LM Studio apply lane. Limit is ${MAX_PATCH_BYTES} bytes.`)
+  }
+  const changedPaths = extractUnifiedDiffPaths(args.unifiedDiff)
+  if (changedPaths.length === 0) throw new Error('No changed file paths were found in the unified diff.')
+  for (const changedPath of changedPaths) {
+    resolveAllowedUpdatePath(changedPath, args.scope, portfolioRoot)
+  }
+
+  const check = await runGitApply(args.unifiedDiff, portfolioRoot, ['--check'])
+  if (args.apply !== true) {
+    return asText({
+      mode: 'dry_run',
+      checked: true,
+      applied: false,
+      changedPaths,
+      reason: args.reason,
+      gitApplyCheck: check,
+      nextStepForModel: `If Vambah approves this exact patch, call apply_portfolio_patch again with apply=true and approvalPhrase="${APPLY_APPROVAL_PHRASE}".`,
+    })
+  }
+
+  if (args.approvalPhrase !== APPLY_APPROVAL_PHRASE) {
+    throw new Error(`Applying requires approvalPhrase="${APPLY_APPROVAL_PHRASE}".`)
+  }
+  const beforeStatus = await runGit(['status', '--short', '--branch'], portfolioRoot).catch((error) => `unavailable: ${error.message}`)
+  const applyResult = await runGitApply(args.unifiedDiff, portfolioRoot, [])
+  const afterStatus = await runGit(['status', '--short', '--branch'], portfolioRoot).catch((error) => `unavailable: ${error.message}`)
+
+  return asText({
+    mode: 'applied',
+    checked: true,
+    applied: true,
+    changedPaths,
+    reason: args.reason,
+    gitApplyCheck: check,
+    gitApply: applyResult,
+    beforeStatus: beforeStatus.trim().split('\n').slice(0, 80),
+    afterStatus: afterStatus.trim().split('\n').slice(0, 120),
+    boundary: 'Patch applied locally only. It was not committed, pushed, deployed, or promoted to durable Open Brain memory.',
+  })
+}
+
+export function extractUnifiedDiffPaths(unifiedDiff: string) {
+  const paths = new Set<string>()
+  for (const line of unifiedDiff.split('\n')) {
+    const gitMatch = line.match(/^diff --git a\/(.+?) b\/(.+)$/)
+    if (gitMatch) {
+      if (gitMatch[1] !== '/dev/null') paths.add(gitMatch[1])
+      if (gitMatch[2] !== '/dev/null') paths.add(gitMatch[2])
+      continue
+    }
+    const fileMatch = line.match(/^(?:---|\+\+\+) (?:a|b)\/(.+)$/)
+    if (fileMatch && fileMatch[1] !== '/dev/null') paths.add(fileMatch[1])
+  }
+  return [...paths].sort()
+}
+
+export function resolveAllowedUpdatePath(relativePath: string, scope: UpdateScope, portfolioRoot = getPortfolioRoot()) {
+  const normalized = relativePath.replaceAll('\\', '/').replace(/^\/+/, '')
+  if (!normalized || normalized.includes('\0')) throw new Error('A relative file path is required.')
+  if (normalized.startsWith('../') || normalized.includes('/../')) throw new Error(`Path escapes Portfolio root: ${relativePath}`)
+  const parts = normalized.split('/')
+  if (parts.some((part) => BLOCKED_PATH_PARTS.has(part))) throw new Error(`Blocked path segment in ${relativePath}`)
+  const basename = parts[parts.length - 1]
+  if (BLOCKED_FILE_NAMES.has(basename)) throw new Error(`Blocked sensitive file: ${relativePath}`)
+  if (BLOCKED_EXTENSIONS.has(path.extname(basename).toLowerCase())) throw new Error(`Blocked generated or binary file: ${relativePath}`)
+  if (!isAllowedScopePath(normalized, scope)) throw new Error(`Path ${relativePath} is outside the ${scope} update scope.`)
+  const absolutePath = path.resolve(portfolioRoot, normalized)
+  if (!absolutePath.startsWith(`${path.resolve(portfolioRoot)}${path.sep}`) && absolutePath !== path.resolve(portfolioRoot)) {
+    throw new Error(`Path escapes Portfolio root: ${relativePath}`)
+  }
+  return { relativePath: normalized, absolutePath }
+}
+
+function isAllowedScopePath(relativePath: string, scope: UpdateScope) {
+  if (scope === 'open_brain') {
+    return relativePath.startsWith('docs/open-brain') ||
+      relativePath.startsWith('scripts/open-brain') ||
+      relativePath.startsWith('lib/open-brain') ||
+      relativePath.startsWith('lib/model-ops-open-brain') ||
+      relativePath.startsWith('app/admin/agents/open-brain/') ||
+      relativePath.startsWith('app/api/admin/agents/open-brain/')
+  }
+  return relativePath.startsWith('docs/') ||
+    relativePath.startsWith('app/') ||
+    relativePath.startsWith('components/') ||
+    relativePath.startsWith('lib/') ||
+    relativePath.startsWith('scripts/') ||
+    relativePath === 'package.json' ||
+    relativePath === 'package-lock.json'
+}
+
+function getPortfolioRoot() {
+  return path.resolve(process.env.OPEN_BRAIN_PORTFOLIO_ROOT || process.cwd())
+}
+
+async function runGit(args: string[], cwd: string) {
+  const result = await execFileAsync('git', args, {
+    cwd,
+    maxBuffer: 1024 * 1024,
+  })
+  return [result.stdout, result.stderr].filter(Boolean).join('\n')
+}
+
+async function runGitApply(unifiedDiff: string, cwd: string, args: string[]) {
+  const dir = await mkdtemp(path.join(tmpdir(), 'open-brain-mcp-patch-'))
+  const patchPath = path.join(dir, 'update.patch')
+  try {
+    await writeFile(patchPath, unifiedDiff)
+    return await runSpawn('git', ['apply', ...args, patchPath], cwd)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}
+
+function runSpawn(command: string, args: string[], cwd: string) {
+  return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+    const child = spawn(command, args, { cwd })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk) => { stdout += String(chunk) })
+    child.stderr.on('data', (chunk) => { stderr += String(chunk) })
+    child.on('error', reject)
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve({ stdout: stdout.trim(), stderr: stderr.trim() })
+        return
+      }
+      reject(new Error(`${command} ${args.join(' ')} failed with exit ${code}: ${stderr || stdout}`))
+    })
+  })
 }
 
 async function main() {


### PR DESCRIPTION
## Summary
- Add an LM Studio-safe update lane to the Open Brain MCP server with workspace context, scoped file reads, and approval-gated patch dry-run/apply tools.
- Document the LM Studio MCP bridge workflow, approval boundaries, troubleshooting, and validation commands.
- Cover the new MCP tool registration, unified-diff path extraction, and scoped path enforcement with focused tests.

## Validation
- `npm install` in `/Users/vambahsillah/Projects/Portfolio.worktrees/lm-studio-open-brain-bridge` to prepare the clean worktree.
- `npm test -- --run scripts/open-brain-mcp-server.test.ts` passed: 7 tests.
- Direct MCP stdio smoke passed: `initialize` + `tools/list` returned 10 tools including `get_update_workspace_context`, `read_update_target`, and `apply_portfolio_patch`.
- `git diff --check` passed.
- Pre-push database health hook ran and skipped locally because `PROD_SUPABASE_URL` and `PROD_SUPABASE_SERVICE_ROLE_KEY` are not set in the clean worktree env.
- No live hosted workflow or customer-data smoke was run.

## Enhancement Impact Preflight
- Enhancement: Give LM Studio a governed Open Brain/Portfolio update lane through the local Open Brain MCP server.
- User-facing surface: LM Studio `mcp/open-brain` tools and local Open Brain update workflow documentation.
- Predicted files: `scripts/open-brain-mcp-server.ts`, `scripts/open-brain-mcp-server.test.ts`, `docs/open-brain-local-service.md`.
- Shared routes/APIs/tables/helpers: Shared Open Brain MCP server only; no admin route, API route, database schema, Supabase table, or hosted setting changed.
- Active PRs or branches checked: `gh pr list --state open` returned no open PRs at the time of this handoff; worktrees were listed before creating this clean branch.
- Dirty worktree files checked: The main checkout had extensive unrelated Agentified, subscription, and admin/content work. This PR was created from a clean `origin/main` worktree and stages only the three files above.
- Overlap rating: yellow.
- Coordination decision: Proceed independently because ownership is limited to the MCP update lane and documentation.
- Merge-order note: Integration Captain should merge after any branch that rewrites `scripts/open-brain-mcp-server.ts` or `docs/open-brain-local-service.md`; otherwise this can land independently.

## Integration Notes
- No database migration.
- No hosted deployment requirement for the local MCP server change.
- No direct edits to `~/.lmstudio/mcp.json`, `~/.codex`, `~/.hermes`, or `~/.open-brain` are included in this PR.
- Vercel – portfolio: not checked, local MCP-only change.
- Vercel – portfolio-staging: not checked, local MCP-only change.
