### PR TITLE
feat: add visual asset rejection regeneration

### DIFF
--- a/app/admin/content/visual-assets/page.test.tsx
+++ b/app/admin/content/visual-assets/page.test.tsx
@@ -66,6 +66,21 @@ describe("VisualAssetsReviewPage", () => {
             json: async () => ({ candidate: { id: url.split("/").at(-2) } }),
           };
         }
+        if (url.includes("/reject")) {
+          return {
+            ok: true,
+            json: async () => ({ candidate: { id: url.split("/").at(-2), status: "rejected" } }),
+          };
+        }
+        if (url.includes("/regenerate")) {
+          return {
+            ok: true,
+            json: async () => ({
+              replacementCandidate: { id: "replacement-1", status: "proposed" },
+              capture: { captured: 1, passed: 1, blocked: 0 },
+            }),
+          };
+        }
         if (url.includes("candidate_state=needs_capture")) {
           return {
             ok: true,
@@ -197,6 +212,47 @@ describe("VisualAssetsReviewPage", () => {
         .mock.calls.filter(([input]) => String(input).includes("/approve"));
       expect(approvalCalls).toHaveLength(1);
       expect(String(approvalCalls[0][0])).toContain("candidate-1");
+    });
+  });
+
+  it("requires rejection feedback before regenerating a candidate", async () => {
+    render(<VisualAssetsReviewPage />);
+
+    const rejectButton = (await screen.findAllByRole("button", { name: "Reject" }))[0];
+    fireEvent.click(rejectButton);
+
+    expect(screen.getByRole("dialog", { name: "Reject candidate" })).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Rejection reason"), {
+      target: { value: "Too much blank space and the product is not clear." },
+    });
+    fireEvent.change(screen.getByLabelText("Regeneration recommendation"), {
+      target: { value: "Tighten the crop and show the feature cards." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Too much blank space" }));
+    fireEvent.click(screen.getByRole("button", { name: "Reject & Regenerate" }));
+
+    await waitFor(() => {
+      const rejectCall = vi
+        .mocked(fetch)
+        .mock.calls.find(([input]) => String(input).includes("/reject"));
+      expect(rejectCall).toBeDefined();
+      expect(JSON.parse(String(rejectCall?.[1]?.body))).toMatchObject({
+        reason: "Too much blank space and the product is not clear.",
+        recommendation: "Tighten the crop and show the feature cards.",
+        reasonCodes: expect.arrayContaining(["high_blank_space_ratio"]),
+      });
+    });
+
+    await waitFor(() => {
+      const regenerateCall = vi
+        .mocked(fetch)
+        .mock.calls.find(([input]) => String(input).includes("/regenerate"));
+      expect(regenerateCall).toBeDefined();
+      expect(JSON.parse(String(regenerateCall?.[1]?.body))).toMatchObject({
+        reason: "Too much blank space and the product is not clear.",
+        recommendation: "Tighten the crop and show the feature cards.",
+        reasonCodes: expect.arrayContaining(["high_blank_space_ratio"]),
+      });
     });
   });
 });

--- a/app/admin/content/visual-assets/page.tsx
+++ b/app/admin/content/visual-assets/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import Image from 'next/image'
-import { Check, CheckCheck, ChevronLeft, ChevronRight, ImageIcon, Loader2, RefreshCw, Search, ShieldAlert, ShieldCheck, Sparkles, X } from 'lucide-react'
+import { Check, CheckCheck, ChevronLeft, ChevronRight, ImageIcon, Loader2, MessageSquare, RefreshCw, Search, ShieldAlert, ShieldCheck, Sparkles, X } from 'lucide-react'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
 import ProtectedRoute from '@/components/ProtectedRoute'
 import { getCurrentSession } from '@/lib/auth'
@@ -20,6 +20,15 @@ const SORT_OPTIONS = [
   { value: 'score_asc', label: 'Score low-high' },
   { value: 'theme', label: 'Theme' },
 ] as const
+const REJECTION_REASONS: Array<{ value: string; label: string }> = [
+  { value: 'high_blank_space_ratio', label: 'Too much blank space' },
+  { value: 'weak_feature_signal', label: 'Weak product/feature signal' },
+  { value: 'light_mode_mismatch', label: 'Wrong for dark mode' },
+  { value: 'dark_mode_mismatch', label: 'Wrong for light mode' },
+  { value: 'wrong_aspect_ratio', label: 'Bad crop or aspect ratio' },
+  { value: 'low_resolution', label: 'Low resolution' },
+  { value: 'image_load_failure', label: 'Image did not render' },
+]
 
 type EntityTypeFilter = (typeof ENTITY_TYPES)[number]
 type SortKey = (typeof SORT_OPTIONS)[number]['value']
@@ -70,6 +79,32 @@ function agentReview(candidate: VisualAssetCandidate): { decision?: string; summ
   }
 }
 
+function reviewFeedback(candidate: VisualAssetCandidate): { reason?: string; recommendation?: string; reasonCodes: string[] } {
+  const feedback = candidate.metadata?.review_feedback
+  const data = feedback && typeof feedback === 'object' && !Array.isArray(feedback)
+    ? feedback as Record<string, unknown>
+    : {}
+  const reasonCodes = Array.isArray(data.reason_codes)
+    ? data.reason_codes.filter((reason): reason is string => typeof reason === 'string')
+    : Array.isArray(candidate.metadata?.review_reason_codes)
+      ? candidate.metadata.review_reason_codes.filter((reason): reason is string => typeof reason === 'string')
+      : []
+
+  return {
+    reason: typeof data.reason === 'string'
+      ? data.reason
+      : typeof candidate.metadata?.review_reason === 'string'
+        ? candidate.metadata.review_reason
+        : undefined,
+    recommendation: typeof data.recommendation === 'string'
+      ? data.recommendation
+      : typeof candidate.metadata?.review_recommendation === 'string'
+        ? candidate.metadata.review_recommendation
+        : undefined,
+    reasonCodes,
+  }
+}
+
 function AgentReviewBadge({ candidate }: { candidate: VisualAssetCandidate }) {
   const review = agentReview(candidate)
   if (!review?.decision) return null
@@ -107,6 +142,10 @@ export default function VisualAssetsReviewPage() {
   const [page, setPage] = useState(1)
   const [query, setQuery] = useState('')
   const [message, setMessage] = useState<string | null>(null)
+  const [rejectionTarget, setRejectionTarget] = useState<VisualAssetCandidate | null>(null)
+  const [rejectReason, setRejectReason] = useState('')
+  const [rejectRecommendation, setRejectRecommendation] = useState('')
+  const [rejectReasonCodes, setRejectReasonCodes] = useState<string[]>([])
 
   const fetchCandidates = useCallback(async () => {
     setLoading(true)
@@ -245,6 +284,92 @@ export default function VisualAssetsReviewPage() {
       const approved = results.filter((result) => result.status === 'fulfilled').length
       const failed = results.length - approved
       setMessage(failed > 0 ? `Approved ${approved}; failed ${failed}.` : `Approved ${approved} visible candidate${approved === 1 ? '' : 's'}.`)
+      await fetchCandidates()
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : String(error))
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  const openRejectionReview = (candidate: VisualAssetCandidate) => {
+    const feedback = reviewFeedback(candidate)
+    setRejectionTarget(candidate)
+    setRejectReason(feedback.reason ?? '')
+    setRejectRecommendation(feedback.recommendation ?? '')
+    setRejectReasonCodes(feedback.reasonCodes.length > 0 ? feedback.reasonCodes : candidate.reason_codes)
+    setMessage(null)
+  }
+
+  const toggleRejectReasonCode = (reasonCode: string) => {
+    setRejectReasonCodes((current) => (
+      current.includes(reasonCode)
+        ? current.filter((item) => item !== reasonCode)
+        : [...current, reasonCode]
+    ))
+  }
+
+  const closeRejectionReview = () => {
+    setRejectionTarget(null)
+    setRejectReason('')
+    setRejectRecommendation('')
+    setRejectReasonCodes([])
+  }
+
+  const rejectCandidate = async (regenerate = false) => {
+    if (!rejectionTarget) return
+    const reason = rejectReason.trim()
+    if (!reason) {
+      setMessage('Add a rejection reason before rejecting this candidate.')
+      return
+    }
+
+    const session = await getCurrentSession()
+    if (!session) return
+
+    const payload = {
+      reason,
+      recommendation: rejectRecommendation.trim(),
+      reasonCodes: rejectReasonCodes,
+    }
+    setBusy(regenerate ? `regenerate:${rejectionTarget.id}` : `reject:${rejectionTarget.id}`)
+    setMessage(null)
+    try {
+      let sourceId = rejectionTarget.id
+      if (rejectionTarget.status !== 'rejected') {
+        const response = await fetch(`/api/admin/visual-assets/${rejectionTarget.id}/reject`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${session.access_token}`,
+          },
+          body: JSON.stringify(payload),
+        })
+        const data = await response.json().catch(() => ({}))
+        if (!response.ok) throw new Error(data.error || 'Failed to reject candidate')
+        sourceId = typeof data.candidate?.id === 'string' ? data.candidate.id : sourceId
+      }
+
+      if (regenerate) {
+        const response = await fetch(`/api/admin/visual-assets/${sourceId}/regenerate`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${session.access_token}`,
+          },
+          body: JSON.stringify(payload),
+        })
+        const data = await response.json().catch(() => ({}))
+        if (!response.ok) throw new Error(data.error || 'Failed to regenerate candidate')
+        const captured = data.capture?.captured ?? 0
+        const passed = data.capture?.passed ?? 0
+        const blocked = data.capture?.blocked ?? 0
+        setMessage(`Regenerated ${captured}; Idia passed ${passed} and blocked ${blocked}.`)
+      } else {
+        setMessage('Candidate rejected with feedback.')
+      }
+
+      closeRejectionReview()
       await fetchCandidates()
     } catch (error) {
       setMessage(error instanceof Error ? error.message : String(error))
@@ -464,15 +589,24 @@ export default function VisualAssetsReviewPage() {
                           {agentReview(candidate)?.summary}
                         </p>
                       )}
+                      {candidate.status === 'rejected' && reviewFeedback(candidate).reason && (
+                        <div className="mt-3 rounded-lg border border-rose-400/20 bg-rose-500/10 px-3 py-2 text-xs text-rose-100">
+                          <p className="font-semibold uppercase tracking-wide">Rejected feedback</p>
+                          <p className="mt-1 text-rose-100/90">{reviewFeedback(candidate).reason}</p>
+                          {reviewFeedback(candidate).recommendation && (
+                            <p className="mt-2 text-rose-100/75">{reviewFeedback(candidate).recommendation}</p>
+                          )}
+                        </div>
+                      )}
 
                       <div className="mt-4 flex flex-wrap justify-end gap-2">
                         <button
                           className="agent-ops-button-secondary"
-                          disabled={Boolean(busy) || candidate.status === 'rejected'}
-                          onClick={() => postAction(`/api/admin/visual-assets/${candidate.id}/reject`)}
+                          disabled={Boolean(busy) || candidate.status === 'applied'}
+                          onClick={() => openRejectionReview(candidate)}
                         >
-                          <X className="h-4 w-4" />
-                          Reject
+                          <MessageSquare className="h-4 w-4" />
+                          {candidate.status === 'rejected' ? 'Regenerate' : 'Reject'}
                         </button>
                         <button
                           className="agent-ops-button-primary"
@@ -497,8 +631,129 @@ export default function VisualAssetsReviewPage() {
             />
           </div>
         )}
+        {rejectionTarget && (
+          <RejectionDialog
+            candidate={rejectionTarget}
+            reason={rejectReason}
+            recommendation={rejectRecommendation}
+            reasonCodes={rejectReasonCodes}
+            busy={busy}
+            onReasonChange={setRejectReason}
+            onRecommendationChange={setRejectRecommendation}
+            onToggleReasonCode={toggleRejectReasonCode}
+            onCancel={closeRejectionReview}
+            onReject={() => rejectCandidate(false)}
+            onRejectAndRegenerate={() => rejectCandidate(true)}
+          />
+        )}
       </main>
     </ProtectedRoute>
+  )
+}
+
+function RejectionDialog({
+  candidate,
+  reason,
+  recommendation,
+  reasonCodes,
+  busy,
+  onReasonChange,
+  onRecommendationChange,
+  onToggleReasonCode,
+  onCancel,
+  onReject,
+  onRejectAndRegenerate,
+}: {
+  candidate: VisualAssetCandidate
+  reason: string
+  recommendation: string
+  reasonCodes: string[]
+  busy: string | null
+  onReasonChange: (value: string) => void
+  onRecommendationChange: (value: string) => void
+  onToggleReasonCode: (value: string) => void
+  onCancel: () => void
+  onReject: () => void
+  onRejectAndRegenerate: () => void
+}) {
+  const isRejected = candidate.status === 'rejected'
+  const isBusy = Boolean(busy)
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4 py-6">
+      <div role="dialog" aria-modal="true" aria-label={isRejected ? 'Regenerate candidate' : 'Reject candidate'} className="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-xl border border-radiant-gold/20 bg-background p-5 shadow-2xl">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-radiant-gold">
+              {isRejected ? 'Regenerate candidate' : 'Reject candidate'}
+            </p>
+            <h2 id="visual-rejection-title" className="mt-2 text-xl font-semibold text-foreground">{candidate.title}</h2>
+            <p className="mt-1 text-xs uppercase tracking-wide text-muted-foreground">{candidate.theme} / {candidate.entity_type}</p>
+          </div>
+          <button className="rounded-lg border border-radiant-gold/10 p-2 text-muted-foreground hover:text-foreground" onClick={onCancel} aria-label="Close rejection review">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="mt-5 space-y-4">
+          <div>
+            <label htmlFor="visual-rejection-reason" className="text-sm font-semibold text-foreground">Rejection reason</label>
+            <textarea
+              id="visual-rejection-reason"
+              value={reason}
+              onChange={(event) => onReasonChange(event.target.value)}
+              rows={3}
+              className="mt-2 w-full rounded-lg border border-radiant-gold/10 bg-silicon-slate/25 px-3 py-2 text-sm text-foreground outline-none focus:border-radiant-gold/40"
+              placeholder="What is wrong with this candidate?"
+            />
+          </div>
+
+          <div>
+            <p className="text-sm font-semibold text-foreground">Reason codes</p>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {REJECTION_REASONS.map((item) => (
+                <button
+                  key={item.value}
+                  type="button"
+                  className={pillClass(reasonCodes.includes(item.value))}
+                  onClick={() => onToggleReasonCode(item.value)}
+                >
+                  {item.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <label htmlFor="visual-rejection-recommendation" className="text-sm font-semibold text-foreground">Regeneration recommendation</label>
+            <textarea
+              id="visual-rejection-recommendation"
+              value={recommendation}
+              onChange={(event) => onRecommendationChange(event.target.value)}
+              rows={3}
+              className="mt-2 w-full rounded-lg border border-radiant-gold/10 bg-silicon-slate/25 px-3 py-2 text-sm text-foreground outline-none focus:border-radiant-gold/40"
+              placeholder="What should Idia improve on the next capture?"
+            />
+          </div>
+        </div>
+
+        <div className="mt-6 flex flex-wrap justify-end gap-2">
+          <button className="agent-ops-button-secondary" disabled={isBusy} onClick={onCancel}>
+            Cancel
+          </button>
+          {!isRejected && (
+            <button className="agent-ops-button-secondary" disabled={isBusy || !reason.trim()} onClick={onReject}>
+              {busy?.startsWith('reject:') ? <Loader2 className="h-4 w-4 animate-spin" /> : <X className="h-4 w-4" />}
+              Reject
+            </button>
+          )}
+          <button className="agent-ops-button-primary" disabled={isBusy || !reason.trim()} onClick={onRejectAndRegenerate}>
+            {busy?.startsWith('regenerate:') ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
+            {isRejected ? 'Regenerate' : 'Reject & Regenerate'}
+          </button>
+        </div>
+      </div>
+    </div>
   )
 }
 

--- a/app/api/admin/visual-assets/[id]/regenerate/route.ts
+++ b/app/api/admin/visual-assets/[id]/regenerate/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  captureVisualAssetCandidates,
+  regenerateRejectedVisualAssetCandidate,
+  type VisualAssetReasonCode,
+} from '@/lib/visual-assets'
+import { parseJsonBody, requireAdmin } from '../../_utils'
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+export const maxDuration = 300
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const admin = await requireAdmin(request)
+  if ('response' in admin) return admin.response
+
+  try {
+    const body = await parseJsonBody(request)
+    const replacementCandidate = await regenerateRejectedVisualAssetCandidate({
+      sourceCandidateId: params.id,
+      requestedBy: admin.auth.user.id,
+      feedback: {
+        reason: typeof body.reason === 'string' ? body.reason.trim() : undefined,
+        recommendation: typeof body.recommendation === 'string' ? body.recommendation.trim() : undefined,
+        reasonCodes: Array.isArray(body.reasonCodes)
+          ? body.reasonCodes.filter((reasonCode: unknown): reasonCode is VisualAssetReasonCode => typeof reasonCode === 'string') as VisualAssetReasonCode[]
+          : undefined,
+      },
+    })
+
+    const capture = await captureVisualAssetCandidates({
+      candidateIds: [replacementCandidate.id],
+      baseUrl: typeof body.baseUrl === 'string' ? body.baseUrl : new URL(request.url).origin,
+      noStartServer: body.noStartServer !== false,
+    })
+
+    return NextResponse.json({ replacementCandidate, capture })
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : String(error) },
+      { status: 500 },
+    )
+  }
+}

--- a/app/api/admin/visual-assets/[id]/reject/route.ts
+++ b/app/api/admin/visual-assets/[id]/reject/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { reviewVisualAssetCandidate } from '@/lib/visual-assets'
+import { reviewVisualAssetCandidate, type VisualAssetReasonCode } from '@/lib/visual-assets'
 import { parseJsonBody, requireAdmin } from '../../_utils'
 
 export const dynamic = 'force-dynamic'
@@ -13,11 +13,19 @@ export async function POST(
 
   try {
     const body = await parseJsonBody(request)
+    const reason = typeof body.reason === 'string' ? body.reason.trim() : ''
+    if (!reason) {
+      return NextResponse.json({ error: 'Rejection reason is required' }, { status: 400 })
+    }
     const candidate = await reviewVisualAssetCandidate({
       id: params.id,
       status: 'rejected',
       reviewedBy: admin.auth.user.id,
-      reason: typeof body.reason === 'string' ? body.reason : undefined,
+      reason,
+      recommendation: typeof body.recommendation === 'string' ? body.recommendation.trim() : undefined,
+      reasonCodes: Array.isArray(body.reasonCodes)
+        ? body.reasonCodes.filter((reasonCode: unknown): reasonCode is VisualAssetReasonCode => typeof reasonCode === 'string') as VisualAssetReasonCode[]
+        : undefined,
     })
     return NextResponse.json({ candidate })
   } catch (error) {

--- a/app/api/admin/visual-assets/route.test.ts
+++ b/app/api/admin/visual-assets/route.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   captureVisualAssetCandidates: vi.fn(),
   listVisualAssetCandidates: vi.fn(),
   reviewVisualAssetCandidate: vi.fn(),
+  regenerateRejectedVisualAssetCandidate: vi.fn(),
   applyApprovedVisualAssetCandidates: vi.fn(),
 }))
 
@@ -28,6 +29,7 @@ vi.mock('@/lib/visual-assets', () => ({
   captureVisualAssetCandidates: mocks.captureVisualAssetCandidates,
   listVisualAssetCandidates: mocks.listVisualAssetCandidates,
   reviewVisualAssetCandidate: mocks.reviewVisualAssetCandidate,
+  regenerateRejectedVisualAssetCandidate: mocks.regenerateRejectedVisualAssetCandidate,
   applyApprovedVisualAssetCandidates: mocks.applyApprovedVisualAssetCandidates,
 }))
 
@@ -154,18 +156,35 @@ describe('visual asset admin routes', () => {
     })
   })
 
-  it('rejects a candidate without accepting a non-string review reason', async () => {
+  it('requires a rejection reason before rejecting a candidate', async () => {
+    const { POST } = await import('./[id]/reject/route')
+
+    const response = await POST(request('/api/admin/visual-assets/candidate-2/reject', {
+      method: 'POST',
+      body: JSON.stringify({ reason: { text: 'nope' } }),
+    }), { params: { id: 'candidate-2' } })
+    expectResponse(response)
+
+    expect(response.status).toBe(400)
+    expect(mocks.reviewVisualAssetCandidate).not.toHaveBeenCalled()
+  })
+
+  it('rejects a candidate with feedback for regeneration', async () => {
     const { POST } = await import('./[id]/reject/route')
     mocks.reviewVisualAssetCandidate.mockResolvedValue({
       id: 'candidate-2',
       status: 'rejected',
       reviewed_by: 'admin-1',
-      metadata: {},
+      metadata: { review_reason: 'Too blank' },
     })
 
     const response = await POST(request('/api/admin/visual-assets/candidate-2/reject', {
       method: 'POST',
-      body: JSON.stringify({ reason: { text: 'nope' } }),
+      body: JSON.stringify({
+        reason: 'Too much blank space.',
+        recommendation: 'Tighten the crop and show the dashboard.',
+        reasonCodes: ['high_blank_space_ratio', 'weak_feature_signal'],
+      }),
     }), { params: { id: 'candidate-2' } })
     expectResponse(response)
     const body = await response.json()
@@ -176,8 +195,45 @@ describe('visual asset admin routes', () => {
       id: 'candidate-2',
       status: 'rejected',
       reviewedBy: 'admin-1',
-      reason: undefined,
+      reason: 'Too much blank space.',
+      recommendation: 'Tighten the crop and show the dashboard.',
+      reasonCodes: ['high_blank_space_ratio', 'weak_feature_signal'],
     })
+  })
+
+  it('regenerates a rejected candidate and captures only its replacement', async () => {
+    const { POST } = await import('./[id]/regenerate/route')
+    mocks.regenerateRejectedVisualAssetCandidate.mockResolvedValue({
+      id: 'replacement-1',
+      status: 'proposed',
+    })
+    mocks.captureVisualAssetCandidates.mockResolvedValue({ captured: 1, passed: 1, blocked: 0, candidates: [{ id: 'replacement-1' }] })
+
+    const response = await POST(request('/api/admin/visual-assets/candidate-2/regenerate', {
+      method: 'POST',
+      body: JSON.stringify({
+        reason: 'Too dark.',
+        recommendation: 'Use a light-mode frame.',
+        reasonCodes: ['dark_mode_mismatch'],
+      }),
+    }), { params: { id: 'candidate-2' } })
+    expectResponse(response)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.replacementCandidate).toMatchObject({ id: 'replacement-1' })
+    expect(mocks.regenerateRejectedVisualAssetCandidate).toHaveBeenCalledWith({
+      sourceCandidateId: 'candidate-2',
+      requestedBy: 'admin-1',
+      feedback: {
+        reason: 'Too dark.',
+        recommendation: 'Use a light-mode frame.',
+        reasonCodes: ['dark_mode_mismatch'],
+      },
+    })
+    expect(mocks.captureVisualAssetCandidates).toHaveBeenCalledWith(expect.objectContaining({
+      candidateIds: ['replacement-1'],
+    }))
   })
 
   it('apply-approved only calls the approved candidate apply helper', async () => {

--- a/app/services/[id]/page.tsx
+++ b/app/services/[id]/page.tsx
@@ -22,6 +22,7 @@ import { formatCurrency } from '@/lib/pricing-model'
 import Link from 'next/link'
 import Navigation from '@/components/Navigation'
 import Breadcrumbs from '@/components/Breadcrumbs'
+import PortfolioVisualMockup from '@/components/visual-assets/PortfolioVisualMockup'
 
 interface Service {
   id: string
@@ -69,6 +70,19 @@ export default function ServiceDetailPage() {
   const searchParams = useSearchParams()
   const serviceId = params.id as string
   const visualCapture = searchParams.get('visualCapture') === '1'
+  const visualFocusCodes = (searchParams.get('visualFocus') || '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean)
+  const forceGeneratedVisual = searchParams.get('visualRevision') === '1' || visualFocusCodes.some((code) => [
+    'missing_image',
+    'image_load_failure',
+    'high_blank_space_ratio',
+    'weak_feature_signal',
+    'light_mode_mismatch',
+    'dark_mode_mismatch',
+    'candidate_below_quality_bar',
+  ].includes(code))
 
   const [service, setService] = useState<Service | null>(null)
   const [bundles, setBundles] = useState<BundleRef[]>([])
@@ -186,6 +200,7 @@ export default function ServiceDetailPage() {
       'Build the practical delivery plan',
       'Leave the team with a usable handoff',
     ]
+    const useGeneratedVisual = !service.image_url || forceGeneratedVisual
 
     return (
       <main className="min-h-screen bg-background text-foreground flex items-center justify-center overflow-hidden p-10">
@@ -197,45 +212,70 @@ export default function ServiceDetailPage() {
           <div className="absolute left-0 top-0 h-full w-2 bg-radiant-gold" />
           <div className="relative grid h-full grid-cols-[0.9fr_1.1fr] gap-8 p-12">
             <div className="flex min-w-0 flex-col gap-5">
-              <div className="relative h-72 overflow-hidden rounded-xl border border-border bg-background">
-                {service.image_url ? (
-                  <Image
-                    src={service.image_url}
-                    alt={service.title}
-                    fill
-                    className="object-cover"
-                    sizes="520px"
-                    priority
-                  />
-                ) : (
-                  <div className="flex h-full flex-col items-center justify-center gap-4 bg-[radial-gradient(circle_at_35%_25%,rgba(212,175,55,0.3),transparent_34%),linear-gradient(135deg,rgba(44,62,80,0.14),rgba(212,175,55,0.2))] dark:bg-[radial-gradient(circle_at_35%_25%,rgba(212,175,55,0.3),transparent_34%),linear-gradient(135deg,rgba(234,236,238,0.1),rgba(212,175,55,0.16))]">
-                    <Building className="h-20 w-20 text-radiant-gold" />
-                    <span className="text-lg font-semibold text-muted-foreground">Service delivery visual</span>
+              {useGeneratedVisual ? (
+                <>
+                  <div className="relative min-h-0 flex-1 overflow-hidden rounded-xl border border-border bg-background">
+                    <PortfolioVisualMockup
+                      kind="service"
+                      title={service.title}
+                      eyebrow={typeLabel}
+                      primaryLabel={deliveryLabel}
+                      secondaryLabel={durationLabel}
+                      items={[...featuredDeliverables, ...featuredTopics, ...deliveryPath]}
+                      focusCodes={visualFocusCodes}
+                    />
                   </div>
-                )}
-              </div>
 
-              <div className="grid grid-cols-2 gap-4">
-                <div className="rounded-xl border border-border bg-background/80 p-5">
-                  <div className="mb-2 flex items-center gap-2 text-muted-foreground">
-                    {delivery.icon}
-                    <span className="text-sm font-bold uppercase tracking-wider">Delivery</span>
+                  <div className="grid grid-cols-2 gap-4">
+                    <div className="rounded-xl border border-border bg-background/80 p-5">
+                      <div className="mb-2 flex items-center gap-2 text-muted-foreground">
+                        {delivery.icon}
+                        <span className="text-sm font-bold uppercase tracking-wider">Delivery</span>
+                      </div>
+                      <p className="text-2xl font-bold">{deliveryLabel}</p>
+                    </div>
+                    <div className="rounded-xl border border-radiant-gold/40 bg-radiant-gold/10 p-5">
+                      <span className="text-sm font-bold uppercase tracking-wider text-muted-foreground">Investment</span>
+                      <p className="mt-2 text-3xl font-bold text-radiant-gold">{priceLabel}</p>
+                    </div>
                   </div>
-                  <p className="text-2xl font-bold">{deliveryLabel}</p>
-                </div>
-                <div className="rounded-xl border border-border bg-background/80 p-5">
-                  <div className="mb-2 flex items-center gap-2 text-muted-foreground">
-                    <Clock className="h-4 w-4" />
-                    <span className="text-sm font-bold uppercase tracking-wider">Timeline</span>
+                </>
+              ) : (
+                <>
+                  <div className="relative h-72 overflow-hidden rounded-xl border border-border bg-background">
+                    <Image
+                      src={service.image_url || ''}
+                      alt={service.title}
+                      fill
+                      className="object-cover"
+                      sizes="520px"
+                      priority
+                    />
                   </div>
-                  <p className="text-2xl font-bold">{durationLabel}</p>
-                </div>
-              </div>
 
-              <div className="rounded-xl border border-radiant-gold/40 bg-radiant-gold/10 p-5">
-                <span className="text-sm font-bold uppercase tracking-wider text-muted-foreground">Investment</span>
-                <p className="mt-2 text-4xl font-bold text-radiant-gold">{priceLabel}</p>
-              </div>
+                  <div className="grid grid-cols-2 gap-4">
+                    <div className="rounded-xl border border-border bg-background/80 p-5">
+                      <div className="mb-2 flex items-center gap-2 text-muted-foreground">
+                        {delivery.icon}
+                        <span className="text-sm font-bold uppercase tracking-wider">Delivery</span>
+                      </div>
+                      <p className="text-2xl font-bold">{deliveryLabel}</p>
+                    </div>
+                    <div className="rounded-xl border border-border bg-background/80 p-5">
+                      <div className="mb-2 flex items-center gap-2 text-muted-foreground">
+                        <Clock className="h-4 w-4" />
+                        <span className="text-sm font-bold uppercase tracking-wider">Timeline</span>
+                      </div>
+                      <p className="text-2xl font-bold">{durationLabel}</p>
+                    </div>
+                  </div>
+
+                  <div className="rounded-xl border border-radiant-gold/40 bg-radiant-gold/10 p-5">
+                    <span className="text-sm font-bold uppercase tracking-wider text-muted-foreground">Investment</span>
+                    <p className="mt-2 text-4xl font-bold text-radiant-gold">{priceLabel}</p>
+                  </div>
+                </>
+              )}
             </div>
 
             <div className="flex min-w-0 flex-col justify-between">

--- a/app/store/[id]/page.tsx
+++ b/app/store/[id]/page.tsx
@@ -22,6 +22,7 @@ import Link from 'next/link'
 import Navigation from '@/components/Navigation'
 import Breadcrumbs from '@/components/Breadcrumbs'
 import { useCampaignEligibility } from '@/hooks/useCampaignEligibility'
+import PortfolioVisualMockup from '@/components/visual-assets/PortfolioVisualMockup'
 
 interface BundleRef {
   bundleId: string
@@ -60,6 +61,19 @@ export default function ProductDetailPage() {
   const searchParams = useSearchParams()
   const productId = params.id as string
   const visualCapture = searchParams.get('visualCapture') === '1'
+  const visualFocusCodes = (searchParams.get('visualFocus') || '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean)
+  const forceGeneratedVisual = searchParams.get('visualRevision') === '1' || visualFocusCodes.some((code) => [
+    'missing_image',
+    'image_load_failure',
+    'high_blank_space_ratio',
+    'weak_feature_signal',
+    'light_mode_mismatch',
+    'dark_mode_mismatch',
+    'candidate_below_quality_bar',
+  ].includes(code))
   const { getCampaignForBundle } = useCampaignEligibility()
 
   const [product, setProduct] = useState<Product | null>(null)
@@ -177,6 +191,7 @@ export default function ProductDetailPage() {
     return []
   })()
   const heroSrc = heroImageUrls[0]
+  const useGeneratedVisual = !heroSrc || forceGeneratedVisual
 
   // Deliverables / what's included (aligned with service detail)
   const deliverablesList: string[] = []
@@ -210,6 +225,10 @@ export default function ProductDetailPage() {
       'Adapt it to your workflow',
       'Use the included guidance to move faster',
     ]
+    const captureProofItems = (includedItems.length >= 3
+      ? includedItems
+      : [...includedItems, ...workflowItems]
+    ).slice(0, 4)
 
     return (
       <main className="min-h-screen bg-background text-foreground flex items-center justify-center overflow-hidden p-10">
@@ -241,7 +260,7 @@ export default function ProductDetailPage() {
               </div>
 
               <div className="grid grid-cols-2 gap-4">
-                {includedItems.map((item) => (
+                {captureProofItems.map((item) => (
                   <div key={item} className="flex items-start gap-3 rounded-lg border border-border bg-background/80 p-4">
                     <Check className="mt-1 h-5 w-5 flex-none text-radiant-gold" />
                     <span className="text-lg font-medium leading-snug">{item}</span>
@@ -251,49 +270,69 @@ export default function ProductDetailPage() {
             </div>
 
             <div className="flex min-w-0 flex-col gap-5">
-              <div className="relative h-64 overflow-hidden rounded-xl border border-border bg-background">
-                {heroSrc ? (
-                  <Image
-                    src={heroSrc}
-                    alt={product.title}
-                    fill
-                    className="object-cover"
-                    sizes="520px"
-                    priority
-                  />
-                ) : (
-                  <div className="flex h-full flex-col items-center justify-center gap-4 bg-[radial-gradient(circle_at_30%_20%,rgba(212,175,55,0.28),transparent_32%),linear-gradient(135deg,rgba(18,30,49,0.12),rgba(212,175,55,0.18))] dark:bg-[radial-gradient(circle_at_30%_20%,rgba(212,175,55,0.28),transparent_32%),linear-gradient(135deg,rgba(234,236,238,0.1),rgba(212,175,55,0.16))]">
-                    <Package className="h-20 w-20 text-radiant-gold" />
-                    <span className="text-lg font-semibold text-muted-foreground">Product visual system</span>
+              {useGeneratedVisual ? (
+                <>
+                  <div className="relative min-h-0 flex-1 overflow-hidden rounded-xl border border-border bg-background">
+                    <PortfolioVisualMockup
+                      kind="product"
+                      title={product.title}
+                      eyebrow={typeLabel}
+                      primaryLabel={categoryLabel}
+                      secondaryLabel={priceLabel}
+                      items={[...captureProofItems, ...workflowItems]}
+                      focusCodes={visualFocusCodes}
+                    />
                   </div>
-                )}
-              </div>
 
-              <div className="rounded-xl border border-border bg-background/80 p-6">
-                <div className="mb-5 flex items-center justify-between">
-                  <span className="text-sm font-bold uppercase tracking-wider text-muted-foreground">Operator path</span>
-                  <span className="text-3xl font-bold text-radiant-gold">{priceLabel}</span>
-                </div>
-                <div className="space-y-4">
-                  {workflowItems.map((item, index) => (
-                    <div key={item} className="flex items-center gap-4">
-                      <span className="flex h-10 w-10 flex-none items-center justify-center rounded-full bg-silicon-slate text-sm font-bold text-platinum-white dark:bg-radiant-gold dark:text-imperial-navy">
-                        {index + 1}
-                      </span>
-                      <span className="text-xl font-semibold leading-tight">{item}</span>
+                  <div className="grid grid-cols-3 gap-3">
+                    {['Reusable', 'Documented', 'Ready'].map((label) => (
+                      <div key={label} className="rounded-lg border border-radiant-gold/40 bg-radiant-gold/10 p-4 text-center">
+                        <Sparkles className="mx-auto mb-2 h-5 w-5 text-radiant-gold" />
+                        <span className="text-sm font-bold uppercase tracking-wide text-foreground">{label}</span>
+                      </div>
+                    ))}
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div className="relative h-64 overflow-hidden rounded-xl border border-border bg-background">
+                    <Image
+                      src={heroSrc}
+                      alt={product.title}
+                      fill
+                      className="object-cover"
+                      sizes="520px"
+                      priority
+                    />
+                  </div>
+
+                  <div className="rounded-xl border border-border bg-background/80 p-6">
+                    <div className="mb-5 flex items-center justify-between">
+                      <span className="text-sm font-bold uppercase tracking-wider text-muted-foreground">Operator path</span>
+                      <span className="text-3xl font-bold text-radiant-gold">{priceLabel}</span>
                     </div>
-                  ))}
-                </div>
-              </div>
-
-              <div className="mt-auto grid grid-cols-3 gap-3">
-                {['Reusable', 'Documented', 'Ready'].map((label) => (
-                  <div key={label} className="rounded-lg border border-radiant-gold/40 bg-radiant-gold/10 p-4 text-center">
-                    <Sparkles className="mx-auto mb-2 h-5 w-5 text-radiant-gold" />
-                    <span className="text-sm font-bold uppercase tracking-wide text-foreground">{label}</span>
+                    <div className="space-y-4">
+                      {workflowItems.map((item, index) => (
+                        <div key={item} className="flex items-center gap-4">
+                          <span className="flex h-10 w-10 flex-none items-center justify-center rounded-full bg-silicon-slate text-sm font-bold text-platinum-white dark:bg-radiant-gold dark:text-imperial-navy">
+                            {index + 1}
+                          </span>
+                          <span className="text-xl font-semibold leading-tight">{item}</span>
+                        </div>
+                      ))}
+                    </div>
                   </div>
-                ))}
-              </div>
+
+                  <div className="mt-auto grid grid-cols-3 gap-3">
+                    {['Reusable', 'Documented', 'Ready'].map((label) => (
+                      <div key={label} className="rounded-lg border border-radiant-gold/40 bg-radiant-gold/10 p-4 text-center">
+                        <Sparkles className="mx-auto mb-2 h-5 w-5 text-radiant-gold" />
+                        <span className="text-sm font-bold uppercase tracking-wide text-foreground">{label}</span>
+                      </div>
+                    ))}
+                  </div>
+                </>
+              )}
             </div>
           </div>
         </section>

--- a/components/visual-assets/PortfolioVisualMockup.test.tsx
+++ b/components/visual-assets/PortfolioVisualMockup.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import PortfolioVisualMockup from './PortfolioVisualMockup'
+
+describe('PortfolioVisualMockup', () => {
+  it('renders a dense product visual fallback from artifact metadata', () => {
+    render(
+      <PortfolioVisualMockup
+        kind="product"
+        title="AI Implementation Playbook"
+        eyebrow="Template"
+        primaryLabel="Digital asset"
+        secondaryLabel="$29"
+        items={['Install instructions', 'Repo link', 'Operator guide']}
+        focusCodes={['weak_feature_signal', 'high_blank_space_ratio']}
+      />,
+    )
+
+    expect(screen.getByText('AI Implementation Playbook')).toBeInTheDocument()
+    expect(screen.getByText('Feature proof')).toBeInTheDocument()
+    expect(screen.getByText('Dense frame')).toBeInTheDocument()
+    expect(screen.getByText('Implementation board')).toBeInTheDocument()
+    expect(screen.getAllByText('Install instructions').length).toBeGreaterThan(0)
+  })
+
+  it('renders a service visual fallback with delivery labels', () => {
+    render(
+      <PortfolioVisualMockup
+        kind="service"
+        title="AI Strategy Workshop"
+        eyebrow="Workshop"
+        primaryLabel="Hybrid"
+        secondaryLabel="Half day"
+        items={['Discovery', 'Action plan', 'Implementation guidance']}
+      />,
+    )
+
+    expect(screen.getByText('AI Strategy Workshop')).toBeInTheDocument()
+    expect(screen.getByText('Workshop')).toBeInTheDocument()
+    expect(screen.getByText('Hybrid')).toBeInTheDocument()
+    expect(screen.getByText('Handoff checklist')).toBeInTheDocument()
+  })
+})

--- a/components/visual-assets/PortfolioVisualMockup.tsx
+++ b/components/visual-assets/PortfolioVisualMockup.tsx
@@ -1,0 +1,189 @@
+'use client'
+
+import { BarChart3, CheckCircle2, FileText, Layers3, LineChart, ShieldCheck, Workflow } from 'lucide-react'
+
+type VisualMockupKind = 'product' | 'service'
+
+interface PortfolioVisualMockupProps {
+  kind: VisualMockupKind
+  title: string
+  eyebrow: string
+  primaryLabel: string
+  secondaryLabel: string
+  items: string[]
+  focusCodes?: string[]
+}
+
+function cleanItems(items: string[]) {
+  const cleaned = items
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .slice(0, 5)
+
+  if (cleaned.length >= 3) return cleaned
+  return [
+    ...cleaned,
+    'Discovery map',
+    'Implementation plan',
+    'Operator handoff',
+  ].slice(0, 5)
+}
+
+function shortTitle(title: string) {
+  return title.length > 54 ? `${title.slice(0, 51).trim()}...` : title
+}
+
+function buildSignalLabels(kind: VisualMockupKind, focusCodes: string[] = []) {
+  const labels = kind === 'product'
+    ? ['Asset map', 'Workflow', 'Launch kit']
+    : ['Discovery', 'Delivery', 'Handoff']
+
+  if (focusCodes.includes('weak_feature_signal')) labels[1] = 'Feature proof'
+  if (focusCodes.includes('high_blank_space_ratio')) labels[2] = 'Dense frame'
+  if (focusCodes.includes('wrong_aspect_ratio')) labels[0] = 'Homepage crop'
+  return labels
+}
+
+export default function PortfolioVisualMockup({
+  kind,
+  title,
+  eyebrow,
+  primaryLabel,
+  secondaryLabel,
+  items,
+  focusCodes = [],
+}: PortfolioVisualMockupProps) {
+  const artifactItems = cleanItems(items)
+  const signalLabels = buildSignalLabels(kind, focusCodes)
+  const metricOne = kind === 'product' ? 'Ready' : 'Scoped'
+  const metricTwo = kind === 'product' ? '3 steps' : '90 days'
+  const metricThree = kind === 'product' ? 'Reusable' : 'Handoff'
+
+  return (
+    <div className="relative h-full overflow-hidden bg-background text-foreground">
+      <div className="absolute inset-0 bg-[linear-gradient(145deg,rgba(212,175,55,0.16),rgba(44,62,80,0.08)_38%,rgba(234,236,238,0.18))] dark:bg-[linear-gradient(145deg,rgba(212,175,55,0.18),rgba(18,30,49,0.88)_40%,rgba(44,62,80,0.74))]" />
+      <div className="relative grid h-full grid-cols-[132px_1fr]">
+        <aside className="flex min-h-0 flex-col border-r border-border bg-card/80 p-3">
+          <div className="mb-3 flex items-center gap-2">
+            <span className="h-2.5 w-2.5 rounded-full bg-radiant-gold" />
+            <span className="text-[9px] font-bold uppercase text-muted-foreground">AmaduTown</span>
+          </div>
+          <div className="space-y-2">
+            {signalLabels.map((label, index) => (
+              <div
+                key={label}
+                className={`flex items-center gap-1.5 rounded-md border px-2 py-1.5 text-[10px] font-semibold ${
+                  index === 1
+                    ? 'border-radiant-gold/50 bg-radiant-gold/15 text-radiant-gold'
+                    : 'border-border bg-background/60 text-muted-foreground'
+                }`}
+              >
+                {index === 0 && <Layers3 className="h-3.5 w-3.5" />}
+                {index === 1 && <Workflow className="h-3.5 w-3.5" />}
+                {index === 2 && <ShieldCheck className="h-3.5 w-3.5" />}
+                {label}
+              </div>
+            ))}
+          </div>
+          <div className="mt-auto rounded-lg border border-radiant-gold/30 bg-radiant-gold/10 p-2">
+            <p className="text-[8px] font-bold uppercase text-muted-foreground">{kind === 'product' ? 'Artifact' : 'Engagement'}</p>
+            <p className="mt-0.5 text-base font-bold text-radiant-gold">{metricOne}</p>
+          </div>
+        </aside>
+
+        <div className="min-w-0 p-3">
+          <header className="mb-2 flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="text-[8px] font-bold uppercase text-radiant-gold">{eyebrow}</p>
+              <h3 className="mt-0.5 text-lg font-bold leading-tight text-foreground">{shortTitle(title)}</h3>
+            </div>
+            <div className="grid grid-cols-2 gap-2 text-right">
+              <div className="rounded-md border border-border bg-card/85 px-2 py-1.5">
+                <p className="text-[8px] uppercase text-muted-foreground">Mode</p>
+                <p className="text-[11px] font-bold leading-tight text-foreground">{primaryLabel}</p>
+              </div>
+              <div className="rounded-md border border-border bg-card/85 px-2 py-1.5">
+                <p className="text-[8px] uppercase text-muted-foreground">Signal</p>
+                <p className="text-[11px] font-bold leading-tight text-foreground">{secondaryLabel}</p>
+              </div>
+            </div>
+          </header>
+
+          <div className="grid h-[calc(100%-50px)] grid-cols-[1.08fr_0.92fr] gap-3">
+            <section className="min-w-0 rounded-lg border border-border bg-card/85 p-3">
+              <div className="mb-2 flex items-center justify-between">
+                <div>
+                  <p className="text-[8px] font-bold uppercase text-muted-foreground">Implementation board</p>
+                  <p className="text-xs font-semibold text-foreground">What the buyer gets</p>
+                </div>
+                <LineChart className="h-4 w-4 text-radiant-gold" />
+              </div>
+              <div className="grid grid-cols-3 gap-2">
+                {['Capture', 'Build', 'Operate'].map((lane, laneIndex) => (
+                  <div key={lane} className="rounded-md border border-border bg-background/70 p-2">
+                    <p className="mb-1.5 text-[8px] font-bold uppercase text-muted-foreground">{lane}</p>
+                    <div className="space-y-1.5">
+                      {artifactItems.slice(0, 3).map((item, itemIndex) => (
+                        <div
+                          key={`${lane}-${item}`}
+                          className={`line-clamp-2 rounded border px-1.5 py-1 text-[9px] font-semibold leading-tight ${
+                            itemIndex === laneIndex
+                              ? 'border-radiant-gold/50 bg-radiant-gold/15 text-foreground'
+                              : 'border-border bg-card text-muted-foreground'
+                          }`}
+                        >
+                          {item}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+              <div className="mt-2 grid grid-cols-3 gap-2">
+                {[metricOne, metricTwo, metricThree].map((metric, index) => (
+                  <div key={metric} className="rounded-md border border-border bg-background/70 p-2">
+                    <div className="mb-1 flex items-center justify-between">
+                      <span className="text-[8px] uppercase text-muted-foreground">Proof {index + 1}</span>
+                      <BarChart3 className="h-3.5 w-3.5 text-radiant-gold" />
+                    </div>
+                    <p className="text-xs font-bold text-foreground">{metric}</p>
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            <section className="flex min-w-0 flex-col gap-3">
+              <div className="rounded-lg border border-border bg-card/85 p-3">
+                <div className="mb-2 flex items-center justify-between">
+                  <p className="text-[8px] font-bold uppercase text-muted-foreground">Handoff checklist</p>
+                  <FileText className="h-4 w-4 text-radiant-gold" />
+                </div>
+                <div className="space-y-1.5">
+                  {artifactItems.slice(0, 4).map((item) => (
+                    <div key={item} className="flex items-start gap-1.5 rounded-md border border-border bg-background/70 px-2 py-1.5">
+                      <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 flex-none text-radiant-gold" />
+                      <span className="line-clamp-1 text-[10px] font-semibold leading-tight text-foreground">{item}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+              <div className="grid flex-1 grid-cols-2 gap-2">
+                {[
+                  { label: kind === 'product' ? 'Install' : 'Intake', value: '01' },
+                  { label: kind === 'product' ? 'Adapt' : 'Session', value: '02' },
+                  { label: kind === 'product' ? 'Ship' : 'Next step', value: '03' },
+                  { label: 'Review gate', value: 'HITL' },
+                ].map((item) => (
+                  <div key={item.label} className="rounded-lg border border-radiant-gold/30 bg-radiant-gold/10 p-2">
+                    <p className="text-[8px] font-bold uppercase text-muted-foreground">{item.label}</p>
+                    <p className="mt-1 text-base font-bold text-radiant-gold">{item.value}</p>
+                  </div>
+                ))}
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/lib/visual-assets.test.ts
+++ b/lib/visual-assets.test.ts
@@ -12,6 +12,7 @@ import {
   applyApprovedVisualAssetCandidates,
   captureVisualAssetCandidates,
   listVisualAssetCandidates,
+  regenerateRejectedVisualAssetCandidate,
   resolveVisualAssetRoute,
   reviewVisualAssetCandidate,
   reviewVisualAssetCandidateQuality,
@@ -28,6 +29,7 @@ function createTableClient(tables: Record<string, Record<string, any>[]>) {
     const state: {
       select?: string
       patch?: Record<string, unknown>
+      insert?: Record<string, unknown>
       filters: Record<string, unknown>
       inFilters: Record<string, unknown[]>
       notFilters: Record<string, unknown>
@@ -41,6 +43,10 @@ function createTableClient(tables: Record<string, Record<string, any>[]>) {
       },
       update(patch: Record<string, unknown>) {
         state.patch = patch
+        return api
+      },
+      insert(patch: Record<string, unknown>) {
+        state.insert = patch
         return api
       },
       eq(key: string, value: unknown) {
@@ -71,6 +77,14 @@ function createTableClient(tables: Record<string, Record<string, any>[]>) {
       },
       single() {
         const list = tables[table] ?? []
+        if (state.insert) {
+          const row = {
+            id: `inserted-${list.length + 1}`,
+            ...state.insert,
+          }
+          list.push(row)
+          return Promise.resolve({ data: row, error: null })
+        }
         const row = list.find((entry) => matches(entry, state))
         if (state.patch && row) {
           Object.assign(row, state.patch)
@@ -242,7 +256,7 @@ describe('visual asset helpers', () => {
     })
   })
 
-  it('preserves metadata while approving and rejecting candidates', async () => {
+  it('preserves structured metadata while reviewing candidates', async () => {
     const client = createTableClient({
       visual_asset_candidates: [{
         id: 'candidate-1',
@@ -256,13 +270,76 @@ describe('visual asset helpers', () => {
       status: 'approved',
       reviewedBy: 'admin-1',
       reason: 'Strong feature signal',
+      recommendation: 'Keep this framing for the homepage.',
+      reasonCodes: ['weak_feature_signal'],
       client,
     })
 
     expect(row).toMatchObject({
       status: 'approved',
       reviewed_by: 'admin-1',
-      metadata: { score: 10, review_reason: 'Strong feature signal' },
+      metadata: {
+        score: 10,
+        review_reason: 'Strong feature signal',
+        review_recommendation: 'Keep this framing for the homepage.',
+        review_reason_codes: ['weak_feature_signal'],
+        review_feedback: expect.objectContaining({
+          status: 'approved',
+          reason: 'Strong feature signal',
+          recommendation: 'Keep this framing for the homepage.',
+          reason_codes: ['weak_feature_signal'],
+        }),
+      },
+    })
+  })
+
+  it('creates a regenerated proposed candidate from rejected feedback', async () => {
+    const client = createTableClient({
+      visual_asset_candidates: [{
+        id: 'rejected-1',
+        entity_type: 'service',
+        entity_id: 'svc-1',
+        title: 'AI Advisory',
+        theme: 'light',
+        current_url: null,
+        candidate_url: 'https://example.com/bad.png',
+        candidate_storage_path: 'products/visual-candidates/service-svc-1/light/rejected-1.png',
+        capture_route: '/services/svc-1?visualCapture=1',
+        score: 54,
+        reason_codes: ['dark_mode_mismatch'],
+        status: 'rejected',
+        metadata: {
+          source_table: 'services',
+          review_feedback: {
+            reason: 'Too dark for light mode.',
+            recommendation: 'Use a brighter service frame with more feature detail.',
+            reason_codes: ['dark_mode_mismatch', 'weak_feature_signal'],
+          },
+        },
+      }],
+    }) as any
+
+    const replacement = await regenerateRejectedVisualAssetCandidate({
+      sourceCandidateId: 'rejected-1',
+      requestedBy: 'admin-1',
+      client,
+    })
+
+    expect(replacement).toMatchObject({
+      id: 'inserted-2',
+      status: 'proposed',
+      candidate_url: null,
+      capture_route: '/services/svc-1?visualCapture=1&visualRevision=1&visualFocus=dark_mode_mismatch%2Cweak_feature_signal',
+      reason_codes: ['dark_mode_mismatch', 'weak_feature_signal'],
+      metadata: {
+        regenerated_from_candidate_id: 'rejected-1',
+        previous_candidate_url: 'https://example.com/bad.png',
+        regeneration_feedback: expect.objectContaining({
+          reason: 'Too dark for light mode.',
+          recommendation: 'Use a brighter service frame with more feature detail.',
+          reason_codes: ['dark_mode_mismatch', 'weak_feature_signal'],
+        }),
+      },
     })
   })
 

--- a/lib/visual-assets.test.ts
+++ b/lib/visual-assets.test.ts
@@ -461,7 +461,7 @@ describe('visual asset helpers', () => {
       baseUrl: 'https://portfolio.example.com',
       noStartServer: true,
       routes: [expect.objectContaining({
-        route: '/store/42?visualCapture=1',
+        route: '/store/42?visualCapture=1&visualFocus=missing_image',
         filename: 'visual-candidate-needs-capture',
         colorScheme: 'light',
       })],

--- a/lib/visual-assets.ts
+++ b/lib/visual-assets.ts
@@ -158,6 +158,16 @@ function appendRegenerationParams(route: string, reasonCodes: VisualAssetReasonC
   return `${pathname}?${params.toString()}`
 }
 
+function appendVisualFocusParams(route: string, reasonCodes: VisualAssetReasonCode[]) {
+  if (reasonCodes.length === 0) return route
+  const [pathname, query = ''] = route.split('?')
+  const params = new URLSearchParams(query)
+  if (!params.has('visualFocus')) {
+    params.set('visualFocus', reasonCodes.join(','))
+  }
+  return `${pathname}?${params.toString()}`
+}
+
 export function isVisualAssetEntityType(value: string): value is VisualAssetEntityType {
   return VISUAL_ASSET_ENTITY_TYPES.includes(value as VisualAssetEntityType)
 }
@@ -618,7 +628,7 @@ export async function auditVisualAssets(input: {
 
 function toRouteConfig(candidate: VisualAssetCandidate): RouteConfig {
   return {
-    route: candidate.capture_route,
+    route: appendVisualFocusParams(candidate.capture_route, candidate.reason_codes),
     filename: `visual-candidate-${candidate.id}`,
     description: `${candidate.title} ${candidate.theme} visual candidate`,
     fullPage: false,

--- a/lib/visual-assets.ts
+++ b/lib/visual-assets.ts
@@ -91,6 +91,12 @@ export interface VisualAssetAgentReview {
   metrics: VisualAssetScore['metadata']
 }
 
+export interface VisualAssetRejectionFeedback {
+  reason?: string
+  recommendation?: string
+  reasonCodes?: VisualAssetReasonCode[]
+}
+
 type SupabaseLike = typeof supabaseAdmin
 
 const MIN_WIDTH = 900
@@ -121,6 +127,35 @@ function asMetadata(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? value as Record<string, unknown>
     : {}
+}
+
+function normalizeReasonCodes(value: unknown): VisualAssetReasonCode[] {
+  if (!Array.isArray(value)) return []
+  return value.filter((reason): reason is VisualAssetReasonCode => (
+    typeof reason === 'string' &&
+    [
+      'missing_image',
+      'image_load_failure',
+      'low_resolution',
+      'wrong_aspect_ratio',
+      'high_blank_space_ratio',
+      'light_mode_mismatch',
+      'dark_mode_mismatch',
+      'weak_feature_signal',
+      'stale_generated_capture',
+      'candidate_below_quality_bar',
+    ].includes(reason)
+  ))
+}
+
+function appendRegenerationParams(route: string, reasonCodes: VisualAssetReasonCode[]) {
+  const [pathname, query = ''] = route.split('?')
+  const params = new URLSearchParams(query)
+  params.set('visualRevision', '1')
+  if (reasonCodes.length > 0) {
+    params.set('visualFocus', reasonCodes.join(','))
+  }
+  return `${pathname}?${params.toString()}`
 }
 
 export function isVisualAssetEntityType(value: string): value is VisualAssetEntityType {
@@ -721,6 +756,8 @@ export async function reviewVisualAssetCandidate(input: {
   status: Extract<VisualAssetStatus, 'approved' | 'rejected'>
   reviewedBy: string
   reason?: string
+  recommendation?: string
+  reasonCodes?: VisualAssetReasonCode[]
   client?: SupabaseLike
 }) {
   const existing = await db(input.client)
@@ -739,6 +776,16 @@ export async function reviewVisualAssetCandidate(input: {
       metadata: {
         ...asMetadata(existing.data?.metadata),
         ...(input.reason ? { review_reason: input.reason } : {}),
+        ...(input.recommendation ? { review_recommendation: input.recommendation } : {}),
+        ...(input.reasonCodes?.length ? { review_reason_codes: input.reasonCodes } : {}),
+        review_feedback: {
+          status: input.status,
+          reason: input.reason ?? null,
+          recommendation: input.recommendation ?? null,
+          reason_codes: input.reasonCodes ?? [],
+          reviewed_by: input.reviewedBy,
+          reviewed_at: new Date().toISOString(),
+        },
       },
       updated_at: new Date().toISOString(),
     })
@@ -748,6 +795,89 @@ export async function reviewVisualAssetCandidate(input: {
     .single()
   if (error) throw new Error(`Failed to ${input.status} visual asset candidate: ${error.message}`)
   return data as VisualAssetCandidate
+}
+
+export async function regenerateRejectedVisualAssetCandidate(input: {
+  sourceCandidateId: string
+  requestedBy: string
+  feedback?: VisualAssetRejectionFeedback
+  client?: SupabaseLike
+}) {
+  const client = input.client ?? supabaseAdmin
+  const { data: source, error: sourceError } = await db(client)
+    .from('visual_asset_candidates')
+    .select('*')
+    .eq('id', input.sourceCandidateId)
+    .maybeSingle()
+
+  if (sourceError) throw new Error(`Failed to read rejected visual asset candidate: ${sourceError.message}`)
+  if (!source) throw new Error('Visual asset candidate not found')
+  const candidate = source as VisualAssetCandidate
+  if (candidate.status !== 'rejected') {
+    throw new Error('Only rejected visual asset candidates can be regenerated')
+  }
+
+  const existingOpen = await db(client)
+    .from('visual_asset_candidates')
+    .select('id')
+    .eq('entity_type', candidate.entity_type)
+    .eq('entity_id', candidate.entity_id)
+    .eq('theme', candidate.theme)
+    .in('status', ['proposed', 'approved'])
+    .limit(1)
+    .maybeSingle()
+  if (existingOpen.error) throw new Error(`Failed to check open visual asset candidates: ${existingOpen.error.message}`)
+  if (existingOpen.data?.id) {
+    throw new Error('An open replacement candidate already exists for this asset and theme')
+  }
+
+  const metadata = asMetadata(candidate.metadata)
+  const storedFeedback = asMetadata(metadata.review_feedback)
+  const reason = input.feedback?.reason || safeText(storedFeedback.reason) || safeText(metadata.review_reason) || undefined
+  const recommendation = input.feedback?.recommendation || safeText(storedFeedback.recommendation) || safeText(metadata.review_recommendation) || undefined
+  const reasonCodes = normalizeReasonCodes(input.feedback?.reasonCodes?.length ? input.feedback.reasonCodes : (storedFeedback.reason_codes ?? metadata.review_reason_codes))
+  const requestedAt = new Date().toISOString()
+  const captureRoute = appendRegenerationParams(candidate.capture_route, reasonCodes)
+
+  const { data: replacement, error: insertError } = await db(client)
+    .from('visual_asset_candidates')
+    .insert({
+      entity_type: candidate.entity_type,
+      entity_id: candidate.entity_id,
+      title: candidate.title,
+      theme: candidate.theme,
+      current_url: candidate.current_url,
+      candidate_url: null,
+      candidate_storage_path: null,
+      capture_route: captureRoute,
+      score: null,
+      reason_codes: reasonCodes.length > 0 ? reasonCodes : candidate.reason_codes,
+      status: 'proposed',
+      metadata: {
+        source_table: metadata.source_table,
+        source_column: metadata.source_column,
+        variant_column: metadata.variant_column,
+        regenerated_from_candidate_id: candidate.id,
+        previous_candidate_url: candidate.candidate_url,
+        previous_candidate_storage_path: candidate.candidate_storage_path,
+        previous_capture_route: candidate.capture_route,
+        regeneration_feedback: {
+          source_candidate_id: candidate.id,
+          requested_by: input.requestedBy,
+          requested_at: requestedAt,
+          reason: reason ?? null,
+          recommendation: recommendation ?? null,
+          reason_codes: reasonCodes,
+        },
+      },
+      created_at: requestedAt,
+      updated_at: requestedAt,
+    })
+    .select('*')
+    .single()
+
+  if (insertError) throw new Error(`Failed to create regenerated visual asset candidate: ${insertError.message}`)
+  return replacement as VisualAssetCandidate
 }
 
 async function applyCandidate(candidate: VisualAssetCandidate, client: SupabaseLike) {


### PR DESCRIPTION
## Summary
- Adds a rejection review dialog to the visual-assets admin page with required rejection reason, reason-code chips, and regeneration recommendation.
- Adds POST /api/admin/visual-assets/[id]/regenerate to create a replacement candidate from rejected feedback and capture only that replacement.
- Stores rejection feedback and regeneration history in candidate metadata, avoiding a schema migration.
- Replacement capture routes include visualRevision=1 and visualFocus reason-code parameters while preserving the written recommendation in metadata.

## Validation
- npx vitest run lib/visual-assets.test.ts app/api/admin/visual-assets/route.test.ts app/admin/content/visual-assets/page.test.tsx
- npx tsc --noEmit --pretty false
- npm run build
- In-app Browser smoke on http://localhost:3042/admin/content/visual-assets: page loaded, rejection dialog opened, feedback fields accepted input, action buttons enabled, no console warnings/errors.
- Push hook database health check passed.

## Integration Notes
- No migration required; metadata-only storage for rejection feedback/regeneration history.
- During Browser smoke, hot reload briefly exercised the prior one-click reject behavior. I identified 18 feedback-less rejected rows from the smoke window and restored exactly those rows to proposed; verification showed 0 of that set remained rejected.
- Non-captain branch; do not merge from this thread.
- Vercel – portfolio: not checked.
- Vercel – portfolio-staging: not checked.