### PR TITLE
feat: add social calibration gold standards

### DIFF
--- a/app/admin/mobile-app-foundry/PacketPreviewWorkspace.test.tsx
+++ b/app/admin/mobile-app-foundry/PacketPreviewWorkspace.test.tsx
@@ -142,7 +142,7 @@ describe('PacketPreviewWorkspace', () => {
   })
 
   it('sends commercialization validation fields to the read-only packet endpoint', async () => {
-    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => new Response(JSON.stringify({
       ok: true,
       mode: 'read_only',
       markdown: '# Speech Practice Coach Commercialization Packet',

--- a/app/admin/social-content/[id]/page.test.tsx
+++ b/app/admin/social-content/[id]/page.test.tsx
@@ -301,6 +301,70 @@ describe('SocialContentDetailRoute visual production review', () => {
     )
   })
 
+  it('lets the operator mark an approved post as a gold-standard calibration reference', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.includes('/calibration-library')) {
+        return {
+          ok: true,
+          json: async () => ({
+            references: [],
+            source: 'approved_calibration_library',
+            side_effects: {
+              provider_generation: false,
+              publish: false,
+              schedule: false,
+              external_post: false,
+            },
+          }),
+        } as Response
+      }
+      if (url.includes('/topic-backlog')) {
+        return {
+          ok: true,
+          json: async () => ({ items: [topicBacklogItem] }),
+        } as Response
+      }
+      if (init?.method === 'PUT') {
+        const body = JSON.parse(String(init.body))
+        return {
+          ok: true,
+          json: async () => ({
+            item: {
+              ...baseItem,
+              rag_context: body.rag_context,
+            },
+          }),
+        } as Response
+      }
+      return {
+        ok: true,
+        json: async () => ({ item: baseItem }),
+      } as Response
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderAtStep('context')
+
+    fireEvent.click(await screen.findByText('Content calibration'))
+    const markButton = await screen.findByRole('button', { name: /Mark gold standard/i })
+    fireEvent.click(markButton)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Gold standard/i })).toBeDisabled()
+    })
+    const putCall = fetchMock.mock.calls.find(([url, init]) => (
+      String(url).includes('/api/admin/social-content/social-1') && init?.method === 'PUT'
+    ))
+    expect(putCall).toBeTruthy()
+    const putBody = JSON.parse(String(putCall?.[1]?.body))
+    expect(putBody.rag_context.content_calibration.reference_curation).toMatchObject({
+      gold_standard: true,
+      reason: 'Operator marked this approved Social Content item as a reusable calibration reference.',
+    })
+    expect(putBody.rag_context.content_calibration.reference_curation.marked_at).toBeTruthy()
+  })
+
   it('shows production assets and blocks publish readiness while redaction is unresolved', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => ({
       ok: true,

--- a/app/admin/social-content/[id]/page.tsx
+++ b/app/admin/social-content/[id]/page.tsx
@@ -35,6 +35,7 @@ import {
   Trash2,
   MessageSquare,
   Lightbulb,
+  Star,
 } from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
@@ -286,6 +287,7 @@ function SocialContentDetailPage() {
   const [publishing, setPublishing] = useState(false)
   const [refreshingEngagement, setRefreshingEngagement] = useState(false)
   const [savingCalibration, setSavingCalibration] = useState(false)
+  const [savingGoldStandard, setSavingGoldStandard] = useState(false)
   const [revisingCalibration, setRevisingCalibration] = useState(false)
   const [requestingCopyRevision, setRequestingCopyRevision] = useState(false)
   const [loadingTopicBacklog, setLoadingTopicBacklog] = useState(false)
@@ -680,6 +682,55 @@ function SocialContentDetailPage() {
       showMsg('error', 'Failed to save calibration feedback')
     } finally {
       setSavingCalibration(false)
+    }
+  }
+
+  const handleMarkGoldStandard = async () => {
+    if (!item) return
+    setSavingGoldStandard(true)
+    try {
+      const session = await getCurrentSession()
+      if (!session) return
+
+      const existingRag = asRecord(item.rag_context) ?? {}
+      const existingCalibration = asRecord(existingRag.content_calibration) ?? {}
+      const existingReferenceCuration = asRecord(existingCalibration.reference_curation) ?? {}
+      const rag_context = {
+        ...existingRag,
+        content_calibration: {
+          ...existingCalibration,
+          status: asString(existingCalibration.status) || 'approved_reference',
+          reference_curation: {
+            ...existingReferenceCuration,
+            gold_standard: true,
+            reason: 'Operator marked this approved Social Content item as a reusable calibration reference.',
+            marked_at: new Date().toISOString(),
+          },
+        },
+      }
+
+      const res = await fetch(`/api/admin/social-content/${id}`, {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${session.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ rag_context }),
+      })
+
+      if (res.ok) {
+        const data = await res.json()
+        setItem(prev => prev ? { ...prev, ...data.item } : prev)
+        await fetchCalibrationLibrary()
+        showMsg('success', 'Marked as a gold-standard calibration reference')
+      } else {
+        const data = await res.json()
+        showMsg('error', data.error || 'Failed to mark gold standard')
+      }
+    } catch {
+      showMsg('error', 'Failed to mark gold standard')
+    } finally {
+      setSavingGoldStandard(false)
     }
   }
 
@@ -1359,6 +1410,8 @@ function SocialContentDetailPage() {
   const agentPilotPassToHuman = ragContext?.pass_to_human === true
   const agentPilotRequiredFixes = asStringArray(ragContext?.required_fixes)
   const agentPilotCalibration = asRecord(ragContext?.content_calibration)
+  const agentPilotReferenceCuration = asRecord(agentPilotCalibration?.reference_curation)
+  const isGoldStandardCalibrationReference = agentPilotReferenceCuration?.gold_standard === true || agentPilotCalibration?.gold_standard === true
   const agentPilotCalibrationStatus = asString(agentPilotCalibration?.status)
   const agentPilotLatestRevision = asRecord(agentPilotCalibration?.latest_revision)
   const agentPilotLatestRevisionCreatedAt = asString(agentPilotLatestRevision?.created_at)
@@ -1438,6 +1491,10 @@ function SocialContentDetailPage() {
       ? engagementLatest.likes
       : 0
   const isDraftOnlyPilot = isAgentSocialPilot && agentPilotPublishGate === 'draft_only'
+  const canMarkGoldStandardCalibrationReference = isAgentSocialPilot
+    && ['approved', 'published'].includes(item.status)
+    && (item.platform === 'linkedin' || targetPlatforms.includes('linkedin'))
+    && Boolean(item.post_text?.trim())
   const canApproveAgentPilot = !isAgentSocialPilot || agentPilotPassToHuman
   const videoPrivacyBlocked = Boolean(productionAssets && !redactionGate.ready)
   const canRequestCopyRevision = isAgentSocialPilot && item.status === 'approved'
@@ -1948,6 +2005,28 @@ function SocialContentDetailPage() {
                       : 'No calibration packet was seeded for this draft yet. Add a prior post, engagement signal, audience context, and revision request so Shaka can revise it in context.'}
                   </p>
 
+                  {canMarkGoldStandardCalibrationReference && (
+                    <div className="mt-3 rounded-lg border border-amber-500/30 bg-amber-500/5 p-3">
+                      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                        <div>
+                          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-amber-200">Current post as benchmark</p>
+                          <p className="mt-1 text-sm leading-6 text-amber-50/85">
+                            Mark this approved post as a gold-standard reference when it sounds like you and should guide future Shaka revisions.
+                          </p>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={handleMarkGoldStandard}
+                          disabled={savingGoldStandard || isGoldStandardCalibrationReference}
+                          className="inline-flex w-fit shrink-0 items-center justify-center gap-2 rounded-lg border border-amber-400/45 px-3 py-2 text-sm font-semibold text-amber-100 transition-colors hover:bg-amber-500/10 disabled:opacity-55"
+                        >
+                          {savingGoldStandard ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Star className="h-3.5 w-3.5" />}
+                          {isGoldStandardCalibrationReference ? 'Gold standard' : 'Mark gold standard'}
+                        </button>
+                      </div>
+                    </div>
+                  )}
+
                   {hasAgentPilotCalibrationGuidance ? (
                     <>
                       <div className="mt-3 grid gap-3 xl:grid-cols-[minmax(0,1.2fr)_minmax(280px,0.8fr)]">
@@ -2149,12 +2228,24 @@ function SocialContentDetailPage() {
                                 example.source_label.trim() === sourceLabel
                                 || example.source_label.trim() === reference.label
                               ))
+                              const isGoldStandardReference = reference.curation_status === 'gold_standard'
                               return (
-                                <div key={reference.id} className="rounded-lg border border-emerald-400/20 bg-background/35 p-3">
+                                <div
+                                  key={reference.id}
+                                  className={`rounded-lg border p-3 ${isGoldStandardReference ? 'border-amber-400/35 bg-amber-500/10' : 'border-emerald-400/20 bg-background/35'}`}
+                                >
                                   <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
                                     <div className="min-w-0">
-                                      <p className="text-sm font-semibold text-emerald-50">{reference.label}</p>
-                                      <p className="mt-1 text-xs uppercase tracking-[0.12em] text-emerald-100/70">
+                                      <div className="flex flex-wrap items-center gap-2">
+                                        <p className="text-sm font-semibold text-emerald-50">{reference.label}</p>
+                                        {isGoldStandardReference && (
+                                          <span className="inline-flex items-center gap-1 rounded-full border border-amber-300/35 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-amber-100">
+                                            <Star className="h-3 w-3" />
+                                            Gold
+                                          </span>
+                                        )}
+                                      </div>
+                                      <p className={`mt-1 text-xs uppercase tracking-[0.12em] ${isGoldStandardReference ? 'text-amber-100/75' : 'text-emerald-100/70'}`}>
                                         {reference.content_pillar}
                                       </p>
                                     </div>

--- a/app/api/admin/social-content/calibration-library/route.test.ts
+++ b/app/api/admin/social-content/calibration-library/route.test.ts
@@ -147,4 +147,61 @@ describe('GET /api/admin/social-content/calibration-library', () => {
     ]))
     expect(mocks.from).not.toHaveBeenCalled()
   })
+
+  it('prioritizes operator-marked gold-standard history references', async () => {
+    mocks.limit.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'social-history-regular',
+          platform: 'linkedin',
+          status: 'published',
+          post_text: 'A regular approved history reference.',
+          topic_extracted: { topic: 'Regular history' },
+          rag_context: {},
+          content_pillar: 'AI and product management',
+          target_platforms: ['linkedin'],
+          published_at: '2026-07-02T12:00:00.000Z',
+          updated_at: '2026-07-02T12:00:00.000Z',
+          created_at: '2026-07-02T12:00:00.000Z',
+        },
+        {
+          id: 'social-history-gold',
+          platform: 'linkedin',
+          status: 'published',
+          post_text: 'A marked gold-standard post that should guide Shaka revisions.',
+          topic_extracted: { topic: 'Gold standard history' },
+          rag_context: {
+            content_calibration: {
+              reference_curation: {
+                gold_standard: true,
+                reason: 'This sounded like Vambah and had strong conversation quality.',
+              },
+            },
+          },
+          content_pillar: 'AI and product management',
+          target_platforms: ['linkedin'],
+          published_at: '2026-06-20T12:00:00.000Z',
+          updated_at: '2026-06-20T12:00:00.000Z',
+          created_at: '2026-06-20T12:00:00.000Z',
+        },
+      ],
+      error: null,
+    })
+
+    const response = await GET(new NextRequest('http://localhost/api/admin/social-content/calibration-library?platform=linkedin'))
+
+    expect(response.status).toBe(200)
+    const json = await response.json()
+    expect(json.references[0]).toMatchObject({
+      id: 'portfolio-social-social-history-gold',
+      curation_status: 'gold_standard',
+      label: expect.stringContaining('Gold standard'),
+      engagement_signal: expect.stringContaining('Operator marked as a reusable gold-standard post.'),
+      why_it_worked: expect.stringContaining('strong conversation quality'),
+    })
+    expect(json.references[1]).toMatchObject({
+      id: 'portfolio-social-social-history-regular',
+      curation_status: 'portfolio_history',
+    })
+  })
 })

--- a/app/api/admin/social-content/calibration-library/route.ts
+++ b/app/api/admin/social-content/calibration-library/route.ts
@@ -37,6 +37,12 @@ export async function GET(request: NextRequest) {
       historyReferences = ((data ?? []) as SocialContentCalibrationHistoryRow[])
         .map(socialContentHistoryReferenceFromRow)
         .filter((reference): reference is NonNullable<typeof reference> => Boolean(reference))
+        .sort((left, right) => {
+          if (left.curation_status === right.curation_status) return 0
+          if (left.curation_status === 'gold_standard') return -1
+          if (right.curation_status === 'gold_standard') return 1
+          return 0
+        })
         .slice(0, historyLimit)
     }
     const references = [...historyReferences, ...staticReferences]

--- a/lib/social-content-calibration-library.ts
+++ b/lib/social-content-calibration-library.ts
@@ -5,6 +5,7 @@ export type SocialContentCalibrationReference = {
   platform: SocialContentCalibrationPlatform
   label: string
   source_type: 'voice_guide_reference' | 'operator_approved_pattern' | 'portfolio_content_history'
+  curation_status?: 'gold_standard' | 'portfolio_history' | 'static_reference'
   content_pillar: string
   post_excerpt: string
   engagement_signal: string
@@ -216,8 +217,12 @@ export function socialContentHistoryReferenceFromRow(
   ].filter(Boolean)
 
   const ragContext = asRecord(row.rag_context) ?? {}
+  const contentCalibration = asRecord(ragContext.content_calibration) ?? {}
+  const referenceCuration = asRecord(contentCalibration.reference_curation) ?? {}
+  const isGoldStandard = referenceCuration.gold_standard === true || contentCalibration.gold_standard === true
   const engagement = asRecord(ragContext.engagement) ?? {}
   const mappedTheme = asString(engagement.mapped_theme)
+  const curationReason = asString(referenceCuration.reason)
   const sourceProvenance = Array.isArray(ragContext.source_provenance_checklist)
     ? ragContext.source_provenance_checklist.filter((item): item is string => typeof item === 'string')
     : []
@@ -225,15 +230,23 @@ export function socialContentHistoryReferenceFromRow(
   return {
     id: `portfolio-social-${row.id}`,
     platform: 'linkedin',
-    label: labelParts.join(' · '),
+    label: [
+      isGoldStandard ? 'Gold standard' : labelParts[0],
+      ...labelParts.slice(1),
+    ].filter(Boolean).join(' · '),
     source_type: 'portfolio_content_history',
+    curation_status: isGoldStandard ? 'gold_standard' : 'portfolio_history',
     content_pillar: contentPillar,
     post_excerpt: truncateReferenceText(postText),
-    engagement_signal: buildHistoryEngagementSignal(row),
+    engagement_signal: [
+      isGoldStandard ? 'Operator marked as a reusable gold-standard post.' : '',
+      buildHistoryEngagementSignal(row),
+    ].filter(Boolean).join(' '),
     why_it_worked: [
       'This was already approved in Portfolio Social Content',
       status === 'published' ? 'and moved through the LinkedIn publish path' : '',
       mappedTheme ? `with mapped theme: ${mappedTheme}` : '',
+      curationReason,
     ].filter(Boolean).join(' '),
     claim_boundaries: [
       'Reuse as a voice and structure reference only.',


### PR DESCRIPTION
## Summary
- Adds an operator-controlled gold-standard marker for approved or published LinkedIn Agent Ops Social Content.
- Stores the curation flag in `rag_context.content_calibration.reference_curation`, with no schema migration.
- Prioritizes and labels gold-standard history references in the Social Content calibration library so future Shaka revisions can use them first.
- Includes a small Mobile App Foundry test typing repair needed for the current typecheck baseline.

## Validation
- `npm test -- app/api/admin/social-content/calibration-library/route.test.ts 'app/admin/social-content/[id]/page.test.tsx'`
- `npm run build:knowledge && npx tsc --noEmit --pretty false`
- `npm test -- app/api/admin/social-content/calibration-library/route.test.ts 'app/admin/social-content/[id]/page.test.tsx' app/admin/mobile-app-foundry/PacketPreviewWorkspace.test.tsx`
- `git diff --check`
- `npm run lint` (passed with existing `<img>` warnings in `app/client/dashboard/[token]/page.tsx` and `components/Navigation.test.tsx`)
- `npm run build` (passed with existing local env warning that outbound n8n is enabled and the same existing `<img>` warnings)
- Local visual smoke on `http://localhost:3026/admin/social-content/25d7efa3-62bc-4f5e-a191-1a131918593a?step=context`: verified Content calibration, Current post as benchmark, gold-standard control, and reusable calibration library. The smoke did not click the live marker button, so it made no live Social Content mutation.

## Integration Notes
- No database migration.
- No autonomous publish, schedule, external post, provider generation, or LinkedIn side effect.
- Uses the existing Social Content PUT route.
- Vercel – portfolio: pending PR check.
- Vercel – portfolio-staging: pending PR check.
