### PR TITLE
feat: add Agentic rollout campaign gates

### DIFF
--- a/app/admin/social-content/[id]/page.tsx
+++ b/app/admin/social-content/[id]/page.tsx
@@ -51,7 +51,12 @@ import {
   getVideoRedactionGate,
   type RedactionReviewDecision,
 } from '@/lib/social-production-assets'
-import { buildPlatformOrchestrationPlan, type PlatformOrchestrationStageState } from '@/lib/social-platform-orchestration'
+import {
+  buildPlatformOrchestrationPlan,
+  getPlatformSubmissionGate,
+  isPlatformSubmissionGateApproved,
+  type PlatformOrchestrationStageState,
+} from '@/lib/social-platform-orchestration'
 import type {
   SocialContentItem,
   SocialContentPublish,
@@ -1049,10 +1054,46 @@ function SocialContentDetailPage() {
           data.published ? 'Published successfully!' : 'No platforms published — check status below')
         fetchItem()
       } else {
-        showMsg('error', 'Publish request failed')
+        const data = await res.json().catch(() => null)
+        showMsg('error', data?.error || 'Publish request failed')
       }
     } catch {
       showMsg('error', 'Failed to trigger publish')
+    } finally {
+      setPublishing(false)
+    }
+  }
+
+  const handleApprovePlatformSubmission = async (platforms?: SocialPlatform[]) => {
+    if (videoPrivacyBlocked) {
+      showMsg('error', redactionGate.message || 'Video privacy review required before platform submission')
+      return
+    }
+    setPublishing(true)
+    try {
+      const session = await getCurrentSession()
+      if (!session) return
+
+      const res = await fetch(`/api/admin/social-content/${id}/platform-submission`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${session.access_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(platforms ? { platforms, submit_after_approval: true } : { submit_after_approval: true }),
+      })
+
+      const data = await res.json()
+      if (res.ok) {
+        if (data.item) setItem(data.item)
+        showMsg(data.submit_triggered ? 'success' : 'error',
+          data.submit_triggered ? 'Final gate approved. Platform submission started.' : 'Final gate approved, but submission did not start.')
+        fetchItem()
+      } else {
+        showMsg('error', data.error || 'Platform submission approval failed')
+      }
+    } catch {
+      showMsg('error', 'Failed to approve platform submission')
     } finally {
       setPublishing(false)
     }
@@ -1388,6 +1429,7 @@ function SocialContentDetailPage() {
   const usingDraftTopicFallback = topicBacklogItems.length === 0 && agentPilotTopicTriggerCandidates.length > 0
   const productionAssets = getProductionAssets(ragContext)
   const redactionGate = getVideoRedactionGate(productionAssets)
+  const platformSubmissionGate = getPlatformSubmissionGate(ragContext)
   const sectionGateReviews = asRecord(ragContext?.section_gate_reviews) ?? {}
   const getSectionGateReview = (gateKey: SectionGateKey) => asRecord(sectionGateReviews[gateKey])
   const getExplicitSectionGateState = (gateKey: SectionGateKey, fallback: GateState): GateState => {
@@ -1511,9 +1553,11 @@ function SocialContentDetailPage() {
         : 'pending'
   const linkedinDraftGateState: GateState = getExplicitSectionGateState('linkedin_draft', linkedinDraftBaseGateState)
   const canCreateLinkedInDraft = isDraftOnlyPilot && linkedinDraftBlockers.length === 0 && linkedinDraftGateState === 'approved'
+  const platformSubmissionTargets = isDraftOnlyPilot ? ['linkedin' as SocialPlatform] : targetPlatforms
+  const finalPlatformSubmissionApproved = isPlatformSubmissionGateApproved(ragContext, platformSubmissionTargets)
   const platformSubmissionPlan = buildPlatformOrchestrationPlan({
     item,
-    targetPlatforms: isDraftOnlyPilot ? ['linkedin'] : targetPlatforms,
+    targetPlatforms: platformSubmissionTargets,
     publishRecords: item.publishes ?? [],
     platformConfigs,
     copyApproved: item.status === 'approved' || item.status === 'scheduled' || item.status === 'published',
@@ -1522,6 +1566,7 @@ function SocialContentDetailPage() {
       : !videoPrivacyBlocked,
     redactionReady: !videoPrivacyBlocked,
     draftHandoffReady: isDraftOnlyPilot ? Boolean(linkedinDraftHandoff) : Boolean(item.publishes?.length),
+    finalSubmissionGateReady: finalPlatformSubmissionApproved,
   })
   const platformNextStages = platformSubmissionPlan.platforms
     .map((platformPlan) => platformPlan.stages.find((stage) => stage.state !== 'complete'))
@@ -3453,12 +3498,19 @@ function SocialContentDetailPage() {
 
           <div className="mt-4 rounded-lg border border-emerald-500/25 bg-emerald-500/10 px-3 py-2 text-xs leading-5 text-emerald-50/90">
             Until the final submission gate is approved, this path does not generate media, upload files, schedule externally, publish, or create public posts.
+            {platformSubmissionGate?.status === 'approved' ? (
+              <span className="mt-1 block text-emerald-100">
+                Final submission approved for {(platformSubmissionGate.platforms ?? platformSubmissionTargets).map((platform) => PLATFORMS.find((candidate) => candidate.value === platform)?.label ?? platform).join(', ')}.
+              </span>
+            ) : null}
           </div>
 
           <div className="mt-4 grid gap-3 lg:grid-cols-2">
             {platformSubmissionPlan.platforms.map((platformPlan) => {
               const automaticStage = platformPlan.stages.find((stage) => stage.key === 'automatic_submission')
+              const finalGateStage = platformPlan.stages.find((stage) => stage.key === 'final_submission_gate')
               const canSubmitPlatform = automaticStage?.state === 'available'
+              const canApproveFinalSubmission = finalGateStage?.state === 'pending'
               return (
                 <div key={platformPlan.platform} className="rounded-lg border border-gray-800 bg-gray-950/45 p-4">
                   <div className="flex items-start justify-between gap-3">
@@ -3499,7 +3551,17 @@ function SocialContentDetailPage() {
 
                   <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                     <p className="text-xs leading-5 text-gray-400">{platformPlan.nextAction}</p>
-                    {canSubmitPlatform ? (
+                    {canApproveFinalSubmission ? (
+                      <button
+                        type="button"
+                        onClick={() => handleApprovePlatformSubmission([platformPlan.platform])}
+                        disabled={publishing}
+                        className="inline-flex min-h-9 shrink-0 items-center justify-center gap-2 rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-xs font-semibold text-emerald-100 transition-colors hover:bg-emerald-500/20 disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        {publishing ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <CheckCircle2 className="h-3.5 w-3.5" />}
+                        Approve & submit
+                      </button>
+                    ) : canSubmitPlatform ? (
                       <button
                         type="button"
                         onClick={() => handleRetryPublish([platformPlan.platform])}

--- a/app/api/admin/social-content/[id]/approve/route.test.ts
+++ b/app/api/admin/social-content/[id]/approve/route.test.ts
@@ -241,7 +241,7 @@ describe('POST /api/admin/social-content/[id]/approve', () => {
 
     expect(response.status).toBe(200)
     const json = await response.json()
-    expect(json.publish_triggered).toBe(true)
+    expect(json.publish_triggered).toBe(false)
     expect(json.publishes).toEqual([
       { content_id: 'social-1', platform: 'linkedin', status: 'pending' },
       { content_id: 'social-1', platform: 'instagram', status: 'pending' },
@@ -250,17 +250,7 @@ describe('POST /api/admin/social-content/[id]/approve', () => {
       { content_id: 'social-1', platform: 'linkedin', status: 'pending' },
       { content_id: 'social-1', platform: 'instagram', status: 'pending' },
     ], { onConflict: 'content_id,platform' })
-    expect(fetchSpy).toHaveBeenCalledWith(
-      'http://localhost/api/admin/social-content/social-1/publish',
-      expect.objectContaining({
-        method: 'POST',
-        headers: {
-          Authorization: 'Bearer admin-token',
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ platforms: ['linkedin', 'instagram'] }),
-      }),
-    )
+    expect(fetchSpy).not.toHaveBeenCalled()
     expect(mocks.createAgentWorkItem).not.toHaveBeenCalled()
     fetchSpy.mockRestore()
   })

--- a/app/api/admin/social-content/[id]/approve/route.ts
+++ b/app/api/admin/social-content/[id]/approve/route.ts
@@ -228,24 +228,9 @@ export async function POST(
       console.error('Error creating publish records:', insertError)
     }
 
-    // If no scheduled_for → trigger immediate publish via internal API
-    let publishTriggered = false
-    if (!updated.scheduled_for) {
-      try {
-        const origin = new URL(request.url).origin
-        const publishRes = await fetch(`${origin}/api/admin/social-content/${id}/publish`, {
-          method: 'POST',
-          headers: {
-            Authorization: request.headers.get('authorization') || '',
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ platforms: targetPlatforms }),
-        })
-        publishTriggered = publishRes.ok
-      } catch (err) {
-        console.error('Failed to trigger publish:', err)
-      }
-    }
+    // Content approval prepares internal platform rows only. External submit now
+    // requires the explicit final platform-submission gate.
+    const publishTriggered = false
 
     // Load publish records for the response
     const { data: publishes } = await admin

--- a/app/api/admin/social-content/[id]/platform-submission/route.test.ts
+++ b/app/api/admin/social-content/[id]/platform-submission/route.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  from: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}))
+
+import { POST } from './route'
+
+function request(body?: unknown) {
+  return new NextRequest('http://localhost/api/admin/social-content/social-1/platform-submission', {
+    method: 'POST',
+    headers: {
+      authorization: 'Bearer admin-token',
+      'content-type': 'application/json',
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  })
+}
+
+function installSupabase({
+  item,
+  publishes,
+  configs,
+}: {
+  item: Record<string, unknown>
+  publishes: Array<Record<string, unknown>>
+  configs: Array<Record<string, unknown>>
+}) {
+  const queueSingle = vi.fn().mockResolvedValue({ data: item, error: null })
+  const queueSelectEq = vi.fn(() => ({ single: queueSingle }))
+  const queueSelect = vi.fn(() => ({ eq: queueSelectEq }))
+
+  const queueUpdateSingle = vi.fn().mockResolvedValue({
+    data: {
+      ...item,
+      rag_context: {
+        ...((item.rag_context as Record<string, unknown> | null) ?? {}),
+        platform_submission_gate: {
+          status: 'approved',
+          approved_by: 'admin-1',
+        },
+      },
+    },
+    error: null,
+  })
+  const queueUpdateSelect = vi.fn(() => ({ single: queueUpdateSingle }))
+  const queueUpdateEq = vi.fn(() => ({ select: queueUpdateSelect }))
+  const queueUpdate = vi.fn(() => ({ eq: queueUpdateEq }))
+
+  const publishUpsert = vi.fn().mockResolvedValue({ data: null, error: null })
+  const publishSelectEq = vi.fn().mockResolvedValue({ data: publishes, error: null })
+  const publishSelect = vi.fn(() => ({ eq: publishSelectEq }))
+
+  const configSelect = vi.fn().mockResolvedValue({ data: configs, error: null })
+
+  mocks.from.mockImplementation((table: string) => {
+    if (table === 'social_content_queue') return { select: queueSelect, update: queueUpdate }
+    if (table === 'social_content_publishes') return { upsert: publishUpsert, select: publishSelect }
+    if (table === 'social_content_config') return { select: configSelect }
+    return {}
+  })
+
+  return { publishUpsert, queueUpdate, queueUpdateSingle }
+}
+
+describe('POST /api/admin/social-content/[id]/platform-submission', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-1' }, isAdmin: true })
+    mocks.isAuthError.mockReturnValue(false)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('records final approval and triggers automatic submission through the publish route', async () => {
+    const { publishUpsert, queueUpdate } = installSupabase({
+      item: {
+        id: 'social-1',
+        status: 'approved',
+        platform: 'linkedin',
+        target_platforms: ['instagram', 'tiktok'],
+        post_text: 'Post text',
+        image_url: 'https://cdn.example.com/image.png',
+        video_url: 'https://cdn.example.com/video.mp4',
+        carousel_slide_urls: null,
+        rag_context: null,
+      },
+      publishes: [
+        { platform: 'instagram', status: 'pending', platform_post_url: null },
+        { platform: 'tiktok', status: 'pending', platform_post_url: null },
+      ],
+      configs: [
+        {
+          platform: 'instagram',
+          is_active: true,
+          credentials: { access_token: 'token', ig_user_id: 'ig-user-1' },
+          settings: {},
+        },
+        {
+          platform: 'tiktok',
+          is_active: true,
+          credentials: { access_token: 'token' },
+          settings: { creator_info_confirmed: true, source_url_approved: true },
+        },
+      ],
+    })
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ published: true }), { status: 200 }),
+    )
+
+    const response = await POST(request({ platforms: ['instagram', 'tiktok'] }), { params: { id: 'social-1' } })
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.submit_triggered).toBe(true)
+    expect(publishUpsert).toHaveBeenCalledWith([
+      { content_id: 'social-1', platform: 'instagram', status: 'pending' },
+      { content_id: 'social-1', platform: 'tiktok', status: 'pending' },
+    ], { onConflict: 'content_id,platform', ignoreDuplicates: true })
+    expect(queueUpdate).toHaveBeenCalledWith({
+      rag_context: expect.objectContaining({
+        platform_submission_gate: expect.objectContaining({
+          status: 'approved',
+          approved_by: 'admin-1',
+          platforms: ['instagram', 'tiktok'],
+        }),
+      }),
+    })
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'http://localhost/api/admin/social-content/social-1/publish',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ platforms: ['instagram', 'tiktok'] }),
+      }),
+    )
+  })
+
+  it('does not approve final submission when platform configuration is blocked', async () => {
+    const { queueUpdateSingle } = installSupabase({
+      item: {
+        id: 'social-1',
+        status: 'approved',
+        platform: 'tiktok',
+        target_platforms: ['tiktok'],
+        post_text: 'Post text',
+        image_url: null,
+        video_url: 'https://cdn.example.com/video.mp4',
+        carousel_slide_urls: null,
+        rag_context: null,
+      },
+      publishes: [
+        { platform: 'tiktok', status: 'pending', platform_post_url: null },
+      ],
+      configs: [],
+    })
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ published: true }), { status: 200 }),
+    )
+
+    const response = await POST(request({ platforms: ['tiktok'] }), { params: { id: 'social-1' } })
+
+    expect(response.status).toBe(409)
+    const body = await response.json()
+    expect(body.error).toBe('Platform submission is blocked.')
+    expect(body.blockers).toEqual(['TikTok: Connect and activate TikTok in Social Content settings.'])
+    expect(queueUpdateSingle).not.toHaveBeenCalled()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not approve final submission when required platform media is missing', async () => {
+    const { queueUpdateSingle } = installSupabase({
+      item: {
+        id: 'social-1',
+        status: 'approved',
+        platform: 'youtube',
+        target_platforms: ['youtube', 'tiktok'],
+        post_text: 'Post text',
+        image_url: null,
+        video_url: null,
+        carousel_slide_urls: null,
+        rag_context: null,
+      },
+      publishes: [
+        { platform: 'youtube', status: 'pending', platform_post_url: null },
+        { platform: 'tiktok', status: 'pending', platform_post_url: null },
+      ],
+      configs: [
+        { platform: 'youtube', is_active: true, credentials: { access_token: 'token' }, settings: {} },
+        {
+          platform: 'tiktok',
+          is_active: true,
+          credentials: { access_token: 'token' },
+          settings: { creator_info_confirmed: true, source_url_approved: true },
+        },
+      ],
+    })
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ published: true }), { status: 200 }),
+    )
+
+    const response = await POST(request({ platforms: ['youtube', 'tiktok'] }), { params: { id: 'social-1' } })
+
+    expect(response.status).toBe(409)
+    const body = await response.json()
+    expect(body.error).toBe('Platform submission is blocked.')
+    expect(body.blockers).toEqual([
+      'YouTube: YouTube needs a final video URL before submission.',
+      'TikTok: TikTok needs a final video URL before Direct Post submission.',
+    ])
+    expect(queueUpdateSingle).not.toHaveBeenCalled()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/admin/social-content/[id]/platform-submission/route.ts
+++ b/app/api/admin/social-content/[id]/platform-submission/route.ts
@@ -1,0 +1,203 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { supabaseAdmin } from '@/lib/supabase'
+import type { SocialPlatform } from '@/lib/social-content'
+import { getProductionAssets, getVideoRedactionGate } from '@/lib/social-production-assets'
+import { buildPlatformOrchestrationPlan } from '@/lib/social-platform-orchestration'
+
+export const dynamic = 'force-dynamic'
+
+const PLATFORM_LABELS: Record<SocialPlatform, string> = {
+  linkedin: 'LinkedIn',
+  youtube: 'YouTube',
+  instagram: 'Instagram',
+  facebook: 'Facebook',
+  tiktok: 'TikTok',
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {}
+}
+
+function normalizePlatforms(value: unknown): SocialPlatform[] {
+  if (!Array.isArray(value)) return []
+  return Array.from(new Set(value)).filter((platform): platform is SocialPlatform => (
+    typeof platform === 'string' && Boolean(PLATFORM_LABELS[platform as SocialPlatform])
+  ))
+}
+
+function targetPlatformsFor(item: Record<string, unknown>, requested: SocialPlatform[]) {
+  if (requested.length) return requested
+  const targets = normalizePlatforms(item.target_platforms)
+  if (targets.length) return targets
+  return normalizePlatforms([item.platform]).length ? normalizePlatforms([item.platform]) : ['linkedin' as SocialPlatform]
+}
+
+function gateBlockers(plan: ReturnType<typeof buildPlatformOrchestrationPlan>) {
+  return plan.platforms
+    .map((platformPlan) => {
+      const blockedStage = platformPlan.stages.find((stage) => stage.state === 'blocked')
+      return blockedStage ? `${platformPlan.label}: ${blockedStage.detail}` : null
+    })
+    .filter((blocker): blocker is string => Boolean(blocker))
+}
+
+/**
+ * POST /api/admin/social-content/[id]/platform-submission
+ * Records the final human platform-submission gate, then optionally triggers
+ * automatic submission through the existing publish dispatcher.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const authResult = await verifyAdmin(request)
+    if (isAuthError(authResult)) {
+      return NextResponse.json({ error: authResult.error }, { status: authResult.status })
+    }
+
+    const admin = supabaseAdmin
+    if (!admin) {
+      return NextResponse.json({ error: 'Server configuration error' }, { status: 500 })
+    }
+
+    const body = await request.json().catch(() => ({}))
+    const requestedPlatforms = normalizePlatforms(body.platforms)
+    const submitAfterApproval = body.submit_after_approval !== false
+    const decisionNote = typeof body.decision_note === 'string' ? body.decision_note.trim() : ''
+
+    const { id } = params
+    const { data: item, error: fetchError } = await admin
+      .from('social_content_queue')
+      .select('*')
+      .eq('id', id)
+      .single()
+
+    if (fetchError || !item) {
+      return NextResponse.json({ error: 'Content not found' }, { status: 404 })
+    }
+
+    const itemRecord = asRecord(item)
+    if (itemRecord.status !== 'approved' && itemRecord.status !== 'scheduled') {
+      return NextResponse.json(
+        { error: 'Content must be approved before platform submission.' },
+        { status: 400 },
+      )
+    }
+
+    const targetPlatforms = targetPlatformsFor(itemRecord, requestedPlatforms)
+    const productionAssets = getProductionAssets(itemRecord.rag_context)
+    const redactionGate = getVideoRedactionGate(productionAssets)
+    if (!redactionGate.ready) {
+      return NextResponse.json(
+        {
+          error: redactionGate.message || 'Video privacy review required before platform submission.',
+          unresolved_redaction_items: redactionGate.unresolvedItems.length,
+        },
+        { status: 409 },
+      )
+    }
+
+    const publishRows = targetPlatforms.map((platform) => ({
+      content_id: id,
+      platform,
+      status: 'pending' as const,
+    }))
+    const { error: upsertError } = await admin
+      .from('social_content_publishes')
+      .upsert(publishRows, { onConflict: 'content_id,platform', ignoreDuplicates: true })
+
+    if (upsertError) {
+      return NextResponse.json({ error: 'Failed to prepare platform publish rows.' }, { status: 500 })
+    }
+
+    const { data: publishes } = await admin
+      .from('social_content_publishes')
+      .select('*')
+      .eq('content_id', id)
+
+    const { data: platformConfigs } = await admin
+      .from('social_content_config')
+      .select('*')
+
+    const readinessPlan = buildPlatformOrchestrationPlan({
+      item: item as never,
+      targetPlatforms,
+      publishRecords: publishes ?? [],
+      platformConfigs: platformConfigs ?? [],
+      copyApproved: true,
+      productionReady: true,
+      redactionReady: true,
+      draftHandoffReady: true,
+      finalSubmissionGateReady: true,
+    })
+    const blockers = gateBlockers(readinessPlan)
+    if (blockers.length) {
+      return NextResponse.json(
+        {
+          error: 'Platform submission is blocked.',
+          blockers,
+          platform_submission_orchestration: readinessPlan,
+        },
+        { status: 409 },
+      )
+    }
+
+    const approvedAt = new Date().toISOString()
+    const updatedRagContext = {
+      ...asRecord(itemRecord.rag_context),
+      platform_submission_gate: {
+        status: 'approved',
+        approved_at: approvedAt,
+        approved_by: authResult.user.id,
+        platforms: targetPlatforms,
+        decision_note: decisionNote || null,
+        submit_after_approval: submitAfterApproval,
+        boundary: 'Final human approval for automatic platform submission. Provider generation, rendering, uploads, scheduling, and publishing remain limited to configured platform adapters.',
+      },
+    }
+
+    const { data: updatedItem, error: updateError } = await admin
+      .from('social_content_queue')
+      .update({ rag_context: updatedRagContext })
+      .eq('id', id)
+      .select('*')
+      .single()
+
+    if (updateError) {
+      return NextResponse.json({ error: 'Failed to record platform submission gate.' }, { status: 500 })
+    }
+
+    let publishResponse: unknown = null
+    let submitTriggered = false
+    if (submitAfterApproval) {
+      const origin = new URL(request.url).origin
+      const response = await fetch(`${origin}/api/admin/social-content/${id}/publish`, {
+        method: 'POST',
+        headers: {
+          Authorization: request.headers.get('authorization') || '',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ platforms: targetPlatforms }),
+      })
+      submitTriggered = response.ok
+      publishResponse = await response.json().catch(() => null)
+    }
+
+    return NextResponse.json({
+      success: true,
+      submit_triggered: submitTriggered,
+      item: updatedItem,
+      publishes: publishes ?? [],
+      platform_submission_gate: updatedRagContext.platform_submission_gate,
+      platform_submission_orchestration: readinessPlan,
+      publish_response: publishResponse,
+    })
+  } catch (error) {
+    console.error('Error in POST /api/admin/social-content/[id]/platform-submission:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/app/api/admin/social-content/[id]/publish/route.test.ts
+++ b/app/api/admin/social-content/[id]/publish/route.test.ts
@@ -114,9 +114,11 @@ describe('POST /api/admin/social-content/[id]/publish redaction gate', () => {
 function installPublishRouteSupabase({
   item,
   publishes,
+  configs,
 }: {
   item: Record<string, unknown>
   publishes: Array<Record<string, unknown>>
+  configs?: Array<Record<string, unknown>>
 }) {
   const queueSingle = vi.fn().mockResolvedValue({ data: item, error: null })
   const queueSelectEq = vi.fn(() => ({ single: queueSingle }))
@@ -129,14 +131,69 @@ function installPublishRouteSupabase({
   const publishUpdateSecondEq = vi.fn().mockResolvedValue({ data: null, error: null })
   const publishUpdateFirstEq = vi.fn(() => ({ eq: publishUpdateSecondEq }))
   const publishUpdate = vi.fn(() => ({ eq: publishUpdateFirstEq }))
+  const configSelect = vi.fn().mockResolvedValue({ data: configs ?? platformConfigsFor(publishes), error: null })
 
   mocks.from.mockImplementation((table: string) => {
     if (table === 'social_content_queue') return { select: queueSelect, update: queueUpdate }
     if (table === 'social_content_publishes') return { select: publishSelect, update: publishUpdate }
+    if (table === 'social_content_config') return { select: configSelect }
     return {}
   })
 
   return { queueUpdate }
+}
+
+function platformConfigsFor(publishes: Array<Record<string, unknown>>) {
+  return publishes.map((publish) => {
+    const platform = publish.platform
+    if (platform === 'linkedin') {
+      return {
+        platform,
+        is_active: true,
+        credentials: { access_token: 'token', author_urn: 'urn:li:person:123' },
+        settings: {},
+      }
+    }
+    if (platform === 'youtube') {
+      return { platform, is_active: true, credentials: { access_token: 'token' }, settings: {} }
+    }
+    if (platform === 'instagram') {
+      return {
+        platform,
+        is_active: true,
+        credentials: { access_token: 'token', ig_user_id: 'ig-user-1' },
+        settings: {},
+      }
+    }
+    if (platform === 'facebook') {
+      return {
+        platform,
+        is_active: true,
+        credentials: { page_access_token: 'token', page_id: 'page-1' },
+        settings: {},
+      }
+    }
+    if (platform === 'tiktok') {
+      return {
+        platform,
+        is_active: true,
+        credentials: { access_token: 'token' },
+        settings: { creator_info_confirmed: true, source_url_approved: true },
+      }
+    }
+    return { platform, is_active: false, credentials: {}, settings: {} }
+  })
+}
+
+function approvedGate(platforms: string[]) {
+  return {
+    platform_submission_gate: {
+      status: 'approved',
+      approved_at: '2026-07-01T00:00:00.000Z',
+      approved_by: 'admin-1',
+      platforms,
+    },
+  }
 }
 
 describe('POST /api/admin/social-content/[id]/publish platform dispatch', () => {
@@ -151,6 +208,33 @@ describe('POST /api/admin/social-content/[id]/publish platform dispatch', () => 
     vi.restoreAllMocks()
   })
 
+  it('blocks direct publish calls until the final platform-submission gate is approved', async () => {
+    installPublishRouteSupabase({
+      item: {
+        id: 'social-1',
+        status: 'approved',
+        post_text: 'Post text',
+        cta_text: null,
+        cta_url: null,
+        hashtags: [],
+        image_url: 'https://cdn.example.com/image.png',
+        video_url: null,
+        carousel_slide_urls: null,
+        rag_context: null,
+      },
+      publishes: [
+        { platform: 'linkedin', status: 'pending' },
+      ],
+    })
+
+    const response = await POST(request({ platforms: ['linkedin'] }), { params: { id: 'social-1' } })
+
+    expect(response.status).toBe(409)
+    const body = await response.json()
+    expect(body.error).toBe('Platform submission requires final approval and connected platform configuration.')
+    expect(mocks.publishToLinkedIn).not.toHaveBeenCalled()
+  })
+
   it('dispatches Instagram and TikTok publish modules from approved content', async () => {
     const { queueUpdate } = installPublishRouteSupabase({
       item: {
@@ -163,7 +247,7 @@ describe('POST /api/admin/social-content/[id]/publish platform dispatch', () => 
         image_url: 'https://cdn.example.com/image.png',
         video_url: 'https://cdn.example.com/video.mp4',
         carousel_slide_urls: null,
-        rag_context: null,
+        rag_context: approvedGate(['instagram', 'tiktok']),
       },
       publishes: [
         { platform: 'instagram', status: 'pending' },
@@ -214,7 +298,7 @@ describe('POST /api/admin/social-content/[id]/publish platform dispatch', () => 
         youtube_title: 'YouTube title',
         youtube_description: 'YouTube description',
         carousel_slide_urls: null,
-        rag_context: null,
+        rag_context: approvedGate(['youtube']),
       },
       publishes: [
         { platform: 'youtube', status: 'pending' },
@@ -243,6 +327,36 @@ describe('POST /api/admin/social-content/[id]/publish platform dispatch', () => 
     }))
   })
 
+  it('blocks final-approved YouTube publish when the final video URL is missing', async () => {
+    installPublishRouteSupabase({
+      item: {
+        id: 'social-1',
+        status: 'approved',
+        post_text: 'Post text',
+        cta_text: 'CTA',
+        cta_url: 'https://example.com',
+        hashtags: ['AI'],
+        image_url: null,
+        video_url: null,
+        youtube_title: 'YouTube title',
+        youtube_description: 'YouTube description',
+        carousel_slide_urls: null,
+        rag_context: approvedGate(['youtube']),
+      },
+      publishes: [
+        { platform: 'youtube', status: 'pending' },
+      ],
+    })
+
+    const response = await POST(request({ platforms: ['youtube'] }), { params: { id: 'social-1' } })
+
+    expect(response.status).toBe(409)
+    const body = await response.json()
+    expect(body.error).toBe('Platform submission requires final approval and connected platform configuration.')
+    expect(body.blockers).toEqual(['YouTube: YouTube needs a final video URL before submission.'])
+    expect(mocks.publishToYouTube).not.toHaveBeenCalled()
+  })
+
   it('dispatches Facebook publishing from approved content', async () => {
     const { queueUpdate } = installPublishRouteSupabase({
       item: {
@@ -257,7 +371,7 @@ describe('POST /api/admin/social-content/[id]/publish platform dispatch', () => 
         youtube_title: null,
         youtube_description: null,
         carousel_slide_urls: null,
-        rag_context: null,
+        rag_context: approvedGate(['facebook']),
       },
       publishes: [
         { platform: 'facebook', status: 'pending' },
@@ -296,7 +410,7 @@ describe('POST /api/admin/social-content/[id]/publish platform dispatch', () => 
         image_url: null,
         video_url: 'https://cdn.example.com/video.mp4',
         carousel_slide_urls: null,
-        rag_context: null,
+        rag_context: approvedGate(['tiktok']),
       },
       publishes: [
         { platform: 'tiktok', status: 'pending' },

--- a/app/api/admin/social-content/[id]/publish/route.ts
+++ b/app/api/admin/social-content/[id]/publish/route.ts
@@ -8,6 +8,7 @@ import { publishToFacebook } from '@/lib/publishing/facebook'
 import { publishToTikTok } from '@/lib/publishing/tiktok'
 import type { SocialPlatform } from '@/lib/social-content'
 import { getProductionAssets, getVideoRedactionGate } from '@/lib/social-production-assets'
+import { buildPlatformOrchestrationPlan, isPlatformSubmissionGateApproved } from '@/lib/social-platform-orchestration'
 
 export const dynamic = 'force-dynamic'
 
@@ -108,6 +109,45 @@ export async function POST(
           skipped: true,
         })),
       })
+    }
+
+    const publishPlatforms = pendingPublishes.map((p: { platform: string }) => p.platform as SocialPlatform)
+    const { data: platformConfigs } = await admin
+      .from('social_content_config')
+      .select('*')
+
+    const platformSubmissionPlan = buildPlatformOrchestrationPlan({
+      item,
+      targetPlatforms: publishPlatforms,
+      publishRecords: publishes,
+      platformConfigs: platformConfigs ?? [],
+      copyApproved: true,
+      productionReady: true,
+      redactionReady: true,
+      draftHandoffReady: true,
+      finalSubmissionGateReady: isPlatformSubmissionGateApproved(item.rag_context, publishPlatforms),
+    })
+    const blockedStages = platformSubmissionPlan.platforms
+      .map((platformPlan) => {
+        const blockedStage = platformPlan.stages.find((stage) => stage.state === 'blocked')
+        return blockedStage ? `${platformPlan.label}: ${blockedStage.detail}` : null
+      })
+      .filter((blocker): blocker is string => Boolean(blocker))
+    const unavailablePlatforms = platformSubmissionPlan.platforms.filter((platformPlan) => {
+      const automaticStage = platformPlan.stages.find((stage) => stage.key === 'automatic_submission')
+      return automaticStage?.state !== 'available'
+    })
+    if (blockedStages.length || unavailablePlatforms.length) {
+      return NextResponse.json(
+        {
+          error: 'Platform submission requires final approval and connected platform configuration.',
+          blockers: blockedStages.length
+            ? blockedStages
+            : unavailablePlatforms.map((platformPlan) => `${platformPlan.label}: ${platformPlan.nextAction}`),
+          platform_submission_orchestration: platformSubmissionPlan,
+        },
+        { status: 409 },
+      )
     }
 
     // Dispatch to platform-specific modules

--- a/docs/content-strategy/README.md
+++ b/docs/content-strategy/README.md
@@ -42,6 +42,7 @@ It does not publish, schedule, upload, generate provider media, send external me
 ## Lane artifacts
 
 - `accelerated-whisper-to-shout-campaign-plan.md`: 14-day campaign plan, calendar, topic backlog, source map, and review gates.
+- `agentic-book-rollout-campaign-plan.md`: 14-day Agentic book rollout campaign plan using Portfolio Agent Ops proof and multi-channel approval gates.
 - `social-draft-workflow.md`: draft creation workflow, approval checklist, review packet template, and publishing prep boundary.
 
 ## Current roadmap status

--- a/docs/content-strategy/agentic-book-rollout-campaign-plan.md
+++ b/docs/content-strategy/agentic-book-rollout-campaign-plan.md
@@ -1,0 +1,88 @@
+# Agentic book rollout whisper_to_shout campaign plan
+
+Status: review-ready campaign seed
+Template: `whisper_to_shout`
+Window: 14 days
+Primary surface: Portfolio Content Intelligence calendar
+
+## Goal
+
+Create a campaign around the Agentic book rollout that proves the central argument before asking anyone to care about the book:
+
+AI agents are moving into real work faster than most teams can explain who owns the output, what evidence it used, what authority it had, and which human approved the handoff.
+
+The campaign should make the operating layer visible. It should use Portfolio as the receipt: source packets, calendar milestones, challenger review, script review, asset review, and platform submission gates.
+
+## Source Packet
+
+Use these existing sources before generating new drafts:
+
+| Source | Use |
+| --- | --- |
+| `docs/agentic-value-communications-plan.md` | Campaign architecture, channel map, challenger loop, first production backlog. |
+| `docs/agentic-content-research-briefs/phase-2-research-dossier.md` | Research-backed claims and proof boundaries. |
+| `docs/agentic-content-linkedin-drafts/wave-1-drafts.md` | First-pass LinkedIn material to revise, not duplicate. |
+| `docs/agentic-content-video-scripts/wave-1-youtube-scripts.md` | YouTube and short-form script source material. |
+| `docs/agentic-content-review-packets/p0-challenger-review-packets.md` | Human-review-ready P0 packet references. |
+| `docs/agentic-content-review-packets/p1-challenger-review-packets.md` | Human-review-ready short-form packet references. |
+| `docs/agentic-os-client-advisory-explainer.md` | Client-safe advisory positioning. |
+
+Private meetings, Chronicle notes, raw chats, credentials, account IDs, and client records stay out of public drafts.
+
+## Campaign Arc
+
+| Day | Phase | Core Message | Primary Calendar Item |
+| --- | --- | --- | --- |
+| 1 | Tease | Anyone can launch an agent now. The harder question is who is responsible when it acts. | LinkedIn flagship post plus Short cutdown. |
+| 4 | Teach | The agent is not the operating system. The harness is. | Framework post plus Short explaining the source -> challenger -> approval path. |
+| 9 | Proof | The receipt is the path the work traveled. | Portfolio proof post with screenshot carousel and b-roll capture list. |
+| 13 | Offer | Follow the Agentic rollout for the field guide behind governed AI operations. | Launch invitation post plus Short/Reel/TikTok handoff. |
+
+## Channel Lanes
+
+Each milestone should create review packets for:
+
+| Channel | Needed Inputs |
+| --- | --- |
+| LinkedIn | Post text, CTA, CTA URL, hashtags, references, visual recommendation. |
+| YouTube Shorts | Hook, first 30 seconds, 45-second script, storyboard, b-roll hints, on-screen text, caption. |
+| Instagram Reels | Hook, script, caption, safe-area notes, b-roll assets. |
+| TikTok | Hook, script, caption, audio rights, safe-area notes. |
+| Thumbnail | Pattern explanation, short text, proof-screen direction, 2-3 variants. |
+
+## Approval Path
+
+The Portfolio path should stay explicit:
+
+1. Shaka proposes the milestone from the campaign calendar.
+2. Source packet and channel drafts are attached to the central backlog work item.
+3. Amina performs challenger review before human review.
+4. Vambah approves or rejects each channel lane with a decision note.
+5. Approved lanes move to asset production.
+6. Asset production moves through privacy/redaction review.
+7. Platform draft handoff is authorized.
+8. Final platform submission is approved separately.
+9. Only then can automatic platform submission run through connected integrations.
+
+## Seeded Fixture
+
+Use Admin Testing demo seed key:
+
+`agentic_book_rollout_campaign_fixture`
+
+Expected fixture output:
+
+- 1 `attraction_campaigns` row.
+- 1 campaign goal in `agent_work_items`.
+- 4 phase work items using `source_type='social_topic_trigger'`.
+- 1 public-safe research packet.
+- 8 calendar items: 4 primary LinkedIn milestones and 4 YouTube Shorts companion milestones.
+- Draft packets for LinkedIn, YouTube Shorts, Instagram Reels, TikTok, and Thumbnail stored in work item metadata.
+
+No provider calls, rendering, uploads, external schedules, platform posts, or publishing should run from the seed.
+
+## Next Production Step
+
+After seeding, open Content Intelligence and filter the calendar to `Agentic Book Rollout Whisper-to-Shout Campaign`. Start with Day 1 Tease. The first approval target should be the LinkedIn post and short-form script packet for:
+
+`Anyone can launch an agent now`

--- a/lib/admin-demo-seed.ts
+++ b/lib/admin-demo-seed.ts
@@ -17,6 +17,7 @@ export const DEMO_SEED_KEYS = [
   'social_content_calendar_fixture',
   'social_channel_review_fixture',
   'accelerated_workshop_campaign_fixture',
+  'agentic_book_rollout_campaign_fixture',
 ] as const
 
 export type DemoSeedKey = (typeof DEMO_SEED_KEYS)[number]
@@ -34,6 +35,9 @@ export const SOCIAL_CHANNEL_REVIEW_FIXTURE_IDEMPOTENCY_KEY = 'demo:social-channe
 export const ACCELERATED_WORKSHOP_CAMPAIGN_FIXTURE_KEY = 'accelerated_workshop_campaign_fixture'
 export const ACCELERATED_WORKSHOP_CAMPAIGN_FIXTURE_SLUG = 'accelerated-workshop-whisper-to-shout'
 export const ACCELERATED_WORKSHOP_CAMPAIGN_IDEMPOTENCY_PREFIX = 'demo:accelerated-workshop-campaign'
+export const AGENTIC_BOOK_ROLLOUT_CAMPAIGN_FIXTURE_KEY = 'agentic_book_rollout_campaign_fixture'
+export const AGENTIC_BOOK_ROLLOUT_CAMPAIGN_FIXTURE_SLUG = 'agentic-book-rollout-whisper-to-shout'
+export const AGENTIC_BOOK_ROLLOUT_CAMPAIGN_IDEMPOTENCY_PREFIX = 'demo:agentic-book-rollout-campaign'
 
 const BUSINESS_CHALLENGES = {
   primary_challenges: [
@@ -212,6 +216,41 @@ async function removeAcceleratedWorkshopCampaignFixture(supabase: SupabaseClient
     .eq('slug', ACCELERATED_WORKSHOP_CAMPAIGN_FIXTURE_SLUG)
 }
 
+async function removeAgenticBookRolloutCampaignFixture(supabase: SupabaseClient): Promise<void> {
+  const { data: campaign } = await supabase
+    .from('attraction_campaigns')
+    .select('id')
+    .eq('slug', AGENTIC_BOOK_ROLLOUT_CAMPAIGN_FIXTURE_SLUG)
+    .maybeSingle()
+
+  await supabase
+    .from('social_content_calendar_items')
+    .delete()
+    .contains('metadata', { demo_seed_key: AGENTIC_BOOK_ROLLOUT_CAMPAIGN_FIXTURE_KEY })
+
+  await supabase
+    .from('agent_work_items')
+    .delete()
+    .like('idempotency_key', `${AGENTIC_BOOK_ROLLOUT_CAMPAIGN_IDEMPOTENCY_PREFIX}:%`)
+
+  await supabase
+    .from('social_content_research_packets')
+    .delete()
+    .contains('actor_metadata', { demo_seed_key: AGENTIC_BOOK_ROLLOUT_CAMPAIGN_FIXTURE_KEY })
+
+  if (campaign?.id != null) {
+    await supabase
+      .from('social_content_calendar_items')
+      .delete()
+      .eq('campaign_id', campaign.id)
+  }
+
+  await supabase
+    .from('attraction_campaigns')
+    .delete()
+    .eq('slug', AGENTIC_BOOK_ROLLOUT_CAMPAIGN_FIXTURE_SLUG)
+}
+
 const ACCELERATED_WORKSHOP_PHASES = [
   {
     phase: 'tease',
@@ -272,6 +311,69 @@ const ACCELERATED_WORKSHOP_PHASES = [
     linkedinCta:
       'If this is the kind of operating layer your team needs, join the Accelerated Workshop interest path or book a discovery call.',
     thumbnailText: 'BUILD THE OPERATING LAYER',
+  },
+] as const
+
+const AGENTIC_BOOK_ROLLOUT_PHASES = [
+  {
+    phase: 'tease',
+    titlePrefix: 'Tease',
+    day: 1,
+    insightTitle: 'Anyone can launch an agent now',
+    triggeringEvent:
+      'The Agentic rollout work exposed the public-facing tension: agent demos are easy to get excited about, but the operating questions show up the moment an agent needs authority.',
+    contentAngle:
+      'The launch should start with the pain: AI agents are moving into real workflows before teams have receipts, scopes, owners, and approval paths.',
+    suggestedHook:
+      'Anyone can launch an agent now. The harder question is who is responsible when it acts.',
+    linkedinCta:
+      'Where have you seen an AI demo move faster than the operating system around it?',
+    thumbnailText: 'AGENTS NEED RECEIPTS',
+  },
+  {
+    phase: 'teach',
+    titlePrefix: 'Teach',
+    day: 4,
+    insightTitle: 'The harness matters more than the agent',
+    triggeringEvent:
+      'The Agentic source plan frames the production harness as source inventory, artifact specification, constrained creation, challenger review, repair, and human approval.',
+    contentAngle:
+      'The audience needs the core model before the bigger announcement: agents become useful when the work is bounded, sourced, challenged, and reviewed.',
+    suggestedHook:
+      'The agent is not the operating system. The harness is.',
+    linkedinCta:
+      'What would you put in the harness before giving an agent more authority?',
+    thumbnailText: 'BUILD THE HARNESS',
+  },
+  {
+    phase: 'proof',
+    titlePrefix: 'Proof',
+    day: 9,
+    insightTitle: 'The Portfolio workflow is the rollout receipt',
+    triggeringEvent:
+      'Portfolio already has named agents, Agent Ops approvals, work items, platform gates, content intelligence, and review packets that can show the operating layer in motion.',
+    contentAngle:
+      'The proof milestone should show the actual system: review queues, source packets, calendar milestones, challenger packets, and gated platform submission.',
+    suggestedHook:
+      'The receipt is not the content. The receipt is the path the content traveled.',
+    linkedinCta:
+      'What proof would make you trust an agentic workflow before it touched a customer?',
+    thumbnailText: 'SHOW THE PATH',
+  },
+  {
+    phase: 'offer',
+    titlePrefix: 'Offer',
+    day: 13,
+    insightTitle: 'Follow the Agentic book rollout',
+    triggeringEvent:
+      'The Agentic book rollout can become the public container for the system Vambah is building: a practical field guide for governed AI work, not another autonomy hype cycle.',
+    contentAngle:
+      'The shout moment invites people into the Agentic rollout: follow the series, review the proof, and book a discovery path if they need governed Agent Ops in their own organization.',
+    suggestedHook:
+      'The next wave of AI work will be judged by its receipts.',
+    linkedinCta:
+      'If you want the Agentic rollout notes as they become public, follow along or reach out through AmaduTown.',
+    thumbnailText: 'THE AGENTIC ROLLOUT',
   },
 ] as const
 
@@ -488,6 +590,246 @@ function acceleratedWorkshopInsightMetadata(input: {
         label: 'Thumbnail',
         decision_note: null,
         draft_packet: acceleratedWorkshopThumbnailPacket({
+          phase: input.phase.phase,
+          generatedAt: input.generatedAt,
+          insightTitle: input.phase.insightTitle,
+          contentAngle: input.phase.contentAngle,
+          thumbnailText: input.phase.thumbnailText,
+        }),
+        review_requested_at: input.generatedAt,
+        updated_at: input.generatedAt,
+        required_inputs: ['pattern explanation', 'short thumbnail text', '2-3 variants'],
+      },
+    },
+    insight,
+    side_effects: {
+      provider_generation: false,
+      upload: false,
+      publish: false,
+      schedule: false,
+      external_post: false,
+    },
+  }
+}
+
+function agenticBookRolloutThumbnailPacket(input: {
+  phase: string
+  generatedAt: string
+  insightTitle: string
+  contentAngle: string
+  thumbnailText: string
+}) {
+  return {
+    channel: 'thumbnail',
+    generated_at: input.generatedAt,
+    approval_status: 'in_review',
+    shared_source: {
+      insight_title: input.insightTitle,
+      triggering_event: `Agentic book rollout ${input.phase} phase`,
+      content_angle: input.contentAngle,
+      evidence_summary:
+        'Uses the shared Agentic rollout source packet, Portfolio Agent Ops proof, and public-safe communications plan.',
+    },
+    source_insight_title: input.insightTitle,
+    source_use_boundary:
+      'Thumbnail concepts are generated for human review only. Public creator and source patterns are structure only, not artwork to copy.',
+    fields: {
+      source_thumbnail_reference: 'Use approved public creator research patterns and owned Portfolio proof screenshots as structure only.',
+      pattern_explanation:
+        'Short accountability promise, one visible operating-system proof cue, and no exaggerated autonomy claim.',
+      amadutown_adaptation_direction:
+        'Use AmaduTown navy/gold/white styling, Agent Ops proof screens, and Vambah as the practitioner explaining the operating layer.',
+      short_thumbnail_text: input.thumbnailText,
+      face_photo_avatar_choice: 'Vambah face/photo, HeyGen avatar still, or clean Agent Ops proof-screen frame.',
+      brand_colors_style: 'AmaduTown navy, radiant gold, white, restrained proof-console accents.',
+      variants: [
+        `${input.thumbnailText} over an Agent Ops approval-gate screenshot.`,
+        `Vambah beside a visible source packet and review path with ${input.phase.toUpperCase()} phase label.`,
+        `Minimal AmaduTown shield plus one proof-screen receipt and a short agent accountability line.`,
+      ],
+      approval_state: 'in_review',
+    },
+    source_research_patterns: [],
+    side_effects: {
+      provider_generation: false,
+      upload: false,
+      publish: false,
+      schedule: false,
+      external_post: false,
+    },
+  }
+}
+
+function agenticBookRolloutInsightMetadata(input: {
+  packetId: string
+  phase: typeof AGENTIC_BOOK_ROLLOUT_PHASES[number]
+  generatedAt: string
+}) {
+  const approvedResearchPattern = {
+    packet_id: input.packetId,
+    source_url: 'local:docs/agentic-value-communications-plan.md',
+    platform: 'other',
+    creator_name: 'AmaduTown',
+    title: 'Agentic book rollout communications plan',
+    outlier_score: 0,
+    pattern_status: 'usable_framework',
+    pattern_packet: {
+      hook_structure:
+        'Open with the agent accountability tension, then show the operating layer that makes agent work reviewable.',
+      promise_value:
+        'Help operators understand agentic AI as governed work, not model novelty.',
+      thumbnail_pattern:
+        'Pair a short accountability line with visible proof from the review, source, or approval surface.',
+      source_use_boundary:
+        'Use owned Portfolio proof, public-safe research summaries, and approved review packets only. Do not expose raw private chats, Chronicle notes, client material, credentials, or hidden admin data.',
+    },
+  }
+  const insight = {
+    title: input.phase.insightTitle,
+    triggering_event: input.phase.triggeringEvent,
+    source_type: 'portfolio_work',
+    source_label: 'Agentic book rollout campaign',
+    source_ids: [
+      AGENTIC_BOOK_ROLLOUT_CAMPAIGN_FIXTURE_KEY,
+      'docs/agentic-value-communications-plan.md',
+      'docs/agentic-content-research-briefs/phase-2-research-dossier.md',
+    ],
+    why_vambah_can_speak:
+      'Vambah is building the Portfolio Agent Ops operating layer directly: named agents, work items, approvals, source packets, challenger review, cost checks, and platform submission gates.',
+    brand_goal:
+      'Position the Agentic book rollout as a practical field guide for governed AI operations and responsible agent adoption.',
+    content_angle: input.phase.contentAngle,
+    suggested_hook: input.phase.suggestedHook,
+    audience:
+      'Product leaders, founders, operators, advisors, and teams trying to move from agent demos to governed execution.',
+    sensitivity: 'public_safe',
+    evidence_summary:
+      'Evidence comes from the Agentic communications plan, research dossier, Portfolio Agent Ops workflow, review packets, content calendar, and gated multi-channel platform submission path.',
+    claim_boundaries: [
+      'Do not imply the Agentic book is publicly launched or available for purchase unless a separate launch gate approves it.',
+      'Do not imply autonomous publishing, rendering, uploads, scheduling, or provider generation is active from this campaign seed.',
+      'Use Portfolio proof surfaces only after privacy review; redact private admin, Chronicle, meeting, client, account, and credential detail.',
+      'Treat public creator or outlier research as reusable structure only, not copy.',
+    ],
+    approved_research_patterns: [approvedResearchPattern],
+  }
+  const drafts = buildLinkedInYoutubeReviewDrafts({ insight, generatedAt: input.generatedAt })
+
+  drafts.linkedin.fields = {
+    ...drafts.linkedin.fields,
+    cta: input.phase.linkedinCta,
+    cta_url: 'https://amadutown.com',
+    visual_mode: input.phase.phase === 'proof'
+      ? 'app_screenshot_carousel'
+      : 'framework_illustration_or_carousel_review',
+    screenshot_routes: [
+      '/admin/agents/content-intelligence',
+      '/admin/content/video-generation',
+      '/admin/social-content',
+      '/admin/agents/runs',
+    ],
+  }
+  drafts.youtube_shorts.fields = {
+    ...drafts.youtube_shorts.fields,
+    target_duration_seconds: 45,
+    caption: `${input.phase.contentAngle} Built for the Agentic book rollout campaign.`,
+    b_roll_hints: [
+      'Agent Ops review queue',
+      'Content Intelligence campaign calendar',
+      'Video Generation script review workspace',
+      'Social Content platform submission path',
+      'Agentic source packet or research dossier',
+    ],
+    on_screen_text: [
+      input.phase.thumbnailText,
+      'Receipts before authority.',
+      'Approval before action.',
+    ],
+  }
+  drafts.instagram_reels.fields = {
+    ...drafts.instagram_reels.fields,
+    caption: `${input.phase.contentAngle} Built for the Agentic book rollout campaign.`,
+    b_roll_assets: [
+      'Agent Ops review queue',
+      'Content Intelligence campaign calendar',
+      'Video Generation script review workspace',
+      'Social Content platform submission path',
+      'Agentic source packet or research dossier',
+    ],
+    safe_area_notes: [
+      'Keep captions and CTA clear of top and bottom app chrome.',
+      'Frame Portfolio proof screens in the vertical center.',
+      'Redact private admin, client, Chronicle, account, or meeting-derived detail before export.',
+    ],
+  }
+  drafts.tiktok.fields = {
+    ...drafts.tiktok.fields,
+    caption: `${input.phase.suggestedHook} Built for the Agentic book rollout campaign.`,
+    b_roll_assets: [
+      'Agent Ops review queue',
+      'Content Intelligence campaign calendar',
+      'Video Generation script review workspace',
+      'Social Content platform submission path',
+      'Agentic source packet or research dossier',
+    ],
+    audio_rights: 'Use original narration, approved provider voiceover, or platform-safe audio only.',
+  }
+
+  return {
+    social_topic_trigger: true,
+    insight_version: 'agentic_book_rollout_campaign_v1',
+    demo_seed_key: AGENTIC_BOOK_ROLLOUT_CAMPAIGN_FIXTURE_KEY,
+    fixture_version: 1,
+    fixture_purpose: 'agentic_book_rollout_whisper_to_shout_review_ready_campaign',
+    campaign_target: 'Agentic book rollout',
+    campaign_window_days: 14,
+    campaign_template_key: 'whisper_to_shout',
+    campaign_language: 'Tease/Wispr/Shout overlay; stored phases remain tease/teach/proof/offer.',
+    conversion_path: 'Agentic rollout interest, then Agent Ops advisory, AI Quick Win, or discovery call.',
+    research_packet_ids: [input.packetId],
+    suggested_research_packet_ids: [input.packetId],
+    channel_lanes: {
+      linkedin: {
+        status: 'in_review',
+        label: 'LinkedIn',
+        decision_note: null,
+        draft_packet: drafts.linkedin,
+        review_requested_at: input.generatedAt,
+        updated_at: input.generatedAt,
+        required_inputs: ['post text', 'CTA', 'CTA URL', 'hashtags', 'references'],
+      },
+      youtube_shorts: {
+        status: 'in_review',
+        label: 'YouTube Shorts',
+        decision_note: null,
+        draft_packet: drafts.youtube_shorts,
+        review_requested_at: input.generatedAt,
+        updated_at: input.generatedAt,
+        required_inputs: ['hook', 'first 30 seconds', 'script', 'storyboard scenes', 'b-roll hints'],
+      },
+      instagram_reels: {
+        status: 'in_review',
+        label: 'Instagram Reels',
+        decision_note: null,
+        draft_packet: drafts.instagram_reels,
+        review_requested_at: input.generatedAt,
+        updated_at: input.generatedAt,
+        required_inputs: ['hook', 'script', 'caption', 'safe-area notes'],
+      },
+      tiktok: {
+        status: 'in_review',
+        label: 'TikTok',
+        decision_note: null,
+        draft_packet: drafts.tiktok,
+        review_requested_at: input.generatedAt,
+        updated_at: input.generatedAt,
+        required_inputs: ['hook', 'script', 'caption', 'audio rights', 'safe-area notes'],
+      },
+      thumbnail: {
+        status: 'in_review',
+        label: 'Thumbnail',
+        decision_note: null,
+        draft_packet: agenticBookRolloutThumbnailPacket({
           phase: input.phase.phase,
           generatedAt: input.generatedAt,
           insightTitle: input.phase.insightTitle,
@@ -1210,6 +1552,286 @@ export async function runDemoSeed(
           ok: true,
           key,
           detail: `Accelerated Workshop campaign ${campaign.id} with campaign goal ${campaignGoal.id}, ${calendarRows.length} calendar items, ${workItems.length} insight work items, and research packet ${packet.id}`,
+        }
+      }
+
+      case 'agentic_book_rollout_campaign_fixture': {
+        await removeAgenticBookRolloutCampaignFixture(supabase)
+
+        const generatedAt = new Date().toISOString()
+        const startsAt = addDaysAtHourISO(1, 9)
+        const endsAt = addDaysAtHourISO(14, 17)
+
+        const { data: campaign, error: campaignError } = await supabase
+          .from('attraction_campaigns')
+          .insert({
+            name: 'Agentic Book Rollout Whisper-to-Shout Campaign',
+            slug: AGENTIC_BOOK_ROLLOUT_CAMPAIGN_FIXTURE_SLUG,
+            description:
+              'A 14-day review-ready campaign for the Agentic book rollout, using Portfolio Agent Ops proof, source packets, challenger review, and gated platform submission.',
+            campaign_type: 'free_challenge',
+            status: 'draft',
+            starts_at: startsAt,
+            ends_at: endsAt,
+            completion_window_days: 14,
+            min_purchase_amount: 0,
+            payout_type: 'credit',
+            payout_amount_type: 'fixed',
+            payout_amount_value: 0,
+            rollover_bonus_multiplier: 1,
+            promo_copy:
+              'Follow the Agentic rollout: a practical field guide for governed AI operations, built from the Portfolio Agent Ops system.',
+          })
+          .select('id, name, slug, starts_at, ends_at')
+          .single()
+
+        if (campaignError || !campaign) {
+          return {
+            ok: false,
+            error: `attraction_campaigns: ${campaignError?.message ?? 'no row'}`,
+          }
+        }
+
+        const { data: packet, error: packetError } = await supabase
+          .from('social_content_research_packets')
+          .insert({
+            source_url: 'local:docs/agentic-value-communications-plan.md',
+            platform: 'other',
+            creator_name: 'AmaduTown',
+            creator_handle: '@amadutown',
+            title: 'Agentic book rollout communications packet',
+            caption:
+              'Public-safe campaign evidence packet for the Agentic book rollout. It reuses the Agentic communications plan, research dossier, review packets, and Portfolio Agent Ops proof surfaces.',
+            thumbnail_url: null,
+            hook_transcript:
+              'Anyone can launch an agent now. The harder question is whether the team can show the source, scope, owner, challenger pass, and human approval before the agent acts.',
+            metrics: {
+              views: null,
+              likes: null,
+              comments: null,
+              shares: null,
+              follower_count: null,
+              retrieved_at: generatedAt,
+            },
+            actor_metadata: {
+              provider: 'free_recorded_evidence',
+              retrieval_method: 'demo_seed',
+              demo_seed_key: AGENTIC_BOOK_ROLLOUT_CAMPAIGN_FIXTURE_KEY,
+              cost_usd: 0,
+              external_execution_enabled: false,
+              source_policy: 'public_safe_owned_positioning',
+              source_paths: [
+                'docs/agentic-value-communications-plan.md',
+                'docs/agentic-content-research-briefs/phase-2-research-dossier.md',
+                'docs/agentic-content-review-packets/p0-challenger-review-packets.md',
+                'docs/agentic-content-review-packets/p1-challenger-review-packets.md',
+              ],
+            },
+            outlier_score: 0,
+            score_breakdown: {
+              strategic_fit: 1,
+              source_type: 'owned_campaign_evidence',
+            },
+            pattern_packet: {
+              hook_structure:
+                'Open with the agent accountability tension, then point to a concrete operating layer.',
+              tension_or_missed_opportunity:
+                'Teams are excited about agent demos before they can explain source boundaries, review gates, ownership, and authority.',
+              promise_value:
+                'The Agentic rollout shows how AI agent work becomes safer when the operating path is visible.',
+              proof_style:
+                'Use owned proof surfaces: Agent Ops approvals, Content Intelligence calendar, Video Generation review workspace, Social Content platform submission gates, and source packets.',
+              title_pattern: 'From agent demo to governed operating system',
+              thumbnail_pattern:
+                'Short accountability text plus a visible proof-screen receipt from Portfolio.',
+              pacing_visual_framing:
+                'Start with a human risk, show the operating harness, cut to proof screens, close with the rollout invitation.',
+              cta_style:
+                'Invite people to follow the Agentic rollout or talk through how governed Agent Ops would apply to their own team.',
+              source_use_boundary:
+                'Use owned proof and public-safe summaries only. Do not expose private meetings, raw Chronicle notes, client records, secrets, or raw AI chat exports.',
+            },
+            pattern_status: 'usable_framework',
+            status: 'review_ready',
+            privacy_notes:
+              'Owned public-safe campaign packet. No provider calls, uploads, publishing, schedules, private meeting excerpts, Chronicle notes, client records, credentials, or raw AI chat exports.',
+            retrieved_at: generatedAt,
+          })
+          .select('id')
+          .single()
+
+        if (packetError || !packet) {
+          return {
+            ok: false,
+            error: `social_content_research_packets: ${packetError?.message ?? 'no row'}`,
+          }
+        }
+
+        const { data: campaignGoal, error: campaignGoalError } = await supabase
+          .from('agent_work_items')
+          .insert({
+            title: 'Launch Agentic book rollout campaign',
+            objective:
+              'Turn the Agentic book rollout into a complete 14-day whisper_to_shout campaign with shared source evidence, campaign calendar items, and human-review-ready LinkedIn, YouTube Shorts, Instagram Reels, TikTok, and Thumbnail draft packets.',
+            status: 'proposed',
+            priority: 'high',
+            owner_agent_key: 'chief-of-staff',
+            owner_runtime: 'manual',
+            source_type: 'campaign_goal',
+            source_id: AGENTIC_BOOK_ROLLOUT_CAMPAIGN_FIXTURE_KEY,
+            source_label: 'Agentic book rollout whisper_to_shout campaign goal',
+            expected_files: [],
+            touched_files: [],
+            overlap_group: 'social-content-intelligence',
+            dependency_ids: [],
+            idempotency_key: `${AGENTIC_BOOK_ROLLOUT_CAMPAIGN_IDEMPOTENCY_PREFIX}:goal`,
+            metadata: {
+              social_campaign_goal: true,
+              demo_seed_key: AGENTIC_BOOK_ROLLOUT_CAMPAIGN_FIXTURE_KEY,
+              campaign_id: campaign.id,
+              campaign_target: 'Agentic book rollout',
+              campaign_template_key: 'whisper_to_shout',
+              campaign_window_days: 14,
+              conversion_path: 'Agentic rollout interest, then Agent Ops advisory, AI Quick Win, or discovery call.',
+              phase_work_item_count: AGENTIC_BOOK_ROLLOUT_PHASES.length,
+              source_paths: [
+                'docs/agentic-value-communications-plan.md',
+                'docs/agentic-content-research-briefs/phase-2-research-dossier.md',
+              ],
+              side_effects: {
+                provider_generation: false,
+                upload: false,
+                publish: false,
+                schedule: false,
+                external_post: false,
+              },
+            },
+          })
+          .select('id')
+          .single()
+
+        if (campaignGoalError || !campaignGoal) {
+          return {
+            ok: false,
+            error: `agent_work_items goal: ${campaignGoalError?.message ?? 'no row'}`,
+          }
+        }
+
+        const workItemRows = AGENTIC_BOOK_ROLLOUT_PHASES.map((phase) => ({
+          title: `Agentic Rollout ${phase.titlePrefix}: ${phase.insightTitle}`,
+          objective:
+            'Prepare human-review-ready LinkedIn, YouTube Shorts, Instagram Reels, TikTok, and Thumbnail draft packets for one phase of the 14-day Agentic book rollout whisper_to_shout campaign.',
+          status: 'proposed',
+          priority: 'high',
+          owner_agent_key: 'chief-of-staff',
+          owner_runtime: 'manual',
+          source_type: 'social_topic_trigger',
+          source_id: `${AGENTIC_BOOK_ROLLOUT_CAMPAIGN_FIXTURE_KEY}:${phase.phase}`,
+          source_label: 'Agentic book rollout whisper_to_shout campaign',
+          parent_work_item_id: campaignGoal.id,
+          expected_files: [],
+          touched_files: [],
+          overlap_group: 'social-content-intelligence',
+          dependency_ids: [campaignGoal.id],
+          idempotency_key: `${AGENTIC_BOOK_ROLLOUT_CAMPAIGN_IDEMPOTENCY_PREFIX}:${phase.phase}`,
+          metadata: agenticBookRolloutInsightMetadata({
+            packetId: String(packet.id),
+            phase,
+            generatedAt,
+          }),
+        }))
+
+        const { data: workItems, error: workItemError } = await supabase
+          .from('agent_work_items')
+          .insert(workItemRows)
+          .select('id, metadata')
+
+        if (workItemError || !workItems || workItems.length !== AGENTIC_BOOK_ROLLOUT_PHASES.length) {
+          return {
+            ok: false,
+            error: `agent_work_items: ${workItemError?.message ?? 'unexpected row count'}`,
+          }
+        }
+
+        const slots = campaignContentPlanSlots({
+          name: String(campaign.name),
+          starts_at: String(campaign.starts_at),
+          ends_at: String(campaign.ends_at),
+        }, { templateKey: 'whisper_to_shout' })
+
+        const calendarRows = slots.flatMap((slot, index) => {
+          const phase = AGENTIC_BOOK_ROLLOUT_PHASES[index]
+          const workItem = workItems[index]
+          const scheduledFor = addDaysAtHourISO(phase.day, phase.phase === 'offer' ? 11 : 10)
+          const commonMetadata = {
+            ...slot.metadata,
+            demo_seed_key: AGENTIC_BOOK_ROLLOUT_CAMPAIGN_FIXTURE_KEY,
+            fixture_version: 1,
+            campaign_target: 'Agentic book rollout',
+            campaign_template_key: 'whisper_to_shout',
+            campaign_window_days: 14,
+            campaign_language: 'Tease/Wispr/Shout overlay; stored phase remains canonical.',
+            linked_work_item_id: workItem.id,
+            linked_research_packet_id: packet.id,
+            conversion_path: 'Agentic rollout interest, then Agent Ops advisory, AI Quick Win, or discovery call.',
+            source_paths: [
+              'docs/agentic-value-communications-plan.md',
+              'docs/agentic-content-research-briefs/phase-2-research-dossier.md',
+            ],
+            external_execution_enabled: false,
+            provider_generation_enabled: false,
+            upload_enabled: false,
+            publish_enabled: false,
+            schedule_enabled: false,
+          }
+          const primaryRow = {
+            ...slot,
+            campaign_id: campaign.id,
+            agent_work_item_id: workItem.id,
+            channel: 'linkedin',
+            title: `${phase.titlePrefix}: ${phase.insightTitle}`,
+            planned_angle: `${phase.contentAngle} LinkedIn, YouTube Shorts, Instagram Reels, TikTok, and Thumbnail drafts are ready for human approval.`,
+            scheduled_for: scheduledFor,
+            authorization_due_at: addDaysAtHourISO(Math.max(0, phase.day - 1), 10),
+            authorization_status: 'pending',
+            metadata: {
+              ...commonMetadata,
+              calendar_item_role: 'primary_phase_item',
+              channel_draft_targets: ['linkedin', 'youtube_shorts', 'instagram_reels', 'tiktok', 'thumbnail'],
+            },
+          }
+          const youtubeRow = {
+            ...slot,
+            campaign_id: campaign.id,
+            agent_work_item_id: workItem.id,
+            channel: 'youtube_shorts',
+            title: `${phase.titlePrefix} Short: ${phase.insightTitle}`,
+            planned_angle: `${phase.suggestedHook} Adapt this phase into the review-ready YouTube Shorts lane before any render or upload.`,
+            scheduled_for: addDaysAtHourISO(phase.day, phase.phase === 'offer' ? 14 : 13),
+            authorization_due_at: addDaysAtHourISO(Math.max(0, phase.day - 1), 10),
+            authorization_status: 'pending',
+            metadata: {
+              ...commonMetadata,
+              calendar_item_role: 'companion_channel_item',
+              primary_channel: 'linkedin',
+              channel_draft_targets: ['youtube_shorts', 'instagram_reels', 'tiktok', 'thumbnail'],
+            },
+          }
+          return [primaryRow, youtubeRow]
+        })
+
+        const { error: calendarError } = await supabase
+          .from('social_content_calendar_items')
+          .insert(calendarRows)
+
+        if (calendarError) {
+          return { ok: false, error: `social_content_calendar_items: ${calendarError.message}` }
+        }
+
+        return {
+          ok: true,
+          key,
+          detail: `Agentic book rollout campaign ${campaign.id} with campaign goal ${campaignGoal.id}, ${calendarRows.length} calendar items, ${workItems.length} insight work items, and research packet ${packet.id}`,
         }
       }
 

--- a/lib/social-platform-orchestration.test.ts
+++ b/lib/social-platform-orchestration.test.ts
@@ -10,6 +10,7 @@ describe('buildPlatformOrchestrationPlan', () => {
       productionReady: true,
       redactionReady: true,
       draftHandoffReady: true,
+      finalSubmissionGateReady: true,
       publishRecords: [{
         platform: 'linkedin',
         status: 'pending',
@@ -41,6 +42,31 @@ describe('buildPlatformOrchestrationPlan', () => {
       publish: false,
       externalPost: false,
     })
+  })
+
+  it('does not treat pending publish rows as final human submission approval', () => {
+    const plan = buildPlatformOrchestrationPlan({
+      targetPlatforms: ['linkedin'],
+      copyApproved: true,
+      productionReady: true,
+      redactionReady: true,
+      draftHandoffReady: true,
+      publishRecords: [{
+        platform: 'linkedin',
+        status: 'pending',
+        platform_post_url: null,
+      }],
+    })
+
+    expect(plan.anyAutomaticSubmissionAvailable).toBe(false)
+    expect(plan.platforms[0].stages.map((stage) => [stage.key, stage.state])).toEqual([
+      ['human_approval', 'complete'],
+      ['asset_readiness', 'complete'],
+      ['platform_draft_handoff', 'complete'],
+      ['platform_configuration', 'complete'],
+      ['final_submission_gate', 'pending'],
+      ['automatic_submission', 'blocked'],
+    ])
   })
 
   it('connects Facebook to the same automatic submission gate path', () => {
@@ -107,5 +133,73 @@ describe('buildPlatformOrchestrationPlan', () => {
       ['final_submission_gate', 'blocked'],
       ['automatic_submission', 'blocked'],
     ])
+  })
+
+  it('blocks video platforms before final submission when the final video asset is missing', () => {
+    const plan = buildPlatformOrchestrationPlan({
+      item: {
+        status: 'approved',
+        platform: 'youtube',
+        target_platforms: ['youtube', 'tiktok'],
+        publishes: [],
+        post_text: 'Approved copy',
+        image_url: null,
+        video_url: null,
+        carousel_slide_urls: null,
+      },
+      copyApproved: true,
+      productionReady: true,
+      redactionReady: true,
+      draftHandoffReady: true,
+      finalSubmissionGateReady: true,
+      platformConfigs: [
+        { platform: 'youtube', is_active: true, credentials: { access_token: 'token' }, settings: {} },
+        {
+          platform: 'tiktok',
+          is_active: true,
+          credentials: { access_token: 'token' },
+          settings: { creator_info_confirmed: true, source_url_approved: true } as never,
+        },
+      ],
+    })
+
+    expect(plan.anyAutomaticSubmissionAvailable).toBe(false)
+    expect(plan.platforms.map((platform) => platform.nextAction)).toEqual([
+      'YouTube needs a final video URL before submission.',
+      'TikTok needs a final video URL before Direct Post submission.',
+    ])
+    expect(plan.platforms.map((platform) => (
+      platform.stages.find((stage) => stage.key === 'asset_readiness')?.state
+    ))).toEqual(['blocked', 'blocked'])
+  })
+
+  it('keeps Instagram blocked until an image, carousel, or Reel video exists', () => {
+    const plan = buildPlatformOrchestrationPlan({
+      item: {
+        status: 'approved',
+        platform: 'instagram',
+        target_platforms: ['instagram'],
+        publishes: [],
+        post_text: 'Caption only',
+        image_url: null,
+        video_url: null,
+        carousel_slide_urls: [],
+      },
+      copyApproved: true,
+      productionReady: true,
+      redactionReady: true,
+      draftHandoffReady: true,
+      finalSubmissionGateReady: true,
+      platformConfigs: [{
+        platform: 'instagram',
+        is_active: true,
+        credentials: { access_token: 'token', ig_user_id: 'ig-user-1' },
+        settings: {},
+      }],
+    })
+
+    expect(plan.anyAutomaticSubmissionAvailable).toBe(false)
+    expect(plan.platforms[0].nextAction).toBe('Instagram needs an image, carousel slide URLs, or final Reel video URL before submission.')
+    expect(plan.platforms[0].stages.find((stage) => stage.key === 'asset_readiness')?.state).toBe('blocked')
   })
 })

--- a/lib/social-platform-orchestration.ts
+++ b/lib/social-platform-orchestration.ts
@@ -47,6 +47,19 @@ export type PlatformOrchestrationPlan = {
   }
 }
 
+export type PlatformSubmissionGate = {
+  status?: 'approved' | 'rejected' | 'pending' | 'blocked'
+  approved_at?: string
+  approved_by?: string
+  platforms?: SocialPlatform[]
+  decision_note?: string
+}
+
+export type PlatformAssetReadiness = {
+  ready: boolean
+  detail: string
+}
+
 const PLATFORM_LABELS: Record<SocialPlatform, string> = {
   linkedin: 'LinkedIn',
   youtube: 'YouTube',
@@ -58,18 +71,30 @@ const PLATFORM_LABELS: Record<SocialPlatform, string> = {
 const AUTOMATIC_SUBMISSION_SUPPORTED = new Set<SocialPlatform>(['linkedin', 'youtube', 'instagram', 'facebook', 'tiktok'])
 
 const SUBMITTED_STATUSES = new Set<PublishStatus>(['published'])
-const SUBMITTABLE_STATUSES = new Set<PublishStatus>(['pending', 'failed'])
-
 export type BuildPlatformOrchestrationInput = {
-  item?: Pick<SocialContentItem, 'status' | 'platform' | 'target_platforms' | 'publishes'> | null
+  item?: Pick<SocialContentItem,
+    | 'status'
+    | 'platform'
+    | 'target_platforms'
+    | 'publishes'
+    | 'post_text'
+    | 'image_url'
+    | 'video_url'
+    | 'carousel_slide_urls'
+  > | null
   targetPlatforms?: SocialPlatform[]
   publishRecords?: Pick<SocialContentPublish, 'platform' | 'status' | 'platform_post_url'>[]
   platformConfigs?: Pick<SocialContentConfig, 'platform' | 'credentials' | 'settings' | 'is_active'>[]
+  platformAssetReadiness?: Partial<Record<SocialPlatform, PlatformAssetReadiness>>
   copyApproved?: boolean
   productionReady?: boolean
   redactionReady?: boolean
   draftHandoffReady?: boolean
   finalSubmissionGateReady?: boolean
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null
 }
 
 function uniquePlatforms(platforms: SocialPlatform[]) {
@@ -81,6 +106,28 @@ function resolveTargetPlatforms(input: BuildPlatformOrchestrationInput) {
   if (input.item?.target_platforms?.length) return uniquePlatforms(input.item.target_platforms)
   if (input.item?.platform) return uniquePlatforms([input.item.platform])
   return ['linkedin'] as SocialPlatform[]
+}
+
+export function getPlatformSubmissionGate(ragContext: unknown): PlatformSubmissionGate | null {
+  const gate = asRecord(asRecord(ragContext)?.platform_submission_gate)
+  if (!gate) return null
+
+  return {
+    status: typeof gate.status === 'string' ? gate.status as PlatformSubmissionGate['status'] : undefined,
+    approved_at: typeof gate.approved_at === 'string' ? gate.approved_at : undefined,
+    approved_by: typeof gate.approved_by === 'string' ? gate.approved_by : undefined,
+    platforms: Array.isArray(gate.platforms)
+      ? uniquePlatforms(gate.platforms.filter((platform): platform is SocialPlatform => typeof platform === 'string' && Boolean(PLATFORM_LABELS[platform as SocialPlatform])) as SocialPlatform[])
+      : undefined,
+    decision_note: typeof gate.decision_note === 'string' ? gate.decision_note : undefined,
+  }
+}
+
+export function isPlatformSubmissionGateApproved(ragContext: unknown, platforms: SocialPlatform[]) {
+  const gate = getPlatformSubmissionGate(ragContext)
+  if (gate?.status !== 'approved') return false
+  const approvedPlatforms = gate.platforms?.length ? gate.platforms : platforms
+  return platforms.every((platform) => approvedPlatforms.includes(platform))
 }
 
 function isCopyApproved(status?: ContentStatus) {
@@ -114,6 +161,74 @@ function configField(config: Pick<SocialContentConfig, 'credentials' | 'settings
 
 function configSettings(config: Pick<SocialContentConfig, 'settings'> | undefined) {
   return config?.settings as Record<string, unknown> | undefined
+}
+
+function hasText(value: unknown) {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function hasListItems(value: unknown) {
+  return Array.isArray(value) && value.some((item) => hasText(item))
+}
+
+export function getPlatformAssetReadiness(
+  item: Pick<SocialContentItem, 'post_text' | 'image_url' | 'video_url' | 'carousel_slide_urls'> | null | undefined,
+  platform: SocialPlatform,
+): PlatformAssetReadiness {
+  if (!item) {
+    return {
+      ready: true,
+      detail: `${PLATFORM_LABELS[platform]} asset readiness check was not requested.`,
+    }
+  }
+
+  const hasPostText = hasText(item.post_text)
+  const hasImage = hasText(item.image_url)
+  const hasVideo = hasText(item.video_url)
+  const hasCarousel = hasListItems(item.carousel_slide_urls)
+
+  switch (platform) {
+    case 'linkedin':
+      return {
+        ready: hasPostText,
+        detail: hasPostText
+          ? 'LinkedIn copy is ready for submission.'
+          : 'LinkedIn needs post text before submission.',
+      }
+    case 'youtube':
+      return {
+        ready: hasVideo,
+        detail: hasVideo
+          ? 'YouTube has a final video URL.'
+          : 'YouTube needs a final video URL before submission.',
+      }
+    case 'instagram':
+      return {
+        ready: hasImage || hasVideo || hasCarousel,
+        detail: hasImage || hasVideo || hasCarousel
+          ? 'Instagram has a publishable image, carousel, or Reel video asset.'
+          : 'Instagram needs an image, carousel slide URLs, or final Reel video URL before submission.',
+      }
+    case 'facebook':
+      return {
+        ready: hasPostText || hasImage || hasVideo,
+        detail: hasPostText || hasImage || hasVideo
+          ? 'Facebook has copy or media ready for submission.'
+          : 'Facebook needs post text, an image, or a video before submission.',
+      }
+    case 'tiktok':
+      return {
+        ready: hasVideo,
+        detail: hasVideo
+          ? 'TikTok has a final video URL.'
+          : 'TikTok needs a final video URL before Direct Post submission.',
+      }
+    default:
+      return {
+        ready: false,
+        detail: `${PLATFORM_LABELS[platform]} asset requirements are not configured.`,
+      }
+  }
 }
 
 function hasPlatformConfiguration(
@@ -207,6 +322,7 @@ export function buildPlatformOrchestrationPlan(input: BuildPlatformOrchestration
   const platforms = targetPlatforms.map((platform) => {
     const publishRecord = publishRecords.find((record) => record.platform === platform)
     const platformConfig = input.platformConfigs?.find((config) => config.platform === platform)
+    const assetReadiness = input.platformAssetReadiness?.[platform] ?? getPlatformAssetReadiness(input.item, platform)
     const configuration = input.platformConfigs ? hasPlatformConfiguration(platform, platformConfig) : {
       ready: true,
       detail: `${PLATFORM_LABELS[platform]} configuration check was not requested.`,
@@ -214,17 +330,25 @@ export function buildPlatformOrchestrationPlan(input: BuildPlatformOrchestration
     const publishStatus = publishRecord?.status ?? null
     const automaticSubmissionSupported = AUTOMATIC_SUBMISSION_SUPPORTED.has(platform)
     const submissionComplete = Boolean(publishStatus && SUBMITTED_STATUSES.has(publishStatus))
-    const finalSubmissionGateReady = input.finalSubmissionGateReady
-      ?? Boolean((publishStatus && SUBMITTABLE_STATUSES.has(publishStatus)) || submissionComplete)
+    const finalSubmissionGateReady = input.finalSubmissionGateReady ?? submissionComplete
 
     const humanApprovalState: PlatformOrchestrationStageState = copyReady ? 'complete' : 'pending'
     const assetState: PlatformOrchestrationStageState = !copyReady
       ? 'blocked'
-      : productionReady
-        ? 'complete'
-        : redactionReady
-          ? 'pending'
-          : 'blocked'
+      : !redactionReady
+        ? 'blocked'
+        : !assetReadiness.ready
+          ? 'blocked'
+          : productionReady
+            ? 'complete'
+            : 'pending'
+    const assetDetail = !redactionReady
+      ? 'Resolve privacy/redaction blockers before submission.'
+      : !assetReadiness.ready
+        ? assetReadiness.detail
+        : productionReady
+          ? assetReadiness.detail
+          : 'Finish visual assets, asset packet, and channel-specific readiness.'
     const draftState: PlatformOrchestrationStageState = assetState !== 'complete'
       ? 'blocked'
       : (draftHandoffReady || Boolean(publishRecord))
@@ -259,11 +383,7 @@ export function buildPlatformOrchestrationPlan(input: BuildPlatformOrchestration
         'asset_readiness',
         'Assets and privacy',
         assetState,
-        assetState === 'complete'
-          ? 'Required assets and privacy checks are ready.'
-          : redactionReady
-            ? 'Finish visual assets, asset packet, and channel-specific readiness.'
-            : 'Resolve privacy/redaction blockers before submission.',
+        assetDetail,
       ),
       stage(
         'platform_draft_handoff',

--- a/lib/testing/scenarios.test.ts
+++ b/lib/testing/scenarios.test.ts
@@ -82,4 +82,31 @@ describe('scenarioIncludesDiagnosticStep', () => {
       'seed_accelerated_workshop_campaign_fixture',
     )
   })
+
+  it('registers the Agentic Book Rollout campaign fixture seed scenario', () => {
+    const scenario = getScenario('seed_agentic_book_rollout_campaign_fixture')
+
+    expect(scenario).toMatchObject({
+      id: 'seed_agentic_book_rollout_campaign_fixture',
+      name: 'Seed: Agentic Book Rollout Campaign Fixture',
+      tags: expect.arrayContaining([
+        'seed',
+        'populate-demo',
+        'content-intelligence',
+        'calendar',
+        'social-review',
+        'agentic',
+      ]),
+    })
+    expect(scenario?.steps[0]).toMatchObject({
+      type: 'apiCall',
+      endpoint: '/api/admin/testing/demo-seed',
+      method: 'POST',
+      body: { key: 'agentic_book_rollout_campaign_fixture' },
+      expectedStatus: 200,
+    })
+    expect(POPULATE_DEMO_SCENARIOS.map((item) => item.id)).toContain(
+      'seed_agentic_book_rollout_campaign_fixture',
+    )
+  })
 })

--- a/lib/testing/scenarios.ts
+++ b/lib/testing/scenarios.ts
@@ -1201,6 +1201,15 @@ export const seedAcceleratedWorkshopCampaignFixtureScenario = demoSeedApiScenari
   ['seed', 'populate-demo', 'content-intelligence', 'calendar', 'social-review', 'accelerated']
 )
 
+export const seedAgenticBookRolloutCampaignFixtureScenario = demoSeedApiScenario(
+  'seed_agentic_book_rollout_campaign_fixture',
+  'Seed: Agentic Book Rollout Campaign Fixture',
+  'Dev-safe 14-day whisper_to_shout campaign with calendar items and review-ready LinkedIn, YouTube Shorts, Instagram Reels, TikTok, and Thumbnail lanes for the Agentic rollout',
+  'agentic_book_rollout_campaign_fixture',
+  'lead',
+  ['seed', 'populate-demo', 'content-intelligence', 'calendar', 'social-review', 'agentic']
+)
+
 /** Scenarios that populate demo data via E2E (no SQL). Run with cleanupAfter: false. */
 export const POPULATE_DEMO_SCENARIOS: TestScenario[] = [
   seedWarmLeadsScenario,
@@ -1216,6 +1225,7 @@ export const POPULATE_DEMO_SCENARIOS: TestScenario[] = [
   seedSocialContentCalendarFixtureScenario,
   seedSocialChannelReviewFixtureScenario,
   seedAcceleratedWorkshopCampaignFixtureScenario,
+  seedAgenticBookRolloutCampaignFixtureScenario,
 ]
 
 // ============================================================================
@@ -1357,6 +1367,7 @@ export const SCENARIOS_BY_ID: Record<string, TestScenario> = {
   seed_social_content_calendar_fixture: seedSocialContentCalendarFixtureScenario,
   seed_social_channel_review_fixture: seedSocialChannelReviewFixtureScenario,
   seed_accelerated_workshop_campaign_fixture: seedAcceleratedWorkshopCampaignFixtureScenario,
+  seed_agentic_book_rollout_campaign_fixture: seedAgenticBookRolloutCampaignFixtureScenario,
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add an explicit final platform submission gate for social content so copy approval and draft handoff no longer imply external submission approval.
- Add a guarded platform-submission API route and update publish orchestration to block direct publish calls until the final human gate is approved.
- Add platform-specific media readiness checks before final submission approval: YouTube and TikTok require final video URLs, Instagram requires image/carousel/Reel media, LinkedIn/Facebook require copy or accepted media as appropriate.
- Seed an Agentic book rollout whisper-to-shout campaign fixture with central backlog work items, calendar milestones, LinkedIn/YouTube/Instagram/TikTok/thumbnail lane packets, and a source-safe strategy doc.

## Validation
- `npm test -- --run lib/testing/scenarios.test.ts lib/admin-demo-seed.test.ts lib/social-platform-orchestration.test.ts app/api/admin/social-content/[id]/publish/route.test.ts app/api/admin/social-content/[id]/approve/route.test.ts app/api/admin/social-content/[id]/platform-submission/route.test.ts` - passed, 31 tests.
- `npm run lint` - passed with existing `<img>` warnings in `app/client/dashboard/[token]/page.tsx` and `components/Navigation.test.tsx`.
- `npx tsc --noEmit --pretty false` - still blocked by existing unrelated `app/admin/mobile-app-foundry/PacketPreviewWorkspace.test.tsx` tuple/body errors.
- Local smoke from the prior push: started `npm run dev -- -p 3085` using a temporary ignored `.env.local` symlink from the main checkout, then verified `HEAD /admin/agents/content-intelligence` and `HEAD /admin/social-content/25d7efa3-62bc-4f5e-a191-1a131918593a` returned `200 OK`. No click actions, provider calls, uploads, scheduling, publishing, or webhook triggers were run.

## Integration Notes
- Non-captain implementation PR; Integration Captain required for merge sequencing, deployment watcher, and branch cleanup.
- No schema migration in this PR.
- New seed key: `agentic_book_rollout_campaign_fixture`.
- External execution remains gated: the campaign fixture records plans and review packets only, platform submission requires explicit final approval, and final approval is blocked until required platform media/configuration is present.
- Pre-push database health check skipped locally because production Supabase credentials were not present; CI should enforce its normal checks.
- Vercel contexts were not checked from this implementation lane and remain Integration Captain scope:
  - Vercel – portfolio
  - Vercel – portfolio-staging
