### PR TITLE
feat: add social channel strategy evidence

### DIFF
--- a/app/admin/agents/social-insights/[id]/page.test.tsx
+++ b/app/admin/agents/social-insights/[id]/page.test.tsx
@@ -66,6 +66,36 @@ function socialWorkItem(overrides: Record<string, unknown> = {}) {
   }
 }
 
+function strategyEvidence(surfaceLabel: string, surfaceRoute: string, assets: string[]) {
+  return {
+    agents: [
+      { name: 'Shaka', role: 'Chief of Staff', responsibility: 'Owns insight and approval routing.' },
+      { name: 'Askia', role: 'Research Analyst', responsibility: 'Summarizes reusable public creator patterns.' },
+      { name: 'Amina', role: 'Challenger Reviewer', responsibility: 'Checks channel fit and Vambah voice.' },
+    ],
+    portfolio_surfaces: [
+      { label: 'Content Intelligence', route: '/admin/agents/content-intelligence', purpose: 'Research packets and channel readiness.' },
+      { label: surfaceLabel, route: surfaceRoute, purpose: 'Channel-specific draft and asset review.' },
+    ],
+    channel_structure: {
+      format: `${surfaceLabel} channel structure`,
+      structure: ['Hook the pain.', 'Show Portfolio proof.', 'Close with a gated next action.'],
+      success_criteria: ['Pain point is visible.', 'Approval remains human-gated.'],
+    },
+    voice_translation: {
+      source: 'Vambah personality corpus plus docs/linkedin-voice.md',
+      principles: ['Open with a concrete tension.', 'Use practical language.'],
+      avoid: ['Generic AI hype.'],
+    },
+    visual_reinforcement: {
+      recommended_assets: assets,
+      portfolio_snapshots: [surfaceRoute],
+      illustration_direction: 'Show the operating path behind the proof.',
+      privacy_notes: ['Redact private admin data.'],
+    },
+  }
+}
+
 describe('SocialInsightDetailPage', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -102,6 +132,7 @@ describe('SocialInsightDetailPage', () => {
                         content_angle: 'AI should reduce burden, but only when authority and evidence are separated.',
                         evidence_summary: 'Review path and visual gate work shipped locally.',
                       },
+                      orchestration_evidence: strategyEvidence('Social Content Review', '/admin/social-content', ['Framework illustration', 'App screenshot carousel']),
                       fields: {
                         post_text: 'The Social Content review flow made the gate visible.\n\nAI should reduce burden.',
                         cta: 'Where have you seen AI create more work because the approval path was never designed?',
@@ -130,6 +161,7 @@ describe('SocialInsightDetailPage', () => {
                         content_angle: 'AI should reduce burden, but only when authority and evidence are separated.',
                         evidence_summary: 'Review path and visual gate work shipped locally.',
                       },
+                      orchestration_evidence: strategyEvidence('Video Generation', '/admin/content/video-generation', ['Portfolio b-roll', 'Thumbnail direction']),
                       fields: {
                         hook: 'AI should reduce burden.',
                         first_30_seconds: 'I noticed this through the social content review flow.',
@@ -158,6 +190,7 @@ describe('SocialInsightDetailPage', () => {
                         content_angle: 'AI should reduce burden, but only when authority and evidence are separated.',
                         evidence_summary: 'Review path and visual gate work shipped locally.',
                       },
+                      orchestration_evidence: strategyEvidence('Visual Assets', '/admin/content/visual-assets', ['Cover frame', 'Vertical proof b-roll']),
                       fields: {
                         hook: 'AI should reduce burden.',
                         script: ['Opening: AI should reduce burden.', 'Trigger: Social Content review flow.'],
@@ -189,6 +222,7 @@ describe('SocialInsightDetailPage', () => {
                         content_angle: 'AI should reduce burden, but only when authority and evidence are separated.',
                         evidence_summary: 'Review path and visual gate work shipped locally.',
                       },
+                      orchestration_evidence: strategyEvidence('Video Generation', '/admin/content/video-generation', ['Original narration', 'Platform-safe b-roll']),
                       fields: {
                         hook: 'AI should reduce burden.',
                         script: ['Opening: AI should reduce burden.', 'Trigger: Social Content review flow.'],
@@ -365,6 +399,10 @@ describe('SocialInsightDetailPage', () => {
     expect(await screen.findByText('LinkedIn, YouTube Shorts, Instagram Reels, and TikTok are ready for human review.')).toBeInTheDocument()
     expect(screen.getByText('Review draft packet')).toBeInTheDocument()
     expect(screen.getByText('Shared source: Approval gates create trust')).toBeInTheDocument()
+    expect(screen.getByText('Agent + Portfolio strategy')).toBeInTheDocument()
+    expect(screen.getByText('Shaka')).toBeInTheDocument()
+    expect(screen.getByText('Social Content Review')).toBeInTheDocument()
+    expect(screen.getByText('Framework illustration')).toBeInTheDocument()
     expect(screen.getByText('No side effects authorized: provider generation, upload, publish, schedule, external post.')).toBeInTheDocument()
     expect(screen.getAllByText((content) => content.includes('The Social Content review flow made the gate visible.'))).toHaveLength(2)
     expect(screen.getByText('#AmaduTownAdvisory')).toBeInTheDocument()
@@ -373,6 +411,8 @@ describe('SocialInsightDetailPage', () => {
 
     expect(screen.getByText('YouTube Shorts production inputs')).toBeInTheDocument()
     expect(screen.getByText('Shared source: Approval gates create trust')).toBeInTheDocument()
+    expect(screen.getByText('Video Generation')).toBeInTheDocument()
+    expect(screen.getByText('Portfolio b-roll')).toBeInTheDocument()
     expect(screen.getByText('No side effects authorized: provider generation, upload, publish, schedule, external post.')).toBeInTheDocument()
     expect(screen.getByText('first 30 seconds')).toBeInTheDocument()
     expect(screen.getByText('I noticed this through the social content review flow.')).toBeInTheDocument()
@@ -381,6 +421,7 @@ describe('SocialInsightDetailPage', () => {
     fireEvent.click(screen.getByRole('tab', { name: /TikTok/ }))
 
     expect(screen.getByText('TikTok production inputs')).toBeInTheDocument()
+    expect(screen.getByText('Platform-safe b-roll')).toBeInTheDocument()
     expect(screen.getByText('audio rights')).toBeInTheDocument()
     expect(screen.getByText('Use original narration or platform-safe audio only.')).toBeInTheDocument()
 

--- a/app/admin/agents/social-insights/[id]/page.tsx
+++ b/app/admin/agents/social-insights/[id]/page.tsx
@@ -471,6 +471,82 @@ function ResearchPatternCard({ pattern }: { pattern: Record<string, unknown> }) 
   )
 }
 
+function StrategyEvidencePanel({ evidence }: { evidence: Record<string, unknown> }) {
+  if (!Object.keys(evidence).length) return null
+
+  const agents = asRecordArray(evidence.agents)
+  const surfaces = asRecordArray(evidence.portfolio_surfaces)
+  const channelStructure = asRecord(evidence.channel_structure)
+  const voiceTranslation = asRecord(evidence.voice_translation)
+  const visualReinforcement = asRecord(evidence.visual_reinforcement)
+
+  return (
+    <details className="mb-4 rounded-lg border border-radiant-gold/35 bg-radiant-gold/10 p-3">
+      <summary className="cursor-pointer text-sm font-semibold text-radiant-gold">
+        Agent + Portfolio strategy
+      </summary>
+      <div className="mt-3 grid gap-3 xl:grid-cols-2">
+        <div className="rounded-md border border-radiant-gold/20 bg-background/35 p-3">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">Agents called</p>
+          <ul className="mt-2 space-y-2 text-xs leading-5 text-muted-foreground">
+            {agents.map((agent) => (
+              <li key={`${asString(agent.name)}-${asString(agent.role)}`}>
+                <span className="font-semibold text-foreground">{asString(agent.name)}</span>
+                {asString(agent.role) ? <span> · {asString(agent.role)}</span> : null}
+                {asString(agent.responsibility) ? <span className="block">{asString(agent.responsibility)}</span> : null}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="rounded-md border border-radiant-gold/20 bg-background/35 p-3">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">Portfolio surfaces</p>
+          <ul className="mt-2 space-y-2 text-xs leading-5 text-muted-foreground">
+            {surfaces.map((surface) => (
+              <li key={`${asString(surface.label)}-${asString(surface.route)}`}>
+                <span className="font-semibold text-foreground">{asString(surface.label)}</span>
+                {asString(surface.route) ? <span> · {asString(surface.route)}</span> : null}
+                {asString(surface.purpose) ? <span className="block">{asString(surface.purpose)}</span> : null}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="rounded-md border border-radiant-gold/20 bg-background/35 p-3">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">Channel structure</p>
+          <p className="mt-2 text-sm font-semibold">{asString(channelStructure.format) || 'Channel-specific structure pending.'}</p>
+          <CompactList values={asStringArray(channelStructure.structure)} />
+          <p className="mt-3 text-xs uppercase tracking-wide text-muted-foreground">Success checks</p>
+          <CompactList values={asStringArray(channelStructure.success_criteria)} />
+        </div>
+        <div className="rounded-md border border-radiant-gold/20 bg-background/35 p-3">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">Vambah voice + visuals</p>
+          <p className="mt-2 text-xs leading-5 text-muted-foreground">
+            Source: {asString(voiceTranslation.source) || 'Voice source pending.'}
+          </p>
+          <CompactList values={asStringArray(voiceTranslation.principles)} />
+          <p className="mt-3 text-xs uppercase tracking-wide text-muted-foreground">Visual reinforcement</p>
+          <CompactList values={asStringArray(visualReinforcement.recommended_assets)} />
+          {asString(visualReinforcement.illustration_direction) ? (
+            <p className="mt-2 rounded border border-radiant-gold/20 bg-background/35 px-2 py-1 text-xs leading-5 text-muted-foreground">
+              {asString(visualReinforcement.illustration_direction)}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </details>
+  )
+}
+
+function CompactList({ values }: { values: string[] }) {
+  if (!values.length) return null
+  return (
+    <ul className="mt-2 list-disc space-y-1 pl-4 text-xs leading-5 text-muted-foreground">
+      {values.map((value) => (
+        <li key={value}>{value}</li>
+      ))}
+    </ul>
+  )
+}
+
 function InsightField({ label, value }: { label: string; value: string }) {
   return (
     <div className="rounded-lg border border-silicon-slate/70 bg-silicon-slate/20 p-3">
@@ -496,6 +572,7 @@ function ChannelInputs({
   const draftApprovalStatus = asString(draftPacket.approval_status)
   const sharedSource = asRecord(draftPacket.shared_source)
   const sharedSourceTitle = asString(sharedSource.insight_title)
+  const orchestrationEvidence = asRecord(draftPacket.orchestration_evidence)
   const sideEffects = asRecord(draftPacket.side_effects)
   const disabledSideEffects = [
     ['provider_generation', 'provider generation'],
@@ -547,6 +624,8 @@ function ChannelInputs({
           ) : null}
         </div>
       ) : null}
+
+      <StrategyEvidencePanel evidence={orchestrationEvidence} />
 
       <div className="grid gap-3 md:grid-cols-2">
         {(hasDraftFields ? Object.entries(fields) : requiredInputs.map((input) => [input, suggestedValue(input, insight)] as const))

--- a/app/api/admin/agents/work-items/[id]/social-channels/prepare-review-drafts/route.test.ts
+++ b/app/api/admin/agents/work-items/[id]/social-channels/prepare-review-drafts/route.test.ts
@@ -148,6 +148,22 @@ describe('/api/admin/agents/work-items/[id]/social-channels/prepare-review-draft
             review_requested_at: '2026-06-24T15:00:00.000Z',
             draft_packet: expect.objectContaining({
               channel: 'linkedin',
+              orchestration_evidence: expect.objectContaining({
+                agents: expect.arrayContaining([
+                  expect.objectContaining({ name: 'Shaka' }),
+                  expect.objectContaining({ name: 'Askia' }),
+                  expect.objectContaining({ name: 'Amina' }),
+                ]),
+                channel_structure: expect.objectContaining({
+                  format: expect.stringContaining('Thought-leadership post'),
+                }),
+                voice_translation: expect.objectContaining({
+                  source: expect.stringContaining('Vambah personality corpus'),
+                }),
+                visual_reinforcement: expect.objectContaining({
+                  recommended_assets: expect.arrayContaining(['Framework illustration', 'App screenshot carousel']),
+                }),
+              }),
               fields: expect.objectContaining({
                 post_text: expect.stringContaining('The Social Content review flow made the gate visible.'),
                 cta: expect.stringContaining('Where have you seen AI'),
@@ -159,6 +175,14 @@ describe('/api/admin/agents/work-items/[id]/social-channels/prepare-review-draft
             review_requested_at: '2026-06-24T15:00:00.000Z',
             draft_packet: expect.objectContaining({
               channel: 'youtube_shorts',
+              orchestration_evidence: expect.objectContaining({
+                portfolio_surfaces: expect.arrayContaining([
+                  expect.objectContaining({ route: '/admin/content/video-generation' }),
+                ]),
+                visual_reinforcement: expect.objectContaining({
+                  recommended_assets: expect.arrayContaining(['Portfolio b-roll', 'Thumbnail direction']),
+                }),
+              }),
               fields: expect.objectContaining({
                 hook: 'AI should reduce burden.',
                 first_30_seconds: expect.stringContaining('I noticed this through the social content review flow'),
@@ -170,6 +194,14 @@ describe('/api/admin/agents/work-items/[id]/social-channels/prepare-review-draft
             review_requested_at: '2026-06-24T15:00:00.000Z',
             draft_packet: expect.objectContaining({
               channel: 'instagram_reels',
+              orchestration_evidence: expect.objectContaining({
+                portfolio_surfaces: expect.arrayContaining([
+                  expect.objectContaining({ route: '/admin/content/visual-assets' }),
+                ]),
+                visual_reinforcement: expect.objectContaining({
+                  recommended_assets: expect.arrayContaining(['Cover frame', 'Vertical proof b-roll']),
+                }),
+              }),
               fields: expect.objectContaining({
                 cover_text: expect.any(String),
                 export_readiness: 'pending_human_approval',
@@ -181,6 +213,16 @@ describe('/api/admin/agents/work-items/[id]/social-channels/prepare-review-draft
             review_requested_at: '2026-06-24T15:00:00.000Z',
             draft_packet: expect.objectContaining({
               channel: 'tiktok',
+              orchestration_evidence: expect.objectContaining({
+                channel_structure: expect.objectContaining({
+                  success_criteria: expect.arrayContaining([
+                    expect.stringContaining('Audio rights'),
+                  ]),
+                }),
+                voice_translation: expect.objectContaining({
+                  avoid: expect.arrayContaining(['Generic AI hype.']),
+                }),
+              }),
               fields: expect.objectContaining({
                 audio_rights: expect.stringContaining('platform-safe audio'),
                 export_readiness: 'pending_human_approval',

--- a/app/api/admin/agents/work-items/[id]/social-channels/workflow.test.ts
+++ b/app/api/admin/agents/work-items/[id]/social-channels/workflow.test.ts
@@ -161,6 +161,19 @@ describe('social content intelligence research-to-channel-approval workflow', ()
         linkedin: expect.objectContaining({
           channel: 'linkedin',
           approval_status: 'in_review',
+          orchestration_evidence: expect.objectContaining({
+            agents: expect.arrayContaining([
+              expect.objectContaining({ name: 'Shaka' }),
+              expect.objectContaining({ name: 'Askia' }),
+              expect.objectContaining({ name: 'Amina' }),
+            ]),
+            channel_structure: expect.objectContaining({
+              format: expect.stringContaining('Thought-leadership post'),
+            }),
+            visual_reinforcement: expect.objectContaining({
+              recommended_assets: expect.arrayContaining(['Framework illustration']),
+            }),
+          }),
           source_research_patterns: [
             expect.objectContaining({
               source_url: 'https://youtube.com/watch?v=abc',
@@ -171,6 +184,11 @@ describe('social content intelligence research-to-channel-approval workflow', ()
         youtube_shorts: expect.objectContaining({
           channel: 'youtube_shorts',
           approval_status: 'in_review',
+          orchestration_evidence: expect.objectContaining({
+            portfolio_surfaces: expect.arrayContaining([
+              expect.objectContaining({ route: '/admin/content/video-generation' }),
+            ]),
+          }),
           fields: expect.objectContaining({
             hook: 'AI should reduce burden.',
             render_readiness: 'pending_human_approval',
@@ -179,6 +197,11 @@ describe('social content intelligence research-to-channel-approval workflow', ()
         instagram_reels: expect.objectContaining({
           channel: 'instagram_reels',
           approval_status: 'in_review',
+          orchestration_evidence: expect.objectContaining({
+            visual_reinforcement: expect.objectContaining({
+              recommended_assets: expect.arrayContaining(['Cover frame']),
+            }),
+          }),
           fields: expect.objectContaining({
             export_readiness: 'pending_human_approval',
           }),
@@ -186,6 +209,11 @@ describe('social content intelligence research-to-channel-approval workflow', ()
         tiktok: expect.objectContaining({
           channel: 'tiktok',
           approval_status: 'in_review',
+          orchestration_evidence: expect.objectContaining({
+            voice_translation: expect.objectContaining({
+              avoid: expect.arrayContaining(['Generic AI hype.']),
+            }),
+          }),
           fields: expect.objectContaining({
             audio_rights: expect.stringContaining('platform-safe audio'),
           }),

--- a/lib/social-content-intelligence.test.ts
+++ b/lib/social-content-intelligence.test.ts
@@ -134,11 +134,36 @@ describe('social-content-intelligence', () => {
       cta: expect.stringContaining('Where have you seen AI'),
       visual_mode: 'carousel_or_framework_illustration_review',
     })
+    expect(drafts.linkedin.orchestration_evidence).toMatchObject({
+      agents: expect.arrayContaining([
+        expect.objectContaining({ name: 'Shaka' }),
+        expect.objectContaining({ name: 'Askia' }),
+        expect.objectContaining({ name: 'Amina' }),
+      ]),
+      channel_structure: expect.objectContaining({
+        format: expect.stringContaining('Thought-leadership post'),
+      }),
+      voice_translation: expect.objectContaining({
+        source: expect.stringContaining('Vambah personality corpus'),
+        avoid: expect.arrayContaining(['Generic AI hype.']),
+      }),
+      visual_reinforcement: expect.objectContaining({
+        recommended_assets: expect.arrayContaining(['Framework illustration', 'App screenshot carousel']),
+      }),
+    })
     expect(drafts.youtube_shorts.fields).toMatchObject({
       hook: 'AI should reduce burden.',
       first_30_seconds: expect.stringContaining('I noticed this through the social content review flow'),
       target_duration_seconds: 45,
       render_readiness: 'pending_human_approval',
+    })
+    expect(drafts.youtube_shorts.orchestration_evidence).toMatchObject({
+      portfolio_surfaces: expect.arrayContaining([
+        expect.objectContaining({ route: '/admin/content/video-generation' }),
+      ]),
+      visual_reinforcement: expect.objectContaining({
+        recommended_assets: expect.arrayContaining(['Portfolio b-roll', 'Thumbnail direction']),
+      }),
     })
     expect(drafts.instagram_reels.fields).toMatchObject({
       hook: 'AI should reduce burden.',
@@ -148,6 +173,9 @@ describe('social-content-intelligence', () => {
       ]),
       export_readiness: 'pending_human_approval',
     })
+    expect(drafts.instagram_reels.orchestration_evidence?.visual_reinforcement.recommended_assets).toEqual(
+      expect.arrayContaining(['Cover frame', 'Vertical proof b-roll']),
+    )
     expect(drafts.tiktok.fields).toMatchObject({
       hook: 'AI should reduce burden.',
       cover_frame: expect.any(String),
@@ -157,6 +185,9 @@ describe('social-content-intelligence', () => {
       ]),
       export_readiness: 'pending_human_approval',
     })
+    expect(drafts.tiktok.orchestration_evidence?.channel_structure.structure).toEqual(
+      expect.arrayContaining(['Use fast proof cuts from Portfolio surfaces.']),
+    )
     expect(drafts.linkedin.fields).not.toHaveProperty('first_30_seconds')
     expect(drafts.youtube_shorts.fields).not.toHaveProperty('post_text')
     expect(drafts.linkedin.side_effects).toEqual({

--- a/lib/social-content-intelligence.ts
+++ b/lib/social-content-intelligence.ts
@@ -49,6 +49,34 @@ export type SocialChannelReviewDraftPacket = {
   source_insight_title: string
   source_use_boundary: string
   fields: Record<string, unknown>
+  orchestration_evidence?: {
+    agents: Array<{
+      name: string
+      role: string
+      responsibility: string
+    }>
+    portfolio_surfaces: Array<{
+      label: string
+      route: string
+      purpose: string
+    }>
+    channel_structure: {
+      format: string
+      structure: string[]
+      success_criteria: string[]
+    }
+    voice_translation: {
+      source: string
+      principles: string[]
+      avoid: string[]
+    }
+    visual_reinforcement: {
+      recommended_assets: string[]
+      portfolio_snapshots: string[]
+      illustration_direction: string
+      privacy_notes: string[]
+    }
+  }
   source_research_patterns: Array<Record<string, unknown>>
   side_effects: {
     provider_generation: false
@@ -661,6 +689,190 @@ function reviewDraftSideEffects(): SocialChannelReviewDraftPacket['side_effects'
   }
 }
 
+function channelOrchestrationEvidence(input: {
+  channel: Exclude<SocialContentIntelligenceChannel, 'thumbnail'>
+  contentAngle: string
+  patternPromise: string
+}) {
+  const sharedAgents = [
+    {
+      name: 'Shaka',
+      role: 'Chief of Staff',
+      responsibility: 'Owns the central insight, campaign fit, backlog routing, and human approval path.',
+    },
+    {
+      name: 'Askia',
+      role: 'Research Analyst',
+      responsibility: 'Summarizes public creator/outlier patterns as reusable structures without copying source wording or visual identity.',
+    },
+    {
+      name: 'Amina',
+      role: 'Challenger Reviewer',
+      responsibility: 'Checks source distance, claim boundaries, channel fit, and whether the draft sounds like Vambah.',
+    },
+  ]
+  const sharedSurfaces = [
+    {
+      label: 'Content Intelligence',
+      route: '/admin/agents/content-intelligence',
+      purpose: 'Campaign calendar, research packets, and channel lane readiness.',
+    },
+    {
+      label: 'Agentic Dashboard Backlog',
+      route: '/admin/agents/coordination',
+      purpose: 'Central Shaka work item and approval state.',
+    },
+  ]
+  const voiceTranslation = {
+    source: 'Vambah personality corpus plus docs/linkedin-voice.md',
+    principles: [
+      'Open with a concrete triggering event or tension.',
+      'Make the operating system visible before making the claim.',
+      'Use plain, practical language with moral clarity.',
+      'Connect the personal builder authority to the useful takeaway.',
+      'End with a specific question, invitation, or next action.',
+    ],
+    avoid: [
+      'Generic AI hype.',
+      'Detached consulting jargon.',
+      'Copying creator scripts, titles, thumbnails, or visual identity.',
+      'Private Chronicle notes, raw chats, client records, credentials, or hidden admin data.',
+    ],
+  }
+  const sharedPrivacyNotes = [
+    'Use public-safe Portfolio/admin proof only.',
+    'Redact private names, client data, tokens, raw Chronicle notes, and personal account details.',
+    'Provider generation, upload, scheduling, and publishing remain separate approval gates.',
+  ]
+  const channelDetails: Record<Exclude<SocialContentIntelligenceChannel, 'thumbnail'>, {
+    format: string
+    structure: string[]
+    success_criteria: string[]
+    portfolio_surfaces: Array<{ label: string; route: string; purpose: string }>
+    recommended_assets: string[]
+    portfolio_snapshots: string[]
+    illustration_direction: string
+  }> = {
+    linkedin: {
+      format: 'Thought-leadership post with carousel or framework illustration support.',
+      structure: [
+        'Triggering event or tension in the first 210 characters.',
+        'Plain-language diagnosis of the operating problem.',
+        'Portfolio proof that shows the workflow, gate, or receipt.',
+        'Practical takeaway and specific response-driving CTA.',
+      ],
+      success_criteria: [
+        'Sounds like Vambah, not a generic company account.',
+        'Names the approval path and evidence without overclaiming autonomy.',
+        'Includes a visual mode recommendation tied to the argument.',
+      ],
+      portfolio_surfaces: [
+        ...sharedSurfaces,
+        {
+          label: 'Social Content Review',
+          route: '/admin/social-content',
+          purpose: 'LinkedIn copy, carousel/illustration, visual QA, and final platform submission gate.',
+        },
+      ],
+      recommended_assets: ['Framework illustration', 'App screenshot carousel', 'Source/evidence references'],
+      portfolio_snapshots: ['/admin/social-content', '/admin/agents/content-intelligence', '/admin/agents/coordination'],
+      illustration_direction: `Show the operating path behind the point: ${input.patternPromise || input.contentAngle}`,
+    },
+    youtube_shorts: {
+      format: 'Vertical short-form script with proof b-roll and render-readiness gate.',
+      structure: [
+        'Hook names the pain in the first 3 seconds.',
+        'Frame the missed operating layer.',
+        'Show proof through Portfolio b-roll or screen snapshots.',
+        'Close with a crisp principle or next action.',
+      ],
+      success_criteria: [
+        'The first 30 seconds include pain, authority, and proof.',
+        'B-roll is tied to storyboard beats.',
+        'Render readiness remains pending until human approval.',
+      ],
+      portfolio_surfaces: [
+        ...sharedSurfaces,
+        {
+          label: 'Video Generation',
+          route: '/admin/content/video-generation',
+          purpose: 'Script review, b-roll, render readiness, generated review, and evidence packet.',
+        },
+      ],
+      recommended_assets: ['Portfolio b-roll', 'Proof-screen snapshots', 'Thumbnail direction', 'Caption-safe on-screen text'],
+      portfolio_snapshots: ['/admin/content/video-generation', '/admin/agents/content-intelligence', '/admin/agents/coordination'],
+      illustration_direction: 'Use motion around the receipt path: source, challenger, approval, platform gate.',
+    },
+    instagram_reels: {
+      format: 'Vertical Reel with cover text, proof b-roll, and safe-area-aware captioning.',
+      structure: [
+        'Visual-first hook with cover text.',
+        'Short spoken or captioned setup of the pain.',
+        'One clear proof screen or b-roll moment.',
+        'Caption expands the practical takeaway.',
+      ],
+      success_criteria: [
+        'Cover text can stand without sound.',
+        'Proof is inspectable on mobile.',
+        'Caption preserves Vambah voice and does not read like a recycled LinkedIn post.',
+      ],
+      portfolio_surfaces: [
+        ...sharedSurfaces,
+        {
+          label: 'Visual Assets',
+          route: '/admin/content/visual-assets',
+          purpose: 'Cover image, b-roll, proof snapshots, and export-readiness review.',
+        },
+      ],
+      recommended_assets: ['Cover frame', 'Vertical proof b-roll', 'Caption-safe screenshots', 'Optional framework illustration crop'],
+      portfolio_snapshots: ['/admin/content/visual-assets', '/admin/content/video-generation', '/admin/agents/content-intelligence'],
+      illustration_direction: 'Create a clean cover frame that translates the proof into an AmaduTown visual cue.',
+    },
+    tiktok: {
+      format: 'Vertical short with direct hook, original narration, and platform-safe audio path.',
+      structure: [
+        'Start with the tension in plain language.',
+        'Use fast proof cuts from Portfolio surfaces.',
+        'Keep on-screen text short and central.',
+        'End with a question or principle that fits the platform.',
+      ],
+      success_criteria: [
+        'Audio rights are explicit before export.',
+        'The proof is understandable without exposing private admin data.',
+        'The hook is conversational, direct, and not overproduced.',
+      ],
+      portfolio_surfaces: [
+        ...sharedSurfaces,
+        {
+          label: 'Video Generation',
+          route: '/admin/content/video-generation',
+          purpose: 'Script, b-roll, audio rights, render readiness, and final review.',
+        },
+      ],
+      recommended_assets: ['Original narration', 'Platform-safe b-roll', 'First-frame cover', 'Caption-safe proof cuts'],
+      portfolio_snapshots: ['/admin/content/video-generation', '/admin/agents/content-intelligence', '/admin/agents/coordination'],
+      illustration_direction: 'Use quick proof cuts rather than a dense diagram; keep the operating path visible but simple.',
+    },
+  }
+  const detail = channelDetails[input.channel]
+  return {
+    agents: sharedAgents,
+    portfolio_surfaces: detail.portfolio_surfaces,
+    channel_structure: {
+      format: detail.format,
+      structure: detail.structure,
+      success_criteria: detail.success_criteria,
+    },
+    voice_translation: voiceTranslation,
+    visual_reinforcement: {
+      recommended_assets: detail.recommended_assets,
+      portfolio_snapshots: detail.portfolio_snapshots,
+      illustration_direction: detail.illustration_direction,
+      privacy_notes: sharedPrivacyNotes,
+    },
+  }
+}
+
 export function buildLinkedInYoutubeReviewDrafts(input: {
   insight: Record<string, unknown>
   generatedAt?: string
@@ -759,6 +971,11 @@ export function buildLinkedInYoutubeReviewDrafts(input: {
         ],
         claim_boundaries: claimBoundaries,
       },
+      orchestration_evidence: channelOrchestrationEvidence({
+        channel: 'linkedin',
+        contentAngle,
+        patternPromise,
+      }),
       source_research_patterns: patterns,
       side_effects: reviewDraftSideEffects(),
     },
@@ -781,6 +998,11 @@ export function buildLinkedInYoutubeReviewDrafts(input: {
         render_readiness: 'pending_human_approval',
         claim_boundaries: claimBoundaries,
       },
+      orchestration_evidence: channelOrchestrationEvidence({
+        channel: 'youtube_shorts',
+        contentAngle,
+        patternPromise,
+      }),
       source_research_patterns: patterns,
       side_effects: reviewDraftSideEffects(),
     },
@@ -808,6 +1030,11 @@ export function buildLinkedInYoutubeReviewDrafts(input: {
         export_readiness: 'pending_human_approval',
         claim_boundaries: claimBoundaries,
       },
+      orchestration_evidence: channelOrchestrationEvidence({
+        channel: 'instagram_reels',
+        contentAngle,
+        patternPromise,
+      }),
       source_research_patterns: patterns,
       side_effects: reviewDraftSideEffects(),
     },
@@ -836,6 +1063,11 @@ export function buildLinkedInYoutubeReviewDrafts(input: {
         export_readiness: 'pending_human_approval',
         claim_boundaries: claimBoundaries,
       },
+      orchestration_evidence: channelOrchestrationEvidence({
+        channel: 'tiktok',
+        contentAngle,
+        patternPromise,
+      }),
       source_research_patterns: patterns,
       side_effects: reviewDraftSideEffects(),
     },


### PR DESCRIPTION
## Summary
- Add per-channel orchestration evidence to social channel review draft packets: agents, Portfolio surfaces, channel structure, voice translation, and visual reinforcement guidance.
- Surface that evidence in the Social Insight channel tabs through a compact disclosure so LinkedIn, YouTube Shorts, Instagram Reels, and TikTok drafts show who/what/why before approval.
- Cover the packet and UI behavior with focused model, API, workflow, and page tests.

## Validation
- `npm test -- --run lib/social-content-intelligence.test.ts 'app/api/admin/agents/work-items/[id]/social-channels/prepare-review-drafts/route.test.ts' 'app/api/admin/agents/work-items/[id]/social-channels/workflow.test.ts' 'app/admin/agents/social-insights/[id]/page.test.tsx'`
- `npx tsc --noEmit --pretty false`
- `npm run lint` (passes; existing `<img>` warnings remain in unrelated files)
- Browser-equivalent smoke covered by the Social Insight React page test; no live authenticated admin browser smoke was run from this implementation lane.

## Integration Notes
- No migrations or env changes.
- No provider generation, uploads, schedules, publishing, or external posts are triggered by this change.
- Pre-push DB health hook skipped production row-count check because prod Supabase credentials are not set in this worktree.
- Integration Captain required for merge sequencing and deployment verification.
- Vercel contexts not checked from this implementation lane:
  - Vercel – portfolio
  - Vercel – portfolio-staging