### PR TITLE
feat: add social calibration comparison loop

### DIFF
--- a/app/admin/social-content/[id]/page.test.tsx
+++ b/app/admin/social-content/[id]/page.test.tsx
@@ -286,19 +286,120 @@ describe('SocialContentDetailRoute visual production review', () => {
     expect(await screen.findByText('Reusable calibration library')).toBeInTheDocument()
     const referenceCard = screen.getByText('Builder insight: production readiness').closest('.rounded-lg')
     expect(referenceCard).toBeTruthy()
-    fireEvent.click(within(referenceCard as HTMLElement).getByRole('button', { name: 'Add' }))
+    fireEvent.click(within(referenceCard as HTMLElement).getByRole('button', { name: 'Add fields' }))
 
     expect(screen.getByDisplayValue('Builder insight: production readiness (docs/linkedin-voice.md)')).toBeInTheDocument()
     expect(screen.getByDisplayValue(/Anyone can build an app right now/)).toBeInTheDocument()
     expect(screen.getByDisplayValue(/Approved voice-guide reference/)).toBeInTheDocument()
     expect(screen.getByDisplayValue('Do not overstate production readiness.')).toBeInTheDocument()
-    expect(within(referenceCard as HTMLElement).getByRole('button', { name: 'Added' })).toBeDisabled()
+    expect(within(referenceCard as HTMLElement).getByRole('button', { name: 'Added fields' })).toBeDisabled()
     expect(fetchMock).toHaveBeenCalledWith(
       expect.stringContaining('/api/admin/social-content/calibration-library?platform=linkedin'),
       expect.objectContaining({
         headers: { Authorization: 'Bearer admin-token' },
       }),
     )
+  })
+
+  it('lets the operator select a gold reference for Shaka comparison before revision', async () => {
+    const draftItem = {
+      ...baseItem,
+      status: 'draft',
+      reviewed_by: null,
+      post_text: 'This draft starts too generic and needs a stronger point of view.',
+    }
+    const goldReference = {
+      id: 'portfolio-social-gold-1',
+      platform: 'linkedin',
+      label: 'Gold standard · Founder operating lesson',
+      source_type: 'portfolio_content_history',
+      curation_status: 'gold_standard',
+      content_pillar: 'AI and product management',
+      post_excerpt: 'I learned the hard way that software only matters when it lowers the load.',
+      engagement_signal: 'Operator marked as a reusable gold-standard post. Strong comments from builders.',
+      why_it_worked: 'It opened from lived operational pressure before naming the framework.',
+      claim_boundaries: ['Keep the story source-safe.'],
+      provenance: 'Portfolio Social Content history',
+    }
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.includes('/calibration-library')) {
+        return {
+          ok: true,
+          json: async () => ({
+            references: [goldReference],
+            source: 'approved_calibration_library',
+            side_effects: {
+              provider_generation: false,
+              publish: false,
+              schedule: false,
+              external_post: false,
+            },
+          }),
+        } as Response
+      }
+      if (url.includes('/topic-backlog')) {
+        return {
+          ok: true,
+          json: async () => ({ items: [topicBacklogItem] }),
+        } as Response
+      }
+      if (url.includes('/calibration-revision')) {
+        return {
+          ok: true,
+          json: async () => ({
+            item: {
+              ...draftItem,
+              post_text: 'Revised draft shaped by the selected benchmark.',
+              rag_context: {
+                ...draftItem.rag_context,
+                content_calibration: {
+                  status: 'revision_generated',
+                },
+              },
+            },
+          }),
+        } as Response
+      }
+      if (init?.method === 'PUT') {
+        return {
+          ok: true,
+          json: async () => ({ item: draftItem }),
+        } as Response
+      }
+      return {
+        ok: true,
+        json: async () => ({ item: draftItem }),
+      } as Response
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderAtStep('context')
+
+    fireEvent.click(await screen.findByText('Content calibration'))
+    const referenceCard = await screen.findByText('Gold standard · Founder operating lesson')
+    fireEvent.click(within(referenceCard.closest('.rounded-lg') as HTMLElement).getByRole('button', { name: 'Compare' }))
+
+    expect(await screen.findByText('Side-by-side comparison packet')).toBeInTheDocument()
+    expect(screen.getByText(/including 1 gold-standard reference/)).toBeInTheDocument()
+    expect(screen.getByText(/This draft starts too generic/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /Revise with feedback/i }))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/api/admin/social-content/social-1/calibration-revision'),
+        expect.objectContaining({ method: 'POST' }),
+      )
+    })
+    const revisionCall = fetchMock.mock.calls.find(([url]) => String(url).includes('/calibration-revision'))
+    const revisionBody = JSON.parse(String(revisionCall?.[1]?.body))
+    expect(revisionBody.operator_feedback.comparison_reference_ids).toEqual(['portfolio-social-gold-1'])
+    expect(revisionBody.operator_feedback.comparison_brief).toContain('Gold standard · Founder operating lesson')
+    expect(revisionBody.operator_feedback.success_examples[0]).toMatchObject({
+      reference_id: 'portfolio-social-gold-1',
+      curation_status: 'gold_standard',
+    })
   })
 
   it('lets the operator mark an approved post as a gold-standard calibration reference', async () => {

--- a/app/admin/social-content/[id]/page.tsx
+++ b/app/admin/social-content/[id]/page.tsx
@@ -189,6 +189,8 @@ type CalibrationFeedback = {
 }
 
 type CalibrationSuccessExample = {
+  reference_id?: string
+  curation_status?: string
   source_label: string
   post_excerpt: string
   engagement_signal: string
@@ -223,10 +225,12 @@ const EMPTY_CALIBRATION_FEEDBACK: CalibrationFeedback = {
 function normalizeSuccessExamples(value: unknown, fallbackExcerpt = '', fallbackEngagement = ''): CalibrationSuccessExample[] {
   const examples = Array.isArray(value)
     ? value
-        .map((item) => {
+        .map((item): CalibrationSuccessExample | null => {
           const record = asRecord(item)
           if (!record) return null
           return {
+            reference_id: asString(record.reference_id),
+            curation_status: asString(record.curation_status),
             source_label: asString(record.source_label),
             post_excerpt: asString(record.post_excerpt),
             engagement_signal: asString(record.engagement_signal),
@@ -331,6 +335,7 @@ function SocialContentDetailPage() {
     linkedin_draft: false,
   })
   const [calibrationLibraryReferences, setCalibrationLibraryReferences] = useState<SocialContentCalibrationReference[]>([])
+  const [selectedComparisonReferenceIds, setSelectedComparisonReferenceIds] = useState<string[]>([])
   const [loadingCalibrationLibrary, setLoadingCalibrationLibrary] = useState(false)
   const [calibrationLibraryUnavailable, setCalibrationLibraryUnavailable] = useState(false)
   const rejectedGateKeysRef = useRef<SectionGateKey[]>([])
@@ -434,6 +439,7 @@ function SocialContentDetailPage() {
           revision_request: asString(operatorFeedback?.revision_request),
           claim_boundaries: asString(operatorFeedback?.claim_boundaries),
         })
+        setSelectedComparisonReferenceIds(asStringArray(operatorFeedback?.comparison_reference_ids))
         setCopyRevisionRequest(asString(operatorFeedback?.revision_request))
       }
     } catch (err) {
@@ -466,6 +472,14 @@ function SocialContentDetailPage() {
     setTimeout(() => setMessage(null), 4000)
   }
 
+  const toggleCalibrationComparisonReference = (reference: SocialContentCalibrationReference) => {
+    setSelectedComparisonReferenceIds((current) => (
+      current.includes(reference.id)
+        ? current.filter((id) => id !== reference.id)
+        : [...current, reference.id].slice(0, 3)
+    ))
+  }
+
   const addCalibrationLibraryReference = (reference: SocialContentCalibrationReference) => {
     setCalibrationFeedback((current) => {
       const sourceLabel = `${reference.label} (${reference.provenance})`
@@ -476,6 +490,8 @@ function SocialContentDetailPage() {
       if (alreadyAdded) return current
 
       const nextExample: CalibrationSuccessExample = {
+        reference_id: reference.id,
+        curation_status: reference.curation_status,
         source_label: sourceLabel,
         post_excerpt: reference.post_excerpt,
         engagement_signal: reference.engagement_signal,
@@ -618,8 +634,20 @@ function SocialContentDetailPage() {
   }
 
   const buildOperatorFeedback = (revisionRequestOverride = calibrationFeedback.revision_request) => {
+    const selectedReferenceExamples = calibrationLibraryReferences
+      .filter((reference) => selectedComparisonReferenceIds.includes(reference.id))
+      .map((reference) => ({
+        reference_id: reference.id,
+        curation_status: reference.curation_status,
+        source_label: `${reference.label} (${reference.provenance})`,
+        post_excerpt: reference.post_excerpt,
+        engagement_signal: reference.engagement_signal,
+        why_it_worked: reference.why_it_worked,
+      }))
     const successExamples = calibrationFeedback.success_examples
       .map((example) => ({
+        reference_id: example.reference_id?.trim(),
+        curation_status: example.curation_status?.trim(),
         source_label: example.source_label.trim(),
         post_excerpt: example.post_excerpt.trim(),
         engagement_signal: example.engagement_signal.trim(),
@@ -631,11 +659,28 @@ function SocialContentDetailPage() {
         || example.engagement_signal
         || example.why_it_worked
       ))
-    const structuredPriorPostExcerpt = formatSuccessExamplesForPrompt(successExamples)
+    const mergedSuccessExamples = [...successExamples]
+    selectedReferenceExamples.forEach((selectedExample) => {
+      const alreadyIncluded = mergedSuccessExamples.some((example) => (
+        example.reference_id === selectedExample.reference_id
+        || example.source_label === selectedExample.source_label
+      ))
+      if (!alreadyIncluded) mergedSuccessExamples.push(selectedExample)
+    })
+    const comparisonLines = selectedReferenceExamples.map((example, index) => [
+      `Reference ${index + 1}: ${example.source_label}`,
+      example.why_it_worked ? `Why it worked: ${example.why_it_worked}` : '',
+      example.engagement_signal ? `Signal: ${example.engagement_signal}` : '',
+    ].filter(Boolean).join('\n'))
+    const structuredPriorPostExcerpt = formatSuccessExamplesForPrompt(mergedSuccessExamples)
     return {
       triggering_event: calibrationFeedback.triggering_event.trim(),
       prior_post_excerpt: structuredPriorPostExcerpt || calibrationFeedback.prior_post_excerpt.trim(),
-      success_examples: successExamples,
+      success_examples: mergedSuccessExamples,
+      comparison_reference_ids: selectedReferenceExamples
+        .map((example) => example.reference_id)
+        .filter((referenceId): referenceId is string => Boolean(referenceId)),
+      comparison_brief: comparisonLines.join('\n\n'),
       engagement_signal: calibrationFeedback.engagement_signal.trim(),
       audience_context: calibrationFeedback.audience_context.trim(),
       revision_request: revisionRequestOverride.trim(),
@@ -968,13 +1013,14 @@ function SocialContentDetailPage() {
       const session = await getCurrentSession()
       if (!session) return
 
+      const feedback = buildOperatorFeedback()
       const res = await fetch(`/api/admin/social-content/${id}/calibration-revision`, {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${session.access_token}`,
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ operator_feedback: calibrationFeedback }),
+        body: JSON.stringify({ operator_feedback: feedback }),
       })
 
       const data = await res.json()
@@ -1501,6 +1547,16 @@ function SocialContentDetailPage() {
     { label: 'Privacy/redaction review', value: redactionGate.ready ? 'ready' : `${redactionGate.unresolvedItems.length} unresolved` },
     { label: 'Visual QA', value: productionAssets.visual_qa.status.replace(/_/g, ' ') },
   ] : []
+  const selectedComparisonReferences = calibrationLibraryReferences
+    .filter((reference) => selectedComparisonReferenceIds.includes(reference.id))
+  const selectedGoldComparisonCount = selectedComparisonReferences
+    .filter((reference) => reference.curation_status === 'gold_standard')
+    .length
+  const currentDraftComparisonExcerpt = (postText || item?.post_text || '')
+    .trim()
+    .split(/\n{2,}/)[0]
+    ?.slice(0, 360)
+    || 'No draft text available yet.'
   const hasCalibrationSuccessExampleInput = calibrationFeedback.success_examples
     .some((example) => (
       example.source_label.trim()
@@ -1509,6 +1565,7 @@ function SocialContentDetailPage() {
       || example.why_it_worked.trim()
     ))
   const hasCalibrationFeedbackInput = hasCalibrationSuccessExampleInput
+    || selectedComparisonReferences.length > 0
     || calibrationFeedback.triggering_event.trim().length > 0
     || calibrationFeedback.prior_post_excerpt.trim().length > 0
     || calibrationFeedback.engagement_signal.trim().length > 0
@@ -2245,7 +2302,7 @@ function SocialContentDetailPage() {
                           <div>
                             <p className="text-xs font-semibold uppercase tracking-[0.14em] text-emerald-200">Reusable calibration library</p>
                             <p className="mt-1 text-sm leading-6 text-emerald-50/80">
-                              Add approved voice patterns as comparison material. These are draft-only references, not publishing instructions.
+                              Select up to three approved voice patterns for Shaka to compare against, then add any that need manual editing.
                             </p>
                           </div>
                           {loadingCalibrationLibrary && (
@@ -2272,12 +2329,14 @@ function SocialContentDetailPage() {
                               const alreadyAdded = calibrationFeedback.success_examples.some((example) => (
                                 example.source_label.trim() === sourceLabel
                                 || example.source_label.trim() === reference.label
+                                || example.reference_id === reference.id
                               ))
                               const isGoldStandardReference = reference.curation_status === 'gold_standard'
+                              const selectedForComparison = selectedComparisonReferenceIds.includes(reference.id)
                               return (
                                 <div
                                   key={reference.id}
-                                  className={`rounded-lg border p-3 ${isGoldStandardReference ? 'border-amber-400/35 bg-amber-500/10' : 'border-emerald-400/20 bg-background/35'}`}
+                                  className={`rounded-lg border p-3 ${selectedForComparison ? 'border-amber-300/60 bg-amber-500/10' : isGoldStandardReference ? 'border-amber-400/35 bg-amber-500/10' : 'border-emerald-400/20 bg-background/35'}`}
                                 >
                                   <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
                                     <div className="min-w-0">
@@ -2294,15 +2353,26 @@ function SocialContentDetailPage() {
                                         {reference.content_pillar}
                                       </p>
                                     </div>
-                                    <button
-                                      type="button"
-                                      onClick={() => addCalibrationLibraryReference(reference)}
-                                      disabled={!isEditable || alreadyAdded}
-                                      className="inline-flex shrink-0 items-center justify-center gap-1 rounded-lg border border-emerald-400/35 px-2.5 py-1.5 text-xs font-semibold text-emerald-100 transition-colors hover:bg-emerald-500/10 disabled:opacity-50"
-                                    >
-                                      {alreadyAdded ? <CheckCircle2 className="h-3 w-3" /> : <Plus className="h-3 w-3" />}
-                                      {alreadyAdded ? 'Added' : 'Add'}
-                                    </button>
+                                    <div className="flex shrink-0 flex-wrap gap-2">
+                                      <button
+                                        type="button"
+                                        onClick={() => toggleCalibrationComparisonReference(reference)}
+                                        disabled={!isEditable || (!selectedForComparison && selectedComparisonReferenceIds.length >= 3)}
+                                        className={`inline-flex items-center justify-center gap-1 rounded-lg border px-2.5 py-1.5 text-xs font-semibold transition-colors disabled:opacity-50 ${selectedForComparison ? 'border-amber-300/55 bg-amber-400 text-slate-950' : 'border-amber-400/35 text-amber-100 hover:bg-amber-500/10'}`}
+                                      >
+                                        {selectedForComparison ? <CheckCircle2 className="h-3 w-3" /> : <Star className="h-3 w-3" />}
+                                        {selectedForComparison ? 'Comparing' : 'Compare'}
+                                      </button>
+                                      <button
+                                        type="button"
+                                        onClick={() => addCalibrationLibraryReference(reference)}
+                                        disabled={!isEditable || alreadyAdded}
+                                        className="inline-flex items-center justify-center gap-1 rounded-lg border border-emerald-400/35 px-2.5 py-1.5 text-xs font-semibold text-emerald-100 transition-colors hover:bg-emerald-500/10 disabled:opacity-50"
+                                      >
+                                        {alreadyAdded ? <CheckCircle2 className="h-3 w-3" /> : <Plus className="h-3 w-3" />}
+                                        {alreadyAdded ? 'Added fields' : 'Add fields'}
+                                      </button>
+                                    </div>
                                   </div>
                                   <p className="mt-2 line-clamp-3 text-xs leading-5 text-emerald-50/75">
                                     {reference.why_it_worked}
@@ -2315,6 +2385,45 @@ function SocialContentDetailPage() {
                             })}
                           </div>
                         )}
+                      </div>
+                    )}
+                    {selectedComparisonReferences.length > 0 && (
+                      <div className="mt-3 rounded-lg border border-amber-400/30 bg-amber-500/5 p-3">
+                        <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                          <div>
+                            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-amber-200">Side-by-side comparison packet</p>
+                            <p className="mt-1 text-sm leading-6 text-amber-50/80">
+                              Shaka will compare this draft against {selectedComparisonReferences.length} selected benchmark{selectedComparisonReferences.length === 1 ? '' : 's'}{selectedGoldComparisonCount ? `, including ${selectedGoldComparisonCount} gold-standard reference${selectedGoldComparisonCount === 1 ? '' : 's'}` : ''}.
+                            </p>
+                          </div>
+                          <span className="w-fit rounded-full border border-amber-300/35 px-3 py-1 text-xs text-amber-100">
+                            Draft-only critique
+                          </span>
+                        </div>
+                        <div className="mt-3 grid gap-3 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+                          <div className="rounded-lg border border-silicon-slate/70 bg-background/35 p-3">
+                            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-gray-500">Current draft opening</p>
+                            <p className="mt-2 text-sm leading-6 text-gray-200">{currentDraftComparisonExcerpt}</p>
+                          </div>
+                          <div className="space-y-2">
+                            {selectedComparisonReferences.map((reference) => (
+                              <div key={reference.id} className="rounded-lg border border-amber-300/20 bg-background/35 p-3">
+                                <div className="flex flex-wrap items-center justify-between gap-2">
+                                  <p className="text-sm font-semibold text-amber-50">{reference.label}</p>
+                                  <button
+                                    type="button"
+                                    onClick={() => toggleCalibrationComparisonReference(reference)}
+                                    className="inline-flex items-center rounded-full border border-amber-300/30 px-2.5 py-1 text-xs font-semibold text-amber-100 transition-colors hover:bg-amber-500/10"
+                                  >
+                                    Remove
+                                  </button>
+                                </div>
+                                <p className="mt-2 text-xs leading-5 text-amber-50/75">{reference.why_it_worked}</p>
+                                <p className="mt-1 text-[11px] leading-5 text-amber-50/55">{reference.engagement_signal}</p>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
                       </div>
                     )}
                     <div className="mt-3 grid gap-3">

--- a/app/api/admin/social-content/[id]/calibration-revision/route.test.ts
+++ b/app/api/admin/social-content/[id]/calibration-revision/route.test.ts
@@ -221,6 +221,60 @@ describe('POST /api/admin/social-content/[id]/calibration-revision', () => {
     }))
   })
 
+  it('preserves selected comparison references in the revision prompt and receipt', async () => {
+    const response = await POST(request({
+      operator_feedback: {
+        triggering_event: 'A draft review showed the post needed to sound more like prior operator-facing posts.',
+        comparison_reference_ids: ['portfolio-social-gold-1'],
+        comparison_brief: 'Reference 1: Gold standard founder lesson\nWhy it worked: It opened from operational pressure.',
+        success_examples: [
+          {
+            reference_id: 'portfolio-social-gold-1',
+            curation_status: 'gold_standard',
+            source_label: 'Gold standard founder lesson',
+            post_excerpt: 'Software only matters when it lowers the load.',
+            engagement_signal: 'Operator marked as reusable.',
+            why_it_worked: 'It opened from operational pressure.',
+          },
+        ],
+        revision_request: 'Revise against the selected benchmark.',
+      },
+    }), { params: { id: 'social-1' } })
+
+    expect(response.status).toBe(200)
+    expect(mocks.generateJsonCompletion).toHaveBeenCalledWith(expect.objectContaining({
+      userPrompt: expect.stringContaining('Selected benchmark reference ids:'),
+    }))
+    expect(mocks.generateJsonCompletion).toHaveBeenCalledWith(expect.objectContaining({
+      userPrompt: expect.stringContaining('portfolio-social-gold-1'),
+    }))
+    expect(mocks.update).toHaveBeenCalledWith(expect.objectContaining({
+      rag_context: expect.objectContaining({
+        content_calibration: expect.objectContaining({
+          operator_feedback: expect.objectContaining({
+            comparison_reference_ids: ['portfolio-social-gold-1'],
+            comparison_brief: expect.stringContaining('Gold standard founder lesson'),
+            success_examples: [
+              expect.objectContaining({
+                reference_id: 'portfolio-social-gold-1',
+                curation_status: 'gold_standard',
+              }),
+            ],
+          }),
+          latest_revision: expect.objectContaining({
+            comparison_reference_ids: ['portfolio-social-gold-1'],
+            comparison_brief: expect.stringContaining('Gold standard founder lesson'),
+            shaka_understanding: expect.objectContaining({
+              planned_changes: expect.arrayContaining([
+                'Use the selected benchmark references as the primary side-by-side comparison before rewriting.',
+              ]),
+            }),
+          }),
+        }),
+      }),
+    }))
+  })
+
   it('creates calibration metadata from operator feedback when the draft has none', async () => {
     mocks.single.mockResolvedValueOnce({
       data: {

--- a/app/api/admin/social-content/[id]/calibration-revision/route.ts
+++ b/app/api/admin/social-content/[id]/calibration-revision/route.ts
@@ -49,6 +49,8 @@ function asRecordArray(value: unknown): Record<string, unknown>[] {
 function normalizeSuccessExamples(value: unknown) {
   return asRecordArray(value)
     .map((item) => ({
+      reference_id: asString(item.reference_id).trim(),
+      curation_status: asString(item.curation_status).trim(),
       source_label: asString(item.source_label).trim(),
       post_excerpt: asString(item.post_excerpt).trim(),
       engagement_signal: asString(item.engagement_signal).trim(),
@@ -65,6 +67,7 @@ function normalizeSuccessExamples(value: unknown) {
 function hasOperatorFeedback(feedback: Record<string, unknown> | null): boolean {
   if (!feedback) return false
   if (normalizeSuccessExamples(feedback.success_examples).length > 0) return true
+  if (asStringArray(feedback.comparison_reference_ids).length > 0) return true
   return [
     'triggering_event',
     'prior_post_excerpt',
@@ -72,6 +75,7 @@ function hasOperatorFeedback(feedback: Record<string, unknown> | null): boolean 
     'audience_context',
     'revision_request',
     'claim_boundaries',
+    'comparison_brief',
   ].some((key) => Boolean(asString(feedback[key]).trim()))
 }
 
@@ -87,6 +91,8 @@ function buildRevisionUnderstanding(feedback: Record<string, unknown> | null) {
   const audienceContext = asString(feedback?.audience_context).trim()
   const engagementSignal = asString(feedback?.engagement_signal).trim()
   const priorPostExcerpt = asString(feedback?.prior_post_excerpt).trim()
+  const comparisonBrief = asString(feedback?.comparison_brief).trim()
+  const comparisonReferenceIds = asStringArray(feedback?.comparison_reference_ids)
   const successExamples = normalizeSuccessExamples(feedback?.success_examples)
   const combined = [
     revisionRequest,
@@ -95,6 +101,7 @@ function buildRevisionUnderstanding(feedback: Record<string, unknown> | null) {
     audienceContext,
     engagementSignal,
     priorPostExcerpt,
+    comparisonBrief,
     successExamples.map((example) => [
       example.source_label,
       example.post_excerpt,
@@ -109,6 +116,9 @@ function buildRevisionUnderstanding(feedback: Record<string, unknown> | null) {
   if (audienceContext) plannedChanges.push(`Tune audience and desired reaction: ${audienceContext}`)
   if (engagementSignal || successExamples.length > 0 || priorPostExcerpt) {
     plannedChanges.push('Compare the draft against the saved successful-post references and engagement signals.')
+  }
+  if (comparisonReferenceIds.length > 0 || comparisonBrief) {
+    plannedChanges.push('Use the selected benchmark references as the primary side-by-side comparison before rewriting.')
   }
   if (includesAny(combined, ['anecdote', 'story', 'scene', 'example'])) {
     plannedChanges.push('Add or strengthen a concrete anecdote before the broader point.')
@@ -148,6 +158,8 @@ function buildRevisionPrompt(row: SocialContentRow) {
   const calibration = asRecord(ragContext.content_calibration) ?? {}
   const feedback = asRecord(calibration.operator_feedback) ?? {}
   const successExamples = normalizeSuccessExamples(feedback.success_examples)
+  const comparisonReferenceIds = asStringArray(feedback.comparison_reference_ids)
+  const comparisonBrief = asString(feedback.comparison_brief).trim()
   const priorPatterns = Array.isArray(calibration.prior_success_patterns)
     ? calibration.prior_success_patterns
     : []
@@ -200,6 +212,12 @@ ${JSON.stringify(priorPatterns, null, 2)}
 
 Operator-provided successful post references:
 ${JSON.stringify(successExamples, null, 2)}
+
+Selected benchmark reference ids:
+${comparisonReferenceIds.map((item) => `- ${item}`).join('\n')}
+
+Side-by-side comparison brief:
+${comparisonBrief}
 
 Voice principles:
 ${voicePrinciples.map((item) => `- ${item}`).join('\n')}
@@ -294,6 +312,8 @@ export async function POST(
         triggering_event: asString(requestedFeedback?.triggering_event).trim(),
         prior_post_excerpt: asString(requestedFeedback?.prior_post_excerpt).trim(),
         success_examples: requestedSuccessExamples,
+        comparison_reference_ids: asStringArray(requestedFeedback?.comparison_reference_ids),
+        comparison_brief: asString(requestedFeedback?.comparison_brief).trim(),
         engagement_signal: asString(requestedFeedback?.engagement_signal).trim(),
         audience_context: asString(requestedFeedback?.audience_context).trim(),
         revision_request: asString(requestedFeedback?.revision_request).trim(),
@@ -352,6 +372,8 @@ Additional role: You are Shaka, the Agent Ops Chief of Staff. Use the operator f
       revision_notes: revision.revision_notes,
       operator_request: asString(operatorFeedback?.revision_request) || null,
       operator_triggering_event: asString(operatorFeedback?.triggering_event) || null,
+      comparison_reference_ids: asStringArray(operatorFeedback?.comparison_reference_ids),
+      comparison_brief: asString(operatorFeedback?.comparison_brief) || null,
       shaka_understanding: revisionUnderstanding,
       operator_feedback_updated_at: asString(operatorFeedback?.updated_at) || null,
     }


### PR DESCRIPTION
## Summary
- Adds a side-by-side comparison loop to Agent Ops Social Content calibration.
- Lets operators select up to three reusable calibration references as Shaka benchmark targets without dumping every reference into manual fields.
- Shows a visible comparison packet with the current draft opening and selected benchmark lessons before revision.
- Persists selected benchmark IDs and comparison briefs through the calibration revision endpoint and Shaka revision receipt.
- No schema migration; metadata stays in existing `rag_context.content_calibration.operator_feedback` and revision history.

## Validation
- `npm test -- app/api/admin/social-content/calibration-library/route.test.ts 'app/api/admin/social-content/[id]/calibration-revision/route.test.ts' 'app/admin/social-content/[id]/page.test.tsx'`
- `npm run build:knowledge && npx tsc --noEmit --pretty false`
- `git diff --check`
- `npm run lint` (passed with existing `<img>` warnings in `app/client/dashboard/[token]/page.tsx` and `components/Navigation.test.tsx`)
- `npm run build` (passed with existing local n8n outbound warning and existing `<img>` warnings)
- Local browser smoke on `http://localhost:3027/admin/social-content/ef3f5046-6796-4fa4-bdda-ab73b4106543?step=context`: selected a benchmark reference and verified the side-by-side comparison packet. Did not trigger Shaka revision or mutate live content during smoke.
- Push hook database health check passed.

## Integration Notes
- No database migration.
- No autonomous publish, schedule, DM, provider generation, external post, deploy, or production mutation.
- Vercel – portfolio: pending PR check.
- Vercel – portfolio-staging: pending PR check.
