### PR TITLE
feat: expand agentic rollout platform calendar

### DIFF
--- a/lib/admin-demo-seed.test.ts
+++ b/lib/admin-demo-seed.test.ts
@@ -3,6 +3,9 @@ import {
   ACCELERATED_WORKSHOP_CAMPAIGN_FIXTURE_KEY,
   ACCELERATED_WORKSHOP_CAMPAIGN_FIXTURE_SLUG,
   ACCELERATED_WORKSHOP_CAMPAIGN_IDEMPOTENCY_PREFIX,
+  AGENTIC_BOOK_ROLLOUT_CAMPAIGN_FIXTURE_KEY,
+  AGENTIC_BOOK_ROLLOUT_CAMPAIGN_FIXTURE_SLUG,
+  AGENTIC_BOOK_ROLLOUT_CAMPAIGN_IDEMPOTENCY_PREFIX,
   isDemoSeedKey,
   runDemoSeed,
   SOCIAL_CHANNEL_REVIEW_FIXTURE_IDEMPOTENCY_KEY,
@@ -453,6 +456,228 @@ describe('admin demo seed', () => {
         calendar_item_role: 'companion_channel_item',
         primary_channel: 'linkedin',
         channel_draft_targets: ['youtube_shorts', 'instagram_reels', 'tiktok', 'thumbnail'],
+      })
+    })
+  })
+
+  it('creates the Agentic rollout fixture with platform-specific calendar rows and strategy evidence', async () => {
+    const inserts: Record<string, unknown[]> = {}
+    const deletes: Array<{ table: string; matcher: string }> = []
+
+    const supabase = {
+      from: vi.fn((table: string) => {
+        if (table === 'attraction_campaigns') {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+              })),
+            })),
+            delete: vi.fn(() => ({
+              eq: vi.fn(async (_column: string, matcher: string) => {
+                deletes.push({ table, matcher })
+                return { data: [], error: null }
+              }),
+            })),
+            insert: vi.fn((row: Record<string, unknown>) => {
+              inserts[table] = [row]
+              return {
+                select: vi.fn(() => ({
+                  single: vi.fn(async () => ({
+                    data: {
+                      id: 'campaign-agentic-1',
+                      name: row.name,
+                      slug: row.slug,
+                      starts_at: row.starts_at,
+                      ends_at: row.ends_at,
+                    },
+                    error: null,
+                  })),
+                })),
+              }
+            }),
+          }
+        }
+
+        if (table === 'social_content_research_packets') {
+          return {
+            delete: vi.fn(() => ({
+              contains: vi.fn(async (_column: string, matcher: Record<string, unknown>) => {
+                deletes.push({ table, matcher: String(matcher.demo_seed_key) })
+                return { data: [], error: null }
+              }),
+            })),
+            insert: vi.fn((row: Record<string, unknown>) => {
+              inserts[table] = [row]
+              return {
+                select: vi.fn(() => ({
+                  single: vi.fn(async () => ({
+                    data: { id: 'packet-agentic-1' },
+                    error: null,
+                  })),
+                })),
+              }
+            }),
+          }
+        }
+
+        if (table === 'agent_work_items') {
+          return {
+            delete: vi.fn(() => ({
+              like: vi.fn(async (_column: string, matcher: string) => {
+                deletes.push({ table, matcher })
+                return { data: [], error: null }
+              }),
+            })),
+            insert: vi.fn((payload: unknown[] | Record<string, unknown>) => {
+              const rows = Array.isArray(payload) ? payload : [payload]
+              inserts[table] = [...(inserts[table] ?? []), ...rows]
+              if (!Array.isArray(payload)) {
+                return {
+                  select: vi.fn(() => ({
+                    single: vi.fn(async () => ({
+                      data: { id: 'work-agentic-goal' },
+                      error: null,
+                    })),
+                  })),
+                }
+              }
+              return {
+                select: vi.fn(async () => ({
+                  data: rows.map((row, index) => ({
+                    id: `work-agentic-${index + 1}`,
+                    metadata: (row as Record<string, unknown>).metadata,
+                  })),
+                  error: null,
+                })),
+              }
+            }),
+          }
+        }
+
+        if (table === 'social_content_calendar_items') {
+          return {
+            delete: vi.fn(() => ({
+              contains: vi.fn(async (_column: string, matcher: Record<string, unknown>) => {
+                deletes.push({ table, matcher: String(matcher.demo_seed_key) })
+                return { data: [], error: null }
+              }),
+              eq: vi.fn(async (_column: string, matcher: string) => {
+                deletes.push({ table, matcher })
+                return { data: [], error: null }
+              }),
+            })),
+            insert: vi.fn(async (rows: unknown[]) => {
+              inserts[table] = rows
+              return { error: null }
+            }),
+          }
+        }
+
+        throw new Error(`Unexpected table ${table}`)
+      }),
+    }
+
+    const result = await runDemoSeed('agentic_book_rollout_campaign_fixture', supabase as never)
+
+    expect(result).toMatchObject({
+      ok: true,
+      key: 'agentic_book_rollout_campaign_fixture',
+    })
+    expect(isDemoSeedKey('agentic_book_rollout_campaign_fixture')).toBe(true)
+    expect(deletes).toEqual(expect.arrayContaining([
+      { table: 'agent_work_items', matcher: `${AGENTIC_BOOK_ROLLOUT_CAMPAIGN_IDEMPOTENCY_PREFIX}:%` },
+      { table: 'social_content_research_packets', matcher: AGENTIC_BOOK_ROLLOUT_CAMPAIGN_FIXTURE_KEY },
+    ]))
+
+    expect(inserts.attraction_campaigns[0]).toMatchObject({
+      name: 'Agentic Book Rollout Whisper-to-Shout Campaign',
+      slug: AGENTIC_BOOK_ROLLOUT_CAMPAIGN_FIXTURE_SLUG,
+      status: 'draft',
+    })
+
+    const allWorkItems = inserts.agent_work_items as Array<Record<string, unknown>>
+    expect(allWorkItems).toHaveLength(5)
+    expect(allWorkItems[0]).toMatchObject({
+      title: 'Launch Agentic book rollout campaign',
+      source_type: 'campaign_goal',
+      idempotency_key: `${AGENTIC_BOOK_ROLLOUT_CAMPAIGN_IDEMPOTENCY_PREFIX}:goal`,
+    })
+
+    const workItems = allWorkItems.slice(1)
+    workItems.forEach((item) => {
+      const metadata = item.metadata as Record<string, unknown>
+      const lanes = metadata.channel_lanes as Record<string, Record<string, unknown>>
+      expect(metadata).toMatchObject({
+        demo_seed_key: AGENTIC_BOOK_ROLLOUT_CAMPAIGN_FIXTURE_KEY,
+        campaign_template_key: 'whisper_to_shout',
+        campaign_window_days: 14,
+        side_effects: {
+          provider_generation: false,
+          upload: false,
+          publish: false,
+          schedule: false,
+          external_post: false,
+        },
+      })
+      expect(lanes.linkedin.status).toBe('in_review')
+      expect(lanes.youtube_shorts.status).toBe('in_review')
+      expect(lanes.instagram_reels.status).toBe('in_review')
+      expect(lanes.tiktok.status).toBe('in_review')
+      expect(lanes.thumbnail.status).toBe('in_review')
+      expect((lanes.thumbnail.draft_packet as Record<string, unknown>).orchestration_evidence).toMatchObject({
+        agents: expect.arrayContaining([
+          expect.objectContaining({ name: 'Shaka' }),
+          expect.objectContaining({ name: 'Askia' }),
+          expect.objectContaining({ name: 'Amina' }),
+        ]),
+        visual_reinforcement: expect.objectContaining({
+          recommended_assets: expect.arrayContaining(['Agent Ops proof screenshot', 'AmaduTown shield']),
+        }),
+      })
+    })
+
+    const calendarRows = inserts.social_content_calendar_items as Array<Record<string, unknown>>
+    expect(calendarRows).toHaveLength(20)
+    expect(calendarRows.map((row) => row.channel)).toEqual([
+      'linkedin',
+      'youtube_shorts',
+      'instagram_reels',
+      'tiktok',
+      'thumbnail',
+      'linkedin',
+      'youtube_shorts',
+      'instagram_reels',
+      'tiktok',
+      'thumbnail',
+      'linkedin',
+      'youtube_shorts',
+      'instagram_reels',
+      'tiktok',
+      'thumbnail',
+      'linkedin',
+      'youtube_shorts',
+      'instagram_reels',
+      'tiktok',
+      'thumbnail',
+    ])
+    expect(calendarRows.filter((row) => row.channel === 'instagram_reels')).toHaveLength(4)
+    expect(calendarRows.filter((row) => row.channel === 'tiktok')).toHaveLength(4)
+    expect(calendarRows.filter((row) => row.channel === 'thumbnail')).toHaveLength(4)
+    calendarRows.forEach((row) => {
+      expect(row).toMatchObject({
+        campaign_id: 'campaign-agentic-1',
+        authorization_status: 'pending',
+        autonomy_eligible: false,
+      })
+      expect(row.metadata).toMatchObject({
+        demo_seed_key: AGENTIC_BOOK_ROLLOUT_CAMPAIGN_FIXTURE_KEY,
+        campaign_template_key: 'whisper_to_shout',
+        external_execution_enabled: false,
+        provider_generation_enabled: false,
+        upload_enabled: false,
+        publish_enabled: false,
+        schedule_enabled: false,
       })
     })
   })

--- a/lib/admin-demo-seed.ts
+++ b/lib/admin-demo-seed.ts
@@ -649,6 +649,77 @@ function agenticBookRolloutThumbnailPacket(input: {
       ],
       approval_state: 'in_review',
     },
+    orchestration_evidence: {
+      agents: [
+        {
+          name: 'Shaka',
+          role: 'Chief of Staff',
+          responsibility: 'Keeps the thumbnail tied to the central Agentic rollout insight and campaign calendar.',
+        },
+        {
+          name: 'Askia',
+          role: 'Research Analyst',
+          responsibility: 'Translates public creator thumbnail patterns into reusable structure without copying artwork.',
+        },
+        {
+          name: 'Amina',
+          role: 'Challenger Reviewer',
+          responsibility: 'Checks source distance, claim boundaries, privacy, and AmaduTown brand fit before approval.',
+        },
+      ],
+      portfolio_surfaces: [
+        {
+          label: 'Content Intelligence',
+          route: '/admin/agents/content-intelligence',
+          purpose: 'Campaign phase, research packet, and channel lane readiness.',
+        },
+        {
+          label: 'Visual Assets',
+          route: '/admin/content/visual-assets',
+          purpose: 'Thumbnail/cover direction, proof screenshots, and brand-safe visual review.',
+        },
+        {
+          label: 'Video Generation',
+          route: '/admin/content/video-generation',
+          purpose: 'YouTube Shorts evidence packet and render-readiness context.',
+        },
+      ],
+      channel_structure: {
+        format: 'Thumbnail and cover concept package for video-led channels.',
+        structure: [
+          'One short accountability phrase.',
+          'One owned Portfolio proof screen or Vambah/avatar still.',
+          'One visible AmaduTown brand cue.',
+        ],
+        success_criteria: [
+          'Reads clearly on mobile before sound or caption context.',
+          'Supports the channel draft without copying public creator thumbnails.',
+          'Keeps all admin proof public-safe and privacy-reviewed.',
+        ],
+      },
+      voice_translation: {
+        source: 'Vambah personality corpus plus Agentic rollout public-safe source packet.',
+        principles: [
+          'Make the pain concrete: agent authority needs receipts.',
+          'Use proof over hype.',
+          'Keep the invitation practical and grounded.',
+        ],
+        avoid: [
+          'Generic AI hype.',
+          'Sensational autonomy claims.',
+          'Copied creator thumbnail text, layout, faces, or visual identity.',
+        ],
+      },
+      visual_reinforcement: {
+        recommended_assets: ['Agent Ops proof screenshot', 'Source packet screenshot', 'Vambah/avatar still', 'AmaduTown shield'],
+        portfolio_snapshots: ['/admin/agents/content-intelligence', '/admin/content/video-generation', '/admin/agents/coordination'],
+        illustration_direction: `Adapt "${input.thumbnailText}" into a mobile-clear proof cover for the ${input.phase} phase.`,
+        privacy_notes: [
+          'Redact private admin, client, Chronicle, meeting, account, and credential detail.',
+          'Provider generation, upload, scheduling, and publishing remain separate approval gates.',
+        ],
+      },
+    },
     source_research_patterns: [],
     side_effects: {
       provider_generation: false,
@@ -1817,7 +1888,58 @@ export async function runDemoSeed(
               channel_draft_targets: ['youtube_shorts', 'instagram_reels', 'tiktok', 'thumbnail'],
             },
           }
-          return [primaryRow, youtubeRow]
+          const instagramRow = {
+            ...slot,
+            campaign_id: campaign.id,
+            agent_work_item_id: workItem.id,
+            channel: 'instagram_reels',
+            title: `${phase.titlePrefix} Reel: ${phase.insightTitle}`,
+            planned_angle: `${phase.suggestedHook} Adapt this phase into the review-ready Instagram Reels lane with safe-area proof b-roll before any export or upload.`,
+            scheduled_for: addDaysAtHourISO(phase.day, phase.phase === 'offer' ? 15 : 14),
+            authorization_due_at: addDaysAtHourISO(Math.max(0, phase.day - 1), 10),
+            authorization_status: 'pending',
+            metadata: {
+              ...commonMetadata,
+              calendar_item_role: 'companion_channel_item',
+              primary_channel: 'linkedin',
+              channel_draft_targets: ['instagram_reels', 'thumbnail'],
+            },
+          }
+          const tiktokRow = {
+            ...slot,
+            campaign_id: campaign.id,
+            agent_work_item_id: workItem.id,
+            channel: 'tiktok',
+            title: `${phase.titlePrefix} TikTok: ${phase.insightTitle}`,
+            planned_angle: `${phase.suggestedHook} Adapt this phase into the review-ready TikTok lane with original narration or platform-safe audio before any export or upload.`,
+            scheduled_for: addDaysAtHourISO(phase.day, phase.phase === 'offer' ? 16 : 15),
+            authorization_due_at: addDaysAtHourISO(Math.max(0, phase.day - 1), 10),
+            authorization_status: 'pending',
+            metadata: {
+              ...commonMetadata,
+              calendar_item_role: 'companion_channel_item',
+              primary_channel: 'linkedin',
+              channel_draft_targets: ['tiktok', 'thumbnail'],
+            },
+          }
+          const thumbnailRow = {
+            ...slot,
+            campaign_id: campaign.id,
+            agent_work_item_id: workItem.id,
+            channel: 'thumbnail',
+            title: `${phase.titlePrefix} Thumbnail: ${phase.thumbnailText}`,
+            planned_angle: `Prepare thumbnail and cover concepts for the ${phase.titlePrefix.toLowerCase()} phase using owned Portfolio proof, AmaduTown styling, and source-safe creator pattern translation.`,
+            scheduled_for: addDaysAtHourISO(Math.max(0, phase.day - 1), 16),
+            authorization_due_at: addDaysAtHourISO(Math.max(0, phase.day - 2), 10),
+            authorization_status: 'pending',
+            metadata: {
+              ...commonMetadata,
+              calendar_item_role: 'companion_asset_item',
+              primary_channel: 'youtube_shorts',
+              channel_draft_targets: ['thumbnail', 'youtube_shorts', 'instagram_reels', 'tiktok'],
+            },
+          }
+          return [primaryRow, youtubeRow, instagramRow, tiktokRow, thumbnailRow]
         })
 
         const { error: calendarError } = await supabase


### PR DESCRIPTION
## Summary
- Expand the Agentic book rollout fixture so every whisper_to_shout phase creates explicit calendar rows for LinkedIn, YouTube Shorts, Instagram Reels, TikTok, and Thumbnail.
- Add thumbnail orchestration evidence so thumbnail/cover concepts show the agents, Portfolio surfaces, channel structure, voice rules, and visual reinforcement guidance before approval.
- Add focused seed coverage for the Agentic rollout fixture, including platform row counts, review-ready lanes, thumbnail strategy evidence, and locked external side effects.

## Validation
- `npm test -- --run lib/admin-demo-seed.test.ts lib/testing/scenarios.test.ts lib/social-content-intelligence.test.ts 'app/admin/agents/social-insights/[id]/page.test.tsx'`
- `npx tsc --noEmit --pretty false`
- `npm run lint` (passes; existing unrelated `<img>` warnings remain)
- Pre-push `npm run db:health-check` passed.
- Local/dev admin API reseed: `POST /api/admin/testing/demo-seed { key: 'agentic_book_rollout_campaign_fixture' }` returned 20 calendar items, 4 insight work items, and 1 research packet.
- Read-only API verification confirmed 4 calendar items each for LinkedIn, YouTube Shorts, Instagram Reels, TikTok, and Thumbnail; every lane is `in_review`, has a draft packet, has strategy evidence, and has provider/upload/schedule/publish side effects locked off.

## Integration Notes
- No migrations or env changes.
- Seed route is still admin-authenticated and dev/demo oriented.
- No provider generation, uploads, schedules, publishing, or external posts are triggered.
- Integration Captain required for merge sequencing and deployment verification.
- Vercel contexts not checked from this implementation lane:
  - Vercel – portfolio
  - Vercel – portfolio-staging