### PR TITLE
docs: add model usage import runbook

### DIFF
--- a/docs/model-usage-import-fixtures/anthropic-usage.jsonl
+++ b/docs/model-usage-import-fixtures/anthropic-usage.jsonl
@@ -1,0 +1,1 @@
+{"id":"synthetic-anthropic-row-20260713-001","occurred_at":"2026-07-13T13:00:00.000Z","model":"claude-3-5-sonnet-20241022","task_category":"planning","client_label":"Portfolio","input_tokens":2200,"output_tokens":500,"cost_usd":0.0141,"operation":"planning_packet_fixture","accepted_output_count":1}

--- a/docs/model-usage-import-fixtures/claude-code-session.json
+++ b/docs/model-usage-import-fixtures/claude-code-session.json
@@ -1,0 +1,16 @@
+{
+  "session_id": "synthetic-claude-code-session-20260713-001",
+  "occurred_at": "2026-07-13T12:15:00.000Z",
+  "model": "claude-sonnet-4-20250514",
+  "task_category": "qa",
+  "client_label": "Portfolio",
+  "agent_key": "amina",
+  "operation": "model_usage_fixture_review",
+  "usage": {
+    "input_tokens": 6400,
+    "output_tokens": 900
+  },
+  "accepted_output_count": 1,
+  "resolved_work_item_count": 1,
+  "retry_count": 0
+}

--- a/docs/model-usage-import-fixtures/codex-session.json
+++ b/docs/model-usage-import-fixtures/codex-session.json
@@ -1,0 +1,17 @@
+{
+  "session_id": "synthetic-codex-session-20260713-001",
+  "occurred_at": "2026-07-13T12:00:00.000Z",
+  "model": "gpt-5-codex",
+  "task_category": "coding",
+  "client_label": "Portfolio",
+  "agent_key": "shaka",
+  "operation": "model_usage_import_runbook_fixture",
+  "usage": {
+    "input_tokens": 12000,
+    "output_tokens": 1800,
+    "cached_tokens": 400
+  },
+  "accepted_output_count": 1,
+  "resolved_work_item_count": 1,
+  "retry_count": 0
+}

--- a/docs/model-usage-import-fixtures/gemini-usage.csv
+++ b/docs/model-usage-import-fixtures/gemini-usage.csv
@@ -1,0 +1,2 @@
+id,timestamp,model,task_category,client_label,input_tokens,output_tokens,cost_usd,operation
+synthetic-gemini-row-20260713-001,2026-07-13T12:30:00.000Z,gemini-2.5-flash,research,Portfolio,"1,000",200,0.01,research_summary_fixture

--- a/docs/model-usage-import-fixtures/local-open-weight-run.json
+++ b/docs/model-usage-import-fixtures/local-open-weight-run.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "synthetic-local-open-weight-run-20260713-001",
+    "occurred_at": "2026-07-13T13:15:00.000Z",
+    "provider": "open-weight",
+    "model": "llama-3.1-8b",
+    "task_category": "rag",
+    "client_label": "Portfolio",
+    "input_tokens": 3000,
+    "output_tokens": 500,
+    "execution_host": "mac-mini",
+    "deployment_target": "local_device",
+    "operation": "local_rag_fixture",
+    "accepted_output_count": 1
+  }
+]

--- a/docs/model-usage-import-fixtures/openai-usage.jsonl
+++ b/docs/model-usage-import-fixtures/openai-usage.jsonl
@@ -1,0 +1,1 @@
+{"id":"synthetic-openai-row-20260713-001","occurred_at":"2026-07-13T12:45:00.000Z","model":"gpt-4o-mini","task_category":"social","client_label":"Portfolio","prompt_tokens":1500,"completion_tokens":300,"cost_usd":0.0024,"operation":"social_draft_fixture","accepted_output_count":1}

--- a/docs/model-usage-import-fixtures/reviewed-source-files-request.json
+++ b/docs/model-usage-import-fixtures/reviewed-source-files-request.json
@@ -1,0 +1,56 @@
+{
+  "dryRun": true,
+  "sourceFiles": [
+    {
+      "kind": "codex_session_json",
+      "clientLabel": "Portfolio",
+      "agentKey": "shaka",
+      "exportBatchId": "synthetic-model-usage-20260713",
+      "text": "{\"session_id\":\"synthetic-codex-session-20260713-001\",\"occurred_at\":\"2026-07-13T12:00:00.000Z\",\"model\":\"gpt-5-codex\",\"task_category\":\"coding\",\"client_label\":\"Portfolio\",\"agent_key\":\"shaka\",\"operation\":\"model_usage_import_runbook_fixture\",\"usage\":{\"input_tokens\":12000,\"output_tokens\":1800,\"cached_tokens\":400},\"accepted_output_count\":1,\"resolved_work_item_count\":1,\"retry_count\":0}"
+    },
+    {
+      "kind": "claude_code_session_json",
+      "clientLabel": "Portfolio",
+      "agentKey": "amina",
+      "exportBatchId": "synthetic-model-usage-20260713",
+      "text": "{\"session_id\":\"synthetic-claude-code-session-20260713-001\",\"occurred_at\":\"2026-07-13T12:15:00.000Z\",\"model\":\"claude-sonnet-4-20250514\",\"task_category\":\"qa\",\"client_label\":\"Portfolio\",\"agent_key\":\"amina\",\"operation\":\"model_usage_fixture_review\",\"usage\":{\"input_tokens\":6400,\"output_tokens\":900},\"accepted_output_count\":1,\"resolved_work_item_count\":1,\"retry_count\":0}"
+    },
+    {
+      "kind": "gemini_usage_csv",
+      "clientLabel": "Portfolio",
+      "exportBatchId": "synthetic-model-usage-20260713",
+      "text": "id,timestamp,model,task_category,client_label,input_tokens,output_tokens,cost_usd,operation\nsynthetic-gemini-row-20260713-001,2026-07-13T12:30:00.000Z,gemini-2.5-flash,research,Portfolio,\"1,000\",200,0.01,research_summary_fixture"
+    },
+    {
+      "kind": "openai_usage_jsonl",
+      "clientLabel": "Portfolio",
+      "exportBatchId": "synthetic-model-usage-20260713",
+      "text": "{\"id\":\"synthetic-openai-row-20260713-001\",\"occurred_at\":\"2026-07-13T12:45:00.000Z\",\"model\":\"gpt-4o-mini\",\"task_category\":\"social\",\"client_label\":\"Portfolio\",\"prompt_tokens\":1500,\"completion_tokens\":300,\"cost_usd\":0.0024,\"operation\":\"social_draft_fixture\",\"accepted_output_count\":1}"
+    },
+    {
+      "kind": "anthropic_usage_jsonl",
+      "clientLabel": "Portfolio",
+      "exportBatchId": "synthetic-model-usage-20260713",
+      "text": "{\"id\":\"synthetic-anthropic-row-20260713-001\",\"occurred_at\":\"2026-07-13T13:00:00.000Z\",\"model\":\"claude-3-5-sonnet-20241022\",\"task_category\":\"planning\",\"client_label\":\"Portfolio\",\"input_tokens\":2200,\"output_tokens\":500,\"cost_usd\":0.0141,\"operation\":\"planning_packet_fixture\",\"accepted_output_count\":1}"
+    },
+    {
+      "kind": "local_model_json",
+      "clientLabel": "Portfolio",
+      "exportBatchId": "synthetic-model-usage-20260713",
+      "text": "[{\"id\":\"synthetic-local-open-weight-run-20260713-001\",\"occurred_at\":\"2026-07-13T13:15:00.000Z\",\"provider\":\"open-weight\",\"model\":\"llama-3.1-8b\",\"task_category\":\"rag\",\"client_label\":\"Portfolio\",\"input_tokens\":3000,\"output_tokens\":500,\"execution_host\":\"mac-mini\",\"deployment_target\":\"local_device\",\"operation\":\"local_rag_fixture\",\"accepted_output_count\":1}]"
+    }
+  ],
+  "subscriptionAllocations": [
+    {
+      "provider": "codex",
+      "runtime": "any",
+      "accountLabel": "Synthetic Codex subscription allocation",
+      "monthlyCostUsd": 20,
+      "periodStart": "2026-07-01T00:00:00.000Z",
+      "periodEnd": "2026-07-31T23:59:59.999Z",
+      "allocationBasis": "token_share",
+      "confidence": "medium",
+      "notes": "Synthetic fixture only; no provider connection."
+    }
+  ]
+}

--- a/docs/runbooks/model-usage-import-runbook.md
+++ b/docs/runbooks/model-usage-import-runbook.md
@@ -1,0 +1,93 @@
+# Model Usage Import Runbook
+
+Use this runbook to import reviewed model usage into Agent Ops without connecting provider billing, syncing credentials, changing model routing, or storing private prompts.
+
+## Scope
+
+This V1 path supports reviewed source-file imports for:
+
+- Codex session JSON
+- Claude Code session JSON
+- Gemini usage CSV
+- OpenAI usage JSONL
+- Anthropic usage JSONL
+- local and open-weight model JSON
+
+The import path writes only normalized model-usage ledger rows and subscription allocation rows after admin review. Provider billing access, OAuth setup, credential sync, hosted workflow activation, outbound sends, publishing, deploys, and automatic model routing remain outside this path.
+
+## Safety Rules
+
+- Use synthetic or reviewed summary files only.
+- Exclude raw prompts, messages, transcripts, content bodies, credentials, API keys, access tokens, refresh tokens, passwords, and secrets.
+- Keep raw exports separate from reviewed source files.
+- Run dry run first.
+- Import only after the dry run returns the expected event count, allocation count, and warnings.
+- Use `clientSafe=true` on the summary API when preparing client-facing projections.
+
+## Admin UI Path
+
+1. Open `/admin/agents/model-usage`.
+2. In `Reviewed source file`, choose the source format.
+3. Paste reviewed source text or load a `.json`, `.jsonl`, `.csv`, or `.txt` file.
+4. Set the client label and optional export batch id.
+5. Click `Stage source file`.
+6. Click `Dry run`.
+7. Review event count, allocation count, warnings, model, task category, client, cost basis, and confidence.
+8. Click `Import reviewed packet` only after the packet is clean.
+9. Use `Copy client-safe JSON` when a scrubbed client projection is needed.
+
+## API Dry Run
+
+```bash
+curl -sS \
+  -X POST "$PORTFOLIO_ORIGIN/api/admin/model-usage/import" \
+  -H "Authorization: Bearer $ADMIN_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data-binary @docs/model-usage-import-fixtures/reviewed-source-files-request.json
+```
+
+The request defaults to `dryRun: true` in the fixture. A successful dry run returns:
+
+- `ok: true`
+- `dryRun: true`
+- `eventCount`
+- `subscriptionAllocationCount`
+- `warnings`
+
+## Client-Safe Projection
+
+```bash
+curl -sS \
+  "$PORTFOLIO_ORIGIN/api/admin/model-usage/summary?from=2026-07-01&to=2026-07-31&clientSafe=true" \
+  -H "Authorization: Bearer $ADMIN_ACCESS_TOKEN"
+```
+
+Client-safe projection redacts private trace ids and internal action labels from events while preserving rollups, cost basis, confidence, and advisory recommendations.
+
+## Fixture Map
+
+| Fixture | Source format | Purpose |
+| --- | --- | --- |
+| `codex-session.json` | Codex JSON | Portfolio coding session summary |
+| `claude-code-session.json` | Claude Code JSON | QA/review session summary |
+| `gemini-usage.csv` | Gemini CSV | Research usage export row |
+| `openai-usage.jsonl` | OpenAI JSONL | Outreach/social API usage row |
+| `anthropic-usage.jsonl` | Anthropic JSONL | Planning/API usage row |
+| `local-open-weight-run.json` | Local JSON | Local/open-weight RAG run summary |
+| `reviewed-source-files-request.json` | Import request | End-to-end dry-run packet using all fixture formats |
+
+## Approval Boundary
+
+This runbook does not authorize:
+
+- connecting a provider account,
+- importing raw provider logs without review,
+- syncing credentials,
+- changing model routing,
+- changing client-facing defaults,
+- creating provider webhooks,
+- sending outbound communications,
+- publishing or deploying,
+- mutating client data outside the model usage ledger.
+
+Any of those actions require a separate `agent_approvals` path.

--- a/lib/model-usage-import-fixtures.test.ts
+++ b/lib/model-usage-import-fixtures.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { buildModelUsageImportPlan } from './model-usage'
+import { buildModelUsageImportPacketFromRequest, buildModelUsageImportPacketFromSourceText, type ModelUsageSourceFileKind } from './model-usage-source-readers'
+
+const fixtureDir = join(process.cwd(), 'docs/model-usage-import-fixtures')
+
+function fixture(name: string) {
+  return readFileSync(join(fixtureDir, name), 'utf8')
+}
+
+describe('model usage import fixtures', () => {
+  it.each([
+    ['codex_session_json', 'codex-session.json', 'codex_session_import'],
+    ['claude_code_session_json', 'claude-code-session.json', 'claude_code_session_import'],
+    ['gemini_usage_csv', 'gemini-usage.csv', 'gemini_usage_export'],
+    ['openai_usage_jsonl', 'openai-usage.jsonl', 'openai_usage_export'],
+    ['anthropic_usage_jsonl', 'anthropic-usage.jsonl', 'anthropic_usage_export'],
+    ['local_model_json', 'local-open-weight-run.json', 'open_weight_model_usage_import'],
+  ] as Array<[ModelUsageSourceFileKind, string, string]>)('parses %s fixture', (kind, fileName, sourceType) => {
+    const packet = buildModelUsageImportPacketFromSourceText({
+      kind,
+      text: fixture(fileName),
+      clientLabel: 'Portfolio',
+      exportBatchId: 'fixture-batch',
+    })
+    const plan = buildModelUsageImportPlan(packet, '2026-07-13T14:00:00.000Z')
+
+    expect(plan.eventRows).toHaveLength(1)
+    expect(plan.eventRows[0]).toMatchObject({
+      source_type: sourceType,
+      scrubbed: true,
+    })
+    expect(plan.eventRows[0].total_tokens).toBeGreaterThan(0)
+  })
+
+  it('validates the reviewed source files request fixture as dry-run only', () => {
+    const request = JSON.parse(fixture('reviewed-source-files-request.json'))
+    const packet = buildModelUsageImportPacketFromRequest(request)
+    const plan = buildModelUsageImportPlan(packet, '2026-07-13T14:00:00.000Z')
+
+    expect(plan.dryRun).toBe(true)
+    expect(plan.eventRows).toHaveLength(6)
+    expect(plan.subscriptionAllocationRows).toHaveLength(1)
+    expect(plan.eventRows.map((row) => row.source_type)).toEqual([
+      'codex_session_import',
+      'claude_code_session_import',
+      'gemini_usage_export',
+      'openai_usage_export',
+      'anthropic_usage_export',
+      'open_weight_model_usage_import',
+    ])
+    expect(plan.warnings).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary
- Adds an operator runbook for reviewed model usage imports through /admin/agents/model-usage and the import API.
- Adds synthetic, client-safe fixtures for Codex JSON, Claude Code JSON, Gemini CSV, OpenAI JSONL, Anthropic JSONL, and local/open-weight model JSON.
- Adds fixture validation tests so the examples stay compatible with the source-reader and import-plan contracts.

## Validation
- npm run build:knowledge
- npm test -- lib/model-usage-import-fixtures.test.ts lib/model-usage-source-readers.test.ts lib/model-usage.test.ts app/api/admin/model-usage/import/route.test.ts app/api/admin/model-usage/summary/route.test.ts app/admin/agents/model-usage/page.test.tsx
- npx tsc --noEmit
- git diff --check
- Pre-push production db health check skipped locally because PROD_SUPABASE_URL and PROD_SUPABASE_SERVICE_ROLE_KEY are not set; CI still runs it.
- No live provider billing, OAuth, credential sync, routing change, outbound send, publishing, deploy, or customer-data smoke was run.

## Enhancement Impact Preflight
- Enhancement: model usage import runbook plus synthetic reviewed source-file fixtures.
- User-facing surface: /admin/agents/model-usage operator workflow and model usage import API examples.
- Predicted files: docs/runbooks/model-usage-import-runbook.md, docs/model-usage-import-fixtures/*, lib/model-usage-import-fixtures.test.ts.
- Shared routes/APIs/tables/helpers: existing model usage import API and source-reader helper are exercised by tests only; no API/schema code changed.
- Active PRs or branches checked: PR #646 only; it touches data/model-ops/reports/latest-dashboard-data.json.
- Dirty worktree files checked: root Portfolio checkout has unrelated agentified/subscription/social work; this branch used a clean client-ai-ops-roadmap worktree.
- Overlap rating: green.
- Coordination decision: proceed independently; this PR is docs/fixtures/tests only.
- Merge-order note: can merge independently of #646.

## Integration Notes
- No migrations or env changes required.
- Fixtures are synthetic and intentionally exclude prompts, transcripts, messages, content bodies, credentials, tokens, and secrets.
- Vercel – portfolio: not checked yet; expected after PR preview starts.
- Vercel – portfolio-staging: verify after merge/deploy gate.