### PR TITLE
Add Open Brain RAG retrieval QA packet

### DIFF
--- a/docs/atas-knowledge-os-rag-governance.md
+++ b/docs/atas-knowledge-os-rag-governance.md
@@ -110,6 +110,20 @@ Each shadow plan also records sanitized Open Brain source/event records:
 These records are trace metadata only. They do not write Pinecone, promote
 private-derived material, or create durable Open Brain memories.
 
+## Open Brain Retrieval QA
+
+Before any Pinecone cutover, run the Open Brain retrieval QA packet:
+
+```bash
+npm run open-brain:rag-retrieval-qa -- --write docs/open-brain-rag-retrieval-qa.md
+```
+
+The packet evaluates approved `public_safe` Open Brain RAG projection documents
+only. It checks retrieval coverage against known governance queries, verifies
+required projection metadata, scans for private/contact/secret-like leakage, and
+keeps Pinecone writes blocked. A failing packet blocks cutover until approved
+Open Brain memories or summaries are corrected.
+
 ## Approval Gates
 
 The following actions require explicit approval:

--- a/docs/open-brain-local-service.md
+++ b/docs/open-brain-local-service.md
@@ -297,6 +297,14 @@ Open Brain-approved `public_safe` memories can be compiled into RAG projection d
 
 Pinecone remains a downstream projection. It must be rebuildable from approved Open Brain records and must not contain private records, unapproved inferences, or raw private exports.
 
+Before any Pinecone cutover, run the local retrieval QA packet:
+
+```bash
+npm run open-brain:rag-retrieval-qa -- --write docs/open-brain-rag-retrieval-qa.md
+```
+
+The packet evaluates only approved `public_safe` Open Brain RAG projection documents. It checks expected retrieval matches, projection metadata completeness, privacy leakage patterns, and keeps `pineconeWriteStatus` at `blocked_pending_approval`. A failing packet is a cutover blocker, not a reason to weaken privacy tiers or ingest raw sources.
+
 `GET /api/knowledge` and `GET /api/knowledge/chatbot` remain backwards-compatible plain-text public-safe chatbot bundles by default. Operators can request `?format=json&include_open_brain=true` to preview the same curated bundle with optional Open Brain public-safe RAG projection documents and provenance metadata. This JSON mode does not write Pinecone, does not promote memories, and does not include non-`public_safe` Open Brain records.
 
 ## V1 Scope

--- a/docs/open-brain-rag-retrieval-qa.md
+++ b/docs/open-brain-rag-retrieval-qa.md
@@ -1,0 +1,66 @@
+# Open Brain RAG Retrieval QA Packet
+
+Generated: 2026-07-13T15:11:55.370Z
+
+Status: `fail`
+
+## Overview
+
+- Documents evaluated: 0
+- Queries evaluated: 3
+- Passed queries: 0
+- Warning queries: 0
+- Failed queries: 3
+- Metadata failures: 0
+- Privacy failures: 0
+- Pinecone write status: `blocked_pending_approval`
+
+## Retrieval Checks
+
+### personality-corpus-projection-rule
+
+- Status: `fail`
+- Score: 0.00
+- Top document: none
+- Source hash: none
+- Matched terms: none
+- Missing terms: `personality corpus`, `public-safe`, `projection`, `agent context`, `rag`
+- Forbidden hits: none
+- Note: No public-safe Open Brain RAG projection documents are available.
+
+### private-export-boundary
+
+- Status: `fail`
+- Score: 0.00
+- Top document: none
+- Source hash: none
+- Matched terms: none
+- Missing terms: `raw private exports`, `local-only`, `wiki pages`, `chatbot knowledge`, `Pinecone`
+- Forbidden hits: none
+- Note: No public-safe Open Brain RAG projection documents are available.
+
+### approval-gated-pinecone
+
+- Status: `fail`
+- Score: 0.00
+- Top document: none
+- Source hash: none
+- Matched terms: none
+- Missing terms: `Pinecone`, `approval`, `downstream`, `projection`, `rebuildable`
+- Forbidden hits: none
+- Note: No public-safe Open Brain RAG projection documents are available.
+
+## Metadata Findings
+
+- None.
+
+## Privacy Findings
+
+- None.
+
+## Recommendations
+
+- Approve at least one public-safe Open Brain memory before staging Open Brain projection content for RAG.
+- Do not cut over Pinecone until failed retrieval checks are corrected with approved public-safe memory content.
+- Keep Pinecone as a downstream rebuildable projection; no writes should occur until explicit cutover approval.
+

--- a/docs/open-brain-roadmap-status.md
+++ b/docs/open-brain-roadmap-status.md
@@ -105,9 +105,10 @@ Completed:
 - Public-safe Open Brain RAG projection documents carry memory/source IDs, privacy tier, source hash, projection version, deletion key, and rollback key.
 - Chatbot knowledge has opt-in JSON mode for public-safe Open Brain projection metadata.
 - RAG ingest endpoint records shadow-plan traces and blocks Pinecone writes pending approval.
+- Local retrieval QA packet exists for approved public-safe Open Brain RAG projection documents.
 
 Remaining:
-- Run retrieval-quality tests before production promotion.
+- Run and review the retrieval QA packet before production promotion.
 - Stage Pinecone ingestion only after explicit cutover approval.
 - Verify deletion and rollback keys in any external vector store staging packet.
 
@@ -117,11 +118,13 @@ Gates:
 
 Evidence:
 - lib/chatbot-knowledge.ts
+- lib/open-brain-rag-retrieval-qa.ts
+- scripts/open-brain-rag-retrieval-qa.ts
 - app/api/knowledge/route.ts
 - app/api/admin/rag-ingest/route.ts
 - docs/open-brain-local-service.md
 
-Next action: Build a retrieval QA packet for the Open Brain public-safe projection before any Pinecone cutover.
+Next action: Run `npm run open-brain:rag-retrieval-qa -- --write docs/open-brain-rag-retrieval-qa.md`, review failures, and only then decide whether Pinecone staging is ready.
 
 ## phase-6: AutoResearch Loop Integration
 

--- a/lib/open-brain-rag-retrieval-qa.test.ts
+++ b/lib/open-brain-rag-retrieval-qa.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import {
+  evaluateOpenBrainRagRetrievalQa,
+  formatOpenBrainRagRetrievalQaReport,
+  type OpenBrainRagRetrievalQaQuery,
+} from './open-brain-rag-retrieval-qa'
+import type { OpenBrainRagProjectionDocument } from './open-brain'
+
+const queries: OpenBrainRagRetrievalQaQuery[] = [
+  {
+    id: 'projection-boundary',
+    question: 'How should public-safe personality corpus context reach agents and RAG?',
+    expectedTerms: ['personality corpus', 'public-safe', 'agent context', 'rag'],
+    forbiddenTerms: ['Anthropic_chat_data', 'ChatGPT export'],
+  },
+]
+
+function document(overrides: Partial<OpenBrainRagProjectionDocument> = {}): OpenBrainRagProjectionDocument {
+  return {
+    id: 'open-brain-rag:memory-1',
+    title: 'Approve personality corpus projection',
+    text: 'The public-safe personality corpus can be used as agent context and RAG projection input. Raw private exports remain local only.',
+    metadata: {
+      openBrainMemoryId: 'memory-1',
+      openBrainSourceIds: ['personality-corpus:public-safe'],
+      privacyTier: 'public_safe',
+      sourceHash: 'hash-1',
+      projectionVersion: 'open-brain-rag-projection-v1',
+      deletionKey: 'open-brain:memory-1',
+      rollbackKey: 'open-brain:hash-1',
+    },
+    ...overrides,
+  }
+}
+
+describe('Open Brain RAG retrieval QA', () => {
+  it('passes public-safe projection documents with complete metadata and expected retrieval terms', () => {
+    const report = evaluateOpenBrainRagRetrievalQa({
+      generatedAt: '2026-07-13T12:00:00.000Z',
+      documents: [document()],
+      queries,
+    })
+
+    expect(report.status).toBe('pass')
+    expect(report.overview).toEqual(expect.objectContaining({
+      documentCount: 1,
+      passedQueries: 1,
+      metadataFailures: 0,
+      privacyFailures: 0,
+      pineconeWriteStatus: 'blocked_pending_approval',
+    }))
+    expect(report.results[0]).toEqual(expect.objectContaining({
+      status: 'pass',
+      topDocumentId: 'open-brain-rag:memory-1',
+      matchedTerms: ['personality corpus', 'public-safe', 'agent context', 'rag'],
+      forbiddenHits: [],
+    }))
+  })
+
+  it('fails when metadata is incomplete or projection text leaks private-looking material', () => {
+    const report = evaluateOpenBrainRagRetrievalQa({
+      documents: [document({
+        text: 'Contact me at private@example.com with API_KEY=secret. public-safe personality corpus agent context rag.',
+        metadata: {
+          ...document().metadata,
+          sourceHash: '',
+          deletionKey: '',
+        },
+      })],
+      queries,
+    })
+
+    expect(report.status).toBe('fail')
+    expect(report.metadataFindings).toEqual(expect.arrayContaining([
+      'open-brain-rag:memory-1: missing source hash',
+      'open-brain-rag:memory-1: missing deletion key',
+    ]))
+    expect(report.privacyFindings).toEqual(expect.arrayContaining([
+      'open-brain-rag:memory-1: email_address detected in projection text',
+      'open-brain-rag:memory-1: secret_like_value detected in projection text',
+    ]))
+  })
+
+  it('reports a cutover blocker when no approved public-safe projection documents exist', () => {
+    const report = evaluateOpenBrainRagRetrievalQa({
+      documents: [],
+      queries,
+    })
+
+    expect(report.status).toBe('fail')
+    expect(report.results[0]).toEqual(expect.objectContaining({
+      status: 'fail',
+      topDocumentId: null,
+      note: 'No public-safe Open Brain RAG projection documents are available.',
+    }))
+    expect(report.recommendations[0]).toBe('Approve at least one public-safe Open Brain memory before staging Open Brain projection content for RAG.')
+  })
+
+  it('formats a markdown packet for review without including raw source bodies beyond projection text checks', () => {
+    const report = evaluateOpenBrainRagRetrievalQa({
+      generatedAt: '2026-07-13T12:00:00.000Z',
+      documents: [document()],
+      queries,
+    })
+    const markdown = formatOpenBrainRagRetrievalQaReport(report)
+
+    expect(markdown).toContain('# Open Brain RAG Retrieval QA Packet')
+    expect(markdown).toContain('Status: `pass`')
+    expect(markdown).toContain('Pinecone write status: `blocked_pending_approval`')
+    expect(markdown).toContain('projection-boundary')
+  })
+})

--- a/lib/open-brain-rag-retrieval-qa.ts
+++ b/lib/open-brain-rag-retrieval-qa.ts
@@ -1,0 +1,303 @@
+import type { OpenBrainRagProjectionDocument } from './open-brain'
+
+export type OpenBrainRagRetrievalQaStatus = 'pass' | 'warn' | 'fail'
+
+export interface OpenBrainRagRetrievalQaQuery {
+  id: string
+  question: string
+  expectedTerms: string[]
+  forbiddenTerms?: string[]
+  minScore?: number
+}
+
+export interface OpenBrainRagRetrievalQaResult {
+  queryId: string
+  question: string
+  status: OpenBrainRagRetrievalQaStatus
+  score: number
+  matchedTerms: string[]
+  missingTerms: string[]
+  forbiddenHits: string[]
+  topDocumentId: string | null
+  topDocumentTitle: string | null
+  sourceHash: string | null
+  note: string
+}
+
+export interface OpenBrainRagRetrievalQaReport {
+  generatedAt: string
+  status: OpenBrainRagRetrievalQaStatus
+  overview: {
+    documentCount: number
+    queryCount: number
+    passedQueries: number
+    warningQueries: number
+    failedQueries: number
+    metadataFailures: number
+    privacyFailures: number
+    pineconeWriteStatus: 'blocked_pending_approval'
+  }
+  results: OpenBrainRagRetrievalQaResult[]
+  metadataFindings: string[]
+  privacyFindings: string[]
+  recommendations: string[]
+}
+
+export const DEFAULT_OPEN_BRAIN_RAG_RETRIEVAL_QA_QUERIES: OpenBrainRagRetrievalQaQuery[] = [
+  {
+    id: 'personality-corpus-projection-rule',
+    question: 'Can Open Brain explain how the public-safe personality corpus should be used by agents and RAG?',
+    expectedTerms: ['personality corpus', 'public-safe', 'projection', 'agent context', 'rag'],
+    forbiddenTerms: ['Anthropic_chat_data', 'ChatGPT export'],
+  },
+  {
+    id: 'private-export-boundary',
+    question: 'Does the retrieved context preserve the boundary around raw private exports?',
+    expectedTerms: ['raw private exports', 'local-only', 'wiki pages', 'chatbot knowledge', 'Pinecone'],
+    forbiddenTerms: ['api key', 'password', 'secret'],
+  },
+  {
+    id: 'approval-gated-pinecone',
+    question: 'Does retrieved context say Pinecone ingestion is downstream and approval-gated?',
+    expectedTerms: ['Pinecone', 'approval', 'downstream', 'projection', 'rebuildable'],
+    forbiddenTerms: ['auto-apply', 'automatic write', 'write without approval'],
+  },
+]
+
+const CONTACT_OR_SECRET_PATTERNS: Array<{ label: string; pattern: RegExp }> = [
+  { label: 'email_address', pattern: /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i },
+  { label: 'phone_number', pattern: /(?:\+?1[\s.-]?)?(?:\(?\d{3}\)?[\s.-]?)\d{3}[\s.-]?\d{4}\b/ },
+  { label: 'secret_like_value', pattern: /\b(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD)\b\s*[:=]/i },
+  { label: 'openai_key_like_value', pattern: /\bsk-[A-Za-z0-9_-]{12,}\b/ },
+  { label: 'github_token_like_value', pattern: /\bgithub_pat_[A-Za-z0-9_]{12,}\b/ },
+]
+
+export function evaluateOpenBrainRagRetrievalQa(input: {
+  documents: OpenBrainRagProjectionDocument[]
+  queries?: OpenBrainRagRetrievalQaQuery[]
+  generatedAt?: string
+}): OpenBrainRagRetrievalQaReport {
+  const generatedAt = input.generatedAt || new Date().toISOString()
+  const documents = input.documents
+  const queries = input.queries || DEFAULT_OPEN_BRAIN_RAG_RETRIEVAL_QA_QUERIES
+  const metadataFindings = validateProjectionMetadata(documents)
+  const privacyFindings = validateProjectionPrivacy(documents)
+  const results = queries.map((query) => evaluateQuery(query, documents))
+  const failedQueries = results.filter((result) => result.status === 'fail').length
+  const warningQueries = results.filter((result) => result.status === 'warn').length
+  const passedQueries = results.filter((result) => result.status === 'pass').length
+  const status: OpenBrainRagRetrievalQaStatus = metadataFindings.length > 0 || privacyFindings.length > 0 || failedQueries > 0
+    ? 'fail'
+    : warningQueries > 0
+      ? 'warn'
+      : 'pass'
+
+  return {
+    generatedAt,
+    status,
+    overview: {
+      documentCount: documents.length,
+      queryCount: queries.length,
+      passedQueries,
+      warningQueries,
+      failedQueries,
+      metadataFailures: metadataFindings.length,
+      privacyFailures: privacyFindings.length,
+      pineconeWriteStatus: 'blocked_pending_approval',
+    },
+    results,
+    metadataFindings,
+    privacyFindings,
+    recommendations: buildRecommendations({
+      documentCount: documents.length,
+      metadataFindings,
+      privacyFindings,
+      failedQueries,
+      warningQueries,
+    }),
+  }
+}
+
+export function formatOpenBrainRagRetrievalQaReport(report: OpenBrainRagRetrievalQaReport): string {
+  const lines = [
+    '# Open Brain RAG Retrieval QA Packet',
+    '',
+    `Generated: ${report.generatedAt}`,
+    '',
+    `Status: \`${report.status}\``,
+    '',
+    '## Overview',
+    '',
+    `- Documents evaluated: ${report.overview.documentCount}`,
+    `- Queries evaluated: ${report.overview.queryCount}`,
+    `- Passed queries: ${report.overview.passedQueries}`,
+    `- Warning queries: ${report.overview.warningQueries}`,
+    `- Failed queries: ${report.overview.failedQueries}`,
+    `- Metadata failures: ${report.overview.metadataFailures}`,
+    `- Privacy failures: ${report.overview.privacyFailures}`,
+    `- Pinecone write status: \`${report.overview.pineconeWriteStatus}\``,
+    '',
+    '## Retrieval Checks',
+    '',
+    ...report.results.flatMap((result) => [
+      `### ${result.queryId}`,
+      '',
+      `- Status: \`${result.status}\``,
+      `- Score: ${result.score.toFixed(2)}`,
+      `- Top document: ${result.topDocumentTitle ? `${result.topDocumentTitle} (\`${result.topDocumentId}\`)` : 'none'}`,
+      `- Source hash: ${result.sourceHash ? `\`${result.sourceHash}\`` : 'none'}`,
+      `- Matched terms: ${result.matchedTerms.length ? result.matchedTerms.map((term) => `\`${term}\``).join(', ') : 'none'}`,
+      `- Missing terms: ${result.missingTerms.length ? result.missingTerms.map((term) => `\`${term}\``).join(', ') : 'none'}`,
+      `- Forbidden hits: ${result.forbiddenHits.length ? result.forbiddenHits.map((term) => `\`${term}\``).join(', ') : 'none'}`,
+      `- Note: ${result.note}`,
+      '',
+    ]),
+    '## Metadata Findings',
+    '',
+    ...(report.metadataFindings.length ? report.metadataFindings.map((finding) => `- ${finding}`) : ['- None.']),
+    '',
+    '## Privacy Findings',
+    '',
+    ...(report.privacyFindings.length ? report.privacyFindings.map((finding) => `- ${finding}`) : ['- None.']),
+    '',
+    '## Recommendations',
+    '',
+    ...report.recommendations.map((recommendation) => `- ${recommendation}`),
+    '',
+  ]
+
+  return `${lines.join('\n')}\n`
+}
+
+function evaluateQuery(
+  query: OpenBrainRagRetrievalQaQuery,
+  documents: OpenBrainRagProjectionDocument[],
+): OpenBrainRagRetrievalQaResult {
+  const minScore = query.minScore ?? 0.6
+  const ranked = documents
+    .map((document) => ({
+      document,
+      expectedMatches: findTerms(document.text, query.expectedTerms),
+      forbiddenHits: findTerms(document.text, query.forbiddenTerms || []),
+      queryOverlap: overlapScore(query.question, `${document.title}\n${document.text}`),
+    }))
+    .sort((a, b) => {
+      const aScore = a.expectedMatches.length + a.queryOverlap
+      const bScore = b.expectedMatches.length + b.queryOverlap
+      return bScore - aScore
+    })
+
+  const top = ranked[0] || null
+  const matchedTerms = top?.expectedMatches || []
+  const forbiddenHits = top?.forbiddenHits || []
+  const missingTerms = query.expectedTerms.filter((term) => !matchedTerms.includes(term))
+  const score = query.expectedTerms.length === 0 ? 1 : matchedTerms.length / query.expectedTerms.length
+  const status: OpenBrainRagRetrievalQaStatus = !top || forbiddenHits.length > 0 || score < minScore
+    ? 'fail'
+    : score < 1
+      ? 'warn'
+      : 'pass'
+
+  return {
+    queryId: query.id,
+    question: query.question,
+    status,
+    score,
+    matchedTerms,
+    missingTerms,
+    forbiddenHits,
+    topDocumentId: top?.document.id || null,
+    topDocumentTitle: top?.document.title || null,
+    sourceHash: top?.document.metadata.sourceHash || null,
+    note: !top
+      ? 'No public-safe Open Brain RAG projection documents are available.'
+      : forbiddenHits.length > 0
+        ? 'Top document contains forbidden retrieval terms.'
+        : score < minScore
+          ? 'Top document did not meet the minimum expected-term coverage.'
+          : score < 1
+            ? 'Top document is usable but missing at least one expected term.'
+            : 'Top document satisfies the retrieval check.',
+  }
+}
+
+function validateProjectionMetadata(documents: OpenBrainRagProjectionDocument[]) {
+  const findings: string[] = []
+  const ids = new Set<string>()
+  for (const document of documents) {
+    if (ids.has(document.id)) findings.push(`${document.id}: duplicate projection document id`)
+    ids.add(document.id)
+    if (!document.title.trim()) findings.push(`${document.id}: title is required`)
+    if (!document.text.trim()) findings.push(`${document.id}: text is required`)
+    if (!document.metadata.openBrainMemoryId) findings.push(`${document.id}: missing Open Brain memory id`)
+    if (!document.metadata.sourceHash) findings.push(`${document.id}: missing source hash`)
+    if (!document.metadata.projectionVersion) findings.push(`${document.id}: missing projection version`)
+    if (!document.metadata.deletionKey) findings.push(`${document.id}: missing deletion key`)
+    if (!document.metadata.rollbackKey) findings.push(`${document.id}: missing rollback key`)
+    if (document.metadata.privacyTier !== 'public_safe') findings.push(`${document.id}: privacy tier must be public_safe`)
+  }
+  return findings
+}
+
+function validateProjectionPrivacy(documents: OpenBrainRagProjectionDocument[]) {
+  const findings: string[] = []
+  for (const document of documents) {
+    for (const { label, pattern } of CONTACT_OR_SECRET_PATTERNS) {
+      if (pattern.test(document.text)) findings.push(`${document.id}: ${label} detected in projection text`)
+    }
+  }
+  return findings
+}
+
+function buildRecommendations(input: {
+  documentCount: number
+  metadataFindings: string[]
+  privacyFindings: string[]
+  failedQueries: number
+  warningQueries: number
+}) {
+  const recommendations: string[] = []
+  if (input.documentCount === 0) {
+    recommendations.push('Approve at least one public-safe Open Brain memory before staging Open Brain projection content for RAG.')
+  }
+  if (input.metadataFindings.length > 0) {
+    recommendations.push('Fix projection metadata before any chatbot or Pinecone staging: memory id, source hash, projection version, deletion key, and rollback key are required.')
+  }
+  if (input.privacyFindings.length > 0) {
+    recommendations.push('Remove private/contact/secret-like material from approved public-safe memories before projection.')
+  }
+  if (input.failedQueries > 0) {
+    recommendations.push('Do not cut over Pinecone until failed retrieval checks are corrected with approved public-safe memory content.')
+  }
+  if (input.warningQueries > 0) {
+    recommendations.push('Review warning queries and improve source summaries before production retrieval promotion.')
+  }
+  recommendations.push('Keep Pinecone as a downstream rebuildable projection; no writes should occur until explicit cutover approval.')
+  return recommendations
+}
+
+function findTerms(text: string, terms: string[]) {
+  const normalized = normalize(text)
+  return terms.filter((term) => normalized.includes(normalize(term)))
+}
+
+function overlapScore(question: string, text: string) {
+  const questionTerms = new Set(tokenize(question))
+  const textTerms = new Set(tokenize(text))
+  if (questionTerms.size === 0) return 0
+  let overlap = 0
+  questionTerms.forEach((term) => {
+    if (textTerms.has(term)) overlap += 1
+  })
+  return overlap / questionTerms.size
+}
+
+function tokenize(text: string) {
+  return normalize(text)
+    .split(/[^a-z0-9]+/)
+    .filter((term) => term.length > 2)
+}
+
+function normalize(text: string) {
+  return text.toLowerCase().replace(/\s+/g, ' ').trim()
+}

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "open-brain:agent-ops-producer": "tsx scripts/open-brain-agent-ops-producer.ts",
     "open-brain:autoresearch-producer": "tsx scripts/open-brain-autoresearch-producer.ts",
     "open-brain:manuscript-summaries": "tsx scripts/open-brain-manuscript-summarizer.ts",
+    "open-brain:rag-retrieval-qa": "tsx scripts/open-brain-rag-retrieval-qa.ts",
     "open-brain:roadmap-status": "tsx scripts/open-brain-roadmap-status.ts",
     "wrm:smoke-gate": "tsx scripts/wrm-production-smoke-gate.ts",
     "source-protocol:smoke": "tsx scripts/source-protocol-smoke.ts",

--- a/scripts/open-brain-rag-retrieval-qa.ts
+++ b/scripts/open-brain-rag-retrieval-qa.ts
@@ -1,0 +1,62 @@
+#!/usr/bin/env tsx
+import dotenv from 'dotenv'
+import { existsSync } from 'fs'
+import { mkdir, writeFile } from 'fs/promises'
+import path from 'path'
+import {
+  evaluateOpenBrainRagRetrievalQa,
+  formatOpenBrainRagRetrievalQaReport,
+} from '../lib/open-brain-rag-retrieval-qa'
+
+const envPath = existsSync(path.join(process.cwd(), '.env.local'))
+  ? path.join(process.cwd(), '.env.local')
+  : '/Users/vambahsillah/Projects/Portfolio/.env.local'
+
+dotenv.config({ path: envPath, quiet: true })
+
+async function main() {
+  const writePath = getWritePath(process.argv.slice(2))
+  const { getOpenBrainSnapshot } = await import('../lib/open-brain')
+  const snapshot = await getOpenBrainSnapshot()
+  const report = evaluateOpenBrainRagRetrievalQa({
+    documents: snapshot.ragProjection.documents,
+    generatedAt: new Date().toISOString(),
+  })
+  const markdown = formatOpenBrainRagRetrievalQaReport(report)
+
+  if (writePath) {
+    await mkdir(path.dirname(writePath), { recursive: true })
+    await writeFile(writePath, markdown, 'utf8')
+  }
+
+  process.stdout.write(JSON.stringify({
+    status: report.status,
+    generatedAt: report.generatedAt,
+    documentCount: report.overview.documentCount,
+    queryCount: report.overview.queryCount,
+    failedQueries: report.overview.failedQueries,
+    metadataFailures: report.overview.metadataFailures,
+    privacyFailures: report.overview.privacyFailures,
+    pineconeWriteStatus: report.overview.pineconeWriteStatus,
+    reportPath: writePath || null,
+    pineconeWriteAttempted: false,
+  }, null, 2))
+  process.stdout.write('\n')
+}
+
+function getWritePath(args: string[]) {
+  const writeIndex = args.findIndex((arg) => arg === '--write')
+  if (writeIndex === -1) return null
+  const value = args[writeIndex + 1]
+  if (!value || value.startsWith('--')) {
+    return path.join(process.cwd(), 'docs/open-brain-rag-retrieval-qa.md')
+  }
+  return path.isAbsolute(value) ? value : path.join(process.cwd(), value)
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('[open-brain-rag-retrieval-qa] failed:', error instanceof Error ? error.message : error)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Summary
- add a deterministic Open Brain RAG retrieval QA harness and CLI packet generator
- write the current local QA packet showing Pinecone cutover is blocked until approved public-safe Open Brain projection docs exist
- document the retrieval QA gate in Open Brain and ATAS RAG governance docs

## Validation
- PATH=/Users/vambahsillah/Projects/Portfolio/node_modules/.bin:/Users/vambahsillah/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/vambahsillah/.codex/tmp/arg0/codex-arg0mIY0E0:/Users/vambahsillah/.npm-global/bin:/Users/vambahsillah/.local/bin:/Users/vambahsillah/.lmstudio/bin:/Applications/ChatGPT.app/Contents/Resources NODE_PATH=/Users/vambahsillah/Projects/Portfolio/node_modules vitest run lib/open-brain-rag-retrieval-qa.test.ts lib/open-brain.test.ts
- npm run open-brain:rag-retrieval-qa -- --write docs/open-brain-rag-retrieval-qa.md
- git diff --check

## Integration note
This is intentionally a non-captain PR. Please leave merge/deploy verification to the integration manager.