### PR TITLE
feat: add mobile foundry decision handoff

### DIFF
--- a/app/admin/mobile-app-foundry/PacketPreviewWorkspace.test.tsx
+++ b/app/admin/mobile-app-foundry/PacketPreviewWorkspace.test.tsx
@@ -106,7 +106,12 @@ describe('PacketPreviewWorkspace', () => {
       confirmation: 'create_mobile_foundry_work_items',
       source_run_id: 'run-123',
     })
-    expect(await screen.findByText(/Proposed Agent Ops work item ready in Decision Queue: work-item-1/i)).toBeInTheDocument()
+    expect(await screen.findByText(/Proposed Agent Ops work item ready in Decision Queue/i)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /work-item-1/i })).toHaveAttribute(
+      'href',
+      '/admin/agents/coordination?proposal=work-item-1',
+    )
+    expect(screen.getByText(/Build execution, repo creation, tester outreach, pricing, and store actions remain outside this workspace/i)).toBeInTheDocument()
   })
 
   it('clears proposal preview state when the backlog record changes', async () => {

--- a/app/admin/mobile-app-foundry/PacketPreviewWorkspace.tsx
+++ b/app/admin/mobile-app-foundry/PacketPreviewWorkspace.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useMemo, useState } from 'react'
-import { AlertTriangle, ClipboardCheck, FileJson, GitPullRequest, Play, ShieldCheck } from 'lucide-react'
+import { AlertTriangle, ArrowRight, ClipboardCheck, FileJson, GitPullRequest, Play, ShieldCheck } from 'lucide-react'
 import { getCurrentSession } from '@/lib/auth'
 
 type PreviewMode = 'prototype' | 'commercialization'
@@ -75,6 +75,12 @@ function previewEndpoint(mode: PreviewMode) {
 
 function workItemsEndpoint() {
   return '/api/admin/mobile-app-foundry/work-items'
+}
+
+function decisionQueueHref(workItemId?: string | null) {
+  return workItemId
+    ? `/admin/agents/coordination?proposal=${encodeURIComponent(workItemId)}`
+    : '/admin/agents/coordination'
 }
 
 export default function PacketPreviewWorkspace() {
@@ -427,8 +433,24 @@ export default function PacketPreviewWorkspace() {
                   </div>
                 )}
                 {workItemResult.work_items?.length ? (
-                  <div className="rounded-lg border border-emerald-400/25 bg-emerald-500/10 p-3 text-sm leading-5 text-emerald-100">
-                    Proposed Agent Ops work item ready in Decision Queue: {workItemResult.work_items.map((item) => item.id).filter(Boolean).join(', ')}
+                  <div className="space-y-2 rounded-lg border border-emerald-400/25 bg-emerald-500/10 p-3 text-sm leading-5 text-emerald-100">
+                    <p className="font-semibold">Proposed Agent Ops work item ready in Decision Queue.</p>
+                    <div className="flex flex-wrap gap-2">
+                      {workItemResult.work_items.map((item) => (
+                        <a
+                          key={item.id ?? item.title}
+                          href={decisionQueueHref(item.id)}
+                          className="inline-flex items-center gap-2 rounded-lg border border-emerald-300/25 bg-emerald-300/10 px-3 py-2 text-xs font-semibold text-emerald-50 transition-colors hover:border-emerald-200/50 hover:bg-emerald-300/15"
+                        >
+                          {item.id || item.title || 'Open work item'}
+                          <ArrowRight size={13} />
+                        </a>
+                      ))}
+                    </div>
+                    <p className="text-xs leading-5 text-emerald-50/80">
+                      Next step for you is to review or route the proposed item from Agent Ops. Build execution, repo
+                      creation, tester outreach, pricing, and store actions remain outside this workspace.
+                    </p>
                   </div>
                 ) : null}
               </div>

--- a/docs/mobile-app-foundry-agent-system.md
+++ b/docs/mobile-app-foundry-agent-system.md
@@ -165,6 +165,7 @@ Use existing Agent Ops patterns:
 - Preview mode is the default when `create_work_items` is not set.
 - Creation requires `confirmation: "create_mobile_foundry_work_items"`.
 - The only Phase 3 side effect is a proposed `agent_work_items` record owned by `engineering-copilot` with Imhotep recorded as the Mobile Foundry prototype role. Repos, GitHub accounts, paid APIs, tester outreach, store submissions, price changes, user-data collection, and public/client-facing claims remain separate approval gates.
+- After creation, the Mobile Foundry admin surface should link the proposed work item back to the central Decision Queue instead of adding local approve/reject controls.
 
 ### Phase 4: Prototype build lane
 


### PR DESCRIPTION
## Summary
- Add a direct Decision Queue handoff after Mobile Foundry creates a proposed Agent Ops work item.
- Link each created proposed item to `/admin/agents/coordination?proposal=<id>` instead of adding local approve/reject controls.
- Preserve the Mobile Foundry boundary: it remains a packet/proposal surface, while build execution, repo creation, tester outreach, pricing, and store actions stay in Agent Ops.
- Document the Phase 3 post-create handoff rule in `docs/mobile-app-foundry-agent-system.md`.

## Validation
- `npm test -- --run app/admin/mobile-app-foundry/PacketPreviewWorkspace.test.tsx app/api/admin/mobile-app-foundry/work-items/route.test.ts app/api/admin/mobile-app-foundry/prototype-packet/route.test.ts app/api/admin/mobile-app-foundry/commercialization-packet/route.test.ts lib/mobile-app-foundry-work-items.test.ts`
- `npm run lint -- --file app/admin/mobile-app-foundry/PacketPreviewWorkspace.tsx --file app/admin/mobile-app-foundry/page.tsx`
- `git diff --check`
- Browser QA through the in-app Browser at `http://localhost:3037/admin/mobile-app-foundry`:
  - Page identity: `Mobile App Foundry | Admin`
  - Nonblank admin page rendered with `Packet Preview Workspace` and `Agent Ops proposal gate`
  - No framework error overlay detected
  - Console errors/warnings: none relevant
  - Interaction proof: non-mutating `Preview proposal` rendered the idempotency key and false side-effect boundary
- Push hook ran `npm run db:health-check` and skipped locally because `PROD_SUPABASE_URL` and `PROD_SUPABASE_SERVICE_ROLE_KEY` are not set in this worktree shell.

## Enhancement Impact Preflight
- Enhancement: Mobile Foundry Decision Queue handoff after proposed work-item creation.
- User-facing surface: `/admin/mobile-app-foundry` and the central `/admin/agents/coordination` link target.
- Predicted files: `app/admin/mobile-app-foundry/PacketPreviewWorkspace.tsx`, `app/admin/mobile-app-foundry/PacketPreviewWorkspace.test.tsx`, `docs/mobile-app-foundry-agent-system.md`.
- Shared routes/APIs/tables/helpers: reads existing `/api/admin/mobile-app-foundry/work-items` response shape and links to existing `/admin/agents/coordination`; no schema or API behavior changes.
- Active PRs checked: #648 (`codex/open-brain-rag-retrieval-qa`), unrelated Open Brain QA packet.
- Dirty worktree files checked: main Portfolio checkout is dirty with unrelated Agentified/subscription/Open Brain work; this branch uses a clean worktree from `origin/main`.
- Overlap rating: green.
- Coordination decision: proceed in a dedicated non-captain branch; no merge from this lane.
- Merge-order note: can merge independently of #648 unless Integration Captain sees deployment sequencing concerns.

## LM Studio Notes
- Used LM Studio with `qwen/qwen3-coder-30b` for a narrow handoff-design check.
- Qwen recommended the existing `?proposal=<id>` Decision Queue route and avoiding new local approval controls; implementation follows that boundary.

## Integration Notes
- No database migration.
- No env changes.
- No Open Brain, Codex memory, Codex automation, or LM Studio config changes.
- Vercel contexts were not manually checked from this non-captain implementation lane:
  - Vercel – portfolio: not checked
  - Vercel – portfolio-staging: not checked
