### PR TITLE
feat: import Agentified launch backlog

### DIFF
--- a/app/admin/content/agentified/page.tsx
+++ b/app/admin/content/agentified/page.tsx
@@ -1,9 +1,23 @@
 'use client'
 
 import Link from 'next/link'
-import { BookOpen, Brain, CheckCircle2, ExternalLink, FileText, ShieldCheck, TerminalSquare } from 'lucide-react'
+import { useState } from 'react'
+import {
+  BookOpen,
+  Brain,
+  CalendarDays,
+  CheckCircle2,
+  ExternalLink,
+  FileText,
+  Loader2,
+  ShieldCheck,
+  TerminalSquare,
+  UploadCloud,
+} from 'lucide-react'
 import ProtectedRoute from '@/components/ProtectedRoute'
 import Breadcrumbs from '@/components/admin/Breadcrumbs'
+import { getCurrentSession } from '@/lib/auth'
+import { agentifiedLaunchSummary } from '@/lib/agentified-launch-campaign'
 import { agentifiedPublication } from '@/lib/agentified-publication'
 
 const draftLinks = [
@@ -14,7 +28,61 @@ const draftLinks = [
   { label: 'Fable 5 handoff', path: agentifiedPublication.fableHandoffPath },
 ]
 
+const campaignSummary = agentifiedLaunchSummary()
+
+type ImportResult = {
+  ok: boolean
+  campaign?: {
+    id: string
+    slug: string
+    created: boolean
+    updated: boolean
+  }
+  work_items?: {
+    total: number
+    ids: string[]
+  }
+  calendar_items?: {
+    inserted_count: number
+    updated_count: number
+    total: number
+  }
+  review_links?: {
+    content_intelligence: string
+    campaign_calendar: string
+    agentified_admin: string
+  }
+  error?: string
+}
+
 export default function AgentifiedAdminPage() {
+  const [importing, setImporting] = useState(false)
+  const [importResult, setImportResult] = useState<ImportResult | null>(null)
+  const [importError, setImportError] = useState<string | null>(null)
+
+  const importLaunchBacklog = async () => {
+    setImporting(true)
+    setImportError(null)
+    try {
+      const session = await getCurrentSession()
+      if (!session?.access_token) throw new Error('Admin session is required')
+      const response = await fetch('/api/admin/content/agentified/campaign/import', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${session.access_token}`,
+          'content-type': 'application/json',
+        },
+      })
+      const data = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(data.error || 'Failed to import launch backlog')
+      setImportResult(data)
+    } catch (error) {
+      setImportError(error instanceof Error ? error.message : 'Failed to import launch backlog')
+    } finally {
+      setImporting(false)
+    }
+  }
+
   return (
     <ProtectedRoute requireAdmin>
       <div className="admin-console-page min-h-screen px-4 py-6 text-foreground sm:px-6 lg:px-8">
@@ -44,6 +112,86 @@ export default function AgentifiedAdminPage() {
               </Link>
             </div>
           </header>
+
+          <section className="admin-console-card mb-6 rounded-lg border p-5">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+              <div className="min-w-0">
+                <div className="mb-2 flex items-center gap-2 text-radiant-gold">
+                  <CalendarDays size={18} />
+                  <h2 className="text-lg font-semibold text-foreground">Launch campaign backlog</h2>
+                </div>
+                <p className="max-w-3xl text-sm leading-6 text-muted-foreground">
+                  Import the prepared Agentified whisper-to-shout packet into the central Agent Ops backlog and campaign calendar.
+                  This creates reviewable internal records only.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={importLaunchBacklog}
+                disabled={importing}
+                className="inline-flex items-center justify-center gap-2 rounded-lg border border-radiant-gold/50 px-4 py-2 text-sm font-semibold text-radiant-gold transition hover:bg-radiant-gold/10 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {importing ? <Loader2 size={16} className="animate-spin" /> : <UploadCloud size={16} />}
+                {importing ? 'Importing...' : 'Import launch backlog'}
+              </button>
+            </div>
+
+            <div className="mt-4 grid gap-3 md:grid-cols-4">
+              <div className="rounded-lg border border-silicon-slate/60 bg-silicon-slate/10 p-3">
+                <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Template</div>
+                <div className="mt-1 text-sm font-semibold text-foreground">{campaignSummary.template_key}</div>
+              </div>
+              <div className="rounded-lg border border-silicon-slate/60 bg-silicon-slate/10 p-3">
+                <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Calendar items</div>
+                <div className="mt-1 text-sm font-semibold text-foreground">{campaignSummary.calendar_item_count}</div>
+              </div>
+              <div className="rounded-lg border border-silicon-slate/60 bg-silicon-slate/10 p-3">
+                <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Channels</div>
+                <div className="mt-1 text-sm font-semibold text-foreground">
+                  {campaignSummary.supported_channels.join(', ')}
+                </div>
+              </div>
+              <div className="rounded-lg border border-silicon-slate/60 bg-silicon-slate/10 p-3">
+                <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">External execution</div>
+                <div className="mt-1 text-sm font-semibold text-foreground">Locked</div>
+              </div>
+            </div>
+
+            {importResult?.ok && (
+              <div className="mt-4 rounded-lg border border-emerald-400/30 bg-emerald-400/10 p-4 text-sm text-emerald-100">
+                <div className="flex items-center gap-2 font-semibold">
+                  <CheckCircle2 size={16} />
+                  Imported {importResult.calendar_items?.total ?? 0} calendar items and {importResult.work_items?.total ?? 0} backlog items.
+                </div>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {importResult.review_links?.content_intelligence && (
+                    <Link
+                      href={importResult.review_links.content_intelligence}
+                      className="inline-flex items-center gap-2 rounded-lg border border-emerald-300/40 px-3 py-2 text-emerald-100 hover:bg-emerald-300/10"
+                    >
+                      <ExternalLink size={14} />
+                      Content Intelligence
+                    </Link>
+                  )}
+                  {importResult.review_links?.campaign_calendar && (
+                    <Link
+                      href={importResult.review_links.campaign_calendar}
+                      className="inline-flex items-center gap-2 rounded-lg border border-emerald-300/40 px-3 py-2 text-emerald-100 hover:bg-emerald-300/10"
+                    >
+                      <ExternalLink size={14} />
+                      Campaign calendar
+                    </Link>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {importError && (
+              <div className="mt-4 rounded-lg border border-red-400/30 bg-red-400/10 p-4 text-sm text-red-100">
+                {importError}
+              </div>
+            )}
+          </section>
 
           <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
             <section className="admin-console-card rounded-lg border p-5">

--- a/app/api/admin/content/agentified/campaign/import/route.test.ts
+++ b/app/api/admin/content/agentified/campaign/import/route.test.ts
@@ -1,0 +1,255 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn(),
+  isAuthError: vi.fn(),
+  from: vi.fn(),
+  createAgentWorkItem: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-server', () => ({
+  verifyAdmin: mocks.verifyAdmin,
+  isAuthError: mocks.isAuthError,
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: { from: mocks.from },
+}))
+
+vi.mock('@/lib/agent-work-items', () => ({
+  createAgentWorkItem: mocks.createAgentWorkItem,
+}))
+
+import { GET, POST } from './route'
+
+function request(method: 'GET' | 'POST' = 'POST') {
+  return new Request('http://localhost/api/admin/content/agentified/campaign/import', {
+    method,
+    headers: { authorization: 'Bearer admin-token', 'content-type': 'application/json' },
+  })
+}
+
+function campaignLookup(data: Record<string, unknown> | null = null) {
+  const maybeSingle = vi.fn(async () => ({ data, error: null }))
+  const eq = vi.fn(() => ({ maybeSingle }))
+  const select = vi.fn(() => ({ eq }))
+  return { select, eq, maybeSingle }
+}
+
+function campaignInsert(id = 'campaign-agentified') {
+  const single = vi.fn(async () => ({
+    data: { id, slug: 'agentified-trust-scale-2026-07' },
+    error: null,
+  }))
+  const select = vi.fn(() => ({ single }))
+  const insert = vi.fn(() => ({ select }))
+  return { insert, select, single }
+}
+
+function calendarLookup(data: Array<Record<string, unknown>> = []) {
+  const eq = vi.fn(async () => ({ data, error: null }))
+  const select = vi.fn(() => ({ eq }))
+  return { select, eq }
+}
+
+function calendarInsert(idPrefix = 'calendar-new') {
+  let count = 0
+  const single = vi.fn(async () => {
+    count += 1
+    return {
+      data: {
+        id: `${idPrefix}-${count}`,
+        title: 'Inserted calendar item',
+        authorization_status: 'pending',
+      },
+      error: null,
+    }
+  })
+  const select = vi.fn(() => ({ single }))
+  const insert = vi.fn(() => ({ select }))
+  return { insert, select, single }
+}
+
+function calendarUpdate(idPrefix = 'calendar-existing') {
+  let count = 0
+  const single = vi.fn(async () => {
+    count += 1
+    return {
+      data: {
+        id: `${idPrefix}-${count}`,
+        title: 'Updated calendar item',
+        authorization_status: 'pending',
+      },
+      error: null,
+    }
+  })
+  const select = vi.fn(() => ({ single }))
+  const eq = vi.fn(() => ({ select }))
+  const update = vi.fn(() => ({ eq }))
+  return { update, eq, select, single }
+}
+
+describe('/api/admin/content/agentified/campaign/import', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyAdmin.mockResolvedValue({ user: { id: 'admin-user', email: 'admin@example.com' } })
+    mocks.isAuthError.mockReturnValue(false)
+    mocks.createAgentWorkItem.mockImplementation((input: { idempotencyKey: string }) => Promise.resolve({
+      id: input.idempotencyKey.replace('agentified-launch:', 'work-'),
+    }))
+  })
+
+  it('requires admin auth', async () => {
+    mocks.verifyAdmin.mockResolvedValue({ error: 'Unauthorized', status: 401 })
+    mocks.isAuthError.mockReturnValue(true)
+
+    const response = await POST(request() as never)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mocks.from).not.toHaveBeenCalled()
+  })
+
+  it('previews the Agentified launch packet summary without mutating data', async () => {
+    const response = await GET(request('GET') as never)
+
+    expect(response.status).toBe(200)
+    expect(mocks.from).not.toHaveBeenCalled()
+    expect(await response.json()).toMatchObject({
+      summary: {
+        campaign_slug: 'agentified-trust-scale-2026-07',
+        template_key: 'whisper_to_shout',
+        calendar_item_count: 12,
+        supported_channels: ['linkedin', 'youtube_shorts', 'thumbnail'],
+        side_effects: expect.objectContaining({
+          social_drafts_created: false,
+          publish: false,
+          external_post: false,
+        }),
+      },
+    })
+  })
+
+  it('imports campaign, central backlog work items, and calendar items without external execution', async () => {
+    const campaignRead = campaignLookup(null)
+    const campaignCreate = campaignInsert('campaign-agentified')
+    const calendarRead = calendarLookup([])
+    const calendarCreate = calendarInsert()
+
+    mocks.from.mockImplementation((table: string) => {
+      if (table === 'attraction_campaigns') {
+        const attractionCalls = mocks.from.mock.calls.filter(([name]) => name === 'attraction_campaigns').length
+        return attractionCalls === 1 ? { select: campaignRead.select } : { insert: campaignCreate.insert }
+      }
+      if (table === 'social_content_calendar_items') {
+        const calendarCalls = mocks.from.mock.calls.filter(([name]) => name === 'social_content_calendar_items').length
+        return calendarCalls === 1 ? { select: calendarRead.select } : { insert: calendarCreate.insert }
+      }
+      return {}
+    })
+
+    const response = await POST(request() as never)
+
+    expect(response.status).toBe(200)
+    expect(campaignCreate.insert).toHaveBeenCalledWith(expect.objectContaining({
+      slug: 'agentified-trust-scale-2026-07',
+      status: 'draft',
+      created_by: 'admin-user',
+    }))
+    expect(mocks.createAgentWorkItem).toHaveBeenCalledTimes(12)
+    expect(mocks.createAgentWorkItem).toHaveBeenCalledWith(expect.objectContaining({
+      source: expect.objectContaining({ type: 'social_topic_trigger', id: 'AGT-LI-01' }),
+      metadata: expect.objectContaining({
+        social_topic_trigger: true,
+        campaign_slug: 'agentified-trust-scale-2026-07',
+        agentified_asset_id: 'AGT-LI-01',
+        channel_lanes: expect.objectContaining({
+          linkedin: expect.objectContaining({ status: 'selected' }),
+        }),
+        insight: expect.objectContaining({
+          approved_research_patterns: expect.arrayContaining([
+            expect.objectContaining({ pattern_status: 'usable_framework' }),
+          ]),
+        }),
+        side_effects: expect.objectContaining({
+          provider_generation: false,
+          publish: false,
+          external_post: false,
+        }),
+      }),
+      idempotencyKey: 'agentified-launch:AGT-LI-01',
+    }))
+    expect(calendarCreate.insert).toHaveBeenCalledTimes(12)
+    expect(calendarCreate.insert).toHaveBeenCalledWith(expect.objectContaining({
+      campaign_id: 'campaign-agentified',
+      agent_work_item_id: 'work-AGT-LI-01',
+      channel: 'linkedin',
+      authorization_status: 'pending',
+      metadata: expect.objectContaining({
+        agentified_asset_id: 'AGT-LI-01',
+        external_execution_enabled: false,
+        side_effects: expect.objectContaining({
+          social_draft_created: false,
+          publish: false,
+          external_post: false,
+        }),
+      }),
+    }))
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      campaign: { id: 'campaign-agentified', created: true },
+      work_items: { total: 12 },
+      calendar_items: { inserted_count: 12, updated_count: 0, total: 12 },
+      side_effects: {
+        provider_generation: false,
+        upload: false,
+        publish: false,
+        external_post: false,
+        social_drafts_created: false,
+      },
+    })
+  })
+
+  it('updates matching Agentified calendar rows instead of inserting duplicates', async () => {
+    const campaignRead = campaignLookup({
+      id: 'campaign-agentified',
+      slug: 'agentified-trust-scale-2026-07',
+      status: 'draft',
+    })
+    const campaignUpdate = calendarUpdate('campaign-updated')
+    const existingCalendar = calendarLookup([
+      { id: 'calendar-li-1', metadata: { agentified_asset_id: 'AGT-LI-01' } },
+    ])
+    const calendarExistingUpdate = calendarUpdate()
+    const calendarCreate = calendarInsert()
+
+    mocks.from.mockImplementation((table: string) => {
+      if (table === 'attraction_campaigns') {
+        const attractionCalls = mocks.from.mock.calls.filter(([name]) => name === 'attraction_campaigns').length
+        return attractionCalls === 1 ? { select: campaignRead.select } : { update: campaignUpdate.update }
+      }
+      if (table === 'social_content_calendar_items') {
+        const calendarCalls = mocks.from.mock.calls.filter(([name]) => name === 'social_content_calendar_items').length
+        if (calendarCalls === 1) return { select: existingCalendar.select }
+        if (calendarCalls === 2) return { update: calendarExistingUpdate.update }
+        return { insert: calendarCreate.insert }
+      }
+      return {}
+    })
+
+    const response = await POST(request() as never)
+
+    expect(response.status).toBe(200)
+    expect(campaignUpdate.update).toHaveBeenCalled()
+    expect(calendarExistingUpdate.update).toHaveBeenCalledWith(expect.objectContaining({
+      agent_work_item_id: 'work-AGT-LI-01',
+      metadata: expect.objectContaining({ agentified_asset_id: 'AGT-LI-01' }),
+    }))
+    expect(calendarCreate.insert).toHaveBeenCalledTimes(11)
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      campaign: { id: 'campaign-updated-1', created: false, updated: true },
+      calendar_items: { inserted_count: 11, updated_count: 1, total: 12 },
+    })
+  })
+})

--- a/app/api/admin/content/agentified/campaign/import/route.ts
+++ b/app/api/admin/content/agentified/campaign/import/route.ts
@@ -1,0 +1,199 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAdmin, isAuthError } from '@/lib/auth-server'
+import { createAgentWorkItem } from '@/lib/agent-work-items'
+import {
+  agentifiedLaunchImportPlan,
+  agentifiedLaunchSummary,
+  buildAgentifiedCalendarRow,
+  buildAgentifiedWorkItemInput,
+} from '@/lib/agentified-launch-campaign'
+import { supabaseAdmin } from '@/lib/supabase'
+
+export const dynamic = 'force-dynamic'
+
+type CampaignRow = {
+  id: string
+  slug: string
+  status?: string | null
+}
+
+type ExistingCalendarRow = {
+  id: string
+  metadata?: Record<string, unknown> | null
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
+}
+
+async function upsertCampaign(userId: string) {
+  const plan = agentifiedLaunchImportPlan()
+  const { data: existing, error: readError } = await supabaseAdmin
+    .from('attraction_campaigns')
+    .select('*')
+    .eq('slug', plan.campaign.slug)
+    .maybeSingle()
+
+  if (readError) throw readError
+
+  const campaignPatch = {
+    name: plan.campaign.name,
+    slug: plan.campaign.slug,
+    description: plan.campaign.description,
+    campaign_type: plan.campaign.campaign_type,
+    starts_at: plan.campaign.starts_at,
+    ends_at: plan.campaign.ends_at,
+    enrollment_deadline: plan.campaign.enrollment_deadline,
+    completion_window_days: plan.campaign.completion_window_days,
+    min_purchase_amount: plan.campaign.min_purchase_amount,
+    payout_type: plan.campaign.payout_type,
+    payout_amount_type: plan.campaign.payout_amount_type,
+    payout_amount_value: plan.campaign.payout_amount_value,
+    rollover_bonus_multiplier: plan.campaign.rollover_bonus_multiplier,
+    hero_image_url: plan.campaign.hero_image_url,
+    promo_copy: plan.campaign.promo_copy,
+  }
+
+  if (existing?.id) {
+    const { data, error } = await supabaseAdmin
+      .from('attraction_campaigns')
+      .update(campaignPatch)
+      .eq('id', existing.id)
+      .select('*')
+      .single()
+
+    if (error) throw error
+    return { campaign: data as CampaignRow, created: false, updated: true }
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from('attraction_campaigns')
+    .insert({
+      ...campaignPatch,
+      status: plan.campaign.status,
+      created_by: userId,
+    })
+    .select('*')
+    .single()
+
+  if (error) throw error
+  return { campaign: data as CampaignRow, created: true, updated: false }
+}
+
+async function readExistingCalendarItems(campaignId: string) {
+  const { data, error } = await supabaseAdmin
+    .from('social_content_calendar_items')
+    .select('id, metadata')
+    .eq('campaign_id', campaignId)
+
+  if (error) {
+    if (error.code === '42P01' || error.code === 'PGRST205') return []
+    throw error
+  }
+
+  return (data ?? []) as ExistingCalendarRow[]
+}
+
+export async function GET(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  return NextResponse.json({
+    summary: agentifiedLaunchSummary(),
+  })
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await verifyAdmin(request)
+  if (isAuthError(auth)) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  try {
+    const plan = agentifiedLaunchImportPlan()
+    const campaignResult = await upsertCampaign(auth.user.id)
+
+    const workItems = []
+    for (const item of plan.calendar_items) {
+      const workItem = await createAgentWorkItem(buildAgentifiedWorkItemInput(item))
+      workItems.push({ asset_id: item.asset_id, work_item: workItem })
+    }
+
+    const existingCalendar = await readExistingCalendarItems(campaignResult.campaign.id)
+    const existingByAssetId = new Map<string, ExistingCalendarRow>()
+    for (const row of existingCalendar) {
+      const assetId = asRecord(row.metadata).agentified_asset_id
+      if (typeof assetId === 'string') existingByAssetId.set(assetId, row)
+    }
+
+    const inserted = []
+    const updated = []
+    for (const { asset_id, work_item } of workItems) {
+      const item = plan.calendar_items.find((candidate) => candidate.asset_id === asset_id)
+      if (!item) continue
+      const row = buildAgentifiedCalendarRow({
+        item,
+        campaignId: campaignResult.campaign.id,
+        workItemId: work_item.id,
+        createdBy: auth.user.id,
+      })
+      const existing = existingByAssetId.get(asset_id)
+
+      if (existing) {
+        const { data, error } = await supabaseAdmin
+          .from('social_content_calendar_items')
+          .update(row)
+          .eq('id', existing.id)
+          .select('id, title, channel, campaign_phase, authorization_status, agent_work_item_id, metadata')
+          .single()
+
+        if (error) throw error
+        updated.push(data)
+      } else {
+        const { data, error } = await supabaseAdmin
+          .from('social_content_calendar_items')
+          .insert(row)
+          .select('id, title, channel, campaign_phase, authorization_status, agent_work_item_id, metadata')
+          .single()
+
+        if (error) throw error
+        inserted.push(data)
+      }
+    }
+
+    return NextResponse.json({
+      ok: true,
+      campaign: {
+        id: campaignResult.campaign.id,
+        slug: campaignResult.campaign.slug,
+        created: campaignResult.created,
+        updated: campaignResult.updated,
+      },
+      work_items: {
+        total: workItems.length,
+        ids: workItems.map(({ work_item }) => work_item.id),
+      },
+      calendar_items: {
+        inserted_count: inserted.length,
+        updated_count: updated.length,
+        total: inserted.length + updated.length,
+        inserted,
+        updated,
+      },
+      review_links: {
+        content_intelligence: '/admin/agents/content-intelligence',
+        campaign_calendar: `/admin/campaigns/${campaignResult.campaign.id}`,
+        agentified_admin: '/admin/content/agentified',
+      },
+      side_effects: plan.side_effects,
+    })
+  } catch (error) {
+    console.error('[agentified-campaign-import] failed:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to import Agentified launch campaign' },
+      { status: 500 },
+    )
+  }
+}

--- a/lib/agentified-launch-campaign.ts
+++ b/lib/agentified-launch-campaign.ts
@@ -1,0 +1,231 @@
+import packet from '@/agentified/campaign/portfolio-campaign-packet.json'
+import {
+  CALENDAR_CHANNEL_LABELS,
+  CALENDAR_SIDE_EFFECTS,
+  type SocialContentCalendarChannel,
+  type SocialContentCampaignPhase,
+} from '@/lib/social-content-calendar'
+import {
+  defaultSocialChannelLanes,
+  type SocialContentIntelligenceChannel,
+} from '@/lib/social-content-intelligence'
+
+const AGENTIFIED_OWNER_AGENT_KEY = 'chief-of-staff'
+const PACKET_PATH = 'agentified/campaign/portfolio-campaign-packet.json'
+
+type PacketCampaign = typeof packet.campaign
+type PacketCalendarItem = (typeof packet.calendar_items)[number]
+
+export type AgentifiedLaunchImportPlan = {
+  packet_path: string
+  packet_status: string
+  campaign: PacketCampaign
+  calendar_items: PacketCalendarItem[]
+  supported_channels: SocialContentCalendarChannel[]
+  side_effects: typeof CALENDAR_SIDE_EFFECTS & {
+    campaign_upsert: true
+    agent_work_items_upsert: true
+    calendar_items_upsert: true
+    social_drafts_created: false
+  }
+}
+
+function unique<T>(values: T[]) {
+  return Array.from(new Set(values))
+}
+
+function channelLabel(channel: string) {
+  return CALENDAR_CHANNEL_LABELS[channel as SocialContentCalendarChannel] ?? channel
+}
+
+function channelToSelectedLane(channel: SocialContentCalendarChannel): SocialContentIntelligenceChannel {
+  if (channel === 'thumbnail') return 'thumbnail'
+  return channel
+}
+
+function phaseLabel(phase: SocialContentCampaignPhase) {
+  return `${phase.slice(0, 1).toUpperCase()}${phase.slice(1)}`
+}
+
+function approvedResearchPattern(item: PacketCalendarItem) {
+  return {
+    source_url: 'agentified/campaign/agentified-rollout-plan.md',
+    source_label: 'Agentified rollout plan',
+    pattern_status: 'usable_framework',
+    hook_structure: `${phaseLabel(item.campaign_phase as SocialContentCampaignPhase)} with a concrete trust/accountability tension before the framework.`,
+    tension_or_missed_opportunity: item.planned_angle,
+    promise_value: 'Show how agentic scale becomes trustworthy only when the operating layer is visible.',
+    proof_style: 'Portfolio/Agent Ops workflow proof, source-safe manuscript positioning, and human approval gates.',
+    title_pattern: `${phaseLabel(item.campaign_phase as SocialContentCampaignPhase)}: practical operating claim`,
+    thumbnail_pattern: 'Inspectable system artifact with AmaduTown restraint and a short trust-oriented phrase.',
+    cta_style: 'Invite operators to inspect the launch asset, request the book/workbook path, or compare their own approval gates.',
+    source_distance_boundary: 'Use as Vambah-owned campaign structure only; do not copy outside creator scripts or private manuscript text.',
+  }
+}
+
+export function agentifiedLaunchImportPlan(): AgentifiedLaunchImportPlan {
+  const supportedChannels = unique(
+    packet.calendar_items.map((item) => item.channel as SocialContentCalendarChannel),
+  )
+
+  return {
+    packet_path: PACKET_PATH,
+    packet_status: packet.packet_status,
+    campaign: packet.campaign,
+    calendar_items: packet.calendar_items,
+    supported_channels: supportedChannels,
+    side_effects: {
+      ...CALENDAR_SIDE_EFFECTS,
+      campaign_upsert: true,
+      agent_work_items_upsert: true,
+      calendar_items_upsert: true,
+      social_drafts_created: false,
+    },
+  }
+}
+
+export function agentifiedLaunchSummary() {
+  const plan = agentifiedLaunchImportPlan()
+  const phaseCounts = plan.calendar_items.reduce<Record<string, number>>((counts, item) => {
+    counts[item.campaign_phase] = (counts[item.campaign_phase] ?? 0) + 1
+    return counts
+  }, {})
+
+  return {
+    campaign_name: plan.campaign.name,
+    campaign_slug: plan.campaign.slug,
+    template_key: 'whisper_to_shout',
+    packet_status: plan.packet_status,
+    packet_path: plan.packet_path,
+    starts_at: plan.campaign.starts_at,
+    ends_at: plan.campaign.ends_at,
+    calendar_item_count: plan.calendar_items.length,
+    supported_channels: plan.supported_channels,
+    phase_counts: phaseCounts,
+    side_effects: plan.side_effects,
+  }
+}
+
+export function buildAgentifiedWorkItemInput(item: PacketCalendarItem) {
+  const channel = item.channel as SocialContentCalendarChannel
+  const selectedLane = channelToSelectedLane(channel)
+  const now = new Date().toISOString()
+  const lanes = defaultSocialChannelLanes()
+  lanes[selectedLane] = {
+    ...lanes[selectedLane],
+    status: 'selected',
+    updated_at: now,
+  }
+
+  return {
+    title: `Agentified ${phaseLabel(item.campaign_phase as SocialContentCampaignPhase)}: ${item.title}`,
+    objective: [
+      `Prepare ${channelLabel(channel)} review assets for the Agentified trust-scale launch.`,
+      item.planned_angle,
+      'Keep all provider generation, uploads, scheduling, and publishing behind later human gates.',
+    ].join(' '),
+    priority: item.campaign_phase === 'offer' || item.campaign_phase === 'proof' ? 'high' as const : 'medium' as const,
+    status: 'queued' as const,
+    ownerAgentKey: AGENTIFIED_OWNER_AGENT_KEY,
+    ownerRuntime: 'manual' as const,
+    source: {
+      type: 'social_topic_trigger',
+      id: item.asset_id,
+      label: item.title,
+    },
+    expectedFiles: [
+      'agentified/campaign/draft-assets.md',
+      'agentified/campaign/release-calendar.md',
+      'agentified/campaign/human-gate-review.md',
+    ],
+    overlapGroup: 'agentified-launch-campaign',
+    metadata: {
+      social_topic_trigger: true,
+      insight_version: 'agentified_launch_campaign_v1',
+      generated_at: now,
+      generated_by: 'agentified_launch_import',
+      trigger_source: 'agentified_campaign_packet',
+      source_policy: 'public_safe_campaign_packet_only',
+      source_counts: {
+        campaign_packet: 1,
+        calendar_item: 1,
+      },
+      privacy_boundary: 'Do not expose raw manuscript drafts, private chats, Chronicle notes, client data, or unpublished provider assets.',
+      research_packet_ids: [],
+      campaign_slug: item.campaign_slug,
+      campaign_phase: item.campaign_phase,
+      calendar_channel: item.channel,
+      agentified_asset_id: item.asset_id,
+      draft_asset_path: item.metadata.draft_asset_path,
+      channel_lanes: lanes,
+      insight: {
+        candidate_id: item.asset_id,
+        title: item.title,
+        triggering_event: 'Agentified book and workbook rollout campaign',
+        source_type: 'agentified_campaign_packet',
+        source_label: PACKET_PATH,
+        source_ids: [item.asset_id],
+        why_vambah_can_speak: 'Vambah is actively building the Portfolio/Agent Ops operating layer that Agentified describes, including evidence, routing, approvals, evals, and human gates.',
+        brand_goal: 'Position Agentified as the practical bridge from AI experimentation to governed agentic execution.',
+        content_angle: item.planned_angle,
+        suggested_hook: item.title,
+        audience: 'Product leaders, builders, founders, nonprofit and small-business operators, and AI-curious teams carrying the risk of agentic work.',
+        sensitivity: 'public_safe_review_required',
+        evidence_summary: 'Prepared from the Agentified campaign packet, release calendar, human gate review, manuscript/workbook proof paths, and Portfolio operating-system surfaces.',
+        claim_boundaries: [
+          'Represent Agentified as a prepare-only launch campaign until Vambah approves public copy.',
+          'Use Portfolio/Agent Ops as proof of operating-system design without exposing private admin records.',
+          'Do not imply autonomous platform publishing, provider rendering, or external scheduling.',
+        ],
+        approved_research_patterns: [approvedResearchPattern(item)],
+      },
+      side_effects: {
+        provider_generation: false,
+        upload: false,
+        schedule: false,
+        publish: false,
+        external_post: false,
+      },
+    },
+    idempotencyKey: `agentified-launch:${item.asset_id}`,
+  }
+}
+
+export function buildAgentifiedCalendarRow(input: {
+  item: PacketCalendarItem
+  campaignId: string
+  workItemId: string
+  createdBy: string
+}) {
+  return {
+    campaign_id: input.campaignId,
+    agent_work_item_id: input.workItemId,
+    social_content_id: null,
+    channel: input.item.channel,
+    campaign_phase: input.item.campaign_phase,
+    title: input.item.title.slice(0, 240),
+    planned_angle: input.item.planned_angle,
+    scheduled_for: input.item.scheduled_for,
+    due_status: input.item.due_status,
+    authorization_status: input.item.authorization_status,
+    authorization_due_at: input.item.authorization_due_at,
+    autonomy_eligible: false,
+    metadata: {
+      ...input.item.metadata,
+      agentified_asset_id: input.item.asset_id,
+      campaign_slug: input.item.campaign_slug,
+      source_packet_path: PACKET_PATH,
+      external_execution_enabled: false,
+      imported_from_agentified_packet: true,
+      side_effects: {
+        provider_generation: false,
+        upload: false,
+        external_schedule: false,
+        publish: false,
+        external_post: false,
+        social_draft_created: false,
+      },
+    },
+    created_by: input.createdBy,
+  }
+}


### PR DESCRIPTION
## Summary
- Add an Agentified launch campaign adapter that converts the prepared `whisper_to_shout` packet into central Agent Ops backlog work items and campaign calendar rows.
- Add an admin-only import endpoint at `/api/admin/content/agentified/campaign/import` with a read-only GET preview and idempotent POST import.
- Add an Agentified admin panel button to import the prepared launch backlog and route review back to Content Intelligence and the campaign calendar.

## Validation
- `npm test -- app/api/admin/content/agentified/campaign/import/route.test.ts`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `npx eslint app/admin/content/agentified/page.tsx app/api/admin/content/agentified/campaign/import/route.ts app/api/admin/content/agentified/campaign/import/route.test.ts lib/agentified-launch-campaign.ts`
- Browser smoke on `http://localhost:3104/admin/content/agentified`: logged in with existing local E2E credentials, confirmed the launch campaign backlog panel, import button, 12 calendar-item count, supported channels, and locked external execution state render. Did not click import during smoke.

## Integration Notes
- No migrations or env changes.
- Import creates/updates internal `attraction_campaigns`, `agent_work_items`, and `social_content_calendar_items` only after an admin explicitly clicks the import action.
- No provider calls, uploads, external scheduling, external posts, social drafts, or publishing are triggered by previewing the page or route.
- Integration Captain should run merge sequencing and deployment verification.
- Vercel contexts not checked by this implementation thread:
  - Vercel – portfolio
  - Vercel – portfolio-staging
