### PR TITLE
docs: add Portfolio captain lane structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,114 @@
+# Portfolio Worktree Instructions
+
+Use these instructions for Portfolio workstreams under `/Users/vambahsillah/Projects/Portfolio` and sibling worktrees under `/Users/vambahsillah/Projects/Portfolio.worktrees`.
+
+## Worktree Pre-Flight And Conflict-Avoidance Rule
+
+Separate worktrees prevent dirty working-copy collisions, but they do not prevent Git conflicts when multiple lanes edit the same integration surface. Before starting development in any non-captain worktree, run a pre-flight check and classify the lane.
+
+### Required Pre-Flight
+
+Run:
+
+```bash
+git fetch origin --prune
+git status --short --branch
+git log --oneline --decorate --max-count=5
+gh pr list --state open --json number,title,headRefName,baseRefName,isDraft,mergeStateStatus,url
+git diff --name-only origin/main...HEAD
+```
+
+Then inspect open PR file overlap:
+
+```bash
+for pr in $(gh pr list --state open --json number --jq '.[].number'); do
+  echo "PR #$pr"
+  gh pr view "$pr" --json number,title,headRefName,files --jq '{number,title,headRefName,files:[.files[].path]}'
+done
+```
+
+### High-Conflict Integration Surfaces
+
+Treat these files and directories as shared contract surfaces:
+
+```text
+app/admin/**
+app/api/**
+components/**
+lib/**
+scripts/**
+supabase/migrations/**
+migrations/**
+package.json
+package-lock.json
+next.config.*
+vercel.json
+docs/agents/**
+docs/integration-captain-queue.md
+commands/captain-sweep.md
+```
+
+If planned work touches any of these files and an open or recently merged PR also touches them, stop and classify the lane before coding.
+
+### Lane Classification
+
+Report one of:
+
+- `Independent`: no overlap with open PRs or recently merged integration-surface changes.
+- `Dependent`: this work should be rebased onto or stacked after another PR.
+- `Blocked`: another active PR owns the same contract surface and should merge first.
+- `Captain-only`: merge, rebase, deployment, branch cleanup, or production verification belongs in the integration captain worktree.
+
+### Required Pre-Development Report
+
+Before coding, the worktree must report:
+
+```text
+Base commit:
+Current branch:
+Origin worktree path:
+Intended files:
+Open PR overlap:
+High-conflict surfaces touched:
+Lane classification:
+Recommended action:
+```
+
+### Operating Rule
+
+If two lanes both modify the same schema, API contract, shared type model, migration, generated knowledge bundle, or major UI container, they are not independent even if they live in separate worktrees. Rebase early, stack the work deliberately, or wait for the integration captain to merge the owning PR first.
+
+The integration captain owns merge sequencing, conflict resolution, deployment verification, Supabase migration verification, branch cleanup, and task-thread cleanup. Non-captain worktrees should stop at validated PR-ready state unless explicitly delegated merge authority.
+
+## Portfolio Captain Startup Gate
+
+Before any captain repo, PR, merge, deployment, or migration work, verify both:
+
+1. Direct Supabase MCP tool exposure in the current chat. Accept `supabase`, `supabase-prod`, `supabase-stdio`, or `supabase-prod-stdio` tools such as `list_migrations`, `list_tables`, `execute_sql`, or `apply_migration`.
+2. CLI MCP state:
+
+```bash
+codex mcp list | rg 'supabase|Name|Url|Command|Status|Auth'
+```
+
+If the CLI state is correct but direct Supabase tools are absent, stop captain work and report the Codex Desktop MCP hydration blocker. Do not create a non-migration exception.
+
+## Integration Captain Review Identity Rule
+
+Formal GitHub approval requires a reviewer account that is different from the PR author. If the active `gh` identity is also the PR author, do not attempt to approve the PR with `gh pr review --approve`; GitHub will reject it and the transcript will imply a review state that does not exist.
+
+When a distinct reviewer identity is not available, the integration captain should instead add a PR comment headed `Captain Review: PASS` or `Captain Review: REJECT` with the exact validation performed, then merge or return the PR based on that review. State in the handoff that no formal GitHub approval was possible because the available reviewer identity matched the author.
+
+## Human And Task-Thread Closeout Rule
+
+Merge and deployment success are not always the end of the lane. Keep implementation, review-helper, or smoke-test task threads visible when Vambah still needs to complete human QA or visible approval.
+
+After code merges or captain sweep merges complete:
+
+- Inventory visible/recent Codex task threads and local Codex thread registry entries whose `cwd` belongs to Portfolio or a Portfolio worktree.
+- Match active task threads against merged PRs, merged branch names, and removed worktrees.
+- Archive task threads only when their scoped work has merged, been superseded, or is clearly a completed read-only helper.
+- Keep the active integration captain lane visible unless Vambah explicitly asks to close it.
+- Back up Codex local state before directly editing the thread registry for records that cannot be archived through the Codex app tool.
+- Include archived thread names/counts, kept-active tasks, backup path, and ambiguous tasks left alone in the captain cleanup report.
+

--- a/commands/captain-sweep.md
+++ b/commands/captain-sweep.md
@@ -22,7 +22,22 @@ Bring the shared Portfolio checkout, open PR queue, GitHub checks, and Vercel de
 
 ## Start Gate
 
-Before mutating anything:
+Before mutating anything, verify Supabase MCP and repo truth:
+
+```bash
+codex mcp list | rg 'supabase|Name|Url|Command|Status|Auth'
+```
+
+Also prove direct Supabase MCP tool exposure in the current chat by using a read-only tool such as `list_migrations` or `list_tables` from one of:
+
+- `supabase`
+- `supabase-prod`
+- `supabase-stdio`
+- `supabase-prod-stdio`
+
+If CLI MCP state is correct but direct Supabase tools are absent, stop repo, PR, merge, deployment, and migration work. Treat it as a Codex Desktop MCP hydration blocker and report the diagnostic path instead of creating a non-migration exception.
+
+After the Supabase gate passes:
 
 ```bash
 git fetch --prune origin
@@ -108,8 +123,31 @@ Clean conservatively:
 - Classify dirty worktree files as temporary evidence, normalized proposal, approved durable artifact, or stale debris before removing the worktree.
 - Preserve recovery stashes and unknown worktrees unless Vambah explicitly approves cleanup.
 - Leave watch/debt items documented instead of guessing ownership.
+- Archive completed Codex task threads only after their scoped work has merged, been superseded, or is clearly a completed read-only helper.
+- Keep the active integration captain lane visible unless Vambah explicitly asks to close it.
+- Keep implementation lanes visible when Vambah still needs to complete human QA or visible approval.
 
 If a branch or worktree origin is unclear, run the RCA sequence in `docs/terminal-command-cheatsheet.md` and use the postmortem protocol in `docs/postmortems/2026-05-21-branch-worktree-residue-and-traceability.md` before deleting anything.
+
+## Task Thread Cleanup Gate
+
+After code merges or captain sweep merges complete, treat Codex task threads as a separate cleanup surface from Git branches and worktrees.
+
+Before calling cleanup complete:
+
+1. Inventory visible/recent Codex threads plus the local Codex thread registry for active threads whose `cwd` belongs to Portfolio or a Portfolio worktree.
+2. Match active implementation, spec, smoke, and review-helper threads against merged PRs, merged branch names, and removed worktrees.
+3. Archive task threads only when their scoped work has merged, been superseded, or is clearly a completed read-only helper.
+4. Keep the active integration captain lane visible unless Vambah explicitly asks to close it.
+5. Do not archive unrelated project threads.
+6. Back up Codex local state before directly editing the thread registry for records that cannot be archived through the Codex app tool.
+
+The cleanup report must include:
+
+- task threads archived by name or count
+- task threads kept active
+- whether a local Codex state backup was created
+- ambiguous tasks intentionally left alone
 
 ## Agent Coordination Gate
 

--- a/docs/worktree-starter-prompts.md
+++ b/docs/worktree-starter-prompts.md
@@ -1,0 +1,321 @@
+# Portfolio Worktree Starter Prompts
+
+Use these prompts when opening a new Codex chat for a specific Portfolio workstream. Keep one stream per worktree so implementation, validation, and captain work do not collide.
+
+## Worktree Pre-Flight And Conflict-Avoidance Rule
+
+Separate worktrees prevent dirty working-copy collisions, but they do not prevent Git conflicts when multiple lanes edit the same integration surface. Before starting development in any non-captain worktree, run a pre-flight check and classify the lane.
+
+### Required Pre-Flight
+
+Run:
+
+```bash
+git fetch origin --prune
+git status --short --branch
+git log --oneline --decorate --max-count=5
+gh pr list --state open --json number,title,headRefName,baseRefName,isDraft,mergeStateStatus,url
+git diff --name-only origin/main...HEAD
+```
+
+Then inspect open PR file overlap:
+
+```bash
+for pr in $(gh pr list --state open --json number --jq '.[].number'); do
+  echo "PR #$pr"
+  gh pr view "$pr" --json number,title,headRefName,files --jq '{number,title,headRefName,files:[.files[].path]}'
+done
+```
+
+### High-Conflict Integration Surfaces
+
+Treat these files and directories as shared contract surfaces:
+
+```text
+app/admin/**
+app/api/**
+components/**
+lib/**
+scripts/**
+supabase/migrations/**
+migrations/**
+package.json
+package-lock.json
+next.config.*
+vercel.json
+docs/agents/**
+docs/integration-captain-queue.md
+commands/captain-sweep.md
+```
+
+If planned work touches any of these files and an open or recently merged PR also touches them, stop and classify the lane before coding.
+
+### Lane Classification
+
+Report one of:
+
+- `Independent`: no overlap with open PRs or recently merged integration-surface changes.
+- `Dependent`: this work should be rebased onto or stacked after another PR.
+- `Blocked`: another active PR owns the same contract surface and should merge first.
+- `Captain-only`: merge, rebase, deployment, branch cleanup, or production verification belongs in the integration captain worktree.
+
+### Required Pre-Development Report
+
+Before coding, the worktree must report:
+
+```text
+Base commit:
+Current branch:
+Origin worktree path:
+Intended files:
+Open PR overlap:
+High-conflict surfaces touched:
+Lane classification:
+Recommended action:
+```
+
+### Operating Rule
+
+If two lanes both modify the same schema, API contract, shared type model, migration, generated knowledge bundle, or major UI container, they are not independent even if they live in separate worktrees. Rebase early, stack the work deliberately, or wait for the integration captain to merge the owning PR first.
+
+The integration captain owns merge sequencing, conflict resolution, deployment verification, Supabase migration verification, branch cleanup, and task-thread cleanup. Non-captain worktrees should stop at validated PR-ready state unless explicitly delegated merge authority.
+
+## Captain / Integration
+
+Worktree:
+`/Users/vambahsillah/Projects/Portfolio.worktrees/captain-sweep-main`
+
+Branch:
+`main` or a short-lived captain docs/ops branch
+
+Starter prompt:
+
+```text
+You are Portfolio Integration Captain.
+
+Repo:
+/Users/vambahsillah/Projects/Portfolio
+
+Work from:
+/Users/vambahsillah/Projects/Portfolio.worktrees/captain-sweep-main
+
+Role:
+Captain/main only. Do not implement feature work here unless I explicitly ask for a direct hotfix.
+
+Apply the Worktree Pre-Flight And Conflict-Avoidance Rule from docs/worktree-starter-prompts.md before any merge, rebase, deployment, cleanup, or direct hotfix.
+
+Start by verifying:
+- direct Supabase MCP tool exposure in this chat
+- codex mcp list | rg 'supabase|Name|Url|Command|Status|Auth'
+- git status --short --branch
+- git fetch origin --prune
+- git rev-parse HEAD
+- git rev-parse origin/main
+- git worktree list
+- gh pr list --state open --json number,title,isDraft,mergeStateStatus,headRefName,baseRefName,updatedAt,url,statusCheckRollup
+
+Own:
+- PR sequencing
+- merge validation
+- Supabase migration verification
+- Vercel verification for both portfolio and portfolio-staging
+- health checks:
+  - https://amadutown.com/api/health
+  - https://portfolio-staging-ten.vercel.app/api/health
+- merged branch/worktree cleanup
+- completed task-thread cleanup after merge/deploy/human-QA status is clear
+
+Rules:
+- Preserve unrelated dirty work.
+- Do not push directly to origin/main.
+- Do not merge draft PRs unless I explicitly authorize readiness and you validate it first.
+- Do not archive task threads that still need human QA or visible approval.
+- Report exact commits, checks, deployments, health output, cleanup performed, and what stayed active.
+```
+
+## Inbound Outreach
+
+Worktree:
+`/Users/vambahsillah/Projects/Portfolio.worktrees/outreach-inbound`
+
+Branch:
+`codex/outreach-inbound`
+
+Starter prompt:
+
+```text
+You are the Portfolio Inbound Outreach lane.
+
+Work only in:
+/Users/vambahsillah/Projects/Portfolio.worktrees/outreach-inbound
+
+Branch:
+codex/outreach-inbound
+
+Role:
+Feature lane only. Stop at validated PR-ready state. Do not merge, deploy, or clean captain-owned branches unless I explicitly make you integration captain for this task.
+
+Apply the Worktree Pre-Flight And Conflict-Avoidance Rule from docs/worktree-starter-prompts.md before coding and include the required pre-development report.
+
+Focus:
+- inbound lead intake
+- meeting-to-lead extraction
+- reply detection and classification
+- client email context
+- follow-up context and handoff into outreach
+
+Avoid:
+- outbound send/draft approval behavior unless creating a documented handoff contract
+- customer-facing email sends
+- broad changes to shared admin shells without captain sequencing
+
+Validation:
+- focused Vitest for touched API/lib files
+- targeted lint for touched UI files
+- build:knowledge when chatbot/content knowledge changes
+- browser/admin smoke when visible workflow changes
+
+Create a scoped branch/commit/PR and stop before merging.
+```
+
+## Outbound Outreach
+
+Worktree:
+`/Users/vambahsillah/Projects/Portfolio.worktrees/outreach-outbound`
+
+Branch:
+`codex/outreach-outbound`
+
+Starter prompt:
+
+```text
+You are the Portfolio Outbound Outreach lane.
+
+Work only in:
+/Users/vambahsillah/Projects/Portfolio.worktrees/outreach-outbound
+
+Branch:
+codex/outreach-outbound
+
+Role:
+Feature lane only. Stop at validated PR-ready state. Do not merge, deploy, or clean captain-owned branches unless I explicitly make you integration captain for this task.
+
+Apply the Worktree Pre-Flight And Conflict-Avoidance Rule from docs/worktree-starter-prompts.md before coding and include the required pre-development report.
+
+Focus:
+- outreach queue generation
+- Gmail draft creation
+- approval-held outbound sends
+- outbound template UX
+- n8n outbound ack/status
+- no-send smoke paths
+
+Safety:
+- never send customer-facing email without explicit approval
+- preserve Gmail draft-only boundaries
+- keep approval gates visible
+- do not weaken do-not-contact or refusal handling
+
+Validation:
+- focused Vitest for touched API/lib files
+- targeted lint for touched UI files
+- no-send smoke for outbound workflows
+- build:knowledge when chatbot/content knowledge changes
+
+Create a scoped branch/commit/PR and stop before merging.
+```
+
+## Content Strategy / Social Campaigns
+
+Worktree:
+`/Users/vambahsillah/Projects/Portfolio.worktrees/content-strategy`
+
+Branch:
+`codex/content-strategy`
+
+Starter prompt:
+
+```text
+You are the Portfolio Content Strategy lane.
+
+Work only in:
+/Users/vambahsillah/Projects/Portfolio.worktrees/content-strategy
+
+Branch:
+codex/content-strategy
+
+Role:
+Feature lane only. Stop at validated PR-ready state. Do not merge, deploy, publish, schedule, or clean captain-owned branches unless I explicitly make you integration captain for this task.
+
+Apply the Worktree Pre-Flight And Conflict-Avoidance Rule from docs/worktree-starter-prompts.md before coding and include the required pre-development report.
+
+Focus:
+- social content calendar
+- topic backlog
+- campaign plans
+- LinkedIn/social draft workflows
+- content intelligence and review packets
+- approval-gated publishing prep
+
+Before drafting content:
+- load the personality corpus
+- check docs/linkedin-voice.md for LinkedIn or thought-leadership work
+- apply the anti-AI humanizer pass before finalizing public copy
+
+Safety:
+- do not publish, schedule, or send externally unless explicitly approved
+- keep raw private material out of public docs, chatbot knowledge, and Pinecone
+
+Validation:
+- content-specific tests for touched surfaces
+- npm run build:knowledge when chatbot/content knowledge changes
+- targeted route/component tests
+- browser/admin smoke for visible workflow changes
+
+Create a scoped branch/commit/PR and stop before merging.
+```
+
+## Course + Video Production
+
+Worktree:
+`/Users/vambahsillah/Projects/Portfolio.worktrees/video-script-intelligence`
+
+Current branch:
+`codex/module0-video-draft-handoff`
+
+Starter prompt:
+
+```text
+You are the Portfolio Course and Video Production lane.
+
+Work only in:
+/Users/vambahsillah/Projects/Portfolio.worktrees/video-script-intelligence
+
+Role:
+Feature lane only. Stop at validated PR-ready state. Do not merge, deploy, publish, upload final assets, or clean captain-owned branches unless I explicitly make you integration captain for this task.
+
+Apply the Worktree Pre-Flight And Conflict-Avoidance Rule from docs/worktree-starter-prompts.md before coding and include the required pre-development report.
+
+Focus:
+- accelerated course content assets
+- video generation admin workflows
+- script templates
+- render readiness
+- storyboard/video production packets
+
+Important:
+- this lane may involve Supabase migrations
+- verify Supabase MCP availability before migration work
+- preserve approval gates for generated/provider outputs
+- use the native avatar video composite rule when provider clips are smoother than programmatic renders
+
+Validation:
+- focused video-generation tests
+- migration checks when applicable
+- npm run course:accelerated:validate when accelerated course content changes
+- build/typecheck before PR
+- final MP4 review for production video artifacts
+
+Create a scoped branch/commit/PR and stop before merging.
+```
+


### PR DESCRIPTION
## Summary
- Add a Portfolio AGENTS.md mirroring the Toastmasters worktree pre-flight, lane classification, captain startup, review identity, and task-thread closeout rules.
- Add docs/worktree-starter-prompts.md with copy-paste prompts for captain, inbound outreach, outbound outreach, content strategy, and course/video lanes.
- Update commands/captain-sweep.md with the hard Supabase MCP startup gate and Codex task-thread cleanup reporting gate.

## Validation
- git diff --check
- npm run build:knowledge
- push hook: npm run db:health-check passed

No app/runtime tests were run because this is docs/ops structure only.

## Integration Notes
- No migrations or env changes.
- No deploy-sensitive runtime code changed.
- Root checkout was dirty and preserved; work was committed from /Users/vambahsillah/Projects/Portfolio.worktrees/captain-sweep-main on branch codex/portfolio-captain-structure.
- Vercel contexts not checked for this PR before merge:
  - Vercel – portfolio: not checked
  - Vercel – portfolio-staging: not checked