### PR TITLE
fix: make Neil KMB seed target explicit

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "client:seed-mark-reversr": "tsx scripts/seed-mark-reversr-build-evidence.ts",
     "client:seed-mark-reversr-assessment": "tsx scripts/seed-mark-reversr-assessment.ts",
     "client:seed-neil-kmb": "tsx scripts/seed-neil-kmb-client-dashboard.ts",
+    "client:seed-neil-kmb:prod:dry-run": "tsx scripts/seed-neil-kmb-client-dashboard.ts --target prod --dry-run",
+    "client:seed-neil-kmb:prod:apply": "tsx scripts/seed-neil-kmb-client-dashboard.ts --target prod --apply",
     "open-brain:mcp": "tsx scripts/open-brain-mcp-server.ts",
     "open-brain:runtime-registration": "tsx scripts/open-brain-runtime-registration.ts",
     "open-brain:personality-corpus": "tsx scripts/open-brain-personality-corpus-producer.ts",

--- a/scripts/seed-neil-kmb-client-dashboard.ts
+++ b/scripts/seed-neil-kmb-client-dashboard.ts
@@ -1,11 +1,55 @@
 #!/usr/bin/env tsx
+/**
+ * Seed the Neil/KMB client dashboard packet.
+ *
+ * Defaults to a dry run against dev credentials. Production must be explicit:
+ *
+ *   npm run client:seed-neil-kmb
+ *   npm run client:seed-neil-kmb -- --target dev --apply
+ *   npm run client:seed-neil-kmb:prod:dry-run
+ *   npm run client:seed-neil-kmb:prod:apply
+ *
+ * Env:
+ *   dev:  NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
+ *   prod: PROD_SUPABASE_URL, PROD_SUPABASE_SERVICE_ROLE_KEY
+ */
 
 import { createClient } from '@supabase/supabase-js'
+import * as dotenv from 'dotenv'
 import { promises as fs } from 'fs'
 import path from 'path'
 
-const args = new Set(process.argv.slice(2))
+type Target = 'dev' | 'prod'
+
+const argv = process.argv.slice(2)
+const args = new Set(argv)
 const apply = args.has('--apply')
+
+function readFlag(name: string): string | null {
+  const index = argv.indexOf(name)
+  if (index >= 0 && argv[index + 1] && !argv[index + 1].startsWith('--')) {
+    return argv[index + 1]
+  }
+  const inline = argv.find((arg) => arg.startsWith(`${name}=`))
+  return inline ? inline.slice(name.length + 1) : null
+}
+
+function resolveEnvFile() {
+  return path.resolve(process.cwd(), readFlag('--env-file') || '.env.local')
+}
+
+function resolveTarget(): Target {
+  const rawTarget = args.has('--prod') ? 'prod' : readFlag('--target') || 'dev'
+  if (rawTarget !== 'dev' && rawTarget !== 'prod') {
+    console.error(`Unsupported target "${rawTarget}". Use --target dev or --target prod.`)
+    process.exit(1)
+  }
+  return rawTarget
+}
+
+dotenv.config({ path: resolveEnvFile(), quiet: true })
+
+const target = resolveTarget()
 
 const CLIENT_EMAIL = 'neil@keepmassbeautiful.org'
 const CONTACT_ID = 21
@@ -295,10 +339,25 @@ function requiredEnv(name: string) {
   return value
 }
 
+function envName(baseName: 'SUPABASE_URL' | 'SUPABASE_SERVICE_ROLE_KEY') {
+  if (target === 'prod') {
+    return baseName === 'SUPABASE_URL' ? 'PROD_SUPABASE_URL' : 'PROD_SUPABASE_SERVICE_ROLE_KEY'
+  }
+  return baseName === 'SUPABASE_URL' ? 'NEXT_PUBLIC_SUPABASE_URL' : 'SUPABASE_SERVICE_ROLE_KEY'
+}
+
+function supabaseUrl() {
+  return requiredEnv(envName('SUPABASE_URL'))
+}
+
+function serviceRoleKey() {
+  return requiredEnv(envName('SUPABASE_SERVICE_ROLE_KEY'))
+}
+
 function supabase() {
   return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL || requiredEnv('SUPABASE_URL'),
-    requiredEnv('SUPABASE_SERVICE_ROLE_KEY'),
+    supabaseUrl(),
+    serviceRoleKey(),
     { auth: { persistSession: false } }
   )
 }
@@ -755,6 +814,12 @@ async function seedTimeEntries(client: ReturnType<typeof supabase>, projectId: s
 }
 
 async function main() {
+  const targetUrl = supabaseUrl()
+  const targetHost = new URL(targetUrl).hostname
+  console.log(`Target: ${target.toUpperCase()} (${targetHost})`)
+  console.log(`Mode: ${apply ? 'APPLY' : 'DRY RUN'}`)
+  console.log(`Env file: ${resolveEnvFile()}`)
+
   const client = supabase()
   const contactSubmissionId = await ensureContact(client)
   const project = await ensureProject(client, contactSubmissionId)
@@ -771,11 +836,13 @@ async function main() {
     JSON.stringify(
       {
         applied: apply,
+        target,
+        targetHost,
         clientProjectId: project.id,
         contactSubmissionId,
         proposalId,
         onboardingPlanId,
-        dashboardUrl: `/client/dashboard/${dashboardToken}`,
+        dashboardAccess: dashboardToken ? 'created-or-reused' : 'not-created',
         documents,
         milestoneCount: milestonePlan.length,
         dashboardTaskCount: taskCount,
@@ -794,6 +861,6 @@ async function main() {
 }
 
 main().catch((error) => {
-  console.error(error)
+  console.error(error instanceof Error ? error.message : error)
   process.exit(1)
 })


### PR DESCRIPTION
## Summary
- Makes the Neil/KMB dashboard seed choose `dev` or `prod` explicitly instead of silently following `NEXT_PUBLIC_SUPABASE_URL`.
- Adds production dry-run/apply package scripts that require `PROD_SUPABASE_URL` and `PROD_SUPABASE_SERVICE_ROLE_KEY`.
- Stops the seed output from printing dashboard tokens or tokenized dashboard URLs.

## Validation
- `git status --short --branch`
- `git fetch origin --prune`
- `gh pr list --state open --limit 50 --json number,title,headRefName,baseRefName,isDraft,mergeStateStatus,reviewDecision,url,updatedAt`
- `codex mcp list`
- Supabase changelog scan for relevant breaking-change entries
- `npx tsc --noEmit --pretty false --target ES2020 --module ESNext --moduleResolution Bundler --esModuleInterop --skipLibCheck scripts/seed-neil-kmb-client-dashboard.ts`
- `npx tsx scripts/seed-neil-kmb-client-dashboard.ts --target invalid` exits with the expected target error
- `npm run client:seed-neil-kmb:prod:dry-run` exits with `Missing PROD_SUPABASE_URL` in this worktree because no prod env is present
- `git diff --check`
- Supabase MCP read-only counts: prod has 0 Neil/KMB `client_projects` and 0 active linked `client_dashboard_access`; dev has 1 and 1
- No live production seed/apply was run
- No Vercel production or staging deployment smoke was run; this is a script/operator-safety PR, not a deployed route change

## Integration Notes
Required captain action after review:
1. Merge this PR or run the branch from a captain-controlled checkout with the intended production env loaded.
2. Run `npm run client:seed-neil-kmb:prod:dry-run` and confirm the output says `Target: PROD (...)`, `Mode: DRY RUN`, and does not print a dashboard token.
3. If the dry run is clean, run `npm run client:seed-neil-kmb:prod:apply`.
4. Verify production rows with Supabase MCP/CLI, without pasting tokens into chat:

```sql
select
  (select count(*) from public.client_projects where client_email = 'neil@keepmassbeautiful.org' or project_name ilike '%KMB FireSpring%') as client_project_count,
  (select count(*) from public.client_dashboard_access cda join public.client_projects cp on cp.id = cda.client_project_id where cda.is_active = true and (cp.client_email = 'neil@keepmassbeautiful.org' or cp.project_name ilike '%KMB FireSpring%')) as active_dashboard_access_count;
```

Expected after apply: both counts are at least 1.

5. For API verification, retrieve the active production token locally through Supabase MCP/CLI, do not paste it into chat or PR comments, then call the production API with that token. Expected result: HTTP 200 with `stage: "client"` and project/company fields for Keep Massachusetts Beautiful.

No migrations or env changes are required beyond having the existing production Supabase env vars available to the captain process.

Vercel context note:
- Vercel - portfolio: not checked for this PR
- Vercel - portfolio-staging: not checked for this PR
