### PR TITLE
fix: polish homepage light mode contrast

### DIFF
--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -34,15 +34,24 @@ export default function Navigation() {
   const isHomePage = pathname === '/'
 
   useEffect(() => {
-    const handleScroll = () => {
+    const updateScrollState = () => {
       setIsScrolled(window.scrollY > 20)
+    }
+    const handleScroll = () => {
+      updateScrollState()
       // Close dropdowns when user scrolls
       setIsMenuOpen(false)
       setIsUserMenuOpen(false)
     }
+
+    updateScrollState()
+    const animationFrame = window.requestAnimationFrame(updateScrollState)
     window.addEventListener('scroll', handleScroll)
-    return () => window.removeEventListener('scroll', handleScroll)
-  }, [])
+    return () => {
+      window.cancelAnimationFrame(animationFrame)
+      window.removeEventListener('scroll', handleScroll)
+    }
+  }, [pathname])
 
   // Close menus when clicking outside
   useEffect(() => {
@@ -76,7 +85,7 @@ export default function Navigation() {
     <nav
       className={`fixed top-0 left-0 right-0 z-50 transition-all duration-500 animate-fade-in-up ${
         isScrolled
-          ? 'py-3 bg-background/90 backdrop-blur-xl border-b border-border'
+          ? 'py-3 bg-background/90 backdrop-blur-xl border-b border-border dark:bg-[#121E31]/90 dark:border-radiant-gold/15'
           : isMenuOpen
             ? 'py-4 bg-card dark:bg-[#121E31]'
             : 'py-4 bg-transparent'

--- a/components/SystemStory.tsx
+++ b/components/SystemStory.tsx
@@ -120,17 +120,17 @@ export default function SystemStory() {
             fill
             sizes="100vw"
             className={`object-cover object-center transition-opacity duration-700 ${
-              activeFrame === index ? 'opacity-[0.18] dark:opacity-[0.44]' : 'opacity-0'
+              activeFrame === index ? 'opacity-[0.34] dark:opacity-[0.44]' : 'opacity-0'
             }`}
             aria-hidden="true"
             priority={index === 0}
           />
         ))}
 
-        <div className="absolute inset-0 bg-[linear-gradient(90deg,#f4f6fa_0%,rgba(244,246,250,0.95)_30%,rgba(244,246,250,0.66)_66%,rgba(244,246,250,0.9)_100%)] dark:bg-[linear-gradient(90deg,#121E31_0%,rgba(18,30,49,0.9)_28%,rgba(18,30,49,0.46)_62%,rgba(18,30,49,0.72)_100%)]" />
+        <div className="absolute inset-0 bg-[linear-gradient(90deg,rgba(244,246,250,0.88)_0%,rgba(244,246,250,0.72)_30%,rgba(244,246,250,0.34)_66%,rgba(244,246,250,0.58)_100%)] dark:bg-[linear-gradient(90deg,#121E31_0%,rgba(18,30,49,0.9)_28%,rgba(18,30,49,0.46)_62%,rgba(18,30,49,0.72)_100%)]" />
         <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_74%_44%,rgba(212,175,55,0.10),transparent_42%)] dark:bg-[radial-gradient(ellipse_at_74%_44%,rgba(212,175,55,0.12),transparent_42%)]" />
-        <div className="absolute inset-x-0 top-0 h-32 bg-gradient-to-b from-[#f4f6fa] to-transparent dark:from-[#121E31]" />
-        <div className="absolute inset-x-0 bottom-0 h-36 bg-gradient-to-t from-[#f4f6fa] to-transparent dark:from-[#121E31]" />
+        <div className="absolute inset-x-0 top-0 h-32 bg-gradient-to-b from-[#f4f6fa]/80 to-transparent dark:from-[#121E31]" />
+        <div className="absolute inset-x-0 bottom-0 h-36 bg-gradient-to-t from-[#f4f6fa]/76 to-transparent dark:from-[#121E31]" />
 
         <div className="pointer-events-none absolute inset-0 opacity-50" aria-hidden="true">
           <svg className="h-full w-full" viewBox="0 0 1440 900" preserveAspectRatio="none">


### PR DESCRIPTION
## Summary
- Restores more System Story background-image presence in light mode by reducing the white overlay strength and increasing image opacity.
- Initializes the navigation scroll state on mount/path changes so deep links or restored scroll positions do not leave the nav transparent over light sections.
- Makes the scrolled nav dark-mode surface explicit while preserving the existing light-mode nav behavior.

## Validation
- `npx eslint components/Navigation.tsx components/SystemStory.tsx`
- `npx tsc --noEmit`
- `./node_modules/.bin/tailwindcss -i app/globals.css -o /tmp/portfolio-homepage-light-polish.css --content components/SystemStory.tsx,components/Navigation.tsx`
- `node ./node_modules/vitest/vitest.mjs run components/SystemStory.test.tsx components/Navigation.test.tsx --pool=forks --maxWorkers=1`
- Pre-push production database health check passed.

## Integration Notes
- No migrations or env changes.
- Vercel preview visual smoke required before merge.
- Captain must verify after merge:
  - Vercel – portfolio
  - Vercel – portfolio-staging
  - https://amadutown.com/api/health
  - https://portfolio-staging-ten.vercel.app/api/health