### PR TITLE
fix: brighten services card text panels

### DIFF
--- a/components/Services.tsx
+++ b/components/Services.tsx
@@ -146,7 +146,7 @@ export default function Services() {
             <div
               key={service.id}
               onClick={() => handleCardClick(service.id)}
-              className={`group relative bg-silicon-slate/40 backdrop-blur-md rounded-2xl overflow-hidden border border-radiant-gold/5 ${accent.border} transition-all duration-500 cursor-pointer reveal-on-scroll is-visible`}
+              className={`group relative overflow-hidden rounded-2xl border border-[#121E31]/10 bg-white/85 shadow-[0_24px_70px_rgba(18,30,49,0.08)] backdrop-blur-md transition-all duration-500 cursor-pointer reveal-on-scroll is-visible dark:border-radiant-gold/5 dark:bg-silicon-slate/40 dark:shadow-none ${accent.border}`}
               style={{ transitionDelay: `${index * 0.08}s` }}
             >
               <div className="relative h-64 overflow-hidden">
@@ -191,7 +191,7 @@ export default function Services() {
                       : 'Free'}
                 </div>
               </div>
-              <div className="p-8">
+              <div className="bg-white/90 p-8 dark:bg-transparent">
                 <div className="flex flex-wrap gap-2 mb-2">
                   <span className="text-[10px] font-heading text-muted-foreground uppercase tracking-wider">
                     {DELIVERY_LABELS[service.delivery_method] || service.delivery_method}


### PR DESCRIPTION
## Summary
- Change homepage Services cards to use a white translucent light-mode card and text panel instead of the grey slate overlay.
- Preserve the existing dark-mode translucent card treatment with explicit dark-mode classes.
- Keep the change scoped to `components/Services.tsx`; no schema or migration changes.

## Validation
- `npx eslint components/Services.tsx`
- `npx tsc --noEmit`
- `tailwindcss -i app/globals.css -o /tmp/portfolio-services-card-contrast.css --content components/Services.tsx`
- Local Playwright smoke at 390, 768, and 1440 widths for light-mode Services cards: card/panel/title/body/CTA computed colors, footer links, no horizontal overflow
- Local dark-mode desktop regression smoke for Services cards: dark card preserved, light text preserved, no horizontal overflow
- No live workflow/customer-data smoke was run before PR; visual browser checks used local dev server only

## Integration Notes
- No migrations or env changes required.
- Vercel contexts to check before/after merge:
  - Vercel – portfolio
  - Vercel – portfolio-staging
