### PR TITLE
fix: restore system story light image

### DIFF
--- a/components/HomepageScrollSections.test.tsx
+++ b/components/HomepageScrollSections.test.tsx
@@ -29,6 +29,12 @@ vi.mock('next/link', () => ({
   ),
 }))
 
+vi.mock('next-themes', () => ({
+  useTheme: () => ({
+    resolvedTheme: 'light',
+  }),
+}))
+
 type SectionGeometry = {
   height: number
   top: number

--- a/components/SystemStory.test.tsx
+++ b/components/SystemStory.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import type { ImgHTMLAttributes, ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import SystemStory from './SystemStory'
@@ -20,6 +20,16 @@ vi.mock('next/link', () => ({
   default: ({ href, children, ...props }: { href: string; children: ReactNode }) => (
     <a href={href} {...props}>{children}</a>
   ),
+}))
+
+const themeState = vi.hoisted(() => ({
+  resolvedTheme: 'light' as 'light' | 'dark' | undefined,
+}))
+
+vi.mock('next-themes', () => ({
+  useTheme: () => ({
+    resolvedTheme: themeState.resolvedTheme,
+  }),
 }))
 
 type RafCallback = FrameRequestCallback
@@ -46,6 +56,7 @@ describe('SystemStory', () => {
   let rafCallbacks: RafCallback[]
 
   beforeEach(() => {
+    themeState.resolvedTheme = 'light'
     rafCallbacks = []
     Object.defineProperty(window, 'innerHeight', {
       configurable: true,
@@ -122,5 +133,32 @@ describe('SystemStory', () => {
       name: /the work is already there/i,
     })).toBeInTheDocument()
     expect(screen.getByText('Intake Drift Detected')).toBeInTheDocument()
+  })
+
+  it('uses the light hero image for the system story in light mode', async () => {
+    const { container } = render(<SystemStory />)
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('img[data-system-story-theme="light"]')).toHaveLength(3)
+    })
+
+    const images = Array.from(container.querySelectorAll('img[data-system-story-theme="light"]'))
+
+    expect(images.every((image) => image.getAttribute('src') === '/prototypes/portfolio-pipeline-hero/higgsfield-light-mode-hero-poster-20260628.webp')).toBe(true)
+    expect(container.querySelector('img[src*="system-story-fragmented-rooms"]')).not.toBeInTheDocument()
+  })
+
+  it('keeps the dark system story images in dark mode', async () => {
+    themeState.resolvedTheme = 'dark'
+    const { container } = render(<SystemStory />)
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('img[data-system-story-theme="dark"]')).toHaveLength(3)
+    })
+
+    expect(container.querySelector('img[src="/prototypes/portfolio-pipeline-hero/system-story-fragmented-rooms-20260617.webp"]')).toBeInTheDocument()
+    expect(container.querySelector('img[src="/prototypes/portfolio-pipeline-hero/system-story-blueprint-map-20260617.webp"]')).toBeInTheDocument()
+    expect(container.querySelector('img[src="/prototypes/portfolio-pipeline-hero/system-story-connected-pipeline-20260617.webp"]')).toBeInTheDocument()
+    expect(container.querySelector('img[src*="higgsfield-light-mode-hero-poster"]')).not.toBeInTheDocument()
   })
 })

--- a/components/SystemStory.tsx
+++ b/components/SystemStory.tsx
@@ -3,14 +3,18 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import { ArrowRight, Route, ScanSearch, Workflow, type LucideIcon } from 'lucide-react'
+import { useTheme } from 'next-themes'
 import { useEffect, useRef, useState } from 'react'
 
 const SYSTEM_STORY_ASSET_PATH = '/prototypes/portfolio-pipeline-hero'
+const LIGHT_SYSTEM_STORY_IMAGE = `${SYSTEM_STORY_ASSET_PATH}/higgsfield-light-mode-hero-poster-20260628.webp`
+
+type SystemStoryTheme = 'light' | 'dark'
 
 type SystemStoryFrame = {
   title: string
   copy: string
-  image: string
+  images: Record<SystemStoryTheme, string>
   icon: LucideIcon
   calloutTitle: string
   detail: string
@@ -21,7 +25,10 @@ const frames: SystemStoryFrame[] = [
     title: "The work is already there. It just isn't connected.",
     copy:
       'Small businesses can have the right people, tools, and intentions while intake, scheduling, communications, delivery, billing, reporting, and knowledge still move in separate rooms.',
-    image: `${SYSTEM_STORY_ASSET_PATH}/system-story-fragmented-rooms-20260617.webp`,
+    images: {
+      light: LIGHT_SYSTEM_STORY_IMAGE,
+      dark: `${SYSTEM_STORY_ASSET_PATH}/system-story-fragmented-rooms-20260617.webp`,
+    },
     icon: ScanSearch,
     calloutTitle: 'Intake Drift Detected',
     detail:
@@ -31,7 +38,10 @@ const frames: SystemStoryFrame[] = [
     title: 'We map the operating system.',
     copy:
       'AmaduTown traces how work enters, where decisions wait, and which handoffs create repeat effort. The map turns scattered activity into a buildable blueprint.',
-    image: `${SYSTEM_STORY_ASSET_PATH}/system-story-blueprint-map-20260617.webp`,
+    images: {
+      light: LIGHT_SYSTEM_STORY_IMAGE,
+      dark: `${SYSTEM_STORY_ASSET_PATH}/system-story-blueprint-map-20260617.webp`,
+    },
     icon: Route,
     calloutTitle: 'Handoffs Under Review',
     detail:
@@ -41,7 +51,10 @@ const frames: SystemStoryFrame[] = [
     title: 'Then we connect the work.',
     copy:
       'Automations, agents, dashboards, and reusable playbooks become the piping between departments, so the business operates with less chasing and clearer follow-through.',
-    image: `${SYSTEM_STORY_ASSET_PATH}/system-story-connected-pipeline-20260617.webp`,
+    images: {
+      light: LIGHT_SYSTEM_STORY_IMAGE,
+      dark: `${SYSTEM_STORY_ASSET_PATH}/system-story-connected-pipeline-20260617.webp`,
+    },
     icon: Workflow,
     calloutTitle: 'Operating Layer Engaged',
     detail:
@@ -63,9 +76,20 @@ function clamp(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max)
 }
 
+function getSystemStoryTheme(resolvedTheme: string | undefined): SystemStoryTheme | null {
+  if (resolvedTheme === 'light' || resolvedTheme === 'dark') return resolvedTheme
+  return null
+}
+
 export default function SystemStory() {
+  const { resolvedTheme } = useTheme()
   const sectionRef = useRef<HTMLElement>(null)
   const [activeFrame, setActiveFrame] = useState(0)
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
 
   useEffect(() => {
     const section = sectionRef.current
@@ -101,6 +125,7 @@ export default function SystemStory() {
   }, [])
 
   const ActiveIcon = frames[activeFrame].icon
+  const activeTheme = mounted ? getSystemStoryTheme(resolvedTheme) : null
 
   return (
     <section
@@ -112,20 +137,23 @@ export default function SystemStory() {
       <div className="sticky top-0 min-h-[100svh] overflow-hidden">
         <div className="absolute inset-0 bg-[#f4f6fa] dark:bg-[#121E31]" />
 
-        {frames.map((frame, index) => (
-          <Image
-            key={frame.image}
-            src={frame.image}
-            alt=""
-            fill
-            sizes="100vw"
-            className={`object-cover object-center transition-opacity duration-700 ${
-              activeFrame === index ? 'opacity-[0.44]' : 'opacity-0'
-            }`}
-            aria-hidden="true"
-            priority={index === 0}
-          />
-        ))}
+        {activeTheme
+          ? frames.map((frame, index) => (
+              <Image
+                key={`${activeTheme}-${frame.images[activeTheme]}-${index}`}
+                src={frame.images[activeTheme]}
+                alt=""
+                fill
+                sizes="100vw"
+                className={`object-cover object-center transition-opacity duration-700 ${
+                  activeFrame === index ? 'opacity-[0.78] dark:opacity-[0.44]' : 'opacity-0'
+                }`}
+                aria-hidden="true"
+                priority={index === 0}
+                data-system-story-theme={activeTheme}
+              />
+            ))
+          : null}
 
         <div className="absolute inset-0 bg-[linear-gradient(90deg,rgba(244,246,250,0.76)_0%,rgba(244,246,250,0.58)_30%,rgba(244,246,250,0.18)_66%,rgba(244,246,250,0.34)_100%)] dark:bg-[linear-gradient(90deg,#121E31_0%,rgba(18,30,49,0.9)_28%,rgba(18,30,49,0.46)_62%,rgba(18,30,49,0.72)_100%)]" />
         <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_74%_44%,rgba(212,175,55,0.10),transparent_42%)] dark:bg-[radial-gradient(ellipse_at_74%_44%,rgba(212,175,55,0.12),transparent_42%)]" />


### PR DESCRIPTION
## Summary
- Make the System Story background images theme-aware.
- Use the approved light hero poster for System Story in light mode.
- Keep the existing three dark System Story images for dark mode.
- Increase only the light-mode active image opacity so the restored light asset remains visible under the existing light overlays.

## Validation
- `npx vitest run components/SystemStory.test.tsx components/HomepageScrollSections.test.tsx components/Hero.test.tsx`
- `npx eslint components/SystemStory.tsx components/SystemStory.test.tsx components/HomepageScrollSections.test.tsx`
- `npx tsc --noEmit`
- `./node_modules/.bin/tailwindcss -i app/globals.css -o /tmp/system-story-light-hero.css --content components/SystemStory.tsx`
- Local Playwright smoke on `http://localhost:3213/` verified System Story light mode renders `higgsfield-light-mode-hero-poster-20260628.webp`, has no `system-story-*` dark image source, and has no horizontal overflow at desktop and mobile widths.
- Local Playwright smoke verified dark mode still renders the `system-story-*` image set and does not render the light poster.
- Push hook database health check passed.

## Integration Notes
- No migrations or environment changes.
- Vercel contexts to verify after merge:
  - Vercel – portfolio
  - Vercel – portfolio-staging