### PR TITLE
fix: lighten contact action fills

### DIFF
--- a/components/Contact.test.tsx
+++ b/components/Contact.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react'
+import type { ImgHTMLAttributes, ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import Contact from './Contact'
+
+vi.mock('framer-motion', () => ({
+  AnimatePresence: ({ children }: { children: ReactNode }) => <>{children}</>,
+  motion: {
+    div: ({
+      animate,
+      children,
+      exit,
+      initial,
+      transition,
+      ...props
+    }: {
+      animate?: unknown
+      children?: ReactNode
+      exit?: unknown
+      initial?: unknown
+      transition?: unknown
+    }) => <div {...props}>{children}</div>,
+    form: ({
+      animate,
+      children,
+      exit,
+      initial,
+      transition,
+      ...props
+    }: {
+      animate?: unknown
+      children?: ReactNode
+      exit?: unknown
+      initial?: unknown
+      transition?: unknown
+    }) => <form {...props}>{children}</form>,
+  },
+}))
+
+vi.mock('next/image', () => ({
+  default: ({
+    alt,
+    fill,
+    src,
+    ...props
+  }: ImgHTMLAttributes<HTMLImageElement> & { fill?: boolean; src: string }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={alt} src={src} {...props} />
+  ),
+}))
+
+vi.mock('@/lib/analytics', () => ({
+  analytics: {
+    contactFormSubmit: vi.fn(),
+    contactFormView: vi.fn(),
+  },
+}))
+
+vi.mock('./chat', () => ({
+  Chat: () => <div data-testid="mock-chat" />,
+}))
+
+describe('Contact light-mode controls', () => {
+  it('uses light aligned fills for inactive tab and social controls', () => {
+    const { container } = render(<Contact />)
+
+    expect(screen.getByRole('button', { name: /chat now/i })).toHaveClass('from-radiant-gold')
+    expect(screen.getByRole('button', { name: /send message/i })).toHaveClass('bg-white/[0.78]')
+
+    const linkedIn = container.querySelector('a[href^="https://www.linkedin.com"]')
+    expect(linkedIn).toHaveClass('bg-white/[0.76]')
+    expect(linkedIn).toHaveClass('dark:bg-silicon-slate/30')
+  })
+})

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -38,6 +38,14 @@ const interestOptions = [
   { value: 'other', label: 'Other' },
 ]
 
+const contactTabBaseClass =
+  'flex items-center gap-2 px-5 py-3 rounded-full text-[10px] font-heading tracking-[0.15em] uppercase transition-all duration-300'
+
+const contactTabActiveClass = 'bg-gradient-to-r from-radiant-gold to-bronze text-imperial-navy'
+
+const contactTabInactiveClass =
+  'border border-[#121E31]/[0.12] bg-white/[0.78] text-[#2F4A66] shadow-[0_10px_28px_rgba(18,30,49,0.08)] hover:border-radiant-gold/45 hover:bg-white hover:text-[#121E31] dark:border-radiant-gold/20 dark:bg-silicon-slate/30 dark:text-muted-foreground dark:shadow-none dark:hover:border-radiant-gold/40 dark:hover:text-foreground'
+
 // Helper function to normalize URLs - adds https:// if missing
 const normalizeUrl = (url: string): string => {
   if (!url || !url.trim()) return url
@@ -192,7 +200,7 @@ export default function Contact() {
                     href={social.href}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="p-3 bg-silicon-slate/30 border border-radiant-gold/10 rounded-full text-muted-foreground hover:text-radiant-gold hover:border-radiant-gold/40 transition-all"
+                    className="p-3 rounded-full border border-[#121E31]/[0.12] bg-white/[0.76] text-[#35516E] shadow-[0_10px_24px_rgba(18,30,49,0.08)] transition-all hover:border-radiant-gold/45 hover:bg-white hover:text-[#121E31] dark:border-radiant-gold/10 dark:bg-silicon-slate/30 dark:text-muted-foreground dark:shadow-none dark:hover:border-radiant-gold/40 dark:hover:text-radiant-gold"
                   >
                     <social.icon size={18} />
                   </a>
@@ -210,10 +218,8 @@ export default function Contact() {
             <div className="flex gap-2 mb-6">
               <button
                 onClick={() => setActiveTab('chat')}
-                className={`flex items-center gap-2 px-5 py-3 rounded-full text-[10px] font-heading tracking-[0.15em] uppercase transition-all duration-300 ${
-                  activeTab === 'chat'
-                    ? 'bg-gradient-to-r from-radiant-gold to-bronze text-imperial-navy'
-                    : 'bg-silicon-slate/30 border border-radiant-gold/20 text-muted-foreground hover:border-radiant-gold/40 hover:text-foreground'
+                className={`${contactTabBaseClass} ${
+                  activeTab === 'chat' ? contactTabActiveClass : contactTabInactiveClass
                 }`}
               >
                 <MessageCircle size={14} />
@@ -221,10 +227,8 @@ export default function Contact() {
               </button>
               <button
                 onClick={() => setActiveTab('form')}
-                className={`flex items-center gap-2 px-5 py-3 rounded-full text-[10px] font-heading tracking-[0.15em] uppercase transition-all duration-300 ${
-                  activeTab === 'form'
-                    ? 'bg-gradient-to-r from-radiant-gold to-bronze text-imperial-navy'
-                    : 'bg-silicon-slate/30 border border-radiant-gold/20 text-muted-foreground hover:border-radiant-gold/40 hover:text-foreground'
+                className={`${contactTabBaseClass} ${
+                  activeTab === 'form' ? contactTabActiveClass : contactTabInactiveClass
                 }`}
               >
                 <FileText size={14} />

--- a/components/chat/Chat.tsx
+++ b/components/chat/Chat.tsx
@@ -573,7 +573,7 @@ export function Chat({ initialMessage, visitorEmail, visitorName }: ChatProps) {
             animate={{ opacity: 1, scale: 1 }}
             exit={{ opacity: 0, scale: 0.9 }}
             onClick={() => setIsExpanded(true)}
-            className="w-full flex items-center justify-center gap-3 py-4 px-6 bg-silicon-slate/30 border border-radiant-gold/20 rounded-xl text-foreground hover:bg-silicon-slate/40 hover:border-radiant-gold/40 transition-all duration-300"
+            className="w-full flex items-center justify-center gap-3 py-4 px-6 rounded-xl border border-[#121E31]/[0.12] bg-white/[0.78] text-[#12304B] shadow-[0_12px_32px_rgba(18,30,49,0.08)] transition-all duration-300 hover:border-radiant-gold/45 hover:bg-white dark:border-radiant-gold/20 dark:bg-silicon-slate/30 dark:text-foreground dark:shadow-none dark:hover:border-radiant-gold/40 dark:hover:bg-silicon-slate/40"
           >
             <MessageCircle size={20} className="text-radiant-gold" />
             <span className="font-heading text-sm tracking-wider uppercase">Chat with AI Assistant</span>
@@ -585,10 +585,10 @@ export function Chat({ initialMessage, visitorEmail, visitorName }: ChatProps) {
             animate={{ opacity: 1, height: 'auto' }}
             exit={{ opacity: 0, height: 0 }}
             transition={{ duration: 0.3 }}
-            className="glass-card border border-radiant-gold/20 rounded-xl overflow-hidden"
+            className="overflow-hidden rounded-xl border border-[#121E31]/[0.12] bg-white/[0.86] shadow-[0_22px_58px_rgba(18,30,49,0.10)] backdrop-blur-xl dark:border-radiant-gold/20 dark:bg-silicon-slate/30 dark:shadow-none"
           >
             {/* Chat Header */}
-            <div className="flex items-center justify-between px-4 py-3 border-b border-radiant-gold/10 bg-silicon-slate/20">
+            <div className="flex items-center justify-between px-4 py-3 border-b border-[#121E31]/[0.08] bg-white/[0.72] dark:border-radiant-gold/10 dark:bg-silicon-slate/20">
               <div className="flex items-center gap-2">
                 <div className={`w-2 h-2 rounded-full ${isVoiceCallActive ? 'bg-radiant-gold' : isDiagnosticMode ? 'bg-radiant-gold' : 'bg-emerald-500'} animate-pulse`} />
                 <span className="text-sm font-heading tracking-wider text-foreground">
@@ -606,7 +606,7 @@ export function Chat({ initialMessage, visitorEmail, visitorName }: ChatProps) {
               <div className="flex items-center gap-2">
                 {/* Voice/Text Mode Toggle - available even in diagnostic mode */}
                 {voiceEnabled && (
-                  <div className="flex items-center bg-silicon-slate/30 rounded-lg p-0.5 mr-2">
+                  <div className="flex items-center rounded-lg bg-[#121E31]/[0.06] p-0.5 mr-2 dark:bg-silicon-slate/30">
                     <motion.button
                       onClick={() => setChatMode('text')}
                       whileHover={{ scale: 1.05 }}
@@ -752,7 +752,7 @@ export function Chat({ initialMessage, visitorEmail, visitorName }: ChatProps) {
                     initial={{ opacity: 0, y: -10 }}
                     animate={{ opacity: 1, y: 0 }}
                     exit={{ opacity: 0, y: -10 }}
-                    className="p-3 bg-silicon-slate/40 border border-radiant-gold/20 rounded-lg"
+                    className="p-3 rounded-lg border border-[#121E31]/[0.10] bg-white/[0.72] dark:border-radiant-gold/20 dark:bg-silicon-slate/40"
                   >
                     <div className="flex justify-between items-start gap-2">
                       <div className="flex-1">
@@ -826,7 +826,7 @@ export function Chat({ initialMessage, visitorEmail, visitorName }: ChatProps) {
                             onClick={() => handleSuggestionClick(action.message)}
                             whileHover={{ scale: 1.02 }}
                             whileTap={{ scale: 0.98 }}
-                            className="flex items-start gap-3 p-3 bg-silicon-slate/20 border border-radiant-gold/10 rounded-lg hover:bg-silicon-slate/30 hover:border-radiant-gold/30 transition-all duration-200 text-left group"
+                            className="flex items-start gap-3 p-3 rounded-lg border border-[#121E31]/[0.10] bg-white/[0.72] text-left shadow-[0_8px_22px_rgba(18,30,49,0.06)] transition-all duration-200 hover:border-radiant-gold/35 hover:bg-white dark:border-radiant-gold/10 dark:bg-silicon-slate/20 dark:shadow-none dark:hover:border-radiant-gold/30 dark:hover:bg-silicon-slate/30 group"
                           >
                             <div className="flex-shrink-0 w-8 h-8 rounded-lg bg-radiant-gold/10 border border-radiant-gold/20 flex items-center justify-center group-hover:bg-radiant-gold/20 group-hover:border-radiant-gold/30 transition-colors">
                               <Icon size={16} className="text-radiant-gold" />
@@ -874,7 +874,7 @@ export function Chat({ initialMessage, visitorEmail, visitorName }: ChatProps) {
             )}
 
             {/* Input Area - Text or Voice */}
-            <div className="p-4 border-t border-radiant-gold/10 bg-silicon-slate/10">
+            <div className="p-4 border-t border-[#121E31]/[0.08] bg-white/[0.66] dark:border-radiant-gold/10 dark:bg-silicon-slate/10">
               <AnimatePresence mode="wait">
                 {chatMode === 'text' ? (
                   <motion.div

--- a/components/chat/ChatInput.tsx
+++ b/components/chat/ChatInput.tsx
@@ -54,7 +54,7 @@ export function ChatInput({
 
   return (
     <form onSubmit={handleSubmit} className="relative">
-      <div className="flex items-end gap-2 p-2 bg-silicon-slate/20 rounded-xl border border-radiant-gold/10 focus-within:border-radiant-gold/30 transition-colors">
+      <div className="flex items-end gap-2 p-2 rounded-xl border border-[#121E31]/[0.10] bg-white/[0.72] transition-colors focus-within:border-radiant-gold/35 dark:border-radiant-gold/10 dark:bg-silicon-slate/20 dark:focus-within:border-radiant-gold/30">
         <textarea
           ref={textareaRef}
           value={message}
@@ -73,7 +73,7 @@ export function ChatInput({
           className={`flex-shrink-0 w-10 h-10 rounded-lg flex items-center justify-center transition-all duration-300 ${
             message.trim() && !disabled && !isLoading
               ? 'bg-gradient-to-br from-radiant-gold to-bronze text-imperial-navy hover:shadow-lg hover:shadow-radiant-gold/20'
-              : 'bg-silicon-slate/30 text-muted-foreground/70 cursor-not-allowed'
+              : 'bg-[#121E31]/[0.08] text-[#49637E]/80 cursor-not-allowed dark:bg-silicon-slate/30 dark:text-muted-foreground/70'
           }`}
         >
           {isLoading ? (

--- a/components/chat/ChatLightSurfaces.test.tsx
+++ b/components/chat/ChatLightSurfaces.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { ChatInput } from './ChatInput'
+import { ChatMessage } from './ChatMessage'
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    button: ({
+      children,
+      whileHover,
+      whileTap,
+      ...props
+    }: {
+      children?: ReactNode
+      whileHover?: unknown
+      whileTap?: unknown
+    }) => <button {...props}>{children}</button>,
+    div: ({
+      animate,
+      children,
+      initial,
+      transition,
+      ...props
+    }: {
+      animate?: unknown
+      children?: ReactNode
+      initial?: unknown
+      transition?: unknown
+    }) => <div {...props}>{children}</div>,
+  },
+}))
+
+vi.mock('react-markdown', () => ({
+  default: ({ children }: { children?: ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('remark-gfm', () => ({
+  default: vi.fn(),
+}))
+
+describe('Chat light-mode surfaces', () => {
+  it('uses light aligned fills for the input shell and disabled send button', () => {
+    render(<ChatInput onSend={vi.fn()} />)
+
+    const inputShell = screen.getByPlaceholderText('Type your message...').parentElement
+    const sendButton = screen.getByRole('button')
+
+    expect(inputShell).toHaveClass('bg-white/[0.72]')
+    expect(inputShell).toHaveClass('dark:bg-silicon-slate/20')
+    expect(sendButton).toHaveClass('bg-[#121E31]/[0.08]')
+    expect(sendButton).toHaveClass('dark:bg-silicon-slate/30')
+  })
+
+  it('uses light aligned fills for assistant avatar and message bubble', () => {
+    const { container } = render(<ChatMessage role="assistant" content="Hello" />)
+
+    const avatar = container.querySelector('.bg-white\\/\\[0\\.78\\]')
+    const messageBubble = container.querySelector('.bg-white\\/\\[0\\.72\\]')
+
+    expect(avatar).toBeInTheDocument()
+    expect(avatar).toHaveClass('dark:bg-silicon-slate/50')
+    expect(messageBubble).toBeInTheDocument()
+    expect(messageBubble).toHaveClass('dark:bg-silicon-slate/30')
+  })
+})

--- a/components/chat/ChatMessage.tsx
+++ b/components/chat/ChatMessage.tsx
@@ -106,7 +106,7 @@ export function ChatMessage({ role, content, timestamp, isTyping, isVoice }: Cha
             ? 'bg-gradient-to-br from-bronze via-radiant-gold to-gold-light text-imperial-navy'
             : isSupport
             ? 'bg-gradient-to-br from-emerald-500 to-emerald-700 text-white'
-            : 'bg-silicon-slate/50 border border-radiant-gold/20 text-radiant-gold'
+            : 'border border-radiant-gold/25 bg-white/[0.78] text-radiant-gold shadow-[0_8px_20px_rgba(18,30,49,0.08)] dark:bg-silicon-slate/50 dark:shadow-none'
         }`}
       >
         {getRoleIcon()}
@@ -126,7 +126,7 @@ export function ChatMessage({ role, content, timestamp, isTyping, isVoice }: Cha
               ? 'bg-gradient-to-br from-radiant-gold/20 to-bronze/20 border border-radiant-gold/30 text-foreground'
               : isSupport
               ? 'bg-emerald-500/10 border border-emerald-500/30 text-foreground'
-              : 'bg-silicon-slate/30 border border-foreground/10 text-foreground/90'
+              : 'border border-[#121E31]/[0.10] bg-white/[0.72] text-foreground/90 shadow-[0_8px_22px_rgba(18,30,49,0.06)] dark:border-foreground/10 dark:bg-silicon-slate/30 dark:shadow-none'
           } ${isUser ? 'rounded-tr-sm' : 'rounded-tl-sm'}`}
         >
           {isTyping ? (


### PR DESCRIPTION
## Summary
- Replace the contact section's light-mode dark grey social/tab fills with white, page-aligned surfaces and stronger navy text.
- Make the embedded chat shell, header, suggestions, input, and assistant message surfaces theme-aware so light mode no longer inherits dark glass fills.
- Add focused regression tests for the contact controls and chat light-mode surfaces.

## Validation
- npx vitest run components/Contact.test.tsx components/chat/ChatLightSurfaces.test.tsx
- npx eslint components/Contact.tsx components/Contact.test.tsx components/chat/Chat.tsx components/chat/ChatInput.tsx components/chat/ChatMessage.tsx components/chat/ChatLightSurfaces.test.tsx
- npx tsc --noEmit
- ./node_modules/.bin/tailwindcss -i app/globals.css -o /tmp/contact-light-button-fills.css --content components/Contact.tsx components/chat/Chat.tsx components/chat/ChatInput.tsx components/chat/ChatMessage.tsx
- Local Playwright smoke on http://localhost:3214/#contact for light desktop, light mobile, and dark desktop; verified button/social/chat fills, zero horizontal overflow, and no page errors.
- Expanded the chat panel in local light mode and verified shell, suggestion row, and input fills.

## Integration Notes
- No migrations or env changes.
- No customer-facing email, send, download, or publish workflow was triggered.
- Vercel contexts to verify after merge:
  - Vercel – portfolio
  - Vercel – portfolio-staging