### PR TITLE
fix: lighten about panel background

### DIFF
--- a/components/About.test.tsx
+++ b/components/About.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react'
+import type { AnchorHTMLAttributes, ImgHTMLAttributes, ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import About from './About'
+
+vi.mock('next/image', () => ({
+  default: ({
+    alt,
+    fill,
+    src,
+    ...props
+  }: ImgHTMLAttributes<HTMLImageElement> & { fill?: boolean; src: string }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={alt} src={src} {...props} />
+  ),
+}))
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: AnchorHTMLAttributes<HTMLAnchorElement> & { children: ReactNode; href: string }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+vi.mock('@/lib/useRevealOnScroll', () => ({
+  useRevealOnScroll: () => null,
+}))
+
+describe('About light-mode background', () => {
+  it('uses a light aligned section background with explicit dark fallback', () => {
+    const { container } = render(<About />)
+
+    const section = container.querySelector('#about')
+    expect(section).toHaveClass('bg-[linear-gradient(180deg,#f8fafc_0%,#f4f7fb_48%,#fbfcfe_100%)]')
+    expect(section).toHaveClass('dark:bg-none')
+    expect(section).toHaveClass('dark:bg-silicon-slate/20')
+
+    expect(screen.getByText('Story').parentElement).toHaveClass('bg-white/[0.78]')
+    expect(screen.getByText('15+ Years').parentElement).toHaveClass('bg-white/[0.84]')
+  })
+})

--- a/components/About.tsx
+++ b/components/About.tsx
@@ -10,7 +10,7 @@ export default function About() {
   const textRef = useRevealOnScroll()
 
   return (
-    <section id="about" className="py-32 px-6 sm:px-10 lg:px-12 bg-silicon-slate/20 relative overflow-hidden">
+    <section id="about" className="py-32 px-6 sm:px-10 lg:px-12 bg-[linear-gradient(180deg,#f8fafc_0%,#f4f7fb_48%,#fbfcfe_100%)] dark:bg-none dark:bg-silicon-slate/20 relative overflow-hidden">
       {/* Aurora */}
       <div className="absolute bottom-0 left-0 w-[600px] h-[600px] bg-bronze/5 blur-[120px] rounded-full" />
 
@@ -38,7 +38,7 @@ export default function About() {
               </div>
               
               <div
-                className="absolute -bottom-6 -right-6 glass-card px-6 py-4 border-radiant-gold/20 shadow-2xl hero-float"
+                className="absolute -bottom-6 -right-6 border border-radiant-gold/20 bg-white/[0.84] px-6 py-4 shadow-[0_18px_42px_rgba(18,30,49,0.10)] backdrop-blur-xl dark:bg-silicon-slate/40 dark:shadow-2xl hero-float"
               >
                 <p className="text-[10px] font-heading tracking-[0.2em] text-radiant-gold uppercase mb-1">Experience</p>
                 <p className="text-xl font-premium text-foreground">15+ Years</p>
@@ -52,7 +52,7 @@ export default function About() {
               ref={textRef}
               className="text-center reveal-on-scroll"
             >
-              <div className="pill-badge bg-silicon-slate/30 border-radiant-gold/20 mb-6 mx-auto">
+              <div className="pill-badge bg-white/[0.78] border-radiant-gold/25 mb-6 mx-auto dark:bg-silicon-slate/30 dark:border-radiant-gold/20">
                 <span className="text-[10px] uppercase tracking-[0.2em] font-heading text-radiant-gold">
                   Story
                 </span>
@@ -92,4 +92,3 @@ export default function About() {
     </section>
   )
 }
-


### PR DESCRIPTION
## Summary
- Lighten the homepage About section background in light mode so it aligns with the surrounding light-mode panels.
- Give the About story pill and experience callout explicit light surfaces while preserving their dark-mode treatment.
- Add a focused component test covering the light/dark background classes.

## Validation
- `npx vitest run components/About.test.tsx`
- `npx eslint components/About.tsx components/About.test.tsx`
- `npx tsc --noEmit`
- `git diff --check`
- `./node_modules/.bin/tailwindcss -i app/globals.css -o /tmp/about-light-panel-background.css --content components/About.tsx` (passes with existing stale Browserslist warning)
- Local Playwright visual smoke at `http://localhost:3215/?qa=about-light-panel-background-v4` for light desktop, light mobile, and dark desktop; no page errors and no horizontal overflow.

## Integration Notes
- No migrations or environment changes.
- Captain must verify both Vercel contexts after merge:
  - Vercel – portfolio
  - Vercel – portfolio-staging
