### PR TITLE
refactor: place client dashboard commentary by section

### DIFF
--- a/app/client/dashboard/[token]/page.tsx
+++ b/app/client/dashboard/[token]/page.tsx
@@ -4,7 +4,11 @@ import { useEffect, useState, useCallback, useRef } from 'react'
 import { useParams } from 'next/navigation'
 import { Check, Copy, Loader2 } from 'lucide-react'
 import DashboardStatCards from '@/components/client-dashboard/DashboardStatCards'
-import ExecutiveSummary from '@/components/client-dashboard/ExecutiveSummary'
+import ExecutiveSummary, {
+  ActionFocusCommentary,
+  AssessmentScoresCommentary,
+  TrajectoryCommentary,
+} from '@/components/client-dashboard/ExecutiveSummary'
 import ScoreRadarChart from '@/components/client-dashboard/ScoreRadarChart'
 import ConfidenceRadar from '@/components/client-dashboard/ConfidenceRadar'
 import StrengthenConfidenceBlock from '@/components/client-dashboard/StrengthenConfidenceBlock'
@@ -317,33 +321,35 @@ export default function ClientDashboardPage() {
 
         <ExecutiveSummary
           clientCompany={project.client_company}
-          overallScore={scores.overallScore}
-          categoryScores={scores.categoryScores}
-          scoreDelta={scores.delta}
-          tasksCompleted={tasksCompleted}
-          tasksTotal={tasks.length}
           highPriorityRemaining={highPriorityRemaining}
-          snapshotsCount={snapshots.length}
-          recommendationsCount={recommendations.length}
           diagnosticSummary={assessment?.diagnostic_summary || null}
           recommendedActions={assessment?.recommended_actions || null}
         />
 
         {/* Row 2: Radar + Trajectory */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-          <ScoreRadarChart scores={scores.categoryScores} />
-          {snapshots.length > 0 ? (
-            <TrajectoryChart token={token} />
-          ) : (
-            <div className="rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-5">
-              <h3 className="mb-2 text-sm font-medium uppercase tracking-wider text-radiant-gold">
-                Score Trajectory
-              </h3>
-              <p className="text-sm text-platinum-white/55">
-                Score trajectory will appear once milestone-based projections are available.
-              </p>
-            </div>
-          )}
+          <div className="space-y-3">
+            <ScoreRadarChart scores={scores.categoryScores} />
+            <AssessmentScoresCommentary categoryScores={scores.categoryScores} />
+          </div>
+          <div className="space-y-3">
+            {snapshots.length > 0 ? (
+              <TrajectoryChart token={token} />
+            ) : (
+              <div className="rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-5">
+                <h3 className="mb-2 text-sm font-medium uppercase tracking-wider text-radiant-gold">
+                  Score Trajectory
+                </h3>
+                <p className="text-sm text-platinum-white/55">
+                  Score trajectory will appear once milestone-based projections are available.
+                </p>
+              </div>
+            )}
+            <TrajectoryCommentary
+              scoreDelta={scores.delta}
+              snapshotsCount={snapshots.length}
+            />
+          </div>
         </div>
 
         {/* Row 3: Assessment */}
@@ -408,11 +414,19 @@ export default function ClientDashboardPage() {
 
         {/* Row 8: Task Checklist */}
         {tasks.length > 0 && (
-          <TaskChecklist
-            tasks={tasks}
-            token={token}
-            onTaskUpdate={handleTaskUpdate}
-          />
+          <div className="space-y-3">
+            <TaskChecklist
+              tasks={tasks}
+              token={token}
+              onTaskUpdate={handleTaskUpdate}
+            />
+            <ActionFocusCommentary
+              tasksCompleted={tasksCompleted}
+              tasksTotal={tasks.length}
+              highPriorityRemaining={highPriorityRemaining}
+              recommendationsCount={recommendations.length}
+            />
+          </div>
         )}
 
         {/* Row 9: Milestones */}

--- a/components/client-dashboard/ExecutiveSummary.test.tsx
+++ b/components/client-dashboard/ExecutiveSummary.test.tsx
@@ -1,6 +1,10 @@
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
-import ExecutiveSummary from './ExecutiveSummary'
+import ExecutiveSummary, {
+  ActionFocusCommentary,
+  AssessmentScoresCommentary,
+  TrajectoryCommentary,
+} from './ExecutiveSummary'
 import type { CategoryScores } from '@/lib/assessment-scoring'
 
 const categoryScores: CategoryScores = {
@@ -13,18 +17,11 @@ const categoryScores: CategoryScores = {
 }
 
 describe('ExecutiveSummary', () => {
-  it('sets client context after the widgets and maps the dashboard visuals', () => {
+  it('keeps the top executive summary focused on dashboard-level context', () => {
     render(
       <ExecutiveSummary
         clientCompany="Keep Massachusetts Beautiful"
-        overallScore={57}
-        categoryScores={categoryScores}
-        scoreDelta={{ absolute: 0, percentage: 0 }}
-        tasksCompleted={0}
-        tasksTotal={6}
         highPriorityRemaining={3}
-        snapshotsCount={2}
-        recommendationsCount={2}
         diagnosticSummary="The current operating picture shows strong community intent with gaps in workflow automation."
         recommendedActions={['Connect intake to follow-up.', 'Prioritize the highest-friction handoffs.']}
       />
@@ -34,26 +31,15 @@ describe('ExecutiveSummary', () => {
     expect(screen.getByText(/current operating picture/i)).toBeInTheDocument()
     expect(screen.getByText('Recommended focus')).toBeInTheDocument()
     expect(screen.getByText(/connect intake to follow-up/i)).toBeInTheDocument()
-    expect(screen.getByText('Widgets')).toBeInTheDocument()
-    expect(screen.getByText('Radar')).toBeInTheDocument()
-    expect(screen.getByText('Trajectory')).toBeInTheDocument()
-    expect(screen.getByText('Actions')).toBeInTheDocument()
-    expect(screen.getByText('57/100')).toBeInTheDocument()
-    expect(screen.getByText(/0\/6 tasks complete/i)).toBeInTheDocument()
+    expect(screen.queryByText('Widgets')).not.toBeInTheDocument()
+    expect(screen.queryByText('Radar')).not.toBeInTheDocument()
   })
 
   it('falls back to a derived summary and action focus when assessment copy is absent', () => {
     render(
       <ExecutiveSummary
         clientCompany={null}
-        overallScore={41}
-        categoryScores={categoryScores}
-        scoreDelta={{ absolute: 5, percentage: 12 }}
-        tasksCompleted={1}
-        tasksTotal={4}
         highPriorityRemaining={1}
-        snapshotsCount={0}
-        recommendationsCount={0}
         diagnosticSummary={null}
         recommendedActions={null}
       />
@@ -61,7 +47,27 @@ describe('ExecutiveSummary', () => {
 
     expect(screen.getByText(/translates the assessment into an operating view/i)).toBeInTheDocument()
     expect(screen.getByText(/start with the 1 high-priority action/i)).toBeInTheDocument()
-    expect(screen.getByText('projected after milestones')).toBeInTheDocument()
-    expect(screen.getByText('25% complete')).toBeInTheDocument()
+  })
+
+  it('renders chart and action commentary as separate section-level notes', () => {
+    render(
+      <>
+        <AssessmentScoresCommentary categoryScores={categoryScores} />
+        <TrajectoryCommentary scoreDelta={{ absolute: 5, percentage: 12 }} snapshotsCount={2} />
+        <ActionFocusCommentary
+          tasksCompleted={1}
+          tasksTotal={4}
+          highPriorityRemaining={1}
+          recommendationsCount={2}
+        />
+      </>
+    )
+
+    expect(screen.getByText('How to read this chart')).toBeInTheDocument()
+    expect(screen.getByText(/Business is the strongest area/i)).toBeInTheDocument()
+    expect(screen.getByText('What the trajectory means')).toBeInTheDocument()
+    expect(screen.getByText(/current path is up 5 points/i)).toBeInTheDocument()
+    expect(screen.getByText('How to use this list')).toBeInTheDocument()
+    expect(screen.getByText(/1\/4 tasks are complete/i)).toBeInTheDocument()
   })
 })

--- a/components/client-dashboard/ExecutiveSummary.tsx
+++ b/components/client-dashboard/ExecutiveSummary.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { ArrowRight, BarChart3, FileText, LineChart, ListChecks, Radar } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { FileText, LineChart, ListChecks, Radar } from 'lucide-react'
 import type { AssessmentCategory, CategoryScores } from '@/lib/assessment-scoring'
 
 const CATEGORY_LABELS: Record<AssessmentCategory, string> = {
@@ -14,23 +15,9 @@ const CATEGORY_LABELS: Record<AssessmentCategory, string> = {
 
 interface ExecutiveSummaryProps {
   clientCompany: string | null
-  overallScore: number
-  categoryScores: CategoryScores
-  scoreDelta: { absolute: number; percentage: number }
-  tasksCompleted: number
-  tasksTotal: number
   highPriorityRemaining: number
-  snapshotsCount: number
-  recommendationsCount: number
   diagnosticSummary: string | null
   recommendedActions: string[] | null
-}
-
-function scoreBand(score: number): string {
-  if (score >= 80) return 'strong operating foundation'
-  if (score >= 60) return 'workable foundation with clear improvement paths'
-  if (score >= 40) return 'developing foundation with visible execution gaps'
-  return 'early foundation that needs the basics connected first'
 }
 
 function formatDelta(delta: { absolute: number; percentage: number }): string {
@@ -56,19 +43,10 @@ function fallbackSummary(clientCompany: string | null): string {
 
 export default function ExecutiveSummary({
   clientCompany,
-  overallScore,
-  categoryScores,
-  scoreDelta,
-  tasksCompleted,
-  tasksTotal,
   highPriorityRemaining,
-  snapshotsCount,
-  recommendationsCount,
   diagnosticSummary,
   recommendedActions,
 }: ExecutiveSummaryProps) {
-  const { strongest, weakest } = strongestAndWeakest(categoryScores)
-  const completionRate = tasksTotal > 0 ? Math.round((tasksCompleted / tasksTotal) * 100) : 0
   const summary = diagnosticSummary?.trim() || fallbackSummary(clientCompany)
   const primaryActions = (recommendedActions || [])
     .map((action) => action.trim())
@@ -80,80 +58,91 @@ export default function ExecutiveSummary({
       ? `Start with the ${highPriorityRemaining} high-priority action${highPriorityRemaining === 1 ? '' : 's'} and use the recommendations below to decide what should be handled first.`
       : 'Use the recommendations below to decide what to sustain, automate, or accelerate next.'
 
-  const mapItems = [
-    {
-      label: 'Widgets',
-      title: 'Current health',
-      value: `${overallScore}/100`,
-      detail: scoreBand(overallScore),
-      icon: BarChart3,
-    },
-    {
-      label: 'Radar',
-      title: 'Category pattern',
-      value: strongest,
-      detail: `strongest; ${weakest} needs the most attention`,
-      icon: Radar,
-    },
-    {
-      label: 'Trajectory',
-      title: 'Progress path',
-      value: snapshotsCount > 0 ? formatDelta(scoreDelta) : 'projected after milestones',
-      detail: snapshotsCount > 0 ? 'based on score snapshots and milestones' : 'will fill in as delivery evidence accumulates',
-      icon: LineChart,
-    },
-    {
-      label: 'Actions',
-      title: 'Execution focus',
-      value: `${completionRate}% complete`,
-      detail: `${tasksCompleted}/${tasksTotal} tasks complete; ${recommendationsCount} acceleration option${recommendationsCount === 1 ? '' : 's'}`,
-      icon: ListChecks,
-    },
-  ]
-
   return (
     <section className="rounded-xl border border-radiant-gold/20 bg-gradient-to-br from-silicon-slate/70 via-imperial-navy/70 to-silicon-slate/45 p-4 shadow-[0_20px_70px_rgba(0,0,0,0.22)] sm:p-5">
-      <div className="grid gap-5 lg:grid-cols-[minmax(0,1.15fr)_minmax(0,1fr)] lg:items-start">
-        <div>
-          <div className="mb-3 flex items-center gap-2">
-            <FileText className="h-4 w-4 text-radiant-gold" />
-            <h2 className="text-sm font-medium uppercase tracking-wider text-radiant-gold">
-              Executive Summary
-            </h2>
-          </div>
-          <p className="max-w-3xl text-sm leading-6 text-platinum-white/78">
-            {summary}
+      <div className="mb-3 flex items-center gap-2">
+        <FileText className="h-4 w-4 text-radiant-gold" />
+        <h2 className="text-sm font-medium uppercase tracking-wider text-radiant-gold">
+          Executive Summary
+        </h2>
+      </div>
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)] lg:items-start">
+        <p className="text-sm leading-6 text-platinum-white/78">
+          {summary}
+        </p>
+        <div className="rounded-lg border border-radiant-gold/15 bg-imperial-navy/45 p-3 sm:p-4">
+          <p className="mb-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-platinum-white/45">
+            Recommended focus
           </p>
-          <div className="mt-4 rounded-lg border border-radiant-gold/15 bg-imperial-navy/45 p-3 sm:p-4">
-            <p className="mb-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-platinum-white/45">
-              Recommended focus
-            </p>
-            <p className="text-sm leading-6 text-platinum-white/82">{recommendationText}</p>
-          </div>
-        </div>
-
-        <div className="grid grid-cols-2 gap-2 sm:gap-3">
-          {mapItems.map((item, index) => (
-            <div
-              key={item.label}
-              className="relative rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-3 sm:p-4"
-            >
-              {index % 2 === 0 && (
-                <ArrowRight className="absolute -right-4 top-1/2 hidden h-4 w-4 -translate-y-1/2 text-radiant-gold/45 sm:block" />
-              )}
-              <div className="mb-3 flex items-center justify-between gap-3">
-                <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-radiant-gold/80">
-                  {item.label}
-                </span>
-                <item.icon className="h-4 w-4 text-radiant-gold/80" />
-              </div>
-              <p className="text-[10px] uppercase tracking-wider text-platinum-white/45 sm:text-xs">{item.title}</p>
-              <p className="mt-1 text-sm font-semibold text-platinum-white">{item.value}</p>
-              <p className="mt-1 hidden text-xs leading-5 text-platinum-white/58 sm:block">{item.detail}</p>
-            </div>
-          ))}
+          <p className="text-sm leading-6 text-platinum-white/82">{recommendationText}</p>
         </div>
       </div>
     </section>
+  )
+}
+
+interface SectionCommentaryProps {
+  icon: typeof Radar
+  title: string
+  children: ReactNode
+}
+
+function SectionCommentary({ icon: Icon, title, children }: SectionCommentaryProps) {
+  return (
+    <div className="rounded-lg border border-radiant-gold/15 bg-imperial-navy/35 p-4">
+      <div className="mb-2 flex items-center gap-2">
+        <Icon className="h-4 w-4 text-radiant-gold/85" />
+        <h3 className="text-[10px] font-semibold uppercase tracking-[0.18em] text-radiant-gold/80">
+          {title}
+        </h3>
+      </div>
+      <p className="text-sm leading-6 text-platinum-white/72">{children}</p>
+    </div>
+  )
+}
+
+export function AssessmentScoresCommentary({ categoryScores }: { categoryScores: CategoryScores }) {
+  const { strongest, weakest } = strongestAndWeakest(categoryScores)
+
+  return (
+    <SectionCommentary icon={Radar} title="How to read this chart">
+      The radar shows the category pattern behind the score. {strongest} is the strongest area right now, while {weakest} is the clearest place to close the gap.
+    </SectionCommentary>
+  )
+}
+
+export function TrajectoryCommentary({
+  scoreDelta,
+  snapshotsCount,
+}: {
+  scoreDelta: { absolute: number; percentage: number }
+  snapshotsCount: number
+}) {
+  return (
+    <SectionCommentary icon={LineChart} title="What the trajectory means">
+      {snapshotsCount > 0
+        ? `The line connects score snapshots and projected milestones, so the current path is ${formatDelta(scoreDelta)} until more delivery evidence changes it.`
+        : 'This will become a progress path once milestone projections and delivery evidence are available.'}
+    </SectionCommentary>
+  )
+}
+
+export function ActionFocusCommentary({
+  tasksCompleted,
+  tasksTotal,
+  highPriorityRemaining,
+  recommendationsCount,
+}: {
+  tasksCompleted: number
+  tasksTotal: number
+  highPriorityRemaining: number
+  recommendationsCount: number
+}) {
+  const completionRate = tasksTotal > 0 ? Math.round((tasksCompleted / tasksTotal) * 100) : 0
+
+  return (
+    <SectionCommentary icon={ListChecks} title="How to use this list">
+      This is the execution view: {tasksCompleted}/{tasksTotal} tasks are complete, the dashboard is {completionRate}% complete, and {highPriorityRemaining} high-priority action{highPriorityRemaining === 1 ? '' : 's'} should be handled before lower-priority work. {recommendationsCount} acceleration option{recommendationsCount === 1 ? '' : 's'} can be used when you want to move faster.
+    </SectionCommentary>
   )
 }


### PR DESCRIPTION
## Summary
- Keep the client dashboard executive summary as the compact top-line interpretation after the metric widgets.
- Move chart-specific commentary underneath the radar and trajectory sections it explains.
- Move action commentary underneath the task checklist so recommendations and execution status stay near the relevant list.

## Validation
- `npx vitest run components/client-dashboard/ExecutiveSummary.test.tsx`
- `npx tsc --noEmit`
- `npx eslint 'app/client/dashboard/[token]/page.tsx' components/client-dashboard/ExecutiveSummary.tsx components/client-dashboard/ExecutiveSummary.test.tsx` (passes with existing dashboard `<img>` warnings)\n- `git diff --check`\n- Local mocked browser QA at desktop and mobile: verified executive summary is top-level only, section notes render below radar/trajectory/tasks, copy action shows `Copied`, no page errors, failed responses, or horizontal overflow.\n\n## Integration Notes\n- No migrations or environment changes.\n- No production data mutation.\n- Captain should verify both Vercel contexts after merge:\n  - Vercel – portfolio\n  - Vercel – portfolio-staging\n