### PR TITLE
feat: paginate client dashboard meeting history

### DIFF
--- a/components/client-dashboard/MeetingHistory.test.tsx
+++ b/components/client-dashboard/MeetingHistory.test.tsx
@@ -1,0 +1,83 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import MeetingHistory from './MeetingHistory'
+
+function makeMeeting(index: number, durationMinutes: number | null = 45) {
+  return {
+    id: `meeting-${index}`,
+    meeting_type: index % 2 === 0 ? 'progress_checkin' : 'discovery',
+    meeting_date: `2026-04-${String(index + 1).padStart(2, '0')}T12:00:00.000Z`,
+    duration_minutes: durationMinutes,
+    structured_notes: null,
+    key_decisions: [`Decision ${index}`],
+    action_items: null,
+    open_questions: null,
+    recording_url: null,
+  }
+}
+
+function mockMeetings(meetings: ReturnType<typeof makeMeeting>[]) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ meetings }),
+    })
+  )
+}
+
+describe('MeetingHistory', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('paginates meeting history after four rows with compact controls', async () => {
+    mockMeetings(Array.from({ length: 7 }, (_, index) => makeMeeting(index + 1)))
+
+    render(<MeetingHistory token="dashboard-token" />)
+
+    expect(await screen.findByText('Showing 1 to 4 of 7 meetings')).toBeInTheDocument()
+    expect(screen.getByText('Page 1 of 2')).toBeInTheDocument()
+    expect(screen.getByText('Sun, Apr 5, 2026 · 45min')).toBeInTheDocument()
+    expect(screen.queryByText('Mon, Apr 6, 2026 · 45min')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Previous' })).toBeDisabled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+
+    expect(screen.getByText('Showing 5 to 7 of 7 meetings')).toBeInTheDocument()
+    expect(screen.getByText('Page 2 of 2')).toBeInTheDocument()
+    expect(screen.getByText('Mon, Apr 6, 2026 · 45min')).toBeInTheDocument()
+    expect(screen.queryByText('Thu, Apr 2, 2026 · 45min')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Previous' }))
+
+    expect(screen.getByText('Showing 1 to 4 of 7 meetings')).toBeInTheDocument()
+    expect(screen.getByText('Page 1 of 2')).toBeInTheDocument()
+  })
+
+  it('omits pagination and zero-minute duration artifacts for short meeting lists', async () => {
+    mockMeetings([
+      makeMeeting(6, 0),
+      makeMeeting(7, null),
+      makeMeeting(8, 30),
+    ])
+
+    render(<MeetingHistory token="dashboard-token" />)
+
+    expect(await screen.findByText('Tue, Apr 7, 2026')).toBeInTheDocument()
+    expect(screen.getByText('Wed, Apr 8, 2026')).toBeInTheDocument()
+    expect(screen.getByText('Thu, Apr 9, 2026 · 30min')).toBeInTheDocument()
+    expect(screen.queryByText(/20260/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Showing 1 to/)).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Next' })).not.toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/client/dashboard/dashboard-token/meetings')
+    })
+  })
+})

--- a/components/client-dashboard/MeetingHistory.tsx
+++ b/components/client-dashboard/MeetingHistory.tsx
@@ -28,10 +28,13 @@ interface MeetingHistoryProps {
   token: string
 }
 
+const MEETINGS_PAGE_SIZE = 4
+
 export default function MeetingHistory({ token }: MeetingHistoryProps) {
   const [meetings, setMeetings] = useState<Meeting[]>([])
   const [loading, setLoading] = useState(true)
   const [expandedId, setExpandedId] = useState<string | null>(null)
+  const [currentPage, setCurrentPage] = useState(1)
 
   useEffect(() => {
     async function fetchMeetings() {
@@ -40,6 +43,8 @@ export default function MeetingHistory({ token }: MeetingHistoryProps) {
         if (res.ok) {
           const data = await res.json()
           setMeetings(data.meetings || [])
+          setCurrentPage(1)
+          setExpandedId(null)
         }
       } catch {
         // Silently fail
@@ -63,15 +68,33 @@ export default function MeetingHistory({ token }: MeetingHistoryProps) {
 
   if (meetings.length === 0) return null
 
+  const totalPages = Math.ceil(meetings.length / MEETINGS_PAGE_SIZE)
+  const hasPagination = meetings.length > MEETINGS_PAGE_SIZE
+  const pageStartIndex = (currentPage - 1) * MEETINGS_PAGE_SIZE
+  const pageEndIndex = Math.min(pageStartIndex + MEETINGS_PAGE_SIZE, meetings.length)
+  const visibleMeetings = meetings.slice(pageStartIndex, pageEndIndex)
+
+  const goToPage = (page: number) => {
+    setCurrentPage(page)
+    setExpandedId(null)
+  }
+
   return (
     <div className="rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-5">
-      <h3 className="text-sm font-medium text-radiant-gold uppercase tracking-wider mb-4 flex items-center gap-2">
-        <Video className="w-4 h-4" />
-        Meeting History
-      </h3>
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <h3 className="text-sm font-medium text-radiant-gold uppercase tracking-wider flex items-center gap-2">
+          <Video className="w-4 h-4" />
+          Meeting History
+        </h3>
+        {hasPagination && (
+          <p className="text-xs text-platinum-white/45">
+            Showing {pageStartIndex + 1} to {pageEndIndex} of {meetings.length} meetings
+          </p>
+        )}
+      </div>
 
       <div className="space-y-2">
-        {meetings.map((meeting) => {
+        {visibleMeetings.map((meeting) => {
           const isExpanded = expandedId === meeting.id
           const hasDetails =
             (meeting.key_decisions && meeting.key_decisions.length > 0) ||
@@ -103,7 +126,7 @@ export default function MeetingHistory({ token }: MeetingHistoryProps) {
                         day: 'numeric',
                         year: 'numeric',
                       })}
-                      {meeting.duration_minutes && (
+                      {meeting.duration_minutes !== null && meeting.duration_minutes > 0 && (
                         <> &middot; {meeting.duration_minutes}min</>
                       )}
                     </p>
@@ -194,6 +217,32 @@ export default function MeetingHistory({ token }: MeetingHistoryProps) {
           )
         })}
       </div>
+
+      {hasPagination && (
+        <div className="mt-4 flex flex-col gap-3 border-t border-radiant-gold/10 pt-4 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-xs text-platinum-white/45">
+            Page {currentPage} of {totalPages}
+          </p>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => goToPage(Math.max(currentPage - 1, 1))}
+              disabled={currentPage === 1}
+              className="rounded-md border border-radiant-gold/20 px-3 py-1.5 text-xs font-medium text-platinum-white/70 transition hover:border-radiant-gold/45 hover:text-radiant-gold disabled:cursor-not-allowed disabled:border-platinum-white/10 disabled:text-platinum-white/25"
+            >
+              Previous
+            </button>
+            <button
+              type="button"
+              onClick={() => goToPage(Math.min(currentPage + 1, totalPages))}
+              disabled={currentPage === totalPages}
+              className="rounded-md border border-radiant-gold/20 px-3 py-1.5 text-xs font-medium text-platinum-white/70 transition hover:border-radiant-gold/45 hover:text-radiant-gold disabled:cursor-not-allowed disabled:border-platinum-white/10 disabled:text-platinum-white/25"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Paginate client dashboard Meeting History at four rows per page to reduce vertical scroll.
- Add compact Portfolio-style controls: `Showing start to end of total meetings`, `Page X of Y`, `Previous`, and `Next`.
- Reset expanded meeting details when changing pages and avoid rendering zero-minute durations as `20260` date artifacts.

## Validation
- `npx vitest run components/client-dashboard/MeetingHistory.test.tsx`
- `npx tsc --noEmit`
- `npx eslint components/client-dashboard/MeetingHistory.tsx components/client-dashboard/MeetingHistory.test.tsx`
- `git diff --check`
- Local Playwright smoke at `http://localhost:3231/client/dashboard/qa-token?qa=meeting-pagination` with mocked seven-meeting payload across desktop and mobile: verified four-row paging, disabled Previous/Next bounds, no `20260` artifact, and no horizontal overflow.

## Integration Notes
- No migrations or environment changes.
- No production data mutation.
- Captain should verify both Vercel contexts after merge:
  - Vercel – portfolio
  - Vercel – portfolio-staging
