### PR TITLE
fix: restore client dashboard package options

### DIFF
--- a/components/client-dashboard/AccelerationCards.test.tsx
+++ b/components/client-dashboard/AccelerationCards.test.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import AccelerationCards from './AccelerationCards'
+import type { AccelerationRecommendation } from '@/lib/acceleration-engine'
+
+const recommendation: AccelerationRecommendation = {
+  id: 'rec-1',
+  client_project_id: 'project-1',
+  pain_point_category_id: null,
+  content_type: 'bundle',
+  content_id: 0,
+  service_title: 'Community Impact Accelerator',
+  gap_category: 'tech_stack',
+  gap_description: 'Close website handoff gaps.',
+  projected_impact_pct: 28,
+  projected_annual_value: 1997,
+  impact_headline: 'Turn the FireSpring proof into cleaner launch-ready decisions.',
+  impact_explanation: 'Connect vendor feedback, navigation decisions, and launch readiness.',
+  data_source: 'client_specific',
+  benchmark_ids: [],
+  value_calculation_id: null,
+  confidence_level: 'high',
+  display_order: 0,
+  is_active: true,
+  cta_type: 'view_proposal',
+  cta_url: '/pricing#community-impact-accelerator',
+  dismissed_at: null,
+  converted_at: null,
+  created_at: '2026-07-18T00:00:00.000Z',
+  updated_at: '2026-07-18T00:00:00.000Z',
+}
+
+describe('AccelerationCards', () => {
+  it('does not render an empty package-options section', () => {
+    const { container } = render(
+      <AccelerationCards recommendations={[]} token="dashboard-token" onDismiss={vi.fn()} />
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('labels active acceleration recommendations as package options', () => {
+    render(
+      <AccelerationCards
+        recommendations={[recommendation]}
+        token="dashboard-token"
+        onDismiss={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('heading', { name: 'Package Options' })).toBeInTheDocument()
+    expect(screen.getByText('Community Impact Accelerator')).toBeInTheDocument()
+    expect(screen.getByText(/assessment gaps, task list/i)).toBeInTheDocument()
+    expect(screen.getByText('$1,997')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /view proposal/i })).toBeInTheDocument()
+  })
+
+  it('opens the recommendation CTA returned by the dashboard API', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        json: async () => ({ ctaUrl: '/pricing#community-impact-accelerator' }),
+      })
+    )
+    const open = vi.fn()
+    vi.stubGlobal('open', open)
+
+    render(
+      <AccelerationCards
+        recommendations={[recommendation]}
+        token="dashboard-token"
+        onDismiss={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /view proposal/i }))
+
+    await vi.waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/client/dashboard/dashboard-token/accelerators/rec-1',
+        expect.objectContaining({ method: 'PATCH' })
+      )
+      expect(open).toHaveBeenCalledWith('/pricing#community-impact-accelerator', '_blank')
+    })
+
+    vi.unstubAllGlobals()
+  })
+})

--- a/components/client-dashboard/AccelerationCards.tsx
+++ b/components/client-dashboard/AccelerationCards.tsx
@@ -19,9 +19,9 @@ interface AccelerationCardsProps {
 }
 
 const CONFIDENCE_STYLES: Record<string, { bg: string; text: string; label: string }> = {
-  high: { bg: 'bg-green-900/40', text: 'text-green-300', label: 'High Confidence' },
-  medium: { bg: 'bg-yellow-900/40', text: 'text-yellow-300', label: 'Moderate Confidence' },
-  low: { bg: 'bg-gray-800', text: 'text-gray-400', label: 'Estimated' },
+  high: { bg: 'bg-emerald-500/15', text: 'text-emerald-200', label: 'High Confidence' },
+  medium: { bg: 'bg-radiant-gold/15', text: 'text-gold-light', label: 'Moderate Confidence' },
+  low: { bg: 'bg-platinum-white/10', text: 'text-platinum-white/65', label: 'Estimated' },
 }
 
 const DATA_SOURCE_LABELS: Record<string, string> = {
@@ -83,15 +83,15 @@ export default function AccelerationCards({
   }
 
   return (
-    <div className="bg-gray-900 rounded-xl border border-gray-800 p-5">
+    <section className="rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-5">
       <div className="flex items-center gap-2 mb-4">
-        <Zap className="w-4 h-4 text-yellow-400" />
-        <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider">
-          Acceleration Opportunities
+        <Zap className="w-4 h-4 text-radiant-gold" />
+        <h3 className="text-sm font-medium text-radiant-gold uppercase tracking-wider">
+          Package Options
         </h3>
       </div>
-      <p className="text-xs text-gray-500 mb-4">
-        Tailored recommendations to help you achieve your goals faster, backed by data.
+      <p className="text-xs text-platinum-white/55 mb-4">
+        Tailored acceleration paths that connect the assessment gaps, task list, and available AmaduTown packages.
       </p>
 
       <div className="flex gap-4 overflow-x-auto pb-2 -mx-1 px-1 snap-x">
@@ -102,19 +102,19 @@ export default function AccelerationCards({
           return (
             <div
               key={rec.id}
-              className={`flex-shrink-0 w-[280px] md:w-[320px] bg-gray-800/60 border border-gray-700/50 rounded-xl p-4 snap-start transition-opacity ${
+              className={`flex-shrink-0 w-[280px] md:w-[320px] rounded-xl border border-radiant-gold/15 bg-imperial-navy/45 p-4 snap-start transition-opacity ${
                 isDismissing ? 'opacity-50' : ''
               }`}
             >
               {/* Header */}
               <div className="flex items-start justify-between mb-3">
                 <div className="flex items-center gap-2">
-                  <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-blue-600/30 to-indigo-600/30 flex items-center justify-center">
-                    <TrendingUp className="w-4 h-4 text-blue-400" />
+                  <div className="w-8 h-8 rounded-lg bg-radiant-gold/10 border border-radiant-gold/20 flex items-center justify-center">
+                    <TrendingUp className="w-4 h-4 text-radiant-gold" />
                   </div>
                   <div>
-                    <p className="text-sm font-medium text-gray-200">{rec.service_title}</p>
-                    <p className="text-[10px] text-gray-500">
+                    <p className="text-sm font-medium text-platinum-white/90">{rec.service_title}</p>
+                    <p className="text-[10px] uppercase tracking-[0.14em] text-platinum-white/42">
                       {rec.gap_category.replace(/_/g, ' ')}
                     </p>
                   </div>
@@ -122,7 +122,7 @@ export default function AccelerationCards({
                 <button
                   onClick={() => handleDismiss(rec.id)}
                   disabled={isDismissing}
-                  className="text-gray-600 hover:text-gray-400 p-1"
+                  className="text-platinum-white/35 hover:text-platinum-white/70 p-1"
                   title="Dismiss"
                 >
                   <X className="w-3.5 h-3.5" />
@@ -131,27 +131,27 @@ export default function AccelerationCards({
 
               {/* Impact Headline */}
               {rec.impact_headline && (
-                <p className="text-xs text-gray-300 mb-3 leading-relaxed">
+                <p className="text-xs text-platinum-white/72 mb-3 leading-relaxed">
                   {rec.impact_headline}
                 </p>
               )}
 
               {/* Projected Value */}
               {rec.projected_annual_value && rec.projected_annual_value > 0 && (
-                <div className="bg-gray-900/60 rounded-lg p-2.5 mb-3">
+                <div className="bg-imperial-navy/55 rounded-lg border border-radiant-gold/10 p-2.5 mb-3">
                   <div className="flex items-center gap-2">
-                    <BarChart className="w-4 h-4 text-emerald-400" />
-                    <span className="text-lg font-bold text-emerald-400">
+                    <BarChart className="w-4 h-4 text-gold-light" />
+                    <span className="text-lg font-bold text-gold-light">
                       {new Intl.NumberFormat('en-US', {
                         style: 'currency',
                         currency: 'USD',
                         maximumFractionDigits: 0,
                       }).format(rec.projected_annual_value)}
-                      <span className="text-xs font-normal text-gray-500">/year</span>
+                      <span className="text-xs font-normal text-platinum-white/42"> package</span>
                     </span>
                   </div>
                   {rec.projected_impact_pct && (
-                    <p className="text-[10px] text-gray-500 mt-0.5">
+                    <p className="text-[10px] text-platinum-white/45 mt-0.5">
                       +{rec.projected_impact_pct}% improvement
                     </p>
                   )}
@@ -166,8 +166,8 @@ export default function AccelerationCards({
                 </span>
               </div>
               <div className="flex items-center gap-1 mb-4">
-                <Info className="w-3 h-3 text-gray-600" />
-                <span className="text-[10px] text-gray-600">
+                <Info className="w-3 h-3 text-platinum-white/35" />
+                <span className="text-[10px] text-platinum-white/42">
                   {DATA_SOURCE_LABELS[rec.data_source] || 'Estimated'}
                 </span>
               </div>
@@ -175,7 +175,7 @@ export default function AccelerationCards({
               {/* CTA */}
               <button
                 onClick={() => handleConvert(rec.id)}
-                className="w-full flex items-center justify-center gap-2 py-2 px-3 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg transition-colors"
+                className="w-full flex items-center justify-center gap-2 rounded-lg border border-radiant-gold/25 bg-radiant-gold/12 px-3 py-2 text-sm font-medium text-gold-light transition-colors hover:bg-radiant-gold/20"
               >
                 {CTA_LABELS[rec.cta_type] || 'Learn More'}
                 <ArrowRight className="w-3.5 h-3.5" />
@@ -184,6 +184,6 @@ export default function AccelerationCards({
           )
         })}
       </div>
-    </div>
+    </section>
   )
 }

--- a/lib/assessment-scoring.test.ts
+++ b/lib/assessment-scoring.test.ts
@@ -25,11 +25,11 @@ describe('buildProjectedTrajectory', () => {
         },
       ],
       milestones: [
-        { week: 1, target_date: '2026-07-22T00:00:00.000Z' },
-        { week: 2, target_date: '2026-07-28T00:00:00.000Z' },
-        { week: 3, target_date: '2026-08-03T00:00:00.000Z' },
-        { week: 4, target_date: '2026-08-09T00:00:00.000Z' },
-        { week: 5, target_date: '2026-08-21T00:00:00.000Z' },
+        { week: 1 },
+        { week: 2 },
+        { week: 3 },
+        { week: 4 },
+        { week: 5 },
       ],
       remainingTasks: [
         { impact_score: 18 },

--- a/lib/assessment-scoring.ts
+++ b/lib/assessment-scoring.ts
@@ -222,9 +222,13 @@ export function buildProjectedTrajectory({
   const latestActual = actual[actual.length - 1]
   const latestActualDate = validDate(latestActual.date) || projectStartDate
   const today = startOfDay(now)
+  const completionDate =
+    projectedCompletionDate.getTime() > latestActualDate.getTime()
+      ? projectedCompletionDate
+      : addDays(latestActualDate, Math.max(7, milestones.length * 7))
   const canCarryForwardCurrent =
     today.getTime() > latestActualDate.getTime() &&
-    today.getTime() < projectedCompletionDate.getTime()
+    today.getTime() < completionDate.getTime()
 
   if (canCarryForwardCurrent) {
     latestActual.label = latestActual.label === 'Current score' ? undefined : latestActual.label
@@ -242,7 +246,7 @@ export function buildProjectedTrajectory({
 
   const currentPoint = actual[actual.length - 1]
   const currentDate = validDate(currentPoint.date) || projectStartDate
-  const completionDate =
+  const effectiveCompletionDate =
     projectedCompletionDate.getTime() > currentDate.getTime()
       ? projectedCompletionDate
       : addDays(currentDate, Math.max(7, milestones.length * 7))
@@ -252,9 +256,9 @@ export function buildProjectedTrajectory({
       ? Math.min(targetScore, currentPoint.overallScore + Math.max(5, milestones.length * 3))
       : currentPoint.overallScore
 
-    if (completionDate.getTime() > currentDate.getTime()) {
+    if (effectiveCompletionDate.getTime() > currentDate.getTime()) {
       actual.push({
-        date: completionDate.toISOString(),
+        date: effectiveCompletionDate.toISOString(),
         overallScore: latestMilestoneScore,
         isProjected: true,
         label: 'Projected completion',
@@ -275,7 +279,7 @@ export function buildProjectedTrajectory({
   let runningScore = currentPoint.overallScore
   const projectionSpanDays = Math.max(
     1,
-    (completionDate.getTime() - currentDate.getTime()) / MS_PER_DAY
+    (effectiveCompletionDate.getTime() - currentDate.getTime()) / MS_PER_DAY
   )
 
   for (let i = 0; i < remainingTasks.length; i++) {
@@ -286,7 +290,7 @@ export function buildProjectedTrajectory({
     )
     const projectedDate =
       completedTasks && completedTasks.length >= 2
-        ? new Date(Math.min(cadenceDate.getTime(), completionDate.getTime()))
+        ? new Date(Math.min(cadenceDate.getTime(), effectiveCompletionDate.getTime()))
         : milestoneDate
     runningScore = Math.min(targetScore, runningScore + (remainingTasks[i].impact_score || 0))
 
@@ -300,9 +304,9 @@ export function buildProjectedTrajectory({
 
   const finalPoint = actual[actual.length - 1]
   const finalDate = validDate(finalPoint.date)
-  if (finalDate && Math.abs(finalDate.getTime() - completionDate.getTime()) > MS_PER_DAY) {
+  if (finalDate && Math.abs(finalDate.getTime() - effectiveCompletionDate.getTime()) > MS_PER_DAY) {
     actual.push({
-      date: completionDate.toISOString(),
+      date: effectiveCompletionDate.toISOString(),
       overallScore: runningScore,
       isProjected: true,
       label: 'Projected completion',

--- a/scripts/seed-neil-kmb-client-dashboard.ts
+++ b/scripts/seed-neil-kmb-client-dashboard.ts
@@ -261,6 +261,11 @@ const dashboardTasks = [
     status: 'pending',
     due_date: '2026-07-15',
     display_order: 0,
+    acceleratedBundleName: 'Community Impact Accelerator',
+    accelerated_headline:
+      'Use the nonprofit implementation package when KMB wants AmaduTown to turn the FireSpring answer into a ready handoff plan.',
+    accelerated_savings:
+      'Reduces decision drift by connecting vendor feedback, navigation choices, and launch criteria in one path.',
   },
   {
     category: 'firespring_feedback',
@@ -272,6 +277,11 @@ const dashboardTasks = [
     status: 'in_progress',
     due_date: '2026-07-15',
     display_order: 1,
+    acceleratedBundleName: 'Community Impact Accelerator',
+    accelerated_headline:
+      'Fast-track the proof review into a documented implementation brief for FireSpring and the KMB board.',
+    accelerated_savings:
+      'Keeps approved navigation decisions from getting lost between proof revisions and launch handoff.',
   },
   {
     category: 'donation_support',
@@ -283,6 +293,11 @@ const dashboardTasks = [
     status: 'in_progress',
     due_date: '2026-07-16',
     display_order: 2,
+    acceleratedBundleName: 'Community Impact Growth',
+    accelerated_headline:
+      'Use the growth package when KMB wants donor, sponsor, shop, and program CTAs mapped into one support pathway.',
+    accelerated_savings:
+      'Connects content cleanup to campaign-ready donation and supporter flows.',
   },
   {
     category: 'donation_support',
@@ -294,6 +309,11 @@ const dashboardTasks = [
     status: 'pending',
     due_date: '2026-07-17',
     display_order: 3,
+    acceleratedBundleName: 'Community Impact Starter',
+    accelerated_headline:
+      'Use the starter option for a light routing audit and implementation checklist around donation conversion.',
+    accelerated_savings:
+      'Keeps the giving path practical without turning it into a full redesign cycle.',
   },
   {
     category: 'support_navigation',
@@ -305,6 +325,11 @@ const dashboardTasks = [
     status: 'pending',
     due_date: '2026-07-17',
     display_order: 4,
+    acceleratedBundleName: 'Community Impact Growth',
+    accelerated_headline:
+      'Package the sponsor, shop, and donation actions into a cleaner supporter journey.',
+    accelerated_savings:
+      'Turns scattered support actions into a clearer conversion path for KMB visitors.',
   },
   {
     category: 'client_decision',
@@ -316,6 +341,61 @@ const dashboardTasks = [
     status: 'pending',
     due_date: '2026-07-24',
     display_order: 5,
+    acceleratedBundleName: null,
+  },
+] as const
+
+const packageRecommendationSeeds = [
+  {
+    bundleName: 'Community Impact Starter',
+    service_title: 'Community Impact Starter',
+    gap_category: 'budget_timeline',
+    gap_description:
+      'Best fit when KMB wants a focused website-decision audit without expanding scope.',
+    projected_impact_pct: 18,
+    projected_annual_value: 0,
+    impact_headline:
+      'A light advisory path for clarifying the donation, support, and navigation decisions before build work expands.',
+    impact_explanation:
+      'This option keeps the next step compact: confirm the priority decisions, document the handoff, and avoid unnecessary rebuild work.',
+    data_source: 'client_specific',
+    confidence_level: 'medium',
+    cta_type: 'learn_more',
+    display_order: 0,
+  },
+  {
+    bundleName: 'Community Impact Accelerator',
+    service_title: 'Community Impact Accelerator',
+    gap_category: 'tech_stack',
+    gap_description:
+      'Best fit when KMB wants the FireSpring proof feedback, content priorities, and launch handoff converted into an implementation packet.',
+    projected_impact_pct: 28,
+    projected_annual_value: 1997,
+    impact_headline:
+      'A guided implementation path for turning the FireSpring Balance proof into cleaner launch-ready decisions.',
+    impact_explanation:
+      'This option connects vendor feedback, navigation decisions, donor-page routing, and launch readiness into one execution track.',
+    data_source: 'client_specific',
+    confidence_level: 'high',
+    cta_type: 'view_proposal',
+    display_order: 1,
+  },
+  {
+    bundleName: 'Community Impact Growth',
+    service_title: 'Community Impact Growth',
+    gap_category: 'automation_needs',
+    gap_description:
+      'Best fit when KMB wants the website migration to become a stronger support, donor, sponsor, and program engagement system.',
+    projected_impact_pct: 35,
+    projected_annual_value: 4997,
+    impact_headline:
+      'A broader growth path for connecting the website migration to supporter journeys and campaign readiness.',
+    impact_explanation:
+      'This option adds a stronger operating layer around donation, sponsor, shop, and program navigation so the site supports ongoing outreach.',
+    data_source: 'client_specific',
+    confidence_level: 'medium',
+    cta_type: 'book_call',
+    display_order: 2,
   },
 ] as const
 
@@ -332,6 +412,9 @@ const scoreSnapshot = {
   dream_outcome_gap: 43,
   trigger: 'manual',
 }
+
+type DashboardTaskSeed = (typeof dashboardTasks)[number]
+type BundleRef = { id: string; pricingTierSlug: string | null }
 
 function requiredEnv(name: string) {
   const value = process.env[name]
@@ -368,6 +451,49 @@ function slugFile(fileName: string) {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-|-$/g, '')
+}
+
+async function resolveBundleIds(client: ReturnType<typeof supabase>, bundleNames: readonly string[]) {
+  const uniqueNames = [...new Set(bundleNames.filter(Boolean))]
+  if (!apply) {
+    return new Map(uniqueNames.map((name) => [name, {
+      id: `dry-run-bundle-${slugFile(name)}`,
+      pricingTierSlug: slugFile(name),
+    } satisfies BundleRef]))
+  }
+
+  const { data, error } = await client
+    .from('offer_bundles')
+    .select('id, name, pricing_tier_slug')
+    .in('name', uniqueNames)
+    .eq('is_active', true)
+
+  if (error) throw new Error(`Failed to read offer bundles for KMB package options: ${error.message}`)
+
+  const bundleIds = new Map<string, BundleRef>()
+  for (const row of data || []) {
+    bundleIds.set(String(row.name), {
+      id: String(row.id),
+      pricingTierSlug: row.pricing_tier_slug ? String(row.pricing_tier_slug) : null,
+    })
+  }
+
+  const missing = uniqueNames.filter((name) => !bundleIds.has(name))
+  if (missing.length > 0) {
+    throw new Error(`Missing active offer bundles for KMB package options: ${missing.join(', ')}`)
+  }
+
+  return bundleIds
+}
+
+function buildDashboardTaskPayload(task: DashboardTaskSeed, bundleIds: Map<string, BundleRef>) {
+  const { acceleratedBundleName, ...taskPayload } = task
+
+  return {
+    ...taskPayload,
+    diy_resources: [],
+    accelerated_bundle_id: acceleratedBundleName ? bundleIds.get(acceleratedBundleName)?.id : null,
+  }
 }
 
 async function ensureContact(client: ReturnType<typeof supabase>) {
@@ -700,7 +826,13 @@ async function upsertOnboardingPlan(client: ReturnType<typeof supabase>, project
 }
 
 async function refreshDashboardTasks(client: ReturnType<typeof supabase>, projectId: string) {
-  if (!apply) return dashboardTasks.length
+  const bundleIds = await resolveBundleIds(
+    client,
+    dashboardTasks.flatMap((task) => task.acceleratedBundleName ? [task.acceleratedBundleName] : [])
+  )
+  const taskPayload = dashboardTasks.map((task) => buildDashboardTaskPayload(task, bundleIds))
+
+  if (!apply) return taskPayload.length
 
   const { error: deleteError } = await client
     .from('dashboard_tasks')
@@ -711,15 +843,61 @@ async function refreshDashboardTasks(client: ReturnType<typeof supabase>, projec
   if (deleteError) throw new Error(`Failed to clear old KMB dashboard tasks: ${deleteError.message}`)
 
   const { error: insertError } = await client.from('dashboard_tasks').insert(
-    dashboardTasks.map((task) => ({
+    taskPayload.map((task) => ({
       client_project_id: projectId,
       ...task,
-      diy_resources: [],
     }))
   )
 
   if (insertError) throw new Error(`Failed to insert KMB dashboard tasks: ${insertError.message}`)
-  return dashboardTasks.length
+  return taskPayload.length
+}
+
+async function refreshAccelerationRecommendations(client: ReturnType<typeof supabase>, projectId: string) {
+  const bundleIds = await resolveBundleIds(
+    client,
+    packageRecommendationSeeds.map((recommendation) => recommendation.bundleName)
+  )
+  const recommendationPayload = packageRecommendationSeeds.map((recommendation) => {
+    const { bundleName, ...payload } = recommendation
+    if (!bundleIds.has(bundleName)) {
+      throw new Error(`Missing active offer bundle for KMB package option: ${bundleName}`)
+    }
+
+    return {
+      client_project_id: projectId,
+      pain_point_category_id: null,
+      content_type: 'bundle',
+      content_id: 0,
+      benchmark_ids: [],
+      value_calculation_id: null,
+      is_active: true,
+      dismissed_at: null,
+      converted_at: null,
+      cta_url: `/pricing#${bundleIds.get(bundleName)?.pricingTierSlug || slugFile(bundleName)}`,
+      ...payload,
+    }
+  })
+
+  if (!apply) return recommendationPayload.length
+
+  const { error: deleteError } = await client
+    .from('acceleration_recommendations')
+    .delete()
+    .eq('client_project_id', projectId)
+    .eq('content_type', 'bundle')
+    .in('service_title', packageRecommendationSeeds.map((recommendation) => recommendation.service_title))
+    .is('dismissed_at', null)
+    .is('converted_at', null)
+
+  if (deleteError) throw new Error(`Failed to clear KMB package options: ${deleteError.message}`)
+
+  const { error: insertError } = await client
+    .from('acceleration_recommendations')
+    .insert(recommendationPayload)
+
+  if (insertError) throw new Error(`Failed to insert KMB package options: ${insertError.message}`)
+  return recommendationPayload.length
 }
 
 async function refreshScoreSnapshot(client: ReturnType<typeof supabase>, projectId: string) {
@@ -828,6 +1006,7 @@ async function main() {
   const documents = await uploadDocuments(client, proposalId)
   const onboardingPlanId = await upsertOnboardingPlan(client, project.id)
   const taskCount = await refreshDashboardTasks(client, project.id)
+  const packageOptionCount = await refreshAccelerationRecommendations(client, project.id)
   const scoreSnapshotId = await refreshScoreSnapshot(client, project.id)
   await linkMeetingsAndActions(client, project.id, contactSubmissionId)
   const timeEntryCount = await seedTimeEntries(client, project.id)
@@ -846,6 +1025,7 @@ async function main() {
         documents,
         milestoneCount: milestonePlan.length,
         dashboardTaskCount: taskCount,
+        packageOptionCount,
         scoreSnapshotId,
         timeEntryCount,
         correspondence: {


### PR DESCRIPTION
## Summary
- Restores the client dashboard package-options surface by relabeling acceleration recommendations as Package Options and aligning the cards with the dashboard visual system.
- Seeds KMB with three nonprofit package options and task-level fast-track package links using active offer bundle records.
- Keeps the current-day trajectory fallback working when week-based milestones would otherwise make the projected completion date stale.

## Validation
- npx vitest run components/client-dashboard/AccelerationCards.test.tsx lib/assessment-scoring.test.ts
- npx tsc --noEmit
- npx eslint lib/assessment-scoring.ts lib/assessment-scoring.test.ts components/client-dashboard/AccelerationCards.tsx components/client-dashboard/AccelerationCards.test.tsx scripts/seed-neil-kmb-client-dashboard.ts
- git diff --check
- npm run client:seed-neil-kmb -- --target prod --dry-run
- npm run build

## Integration Notes
- No schema migration required.
- Production data apply required after deploy: npm run client:seed-neil-kmb:prod:apply
- Vercel checks before merge: pending captain verification.
- Vercel checks after merge: pending captain verification for Vercel – portfolio and Vercel – portfolio-staging.
