### PR TITLE
fix: hide free package value placeholder

### DIFF
--- a/components/client-dashboard/AccelerationCards.test.tsx
+++ b/components/client-dashboard/AccelerationCards.test.tsx
@@ -55,6 +55,27 @@ describe('AccelerationCards', () => {
     expect(screen.getByRole('button', { name: /view proposal/i })).toBeInTheDocument()
   })
 
+  it('does not render a stray zero for free package options', () => {
+    render(
+      <AccelerationCards
+        recommendations={[{
+          ...recommendation,
+          id: 'rec-free',
+          service_title: 'Community Impact Starter',
+          projected_annual_value: 0,
+          projected_impact_pct: 18,
+          cta_type: 'learn_more',
+        }]}
+        token="dashboard-token"
+        onDismiss={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Community Impact Starter')).toBeInTheDocument()
+    expect(screen.queryByText('0')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /learn more/i })).toBeInTheDocument()
+  })
+
   it('opens the recommendation CTA returned by the dashboard API', async () => {
     vi.stubGlobal(
       'fetch',

--- a/components/client-dashboard/AccelerationCards.tsx
+++ b/components/client-dashboard/AccelerationCards.tsx
@@ -98,6 +98,8 @@ export default function AccelerationCards({
         {recommendations.map((rec) => {
           const confidence = CONFIDENCE_STYLES[rec.confidence_level] || CONFIDENCE_STYLES.low
           const isDismissing = dismissing === rec.id
+          const projectedAnnualValue = Number(rec.projected_annual_value || 0)
+          const projectedImpactPct = Number(rec.projected_impact_pct || 0)
 
           return (
             <div
@@ -137,7 +139,7 @@ export default function AccelerationCards({
               )}
 
               {/* Projected Value */}
-              {rec.projected_annual_value && rec.projected_annual_value > 0 && (
+              {projectedAnnualValue > 0 && (
                 <div className="bg-imperial-navy/55 rounded-lg border border-radiant-gold/10 p-2.5 mb-3">
                   <div className="flex items-center gap-2">
                     <BarChart className="w-4 h-4 text-gold-light" />
@@ -146,13 +148,13 @@ export default function AccelerationCards({
                         style: 'currency',
                         currency: 'USD',
                         maximumFractionDigits: 0,
-                      }).format(rec.projected_annual_value)}
+                      }).format(projectedAnnualValue)}
                       <span className="text-xs font-normal text-platinum-white/42"> package</span>
                     </span>
                   </div>
-                  {rec.projected_impact_pct && (
+                  {projectedImpactPct > 0 && (
                     <p className="text-[10px] text-platinum-white/45 mt-0.5">
-                      +{rec.projected_impact_pct}% improvement
+                      +{projectedImpactPct}% improvement
                     </p>
                   )}
                 </div>


### PR DESCRIPTION
## Summary
- Prevents free package options from rendering a stray `0` in the client dashboard package-options cards.
- Covers the free package case in the AccelerationCards test.

## Validation
- npx vitest run components/client-dashboard/AccelerationCards.test.tsx
- npx eslint components/client-dashboard/AccelerationCards.tsx components/client-dashboard/AccelerationCards.test.tsx
- npx tsc --noEmit
- git diff --check

## Integration Notes
- No migration required.
- Vercel checks before merge: pending captain verification.
- Vercel checks after merge: pending captain verification for Vercel – portfolio and Vercel – portfolio-staging.
