### PR TITLE
fix: recover client dashboard account context

### DIFF
--- a/app/client/dashboard/[token]/page.tsx
+++ b/app/client/dashboard/[token]/page.tsx
@@ -10,6 +10,7 @@ import ExecutiveSummary, {
   TrajectoryCommentary,
 } from '@/components/client-dashboard/ExecutiveSummary'
 import ScoreRadarChart from '@/components/client-dashboard/ScoreRadarChart'
+import AssessmentScoreBreakdown from '@/components/client-dashboard/AssessmentScoreBreakdown'
 import ConfidenceRadar from '@/components/client-dashboard/ConfidenceRadar'
 import StrengthenConfidenceBlock from '@/components/client-dashboard/StrengthenConfidenceBlock'
 import TrajectoryChart from '@/components/client-dashboard/TrajectoryChart'
@@ -22,6 +23,7 @@ import CampaignProgressSection from '@/components/client-dashboard/CampaignProgr
 import DocumentsSection from '@/components/client-dashboard/DocumentsSection'
 import ReportsSection from '@/components/client-dashboard/ReportsSection'
 import TimeTrackingSection from '@/components/client-dashboard/TimeTrackingSection'
+import AccountSummarySection from '@/components/client-dashboard/AccountSummarySection'
 import MeetingHistory from '@/components/client-dashboard/MeetingHistory'
 import AiOpsRoadmapSection from '@/components/client-dashboard/AiOpsRoadmapSection'
 import BuildEvidenceInvestmentSection from '@/components/client-dashboard/BuildEvidenceInvestmentSection'
@@ -257,6 +259,7 @@ export default function ClientDashboardPage() {
     gammaReports,
     aiOpsRoadmap,
     buildEvidence,
+    accountSummary,
   } = dashboard as DashboardData
 
   const tasksCompleted = tasks.filter((t: DashboardTask) => t.status === 'complete').length
@@ -331,6 +334,7 @@ export default function ClientDashboardPage() {
           <div className="space-y-3">
             <ScoreRadarChart scores={scores.categoryScores} />
             <AssessmentScoresCommentary categoryScores={scores.categoryScores} />
+            <AssessmentScoreBreakdown scores={scores.categoryScores} />
           </div>
           <div className="space-y-3">
             {snapshots.length > 0 ? (
@@ -394,6 +398,11 @@ export default function ClientDashboardPage() {
             milestones={(milestones || []) as Array<{ title?: string }>}
           />
         </div>
+
+        <AccountSummarySection
+          accountSummary={accountSummary}
+          timeTracking={timeTracking || { total_seconds: 0, by_target: [] }}
+        />
 
         {buildEvidence && (
           <BuildEvidenceInvestmentSection buildEvidence={buildEvidence} />

--- a/components/client-dashboard/AccelerationCards.test.tsx
+++ b/components/client-dashboard/AccelerationCards.test.tsx
@@ -106,4 +106,38 @@ describe('AccelerationCards', () => {
 
     vi.unstubAllGlobals()
   })
+
+  it('labels contract extension options as account actions', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        json: async () => ({ ctaUrl: '#account-summary' }),
+      })
+    )
+
+    render(
+      <AccelerationCards
+        recommendations={[{
+          ...recommendation,
+          id: 'rec-contract',
+          content_type: 'contract_option',
+          service_title: 'Extend Existing Contract',
+          projected_annual_value: 1200,
+        }]}
+        token="dashboard-token"
+        onDismiss={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Extend Existing Contract')).toBeInTheDocument()
+    expect(screen.getByText('contract')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /view account/i }))
+
+    await vi.waitFor(() => {
+      expect(window.location.hash).toBe('#account-summary')
+    })
+
+    vi.unstubAllGlobals()
+  })
 })

--- a/components/client-dashboard/AccelerationCards.tsx
+++ b/components/client-dashboard/AccelerationCards.tsx
@@ -37,6 +37,11 @@ const CTA_LABELS: Record<string, string> = {
   start_trial: 'Start Trial',
 }
 
+function getCtaLabel(rec: AccelerationRecommendation): string {
+  if (rec.content_type === 'contract_option') return 'View Account'
+  return CTA_LABELS[rec.cta_type] || 'Learn More'
+}
+
 export default function AccelerationCards({
   recommendations,
   token,
@@ -75,7 +80,11 @@ export default function AccelerationCards({
       })
       const data = await res.json()
       if (data.ctaUrl) {
-        window.open(data.ctaUrl, '_blank')
+        if (typeof data.ctaUrl === 'string' && data.ctaUrl.startsWith('#')) {
+          window.location.hash = data.ctaUrl
+        } else {
+          window.open(data.ctaUrl, '_blank')
+        }
       }
     } catch {
       // Silent fail
@@ -100,6 +109,7 @@ export default function AccelerationCards({
           const isDismissing = dismissing === rec.id
           const projectedAnnualValue = Number(rec.projected_annual_value || 0)
           const projectedImpactPct = Number(rec.projected_impact_pct || 0)
+          const isContractOption = rec.content_type === 'contract_option'
 
           return (
             <div
@@ -149,7 +159,9 @@ export default function AccelerationCards({
                         currency: 'USD',
                         maximumFractionDigits: 0,
                       }).format(projectedAnnualValue)}
-                      <span className="text-xs font-normal text-platinum-white/42"> package</span>
+                      <span className="text-xs font-normal text-platinum-white/42">
+                        {' '}{isContractOption ? 'contract' : 'package'}
+                      </span>
                     </span>
                   </div>
                   {projectedImpactPct > 0 && (
@@ -179,7 +191,7 @@ export default function AccelerationCards({
                 onClick={() => handleConvert(rec.id)}
                 className="w-full flex items-center justify-center gap-2 rounded-lg border border-radiant-gold/25 bg-radiant-gold/12 px-3 py-2 text-sm font-medium text-gold-light transition-colors hover:bg-radiant-gold/20"
               >
-                {CTA_LABELS[rec.cta_type] || 'Learn More'}
+                {getCtaLabel(rec)}
                 <ArrowRight className="w-3.5 h-3.5" />
               </button>
             </div>

--- a/components/client-dashboard/AccountSummarySection.test.tsx
+++ b/components/client-dashboard/AccountSummarySection.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import AccountSummarySection from './AccountSummarySection'
+import type { AccountSummaryData, TimeTrackingData } from '@/lib/client-dashboard'
+
+const accountSummary: AccountSummaryData = {
+  contract_value: 1200,
+  paid_to_date: 1200,
+  balance_due: 0,
+  current_packet_value: 0,
+  service_lines: [
+    {
+      id: 'proposal-1:Website UX Refresh',
+      label: 'Website UX Refresh',
+      description: "Refresh and restructure a client's existing website",
+      amount: 1200,
+      status: 'paid',
+      source: 'contract',
+      date: '2026-03-19T14:54:20.088Z',
+    },
+    {
+      id: 'proposal-2:FireSpring Balance proof feedback and migration advisory',
+      label: 'FireSpring Balance proof feedback and migration advisory',
+      description: 'Template-fit recommendations and launch-readiness handoff assets.',
+      amount: 0,
+      status: 'sent',
+      source: 'current_packet',
+      date: '2026-07-18T19:47:32.599Z',
+    },
+  ],
+}
+
+const timeTracking: TimeTrackingData = {
+  total_seconds: 23400,
+  by_target: [
+    {
+      target_type: 'milestone',
+      target_id: '0',
+      total_seconds: 7200,
+      entry_count: 1,
+      descriptions: [
+        'KMB dashboard seed: FireSpring proof review, vendor recommendation research, and feedback synthesis',
+      ],
+    },
+  ],
+}
+
+describe('AccountSummarySection', () => {
+  it('summarizes contract value, paid balance, and services rendered', () => {
+    render(
+      <AccountSummarySection
+        accountSummary={accountSummary}
+        timeTracking={timeTracking}
+      />
+    )
+
+    expect(screen.getByRole('heading', { name: /account summary/i })).toBeInTheDocument()
+    expect(screen.getAllByText('$1,200')).toHaveLength(3)
+    expect(screen.getByText('No balance due')).toBeInTheDocument()
+    expect(screen.getByText('Included')).toBeInTheDocument()
+    expect(screen.getByText('Website UX Refresh')).toBeInTheDocument()
+    expect(screen.getByText(/FireSpring proof review/i)).toBeInTheDocument()
+    expect(screen.getByText('6h 30m logged')).toBeInTheDocument()
+  })
+})

--- a/components/client-dashboard/AccountSummarySection.tsx
+++ b/components/client-dashboard/AccountSummarySection.tsx
@@ -1,0 +1,141 @@
+'use client'
+
+import { Briefcase, CheckCircle2, Clock, Receipt } from 'lucide-react'
+import type { AccountSummaryData, TimeTrackingData } from '@/lib/client-dashboard'
+
+interface AccountSummarySectionProps {
+  accountSummary: AccountSummaryData | null
+  timeTracking: TimeTrackingData
+}
+
+function formatCurrency(value: number): string {
+  if (value === 0) return 'Included'
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  }).format(value)
+}
+
+function formatBalance(value: number): string {
+  if (value === 0) return 'No balance due'
+  return formatCurrency(value)
+}
+
+function formatHours(seconds: number): string {
+  const hours = Math.floor(seconds / 3600)
+  const minutes = Math.floor((seconds % 3600) / 60)
+  if (hours > 0 && minutes > 0) return `${hours}h ${minutes}m`
+  if (hours > 0) return `${hours}h`
+  if (minutes > 0) return `${minutes}m`
+  return '<1m'
+}
+
+function formatDate(value: string | null): string | null {
+  if (!value) return null
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return null
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+export default function AccountSummarySection({
+  accountSummary,
+  timeTracking,
+}: AccountSummarySectionProps) {
+  if (!accountSummary && (!timeTracking || timeTracking.total_seconds === 0)) return null
+
+  const serviceDescriptions = (timeTracking?.by_target || [])
+    .flatMap((entry) => entry.descriptions || [])
+    .filter(Boolean)
+
+  return (
+    <section id="account-summary" className="rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-5">
+      <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h3 className="flex items-center gap-2 text-sm font-medium uppercase tracking-wider text-radiant-gold">
+            <Receipt className="h-4 w-4" />
+            Account Summary
+          </h3>
+          <p className="mt-1 text-xs text-platinum-white/55">
+            Contract value, paid balance, and services rendered to date.
+          </p>
+        </div>
+        {timeTracking?.total_seconds > 0 && (
+          <div className="inline-flex items-center gap-1.5 rounded-md border border-radiant-gold/15 bg-imperial-navy/45 px-2.5 py-1 text-xs text-platinum-white/72">
+            <Clock className="h-3.5 w-3.5 text-radiant-gold" />
+            {formatHours(timeTracking.total_seconds)} logged
+          </div>
+        )}
+      </div>
+
+      {accountSummary && (
+        <div className="mb-4 grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <div className="rounded-lg border border-radiant-gold/10 bg-imperial-navy/35 p-3">
+            <p className="text-[10px] uppercase tracking-[0.16em] text-platinum-white/42">Contract value</p>
+            <p className="mt-1 text-lg font-semibold text-platinum-white">
+              {formatCurrency(accountSummary.contract_value)}
+            </p>
+          </div>
+          <div className="rounded-lg border border-radiant-gold/10 bg-imperial-navy/35 p-3">
+            <p className="text-[10px] uppercase tracking-[0.16em] text-platinum-white/42">Paid to date</p>
+            <p className="mt-1 text-lg font-semibold text-platinum-white">
+              {formatCurrency(accountSummary.paid_to_date)}
+            </p>
+          </div>
+          <div className="rounded-lg border border-radiant-gold/10 bg-imperial-navy/35 p-3">
+            <p className="text-[10px] uppercase tracking-[0.16em] text-platinum-white/42">Balance</p>
+            <p className="mt-1 text-lg font-semibold text-platinum-white">
+              {formatBalance(accountSummary.balance_due)}
+            </p>
+          </div>
+        </div>
+      )}
+
+      {accountSummary?.service_lines.length ? (
+        <div className="mb-4 space-y-2">
+          <p className="text-xs font-medium uppercase tracking-[0.14em] text-platinum-white/50">
+            Contracted services
+          </p>
+          {accountSummary.service_lines.map((line) => {
+            const date = formatDate(line.date)
+            return (
+              <div key={line.id} className="rounded-lg border border-radiant-gold/10 bg-imperial-navy/30 p-3">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-platinum-white/86">{line.label}</p>
+                    {line.description && (
+                      <p className="mt-1 text-xs leading-5 text-platinum-white/55">{line.description}</p>
+                    )}
+                  </div>
+                  <div className="shrink-0 text-left sm:text-right">
+                    <p className="text-sm font-semibold text-gold-light">{formatCurrency(line.amount)}</p>
+                    <p className="text-[10px] uppercase tracking-[0.12em] text-platinum-white/40">
+                      {line.status}{date ? ` · ${date}` : ''}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      ) : null}
+
+      {serviceDescriptions.length > 0 && (
+        <div className="rounded-lg border border-radiant-gold/10 bg-imperial-navy/30 p-3">
+          <p className="mb-2 flex items-center gap-2 text-xs font-medium uppercase tracking-[0.14em] text-platinum-white/50">
+            <Briefcase className="h-3.5 w-3.5 text-radiant-gold/80" />
+            Services rendered
+          </p>
+          <ul className="space-y-2">
+            {serviceDescriptions.map((description) => (
+              <li key={description} className="flex gap-2 text-xs leading-5 text-platinum-white/68">
+                <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0 text-radiant-gold/75" />
+                <span>{description.replace(/^KMB dashboard seed:\s*/i, '')}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/components/client-dashboard/AssessmentScoreBreakdown.test.tsx
+++ b/components/client-dashboard/AssessmentScoreBreakdown.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import AssessmentScoreBreakdown from './AssessmentScoreBreakdown'
+
+describe('AssessmentScoreBreakdown', () => {
+  it('renders category scores with compact explanations and target gaps', () => {
+    render(
+      <AssessmentScoreBreakdown
+        scores={{
+          business_challenges: 78,
+          tech_stack: 52,
+          automation_needs: 44,
+          ai_readiness: 36,
+          budget_timeline: 62,
+          decision_making: 68,
+        }}
+      />
+    )
+
+    expect(screen.getByText('Score breakdown')).toBeInTheDocument()
+    expect(screen.getByText('AI readiness')).toBeInTheDocument()
+    expect(screen.getByText('54 points below target')).toBeInTheDocument()
+    expect(screen.getByText(/FireSpring can support the work/i)).toBeInTheDocument()
+    expect(screen.getByText(/current contract should not absorb unlimited rebuild work/i)).toBeInTheDocument()
+  })
+})

--- a/components/client-dashboard/AssessmentScoreBreakdown.tsx
+++ b/components/client-dashboard/AssessmentScoreBreakdown.tsx
@@ -1,0 +1,125 @@
+'use client'
+
+import { AlertTriangle, CheckCircle2, MinusCircle } from 'lucide-react'
+import type { AssessmentCategory, CategoryScores } from '@/lib/assessment-scoring'
+
+interface AssessmentScoreBreakdownProps {
+  scores: CategoryScores
+  dreamScores?: Partial<CategoryScores>
+}
+
+const CATEGORY_EXPLANATIONS: Record<AssessmentCategory, string> = {
+  business_challenges:
+    'The business need and migration outcome are clear enough to guide decisions.',
+  tech_stack:
+    'FireSpring can support the work, but template limits and navigation depth still need confirmation.',
+  automation_needs:
+    'Supporter, donor, sponsor, and program paths still rely on manual routing and follow-up.',
+  ai_readiness:
+    'AI is not the immediate blocker; reusable knowledge capture can improve after launch decisions stabilize.',
+  budget_timeline:
+    'Scope control and vendor timing matter because the current contract should not absorb unlimited rebuild work.',
+  decision_making:
+    'The main choices are known, but board and vendor feedback still decide final launch readiness.',
+}
+
+const SHORT_LABELS: Record<AssessmentCategory, string> = {
+  business_challenges: 'Business',
+  tech_stack: 'Tech',
+  automation_needs: 'Automation',
+  ai_readiness: 'AI readiness',
+  budget_timeline: 'Budget',
+  decision_making: 'Decision',
+}
+
+const CATEGORY_ORDER: AssessmentCategory[] = [
+  'business_challenges',
+  'tech_stack',
+  'automation_needs',
+  'ai_readiness',
+  'budget_timeline',
+  'decision_making',
+]
+
+const TARGET_SCORE = 90
+
+function getStatus(score: number, target: number) {
+  const gap = Math.max(target - score, 0)
+  if (gap <= 10) return { label: 'Strong', Icon: CheckCircle2, className: 'text-emerald-200' }
+  if (gap <= 25) return { label: 'Watch', Icon: MinusCircle, className: 'text-gold-light' }
+  return { label: 'Gap', Icon: AlertTriangle, className: 'text-amber-200' }
+}
+
+export default function AssessmentScoreBreakdown({
+  scores,
+  dreamScores,
+}: AssessmentScoreBreakdownProps) {
+  const entries = CATEGORY_ORDER
+    .map((category) => {
+      const score = Number(scores[category] || 0)
+      const target = Number(dreamScores?.[category] ?? TARGET_SCORE)
+      return {
+        category,
+        score,
+        target,
+        gap: Math.max(target - score, 0),
+      }
+    })
+    .sort((a, b) => b.gap - a.gap)
+
+  return (
+    <div className="rounded-lg border border-radiant-gold/15 bg-imperial-navy/35 p-4">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <div>
+          <h3 className="text-[10px] font-semibold uppercase tracking-[0.18em] text-radiant-gold/80">
+            Score breakdown
+          </h3>
+          <p className="mt-1 text-xs text-platinum-white/52">
+            Category detail behind the radar chart.
+          </p>
+        </div>
+        <div className="text-right text-[10px] uppercase tracking-[0.14em] text-platinum-white/42">
+          Target {TARGET_SCORE}
+        </div>
+      </div>
+      <div className="space-y-3">
+        {entries.map(({ category, score, target, gap }) => {
+          const status = getStatus(score, target)
+          const pct = Math.max(0, Math.min(100, score))
+          const StatusIcon = status.Icon
+
+          return (
+            <div key={category} className="rounded-lg border border-radiant-gold/10 bg-silicon-slate/25 p-3">
+              <div className="mb-2 flex items-start justify-between gap-3">
+                <div>
+                  <p className="text-sm font-medium text-platinum-white/86">
+                    {SHORT_LABELS[category]}
+                  </p>
+                  <p className="mt-1 text-xs leading-5 text-platinum-white/58">
+                    {CATEGORY_EXPLANATIONS[category]}
+                  </p>
+                </div>
+                <div className="shrink-0 text-right">
+                  <p className="text-lg font-semibold text-platinum-white">{score}</p>
+                  <div className={`mt-0.5 inline-flex items-center gap-1 text-[10px] uppercase tracking-[0.12em] ${status.className}`}>
+                    <StatusIcon className="h-3 w-3" />
+                    {status.label}
+                  </div>
+                </div>
+              </div>
+              <div className="h-1.5 overflow-hidden rounded-full bg-imperial-navy/70">
+                <div
+                  className="h-full rounded-full bg-radiant-gold/80"
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+              <p className="mt-1 text-[10px] text-platinum-white/40">
+                {gap > 0 ? `${gap} points below target` : 'At target'}
+              </p>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/lib/client-dashboard.ts
+++ b/lib/client-dashboard.ts
@@ -136,11 +136,30 @@ export interface TimeEntrySummary {
   target_id: string
   total_seconds: number
   entry_count: number
+  descriptions?: string[]
 }
 
 export interface TimeTrackingData {
   total_seconds: number
   by_target: TimeEntrySummary[]
+}
+
+export interface AccountServiceLine {
+  id: string
+  label: string
+  description: string | null
+  amount: number
+  status: string
+  source: 'contract' | 'current_packet'
+  date: string | null
+}
+
+export interface AccountSummaryData {
+  contract_value: number
+  paid_to_date: number
+  balance_due: number
+  current_packet_value: number
+  service_lines: AccountServiceLine[]
 }
 
 export interface ClientValueReport {
@@ -197,6 +216,7 @@ export interface DashboardData {
   snapshots: ScoreSnapshot[]
   documents: DashboardDocument[]
   timeTracking: TimeTrackingData
+  accountSummary: AccountSummaryData | null
   nextMeeting: {
     meeting_date: string
     meeting_type: string
@@ -472,6 +492,7 @@ export async function getDashboardByToken(
     allValueReportsResult,
     allGammaReportsResult,
     buildEvidenceResult,
+    allClientProposalsResult,
   ] = await Promise.all([
     // Diagnostic audit via contact_submission -> diagnostic_audits
     project.contact_submission_id
@@ -602,6 +623,12 @@ export async function getDashboardByToken(
       : Promise.resolve({ data: null, error: null }),
 
     getBuildEvidenceForClientProject(projectId),
+
+    supabaseAdmin
+      .from('proposals')
+      .select('id, bundle_name, line_items, total_amount, status, paid_at, accepted_at, created_at')
+      .eq('client_email', project.client_email)
+      .order('created_at', { ascending: false }),
   ])
 
   const audit = auditResult.data
@@ -687,7 +714,12 @@ export async function getDashboardByToken(
   }
 
   // Aggregate time tracking data
-  const rawTimeEntries = (timeEntriesResult.data || []) as { target_type: string; target_id: string; duration_seconds: number }[]
+  const rawTimeEntries = (timeEntriesResult.data || []) as {
+    target_type: string
+    target_id: string
+    duration_seconds: number
+    description: string | null
+  }[]
   const targetMap = new Map<string, TimeEntrySummary>()
   let totalTimeSeconds = 0
   for (const te of rawTimeEntries) {
@@ -702,7 +734,15 @@ export async function getDashboardByToken(
         target_id: te.target_id,
         total_seconds: te.duration_seconds,
         entry_count: 1,
+        descriptions: [],
       })
+    }
+    if (typeof te.description === 'string' && te.description.trim().length > 0) {
+      const summary = targetMap.get(key)
+      if (summary) {
+        summary.descriptions = summary.descriptions || []
+        summary.descriptions.push(te.description.trim())
+      }
     }
     totalTimeSeconds += te.duration_seconds
   }
@@ -785,6 +825,7 @@ export async function getDashboardByToken(
 
   const valueReports = (allValueReportsResult.data || []) as ClientValueReport[]
   const gammaReports = (allGammaReportsResult.data || []) as ClientGammaReport[]
+  const accountSummary = buildAccountSummary(allClientProposalsResult.data || [])
   const aiOpsRoadmap = await getRoadmapBundleForProject(projectId).then((bundle) => bundle?.clientView ?? null).catch(() => null)
   const buildEvidence = buildEvidenceResult ?? null
 
@@ -812,6 +853,7 @@ export async function getDashboardByToken(
       snapshots,
       documents,
       timeTracking,
+      accountSummary,
       nextMeeting: meetingResult.data || null,
       valueReport: valueReportResult.data || null,
       valueReports,
@@ -820,6 +862,90 @@ export async function getDashboardByToken(
       buildEvidence,
     },
     stage: 'client',
+  }
+}
+
+type ProposalHistoryRow = {
+  id: string
+  bundle_name: string | null
+  line_items: unknown
+  total_amount: number | string | null
+  status: string | null
+  paid_at: string | null
+  accepted_at: string | null
+  created_at: string | null
+}
+
+function numberFromCurrency(value: number | string | null | undefined): number {
+  const parsed = Number(value ?? 0)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+function proposalDate(row: ProposalHistoryRow): string | null {
+  return row.paid_at || row.accepted_at || row.created_at || null
+}
+
+function normalizeLineItems(value: unknown): Array<{ label: string; description: string | null; amount: number }> {
+  if (!Array.isArray(value)) return []
+
+  return value
+    .map((item) => {
+      if (!item || typeof item !== 'object') return null
+      const record = item as Record<string, unknown>
+      const label = String(record.name || record.title || '').trim()
+      if (!label) return null
+      return {
+        label,
+        description: typeof record.description === 'string' ? record.description : null,
+        amount: numberFromCurrency(record.price as number | string | null | undefined),
+      }
+    })
+    .filter((item): item is { label: string; description: string | null; amount: number } => Boolean(item))
+}
+
+function buildAccountSummary(rows: unknown[]): AccountSummaryData | null {
+  const proposals = rows as ProposalHistoryRow[]
+  if (proposals.length === 0) return null
+
+  const paidRows = proposals.filter((row) => row.status === 'paid')
+  const currentPacketRows = proposals.filter((row) => row.bundle_name === 'KMB FireSpring Migration Working Packet')
+  const paidToDate = paidRows.reduce((sum, row) => sum + numberFromCurrency(row.total_amount), 0)
+  const currentPacketValue = currentPacketRows.reduce((sum, row) => sum + numberFromCurrency(row.total_amount), 0)
+  const contractValue = paidToDate + currentPacketValue
+  const balanceDue = Math.max(0, contractValue - paidToDate)
+
+  const seenServiceKeys = new Set<string>()
+  const serviceLines: AccountServiceLine[] = []
+
+  for (const row of proposals) {
+    const source: AccountServiceLine['source'] =
+      row.bundle_name === 'KMB FireSpring Migration Working Packet' ? 'current_packet' : 'contract'
+    const lineItems = normalizeLineItems(row.line_items)
+
+    for (const item of lineItems) {
+      const key = `${item.label}:${item.amount}:${source}`
+      if (seenServiceKeys.has(key)) continue
+      seenServiceKeys.add(key)
+      serviceLines.push({
+        id: `${row.id}:${item.label}`,
+        label: item.label,
+        description: item.description,
+        amount: item.amount,
+        status: row.status || 'recorded',
+        source,
+        date: proposalDate(row),
+      })
+    }
+  }
+
+  if (contractValue === 0 && serviceLines.length === 0) return null
+
+  return {
+    contract_value: contractValue,
+    paid_to_date: paidToDate,
+    balance_due: balanceDue,
+    current_packet_value: currentPacketValue,
+    service_lines: serviceLines,
   }
 }
 

--- a/scripts/seed-neil-kmb-client-dashboard.ts
+++ b/scripts/seed-neil-kmb-client-dashboard.ts
@@ -347,7 +347,27 @@ const dashboardTasks = [
 
 const packageRecommendationSeeds = [
   {
+    bundleName: null,
+    service_title: 'Extend Existing Contract',
+    gap_category: 'budget_timeline',
+    gap_description:
+      'Best fit when KMB wants to keep using the existing Website UX Refresh engagement for focused FireSpring proof feedback and launch-readiness support.',
+    projected_impact_pct: 20,
+    projected_annual_value: 1200,
+    impact_headline:
+      'Continue the current contract path instead of starting a separate package.',
+    impact_explanation:
+      'This option keeps the work tied to the paid Website UX Refresh engagement while documenting the additional proof feedback, services rendered, and next support balance.',
+    data_source: 'client_specific',
+    confidence_level: 'high',
+    cta_type: 'view_proposal',
+    cta_url: '#account-summary',
+    content_type: 'contract_option',
+    display_order: 0,
+  },
+  {
     bundleName: 'Community Impact Starter',
+    content_type: 'bundle',
     service_title: 'Community Impact Starter',
     gap_category: 'budget_timeline',
     gap_description:
@@ -361,10 +381,12 @@ const packageRecommendationSeeds = [
     data_source: 'client_specific',
     confidence_level: 'medium',
     cta_type: 'learn_more',
-    display_order: 0,
+    cta_url: null,
+    display_order: 1,
   },
   {
     bundleName: 'Community Impact Accelerator',
+    content_type: 'bundle',
     service_title: 'Community Impact Accelerator',
     gap_category: 'tech_stack',
     gap_description:
@@ -378,10 +400,12 @@ const packageRecommendationSeeds = [
     data_source: 'client_specific',
     confidence_level: 'high',
     cta_type: 'view_proposal',
-    display_order: 1,
+    cta_url: null,
+    display_order: 2,
   },
   {
     bundleName: 'Community Impact Growth',
+    content_type: 'bundle',
     service_title: 'Community Impact Growth',
     gap_category: 'automation_needs',
     gap_description:
@@ -395,7 +419,8 @@ const packageRecommendationSeeds = [
     data_source: 'client_specific',
     confidence_level: 'medium',
     cta_type: 'book_call',
-    display_order: 2,
+    cta_url: null,
+    display_order: 3,
   },
 ] as const
 
@@ -854,27 +879,30 @@ async function refreshDashboardTasks(client: ReturnType<typeof supabase>, projec
 }
 
 async function refreshAccelerationRecommendations(client: ReturnType<typeof supabase>, projectId: string) {
+  const bundleNames = packageRecommendationSeeds.flatMap((recommendation) =>
+    recommendation.bundleName ? [recommendation.bundleName] : []
+  )
   const bundleIds = await resolveBundleIds(
     client,
-    packageRecommendationSeeds.map((recommendation) => recommendation.bundleName)
+    bundleNames
   )
   const recommendationPayload = packageRecommendationSeeds.map((recommendation) => {
-    const { bundleName, ...payload } = recommendation
-    if (!bundleIds.has(bundleName)) {
+    const { bundleName, cta_url, content_type, ...payload } = recommendation
+    if (bundleName && !bundleIds.has(bundleName)) {
       throw new Error(`Missing active offer bundle for KMB package option: ${bundleName}`)
     }
 
     return {
       client_project_id: projectId,
       pain_point_category_id: null,
-      content_type: 'bundle',
+      content_type: content_type || 'bundle',
       content_id: 0,
       benchmark_ids: [],
       value_calculation_id: null,
       is_active: true,
       dismissed_at: null,
       converted_at: null,
-      cta_url: `/pricing#${bundleIds.get(bundleName)?.pricingTierSlug || slugFile(bundleName)}`,
+      cta_url: cta_url || (bundleName ? `/pricing#${bundleIds.get(bundleName)?.pricingTierSlug || slugFile(bundleName)}` : null),
       ...payload,
     }
   })
@@ -885,7 +913,7 @@ async function refreshAccelerationRecommendations(client: ReturnType<typeof supa
     .from('acceleration_recommendations')
     .delete()
     .eq('client_project_id', projectId)
-    .eq('content_type', 'bundle')
+    .in('content_type', ['bundle', 'contract_option'])
     .in('service_title', packageRecommendationSeeds.map((recommendation) => recommendation.service_title))
     .is('dismissed_at', null)
     .is('converted_at', null)


### PR DESCRIPTION
## Summary
- Restore the KMB client dashboard account context with contract value, paid-to-date, balance, contracted services, and services-rendered summaries from proposal/time-entry data.
- Add a compact score breakdown directly under the business assessment radar so each category has score, gap, and interpretation.
- Restore the client-specific Extend Existing Contract package option and route its CTA to the account summary instead of a generic pricing page.

## Validation
- npx vitest run components/client-dashboard/AccelerationCards.test.tsx components/client-dashboard/AssessmentScoreBreakdown.test.tsx components/client-dashboard/AccountSummarySection.test.tsx
- npx tsc --noEmit
- npm run lint (passes with existing img warnings)
- npm run client:seed-neil-kmb:prod:dry-run (packageOptionCount: 4)
- npm run build (passes with existing env-check and img warnings)
- git diff --check

## Integration Notes
- No schema migration required.
- Production KMB seed apply is needed after merge to publish the restored fourth package option.
- Vercel contexts to verify after merge:
- Vercel – portfolio
- Vercel – portfolio-staging
