### PR TITLE
fix: clarify client dashboard contract capacity

### DIFF
--- a/app/client/dashboard/[token]/page.tsx
+++ b/app/client/dashboard/[token]/page.tsx
@@ -22,7 +22,6 @@ import AccelerationCards from '@/components/client-dashboard/AccelerationCards'
 import CampaignProgressSection from '@/components/client-dashboard/CampaignProgressSection'
 import DocumentsSection from '@/components/client-dashboard/DocumentsSection'
 import ReportsSection from '@/components/client-dashboard/ReportsSection'
-import TimeTrackingSection from '@/components/client-dashboard/TimeTrackingSection'
 import AccountSummarySection from '@/components/client-dashboard/AccountSummarySection'
 import MeetingHistory from '@/components/client-dashboard/MeetingHistory'
 import AiOpsRoadmapSection from '@/components/client-dashboard/AiOpsRoadmapSection'
@@ -390,18 +389,15 @@ export default function ClientDashboardPage() {
           <AiOpsRoadmapSection roadmap={aiOpsRoadmap} />
         )}
 
-        {/* Row 5: Documents & Time Investment */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Row 5: Documents and account context */}
+        <div className="grid grid-cols-1 gap-6">
           <DocumentsSection documents={documents || []} />
-          <TimeTrackingSection
-            timeTracking={timeTracking || { total_seconds: 0, by_target: [] }}
-            milestones={(milestones || []) as Array<{ title?: string }>}
-          />
         </div>
 
         <AccountSummarySection
           accountSummary={accountSummary}
           timeTracking={timeTracking || { total_seconds: 0, by_target: [] }}
+          milestones={(milestones || []) as Array<{ title?: string }>}
         />
 
         {buildEvidence && (

--- a/components/client-dashboard/AccountSummarySection.test.tsx
+++ b/components/client-dashboard/AccountSummarySection.test.tsx
@@ -8,6 +8,10 @@ const accountSummary: AccountSummaryData = {
   paid_to_date: 1200,
   balance_due: 0,
   current_packet_value: 0,
+  total_logged_seconds: 23400,
+  services_rendered_value: 1200,
+  remaining_contract_value: 0,
+  effective_hourly_rate: 184.6153846153846,
   service_lines: [
     {
       id: 'proposal-1:Website UX Refresh',
@@ -51,15 +55,20 @@ describe('AccountSummarySection', () => {
       <AccountSummarySection
         accountSummary={accountSummary}
         timeTracking={timeTracking}
+        milestones={[{ title: 'Consolidate Balance proof feedback' }]}
       />
     )
 
     expect(screen.getByRole('heading', { name: /account summary/i })).toBeInTheDocument()
-    expect(screen.getAllByText('$1,200')).toHaveLength(3)
+    expect(screen.getAllByText('$1,200')).toHaveLength(4)
     expect(screen.getByText('No balance due')).toBeInTheDocument()
+    expect(screen.getByText('Contract exhausted')).toBeInTheDocument()
+    expect(screen.getByText('$185/hr')).toBeInTheDocument()
+    expect(screen.getByText(/6h 30m dedicated/i)).toBeInTheDocument()
+    expect(screen.getByText(/2h · \$369/i)).toBeInTheDocument()
     expect(screen.getByText('Included')).toBeInTheDocument()
     expect(screen.getByText('Website UX Refresh')).toBeInTheDocument()
     expect(screen.getByText(/FireSpring proof review/i)).toBeInTheDocument()
-    expect(screen.getByText('6h 30m logged')).toBeInTheDocument()
+    expect(screen.getByText(/contract extension or package option/i)).toBeInTheDocument()
   })
 })

--- a/components/client-dashboard/AccountSummarySection.tsx
+++ b/components/client-dashboard/AccountSummarySection.tsx
@@ -1,11 +1,12 @@
 'use client'
 
-import { Briefcase, CheckCircle2, Clock, Receipt } from 'lucide-react'
+import { Briefcase, CheckCircle2, Clock, Receipt, TrendingUp } from 'lucide-react'
 import type { AccountSummaryData, TimeTrackingData } from '@/lib/client-dashboard'
 
 interface AccountSummarySectionProps {
   accountSummary: AccountSummaryData | null
   timeTracking: TimeTrackingData
+  milestones?: Array<{ title?: string }>
 }
 
 function formatCurrency(value: number): string {
@@ -20,6 +21,16 @@ function formatCurrency(value: number): string {
 function formatBalance(value: number): string {
   if (value === 0) return 'No balance due'
   return formatCurrency(value)
+}
+
+function formatCapacity(value: number): string {
+  if (value === 0) return 'Contract exhausted'
+  return formatCurrency(value)
+}
+
+function formatHourlyRate(value: number | null): string {
+  if (value == null) return 'Not enough time data'
+  return `${formatCurrency(value)}/hr`
 }
 
 function formatHours(seconds: number): string {
@@ -38,15 +49,39 @@ function formatDate(value: string | null): string | null {
   return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
 }
 
+function finiteNumber(value: number | null | undefined): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
 export default function AccountSummarySection({
   accountSummary,
   timeTracking,
+  milestones = [],
 }: AccountSummarySectionProps) {
   if (!accountSummary && (!timeTracking || timeTracking.total_seconds === 0)) return null
 
+  const totalSeconds = timeTracking?.total_seconds || 0
+  const totalHours = totalSeconds / 3600
+  const contractValue = accountSummary?.contract_value ?? 0
+  const effectiveHourlyRate =
+    finiteNumber(accountSummary?.effective_hourly_rate) ??
+    (contractValue > 0 && totalHours > 0 ? contractValue / totalHours : null)
+  const servicesRenderedValue =
+    finiteNumber(accountSummary?.services_rendered_value) ??
+    (effectiveHourlyRate == null ? 0 : Math.min(contractValue, effectiveHourlyRate * totalHours))
+  const remainingContractValue =
+    finiteNumber(accountSummary?.remaining_contract_value) ??
+    Math.max(0, contractValue - servicesRenderedValue)
+  const milestoneEntries = (timeTracking?.by_target || [])
+    .filter((entry) => entry.target_type === 'milestone')
+    .sort((a, b) => Number(a.target_id) - Number(b.target_id))
   const serviceDescriptions = (timeTracking?.by_target || [])
     .flatMap((entry) => entry.descriptions || [])
     .filter(Boolean)
+  const nextGuidance =
+    accountSummary && remainingContractValue === 0
+      ? 'The paid contract value is fully allocated to work delivered so far. The next gap-closing work should be scoped as a contract extension or package option.'
+      : 'Use the remaining contract capacity before opening a separate package, then scope any new gap-closing work as an extension.'
 
   return (
     <section id="account-summary" className="rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-5">
@@ -57,19 +92,19 @@ export default function AccountSummarySection({
             Account Summary
           </h3>
           <p className="mt-1 text-xs text-platinum-white/55">
-            Contract value, paid balance, and services rendered to date.
+            Paid value, dedicated hours, service value, and remaining contract capacity.
           </p>
         </div>
-        {timeTracking?.total_seconds > 0 && (
+        {totalSeconds > 0 && (
           <div className="inline-flex items-center gap-1.5 rounded-md border border-radiant-gold/15 bg-imperial-navy/45 px-2.5 py-1 text-xs text-platinum-white/72">
             <Clock className="h-3.5 w-3.5 text-radiant-gold" />
-            {formatHours(timeTracking.total_seconds)} logged
+            {formatHours(totalSeconds)} dedicated
           </div>
         )}
       </div>
 
       {accountSummary && (
-        <div className="mb-4 grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <div className="mb-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
           <div className="rounded-lg border border-radiant-gold/10 bg-imperial-navy/35 p-3">
             <p className="text-[10px] uppercase tracking-[0.16em] text-platinum-white/42">Contract value</p>
             <p className="mt-1 text-lg font-semibold text-platinum-white">
@@ -83,10 +118,74 @@ export default function AccountSummarySection({
             </p>
           </div>
           <div className="rounded-lg border border-radiant-gold/10 bg-imperial-navy/35 p-3">
-            <p className="text-[10px] uppercase tracking-[0.16em] text-platinum-white/42">Balance</p>
+            <p className="text-[10px] uppercase tracking-[0.16em] text-platinum-white/42">Services rendered</p>
             <p className="mt-1 text-lg font-semibold text-platinum-white">
+              {formatCurrency(servicesRenderedValue)}
+            </p>
+          </div>
+          <div className="rounded-lg border border-radiant-gold/10 bg-imperial-navy/35 p-3">
+            <p className="text-[10px] uppercase tracking-[0.16em] text-platinum-white/42">Remaining capacity</p>
+            <p className="mt-1 text-lg font-semibold text-platinum-white">
+              {formatCapacity(remainingContractValue)}
+            </p>
+          </div>
+        </div>
+      )}
+
+      {accountSummary && (
+        <div className="mb-4 grid grid-cols-1 gap-3 lg:grid-cols-[1fr_1fr_1.4fr]">
+          <div className="rounded-lg border border-radiant-gold/10 bg-imperial-navy/30 p-3">
+            <p className="text-[10px] uppercase tracking-[0.16em] text-platinum-white/42">Effective rate</p>
+            <p className="mt-1 text-sm font-semibold text-platinum-white">
+              {formatHourlyRate(effectiveHourlyRate)}
+            </p>
+          </div>
+          <div className="rounded-lg border border-radiant-gold/10 bg-imperial-navy/30 p-3">
+            <p className="text-[10px] uppercase tracking-[0.16em] text-platinum-white/42">Client balance due</p>
+            <p className="mt-1 text-sm font-semibold text-platinum-white">
               {formatBalance(accountSummary.balance_due)}
             </p>
+          </div>
+          <div className="rounded-lg border border-radiant-gold/10 bg-imperial-navy/30 p-3">
+            <p className="text-[10px] uppercase tracking-[0.16em] text-radiant-gold/85">What this means</p>
+            <p className="mt-1 text-xs leading-5 text-platinum-white/68">{nextGuidance}</p>
+          </div>
+        </div>
+      )}
+
+      {milestoneEntries.length > 0 && (
+        <div className="mb-4 rounded-lg border border-radiant-gold/10 bg-imperial-navy/30 p-3">
+          <div className="mb-3 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+            <p className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.14em] text-platinum-white/50">
+              <TrendingUp className="h-3.5 w-3.5 text-radiant-gold/80" />
+              Time investment by milestone
+            </p>
+            <p className="text-xs text-platinum-white/55">
+              {formatHours(totalSeconds)} at {formatHourlyRate(effectiveHourlyRate)}
+            </p>
+          </div>
+          <div className="space-y-3">
+            {milestoneEntries.map((entry) => {
+              const idx = Number(entry.target_id)
+              const title = milestones[idx]?.title || `Milestone ${idx + 1}`
+              const pct = totalSeconds > 0 ? Math.round((entry.total_seconds / totalSeconds) * 100) : 0
+              const dollarValue =
+                effectiveHourlyRate == null ? null : (entry.total_seconds / 3600) * effectiveHourlyRate
+              return (
+                <div key={entry.target_id}>
+                  <div className="mb-1 flex items-center justify-between gap-3">
+                    <span className="min-w-0 truncate text-xs text-platinum-white/78">{title}</span>
+                    <span className="shrink-0 text-xs text-platinum-white/55">
+                      {formatHours(entry.total_seconds)}
+                      {dollarValue != null ? ` · ${formatCurrency(dollarValue)}` : ''}
+                    </span>
+                  </div>
+                  <div className="h-1.5 overflow-hidden rounded-full bg-imperial-navy/70">
+                    <div className="h-full rounded-full bg-radiant-gold/75" style={{ width: `${pct}%` }} />
+                  </div>
+                </div>
+              )
+            })}
           </div>
         </div>
       )}

--- a/lib/client-dashboard.ts
+++ b/lib/client-dashboard.ts
@@ -159,6 +159,10 @@ export interface AccountSummaryData {
   paid_to_date: number
   balance_due: number
   current_packet_value: number
+  total_logged_seconds: number
+  services_rendered_value: number
+  remaining_contract_value: number
+  effective_hourly_rate: number | null
   service_lines: AccountServiceLine[]
 }
 
@@ -598,7 +602,7 @@ export async function getDashboardByToken(
     // Time entries (completed only — no running timers for client view)
     supabaseAdmin
       .from('time_entries')
-      .select('target_type, target_id, duration_seconds')
+      .select('target_type, target_id, duration_seconds, description')
       .eq('client_project_id', projectId)
       .eq('is_running', false)
       .not('duration_seconds', 'is', null),
@@ -825,7 +829,7 @@ export async function getDashboardByToken(
 
   const valueReports = (allValueReportsResult.data || []) as ClientValueReport[]
   const gammaReports = (allGammaReportsResult.data || []) as ClientGammaReport[]
-  const accountSummary = buildAccountSummary(allClientProposalsResult.data || [])
+  const accountSummary = buildAccountSummary(allClientProposalsResult.data || [], timeTracking)
   const aiOpsRoadmap = await getRoadmapBundleForProject(projectId).then((bundle) => bundle?.clientView ?? null).catch(() => null)
   const buildEvidence = buildEvidenceResult ?? null
 
@@ -903,7 +907,7 @@ function normalizeLineItems(value: unknown): Array<{ label: string; description:
     .filter((item): item is { label: string; description: string | null; amount: number } => Boolean(item))
 }
 
-function buildAccountSummary(rows: unknown[]): AccountSummaryData | null {
+function buildAccountSummary(rows: unknown[], timeTracking: TimeTrackingData): AccountSummaryData | null {
   const proposals = rows as ProposalHistoryRow[]
   if (proposals.length === 0) return null
 
@@ -913,6 +917,12 @@ function buildAccountSummary(rows: unknown[]): AccountSummaryData | null {
   const currentPacketValue = currentPacketRows.reduce((sum, row) => sum + numberFromCurrency(row.total_amount), 0)
   const contractValue = paidToDate + currentPacketValue
   const balanceDue = Math.max(0, contractValue - paidToDate)
+  const totalLoggedHours = timeTracking.total_seconds / 3600
+  const effectiveHourlyRate =
+    contractValue > 0 && totalLoggedHours > 0 ? contractValue / totalLoggedHours : null
+  const servicesRenderedValue =
+    effectiveHourlyRate == null ? 0 : Math.min(contractValue, effectiveHourlyRate * totalLoggedHours)
+  const remainingContractValue = Math.max(0, contractValue - servicesRenderedValue)
 
   const seenServiceKeys = new Set<string>()
   const serviceLines: AccountServiceLine[] = []
@@ -945,6 +955,10 @@ function buildAccountSummary(rows: unknown[]): AccountSummaryData | null {
     paid_to_date: paidToDate,
     balance_due: balanceDue,
     current_packet_value: currentPacketValue,
+    total_logged_seconds: timeTracking.total_seconds,
+    services_rendered_value: servicesRenderedValue,
+    remaining_contract_value: remainingContractValue,
+    effective_hourly_rate: effectiveHourlyRate,
     service_lines: serviceLines,
   }
 }


### PR DESCRIPTION
## Summary
- Combines the client dashboard time investment and account summary into one account context block.
- Adds effective hourly rate, services rendered value, remaining contract capacity, and client balance due.
- Selects time-entry descriptions so services rendered can show the actual work performed.
- Keeps safe UI fallbacks for old API payloads during deployment transitions.

## Validation
- npx vitest run components/client-dashboard/AccountSummarySection.test.tsx components/client-dashboard/AccelerationCards.test.tsx components/client-dashboard/AssessmentScoreBreakdown.test.tsx
- npx tsc --noEmit
- npm run lint
- npm run build
- git diff --check
- Local production Playwright smoke using the production dashboard API payload as a fixture; checked desktop and mobile account summary with no horizontal overflow.

## Integration Notes
- No migrations or env changes.
- No production data mutation.
- Vercel contexts still need post-merge verification:
  - Vercel – portfolio
  - Vercel – portfolio-staging