### PR TITLE
fix: clarify client dashboard decision flow

### DIFF
--- a/app/client/dashboard/[token]/page.tsx
+++ b/app/client/dashboard/[token]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback, useRef } from 'react'
 import { useParams } from 'next/navigation'
-import { Check, Copy, Loader2 } from 'lucide-react'
+import { ArrowRight, Check, Copy, Loader2 } from 'lucide-react'
 import DashboardStatCards from '@/components/client-dashboard/DashboardStatCards'
 import ExecutiveSummary, {
   ActionFocusCommentary,
@@ -328,39 +328,37 @@ export default function ClientDashboardPage() {
           recommendedActions={assessment?.recommended_actions || null}
         />
 
-        {/* Row 2: Radar + Trajectory */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-          <div className="space-y-3">
-            <div className="grid gap-3 xl:grid-cols-[minmax(220px,0.75fr)_minmax(0,1.25fr)] xl:items-stretch">
-              <AssessmentScoresCommentary categoryScores={scores.categoryScores} />
-              <ScoreRadarChart scores={scores.categoryScores} />
-            </div>
-            <AssessmentScoreBreakdown
-              scores={scores.categoryScores}
-              hasFormalAssessment={Boolean(assessment)}
-              formalAssessmentHref="/tools/audit"
-            />
+        {/* Row 2: Business Assessment Scores */}
+        <div className="space-y-3">
+          <div className="grid gap-4 lg:grid-cols-[minmax(280px,0.36fr)_minmax(0,1fr)] lg:items-stretch">
+            <AssessmentScoresCommentary categoryScores={scores.categoryScores} />
+            <ScoreRadarChart scores={scores.categoryScores} />
           </div>
-          <div className="space-y-3">
-            <div className="grid gap-3 xl:grid-cols-[minmax(220px,0.75fr)_minmax(0,1.25fr)] xl:items-stretch">
-              <TrajectoryCommentary
-                scoreDelta={scores.delta}
-                snapshotsCount={snapshots.length}
-              />
-              {snapshots.length > 0 ? (
-                <TrajectoryChart token={token} />
-              ) : (
-                <div className="rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-5">
-                  <h3 className="mb-2 text-sm font-medium uppercase tracking-wider text-radiant-gold">
-                    Score Trajectory
-                  </h3>
-                  <p className="text-sm text-platinum-white/55">
-                    Score trajectory will appear once milestone-based projections are available.
-                  </p>
-                </div>
-              )}
+          <AssessmentScoreBreakdown
+            scores={scores.categoryScores}
+            hasFormalAssessment={Boolean(assessment)}
+            formalAssessmentHref="/tools/audit"
+          />
+        </div>
+
+        {/* Row 3: Score Trajectory */}
+        <div className="grid gap-4 lg:grid-cols-[minmax(280px,0.36fr)_minmax(0,1fr)] lg:items-stretch">
+          <TrajectoryCommentary
+            scoreDelta={scores.delta}
+            snapshotsCount={snapshots.length}
+          />
+          {snapshots.length > 0 ? (
+            <TrajectoryChart token={token} />
+          ) : (
+            <div className="rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-5">
+              <h3 className="mb-2 text-sm font-medium uppercase tracking-wider text-radiant-gold">
+                Score Trajectory
+              </h3>
+              <p className="text-sm text-platinum-white/55">
+                Score trajectory will appear once milestone-based projections are available.
+              </p>
             </div>
-          </div>
+          )}
         </div>
 
         <AccountSummarySection
@@ -370,17 +368,17 @@ export default function ClientDashboardPage() {
           documents={documents || []}
         />
 
-        {/* Row 3: Gap Analysis */}
+        {/* Row 4: Gap Analysis */}
         <GapAnalysisPanel gaps={gapAnalysis} />
 
-        {/* Row 4: Acceleration Opportunities */}
+        {/* Row 5: Acceleration Opportunities */}
         <AccelerationCards
           recommendations={recommendations}
           token={token}
           onDismiss={handleDismissRec}
         />
 
-        {/* Row 5: Assessment */}
+        {/* Row 6: Assessment */}
         <div className="grid grid-cols-1 gap-6">
           <div>
             {assessment ? (
@@ -395,14 +393,21 @@ export default function ClientDashboardPage() {
                   Assessment
                 </h3>
                 <p className="text-platinum-white/55 text-sm">
-                  No assessment data available yet.
+                  No formal assessment data is available yet. Use the assessment to replace projected scores with client-entered answers.
                 </p>
+                <a
+                  href="/tools/audit"
+                  className="mt-4 inline-flex items-center justify-center gap-2 rounded-lg border border-radiant-gold/25 bg-radiant-gold/12 px-4 py-2 text-sm font-medium text-gold-light transition-colors hover:bg-radiant-gold/20"
+                >
+                  Complete assessment
+                  <ArrowRight className="h-3.5 w-3.5" />
+                </a>
               </div>
             )}
           </div>
         </div>
 
-        {/* Row 6: Reports & Presentations (only when reports exist) */}
+        {/* Row 7: Reports & Presentations (only when reports exist) */}
         {((valueReports && valueReports.length > 0) || (gammaReports && gammaReports.length > 0)) && (
           <ReportsSection
             valueReports={valueReports || []}
@@ -414,7 +419,7 @@ export default function ClientDashboardPage() {
           <AiOpsRoadmapSection roadmap={aiOpsRoadmap} />
         )}
 
-        {/* Row 7: Documents and resources */}
+        {/* Row 8: Documents and resources */}
         <div className="grid grid-cols-1 gap-6">
           <DocumentsSection documents={documents || []} />
         </div>

--- a/components/client-dashboard/AccelerationCards.test.tsx
+++ b/components/client-dashboard/AccelerationCards.test.tsx
@@ -51,8 +51,41 @@ describe('AccelerationCards', () => {
     expect(screen.getByRole('heading', { name: 'Package Options' })).toBeInTheDocument()
     expect(screen.getByText('Community Impact Accelerator')).toBeInTheDocument()
     expect(screen.getByText(/assessment gaps, task list/i)).toBeInTheDocument()
+    expect(screen.getByText('Recommended next phase')).toBeInTheDocument()
+    expect(screen.getByText('Why this fits')).toBeInTheDocument()
+    expect(screen.getByText('Confidence basis')).toBeInTheDocument()
     expect(screen.getByText('$1,997')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /view proposal/i })).toBeInTheDocument()
+  })
+
+  it('ranks package options by confidence before display order', () => {
+    render(
+      <AccelerationCards
+        recommendations={[
+          {
+            ...recommendation,
+            id: 'rec-medium',
+            service_title: 'Community Impact Growth',
+            confidence_level: 'medium',
+            display_order: 0,
+          },
+          {
+            ...recommendation,
+            id: 'rec-high',
+            service_title: 'Extend Existing Contract',
+            content_type: 'contract_option',
+            confidence_level: 'high',
+            display_order: 2,
+          },
+        ]}
+        token="dashboard-token"
+        onDismiss={vi.fn()}
+      />
+    )
+
+    const recommendedBlock = screen.getByText('Recommended next phase').closest('div')
+    expect(recommendedBlock).toHaveTextContent('Extend Existing Contract')
+    expect(screen.getByText('Other paths, ranked by confidence')).toBeInTheDocument()
   })
 
   it('does not render a stray zero for free package options', () => {

--- a/components/client-dashboard/AccelerationCards.tsx
+++ b/components/client-dashboard/AccelerationCards.tsx
@@ -37,9 +37,54 @@ const CTA_LABELS: Record<string, string> = {
   start_trial: 'Start Trial',
 }
 
+const CONFIDENCE_RANK: Record<string, number> = {
+  high: 0,
+  medium: 1,
+  low: 2,
+}
+
 function getCtaLabel(rec: AccelerationRecommendation): string {
   if (rec.content_type === 'contract_option') return 'View Account'
   return CTA_LABELS[rec.cta_type] || 'Learn More'
+}
+
+function getGoalFit(rec: AccelerationRecommendation): string {
+  if (rec.content_type === 'contract_option') {
+    return 'Best if the priority is continuing the current work without opening a separate package decision.'
+  }
+
+  const category = rec.gap_category.replace(/_/g, ' ').toLowerCase()
+  if (category.includes('tech')) {
+    return 'Best if the priority is making the FireSpring launch path cleaner and easier to hand off.'
+  }
+  if (category.includes('automation')) {
+    return 'Best if the priority is reducing manual routing across supporter, donor, sponsor, and program workflows.'
+  }
+  if (category.includes('budget')) {
+    return 'Best if the priority is protecting scope, budget, and decision timing before more work begins.'
+  }
+  if (category.includes('ai')) {
+    return 'Best if the priority is turning project knowledge into reusable operating assets after launch decisions settle.'
+  }
+  return 'Best if the priority is closing the highest visible gap from the current assessment pattern.'
+}
+
+function confidenceReason(rec: AccelerationRecommendation): string {
+  const confidence = CONFIDENCE_STYLES[rec.confidence_level] || CONFIDENCE_STYLES.low
+  const source = DATA_SOURCE_LABELS[rec.data_source] || 'Estimated'
+  return `${confidence.label}; ${source.toLowerCase()}.`
+}
+
+function sortedRecommendations(recommendations: AccelerationRecommendation[]) {
+  return [...recommendations].sort((a, b) => {
+    const confidenceDelta =
+      (CONFIDENCE_RANK[a.confidence_level] ?? CONFIDENCE_RANK.low) -
+      (CONFIDENCE_RANK[b.confidence_level] ?? CONFIDENCE_RANK.low)
+    if (confidenceDelta !== 0) return confidenceDelta
+    const impactDelta = Number(b.projected_impact_pct || 0) - Number(a.projected_impact_pct || 0)
+    if (impactDelta !== 0) return impactDelta
+    return a.display_order - b.display_order
+  })
 }
 
 export default function AccelerationCards({
@@ -91,6 +136,120 @@ export default function AccelerationCards({
     }
   }
 
+  const orderedRecommendations = sortedRecommendations(recommendations)
+  const recommended = orderedRecommendations[0]
+  const alternatives = orderedRecommendations.slice(1)
+
+  const renderRecommendation = (rec: AccelerationRecommendation, featured = false) => {
+    const confidence = CONFIDENCE_STYLES[rec.confidence_level] || CONFIDENCE_STYLES.low
+    const isDismissing = dismissing === rec.id
+    const projectedAnnualValue = Number(rec.projected_annual_value || 0)
+    const projectedImpactPct = Number(rec.projected_impact_pct || 0)
+    const isContractOption = rec.content_type === 'contract_option'
+
+    return (
+      <div
+        key={rec.id}
+        className={`rounded-xl border p-4 transition-opacity ${
+          featured
+            ? 'border-radiant-gold/35 bg-radiant-gold/10'
+            : 'border-radiant-gold/15 bg-imperial-navy/45'
+        } ${isDismissing ? 'opacity-50' : ''}`}
+      >
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+          <div className="min-w-0 flex-1">
+            <div className="mb-2 flex items-start justify-between gap-3">
+              <div className="flex min-w-0 items-center gap-2">
+                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-radiant-gold/20 bg-radiant-gold/10">
+                  <TrendingUp className="h-4 w-4 text-radiant-gold" />
+                </div>
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium text-platinum-white/90">{rec.service_title}</p>
+                  <p className="text-[10px] uppercase tracking-[0.14em] text-platinum-white/42">
+                    {rec.gap_category.replace(/_/g, ' ')}
+                  </p>
+                </div>
+              </div>
+              <button
+                onClick={() => handleDismiss(rec.id)}
+                disabled={isDismissing}
+                className="shrink-0 p-1 text-platinum-white/35 hover:text-platinum-white/70"
+                title="Dismiss"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </div>
+
+            {rec.impact_headline && (
+              <p className="mb-3 text-xs leading-relaxed text-platinum-white/72">
+                {rec.impact_headline}
+              </p>
+            )}
+
+            <div className="grid gap-2 md:grid-cols-2">
+              <div className="rounded-lg border border-radiant-gold/10 bg-imperial-navy/45 p-2.5">
+                <p className="mb-1 text-[10px] uppercase tracking-[0.14em] text-radiant-gold/75">
+                  Why this fits
+                </p>
+                <p className="text-xs leading-5 text-platinum-white/68">{getGoalFit(rec)}</p>
+              </div>
+              <div className="rounded-lg border border-radiant-gold/10 bg-imperial-navy/45 p-2.5">
+                <p className="mb-1 text-[10px] uppercase tracking-[0.14em] text-radiant-gold/75">
+                  Confidence basis
+                </p>
+                <p className="text-xs leading-5 text-platinum-white/68">{confidenceReason(rec)}</p>
+              </div>
+            </div>
+          </div>
+
+          <div className="w-full shrink-0 space-y-3 lg:w-64">
+            {projectedAnnualValue > 0 && (
+              <div className="rounded-lg border border-radiant-gold/10 bg-imperial-navy/55 p-2.5">
+                <div className="flex items-center gap-2">
+                  <BarChart className="h-4 w-4 text-gold-light" />
+                  <span className="text-lg font-bold text-gold-light">
+                    {new Intl.NumberFormat('en-US', {
+                      style: 'currency',
+                      currency: 'USD',
+                      maximumFractionDigits: 0,
+                    }).format(projectedAnnualValue)}
+                    <span className="text-xs font-normal text-platinum-white/42">
+                      {' '}{isContractOption ? 'contract' : 'package'}
+                    </span>
+                  </span>
+                </div>
+                {projectedImpactPct > 0 && (
+                  <p className="mt-0.5 text-[10px] text-platinum-white/45">
+                    +{projectedImpactPct}% improvement
+                  </p>
+                )}
+              </div>
+            )}
+
+            <div className="flex flex-wrap items-center gap-2">
+              <span className={`rounded px-1.5 py-0.5 text-[10px] ${confidence.bg} ${confidence.text}`}>
+                <Shield className="mr-0.5 inline h-2.5 w-2.5" />
+                {confidence.label}
+              </span>
+              <span className="inline-flex items-center gap-1 text-[10px] text-platinum-white/42">
+                <Info className="h-3 w-3 text-platinum-white/35" />
+                {DATA_SOURCE_LABELS[rec.data_source] || 'Estimated'}
+              </span>
+            </div>
+
+            <button
+              onClick={() => handleConvert(rec.id)}
+              className="flex w-full items-center justify-center gap-2 rounded-lg border border-radiant-gold/25 bg-radiant-gold/12 px-3 py-2 text-sm font-medium text-gold-light transition-colors hover:bg-radiant-gold/20"
+            >
+              {getCtaLabel(rec)}
+              <ArrowRight className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <section className="rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-5">
       <div className="flex items-center gap-2 mb-4">
@@ -103,100 +262,24 @@ export default function AccelerationCards({
         Tailored acceleration paths that connect the assessment gaps, task list, and available AmaduTown packages.
       </p>
 
-      <div className="flex gap-4 overflow-x-auto pb-2 -mx-1 px-1 snap-x">
-        {recommendations.map((rec) => {
-          const confidence = CONFIDENCE_STYLES[rec.confidence_level] || CONFIDENCE_STYLES.low
-          const isDismissing = dismissing === rec.id
-          const projectedAnnualValue = Number(rec.projected_annual_value || 0)
-          const projectedImpactPct = Number(rec.projected_impact_pct || 0)
-          const isContractOption = rec.content_type === 'contract_option'
+      <div className="space-y-4">
+        <div>
+          <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-radiant-gold/80">
+            Recommended next phase
+          </p>
+          {renderRecommendation(recommended, true)}
+        </div>
 
-          return (
-            <div
-              key={rec.id}
-              className={`flex-shrink-0 w-[280px] md:w-[320px] rounded-xl border border-radiant-gold/15 bg-imperial-navy/45 p-4 snap-start transition-opacity ${
-                isDismissing ? 'opacity-50' : ''
-              }`}
-            >
-              {/* Header */}
-              <div className="flex items-start justify-between mb-3">
-                <div className="flex items-center gap-2">
-                  <div className="w-8 h-8 rounded-lg bg-radiant-gold/10 border border-radiant-gold/20 flex items-center justify-center">
-                    <TrendingUp className="w-4 h-4 text-radiant-gold" />
-                  </div>
-                  <div>
-                    <p className="text-sm font-medium text-platinum-white/90">{rec.service_title}</p>
-                    <p className="text-[10px] uppercase tracking-[0.14em] text-platinum-white/42">
-                      {rec.gap_category.replace(/_/g, ' ')}
-                    </p>
-                  </div>
-                </div>
-                <button
-                  onClick={() => handleDismiss(rec.id)}
-                  disabled={isDismissing}
-                  className="text-platinum-white/35 hover:text-platinum-white/70 p-1"
-                  title="Dismiss"
-                >
-                  <X className="w-3.5 h-3.5" />
-                </button>
-              </div>
-
-              {/* Impact Headline */}
-              {rec.impact_headline && (
-                <p className="text-xs text-platinum-white/72 mb-3 leading-relaxed">
-                  {rec.impact_headline}
-                </p>
-              )}
-
-              {/* Projected Value */}
-              {projectedAnnualValue > 0 && (
-                <div className="bg-imperial-navy/55 rounded-lg border border-radiant-gold/10 p-2.5 mb-3">
-                  <div className="flex items-center gap-2">
-                    <BarChart className="w-4 h-4 text-gold-light" />
-                    <span className="text-lg font-bold text-gold-light">
-                      {new Intl.NumberFormat('en-US', {
-                        style: 'currency',
-                        currency: 'USD',
-                        maximumFractionDigits: 0,
-                      }).format(projectedAnnualValue)}
-                      <span className="text-xs font-normal text-platinum-white/42">
-                        {' '}{isContractOption ? 'contract' : 'package'}
-                      </span>
-                    </span>
-                  </div>
-                  {projectedImpactPct > 0 && (
-                    <p className="text-[10px] text-platinum-white/45 mt-0.5">
-                      +{projectedImpactPct}% improvement
-                    </p>
-                  )}
-                </div>
-              )}
-
-              {/* Confidence + Data Source */}
-              <div className="flex items-center gap-2 mb-3">
-                <span className={`text-[10px] px-1.5 py-0.5 rounded ${confidence.bg} ${confidence.text}`}>
-                  <Shield className="w-2.5 h-2.5 inline mr-0.5" />
-                  {confidence.label}
-                </span>
-              </div>
-              <div className="flex items-center gap-1 mb-4">
-                <Info className="w-3 h-3 text-platinum-white/35" />
-                <span className="text-[10px] text-platinum-white/42">
-                  {DATA_SOURCE_LABELS[rec.data_source] || 'Estimated'}
-                </span>
-              </div>
-
-              {/* CTA */}
-              <button
-                onClick={() => handleConvert(rec.id)}
-                className="w-full flex items-center justify-center gap-2 rounded-lg border border-radiant-gold/25 bg-radiant-gold/12 px-3 py-2 text-sm font-medium text-gold-light transition-colors hover:bg-radiant-gold/20"
-              >
-                {getCtaLabel(rec)}
-                <ArrowRight className="w-3.5 h-3.5" />
-              </button>
+        {alternatives.length > 0 && (
+          <div>
+            <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-platinum-white/45">
+              Other paths, ranked by confidence
+            </p>
+            <div className="space-y-3">
+              {alternatives.map((rec) => renderRecommendation(rec))}
             </div>
-          )
-        })}
+          </div>
+        )}
       </div>
     </section>
   )

--- a/components/client-dashboard/AccountSummarySection.test.tsx
+++ b/components/client-dashboard/AccountSummarySection.test.tsx
@@ -62,7 +62,7 @@ const documents: DashboardDocument[] = [
 ]
 
 describe('AccountSummarySection', () => {
-  it('summarizes contract value, paid balance, and services rendered', () => {
+  it('summarizes paid value, time investment, remaining balance, and source detail', () => {
     render(
       <AccountSummarySection
         accountSummary={accountSummary}
@@ -85,12 +85,15 @@ describe('AccountSummarySection', () => {
     )
 
     expect(screen.getByRole('heading', { name: /account summary/i })).toBeInTheDocument()
-    expect(screen.getAllByText('$1,200')).toHaveLength(4)
-    expect(screen.getByText('No balance due')).toBeInTheDocument()
+    expect(screen.getByText('Time investment value')).toBeInTheDocument()
+    expect(screen.getByText('Paid balance remaining')).toBeInTheDocument()
+    expect(screen.getAllByText('No balance due')).toHaveLength(2)
     expect(screen.getByText('Contract exhausted')).toBeInTheDocument()
     expect(screen.getByText('$185/hr')).toBeInTheDocument()
     expect(screen.getByText(/6h 30m dedicated/i)).toBeInTheDocument()
     expect(screen.getByText(/2h · \$369/i)).toBeInTheDocument()
+    expect(screen.getByText('Total time investment')).toBeInTheDocument()
+    expect(screen.getByText(/\$1,200 paid - \$1,200 applied = No balance due/i)).toBeInTheDocument()
     expect(screen.getByText('Work performed')).toBeInTheDocument()
     expect(screen.getByText('KMB Drive package')).toBeInTheDocument()
     expect(screen.getByText('Firespring Template Comparison for KMB')).toBeInTheDocument()

--- a/components/client-dashboard/AccountSummarySection.tsx
+++ b/components/client-dashboard/AccountSummarySection.tsx
@@ -114,13 +114,15 @@ export default function AccountSummarySection({
   const remainingContractValue =
     finiteNumber(accountSummary?.remaining_contract_value) ??
     Math.max(0, contractValue - servicesRenderedValue)
+  const paidToDate = accountSummary?.paid_to_date ?? 0
+  const paidBalanceRemaining = Math.max(0, paidToDate - servicesRenderedValue)
   const milestoneEntries = (timeTracking?.by_target || [])
     .filter((entry) => entry.target_type === 'milestone')
     .sort((a, b) => Number(a.target_id) - Number(b.target_id))
   const nextGuidance =
-    accountSummary && remainingContractValue === 0
-      ? 'The paid contract value is fully allocated to work delivered so far. The next gap-closing work should be scoped as a contract extension or package option.'
-      : 'Use the remaining contract capacity before opening a separate package, then scope any new gap-closing work as an extension.'
+    accountSummary && paidBalanceRemaining === 0
+      ? 'Paid value has been fully allocated to delivered work. The next gap-closing work should be scoped as a contract extension or package option.'
+      : 'Use the remaining paid balance before opening a separate package, then scope any new gap-closing work as an extension.'
 
   return (
     <section id="account-summary" className="rounded-lg border border-radiant-gold/15 bg-silicon-slate/35 p-5">
@@ -131,7 +133,7 @@ export default function AccountSummarySection({
             Account Summary
           </h3>
           <p className="mt-1 text-xs text-platinum-white/55">
-            Paid value, dedicated hours, service value, and remaining contract capacity.
+            Paid value, dedicated hours, applied service value, and remaining paid balance.
           </p>
         </div>
         {totalSeconds > 0 && (
@@ -153,30 +155,36 @@ export default function AccountSummarySection({
           <div className="rounded-lg border border-radiant-gold/10 bg-imperial-navy/35 p-3">
             <p className="text-[10px] uppercase tracking-[0.16em] text-platinum-white/42">Paid to date</p>
             <p className="mt-1 text-lg font-semibold text-platinum-white">
-              {formatCurrency(accountSummary.paid_to_date)}
+              {formatCurrency(paidToDate)}
             </p>
           </div>
           <div className="rounded-lg border border-radiant-gold/10 bg-imperial-navy/35 p-3">
-            <p className="text-[10px] uppercase tracking-[0.16em] text-platinum-white/42">Services rendered</p>
+            <p className="text-[10px] uppercase tracking-[0.16em] text-platinum-white/42">Time investment value</p>
             <p className="mt-1 text-lg font-semibold text-platinum-white">
               {formatCurrency(servicesRenderedValue)}
             </p>
           </div>
           <div className="rounded-lg border border-radiant-gold/10 bg-imperial-navy/35 p-3">
-            <p className="text-[10px] uppercase tracking-[0.16em] text-platinum-white/42">Remaining capacity</p>
+            <p className="text-[10px] uppercase tracking-[0.16em] text-platinum-white/42">Paid balance remaining</p>
             <p className="mt-1 text-lg font-semibold text-platinum-white">
-              {formatCapacity(remainingContractValue)}
+              {formatBalance(paidBalanceRemaining)}
             </p>
           </div>
         </div>
       )}
 
       {accountSummary && (
-        <div className="mb-4 grid grid-cols-1 gap-3 lg:grid-cols-[1fr_1fr_1.4fr]">
+        <div className="mb-4 grid grid-cols-1 gap-3 lg:grid-cols-[1fr_1fr_1fr_1.4fr]">
           <div className="rounded-lg border border-radiant-gold/10 bg-imperial-navy/30 p-3">
             <p className="text-[10px] uppercase tracking-[0.16em] text-platinum-white/42">Effective rate</p>
             <p className="mt-1 text-sm font-semibold text-platinum-white">
               {formatHourlyRate(effectiveHourlyRate)}
+            </p>
+          </div>
+          <div className="rounded-lg border border-radiant-gold/10 bg-imperial-navy/30 p-3">
+            <p className="text-[10px] uppercase tracking-[0.16em] text-platinum-white/42">Contract capacity</p>
+            <p className="mt-1 text-sm font-semibold text-platinum-white">
+              {formatCapacity(remainingContractValue)}
             </p>
           </div>
           <div className="rounded-lg border border-radiant-gold/10 bg-imperial-navy/30 p-3">
@@ -287,6 +295,26 @@ export default function AccountSummarySection({
                 </div>
               )
             })}
+          </div>
+          <div className="mt-3 rounded-lg border border-radiant-gold/20 bg-radiant-gold/10 p-3">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-radiant-gold/85">
+                  Total time investment
+                </p>
+                <p className="mt-1 text-sm text-platinum-white/70">
+                  {formatHours(totalSeconds)} at {formatHourlyRate(effectiveHourlyRate)}
+                </p>
+              </div>
+              <div className="text-left sm:text-right">
+                <p className="text-lg font-semibold text-platinum-white">
+                  {formatCurrency(servicesRenderedValue)}
+                </p>
+                <p className="text-xs text-platinum-white/58">
+                  {formatCurrency(paidToDate)} paid - {formatCurrency(servicesRenderedValue)} applied = {formatBalance(paidBalanceRemaining)}
+                </p>
+              </div>
+            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- Split the dashboard chart area into one full-width radar row and one full-width trajectory row so the visuals are no longer squeezed into four columns.
- Keep the score breakdown full-width under the radar, with the existing formal-assessment CTA intact.
- Rework Account Summary so paid-to-date minus time-investment value is explicit, with a total time-investment roll-up at the bottom of the milestone breakdown.
- Replace the horizontal package scroller with a ranked vertical recommendation flow: recommended next phase first, then other paths ranked by confidence.
- Add a non-dead-end empty Assessment state with a CTA to complete the assessment.

## Validation
- `npx vitest run components/client-dashboard/AccountSummarySection.test.tsx components/client-dashboard/AssessmentScoreBreakdown.test.tsx components/client-dashboard/AccelerationCards.test.tsx components/client-dashboard/ExecutiveSummary.test.tsx`
- `npx tsc --noEmit`
- `git diff --check`
- `npm run lint` passes with existing `<img>` warnings in `app/client/dashboard/[token]/page.tsx` and `components/Navigation.test.tsx`.
- `npm run build` passes with the existing local n8n env warning during page-data collection and existing `<img>` warnings.
- Local production browser smoke on `http://localhost:3074/client/dashboard/<token>` using the live dashboard API payload intercepted locally:
  - desktop 1365x880: radar/trajectory are separate full-width rows; score breakdown is full-width; account total math is visible; package options are vertical/ranked with no horizontal overflow; assessment CTA is visible.
  - mobile 390x1000: recommended next phase, total time investment, and assessment CTA visible; no horizontal overflow.

## Integration Notes
- No migrations.
- No env changes.
- No production data mutation.
- Post-merge captain gate still needs both Vercel contexts checked:
  - Vercel – portfolio
  - Vercel – portfolio-staging
