### PR TITLE
data: refresh Model Ops snapshot

### DIFF
--- a/data/model-ops/reports/latest-dashboard-data.json
+++ b/data/model-ops/reports/latest-dashboard-data.json
@@ -1,6 +1,6 @@
 {
   "projectName": "Local LLM Model Ops & Hermes Automation",
-  "generatedAt": "2026-07-13T14:24:14.073Z",
+  "generatedAt": "2026-07-20T12:03:23.202Z",
   "recommendations": {
     "replyIntentDefault": "Keep qwen3-4b-instruct-2507 for reply-intent classification. It has the best current accuracy/latency balance.",
     "ragDefault": "Use routed local RAG as the leading local/shadow candidate, with Pinecone/OpenAI fallback until larger answer-level evals pass.",


### PR DESCRIPTION
## Summary
- refresh sanitized Model Ops dashboard snapshot from the 2026-07-20 local dashboard rebuild
- timestamp-only change relative to current main

## Validation
- npm --prefix /Users/vambahsillah/Projects/Portfolio run model-ops:snapshot
- npm --prefix /Users/vambahsillah/Projects/Portfolio run model-ops:research:plan -- --repo-snapshot
- PATH="/Users/vambahsillah/Projects/Portfolio/node_modules/.bin:/Users/vambahsillah/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/vambahsillah/.codex/tmp/arg0/codex-arg0s6yKGS:/Users/vambahsillah/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/override:/Users/vambahsillah/.npm-global/bin:/Users/vambahsillah/.local/bin:/Users/vambahsillah/.lmstudio/bin:/Users/vambahsillah/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:/Applications/ChatGPT.app/Contents/Resources" npm --prefix /Users/vambahsillah/Projects/Portfolio.worktrees/model-ops-snapshot-20260720 run model-ops:snapshot
- PATH="/Users/vambahsillah/Projects/Portfolio/node_modules/.bin:/Users/vambahsillah/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/vambahsillah/.codex/tmp/arg0/codex-arg0s6yKGS:/Users/vambahsillah/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/override:/Users/vambahsillah/.npm-global/bin:/Users/vambahsillah/.local/bin:/Users/vambahsillah/.lmstudio/bin:/Users/vambahsillah/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:/Applications/ChatGPT.app/Contents/Resources" npm --prefix /Users/vambahsillah/Projects/Portfolio.worktrees/model-ops-snapshot-20260720 run model-ops:snapshot:check

Labels: codex and codex-automation were not available in this repository.