### PR TITLE
data: refresh Model Ops snapshot

### DIFF
--- a/data/model-ops/reports/latest-dashboard-data.json
+++ b/data/model-ops/reports/latest-dashboard-data.json
@@ -1,6 +1,6 @@
 {
   "projectName": "Local LLM Model Ops & Hermes Automation",
-  "generatedAt": "2026-07-20T12:03:23.202Z",
+  "generatedAt": "2026-07-27T13:16:53.748Z",
   "recommendations": {
     "replyIntentDefault": "Keep qwen3-4b-instruct-2507 for reply-intent classification. It has the best current accuracy/latency balance.",
     "ragDefault": "Use routed local RAG as the leading local/shadow candidate, with Pinecone/OpenAI fallback until larger answer-level evals pass.",
@@ -339,5 +339,7 @@
       }
     }
   ],
-  "swapRequests": []
+  "swapRequests": [
+    {}
+  ]
 }


### PR DESCRIPTION
## Summary

- refreshes the sanitized Model Ops dashboard snapshot for the July 27 automation run
- carries forward the same 8 reply-intent runs and 4 RAG runs
- records the newly indexed proposal-only Kimi swap request placeholder in the admin snapshot

## Validation

- `PATH="/Users/vambahsillah/Projects/Portfolio/node_modules/.bin:$PATH" npm --prefix /Users/vambahsillah/Projects/Portfolio.worktrees/model-ops-snapshot-20260727 run model-ops:snapshot`
- `PATH="/Users/vambahsillah/Projects/Portfolio/node_modules/.bin:$PATH" npm --prefix /Users/vambahsillah/Projects/Portfolio.worktrees/model-ops-snapshot-20260727 run model-ops:snapshot:check`
- `PATH="/Users/vambahsillah/Projects/Portfolio/node_modules/.bin:$PATH" npm --prefix /Users/vambahsillah/Projects/Portfolio.worktrees/model-ops-snapshot-20260727 run model-ops:research:plan -- --repo-snapshot --json`

No model defaults, production routing, n8n production logic, Supabase/Pinecone resources, secrets, merge, or deployment changed.