### PR TITLE
fix: remove feedback-only copy rejection

### DIFF
--- a/app/admin/social-content/[id]/page.test.tsx
+++ b/app/admin/social-content/[id]/page.test.tsx
@@ -146,12 +146,12 @@ describe('SocialContentDetailRoute visual production review', () => {
     expect(screen.queryByText(/Mark this draft rejected/i)).not.toBeInTheDocument()
     expect(screen.queryByLabelText('Triggering event or recent proof')).not.toBeInTheDocument()
     expect(screen.queryByLabelText('Revision feedback for Shaka')).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /Reopen for Revision/i })).not.toBeDisabled()
-    expect(screen.getByRole('button', { name: /Reject and Generate Revision/i })).not.toBeDisabled()
-    fireEvent.click(screen.getByRole('button', { name: /Reopen for Revision/i }))
+    expect(screen.queryByRole('button', { name: /Reject with Feedback/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Reopen and Generate Revision/i })).not.toBeDisabled()
+    fireEvent.click(screen.getByRole('button', { name: /Reopen and Generate Revision/i }))
     expect(screen.getByLabelText('Triggering event or recent proof')).not.toBeDisabled()
     expect(screen.getByLabelText('Revision feedback for Shaka')).not.toBeDisabled()
-    expect(screen.getByRole('button', { name: /Add Feedback to Continue/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /Add Feedback to Generate/i })).toBeDisabled()
     expect(screen.getByDisplayValue('The draft copy is approved and should stay locked.')).toBeDisabled()
     expect(screen.getByText('AmaduTown')).toBeInTheDocument()
     expect(screen.queryByText('Amadou Town')).not.toBeInTheDocument()
@@ -223,8 +223,8 @@ describe('SocialContentDetailRoute visual production review', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Use topic/i }))
 
-    expect(screen.getByRole('button', { name: /Reject and Generate Revision/i })).not.toBeDisabled()
-    fireEvent.click(screen.getByRole('button', { name: /Reject and Generate Revision/i }))
+    expect(screen.getByRole('button', { name: /Reopen and Generate Revision/i })).not.toBeDisabled()
+    fireEvent.click(screen.getByRole('button', { name: /Reopen and Generate Revision/i }))
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
         expect.stringContaining('/api/admin/social-content/topic-backlog'),
@@ -333,7 +333,8 @@ describe('SocialContentDetailRoute visual production review', () => {
     const decisionGate = screen.getByText('Copy Review Decision').closest('section')
     expect(decisionGate).not.toBeNull()
     expect(within(decisionGate as HTMLElement).getByRole('button', { name: /Approve Draft & Next/i })).not.toBeDisabled()
-    expect(within(decisionGate as HTMLElement).getByRole('button', { name: /Reject with Feedback/i })).toBeInTheDocument()
+    expect(within(decisionGate as HTMLElement).queryByRole('button', { name: /Reject with Feedback/i })).not.toBeInTheDocument()
+    expect(within(decisionGate as HTMLElement).getByRole('button', { name: /Reject and Generate Revision/i })).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: /Approve Draft & Next/i }))
 
@@ -403,15 +404,16 @@ describe('SocialContentDetailRoute visual production review', () => {
     expect(screen.getByRole('button', { name: /Approve Draft/i })).not.toBeDisabled()
 
     expect(screen.queryByLabelText('Revision feedback for Shaka')).not.toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: /Reject with Feedback/i }))
+    expect(screen.queryByRole('button', { name: /Reject with Feedback/i })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /Reject and Generate Revision/i }))
     expect(screen.getByRole('button', { name: /Cancel feedback/i })).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /Cancel feedback/i }))
     expect(screen.queryByLabelText('Revision feedback for Shaka')).not.toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: /Reject with Feedback/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Reject and Generate Revision/i }))
     fireEvent.change(screen.getByLabelText('Revision feedback for Shaka'), {
       target: { value: 'The framework reference is clear now, but the opening still needs a more concrete scene.' },
     })
-    fireEvent.click(screen.getByRole('button', { name: /Reject with Feedback/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Reject and Generate Revision/i }))
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
@@ -422,11 +424,11 @@ describe('SocialContentDetailRoute visual production review', () => {
     const rejectCall = fetchMock.mock.calls.find(([, init]) => init?.method === 'PUT')
     const body = JSON.parse(String(rejectCall?.[1]?.body))
     expect(body.status).toBe('rejected')
-    expect(body.rag_context.content_calibration.status).toBe('revision_requested')
+    expect(body.rag_context.content_calibration.status).toBe('revision_generation_requested')
     expect(body.rag_context.content_calibration.operator_feedback.revision_request).toContain('concrete scene')
     expect(body.rag_context.content_calibration.revision_requests[0]).toMatchObject({
       previous_status: 'draft',
-      action: 'reject_with_feedback',
+      action: 'reject_and_generate_revision',
     })
     expect(body.admin_notes).toContain('Copy revision requested')
   })
@@ -926,7 +928,7 @@ describe('SocialContentDetailRoute visual production review', () => {
     expect(await screen.findByText('Post Text')).toBeInTheDocument()
     expect(screen.queryByText('Request copy revision')).not.toBeInTheDocument()
     expect(screen.queryByLabelText('Triggering event or recent proof')).not.toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: /Reject and Generate Revision/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Reopen and Generate Revision/i }))
     const triggeringEventInput = screen.getByLabelText('Triggering event or recent proof')
     expect(triggeringEventInput).toBeTruthy()
     fireEvent.change(triggeringEventInput as HTMLTextAreaElement, {
@@ -935,7 +937,7 @@ describe('SocialContentDetailRoute visual production review', () => {
     fireEvent.change(screen.getByLabelText('Revision feedback for Shaka'), {
       target: { value: feedback },
     })
-    fireEvent.click(screen.getByRole('button', { name: /Reject and Generate Revision/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Reopen and Generate Revision/i }))
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(

--- a/app/admin/social-content/[id]/page.tsx
+++ b/app/admin/social-content/[id]/page.tsx
@@ -244,7 +244,7 @@ type AcronymClarityIssue = AcronymDefinition & {
   status: 'ready' | 'needs_expansion'
 }
 
-type CopyRevisionAction = 'feedback' | 'generate' | null
+type CopyRevisionAction = 'generate' | null
 
 const SOCIAL_COPY_ACRONYMS: AcronymDefinition[] = [
   {
@@ -966,7 +966,7 @@ function SocialContentDetailPage() {
     showMsg('success', 'Topic from Shaka backlog added to the copy review')
   }
 
-  const handleRequestCopyRevision = async (generateRevision: boolean) => {
+  const handleRequestCopyRevision = async () => {
     if (!item) return
     const triggeringEvent = calibrationFeedback.triggering_event.trim()
     const revisionRequest = copyRevisionRequest.trim()
@@ -991,7 +991,7 @@ function SocialContentDetailPage() {
         ...existingRag,
         content_calibration: {
           ...existingCalibration,
-          status: generateRevision ? 'revision_generation_requested' : 'revision_requested',
+          status: 'revision_generation_requested',
           operator_feedback: feedback,
           approval_reversal: {
             reverted_at: requestedAt,
@@ -1004,11 +1004,7 @@ function SocialContentDetailPage() {
               created_at: requestedAt,
               previous_status: item.status,
               request: revisionRequest,
-              action: generateRevision
-                ? 'reject_and_generate_revision'
-                : copyRevisionIsApprovalRollback
-                  ? 'reopen_for_revision'
-                  : 'reject_with_feedback',
+              action: 'reject_and_generate_revision',
             },
           ].slice(-10),
         },
@@ -1044,14 +1040,6 @@ function SocialContentDetailPage() {
         ...current,
         revision_request: revisionRequest,
       }))
-
-      if (!generateRevision) {
-        setCopyRevisionAction(null)
-        showMsg('success', copyRevisionIsApprovalRollback
-          ? 'Approval reverted. Revision feedback saved.'
-          : 'Draft rejected. Feedback saved for iteration.')
-        return
-      }
 
       const revisionRes = await fetch(`/api/admin/social-content/${id}/calibration-revision`, {
         method: 'POST',
@@ -1091,7 +1079,7 @@ function SocialContentDetailPage() {
       setCopyRevisionAction(action)
       return
     }
-    handleRequestCopyRevision(action === 'generate')
+    handleRequestCopyRevision()
   }
 
   const handleCancelCopyRevision = () => {
@@ -1776,29 +1764,13 @@ function SocialContentDetailPage() {
   const copyRevisionIsApprovalRollback = item.status === 'approved'
   const copyRevisionDetailsOpen = copyRevisionAction !== null
   const copyRevisionHasContext = Boolean(copyRevisionRequest.trim() || calibrationFeedback.triggering_event.trim())
-  const copyRevisionFeedbackButtonLabel = copyRevisionAction === 'feedback' && !copyRevisionHasContext
-    ? 'Add Feedback to Continue'
-    : copyRevisionIsApprovalRollback
-      ? 'Reopen for Revision'
-      : 'Reject with Feedback'
   const copyRevisionGenerateButtonLabel = copyRevisionAction === 'generate' && !copyRevisionHasContext
     ? 'Add Feedback to Generate'
-    : 'Reject and Generate Revision'
+    : copyRevisionIsApprovalRollback
+      ? 'Reopen and Generate Revision'
+      : 'Reject and Generate Revision'
   const copyRevisionActionButtons = canRequestCopyRevision ? (
     <div className="flex flex-wrap items-center gap-2">
-      <button
-        type="button"
-        onClick={() => handleCopyRevisionAction('feedback')}
-        disabled={requestingCopyRevision || (copyRevisionAction === 'feedback' && !copyRevisionHasContext)}
-        className={`inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
-          copyRevisionAction === 'feedback'
-            ? 'border-amber-300 bg-amber-500/15 text-amber-50'
-            : 'border-amber-400/45 text-amber-100 hover:bg-amber-500/10'
-        }`}
-      >
-        {requestingCopyRevision ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <XCircle className="h-3.5 w-3.5" />}
-        {copyRevisionFeedbackButtonLabel}
-      </button>
       <button
         type="button"
         onClick={() => handleCopyRevisionAction('generate')}


### PR DESCRIPTION
## Summary
- Remove the standalone `Reject with Feedback` action from the social-content copy review decision gate.
- Keep a single rejection path that captures feedback and requests Shaka revision generation.
- Update copy-review tests for draft rejection and approved-copy reopen flows.

## Validation
- `npm test -- --run 'app/admin/social-content/[id]/page.test.tsx'` PASS
- `npm run lint` PASS with existing warnings in `app/client/dashboard/[token]/page.tsx` and `components/Navigation.test.tsx` about `<img>` usage, outside the touched files
- `git diff --check` PASS
- Push hook database health check PASS
- No live workflow/customer-data smoke run before PR; this is a UI action simplification with focused component coverage

## Integration Notes
- No migrations or env changes.
- Vercel contexts still need captain verification after merge:
  - Vercel - portfolio
  - Vercel - portfolio-staging
