### PR TITLE
feat: show inline social review evidence

### DIFF
--- a/components/admin/AgenticContentReviewPacketCard.test.tsx
+++ b/components/admin/AgenticContentReviewPacketCard.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import AgenticContentReviewPacketCard from './AgenticContentReviewPacketCard'
+import { getAgenticContentReviewPacketByAssetId } from '@/lib/agentic-content-review-packets'
+
+describe('AgenticContentReviewPacketCard', () => {
+  it('renders inline evidence so reviewers do not have to leave the queue page first', () => {
+    const packet = getAgenticContentReviewPacketByAssetId('p0-linkedin-flagship-agentic-operating-system')
+
+    expect(packet).not.toBeNull()
+    render(
+      <AgenticContentReviewPacketCard
+        packet={packet!}
+        nextGateHref="#social-content-approval-queue"
+        nextGateLabel="Open approval queue"
+      />,
+    )
+
+    expect(screen.getByText('Evidence packet')).toBeInTheDocument()
+    expect(screen.getByText(/The demo is no longer the hard part/)).toBeInTheDocument()
+    expect(screen.getByText('Source basis')).toBeInTheDocument()
+    expect(screen.getByText('Amina clearance')).toBeInTheDocument()
+    expect(screen.getByText('Human checks')).toBeInTheDocument()
+    expect(screen.getByText('Still gated')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Open source packet/i })).toBeInTheDocument()
+  })
+})

--- a/components/admin/AgenticContentReviewPacketCard.tsx
+++ b/components/admin/AgenticContentReviewPacketCard.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { AlertTriangle, CheckCircle2, ExternalLink, PauseCircle, RotateCcw } from 'lucide-react'
+import { AlertTriangle, CheckCircle2, ExternalLink, FileText, PauseCircle, RotateCcw } from 'lucide-react'
 import {
   buildAgenticContentReviewActionHref,
   type AgenticContentReviewPacket,
@@ -96,6 +96,50 @@ export default function AgenticContentReviewPacketCard({
         <div><span className="text-gray-500">Next gate:</span> {packet.nextGate}</div>
       </div>
 
+      {packet.evidencePacket ? (
+        <div className="mt-3 rounded-md border border-blue-400/20 bg-blue-500/10 p-3">
+          <div className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-blue-200">
+            <FileText className="h-3.5 w-3.5" />
+            Evidence packet
+          </div>
+          <p className="mt-2 text-xs leading-5 text-gray-100">{packet.evidencePacket.draftPreview}</p>
+          <div className="mt-3 grid gap-3 text-[11px] leading-5 lg:grid-cols-2">
+            <div>
+              <div className="font-semibold uppercase tracking-[0.12em] text-radiant-gold/90">Source basis</div>
+              <ul className="mt-1 space-y-1 text-gray-300">
+                {packet.evidencePacket.sourceBasis.map((source) => (
+                  <li key={source}>- {source}</li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <div className="font-semibold uppercase tracking-[0.12em] text-emerald-300">Amina clearance</div>
+              <ul className="mt-1 space-y-1 text-gray-300">
+                {packet.evidencePacket.challengerFindings.map((finding) => (
+                  <li key={finding}>- {finding}</li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <div className="font-semibold uppercase tracking-[0.12em] text-amber-300">Human checks</div>
+              <ul className="mt-1 space-y-1 text-gray-300">
+                {packet.evidencePacket.humanChecks.map((check) => (
+                  <li key={check}>- {check}</li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <div className="font-semibold uppercase tracking-[0.12em] text-rose-300">Still gated</div>
+              <ul className="mt-1 space-y-1 text-gray-300">
+                {packet.evidencePacket.closedGates.map((gate) => (
+                  <li key={gate}>- {gate}</li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
       <div className="mt-3 grid gap-2 text-[11px] leading-5 sm:grid-cols-3">
         <Link
           href={buildAgenticContentReviewActionHref(packet, 'approve_next_gate')}
@@ -140,7 +184,7 @@ export default function AgenticContentReviewPacketCard({
             className="inline-flex items-center gap-1.5 rounded-md border border-emerald-500/35 bg-emerald-500/10 px-3 py-2 text-xs font-medium text-emerald-100 transition-colors hover:border-emerald-400 hover:text-emerald-50"
           >
             <ExternalLink className="h-3.5 w-3.5" />
-            Review launch draft
+            Open source draft
           </a>
         ) : null}
         <a
@@ -150,7 +194,7 @@ export default function AgenticContentReviewPacketCard({
           className="inline-flex items-center gap-1.5 rounded-md border border-silicon-slate bg-background/50 px-3 py-2 text-xs font-medium text-gray-200 transition-colors hover:border-radiant-gold/50 hover:text-radiant-gold"
         >
           <ExternalLink className="h-3.5 w-3.5" />
-          View Evidence Packet
+          Open source packet
         </a>
         {nextGateHref ? (
           <a

--- a/lib/agentic-content-review-packets.test.ts
+++ b/lib/agentic-content-review-packets.test.ts
@@ -75,4 +75,16 @@ describe('agentic content review packet registry', () => {
       'p2-client-one-pager-governed-agentic-operations',
     ])
   })
+
+  it('keeps social review packets self-contained enough for inline human review', () => {
+    const socialPackets = getAgenticContentReviewPacketsForSurface('social')
+
+    for (const packet of socialPackets) {
+      expect(packet.evidencePacket?.draftPreview).toMatch(/\w/)
+      expect(packet.evidencePacket?.sourceBasis.length).toBeGreaterThanOrEqual(2)
+      expect(packet.evidencePacket?.challengerFindings.join(' ')).toMatch(/Amina/)
+      expect(packet.evidencePacket?.humanChecks.length).toBeGreaterThan(0)
+      expect(packet.evidencePacket?.closedGates.join(' ')).toMatch(/Publishing|scheduling/)
+    }
+  })
 })

--- a/lib/agentic-content-review-packets.ts
+++ b/lib/agentic-content-review-packets.ts
@@ -21,9 +21,93 @@ export type AgenticContentReviewPacket = {
   sendBackMeaning: string
   targetSurface: AgenticContentReviewSurface
   launchDraftPath?: string
+  evidencePacket?: {
+    draftPreview: string
+    sourceBasis: string[]
+    challengerFindings: string[]
+    humanChecks: string[]
+    closedGates: string[]
+  }
 }
 
 const SALES_OUTREACH_LAUNCH_DRAFT_PATH = 'docs/agentic-content-linkedin-drafts/2026-06-04-sales-outreach-launch-drafts.md'
+
+const SHARED_SOCIAL_CLOSED_GATES = [
+  'Publishing and scheduling remain separately approval-gated.',
+  'No provider work, outreach send, visual build, or production settings change is approved by this packet.',
+]
+
+const FLAGSHIP_SOCIAL_EVIDENCE: AgenticContentReviewPacket['evidencePacket'] = {
+  draftPreview: 'Anyone can launch an agent now. The demo is no longer the hard part; governed execution is where the value starts.',
+  sourceBasis: [
+    'Core system frame from docs/agentic-enterprise-value-map.md.',
+    'Launch order and challenger standard from docs/agentic-value-communications-plan.md.',
+    'Public-safe market and Portfolio claims from the research dossier and LinkedIn wave-one drafts.',
+  ],
+  challengerFindings: [
+    'Amina found no unsupported claims, privacy flags, or implementation drift.',
+    'The post frames Portfolio as a governed proof surface, not a finished autonomous enterprise platform.',
+  ],
+  humanChecks: [
+    'Decide whether to keep enterprise language or broaden the audience to business operators.',
+    'Confirm whether the series tagline should stay in the body or move to the close.',
+  ],
+  closedGates: SHARED_SOCIAL_CLOSED_GATES,
+}
+
+const CAROUSEL_SOCIAL_EVIDENCE: AgenticContentReviewPacket['evidencePacket'] = {
+  draftPreview: 'The 7 things your enterprise agent needs after the demo: receipt, scope, handoff, approval, compliance, QA, and Mission Control.',
+  sourceBasis: [
+    'Component model from docs/agentic-value-communications-plan.md.',
+    'Trace and Mission Control claims from the research PRDs.',
+    'Public-safe market framing from the phase-two research dossier.',
+  ],
+  challengerFindings: [
+    'Amina found no unsupported claims in outline form.',
+    'Final visuals must stay structural and avoid saying every path is fully autonomous.',
+  ],
+  humanChecks: [
+    'Choose enterprise agent vs. business agent for the cover.',
+    'Approve the slide sequence before visual build.',
+  ],
+  closedGates: SHARED_SOCIAL_CLOSED_GATES,
+}
+
+const SCOPE_SOCIAL_EVIDENCE: AgenticContentReviewPacket['evidencePacket'] = {
+  draftPreview: 'Agent access should feel less like a blank check and more like a permission slip.',
+  sourceBasis: [
+    'Scope, runtime policy, capability, and approval-boundary claims from the permission-scopes PRD.',
+    'Channel constraints and challenger gate from the communications plan.',
+    'Existing receipt and handoff language from the LinkedIn wave-one source set.',
+  ],
+  challengerFindings: [
+    'Amina found no unsupported claims, privacy flags, or channel-fit blockers.',
+    'The post stays at the operating-boundary level and does not expose private run details.',
+  ],
+  humanChecks: [
+    'Confirm the safety framing is practical enough for non-security readers.',
+    'Approve copy before any schedule or publish action.',
+  ],
+  closedGates: SHARED_SOCIAL_CLOSED_GATES,
+}
+
+const QA_SOCIAL_EVIDENCE: AgenticContentReviewPacket['evidencePacket'] = {
+  draftPreview: 'Agent QA needs scorecards before authority expands, not after a confident first pass reaches approval.',
+  sourceBasis: [
+    'QA, rubric, coaching, and promotion-gate claims from the self-evaluation PRD.',
+    'Channel constraints and challenger gate from the communications plan.',
+    'Existing QA post language from the LinkedIn wave-one source set.',
+  ],
+  challengerFindings: [
+    'Amina cleared the claim when it stays tied to scorecards, rubrics, and review gates.',
+    'The post should avoid implying that automated QA replaces human judgment.',
+  ],
+  humanChecks: [
+    'Confirm the scorecard framing matches Vambah voice and the Agentified release angle.',
+    'Approve copy before any schedule or publish action.',
+  ],
+  closedGates: SHARED_SOCIAL_CLOSED_GATES,
+}
 
 export const AGENTIC_CONTENT_REVIEW_PACKETS: AgenticContentReviewPacket[] = [
   {
@@ -46,6 +130,7 @@ export const AGENTIC_CONTENT_REVIEW_PACKETS: AgenticContentReviewPacket[] = [
     sendBackMeaning: 'Route a repair task if the claim, voice, source support, or channel fit is not ready for public review.',
     targetSurface: 'social',
     launchDraftPath: SALES_OUTREACH_LAUNCH_DRAFT_PATH,
+    evidencePacket: FLAGSHIP_SOCIAL_EVIDENCE,
   },
   {
     assetId: 'p0-carousel-seven-things-after-agent-demo',
@@ -67,6 +152,7 @@ export const AGENTIC_CONTENT_REVIEW_PACKETS: AgenticContentReviewPacket[] = [
     sendBackMeaning: 'Route a repair task if the slide story, evidence, or sequence needs another challenger pass.',
     targetSurface: 'social',
     launchDraftPath: SALES_OUTREACH_LAUNCH_DRAFT_PATH,
+    evidencePacket: CAROUSEL_SOCIAL_EVIDENCE,
   },
   {
     assetId: 'p1-linkedin-scope-safety-model',
@@ -88,6 +174,7 @@ export const AGENTIC_CONTENT_REVIEW_PACKETS: AgenticContentReviewPacket[] = [
     sendBackMeaning: 'Route a repair task if the scope claim, safety framing, source support, or voice needs revision.',
     targetSurface: 'social',
     launchDraftPath: SALES_OUTREACH_LAUNCH_DRAFT_PATH,
+    evidencePacket: SCOPE_SOCIAL_EVIDENCE,
   },
   {
     assetId: 'p1-linkedin-agent-qa-scorecards',
@@ -109,6 +196,7 @@ export const AGENTIC_CONTENT_REVIEW_PACKETS: AgenticContentReviewPacket[] = [
     sendBackMeaning: 'Route a repair task if the QA claim, scorecard framing, source support, or voice needs revision.',
     targetSurface: 'social',
     launchDraftPath: SALES_OUTREACH_LAUNCH_DRAFT_PATH,
+    evidencePacket: QA_SOCIAL_EVIDENCE,
   },
   {
     assetId: 'p0-youtube-agentic-ai-teams-skip',


### PR DESCRIPTION
## Summary
- Add compact inline evidence packets to social content review cards so reviewers can see the draft basis, Amina clearance, human checks, and still-gated actions without leaving the queue page first.
- Keep source links available as secondary provenance trails, renamed to source-oriented labels.
- Cover the registry and rendered review-card behavior with focused tests.

## Validation
- npm test -- --run lib/agentic-content-review-packets.test.ts components/admin/AgenticContentReviewPacketCard.test.tsx
- git diff --check
- npm run lint (passes; existing unrelated <img> warnings remain in app/client/dashboard/[token]/page.tsx and components/Navigation.test.tsx)
- npm run build (passes; existing env/browserlist warnings only)
- Pre-push db:health-check passed
- Local authenticated browser smoke for /admin/social-content was blocked by dev login redirect; deployment/authenticated smoke still required before human QA.

## Integration Notes
- No Supabase migration.
- No env changes.
- No publishing, scheduling, provider, outreach-send, or production settings action is introduced.
- Vercel contexts to verify after merge:
  - Vercel – portfolio
  - Vercel – portfolio-staging