### PR TITLE
fix: align extraction status drawer

### DIFF
--- a/components/admin/ExtractionStatusChip.tsx
+++ b/components/admin/ExtractionStatusChip.tsx
@@ -873,7 +873,7 @@ export function ExtractionStatusChip({
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -8 }}
             transition={{ duration: 0.15 }}
-            className="absolute left-0 top-full z-[70] mt-2 w-[360px] max-w-[calc(100vw-2rem)] overflow-hidden rounded-lg border border-gray-700 bg-gray-800/95 shadow-xl backdrop-blur-sm"
+            className="absolute right-0 top-full z-[70] mt-2 w-[360px] max-w-[calc(100vw-2rem)] overflow-hidden rounded-lg border border-gray-700 bg-gray-800/95 shadow-xl backdrop-blur-sm"
           >
             {/* Current run detail */}
             {currentRun && (


### PR DESCRIPTION
## Summary
- Right-aligns the extraction status drawer under its status chip.
- Prevents the drawer from overflowing off the right edge when the chip appears near the end of a card.

## Validation
- npm run lint -- --file components/admin/ExtractionStatusChip.tsx
- git diff --check
- npm run build
- Pre-push database health check passed.
- Production smoke from PR #702 found the drawer was vertically unclipped but could overflow right; this PR addresses that specific issue.

## Integration Notes
- No migrations.
- No env changes.
- No publishing, scheduling, provider generation, outbound sending, or production settings changes.
- Vercel contexts to check after merge:
  - Vercel – portfolio
  - Vercel – portfolio-staging